### PR TITLE
Constant was accidentally removed during deprecation transition

### DIFF
--- a/src/huggingface_hub/snapshot_download.py
+++ b/src/huggingface_hub/snapshot_download.py
@@ -12,3 +12,4 @@ warnings.warn(
 )
 
 from ._snapshot_download import *  # noqa
+from .constants import REPO_ID_SEPARATOR  # noqa

--- a/tests/test_snapshot_download.py
+++ b/tests/test_snapshot_download.py
@@ -358,3 +358,7 @@ def test_snapshot_download_import():
         from huggingface_hub.snapshot_download import snapshot_download as x  # noqa
 
     assert x is snapshot_download
+
+
+def test_snapshot_download_import_constant_not_raise():
+    from huggingface_hub.snapshot_download import REPO_ID_SEPARATOR  # noqa


### PR DESCRIPTION
This constant was available before the deprecation notice, so it should be available during the warning transition period.
Note that the sentence-transformers library makes use of this constant [link to code](https://github.com/UKPLab/sentence-transformers/blob/3433c001e5a9e0991ea09e85f8861f38eb0d6583/sentence_transformers/util.py#L407)