### PR TITLE
[Hotfix][API] card_data => cardData on /api/datasets

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -200,7 +200,7 @@ class DatasetInfo:
         author: Optional[str] = None,  # community datasets only
         description: Optional[str] = None,
         citation: Optional[str] = None,
-        card_data: Optional[dict] = None,
+        cardData: Optional[dict] = None,
         **kwargs,
     ):
         self.id = id
@@ -210,7 +210,7 @@ class DatasetInfo:
         self.author = author
         self.description = description
         self.citation = citation
-        self.card_data = card_data
+        self.cardData = cardData
         self.siblings = (
             [DatasetFile(**x) for x in siblings] if siblings is not None else None
         )
@@ -525,7 +525,7 @@ class HfApi:
             limit (:obj:`int`, `optional`):
                 The limit on the number of datasets fetched. Leaving this option to `None` fetches all datasets.
             full (:obj:`bool`, `optional`):
-                Whether to fetch all dataset data, including the `lastModified` and the `card_data`.
+                Whether to fetch all dataset data, including the `lastModified` and the `cardData`.
 
         """
         path = "{}/api/datasets".format(self.endpoint)

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -547,14 +547,14 @@ class HfApiPublicTest(unittest.TestCase):
         self.assertGreater(len(datasets), 100)
         dataset = datasets[0]
         self.assertIsInstance(dataset, DatasetInfo)
-        self.assertTrue(any(dataset.card_data for dataset in datasets))
+        self.assertTrue(any(dataset.cardData for dataset in datasets))
 
     @with_production_testing
     def test_dataset_info(self):
         _api = HfApi()
         dataset = _api.dataset_info(repo_id=DUMMY_DATASET_ID)
         self.assertTrue(
-            isinstance(dataset.card_data, dict) and len(dataset.card_data) > 0
+            isinstance(dataset.cardData, dict) and len(dataset.cardData) > 0
         )
         self.assertTrue(
             isinstance(dataset.siblings, list) and len(dataset.siblings) > 0

--- a/tests/test_hubmixin.py
+++ b/tests/test_hubmixin.py
@@ -49,7 +49,6 @@ if is_torch_available():
         def forward(self, x):
             return self.l1(x)
 
-
 else:
     DummyModel = None
 

--- a/tests/test_keras_integration.py
+++ b/tests/test_keras_integration.py
@@ -58,7 +58,6 @@ if is_tf_available():
         def call(self, x):
             return self.l1(x)
 
-
 else:
     DummyModel = None
 


### PR DESCRIPTION
api change: /api/datasets[...] now returns cardData not card_data (for consistency with models)

We didn't find any evidence for people using this API attribute yet so are hotfixing it on master