### PR TITLE
Fix raise syntax: remove markdown bullet point

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -667,9 +667,9 @@ class HfApi:
         Returns:
             Validated token and the name of the repository.
         Raises:
-            - [`EnvironmentError`](https://docs.python.org/3/library/exceptions.html#EnvironmentError)
+            [`EnvironmentError`](https://docs.python.org/3/library/exceptions.html#EnvironmentError)
               If the token is not passed and there's no token saved locally.
-            - [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
+            [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
               If organization token or invalid token is passed.
         """
         if token is None or token is True:
@@ -1974,15 +1974,15 @@ class HfApi:
                 on the Hub. Otherwise returns `None`.
 
         Raises:
-            - [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
+            [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
                 If commit message is empty.
-            - [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
+            [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
                 If parent commit is not a valid commit OID.
-            - [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
+            [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
                 If the Hub API returns an HTTP 400 error (bad request)
-            - [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
+            [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
                 If `create_pr` is `True` and revision is neither `None` nor `"main"`.
-            - [`~utils.RepositoryNotFoundError`]:
+            [`~utils.RepositoryNotFoundError`]:
                 If repository is not found (error 404): wrong repo_id/repo_type, private
                 but not authenticated or repo does not exist.
 

--- a/src/huggingface_hub/utils/_cache_manager.py
+++ b/src/huggingface_hub/utils/_cache_manager.py
@@ -282,7 +282,7 @@ def scan_cache_dir(cache_dir: Optional[Union[str, Path]] = None) -> HFCacheInfo:
 
     Raises:
 
-        - [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
+        [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
           If directory to scan is missing or is a file.
 
     </Tip>

--- a/src/huggingface_hub/utils/_validators.py
+++ b/src/huggingface_hub/utils/_validators.py
@@ -71,7 +71,7 @@ def validate_hf_hub_args(fn: Callable) -> Callable:
     <Tip warning={true}>
 
     Raises:
-        - [`~utils.HFValidationError`]: If an input is not valid.
+        [`~utils.HFValidationError`]: If an input is not valid.
 
     </Tip>
     """


### PR DESCRIPTION
There were extra markdown bullet points in `Raise` docstrings

which is causing UI bug: 
<img width="500" alt="image" src="https://user-images.githubusercontent.com/11827707/188477243-b7a0c101-b926-4818-b54d-39426be75d2a.png">
