### PR TITLE
SpeechBrain pipeline for source separation inference

### DIFF
--- a/api-inference-community/docker_images/speechbrain/app/pipelines/audio_source_separation.py
+++ b/api-inference-community/docker_images/speechbrain/app/pipelines/audio_source_separation.py
@@ -2,18 +2,16 @@ from typing import Tuple
 
 import numpy as np
 from app.pipelines import Pipeline
+from speechbrain.pretrained import SepformerSeparation
+import torch
+import torchaudio
 
 
 class AudioSourceSeparationPipeline(Pipeline):
     def __init__(self, model_id: str):
-        # IMPLEMENT_THIS
-        # Preload all the elements you are going to need at inference.
-        # For instance your model, processors, tokenizer that might be needed.
-        # This function is only called once, so do all the heavy processing I/O here
-        raise NotImplementedError(
-            "Please implement AudioSourceSeparationPipeline __init__ function"
-        )
+        self.model = SepformerSeparation.from_hparams(source=model_id)
 
+        
     def __call__(self, inputs: np.array) -> Tuple[np.array, int]:
         """
         Args:
@@ -22,9 +20,36 @@ class AudioSourceSeparationPipeline(Pipeline):
                 Check `app.validation` if a different sample rate is required
                 or if it depends on the model
         Return:
-            A :obj:`np.array` and a :obj:`int`: The raw waveform as a numpy array, and the sampling rate as an int.
+            est_sources: np.array  
+            
+                The raw waveforms as a numpy array of size T x S, where T is number of time points and S is the number of sources, and the sampling rate as an int.
+
+            fs : int:
+                The sampling frequency for the estimated sources
         """
-        # IMPLEMENT_THIS
-        raise NotImplementedError(
-            "Please implement AudioSourceSeparationPipeline __call__ function"
-        )
+
+
+        fs_model = self.model.hparams.sample_rate
+
+        # we resample to the model's sampling frequency if needed
+        # we assume that the input is at 16kHz
+        mix = torch.from_numpy(inputs)
+        if 16000 != fs_model:
+            resamp = torchaudio.transforms.Resample(
+                orig_freq=16000, new_freq=fs_model
+            )
+            mix = resamp(mix)
+
+        # separate
+        est_sources = self.model.separate_batch(mix)
+
+        # normalize for loudness
+        est_sources = est_sources / est_sources.max(dim=1, keepdim=True)[0]
+
+        # return estimated sources as a T(time) x S(n.sources) matrix 
+        return est_sources[0].numpy(), fs_model
+
+         
+
+        
+        

--- a/api-inference-community/docker_images/speechbrain/app/pipelines/audio_source_separation.py
+++ b/api-inference-community/docker_images/speechbrain/app/pipelines/audio_source_separation.py
@@ -43,13 +43,15 @@ class AudioSourceSeparationPipeline(Pipeline):
         # separate
         est_sources = self.model.separate_batch(mix)
 
-        # normalize for loudness
-        est_sources = est_sources / est_sources.max(dim=1, keepdim=True)[0]
+        # Only 1 element in the batch is present
+        est_sources = est_sources[0]
+
+        #normalize for loudness
+        est_sources = est_sources / est_sources.abs().max(dim=0, keepdim=True)[0]
 
         # return estimated sources as a T(time) x S(n.sources) matrix 
-        return est_sources[0].numpy(), fs_model
+        return est_sources.numpy(), fs_model
 
-         
 
-        
+
         


### PR DESCRIPTION
Here's a commit for SpeechBrain source separation pipeline. 

The `__call__` function returns a numpy array of size `Ntimepoints x Nsources`. 

I am not sure if this would work for the huggingface's interface, but I wanted to ask via this PR.   
