### PR TITLE
Include a readable repr for ModelInfo

### DIFF
--- a/src/huggingface_hub/commands/lfs.py
+++ b/src/huggingface_hub/commands/lfs.py
@@ -99,7 +99,7 @@ def write_msg(msg: Dict):
 
 
 def read_msg() -> Optional[Dict]:
-    """Read Line delimited JSON from stdin. """
+    """Read Line delimited JSON from stdin."""
     msg = json.loads(sys.stdin.readline().strip())
 
     if "terminate" in (msg.get("type"), msg.get("event")):

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -73,6 +73,11 @@ class ModelInfo:
         )
         for k, v in kwargs.items():
             setattr(self, k, v)
+            
+    def __repr__(self): 
+        r = f'Model Name: {self.modelId}, Tags: {self.tags}'
+        if self.pipeline_tag: r += f', Task: {self.pipeline_tag}'
+        return r
 
 
 class HfApi:

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -74,7 +74,13 @@ class ModelInfo:
         for k, v in kwargs.items():
             setattr(self, k, v)
             
-    def __repr__(self): 
+    def __repr__(self):
+        s = f'{self.__class__.__name__}:' + ' {'
+        for key, val in self.__dict__.items():
+            s += f'\n\t{key}: {val}'
+        return s + '\n}'
+    
+    def __str__(self):
         r = f'Model Name: {self.modelId}, Tags: {self.tags}'
         if self.pipeline_tag: r += f', Task: {self.pipeline_tag}'
         return r

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -62,7 +62,7 @@ class ModelInfo:
         siblings: Optional[
             List[Dict]
         ] = None,  # list of files that constitute the model
-        **kwargs
+        **kwargs,
     ):
         self.modelId = modelId
         self.sha = sha
@@ -73,16 +73,17 @@ class ModelInfo:
         )
         for k, v in kwargs.items():
             setattr(self, k, v)
-            
+
     def __repr__(self):
-        s = f'{self.__class__.__name__}:' + ' {'
+        s = f"{self.__class__.__name__}:" + " {"
         for key, val in self.__dict__.items():
-            s += f'\n\t{key}: {val}'
-        return s + '\n}'
-    
+            s += f"\n\t{key}: {val}"
+        return s + "\n}"
+
     def __str__(self):
-        r = f'Model Name: {self.modelId}, Tags: {self.tags}'
-        if self.pipeline_tag: r += f', Task: {self.pipeline_tag}'
+        r = f"Model Name: {self.modelId}, Tags: {self.tags}"
+        if self.pipeline_tag:
+            r += f", Task: {self.pipeline_tag}"
         return r
 
 


### PR DESCRIPTION
This includes the start of a better `__repr__` for the `ModelInfo` class, started from this issue: https://github.com/huggingface/huggingface_hub/issues/31

This is based on what I've started for the [AdaptNLP](https://github.com/Novetta/adaptnlp/blob/nbdev_conversion/adaptnlp/model_hub.py#L51)

A few points of difference that could be done here is we could also programmatically include the tasks available for it, similar to what was done in AdaptNLP, but I guess the key information is what would be the best-case scenario for a model repr? Currently what I have lets it look like so:
```python
Model Name: "gpt2", Tags: ['pytorch', 'tf', 't5'], Task: ['summarization']
```

For adapt I go a bit further (with the whole programmatic way I mentioned early) by checking what tags are also tasks and assigning them then.

The last thing is if we want something like:
```python
Model Name: "gpt2-hybrid", Author: "username", Tags: ..., Task: ...
```

What are your thoughts? 

cc: @LysandreJik 