### PR TITLE
More robust endpoint with toggled staging endpoint

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -3,7 +3,7 @@ name: Python tests
 on:
   push:
     branches:
-      - main
+      - *
     paths-ignore:
       - "interfaces/**"
       - "widgets/**"

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -13,6 +13,9 @@ on:
       - "interfaces/**"
       - "widgets/**"
 
+env:
+  HUGGINGFACE_CO_STAGING: yes
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -30,7 +30,7 @@ from .constants import (
     TF_WEIGHTS_NAME,
 )
 from .file_download import cached_download, hf_hub_download, hf_hub_url
-from .hf_api import HfApi, HfFolder
+from .hf_api import HfApi, HfFolder, repo_type_and_id_from_hf_id
 from .hub_mixin import ModelHubMixin
 from .repository import Repository
 from .snapshot_download import snapshot_download

--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -36,6 +36,7 @@ REPO_TYPES_URL_PREFIXES = {
     REPO_TYPE_DATASET: "datasets/",
     REPO_TYPE_SPACE: "spaces/",
 }
+REPO_TYPES_MAPPING = {"datasets": REPO_TYPE_DATASET, "spaces": REPO_TYPE_SPACE}
 
 
 # default cache

--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -16,9 +16,17 @@ CONFIG_NAME = "config.json"
 
 HUGGINGFACE_CO_URL_HOME = "https://huggingface.co/"
 
-HUGGINGFACE_CO_URL_TEMPLATE = (
-    "https://huggingface.co/{repo_id}/resolve/{revision}/{filename}"
+ENV_VARS_TRUE_VALUES = {"1", "ON", "YES", "TRUE"}
+_staging_mode = (
+    os.environ.get("HUGGINGFACE_CO_STAGING", "NO").upper() in ENV_VARS_TRUE_VALUES
 )
+
+ENDPOINT = (
+    "https://moon-staging.huggingface.co" if _staging_mode else "https://huggingface.co"
+)
+
+
+HUGGINGFACE_CO_URL_TEMPLATE = ENDPOINT + "/{repo_id}/resolve/{revision}/{filename}"
 
 REPO_TYPE_DATASET = "dataset"
 REPO_TYPE_SPACE = "space"

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -25,7 +25,7 @@ from typing import BinaryIO, Dict, Iterable, List, Optional, Tuple, Union
 import requests
 from requests.exceptions import HTTPError
 
-from .constants import REPO_TYPES, REPO_TYPES_URL_PREFIXES
+from .constants import ENDPOINT, REPO_TYPES, REPO_TYPES_URL_PREFIXES
 
 
 if sys.version_info >= (3, 8):
@@ -33,15 +33,6 @@ if sys.version_info >= (3, 8):
 else:
     from typing_extensions import Literal
 
-
-ENV_VARS_TRUE_VALUES = {"1", "ON", "YES", "TRUE"}
-_staging_mode = (
-    os.environ.get("HUGGINGFACE_CO_STAGING", "NO").upper() in ENV_VARS_TRUE_VALUES
-)
-
-ENDPOINT = (
-    "https://moon-staging.huggingface.co" if _staging_mode else "https://huggingface.co"
-)
 
 REMOTE_FILEPATH_REGEX = re.compile(r"^\w[\w\/]*(\.\w+)?$")
 # ^^ No trailing slash, no backslash, no spaces, no relative parts ("." or "..")

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -34,7 +34,15 @@ else:
     from typing_extensions import Literal
 
 
-ENDPOINT = "https://huggingface.co"
+ENV_VARS_TRUE_VALUES = {"1", "ON", "YES", "TRUE"}
+_staging_mode = (
+    os.environ.get("HUGGINGFACE_CO_STAGING", "NO").upper() in ENV_VARS_TRUE_VALUES
+)
+
+ENDPOINT = (
+    "https://moon-staging.huggingface.co" if _staging_mode else "https://huggingface.co"
+)
+
 REMOTE_FILEPATH_REGEX = re.compile(r"^\w[\w\/]*(\.\w+)?$")
 # ^^ No trailing slash, no backslash, no spaces, no relative parts ("." or "..")
 #    Only word characters and an optional extension

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -25,7 +25,7 @@ from typing import BinaryIO, Dict, Iterable, List, Optional, Tuple, Union
 import requests
 from requests.exceptions import HTTPError
 
-from .constants import ENDPOINT, REPO_TYPES, REPO_TYPES_URL_PREFIXES
+from .constants import ENDPOINT, REPO_TYPES, REPO_TYPES_MAPPING, REPO_TYPES_URL_PREFIXES
 
 
 if sys.version_info >= (3, 8):
@@ -37,6 +37,53 @@ else:
 REMOTE_FILEPATH_REGEX = re.compile(r"^\w[\w\/]*(\.\w+)?$")
 # ^^ No trailing slash, no backslash, no spaces, no relative parts ("." or "..")
 #    Only word characters and an optional extension
+
+
+def repo_type_and_id_from_hf_id(hf_id: str):
+    """
+    Returns the repo type and ID from a huggingface.co URL linking to a repository
+
+    Args:
+        hf_id (``str``):
+            An URL or ID of a repository on the HF hub. Accepted values are:
+            - https://huggingface.co/<repo_type>/<namespace>/<repo_id>
+            - https://huggingface.co/<namespace>/<repo_id>
+            - <repo_type>/<namespace>/<repo_id>
+            - <namespace>/<repo_id>
+            - <repo_id>
+    """
+    is_hf_url = "huggingface.co" in hf_id and "@" not in hf_id
+    url_segments = hf_id.split("/")
+    is_hf_id = len(url_segments) <= 3
+
+    if is_hf_url:
+        namespace, repo_id = url_segments[-2:]
+        if len(url_segments) > 2 and "huggingface.co" not in url_segments[-3]:
+            repo_type = url_segments[-3]
+        else:
+            repo_type = None
+    elif is_hf_id:
+        if len(url_segments) == 3:
+            # Passed <repo_type>/<user>/<model_id> or <repo_type>/<org>/<model_id>
+            repo_type, namespace, repo_id = url_segments[-3:]
+        elif len(url_segments) == 2:
+            # Passed <user>/<model_id> or <org>/<model_id>
+            namespace, repo_id = hf_id.split("/")[-2:]
+            repo_type = None
+        else:
+            # Passed <model_id>
+            repo_id = url_segments[0]
+            namespace, repo_type = None, None
+    else:
+        raise ValueError(
+            f"Unable to retrieve user and repo ID from the passed HF ID: {hf_id}"
+        )
+
+    repo_type = (
+        repo_type if repo_type in REPO_TYPES else REPO_TYPES_MAPPING.get(repo_type)
+    )
+
+    return repo_type, namespace, repo_id
 
 
 class RepoObj:

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -161,14 +161,11 @@ class Repository:
         """
         token = use_auth_token if use_auth_token is not None else self.huggingface_token
         if token is not None and "huggingface.co" in repo_url and "@" not in repo_url:
-            endpoint = "/".join(repo_url.split("/")[:-2])
-            # adds huggingface_token to repo url if it is provided.
-            # do not leak user token if it's not a repo on hf.co
             repo_url = repo_url.replace("https://", f"https://user:{token}@")
 
             organization, repo_id = repo_url.split("/")[-2:]
 
-            HfApi(endpoint=endpoint).create_repo(
+            HfApi().create_repo(
                 token,
                 repo_id,
                 organization=organization,

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -6,7 +6,9 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import List, Optional, Union
 
-from .hf_api import ENDPOINT, HfApi, HfFolder
+from huggingface_hub.constants import REPO_TYPES_URL_PREFIXES
+
+from .hf_api import ENDPOINT, HfApi, HfFolder, repo_type_and_id_from_hf_id
 from .lfs import LFS_MULTIPART_UPLOAD_COMMAND
 
 
@@ -58,6 +60,7 @@ class Repository:
         self,
         local_dir: str,
         clone_from: Optional[str] = None,
+        repo_type: Optional[str] = None,
         use_auth_token: Union[bool, str, None] = None,
         git_user: Optional[str] = None,
         git_email: Optional[str] = None,
@@ -76,8 +79,10 @@ class Repository:
         Args:
             local_dir (``str``):
                 path (e.g. ``'my_trained_model/'``) to the local directory, where the ``Repository`` will be initalized.
-            clone_from (``str``, optional):
+            clone_from (``str``, `optional`):
                 repository url (e.g. ``'https://huggingface.co/philschmid/playground-tests'``).
+            repo_type (``str``, `optional`):
+                To set when creating a repo: et to "dataset" or "space" if creating a dataset or space, default is model.
             use_auth_token (``str`` or ``bool``, `optional`, defaults ``None``):
                 huggingface_token can be extract from ``HfApi().login(username, password)`` and is used to authenticate against the hub
                 (useful from Google Colab for instance).
@@ -89,6 +94,7 @@ class Repository:
 
         os.makedirs(local_dir, exist_ok=True)
         self.local_dir = os.path.join(os.getcwd(), local_dir)
+        self.repo_type = repo_type
 
         self.check_git_versions()
 
@@ -100,10 +106,6 @@ class Repository:
             self.huggingface_token = None
 
         if clone_from is not None:
-
-            if "http" not in clone_from:
-                clone_from = f"{ENDPOINT}/{clone_from}"
-
             self.clone_from(repo_url=clone_from)
         else:
             if is_git_repo(self.local_dir):
@@ -160,17 +162,35 @@ class Repository:
         If this folder is a git repository with linked history, will try to update the repository.
         """
         token = use_auth_token if use_auth_token is not None else self.huggingface_token
-        if token is not None and "huggingface.co" in repo_url and "@" not in repo_url:
+        api = HfApi()
+
+        if token is not None:
+            user, valid_organisations = api.whoami(token)
+            repo_type, namespace, repo_id = repo_type_and_id_from_hf_id(repo_url)
+
+            if namespace is None:
+                namespace = user
+
+            if repo_type is not None:
+                self.repo_type = repo_type
+
+            repo_url = ENDPOINT + "/"
+
+            if self.repo_type in REPO_TYPES_URL_PREFIXES:
+                repo_url += REPO_TYPES_URL_PREFIXES[self.repo_type]
+
+            repo_url += f"{namespace}/{repo_id}"
+
             repo_url = repo_url.replace("https://", f"https://user:{token}@")
 
-            organization, repo_id = repo_url.split("/")[-2:]
-
-            HfApi().create_repo(
-                token,
-                repo_id,
-                organization=organization,
-                exist_ok=True,
-            )
+            if namespace == user or namespace in valid_organisations:
+                api.create_repo(
+                    token,
+                    repo_id,
+                    repo_type=self.repo_type,
+                    organization=namespace,
+                    exist_ok=True,
+                )
         # For error messages, it's cleaner to show the repo url without the token.
         clean_repo_url = re.sub(r"https://.*@", "https://", repo_url)
         try:

--- a/tests/fixtures/tiny_dataset/some_text.txt
+++ b/tests/fixtures/tiny_dataset/some_text.txt
@@ -1,0 +1,3 @@
+foo
+bar
+foobar

--- a/tests/fixtures/tiny_dataset/test.py
+++ b/tests/fixtures/tiny_dataset/test.py
@@ -1,0 +1,47 @@
+import datasets
+
+
+_CITATION = """\
+"""
+
+_DESCRIPTION = """\
+This is a test dataset.
+"""
+
+_URLS = {"train": "https://pastebin.com/raw/HvpE1CnA", "dev": "some_text.txt"}
+
+
+class Test(datasets.GeneratorBasedBuilder):
+    """SQUAD: The Stanford Question Answering Dataset. Version 1.1."""
+
+    def _info(self):
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=datasets.Features(
+                {
+                    "text": datasets.Value("string"),
+                }
+            ),
+            supervised_keys=None,
+            homepage="https://huggingface.co/datasets/lhoestq/test",
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager):
+        downloaded_files = dl_manager.download_and_extract(_URLS)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={"filepath": downloaded_files["train"]},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={"filepath": downloaded_files["dev"]},
+            ),
+        ]
+
+    def _generate_examples(self, filepath):
+        """This function returns the examples in the raw (text) form."""
+        for _id, line in enumerate(open(filepath, encoding="utf-8")):
+            yield _id, {"text": line.rstrip()}

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -36,6 +36,7 @@ from .testing_utils import (
     SAMPLE_DATASET_IDENTIFIER,
     OfflineSimulationMode,
     offline,
+    with_production_testing,
 )
 
 
@@ -51,6 +52,7 @@ DATASET_REVISION_ID_ONE_SPECIFIC_COMMIT = "e25d55a1c4933f987c46cc75d8ffadd67f257
 DATASET_SAMPLE_PY_FILE = "custom_squad.py"
 
 
+@with_production_testing
 class CachedDownloadTests(unittest.TestCase):
     def test_bogus_url(self):
         url = "https://bogus"

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -32,6 +32,7 @@ from .testing_utils import (
     DUMMY_MODEL_ID_REVISION_ONE_SPECIFIC_COMMIT,
     require_git_lfs,
     set_write_permission_and_retry,
+    with_production_testing,
 )
 
 
@@ -311,12 +312,14 @@ class HfApiPublicTest(unittest.TestCase):
         _api = HfApi(endpoint=ENDPOINT_STAGING)
         _ = _api.list_models()
 
+    @with_production_testing
     def test_list_models(self):
         _api = HfApi()
         models = _api.list_models()
         self.assertGreater(len(models), 100)
         self.assertIsInstance(models[0], ModelInfo)
 
+    @with_production_testing
     def test_list_models_complex_query(self):
         # Let's list the 10 most recent models
         # with tags "bert" and "jax",
@@ -332,6 +335,7 @@ class HfApiPublicTest(unittest.TestCase):
         self.assertIsInstance(model, ModelInfo)
         self.assertTrue(all(tag in model.tags for tag in ["bert", "jax"]))
 
+    @with_production_testing
     def test_model_info(self):
         _api = HfApi()
         model = _api.model_info(repo_id=DUMMY_MODEL_ID)

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -23,7 +23,13 @@ from io import BytesIO
 
 from huggingface_hub.constants import REPO_TYPE_DATASET, REPO_TYPE_SPACE
 from huggingface_hub.file_download import cached_download
-from huggingface_hub.hf_api import HfApi, HfFolder, ModelInfo, RepoObj
+from huggingface_hub.hf_api import (
+    HfApi,
+    HfFolder,
+    ModelInfo,
+    RepoObj,
+    repo_type_and_id_from_hf_id,
+)
 from requests.exceptions import HTTPError
 
 from .testing_constants import ENDPOINT_STAGING, ENDPOINT_STAGING_BASIC_AUTH, PASS, USER
@@ -487,3 +493,19 @@ class HfLargefilesTest(HfApiCommonTest):
         start_time = time.time()
         subprocess.run(["git", "push"], check=True, cwd=WORKING_REPO_DIR)
         print("took", time.time() - start_time)
+
+
+class HfApiMiscTest(unittest.TestCase):
+    def test_repo_type_and_id_from_hf_id(self):
+        possible_values = {
+            "https://huggingface.co/user/id": [None, "user", "id"],
+            "https://huggingface.co/datasets/user/id": ["dataset", "user", "id"],
+            "https://huggingface.co/spaces/user/id": ["space", "user", "id"],
+            "user/id": [None, "user", "id"],
+            "dataset/user/id": ["dataset", "user", "id"],
+            "space/user/id": ["space", "user", "id"],
+            "id": [None, None, "id"],
+        }
+
+        for key, value in possible_values.items():
+            self.assertEqual(repo_type_and_id_from_hf_id(key), tuple(value))

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -207,7 +207,7 @@ class RepositoryTest(RepositoryCommonTest):
     def test_clone_with_repo_name_and_organization(self):
         clone = Repository(
             REPO_NAME,
-            clone_from=f"{ENDPOINT_STAGING}/valid_org/{REPO_NAME}",
+            clone_from=f"valid_org/{REPO_NAME}",
             use_auth_token=self._token,
             git_user="ci",
             git_email="ci@dummy.com",
@@ -236,7 +236,7 @@ class RepositoryTest(RepositoryCommonTest):
     def test_clone_with_repo_name_and_user_namespace(self):
         clone = Repository(
             REPO_NAME,
-            clone_from=f"{ENDPOINT_STAGING}/{USER}/{REPO_NAME}",
+            clone_from=f"{USER}/{REPO_NAME}",
             use_auth_token=self._token,
             git_user="ci",
             git_email="ci@dummy.com",

--- a/tests/test_snapshot_download.py
+++ b/tests/test_snapshot_download.py
@@ -22,7 +22,11 @@ class SnapshotDownloadTests(unittest.TestCase):
 
     def setUp(self) -> None:
         repo = Repository(
-            REPO_NAME, clone_from=f"{USER}/{REPO_NAME}", use_auth_token=self._token
+            REPO_NAME,
+            clone_from=f"{USER}/{REPO_NAME}",
+            use_auth_token=self._token,
+            git_user="ci",
+            git_email="ci@dummy.com",
         )
 
         with repo.commit("Add file to main branch"):

--- a/tests/testing_constants.py
+++ b/tests/testing_constants.py
@@ -1,5 +1,10 @@
 USER = "__DUMMY_TRANSFORMERS_USER__"
 PASS = "__DUMMY_TRANSFORMERS_PASS__"
 
+ENDPOINT_PRODUCTION = "https://huggingface.co"
 ENDPOINT_STAGING = "https://moon-staging.huggingface.co"
 ENDPOINT_STAGING_BASIC_AUTH = f"https://{USER}:{PASS}@moon-staging.huggingface.co"
+
+ENDPOINT_PRODUCTION_URL_SCHEME = (
+    ENDPOINT_PRODUCTION + "/{repo_id}/resolve/{revision}/{filename}"
+)

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -6,6 +6,8 @@ from distutils.util import strtobool
 from enum import Enum
 from unittest.mock import patch
 
+from tests.testing_constants import ENDPOINT_PRODUCTION, ENDPOINT_PRODUCTION_URL_SCHEME
+
 
 SMALL_MODEL_IDENTIFIER = "julien-c/bert-xsmall-dummy"
 DUMMY_DIFF_TOKENIZER_IDENTIFIER = "julien-c/dummy-diff-tokenizer"
@@ -145,3 +147,17 @@ def offline(mode=OfflineSimulationMode.CONNECTION_FAILS, timeout=1e-16):
 def set_write_permission_and_retry(func, path, excinfo):
     os.chmod(path, stat.S_IWRITE)
     func(path)
+
+
+def with_production_testing(func):
+    file_download = patch(
+        "huggingface_hub.file_download.HUGGINGFACE_CO_URL_TEMPLATE",
+        ENDPOINT_PRODUCTION_URL_SCHEME,
+    )
+
+    hf_api = patch(
+        "huggingface_hub.hf_api.ENDPOINT",
+        ENDPOINT_PRODUCTION,
+    )
+
+    return hf_api(file_download(func))


### PR DESCRIPTION
This PR switches the default endpoint to use the moon-landing endpoint when the `HUGGINGFACE_CO_STAGING` environment variable is set.

Doing this enables testing for HF Hub IDs without needing to specify the moon-landing endpoint explicitly, in turn adding coverage for the user/organization and model ID identification.