### PR TITLE
Change sentence transformers source to original repo

### DIFF
--- a/api-inference-community/docker_images/sentence_transformers/requirements.txt
+++ b/api-inference-community/docker_images/sentence_transformers/requirements.txt
@@ -1,4 +1,4 @@
 starlette==0.14.2
 api-inference-community==0.0.7
--e git+https://github.com/osanseviero/sentence-transformers@v2_dev#egg=sentence-transformers
+-e git+https://github.com/UKPLab/sentence-transformers@v2_dev#egg=sentence-transformers
 protobuf==3.17.1


### PR DESCRIPTION
This might potentially break some of the existing models with the previous v2 (I think they were all mine though), but this will make sure @nreimers can try out Inference API with latest changes.