### PR TITLE
removed show_layer_activations for old version compatibility

### DIFF
--- a/src/huggingface_hub/keras_mixin.py
+++ b/src/huggingface_hub/keras_mixin.py
@@ -72,7 +72,7 @@ def _plot_network(model, save_directory):
         rankdir="TB",
         expand_nested=False,
         dpi=96,
-        layer_range=None
+        layer_range=None,
     )
 
 

--- a/src/huggingface_hub/keras_mixin.py
+++ b/src/huggingface_hub/keras_mixin.py
@@ -72,8 +72,7 @@ def _plot_network(model, save_directory):
         rankdir="TB",
         expand_nested=False,
         dpi=96,
-        layer_range=None,
-        show_layer_activations=True,
+        layer_range=None
     )
 
 


### PR DESCRIPTION
Removed `show_layer_activations` for old version compatibility. see [the PR](https://github.com/huggingface/huggingface_hub/pull/760)