### PR TITLE
Add repr() to ModelFile and RepoObj

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -49,6 +49,10 @@ class RepoObj:
         for k, v in kwargs.items():
             setattr(self, k, v)
 
+    def __repr__(self):
+        items = (f"{k}='{v}'" for k, v in self.__dict__.items())
+        return f"{self.__class__.__name__}({', '.join(items)})"
+
 
 class ModelFile:
     """
@@ -59,6 +63,10 @@ class ModelFile:
         self.rfilename = rfilename  # filename relative to the model root
         for k, v in kwargs.items():
             setattr(self, k, v)
+
+    def __repr__(self):
+        items = (f"{k}='{v}'" for k, v in self.__dict__.items())
+        return f"{self.__class__.__name__}({', '.join(items)})"
 
 
 class ModelInfo:


### PR DESCRIPTION
This PR adds `__repr__` functions to:

* `ModelFile`
* `RepoObj`

Examples:

```python
RepoObj(rfilename='.gitattributes', size='732', lastModified='2021-05-17T14:22:56.000Z', commit='f8f9bdad8756476f0efaf68e105635cabcd7f8bc', filename='lewtun/autonlp-imdb_fewshot-111958/.gitattributes')

ModelFile(rfilename='.gitattributes')
```

Unlike the `ModelInfo` class which has quite a few attributes, I did not see a strong reason to implement both `__str__` and `__repr__`.