### PR TITLE
FIX fix a bug in _filter_emissions to accept numbers w/o decimal and dict emissions

### DIFF
--- a/src/huggingface_hub/utils/endpoint_helpers.py
+++ b/src/huggingface_hub/utils/endpoint_helpers.py
@@ -54,7 +54,7 @@ def _filter_emissions(
                 if emission:
                     emission = str(emission)
                     if any(char.isdigit() for char in emission):
-                        emission = re.search("\d+\.\d+|\d+", str(emission)).group(0)
+                        emission = re.search("\d+\.\d+|\d+", emission).group(0)
                         emissions.append((i, float(emission)))
     filtered_results = []
     for (idx, emission) in emissions:

--- a/src/huggingface_hub/utils/endpoint_helpers.py
+++ b/src/huggingface_hub/utils/endpoint_helpers.py
@@ -49,12 +49,12 @@ def _filter_emissions(
         if hasattr(model, "cardData"):
             if isinstance(model.cardData, dict):
                 emission = model.cardData.get("co2_eq_emissions", None)
-                if isinstance(emissions, dict):
-                    emission = emissions["emissions"]
+                if isinstance(emission, dict):
+                    emission = emission["emissions"]
                 if emission:
                     emission = str(emission)
                     if any(char.isdigit() for char in emission):
-                        emission = re.search("\d+\.\d+", str(emission)).group(0)
+                        emission = re.search("\d+\.\d+|\d+", str(emission)).group(0)
                         emissions.append((i, float(emission)))
     filtered_results = []
     for (idx, emission) in emissions:

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -47,8 +47,11 @@ from huggingface_hub.hf_api import (
     repo_type_and_id_from_hf_id,
 )
 from huggingface_hub.utils import logging
-from huggingface_hub.utils.endpoint_helpers import DatasetFilter, ModelFilter
-from huggingface_hub.utils.endpoint_helpers import _filter_emissions
+from huggingface_hub.utils.endpoint_helpers import (
+    DatasetFilter,
+    ModelFilter,
+    _filter_emissions,
+)
 from requests.exceptions import HTTPError
 
 from .testing_constants import (

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -48,6 +48,7 @@ from huggingface_hub.hf_api import (
 )
 from huggingface_hub.utils import logging
 from huggingface_hub.utils.endpoint_helpers import DatasetFilter, ModelFilter
+from huggingface_hub.utils.endpoint_helpers import _filter_emissions
 from requests.exceptions import HTTPError
 
 from .testing_constants import (
@@ -860,6 +861,14 @@ class HfApiPublicTest(unittest.TestCase):
         self.assertTrue([hasattr(model, "cardData") for model in models])
         models = _api.list_models("co2_eq_emissions")
         self.assertTrue(all([not hasattr(model, "cardData") for model in models]))
+
+    def test_filter_emissions_dict(self):
+        # tests that dictionary is handled correctly as "emissions" and that
+        # 17g is accepted and parsed correctly as a value
+        # regression test for #753
+        model = ModelInfo(cardData={"co2_eq_emissions": {"emissions": "17g"}})
+        res = _filter_emissions([model], -1, 100)
+        assert len(res) == 1
 
     @with_production_testing
     def test_filter_emissions_with_max(self):


### PR DESCRIPTION
This PR fixes a but where it would raise if emissions is a dict, and when the value is something such as `"17g"`

This issue recently caused a failure in the test suite.

cc @muellerzr @osanseviero @LysandreJik 