### PR TITLE
Allow installation on Python 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
             "huggingface-cli=huggingface_hub.commands.huggingface_cli:main"
         ]
     },
-    python_requires=">=3.7.0",
+    python_requires=">=3.6.0",
     install_requires=install_requires,
     classifiers=[
         "Intended Audience :: Developers",


### PR DESCRIPTION
This PR unrolls a change introduced by:
- #790

That change prevents the installation of `huggingface_hub` on Python 3.6 (used by `datasets` CI).