### PR TITLE
Add Adapter Transformers snippet

### DIFF
--- a/interfaces/Libraries.ts
+++ b/interfaces/Libraries.ts
@@ -48,7 +48,7 @@ interface ModelData {
 	/**
 	 * this dictionary has useful information about the model configuration
 	 */
-	config: Obj
+	config: Record<string, any>;
 }
 
 
@@ -264,4 +264,3 @@ export const MODEL_LIBRARIES_UI_ELEMENTS: { [key in keyof typeof ModelLibrary]: 
 		snippet: transformers,
 	},
 } as const;
-

--- a/interfaces/Libraries.ts
+++ b/interfaces/Libraries.ts
@@ -2,7 +2,8 @@
 /**
  * Add your new library here.
  */
-export enum ModelLibrary {
+ export enum ModelLibrary {
+	'adapter-transformers'   = 'Adapter Transformers',
 	'asteroid'               = 'Asteroid',
 	'espnet'                 = 'ESPnet',
 	'flair'                  = 'Flair',
@@ -37,6 +38,10 @@ interface ModelData {
 	 * this is transformers-specific
 	 */
 	autoArchitecture: string;
+	/**
+	 * this dictionary has useful information about the model configuration
+	 */
+	config: Obj
 }
 
 
@@ -69,6 +74,13 @@ function nameWithoutNamespace(modelId: string): string {
 }
 
 //#region snippets
+
+const adapter_transformers = (model: ModelData) =>
+`from transformers import ${model.config.adapter_transformers.model_class}
+
+model = ${model.config.adapter_transformers.model_class}.from_pretrained("${model.config.adapter_transformers.model_name}")
+model.load_adapter("${model.modelId}", source="hf")`;
+
 
 const asteroid = (model: ModelData) =>
 `from asteroid.models import BaseModel
@@ -184,6 +196,12 @@ model = ${model.autoArchitecture}.from_pretrained("${model.modelId}"${model.priv
 
 
 export const MODEL_LIBRARIES_UI_ELEMENTS: { [key in keyof typeof ModelLibrary]: LibraryUiElement } = {
+	"adapter-transformers": {
+		btnLabel: "Adapter Transformers",
+		repoName: "adapter-transformers",
+		repoUrl: "https://github.com/Adapter-Hub/adapter-transformers",
+		snippet: adapter_transformers,
+	},
 	asteroid: {
 		btnLabel: "Asteroid",
 		repoName: "Asteroid",

--- a/interfaces/Libraries.ts
+++ b/interfaces/Libraries.ts
@@ -1,12 +1,5 @@
 
 /**
- * Hf helper type for a dictionary-like object with arbitrary keys.
- */
- declare interface Obj<T = any> {
-	[key: string]: T
-}
-
-/**
  * Add your new library here.
  */
 export enum ModelLibrary {

--- a/interfaces/Libraries.ts
+++ b/interfaces/Libraries.ts
@@ -257,3 +257,4 @@ export const MODEL_LIBRARIES_UI_ELEMENTS: { [key in keyof typeof ModelLibrary]: 
 		snippet: transformers,
 	},
 } as const;
+

--- a/interfaces/Libraries.ts
+++ b/interfaces/Libraries.ts
@@ -1,5 +1,12 @@
 
 /**
+ * Hf helper type for a dictionary-like object with arbitrary keys.
+ */
+ declare interface Obj<T = any> {
+	[key: string]: T
+}
+
+/**
  * Add your new library here.
  */
 export enum ModelLibrary {

--- a/interfaces/Libraries.ts
+++ b/interfaces/Libraries.ts
@@ -2,7 +2,7 @@
 /**
  * Add your new library here.
  */
- export enum ModelLibrary {
+export enum ModelLibrary {
 	'adapter-transformers'   = 'Adapter Transformers',
 	'asteroid'               = 'Asteroid',
 	'espnet'                 = 'ESPnet',


### PR DESCRIPTION
Sibling [PR]( https://github.com/huggingface/moon-landing/pull/734) in moon landing. Thanks to that PR, the config is read from `adapter_config.json` and we get access to specific info from there for the code snippet.

🚀 🚀 

<img width="1194" alt="Screen Shot 2021-06-01 at 11 11 00 AM" src="https://user-images.githubusercontent.com/7246357/120298118-123b7180-c2ca-11eb-850a-b3fcbdbf3cb1.png">

@calpt FYI :)

