### PR TITLE
🩹 Remove mutable default params

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -211,7 +211,7 @@ class ModelInfo:
         modelId: Optional[str] = None,
         sha: Optional[str] = None,
         lastModified: Optional[str] = None,
-        tags: List[str] = [],
+        tags: Optional[List[str]] = None,
         pipeline_tag: Optional[str] = None,
         siblings: Optional[List[Dict]] = None,
         private: Optional[bool] = None,
@@ -222,7 +222,7 @@ class ModelInfo:
         self.modelId = modelId
         self.sha = sha
         self.lastModified = lastModified
-        self.tags = tags
+        self.tags = tags if tags is not None else []
         self.pipeline_tag = pipeline_tag
         self.siblings = (
             [RepoFile(**x) for x in siblings] if siblings is not None else None
@@ -281,7 +281,7 @@ class DatasetInfo:
         id: Optional[str] = None,
         sha: Optional[str] = None,
         lastModified: Optional[str] = None,
-        tags: List[str] = [],
+        tags: Optional[List[str]] = None,
         siblings: Optional[List[Dict]] = None,
         private: Optional[bool] = None,
         author: Optional[str] = None,
@@ -293,7 +293,7 @@ class DatasetInfo:
         self.id = id
         self.sha = sha
         self.lastModified = lastModified
-        self.tags = tags
+        self.tags = tags if tags is not None else []
         self.private = private
         self.author = author
         self.description = description

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -222,7 +222,7 @@ class ModelInfo:
         self.modelId = modelId
         self.sha = sha
         self.lastModified = lastModified
-        self.tags = tags or []
+        self.tags = tags
         self.pipeline_tag = pipeline_tag
         self.siblings = (
             [RepoFile(**x) for x in siblings] if siblings is not None else None
@@ -293,7 +293,7 @@ class DatasetInfo:
         self.id = id
         self.sha = sha
         self.lastModified = lastModified
-        self.tags = tags or []
+        self.tags = tags
         self.private = private
         self.author = author
         self.description = description

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -222,7 +222,7 @@ class ModelInfo:
         self.modelId = modelId
         self.sha = sha
         self.lastModified = lastModified
-        self.tags = tags if tags is not None else []
+        self.tags = tags or []
         self.pipeline_tag = pipeline_tag
         self.siblings = (
             [RepoFile(**x) for x in siblings] if siblings is not None else None
@@ -293,7 +293,7 @@ class DatasetInfo:
         self.id = id
         self.sha = sha
         self.lastModified = lastModified
-        self.tags = tags if tags is not None else []
+        self.tags = tags or []
         self.private = private
         self.author = author
         self.description = description


### PR DESCRIPTION
Using mutable defaults for function parameters is a bad practice that can lead to unexpected and tricky bugs.

Defaults are evaluated only once at import time. A new list is created once when the function is defined, and the same list is used in each successive call. Mutating the `tags` argument would result in mutating the default for subsequent calls of the method.

See https://docs.python-guide.org/writing/gotchas/#mutable-default-arguments