### PR TITLE
✨ create_commit: more user-friendly errors on HTTP 400

### DIFF
--- a/src/huggingface_hub/_commit_api.py
+++ b/src/huggingface_hub/_commit_api.py
@@ -360,6 +360,8 @@ def fetch_upload_modes(
     Raises:
         :class:`requests.HTTPError`:
             If the Hub API returned an error
+        :class:`ValueError`:
+            If the Hub API returned an HTTP 400 error (bad request)
     """
     endpoint = endpoint if endpoint is not None else ENDPOINT
     headers = {"authorization": f"Bearer {token}"} if token is not None else None

--- a/src/huggingface_hub/_commit_api.py
+++ b/src/huggingface_hub/_commit_api.py
@@ -380,7 +380,7 @@ def fetch_upload_modes(
         json=payload,
         headers=headers,
     )
-    _raise_convert_bad_request(resp)
+    _raise_convert_bad_request(resp, endpoint_name="preupload")
 
     preupload_info = validate_preupload_info(resp.json())
 

--- a/src/huggingface_hub/_commit_api.py
+++ b/src/huggingface_hub/_commit_api.py
@@ -23,6 +23,7 @@ import requests
 from .constants import ENDPOINT
 from .lfs import UploadInfo, _validate_batch_actions, lfs_upload, post_lfs_batch_info
 from .utils import logging
+from .utils._errors import _raise_convert_bad_request
 
 
 logger = logging.get_logger(__name__)
@@ -379,7 +380,7 @@ def fetch_upload_modes(
         json=payload,
         headers=headers,
     )
-    resp.raise_for_status()
+    _raise_convert_bad_request(resp)
 
     preupload_info = validate_preupload_info(resp.json())
 

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -1861,6 +1861,10 @@ class HfApi:
             `str` or `None`:
                 If `create_pr` is `True`, returns the URL to the newly created Pull Request
                 on the Hub. Otherwise returns `None`.
+
+        Raises:
+            :class:`ValueError`:
+                If the Hub API returns an HTTP 400 error (bad request)
         """
         commit_description = (
             commit_description if commit_description is not None else ""

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -43,7 +43,11 @@ from .constants import (
 )
 from .utils import logging
 from .utils._deprecation import _deprecate_positional_args
-from .utils._errors import _raise_for_status, _raise_with_request_id
+from .utils._errors import (
+    _raise_convert_bad_request,
+    _raise_for_status,
+    _raise_with_request_id,
+)
 from .utils.endpoint_helpers import (
     AttributeDictionary,
     DatasetFilter,
@@ -1916,7 +1920,7 @@ class HfApi:
             json=commit_payload,
             params={"create_pr": 1} if create_pr else None,
         )
-        _raise_for_status(commit_resp)
+        _raise_convert_bad_request(commit_resp)
         return commit_resp.json().get("pullRequestUrl", None)
 
     def upload_file(

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -1920,7 +1920,7 @@ class HfApi:
             json=commit_payload,
             params={"create_pr": 1} if create_pr else None,
         )
-        _raise_convert_bad_request(commit_resp)
+        _raise_convert_bad_request(commit_resp, endpoint_name="commit")
         return commit_resp.json().get("pullRequestUrl", None)
 
     def upload_file(

--- a/src/huggingface_hub/utils/_errors.py
+++ b/src/huggingface_hub/utils/_errors.py
@@ -67,6 +67,7 @@ class BadRequestError(ValueError, HTTPError):
     huggingface_hub.utils._errors.BadRequestError: Bad request for check endpoint: {details} (Request ID: XXX)
     ```
     """
+
     def __init__(self, message, response):
         super().__init__(message, response=response)
 
@@ -147,7 +148,8 @@ def _raise_convert_bad_request(resp: Response, endpoint_name: str):
             raise exc
         if resp.status_code == 400 and details:
             raise BadRequestError(
-                f"Bad request for {endpoint_name} endpoint: {details} (Request ID: {request_id})",
+                f"Bad request for {endpoint_name} endpoint: {details} (Request ID:"
+                f" {request_id})",
                 response=resp,
             ) from exc
         _add_request_id_to_error_args(exc, request_id=request_id)


### PR DESCRIPTION
Related to #962 

This PR converts HTTP 400 errors from `/api/preupload` and `/api/commit` APIs into `ValueError`s

Suggestions/feedback welcome
