### PR TITLE
display git push warnings

### DIFF
--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -827,10 +827,10 @@ class Repository:
                 ).stderr.strip()
         except subprocess.CalledProcessError as exc:
             raise EnvironmentError(exc.stderr)
-        
+
         if len(stderr):
             logger.warning(stderr)
-        
+
         return self.git_head_commit_url()
 
     def git_checkout(self, revision, create_branch_ok=False):

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -817,17 +817,20 @@ class Repository:
 
         try:
             with lfs_log_progress():
-                subprocess.run(
+                stderr = subprocess.run(
                     command.split(),
                     stderr=subprocess.PIPE,
                     stdout=subprocess.PIPE,
                     check=True,
                     encoding="utf-8",
                     cwd=self.local_dir,
-                )
+                ).stderr.strip()
         except subprocess.CalledProcessError as exc:
             raise EnvironmentError(exc.stderr)
-
+        
+        if len(stderr):
+            logger.warning(stderr)
+        
         return self.git_head_commit_url()
 
     def git_checkout(self, revision, create_branch_ok=False):

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -500,7 +500,7 @@ class Repository:
                 if not in_repository:
                     raise EnvironmentError(
                         "Tried to clone a repository in a non-empty folder that isn't a git repository. If you really "
-                        "want to do this, do it manually:\m"
+                        "want to do this, do it manually:\n"
                         "git init && git remote add origin && git pull origin main\n"
                         " or clone repo to a new folder and move your existing files there afterwards."
                     )


### PR DESCRIPTION
- git push errors rejections should be displayed well, as discussed with @LysandreJik, we'll verify this once https://github.com/huggingface/moon-landing/pull/958 is in production.
- **But** git push will also output model-card warnings (but git push accepted) in stderr thatn we want huggingface_hub to display. cf. https://github.com/huggingface/moon-landing/pull/958