### PR TITLE
Add auth to snapshot download

### DIFF
--- a/src/huggingface_hub/snapshot_download.py
+++ b/src/huggingface_hub/snapshot_download.py
@@ -18,6 +18,7 @@ def snapshot_download(
     library_name: Optional[str] = None,
     library_version: Optional[str] = None,
     user_agent: Union[Dict, str, None] = None,
+    token: Union[str, None] = None,
 ) -> str:
     """
     Downloads a whole snapshot of a repo's files at the specified revision.
@@ -42,22 +43,16 @@ def snapshot_download(
         cache_dir = str(cache_dir)
 
     _api = HfApi()
-    model_info = _api.model_info(repo_id=repo_id, revision=revision)
+    model_info = _api.model_info(repo_id=repo_id, revision=revision, token=token)
 
-    storage_folder = os.path.join(
-        cache_dir, repo_id.replace("/", REPO_ID_SEPARATOR) + "." + model_info.sha
-    )
+    storage_folder = os.path.join(cache_dir, repo_id.replace("/", REPO_ID_SEPARATOR) + "." + model_info.sha)
 
     for model_file in model_info.siblings:
-        url = hf_hub_url(
-            repo_id, filename=model_file.rfilename, revision=model_info.sha
-        )
+        url = hf_hub_url(repo_id, filename=model_file.rfilename, revision=model_info.sha)
         relative_filepath = os.path.join(*model_file.rfilename.split("/"))
 
         # Create potential nested dir
-        nested_dirname = os.path.dirname(
-            os.path.join(storage_folder, relative_filepath)
-        )
+        nested_dirname = os.path.dirname(os.path.join(storage_folder, relative_filepath))
         os.makedirs(nested_dirname, exist_ok=True)
 
         path = cached_download(
@@ -67,6 +62,7 @@ def snapshot_download(
             library_name=library_name,
             library_version=library_version,
             user_agent=user_agent,
+            use_auth_token=token,
         )
 
         if os.path.exists(path + ".lock"):

--- a/src/huggingface_hub/snapshot_download.py
+++ b/src/huggingface_hub/snapshot_download.py
@@ -45,14 +45,20 @@ def snapshot_download(
     _api = HfApi()
     model_info = _api.model_info(repo_id=repo_id, revision=revision, token=token)
 
-    storage_folder = os.path.join(cache_dir, repo_id.replace("/", REPO_ID_SEPARATOR) + "." + model_info.sha)
+    storage_folder = os.path.join(
+        cache_dir, repo_id.replace("/", REPO_ID_SEPARATOR) + "." + model_info.sha
+    )
 
     for model_file in model_info.siblings:
-        url = hf_hub_url(repo_id, filename=model_file.rfilename, revision=model_info.sha)
+        url = hf_hub_url(
+            repo_id, filename=model_file.rfilename, revision=model_info.sha
+        )
         relative_filepath = os.path.join(*model_file.rfilename.split("/"))
 
         # Create potential nested dir
-        nested_dirname = os.path.dirname(os.path.join(storage_folder, relative_filepath))
+        nested_dirname = os.path.dirname(
+            os.path.join(storage_folder, relative_filepath)
+        )
         os.makedirs(nested_dirname, exist_ok=True)
 
         path = cached_download(

--- a/src/huggingface_hub/snapshot_download.py
+++ b/src/huggingface_hub/snapshot_download.py
@@ -4,7 +4,7 @@ from typing import Dict, Optional, Union
 
 from .constants import HUGGINGFACE_HUB_CACHE
 from .file_download import cached_download, hf_hub_url
-from .hf_api import HfApi
+from .hf_api import HfApi, HfFolder
 
 
 REPO_ID_SEPARATOR = "__"
@@ -18,7 +18,7 @@ def snapshot_download(
     library_name: Optional[str] = None,
     library_version: Optional[str] = None,
     user_agent: Union[Dict, str, None] = None,
-    token: Union[str, None] = None,
+    use_auth_token: Union[bool, str, None] = None,
 ) -> str:
     """
     Downloads a whole snapshot of a repo's files at the specified revision.
@@ -41,6 +41,13 @@ def snapshot_download(
         cache_dir = HUGGINGFACE_HUB_CACHE
     if isinstance(cache_dir, Path):
         cache_dir = str(cache_dir)
+
+    if use_auth_token:
+        token = HfFolder.get_token()
+        if token is None:
+            raise EnvironmentError(
+                "You specified use_auth_token=True, but a Hugging Face token was not found."
+            )
 
     _api = HfApi()
     model_info = _api.model_info(repo_id=repo_id, revision=revision, token=token)
@@ -68,7 +75,7 @@ def snapshot_download(
             library_name=library_name,
             library_version=library_version,
             user_agent=user_agent,
-            use_auth_token=token,
+            use_auth_token=use_auth_token,
         )
 
         if os.path.exists(path + ".lock"):

--- a/src/huggingface_hub/snapshot_download.py
+++ b/src/huggingface_hub/snapshot_download.py
@@ -42,7 +42,9 @@ def snapshot_download(
     if isinstance(cache_dir, Path):
         cache_dir = str(cache_dir)
 
-    if use_auth_token == True:
+    if isinstance(use_auth_token, str):
+        token = use_auth_token
+    elif use_auth_token:
         token = HfFolder.get_token()
         if token is None:
             raise EnvironmentError(

--- a/src/huggingface_hub/snapshot_download.py
+++ b/src/huggingface_hub/snapshot_download.py
@@ -50,6 +50,8 @@ def snapshot_download(
             raise EnvironmentError(
                 "You specified use_auth_token=True, but a Hugging Face token was not found."
             )
+    else:
+        token = None
 
     _api = HfApi()
     model_info = _api.model_info(repo_id=repo_id, revision=revision, token=token)

--- a/src/huggingface_hub/snapshot_download.py
+++ b/src/huggingface_hub/snapshot_download.py
@@ -42,7 +42,7 @@ def snapshot_download(
     if isinstance(cache_dir, Path):
         cache_dir = str(cache_dir)
 
-    if use_auth_token:
+    if use_auth_token == True:
         token = HfFolder.get_token()
         if token is None:
             raise EnvironmentError(

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -21,6 +21,7 @@ import time
 import unittest
 from io import BytesIO
 
+import requests
 from huggingface_hub.constants import REPO_TYPE_DATASET, REPO_TYPE_SPACE
 from huggingface_hub.file_download import cached_download
 from huggingface_hub.hf_api import (
@@ -448,6 +449,28 @@ class HfFolderTest(unittest.TestCase):
         # ^^ not an error, we test that the
         # second call does not fail.
         self.assertEqual(HfFolder.get_token(), None)
+
+
+class HfApiPrivateTest(HfApiCommonTestWithLogin):
+    def setUp(self) -> None:
+        super().setUp()
+        self._api.create_repo(token=self._token, name=REPO_NAME)
+        self._api.update_repo_visibility(
+            token=self._token, name=REPO_NAME, private=True
+        )
+
+    def tearDown(self) -> None:
+        self._api.delete_repo(token=self._token, name=REPO_NAME)
+
+    def test_model_info(self):
+        # Test we cannot access model info without a token
+        with self.assertRaisesRegex(requests.exceptions.HTTPError, "404 Client Error"):
+            _ = self._api.model_info(repo_id=f"{USER}/{REPO_NAME}")
+        # Test we can access model info with a token
+        model_info = self._api.model_info(
+            repo_id=f"{USER}/{REPO_NAME}", token=self._token
+        )
+        self.assertIsInstance(model_info, ModelInfo)
 
 
 @require_git_lfs

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -21,7 +21,6 @@ import time
 import unittest
 from io import BytesIO
 
-import requests
 from huggingface_hub.constants import REPO_TYPE_DATASET, REPO_TYPE_SPACE
 from huggingface_hub.file_download import cached_download
 from huggingface_hub.hf_api import (
@@ -449,28 +448,6 @@ class HfFolderTest(unittest.TestCase):
         # ^^ not an error, we test that the
         # second call does not fail.
         self.assertEqual(HfFolder.get_token(), None)
-
-
-class HfApiPrivateTest(HfApiCommonTestWithLogin):
-    def setUp(self) -> None:
-        super().setUp()
-        self._api.create_repo(token=self._token, name=REPO_NAME)
-        self._api.update_repo_visibility(
-            token=self._token, name=REPO_NAME, private=True
-        )
-
-    def tearDown(self) -> None:
-        self._api.delete_repo(token=self._token, name=REPO_NAME)
-
-    def test_model_info(self):
-        # Test we cannot access model info without a token
-        with self.assertRaisesRegex(requests.exceptions.HTTPError, "404 Client Error"):
-            _ = self._api.model_info(repo_id=f"{USER}/{REPO_NAME}")
-        # Test we can access model info with a token
-        model_info = self._api.model_info(
-            repo_id=f"{USER}/{REPO_NAME}", token=self._token
-        )
-        self.assertIsInstance(model_info, ModelInfo)
 
 
 @require_git_lfs

--- a/tests/test_snapshot_download.py
+++ b/tests/test_snapshot_download.py
@@ -93,6 +93,7 @@ class SnapshotDownloadTests(unittest.TestCase):
 
     def test_download_private_model(self):
         self._api.update_repo_visibility(self._token, REPO_NAME, private=True)
+
         # Test download fails without token
         with tempfile.TemporaryDirectory() as tmpdirname:
             with self.assertRaisesRegex(
@@ -101,6 +102,7 @@ class SnapshotDownloadTests(unittest.TestCase):
                 _ = snapshot_download(
                     f"{USER}/{REPO_NAME}", revision="main", cache_dir=tmpdirname
                 )
+
         # Test we can download with token from cache
         with tempfile.TemporaryDirectory() as tmpdirname:
             HfFolder.save_token(self._token)

--- a/tests/test_snapshot_download.py
+++ b/tests/test_snapshot_download.py
@@ -149,3 +149,5 @@ class SnapshotDownloadTests(unittest.TestCase):
 
             # folder name contains the revision's commit sha.
             self.assertTrue(self.second_commit_hash in storage_folder)
+
+        self._api.update_repo_visibility(self._token, REPO_NAME, private=False)


### PR DESCRIPTION
This PR adds a `use_auth_token` argument to `snapshot_download` so private repos can be downloaded from the Hub. 

## Usage

```python
from huggingface_hub import snapshot_download

# Download with explicit token
filepath = snapshot_download("some-private-repo", use_auth_token="api_XXX")
# Download with token from cache
filepath = snapshot_download("some-private-repo", use_auth_token=True)
```