### PR TITLE
Remove redundant part of security test

### DIFF
--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -731,15 +731,6 @@ class HfApiPublicTest(unittest.TestCase):
         )
         self.assertIsInstance(model, ModelInfo)
         self.assertEqual(model.sha, DUMMY_MODEL_ID_REVISION_ONE_SPECIFIC_COMMIT)
-        model = _api.model_info(
-            repo_id=DUMMY_MODEL_ID,
-            revision=DUMMY_MODEL_ID_REVISION_ONE_SPECIFIC_COMMIT,
-            securityStatus=True,
-        )
-        self.assertEqual(
-            getattr(model, "securityStatus"),
-            {"containsInfected": False, "infectionTypes": []},
-        )
 
     @with_production_testing
     def test_model_info_with_security(self):


### PR DESCRIPTION
There is a test few lines below that does exactly the same (test_model_info_with_security).

This partially fixes #785. There is an unrelated TF test failing (cc @merveenoyan)