### PR TITLE
Add request ID to all requests

### DIFF
--- a/src/huggingface_hub/commands/lfs.py
+++ b/src/huggingface_hub/commands/lfs.py
@@ -29,6 +29,7 @@ from huggingface_hub.commands import BaseHuggingfaceCLICommand
 from huggingface_hub.lfs import LFS_MULTIPART_UPLOAD_COMMAND
 
 from ..utils import logging
+from ..utils._errors import _raise_with_request_id
 
 
 logger = logging.get_logger(__name__)
@@ -212,7 +213,7 @@ class LfsUploadCommand:
                     filepath, seek_from=i * chunk_size, read_limit=chunk_size
                 ) as data:
                     r = requests.put(presigned_url, data=data)
-                    r.raise_for_status()
+                    _raise_with_request_id(r)
                     parts.append(
                         {
                             "etag": r.headers.get("etag"),
@@ -238,6 +239,6 @@ class LfsUploadCommand:
                     "parts": parts,
                 },
             )
-            r.raise_for_status()
+            _raise_with_request_id(r)
 
             write_msg({"event": "complete", "oid": oid})

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -32,7 +32,6 @@ from .constants import (
     SPACES_SDK_TYPES,
 )
 from .utils import logging
-from .utils._deprecation import _deprecate_positional_args
 from .utils._errors import _raise_for_status, _raise_with_request_id
 from .utils._fixes import JSONDecodeError
 from .utils.endpoint_helpers import (

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -33,7 +33,7 @@ from .constants import (
 )
 from .utils import logging
 from .utils._deprecation import _deprecate_positional_args
-from .utils._errors import _raise_for_status
+from .utils._errors import _raise_for_status, _raise_with_request_id
 from .utils._fixes import JSONDecodeError
 from .utils.endpoint_helpers import (
     AttributeDictionary,
@@ -591,7 +591,7 @@ class HfApi:
         )
         path = f"{self.endpoint}/api/login"
         r = requests.post(path, json={"username": username, "password": password})
-        r.raise_for_status()
+        _raise_with_request_id(r)
         d = r.json()
 
         write_to_credential_store(username, password)
@@ -616,7 +616,7 @@ class HfApi:
         path = f"{self.endpoint}/api/whoami-v2"
         r = requests.get(path, headers={"authorization": f"Bearer {token}"})
         try:
-            r.raise_for_status()
+            _raise_with_request_id(r)
         except HTTPError as e:
             raise HTTPError(
                 "Invalid user token. If you didn't pass a user token, make sure you "
@@ -721,7 +721,7 @@ class HfApi:
 
         path = f"{self.endpoint}/api/logout"
         r = requests.post(path, headers={"authorization": f"Bearer {token}"})
-        r.raise_for_status()
+        _raise_with_request_id(r)
 
     @staticmethod
     def set_access_token(access_token: str):
@@ -746,7 +746,7 @@ class HfApi:
         "Gets all valid model tags as a nested namespace object"
         path = f"{self.endpoint}/api/models-tags-by-type"
         r = requests.get(path)
-        r.raise_for_status()
+        _raise_with_request_id(r)
         d = r.json()
         return ModelTags(d)
 
@@ -756,7 +756,7 @@ class HfApi:
         """
         path = f"{self.endpoint}/api/datasets-tags-by-type"
         r = requests.get(path)
-        r.raise_for_status()
+        _raise_with_request_id(r)
         d = r.json()
         return DatasetTags(d)
 
@@ -896,7 +896,7 @@ class HfApi:
         if cardData is not None:
             params.update({"cardData": cardData})
         r = requests.get(path, params=params, headers=headers)
-        r.raise_for_status()
+        _raise_with_request_id(r)
         d = r.json()
         res = [ModelInfo(**x) for x in d]
         if emissions_thresholds is not None:
@@ -1090,7 +1090,7 @@ class HfApi:
             if cardData:
                 params.update({"full": True})
         r = requests.get(path, params=params, headers=headers)
-        r.raise_for_status()
+        _raise_with_request_id(r)
         d = r.json()
         return [DatasetInfo(**x) for x in d]
 
@@ -1145,7 +1145,7 @@ class HfApi:
         path = f"{self.endpoint}/api/metrics"
         params = {}
         r = requests.get(path, params=params)
-        r.raise_for_status()
+        _raise_with_request_id(r)
         d = r.json()
         return [MetricInfo(**x) for x in d]
 
@@ -1532,7 +1532,7 @@ class HfApi:
         )
 
         try:
-            r.raise_for_status()
+            _raise_with_request_id(r)
         except HTTPError as err:
             if not (exist_ok and err.response.status_code == 409):
                 try:

--- a/src/huggingface_hub/utils/_errors.py
+++ b/src/huggingface_hub/utils/_errors.py
@@ -52,27 +52,44 @@ def _raise_for_status(request):
     Internal version of `request.raise_for_status()` that will refine a
     potential HTTPError.
     """
+    request_id = request.headers.get("X-Request-Id")
+
     if "X-Error-Code" in request.headers:
         error_code = request.headers["X-Error-Code"]
         if error_code == "RepoNotFound":
             raise RepositoryNotFoundError(
-                f"404 Client Error: Repository Not Found for url: {request.url}. "
-                "If the repo is private, make sure you are authenticated."
+                f"404 Client Error: Repository Not Found for url: {request.url}. If the"
+                " repo is private, make sure you are authenticated. (Request ID:"
+                f" f{request_id})"
             )
         elif error_code == "RevisionNotFound":
             raise RevisionNotFoundError(
-                f"404 Client Error: Revision Not Found for url: {request.url}"
+                f"404 Client Error: Revision Not Found for url: {request.url}. (Request"
+                f" ID: f{request_id})"
             )
         elif error_code == "EntryNotFound":
             raise EntryNotFoundError(
-                f"404 Client Error: Entry Not Found for url: {request.url}"
+                f"404 Client Error: Entry Not Found for url: {request.url}. (Request"
+                f" ID: f{request_id})"
             )
 
     if request.status_code == 401:
         # The repo was not found and the user is not Authenticated
         raise RepositoryNotFoundError(
-            f"401 Client Error: Repository Not Found for url: {request.url}. "
-            "If the repo is private, make sure you are authenticated."
+            f"401 Client Error: Repository Not Found for url: {request.url}. If the"
+            " repo is private, make sure you are authenticated. (Request ID:"
+            " f{request_id})"
         )
 
-    request.raise_for_status()
+    _raise_with_request_id(request)
+
+
+def _raise_with_request_id(request):
+    request_id = request.headers.get("X-Request-Id")
+    try:
+        request.raise_for_status()
+    except Exception as e:
+        if request_id is not None and len(e.args) and isinstance(e.args[0], str):
+            e.args = (e.args[0] + f" (Request ID: {request_id})",) + e.args[1:]
+
+        raise e.with_traceback(e.__traceback__)

--- a/src/huggingface_hub/utils/_errors.py
+++ b/src/huggingface_hub/utils/_errors.py
@@ -60,17 +60,17 @@ def _raise_for_status(request):
             raise RepositoryNotFoundError(
                 f"404 Client Error: Repository Not Found for url: {request.url}. If the"
                 " repo is private, make sure you are authenticated. (Request ID:"
-                f" f{request_id})"
+                f" {request_id})"
             )
         elif error_code == "RevisionNotFound":
             raise RevisionNotFoundError(
                 f"404 Client Error: Revision Not Found for url: {request.url}. (Request"
-                f" ID: f{request_id})"
+                f" ID: {request_id})"
             )
         elif error_code == "EntryNotFound":
             raise EntryNotFoundError(
                 f"404 Client Error: Entry Not Found for url: {request.url}. (Request"
-                f" ID: f{request_id})"
+                f" ID: {request_id})"
             )
 
     if request.status_code == 401:
@@ -78,7 +78,7 @@ def _raise_for_status(request):
         raise RepositoryNotFoundError(
             f"401 Client Error: Repository Not Found for url: {request.url}. If the"
             " repo is private, make sure you are authenticated. (Request ID:"
-            " f{request_id})"
+            f" {request_id})"
         )
 
     _raise_with_request_id(request)
@@ -92,4 +92,4 @@ def _raise_with_request_id(request):
         if request_id is not None and len(e.args) and isinstance(e.args[0], str):
             e.args = (e.args[0] + f" (Request ID: {request_id})",) + e.args[1:]
 
-        raise e.with_traceback(e.__traceback__)
+        raise e

--- a/src/huggingface_hub/utils/_errors.py
+++ b/src/huggingface_hub/utils/_errors.py
@@ -89,7 +89,7 @@ def _raise_with_request_id(request):
     try:
         request.raise_for_status()
     except Exception as e:
-        if request_id is not None and len(e.args) and isinstance(e.args[0], str):
+        if request_id is not None and len(e.args) > 0 and isinstance(e.args[0], str):
             e.args = (e.args[0] + f" (Request ID: {request_id})",) + e.args[1:]
 
         raise e

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -1076,7 +1076,7 @@ class HfApiPrivateTest(HfApiCommonTestWithLogin):
         )
 
     def test_model_info(self):
-        shutil.rmtree(os.path.dirname(HfFolder.path_token), ignore_errors=True)
+        shutil.rmtree(os.path.dirname(HfFolder.path_token))
         # Test we cannot access model info without a token
         with self.assertRaisesRegex(
             requests.exceptions.HTTPError,


### PR DESCRIPTION
This adds the `X-Request-ID` header to all requests that have it.

This will result in the following change:
```diff
- requests.exceptions.HTTPError: 401 Client Error: Unauthorized for url: https://huggingface.co/api/login
+ requests.exceptions.HTTPError: 401 Client Error: Unauthorized for url: https://huggingface.co/api/login (Request ID: T97cILAtyKzdWeL6dRYYW)
```


Closes https://github.com/huggingface/huggingface_hub/issues/906