### PR TITLE
rollback to pyyaml

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ install_requires = [
     "filelock",
     "requests",
     "tqdm",
-    "ruamel.yaml==0.17.16",
+    "pyyaml",
     "typing-extensions",
     "importlib_metadata;python_version<'3.8'",
     "packaging>=20.9",

--- a/src/huggingface_hub/repocard.py
+++ b/src/huggingface_hub/repocard.py
@@ -1,15 +1,9 @@
-import io
 import os
 import re
+import yaml
 from pathlib import Path
 from typing import Dict, Optional, Union
 
-from ruamel.yaml import YAML
-
-
-# the default loader/dumper type is 'rt' round-trip, preserving existing yaml formatting
-# 'rt' derivates from safe loader/dumper
-yaml = YAML()
 
 # exact same regex as in the Hub server. Please keep in sync.
 REGEX_YAML_BLOCK = re.compile(r"---[\n\r]+([\S\s]*?)[\n\r]+---[\n\r]")
@@ -20,7 +14,7 @@ def metadata_load(local_path: Union[str, Path]) -> Optional[Dict]:
     match = REGEX_YAML_BLOCK.search(content)
     if match:
         yaml_block = match.group(1)
-        data = yaml.load(yaml_block)
+        data = yaml.safe_load(yaml_block)
         if isinstance(data, dict):
             return data
         else:
@@ -50,9 +44,7 @@ def metadata_save(local_path: Union[str, Path], data: Dict) -> None:
 
     # creates a new file if it not
     with open(local_path, "w", newline="") as readme:
-        stream = io.StringIO()
-        yaml.dump(data, stream)
-        data_yaml = stream.getvalue()
+        data_yaml = yaml.dump(data, sort_keys=False, line_break=line_break)
         # sort_keys: keep dict order
         match = REGEX_YAML_BLOCK.search(content)
         if match:
@@ -66,4 +58,3 @@ def metadata_save(local_path: Union[str, Path], data: Dict) -> None:
 
         readme.write(output)
         readme.close()
-        stream.close()

--- a/tests/test_repocard.py
+++ b/tests/test_repocard.py
@@ -123,29 +123,3 @@ class RepocardTest(unittest.TestCase):
         filepath.write_text(DUMMY_MODELCARD_TARGET_NO_TAGS)
         data = metadata_load(filepath)
         self.assertEqual(data, None)
-
-    def test_metadata_roundtrip(self):
-        filename = "dummy_target.md"
-        filepath = Path(REPOCARD_DIR) / filename
-        filepath.write_text(ROUND_TRIP_MODELCARD_CASE)
-        metadata = metadata_load(filepath)
-        self.assertDictEqual(
-            {
-                "language": "no",
-                "datasets": "CLUECorpusSmall",
-                "widget": [{"text": "北京是[MASK]国的首都。"}],
-            },
-            metadata,
-        )
-        metadata_save(filepath, metadata)
-        content = filepath.read_text()
-        self.assertEqual(content, ROUND_TRIP_MODELCARD_CASE)
-        metadata = metadata_load(filepath)
-        self.assertDictEqual(
-            {
-                "language": "no",
-                "datasets": "CLUECorpusSmall",
-                "widget": [{"text": "北京是[MASK]国的首都。"}],
-            },
-            metadata,
-        )


### PR DESCRIPTION
Since YAML spec 1.2 is planned for pyyaml 6.1 https://github.com/yaml/pyyaml/pull/555, we here drop support for **not parsing** values `no` (and other non-quoted strings) to boolean.