### PR TITLE
1055 deprecate private and repo type in repository class

### DIFF
--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -558,7 +558,7 @@ class Repository:
     @property
     @_deprecate_method(
         version="0.12",
-        message="`repo_type` attribute is not a reliable information in `Repository`.",
+        message="Attribute `repo_type` is not a reliable information.",
     )
     def repo_type(self) -> Optional[str]:
         """Make `repo_type` a private attribute to warn users this is not a value to
@@ -570,7 +570,7 @@ class Repository:
     @property
     @_deprecate_method(
         version="0.12",
-        message="`private` attribute will soon be removed.",
+        message="Attribute `private` is not a reliable information.",
     )
     def private(self) -> Optional[str]:
         """Make `private` a private attribute to warn users this is not a value to

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -570,7 +570,7 @@ class Repository:
     @property
     @_deprecate_method(
         version="0.12",
-        message="Attribute `private` is not a reliable information.",
+        message="`private` is only used in a deprecated use case of `clone_from`.",
     )
     def private(self) -> Optional[str]:
         """Make `private` a private attribute to warn users this is not a value to

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -558,7 +558,7 @@ class Repository:
     @property
     @_deprecate_method(
         version="0.12",
-        message="Attribute `repo_type` is not a reliable information.",
+        message="`repo_type` is only used in a deprecated use case of `clone_from`.",
     )
     def repo_type(self) -> Optional[str]:
         """Make `repo_type` a private attribute to warn users this is not a value to

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1634,6 +1634,34 @@ class RepositoryOfflineTest(RepositoryCommonTest):
 
         self.assertFalse(repo.is_repo_clean())
 
+    @expect_deprecation("__init__")
+    def test_private_deprecation_on_init(self):
+        Repository(
+            WORKING_REPO_DIR,
+            private=True,
+            git_user="RANDOM_USER",
+            git_email="EMAIL@EMAIL.EMAIL",
+        )
+
+    @expect_deprecation("private")
+    def test_private_deprecation_on_attribute(self):
+        repo = Repository(
+            WORKING_REPO_DIR,
+            git_user="RANDOM_USER",
+            git_email="EMAIL@EMAIL.EMAIL",
+        )
+        self.assertFalse(repo.private)
+
+    @expect_deprecation("repo_type")
+    def test_repo_type_deprecation_on_attribute(self):
+        repo = Repository(
+            WORKING_REPO_DIR,
+            git_user="RANDOM_USER",
+            git_email="EMAIL@EMAIL.EMAIL",
+            repo_type="toto",
+        )
+        self.assertEqual(repo.repo_type, "toto")
+
 
 class RepositoryDatasetTest(RepositoryCommonTest):
     @classmethod


### PR DESCRIPTION
Fix https://github.com/huggingface/huggingface_hub/issues/1055.

I also start to think that `clone_from` method should be a standalone private helper (e.g.: not meant to be used by end users, just via the `clone_from` attribute at init). This would avoid having HF-specific attributes like `repo_type` in `Repository`: once initialized the value is not needed anymore.