### PR TITLE
Add HF_HUB_OFFLINE env var

### DIFF
--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -1,6 +1,11 @@
 import os
 
 
+# Possible values for env variables
+
+ENV_VARS_TRUE_VALUES = {"1", "ON", "YES", "TRUE"}
+ENV_VARS_TRUE_AND_AUTO_VALUES = ENV_VARS_TRUE_VALUES.union({"AUTO"})
+
 # Constants for file downloads
 
 PYTORCH_WEIGHTS_NAME = "pytorch_model.bin"
@@ -30,3 +35,9 @@ hf_cache_home = os.path.expanduser(
 default_cache_path = os.path.join(hf_cache_home, "hub")
 
 HUGGINGFACE_HUB_CACHE = os.getenv("HUGGINGFACE_HUB_CACHE", default_cache_path)
+
+HF_HUB_OFFLINE = os.environ.get("HF_HUB_OFFLINE", "AUTO").upper()
+if HF_HUB_OFFLINE in ENV_VARS_TRUE_VALUES:
+    HF_HUB_OFFLINE = True
+else:
+    HF_HUB_OFFLINE = False

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -348,14 +348,14 @@ def cached_download(
             # between the HEAD and the GET (unlikely, but hey).
             if 300 <= r.status_code <= 399:
                 url_to_download = r.headers["Location"]
+        except (requests.exceptions.SSLError, requests.exceptions.ProxyError):
+            # Actually raise for those subclasses of ConnectionError
+            raise
         except (
             requests.exceptions.ConnectionError,
             requests.exceptions.Timeout,
             OfflineModeIsEnabled,
-        ) as exc:
-            # Actually raise for those subclasses of ConnectionError:
-            if isinstance(exc, requests.exceptions.ProxyError):
-                raise exc
+        ):
             # Otherwise, our Internet connection is down.
             # etag is None
             pass

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -198,7 +198,7 @@ def _request_with_retry(
 ) -> requests.Response:
     """Wrapper around requests to retry in case it fails with a ConnectTimeout, with exponential backoff.
 
-    Note that if the environment variable HF_DATASETS_OFFLINE is set to 1, then a OfflineModeIsEnabled error is raised.
+    Note that if the environment variable HF_HUB_OFFLINE is set to 1, then a OfflineModeIsEnabled error is raised.
 
     Args:
         method (str): HTTP method, such as 'GET' or 'HEAD'

--- a/tests/test_offline_utils.py
+++ b/tests/test_offline_utils.py
@@ -1,0 +1,36 @@
+from io import BytesIO
+
+import pytest
+
+import requests
+from huggingface_hub.file_download import http_get
+
+from .testing_utils import (
+    OfflineSimulationMode,
+    RequestWouldHangIndefinitelyError,
+    offline,
+)
+
+
+def test_offline_with_timeout():
+    with offline(OfflineSimulationMode.CONNECTION_TIMES_OUT):
+        with pytest.raises(RequestWouldHangIndefinitelyError):
+            requests.request("GET", "https://huggingface.co")
+        with pytest.raises(requests.exceptions.ConnectTimeout):
+            requests.request("GET", "https://huggingface.co", timeout=1.0)
+        with pytest.raises(requests.exceptions.ConnectTimeout):
+            http_get("https://huggingface.co", BytesIO())
+
+
+def test_offline_with_connection_error():
+    with offline(OfflineSimulationMode.CONNECTION_FAILS):
+        with pytest.raises(requests.exceptions.ConnectionError):
+            requests.request("GET", "https://huggingface.co")
+        with pytest.raises(requests.exceptions.ConnectionError):
+            http_get("https://huggingface.co", BytesIO())
+
+
+def test_offline_with_datasets_offline_mode_enabled():
+    with offline(OfflineSimulationMode.HF_HUB_OFFLINE_SET_TO_1):
+        with pytest.raises(ConnectionError):
+            http_get("https://huggingface.co", BytesIO())

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -1,6 +1,9 @@
 import os
 import unittest
+from contextlib import contextmanager
 from distutils.util import strtobool
+from enum import Enum
+from unittest.mock import patch
 
 
 SMALL_MODEL_IDENTIFIER = "julien-c/bert-xsmall-dummy"
@@ -55,3 +58,70 @@ def require_git_lfs(test_case):
         return unittest.skip("test of git lfs workflow")(test_case)
     else:
         return test_case
+
+
+class RequestWouldHangIndefinitelyError(Exception):
+    pass
+
+
+class OfflineSimulationMode(Enum):
+    CONNECTION_FAILS = 0
+    CONNECTION_TIMES_OUT = 1
+    HF_HUB_OFFLINE_SET_TO_1 = 2
+
+
+@contextmanager
+def offline(mode=OfflineSimulationMode.CONNECTION_FAILS, timeout=1e-16):
+    """
+    Simulate offline mode.
+
+    There are three offline simulatiom modes:
+
+    CONNECTION_FAILS (default mode): a ConnectionError is raised for each network call.
+        Connection errors are created by mocking socket.socket
+    CONNECTION_TIMES_OUT: the connection hangs until it times out.
+        The default timeout value is low (1e-16) to speed up the tests.
+        Timeout errors are created by mocking requests.request
+    HF_HUB_OFFLINE_SET_TO_1: the HF_HUB_OFFLINE_SET_TO_1 environment variable is set to 1.
+        This makes the http/ftp calls of the library instantly fail and raise an OfflineModeEmabled error.
+    """
+    import socket
+
+    from requests import request as online_request
+
+    def timeout_request(method, url, **kwargs):
+        # Change the url to an invalid url so that the connection hangs
+        invalid_url = "https://10.255.255.1"
+        if kwargs.get("timeout") is None:
+            raise RequestWouldHangIndefinitelyError(
+                f"Tried a call to {url} in offline mode with no timeout set. Please set a timeout."
+            )
+        kwargs["timeout"] = timeout
+        try:
+            return online_request(method, invalid_url, **kwargs)
+        except Exception as e:
+            # The following changes in the error are just here to make the offline timeout error prettier
+            e.request.url = url
+            max_retry_error = e.args[0]
+            max_retry_error.args = (
+                max_retry_error.args[0].replace("10.255.255.1", f"OfflineMock[{url}]"),
+            )
+            e.args = (max_retry_error,)
+            raise
+
+    def offline_socket(*args, **kwargs):
+        raise socket.error("Offline mode is enabled.")
+
+    if mode is OfflineSimulationMode.CONNECTION_FAILS:
+        # inspired from https://stackoverflow.com/a/18601897
+        with patch("socket.socket", offline_socket):
+            yield
+    elif mode is OfflineSimulationMode.CONNECTION_TIMES_OUT:
+        # inspired from https://stackoverflow.com/a/904609
+        with patch("requests.request", timeout_request):
+            yield
+    elif mode is OfflineSimulationMode.HF_HUB_OFFLINE_SET_TO_1:
+        with patch("huggingface_hub.constants.HF_HUB_OFFLINE", True):
+            yield
+    else:
+        raise ValueError("Please use a value from the OfflineSimulationMode enum.")


### PR DESCRIPTION
This adds the `HF_HUB_OFFLINE` env var to tell `huggingface_hub` (same as in hf/transformers and hf/datasets).

This allows to tell the library to look directly at the cache instead of trying network calls.

Moreover I fixed/changed a few things:
- I added a default timeout for requests in file_download.py (otherwise they could hang in a firewalled environment) and never fall back on the cache
- I made it so `force_download=True` doesn't check the cache if there's no internet connection, but raises an error instead.
- I added retries as in hf/datasets if one network call fails if you're unlucky or have bad wifi
- I added a testing utility context manager called `offline` that you can use to test the library's behavior under different offline modes (same as in hf/datasets)

I'm not sure why the CI fails for python 3.9 though