### PR TITLE
Enable flake8 on W605

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,5 +48,5 @@ multi_line_output = 3
 use_parentheses = True
 
 [flake8]
-ignore = E203, E501, E741, W503, W605
+ignore = E203, E501, E741, W503
 max-line-length = 88

--- a/src/huggingface_hub/utils/endpoint_helpers.py
+++ b/src/huggingface_hub/utils/endpoint_helpers.py
@@ -54,7 +54,7 @@ def _filter_emissions(
                 if emission:
                     emission = str(emission)
                     if any(char.isdigit() for char in emission):
-                        emission = re.search("\d+\.\d+|\d+", emission).group(0)
+                        emission = re.search(r"\d+\.\d+|\d+", emission).group(0)
                         emissions.append((i, float(emission)))
     filtered_results = []
     for idx, emission in emissions:


### PR DESCRIPTION
Low priority but W605 was disabled in flake8 checks. This PR re-enables it.

In short, since `"\d"` is not a proper escape sequence, python converts it to a `"\\d"` (and generates a `DeprecationWarning `). Good practice is to use the a r-string `r"\d"`.

This can also lead to misleading escape ("n" is escaped but not "d" in the example below):
```py
>>> "\n\d"
'\n\\d'
>>> r"\n\d"
'\\n\\d'
```