### PR TITLE
Disable codecov + configure pytest FutureWarnings

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -42,14 +42,11 @@ jobs:
       - run: |
           if [[ "${{ matrix.test_repository }}" == "Repository only" ]]
           then
-            pytest --cov -Werror::FutureWarning --log-cli-level=INFO -sv ./tests/test_repository.py -k RepositoryTest
+            pytest --log-cli-level=INFO -sv ./tests/test_repository.py -k RepositoryTest
 
           else
-            pytest --cov -Werror::FutureWarning --log-cli-level=INFO -sv ./tests/ -k 'not RepositoryTest'
+            pytest --log-cli-level=INFO -sv ./tests/ -k 'not RepositoryTest'
           fi
-
-      - name: Upload coverage reports to Codecov with GitHub Action
-        uses: codecov/codecov-action@v3
 
   build_pytorch:
     runs-on: ubuntu-latest
@@ -70,10 +67,7 @@ jobs:
         pip install --upgrade pip
         pip install .[testing,torch]
 
-    - run: pytest --cov -Werror::FutureWarning -sv ./tests/test_hubmixin*
-
-    - name: Upload coverage reports to Codecov with GitHub Action
-      uses: codecov/codecov-action@v3
+    - run: pytest -sv ./tests/test_hubmixin*
 
   build_tensorflow:
     runs-on: ubuntu-latest
@@ -95,12 +89,9 @@ jobs:
         pip install --upgrade pip
         pip install .[testing,tensorflow]
 
-    - run: pytest --cov -Werror::FutureWarning -sv ./tests/test_tf*
+    - run: pytest -sv ./tests/test_tf*
 
-    - run: pytest --cov -Werror::FutureWarning -sv ./tests/test_keras*
-
-    - name: Upload coverage reports to Codecov with GitHub Action
-      uses: codecov/codecov-action@v3
+    - run: pytest -sv ./tests/test_keras*
 
   build_fastai:
     runs-on: ubuntu-latest
@@ -121,10 +112,7 @@ jobs:
         pip install --upgrade pip
         pip install .[testing,fastai]
 
-    - run: pytest --cov -Werror::FutureWarning -sv ./tests/test_fastai*
-
-    - name: Upload coverage reports to Codecov with GitHub Action
-      uses: codecov/codecov-action@v3
+    - run: pytest -sv ./tests/test_fastai*
 
   tests_lfs:
     runs-on: ubuntu-latest
@@ -146,7 +134,4 @@ jobs:
         pip install --upgrade pip
         pip install .[testing]
 
-    - run: RUN_GIT_LFS_TESTS=1 pytest --cov -Werror::FutureWarning -sv ./tests/ -k "HfLargefilesTest"
-
-    - name: Upload coverage reports to Codecov with GitHub Action
-      uses: codecov/codecov-action@v3
+    - run: RUN_GIT_LFS_TESTS=1 pytest -sv ./tests/ -k "HfLargefilesTest"

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,3 +50,6 @@ use_parentheses = True
 [flake8]
 ignore = E203, E501, E741, W503, W605
 max-line-length = 88
+
+[tool:pytest]
+addopts = -Werror::FutureWarning

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ extras["tensorflow"] = ["tensorflow", "pydot", "graphviz"]
 
 extras["testing"] = [
     "pytest",
-    "pytest-cov",
     "datasets",
     "soundfile",
 ]


### PR DESCRIPTION
## What does this PR do?

In the CI, we currently run the tests with the `--cov` option to get a code coverage report. However, as pointed out by @osanseviero in this PR (https://github.com/huggingface/huggingface_hub/pull/925), it is broken at the moment and only check coverage of the tests themselves. It has apparently already been discussed [here (internal url)](https://huggingface.slack.com/archives/C02V5EA0A95/p1657176912893549?thread_ts=1657099388.126399&cid=C02V5EA0A95) and [here (internal url)](https://huggingface.slack.com/archives/C02V5EA0A95/p1655984527352979). The purpose of the PR is to simply remove coverage for now as it is broken and give unreliable information. I will create a separate issue to fix it and enable it again (EDIT: this one https://github.com/huggingface/huggingface_hub/issues/977).

Also, this PR sets the `-Werror::FutureWarning` flag by default. This should lead to less friction as contributors will run exactly the same tests locally and on CI.
