### PR TITLE
Enable filtering by carbon emission

### DIFF
--- a/src/huggingface_hub/utils/endpoint_helpers.py
+++ b/src/huggingface_hub/utils/endpoint_helpers.py
@@ -14,8 +14,53 @@ Helpful utility functions and classes in relation to exploring API endpoints
 with the aim for a user-friendly interface
 """
 
+import math
+import re
 from dataclasses import dataclass
 from typing import List, Union
+
+
+def _filter_emissions(
+    models,
+    minimum_threshold: Union[int, float] = None,
+    maximum_threshold: Union[int, float] = None,
+):
+    """Filters a list of models for those that include an emission tag
+    and limit them to between two thresholds
+
+    Args:
+        models (:obj:`ModelInfo` or :class:`List`):
+            A list of `ModelInfo`'s to filter by
+        minimum_threshold (:obj:`int` or :obj:`float`):
+            A minimum carbon threshold to filter by, such as 1.
+        maximum_threshold (:obj:`int` or :obj:`float):
+            A maximum carbon threshold to filter by, such as 10.
+    """
+    if minimum_threshold is None and maximum_threshold is None:
+        raise ValueError(
+            "Both `minimum_threshold` and `maximum_threshold` cannot both be `None`"
+        )
+    if not minimum_threshold:
+        minimum_threshold = -1
+    if not maximum_threshold:
+        maximum_threshold = math.inf
+    emissions = []
+    for i, model in enumerate(models):
+        if hasattr(model, "cardData"):
+            if isinstance(model.cardData, dict):
+                emission = model.cardData.get("co2_eq_emissions", None)
+                if isinstance(emissions, dict):
+                    emission = emissions["emissions"]
+                if emission:
+                    emission = str(emission)
+                    if any(char.isdigit() for char in emission):
+                        emission = re.search("\d+\.\d+", str(emission)).group(0)
+                        emissions.append((i, float(emission)))
+    filtered_results = []
+    for (idx, emission) in emissions:
+        if emission >= minimum_threshold and emission <= maximum_threshold:
+            filtered_results.append(models[idx])
+    return filtered_results
 
 
 @dataclass

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -803,6 +803,33 @@ class HfApiPublicTest(unittest.TestCase):
         models = _api.list_models("co2_eq_emissions")
         self.assertTrue(all([not hasattr(model, "cardData") for model in models]))
 
+    @with_production_testing
+    def test_filter_emissions_with_max(self):
+        _api = HfApi()
+        models = _api.list_models(emissions_threshold=(None, 100))
+        self.assertTrue(
+            all([model.cardData["co2_eq_emissions"] <= 100 for model in models])
+        )
+
+    @with_production_testing
+    def test_filter_emissions_with_min(self):
+        _api = HfApi()
+        models = _api.list_models(emissions_threshold=(5, None))
+        self.assertTrue(
+            all([model.cardData["co2_eq_emissions"] >= 5 for model in models])
+        )
+
+    @with_production_testing
+    def test_filter_emissions_with_min_and_max(self):
+        _api = HfApi()
+        models = _api.list_models(emissions_threshold=(5, 100))
+        self.assertTrue(
+            all([model.cardData["co2_eq_emissions"] >= 5 for model in models])
+        )
+        self.assertTrue(
+            all([model.cardData["co2_eq_emissions"] <= 100 for model in models])
+        )
+
 
 class HfApiPrivateTest(HfApiCommonTestWithLogin):
     def setUp(self) -> None:


### PR DESCRIPTION
This enables filtering via a carbon emission threshold when searching models at the base level.

If we like this, I'll also go include it to the `ModelFilter` before merging.

cc @sashavor 