### PR TITLE
Git credentials

### DIFF
--- a/src/huggingface_hub/commands/user.py
+++ b/src/huggingface_hub/commands/user.py
@@ -117,7 +117,7 @@ def tabulate(rows: List[List[Union[str, int]]], headers: List[str]) -> str:
     return "\n".join(lines)
 
 
-def currently_setup_credential_helper():
+def currently_setup_credential_helper(directory=None):
     try:
         output = subprocess.run(
             "git config --list".split(),
@@ -125,6 +125,7 @@ def currently_setup_credential_helper():
             stdout=subprocess.PIPE,
             encoding="utf-8",
             check=True,
+            cwd=directory,
         ).stdout.split("\n")
 
         current_credential_helper = ""

--- a/src/huggingface_hub/commands/user.py
+++ b/src/huggingface_hub/commands/user.py
@@ -117,7 +117,7 @@ def tabulate(rows: List[List[Union[str, int]]], headers: List[str]) -> str:
     return "\n".join(lines)
 
 
-def currently_setup_credential_helper(directory=None):
+def currently_setup_credential_helpers(directory=None) -> List[str]:
     try:
         output = subprocess.run(
             "git config --list".split(),
@@ -128,14 +128,14 @@ def currently_setup_credential_helper(directory=None):
             cwd=directory,
         ).stdout.split("\n")
 
-        current_credential_helper = ""
+        current_credential_helpers = []
         for line in output:
             if "credential.helper" in line:
-                current_credential_helper = line.split("=")[-1]
+                current_credential_helpers.append(line.split("=")[-1])
     except subprocess.CalledProcessError as exc:
         raise EnvironmentError(exc.stderr)
 
-    return current_credential_helper
+    return current_credential_helpers
 
 
 class BaseUserCommand:
@@ -168,9 +168,9 @@ class LoginCommand(BaseUserCommand):
         HfFolder.save_token(token)
         print("Login successful")
         print("Your token has been saved to", HfFolder.path_token)
-        helper = currently_setup_credential_helper()
+        helpers = currently_setup_credential_helpers()
 
-        if helper != "store":
+        if "store" not in helpers:
             print(
                 ANSI.red(
                     "Authenticated through git-crendential store but this isn't the helper defined on your machine.\nYou "

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -226,20 +226,19 @@ class DatasetInfo:
 
 
 def write_to_credential_store(username: str, password: str):
-    process = subprocess.Popen(
+    with subprocess.Popen(
         "git credential-store store".split(),
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
-    )
+    ) as process:
+        input_username = f"username={username}"
+        input_password = f"password={password}"
 
-    input_username = f"username={username}"
-    input_password = f"password={password}"
-
-    process.stdin.write(
-        f"url={ENDPOINT}\n{input_username}\n{input_password}\n\n".encode("utf-8")
-    )
-    process.stdin.flush()
+        process.stdin.write(
+            f"url={ENDPOINT}\n{input_username}\n{input_password}\n\n".encode("utf-8")
+        )
+        process.stdin.flush()
 
 
 def read_from_credential_store(
@@ -249,23 +248,26 @@ def read_from_credential_store(
     Reads the credential store relative to huggingface.co. If no `username` is specified, will read the first
     entry for huggingface.co, otherwise will read the entry corresponding to the username specified.
     """
-    process = subprocess.Popen(
+    with subprocess.Popen(
         "git credential-store get".split(),
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
-    )
+    ) as process:
+        standard_input = f"url={ENDPOINT}\n"
 
-    standard_input = f"url={ENDPOINT}\n"
+        if username is not None:
+            standard_input += f"username={username}\n"
 
-    if username is not None:
-        standard_input += f"username={username}\n"
+        standard_input += "\n"
+        print(standard_input.encode("utf-8"))
 
-    standard_input += "\n"
-
-    process.stdin.write(standard_input.encode("utf-8"))
-    process.stdin.flush()
-    output = process.stdout.read().decode("utf-8")
+        process.stdin.write(standard_input.encode("utf-8"))
+        process.stdin.flush()
+        output = process.stdout.read()
+        print(output)
+        output = output.decode("utf-8")
+        print(output)
 
     if len(output) == 0:
         return None, None
@@ -279,22 +281,22 @@ def erase_from_credential_store(username=None):
     Erases the credential store relative to huggingface.co. If no `username` is specified, will erase the first
     entry for huggingface.co, otherwise will erase the entry corresponding to the username specified.
     """
-    process = subprocess.Popen(
+    with subprocess.Popen(
         "git credential-store erase".split(),
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
-    )
+    ) as process:
+        standard_input = f"url={ENDPOINT}\n"
 
-    standard_input = f"url={ENDPOINT}\n"
+        if username is not None:
+            standard_input += f"username={username}\n"
 
-    if username is not None:
-        standard_input += f"username={username}\n"
+        standard_input += "\n"
 
-    standard_input += "\n"
-
-    process.stdin.write(standard_input.encode("utf-8"))
-    process.stdin.flush()
+        process.stdin.write(standard_input.encode("utf-8"))
+        print(standard_input)
+        process.stdin.flush()
 
 
 class HfApi:

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -232,7 +232,7 @@ def write_to_credential_store(username: str, password: str):
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
     ) as process:
-        input_username = f"username={username}"
+        input_username = f"username={username.lower()}"
         input_password = f"password={password}"
 
         process.stdin.write(
@@ -247,6 +247,8 @@ def read_from_credential_store(
     """
     Reads the credential store relative to huggingface.co. If no `username` is specified, will read the first
     entry for huggingface.co, otherwise will read the entry corresponding to the username specified.
+
+    The username returned will be all lowercase.
     """
     with subprocess.Popen(
         "git credential-store get".split(),
@@ -257,17 +259,14 @@ def read_from_credential_store(
         standard_input = f"url={ENDPOINT}\n"
 
         if username is not None:
-            standard_input += f"username={username}\n"
+            standard_input += f"username={username.lower()}\n"
 
         standard_input += "\n"
-        print(standard_input.encode("utf-8"))
 
         process.stdin.write(standard_input.encode("utf-8"))
         process.stdin.flush()
         output = process.stdout.read()
-        print(output)
         output = output.decode("utf-8")
-        print(output)
 
     if len(output) == 0:
         return None, None
@@ -290,7 +289,7 @@ def erase_from_credential_store(username=None):
         standard_input = f"url={ENDPOINT}\n"
 
         if username is not None:
-            standard_input += f"username={username}\n"
+            standard_input += f"username={username.lower()}\n"
 
         standard_input += "\n"
 
@@ -316,8 +315,7 @@ class HfApi:
         r.raise_for_status()
         d = r.json()
 
-        cased_username = self.whoami(d["token"])["name"]
-        write_to_credential_store(cased_username, password)
+        write_to_credential_store(username, password)
         return d["token"]
 
     def whoami(self, token: str) -> Dict:

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -305,6 +305,7 @@ class Repository:
             self.git_config_username_and_email(git_user, git_email)
 
         self.lfs_enable_largefiles()
+        self.git_credential_helper_store()
 
         if revision is not None:
             self.git_checkout(revision, create_branch_ok=True)
@@ -498,6 +499,22 @@ class Repository:
                     encoding="utf-8",
                     cwd=self.local_dir,
                 )
+        except subprocess.CalledProcessError as exc:
+            raise EnvironmentError(exc.stderr)
+
+    def git_credential_helper_store(self):
+        """
+        sets the git credential helper to `store`
+        """
+        try:
+            subprocess.run(
+                ["git", "config", "credential.helper", "store"],
+                stderr=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                check=True,
+                encoding="utf-8",
+                cwd=self.local_dir,
+            )
         except subprocess.CalledProcessError as exc:
             raise EnvironmentError(exc.stderr)
 

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -300,7 +300,17 @@ class Repository:
                     "If not specifying `clone_from`, you need to pass Repository a valid git clone."
                 )
 
-        # overrides .git config if user and email is provided.
+        if self.huggingface_token is not None and (
+            git_email is None or git_user is None
+        ):
+            user = HfApi().whoami(self.huggingface_token)
+
+            if git_email is None:
+                git_email = user["email"]
+
+            if git_user is None:
+                git_user = user["fullname"]
+
         if git_user is not None or git_email is not None:
             self.git_config_username_and_email(git_user, git_email)
 

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -83,7 +83,7 @@ class HfApiLoginTest(HfApiCommonTest):
     def test_login_git_credentials(self):
         self.assertTupleEqual(read_from_credential_store(USER), (None, None))
         token = self._api.login(username=USER, password=PASS)
-        self.assertTupleEqual(read_from_credential_store(USER), (USER, PASS))
+        self.assertTupleEqual(read_from_credential_store(USER), (USER.lower(), PASS))
         self._api.logout(token)
         self.assertTupleEqual(read_from_credential_store(USER), (None, None))
 

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -72,6 +72,10 @@ class HfApiLoginTest(HfApiCommonTest):
     def setUp(self) -> None:
         erase_from_credential_store(USER)
 
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls._api.login(username=USER, password=PASS)
+
     def test_login_invalid(self):
         with self.assertRaises(HTTPError):
             self._api.login(username=USER, password="fake")
@@ -82,9 +86,9 @@ class HfApiLoginTest(HfApiCommonTest):
 
     def test_login_git_credentials(self):
         self.assertTupleEqual(read_from_credential_store(USER), (None, None))
-        token = self._api.login(username=USER, password=PASS)
+        self._api.login(username=USER, password=PASS)
         self.assertTupleEqual(read_from_credential_store(USER), (USER.lower(), PASS))
-        self._api.logout(token)
+        erase_from_credential_store(username=USER)
         self.assertTupleEqual(read_from_credential_store(USER), (None, None))
 
 

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -830,7 +830,7 @@ class RepositoryOfflineTest(RepositoryCommonTest):
             check=True,
             encoding="utf-8",
             cwd=repo.local_dir,
-        )
+        ).stdout.strip()
         email = subprocess.run(
             ["git", "config", "user.email"],
             stderr=subprocess.PIPE,
@@ -838,7 +838,7 @@ class RepositoryOfflineTest(RepositoryCommonTest):
             check=True,
             encoding="utf-8",
             cwd=repo.local_dir,
-        )
+        ).stdout.strip()
 
         self.assertEqual(username, user["fullname"])
         self.assertEqual(email, user["email"])
@@ -859,7 +859,7 @@ class RepositoryOfflineTest(RepositoryCommonTest):
             check=True,
             encoding="utf-8",
             cwd=repo.local_dir,
-        )
+        ).stdout.strip()
         email = subprocess.run(
             ["git", "config", "user.email"],
             stderr=subprocess.PIPE,
@@ -867,7 +867,7 @@ class RepositoryOfflineTest(RepositoryCommonTest):
             check=True,
             encoding="utf-8",
             cwd=repo.local_dir,
-        )
+        ).stdout.strip()
 
         self.assertEqual(username, "RANDOM_USER")
         self.assertEqual(email, "EMAIL@EMAIL.EMAIL")
@@ -882,7 +882,7 @@ class RepositoryOfflineTest(RepositoryCommonTest):
         )
         repo = Repository(WORKING_REPO_DIR)
         self.assertListEqual(
-            currently_setup_credential_helpers(repo.local_dir), ["store"]
+            currently_setup_credential_helpers(repo.local_dir), ["get", "store"]
         )
         self.assertEqual(currently_setup_credential_helpers(), ["get"])
 

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -22,7 +22,7 @@ import unittest
 from io import BytesIO
 
 import requests
-from huggingface_hub.commands.user import currently_setup_credential_helper
+from huggingface_hub.commands.user import currently_setup_credential_helpers
 from huggingface_hub.hf_api import HfApi
 from huggingface_hub.repository import (
     Repository,
@@ -881,8 +881,10 @@ class RepositoryOfflineTest(RepositoryCommonTest):
             encoding="utf-8",
         )
         repo = Repository(WORKING_REPO_DIR)
-        self.assertEqual(currently_setup_credential_helper(repo.local_dir), "store")
-        self.assertEqual(currently_setup_credential_helper(), "get")
+        self.assertListEqual(
+            currently_setup_credential_helpers(repo.local_dir), ["store"]
+        )
+        self.assertEqual(currently_setup_credential_helpers(), ["get"])
 
 
 class RepositoryDatasetTest(RepositoryCommonTest):


### PR DESCRIPTION
*Thoroughly tested in practice, will implement unit tests in a bit but the API will remain as it is so pinging you for review.*

Fixes https://github.com/huggingface/huggingface_hub/issues/211 and https://github.com/huggingface/moon-landing/issues/150

#### Problem

This PR offers a long-awaited overhaul of the login system through the `huggingface_hub` library. The way the login system is currently designed is complex and led to a lot of errors mid-training during the Jax/Flax community week - as well as a general misunderstanding of what was happening behind the scenes.

The core issue is that logging in through `huggingface_cli login` does *not* log the user through git. The user will have to reauthenticate when pushing. This is particularly an issue on Google Colab, where a simple `git push` is met by a fatal error:
```
fatal: could not read Username for 'https://huggingface.co': No such device or address
```
The workarounds are cumbersome (see [#12572](https://github.com/huggingface/transformers/issues/12572)).

#### Solving the issue

This PR offers to use the `git-credential` API to store the username and password in a way that git can leverage when authenticating the user on `huggingface.co`. It leverages the `git credential.helper store` helper, which stores the username/password under plain text in a file with the user's permission.

It does not set the global credential helper to `store` as this could disrupt the user's git configuration - it instead detects what is the current helper, and if it isn't `store`, mentions that users will need to reauthenticate. If users do not wish to reauthenticate, a command to be run (which will set the helper to `store`) is printed out.

Additionally, in order to improve the experience across platforms, this PR adjusts two configuration attributes which are linked to the above:
- Cloning a repository through `Repository(xxx, clone_from=yyy)` will set the helper of that repository to `store`. 
- Using the `Repository` without explicitly passing a `git_email` or a `git_user`, instead of leveraging the system's default, will leverage the token to be used by that `Repository`.
