### PR TITLE
Revert speechbrain version to a stable one

### DIFF
--- a/api-inference-community/docker_images/speechbrain/app/pipelines/automatic_speech_recognition.py
+++ b/api-inference-community/docker_images/speechbrain/app/pipelines/automatic_speech_recognition.py
@@ -4,14 +4,15 @@ import numpy as np
 import torch
 from app.common import ModelType, get_type
 from app.pipelines import Pipeline
-from speechbrain.pretrained import EncoderASR, EncoderDecoderASR
+from speechbrain.pretrained import EncoderDecoderASR
 
 
 class AutomaticSpeechRecognitionPipeline(Pipeline):
     def __init__(self, model_id: str):
         model_type = get_type(model_id)
         if model_type is ModelType.ENCODERASR:
-            self.model = EncoderASR.from_hparams(source=model_id)
+            # self.model = EncoderASR.from_hparams(source=model_id)
+            raise ValueError("EncoderASR is not a supported interface at the moment")
         elif model_type is ModelType.ENCODERDECODERASR:
             self.model = EncoderDecoderASR.from_hparams(source=model_id)
 

--- a/api-inference-community/docker_images/speechbrain/requirements.txt
+++ b/api-inference-community/docker_images/speechbrain/requirements.txt
@@ -1,4 +1,4 @@
 starlette==0.14.2
 api-inference-community==0.0.19
-speechbrain==0.5.10
-transformers==4.10.2
+speechbrain==0.5.7
+transformers==4.5.1

--- a/api-inference-community/tests/test_dockers.py
+++ b/api-inference-community/tests/test_dockers.py
@@ -126,11 +126,12 @@ class DockerImageTests(unittest.TestCase):
             "speechbrain/asr-crdnn-commonvoice-it",
         )
 
-        self.framework_docker_test(
-            "speechbrain",
-            "automatic-speech-recognition",
-            "speechbrain/asr-wav2vec2-commonvoice-fr",
-        )
+        # Enable when latest release of speechbrain is fixed
+        #self.framework_docker_test(
+        #    "speechbrain",
+        #    "automatic-speech-recognition",
+        #    "speechbrain/asr-wav2vec2-commonvoice-fr",
+        #)
 
         self.framework_invalid_test("speechbrain")
 

--- a/api-inference-community/tests/test_dockers.py
+++ b/api-inference-community/tests/test_dockers.py
@@ -126,12 +126,12 @@ class DockerImageTests(unittest.TestCase):
             "speechbrain/asr-crdnn-commonvoice-it",
         )
 
-        # Enable when latest release of speechbrain is fixed
-        #self.framework_docker_test(
+        # Enable when latest release of speechbrain is fixed
+        # self.framework_docker_test(
         #    "speechbrain",
         #    "automatic-speech-recognition",
         #    "speechbrain/asr-wav2vec2-commonvoice-fr",
-        #)
+        # )
 
         self.framework_invalid_test("speechbrain")
 

--- a/api-inference-community/tests/test_dockers.py
+++ b/api-inference-community/tests/test_dockers.py
@@ -151,7 +151,7 @@ class DockerImageTests(unittest.TestCase):
         self.framework_docker_test(
             "speechbrain",
             "audio-classification",
-            "speechbrain/lang-id-commonlanguage_ecapa",
+            "speechbrain/urbansound8k_ecapa",
         )
 
     def test_timm(self):


### PR DESCRIPTION
Latest `speechbrain` version fails for some `audio-classification` models. This PR reverts to a working version and reverts `EncoderASR` changes since it's not in previous versions. 