### PR TITLE
Add utility to load files from cache

### DIFF
--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -141,7 +141,12 @@ __getattr__, __dir__, __all__ = _attach(
             "from_pretrained_fastai",
             "push_to_hub_fastai",
         ],
-        "file_download": ["cached_download", "hf_hub_download", "hf_hub_url"],
+        "file_download": [
+            "cached_download",
+            "hf_hub_download",
+            "hf_hub_url",
+            "try_to_load_from_cache",
+        ],
         "hf_api": [
             "CommitOperation",
             "CommitOperationAdd",

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1199,9 +1199,9 @@ def try_to_load_from_cache(
 ) -> Optional[str]:
     """
     Explores the cache to return the latest cached file for a given revision if found.
-    
+
     This function will not raise any exception if the file in not cached.
-    
+
     Returns:
         Local path (string) of file or `None` if no cached file is found.
     """
@@ -1214,26 +1214,28 @@ def try_to_load_from_cache(
             f"Invalid repo type: {repo_type}. Accepted repo types are:"
             f" {str(REPO_TYPES)}"
         )
+    if cache_dir is None:
+        cache_dir = HUGGINGFACE_HUB_CACHE
 
-    model_id = repo_id.replace("/", "--")
-    model_cache = os.path.join(cache_dir, f"{repo_type}--{model_id}")
-    if not os.path.isdir(model_cache):
+    object_id = repo_id.replace("/", "--")
+    repo_cache = os.path.join(cache_dir, f"{repo_type}s--{object_id}")
+    if not os.path.isdir(repo_cache):
         # No cache for this model
         return None
     for subfolder in ["refs", "snapshots"]:
-        if not os.path.isdir(os.path.join(model_cache, subfolder)):
+        if not os.path.isdir(os.path.join(repo_cache, subfolder)):
             return None
 
     # Resolve refs (for instance to convert main to the associated commit sha)
-    cached_refs = os.listdir(os.path.join(model_cache, "refs"))
+    cached_refs = os.listdir(os.path.join(repo_cache, "refs"))
     if revision in cached_refs:
-        with open(os.path.join(model_cache, "refs", revision)) as f:
+        with open(os.path.join(repo_cache, "refs", revision)) as f:
             revision = f.read()
 
-    cached_shas = os.listdir(os.path.join(model_cache, "snapshots"))
+    cached_shas = os.listdir(os.path.join(repo_cache, "snapshots"))
     if revision not in cached_shas:
         # No cache for this revision and we won't try to return a random revision
         return None
 
-    cached_file = os.path.join(model_cache, "snapshots", revision, filename)
+    cached_file = os.path.join(repo_cache, "snapshots", revision, filename)
     return cached_file if os.path.isfile(cached_file) else None

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1190,9 +1190,20 @@ def hf_hub_download(
     return pointer_path
 
 
-def try_to_load_from_cache(cache_dir, repo_id, filename, revision=None, repo_type=None):
+def try_to_load_from_cache(
+    repo_id: str,
+    filename: str,
+    cache_dir: Union[str, Path, None] = None,
+    revision: Optional[str] = None,
+    repo_type: Optional[str] = None,
+) -> Optional[str]:
     """
-    Explores the cache to return the latest cached file for a given revision.
+    Explores the cache to return the latest cached file for a given revision if found.
+    
+    This function will not raise any exception if the file in not cached.
+    
+    Returns:
+        Local path (string) of file or `None` if no cached file is found.
     """
     if revision is None:
         revision = "main"

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1190,15 +1190,22 @@ def hf_hub_download(
     return pointer_path
 
 
-def try_to_load_from_cache(cache_dir, repo_id, filename, revision=None):
+def try_to_load_from_cache(cache_dir, repo_id, filename, revision=None, repo_type=None):
     """
     Explores the cache to return the latest cached file for a given revision.
     """
     if revision is None:
         revision = "main"
+    if repo_type is None:
+        repo_type = "model"
+    if repo_type not in REPO_TYPES:
+        raise ValueError(
+            f"Invalid repo type: {repo_type}. Accepted repo types are:"
+            f" {str(REPO_TYPES)}"
+        )
 
     model_id = repo_id.replace("/", "--")
-    model_cache = os.path.join(cache_dir, f"models--{model_id}")
+    model_cache = os.path.join(cache_dir, f"{repo_type}--{model_id}")
     if not os.path.isdir(model_cache):
         # No cache for this model
         return None

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -16,7 +16,6 @@ import unittest
 
 from huggingface_hub.constants import (
     CONFIG_NAME,
-    HUGGINGFACE_HUB_CACHE,
     PYTORCH_WEIGHTS_NAME,
     REPO_TYPE_DATASET,
 )
@@ -193,29 +192,23 @@ class CachedDownloadTests(unittest.TestCase):
         # Make sure the file is cached
         filepath = hf_hub_download(DUMMY_MODEL_ID, filename=CONFIG_NAME)
 
+        new_file_path = try_to_load_from_cache(DUMMY_MODEL_ID, filename=CONFIG_NAME)
+        self.assertEqual(filepath, new_file_path)
+
         new_file_path = try_to_load_from_cache(
-            HUGGINGFACE_HUB_CACHE, DUMMY_MODEL_ID, filename=CONFIG_NAME
+            DUMMY_MODEL_ID, filename=CONFIG_NAME, revision="main"
         )
         self.assertEqual(filepath, new_file_path)
 
         # If file is not cached, returns None
-        self.assertIsNone(
-            try_to_load_from_cache(
-                HUGGINGFACE_HUB_CACHE, DUMMY_MODEL_ID, filename="conf.json"
-            )
-        )
+        self.assertIsNone(try_to_load_from_cache(DUMMY_MODEL_ID, filename="conf.json"))
         # Same for uncached revisions
         self.assertIsNone(
             try_to_load_from_cache(
-                HUGGINGFACE_HUB_CACHE,
                 DUMMY_MODEL_ID,
                 filename=CONFIG_NAME,
                 revision="aaa",
             )
         )
         # Same for uncached models
-        self.assertIsNone(
-            try_to_load_from_cache(
-                HUGGINGFACE_HUB_CACHE, "bert-base", filename=CONFIG_NAME
-            )
-        )
+        self.assertIsNone(try_to_load_from_cache("bert-base", filename=CONFIG_NAME))


### PR DESCRIPTION
This PR adds the utility we use in Transformers to check if a file is in the cache when there is a connection error, while making it handle any repo type. I haven't done anything for it to be automatically used in case of connection error in `hf_hub_download`, as I don't know if it's something you want automatically baked in the library or not (in Transformers, we use this to load the files from the cache when there is any connection error, for instance a downtime on hf.co).

See [this comment](https://github.com/huggingface/transformers/pull/18438#discussion_r941304410) where we were talking of moving is here.