### PR TITLE
force filename and remove `.lock`

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -529,7 +529,7 @@ def hf_hub_download(
         repo_id, filename, subfolder=subfolder, repo_type=repo_type, revision=revision
     )
 
-    path = cached_download(
+    return cached_download(
         url,
         library_name=library_name,
         library_version=library_version,
@@ -543,8 +543,3 @@ def hf_hub_download(
         use_auth_token=use_auth_token,
         local_files_only=local_files_only,
     )
-    # removes lock file if created
-    if os.path.exists(path + ".lock"):
-        os.remove(path + ".lock")
-        
-    return path

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -529,17 +529,22 @@ def hf_hub_download(
         repo_id, filename, subfolder=subfolder, repo_type=repo_type, revision=revision
     )
 
-    return cached_download(
+    path = cached_download(
         url,
         library_name=library_name,
         library_version=library_version,
         cache_dir=cache_dir,
         user_agent=user_agent,
         force_download=force_download,
-        force_filename=force_filename,
+        force_filename=filename,
         proxies=proxies,
         etag_timeout=etag_timeout,
         resume_download=resume_download,
         use_auth_token=use_auth_token,
         local_files_only=local_files_only,
     )
+    # removes lock file if created
+    if os.path.exists(path + ".lock"):
+        os.remove(path + ".lock")
+        
+    return path


### PR DESCRIPTION
# What does this PR do? 

This PR forces file for `hf_hub_download` download method to use the provided `filename`. That way the file will be saved with the file name and not with a hash. 

Question: the `snapshot_download` method also removes created `.lock` files, should we add an option to remove them as well? 