### PR TITLE
Ensure `post_method` is only executed once

### DIFF
--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -48,6 +48,7 @@ class CommandInProgress:
 
         if result and self._post_method is not None:
             self._post_method()
+            self._post_method = None
 
         return result
 


### PR DESCRIPTION
Currently, the `post_method` of a `CommandInProgress` is executed each time the flag `is_done` is accessed. This can yield to errors as seen in the Transformers CI (with some LFS pruning attempted in folders that don't exist anymore).

This PR destroys the `post_method` once executed, which ensures it is only executed once.