### PR TITLE
Remove trailing new line character from token

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -732,7 +732,7 @@ class HfFolder:
         """
         try:
             with open(cls.path_token, "r") as f:
-                return f.read()
+                return f.read().strip()
         except FileNotFoundError:
             pass
 


### PR DESCRIPTION
Python `f.read()` returns string with a trailing new line character:
```
"my-token-read-from-file\n"
```

This PR removes trailing new line character:
```python
"my-token-read-from-file"
```