### PR TITLE
Add `list_repo_files` util

### DIFF
--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -40,6 +40,7 @@ from .hf_api import (
     get_full_repo_name,
     list_datasets,
     list_models,
+    list_repo_files,
     list_repos_objs,
     login,
     logout,

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -536,6 +536,19 @@ class HfApi:
         d = r.json()
         return ModelInfo(**d)
 
+    def list_repo_files(
+        self,
+        repo_id: str,
+        revision: Optional[str] = None,
+        token: Optional[str] = None,
+        timeout: Optional[float] = None,
+    ) -> ModelInfo:
+        """
+        Get the list of files in a given repo.
+        """
+        info = self.model_info(repo_id, revision=revision, token=token, timeout=timeout)
+        return [f.rfilename for f in info.siblings]
+
     def list_repos_objs(
         self, token: Optional[str] = None, organization: Optional[str] = None
     ) -> List[RepoObj]:
@@ -991,6 +1004,7 @@ whoami = api.whoami
 
 list_models = api.list_models
 model_info = api.model_info
+list_repo_files = api.list_repo_files
 list_repos_objs = api.list_repos_objs
 
 list_datasets = api.list_datasets

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -404,6 +404,22 @@ class HfApiPublicTest(unittest.TestCase):
         self.assertIsInstance(model, ModelInfo)
         self.assertEqual(model.sha, DUMMY_MODEL_ID_REVISION_ONE_SPECIFIC_COMMIT)
 
+    @with_production_testing
+    def test_list_repo_files(self):
+        _api = HfApi()
+        files = _api.list_repo_files(repo_id=DUMMY_MODEL_ID)
+        expected_files = [
+            ".gitattributes",
+            "README.md",
+            "config.json",
+            "flax_model.msgpack",
+            "merges.txt",
+            "pytorch_model.bin",
+            "tf_model.h5",
+            "vocab.json",
+        ]
+        self.assertListEqual(files, expected_files)
+
     def test_staging_list_datasets(self):
         _api = HfApi(endpoint=ENDPOINT_STAGING)
         _ = _api.list_datasets()


### PR DESCRIPTION
This PR adds a util to directly list all the files in a repo. It will be used in the Course and Transformers.