### PR TITLE
Add model info test for private models

### DIFF
--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -438,10 +438,7 @@ class HfApiPublicTest(unittest.TestCase):
 class HfApiPrivateTest(HfApiCommonTestWithLogin):
     def setUp(self) -> None:
         super().setUp()
-        self._api.create_repo(token=self._token, name=REPO_NAME)
-        self._api.update_repo_visibility(
-            token=self._token, name=REPO_NAME, private=True
-        )
+        self._api.create_repo(token=self._token, name=REPO_NAME, private=True)
 
     def tearDown(self) -> None:
         self._api.delete_repo(token=self._token, name=REPO_NAME)


### PR DESCRIPTION
In PR #340, we observed that `HfApi.model_info` isn't explicitly tested for private repositories, where the absence of a token should throw a HTTP 404 error. This PR aims to cover this case. 

I took inspiration from `HfApiPublicTest` test class to create a private version.