### PR TITLE
Repository power-up

### DIFF
--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+from pathlib import Path
 from typing import Dict, Optional, Union
 
 import requests
@@ -200,74 +201,108 @@ class ModelHubMixin:
 
         return model
 
-    @staticmethod
     def push_to_hub(
-        save_directory: Optional[str],
-        model_id: Optional[str] = None,
+        self,
+        repo_path_or_name: Optional[str] = None,
         repo_url: Optional[str] = None,
-        commit_message: Optional[str] = "add model",
+        commit_message: Optional[str] = "Add model",
         organization: Optional[str] = None,
-        private: bool = None,
-        api_endpoint=None,
-        use_auth_token: Union[bool, str, None] = None,
+        private: Optional[bool] = None,
+        api_endpoint: Optional[str] = None,
+        use_auth_token: Optional[Union[bool, str]] = None,
         git_user: Optional[str] = None,
         git_email: Optional[str] = None,
+        config: Optional[dict] = None,
     ) -> str:
         """
+        Upload model checkpoint or tokenizer files to the 🤗 Model Hub while synchronizing a local clone of the repo in
+        :obj:`repo_path_or_name`.
+
         Parameters:
-            save_directory (:obj:`Union[str, os.PathLike]`):
-                Directory having model weights & config.
-            model_id (:obj:`str`, `optional`, defaults to :obj:`save_directory`):
-                Repo name in huggingface_hub. If not specified, repo name will be same as `save_directory`
+            repo_path_or_name (:obj:`str`, `optional`):
+                Can either be a repository name for your model or tokenizer in the Hub or a path to a local folder (in
+                which case the repository will have the name of that local folder). If not specified, will default to
+                the name given by :obj:`repo_url` and a local directory with that name will be created.
             repo_url (:obj:`str`, `optional`):
-                Specify this in case you want to push to existing repo in hub.
+                Specify this in case you want to push to an existing repository in the hub. If unspecified, a new
+                repository will be created in your namespace (unless you specify an :obj:`organization`) with
+                :obj:`repo_name`.
+            commit_message (:obj:`str`, `optional`):
+                Message to commit while pushing. Will default to :obj:`"add config"`, :obj:`"add tokenizer"` or
+                :obj:`"add model"` depending on the type of the class.
             organization (:obj:`str`, `optional`):
-                Organization in which you want to push your model.
+                Organization in which you want to push your model or tokenizer (you must be a member of this
+                organization).
             private (:obj:`bool`, `optional`):
-                private: Whether the model repo should be private (requires a paid huggingface.co account)
-            commit_message (:obj:`str`, `optional`, defaults to :obj:`add model`):
-                Message to commit while pushing
+                Whether or not the repository created should be private (requires a paying subscription).
             api_endpoint (:obj:`str`, `optional`):
                 The API endpoint to use when pushing the model to the hub.
-            use_auth_token (``str`` or ``bool``, `optional`, defaults ``None``):
-                huggingface_token can be extract from ``HfApi().login(username, password)`` and is used to authenticate
-                 against the hub (useful from Google Colab for instance).
-            git_user (``str``, `optional`, defaults ``None``):
+            use_auth_token (:obj:`bool` or :obj:`str`, `optional`):
+                The token to use as HTTP bearer authorization for remote files. If :obj:`True`, will use the token
+                generated when running :obj:`transformers-cli login` (stored in :obj:`~/.huggingface`). Will default to
+                :obj:`True` if :obj:`repo_url` is not specified.
+            git_user (``str``, `optional`):
                 will override the ``git config user.name`` for committing and pushing files to the hub.
-            git_email (``str``, `optional`, defaults ``None``):
+            git_email (``str``, `optional`):
                 will override the ``git config user.email`` for committing and pushing files to the hub.
+            config (:obj:`dict`, `optional`):
+                Configuration object to be saved alongside the model weights.
+
 
         Returns:
-            url to commit on remote repo.
+            The url of the commit of your model in the given repository.
         """
-        if model_id is None:
-            model_id = save_directory.split("/")[-1]
 
-        # The auth token is necessary to create a repo
-        if isinstance(use_auth_token, str):
-            huggingface_token = use_auth_token
-        elif use_auth_token is None and repo_url is not None:
-            # If the repo url exists, then no need for a token
-            huggingface_token = None
+        if repo_path_or_name is None and repo_url is None:
+            raise ValueError(
+                "You need to specify a `repo_path_or_name` or a `repo_url`."
+            )
+
+        if use_auth_token is None and repo_url is None:
+            token = HfFolder.get_token()
+            if token is None:
+                raise ValueError(
+                    "You must login to the Hugging Face hub on this computer by typing `transformers-cli login` and "
+                    "entering your credentials to use `use_auth_token=True`. Alternatively, you can pass your own "
+                    "token as the `use_auth_token` argument."
+                )
+        elif isinstance(use_auth_token, str):
+            token = use_auth_token
         else:
-            huggingface_token = HfFolder.get_token()
+            token = None
 
-        if repo_url is None:
+        if repo_path_or_name is None:
+            repo_path_or_name = repo_url.split("/")[-1]
+
+        # If no URL is passed and there's no path to a directory containing files, create a repo
+        if repo_url is None and not os.path.exists(repo_path_or_name):
+            repo_name = Path(repo_path_or_name).name
             repo_url = HfApi(endpoint=api_endpoint).create_repo(
-                huggingface_token,
-                model_id,
+                token,
+                repo_name,
                 organization=organization,
                 private=private,
                 repo_type=None,
                 exist_ok=True,
             )
 
+        # Create a working directory if it does not exist.
+        if not os.path.exists(repo_path_or_name):
+            os.makedirs(repo_path_or_name)
+
         repo = Repository(
-            save_directory,
+            repo_path_or_name,
             clone_from=repo_url,
             use_auth_token=use_auth_token,
             git_user=git_user,
             git_email=git_email,
         )
+        repo.git_pull()
 
-        return repo.push_to_hub(commit_message=commit_message)
+        # Save the files in the cloned repo
+        self.save_pretrained(repo_path_or_name, config=config)
+
+        # Commit and push!
+        repo.git_add()
+        repo.git_commit(commit_message)
+        return repo.git_push()

--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -286,10 +286,6 @@ class ModelHubMixin:
                 exist_ok=True,
             )
 
-        # Create a working directory if it does not exist.
-        if not os.path.exists(repo_path_or_name):
-            os.makedirs(repo_path_or_name)
-
         repo = Repository(
             repo_path_or_name,
             clone_from=repo_url,
@@ -297,7 +293,7 @@ class ModelHubMixin:
             git_user=git_user,
             git_email=git_email,
         )
-        repo.git_pull()
+        repo.git_pull(rebase=True)
 
         # Save the files in the cloned repo
         self.save_pretrained(repo_path_or_name, config=config)

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -213,7 +213,10 @@ class Repository:
 
                 if not in_repository:
                     raise EnvironmentError(
-                        "Tried to clone a repository in a non-empty folder that isn't a git repository."
+                        "Tried to clone a repository in a non-empty folder that isn't a git repository. If you really "
+                        "want to do this, do it manually:\m"
+                        "git init && git remote add origin && git pull origin main\n"
+                        " or clone repo to a new folder and move your existing files there afterwards."
                     )
 
         except subprocess.CalledProcessError as exc:

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -153,7 +153,10 @@ class Repository:
                 # Check if the folder is the root of a git repository
                 in_repository = (
                     os.path.exists(os.path.join(self.local_dir, ".git"))
-                    and subprocess.run("git branch".split(), cwd=self.local_dir).returncode == 0
+                    and subprocess.run(
+                        "git branch".split(), cwd=self.local_dir
+                    ).returncode
+                    == 0
                 )
 
                 if in_repository:
@@ -188,9 +191,7 @@ class Repository:
                             f"error, please add a remote with the following URL: {repo_url}."
                         )
                         if output.returncode == 0:
-                            error_msg += (
-                                f"\nLocal path has its origin defined as: {output.stdout}"
-                            )
+                            error_msg += f"\nLocal path has its origin defined as: {output.stdout}"
 
                         raise EnvironmentError(error_msg)
 

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -12,15 +12,20 @@ logger = logging.getLogger(__name__)
 
 
 def is_git_repo(folder):
-    # Check if the folder is the root of a git repository
-    git_folder = os.path.join(folder, ".git")
-    return (
-        os.path.exists(git_folder)
-        and subprocess.run("git branch".split(), cwd=folder).returncode == 0
+    """
+    Check if the folder is the root of a git repository
+    """
+    folder_exists = os.path.exists(os.path.join(folder, ".git"))
+    git_branch = subprocess.run(
+        "git branch".split(), cwd=folder, stdout=subprocess.PIPE, stderr=subprocess.PIPE
     )
+    return folder_exists and git_branch.returncode == 0
 
 
 def is_local_clone(folder, remote_url):
+    """
+    Check if the folder is the a local clone of the remote_url
+    """
     if not is_git_repo(folder):
         return False
 

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -2,6 +2,7 @@ import logging
 import os
 import re
 import subprocess
+from pathlib import Path
 from typing import List, Optional, Union
 
 from .hf_api import HfFolder
@@ -11,7 +12,7 @@ from .lfs import LFS_MULTIPART_UPLOAD_COMMAND
 logger = logging.getLogger(__name__)
 
 
-def is_git_repo(folder):
+def is_git_repo(folder: Union[str, Path]):
     """
     Check if the folder is the root of a git repository
     """
@@ -22,7 +23,7 @@ def is_git_repo(folder):
     return folder_exists and git_branch.returncode == 0
 
 
-def is_local_clone(folder, remote_url):
+def is_local_clone(folder: Union[str, Path], remote_url: str):
     """
     Check if the folder is the a local clone of the remote_url
     """

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -169,7 +169,9 @@ class Repository:
                         cwd=self.local_dir,
                     ).stdout
 
-                    if repo_url in remotes.split():
+                    # Remove token for the test with remotes.
+                    remote_url = re.sub(r"https://.*@", "https://", repo_url)
+                    if remote_url in remotes.split():
                         try:
                             self.git_pull()
                         except EnvironmentError as e:

--- a/tests/test_hubmixin.py
+++ b/tests/test_hubmixin.py
@@ -113,18 +113,13 @@ class HubMixingTest(HubMixingCommonTest):
 
     def test_push_to_hub(self):
         model = DummyModel()
-        model.save_pretrained(
-            f"{WORKING_REPO_DIR}/{REPO_NAME}-PUSH_TO_HUB",
-            config={"num": 7, "act": "gelu_fast"},
-        )
-
         model.push_to_hub(
-            f"{WORKING_REPO_DIR}/{REPO_NAME}-PUSH_TO_HUB",
-            f"{REPO_NAME}-PUSH_TO_HUB",
+            repo_path_or_name=f"{WORKING_REPO_DIR}/{REPO_NAME}-PUSH_TO_HUB",
             api_endpoint=ENDPOINT_STAGING,
             use_auth_token=self._token,
             git_user="ci",
             git_email="ci@dummy.com",
+            config={"num": 7, "act": "gelu_fast"},
         )
 
         model_info = self._api.model_info(

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -97,10 +97,9 @@ class RepositoryTest(RepositoryCommonTest):
             f.write("hello")
         with open(os.path.join(WORKING_REPO_DIR, "model.bin"), "w") as f:
             f.write("hello")
-        repo = Repository(WORKING_REPO_DIR, clone_from=self._repo_url)
-        repo.lfs_track(["*.pdf"])
-        repo.lfs_enable_largefiles()
-        repo.git_pull()
+        self.assertRaises(
+            OSError, Repository, WORKING_REPO_DIR, clone_from=self._repo_url
+        )
 
     def test_init_clone_in_nonempty_non_linked_git_repo(self):
         # Create a new repository on the HF Hub
@@ -137,9 +136,9 @@ class RepositoryTest(RepositoryCommonTest):
             repo_id=f"{USER}/{REPO_NAME}",
         )
 
-        # Cloning the repository in the same directory should result in a git pull.
+        # Cloning the repository in the same directory should not result in a git pull.
         Repository(WORKING_REPO_DIR, clone_from=self._repo_url)
-        self.assertIn("random_file_3.txt", os.listdir(WORKING_REPO_DIR))
+        self.assertNotIn("random_file_3.txt", os.listdir(WORKING_REPO_DIR))
 
     def test_init_clone_in_nonempty_linked_git_repo_unrelated_histories(self):
         # Clone the repository to disk
@@ -164,10 +163,8 @@ class RepositoryTest(RepositoryCommonTest):
             repo_id=f"{USER}/{REPO_NAME}",
         )
 
-        # Cloning the repository in the same directory should result in a git pull.
-        self.assertRaises(
-            EnvironmentError, Repository, WORKING_REPO_DIR, clone_from=self._repo_url
-        )
+        # The repo should initialize correctly as the remote is the same, even with unrelated historied
+        Repository(WORKING_REPO_DIR, clone_from=self._repo_url)
 
     def test_add_commit_push(self):
         repo = Repository(

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -143,7 +143,12 @@ class RepositoryTest(RepositoryCommonTest):
 
     def test_init_clone_in_nonempty_linked_git_repo_unrelated_histories(self):
         # Clone the repository to disk
-        repo = Repository(WORKING_REPO_DIR, clone_from=self._repo_url)
+        repo = Repository(
+            WORKING_REPO_DIR,
+            clone_from=self._repo_url,
+            git_user="ci",
+            git_email="ci@dummy.com",
+        )
 
         with open(f"{WORKING_REPO_DIR}/random_file_3.txt", "w+") as f:
             f.write("New file.")

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -116,7 +116,7 @@ class RepositoryTest(RepositoryCommonTest):
 
         # Clone the new repository
         os.makedirs(WORKING_REPO_DIR, exist_ok=True)
-        repo = Repository(WORKING_REPO_DIR, clone_from=self._repo_url)
+        Repository(WORKING_REPO_DIR, clone_from=self._repo_url)
 
         # Try and clone another repository within the same directory. Should error out due to mismatched remotes.
         self.assertRaises(
@@ -127,7 +127,7 @@ class RepositoryTest(RepositoryCommonTest):
 
     def test_init_clone_in_nonempty_linked_git_repo(self):
         # Clone the repository to disk
-        repo = Repository(WORKING_REPO_DIR, clone_from=self._repo_url)
+        Repository(WORKING_REPO_DIR, clone_from=self._repo_url)
 
         # Add to the remote repository without doing anything to the local repository.
         self._api.upload_file(
@@ -138,7 +138,7 @@ class RepositoryTest(RepositoryCommonTest):
         )
 
         # Cloning the repository in the same directory should result in a git pull.
-        repo = Repository(WORKING_REPO_DIR, clone_from=self._repo_url)
+        Repository(WORKING_REPO_DIR, clone_from=self._repo_url)
         self.assertIn("random_file_3.txt", os.listdir(WORKING_REPO_DIR))
 
     def test_init_clone_in_nonempty_linked_git_repo_unrelated_histories(self):
@@ -165,8 +165,9 @@ class RepositoryTest(RepositoryCommonTest):
         )
 
         # Cloning the repository in the same directory should result in a git pull.
-        repo = Repository(WORKING_REPO_DIR, clone_from=self._repo_url)
-        self.assertIn("random_file_3.txt", os.listdir(WORKING_REPO_DIR))
+        self.assertRaises(
+            EnvironmentError, Repository, WORKING_REPO_DIR, clone_from=self._repo_url
+        )
 
     def test_add_commit_push(self):
         repo = Repository(

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -18,6 +18,7 @@ import subprocess
 import tempfile
 import time
 import unittest
+from io import BytesIO
 
 import requests
 from huggingface_hub.hf_api import HfApi
@@ -54,6 +55,12 @@ class RepositoryTest(RepositoryCommonTest):
             pass
 
         self._repo_url = self._api.create_repo(token=self._token, name=REPO_NAME)
+        self._api.upload_file(
+            token=self._token,
+            path_or_fileobj=BytesIO(b"some initial binary data: \x00\x01"),
+            path_in_repo="random_file.txt",
+            repo_id=f"{USER}/{REPO_NAME}",
+        )
 
     def tearDown(self):
         self._api.delete_repo(token=self._token, name=REPO_NAME)
@@ -80,6 +87,8 @@ class RepositoryTest(RepositoryCommonTest):
         repo.lfs_enable_largefiles()
         repo.git_pull()
 
+        self.assertIn("random_file.txt", os.listdir(WORKING_REPO_DIR))
+
     def test_init_clone_in_nonempty_folder(self):
         # Create dummy files
         # one is lfs-tracked, the other is not.
@@ -92,6 +101,67 @@ class RepositoryTest(RepositoryCommonTest):
         repo.lfs_track(["*.pdf"])
         repo.lfs_enable_largefiles()
         repo.git_pull()
+
+    def test_init_clone_in_nonempty_non_linked_git_repo(self):
+        # Create a new repository on the HF Hub
+        temp_repo_url = self._api.create_repo(
+            token=self._token, name=f"{REPO_NAME}-temp"
+        )
+        self._api.upload_file(
+            token=self._token,
+            path_or_fileobj=BytesIO(b"some initial binary data: \x00\x01"),
+            path_in_repo="random_file_2.txt",
+            repo_id=f"{USER}/{REPO_NAME}-temp",
+        )
+
+        # Clone the new repository
+        os.makedirs(WORKING_REPO_DIR, exist_ok=True)
+        repo = Repository(WORKING_REPO_DIR, clone_from=self._repo_url)
+
+        # Try and clone another repository within the same directory. Should error out due to mismatched remotes.
+        self.assertRaises(
+            EnvironmentError, Repository, WORKING_REPO_DIR, clone_from=temp_repo_url
+        )
+
+        self._api.delete_repo(token=self._token, name=f"{REPO_NAME}-temp")
+
+    def test_init_clone_in_nonempty_linked_git_repo(self):
+        # Clone the repository to disk
+        repo = Repository(WORKING_REPO_DIR, clone_from=self._repo_url)
+
+        # Add to the remote repository without doing anything to the local repository.
+        self._api.upload_file(
+            token=self._token,
+            path_or_fileobj=BytesIO(b"some initial binary data: \x00\x01"),
+            path_in_repo="random_file_3.txt",
+            repo_id=f"{USER}/{REPO_NAME}",
+        )
+
+        # Cloning the repository in the same directory should result in a git pull.
+        repo = Repository(WORKING_REPO_DIR, clone_from=self._repo_url)
+        self.assertIn("random_file_3.txt", os.listdir(WORKING_REPO_DIR))
+
+    def test_init_clone_in_nonempty_linked_git_repo_unrelated_histories(self):
+        # Clone the repository to disk
+        repo = Repository(WORKING_REPO_DIR, clone_from=self._repo_url)
+
+        with open(f"{WORKING_REPO_DIR}/random_file_3.txt", "w+") as f:
+            f.write("New file.")
+
+        repo.git_add()
+        repo.git_commit("Unrelated commit")
+
+        # Add to the remote repository without doing anything to the local repository.
+        self._api.upload_file(
+            token=self._token,
+            path_or_fileobj=BytesIO(b"some initial binary data: \x00\x01"),
+            path_in_repo="random_file_3.txt",
+            repo_id=f"{USER}/{REPO_NAME}",
+        )
+
+        # Cloning the repository in the same directory should result in a git pull.
+        repo = Repository(WORKING_REPO_DIR, clone_from=self._repo_url)
+        self.assertIn("random_file_3.txt", os.listdir(WORKING_REPO_DIR))
 
     def test_add_commit_push(self):
         repo = Repository(


### PR DESCRIPTION
This PR offers a slightly reworked `Repository.clone_from` method. 

It currently behaves as follows:

```
clone_from
    -> Empty folder
        -> Clones the repository inside the empty folder
    -> Folder contains files
        -> git init, git fetch, git reset origin/main, git checkout origin/main
```

The principal reason that led to this proposal are:

- It is currently possible to use `clone_from` in a directory that contains a `.git` that has a completely unrelated git history, replacing the `.git` but keeping all other files in the working directory. No file on the remote repository will be pulled in the local directory.

This PR proposes to change the behavior when the folder contains files:

```
clone_from
    -> Empty folder
        -> Clones the repository inside the empty folder
    -> Folder contains files
        -> The folder is not a git repository
            -> ERROR
        -> The folder is a git repository
            -> The folder contains an unrelated .git
                -> ERROR
            -> The folder contains a related .git
                -> Do nothing
```