### PR TITLE
Add object-detection to community Inference API

### DIFF
--- a/api-inference-community/api_inference_community/validation.py
+++ b/api-inference-community/api_inference_community/validation.py
@@ -218,7 +218,9 @@ IMAGE_INPUTS = {
     "image-classification",
     "image-segmentation",
     "image-to-text",
+    "object-detection",
 }
+
 TEXT_INPUTS = {
     "conversational",
     "feature-extraction",


### PR DESCRIPTION
This is required to unblock #747 and as part of #332.