### PR TITLE
Repository fixes

### DIFF
--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -654,7 +654,7 @@ class Repository:
         try:
             yield self
         finally:
-            self.git_add(auto_lfs_track=True)
+            self.git_add(auto_lfs_track=track_large_files)
 
             try:
                 self.git_commit(commit_message)

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -223,39 +223,42 @@ class Repository:
         token = use_auth_token if use_auth_token is not None else self.huggingface_token
         api = HfApi()
 
-        repo_type, namespace, repo_id = repo_type_and_id_from_hf_id(repo_url)
+        if "huggingface.co" in repo_url or (
+            "http" not in repo_url and len(repo_url.split("/")) <= 2
+        ):
+            repo_type, namespace, repo_id = repo_type_and_id_from_hf_id(repo_url)
 
-        if repo_type is not None:
-            self.repo_type = repo_type
+            if repo_type is not None:
+                self.repo_type = repo_type
 
-        repo_url = ENDPOINT + "/"
+            repo_url = ENDPOINT + "/"
 
-        if self.repo_type in REPO_TYPES_URL_PREFIXES:
-            repo_url += REPO_TYPES_URL_PREFIXES[self.repo_type]
+            if self.repo_type in REPO_TYPES_URL_PREFIXES:
+                repo_url += REPO_TYPES_URL_PREFIXES[self.repo_type]
 
-        if token is not None:
-            whoami_info = api.whoami(token)
-            user = whoami_info["name"]
-            valid_organisations = [org["name"] for org in whoami_info["orgs"]]
+            if token is not None:
+                whoami_info = api.whoami(token)
+                user = whoami_info["name"]
+                valid_organisations = [org["name"] for org in whoami_info["orgs"]]
 
-            if namespace is not None:
-                repo_url += f"{namespace}/"
-            repo_url += repo_id
+                if namespace is not None:
+                    repo_url += f"{namespace}/"
+                repo_url += repo_id
 
-            repo_url = repo_url.replace("https://", f"https://user:{token}@")
+                repo_url = repo_url.replace("https://", f"https://user:{token}@")
 
-            if namespace == user or namespace in valid_organisations:
-                api.create_repo(
-                    token,
-                    repo_id,
-                    repo_type=self.repo_type,
-                    organization=namespace,
-                    exist_ok=True,
-                )
-        else:
-            if namespace is not None:
-                repo_url += f"{namespace}/"
-            repo_url += repo_id
+                if namespace == user or namespace in valid_organisations:
+                    api.create_repo(
+                        token,
+                        repo_id,
+                        repo_type=self.repo_type,
+                        organization=namespace,
+                        exist_ok=True,
+                    )
+            else:
+                if namespace is not None:
+                    repo_url += f"{namespace}/"
+                repo_url += repo_id
 
         # For error messages, it's cleaner to show the repo url without the token.
         clean_repo_url = re.sub(r"https://.*@", "https://", repo_url)

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -361,7 +361,7 @@ class RepositoryTest(RepositoryCommonTest):
         # Should not error out
         Repository(
             f"{WORKING_REPO_DIR}/{REPO_NAME}",
-            clone_from=f"https://hf.co/hf-internal-testing/huggingface-hub-dummy-repository",
+            clone_from="https://hf.co/hf-internal-testing/huggingface-hub-dummy-repository",
         )
 
     @with_production_testing

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -357,6 +357,13 @@ class RepositoryTest(RepositoryCommonTest):
             git_email="ci@dummy.com",
         )
 
+    def test_clone_not_hf_url(self):
+        # Should not error out
+        Repository(
+            f"{WORKING_REPO_DIR}/{REPO_NAME}",
+            clone_from=f"https://hf.co/hf-internal-testing/huggingface-hub-dummy-repository",
+        )
+
     @with_production_testing
     def test_clone_repo_at_root(self):
         os.environ["GIT_LFS_SKIP_SMUDGE"] = "1"


### PR DESCRIPTION
Fixes two issues with the `Repository` class and adds tests:

- The context manager `commit`'s track_large_files was not taken into account in the `git_add`.
- The `repo_type_and_id_from_hf_id` introduction ended up making the `Repository` unable to clone a repository that wasn't hosted on the `huggingface.co` website. This fixes that and introduces a regression test.