### PR TITLE
Widget text to image

### DIFF
--- a/widgets/src/lib/InferenceWidget/InferenceWidget.svelte
+++ b/widgets/src/lib/InferenceWidget/InferenceWidget.svelte
@@ -14,6 +14,7 @@
 	import SummarizationWidget from "./widgets/SummarizationWidget/SummarizationWidget.svelte";
 	import TableQuestionAnsweringWidget from "./widgets/TableQuestionAnsweringWidget/TableQuestionAnsweringWidget.svelte";
 	import TextGenerationWidget from "./widgets/TextGenerationWidget/TextGenerationWidget.svelte";
+	import TextToImageWidget from "./widgets/TextToImageWidget/TextToImageWidget.svelte";
 	import TextToSpeechWidget from "./widgets/TextToSpeechWidget/TextToSpeechWidget.svelte";
 	import TokenClassificationWidget from "./widgets/TokenClassificationWidget/TokenClassificationWidget.svelte";
 	import StructuredDataClassificationWidget from "./widgets/StructuredDataClassificationWidget/StructuredDataClassificationWidget.svelte";
@@ -48,6 +49,7 @@
 		"text-classification": FillMaskWidget,
 		"text-generation": TextGenerationWidget,
 		"token-classification": TokenClassificationWidget,
+		"text-to-image": TextToImageWidget,
 		"text-to-speech": TextToSpeechWidget,
 		translation: TextGenerationWidget,
 		"structured-data-classification": StructuredDataClassificationWidget,

--- a/widgets/src/lib/InferenceWidget/widgets/TextToImageWidget/TextToImageWidget.svelte
+++ b/widgets/src/lib/InferenceWidget/widgets/TextToImageWidget/TextToImageWidget.svelte
@@ -88,14 +88,17 @@
 			};
 			getOutput(true);
 		} else if (res.status === "error") {
-			error = res.error;
+			error = res.error || `Error encountered on input "${trimmedText}"`;
 		}
 	}
 
 	function parseOutput(body: unknown): string {
-		return body && typeof body === "object" && body instanceof Blob
-			? URL.createObjectURL(body)
-			: "";
+		if (body && typeof body === "object" && body instanceof Blob) {
+			return URL.createObjectURL(body);
+		}
+		throw new TypeError(
+			"Invalid output: output must be of type object & of instance Blob"
+		);
 	}
 </script>
 

--- a/widgets/src/lib/InferenceWidget/widgets/TextToImageWidget/TextToImageWidget.svelte
+++ b/widgets/src/lib/InferenceWidget/widgets/TextToImageWidget/TextToImageWidget.svelte
@@ -1,0 +1,125 @@
+<script>
+	import type { WidgetProps } from "../../shared/types";
+
+	import { onMount } from "svelte";
+	import WidgetQuickInput from "../../shared/WidgetQuickInput/WidgetQuickInput.svelte";
+	import WidgetWrapper from "../../shared/WidgetWrapper/WidgetWrapper.svelte";
+	import {
+		getDemoInputs,
+		getResponse,
+		getSearchParams,
+		updateUrl,
+	} from "../../shared/helpers";
+
+	export let apiToken: WidgetProps["apiToken"];
+	export let apiUrl: WidgetProps["apiUrl"];
+	export let callApiOnMount: WidgetProps["callApiOnMount"];
+	export let model: WidgetProps["model"];
+	export let noTitle: WidgetProps["noTitle"];
+	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
+
+	let computeTime = "";
+	let error: string = "";
+	let isLoading = false;
+	let modelLoading = {
+		isLoading: false,
+		estimatedTime: 0,
+	};
+	let output = "";
+	let outputJson = "";
+	let text = "";
+
+	onMount(() => {
+		const [textParam] = getSearchParams(["text"]);
+		if (textParam) {
+			text = textParam;
+			getOutput();
+		} else {
+			const [demoText] = getDemoInputs(model, ["text"]);
+			text = (demoText as string) ?? "";
+			if (text && callApiOnMount) {
+				getOutput();
+			}
+		}
+	});
+
+	async function getOutput(withModelLoading = false) {
+		const trimmedText = text.trim();
+
+		if (!trimmedText) {
+			error = "You need to input some text";
+			output = "";
+			return;
+		}
+
+		if (shouldUpdateUrl) {
+			updateUrl({ text: trimmedText });
+		}
+
+		const requestBody = { inputs: trimmedText };
+
+		isLoading = true;
+
+		const res = await getResponse(
+			apiUrl,
+			model.modelId,
+			requestBody,
+			apiToken,
+			parseOutput,
+			withModelLoading
+		);
+
+		isLoading = false;
+		// Reset values
+		computeTime = "";
+		error = "";
+		modelLoading = { isLoading: false, estimatedTime: 0 };
+		output = "";
+		outputJson = "";
+
+		if (res.status === "success") {
+			computeTime = res.computeTime;
+			output = res.output;
+			outputJson = res.outputJson;
+		} else if (res.status === "loading-model") {
+			modelLoading = {
+				isLoading: true,
+				estimatedTime: res.estimatedTime,
+			};
+			getOutput(true);
+		} else if (res.status === "error") {
+			error = res.error;
+		}
+	}
+
+	function parseOutput(body: unknown): string {
+		return body && typeof body === "object" && body instanceof Blob
+			? URL.createObjectURL(body)
+			: "";
+	}
+</script>
+
+<WidgetWrapper
+	{apiUrl}
+	{computeTime}
+	{error}
+	{model}
+	{modelLoading}
+	{noTitle}
+	{outputJson}
+>
+	<svelte:fragment slot="top">
+		<form>
+			<WidgetQuickInput
+				bind:value={text}
+				{isLoading}
+				onClickSubmitBtn={() => getOutput()}
+			/>
+		</form>
+	</svelte:fragment>
+	<svelte:fragment slot="bottom">
+		{#if output.length}
+			<img class="mt-4 object-contain" src={output} alt="" />
+		{/if}
+	</svelte:fragment>
+</WidgetWrapper>

--- a/widgets/src/routes/index.svelte
+++ b/widgets/src/routes/index.svelte
@@ -137,6 +137,10 @@
 			widgetData: [{ text: "Hey my name is Julien! How are you?" }],
 		},
 		{
+			modelId: "osanseviero/BigGAN-deep-128",
+			pipeline_tag: "text-to-image",
+		},
+		{
 			modelId: "julien-c/kan-bayashi_csmsc_tacotron2",
 			pipeline_tag: "text-to-speech",
 			widgetData: [{ text: "请您说得慢些好吗" }],


### PR DESCRIPTION
Closes #131 read #131 for more details.
Creating a new PR here since #131 is trying to merge a branch from my fork into `hugginface_hub`, which is not supported by Github Actions (thus, action workflows are failing).

@beurkinger, regarding [this comment](https://github.com/huggingface/huggingface_hub/pull/131#pullrequestreview-729500327), `huggingface_hub` doesn't have [[INTERNAL](https://github.com/huggingface/moon-landing/blob/master/front/theme/various.css#L47-L61)] alert-error css, which is why the error doesn't have red background. However, when consumed from moon-landing, everything works since `alert-error` css is defined there. 

Find screenshots here:
<img width="300" alt="Screenshot 2021-08-16 at 11 15 46" src="https://user-images.githubusercontent.com/11827707/129621845-ab3fdc8b-c24e-4b6d-b29b-71e4f958541c.png">
<img width="300" alt="Screenshot 2021-08-16 at 11 15 31" src="https://user-images.githubusercontent.com/11827707/129621851-91c13d19-fe5e-44fd-8d24-06201d0bed50.png">
<img width="300" alt="Screenshot 2021-08-16 at 10 38 04" src="https://user-images.githubusercontent.com/11827707/129621860-05d71109-dd0d-4b11-a57b-8c5790d7a9a2.png">
