### PR TITLE
Make widgetinputsamples wider & rounded

### DIFF
--- a/widgets/src/lib/InferenceWidget/shared/WidgetInputSamples/WidgetInputSamples.svelte
+++ b/widgets/src/lib/InferenceWidget/shared/WidgetInputSamples/WidgetInputSamples.svelte
@@ -11,7 +11,7 @@
 
 <!-- svelte-ignore a11y-no-onchange -->
 <select
-	class="border-none text-sm w-28 truncate dark:bg-gray-950"
+	class="border-none text-sm w-32 truncate dark:bg-gray-950 rounded"
 	on:change={onChange}
 >
 	<option selected disabled>Examples</option>

--- a/widgets/src/lib/InferenceWidget/shared/WidgetInputSamples/WidgetInputSamples.svelte
+++ b/widgets/src/lib/InferenceWidget/shared/WidgetInputSamples/WidgetInputSamples.svelte
@@ -11,7 +11,7 @@
 
 <!-- svelte-ignore a11y-no-onchange -->
 <select
-	class="border-none text-sm w-32 truncate dark:bg-gray-950 rounded"
+	class="text-sm py-1  w-32 lg:w-44 border border-gray-100 truncate dark:bg-gray-950 rounded"
 	on:change={onChange}
 >
 	<option selected disabled>Examples</option>

--- a/widgets/src/routes/index.svelte
+++ b/widgets/src/routes/index.svelte
@@ -132,7 +132,7 @@
 			],
 		},
 		{
-			id: "google/t5-small-ssm-nq",
+			id: "bigscience/T0pp",
 			pipeline_tag: "text2text-generation",
 		},
 		{


### PR DESCRIPTION
CSS style update for WidgetInputSamples.svelte
1. Rounded outline
2. Wider

<img width="532" alt="Screenshot 2021-10-28 at 15 18 40" src="https://user-images.githubusercontent.com/11827707/139263842-059ac161-c443-4a5f-af2e-442f7b76bf72.png">

Checkout demo [here](https://617aa41f47f6b43722756eeb--huggingface-widgets.netlify.app/bigscience/T0pp)