### PR TITLE
Fix stanza zh hardcoding

### DIFF
--- a/api-inference-community/docker_images/stanza/app/pipelines/token_classification.py
+++ b/api-inference-community/docker_images/stanza/app/pipelines/token_classification.py
@@ -11,7 +11,7 @@ class TokenClassificationPipeline(Pipeline):
         self,
         model_id: str,
     ):
-        _, model_name = model_id.split("/")
+        namespace, model_name = model_id.split("/")
 
         path = os.path.join(
             os.environ.get("HUGGINGFACE_HUB_CACHE", "."), namespace, model_name


### PR DESCRIPTION
* `zh-hans` is actually accepted, so no need to map it to zh.
* also it was using the model_id, not the model_name, so it was not going to work

cc @merveenoyan 