### PR TITLE
Branch push to hub

### DIFF
--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -117,22 +117,21 @@ def is_tracked_upstream(folder: Union[str, Path]) -> bool:
     Check if the current checked-out branch is tracked upstream.
     """
     try:
-        p = subprocess.run(
-            ["git", "status", "-sb"],
+        command = "git rev-parse --symbolic-full-name --abbrev-ref @{u}"
+        subprocess.run(
+            command.split(),
             stderr=subprocess.PIPE,
             stdout=subprocess.PIPE,
             encoding="utf-8",
+            check=True,
             cwd=folder,
         )
-        status = p.stdout
+        return True
     except subprocess.CalledProcessError as exc:
-        raise OSError(exc.stderr)
+        if "HEAD" in exc.stderr:
+            raise OSError("No branch checked out")
 
-    if "HEAD" in status:
-        raise OSError("No branch checked out.")
-
-    is_tracked = ".." in status
-    return is_tracked
+        return False
 
 
 @contextmanager

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -179,7 +179,7 @@ def lfs_log_progress():
         while not os.path.exists(os.environ["GIT_LFS_PROGRESS"]):
             if stopping_event.is_set():
                 close_pbars()
-                break
+                return
 
             time.sleep(2)
 
@@ -773,7 +773,7 @@ class Repository:
         try:
             with lfs_log_progress():
                 subprocess.run(
-                    "git push".split(),
+                    command.split(),
                     stderr=subprocess.PIPE,
                     stdout=subprocess.PIPE,
                     check=True,

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -272,7 +272,7 @@ class Repository:
                 will override the ``git config user.email`` for committing and pushing files to the hub.
             revision (``str``, `optional`):
                 Revision to checkout after initializing the repository. If the revision doesn't exist, a
-                branch will be created with that revision name.
+                branch will be created with that revision name from the default branch's current HEAD.
         """
 
         os.makedirs(local_dir, exist_ok=True)
@@ -308,7 +308,7 @@ class Repository:
         self.lfs_enable_largefiles()
 
         if revision is not None:
-            self.git_checkout(revision)
+            self.git_checkout(revision, create_branch_ok=True)
 
     @property
     def current_branch(self):

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -313,11 +313,7 @@ class Repository:
     @property
     def current_branch(self):
         """
-        git checkout
-
-        Specify `create_branch` to `True` to create the branch if it doesn't exist.
-
-        Returns url to commit on remote repo.
+        Returns the current checked out branch.
         """
         command = "git rev-parse --abbrev-ref HEAD"
         try:
@@ -794,8 +790,6 @@ class Repository:
         git checkout a given revision
 
         Specifying `create_branch_ok` to `True` will create the branch to the given revision if that revision doesn't exist.
-
-        Returns url to commit on remote repo.
         """
         command = f"git checkout {revision}"
         try:

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -23,7 +23,11 @@ from io import BytesIO
 
 import requests
 from huggingface_hub.hf_api import HfApi
-from huggingface_hub.repository import Repository, is_tracked_with_lfs
+from huggingface_hub.repository import (
+    Repository,
+    is_tracked_upstream,
+    is_tracked_with_lfs,
+)
 
 from .testing_constants import ENDPOINT_STAGING, PASS, USER
 from .testing_utils import set_write_permission_and_retry, with_production_testing
@@ -403,8 +407,82 @@ class RepositoryTest(RepositoryCommonTest):
             clone_from="https://huggingface.co/bert-base-cased",
         )
 
+    def test_is_tracked_upstream(self):
+        repo = Repository(
+            REPO_NAME,
+            clone_from=f"{USER}/{REPO_NAME}",
+            use_auth_token=self._token,
+            git_user="ci",
+            git_email="ci@dummy.com",
+        )
 
-class RepositoryAutoLFSTrackingTest(RepositoryCommonTest):
+        self.assertTrue(is_tracked_upstream(repo.local_dir))
+
+    def test_push_errors_on_wrong_checkout(self):
+        repo = Repository(
+            REPO_NAME,
+            clone_from=f"{USER}/{REPO_NAME}",
+            use_auth_token=self._token,
+            git_user="ci",
+            git_email="ci@dummy.com",
+        )
+
+        head_commit_ref = subprocess.run(
+            "git show --oneline -s".split(),
+            stderr=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            check=True,
+            cwd=WORKING_REPO_DIR,
+        ).stdout.split()[0]
+
+        repo.git_checkout(head_commit_ref)
+
+        with self.assertRaises(OSError):
+            with repo.commit("New commit"):
+                with open("new_file", "w+") as f:
+                    f.write("Ok")
+
+    def test_commits_on_correct_branch(self):
+        repo = Repository(
+            REPO_NAME,
+            clone_from=f"{USER}/{REPO_NAME}",
+            use_auth_token=self._token,
+            git_user="ci",
+            git_email="ci@dummy.com",
+        )
+        branch = repo.current_branch
+        repo.git_checkout("new-branch", create_branch=True)
+        repo.git_checkout(branch)
+
+        with repo.commit("New commit"):
+            with open("file.txt", "w+") as f:
+                f.write("Ok")
+
+        repo.git_checkout("new-branch")
+
+        with repo.commit("New commit"):
+            with open("new_file.txt", "w+") as f:
+                f.write("Ok")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            clone = Repository(
+                tmp,
+                clone_from=f"{USER}/{REPO_NAME}",
+                use_auth_token=self._token,
+                git_user="ci",
+                git_email="ci@dummy.com",
+            )
+            files = os.listdir(clone.local_dir)
+            self.assertTrue("file.txt" in files)
+            self.assertFalse("new_file.txt" in files)
+
+            clone.git_checkout("new-branch")
+            files = os.listdir(clone.local_dir)
+            self.assertFalse("file.txt" in files)
+            self.assertTrue("new_file.txt" in files)
+
+
+class RepositoryOfflineTest(RepositoryCommonTest):
     @classmethod
     def setUpClass(cls) -> None:
         if os.path.exists(WORKING_REPO_DIR):
@@ -667,6 +745,42 @@ class RepositoryAutoLFSTrackingTest(RepositoryCommonTest):
         self.assertFalse(
             is_tracked_with_lfs(os.path.join(WORKING_REPO_DIR, "large_file.txt"))
         )
+
+    def test_checkout_non_existant_branch(self):
+        Repository(WORKING_REPO_DIR)
+        self.assertRaises(Repository.git_checkout, "new-branch")
+
+    def test_checkout_new_branch(self):
+        repo = Repository(WORKING_REPO_DIR)
+        repo.git_checkout("new-branch", create_branch=True)
+
+        self.assertEqual(repo.current_branch, "new-branch")
+
+    def test_checkout_existing_branch(self):
+        repo = Repository(WORKING_REPO_DIR)
+        repo.git_checkout("new-branch", create_branch=True)
+        repo.git_checkout("new-branch-2", create_branch=True)
+
+        self.assertRaises(repo.git_checkout, "new-branch", create_branch=True)
+
+    def test_is_not_tracked_upstream(self):
+        repo = Repository(WORKING_REPO_DIR)
+        repo.git_checkout("new-branch", create_branch=True)
+        self.assertFalse(is_tracked_upstream(repo.local_dir))
+
+    def test_no_branch_checked_out_raises(self):
+        repo = Repository(WORKING_REPO_DIR)
+
+        head_commit_ref = subprocess.run(
+            "git show --oneline -s".split(),
+            stderr=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            check=True,
+            cwd=WORKING_REPO_DIR,
+        ).stdout.split()[0]
+
+        repo.git_checkout(head_commit_ref)
+        self.assertRaises(is_tracked_upstream, repo.local_dir)
 
 
 class RepositoryDatasetTest(RepositoryCommonTest):


### PR DESCRIPTION
This PR offers the ability to manage revisions (and therefore branches) with the `Repository` class. The revision management is introduced at two levels:
- When initializing a repository, with the `revision` keyword argument. If the revision exists (it is a reference to a commit, a branch, or a tag), then this revision will be checked out. If the revision does not exist, a new branch will be created with the branching point set to the current default branch's head.
- Using the `git_checkout` method to manually check out a `revision`. It has a `create_branch_ok` argument that is meant to behave as the `exist_ok` argument of `os.makedir` -> it checks out the revision if it exists, otherwise it creates the branch. I found this to be the most compatible with the way repositories would be used in scripts.


