### PR TITLE
Add the SegFormer blog post to Image Segmentation Task

### DIFF
--- a/tasks/src/image-segmentation/about.md
+++ b/tasks/src/image-segmentation/about.md
@@ -39,3 +39,9 @@ model("cat.png")
 #  'score': 0.999}
 # ...]
 ```
+
+## Useful Resources
+
+Would you like to learn more about token classification? Great! Here you can find some curated resources that you may find helpful!
+
+- [Fine-Tune a Semantic Segmentation Model with a Custom Dataset](https://huggingface.co/blog/fine-tune-segformer)

--- a/tasks/src/image-segmentation/data.ts
+++ b/tasks/src/image-segmentation/data.ts
@@ -9,6 +9,10 @@ const taskData: TaskData = {
 			description: "Widely used benchmark dataset for multiple Vision tasks.",
 			id:          "merve/coco2017",
 		},
+		{
+			description: "A dataset of sidewalk images with semantic segmentation labels.",
+			id:          "segments/sidewalk-semantic",
+		},
 	],
 	demo: {
 		inputs: [
@@ -50,6 +54,10 @@ const taskData: TaskData = {
 			// TO DO: write description
 			description: "Solid panoptic segmentation model trained on the COCO 2017 benchmark dataset.",
 			id:          "facebook/detr-resnet-50-panoptic",
+		},
+		{
+			description: "SegFormer (semantic segmentation model) fine-tuned on sidewalk images.",
+			id: "segments-tobias/segformer-b3-finetuned-segments-sidewalk"
 		}
 	],
 	summary:      "Image Segmentation divides an image into segments where each pixel in the image is mapped to an object. This task has multiple variants such as instance segmentation, panoptic segmentation and semantic segmentation.",


### PR DESCRIPTION
Today, a blog post on how to "[Fine-Tune a Semantic Segmentation Model with a Custom Dataset](https://huggingface.co/blog/fine-tune-segformer)" was released on the HF blog (see [PR #234](https://github.com/huggingface/blog/pull/234)).

This PR links the blog post in the "Useful Resources" section of the Image Segmentation task.
It also adds the `segments/sidewalk-semantic` dataset and `segments-tobias/segformer-b3-finetuned-segments-sidewalk` model as an example.