### PR TITLE
Remove paying subscription mention from docstring

### DIFF
--- a/js/src/lib/components/InferenceWidget/shared/WidgetTextarea/WidgetTextarea.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetTextarea/WidgetTextarea.svelte
@@ -1,43 +1,40 @@
 <script>
+	import { tick } from "svelte";
+
 	import WidgetLabel from "../WidgetLabel/WidgetLabel.svelte";
 
 	export let label: string = "";
 	export let placeholder: string = "Your sentence here...";
 	export let value: string;
 
-	// hack to handle FireFox contenteditable bug
-	let innterHTML: string;
-	let spanEl: HTMLSpanElement;
-	const REGEX_SPAN = /<span .+>(.*)<\/span>/gms;
-	$: {
-		if (spanEl && innterHTML && REGEX_SPAN.test(innterHTML)) {
-			innterHTML = innterHTML.replace(REGEX_SPAN, (_, txt) => {
-				return txt;
-			});
-			spanEl.blur();
+	let textAreaEl: HTMLTextAreaElement;
+
+	const HEIGHT_LIMIT = 500 as const;
+
+	async function resize() {
+		if (!!textAreaEl) {
+			textAreaEl.style.height = "0px";
+			await tick();
+			textAreaEl.style.height =
+				Math.min(textAreaEl.scrollHeight, HEIGHT_LIMIT) + "px";
 		}
+	}
+
+	$: {
+		value;
+		resize();
 	}
 </script>
 
 <WidgetLabel {label}>
 	<svelte:fragment slot="after">
-		<span
-			bind:textContent={value}
-			bind:innerHTML={innterHTML}
-			bind:this={spanEl}
+		<textarea
+			bind:this={textAreaEl}
+			bind:value
 			class="{label
 				? 'mt-1.5'
-				: ''} block overflow-auto resize-y py-2 px-3 w-full min-h-[42px] max-h-[500px] border border-gray-200 rounded-lg shadow-inner outline-none focus:ring-1 focus:ring-inset focus:ring-indigo-200 focus:shadow-inner dark:bg-gray-925"
-			role="textbox"
-			contenteditable
-			style="--placeholder: '{placeholder}'"
+				: ''} block w-full border border-gray-200 rounded-lg shadow-inner outline-none focus:ring-1 focus:ring-inset focus:ring-indigo-200 focus:shadow-inner dark:bg-gray-925"
+			{placeholder}
 		/>
 	</svelte:fragment>
 </WidgetLabel>
-
-<style>
-	span[contenteditable]:empty::before {
-		content: var(--placeholder);
-		color: rgba(156, 163, 175);
-	}
-</style>

--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -213,7 +213,7 @@ class ModelHubMixin:
                 Organization in which you want to push your model or tokenizer (you must be a member of this
                 organization).
             private (:obj:`bool`, `optional`):
-                Whether or not the repository created should be private (requires a paying subscription).
+                Whether or not the repository created should be private.
             api_endpoint (:obj:`str`, `optional`):
                 The API endpoint to use when pushing the model to the hub.
             use_auth_token (:obj:`bool` or :obj:`str`, `optional`):

--- a/src/huggingface_hub/keras_mixin.py
+++ b/src/huggingface_hub/keras_mixin.py
@@ -103,7 +103,7 @@ def push_to_hub_keras(
             Organization in which you want to push your model or tokenizer (you must be a member of this
             organization).
         private (:obj:`bool`, `optional`):
-            Whether or not the repository created should be private (requires a paying subscription).
+            Whether or not the repository created should be private.
         api_endpoint (:obj:`str`, `optional`):
             The API endpoint to use when pushing the model to the hub.
         use_auth_token (:obj:`bool` or :obj:`str`, `optional`):


### PR DESCRIPTION
Private repositories do not need a paying subscription; this PR removes that from the docstring of the `push_to_hub` function.

cc @osanseviero 