### PR TITLE
Push to hub/commit with branches

### DIFF
--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -735,7 +735,7 @@ class Repository:
         """
         if auto_lfs_track:
             tracked_files = self.auto_track_large_files(pattern)
-            if len(tracked_files) > 0:
+            if tracked_files:
                 logger.warning(
                     f"Adding files tracked by Git LFS: {tracked_files}. This may take a bit of time if the files are large."
                 )

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -841,6 +841,8 @@ class Repository:
     def push_to_hub(self, commit_message: str = "commit files to HF hub") -> str:
         """
         Helper to add, commit, and push files to remote repository on the HuggingFace Hub.
+        Will automatically track large files (>10MB).
+
         Args:
             commit_message: commit message.
         """
@@ -858,6 +860,14 @@ class Repository:
         """
         Context manager utility to handle committing to a repository. This automatically tracks large files (>10Mb)
         with git-lfs. Set the `track_large_files` argument to `False` if you wish to ignore that behavior.
+
+        Args:
+            commit_message (`str`):
+                Message to use for the commit.
+            branch (`str`, `optional`):
+                The branch on which the commit will appear. This branch will be checked-out before any operation.
+            track_large_files (`bool`, `optional`, defaults to `True`):
+                Whether to automatically track large files or not. Will do so by default.
 
         Examples:
 

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -76,6 +76,11 @@ class RepositoryTest(RepositoryCommonTest):
 
     def tearDown(self):
         try:
+            self._api.delete_repo(token=self._token, name=f"{USER}/{REPO_NAME}")
+        except requests.exceptions.HTTPError:
+            pass
+
+        try:
             self._api.delete_repo(token=self._token, name=REPO_NAME)
         except requests.exceptions.HTTPError:
             pass

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -257,7 +257,7 @@ class RepositoryTest(RepositoryCommonTest):
 
     def test_clone_with_endpoint(self):
         clone = Repository(
-            REPO_NAME,
+            WORKING_REPO_DIR,
             clone_from=f"{ENDPOINT_STAGING}/valid_org/{REPO_NAME}",
             use_auth_token=self._token,
             git_user="ci",
@@ -286,7 +286,7 @@ class RepositoryTest(RepositoryCommonTest):
 
     def test_clone_with_repo_name_and_org(self):
         clone = Repository(
-            REPO_NAME,
+            WORKING_REPO_DIR,
             clone_from=f"valid_org/{REPO_NAME}",
             use_auth_token=self._token,
             git_user="ci",
@@ -315,7 +315,7 @@ class RepositoryTest(RepositoryCommonTest):
 
     def test_clone_with_repo_name_and_user_namespace(self):
         clone = Repository(
-            REPO_NAME,
+            WORKING_REPO_DIR,
             clone_from=f"{USER}/{REPO_NAME}",
             use_auth_token=self._token,
             git_user="ci",
@@ -425,7 +425,7 @@ class RepositoryTest(RepositoryCommonTest):
 
     def test_push_errors_on_wrong_checkout(self):
         repo = Repository(
-            REPO_NAME,
+            WORKING_REPO_DIR,
             clone_from=f"{USER}/{REPO_NAME}",
             use_auth_token=self._token,
             git_user="ci",
@@ -453,7 +453,7 @@ class RepositoryTest(RepositoryCommonTest):
 
     def test_commits_on_correct_branch(self):
         repo = Repository(
-            REPO_NAME,
+            WORKING_REPO_DIR,
             clone_from=f"{USER}/{REPO_NAME}",
             use_auth_token=self._token,
             git_user="ci",
@@ -492,7 +492,7 @@ class RepositoryTest(RepositoryCommonTest):
 
     def test_repo_checkout_push(self):
         repo = Repository(
-            REPO_NAME,
+            WORKING_REPO_DIR,
             clone_from=f"{USER}/{REPO_NAME}",
             use_auth_token=self._token,
             git_user="ci",
@@ -532,11 +532,12 @@ class RepositoryTest(RepositoryCommonTest):
 
     def test_repo_checkout_commit_context_manager(self):
         repo = Repository(
-            REPO_NAME,
+            WORKING_REPO_DIR,
             clone_from=f"{USER}/{REPO_NAME}",
             use_auth_token=self._token,
             git_user="ci",
             git_email="ci@dummy.com",
+            revision="main",
         )
 
         with repo.commit("Commit #1", branch="new-branch"):

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -257,7 +257,7 @@ class RepositoryTest(RepositoryCommonTest):
 
     def test_clone_with_endpoint(self):
         clone = Repository(
-            WORKING_REPO_DIR,
+            f"{WORKING_REPO_DIR}/{REPO_NAME}",
             clone_from=f"{ENDPOINT_STAGING}/valid_org/{REPO_NAME}",
             use_auth_token=self._token,
             git_user="ci",
@@ -270,7 +270,7 @@ class RepositoryTest(RepositoryCommonTest):
             with open("model.bin", "w") as f:
                 f.write("hello")
 
-        shutil.rmtree(REPO_NAME)
+        shutil.rmtree(f"{WORKING_REPO_DIR}/{REPO_NAME}")
 
         Repository(
             f"{WORKING_REPO_DIR}/{REPO_NAME}",
@@ -286,7 +286,7 @@ class RepositoryTest(RepositoryCommonTest):
 
     def test_clone_with_repo_name_and_org(self):
         clone = Repository(
-            WORKING_REPO_DIR,
+            f"{WORKING_REPO_DIR}/{REPO_NAME}",
             clone_from=f"valid_org/{REPO_NAME}",
             use_auth_token=self._token,
             git_user="ci",
@@ -299,7 +299,7 @@ class RepositoryTest(RepositoryCommonTest):
             with open("model.bin", "w") as f:
                 f.write("hello")
 
-        shutil.rmtree(REPO_NAME)
+        shutil.rmtree(f"{WORKING_REPO_DIR}/{REPO_NAME}")
 
         Repository(
             f"{WORKING_REPO_DIR}/{REPO_NAME}",
@@ -315,7 +315,7 @@ class RepositoryTest(RepositoryCommonTest):
 
     def test_clone_with_repo_name_and_user_namespace(self):
         clone = Repository(
-            WORKING_REPO_DIR,
+            f"{WORKING_REPO_DIR}/{REPO_NAME}",
             clone_from=f"{USER}/{REPO_NAME}",
             use_auth_token=self._token,
             git_user="ci",
@@ -330,7 +330,7 @@ class RepositoryTest(RepositoryCommonTest):
             with open("model.bin", "w") as f:
                 f.write("hello")
 
-        shutil.rmtree(REPO_NAME)
+        shutil.rmtree(f"{WORKING_REPO_DIR}/{REPO_NAME}")
 
         Repository(
             f"{WORKING_REPO_DIR}/{REPO_NAME}",


### PR DESCRIPTION
Completes the `revision`-based API by adding branches management to `push_to_hub` and the `commit` context manager.

### Examples of usage:

#### Using `revision` from `Repository.__init__`

```python
project_name = 'org/project'

# Checkout revision
hf_repo = Repository(project_name, clone_from=project_name, revision='test-1')

model = GPT2LMHeadModel.from_pretrained(project_name)
model.save_pretrained(project_name)

hf_repo.push_to_hub(commit_message=f'step {step}')
```

#### Using `git_checkout` from `Repository`

```python
project_name = 'org/project'

# Checkout revision
hf_repo = Repository(project_name, clone_from=project_name)
hf_repo.git_checkout("branch")

model = GPT2LMHeadModel.from_pretrained(project_name)
model.save_pretrained(project_name)

hf_repo.push_to_hub(commit_message=f'step {step}')
```

Note that the `push_to_hub` method interacts in a complex manner:
- The branch must first be checked out
- The files are saved
- Push to hub should be called

#### Using the `Repository.commit` context manager

Therefore, I would instead recommend using the `Repository.commit` context manager as I find it has a better API, as can be seen below. I think the two could eventually be merged into a single `with Repository.push_to_hub`. See details of the API with usage below:

```python
repo = Repository("local_directory", clone_from="Jikiwa/with-commit-1")

with repo.commit("Add files"):
    with open("file.txt", "w+") as f:
        f.write("Nice")

with repo.commit("Add files to brand-new-branch", branch="brand-new-branch"):
    with open("brand-new-file.txt", "w+") as f:
        f.write("Nice Nice")

repo.git_checkout("nice-branch", create_branch_ok=True)

# Will use lastly checked-out branch
with repo.commit("Add files in nice-branch"):
    with open("file.txt", "w+") as f:
        f.write("Nice")
```

A caveat with `git_checkout` is that it may result in a fatal error if some files are added/modified as the changes would be overridden by the checkout.