### PR TITLE
Allow https://huggingface.co/ prefix

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -55,6 +55,7 @@ TF_WEIGHTS_NAME = "model.ckpt"
 FLAX_WEIGHTS_NAME = "flax_model.msgpack"
 CONFIG_NAME = "config.json"
 
+HUGGINGFACE_CO_REPO_URL_BASE = "https://huggingface.co/"
 HUGGINGFACE_CO_URL_TEMPLATE = (
     "https://huggingface.co/{model_id}/resolve/{revision}/{filename}"
 )
@@ -92,6 +93,9 @@ def hf_hub_url(
     In terms of client-side caching from this library, we base our caching on the objects' ETag. An object's ETag is:
     its git-sha1 if stored in git, or its sha256 if stored in git-lfs.
     """
+    if model_id.startswith(HUGGINGFACE_CO_REPO_URL_BASE):
+        model_id = model_id[len(HUGGINGFACE_CO_REPO_URL_BASE) :]
+
     if subfolder is not None:
         filename = f"{subfolder}/{filename}"
 

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -17,6 +17,7 @@ import unittest
 import requests
 from huggingface_hub.file_download import (
     CONFIG_NAME,
+    HUGGINGFACE_CO_REPO_URL_BASE,
     PYTORCH_WEIGHTS_NAME,
     cached_download,
     filename_to_url,
@@ -78,6 +79,11 @@ class CachedDownloadTests(unittest.TestCase):
         metadata = filename_to_url(filepath)
         self.assertNotEqual(metadata[1], f'"{PINNED_SHA1}"')
         # Caution: check that the etag is *not* equal to the one from `test_standard_object`
+
+    def test_repo_url(self):
+        url1 = hf_hub_url(HUGGINGFACE_CO_REPO_URL_BASE + MODEL_ID, filename=CONFIG_NAME, revision=REVISION_ID_DEFAULT)
+        url2  = hf_hub_url(MODEL_ID, filename=CONFIG_NAME, revision=REVISION_ID_DEFAULT)
+        assert url1 == url2
 
     def test_lfs_object(self):
         url = hf_hub_url(


### PR DESCRIPTION
As discussed in https://github.com/asteroid-team/asteroid/issues/401 I'm submitting a patch to allow repo URLs as download URLs. Curious what you think of the change.﻿
