### PR TITLE
FIX don't raise if name/organizaiton are passed postionally

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -59,7 +59,7 @@ logger = logging.get_logger(__name__)
 def _validate_repo_id_deprecation(repo_id, name, organization):
     """Returns (name, organization) from the input."""
     if repo_id and not name and organization:
-        # this means the user pad passed name as positional, now mapped to
+        # this means the user had passed name as positional, now mapped to
         # repo_id and is passing organization as well. This wouldn't be an
         # issue if they pass everything as kwarg. So we switch the parameters
         # here:

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -58,6 +58,13 @@ logger = logging.get_logger(__name__)
 # TODO: remove after deprecation period is over (v0.7)
 def _validate_repo_id_deprecation(repo_id, name, organization):
     """Returns (name, organization) from the input."""
+    if repo_id and not name and organization:
+        # this means the user pad passed name as positional, now mapped to
+        # repo_id and is passing organization as well. This wouldn't be an
+        # issue if they pass everything as kwarg. So we switch the parameters
+        # here:
+        repo_id, name = name, repo_id
+
     if not (repo_id or name):
         raise ValueError(
             "No name provided. Please pass `repo_id` with a valid repository name."

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -227,6 +227,14 @@ def test_validate_repo_id_deprecation():
             repo_id="repo_id", name="name", organization="organization"
         )
 
+    # regression test for
+    # https://github.com/huggingface/huggingface_hub/issues/821
+    with pytest.warns(FutureWarning, match="input arguments are deprecated"):
+        name, org = _validate_repo_id_deprecation(
+            repo_id="repo", name=None, organization="org"
+        )
+        assert name == "repo" and org == "org"
+
 
 @retry_endpoint
 def test_name_org_deprecation_warning():


### PR DESCRIPTION
Fixes https://github.com/huggingface/huggingface_hub/issues/821

If user passes `name` as a positional argument and pass `organization` as well, we fail, whereas we should raise a `FutureWarning`.

cc @LysandreJik @osanseviero 

This needs to be backported to 0.5.1 for a patch release.