### PR TITLE
Fix typing-extensions minimum version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ install_requires = [
     "requests",
     "tqdm",
     "pyyaml",
-    "typing-extensions",
+    "typing-extensions>=3.7.4.3",  # to be able to import TypeAlias
     "importlib_metadata;python_version<'3.8'",
     "packaging>=20.9",
 ]


### PR DESCRIPTION
To be able to do
```python
from typing_extensions import TypeAlias
```

we need to have `typing-extensions>=3.7.4.3`

Fix https://github.com/huggingface/huggingface_hub/issues/452