### PR TITLE
CI support python 3.7-3.10 - remove 3.6 support

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -100,7 +100,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.10
+        python-version: "3.10"
 
     - run: |
         git config --global user.email "ci@dummy.com"

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.9"]
+        python-version: ["3.7", "3.10"]
         test_repository: ["Repository only", "Everything else"]
 
     steps:
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.9"]
+        python-version: ["3.7", "3.10"]
 
     steps:
     - uses: actions/checkout@v2
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.9"]
+        python-version: ["3.7", "3.10"]
 
     steps:
     - uses: actions/checkout@v2
@@ -100,7 +100,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: 3.10
 
     - run: |
         git config --global user.email "ci@dummy.com"

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
             "huggingface-cli=huggingface_hub.commands.huggingface_cli:main"
         ]
     },
-    python_requires=">=3.6.0",
+    python_requires=">=3.7.0",
     install_requires=install_requires,
     classifiers=[
         "Intended Audience :: Developers",


### PR DESCRIPTION
This PR removes tests on 3.6 and adds 3.10 support on the CI.

Fixes #786