### PR TITLE
Fixing the stanza caching on docker by using the correct `/data/` directory that is mounted externally so it can reuse the model files on subsequent docker loading.

### DIFF
--- a/api-inference-community/docker_images/stanza/app/pipelines/token_classification.py
+++ b/api-inference-community/docker_images/stanza/app/pipelines/token_classification.py
@@ -1,3 +1,4 @@
+import os
 from typing import Any, Dict, List
 
 import stanza
@@ -12,8 +13,16 @@ class TokenClassificationPipeline(Pipeline):
     ):
         namespace, model_name = model_id.split("/")
 
-        stanza.download(model_dir=f"/data/{namespace}/{model_name}")
-        self.model = pipeline(model_dir=f"/data/{namespace}/{model_name}")
+        path = os.path.join(
+            os.environ.get("HUGGINGFACE_HUB_CACHE", "."), namespace, model_name
+        )
+
+        if model_id == "stanza-zh-hans":
+            lang = "zh"
+        else:
+            lang = model_id.split("-", 1)[-1]
+        stanza.download(model_dir=path, lang=lang)
+        self.model = pipeline(model_dir=path)
 
     def __call__(self, inputs: str) -> List[Dict[str, Any]]:
         """


### PR DESCRIPTION
With the previous code, the directory would contain `https://` which is unintuitive, but most importantly it would miss the cache hit.

Dockers are loaded with `/data` be mounted from a shared disk, allowing to reuse the model files without downloading the model files on every start leading to faster ready state, less network, less work on the shared disk.

Without it, this could other cause issues on every other library using this shared disk by slowing it down.

This fix simply uses that directory as the directory for the download. Does the stanza mecanism handle model changes ? 