### PR TITLE
Fix empty error message

### DIFF
--- a/widgets/src/lib/InferenceWidget/shared/helpers.ts
+++ b/widgets/src/lib/InferenceWidget/shared/helpers.ts
@@ -150,7 +150,8 @@ export async function getResponse<T>(
 			return { error: body["error"], estimatedTime: body["estimated_time"], status: 'loading-model' };
 		} else {
 			// Other errors
-			return { error: body["error"] ?? body["traceback"] ?? body, status: 'error' };
+			const { status, statusText } = response;
+			return { error: body["error"] ?? body["traceback"] ?? `${status} ${statusText}`, status: 'error' };
 		}
 	}
 }


### PR DESCRIPTION
Fixes and issue when `body` is `{}` and status is error, it results in error message `[object Object]` (see screenshot)
https://github.com/huggingface/huggingface_hub/blob/53b997d4c47fa25127c846638f5b5cb32ddbf8a6/widgets/src/lib/InferenceWidget/shared/helpers.ts#L142
<img width="569" alt="Screenshot 2021-10-22 at 10 48 37" src="https://user-images.githubusercontent.com/11827707/138424491-2d5383a6-0e50-4178-ab94-d939476426ab.png">

