### PR TITLE
[Doc] Update "Upload files to the Hub" doc

### DIFF
--- a/docs/dev/release.md
+++ b/docs/dev/release.md
@@ -51,5 +51,4 @@ __version__ = "<VERSION+1>.dev0"  # For example, after releasing v0.5.0 or v0.5.
 10. Push the changes!
 ```
 git push origin main
-    ```
-"""
+```

--- a/docs/source/how-to-upstream.mdx
+++ b/docs/source/how-to-upstream.mdx
@@ -1,11 +1,11 @@
 # Upload files to the Hub
 
-Sharing your files and work is a very important aspect of the Hub. The `huggingface_hub` uses a Git-based workflow to upload files to the Hub. You can use these functions independently or integrate them into your own library, making it more convenient for your users to interact with the Hub. This guide will show you how to:
+Sharing your files and work is a very important aspect of the Hub. The `huggingface_hub` uses a Git-based workflow to upload files to the Hub, but in most cases you don't need git or git-lfs installed locally. You can use these functions independently or integrate them into your own library, making it more convenient for your users to interact with the Hub. This guide will show you how to:
 
+* Push files directly from this library's [`HfApi`], without even needing Git or git-lfs installed.
+* Push files from the command line using git and [Git LFS](https://git-lfs.github.com/).
 * Push files with a `commit` context manager.
 * Push files with the [`~Repository.push_to_hub`] function.
-* Upload very large files with [Git LFS](https://git-lfs.github.com/).
-* Push files without Git installed with [`HfApi`]
 
 Whenever you want to upload files to the Hub, you need to log in to your Hugging Face account:
 
@@ -22,9 +22,58 @@ Whenever you want to upload files to the Hub, you need to log in to your Hugging
    >>> notebook_login()
    ```
 
-   [`notebook_login`] will launch a widget in your notebook from which you can enter your Hugging Face credentials.
 
-## commit context manager
+## Push files directly from this library's [`HfApi`] with the `create_commit` API
+
+`huggingface_hub` offers a way to upload files to the Hub without Git installed on your system with the [`create_commit`] method of [`HfApi`].
+For example, if you want to upload two files and delete another file in a Hub repo, in a single commit:
+
+```py
+>>> from huggingface_hub import HfApi, CommitOperationAdd, CommitOperationDelete
+>>> api = HfApi()
+>>> operations = [
+...     CommitOperationAdd(path_in_repo="LICENSE.md", path_or_fileobj="~/repo/LICENSE.md"),
+...     CommitOperationAdd(path_in_repo="weights.h5", path_or_fileobj="~/repo/weights-final.h5"),
+...     CommitOperationDelete(path_in_repo="old-weights.h5"),
+... ]
+>>> api.create_commit(
+...     repo_id="lysandre/test-model",
+...     operations=operations,
+... )
+```
+
+[`create_commit`] uses the HTTP protocol to upload files to the Hub. It automatically takes care of uploading large files and binary files with the Git LFS protocol.
+There are two operations supported by the [`create_commit`] method:
+
+1. [`CommitOperationAdd`] to upload a file to the Hub. If the file already exists, its content will be overwritten. It takes two arguments:
+   * `path_in_repo`: the path in the repository where the file should be uploaded
+   * `path_or_fileobj`: either a path to a file on your filesystem, or a file-like object. The content of the file to upload to the Hub.
+2. [`CommitOperationDelete`] to remove a file from a repository. It takes `path_in_repo` as an argument.
+
+Instead of [`create_commit`], you can also use the following convenience methods:
+* [`upload_file`] to upload a single file to a repo on the Hub
+* [`upload_folder`] to upload a local directory to a repo on the Hub
+* [`delete_file`] to delete a single file from a repo on the Hub 
+* [`metadata_update`] to update a repo's metadata
+
+All these methods use the `create_commit` API under the hood.
+For a more detailed description, visit the [`hf_api`] documentation page.
+
+## Push from Git and Git LFS on the command line
+
+You can always also use Git and Git LFS on the command line to push your changes to your repo.
+
+Note that for huge files (>5GB), you need to install a custom transfer agent for Git LFS:
+
+```bash
+huggingface-cli lfs-enable-largefiles
+```
+
+You should install this for each model repository that contains a model file. Once installed, you are now able to push files larger than 5GB.
+
+## Push with a commit context manager
+
+This is another option to programmatically push changes to your repo, but this one uses git and git-lfs under the hood (so it requires to have them installed locally).
 
 The `commit` context manager handles four of the most common Git commands: pull, add, commit, and push. `git-lfs` automatically tracks any file larger than 10MB. In the following example, the `commit` context manager:
 
@@ -83,9 +132,9 @@ When `blocking=False`, commands are tracked, and your script will only exit when
 >>> last_command.failed
 ```
 
-## push_to_hub
+## Repository.push_to_hub
 
-The [`Repository`] class also has a [`~Repository.push_to_hub`] function to add files, make a commit, and push them to a repository. Unlike the `commit` context manager, [`~Repository.push_to_hub`] requires you to pull from a repository first, save the files, and then call [`~Repository.push_to_hub`].
+Finally, the [`Repository`] class also has a [`~Repository.push_to_hub`] function to add files, make a commit, and push them to a repository. Unlike the `commit` context manager, [`~Repository.push_to_hub`] requires you to pull from a repository first, save the files, and then call [`~Repository.push_to_hub`].
 
 ```python
 >>> from huggingface_hub import Repository
@@ -105,49 +154,3 @@ Once you're ready, you can push your file to your repository with [`~Repository.
 ```py
 >>> repo.git_push()
 ```
-
-## Upload with Git LFS
-
-For huge files (>5GB), you need to install a custom transfer agent for Git LFS:
-
-```bash
-huggingface-cli lfs-enable-largefiles
-```
-
-You should install this for each model repository that contains a model file. Once installed, you are now able to push files larger than 5GB.
-
-## Managing files in a repo without Git with the `create_commit` API
-
-`huggingface_hub` also offers a way to upload files to the Hub without Git installed on your system with the [`create_commit`] method of [`HfApi`].
-For example, if you want to upload two files and delete another file in a Hub repo:
-
-```py
->>> from huggingface_hub import HfApi, CommitOperationAdd, CommitOperationDelete
->>> api = HfApi()
->>> operations = [
-...     CommitOperationAdd(path_in_repo="LICENSE.md", path_or_fileobj="~/repo/LICENSE.md"),
-...     CommitOperationAdd(path_in_repo="weights.h5", path_or_fileobj="~/repo/weights-final.h5"),
-...     CommitOperationDelete(path_in_repo="old-weights.h5"),
-... ]
->>> api.create_commit(
-...     repo_id="lysandre/test-model",
-...     operations=operations,
-... )
-```
-
-[`create_commit`] uses the HTTP protocol to upload files to the Hub. It automatically takes care of uploading large files and binary files with the Git LFS protocol.
-There are currently two kind of operations supported by the [`create_commit`] method:
-
-1. [`CommitOperationAdd`] to upload a file to the Hub. If the file already exists, its content will be overwritten. It takes two arguments:
-   * `path_in_repo`: the path in the repository where the file should be uploaded
-   * `path_or_fileobj`: either a path to a file on your filesystem, or a file-like object. The content of the file to upload to the Hub.
-2. [`CommitOperationDelete`] to remove a file from a repository. It takes `path_in_repo` as an argument.
-
-Instead of [`create_commit`], you can also use the following convenience methods:
-* [`upload_file`] to upload a single file to a repo on the Hub
-* [`upload_folder`] to upload a local directory to a repo on the Hub
-* [`delete_file`] to delete a single file from a repo on the Hub 
-* [`metadata_update`] to update a repo's metadata
-
-All these methods use the `create_commit` API under the hood.
-For a more detailed description, visit the [`hf_api`] documentation page.

--- a/docs/source/quick-start.mdx
+++ b/docs/source/quick-start.mdx
@@ -121,8 +121,7 @@ need to specify:
 ```
 
 To upload more than one file at a time, take a look at this [guide](how-to-upstream)
-which will introduce you to the [`Repository`] class and other methods for uploading
-files.
+which will introduce you to several methods for uploading files.
 
 ## Next steps
 

--- a/src/huggingface_hub/README.md
+++ b/src/huggingface_hub/README.md
@@ -92,7 +92,7 @@ to the Hub: https://huggingface.co/docs/hub/adding-a-model.
 
 ### API utilities in `hf_api.py`
 
-You don't need them for the standard publishing workflow, however, if you need a
+You don't need them for the standard publishing workflow (ie. using git command line), however, if you need a
 programmatic way of creating a repo, deleting it (`⚠️ caution`), pushing a
 single file to a repo or listing models from the Hub, you'll find helpers in
 `hf_api.py`. Some example functionality available with the `HfApi` class:
@@ -105,6 +105,7 @@ single file to a repo or listing models from the Hub, you'll find helpers in
 * `list_repo_objects()`
 * `delete_repo()`
 * `update_repo_visibility()`
+* `create_commit()`
 * `upload_file()`
 * `delete_file()`
 
@@ -297,7 +298,7 @@ if other errors happen in your script (a failed push counts as done).
 
 ### Need to upload very large (>5GB) files?
 
-To upload large files (>5GB 🔥), you need to install the custom transfer agent
+To upload large files (>5GB 🔥) from git command-line, you need to install the custom transfer agent
 for git-lfs, bundled in this package. 
 
 To install, just run:


### PR DESCRIPTION
Main change is to re-order the methods presented in `how to upload` doc to steer users to (in that order):

1. `create_commit` and related methods
2. git and git-lfs command line
3. `Repository` based methods
