### PR TITLE
Deprecate `list_repos_objs` as probably no-one uses it

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -614,10 +614,17 @@ class HfApi:
         self, token: Optional[str] = None, organization: Optional[str] = None
     ) -> List[RepoObj]:
         """
+        Deprecated
+
         HuggingFace git-based system, used for models, datasets, and spaces.
 
         Call HF API to list all stored files for user (or one of their organizations).
         """
+        warnings.warn(
+            "This method has been deprecated and will be removed in a future version."
+            "You can achieve the same result by listing your repos then listing their respective files."
+        )
+
         if token is None:
             token = HfFolder.get_token()
         if token is None:

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -37,7 +37,6 @@ from huggingface_hub.hf_api import (
     HfFolder,
     MetricInfo,
     ModelInfo,
-    RepoObj,
     erase_from_credential_store,
     read_from_credential_store,
     repo_type_and_id_from_hf_id,
@@ -129,13 +128,6 @@ class HfApiEndpointsTest(HfApiCommonTestWithLogin):
         self.assertEqual(info["fullname"], FULL_NAME)
         self.assertIsInstance(info["orgs"], list)
         self.assertIsInstance(info["orgs"][0]["apiToken"], str)
-
-    def test_list_repos_objs(self):
-        objs = self._api.list_repos_objs(token=self._token)
-        self.assertIsInstance(objs, list)
-        if len(objs) > 0:
-            o = objs[-1]
-            self.assertIsInstance(o, RepoObj)
 
     def test_create_update_and_delete_repo(self):
         REPO_NAME = repo_name("crud")


### PR DESCRIPTION
it was initially implemented just for backward compat to the old S3 system

I doubt anyone's using it, and it feels "unnatural" as an API now that every file is repo-centric