### PR TITLE
Refine 404 errors

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -27,6 +27,6 @@
       title: Mixins & serialization methods
     - local: package_reference/inference_api
       title: Inference API
-    - local: package_reference/logging
-      title: Logging
+    - local: package_reference/utilities
+      title: Utilities
   title: "Reference"

--- a/docs/source/package_reference/utilities.mdx
+++ b/docs/source/package_reference/utilities.mdx
@@ -1,4 +1,6 @@
-# Controlling the logging of `huggingface_hub`
+# Utilities
+
+## Controlling the logging of `huggingface_hub`
 
 The `huggingface_hub` package exposes a `logging` utility to control the logging level of the package itself.
 You can import it as such:
@@ -40,9 +42,19 @@ under the hood.
 [[autodoc]] logging.disable_propagation
 [[autodoc]] logging.enable_propagation
 
-# Repo-specific helper methods
+### Repo-specific helper methods
 
 The methods exposed below are relevant when modifying modules from the `huggingface_hub` library itself.
 Using these shouldn't be necessary if you use `huggingface_hub` and you don't modify them.
 
 [[autodoc]] logging.get_logger
+
+## Custom errors
+
+See below for all custom errors thrown by different methods across the package.
+
+[[autodoc]] huggingface_hub.utils.RepositoryNotFoundError
+
+[[autodoc]] huggingface_hub.utils.RevisionNotFoundError
+
+[[autodoc]] huggingface_hub.utils.EntryNotFoundError

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -906,6 +906,13 @@ def hf_hub_download(
           if ETag cannot be determined.
         - [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
           if some parameter value is invalid
+        - [`~huggingface_hub.utils.RepositoryNotFoundError`]
+          If the repository to download from cannot be found. This may be because it doesn't exist,
+          or because it is set to `private` and you do not have access.
+        - [`~huggingface_hub.utils.RevisionNotFoundError`]
+          If the revision to download from cannot be found.
+        - [`~huggingface_hub.utils.EntryNotFoundError`]
+          If the file to download cannot be found.
 
     </Tip>
     """

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -437,7 +437,7 @@ def http_get(
     max_retries=0,
 ):
     """
-    Donwload remote file. Do not gobble up errors.
+    Donwload a remote file. Do not gobble up errors, and will return errors tailored to the Hugging Face Hub.
     """
     headers = copy.deepcopy(headers)
     if resume_size > 0:
@@ -493,6 +493,8 @@ def cached_download(
     Given a URL, this function looks for the corresponding file in the local
     cache. If it's not there, download it. Then return the path to the cached
     file.
+
+    Will raise errors tailored to the Hugging Face Hub.
 
     Args:
         url (`str`):

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -35,6 +35,7 @@ from .constants import (
 from .hf_api import HfFolder
 from .utils import logging
 from .utils._deprecation import _deprecate_positional_args
+from .utils._errors import _raise_for_status
 
 
 logger = logging.get_logger(__name__)
@@ -450,7 +451,7 @@ def http_get(
         timeout=timeout,
         max_retries=max_retries,
     )
-    r.raise_for_status()
+    _raise_for_status(r)
     content_length = r.headers.get("Content-Length")
     total = resume_size + int(content_length) if content_length is not None else None
     progress = tqdm(
@@ -592,7 +593,7 @@ def cached_download(
                 proxies=proxies,
                 timeout=etag_timeout,
             )
-            r.raise_for_status()
+            _raise_for_status(r)
             etag = r.headers.get("X-Linked-Etag") or r.headers.get("ETag")
             # We favor a custom header indicating the etag of the linked resource, and
             # we fallback to the regular etag header.

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -546,6 +546,13 @@ def cached_download(
           if ETag cannot be determined.
         - [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
           if some parameter value is invalid
+        - [`~huggingface_hub.utils.RepositoryNotFoundError`]
+          If the repository to download from cannot be found. This may be because it doesn't exist,
+          or because it is set to `private` and you do not have access.
+        - [`~huggingface_hub.utils.RevisionNotFoundError`]
+          If the revision to download from cannot be found.
+        - [`~huggingface_hub.utils.EntryNotFoundError`]
+          If the file to download cannot be found.
 
     </Tip>
     """

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1011,7 +1011,7 @@ def hf_hub_download(
                 proxies=proxies,
                 timeout=etag_timeout,
             )
-            r.raise_for_status()
+            _raise_for_status(r)
             commit_hash = r.headers[HUGGINGFACE_HEADER_X_REPO_COMMIT]
             if commit_hash is None:
                 raise OSError(

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -1181,6 +1181,18 @@ class HfApi:
 
         Returns:
             [`huggingface_hub.hf_api.ModelInfo`]: The model repository information.
+
+        <Tip>
+
+        Raises the following errors:
+
+            - [`~huggingface_hub.utils.RepositoryNotFoundError`]
+              If the repository to download from cannot be found. This may be because it doesn't exist,
+              or because it is set to `private` and you do not have access.
+            - [`~huggingface_hub.utils.RevisionNotFoundError`]
+              If the revision to download from cannot be found.
+
+        </Tip>
         """
         if token is None:
             token = HfFolder.get_token()
@@ -1227,6 +1239,18 @@ class HfApi:
 
         Returns:
             [`DatasetInfo`]: The dataset repository information.
+
+        <Tip>
+
+        Raises the following errors:
+
+            - [`~huggingface_hub.utils.RepositoryNotFoundError`]
+              If the repository to download from cannot be found. This may be because it doesn't exist,
+              or because it is set to `private` and you do not have access.
+            - [`~huggingface_hub.utils.RevisionNotFoundError`]
+              If the revision to download from cannot be found.
+
+        </Tip>
         """
         if token is None:
             token = HfFolder.get_token()
@@ -1270,6 +1294,18 @@ class HfApi:
 
         Returns:
             [`SpaceInfo`]: The space repository information.
+
+        <Tip>
+
+        Raises the following errors:
+
+            - [`~huggingface_hub.utils.RepositoryNotFoundError`]
+              If the repository to download from cannot be found. This may be because it doesn't exist,
+              or because it is set to `private` and you do not have access.
+            - [`~huggingface_hub.utils.RevisionNotFoundError`]
+              If the revision to download from cannot be found.
+
+        </Tip>
         """
         if token is None:
             token = HfFolder.get_token()
@@ -1313,6 +1349,18 @@ class HfApi:
         Returns:
             `Union[SpaceInfo, DatasetInfo, ModelInfo]`: The repository
             information.
+
+        <Tip>
+
+        Raises the following errors:
+
+            - [`~huggingface_hub.utils.RepositoryNotFoundError`]
+              If the repository to download from cannot be found. This may be because it doesn't exist,
+              or because it is set to `private` and you do not have access.
+            - [`~huggingface_hub.utils.RevisionNotFoundError`]
+              If the revision to download from cannot be found.
+
+        </Tip>
         """
         if repo_type is None or repo_type == "model":
             return self.model_info(
@@ -1529,6 +1577,16 @@ class HfApi:
             repo_type (`str`, *optional*):
                 Set to `"dataset"` or `"space"` if uploading to a dataset or
                 space, `None` or `"model"` if uploading to a model.
+
+        <Tip>
+
+        Raises the following errors:
+
+            - [`~huggingface_hub.utils.RepositoryNotFoundError`]
+              If the repository to download from cannot be found. This may be because it doesn't exist,
+              or because it is set to `private` and you do not have access.
+
+        </Tip>
         """
         name, organization = _validate_repo_id_deprecation(repo_id, name, organization)
 
@@ -1628,6 +1686,16 @@ class HfApi:
 
         Returns:
             The HTTP response in json.
+
+        <Tip>
+
+        Raises the following errors:
+
+            - [`~huggingface_hub.utils.RepositoryNotFoundError`]
+              If the repository to download from cannot be found. This may be because it doesn't exist,
+              or because it is set to `private` and you do not have access.
+
+        </Tip>
         """
         if repo_type not in REPO_TYPES:
             raise ValueError("Invalid repo type")
@@ -1689,6 +1757,15 @@ class HfApi:
             token (`str`, *optional*):
                 An authentication token (See https://huggingface.co/settings/token)
 
+        <Tip>
+
+        Raises the following errors:
+
+            - [`~huggingface_hub.utils.RepositoryNotFoundError`]
+              If the repository to download from cannot be found. This may be because it doesn't exist,
+              or because it is set to `private` and you do not have access.
+
+        </Tip>
         """
 
         token, name = self._validate_or_retrieve_token(token)
@@ -1783,6 +1860,11 @@ class HfApi:
               if the HuggingFace API returned an error
             - [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
               if some parameter value is invalid
+            - [`~huggingface_hub.utils.RepositoryNotFoundError`]
+              If the repository to download from cannot be found. This may be because it doesn't exist,
+              or because it is set to `private` and you do not have access.
+            - [`~huggingface_hub.utils.RevisionNotFoundError`]
+              If the revision to download from cannot be found.
 
         </Tip>
 
@@ -1911,6 +1993,13 @@ class HfApi:
               if the HuggingFace API returned an error
             - [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
               if some parameter value is invalid
+            - [`~huggingface_hub.utils.RepositoryNotFoundError`]
+              If the repository to download from cannot be found. This may be because it doesn't exist,
+              or because it is set to `private` and you do not have access.
+            - [`~huggingface_hub.utils.RevisionNotFoundError`]
+              If the revision to download from cannot be found.
+            - [`~huggingface_hub.utils.EntryNotFoundError`]
+              If the file to download cannot be found.
 
         </Tip>
 

--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -15,4 +15,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 
+from ._errors import EntryNotFoundError, RepositoryNotFoundError, RevisionNotFoundError
 from ._subprocess import run_subprocess

--- a/src/huggingface_hub/utils/_errors.py
+++ b/src/huggingface_hub/utils/_errors.py
@@ -1,0 +1,41 @@
+from requests import HTTPError
+
+
+class RepositoryNotFoundError(HTTPError):
+    """
+    Raised when trying to access a hf.co URL with an invalid repository name, or
+    with a private repo name the user does not have access to.
+    """
+
+
+class EntryNotFoundError(HTTPError):
+    """Raised when trying to access a hf.co URL with a valid repository and revision
+    but an invalid filename."""
+
+
+class RevisionNotFoundError(HTTPError):
+    """Raised when trying to access a hf.co URL with a valid repository but an invalid
+    revision."""
+
+
+def _raise_for_status(request):
+    """
+    Internal version of `request.raise_for_status()` that will refine a
+    potential HTTPError.
+    """
+    if "X-Error-Code" in request.headers:
+        error_code = request.headers["X-Error-Code"]
+        if error_code == "RepoNotFound":
+            raise RepositoryNotFoundError(
+                f"404 Client Error: Repository Not Found for url: {request.url}"
+            )
+        elif error_code == "EntryNotFound":
+            raise EntryNotFoundError(
+                f"404 Client Error: Entry Not Found for url: {request.url}"
+            )
+        elif error_code == "RevisionNotFound":
+            raise RevisionNotFoundError(
+                f"404 Client Error: Revision Not Found for url: {request.url}"
+            )
+
+    request.raise_for_status()

--- a/src/huggingface_hub/utils/_errors.py
+++ b/src/huggingface_hub/utils/_errors.py
@@ -67,4 +67,11 @@ def _raise_for_status(request):
                 f"404 Client Error: Entry Not Found for url: {request.url}"
             )
 
+    if request.status_code == 401:
+        # The repo was not found and the user is not Authenticated
+        raise RepositoryNotFoundError(
+            f"401 Client Error: Repository not found for url: {request.url}. "
+            "If the repo is private, make sure you are authenticated."
+        )
+
     request.raise_for_status()

--- a/src/huggingface_hub/utils/_errors.py
+++ b/src/huggingface_hub/utils/_errors.py
@@ -56,7 +56,8 @@ def _raise_for_status(request):
         error_code = request.headers["X-Error-Code"]
         if error_code == "RepoNotFound":
             raise RepositoryNotFoundError(
-                f"404 Client Error: Repository Not Found for url: {request.url}"
+                f"404 Client Error: Repository Not Found for url: {request.url}. "
+                "If the repo is private, make sure you are authenticated."
             )
         elif error_code == "RevisionNotFound":
             raise RevisionNotFoundError(
@@ -70,7 +71,7 @@ def _raise_for_status(request):
     if request.status_code == 401:
         # The repo was not found and the user is not Authenticated
         raise RepositoryNotFoundError(
-            f"401 Client Error: Repository not found for url: {request.url}. "
+            f"401 Client Error: Repository Not Found for url: {request.url}. "
             "If the repo is private, make sure you are authenticated."
         )
 

--- a/src/huggingface_hub/utils/_errors.py
+++ b/src/huggingface_hub/utils/_errors.py
@@ -16,6 +16,22 @@ class RepositoryNotFoundError(HTTPError):
     """
 
 
+class RevisionNotFoundError(HTTPError):
+    """
+    Raised when trying to access a hf.co URL with a valid repository but an invalid
+    revision.
+
+    Example:
+
+    ```py
+    >>> from huggingface_hub import hf_hub_download
+    >>> hf_hub_download('bert-base-cased', 'config.json', revision='<non-existant-revision>')
+    huggingface_hub.utils._errors.RevisionNotFoundError: 404 Client Error: Revision Not Found for url: <url>
+    ```
+
+    """
+
+
 class EntryNotFoundError(HTTPError):
     """
     Raised when trying to access a hf.co URL with a valid repository and revision
@@ -24,16 +40,11 @@ class EntryNotFoundError(HTTPError):
     Example:
 
     ```py
-    >>> from huggingface_hub import model_info
-    >>> model_info("<non_existant_repository>")
-    huggingface_hub.utils._errors.RepositoryNotFoundError: 404 Client Error: Repository Not Found for url: <url>
+    >>> from huggingface_hub import hf_hub_download
+    >>> hf_hub_download('bert-base-cased', '<non-existant-file>')
+    huggingface_hub.utils._errors.EntryNotFoundError: 404 Client Error: Entry Not Found for url: <url>
     ```
     """
-
-
-class RevisionNotFoundError(HTTPError):
-    """Raised when trying to access a hf.co URL with a valid repository but an invalid
-    revision."""
 
 
 def _raise_for_status(request):

--- a/src/huggingface_hub/utils/_errors.py
+++ b/src/huggingface_hub/utils/_errors.py
@@ -5,12 +5,30 @@ class RepositoryNotFoundError(HTTPError):
     """
     Raised when trying to access a hf.co URL with an invalid repository name, or
     with a private repo name the user does not have access to.
+
+    Example:
+
+    ```py
+    >>> from huggingface_hub import model_info
+    >>> model_info("<non_existant_repository>")
+    huggingface_hub.utils._errors.RepositoryNotFoundError: 404 Client Error: Repository Not Found for url: <url>
+    ```
     """
 
 
 class EntryNotFoundError(HTTPError):
-    """Raised when trying to access a hf.co URL with a valid repository and revision
-    but an invalid filename."""
+    """
+    Raised when trying to access a hf.co URL with a valid repository and revision
+    but an invalid filename.
+
+    Example:
+
+    ```py
+    >>> from huggingface_hub import model_info
+    >>> model_info("<non_existant_repository>")
+    huggingface_hub.utils._errors.RepositoryNotFoundError: 404 Client Error: Repository Not Found for url: <url>
+    ```
+    """
 
 
 class RevisionNotFoundError(HTTPError):
@@ -29,13 +47,13 @@ def _raise_for_status(request):
             raise RepositoryNotFoundError(
                 f"404 Client Error: Repository Not Found for url: {request.url}"
             )
-        elif error_code == "EntryNotFound":
-            raise EntryNotFoundError(
-                f"404 Client Error: Entry Not Found for url: {request.url}"
-            )
         elif error_code == "RevisionNotFound":
             raise RevisionNotFoundError(
                 f"404 Client Error: Revision Not Found for url: {request.url}"
+            )
+        elif error_code == "EntryNotFound":
+            raise EntryNotFoundError(
+                f"404 Client Error: Entry Not Found for url: {request.url}"
             )
 
     request.raise_for_status()

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -111,7 +111,7 @@ class CachedDownloadTests(unittest.TestCase):
         # Invalid model file.
         url = hf_hub_url("bert-base", filename="pytorch_model.bin")
         with self.assertRaisesRegex(
-            RepositoryNotFoundError, "404 Client Error: Repository Not Found"
+            RepositoryNotFoundError, "401 Client Error: Repository Not Found"
         ):
             _ = cached_download(url, legacy_cache_layout=True)
 

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -14,7 +14,6 @@
 
 import unittest
 
-import requests
 from huggingface_hub.constants import (
     CONFIG_NAME,
     PYTORCH_WEIGHTS_NAME,
@@ -25,6 +24,11 @@ from huggingface_hub.file_download import (
     filename_to_url,
     hf_hub_download,
     hf_hub_url,
+)
+from huggingface_hub.utils import (
+    EntryNotFoundError,
+    RepositoryNotFoundError,
+    RevisionNotFoundError,
 )
 
 from .testing_utils import (
@@ -86,7 +90,9 @@ class CachedDownloadTests(unittest.TestCase):
     def test_file_not_found(self):
         # Valid revision (None) but missing file.
         url = hf_hub_url(DUMMY_MODEL_ID, filename="missing.bin")
-        with self.assertRaisesRegex(requests.exceptions.HTTPError, "404 Client Error"):
+        with self.assertRaisesRegex(
+            EntryNotFoundError, "404 Client Error: Entry Not Found"
+        ):
             _ = cached_download(url, legacy_cache_layout=True)
 
     def test_revision_not_found(self):
@@ -96,8 +102,18 @@ class CachedDownloadTests(unittest.TestCase):
             filename=CONFIG_NAME,
             revision=DUMMY_MODEL_ID_REVISION_INVALID,
         )
-        with self.assertRaisesRegex(requests.exceptions.HTTPError, "404 Client Error"):
+        with self.assertRaisesRegex(
+            RevisionNotFoundError, "404 Client Error: Revision Not Found"
+        ):
             _ = cached_download(url, legacy_cache_layout=True)
+
+    def test_repo_not_found(self):
+        # Invalid model file.
+        url = hf_hub_url("bert-base", filename="pytorch_model.bin")
+        with self.assertRaisesRegex(
+            RepositoryNotFoundError, "404 Client Error: Repository Not Found"
+        ):
+            _ = cached_download(url)
 
     def test_standard_object(self):
         url = hf_hub_url(

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -113,7 +113,7 @@ class CachedDownloadTests(unittest.TestCase):
         with self.assertRaisesRegex(
             RepositoryNotFoundError, "404 Client Error: Repository Not Found"
         ):
-            _ = cached_download(url)
+            _ = cached_download(url, legacy_cache_layout=True)
 
     def test_standard_object(self):
         url = hf_hub_url(

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -304,9 +304,7 @@ class HfApiEndpointsTest(HfApiCommonTestWithLogin):
         # test for #751
         with pytest.raises(
             HTTPError,
-            match=(
-                "404 Client Error: Repository Not Found"
-            ),
+            match="404 Client Error: Repository Not Found",
         ):
             self._api.delete_repo("repo-that-does-not-exist", token=self._token)
 

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -305,8 +305,7 @@ class HfApiEndpointsTest(HfApiCommonTestWithLogin):
         with pytest.raises(
             HTTPError,
             match=(
-                "No model repo found matching __DUMMY_TRANSFORMERS_USER__/"
-                "repo-that-does-not-exist"
+                "404 Client Error: Repository Not Found"
             ),
         ):
             self._api.delete_repo("repo-that-does-not-exist", token=self._token)
@@ -1109,7 +1108,9 @@ class HfApiPrivateTest(HfApiCommonTestWithLogin):
     def test_model_info(self):
         shutil.rmtree(os.path.dirname(HfFolder.path_token))
         # Test we cannot access model info without a token
-        with self.assertRaisesRegex(requests.exceptions.HTTPError, "404 Client Error"):
+        with self.assertRaisesRegex(
+            requests.exceptions.HTTPError, "404 Client Error: Repository Not Found"
+        ):
             _ = self._api.model_info(repo_id=f"{USER}/{self.REPO_NAME}")
         # Test we can access model info with a token
         model_info = self._api.model_info(


### PR DESCRIPTION
This PR adds finer error management to the Hugging Face Hub error messages.

Here's the difference between current `main` and this PR on the following errors:

<details>

<summary>An example for <code>hf_api</code>: <code>model_info</code></summary

<br>

Using the `model_info` method:
```py
In [1]: from huggingface_hub import model_info

In [2]: model_info('random_model')
```

Before:
```
---------------------------------------------------------------------------
HTTPError                                 Traceback (most recent call last)
Input In [2], in <cell line: 1>()
----> 1 model_info('random_model')

[...]

File ~/Workspaces/Python/huggingface_hub/.env/lib/python3.10/site-packages/requests/models.py:960, in Response.raise_for_status(self)
    957     http_error_msg = u'%s Server Error: %s for url: %s' % (self.status_code, reason, self.url)
    959 if http_error_msg:
--> 960     raise HTTPError(http_error_msg, response=self)

HTTPError: 404 Client Error: Not Found for url: https://huggingface.co/api/models/random_model
```

After:
```
---------------------------------------------------------------------------
RepositoryNotFoundError                   Traceback (most recent call last)
Input In [2], in <cell line: 1>()
----> 1 model_info('random_model')

[...]

File ~/Workspaces/Python/huggingface_hub/src/huggingface_hub/utils/_errors.py:29, in _raise_for_status(request)
     27 error_code = request.headers["X-Error-Code"]
     28 if error_code == "RepoNotFound":
---> 29     raise RepositoryNotFoundError(
     30         f"404 Client Error: Repository Not Found for url: {request.url}"
     31     )
     32 elif error_code == "EntryNotFound":
     33     raise EntryNotFoundError(
     34         f"404 Client Error: Entry Not Found for url: {request.url}"
     35     )

RepositoryNotFoundError: 404 Client Error: Repository Not Found for url: https://huggingface.co/api/models/random_model
```

</details>

<details>

<summary>An example for <code>cached_download</code></summary>

<br>

`cached_download` is an interesting test-case as it can raise the three different errors. Right now, on `main`, using either of the three following errors results in the same error message:

```py
In [1]: cached_download(hf_hub_url('<bad_repo_id>', 'config.json'))
In [1]: cached_download(hf_hub_url('lysandre/sharded-repo, '<bad_file>'))
In [1]: cached_download(hf_hub_url('lysandre/sharded-repo', 'config.json', revision='<bad_revision>'))
```

```
In [1]: cached_download('https://huggingface.co/random_org/random_repo', 'file.json')

[...]

File ~/Workspaces/Python/huggingface_hub/.env/lib/python3.10/site-packages/requests/models.py:960, in Response.raise_for_status(self)
    957     http_error_msg = u'%s Server Error: %s for url: %s' % (self.status_code, reason, self.url)
    959 if http_error_msg:
--> 960     raise HTTPError(http_error_msg, response=self)

HTTPError: 404 Client Error: Not Found for url: <URL>
```

This PR will now provide tailored error messages:

*Wrong repo ID*

```py
In [1]: cached_download(hf_hub_url('<bad_repo_id>', 'config.json'))
```
```

[...]

File ~/Workspaces/Python/huggingface_hub/src/huggingface_hub/utils/_errors.py:29, in _raise_for_status(request)
     27 error_code = request.headers["X-Error-Code"]
     28 if error_code == "RepoNotFound":
---> 29     raise RepositoryNotFoundError(
     30         f"404 Client Error: Repository Not Found for url: {request.url}"
     31     )
     32 elif error_code == "EntryNotFound":
     33     raise EntryNotFoundError(
     34         f"404 Client Error: Entry Not Found for url: {request.url}"
     35     )

RepositoryNotFoundError: 404 Client Error: Repository Not Found for url: https://huggingface.co/%3Cbad_repo%3E/resolve/main/config.json
```

*Wrong file*

```py
In [1]: cached_download(hf_hub_url('lysandre/sharded-repo, '<bad_file>'))
```

```

[...]

File ~/Workspaces/Python/huggingface_hub/src/huggingface_hub/utils/_errors.py:33, in _raise_for_status(request)
     29     raise RepositoryNotFoundError(
     30         f"404 Client Error: Repository Not Found for url: {request.url}"
     31     )
     32 elif error_code == "EntryNotFound":
---> 33     raise EntryNotFoundError(
     34         f"404 Client Error: Entry Not Found for url: {request.url}"
     35     )
     36 elif error_code == "RevisionNotFound":
     37     raise RevisionNotFoundError(
     38         f"404 Client Error: Revision Not Found for url: {request.url}"
     39     )

EntryNotFoundError: 404 Client Error: Entry Not Found for url: https://huggingface.co/lysandre/sharded-repo/resolve/main/%3Cbad%3E
```

*Wrong revision*
```py
In [1]: cached_download(hf_hub_url('lysandre/sharded-repo', 'config.json', revision='<bad_revision>'))
```

```
In [2]: cached_download(hf_hub_url('lysandre/sharded-repo', 'config.json', revision='bad'))

[...]

File ~/Workspaces/Python/huggingface_hub/src/huggingface_hub/utils/_errors.py:37, in _raise_for_status(request)
     33         raise EntryNotFoundError(
     34             f"404 Client Error: Entry Not Found for url: {request.url}"
     35         )
     36     elif error_code == "RevisionNotFound":
---> 37         raise RevisionNotFoundError(
     38             f"404 Client Error: Revision Not Found for url: {request.url}"
     39         )
     41 request.raise_for_status()

RevisionNotFoundError: 404 Client Error: Revision Not Found for url: https://huggingface.co/lysandre/sharded-repo/resolve/bad/config.json
```

</details>