### PR TITLE
Update landing page

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -1,6 +1,6 @@
 - sections:
   - local: index
-    title: 🤗 Hugging Face Hub Python Wrapper
+    title: Home
   - local: how-to-downstream
     title: How to download files from the hub
   - local: how-to-upstream

--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -13,11 +13,11 @@ repository, and upload files to the Hub.
 
 Keep reading to learn even more about how to:
 
-- Delete and clone a repository, and create and update a branch.
+- [Delete and clone a repository, and create and update a branch](how-to-manage).
 - [Download an entire repository and use regex matching to filter and download specific
   files](how-to-downstream).
-- [Pull files from a repository before adding, committing, and pushing to the
-  Hub](how-to-upstream).
+- [Upload your files with a context manager or use a helper to push files to a remote
+  repository](how-to-upstream).
 - [Search thousands of models and datasets on the Hub with specific filters and
   parameters to only return the best results](searching-the-hub).
 - [Access the Inference API for accelerated inference](how-to-inference).

--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -7,16 +7,32 @@ machine learning apps hosted on the Hub. You can also create and share your own 
 and datasets with the community. The `huggingface_hub` library provides a simple way to
 do all these things with Python.
 
-Read the quick start guide to get up and running with the `huggingface_hub` library. You
-will learn how to download files from the Hub, create a repository, and upload files to
-the Hub.
+Read the [quick start guide](quick-start) to get up and running with the
+`huggingface_hub` library. You will learn how to download files from the Hub, create a
+repository, and upload files to the Hub.
 
 Keep reading to learn even more about how to:
 
 - Delete and clone a repository, and create and update a branch.
-- Download an entire repository and use regex matching to filter and download specific
-  files.
-- Pull files from a repository before adding, committing, and pushing to the Hub.
-- Search thousands of models and datasets on the Hub with specific filters and
-  parameters to only return the best results.
-- Access the Inference API for accelerated inference.
+- [Download an entire repository and use regex matching to filter and download specific
+  files](how-to-downstream).
+- [Pull files from a repository before adding, committing, and pushing to the
+  Hub](how-to-upstream).
+- [Search thousands of models and datasets on the Hub with specific filters and
+  parameters to only return the best results](searching-the-hub).
+- [Access the Inference API for accelerated inference](how-to-inference).
+
+## Contribute
+
+All contributions to the `huggingface_hub` are welcomed and equally valued! 🤗 Besides
+adding or fixing existing issues in the code, you can also help improve the
+documentation by making sure it is accurate and up-to-date, help answer questions on
+issues, and request new features you think will improve the library. Take a look at the
+[contribution
+guide](https://github.com/huggingface/huggingface_hub/blob/main/CONTRIBUTING.md) to
+learn more about how to submit a new issue or feature request, how to submit a pull
+request, and how to test your contributions to make sure everything works as expected.
+
+Contributors should also be respectful of our [code of
+conduct](https://github.com/huggingface/huggingface_hub/blob/main/CODE_OF_CONDUCT.md) to
+create an inclusive and welcoming collaborative space for everyone.

--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -1,76 +1,22 @@
-# `huggingface_hub`
+# Hub client library
 
-## Welcome to the Hub repo! Here you can find all the open source things related to the Hugging Face Hub.
+The `huggingface_hub` library allows you to interact with the [Hugging Face
+Hub](https://hf.co), a machine learning platform for creators and collaborators.
+Discover pre-trained models and datasets for your projects or play with the hundreds of
+machine learning apps hosted on the Hub. You can also create and share your own models
+and datasets with the community. The `huggingface_hub` library provides a simple way to
+do all these things with Python.
 
-<p align="center">
-	<img alt="Build" src="https://github.com/huggingface/huggingface_hub/workflows/Python%20tests/badge.svg">
-	<a href="https://github.com/huggingface/huggingface_hub/blob/master/LICENSE">
-		<img alt="GitHub" src="https://img.shields.io/github/license/huggingface/huggingface_hub.svg?color=blue">
-	</a>
-	<a href="https://github.com/huggingface/huggingface_hub/releases">
-		<img alt="GitHub release" src="https://img.shields.io/github/release/huggingface/huggingface_hub.svg">
-	</a>
-</p>
+Read the quick start guide to get up and running with the `huggingface_hub` library. You
+will learn how to download files from the Hub, create a repository, and upload files to
+the Hub.
 
-What can you find in this repo?
+Keep reading to learn even more about how to:
 
-* [`huggingface_hub`](https://github.com/huggingface/huggingface_hub/tree/main/src/huggingface_hub), a client library to download and publish on the Hugging Face Hub as well as extracting useful information from there.
-* [`api-inference-community`](https://github.com/huggingface/huggingface_hub/tree/main/api-inference-community), the Inference API for open source machine learning libraries.
-* [`js`](https://github.com/huggingface/huggingface_hub/tree/main/js), the open sourced widgets that allow people to try out the models in the browser.
-  * [`interfaces`](https://github.com/huggingface/huggingface_hub/tree/main/js/src/lib/interfaces), Typescript definition files for the Hugging Face Hub.
-* [`docs`](https://github.com/huggingface/huggingface_hub/tree/main/docs), containing the official [Hugging Face Hub documentation](https://hf.co/docs).
-
-## The `huggingface_hub` client library
-
-This library allows anyone to work with the Hub repositories: you can clone them, create them and upload your models to them. On top of this, the library also offers methods to access information from the Hub. For example, listing all models that meet specific criteria or get all the files from a specific repo. You can find the library implementation [here](https://github.com/huggingface/huggingface_hub/tree/main/src/huggingface_hub).
-
-<br>
-
-## Integrating to the Hub.
-
-We're partnering with cool open source ML libraries to provide free model hosting and versioning. You can find the existing integrations [here](https://huggingface.co/docs/hub/libraries).
-
-The advantages are:
-
-- Free model hosting for libraries and their users.
-- Built-in file versioning, even with very large files, thanks to a git-based approach.
-- Hosted inference API for all models publicly available.
-- In-browser widgets to play with the uploaded models.
-- Anyone can upload a new model for your library, they just need to add the corresponding tag for the model to be discoverable.
-- Fast downloads! We use Cloudfront (a CDN) to geo-replicate downloads so they're blazing fast from anywhere on the globe.
-- Usage stats and more features to come.
-
-If you would like to integrate your library, feel free to open an issue to begin the discussion. We wrote a [step-by-step guide](https://huggingface.co/docs/hub/adding-a-library) with ❤️ showing how to do this integration.
-
-<br>
-
-## Inference API integration into the Hugging Face Hub
-
-In order to get a functional Inference API on the Hub for your models (and thus, cool working widgets!) check out this [doc](https://github.com/huggingface/huggingface_hub/tree/main/api-inference-community). There is a docker image for each library. Within the image, you can find the implementation for supported pipelines for the given library.
-
-<br>
-
-
-## Widgets
-
-All our widgets are open-sourced. Feel free to propose and implement widgets. You can try all of them out [here](https://huggingface-widgets.netlify.app/).
-
-
-<br>
-
-## Code Snippets
-
-We'll implement a few tweaks to improve the UX for your models on the website – let's use [Asteroid](https://github.com/asteroid-team/asteroid) as an example.
-
-Model authors add an `asteroid` tag to their model card and they get the advantages of model versioning built-in
-
-![asteroid-model](docs/assets/asteroid_repo.png)
-
-We add a custom "Use in Asteroid" button. When clicked, you get a library-specific code sample that you'll be able to specify. 🔥
-
-![asteroid-code-sample](docs/assets/asteroid_snippet.png)
-
-
-<br>
-
-## Feedback (feature requests, bugs, etc.) is super welcome 💙💚💛💜♥️🧡
+- Delete and clone a repository, and create and update a branch.
+- Download an entire repository and use regex matching to filter and download specific
+  files.
+- Pull files from a repository before adding, committing, and pushing to the Hub.
+- Search thousands of models and datasets on the Hub with specific filters and
+  parameters to only return the best results.
+- Access the Inference API for accelerated inference.


### PR DESCRIPTION
This PR updates `index.md` to focus only on the `huggingface_hub` library and removes mentions of the widgets and community API inference. This page provides: 

- A brief overview of what the Hub is and how the `huggingface_hub` is related to the Hub and what it can do. I think there may be some potential for confusion from users over the naming of the Hub (as a product) and `huggingface_hub` (as a library), so please let me know if I've made this distinction clear enough here!
- A lot of guardrails that will help users down the right path and find what they are looking for. This ensures a user can choose their topic and then find a resource to help them accomplish their task. Once we've merged the other PRs, I can add the links in :)

I didn't mention integrating third-party libraries yet since we don't really have anything concrete yet. We can update the landing page once we have something (next on my to-do list!).