### PR TITLE
Update links to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This library allows anyone to work with the Hub repositories: you can clone them
 
 ## Integrating to the Hub.
 
-We're partnering with cool open source ML libraries to provide free model hosting and versioning. You can find the existing integrations [here](https://huggingface.co/docs/libraries).
+We're partnering with cool open source ML libraries to provide free model hosting and versioning. You can find the existing integrations [here](https://huggingface.co/docs/hub/libraries).
 
 The advantages are:
 
@@ -40,7 +40,7 @@ The advantages are:
 - Fast downloads! We use Cloudfront (a CDN) to geo-replicate downloads so they're blazing fast from anywhere on the globe.
 - Usage stats and more features to come.
 
-If you would like to integrate your library, feel free to open an issue to begin the discussion. We wrote a [step-by-step guide](https://huggingface.co/docs/adding-a-library) with ❤️ showing how to do this integration.
+If you would like to integrate your library, feel free to open an issue to begin the discussion. We wrote a [step-by-step guide](https://huggingface.co/docs/hub/adding-a-library) with ❤️ showing how to do this integration.
 
 <br>
 

--- a/docs/hub/adding-a-library.md
+++ b/docs/hub/adding-a-library.md
@@ -8,7 +8,7 @@ title: Adding your Library
 
 The Hugging Face Hub aims to facilitate the sharing of machine learning models, checkpoints, and artifacts.  This endeavor starts with the integration of its tool stack within downstream libraries, and we're happy to announce  the fruitful collaboration between Hugging Face and spaCy, AllenNLP, and Timm, among many other incredible libraries.
 
-**For a full list of supported libraries, see [the following table](/docs/libraries).**
+**For a full list of supported libraries, see [the following table](/docs/hub/libraries).**
 
 We believe the Hub is a step in the correct direction for several reasons. It offers:
 
@@ -281,7 +281,7 @@ model-index:
 ---
 ```
 
-None of the fields are required - but any added field will improve the discoverability of your model and open it to features such as the inference API. You can find more information on repos and model cards [here](/docs/model-repos).
+None of the fields are required - but any added field will improve the discoverability of your model and open it to features such as the inference API. You can find more information on repos and model cards [here](/docs/hub/model-repos).
 
 ## Setting up the Inference API
 

--- a/docs/hub/inference.md
+++ b/docs/hub/inference.md
@@ -16,7 +16,7 @@ On top of `Pipelines` and depending on the model type, we build a number of prod
 - maintaining a Least Recently Used cache ensuring that the most popular models are always loaded,
 - scaling the underlying compute infrastructure on the fly depending on the load constraints.
 
-For models from [other libraries](/docs/libraries), the API uses [Starlette](https://www.starlette.io) and runs in [Docker containers](https://github.com/huggingface/huggingface_hub/tree/main/api-inference-community/docker_images). Each library defines the implementation of [different pipelines](https://github.com/huggingface/huggingface_hub/tree/main/api-inference-community/docker_images/sentence_transformers/app/pipelines).
+For models from [other libraries](/docs/hub/libraries), the API uses [Starlette](https://www.starlette.io) and runs in [Docker containers](https://github.com/huggingface/huggingface_hub/tree/main/api-inference-community/docker_images). Each library defines the implementation of [different pipelines](https://github.com/huggingface/huggingface_hub/tree/main/api-inference-community/docker_images/sentence_transformers/app/pipelines).
 
 
 ## How can I turn off the inference API for my model?

--- a/docs/hub/libraries.md
+++ b/docs/hub/libraries.md
@@ -28,4 +28,4 @@ The table below summarizes the supported libraries and how they are integrated. 
 
 ## How can I add a new library to the Inference API?
 
-Read about it in [Adding a Library Guide](/docs/adding-a-library).
+Read about it in [Adding a Library Guide](/docs/hub/adding-a-library).

--- a/docs/hub/main.md
+++ b/docs/hub/main.md
@@ -27,7 +27,7 @@ On top of that, Hugging Face Hub repositories have many other advantages:
 * Repos provide useful [metadata](https://raw.githubusercontent.com/huggingface/huggingface_hub/main/modelcard.md) about their tasks, languages, metrics, etc.
 * Anyone can play with the model directly in the browser!
 * An API is provided to use the models in production settings.
-* [Over 10 frameworks](/docs/libraries) such as 🤗 Transformers, Asteroid and ESPnet support using models from the Hugging Face Hub. 
+* [Over 10 frameworks](/docs/hub/libraries) such as 🤗 Transformers, Asteroid and ESPnet support using models from the Hugging Face Hub. 
 
 
 ## What's a widget?

--- a/docs/hub/model-repos.md
+++ b/docs/hub/model-repos.md
@@ -82,7 +82,7 @@ tags:
 - flair
 ```
 
-Find more about our supported libraries [here](/docs/libraries)!
+Find more about our supported libraries [here](/docs/hub/libraries)!
 
 ## How can I link a model to a dataset?
 


### PR DESCRIPTION
With https://github.com/huggingface/huggingface_hub/pull/145 the links to the documentation need to be updated or point to a 404

Closes https://github.com/huggingface/huggingface_hub/issues/146