### PR TITLE
added framework to snapshot download for SageMaker integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Parameters:
 - a `repo_id` in the format `namespace/repository`
 - a `revision` on which the repository will be downloaded
 - a `cache_dir` which you can specify if you want to control where on disk the files are cached.
+- a `use_auth_token` if a api token should be used to download the repository, required for private models
 - a `framework` if only framework specific files should be downloaded. 
 
 <br>

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Parameters:
 - a `repo_id` in the format `namespace/repository`
 - a `revision` on which the repository will be downloaded
 - a `cache_dir` which you can specify if you want to control where on disk the files are cached.
+- a `framework` if only framework specific files should be downloaded. 
 
 <br>
 

--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -14,6 +14,17 @@ TF_WEIGHTS_NAME = "model.ckpt"
 FLAX_WEIGHTS_NAME = "flax_model.msgpack"
 CONFIG_NAME = "config.json"
 
+FILE_LIST_NAMES = [
+    "config.json",
+    "special_tokens_map.json",
+    "tokenizer_config.json",
+    "tokenizer.json",
+    "vocab.json",
+    "vocab.txt",
+    "merges.txt",
+    "preprocessor_config.json",
+]
+
 HUGGINGFACE_CO_URL_HOME = "https://huggingface.co/"
 
 HUGGINGFACE_CO_URL_TEMPLATE = (

--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -23,13 +23,14 @@ FILE_LIST_NAMES = [
     "vocab.txt",
     "merges.txt",
     "preprocessor_config.json",
+    "added_tokens.json",
+    "README.md",
+    "spiece.model",
 ]
 
 HUGGINGFACE_CO_URL_HOME = "https://huggingface.co/"
 
-HUGGINGFACE_CO_URL_TEMPLATE = (
-    "https://huggingface.co/{repo_id}/resolve/{revision}/{filename}"
-)
+HUGGINGFACE_CO_URL_TEMPLATE = "https://huggingface.co/{repo_id}/resolve/{revision}/{filename}"
 
 REPO_TYPE_DATASET = "dataset"
 REPO_TYPES = [None, REPO_TYPE_DATASET]
@@ -39,9 +40,7 @@ REPO_TYPE_DATASET_URL_PREFIX = "datasets/"
 
 # default cache
 hf_cache_home = os.path.expanduser(
-    os.getenv(
-        "HF_HOME", os.path.join(os.getenv("XDG_CACHE_HOME", "~/.cache"), "huggingface")
-    )
+    os.getenv("HF_HOME", os.path.join(os.getenv("XDG_CACHE_HOME", "~/.cache"), "huggingface"))
 )
 default_cache_path = os.path.join(hf_cache_home, "hub")
 

--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -30,7 +30,9 @@ FILE_LIST_NAMES = [
 
 HUGGINGFACE_CO_URL_HOME = "https://huggingface.co/"
 
-HUGGINGFACE_CO_URL_TEMPLATE = "https://huggingface.co/{repo_id}/resolve/{revision}/{filename}"
+HUGGINGFACE_CO_URL_TEMPLATE = (
+    "https://huggingface.co/{repo_id}/resolve/{revision}/{filename}"
+)
 
 REPO_TYPE_DATASET = "dataset"
 REPO_TYPES = [None, REPO_TYPE_DATASET]
@@ -40,7 +42,9 @@ REPO_TYPE_DATASET_URL_PREFIX = "datasets/"
 
 # default cache
 hf_cache_home = os.path.expanduser(
-    os.getenv("HF_HOME", os.path.join(os.getenv("XDG_CACHE_HOME", "~/.cache"), "huggingface"))
+    os.getenv(
+        "HF_HOME", os.path.join(os.getenv("XDG_CACHE_HOME", "~/.cache"), "huggingface")
+    )
 )
 default_cache_path = os.path.join(hf_cache_home, "hub")
 

--- a/src/huggingface_hub/snapshot_download.py
+++ b/src/huggingface_hub/snapshot_download.py
@@ -38,6 +38,7 @@ def snapshot_download(
     repo_id: str,
     revision: Optional[str] = None,
     cache_dir: Union[str, Path, None] = None,
+    use_auth_token: Union[bool, str, None] = None,
     framework: Optional[Frameworks] = None,
 ) -> str:
     """
@@ -60,6 +61,8 @@ def snapshot_download(
             Specifies the revision on which the repository will be downloaded.
         cache_dir (:obj:`str`, `optional`):
             Directory which you can specify if you want to control where on disk the files are cached.
+        use_auth_token (:obj:`str`, `optional`):
+            Defines a Hub api token used for downloading
         framework (:obj:`Frameworks`, `optional`):
             Specify the framework and filters the download files to only load the framework specific ones.
     Return:
@@ -98,7 +101,10 @@ def snapshot_download(
         os.makedirs(nested_dirname, exist_ok=True)
 
         path = cached_download(
-            url, cache_dir=storage_folder, force_filename=relative_filepath
+            url,
+            cache_dir=storage_folder,
+            force_filename=relative_filepath,
+            use_auth_token=use_auth_token,
         )
 
         if os.path.exists(path + ".lock"):


### PR DESCRIPTION
# This PR adds 

the option to define a `framework` in `snapshot_download()` #25 to download only the framework-specific files. For PyTorch -> `pytorch_model.bin`, TensorFlow -> `tf_model.h5`....

I added this feature to the SageMaker inference integration to download models from the hub for a specific framework without using `from_pretrained`and loading the model into memory. 

