### PR TITLE
Auto track binary files

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -569,23 +569,19 @@ class HfApi:
         function_name: Optional[str] = None,
     ):
         """
-        Args:
         Retrieves and validates stored token or validates passed token.
+        Args:
             token (``str``, `optional`):
-                Hugging Face token. Will default to the locally saved token if
-                not provided.
+                Hugging Face token. Will default to the locally saved token if not provided.
             name (``str``, `optional`):
-                Name of the repository. This is deprecated in favor of repo_id
-                and will be removed in v0.7.
+                Name of the repository. This is deprecated in favor of repo_id and will be removed in v0.7.
             function_name (``str``, `optional`):
-                If _validate_or_retrieve_token is called from a function, name
-                of that function to be passed inside deprecation warning.
+                If _validate_or_retrieve_token is called from a function, name of that function to be passed inside deprecation warning.
         Returns:
             Validated token and the name of the repository.
         Raises:
-            :class:`EnvironmentError`: If the token is not passed and there's no
-            token saved locally. :class:`ValueError`: If organization token or
-            invalid token is passed.
+            :class:`EnvironmentError`: If the token is not passed and there's no token saved locally.
+            :class:`ValueError`: If organization token or invalid token is passed.
         """
         if token is None or token is True:
             token = HfFolder.get_token()
@@ -1851,8 +1847,8 @@ class HfFolder:
         """
         Get token or None if not existent.
 
-        Note that a token can be also provided using the
-        `HUGGING_FACE_HUB_TOKEN` environment variable.
+        Note that a token can be also provided using the `HUGGING_FACE_HUB_TOKEN`
+        environment variable.
 
         Returns:
             `str` or `None`: The token, `None` if it doesn't exist.

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -569,19 +569,23 @@ class HfApi:
         function_name: Optional[str] = None,
     ):
         """
-        Retrieves and validates stored token or validates passed token.
         Args:
+        Retrieves and validates stored token or validates passed token.
             token (``str``, `optional`):
-                Hugging Face token. Will default to the locally saved token if not provided.
+                Hugging Face token. Will default to the locally saved token if
+                not provided.
             name (``str``, `optional`):
-                Name of the repository. This is deprecated in favor of repo_id and will be removed in v0.7.
+                Name of the repository. This is deprecated in favor of repo_id
+                and will be removed in v0.7.
             function_name (``str``, `optional`):
-                If _validate_or_retrieve_token is called from a function, name of that function to be passed inside deprecation warning.
+                If _validate_or_retrieve_token is called from a function, name
+                of that function to be passed inside deprecation warning.
         Returns:
             Validated token and the name of the repository.
         Raises:
-            :class:`EnvironmentError`: If the token is not passed and there's no token saved locally.
-            :class:`ValueError`: If organization token or invalid token is passed.
+            :class:`EnvironmentError`: If the token is not passed and there's no
+            token saved locally. :class:`ValueError`: If organization token or
+            invalid token is passed.
         """
         if token is None or token is True:
             token = HfFolder.get_token()
@@ -1847,8 +1851,8 @@ class HfFolder:
         """
         Get token or None if not existent.
 
-        Note that a token can be also provided using the `HUGGING_FACE_HUB_TOKEN`
-        environment variable.
+        Note that a token can be also provided using the
+        `HUGGING_FACE_HUB_TOKEN` environment variable.
 
         Returns:
             `str` or `None`: The token, `None` if it doesn't exist.

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -239,7 +239,7 @@ def is_binary_file(filename: Union[str, Path]) -> bool:
     """
     try:
         with open(filename) as f:
-            content = f.read()
+            content = f.read(512)
 
         # Check for the presence of the null character in the string
         return "\x00" in content

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -238,11 +238,15 @@ def is_binary_file(filename: Union[str, Path]) -> bool:
         `bool`: `True` if the file passed is a binary file, `False` otherwise.
     """
     try:
-        with open(filename) as f:
+        with open(filename, "rb") as f:
             content = f.read()
 
-        # Check for the presence of the null character in the string
-        return "\x00" in content
+        # Code sample taken from the following stack overflow thread
+        # https://stackoverflow.com/questions/898669/how-can-i-detect-if-a-file-is-binary-non-text-in-python/7392391#7392391
+        text_chars = bytearray(
+            {7, 8, 9, 10, 12, 13, 27} | set(range(0x20, 0x100)) - {0x7F}
+        )
+        return bool(content.translate(None, text_chars))
     except UnicodeDecodeError:
         return True
 

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -235,15 +235,14 @@ def is_binary_file(filename: Union[str, Path]) -> bool:
             The filename to check.
 
     Returns:
-        `bool`: `True` if the file passed is a binary file, `False`
-        otherwise.
+        `bool`: `True` if the file passed is a binary file, `False` otherwise.
     """
     try:
         with open(filename) as f:
             content = f.read()
 
         # Check for the presence of the null character in the string
-        return '\x00' in content
+        return "\x00" in content
     except UnicodeDecodeError:
         return True
 
@@ -507,8 +506,8 @@ class Repository:
             skip_lfs_files (`bool`, *optional*, defaults to `False`):
                 whether to skip git-LFS files or not.
             client (`HfApi`, *optional*):
-                Instance of HfApi to use when calling the HF Hub API.
-                A new instance will be created if this is left to `None`.
+                Instance of HfApi to use when calling the HF Hub API. A new
+                instance will be created if this is left to `None`.
         """
 
         os.makedirs(local_dir, exist_ok=True)
@@ -1012,7 +1011,8 @@ class Repository:
                 The pattern with which to track files that are above 10MBs.
 
         Returns:
-            `List[str]`: List of filenames that are now tracked due to being binary files
+            `List[str]`: List of filenames that are now tracked due to being
+            binary files
         """
         files_to_be_tracked_with_lfs = []
 
@@ -1026,9 +1026,9 @@ class Repository:
             is_binary = is_binary_file(path_to_file)
 
             if (
-                    is_binary
-                    and not is_tracked_with_lfs(path_to_file)
-                    and not is_git_ignored(path_to_file)
+                is_binary
+                and not is_tracked_with_lfs(path_to_file)
+                and not is_git_ignored(path_to_file)
             ):
                 self.lfs_track(filename)
                 files_to_be_tracked_with_lfs.append(filename)
@@ -1147,13 +1147,14 @@ class Repository:
             pattern (`str`, *optional*, defaults to "."):
                 The pattern with which to add files to staging.
             auto_lfs_track (`bool`, *optional*, defaults to `False`):
-                Whether to automatically track large files with git-lfs. Any
-                file over 10MB in size will be automatically tracked.
+                Whether to automatically track large and binaryfiles with
+                git-lfs. Any file over 10MB in size, or in binary format, will
+                be automatically tracked.
         """
         if auto_lfs_track:
             tracked_files = [
                 *self.auto_track_large_files(pattern),
-                *self.auto_track_binary_files(pattern)
+                *self.auto_track_binary_files(pattern),
             ]
             if tracked_files:
                 logger.warning(

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -240,8 +240,10 @@ def is_binary_file(filename: Union[str, Path]) -> bool:
     """
     try:
         with open(filename) as f:
-            f.read()
-        return False
+            content = f.read()
+
+        # Check for the presence of the null character in the string
+        return '\x00' in content
     except UnicodeDecodeError:
         return True
 

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -239,7 +239,7 @@ def is_binary_file(filename: Union[str, Path]) -> bool:
     """
     try:
         with open(filename, "rb") as f:
-            content = f.read()
+            content = f.read(10 * (1024**2))  # Read a maximum of 10MB
 
         # Code sample taken from the following stack overflow thread
         # https://stackoverflow.com/questions/898669/how-can-i-detect-if-a-file-is-binary-non-text-in-python/7392391#7392391

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -1008,7 +1008,7 @@ class Repository:
 
         Args:
             pattern (`str`, *optional*, defaults to "."):
-                The pattern with which to track files that are above 10MBs.
+                The pattern with which to track files that are binary.
 
         Returns:
             `List[str]`: List of filenames that are now tracked due to being
@@ -1147,7 +1147,7 @@ class Repository:
             pattern (`str`, *optional*, defaults to "."):
                 The pattern with which to add files to staging.
             auto_lfs_track (`bool`, *optional*, defaults to `False`):
-                Whether to automatically track large and binaryfiles with
+                Whether to automatically track large and binary files with
                 git-lfs. Any file over 10MB in size, or in binary format, will
                 be automatically tracked.
         """

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1075,17 +1075,11 @@ class RepositoryOfflineTest(RepositoryCommonTest):
         # This content is 20MB (over 10MB)
         large_file = [100] * int(4e6)
 
-        # This content is binary (contains the null character)
-        binary_file = "\x00\x00\x00\x00"
-
         with open(f"{WORKING_REPO_DIR}/large_file.txt", "w+") as f:
             f.write(json.dumps(large_file))
 
         with open(f"{WORKING_REPO_DIR}/small_file.txt", "w+") as f:
             f.write(json.dumps(small_file))
-
-        with open(f"{WORKING_REPO_DIR}/binary_file.txt", "w+") as f:
-            f.write(binary_file)
 
         os.makedirs(f"{WORKING_REPO_DIR}/dir", exist_ok=True)
 
@@ -1095,11 +1089,7 @@ class RepositoryOfflineTest(RepositoryCommonTest):
         with open(f"{WORKING_REPO_DIR}/dir/small_file.txt", "w+") as f:
             f.write(json.dumps(small_file))
 
-        with open(f"{WORKING_REPO_DIR}/dir/binary_file.txt", "w+") as f:
-            f.write(binary_file)
-
         repo.auto_track_large_files("dir")
-        repo.auto_track_binary_files("dir")
 
         self.assertFalse(
             is_tracked_with_lfs(os.path.join(WORKING_REPO_DIR, "large_file.txt"))
@@ -1107,17 +1097,11 @@ class RepositoryOfflineTest(RepositoryCommonTest):
         self.assertFalse(
             is_tracked_with_lfs(os.path.join(WORKING_REPO_DIR, "small_file.txt"))
         )
-        self.assertFalse(
-            is_tracked_with_lfs(os.path.join(WORKING_REPO_DIR, "binary_file.txt"))
-        )
         self.assertTrue(
             is_tracked_with_lfs(os.path.join(WORKING_REPO_DIR, "dir/large_file.txt"))
         )
         self.assertFalse(
             is_tracked_with_lfs(os.path.join(WORKING_REPO_DIR, "dir/small_file.txt"))
-        )
-        self.assertTrue(
-            is_tracked_with_lfs(os.path.join(WORKING_REPO_DIR, "dir/binary_file.txt"))
         )
 
     def test_auto_track_large_files(self):
@@ -1129,26 +1113,40 @@ class RepositoryOfflineTest(RepositoryCommonTest):
         # This content is 20MB (over 10MB)
         large_file = [100] * int(4e6)
 
-        # This content is binary (contains the null character)
-        binary_file = "\x00\x00\x00\x00"
-
         with open(f"{WORKING_REPO_DIR}/large_file.txt", "w+") as f:
             f.write(json.dumps(large_file))
 
         with open(f"{WORKING_REPO_DIR}/small_file.txt", "w+") as f:
             f.write(json.dumps(small_file))
 
-        with open(f"{WORKING_REPO_DIR}/binary_file.txt", "w+") as f:
-            f.write(binary_file)
-
         repo.auto_track_large_files()
-        repo.auto_track_binary_files()
 
         self.assertTrue(
             is_tracked_with_lfs(os.path.join(WORKING_REPO_DIR, "large_file.txt"))
         )
         self.assertFalse(
             is_tracked_with_lfs(os.path.join(WORKING_REPO_DIR, "small_file.txt"))
+        )
+
+    def test_auto_track_binary_files(self):
+        repo = Repository(WORKING_REPO_DIR)
+
+        # This content is non-binary
+        non_binary_file = [100] * int(1e6)
+
+        # This content is binary (contains the null character)
+        binary_file = "\x00\x00\x00\x00"
+
+        with open(f"{WORKING_REPO_DIR}/non_binary_file.txt", "w+") as f:
+            f.write(json.dumps(non_binary_file))
+
+        with open(f"{WORKING_REPO_DIR}/binary_file.txt", "w+") as f:
+            f.write(binary_file)
+
+        repo.auto_track_binary_files()
+
+        self.assertFalse(
+            is_tracked_with_lfs(os.path.join(WORKING_REPO_DIR, "non_binary)file.txt"))
         )
         self.assertTrue(
             is_tracked_with_lfs(os.path.join(WORKING_REPO_DIR, "binary_file.txt"))
@@ -1160,17 +1158,14 @@ class RepositoryOfflineTest(RepositoryCommonTest):
         # This content is 20MB (over 10MB)
         large_file = [100] * int(4e6)
 
-        # This content is binary (contains the null character)
-        binary_file = "\x00\x00\x00\x00"
-
         # Test nested gitignores
         os.makedirs(f"{WORKING_REPO_DIR}/directory")
 
         with open(f"{WORKING_REPO_DIR}/.gitignore", "w+") as f:
-            f.write("large_file.txt\nbinary_file.txt")
+            f.write("large_file.txt")
 
         with open(f"{WORKING_REPO_DIR}/directory/.gitignore", "w+") as f:
-            f.write("large_file_3.txt\nbinary_file_3.txt")
+            f.write("large_file_3.txt")
 
         with open(f"{WORKING_REPO_DIR}/large_file.txt", "w+") as f:
             f.write(json.dumps(large_file))
@@ -1185,20 +1180,6 @@ class RepositoryOfflineTest(RepositoryCommonTest):
             f.write(json.dumps(large_file))
 
         repo.auto_track_large_files()
-
-        with open(f"{WORKING_REPO_DIR}/binary_file.txt", "w+") as f:
-            f.write(binary_file)
-
-        with open(f"{WORKING_REPO_DIR}/binary_file_2.txt", "w+") as f:
-            f.write(binary_file)
-
-        with open(f"{WORKING_REPO_DIR}/directory/binary_file_3.txt", "w+") as f:
-            f.write(binary_file)
-
-        with open(f"{WORKING_REPO_DIR}/directory/binary_file_4.txt", "w+") as f:
-            f.write(binary_file)
-
-        repo.auto_track_binary_files()
 
         # Large files
         self.assertFalse(
@@ -1219,6 +1200,35 @@ class RepositoryOfflineTest(RepositoryCommonTest):
             )
         )
 
+    def test_auto_track_binary_files_ignored_with_gitignore(self):
+        repo = Repository(WORKING_REPO_DIR)
+
+        # This content is binary (contains the null character)
+        binary_file = "\x00\x00\x00\x00"
+
+        # Test nested gitignores
+        os.makedirs(f"{WORKING_REPO_DIR}/directory")
+
+        with open(f"{WORKING_REPO_DIR}/.gitignore", "w+") as f:
+            f.write("binary_file.txt")
+
+        with open(f"{WORKING_REPO_DIR}/directory/.gitignore", "w+") as f:
+            f.write("binary_file_3.txt")
+
+        with open(f"{WORKING_REPO_DIR}/binary_file.txt", "w+") as f:
+            f.write(binary_file)
+
+        with open(f"{WORKING_REPO_DIR}/binary_file_2.txt", "w+") as f:
+            f.write(binary_file)
+
+        with open(f"{WORKING_REPO_DIR}/directory/binary_file_3.txt", "w+") as f:
+            f.write(binary_file)
+
+        with open(f"{WORKING_REPO_DIR}/directory/binary_file_4.txt", "w+") as f:
+            f.write(binary_file)
+
+        repo.auto_track_binary_files()
+
         # Binary files
         self.assertFalse(
             is_tracked_with_lfs(os.path.join(WORKING_REPO_DIR, "binary_file.txt"))
@@ -1238,7 +1248,7 @@ class RepositoryOfflineTest(RepositoryCommonTest):
             )
         )
 
-    def test_auto_track_files_through_git_add(self):
+    def test_auto_track_large_files_through_git_add(self):
         repo = Repository(WORKING_REPO_DIR)
 
         # This content is 5MB (under 10MB)
@@ -1247,17 +1257,11 @@ class RepositoryOfflineTest(RepositoryCommonTest):
         # This content is 20MB (over 10MB)
         large_file = [100] * int(4e6)
 
-        # This content is binary (contains the null character)
-        binary_file = "\x00\x00\x00\x00"
-
         with open(f"{WORKING_REPO_DIR}/large_file.txt", "w+") as f:
             f.write(json.dumps(large_file))
 
         with open(f"{WORKING_REPO_DIR}/small_file.txt", "w+") as f:
             f.write(json.dumps(small_file))
-
-        with open(f"{WORKING_REPO_DIR}/binary_file.txt", "w+") as f:
-            f.write(binary_file)
 
         repo.git_add(auto_lfs_track=True)
 
@@ -1267,11 +1271,32 @@ class RepositoryOfflineTest(RepositoryCommonTest):
         self.assertFalse(
             is_tracked_with_lfs(os.path.join(WORKING_REPO_DIR, "small_file.txt"))
         )
+
+    def test_auto_track_binary_files_through_git_add(self):
+        repo = Repository(WORKING_REPO_DIR)
+
+        # This content is non binary
+        non_binary_file = [100] * int(1e6)
+
+        # This content is binary (contains the null character)
+        binary_file = "\x00\x00\x00\x00"
+
+        with open(f"{WORKING_REPO_DIR}/small_file.txt", "w+") as f:
+            f.write(json.dumps(non_binary_file))
+
+        with open(f"{WORKING_REPO_DIR}/binary_file.txt", "w+") as f:
+            f.write(binary_file)
+
+        repo.git_add(auto_lfs_track=True)
+
+        self.assertFalse(
+            is_tracked_with_lfs(os.path.join(WORKING_REPO_DIR, "non_binary_file.txt"))
+        )
         self.assertTrue(
             is_tracked_with_lfs(os.path.join(WORKING_REPO_DIR, "binary_file.txt"))
         )
 
-    def test_auto_no_track_files_through_git_add(self):
+    def test_auto_no_track_large_files_through_git_add(self):
         repo = Repository(WORKING_REPO_DIR)
 
         # This content is 5MB (under 10MB)
@@ -1280,17 +1305,11 @@ class RepositoryOfflineTest(RepositoryCommonTest):
         # This content is 20MB (over 10MB)
         large_file = [100] * int(4e6)
 
-        # This content is binary (contains the null character)
-        binary_file = "\x00\x00\x00\x00"
-
         with open(f"{WORKING_REPO_DIR}/large_file.txt", "w+") as f:
             f.write(json.dumps(large_file))
 
         with open(f"{WORKING_REPO_DIR}/small_file.txt", "w+") as f:
             f.write(json.dumps(small_file))
-
-        with open(f"{WORKING_REPO_DIR}/binary_file.txt", "w+") as f:
-            f.write(binary_file)
 
         repo.git_add(auto_lfs_track=False)
 
@@ -1299,6 +1318,27 @@ class RepositoryOfflineTest(RepositoryCommonTest):
         )
         self.assertFalse(
             is_tracked_with_lfs(os.path.join(WORKING_REPO_DIR, "small_file.txt"))
+        )
+
+    def test_auto_no_track_binary_files_through_git_add(self):
+        repo = Repository(WORKING_REPO_DIR)
+
+        # This content is non-binary
+        non_binary_file = [100] * int(1e6)
+
+        # This content is binary (contains the null character)
+        binary_file = "\x00\x00\x00\x00"
+
+        with open(f"{WORKING_REPO_DIR}/small_file.txt", "w+") as f:
+            f.write(json.dumps(non_binary_file))
+
+        with open(f"{WORKING_REPO_DIR}/binary_file.txt", "w+") as f:
+            f.write(binary_file)
+
+        repo.git_add(auto_lfs_track=False)
+
+        self.assertFalse(
+            is_tracked_with_lfs(os.path.join(WORKING_REPO_DIR, "non_binary_file.txt"))
         )
         self.assertFalse(
             is_tracked_with_lfs(os.path.join(WORKING_REPO_DIR, "binary_file.txt"))


### PR DESCRIPTION
Closes https://github.com/huggingface/huggingface_hub/issues/825.
Closed https://github.com/huggingface/huggingface_hub/issues/687.

This adds the option to automatically track binary files. It follows the following two assumptions:
- Binary files usually cannot be read with the `open` file object reader, which raises a unicode error.
- The file can sometimes be read even with the `open` keyword; in that case, we search for the null character which should only be present in binary files, and which seems to be what `grep` uses in order to identify binary files (and we use `grep` in the backend to look for these binary files)

This PR adds a new method, `auto_track_binary_files`, which automatically tracks binary files. 

A change could be seen as a breaking change, which is the `auto_lfs_track` keyword of the `git_add` method. Previously, it only tracked large files, it now tracks both large files and binary files.
I left it as I believe it's more of a bugfix than a breaking change, as all binary files would have been previously rejected, resulting in errors. 

If this is not deemed acceptable, the deprecation cycle would be to:
- add the `auto_track_large_files` and `auto_track_binary_files` keyword arguments to `git_add`, to toggle manually, and deprecate `auto_lfs_track` to mention that it will soon handle both large and binary files.

The tests have been added directly to the others that test for large files, as this results in a significant speedup vs splitting these over two tests.