### PR TITLE
Fix python version check

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -32,7 +32,7 @@ from .hf_api import HfFolder
 
 logger = logging.getLogger(__name__)
 
-_PY_VERSION: str = sys.version.split()[0]
+_PY_VERSION: str = sys.version.split()[0].rstrip("+")
 
 if tuple(int(i) for i in _PY_VERSION.split(".")) < (3, 8, 0):
     import importlib_metadata


### PR DESCRIPTION
I'm using poetry to manage my environment and using python 3.9 on Ubuntu. On my system, `sys.version` lists my python version as "3.9.0+", which was causing an error in the file I modified. This should solve the problem.