### PR TITLE
Update rename/transfer repo rule docs

### DIFF
--- a/docs/hub/main.md
+++ b/docs/hub/main.md
@@ -98,14 +98,16 @@ Here is a video to learn more about it from our [course](http://hf.co/course)!
 
 You can go to the settings page in any repo to achieve this. Note that there are certain limitations in terms of use cases.
 
-Moving can be used for three use cases ✅ 
+Moving can be used in these use cases ✅ 
 - Renaming a repository within same user.
 - Renaming a repository within same organization. The user must be part of the organization and have "write" or "admin" rights in the organization.
-- Transfering repository from user to an organization. The user must be part of the organization and have "write" or "admin" rights in the organization.
+- Transferring repository from user to an organization. The user must be part of the organization and have "write" or "admin" rights in the organization.
+- Transferring a repository from an organization to yourself. You must be part of the organization, and have "admin" rights in the organization.
+- Transferring a repository from an organization to another organization. The user must have "admin" rights in the source organization and either "write" or "admin" rights in the target organization. 
 
 Moving does not work for ❌
-- Transfering a repository from an organization to another user or organization.
-- Transfering a repository from user A to user B.
+- Transferring a repository from an organization to another user or organization.
+- Transferring a repository from user A to user B.
 
 If these are use cases you need help with, please send us an email at **website at huggingface.co**.
 

--- a/docs/hub/main.md
+++ b/docs/hub/main.md
@@ -103,10 +103,11 @@ Moving can be used in these use cases ✅
 - Renaming a repository within same organization. The user must be part of the organization and have "write" or "admin" rights in the organization.
 - Transferring repository from user to an organization. The user must be part of the organization and have "write" or "admin" rights in the organization.
 - Transferring a repository from an organization to yourself. You must be part of the organization, and have "admin" rights in the organization.
-- Transferring a repository from an organization to another organization. The user must have "admin" rights in the source organization and either "write" or "admin" rights in the target organization. 
+- Transferring a repository from a source organization to another target organization. The user must have "admin" rights in the source organization **and** either "write" or "admin" rights in the target organization. 
 
 Moving does not work for ❌
-- Transferring a repository from an organization to another user or organization.
+- Transferring a repository from an organization to another user who is not yourself.
+- Transferring a repository from a source organization to another target organization if the user does not have both "admin" rights in the source organization **and** either "write" or "admin" rights in the target organization.
 - Transferring a repository from user A to user B.
 
 If these are use cases you need help with, please send us an email at **website at huggingface.co**.


### PR DESCRIPTION
Updated to reflect new move repo authorizations in https://github.com/huggingface/moon-landing/pull/2204 (and fixed a few typos)