### PR TITLE
Display endpoint URL in whoami command

### DIFF
--- a/src/huggingface_hub/commands/user.py
+++ b/src/huggingface_hub/commands/user.py
@@ -19,10 +19,10 @@ from typing import List, Union
 
 from huggingface_hub.commands import BaseHuggingfaceCLICommand
 from huggingface_hub.constants import (
+    ENDPOINT,
     REPO_TYPES,
     REPO_TYPES_URL_PREFIXES,
     SPACES_SDK_TYPES,
-    ENDPOINT,
 )
 from huggingface_hub.hf_api import HfApi, HfFolder
 from requests.exceptions import HTTPError

--- a/src/huggingface_hub/commands/user.py
+++ b/src/huggingface_hub/commands/user.py
@@ -191,7 +191,8 @@ class WhoamiCommand(BaseUserCommand):
             exit()
         try:
             info = self._api.whoami(token)
-            print(ENDPOINT)
+            if ENDPOINT != "https://huggingface.co":
+                print(ENDPOINT)
             print(info["name"])
             orgs = [org["name"] for org in info["orgs"]]
             if orgs:

--- a/src/huggingface_hub/commands/user.py
+++ b/src/huggingface_hub/commands/user.py
@@ -22,6 +22,7 @@ from huggingface_hub.constants import (
     REPO_TYPES,
     REPO_TYPES_URL_PREFIXES,
     SPACES_SDK_TYPES,
+    ENDPOINT
 )
 from huggingface_hub.hf_api import HfApi, HfFolder
 from requests.exceptions import HTTPError
@@ -190,6 +191,7 @@ class WhoamiCommand(BaseUserCommand):
             exit()
         try:
             info = self._api.whoami(token)
+            print(ENDPOINT)
             print(info["name"])
             orgs = [org["name"] for org in info["orgs"]]
             if orgs:

--- a/src/huggingface_hub/commands/user.py
+++ b/src/huggingface_hub/commands/user.py
@@ -22,7 +22,7 @@ from huggingface_hub.constants import (
     REPO_TYPES,
     REPO_TYPES_URL_PREFIXES,
     SPACES_SDK_TYPES,
-    ENDPOINT
+    ENDPOINT,
 )
 from huggingface_hub.hf_api import HfApi, HfFolder
 from requests.exceptions import HTTPError


### PR DESCRIPTION
This is a convenient way to check what hub endpoint you're logged on to (public hub, private hub, etc.):

```
% huggingface-cli whoami
https://private-hub.huggingface.cloud
juliensimon
```

The codebase has some informational messages with hard-coded references to huggingface.co. I've left these alone, maybe we should clean them up at some point.