### PR TITLE
Update validation for NLP tasks

### DIFF
--- a/api-inference-community/api_inference_community/validation.py
+++ b/api-inference-community/api_inference_community/validation.py
@@ -9,11 +9,17 @@ from pydantic import BaseModel, ConstrainedFloat, ConstrainedInt, ConstrainedLis
 
 class MinLength(ConstrainedInt):
     ge = 1
-    le = 256
+    le = 500
     strict = True
 
 
 class MaxLength(ConstrainedInt):
+    ge = 1
+    le = 500
+    strict = True
+
+
+class MaxNewTokensTextGeneration(ConstrainedInt):
     ge = 1
     le = 256
     strict = True
@@ -63,7 +69,7 @@ class ZeroShotParamsCheck(BaseModel):
 
 
 class TextGenerationParamsCheck(BaseModel):
-    max_new_tokens: Optional[MaxLength] = None
+    max_new_tokens: Optional[MaxNewTokensTextGeneration] = None
     top_k: Optional[TopK] = None
     top_p: Optional[TopP] = None
     repetition_penalty: Optional[RepetitionPenalty] = None


### PR DESCRIPTION
Summary of changes:
* Aligned max length with `max_new_tokens` in [docs](https://api-inference.huggingface.co/docs/python/html/detailed_parameters.html). 
* Changed `max_length` to `max_new_tokens` for `text-generation`, which I think would be the right param.
* Added `return_full_text` and `num_return_sequences` for `text-generation`
* Added `summarization`, `table-question-answering`, and `text2text-generation` validation.
* Fixed `conversational`. It was using params instead of inputs, and the inputs are others.

Let me know if you disagree with any and I can revert :)