### PR TITLE
Fix link to library tags image

### DIFF
--- a/docs/hub/adding-a-library.md
+++ b/docs/hub/adding-a-library.md
@@ -147,7 +147,7 @@ understanding of Typescript isn't necessary to edit the file.
 Additionally, this will add a tag with which users may filter models. All models from your library will 
 be easily identifiable!
 
-![assets/libraries-tags.png](assets/libraries-tags.png)
+![/docs/assets/hub/libraries-tags.png](/docs/assets/hub/libraries-tags.png)
 
 ## Upstream: creating repositories and uploading files to the hub
 


### PR DESCRIPTION
This PR fixes a broken link to one of the images in the docs.

Before
<img width="904" alt="Screen Shot 2021-09-03 at 10 19 54" src="https://user-images.githubusercontent.com/26859204/131974352-a25d8f2f-c4be-420c-ae71-10db6ebf3390.png">

After
<img width="1103" alt="Screen Shot 2021-09-03 at 10 19 47" src="https://user-images.githubusercontent.com/26859204/131974405-f204d405-421c-4c63-8d77-2c7d4d570709.png">
