### PR TITLE
Add text2image max-width

### DIFF
--- a/widgets/src/lib/InferenceWidget/widgets/TextToImageWidget/TextToImageWidget.svelte
+++ b/widgets/src/lib/InferenceWidget/widgets/TextToImageWidget/TextToImageWidget.svelte
@@ -122,7 +122,9 @@
 	</svelte:fragment>
 	<svelte:fragment slot="bottom">
 		{#if output.length}
-			<img class="mt-4 object-contain" src={output} alt="" />
+			<div class="flex justify-center mt-4">
+				<img class="max-w-sm object-contain" src={output} alt="" />
+			</div>
 		{/if}
 	</svelte:fragment>
 </WidgetWrapper>


### PR DESCRIPTION
Render images in their original size (output from pipeline) and clip the size with `max-width` css if needed.
Fixes the problem of images being rendered as too big:
<img width="800" alt="Screenshot 2021-08-30 at 10 01 31" src="https://user-images.githubusercontent.com/11827707/131306537-da5f9e82-8847-4016-a43d-6fdfcddf82db.png">
