### PR TITLE
Hotifixing `fairseq`.

### DIFF
--- a/api-inference-community/docker_images/fairseq/app/pipelines/audio_to_audio.py
+++ b/api-inference-community/docker_images/fairseq/app/pipelines/audio_to_audio.py
@@ -75,4 +75,4 @@ class SpeechToSpeechPipeline(Pipeline):
             wav, sr = TTSHubInterface.get_prediction(
                 self.tts_task, self.tts_model, self.tts_generator, tts_sample
             )
-            return wav.numpy(), sr, [text]
+            return wav.unsqueeze(0).numpy(), sr, [text]


### PR DESCRIPTION
Fixes the dimension of the output of AudioToAudioPipeline.