### PR TITLE
Add securityStatus to ModelInfo object with default value None.

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -239,7 +239,7 @@ class ModelInfo:
             Model configuration information
         securityStatus (`Dict`, *optional*):
             Security status of the model.
-            Example: {"containsInfected": False}
+            Example: `{"containsInfected": False}`
         kwargs (`Dict`, *optional*):
             Kwargs that will be become attributes of the class.
     """

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -225,7 +225,7 @@ class ModelInfo:
             repo sha at this particular revision
         lastModified (`str`, *optional*):
             date of last commit to repo
-        tags (`Listr[str]`, *optional*):
+        tags (`List[str]`, *optional*):
             List of tags.
         pipeline_tag (`str`, *optional*):
             Pipeline tag to identify the correct widget.
@@ -237,6 +237,9 @@ class ModelInfo:
             repo author
         config (`Dict`, *optional*):
             Model configuration information
+        securityStatus (`Dict`, *optional*):
+            Security status of the model.
+            Example: {"containsInfected": False}
         kwargs (`Dict`, *optional*):
             Kwargs that will be become attributes of the class.
     """
@@ -253,6 +256,7 @@ class ModelInfo:
         private: bool = False,
         author: Optional[str] = None,
         config: Optional[Dict] = None,
+        securityStatus: Optional[Dict] = None,
         **kwargs,
     ):
         self.modelId = modelId
@@ -266,6 +270,7 @@ class ModelInfo:
         self.private = private
         self.author = author
         self.config = config
+        self.securityStatus = securityStatus
         for k, v in kwargs.items():
             setattr(self, k, v)
 


### PR DESCRIPTION
Fix https://github.com/huggingface/huggingface_hub/issues/1002. See https://github.com/huggingface/huggingface_hub/issues/1002#issuecomment-1223698972.

Since `securityStatus` can be explicitly requested by a user, let's add it to the default ModelInfo class.

Note: it was already implicitly added when returned by the server (see code below from [`__init__`](https://github.com/huggingface/huggingface_hub/blob/c03bd2917c35b44d6a38a63dac4b0f72dad3ab99/src/huggingface_hub/hf_api.py#L269) and discussed [here](https://github.com/huggingface/huggingface_hub/pull/951#discussion_r926460408)) but not default to None if not returned.
```py
        for k, v in kwargs.items():
            setattr(self, k, v)
```