### PR TITLE
Remove custom language pack behavior

### DIFF
--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -71,7 +71,7 @@ def is_tracked_with_lfs(filename: Union[str, Path]) -> bool:
         )
         attributes = p.stdout.strip()
     except subprocess.CalledProcessError as exc:
-        if "not a git repository" in exc.stderr:
+        if not is_git_repo(folder):
             return False
         else:
             raise OSError(exc.stderr)


### PR DESCRIPTION
The `is_tracked_with_lfs` method has branching logic set according to the contents of an error message. However, this error message comes from `git` which has localization support: if the default locale is set to something other than English, then the error message will be different. 

While it isn't an issue in other parts of the library where we leverage this error message to give more information about the error, it would be an issue here as the end result is vastly different: from a `return False` to a `raise Exception`. Raising an exception here would result in a non-understandable error that would be complex to diagnose.

Instead, we choose to check if the folder is a git repository when an error is detected: if it is not, then the file is not tracked with GIT LFS. If it is a git repository but the command still resulted in an error, the error is raised.

Another possibility would have been to force the locale to be a given language, such as English with the following environment variable set: `LC_ALL=en_EN` before launching the program. This, however, relies on the user having the English language pack already installed in their environment, which may not be the case.