### PR TITLE
FIX Avoid creating repository when it exists on remote

### DIFF
--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -5,7 +5,6 @@ import subprocess
 import tempfile
 import threading
 import time
-import warnings
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Callable, Dict, Iterator, List, Optional, Tuple, Union
@@ -648,10 +647,12 @@ class Repository:
                     try:
                         _ = HfApi().repo_info(f"{namespace}/{repo_id}")
                     except HTTPError:
-                        warnings.warn(
-                            "There's no repository in the given link in clone_from."
-                            " Creating a new repository.",
-                            UserWarning,
+                        self.client.create_repo(
+                            repo_id=repo_id,
+                            token=token,
+                            repo_type=self.repo_type,
+                            exist_ok=True,
+                            private=self.private,
                         )
 
             else:

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -648,13 +648,20 @@ class Repository:
                             f"{repo_id}", repo_type=self.repo_type, token=token
                         )
                     except HTTPError:
-                        self.client.create_repo(
-                            repo_id=repo_id,
-                            token=token,
-                            repo_type=self.repo_type,
-                            exist_ok=True,
-                            private=self.private,
-                        )
+                        if self.repo_type is "space":
+                            raise ValueError(
+                                "Creating a Space through passing Space link to"
+                                " clone_from is not allowed. Make sure the Space exists"
+                                " on Hugging Face Hub."
+                            )
+                        else:
+                            self.client.create_repo(
+                                repo_id=repo_id,
+                                token=token,
+                                repo_type=self.repo_type,
+                                exist_ok=True,
+                                private=self.private,
+                            )
 
             else:
                 if namespace is not None:

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -224,7 +224,7 @@ def is_binary_file(filename: Union[str, Path]) -> bool:
     """
     try:
         with open(filename, "rb") as f:
-            content = f.read(10 * (1024 ** 2))  # Read a maximum of 10MB
+            content = f.read(10 * (1024**2))  # Read a maximum of 10MB
 
         # Code sample taken from the following stack overflow thread
         # https://stackoverflow.com/questions/898669/how-can-i-detect-if-a-file-is-binary-non-text-in-python/7392391#7392391
@@ -684,7 +684,8 @@ class Repository:
                         env.update({"GIT_LFS_SKIP_SMUDGE": "1"})
 
                     run_subprocess(
-                        f"{'git clone' if self.skip_lfs_files else 'git lfs clone'} {repo_url} .".split(),
+                        f"{'git clone' if self.skip_lfs_files else 'git lfs clone'} {repo_url} ."
+                        .split(),
                         self.local_dir,
                         env=env,
                     )

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -224,7 +224,7 @@ def is_binary_file(filename: Union[str, Path]) -> bool:
     """
     try:
         with open(filename, "rb") as f:
-            content = f.read(10 * (1024**2))  # Read a maximum of 10MB
+            content = f.read(10 * (1024 ** 2))  # Read a maximum of 10MB
 
         # Code sample taken from the following stack overflow thread
         # https://stackoverflow.com/questions/898669/how-can-i-detect-if-a-file-is-binary-non-text-in-python/7392391#7392391
@@ -684,8 +684,7 @@ class Repository:
                         env.update({"GIT_LFS_SKIP_SMUDGE": "1"})
 
                     run_subprocess(
-                        f"{'git clone' if self.skip_lfs_files else 'git lfs clone'} {repo_url} ."
-                        .split(),
+                        f"{'git clone' if self.skip_lfs_files else 'git lfs clone'} {repo_url} .".split(),
                         self.local_dir,
                         env=env,
                     )

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -645,7 +645,7 @@ class Repository:
 
                 if namespace == user or namespace in valid_organisations:
                     try:
-                        _ = HfApi().repository_info(f"{namespace}/{repo_id}")
+                        _ = HfApi().repo_info(f"{namespace}/{repo_id}")
                     except HTTPError:
                         self.client.create_repo(
                             repo_id=repo_id,

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -642,7 +642,6 @@ class Repository:
 
                 scheme = urlparse(repo_url).scheme
                 repo_url = repo_url.replace(f"{scheme}://", f"{scheme}://user:{token}@")
-                breakpoint()
                 if namespace == user or namespace in valid_organisations:
                     try:
                         _ = HfApi().repo_info(

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -642,10 +642,12 @@ class Repository:
 
                 scheme = urlparse(repo_url).scheme
                 repo_url = repo_url.replace(f"{scheme}://", f"{scheme}://user:{token}@")
-
+                breakpoint()
                 if namespace == user or namespace in valid_organisations:
                     try:
-                        _ = HfApi().repo_info(f"{namespace}/{repo_id}")
+                        _ = HfApi().repo_info(
+                            f"{repo_id}", repo_type=self.repo_type, token=token
+                        )
                     except HTTPError:
                         self.client.create_repo(
                             repo_id=repo_id,

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -5,6 +5,7 @@ import subprocess
 import tempfile
 import threading
 import time
+import warnings
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Callable, Dict, Iterator, List, Optional, Tuple, Union
@@ -647,12 +648,10 @@ class Repository:
                     try:
                         _ = HfApi().repo_info(f"{namespace}/{repo_id}")
                     except HTTPError:
-                        self.client.create_repo(
-                            repo_id=repo_id,
-                            token=token,
-                            repo_type=self.repo_type,
-                            exist_ok=True,
-                            private=self.private,
+                        warnings.warn(
+                            "There's no repository in the given link in clone_from."
+                            " Creating a new repository.",
+                            UserWarning,
                         )
 
             else:

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -648,7 +648,7 @@ class Repository:
                             f"{repo_id}", repo_type=self.repo_type, token=token
                         )
                     except HTTPError:
-                        if self.repo_type is "space":
+                        if self.repo_type == "space":
                             raise ValueError(
                                 "Creating a Space through passing Space link to"
                                 " clone_from is not allowed. Make sure the Space exists"

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -118,7 +118,6 @@ class RepositoryTest(RepositoryCommonTest):
         Repository(
             WORKING_REPO_DIR, clone_from=temp_repo_url, use_auth_token=self._token
         )
-        self._api.delete_repo(repo_id=f"{self.REPO_NAME}-temp", token=self._token)
 
     def test_init_from_existing_local_clone(self):
         subprocess.run(

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -14,6 +14,7 @@
 import json
 import os
 import pathlib
+import pytest
 import shutil
 import subprocess
 import tempfile
@@ -118,28 +119,36 @@ class RepositoryTest(RepositoryCommonTest):
             repo_type="space",
             use_auth_token=self._token,
         )
+        self._api.delete_repo(repo_id=f"{USER}/{self.REPO_NAME}-temp", token=self._token)
+
 
     def test_clone_from_space(self):
-        non_existing_repo = f"https://huggingface.co/spaces/user/{uuid.uuid4()}"
+        temp_repo_url = self._api.create_repo(
+            repo_id=f"{self.REPO_NAME}-temp", token=self._token, repo_type="space",
+            space_sdk="gradio"
+        )        
         with pytest.raises(
-            ValueError, match="Creating a Space through passing Space link*"
-        ):
+            ValueError, match="Creating a Space through passing Space link*"):
             Repository(
                 WORKING_REPO_DIR,
-                clone_from=non_existing_repo,
+                clone_from=temp_repo_url,
                 repo_type="space",
                 use_auth_token=self._token,
             )
+        self._api.delete_repo(repo_id=f"{USER}/{self.REPO_NAME}-temp", token=self._token)
 
     def test_clone_from_model(self):
-        non_existing_repo = f"https://huggingface.co/models/user/{uuid.uuid4()}"
-
-        Repository(
-            WORKING_REPO_DIR,
-            clone_from=non_existing_repo,
-            repo_type="model",
-            use_auth_token=self._token,
+        temp_repo_url = self._api.create_repo(
+            repo_id=f"{self.REPO_NAME}-temp", token=self._token, repo_type="model"
         )
+        Repository(
+                WORKING_REPO_DIR,
+                clone_from=temp_repo_url,
+                repo_type="model",
+                use_auth_token=self._token,
+            )
+        self._api.delete_repo(repo_id=f"{USER}/{self.REPO_NAME}-temp", token=self._token)
+
 
     def test_init_from_existing_local_clone(self):
         subprocess.run(

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -14,7 +14,6 @@
 import json
 import os
 import pathlib
-import pytest
 import shutil
 import subprocess
 import tempfile
@@ -22,6 +21,8 @@ import time
 import unittest
 import uuid
 from io import BytesIO
+
+import pytest
 
 import requests
 from huggingface_hub.commands.user import currently_setup_credential_helpers
@@ -111,7 +112,10 @@ class RepositoryTest(RepositoryCommonTest):
 
     def test_init_clone_from(self):
         temp_repo_url = self._api.create_repo(
-            repo_id=f"{self.REPO_NAME}-temp", token=self._token, repo_type="space", space_sdk="gradio"
+            repo_id=f"{self.REPO_NAME}-temp",
+            token=self._token,
+            repo_type="space",
+            space_sdk="gradio",
         )
         Repository(
             WORKING_REPO_DIR,
@@ -119,32 +123,37 @@ class RepositoryTest(RepositoryCommonTest):
             repo_type="space",
             use_auth_token=self._token,
         )
-        self._api.delete_repo(repo_id=f"{USER}/{self.REPO_NAME}-temp", token=self._token)
+        self._api.delete_repo(
+            repo_id=f"{USER}/{self.REPO_NAME}-temp", token=self._token
+        )
 
-
-    def test_clone_from_space(self):    
+    def test_clone_from_space(self):
         with pytest.raises(
-            ValueError, match="Creating a Space through passing Space link*"):
+            ValueError, match="Creating a Space through passing Space link*"
+        ):
             Repository(
                 WORKING_REPO_DIR,
                 clone_from=f"https://huggingface.co/spaces/{USER}/{uuid.uuid4()}",
                 repo_type="space",
                 use_auth_token=self._token,
             )
-        self._api.delete_repo(repo_id=f"{USER}/{self.REPO_NAME}-temp", token=self._token)
+        self._api.delete_repo(
+            repo_id=f"{USER}/{self.REPO_NAME}-temp", token=self._token
+        )
 
     def test_clone_from_model(self):
         temp_repo_url = self._api.create_repo(
             repo_id=f"{self.REPO_NAME}-temp", token=self._token, repo_type="model"
         )
         Repository(
-                WORKING_REPO_DIR,
-                clone_from=temp_repo_url,
-                repo_type="model",
-                use_auth_token=self._token,
-            )
-        self._api.delete_repo(repo_id=f"{USER}/{self.REPO_NAME}-temp", token=self._token)
-
+            WORKING_REPO_DIR,
+            clone_from=temp_repo_url,
+            repo_type="model",
+            use_auth_token=self._token,
+        )
+        self._api.delete_repo(
+            repo_id=f"{USER}/{self.REPO_NAME}-temp", token=self._token
+        )
 
     def test_init_from_existing_local_clone(self):
         subprocess.run(

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -108,6 +108,18 @@ class RepositoryTest(RepositoryCommonTest):
         except requests.exceptions.HTTPError:
             pass
 
+    def test_init_clone_from(self):
+        temp_repo_url = self._api.create_repo(
+            repo_id=f"{self.REPO_NAME}-temp",
+            token=self._token,
+            repo_type="space",
+            space_sdk="gradio",
+        )
+        Repository(
+            WORKING_REPO_DIR, clone_from=temp_repo_url, use_auth_token=self._token
+        )
+        self._api.delete_repo(repo_id=f"{self.REPO_NAME}-temp", token=self._token)
+
     def test_init_from_existing_local_clone(self):
         subprocess.run(
             ["git", "clone", self._repo_url, WORKING_REPO_DIR],

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -124,7 +124,9 @@ class RepositoryTest(RepositoryCommonTest):
             use_auth_token=self._token,
         )
         self._api.delete_repo(
-            repo_id=f"{USER}/{self.REPO_NAME}-temp", token=self._token
+            repo_id=f"{USER}/{self.REPO_NAME}-temp",
+            token=self._token,
+            repo_type="space",
         )
 
     def test_clone_from_space(self):
@@ -133,7 +135,7 @@ class RepositoryTest(RepositoryCommonTest):
         ):
             Repository(
                 WORKING_REPO_DIR,
-                clone_from=f"https://huggingface.co/spaces/{USER}/{uuid.uuid4()}",
+                clone_from=f"{USER}/{uuid.uuid4()}",
                 repo_type="space",
                 use_auth_token=self._token,
             )

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -137,9 +137,6 @@ class RepositoryTest(RepositoryCommonTest):
                 repo_type="space",
                 use_auth_token=self._token,
             )
-        self._api.delete_repo(
-            repo_id=f"{USER}/{self.REPO_NAME}-temp", token=self._token
-        )
 
     def test_clone_from_model(self):
         temp_repo_url = self._api.create_repo(

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -111,7 +111,7 @@ class RepositoryTest(RepositoryCommonTest):
 
     def test_init_clone_from(self):
         temp_repo_url = self._api.create_repo(
-            repo_id=f"{self.REPO_NAME}-temp", token=self._token, repo_type="space"
+            repo_id=f"{self.REPO_NAME}-temp", token=self._token, repo_type="space", space_sdk="gradio"
         )
         Repository(
             WORKING_REPO_DIR,
@@ -122,16 +122,12 @@ class RepositoryTest(RepositoryCommonTest):
         self._api.delete_repo(repo_id=f"{USER}/{self.REPO_NAME}-temp", token=self._token)
 
 
-    def test_clone_from_space(self):
-        temp_repo_url = self._api.create_repo(
-            repo_id=f"{self.REPO_NAME}-temp", token=self._token, repo_type="space",
-            space_sdk="gradio"
-        )        
+    def test_clone_from_space(self):    
         with pytest.raises(
             ValueError, match="Creating a Space through passing Space link*"):
             Repository(
                 WORKING_REPO_DIR,
-                clone_from=temp_repo_url,
+                clone_from=f"https://huggingface.co/spaces/{USER}/{uuid.uuid4()}",
                 repo_type="space",
                 use_auth_token=self._token,
             )

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -110,13 +110,35 @@ class RepositoryTest(RepositoryCommonTest):
 
     def test_init_clone_from(self):
         temp_repo_url = self._api.create_repo(
-            repo_id=f"{self.REPO_NAME}-temp",
-            token=self._token,
-            repo_type="space",
-            space_sdk="gradio",
+            repo_id=f"{self.REPO_NAME}-temp", token=self._token, repo_type="space"
         )
         Repository(
-            WORKING_REPO_DIR, clone_from=temp_repo_url, use_auth_token=self._token
+            WORKING_REPO_DIR,
+            clone_from=temp_repo_url,
+            repo_type="space",
+            use_auth_token=self._token,
+        )
+
+    def test_clone_from_space(self):
+        non_existing_repo = f"https://huggingface.co/spaces/user/{uuid.uuid4()}"
+        with pytest.raises(
+            ValueError, match="Creating a Space through passing Space link*"
+        ):
+            Repository(
+                WORKING_REPO_DIR,
+                clone_from=non_existing_repo,
+                repo_type="space",
+                use_auth_token=self._token,
+            )
+
+    def test_clone_from_model(self):
+        non_existing_repo = f"https://huggingface.co/models/user/{uuid.uuid4()}"
+
+        Repository(
+            WORKING_REPO_DIR,
+            clone_from=non_existing_repo,
+            repo_type="model",
+            use_auth_token=self._token,
         )
 
     def test_init_from_existing_local_clone(self):

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -115,7 +115,7 @@ class RepositoryTest(RepositoryCommonTest):
             repo_id=f"{self.REPO_NAME}-temp",
             token=self._token,
             repo_type="space",
-            space_sdk="gradio",
+            space_sdk="static",
         )
         Repository(
             WORKING_REPO_DIR,


### PR DESCRIPTION
This PR partially fixes https://github.com/huggingface/huggingface_hub/issues/672. 

I observed that the following error pops up when I create a repository using huggingface API `create_repo` and then have a local repository cloning from the URL **using a token** ([here](https://github.com/huggingface/huggingface_hub/issues/672#issuecomment-1150972003))
`ValueError: No space_sdk provided. create_repo expects space_sdk to be one of ['gradio', 'streamlit', 'static'] when repo_type is 'space'`
So I noticed the following block was causing the problem:

```
if token is not None:
                whoami_info = self.client.whoami(token)
                user = whoami_info["name"]
                valid_organisations = [org["name"] for org in whoami_info["orgs"]]

                if namespace is not None:
                    repo_id = f"{namespace}/{repo_id}"
                repo_url += repo_id

                scheme = urlparse(repo_url).scheme
                repo_url = repo_url.replace(f"{scheme}://", f"{scheme}://user:{token}@")

                if namespace == user or namespace in valid_organisations:
                    self.client.create_repo(
                        repo_id=repo_id,
                        token=token,
                        repo_type=self.repo_type,
                        exist_ok=True,
                        private=self.private,
                    )
            else:
                if namespace is not None:
                    repo_url += f"{namespace}/"
                repo_url += repo_id
```

Only name being valid shouldn't be enough to create a repository, we have to check if the repository exists on remote so I added a small check on that (thanks @muellerzr for pointing out to particular HfApi function that does it).

With this, `space_sdk` error should be gone. I'll add test once @LysandreJik approves my logic in here.


Also this is separate but IDK if it's good to have an attribute `clone_from` and the `clone_from()` function. I can refactor couple of things I saw there that's not good to me as well.