### PR TITLE
Bump fairseq version to avoid bug

### DIFF
--- a/api-inference-community/docker_images/fairseq/requirements.txt
+++ b/api-inference-community/docker_images/fairseq/requirements.txt
@@ -5,4 +5,4 @@ phonemizer==2.2.1
 librosa==0.8.1
 hanziconv==0.3.2
 sentencepiece==0.1.91
-git+git://github.com/pytorch/fairseq.git@1d5da6d5b954ba01fc3df12d25d63df27437e20e
+git+git://github.com/pytorch/fairseq.git@5175fd5c267adceec9445bf067597686e159e7e7


### PR DESCRIPTION
[facebook/tts_transformer-en-ljspeech](https://huggingface.co/facebook/tts_transformer-en-ljspeech?text=Hello%2C+this+is+a+test+run.) inference is broken, but this is fixed in a later `fairseq` version (this has not made to a release yet). I could add this to a unit test, but the library failing for a certain type of model is not something we should have in our test coverage imo
