### PR TITLE
:bug: Fix timm code sample

### DIFF
--- a/widgets/src/lib/interfaces/Libraries.ts
+++ b/widgets/src/lib/interfaces/Libraries.ts
@@ -163,7 +163,7 @@ const tensorflowtts = (model: ModelData) => {
 const timm = (model: ModelData) =>
 `import timm
 
-model = timm.create_model("${model.modelId}", pretrained=True)`;
+model = timm.create_model("hf_hub:${model.modelId}", pretrained=True)`;
 
 const sklearn = (model: ModelData) => 
 `from huggingface_hub import hf_hub_download


### PR DESCRIPTION
In `timm`, you must add the prefix `hf_hub:` before any Hugging Face model identifier when using `timm.create_model`. 

The code sample currently being shown on the hub is incorrect, and will fail when you run it. 