### PR TITLE
Cache non-existence of files or completeness of repo

### DIFF
--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -217,4 +217,9 @@ def snapshot_download(
             use_auth_token=use_auth_token,
         )
 
+    # Mark the repo is complete
+    complete_path = os.path.join(storage_folder, ".complete")
+    os.makedirs(os.path.dirname(complete_path), exist_ok=True)
+    (Path(complete_path) / commit_hash).touch()
+
     return snapshot_folder

--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -217,9 +217,4 @@ def snapshot_download(
             use_auth_token=use_auth_token,
         )
 
-    # Mark the repo is complete
-    complete_path = os.path.join(storage_folder, ".complete")
-    os.makedirs(os.path.dirname(complete_path), exist_ok=True)
-    (Path(complete_path) / commit_hash).touch()
-
     return snapshot_folder

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1101,11 +1101,14 @@ def hf_hub_download(
             except EntryNotFoundError:
                 commit_hash = r.headers.get(HUGGINGFACE_HEADER_X_REPO_COMMIT)
                 if commit_hash is not None and not legacy_cache_layout:
-                    no_exist_path = os.path.join(
-                        storage_folder, ".no_exist", commit_hash
+                    no_exist_file_path = (
+                        Path(storage_folder)
+                        / ".no_exist"
+                        / commit_hash
+                        / relative_filename
                     )
-                    os.makedirs(no_exist_path, exist_ok=True)
-                    (Path(no_exist_path) / relative_filename).touch()
+                    no_exist_file_path.parent.mkdir(parents=True, exist_ok=True)
+                    no_exist_file_path.touch()
                     _cache_commit_hash_for_specific_revision(
                         storage_folder, revision, commit_hash
                     )

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -41,7 +41,6 @@ from .utils._errors import (
 )
 
 
-
 logger = logging.get_logger(__name__)
 
 _PY_VERSION: str = sys.version.split()[0].rstrip("+")

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -857,10 +857,9 @@ def _cache_commit_hash_for_specific_revision(
     """
     if revision != commit_hash:
         ref_path = os.path.join(storage_folder, "refs", revision)
-        if not os.path.exists(ref_path):
-            os.makedirs(os.path.dirname(ref_path), exist_ok=True)
-            with open(ref_path, "w") as f:
-                f.write(commit_hash)
+        os.makedirs(os.path.dirname(ref_path), exist_ok=True)
+        with open(ref_path, "w") as f:
+            f.write(commit_hash)
 
 
 def repo_folder_name(*, repo_id: str, repo_type: str) -> str:

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1027,14 +1027,12 @@ def hf_hub_download(
             try:
                 _raise_for_status(r)
             except EntryNotFoundError:
-                print("Error intercepted")
                 commit_hash = r.headers.get(HUGGINGFACE_HEADER_X_REPO_COMMIT)
                 if commit_hash is not None and not legacy_cache_layout:
                     no_exist_path = os.path.join(
                         storage_folder, ".no_exist", commit_hash
                     )
                     os.makedirs(no_exist_path, exist_ok=True)
-                    print(f"Making folder {no_exist_path}")
                     (Path(no_exist_path) / relative_filename).touch()
                 raise
             commit_hash = r.headers[HUGGINGFACE_HEADER_X_REPO_COMMIT]

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -34,7 +34,11 @@ from .constants import (
 )
 from .hf_api import HfFolder
 from .utils import logging, tqdm
-from .utils._errors import EntryNotFoundError, LocalEntryNotFoundError, _raise_for_status
+from .utils._errors import (
+    EntryNotFoundError,
+    LocalEntryNotFoundError,
+    _raise_for_status,
+)
 
 
 

--- a/tests/test_cache_layout.py
+++ b/tests/test_cache_layout.py
@@ -122,8 +122,6 @@ class CacheFileLayoutHfHubDownload(unittest.TestCase):
 
     def test_no_exist_file_is_cached(self):
         with tempfile.TemporaryDirectory() as cache:
-            hf_hub_download(MODEL_IDENTIFIER, "file_0.txt", cache_dir=cache)
-
             filename = "this_does_not_exist.txt"
             with self.assertRaises(EntryNotFoundError):
                 # The file does not exist, so we get an exception.
@@ -163,10 +161,6 @@ class CacheFileLayoutHfHubDownload(unittest.TestCase):
 
     def test_no_exist_file_is_cached_with_revision(self):
         with tempfile.TemporaryDirectory() as cache:
-            hf_hub_download(
-                MODEL_IDENTIFIER, "file_0.txt", cache_dir=cache, revision="file-2"
-            )
-
             filename = "this_does_not_exist.txt"
             with self.assertRaises(EntryNotFoundError):
                 # The file does not exist, so we get an exception.

--- a/tests/test_cache_layout.py
+++ b/tests/test_cache_layout.py
@@ -33,92 +33,63 @@ def get_file_contents(path):
 @with_production_testing
 class CacheFileLayoutHfHubDownload(unittest.TestCase):
     def test_file_downloaded_in_cache(self):
-        with tempfile.TemporaryDirectory() as cache:
-            hf_hub_download(MODEL_IDENTIFIER, "file_0.txt", cache_dir=cache)
+        for revision, expected_reference in (
+            (None, "main"),
+            ("file-2", "file-2"),
+        ):
+            with self.subTest(revision), tempfile.TemporaryDirectory() as cache:
+                with tempfile.TemporaryDirectory() as cache:
+                    hf_hub_download(
+                        MODEL_IDENTIFIER,
+                        "file_0.txt",
+                        cache_dir=cache,
+                        revision=revision,
+                    )
 
-            expected_directory_name = f'models--{MODEL_IDENTIFIER.replace("/", "--")}'
-            expected_path = os.path.join(cache, expected_directory_name)
+                    expected_directory_name = (
+                        f'models--{MODEL_IDENTIFIER.replace("/", "--")}'
+                    )
+                    expected_path = os.path.join(cache, expected_directory_name)
 
-            refs = os.listdir(os.path.join(expected_path, "refs"))
-            snapshots = os.listdir(os.path.join(expected_path, "snapshots"))
+                    refs = os.listdir(os.path.join(expected_path, "refs"))
+                    snapshots = os.listdir(os.path.join(expected_path, "snapshots"))
 
-            expected_reference = "main"
+                    # Only reference should be the expected one.
+                    self.assertListEqual(refs, [expected_reference])
 
-            # Only reference should be `main`.
-            self.assertListEqual(refs, [expected_reference])
+                    with open(
+                        os.path.join(expected_path, "refs", expected_reference)
+                    ) as f:
+                        snapshot_name = f.readline().strip()
 
-            with open(os.path.join(expected_path, "refs", expected_reference)) as f:
-                snapshot_name = f.readline().strip()
+                    # The `main` reference should point to the only snapshot we have downloaded
+                    self.assertListEqual(snapshots, [snapshot_name])
 
-            # The `main` reference should point to the only snapshot we have downloaded
-            self.assertListEqual(snapshots, [snapshot_name])
+                    snapshot_path = os.path.join(
+                        expected_path, "snapshots", snapshot_name
+                    )
+                    snapshot_content = os.listdir(snapshot_path)
 
-            snapshot_path = os.path.join(expected_path, "snapshots", snapshot_name)
-            snapshot_content = os.listdir(snapshot_path)
+                    # Only a single file in the snapshot
+                    self.assertEqual(len(snapshot_content), 1)
 
-            # Only a single file in the snapshot
-            self.assertEqual(len(snapshot_content), 1)
+                    snapshot_content_path = os.path.join(
+                        snapshot_path, snapshot_content[0]
+                    )
 
-            snapshot_content_path = os.path.join(snapshot_path, snapshot_content[0])
+                    # The snapshot content should link to a blob
+                    self.assertTrue(os.path.islink(snapshot_content_path))
 
-            # The snapshot content should link to a blob
-            self.assertTrue(os.path.islink(snapshot_content_path))
+                    resolved_blob_relative = os.readlink(snapshot_content_path)
+                    resolved_blob_absolute = os.path.normpath(
+                        os.path.join(snapshot_path, resolved_blob_relative)
+                    )
 
-            resolved_blob_relative = os.readlink(snapshot_content_path)
-            resolved_blob_absolute = os.path.normpath(
-                os.path.join(snapshot_path, resolved_blob_relative)
-            )
+                    with open(resolved_blob_absolute) as f:
+                        blob_contents = f.readline().strip()
 
-            with open(resolved_blob_absolute) as f:
-                blob_contents = f.read().strip()
-
-            # The contents of the file should be 'File 0'.
-            self.assertEqual(blob_contents, "File 0")
-
-    def test_file_downloaded_in_cache_with_revision(self):
-        with tempfile.TemporaryDirectory() as cache:
-            hf_hub_download(
-                MODEL_IDENTIFIER, "file_0.txt", cache_dir=cache, revision="file-2"
-            )
-
-            expected_directory_name = f'models--{MODEL_IDENTIFIER.replace("/", "--")}'
-            expected_path = os.path.join(cache, expected_directory_name)
-
-            refs = os.listdir(os.path.join(expected_path, "refs"))
-            snapshots = os.listdir(os.path.join(expected_path, "snapshots"))
-
-            expected_reference = "file-2"
-
-            # Only reference should be `file-2`.
-            self.assertListEqual(refs, [expected_reference])
-
-            with open(os.path.join(expected_path, "refs", expected_reference)) as f:
-                snapshot_name = f.read().strip()
-
-            # The `main` reference should point to the only snapshot we have downloaded
-            self.assertListEqual(snapshots, [snapshot_name])
-
-            snapshot_path = os.path.join(expected_path, "snapshots", snapshot_name)
-            snapshot_content = os.listdir(snapshot_path)
-
-            # Only a single file in the snapshot
-            self.assertEqual(len(snapshot_content), 1)
-
-            snapshot_content_path = os.path.join(snapshot_path, snapshot_content[0])
-
-            # The snapshot content should link to a blob
-            self.assertTrue(os.path.islink(snapshot_content_path))
-
-            resolved_blob_relative = os.readlink(snapshot_content_path)
-            resolved_blob_absolute = os.path.normpath(
-                os.path.join(snapshot_path, resolved_blob_relative)
-            )
-
-            with open(resolved_blob_absolute) as f:
-                blob_contents = f.readline().strip()
-
-            # The contents of the file should be 'File 0'.
-            self.assertEqual(blob_contents, "File 0")
+                    # The contents of the file should be 'File 0'.
+                    self.assertEqual(blob_contents, "File 0")
 
     def test_no_exist_file_is_cached(self):
         revisions = [None, "file-2"]

--- a/tests/test_cache_layout.py
+++ b/tests/test_cache_layout.py
@@ -13,6 +13,7 @@ from huggingface_hub import (
     upload_file,
 )
 from huggingface_hub.utils import logging
+from huggingface_hub.utils._errors import EntryNotFoundError
 
 from .testing_constants import ENDPOINT_STAGING, TOKEN, USER
 from .testing_utils import repo_name, with_production_testing
@@ -74,6 +75,47 @@ class CacheFileLayoutHfHubDownload(unittest.TestCase):
             # The contents of the file should be 'File 0'.
             self.assertEqual(blob_contents, "File 0")
 
+    def test_no_exist_file_is_cached(self):
+        with tempfile.TemporaryDirectory() as cache:
+            hf_hub_download(MODEL_IDENTIFIER, "file_0.txt", cache_dir=cache)
+
+            filename = "this_does_not_exist.txt"
+            with self.assertRaises(EntryNotFoundError):
+                # The file does not exist, so we get an exception.
+                hf_hub_download(MODEL_IDENTIFIER, filename, cache_dir=cache)
+
+            expected_directory_name = f'models--{MODEL_IDENTIFIER.replace("/", "--")}'
+            expected_path = os.path.join(cache, expected_directory_name)
+
+            refs = os.listdir(os.path.join(expected_path, "refs"))
+            no_exist_snapshots = os.listdir(os.path.join(expected_path, ".no_exist"))
+
+            expected_reference = "main"
+
+            # Only reference should be `main`.
+            self.assertListEqual(refs, [expected_reference])
+
+            with open(os.path.join(expected_path, "refs", expected_reference)) as f:
+                snapshot_name = f.readline().strip()
+
+            # The `main` reference should point to the only snapshot we have downloaded
+            self.assertListEqual(no_exist_snapshots, [snapshot_name])
+
+            no_exist_path = os.path.join(expected_path, ".no_exist", snapshot_name)
+            no_exist_content = os.listdir(no_exist_path)
+
+            # Only a single file in the no_exist snapshot
+            self.assertEqual(len(no_exist_content), 1)
+
+            # The no_exist content should be our file
+            self.assertEqual(no_exist_content[0], filename)
+
+            with open(os.path.join(no_exist_path, filename)) as f:
+                content = f.read().strip()
+
+            # The contents of the file should be empty.
+            self.assertEqual(content, "")
+
     def test_file_downloaded_in_cache_with_revision(self):
         with tempfile.TemporaryDirectory() as cache:
             hf_hub_download(
@@ -118,6 +160,92 @@ class CacheFileLayoutHfHubDownload(unittest.TestCase):
 
             # The contents of the file should be 'File 0'.
             self.assertEqual(blob_contents, "File 0")
+
+    def test_no_exist_file_is_cached(self):
+        with tempfile.TemporaryDirectory() as cache:
+            hf_hub_download(MODEL_IDENTIFIER, "file_0.txt", cache_dir=cache)
+
+            filename = "this_does_not_exist.txt"
+            with self.assertRaises(EntryNotFoundError):
+                # The file does not exist, so we get an exception.
+                hf_hub_download(MODEL_IDENTIFIER, filename, cache_dir=cache)
+
+            expected_directory_name = f'models--{MODEL_IDENTIFIER.replace("/", "--")}'
+            expected_path = os.path.join(cache, expected_directory_name)
+
+            refs = os.listdir(os.path.join(expected_path, "refs"))
+            no_exist_snapshots = os.listdir(os.path.join(expected_path, ".no_exist"))
+
+            expected_reference = "main"
+
+            # Only reference should be `main`.
+            self.assertListEqual(refs, [expected_reference])
+
+            with open(os.path.join(expected_path, "refs", expected_reference)) as f:
+                snapshot_name = f.readline().strip()
+
+            # The `main` reference should point to the only snapshot we have downloaded
+            self.assertListEqual(no_exist_snapshots, [snapshot_name])
+
+            no_exist_path = os.path.join(expected_path, ".no_exist", snapshot_name)
+            no_exist_content = os.listdir(no_exist_path)
+
+            # Only a single file in the no_exist snapshot
+            self.assertEqual(len(no_exist_content), 1)
+
+            # The no_exist content should be our file
+            self.assertEqual(no_exist_content[0], filename)
+
+            with open(os.path.join(no_exist_path, filename)) as f:
+                content = f.read().strip()
+
+            # The contents of the file should be empty.
+            self.assertEqual(content, "")
+
+    def test_no_exist_file_is_cached_with_revision(self):
+        with tempfile.TemporaryDirectory() as cache:
+            hf_hub_download(
+                MODEL_IDENTIFIER, "file_0.txt", cache_dir=cache, revision="file-2"
+            )
+
+            filename = "this_does_not_exist.txt"
+            with self.assertRaises(EntryNotFoundError):
+                # The file does not exist, so we get an exception.
+                hf_hub_download(
+                    MODEL_IDENTIFIER, filename, cache_dir=cache, revision="file-2"
+                )
+
+            expected_directory_name = f'models--{MODEL_IDENTIFIER.replace("/", "--")}'
+            expected_path = os.path.join(cache, expected_directory_name)
+
+            refs = os.listdir(os.path.join(expected_path, "refs"))
+            no_exist_snapshots = os.listdir(os.path.join(expected_path, ".no_exist"))
+
+            expected_reference = "file-2"
+
+            # Only reference should be `file-2`.
+            self.assertListEqual(refs, [expected_reference])
+
+            with open(os.path.join(expected_path, "refs", expected_reference)) as f:
+                snapshot_name = f.readline().strip()
+
+            # The `main` reference should point to the only snapshot we have downloaded
+            self.assertListEqual(no_exist_snapshots, [snapshot_name])
+
+            no_exist_path = os.path.join(expected_path, ".no_exist", snapshot_name)
+            no_exist_content = os.listdir(no_exist_path)
+
+            # Only a single file in the no_exist snapshot
+            self.assertEqual(len(no_exist_content), 1)
+
+            # The no_exist content should be our file
+            self.assertEqual(no_exist_content[0], filename)
+
+            with open(os.path.join(no_exist_path, filename)) as f:
+                content = f.read().strip()
+
+            # The contents of the file should be empty.
+            self.assertEqual(content, "")
 
     def test_file_download_happens_once(self):
         # Tests that a file is only downloaded once if it's not updated.

--- a/tests/test_cache_layout.py
+++ b/tests/test_cache_layout.py
@@ -75,47 +75,6 @@ class CacheFileLayoutHfHubDownload(unittest.TestCase):
             # The contents of the file should be 'File 0'.
             self.assertEqual(blob_contents, "File 0")
 
-    def test_no_exist_file_is_cached(self):
-        with tempfile.TemporaryDirectory() as cache:
-            hf_hub_download(MODEL_IDENTIFIER, "file_0.txt", cache_dir=cache)
-
-            filename = "this_does_not_exist.txt"
-            with self.assertRaises(EntryNotFoundError):
-                # The file does not exist, so we get an exception.
-                hf_hub_download(MODEL_IDENTIFIER, filename, cache_dir=cache)
-
-            expected_directory_name = f'models--{MODEL_IDENTIFIER.replace("/", "--")}'
-            expected_path = os.path.join(cache, expected_directory_name)
-
-            refs = os.listdir(os.path.join(expected_path, "refs"))
-            no_exist_snapshots = os.listdir(os.path.join(expected_path, ".no_exist"))
-
-            expected_reference = "main"
-
-            # Only reference should be `main`.
-            self.assertListEqual(refs, [expected_reference])
-
-            with open(os.path.join(expected_path, "refs", expected_reference)) as f:
-                snapshot_name = f.readline().strip()
-
-            # The `main` reference should point to the only snapshot we have downloaded
-            self.assertListEqual(no_exist_snapshots, [snapshot_name])
-
-            no_exist_path = os.path.join(expected_path, ".no_exist", snapshot_name)
-            no_exist_content = os.listdir(no_exist_path)
-
-            # Only a single file in the no_exist snapshot
-            self.assertEqual(len(no_exist_content), 1)
-
-            # The no_exist content should be our file
-            self.assertEqual(no_exist_content[0], filename)
-
-            with open(os.path.join(no_exist_path, filename)) as f:
-                content = f.read().strip()
-
-            # The contents of the file should be empty.
-            self.assertEqual(content, "")
-
     def test_file_downloaded_in_cache_with_revision(self):
         with tempfile.TemporaryDirectory() as cache:
             hf_hub_download(


### PR DESCRIPTION
In Transformers, we very often try to download files that do not exist: this is because each tokenizer has a list of optional files so we try to download them all and intercept the errors for those that do not exist. There is also the situation with very large model not having a weight filename like regular models but an index file instead.

This works all fine, but some users are trying to optimize things like calls to `pipeline`, and each of those requests where a file does not exist takes a bit of time. Therefore, this PR proposes a way to cache the non-existence of files at a given commit, so we can use that cache information and not try to download a file we know does not exist at a specific commit.

I suggest using the same architecture as the `snapshots` folder with a `.no_exist` folder: one level for the commit shas, then an empty file for each file we tried to download but do not exist.

@julien-c also suggested adding a `.complete` folder which contains the commit hashes for which we know we have all files (as a result of `snapshot_download` for instance).

A picture is worth a thousand words:
![image](https://user-images.githubusercontent.com/35901082/183976423-07edd6c3-b00c-4d8d-bddb-52b817715337.png)


I haven't implemented any tests yet, just want to see what everyone thinks and will add some if this is of interest.