### PR TITLE
Add pyopenjtalk to espnet dependencies

### DIFF
--- a/api-inference-community/docker_images/espnet/requirements.txt
+++ b/api-inference-community/docker_images/espnet/requirements.txt
@@ -1,5 +1,6 @@
 api-inference-community==0.0.19
 espnet==0.10.2
+pyopenjtalk==0.1.5
 torch==1.8.1
 torchaudio==0.8.1
 torch_optimizer==0.1.0

--- a/api-inference-community/docker_images/espnet/requirements.txt
+++ b/api-inference-community/docker_images/espnet/requirements.txt
@@ -1,6 +1,6 @@
 api-inference-community==0.0.19
 espnet==0.10.2
-pyopenjtalk==0.1.5
+pyopenjtalk==0.1.3
 torch==1.8.1
 torchaudio==0.8.1
 torch_optimizer==0.1.0


### PR DESCRIPTION
Add `pyopenjtalk` to dependencies for `espnet`, which is required for models as discovered in https://github.com/espnet/espnet/pull/3326#discussion_r663513293