### PR TITLE
Adapt notebook login to use tokens

### DIFF
--- a/src/huggingface_hub/commands/user.py
+++ b/src/huggingface_hub/commands/user.py
@@ -399,6 +399,9 @@ def _login(hf_api, username=None, password=None, token=None):
             print(e)
             print(ANSI.red(e.response.text))
             exit(1)
+    elif not hf_api._is_valid_token(token):
+        raise ValueError("Invalid token passed.")
+
     HfFolder.save_token(token)
     print("Login successful")
     print("Your token has been saved to", HfFolder.path_token)

--- a/src/huggingface_hub/commands/user.py
+++ b/src/huggingface_hub/commands/user.py
@@ -301,9 +301,7 @@ Immediately click login after typing your password or it might be stored in plai
 NOTEBOOK_LOGIN_TOKEN_HTML_START = """<center>
 <img src=https://huggingface.co/front/assets/huggingface_logo-noborder.svg alt='Hugging Face'>
 <br>
-<b>The AI community building the future</b>
-<br>
-Copy a token from <a href="https://huggingface.co/settings/token" target="_blank">you Hugging Face account</a> and paste it below.
+Copy a token from <a href="https://huggingface.co/settings/token" target="_blank">your Hugging Face tokens page</a> and paste it below.
 <br>
 Immediately click login after copying your token or it might be stored in plain text in this notebook file.
 </center>"""

--- a/src/huggingface_hub/commands/user.py
+++ b/src/huggingface_hub/commands/user.py
@@ -292,8 +292,6 @@ class RepoCreateCommand(BaseUserCommand):
 NOTEBOOK_LOGIN_PASSWORD_HTML = """<center>
 <img src=https://huggingface.co/front/assets/huggingface_logo-noborder.svg alt='Hugging Face'>
 <br>
-<b>The AI community building the future</b>
-<br>
 Immediately click login after typing your password or it might be stored in plain text in this notebook file.
 </center>"""
 


### PR DESCRIPTION
This PR adapts the `notebook_login` widget to use the new token system (it doesn't change anything behind the scenes, it's just a front change) by linking to the token page of the user and hiding the login with password by default:

![image](https://user-images.githubusercontent.com/35901082/142430625-c7f09fc9-a557-449b-84ac-ec9e11797ecd.png)

Clicking the link sends the user [here](https://huggingface.co/settings/token). Clicking the button at the button switches to the old notebook login interface.