### PR TITLE
MNT add tabular task types to InferenceApi

### DIFF
--- a/src/huggingface_hub/inference_api.py
+++ b/src/huggingface_hub/inference_api.py
@@ -38,7 +38,8 @@ ALL_TASKS = [
     "image-segmentation",
     "text-to-image",
     # Others
-    "structured-data-classification",
+    "tabular-classification",
+    "tabular-regression",
 ]
 
 


### PR DESCRIPTION
We've moved to using `"tabular-{classification, regression}"` names for tasks, this reflects the change on the API backend side.

cc @Narsil @osanseviero 