### PR TITLE
subprocess.run -> run_subprocess

### DIFF
--- a/src/huggingface_hub/commands/user.py
+++ b/src/huggingface_hub/commands/user.py
@@ -26,6 +26,8 @@ from huggingface_hub.constants import (
 from huggingface_hub.hf_api import HfApi, HfFolder
 from requests.exceptions import HTTPError
 
+from ..utils import run_subprocess
+
 
 class UserCommands(BaseHuggingfaceCLICommand):
     @staticmethod
@@ -122,13 +124,9 @@ def tabulate(rows: List[List[Union[str, int]]], headers: List[str]) -> str:
 
 def currently_setup_credential_helpers(directory=None) -> List[str]:
     try:
-        output = subprocess.run(
+        output = run_subprocess(
             "git config --list".split(),
-            stderr=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            encoding="utf-8",
-            check=True,
-            cwd=directory,
+            directory,
         ).stdout.split("\n")
 
         current_credential_helpers = []

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -245,7 +245,7 @@ def files_to_be_staged(pattern: str, folder: Union[str, Path]) -> List[str]:
         `List[str]`: List of files that are to be staged.
     """
     try:
-        p = run_subprocess(f"git ls-files -mo {pattern}".split(), folder)
+        p = run_subprocess("git ls-files -mo".split() + [pattern], folder)
         if len(p.stdout.strip()):
             files = p.stdout.strip().split("\n")
         else:
@@ -666,6 +666,7 @@ class Repository:
                     run_subprocess(
                         f"{'git clone' if self.skip_lfs_files else 'git lfs clone'} {repo_url} .".split(),
                         self.local_dir,
+                        env=env,
                     )
             else:
                 # Check if the folder is the root of a git repository

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -17,7 +17,7 @@ from huggingface_hub.repocard import metadata_load, metadata_save
 
 from .hf_api import HfApi, HfFolder, repo_type_and_id_from_hf_id
 from .lfs import LFS_MULTIPART_UPLOAD_COMMAND
-from .utils import logging
+from .utils import logging, run_subprocess
 
 
 logger = logging.get_logger(__name__)
@@ -136,14 +136,7 @@ def is_local_clone(folder: Union[str, Path], remote_url: str) -> bool:
     if not is_git_repo(folder):
         return False
 
-    remotes = subprocess.run(
-        "git remote -v".split(),
-        stderr=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        check=True,
-        encoding="utf-8",
-        cwd=folder,
-    ).stdout
+    remotes = run_subprocess("git remote -v".split(), folder).stdout
 
     # Remove token for the test with remotes.
     remote_url = re.sub(r"https://.*@", "https://", remote_url)
@@ -167,14 +160,7 @@ def is_tracked_with_lfs(filename: Union[str, Path]) -> bool:
     filename = Path(filename).name
 
     try:
-        p = subprocess.run(
-            ["git", "check-attr", "-a", filename],
-            stderr=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            check=True,
-            encoding="utf-8",
-            cwd=folder,
-        )
+        p = run_subprocess("git check-attr -a".split() + [filename], folder)
         attributes = p.stdout.strip()
     except subprocess.CalledProcessError as exc:
         if not is_git_repo(folder):
@@ -211,13 +197,7 @@ def is_git_ignored(filename: Union[str, Path]) -> bool:
     filename = Path(filename).name
 
     try:
-        p = subprocess.run(
-            ["git", "check-ignore", filename],
-            stderr=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            encoding="utf-8",
-            cwd=folder,
-        )
+        p = run_subprocess("git check-ignore".split() + [filename], folder, check=False)
         # Will return exit code 1 if not gitignored
         is_ignored = not bool(p.returncode)
     except subprocess.CalledProcessError as exc:
@@ -265,14 +245,7 @@ def files_to_be_staged(pattern: str, folder: Union[str, Path]) -> List[str]:
         `List[str]`: List of files that are to be staged.
     """
     try:
-        p = subprocess.run(
-            ["git", "ls-files", "-mo", pattern],
-            stderr=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            check=True,
-            encoding="utf-8",
-            cwd=folder,
-        )
+        p = run_subprocess(f"git ls-files -mo {pattern}".split(), folder)
         if len(p.stdout.strip()):
             files = p.stdout.strip().split("\n")
         else:
@@ -296,14 +269,8 @@ def is_tracked_upstream(folder: Union[str, Path]) -> bool:
         `False` otherwise.
     """
     try:
-        command = "git rev-parse --symbolic-full-name --abbrev-ref @{u}"
-        subprocess.run(
-            command.split(),
-            stderr=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            encoding="utf-8",
-            check=True,
-            cwd=folder,
+        run_subprocess(
+            "git rev-parse --symbolic-full-name --abbrev-ref @{u}".split(), folder
         )
         return True
     except subprocess.CalledProcessError as exc:
@@ -329,15 +296,7 @@ def commits_to_push(folder: Union[str, Path], upstream: Optional[str] = None) ->
             push` to proceed.
     """
     try:
-        command = f"git cherry -v {upstream or ''}"
-        result = subprocess.run(
-            command.split(),
-            stderr=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            encoding="utf-8",
-            check=True,
-            cwd=folder,
-        )
+        result = run_subprocess(f"git cherry -v {upstream or ''}".split(), folder)
         return len(result.stdout.split("\n")) - 1
     except subprocess.CalledProcessError as exc:
         raise EnvironmentError(exc.stderr)
@@ -573,15 +532,9 @@ class Repository:
         Returns:
             `str`: Current checked out branch.
         """
-        command = "git rev-parse --abbrev-ref HEAD"
         try:
-            result = subprocess.run(
-                command.split(),
-                stderr=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                check=True,
-                encoding="utf-8",
-                cwd=self.local_dir,
+            result = run_subprocess(
+                "git rev-parse --abbrev-ref HEAD".split(), self.local_dir
             ).stdout.strip()
         except subprocess.CalledProcessError as exc:
             raise EnvironmentError(exc.stderr)
@@ -596,12 +549,8 @@ class Repository:
             `EnvironmentError`: if `git` or `git-lfs` are not installed.
         """
         try:
-            git_version = subprocess.run(
-                ["git", "--version"],
-                stderr=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                check=True,
-                encoding="utf-8",
+            git_version = run_subprocess(
+                "git --version".split(), self.local_dir
             ).stdout.strip()
         except FileNotFoundError:
             raise EnvironmentError(
@@ -609,12 +558,8 @@ class Repository:
             )
 
         try:
-            lfs_version = subprocess.run(
-                ["git-lfs", "--version"],
-                encoding="utf-8",
-                check=True,
-                stderr=subprocess.PIPE,
-                stdout=subprocess.PIPE,
+            lfs_version = run_subprocess(
+                "git-lfs --version".split(), self.local_dir
             ).stdout.strip()
         except FileNotFoundError:
             raise EnvironmentError(
@@ -706,13 +651,7 @@ class Repository:
         # For error messages, it's cleaner to show the repo url without the token.
         clean_repo_url = re.sub(r"(https?)://.*@", r"\1://", repo_url)
         try:
-            subprocess.run(
-                "git lfs install".split(),
-                stderr=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                check=True,
-                encoding="utf-8",
-            )
+            run_subprocess("git lfs install".split(), self.local_dir)
 
             # checks if repository is initialized in a empty repository or in one with files
             if len(os.listdir(self.local_dir)) == 0:
@@ -724,14 +663,9 @@ class Repository:
                     if self.skip_lfs_files:
                         env.update({"GIT_LFS_SKIP_SMUDGE": "1"})
 
-                    subprocess.run(
+                    run_subprocess(
                         f"{'git clone' if self.skip_lfs_files else 'git lfs clone'} {repo_url} .".split(),
-                        stderr=subprocess.PIPE,
-                        stdout=subprocess.PIPE,
-                        check=True,
-                        encoding="utf-8",
-                        cwd=self.local_dir,
-                        env=env,
+                        self.local_dir,
                     )
             else:
                 # Check if the folder is the root of a git repository
@@ -744,12 +678,10 @@ class Repository:
                             "changes with `repo.git_pull()`."
                         )
                     else:
-                        output = subprocess.run(
+                        output = run_subprocess(
                             "git remote get-url origin".split(),
-                            stderr=subprocess.PIPE,
-                            stdout=subprocess.PIPE,
-                            encoding="utf-8",
-                            cwd=self.local_dir,
+                            self.local_dir,
+                            check=False,
                         )
 
                         error_msg = (
@@ -789,22 +721,13 @@ class Repository:
         """
         try:
             if git_user is not None:
-                subprocess.run(
-                    ["git", "config", "user.name", git_user],
-                    stderr=subprocess.PIPE,
-                    stdout=subprocess.PIPE,
-                    check=True,
-                    encoding="utf-8",
-                    cwd=self.local_dir,
+                run_subprocess(
+                    "git config user.name".split() + [git_user], self.local_dir
                 )
+
             if git_email is not None:
-                subprocess.run(
-                    ["git", "config", "user.email", git_email],
-                    stderr=subprocess.PIPE,
-                    stdout=subprocess.PIPE,
-                    check=True,
-                    encoding="utf-8",
-                    cwd=self.local_dir,
+                run_subprocess(
+                    f"git config user.email {git_email}".split(), self.local_dir
                 )
         except subprocess.CalledProcessError as exc:
             raise EnvironmentError(exc.stderr)
@@ -814,14 +737,7 @@ class Repository:
         Sets the git credential helper to `store`
         """
         try:
-            subprocess.run(
-                ["git", "config", "credential.helper", "store"],
-                stderr=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                check=True,
-                encoding="utf-8",
-                cwd=self.local_dir,
-            )
+            run_subprocess("git config credential.helper store".split(), self.local_dir)
         except subprocess.CalledProcessError as exc:
             raise EnvironmentError(exc.stderr)
 
@@ -833,14 +749,7 @@ class Repository:
             `str`: The current checked out commit SHA.
         """
         try:
-            p = subprocess.run(
-                "git rev-parse HEAD".split(),
-                stderr=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                encoding="utf-8",
-                check=True,
-                cwd=self.local_dir,
-            )
+            p = run_subprocess("git rev-parse HEAD".split(), self.local_dir)
             return p.stdout.strip()
         except subprocess.CalledProcessError as exc:
             raise EnvironmentError(exc.stderr)
@@ -853,13 +762,8 @@ class Repository:
             `str`: The URL of the `origin` remote.
         """
         try:
-            p = subprocess.run(
-                "git config --get remote.origin.url".split(),
-                stderr=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                encoding="utf-8",
-                check=True,
-                cwd=self.local_dir,
+            p = run_subprocess(
+                "git config --get remote.origin.url".split(), self.local_dir
             )
             url = p.stdout.strip()
             # Strip basic auth info.
@@ -891,13 +795,8 @@ class Repository:
             directory or index.
         """
         try:
-            git_status = subprocess.run(
-                ["git", "status", "-s"],
-                stderr=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                check=True,
-                encoding="utf-8",
-                cwd=self.local_dir,
+            git_status = run_subprocess(
+                "git status -s".split(), self.local_dir
             ).stdout.strip()
         except subprocess.CalledProcessError as exc:
             raise EnvironmentError(exc.stderr)
@@ -947,15 +846,9 @@ class Repository:
             patterns = [patterns]
         try:
             for pattern in patterns:
-                cmd = f"git lfs track {'--filename' if filename else ''} {pattern}"
-                subprocess.run(
-                    cmd.split(),
-                    stderr=subprocess.PIPE,
-                    stdout=subprocess.PIPE,
-                    check=True,
-                    encoding="utf-8",
-                    cwd=self.local_dir,
-                )
+                cmd = f"git lfs track {'--filename' if filename else ''}".split()
+                cmd.append(pattern)
+                run_subprocess(cmd, self.local_dir)
         except subprocess.CalledProcessError as exc:
             raise EnvironmentError(exc.stderr)
 
@@ -971,14 +864,7 @@ class Repository:
             patterns = [patterns]
         try:
             for pattern in patterns:
-                subprocess.run(
-                    ["git", "lfs", "untrack", pattern],
-                    stderr=subprocess.PIPE,
-                    stdout=subprocess.PIPE,
-                    check=True,
-                    encoding="utf-8",
-                    cwd=self.local_dir,
-                )
+                run_subprocess("git lfs untrack".split() + [pattern], self.local_dir)
         except subprocess.CalledProcessError as exc:
             raise EnvironmentError(exc.stderr)
 
@@ -987,21 +873,11 @@ class Repository:
         HF-specific. This enables upload support of files >5GB.
         """
         try:
-            subprocess.run(
-                "git config lfs.customtransfer.multipart.path huggingface-cli".split(),
-                stderr=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                check=True,
-                encoding="utf-8",
-                cwd=self.local_dir,
-            )
-            subprocess.run(
-                f"git config lfs.customtransfer.multipart.args {LFS_MULTIPART_UPLOAD_COMMAND}".split(),
-                stderr=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                check=True,
-                encoding="utf-8",
-                cwd=self.local_dir,
+            lfs_config = "git config lfs.customtransfer.multipart"
+            run_subprocess(f"{lfs_config}.path huggingface-cli".split(), self.local_dir)
+            run_subprocess(
+                f"{lfs_config}.args {LFS_MULTIPART_UPLOAD_COMMAND}".split(),
+                self.local_dir,
             )
         except subprocess.CalledProcessError as exc:
             raise EnvironmentError(exc.stderr)
@@ -1102,13 +978,9 @@ class Repository:
             args.append("--recent")
         try:
             with _lfs_log_progress():
-                result = subprocess.run(
+                result = run_subprocess(
                     args,
-                    stderr=subprocess.PIPE,
-                    stdout=subprocess.PIPE,
-                    check=True,
-                    encoding="utf-8",
-                    cwd=self.local_dir,
+                    self.local_dir,
                 )
                 logger.info(result.stdout)
         except subprocess.CalledProcessError as exc:
@@ -1128,18 +1000,14 @@ class Repository:
                 files; calling `repo.git_pull(lfs=True)` will then fetch the LFS
                 file from the remote repository.
         """
-        args = ("git pull" if not lfs else "git lfs pull").split()
+        command = ("git pull" if not lfs else "git lfs pull").split()
         if rebase:
-            args.append("--rebase")
+            command.append("--rebase")
         try:
             with _lfs_log_progress():
-                result = subprocess.run(
-                    args,
-                    stderr=subprocess.PIPE,
-                    stdout=subprocess.PIPE,
-                    check=True,
-                    encoding="utf-8",
-                    cwd=self.local_dir,
+                result = run_subprocess(
+                    command,
+                    self.local_dir,
                 )
                 logger.info(result.stdout)
         except subprocess.CalledProcessError as exc:
@@ -1175,14 +1043,7 @@ class Repository:
                 )
 
         try:
-            result = subprocess.run(
-                ["git", "add", "-v", pattern],
-                stderr=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                check=True,
-                encoding="utf-8",
-                cwd=self.local_dir,
-            )
+            result = run_subprocess("git add -v".split() + [pattern], self.local_dir)
             logger.info(f"Adding to index:\n{result.stdout}\n")
         except subprocess.CalledProcessError as exc:
             raise EnvironmentError(exc.stderr)
@@ -1196,13 +1057,8 @@ class Repository:
                 The message attributed to the commit.
         """
         try:
-            result = subprocess.run(
-                ["git", "commit", "-m", commit_message, "-v"],
-                stderr=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                check=True,
-                encoding="utf-8",
-                cwd=self.local_dir,
+            result = run_subprocess(
+                "git commit -v -m".split() + [commit_message], self.local_dir
             )
             logger.info(f"Committed:\n{result.stdout}\n")
         except subprocess.CalledProcessError as exc:
@@ -1322,14 +1178,7 @@ class Repository:
         """
         command = f"git checkout {revision}"
         try:
-            result = subprocess.run(
-                command.split(),
-                stderr=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                check=True,
-                encoding="utf-8",
-                cwd=self.local_dir,
-            )
+            result = run_subprocess(command.split(), self.local_dir)
             logger.warning(f"Checked out {revision} from {self.current_branch}.")
             logger.warning(result.stdout)
         except subprocess.CalledProcessError as exc:
@@ -1338,14 +1187,7 @@ class Repository:
             else:
                 command = f"git checkout -b {revision}"
                 try:
-                    result = subprocess.run(
-                        command.split(),
-                        stderr=subprocess.PIPE,
-                        stdout=subprocess.PIPE,
-                        check=True,
-                        encoding="utf-8",
-                        cwd=self.local_dir,
-                    )
+                    result = run_subprocess(command.split(), self.local_dir)
                     logger.warning(
                         f"Revision `{revision}` does not exist. Created and checked out branch `{revision}`."
                     )
@@ -1369,13 +1211,8 @@ class Repository:
         """
         if remote:
             try:
-                result = subprocess.run(
-                    ["git", "ls-remote", "origin", f"refs/tags/{tag_name}"],
-                    stderr=subprocess.PIPE,
-                    stdout=subprocess.PIPE,
-                    check=True,
-                    encoding="utf-8",
-                    cwd=self.local_dir,
+                result = run_subprocess(
+                    f"git ls-remote origin refs/tags/{tag_name}".split(), self.local_dir
                 ).stdout.strip()
             except subprocess.CalledProcessError as exc:
                 raise EnvironmentError(exc.stderr)
@@ -1383,13 +1220,8 @@ class Repository:
             return len(result) != 0
         else:
             try:
-                git_tags = subprocess.run(
-                    ["git", "tag"],
-                    stderr=subprocess.PIPE,
-                    stdout=subprocess.PIPE,
-                    check=True,
-                    encoding="utf-8",
-                    cwd=self.local_dir,
+                git_tags = run_subprocess(
+                    "git tag".split(), self.local_dir
                 ).stdout.strip()
             except subprocess.CalledProcessError as exc:
                 raise EnvironmentError(exc.stderr)
@@ -1422,26 +1254,16 @@ class Repository:
 
         if delete_locally:
             try:
-                subprocess.run(
-                    ["git", "tag", "-d", tag_name],
-                    stderr=subprocess.PIPE,
-                    stdout=subprocess.PIPE,
-                    check=True,
-                    encoding="utf-8",
-                    cwd=self.local_dir,
+                run_subprocess(
+                    ["git", "tag", "-d", tag_name], self.local_dir
                 ).stdout.strip()
             except subprocess.CalledProcessError as exc:
                 raise EnvironmentError(exc.stderr)
 
         if remote and delete_remotely:
             try:
-                subprocess.run(
-                    ["git", "push", remote, "--delete", tag_name],
-                    stderr=subprocess.PIPE,
-                    stdout=subprocess.PIPE,
-                    check=True,
-                    encoding="utf-8",
-                    cwd=self.local_dir,
+                run_subprocess(
+                    f"git push {remote} --delete {tag_name}".split(), self.local_dir
                 ).stdout.strip()
             except subprocess.CalledProcessError as exc:
                 raise EnvironmentError(exc.stderr)
@@ -1470,27 +1292,16 @@ class Repository:
             tag_args = ["git", "tag", "-a", tag_name, "-m", message]
         else:
             tag_args = ["git", "tag", tag_name]
+
         try:
-            subprocess.run(
-                tag_args,
-                stderr=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                check=True,
-                encoding="utf-8",
-                cwd=self.local_dir,
-            ).stdout.strip()
+            run_subprocess(tag_args, self.local_dir).stdout.strip()
         except subprocess.CalledProcessError as exc:
             raise EnvironmentError(exc.stderr)
 
         if remote:
             try:
-                subprocess.run(
-                    ["git", "push", remote, tag_name],
-                    stderr=subprocess.PIPE,
-                    stdout=subprocess.PIPE,
-                    check=True,
-                    encoding="utf-8",
-                    cwd=self.local_dir,
+                run_subprocess(
+                    f"git push {remote} {tag_name}".split(), self.local_dir
                 ).stdout.strip()
             except subprocess.CalledProcessError as exc:
                 raise EnvironmentError(exc.stderr)
@@ -1503,13 +1314,8 @@ class Repository:
             `bool`: `True` if the git status is clean, `False` otherwise.
         """
         try:
-            git_status = subprocess.run(
-                ["git", "status", "--porcelain"],
-                stderr=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                check=True,
-                encoding="utf-8",
-                cwd=self.local_dir,
+            git_status = run_subprocess(
+                "git status --porcelain".split(), self.local_dir
             ).stdout.strip()
         except subprocess.CalledProcessError as exc:
             raise EnvironmentError(exc.stderr)

--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 #!/usr/bin/env python
 # coding=utf-8
 # Copyright 2021 The HuggingFace Inc. team. All rights reserved.
@@ -14,46 +15,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 
-import subprocess
-from typing import List
-
-from .logging import get_logger
-
-
-logger = get_logger(__name__)
-
-
-def run_subprocess(
-    command: List[str], folder: str, check=True, **kwargs
-) -> subprocess.CompletedProcess:
-    """
-    Method to run subprocesses. Calling this will capture the `stderr` and `stdout`,
-    please call `subprocess.run` manually in case you would like for them not to
-    be captured.
-
-    Args:
-        command (`List[str]`):
-            The command to execute as a list of strings.
-        folder (`str`):
-            The folder in which to run the command.
-        check (`bool`, *optional*, defaults to `True`):
-            Setting `check` to `True` will raise a `subprocess.CalledProcessError`
-            when the subprocess has a non-zero exit code.
-        kwargs (`Dict[str]`):
-            Keyword arguments to be passed to the `subprocess.run` underlying command.
-
-    Returns:
-        `subprocess.CompletedProcess`: The completed process.
-    """
-    if isinstance(command, str):
-        raise ValueError("`run_subprocess` should be called with a list of strings.")
-
-    return subprocess.run(
-        command,
-        stderr=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        check=check,
-        encoding="utf-8",
-        cwd=folder,
-        **kwargs
-    )
+from ._subprocess import run_subprocess

--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -23,9 +23,25 @@ logger = get_logger(__name__)
 
 
 def run_subprocess(command, folder, check=True) -> subprocess.CompletedProcess:
+    """
+    Method to run subprocesses. Calling this will capture the `stderr` and `stdout`,
+    please call `subprocess.run` manually in case you would like for them not to
+    be captured.
+
+    Args:
+        command (`str`):
+            The command to execute
+        folder (`str`):
+            The folder in which to run the command.
+        check (`bool`, *optional*, defaults to `True`):
+            Setting `check` to `True` will raise a `subprocess.CalledProcessError`
+            when the subprocess has a non-zero exit code.
+
+    Returns:
+        `subprocess.CompletedProcess`: The completed process.
+    """
     if isinstance(command, str):
-        logger.error("`run_subprocess` should be called with a list of strings.")
-        command = command.split()
+        raise ValueError("`run_subprocess` should be called with a list of strings.")
 
     return subprocess.run(
         command,

--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -13,3 +13,25 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License
+
+import subprocess
+
+from .logging import get_logger
+
+
+logger = get_logger(__name__)
+
+
+def run_subprocess(command, folder, check=True) -> subprocess.CompletedProcess:
+    if isinstance(command, str):
+        logger.error("`run_subprocess` should be called with a list of strings.")
+        command = command.split()
+
+    return subprocess.run(
+        command,
+        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        check=check,
+        encoding="utf-8",
+        cwd=folder,
+    )

--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -15,6 +15,7 @@
 # limitations under the License
 
 import subprocess
+from typing import List
 
 from .logging import get_logger
 
@@ -22,20 +23,24 @@ from .logging import get_logger
 logger = get_logger(__name__)
 
 
-def run_subprocess(command, folder, check=True) -> subprocess.CompletedProcess:
+def run_subprocess(
+    command: List[str], folder: str, check=True, **kwargs
+) -> subprocess.CompletedProcess:
     """
     Method to run subprocesses. Calling this will capture the `stderr` and `stdout`,
     please call `subprocess.run` manually in case you would like for them not to
     be captured.
 
     Args:
-        command (`str`):
-            The command to execute
+        command (`List[str]`):
+            The command to execute as a list of strings.
         folder (`str`):
             The folder in which to run the command.
         check (`bool`, *optional*, defaults to `True`):
             Setting `check` to `True` will raise a `subprocess.CalledProcessError`
             when the subprocess has a non-zero exit code.
+        kwargs (`Dict[str]`):
+            Keyword arguments to be passed to the `subprocess.run` underlying command.
 
     Returns:
         `subprocess.CompletedProcess`: The completed process.
@@ -50,4 +55,5 @@ def run_subprocess(command, folder, check=True) -> subprocess.CompletedProcess:
         check=check,
         encoding="utf-8",
         cwd=folder,
+        **kwargs
     )

--- a/src/huggingface_hub/utils/_subprocess.py
+++ b/src/huggingface_hub/utils/_subprocess.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+# coding=utf-8
+# Copyright 2021 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+import subprocess
+from typing import List
+
+from .logging import get_logger
+
+
+logger = get_logger(__name__)
+
+
+def run_subprocess(
+    command: List[str], folder: str, check=True, **kwargs
+) -> subprocess.CompletedProcess:
+    """
+    Method to run subprocesses. Calling this will capture the `stderr` and `stdout`,
+    please call `subprocess.run` manually in case you would like for them not to
+    be captured.
+
+    Args:
+        command (`List[str]`):
+            The command to execute as a list of strings.
+        folder (`str`):
+            The folder in which to run the command.
+        check (`bool`, *optional*, defaults to `True`):
+            Setting `check` to `True` will raise a `subprocess.CalledProcessError`
+            when the subprocess has a non-zero exit code.
+        kwargs (`Dict[str]`):
+            Keyword arguments to be passed to the `subprocess.run` underlying command.
+
+    Returns:
+        `subprocess.CompletedProcess`: The completed process.
+    """
+    if isinstance(command, str):
+        raise ValueError("`run_subprocess` should be called with a list of strings.")
+
+    return subprocess.run(
+        command,
+        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        check=check,
+        encoding="utf-8",
+        cwd=folder,
+        **kwargs
+    )


### PR DESCRIPTION
Implement a `run_subprocess` method to remove most of the verbosity introduced by `subprocess.run`