### PR TITLE
Fix sample chooser for vision & audio widgets

### DIFF
--- a/widgets/src/lib/InferenceWidget/shared/WidgetDropzone/WidgetDropzone.svelte
+++ b/widgets/src/lib/InferenceWidget/shared/WidgetDropzone/WidgetDropzone.svelte
@@ -1,6 +1,6 @@
 <script>
 	import IconSpin from "../../../Icons/IconSpin.svelte";
-	import { proxify } from "../../shared/helpers";
+	import { getBlobFromUrl } from "../../shared/helpers";
 
 	export let accept = "image/*";
 	export let classNames = "";
@@ -38,9 +38,7 @@
 			const url = await new Promise<string>((resolve) =>
 				uriItem.getAsString((s) => resolve(s))
 			);
-			const proxiedUrl = proxify(url);
-			const res = await fetch(proxiedUrl);
-			const file = await res.blob();
+			const file = await getBlobFromUrl(url);
 
 			onSelectFile(file);
 		} else if (fileItem) {

--- a/widgets/src/lib/InferenceWidget/shared/WidgetInputSamples/WidgetInputSamples.svelte
+++ b/widgets/src/lib/InferenceWidget/shared/WidgetInputSamples/WidgetInputSamples.svelte
@@ -21,7 +21,7 @@
 	function _previewInputSample(idx: number, isTocuh = false) {
 		const sample = inputSamples[idx];
 		previewInputSample(sample);
-		if(isTocuh){
+		if (isTocuh) {
 			isTouchOptionClicked = true;
 			selectedIdx = idx;
 		}
@@ -53,11 +53,11 @@
 			/>
 		</svg>
 	</div>
-		{#if !isTouchOptionClicked}
+	{#if !isTouchOptionClicked}
 		<div
-		class="with-hover:hidden inline-flex justify-between w-32 lg:w-44 rounded-md border border-gray-100 px-4 py-1"
-		on:click={toggleOptionsVisibility}
-	>
+			class="with-hover:hidden inline-flex justify-between w-32 lg:w-44 rounded-md border border-gray-100 px-4 py-1"
+			on:click={toggleOptionsVisibility}
+		>
 			<p class="text-sm truncate">{title}</p>
 			<svg
 				class="-mr-1 ml-2 h-5 w-5 transition ease-in-out transform"
@@ -73,14 +73,14 @@
 				/>
 			</svg>
 		</div>
-		{:else}
+	{:else}
 		<div
-		class="with-hover:hidden inline-flex justify-center w-32 lg:w-44 rounded-md border border-green-500 px-4 py-1"
-		on:click={() => _applyInputSample(selectedIdx)}
-	>
-			 <p class="text-green-500">Confirm</p>
-			</div>
-		{/if}
+			class="with-hover:hidden inline-flex justify-center w-32 lg:w-44 rounded-md border border-green-500 px-4 py-1"
+			on:click={() => _applyInputSample(selectedIdx)}
+		>
+			<p class="text-green-500">Confirm</p>
+		</div>
+	{/if}
 
 	{#if isOptionsVisible}
 		<div

--- a/widgets/src/lib/InferenceWidget/shared/WidgetInputSamples/WidgetInputSamples.svelte
+++ b/widgets/src/lib/InferenceWidget/shared/WidgetInputSamples/WidgetInputSamples.svelte
@@ -11,7 +11,7 @@
 
 <!-- svelte-ignore a11y-no-onchange -->
 <select
-	class="border-none text-sm w-28 truncate dark:bg-gray-950"
+	class="text-sm py-1  w-32 lg:w-44 border border-gray-100 truncate dark:bg-gray-950 rounded"
 	on:change={onChange}
 >
 	<option selected disabled>Examples</option>

--- a/widgets/src/lib/InferenceWidget/shared/WidgetInputSamples/WidgetInputSamples.svelte
+++ b/widgets/src/lib/InferenceWidget/shared/WidgetInputSamples/WidgetInputSamples.svelte
@@ -95,6 +95,7 @@
 			</svg>
 		</div>
 	{:else}
+		<!-- Better UX for mobile/table through CSS breakpoints -->
 		<div
 			class="with-hover:hidden inline-flex justify-center w-32 lg:w-44 rounded-md border border-green-500 px-4 py-1"
 			on:click={() => _applyInputSample(touchSelectedIdx)}
@@ -117,6 +118,7 @@
 					>
 						{example_title}
 					</p>
+					<!-- Better UX for mobile/table through CSS breakpoints -->
 					<p
 						class="with-hover:hidden px-4 py-2 text-sm hover:bg-gray-100 hover:text-gray-900 dark:hover:bg-gray-800 dark:hover:text-gray-200"
 						on:click={() => _previewInputSample(i, true)}

--- a/widgets/src/lib/InferenceWidget/shared/WidgetInputSamples/WidgetInputSamples.svelte
+++ b/widgets/src/lib/InferenceWidget/shared/WidgetInputSamples/WidgetInputSamples.svelte
@@ -5,7 +5,7 @@
 	export let applyInputSample: (sample: Record<string, any>) => void;
 	export let previewInputSample: (sample: Record<string, any>) => void;
 
-	let isOptionsVisible = true;
+	let isOptionsVisible = false;
 	let title = "Examples";
 
 	function _applyInputSample(idx: number) {

--- a/widgets/src/lib/InferenceWidget/shared/WidgetInputSamples/WidgetInputSamples.svelte
+++ b/widgets/src/lib/InferenceWidget/shared/WidgetInputSamples/WidgetInputSamples.svelte
@@ -1,21 +1,68 @@
 <script>
-	export let inputSamples: Record<string, any>[];
-	export let applyInputSample: (sample: Record<string, any>[]) => void;
+	import { slide } from "svelte/transition";
 
-	function onChange(e: Event) {
-		const { value } = e.target as HTMLOptionElement;
-		const sample = inputSamples[value];
+	export let inputSamples: Record<string, any>[];
+	export let applyInputSample: (sample: Record<string, any>) => void;
+	export let previewInputSample: (sample: Record<string, any>) => void;
+
+	let isOptionsVisible = true;
+	let title = "Examples";
+
+	function _applyInputSample(idx: number) {
+		const sample = inputSamples[idx];
+		title = sample.example_title;
+		isOptionsVisible = false;
 		applyInputSample(sample);
+	}
+
+	function _previewInputSample(idx: number) {
+		const sample = inputSamples[idx];
+		previewInputSample(sample);
+	}
+
+	function toggleOptionsVisibility() {
+		isOptionsVisible = !isOptionsVisible;
 	}
 </script>
 
-<!-- svelte-ignore a11y-no-onchange -->
-<select
-	class="text-sm py-1  w-32 lg:w-44 border border-gray-100 truncate dark:bg-gray-950 rounded"
-	on:change={onChange}
->
-	<option selected disabled>Examples</option>
-	{#each inputSamples as { example_title }, i}
-		<option value={i}>{example_title}</option>
-	{/each}
-</select>
+<div class="relative z-10">
+	<div
+		class="inline-flex justify-between w-32 lg:w-44 rounded-md border border-gray-100 px-4 py-1"
+		on:click={toggleOptionsVisibility}
+	>
+		<p class="text-sm truncate">{title}</p>
+		<svg
+			class="-mr-1 ml-2 h-5 w-5 transition ease-in-out transform {isOptionsVisible &&
+				'-rotate-180'}"
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 20 20"
+			fill="currentColor"
+			aria-hidden="true"
+		>
+			<path
+				fill-rule="evenodd"
+				d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
+				clip-rule="evenodd"
+			/>
+		</svg>
+	</div>
+
+	{#if isOptionsVisible}
+		<div
+			class="origin-top-right absolute right-0 mt-1 w-full rounded-md ring-1 ring-black ring-opacity-10"
+			transition:slide
+		>
+			<div class="py-1 bg-white rounded-md" role="none">
+				{#each inputSamples as { example_title }, i}
+					<p
+						class="px-4 py-2 text-sm hover:bg-gray-100 hover:text-gray-900 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+						on:mouseover={() => _previewInputSample(i)}
+						on:click={() => _applyInputSample(i)}
+					>
+						{example_title}
+					</p>
+				{/each}
+			</div>
+		</div>
+	{/if}
+</div>

--- a/widgets/src/lib/InferenceWidget/shared/WidgetInputSamples/WidgetInputSamples.svelte
+++ b/widgets/src/lib/InferenceWidget/shared/WidgetInputSamples/WidgetInputSamples.svelte
@@ -6,18 +6,25 @@
 	export let previewInputSample: (sample: Record<string, any>) => void;
 
 	let isOptionsVisible = false;
+	let isTouchOptionClicked = false;
+	let selectedIdx: number;
 	let title = "Examples";
 
 	function _applyInputSample(idx: number) {
+		isOptionsVisible = false;
+		isTouchOptionClicked = false;
 		const sample = inputSamples[idx];
 		title = sample.example_title;
-		isOptionsVisible = false;
 		applyInputSample(sample);
 	}
 
-	function _previewInputSample(idx: number) {
+	function _previewInputSample(idx: number, isTocuh = false) {
 		const sample = inputSamples[idx];
 		previewInputSample(sample);
+		if(isTocuh){
+			isTouchOptionClicked = true;
+			selectedIdx = idx;
+		}
 	}
 
 	function toggleOptionsVisibility() {
@@ -27,7 +34,7 @@
 
 <div class="relative z-10">
 	<div
-		class="inline-flex justify-between w-32 lg:w-44 rounded-md border border-gray-100 px-4 py-1"
+		class="no-hover:hidden inline-flex justify-between w-32 lg:w-44 rounded-md border border-gray-100 px-4 py-1"
 		on:click={toggleOptionsVisibility}
 	>
 		<p class="text-sm truncate">{title}</p>
@@ -46,6 +53,34 @@
 			/>
 		</svg>
 	</div>
+		{#if !isTouchOptionClicked}
+		<div
+		class="with-hover:hidden inline-flex justify-between w-32 lg:w-44 rounded-md border border-gray-100 px-4 py-1"
+		on:click={toggleOptionsVisibility}
+	>
+			<p class="text-sm truncate">{title}</p>
+			<svg
+				class="-mr-1 ml-2 h-5 w-5 transition ease-in-out transform"
+				xmlns="http://www.w3.org/2000/svg"
+				viewBox="0 0 20 20"
+				fill="currentColor"
+				aria-hidden="true"
+			>
+				<path
+					fill-rule="evenodd"
+					d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
+					clip-rule="evenodd"
+				/>
+			</svg>
+		</div>
+		{:else}
+		<div
+		class="with-hover:hidden inline-flex justify-center w-32 lg:w-44 rounded-md border border-green-500 px-4 py-1"
+		on:click={() => _applyInputSample(selectedIdx)}
+	>
+			 <p class="text-green-500">Confirm</p>
+			</div>
+		{/if}
 
 	{#if isOptionsVisible}
 		<div
@@ -55,9 +90,15 @@
 			<div class="py-1 bg-white rounded-md" role="none">
 				{#each inputSamples as { example_title }, i}
 					<p
-						class="px-4 py-2 text-sm hover:bg-gray-100 hover:text-gray-900 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+						class="no-hover:hidden px-4 py-2 text-sm hover:bg-gray-100 hover:text-gray-900 dark:hover:bg-gray-800 dark:hover:text-gray-200"
 						on:mouseover={() => _previewInputSample(i)}
 						on:click={() => _applyInputSample(i)}
+					>
+						{example_title}
+					</p>
+					<p
+						class="with-hover:hidden px-4 py-2 text-sm hover:bg-gray-100 hover:text-gray-900 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+						on:click={() => _previewInputSample(i, true)}
 					>
 						{example_title}
 					</p>

--- a/widgets/src/lib/InferenceWidget/shared/WidgetInputSamples/WidgetInputSamples.svelte
+++ b/widgets/src/lib/InferenceWidget/shared/WidgetInputSamples/WidgetInputSamples.svelte
@@ -5,14 +5,14 @@
 	export let applyInputSample: (sample: Record<string, any>) => void;
 	export let previewInputSample: (sample: Record<string, any>) => void;
 
+	let containerEl: HTMLElement;
 	let isOptionsVisible = false;
 	let isTouchOptionClicked = false;
-	let selectedIdx: number;
+	let touchSelectedIdx: number;
 	let title = "Examples";
 
 	function _applyInputSample(idx: number) {
-		isOptionsVisible = false;
-		isTouchOptionClicked = false;
+		hideOptions();
 		const sample = inputSamples[idx];
 		title = sample.example_title;
 		applyInputSample(sample);
@@ -23,16 +23,36 @@
 		previewInputSample(sample);
 		if (isTocuh) {
 			isTouchOptionClicked = true;
-			selectedIdx = idx;
+			touchSelectedIdx = idx;
 		}
 	}
 
 	function toggleOptionsVisibility() {
 		isOptionsVisible = !isOptionsVisible;
 	}
+
+	function onClick(e: MouseEvent | TouchEvent) {
+		let targetElement = e.target;
+		do {
+			if (targetElement == containerEl) {
+				// This is a click inside. Do nothing, just return.
+				return;
+			}
+			targetElement = (targetElement as HTMLElement).parentElement;
+		} while (targetElement);
+		// This is a click outside
+		hideOptions();
+	}
+
+	function hideOptions() {
+		isOptionsVisible = false;
+		isTouchOptionClicked = false;
+	}
 </script>
 
-<div class="relative z-10">
+<svelte:window on:click={onClick} />
+
+<div class="relative z-10" bind:this={containerEl}>
 	<div
 		class="no-hover:hidden inline-flex justify-between w-32 lg:w-44 rounded-md border border-gray-100 px-4 py-1"
 		on:click={toggleOptionsVisibility}
@@ -60,7 +80,8 @@
 		>
 			<p class="text-sm truncate">{title}</p>
 			<svg
-				class="-mr-1 ml-2 h-5 w-5 transition ease-in-out transform"
+				class="-mr-1 ml-2 h-5 w-5 transition ease-in-out transform {isOptionsVisible &&
+					'-rotate-180'}"
 				xmlns="http://www.w3.org/2000/svg"
 				viewBox="0 0 20 20"
 				fill="currentColor"
@@ -76,7 +97,7 @@
 	{:else}
 		<div
 			class="with-hover:hidden inline-flex justify-center w-32 lg:w-44 rounded-md border border-green-500 px-4 py-1"
-			on:click={() => _applyInputSample(selectedIdx)}
+			on:click={() => _applyInputSample(touchSelectedIdx)}
 		>
 			<p class="text-green-500">Confirm</p>
 		</div>

--- a/widgets/src/lib/InferenceWidget/shared/WidgetInputSamples/WidgetInputSamples.svelte
+++ b/widgets/src/lib/InferenceWidget/shared/WidgetInputSamples/WidgetInputSamples.svelte
@@ -20,11 +20,11 @@
 
 	function _previewInputSample(idx: number, isTocuh = false) {
 		const sample = inputSamples[idx];
-		previewInputSample(sample);
 		if (isTocuh) {
 			isTouchOptionClicked = true;
 			touchSelectedIdx = idx;
 		}
+		previewInputSample(sample);
 	}
 
 	function toggleOptionsVisibility() {

--- a/widgets/src/lib/InferenceWidget/shared/WidgetInputSamples/WidgetInputSamples.svelte
+++ b/widgets/src/lib/InferenceWidget/shared/WidgetInputSamples/WidgetInputSamples.svelte
@@ -52,7 +52,7 @@
 
 <svelte:window on:click={onClick} />
 
-<div class="relative z-10" bind:this={containerEl}>
+<div class="relative z-10 ml-2" bind:this={containerEl}>
 	<div
 		class="no-hover:hidden inline-flex justify-between w-32 lg:w-44 rounded-md border border-gray-100 px-4 py-1"
 		on:click={toggleOptionsVisibility}

--- a/widgets/src/lib/InferenceWidget/shared/WidgetWrapper/WidgetWrapper.svelte
+++ b/widgets/src/lib/InferenceWidget/shared/WidgetWrapper/WidgetWrapper.svelte
@@ -57,17 +57,19 @@
 		</button>
 	{/if}
 	<WidgetHeader {noTitle} pipeline={model.pipeline_tag}>
-		{#if model.pipeline_tag === "fill-mask"}
-			Mask token: <code>{model.mask_token}</code>
-		{/if}
-		{#if inputSamples.length > 1}
-			<!-- Show samples selector when there are more than one sample -->
-			<WidgetInputSamples
-				{inputSamples}
-				{applyInputSample}
-				{previewInputSample}
-			/>
-		{/if}
+		<div class="flex items-center">
+			{#if model.pipeline_tag === "fill-mask"}
+				Mask token: <code>{model.mask_token}</code>
+			{/if}
+			{#if inputSamples.length > 1}
+				<!-- Show samples selector when there are more than one sample -->
+				<WidgetInputSamples
+					{inputSamples}
+					{applyInputSample}
+					{previewInputSample}
+				/>
+			{/if}
+		</div>
 	</WidgetHeader>
 	<slot name="top" />
 	<WidgetInfo {computeTime} {error} {modelStatus} />

--- a/widgets/src/lib/InferenceWidget/shared/WidgetWrapper/WidgetWrapper.svelte
+++ b/widgets/src/lib/InferenceWidget/shared/WidgetWrapper/WidgetWrapper.svelte
@@ -20,8 +20,10 @@
 	};
 	export let noTitle = false;
 	export let outputJson: string;
-	export let applyInputSample: (sample: Record<string, any>[]) => void =
-		([]) => {};
+	export let applyInputSample: (sample: Record<string, any>) => void =
+		({}) => {};
+	export let previewInputSample: (sample: Record<string, any>) => void =
+		({}) => {};
 
 	let isMaximized = false;
 	let modelStatus: LoadingStatus = "unknown";
@@ -60,7 +62,11 @@
 		{/if}
 		{#if inputSamples.length > 1}
 			<!-- Show samples selector when there are more than one sample -->
-			<WidgetInputSamples {inputSamples} {applyInputSample} />
+			<WidgetInputSamples
+				{inputSamples}
+				{applyInputSample}
+				{previewInputSample}
+			/>
 		{/if}
 	</WidgetHeader>
 	<slot name="top" />

--- a/widgets/src/lib/InferenceWidget/shared/helpers.ts
+++ b/widgets/src/lib/InferenceWidget/shared/helpers.ts
@@ -40,11 +40,19 @@ export function updateUrl(obj: Record<string, string>) {
 }
 
 // Run through our own proxy to bypass CORS:
-export function proxify(url: string): string {
+function proxify(url: string): string {
 	return url.startsWith(`http://localhost`)
 		|| new URL(url).host === window.location.host
 		? url
 		: `https://widgets-cors-proxy.huggingface.co/proxy?url=${url}`;
+}
+
+// Get BLOB from a given URL after proxifying the URL
+export async function getBlobFromUrl(url: string): Promise<Blob>{
+	const proxiedUrl = proxify(url);
+	const res = await fetch(proxiedUrl);
+	const blob = await res.blob();
+	return blob;
 }
 
 async function callApi(

--- a/widgets/src/lib/InferenceWidget/shared/types.ts
+++ b/widgets/src/lib/InferenceWidget/shared/types.ts
@@ -16,9 +16,16 @@ export type TableData = Record<string, (string | number)[]>;
 
 export type HighlightCoordinates = Record<string, string>;
 
-export type Box = {
+type Box = {
 	xmin: number;
 	ymin: number;
 	xmax: number;
 	ymax: number;
 };
+
+export type DetectedObject = {
+	box: Box;
+	label: string;
+	score: number;
+	color?: string;
+}

--- a/widgets/src/lib/InferenceWidget/widgets/AudioClassificationWidget/AudioClassificationWidget.svelte
+++ b/widgets/src/lib/InferenceWidget/widgets/AudioClassificationWidget/AudioClassificationWidget.svelte
@@ -129,6 +129,7 @@
 		filename = sample.example_title;
 		fileUrl = sample.src;
 		selectedSampleUrl = sample.src;
+		getOutput();
 	}
 
 	function previewInputSample(sample: Record<string, any>) {

--- a/widgets/src/lib/InferenceWidget/widgets/AudioClassificationWidget/AudioClassificationWidget.svelte
+++ b/widgets/src/lib/InferenceWidget/widgets/AudioClassificationWidget/AudioClassificationWidget.svelte
@@ -4,7 +4,6 @@
 	import WidgetAudioTrack from "../../shared/WidgetAudioTrack/WidgetAudioTrack.svelte";
 	import WidgetFileInput from "../../shared/WidgetFileInput/WidgetFileInput.svelte";
 	import WidgetOutputChart from "../../shared/WidgetOutputChart/WidgetOutputChart.svelte";
-	import WidgetRadio from "../../shared/WidgetRadio/WidgetRadio.svelte";
 	import WidgetRecorder from "../../shared/WidgetRecorder/WidgetRecorder.svelte";
 	import WidgetSubmitBtn from "../../shared/WidgetSubmitBtn/WidgetSubmitBtn.svelte";
 	import WidgetWrapper from "../../shared/WidgetWrapper/WidgetWrapper.svelte";
@@ -15,7 +14,6 @@
 	export let model: WidgetProps["model"];
 	export let noTitle: WidgetProps["noTitle"];
 
-	let areSamplesVisible = true;
 	let computeTime = "";
 	let error: string = "";
 	let file: Blob | File | null = null;
@@ -30,15 +28,9 @@
 	let output: Array<{ label: string; score: number }> = [];
 	let outputJson: string;
 	let selectedSampleUrl = "";
-
-	function onChangeRadio() {
-		file = null;
-		filename = "";
-		fileUrl = "";
-	}
+	let shouldAudioAutoplay = true;
 
 	function onRecordStart() {
-		areSamplesVisible = false;
 		file = null;
 		filename = "";
 		fileUrl = "";
@@ -50,7 +42,7 @@
 	}
 
 	function onSelectFile(updatedFile: Blob | File) {
-		areSamplesVisible = false;
+		shouldAudioAutoplay = false;
 		isRecording = false;
 		selectedSampleUrl = "";
 
@@ -133,7 +125,18 @@
 	}
 
 	function applyInputSample(sample: Record<string, any>) {
+		shouldAudioAutoplay = false;
+		filename = sample.example_title;
+		fileUrl = sample.src;
 		selectedSampleUrl = sample.src;
+	}
+
+	function previewInputSample(sample: Record<string, any>) {
+		shouldAudioAutoplay = true;
+		filename = sample.example_title;
+		fileUrl = sample.src;
+		output = [];
+		outputJson = "";
 	}
 </script>
 
@@ -146,6 +149,7 @@
 	{modelLoading}
 	{noTitle}
 	{outputJson}
+	{previewInputSample}
 >
 	<svelte:fragment slot="top">
 		<form>
@@ -164,29 +168,12 @@
 				/>
 			</div>
 			{#if fileUrl}
-				<WidgetAudioTrack classNames="mt-3" label={filename} src={fileUrl} />
-			{/if}
-			{#if model.widgetData}
-				<details
-					open={areSamplesVisible}
-					class="text-gray-500 text-sm mt-4 mb-2"
-				>
-					<summary class="mb-2">Or pick a sample audio file</summary>
-					<div class="mt-4 space-y-5">
-						<!-- Shouldnt this be an option ? -->
-						{#each model.widgetData as widgetData}
-							<WidgetAudioTrack classNames="mt-3" src={String(widgetData.src)}>
-								<WidgetRadio
-									bind:group={selectedSampleUrl}
-									classNames="mb-1.5"
-									label={String(widgetData.label)}
-									onChange={onChangeRadio}
-									value={String(widgetData.src)}
-								/>
-							</WidgetAudioTrack>
-						{/each}
-					</div>
-				</details>
+				<WidgetAudioTrack
+					classNames="mt-3"
+					autoplay={shouldAudioAutoplay}
+					label={filename}
+					src={fileUrl}
+				/>
 			{/if}
 			<WidgetSubmitBtn
 				classNames="mt-2"

--- a/widgets/src/lib/InferenceWidget/widgets/AudioClassificationWidget/AudioClassificationWidget.svelte
+++ b/widgets/src/lib/InferenceWidget/widgets/AudioClassificationWidget/AudioClassificationWidget.svelte
@@ -8,7 +8,7 @@
 	import WidgetRecorder from "../../shared/WidgetRecorder/WidgetRecorder.svelte";
 	import WidgetSubmitBtn from "../../shared/WidgetSubmitBtn/WidgetSubmitBtn.svelte";
 	import WidgetWrapper from "../../shared/WidgetWrapper/WidgetWrapper.svelte";
-	import { getResponse, proxify } from "../../shared/helpers";
+	import { getResponse, getBlobFromUrl } from "../../shared/helpers";
 
 	export let apiToken: WidgetProps["apiToken"];
 	export let apiUrl: WidgetProps["apiUrl"];
@@ -75,9 +75,7 @@
 		}
 
 		if (!file && selectedSampleUrl) {
-			const proxiedUrl = proxify(selectedSampleUrl);
-			const res = await fetch(proxiedUrl);
-			file = await res.blob();
+			file = await getBlobFromUrl(selectedSampleUrl);
 		}
 
 		const requestBody = { file };
@@ -135,7 +133,7 @@
 	}
 
 	function applyInputSample(sample: Record<string, any>) {
-		fileUrl = sample.src;
+		selectedSampleUrl = sample.src;
 	}
 </script>
 

--- a/widgets/src/lib/InferenceWidget/widgets/AudioToAudioWidget/AudioToAudioWidget.svelte
+++ b/widgets/src/lib/InferenceWidget/widgets/AudioToAudioWidget/AudioToAudioWidget.svelte
@@ -3,7 +3,6 @@
 
 	import WidgetAudioTrack from "../../shared/WidgetAudioTrack/WidgetAudioTrack.svelte";
 	import WidgetFileInput from "../../shared/WidgetFileInput/WidgetFileInput.svelte";
-	import WidgetRadio from "../../shared/WidgetRadio/WidgetRadio.svelte";
 	import WidgetRecorder from "../../shared/WidgetRecorder/WidgetRecorder.svelte";
 	import WidgetSubmitBtn from "../../shared/WidgetSubmitBtn/WidgetSubmitBtn.svelte";
 	import WidgetWrapper from "../../shared/WidgetWrapper/WidgetWrapper.svelte";
@@ -14,7 +13,6 @@
 	export let model: WidgetProps["model"];
 	export let noTitle: WidgetProps["noTitle"];
 
-	let areSamplesVisible = true;
 	let computeTime = "";
 	let error: string = "";
 	let file: Blob | File | null = null;
@@ -29,6 +27,7 @@
 	let output: AudioItem[] = [];
 	let outputJson: string;
 	let selectedSampleUrl = "";
+	let shouldAudioAutoplay = true;
 
 	interface AudioItem {
 		blob: string;
@@ -37,14 +36,7 @@
 		"content-type": string;
 	}
 
-	function onChangeRadio() {
-		file = null;
-		filename = "";
-		fileUrl = "";
-	}
-
 	function onRecordStart() {
-		areSamplesVisible = false;
 		file = null;
 		filename = "";
 		fileUrl = "";
@@ -56,7 +48,7 @@
 	}
 
 	function onSelectFile(updatedFile: Blob | File) {
-		areSamplesVisible = false;
+		shouldAudioAutoplay = false;
 		isRecording = false;
 		selectedSampleUrl = "";
 		if (updatedFile.size !== 0) {
@@ -139,7 +131,18 @@
 	}
 
 	function applyInputSample(sample: Record<string, any>) {
+		shouldAudioAutoplay = false;
+		filename = sample.example_title;
+		fileUrl = sample.src;
 		selectedSampleUrl = sample.src;
+	}
+
+	function previewInputSample(sample: Record<string, any>) {
+		shouldAudioAutoplay = true;
+		filename = sample.example_title;
+		fileUrl = sample.src;
+		output = [];
+		outputJson = "";
 	}
 </script>
 
@@ -152,6 +155,7 @@
 	{modelLoading}
 	{noTitle}
 	{outputJson}
+	{previewInputSample}
 >
 	<svelte:fragment slot="top">
 		<form>
@@ -170,28 +174,12 @@
 				/>
 			</div>
 			{#if fileUrl}
-				<WidgetAudioTrack classNames="mt-3" label={filename} src={fileUrl} />
-			{/if}
-			{#if model.widgetData}
-				<details
-					open={areSamplesVisible}
-					class="text-gray-500 text-sm mt-4 mb-2"
-				>
-					<summary class="mb-2">Or pick a sample audio file</summary>
-					<div class="mt-4 space-y-5">
-						{#each model.widgetData as widgetData}
-							<WidgetAudioTrack classNames="mt-3" src={String(widgetData.src)}>
-								<WidgetRadio
-									bind:group={selectedSampleUrl}
-									classNames="mb-1.5"
-									label={String(widgetData.label)}
-									onChange={onChangeRadio}
-									value={String(widgetData.src)}
-								/>
-							</WidgetAudioTrack>
-						{/each}
-					</div>
-				</details>
+				<WidgetAudioTrack
+					classNames="mt-3"
+					autoplay={shouldAudioAutoplay}
+					label={filename}
+					src={fileUrl}
+				/>
 			{/if}
 			<WidgetSubmitBtn
 				classNames="mt-2"

--- a/widgets/src/lib/InferenceWidget/widgets/AudioToAudioWidget/AudioToAudioWidget.svelte
+++ b/widgets/src/lib/InferenceWidget/widgets/AudioToAudioWidget/AudioToAudioWidget.svelte
@@ -7,7 +7,7 @@
 	import WidgetRecorder from "../../shared/WidgetRecorder/WidgetRecorder.svelte";
 	import WidgetSubmitBtn from "../../shared/WidgetSubmitBtn/WidgetSubmitBtn.svelte";
 	import WidgetWrapper from "../../shared/WidgetWrapper/WidgetWrapper.svelte";
-	import { getResponse, proxify } from "../../shared/helpers";
+	import { getResponse, getBlobFromUrl } from "../../shared/helpers";
 
 	export let apiToken: WidgetProps["apiToken"];
 	export let apiUrl: WidgetProps["apiUrl"];
@@ -78,9 +78,7 @@
 		}
 
 		if (!file && selectedSampleUrl) {
-			const proxiedUrl = proxify(selectedSampleUrl);
-			const res = await fetch(proxiedUrl);
-			file = await res.blob();
+			file = await getBlobFromUrl(selectedSampleUrl);
 		}
 		const requestBody = { file };
 
@@ -141,7 +139,7 @@
 	}
 
 	function applyInputSample(sample: Record<string, any>) {
-		fileUrl = sample.src;
+		selectedSampleUrl = sample.src;
 	}
 </script>
 

--- a/widgets/src/lib/InferenceWidget/widgets/AudioToAudioWidget/AudioToAudioWidget.svelte
+++ b/widgets/src/lib/InferenceWidget/widgets/AudioToAudioWidget/AudioToAudioWidget.svelte
@@ -135,6 +135,7 @@
 		filename = sample.example_title;
 		fileUrl = sample.src;
 		selectedSampleUrl = sample.src;
+		getOutput();
 	}
 
 	function previewInputSample(sample: Record<string, any>) {

--- a/widgets/src/lib/InferenceWidget/widgets/AutomaticSpeechRecognitionWidget/AutomaticSpeechRecognitionWidget.svelte
+++ b/widgets/src/lib/InferenceWidget/widgets/AutomaticSpeechRecognitionWidget/AutomaticSpeechRecognitionWidget.svelte
@@ -118,6 +118,7 @@
 		filename = sample.example_title;
 		fileUrl = sample.src;
 		selectedSampleUrl = sample.src;
+		getOutput();
 	}
 
 	function previewInputSample(sample: Record<string, any>) {

--- a/widgets/src/lib/InferenceWidget/widgets/AutomaticSpeechRecognitionWidget/AutomaticSpeechRecognitionWidget.svelte
+++ b/widgets/src/lib/InferenceWidget/widgets/AutomaticSpeechRecognitionWidget/AutomaticSpeechRecognitionWidget.svelte
@@ -4,7 +4,6 @@
 	import WidgetAudioTrack from "../../shared/WidgetAudioTrack/WidgetAudioTrack.svelte";
 	import WidgetFileInput from "../../shared/WidgetFileInput/WidgetFileInput.svelte";
 	import WidgetOutputText from "../../shared/WidgetOutputText/WidgetOutputText.svelte";
-	import WidgetRadio from "../../shared/WidgetRadio/WidgetRadio.svelte";
 	import WidgetRecorder from "../../shared/WidgetRecorder/WidgetRecorder.svelte";
 	import WidgetSubmitBtn from "../../shared/WidgetSubmitBtn/WidgetSubmitBtn.svelte";
 	import WidgetWrapper from "../../shared/WidgetWrapper/WidgetWrapper.svelte";
@@ -15,7 +14,6 @@
 	export let model: WidgetProps["model"];
 	export let noTitle: WidgetProps["noTitle"];
 
-	let areSamplesVisible = true;
 	let computeTime = "";
 	let error: string = "";
 	let file: Blob | File | null = null;
@@ -30,15 +28,9 @@
 	let output = "";
 	let outputJson: string;
 	let selectedSampleUrl = "";
-
-	function onChangeRadio() {
-		file = null;
-		filename = "";
-		fileUrl = "";
-	}
+	let shouldAudioAutoplay = true;
 
 	function onRecordStart() {
-		areSamplesVisible = false;
 		file = null;
 		filename = "";
 		fileUrl = "";
@@ -50,7 +42,7 @@
 	}
 
 	function onSelectFile(updatedFile: Blob | File) {
-		areSamplesVisible = false;
+		shouldAudioAutoplay = false;
 		isRecording = false;
 		selectedSampleUrl = "";
 
@@ -122,7 +114,18 @@
 	}
 
 	function applyInputSample(sample: Record<string, any>) {
+		shouldAudioAutoplay = false;
+		filename = sample.example_title;
+		fileUrl = sample.src;
 		selectedSampleUrl = sample.src;
+	}
+
+	function previewInputSample(sample: Record<string, any>) {
+		shouldAudioAutoplay = true;
+		filename = sample.example_title;
+		fileUrl = sample.src;
+		output = "";
+		outputJson = "";
 	}
 </script>
 
@@ -135,6 +138,7 @@
 	{modelLoading}
 	{noTitle}
 	{outputJson}
+	{previewInputSample}
 >
 	<svelte:fragment slot="top">
 		<form>
@@ -153,29 +157,12 @@
 				/>
 			</div>
 			{#if fileUrl}
-				<WidgetAudioTrack classNames="mt-3" label={filename} src={fileUrl} />
-			{/if}
-			{#if model.widgetData}
-				<details
-					open={areSamplesVisible}
-					class="text-gray-500 text-sm mt-4 mb-2"
-				>
-					<summary class="mb-2">Or pick a sample audio file</summary>
-					<div class="mt-4 space-y-5">
-						<!-- Shouldnt this be an option ? -->
-						{#each model.widgetData as widgetData}
-							<WidgetAudioTrack classNames="mt-3" src={String(widgetData.src)}>
-								<WidgetRadio
-									bind:group={selectedSampleUrl}
-									classNames="mb-1.5"
-									label={String(widgetData.label)}
-									onChange={onChangeRadio}
-									value={String(widgetData.src)}
-								/>
-							</WidgetAudioTrack>
-						{/each}
-					</div>
-				</details>
+				<WidgetAudioTrack
+					classNames="mt-3"
+					autoplay={shouldAudioAutoplay}
+					label={filename}
+					src={fileUrl}
+				/>
 			{/if}
 			<WidgetSubmitBtn
 				classNames="mt-2"

--- a/widgets/src/lib/InferenceWidget/widgets/AutomaticSpeechRecognitionWidget/AutomaticSpeechRecognitionWidget.svelte
+++ b/widgets/src/lib/InferenceWidget/widgets/AutomaticSpeechRecognitionWidget/AutomaticSpeechRecognitionWidget.svelte
@@ -8,7 +8,7 @@
 	import WidgetRecorder from "../../shared/WidgetRecorder/WidgetRecorder.svelte";
 	import WidgetSubmitBtn from "../../shared/WidgetSubmitBtn/WidgetSubmitBtn.svelte";
 	import WidgetWrapper from "../../shared/WidgetWrapper/WidgetWrapper.svelte";
-	import { getResponse, proxify } from "../../shared/helpers";
+	import { getResponse, getBlobFromUrl } from "../../shared/helpers";
 
 	export let apiToken: WidgetProps["apiToken"];
 	export let apiUrl: WidgetProps["apiUrl"];
@@ -75,9 +75,7 @@
 		}
 
 		if (!file && selectedSampleUrl) {
-			const proxiedUrl = proxify(selectedSampleUrl);
-			const res = await fetch(proxiedUrl);
-			file = await res.blob();
+			file = await getBlobFromUrl(selectedSampleUrl);
 		}
 
 		const requestBody = { file };
@@ -124,7 +122,7 @@
 	}
 
 	function applyInputSample(sample: Record<string, any>) {
-		fileUrl = sample.src;
+		selectedSampleUrl = sample.src;
 	}
 </script>
 

--- a/widgets/src/lib/InferenceWidget/widgets/ConversationalWidget/ConversationalWidget.svelte
+++ b/widgets/src/lib/InferenceWidget/widgets/ConversationalWidget/ConversationalWidget.svelte
@@ -153,8 +153,13 @@
 		);
 	}
 
+	function previewInputSample(sample: Record<string, any>) {
+		text = sample.text;
+	}
+
 	function applyInputSample(sample: Record<string, any>) {
 		text = sample.text;
+		getOutput();
 	}
 </script>
 
@@ -167,6 +172,7 @@
 	{modelLoading}
 	{noTitle}
 	{outputJson}
+	{previewInputSample}
 >
 	<svelte:fragment slot="top">
 		<WidgetOutputConvo modelId={model.id} {output} />

--- a/widgets/src/lib/InferenceWidget/widgets/FeatureExtractionWidget/FeatureExtractionWidget.svelte
+++ b/widgets/src/lib/InferenceWidget/widgets/FeatureExtractionWidget/FeatureExtractionWidget.svelte
@@ -121,8 +121,13 @@
 		return Math.ceil(total_elems / SINGLE_DIM_COLS);
 	};
 
+	function previewInputSample(sample: Record<string, any>) {
+		text = sample.text;
+	}
+
 	function applyInputSample(sample: Record<string, any>) {
 		text = sample.text;
+		getOutput();
 	}
 </script>
 
@@ -135,6 +140,7 @@
 	{modelLoading}
 	{noTitle}
 	{outputJson}
+	{previewInputSample}
 >
 	<svelte:fragment slot="top">
 		<form>

--- a/widgets/src/lib/InferenceWidget/widgets/FillMaskWidget/FillMaskWidget.svelte
+++ b/widgets/src/lib/InferenceWidget/widgets/FillMaskWidget/FillMaskWidget.svelte
@@ -114,8 +114,13 @@
 		throw new TypeError("Invalid output: output must be of type Array");
 	}
 
+	function previewInputSample(sample: Record<string, any>) {
+		text = sample.text;
+	}
+
 	function applyInputSample(sample: Record<string, any>) {
 		text = sample.text;
+		getOutput();
 	}
 </script>
 
@@ -128,6 +133,7 @@
 	{modelLoading}
 	{noTitle}
 	{outputJson}
+	{previewInputSample}
 >
 	<svelte:fragment slot="top">
 		<form>

--- a/widgets/src/lib/InferenceWidget/widgets/ImageClassificationWidget/ImageClassificationWidget.svelte
+++ b/widgets/src/lib/InferenceWidget/widgets/ImageClassificationWidget/ImageClassificationWidget.svelte
@@ -92,6 +92,12 @@
 		const blob = await getBlobFromUrl(imgSrc);
 		getOutput(blob);
 	}
+
+	function previewInputSample(sample: Record<string, any>) {
+		imgSrc = sample.src;
+		output = [];
+		outputJson = "";
+	}
 </script>
 
 <WidgetWrapper
@@ -103,6 +109,7 @@
 	{modelLoading}
 	{noTitle}
 	{outputJson}
+	{previewInputSample}
 >
 	<svelte:fragment slot="top">
 		<form>

--- a/widgets/src/lib/InferenceWidget/widgets/ImageClassificationWidget/ImageClassificationWidget.svelte
+++ b/widgets/src/lib/InferenceWidget/widgets/ImageClassificationWidget/ImageClassificationWidget.svelte
@@ -5,7 +5,7 @@
 	import WidgetDropzone from "../../shared/WidgetDropzone/WidgetDropzone.svelte";
 	import WidgetOutputChart from "../../shared/WidgetOutputChart/WidgetOutputChart.svelte";
 	import WidgetWrapper from "../../shared/WidgetWrapper/WidgetWrapper.svelte";
-	import { getResponse } from "../../shared/helpers";
+	import { getResponse, getBlobFromUrl } from "../../shared/helpers";
 
 	export let apiToken: WidgetProps["apiToken"];
 	export let apiUrl: WidgetProps["apiUrl"];
@@ -87,8 +87,10 @@
 		);
 	}
 
-	function applyInputSample(sample: Record<string, any>) {
-		imgSrc = sample.src;
+	async function applyInputSample(sample: Record<string, any>) {
+		imgSrc = sample.image;
+		const blob = await getBlobFromUrl(imgSrc);
+		getOutput(blob);
 	}
 </script>
 

--- a/widgets/src/lib/InferenceWidget/widgets/ImageClassificationWidget/ImageClassificationWidget.svelte
+++ b/widgets/src/lib/InferenceWidget/widgets/ImageClassificationWidget/ImageClassificationWidget.svelte
@@ -88,7 +88,7 @@
 	}
 
 	async function applyInputSample(sample: Record<string, any>) {
-		imgSrc = sample.image;
+		imgSrc = sample.src;
 		const blob = await getBlobFromUrl(imgSrc);
 		getOutput(blob);
 	}

--- a/widgets/src/lib/InferenceWidget/widgets/ImageClassificationWidget/ImageClassificationWidget.svelte
+++ b/widgets/src/lib/InferenceWidget/widgets/ImageClassificationWidget/ImageClassificationWidget.svelte
@@ -131,7 +131,7 @@
 			<!-- Better UX for mobile/table through CSS breakpoints -->
 			{#if imgSrc}
 				{#if imgSrc}
-					<div class="mb-2 flex justify-center bg-gray-50 with-hover:hidden">
+					<div class="mb-2 flex justify-center bg-gray-50 dark:bg-gray-900 with-hover:hidden">
 						<img src={imgSrc} class="pointer-events-none max-h-44" alt="" />
 					</div>
 				{/if}

--- a/widgets/src/lib/InferenceWidget/widgets/ImageClassificationWidget/ImageClassificationWidget.svelte
+++ b/widgets/src/lib/InferenceWidget/widgets/ImageClassificationWidget/ImageClassificationWidget.svelte
@@ -131,7 +131,9 @@
 			<!-- Better UX for mobile/table through CSS breakpoints -->
 			{#if imgSrc}
 				{#if imgSrc}
-					<div class="mb-2 flex justify-center bg-gray-50 dark:bg-gray-900 with-hover:hidden">
+					<div
+						class="mb-2 flex justify-center bg-gray-50 dark:bg-gray-900 with-hover:hidden"
+					>
 						<img src={imgSrc} class="pointer-events-none max-h-44" alt="" />
 					</div>
 				{/if}

--- a/widgets/src/lib/InferenceWidget/widgets/ObjectDetectionWidget/ObjectDetectionWidget.svelte
+++ b/widgets/src/lib/InferenceWidget/widgets/ObjectDetectionWidget/ObjectDetectionWidget.svelte
@@ -7,7 +7,7 @@
 	import WidgetDropzone from "../../shared/WidgetDropzone/WidgetDropzone.svelte";
 	import WidgetOutputChart from "../../shared/WidgetOutputChart/WidgetOutputChart.svelte";
 	import WidgetWrapper from "../../shared/WidgetWrapper/WidgetWrapper.svelte";
-	import { getResponse } from "../../shared/helpers";
+	import { getResponse, getBlobFromUrl } from "../../shared/helpers";
 
 	export let apiToken: WidgetProps["apiToken"];
 	export let apiUrl: WidgetProps["apiUrl"];
@@ -135,8 +135,10 @@
 		highlightIndex = index;
 	}
 
-	function applyInputSample(sample: Record<string, any>) {
-		imgSrc = sample.src;
+	async function applyInputSample(sample: Record<string, any>) {
+		imgSrc = sample.image;
+		const blob = await getBlobFromUrl(imgSrc);
+		getOutput(blob);
 	}
 </script>
 

--- a/widgets/src/lib/InferenceWidget/widgets/ObjectDetectionWidget/ObjectDetectionWidget.svelte
+++ b/widgets/src/lib/InferenceWidget/widgets/ObjectDetectionWidget/ObjectDetectionWidget.svelte
@@ -136,7 +136,7 @@
 	}
 
 	async function applyInputSample(sample: Record<string, any>) {
-		imgSrc = sample.image;
+		imgSrc = sample.src;
 		const blob = await getBlobFromUrl(imgSrc);
 		getOutput(blob);
 	}

--- a/widgets/src/lib/InferenceWidget/widgets/ObjectDetectionWidget/SvgBoundingBoxes.svelte
+++ b/widgets/src/lib/InferenceWidget/widgets/ObjectDetectionWidget/SvgBoundingBoxes.svelte
@@ -10,7 +10,7 @@ text-cyan-400
 text-lime-400
  -->
 <script>
-	import type { Box } from "../../shared/types";
+	import type { DetectedObject } from "../../shared/types";
 
 	import { afterUpdate } from "svelte";
 
@@ -29,7 +29,7 @@ text-lime-400
 	export let classNames = "";
 	export let highlightIndex = -1;
 	export let imgSrc: string;
-	export let output: Array<{ box: Box; color: string }> = [];
+	export let output: DetectedObject[] = [];
 	export let mouseover: (index: number) => void = () => {};
 	export let mouseout: () => void = () => {};
 

--- a/widgets/src/lib/InferenceWidget/widgets/QuestionAnsweringWidget/QuestionAnsweringWidget.svelte
+++ b/widgets/src/lib/InferenceWidget/widgets/QuestionAnsweringWidget/QuestionAnsweringWidget.svelte
@@ -128,9 +128,15 @@
 		);
 	}
 
+	function previewInputSample(sample: Record<string, any>) {
+		question = sample.text;
+		context = sample.context;
+	}
+
 	function applyInputSample(sample: Record<string, any>) {
 		question = sample.text;
 		context = sample.context;
+		getOutput();
 	}
 </script>
 
@@ -143,6 +149,7 @@
 	{modelLoading}
 	{noTitle}
 	{outputJson}
+	{previewInputSample}
 >
 	<svelte:fragment slot="top">
 		<form class="space-y-2">

--- a/widgets/src/lib/InferenceWidget/widgets/SentenceSimilarityWidget/SentenceSimilarityWidget.svelte
+++ b/widgets/src/lib/InferenceWidget/widgets/SentenceSimilarityWidget/SentenceSimilarityWidget.svelte
@@ -126,10 +126,17 @@
 		throw new TypeError("Invalid output: output must be of type Array");
 	}
 
+	function previewInputSample(sample: Record<string, any>) {
+		sourceSentence = sample.source_sentence;
+		comparisonSentences = sample.sentences;
+		nComparisonSentences = comparisonSentences.length;
+	}
+
 	function applyInputSample(sample: Record<string, any>) {
 		sourceSentence = sample.source_sentence;
 		comparisonSentences = sample.sentences;
 		nComparisonSentences = comparisonSentences.length;
+		getOutput();
 	}
 </script>
 
@@ -142,6 +149,7 @@
 	{modelLoading}
 	{noTitle}
 	{outputJson}
+	{previewInputSample}
 >
 	<svelte:fragment slot="top">
 		<form class="flex flex-col space-y-2">

--- a/widgets/src/lib/InferenceWidget/widgets/StructuredDataClassificationWidget/StructuredDataClassificationWidget.svelte
+++ b/widgets/src/lib/InferenceWidget/widgets/StructuredDataClassificationWidget/StructuredDataClassificationWidget.svelte
@@ -184,8 +184,13 @@
 		}, {});
 	}
 
+	function previewInputSample(sample: Record<string, any>) {
+		table = sample.structuredData;
+	}
+
 	function applyInputSample(sample: Record<string, any>) {
 		table = sample.structuredData;
+		getOutput();
 	}
 </script>
 
@@ -198,6 +203,7 @@
 	{modelLoading}
 	{noTitle}
 	{outputJson}
+	{previewInputSample}
 >
 	<svelte:fragment slot="top">
 		<form>

--- a/widgets/src/lib/InferenceWidget/widgets/SummarizationWidget/SummarizationWidget.svelte
+++ b/widgets/src/lib/InferenceWidget/widgets/SummarizationWidget/SummarizationWidget.svelte
@@ -106,8 +106,13 @@
 		);
 	}
 
+	function previewInputSample(sample: Record<string, any>) {
+		text = sample.text;
+	}
+
 	function applyInputSample(sample: Record<string, any>) {
 		text = sample.text;
+		getOutput();
 	}
 </script>
 
@@ -120,6 +125,7 @@
 	{modelLoading}
 	{noTitle}
 	{outputJson}
+	{previewInputSample}
 >
 	<svelte:fragment slot="top">
 		<form class="space-y-2">

--- a/widgets/src/lib/InferenceWidget/widgets/TableQuestionAnsweringWidget/TableQuestionAnsweringWidget.svelte
+++ b/widgets/src/lib/InferenceWidget/widgets/TableQuestionAnsweringWidget/TableQuestionAnsweringWidget.svelte
@@ -155,9 +155,15 @@
 		);
 	}
 
+	function previewInputSample(sample: Record<string, any>) {
+		query = sample.text;
+		table = sample.table;
+	}
+
 	function applyInputSample(sample: Record<string, any>) {
 		query = sample.text;
 		table = sample.table;
+		getOutput();
 	}
 </script>
 
@@ -170,6 +176,7 @@
 	{modelLoading}
 	{noTitle}
 	{outputJson}
+	{previewInputSample}
 >
 	<svelte:fragment slot="top">
 		<form>

--- a/widgets/src/lib/InferenceWidget/widgets/TextGenerationWidget/TextGenerationWidget.svelte
+++ b/widgets/src/lib/InferenceWidget/widgets/TextGenerationWidget/TextGenerationWidget.svelte
@@ -121,8 +121,13 @@
 		);
 	}
 
+	function previewInputSample(sample: Record<string, any>) {
+		text = sample.text;
+	}
+
 	function applyInputSample(sample: Record<string, any>) {
 		text = sample.text;
+		getOutput();
 	}
 </script>
 
@@ -135,6 +140,7 @@
 	{modelLoading}
 	{noTitle}
 	{outputJson}
+	{previewInputSample}
 >
 	<svelte:fragment slot="top">
 		<form class="space-y-2">

--- a/widgets/src/lib/InferenceWidget/widgets/TextToImageWidget/TextToImageWidget.svelte
+++ b/widgets/src/lib/InferenceWidget/widgets/TextToImageWidget/TextToImageWidget.svelte
@@ -103,8 +103,13 @@
 		);
 	}
 
+	function previewInputSample(sample: Record<string, any>) {
+		text = sample.text;
+	}
+
 	function applyInputSample(sample: Record<string, any>) {
 		text = sample.text;
+		getOutput();
 	}
 </script>
 
@@ -117,6 +122,7 @@
 	{modelLoading}
 	{noTitle}
 	{outputJson}
+	{previewInputSample}
 >
 	<svelte:fragment slot="top">
 		<form>

--- a/widgets/src/lib/InferenceWidget/widgets/TextToSpeechWidget/TextToSpeechWidget.svelte
+++ b/widgets/src/lib/InferenceWidget/widgets/TextToSpeechWidget/TextToSpeechWidget.svelte
@@ -104,8 +104,13 @@
 		);
 	}
 
+	function previewInputSample(sample: Record<string, any>) {
+		text = sample.text;
+	}
+
 	function applyInputSample(sample: Record<string, any>) {
 		text = sample.text;
+		getOutput();
 	}
 </script>
 
@@ -118,6 +123,7 @@
 	{modelLoading}
 	{noTitle}
 	{outputJson}
+	{previewInputSample}
 >
 	<svelte:fragment slot="top">
 		<form>

--- a/widgets/src/lib/InferenceWidget/widgets/TokenClassificationWidget/TokenClassificationWidget.svelte
+++ b/widgets/src/lib/InferenceWidget/widgets/TokenClassificationWidget/TokenClassificationWidget.svelte
@@ -228,8 +228,13 @@
 		return a.type === b.type && a.start === b.start && a.end === b.end;
 	}
 
+	function previewInputSample(sample: Record<string, any>) {
+		text = sample.text;
+	}
+
 	function applyInputSample(sample: Record<string, any>) {
 		text = sample.text;
+		getOutput();
 	}
 </script>
 
@@ -242,6 +247,7 @@
 	{modelLoading}
 	{noTitle}
 	{outputJson}
+	{previewInputSample}
 >
 	<svelte:fragment slot="top">
 		<form>

--- a/widgets/src/lib/InferenceWidget/widgets/ZeroShowClassificationWidget/ZeroShotClassificationWidget.svelte
+++ b/widgets/src/lib/InferenceWidget/widgets/ZeroShowClassificationWidget/ZeroShotClassificationWidget.svelte
@@ -149,10 +149,17 @@
 		);
 	}
 
+	function previewInputSample(sample: Record<string, any>) {
+		candidateLabels = sample.candidate_labels;
+		multiClass = sample.multi_class;
+		text = sample.text;
+	}
+
 	function applyInputSample(sample: Record<string, any>) {
 		candidateLabels = sample.candidate_labels;
 		multiClass = sample.multi_class;
 		text = sample.text;
+		getOutput();
 	}
 </script>
 
@@ -165,6 +172,7 @@
 	{modelLoading}
 	{noTitle}
 	{outputJson}
+	{previewInputSample}
 >
 	<svelte:fragment slot="top">
 		<form class="flex flex-col space-y-2">

--- a/widgets/src/routes/index.svelte
+++ b/widgets/src/routes/index.svelte
@@ -132,7 +132,7 @@
 			],
 		},
 		{
-			id: "google/t5-small-ssm-nq",
+			id: "bigscience/T0pp",
 			pipeline_tag: "text2text-generation",
 		},
 		{


### PR DESCRIPTION
# This PR fixed #438 for vision & audio widgets
Update: vision & audio preview before selecting

| Vision widget                                                                                         | Audio widget                                                                                          |
|-------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------|
| <video src="https://user-images.githubusercontent.com/11827707/139964749-2e608b42-e139-41fb-a0c9-0a3dbf3ec3b3.mov" controls autoplay loop/> | <video src="https://user-images.githubusercontent.com/11827707/139964788-e0176b92-c6c3-4b74-8186-06d451eca979.mov" controls autoplay loop/> |

| NLP widget                                                                                         | Mobile widget                                                                                          |
|-------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------|
| <video src="https://user-images.githubusercontent.com/11827707/140034453-ebd742ab-b419-42d6-91fe-d5d6e788aac6.mov" controls autoplay loop/> | <video src="https://user-images.githubusercontent.com/11827707/140034987-341a2f5d-ee2c-44d9-bb54-0979bc80c5de.mov" controls autoplay loop/> |

For the audio widgets, the audio autoplays during the examples previews

Removed "old" audio sample picker since it is redundant now
<img width="350" alt="Screenshot 2021-11-01 at 09 22 34" src="https://user-images.githubusercontent.com/11827707/139642841-ca20f630-9103-48b3-8310-0639d73db8eb.png">

