### PR TITLE
Replace obsolete function argument name in docs for `api.create_repo`

### DIFF
--- a/docs/hub/adding-a-model.md
+++ b/docs/hub/adding-a-model.md
@@ -215,7 +215,7 @@ First we need to instantiate the `HfApi` class, which holds all of the magic:
 Afterwards we can run the `create_repo` function, specifying a number of settings and options for our new repository:
 ```python
 >>> api.create_repo(
->>>   repo_id = "dummy", # The name of our repository, by default under your user
+>>>   name = "dummy", # The name of our repository, by default under your user
 >>>   private = False, # Whether the repo should be public or private
 >>>   repo_type = "model" # The type of repository, such as "model", "space", "dataset"
 >>> )


### PR DESCRIPTION
`repo_id` does not appear to work. Is `name` the newer version?