### PR TITLE
Adding a handler

### DIFF
--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -232,6 +232,7 @@ def lfs_log_progress():
 
     with tempfile.TemporaryDirectory() as tmpdir:
         os.environ["GIT_LFS_PROGRESS"] = os.path.join(tmpdir, "lfs_progress")
+        logger.debug(f"Following progress in {os.environ['GIT_LFS_PROGRESS']}")
 
         exit_event = threading.Event()
         x = threading.Thread(target=output_progress, args=(exit_event,), daemon=True)

--- a/src/huggingface_hub/utils/logging.py
+++ b/src/huggingface_hub/utils/logging.py
@@ -66,7 +66,8 @@ def _get_default_logging_level():
 
 def _configure_library_root_logger() -> None:
     library_root_logger = _get_library_root_logger()
-    library_root_logger.setLevel(logging.INFO)
+    library_root_logger.addHandler(logging.StreamHandler())
+    library_root_logger.setLevel(_get_default_logging_level())
 
 
 def _reset_library_root_logger() -> None:


### PR DESCRIPTION
Without setting a default handler, the `logging` library defaults to using the fallback logger which has a level of `WARNING` which cannot be updated. Linked issue in `datasets`: https://github.com/huggingface/datasets/issues/2832