### PR TITLE
Remove rogue API token

### DIFF
--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -149,6 +149,8 @@ class HfApiEndpointsTest(HfApiCommonTestWithLogin):
         self.assertEqual(info["name"], USER)
         self.assertEqual(info["fullname"], FULL_NAME)
         self.assertIsInstance(info["orgs"], list)
+        valid_org = [org for org in info['orgs'] if org['name'] == 'valid_org'][0]
+        self.assertIsInstance(valid_org["apiToken"], str)
 
     def test_create_update_and_delete_repo(self):
         REPO_NAME = repo_name("crud")

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -149,7 +149,7 @@ class HfApiEndpointsTest(HfApiCommonTestWithLogin):
         self.assertEqual(info["name"], USER)
         self.assertEqual(info["fullname"], FULL_NAME)
         self.assertIsInstance(info["orgs"], list)
-        valid_org = [org for org in info['orgs'] if org['name'] == 'valid_org'][0]
+        valid_org = [org for org in info["orgs"] if org["name"] == "valid_org"][0]
         self.assertIsInstance(valid_org["apiToken"], str)
 
     def test_create_update_and_delete_repo(self):

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -149,7 +149,6 @@ class HfApiEndpointsTest(HfApiCommonTestWithLogin):
         self.assertEqual(info["name"], USER)
         self.assertEqual(info["fullname"], FULL_NAME)
         self.assertIsInstance(info["orgs"], list)
-        self.assertIsInstance(info["orgs"][0]["apiToken"], str)
 
     def test_create_update_and_delete_repo(self):
         REPO_NAME = repo_name("crud")


### PR DESCRIPTION
The `apiToken` is only available on the `valid_org` organization in the staging environment.

Thanks for raising the issue, @julien-c.