### PR TITLE
Set use_auth_token to True by default

### DIFF
--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -120,7 +120,7 @@ class Repository:
         local_dir: str,
         clone_from: Optional[str] = None,
         repo_type: Optional[str] = None,
-        use_auth_token: Union[bool, str, None] = None,
+        use_auth_token: Union[bool, str] = True,
         git_user: Optional[str] = None,
         git_email: Optional[str] = None,
     ):


### PR DESCRIPTION
This sets the `use_auth_token` parameter to `True` by default for the `Repository` instantiation.

If users are not logged in, then it will behave similarly to the previous default, or if the `use_auth_token` parameter was set to `False`: the `HfFolder().get_token()` returns `None`, and the `Repository` behaves as unauthenticated.

For logged-in users, however, this should dramatically reduce the user errors linked to cloning a repository without specifying the authentication token, in turn being unable to push to that repository with an unhelpful error.

Fix https://github.com/huggingface/huggingface_hub/issues/187