### PR TITLE
Adjust widget responsiveness

### DIFF
--- a/widgets/src/lib/InferenceWidget/shared/WidgetDropzone/WidgetDropzone.svelte
+++ b/widgets/src/lib/InferenceWidget/shared/WidgetDropzone/WidgetDropzone.svelte
@@ -62,9 +62,7 @@
 />
 <div
 	class="relative border-2 border-dashed rounded px-3 py-7 text-center cursor-pointer 
-		{isDragging
-			? 'border-green-300 bg-green-50 text-green-500'
-			: 'text-gray-500'} 
+		{isDragging ? 'border-green-300 bg-green-50 text-green-500' : 'text-gray-500'} 
 		{classNames}"
 	on:click={() => {
 		fileInput.click();

--- a/widgets/src/lib/InferenceWidget/shared/WidgetDropzone/WidgetDropzone.svelte
+++ b/widgets/src/lib/InferenceWidget/shared/WidgetDropzone/WidgetDropzone.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import IconSpin from "../../../Icons/IconSpin.svelte";
 	import { getBlobFromUrl } from "../../shared/helpers";
 
@@ -61,9 +61,11 @@
 	type="file"
 />
 <div
-	class="relative border-2 border-dashed rounded mb-2 px-3 py-7 text-center cursor-pointer {isDragging
-		? 'border-green-300 bg-green-50 text-green-500'
-		: 'text-gray-500'} {classNames}"
+	class="relative border-2 border-dashed rounded px-3 py-7 text-center cursor-pointer 
+		{isDragging
+			? 'border-green-300 bg-green-50 text-green-500'
+			: 'text-gray-500'} 
+		{classNames}"
 	on:click={() => {
 		fileInput.click();
 	}}

--- a/widgets/src/lib/InferenceWidget/shared/WidgetHeader/WidgetHeader.svelte
+++ b/widgets/src/lib/InferenceWidget/shared/WidgetHeader/WidgetHeader.svelte
@@ -18,7 +18,9 @@
 		</a>
 	{/if}
 </div>
-<div class="flex items-center justify-between flex-wrap w-full max-w-full text-sm text-gray-500 mb-0.5">
+<div
+	class="flex items-center justify-between flex-wrap w-full max-w-full text-sm text-gray-500 mb-0.5"
+>
 	{#if pipeline}
 		<ModelPipelineTag classNames="mr-2 mb-1.5" {pipeline} />
 	{/if}

--- a/widgets/src/lib/InferenceWidget/shared/WidgetHeader/WidgetHeader.svelte
+++ b/widgets/src/lib/InferenceWidget/shared/WidgetHeader/WidgetHeader.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import IconInfo from "../../../Icons/IconInfo.svelte";
 	import IconLightning from "../../../Icons/IconLightning.svelte";
 	import ModelPipelineTag from "../../../ModelPipelineTag/ModelPipelineTag.svelte";
@@ -18,11 +18,9 @@
 		</a>
 	{/if}
 </div>
-<div class="flex items-center text-sm text-gray-500 mb-1.5">
+<div class="flex items-center justify-between flex-wrap w-full max-w-full text-sm text-gray-500 mb-0.5">
 	{#if pipeline}
-		<ModelPipelineTag {pipeline} />
+		<ModelPipelineTag classNames="mr-2 mb-1.5" {pipeline} />
 	{/if}
-	<div class="ml-auto">
-		<slot />
-	</div>
+	<slot />
 </div>

--- a/widgets/src/lib/InferenceWidget/shared/WidgetInfo/WidgetInfo.svelte
+++ b/widgets/src/lib/InferenceWidget/shared/WidgetInfo/WidgetInfo.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import type { LoadingStatus } from "../types";
 
 	export let computeTime: string;
@@ -12,7 +12,7 @@
 	} as const;
 </script>
 
-<div class="mt-1.5">
+<div class="mt-2">
 	<div class="text-gray-400 text-xs">
 		{#if computeTime}
 			Computation time on cpu: {computeTime}

--- a/widgets/src/lib/InferenceWidget/shared/WidgetInputSamples/WidgetInputSamples.svelte
+++ b/widgets/src/lib/InferenceWidget/shared/WidgetInputSamples/WidgetInputSamples.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import { slide } from "svelte/transition";
 
 	export let isLoading = false;
@@ -54,8 +54,9 @@
 <svelte:window on:click={onClick} />
 
 <div
-	class="relative ml-2 {isLoading &&
-		'pointer-events-none opacity-50'} {isOptionsVisible && 'z-10'}"
+	class="relative mb-1.5
+		{isLoading && 'pointer-events-none opacity-50'} 
+		{isOptionsVisible && 'z-10'}"
 	bind:this={containerEl}
 >
 	<div

--- a/widgets/src/lib/InferenceWidget/shared/WidgetQuickInput/WidgetQuickInput.svelte
+++ b/widgets/src/lib/InferenceWidget/shared/WidgetQuickInput/WidgetQuickInput.svelte
@@ -12,7 +12,7 @@
 <div class="flex h-10">
 	<input
 		bind:value
-		class="form-input-alt flex-1 rounded-r-none {flatTop
+		class="form-input-alt flex-1 rounded-r-none min-w-0 {flatTop
 			? 'rounded-t-none'
 			: ''}"
 		{placeholder}

--- a/widgets/src/lib/InferenceWidget/shared/WidgetWrapper/WidgetWrapper.svelte
+++ b/widgets/src/lib/InferenceWidget/shared/WidgetWrapper/WidgetWrapper.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import type { WidgetProps, LoadingStatus } from "../types";
 
 	import { onMount } from "svelte";
@@ -58,20 +58,15 @@
 		</button>
 	{/if}
 	<WidgetHeader {noTitle} pipeline={model.pipeline_tag}>
-		<div class="flex items-center">
-			{#if model.pipeline_tag === "fill-mask"}
-				Mask token: <code>{model.mask_token}</code>
-			{/if}
-			{#if inputSamples.length}
-				<!-- Show samples selector when there are more than one sample -->
-				<WidgetInputSamples
-					{isLoading}
-					{inputSamples}
-					{applyInputSample}
-					{previewInputSample}
-				/>
-			{/if}
-		</div>
+		{#if inputSamples.length}
+			<!-- Show samples selector when there are more than one sample -->
+			<WidgetInputSamples
+				{isLoading}
+				{inputSamples}
+				{applyInputSample}
+				{previewInputSample}
+			/>
+		{/if}
 	</WidgetHeader>
 	<slot name="top" />
 	<WidgetInfo {computeTime} {error} {modelStatus} />

--- a/widgets/src/lib/InferenceWidget/widgets/FillMaskWidget/FillMaskWidget.svelte
+++ b/widgets/src/lib/InferenceWidget/widgets/FillMaskWidget/FillMaskWidget.svelte
@@ -139,6 +139,9 @@
 >
 	<svelte:fragment slot="top">
 		<form>
+			<div class="text-sm text-gray-500 mb-1.5">
+				Mask token: <code>{model.mask_token}</code>
+			</div>
 			<WidgetTextarea bind:value={text} />
 			<WidgetSubmitBtn
 				classNames="mt-2"

--- a/widgets/src/lib/InferenceWidget/widgets/TableQuestionAnsweringWidget/TableQuestionAnsweringWidget.svelte
+++ b/widgets/src/lib/InferenceWidget/widgets/TableQuestionAnsweringWidget/TableQuestionAnsweringWidget.svelte
@@ -189,8 +189,6 @@
 				}}
 			/>
 		</form>
-	</svelte:fragment>
-	<svelte:fragment slot="bottom">
 		<div class="mt-4">
 			{#if output}
 				<WidgetOutputTableQA {output} />

--- a/widgets/src/lib/ModelPipelineTag/ModelPipelineTag.svelte
+++ b/widgets/src/lib/ModelPipelineTag/ModelPipelineTag.svelte
@@ -1,11 +1,12 @@
-<script>
+<script lang="ts">
 	import { PipelineType } from "../interfaces/Types";
 	import ModelPipelineIcon from "../ModelPipelineIcon/ModelPipelineIcon.svelte";
 
+	export let classNames = "";
 	export let pipeline = "";
 </script>
 
-<div class="inline-flex items-center">
+<div class="inline-flex items-center {classNames}">
 	<ModelPipelineIcon classNames="mr-1" {pipeline} />
 	<span>
 		{PipelineType[pipeline] ?? pipeline}


### PR DESCRIPTION
Fix  [#1627](https://github.com/huggingface/moon-landing/issues/1627)

WDYT @gary149  ? One minor issue with the current design is that on mobile the "select example" dropdown sometimes looks like it's part of the widget form it self. Maybe we could accentuate a bit the difference between the two section - not sure how much it really matters.

<img width="2032" alt="Screen Shot 2022-01-07 at 5 09 39 PM" src="https://user-images.githubusercontent.com/8323351/148572381-e4df8cab-0549-4dfc-86da-ac8f313e7401.png">
<img width="498" alt="Screen Shot 2022-01-07 at 5 09 58 PM" src="https://user-images.githubusercontent.com/8323351/148572396-952d14dc-277b-4932-9a89-5770ab0ad9cd.png">
<img width="499" alt="Screen Shot 2022-01-07 at 5 10 34 PM" src="https://user-images.githubusercontent.com/8323351/148572404-d4860e0f-9a80-4a2e-9864-e1e53f83b78c.png">

