### PR TITLE
TextGeneration widgets use text area

### DIFF
--- a/widgets/src/lib/InferenceWidget/widgets/TextGenerationWidget/TextGenerationWidget.svelte
+++ b/widgets/src/lib/InferenceWidget/widgets/TextGenerationWidget/TextGenerationWidget.svelte
@@ -4,7 +4,8 @@
 
 	import { onMount } from "svelte";
 	import WidgetOutputText from "../../shared/WidgetOutputText/WidgetOutputText.svelte";
-	import WidgetQuickInput from "../../shared/WidgetQuickInput/WidgetQuickInput.svelte";
+	import WidgetSubmitBtn from "../../shared/WidgetSubmitBtn/WidgetSubmitBtn.svelte";
+	import WidgetTextarea from "../../shared/WidgetTextarea/WidgetTextarea.svelte";
 	import WidgetWrapper from "../../shared/WidgetWrapper/WidgetWrapper.svelte";
 	import {
 		addInferenceParameters,
@@ -131,11 +132,11 @@
 	{outputJson}
 >
 	<svelte:fragment slot="top">
-		<form>
-			<WidgetQuickInput
-				bind:value={text}
+		<form class="space-y-2">
+			<WidgetTextarea bind:value={text} />
+			<WidgetSubmitBtn
 				{isLoading}
-				onClickSubmitBtn={() => {
+				onClick={() => {
 					getOutput();
 				}}
 			/>


### PR DESCRIPTION
Modified Text Generation widgets to use text areas, rather than single line text inputs

<img width="479" alt="Screenshot 2021-10-12 at 11 02 19" src="https://user-images.githubusercontent.com/11827707/136926211-000fb39d-7530-4f91-bcdf-1f799f5d2150.png">

[Netlify demo here](https://61654f41bb82bbd611dffda1--huggingface-widgets.netlify.app/)

cc: @julien-c @VictorSanh @NielsRogge 