### PR TITLE
Add text to image pipeline to generic inference

### DIFF
--- a/api-inference-community/docker_images/common/app/pipelines/text_to_image.py
+++ b/api-inference-community/docker_images/common/app/pipelines/text_to_image.py
@@ -1,5 +1,9 @@
+from typing import TYPE_CHECKING
+
 from app.pipelines import Pipeline
 
+if TYPE_CHECKING:
+    from PIL import Image
 
 class TextToImagePipeline(Pipeline):
     def __init__(self, model_id: str):
@@ -11,13 +15,13 @@ class TextToImagePipeline(Pipeline):
             "Please implement TextToImagePipeline.__init__ function"
         )
 
-    def __call__(self, inputs: str) -> str:
+    def __call__(self, inputs: str) -> "Image.Image":
         """
         Args:
             inputs (:obj:`str`):
                 a string containing some text
         Return:
-            A :obj:`str`. A base64 string representing the image.
+            A :obj:`PIL.Image` with the raw image representation as PIL.
         """
         # IMPLEMENT_THIS
         raise NotImplementedError(

--- a/api-inference-community/docker_images/common/app/pipelines/text_to_image.py
+++ b/api-inference-community/docker_images/common/app/pipelines/text_to_image.py
@@ -1,0 +1,25 @@
+from app.pipelines import Pipeline
+
+
+class TextToImagePipeline(Pipeline):
+    def __init__(self, model_id: str):
+        # IMPLEMENT_THIS
+        # Preload all the elements you are going to need at inference.
+        # For instance your model, processors, tokenizer that might be needed.
+        # This function is only called once, so do all the heavy processing I/O here
+        raise NotImplementedError(
+            "Please implement TextToImagePipeline __init__ function"
+        )
+
+    def __call__(self, inputs: str) -> str:
+        """
+        Args:
+            inputs (:obj:`str`):
+                a string containing some text
+        Return:
+            A :obj:`str`. A base64 string representing the image.
+        """
+        # IMPLEMENT_THIS
+        raise NotImplementedError(
+            "Please implement TextToImagePipeline __call__ function"
+        )

--- a/api-inference-community/docker_images/common/tests/test_api_text_to_image.py
+++ b/api-inference-community/docker_images/common/tests/test_api_text_to_image.py
@@ -15,11 +15,11 @@ from tests.test_api import TESTABLE_MODELS
 )
 class TextToImageTestCase(TestCase):
     def setUp(self):
-        model_id = TESTABLE_MODELS["text-to-speech"]
+        model_id = TESTABLE_MODELS["text-to-image"]
         self.old_model_id = os.getenv("MODEL_ID")
         self.old_task = os.getenv("TASK")
         os.environ["MODEL_ID"] = model_id
-        os.environ["TASK"] = "text-to-speech"
+        os.environ["TASK"] = "text-to-image"
         from app.main import app
 
         self.app = app

--- a/api-inference-community/docker_images/common/tests/test_api_text_to_image.py
+++ b/api-inference-community/docker_images/common/tests/test_api_text_to_image.py
@@ -1,30 +1,26 @@
-import json
+import base64
 import os
+from io import BytesIO
 from unittest import TestCase, skipIf
 
+import PIL
 from app.main import ALLOWED_TASKS
-from parameterized import parameterized_class
 from starlette.testclient import TestClient
 from tests.test_api import TESTABLE_MODELS
 
 
 @skipIf(
-    "token-classification" not in ALLOWED_TASKS,
-    "token-classification not implemented",
+    "text-to-image" not in ALLOWED_TASKS,
+    "text-to-image not implemented",
 )
-@parameterized_class(
-    [{"model_id": model_id} for model_id in TESTABLE_MODELS["token-classification"]]
-)
-class TokenClassificationTestCase(TestCase):
+class TextToImageTestCase(TestCase):
     def setUp(self):
+        model_id = TESTABLE_MODELS["text-to-speech"]
         self.old_model_id = os.getenv("MODEL_ID")
         self.old_task = os.getenv("TASK")
-        os.environ["MODEL_ID"] = self.model_id
-        os.environ["TASK"] = "token-classification"
-
-        from app.main import app, get_pipeline
-
-        get_pipeline.cache_clear()
+        os.environ["MODEL_ID"] = model_id
+        os.environ["TASK"] = "text-to-speech"
+        from app.main import app
 
         self.app = app
 
@@ -45,42 +41,22 @@ class TokenClassificationTestCase(TestCase):
             del os.environ["TASK"]
 
     def test_simple(self):
-        inputs = "Hello, my name is John and I live in New York"
+        inputs = "soap bubble"
 
         with TestClient(self.app) as client:
             response = client.post("/", json={"inputs": inputs})
 
-        print(response.to_json())
         self.assertEqual(
             response.status_code,
             200,
         )
-        content = json.loads(response.content)
-        self.assertEqual(type(content), list)
-        self.assertEqual(
-            set(k for el in content for k in el.keys()),
-            {"entity_group", "word", "start", "end", "score"},
-        )
+        image = PIL.Image.open(BytesIO(base64.b64decode(response.text)))
+        self.assertTrue(isinstance(image, PIL.Image.Image))
 
-        with TestClient(self.app) as client:
-            response = client.post("/", json=inputs)
-
-        self.assertEqual(
-            response.status_code,
-            200,
-        )
-        content = json.loads(response.content)
-        self.assertEqual(type(content), list)
-        self.assertEqual(
-            set(k for el in content for k in el.keys()),
-            {"entity_group", "word", "start", "end", "score"},
-        )
-
-    def test_malformed_question(self):
+    def test_malformed_input(self):
         with TestClient(self.app) as client:
             response = client.post("/", data=b"\xc3\x28")
 
-        print(response.to_json())
         self.assertEqual(
             response.status_code,
             400,

--- a/api-inference-community/docker_images/common/tests/test_api_text_to_image.py
+++ b/api-inference-community/docker_images/common/tests/test_api_text_to_image.py
@@ -50,7 +50,8 @@ class TextToImageTestCase(TestCase):
             response.status_code,
             200,
         )
-        image = PIL.Image.open(BytesIO(base64.b64decode(response.text)))
+
+        image = PIL.Image.open(BytesIO(response.content))
         self.assertTrue(isinstance(image, PIL.Image.Image))
 
     def test_malformed_input(self):

--- a/api-inference-community/docker_images/generic/app/main.py
+++ b/api-inference-community/docker_images/generic/app/main.py
@@ -4,7 +4,7 @@ import os
 from typing import Dict, Type
 
 from api_inference_community.routes import pipeline_route, status_ok
-from app.pipelines import Pipeline, TokenClassificationPipeline
+from app.pipelines import Pipeline, TextToImagePipeline, TokenClassificationPipeline
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.middleware.gzip import GZipMiddleware
@@ -33,7 +33,8 @@ logger = logging.getLogger(__name__)
 # You can check the requirements and expectations of each pipelines in their respective
 # directories. Implement directly within the directories.
 ALLOWED_TASKS: Dict[str, Type[Pipeline]] = {
-    "token-classification": TokenClassificationPipeline
+    "token-classification": TokenClassificationPipeline,
+    "text-to-image": TextToImagePipeline,
 }
 
 

--- a/api-inference-community/docker_images/generic/app/pipelines/__init__.py
+++ b/api-inference-community/docker_images/generic/app/pipelines/__init__.py
@@ -12,5 +12,6 @@ from app.pipelines.speech_segmentation import SpeechSegmentationPipeline
 from app.pipelines.structured_data_classification import (
     StructuredDataClassificationPipeline,
 )
+from app.pipelines.text_to_image import TextToImagePipeline
 from app.pipelines.text_to_speech import TextToSpeechPipeline
 from app.pipelines.token_classification import TokenClassificationPipeline

--- a/api-inference-community/docker_images/generic/app/pipelines/text_to_image.py
+++ b/api-inference-community/docker_images/generic/app/pipelines/text_to_image.py
@@ -1,16 +1,20 @@
+from typing import TYPE_CHECKING
+
 from app.pipelines import Pipeline
 
+if TYPE_CHECKING:
+    from PIL import Image
 
 class TextToImagePipeline(Pipeline):
     def __init__(self, model_id: str):
         super().__init__(model_id)
 
-    def __call__(self, inputs: str) -> str:
+    def __call__(self, inputs: str) -> "Image.Image":
         """
         Args:
             inputs (:obj:`str`):
                 a string containing some text
         Return:
-            A :obj:`str`. A base64 string representing the image.
+            A :obj:`PIL.Image` with the raw image representation as PIL.
         """
         return super().__call__(inputs)

--- a/api-inference-community/docker_images/generic/app/pipelines/text_to_image.py
+++ b/api-inference-community/docker_images/generic/app/pipelines/text_to_image.py
@@ -1,0 +1,16 @@
+from app.pipelines import Pipeline
+
+
+class TextToImagePipeline(Pipeline):
+    def __init__(self, model_id: str):
+        super().__init__(model_id)
+
+    def __call__(self, inputs: str) -> str:
+        """
+        Args:
+            inputs (:obj:`str`):
+                a string containing some text
+        Return:
+            A :obj:`str`. A base64 string representing the image.
+        """
+        return super().__call__(inputs)

--- a/api-inference-community/docker_images/generic/requirements.txt
+++ b/api-inference-community/docker_images/generic/requirements.txt
@@ -1,5 +1,5 @@
 starlette==0.14.2
-api-inference-community==0.0.13
+api-inference-community==0.0.17
 torch>=1.7.0
 scikit-learn>=0.23.2
 scipy>=1.5.4

--- a/api-inference-community/docker_images/generic/tests/test_api.py
+++ b/api-inference-community/docker_images/generic/tests/test_api.py
@@ -1,5 +1,5 @@
 import os
-from typing import Dict
+from typing import Dict, List
 from unittest import TestCase, skipIf
 
 from app.main import ALLOWED_TASKS, get_pipeline
@@ -8,7 +8,10 @@ from app.main import ALLOWED_TASKS, get_pipeline
 # Must contain at least one example of each implemented pipeline
 # Tests do not check the actual values of the model output, so small dummy
 # models are recommended for faster tests.
-TESTABLE_MODELS: Dict[str, str] = {"token-classification": "osanseviero/en_core_web_sm"}
+TESTABLE_MODELS: Dict[str, List[str]] = {
+    "text-to-image": ["osanseviero/BigGAN-deep-128"],
+    "token-classification": ["osanseviero/en_core_web_sm"],
+}
 
 
 ALL_TASKS = {

--- a/api-inference-community/docker_images/generic/tests/test_api_text_to_image.py
+++ b/api-inference-community/docker_images/generic/tests/test_api_text_to_image.py
@@ -57,7 +57,7 @@ class TextToImageTestCase(TestCase):
             200,
         )
 
-        image = PIL.Image.open(BytesIO(base64.b64decode(response.text)))
+        image = PIL.Image.open(BytesIO(response.content))
         self.assertTrue(isinstance(image, PIL.Image.Image))
 
     def test_malformed_input(self):

--- a/api-inference-community/docker_images/generic/tests/test_api_text_to_image.py
+++ b/api-inference-community/docker_images/generic/tests/test_api_text_to_image.py
@@ -56,6 +56,7 @@ class TextToImageTestCase(TestCase):
             response.status_code,
             200,
         )
+
         image = PIL.Image.open(BytesIO(base64.b64decode(response.text)))
         self.assertTrue(isinstance(image, PIL.Image.Image))
 

--- a/api-inference-community/docker_images/generic/tests/test_api_text_to_image.py
+++ b/api-inference-community/docker_images/generic/tests/test_api_text_to_image.py
@@ -1,7 +1,9 @@
-import json
+import base64
 import os
+from io import BytesIO
 from unittest import TestCase, skipIf
 
+import PIL
 from app.main import ALLOWED_TASKS
 from parameterized import parameterized_class
 from starlette.testclient import TestClient
@@ -9,18 +11,18 @@ from tests.test_api import TESTABLE_MODELS
 
 
 @skipIf(
-    "token-classification" not in ALLOWED_TASKS,
-    "token-classification not implemented",
+    "text-to-image" not in ALLOWED_TASKS,
+    "text-to-image not implemented",
 )
 @parameterized_class(
-    [{"model_id": model_id} for model_id in TESTABLE_MODELS["token-classification"]]
+    [{"model_id": model_id} for model_id in TESTABLE_MODELS["text-to-image"]]
 )
-class TokenClassificationTestCase(TestCase):
+class TextToImageTestCase(TestCase):
     def setUp(self):
         self.old_model_id = os.getenv("MODEL_ID")
         self.old_task = os.getenv("TASK")
         os.environ["MODEL_ID"] = self.model_id
-        os.environ["TASK"] = "token-classification"
+        os.environ["TASK"] = "text-to-image"
 
         from app.main import app, get_pipeline
 
@@ -45,42 +47,22 @@ class TokenClassificationTestCase(TestCase):
             del os.environ["TASK"]
 
     def test_simple(self):
-        inputs = "Hello, my name is John and I live in New York"
+        inputs = "soap bubble"
 
         with TestClient(self.app) as client:
             response = client.post("/", json={"inputs": inputs})
 
-        print(response.to_json())
         self.assertEqual(
             response.status_code,
             200,
         )
-        content = json.loads(response.content)
-        self.assertEqual(type(content), list)
-        self.assertEqual(
-            set(k for el in content for k in el.keys()),
-            {"entity_group", "word", "start", "end", "score"},
-        )
+        image = PIL.Image.open(BytesIO(base64.b64decode(response.text)))
+        self.assertTrue(isinstance(image, PIL.Image.Image))
 
-        with TestClient(self.app) as client:
-            response = client.post("/", json=inputs)
-
-        self.assertEqual(
-            response.status_code,
-            200,
-        )
-        content = json.loads(response.content)
-        self.assertEqual(type(content), list)
-        self.assertEqual(
-            set(k for el in content for k in el.keys()),
-            {"entity_group", "word", "start", "end", "score"},
-        )
-
-    def test_malformed_question(self):
+    def test_malformed_input(self):
         with TestClient(self.app) as client:
             response = client.post("/", data=b"\xc3\x28")
 
-        print(response.to_json())
         self.assertEqual(
             response.status_code,
             400,

--- a/api-inference-community/docker_images/generic/tests/test_api_token_classification.py
+++ b/api-inference-community/docker_images/generic/tests/test_api_token_classification.py
@@ -50,7 +50,6 @@ class TokenClassificationTestCase(TestCase):
         with TestClient(self.app) as client:
             response = client.post("/", json={"inputs": inputs})
 
-        print(response.to_json())
         self.assertEqual(
             response.status_code,
             200,
@@ -80,7 +79,6 @@ class TokenClassificationTestCase(TestCase):
         with TestClient(self.app) as client:
             response = client.post("/", data=b"\xc3\x28")
 
-        print(response.to_json())
         self.assertEqual(
             response.status_code,
             400,


### PR DESCRIPTION
Similar to #244, this PR adds support for `text-to-image` pipeline.

Here is an [example repo](https://huggingface.co/osanseviero/BigGAN-deep-128) that uses BigGAN-deep-128 (the return of pytorch-pretrained-BigGAN). As can be seen, users specify their own `requirements.txt` and `pipeline.py`. I struggled a bit with the output, but it's a base64 string of the image. This PR should unblock #131. 

Here is a corresponding repo template https://huggingface.co/templates/text-to-image