### PR TITLE
[API Reference docs] Fix `build_documentation` Action

### DIFF
--- a/.github/workflows/build_documentation.yaml
+++ b/.github/workflows/build_documentation.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
    build:
-    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@workflow_templates
+    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml
     with:
       commit_sha: ${{ github.sha }}
       package: huggingface_hub


### PR DESCRIPTION
This PR fixes the `build_documentation` action by removing the git reference used previously. This was a reference to a branch that has since been merged in the default branch.

Closes https://github.com/huggingface/huggingface_hub/issues/811