### PR TITLE
Tidy up docs

### DIFF
--- a/docs/source/how-to-downstream.mdx
+++ b/docs/source/how-to-downstream.mdx
@@ -12,7 +12,7 @@ Utilities that allow your library to download files from the Hub are referred to
 
 ## hf_hub_url
 
-Use `hf_hub_url` to retrieve the URL of a specific file to download by providing a `filename`.
+Use [`hf_hub_url`] to retrieve the URL of a specific file to download by providing a `filename`.
 
 ![/docs/assets/hub/repo.png](/docs/assets/hub/repo.png)
 
@@ -31,7 +31,7 @@ When using the commit hash, it must be the full-length hash instead of a 7-chara
 'https://huggingface.co/lysandre/arxiv-nlp/resolve/877b84a8f93f2d619faa2a6e514a32beef88ab0a/config.json'
 ```
 
-`hf_hub_url` can also use the branch name to specify a file revision:
+[`hf_hub_url`] can also use the branch name to specify a file revision:
 
 ```python
 hf_hub_url(repo_id="lysandre/arxiv-nlp", filename="config.json", revision="main")
@@ -45,9 +45,9 @@ hf_hub_url(repo_id="lysandre/arxiv-nlp", filename="config.json", revision="v1.0"
 
 ## cached_download
 
-`cached_download` is useful for downloading and caching a file on your local disk. Once stored in your cache, you don't have to redownload the file the next time you use it. `cached_download` is a hands-free solution for staying up to date with new file versions. When a downloaded file is updated in the remote repository, `cached_download` will automatically download and store it for you.
+[`cached_download`] is useful for downloading and caching a file on your local disk. Once stored in your cache, you don't have to redownload the file the next time you use it. [`cached_download`] is a hands-free solution for staying up to date with new file versions. When a downloaded file is updated in the remote repository, [`cached_download`] will automatically download and store it for you.
 
-Begin by retrieving your file URL with `hf_hub_url`, and then pass the specified URL to `cached_download` to download the file:
+Begin by retrieving your file URL with [`hf_hub_url`], and then pass the specified URL to [`cached_download`] to download the file:
 
 ```python
 >>> from huggingface_hub import hf_hub_url, cached_download
@@ -56,7 +56,7 @@ Begin by retrieving your file URL with `hf_hub_url`, and then pass the specified
 '/home/lysandre/.cache/huggingface/hub/bc0e8cc2f8271b322304e8bb84b3b7580701d53a335ab2d75da19c249e2eeebb.066dae6fdb1e2b8cce60c35cc0f78ed1451d9b341c78de19f3ad469d10a8cbb1'
 ```
 
-`hf_hub_url` and `cached_download` work hand in hand to download a file. This is precisely how `hf_hub_download` from the tutorial works! `hf_hub_download` is simply a wrapper that calls both `hf_hub_url` and `cached_download`.
+[`hf_hub_url`] and [`cached_download`] work hand in hand to download a file. This is precisely how [`hf_hub_download`] from the tutorial works! [`hf_hub_download`] is simply a wrapper that calls both [`hf_hub_url`] and [`cached_download`].
 
 ```python
 >>> from huggingface_hub import hf_hub_download
@@ -65,7 +65,7 @@ Begin by retrieving your file URL with `hf_hub_url`, and then pass the specified
 
 ## snapshot_download
 
-`snapshot_download` downloads an entire repository at a given revision. Like `cached_download`, all downloaded files are cached on your local disk. However, even if only a single file is updated, the entire repository will be redownloaded.
+[`snapshot_download`] downloads an entire repository at a given revision. Like [`cached_download`], all downloaded files are cached on your local disk. However, even if only a single file is updated, the entire repository will be redownloaded.
 
 Download a whole repository as shown in the following:
 
@@ -75,18 +75,18 @@ Download a whole repository as shown in the following:
 '/home/lysandre/.cache/huggingface/hub/lysandre__arxiv-nlp.894a9adde21d9a3e3843e6d5aeaaf01875c7fade'
 ```
 
-`snapshot_download` downloads the latest revision by default. If you want a specific repository revision, use the `revision` parameter as shown with `hf_hub_url`.
+[`snapshot_download`] downloads the latest revision by default. If you want a specific repository revision, use the `revision` parameter as shown with [`hf_hub_url`].
 
 ```python
 >>> from huggingface_hub import snapshot_download
 >>> snapshot_download(repo_id="lysandre/arxiv-nlp", revision="main")
 ```
 
-In general, it is usually better to manually download files with `hf_hub_download` (if you already know the file name) to avoid re-downloading an entire repository. `snapshot_download` is helpful when your library's downloading utility is a helper, and unaware of which files need to be downloaded.
+In general, it is usually better to manually download files with [`hf_hub_download`] (if you already know the file name) to avoid re-downloading an entire repository. [`snapshot_download`] is helpful when your library's downloading utility is a helper, and unaware of which files need to be downloaded.
 
-However, you don't want to always download the contents of an entire repository with `snapshot_download`. Even if you don't know the file name and only know the file type, you can download specific files with `allow_regex` and `ignore_regex`.
-use of the `allow_regex` and `ignore_regex` arguments to specify 
-which files shall be downloaded.
+However, you don't want to always download the contents of an entire repository with [`snapshot_download`]. Even if you don't know the file name and only know the file type, you can download specific files with `allow_regex` and `ignore_regex`.
+Use the `allow_regex` and `ignore_regex` arguments to specify 
+which files to download.
 `allow_regex` and `ignore_regex` accept either a single regex or a list of regexes. 
 The regex matching is based on [`fnmatch`](https://docs.python.org/3/library/fnmatch.html) which means it provides support for Unix shell-style wildcards.
 
@@ -106,8 +106,8 @@ or `.h5` extensions, you could make use of `ignore_regex`:
 ```
 
 Passing a regex can be especially useful when repositories contain files that 
-are never expected to be downloaded by `snapshot_download`.
+are never expected to be downloaded by [`snapshot_download`].
 
 Note that passing `allow_regex` or `ignore_regex` does **not** prevent 
-`snapshot_download` from re-downloading the entire model repository if an ignored
+[`snapshot_download`] from re-downloading the entire model repository if an ignored
 file is changed.

--- a/docs/source/how-to-inference.mdx
+++ b/docs/source/how-to-inference.mdx
@@ -23,7 +23,7 @@ The pipeline is determined from the metadata in the model card and configuration
 >>> from huggingface_hub.inference_api import InferenceApi
 >>> inference = InferenceApi(repo_id="bert-base-uncased", token=API_TOKEN)
 >>> inference(inputs="The goal of life is [MASK].")
->>> [{'sequence': 'the goal of life is life.', 'score': 0.10933292657136917, 'token': 2166, 'token_str': 'life'}]
+[{'sequence': 'the goal of life is life.', 'score': 0.10933292657136917, 'token': 2166, 'token_str': 'life'}]
 ```
 
 Each task requires a different type of input. A `question-answering` task expects a dictionary with the `question` and `context` keys as the input:
@@ -32,7 +32,7 @@ Each task requires a different type of input. A `question-answering` task expect
 >>> inference = InferenceApi(repo_id="deepset/roberta-base-squad2", token=API_TOKEN)
 >>> inputs = {"question":"Where is Hugging Face headquarters?", "context":"Hugging Face is based in Brooklyn, New York. There is also an office in Paris, France."}
 >>> inference(inputs)
->>> {'score': 0.94622403383255, 'start': 25, 'end': 43, 'answer': 'Brooklyn, New York'}
+{'score': 0.94622403383255, 'start': 25, 'end': 43, 'answer': 'Brooklyn, New York'}
 ```
 
 Some tasks may require additional parameters (see [here](https://api-inference.huggingface.co/docs/python/html/detailed_parameters.html) for a detailed list of all parameters for each task). As an example, for `zero-shot-classification` tasks, the model needs candidate labels that can be supplied to `params`:
@@ -42,7 +42,7 @@ Some tasks may require additional parameters (see [here](https://api-inference.h
 >>> inputs = "Hi, I recently bought a device from your company but it is not working as advertised and I would like to get reimbursed!"
 >>> params = {"candidate_labels":["refund", "legal", "faq"]}
 >>> inference(inputs, params)
->>> {'sequence': 'Hi, I recently bought a device from your company but it is not working as advertised and I would like to get reimbursed!', 'labels': ['refund', 'faq', 'legal'], 'scores': [0.9378499388694763, 0.04914155602455139, 0.013008488342165947]}
+{'sequence': 'Hi, I recently bought a device from your company but it is not working as advertised and I would like to get reimbursed!', 'labels': ['refund', 'faq', 'legal'], 'scores': [0.9378499388694763, 0.04914155602455139, 0.013008488342165947]}
 ```
 
 Some models may support multiple tasks. The `sentence-transformers` models can complete both `sentence-similarity` and `feature-extraction` tasks. Specify which task you want to perform with the `task` parameter:

--- a/docs/source/how-to-upstream.mdx
+++ b/docs/source/how-to-upstream.mdx
@@ -20,7 +20,7 @@ The `huggingface_hub` package offers high-level methods that wraps around HTTP r
 
 ### List and filter
 
-It can be helpful for users to see a list of available models and filter them according to a specific language or library. This can be especially useful for library and organization owners who want to view all their models. Use the `list_models` function with the `filter` parameter to search for specific models.
+It can be helpful for users to see a list of available models and filter them according to a specific language or library. This can be especially useful for library and organization owners who want to view all their models. Use the [`list_models`] function with the `filter` parameter to search for specific models.
 
 You can view all the available filters on the left of the [model Hub](http://hf.co/models).
 
@@ -45,7 +45,7 @@ You can view all the available filters on the left of the [model Hub](http://hf.
 >>> list_models(filter="spacy")
 ```
 
-Explore available public datasets with `list_datasets`:
+Explore available public datasets with [`list_datasets`]:
 
 ```python
 >>> from huggingface_hub import list_datasets
@@ -73,7 +73,7 @@ Get important information about a model or dataset as shown below:
 
 ### Create a repository
 
-Create a repository with `create_repo` and give it a name with the `name` parameter.
+Create a repository with [`create_repo`] and give it a name with the `name` parameter.
 
 ```python
 >>> from huggingface_hub import create_repo
@@ -82,9 +82,9 @@ Create a repository with `create_repo` and give it a name with the `name` parame
 ```
 ### Delete a repository
 
-Delete a repository with `delete_repo`. Make sure you are certain you want to delete a repository because this is an irreversible process!
+Delete a repository with [`delete_repo`]. Make sure you are certain you want to delete a repository because this is an irreversible process!
 
-Pass the full repository ID to `delete_repo`. The full repository ID looks like `{username_or_org}/{repo_name}`, and you can retrieve it with `get_full_repo_name()` as shown below:
+Pass the full repository ID to [`delete_repo`]. The full repository ID looks like `{username_or_org}/{repo_name}`, and you can retrieve it with [`get_full_repo_name()`] as shown below:
 
 ```python
 >>> from huggingface_hub import get_full_repo_name, delete_repo
@@ -109,7 +109,7 @@ A repository can be public or private. A private repository is only visible to y
 
 ## Repository 
 
-The `Repository` class allows you to push models or other repositories to the Hub. `Repository` is a wrapper over Git and Git-LFS methods, so make sure you have Git-LFS installed (see [here](https://git-lfs.github.com/) for installation instructions) and set up before you begin. The `Repository` class should feel familiar if you are already familiar with common Git commands. 
+The [`Repository`] class allows you to push models or other repositories to the Hub. [`Repository`] is a wrapper over Git and Git-LFS methods, so make sure you have Git-LFS installed (see [here](https://git-lfs.github.com/) for installation instructions) and set up before you begin. The [`Repository`] class should feel familiar if you are already familiar with common Git commands. 
 
 ### Clone a repository
 
@@ -125,7 +125,7 @@ The `clone_from` parameter clones a repository from a Hugging Face model ID to a
 >>> repo = Repository(local_dir="huggingface-hub", clone_from="https://github.com/huggingface/huggingface_hub")
 ```
 
-Easily combine the `clone_from` parameter with `create_repo` to create and clone a repository:
+Easily combine the `clone_from` parameter with [`create_repo`] to create and clone a repository:
 
 ```python
 >>> repo_url = create_repo(repo_id="repo_name")
@@ -134,7 +134,7 @@ Easily combine the `clone_from` parameter with `create_repo` to create and clone
 
 ### Using a local clone
 
-Instantiate a `Repository` object with a path to a local Git clone or repository:
+Instantiate a [`Repository`] object with a path to a local Git clone or repository:
 
 ```python
 >>> from huggingface_hub import Repository
@@ -151,16 +151,16 @@ If you want to commit or push to a cloned repository that belongs to you or your
    huggingface-cli login
    ```
 
-2. Alternatively, if you prefer working from a Jupyter or Colaboratory notebook, login with `notebook_login`:
+2. Alternatively, if you prefer working from a Jupyter or Colaboratory notebook, login with [`notebook_login`]:
 
    ```python
    >>> from huggingface_hub import notebook_login
    >>> notebook_login()
    ```
 
-   `notebook_login` will launch a widget in your notebook from which you can enter your Hugging Face credentials.
+   [`notebook_login`] will launch a widget in your notebook from which you can enter your Hugging Face credentials.
 
-3. Instantiate a `Repository` class:
+3. Instantiate a [`Repository`] class:
    
    ```python
    >>> repo = Repository(local_dir="my-model", clone_from="<user>/<model_id>")
@@ -181,7 +181,7 @@ You can also attribute a Git username and email to a cloned repository by specif
 
 ### Branch
 
-Switch between branches with `git_checkout`. For example, if you want to switch from `branch1` to `branch2`:
+Switch between branches with [`git_checkout`]. For example, if you want to switch from `branch1` to `branch2`:
 
 ```python
 >>> repo = Repository(local_dir="huggingface-hub", clone_from="<user>/<dataset_id>", revision='branch1')
@@ -190,7 +190,7 @@ Switch between branches with `git_checkout`. For example, if you want to switch 
 
 ### Pull
 
-Update a current local branch with `git_pull`:
+Update a current local branch with [`git_pull`]:
 
 ```python
 >>> repo.git_pull()
@@ -202,9 +202,9 @@ Set `rebase=True` if you want your local commits to occur after your branch is u
 >>> repo.git_pull(rebase=True)
 ```
 
-### `commit` context manager
+### commit context manager
 
-The `commit` context manager is a simple utility that handles four of the most common Git commands: pull, add, commit, and push. `git-lfs` automatically tracks any file larger than 10MB. In the following example, the `commit` context manager:
+The [`commit`] context manager is a simple utility that handles four of the most common Git commands: pull, add, commit, and push. `git-lfs` automatically tracks any file larger than 10MB. In the following example, the [`commit`] context manager:
 
 1. Pulls from the `text-files` repository.
 2. Adds a change made to `file.txt`.
@@ -255,9 +255,9 @@ When `blocking=False`, commands are tracked, and your script will only exit when
 >>> last_command.failed
 ```
 
-### `push_to_hub`
+### push_to_hub
 
-The `Repository` class also has a `push_to_hub` utility to add files, make a commit, and push them to a repository. Unlike the `commit` context manager, `push_to_hub` requires you to pull from a repository first, save the files, and then call `push_to_hub`.
+The [`Repository`] class also has a [`push_to_hub`] utility to add files, make a commit, and push them to a repository. Unlike the [`commit`] context manager, [`push_to_hub`] requires you to pull from a repository first, save the files, and then call [`push_to_hub`].
 
 ```python
 >>> repo.git_pull()

--- a/docs/source/package_reference/hf_api.mdx
+++ b/docs/source/package_reference/hf_api.mdx
@@ -43,3 +43,7 @@ Some helpers to filter repositories on the Hub are available in the `huggingface
 [[autodoc]] DatasetFilter
 
 [[autodoc]] ModelFilter
+
+[[autodoc]] DatasetSearchArguments
+
+[[autodoc]] ModelSearchArguments

--- a/docs/source/searching-the-hub.mdx
+++ b/docs/source/searching-the-hub.mdx
@@ -11,7 +11,7 @@ In this tutorial, we will explore how to interact and explore the Hugging Face H
 pip install huggingface_hub
 ```
 
-It comes packaged with an interface that can interact with the Hub in the `HfApi` class:
+It comes packaged with an interface that can interact with the Hub in the [`HfApi`] class:
 
 
 ```python
@@ -20,8 +20,8 @@ It comes packaged with an interface that can interact with the Hub in the `HfApi
 ```
 
 This class lets you perform a variety of operations that interact with the raw Hub API. We'll be focusing on two specific functions:
-- `list_models`
-- `list_datasets`
+- [`list_models`]
+- [`list_datasets`]
 
 If you look at what can be passed into each function, you will find the parameter list looks something like:
 - `filter`
@@ -33,7 +33,7 @@ Two of these parameters are intuitive (`author` and `search`), but what about th
 
 ## Search Parameters
 
-The `huggingface_hub` provides a user-friendly interface to know what exactly can be passed into this `filter` parameter through the `ModelSearchArguments` and `DatasetSearchArguments` classes:
+The `huggingface_hub` provides a user-friendly interface to know what exactly can be passed into this `filter` parameter through the [`ModelSearchArguments`] and [`DatasetSearchArguments`] classes:
 
 
 ```python
@@ -55,21 +55,15 @@ If you check what is available in `model_args` by checking it's output, you will
 
 ```python
 >>> model_args
+Available Attributes or Keys:
+ * author
+ * dataset
+ * language
+ * library
+ * license
+ * model_name
+ * pipeline_tag
 ```
-
-
-
-
-    Available Attributes or Keys:
-     * author
-     * dataset
-     * language
-     * library
-     * license
-     * model_name
-     * pipeline_tag
-
-
 
 It has a variety of attributes or keys available to you. This is because it is both an object and a dictionary, so you can either do `model_args["author"]` or `model_args.author`. For this tutorial, let's follow the latter format.
 
@@ -78,122 +72,102 @@ The first criteria is getting all PyTorch models. This would be found under the 
 
 ```python
 >>> model_args.library
+Available Attributes or Keys:
+ * AdapterTransformers
+ * Asteroid
+ * ESPnet
+ * Fairseq
+ * Flair
+ * JAX
+ * Joblib
+ * Keras
+ * ONNX
+ * PyTorch
+ * Rust
+ * Scikit_learn
+ * SentenceTransformers
+ * Stable_Baselines3 (Key only)
+ * Stanza
+ * TFLite
+ * TensorBoard
+ * TensorFlow
+ * TensorFlowTTS
+ * Timm
+ * Transformers
+ * allenNLP
+ * fastText
+ * fastai
+ * pyannote_audio
+ * spaCy
+ * speechbrain
 ```
-
-
-
-
-    Available Attributes or Keys:
-     * AdapterTransformers
-     * Asteroid
-     * ESPnet
-     * Flair
-     * JAX
-     * Joblib
-     * Keras
-     * ONNX
-     * PyTorch
-     * Pyannote
-     * Rust
-     * Scikit_learn
-     * SentenceTransformers
-     * Stanza
-     * TFLite
-     * TensorBoard
-     * TensorFlow
-     * TensorFlowTTS
-     * Timm
-     * Transformers
-     * allennlp
-     * fastText
-     * fastai
-     * spaCy
-     * speechbrain
-
-
 
 It is! The `PyTorch` name is there, so you'll need to use `model_args.library.PyTorch`:
 
 
 ```python
 >>> model_args.library.PyTorch
+'pytorch'
 ```
-
-
-
-
-    'pytorch'
-
-
 
 Below is an animation repeating the process for finding both the `Text Classification` and `glue` requirements:
 
-![Animation exploring `model_args.pipeline_tag`](../assets/hub/search_text_classification.gif)
+![Animation exploring `model_args.pipeline_tag`](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/search_text_classification.gif)
 
-![Animation exploring `model_args.dataset`](../assets/hub/search_glue.gif)
+![Animation exploring `model_args.dataset`](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/search_glue.gif)
 
-Now that all the pieces are there, the last step is to combine them all for something the API can use through the `ModelFilter` and `DatasetFilter` classes. The classes transform the outputs of the previous step into something the API can use conveniently:
+Now that all the pieces are there, the last step is to combine them all for something the API can use through the [`ModelFilter`] and [`DatasetFilter`] classes. The classes transform the outputs of the previous step into something the API can use conveniently:
 
 
 ```python
 >>> from huggingface_hub import ModelFilter, DatasetFilter
 
 >>> filt = ModelFilter(
->>>     task=args.pipeline_tag.TextClassification, 
->>>     trained_dataset=args.dataset.glue, 
->>>     library=args.library.PyTorch
->>> )
+...     task=model_args.pipeline_tag.TextClassification, 
+...     trained_dataset=dataset_args.dataset_name.glue, 
+...     library=model_args.library.PyTorch
+... )
 >>> api.list_models(filter=filt)[0]
+ModelInfo: {
+	modelId: Jiva/xlm-roberta-large-it-mnli
+	sha: c6e64469ec4aa17fedbd1b2522256f90a90b5b86
+	lastModified: 2021-12-10T14:56:38.000Z
+	tags: ['pytorch', 'xlm-roberta', 'text-classification', 'it', 'dataset:multi_nli', 'dataset:glue', 'arxiv:1911.02116', 'transformers', 'tensorflow', 'license:mit', 'zero-shot-classification']
+	pipeline_tag: zero-shot-classification
+	siblings: [ModelFile(rfilename='.gitattributes'), ModelFile(rfilename='README.md'), ModelFile(rfilename='config.json'), ModelFile(rfilename='pytorch_model.bin'), ModelFile(rfilename='sentencepiece.bpe.model'), ModelFile(rfilename='special_tokens_map.json'), ModelFile(rfilename='tokenizer.json'), ModelFile(rfilename='tokenizer_config.json')]
+	config: None
+	id: Jiva/xlm-roberta-large-it-mnli
+	private: False
+	downloads: 11061
+	library_name: transformers
+	likes: 1
+}
 ```
-
-
-
-
-    ModelInfo: {
-    	modelId: 09panesara/distilbert-base-uncased-finetuned-cola
-    	sha: f89a85cb8703676115912fffa55842f23eb981ab
-    	lastModified: 2021-12-21T14:03:01.000Z
-    	tags: ['pytorch', 'tensorboard', 'distilbert', 'text-classification', 'dataset:glue', 'transformers', 'license:apache-2.0', 'generated_from_trainer', 'model-index', 'infinity_compatible']
-    	pipeline_tag: text-classification
-    	siblings: [ModelFile(rfilename='.gitattributes'), ModelFile(rfilename='.gitignore'), ModelFile(rfilename='README.md'), ModelFile(rfilename='config.json'), ModelFile(rfilename='pytorch_model.bin'), ModelFile(rfilename='special_tokens_map.json'), ModelFile(rfilename='tokenizer.json'), ModelFile(rfilename='tokenizer_config.json'), ModelFile(rfilename='training_args.bin'), ModelFile(rfilename='vocab.txt'), ModelFile(rfilename='runs/Dec21_13-51-40_bc62d5d57d92/events.out.tfevents.1640094759.bc62d5d57d92.77.0'), ModelFile(rfilename='runs/Dec21_13-51-40_bc62d5d57d92/events.out.tfevents.1640095117.bc62d5d57d92.77.2'), ModelFile(rfilename='runs/Dec21_13-51-40_bc62d5d57d92/1640094759.4067502/events.out.tfevents.1640094759.bc62d5d57d92.77.1')]
-    	config: None
-    	private: False
-    	downloads: 6
-    	library_name: transformers
-    	likes: 0
-    }
-
-
 
 As you can see, it found the models that fit all the criteria. You can even take it further by passing in an array for each of the parameters from before. For example, let's take a look for the same configuration, but also include `TensorFlow` in the filter:
 
 
 ```python
 >>> filt = ModelFilter(
->>>     task=args.pipeline_tag.TextClassification, 
->>>     library=[args.library.PyTorch, args.library.TensorFlow]
+...     task=model_args.pipeline_tag.TextClassification, 
+...     library=[model_args.library.PyTorch, model_args.library.TensorFlow]
 >>> )
 >>> api.list_models(filter=filt)[0]
+ModelInfo: {
+	modelId: distilbert-base-uncased-finetuned-sst-2-english
+	sha: ada5cc01a40ea664f0a490d0b5f88c97ab460470
+	lastModified: 2022-03-22T19:47:08.000Z
+	tags: ['pytorch', 'tf', 'rust', 'distilbert', 'text-classification', 'en', 'dataset:sst-2', 'transformers', 'license:apache-2.0', 'infinity_compatible']
+	pipeline_tag: text-classification
+	siblings: [ModelFile(rfilename='.gitattributes'), ModelFile(rfilename='README.md'), ModelFile(rfilename='config.json'), ModelFile(rfilename='map.jpeg'), ModelFile(rfilename='pytorch_model.bin'), ModelFile(rfilename='rust_model.ot'), ModelFile(rfilename='tf_model.h5'), ModelFile(rfilename='tokenizer_config.json'), ModelFile(rfilename='vocab.txt')]
+	config: None
+	id: distilbert-base-uncased-finetuned-sst-2-english
+	private: False
+	downloads: 3917525
+	library_name: transformers
+	likes: 49
+}
 ```
-
-
-
-
-    ModelInfo: {
-    	modelId: CAMeL-Lab/bert-base-arabic-camelbert-ca-poetry
-    	sha: bc50b6dc1c97dc66998287efb6d044bdaa8f7057
-    	lastModified: 2021-10-17T12:09:38.000Z
-    	tags: ['pytorch', 'tf', 'bert', 'text-classification', 'ar', 'arxiv:1905.05700', 'arxiv:2103.06678', 'transformers', 'license:apache-2.0', 'infinity_compatible']
-    	pipeline_tag: text-classification
-    	siblings: [ModelFile(rfilename='.gitattributes'), ModelFile(rfilename='README.md'), ModelFile(rfilename='config.json'), ModelFile(rfilename='pytorch_model.bin'), ModelFile(rfilename='special_tokens_map.json'), ModelFile(rfilename='tf_model.h5'), ModelFile(rfilename='tokenizer_config.json'), ModelFile(rfilename='training_args.bin'), ModelFile(rfilename='vocab.txt')]
-    	config: None
-    	private: False
-    	downloads: 21
-    	library_name: transformers
-    	likes: 0
-    }
-
-
 
 ## Searching for a Dataset
 
@@ -202,76 +176,110 @@ Similarly to finding a model, you can find a dataset easily by following the sam
 The new scenario will be:
 > I want to search the Hub for all datasets that can be used for `text_classification` and are in English.
 
-First, you should look at what is available in the `DatasetSearchArguments`, similar to the `ModelSearchArguments`:
+First, you should look at what is available in the [`DatasetSearchArguments`], similar to the [`ModelSearchArguments`]:
 
 
 ```python
 >>> dataset_args = DatasetSearchArguments()
 >>> dataset_args
+Available Attributes or Keys:
+ * author
+ * benchmark
+ * dataset_name
+ * language_creators
+ * languages
+ * licenses
+ * multilinguality
+ * size_categories
+ * task_categories
+ * task_ids
 ```
-
-
-
-
-    Available Attributes or Keys:
-     * author
-     * benchmark
-     * dataset_name
-     * language_creators
-     * languages
-     * licenses
-     * multilinguality
-     * size_categories
-     * task_categories
-     * task_ids
-
-
 
 `text_classification` is a *task*, so first you should check `task_categories`:
 
 
 ```python
-dataset_args.task_categories
+>>> dataset_args.task_categories
+Available Attributes or Keys:
+ * CodeGeneration
+ * Evaluationoflanguagemodels
+ * InclusiveLanguage
+ * InformationRetrieval
+ * SemanticSearch
+ * Summarization
+ * Text2Textgeneration (Key only)
+ * TextNeutralization
+ * TokenClassification
+ * Translation
+ * audio_classification
+ * automatic_speech_recognition
+ * caption_retrieval
+ * code_generation
+ * computer_vision
+ * conditional_text_generation
+ * conversational
+ * cross_language_transcription
+ * crowdsourced
+ * dialogue_system
+ * entity_extraction
+ * feature_extraction
+ * fill_mask
+ * generative_modelling
+ * gpt_3 (Key only)
+ * grammaticalerrorcorrection
+ * image
+ * image_captioning
+ * image_classification
+ * image_retrieval
+ * image_segmentation
+ * image_to_text
+ * information_retrieval
+ * language_modeling
+ * machine_translation
+ * multiple_choice
+ * named_entity_disambiguation
+ * named_entity_recognition
+ * natural_language_inference
+ * news_classification
+ * object_detection
+ * other
+ * other_test
+ * other_text_search
+ * paraphrase
+ * paraphrasedetection
+ * query_paraphrasing
+ * question_answering
+ * question_generation
+ * question_pairing
+ * sentiment_analysis
+ * sequence2sequence (Key only)
+ * sequence_modeling
+ * speech_processing
+ * structure_prediction
+ * summarization
+ * table_to_text
+ * tabular_to_text
+ * text2text_generation (Key only)
+ * text_classification
+ * text_generation
+ * text_generation_other_code_modeling
+ * text_generation_other_common_sense_inference
+ * text_generation_other_discourse_analysis
+ * text_regression
+ * text_retrieval
+ * text_scoring
+ * text_to_structured
+ * text_to_tabular
+ * textual_entailment
+ * time_series_forecasting
+ * token_classification
+ * transkation
+ * translation
+ * tts
+ * unpaired_image_to_image_translation
+ * zero_shot_information_retrieval
+ * zero_shot_retrieval
 ```
-
-
-
-
-    Available Attributes or Keys:
-     * Summarization
-     * audio_classification
-     * automatic_speech_recognition
-     * code_generation
-     * conditional_text_generation
-     * cross_language_transcription
-     * dialogue_system
-     * grammaticalerrorcorrection
-     * machine_translation
-     * named_entity_disambiguation
-     * named_entity_recognition
-     * natural_language_inference
-     * news_classification
-     * other
-     * other_test
-     * other_text_search
-     * paraphrase
-     * paraphrasedetection
-     * query_paraphrasing
-     * question_answering
-     * question_generation
-     * sentiment_analysis
-     * sequence_modeling
-     * speech_processing
-     * structure_prediction
-     * summarization
-     * text_classification
-     * text_generation
-     * text_retrieval
-     * text_scoring
-     * textual_entailment
-     * translation
-
-
 
 There you will find `text_classification`, so you should use `dataset_args.task_categories.text_classification`.
 
@@ -280,23 +288,17 @@ Next we need to find the proper language. There is a `languages` property we can
 
 ```python
 >>> "en" in dataset_args.languages
+True
 ```
-
-
-
-
-    True
-
-
 
 Now that the pieces are found, you can write a filter:
 
 
 ```python
 >>> filt = DatasetFilter(
->>>    languages=dataset_args.languages.en,
->>>    task_categories=dataset_args.task_categories.text_classification
->>> )
+...    languages=dataset_args.languages.en,
+...    task_categories=dataset_args.task_categories.text_classification
+... )
 ```
 
 And search the API!
@@ -304,24 +306,19 @@ And search the API!
 
 ```python
 >>> api.list_datasets(filter=filt)[0]
+DatasetInfo: {
+    id: Abirate/english_quotes
+    lastModified: None
+    tags: ['annotations_creators:expert-generated', 'language_creators:expert-generated', 'language_creators:crowdsourced', 'languages:en', 'multilinguality:monolingual', 'source_datasets:original', 'task_categories:text-classification', 'task_ids:multi-label-classification']
+    private: False
+    author: Abirate
+    description: None
+    citation: None
+    cardData: None
+    siblings: None
+    gated: False
+}
 ```
-
-
-
-
-    DatasetInfo: {
-    	id: Abirate/english_quotes
-    	lastModified: None
-    	tags: ['annotations_creators:expert-generated', 'language_creators:expert-generated', 'language_creators:crowdsourced', 'languages:en', 'multilinguality:monolingual', 'source_datasets:original', 'task_categories:text-classification', 'task_ids:multi-label-classification']
-    	private: False
-    	author: Abirate
-    	description: None
-    	citation: None
-    	cardData: None
-    	siblings: None
-    	gated: False
-    }
-
 
 
 With these two functionalities combined, you can search for all available parameters and tags within the Hub to search for with ease for both Datasets and Models!


### PR DESCRIPTION
This PR adds some general maintenance to the docs:

- Links functions to the appropriate section in the API reference.
- Cleans up code outputs, formatting, images/fixes code examples in Searching the Hub.
- Adds `DatasetSearchArguments` and `ModelSearchArguments` to the API reference.