### PR TITLE
ENH Keras Use table instead of dictionary for hyperparameters in model card

### DIFF
--- a/src/huggingface_hub/keras_mixin.py
+++ b/src/huggingface_hub/keras_mixin.py
@@ -28,7 +28,7 @@ if is_tf_available():
 
 
 def _create_hyperparameter_table(model):
-    """This function parses hyperparameter dictionary into a markdown table."""
+    """Parse hyperparameter dictionary into a markdown table."""
     if model.optimizer is not None:
         optimizer_params = model.optimizer.get_config()
         optimizer_params[


### PR DESCRIPTION
This PR turns hyperparameters dictionary to table on model card.
Before: https://huggingface.co/merve/model-card-example
After: https://huggingface.co/merve/hyperparam_table
![Ekran Resmi 2022-05-17 12 01 27](https://user-images.githubusercontent.com/53175384/168785867-95383d3c-c98e-449d-9cfc-1b8c736ec13a.png)
<img width="579" alt="Ekran Resmi 2022-05-17 12 01 49" src="https://user-images.githubusercontent.com/53175384/168785927-4abf8b39-c1e1-4321-b9b5-ebcb5f842a1d.png">
<img width="523" alt="Ekran Resmi 2022-05-17 12 02 28" src="https://user-images.githubusercontent.com/53175384/168786083-e23b99fa-2bf7-4961-854d-0de4397d543f.png">
(You can scroll for more hyperparams)
