### PR TITLE
Fix filename for external dependencies in a Space

### DIFF
--- a/docs/hub/spaces.md
+++ b/docs/hub/spaces.md
@@ -50,7 +50,7 @@ Create a Space by clicking on [New Space](https://huggingface.co/new-space) unde
 
 If you need other Python packages to run your app, add it to a **requirements.txt** file at the root of your repository. Spaces runtime engine will create a custom environment on-the-fly. 
 
-Debian dependencies are also supported. Add a **package.txt** file at the root of your repository, and list all your dependencies in it. Each dependency should be on a separate line, and each line will be read and installed by `apt-get install`.
+Debian dependencies are also supported. Add a **packages.txt** file at the root of your repository, and list all your dependencies in it. Each dependency should be on a separate line, and each line will be read and installed by `apt-get install`.
 
 ### Manage secrets
 


### PR DESCRIPTION
This PR fixes a mismatch between the filename `package.txt` needed to install external dependencies in a Space and what is actually used in the Docker logs:

```
Step 5/25 : COPY packages.txt /root/packages.txt
```

This problem was reported by a participant in the 🤗 course event 😉 