### PR TITLE
added library_name to yaml template

### DIFF
--- a/modelcard.md
+++ b/modelcard.md
@@ -3,7 +3,7 @@ language:
 - {lang_0}  # Example: fr
 - {lang_1}  # Example: en
 license: {license}  # Example: apache-2.0 or any license from https://hf.co/docs/hub/model-repos#list-of-license-identifiers
-library_name: {library_name} # Example: keras
+library_name: {library_name} # Example: keras or any library from https://github.com/huggingface/huggingface_hub/blob/main/js/src/lib/interfaces/Libraries.ts
 tags:
 - {tag_0}  # Example: audio
 - {tag_1}  # Example: automatic-speech-recognition

--- a/modelcard.md
+++ b/modelcard.md
@@ -3,6 +3,7 @@ language:
 - {lang_0}  # Example: fr
 - {lang_1}  # Example: en
 license: {license}  # Example: apache-2.0 or any license from https://hf.co/docs/hub/model-repos#list-of-license-identifiers
+library_name: {library_name} # Example: keras
 tags:
 - {tag_0}  # Example: audio
 - {tag_1}  # Example: automatic-speech-recognition

--- a/modelcard.md
+++ b/modelcard.md
@@ -3,7 +3,7 @@ language:
 - {lang_0}  # Example: fr
 - {lang_1}  # Example: en
 license: {license}  # Example: apache-2.0 or any license from https://hf.co/docs/hub/model-repos#list-of-license-identifiers
-library_name: {library_name} # Example: keras or any library from https://github.com/huggingface/huggingface_hub/blob/main/js/src/lib/interfaces/Libraries.ts
+library_name: {library_name}  # Example: keras or any library from https://github.com/huggingface/huggingface_hub/blob/main/js/src/lib/interfaces/Libraries.ts
 tags:
 - {tag_0}  # Example: audio
 - {tag_1}  # Example: automatic-speech-recognition


### PR DESCRIPTION
`library_name` was missing in the docs (which was the reason why I broke the 🤗 Hub yesterday) so I added it.
