### PR TITLE
[RFC] Proposal of a non git-based mixin

### DIFF
--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -1,14 +1,14 @@
 import json
 import os
+import tempfile
 from pathlib import Path
-from typing import Dict, Optional, Union
+from typing import Dict, List, Optional, Union
 
 import requests
 
 from .constants import CONFIG_NAME, PYTORCH_WEIGHTS_NAME
 from .file_download import hf_hub_download, is_torch_available
 from .hf_api import HfApi, HfFolder
-from .repository import Repository
 from .utils import logging
 
 
@@ -58,12 +58,14 @@ class ModelHubMixin:
                 json.dump(config, f)
 
         # saving model weights/files
-        self._save_pretrained(save_directory, **kwargs)
+        files = self._save_pretrained(save_directory, **kwargs)
 
         if push_to_hub:
             return self.push_to_hub(save_directory, **kwargs)
 
-    def _save_pretrained(self, save_directory, **kwargs):
+        return files
+
+    def _save_pretrained(self, save_directory, **kwargs) -> List[str]:
         """
         Overwrite this method in subclass to define how to save your model.
         """
@@ -254,9 +256,9 @@ class ModelHubMixin:
             repo_path_or_name = repo_url.split("/")[-1]
 
         # If no URL is passed and there's no path to a directory containing files, create a repo
-        if repo_url is None and not os.path.exists(repo_path_or_name):
+        if repo_url is None:
             repo_name = Path(repo_path_or_name).name
-            repo_url = HfApi(endpoint=api_endpoint).create_repo(
+            HfApi(endpoint=api_endpoint).create_repo(
                 token,
                 repo_name,
                 organization=organization,
@@ -265,22 +267,25 @@ class ModelHubMixin:
                 exist_ok=True,
             )
 
-        repo = Repository(
-            repo_path_or_name,
-            clone_from=repo_url,
-            use_auth_token=use_auth_token,
-            git_user=git_user,
-            git_email=git_email,
-        )
-        repo.git_pull(rebase=True)
+        name = Path(repo_path_or_name).name
 
         # Save the files in the cloned repo
-        self.save_pretrained(repo_path_or_name, config=config)
+        with tempfile.TemporaryDirectory() as tmp:
+            saved_path = Path(tmp) / name
+            files = self.save_pretrained(saved_path, config=config)
+            api = HfApi(endpoint=api_endpoint)
 
-        # Commit and push!
-        repo.git_add()
-        repo.git_commit(commit_message)
-        return repo.git_push()
+            if organization is not None:
+                name = "/".join([organization, name])
+            else:
+                whoami_info = api.whoami(token)
+                user = whoami_info["name"]
+                name = "/".join([user, name])
+
+            for file in files:
+                common_prefix = os.path.commonprefix([saved_path, file])
+                relative_path = os.path.relpath(file, common_prefix)
+                api.upload_file(token, file, path_in_repo=relative_path, repo_id=name)
 
 
 class PyTorchModelHubMixin(ModelHubMixin):
@@ -308,13 +313,15 @@ class PyTorchModelHubMixin(ModelHubMixin):
             >>> model = MyModel.from_pretrained("username/mymodel@main")
         """
 
-    def _save_pretrained(self, save_directory):
+    def _save_pretrained(self, save_directory) -> List[str]:
         """
         Overwrite this method in case you don't want to save complete model, rather some specific layers
         """
         path = os.path.join(save_directory, PYTORCH_WEIGHTS_NAME)
         model_to_save = self.module if hasattr(self, "module") else self
         torch.save(model_to_save.state_dict(), path)
+
+        return [path]
 
     @classmethod
     def _from_pretrained(


### PR DESCRIPTION
This proposal is a request for comments and a proposal for a non-git-based mixin. The current Mixin approach uses a git workflow in order to contribute files to the hub. This, unfortunately, has drawbacks with limited advantages. I will take the `PyTorchModelHubMixin` as an example. Here's a typical use-case with the mixin:

```py
import torch
from huggingface_hub import PyTorchModelHubMixin

class MyModel(torch.nn.Module, PyTorchModelHubMixin):
    def __init__(self):
        super().__init__()
        self.transformer = torch.nn.Transformer()

model = MyModel()
model.push_to_hub(repo_path_or_name="<path_to_repo>")
```

This will:
- Create the repo if it doesn't exist
- Clone the repo in the `<path_to_repo>`
- Call `save_pretrained` in the `<path_to_repo>`
- Add, commit & push to the remote

## Issues encountered

There are points of friction with this approach, which are detailed below.

### `save_pretrained` and unrelated folders

The `save_pretrained` method doesn't need to be called before as `push_to_hub` already saves files in a local folder - but now calling it before calling `push_to_hub` will result in an error.

```py
model = MyModel()
model.save_pretrained("<path_to_repo>")
model.push_to_hub(repo_path_or_name="<path_to_repo>"
```

This will not work as the folder `<path_to_repo>` is now a non-git folder in which the new `<user>/<path_to_repo>` repository would need to be cloned.

> <details>
> <summary>Why don't we allow cloning remote repositories in non-empty local folders?</summary>
> 
> We try to follow `git` to the letter (albeit with a few tweaks that make user experience more friendly). `git` does not support cloning repositories in non-empty folders as some complex questions arise: 
> - Should the newly instantiated git folder pull the remote files, or should it simply have the remote set?
> - In case we want to pull the files, which files should overwrite which?
> - What happens if the folder is already a git repository? Should the clone behave differently according to what is contained in the folder?
> 
> </details>

### Existing changes in the current directory

Since the entire folder in which the model is saved is now a git folder, any file saved in it will also be pushed to the remote.

```py
model = MyModel()
model.push_to_hub(repo_path_or_name="<path_to_repo>")

with open("<path_to_repo>/README.md", "w+") as f:
    f.write("# My model")

model.push_to_hub(repo_path_or_name="<path_to_repo>")
```

This will also push the `README.md` even though the method seems to only push the model (the name being `model.push_to_hub`). This can be a problem, for example with `transformers` we need to have both the model and tokenizer in the same folder - but each of those objects has a `push_to_hub` method. Each `push_to_hub` method will add everything, commit and push

:warning: This could be potentially fixed by only doing `git add <name_of_file_in_particular>` (which isn't the case in any mixin right now)

### No two consecutive `push_to_hub`

Piggy-backing on the issue above, calling `push_to_hub` twice in a row without any changes will result in an error:

```
OSError: On branch main
Your branch is up to date with 'origin/main'.

nothing to commit, working tree clean
```

This would happen in case users were misled into thinking

```py
model.push_to_hub(...)
tokenizer.push_to_hub(...)
```

:warning: This too could be potentially fixed by only doing `git add <name_of_file_in_particular>` (which isn't the case in any mixin right now)

### `push_to_hub` indicates something that is different than what is actually happening

The `push_to_hub` name implies that the files are pushed to the hub. However, what is happening under the hood is very different as it maintains a local clone of the remote repository. This method will apply changes to the local clone while its name implies it will only push files to the remote.

Therefore, I believe the following is misleading:

```py
# Existing <path_to_repo> with a past model
model.push_to_hub(repo_path_or_name="<path_to_repo>")
```

Where a user may believe that by calling `push_to_hub` they have simply published the new model weights on the repo, the local clone of that repo is now full of remote and potentially unexpected (if working in collaboration with others) changes. 

## Proposal

IMO, the git-based approach is solid in cases where maintaining a local clone of the repository makes sense:
- During training, in order to store different checkpoints
- During training, In order to store tensorboard traces and other training artefacts 
- In order to have a fluid versioning system

I believe it is a valid approach for tools like the `Trainer` or when users want to keep a local versioned copy of their work before pushing everything remotely.

However, I believe it is ill-suited to the management of separate, independent items like a `model`. I believe that the `push_to_hub` method indicates that it will upload only the necessary files to the hub, and is, therefore, better suited to a simple HTTP post request rather than a full-blown local git workflow.

This PR offers an alternative approach leveraging the `upload_file` method instead of the `Repository` as the backbone for uploads.

This enables the following use-cases:

```py
import torch
from huggingface_hub import PyTorchModelHubMixin

class MyModel(torch.nn.Module, PyTorchModelHubMixin):
    def __init__(self):
        super().__init__()

        self.transformer = torch.nn.Linear(2, 2)

model = MyModel()

model.save_pretrained("<local_path>")
# Already saved in non-git folder, but still works
model.push_to_hub(repo_path_or_name="<local_path>")
```

```py
import torch
from huggingface_hub import PyTorchModelHubMixin


class MyModel(torch.nn.Module, PyTorchModelHubMixin):
    def __init__(self):
        super().__init__()

        self.transformer = torch.nn.Linear(2, 2)


model = MyModel()
model.push_to_hub(repo_path_or_name="<local_path>")
# Already pushed, but still works
model.push_to_hub(repo_path_or_name="<local_path>")
```

This implementation works with a temporary directory which means that the user doesn't need to be aware of a local directory to maintain -> only the object's serialization files will be pushed to the hub with no local side effects. 

This is a POC with a few shortcomings that would need to be resolved before continuing if this is of interest:
- The maximum file size is currently 5GB with HTTP post requests
- There are no progress bars currently with `upload_file`
- A list of files must be returned by the `_save_pretrained` method in order to know which files should be uploaded to the hub
- Tests and doc :)

Looking forward to your comments!