### PR TITLE
Add timeout to dataset_info

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -492,7 +492,11 @@ class HfApi:
         return [DatasetInfo(**x) for x in d]
 
     def model_info(
-        self, repo_id: str, revision: Optional[str] = None, token: Optional[str] = None
+        self,
+        repo_id: str,
+        revision: Optional[str] = None,
+        token: Optional[str] = None,
+        timeout: Optional[float] = None,
     ) -> ModelInfo:
         """
         Get info on one specific model on huggingface.co
@@ -509,7 +513,7 @@ class HfApi:
         headers = (
             {"authorization": "Bearer {}".format(token)} if token is not None else None
         )
-        r = requests.get(path, headers=headers)
+        r = requests.get(path, headers=headers, timeout=timeout)
         r.raise_for_status()
         d = r.json()
         return ModelInfo(**d)
@@ -532,7 +536,11 @@ class HfApi:
         return [RepoObj(**x) for x in d]
 
     def dataset_info(
-        self, repo_id: str, revision: Optional[str] = None, token: Optional[str] = None
+        self,
+        repo_id: str,
+        revision: Optional[str] = None,
+        token: Optional[str] = None,
+        timeout: Optional[float] = None,
     ) -> DatasetInfo:
         """
         Get info on one specific dataset on huggingface.co
@@ -550,7 +558,7 @@ class HfApi:
             {"authorization": "Bearer {}".format(token)} if token is not None else None
         )
         params = {"full": "true"}
-        r = requests.get(path, headers=headers, params=params)
+        r = requests.get(path, headers=headers, params=params, timeout=timeout)
         r.raise_for_status()
         d = r.json()
         return DatasetInfo(**d)


### PR DESCRIPTION
In certain environments such as the Jean Zay cluster, there is no internet connection and internet requests hang indefinitely.

To be able to properly raise an error in such cases instead of making the program hang, I think it would be nice to add a `timeout` parameter to `HfApi.dataset_info` that can be passed to `requests.get`.

I added `timeout` to `HfApi.dataset_info` and also `HfApi.model_info` for consistency

Close #372 

Related to the new integration of `dataset_info` in `datasets` at https://github.com/huggingface/datasets/pull/2986