### PR TITLE
[Docs] Update link to Gradio documentation 

### DIFF
--- a/docs/hub/spaces.md
+++ b/docs/hub/spaces.md
@@ -28,7 +28,7 @@ We then deploy a containerized version of your code on our Infra, each time you 
 
 We recommend you try both as they're both really awesome! 😎
 
-Streamlit's documentation is at https://docs.streamlit.io/, and Gradio's doc is https://gradio.app/docs.
+Streamlit's documentation is at https://docs.streamlit.io/, and Gradio's doc is https://gradio.app/getting_started.
 
 In the default environment, we're currently running version `"0.79.0"` of Streamlit and version `"2.0.9"` of Gradio.
 


### PR DESCRIPTION
This new link is a more readable getting started page 