### PR TITLE
Pass the HfApi object when using `notebook_login` with a token

### DIFF
--- a/src/huggingface_hub/commands/user.py
+++ b/src/huggingface_hub/commands/user.py
@@ -379,7 +379,7 @@ def notebook_login():
         # Erase token and clear value to make sure it's not saved in the notebook.
         token_widget.value = ""
         clear_output()
-        _login(token=token)
+        _login(HfApi(), token=token)
 
     token_finish_button.on_click(login_token_event)
 


### PR DESCRIPTION
Quick fix for:
```python
TypeError                                 Traceback (most recent call last)
/usr/local/lib/python3.7/dist-packages/huggingface_hub/commands/user.py in login_token_event(t)
    380         token_widget.value = ""
    381         clear_output()
--> 382         _login(token=token)
    383 
    384     token_finish_button.on_click(login_token_event)

TypeError: _login() missing 1 required positional argument: 'hf_api'
```

cc @patrickvonplaten : small blocker for the CommonVoice demo