### PR TITLE
Add support for private hub

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -410,6 +410,8 @@ def erase_from_credential_store(username=None):
 
 class HfApi:
     def __init__(self, endpoint=None):
+        if endpoint is None:
+            endpoint = os.getenv('HF_ENDPOINT')
         self.endpoint = endpoint if endpoint is not None else ENDPOINT
 
     def login(self, username: str, password: str) -> str:

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -410,9 +410,9 @@ def erase_from_credential_store(username=None):
 
 class HfApi:
     def __init__(self, endpoint=None):
-        if endpoint is None:
-            endpoint = os.getenv("HF_ENDPOINT")
-        self.endpoint = endpoint if endpoint is not None else ENDPOINT
+        self.endpoint = (
+            endpoint if endpoint is not None else os.getenv("HF_ENDPOINT", ENDPOINT)
+        )
 
     def login(self, username: str, password: str) -> str:
         """

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -411,7 +411,7 @@ def erase_from_credential_store(username=None):
 class HfApi:
     def __init__(self, endpoint=None):
         if endpoint is None:
-            endpoint = os.getenv('HF_ENDPOINT')
+            endpoint = os.getenv("HF_ENDPOINT")
         self.endpoint = endpoint if endpoint is not None else ENDPOINT
 
     def login(self, username: str, password: str) -> str:


### PR DESCRIPTION
This fixes https://github.com/huggingface/huggingface_hub/issues/650

We simply set HF_ENDPOINT to the URL of a private hub, and use the API as-is.  If the API itself has the endpoint, then the environment variable is ignored.

FYI, the same variable is used by the datasets library for a similar purpose.