### PR TITLE
Remove beta Spaces

### DIFF
--- a/docs/hub/_sections.yml
+++ b/docs/hub/_sections.yml
@@ -17,7 +17,7 @@
   title: Hub API Endpoints
 
 - local: spaces
-  title: Spaces documentation (beta)
+  title: Spaces documentation
 
 - local: adding-a-library
   title: Integrate a library with the Hub


### PR DESCRIPTION
Remove "beta" from Spaces in the docs side navigation menu.