### PR TITLE
Last fixes for `datasets`' `push_to_hub` method

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -35,7 +35,7 @@ else:
     from typing_extensions import Literal
 
 
-REMOTE_FILEPATH_REGEX = re.compile(r"^\w[\w\/]*(\.\w+)?$")
+REMOTE_FILEPATH_REGEX = re.compile(r"^\w[\w\/\-]*(\.\w+)?$")
 # ^^ No trailing slash, no backslash, no spaces, no relative parts ("." or "..")
 #    Only word characters and an optional extension
 
@@ -584,13 +584,24 @@ class HfApi:
         self,
         repo_id: str,
         revision: Optional[str] = None,
+        repo_type: Optional[str] = None,
         token: Optional[str] = None,
         timeout: Optional[float] = None,
-    ) -> ModelInfo:
+    ) -> List[str]:
         """
         Get the list of files in a given repo.
         """
-        info = self.model_info(repo_id, revision=revision, token=token, timeout=timeout)
+        if repo_type is None:
+            info = self.model_info(
+                repo_id, revision=revision, token=token, timeout=timeout
+            )
+        elif repo_type == "dataset":
+            info = self.dataset_info(
+                repo_id, revision=revision, token=token, timeout=timeout
+            )
+        else:
+            raise ValueError("Spaces are not available yet.")
+
         return [f.rfilename for f in info.siblings]
 
     def list_repos_objs(


### PR DESCRIPTION
This PR implements a few fixes necessary to have the `datasets`' `push_to_hub` method implemented:

- The regex for filenames that can be pushed to the hub does not allow the use of the `-` symbol which is necessary for files in the format `<split_name>-00001-of-00010`
- The `list_repo_files` actually only works for models. This adds support for datasets, and a future PR should also enable spaces.