### PR TITLE
Make error message more verbose when creating a repo

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -240,10 +240,10 @@ class HfApi:
         try:
             r.raise_for_status()
         except HTTPError as e:
-            if r.text:
-                raise HTTPError("{} - {}".format(e, r.json()["error"]))
-            else:
-                raise e
+            if r.json():
+                if "error" in r.json():
+                    raise HTTPError("{} - {}".format(e, r.json()["error"]))
+            raise e
 
         d = r.json()
         return d["url"]

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -22,6 +22,7 @@ from os.path import expanduser
 from typing import BinaryIO, Dict, List, Optional, Tuple, Union
 
 import requests
+from requests.exceptions import HTTPError
 
 from .constants import REPO_TYPE_DATASET, REPO_TYPE_DATASET_URL_PREFIX, REPO_TYPES
 
@@ -235,7 +236,15 @@ class HfApi:
         if exist_ok and r.status_code == 409:
             d = r.json()
             return d["url"]
-        r.raise_for_status()
+
+        try:
+            r.raise_for_status()
+        except HTTPError as e:
+            if r.text:
+                raise HTTPError("{} - {}".format(e, r.json()["error"]))
+            else:
+                raise e
+
         d = r.json()
         return d["url"]
 


### PR DESCRIPTION
I recently had some issues which could have been easily found if the error message was more verbose.

Before: 

> requests.exceptions.HTTPError: 400 Client Error: Bad Request for url: https://huggingface.co/api/repos/create


After: 

> requests.exceptions.HTTPError: 400 Client Error: Bad Request for url: https://huggingface.co/api/repos/create - Only regular characters and '-', '_', '.' accepted