### PR TITLE
Keras: Saving history in a JSON file

### DIFF
--- a/src/huggingface_hub/keras_mixin.py
+++ b/src/huggingface_hub/keras_mixin.py
@@ -44,8 +44,8 @@ def _parse_model_history(model, save_directory):
     if model.history is not None:
         if model.history.history != {}:
             path = os.path.join(save_directory, "history.json")
-            with open(path, "w") as f:
-                json.dump(model.history.history, f)
+            with open(path, "w", encoding="utf-8") as f:
+                json.dump(model.history.history, f, indent=2, sort_keys=True)
             lines = []
             logs = model.history.history
             num_epochs = len(logs["loss"])

--- a/src/huggingface_hub/keras_mixin.py
+++ b/src/huggingface_hub/keras_mixin.py
@@ -39,10 +39,13 @@ def _extract_hyperparameters_from_keras(model):
     return hyperparameters
 
 
-def _parse_model_history(model):
+def _parse_model_history(model, save_directory):
     lines = None
     if model.history is not None:
         if model.history.history != {}:
+            path = os.path.join(save_directory, "history.json")
+            with open(path, "w") as f:
+                json.dump(model.history.history, f)
             lines = []
             logs = model.history.history
             num_epochs = len(logs["loss"])
@@ -79,8 +82,8 @@ def _plot_network(model, save_directory):
     )
 
 
-def _write_metrics(model, model_card):
-    lines = _parse_model_history(model)
+def _write_metrics(model, model_card, save_directory):
+    lines = _parse_model_history(model, save_directory)
     if lines is not None:
         model_card += "\n| Epochs |"
 
@@ -128,7 +131,7 @@ def _create_model_card(
         )
         model_card += "\n"
     model_card += "\n ## Training Metrics\n"
-    model_card = _write_metrics(model, model_card)
+    model_card = _write_metrics(model, model_card, repo_dir)
     if plot_model and os.path.exists(f"{repo_dir}/model.png"):
         model_card += "\n ## Model Plot\n"
         model_card += "\n<details>"

--- a/tests/test_keras_integration.py
+++ b/tests/test_keras_integration.py
@@ -225,7 +225,8 @@ class HubKerasSequentialTest(HubMixingTestKeras):
         self.assertIn("keras_metadata.pb", files)
         self.assertIn("model.png", files)
         self.assertIn("README.md", files)
-        self.assertEqual(len(files), 6)
+        self.assertIn("history.json", files)
+        self.assertEqual(len(files), 7)
 
     def test_save_pretrained_optimizer_state(self):
         REPO_NAME = repo_name("save")
@@ -490,4 +491,4 @@ class HubKerasFunctionalTest(HubKerasSequentialTest):
 
         self.assertIn("saved_model.pb", files)
         self.assertIn("keras_metadata.pb", files)
-        self.assertEqual(len(files), 6)
+        self.assertEqual(len(files), 7)


### PR DESCRIPTION
This is a minor change that saves history as a JSON file, if history exists.
We check if history exists or not during parsing it to a markdown in `_parse_model_history()` so I handled it there not to write repetitive checks. It can be further improved inside, just wanted to keep them separately for the sake of readability. (will later refactor the whole mixin and card creation after sprint is done) This might not be the best choice ever so feel free to criticize.
Wrote a test to check if the file is there.