### PR TITLE
Have large files enabled by default when using `Repository`

### DIFF
--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -181,6 +181,8 @@ class Repository:
         if git_user is not None or git_email is not None:
             self.git_config_username_and_email(git_user, git_email)
 
+        self.lfs_enable_largefiles()
+
     def check_git_versions(self):
         """
         print git and git-lfs versions, raises if they aren't installed.


### PR DESCRIPTION
Enable large files by default when using `Repository`

Closes https://github.com/huggingface/huggingface_hub/issues/217