### PR TITLE
MNT deprecate imports from snapshot_download

### DIFF
--- a/src/huggingface_hub/snapshot_download.py
+++ b/src/huggingface_hub/snapshot_download.py
@@ -1,0 +1,14 @@
+# TODO: remove in 0.11
+
+import warnings
+
+
+warnings.warn(
+    "snapshot_download.py has been made private and will no longer be available from"
+    " version 0.11. Please use `from huggingface_hub import snapshot_download` to"
+    " import the only public function in this module. Other members of the file may be"
+    " changed without a deprecation notice.",
+    FutureWarning,
+)
+
+from ._snapshot_download import *  # noqa

--- a/tests/test_snapshot_download.py
+++ b/tests/test_snapshot_download.py
@@ -4,6 +4,8 @@ import tempfile
 import time
 import unittest
 
+import pytest
+
 import requests
 from huggingface_hub import HfApi, Repository, snapshot_download
 from huggingface_hub.hf_api import HfFolder
@@ -357,3 +359,8 @@ class SnapshotDownloadTests(unittest.TestCase):
 
     def test_download_model_with_ignore_regex_list(self):
         self.check_download_model_with_regex(["*.git*", "*.pt"], allow=False)
+
+
+def test_snapshot_download_import():
+    with pytest.warns(FutureWarning, match="has been made private"):
+        from huggingface_hub.snapshot_download import snapshot_download  # noqa

--- a/tests/test_snapshot_download.py
+++ b/tests/test_snapshot_download.py
@@ -363,4 +363,6 @@ class SnapshotDownloadTests(unittest.TestCase):
 
 def test_snapshot_download_import():
     with pytest.warns(FutureWarning, match="has been made private"):
-        from huggingface_hub.snapshot_download import snapshot_download  # noqa
+        from huggingface_hub.snapshot_download import snapshot_download as x  # noqa
+
+    assert x is snapshot_download


### PR DESCRIPTION
In https://github.com/huggingface/huggingface_hub/pull/874 we had to rename the `snapshot_download.py` file which makes `from huggingface_hub.snapshot_download import blah` fail.

This PR deprecated such imports and warns the user instead of failing.

Ref: https://github.com/scientific-python/lazy_loader/pull/9

cc @LysandreJik @osanseviero 

P.S.: I won't be available to apply suggestions here this week, but I think we should have this in the release. If you think anything needs to be changed in this PR, please apply the suggestions and then merge :) 