### PR TITLE
Docs: Fix some missing images and broken links

### DIFF
--- a/docs/source/how-to-downstream.mdx
+++ b/docs/source/how-to-downstream.mdx
@@ -20,7 +20,10 @@ specific file to download:
 'https://huggingface.co/lysandre/arxiv-nlp/resolve/main/config.json'
 ```
 
-![/docs/assets/hub/repo.png](/docs/assets/hub/repo.png)
+<div class="flex justify-center">
+<img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/repo.png"/>
+<img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/repo-dark.png"/>
+</div>
 
 Specify a particular file version by providing the file revision, which can be the
 branch name, a tag, or a commit hash. When using the commit hash, it must be the

--- a/docs/source/how-to-inference.mdx
+++ b/docs/source/how-to-inference.mdx
@@ -8,7 +8,10 @@ If you want to make the HTTP calls directly, please refer to [Accelerated Infere
 
 </Tip>
 
-![Snippet of code to make calls to the Inference API](/docs/assets/hub/inference_api_snippet.png)
+<div class="flex justify-center">
+<img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/inference_api_snippet.png"/>
+<img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/inference_api_snippet-dark.png"/>
+</div>
 
 Begin by creating an instance of the [`InferenceApi`] with the model repository ID of the model you want to use. You can find your `API_TOKEN` under Settings from your Hugging Face account. The `API_TOKEN` will allow you to send requests to the Inference API.
 
@@ -17,7 +20,7 @@ Begin by creating an instance of the [`InferenceApi`] with the model repository 
 >>> inference = InferenceApi(repo_id="bert-base-uncased", token=API_TOKEN)
 ```
 
-The metadata in the model card and configuration files (see [here](https://huggingface.co/docs/hub/main#how-is-a-models-type-of-inference-api-and-widget-determined) for more details) determines the pipeline type. For example, when using the [bert-base-uncased](https://huggingface.co/bert-base-uncased) model, the Inference API can automatically infer that this model should be used for a `fill-mask` task.
+The metadata in the model card and configuration files (see [here](https://huggingface.co/docs/hub/models-widgets#enabling-a-widget) for more details) determines the pipeline type. For example, when using the [bert-base-uncased](https://huggingface.co/bert-base-uncased) model, the Inference API can automatically infer that this model should be used for a `fill-mask` task.
 
 ```python
 >>> from huggingface_hub.inference_api import InferenceApi

--- a/docs/source/quick-start.mdx
+++ b/docs/source/quick-start.mdx
@@ -58,7 +58,7 @@ For more details and options, see the API reference for [`hf_hub_download`].
 
 To create and share files to the Hub, you need to have a Hugging Face account. [Create
 an account](https://hf.co/join) if you don't already have one, and then sign in to find
-your [User Access Token](https://huggingface.co/docs/hub/security#user-access-tokens) in
+your [User Access Token](https://huggingface.co/docs/hub/security-tokens) in
 your Settings. The User Access Token is used to authenticate your identity to the Hub.
 
 <Tip>


### PR DESCRIPTION
Fixes #929. When the hub-docs were separated from this repo, all the assets were moved to the documentation-images dataset on the Hub, and these links weren't fixed.

There are also a couple URLs to the hub-docs that I've fixed here.