### PR TITLE
Add validation for text to image in Inference API

### DIFF
--- a/api-inference-community/api_inference_community/validation.py
+++ b/api-inference-community/api_inference_community/validation.py
@@ -103,10 +103,6 @@ class SummarizationParamsCheck(SharedGenerationParams):
     num_return_sequences: Optional[NumReturnSequences] = None
 
 
-class TextToImageParamsCheck(BaseModel):
-    num_return_images: Optional[NumReturnSequences] = None
-
-
 class ConversationalInputsCheck(BaseModel):
     text: str
     past_user_inputs: List[str]
@@ -170,7 +166,6 @@ PARAMS_MAPPING = {
     "fill-mask": FillMaskParamsCheck,
     "text2text-generation": TextGenerationParamsCheck,
     "text-generation": TextGenerationParamsCheck,
-    "text-to-image": TextToImageParamsCheck,
     "summarization": SummarizationParamsCheck,
     "zero-shot-classification": ZeroShotParamsCheck,
 }

--- a/api-inference-community/api_inference_community/validation.py
+++ b/api-inference-community/api_inference_community/validation.py
@@ -103,6 +103,10 @@ class SummarizationParamsCheck(SharedGenerationParams):
     num_return_sequences: Optional[NumReturnSequences] = None
 
 
+class TextToImageParamsCheck(BaseModel):
+    num_return_images: Optional[NumReturnSequences] = None
+
+
 class ConversationalInputsCheck(BaseModel):
     text: str
     past_user_inputs: List[str]
@@ -166,6 +170,7 @@ PARAMS_MAPPING = {
     "fill-mask": FillMaskParamsCheck,
     "text2text-generation": TextGenerationParamsCheck,
     "text-generation": TextGenerationParamsCheck,
+    "text-to-image": TextToImageParamsCheck,
     "summarization": SummarizationParamsCheck,
     "zero-shot-classification": ZeroShotParamsCheck,
 }
@@ -186,6 +191,7 @@ INPUTS_MAPPING = {
     "translation": StringInput,
     "zero-shot-classification": StringInput,
     "text-to-speech": StringInput,
+    "text-to-image": StringInput,
 }
 
 BATCH_ENABLED_PIPELINES = ["feature-extraction"]

--- a/api-inference-community/tests/test_nlp.py
+++ b/api-inference-community/tests/test_nlp.py
@@ -490,40 +490,6 @@ class FeatureExtractionTestCase(TestCase):
             normalize_payload_nlp(bpayload, "feature-extraction")
 
 
-class TextToImageTestCase(TestCase):
-    def test_valid_string(self):
-        bpayload = json.dumps({"inputs": "whatever"}).encode("utf-8")
-        normalized_inputs, processed_params = normalize_payload_nlp(
-            bpayload, "text-to-image"
-        )
-        self.assertEqual(processed_params, {})
-        self.assertEqual(normalized_inputs, "whatever")
-
-    def test_invalid_input(self):
-        bpayload = json.dumps({"inputs": [1, 2]}).encode("utf-8")
-        with self.assertRaises(ValidationError):
-            normalize_payload_nlp(bpayload, "text-to-image")
-
-    def test_with_valid_number_of_images(self):
-        params = {"num_return_images": 2}
-        bpayload = json.dumps({"inputs": "whatever", "parameters": params}).encode(
-            "utf-8"
-        )
-        normalized_inputs, processed_params = normalize_payload_nlp(
-            bpayload, "text-to-image"
-        )
-        self.assertEqual(processed_params, params)
-        self.assertEqual(normalized_inputs, "whatever")
-
-    def test_with_invalid_number_of_images(self):
-        params = {"num_return_images": 100}
-        bpayload = json.dumps({"inputs": "whatever", "parameters": params}).encode(
-            "utf-8"
-        )
-        with self.assertRaises(ValidationError):
-            normalize_payload_nlp(bpayload, "text-to-image")
-
-
 class TasksWithOnlyInputStringTestCase(TestCase):
     def test_fill_mask_accept_string_no_params(self):
         bpayload = json.dumps({"inputs": "whatever"}).encode("utf-8")
@@ -553,6 +519,14 @@ class TasksWithOnlyInputStringTestCase(TestCase):
         bpayload = json.dumps({"inputs": "whatever"}).encode("utf-8")
         normalized_inputs, processed_params = normalize_payload_nlp(
             bpayload, "translation"
+        )
+        self.assertEqual(processed_params, {})
+        self.assertEqual(normalized_inputs, "whatever")
+
+    def test_text_to_image_accept_string_no_params(self):
+        bpayload = json.dumps({"inputs": "whatever"}).encode("utf-8")
+        normalized_inputs, processed_params = normalize_payload_nlp(
+            bpayload, "text-to-image"
         )
         self.assertEqual(processed_params, {})
         self.assertEqual(normalized_inputs, "whatever")

--- a/api-inference-community/tests/test_nlp.py
+++ b/api-inference-community/tests/test_nlp.py
@@ -490,6 +490,40 @@ class FeatureExtractionTestCase(TestCase):
             normalize_payload_nlp(bpayload, "feature-extraction")
 
 
+class TextToImageTestCase(TestCase):
+    def test_valid_string(self):
+        bpayload = json.dumps({"inputs": "whatever"}).encode("utf-8")
+        normalized_inputs, processed_params = normalize_payload_nlp(
+            bpayload, "text-to-image"
+        )
+        self.assertEqual(processed_params, {})
+        self.assertEqual(normalized_inputs, "whatever")
+
+    def test_invalid_input(self):
+        bpayload = json.dumps({"inputs": [1, 2]}).encode("utf-8")
+        with self.assertRaises(ValidationError):
+            normalize_payload_nlp(bpayload, "text-to-image")
+
+    def test_with_valid_number_of_images(self):
+        params = {"num_return_images": 2}
+        bpayload = json.dumps({"inputs": "whatever", "parameters": params}).encode(
+            "utf-8"
+        )
+        normalized_inputs, processed_params = normalize_payload_nlp(
+            bpayload, "text-to-image"
+        )
+        self.assertEqual(processed_params, params)
+        self.assertEqual(normalized_inputs, "whatever")
+
+    def test_with_invalid_number_of_images(self):
+        params = {"num_return_images": 100}
+        bpayload = json.dumps({"inputs": "whatever", "parameters": params}).encode(
+            "utf-8"
+        )
+        with self.assertRaises(ValidationError):
+            normalize_payload_nlp(bpayload, "text-to-image")
+
+
 class TasksWithOnlyInputStringTestCase(TestCase):
     def test_fill_mask_accept_string_no_params(self):
         bpayload = json.dumps({"inputs": "whatever"}).encode("utf-8")


### PR DESCRIPTION
This is based on https://github.com/huggingface/huggingface_hub/issues/113 and https://github.com/huggingface/huggingface_hub/pull/131. The API contract allows defining how many images will be returned, which can go from 1 to 10. Let me know if you think we should not allow generating multiple images in a single go, but this resembles well the text to text Inference API.

FYI @mishig25