### PR TITLE
Add basic `upload_folder` feature

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -17,9 +17,9 @@ import re
 import subprocess
 import sys
 import warnings
-from pathlib import Path
 from io import BufferedIOBase, RawIOBase
 from os.path import expanduser
+from pathlib import Path
 from typing import IO, Dict, Iterable, List, Optional, Tuple, Union
 
 import requests
@@ -1880,7 +1880,7 @@ class HfApi:
         repo_type: Optional[str] = None,
         revision: Optional[str] = None,
         identical_ok: bool = True,
-        glob_pattern: Optional[str] = '**/*',
+        glob_pattern: Optional[str] = "**/*",
     ):
         path = Path(path)
 
@@ -1894,7 +1894,7 @@ class HfApi:
                 continue
 
             filepath_in_repo = Path(path_in_repo) / file.relative_to(path)
-        
+
             upload_file(
                 path_or_fileobj=str(file),
                 path_in_repo=filepath_in_repo.as_posix(),

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -581,14 +581,14 @@ class HfApiUploadFileTest(HfApiCommonTestWithLogin):
         REPO_NAME = repo_name("folder")
         self._api.create_repo(token=self._token, repo_id=REPO_NAME)
         try:
-            upload_dir = Path(self.tmp_dir) / 'data'
+            upload_dir = Path(self.tmp_dir) / "data"
             upload_dir.mkdir()
-            (upload_dir / 'a.txt').touch()
-            (upload_dir / 'b.txt').touch()
-            subdir = upload_dir / 'subdir'
+            (upload_dir / "a.txt").touch()
+            (upload_dir / "b.txt").touch()
+            subdir = upload_dir / "subdir"
             subdir.mkdir()
-            (subdir / 'c.txt').touch()
-            (subdir / 'd.py').touch()
+            (subdir / "c.txt").touch()
+            (subdir / "d.py").touch()
 
             self._api.upload_folder(
                 path=upload_dir,


### PR DESCRIPTION
As discussed in #497, here's a quick draft of a basic `upload_folder` that will sequentially upload files within a folder. It's not ideal by any means, but it could get the job done for many simple cases. 