### PR TITLE
CI Error on FutureWarning

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -42,10 +42,10 @@ jobs:
       - run: |
           if [[ "${{ matrix.test_repository }}" == "Repository only" ]]
           then
-            pytest --log-cli-level=INFO -sv ./tests/test_repository.py -k RepositoryTest
+            pytest -Werror::FutureWarning --log-cli-level=INFO -sv ./tests/test_repository.py -k RepositoryTest
           
           else
-            pytest --log-cli-level=INFO -sv ./tests/ -k 'not RepositoryTest'
+            pytest -Werror::FutureWarning --log-cli-level=INFO -sv ./tests/ -k 'not RepositoryTest'
           fi
 
   build_pytorch:
@@ -67,7 +67,7 @@ jobs:
         pip install --upgrade pip
         pip install .[testing,torch]
 
-    - run: pytest -sv ./tests/test_hubmixin*
+    - run: pytest -Werror::FutureWarning -sv ./tests/test_hubmixin*
 
   build_tensorflow:
     runs-on: ubuntu-latest
@@ -89,7 +89,7 @@ jobs:
         pip install --upgrade pip
         pip install .[testing,tensorflow]
 
-    - run: pytest -sv ./tests/test_keras*
+    - run: pytest -Werror::FutureWarning -sv ./tests/test_keras*
 
   tests_lfs:
     runs-on: ubuntu-latest
@@ -111,4 +111,4 @@ jobs:
         pip install --upgrade pip
         pip install .[testing]
 
-    - run: RUN_GIT_LFS_TESTS=1 pytest -sv ./tests/ -k "HfLargefilesTest"
+    - run: RUN_GIT_LFS_TESTS=1 pytest -Werror::FutureWarning -sv ./tests/ -k "HfLargefilesTest"

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -1378,7 +1378,8 @@ class HfApi:
                         The repository to which the file will be uploaded, for example: :obj:`"username/custom_transformers"`
 
                     token (``str``):
-                        Authentication token, obtained with :function:`HfApi.login` method. Will default to the stored token.
+                        Authentication token which can be obtained from
+                        https://huggingface.co/settings/tokens.
 
                     repo_type (``str``, Optional):
                         Set to :obj:`"dataset"` or :obj:`"space"` if uploading to a dataset or space, :obj:`None` or :obj:`"model"` if uploading to a model. Default is :obj:`None`.
@@ -1501,7 +1502,8 @@ class HfApi:
                 The repository from which the file will be deleted, for example: :obj:`"username/custom_transformers"`
 
             token (``str``):
-                Authentication token, obtained with :function:`HfApi.login` method. Will default to the stored token.
+                Authentication token which can be obtained from
+                https://huggingface.co/settings/tokens.
 
             repo_type (``str``, Optional):
                 Set to :obj:`"dataset"` or :obj:`"space"` if the file is in a dataset or space, :obj:`None` or :obj:`"model"` if in a model. Default is :obj:`None`.

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -116,12 +116,14 @@ class HfApiLoginTest(HfApiCommonTest):
         cls._api.set_access_token(TOKEN)
 
     def test_login_invalid(self):
-        with self.assertRaises(HTTPError):
-            self._api.set_access_token(TOKEN)
+        with pytest.raises(HTTPError):
+            with pytest.warns(FutureWarning, "This method is deprecated"):
+                self._api.login(username=USER, password="fake")
 
     def test_login_valid(self):
-        token = self._api.set_access_token(TOKEN)
-        self.assertIsInstance(token, str)
+        with pytest.warns(FutureWarning, "This method is deprecated"):
+            token = self._api.login(username=USER, password=PASS)
+        assert isinstance(TOKEN, str)
 
     def test_login_git_credentials(self):
         self.assertTupleEqual(read_from_credential_store(USER), (None, None))
@@ -173,7 +175,8 @@ class HfApiCommonTestWithLogin(HfApiCommonTest):
         """
         Share this valid token in all tests below.
         """
-        cls._token = cls._api.set_access_token(TOKEN)
+        cls._token = TOKEN
+        cls._api.set_access_token(TOKEN)
 
 
 @retry_endpoint
@@ -181,7 +184,6 @@ def test_repo_id_no_warning():
     # tests that passing repo_id as positional arg doesn't raise any warnings
     # for {create, delete}_repo and update_repo_visibility
     api = HfApi(endpoint=ENDPOINT_STAGING)
-    token = api.set_access_token(TOKEN)
     REPO_NAME = repo_name("crud")
 
     args = [
@@ -193,7 +195,7 @@ def test_repo_id_no_warning():
     for method, kwargs in args:
         with warnings.catch_warnings(record=True) as record:
             getattr(api, method)(
-                REPO_NAME, token=token, repo_type=REPO_TYPE_MODEL, **kwargs
+                REPO_NAME, token=TOKEN, repo_type=REPO_TYPE_MODEL, **kwargs
             )
         assert not len(record)
 
@@ -223,7 +225,6 @@ def test_name_org_deprecation_warning():
     # test that the right warning is raised when passing name to
     # {create, delete}_repo and update_repo_visibility
     api = HfApi(endpoint=ENDPOINT_STAGING)
-    token = api.set_access_token(TOKEN)
     REPO_NAME = repo_name("crud")
 
     args = [
@@ -238,7 +239,7 @@ def test_name_org_deprecation_warning():
             match=re.escape("`name` and `organization` input arguments are deprecated"),
         ):
             getattr(api, method)(
-                name=REPO_NAME, token=token, repo_type=REPO_TYPE_MODEL, **kwargs
+                name=REPO_NAME, token=TOKEN, repo_type=REPO_TYPE_MODEL, **kwargs
             )
 
 
@@ -247,7 +248,6 @@ def test_name_org_deprecation_error():
     # tests that the right error is raised when passing both name and repo_id
     # to {create, delete}_repo and update_repo_visibility
     api = HfApi(endpoint=ENDPOINT_STAGING)
-    token = api.set_access_token(TOKEN)
     REPO_NAME = repo_name("crud")
 
     args = [
@@ -264,7 +264,7 @@ def test_name_org_deprecation_error():
             getattr(api, method)(
                 repo_id="test",
                 name=REPO_NAME,
-                token=token,
+                token=TOKEN,
                 repo_type=REPO_TYPE_MODEL,
                 **kwargs,
             )
@@ -1109,7 +1109,8 @@ class HfLargefilesTest(HfApiCommonTest):
         """
         Share this valid token in all tests below.
         """
-        cls._token = cls._api.set_access_token(TOKEN)
+        cls._token = TOKEN
+        cls._api.set_access_token(TOKEN)
 
     def setUp(self):
         self.REPO_NAME_LARGE_FILE = repo_name_large_file()

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -113,19 +113,20 @@ class HfApiLoginTest(HfApiCommonTest):
 
     @classmethod
     def tearDownClass(cls) -> None:
-        cls._api.login(username=USER, password=PASS)
+        cls._api.set_access_token(TOKEN)
 
     def test_login_invalid(self):
         with self.assertRaises(HTTPError):
-            self._api.login(username=USER, password="fake")
+            self._api.set_access_token(TOKEN)
 
     def test_login_valid(self):
-        token = self._api.login(username=USER, password=PASS)
+        token = self._api.set_access_token(TOKEN)
         self.assertIsInstance(token, str)
 
     def test_login_git_credentials(self):
         self.assertTupleEqual(read_from_credential_store(USER), (None, None))
-        self._api.login(username=USER, password=PASS)
+        with pytest.warns(FutureWarning, match="This method is deprecated"):
+            self._api.login(username=USER, password=PASS)
         self.assertTupleEqual(read_from_credential_store(USER), (USER.lower(), PASS))
         erase_from_credential_store(username=USER)
         self.assertTupleEqual(read_from_credential_store(USER), (None, None))
@@ -172,7 +173,7 @@ class HfApiCommonTestWithLogin(HfApiCommonTest):
         """
         Share this valid token in all tests below.
         """
-        cls._token = cls._api.login(username=USER, password=PASS)
+        cls._token = cls._api.set_access_token(TOKEN)
 
 
 @retry_endpoint
@@ -180,7 +181,7 @@ def test_repo_id_no_warning():
     # tests that passing repo_id as positional arg doesn't raise any warnings
     # for {create, delete}_repo and update_repo_visibility
     api = HfApi(endpoint=ENDPOINT_STAGING)
-    token = api.login(username=USER, password=PASS)
+    token = api.set_access_token(TOKEN)
     REPO_NAME = repo_name("crud")
 
     args = [
@@ -222,7 +223,7 @@ def test_name_org_deprecation_warning():
     # test that the right warning is raised when passing name to
     # {create, delete}_repo and update_repo_visibility
     api = HfApi(endpoint=ENDPOINT_STAGING)
-    token = api.login(username=USER, password=PASS)
+    token = api.set_access_token(TOKEN)
     REPO_NAME = repo_name("crud")
 
     args = [
@@ -246,7 +247,7 @@ def test_name_org_deprecation_error():
     # tests that the right error is raised when passing both name and repo_id
     # to {create, delete}_repo and update_repo_visibility
     api = HfApi(endpoint=ENDPOINT_STAGING)
-    token = api.login(username=USER, password=PASS)
+    token = api.set_access_token(TOKEN)
     REPO_NAME = repo_name("crud")
 
     args = [
@@ -1108,7 +1109,7 @@ class HfLargefilesTest(HfApiCommonTest):
         """
         Share this valid token in all tests below.
         """
-        cls._token = cls._api.login(username=USER, password=PASS)
+        cls._token = cls._api.set_access_token(TOKEN)
 
     def setUp(self):
         self.REPO_NAME_LARGE_FILE = repo_name_large_file()

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -113,15 +113,16 @@ class HfApiLoginTest(HfApiCommonTest):
 
     @classmethod
     def tearDownClass(cls) -> None:
-        cls._api.set_access_token(TOKEN)
+        with pytest.warns(FutureWarning, match="This method is deprecated"):
+            cls._api.login(username=USER, password=PASS)
 
     def test_login_invalid(self):
-        with pytest.raises(HTTPError):
-            with pytest.warns(FutureWarning, "This method is deprecated"):
+        with pytest.warns(FutureWarning, match="This method is deprecated"):
+            with pytest.raises(HTTPError):
                 self._api.login(username=USER, password="fake")
 
     def test_login_valid(self):
-        with pytest.warns(FutureWarning, "This method is deprecated"):
+        with pytest.warns(FutureWarning, match="This method is deprecated"):
             token = self._api.login(username=USER, password=PASS)
         assert isinstance(token, str)
 
@@ -134,7 +135,8 @@ class HfApiLoginTest(HfApiCommonTest):
         self.assertTupleEqual(read_from_credential_store(USER), (None, None))
 
     def test_login_cli(self):
-        _login(self._api, username=USER, password=PASS)
+        with pytest.warns(FutureWarning, match="This method is deprecated"):
+            _login(self._api, username=USER, password=PASS)
         self.assertTupleEqual(read_from_credential_store(USER), (USER.lower(), PASS))
         erase_from_credential_store(username=USER)
         self.assertTupleEqual(read_from_credential_store(USER), (None, None))

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -123,7 +123,7 @@ class HfApiLoginTest(HfApiCommonTest):
     def test_login_valid(self):
         with pytest.warns(FutureWarning, "This method is deprecated"):
             token = self._api.login(username=USER, password=PASS)
-        assert isinstance(TOKEN, str)
+        assert isinstance(token, str)
 
     def test_login_git_credentials(self):
         self.assertTupleEqual(read_from_credential_store(USER), (None, None))
@@ -271,7 +271,7 @@ def test_name_org_deprecation_error():
 
     for method, kwargs in args:
         with pytest.raises(ValueError, match="No name provided"):
-            getattr(api, method)(token=token, repo_type=REPO_TYPE_MODEL, **kwargs)
+            getattr(api, method)(token=TOKEN, repo_type=REPO_TYPE_MODEL, **kwargs)
 
 
 class HfApiEndpointsTest(HfApiCommonTestWithLogin):

--- a/tests/test_hubmixin.py
+++ b/tests/test_hubmixin.py
@@ -74,7 +74,8 @@ class HubMixingTest(HubMixingCommonTest):
         """
         Share this valid token in all tests below.
         """
-        cls._token = cls._api.set_access_token(TOKEN)
+        cls._token = TOKEN
+        cls._api.set_access_token(TOKEN)
 
     def test_save_pretrained(self):
         REPO_NAME = repo_name("save")

--- a/tests/test_hubmixin.py
+++ b/tests/test_hubmixin.py
@@ -9,7 +9,7 @@ from huggingface_hub.file_download import is_torch_available
 from huggingface_hub.hub_mixin import PyTorchModelHubMixin
 from huggingface_hub.utils import logging
 
-from .testing_constants import ENDPOINT_STAGING, PASS, USER
+from .testing_constants import ENDPOINT_STAGING, TOKEN, USER
 from .testing_utils import set_write_permission_and_retry
 
 
@@ -74,7 +74,7 @@ class HubMixingTest(HubMixingCommonTest):
         """
         Share this valid token in all tests below.
         """
-        cls._token = cls._api.login(username=USER, password=PASS)
+        cls._token = cls._api.set_access_token(TOKEN)
 
     def test_save_pretrained(self):
         REPO_NAME = repo_name("save")

--- a/tests/test_keras_integration.py
+++ b/tests/test_keras_integration.py
@@ -85,7 +85,8 @@ class HubMixingTestKeras(unittest.TestCase):
         Share this valid token in all tests below.
         """
         cls._api = HfApi(endpoint=ENDPOINT_STAGING)
-        cls._token = cls._api.set_access_token(TOKEN)
+        cls._token = TOKEN
+        cls._api.set_access_token(TOKEN)
 
     def test_save_pretrained(self):
         REPO_NAME = repo_name("save")

--- a/tests/test_keras_integration.py
+++ b/tests/test_keras_integration.py
@@ -21,7 +21,7 @@ from huggingface_hub.keras_mixin import (
 )
 from huggingface_hub.utils import logging
 
-from .testing_constants import ENDPOINT_STAGING, PASS, USER
+from .testing_constants import ENDPOINT_STAGING, TOKEN, USER
 from .testing_utils import retry_endpoint, set_write_permission_and_retry
 
 
@@ -85,7 +85,7 @@ class HubMixingTestKeras(unittest.TestCase):
         Share this valid token in all tests below.
         """
         cls._api = HfApi(endpoint=ENDPOINT_STAGING)
-        cls._token = cls._api.login(username=USER, password=PASS)
+        cls._token = cls._api.set_access_token(TOKEN)
 
     def test_save_pretrained(self):
         REPO_NAME = repo_name("save")

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -70,7 +70,7 @@ class RepositoryTest(RepositoryCommonTest):
         Share this valid token in all tests below.
         """
         cls._api.set_access_token(TOKEN)
-        self._token = TOKEN
+        cls._token = TOKEN
 
     @retry_endpoint
     def setUp(self):

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -32,7 +32,7 @@ from huggingface_hub.repository import (
 )
 from huggingface_hub.utils import logging
 
-from .testing_constants import ENDPOINT_STAGING, PASS, USER
+from .testing_constants import ENDPOINT_STAGING, TOKEN
 from .testing_utils import (
     retry_endpoint,
     set_write_permission_and_retry,
@@ -69,7 +69,7 @@ class RepositoryTest(RepositoryCommonTest):
         """
         Share this valid token in all tests below.
         """
-        cls._token = cls._api.login(username=USER, password=PASS)
+        cls._token = cls._api.set_access_token(TOKEN)
 
     @retry_endpoint
     def setUp(self):
@@ -1328,7 +1328,7 @@ class RepositoryOfflineTest(RepositoryCommonTest):
 
     def test_repo_user(self):
         api = HfApi(endpoint=ENDPOINT_STAGING)
-        token = api.login(USER, PASS)
+        token = api.set_access_token(TOKEN)
 
         repo = Repository(WORKING_REPO_DIR, use_auth_token=token)
         user = api.whoami(token)
@@ -1355,7 +1355,7 @@ class RepositoryOfflineTest(RepositoryCommonTest):
 
     def test_repo_passed_user(self):
         api = HfApi(endpoint=ENDPOINT_STAGING)
-        token = api.login(USER, PASS)
+        token = api.set_access_token(TOKEN)
         repo = Repository(
             WORKING_REPO_DIR,
             git_user="RANDOM_USER",
@@ -1461,7 +1461,7 @@ class RepositoryDatasetTest(RepositoryCommonTest):
         """
         Share this valid token in all tests below.
         """
-        cls._token = cls._api.login(username=USER, password=PASS)
+        cls._token = cls._api.set_access_token(TOKEN)
 
     def setUp(self):
         self.REPO_NAME = repo_name()

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -69,7 +69,8 @@ class RepositoryTest(RepositoryCommonTest):
         """
         Share this valid token in all tests below.
         """
-        cls._token = cls._api.set_access_token(TOKEN)
+        cls._api.set_access_token(TOKEN)
+        self._token = TOKEN
 
     @retry_endpoint
     def setUp(self):
@@ -1328,7 +1329,8 @@ class RepositoryOfflineTest(RepositoryCommonTest):
 
     def test_repo_user(self):
         api = HfApi(endpoint=ENDPOINT_STAGING)
-        token = api.set_access_token(TOKEN)
+        token = TOKEN
+        api.set_access_token(TOKEN)
 
         repo = Repository(WORKING_REPO_DIR, use_auth_token=token)
         user = api.whoami(token)
@@ -1355,7 +1357,8 @@ class RepositoryOfflineTest(RepositoryCommonTest):
 
     def test_repo_passed_user(self):
         api = HfApi(endpoint=ENDPOINT_STAGING)
-        token = api.set_access_token(TOKEN)
+        token = TOKEN
+        api.set_access_token(TOKEN)
         repo = Repository(
             WORKING_REPO_DIR,
             git_user="RANDOM_USER",
@@ -1461,7 +1464,8 @@ class RepositoryDatasetTest(RepositoryCommonTest):
         """
         Share this valid token in all tests below.
         """
-        cls._token = cls._api.set_access_token(TOKEN)
+        cls._token = TOKEN
+        cls._api.set_access_token(TOKEN)
 
     def setUp(self):
         self.REPO_NAME = repo_name()

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -32,7 +32,7 @@ from huggingface_hub.repository import (
 )
 from huggingface_hub.utils import logging
 
-from .testing_constants import ENDPOINT_STAGING, TOKEN
+from .testing_constants import ENDPOINT_STAGING, TOKEN, USER
 from .testing_utils import (
     retry_endpoint,
     set_write_permission_and_retry,

--- a/tests/test_snapshot_download.py
+++ b/tests/test_snapshot_download.py
@@ -171,7 +171,7 @@ class SnapshotDownloadTests(unittest.TestCase):
             self.assertTrue(self.second_commit_hash in storage_folder)
 
         self._api.update_repo_visibility(
-            token=self._token, name=REPO_NAME, private=False
+            token=self._token, repo_id=REPO_NAME, private=False
         )
 
     def test_download_model_local_only(self):

--- a/tests/test_snapshot_download.py
+++ b/tests/test_snapshot_download.py
@@ -111,7 +111,7 @@ class SnapshotDownloadTests(unittest.TestCase):
 
     def test_download_private_model(self):
         self._api.update_repo_visibility(
-            token=self._token, name=REPO_NAME, private=True
+            token=self._token, repo_id=REPO_NAME, private=True
         )
 
         # Test download fails without token

--- a/tests/test_snapshot_download.py
+++ b/tests/test_snapshot_download.py
@@ -10,7 +10,7 @@ from huggingface_hub.hf_api import HfFolder
 from huggingface_hub.snapshot_download import snapshot_download
 from huggingface_hub.utils import logging
 
-from .testing_constants import ENDPOINT_STAGING, PASS, USER
+from .testing_constants import ENDPOINT_STAGING, TOKEN, USER
 from .testing_utils import retry_endpoint, set_write_permission_and_retry
 
 
@@ -27,7 +27,7 @@ class SnapshotDownloadTests(unittest.TestCase):
         """
         Share this valid token in all tests below.
         """
-        cls._token = cls._api.login(username=USER, password=PASS)
+        cls._token = cls._api.set_access_token(TOKEN)
 
     @retry_endpoint
     def setUp(self) -> None:

--- a/tests/test_snapshot_download.py
+++ b/tests/test_snapshot_download.py
@@ -27,7 +27,8 @@ class SnapshotDownloadTests(unittest.TestCase):
         """
         Share this valid token in all tests below.
         """
-        cls._token = cls._api.set_access_token(TOKEN)
+        cls._token = TOKEN
+        cls._api.set_access_token(TOKEN)
 
     @retry_endpoint
     def setUp(self) -> None:


### PR DESCRIPTION
This PR makes the CI to fail on `FutureWarning` so that our test suite won't use our own deprecated API and our codebase use new API from our dependencies.