### PR TITLE
Non blocking git push

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,5 +127,6 @@ dmypy.json
 # Pyre type checker
 .pyre/
 .vscode/
+.idea/
 
 .DS_Store

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -1,3 +1,4 @@
+import atexit
 import os
 import re
 import subprocess
@@ -6,7 +7,7 @@ import threading
 import time
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Iterator, List, Optional, Union
+from typing import Callable, Iterator, List, Optional, Tuple, Union
 
 from tqdm.auto import tqdm
 
@@ -18,6 +19,70 @@ from .utils import logging
 
 
 logger = logging.get_logger(__name__)
+
+
+class CommandInProgress:
+    def __init__(
+        self,
+        title: str,
+        is_done_method: Callable,
+        status_method: Callable,
+        process: subprocess.Popen,
+    ):
+        self.title = title
+        self._is_done = is_done_method
+        self._status = status_method
+        self._process = process
+        self._stderr = ""
+        self._stdout = ""
+
+    @property
+    def is_done(self) -> bool:
+        """
+        Whether the process is done.
+        """
+        return self._is_done()
+
+    @property
+    def status(self) -> int:
+        """
+        The exit code/status of the current action. Will return `0` if the command has completed
+        successfully, and a number between 1 and 255 if the process errored-out.
+
+        Will return -1 if the command is still ongoing.
+        """
+        return self._status()
+
+    @property
+    def failed(self) -> bool:
+        """
+        Whether the process errored-out.
+        """
+        return self.status > 0
+
+    @property
+    def stderr(self) -> str:
+        """
+        The current output message on the standard error.
+        """
+        self._stderr += self._process.stderr.read()
+        return self._stderr
+
+    @property
+    def stdout(self) -> str:
+        """
+        The current output message on the standard output.
+        """
+        self._stdout += self._process.stdout.read()
+        return self._stdout
+
+    def __repr__(self):
+        status = self.status
+
+        if status == -1:
+            status = "running"
+
+        return f"[{self.title} command, status code: {status}, {'in progress.' if not self.is_done else 'finished.'} PID: {self._process.pid}]"
 
 
 def is_git_repo(folder: Union[str, Path]) -> bool:
@@ -154,6 +219,25 @@ def is_tracked_upstream(folder: Union[str, Path]) -> bool:
         return False
 
 
+def commits_to_push(folder: Union[str, Path], upstream: Optional[str] = None) -> int:
+    """
+    Check the number of commits that would be pushed upstream
+    """
+    try:
+        command = f"git cherry -v {upstream or ''}"
+        result = subprocess.run(
+            command.split(),
+            stderr=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            encoding="utf-8",
+            check=True,
+            cwd=folder,
+        )
+        return len(result.stdout.split("\n")) - 1
+    except subprocess.CalledProcessError as exc:
+        raise EnvironmentError(exc.stderr)
+
+
 @contextmanager
 def lfs_log_progress():
     """
@@ -261,6 +345,8 @@ class Repository:
     though not a lot here (if any) is actually specific to huggingface.co.
     """
 
+    command_queue: List[CommandInProgress]
+
     def __init__(
         self,
         local_dir: str,
@@ -307,6 +393,7 @@ class Repository:
         os.makedirs(local_dir, exist_ok=True)
         self.local_dir = os.path.join(os.getcwd(), local_dir)
         self.repo_type = repo_type
+        self.command_queue = []
         self.private = private
 
         self.check_git_versions()
@@ -347,6 +434,10 @@ class Repository:
 
         if revision is not None:
             self.git_checkout(revision, create_branch_ok=True)
+
+        # This ensures that all commands exit before exiting the Python runtime.
+        # This will ensure all pushes register on the hub, even if other errors happen in subsequent operations.
+        atexit.register(self.wait_for_commands)
 
     @property
     def current_branch(self):
@@ -651,7 +742,9 @@ class Repository:
 
         return deleted_files
 
-    def lfs_track(self, patterns: Union[str, List[str]], filename: bool = False):
+    def lfs_track(
+        self, patterns: Union[str, List[str]], filename: Optional[bool] = False
+    ):
         """
         Tell git-lfs to track those files.
 
@@ -718,7 +811,7 @@ class Repository:
         except subprocess.CalledProcessError as exc:
             raise EnvironmentError(exc.stderr)
 
-    def auto_track_large_files(self, pattern=".") -> List[str]:
+    def auto_track_large_files(self, pattern: Optional[str] = ".") -> List[str]:
         """
         Automatically track large files with git-lfs
         """
@@ -767,7 +860,9 @@ class Repository:
         except subprocess.CalledProcessError as exc:
             raise EnvironmentError(exc.stderr)
 
-    def git_add(self, pattern=".", auto_lfs_track=False):
+    def git_add(
+        self, pattern: Optional[str] = ".", auto_lfs_track: Optional[bool] = False
+    ):
         """
         git add
 
@@ -794,7 +889,7 @@ class Repository:
         except subprocess.CalledProcessError as exc:
             raise EnvironmentError(exc.stderr)
 
-    def git_commit(self, commit_message="commit files to HF hub"):
+    def git_commit(self, commit_message: str = "commit files to HF hub"):
         """
         git commit
         """
@@ -814,36 +909,91 @@ class Repository:
             else:
                 raise EnvironmentError(exc.stdout)
 
-    def git_push(self, upstream=None) -> str:
+    def git_push(
+        self,
+        upstream: Optional[str] = None,
+        blocking: Optional[bool] = True,
+    ) -> Union[str, Tuple[str, CommandInProgress]]:
         """
         git push
 
-        Returns url to commit on remote repo.
+        If used without setting `blocking`, will return url to commit on remote repo.
+        If used with `blocking=True`, will return a tuple containing the url to commit
+        and the command object to follow for information about the process.
+
+        Args:
+            upstream (`str`, `optional`):
+                Upstream to which this should push. If not specified, will push
+                to the lastly defined upstream or to the default one (`origin main`).
+            blocking (`bool`, defaults to `True`):
+                Whether the function should return only when the push has finished.
+                Setting this to `False` will return an `CommandInProgress` object
+                which has an `is_done` property. This property will be set to
+                `True` when the push is finished.
         """
         command = "git push"
 
         if upstream:
             command += f" --set-upstream {upstream}"
 
+        number_of_commits = commits_to_push(self.local_dir, upstream)
+
+        if number_of_commits > 1:
+            logger.warning(
+                f"Several commits ({number_of_commits}) will be pushed upstream."
+            )
+            if blocking:
+                logger.warning("The progress bars may be unreliable.")
+
         try:
             with lfs_log_progress():
-                stderr = subprocess.run(
+                process = subprocess.Popen(
                     command.split(),
                     stderr=subprocess.PIPE,
                     stdout=subprocess.PIPE,
-                    check=True,
                     encoding="utf-8",
                     cwd=self.local_dir,
-                ).stderr.strip()
+                )
+
+                if blocking:
+                    stdout, stderr = process.communicate()
+                    return_code = process.poll()
+                    process.kill()
+
+                    if len(stderr):
+                        logger.warning(stderr)
+
+                    if return_code:
+                        raise subprocess.CalledProcessError(
+                            return_code, process.args, output=stdout, stderr=stderr
+                        )
+
         except subprocess.CalledProcessError as exc:
             raise EnvironmentError(exc.stderr)
 
-        if len(stderr):
-            logger.warning(stderr)
+        if not blocking:
+
+            def status_method():
+                status = process.poll()
+                if status is None:
+                    return -1
+                else:
+                    return status
+
+            command = CommandInProgress(
+                "push",
+                is_done_method=lambda: process.poll() is not None,
+                status_method=status_method,
+                process=process,
+            )
+
+            self.command_queue.append(command)
+
+            return self.git_head_commit_url(), command
 
         return self.git_head_commit_url()
 
-    def git_checkout(self, revision, create_branch_ok=False):
+    def git_checkout(self, revision: str, create_branch_ok: Optional[bool] = False):
         """
         git checkout a given revision
 
@@ -882,24 +1032,34 @@ class Repository:
                 except subprocess.CalledProcessError as exc:
                     raise EnvironmentError(exc.stderr)
 
-    def push_to_hub(self, commit_message: str = "commit files to HF hub") -> str:
+    def push_to_hub(
+        self,
+        commit_message: Optional[str] = "commit files to HF hub",
+        blocking: Optional[bool] = True,
+    ) -> str:
         """
         Helper to add, commit, and push files to remote repository on the HuggingFace Hub.
         Will automatically track large files (>10MB).
 
         Args:
-            commit_message: commit message.
+            commit_message (`str`):
+                Message to use for the commit.
+            blocking (`bool`, `optional`, defaults to `True`):
+                Whether the function should return only when the `git push` has finished.
         """
         self.git_add(auto_lfs_track=True)
         self.git_commit(commit_message)
-        return self.git_push(upstream=f"origin {self.current_branch}")
+        return self.git_push(
+            upstream=f"origin {self.current_branch}", blocking=blocking
+        )
 
     @contextmanager
     def commit(
         self,
         commit_message: str,
         branch: Optional[str] = None,
-        track_large_files: bool = True,
+        track_large_files: Optional[bool] = True,
+        blocking: Optional[bool] = True,
     ):
         """
         Context manager utility to handle committing to a repository. This automatically tracks large files (>10Mb)
@@ -912,6 +1072,8 @@ class Repository:
                 The branch on which the commit will appear. This branch will be checked-out before any operation.
             track_large_files (`bool`, `optional`, defaults to `True`):
                 Whether to automatically track large files or not. Will do so by default.
+            blocking (`bool`, `optional`, defaults to `True`):
+                Whether the function should return only when the `git push` has finished.
 
         Examples:
 
@@ -965,7 +1127,9 @@ class Repository:
                     raise e
 
             try:
-                self.git_push(upstream=f"origin {self.current_branch}")
+                self.git_push(
+                    upstream=f"origin {self.current_branch}", blocking=blocking
+                )
             except OSError as e:
                 # If no changes are detected, there is nothing to commit.
                 if "could not read Username" in str(e):
@@ -976,3 +1140,29 @@ class Repository:
                     raise e
 
             os.chdir(current_working_directory)
+
+    @property
+    def commands_failed(self):
+        return [c for c in self.command_queue if c.status > 0]
+
+    @property
+    def commands_in_progress(self):
+        return [c for c in self.command_queue if not c.is_done]
+
+    def wait_for_commands(self):
+        index = 0
+        for command_failed in self.commands_failed:
+            logger.error(
+                f"The {command_failed.title} command with PID {command_failed._process.pid} failed."
+            )
+            logger.error(command_failed.stderr)
+
+        while self.commands_in_progress:
+            if index % 10 == 0:
+                logger.error(
+                    f"Waiting for the following commands to finish before shutting down: {self.commands_in_progress}."
+                )
+
+            index += 1
+
+            time.sleep(1)

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -324,11 +324,9 @@ class RepositoryTest(RepositoryCommonTest):
         # Create dummy files
         # one is lfs-tracked, the other is not.
         with open(os.path.join(WORKING_REPO_DIR, "dummy.txt"), "w") as f:
-            f.write("hello")
-        with open(os.path.join(WORKING_REPO_DIR, "model.bin"), "w") as f:
-            f.write("hello")
+            f.write(str([[1] * 10000] * 1000))
 
-        repo.git_add()
+        repo.git_add(auto_lfs_track=True)
         repo.git_commit()
         url, result = repo.git_push(blocking=False)
 

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -324,7 +324,7 @@ class RepositoryTest(RepositoryCommonTest):
         # Create dummy files
         # one is lfs-tracked, the other is not.
         with open(os.path.join(WORKING_REPO_DIR, "dummy.txt"), "w") as f:
-            f.write(str([[1] * 10000] * 1000))
+            f.write(str([[[1] * 10000] * 1000] * 10))
 
         repo.git_add(auto_lfs_track=True)
         repo.git_commit()

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -244,15 +244,105 @@ class RepositoryTest(RepositoryCommonTest):
 
         repo.git_add()
         repo.git_commit()
-        try:
-            url = repo.git_push()
-        except subprocess.CalledProcessError as exc:
-            print(exc.stderr)
-            raise exc
+        url = repo.git_push()
         # Check that the returned commit url
         # actually exists.
         r = requests.head(url)
         r.raise_for_status()
+
+        shutil.rmtree(WORKING_REPO_DIR)
+
+    def test_add_commit_push_non_blocking(self):
+        repo = Repository(
+            WORKING_REPO_DIR,
+            clone_from=self._repo_url,
+            use_auth_token=self._token,
+            git_user="ci",
+            git_email="ci@dummy.com",
+        )
+
+        # Create dummy files
+        # one is lfs-tracked, the other is not.
+        with open(os.path.join(WORKING_REPO_DIR, "dummy.txt"), "w") as f:
+            f.write("hello")
+        with open(os.path.join(WORKING_REPO_DIR, "model.bin"), "w") as f:
+            f.write("hello")
+
+        repo.git_add()
+        repo.git_commit()
+        url, result = repo.git_push(blocking=False)
+        # Check that the returned commit url
+        # actually exists.
+
+        if result._process.poll() is None:
+            self.assertEqual(result.status, -1)
+
+        while not result.is_done:
+            time.sleep(0.5)
+
+        self.assertTrue(result.is_done)
+        self.assertEqual(result.status, 0)
+
+        r = requests.head(url)
+        r.raise_for_status()
+
+        shutil.rmtree(WORKING_REPO_DIR)
+
+    def test_context_manager_non_blocking(self):
+        repo = Repository(
+            WORKING_REPO_DIR,
+            clone_from=self._repo_url,
+            use_auth_token=self._token,
+            git_user="ci",
+            git_email="ci@dummy.com",
+        )
+
+        with repo.commit("New commit", blocking=False):
+            with open(os.path.join(WORKING_REPO_DIR, "dummy.txt"), "w") as f:
+                f.write("hello")
+
+        while repo.commands_in_progress:
+            time.sleep(1)
+
+        self.assertEqual(len(repo.commands_in_progress), 0)
+        self.assertEqual(len(repo.command_queue), 1)
+        self.assertEqual(repo.command_queue[-1].status, 0)
+        self.assertEqual(repo.command_queue[-1].is_done, True)
+        self.assertEqual(repo.command_queue[-1].title, "push")
+
+        shutil.rmtree(WORKING_REPO_DIR)
+
+    def test_add_commit_push_non_blocking_process_killed(self):
+        repo = Repository(
+            WORKING_REPO_DIR,
+            clone_from=self._repo_url,
+            use_auth_token=self._token,
+            git_user="ci",
+            git_email="ci@dummy.com",
+        )
+
+        # Create dummy files
+        # one is lfs-tracked, the other is not.
+        with open(os.path.join(WORKING_REPO_DIR, "dummy.txt"), "w") as f:
+            f.write("hello")
+        with open(os.path.join(WORKING_REPO_DIR, "model.bin"), "w") as f:
+            f.write("hello")
+
+        repo.git_add()
+        repo.git_commit()
+        url, result = repo.git_push(blocking=False)
+
+        result._process.kill()
+
+        while result._process.poll() is None:
+            time.sleep(0.5)
+
+        self.assertTrue(result.is_done)
+        self.assertEqual(result.status, -9)
+
+        r = requests.head(url)
+        with self.assertRaises(requests.exceptions.HTTPError):
+            r.raise_for_status()
 
         shutil.rmtree(WORKING_REPO_DIR)
 

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -338,10 +338,6 @@ class RepositoryTest(RepositoryCommonTest):
         self.assertTrue(result.is_done)
         self.assertEqual(result.status, -9)
 
-        r = requests.head(url)
-        with self.assertRaises(requests.exceptions.HTTPError):
-            r.raise_for_status()
-
         shutil.rmtree(WORKING_REPO_DIR)
 
     def test_clone_with_endpoint(self):


### PR DESCRIPTION
This PR introduces a non-blocking git push as asked in https://github.com/huggingface/huggingface_hub/issues/169 and proposed by @cccntu in https://github.com/huggingface/huggingface_hub/pull/171.

It is currently painful to have to wait until a `git push` is over before continuing to something else. Since this uses nothing else than bandwidth, it is fine for it to happen behind the scenes.

This implementation:
- Implements a `blocking` parameter to `git_push` and the `commit` context manager; these variables default to `True`.
- In case of `blocking=False`, outputs a variable that can be monitored to follow the status of the `git push` command
- In case of `blocking=False`, outputs a variable that can be monitored to ensure the `git push` command has terminated
- These variables are added to the instance variable `command_queue` to be managed. More information about this can be found below.
- This implementation leverages the `atexit` official lib to ensure that all processes have completed before exiting the Python runtime.
- The progress bars are not managed when using a `blocking=False` parameter.
- Implements a warning when several commits are about to be pushed. The progress bars may be unreliable as a single progress bar may monitor the upload of several versions of a single file, therefore resulting in a jump between the two uploads on the progress bars.

It is recommended to monitor the progress of the current push before attempting a second one; however, several pushes may be launched concurrently. See below for the expected behaviors:

### What happens when two git pushes are done simultaneously?

If two identical git pushes are done, then no error in the workflow will happen. The remote correctly registers the updated version.

Two times more bandwidth is consumed as both pushes will upload all files.

### What happens when two git pushes are done simultaneously, with the second git push having one or several additional commits?

All commits are correctly registered on the remote. More bandwidth is consumed as both pushes will upload all files.

### What happens if one of the pushes errors out?

Given that the pushes are independent of each other as the remote isn't updated until a push is complete, the workflow should complete.

---

## The `command_queue`

This implementation implements a `command_queue` so that users may be aware of the current status of all commands launched.

It can be accessed as follows:

```py
# Access to command queue
command_queue = repo.command_queue

# Accessing a single command
last_command = repo.command_queue[-1]

# Vizualizing the command
print(last_command)
# [push command, status code: running, in progress. PID: 299167]

# Accessing the command's properties
last_command.status
last_command.is_done
last_command.title
last_command.stderr
last_command.stdout

# Accessing the commands that are currently in progress
commands_in_progress = repo.commands_in_progress

# Accessing the commands that failed
commands_failed = repo.commands_failed
```
