### PR TITLE
Fix conda by specifying python version + add tests to main branch

### DIFF
--- a/.github/workflows/python-quality.yml
+++ b/.github/workflows/python-quality.yml
@@ -1,6 +1,9 @@
 name: Python quality
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     types: [assigned, opened, synchronize, reopened]
 

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,6 +1,9 @@
 name: Python tests
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     types: [assigned, opened, synchronize, reopened]
 

--- a/.github/workflows/release-conda.yml
+++ b/.github/workflows/release-conda.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           auto-update-conda: true
           auto-activate-base: false
+          python-version: 3.8
           activate-environment: "build-hub"
 
       - name: Setup conda env


### PR DESCRIPTION
This PR fixes two things:

- The anaconda upload fails because it lacks support for python 3.9, while python 3.9 is the default conda installation. This PR sets python 3.8 as the default
- The current CI doesn't run on `main`