### PR TITLE
Render newlines in code outputs

### DIFF
--- a/widgets/src/lib/InferenceWidget/shared/WidgetOutputText/WidgetOutputText.svelte
+++ b/widgets/src/lib/InferenceWidget/shared/WidgetOutputText/WidgetOutputText.svelte
@@ -1,10 +1,18 @@
 <script>
 	export let classNames: string;
 	export let output: string;
+
+	$: isCode = output?.includes("\n");
 </script>
 
 {#if output.length}
-	<p class="alert alert-success {classNames}">
-		{output}
-	</p>
+	{#if isCode}
+		<pre class="alert alert-success overflow-auto {classNames}">
+			{output}
+		</pre>
+	{:else}
+		<p class="alert alert-success {classNames}">
+			{output}
+		</p>
+	{/if}
 {/if}

--- a/widgets/src/routes/index.svelte
+++ b/widgets/src/routes/index.svelte
@@ -76,6 +76,11 @@
 			],
 		},
 		{
+			id: "huggingface-course/codeparrot-ds",
+			pipeline_tag: "text-generation",
+			widgetData: [{ text: "plt.imshow(" }],
+		},
+		{
 			id: "distilroberta-base",
 			pipeline_tag: "fill-mask",
 			mask_token: "<mask>",


### PR DESCRIPTION
When there is a newline, render output of TextGenerationWidget as code output (pre with new line rendering)

[Try here](https://6197ca7027904a0a2fd3ff80--huggingface-widgets.netlify.app/) the `huggingface-course/codeparrot-ds` checkpoint

<video src="https://user-images.githubusercontent.com/11827707/142653609-b7edca42-70ee-4128-9d97-41d6ae6486fe.mov" controls autoplay loop/>

cc: @lvwerra 