### PR TITLE
MNT support oder requests versions

### DIFF
--- a/.github/conda/meta.yaml
+++ b/.github/conda/meta.yaml
@@ -1,4 +1,4 @@
-{% set name = "huggingface_hub" %}  # noqa
+{% set name = "huggingface_hub" %}
 
 package:
   name: "{{ name|lower }}"

--- a/.github/conda/meta.yaml
+++ b/.github/conda/meta.yaml
@@ -1,4 +1,4 @@
-{% set name = "huggingface_hub" %}
+{% set name = "huggingface_hub" %}  # noqa
 
 package:
   name: "{{ name|lower }}"
@@ -15,7 +15,7 @@ requirements:
     - python
     - pip
     - filelock
-    - requests <=2.23
+    - requests
     - tqdm
     - typing-extensions
     - packaging
@@ -24,7 +24,7 @@ requirements:
     - python
     - pip
     - filelock
-    - requests <=2.23
+    - requests
     - tqdm
     - typing-extensions
     - packaging

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,7 @@ repos:
     rev: v4.1.0
     hooks:
     -   id: check-yaml
+        exclude: .github/conda/meta.yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
     -   id: check-case-conflict

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def get_version() -> str:
 
 install_requires = [
     "filelock",
-    "requests>=2.27",
+    "requests",
     "tqdm",
     "pyyaml",
     "typing-extensions>=3.7.4.3",  # to be able to import TypeAlias

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -22,7 +22,7 @@ from os.path import expanduser
 from typing import IO, Dict, Iterable, List, Optional, Tuple, Union
 
 import requests
-from requests.exceptions import HTTPError, JSONDecodeError
+from requests.exceptions import HTTPError
 
 from .constants import (
     ENDPOINT,
@@ -33,6 +33,7 @@ from .constants import (
 )
 from .utils import logging
 from .utils._deprecation import _deprecate_positional_args
+from .utils._fixes import JSONDecodeError
 from .utils.endpoint_helpers import (
     AttributeDictionary,
     DatasetFilter,

--- a/src/huggingface_hub/utils/_fixes.py
+++ b/src/huggingface_hub/utils/_fixes.py
@@ -1,0 +1,10 @@
+# JSONDecodeError was introduced in requests=2.27 released in 2022.
+# This allows us to support older requests for users
+# More information: https://github.com/psf/requests/pull/5856
+try:
+    from requests import JSONDecodeError  # noqa
+except ImportError:
+    try:
+        from simplejson import JSONDecodeError  # noqa
+    except ImportError:
+        from json import JSONDecodeError  # noqa


### PR DESCRIPTION
I've tested locally for all possibilities of installed packages (simplejson, json, old and new requests).

I don't think we need to add CI to test for old requests though.

Fixes #816 