### PR TITLE
Use config for Speechbrain instead of the tags

### DIFF
--- a/.github/workflows/python-api-speechbrain.yaml
+++ b/.github/workflows/python-api-speechbrain.yaml
@@ -1,0 +1,29 @@
+# TODO: Merge this with allenNLP to have a single workflow for all docker images.
+name: speechbrain-docker
+
+on:
+  pull_request:
+    paths:
+      - "api-inference-community/docker_images/speechbrain/**"
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Install dependencies
+        working-directory: api-inference-community
+        run: |
+          pip install --upgrade pip
+          pip install pytest pillow httpx
+          pip install -e .
+      - run: RUN_DOCKER_TESTS=1 pytest -sv tests/test_dockers.py::DockerImageTests::test_speechbrain
+        working-directory: api-inference-community

--- a/api-inference-community/docker_images/speechbrain/app/common.py
+++ b/api-inference-community/docker_images/speechbrain/app/common.py
@@ -1,0 +1,24 @@
+from enum import Enum
+
+from huggingface_hub import HfApi
+
+
+class ModelType(Enum):
+    # audio-to-audio
+    SEPFORMERSEPARATION = "SEPFORMERSEPARATION"
+    SPECTRALMASKENHANCEMENT = "SPECTRALMASKENHANCEMENT"
+    # automatic-speech-recognition
+    ENCODERASR = "ENCODERASR"
+    ENCODERDECODERASR = "ENCODERDECODERASR"
+    # audio-clasification
+    ENCODERCLASSIFIER = "ENCODERCLASSIFIER"
+
+
+def get_type(model_id):
+    info = HfApi().model_info(repo_id=model_id)
+    if info.config:
+        if "speechbrain" in info.config:
+            return ModelType(info.config["speechbrain"]["interface"].upper())
+        else:
+            raise ValueError("speechbrain not in config.json")
+    raise ValueError("no config.json in repository")

--- a/api-inference-community/docker_images/speechbrain/app/pipelines/audio_classification.py
+++ b/api-inference-community/docker_images/speechbrain/app/pipelines/audio_classification.py
@@ -2,12 +2,17 @@ from typing import Dict, List
 
 import numpy as np
 import torch
+from app.common import ModelType, get_type
 from app.pipelines import Pipeline
 from speechbrain.pretrained import EncoderClassifier
 
 
 class AudioClassificationPipeline(Pipeline):
     def __init__(self, model_id: str):
+        model_type = get_type(model_id)
+        if model_type != ModelType.ENCODERCLASSIFIER:
+            raise ValueError(f"{model_type.value} is invalid for audio-classification")
+
         self.model = EncoderClassifier.from_hparams(source=model_id)
 
         self.top_k = 5

--- a/api-inference-community/docker_images/speechbrain/app/pipelines/audio_to_audio.py
+++ b/api-inference-community/docker_images/speechbrain/app/pipelines/audio_to_audio.py
@@ -24,10 +24,13 @@ def interface_to_type(interface_str):
 
 def get_type(model_id):
     info = HfApi().model_info(repo_id=model_id)
-    if "speechbrain" in info.config:
-        interface_str = info.config["speechbrain"].get(
-            "interface", "SepformerSeparation"
-        )
+    if info.config:
+        if "speechbrain" in info.config:
+            interface_str = info.config["speechbrain"].get(
+                "interface", "SepformerSeparation"
+            )
+        else:
+            interface_str = "SepformerSeparation"
     else:
         interface_str = "SepformerSeparation"
     return interface_to_type(interface_str)

--- a/api-inference-community/docker_images/speechbrain/app/pipelines/audio_to_audio.py
+++ b/api-inference-community/docker_images/speechbrain/app/pipelines/audio_to_audio.py
@@ -1,17 +1,17 @@
-import json
+from enum import Enum
 from typing import List, Tuple
 
 import numpy as np
-import requests
 import torch
 from app.pipelines import Pipeline
-from speechbrain.pretrained import SepformerSeparation, SpectralMaskEnhancement
-from enum import Enum
 from huggingface_hub import HfApi
+from speechbrain.pretrained import SepformerSeparation, SpectralMaskEnhancement
+
 
 class ModelType(Enum):
     AUDIO_SOURCE_SEPARATION = 1
     SPEECH_ENHANCEMENT = 2
+
 
 def interface_to_type(interface_str):
     if interface_str == "SepformerSeparation":
@@ -19,14 +19,15 @@ def interface_to_type(interface_str):
     elif interface_str == "SpectralMaskEnhancement":
         return ModelType.SPEECH_ENHANCEMENT
     else:
-        raise ValueError(
-            f"Invalid interface: {interface_str} for Audio to Audio."
-        )
+        raise ValueError(f"Invalid interface: {interface_str} for Audio to Audio.")
+
 
 def get_type(model_id):
     info = HfApi().model_info(repo_id=model_id)
     if "speechbrain" in info.config:
-        interface_str = info.config["speechbrain"].get("interface", "SepformerSeparation")
+        interface_str = info.config["speechbrain"].get(
+            "interface", "SepformerSeparation"
+        )
     else:
         interface_str = "SepformerSeparation"
     return interface_to_type(interface_str)

--- a/api-inference-community/docker_images/speechbrain/app/pipelines/automatic_speech_recognition.py
+++ b/api-inference-community/docker_images/speechbrain/app/pipelines/automatic_speech_recognition.py
@@ -1,15 +1,17 @@
+from enum import Enum
 from typing import Dict
 
 import numpy as np
 import torch
 from app.pipelines import Pipeline
-from speechbrain.pretrained import  EncoderDecoderASR
 from huggingface_hub import HfApi
-from enum import Enum
+from speechbrain.pretrained import EncoderDecoderASR
+
 
 class ModelType(Enum):
     ENCODER_ASR = 1
     ENCODER_DECODER_ASR = 2
+
 
 def interface_to_type(interface_str):
     if interface_str == "EncoderASR":
@@ -21,23 +23,26 @@ def interface_to_type(interface_str):
             f"Invalid interface: {interface_str} for Automatic Speech Recognition."
         )
 
+
 def get_type(model_id):
     info = HfApi().model_info(repo_id=model_id)
     if info.config:
         if hasattr(info.config, "speechbrain"):
-            interface_str = info.config["speechbrain"].get("interface", "EncoderDecoderASR")
-        else: 
+            interface_str = info.config["speechbrain"].get(
+                "interface", "EncoderDecoderASR"
+            )
+        else:
             interface_str = "EncoderDecoderASR"
     else:
         interface_str = "EncoderDecoderASR"
     return interface_to_type(interface_str)
-        
+
 
 class AutomaticSpeechRecognitionPipeline(Pipeline):
     def __init__(self, model_id: str):
         model_type = get_type(model_id)
         if model_type == ModelType.ENCODER_ASR:
-            # TODO: Change once Speechbrain has new release
+            # TODO: Change once Speechbrain has new release
             self.model = EncoderDecoderASR.from_hparams(source=model_id)
         elif model_type == ModelType.ENCODER_DECODER_ASR:
             self.model = EncoderDecoderASR.from_hparams(source=model_id)

--- a/api-inference-community/docker_images/speechbrain/requirements.txt
+++ b/api-inference-community/docker_images/speechbrain/requirements.txt
@@ -1,4 +1,4 @@
 starlette==0.14.2
 api-inference-community==0.0.19
-speechbrain==0.5.7
-transformers==4.5.1
+speechbrain==0.5.10
+transformers==4.10.2

--- a/api-inference-community/docker_images/speechbrain/tests/test_api.py
+++ b/api-inference-community/docker_images/speechbrain/tests/test_api.py
@@ -17,8 +17,18 @@ TESTABLE_MODELS: Dict[str, List[str]] = {
         # Speaker recognition
         "speechbrain/spkrec-xvect-voxceleb",
     ],
-    "audio-to-audio": ["speechbrain/mtl-mimic-voicebank"],
-    "automatic-speech-recognition": ["speechbrain/asr-crdnn-commonvoice-it"],
+    "audio-to-audio": [
+        # Speech Enhancement
+        "speechbrain/mtl-mimic-voicebank",
+        # Source separation
+        "speechbrain/mtl-mimic-voicebank",
+    ],
+    "automatic-speech-recognition": [
+        # ASR with EncoderASR
+        "speechbrain/asr-wav2vec2-commonvoice-fr",
+        # ASR with EncoderDecoderASR
+        "speechbrain/asr-crdnn-commonvoice-it",
+    ],
 }
 
 

--- a/api-inference-community/docker_images/speechbrain/tests/test_api.py
+++ b/api-inference-community/docker_images/speechbrain/tests/test_api.py
@@ -21,7 +21,7 @@ TESTABLE_MODELS: Dict[str, List[str]] = {
         # Speech Enhancement
         "speechbrain/mtl-mimic-voicebank",
         # Source separation
-        "speechbrain/mtl-mimic-voicebank",
+        "speechbrain/sepformer-wham",
     ],
     "automatic-speech-recognition": [
         # ASR with EncoderASR

--- a/api-inference-community/docker_images/speechbrain/tests/test_api.py
+++ b/api-inference-community/docker_images/speechbrain/tests/test_api.py
@@ -18,13 +18,13 @@ TESTABLE_MODELS: Dict[str, List[str]] = {
         "speechbrain/spkrec-xvect-voxceleb",
     ],
     "audio-to-audio": [
-        # Speech Enhancement
+        # Speech Enhancement
         "speechbrain/mtl-mimic-voicebank",
-        # Source separation
+        # Source separation
         "speechbrain/mtl-mimic-voicebank",
     ],
     "automatic-speech-recognition": [
-        # ASR with EncoderASR
+        # ASR with EncoderASR
         "speechbrain/asr-wav2vec2-commonvoice-fr",
         # ASR with EncoderDecoderASR
         "speechbrain/asr-crdnn-commonvoice-it",

--- a/api-inference-community/docker_images/speechbrain/tests/test_api_audio_to_audio.py
+++ b/api-inference-community/docker_images/speechbrain/tests/test_api_audio_to_audio.py
@@ -55,7 +55,6 @@ class AudioToAudioTestCase(TestCase):
 
         with TestClient(self.app) as client:
             response = client.post("/", data=bpayload)
-
         self.assertEqual(
             response.status_code,
             200,
@@ -67,7 +66,7 @@ class AudioToAudioTestCase(TestCase):
         self.assertEqual(set(audio[0].keys()), {"blob", "content-type", "label"})
 
         data = base64.b64decode(audio[0]["blob"])
-        wavform = ffmpeg_read(data)
+        wavform = ffmpeg_read(data, 16000)
         self.assertGreater(wavform.shape[0], 1000)
         self.assertTrue(isinstance(audio[0]["content-type"], str))
         self.assertTrue(isinstance(audio[0]["label"], str))
@@ -100,7 +99,7 @@ class AudioToAudioTestCase(TestCase):
         self.assertEqual(set(audio[0].keys()), {"blob", "content-type", "label"})
 
         data = base64.b64decode(audio[0]["blob"])
-        wavform = ffmpeg_read(data)
+        wavform = ffmpeg_read(data, 16000)
         self.assertGreater(wavform.shape[0], 1000)
         self.assertTrue(isinstance(audio[0]["content-type"], str))
         self.assertTrue(isinstance(audio[0]["label"], str))
@@ -121,7 +120,7 @@ class AudioToAudioTestCase(TestCase):
         self.assertEqual(set(audio[0].keys()), {"blob", "content-type", "label"})
 
         data = base64.b64decode(audio[0]["blob"])
-        wavform = ffmpeg_read(data)
+        wavform = ffmpeg_read(data, 16000)
         self.assertGreater(wavform.shape[0], 1000)
         self.assertTrue(isinstance(audio[0]["content-type"], str))
         self.assertTrue(isinstance(audio[0]["label"], str))

--- a/api-inference-community/docker_images/speechbrain/tests/test_api_automatic_speech_recognition.py
+++ b/api-inference-community/docker_images/speechbrain/tests/test_api_automatic_speech_recognition.py
@@ -57,7 +57,6 @@ class AutomaticSpeecRecognitionTestCase(TestCase):
         with TestClient(self.app) as client:
             response = client.post("/", data=bpayload)
 
-        print(response.content)
         self.assertEqual(
             response.status_code,
             200,

--- a/api-inference-community/docker_images/speechbrain/tests/test_api_automatic_speech_recognition.py
+++ b/api-inference-community/docker_images/speechbrain/tests/test_api_automatic_speech_recognition.py
@@ -57,6 +57,7 @@ class AutomaticSpeecRecognitionTestCase(TestCase):
         with TestClient(self.app) as client:
             response = client.post("/", data=bpayload)
 
+        print(response.content)
         self.assertEqual(
             response.status_code,
             200,

--- a/api-inference-community/tests/test_dockers.py
+++ b/api-inference-community/tests/test_dockers.py
@@ -134,14 +134,14 @@ class DockerImageTests(unittest.TestCase):
 
         self.framework_invalid_test("speechbrain")
 
-        # source-separation
+        # source-separation
         self.framework_docker_test(
             "speechbrain",
             "audio-to-audio",
             "speechbrain/sepformer-wham",
         )
 
-        # speech-enchancement
+        # speech-enchancement
         self.framework_docker_test(
             "speechbrain",
             "audio-to-audio",

--- a/api-inference-community/tests/test_dockers.py
+++ b/api-inference-community/tests/test_dockers.py
@@ -126,14 +126,22 @@ class DockerImageTests(unittest.TestCase):
             "speechbrain/asr-crdnn-commonvoice-it",
         )
 
+        self.framework_docker_test(
+            "speechbrain",
+            "automatic-speech-recognition",
+            "speechbrain/asr-wav2vec2-commonvoice-fr",
+        )
+
         self.framework_invalid_test("speechbrain")
 
+        # source-separation
         self.framework_docker_test(
             "speechbrain",
             "audio-to-audio",
             "speechbrain/sepformer-wham",
         )
 
+        # speech-enchancement
         self.framework_docker_test(
             "speechbrain",
             "audio-to-audio",


### PR DESCRIPTION
This PR changes the `speechbrain` Inference to use the class specified in the `config` instead of basing in the model card tag. This also upgrades the `speechbrain` version so it works with `EncoderASR`.
 
CC @TParcollet