### PR TITLE
Add config to list_models

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -155,7 +155,7 @@ class HfApi:
         direction: Optional[Literal[-1]] = None,
         limit: Optional[int] = None,
         full: Optional[bool] = None,
-        config: Optional[bool] = None,
+        fetch_config: Optional[bool] = None,
     ) -> List[ModelInfo]:
         """
         Get the public list of all the models on huggingface.co
@@ -193,7 +193,7 @@ class HfApi:
             full (:obj:`bool`, `optional`):
                 Whether to fetch all model data, including the `lastModified`, the `sha`, the files and the `tags`.
                 This is set to `True` by default when using a filter.
-            config (:obj:`bool`, `optional`):
+            fetch_config (:obj:`bool`, `optional`):
                 Whether to fetch the model configs as well. This is not included in `full` due to its size.
 
         """
@@ -213,8 +213,8 @@ class HfApi:
                 params.update({"full": True})
             elif "full" in params:
                 del params["full"]
-        if config is not None:
-            params.update({"config": config})
+        if fetch_config is not None:
+            params.update({"config": fetch_config})
         r = requests.get(path, params=params)
         r.raise_for_status()
         d = r.json()

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -155,6 +155,7 @@ class HfApi:
         direction: Optional[Literal[-1]] = None,
         limit: Optional[int] = None,
         full: Optional[bool] = None,
+        config: Optional[bool] = None,
     ) -> List[ModelInfo]:
         """
         Get the public list of all the models on huggingface.co
@@ -192,6 +193,8 @@ class HfApi:
             full (:obj:`bool`, `optional`):
                 Whether to fetch all model data, including the `lastModified`, the `sha`, the files and the `tags`.
                 This is set to `True` by default when using a filter.
+            config (:obj:`bool`, `optional`):
+                Whether to fetch the model configs as well. This is not included in `full` due to its size.
 
         """
         path = "{}/api/models".format(self.endpoint)
@@ -210,6 +213,8 @@ class HfApi:
                 params.update({"full": True})
             elif "full" in params:
                 del params["full"]
+        if config is not None:
+            params.update({"config": config})
         r = requests.get(path, params=params)
         r.raise_for_status()
         d = r.json()

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -332,6 +332,15 @@ class HfApiPublicTest(unittest.TestCase):
         self.assertIsInstance(model, ModelInfo)
         self.assertTrue(all(tag in model.tags for tag in ["bert", "jax"]))
 
+    def test_list_models_with_config(self):
+        _api = HfApi()
+        models = _api.list_models(filter="adapter-transformers", config=True, limit=20)
+        found_configs = 0
+        for model in models:
+            if model.config:
+                found_configs = found_configs + 1
+        self.assertGreater(found_configs, 0)
+
     def test_model_info(self):
         _api = HfApi()
         model = _api.model_info(repo_id=DUMMY_MODEL_ID)

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -334,7 +334,9 @@ class HfApiPublicTest(unittest.TestCase):
 
     def test_list_models_with_config(self):
         _api = HfApi()
-        models = _api.list_models(filter="adapter-transformers", config=True, limit=20)
+        models = _api.list_models(
+            filter="adapter-transformers", fetch_config=True, limit=20
+        )
         found_configs = 0
         for model in models:
             if model.config:


### PR DESCRIPTION
Here is an example from `list_models` for `adapter-transformers`.

FYI @calpt

```
ModelInfo: {
	modelId: AdapterHub/roberta-base-pf-sick
	sha: b4cbe28cab4c4ac47d1cb431c73ac7917e38c0d0
	lastModified: 2021-06-16T16:11:08.000Z
	tags: ['roberta', 'en', 'dataset:sick', 'adapter-transformers']
	pipeline_tag: None
	siblings: [ModelFile(rfilename='.gitattributes'), ModelFile(rfilename='README.md'), ModelFile(rfilename='adapter_config.json'), ModelFile(rfilename='head_config.json'), ModelFile(rfilename='pytorch_adapter.bin'), ModelFile(rfilename='pytorch_model_head.bin')]
	config: {'model_type': 'roberta', 'adapter_transformers': {'model_name': 'roberta-base', 'model_class': 'RobertaModelWithHeads'}}
	private: False
	library_name: adapter-transformers
}
ModelInfo: {
	modelId: calpt/adapter-bert-base-squad1
	sha: 9d63a706848c70bbd52ab7124dba3256e659d12a
	lastModified: 2021-06-08T10:13:48.000Z
	tags: ['bert', 'adapter-transformers', 'adapterhub:qa/squad1']
	pipeline_tag: None
	siblings: [ModelFile(rfilename='.gitattributes'), ModelFile(rfilename='README.md'), ModelFile(rfilename='adapter_config.json'), ModelFile(rfilename='head_config.json'), ModelFile(rfilename='pytorch_adapter.bin'), ModelFile(rfilename='pytorch_model_head.bin')]
	config: {'model_type': 'bert', 'adapter_transformers': {'model_name': 'bert-base-uncased', 'model_class': 'BertModelWithHeads'}}
	private: False
	library_name: adapter-transformers
}
ModelInfo: {
	modelId: calpt/adapter_test
	sha: 000caa859c43bc5bc6825db4bd8c003211f95d7a
	lastModified: 2021-06-28T12:01:43.000Z
	tags: ['bert', 'dataset:imdb', 'adapter-transformers', 'adapterhub:sentiment/imdb']
	pipeline_tag: None
	siblings: [ModelFile(rfilename='README.md'), ModelFile(rfilename='adapter_config.json'), ModelFile(rfilename='head_config.json'), ModelFile(rfilename='pytorch_adapter.bin'), ModelFile(rfilename='pytorch_model_head.bin')]
	config: {'model_type': 'bert', 'adapter_transformers': {'model_name': 'bert-base-uncased', 'model_class': 'BertModelWithHeads'}}
	private: False
	library_name: adapter-transformers
}
```
