### PR TITLE
Clickable link in huggingface-cli 

### DIFF
--- a/src/huggingface_hub/commands/user.py
+++ b/src/huggingface_hub/commands/user.py
@@ -167,7 +167,7 @@ class LoginCommand(BaseUserCommand):
         _|    _|  _|    _|  _|    _|  _|    _|    _|    _|    _|_|  _|    _|      _|        _|    _|  _|        _|
         _|    _|    _|_|      _|_|_|    _|_|_|  _|_|_|  _|      _|    _|_|_|      _|        _|    _|    _|_|_|  _|_|_|_|
 
-        To login, `huggingface_hub` now requires a token generated from https://huggingface.co/settings/tokens.
+        To login, `huggingface_hub` now requires a token generated from https://huggingface.co/settings/tokens .
         (Deprecated, will be removed in v0.3.0) To login with username and password instead, interrupt with Ctrl+C.
         """
         )


### PR DESCRIPTION
When invoking huggingface-cli login without active authentication, a helpful feedback message containing a link to the tokens page is given. The link however is followed immediately by a full stop . so that it lands on a 404 when clicked (macOS / "hyper" shell). This PR adds one space to avoid the false 404 and land on the right page.