### PR TITLE
Don't pull to same directory for push_to_hub in mixin

### DIFF
--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -3,7 +3,9 @@ import logging
 import os
 from typing import Dict, Optional, Union
 
+from distutils.dir_util import copy_tree
 import requests
+import tempfile
 
 from .constants import CONFIG_NAME, PYTORCH_WEIGHTS_NAME
 from .file_download import cached_download, hf_hub_url, is_torch_available
@@ -261,7 +263,6 @@ class ModelHubMixin(object):
                 repo_type=None,
                 exist_ok=True,
             )
-
         repo = Repository(
             save_directory,
             clone_from=repo_url,
@@ -270,4 +271,16 @@ class ModelHubMixin(object):
             git_email=git_email,
         )
 
-        return repo.push_to_hub(commit_message=commit_message)
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            # First create the repo (and clone its content if it's nonempty), then add the files (otherwise there is
+            # no diff so nothing is pushed).
+            repo = Repository(
+                tmp_dir,
+                clone_from=repo_url,
+                use_auth_token=use_auth_token,
+                git_user=git_user,
+                git_email=git_email,
+            )
+
+            copy_tree(save_directory, tmp_dir)
+            return repo.push_to_hub(commit_message=commit_message)

--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -1,11 +1,11 @@
 import json
 import logging
 import os
+import tempfile
+from distutils.dir_util import copy_tree
 from typing import Dict, Optional, Union
 
-from distutils.dir_util import copy_tree
 import requests
-import tempfile
 
 from .constants import CONFIG_NAME, PYTORCH_WEIGHTS_NAME
 from .file_download import cached_download, hf_hub_url, is_torch_available
@@ -263,17 +263,10 @@ class ModelHubMixin(object):
                 repo_type=None,
                 exist_ok=True,
             )
-        repo = Repository(
-            save_directory,
-            clone_from=repo_url,
-            use_auth_token=use_auth_token,
-            git_user=git_user,
-            git_email=git_email,
-        )
 
         with tempfile.TemporaryDirectory() as tmp_dir:
-            # First create the repo (and clone its content if it's nonempty), then add the files (otherwise there is
-            # no diff so nothing is pushed).
+            # First create the repo (and clone its content if it's nonempty), then
+            # add the files (otherwise there is no diff so nothing is pushed).
             repo = Repository(
                 tmp_dir,
                 clone_from=repo_url,


### PR DESCRIPTION
The current approach clones the repo to the same directory as where the files where saved, which leads to files unexpectedly appearing when pushing to hub. Also, if you then delete files cloned files locally, they are deleted in the remote repo.

This change is consistent with what is done in transformers [implementation](https://github.com/huggingface/transformers/blob/a55dc157e3667b7c1e8696fbbb5d94df46e7a354/src/transformers/file_utils.py#L1959)