### PR TITLE
don't check if 'json' in filename when loading config file

### DIFF
--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -147,7 +147,7 @@ class ModelHubMixin:
                 logger.warning(f"{CONFIG_NAME} not found in HuggingFace Hub")
                 config_file = None
 
-        if config_file is not None and config_file.endswith(".json"):
+        if config_file is not None:
             with open(config_file, "r", encoding="utf-8") as f:
                 config = json.load(f)
             model_kwargs.update({"config": config})


### PR DESCRIPTION
Checking if json is in the filename can be problematic when loading from the hub, as the config file name might be a hash. 