### PR TITLE
Add quickstart and installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ What can you find in this repo?
 
 
 ## Quickstart
+
+In this quick tour, we show you how to install the library and some of its core features.
 ### Installation
 
 To install, run:

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ What can you find in this repo?
 ## Quickstart
 
 In this quick tour, we show you how to install the library and some of its core features.
+
 ### Installation
 
 To install, run:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# `huggingface_hub`
+# Hugging Face Hub
 
 ## Welcome to the Hub repo! Here you can find all the open source things related to the Hugging Face Hub.
 
@@ -19,6 +19,123 @@ What can you find in this repo?
 * [`widgets`](https://github.com/huggingface/huggingface_hub/tree/main/widgets), the open sourced widgets that allow people to try out the models in the browser.
   * [`interfaces`](https://github.com/huggingface/huggingface_hub/tree/main/widgets/src/lib/interfaces), Typescript definition files for the Hugging Face Hub.
 * [`docs`](https://github.com/huggingface/huggingface_hub/tree/main/docs), containing the official [Hugging Face Hub documentation](https://hf.co/docs).
+
+
+## Quickstart
+### Installation
+
+To install, run:
+
+```bash
+python -m pip install -U huggingface-hub
+```
+### Extracting information from the Hub
+
+`huggingface_hub` provides a `HfApi` class that allows you to programatically interact with the Hub in various ways. For example, you can list all the public models on the Hub and apply filters via the `HfApi.list_models` function:
+
+```python
+from huggingface_hub import HfApi
+
+api = HfApi()
+
+# List all models
+api.list_models()
+
+# List only the text classification models
+api.list_models(filter="text-classification")
+
+# List only the russian models compatible with pytorch
+api.list_models(filter=("ru", "pytorch"))
+
+# List only the models trained on the "common_voice" dataset
+api.list_models(filter="dataset:common_voice")
+
+# List only the models from the spaCy library
+api.list_models(filter="spacy")
+```
+
+Similarly, you can also inspect all the public datasets on the Hub via the `HfApi.list_datasets` function:
+
+```python
+from huggingface_hub import HfApi
+
+api = HfApi()
+
+# List only the text classification datasets
+api.list_datasets(filter="task_categories:text-classification")
+
+# List only the datasets in russian for language modeling
+api.list_datasets(filter=("languages:ru", "task_ids:language-modeling"))
+```
+
+If you want to inspect the metadata of a single model or dataset, you can use the following functions:
+
+```python
+from huggingface_hub import HfApi
+
+api = HfApi()
+
+# Get metadata of a single model
+api.model_info("distilbert-base-uncased")
+
+# Get metadata of a single dataset
+api.dataset_info("glue")
+```
+
+### Creating and deleting a repo
+
+The `HfApi` class also allows you to create and delete repos, as well as change their visibility from public to private. Here is how it's done for model repos:
+
+```python
+from huggingface_hub import HfApi
+
+api = HfApi()
+
+# Create a public model repo
+api.create_repo(token=YOUR_HF_API_TOKEN, name=REPO_NAME)
+
+# Make it private
+api.update_repo_visibility(token=YOUR_HF_API_TOKEN name=REPO_NAME, private=True)
+
+# Delete the model repo - irreversible so be careful!
+api.delete_repo(token=YOUR_HF_API_TOKEN name=REPO_NAME)
+```
+
+You can find your API token by clicking on your Hub profile and selecting _Settings > API Tokens_. To create and delete dataset repos, you simply need to provide an additional `type="dataset"` argument:
+
+```python
+from huggingface_hub import HfApi
+
+api = HfApi()
+
+# Create a public dataset repo
+api.create_repo(token=YOUR_HF_API_TOKEN, name=REPO_NAME, type="dataset")
+```
+
+### Mixins to push your models to the Hub
+
+`huggingface_hub` provides a `ModelHubMixin` that can be subclassed to create custom logic for saving and loading your models in any framework. See the source of `PyTorchModelHubMixin` which allows you to push PyTorch models to the Hub as follows:
+
+```python
+import torch
+from huggingface_hub import PyTorchModelHubMixin
+
+class MyModel(torch.nn.Module, PyTorchModelHubMixin):
+    def __init__(self):
+        super().__init__()
+        self.transformer = torch.nn.Transformer()
+
+model = MyModel()
+# Pushes pytorch_model.bin to the Hub
+model.push_to_hub(repo_path_or_name=REPO_NAME)
+```
+
+Once the model's files are pushed to the Hub, you can then reload from anywhere with
+
+```python
+model = MyModel()
+model.from_pretrained(model_id=REPO_NAME)
+```
 
 ## The `huggingface_hub` client library
 
@@ -73,4 +190,24 @@ We add a custom "Use in Asteroid" button. When clicked, you get a library-specif
 
 <br>
 
-## Feedback (feature requests, bugs, etc.) is super welcome 💙💚💛💜♥️🧡
+## Contributing
+
+Feedback (feature requests, bugs, etc.) is super welcome 💙💚💛💜♥️🧡.
+
+### Developer installation
+
+To contribute a feature to `huggingface_hub`, first fork the repository by clicking the "Fork" button on the repository’s page. This creates a clone of the repository under your GitHub user. Next, clone the fork and install the project's requirements:
+
+```bash
+git clone git@github.com:{YOUR_GITHUB_USERNAME}/huggingface_hub.git
+cd huggingface_hub
+python -m pip install -e ".[dev]"
+```
+### Testing
+
+Use the following environment variable to run the tests locally:
+
+```bash
+HUGGINGFACE_CO_STAGING=yes pytest -sv ./tests/
+```
+


### PR DESCRIPTION
This PR adds some basic info to the README (mostly ripped from docstrings), to help newcomers get started / contribute. 

Although much of this could be migrated to the [docs](https://huggingface.co/docs/hub/main), I personally am more likely to try out a library if I can copy-paste some examples from the README 😃 