### PR TITLE
Make private a boolean-only value.

### DIFF
--- a/src/huggingface_hub/fastai_utils.py
+++ b/src/huggingface_hub/fastai_utils.py
@@ -353,7 +353,7 @@ def push_to_hub_fastai(
     learner,
     repo_id: str,
     commit_message: Optional[str] = "Add model",
-    private: Optional[bool] = None,
+    private: bool = False,
     token: Optional[str] = None,
     config: Optional[dict] = None,
     **kwargs,
@@ -369,7 +369,7 @@ def push_to_hub_fastai(
             The repository id for your model in Hub in the format of "namespace/repo_name". The namespace can be your individual account or an organization to which you have write access (for example, 'stanfordnlp/stanza-de').
         commit_message (`str`, *optional*):
             Message to commit while pushing. Will default to :obj:`"add model"`.
-        private (`bool`, *optional*):
+        private (`bool`, *optional*, defaults to `False`):
             Whether or not the repository created should be private.
         token (`str`, *optional*):
             The Hugging Face account token to use as HTTP bearer authorization for remote files. If :obj:`None`, the token will be asked by a prompt.

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -237,7 +237,7 @@ class ModelInfo:
             Pipeline tag to identify the correct widget.
         siblings (`List[RepoFile]`, *optional*):
             list of ([`huggingface_hub.hf_api.RepoFile`]) objects that constitute the model.
-        private (`bool`, *optional*):
+        private (`bool`, *optional*, defaults to `False`):
             is the repo private
         author (`str`, *optional*):
             repo author
@@ -256,7 +256,7 @@ class ModelInfo:
         tags: Optional[List[str]] = None,
         pipeline_tag: Optional[str] = None,
         siblings: Optional[List[Dict]] = None,
-        private: Optional[bool] = None,
+        private: bool = False,
         author: Optional[str] = None,
         config: Optional[Dict] = None,
         **kwargs,
@@ -303,7 +303,7 @@ class DatasetInfo:
             List of tags.
         siblings (`List[RepoFile]`, *optional*):
             list of [`huggingface_hub.hf_api.RepoFile`] objects that constitute the dataset.
-        private (`bool`, *optional*):
+        private (`bool`, *optional*, defaults to `False`):
             is the repo private
         author (`str`, *optional*):
             repo author
@@ -325,7 +325,7 @@ class DatasetInfo:
         lastModified: Optional[str] = None,
         tags: Optional[List[str]] = None,
         siblings: Optional[List[Dict]] = None,
-        private: Optional[bool] = None,
+        private: bool = False,
         author: Optional[str] = None,
         description: Optional[str] = None,
         citation: Optional[str] = None,
@@ -378,7 +378,7 @@ class SpaceInfo:
             date of last commit to repo
         siblings (`List[RepoFile]`, *optional*):
             list of [`huggingface_hub.hf_api.RepoFIle`] objects that constitute the Space
-        private (`bool`, *optional*):
+        private (`bool`, *optional*, defaults to `False`):
             is the repo private
         author (`str`, *optional*):
             repo author
@@ -393,7 +393,7 @@ class SpaceInfo:
         sha: Optional[str] = None,
         lastModified: Optional[str] = None,
         siblings: Optional[List[Dict]] = None,
-        private: Optional[bool] = None,
+        private: bool = False,
         author: Optional[str] = None,
         **kwargs,
     ):
@@ -1525,7 +1525,7 @@ class HfApi:
         *,
         token: Optional[str] = None,
         organization: Optional[str] = None,
-        private: Optional[bool] = None,
+        private: bool = False,
         repo_type: Optional[str] = None,
         exist_ok: Optional[bool] = False,
         space_sdk: Optional[str] = None,
@@ -1546,7 +1546,7 @@ class HfApi:
 
             token (`str`, *optional*):
                 An authentication token (See https://huggingface.co/settings/token)
-            private (`bool`, *optional*):
+            private (`bool`, *optional*, defaults to `False`):
                 Whether the model repo should be private.
             repo_type (`str`, *optional*):
                 Set to `"dataset"` or `"space"` if uploading to a dataset or

--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -256,7 +256,7 @@ class ModelHubMixin:
         repo_url: Optional[str] = None,
         commit_message: Optional[str] = "Add model",
         organization: Optional[str] = None,
-        private: Optional[bool] = None,
+        private: bool = False,
         api_endpoint: Optional[str] = None,
         use_auth_token: Optional[Union[bool, str]] = None,
         git_user: Optional[str] = None,
@@ -274,7 +274,7 @@ class ModelHubMixin:
         # repo_id: str,
         # *,
         # commit_message: Optional[str] = "Add model",
-        # private: Optional[bool] = None,
+        # private: bool = False,
         # api_endpoint: Optional[str] = None,
         # token: Optional[str] = None,
         # branch: Optional[str] = None,
@@ -294,7 +294,7 @@ class ModelHubMixin:
                 Repository name to which push.
             commit_message (`str`, *optional*):
                 Message to commit while pushing.
-            private (`bool`, *optional*):
+            private (`bool`, *optional*, defaults to `False`):
                 Whether the repository created should be private.
             api_endpoint (`str`, *optional*):
                 The API endpoint to use when pushing the model to the hub.

--- a/src/huggingface_hub/keras_mixin.py
+++ b/src/huggingface_hub/keras_mixin.py
@@ -315,7 +315,7 @@ def push_to_hub_keras(
     log_dir: Optional[str] = None,
     commit_message: Optional[str] = "Add model",
     organization: Optional[str] = None,
-    private: Optional[bool] = None,
+    private: bool = False,
     api_endpoint: Optional[str] = None,
     use_auth_token: Optional[Union[bool, str]] = True,
     git_user: Optional[str] = None,
@@ -337,7 +337,7 @@ def push_to_hub_keras(
     # repo_id: str,
     # *,
     # commit_message: Optional[str] = "Add model",
-    # private: Optional[bool] = None,
+    # private: bool = None,
     # api_endpoint: Optional[str] = None,
     # token: Optional[str] = True,
     # branch: Optional[str] = None,
@@ -367,7 +367,7 @@ def push_to_hub_keras(
             Repository name to which push
         commit_message (`str`, *optional*, defaults to "Add message"):
             Message to commit while pushing.
-        private (`bool`, *optional*):
+        private (`bool`, *optional*, defaults to `False`):
             Whether the repository created should be private.
         api_endpoint (`str`, *optional*):
             The API endpoint to use when pushing the model to the hub.


### PR DESCRIPTION
Fix https://github.com/huggingface/huggingface_hub/issues/897. 

Mentioned issue has been solved server-side but it's still a good excuse to align the type for `private` argument. Currently it was either `private: Optional[bool] = None` or `private: bool = None`. This PR removes the possibility to have a `None` value for `private`. Default value is not `False`. Behaviour is expected to be exactly the same everywhere.