### PR TITLE
Add `filename` option to `lfs_track`

### DIFF
--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -444,7 +444,7 @@ class Repository:
 
         Setting the `filename` argument to `True` will treat the arguments as literal filenames,
         not as patterns. Any special glob characters in the filename will be escaped when
-        writing the .gitattributes file.
+        writing to the .gitattributes file.
         """
         if isinstance(patterns, str):
             patterns = [patterns]

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -438,16 +438,21 @@ class Repository:
 
         return deleted_files
 
-    def lfs_track(self, patterns: Union[str, List[str]]):
+    def lfs_track(self, patterns: Union[str, List[str]], filename: bool = False):
         """
         Tell git-lfs to track those files.
+
+        Setting the `filename` argument to `True` will treat the arguments as literal filenames,
+        not as patterns. Any special glob characters in the filename will be escaped when
+        writing the .gitattributes file.
         """
         if isinstance(patterns, str):
             patterns = [patterns]
         try:
             for pattern in patterns:
+                cmd = f"git lfs track {'--filename' if filename else ''} {pattern}"
                 subprocess.run(
-                    ["git", "lfs", "track", pattern],
+                    cmd.split(),
                     stderr=subprocess.PIPE,
                     stdout=subprocess.PIPE,
                     check=True,

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -107,6 +107,30 @@ class RepositoryTest(RepositoryCommonTest):
 
         self.assertIn("random_file.txt", os.listdir(WORKING_REPO_DIR))
 
+    def test_git_lfs_filename(self):
+        os.mkdir(WORKING_REPO_DIR)
+        subprocess.run(
+            ["git", "init"],
+            stderr=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            check=True,
+            cwd=WORKING_REPO_DIR,
+        )
+
+        repo = Repository(WORKING_REPO_DIR)
+
+        large_file = [100] * int(4e6)
+        with open(os.path.join(WORKING_REPO_DIR, "[].txt"), "w") as f:
+            f.write(json.dumps(large_file))
+
+        repo.git_add()
+
+        repo.lfs_track(["[].txt"])
+        self.assertFalse(is_tracked_with_lfs(f"{WORKING_REPO_DIR}/[].txt"))
+
+        repo.lfs_track(["[].txt"], filename=True)
+        self.assertTrue(is_tracked_with_lfs(f"{WORKING_REPO_DIR}/[].txt"))
+
     def test_init_clone_in_nonempty_folder(self):
         # Create dummy files
         # one is lfs-tracked, the other is not.


### PR DESCRIPTION
Adds the `filename` parameter which can be used to set all the `patterns` passed to `lfs_track` as filenames rather than globs.

Closes https://github.com/huggingface/huggingface_hub/issues/168