### PR TITLE
Fix model-repos.md title level

### DIFF
--- a/docs/hub/model-repos.md
+++ b/docs/hub/model-repos.md
@@ -142,7 +142,7 @@ $$
 
 $$ E=mc^2 $$
 
-### How can I fork or rebase a repository with LFS pointers?
+## How can I fork or rebase a repository with LFS pointers?
 
 When you want to fork or [rebase](https://git-scm.com/docs/git-rebase) a repository with [LFS](https://git-lfs.github.com/) files (all files over 20MB are stored as such), you cannot use the usual Git approach since you need to be careful to not break the LFS pointers. Forking can take time depending on your bandwidth, because you will have to fetch an re-upload all the LFS files in your fork.
 


### PR DESCRIPTION
## Why

Currently the title fixed does not appear in the sidebar of the docs : https://huggingface.co/docs/hub/model-repos#how-can-i-fork-or-rebase-a-repository-with-lfs-pointers

This PR fixes that