### PR TITLE
[Repository] Add better error message

### DIFF
--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -595,20 +595,23 @@ class Repository:
                 - `None`, which would retrieve the value of
                   `self.huggingface_token`.
 
-        Raises:
-            `ValueError`: if the `token` cannot be identified and the `private`
-            keyword is set to `True`. The `token`
-                must be passed in order to handle private repositories.
+        <Tip>
 
-        Raises:
-            `ValueError`: if an organization token (starts with "api_org")
-            is passed.
+        Raises the following error:
 
-        Raises:
-            `EnvironmentError`: if you are trying to clone the repository in a
-            non-empty folder, or if the `git`
-                operations raise errors.
+            - [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
+              if the `token` cannot be identified and the `private` keyword is set to
+              `True`. The `token` must be passed in order to handle private repositories.
 
+            - [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
+              if an organization token (starts with "api_org") is passed. Use must use
+              your own personal access token (see https://hf.co/settings/tokens).
+
+            - [`EnvironmentError`](https://docs.python.org/3/library/exceptions.html#EnvironmentError)
+              if you are trying to clone the repository in a non-empty folder, or if the
+              `git` operations raise errors.
+
+        </Tip>
         """
         token = use_auth_token if use_auth_token is not None else self.huggingface_token
         if token is None and self.private:

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -636,7 +636,6 @@ class Repository:
 
                 whoami_info = self.client.whoami(token)
                 user = whoami_info["name"]
-
                 valid_organisations = [org["name"] for org in whoami_info["orgs"]]
 
                 if namespace is not None:

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -601,6 +601,10 @@ class Repository:
                 must be passed in order to handle private repositories.
 
         Raises:
+            `ValueError`: if an organization token (starts with "api_org")
+            is passed.
+
+        Raises:
             `EnvironmentError`: if you are trying to clone the repository in a
             non-empty folder, or if the `git`
                 operations raise errors.

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -631,8 +631,12 @@ class Repository:
                 repo_url += REPO_TYPES_URL_PREFIXES[self.repo_type]
 
             if token is not None:
+                if token.startswith("api_org"):
+                    raise ValueError("You must use your personal account token.")
+
                 whoami_info = self.client.whoami(token)
                 user = whoami_info["name"]
+
                 valid_organisations = [org["name"] for org in whoami_info["orgs"]]
 
                 if namespace is not None:

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -619,7 +619,10 @@ class Repository:
                 " `use_auth_token` key."
             )
         elif token is not None and token.startswith("api_org"):
-            raise ValueError("You must use your personal access token.")
+            raise ValueError(
+                "You must use your personal access token (see"
+                " https://hf.co/settings/tokens)."
+            )
 
         hub_url = self.client.endpoint
         if hub_url in repo_url or (

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -614,6 +614,9 @@ class Repository:
                 " `huggingface-cli login` or provide your token manually with the"
                 " `use_auth_token` key."
             )
+        elif token is not None and token.startswith("api_org"):
+            raise ValueError("You must use your personal access token.")
+
         hub_url = self.client.endpoint
         if hub_url in repo_url or (
             "http" not in repo_url and len(repo_url.split("/")) <= 2
@@ -631,9 +634,6 @@ class Repository:
                 repo_url += REPO_TYPES_URL_PREFIXES[self.repo_type]
 
             if token is not None:
-                if token.startswith("api_org"):
-                    raise ValueError("You must use your personal account token.")
-
                 whoami_info = self.client.whoami(token)
                 user = whoami_info["name"]
                 valid_organisations = [org["name"] for org in whoami_info["orgs"]]

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -620,8 +620,8 @@ class Repository:
             )
         elif token is not None and token.startswith("api_org"):
             raise ValueError(
-                "You must use your personal access token (see"
-                " https://hf.co/settings/tokens)."
+                "You must use your personal access token, not an Organization token"
+                " (see https://hf.co/settings/tokens)."
             )
 
         hub_url = self.client.endpoint


### PR DESCRIPTION
This PR simply adds a better error message for the following use case:

```python
from huggingface_hub import Repository
repo = Repository(local_dir="data", clone_from=DATASET_REPO_URL, use_auth_token=TOKEN)
```

where `TOKEN` is an org token