### PR TITLE
Search by authors and string

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -522,6 +522,8 @@ class HfApi:
     def list_datasets(
         self,
         filter: Union[str, Iterable[str], None] = None,
+        author: Optional[str] = None,
+        search: Optional[str] = None,
         sort: Union[Literal["lastModified"], str, None] = None,
         direction: Optional[Literal[-1]] = None,
         limit: Optional[int] = None,
@@ -546,6 +548,30 @@ class HfApi:
 
                     >>> # List only the datasets in russian for language modeling
                     >>> api.list_datasets(filter=("languages:ru", "task_ids:language-modeling"))
+            author (:obj:`str`, `optional`):
+                A string which identify the author of the returned models
+                Example usage:
+
+                    >>> from huggingface_hub import HfApi
+                    >>> api = HfApi()
+
+                    >>> # List all datasets from google
+                    >>> api.list_datasets(author="google")
+
+                    >>> # List only the text classification datasets from google
+                    >>> api.list_datasets(filter="text-classification", author="google")
+            search (:obj:`str`, `optional`):
+                A string that will be contained in the returned models
+                Example usage:
+
+                    >>> from huggingface_hub import HfApi
+                    >>> api = HfApi()
+
+                    >>> # List all datasets with "text" in their name
+                    >>> api.list_datasets(search="text")
+
+                    >>> #List all datasets with "text" in their name made by google
+                    >>> api.list_datasets(search="text", author="google")
             sort (:obj:`Literal["lastModified"]` or :obj:`str`, `optional`):
                 The key with which to sort the resulting datasets. Possible values are the properties of the `DatasetInfo`
                 class.
@@ -562,6 +588,10 @@ class HfApi:
         params = {}
         if filter is not None:
             params.update({"filter": filter})
+        if author is not None:
+            params.update({"author": author})
+        if search is not None:
+            params.update({"search": search})
         if sort is not None:
             params.update({"sort": sort})
         if direction is not None:

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -420,6 +420,8 @@ class HfApi:
     def list_models(
         self,
         filter: Union[str, Iterable[str], None] = None,
+        author: Optional[str] = None,
+        search: Optional[str] = None,
         sort: Union[Literal["lastModified"], str, None] = None,
         direction: Optional[Literal[-1]] = None,
         limit: Optional[int] = None,
@@ -451,6 +453,30 @@ class HfApi:
 
                     >>> # List only the models from the AllenNLP library
                     >>> api.list_models(filter="allennlp")
+            author (:obj:`str`, `optional`):
+                A string which identify the author of the returned models
+                Example usage:
+
+                    >>> from huggingface_hub import HfApi
+                    >>> api = HfApi()
+
+                    >>> # List all models from google
+                    >>> api.list_models(author="google")
+
+                    >>> # List only the text classification models from google
+                    >>> api.list_models(filter="text-classification", author="google")
+            search (:obj:`str`, `optional`):
+                A string that will be contained in the returned models
+                Example usage:
+
+                    >>> from huggingface_hub import HfApi
+                    >>> api = HfApi()
+
+                    >>> # List all models with "bert" in their name
+                    >>> api.list_models(search="bert")
+
+                    >>> #List all models with "bert" in their name made by google
+                    >>> api.list_models(search="bert", author="google")
             sort (:obj:`Literal["lastModified"]` or :obj:`str`, `optional`):
                 The key with which to sort the resulting models. Possible values are the properties of the `ModelInfo`
                 class.
@@ -471,6 +497,10 @@ class HfApi:
         if filter is not None:
             params.update({"filter": filter})
             params.update({"full": True})
+        if author is not None:
+            params.update({"author": author})
+        if search is not None:
+            params.update({"search": search})
         if sort is not None:
             params.update({"sort": sort})
         if direction is not None:

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -1169,22 +1169,25 @@ class HfFolder:
             f.write(token)
 
     @classmethod
-    def get_token(cls) -> Optional[str]:
+    def get_token(cls):
         """
-        Get token or None if not existent. A token can be also provided using env variables
-
-        >>> export HUGGING_FACE_HUB_TOKEN=<YOUR_TOKEN>
+        Get token or None if not existent.
         """
+        try:
+            with open(cls.path_token, "r") as f:
+                return f.read()
+        except FileNotFoundError:
+            pass
 
-        path_token: Path = Path(cls.path_token)
-        token: Optional[str] = os.environ.get("HUGGING_FACE_HUB_TOKEN")
-
-        if token is None:
-            # fall back to disk
-            if path_token.exists():
-                with path_token.open("r") as f:
-                    token = f.read()
-        return token
+    @classmethod
+    def delete_token(cls):
+        """
+        Delete token. Do not fail if token does not exist.
+        """
+        try:
+            os.remove(cls.path_token)
+        except FileNotFoundError:
+            pass
 
     @classmethod
     def delete_token(cls):

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -21,7 +21,6 @@ import warnings
 from io import BufferedIOBase, RawIOBase
 from os.path import expanduser
 from typing import IO, Dict, Iterable, List, Optional, Tuple, Union
-from pathlib import Path
 import requests
 from requests.exceptions import HTTPError
 

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -1218,16 +1218,6 @@ class HfFolder:
         except FileNotFoundError:
             pass
 
-    @classmethod
-    def delete_token(cls):
-        """
-        Delete token. Do not fail if token does not exist.
-        """
-        try:
-            os.remove(cls.path_token)
-        except FileNotFoundError:
-            pass
-
 
 api = HfApi()
 

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -21,6 +21,7 @@ import warnings
 from io import BufferedIOBase, RawIOBase
 from os.path import expanduser
 from typing import IO, Dict, Iterable, List, Optional, Tuple, Union
+
 import requests
 from requests.exceptions import HTTPError
 

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -21,7 +21,6 @@ import time
 import unittest
 import uuid
 from io import BytesIO
-from unittest import mock
 import pytest
 
 import requests

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -564,6 +564,20 @@ class HfApiPublicTest(unittest.TestCase):
         self.assertTrue(any(dataset.cardData for dataset in datasets))
 
     @with_production_testing
+    def test_list_datasets_author(self):
+        _api = HfApi()
+        datasets = _api.list_datasets(author="huggingface")
+        self.assertGreater(len(datasets), 4)
+        self.assertIsInstance(datasets[0], DatasetInfo)
+
+    @with_production_testing
+    def test_list_datasets_search(self):
+        _api = HfApi()
+        datasets = _api.list_datasets(search="wikipedia")
+        self.assertGreater(len(datasets), 10)
+        self.assertIsInstance(datasets[0], DatasetInfo)
+
+    @with_production_testing
     def test_dataset_info(self):
         _api = HfApi()
         dataset = _api.dataset_info(repo_id=DUMMY_DATASET_ID)

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -473,6 +473,20 @@ class HfApiPublicTest(unittest.TestCase):
         self.assertIsInstance(models[0], ModelInfo)
 
     @with_production_testing
+    def test_list_models_author(self):
+        _api = HfApi()
+        models = _api.list_models(author="google")
+        self.assertGreater(len(models), 10)
+        self.assertIsInstance(models[0], ModelInfo)
+
+    @with_production_testing
+    def test_list_models_search(self):
+        _api = HfApi()
+        models = _api.list_models(search="bert")
+        self.assertGreater(len(models), 10)
+        self.assertIsInstance(models[0], ModelInfo)
+
+    @with_production_testing
     def test_list_models_complex_query(self):
         # Let's list the 10 most recent models
         # with tags "bert" and "jax",

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -21,6 +21,7 @@ import time
 import unittest
 import uuid
 from io import BytesIO
+
 import pytest
 
 import requests
@@ -477,6 +478,7 @@ class HfApiPublicTest(unittest.TestCase):
         models = _api.list_models(author="google")
         self.assertGreater(len(models), 10)
         self.assertIsInstance(models[0], ModelInfo)
+        [self.assertTrue("google" in model.author for model in models)]
 
     @with_production_testing
     def test_list_models_search(self):
@@ -484,6 +486,7 @@ class HfApiPublicTest(unittest.TestCase):
         models = _api.list_models(search="bert")
         self.assertGreater(len(models), 10)
         self.assertIsInstance(models[0], ModelInfo)
+        [self.assertTrue("bert" in model.modelId.lower()) for model in models]
 
     @with_production_testing
     def test_list_models_complex_query(self):

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -629,11 +629,6 @@ class HfFolderTest(unittest.TestCase):
         HfFolder.delete_token()
         # ^^ not an error, we test that the
         # second call does not fail.
-        self.assertEqual(HfFolder.get_token(), None)
-        with mock.patch.dict(os.environ, {"HUGGING_FACE_HUB_TOKEN": token}):
-            self.assertEqual(HfFolder.get_token(), token)
-        with mock.patch.dict(os.environ, {"HUGGING_FACE_HUB_TOKEN": None}):
-            self.assertEqual(HfFolder.get_token(), None)
 
 
 @require_git_lfs

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -643,6 +643,7 @@ class HfFolderTest(unittest.TestCase):
         HfFolder.delete_token()
         # ^^ not an error, we test that the
         # second call does not fail.
+        self.assertEqual(HfFolder.get_token(), None)
 
 
 @require_git_lfs

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -567,7 +567,7 @@ class HfApiPublicTest(unittest.TestCase):
     def test_list_datasets_author(self):
         _api = HfApi()
         datasets = _api.list_datasets(author="huggingface")
-        self.assertGreater(len(datasets), 4)
+        self.assertGreater(len(datasets), 1)
         self.assertIsInstance(datasets[0], DatasetInfo)
 
     @with_production_testing


### PR DESCRIPTION
## Why
Searching by `authors` and `search` (so just a string) is currently missing, linked to #513 

## How

I've edited the logic inside `hf_api.HfApi.list_models`. Pasted below for convenience

```python

  def list_models(....):
     ....
     if filter is not None:
          params.update({"filter": filter})
          params.update({"full": True})
      if author is not None: # <- here
          params.update({"author": author})
      if search is not None: # <- here
          params.update({"search": search})
      .....
```

[EDIT] After discussing it we also included the same logic in `list_datasets`
## Test it
I've added a few new lines in the tests under `HfApiPublicTest`, maybe a test with a complex query + `authors`, `search` is not a bad idea.


**Since I've edited my `main` branch on the `fork` this branch has the commits from the `main` branch that contains the code for 
#522. Unfortunately, I am not a git wizard so I've removed that code. I am not sure what's the best way to clean it up while having my other PR open (#522)**

Thanks

Francesco