### PR TITLE
Add identical_ok option to HfApi.upload_file method

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -398,6 +398,7 @@ class HfApi:
         repo_id: str,
         repo_type: Optional[str] = None,
         revision: Optional[str] = None,
+        identical_ok: bool = True,
     ) -> str:
         """
         Upload a local file (up to 5GB) to the given repo, tracking it with LFS if it's larger than 10MB
@@ -420,6 +421,10 @@ class HfApi:
 
             revision (``str``, Optional):
                 The git revision to commit from. Defaults to the :obj:`"main"` branch.
+
+            identical_ok (``bool``, defaults to ``True``):
+                When set to false, will raise an HTTPError when the file you're trying to upload already exists on the hub
+                and its content did not change.
 
         Returns:
             ``str``: The URL to visualize the uploaded file on the hub
@@ -501,7 +506,12 @@ class HfApi:
         else:
             r = requests.post(path, headers=headers, data=path_or_fileobj)
 
-        r.raise_for_status()
+        try:
+            r.raise_for_status()
+        except HTTPError as err:
+            if not (identical_ok and err.response.status_code == 409):
+                raise err
+
         d = r.json()
         return d["url"]
 


### PR DESCRIPTION
Explicitly mention the request returns 409 when the uploaded file already exists on the hub and is identical

cc @osanseviero 