### PR TITLE
add missing licenses to docs

### DIFF
--- a/docs/hub/model-repos.md
+++ b/docs/hub/model-repos.md
@@ -157,6 +157,7 @@ Creative Commons license family	| `cc`
 Creative Commons Zero v1.0 Universal	| `cc0-1.0`
 Creative Commons Attribution 4.0	| `cc-by-4.0`
 Creative Commons Attribution Share Alike 4.0	| `cc-by-sa-4.0`
+Creative Commons Attribution Non Commercial Share Alike  4.0| `cc-by-nc-sa-4.0`
 Do What The F*ck You Want To Public License	| `wtfpl`
 Educational Community License v2.0	| `ecl-2.0`
 Eclipse Public License 1.0	| `epl-1.0`
@@ -180,3 +181,5 @@ SIL Open Font License 1.1	| `ofl-1.1`
 University of Illinois/NCSA Open Source License	| `ncsa`
 The Unlicense	| `unlicense`
 zLib License	| `zlib`
+Open Data Commons Public Domain Dedication and License | `pddl`
+Lesser General Public License For Linguistic Resources | `lgpllr`

--- a/docs/hub/model-repos.md
+++ b/docs/hub/model-repos.md
@@ -157,6 +157,7 @@ Creative Commons license family	| `cc`
 Creative Commons Zero v1.0 Universal	| `cc0-1.0`
 Creative Commons Attribution 4.0	| `cc-by-4.0`
 Creative Commons Attribution Share Alike 4.0	| `cc-by-sa-4.0`
+Creative Commons Attribution Non Commercial 4.0	|`cc-by-nc-4.0`
 Creative Commons Attribution Non Commercial Share Alike  4.0| `cc-by-nc-sa-4.0`
 Do What The F*ck You Want To Public License	| `wtfpl`
 Educational Community License v2.0	| `ecl-2.0`


### PR DESCRIPTION
# Summary

- Context : metadata validation on the git server side
- Those licenses are already present in the hub, and it makes sense keeping them