### PR TITLE
Globally set git credential.helper to `store` in google colab

### DIFF
--- a/src/huggingface_hub/commands/user.py
+++ b/src/huggingface_hub/commands/user.py
@@ -333,15 +333,13 @@ def _is_google_colab() -> bool:
     See https://github.com/huggingface/huggingface_hub/issues/1043
 
     Taken from https://stackoverflow.com/a/63519730.
+    Note: looking in __builtin__  as suggested on SO did not work on google colab for me
+          so let's use a simple try/catch.
     """
-    import pdb
-
-    pdb.set_trace()
-    return (
+    try:
         "google.colab" in str(get_ipython())  # noqa: F821
-        if hasattr(__builtins__, "__IPYTHON__")
-        else False
-    )
+    except NameError:
+        return False
 
 
 def _set_store_as_git_credential_helper_globally() -> None:

--- a/src/huggingface_hub/commands/user.py
+++ b/src/huggingface_hub/commands/user.py
@@ -314,14 +314,11 @@ def _login(hf_api, token=None):
         _set_store_as_git_credential_helper_globally()
 
     print("******************************")
-    print(helpers)
     print(currently_setup_credential_helpers())
     print(_is_google_colab())
     print(os.getcwd())
     print(_set_store_as_git_credential_helper_globally())
     print(run_subprocess("git config --global credential.helper store"))
-    print(helpers)
-    print(currently_setup_credential_helpers())
     print("******************************")
 
     try:

--- a/src/huggingface_hub/commands/user.py
+++ b/src/huggingface_hub/commands/user.py
@@ -337,7 +337,7 @@ def _is_google_colab() -> bool:
           so let's use a simple try/catch.
     """
     try:
-        "google.colab" in str(get_ipython())  # noqa: F821
+        return "google.colab" in str(get_ipython())  # noqa: F821
     except NameError:
         return False
 

--- a/src/huggingface_hub/commands/user.py
+++ b/src/huggingface_hub/commands/user.py
@@ -314,9 +314,12 @@ def _login(hf_api, token=None):
 
     helpers = currently_setup_credential_helpers()
 
-    import pdb
-
-    pdb.set_trace()
+    print("******************************")
+    print(helpers())
+    print(_is_google_colab())
+    print(_set_store_as_git_credential_helper_globally())
+    print(run_subprocess("git config --global credential.helper store"))
+    print("******************************")
 
     if "store" not in helpers:
         print(

--- a/src/huggingface_hub/commands/user.py
+++ b/src/huggingface_hub/commands/user.py
@@ -313,8 +313,6 @@ def _login(hf_api, token=None):
     if _is_google_colab():
         _set_store_as_git_credential_helper_globally()
 
-    helpers = currently_setup_credential_helpers()
-
     print("******************************")
     print(helpers)
     print(currently_setup_credential_helpers())
@@ -322,7 +320,19 @@ def _login(hf_api, token=None):
     print(os.getcwd())
     print(_set_store_as_git_credential_helper_globally())
     print(run_subprocess("git config --global credential.helper store"))
+    print(helpers)
+    print(currently_setup_credential_helpers())
     print("******************************")
+
+    try:
+        print(get_ipython())
+        print("c'est bon?")
+    except NameError as e:
+        print(e)
+
+    print("******************************")
+
+    helpers = currently_setup_credential_helpers()
 
     if "store" not in helpers:
         print(

--- a/src/huggingface_hub/commands/user.py
+++ b/src/huggingface_hub/commands/user.py
@@ -314,6 +314,10 @@ def _login(hf_api, token=None):
 
     helpers = currently_setup_credential_helpers()
 
+    import pdb
+
+    pdb.set_trace()
+
     if "store" not in helpers:
         print(
             ANSI.red(

--- a/src/huggingface_hub/commands/user.py
+++ b/src/huggingface_hub/commands/user.py
@@ -334,6 +334,9 @@ def _is_google_colab() -> bool:
 
     Taken from https://stackoverflow.com/a/63519730.
     """
+    import pdb
+
+    pdb.set_trace()
     return (
         "google.colab" in str(get_ipython())  # noqa: F821
         if hasattr(__builtins__, "__IPYTHON__")

--- a/src/huggingface_hub/commands/user.py
+++ b/src/huggingface_hub/commands/user.py
@@ -32,6 +32,19 @@ from ..utils import run_subprocess
 from ._cli_utils import ANSI
 
 
+try:
+    # Set to `True` if script is running in a Google Colab notebook.
+    # If running in Google Colab, git credential store is set globally which makes the
+    # warning disappear. See https://github.com/huggingface/huggingface_hub/issues/1043
+    #
+    # Taken from https://stackoverflow.com/a/63519730.
+    # Got some trouble to make it work inside `login_token_event` callback so now set as
+    # global variable.
+    _is_google_colab = "google.colab" in str(get_ipython())  # noqa: F821
+except NameError:
+    _is_google_colab = False
+
+
 class UserCommands(BaseHuggingfaceCLICommand):
     @staticmethod
     def register_subcommand(parser: ArgumentParser):
@@ -310,12 +323,12 @@ def _login(hf_api, token=None):
 
     # Only in Google Colab to avoid the warning message
     # See https://github.com/huggingface/huggingface_hub/issues/1043#issuecomment-1247010710
-    if _is_google_colab():
+    if _is_google_colab:
         _set_store_as_git_credential_helper_globally()
 
     print("******************************")
     print(currently_setup_credential_helpers())
-    print(_is_google_colab())
+    print(_is_google_colab)
     print(os.getcwd())
     print(_set_store_as_git_credential_helper_globally())
     print(run_subprocess("git config --global credential.helper store"))
@@ -341,22 +354,6 @@ def _login(hf_api, token=None):
                 " default\n\ngit config --global credential.helper store"
             )
         )
-
-
-def _is_google_colab() -> bool:
-    """Return `True` if script is running in a Google Colab notebook.
-
-    If running in Google Colab, warning about by default.
-    See https://github.com/huggingface/huggingface_hub/issues/1043
-
-    Taken from https://stackoverflow.com/a/63519730.
-    Note: looking in __builtin__  as suggested on SO did not work on google colab for me
-          so let's use a simple try/catch.
-    """
-    try:
-        return "google.colab" in str(get_ipython())  # noqa: F821
-    except NameError:
-        return False
 
 
 def _set_store_as_git_credential_helper_globally() -> None:

--- a/src/huggingface_hub/commands/user.py
+++ b/src/huggingface_hub/commands/user.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import subprocess
 from argparse import ArgumentParser
 from getpass import getpass
@@ -315,8 +316,10 @@ def _login(hf_api, token=None):
     helpers = currently_setup_credential_helpers()
 
     print("******************************")
-    print(helpers())
+    print(helpers)
+    print(currently_setup_credential_helpers())
     print(_is_google_colab())
+    print(os.getcwd())
     print(_set_store_as_git_credential_helper_globally())
     print(run_subprocess("git config --global credential.helper store"))
     print("******************************")

--- a/src/huggingface_hub/commands/user.py
+++ b/src/huggingface_hub/commands/user.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import subprocess
 from argparse import ArgumentParser
 from getpass import getpass
@@ -325,22 +324,6 @@ def _login(hf_api, token=None):
     # See https://github.com/huggingface/huggingface_hub/issues/1043#issuecomment-1247010710
     if _is_google_colab:
         _set_store_as_git_credential_helper_globally()
-
-    print("******************************")
-    print(currently_setup_credential_helpers())
-    print(_is_google_colab)
-    print(os.getcwd())
-    print(_set_store_as_git_credential_helper_globally())
-    print(run_subprocess("git config --global credential.helper store"))
-    print("******************************")
-
-    try:
-        print(get_ipython())
-        print("c'est bon?")
-    except NameError as e:
-        print(e)
-
-    print("******************************")
 
     helpers = currently_setup_credential_helpers()
 

--- a/src/huggingface_hub/utils/_subprocess.py
+++ b/src/huggingface_hub/utils/_subprocess.py
@@ -13,9 +13,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License
-
+import os
 import subprocess
-from typing import List
+from typing import List, Optional, Union
 
 from .logging import get_logger
 
@@ -24,7 +24,7 @@ logger = get_logger(__name__)
 
 
 def run_subprocess(
-    command: List[str], folder: str, check=True, **kwargs
+    command: Union[str, List[str]], folder: Optional[str] = None, check=True, **kwargs
 ) -> subprocess.CompletedProcess:
     """
     Method to run subprocesses. Calling this will capture the `stderr` and `stdout`,
@@ -32,10 +32,11 @@ def run_subprocess(
     be captured.
 
     Args:
-        command (`List[str]`):
-            The command to execute as a list of strings.
-        folder (`str`):
-            The folder in which to run the command.
+        command (`str` or `List[str]`):
+            The command to execute as a string or list of strings.
+        folder (`str`, *optional*):
+            The folder in which to run the command. Defaults to current working
+            directory (from `os.getcwd()`).
         check (`bool`, *optional*, defaults to `True`):
             Setting `check` to `True` will raise a `subprocess.CalledProcessError`
             when the subprocess has a non-zero exit code.
@@ -46,7 +47,7 @@ def run_subprocess(
         `subprocess.CompletedProcess`: The completed process.
     """
     if isinstance(command, str):
-        raise ValueError("`run_subprocess` should be called with a list of strings.")
+        command = command.split()
 
     return subprocess.run(
         command,
@@ -54,6 +55,6 @@ def run_subprocess(
         stdout=subprocess.PIPE,
         check=check,
         encoding="utf-8",
-        cwd=folder,
+        cwd=folder or os.getcwd(),
         **kwargs,
     )

--- a/tests/test_cli_user_utils.py
+++ b/tests/test_cli_user_utils.py
@@ -12,7 +12,7 @@ from huggingface_hub.utils import run_subprocess
 class TestMiscUserUtils(unittest.TestCase):
     def test_is_google_colab(self) -> None:
         """Test `_is_google_colab`."""
-        self.assertFalse(_is_google_colab())
+        self.assertFalse(_is_google_colab)
 
 
 class TestSetGlobalStore(unittest.TestCase):

--- a/tests/test_cli_user_utils.py
+++ b/tests/test_cli_user_utils.py
@@ -1,0 +1,48 @@
+import subprocess
+import unittest
+from typing import Optional
+
+from huggingface_hub.commands.user import (
+    _is_google_colab,
+    _set_store_as_git_credential_helper_globally,
+)
+from huggingface_hub.utils import run_subprocess
+
+
+class TestMiscUserUtils(unittest.TestCase):
+    def test_is_google_colab(self) -> None:
+        """Test `_is_google_colab`."""
+        self.assertFalse(_is_google_colab())
+
+
+class TestSetGlobalStore(unittest.TestCase):
+    previous_config: Optional[str]
+
+    def setUp(self) -> None:
+        """Get current global config value."""
+        try:
+            self.previous_config = run_subprocess(
+                "git config --global credential.helper"
+            ).stdout
+        except subprocess.CalledProcessError:
+            self.previous_config = None  # Means global credential.helper value not set
+
+        run_subprocess("git config --global credential.helper store")
+
+    def tearDown(self) -> None:
+        """Reset global config value."""
+        if self.previous_config is None:
+            run_subprocess("git config --global --unset credential.helper")
+        else:
+            run_subprocess(
+                f"git config --global credential.helper {self.previous_config}"
+            )
+
+    def test_set_store_as_git_credential_helper_globally(self) -> None:
+        """Test `_set_store_as_git_credential_helper_globally` works as expected.
+
+        Previous value from the machine is restored after the test.
+        """
+        _set_store_as_git_credential_helper_globally()
+        new_config = run_subprocess("git config --global credential.helper").stdout
+        self.assertEqual(new_config, "store\n")


### PR DESCRIPTION
Fix warning message as discussed in https://github.com/huggingface/huggingface_hub/issues/1043 (https://github.com/huggingface/huggingface_hub/issues/1043#issuecomment-1247010710)

Now if `huggingface_hub` detects that it runs in a google colab, `git config --global credential.helper store` is ran by default without warning message to ask the user to do it.

Here is a [Google Colab](https://colab.research.google.com/drive/1J0rbwsumHWtSUY0pFdzUoLykth3PNTIi#scrollTo=kE-I-Y4s-28u) to test it.

(cc @apolinario)