### PR TITLE
:bug: Fix multilinguality filter value

### DIFF
--- a/src/huggingface_hub/utils/endpoint_helpers.py
+++ b/src/huggingface_hub/utils/endpoint_helpers.py
@@ -125,7 +125,7 @@ class DatasetFilter:
     >>> new_filter = DatasetFilter(language="en")
 
     >>> # Using multilinguality
-    >>> new_filter = DatasetFilter(multilinguality="yes")
+    >>> new_filter = DatasetFilter(multilinguality="multilingual")
 
     >>> # Using size_categories
     >>> new_filter = DatasetFilter(size_categories="100K<n<1M")

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -998,10 +998,10 @@ class HfApiPublicTest(unittest.TestCase):
     @with_production_testing
     def test_filter_datasets_by_multilinguality(self):
         _api = HfApi()
-        f = DatasetFilter(multilinguality="yes")
+        f = DatasetFilter(multilinguality="multilingual")
         datasets = _api.list_datasets(filter=f)
         self.assertGreater(len(datasets), 0)
-        self.assertTrue("multilinguality:yes" in datasets[0].tags)
+        self.assertTrue("multilinguality:multilingual" in datasets[0].tags)
 
     @with_production_testing
     def test_filter_datasets_by_size_categories(self):


### PR DESCRIPTION
There were some updates to dataset metadata on the Hub that caused the `multilinguality` filter to break and thus broke the CI. This PR fixes that issue.

CC @muellerzr 