### PR TITLE
Access tokens

### DIFF
--- a/src/huggingface_hub/commands/user.py
+++ b/src/huggingface_hub/commands/user.py
@@ -209,7 +209,7 @@ class LogoutCommand(BaseUserCommand):
         except HTTPError as e:
             if e.response.status_code == 400:
                 # Logging out with an access token will return a client error.
-                pass
+                HfApi.unset_access_token()
             else:
                 raise e
         print("Successfully logged out.")

--- a/src/huggingface_hub/commands/user.py
+++ b/src/huggingface_hub/commands/user.py
@@ -164,11 +164,19 @@ class LoginCommand(BaseUserCommand):
         _|    _|  _|    _|  _|    _|  _|    _|    _|    _|    _|_|  _|    _|      _|        _|    _|  _|        _|
         _|    _|    _|_|      _|_|_|    _|_|_|  _|_|_|  _|      _|    _|_|_|      _|        _|    _|    _|_|_|  _|_|_|_|
 
+        To login, `huggingface_hub` now requires a token generated from https://huggingface.co/settings/token.
+        To login with username and password instead, interrupt with Ctrl+C.
         """
         )
-        username = input("Username: ")
-        password = getpass()
-        _login(self._api, username, password)
+
+        try:
+            token = getpass("Token: ")
+            _login(self._api, token=token)
+
+        except KeyboardInterrupt:
+            username = input("\rUsername: ")
+            password = getpass()
+            _login(self._api, username, password)
 
 
 class WhoamiCommand(BaseUserCommand):
@@ -196,7 +204,14 @@ class LogoutCommand(BaseUserCommand):
             print("Not logged in")
             exit()
         HfFolder.delete_token()
-        self._api.logout(token)
+        try:
+            self._api.logout(token)
+        except HTTPError as e:
+            if e.response.status_code == 400:
+                # Logging out with an access token will return a client error.
+                pass
+            else:
+                raise e
         print("Successfully logged out.")
 
 
@@ -398,6 +413,7 @@ def _login(hf_api, username=None, password=None, token=None):
     elif not hf_api._is_valid_token(token):
         raise ValueError("Invalid token passed.")
 
+    hf_api.set_access_token(token)
     HfFolder.save_token(token)
     print("Login successful")
     print("Your token has been saved to", HfFolder.path_token)

--- a/src/huggingface_hub/commands/user.py
+++ b/src/huggingface_hub/commands/user.py
@@ -165,7 +165,7 @@ class LoginCommand(BaseUserCommand):
         _|    _|    _|_|      _|_|_|    _|_|_|  _|_|_|  _|      _|    _|_|_|      _|        _|    _|    _|_|_|  _|_|_|_|
 
         To login, `huggingface_hub` now requires a token generated from https://huggingface.co/settings/token.
-        To login with username and password instead, interrupt with Ctrl+C.
+        (Deprecated, will be removed in v0.3.0) To login with username and password instead, interrupt with Ctrl+C.
         """
         )
 
@@ -204,13 +204,12 @@ class LogoutCommand(BaseUserCommand):
             print("Not logged in")
             exit()
         HfFolder.delete_token()
+        HfApi.unset_access_token()
         try:
             self._api.logout(token)
         except HTTPError as e:
-            if e.response.status_code == 400:
-                # Logging out with an access token will return a client error.
-                HfApi.unset_access_token()
-            else:
+            # Logging out with an access token will return a client error.
+            if not e.response.status_code == 400:
                 raise e
         print("Successfully logged out.")
 

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -347,7 +347,7 @@ class HfApi:
 
         Throws: requests.exceptions.HTTPError if credentials are invalid
         """
-        logging.error("This method is deprecated in favor of `set_access_token`.")
+        logging.error("HfApi.login: This method is deprecated in favor of `set_access_token`.")
         path = "{}/api/login".format(self.endpoint)
         r = requests.post(path, json={"username": username, "password": password})
         r.raise_for_status()

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -349,7 +349,9 @@ class HfApi:
 
         Throws: requests.exceptions.HTTPError if credentials are invalid
         """
-        logging.error("HfApi.login: This method is deprecated in favor of `set_access_token`.")
+        logging.error(
+            "HfApi.login: This method is deprecated in favor of `set_access_token`."
+        )
         path = "{}/api/login".format(self.endpoint)
         r = requests.post(path, json={"username": username, "password": password})
         r.raise_for_status()

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -40,6 +40,8 @@ else:
     from typing_extensions import Literal
 
 
+USERNAME_PLACEHOLDER = "hf_user"
+
 REMOTE_FILEPATH_REGEX = re.compile(r"^\w[\w\/\-]*(\.\w+)?$")
 # ^^ No trailing slash, no backslash, no spaces, no relative parts ("." or "..")
 #    Only word characters and an optional extension
@@ -407,11 +409,11 @@ class HfApi:
 
     @staticmethod
     def set_access_token(access_token: str):
-        write_to_credential_store("username", access_token)
+        write_to_credential_store(USERNAME_PLACEHOLDER, access_token)
 
     @staticmethod
     def unset_access_token():
-        erase_from_credential_store("username")
+        erase_from_credential_store(USERNAME_PLACEHOLDER)
 
     def list_models(
         self,

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -12,8 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
+import logging
 import os
 import re
 import subprocess
@@ -333,7 +332,6 @@ def erase_from_credential_store(username=None):
         standard_input += "\n"
 
         process.stdin.write(standard_input.encode("utf-8"))
-        print(standard_input)
         process.stdin.flush()
 
 
@@ -349,6 +347,7 @@ class HfApi:
 
         Throws: requests.exceptions.HTTPError if credentials are invalid
         """
+        logging.error("This method is deprecated in favor of `set_access_token`.")
         path = "{}/api/login".format(self.endpoint)
         r = requests.post(path, json={"username": username, "password": password})
         r.raise_for_status()
@@ -391,6 +390,7 @@ class HfApi:
             token (``str``, `optional`):
                 Hugging Face token. Will default to the locally saved token if not provided.
         """
+        logging.error("This method is deprecated in favor of `unset_access_token`.")
         if token is None:
             token = HfFolder.get_token()
         if token is None:
@@ -404,6 +404,14 @@ class HfApi:
         path = "{}/api/logout".format(self.endpoint)
         r = requests.post(path, headers={"authorization": "Bearer {}".format(token)})
         r.raise_for_status()
+
+    @staticmethod
+    def set_access_token(access_token: str):
+        write_to_credential_store("username", access_token)
+
+    @staticmethod
+    def unset_access_token():
+        erase_from_credential_store("username")
 
     def list_models(
         self,

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -33,6 +33,7 @@ from huggingface_hub.constants import (
 )
 from huggingface_hub.file_download import cached_download, hf_hub_download
 from huggingface_hub.hf_api import (
+    USERNAME_PLACEHOLDER,
     DatasetInfo,
     HfApi,
     HfFolder,
@@ -121,10 +122,13 @@ class HfApiLoginTest(HfApiCommonTest):
 
         _login(self._api, token=TOKEN)
         self.assertTupleEqual(
-            read_from_credential_store("username"), ("username", TOKEN)
+            read_from_credential_store(USERNAME_PLACEHOLDER),
+            (USERNAME_PLACEHOLDER, TOKEN),
         )
-        erase_from_credential_store(username="username")
-        self.assertTupleEqual(read_from_credential_store("username"), (None, None))
+        erase_from_credential_store(username=USERNAME_PLACEHOLDER)
+        self.assertTupleEqual(
+            read_from_credential_store(USERNAME_PLACEHOLDER), (None, None)
+        )
 
 
 class HfApiCommonTestWithLogin(HfApiCommonTest):

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -25,6 +25,7 @@ from io import BytesIO
 import pytest
 
 import requests
+from huggingface_hub.commands.user import _login
 from huggingface_hub.constants import (
     REPO_TYPE_DATASET,
     REPO_TYPE_SPACE,
@@ -48,6 +49,7 @@ from .testing_constants import (
     ENDPOINT_STAGING_BASIC_AUTH,
     FULL_NAME,
     PASS,
+    TOKEN,
     USER,
 )
 from .testing_utils import (
@@ -110,6 +112,19 @@ class HfApiLoginTest(HfApiCommonTest):
         self.assertTupleEqual(read_from_credential_store(USER), (USER.lower(), PASS))
         erase_from_credential_store(username=USER)
         self.assertTupleEqual(read_from_credential_store(USER), (None, None))
+
+    def test_login_cli(self):
+        _login(self._api, username=USER, password=PASS)
+        self.assertTupleEqual(read_from_credential_store(USER), (USER.lower(), PASS))
+        erase_from_credential_store(username=USER)
+        self.assertTupleEqual(read_from_credential_store(USER), (None, None))
+
+        _login(self._api, token=TOKEN)
+        self.assertTupleEqual(
+            read_from_credential_store("username"), ("username", TOKEN)
+        )
+        erase_from_credential_store(username="username")
+        self.assertTupleEqual(read_from_credential_store("username"), (None, None))
 
 
 class HfApiCommonTestWithLogin(HfApiCommonTest):

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -591,6 +591,7 @@ class HfApiPrivateTest(HfApiCommonTestWithLogin):
         self._api.delete_repo(name=self.REPO_NAME, token=self._token)
 
     def test_model_info(self):
+        shutil.rmtree(os.path.dirname(HfFolder.path_token))
         # Test we cannot access model info without a token
         with self.assertRaisesRegex(requests.exceptions.HTTPError, "404 Client Error"):
             _ = self._api.model_info(repo_id=f"{USER}/{self.REPO_NAME}")

--- a/tests/testing_constants.py
+++ b/tests/testing_constants.py
@@ -1,6 +1,7 @@
 USER = "__DUMMY_TRANSFORMERS_USER__"
 FULL_NAME = "Dummy User"
 PASS = "__DUMMY_TRANSFORMERS_PASS__"
+TOKEN = "hf_94wBhPGp6KrrTH3KDchhKpRxZwd6dmHWLL"
 
 ENDPOINT_PRODUCTION = "https://huggingface.co"
 ENDPOINT_STAGING = "https://moon-staging.huggingface.co"

--- a/tests/testing_constants.py
+++ b/tests/testing_constants.py
@@ -1,6 +1,8 @@
 USER = "__DUMMY_TRANSFORMERS_USER__"
 FULL_NAME = "Dummy User"
 PASS = "__DUMMY_TRANSFORMERS_PASS__"
+
+# Not critical, only usable on the sandboxed CI instance.
 TOKEN = "hf_94wBhPGp6KrrTH3KDchhKpRxZwd6dmHWLL"
 
 ENDPOINT_PRODUCTION = "https://huggingface.co"


### PR DESCRIPTION
Offers the access tokens as the main login handler.

When doing `huggingface-cli login`, a `Token: ` prompt will appear, preceded by the following:
```
        To login, `huggingface_hub` now requires a token generated from https://huggingface.co/settings/token.
        To login with username and password instead, interrupt with Ctrl+C.
```

If the user does Ctrl+C, it redirects automatically to a Username/Password prompt:

![file](https://user-images.githubusercontent.com/30755778/143884479-556878c6-ec08-4717-8c9b-52ea459fd985.gif)
