### PR TITLE
Pushback deprecation for v0.7 release

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -55,7 +55,7 @@ USERNAME_PLACEHOLDER = "hf_user"
 logger = logging.get_logger(__name__)
 
 
-# TODO: remove after deprecation period is over (v0.7)
+# TODO: remove after deprecation period is over (v0.8)
 def _validate_repo_id_deprecation(repo_id, name, organization):
     """Returns (name, organization) from the input."""
     if repo_id and not name and organization:
@@ -78,7 +78,7 @@ def _validate_repo_id_deprecation(repo_id, name, organization):
     elif name or organization:
         warnings.warn(
             "`name` and `organization` input arguments are deprecated and "
-            "will be removed in v0.7. Pass `repo_id` instead.",
+            "will be removed in v0.8. Pass `repo_id` instead.",
             FutureWarning,
         )
     else:
@@ -558,7 +558,7 @@ class HfApi:
 
         <Tip>
 
-        Warning: Deprecated, will be removed in v0.7. Please use
+        Warning: Deprecated, will be removed in v0.8. Please use
         [`HfApi.set_access_token`] instead.
 
         </Tip>
@@ -583,7 +583,7 @@ class HfApi:
         """
         warnings.warn(
             "HfApi.login: This method is deprecated in favor of `set_access_token`"
-            " and will be removed in v0.7.",
+            " and will be removed in v0.8.",
             FutureWarning,
         )
         path = f"{self.endpoint}/api/login"
@@ -651,7 +651,7 @@ class HfApi:
             token (``str``, `optional`):
                 Hugging Face token. Will default to the locally saved token if not provided.
             name (``str``, `optional`):
-                Name of the repository. This is deprecated in favor of repo_id and will be removed in v0.7.
+                Name of the repository. This is deprecated in favor of repo_id and will be removed in v0.8.
             function_name (``str``, `optional`):
                 If _validate_or_retrieve_token is called from a function, name of that function to be passed inside deprecation warning.
         Returns:
@@ -690,7 +690,7 @@ class HfApi:
 
         <Tip>
 
-        Warning: Deprecated, will be removed in v0.7. Please use
+        Warning: Deprecated, will be removed in v0.8. Please use
         [`HfApi.unset_access_token`] instead.
 
         </Tip>
@@ -702,7 +702,7 @@ class HfApi:
         """
         warnings.warn(
             "HfApi.logout: This method is deprecated in favor of `unset_access_token` "
-            "and will be removed in v0.7.",
+            "and will be removed in v0.8.",
             FutureWarning,
         )
         if token is None:

--- a/src/huggingface_hub/utils/_deprecation.py
+++ b/src/huggingface_hub/utils/_deprecation.py
@@ -3,7 +3,7 @@ from functools import wraps
 from inspect import Parameter, signature
 
 
-def _deprecate_positional_args(func=None, *, version="0.7"):
+def _deprecate_positional_args(func=None, *, version="0.8"):
     """Decorator for methods that issues warnings for positional arguments.
     Using the keyword-only argument syntax in pep 3102, arguments after the
     * will issue a warning when passed as a positional argument.
@@ -11,7 +11,7 @@ def _deprecate_positional_args(func=None, *, version="0.7"):
     Args:
         func (``Callable``, `optional`):
             Function to check arguments on.
-        version (``Callable``, `optional`, defaults to ``"0.7"``):
+        version (``Callable``, `optional`, defaults to ``"0.8"``):
             The version when positional arguments will result in error.
     """
 

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -161,7 +161,7 @@ class HfApiLoginTest(HfApiCommonTest):
         with pytest.warns(
             FutureWarning,
             match=r"HfApi.login: This method is deprecated in favor of "
-            r"`set_access_token` and will be removed in v0.7.",
+            r"`set_access_token` and will be removed in v0.8.",
         ):
             self._api.login(username=USER, password=PASS)
 
@@ -169,7 +169,7 @@ class HfApiLoginTest(HfApiCommonTest):
         with pytest.warns(
             FutureWarning,
             match=r"HfApi.logout: This method is deprecated in favor of "
-            r"`unset_access_token` and will be removed in v0.7.",
+            r"`unset_access_token` and will be removed in v0.8.",
         ):
             try:
                 self._api.logout()


### PR DESCRIPTION
Pushes back the deprecation warnings to v0.8 as we're doing an express release for a forgotten commit.