### PR TITLE
Logging fix for `hf_api`, logging documentation

### DIFF
--- a/src/huggingface_hub/README.md
+++ b/src/huggingface_hub/README.md
@@ -372,3 +372,37 @@ API.
 ```python
 inference = InferenceApi("bert-base-uncased", task="feature-extraction", token=API_TOKEN)
 ```
+
+## Controlling the logging of `huggingface_hub`
+
+The `huggingface_hub` package exposes a `logging` utility to control the logging level of the package itself.
+You can import it as such:
+
+```py
+from huggingface_hub import logging
+```
+
+Then, you may define the verbosity in order to update the amount of logs you'll see:
+
+```python
+from huggingface_hub import logging
+
+logging.set_verbosity_error()
+logging.set_verbosity_warning()
+logging.set_verbosity_info()
+logging.set_verbosity_debug()
+
+logging.set_verbosity(...)
+```
+
+The levels should be understood as follows:
+
+- `error`: this will only show critical logs about usage which may result in an error or unexpected behavior.
+- `warning`: this will show logs which aren't critical, about usage which may result in unintended behavior.
+  Additionally, important informative logs may be shown.
+- `info`: this will show most logs, including some verbose logging regarding what is happening under the hood.
+  If something is behaving in an unexpected manner, we recommend switching the verbosity level to this in order
+  to get more information.
+- `debug`: this shows all logs, including some internal logs which may be used to track exactly what's happening
+  under the hood.
+

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -424,8 +424,9 @@ class HfApi:
 
         Throws: requests.exceptions.HTTPError if credentials are invalid
         """
-        logger.error(
-            "HfApi.login: This method is deprecated in favor of `set_access_token`."
+        warnings.warn(
+            "HfApi.login: This method is deprecated in favor of `set_access_token`.",
+            FutureWarning,
         )
         path = f"{self.endpoint}/api/login"
         r = requests.post(path, json={"username": username, "password": password})
@@ -494,7 +495,9 @@ class HfApi:
             token (``str``, `optional`):
                 Hugging Face token. Will default to the locally saved token if not provided.
         """
-        logger.error("This method is deprecated in favor of `unset_access_token`.")
+        warnings.warn(
+            "This method is deprecated in favor of `unset_access_token`.", FutureWarning
+        )
         if token is None:
             token = HfFolder.get_token()
         if token is None:

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -425,7 +425,7 @@ class HfApi:
         Throws: requests.exceptions.HTTPError if credentials are invalid
         """
         warnings.warn(
-            "HfApi.login: This method is deprecated in favor of `set_access_token`.",
+            "HfApi.login: This method is deprecated in favor of `set_access_token` and will be removed in v0.7.",
             FutureWarning,
         )
         path = f"{self.endpoint}/api/login"
@@ -496,7 +496,8 @@ class HfApi:
                 Hugging Face token. Will default to the locally saved token if not provided.
         """
         warnings.warn(
-            "This method is deprecated in favor of `unset_access_token`.", FutureWarning
+            "HfApi.logout: This method is deprecated in favor of `unset_access_token` and will be removed in v0.7.",
+            FutureWarning,
         )
         if token is None:
             token = HfFolder.get_token()

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import logging
 import os
 import subprocess
 import sys
@@ -31,6 +30,7 @@ from .constants import (
     REPO_TYPES_URL_PREFIXES,
     SPACES_SDK_TYPES,
 )
+from .utils import logging
 from .utils.endpoint_helpers import (
     AttributeDictionary,
     DatasetFilter,
@@ -48,6 +48,8 @@ else:
 
 
 USERNAME_PLACEHOLDER = "hf_user"
+
+logger = logging.get_logger(__name__)
 
 
 def repo_type_and_id_from_hf_id(hf_id: str):
@@ -422,7 +424,7 @@ class HfApi:
 
         Throws: requests.exceptions.HTTPError if credentials are invalid
         """
-        logging.error(
+        logger.error(
             "HfApi.login: This method is deprecated in favor of `set_access_token`."
         )
         path = f"{self.endpoint}/api/login"
@@ -492,7 +494,7 @@ class HfApi:
             token (``str``, `optional`):
                 Hugging Face token. Will default to the locally saved token if not provided.
         """
-        logging.error("This method is deprecated in favor of `unset_access_token`.")
+        logger.error("This method is deprecated in favor of `unset_access_token`.")
         if token is None:
             token = HfFolder.get_token()
         if token is None:
@@ -1265,7 +1267,7 @@ class HfApi:
                 )
             else:
                 raise e
-        logging.info(
+        logger.info(
             "Accepted transfer request. You will get an email once this is successfully completed."
         )
 

--- a/src/huggingface_hub/keras_mixin.py
+++ b/src/huggingface_hub/keras_mixin.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import os
 from pathlib import Path
 from shutil import copytree, rmtree
@@ -16,9 +15,10 @@ from huggingface_hub.snapshot_download import snapshot_download
 from .constants import CONFIG_NAME
 from .hf_api import HfApi, HfFolder
 from .repository import Repository
+from .utils import logging
 
 
-logger = logging.getLogger(__name__)
+logger = logging.get_logger(__name__)
 
 if is_tf_available():
     import tensorflow as tf

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -139,6 +139,25 @@ class HfApiLoginTest(HfApiCommonTest):
             read_from_credential_store(USERNAME_PLACEHOLDER), (None, None)
         )
 
+    def test_login_deprecation_error(self):
+        with pytest.warns(
+            FutureWarning,
+            match=r"HfApi.login: This method is deprecated in favor of "
+            r"`set_access_token` and will be removed in v0.7.",
+        ):
+            self._api.login(username=USER, password=PASS)
+
+    def test_logout_deprecation_error(self):
+        with pytest.warns(
+            FutureWarning,
+            match=r"HfApi.logout: This method is deprecated in favor of "
+            r"`unset_access_token` and will be removed in v0.7.",
+        ):
+            try:
+                self._api.logout()
+            except HTTPError:
+                pass
+
 
 class HfApiCommonTestWithLogin(HfApiCommonTest):
     @classmethod


### PR DESCRIPTION
This fixes an issue with the logging of `hf_api`, replaces `logger.error` for deprecation warnings by a `FutureWarning`, and adds a small document regarding how to use logging with `huggingface_hub`.

cc @FrancescoSaverioZuppichini as you have raised the issue with `hf_api` this morning.