### PR TITLE
Add documentation to GitHub and the Hub docs about the Inference client wrapper

### DIFF
--- a/docs/hub/inference.md
+++ b/docs/hub/inference.md
@@ -34,11 +34,13 @@ You can head to the [Inference API dashboard](https://api-inference.huggingface.
 
 ## Is there programmatic access to the Inference API?
 
-Yes, you can do usual HTTP requests. For Python users, we also provide the `huggingface_hub` client [library](https://github.com/huggingface/huggingface_hub/tree/main/src/huggingface_hub) which has a wrapper to make calls to the Inference API.
+Yes, you can do usual HTTP requests with the language and tools of your choice. Take a look at the [Inference API documentation](https://api-inference.huggingface.co/docs/python/html/detailed_parameters.html) for more information on the requests. 
+
+For Python users, we also provide the `huggingface_hub` client [library](https://github.com/huggingface/huggingface_hub/tree/main/src/huggingface_hub) which has a wrapper to make calls to the Inference API.
 
 ```
 from huggingface_hub.inference_api import InferenceApi
 inference = InferenceApi("bert-base-uncased")
-inference(inputs="The goal of life is [MASK].")
+inference(inputs="The goal of life is [MASK].", token=API_TOKEN)
 >> [{'sequence': 'the goal of life is life.', 'score': 0.10933292657136917, 'token': 2166, 'token_str': 'life'}]
 ```

--- a/docs/hub/inference.md
+++ b/docs/hub/inference.md
@@ -31,3 +31,14 @@ If you are interested in accelerated inference and/or higher volumes of requests
 ## How can I see my usage?
 
 You can head to the [Inference API dashboard](https://api-inference.huggingface.co/dashboard/). Learn more about it in the [Inference API documentation](https://api-inference.huggingface.co/docs/python/html/usage.html#api-usage-dashboard). 
+
+## Is there programmatic access to the Inference API?
+
+Yes, you can do usual HTTP requests. For Python users, we also provide the `huggingface_hub` client [library](https://github.com/huggingface/huggingface_hub/tree/main/src/huggingface_hub) which has a wrapper to make calls to the Inference API.
+
+```
+from huggingface_hub.inference_api import InferenceApi
+inference = InferenceApi("bert-base-uncased")
+inference(inputs="The goal of life is [MASK].")
+>> [{'sequence': 'the goal of life is life.', 'score': 0.10933292657136917, 'token': 2166, 'token_str': 'life'}]
+```

--- a/src/huggingface_hub/README.md
+++ b/src/huggingface_hub/README.md
@@ -187,11 +187,16 @@ Examples using the `commit` context manager:
 
 `huggingface_hub` comes with a wrapper client to make calls to the Inference API! You can find some examples below, but we encourage you to visit the Inference API [documentation](https://api-inference.huggingface.co/docs/python/html/detailed_parameters.html) to review the specific parameters for the different tasks.
 
+When you instantiate the wrapper to the Inference API, you specify the model repository id. The pipeline (`text-classification`,  `text-to-speech`, etc) is automatically extracted from the [repository](https://huggingface.co/docs/hub/main#how-is-a-models-type-of-inference-api-and-widget-determined), but you can also override it as shown below.
+
+
+### Examples
+
 Here is a basic example of calling the Inference API for a `fill-mask` task using the `bert-base-uncased` model. The `fill-mask` task only expects a string (or list of strings) as input.
 
 ```
 from huggingface_hub.inference_api import InferenceApi
-inference = InferenceApi("bert-base-uncased")
+inference = InferenceApi("bert-base-uncased", token=API_TOKEN)
 inference(inputs="The goal of life is [MASK].")
 >> [{'sequence': 'the goal of life is life.', 'score': 0.10933292657136917, 'token': 2166, 'token_str': 'life'}]
 ```
@@ -199,7 +204,7 @@ inference(inputs="The goal of life is [MASK].")
 This is an example of a task (`question-answering`) which requires a dictionary as input thas has the `question` and `context` keys.
 
 ```
-inference = InferenceApi("deepset/roberta-base-squad2")
+inference = InferenceApi("deepset/roberta-base-squad2", token=API_TOKEN)
 inputs = {"question":"What's my name?", "context":"My name is Clara and I live in Berkeley."}
 inference(inputs)
 >> {'score': 0.9326569437980652, 'start': 11, 'end': 16, 'answer': 'Clara'}
@@ -208,7 +213,7 @@ inference(inputs)
 Some tasks might also require additional params in the request. Here is an example using a `zero-shot-classification` model.
 
 ```
-inference = InferenceApi("typeform/distilbert-base-uncased-mnli")
+inference = InferenceApi("typeform/distilbert-base-uncased-mnli", token=API_TOKEN)
 inputs = "Hi, I recently bought a device from your company but it is not working as advertised and I would like to get reimbursed!"
 params = {"candidate_labels":["refund", "legal", "faq"]}
 inference(inputs, params)
@@ -218,7 +223,7 @@ inference(inputs, params)
 Finally, there are some models that might support multiple tasks. For example, `sentence-transformers` models can do `sentence-similarity` and `feature-extraction`. You can override the configured task when initializing the API.
 
 ```
-inference = InferenceApi("bert-base-uncased", task="feature-extraction")
+inference = InferenceApi("bert-base-uncased", task="feature-extraction", token=API_TOKEN)
 ```
 
 ## Feedback (feature requests, bugs, etc.) is super welcome 💙💚💛💜♥️🧡

--- a/src/huggingface_hub/README.md
+++ b/src/huggingface_hub/README.md
@@ -183,4 +183,42 @@ Examples using the `commit` context manager:
 
 <br>
 
+## Using the Inference API wrapper
+
+`huggingface_hub` comes with a wrapper client to make calls to the Inference API! You can find some examples below, but we encourage you to visit the Inference API [documentation](https://api-inference.huggingface.co/docs/python/html/detailed_parameters.html) to review the specific parameters for the different tasks.
+
+Here is a basic example of calling the Inference API for a `fill-mask` task using the `bert-base-uncased` model. The `fill-mask` task only expects a string (or list of strings) as input.
+
+```
+from huggingface_hub.inference_api import InferenceApi
+inference = InferenceApi("bert-base-uncased")
+inference(inputs="The goal of life is [MASK].")
+>> [{'sequence': 'the goal of life is life.', 'score': 0.10933292657136917, 'token': 2166, 'token_str': 'life'}]
+```
+
+This is an example of a task (`question-answering`) which requires a dictionary as input thas has the `question` and `context` keys.
+
+```
+inference = InferenceApi("deepset/roberta-base-squad2")
+inputs = {"question":"What's my name?", "context":"My name is Clara and I live in Berkeley."}
+inference(inputs)
+>> {'score': 0.9326569437980652, 'start': 11, 'end': 16, 'answer': 'Clara'}
+```
+
+Some tasks might also require additional params in the request. Here is an example using a `zero-shot-classification` model.
+
+```
+inference = InferenceApi("typeform/distilbert-base-uncased-mnli")
+inputs = "Hi, I recently bought a device from your company but it is not working as advertised and I would like to get reimbursed!"
+params = {"candidate_labels":["refund", "legal", "faq"]}
+inference(inputs, params)
+>> {'sequence': 'Hi, I recently bought a device from your company but it is not working as advertised and I would like to get reimbursed!', 'labels': ['refund', 'faq', 'legal'], 'scores': [0.9378499388694763, 0.04914155602455139, 0.013008488342165947]}
+```
+
+Finally, there are some models that might support multiple tasks. For example, `sentence-transformers` models can do `sentence-similarity` and `feature-extraction`. You can override the configured task when initializing the API.
+
+```
+inference = InferenceApi("bert-base-uncased", task="feature-extraction")
+```
+
 ## Feedback (feature requests, bugs, etc.) is super welcome 💙💚💛💜♥️🧡

--- a/src/huggingface_hub/inference_api.py
+++ b/src/huggingface_hub/inference_api.py
@@ -49,25 +49,25 @@ class InferenceApi:
             >>> from huggingface_hub.inference_api import InferenceApi
 
             >>> # Mask-fill example
-            >>> api = InferenceApi("bert-base-uncased")
-            >>> api(inputs="The goal of life is [MASK].")
+            >>> inference = InferenceApi("bert-base-uncased")
+            >>> inference(inputs="The goal of life is [MASK].")
             >>> >> [{'sequence': 'the goal of life is life.', 'score': 0.10933292657136917, 'token': 2166, 'token_str': 'life'}]
 
             >>> # Question Answering example
-            >>> api = InferenceApi("deepset/roberta-base-squad2")
+            >>> inference = InferenceApi("deepset/roberta-base-squad2")
             >>> inputs = {"question":"What's my name?", "context":"My name is Clara and I live in Berkeley."}
-            >>> api(inputs)
+            >>> inference(inputs)
             >>> >> {'score': 0.9326569437980652, 'start': 11, 'end': 16, 'answer': 'Clara'}
 
             >>> # Zero-shot example
-            >>> api = InferenceApi("typeform/distilbert-base-uncased-mnli")
+            >>> inference = InferenceApi("typeform/distilbert-base-uncased-mnli")
             >>> inputs = "Hi, I recently bought a device from your company but it is not working as advertised and I would like to get reimbursed!"
             >>> params = {"candidate_labels":["refund", "legal", "faq"]}
-            >>> api(inputs, params)
+            >>> inference(inputs, params)
             >>> >> {'sequence': 'Hi, I recently bought a device from your company but it is not working as advertised and I would like to get reimbursed!', 'labels': ['refund', 'faq', 'legal'], 'scores': [0.9378499388694763, 0.04914155602455139, 0.013008488342165947]}
 
             >>> # Overriding configured task
-            >>> api = InferenceApi("bert-base-uncased", task="feature-extraction")
+            >>> inference = InferenceApi("bert-base-uncased", task="feature-extraction")
     """
 
     def __init__(


### PR DESCRIPTION
TODO: add documentation to https://api-inference.huggingface.co/docs/python/html/detailed_parameters.html (different repo)