### PR TITLE
Update some widgets to use `textarea` rather than `input`

### DIFF
--- a/widgets/src/lib/InferenceWidget/shared/WidgetTextarea/WidgetTextarea.svelte
+++ b/widgets/src/lib/InferenceWidget/shared/WidgetTextarea/WidgetTextarea.svelte
@@ -12,7 +12,7 @@
 			bind:textContent={value}
 			class="{label
 				? 'mt-1.5'
-				: ''} block overflow-auto resize-y py-1 px-2 w-full max-h-[500px] border border-gray-200 rounded-lg shadow-inner outline-none focus:ring-1 focus:ring-inset focus:ring-indigo-200 focus:shadow-inner dark:bg-gray-925"
+				: ''} block overflow-auto resize-y py-2 px-3 w-full max-h-[500px] border border-gray-200 rounded-lg shadow-inner outline-none focus:ring-1 focus:ring-inset focus:ring-indigo-200 focus:shadow-inner dark:bg-gray-925"
 			role="textbox"
 			contenteditable
 			style="--placeholder: '{placeholder}'"

--- a/widgets/src/lib/InferenceWidget/shared/WidgetTextarea/WidgetTextarea.svelte
+++ b/widgets/src/lib/InferenceWidget/shared/WidgetTextarea/WidgetTextarea.svelte
@@ -4,15 +4,28 @@
 	export let label: string = "";
 	export let placeholder: string = "Your sentence here...";
 	export let value: string;
+
+	let spanEl: HTMLSpanElement;
+	let textContent: string;
+
+	// hack to handle FireFox contenteditable bug
+	$: {
+		if (spanEl && value.includes("contenteditable")) {
+			value = textContent;
+			spanEl.blur();
+		}
+	}
 </script>
 
 <WidgetLabel {label}>
 	<svelte:fragment slot="after">
 		<span
-			bind:textContent={value}
+			bind:innerHTML={value}
+			bind:textContent
+			bind:this={spanEl}
 			class="{label
 				? 'mt-1.5'
-				: ''} block overflow-auto resize-y py-2 px-3 w-full max-h-[500px] border border-gray-200 rounded-lg shadow-inner outline-none focus:ring-1 focus:ring-inset focus:ring-indigo-200 focus:shadow-inner dark:bg-gray-925"
+				: ''} block overflow-auto resize-y py-2 px-3 w-full min-h-[42px] max-h-[500px] border border-gray-200 rounded-lg shadow-inner outline-none focus:ring-1 focus:ring-inset focus:ring-indigo-200 focus:shadow-inner dark:bg-gray-925"
 			role="textbox"
 			contenteditable
 			style="--placeholder: '{placeholder}'"

--- a/widgets/src/lib/InferenceWidget/shared/WidgetTextarea/WidgetTextarea.svelte
+++ b/widgets/src/lib/InferenceWidget/shared/WidgetTextarea/WidgetTextarea.svelte
@@ -8,13 +8,21 @@
 
 <WidgetLabel {label}>
 	<svelte:fragment slot="after">
-		<textarea
-			bind:value
+		<span
+			bind:textContent={value}
 			class="{label
 				? 'mt-1.5'
-				: ''} block w-full border border-gray-200 rounded-lg shadow-inner outline-none focus:ring-1 focus:ring-inset focus:ring-indigo-200 focus:shadow-inner dark:bg-gray-925"
-			{placeholder}
-			rows="3"
+				: ''} block overflow-auto resize-y py-1 px-2 w-full max-h-[500px] border border-gray-200 rounded-lg shadow-inner outline-none focus:ring-1 focus:ring-inset focus:ring-indigo-200 focus:shadow-inner dark:bg-gray-925"
+			role="textbox"
+			contenteditable
+			style="--placeholder: '{placeholder}'"
 		/>
 	</svelte:fragment>
 </WidgetLabel>
+
+<style>
+	span[contenteditable]:empty::before {
+		content: var(--placeholder);
+		color: rgba(156, 163, 175);
+	}
+</style>

--- a/widgets/src/lib/InferenceWidget/widgets/FillMaskWidget/FillMaskWidget.svelte
+++ b/widgets/src/lib/InferenceWidget/widgets/FillMaskWidget/FillMaskWidget.svelte
@@ -3,7 +3,8 @@
 
 	import { onMount } from "svelte";
 	import WidgetOutputChart from "../../shared/WidgetOutputChart/WidgetOutputChart.svelte";
-	import WidgetQuickInput from "../../shared/WidgetQuickInput/WidgetQuickInput.svelte";
+	import WidgetTextarea from "../../shared/WidgetTextarea/WidgetTextarea.svelte";
+	import WidgetSubmitBtn from "../../shared/WidgetSubmitBtn/WidgetSubmitBtn.svelte";
 	import WidgetWrapper from "../../shared/WidgetWrapper/WidgetWrapper.svelte";
 	import {
 		addInferenceParameters,
@@ -138,10 +139,10 @@
 >
 	<svelte:fragment slot="top">
 		<form>
-			<WidgetQuickInput
-				bind:value={text}
+			<WidgetTextarea bind:value={text} />
+			<WidgetSubmitBtn
 				{isLoading}
-				onClickSubmitBtn={() => {
+				onClick={() => {
 					getOutput();
 				}}
 			/>

--- a/widgets/src/lib/InferenceWidget/widgets/FillMaskWidget/FillMaskWidget.svelte
+++ b/widgets/src/lib/InferenceWidget/widgets/FillMaskWidget/FillMaskWidget.svelte
@@ -141,6 +141,7 @@
 		<form>
 			<WidgetTextarea bind:value={text} />
 			<WidgetSubmitBtn
+				classNames="mt-2"
 				{isLoading}
 				onClick={() => {
 					getOutput();

--- a/widgets/src/lib/InferenceWidget/widgets/TextToSpeechWidget/TextToSpeechWidget.svelte
+++ b/widgets/src/lib/InferenceWidget/widgets/TextToSpeechWidget/TextToSpeechWidget.svelte
@@ -2,8 +2,9 @@
 	import type { WidgetProps } from "../../shared/types";
 
 	import { onMount } from "svelte";
-	import WidgetQuickInput from "../../shared/WidgetQuickInput/WidgetQuickInput.svelte";
 	import WidgetAudioTrack from "../../shared/WidgetAudioTrack/WidgetAudioTrack.svelte";
+	import WidgetTextarea from "../../shared/WidgetTextarea/WidgetTextarea.svelte";
+	import WidgetSubmitBtn from "../../shared/WidgetSubmitBtn/WidgetSubmitBtn.svelte";
 	import WidgetWrapper from "../../shared/WidgetWrapper/WidgetWrapper.svelte";
 	import {
 		addInferenceParameters,
@@ -128,10 +129,10 @@
 >
 	<svelte:fragment slot="top">
 		<form>
-			<WidgetQuickInput
-				bind:value={text}
+			<WidgetTextarea bind:value={text} />
+			<WidgetSubmitBtn
 				{isLoading}
-				onClickSubmitBtn={() => {
+				onClick={() => {
 					getOutput();
 				}}
 			/>

--- a/widgets/src/lib/InferenceWidget/widgets/TextToSpeechWidget/TextToSpeechWidget.svelte
+++ b/widgets/src/lib/InferenceWidget/widgets/TextToSpeechWidget/TextToSpeechWidget.svelte
@@ -131,6 +131,7 @@
 		<form>
 			<WidgetTextarea bind:value={text} />
 			<WidgetSubmitBtn
+				classNames="mt-2"
 				{isLoading}
 				onClick={() => {
 					getOutput();

--- a/widgets/src/lib/InferenceWidget/widgets/TokenClassificationWidget/TokenClassificationWidget.svelte
+++ b/widgets/src/lib/InferenceWidget/widgets/TokenClassificationWidget/TokenClassificationWidget.svelte
@@ -255,6 +255,7 @@
 		<form>
 			<WidgetTextarea bind:value={text} />
 			<WidgetSubmitBtn
+				classNames="mt-2"
 				{isLoading}
 				onClick={() => {
 					getOutput();

--- a/widgets/src/lib/InferenceWidget/widgets/TokenClassificationWidget/TokenClassificationWidget.svelte
+++ b/widgets/src/lib/InferenceWidget/widgets/TokenClassificationWidget/TokenClassificationWidget.svelte
@@ -2,8 +2,9 @@
 	import type { WidgetProps } from "../../shared/types";
 
 	import { onMount } from "svelte";
-	import WidgetQuickInput from "../../shared/WidgetQuickInput/WidgetQuickInput.svelte";
 	import WidgetOuputTokens from "../../shared/WidgetOutputTokens/WidgetOutputTokens.svelte";
+	import WidgetTextarea from "../../shared/WidgetTextarea/WidgetTextarea.svelte";
+	import WidgetSubmitBtn from "../../shared/WidgetSubmitBtn/WidgetSubmitBtn.svelte";
 	import WidgetWrapper from "../../shared/WidgetWrapper/WidgetWrapper.svelte";
 	import {
 		addInferenceParameters,
@@ -252,10 +253,10 @@
 >
 	<svelte:fragment slot="top">
 		<form>
-			<WidgetQuickInput
-				bind:value={text}
+			<WidgetTextarea bind:value={text} />
+			<WidgetSubmitBtn
 				{isLoading}
-				onClickSubmitBtn={() => {
+				onClick={() => {
 					getOutput();
 				}}
 			/>


### PR DESCRIPTION
1. Updated widgets (FillMaskWidget (which is TextClsWidget), TokenClsWidget, TextToSpeechWidget) to use `textarea` as their input element, rather than `input`. 
2. Made `textarea` input height auto-growable until 500px

[Checkout netlfy demo here](https://6193b4a5ec227207e6ff4874--huggingface-widgets.netlify.app/)

cc: @Pierrci @lewtun 

Closes https://github.com/huggingface/moon-landing/issues/1523

<video src="https://user-images.githubusercontent.com/11827707/141996190-8c8f551f-f4d0-48b6-b451-071ea81737f7.mov" controls autoplay loop/>