### PR TITLE
multipart: don't wait for first chunk to be uploaded to start all workers

### DIFF
--- a/src/huggingface_hub/commands/lfs.py
+++ b/src/huggingface_hub/commands/lfs.py
@@ -189,6 +189,18 @@ class LfsUploadCommand:
             chunk_size = int(header.pop("chunk_size"))
             presigned_urls: List[str] = list(header.values())
 
+            # Send a "started" progress event to allow other workers to start.
+            # Otherwise they're delayed until first "progress" event is reported,
+            # i.e. after the first 5GB by default (!)
+            write_msg(
+                {
+                    "event": "progress",
+                    "oid": oid,
+                    "bytesSoFar": 1,
+                    "bytesSinceLast": 0,
+                }
+            )
+
             parts = []
             for i, presigned_url in enumerate(presigned_urls):
                 with FileSlice(


### PR DESCRIPTION
Got reminded about that by https://github.com/huggingface/autonlp/pull/18#discussion_r585660502

<img width="941" alt="Screen Shot 2021-03-02 at 2 35 55 PM" src="https://user-images.githubusercontent.com/5020707/109704449-9f084f00-7b64-11eb-8fad-74eed87586bd.png">
