### PR TITLE
Add update metadata

### DIFF
--- a/src/huggingface_hub/repocard.py
+++ b/src/huggingface_hub/repocard.py
@@ -110,6 +110,25 @@ def metadata_update(
     overwrite: bool = False,
     token: str = None,
 ) -> None:
+    """
+    Updates the metadata in the README.md of a repository on the Hugging Face Hub.
+
+    Args:
+        repo_id (`str`):
+            The name of the repository.
+        metadata (`dict`):
+            A dictionary containing the metadata to be updated.
+        repo_type (`str`, *optional*):
+            Set to `"dataset"` or `"space"` if updating to a dataset or space,
+            `None` or `"model"` if updating to a model. Default is `None`.
+        overwrite (`bool`, *optional*):
+            If set to `True` an existing field can be overwritten, otherwise
+            attempting to overwrite an existing field will cause an error.
+            Default is `False`.
+        token (`str`, *optional*):
+            The Hugging Face authentication token
+    """
+
     filepath = hf_hub_download(
         repo_id,
         filename="README.md",

--- a/tests/test_repocard.py
+++ b/tests/test_repocard.py
@@ -13,14 +13,26 @@
 # limitations under the License.
 import os
 import shutil
+import time
 import unittest
 from pathlib import Path
 
+import pytest
+
+import yaml
 from huggingface_hub.constants import REPOCARD_NAME
-from huggingface_hub.repocard import metadata_eval_result, metadata_load, metadata_save
+from huggingface_hub.hf_api import HfApi
+from huggingface_hub.repocard import (
+    metadata_eval_result,
+    metadata_load,
+    metadata_save,
+    metadata_update,
+)
+from huggingface_hub.repository import Repository
 from huggingface_hub.utils import logging
 
-from .testing_utils import set_write_permission_and_retry
+from .testing_constants import ENDPOINT_STAGING, TOKEN, USER
+from .testing_utils import retry_endpoint, set_write_permission_and_retry
 
 
 ROUND_TRIP_MODELCARD_CASE = """
@@ -97,6 +109,8 @@ REPOCARD_DIR = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), "fixtures/repocard"
 )
 
+REPO_NAME = "dummy-hf-hub-{}".format(int(time.time() * 10e3))
+
 
 class RepocardTest(unittest.TestCase):
     def setUp(self):
@@ -159,3 +173,142 @@ class RepocardTest(unittest.TestCase):
         metadata_save(filepath, data)
         content = filepath.read_text().splitlines()
         self.assertEqual(content, DUMMY_MODELCARD_EVAL_RESULT.splitlines())
+
+
+class RepocardUpdateTest(unittest.TestCase):
+    _api = HfApi(endpoint=ENDPOINT_STAGING)
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Share this valid token in all tests below.
+        """
+        cls._token = TOKEN
+        cls._api.set_access_token(TOKEN)
+
+    @retry_endpoint
+    def setUp(self) -> None:
+        if os.path.exists(REPO_NAME):
+            shutil.rmtree(REPO_NAME, onerror=set_write_permission_and_retry)
+        logger.info(f"Does {REPO_NAME} exist: {os.path.exists(REPO_NAME)}")
+        self.repo = Repository(
+            REPO_NAME,
+            clone_from=f"{USER}/{REPO_NAME}",
+            use_auth_token=self._token,
+            git_user="ci",
+            git_email="ci@dummy.com",
+        )
+
+        with self.repo.commit("Add README to main branch"):
+            with open("README.md", "w+") as f:
+                f.write(DUMMY_MODELCARD_EVAL_RESULT)
+
+        self.existing_metadata = yaml.safe_load(
+            DUMMY_MODELCARD_EVAL_RESULT.strip().strip("---")
+        )
+
+    def tearDown(self) -> None:
+        self._api.delete_repo(repo_id=f"{REPO_NAME}", token=self._token)  # {USER}/
+        shutil.rmtree(REPO_NAME)
+
+    def test_update_dataset_name(self):
+        new_datasets_data = {"datasets": "['test/test_dataset']"}
+        metadata_update(f"{USER}/{REPO_NAME}", new_datasets_data, token=self._token)
+
+        self.repo.git_pull()
+        updated_metadata = metadata_load(f"{REPO_NAME}/README.md")
+        expected_metadata = self.existing_metadata.copy()
+        expected_metadata.update(new_datasets_data)
+        self.assertDictEqual(updated_metadata, expected_metadata)
+
+    def test_update_existing_result_with_overwrite(self):
+        new_metadata = self.existing_metadata.copy()
+        new_metadata["model-index"][0]["results"][0]["metrics"][0][
+            "value"
+        ] = 0.2862102282047272
+        metadata_update(
+            f"{USER}/{REPO_NAME}", new_metadata, token=self._token, overwrite=True
+        )
+
+        self.repo.git_pull()
+        updated_metadata = metadata_load(f"{REPO_NAME}/README.md")
+        self.assertDictEqual(updated_metadata, new_metadata)
+
+    def test_update_existing_result_without_overwrite(self):
+        new_metadata = self.existing_metadata.copy()
+        new_metadata["model-index"][0]["results"][0]["metrics"][0][
+            "value"
+        ] = 0.2862102282047272
+
+        with pytest.raises(
+            ValueError,
+            match="You passed a new value for the existing metric 'Accuracy'. Set `overwrite=True` to overwrite existing metrics.",
+        ):
+            metadata_update(
+                f"{USER}/{REPO_NAME}", new_metadata, token=self._token, overwrite=False
+            )
+
+    def test_update_existing_field_without_overwrite(self):
+        new_datasets_data = {"datasets": "['test/test_dataset']"}
+        metadata_update(f"{USER}/{REPO_NAME}", new_datasets_data, token=self._token)
+
+        with pytest.raises(
+            ValueError,
+            match="You passed a new value for the existing meta data field 'datasets'. Set `overwrite=True` to overwrite existing metadata.",
+        ):
+            new_datasets_data = {"datasets": "['test/test_dataset_2']"}
+            metadata_update(
+                f"{USER}/{REPO_NAME}",
+                new_datasets_data,
+                token=self._token,
+                overwrite=False,
+            )
+
+    def test_update_new_result_existing_dataset(self):
+        new_result = metadata_eval_result(
+            model_pretty_name="RoBERTa fine-tuned on ReactionGIF",
+            task_pretty_name="Text Classification",
+            task_id="text-classification",
+            metrics_pretty_name="Recall",
+            metrics_id="recall",
+            metrics_value=0.7762102282047272,
+            dataset_pretty_name="ReactionGIF",
+            dataset_id="julien-c/reactiongif",
+        )
+
+        metadata_update(
+            f"{USER}/{REPO_NAME}", new_result, token=self._token, overwrite=False
+        )
+
+        expected_metadata = self.existing_metadata.copy()
+        expected_metadata["model-index"][0]["results"][0]["metrics"].append(
+            new_result["model-index"][0]["results"][0]["metrics"][0]
+        )
+
+        self.repo.git_pull()
+        updated_metadata = metadata_load(f"{REPO_NAME}/README.md")
+        self.assertDictEqual(updated_metadata, expected_metadata)
+
+    def test_update_new_result_new_dataset(self):
+        new_result = metadata_eval_result(
+            model_pretty_name="RoBERTa fine-tuned on ReactionGIF",
+            task_pretty_name="Text Classification",
+            task_id="text-classification",
+            metrics_pretty_name="Accuracy",
+            metrics_id="accuracy",
+            metrics_value=0.2662102282047272,
+            dataset_pretty_name="ReactionJPEG",
+            dataset_id="julien-c/reactionjpeg",
+        )
+
+        metadata_update(
+            f"{USER}/{REPO_NAME}", new_result, token=self._token, overwrite=False
+        )
+
+        expected_metadata = self.existing_metadata.copy()
+        expected_metadata["model-index"][0]["results"].append(
+            new_result["model-index"][0]["results"][0]
+        )
+        self.repo.git_pull()
+        updated_metadata = metadata_load(f"{REPO_NAME}/README.md")
+        self.assertDictEqual(updated_metadata, expected_metadata)


### PR DESCRIPTION
This PR adds a `metadata_update` function that allows the user to update the metadata in a repository on the hub. The function accepts a dict with metadata (following the same pattern as the YAML in the README) and behaves as follows for all top level fields except `model-index`:

- if field in existing README does not exist it is added.
- if it exists an error is thrown except if `overwrite=True` is passed as a safety guard.

For `model-index` the behaviour is more nuanced:

- if an entry with the same `task` and `dataset` exist, then
    - if the same metric type/name does not exist the metric is appended to the list
    - if the same metric type/name exists the value is overwritten (given `overwrite=True`)
- if an entry with the same `task` and `dataset` does not exist, the result is appended to the results

For reference this is an example of a model's metadata structure as a dictionary:
```Python
{'datasets': ['lvwerra/codeparrot-clean-train'],
 'language': 'code',
 'model-index': [{'name': 'codeparrot',
                  'results': [{'dataset': {'name': 'HumanEval',
                                           'type': 'openai_humaneval'},
                               'metrics': [{'name': 'pass@1',
                                            'type': 'code_eval',
                                            'value': 3.99},
                                           {'name': 'pass@10',
                                            'type': 'code_eval',
                                            'value': 8.69},
                                           {'name': 'pass@100',
                                            'type': 'code_eval',
                                            'value': 17.88}],
                               'task': {'name': 'Code Generation',
                                        'type': 'code-generation'}}]}],
 'tags': ['code', 'gpt2', 'generation'],
 'widget': [{'example_title': 'Transformers',
             'text': 'from transformer import'},
            {'example_title': 'Hello World!',
             'text': 'def print_hello_world():\n\t'},
            {'example_title': 'File size',
             'text': 'def get_file_size(filepath):'},
            {'example_title': 'Numpy', 'text': 'import numpy as'}]}
```

One minor issue I found is that I need to use `force_download=True` for the tests to pass as otherwise the `hf_hub_download` uses the cached but outdated version of the README even if the README has been updated on the remote. cc @LysandreJik 
https://github.com/huggingface/huggingface_hub/blob/a191950c1b21c0f709cfe012e283d5371c4ce9eb/src/huggingface_hub/repocard.py#L137
This feature will be used for https://github.com/huggingface/evaluate/issues/6 and closes #835.