### PR TITLE
Alignment on modelcard metadata specification

### DIFF
--- a/modelcard.md
+++ b/modelcard.md
@@ -27,6 +27,7 @@ model-index:
       - name: {metric_name}  # Example: Test WER
         type: {metric_type}  # Example: wer
         value: {metric_value}  # Example: 20.90
+        args: {arg_0}  # Example for BLEU: max_order
 ---
 
 This markdown file contains the spec for the modelcard metadata regarding evaluation parameters. 

--- a/modelcard.md
+++ b/modelcard.md
@@ -29,3 +29,4 @@ model-index:
         value: {metric_value}  # Example: 20.90
 ---
 
+This markdown file contains the spec for the modelcard metadata regarding evaluation parameters. 

--- a/modelcard.md
+++ b/modelcard.md
@@ -1,0 +1,31 @@
+---
+language:
+- {lang_0}  # Example: fr
+- {lang_1}  # Example: en
+license: {license}  # Example: apache-2.0
+tags:
+- {tag_0}  # Example: audio
+- {tag_1}  # Example: automatic-speech-recognition
+- {tag_2}  # Example: speech
+- {tag_3}  # Example to specify a library: allennlp
+datasets:
+- {dataset_0}  # Example: common_voice
+metrics:
+- {metric_0}  # Example: wer
+
+model-index:  
+- name: {model_id}
+  results:
+  - task: 
+      name: {task_name}  # Example: Speech Recognition
+      type: {task_type}  # Example: automatic-speech-recognition
+    dataset:
+      name: {dataset_name}  # Example: Common Voice zh-CN
+      type: {dataset_type}  # Example: common_voice
+      args: {arg_0}  # Example: zh-CN
+    metrics:
+      - name: {metric_name}  # Example: Test WER
+        type: {metric_type}  # Example: wer
+        value: {metric_value}  # Example: 20.90
+---
+


### PR DESCRIPTION
Hi all, opening this PR so that we can all align on the metadata spec for model cards. This metadata is important as it closes the bridge between tasks, datasets, and metrics for a given checkpoint. This will eventually allow programmatic analysis and handling of model cards' metadata on the hub.

The metadata was drafted during the collaboration with papers-with-code in order to have a ranked leaderboard for the XLSR sprint. The following format was adopted:

```
model-index:  
- name: {model_id}
  results:
  - task: 
      name: {task_name}
      type: {task_type}
    dataset:
      name: {dataset_name}
      type: {dataset_type}
      args: {arg_0}
    metrics:
      - name: {metric_name} 
        type: {metric_type}
        value: {metric_value}
        args: {arg_0}
```

This format should allow for multiple tasks and multiple metrics within each task.

Some existing examples of modelcards with this format are the modelcards uploaded during the XLSR sprint, like the following [ydshieh/wav2vec2-large-xlsr-53-chinese-zh-cn-gpt](https://huggingface.co/ydshieh/wav2vec2-large-xlsr-53-chinese-zh-cn-gpt/blob/main/README.md)

Looking forward to your feedback.

Transformers: @sgugger @patrickvonplaten 
Datasets: @lhoestq 
AutoNLP: @abhi1thakur @SBrandeis 
Evaluation: @lewtun 

@Pierrci @julien-c @thomwolf 