### PR TITLE
Adding mixin class for ease saving, uploading, downloading (as discussed in issue #9).

### DIFF
--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -30,5 +30,5 @@ from .constants import (
 )
 from .file_download import cached_download, hf_hub_url
 from .hf_api import HfApi, HfFolder
-from .repository import Repository
 from .hub_mixin import ModelHubMixin
+from .repository import Repository

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -31,3 +31,4 @@ from .constants import (
 from .file_download import cached_download, hf_hub_url
 from .hf_api import HfApi, HfFolder
 from .repository import Repository
+from .hub_mixin import ModelHubMixin

--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -43,7 +43,7 @@ class ModelHubMixin(object):
 
     def save_pretrained(
         self,
-        save_directory: Optional[str],
+        save_directory: str,
         config: Optional[dict] = None,
         push_to_hub: bool = False,
         **kwargs,
@@ -206,7 +206,7 @@ class ModelHubMixin(object):
         commit_message: Optional[str] = "add model",
         organization: Optional[str] = None,
         private: bool = None,
-    ):
+    ) -> str:
         """
         Parameters:
             save_directory (:obj:`Union[str, os.PathLike]`):
@@ -221,6 +221,9 @@ class ModelHubMixin(object):
                 private: Whether the model repo should be private (requires a paid huggingface.co account)
             commit_message (:obj:`str`, `optional`, defaults to :obj:`add model`):
                 Message to commit while pushing
+
+        Returns:
+            url to commit on remote repo.
         """
         if model_id is None:
             model_id = save_directory

--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -116,10 +116,6 @@ class ModelHubMixin(object):
                       since we use a git-based system for storing models and other artifacts on huggingface.co, so ``revision`` can be any identifier allowed by git.
                     - A path to a `directory` containing model weights saved using
                       :func:`~transformers.PreTrainedModel.save_pretrained`, e.g., ``./my_model_directory/``.
-                    - A path or url to a `tensorflow index checkpoint file` (e.g, ``./tf_model/model.ckpt.index``). In
-                      this case, ``from_tf`` should be set to :obj:`True` and a configuration object should be provided
-                      as ``config`` argument. This loading path is slower than converting the TensorFlow checkpoint in
-                      a PyTorch model using the provided conversion scripts and loading the PyTorch model afterwards.
                     - :obj:`None` if you are both providing the configuration and state dictionary (resp. with keyword
                       arguments ``config`` and ``state_dict``).
             cache_dir (:obj:`Union[str, os.PathLike]`, `optional`):

--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -1,17 +1,15 @@
-
-import os
 import json
-
-from .file_download import hf_hub_url, cached_download
-from .constants import CONFIG_NAME, PYTORCH_WEIGHTS_NAME
-from .hf_api import HfApi, HfFolder
-from .repository import Repository
+import os
 
 import torch
 
+from .constants import CONFIG_NAME, PYTORCH_WEIGHTS_NAME
+from .file_download import cached_download, hf_hub_url
+from .hf_api import HfApi, HfFolder
+from .repository import Repository
+
 
 class ModelHubMixin(object):
-
     def __init__(self, *args, **kwargs):
         """
         Mix this class with your torch-model class for ease process of saving & loading from huggingface-hub
@@ -35,21 +33,23 @@ class ModelHubMixin(object):
             >>> model = MyModel.from_pretrained("username/mymodel")
         """
 
-    def save_pretrained(self, save_directory:str, config:dict=None, push_to_hub=False, model_id=None):
+    def save_pretrained(
+        self, save_directory: str, config: dict = None, push_to_hub=False, model_id=None
+    ):
         """
-            Saving weights in local directory.
+        Saving weights in local directory.
 
-            Parameters:
-                save_directory (:obj:`str`):
-                    Directory in which you want to save weights.
-                config (:obj:`dict`, `optional`):
-                    specify config incase you want to save config.
+        Parameters:
+            save_directory (:obj:`str`):
+                Directory in which you want to save weights.
+            config (:obj:`dict`, `optional`):
+                specify config incase you want to save config.
         """
         os.makedirs(save_directory, exist_ok=True)
         config_to_save = None
 
         # saving config
-        if hasattr(self, 'config'):
+        if hasattr(self, "config"):
             if isinstance(self.config, dict):
                 config_to_save = self.config
 
@@ -73,13 +73,13 @@ class ModelHubMixin(object):
 
     def _save_pretrained(self, path):
         """
-            Overwrite this method in case you don't want to save complete model, rather some specific layers
+        Overwrite this method in case you don't want to save complete model, rather some specific layers
         """
         model_to_save = self.module if hasattr(self, "module") else self
         torch.save(model_to_save.state_dict(), path)
 
     @classmethod
-    def from_pretrained(cls, pretrained_model_name_or_path:str, *model_args, **kwargs):
+    def from_pretrained(cls, pretrained_model_name_or_path: str, *model_args, **kwargs):
         r"""
         Instantiate a pretrained pytorch model from a pre-trained model configuration from huggingface-hub.
         The model is set in evaluation mode by default using ``model.eval()`` (Dropout modules are deactivated). To
@@ -91,8 +91,8 @@ class ModelHubMixin(object):
                     - A string, the `model id` of a pretrained model hosted inside a model repo on huggingface.co.
                       Valid model ids can be located at the root-level, like ``bert-base-uncased``, or namespaced under
                       a user or organization name, like ``dbmdz/bert-base-german-cased``.
-                    - You can add `revision` by appending `@` at the end of model_id simply like this: ``dbmdz/bert-base-german-cased@main`` 
-                      Revision is the specific model version to use. It can be a branch name, a tag name, or a commit id, 
+                    - You can add `revision` by appending `@` at the end of model_id simply like this: ``dbmdz/bert-base-german-cased@main``
+                      Revision is the specific model version to use. It can be a branch name, a tag name, or a commit id,
                       since we use a git-based system for storing models and other artifacts on huggingface.co, so ``revision`` can be any identifier allowed by git.
                     - A path to a `directory` containing model weights saved using
                       :func:`~transformers.PreTrainedModel.save_pretrained`, e.g., ``./my_model_directory/``.
@@ -139,16 +139,26 @@ class ModelHubMixin(object):
             _, name = model_id.split("/")
 
         revision = "main"
-        if len(name.split('@')) > 1:
-            name, revision = name.split('@')
+        if len(name.split("@")) > 1:
+            name, revision = name.split("@")
 
         if name in os.listdir() and CONFIG_NAME in os.listdir(name):
             print("LOADING weights from local directory")
             config_file = os.path.join(name, CONFIG_NAME)
         else:
             try:
-                config_url = hf_hub_url(model_id, filename=CONFIG_NAME, revision=revision)
-                config_file = cached_download(config_url, cache_dir=cache_dir, force_download=force_download, proxies=proxies, resume_download=resume_download, local_files_only=local_files_only, use_auth_token=use_auth_token)
+                config_url = hf_hub_url(
+                    model_id, filename=CONFIG_NAME, revision=revision
+                )
+                config_file = cached_download(
+                    config_url,
+                    cache_dir=cache_dir,
+                    force_download=force_download,
+                    proxies=proxies,
+                    resume_download=resume_download,
+                    local_files_only=local_files_only,
+                    use_auth_token=use_auth_token,
+                )
             except:
                 config_file = None
 
@@ -156,8 +166,18 @@ class ModelHubMixin(object):
             print("LOADING weights from local directory")
             model_file = os.path.join(name, PYTORCH_WEIGHTS_NAME)
         else:
-            model_url = hf_hub_url(model_id, filename=PYTORCH_WEIGHTS_NAME, revision=revision)
-            model_file = cached_download(model_url, cache_dir=cache_dir, force_download=force_download, proxies=proxies, resume_download=resume_download, local_files_only=local_files_only, use_auth_token=use_auth_token)
+            model_url = hf_hub_url(
+                model_id, filename=PYTORCH_WEIGHTS_NAME, revision=revision
+            )
+            model_file = cached_download(
+                model_url,
+                cache_dir=cache_dir,
+                force_download=force_download,
+                proxies=proxies,
+                resume_download=resume_download,
+                local_files_only=local_files_only,
+                use_auth_token=use_auth_token,
+            )
 
         if config_file is not None:
             with open(config_file, "r", encoding="utf-8") as f:
@@ -187,13 +207,20 @@ class ModelHubMixin(object):
         private = kwargs.pop("private", None)
 
         revision = "main"
-        if len(model_id.split('@')) > 1:
-            model_id, revision = model_id.split('@')
+        if len(model_id.split("@")) > 1:
+            model_id, revision = model_id.split("@")
 
         token = HfFolder.get_token()
         if repo_url is None:
-            repo_url = HfApi().create_repo(token, model_id, organization=organization, private=private, repo_type=None, exist_ok=True)
+            repo_url = HfApi().create_repo(
+                token,
+                model_id,
+                organization=organization,
+                private=private,
+                repo_type=None,
+                exist_ok=True,
+            )
 
         repo = Repository(weights_directory, clone_from=repo_url, use_auth_token=token)
-        
+
         return repo.push_to_hub(commit_message=commit_message)

--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -15,19 +15,38 @@ PREFIX = "https://huggingface.co/"
 
 class ModelHubMixin(object):
 
-    def __init__(self, **kwargs):
+    def __init__(self, *args, **kwargs):
         """
+        Mix this class with your torch-model class for ease process of saving & loading from huggingface-hub
 
+        Example::
+
+            >>> from huggingface_hub import ModelHubMixin
+
+            >>> class MyModel(nn.Module, ModelHubMixin):
+            ...    def __init__(self):
+            ...        super().__init__()
+            ...        self.layer = ...
+            ...    def forward(self, ...)
+            ...        return ...
+
+            >>> model = MyModel()
+            >>> # train your model using whatever trainer you link
+            >>> # Saving model-weights in required format in specified directory
+            >>> model.save_pretrained("mymodel")
+            >>> # Pushing model-weights to hf-hub
+            >>> model.upload_to_hub("username/mymodel")
+            >>> # Downloading weights from hf-hub & model will be initialized from those weights
+            >>> model = MyModel.from_pretrained("username/mymodel")
         """
 
     def save_pretrained(self, save_directory:str):
         """
-            Saving weights in local directory that can be loaded directly from huggingface-hub
+            Saving weights in local directory that can be loaded pushed directly to huggingface-hub
         """
-        self.wts_directory = save_directory
+        os.makedirs(save_directory, exist_ok=True)
 
-        if save_directory not in os.listdir(): 
-            os.makedirs(save_directory)
+        self.wts_directory = save_directory
 
         # saving config
         if hasattr(self, 'config'):
@@ -35,32 +54,73 @@ class ModelHubMixin(object):
             with open(path, "w") as f:
                 json.dump(self.config, f)
 
-        # saving only the adapter weights and length embedding
+        # saving model weights
         path = os.path.join(save_directory, PYTORCH_WEIGHTS_NAME)
-        self._save_pretrained(path, verbose=False)
+        self._save_pretrained(path)
 
-        return True
-
-    def _save_pretrained(self, path, verbose):
+    def _save_pretrained(self, path):
         """
             Overwrite this method in case you don't want to save complete model, rather some specific layers
         """
-
-        # Only save the model itself if we are using distributed training
         model_to_save = self.module if hasattr(self, "module") else self
-
         torch.save(model_to_save.state_dict(), path)
-        if verbose:
-            print(f"saving model weights")
 
     @classmethod
-    def from_pretrained(cls, pretrained_model_name_or_path:str, **kwargs):
+    def from_pretrained(cls, pretrained_model_name_or_path:str, *model_args, **kwargs):
+        r"""
+        Instantiate a pretrained pytorch model from a pre-trained model configuration from huggingface-hub.
+        The model is set in evaluation mode by default using ``model.eval()`` (Dropout modules are deactivated). To
+        train the model, you should first set it back in training mode with ``model.train()``.
+
+        Parameters:
+            pretrained_model_name_or_path (:obj:`str` or :obj:`os.PathLike`, `optional`):
+                Can be either:
+                    - A string, the `model id` of a pretrained model hosted inside a model repo on huggingface.co.
+                      Valid model ids can be located at the root-level, like ``bert-base-uncased``, or namespaced under
+                      a user or organization name, like ``dbmdz/bert-base-german-cased``.
+                    - A path to a `directory` containing model weights saved using
+                      :func:`~transformers.PreTrainedModel.save_pretrained`, e.g., ``./my_model_directory/``.
+                    - A path or url to a `tensorflow index checkpoint file` (e.g, ``./tf_model/model.ckpt.index``). In
+                      this case, ``from_tf`` should be set to :obj:`True` and a configuration object should be provided
+                      as ``config`` argument. This loading path is slower than converting the TensorFlow checkpoint in
+                      a PyTorch model using the provided conversion scripts and loading the PyTorch model afterwards.
+                    - :obj:`None` if you are both providing the configuration and state dictionary (resp. with keyword
+                      arguments ``config`` and ``state_dict``).
+            cache_dir (:obj:`Union[str, os.PathLike]`, `optional`):
+                Path to a directory in which a downloaded pretrained model configuration should be cached if the
+                standard cache should not be used.
+            force_download (:obj:`bool`, `optional`, defaults to :obj:`False`):
+                Whether or not to force the (re-)download of the model weights and configuration files, overriding the
+                cached versions if they exist.
+            resume_download (:obj:`bool`, `optional`, defaults to :obj:`False`):
+                Whether or not to delete incompletely received files. Will attempt to resume the download if such a
+                file exists.
+            proxies (:obj:`Dict[str, str], `optional`):
+                A dictionary of proxy servers to use by protocol or endpoint, e.g., :obj:`{'http': 'foo.bar:3128',
+                'http://hostname': 'foo.bar:4012'}`. The proxies are used on each request.
+            local_files_only(:obj:`bool`, `optional`, defaults to :obj:`False`):
+                Whether or not to only look at local files (i.e., do not try to download the model).
+            use_auth_token (:obj:`str` or `bool`, `optional`):
+                The token to use as HTTP bearer authorization for remote files. If :obj:`True`, will use the token
+                generated when running :obj:`transformers-cli login` (stored in :obj:`~/.huggingface`).
+            revision(:obj:`str`, `optional`, defaults to :obj:`"main"`):
+                The specific model version to use. It can be a branch name, a tag name, or a commit id, since we use a
+                git-based system for storing models and other artifacts on huggingface.co, so ``revision`` can be any
+                identifier allowed by git.
+        .. note::
+            Passing :obj:`use_auth_token=True` is required when you want to use a private model.
         """
-            Setting up this method will enable to load directly from huggingface hub just like other HF models are loaded
-        """
+
         model_id = pretrained_model_name_or_path
         strict = kwargs.pop("strict", True)
         map_location = kwargs.pop("map_location", torch.device("cpu"))
+        revision = kwargs.pop("revision", None)
+        force_download = kwargs.pop("force_download", False)
+        resume_download = kwargs.pop("resume_download", False)
+        proxies = kwargs.pop("proxies", None)
+        use_auth_token = kwargs.pop("use_auth_token", None)
+        cache_dir = kwargs.pop("cache_dir", None)
+        local_files_only = kwargs.pop("local_files_only", False)
 
         if len(model_id.split("/")) == 1:
             name = model_id
@@ -72,8 +132,8 @@ class ModelHubMixin(object):
             config_file = os.path.join(name, CONFIG_NAME)
         else:
             try:
-                config_url = hf_hub_url(model_id, filename=CONFIG_NAME)
-                config_file = cached_download(config_url)
+                config_url = hf_hub_url(model_id, filename=CONFIG_NAME, revision=revision)
+                config_file = cached_download(config_url, cache_dir=cache_dir, force_download=force_download, proxies=proxies, resume_download=resume_download, local_files_only=local_files_only, use_auth_token=use_auth_token)
             except:
                 config_file = None
 
@@ -81,8 +141,8 @@ class ModelHubMixin(object):
             print("LOADING weights from local directory")
             model_file = os.path.join(name, PYTORCH_WEIGHTS_NAME)
         else:
-            model_url = hf_hub_url(model_id, filename=PYTORCH_WEIGHTS_NAME)
-            model_file = cached_download(model_url)
+            model_url = hf_hub_url(model_id, filename=PYTORCH_WEIGHTS_NAME, revision=revision)
+            model_file = cached_download(model_url, cache_dir=cache_dir, force_download=force_download, proxies=proxies, resume_download=resume_download, local_files_only=local_files_only, use_auth_token=use_auth_token)
 
         if config_file is not None:
             with open(config_file, "r", encoding="utf-8") as f:
@@ -97,56 +157,63 @@ class ModelHubMixin(object):
 
         return model
 
-    def upload_to_hub(self, model_id:str, wts_directory:str=None, branch:str="main", commit_message:str="add model"):
+    def upload_to_hub(self, model_id:str, **kwargs):
         """
-            This method will upload your model weights to huggingface-hub
+            This method will upload your model weights to huggingface-hub.
 
-            ARGUMENTS:
-                model_id :       model_id which will be used later using from_pretrained (Generally: username/model_name)   
-                wts_directory :  directory made using save_pretrained
+            Parameters:
+                model_id (:obj:`str`):
+                    model_id which will be used later using from_pretrained (Generally: username/model_name)   
+                wts_directory (:obj:`str`, `optional`):  
+                    Directory having model-weights & config. Specify this only incase you are not saving using `.save_pretrained()` method
+                branch (:obj:`str`, `optional`):
+                    Since huggingface-hub is relying on git-lfs for versioning weights, you can specify branch in which you want to commit
+                commit_message(:obj:`str`, `optional`):
+                    your commit message to hub
+                track_extensions(:obj:`list`, `optional`):
+                    extensions of large files which should be tracked with git-lfs
 
             NOTE:
-                - You need to create repository in huggingface hub manually
-                - This may take some time depending on your directory size
+                - You need to have `git-lfs` installed
+                    Ubuntu: `sudo apt-get install git-lfs`
+                    Gcolab: `!sudo apt-get install git-lfs`
+                    MAC-OS: `brew install git-lfs`
+                - You need to create repository in huggingface-hub manually
         """
 
+        wts_directory = kwargs.pop("wts_directory", None)
+        branch = kwargs.pop("branch", "main")
+        commit_message = kwargs.pop("commit_message", "add model")
+        track_extensions = kwargs.pop("track_extensions", ["*.bin", "*pt", ".h5"])
+
         if wts_directory is None:
-            wts_directory = self.wts_directory if hasattr(self, wts_directory) else wts_directory
+            wts_directory = self.wts_directory if hasattr(self, "wts_directory") else wts_directory
 
         if not os.path.isdir(wts_directory):
             raise FileExistsError(f"{wts_directory} doesn't exist")
 
         os.chdir(wts_directory)
         if not os.path.isdir(".git"):
-            print(1)
             subprocess.run(["git", "init"], stdout=subprocess.PIPE)
 
         if not os.path.isdir(".git/lfs"):
-            print(2)
             subprocess.run(["git-lfs", "install"], stdout=subprocess.PIPE)
 
         with open(".git/config", "r") as f:
             git_config = f.read().split()
         if "url" not in git_config:
-            print(3)
             subprocess.run(["git", "remote", "add", "origin", PREFIX+model_id], stdout=subprocess.PIPE)
-            subprocess.run(["git", "pull", "origin", branch, "--rebase"])
 
         if not branch in os.listdir(".git/refs/heads"):
-            print(4)
             subprocess.run(["git", "checkout", "-b", branch], stdout=subprocess.PIPE)
 
-        print(5)
-        subprocess.run(["git", "add", "--all"], stdout=subprocess.PIPE)
-        print(6)
+        if (branch == "main") and ("url" not in git_config):
+            subprocess.run(["git", "pull", "origin", "main"], stdout=subprocess.PIPE)
+
+        subprocess.run(["git-lfs", "track"]+track_extensions, stdout=subprocess.PIPE)
+
+        subprocess.run(["git", "add", "."], stdout=subprocess.PIPE)
         subprocess.run(["git", "commit", "-m", commit_message], stdout=subprocess.PIPE)
 
-        print(7)
         subprocess.run(["git", "push", "origin", branch])
-        print(8)
-
-
-if __name__ == "__main__":
-
-    mix = ModelHubMixin()
-    mix.upload_to_hub("vasudevgupta/test", "test")
+        os.chdir("../")

--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -19,47 +19,48 @@ class ModelHubMixin(object):
             >>> from huggingface_hub import ModelHubMixin
 
             >>> class MyModel(nn.Module, ModelHubMixin):
-            ...    def __init__(self):
+            ...    def __init__(self, **kwargs):
             ...        super().__init__()
+            ...        self.config = kwargs.pop("config", None)
             ...        self.layer = ...
             ...    def forward(self, ...)
             ...        return ...
 
             >>> model = MyModel()
-            >>> model.save_pretrained("mymodel") # Saving model weights in the directory
-            >>> model.upload_to_hub("mymodel", "model-1") # Pushing model-weights to hf-hub
+            >>> model.save_pretrained("mymodel", push_to_hub=False) # Saving model weights in the directory
+            >>> model.push_to_hub("mymodel", "model-1") # Pushing model-weights to hf-hub
 
             >>> # Downloading weights from hf-hub & model will be initialized from those weights
-            >>> model = MyModel.from_pretrained("username/mymodel")
+            >>> model = MyModel.from_pretrained("username/mymodel@main")
         """
 
     def save_pretrained(
-        self, save_directory: str, config: dict = None, push_to_hub=False, model_id=None
+        self,
+        save_directory: str,
+        config: dict = None,
+        push_to_hub: bool = False,
+        model_id: str = None,
     ):
         """
         Saving weights in local directory.
 
         Parameters:
             save_directory (:obj:`str`):
-                Directory in which you want to save weights.
+                Specify directory in which you want to save weights.
             config (:obj:`dict`, `optional`):
-                specify config incase you want to save config.
+                specify config (must be dict) incase you want to save it.
+            push_to_hub (:obj:`bool`, `optional`, defaults to :obj:`False`):
+                Set it to `True` in case you want to push your weights to huggingface_hub
+            model_id (:obj:`str`, `optional`, defaults to :obj:`save_directory`):
+                Repo name in huggingface_hub. If not specified, repo name will be same as `save_directory`
         """
         os.makedirs(save_directory, exist_ok=True)
-        config_to_save = None
 
         # saving config
-        if hasattr(self, "config"):
-            if isinstance(self.config, dict):
-                config_to_save = self.config
-
         if isinstance(config, dict):
-            config_to_save = config
-
-        if config_to_save is not None:
             path = os.path.join(save_directory, CONFIG_NAME)
             with open(path, "w") as f:
-                json.dump(config_to_save, f)
+                json.dump(config, f)
 
         # saving model weights
         path = os.path.join(save_directory, PYTORCH_WEIGHTS_NAME)
@@ -69,7 +70,7 @@ class ModelHubMixin(object):
             model_id = save_directory
 
         if push_to_hub:
-            self.push_to_hub(save_directory, model_id)
+            return self.push_to_hub(save_directory, model_id=model_id)
 
     def _save_pretrained(self, path):
         """
@@ -79,7 +80,7 @@ class ModelHubMixin(object):
         torch.save(model_to_save.state_dict(), path)
 
     @classmethod
-    def from_pretrained(cls, pretrained_model_name_or_path: str, *model_args, **kwargs):
+    def from_pretrained(cls, pretrained_model_name_or_path: str, **kwargs):
         r"""
         Instantiate a pretrained pytorch model from a pre-trained model configuration from huggingface-hub.
         The model is set in evaluation mode by default using ``model.eval()`` (Dropout modules are deactivated). To
@@ -133,18 +134,12 @@ class ModelHubMixin(object):
         cache_dir = kwargs.pop("cache_dir", None)
         local_files_only = kwargs.pop("local_files_only", False)
 
-        if len(model_id.split("/")) == 1:
-            name = model_id
-        else:
-            _, name = model_id.split("/")
+        revision = None
+        if len(model_id.split("@")) == 2:
+            model_id, revision = model_id.split("@")
 
-        revision = "main"
-        if len(name.split("@")) > 1:
-            name, revision = name.split("@")
-
-        if name in os.listdir() and CONFIG_NAME in os.listdir(name):
-            print("LOADING weights from local directory")
-            config_file = os.path.join(name, CONFIG_NAME)
+        if model_id in os.listdir() and CONFIG_NAME in os.listdir(model_id):
+            config_file = os.path.join(model_id, CONFIG_NAME)
         else:
             try:
                 config_url = hf_hub_url(
@@ -162,9 +157,9 @@ class ModelHubMixin(object):
             except:
                 config_file = None
 
-        if name in os.listdir():
+        if model_id in os.listdir():
             print("LOADING weights from local directory")
-            model_file = os.path.join(name, PYTORCH_WEIGHTS_NAME)
+            model_file = os.path.join(model_id, PYTORCH_WEIGHTS_NAME)
         else:
             model_url = hf_hub_url(
                 model_id, filename=PYTORCH_WEIGHTS_NAME, revision=revision
@@ -182,9 +177,9 @@ class ModelHubMixin(object):
         if config_file is not None:
             with open(config_file, "r", encoding="utf-8") as f:
                 config = json.load(f)
-            model = cls(config, **kwargs)
-        else:
-            model = cls(**kwargs)
+            kwargs.update({"config": config})
+
+        model = cls(**kwargs)
 
         state_dict = torch.load(model_file, map_location=map_location)
         model.load_state_dict(state_dict, strict=strict)
@@ -193,22 +188,27 @@ class ModelHubMixin(object):
         return model
 
     @staticmethod
-    def push_to_hub(weights_directory: str, model_id: str, **kwargs):
+    def push_to_hub(save_directory: str, **kwargs):
         """
         Parameters:
-            weights_directory (:obj:`Union[str, os.PathLike]`):
-                Directory having model-weights & config.
-            model_id is like ``bert-base-uncased@main``
+            save_directory (:obj:`Union[str, os.PathLike]`):
+                Directory having model weights & config.
+            model_id (:obj:`str`, `optional`, defaults to :obj:`save_directory`):
+                Repo name in huggingface_hub. If not specified, repo name will be same as `save_directory`
+            repo_url (:obj:`str`, `optional`):
+                Specify this in case you want to push to existing repo in hub.
+            organization (:obj:`str`, `optional`):
+                Organization in which you want to push your model.
+            private (:obj:`bool`, `optional`):
+                private: Whether the model repo should be private (requires a paid huggingface.co account)
+            commit_message (:obj:`str`, `optional`, defaults to :obj:`add model`):
+                Message to commit while pushing
         """
         repo_url = kwargs.pop("repo_url", None)
-
         commit_message = kwargs.pop("commit_message", "add model")
         organization = kwargs.pop("organization", None)
         private = kwargs.pop("private", None)
-
-        revision = "main"
-        if len(model_id.split("@")) > 1:
-            model_id, revision = model_id.split("@")
+        model_id = kwargs.pop("model_id", save_directory)
 
         token = HfFolder.get_token()
         if repo_url is None:
@@ -221,6 +221,6 @@ class ModelHubMixin(object):
                 exist_ok=True,
             )
 
-        repo = Repository(weights_directory, clone_from=repo_url, use_auth_token=token)
+        repo = Repository(save_directory, clone_from=repo_url, use_auth_token=token)
 
         return repo.push_to_hub(commit_message=commit_message)

--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -3,14 +3,16 @@ import logging
 import os
 from typing import Dict, Optional
 
-import torch
-
 import requests
 
 from .constants import CONFIG_NAME, PYTORCH_WEIGHTS_NAME
-from .file_download import cached_download, hf_hub_url
+from .file_download import cached_download, hf_hub_url, is_torch_available
 from .hf_api import HfApi, HfFolder
 from .repository import Repository
+
+
+if is_torch_available():
+    import torch
 
 
 logger = logging.getLogger(__name__)

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -169,7 +169,7 @@ class Repository:
                     cwd=self.local_dir,
                 )
 
-                if not "origin" in output.stdout.split():
+                if "origin" not in output.stdout.split():
                     subprocess.run(
                         ["git", "remote", "add", "origin", repo_url],
                         stderr=subprocess.PIPE,
@@ -205,7 +205,7 @@ class Repository:
                     cwd=self.local_dir,
                 )
 
-                if not "main" in output.stdout.split():
+                if "main" not in output.stdout.split():
                     # TODO(check if we really want the --force flag)
                     subprocess.run(
                         "git checkout origin/main -ft".split(),

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -327,7 +327,7 @@ class Repository:
         """
         git pull
         """
-        args = "git pull origin main".split()
+        args = "git pull".split()
         if rebase:
             args.append("--rebase")
         try:

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -385,7 +385,7 @@ class Repository:
         """
         try:
             result = subprocess.run(
-                "git push".split(),
+                "git push origin main".split(),
                 stderr=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 check=True,

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -159,14 +159,19 @@ class Repository:
                     encoding="utf-8",
                     cwd=self.local_dir,
                 )
-                subprocess.run(
-                    ["git", "remote", "add", "origin", repo_url],
-                    stderr=subprocess.PIPE,
-                    stdout=subprocess.PIPE,
-                    check=True,
-                    encoding="utf-8",
-                    cwd=self.local_dir,
-                )
+
+                try:
+                    subprocess.run(
+                        ["git", "remote", "add", "origin", repo_url],
+                        stderr=subprocess.PIPE,
+                        stdout=subprocess.PIPE,
+                        check=True,
+                        encoding="utf-8",
+                        cwd=self.local_dir,
+                    )
+                except:
+                    logger.info("remote ORIGIN already exist")
+
                 subprocess.run(
                     "git fetch".split(),
                     stderr=subprocess.PIPE,
@@ -184,14 +189,18 @@ class Repository:
                     cwd=self.local_dir,
                 )
                 # TODO(check if we really want the --force flag)
-                subprocess.run(
-                    "git checkout origin/main -ft".split(),
-                    stderr=subprocess.PIPE,
-                    stdout=subprocess.PIPE,
-                    encoding="utf-8",
-                    check=True,
-                    cwd=self.local_dir,
-                )
+                try:
+                    subprocess.run(
+                        "git checkout origin/main -ft".split(),
+                        stderr=subprocess.PIPE,
+                        stdout=subprocess.PIPE,
+                        encoding="utf-8",
+                        check=True,
+                        cwd=self.local_dir,
+                    )
+                except:
+                    logger.info("Already on branch main")
+
         except subprocess.CalledProcessError as exc:
             raise EnvironmentError(exc.stderr)
 

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -160,7 +160,16 @@ class Repository:
                     cwd=self.local_dir,
                 )
 
-                try:
+                output = subprocess.run(
+                    "git remote -v".split(),
+                    stderr=subprocess.PIPE,
+                    stdout=subprocess.PIPE,
+                    check=True,
+                    encoding="utf-8",
+                    cwd=self.local_dir,
+                )
+
+                if not "origin" in output.stdout.split():
                     subprocess.run(
                         ["git", "remote", "add", "origin", repo_url],
                         stderr=subprocess.PIPE,
@@ -169,8 +178,6 @@ class Repository:
                         encoding="utf-8",
                         cwd=self.local_dir,
                     )
-                except:
-                    logger.info("remote ORIGIN already exist")
 
                 subprocess.run(
                     "git fetch".split(),
@@ -188,8 +195,18 @@ class Repository:
                     check=True,
                     cwd=self.local_dir,
                 )
-                # TODO(check if we really want the --force flag)
-                try:
+
+                output = subprocess.run(
+                    "git branch".split(),
+                    stderr=subprocess.PIPE,
+                    stdout=subprocess.PIPE,
+                    check=True,
+                    encoding="utf-8",
+                    cwd=self.local_dir,
+                )
+
+                if not "main" in output.stdout.split():
+                    # TODO(check if we really want the --force flag)
                     subprocess.run(
                         "git checkout origin/main -ft".split(),
                         stderr=subprocess.PIPE,
@@ -198,8 +215,6 @@ class Repository:
                         check=True,
                         cwd=self.local_dir,
                     )
-                except:
-                    logger.info("Already on branch main")
 
         except subprocess.CalledProcessError as exc:
             raise EnvironmentError(exc.stderr)
@@ -385,7 +400,7 @@ class Repository:
         """
         try:
             result = subprocess.run(
-                "git push origin main".split(),
+                "git push".split(),
                 stderr=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 check=True,

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -327,7 +327,7 @@ class Repository:
         """
         git pull
         """
-        args = "git pull".split()
+        args = "git pull origin main".split()
         if rebase:
             args.append("--rebase")
         try:

--- a/src/huggingface_hub/saving_utils.py
+++ b/src/huggingface_hub/saving_utils.py
@@ -1,0 +1,94 @@
+import os
+import json
+from .file_download import (
+    hf_hub_url, 
+    cached_download,
+    CONFIG_NAME,
+    PYTORCH_WEIGHTS_NAME
+    )
+
+import torch
+
+
+class SavingUtils(object):
+
+    def __init__(self, **kwargs):
+        """
+
+        """
+
+    def save_pretrained(self, save_directory:str):
+        """
+            Saving weights in local directory that can be loaded directly from huggingface hub
+        """
+
+        if save_directory not in os.listdir(): 
+            os.makedirs(save_directory)
+
+        # saving config
+        if hasattr(self, 'config'):
+            path = os.path.join(save_directory, CONFIG_NAME)
+            with open(path, "w") as f:
+                json.dump(self.config, f)
+
+        # saving only the adapter weights and length embedding
+        path = os.path.join(save_directory, PYTORCH_WEIGHTS_NAME)
+        self._save_pretrained(path, verbose=False)
+
+        return True
+
+    def _save_pretrained(self, path, verbose):
+        """
+            Overwrite this method in case you don't want to save complete model, rather some specific layers
+        """
+
+        # Only save the model itself if we are using distributed training
+        model_to_save = self.module if hasattr(self, "module") else self
+
+        torch.save(model_to_save.state_dict(), path)
+        if verbose:
+            print(f"saving model weights")
+
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path:str, **kwargs):
+        """
+            Setting up this method will enable to load directly from huggingface hub just like other HF models are loaded
+        """
+        model_id = pretrained_model_name_or_path
+        strict = kwargs.pop("strict", True)
+        map_location = kwargs.pop("map_location", torch.device("cpu"))
+
+        if len(model_id.split("/")) == 1:
+            name = model_id
+        else:
+            _, name = model_id.split("/")
+
+        if name in os.listdir() and CONFIG_NAME in os.listdir(name):
+            print("LOADING weights from local directory")
+            config_file = os.path.join(name, CONFIG_NAME)
+        else:
+            try:
+                config_url = hf_hub_url(model_id, filename=CONFIG_NAME)
+                config_file = cached_download(config_url)
+            except:
+                config_file = None
+
+        if name in os.listdir():
+            print("LOADING weights from local directory")
+            model_file = os.path.join(name, PYTORCH_WEIGHTS_NAME)
+        else:
+            model_url = hf_hub_url(model_id, filename=PYTORCH_WEIGHTS_NAME)
+            model_file = cached_download(model_url)
+
+        if config_file is not None:
+            with open(config_file, "r", encoding="utf-8") as f:
+                config = json.load(f)
+            model = cls(config, **kwargs)
+        else:
+            model = cls(**kwargs)
+
+        state_dict = torch.load(model_file, map_location=map_location)
+        model.load_state_dict(state_dict, strict=strict)
+        model.eval()
+
+        return model

--- a/tests/test_hubmixin.py
+++ b/tests/test_hubmixin.py
@@ -46,3 +46,10 @@ class DummyModelTest(unittest.TestCase):
         model = DummyModel()
         model.save_pretrained("dummy-wts", push_to_hub=False)
         model.push_to_hub("dummy-wts", model_id=DUMMY_REPO_NAME)
+
+
+if __name__ == "__main__":
+    DummyModelTest().test_push_to_hub()
+    DummyModelTest().test_save_pretrained()
+    DummyModelTest().test_from_pretrained()
+    # DummyModel.from_pretrained("vasudevgupta/dummy")

--- a/tests/test_hubmixin.py
+++ b/tests/test_hubmixin.py
@@ -46,6 +46,3 @@ class DummyModelTest(unittest.TestCase):
         model = DummyModel()
         _ = model.save_pretrained("dummy-wts", push_to_hub=False)
         model.push_to_hub("dummy-wts", model_id=DUMMY_REPO_NAME)
-
-if __name__ == '__main__':
-    DummyModelTest().test_save_pretrained()

--- a/tests/test_hubmixin.py
+++ b/tests/test_hubmixin.py
@@ -1,0 +1,51 @@
+import unittest
+
+import torch.nn as nn
+
+from huggingface_hub import ModelHubMixin
+
+
+HUGGINGFACE_ID = "vasudevgupta"
+DUMMY_REPO_NAME = "dummy"
+
+
+class DummyModel(nn.Module, ModelHubMixin):
+    def __init__(self, **kwargs):
+        super().__init__()
+        self.config = kwargs.pop("config", None)
+        self.l1 = nn.Linear(2, 2)
+
+    def forward(self, x):
+        return self.l1(x)
+
+
+class DummyModelTest(unittest.TestCase):
+    def test_save_pretrained(self):
+        model = DummyModel()
+        _ = model.save_pretrained(DUMMY_REPO_NAME)
+        _ = model.save_pretrained(
+            DUMMY_REPO_NAME, config={"num": 12, "act": "gelu"}, push_to_hub=True
+        )
+        _ = model.save_pretrained(
+            DUMMY_REPO_NAME, config={"num": 24, "act": "relu"}, push_to_hub=True
+        )
+        _ = model.save_pretrained(
+            "dummy-wts", config=None, push_to_hub=True, model_id=DUMMY_REPO_NAME
+        )
+
+    def test_from_pretrained(self):
+        model = DummyModel()
+        _ = model.save_pretrained(
+            DUMMY_REPO_NAME, config={"num": 7, "act": "gelu_fast"}, push_to_hub=True
+        )
+
+        model = DummyModel.from_pretrained(f"{HUGGINGFACE_ID}/{DUMMY_REPO_NAME}@main")
+        self.assertTrue(model.config == {"num": 7, "act": "gelu_fast"})
+
+    def test_push_to_hub(self):
+        model = DummyModel()
+        _ = model.save_pretrained("dummy-wts", push_to_hub=False)
+        model.push_to_hub("dummy-wts", model_id=DUMMY_REPO_NAME)
+
+if __name__ == '__main__':
+    DummyModelTest().test_save_pretrained()

--- a/tests/test_hubmixin.py
+++ b/tests/test_hubmixin.py
@@ -22,20 +22,20 @@ class DummyModel(nn.Module, ModelHubMixin):
 class DummyModelTest(unittest.TestCase):
     def test_save_pretrained(self):
         model = DummyModel()
-        _ = model.save_pretrained(DUMMY_REPO_NAME)
-        _ = model.save_pretrained(
+        model.save_pretrained(DUMMY_REPO_NAME)
+        model.save_pretrained(
             DUMMY_REPO_NAME, config={"num": 12, "act": "gelu"}, push_to_hub=True
         )
-        _ = model.save_pretrained(
+        model.save_pretrained(
             DUMMY_REPO_NAME, config={"num": 24, "act": "relu"}, push_to_hub=True
         )
-        _ = model.save_pretrained(
+        model.save_pretrained(
             "dummy-wts", config=None, push_to_hub=True, model_id=DUMMY_REPO_NAME
         )
 
     def test_from_pretrained(self):
         model = DummyModel()
-        _ = model.save_pretrained(
+        model.save_pretrained(
             DUMMY_REPO_NAME, config={"num": 7, "act": "gelu_fast"}, push_to_hub=True
         )
 
@@ -44,5 +44,5 @@ class DummyModelTest(unittest.TestCase):
 
     def test_push_to_hub(self):
         model = DummyModel()
-        _ = model.save_pretrained("dummy-wts", push_to_hub=False)
+        model.save_pretrained("dummy-wts", push_to_hub=False)
         model.push_to_hub("dummy-wts", model_id=DUMMY_REPO_NAME)

--- a/tests/test_hubmixin.py
+++ b/tests/test_hubmixin.py
@@ -26,7 +26,7 @@ def require_torch(test_case):
 
 
 @require_torch
-class DummyModel(nn.Module, ModelHubMixin):
+class DummyModel(ModelHubMixin):
     def __init__(self, **kwargs):
         super().__init__()
         self.config = kwargs.pop("config", None)

--- a/tests/test_hubmixin.py
+++ b/tests/test_hubmixin.py
@@ -1,14 +1,31 @@
 import unittest
 
-import torch.nn as nn
+from huggingface_hub.file_download import is_torch_available
+from huggingface_hub.hub_mixin import ModelHubMixin
 
-from huggingface_hub import ModelHubMixin
+
+if is_torch_available():
+    import torch.nn as nn
 
 
 HUGGINGFACE_ID = "vasudevgupta"
 DUMMY_REPO_NAME = "dummy"
 
 
+def require_torch(test_case):
+    """
+    Decorator marking a test that requires PyTorch.
+
+    These tests are skipped when PyTorch isn't installed.
+
+    """
+    if not is_torch_available():
+        return unittest.skip("test requires PyTorch")(test_case)
+    else:
+        return test_case
+
+
+@require_torch
 class DummyModel(nn.Module, ModelHubMixin):
     def __init__(self, **kwargs):
         super().__init__()
@@ -19,6 +36,7 @@ class DummyModel(nn.Module, ModelHubMixin):
         return self.l1(x)
 
 
+@require_torch
 class DummyModelTest(unittest.TestCase):
     def test_save_pretrained(self):
         model = DummyModel()

--- a/tests/test_hubmixin.py
+++ b/tests/test_hubmixin.py
@@ -46,10 +46,3 @@ class DummyModelTest(unittest.TestCase):
         model = DummyModel()
         model.save_pretrained("dummy-wts", push_to_hub=False)
         model.push_to_hub("dummy-wts", model_id=DUMMY_REPO_NAME)
-
-
-if __name__ == "__main__":
-    DummyModelTest().test_push_to_hub()
-    DummyModelTest().test_save_pretrained()
-    DummyModelTest().test_from_pretrained()
-    # DummyModel.from_pretrained("vasudevgupta/dummy")


### PR DESCRIPTION
This PR will add feature as discussed in issue #9.

## Example
```python
from huggingface_hub import ModelHubMixin

class MyModel(nn.Module, ModelHubMixin):
   def __init__(self, **kwargs):
      super().__init__()
      self.config = kwargs.pop("config", None)
      self.layer = ...
   def forward(self, ...):
      return ...

model = MyModel()

# saving model to local directory & pushing to hub
model.save_pretrained("mymodel", upload_to_hub=True, config={"act": "gelu"})

# initiatizing model & loading it from trained-weights
model = MyModel.from_pretrained("username/mymodel@main")
```

## Note
 - In case user want to save some specific layers as per his needs, he can simple overwrite `._save_pretrained()` method.
 - Supporting all kind of `PyTorch` model.
 - `tf2` not supported currently
