### PR TITLE
Allow empty commits and implement them in `push_to_hub`

### DIFF
--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -280,7 +280,7 @@ class ModelHubMixin:
 
         # Commit and push!
         repo.git_add()
-        repo.git_commit(commit_message)
+        repo.git_commit(commit_message, allow_empty=True)
         return repo.git_push()
 
 

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -582,13 +582,19 @@ class Repository:
         except subprocess.CalledProcessError as exc:
             raise EnvironmentError(exc.stderr)
 
-    def git_commit(self, commit_message="commit files to HF hub"):
+    def git_commit(
+        self, commit_message: str = "commit files to HF hub", allow_empty: bool = False
+    ):
         """
         git commit
         """
         try:
+            command = ["git", "commit", "-m", commit_message]
+            if allow_empty:
+                command += ["--allow-empty"]
+
             subprocess.run(
-                ["git", "commit", "-m", commit_message],
+                command,
                 stderr=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 check=True,
@@ -629,7 +635,7 @@ class Repository:
             commit_message: commit message.
         """
         self.git_add()
-        self.git_commit(commit_message)
+        self.git_commit(commit_message, allow_empty=True)
         return self.git_push()
 
     @contextmanager

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -397,7 +397,7 @@ class RepositoryTest(RepositoryCommonTest):
         )
 
 
-class RepositoryAutoLFSTrackingTest(RepositoryCommonTest):
+class RepositoryOfflineTests(RepositoryCommonTest):
     @classmethod
     def setUpClass(cls) -> None:
         if os.path.exists(WORKING_REPO_DIR):
@@ -439,6 +439,22 @@ class RepositoryAutoLFSTrackingTest(RepositoryCommonTest):
     @classmethod
     def tearDownClass(cls) -> None:
         shutil.rmtree(WORKING_REPO_DIR, onerror=set_write_permission_and_retry)
+
+    def test_empty_commit(self):
+        repo = Repository(WORKING_REPO_DIR)
+
+        # This content is under 10MB
+        small_file = [100]
+
+        with open(f"{WORKING_REPO_DIR}/small_file.txt", "w+") as f:
+            f.write(json.dumps(small_file))
+
+        repo.git_add("small_file.txt")
+        repo.git_commit("New commit")
+
+        self.assertRaises(OSError, repo.git_commit, "Second commit")
+
+        repo.git_commit("Third commit", allow_empty=True)
 
     def test_is_tracked_with_lfs(self):
         repo = Repository(WORKING_REPO_DIR)


### PR DESCRIPTION
Allow empty commits that `push_to_hub` methods may leverage.

Closes https://github.com/huggingface/transformers/issues/12839