### PR TITLE
Fix pytorch and tensorflow python matrix

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -50,6 +50,9 @@ jobs:
 
   build_pytorch:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.6", "3.9"]
 
     steps:
     - uses: actions/checkout@v2
@@ -68,6 +71,9 @@ jobs:
 
   build_tensorflow:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.6", "3.9"]
 
     steps:
     - uses: actions/checkout@v2

--- a/src/huggingface_hub/keras_mixin.py
+++ b/src/huggingface_hub/keras_mixin.py
@@ -73,7 +73,6 @@ def _plot_network(model, save_directory):
         expand_nested=False,
         dpi=96,
         layer_range=None,
-        show_layer_activations=True,
     )
 
 


### PR DESCRIPTION
The GH Actions workflow makes reference to the python-version but there is no matrix being set. I'm not sure what's the behavior right now, but I think this is a bug

cc @merveenoyan @nateraw @muellerzr 