### PR TITLE
Add server message to HTTPError (if any)

### DIFF
--- a/src/huggingface_hub/utils/_errors.py
+++ b/src/huggingface_hub/utils/_errors.py
@@ -101,6 +101,26 @@ def _add_request_id_to_error_args(e, request_id):
         e.args = (e.args[0] + f" (Request ID: {request_id})",) + e.args[1:]
 
 
+def _add_server_message_to_error_args(e: HTTPError, response: Response):
+    """
+    If the server response raises an HTTPError, we try to decode the response body and
+    find an error message. If the server returned one, it is added to the HTTPError
+    message.
+    """
+    try:
+        server_message = response.json().get("error", None)
+    except JSONDecodeError:
+        return
+
+    if (
+        server_message is not None
+        and len(server_message) > 0
+        and len(e.args) > 0
+        and isinstance(e.args[0], str)
+    ):
+        e.args = (e.args[0] + "\n\n" + str(server_message),) + e.args[1:]
+
+
 def _raise_for_status(response):
     """
     Internal version of `response.raise_for_status()` that will refine a
@@ -144,6 +164,7 @@ def _raise_for_status(response):
             e = RepositoryNotFoundError(message, response)
 
         _add_request_id_to_error_args(e, request_id)
+        _add_server_message_to_error_args(e, response)
 
         raise e
 

--- a/src/huggingface_hub/utils/_errors.py
+++ b/src/huggingface_hub/utils/_errors.py
@@ -12,7 +12,7 @@ class RepositoryNotFoundError(HTTPError):
 
     ```py
     >>> from huggingface_hub import model_info
-    >>> model_info("<non_existant_repository>")
+    >>> model_info("<non_existent_repository>")
     huggingface_hub.utils._errors.RepositoryNotFoundError: 404 Client Error: Repository Not Found for url: <url>
     ```
     """
@@ -30,7 +30,7 @@ class RevisionNotFoundError(HTTPError):
 
     ```py
     >>> from huggingface_hub import hf_hub_download
-    >>> hf_hub_download('bert-base-cased', 'config.json', revision='<non-existant-revision>')
+    >>> hf_hub_download('bert-base-cased', 'config.json', revision='<non-existent-revision>')
     huggingface_hub.utils._errors.RevisionNotFoundError: 404 Client Error: Revision Not Found for url: <url>
     ```
     """
@@ -48,7 +48,7 @@ class EntryNotFoundError(HTTPError):
 
     ```py
     >>> from huggingface_hub import hf_hub_download
-    >>> hf_hub_download('bert-base-cased', '<non-existant-file>')
+    >>> hf_hub_download('bert-base-cased', '<non-existent-file>')
     huggingface_hub.utils._errors.EntryNotFoundError: 404 Client Error: Entry Not Found for url: <url>
     ```
     """

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -882,6 +882,11 @@ class CommitApiTest(HfApiCommonTestWithLogin):
                     parent_commit=parent_commit,
                 )
             self.assertEqual(exc_ctx.exception.response.status_code, 412)
+            self.assertIn(
+                # Check the server message is added to the exception
+                "A commit has happened since. Please refresh and try again.",
+                str(exc_ctx.exception),
+            )
         except Exception as err:
             self.fail(err)
         finally:


### PR DESCRIPTION
Related to https://github.com/huggingface/huggingface_hub/issues/1012 and https://github.com/huggingface/moon-landing/issues/3703.

Now the error message returned by the server is added to the HTTPError. Example for a gated dataset:

```py
from huggingface_hub import snapshot_download

snapshot_download(
    "sbrandeis/gated-fields",
    repo_type="dataset",
    use_auth_token="xxx",
)
```

```
Traceback (most recent call last):
  File "/Users/lucain/projects/huggingface/huggingface_hub/imtesting.py", line 3, in <module>
    snapshot_download(
  File "/Users/lucain/projects/huggingface/huggingface_hub/src/huggingface_hub/utils/_deprecation.py", line 93, in inner_f
    return f(*args, **kwargs)
  File "/Users/lucain/projects/huggingface/huggingface_hub/src/huggingface_hub/_snapshot_download.py", line 168, in snapshot_download
    repo_info = _api.repo_info(
  File "/Users/lucain/projects/huggingface/huggingface_hub/src/huggingface_hub/hf_api.py", line 1462, in repo_info
    return self.dataset_info(
  File "/Users/lucain/projects/huggingface/huggingface_hub/src/huggingface_hub/hf_api.py", line 1340, in dataset_info
    _raise_for_status(r)
  File "/Users/lucain/projects/huggingface/huggingface_hub/src/huggingface_hub/utils/_errors.py", line 169, in _raise_for_status
    raise e
  File "/Users/lucain/projects/huggingface/huggingface_hub/src/huggingface_hub/utils/_errors.py", line 131, in _raise_for_status
    response.raise_for_status()
  File "/Users/lucain/projects/huggingface/huggingface_hub/.venv310_no_ml/lib/python3.10/site-packages/requests/models.py", line 1021, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 403 Client Error: Forbidden for url: https://huggingface.co/api/datasets/sbrandeis/gated-fields/revision/main (Request ID: M9tpczsa85hzfImiSj3WX)

Access to dataset sbrandeis/gated-fields is restricted and you are not in the authorized list. Visit https://huggingface.co/datasets/sbrandeis/gated-fields to ask for access.
```

@SBrandeis @Pierrci how would you test that ? I wanted to create a gated repo on the staging platform but since it would be created by the user itself, the gate is automatically open. And as far as I understand, when we use the production server in the CI it's only for public and open repositories (no token). 