### PR TITLE
Use a finer exception when local_files_only=True and a file is missing in cache

### DIFF
--- a/docs/source/package_reference/utilities.mdx
+++ b/docs/source/package_reference/utilities.mdx
@@ -58,3 +58,5 @@ See below for all custom errors thrown by different methods across the package.
 [[autodoc]] huggingface_hub.utils.RevisionNotFoundError
 
 [[autodoc]] huggingface_hub.utils.EntryNotFoundError
+
+[[autodoc]] huggingface_hub.utils.LocalEntryNotFoundError

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -35,7 +35,7 @@ from .constants import (
 )
 from .hf_api import HfFolder
 from .utils import logging
-from .utils._errors import _raise_for_status
+from .utils._errors import LocalEntryNotFoundError, _raise_for_status
 
 
 logger = logging.get_logger(__name__)
@@ -553,6 +553,8 @@ def cached_download(
           If the revision to download from cannot be found.
         - [`~huggingface_hub.utils.EntryNotFoundError`]
           If the file to download cannot be found.
+        - [`~huggingface_hub.utils.LocalEntryNotFoundError`]
+          If network is disabled and file is not found is cache.
 
     </Tip>
     """
@@ -659,13 +661,13 @@ def cached_download(
                 # the models might've been found if local_files_only=False
                 # Notify the user about that
                 if local_files_only:
-                    raise ValueError(
+                    raise LocalEntryNotFoundError(
                         "Cannot find the requested files in the cached path and"
                         " outgoing traffic has been disabled. To enable model look-ups"
                         " and downloads online, set 'local_files_only' to False."
                     )
                 else:
-                    raise ValueError(
+                    raise LocalEntryNotFoundError(
                         "Connection error, and we cannot find the requested files in"
                         " the cached path. Please try again or make sure your Internet"
                         " connection is on."
@@ -911,6 +913,8 @@ def hf_hub_download(
           If the revision to download from cannot be found.
         - [`~huggingface_hub.utils.EntryNotFoundError`]
           If the file to download cannot be found.
+        - [`~huggingface_hub.utils.LocalEntryNotFoundError`]
+          If network is disabled and file is not found is cache.
 
     </Tip>
     """
@@ -1089,13 +1093,13 @@ def hf_hub_download(
         # the models might've been found if local_files_only=False
         # Notify the user about that
         if local_files_only:
-            raise ValueError(
+            raise LocalEntryNotFoundError(
                 "Cannot find the requested files in the disk cache and"
                 " outgoing traffic has been disabled. To enable hf.co look-ups"
                 " and downloads online, set 'local_files_only' to False."
             )
         else:
-            raise ValueError(
+            raise LocalEntryNotFoundError(
                 "Connection error, and we cannot find the requested files in"
                 " the disk cache. Please try again or make sure your Internet"
                 " connection is on."

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -554,7 +554,7 @@ def cached_download(
         - [`~huggingface_hub.utils.EntryNotFoundError`]
           If the file to download cannot be found.
         - [`~huggingface_hub.utils.LocalEntryNotFoundError`]
-          If network is disabled and file is not found is cache.
+          If network is disabled or unavailable and file is not found in cache.
 
     </Tip>
     """
@@ -914,7 +914,7 @@ def hf_hub_download(
         - [`~huggingface_hub.utils.EntryNotFoundError`]
           If the file to download cannot be found.
         - [`~huggingface_hub.utils.LocalEntryNotFoundError`]
-          If network is disabled and file is not found is cache.
+          If network is disabled or unavailable and file is not found in cache.
 
     </Tip>
     """

--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -15,5 +15,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 
-from ._errors import EntryNotFoundError, RepositoryNotFoundError, RevisionNotFoundError
+from ._errors import (
+    EntryNotFoundError,
+    LocalEntryNotFoundError,
+    RepositoryNotFoundError,
+    RevisionNotFoundError,
+)
 from ._subprocess import run_subprocess

--- a/src/huggingface_hub/utils/_errors.py
+++ b/src/huggingface_hub/utils/_errors.py
@@ -57,6 +57,28 @@ class EntryNotFoundError(HTTPError):
         super().__init__(message, response=response)
 
 
+class LocalEntryNotFoundError(EntryNotFoundError, FileNotFoundError, ValueError):
+    """
+    Raised when trying to access a file that is not on the disk when network is
+    disabled. The entry may exist on the Hub.
+
+    Note: `ValueError` type is to ensure backward compatibility.
+    Note: `LocalEntryNotFoundError` derives from `HTTPError` because of `EntryNotFoundError`
+          even though it is not network related.
+
+    Example:
+
+    ```py
+    >>> from huggingface_hub import hf_hub_download
+    >>> hf_hub_download('bert-base-cased', '<non-cached-file>',  local_files_only=True)
+    huggingface_hub.utils._errors.LocalEntryNotFoundError: Cannot find the requested files in the disk cache and outgoing traffic has been disabled. To enable hf.co look-ups and downloads online, set 'local_files_only' to False.
+    ```
+    """
+
+    def __init__(self, message):
+        super().__init__(message, response=None)
+
+
 class BadRequestError(ValueError, HTTPError):
     """
     Raised by `_raise_convert_bad_request` when the server returns HTTP 400 error

--- a/src/huggingface_hub/utils/_errors.py
+++ b/src/huggingface_hub/utils/_errors.py
@@ -60,11 +60,11 @@ class EntryNotFoundError(HTTPError):
 class LocalEntryNotFoundError(EntryNotFoundError, FileNotFoundError, ValueError):
     """
     Raised when trying to access a file that is not on the disk when network is
-    disabled. The entry may exist on the Hub.
+    disabled or unavailable (connection issue). The entry may exist on the Hub.
 
     Note: `ValueError` type is to ensure backward compatibility.
     Note: `LocalEntryNotFoundError` derives from `HTTPError` because of `EntryNotFoundError`
-          even though it is not network related.
+          even when it is not a network issue.
 
     Example:
 

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -93,7 +93,7 @@ class CachedDownloadTests(unittest.TestCase):
                 )
 
     def test_file_not_found_on_repo(self):
-        # Valid revision (None) but missing file.
+        # Valid revision (None) but missing file on repo.
         url = hf_hub_url(DUMMY_MODEL_ID, filename="missing.bin")
         with self.assertRaisesRegex(
             EntryNotFoundError, "404 Client Error: Entry Not Found"
@@ -101,7 +101,7 @@ class CachedDownloadTests(unittest.TestCase):
             _ = cached_download(url, legacy_cache_layout=True)
 
     def test_file_not_found_locally_and_network_disabled(self):
-        # Valid revision (None) but missing file.
+        # Valid file but missing locally and network is disabled.
         with TemporaryDirectory() as tmpdir:
             # Download a first time to get the refs ok
             filepath = hf_hub_download(
@@ -124,7 +124,7 @@ class CachedDownloadTests(unittest.TestCase):
                 )
 
     def test_file_not_found_locally_and_network_disabled_legacy(self):
-        # Valid revision (None) but missing file.
+        # Valid file but missing locally and network is disabled.
         url = hf_hub_url(DUMMY_MODEL_ID, filename=CONFIG_NAME)
         with TemporaryDirectory() as tmpdir:
             # Get without network must fail


### PR DESCRIPTION
Fix https://github.com/huggingface/huggingface_hub/issues/979. See discussion is issue about `LocalEntryNotFound` inheritance.