### PR TITLE
Update how to guides

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -2,9 +2,11 @@
   - local: index
     title: 🤗 Hugging Face Hub Python Wrapper
   - local: how-to-downstream
-    title: How to download files from the hub
+    title: How to download files
   - local: how-to-upstream
-    title: How to upload files to the hub
+    title: How to upload files
+  - local: how-to-manage
+    title: How to manage and create repositories
   - local: searching-the-hub
     title: Searching the Hub
   - local: how-to-inference

--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -5,6 +5,8 @@
     title: Quick start
   title: "Get started"
 - sections:
+  - local: how-to-manage
+    title: Create and manage repositories
   - local: how-to-downstream
     title: Download files from the Hub
   - local: how-to-upstream

--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -2,15 +2,15 @@
   - local: index
     title: 🤗 Hugging Face Hub Python Wrapper
   - local: how-to-manage
-    title: How to manage and create repositories
+    title: Create and manage repositories
   - local: how-to-downstream
-    title: How to download files
+    title: Download files from the Hub
   - local: how-to-upstream
-    title: How to upload files
+    title: Upload files to the Hub
   - local: searching-the-hub
     title: Searching the Hub
   - local: how-to-inference
-    title: How to access the Inference API
+    title: Access the Inference API
   title: "Guides"
 - sections:
     - local: package_reference/repository

--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -1,12 +1,12 @@
 - sections:
   - local: index
     title: 🤗 Hugging Face Hub Python Wrapper
+  - local: how-to-manage
+    title: How to manage and create repositories
   - local: how-to-downstream
     title: How to download files
   - local: how-to-upstream
     title: How to upload files
-  - local: how-to-manage
-    title: How to manage and create repositories
   - local: searching-the-hub
     title: Searching the Hub
   - local: how-to-inference

--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -10,7 +10,7 @@
   - local: searching-the-hub
     title: Searching the Hub
   - local: how-to-inference
-    title: How to programmatically access the Inference API
+    title: How to access the Inference API
   title: "Guides"
 - sections:
     - local: package_reference/repository
@@ -21,6 +21,8 @@
       title: Downloading files
     - local: package_reference/mixins
       title: Mixins & serialization methods
+    - local: package_reference/inference_api
+      title: Inference API
     - local: package_reference/logging
       title: Logging
   title: "Reference"

--- a/docs/source/how-to-downstream.mdx
+++ b/docs/source/how-to-downstream.mdx
@@ -1,20 +1,14 @@
----
-title: How to download files from the Hub
----
+# How to download files from the Hub
 
-# How to integrate downstream utilities in your library
+The `huggingface_hub` library provides functions to download files from the model and dataset repositories stored on the Hub. You can use these functions independently or integrate them into your own library so it is more convenient for your users to interact with the Hub. This guide will show you how to:
 
-Utilities that allow your library to download files from the Hub are referred to as *downstream* utilities. This guide introduces additional downstream utilities you can integrate with your library, or use separately on their own. You will learn how to:
-
-* Retrieve a URL to download.
-* Download a file and cache it on your disk.
+* Specify a file to download from the Hub.
+* Download and cache a file on your disk.
 * Download all the files in a repository.
 
-## hf_hub_url
+## Choose a file to download
 
-Use `hf_hub_url` to retrieve the URL of a specific file to download by providing a `filename`.
-
-![/docs/assets/hub/repo.png](/docs/assets/hub/repo.png)
+Use the `filename` parameter in the [`hf_hub_url`] function to retrieve the URL of a specific file to download:
 
 ```python
 >>> from huggingface_hub import hf_hub_url
@@ -22,7 +16,9 @@ Use `hf_hub_url` to retrieve the URL of a specific file to download by providing
 'https://huggingface.co/lysandre/arxiv-nlp/resolve/main/config.json'
 ```
 
-Specify a particular file version by providing the file revision. The file revision can be a branch, a tag, or a commit hash.
+![/docs/assets/hub/repo.png](/docs/assets/hub/repo.png)
+
+Specify a particular file version by providing the file revision, which can be a branch, a tag, or a commit hash.
 
 When using the commit hash, it must be the full-length hash instead of a 7-character commit hash:
 
@@ -31,23 +27,23 @@ When using the commit hash, it must be the full-length hash instead of a 7-chara
 'https://huggingface.co/lysandre/arxiv-nlp/resolve/877b84a8f93f2d619faa2a6e514a32beef88ab0a/config.json'
 ```
 
-`hf_hub_url` can also use the branch name to specify a file revision:
+[`hf_hub_url`] can also use the branch name to specify a file revision:
 
 ```python
-hf_hub_url(repo_id="lysandre/arxiv-nlp", filename="config.json", revision="main")
+>>> hf_hub_url(repo_id="lysandre/arxiv-nlp", filename="config.json", revision="main")
 ```
 
-Specify a file revision with a tag identifier. For example, if you want `v1.0` of the `config.json` file:
+You can also specify a file revision with a tag identifier. For example, if you want `v1.0` of the `config.json` file:
 
 ```python
-hf_hub_url(repo_id="lysandre/arxiv-nlp", filename="config.json", revision="v1.0")
+>>> hf_hub_url(repo_id="lysandre/arxiv-nlp", filename="config.json", revision="v1.0")
 ```
 
-## cached_download
+## Download and store a file
 
-`cached_download` is useful for downloading and caching a file on your local disk. Once stored in your cache, you don't have to redownload the file the next time you use it. `cached_download` is a hands-free solution for staying up to date with new file versions. When a downloaded file is updated in the remote repository, `cached_download` will automatically download and store it for you.
+[`cached_download`] is useful for downloading and caching a file on your local disk. Once a file is stored in your cache, you don't have to redownload the file the next time you use it. [`cached_download`] is a hands-free solution for staying up to date with new file versions. When a downloaded file is updated in the remote repository, `cached_download` will automatically download and store it.
 
-Begin by retrieving your file URL with `hf_hub_url`, and then pass the specified URL to `cached_download` to download the file:
+Begin by retrieving your file URL with [`hf_hub_url`], and then pass the specified URL to [`cached_download`] to download the file:
 
 ```python
 >>> from huggingface_hub import hf_hub_url, cached_download
@@ -56,16 +52,16 @@ Begin by retrieving your file URL with `hf_hub_url`, and then pass the specified
 '/home/lysandre/.cache/huggingface/hub/bc0e8cc2f8271b322304e8bb84b3b7580701d53a335ab2d75da19c249e2eeebb.066dae6fdb1e2b8cce60c35cc0f78ed1451d9b341c78de19f3ad469d10a8cbb1'
 ```
 
-`hf_hub_url` and `cached_download` work hand in hand to download a file. This is precisely how `hf_hub_download` from the tutorial works! `hf_hub_download` is simply a wrapper that calls both `hf_hub_url` and `cached_download`.
+[`hf_hub_url`] and [`cached_download`] work hand-in-hand to download a file. This is precisely how `hf_hub_download` from the tutorial works! `hf_hub_download` is simply a wrapper that calls both `hf_hub_url` and `cached_download`.
 
 ```python
 >>> from huggingface_hub import hf_hub_download
 >>> hf_hub_download(repo_id="lysandre/arxiv-nlp", filename="config.json")
 ```
 
-## snapshot_download
+## Download an entire repository
 
-`snapshot_download` downloads an entire repository at a given revision. Like `cached_download`, all downloaded files are cached on your local disk. However, even if only a single file is updated, the entire repository will be redownloaded.
+[`snapshot_download`] downloads an entire repository at a given revision. Like [`cached_download`], all downloaded files are cached on your local disk. However, even if only a single file is updated, the entire repository will be redownloaded.
 
 Download a whole repository as shown in the following:
 
@@ -75,19 +71,19 @@ Download a whole repository as shown in the following:
 '/home/lysandre/.cache/huggingface/hub/lysandre__arxiv-nlp.894a9adde21d9a3e3843e6d5aeaaf01875c7fade'
 ```
 
-`snapshot_download` downloads the latest revision by default. If you want a specific repository revision, use the `revision` parameter as shown with `hf_hub_url`.
+[`snapshot_download`] downloads the latest revision by default. If you want a specific repository revision, use the `revision` parameter:
 
 ```python
 >>> from huggingface_hub import snapshot_download
 >>> snapshot_download(repo_id="lysandre/arxiv-nlp", revision="main")
 ```
 
-In general, it is usually better to manually download files with `hf_hub_download` (if you already know the file name) to avoid re-downloading an entire repository. `snapshot_download` is helpful when your library's downloading utility is a helper, and unaware of which files need to be downloaded.
+In general, it is usually better to manually download files with [`hf_hub_download`] - if you already know the file name - to avoid re-downloading an entire repository. [`snapshot_download`] is helpful when you are unaware of which files need to be downloaded.
 
-However, you don't want to always download the contents of an entire repository with `snapshot_download`. Even if you don't know the file name and only know the file type, you can download specific files with `allow_regex` and `ignore_regex`.
-use of the `allow_regex` and `ignore_regex` arguments to specify 
-which files shall be downloaded.
-`allow_regex` and `ignore_regex` accept either a single regex or a list of regexes. 
+However, you don't want to always download the contents of an entire repository with `snapshot_download`. Even if you don't know the file name, you can download specific files if you know the file type with `allow_regex` and `ignore_regex`.
+Use the `allow_regex` and `ignore_regex` arguments to specify 
+which files to download.
+These parameters accept either a single regex or a list of regexes. 
 The regex matching is based on [`fnmatch`](https://docs.python.org/3/library/fnmatch.html) which means it provides support for Unix shell-style wildcards.
 
 For example, you can use `allow_regex` to only download JSON configuration files:
@@ -98,7 +94,6 @@ For example, you can use `allow_regex` to only download JSON configuration files
 ```
 
 On the other hand, `ignore_regex` can be used to exclude certain files from being downloaded. The following example ignores the `.msgpack` and `.h5` file extensions:
-or `.h5` extensions, you could make use of `ignore_regex`:
 
 ```python
 >>> from huggingface_hub import snapshot_download
@@ -106,8 +101,8 @@ or `.h5` extensions, you could make use of `ignore_regex`:
 ```
 
 Passing a regex can be especially useful when repositories contain files that 
-are never expected to be downloaded by `snapshot_download`.
+are never expected to be downloaded by [`snapshot_download`].
 
 Note that passing `allow_regex` or `ignore_regex` does **not** prevent 
-`snapshot_download` from re-downloading the entire model repository if an ignored
+[`snapshot_download`] from re-downloading the entire model repository if an ignored
 file is changed.

--- a/docs/source/how-to-downstream.mdx
+++ b/docs/source/how-to-downstream.mdx
@@ -18,9 +18,7 @@ Use the `filename` parameter in the [`hf_hub_url`] function to retrieve the URL 
 
 ![/docs/assets/hub/repo.png](/docs/assets/hub/repo.png)
 
-Specify a particular file version by providing the file revision, which can be a branch, a tag, or a commit hash.
-
-When using the commit hash, it must be the full-length hash instead of a 7-character commit hash:
+Specify a particular file version by providing the file revision, which can be a branch, a tag, or a commit hash. When using the commit hash, it must be the full-length hash instead of a 7-character commit hash:
 
 ```python
 >>> hf_hub_url(repo_id="lysandre/arxiv-nlp", filename="config.json", revision="877b84a8f93f2d619faa2a6e514a32beef88ab0a")
@@ -41,7 +39,7 @@ You can also specify a file revision with a tag identifier. For example, if you 
 
 ## Download and store a file
 
-[`cached_download`] is useful for downloading and caching a file on your local disk. Once a file is stored in your cache, you don't have to redownload the file the next time you use it. [`cached_download`] is a hands-free solution for staying up to date with new file versions. When a downloaded file is updated in the remote repository, `cached_download` will automatically download and store it.
+[`cached_download`] is used to download and cache a file on your local disk. Once a file is stored in your cache, you don't have to redownload the file the next time you use it. [`cached_download`] is a hands-free solution for staying up to date with new file versions. When a downloaded file is updated in the remote repository, [`cached_download`] will automatically download and store it.
 
 Begin by retrieving your file URL with [`hf_hub_url`], and then pass the specified URL to [`cached_download`] to download the file:
 
@@ -80,7 +78,7 @@ Download a whole repository as shown in the following:
 
 In general, it is usually better to manually download files with [`hf_hub_download`] - if you already know the file name - to avoid re-downloading an entire repository. [`snapshot_download`] is helpful when you are unaware of which files need to be downloaded.
 
-However, you don't want to always download the contents of an entire repository with `snapshot_download`. Even if you don't know the file name, you can download specific files if you know the file type with `allow_regex` and `ignore_regex`.
+However, you don't want to always download the contents of an entire repository with [`snapshot_download`]. Even if you don't know the file name, you can download specific files if you know the file type with `allow_regex` and `ignore_regex`.
 Use the `allow_regex` and `ignore_regex` arguments to specify 
 which files to download.
 These parameters accept either a single regex or a list of regexes. 

--- a/docs/source/how-to-downstream.mdx
+++ b/docs/source/how-to-downstream.mdx
@@ -1,6 +1,9 @@
 # Download files from the Hub
 
-The `huggingface_hub` library provides functions to download files from the repositories stored on the Hub. You can use these functions independently or integrate them into your own library so it is more convenient for your users to interact with the Hub. This guide will show you how to:
+The `huggingface_hub` library provides functions to download files from the repositories
+stored on the Hub. You can use these functions independently or integrate them into your
+own library, making it more convenient for your users to interact with the Hub. This
+guide will show you how to:
 
 * Specify a file to download from the Hub.
 * Download and cache a file on your disk.
@@ -8,7 +11,8 @@ The `huggingface_hub` library provides functions to download files from the repo
 
 ## Choose a file to download
 
-Use the `filename` parameter in the [`hf_hub_url`] function to retrieve the URL of a specific file to download:
+Use the `filename` parameter in the [`hf_hub_url`] function to retrieve the URL of a
+specific file to download:
 
 ```python
 >>> from huggingface_hub import hf_hub_url
@@ -18,20 +22,26 @@ Use the `filename` parameter in the [`hf_hub_url`] function to retrieve the URL 
 
 ![/docs/assets/hub/repo.png](/docs/assets/hub/repo.png)
 
-Specify a particular file version by providing the file revision, which can be a branch, a tag, or a commit hash. When using the commit hash, it must be the full-length hash instead of a 7-character commit hash:
+Specify a particular file version by providing the file revision, which can be the
+branch name, a tag, or a commit hash. When using the commit hash, it must be the
+full-length hash instead of a 7-character commit hash:
 
 ```python
->>> hf_hub_url(repo_id="lysandre/arxiv-nlp", filename="config.json", revision="877b84a8f93f2d619faa2a6e514a32beef88ab0a")
+>>> hf_hub_url(repo_id="lysandre/arxiv-nlp", 
+...            filename="config.json", 
+...            revision="877b84a8f93f2d619faa2a6e514a32beef88ab0a",
+... )
 'https://huggingface.co/lysandre/arxiv-nlp/resolve/877b84a8f93f2d619faa2a6e514a32beef88ab0a/config.json'
 ```
 
-[`hf_hub_url`] can also use the branch name to specify a file revision:
+To specify a file revision with the branch name:
 
 ```python
 >>> hf_hub_url(repo_id="lysandre/arxiv-nlp", filename="config.json", revision="main")
 ```
 
-You can also specify a file revision with a tag identifier. For example, if you want `v1.0` of the `config.json` file:
+To specify a file revision with a tag identifier. For example, if you want `v1.0` of the
+`config.json` file:
 
 ```python
 >>> hf_hub_url(repo_id="lysandre/arxiv-nlp", filename="config.json", revision="v1.0")
@@ -39,9 +49,14 @@ You can also specify a file revision with a tag identifier. For example, if you 
 
 ## Download and store a file
 
-[`cached_download`] is used to download and cache a file on your local disk. Once a file is stored in your cache, you don't have to redownload the file the next time you use it. [`cached_download`] is a hands-free solution for staying up to date with new file versions. When a downloaded file is updated in the remote repository, [`cached_download`] will automatically download and store it.
+[`cached_download`] is used to download and cache a file on your local disk. Once a file
+is stored in your cache, you don't have to redownload it the next time you use it.
+[`cached_download`] is a hands-free solution for staying up to date with new file
+versions. When a downloaded file is updated in the remote repository,
+[`cached_download`] will automatically download and store it.
 
-Begin by retrieving your file URL with [`hf_hub_url`], and then pass the specified URL to [`cached_download`] to download the file:
+Begin by retrieving the file URL with [`hf_hub_url`], and then pass the specified URL to
+[`cached_download`] to download the file:
 
 ```python
 >>> from huggingface_hub import hf_hub_url, cached_download
@@ -50,7 +65,9 @@ Begin by retrieving your file URL with [`hf_hub_url`], and then pass the specifi
 '/home/lysandre/.cache/huggingface/hub/bc0e8cc2f8271b322304e8bb84b3b7580701d53a335ab2d75da19c249e2eeebb.066dae6fdb1e2b8cce60c35cc0f78ed1451d9b341c78de19f3ad469d10a8cbb1'
 ```
 
-[`hf_hub_url`] and [`cached_download`] work hand-in-hand to download a file. This is precisely how `hf_hub_download` from the tutorial works! `hf_hub_download` is simply a wrapper that calls both `hf_hub_url` and `cached_download`.
+[`hf_hub_url`] and [`cached_download`] work hand-in-hand to download a file. This is
+such a standard workflow that [`hf_hub_download`] is a wrapper that calls both of these
+functions.
 
 ```python
 >>> from huggingface_hub import hf_hub_download
@@ -59,7 +76,9 @@ Begin by retrieving your file URL with [`hf_hub_url`], and then pass the specifi
 
 ## Download an entire repository
 
-[`snapshot_download`] downloads an entire repository at a given revision. Like [`cached_download`], all downloaded files are cached on your local disk. However, even if only a single file is updated, the entire repository will be redownloaded.
+[`snapshot_download`] downloads an entire repository at a given revision. Like
+[`cached_download`], all downloaded files are cached on your local disk. However, even
+if only a single file is updated, the entire repository will be redownloaded.
 
 Download a whole repository as shown in the following:
 
@@ -69,21 +88,27 @@ Download a whole repository as shown in the following:
 '/home/lysandre/.cache/huggingface/hub/lysandre__arxiv-nlp.894a9adde21d9a3e3843e6d5aeaaf01875c7fade'
 ```
 
-[`snapshot_download`] downloads the latest revision by default. If you want a specific repository revision, use the `revision` parameter:
+[`snapshot_download`] downloads the latest revision by default. If you want a specific
+repository revision, use the `revision` parameter:
 
 ```python
 >>> from huggingface_hub import snapshot_download
 >>> snapshot_download(repo_id="lysandre/arxiv-nlp", revision="main")
 ```
 
-In general, it is usually better to download files with [`hf_hub_download`] - if you already know the file name - to avoid re-downloading an entire repository. [`snapshot_download`] is helpful when you are unaware of which files need to be downloaded.
+In general, it is usually better to download files with [`hf_hub_download`] - if you
+already know the file name - to avoid redownloading an entire repository.
+[`snapshot_download`] is helpful when you are unaware of which files to download.
 
-However, you don't want to always download the contents of an entire repository with [`snapshot_download`]. Even if you don't know the file name, you can download specific files if you know the file type with `allow_regex` and `ignore_regex`.
-Use the `allow_regex` and `ignore_regex` arguments to specify 
-which files to download.
-These parameters accept either a single regex or a list of regexes. 
+However, you don't always want to download the contents of an entire repository with
+[`snapshot_download`]. Even if you don't know the file name, you can download specific
+files if you know the file type with `allow_regex` and `ignore_regex`. Use the
+`allow_regex` and `ignore_regex` arguments to specify which files to download. These
+parameters accept either a single regex or a list of regexes. 
 
-The regex matching is based on [`fnmatch`](https://docs.python.org/3/library/fnmatch.html) which means it provides support for Unix shell-style wildcards.
+The regex matching is based on
+[`fnmatch`](https://docs.python.org/3/library/fnmatch.html), which provides support for
+Unix shell-style wildcards.
 
 For example, you can use `allow_regex` to only download JSON configuration files:
 
@@ -92,16 +117,17 @@ For example, you can use `allow_regex` to only download JSON configuration files
 >>> snapshot_download(repo_id="lysandre/arxiv-nlp", allow_regex="*.json")
 ```
 
-On the other hand, `ignore_regex` can be used to exclude certain files from being downloaded. The following example ignores the `.msgpack` and `.h5` file extensions:
+On the other hand, `ignore_regex` can exclude certain files from being downloaded. The
+following example ignores the `.msgpack` and `.h5` file extensions:
 
 ```python
 >>> from huggingface_hub import snapshot_download
 >>> snapshot_download(repo_id="lysandre/arxiv-nlp", ignore_regex=["*.msgpack", "*.h5"])
 ```
 
-Passing a regex can be especially useful when repositories contain files that 
-are never expected to be downloaded by [`snapshot_download`].
+Passing a regex can be especially useful when repositories contain files that are never
+expected to be downloaded by [`snapshot_download`].
 
-Note that passing `allow_regex` or `ignore_regex` does **not** prevent 
-[`snapshot_download`] from re-downloading the entire model repository if an ignored
-file is changed.
+Note that passing `allow_regex` or `ignore_regex` does **not** prevent
+[`snapshot_download`] from redownloading the entire model repository if an ignored file
+is changed.

--- a/docs/source/how-to-downstream.mdx
+++ b/docs/source/how-to-downstream.mdx
@@ -1,6 +1,6 @@
-# How to download files from the Hub
+# Download files from the Hub
 
-The `huggingface_hub` library provides functions to download files from the model and dataset repositories stored on the Hub. You can use these functions independently or integrate them into your own library so it is more convenient for your users to interact with the Hub. This guide will show you how to:
+The `huggingface_hub` library provides functions to download files from the repositories stored on the Hub. You can use these functions independently or integrate them into your own library so it is more convenient for your users to interact with the Hub. This guide will show you how to:
 
 * Specify a file to download from the Hub.
 * Download and cache a file on your disk.
@@ -76,7 +76,7 @@ Download a whole repository as shown in the following:
 >>> snapshot_download(repo_id="lysandre/arxiv-nlp", revision="main")
 ```
 
-In general, it is usually better to manually download files with [`hf_hub_download`] - if you already know the file name - to avoid re-downloading an entire repository. [`snapshot_download`] is helpful when you are unaware of which files need to be downloaded.
+In general, it is usually better to download files with [`hf_hub_download`] - if you already know the file name - to avoid re-downloading an entire repository. [`snapshot_download`] is helpful when you are unaware of which files need to be downloaded.
 
 However, you don't want to always download the contents of an entire repository with [`snapshot_download`]. Even if you don't know the file name, you can download specific files if you know the file type with `allow_regex` and `ignore_regex`.
 Use the `allow_regex` and `ignore_regex` arguments to specify 

--- a/docs/source/how-to-inference.mdx
+++ b/docs/source/how-to-inference.mdx
@@ -1,8 +1,12 @@
 # Access the Inference API
 
-The Inference API provides fast inference for your hosted models. The Inference API can be accessed via usual HTTP requests with your favorite programming languages, but the `huggingface_hub` library has a client wrapper to access the Inference API programmatically. This guide will show you how to make calls to the Inference API with the `huggingface_hub` library.
+The Inference API provides fast inference for your hosted models. The Inference API can be accessed via usual HTTP requests with your favorite programming language, but the `huggingface_hub` library has a client wrapper to access the Inference API programmatically. This guide will show you how to make calls to the Inference API with the `huggingface_hub` library.
 
-**If you want to make the HTTP calls directly, please refer to [Accelerated Inference API Documentation](https://api-inference.huggingface.co/docs/python/html/index.html) or to the sample snippets visible on every supported model page.**
+<Tip>
+
+If you want to make the HTTP calls directly, please refer to [Accelerated Inference API Documentation](https://api-inference.huggingface.co/docs/python/html/index.html) or to the sample snippets visible on every supported model page.
+
+</Tip>
 
 ![Snippet of code to make calls to the Inference API](/docs/assets/hub/inference_api_snippet.png)
 
@@ -13,7 +17,7 @@ Begin by creating an instance of the [`InferenceApi`] with the model repository 
 >>> inference = InferenceApi(repo_id="bert-base-uncased", token=API_TOKEN)
 ```
 
-The pipeline is determined from the metadata in the model card and configuration files (see [here](https://huggingface.co/docs/hub/main#how-is-a-models-type-of-inference-api-and-widget-determined) for more details). For example, when using the [bert-base-uncased](https://huggingface.co/bert-base-uncased) model, the Inference API can automatically infer that this model should be used for a `fill-mask` task.
+The metadata in the model card and configuration files (see [here](https://huggingface.co/docs/hub/main#how-is-a-models-type-of-inference-api-and-widget-determined) for more details) determines the pipeline type. For example, when using the [bert-base-uncased](https://huggingface.co/bert-base-uncased) model, the Inference API can automatically infer that this model should be used for a `fill-mask` task.
 
 ```python
 >>> from huggingface_hub.inference_api import InferenceApi
@@ -44,5 +48,8 @@ Some tasks may require additional parameters (see [here](https://api-inference.h
 Some models may support multiple tasks. The `sentence-transformers` models can complete both `sentence-similarity` and `feature-extraction` tasks. Specify which task you want to perform with the `task` parameter:
 
 ```python
->>> inference = InferenceApi(repo_id="paraphrase-xlm-r-multilingual-v1", task="feature-extraction", token=API_TOKEN)
+>>> inference = InferenceApi(repo_id="paraphrase-xlm-r-multilingual-v1", 
+...                          task="feature-extraction", 
+...                          token=API_TOKEN,
+... )
 ```

--- a/docs/source/how-to-inference.mdx
+++ b/docs/source/how-to-inference.mdx
@@ -1,4 +1,4 @@
-# How to access the Inference API
+# Access the Inference API
 
 The Inference API provides fast inference for your hosted models. The Inference API can be accessed via usual HTTP requests with your favorite programming languages, but the `huggingface_hub` library has a client wrapper to access the Inference API programmatically. This guide will show you how to make calls to the Inference API with the `huggingface_hub` library.
 

--- a/docs/source/how-to-inference.mdx
+++ b/docs/source/how-to-inference.mdx
@@ -1,8 +1,4 @@
----
-title: How to programmatically access the Inference API
----
-
-# How to programmatically access the Inference API
+# How to access the Inference API
 
 The Inference API provides fast inference for your hosted models. The Inference API can be accessed via usual HTTP requests with your favorite programming languages, but the `huggingface_hub` library has a client wrapper to access the Inference API programmatically. This guide will show you how to make calls to the Inference API with the `huggingface_hub` library.
 
@@ -10,7 +6,7 @@ The Inference API provides fast inference for your hosted models. The Inference 
 
 ![Snippet of code to make calls to the Inference API](/docs/assets/hub/inference_api_snippet.png)
 
-Begin by creating an instance of the `InferenceApi` with a specific model repository ID. You can find your `API_TOKEN` under Settings from your Hugging Face account. The `API_TOKEN` will allow you to send requests to the Inference API.
+Begin by creating an instance of the [`InferenceApi`] with the model repository ID of the model you want to use. You can find your `API_TOKEN` under Settings from your Hugging Face account. The `API_TOKEN` will allow you to send requests to the Inference API.
 
 ```python
 >>> from huggingface_hub.inference_api import InferenceApi

--- a/docs/source/how-to-manage.mdx
+++ b/docs/source/how-to-manage.mdx
@@ -1,0 +1,197 @@
+# How to create and manage a repository
+
+* Use the repository-management methods available in the `huggingface_hub` package.
+* Use the `Repository` class to handle files and version control a repository with Git-like commands.
+
+## huggingface_hub repository-management methods
+
+The `huggingface_hub` package offers high-level methods that wraps around HTTP requests. There are many valuable tasks you can accomplish with it, including: 
+
+- List and filter models and datasets.
+- Inspect model or dataset metadata.
+- Delete a repository.
+- Change the visibility of a repository.
+
+### List and filter
+
+It can be helpful for users to see a list of available models and filter them according to a specific language or library. This can be especially useful for library and organization owners who want to view all their models. Use the `list_models` function with the `filter` parameter to search for specific models.
+
+You can view all the available filters on the left of the [model Hub](http://hf.co/models).
+
+![/docs/assets/hub/hub_filters.png](/docs/assets/hub/hub_filters.png)
+
+```python
+>>> from huggingface_hub import list_models
+
+# List all models.
+>>> list_models()
+
+# List only text classification models.
+>>> list_models(filter="text-classification")
+
+# List only Russian models compatible with PyTorch.
+>>> list_models(filter=("languages:ru", "pytorch"))
+
+# List only the models trained on the "common_voice" dataset.
+>>> list_models(filter="dataset:common_voice")
+
+# List only the models from the spaCy library.
+>>> list_models(filter="spacy")
+```
+
+Explore available public datasets with `list_datasets`:
+
+```python
+>>> from huggingface_hub import list_datasets
+
+# List only text classification datasets.
+>>> list_datasets(filter="task_categories:text-classification")
+
+# List only datasets in Russian for language modeling.
+>>> list_datasets(filter=("languages:ru", "task_ids:language-modeling"))
+```
+
+### Inspect model or dataset metadata
+
+Get important information about a model or dataset as shown below:
+
+```python
+>>> from huggingface_hub import model_info, dataset_info
+
+# Get metadata of a single model.
+>>> model_info("distilbert-base-uncased")
+
+# Get metadata of a single dataset.
+>>> dataset_info("glue")
+```
+
+### Create a repository
+
+Create a repository with `create_repo` and give it a name with the `name` parameter.
+
+```python
+>>> from huggingface_hub import create_repo
+>>> create_repo("test-model")
+'https://huggingface.co/lysandre/test-model'
+```
+### Delete a repository
+
+Delete a repository with `delete_repo`. Make sure you are certain you want to delete a repository because this is an irreversible process!
+
+Pass the full repository ID to `delete_repo`. The full repository ID looks like `{username_or_org}/{repo_name}`, and you can retrieve it with `get_full_repo_name()` as shown below:
+
+```python
+>>> from huggingface_hub import get_full_repo_name, delete_repo
+>>> name = get_full_repo_name(repo_name)
+>>> delete_repo(repo_id=name)
+```
+
+Delete a dataset repository by adding the `repo_type` parameter:
+
+```python
+>>> delete_repo(repo_id=REPO_NAME, repo_type="dataset")
+```
+
+### Change repository visibility
+
+A repository can be public or private. A private repository is only visible to you or members of the organization in which the repository is located. Change a repository to private as shown in the following:
+
+```python
+>>> from huggingface_hub import update_repo_visibility
+>>> update_repo_visibility(name=REPO_NAME, private=True)
+```
+
+## Repository 
+
+The `Repository` class allows you to push models or other repositories to the Hub. `Repository` is a wrapper over Git and Git-LFS methods, so make sure you have Git-LFS installed (see [here](https://git-lfs.github.com/) for installation instructions) and set up before you begin. The `Repository` class should feel familiar if you are already familiar with common Git commands. 
+
+### Clone a repository
+
+The `clone_from` parameter clones a repository from a Hugging Face model ID to a directory specified by the `local_dir` argument:
+
+```python
+>>> repo = Repository(local_dir="w2v2", clone_from="facebook/wav2vec2-large-960h-lv60")
+```
+
+`clone_from` can also clone a repository from a specified directory using a URL (if you are working offline, this parameter should be `None`):
+
+```python
+>>> repo = Repository(local_dir="huggingface-hub", clone_from="https://github.com/huggingface/huggingface_hub")
+```
+
+Easily combine the `clone_from` parameter with `create_repo` to create and clone a repository:
+
+```python
+>>> repo_url = create_repo(repo_id="repo_name")
+>>> repo = Repository(local_dir="repo_local_path", clone_from=repo_url)
+```
+
+### Using a local clone
+
+Instantiate a `Repository` object with a path to a local Git clone or repository:
+
+```python
+>>> from huggingface_hub import Repository
+>>> repo = Repository(local_dir="<path>/<to>/<folder>")
+```
+
+### Commit and push to a cloned repository
+
+If you want to commit or push to a cloned repository that belongs to you or your organizations:
+
+1. Log in to your Hugging Face account with the following command:
+
+   ```bash
+   huggingface-cli login
+   ```
+
+2. Alternatively, if you prefer working from a Jupyter or Colaboratory notebook, login with `notebook_login`:
+
+   ```python
+   >>> from huggingface_hub import notebook_login
+   >>> notebook_login()
+   ```
+
+   `notebook_login` will launch a widget in your notebook from which you can enter your Hugging Face credentials.
+
+3. Instantiate a `Repository` class:
+   
+   ```python
+   >>> repo = Repository(local_dir="my-model", clone_from="<user>/<model_id>")
+   ```
+
+You can also attribute a Git username and email to a cloned repository by specifying the `git_user` and `git_email` parameters. When users commit to that repository, Git will be aware of the commit author.
+
+```python
+>>> repo = Repository(
+...   "my-dataset", 
+...   clone_from="<user>/<dataset_id>", 
+...   use_auth_token=True, 
+...   repo_type="dataset",
+...   git_user="MyName",
+...   git_email="me@cool.mail"
+... )
+```
+
+### Branch
+
+Switch between branches with `git_checkout`. For example, if you want to switch from `branch1` to `branch2`:
+
+```python
+>>> repo = Repository(local_dir="huggingface-hub", clone_from="<user>/<dataset_id>", revision='branch1')
+>>> repo.git_checkout("branch2")
+```
+
+### Pull
+
+Update a current local branch with `git_pull`:
+
+```python
+>>> repo.git_pull()
+```
+
+Set `rebase=True` if you want your local commits to occur after your branch is updated with the new commits from the remote:
+
+```python
+>>> repo.git_pull(rebase=True)
+```

--- a/docs/source/how-to-manage.mdx
+++ b/docs/source/how-to-manage.mdx
@@ -1,84 +1,49 @@
 # How to create and manage a repository
 
-* Use the repository-management methods available in the `huggingface_hub` package.
-* Use the `Repository` class to handle files and version control a repository with Git-like commands.
+A repository is a space for you to store your model or dataset files. This guide will show you how to:
 
-## huggingface_hub repository-management methods
+* Create and delete a repository.
+* Adjust repository visibility.
+* Use the [`Repository`] class for common Git operations like clone, branch, push, etc.
 
-The `huggingface_hub` package offers high-level methods that wraps around HTTP requests. There are many valuable tasks you can accomplish with it, including: 
+## Create a repository
 
-- List and filter models and datasets.
-- Inspect model or dataset metadata.
-- Delete a repository.
-- Change the visibility of a repository.
-
-### List and filter
-
-It can be helpful for users to see a list of available models and filter them according to a specific language or library. This can be especially useful for library and organization owners who want to view all their models. Use the `list_models` function with the `filter` parameter to search for specific models.
-
-You can view all the available filters on the left of the [model Hub](http://hf.co/models).
-
-![/docs/assets/hub/hub_filters.png](/docs/assets/hub/hub_filters.png)
-
-```python
->>> from huggingface_hub import list_models
-
-# List all models.
->>> list_models()
-
-# List only text classification models.
->>> list_models(filter="text-classification")
-
-# List only Russian models compatible with PyTorch.
->>> list_models(filter=("languages:ru", "pytorch"))
-
-# List only the models trained on the "common_voice" dataset.
->>> list_models(filter="dataset:common_voice")
-
-# List only the models from the spaCy library.
->>> list_models(filter="spacy")
-```
-
-Explore available public datasets with `list_datasets`:
-
-```python
->>> from huggingface_hub import list_datasets
-
-# List only text classification datasets.
->>> list_datasets(filter="task_categories:text-classification")
-
-# List only datasets in Russian for language modeling.
->>> list_datasets(filter=("languages:ru", "task_ids:language-modeling"))
-```
-
-### Inspect model or dataset metadata
-
-Get important information about a model or dataset as shown below:
-
-```python
->>> from huggingface_hub import model_info, dataset_info
-
-# Get metadata of a single model.
->>> model_info("distilbert-base-uncased")
-
-# Get metadata of a single dataset.
->>> dataset_info("glue")
-```
-
-### Create a repository
-
-Create a repository with `create_repo` and give it a name with the `name` parameter.
+Create an empty repository with [`create_repo`] and give it a name with the `repo_id` parameter. The `repo_id` is your namespace followed by the repository name: `{username_or_org}/{repo_name}`.
 
 ```python
 >>> from huggingface_hub import create_repo
->>> create_repo("test-model")
+>>> create_repo("lysandre/test-model")
 'https://huggingface.co/lysandre/test-model'
 ```
-### Delete a repository
 
-Delete a repository with `delete_repo`. Make sure you are certain you want to delete a repository because this is an irreversible process!
+By default, [`create_repo`] creates a model repository. But you can use the `repo_type` parameter to specify another repository type. For example, if you want to create a dataset repository:
 
-Pass the full repository ID to `delete_repo`. The full repository ID looks like `{username_or_org}/{repo_name}`, and you can retrieve it with `get_full_repo_name()` as shown below:
+```py
+>>> from huggingface_hub import create_repo
+>>> create_repo("lysandre/test-dataset", repo_type="dataset")
+'https://huggingface.co/lysandre/test-dataset'
+```
+
+When creating a repository, you also have the option to set your repository visibility with the `private` parameter. For example, if you want to create a private repository:
+
+```py
+>>> from huggingface_hub import create_repo
+>>> create_repo("lysandre/test-private", private=True)
+```
+
+If you want to change the repository visibility at a later time, you can use the [`update_repo_visibility`] function. 
+
+## Delete a repository
+
+Delete a repository with [`delete_repo`]. Make sure you are certain you want to delete a repository because this is an irreversible process!
+
+Specify the `repo_id` of the repository you want to delete:
+
+```py
+>>> delete_repo(repo_id=name)
+```
+
+If you aren't sure what the `repo_id` is or you want to quickly retrieve it, you can also use the [`get_full_repo_name`] function:
 
 ```python
 >>> from huggingface_hub import get_full_repo_name, delete_repo
@@ -86,13 +51,13 @@ Pass the full repository ID to `delete_repo`. The full repository ID looks like 
 >>> delete_repo(repo_id=name)
 ```
 
-Delete a dataset repository by adding the `repo_type` parameter:
+You can also specify the repository type to delete by adding the `repo_type` parameter:
 
 ```python
 >>> delete_repo(repo_id=REPO_NAME, repo_type="dataset")
 ```
 
-### Change repository visibility
+## Change repository visibility
 
 A repository can be public or private. A private repository is only visible to you or members of the organization in which the repository is located. Change a repository to private as shown in the following:
 
@@ -101,13 +66,22 @@ A repository can be public or private. A private repository is only visible to y
 >>> update_repo_visibility(name=REPO_NAME, private=True)
 ```
 
-## Repository 
+## The Repository class 
 
-The `Repository` class allows you to push models or other repositories to the Hub. `Repository` is a wrapper over Git and Git-LFS methods, so make sure you have Git-LFS installed (see [here](https://git-lfs.github.com/) for installation instructions) and set up before you begin. The `Repository` class should feel familiar if you are already familiar with common Git commands. 
+The [`Repository`] class allows you to interact with files and repositories on the Hub with functions similar to `git` commands. [`Repository`] is a wrapper over Git and Git-LFS methods, so make sure you have Git-LFS installed (see [here](https://git-lfs.github.com/) for installation instructions) and set up before you begin. With [`Repository`], you can use the Git commands you already know and love.
 
-### Clone a repository
+### Use a local repository
 
-The `clone_from` parameter clones a repository from a Hugging Face model ID to a directory specified by the `local_dir` argument:
+Instantiate a [`Repository`] object with a path to a local repository:
+
+```python
+>>> from huggingface_hub import Repository
+>>> repo = Repository(local_dir="<path>/<to>/<folder>")
+```
+
+### Clone
+
+The `clone_from` parameter clones a repository from a Hugging Face repository ID to a local directory specified by the `local_dir` argument:
 
 ```python
 >>> repo = Repository(local_dir="w2v2", clone_from="facebook/wav2vec2-large-960h-lv60")
@@ -116,49 +90,15 @@ The `clone_from` parameter clones a repository from a Hugging Face model ID to a
 `clone_from` can also clone a repository from a specified directory using a URL (if you are working offline, this parameter should be `None`):
 
 ```python
->>> repo = Repository(local_dir="huggingface-hub", clone_from="https://github.com/huggingface/huggingface_hub")
+>>> repo = Repository(local_dir="huggingface-hub", clone_from="https://huggingface.co/facebook/wav2vec2-large-960h-lv60")
 ```
 
-Easily combine the `clone_from` parameter with `create_repo` to create and clone a repository:
+You can combine the `clone_from` parameter with [`create_repo`] to create and clone a repository:
 
 ```python
 >>> repo_url = create_repo(repo_id="repo_name")
 >>> repo = Repository(local_dir="repo_local_path", clone_from=repo_url)
 ```
-
-### Using a local clone
-
-Instantiate a `Repository` object with a path to a local Git clone or repository:
-
-```python
->>> from huggingface_hub import Repository
->>> repo = Repository(local_dir="<path>/<to>/<folder>")
-```
-
-### Commit and push to a cloned repository
-
-If you want to commit or push to a cloned repository that belongs to you or your organizations:
-
-1. Log in to your Hugging Face account with the following command:
-
-   ```bash
-   huggingface-cli login
-   ```
-
-2. Alternatively, if you prefer working from a Jupyter or Colaboratory notebook, login with `notebook_login`:
-
-   ```python
-   >>> from huggingface_hub import notebook_login
-   >>> notebook_login()
-   ```
-
-   `notebook_login` will launch a widget in your notebook from which you can enter your Hugging Face credentials.
-
-3. Instantiate a `Repository` class:
-   
-   ```python
-   >>> repo = Repository(local_dir="my-model", clone_from="<user>/<model_id>")
-   ```
 
 You can also attribute a Git username and email to a cloned repository by specifying the `git_user` and `git_email` parameters. When users commit to that repository, Git will be aware of the commit author.
 
@@ -175,7 +115,7 @@ You can also attribute a Git username and email to a cloned repository by specif
 
 ### Branch
 
-Switch between branches with `git_checkout`. For example, if you want to switch from `branch1` to `branch2`:
+Branches are important for collaboration and experimentation without impacting your current files and code. Switch between branches with [`git_checkout`]. For example, if you want to switch from `branch1` to `branch2`:
 
 ```python
 >>> repo = Repository(local_dir="huggingface-hub", clone_from="<user>/<dataset_id>", revision='branch1')
@@ -184,7 +124,7 @@ Switch between branches with `git_checkout`. For example, if you want to switch 
 
 ### Pull
 
-Update a current local branch with `git_pull`:
+Pull allows you to update a current local branch with changes from a remote repository:
 
 ```python
 >>> repo.git_pull()
@@ -195,3 +135,35 @@ Set `rebase=True` if you want your local commits to occur after your branch is u
 ```python
 >>> repo.git_pull(rebase=True)
 ```
+
+### Add
+
+Stage a file to add to your repository with [`git_add]:
+
+```py
+>>> repo.git_add("path/to/file")
+```
+
+To automatically track large files (>10MB), set `auto_lfs_track=True`:
+
+```py
+>>> repo.git_add("path/to/file", auto_lfs_track=True)
+```
+
+### Commit
+
+After staging a file to add, commit the staged changes with [`git_commit`]. You can also add a commit message to describe the changes:
+
+```py
+>>> repo.git_commit(commit_message="add my first model config file :)")
+```
+
+### Push
+
+Finally, push your file to your repository with [`git_push`]:
+
+```py
+>>> repo.git_push()
+```
+
+Since this workflow is so common, there is a `commit` context manager to pull, add, commit and push files all in one step (see this [guide](how-to-upstream#commit-context-manager) for more details).

--- a/docs/source/how-to-manage.mdx
+++ b/docs/source/how-to-manage.mdx
@@ -1,4 +1,4 @@
-# How to create and manage a repository
+# Create and manage a repository
 
 A repository is a space for you to store your model or dataset files. This guide will show you how to:
 
@@ -60,14 +60,6 @@ Specify the `repo_id` of the repository you want to delete:
 >>> delete_repo(repo_id=name)
 ```
 
-If you aren't sure what the `repo_id` is or you want to quickly retrieve it, you can also use the [`get_full_repo_name`] function:
-
-```python
->>> from huggingface_hub import get_full_repo_name, delete_repo
->>> name = get_full_repo_name(repo_name)
->>> delete_repo(repo_id=name)
-```
-
 You can also specify the repository type to delete by adding the `repo_type` parameter:
 
 ```python
@@ -117,7 +109,7 @@ You can combine the `clone_from` parameter with [`create_repo`] to create and cl
 >>> repo = Repository(local_dir="repo_local_path", clone_from=repo_url)
 ```
 
-You can also attribute a Git username and email to a cloned repository by specifying the `git_user` and `git_email` parameters. When users commit to that repository, Git will be aware of the commit author.
+When you clone a repository, you can also attribute a Git username and email to a cloned repository by specifying the `git_user` and `git_email` parameters. When users commit to that repository, Git will be aware of the commit author.
 
 ```python
 >>> repo = Repository(
@@ -152,35 +144,3 @@ Set `rebase=True` if you want your local commits to occur after your branch is u
 ```python
 >>> repo.git_pull(rebase=True)
 ```
-
-### Add
-
-Stage a file to add to your repository with [`git_add]:
-
-```py
->>> repo.git_add("path/to/file")
-```
-
-To automatically track large files (>10MB), set `auto_lfs_track=True`:
-
-```py
->>> repo.git_add("path/to/file", auto_lfs_track=True)
-```
-
-### Commit
-
-After staging a file to add, commit the staged changes with [`git_commit`]. You can also add a commit message to describe the changes:
-
-```py
->>> repo.git_commit(commit_message="add my first model config file :)")
-```
-
-### Push
-
-Finally, push your file to your repository with [`git_push`]:
-
-```py
->>> repo.git_push()
-```
-
-Since this workflow is so common, there is a `commit` context manager to pull, add, commit and push files all in one step (see this [guide](how-to-upstream#commit-context-manager) for more details).

--- a/docs/source/how-to-manage.mdx
+++ b/docs/source/how-to-manage.mdx
@@ -124,7 +124,7 @@ When you clone a repository, you can also attribute a Git username and email to 
 
 ### Branch
 
-Branches are important for collaboration and experimentation without impacting your current files and code. Switch between branches with [`git_checkout`]. For example, if you want to switch from `branch1` to `branch2`:
+Branches are important for collaboration and experimentation without impacting your current files and code. Switch between branches with [`~Repository.git_checkout`]. For example, if you want to switch from `branch1` to `branch2`:
 
 ```python
 >>> repo = Repository(local_dir="huggingface-hub", clone_from="<user>/<dataset_id>", revision='branch1')

--- a/docs/source/how-to-manage.mdx
+++ b/docs/source/how-to-manage.mdx
@@ -4,7 +4,7 @@ A repository is a space for you to store your model or dataset files. This guide
 
 * Create and delete a repository.
 * Adjust repository visibility.
-* Use the [`Repository`] class for common Git operations like clone, branch, push, etc.
+* Use the [`Repository`] class for common Git operations like clone, branch, and pull.
 
 If you want to create a repository on the Hub, you need to log in to your Hugging Face account:
 
@@ -27,7 +27,7 @@ If you want to create a repository on the Hub, you need to log in to your Huggin
 
 Create an empty repository with [`create_repo`] and give it a name with the `repo_id` parameter. The `repo_id` is your namespace followed by the repository name: `{username_or_org}/{repo_name}`.
 
-```python
+```py
 >>> from huggingface_hub import create_repo
 >>> create_repo("lysandre/test-model")
 'https://huggingface.co/lysandre/test-model'
@@ -41,7 +41,7 @@ By default, [`create_repo`] creates a model repository. But you can use the `rep
 'https://huggingface.co/lysandre/test-dataset'
 ```
 
-When creating a repository, you also have the option to set your repository visibility with the `private` parameter. For example, if you want to create a private repository:
+When you create a repository, you can set your repository visibility with the `private` parameter. For example, if you want to create a private repository:
 
 ```py
 >>> from huggingface_hub import create_repo
@@ -52,7 +52,7 @@ If you want to change the repository visibility at a later time, you can use the
 
 ## Delete a repository
 
-Delete a repository with [`delete_repo`]. Make sure you are certain you want to delete a repository because this is an irreversible process!
+Delete a repository with [`delete_repo`]. Make sure you want to delete a repository because this is an irreversible process!
 
 Specify the `repo_id` of the repository you want to delete:
 
@@ -62,7 +62,7 @@ Specify the `repo_id` of the repository you want to delete:
 
 You can also specify the repository type to delete by adding the `repo_type` parameter:
 
-```python
+```py
 >>> delete_repo(repo_id=REPO_NAME, repo_type="dataset")
 ```
 
@@ -70,20 +70,20 @@ You can also specify the repository type to delete by adding the `repo_type` par
 
 A repository can be public or private. A private repository is only visible to you or members of the organization in which the repository is located. Change a repository to private as shown in the following:
 
-```python
+```py
 >>> from huggingface_hub import update_repo_visibility
 >>> update_repo_visibility(name=REPO_NAME, private=True)
 ```
 
 ## The Repository class 
 
-The [`Repository`] class allows you to interact with files and repositories on the Hub with functions similar to `git` commands. [`Repository`] is a wrapper over Git and Git-LFS methods, so make sure you have Git-LFS installed (see [here](https://git-lfs.github.com/) for installation instructions) and set up before you begin. With [`Repository`], you can use the Git commands you already know and love.
+The [`Repository`] class allows you to interact with files and repositories on the Hub with functions similar to Git commands. [`Repository`] is a wrapper over Git and Git-LFS methods, so make sure you have Git-LFS installed (see [here](https://git-lfs.github.com/) for installation instructions) and set up before you begin. With [`Repository`], you can use the Git commands you already know and love.
 
 ### Use a local repository
 
 Instantiate a [`Repository`] object with a path to a local repository:
 
-```python
+```py
 >>> from huggingface_hub import Repository
 >>> repo = Repository(local_dir="<path>/<to>/<folder>")
 ```
@@ -92,26 +92,27 @@ Instantiate a [`Repository`] object with a path to a local repository:
 
 The `clone_from` parameter clones a repository from a Hugging Face repository ID to a local directory specified by the `local_dir` argument:
 
-```python
+```py
+>>> from huggingface_hub import Repository
 >>> repo = Repository(local_dir="w2v2", clone_from="facebook/wav2vec2-large-960h-lv60")
 ```
 
 `clone_from` can also clone a repository from a specified directory using a URL (if you are working offline, this parameter should be `None`):
 
-```python
+```py
 >>> repo = Repository(local_dir="huggingface-hub", clone_from="https://huggingface.co/facebook/wav2vec2-large-960h-lv60")
 ```
 
 You can combine the `clone_from` parameter with [`create_repo`] to create and clone a repository:
 
-```python
+```py
 >>> repo_url = create_repo(repo_id="repo_name")
 >>> repo = Repository(local_dir="repo_local_path", clone_from=repo_url)
 ```
 
-When you clone a repository, you can also attribute a Git username and email to a cloned repository by specifying the `git_user` and `git_email` parameters. When users commit to that repository, Git will be aware of the commit author.
+You can also attribute a Git username and email to a cloned repository by specifying the `git_user` and `git_email` parameters when you clone a repository. When users commit to that repository, Git will be aware of the commit author.
 
-```python
+```py
 >>> repo = Repository(
 ...   "my-dataset", 
 ...   clone_from="<user>/<dataset_id>", 
@@ -126,21 +127,23 @@ When you clone a repository, you can also attribute a Git username and email to 
 
 Branches are important for collaboration and experimentation without impacting your current files and code. Switch between branches with [`~Repository.git_checkout`]. For example, if you want to switch from `branch1` to `branch2`:
 
-```python
+```py
+>>> from huggingface_hub import Repository
 >>> repo = Repository(local_dir="huggingface-hub", clone_from="<user>/<dataset_id>", revision='branch1')
 >>> repo.git_checkout("branch2")
 ```
 
 ### Pull
 
-Pull allows you to update a current local branch with changes from a remote repository:
+[`~Repository.git_pull`] allows you to update a current local branch with changes from a remote repository:
 
-```python
+```py
+>>> from huggingface_hub import Repository
 >>> repo.git_pull()
 ```
 
 Set `rebase=True` if you want your local commits to occur after your branch is updated with the new commits from the remote:
 
-```python
+```py
 >>> repo.git_pull(rebase=True)
 ```

--- a/docs/source/how-to-manage.mdx
+++ b/docs/source/how-to-manage.mdx
@@ -6,6 +6,23 @@ A repository is a space for you to store your model or dataset files. This guide
 * Adjust repository visibility.
 * Use the [`Repository`] class for common Git operations like clone, branch, push, etc.
 
+If you want to create a repository on the Hub, you need to log in to your Hugging Face account:
+
+1. Log in to your Hugging Face account with the following command:
+
+   ```bash
+   huggingface-cli login
+   ```
+
+2. Alternatively, if you prefer working from a Jupyter or Colaboratory notebook, login with [`notebook_login`]:
+
+   ```python
+   >>> from huggingface_hub import notebook_login
+   >>> notebook_login()
+   ```
+
+   [`notebook_login`] will launch a widget in your notebook from which you can enter your Hugging Face credentials.
+
 ## Create a repository
 
 Create an empty repository with [`create_repo`] and give it a name with the `repo_id` parameter. The `repo_id` is your namespace followed by the repository name: `{username_or_org}/{repo_name}`.

--- a/docs/source/how-to-upstream.mdx
+++ b/docs/source/how-to-upstream.mdx
@@ -1,4 +1,4 @@
-# How to upload files to the Hub
+# Upload files to the Hub
 
 Sharing your files and work is a very important aspect of the Hub. The `huggingface_hub` uses a Git-based workflow to upload files to the Hub. You can use these functions independently or integrate them into your own library so it is more convenient for your users to interact with the Hub. This guide will show you how to:
 
@@ -83,6 +83,19 @@ The [`Repository`] class also has a [`~Repository.push_to_hub`] function to add 
 ```python
 >>> repo.git_pull()
 >>> repo.push_to_hub(commit_message="Commit my-awesome-file to the Hub")
+```
+
+However, if you aren't ready to push a file yet, you can still use [`git_add`] and [`git_commit`] to add and commit your file:
+
+```py
+>>> repo.git_add("path/to/file")
+>>> repo.git_commit(commit_message="add my first model config file :)")
+```
+
+Once you're ready, you can push your file to your repository with [`git_push`]:
+
+```py
+>>> repo.git_push()
 ```
 
 ## Upload with Git LFS

--- a/docs/source/how-to-upstream.mdx
+++ b/docs/source/how-to-upstream.mdx
@@ -1,210 +1,14 @@
----
-title: How to create repositories and upload files to the Hub
----
+# How to upload files to the Hub
 
-# How to integrate upstream utilities in your library
+Sharing your files and work is a very important aspect of the Hub. The `huggingface_hub` uses a Git-based workflow to upload files to the Hub. You can use these functions independently or integrate them into your own library so it is more convenient for your users to interact with the Hub. This guide will show you how to:
 
-*Upstream* utilities allow you to publish files to the Hub from your library. This guide will show you how to:
+* Push files with a `commit` context manager.
+* Push files with the [`push_to_hub`] function.
+* Upload very large files with [Git LFS](https://git-lfs.github.com/).
 
-* Use the repository-management methods available in the `huggingface_hub` package.
-* Use the `Repository` class to handle files and version control a repository with Git-like commands.
+## commit context manager
 
-## huggingface_hub repository-management methods
-
-The `huggingface_hub` package offers high-level methods that wraps around HTTP requests. There are many valuable tasks you can accomplish with it, including: 
-
-- List and filter models and datasets.
-- Inspect model or dataset metadata.
-- Delete a repository.
-- Change the visibility of a repository.
-
-### List and filter
-
-It can be helpful for users to see a list of available models and filter them according to a specific language or library. This can be especially useful for library and organization owners who want to view all their models. Use the `list_models` function with the `filter` parameter to search for specific models.
-
-You can view all the available filters on the left of the [model Hub](http://hf.co/models).
-
-![/docs/assets/hub/hub_filters.png](/docs/assets/hub/hub_filters.png)
-
-```python
->>> from huggingface_hub import list_models
-
-# List all models.
->>> list_models()
-
-# List only text classification models.
->>> list_models(filter="text-classification")
-
-# List only Russian models compatible with PyTorch.
->>> list_models(filter=("languages:ru", "pytorch"))
-
-# List only the models trained on the "common_voice" dataset.
->>> list_models(filter="dataset:common_voice")
-
-# List only the models from the spaCy library.
->>> list_models(filter="spacy")
-```
-
-Explore available public datasets with `list_datasets`:
-
-```python
->>> from huggingface_hub import list_datasets
-
-# List only text classification datasets.
->>> list_datasets(filter="task_categories:text-classification")
-
-# List only datasets in Russian for language modeling.
->>> list_datasets(filter=("languages:ru", "task_ids:language-modeling"))
-```
-
-### Inspect model or dataset metadata
-
-Get important information about a model or dataset as shown below:
-
-```python
->>> from huggingface_hub import model_info, dataset_info
-
-# Get metadata of a single model.
->>> model_info("distilbert-base-uncased")
-
-# Get metadata of a single dataset.
->>> dataset_info("glue")
-```
-
-### Create a repository
-
-Create a repository with `create_repo` and give it a name with the `name` parameter.
-
-```python
->>> from huggingface_hub import create_repo
->>> create_repo("test-model")
-'https://huggingface.co/lysandre/test-model'
-```
-### Delete a repository
-
-Delete a repository with `delete_repo`. Make sure you are certain you want to delete a repository because this is an irreversible process!
-
-Pass the full repository ID to `delete_repo`. The full repository ID looks like `{username_or_org}/{repo_name}`, and you can retrieve it with `get_full_repo_name()` as shown below:
-
-```python
->>> from huggingface_hub import get_full_repo_name, delete_repo
->>> name = get_full_repo_name(repo_name)
->>> delete_repo(repo_id=name)
-```
-
-Delete a dataset repository by adding the `repo_type` parameter:
-
-```python
->>> delete_repo(repo_id=REPO_NAME, repo_type="dataset")
-```
-
-### Change repository visibility
-
-A repository can be public or private. A private repository is only visible to you or members of the organization in which the repository is located. Change a repository to private as shown in the following:
-
-```python
->>> from huggingface_hub import update_repo_visibility
->>> update_repo_visibility(name=REPO_NAME, private=True)
-```
-
-## Repository 
-
-The `Repository` class allows you to push models or other repositories to the Hub. `Repository` is a wrapper over Git and Git-LFS methods, so make sure you have Git-LFS installed (see [here](https://git-lfs.github.com/) for installation instructions) and set up before you begin. The `Repository` class should feel familiar if you are already familiar with common Git commands. 
-
-### Clone a repository
-
-The `clone_from` parameter clones a repository from a Hugging Face model ID to a directory specified by the `local_dir` argument:
-
-```python
->>> repo = Repository(local_dir="w2v2", clone_from="facebook/wav2vec2-large-960h-lv60")
-```
-
-`clone_from` can also clone a repository from a specified directory using a URL (if you are working offline, this parameter should be `None`):
-
-```python
->>> repo = Repository(local_dir="huggingface-hub", clone_from="https://github.com/huggingface/huggingface_hub")
-```
-
-Easily combine the `clone_from` parameter with `create_repo` to create and clone a repository:
-
-```python
->>> repo_url = create_repo(repo_id="repo_name")
->>> repo = Repository(local_dir="repo_local_path", clone_from=repo_url)
-```
-
-### Using a local clone
-
-Instantiate a `Repository` object with a path to a local Git clone or repository:
-
-```python
->>> from huggingface_hub import Repository
->>> repo = Repository(local_dir="<path>/<to>/<folder>")
-```
-
-### Commit and push to a cloned repository
-
-If you want to commit or push to a cloned repository that belongs to you or your organizations:
-
-1. Log in to your Hugging Face account with the following command:
-
-   ```bash
-   huggingface-cli login
-   ```
-
-2. Alternatively, if you prefer working from a Jupyter or Colaboratory notebook, login with `notebook_login`:
-
-   ```python
-   >>> from huggingface_hub import notebook_login
-   >>> notebook_login()
-   ```
-
-   `notebook_login` will launch a widget in your notebook from which you can enter your Hugging Face credentials.
-
-3. Instantiate a `Repository` class:
-   
-   ```python
-   >>> repo = Repository(local_dir="my-model", clone_from="<user>/<model_id>")
-   ```
-
-You can also attribute a Git username and email to a cloned repository by specifying the `git_user` and `git_email` parameters. When users commit to that repository, Git will be aware of the commit author.
-
-```python
->>> repo = Repository(
-...   "my-dataset", 
-...   clone_from="<user>/<dataset_id>", 
-...   use_auth_token=True, 
-...   repo_type="dataset",
-...   git_user="MyName",
-...   git_email="me@cool.mail"
-... )
-```
-
-### Branch
-
-Switch between branches with `git_checkout`. For example, if you want to switch from `branch1` to `branch2`:
-
-```python
->>> repo = Repository(local_dir="huggingface-hub", clone_from="<user>/<dataset_id>", revision='branch1')
->>> repo.git_checkout("branch2")
-```
-
-### Pull
-
-Update a current local branch with `git_pull`:
-
-```python
->>> repo.git_pull()
-```
-
-Set `rebase=True` if you want your local commits to occur after your branch is updated with the new commits from the remote:
-
-```python
->>> repo.git_pull(rebase=True)
-```
-
-### `commit` context manager
-
-The `commit` context manager is a simple utility that handles four of the most common Git commands: pull, add, commit, and push. `git-lfs` automatically tracks any file larger than 10MB. In the following example, the `commit` context manager:
+The `commit` context manager handles four of the most common Git commands: pull, add, commit, and push. `git-lfs` automatically tracks any file larger than 10MB. In the following example, the `commit` context manager:
 
 1. Pulls from the `text-files` repository.
 2. Adds a change made to `file.txt`.
@@ -232,7 +36,7 @@ Set `blocking=False` if you would like to push your commits asynchronously. Non-
 >>> with repo.commit(commit_message="My cool model :)", blocking=False)
 ```
 
-You can check the status of your push with the `command_queue` property:
+You can check the status of your push with the `command_queue` method:
 
 ```python
 >>> last_command = repo.command_queue[-1]
@@ -242,7 +46,7 @@ You can check the status of your push with the `command_queue` property:
 # -> Non-zero code indicates the error code if there was an error.
 ```
 
-When `blocking=False`, commands are tracked, and your script will only exit when all pushes are completed, even if other errors occur in your script. Some additional useful commands for checking the status of a push include:
+When `blocking=False`, commands are tracked, and your script will only exit when all pushes are completed even if other errors occur in your script. Some additional useful commands for checking the status of a push include:
 
 ```python
 # Inspect an error.
@@ -255,18 +59,18 @@ When `blocking=False`, commands are tracked, and your script will only exit when
 >>> last_command.failed
 ```
 
-### `push_to_hub`
+## push_to_hub
 
-The `Repository` class also has a `push_to_hub` utility to add files, make a commit, and push them to a repository. Unlike the `commit` context manager, `push_to_hub` requires you to pull from a repository first, save the files, and then call `push_to_hub`.
+The [`Repository`] class also has a [`push_to_hub`] function to add files, make a commit, and push them to a repository. Unlike the `commit` context manager, [`push_to_hub`] requires you to pull from a repository first, save the files, and then call [`push_to_hub`].
 
 ```python
 >>> repo.git_pull()
 >>> repo.push_to_hub(commit_message="Commit my-awesome-file to the Hub")
 ```
 
-## Upload very large files
+## Upload with Git LFS
 
-For huge files (>5GB), you need to install a custom transfer agent for Git-LFS:
+For huge files (>5GB), you need to install a custom transfer agent for Git LFS:
 
 ```bash
 huggingface-cli lfs-enable-largefiles

--- a/docs/source/how-to-upstream.mdx
+++ b/docs/source/how-to-upstream.mdx
@@ -3,8 +3,25 @@
 Sharing your files and work is a very important aspect of the Hub. The `huggingface_hub` uses a Git-based workflow to upload files to the Hub. You can use these functions independently or integrate them into your own library so it is more convenient for your users to interact with the Hub. This guide will show you how to:
 
 * Push files with a `commit` context manager.
-* Push files with the [`push_to_hub`] function.
+* Push files with the [`~Repository.push_to_hub`] function.
 * Upload very large files with [Git LFS](https://git-lfs.github.com/).
+
+Whenever you want to upload files to the Hub, you need to log in to your Hugging Face account:
+
+1. Log in to your Hugging Face account with the following command:
+
+   ```bash
+   huggingface-cli login
+   ```
+
+2. Alternatively, if you prefer working from a Jupyter or Colaboratory notebook, login with [`notebook_login`]:
+
+   ```python
+   >>> from huggingface_hub import notebook_login
+   >>> notebook_login()
+   ```
+
+   [`notebook_login`] will launch a widget in your notebook from which you can enter your Hugging Face credentials.
 
 ## commit context manager
 
@@ -61,7 +78,7 @@ When `blocking=False`, commands are tracked, and your script will only exit when
 
 ## push_to_hub
 
-The [`Repository`] class also has a [`push_to_hub`] function to add files, make a commit, and push them to a repository. Unlike the `commit` context manager, [`push_to_hub`] requires you to pull from a repository first, save the files, and then call [`push_to_hub`].
+The [`Repository`] class also has a [`~Repository.push_to_hub`] function to add files, make a commit, and push them to a repository. Unlike the `commit` context manager, [`~Repository.push_to_hub`] requires you to pull from a repository first, save the files, and then call [`~Repository.push_to_hub`].
 
 ```python
 >>> repo.git_pull()

--- a/docs/source/how-to-upstream.mdx
+++ b/docs/source/how-to-upstream.mdx
@@ -85,14 +85,14 @@ The [`Repository`] class also has a [`~Repository.push_to_hub`] function to add 
 >>> repo.push_to_hub(commit_message="Commit my-awesome-file to the Hub")
 ```
 
-However, if you aren't ready to push a file yet, you can still use [`git_add`] and [`git_commit`] to add and commit your file:
+However, if you aren't ready to push a file yet, you can still use [`~Repository.git_add`] and [`~Repository.git_commit`] to add and commit your file:
 
 ```py
 >>> repo.git_add("path/to/file")
 >>> repo.git_commit(commit_message="add my first model config file :)")
 ```
 
-Once you're ready, you can push your file to your repository with [`git_push`]:
+Once you're ready, you can push your file to your repository with [`~Repository.git_push`]:
 
 ```py
 >>> repo.git_push()

--- a/docs/source/how-to-upstream.mdx
+++ b/docs/source/how-to-upstream.mdx
@@ -1,6 +1,6 @@
 # Upload files to the Hub
 
-Sharing your files and work is a very important aspect of the Hub. The `huggingface_hub` uses a Git-based workflow to upload files to the Hub. You can use these functions independently or integrate them into your own library so it is more convenient for your users to interact with the Hub. This guide will show you how to:
+Sharing your files and work is a very important aspect of the Hub. The `huggingface_hub` uses a Git-based workflow to upload files to the Hub. You can use these functions independently or integrate them into your own library, making it more convenient for your users to interact with the Hub. This guide will show you how to:
 
 * Push files with a `commit` context manager.
 * Push files with the [`~Repository.push_to_hub`] function.
@@ -33,6 +33,7 @@ The `commit` context manager handles four of the most common Git commands: pull,
 4. Pushes the change to the `text-files` repository.
 
 ```python
+>>> from huggingface_hub import Repository
 >>> with Repository(local_dir="text-files", clone_from="<user>/text-files").commit(commit_message="My first file :)"):
 ...     with open("file.txt", "w+") as f:
 ...         f.write(json.dumps({"hey": 8}))
@@ -58,12 +59,17 @@ You can check the status of your push with the `command_queue` method:
 ```python
 >>> last_command = repo.command_queue[-1]
 >>> last_command.status
-# -> -1 indicates the push is ongoing.
-# -> 0 indicates the push has completed successfully.
-# -> Non-zero code indicates the error code if there was an error.
 ```
 
-When `blocking=False`, commands are tracked, and your script will only exit when all pushes are completed even if other errors occur in your script. Some additional useful commands for checking the status of a push include:
+Refer to the table below for the possible statuses:
+
+| Status   | Description                          |
+|----------|--------------------------------------|
+| -1       | The push is ongoing.                 |
+| 0        | The push has completed successfully. |
+| Non-zero | An error has occurred.               |
+
+When `blocking=False`, commands are tracked, and your script will only exit when all pushes are completed, even if other errors occur in your script. Some additional useful commands for checking the status of a push include:
 
 ```python
 # Inspect an error.
@@ -81,6 +87,7 @@ When `blocking=False`, commands are tracked, and your script will only exit when
 The [`Repository`] class also has a [`~Repository.push_to_hub`] function to add files, make a commit, and push them to a repository. Unlike the `commit` context manager, [`~Repository.push_to_hub`] requires you to pull from a repository first, save the files, and then call [`~Repository.push_to_hub`].
 
 ```python
+>>> from huggingface_hub import Repository
 >>> repo.git_pull()
 >>> repo.push_to_hub(commit_message="Commit my-awesome-file to the Hub")
 ```

--- a/docs/source/package_reference/inference_api.mdx
+++ b/docs/source/package_reference/inference_api.mdx
@@ -1,0 +1,5 @@
+# Inference API
+
+The `huggingface_hub` library allows users to programmatically access the Inference API. For more information about the Accelerated Inference API, please refer to the documentation [here](https://huggingface.co/docs/api-inference/index).
+
+[[autodoc]] InferenceApi


### PR DESCRIPTION
As discussed in #818, this PR de-emphasizes integrating download/upload functions into third-party libraries. The guides simply tell a user how to use these functions. We can follow this up with an integration guide that provides more value to library maintainers/developers who want to integrate these functions into their libraries. This PR also splits the old upstream utility doc into:

1. How to upload files (`commit` context manager, `push_to_hub` and Git LFS).
2. How to create and manage a repository (`create_repo`, `delete_repo` `update_repo_visibility`, the `Repository` class and its associated git-commands). ~This page is still a work in progress :)~
3. Documents other `Repository` commands like `pull`, `add`, `commit` and `push`. I think it's nice for users to see they can manually do this if they want to instead of using the `commit` context manager or `push_to_hub`.
4. Rename some section headers so it's easier for users to find what they're looking for. Users might not know what `snapshot_download` is when they scan the headers.
5. Adds `InferenceApi` to the API Reference.

Something I would appreciate feedback on:

Do we still want to keep the `list_model/dataset(filter=...)` and `model/dataset_info` sections? It looks like you can do the same thing more efficiently with what is currently in the Searching the Hub doc.

### To do:

- [x] Finish doc on how to create and manage a repository.