### PR TITLE
Add fastai as supported library

### DIFF
--- a/widgets/src/lib/interfaces/Libraries.ts
+++ b/widgets/src/lib/interfaces/Libraries.ts
@@ -17,7 +17,7 @@ export enum ModelLibrary {
 	'speechbrain'            = 'speechbrain',
 	'tensorflowtts'          = 'TensorFlowTTS',
 	'timm'                   = 'Timm',
-	'fastai'           	 = 'Fastai',
+	'fastai'           	 = 'fastai',
 	'transformers'           = 'Transformers',
 };
 


### PR DESCRIPTION
Required for UI items in the Hub and as a step towards the integration of fastai.

- I followed the integration made for sklearn in this document
- fastai models are usually stored and imported from *.pkl formats so this would make sense for practitioners
- The 'espejelomar/fastai-pet-breeds-classification' model can be used as an example of how this would work:

```
from huggingface_hub import hf_hub_download
from fastai.learner import load_learner

model = load_learner(
    hf_hub_download('espejelomar/fastai-pet-breeds-classification', filename="model.pkl")
    )
```