### PR TITLE
Add a widget to login in notebook

### DIFF
--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -18,6 +18,7 @@
 
 __version__ = "0.0.16"
 
+from .commands.user import notebook_login
 from .constants import (
     CONFIG_NAME,
     FLAX_WEIGHTS_NAME,

--- a/src/huggingface_hub/commands/user.py
+++ b/src/huggingface_hub/commands/user.py
@@ -158,26 +158,7 @@ class LoginCommand(BaseUserCommand):
         )
         username = input("Username: ")
         password = getpass()
-        try:
-            token = self._api.login(username, password)
-        except HTTPError as e:
-            # probably invalid credentials, display error message.
-            print(e)
-            print(ANSI.red(e.response.text))
-            exit(1)
-        HfFolder.save_token(token)
-        print("Login successful")
-        print("Your token has been saved to", HfFolder.path_token)
-        helpers = currently_setup_credential_helpers()
-
-        if "store" not in helpers:
-            print(
-                ANSI.red(
-                    "Authenticated through git-crendential store but this isn't the helper defined on your machine.\nYou "
-                    "will have to re-authenticate when pushing to the Hugging Face Hub. Run the following command in your "
-                    "terminal to set it as the default\n\ngit config --global credential.helper store"
-                )
-            )
+        _login(self._api, username, password)
 
 
 class WhoamiCommand(BaseUserCommand):
@@ -339,15 +320,17 @@ def notebook_login():
     def login_event(t):
         username = input_widget.value
         password = password_widget.value
+        # Erase password and clear value to make sure it's not saved in the notebook.
+        password_widget.value = ""
         clear_output()
-        _login(username, password)
+        _login(HfApi(), username, password)
 
     finish_button.on_click(login_event)
 
 
-def _login(username, password):
+def _login(hf_api, username, password):
     try:
-        token = HfApi().login(username, password)
+        token = hf_api.login(username, password)
     except HTTPError as e:
         # probably invalid credentials, display error message.
         print(e)


### PR DESCRIPTION
This PR adds a widget to be able to login to the HF website from a Jupyter Notebook. The command
```
! huggingface-cli login
```
does not work in a Jupyter notebook, as one cannot write in the output of the cell (it does work in a colab however).

With this PR, a user can do:
```
from huggingface_hub import notebook_login

notebook_login()
```
and they will get the following:
![image](https://user-images.githubusercontent.com/35901082/132546156-8822cb5e-d006-4ce1-9034-e344da4cded6.png)

Filling the username and password will then login like the `huggingface-cli login` command.