### PR TITLE
Remove repo_id validation in hf_hub_url and hf_hub_download

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -169,6 +169,7 @@ def get_jinja_version():
 
 REGEX_COMMIT_HASH = re.compile(r"^[0-9a-f]{40}$")
 
+
 # Do not validate `repo_id` in `hf_hub_url` for now as the `repo_id="datasets/.../..."`
 # pattern is used/advertised in Transformers examples.
 # Related: https://github.com/huggingface/huggingface_hub/pull/1029

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -169,8 +169,11 @@ def get_jinja_version():
 
 REGEX_COMMIT_HASH = re.compile(r"^[0-9a-f]{40}$")
 
-
-@validate_hf_hub_args
+# Do not validate `repo_id` in `hf_hub_url` for now as the `repo_id="datasets/.../..."`
+# pattern is used/advertised in Transformers examples.
+# Related: https://github.com/huggingface/huggingface_hub/pull/1029
+# TODO: set back validation in V0.12.
+# @validate_hf_hub_args
 def hf_hub_url(
     repo_id: str,
     filename: str,
@@ -896,7 +899,11 @@ def repo_folder_name(*, repo_id: str, repo_type: str) -> str:
     return REPO_ID_SEPARATOR.join(parts)
 
 
-@validate_hf_hub_args
+# Do not validate `repo_id` in `hf_hub_download` for now as the `repo_id="datasets/.../..."`
+# pattern is used/advertised in Transformers examples.
+# Related: https://github.com/huggingface/huggingface_hub/pull/1029
+# TODO: set back validation in V0.12.
+# @validate_hf_hub_args
 def hf_hub_download(
     repo_id: str,
     filename: str,


### PR DESCRIPTION
@sgugger Sorry I realized I merged https://github.com/huggingface/huggingface_hub/pull/1029 without removing the validation for `hf_hub_url` and `hf_hub_download`. As `repo_id="datasets/.../..."` is used in `transformers` I guess it's better to remove the validation for now until `transformers` is updated. Since I'm not exactly sure how critical/problematic this is, I let you tell me what you prefer to do. I can also put a warning message for wrong usage if you think it's not damaging the user experience.

My only concern is that we set validation back whenever possible and at most in a few releases (v0.12 ?). Your call :)

(cc @LysandreJik also)

Related: https://github.com/huggingface/huggingface_hub/issues/1008, https://github.com/huggingface/huggingface_hub/pull/1029#issue-1358903151 and https://github.com/huggingface/huggingface_hub/pull/1029#issuecomment-1236694089