### PR TITLE
Token in env variables

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -22,7 +22,7 @@ import warnings
 from io import BufferedIOBase, RawIOBase
 from os.path import expanduser
 from typing import IO, Dict, Iterable, List, Optional, Tuple, Union
-
+from pathlib import Path
 import requests
 from requests.exceptions import HTTPError
 
@@ -1127,15 +1127,22 @@ class HfFolder:
             f.write(token)
 
     @classmethod
-    def get_token(cls):
+    def get_token(cls) -> Optional[str]:
         """
-        Get token or None if not existent.
+        Get token or None if not existent. A token can be also provided using env variables
+
+        >>> export HUGGING_FACE_HUB_TOKEN=<YOUR_TOKEN>
         """
-        try:
-            with open(cls.path_token, "r") as f:
-                return f.read()
-        except FileNotFoundError:
-            pass
+
+        path_token: Path = Path(cls.path_token)
+        token: Optional[str] = os.environ.get("HUGGING_FACE_HUB_TOKEN")
+
+        if token is None:
+            # fall back to disk
+            if path_token.exists():
+                with path_token.open("r") as f:
+                    token = f.read()
+        return token
 
     @classmethod
     def delete_token(cls):

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -21,7 +21,7 @@ import time
 import unittest
 import uuid
 from io import BytesIO
-
+from unittest import mock
 import pytest
 
 import requests
@@ -596,6 +596,10 @@ class HfFolderTest(unittest.TestCase):
         # ^^ not an error, we test that the
         # second call does not fail.
         self.assertEqual(HfFolder.get_token(), None)
+        with mock.patch.dict(os.environ, {"HUGGING_FACE_HUB_TOKEN": token}):
+            self.assertEqual(HfFolder.get_token(), token)
+        with mock.patch.dict(os.environ, {"HUGGING_FACE_HUB_TOKEN": None}):
+            self.assertEqual(HfFolder.get_token(), None)
 
 
 @require_git_lfs


### PR DESCRIPTION
## Why
Sometimes (tests, docker, ... etc) it's easier to pass the token required to use the hub in a env variable, something like:

```
export HUGGING_FACE_HUB_TOKEN=<YOUR_TOKEN>
```

This avoids the need of getting the token, create a folder, and store it inside

## How

I've edited the logic inside `hf_api.HFolder.get_token`. Pasted below for convenience

```python
@classmethod
    def get_token(cls) -> Optional[str]:
        """
        Get token or None if not existent. A token can be also provided using env variables

        >>> export HUGGING_FACE_HUB_TOKEN=<YOUR_TOKEN>
        """

        path_token: Path = Path(cls.path_token)
        token: Optional[str] = os.environ.get("HUGGING_FACE_HUB_TOKEN")

        if token is None:
            # fall back to disk
            if path_token.exists():
                with path_token.open("r") as f:
                    token = f.read()
        return token
```

## Test it
I've added a few new line in the tests but even if I've mocked the `os.environ` dict the token is still `None`, I can use a little help :pray: 

Thanks

Francesco