### PR TITLE
Fix pasting copied text inside TextAreaWidget

### DIFF
--- a/js/src/lib/components/InferenceWidget/shared/WidgetTextarea/WidgetTextarea.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetTextarea/WidgetTextarea.svelte
@@ -1,39 +1,40 @@
 <script>
+	import { onMount, tick } from "svelte";
+
 	import WidgetLabel from "../WidgetLabel/WidgetLabel.svelte";
 
 	export let label: string = "";
 	export let placeholder: string = "Your sentence here...";
 	export let value: string;
 
-	function handlePaste(e: ClipboardEvent) {
-		e.preventDefault();
+	let textAreaEl: HTMLTextAreaElement;
 
-		const text = e.clipboardData.getData("text/plain");
-		const sel = window.getSelection();
-		const range = sel.getRangeAt(0);
-		range.insertNode(document.createTextNode(text));
-		range.collapse(false);
+	const HEIGHT_LIMIT = 500 as const;
+
+	async function resize() {
+		if (!!textAreaEl) {
+			textAreaEl.style.height = "";
+			await tick();
+			textAreaEl.style.height =
+				Math.min(textAreaEl.scrollHeight, HEIGHT_LIMIT) + "px";
+		}
+	}
+
+	$: {
+		value;
+		resize();
 	}
 </script>
 
 <WidgetLabel {label}>
 	<svelte:fragment slot="after">
-		<span
-			bind:textContent={value}
-			on:paste={handlePaste}
+		<textarea
+			bind:this={textAreaEl}
+			bind:value
 			class="{label
 				? 'mt-1.5'
-				: ''} block overflow-auto resize-y py-2 px-3 w-full min-h-[42px] max-h-[500px] border border-gray-200 rounded-lg shadow-inner outline-none focus:ring-1 focus:ring-inset focus:ring-indigo-200 focus:shadow-inner dark:bg-gray-925"
-			role="textbox"
-			contenteditable
-			style="--placeholder: '{placeholder}'"
+				: ''} block w-full border border-gray-200 rounded-lg shadow-inner outline-none focus:ring-1 focus:ring-inset focus:ring-indigo-200 focus:shadow-inner dark:bg-gray-925"
+			{placeholder}
 		/>
 	</svelte:fragment>
 </WidgetLabel>
-
-<style>
-	span[contenteditable]:empty::before {
-		content: var(--placeholder);
-		color: rgba(156, 163, 175);
-	}
-</style>

--- a/js/src/lib/components/InferenceWidget/shared/WidgetTextarea/WidgetTextarea.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetTextarea/WidgetTextarea.svelte
@@ -1,29 +1,34 @@
 <script>
+	import { onMount } from "svelte";
+
 	import WidgetLabel from "../WidgetLabel/WidgetLabel.svelte";
 
 	export let label: string = "";
 	export let placeholder: string = "Your sentence here...";
 	export let value: string;
 
-	// hack to handle FireFox contenteditable bug
-	let innterHTML: string;
 	let spanEl: HTMLSpanElement;
-	const REGEX_SPAN = /<span .+>(.*)<\/span>/gms;
-	$: {
-		if (spanEl && innterHTML && REGEX_SPAN.test(innterHTML)) {
-			innterHTML = innterHTML.replace(REGEX_SPAN, (_, txt) => {
-				return txt;
-			});
-			spanEl.blur();
-		}
+
+	function insertTextAtCaret(text) {
+		const sel = window.getSelection();
+		const range = sel.getRangeAt(0);
+		range.insertNode(document.createTextNode(text));
+		range.collapse(false);
 	}
+
+	onMount(() => {
+		spanEl.addEventListener("paste", (e) => {
+			e.preventDefault();
+			const text = e.clipboardData.getData("text/plain");
+			insertTextAtCaret(text);
+		});
+	});
 </script>
 
 <WidgetLabel {label}>
 	<svelte:fragment slot="after">
 		<span
 			bind:textContent={value}
-			bind:innerHTML={innterHTML}
 			bind:this={spanEl}
 			class="{label
 				? 'mt-1.5'

--- a/js/src/lib/components/InferenceWidget/shared/WidgetTextarea/WidgetTextarea.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetTextarea/WidgetTextarea.svelte
@@ -9,7 +9,7 @@
 
 	let spanEl: HTMLSpanElement;
 
-	function insertTextAtCaret(text) {
+	function insertTextAtCaret(text: string) {
 		const sel = window.getSelection();
 		const range = sel.getRangeAt(0);
 		range.insertNode(document.createTextNode(text));

--- a/js/src/lib/components/InferenceWidget/shared/WidgetTextarea/WidgetTextarea.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetTextarea/WidgetTextarea.svelte
@@ -13,7 +13,7 @@
 
 	async function resize() {
 		if (!!textAreaEl) {
-			textAreaEl.style.height = "";
+			textAreaEl.style.height = "0px";
 			await tick();
 			textAreaEl.style.height =
 				Math.min(textAreaEl.scrollHeight, HEIGHT_LIMIT) + "px";

--- a/js/src/lib/components/InferenceWidget/shared/WidgetTextarea/WidgetTextarea.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetTextarea/WidgetTextarea.svelte
@@ -1,35 +1,26 @@
 <script>
-	import { onMount } from "svelte";
-
 	import WidgetLabel from "../WidgetLabel/WidgetLabel.svelte";
 
 	export let label: string = "";
 	export let placeholder: string = "Your sentence here...";
 	export let value: string;
 
-	let spanEl: HTMLSpanElement;
+	function handlePaste(e: ClipboardEvent){
+		e.preventDefault();
 
-	function insertTextAtCaret(text: string) {
+		const text = e.clipboardData.getData("text/plain");
 		const sel = window.getSelection();
 		const range = sel.getRangeAt(0);
 		range.insertNode(document.createTextNode(text));
 		range.collapse(false);
 	}
-
-	onMount(() => {
-		spanEl.addEventListener("paste", (e) => {
-			e.preventDefault();
-			const text = e.clipboardData.getData("text/plain");
-			insertTextAtCaret(text);
-		});
-	});
 </script>
 
 <WidgetLabel {label}>
 	<svelte:fragment slot="after">
 		<span
 			bind:textContent={value}
-			bind:this={spanEl}
+			on:paste={handlePaste}
 			class="{label
 				? 'mt-1.5'
 				: ''} block overflow-auto resize-y py-2 px-3 w-full min-h-[42px] max-h-[500px] border border-gray-200 rounded-lg shadow-inner outline-none focus:ring-1 focus:ring-inset focus:ring-indigo-200 focus:shadow-inner dark:bg-gray-925"

--- a/js/src/lib/components/InferenceWidget/shared/WidgetTextarea/WidgetTextarea.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetTextarea/WidgetTextarea.svelte
@@ -1,5 +1,5 @@
 <script>
-	import { onMount, tick } from "svelte";
+	import { tick } from "svelte";
 
 	import WidgetLabel from "../WidgetLabel/WidgetLabel.svelte";
 

--- a/js/src/lib/components/InferenceWidget/shared/WidgetTextarea/WidgetTextarea.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetTextarea/WidgetTextarea.svelte
@@ -5,7 +5,7 @@
 	export let placeholder: string = "Your sentence here...";
 	export let value: string;
 
-	function handlePaste(e: ClipboardEvent){
+	function handlePaste(e: ClipboardEvent) {
 		e.preventDefault();
 
 		const text = e.clipboardData.getData("text/plain");


### PR DESCRIPTION
This PR fixes a bug where copied text was being pasted with a style inside the span text area (which is the default span behaviour)

Test it [here on netlify](https://61f16ed04efc61d1044b4c73--huggingface-widgets.netlify.app/facebook/bart-large-cnn)