### PR TITLE
FIX LFS track fix for Hub Mixin

### DIFF
--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -156,7 +156,6 @@ def snapshot_download(
     # If the specified revision is a commit hash, look inside "snapshots".
     # If the specified revision is a branch or tag, look inside "refs".
     if local_files_only:
-
         if REGEX_COMMIT_HASH.match(revision):
             commit_hash = revision
         else:

--- a/src/huggingface_hub/commands/user.py
+++ b/src/huggingface_hub/commands/user.py
@@ -253,7 +253,6 @@ class RepoCreateCommand(BaseUserCommand):
                 print("Abort")
                 exit()
         try:
-
             url = self._api.create_repo(
                 repo_id=repo_id,
                 token=token,

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -687,7 +687,6 @@ def cached_download(
         cache_path = "\\\\?\\" + os.path.abspath(cache_path)
 
     with FileLock(lock_path):
-
         # If the download just completed while the lock was activated.
         if os.path.exists(cache_path) and not force_download:
             # Even if returning early like here, the lock will be released.
@@ -1140,7 +1139,6 @@ def hf_hub_download(
         blob_path = "\\\\?\\" + os.path.abspath(blob_path)
 
     with FileLock(lock_path):
-
         # If the download just completed while the lock was activated.
         if os.path.exists(pointer_path) and not force_download:
             # Even if returning early like here, the lock will be released.

--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -319,7 +319,7 @@ class ModelHubMixin:
         self.save_pretrained(repo_path_or_name, config=config)
 
         # Commit and push!
-        repo.git_add()
+        repo.git_add(auto_lfs_track=True)
         repo.git_commit(commit_message)
         return repo.git_push()
 

--- a/src/huggingface_hub/utils/logging.py
+++ b/src/huggingface_hub/utils/logging.py
@@ -43,7 +43,6 @@ def _get_library_name() -> str:
 
 
 def _get_library_root_logger() -> logging.Logger:
-
     return logging.getLogger(_get_library_name())
 
 

--- a/src/huggingface_hub/utils/sha.py
+++ b/src/huggingface_hub/utils/sha.py
@@ -8,7 +8,8 @@ from typing import BinaryIO, Iterable, Optional
 def iter_fileobj(
     fileobj: BinaryIO, chunk_size: Optional[int] = None
 ) -> Iterable[bytes]:
-    """Returns an iterator over the content of ``fileobj`` in chunks of ``chunk_size``"""
+    """Returns an iterator over the content of ``fileobj`` in chunks of ``chunk_size``
+    """
     chunk_size = chunk_size or -1
     return iter(partial(fileobj.read, chunk_size), b"")
 

--- a/src/huggingface_hub/utils/sha.py
+++ b/src/huggingface_hub/utils/sha.py
@@ -8,8 +8,7 @@ from typing import BinaryIO, Iterable, Optional
 def iter_fileobj(
     fileobj: BinaryIO, chunk_size: Optional[int] = None
 ) -> Iterable[bytes]:
-    """Returns an iterator over the content of ``fileobj`` in chunks of ``chunk_size``
-    """
+    """Returns an iterator over the content of ``fileobj`` in chunks of ``chunk_size``"""
     chunk_size = chunk_size or -1
     return iter(partial(fileobj.read, chunk_size), b"")
 

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -394,7 +394,6 @@ class CommitApiTest(HfApiCommonTestWithLogin):
         with self.assertRaises(
             ValueError, msg="path_or_fileobj is str but does not point to a file"
         ):
-
             operation.validate()
 
     @retry_endpoint

--- a/tests/test_hubmixin.py
+++ b/tests/test_hubmixin.py
@@ -1,3 +1,4 @@
+import json
 import os
 import shutil
 import time
@@ -133,3 +134,21 @@ class HubMixingTest(HubMixingCommonTest):
         self.assertEqual(model_info.modelId, f"{USER}/{REPO_NAME}")
 
         self._api.delete_repo(repo_id=f"{REPO_NAME}", token=self._token)
+
+    def test_auto_lfs(self):
+
+        REPO_NAME = repo_name("PUSH_TO_HUB")
+        model = DummyModel()
+        large_file = [100] * int(4e6)
+
+        with open(f"{WORKING_REPO_DIR}/{REPO_NAME}/large_file.txt", "w+") as f:
+            f.write(json.dumps(large_file))
+
+        model.push_to_hub(
+            repo_path_or_name=f"{WORKING_REPO_DIR}/{REPO_NAME}",
+            api_endpoint=ENDPOINT_STAGING,
+            use_auth_token=self._token,
+            git_user="ci",
+            git_email="ci@dummy.com",
+            config={"num": 7, "act": "gelu_fast"},
+        )

--- a/tests/test_hubmixin.py
+++ b/tests/test_hubmixin.py
@@ -9,9 +9,8 @@ import uuid
 from huggingface_hub import HfApi
 from huggingface_hub.file_download import is_torch_available
 from huggingface_hub.hub_mixin import PyTorchModelHubMixin
-from huggingface_hub.utils import logging
 from huggingface_hub.repository import Repository
-
+from huggingface_hub.utils import logging
 
 from .testing_constants import ENDPOINT_STAGING, TOKEN, USER
 from .testing_utils import set_write_permission_and_retry
@@ -143,7 +142,7 @@ class HubMixingTest(HubMixingCommonTest):
         with tempfile.TemporaryDirectory() as tmpdirname:
             os.makedirs(f"{tmpdirname}/{WORKING_REPO_DIR}/{REPO_NAME}")
             self._repo_url = self._api.create_repo(repo_id=REPO_NAME, token=self._token)
-            repo = Repository(
+            Repository(
                 local_dir=f"{tmpdirname}/{WORKING_REPO_DIR}/{REPO_NAME}",
                 clone_from=self._repo_url,
             )

--- a/tests/test_hubmixin.py
+++ b/tests/test_hubmixin.py
@@ -142,15 +142,17 @@ class HubMixingTest(HubMixingCommonTest):
         REPO_NAME = repo_name("PUSH_TO_HUB_LFS")
         with tempfile.TemporaryDirectory() as tmpdirname:
             os.makedirs(f"{tmpdirname}/{WORKING_REPO_DIR}/{REPO_NAME}")
-            self._repo_url = self._api.create_repo(
-            repo_id=REPO_NAME, token=self._token
+            self._repo_url = self._api.create_repo(repo_id=REPO_NAME, token=self._token)
+            repo = Repository(
+                local_dir=f"{tmpdirname}/{WORKING_REPO_DIR}/{REPO_NAME}",
+                clone_from=self._repo_url,
             )
-            repo = Repository(local_dir = f"{tmpdirname}/{WORKING_REPO_DIR}/{REPO_NAME}",
-            clone_from=self._repo_url)
 
             model = DummyModel()
             large_file = [100] * int(4e6)
-            with open(f"{tmpdirname}/{WORKING_REPO_DIR}/{REPO_NAME}/large_file.txt", "w+") as f:
+            with open(
+                f"{tmpdirname}/{WORKING_REPO_DIR}/{REPO_NAME}/large_file.txt", "w+"
+            ) as f:
                 f.write(json.dumps(large_file))
 
             model.push_to_hub(
@@ -163,5 +165,7 @@ class HubMixingTest(HubMixingCommonTest):
             )
             model_info = self._api.model_info(f"{USER}/{REPO_NAME}", token=self._token)
 
-            self.assertTrue("large_file.txt" in [f.rfilename for f in model_info.siblings])
+            self.assertTrue(
+                "large_file.txt" in [f.rfilename for f in model_info.siblings]
+            )
             self._api.delete_repo(repo_id=f"{REPO_NAME}", token=self._token)

--- a/tests/test_hubmixin.py
+++ b/tests/test_hubmixin.py
@@ -140,7 +140,7 @@ class HubMixingTest(HubMixingCommonTest):
         REPO_NAME = repo_name("PUSH_TO_HUB")
         model = DummyModel()
         large_file = [100] * int(4e6)
-
+        model.save_pretrained(f"{WORKING_REPO_DIR}/{REPO_NAME}")
         with open(f"{WORKING_REPO_DIR}/{REPO_NAME}/large_file.txt", "w+") as f:
             f.write(json.dumps(large_file))
 
@@ -152,3 +152,7 @@ class HubMixingTest(HubMixingCommonTest):
             git_email="ci@dummy.com",
             config={"num": 7, "act": "gelu_fast"},
         )
+        model_info = self._api.model_info(f"{USER}/{REPO_NAME}", token=self._token)
+
+        self.assertTrue("large_file.txt" in [f.rfilename for f in model_info.siblings])
+        self._api.delete_repo(repo_id=f"{REPO_NAME}", token=self._token)

--- a/tests/test_hubmixin.py
+++ b/tests/test_hubmixin.py
@@ -141,7 +141,6 @@ class HubMixingTest(HubMixingCommonTest):
     def test_auto_lfs(self):
         REPO_NAME = repo_name("PUSH_TO_HUB_LFS")
         with tempfile.TemporaryDirectory() as tmpdirname:
-            breakpoint()
             os.makedirs(f"{tmpdirname}/{WORKING_REPO_DIR}/{REPO_NAME}")
             self._repo_url = self._api.create_repo(
             repo_id=REPO_NAME, token=self._token

--- a/tests/test_keras_integration.py
+++ b/tests/test_keras_integration.py
@@ -55,7 +55,6 @@ def require_tf(test_case):
 
 
 if is_tf_available():
-
     # Define dummy mixin model...
     class DummyModel(tf.keras.Model, KerasModelHubMixin):
         def __init__(self, **kwargs):

--- a/tests/test_lfs.py
+++ b/tests/test_lfs.py
@@ -45,7 +45,6 @@ class TestSliceFileObj(unittest.TestCase):
         self.content = b"RANDOM self.content uauabciabeubahveb" * 1024
 
     def test_slice_fileobj_BytesIO(self):
-
         fileobj = BytesIO(self.content)
         prev_pos = fileobj.tell()
 


### PR DESCRIPTION
Addresing [this](https://discuss.huggingface.co/t/push-keras-to-hub-fail-because-of-binary-files/19387/3) forum post. `git_add()` wasn't tracking for Hub Mixin so I fixed it.