### PR TITLE
Test fixes for audio inference API call

### DIFF
--- a/tests/test_inference_api.py
+++ b/tests/test_inference_api.py
@@ -63,14 +63,14 @@ class InferenceApiTest(unittest.TestCase):
 
     @with_production_testing
     def test_inference_with_audio(self):
-        api = InferenceApi("facebook/wav2vec2-large-960h-lv60-self")
+        api = InferenceApi("facebook/wav2vec2-base-960h")
         dataset = datasets.load_dataset(
             "patrickvonplaten/librispeech_asr_dummy", "clean", split="validation"
         )
         data = self.read(dataset["file"][0])
         result = api(data=data)
         self.assertIsInstance(result, dict)
-        self.assertTrue("text" in result)
+        self.assertTrue("text" in result, f"We received {result} instead")
 
     @with_production_testing
     def test_inference_with_image(self):


### PR DESCRIPTION
The test was failing as the model called through the inference API was not pinned, hence it was taking some time to load and returning the load message. This change uses a pinned test model.