### PR TITLE
TST calling delete_repo under tempfile for fixing the test

### DIFF
--- a/tests/test_keras_integration.py
+++ b/tests/test_keras_integration.py
@@ -371,33 +371,6 @@ class HubKerasSequentialTest(HubMixingTestKeras):
         self._api.delete_repo(repo_id=f"{REPO_NAME}", token=self._token)
 
     @retry_endpoint
-    def test_push_to_hub_tensorboard(self):
-        REPO_NAME = "PUSH_TO_HUB_TB"
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            os.makedirs(f"{tmpdirname}/log_dir")
-            with open(f"{tmpdirname}/log_dir/tensorboard.txt", "w") as fp:
-                fp.write("Keras FTW")
-            model = self.model_init()
-            model = self.model_fit(model)
-            push_to_hub_keras(
-                model,
-                repo_path_or_name=f"{WORKING_REPO_DIR}/{REPO_NAME}",
-                log_dir=f"{tmpdirname}/log_dir",
-                api_endpoint=ENDPOINT_STAGING,
-                use_auth_token=self._token,
-                git_user="ci",
-                git_email="ci@dummy.com",
-            )
-            model_info = HfApi(endpoint=ENDPOINT_STAGING).model_info(
-                f"{USER}/{REPO_NAME}",
-            )
-
-            self.assertTrue(
-                "logs/tensorboard.txt" in [f.rfilename for f in model_info.siblings]
-            )
-            self._api.delete_repo(repo_id=f"{REPO_NAME}", token=self._token)
-
-    @retry_endpoint
     def test_override_tensorboard(self):
         REPO_NAME = repo_name("TB_OVERRIDE")
         with tempfile.TemporaryDirectory() as tmpdirname:

--- a/tests/test_keras_integration.py
+++ b/tests/test_keras_integration.py
@@ -388,14 +388,14 @@ class HubKerasSequentialTest(HubMixingTestKeras):
                 git_user="ci",
                 git_email="ci@dummy.com",
             )
-        model_info = HfApi(endpoint=ENDPOINT_STAGING).model_info(
-            f"{USER}/{REPO_NAME}",
-        )
+            model_info = HfApi(endpoint=ENDPOINT_STAGING).model_info(
+                f"{USER}/{REPO_NAME}",
+            )
 
-        self.assertTrue(
-            "logs/tensorboard.txt" in [f.rfilename for f in model_info.siblings]
-        )
-        self._api.delete_repo(repo_id=f"{REPO_NAME}", token=self._token)
+            self.assertTrue(
+                "logs/tensorboard.txt" in [f.rfilename for f in model_info.siblings]
+            )
+            self._api.delete_repo(repo_id=f"{REPO_NAME}", token=self._token)
 
     @retry_endpoint
     def test_override_tensorboard(self):
@@ -428,17 +428,17 @@ class HubKerasSequentialTest(HubMixingTestKeras):
                 git_email="ci@dummy.com",
             )
 
-        model_info = HfApi(endpoint=ENDPOINT_STAGING).model_info(
-            f"{USER}/{REPO_NAME}",
-        )
-        self.assertTrue(
-            "logs/override.txt" in [f.rfilename for f in model_info.siblings]
-        )
-        self.assertFalse(
-            "logs/tensorboard.txt" in [f.rfilename for f in model_info.siblings]
-        )
+            model_info = HfApi(endpoint=ENDPOINT_STAGING).model_info(
+                f"{USER}/{REPO_NAME}",
+            )
+            self.assertTrue(
+                "logs/override.txt" in [f.rfilename for f in model_info.siblings]
+            )
+            self.assertFalse(
+                "logs/tensorboard.txt" in [f.rfilename for f in model_info.siblings]
+            )
 
-        self._api.delete_repo(repo_id=f"{REPO_NAME}", token=self._token)
+            self._api.delete_repo(repo_id=f"{REPO_NAME}", token=self._token)
 
     @retry_endpoint
     def test_push_to_hub_model_kwargs(self):


### PR DESCRIPTION
I thought I pushed this change but it wasn't pushed and then I saw the other branch was removed because it was merged.

I couldn't reproduce the error on my local, my guess is that I was calling `delete_repo` out of `tempfile` which caused the repository not found error. Hopefully this fix will work. 