### PR TITLE
Fixing audio-to-audio validation.

### DIFF
--- a/widgets/src/lib/InferenceWidget/widgets/AudioToAudioWidget/AudioToAudioWidget.svelte
+++ b/widgets/src/lib/InferenceWidget/widgets/AudioToAudioWidget/AudioToAudioWidget.svelte
@@ -34,7 +34,7 @@
 		blob: string;
 		label: string;
 		src?: string;
-        content-type: string;
+        "content-type": string;
 	}
 
 	function onChangeRadio() {

--- a/widgets/src/lib/InferenceWidget/widgets/AudioToAudioWidget/AudioToAudioWidget.svelte
+++ b/widgets/src/lib/InferenceWidget/widgets/AudioToAudioWidget/AudioToAudioWidget.svelte
@@ -33,7 +33,8 @@
 	interface AudioItem {
 		blob: string;
 		label: string;
-		src: string;
+		src?: string;
+        content-type: string;
 	}
 
 	function onChangeRadio() {
@@ -110,7 +111,7 @@
 				(x) =>
 					typeof x.blob === "string" &&
 					typeof x.label === "string" &&
-					typeof x.src === "string"
+					typeof x["content-type"] === "string"
 			)
 		);
 	}

--- a/widgets/src/lib/InferenceWidget/widgets/AudioToAudioWidget/AudioToAudioWidget.svelte
+++ b/widgets/src/lib/InferenceWidget/widgets/AudioToAudioWidget/AudioToAudioWidget.svelte
@@ -34,7 +34,7 @@
 		blob: string;
 		label: string;
 		src?: string;
-        "content-type": string;
+		"content-type": string;
 	}
 
 	function onChangeRadio() {

--- a/widgets/src/routes/index.svelte
+++ b/widgets/src/routes/index.svelte
@@ -166,6 +166,13 @@
 			tags: ["audio-source-separation"],
 			widgetData: [],
 		},
+		{
+			modelId: "julien-c/DPRNNTasNet-ks16_WHAM_sepclean",
+			private: false,
+			pipeline_tag: "audio-to-audio",
+			tags: ["audio-source-separation"],
+			widgetData: [],
+		},
 	];
 </script>
 


### PR DESCRIPTION
`src` does NOT exist on the incoming payload.

`content-type`, `blob` and `label` are the keys.
`src` is only added later as a convenience to display.

Example of usable model: https://huggingface.co/julien-c/DPRNNTasNet-ks16_WHAM_sepclean