### PR TITLE
Add test directions

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,14 @@
+# Running Tests
+
+To run the test suite, please perform the following from the root directory of this repository:
+
+1. `pip install -e .[testing]`
+
+      This will install all the testing requirements.
+2. `sudo apt-get update; sudo apt-get install git-lfs -y`
+
+      We need git-lfs on our system to run some of the tests
+3. `export HUGGINGFACE_CO_STAGING=1`
+
+      This is an environmental variable to make sure the private API tests can run
+4. `pytest -sv ./tests/`

--- a/tests/README.md
+++ b/tests/README.md
@@ -8,7 +8,7 @@ To run the test suite, please perform the following from the root directory of t
 2. `sudo apt-get update; sudo apt-get install git-lfs -y`
 
       We need git-lfs on our system to run some of the tests
-3. `export HUGGINGFACE_CO_STAGING=1`
-
-      This is an environmental variable to make sure the private API tests can run
-4. `pytest -sv ./tests/`
+    
+3. `HUGGINGFACE_CO_STAGING=1 pytest -sv ./tests/`
+    
+    We need to set an environmental variable to make sure the private API tests can run. 

--- a/tests/README.md
+++ b/tests/README.md
@@ -11,4 +11,4 @@ To run the test suite, please perform the following from the root directory of t
     
 3. `HUGGINGFACE_CO_STAGING=1 pytest -sv ./tests/`
     
-    We need to set an environmental variable to make sure the private API tests can run. 
+      We need to set an environmental variable to make sure the private API tests can run. 


### PR DESCRIPTION
Adds a small markdown file that contains directions for running the test suite, since it took me a moment to get everything setup on my side. 