### PR TITLE
Allow passing only model ID to clone when authenticated

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -3,7 +3,7 @@ name: Python tests
 on:
   push:
     branches:
-      - main
+      - *
     paths-ignore:
       - "interfaces/**"
       - "widgets/**"

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -30,7 +30,7 @@ from .constants import (
     TF_WEIGHTS_NAME,
 )
 from .file_download import cached_download, hf_hub_download, hf_hub_url
-from .hf_api import HfApi, HfFolder
+from .hf_api import HfApi, HfFolder, repo_type_and_id_from_hf_id
 from .hub_mixin import ModelHubMixin
 from .repository import Repository
 from .snapshot_download import snapshot_download

--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -36,6 +36,7 @@ REPO_TYPES_URL_PREFIXES = {
     REPO_TYPE_DATASET: "datasets/",
     REPO_TYPE_SPACE: "spaces/",
 }
+REPO_TYPES_MAPPING = {"datasets": REPO_TYPE_DATASET, "spaces": REPO_TYPE_SPACE}
 
 
 # default cache

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -25,7 +25,7 @@ from typing import BinaryIO, Dict, Iterable, List, Optional, Tuple, Union
 import requests
 from requests.exceptions import HTTPError
 
-from .constants import ENDPOINT, REPO_TYPES, REPO_TYPES_URL_PREFIXES
+from .constants import ENDPOINT, REPO_TYPES, REPO_TYPES_MAPPING, REPO_TYPES_URL_PREFIXES
 
 
 if sys.version_info >= (3, 8):
@@ -37,6 +37,53 @@ else:
 REMOTE_FILEPATH_REGEX = re.compile(r"^\w[\w\/]*(\.\w+)?$")
 # ^^ No trailing slash, no backslash, no spaces, no relative parts ("." or "..")
 #    Only word characters and an optional extension
+
+
+def repo_type_and_id_from_hf_id(hf_id: str):
+    """
+    Returns the repo type and ID from a huggingface.co URL linking to a repository
+
+    Args:
+        hf_id (``str``):
+            An URL or ID of a repository on the HF hub. Accepted values are:
+            - https://huggingface.co/<repo_type>/<namespace>/<repo_id>
+            - https://huggingface.co/<namespace>/<repo_id>
+            - <repo_type>/<namespace>/<repo_id>
+            - <namespace>/<repo_id>
+            - <repo_id>
+    """
+    is_hf_url = "huggingface.co" in hf_id and "@" not in hf_id
+    url_segments = hf_id.split("/")
+    is_hf_id = len(url_segments) <= 3
+
+    if is_hf_url:
+        namespace, repo_id = url_segments[-2:]
+        if len(url_segments) > 2 and "huggingface.co" not in url_segments[-3]:
+            repo_type = url_segments[-3]
+        else:
+            repo_type = None
+    elif is_hf_id:
+        if len(url_segments) == 3:
+            # Passed <repo_type>/<user>/<model_id> or <repo_type>/<org>/<model_id>
+            repo_type, namespace, repo_id = url_segments[-3:]
+        elif len(url_segments) == 2:
+            # Passed <user>/<model_id> or <org>/<model_id>
+            namespace, repo_id = hf_id.split("/")[-2:]
+            repo_type = None
+        else:
+            # Passed <model_id>
+            repo_id = url_segments[0]
+            namespace, repo_type = None, None
+    else:
+        raise ValueError(
+            f"Unable to retrieve user and repo ID from the passed HF ID: {hf_id}"
+        )
+
+    repo_type = (
+        repo_type if repo_type in REPO_TYPES else REPO_TYPES_MAPPING.get(repo_type)
+    )
+
+    return repo_type, namespace, repo_id
 
 
 class RepoObj:

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -6,7 +6,9 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import List, Optional, Union
 
-from .hf_api import ENDPOINT, HfApi, HfFolder
+from huggingface_hub.constants import REPO_TYPES_URL_PREFIXES
+
+from .hf_api import ENDPOINT, HfApi, HfFolder, repo_type_and_id_from_hf_id
 from .lfs import LFS_MULTIPART_UPLOAD_COMMAND
 
 
@@ -58,6 +60,7 @@ class Repository:
         self,
         local_dir: str,
         clone_from: Optional[str] = None,
+        repo_type: Optional[str] = None,
         use_auth_token: Union[bool, str, None] = None,
         git_user: Optional[str] = None,
         git_email: Optional[str] = None,
@@ -76,8 +79,10 @@ class Repository:
         Args:
             local_dir (``str``):
                 path (e.g. ``'my_trained_model/'``) to the local directory, where the ``Repository`` will be initalized.
-            clone_from (``str``, optional):
+            clone_from (``str``, `optional`):
                 repository url (e.g. ``'https://huggingface.co/philschmid/playground-tests'``).
+            repo_type (``str``, `optional`):
+                To set when creating a repo: et to "dataset" or "space" if creating a dataset or space, default is model.
             use_auth_token (``str`` or ``bool``, `optional`, defaults ``None``):
                 huggingface_token can be extract from ``HfApi().login(username, password)`` and is used to authenticate against the hub
                 (useful from Google Colab for instance).
@@ -89,6 +94,7 @@ class Repository:
 
         os.makedirs(local_dir, exist_ok=True)
         self.local_dir = os.path.join(os.getcwd(), local_dir)
+        self.repo_type = repo_type
 
         self.check_git_versions()
 
@@ -156,36 +162,35 @@ class Repository:
         If this folder is a git repository with linked history, will try to update the repository.
         """
         token = use_auth_token if use_auth_token is not None else self.huggingface_token
-        is_hf_url = "huggingface.co" in repo_url and "@" not in repo_url
-        is_hf_id = len(repo_url.split("/")) <= 2
         api = HfApi()
 
         if token is not None:
-            if is_hf_url:
-                organization, repo_id = repo_url.split("/")[-2:]
-            elif is_hf_id:
-                if len(repo_url.split("/")) == 2:
-                    # Passed <user>/<model_id> or <org>/<model_id>
-                    organization, repo_id = repo_url.split("/")[-2:]
-                else:
-                    # Passed <model_id>
-                    organization, repo_id = api.whoami(token)[0], repo_url
+            user, valid_organisations = api.whoami(token)
+            repo_type, namespace, repo_id = repo_type_and_id_from_hf_id(repo_url)
 
-                repo_url = f"{ENDPOINT}/{organization}/{repo_id}"
-            else:
-                raise ValueError(
-                    f"Unable to retrieve user and repo ID from the passed clone URL: {repo_url}"
-                )
+            if namespace is None:
+                namespace = user
+
+            if repo_type is not None:
+                self.repo_type = repo_type
+
+            repo_url = ENDPOINT + "/"
+
+            if self.repo_type in REPO_TYPES_URL_PREFIXES:
+                repo_url += REPO_TYPES_URL_PREFIXES[self.repo_type]
+
+            repo_url += f"{namespace}/{repo_id}"
 
             repo_url = repo_url.replace("https://", f"https://user:{token}@")
 
-            print("Creating model under", repo_id, organization)
-            api.create_repo(
-                token,
-                repo_id,
-                organization=organization,
-                exist_ok=True,
-            )
+            if namespace == user or namespace in valid_organisations:
+                api.create_repo(
+                    token,
+                    repo_id,
+                    repo_type=self.repo_type,
+                    organization=namespace,
+                    exist_ok=True,
+                )
         # For error messages, it's cleaner to show the repo url without the token.
         clean_repo_url = re.sub(r"https://.*@", "https://", repo_url)
         try:

--- a/tests/fixtures/tiny_dataset/some_text.txt
+++ b/tests/fixtures/tiny_dataset/some_text.txt
@@ -1,0 +1,3 @@
+foo
+bar
+foobar

--- a/tests/fixtures/tiny_dataset/test.py
+++ b/tests/fixtures/tiny_dataset/test.py
@@ -1,0 +1,47 @@
+import datasets
+
+
+_CITATION = """\
+"""
+
+_DESCRIPTION = """\
+This is a test dataset.
+"""
+
+_URLS = {"train": "https://pastebin.com/raw/HvpE1CnA", "dev": "some_text.txt"}
+
+
+class Test(datasets.GeneratorBasedBuilder):
+    """SQUAD: The Stanford Question Answering Dataset. Version 1.1."""
+
+    def _info(self):
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=datasets.Features(
+                {
+                    "text": datasets.Value("string"),
+                }
+            ),
+            supervised_keys=None,
+            homepage="https://huggingface.co/datasets/lhoestq/test",
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager):
+        downloaded_files = dl_manager.download_and_extract(_URLS)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={"filepath": downloaded_files["train"]},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={"filepath": downloaded_files["dev"]},
+            ),
+        ]
+
+    def _generate_examples(self, filepath):
+        """This function returns the examples in the raw (text) form."""
+        for _id, line in enumerate(open(filepath, encoding="utf-8")):
+            yield _id, {"text": line.rstrip()}

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -23,7 +23,13 @@ from io import BytesIO
 
 from huggingface_hub.constants import REPO_TYPE_DATASET, REPO_TYPE_SPACE
 from huggingface_hub.file_download import cached_download
-from huggingface_hub.hf_api import HfApi, HfFolder, ModelInfo, RepoObj
+from huggingface_hub.hf_api import (
+    HfApi,
+    HfFolder,
+    ModelInfo,
+    RepoObj,
+    repo_type_and_id_from_hf_id,
+)
 from requests.exceptions import HTTPError
 
 from .testing_constants import ENDPOINT_STAGING, ENDPOINT_STAGING_BASIC_AUTH, PASS, USER
@@ -487,3 +493,19 @@ class HfLargefilesTest(HfApiCommonTest):
         start_time = time.time()
         subprocess.run(["git", "push"], check=True, cwd=WORKING_REPO_DIR)
         print("took", time.time() - start_time)
+
+
+class HfApiMiscTest(unittest.TestCase):
+    def test_repo_type_and_id_from_hf_id(self):
+        possible_values = {
+            "https://huggingface.co/user/id": [None, "user", "id"],
+            "https://huggingface.co/datasets/user/id": ["dataset", "user", "id"],
+            "https://huggingface.co/spaces/user/id": ["space", "user", "id"],
+            "user/id": [None, "user", "id"],
+            "dataset/user/id": ["dataset", "user", "id"],
+            "space/user/id": ["space", "user", "id"],
+            "id": [None, None, "id"],
+        }
+
+        for key, value in possible_values.items():
+            self.assertEqual(repo_type_and_id_from_hf_id(key), tuple(value))

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -263,3 +263,34 @@ class RepositoryTest(RepositoryCommonTest):
         files = os.listdir(f"{WORKING_REPO_DIR}/{REPO_NAME}")
         self.assertTrue("dummy.txt" in files)
         self.assertTrue("model.bin" in files)
+
+    def test_clone_with_repo_name_and_no_namespace(self):
+        clone = Repository(
+            REPO_NAME,
+            clone_from=REPO_NAME,
+            use_auth_token=self._token,
+            git_user="ci",
+            git_email="ci@dummy.com",
+        )
+
+        with clone.commit("Commit"):
+            # Create dummy files
+            # one is lfs-tracked, the other is not.
+            with open("dummy.txt", "w") as f:
+                f.write("hello")
+            with open("model.bin", "w") as f:
+                f.write("hello")
+
+        shutil.rmtree(REPO_NAME)
+
+        Repository(
+            f"{WORKING_REPO_DIR}/{REPO_NAME}",
+            clone_from=f"{ENDPOINT_STAGING}/{USER}/{REPO_NAME}",
+            use_auth_token=self._token,
+            git_user="ci",
+            git_email="ci@dummy.com",
+        )
+
+        files = os.listdir(f"{WORKING_REPO_DIR}/{REPO_NAME}")
+        self.assertTrue("dummy.txt" in files)
+        self.assertTrue("model.bin" in files)

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import pathlib
 import shutil
 import subprocess
 import tempfile
@@ -33,6 +34,13 @@ REPO_NAME = "repo-{}".format(int(time.time() * 10e3))
 
 WORKING_REPO_DIR = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), "fixtures/working_repo_2"
+)
+
+DATASET_FIXTURE = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "fixtures/tiny_dataset"
+)
+WORKING_DATASET_DIR = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "fixtures/working_dataset"
 )
 
 
@@ -63,7 +71,12 @@ class RepositoryTest(RepositoryCommonTest):
         )
 
     def tearDown(self):
-        self._api.delete_repo(token=self._token, name=REPO_NAME)
+        try:
+            self._api.delete_repo(token=self._token, name=REPO_NAME)
+        except requests.exceptions.HTTPError:
+            self._api.delete_repo(
+                token=self._token, organization="valid_org", name=REPO_NAME
+            )
 
     def test_init_from_existing_local_clone(self):
         subprocess.run(
@@ -204,7 +217,36 @@ class RepositoryTest(RepositoryCommonTest):
 
         shutil.rmtree(WORKING_REPO_DIR)
 
-    def test_clone_with_repo_name_and_organization(self):
+    def test_clone_with_endpoint(self):
+        clone = Repository(
+            REPO_NAME,
+            clone_from=f"{ENDPOINT_STAGING}/valid_org/{REPO_NAME}",
+            use_auth_token=self._token,
+            git_user="ci",
+            git_email="ci@dummy.com",
+        )
+
+        with clone.commit("Commit"):
+            with open("dummy.txt", "w") as f:
+                f.write("hello")
+            with open("model.bin", "w") as f:
+                f.write("hello")
+
+        shutil.rmtree(REPO_NAME)
+
+        Repository(
+            f"{WORKING_REPO_DIR}/{REPO_NAME}",
+            clone_from=f"{ENDPOINT_STAGING}/valid_org/{REPO_NAME}",
+            use_auth_token=self._token,
+            git_user="ci",
+            git_email="ci@dummy.com",
+        )
+
+        files = os.listdir(f"{WORKING_REPO_DIR}/{REPO_NAME}")
+        self.assertTrue("dummy.txt" in files)
+        self.assertTrue("model.bin" in files)
+
+    def test_clone_with_repo_name_and_org(self):
         clone = Repository(
             REPO_NAME,
             clone_from=f"valid_org/{REPO_NAME}",
@@ -223,7 +265,7 @@ class RepositoryTest(RepositoryCommonTest):
 
         Repository(
             f"{WORKING_REPO_DIR}/{REPO_NAME}",
-            clone_from=f"{ENDPOINT_STAGING}/valid_org/{REPO_NAME}",
+            clone_from=f"valid_org/{REPO_NAME}",
             use_auth_token=self._token,
             git_user="ci",
             git_email="ci@dummy.com",
@@ -254,7 +296,7 @@ class RepositoryTest(RepositoryCommonTest):
 
         Repository(
             f"{WORKING_REPO_DIR}/{REPO_NAME}",
-            clone_from=f"{ENDPOINT_STAGING}/{USER}/{REPO_NAME}",
+            clone_from=f"{USER}/{REPO_NAME}",
             use_auth_token=self._token,
             git_user="ci",
             git_email="ci@dummy.com",
@@ -285,7 +327,7 @@ class RepositoryTest(RepositoryCommonTest):
 
         Repository(
             f"{WORKING_REPO_DIR}/{REPO_NAME}",
-            clone_from=f"{ENDPOINT_STAGING}/{USER}/{REPO_NAME}",
+            clone_from=REPO_NAME,
             use_auth_token=self._token,
             git_user="ci",
             git_email="ci@dummy.com",
@@ -294,3 +336,145 @@ class RepositoryTest(RepositoryCommonTest):
         files = os.listdir(f"{WORKING_REPO_DIR}/{REPO_NAME}")
         self.assertTrue("dummy.txt" in files)
         self.assertTrue("model.bin" in files)
+
+
+class RepositoryDatasetTest(RepositoryCommonTest):
+    @classmethod
+    def setUpClass(cls):
+        """
+        Share this valid token in all tests below.
+        """
+        cls._token = cls._api.login(username=USER, password=PASS)
+
+    def tearDown(self):
+        try:
+            self._api.delete_repo(
+                token=self._token, name=REPO_NAME, repo_type="dataset"
+            )
+        except requests.exceptions.HTTPError:
+            self._api.delete_repo(
+                token=self._token,
+                organization="valid_org",
+                name=REPO_NAME,
+                repo_type="dataset",
+            )
+
+        shutil.rmtree(
+            f"{WORKING_DATASET_DIR}/{REPO_NAME}", onerror=set_write_permission_and_retry
+        )
+
+    def test_clone_with_endpoint(self):
+        clone = Repository(
+            f"{WORKING_DATASET_DIR}/{REPO_NAME}",
+            clone_from=f"{ENDPOINT_STAGING}/datasets/{USER}/{REPO_NAME}",
+            repo_type="dataset",
+            use_auth_token=self._token,
+            git_user="ci",
+            git_email="ci@dummy.com",
+        )
+
+        with clone.commit("Commit"):
+            for file in os.listdir(DATASET_FIXTURE):
+                shutil.copyfile(pathlib.Path(DATASET_FIXTURE) / file, file)
+
+        shutil.rmtree(f"{WORKING_DATASET_DIR}/{REPO_NAME}")
+
+        Repository(
+            f"{WORKING_DATASET_DIR}/{REPO_NAME}",
+            clone_from=f"{ENDPOINT_STAGING}/datasets/{USER}/{REPO_NAME}",
+            use_auth_token=self._token,
+            repo_type="dataset",
+            git_user="ci",
+            git_email="ci@dummy.com",
+        )
+
+        files = os.listdir(f"{WORKING_DATASET_DIR}/{REPO_NAME}")
+        self.assertTrue("some_text.txt" in files)
+        self.assertTrue("test.py" in files)
+
+    def test_clone_with_repo_name_and_org(self):
+        clone = Repository(
+            f"{WORKING_DATASET_DIR}/{REPO_NAME}",
+            clone_from=f"valid_org/{REPO_NAME}",
+            repo_type="dataset",
+            use_auth_token=self._token,
+            git_user="ci",
+            git_email="ci@dummy.com",
+        )
+
+        with clone.commit("Commit"):
+            for file in os.listdir(DATASET_FIXTURE):
+                shutil.copyfile(pathlib.Path(DATASET_FIXTURE) / file, file)
+
+        shutil.rmtree(f"{WORKING_DATASET_DIR}/{REPO_NAME}")
+
+        Repository(
+            f"{WORKING_DATASET_DIR}/{REPO_NAME}",
+            clone_from=f"valid_org/{REPO_NAME}",
+            use_auth_token=self._token,
+            repo_type="dataset",
+            git_user="ci",
+            git_email="ci@dummy.com",
+        )
+
+        files = os.listdir(f"{WORKING_DATASET_DIR}/{REPO_NAME}")
+        self.assertTrue("some_text.txt" in files)
+        self.assertTrue("test.py" in files)
+
+    def test_clone_with_repo_name_and_user_namespace(self):
+        clone = Repository(
+            f"{WORKING_DATASET_DIR}/{REPO_NAME}",
+            clone_from=f"{USER}/{REPO_NAME}",
+            repo_type="dataset",
+            use_auth_token=self._token,
+            git_user="ci",
+            git_email="ci@dummy.com",
+        )
+
+        with clone.commit("Commit"):
+            for file in os.listdir(DATASET_FIXTURE):
+                shutil.copyfile(pathlib.Path(DATASET_FIXTURE) / file, file)
+
+        shutil.rmtree(f"{WORKING_DATASET_DIR}/{REPO_NAME}")
+
+        Repository(
+            f"{WORKING_DATASET_DIR}/{REPO_NAME}",
+            clone_from=f"{USER}/{REPO_NAME}",
+            use_auth_token=self._token,
+            repo_type="dataset",
+            git_user="ci",
+            git_email="ci@dummy.com",
+        )
+
+        files = os.listdir(f"{WORKING_DATASET_DIR}/{REPO_NAME}")
+        self.assertTrue("some_text.txt" in files)
+        self.assertTrue("test.py" in files)
+
+    def test_clone_with_repo_name_and_no_namespace(self):
+        clone = Repository(
+            f"{WORKING_DATASET_DIR}/{REPO_NAME}",
+            clone_from=REPO_NAME,
+            repo_type="dataset",
+            use_auth_token=self._token,
+            git_user="ci",
+            git_email="ci@dummy.com",
+        )
+
+        with clone.commit("Commit"):
+            for file in os.listdir(DATASET_FIXTURE):
+                shutil.copyfile(pathlib.Path(DATASET_FIXTURE) / file, file)
+
+        shutil.rmtree(f"{WORKING_DATASET_DIR}/{REPO_NAME}")
+
+        Repository(
+            f"{WORKING_DATASET_DIR}/{REPO_NAME}",
+            clone_from=REPO_NAME,
+            use_auth_token=self._token,
+            repo_type="dataset",
+            git_user="ci",
+            git_email="ci@dummy.com",
+        )
+
+        files = os.listdir(f"{WORKING_DATASET_DIR}/{REPO_NAME}")
+        self.assertTrue("some_text.txt" in files)
+        self.assertTrue("test.py" in files)


### PR DESCRIPTION
This PR is built on top of https://github.com/huggingface/huggingface_hub/pull/148 for the tests.

This enables doing the following when authenticated:

```py
from huggingface_hub import Repository

repo = Repository(local_directory, clone_from="torch-model", use_auth_token=True)
```
It uses the user namespace by default.

previously this required passing the namespace as well:
```py
from huggingface_hub import Repository

repo = Repository(local_directory, clone_from="user/torch-model", use_auth_token=True)
# or 
repo = Repository(local_directory, clone_from="org/torch-model", use_auth_token=True)
```