### PR TITLE
Handle redirections in `hf_hub_download` for a renamed repo

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -470,6 +470,14 @@ def _request_wrapper(
     return response
 
 
+def _request_with_retry(*args, **kwargs) -> requests.Response:
+    """Deprecated method. Please use `_request_wrapper` instead.
+
+    Alias to keep backward compatibility (used in Transformers).
+    """
+    return _request_wrapper(*args, **kwargs)
+
+
 def http_get(
     url: str,
     temp_file: BinaryIO,

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -13,7 +13,7 @@ from functools import partial
 from hashlib import sha256
 from pathlib import Path
 from typing import BinaryIO, Dict, Optional, Tuple, Union
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 
 import packaging.version
 from tqdm.auto import tqdm
@@ -366,7 +366,7 @@ def _raise_if_offline_mode_is_enabled(msg: Optional[str] = None):
         )
 
 
-def _request_with_retry(
+def _request_wrapper(
     method: str,
     url: str,
     *,
@@ -374,34 +374,79 @@ def _request_with_retry(
     base_wait_time: float = 0.5,
     max_wait_time: float = 2,
     timeout: float = 10.0,
+    force_internal_redirects: bool = False,
     **params,
 ) -> requests.Response:
-    """Wrapper around requests to retry in case it fails with a `ConnectTimeout`, with
-    exponential backoff.
+    """Wrapper around requests methods to add several features.
 
-        Note that if the environment variable HF_HUB_OFFLINE is set to 1, then a
-        `OfflineModeIsEnabled` error is raised.
+    What it does:
+    1. Ensure offline mode is disabled (env variable `HF_HUB_OFFLINE` not set to 1).
+       If enabled, a `OfflineModeIsEnabled` exception is raised.
+    2. Handle internal redirection (if `force_internal_redirects=True`).
+    3. Retry in case request fails with a `ConnectTimeout`, with exponential backoff.
 
-        Args:
-            method (`str`):
-                HTTP method, such as 'GET' or 'HEAD'.
-            url (`str`):
-                The URL of the resource to fetch.
-            max_retries (`int`, *optional*, defaults to `0`):
-                Maximum number of retries, defaults to 0 (no retries).
-            base_wait_time (`float`, *optional*, defaults to `0.5`):
-                Duration (in seconds) to wait before retrying the first time.
-                Wait time between retries then grows exponentially, capped by
-                `max_wait_time`.
-            max_wait_time (`float`, *optional*, defaults to `2`):
-                Maximum amount of time between two retries, in seconds.
-            timeout (`float`, *optional*, defaults to `10`):
-                How many seconds to wait for the server to send data before
-                giving up which is passed to `requests.request`.
-            **params (`dict`, *optional*):
-                Params to pass to `requests.request`.
+    Args:
+        method (`str`):
+            HTTP method, such as 'GET' or 'HEAD'.
+        url (`str`):
+            The URL of the resource to fetch.
+        max_retries (`int`, *optional*, defaults to `0`):
+            Maximum number of retries, defaults to 0 (no retries).
+        base_wait_time (`float`, *optional*, defaults to `0.5`):
+            Duration (in seconds) to wait before retrying the first time.
+            Wait time between retries then grows exponentially, capped by
+            `max_wait_time`.
+        max_wait_time (`float`, *optional*, defaults to `2`):
+            Maximum amount of time between two retries, in seconds.
+        timeout (`float`, *optional*, defaults to `10`):
+            How many seconds to wait for the server to send data before
+            giving up which is passed to `requests.request`.
+        force_internal_redirects (`bool`, *optional*, defaults to `False`)
+            If True, internal (relative) redirection will be resolved even when
+            `allow_redirection` is set to False.
+        **params (`dict`, *optional*):
+            Params to pass to `requests.request`.
     """
+    # 1. Check online mode
     _raise_if_offline_mode_is_enabled(f"Tried to reach {url}")
+
+    # 2. Force internal redirection
+    if force_internal_redirects:
+        response = _request_wrapper(
+            method=method,
+            url=url,
+            max_retries=max_retries,
+            base_wait_time=base_wait_time,
+            max_wait_time=max_wait_time,
+            timeout=timeout,
+            force_internal_redirects=False,
+            **params,
+        )
+
+        # If redirection, we redirect only relative paths.
+        # This is useful in case of a renamed repository.
+        if 300 <= response.status_code <= 399:
+            parsed_target = urlparse(response.headers["Location"])
+            if parsed_target.netloc == "":
+                # This means it is a relative 'location' headers, as allowed by RFC 7231.
+                # (e.g. '/path/to/resource' instead of 'http://domain.tld/path/to/resource')
+                # We want to follow this internal redirect !
+                #
+                # Highly inspired by `resolve_redirects` from requests library.
+                # See https://github.com/psf/requests/blob/main/requests/sessions.py#L159
+                return _request_wrapper(
+                    method=method,
+                    url=urlparse(url)._replace(path=parsed_target.path).geturl(),
+                    max_retries=max_retries,
+                    base_wait_time=base_wait_time,
+                    max_wait_time=max_wait_time,
+                    timeout=timeout,
+                    force_internal_redirects=True,
+                    **params,
+                )
+        return response
+
+    # 3. Exponential backoff
     tries, success = 0, False
     while not success:
         tries += 1
@@ -441,7 +486,7 @@ def http_get(
     headers = copy.deepcopy(headers)
     if resume_size > 0:
         headers["Range"] = "bytes=%d-" % (resume_size,)
-    r = _request_with_retry(
+    r = _request_wrapper(
         method="GET",
         url=url,
         stream=True,
@@ -592,11 +637,12 @@ def cached_download(
     etag = None
     if not local_files_only:
         try:
-            r = _request_with_retry(
+            r = _request_wrapper(
                 method="HEAD",
                 url=url,
                 headers=headers,
                 allow_redirects=False,
+                force_internal_redirects=True,
                 proxies=proxies,
                 timeout=etag_timeout,
             )
@@ -610,10 +656,10 @@ def cached_download(
                     "Distant resource does not have an ETag, we won't be able to"
                     " reliably ensure reproducibility."
                 )
-            # In case of a redirect,
-            # save an extra redirect on the request.get call,
+            # In case of a redirect, save an extra redirect on the request.get call,
             # and ensure we download the exact atomic version even if it changed
             # between the HEAD and the GET (unlikely, but hey).
+            # Useful for lfs blobs that are stored on a CDN.
             if 300 <= r.status_code <= 399:
                 url_to_download = r.headers["Location"]
         except (requests.exceptions.SSLError, requests.exceptions.ProxyError):
@@ -1008,11 +1054,12 @@ def hf_hub_download(
     commit_hash = None
     if not local_files_only:
         try:
-            r = _request_with_retry(
+            r = _request_wrapper(
                 method="HEAD",
                 url=url,
                 headers=headers,
                 allow_redirects=False,
+                force_internal_redirects=True,
                 proxies=proxies,
                 timeout=etag_timeout,
             )
@@ -1035,10 +1082,10 @@ def hf_hub_download(
                     " reliably ensure reproducibility."
                 )
             etag = _normalize_etag(etag)
-            # In case of a redirect,
-            # save an extra redirect on the request.get call,
+            # In case of a redirect, save an extra redirect on the request.get call,
             # and ensure we download the exact atomic version even if it changed
             # between the HEAD and the GET (unlikely, but hey).
+            # Useful for lfs blobs that are stored on a CDN.
             if 300 <= r.status_code <= 399:
                 url_to_download = r.headers["Location"]
                 if (

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -11,8 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import os
 import unittest
+from tempfile import TemporaryDirectory
 
 from huggingface_hub.constants import (
     CONFIG_NAME,
@@ -37,6 +38,7 @@ from .testing_utils import (
     DUMMY_MODEL_ID_PINNED_SHA256,
     DUMMY_MODEL_ID_REVISION_INVALID,
     DUMMY_MODEL_ID_REVISION_ONE_SPECIFIC_COMMIT,
+    DUMMY_RENAMED_MODEL_ID,
     SAMPLE_DATASET_IDENTIFIER,
     OfflineSimulationMode,
     offline,
@@ -175,6 +177,34 @@ class CachedDownloadTests(unittest.TestCase):
             metadata,
             (url, '"95aa6a52d5d6a735563366753ca50492a658031da74f301ac5238b03966972c9"'),
         )
+
+    def test_download_from_a_renamed_repo_with_hf_hub_download(self):
+        """Checks `hf_hub_download` works also on a renamed repo.
+
+        Regression test for #981.
+        https://github.com/huggingface/huggingface_hub/issues/981
+        """
+        with TemporaryDirectory() as tmpdir:
+            filepath = hf_hub_download(
+                DUMMY_RENAMED_MODEL_ID, "config.json", cache_dir=tmpdir
+            )
+            self.assertTrue(os.path.exists(filepath))
+
+    def test_download_from_a_renamed_repo_with_cached_download(self):
+        """Checks `cached_download` works also on a renamed repo.
+
+        Regression test for #981.
+        https://github.com/huggingface/huggingface_hub/issues/981
+        """
+        with TemporaryDirectory() as tmpdir:
+            filepath = cached_download(
+                hf_hub_url(
+                    DUMMY_RENAMED_MODEL_ID,
+                    filename="config.json",
+                ),
+                cache_dir=tmpdir,
+            )
+            self.assertTrue(os.path.exists(filepath))
 
     def test_hf_hub_download_legacy(self):
         filepath = hf_hub_download(

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -15,6 +15,8 @@ import os
 import unittest
 from tempfile import TemporaryDirectory
 
+import pytest
+
 from huggingface_hub.constants import (
     CONFIG_NAME,
     PYTORCH_WEIGHTS_NAME,
@@ -196,15 +198,16 @@ class CachedDownloadTests(unittest.TestCase):
         Regression test for #981.
         https://github.com/huggingface/huggingface_hub/issues/981
         """
-        with TemporaryDirectory() as tmpdir:
-            filepath = cached_download(
-                hf_hub_url(
-                    DUMMY_RENAMED_MODEL_ID,
-                    filename="config.json",
-                ),
-                cache_dir=tmpdir,
-            )
-            self.assertTrue(os.path.exists(filepath))
+        with pytest.warns(FutureWarning):
+            with TemporaryDirectory() as tmpdir:
+                filepath = cached_download(
+                    hf_hub_url(
+                        DUMMY_RENAMED_MODEL_ID,
+                        filename="config.json",
+                    ),
+                    cache_dir=tmpdir,
+                )
+                self.assertTrue(os.path.exists(filepath))
 
     def test_hf_hub_download_legacy(self):
         filepath = hf_hub_download(

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -34,6 +34,10 @@ DUMMY_MODEL_ID_PINNED_SHA256 = (
 )
 # Sha-256 of pytorch_model.bin on the top of `main`, for checking purposes
 
+# "hf-internal-testing/dummy-will-be-renamed" has been renamed to "hf-internal-testing/dummy-renamed"
+DUMMY_RENAMED_MODEL_ID = (  # Regression test #941
+    "hf-internal-testing/dummy-will-be-renamed"
+)
 
 SAMPLE_DATASET_IDENTIFIER = "lhoestq/custom_squad"
 # Example dataset ids


### PR DESCRIPTION
Fix https://github.com/huggingface/huggingface_hub/issues/981.

Solution I went for is to force redirection only when the `Location` header is relative which is the case for renamed repos. It doesn't seem that an out-of-the-box argument exists to do that in `requests` so (internal) redirections are resolved and unpiled in this PR's code.

Also, I renamed `_request_with_retry` to `_request_wrapper` as it is an internal helper and its scope has expanded. I saw 
it was used at 3 different places only for its "_raise_if_offline_mode_is_enabled" feature instead of the initial "backoff" feature. I think a generic `_request_wrapper` is less misleading in that case.
@sgugger this impacts you this I saw it is used [here in Transformers](https://github.com/huggingface/transformers/blob/main/src/transformers/utils/hub.py#L908). I didn't want to go for the "deprecation + removal in 2 months" process since it is internal and used only once in Transformers. You can just rename the function and keep the same arguments.