### PR TITLE
Update Keras Mixin

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -57,6 +57,23 @@ jobs:
 
     - run: pytest -sv ./tests/
 
+  build_tensorflow:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        pip install --upgrade pip
+        pip install .[testing,tensorflow]
+
+    - run: pytest -sv ./tests/
 
   tests_lfs:
     runs-on: ubuntu-latest

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,10 @@ extras["torch"] = [
     "torch",
 ]
 
+extras["tensorflow"] = [
+    "tensorflow",
+]
+
 extras["testing"] = [
     "pytest",
     "datasets",

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -34,6 +34,7 @@ from .file_download import cached_download, hf_hub_download, hf_hub_url
 from .hf_api import HfApi, HfFolder, repo_type_and_id_from_hf_id
 from .hub_mixin import ModelHubMixin, PyTorchModelHubMixin
 from .inference_api import InferenceApi
+from .keras_mixin import KerasModelHubMixin
 from .repository import Repository
 from .snapshot_download import snapshot_download
 from .utils import logging

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -34,7 +34,12 @@ from .file_download import cached_download, hf_hub_download, hf_hub_url
 from .hf_api import HfApi, HfFolder, repo_type_and_id_from_hf_id
 from .hub_mixin import ModelHubMixin, PyTorchModelHubMixin
 from .inference_api import InferenceApi
-from .keras_mixin import KerasModelHubMixin
+from .keras_mixin import (
+    KerasModelHubMixin,
+    from_pretrained_keras,
+    push_to_hub_keras,
+    save_pretrained_keras,
+)
 from .repository import Repository
 from .snapshot_download import snapshot_download
 from .utils import logging

--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -26,9 +26,6 @@ class ModelHubMixin:
     your classes. See ``huggingface_hub.PyTorchModelHubMixin`` for an example.
     """
 
-    _CONFIG_NAME = CONFIG_NAME
-    _WEIGHTS_NAME = PYTORCH_WEIGHTS_NAME
-
     def save_pretrained(
         self,
         save_directory: str,
@@ -56,7 +53,7 @@ class ModelHubMixin:
 
         # saving config
         if isinstance(config, dict):
-            path = os.path.join(save_directory, self._CONFIG_NAME)
+            path = os.path.join(save_directory, CONFIG_NAME)
             with open(path, "w") as f:
                 json.dump(config, f)
 
@@ -131,13 +128,13 @@ class ModelHubMixin:
         if len(model_id.split("@")) == 2:
             model_id, revision = model_id.split("@")
 
-        if os.path.isdir(model_id) and cls._CONFIG_NAME in os.listdir(model_id):
-            config_file = os.path.join(model_id, cls._CONFIG_NAME)
+        if os.path.isdir(model_id) and CONFIG_NAME in os.listdir(model_id):
+            config_file = os.path.join(model_id, CONFIG_NAME)
         else:
             try:
                 config_file = hf_hub_download(
                     repo_id=model_id,
-                    filename=cls._CONFIG_NAME,
+                    filename=CONFIG_NAME,
                     revision=revision,
                     cache_dir=cache_dir,
                     force_download=force_download,
@@ -147,7 +144,7 @@ class ModelHubMixin:
                     local_files_only=local_files_only,
                 )
             except requests.exceptions.RequestException:
-                logger.warning(f"{cls._CONFIG_NAME} NOT FOUND in HuggingFace Hub")
+                logger.warning(f"{CONFIG_NAME} NOT FOUND in HuggingFace Hub")
                 config_file = None
 
         if config_file is not None and config_file.endswith(".json"):

--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -144,7 +144,7 @@ class ModelHubMixin:
                     local_files_only=local_files_only,
                 )
             except requests.exceptions.RequestException:
-                logger.warning(f"{CONFIG_NAME} NOT FOUND in HuggingFace Hub")
+                logger.warning(f"{CONFIG_NAME} not found in HuggingFace Hub")
                 config_file = None
 
         if config_file is not None and config_file.endswith(".json"):

--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -58,12 +58,12 @@ class ModelHubMixin:
                 json.dump(config, f)
 
         # saving model weights/files
-        self._save_pretrained(save_directory, **kwargs)
+        self._save_pretrained(save_directory)
 
         if push_to_hub:
             return self.push_to_hub(save_directory, **kwargs)
 
-    def _save_pretrained(self, save_directory, **kwargs):
+    def _save_pretrained(self, save_directory):
         """
         Overwrite this method in subclass to define how to save your model.
         """
@@ -144,10 +144,10 @@ class ModelHubMixin:
                     local_files_only=local_files_only,
                 )
             except requests.exceptions.RequestException:
-                logger.warning("config.json NOT FOUND in HuggingFace Hub")
+                logger.warning(f"{CONFIG_NAME} NOT FOUND in HuggingFace Hub")
                 config_file = None
 
-        if config_file is not None:
+        if config_file is not None and config_file.suffix == '.json':
             with open(config_file, "r", encoding="utf-8") as f:
                 config = json.load(f)
             model_kwargs.update({"config": config})

--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -26,6 +26,9 @@ class ModelHubMixin:
     your classes. See ``huggingface_hub.PyTorchModelHubMixin`` for an example.
     """
 
+    _CONFIG_NAME = CONFIG_NAME
+    _WEIGHTS_NAME = PYTORCH_WEIGHTS_NAME
+
     def save_pretrained(
         self,
         save_directory: str,
@@ -53,7 +56,7 @@ class ModelHubMixin:
 
         # saving config
         if isinstance(config, dict):
-            path = os.path.join(save_directory, CONFIG_NAME)
+            path = os.path.join(save_directory, self._CONFIG_NAME)
             with open(path, "w") as f:
                 json.dump(config, f)
 
@@ -128,13 +131,13 @@ class ModelHubMixin:
         if len(model_id.split("@")) == 2:
             model_id, revision = model_id.split("@")
 
-        if os.path.isdir(model_id) and CONFIG_NAME in os.listdir(model_id):
-            config_file = os.path.join(model_id, CONFIG_NAME)
+        if os.path.isdir(model_id) and cls._CONFIG_NAME in os.listdir(model_id):
+            config_file = os.path.join(model_id, cls._CONFIG_NAME)
         else:
             try:
                 config_file = hf_hub_download(
                     repo_id=model_id,
-                    filename=CONFIG_NAME,
+                    filename=cls._CONFIG_NAME,
                     revision=revision,
                     cache_dir=cache_dir,
                     force_download=force_download,
@@ -144,10 +147,10 @@ class ModelHubMixin:
                     local_files_only=local_files_only,
                 )
             except requests.exceptions.RequestException:
-                logger.warning(f"{CONFIG_NAME} NOT FOUND in HuggingFace Hub")
+                logger.warning(f"{cls._CONFIG_NAME} NOT FOUND in HuggingFace Hub")
                 config_file = None
 
-        if config_file is not None and config_file.suffix == '.json':
+        if config_file is not None and config_file.endswith(".json"):
             with open(config_file, "r", encoding="utf-8") as f:
                 config = json.load(f)
             model_kwargs.update({"config": config})

--- a/src/huggingface_hub/keras_mixin.py
+++ b/src/huggingface_hub/keras_mixin.py
@@ -93,7 +93,7 @@ def push_to_hub_keras(
     )
     repo.git_pull(rebase=True)
 
-    save_pretrained_keras(model, repo_path_or_name, config=config)
+    save_pretrained_keras(model, repo_path_or_name)
 
     # Commit and push!
     repo.git_add()
@@ -123,7 +123,7 @@ class KerasModelHubMixin(ModelHubMixin):
             >>> model = MyModel()
             >>> model.compile(...)
             >>> # Build the graph by training it or passing dummy inputs
-            >>> model(model.dummy_inputs)
+            >>> _ = model(model.dummy_inputs)
             >>> # You can save your model like this
             >>> model.save_pretrained("local_model_dir/", push_to_hub=False)
             >>> # Or, you can push to a new public model repo like this

--- a/src/huggingface_hub/keras_mixin.py
+++ b/src/huggingface_hub/keras_mixin.py
@@ -105,7 +105,7 @@ def push_to_hub_keras(
     if repo_path_or_name is None and repo_url is None:
         raise ValueError("You need to specify a `repo_path_or_name` or a `repo_url`.")
 
-    if use_auth_token:
+    if isinstance(use_auth_token, bool) and use_auth_token:
         token = HfFolder.get_token()
         if token is None:
             raise ValueError(

--- a/src/huggingface_hub/keras_mixin.py
+++ b/src/huggingface_hub/keras_mixin.py
@@ -2,26 +2,47 @@ import logging
 import os
 from pathlib import Path
 
+from huggingface_hub.file_download import is_tf_available
+from huggingface_hub.snapshot_download import snapshot_download
 from huggingface_hub import ModelHubMixin, hf_hub_download
+from huggingface_hub.constants import HUGGINGFACE_HUB_CACHE
 
 
 logger = logging.getLogger(__name__)
 
+if is_tf_available():
+    import tensorflow as tf
+
+
+def save_pretrained_keras(model, save_dir):
+    """Function mimicing save_pretrained. Use this if you're using the Functional or Sequential APIs."""
+    if not model.built:
+        raise ValueError("Model should be built before trying to save")
+
+    tf.keras.models.save_model(model, save_dir)
+
+def from_pretrained_keras(model_name_or_path, revision=None, cache_dir=None, **kwargs):
+    """Function mimicing from_pretrained. Use this if you're using the Functional or Sequential APIs."""    
+
+    # Root is either a local filepath matching model_id or a cached snapshot
+    storage_folder = snapshot_download(
+        repo_id=model_name_or_path,
+        revision=revision,
+        cache_dir=cache_dir
+    ) if not os.path.isdir(model_name_or_path) else model_name_or_path
+
+    return tf.keras.models.load_model(storage_folder, **kwargs)
+
+def push_to_hub_keras(model, *args, **kwargs):
+    """Here we simply call the mixin's push_to_hub function. Would it be better to do it the other way around?"""
+    return ModelHubMixin.push_to_hub(model, *args, **kwargs)
+
 
 class KerasModelHubMixin(ModelHubMixin):
-
-    _CONFIG_NAME = "config.json"
-    _WEIGHTS_NAME = "tf_model.h5"
 
     def __init__(self, *args, **kwargs):
         """
         Mix this class with your keras-model class for ease process of saving & loading from huggingface-hub
-
-        NOTE - Dummy Inputs are required to save/load models using this mixin. When saving, you are required to either:
-
-            1. Assign an attribute to your class, self.dummy_inputs, that defines inputs to be passed to the model's call
-            function to build the model.
-            2. Pass the dummy_inputs kwarg to save_pretrained. We will save this along with the model (as if it were an attribute).
 
         Example::
 
@@ -35,34 +56,23 @@ class KerasModelHubMixin(ModelHubMixin):
             ...        self.layer = ...
             ...    def call(self, ...)
             ...        return ...
-
+            
+            >>> # Init and compile the model as you normally would
             >>> model = MyModel()
-            >>> model.save_pretrained("mymodel", push_to_hub=False) # Saving model weights in the directory
-            >>> model.push_to_hub("mymodel", "model-1") # Pushing model-weights to hf-hub
+            >>> model.compile(...)
+            >>> # Build the graph by training it or passing dummy inputs
+            >>> model(model.dummy_inputs)
+            >>> # You can save your model like this
+            >>> model.save_pretrained("local_model_dir/", push_to_hub=False)
+            >>> # Or, you can push to a new public model repo like this
+            >>> model.push_to_hub("super-cool-model", git_user="your-hf-username", git_email="you@somesite.com")
 
             >>> # Downloading weights from hf-hub & model will be initialized from those weights
             >>> model = MyModel.from_pretrained("username/mymodel@main")
         """
 
-    def _save_pretrained(self, save_directory, dummy_inputs=None, **kwargs):
-
-        dummy_inputs = (
-            dummy_inputs
-            if dummy_inputs is not None
-            else getattr(self, "dummy_inputs", None)
-        )
-
-        if dummy_inputs is None:
-            raise RuntimeError(
-                "You must either provide dummy inputs or have them assigned as an attribute of this model"
-            )
-
-        _ = self(dummy_inputs, training=False)
-
-        save_directory = Path(save_directory)
-        model_file = save_directory / self._WEIGHTS_NAME
-        self.save_weights(model_file)
-        logger.info(f"Model weights saved in {model_file}")
+    def _save_pretrained(self, save_directory):
+        save_pretrained_keras(self, save_directory)
 
     @classmethod
     def _from_pretrained(
@@ -75,34 +85,10 @@ class KerasModelHubMixin(ModelHubMixin):
         resume_download,
         local_files_only,
         use_auth_token,
-        by_name=False,
         **model_kwargs,
     ):
-        if os.path.isdir(model_id):
-            print("Loading weights from local directory")
-            model_file = os.path.join(model_id, cls._WEIGHTS_NAME)
-        else:
-            model_file = hf_hub_download(
-                repo_id=model_id,
-                filename=cls._WEIGHTS_NAME,
-                revision=revision,
-                cache_dir=cache_dir,
-                force_download=force_download,
-                proxies=proxies,
-                resume_download=resume_download,
-                use_auth_token=use_auth_token,
-                local_files_only=local_files_only,
-            )
-
-        model = cls(**model_kwargs)
-
-        if hasattr(model, "dummy_inputs") and model.dummy_inputs is not None:
-            raise ValueError("Model must have a dummy_inputs attribute")
-
-        _ = model(model.dummy_inputs, training=False)
-
-        model.load_weights(model_file, by_name=by_name)
-
-        _ = model(model.dummy_inputs, training=False)
-
-        return model
+        """Here we just call from_pretrained_keras function so both the mixin and functional APIs stay in sync.
+        
+        TODO - Some args above aren't used since we are calling snapshot_download instead of hf_hub_download.
+        """
+        return from_pretrained_keras(model_id, revision, cache_dir, **model_kwargs)

--- a/src/huggingface_hub/keras_mixin.py
+++ b/src/huggingface_hub/keras_mixin.py
@@ -58,7 +58,7 @@ def push_to_hub_keras(
     organization: Optional[str] = None,
     private: Optional[bool] = None,
     api_endpoint: Optional[str] = None,
-    use_auth_token: Optional[Union[bool, str]] = None,
+    use_auth_token: Optional[Union[bool, str]] = True,
     git_user: Optional[str] = None,
     git_email: Optional[str] = None,
     config: Optional[dict] = None,
@@ -79,8 +79,7 @@ def push_to_hub_keras(
             repository will be created in your namespace (unless you specify an :obj:`organization`) with
             :obj:`repo_name`.
         commit_message (:obj:`str`, `optional`):
-            Message to commit while pushing. Will default to :obj:`"add config"`, :obj:`"add tokenizer"` or
-            :obj:`"add model"` depending on the type of the class.
+            Message to commit while pushing. Will default to :obj:`"add model"`.
         organization (:obj:`str`, `optional`):
             Organization in which you want to push your model or tokenizer (you must be a member of this
             organization).
@@ -91,7 +90,7 @@ def push_to_hub_keras(
         use_auth_token (:obj:`bool` or :obj:`str`, `optional`):
             The token to use as HTTP bearer authorization for remote files. If :obj:`True`, will use the token
             generated when running :obj:`transformers-cli login` (stored in :obj:`~/.huggingface`). Will default to
-            :obj:`True` if :obj:`repo_url` is not specified.
+            :obj:`True`.
         git_user (``str``, `optional`):
             will override the ``git config user.name`` for committing and pushing files to the hub.
         git_email (``str``, `optional`):
@@ -106,7 +105,7 @@ def push_to_hub_keras(
     if repo_path_or_name is None and repo_url is None:
         raise ValueError("You need to specify a `repo_path_or_name` or a `repo_url`.")
 
-    if use_auth_token is None and repo_url is None:
+    if use_auth_token:
         token = HfFolder.get_token()
         if token is None:
             raise ValueError(
@@ -146,7 +145,7 @@ def push_to_hub_keras(
     save_pretrained_keras(model, repo_path_or_name, config=config)
 
     # Commit and push!
-    repo.git_add()
+    repo.git_add(auto_lfs_track=True)
     repo.git_commit(commit_message)
     return repo.git_push()
 

--- a/src/huggingface_hub/keras_mixin.py
+++ b/src/huggingface_hub/keras_mixin.py
@@ -216,7 +216,7 @@ class KerasModelHubMixin(ModelHubMixin):
 
         model = tf.keras.models.load_model(storage_folder, **model_kwargs)
 
-        # For now, we add a new attribute, hf_config, to store the config loaded from the hub/a local dir.
-        model.hf_config = cfg
+        # For now, we add a new attribute, config, to store the config loaded from the hub/a local dir.
+        model.config = cfg
 
         return model

--- a/src/huggingface_hub/keras_mixin.py
+++ b/src/huggingface_hub/keras_mixin.py
@@ -1,11 +1,14 @@
 import logging
 import os
 from pathlib import Path
+from typing import Optional, Union
 
 from huggingface_hub.file_download import is_tf_available
 from huggingface_hub.snapshot_download import snapshot_download
 from huggingface_hub import ModelHubMixin, hf_hub_download
 from huggingface_hub.constants import HUGGINGFACE_HUB_CACHE
+from .hf_api import HfApi, HfFolder
+from .repository import Repository
 
 
 logger = logging.getLogger(__name__)
@@ -21,6 +24,7 @@ def save_pretrained_keras(model, save_dir):
 
     tf.keras.models.save_model(model, save_dir)
 
+
 def from_pretrained_keras(model_name_or_path, revision=None, cache_dir=None, **kwargs):
     """Function mimicing from_pretrained. Use this if you're using the Functional or Sequential APIs."""    
 
@@ -33,9 +37,68 @@ def from_pretrained_keras(model_name_or_path, revision=None, cache_dir=None, **k
 
     return tf.keras.models.load_model(storage_folder, **kwargs)
 
-def push_to_hub_keras(model, *args, **kwargs):
-    """Here we simply call the mixin's push_to_hub function. Would it be better to do it the other way around?"""
-    return ModelHubMixin.push_to_hub(model, *args, **kwargs)
+
+def push_to_hub_keras(
+    model,
+    repo_path_or_name: Optional[str] = None,
+    repo_url: Optional[str] = None,
+    commit_message: Optional[str] = "Add model",
+    organization: Optional[str] = None,
+    private: Optional[bool] = None,
+    api_endpoint: Optional[str] = None,
+    use_auth_token: Optional[Union[bool, str]] = None,
+    git_user: Optional[str] = None,
+    git_email: Optional[str] = None,
+    config: Optional[dict] = None,
+):
+    if repo_path_or_name is None and repo_url is None:
+        raise ValueError(
+            "You need to specify a `repo_path_or_name` or a `repo_url`."
+        )
+
+    if use_auth_token is None and repo_url is None:
+        token = HfFolder.get_token()
+        if token is None:
+            raise ValueError(
+                "You must login to the Hugging Face hub on this computer by typing `transformers-cli login` and "
+                "entering your credentials to use `use_auth_token=True`. Alternatively, you can pass your own "
+                "token as the `use_auth_token` argument."
+            )
+    elif isinstance(use_auth_token, str):
+        token = use_auth_token
+    else:
+        token = None
+
+    if repo_path_or_name is None:
+        repo_path_or_name = repo_url.split("/")[-1]
+
+    # If no URL is passed and there's no path to a directory containing files, create a repo
+    if repo_url is None and not os.path.exists(repo_path_or_name):
+        repo_name = Path(repo_path_or_name).name
+        repo_url = HfApi(endpoint=api_endpoint).create_repo(
+            token,
+            repo_name,
+            organization=organization,
+            private=private,
+            repo_type=None,
+            exist_ok=True,
+        )
+
+    repo = Repository(
+        repo_path_or_name,
+        clone_from=repo_url,
+        use_auth_token=use_auth_token,
+        git_user=git_user,
+        git_email=git_email,
+    )
+    repo.git_pull(rebase=True)
+
+    save_pretrained_keras(model, repo_path_or_name, config=config)
+
+    # Commit and push!
+    repo.git_add()
+    repo.git_commit(commit_message)
+    return repo.git_push()
 
 
 class KerasModelHubMixin(ModelHubMixin):

--- a/src/huggingface_hub/keras_mixin.py
+++ b/src/huggingface_hub/keras_mixin.py
@@ -3,8 +3,7 @@ import os
 from pathlib import Path
 from typing import Optional, Union
 
-from huggingface_hub import ModelHubMixin, hf_hub_download
-from huggingface_hub.constants import HUGGINGFACE_HUB_CACHE
+from huggingface_hub import ModelHubMixin
 from huggingface_hub.file_download import is_tf_available
 from huggingface_hub.snapshot_download import snapshot_download
 

--- a/src/huggingface_hub/keras_mixin.py
+++ b/src/huggingface_hub/keras_mixin.py
@@ -25,7 +25,7 @@ def save_pretrained_keras(
     """Saves a Keras model to save_directory in SavedModel format. Use this if you're using the Functional or Sequential APIs.
 
     model:
-        The Keras model you'd like to save. It model must be compiled and built.
+        The Keras model you'd like to save. The model must be compiled and built.
     save_directory (:obj:`str`):
         Specify directory in which you want to save the Keras model.
     config (:obj:`dict`, `optional`):

--- a/src/huggingface_hub/keras_mixin.py
+++ b/src/huggingface_hub/keras_mixin.py
@@ -38,7 +38,11 @@ def save_pretrained_keras(
     os.makedirs(save_directory, exist_ok=True)
 
     # saving config
-    if isinstance(config, dict):
+    if config:
+        if not isinstance(config, dict):
+            raise RuntimeError(
+                f"Provided config to save_pretrained_keras should be a dict. Got: '{type(config)}'"
+            )
         path = os.path.join(save_directory, CONFIG_NAME)
         with open(path, "w") as f:
             json.dump(config, f)
@@ -107,16 +111,17 @@ def push_to_hub_keras(
 
     if isinstance(use_auth_token, bool) and use_auth_token:
         token = HfFolder.get_token()
-        if token is None:
-            raise ValueError(
-                "You must login to the Hugging Face hub on this computer by typing `transformers-cli login` and "
-                "entering your credentials to use `use_auth_token=True`. Alternatively, you can pass your own "
-                "token as the `use_auth_token` argument."
-            )
     elif isinstance(use_auth_token, str):
         token = use_auth_token
     else:
         token = None
+
+    if token is None:
+        raise ValueError(
+            "You must login to the Hugging Face hub on this computer by typing `huggingface-cli login` and "
+            "entering your credentials to use `use_auth_token=True`. Alternatively, you can pass your own "
+            "token as the `use_auth_token` argument."
+        )
 
     if repo_path_or_name is None:
         repo_path_or_name = repo_url.split("/")[-1]

--- a/tests/test_keras_integration.py
+++ b/tests/test_keras_integration.py
@@ -190,14 +190,15 @@ def hf_token():
     "model",
     [
         pytest.param(
-            tf.keras.models.clone_model(dummy_model_sequential), id="sequential"
+            dummy_model_sequential, id="sequential"
         ),
         pytest.param(
-            tf.keras.models.clone_model(dummy_model_functional), id="functional"
+            dummy_model_functional, id="functional"
         ),
     ],
 )
 def test_save_pretrained(model, hf_token):
+    model = tf.keras.models.clone_model(model)
     model.build((None, 2))
     save_pretrained_keras(model, f"{WORKING_REPO_DIR}/{REPO_NAME}")
     files = os.listdir(f"{WORKING_REPO_DIR}/{REPO_NAME}")
@@ -212,14 +213,15 @@ def test_save_pretrained(model, hf_token):
     "model",
     [
         pytest.param(
-            tf.keras.models.clone_model(dummy_model_sequential), id="sequential"
+            dummy_model_sequential, id="sequential"
         ),
         pytest.param(
-            tf.keras.models.clone_model(dummy_model_functional), id="functional"
+            dummy_model_functional, id="functional"
         ),
     ],
 )
 def test_keras_from_pretrained_weights(model, hf_token):
+    model = tf.keras.models.clone_model(model)
     model.build((None, 2))
 
     save_pretrained_keras(model, f"{WORKING_REPO_DIR}/{REPO_NAME}")
@@ -243,14 +245,15 @@ def test_keras_from_pretrained_weights(model, hf_token):
     "model",
     [
         pytest.param(
-            tf.keras.models.clone_model(dummy_model_sequential), id="sequential"
+            dummy_model_sequential, id="sequential"
         ),
         pytest.param(
-            tf.keras.models.clone_model(dummy_model_functional), id="functional"
+            dummy_model_functional, id="functional"
         ),
     ],
 )
 def test_rel_path_from_pretrained(model, hf_token):
+    model = tf.keras.models.clone_model(model)
     model.build((None, 2))
     save_pretrained_keras(
         model,
@@ -268,14 +271,15 @@ def test_rel_path_from_pretrained(model, hf_token):
     "model",
     [
         pytest.param(
-            tf.keras.models.clone_model(dummy_model_sequential), id="sequential"
+            dummy_model_sequential, id="sequential"
         ),
         pytest.param(
-            tf.keras.models.clone_model(dummy_model_functional), id="functional"
+            dummy_model_functional, id="functional"
         ),
     ],
 )
 def test_abs_path_from_pretrained(model, hf_token):
+    model = tf.keras.models.clone_model(model)
     model.build((None, 2))
     save_pretrained_keras(
         model,
@@ -291,15 +295,15 @@ def test_abs_path_from_pretrained(model, hf_token):
     "model",
     [
         pytest.param(
-            tf.keras.models.clone_model(dummy_model_sequential), id="sequential"
+            dummy_model_sequential, id="sequential"
         ),
         pytest.param(
-            tf.keras.models.clone_model(dummy_model_functional), id="functional"
+            dummy_model_functional, id="functional"
         ),
     ],
 )
 def test_push_to_hub(model, hf_token):
-
+    model = tf.keras.models.clone_model(model)
     model.build((None, 2))
     push_to_hub_keras(
         model,

--- a/tests/test_keras_integration.py
+++ b/tests/test_keras_integration.py
@@ -189,12 +189,8 @@ def hf_token():
 @pytest.mark.parametrize(
     "model",
     [
-        pytest.param(
-            dummy_model_sequential, id="sequential"
-        ),
-        pytest.param(
-            dummy_model_functional, id="functional"
-        ),
+        pytest.param(dummy_model_sequential, id="sequential"),
+        pytest.param(dummy_model_functional, id="functional"),
     ],
 )
 def test_save_pretrained(model, hf_token):
@@ -212,12 +208,8 @@ def test_save_pretrained(model, hf_token):
 @pytest.mark.parametrize(
     "model",
     [
-        pytest.param(
-            dummy_model_sequential, id="sequential"
-        ),
-        pytest.param(
-            dummy_model_functional, id="functional"
-        ),
+        pytest.param(dummy_model_sequential, id="sequential"),
+        pytest.param(dummy_model_functional, id="functional"),
     ],
 )
 def test_keras_from_pretrained_weights(model, hf_token):
@@ -244,12 +236,8 @@ def test_keras_from_pretrained_weights(model, hf_token):
 @pytest.mark.parametrize(
     "model",
     [
-        pytest.param(
-            dummy_model_sequential, id="sequential"
-        ),
-        pytest.param(
-            dummy_model_functional, id="functional"
-        ),
+        pytest.param(dummy_model_sequential, id="sequential"),
+        pytest.param(dummy_model_functional, id="functional"),
     ],
 )
 def test_rel_path_from_pretrained(model, hf_token):
@@ -270,12 +258,8 @@ def test_rel_path_from_pretrained(model, hf_token):
 @pytest.mark.parametrize(
     "model",
     [
-        pytest.param(
-            dummy_model_sequential, id="sequential"
-        ),
-        pytest.param(
-            dummy_model_functional, id="functional"
-        ),
+        pytest.param(dummy_model_sequential, id="sequential"),
+        pytest.param(dummy_model_functional, id="functional"),
     ],
 )
 def test_abs_path_from_pretrained(model, hf_token):
@@ -294,12 +278,8 @@ def test_abs_path_from_pretrained(model, hf_token):
 @pytest.mark.parametrize(
     "model",
     [
-        pytest.param(
-            dummy_model_sequential, id="sequential"
-        ),
-        pytest.param(
-            dummy_model_functional, id="functional"
-        ),
+        pytest.param(dummy_model_sequential, id="sequential"),
+        pytest.param(dummy_model_functional, id="functional"),
     ],
 )
 def test_push_to_hub(model, hf_token):

--- a/tests/test_keras_integration.py
+++ b/tests/test_keras_integration.py
@@ -48,7 +48,6 @@ if is_tf_available():
     class DummyModel(tf.keras.Model, KerasModelHubMixin):
         def __init__(self, **kwargs):
             super().__init__()
-            self.config = kwargs.pop("config", None)
             self.l1 = tf.keras.layers.Dense(2, activation="relu")
             dummy_batch_size = input_dim = 2
             self.dummy_inputs = tf.ones([dummy_batch_size, input_dim])
@@ -126,7 +125,7 @@ class HubMixingTestKeras(unittest.TestCase):
         model = DummyModel.from_pretrained(
             f"tests/{WORKING_REPO_SUBDIR}/FROM_PRETRAINED"
         )
-        self.assertTrue(model.hf_config == {"num": 10, "act": "gelu_fast"})
+        self.assertTrue(model.config == {"num": 10, "act": "gelu_fast"})
 
     def test_abs_path_from_pretrained(self):
         model = DummyModel()
@@ -139,7 +138,7 @@ class HubMixingTestKeras(unittest.TestCase):
         model = DummyModel.from_pretrained(
             f"{WORKING_REPO_DIR}/{REPO_NAME}-FROM_PRETRAINED"
         )
-        self.assertDictEqual(model.hf_config, {"num": 10, "act": "gelu_fast"})
+        self.assertDictEqual(model.config, {"num": 10, "act": "gelu_fast"})
 
     def test_push_to_hub(self):
         model = DummyModel()
@@ -220,7 +219,7 @@ class HubKerasSequentialTest(HubMixingTestKeras):
         self.assertTrue(tf.reduce_all(tf.equal(new_model.weights[0], model.weights[0])))
 
         # Check saved configuration is what we expect
-        self.assertTrue(new_model.hf_config == {"num": 10, "act": "gelu_fast"})
+        self.assertTrue(new_model.config == {"num": 10, "act": "gelu_fast"})
 
     def test_abs_path_from_pretrained(self):
         model = self.model_init()
@@ -235,7 +234,7 @@ class HubKerasSequentialTest(HubMixingTestKeras):
             f"{WORKING_REPO_DIR}/{REPO_NAME}-FROM_PRETRAINED"
         )
         assert tf.reduce_all(tf.equal(new_model.weights[0], model.weights[0]))
-        self.assertTrue(new_model.hf_config == {"num": 10, "act": "gelu_fast"})
+        self.assertTrue(new_model.config == {"num": 10, "act": "gelu_fast"})
 
     def test_push_to_hub(self):
         model = self.model_init()

--- a/tests/test_keras_integration.py
+++ b/tests/test_keras_integration.py
@@ -177,9 +177,9 @@ class HubKerasSequentialTest(HubMixingTestKeras):
         save_pretrained_keras(model, f"{WORKING_REPO_DIR}/{REPO_NAME}")
         files = os.listdir(f"{WORKING_REPO_DIR}/{REPO_NAME}")
 
-        assert "saved_model.pb" in files
-        assert "keras_metadata.pb" in files
-        assert len(files) == 4
+        self.assertIn("saved_model.pb", files)
+        self.assertIn("keras_metadata.pb", files)
+        self.assertEqual(len(files), 4)
 
     def test_from_pretrained_weights(self):
         model = self.model_init()
@@ -189,12 +189,12 @@ class HubKerasSequentialTest(HubMixingTestKeras):
         new_model = from_pretrained_keras(f"{WORKING_REPO_DIR}/{REPO_NAME}")
 
         # Check the reloaded model's weights match the original model's weights
-        assert tf.reduce_all(tf.equal(new_model.weights[0], model.weights[0]))
+        self.assertTrue(tf.reduce_all(tf.equal(new_model.weights[0], model.weights[0])))
 
         # Check a new model's weights are not the same as the reloaded model's weights
         another_model = DummyModel()
         another_model(tf.ones([2, 2]))
-        assert not (
+        self.assertFalse(
             tf.reduce_all(tf.equal(new_model.weights[0], another_model.weights[0]))
             .numpy()
             .item()
@@ -231,7 +231,7 @@ class HubKerasSequentialTest(HubMixingTestKeras):
         new_model = from_pretrained_keras(
             f"{WORKING_REPO_DIR}/{REPO_NAME}-FROM_PRETRAINED"
         )
-        assert tf.reduce_all(tf.equal(new_model.weights[0], model.weights[0]))
+        self.assertTrue(tf.reduce_all(tf.equal(new_model.weights[0], model.weights[0])))
         self.assertTrue(new_model.config == {"num": 10, "act": "gelu_fast"})
 
     def test_push_to_hub(self):
@@ -250,7 +250,7 @@ class HubKerasSequentialTest(HubMixingTestKeras):
         model_info = HfApi(endpoint=ENDPOINT_STAGING).model_info(
             f"{USER}/{REPO_NAME}-PUSH_TO_HUB",
         )
-        assert model_info.modelId == f"{USER}/{REPO_NAME}-PUSH_TO_HUB"
+        self.assertEqual(model_info.modelId, f"{USER}/{REPO_NAME}-PUSH_TO_HUB")
 
         self._api.delete_repo(token=self._token, name=f"{REPO_NAME}-PUSH_TO_HUB")
 

--- a/tests/test_keras_integration.py
+++ b/tests/test_keras_integration.py
@@ -195,7 +195,17 @@ def hf_token():
 )
 def test_save_pretrained(model, hf_token):
     model = tf.keras.models.clone_model(model)
+
+    # Here we make sure saving doesn't work for Sequential API if it hasn't been built yet.
+    # NOTE - Functional API comes built as we passed inputs on init, so this just runs for dummy_model_sequential.
+    if not model.built:
+        with pytest.raises(ValueError, match="Model should be built*"):
+            save_pretrained_keras(model, f"{WORKING_REPO_DIR}/{REPO_NAME}")
+
+    # Builds the sequential model.
+    # NOTE - For functional model, this won't do anything since it's already built.
     model.build((None, 2))
+
     save_pretrained_keras(model, f"{WORKING_REPO_DIR}/{REPO_NAME}")
     files = os.listdir(f"{WORKING_REPO_DIR}/{REPO_NAME}")
 

--- a/tests/test_keras_integration.py
+++ b/tests/test_keras_integration.py
@@ -3,9 +3,16 @@ import shutil
 import time
 import unittest
 
+import pytest
+
 from huggingface_hub import HfApi
 from huggingface_hub.file_download import is_tf_available
-from huggingface_hub.keras_mixin import KerasModelHubMixin
+from huggingface_hub.keras_mixin import (
+    KerasModelHubMixin,
+    from_pretrained_keras,
+    push_to_hub_keras,
+    save_pretrained_keras,
+)
 
 from .testing_constants import ENDPOINT_STAGING, PASS, USER
 from .testing_utils import set_write_permission_and_retry
@@ -37,6 +44,7 @@ def require_tf(test_case):
 
 if is_tf_available():
 
+    # Define dummy mixin model...
     class DummyModel(tf.keras.Model, KerasModelHubMixin):
         def __init__(self, **kwargs):
             super().__init__()
@@ -48,6 +56,16 @@ if is_tf_available():
         def call(self, x):
             return self.l1(x)
 
+    # Define dummy sequential model...
+    dummy_model_sequential = tf.keras.models.Sequential()
+    dummy_model_sequential.add(tf.keras.layers.Dense(2, activation="relu"))
+    dummy_model_sequential.compile(optimizer="adam", loss="mse")
+
+    # Define dummy functional model...
+    inputs = tf.keras.layers.Input(shape=(2,))
+    x = tf.keras.layers.Dense(2, activation="relu")(inputs)
+    dummy_model_functional = tf.keras.models.Model(inputs=inputs, outputs=x)
+    dummy_model_functional.compile(optimizer="adam", loss="mse")
 
 else:
     DummyModel = None
@@ -152,3 +170,124 @@ class HubMixingTest(HubMixingCommonTest):
         self.assertEqual(model_info.modelId, f"{USER}/{REPO_NAME}-PUSH_TO_HUB")
 
         self._api.delete_repo(token=self._token, name=f"{REPO_NAME}-PUSH_TO_HUB")
+
+
+@pytest.fixture()
+def hf_token():
+    _api = HfApi(endpoint=ENDPOINT_STAGING)
+    token = _api.login(username=USER, password=PASS)
+    yield token
+    try:
+        shutil.rmtree(WORKING_REPO_DIR, onerror=set_write_permission_and_retry)
+    except FileNotFoundError:
+        pass
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        pytest.param(dummy_model_sequential, id="sequential"),
+        pytest.param(dummy_model_functional, id="functional"),
+    ],
+)
+def test_save_pretrained(model, hf_token):
+    # model = dummy_model_sequential if model_type == 'sequential' else dummy_model_functional
+    model.build((None, 2))
+    save_pretrained_keras(model, f"{WORKING_REPO_DIR}/{REPO_NAME}")
+    files = os.listdir(f"{WORKING_REPO_DIR}/{REPO_NAME}")
+
+    assert "saved_model.pb" in files
+    assert "keras_metadata.pb" in files
+    assert len(files) == 4
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        pytest.param(dummy_model_sequential, id="sequential"),
+        pytest.param(dummy_model_functional, id="functional"),
+    ],
+)
+def test_keras_from_pretrained_weights(model, hf_token):
+    model.build((None, 2))
+
+    save_pretrained_keras(model, f"{WORKING_REPO_DIR}/{REPO_NAME}")
+    new_model = from_pretrained_keras(f"{WORKING_REPO_DIR}/{REPO_NAME}")
+
+    # Check the reloaded model's weights match the original model's weights
+    assert tf.reduce_all(tf.equal(new_model.weights[0], model.weights[0]))
+
+    # Check a new model's weights are not the same as the reloaded model's weights
+    another_model = DummyModel()
+    another_model(tf.ones([2, 2]))
+    assert not (
+        tf.reduce_all(tf.equal(new_model.weights[0], another_model.weights[0]))
+        .numpy()
+        .item()
+    )
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        pytest.param(dummy_model_sequential, id="sequential"),
+        pytest.param(dummy_model_functional, id="functional"),
+    ],
+)
+def test_rel_path_from_pretrained(model, hf_token):
+    model.build((None, 2))
+    save_pretrained_keras(
+        model,
+        f"tests/{WORKING_REPO_SUBDIR}/FROM_PRETRAINED",
+    )
+
+    new_model = from_pretrained_keras(f"tests/{WORKING_REPO_SUBDIR}/FROM_PRETRAINED")
+
+    # Check the reloaded model's weights match the original model's weights
+    assert tf.reduce_all(tf.equal(new_model.weights[0], model.weights[0]))
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        pytest.param(dummy_model_sequential, id="sequential"),
+        pytest.param(dummy_model_functional, id="functional"),
+    ],
+)
+def test_abs_path_from_pretrained(model, hf_token):
+    model.build((None, 2))
+    save_pretrained_keras(
+        model,
+        f"{WORKING_REPO_DIR}/{REPO_NAME}-FROM_PRETRAINED",
+    )
+
+    new_model = from_pretrained_keras(f"{WORKING_REPO_DIR}/{REPO_NAME}-FROM_PRETRAINED")
+    assert tf.reduce_all(tf.equal(new_model.weights[0], model.weights[0]))
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        pytest.param(dummy_model_sequential, id="sequential"),
+        pytest.param(dummy_model_functional, id="functional"),
+    ],
+)
+def test_push_to_hub(model, hf_token):
+
+    model.build((None, 2))
+    push_to_hub_keras(
+        model,
+        repo_path_or_name=f"{WORKING_REPO_DIR}/{REPO_NAME}-PUSH_TO_HUB",
+        api_endpoint=ENDPOINT_STAGING,
+        use_auth_token=hf_token,
+        git_user="ci",
+        git_email="ci@dummy.com",
+        config={"num": 7, "act": "gelu_fast"},
+    )
+
+    model_info = HfApi().model_info(
+        f"{USER}/{REPO_NAME}-PUSH_TO_HUB",
+    )
+    assert model_info.modelId == f"{USER}/{REPO_NAME}-PUSH_TO_HUB"
+
+    HfApi().delete_repo(token=hf_token, name=f"{REPO_NAME}-PUSH_TO_HUB")

--- a/tests/test_keras_integration.py
+++ b/tests/test_keras_integration.py
@@ -198,7 +198,6 @@ def hf_token():
     ],
 )
 def test_save_pretrained(model, hf_token):
-    # model = dummy_model_sequential if model_type == 'sequential' else dummy_model_functional
     model.build((None, 2))
     save_pretrained_keras(model, f"{WORKING_REPO_DIR}/{REPO_NAME}")
     files = os.listdir(f"{WORKING_REPO_DIR}/{REPO_NAME}")

--- a/tests/test_keras_integration.py
+++ b/tests/test_keras_integration.py
@@ -126,7 +126,7 @@ class HubMixingTestKeras(unittest.TestCase):
         model = DummyModel.from_pretrained(
             f"tests/{WORKING_REPO_SUBDIR}/FROM_PRETRAINED"
         )
-        self.assertTrue(model.config == {"num": 10, "act": "gelu_fast"})
+        self.assertTrue(model.hf_config == {"num": 10, "act": "gelu_fast"})
 
     def test_abs_path_from_pretrained(self):
         model = DummyModel()
@@ -139,7 +139,7 @@ class HubMixingTestKeras(unittest.TestCase):
         model = DummyModel.from_pretrained(
             f"{WORKING_REPO_DIR}/{REPO_NAME}-FROM_PRETRAINED"
         )
-        self.assertDictEqual(model.config, {"num": 10, "act": "gelu_fast"})
+        self.assertDictEqual(model.hf_config, {"num": 10, "act": "gelu_fast"})
 
     def test_push_to_hub(self):
         model = DummyModel()
@@ -208,6 +208,7 @@ class HubKerasSequentialTest(HubMixingTestKeras):
         save_pretrained_keras(
             model,
             f"tests/{WORKING_REPO_SUBDIR}/FROM_PRETRAINED",
+            config={"num": 10, "act": "gelu_fast"},
         )
 
         new_model = from_pretrained_keras(
@@ -215,7 +216,10 @@ class HubKerasSequentialTest(HubMixingTestKeras):
         )
 
         # Check the reloaded model's weights match the original model's weights
-        assert tf.reduce_all(tf.equal(new_model.weights[0], model.weights[0]))
+        self.assertTrue(tf.reduce_all(tf.equal(new_model.weights[0], model.weights[0])))
+
+        # Check saved configuration is what we expect
+        self.assertTrue(new_model.hf_config == {"num": 10, "act": "gelu_fast"})
 
     def test_abs_path_from_pretrained(self):
         model = self.model_init()
@@ -223,12 +227,14 @@ class HubKerasSequentialTest(HubMixingTestKeras):
         save_pretrained_keras(
             model,
             f"{WORKING_REPO_DIR}/{REPO_NAME}-FROM_PRETRAINED",
+            config={"num": 10, "act": "gelu_fast"},
         )
 
         new_model = from_pretrained_keras(
             f"{WORKING_REPO_DIR}/{REPO_NAME}-FROM_PRETRAINED"
         )
         assert tf.reduce_all(tf.equal(new_model.weights[0], model.weights[0]))
+        self.assertTrue(new_model.hf_config == {"num": 10, "act": "gelu_fast"})
 
     def test_push_to_hub(self):
         model = self.model_init()

--- a/tests/test_keras_integration.py
+++ b/tests/test_keras_integration.py
@@ -305,9 +305,11 @@ def test_push_to_hub(model, hf_token):
         config={"num": 7, "act": "gelu_fast"},
     )
 
-    model_info = HfApi().model_info(
+    model_info = HfApi(endpoint=ENDPOINT_STAGING).model_info(
         f"{USER}/{REPO_NAME}-PUSH_TO_HUB",
     )
     assert model_info.modelId == f"{USER}/{REPO_NAME}-PUSH_TO_HUB"
 
-    HfApi().delete_repo(token=hf_token, name=f"{REPO_NAME}-PUSH_TO_HUB")
+    HfApi(endpoint=ENDPOINT_STAGING).delete_repo(
+        token=hf_token, name=f"{REPO_NAME}-PUSH_TO_HUB"
+    )

--- a/tests/test_keras_integration.py
+++ b/tests/test_keras_integration.py
@@ -143,6 +143,7 @@ class HubMixingTestKeras(unittest.TestCase):
 
     def test_push_to_hub(self):
         model = DummyModel()
+        model(model.dummy_inputs)
         model.push_to_hub(
             repo_path_or_name=f"{WORKING_REPO_DIR}/{REPO_NAME}-PUSH_TO_HUB",
             api_endpoint=ENDPOINT_STAGING,

--- a/tests/test_keras_integration.py
+++ b/tests/test_keras_integration.py
@@ -73,7 +73,6 @@ else:
     dummy_model_functional = None
 
 
-
 @require_tf
 class HubMixingCommonTest(unittest.TestCase):
     _api = HfApi(endpoint=ENDPOINT_STAGING)
@@ -190,8 +189,12 @@ def hf_token():
 @pytest.mark.parametrize(
     "model",
     [
-        pytest.param(dummy_model_sequential, id="sequential"),
-        pytest.param(dummy_model_functional, id="functional"),
+        pytest.param(
+            tf.keras.models.clone_model(dummy_model_sequential), id="sequential"
+        ),
+        pytest.param(
+            tf.keras.models.clone_model(dummy_model_functional), id="functional"
+        ),
     ],
 )
 def test_save_pretrained(model, hf_token):
@@ -209,8 +212,12 @@ def test_save_pretrained(model, hf_token):
 @pytest.mark.parametrize(
     "model",
     [
-        pytest.param(dummy_model_sequential, id="sequential"),
-        pytest.param(dummy_model_functional, id="functional"),
+        pytest.param(
+            tf.keras.models.clone_model(dummy_model_sequential), id="sequential"
+        ),
+        pytest.param(
+            tf.keras.models.clone_model(dummy_model_functional), id="functional"
+        ),
     ],
 )
 def test_keras_from_pretrained_weights(model, hf_token):
@@ -236,8 +243,12 @@ def test_keras_from_pretrained_weights(model, hf_token):
 @pytest.mark.parametrize(
     "model",
     [
-        pytest.param(dummy_model_sequential, id="sequential"),
-        pytest.param(dummy_model_functional, id="functional"),
+        pytest.param(
+            tf.keras.models.clone_model(dummy_model_sequential), id="sequential"
+        ),
+        pytest.param(
+            tf.keras.models.clone_model(dummy_model_functional), id="functional"
+        ),
     ],
 )
 def test_rel_path_from_pretrained(model, hf_token):
@@ -257,8 +268,12 @@ def test_rel_path_from_pretrained(model, hf_token):
 @pytest.mark.parametrize(
     "model",
     [
-        pytest.param(dummy_model_sequential, id="sequential"),
-        pytest.param(dummy_model_functional, id="functional"),
+        pytest.param(
+            tf.keras.models.clone_model(dummy_model_sequential), id="sequential"
+        ),
+        pytest.param(
+            tf.keras.models.clone_model(dummy_model_functional), id="functional"
+        ),
     ],
 )
 def test_abs_path_from_pretrained(model, hf_token):
@@ -276,8 +291,12 @@ def test_abs_path_from_pretrained(model, hf_token):
 @pytest.mark.parametrize(
     "model",
     [
-        pytest.param(dummy_model_sequential, id="sequential"),
-        pytest.param(dummy_model_functional, id="functional"),
+        pytest.param(
+            tf.keras.models.clone_model(dummy_model_sequential), id="sequential"
+        ),
+        pytest.param(
+            tf.keras.models.clone_model(dummy_model_functional), id="functional"
+        ),
     ],
 )
 def test_push_to_hub(model, hf_token):

--- a/tests/test_keras_integration.py
+++ b/tests/test_keras_integration.py
@@ -183,6 +183,7 @@ def hf_token():
         pass
 
 
+@require_tf
 @pytest.mark.parametrize(
     "model",
     [
@@ -201,6 +202,7 @@ def test_save_pretrained(model, hf_token):
     assert len(files) == 4
 
 
+@require_tf
 @pytest.mark.parametrize(
     "model",
     [
@@ -227,6 +229,7 @@ def test_keras_from_pretrained_weights(model, hf_token):
     )
 
 
+@require_tf
 @pytest.mark.parametrize(
     "model",
     [
@@ -247,6 +250,7 @@ def test_rel_path_from_pretrained(model, hf_token):
     assert tf.reduce_all(tf.equal(new_model.weights[0], model.weights[0]))
 
 
+@require_tf
 @pytest.mark.parametrize(
     "model",
     [
@@ -265,6 +269,7 @@ def test_abs_path_from_pretrained(model, hf_token):
     assert tf.reduce_all(tf.equal(new_model.weights[0], model.weights[0]))
 
 
+@require_tf
 @pytest.mark.parametrize(
     "model",
     [

--- a/tests/test_keras_integration.py
+++ b/tests/test_keras_integration.py
@@ -20,7 +20,7 @@ from .testing_utils import set_write_permission_and_retry
 
 REPO_NAME = "mixin-repo-{}".format(int(time.time() * 10e3))
 
-WORKING_REPO_SUBDIR = "fixtures/working_repo_3"
+WORKING_REPO_SUBDIR = f"fixtures/working_repo_{__name__.split('.')[-1]}"
 WORKING_REPO_DIR = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), WORKING_REPO_SUBDIR
 )

--- a/tests/test_keras_integration.py
+++ b/tests/test_keras_integration.py
@@ -58,8 +58,6 @@ if is_tf_available():
 
 else:
     DummyModel = None
-    dummy_model_sequential = None
-    dummy_model_functional = None
 
 
 @require_tf

--- a/tests/test_keras_integration.py
+++ b/tests/test_keras_integration.py
@@ -69,6 +69,9 @@ if is_tf_available():
 
 else:
     DummyModel = None
+    dummy_model_sequential = None
+    dummy_model_functional = None
+
 
 
 @require_tf

--- a/tests/test_keras_mixin.py
+++ b/tests/test_keras_mixin.py
@@ -75,27 +75,26 @@ class HubMixingTest(HubMixingCommonTest):
 
     def test_save_pretrained(self):
         model = DummyModel()
-
+        model(model.dummy_inputs)
         model.save_pretrained(f"{WORKING_REPO_DIR}/{REPO_NAME}")
         files = os.listdir(f"{WORKING_REPO_DIR}/{REPO_NAME}")
-        self.assertTrue("tf_model.h5" in files)
-        self.assertEqual(len(files), 1)
+        self.assertTrue("saved_model.pb" in files)
+        self.assertTrue("keras_metadata.pb" in files)
+        self.assertEqual(len(files), 4)
 
         model.save_pretrained(
             f"{WORKING_REPO_DIR}/{REPO_NAME}", config={"num": 12, "act": "gelu"}
         )
         files = os.listdir(f"{WORKING_REPO_DIR}/{REPO_NAME}")
         self.assertTrue("config.json" in files)
-        self.assertTrue("tf_model.h5" in files)
-        self.assertEqual(len(files), 2)
+        self.assertTrue("saved_model.pb" in files)
+        self.assertEqual(len(files), 5)
 
     def test_keras_from_pretrained_weights(self):
         model = DummyModel()
-        model.dummy_inputs = None
-        model.save_pretrained(
-            f"{WORKING_REPO_DIR}/{REPO_NAME}", dummy_inputs=tf.ones([2, 2])
-        )
-        assert model.built
+        model(model.dummy_inputs)
+
+        model.save_pretrained(f"{WORKING_REPO_DIR}/{REPO_NAME}")
         new_model = DummyModel.from_pretrained(f"{WORKING_REPO_DIR}/{REPO_NAME}")
 
         # Check the reloaded model's weights match the original model's weights
@@ -112,6 +111,7 @@ class HubMixingTest(HubMixingCommonTest):
 
     def test_rel_path_from_pretrained(self):
         model = DummyModel()
+        model(model.dummy_inputs)
         model.save_pretrained(
             f"tests/{WORKING_REPO_SUBDIR}/FROM_PRETRAINED",
             config={"num": 10, "act": "gelu_fast"},
@@ -124,6 +124,7 @@ class HubMixingTest(HubMixingCommonTest):
 
     def test_abs_path_from_pretrained(self):
         model = DummyModel()
+        model(model.dummy_inputs)
         model.save_pretrained(
             f"{WORKING_REPO_DIR}/{REPO_NAME}-FROM_PRETRAINED",
             config={"num": 10, "act": "gelu_fast"},


### PR DESCRIPTION
- [x] Use SavedModel format instead of h5
- [x] Add functional API

Both mentioned in #230 

---

**Note** -  I had to switch to using `snapshot_download` because:
1. The SavedModel format doesn't play nice when filenames are hashes instead of folder containing `keras_model.pb` `metadata.pb`, `variables/`, etc.
2. You have to enforce the structure of the directory tree.

Using `forced_filename` also _could_ have worked, but you'd have to gather up all the files within `variables`/`assets`/etc

I've seen some folks just [zip up the specific file tree](https://gist.github.com/ramdesh/f00ec1f5d01f03114264e8f3d0c226e8) instead due to similar issues.