### PR TITLE
Fix the progress bars when cloning a repository

### DIFF
--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -329,7 +329,8 @@ def lfs_log_progress():
     current_lfs_progress_value = os.environ.get("GIT_LFS_PROGRESS", "")
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        os.environ["GIT_LFS_PROGRESS"] = os.path.join(tmpdir, "lfs_progress")
+        path = os.path.join(tmpdir, "lfs_progress")
+        os.environ["GIT_LFS_PROGRESS"] = path
         logger.debug(f"Following progress in {os.environ['GIT_LFS_PROGRESS']}")
 
         exit_event = threading.Event()
@@ -337,7 +338,7 @@ def lfs_log_progress():
         x.start()
 
         try:
-            yield
+            yield path
         finally:
             exit_event.set()
             x.join()
@@ -578,7 +579,8 @@ class Repository:
                 else:
                     clone = "git lfs clone"
 
-                with lfs_log_progress():
+                with lfs_log_progress() as lfs_progress_path:
+                    env["GIT_LFS_PROGRESS"] = lfs_progress_path
                     subprocess.run(
                         f"{clone} {repo_url} .".split(),
                         stderr=subprocess.PIPE,

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -572,6 +572,11 @@ class Repository:
                 logger.warning(f"Cloning {clean_repo_url} into local empty directory.")
 
                 with lfs_log_progress():
+                    env = os.environ.copy()
+
+                    if self.skip_lfs_files:
+                        env.update({"GIT_LFS_SKIP_SMUDGE": "1"})
+
                     subprocess.run(
                         f"{'git clone' if self.skip_lfs_files else 'git lfs clone'} {repo_url} .".split(),
                         stderr=subprocess.PIPE,
@@ -579,9 +584,7 @@ class Repository:
                         check=True,
                         encoding="utf-8",
                         cwd=self.local_dir,
-                        env=os.environ.copy().update(
-                            {"GIT_LFS_SKIP_SMUDGE": "1"} if self.skip_lfs_files else {}
-                        ),
+                        env=env,
                     )
             else:
                 # Check if the folder is the root of a git repository


### PR DESCRIPTION
The environment changes that had to happen for the `GIT_LFS_SKIP_SMUDGE` ended up modifying the progress bars for that specific command.

A test should be setup to ensure this doesn't happen.