### PR TITLE
Solve compatibility issues when calling `subprocess.run`

### DIFF
--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -318,7 +318,8 @@ class HfLargefilesTest(HfApiCommonTest):
         subprocess.run(
             ["git", "clone", REMOTE_URL_AUTH, WORKING_REPO_DIR],
             check=True,
-            capture_output=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
         )
         subprocess.run(
             ["git", "lfs", "track", "*.pdf"], check=True, cwd=WORKING_REPO_DIR
@@ -336,7 +337,8 @@ class HfLargefilesTest(HfApiCommonTest):
         subprocess.run(
             ["wget", LARGE_FILE_18MB],
             check=True,
-            capture_output=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             cwd=WORKING_REPO_DIR,
         )
         subprocess.run(["git", "add", "*"], check=True, cwd=WORKING_REPO_DIR)
@@ -346,7 +348,10 @@ class HfLargefilesTest(HfApiCommonTest):
 
         # This will fail as we haven't set up our custom transfer agent yet.
         failed_process = subprocess.run(
-            ["git", "push"], capture_output=True, cwd=WORKING_REPO_DIR
+            ["git", "push"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=WORKING_REPO_DIR,
         )
         self.assertEqual(failed_process.returncode, 1)
         self.assertIn("cli lfs-enable-largefiles", failed_process.stderr.decode())
@@ -366,7 +371,8 @@ class HfLargefilesTest(HfApiCommonTest):
         subprocess.run(
             ["wget", pdf_url, "-O", DEST_FILENAME],
             check=True,
-            capture_output=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             cwd=WORKING_REPO_DIR,
         )
         dest_filesize = os.stat(os.path.join(WORKING_REPO_DIR, DEST_FILENAME)).st_size
@@ -384,13 +390,15 @@ class HfLargefilesTest(HfApiCommonTest):
         subprocess.run(
             ["wget", LARGE_FILE_18MB],
             check=True,
-            capture_output=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             cwd=WORKING_REPO_DIR,
         )
         subprocess.run(
             ["wget", LARGE_FILE_14MB],
             check=True,
-            capture_output=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             cwd=WORKING_REPO_DIR,
         )
         subprocess.run(["git", "add", "*"], check=True, cwd=WORKING_REPO_DIR)


### PR DESCRIPTION
The `check_output` of `subprocess.run` argument is not available in Python 3.6, but the lib is advertized to be compatible with Python >= 3.6

