### PR TITLE
Pin black to 22.3.0 to benefit from a stable --preview flag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ extras["testing"] = [
 ]
 
 extras["quality"] = [
-    "black~=22.0",
+    "black==22.3",
     "isort>=5.5.4",
     "flake8>=3.8.3",
 ]


### PR DESCRIPTION
Pins black to 22.3.0 in order to benefit from the --preview flag continuously. This flag adds reformats for strings, exceptions, logs, and others.

The recent black 22.6.0 version's --preview flag isn't compatible with the 22.3.0 and results in line changes.

This PR pins 22.3.0 as it was deemed the path with the least friction.