### PR TITLE
DOC use npm ci instead on npm install

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -15,7 +15,8 @@ TODO: write more documentation
 ## How to develop
 
 Once you've created a project and installed dependencies with `npm ci` (or
-`pnpm install` or `yarn`), start a development server:
+`pnpm install --frozen-lockfile` or `yarn install --frozen-lockfile`), start a
+development server:
 
 ```bash
 npm run dev

--- a/js/README.md
+++ b/js/README.md
@@ -14,7 +14,8 @@ TODO: write more documentation
 
 ## How to develop
 
-Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn`), start a development server:
+Once you've created a project and installed dependencies with `npm ci` (or
+`pnpm install` or `yarn`), start a development server:
 
 ```bash
 npm run dev
@@ -28,4 +29,3 @@ npm run dev -- --open
 ```bash
 npm run build
 ```
-


### PR DESCRIPTION
`package.json` and `package-lock.json` are not in sync, and doing an `npm install` wouldn't work. We either need to sync them up, or ask users to install with `npm ci` instead. This PR suggests the latter.

Note that I'm an absolute newbie with JS, and took me a while to figure this out with the help of a friend of mine, and I'm not sure which solution we should take.