### PR TITLE
[Windows support] Very long filenames

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -409,6 +409,15 @@ def cached_download(
 
     # Prevent parallel downloads of the same file with a lock.
     lock_path = cache_path + ".lock"
+
+    # Some Windows versions do not allow for paths longer than 255 characters.
+    # In this case, we must specify it is an extended path by using the "\\?\" prefix.
+    if os.name == "nt" and len(os.path.abspath(lock_path)) > 255:
+        lock_path = u"\\\\?\\" + os.path.abspath(lock_path)
+
+    if os.name == "nt" and len(os.path.abspath(cache_path)) > 255:
+        cache_path = u"\\\\?\\" + os.path.abspath(cache_path)
+
     with FileLock(lock_path):
 
         # If the download just completed while the lock was activated.


### PR DESCRIPTION
The `huggingface_hub` downloads files with very long filenames (135 characters). Since these files may be downloaded to any arbitrary folder, the total length of the path may exceed the 260 character limit imposed by some Windows versions, as visible [here](https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=cmd)

> In the Windows API (with some exceptions discussed in the following paragraphs), the maximum length for a path is MAX_PATH, which is defined as 260 characters.

This PR allows identifying if we're running on the Windows platform and if so checks the absolute length of both the lock file and the actual file to be downloaded. If either of the two resulting paths is too long, it concatenates the `\\?\` prefix that specifies it is an extended path, which has a limit of 32k+ characters.

Closes https://github.com/huggingface/huggingface_hub/issues/35