### PR TITLE
1025 add time details to scan cache

### DIFF
--- a/docs/source/how-to-cache.mdx
+++ b/docs/source/how-to-cache.mdx
@@ -128,14 +128,14 @@ cached.
 
 ```text
 ➜ huggingface-cli scan-cache
-REPO ID                     REPO TYPE SIZE ON DISK NB FILES REFS                LOCAL PATH
---------------------------- --------- ------------ -------- ------------------- -------------------------------------------------------------------------
-glue                        dataset         116.3K       15 2.4.0, main, 1.17.0 /Users/lucain/.cache/huggingface/hub/datasets--glue
-google/fleurs               dataset          64.9M        6 refs/pr/1, main     /Users/lucain/.cache/huggingface/hub/datasets--google--fleurs
-Jean-Baptiste/camembert-ner model           441.0M        7 main                /Users/lucain/.cache/huggingface/hub/models--Jean-Baptiste--camembert-ner
-bert-base-cased             model             1.9G       13 main                /Users/lucain/.cache/huggingface/hub/models--bert-base-cased
-t5-base                     model            10.1K        3 main                /Users/lucain/.cache/huggingface/hub/models--t5-base
-t5-small                    model           970.7M       11 refs/pr/1, main     /Users/lucain/.cache/huggingface/hub/models--t5-small
+REPO ID                     REPO TYPE SIZE ON DISK NB FILES LAST_ACCESSED LAST_MODIFIED REFS                LOCAL PATH
+--------------------------- --------- ------------ -------- ------------- ------------- ------------------- -------------------------------------------------------------------------
+glue                        dataset         116.3K       15 4 days ago    4 days ago    2.4.0, main, 1.17.0 /home/wauplin/.cache/huggingface/hub/datasets--glue
+google/fleurs               dataset          64.9M        6 1 week ago    1 week ago    refs/pr/1, main     /home/wauplin/.cache/huggingface/hub/datasets--google--fleurs
+Jean-Baptiste/camembert-ner model           441.0M        7 2 weeks ago   16 hours ago  main                /home/wauplin/.cache/huggingface/hub/models--Jean-Baptiste--camembert-ner
+bert-base-cased             model             1.9G       13 1 week ago    2 years ago                       /home/wauplin/.cache/huggingface/hub/models--bert-base-cased
+t5-base                     model            10.1K        3 3 months ago  3 months ago  main                /home/wauplin/.cache/huggingface/hub/models--t5-base
+t5-small                    model           970.7M       11 3 days ago    3 days ago    refs/pr/1, main     /home/wauplin/.cache/huggingface/hub/models--t5-small
 
 Done in 0.0s. Scanned 6 repo(s) for a total of 3.4G.
 Got 1 warning(s) while scanning. Use -vvv to print details.
@@ -150,19 +150,19 @@ usage is only 1.9G.
 
 ```text
 ➜ huggingface-cli scan-cache -v
-REPO ID                     REPO TYPE REVISION                                 SIZE ON DISK NB FILES REFS        LOCAL PATH
---------------------------- --------- ---------------------------------------- ------------ -------- ----------- ----------------------------------------------------------------------------------------------------------------------------
-glue                        dataset   9338f7b671827df886678df2bdd7cc7b4f36dffd        97.7K       14 main, 2.4.0 /Users/lucain/.cache/huggingface/hub/datasets--glue/snapshots/9338f7b671827df886678df2bdd7cc7b4f36dffd
-glue                        dataset   f021ae41c879fcabcf823648ec685e3fead91fe7        97.8K       14 1.17.0      /Users/lucain/.cache/huggingface/hub/datasets--glue/snapshots/f021ae41c879fcabcf823648ec685e3fead91fe7
-google/fleurs               dataset   129b6e96cf1967cd5d2b9b6aec75ce6cce7c89e8        25.4K        3 refs/pr/1   /Users/lucain/.cache/huggingface/hub/datasets--google--fleurs/snapshots/129b6e96cf1967cd5d2b9b6aec75ce6cce7c89e8
-google/fleurs               dataset   24f85a01eb955224ca3946e70050869c56446805        64.9M        4 main        /Users/lucain/.cache/huggingface/hub/datasets--google--fleurs/snapshots/24f85a01eb955224ca3946e70050869c56446805
-Jean-Baptiste/camembert-ner model     dbec8489a1c44ecad9da8a9185115bccabd799fe       441.0M        7 main        /Users/lucain/.cache/huggingface/hub/models--Jean-Baptiste--camembert-ner/snapshots/dbec8489a1c44ecad9da8a9185115bccabd799fe
-bert-base-cased             model     378aa1bda6387fd00e824948ebe3488630ad8565         1.5G        9             /Users/lucain/.cache/huggingface/hub/models--bert-base-cased/snapshots/378aa1bda6387fd00e824948ebe3488630ad8565
-bert-base-cased             model     a8d257ba9925ef39f3036bfc338acf5283c512d9         1.4G        9 main        /Users/lucain/.cache/huggingface/hub/models--bert-base-cased/snapshots/a8d257ba9925ef39f3036bfc338acf5283c512d9
-t5-base                     model     23aa4f41cb7c08d4b05c8f327b22bfa0eb8c7ad9        10.1K        3 main        /Users/lucain/.cache/huggingface/hub/models--t5-base/snapshots/23aa4f41cb7c08d4b05c8f327b22bfa0eb8c7ad9
-t5-small                    model     98ffebbb27340ec1b1abd7c45da12c253ee1882a       726.2M        6 refs/pr/1   /Users/lucain/.cache/huggingface/hub/models--t5-small/snapshots/98ffebbb27340ec1b1abd7c45da12c253ee1882a
-t5-small                    model     d0a119eedb3718e34c648e594394474cf95e0617       485.8M        6             /Users/lucain/.cache/huggingface/hub/models--t5-small/snapshots/d0a119eedb3718e34c648e594394474cf95e0617
-t5-small                    model     d78aea13fa7ecd06c29e3e46195d6341255065d5       970.7M        9 main        /Users/lucain/.cache/huggingface/hub/models--t5-small/snapshots/d78aea13fa7ecd06c29e3e46195d6341255065d5
+REPO ID                     REPO TYPE REVISION                                 SIZE ON DISK NB FILES LAST_MODIFIED REFS        LOCAL PATH
+--------------------------- --------- ---------------------------------------- ------------ -------- ------------- ----------- ----------------------------------------------------------------------------------------------------------------------------
+glue                        dataset   9338f7b671827df886678df2bdd7cc7b4f36dffd        97.7K       14 4 days ago    main, 2.4.0 /home/wauplin/.cache/huggingface/hub/datasets--glue/snapshots/9338f7b671827df886678df2bdd7cc7b4f36dffd
+glue                        dataset   f021ae41c879fcabcf823648ec685e3fead91fe7        97.8K       14 1 week ago    1.17.0      /home/wauplin/.cache/huggingface/hub/datasets--glue/snapshots/f021ae41c879fcabcf823648ec685e3fead91fe7
+google/fleurs               dataset   129b6e96cf1967cd5d2b9b6aec75ce6cce7c89e8        25.4K        3 2 weeks ago   refs/pr/1   /home/wauplin/.cache/huggingface/hub/datasets--google--fleurs/snapshots/129b6e96cf1967cd5d2b9b6aec75ce6cce7c89e8
+google/fleurs               dataset   24f85a01eb955224ca3946e70050869c56446805        64.9M        4 1 week ago    main        /home/wauplin/.cache/huggingface/hub/datasets--google--fleurs/snapshots/24f85a01eb955224ca3946e70050869c56446805
+Jean-Baptiste/camembert-ner model     dbec8489a1c44ecad9da8a9185115bccabd799fe       441.0M        7 16 hours ago  main        /home/wauplin/.cache/huggingface/hub/models--Jean-Baptiste--camembert-ner/snapshots/dbec8489a1c44ecad9da8a9185115bccabd799fe
+bert-base-cased             model     378aa1bda6387fd00e824948ebe3488630ad8565         1.5G        9 2 years ago               /home/wauplin/.cache/huggingface/hub/models--bert-base-cased/snapshots/378aa1bda6387fd00e824948ebe3488630ad8565
+bert-base-cased             model     a8d257ba9925ef39f3036bfc338acf5283c512d9         1.4G        9 3 days ago    main        /home/wauplin/.cache/huggingface/hub/models--bert-base-cased/snapshots/a8d257ba9925ef39f3036bfc338acf5283c512d9
+t5-base                     model     23aa4f41cb7c08d4b05c8f327b22bfa0eb8c7ad9        10.1K        3 1 week ago    main        /home/wauplin/.cache/huggingface/hub/models--t5-base/snapshots/23aa4f41cb7c08d4b05c8f327b22bfa0eb8c7ad9
+t5-small                    model     98ffebbb27340ec1b1abd7c45da12c253ee1882a       726.2M        6 1 week ago    refs/pr/1   /home/wauplin/.cache/huggingface/hub/models--t5-small/snapshots/98ffebbb27340ec1b1abd7c45da12c253ee1882a
+t5-small                    model     d0a119eedb3718e34c648e594394474cf95e0617       485.8M        6 4 weeks ago               /home/wauplin/.cache/huggingface/hub/models--t5-small/snapshots/d0a119eedb3718e34c648e594394474cf95e0617
+t5-small                    model     d78aea13fa7ecd06c29e3e46195d6341255065d5       970.7M        9 1 week ago    main        /home/wauplin/.cache/huggingface/hub/models--t5-small/snapshots/d78aea13fa7ecd06c29e3e46195d6341255065d5
 
 Done in 0.0s. Scanned 6 repo(s) for a total of 3.4G.
 Got 1 warning(s) while scanning. Use -vvv to print details.
@@ -176,9 +176,9 @@ model on a Unix-based machine.
 
 ```text
 ➜ eval "huggingface-cli scan-cache -v" | grep "t5-small"
-t5-small                    model     98ffebbb27340ec1b1abd7c45da12c253ee1882a       726.2M        6 refs/pr/1   /Users/lucain/.cache/huggingface/hub/models--t5-small/snapshots/98ffebbb27340ec1b1abd7c45da12c253ee1882a
-t5-small                    model     d0a119eedb3718e34c648e594394474cf95e0617       485.8M        6             /Users/lucain/.cache/huggingface/hub/models--t5-small/snapshots/d0a119eedb3718e34c648e594394474cf95e0617
-t5-small                    model     d78aea13fa7ecd06c29e3e46195d6341255065d5       970.7M        9 main        /Users/lucain/.cache/huggingface/hub/models--t5-small/snapshots/d78aea13fa7ecd06c29e3e46195d6341255065d5
+t5-small                    model     98ffebbb27340ec1b1abd7c45da12c253ee1882a       726.2M        6 1 week ago    refs/pr/1   /home/wauplin/.cache/huggingface/hub/models--t5-small/snapshots/98ffebbb27340ec1b1abd7c45da12c253ee1882a
+t5-small                    model     d0a119eedb3718e34c648e594394474cf95e0617       485.8M        6 4 weeks ago               /home/wauplin/.cache/huggingface/hub/models--t5-small/snapshots/d0a119eedb3718e34c648e594394474cf95e0617
+t5-small                    model     d78aea13fa7ecd06c29e3e46195d6341255065d5       970.7M        9 1 week ago    main        /home/wauplin/.cache/huggingface/hub/models--t5-small/snapshots/d78aea13fa7ecd06c29e3e46195d6341255065d5
 ```
 
 ### From Python
@@ -208,17 +208,23 @@ HFCacheInfo(
             repo_path=PosixPath(...),
             size_on_disk=970726914,
             nb_files=11,
+            last_accessed=1662971707.3567169,
+            last_modified=1662971107.3567169,
             revisions=frozenset({
                 CachedRevisionInfo(
                     commit_hash='d78aea13fa7ecd06c29e3e46195d6341255065d5',
                     size_on_disk=970726339,
                     snapshot_path=PosixPath(...),
+                    # No `last_accessed` as blobs are shared among revisions
+                    last_modified=1662971107.3567169,
                     files=frozenset({
                         CachedFileInfo(
                             file_name='config.json',
                             size_on_disk=1197
                             file_path=PosixPath(...),
                             blob_path=PosixPath(...),
+                            blob_last_accessed=1662971707.3567169,
+                            blob_last_modified=1662971107.3567169,
                         ),
                         CachedFileInfo(...),
                         ...

--- a/src/huggingface_hub/commands/cache.py
+++ b/src/huggingface_hub/commands/cache.py
@@ -81,6 +81,8 @@ class ScanCacheCommand(BaseHuggingfaceCLICommand):
                             repo.repo_type,
                             "{:>12}".format(repo.size_on_disk_str),
                             repo.nb_files,
+                            repo.last_accessed_str,
+                            repo.last_modified_str,
                             ", ".join(sorted(repo.refs)),
                             str(repo.repo_path),
                         ]
@@ -93,6 +95,8 @@ class ScanCacheCommand(BaseHuggingfaceCLICommand):
                         "REPO TYPE",
                         "SIZE ON DISK",
                         "NB FILES",
+                        "LAST_ACCESSED",
+                        "LAST_MODIFIED",
                         "REFS",
                         "LOCAL PATH",
                     ],
@@ -108,6 +112,7 @@ class ScanCacheCommand(BaseHuggingfaceCLICommand):
                             revision.commit_hash,
                             "{:>12}".format(revision.size_on_disk_str),
                             revision.nb_files,
+                            revision.last_modified_str,
                             ", ".join(sorted(revision.refs)),
                             str(revision.snapshot_path),
                         ]
@@ -124,6 +129,7 @@ class ScanCacheCommand(BaseHuggingfaceCLICommand):
                         "REVISION",
                         "SIZE ON DISK",
                         "NB FILES",
+                        "LAST_MODIFIED",
                         "REFS",
                         "LOCAL PATH",
                     ],

--- a/src/huggingface_hub/utils/_cache_manager.py
+++ b/src/huggingface_hub/utils/_cache_manager.py
@@ -80,7 +80,7 @@ class CachedFileInfo:
 
         Example: "2 weeks ago".
         """
-        return _format_ts(self.blob_last_accessed)
+        return _format_timesince(self.blob_last_accessed)
 
     @property
     def blob_last_modified_str(self) -> str:
@@ -90,7 +90,7 @@ class CachedFileInfo:
 
         Example: "2 weeks ago".
         """
-        return _format_ts(self.blob_last_modified)
+        return _format_timesince(self.blob_last_modified)
 
     @property
     def size_on_disk_str(self) -> str:
@@ -160,7 +160,7 @@ class CachedRevisionInfo:
 
         Example: "2 weeks ago".
         """
-        return _format_ts(self.last_modified)
+        return _format_timesince(self.last_modified)
 
     @property
     def size_on_disk_str(self) -> str:
@@ -236,7 +236,7 @@ class CachedRepoInfo:
 
         Example: "2 weeks ago".
         """
-        return _format_ts(self.last_accessed)
+        return _format_timesince(self.last_accessed)
 
     @property
     def last_modified_str(self) -> str:
@@ -246,7 +246,7 @@ class CachedRepoInfo:
 
         Example: "2 weeks ago".
         """
-        return _format_ts(self.last_modified)
+        return _format_timesince(self.last_modified)
 
     @property
     def size_on_disk_str(self) -> str:
@@ -770,7 +770,7 @@ _TIMESINCE_CHUNKS = (
 )
 
 
-def _format_ts(ts: float) -> str:
+def _format_timesince(ts: float) -> str:
     """Format timestamp in seconds into a human-readable string, relative to now.
 
     Vaguely inspired by Django's `timesince` formatter.

--- a/src/huggingface_hub/utils/_cache_manager.py
+++ b/src/huggingface_hub/utils/_cache_manager.py
@@ -776,8 +776,8 @@ def _format_ts(ts: float) -> str:
     Vaguely inspired by Django's `timesince` formatter.
     """
     delta = time.time() - ts
-    if delta < 2:
-        return "now"
+    if delta < 20:
+        return "a few seconds ago"
     for label, divider, max_value in _TIMESINCE_CHUNKS:
         value = round(delta / divider)
         if max_value is None or value <= max_value:

--- a/tests/test_utils_cache.py
+++ b/tests/test_utils_cache.py
@@ -201,10 +201,10 @@ class TestValidCacheUtils(unittest.TestCase):
         sys.stdout = previous_output
 
         expected_output = f"""
-        REPO ID                       REPO TYPE SIZE ON DISK NB FILES REFS            LOCAL PATH
-        ----------------------------- --------- ------------ -------- --------------- -------------------------------------------------------------------------------------------------------------
-        valid_org/test_scan_dataset_b dataset           2.2K        2 main            {self.cache_dir}/datasets--valid_org--test_scan_dataset_b
-        valid_org/test_scan_repo_a    model             1.4K        4 main, refs/pr/1 {self.cache_dir}/models--valid_org--test_scan_repo_a
+        REPO ID                       REPO TYPE SIZE ON DISK NB FILES LAST_ACCESSED     LAST_MODIFIED     REFS            LOCAL PATH
+        ----------------------------- --------- ------------ -------- ----------------- ----------------- --------------- ---------------------------------------------------------
+        valid_org/test_scan_dataset_b dataset           2.2K        2 a few seconds ago a few seconds ago main            {self.cache_dir}/datasets--valid_org--test_scan_dataset_b
+        valid_org/test_scan_repo_a    model             1.4K        4 a few seconds ago a few seconds ago main, refs/pr/1 {self.cache_dir}/models--valid_org--test_scan_repo_a
 
         Done in 0.0s. Scanned 2 repo(s) for a total of \x1b[1m\x1b[31m3.5K\x1b[0m.
         """
@@ -231,12 +231,12 @@ class TestValidCacheUtils(unittest.TestCase):
         sys.stdout = previous_output
 
         expected_output = f"""
-        REPO ID                       REPO TYPE REVISION                                 SIZE ON DISK NB FILES REFS      LOCAL PATH
-        ----------------------------- --------- ---------------------------------------- ------------ -------- --------- ----------------------------------------------------------------------------------------------------------------------------------------------------------------
-        valid_org/test_scan_dataset_b dataset   1ac47c6f707cbc4825c2aa431ad5ab8cf09e60ed         2.2K        2 main      {self.cache_dir}/datasets--valid_org--test_scan_dataset_b/snapshots/1ac47c6f707cbc4825c2aa431ad5ab8cf09e60ed
-        valid_org/test_scan_repo_a    model     1da18ebd9185d146bcf84e308de53715d97d67d1         1.3K        1           {self.cache_dir}/models--valid_org--test_scan_repo_a/snapshots/1da18ebd9185d146bcf84e308de53715d97d67d1
-        valid_org/test_scan_repo_a    model     401874e6a9c254a8baae85edd8a073921ecbd7f5         1.4K        3 main      {self.cache_dir}/models--valid_org--test_scan_repo_a/snapshots/401874e6a9c254a8baae85edd8a073921ecbd7f5
-        valid_org/test_scan_repo_a    model     fc674b0d440d3ea6f94bc4012e33ebd1dfc11b5b         1.4K        4 refs/pr/1 {self.cache_dir}/models--valid_org--test_scan_repo_a/snapshots/fc674b0d440d3ea6f94bc4012e33ebd1dfc11b5b
+        REPO ID                       REPO TYPE REVISION                                 SIZE ON DISK NB FILES LAST_MODIFIED     REFS      LOCAL PATH
+        ----------------------------- --------- ---------------------------------------- ------------ -------- ----------------- --------- ------------------------------------------------------------------------------------------------------------
+        valid_org/test_scan_dataset_b dataset   1ac47c6f707cbc4825c2aa431ad5ab8cf09e60ed         2.2K        2 a few seconds ago main      {self.cache_dir}/datasets--valid_org--test_scan_dataset_b/snapshots/1ac47c6f707cbc4825c2aa431ad5ab8cf09e60ed
+        valid_org/test_scan_repo_a    model     1da18ebd9185d146bcf84e308de53715d97d67d1         1.3K        1 a few seconds ago           {self.cache_dir}/models--valid_org--test_scan_repo_a/snapshots/1da18ebd9185d146bcf84e308de53715d97d67d1
+        valid_org/test_scan_repo_a    model     401874e6a9c254a8baae85edd8a073921ecbd7f5         1.4K        3 a few seconds ago main      {self.cache_dir}/models--valid_org--test_scan_repo_a/snapshots/401874e6a9c254a8baae85edd8a073921ecbd7f5
+        valid_org/test_scan_repo_a    model     fc674b0d440d3ea6f94bc4012e33ebd1dfc11b5b         1.4K        4 a few seconds ago refs/pr/1 {self.cache_dir}/models--valid_org--test_scan_repo_a/snapshots/fc674b0d440d3ea6f94bc4012e33ebd1dfc11b5b
 
         Done in 0.0s. Scanned 2 repo(s) for a total of \x1b[1m\x1b[31m3.5K\x1b[0m.
         """
@@ -660,12 +660,13 @@ class TestStringFormatters(unittest.TestCase):
     SIZES = {
         16.0: "16.0",
         1000.0: "1.0K",
-        1024 * 1024 * 1024: "1.1G",  # not 1.0GB
+        1024 * 1024 * 1024: "1.1G",  # not 1.0GiB
     }
 
     SINCE = {
-        1: "now",
-        5: "5 seconds ago",
+        1: "a few seconds ago",
+        15: "a few seconds ago",
+        25: "25 seconds ago",
         80: "1 minute ago",
         1000: "17 minutes ago",
         4000: "1 hour ago",

--- a/tests/test_utils_cache.py
+++ b/tests/test_utils_cache.py
@@ -751,7 +751,11 @@ class TestStringFormatters(unittest.TestCase):
     def test_format_size(self) -> None:
         """Test `_format_size` formatter."""
         for size, expected in self.SIZES.items():
-            self.assertEqual(_format_size(size), expected)
+            self.assertEqual(
+                _format_size(size),
+                expected,
+                msg=f"Wrong formatting for {size} == '{expected}'",
+            )
 
     def test_format_timesince(self) -> None:
         """Test `_format_timesince` formatter."""
@@ -759,5 +763,5 @@ class TestStringFormatters(unittest.TestCase):
             self.assertEqual(
                 _format_timesince(time.time() - ts),
                 expected,
-                msg=f"Wrong formatting for {ts}",
+                msg=f"Wrong formatting for {ts} == '{expected}'",
             )

--- a/tests/test_utils_cache.py
+++ b/tests/test_utils_cache.py
@@ -17,7 +17,7 @@ from huggingface_hub.commands.cache import ScanCacheCommand
 from huggingface_hub.utils import DeleteCacheStrategy, HFCacheInfo, scan_cache_dir
 from huggingface_hub.utils._cache_manager import (
     _format_size,
-    _format_ts,
+    _format_timesince,
     _try_delete_path,
 )
 
@@ -753,9 +753,11 @@ class TestStringFormatters(unittest.TestCase):
         for size, expected in self.SIZES.items():
             self.assertEqual(_format_size(size), expected)
 
-    def test_format_ts(self) -> None:
-        """Test `_format_ts` formatter."""
+    def test_format_timesince(self) -> None:
+        """Test `_format_timesince` formatter."""
         for ts, expected in self.SINCE.items():
             self.assertEqual(
-                _format_ts(time.time() - ts), expected, msg=f"Wrong formatting for {ts}"
+                _format_timesince(time.time() - ts),
+                expected,
+                msg=f"Wrong formatting for {ts}",
             )


### PR DESCRIPTION
Add `last_modified` and `last_accessed` info to the cache scanner. Scanned as float values (timestamp) and displayed as "timesince" string (`2 weeks ago`).

This is a preliminary work for the https://github.com/huggingface/huggingface_hub/issues/1025.

Implementation is based on [python's `os.stat` function](https://docs.python.org/3/library/os.html#os.stat) and applied only to the blob files themselves and not the symlinks (that are more platform-dependent).


```text
REPO ID                       REPO TYPE SIZE ON DISK NB FILES LAST_ACCESSED LAST_MODIFIED REFS            LOCAL PATH                                                                   
----------------------------- --------- ------------ -------- ------------- ------------- --------------- ---------------------------------------------------------------------------- 
chrisjay/crowd-speech-africa  dataset         761.7M     4269 4 days ago    4 days ago    main            /home/wauplin/.cache/huggingface/hub/datasets--chrisjay--crowd-speech-africa 
oscar                         dataset           3.3M        3 3 days ago    3 days ago    main            /home/wauplin/.cache/huggingface/hub/datasets--oscar                         
wikiann                       dataset         804.1K      180 1 week ago    1 week ago    main            /home/wauplin/.cache/huggingface/hub/datasets--wikiann                       
z-uo/male-LJSpeech-italian    dataset           5.5G     9409 4 days ago    4 days ago    main            /home/wauplin/.cache/huggingface/hub/datasets--z-uo--male-LJSpeech-italian   
chrisjay/crowd-speech-africa  model             1.2K        1 4 days ago    4 days ago    main            /home/wauplin/.cache/huggingface/hub/models--chrisjay--crowd-speech-africa   
datasets/lhoestq/custom_squad model             4.9M        2 2 weeks ago   2 weeks ago                   /home/wauplin/.cache/huggingface/hub/models--datasets--lhoestq--custom_squad 
gpt2                          model             3.1G       14 1 week ago    1 week ago    main, refs/pr/1 /home/wauplin/.cache/huggingface/hub/models--gpt2                            
osanseviero/flair_test3       model            714.0        1 2 weeks ago   2 weeks ago   main            /home/wauplin/.cache/huggingface/hub/models--osanseviero--flair_test3        

Done in 1.1s. Scanned 8 repo(s) for a total of 9.4G.
Got 2875 warning(s) while scanning. Use -vvv to print details.
```