### PR TITLE
🏗 Use `hub-ci` for tests

### DIFF
--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -25,7 +25,7 @@ _staging_mode = (
 )
 
 ENDPOINT = os.getenv("HF_ENDPOINT") or (
-    "https://moon-staging.huggingface.co" if _staging_mode else "https://huggingface.co"
+    "https://hub-ci.huggingface.co" if _staging_mode else "https://huggingface.co"
 )
 
 HUGGINGFACE_CO_URL_TEMPLATE = ENDPOINT + "/{repo_id}/resolve/{revision}/{filename}"

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -1891,7 +1891,7 @@ class HfApi:
         if identical_ok is not None:
             warnings.warn(
                 "`identical_ok` has no effect and is deprecated. It will be removed in"
-                " 0.10.0.",
+                " 0.11.0.",
                 FutureWarning,
             )
         if repo_type not in REPO_TYPES:

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -1844,7 +1844,7 @@ class HfApi:
                 The git revision to commit from. Defaults to the head of the
                 `"main"` branch.
             identical_ok (`bool`, *optional*, defaults to `True`):
-                Deprecated: will be removed in 0.10.0.
+                Deprecated: will be removed in 0.11.0.
                 Changing this value has no effect.
 
         Returns:

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -1816,7 +1816,7 @@ class HfApi:
         token: Optional[str] = None,
         repo_type: Optional[str] = None,
         revision: Optional[str] = None,
-        identical_ok: bool = True,
+        identical_ok: Optional[bool] = None,
     ) -> str:
         """
         Upload a local file (up to 5GB) to the given repo. The upload is done
@@ -1844,10 +1844,8 @@ class HfApi:
                 The git revision to commit from. Defaults to the head of the
                 `"main"` branch.
             identical_ok (`bool`, *optional*, defaults to `True`):
-                When set to false, will raise an [HTTPError](
-                https://2.python-requests.org/en/master/api/#requests.HTTPError)
-                when the file you're trying to upload already exists on the hub
-                and its content did not change.
+                Deprecated: will be removed in 0.10.0.
+                Changing this value has no effect.
 
         Returns:
             `str`: The URL to visualize the uploaded file on the hub
@@ -1890,6 +1888,12 @@ class HfApi:
         "https://huggingface.co/username/my-model/blob/main/remote/file/path.h5"
         ```
         """
+        if identical_ok is not None:
+            warnings.warn(
+                "`identical_ok` has no effect and is deprecated. It will be removed in"
+                " 0.10.0.",
+                FutureWarning,
+            )
         if repo_type not in REPO_TYPES:
             raise ValueError(f"Invalid repo type, must be one of {REPO_TYPES}")
 
@@ -1940,18 +1944,7 @@ class HfApi:
         else:
             r = requests.post(path, headers=headers, data=path_or_fileobj)
 
-        try:
-            _raise_for_status(r)
-        except HTTPError as err:
-            if identical_ok and err.response.status_code == 409:
-                from .file_download import hf_hub_url
-
-                return hf_hub_url(
-                    repo_id, path_in_repo, revision=revision, repo_type=repo_type
-                )
-            else:
-                raise err
-
+        _raise_for_status(r)
         d = r.json()
         return d["url"]
 

--- a/src/huggingface_hub/repocard.py
+++ b/src/huggingface_hub/repocard.py
@@ -195,7 +195,6 @@ def metadata_update(
             path_in_repo=REPOCARD_NAME,
             repo_id=repo_id,
             repo_type=repo_type,
-            identical_ok=False,
             token=token,
         )
 

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -596,44 +596,6 @@ class HfApiUploadFileTest(HfApiCommonTestWithLogin):
             self._api.create_repo(repo_id=REPO_NAME)
 
     @retry_endpoint
-    def test_upload_file_conflict(self):
-        REPO_NAME = repo_name("conflict")
-        self._api.create_repo(repo_id=REPO_NAME, token=self._token)
-        try:
-            filecontent = BytesIO(b"File content, but in bytes IO")
-            self._api.upload_file(
-                path_or_fileobj=filecontent,
-                path_in_repo="temp/new_file.md",
-                repo_id=f"{USER}/{REPO_NAME}",
-                token=self._token,
-                identical_ok=True,
-            )
-
-            # No exception raised when identical_ok is True
-            self._api.upload_file(
-                path_or_fileobj=filecontent,
-                path_in_repo="temp/new_file.md",
-                repo_id=f"{USER}/{REPO_NAME}",
-                token=self._token,
-                identical_ok=True,
-            )
-
-            with self.assertRaises(HTTPError) as err_ctx:
-                self._api.upload_file(
-                    path_or_fileobj=filecontent,
-                    path_in_repo="temp/new_file.md",
-                    repo_id=f"{USER}/{REPO_NAME}",
-                    token=self._token,
-                    identical_ok=False,
-                )
-                self.assertEqual(err_ctx.exception.response.status_code, 409)
-
-        except Exception as err:
-            self.fail(err)
-        finally:
-            self._api.delete_repo(repo_id=REPO_NAME, token=self._token)
-
-    @retry_endpoint
     def test_upload_buffer(self):
         REPO_NAME = repo_name("buffer")
         self._api.create_repo(repo_id=REPO_NAME, token=self._token)

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -1107,7 +1107,7 @@ class HfApiPrivateTest(HfApiCommonTestWithLogin):
         shutil.rmtree(os.path.dirname(HfFolder.path_token))
         # Test we cannot access model info without a token
         with self.assertRaisesRegex(
-            requests.exceptions.HTTPError, "404 Client Error: Repository Not Found"
+            requests.exceptions.HTTPError, "401 Client Error: Repository Not Found"
         ):
             _ = self._api.model_info(repo_id=f"{USER}/{self.REPO_NAME}")
         # Test we can access model info with a token

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -1061,9 +1061,15 @@ class HfApiPrivateTest(HfApiCommonTestWithLogin):
         super().setUp()
         self.REPO_NAME = repo_name("private")
         self._api.create_repo(repo_id=self.REPO_NAME, token=self._token, private=True)
+        self._api.create_repo(
+            repo_id=self.REPO_NAME, token=self._token, private=True, repo_type="dataset"
+        )
 
     def tearDown(self) -> None:
         self._api.delete_repo(repo_id=self.REPO_NAME, token=self._token)
+        self._api.delete_repo(
+            repo_id=self.REPO_NAME, token=self._token, repo_type="dataset"
+        )
 
     def test_model_info(self):
         shutil.rmtree(os.path.dirname(HfFolder.path_token))
@@ -1078,14 +1084,12 @@ class HfApiPrivateTest(HfApiCommonTestWithLogin):
         )
         self.assertIsInstance(model_info, ModelInfo)
 
-    @with_production_testing
-    def test_list_private_models(self):
+    def test_list_private_datasets(self):
         orig = len(self._api.list_datasets())
         new = len(self._api.list_datasets(use_auth_token=self._token))
         self.assertGreater(new, orig)
 
-    @with_production_testing
-    def test_list_private_datasets(self):
+    def test_list_private_models(self):
         orig = len(self._api.list_models())
         new = len(self._api.list_models(use_auth_token=self._token))
         self.assertGreater(new, orig)

--- a/tests/test_snapshot_download.py
+++ b/tests/test_snapshot_download.py
@@ -118,7 +118,7 @@ class SnapshotDownloadTests(unittest.TestCase):
         # Test download fails without token
         with tempfile.TemporaryDirectory() as tmpdirname:
             with self.assertRaisesRegex(
-                requests.exceptions.HTTPError, "404 Client Error"
+                requests.exceptions.HTTPError, "401 Client Error"
             ):
                 _ = snapshot_download(
                     f"{USER}/{REPO_NAME}", revision="main", cache_dir=tmpdirname

--- a/tests/testing_constants.py
+++ b/tests/testing_constants.py
@@ -6,8 +6,8 @@ PASS = "__DUMMY_TRANSFORMERS_PASS__"
 TOKEN = "hf_94wBhPGp6KrrTH3KDchhKpRxZwd6dmHWLL"
 
 ENDPOINT_PRODUCTION = "https://huggingface.co"
-ENDPOINT_STAGING = "https://moon-staging.huggingface.co"
-ENDPOINT_STAGING_BASIC_AUTH = f"https://{USER}:{PASS}@moon-staging.huggingface.co"
+ENDPOINT_STAGING = "https://hub-ci.huggingface.co"
+ENDPOINT_STAGING_BASIC_AUTH = f"https://{USER}:{PASS}@hub-ci.huggingface.co"
 
 ENDPOINT_PRODUCTION_URL_SCHEME = (
     ENDPOINT_PRODUCTION + "/{repo_id}/resolve/{revision}/{filename}"


### PR DESCRIPTION
cc @XCiD

Uses the new CI environment for tests, which uses Gitaly and is automatically updated to the latest version of the Hub.
