### PR TITLE
Better error message for bad token.

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -327,7 +327,13 @@ class HfApi:
         """
         path = "{}/api/whoami-v2".format(self.endpoint)
         r = requests.get(path, headers={"authorization": "Bearer {}".format(token)})
-        r.raise_for_status()
+        try:
+            r.raise_for_status()
+        except HTTPError as e:
+            raise HTTPError(
+                "Invalid user token. If you didn't pass a user token, make sure you are properly logged in by "
+                "executing `huggingface-cli login`, and if you did pass a user token, double-check it's correct."
+            ) from e
         return r.json()
 
     def logout(self, token: str) -> None:


### PR DESCRIPTION
When a user passed a bad token to create a Repository, it ends up with a bit of cryptic error in `HfApi.whoami`:
```
Traceback (most recent call last):
  File "examples/pytorch/text-classification/run_glue_no_trainer.py", line 488, in <module>
    main()
  File "examples/pytorch/text-classification/run_glue_no_trainer.py", line 203, in main
    repo_name = get_full_repo_name(Path(args.output_dir).name, token=args.hub_token)
  File "/home/sgugger/git/transformers/src/transformers/file_utils.py", line 2249, in get_full_repo_name
    username = HfApi().whoami(token)["name"]
  File "/home/sgugger/git/huggingface_hub/src/huggingface_hub/hf_api.py", line 330, in whoami
    r.raise_for_status()
  File "/home/sgugger/.pyenv/versions/3.7.9/envs/base/lib/python3.7/site-packages/requests/models.py", line 941, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 401 Client Error: Unauthorized for url: https://huggingface.co/api/whoami-v2
```

This PR addresses that by writing a more helpful error message.