### PR TITLE
Fixes: #805 Added h5 save format compatibility

### DIFF
--- a/src/huggingface_hub/keras_mixin.py
+++ b/src/huggingface_hub/keras_mixin.py
@@ -233,6 +233,10 @@ def save_pretrained_keras(
             metadata["tags"] = [task_name]
 
     _create_model_card(model, save_directory, plot_model, metadata)
+    if model_save_kwargs.get('save_format')=='h5':
+        filepath = model_save_kwargs.pop('filepath', None)
+        if filepath:
+            save_directory = os.path.join(save_directory, filepath)
     tf.keras.models.save_model(
         model, save_directory, include_optimizer=include_optimizer, **model_save_kwargs
     )


### PR DESCRIPTION
```
from huggingface_hub import push_to_hub_keras
push_to_hub_keras(transformer, repo_url = "rushic24/keras-english-to-spanish", include_optimizer=True, save_format='h5', filepath='mpath')
```

![image](https://user-images.githubusercontent.com/6279035/171098608-80630554-7d00-475a-ae82-b133942db7c1.png)
