### PR TITLE
Remove `--no_renames` argument to list deleted files.

### DIFF
--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -403,7 +403,7 @@ class Repository:
         """
         try:
             git_status = subprocess.run(
-                ["git", "status", "--no-renames", "-s"],
+                ["git", "status", "-s"],
                 stderr=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 check=True,


### PR DESCRIPTION
The `--no-renames` argument was introduced in git version 2.18, and git is installed with version 2.17 on colab notebooks. Removing this argument so that `hfh` is compatible with colab notebooks.