### PR TITLE
Fix API_URL in servePython.ts

### DIFF
--- a/js/src/lib/inferenceSnippets/servePython.ts
+++ b/js/src/lib/inferenceSnippets/servePython.ts
@@ -38,7 +38,7 @@ export function getPythonInferenceSnippet(model: ModelData, accessToken: string)
 
 	return `import requests
 
-API_URL = "https://api-inference.huggingface.co/models/${model.id, accessToken}"
+API_URL = "https://api-inference.huggingface.co/models/${model.id}"
 headers = {"Authorization": ${accessToken ? `"Bearer ${accessToken}"` : `f"Bearer {API_TOKEN}"`}}
 
 def query(payload):


### PR DESCRIPTION
Right now the API url displays the user token instead of the modelId 🙈 