### PR TITLE
Remove "beta" label from Spaces documentation

### DIFF
--- a/docs/hub/_sections.yml
+++ b/docs/hub/_sections.yml
@@ -17,7 +17,7 @@
   title: Hub API Endpoints
 
 - local: spaces
-  title: Spaces documentation (beta)
+  title: Spaces documentation
 
 - local: adding-a-library
   title: Integrate a library with the Hub


### PR DESCRIPTION
Since Spaces is now out of beta, this PR updates the section title to remove this label. You can see the current state in the screenshot below:

<img width="315" alt="Screen Shot 2021-11-19 at 18 56 14" src="https://user-images.githubusercontent.com/26859204/142670340-93767d46-0fdb-4f53-8151-9eb2810ef951.png">
