### PR TITLE
Disable logging in with organization token

### DIFF
--- a/src/huggingface_hub/commands/user.py
+++ b/src/huggingface_hub/commands/user.py
@@ -383,8 +383,11 @@ def _login(hf_api, username=None, password=None, token=None):
             print(e)
             print(ANSI.red(e.response.text))
             exit(1)
-    elif not hf_api._is_valid_token(token):
-        raise ValueError("Invalid token passed.")
+    elif isinstance(token, str):
+        if token.startswith("api_org"):
+            raise ValueError("You must use your personal account token for login.")
+        elif not hf_api._is_valid_token(token):
+            raise ValueError("Invalid token passed.")
 
     hf_api.set_access_token(token)
     HfFolder.save_token(token)

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -477,7 +477,6 @@ class HfApi:
             raise ValueError(
                 "You need to pass a valid `token` or login by using `huggingface-cli login`"
             )
-
         path = f"{self.endpoint}/api/whoami-v2"
         r = requests.get(path, headers={"authorization": f"Bearer {token}"})
         try:
@@ -510,8 +509,11 @@ class HfApi:
                     "You need to provide a `token` or be logged in to Hugging Face with "
                     "`huggingface-cli login`."
                 )
-        elif not self._is_valid_token(token):
-            raise ValueError("Invalid token passed!")
+        elif isinstance(token, str):
+            if token.startswith("api_org"):
+                raise ValueError("You must use your personal account token for login.")
+            elif not self._is_valid_token(token):
+                raise ValueError("Invalid token passed!")
         return token
 
     def logout(self, token: Optional[str] = None) -> None:
@@ -1069,16 +1071,19 @@ class HfApi:
         path = f"{self.endpoint}/api/repos/create"
         if token is None:
             token = self._validate_or_retrieve_token()
-        elif not self._is_valid_token(token):
-            if self._is_valid_token(name):
-                warnings.warn(
-                    "`create_repo` now takes `token` as an optional positional argument. "
-                    "Be sure to adapt your code!",
-                    FutureWarning,
-                )
-                token, name = name, token
-            else:
-                raise ValueError("Invalid token passed!")
+        elif isinstance(token, str):
+            if token.startswith("api_org"):
+                raise ValueError("You must use your personal account token for login.")
+            elif not self._is_valid_token(token):
+                if self._is_valid_token(name):
+                    warnings.warn(
+                        "`create_repo` now takes `token` as an optional positional argument. "
+                        "Be sure to adapt your code!",
+                        FutureWarning,
+                    )
+                    token, name = name, token
+                else:
+                    raise ValueError("Invalid token passed!")
 
         checked_name = repo_type_and_id_from_hf_id(name)
 
@@ -1188,16 +1193,19 @@ class HfApi:
         path = f"{self.endpoint}/api/repos/delete"
         if token is None:
             token = self._validate_or_retrieve_token()
-        elif not self._is_valid_token(token):
-            if self._is_valid_token(name):
-                warnings.warn(
-                    "`delete_repo` now takes `token` as an optional positional argument. "
-                    "Be sure to adapt your code!",
-                    FutureWarning,
-                )
-                token, name = name, token
-            else:
-                raise ValueError("Invalid token passed!")
+        elif isinstance(token, str):
+            if token.startswith("api_org"):
+                raise ValueError("You must use your personal account token for login.")
+            elif not self._is_valid_token(token):
+                if self._is_valid_token(name):
+                    warnings.warn(
+                        "`delete_repo` now takes `token` as an optional positional argument. "
+                        "Be sure to adapt your code!",
+                        FutureWarning,
+                    )
+                    token, name = name, token
+                else:
+                    raise ValueError("Invalid token passed!")
 
         checked_name = repo_type_and_id_from_hf_id(name)
 
@@ -1277,16 +1285,19 @@ class HfApi:
 
         if token is None:
             token = self._validate_or_retrieve_token()
-        elif not self._is_valid_token(token):
-            if self._is_valid_token(name):
-                warnings.warn(
-                    "`update_repo_visibility` now takes `token` as an optional positional argument. "
-                    "Be sure to adapt your code!",
-                    FutureWarning,
-                )
-                token, name, private = name, private, token
-            else:
-                raise ValueError("Invalid token passed!")
+        elif isinstance(token, str):
+            if token.startswith("api_org"):
+                raise ValueError("You must use your personal account token for login.")
+            elif not self._is_valid_token(token):
+                if self._is_valid_token(name):
+                    warnings.warn(
+                        "`update_repo_visibility` now takes `token` as an optional positional argument. "
+                        "Be sure to adapt your code!",
+                        FutureWarning,
+                    )
+                    token, name, private = name, private, token
+                else:
+                    raise ValueError("Invalid token passed!")
 
         if organization is None:
             namespace = self.whoami(token)["name"]
@@ -1424,21 +1435,24 @@ class HfApi:
 
         if token is None:
             token = self._validate_or_retrieve_token()
-        elif not self._is_valid_token(token):
-            if self._is_valid_token(path_or_fileobj):
-                warnings.warn(
-                    "`upload_file` now takes `token` as an optional positional argument. "
-                    "Be sure to adapt your code!",
-                    FutureWarning,
-                )
-                token, path_or_fileobj, path_in_repo, repo_id = (
-                    path_or_fileobj,
-                    path_in_repo,
-                    repo_id,
-                    token,
-                )
-            else:
-                raise ValueError("Invalid token passed!")
+        elif isinstance(token, str):
+            if token.startswith("api_org"):
+                raise ValueError("You must use your personal account token for login.")
+            elif not self._is_valid_token(token):
+                if self._is_valid_token(path_or_fileobj):
+                    warnings.warn(
+                        "`upload_file` now takes `token` as an optional positional argument. "
+                        "Be sure to adapt your code!",
+                        FutureWarning,
+                    )
+                    token, path_or_fileobj, path_in_repo, repo_id = (
+                        path_or_fileobj,
+                        path_in_repo,
+                        repo_id,
+                        token,
+                    )
+                else:
+                    raise ValueError("Invalid token passed!")
 
         # Validate path_or_fileobj
         if isinstance(path_or_fileobj, str):

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -509,7 +509,7 @@ class HfApi:
                     "You need to provide a `token` or be logged in to Hugging Face with "
                     "`huggingface-cli login`."
                 )
-        elif isinstance(token, str):
+        if isinstance(token, str):
             if token.startswith("api_org"):
                 raise ValueError("You must use your personal account token for login.")
             elif not self._is_valid_token(token):

--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -241,7 +241,7 @@ class ModelHubMixin:
             token = HfFolder.get_token()
             if token is None:
                 raise ValueError(
-                    "You must login to the Hugging Face hub on this computer by typing `transformers-cli login` and "
+                    "You must login to the Hugging Face hub on this computer by typing `huggingface-cli login` and "
                     "entering your credentials to use `use_auth_token=True`. Alternatively, you can pass your own "
                     "token as the `use_auth_token` argument."
                 )

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -146,6 +146,12 @@ class HfApiLoginTest(HfApiCommonTest):
             read_from_credential_store(USERNAME_PLACEHOLDER), (None, None)
         )
 
+    def test_login_cli_org_fail(self):
+        with pytest.raises(
+            ValueError, match="You must use your personal account token for login."
+        ):
+            _login(self._api, token="api_org_dummy_token")
+
     def test_login_deprecation_error(self):
         with pytest.warns(
             FutureWarning,
@@ -545,6 +551,14 @@ class HfApiUploadFileTest(HfApiCommonTestWithLogin):
             self.fail(err)
         finally:
             self._api.delete_repo(repo_id=REPO_NAME, token=self._token)
+
+    @retry_endpoint
+    def test_create_repo_org_token_fail(self):
+        REPO_NAME = repo_name("org")
+        with pytest.raises(
+            ValueError, match="You must use your personal account token for login."
+        ):
+            self._api.create_repo(repo_id=REPO_NAME, token="api_org_dummy_token")
 
     @retry_endpoint
     def test_upload_file_conflict(self):

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -561,6 +561,15 @@ class HfApiUploadFileTest(HfApiCommonTestWithLogin):
             self._api.create_repo(repo_id=REPO_NAME, token="api_org_dummy_token")
 
     @retry_endpoint
+    def test_create_repo_org_token_none_fail(self):
+        REPO_NAME = repo_name("org")
+        HfFolder.save_token("api_org_dummy_token")
+        with pytest.raises(
+            ValueError, match="You must use your personal account token for login."
+        ):
+            self._api.create_repo(repo_id=REPO_NAME)
+
+    @retry_endpoint
     def test_upload_file_conflict(self):
         REPO_NAME = repo_name("conflict")
         self._api.create_repo(repo_id=REPO_NAME, token=self._token)


### PR DESCRIPTION
Hello 👋  I dived into code to see where the user might login and where tokens are checked. I've seen three cases:
- When the token in the folder is retrieved (when user doesn't give it)
- When user logs in through CLI or notebook (_login)
- When user passes the token directly (which are checked inside repository related functions that are used in places like mixins) like so: 
`if token is None:
            token = self._validate_or_retrieve_token()
        elif isinstance(token, str):
            if token.startswith("api_org"):
                raise ValueError("You must use your personal account token for login.")
            elif not self._is_valid_token(token):
                if self._is_valid_token(name):
                    warnings.warn(
                        "`create_repo` now takes `token` as an optional positional argument. "
                        "Be sure to adapt your code!",
                        FutureWarning,
                    )
                    token, name = name, token
                else:
                    raise ValueError("Invalid token passed!")`

So I added checks there and wrote tests for those three cases too.
cc: @osanseviero 