### PR TITLE
Solve `rmtree` issue on windows

### DIFF
--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -31,6 +31,7 @@ from .testing_utils import (
     DUMMY_MODEL_ID,
     DUMMY_MODEL_ID_REVISION_ONE_SPECIFIC_COMMIT,
     require_git_lfs,
+    set_write_permission_and_retry,
 )
 
 
@@ -118,7 +119,9 @@ class HfApiUploadFileTest(HfApiEndpointsTest):
         self.tmp_file_content = "Content of the file"
         with open(self.tmp_file, "w+") as f:
             f.write(self.tmp_file_content)
-        self.addCleanup(lambda: shutil.rmtree(self.tmp_dir))
+        self.addCleanup(
+            lambda: shutil.rmtree(self.tmp_dir, onerror=set_write_permission_and_retry)
+        )
 
     def test_upload_file_validation(self):
         with self.assertRaises(ValueError, msg="Wrong repo type"):
@@ -304,7 +307,7 @@ class HfLargefilesTest(HfApiCommonTest):
 
     def setUp(self):
         try:
-            shutil.rmtree(WORKING_REPO_DIR)
+            shutil.rmtree(WORKING_REPO_DIR, onerror=set_write_permission_and_retry)
         except FileNotFoundError:
             pass
 

--- a/tests/test_hubmixin.py
+++ b/tests/test_hubmixin.py
@@ -8,6 +8,7 @@ from huggingface_hub.file_download import is_torch_available
 from huggingface_hub.hub_mixin import ModelHubMixin
 
 from .testing_constants import ENDPOINT_STAGING, PASS, USER
+from .testing_utils import set_write_permission_and_retry
 
 
 REPO_NAME = "mixin-repo-{}".format(int(time.time() * 10e3))
@@ -59,7 +60,7 @@ class HubMixingCommonTest(unittest.TestCase):
 class HubMixingTest(HubMixingCommonTest):
     def tearDown(self) -> None:
         try:
-            shutil.rmtree(WORKING_REPO_DIR)
+            shutil.rmtree(WORKING_REPO_DIR, onerror=set_write_permission_and_retry)
         except FileNotFoundError:
             pass
 

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -24,6 +24,7 @@ from huggingface_hub.hf_api import HfApi
 from huggingface_hub.repository import Repository
 
 from .testing_constants import ENDPOINT_STAGING, PASS, USER
+from .testing_utils import set_write_permission_and_retry
 
 
 REPO_NAME = "repo-{}".format(int(time.time() * 10e3))
@@ -48,7 +49,7 @@ class RepositoryTest(RepositoryCommonTest):
 
     def setUp(self):
         try:
-            shutil.rmtree(WORKING_REPO_DIR)
+            shutil.rmtree(WORKING_REPO_DIR, onerror=set_write_permission_and_retry)
         except FileNotFoundError:
             pass
 

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -1,4 +1,5 @@
 import os
+import stat
 import unittest
 from contextlib import contextmanager
 from distutils.util import strtobool
@@ -139,3 +140,8 @@ def offline(mode=OfflineSimulationMode.CONNECTION_FAILS, timeout=1e-16):
             yield
     else:
         raise ValueError("Please use a value from the OfflineSimulationMode enum.")
+
+
+def set_write_permission_and_retry(func, path, excinfo):
+    os.chmod(path, stat.S_IWRITE)
+    func(path)


### PR DESCRIPTION
Removing `.git` directories on Windows with `shutil.rmtree` raises a permission error.

Changing the file's permission and retrying solves this.