### PR TITLE
Revert "Render newlines in code outputs"

### DIFF
--- a/widgets/src/lib/InferenceWidget/shared/WidgetOutputText/WidgetOutputText.svelte
+++ b/widgets/src/lib/InferenceWidget/shared/WidgetOutputText/WidgetOutputText.svelte
@@ -1,18 +1,10 @@
 <script>
 	export let classNames: string;
 	export let output: string;
-
-	$: isCode = output?.includes("\n");
 </script>
 
 {#if output.length}
-	{#if isCode}
-		<pre class="alert alert-success overflow-auto {classNames}">
-			{output}
-		</pre>
-	{:else}
-		<p class="alert alert-success {classNames}">
-			{output}
-		</p>
-	{/if}
+	<p class="alert alert-success {classNames}">
+		{output}
+	</p>
 {/if}

--- a/widgets/src/routes/index.svelte
+++ b/widgets/src/routes/index.svelte
@@ -76,11 +76,6 @@
 			],
 		},
 		{
-			id: "huggingface-course/codeparrot-ds",
-			pipeline_tag: "text-generation",
-			widgetData: [{ text: "plt.imshow(" }],
-		},
-		{
 			id: "distilroberta-base",
 			pipeline_tag: "fill-mask",
 			mask_token: "<mask>",


### PR DESCRIPTION
Reverts huggingface/huggingface_hub#484

#484 was doing:
if output contains `\n` newline character, then render like code output
otherwise, render as a normal text output