### PR TITLE
Enable dataset repositories

### DIFF
--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -30,7 +30,7 @@ from .constants import (
     TF_WEIGHTS_NAME,
 )
 from .file_download import cached_download, hf_hub_download, hf_hub_url
-from .hf_api import HfApi, HfFolder
+from .hf_api import HfApi, HfFolder, repo_type_and_id_from_hf_id
 from .hub_mixin import ModelHubMixin
 from .repository import Repository
 from .snapshot_download import snapshot_download

--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -36,6 +36,7 @@ REPO_TYPES_URL_PREFIXES = {
     REPO_TYPE_DATASET: "datasets/",
     REPO_TYPE_SPACE: "spaces/",
 }
+REPO_TYPES_MAPPING = {"datasets": REPO_TYPE_DATASET, "spaces": REPO_TYPE_SPACE}
 
 
 # default cache

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -79,7 +79,9 @@ def repo_type_and_id_from_hf_id(hf_id: str):
             f"Unable to retrieve user and repo ID from the passed HF ID: {hf_id}"
         )
 
-    repo_type = REPO_TYPES_MAPPING.get(repo_type)
+    repo_type = (
+        repo_type if repo_type in REPO_TYPES else REPO_TYPES_MAPPING.get(repo_type)
+    )
 
     return repo_type, namespace, repo_id
 

--- a/tests/fixtures/tiny_dataset/some_text.txt
+++ b/tests/fixtures/tiny_dataset/some_text.txt
@@ -1,0 +1,3 @@
+foo
+bar
+foobar

--- a/tests/fixtures/tiny_dataset/test.py
+++ b/tests/fixtures/tiny_dataset/test.py
@@ -1,0 +1,47 @@
+import datasets
+
+
+_CITATION = """\
+"""
+
+_DESCRIPTION = """\
+This is a test dataset.
+"""
+
+_URLS = {"train": "https://pastebin.com/raw/HvpE1CnA", "dev": "some_text.txt"}
+
+
+class Test(datasets.GeneratorBasedBuilder):
+    """SQUAD: The Stanford Question Answering Dataset. Version 1.1."""
+
+    def _info(self):
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=datasets.Features(
+                {
+                    "text": datasets.Value("string"),
+                }
+            ),
+            supervised_keys=None,
+            homepage="https://huggingface.co/datasets/lhoestq/test",
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager):
+        downloaded_files = dl_manager.download_and_extract(_URLS)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={"filepath": downloaded_files["train"]},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={"filepath": downloaded_files["dev"]},
+            ),
+        ]
+
+    def _generate_examples(self, filepath):
+        """This function returns the examples in the raw (text) form."""
+        for _id, line in enumerate(open(filepath, encoding="utf-8")):
+            yield _id, {"text": line.rstrip()}

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -23,7 +23,13 @@ from io import BytesIO
 
 from huggingface_hub.constants import REPO_TYPE_DATASET, REPO_TYPE_SPACE
 from huggingface_hub.file_download import cached_download
-from huggingface_hub.hf_api import HfApi, HfFolder, ModelInfo, RepoObj
+from huggingface_hub.hf_api import (
+    HfApi,
+    HfFolder,
+    ModelInfo,
+    RepoObj,
+    repo_type_and_id_from_hf_id,
+)
 from requests.exceptions import HTTPError
 
 from .testing_constants import ENDPOINT_STAGING, ENDPOINT_STAGING_BASIC_AUTH, PASS, USER
@@ -487,3 +493,19 @@ class HfLargefilesTest(HfApiCommonTest):
         start_time = time.time()
         subprocess.run(["git", "push"], check=True, cwd=WORKING_REPO_DIR)
         print("took", time.time() - start_time)
+
+
+class HfApiMiscTest(unittest.TestCase):
+    def test_repo_type_and_id_from_hf_id(self):
+        possible_values = {
+            "https://huggingface.co/user/id": [None, "user", "id"],
+            "https://huggingface.co/dataset/user/id": ["dataset", "user", "id"],
+            "https://huggingface.co/space/user/id": ["space", "user", "id"],
+            "user/id": [None, "user", "id"],
+            "dataset/user/id": ["dataset", "user", "id"],
+            "space/user/id": ["space", "user", "id"],
+            "id": [None, None, "id"],
+        }
+
+        for key, value in possible_values.items():
+            self.assertEqual(repo_type_and_id_from_hf_id(key), tuple(value))

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -499,8 +499,8 @@ class HfApiMiscTest(unittest.TestCase):
     def test_repo_type_and_id_from_hf_id(self):
         possible_values = {
             "https://huggingface.co/user/id": [None, "user", "id"],
-            "https://huggingface.co/dataset/user/id": ["dataset", "user", "id"],
-            "https://huggingface.co/space/user/id": ["space", "user", "id"],
+            "https://huggingface.co/datasets/user/id": ["dataset", "user", "id"],
+            "https://huggingface.co/spaces/user/id": ["space", "user", "id"],
             "user/id": [None, "user", "id"],
             "dataset/user/id": ["dataset", "user", "id"],
             "space/user/id": ["space", "user", "id"],

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import pathlib
 import shutil
 import subprocess
 import tempfile
@@ -33,6 +34,13 @@ REPO_NAME = "repo-{}".format(int(time.time() * 10e3))
 
 WORKING_REPO_DIR = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), "fixtures/working_repo_2"
+)
+
+DATASET_FIXTURE = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "fixtures/tiny_dataset"
+)
+WORKING_DATASET_DIR = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "fixtures/working_dataset"
 )
 
 
@@ -63,7 +71,12 @@ class RepositoryTest(RepositoryCommonTest):
         )
 
     def tearDown(self):
-        self._api.delete_repo(token=self._token, name=REPO_NAME)
+        try:
+            self._api.delete_repo(token=self._token, name=REPO_NAME)
+        except requests.exceptions.HTTPError:
+            self._api.delete_repo(
+                token=self._token, organization="valid_org", name=REPO_NAME
+            )
 
     def test_init_from_existing_local_clone(self):
         subprocess.run(
@@ -204,7 +217,36 @@ class RepositoryTest(RepositoryCommonTest):
 
         shutil.rmtree(WORKING_REPO_DIR)
 
-    def test_clone_with_repo_name_and_organization(self):
+    def test_clone_with_endpoint(self):
+        clone = Repository(
+            REPO_NAME,
+            clone_from=f"{ENDPOINT_STAGING}/valid_org/{REPO_NAME}",
+            use_auth_token=self._token,
+            git_user="ci",
+            git_email="ci@dummy.com",
+        )
+
+        with clone.commit("Commit"):
+            with open("dummy.txt", "w") as f:
+                f.write("hello")
+            with open("model.bin", "w") as f:
+                f.write("hello")
+
+        shutil.rmtree(REPO_NAME)
+
+        Repository(
+            f"{WORKING_REPO_DIR}/{REPO_NAME}",
+            clone_from=f"{ENDPOINT_STAGING}/valid_org/{REPO_NAME}",
+            use_auth_token=self._token,
+            git_user="ci",
+            git_email="ci@dummy.com",
+        )
+
+        files = os.listdir(f"{WORKING_REPO_DIR}/{REPO_NAME}")
+        self.assertTrue("dummy.txt" in files)
+        self.assertTrue("model.bin" in files)
+
+    def test_clone_with_repo_name_and_org(self):
         clone = Repository(
             REPO_NAME,
             clone_from=f"valid_org/{REPO_NAME}",
@@ -223,7 +265,7 @@ class RepositoryTest(RepositoryCommonTest):
 
         Repository(
             f"{WORKING_REPO_DIR}/{REPO_NAME}",
-            clone_from=f"{ENDPOINT_STAGING}/valid_org/{REPO_NAME}",
+            clone_from=f"valid_org/{REPO_NAME}",
             use_auth_token=self._token,
             git_user="ci",
             git_email="ci@dummy.com",
@@ -254,7 +296,7 @@ class RepositoryTest(RepositoryCommonTest):
 
         Repository(
             f"{WORKING_REPO_DIR}/{REPO_NAME}",
-            clone_from=f"{ENDPOINT_STAGING}/{USER}/{REPO_NAME}",
+            clone_from=f"{USER}/{REPO_NAME}",
             use_auth_token=self._token,
             git_user="ci",
             git_email="ci@dummy.com",
@@ -285,7 +327,7 @@ class RepositoryTest(RepositoryCommonTest):
 
         Repository(
             f"{WORKING_REPO_DIR}/{REPO_NAME}",
-            clone_from=f"{ENDPOINT_STAGING}/{USER}/{REPO_NAME}",
+            clone_from=REPO_NAME,
             use_auth_token=self._token,
             git_user="ci",
             git_email="ci@dummy.com",
@@ -294,3 +336,145 @@ class RepositoryTest(RepositoryCommonTest):
         files = os.listdir(f"{WORKING_REPO_DIR}/{REPO_NAME}")
         self.assertTrue("dummy.txt" in files)
         self.assertTrue("model.bin" in files)
+
+
+class RepositoryDatasetTest(RepositoryCommonTest):
+    @classmethod
+    def setUpClass(cls):
+        """
+        Share this valid token in all tests below.
+        """
+        cls._token = cls._api.login(username=USER, password=PASS)
+
+    def tearDown(self):
+        try:
+            self._api.delete_repo(
+                token=self._token, name=REPO_NAME, repo_type="dataset"
+            )
+        except requests.exceptions.HTTPError:
+            self._api.delete_repo(
+                token=self._token,
+                organization="valid_org",
+                name=REPO_NAME,
+                repo_type="dataset",
+            )
+
+        shutil.rmtree(
+            f"{WORKING_DATASET_DIR}/{REPO_NAME}", onerror=set_write_permission_and_retry
+        )
+
+    def test_clone_with_endpoint(self):
+        clone = Repository(
+            f"{WORKING_DATASET_DIR}/{REPO_NAME}",
+            clone_from=f"{ENDPOINT_STAGING}/datasets/{USER}/{REPO_NAME}",
+            repo_type="dataset",
+            use_auth_token=self._token,
+            git_user="ci",
+            git_email="ci@dummy.com",
+        )
+
+        with clone.commit("Commit"):
+            for file in os.listdir(DATASET_FIXTURE):
+                shutil.copyfile(pathlib.Path(DATASET_FIXTURE) / file, file)
+
+        shutil.rmtree(f"{WORKING_DATASET_DIR}/{REPO_NAME}")
+
+        Repository(
+            f"{WORKING_DATASET_DIR}/{REPO_NAME}",
+            clone_from=f"{ENDPOINT_STAGING}/datasets/{USER}/{REPO_NAME}",
+            use_auth_token=self._token,
+            repo_type="dataset",
+            git_user="ci",
+            git_email="ci@dummy.com",
+        )
+
+        files = os.listdir(f"{WORKING_DATASET_DIR}/{REPO_NAME}")
+        self.assertTrue("some_text.txt" in files)
+        self.assertTrue("test.py" in files)
+
+    def test_clone_with_repo_name_and_org(self):
+        clone = Repository(
+            f"{WORKING_DATASET_DIR}/{REPO_NAME}",
+            clone_from=f"valid_org/{REPO_NAME}",
+            repo_type="dataset",
+            use_auth_token=self._token,
+            git_user="ci",
+            git_email="ci@dummy.com",
+        )
+
+        with clone.commit("Commit"):
+            for file in os.listdir(DATASET_FIXTURE):
+                shutil.copyfile(pathlib.Path(DATASET_FIXTURE) / file, file)
+
+        shutil.rmtree(f"{WORKING_DATASET_DIR}/{REPO_NAME}")
+
+        Repository(
+            f"{WORKING_DATASET_DIR}/{REPO_NAME}",
+            clone_from=f"valid_org/{REPO_NAME}",
+            use_auth_token=self._token,
+            repo_type="dataset",
+            git_user="ci",
+            git_email="ci@dummy.com",
+        )
+
+        files = os.listdir(f"{WORKING_DATASET_DIR}/{REPO_NAME}")
+        self.assertTrue("some_text.txt" in files)
+        self.assertTrue("test.py" in files)
+
+    def test_clone_with_repo_name_and_user_namespace(self):
+        clone = Repository(
+            f"{WORKING_DATASET_DIR}/{REPO_NAME}",
+            clone_from=f"{USER}/{REPO_NAME}",
+            repo_type="dataset",
+            use_auth_token=self._token,
+            git_user="ci",
+            git_email="ci@dummy.com",
+        )
+
+        with clone.commit("Commit"):
+            for file in os.listdir(DATASET_FIXTURE):
+                shutil.copyfile(pathlib.Path(DATASET_FIXTURE) / file, file)
+
+        shutil.rmtree(f"{WORKING_DATASET_DIR}/{REPO_NAME}")
+
+        Repository(
+            f"{WORKING_DATASET_DIR}/{REPO_NAME}",
+            clone_from=f"{USER}/{REPO_NAME}",
+            use_auth_token=self._token,
+            repo_type="dataset",
+            git_user="ci",
+            git_email="ci@dummy.com",
+        )
+
+        files = os.listdir(f"{WORKING_DATASET_DIR}/{REPO_NAME}")
+        self.assertTrue("some_text.txt" in files)
+        self.assertTrue("test.py" in files)
+
+    def test_clone_with_repo_name_and_no_namespace(self):
+        clone = Repository(
+            f"{WORKING_DATASET_DIR}/{REPO_NAME}",
+            clone_from=REPO_NAME,
+            repo_type="dataset",
+            use_auth_token=self._token,
+            git_user="ci",
+            git_email="ci@dummy.com",
+        )
+
+        with clone.commit("Commit"):
+            for file in os.listdir(DATASET_FIXTURE):
+                shutil.copyfile(pathlib.Path(DATASET_FIXTURE) / file, file)
+
+        shutil.rmtree(f"{WORKING_DATASET_DIR}/{REPO_NAME}")
+
+        Repository(
+            f"{WORKING_DATASET_DIR}/{REPO_NAME}",
+            clone_from=REPO_NAME,
+            use_auth_token=self._token,
+            repo_type="dataset",
+            git_user="ci",
+            git_email="ci@dummy.com",
+        )
+
+        files = os.listdir(f"{WORKING_DATASET_DIR}/{REPO_NAME}")
+        self.assertTrue("some_text.txt" in files)
+        self.assertTrue("test.py" in files)


### PR DESCRIPTION
This PR is built on top of https://github.com/huggingface/huggingface_hub/pull/148 for the tests and https://github.com/huggingface/huggingface_hub/pull/150 for the lack of requirement regarding the namespace definition in the clone.

This enables `datasets` handling from `Repository`'s `clone_from` method.

Closes https://github.com/huggingface/huggingface_hub/issues/144

@SBrandeis could you try it out and let me know if it fixes your issue?