### PR TITLE
Separate Repository tests into their own matrix

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -39,7 +39,7 @@ jobs:
           pip install --upgrade pip
           pip install .[testing]
 
-      - run: pytest -sv ./tests/${{test_repository}}
+      - run: pytest -sv ./tests/${{ matrix.test_repository }}
 
   build_pytorch:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.9"]
+        python-version: ["3.9"]
         test_repository: [" --ignore tests/test_repository.py", "test_repository.py"]
 
     steps:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -22,8 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9"]
-        test_repository: [" --ignore tests/test_repository.py", "test_repository.py"]
+        python-version: ["3.6", "3.9"]
+        test_repository: [" --ignore tests/test_repository.py::RepositoryTest", "test_repository.py::RepositoryTest"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.6"]
         test_repository: [" --ignore tests/test_repository.py", "test_repository.py"]
 
     steps:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.6", "3.9"]
-        test_repository: [" --ignore tests/test_repository.py::RepositoryTest", "test_repository.py::RepositoryTest"]
+        test_repository: [" --ignore tests/test_repository.py", "test_repository.py"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6"]
+        python-version: ["3.9"]
         test_repository: [" --ignore tests/test_repository.py", "test_repository.py"]
 
     steps:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -23,6 +23,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.6", "3.9"]
+        test_repository: [" --ignore tests/test_repository.py", "test_repository.py"]
 
     steps:
       - uses: actions/checkout@v2
@@ -38,7 +39,7 @@ jobs:
           pip install --upgrade pip
           pip install .[testing]
 
-      - run: pytest -sv ./tests/
+      - run: pytest -sv ./tests/${{test_repository}}
 
   build_pytorch:
     runs-on: ubuntu-latest

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -21,7 +21,6 @@ import time
 import unittest
 import uuid
 from io import BytesIO
-import time
 
 import requests
 from huggingface_hub.commands.user import currently_setup_credential_helpers

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -95,7 +95,6 @@ class RepositoryTest(RepositoryCommonTest):
             )
         except requests.exceptions.HTTPError:
             pass
-        time.sleep(1)
 
     def test_init_from_existing_local_clone(self):
         subprocess.run(

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -95,7 +95,7 @@ class RepositoryTest(RepositoryCommonTest):
             )
         except requests.exceptions.HTTPError:
             pass
-        time.sleep(0.2)
+        time.sleep(1)
 
     def test_init_from_existing_local_clone(self):
         subprocess.run(

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -21,6 +21,7 @@ import time
 import unittest
 import uuid
 from io import BytesIO
+import time
 
 import requests
 from huggingface_hub.commands.user import currently_setup_credential_helpers
@@ -95,6 +96,7 @@ class RepositoryTest(RepositoryCommonTest):
             )
         except requests.exceptions.HTTPError:
             pass
+        time.sleep(0.2)
 
     def test_init_from_existing_local_clone(self):
         subprocess.run(


### PR DESCRIPTION
## What:
Seperates out the very long `Repository` tests into their own CI/CD matrix

## Why:
CI/CD can now take just as little as 6-8 minutes or so, rather than 10-15 due to how long the Repository tests take

## What this does not do
This doesn't fix our stability issues sadly, and why we get 504 errors so much

## What we watch for
Just like before, we want to make sure some combination of `--ignore` + `test_repository` pass at least once to consider it "stable".

cc @LysandreJik 