### PR TITLE
Upgrade black to version ~=22.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ extras["testing"] = [
 ]
 
 extras["quality"] = [
-    "black==21.4b0",
+    "black~=22.0",
     "isort>=5.5.4",
     "flake8>=3.8.3",
 ]

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -879,7 +879,7 @@ class HfLargefilesTest(HfApiCommonTest):
         REMOTE_URL = self._api.create_repo(
             name=self.REPO_NAME_LARGE_FILE,
             token=self._token,
-            lfsmultipartthresh=6 * 10 ** 6,
+            lfsmultipartthresh=6 * 10**6,
         )
         self.setup_local_clone(REMOTE_URL)
 
@@ -932,7 +932,7 @@ class HfLargefilesTest(HfApiCommonTest):
         REMOTE_URL = self._api.create_repo(
             name=self.REPO_NAME_LARGE_FILE,
             token=self._token,
-            lfsmultipartthresh=16 * 10 ** 6,
+            lfsmultipartthresh=16 * 10**6,
         )
         self.setup_local_clone(REMOTE_URL)
 

--- a/tests/test_hubmixin.py
+++ b/tests/test_hubmixin.py
@@ -49,7 +49,6 @@ if is_torch_available():
         def forward(self, x):
             return self.l1(x)
 
-
 else:
     DummyModel = None
 

--- a/tests/test_keras_integration.py
+++ b/tests/test_keras_integration.py
@@ -58,7 +58,6 @@ if is_tf_available():
         def call(self, x):
             return self.l1(x)
 
-
 else:
     DummyModel = None
 


### PR DESCRIPTION
Upgrades the `huggingface_hub` library quality tool `black` to use the first stable release of `black`, version 22.0.