### PR TITLE
Warn empty valid output

### DIFF
--- a/js/src/lib/components/InferenceWidget/widgets/AudioClassificationWidget/AudioClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/AudioClassificationWidget/AudioClassificationWidget.svelte
@@ -28,6 +28,7 @@
 	let output: Array<{ label: string; score: number }> = [];
 	let outputJson: string;
 	let selectedSampleUrl = "";
+	let warning: string = "";
 
 	function onRecordStart() {
 		file = null;
@@ -93,6 +94,9 @@
 			computeTime = res.computeTime;
 			output = res.output;
 			outputJson = res.outputJson;
+			if (output.length === 0) {
+				warning = "No classes were detected";
+			}
 		} else if (res.status === "loading-model") {
 			modelLoading = {
 				isLoading: true,
@@ -177,6 +181,9 @@
 					getOutput();
 				}}
 			/>
+			{#if warning}
+				<div class="alert alert-warning mt-2">{warning}</div>
+			{/if}
 		</form>
 	</svelte:fragment>
 	<svelte:fragment slot="bottom">

--- a/js/src/lib/components/InferenceWidget/widgets/AudioClassificationWidget/AudioClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/AudioClassificationWidget/AudioClassificationWidget.svelte
@@ -86,6 +86,7 @@
 		// Reset values
 		computeTime = "";
 		error = "";
+		warning = "";
 		modelLoading = { isLoading: false, estimatedTime: 0 };
 		output = [];
 		outputJson = "";

--- a/js/src/lib/components/InferenceWidget/widgets/AutomaticSpeechRecognitionWidget/AutomaticSpeechRecognitionWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/AutomaticSpeechRecognitionWidget/AutomaticSpeechRecognitionWidget.svelte
@@ -86,6 +86,7 @@
 		// Reset values
 		computeTime = "";
 		error = "";
+		warning = "";
 		modelLoading = { isLoading: false, estimatedTime: 0 };
 		output = "";
 		outputJson = "";

--- a/js/src/lib/components/InferenceWidget/widgets/AutomaticSpeechRecognitionWidget/AutomaticSpeechRecognitionWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/AutomaticSpeechRecognitionWidget/AutomaticSpeechRecognitionWidget.svelte
@@ -28,6 +28,7 @@
 	let output = "";
 	let outputJson: string;
 	let selectedSampleUrl = "";
+	let warning: string = "";
 
 	function onRecordStart() {
 		file = null;
@@ -93,6 +94,9 @@
 			computeTime = res.computeTime;
 			output = res.output;
 			outputJson = res.outputJson;
+			if (output.length === 0) {
+				warning = "No speech was detected";
+			}
 		} else if (res.status === "loading-model") {
 			modelLoading = {
 				isLoading: true,
@@ -166,6 +170,9 @@
 					getOutput();
 				}}
 			/>
+			{#if warning}
+				<div class="alert alert-warning mt-2">{warning}</div>
+			{/if}
 		</form>
 	</svelte:fragment>
 	<svelte:fragment slot="bottom">

--- a/js/src/lib/components/InferenceWidget/widgets/ImageClassificationWidget/ImageClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ImageClassificationWidget/ImageClassificationWidget.svelte
@@ -22,6 +22,7 @@
 	};
 	let output: Array<{ label: string; score: number }> = [];
 	let outputJson: string;
+	let warning: string = "";
 
 	function onSelectFile(file: File | Blob) {
 		imgSrc = URL.createObjectURL(file);
@@ -59,6 +60,9 @@
 			computeTime = res.computeTime;
 			output = res.output;
 			outputJson = res.outputJson;
+			if (output.length === 0) {
+				warning = "No classes were detected";
+			}
 		} else if (res.status === "loading-model") {
 			modelLoading = {
 				isLoading: true,
@@ -147,6 +151,9 @@
 				label="Browse for image"
 				{onSelectFile}
 			/>
+			{#if warning}
+				<div class="alert alert-warning mt-2">{warning}</div>
+			{/if}
 		</form>
 	</svelte:fragment>
 	<svelte:fragment slot="bottom">

--- a/js/src/lib/components/InferenceWidget/widgets/ImageClassificationWidget/ImageClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ImageClassificationWidget/ImageClassificationWidget.svelte
@@ -37,6 +37,7 @@
 		// Reset values
 		computeTime = "";
 		error = "";
+		warning = "";
 		output = [];
 		outputJson = "";
 

--- a/js/src/lib/components/InferenceWidget/widgets/ObjectDetectionWidget/ObjectDetectionWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ObjectDetectionWidget/ObjectDetectionWidget.svelte
@@ -17,7 +17,6 @@
 
 	let computeTime = "";
 	let error: string = "";
-	let warning: string = "";
 	let isLoading = false;
 	let imgSrc = "";
 	let modelLoading = {
@@ -27,6 +26,7 @@
 	let output: DetectedObject[] = [];
 	let outputJson: string;
 	let highlightIndex = -1;
+	let warning: string = "";
 
 	function onSelectFile(file: File | Blob) {
 		imgSrc = URL.createObjectURL(file);

--- a/js/src/lib/components/InferenceWidget/widgets/TextGenerationWidget/TextGenerationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TextGenerationWidget/TextGenerationWidget.svelte
@@ -32,6 +32,7 @@
 	let output = "";
 	let outputJson: string;
 	let text = "";
+	let warning: string = "";
 
 	// Deactivate server caching for these two pipeline types
 	// (translation uses this widget too and still needs caching)
@@ -96,6 +97,9 @@
 			computeTime = res.computeTime;
 			output = res.output;
 			outputJson = res.outputJson;
+			if (output.length === 0) {
+				warning = "No text was generated";
+			}
 		} else if (res.status === "loading-model") {
 			modelLoading = {
 				isLoading: true,
@@ -152,6 +156,9 @@
 					getOutput();
 				}}
 			/>
+			{#if warning}
+				<div class="alert alert-warning mt-2">{warning}</div>
+			{/if}
 		</form>
 	</svelte:fragment>
 	<svelte:fragment slot="bottom">

--- a/js/src/lib/components/InferenceWidget/widgets/TextGenerationWidget/TextGenerationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TextGenerationWidget/TextGenerationWidget.svelte
@@ -89,6 +89,7 @@
 		// Reset values
 		computeTime = "";
 		error = "";
+		warning = "";
 		modelLoading = { isLoading: false, estimatedTime: 0 };
 		output = "";
 		outputJson = "";

--- a/js/src/lib/components/InferenceWidget/widgets/TokenClassificationWidget/TokenClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TokenClassificationWidget/TokenClassificationWidget.svelte
@@ -47,6 +47,7 @@
 	let outputJson: string;
 	let text = "";
 	let outputText = "";
+	let warning: string = "";
 
 	onMount(() => {
 		const [textParam] = getSearchParams(["text"]);
@@ -103,6 +104,9 @@
 			output = res.output;
 			outputJson = res.outputJson;
 			outputText = text;
+			if (output.length === 0) {
+				warning = "No token was detected";
+			}
 		} else if (res.status === "loading-model") {
 			modelLoading = {
 				isLoading: true,
@@ -261,6 +265,9 @@
 					getOutput();
 				}}
 			/>
+			{#if warning}
+				<div class="alert alert-warning mt-2">{warning}</div>
+			{/if}
 		</form>
 	</svelte:fragment>
 	<svelte:fragment slot="bottom">

--- a/js/src/lib/components/InferenceWidget/widgets/TokenClassificationWidget/TokenClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TokenClassificationWidget/TokenClassificationWidget.svelte
@@ -95,6 +95,7 @@
 		// Reset values
 		computeTime = "";
 		error = "";
+		warning = "";
 		modelLoading = { isLoading: false, estimatedTime: 0 };
 		output = [];
 		outputJson = "";

--- a/js/src/lib/components/InferenceWidget/widgets/ZeroShowClassificationWidget/ZeroShotClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ZeroShowClassificationWidget/ZeroShotClassificationWidget.svelte
@@ -112,6 +112,7 @@
 		// Reset values
 		computeTime = "";
 		error = "";
+		warning = "";
 		modelLoading = { isLoading: false, estimatedTime: 0 };
 		output = [];
 		outputJson = "";

--- a/js/src/lib/components/InferenceWidget/widgets/ZeroShowClassificationWidget/ZeroShotClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ZeroShowClassificationWidget/ZeroShotClassificationWidget.svelte
@@ -35,6 +35,7 @@
 	let output: Array<{ label: string; score: number }> = [];
 	let outputJson: string;
 	let text = "";
+	let warning: string = "";
 
 	onMount(() => {
 		const [candidateLabelsParam, multiClassParam, textParam] = getSearchParams([
@@ -119,6 +120,9 @@
 			computeTime = res.computeTime;
 			output = res.output;
 			outputJson = res.outputJson;
+			if (output.length === 0) {
+				warning = "No classes were detected";
+			}
 		} else if (res.status === "loading-model") {
 			modelLoading = {
 				isLoading: true,
@@ -193,6 +197,9 @@
 					getOutput();
 				}}
 			/>
+			{#if warning}
+				<div class="alert alert-warning mt-2">{warning}</div>
+			{/if}
 		</form>
 	</svelte:fragment>
 	<svelte:fragment slot="bottom">


### PR DESCRIPTION
Closes huggingface/hub-docs#18

Some pipeline types can produce valid empty output. Despite the output being valid, it is rather confusing for a user. Therefore, in those situation, there will be warning message about empty output. 

(we already handle it for empty outputs in Object Detection pipeline (see [internal](https://huggingface.slack.com/archives/C025RSDHH54/p1632151012057600?thread_ts=1632148300.052900&cid=C025RSDHH54)), this PR applying the same warning UI to other pipelines)

<img width="600" alt="Screenshot 2022-02-02 at 16 36 05" src="https://user-images.githubusercontent.com/11827707/152185896-6cc0fdba-9b25-479b-ab39-e9dbd3940dbf.png">

[try netlify](https://61faa5931f3fb90085d0d5ab--huggingface-widgets.netlify.app/dbmdz/bert-large-cased-finetuned-conll03-english)

cc: @osanseviero @adrinjalali 