### PR TITLE
Always send the cached token when user is logged in

### DIFF
--- a/docs/source/quick-start.mdx
+++ b/docs/source/quick-start.mdx
@@ -113,6 +113,14 @@ If you want your repository to be private, then:
 
 Private repositories will not be visible to anyone except yourself.
 
+<Tip>
+
+To create a repository or to push content to the Hub, you must provide a User Access
+Token that has the `write` permission. You can choose the permission when creating the
+token in your [Settings page](https://huggingface.co/settings/tokens).
+
+</Tip>
+
 ## Share files to the Hub
 
 Use the [`upload_file`] function to add a file to your newly created repository. You

--- a/docs/source/quick-start.mdx
+++ b/docs/source/quick-start.mdx
@@ -54,21 +54,16 @@ full-length hash instead of the shorter 7-character commit hash:
 
 For more details and options, see the API reference for [`hf_hub_download`].
 
-## Create a repository
+## Login
 
-To create and share files to the Hub, you need to have a Hugging Face account. [Create
-an account](https://hf.co/join) if you don't already have one, and then sign in to find
-your [User Access Token](https://huggingface.co/docs/hub/security-tokens) in
-your Settings. The User Access Token is used to authenticate your identity to the Hub.
+In a lot of cases, you must be logged in with a Hugging Face account to interact with
+the Hub: download private repos, upload files, create PRs,...
+[Create an account](https://hf.co/join) if you don't already have one, and then sign in
+to get your [User Access Token](https://huggingface.co/docs/hub/security-tokens) from
+your [Settings page](https://huggingface.co/settings/tokens). The User Access Token is
+used to authenticate your identity to the Hub.
 
-<Tip>
-
-You can also provide your token to our functions and methods. This way you don't need to
-store your token anywhere.
-
-</Tip>
-
-1. Log in to your Hugging Face account with the following command:
+Once you have your User Access Token, run the following command in your terminal:
 
 ```bash
 huggingface-cli login
@@ -82,9 +77,25 @@ Or if you prefer to work from a Jupyter or Colaboratory notebook, then login wit
 >>> notebook_login()
 ```
 
-2. Enter your User Access Token to authenticate your identity to the Hub.
+<Tip>
 
-After you've created an account, create a repository with the [`create_repo`] function:
+You can also provide your token to our functions and methods. This way you don't need to
+store your token anywhere.
+
+</Tip>
+
+<Tip>
+
+Once you are logged in, all requests to the Hub will use your access token by default.
+If you want to disable implicit use of your token, you should set the
+`DISABLE_IMPLICIT_HF_TOKEN` environment variable.
+
+</Tip>
+
+## Create a repository
+
+Once you've registered and logged in, create a repository with the [`create_repo`]
+function:
 
 ```py
 >>> from huggingface_hub import HfApi

--- a/docs/source/quick-start.mdx
+++ b/docs/source/quick-start.mdx
@@ -88,7 +88,7 @@ store your token anywhere.
 
 Once you are logged in, all requests to the Hub will use your access token by default.
 If you want to disable implicit use of your token, you should set the
-`DISABLE_IMPLICIT_HF_TOKEN` environment variable.
+`HF_HUB_DISABLE_IMPLICIT_TOKEN` environment variable.
 
 </Tip>
 

--- a/docs/source/quick-start.mdx
+++ b/docs/source/quick-start.mdx
@@ -79,7 +79,7 @@ Or if you prefer to work from a Jupyter or Colaboratory notebook, then login wit
 
 <Tip>
 
-You can also provide your token to our functions and methods. This way you don't need to
+You can also provide your token to the functions and methods. This way you don't need to
 store your token anywhere.
 
 </Tip>

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,6 @@ extras["fastai"] = [
 extras["tensorflow"] = ["tensorflow", "pydot", "graphviz"]
 
 extras["testing"] = extras["cli"] + [
-    "datasets",
     "isort>=5.5.4",
     "jedi",
     "Jinja2",

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -96,7 +96,6 @@ _SUBMOD_ATTRS = {
         "CommitOperationDelete",
         "DatasetSearchArguments",
         "HfApi",
-        "HfFolder",
         "ModelSearchArguments",
         "change_discussion_status",
         "comment_discussion",
@@ -167,6 +166,7 @@ _SUBMOD_ATTRS = {
         "CorruptedCacheException",
         "DeleteCacheStrategy",
         "HFCacheInfo",
+        "HfFolder",
         "logging",
         "scan_cache_dir",
     ],
@@ -307,7 +307,6 @@ if TYPE_CHECKING:  # pragma: no cover
     from .hf_api import CommitOperationDelete  # noqa: F401
     from .hf_api import DatasetSearchArguments  # noqa: F401
     from .hf_api import HfApi  # noqa: F401
-    from .hf_api import HfFolder  # noqa: F401
     from .hf_api import ModelSearchArguments  # noqa: F401
     from .hf_api import change_discussion_status  # noqa: F401
     from .hf_api import comment_discussion  # noqa: F401
@@ -364,6 +363,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from .utils import CorruptedCacheException  # noqa: F401
     from .utils import DeleteCacheStrategy  # noqa: F401
     from .utils import HFCacheInfo  # noqa: F401
+    from .utils import HfFolder  # noqa: F401
     from .utils import logging  # noqa: F401
     from .utils import scan_cache_dir  # noqa: F401
     from .utils.endpoint_helpers import DatasetFilter  # noqa: F401

--- a/src/huggingface_hub/_commit_api.py
+++ b/src/huggingface_hub/_commit_api.py
@@ -14,7 +14,7 @@ import requests
 
 from .constants import ENDPOINT
 from .lfs import UploadInfo, _validate_batch_actions, lfs_upload, post_lfs_batch_info
-from .utils import hf_raise_for_status, logging, validate_hf_hub_args
+from .utils import build_hf_headers, hf_raise_for_status, logging, validate_hf_hub_args
 from .utils._typing import Literal
 
 
@@ -355,7 +355,12 @@ def fetch_upload_modes(
             If the Hub API returned an HTTP 400 error (bad request)
     """
     endpoint = endpoint if endpoint is not None else ENDPOINT
-    headers = {"authorization": f"Bearer {token}"} if token is not None else None
+    headers = build_hf_headers(
+        endpoint=endpoint,
+        token=token,
+        repo_id=repo_id,
+        repo_type=repo_type,
+    )
     payload = {
         "files": [
             {

--- a/src/huggingface_hub/_commit_api.py
+++ b/src/huggingface_hub/_commit_api.py
@@ -355,12 +355,7 @@ def fetch_upload_modes(
             If the Hub API returned an HTTP 400 error (bad request)
     """
     endpoint = endpoint if endpoint is not None else ENDPOINT
-    headers = build_hf_headers(
-        endpoint=endpoint,
-        token=token,
-        repo_id=repo_id,
-        repo_type=repo_type,
-    )
+    headers = build_hf_headers(use_auth_token=token)
     payload = {
         "files": [
             {

--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Optional, Union
 from .constants import DEFAULT_REVISION, HUGGINGFACE_HUB_CACHE, REPO_TYPES
 from .file_download import REGEX_COMMIT_HASH, hf_hub_download, repo_folder_name
 from .hf_api import HfApi
-from .utils import HfFolder, filter_repo_objects, logging, tqdm, validate_hf_hub_args
+from .utils import filter_repo_objects, logging, tqdm, validate_hf_hub_args
 from .utils._deprecation import _deprecate_arguments
 
 
@@ -108,18 +108,6 @@ def snapshot_download(
     if isinstance(cache_dir, Path):
         cache_dir = str(cache_dir)
 
-    if isinstance(use_auth_token, str):
-        token = use_auth_token
-    elif use_auth_token:
-        token = HfFolder.get_token()
-        if token is None:
-            raise EnvironmentError(
-                "You specified use_auth_token=True, but a Hugging Face token was not"
-                " found."
-            )
-    else:
-        token = None
-
     if repo_type is None:
         repo_type = "model"
     if repo_type not in REPO_TYPES:
@@ -167,7 +155,10 @@ def snapshot_download(
     # if we have internet connection we retrieve the correct folder name from the huggingface api
     _api = HfApi()
     repo_info = _api.repo_info(
-        repo_id=repo_id, repo_type=repo_type, revision=revision, use_auth_token=token
+        repo_id=repo_id,
+        repo_type=repo_type,
+        revision=revision,
+        use_auth_token=use_auth_token,
     )
     filtered_repo_files = list(
         filter_repo_objects(

--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -4,8 +4,8 @@ from typing import Dict, List, Optional, Union
 
 from .constants import DEFAULT_REVISION, HUGGINGFACE_HUB_CACHE, REPO_TYPES
 from .file_download import REGEX_COMMIT_HASH, hf_hub_download, repo_folder_name
-from .hf_api import HfApi, HfFolder
-from .utils import filter_repo_objects, logging, tqdm, validate_hf_hub_args
+from .hf_api import HfApi
+from .utils import HfFolder, filter_repo_objects, logging, tqdm, validate_hf_hub_args
 from .utils._deprecation import _deprecate_arguments
 
 

--- a/src/huggingface_hub/commands/user.py
+++ b/src/huggingface_hub/commands/user.py
@@ -27,7 +27,6 @@ from huggingface_hub.hf_api import HfApi
 from requests.exceptions import HTTPError
 
 from ..utils import HfFolder, run_subprocess
-from ..utils._headers import _is_valid_token
 from ._cli_utils import ANSI
 
 
@@ -316,7 +315,7 @@ def notebook_login():
 def _login(hf_api: HfApi, token: str) -> None:
     if token.startswith("api_org"):
         raise ValueError("You must use your personal account token.")
-    if not _is_valid_token(endpoint=hf_api.endpoint, token=token):
+    if not hf_api._is_valid_token(token=token):
         raise ValueError("Invalid token passed!")
     hf_api.set_access_token(token)
     HfFolder.save_token(token)

--- a/src/huggingface_hub/commands/user.py
+++ b/src/huggingface_hub/commands/user.py
@@ -24,10 +24,10 @@ from huggingface_hub.constants import (
     REPO_TYPES_URL_PREFIXES,
     SPACES_SDK_TYPES,
 )
-from huggingface_hub.hf_api import HfApi, HfFolder
+from huggingface_hub.hf_api import HfApi
 from requests.exceptions import HTTPError
 
-from ..utils import run_subprocess
+from ..utils import HfFolder, run_subprocess
 from ._cli_utils import ANSI
 
 

--- a/src/huggingface_hub/fastai_utils.py
+++ b/src/huggingface_hub/fastai_utils.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional, Union
 
 from packaging import version
 
-from huggingface_hub import hf_api, snapshot_download
+from huggingface_hub import snapshot_download
 from huggingface_hub.constants import CONFIG_NAME
 from huggingface_hub.file_download import (
     _PY_VERSION,
@@ -437,7 +437,6 @@ def push_to_hub_fastai(
     """
 
     _check_fastai_fastcore_versions()
-    token, _ = hf_api._validate_or_retrieve_token(token)
     api = HfApi(endpoint=api_endpoint)
     api.create_repo(
         repo_id=repo_id,

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -32,9 +32,9 @@ from .constants import (
     REPO_TYPES,
     REPO_TYPES_URL_PREFIXES,
 )
-from .hf_api import HfFolder
 from .utils import (
     EntryNotFoundError,
+    HfFolder,
     LocalEntryNotFoundError,
     hf_raise_for_status,
     http_backoff,

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1409,18 +1409,7 @@ def get_hf_file_metadata(
         A [`HfFileMetadata`] object containing metadata such as location, etag and
         commit_hash.
     """
-    # TODO: helper to get headers from `use_auth_token` (copy-pasted several times)
-    headers = {}
-    if isinstance(use_auth_token, str):
-        headers["authorization"] = f"Bearer {use_auth_token}"
-    elif use_auth_token:
-        token = HfFolder.get_token()
-        if token is None:
-            raise EnvironmentError(
-                "You specified use_auth_token=True, but a huggingface token was not"
-                " found."
-            )
-        headers["authorization"] = f"Bearer {token}"
+    headers = build_hf_headers(url=url, use_auth_token=use_auth_token)
 
     # Retrieve metadata
     r = _request_wrapper(

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -34,8 +34,8 @@ from .constants import (
 )
 from .utils import (
     EntryNotFoundError,
-    HfFolder,
     LocalEntryNotFoundError,
+    build_hf_headers,
     hf_raise_for_status,
     http_backoff,
     logging,
@@ -649,23 +649,12 @@ def cached_download(
 
     os.makedirs(cache_dir, exist_ok=True)
 
-    headers = {
-        "user-agent": http_user_agent(
-            library_name=library_name,
-            library_version=library_version,
-            user_agent=user_agent,
-        )
-    }
-    if isinstance(use_auth_token, str):
-        headers["authorization"] = f"Bearer {use_auth_token}"
-    elif use_auth_token:
-        token = HfFolder.get_token()
-        if token is None:
-            raise EnvironmentError(
-                "You specified use_auth_token=True, but a huggingface token was not"
-                " found."
-            )
-        headers["authorization"] = f"Bearer {token}"
+    headers = build_hf_headers(url=url, use_auth_token=use_auth_token)
+    headers["user-agent"] = http_user_agent(
+        library_name=library_name,
+        library_version=library_version,
+        user_agent=user_agent,
+    )
 
     url_to_download = url
     etag = None
@@ -1089,23 +1078,12 @@ def hf_hub_download(
 
     url = hf_hub_url(repo_id, filename, repo_type=repo_type, revision=revision)
 
-    headers = {
-        "user-agent": http_user_agent(
-            library_name=library_name,
-            library_version=library_version,
-            user_agent=user_agent,
-        )
-    }
-    if isinstance(use_auth_token, str):
-        headers["authorization"] = f"Bearer {use_auth_token}"
-    elif use_auth_token:
-        token = HfFolder.get_token()
-        if token is None:
-            raise EnvironmentError(
-                "You specified use_auth_token=True, but a huggingface token was not"
-                " found."
-            )
-        headers["authorization"] = f"Bearer {token}"
+    headers = build_hf_headers(url=url, use_auth_token=use_auth_token)
+    headers["user-agent"] = http_user_agent(
+        library_name=library_name,
+        library_version=library_version,
+        user_agent=user_agent,
+    )
 
     url_to_download = url
     etag = None

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -670,7 +670,7 @@ def cached_download(
 
     os.makedirs(cache_dir, exist_ok=True)
 
-    headers = build_hf_headers(url=url, use_auth_token=use_auth_token)
+    headers = build_hf_headers(use_auth_token=use_auth_token)
     headers["user-agent"] = http_user_agent(
         library_name=library_name,
         library_version=library_version,
@@ -1102,7 +1102,7 @@ def hf_hub_download(
 
     url = hf_hub_url(repo_id, filename, repo_type=repo_type, revision=revision)
 
-    headers = build_hf_headers(url=url, use_auth_token=use_auth_token)
+    headers = build_hf_headers(use_auth_token=use_auth_token)
     headers["user-agent"] = http_user_agent(
         library_name=library_name,
         library_version=library_version,
@@ -1409,7 +1409,7 @@ def get_hf_file_metadata(
         A [`HfFileMetadata`] object containing metadata such as location, etag and
         commit_hash.
     """
-    headers = build_hf_headers(url=url, use_auth_token=use_auth_token)
+    headers = build_hf_headers(use_auth_token=use_auth_token)
 
     # Retrieve metadata
     r = _request_wrapper(

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -49,6 +49,7 @@ from .constants import (
     REPO_TYPES_URL_PREFIXES,
     SPACES_SDK_TYPES,
 )
+from .utils import HfFolder  # noqa: F401 # imported for backward compatibility
 from .utils import (
     build_hf_headers,
     filter_repo_objects,

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -57,7 +57,7 @@ from .utils import (
     parse_datetime,
     validate_hf_hub_args,
 )
-from .utils._deprecation import _deprecate_positional_args
+from .utils._deprecation import _deprecate_arguments, _deprecate_positional_args
 from .utils._typing import Literal, TypedDict
 from .utils.endpoint_helpers import (
     AttributeDictionary,
@@ -1157,6 +1157,7 @@ class HfApi:
         return [SpaceInfo(**x) for x in d]
 
     @validate_hf_hub_args
+    @_deprecate_arguments(version="0.12", deprecated_args={"token"})
     def model_info(
         self,
         repo_id: str,
@@ -1241,6 +1242,7 @@ class HfApi:
         return ModelInfo(**d)
 
     @validate_hf_hub_args
+    @_deprecate_arguments(version="0.12", deprecated_args={"token"})
     def dataset_info(
         self,
         repo_id: str,
@@ -1315,6 +1317,7 @@ class HfApi:
         return DatasetInfo(**d)
 
     @validate_hf_hub_args
+    @_deprecate_arguments(version="0.12", deprecated_args={"token"})
     def space_info(
         self,
         repo_id: str,

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -2511,7 +2511,7 @@ class HfApi:
             if "/" in model_id:
                 username = model_id.split("/")[0]
             else:
-                username = self.whoami(token=token)["name"]
+                username = self.whoami(token=token or use_auth_token)["name"]
             return f"{username}/{model_id}"
         else:
             return f"{organization}/{model_id}"

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -985,7 +985,6 @@ class HfApi:
         ```
         """
         path = f"{self.endpoint}/api/datasets"
-        headers = {}
         headers = build_hf_headers(
             use_auth_token=use_auth_token, endpoint=self.endpoint
         )

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -16,7 +16,6 @@ import os
 import re
 import subprocess
 import warnings
-from os.path import expanduser
 from typing import BinaryIO, Dict, Iterable, Iterator, List, Optional, Tuple, Union
 from urllib.parse import quote
 
@@ -51,6 +50,7 @@ from .constants import (
     SPACES_SDK_TYPES,
 )
 from .utils import (
+    HfFolder,
     filter_repo_objects,
     hf_raise_for_status,
     logging,
@@ -3314,54 +3314,6 @@ class HfApi:
             resource=f"comment/{comment_id.lower()}/hide",
         )
         return deserialize_event(resp.json()["updatedComment"])
-
-
-class HfFolder:
-    path_token = expanduser("~/.huggingface/token")
-
-    @classmethod
-    def save_token(cls, token):
-        """
-        Save token, creating folder as needed.
-
-        Args:
-            token (`str`):
-                The token to save to the [`HfFolder`]
-        """
-        os.makedirs(os.path.dirname(cls.path_token), exist_ok=True)
-        with open(cls.path_token, "w+") as f:
-            f.write(token)
-
-    @classmethod
-    def get_token(cls) -> Optional[str]:
-        """
-        Get token or None if not existent.
-
-        Note that a token can be also provided using the
-        `HUGGING_FACE_HUB_TOKEN` environment variable.
-
-        Returns:
-            `str` or `None`: The token, `None` if it doesn't exist.
-
-        """
-        token: Optional[str] = os.environ.get("HUGGING_FACE_HUB_TOKEN")
-        if token is None:
-            try:
-                with open(cls.path_token, "r") as f:
-                    token = f.read()
-            except FileNotFoundError:
-                pass
-        return token
-
-    @classmethod
-    def delete_token(cls):
-        """
-        Deletes the token from storage. Does not fail if token does not exist.
-        """
-        try:
-            os.remove(cls.path_token)
-        except FileNotFoundError:
-            pass
 
 
 def _prepare_upload_folder_commit(

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -616,11 +616,9 @@ class HfApi:
         r = requests.get(
             f"{self.endpoint}/api/whoami-v2",
             headers=build_hf_headers(
-                token=token,
-                endpoint=self.endpoint,
                 # If `token` is provided and not `None`, it will be used by default.
                 # Otherwise, the token must be retrieved from cache or env variable.
-                use_auth_token=True,
+                use_auth_token=(token or True),
             ),
         )
         try:
@@ -633,7 +631,7 @@ class HfApi:
             ) from e
         return r.json()
 
-    def _is_valid_token(self, token: str):
+    def _is_valid_token(self, token: str) -> bool:
         """
         Determines whether `token` is a valid token or not.
 
@@ -794,9 +792,7 @@ class HfApi:
         ```
         """
         path = f"{self.endpoint}/api/models"
-        headers = build_hf_headers(
-            use_auth_token=use_auth_token, endpoint=self.endpoint
-        )
+        headers = build_hf_headers(use_auth_token=use_auth_token)
         params = {}
         if filter is not None:
             if isinstance(filter, ModelFilter):
@@ -991,9 +987,7 @@ class HfApi:
         ```
         """
         path = f"{self.endpoint}/api/datasets"
-        headers = build_hf_headers(
-            use_auth_token=use_auth_token, endpoint=self.endpoint
-        )
+        headers = build_hf_headers(use_auth_token=use_auth_token)
         params = {}
         if filter is not None:
             if isinstance(filter, DatasetFilter):
@@ -1130,9 +1124,7 @@ class HfApi:
             `List[SpaceInfo]`: a list of [`huggingface_hub.hf_api.SpaceInfo`] objects
         """
         path = f"{self.endpoint}/api/spaces"
-        headers = build_hf_headers(
-            use_auth_token=use_auth_token, endpoint=self.endpoint
-        )
+        headers = build_hf_headers(use_auth_token=use_auth_token)
         params = {}
         if filter is not None:
             params.update({"filter": filter})
@@ -1217,13 +1209,7 @@ class HfApi:
 
         </Tip>
         """
-        headers = build_hf_headers(
-            token=token,
-            use_auth_token=use_auth_token,
-            endpoint=self.endpoint,
-            repo_id=repo_id,
-            repo_type="model",
-        )
+        headers = build_hf_headers(use_auth_token=token or use_auth_token)
         path = (
             f"{self.endpoint}/api/models/{repo_id}"
             if revision is None
@@ -1298,13 +1284,7 @@ class HfApi:
 
         </Tip>
         """
-        headers = build_hf_headers(
-            token=token,
-            use_auth_token=use_auth_token,
-            endpoint=self.endpoint,
-            repo_id=repo_id,
-            repo_type="dataset",
-        )
+        headers = build_hf_headers(use_auth_token=token or use_auth_token)
         path = (
             f"{self.endpoint}/api/datasets/{repo_id}"
             if revision is None
@@ -1373,13 +1353,7 @@ class HfApi:
 
         </Tip>
         """
-        headers = build_hf_headers(
-            token=token,
-            use_auth_token=use_auth_token,
-            endpoint=self.endpoint,
-            repo_id=repo_id,
-            repo_type="space",
-        )
+        headers = build_hf_headers(use_auth_token=token or use_auth_token)
         path = (
             f"{self.endpoint}/api/spaces/{repo_id}"
             if revision is None
@@ -1617,9 +1591,7 @@ class HfApi:
 
         if getattr(self, "_lfsmultipartthresh", None):
             json["lfsmultipartthresh"] = self._lfsmultipartthresh
-        headers = build_hf_headers(
-            token=token, endpoint=self.endpoint, is_write_action=True
-        )
+        headers = build_hf_headers(use_auth_token=token, is_write_action=True)
         r = requests.post(path, headers=headers, json=json)
 
         try:
@@ -1720,13 +1692,7 @@ class HfApi:
         if repo_type is not None:
             json["type"] = repo_type
 
-        headers = build_hf_headers(
-            token=token,
-            endpoint=self.endpoint,
-            is_write_action=True,
-            repo_id=repo_id,
-            repo_type=repo_type,
-        )
+        headers = build_hf_headers(use_auth_token=token, is_write_action=True)
         r = requests.delete(path, headers=headers, json=json)
         hf_raise_for_status(r)
 
@@ -1789,18 +1755,11 @@ class HfApi:
         if repo_type is None:
             repo_type = REPO_TYPE_MODEL  # default repo type
 
-        path = f"{self.endpoint}/api/{repo_type}s/{namespace}/{name}/settings"
-
-        json = {"private": private}
-
-        headers = build_hf_headers(
-            token=token,
-            endpoint=self.endpoint,
-            is_write_action=True,
-            repo_id=repo_id,
-            repo_type=repo_type,
+        r = requests.put(
+            url=f"{self.endpoint}/api/{repo_type}s/{namespace}/{name}/settings",
+            headers=build_hf_headers(use_auth_token=token, is_write_action=True),
+            json={"private": private},
         )
-        r = requests.put(path, headers=headers, json=json)
         hf_raise_for_status(r)
         return r.json()
 
@@ -1858,13 +1817,7 @@ class HfApi:
         json = {"fromRepo": from_id, "toRepo": to_id, "type": repo_type}
 
         path = f"{self.endpoint}/api/repos/move"
-        headers = build_hf_headers(
-            token=token,
-            endpoint=self.endpoint,
-            is_write_action=True,
-            repo_id=from_id,
-            repo_type=repo_type,
-        )
+        headers = build_hf_headers(use_auth_token=token, is_write_action=True)
         r = requests.post(path, headers=headers, json=json)
         try:
             hf_raise_for_status(r)
@@ -2053,13 +2006,7 @@ class HfApi:
         )
         commit_url = f"{self.endpoint}/api/{repo_type}s/{repo_id}/commit/{revision}"
 
-        headers = build_hf_headers(
-            token=token,
-            endpoint=self.endpoint,
-            is_write_action=True,
-            repo_id=repo_id,
-            repo_type=repo_type,
-        )
+        headers = build_hf_headers(use_auth_token=token, is_write_action=True)
         commit_resp = requests.post(
             url=commit_url,
             headers=headers,
@@ -2570,9 +2517,7 @@ class HfApi:
         if repo_type is None:
             repo_type = REPO_TYPE_MODEL
 
-        headers = build_hf_headers(
-            token=token, endpoint=self.endpoint, repo_id=repo_id, repo_type=repo_type
-        )
+        headers = build_hf_headers(use_auth_token=token)
 
         def _fetch_discussion_page(page_index: int):
             path = (
@@ -2654,9 +2599,7 @@ class HfApi:
         path = (
             f"{self.endpoint}/api/{repo_type}s/{repo_id}/discussions/{discussion_num}"
         )
-        headers = build_hf_headers(
-            token=token, endpoint=self.endpoint, repo_id=repo_id, repo_type=repo_type
-        )
+        headers = build_hf_headers(use_auth_token=token)
         resp = requests.get(path, params={"diff": "1"}, headers=headers)
         hf_raise_for_status(resp)
 
@@ -2761,13 +2704,7 @@ class HfApi:
             )
         )
 
-        headers = build_hf_headers(
-            token=token,
-            endpoint=self.endpoint,
-            is_write_action=True,
-            repo_id=repo_id,
-            repo_type=repo_type,
-        )
+        headers = build_hf_headers(use_auth_token=token, is_write_action=True)
         resp = requests.post(
             f"{self.endpoint}/api/{repo_type}s/{repo_id}/discussions",
             json={
@@ -2865,13 +2802,7 @@ class HfApi:
 
         path = f"{self.endpoint}/api/{repo_id}/discussions/{discussion_num}/{resource}"
 
-        headers = build_hf_headers(
-            token=token,
-            is_write_action=True,
-            endpoint=self.endpoint,
-            repo_id=repo_id,
-            repo_type=repo_type,
-        )
+        headers = build_hf_headers(use_auth_token=token, is_write_action=True)
         resp = requests.post(path, headers=headers, json=body)
         hf_raise_for_status(resp)
         return resp

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -615,7 +615,13 @@ class HfApi:
         """
         r = requests.get(
             f"{self.endpoint}/api/whoami-v2",
-            headers=build_hf_headers(token=token, endpoint=self.endpoint),
+            headers=build_hf_headers(
+                token=token,
+                endpoint=self.endpoint,
+                # If `token` is provided and not `None`, it will be used by default.
+                # Otherwise, the token must be retrieved from cache or env variable.
+                use_auth_token=True,
+            ),
         )
         try:
             hf_raise_for_status(r)

--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from typing import Dict, List, Optional, Union
 
 import requests
-from huggingface_hub import hf_api
 
 from .constants import CONFIG_NAME, PYTORCH_WEIGHTS_NAME
 from .file_download import hf_hub_download, is_torch_available
@@ -326,9 +325,7 @@ class ModelHubMixin:
         # If the repo id is set, it means we use the new version using HTTP endpoint
         # (introduced in v0.9).
         if repo_id is not None:
-            token, _ = hf_api._validate_or_retrieve_token(token)
             api = HfApi(endpoint=api_endpoint)
-
             api.create_repo(
                 repo_id=repo_id,
                 repo_type="model",

--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -9,9 +9,9 @@ from huggingface_hub import hf_api
 
 from .constants import CONFIG_NAME, PYTORCH_WEIGHTS_NAME
 from .file_download import hf_hub_download, is_torch_available
-from .hf_api import HfApi, HfFolder
+from .hf_api import HfApi
 from .repository import Repository
-from .utils import logging, validate_hf_hub_args
+from .utils import HfFolder, logging, validate_hf_hub_args
 from .utils._deprecation import _deprecate_arguments, _deprecate_positional_args
 
 

--- a/src/huggingface_hub/keras_mixin.py
+++ b/src/huggingface_hub/keras_mixin.py
@@ -23,14 +23,9 @@ from huggingface_hub.file_download import (
 )
 
 from .constants import CONFIG_NAME, DEFAULT_REVISION
-from .hf_api import (
-    HfApi,
-    HfFolder,
-    _parse_revision_from_pr_url,
-    _prepare_upload_folder_commit,
-)
+from .hf_api import HfApi, _parse_revision_from_pr_url, _prepare_upload_folder_commit
 from .repository import Repository
-from .utils import logging, validate_hf_hub_args
+from .utils import HfFolder, logging, validate_hf_hub_args
 from .utils._deprecation import _deprecate_arguments, _deprecate_positional_args
 
 

--- a/src/huggingface_hub/keras_mixin.py
+++ b/src/huggingface_hub/keras_mixin.py
@@ -9,12 +9,7 @@ from typing import Any, Dict, List, Optional, Union
 from urllib.parse import quote
 
 import yaml
-from huggingface_hub import (
-    CommitOperationDelete,
-    ModelHubMixin,
-    hf_api,
-    snapshot_download,
-)
+from huggingface_hub import CommitOperationDelete, ModelHubMixin, snapshot_download
 from huggingface_hub.file_download import (
     get_tf_version,
     is_graphviz_available,
@@ -404,9 +399,7 @@ def push_to_hub_keras(
         The url of the commit of your model in the given repository.
     """
     if repo_id is not None:
-        token, _ = hf_api._validate_or_retrieve_token(token)
         api = HfApi(endpoint=api_endpoint)
-
         api.create_repo(
             repo_id=repo_id,
             repo_type="model",

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -15,9 +15,9 @@ from huggingface_hub.constants import REPO_TYPES_URL_PREFIXES, REPOCARD_NAME
 from huggingface_hub.repocard import metadata_load, metadata_save
 from requests.exceptions import HTTPError
 
-from .hf_api import HfApi, HfFolder, repo_type_and_id_from_hf_id
+from .hf_api import HfApi, repo_type_and_id_from_hf_id
 from .lfs import LFS_MULTIPART_UPLOAD_COMMAND
-from .utils import logging, run_subprocess, tqdm
+from .utils import HfFolder, logging, run_subprocess, tqdm
 from .utils._deprecation import _deprecate_arguments, _deprecate_method
 
 

--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -35,6 +35,8 @@ from ._errors import (
     RevisionNotFoundError,
     hf_raise_for_status,
 )
+from ._headers import build_hf_headers
+from ._hf_folder import HfFolder
 from ._http import http_backoff
 from ._paths import filter_repo_objects
 from ._subprocess import run_subprocess

--- a/src/huggingface_hub/utils/_deprecation.py
+++ b/src/huggingface_hub/utils/_deprecation.py
@@ -76,8 +76,13 @@ def _deprecate_arguments(
             for _, parameter in zip(args, sig.parameters.values()):
                 if parameter.name in deprecated_args:
                     used_deprecated_args.append(parameter.name)
-            for kwarg_name in kwargs:
-                if kwarg_name in deprecated_args:
+            for kwarg_name, kwarg_value in kwargs.items():
+                if (
+                    # If argument is deprecated but still used
+                    kwarg_name in deprecated_args
+                    # And then the value is not the default value
+                    and kwarg_value != sig.parameters[kwarg_name].default
+                ):
                     used_deprecated_args.append(kwarg_name)
 
             # Warn and proceed

--- a/src/huggingface_hub/utils/_headers.py
+++ b/src/huggingface_hub/utils/_headers.py
@@ -195,7 +195,7 @@ def _get_token_to_send(
     return token_to_send
 
 
-@lru_cache
+@lru_cache()
 def _is_private(
     url: Optional[str],
     endpoint: Optional[str],
@@ -232,7 +232,7 @@ def _is_private(
         return True
 
 
-@lru_cache
+@lru_cache()
 def _is_valid_token(endpoint: str, token: str) -> None:
     """Check if the given token is valid.
 

--- a/src/huggingface_hub/utils/_headers.py
+++ b/src/huggingface_hub/utils/_headers.py
@@ -81,13 +81,16 @@ def _get_token_to_send(use_auth_token: Optional[Union[bool, str]]) -> Optional[s
     # Token is not provided: we get it from local cache
     cached_token = HfFolder().get_token()
 
-    # Case token is explicitly required but not found
-    if use_auth_token is True and cached_token is None:
-        raise EnvironmentError(
-            "Token is required (`use_auth_token=True`), but no token found. You need to"
-            " provide a token or be logged in to Hugging Face with `huggingface-cli"
-            " login` or `notebook_login`. See https://huggingface.co/settings/tokens."
-        )
+    # Case token is explicitly required
+    if use_auth_token is True:
+        if cached_token is None:
+            raise EnvironmentError(
+                "Token is required (`use_auth_token=True`), but no token found. You"
+                " need to provide a token or be logged in to Hugging Face with"
+                " `huggingface-cli login` or `notebook_login`. See"
+                " https://huggingface.co/settings/tokens."
+            )
+        return cached_token
 
     # Case implicit use of the token is forbidden by env variable
     if os.environ.get("DISABLE_IMPLICIT_HF_TOKEN"):

--- a/src/huggingface_hub/utils/_headers.py
+++ b/src/huggingface_hub/utils/_headers.py
@@ -50,23 +50,23 @@ def build_hf_headers(
 
     Example:
     ```py
-        > build_hf_headers(use_auth_token="hf_***") # explicit token
+        >>> build_hf_headers(use_auth_token="hf_***") # explicit token
         {"authorization": "Bearer hf_***"}
 
-        > build_hf_headers(use_auth_token=True) # explicitly use cached token
+        >>> build_hf_headers(use_auth_token=True) # explicitly use cached token
         {"authorization": "Bearer hf_***"}
 
-        > build_hf_headers(use_auth_token=False) # explicitly don't use cached token
+        >>> build_hf_headers(use_auth_token=False) # explicitly don't use cached token
         {}
 
-        > build_hf_headers() # implicit use of the cached token
+        >>> build_hf_headers() # implicit use of the cached token
         {"authorization": "Bearer hf_***"}
 
         # HF_HUB_DISABLE_IMPLICIT_TOKEN=True # to set as env variable
-        > build_hf_headers() # token is not sent
+        >>> build_hf_headers() # token is not sent
         {}
 
-        > build_hf_headers(use_auth_token="api_org_***", is_write_action=True)
+        >>> build_hf_headers(use_auth_token="api_org_***", is_write_action=True)
         ValueError: You must use your personal account token for write-access methods.
     ```
 

--- a/src/huggingface_hub/utils/_headers.py
+++ b/src/huggingface_hub/utils/_headers.py
@@ -13,74 +13,37 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Contains utilities to handle headers to send in calls to Huggingface Hub."""
-from functools import lru_cache
+import os
 from typing import Dict, Optional, Union
 
-import requests
-
-from ._errors import RepositoryNotFoundError, hf_raise_for_status
 from ._hf_folder import HfFolder
 
 
 def build_hf_headers(
-    *,
-    token: Optional[str] = None,
-    use_auth_token: Optional[Union[bool, str]] = None,
-    is_write_action: bool = False,
-    url: Optional[str] = None,
-    endpoint: Optional[str] = None,
-    repo_id: Optional[str] = None,
-    repo_type: Optional[str] = None,
+    *, use_auth_token: Optional[Union[bool, str]] = None, is_write_action: bool = False
 ) -> Dict[str, str]:
     """
     Build headers dictionary to send in a HF Hub call.
 
-    Authorization token is either given in argument (explicit use) or retrieved from the
-    machine (e.g. after a `huggingface-cli login` or using `HUGGING_FACE_HUB_TOKEN` env
-    variable). In case of an implicit use of the token, we check if the repo on which
-    the call will be made is private/gated. If it is a public repo and only read-access
-    is required, the token is not passed to preserve privacy. If the API call is not
-    made against a repo, it is considered a public call.
+    By default, authorization token is always provided either from argument (explicit
+    use) or retrieved from the cache (implicit use). To explicitly avoid sending the
+    token to the Hub, set `use_auth_token=False` or set the `DISABLE_IMPLICIT_HF_TOKEN`
+    environment variable.
 
-    Returned token is also validated. An error is thrown if the server doesn't recognize
-    the token or if a write-access token is required but the token is an organization
-    one (starting with "api_org***").
-
-    The request that will be made must either be a call to the API or an url pointing to
-    the Hub. In case of an API call, use `endpoint` argument (and optionally `repo_id`/
-    `repo_type`). In case of a direct URL call, use `url` argument and ignore
-    `endpoint`. In this later case, the validity of the token is not tested.
+    In case of an API call that requires write access, an error is thrown if token is
+    `None` or token is an organization token (starting with `"api_org***"`).
 
     Args:
-        token (`str`, `optional`):
-            Hugging Face token. Will default to the locally saved token if not provided.
         use_auth_token (`str`, `bool`, *optional*):
-            A token to be used for the download. If `True`, the token is read from the
-            machine (cache or env variable). If a string, it's used as the Hugging Face
-            token. If None, the token is read from the machine only if necessary
-            (write-access call or private repo).
+            The token to be sent in authorization header for the Hub call:
+                - if a string, it is used as the Hugging Face token
+                - if `True`, the token is read from the machine (cache or env variable)
+                - if `False`, authorization header is not set
+                - if `None`, the token is read from the machine only except if
+                  `DISABLE_IMPLICIT_HF_TOKEN` env variable is set.
         is_write_action (`bool`, default to `False`):
-            Set to True if the API call requires a write access. If `True` and token is
-            not provided, it will be read from machine. If no token is found, raises an
-            exception.
-        url (`str`, *optional*):
-            Full url that will be called. For example used when downloading a file for
-            which you have the full url. If you are making an API call, use `endpoint`
-            instead.
-        endpoint (`str`, *optional*):
-            API endpoint to which the call will be made. Used to check token validity.
-            If making a call to the Hub for which you only have a full url, pass it
-            `url` to ignore `endpoint`, `repo_id` and `repo_type`.
-        repo_id (`str`, `optional`):
-            Id of the repo if the api call is made on a repo (create a commit,
-            list files,...). To be used only combined with both `endpoint` and
-            `use_auth_token` arguments. Use `None` if the api call is not bound to a
-            repo (list models, create a repo,...).
-        repo_type (`str`, `optional`):
-            Repo type if the api call is made on a repo (create a commit,
-            list files,...). To be used only combined with both `endpoint` and
-            `use_auth_token` arguments. Use `None` if the api call is not bound to a
-            repo (list models, create a repo,...).
+            Set to True if the API call requires a write access. If `True`, the token
+            will be validated (cannot be `None`, cannot start by `"api_org***"`).
 
     Returns:
         A `Dict` of headers to pass in your API call.
@@ -89,24 +52,13 @@ def build_hf_headers(
         [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
             If organization token is passed and "write" access is required.
         [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
-            If token is invalid (not recognized by the server).
-        [`EnvironmentError`](https://docs.python.org/3/library/exceptions.html#EnvironmentError)
             If "write" access is required but token is not passed and not saved locally.
+        [`EnvironmentError`](https://docs.python.org/3/library/exceptions.html#EnvironmentError)
+            If `use_auth_token=True` but token is not saved locally.
     """
     # Get auth token to send
-    token_to_send = _get_token_to_send(
-        token=token,
-        use_auth_token=use_auth_token,
-        is_write_action=is_write_action,
-        endpoint=endpoint,
-        repo_id=repo_id,
-        repo_type=repo_type,
-        url=url,
-    )
-    if token_to_send is not None:
-        _validate_token_to_send(
-            token_to_send, endpoint=endpoint, is_write_action=is_write_action
-        )
+    token_to_send = _get_token_to_send(use_auth_token)
+    _validate_token_to_send(token_to_send, is_write_action=is_write_action)
 
     # Combine headers
     headers = {}
@@ -116,131 +68,47 @@ def build_hf_headers(
     return headers
 
 
-def _get_token_to_send(
-    token: Optional[str],
-    use_auth_token: Optional[Union[bool, str]],
-    is_write_action: bool,
-    repo_id: Optional[str],
-    repo_type: Optional[str],
-    endpoint: Optional[str],
-    url: Optional[str],
-) -> Optional[str]:
-    """Determine if the token must be provided or validates it.
-
-    Strategy is made is such a way to preserve as much as possible user's privacy. See
-    `build_hf_headers` docstring for more details.
-    """
-    # Case token is explicitly provided via `token`
-    if token is not None:
-        return token
-
-    # Case token is explicitly provided via `use_auth_token`
-    elif isinstance(use_auth_token, str):
+def _get_token_to_send(use_auth_token: Optional[Union[bool, str]]) -> Optional[str]:
+    """Select the token to send from either `use_auth_token` or the cache."""
+    # Case token is explicitly provided
+    if isinstance(use_auth_token, str):
         return use_auth_token
 
     # Case token is explicitly forbidden
-    elif use_auth_token is False:
+    if use_auth_token is False:
         return None
 
-    # Case token is explicitly required
-    elif use_auth_token is True:
-        cached_token = HfFolder().get_token()
-        if cached_token is None:
-            raise EnvironmentError(
-                "Token is required (`use_auth_token=True`), but no token found. You"
-                " need to provide a token or be logged in to Hugging Face with"
+    # Token is not provided: we get it from local cache
+    cached_token = HfFolder().get_token()
+
+    # Case token is explicitly required but not found
+    if use_auth_token is True and cached_token is None:
+        raise EnvironmentError(
+            "Token is required (`use_auth_token=True`), but no token found. You need to"
+            " provide a token or be logged in to Hugging Face with `huggingface-cli"
+            " login` or `notebook_login`. See https://huggingface.co/settings/tokens."
+        )
+
+    # Case implicit use of the token is forbidden by env variable
+    if os.environ.get("DISABLE_IMPLICIT_HF_TOKEN"):
+        return None
+
+    # Otherwise: we use the cached token as the user has not explicitly forbidden it
+    return cached_token
+
+
+def _validate_token_to_send(token: Optional[str], is_write_action: bool) -> None:
+    if is_write_action:
+        if token is None:
+            raise ValueError(
+                "Token is required (write-access action) but no token found. You need"
+                " to provide a token or be logged in to Hugging Face with"
                 " `huggingface-cli login` or `notebook_login`. See"
                 " https://huggingface.co/settings/tokens."
             )
-        return cached_token
-
-    # Otherwise: user did not give a preference whether to send a token or not.
-    # In order to preserve user privacy, token is sent only for private/gated repos or
-    # for if the `write` permission is required:
-    elif is_write_action or _is_private(
-        url=url, endpoint=endpoint, repo_id=repo_id, repo_type=repo_type
-    ):
-        cached_token = HfFolder().get_token()
-        if cached_token is None and is_write_action:
-            raise EnvironmentError(
-                "Token is required (write-access action) but no token found. You"
-                " need to provide a token or be logged in to Hugging Face with"
-                " `huggingface-cli login` or `notebook_login`. See"
-                " https://huggingface.co/settings/tokens."
+        if token.startswith("api_org"):
+            raise ValueError(
+                "You must use your personal account token for write-access methods. To"
+                " generate a write-access token, go to"
+                " https://huggingface.co/settings/tokens"
             )
-        return cached_token
-    else:  # "read" permission + repo is not private/gated
-        return None
-
-
-def _validate_token_to_send(
-    token: str, endpoint: Optional[str], is_write_action: bool
-) -> None:
-    if is_write_action and token.startswith("api_org"):
-        raise ValueError(
-            "You must use your personal account token for write-access methods. To"
-            " generate a write-access token, go to"
-            " https://huggingface.co/settings/tokens"
-        )
-    if endpoint is not None and not _is_valid_token(endpoint, token):
-        raise ValueError(
-            "Invalid token passed! Go to https://huggingface.co/settings/tokens to"
-            " get one."
-        )
-
-
-@lru_cache()
-def _is_private(
-    url: Optional[str],
-    endpoint: Optional[str],
-    repo_id: Optional[str],
-    repo_type: Optional[str],
-) -> bool:
-    """Check if the repo on which the API call will be made is private or not.
-
-    Result is cached to avoid multiple `repo_info` API calls.
-    """
-    # HEAD call to url without headers to check if private or not
-    if url is not None:
-        try:
-            hf_raise_for_status(requests.head(url))
-            return False
-        except RepositoryNotFoundError:
-            return True
-        except Exception:  # Anything else: don't assume private repo
-            return False
-
-    # Should not happen
-    if endpoint is None:
-        raise ValueError("Either `url` or `endpoint` must be not `None`!")
-
-    # Means it is a generic action -> public
-    if repo_id is None:
-        return False
-
-    # If action on a repo, is it a private one ?
-    if repo_type is None:
-        repo_type = "model"
-    try:
-        hf_raise_for_status(requests.head(f"{endpoint}/api/{repo_type}s/{repo_id}"))
-        return False
-    except RepositoryNotFoundError:
-        return True
-    except Exception:  # Anything else: don't assume private repo
-        return False
-
-
-@lru_cache()
-def _is_valid_token(endpoint: str, token: str) -> None:
-    """Check if the given token is valid.
-
-    Result is cached to avoid multiple `whoami` API calls.
-    """
-    r = requests.get(
-        f"{endpoint}/api/whoami-v2", headers={"authorization": f"Bearer {token}"}
-    )
-    try:
-        hf_raise_for_status(r)
-        return True
-    except Exception:
-        return False

--- a/src/huggingface_hub/utils/_headers.py
+++ b/src/huggingface_hub/utils/_headers.py
@@ -27,7 +27,7 @@ def build_hf_headers(
 
     By default, authorization token is always provided either from argument (explicit
     use) or retrieved from the cache (implicit use). To explicitly avoid sending the
-    token to the Hub, set `use_auth_token=False` or set the `DISABLE_IMPLICIT_HF_TOKEN`
+    token to the Hub, set `use_auth_token=False` or set the `HF_HUB_DISABLE_IMPLICIT_TOKEN`
     environment variable.
 
     In case of an API call that requires write access, an error is thrown if token is
@@ -40,7 +40,7 @@ def build_hf_headers(
                 - if `True`, the token is read from the machine (cache or env variable)
                 - if `False`, authorization header is not set
                 - if `None`, the token is read from the machine only except if
-                  `DISABLE_IMPLICIT_HF_TOKEN` env variable is set.
+                  `HF_HUB_DISABLE_IMPLICIT_TOKEN` env variable is set.
         is_write_action (`bool`, default to `False`):
             Set to True if the API call requires a write access. If `True`, the token
             will be validated (cannot be `None`, cannot start by `"api_org***"`).
@@ -62,7 +62,7 @@ def build_hf_headers(
         > build_hf_headers() # implicit use of the cached token
         {"authorization": "Bearer hf_***"}
 
-        # DISABLE_IMPLICIT_HF_TOKEN=True # to set as env variable
+        # HF_HUB_DISABLE_IMPLICIT_TOKEN=True # to set as env variable
         > build_hf_headers() # token is not sent
         {}
 
@@ -115,7 +115,7 @@ def _get_token_to_send(use_auth_token: Optional[Union[bool, str]]) -> Optional[s
         return cached_token
 
     # Case implicit use of the token is forbidden by env variable
-    if os.environ.get("DISABLE_IMPLICIT_HF_TOKEN"):
+    if os.environ.get("HF_HUB_DISABLE_IMPLICIT_TOKEN"):
         return None
 
     # Otherwise: we use the cached token as the user has not explicitly forbidden it

--- a/src/huggingface_hub/utils/_headers.py
+++ b/src/huggingface_hub/utils/_headers.py
@@ -1,0 +1,198 @@
+# coding=utf-8
+# Copyright 2022-present, the HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Contains utilities to handle headers to send in calls to Huggingface Hub."""
+from functools import lru_cache
+from typing import Dict, Literal, Optional, Union
+
+import requests
+
+from ._errors import HTTPError, RepositoryNotFoundError, hf_raise_for_status
+from ._hf_folder import HfFolder
+
+
+PERMISSION_T = Literal["read", "write"]
+
+
+def build_hf_headers(
+    endpoint: str,
+    token: Optional[str] = None,
+    use_auth_token: Optional[Union[bool, str]] = None,
+    required_permission: PERMISSION_T = "read",
+    repo_id: Optional[str] = None,
+    repo_type: Optional[str] = None,
+) -> Dict[str, str]:
+    """
+    Build headers dictionary to send in a HF Hub API call.
+
+    Authorization token is either given in argument (explicit use) or retrieved from the
+    machine (e.g. after a `huggingface-cli login` or using `HUGGING_FACE_HUB_TOKEN` env
+    variable). In case of an implicit use of the token, we check if the repo on which
+    the call will be made is private/gated. If it is a public repo and only read-access
+    is required, the token is not passed to preserve privacy. If the API call is not
+    made against a repo, it is considered a public call.
+
+    Returned token is also validated. An error is thrown if the server doesn't recognize
+    the token or if a write-access token is required but the token is an organization
+    one (starting with "api_org***").
+
+    Args:
+        endpoint (`str`):
+            Endpoint url to which the API call will be made. Used to check token
+            validity.
+        token (`str`, `optional`):
+            Hugging Face token. Will default to the locally saved token if not provided.
+        use_auth_token (`str`, `bool`, *optional*):
+            A token to be used for the download. If `True`, the token is read from the
+            machine (cache or env variable). If a string, it's used as the Hugging Face
+            token. If None, the token is read from the machine only if necessary
+            (write-access call or private repo).
+        required_permission (`Literal['read', 'write']`):
+            The permission required by the API call.
+        repo_id (`str`, `optional`):
+            Id of the repo if the api call is made on a repo (download a file, create a
+            commit, list files,...). Use `None` if the api call is not bound to a repo
+            (list models, create a repo,...).
+        repo_type (`str`, `optional`):
+            Repo type if the api call is made on a repo (download a file, create a
+            commit, list files,...). Use `None` if the api call is not bound to a repo
+            (list models, create a repo,...).
+
+    Returns:
+        A `Dict` of headers to pass in your API call..
+
+    Raises:
+        [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
+            If organization token is passed and "write" access is required.
+        [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
+            If token is invalid (not recognized by the server).
+        [`EnvironmentError`](https://docs.python.org/3/library/exceptions.html#EnvironmentError)
+            If "write" access is required but token is not passed and not saved locally.
+        [`EnvironmentError`](https://docs.python.org/3/library/exceptions.html#EnvironmentError)
+            If making a call to a private repo but token is not passed and not saved
+            locally.
+    """
+    # Get auth token to send
+    token_to_send = _get_token_to_send(
+        endpoint, repo_id, repo_type, token, use_auth_token, required_permission
+    )
+
+    # Combine headers
+    headers = {}
+    if token_to_send is not None:
+        headers["authorization"] = f"Bearer {token_to_send}"
+    # TODO: add user agent in headers
+    return headers
+
+
+def _get_token_to_send(
+    endpoint: str,
+    repo_id: str,
+    repo_type: Optional[str] = None,
+    token: Optional[str] = None,
+    use_auth_token: Optional[Union[bool, str]] = None,
+    required_permission: PERMISSION_T = "read",
+) -> Optional[str]:
+    # Case token is explicitly provided via `token`
+    if token is not None:
+        token_to_send = token
+
+    # Case token is explicitly provided via `use_auth_token`
+    elif isinstance(use_auth_token, str):
+        token_to_send = use_auth_token
+
+    # Case token is explicitly forbidden
+    elif use_auth_token is False:
+        token_to_send = None
+
+    # Case token is explicitly required
+    elif use_auth_token is True:
+        cached_token = HfFolder().get_token()
+        if cached_token is None:
+            raise EnvironmentError(
+                "Token is required (`use_auth_token=True`), but no token found. You"
+                " need to provide a token or be logged in to Hugging Face with"
+                " `huggingface-cli login` or `notebook_login`."
+            )
+        token_to_send = cached_token
+
+    # Otherwise: user did not give a preference whether to send a token or not.
+    # In order to preserve user privacy, token is sent only for private/gated repos or
+    # for if the `write` permission is required:
+    elif required_permission == "write" or _is_private(endpoint, repo_id, repo_type):
+        cached_token = HfFolder().get_token()
+        if cached_token is None:
+            if required_permission == "write":
+                raise EnvironmentError(
+                    "Token is required (write-access action) but no token found. You"
+                    " need to provide a token or be logged in to Hugging Face with"
+                    " `huggingface-cli login` or `notebook_login`."
+                )
+            else:
+                raise EnvironmentError(
+                    "Token is required to perform an action on a private repo but no"
+                    " token found. You need to provide a token or be logged in to"
+                    " Hugging Face with `huggingface-cli login` or `notebook_login`."
+                )
+        token_to_send = cached_token
+    else:  # "read" permission + repo is not private/gated
+        token_to_send = None
+
+    # Validate token and return
+    if token_to_send is not None:
+        if required_permission == "write" and token_to_send.startswith("api_org"):
+            raise ValueError(
+                "You must use your personal account token for write-access methods. To"
+                " generate a write-access token, go to"
+                " https://huggingface.co/settings/tokens"
+            )
+        if not _is_valid_token(endpoint, token_to_send):
+            raise ValueError("Invalid token passed!")
+    return token_to_send
+
+
+@lru_cache
+def _is_private(endpoint: str, repo_id: str, repo_type: Optional[str] = None) -> bool:
+    """Check if the repo on which the API call will be made is private or not.
+
+    Result is cached to avoid multiple `repo_info` API calls.
+    """
+    if repo_id is None:
+        # Means it is a generic API -> public
+        return False
+
+    if repo_type is None:
+        repo_type = "model"
+    r = requests.get(f"{endpoint}/api/{repo_type}s/{repo_id}")
+    try:
+        hf_raise_for_status(r)
+        return False
+    except RepositoryNotFoundError:
+        return True
+
+
+@lru_cache
+def _is_valid_token(endpoint: str, token: str) -> None:
+    """Check if the given token is valid.
+
+    Result is cached to avoid multiple `whoami` API calls.
+    """
+    r = requests.get(
+        f"{endpoint}/api/whoami-v2", headers={"authorization": f"Bearer {token}"}
+    )
+    try:
+        hf_raise_for_status(r)
+        return True
+    except HTTPError:
+        return False

--- a/src/huggingface_hub/utils/_headers.py
+++ b/src/huggingface_hub/utils/_headers.py
@@ -48,6 +48,28 @@ def build_hf_headers(
     Returns:
         A `Dict` of headers to pass in your API call.
 
+    Example:
+    ```py
+        > build_hf_headers(use_auth_token="hf_***") # explicit token
+        {"authorization": "Bearer hf_***"}
+
+        > build_hf_headers(use_auth_token=True) # explicitly use cached token
+        {"authorization": "Bearer hf_***"}
+
+        > build_hf_headers(use_auth_token=False) # explicitly don't use cached token
+        {}
+
+        > build_hf_headers() # implicit use of the cached token
+        {"authorization": "Bearer hf_***"}
+
+        # DISABLE_IMPLICIT_HF_TOKEN=True # to set as env variable
+        > build_hf_headers() # token is not sent
+        {}
+
+        > build_hf_headers(use_auth_token="api_org_***", is_write_action=True)
+        ValueError: You must use your personal account token for write-access methods.
+    ```
+
     Raises:
         [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
             If organization token is passed and "write" access is required.

--- a/src/huggingface_hub/utils/_headers.py
+++ b/src/huggingface_hub/utils/_headers.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 """Contains utilities to handle headers to send in calls to Huggingface Hub."""
 from functools import lru_cache
-from typing import Dict, Literal, Optional, Union
+from typing import Dict, Optional, Union
 
 import requests
 
@@ -22,19 +22,18 @@ from ._errors import HTTPError, RepositoryNotFoundError, hf_raise_for_status
 from ._hf_folder import HfFolder
 
 
-PERMISSION_T = Literal["read", "write"]
-
-
 def build_hf_headers(
-    endpoint: str,
+    *,
     token: Optional[str] = None,
     use_auth_token: Optional[Union[bool, str]] = None,
-    required_permission: PERMISSION_T = "read",
+    is_write_action: bool = False,
+    url: Optional[str] = None,
+    endpoint: Optional[str] = None,
     repo_id: Optional[str] = None,
     repo_type: Optional[str] = None,
 ) -> Dict[str, str]:
     """
-    Build headers dictionary to send in a HF Hub API call.
+    Build headers dictionary to send in a HF Hub call.
 
     Authorization token is either given in argument (explicit use) or retrieved from the
     machine (e.g. after a `huggingface-cli login` or using `HUGGING_FACE_HUB_TOKEN` env
@@ -47,10 +46,12 @@ def build_hf_headers(
     the token or if a write-access token is required but the token is an organization
     one (starting with "api_org***").
 
+    The request that will be made must either be a call to the API or an url pointing to
+    the Hub. In case of an API call, use `endpoint` argument (and optionally `repo_id`/
+    `repo_type`). In case of a direct URL call, use `url` argument and ignore
+    `endpoint`. In this later case, the validity of the token is not tested.
+
     Args:
-        endpoint (`str`):
-            Endpoint url to which the API call will be made. Used to check token
-            validity.
         token (`str`, `optional`):
             Hugging Face token. Will default to the locally saved token if not provided.
         use_auth_token (`str`, `bool`, *optional*):
@@ -58,19 +59,31 @@ def build_hf_headers(
             machine (cache or env variable). If a string, it's used as the Hugging Face
             token. If None, the token is read from the machine only if necessary
             (write-access call or private repo).
-        required_permission (`Literal['read', 'write']`):
-            The permission required by the API call.
+        is_write_action (`bool`, default to `False`):
+            Set to True if the API call requires a write access. If `True` and token is
+            not provided, it will be read from machine. If no token is found, raises an
+            exception.
+        url (`str`, *optional*):
+            Full url that will be called. For example used when downloading a file for
+            which you have the full url. If you are making an API call, use `endpoint`
+            instead.
+        endpoint (`str`, *optional*):
+            API endpoint to which the call will be made. Used to check token validity.
+            If making a call to the Hub for which you only have a full url, pass it
+            `url` to ignore `endpoint`, `repo_id` and `repo_type`.
         repo_id (`str`, `optional`):
-            Id of the repo if the api call is made on a repo (download a file, create a
-            commit, list files,...). Use `None` if the api call is not bound to a repo
-            (list models, create a repo,...).
+            Id of the repo if the api call is made on a repo (create a commit,
+            list files,...). To be used only combined with both `endpoint` and
+            `use_auth_token` arguments. Use `None` if the api call is not bound to a
+            repo (list models, create a repo,...).
         repo_type (`str`, `optional`):
-            Repo type if the api call is made on a repo (download a file, create a
-            commit, list files,...). Use `None` if the api call is not bound to a repo
-            (list models, create a repo,...).
+            Repo type if the api call is made on a repo (create a commit,
+            list files,...). To be used only combined with both `endpoint` and
+            `use_auth_token` arguments. Use `None` if the api call is not bound to a
+            repo (list models, create a repo,...).
 
     Returns:
-        A `Dict` of headers to pass in your API call..
+        A `Dict` of headers to pass in your API call.
 
     Raises:
         [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
@@ -85,7 +98,13 @@ def build_hf_headers(
     """
     # Get auth token to send
     token_to_send = _get_token_to_send(
-        endpoint, repo_id, repo_type, token, use_auth_token, required_permission
+        token=token,
+        use_auth_token=use_auth_token,
+        is_write_action=is_write_action,
+        endpoint=endpoint,
+        repo_id=repo_id,
+        repo_type=repo_type,
+        url=url,
     )
 
     # Combine headers
@@ -97,13 +116,19 @@ def build_hf_headers(
 
 
 def _get_token_to_send(
-    endpoint: str,
-    repo_id: str,
-    repo_type: Optional[str] = None,
-    token: Optional[str] = None,
-    use_auth_token: Optional[Union[bool, str]] = None,
-    required_permission: PERMISSION_T = "read",
+    token: Optional[str],
+    use_auth_token: Optional[Union[bool, str]],
+    is_write_action: bool,
+    repo_id: Optional[str],
+    repo_type: Optional[str],
+    endpoint: Optional[str],
+    url: Optional[str],
 ) -> Optional[str]:
+    """Determine if the token must be provided or validates it.
+
+    Strategy is made is such a way to preserve as much as possible user's privacy. See
+    `build_hf_headers` docstring for more details.
+    """
     # Case token is explicitly provided via `token`
     if token is not None:
         token_to_send = token
@@ -123,27 +148,32 @@ def _get_token_to_send(
             raise EnvironmentError(
                 "Token is required (`use_auth_token=True`), but no token found. You"
                 " need to provide a token or be logged in to Hugging Face with"
-                " `huggingface-cli login` or `notebook_login`."
+                " `huggingface-cli login` or `notebook_login`. See"
+                " https://huggingface.co/settings/tokens."
             )
         token_to_send = cached_token
 
     # Otherwise: user did not give a preference whether to send a token or not.
     # In order to preserve user privacy, token is sent only for private/gated repos or
     # for if the `write` permission is required:
-    elif required_permission == "write" or _is_private(endpoint, repo_id, repo_type):
+    elif is_write_action or _is_private(
+        url=url, endpoint=endpoint, repo_id=repo_id, repo_type=repo_type
+    ):
         cached_token = HfFolder().get_token()
         if cached_token is None:
-            if required_permission == "write":
+            if is_write_action:
                 raise EnvironmentError(
                     "Token is required (write-access action) but no token found. You"
                     " need to provide a token or be logged in to Hugging Face with"
-                    " `huggingface-cli login` or `notebook_login`."
+                    " `huggingface-cli login` or `notebook_login`. See"
+                    " https://huggingface.co/settings/tokens."
                 )
             else:
                 raise EnvironmentError(
                     "Token is required to perform an action on a private repo but no"
                     " token found. You need to provide a token or be logged in to"
                     " Hugging Face with `huggingface-cli login` or `notebook_login`."
+                    " See https://huggingface.co/settings/tokens."
                 )
         token_to_send = cached_token
     else:  # "read" permission + repo is not private/gated
@@ -151,32 +181,52 @@ def _get_token_to_send(
 
     # Validate token and return
     if token_to_send is not None:
-        if required_permission == "write" and token_to_send.startswith("api_org"):
+        if is_write_action and token_to_send.startswith("api_org"):
             raise ValueError(
                 "You must use your personal account token for write-access methods. To"
                 " generate a write-access token, go to"
                 " https://huggingface.co/settings/tokens"
             )
-        if not _is_valid_token(endpoint, token_to_send):
-            raise ValueError("Invalid token passed!")
+        if endpoint is not None and not _is_valid_token(endpoint, token_to_send):
+            raise ValueError(
+                "Invalid token passed! Go to https://huggingface.co/settings/tokens to"
+                " get one."
+            )
     return token_to_send
 
 
 @lru_cache
-def _is_private(endpoint: str, repo_id: str, repo_type: Optional[str] = None) -> bool:
+def _is_private(
+    url: Optional[str],
+    endpoint: Optional[str],
+    repo_id: Optional[str],
+    repo_type: Optional[str],
+) -> bool:
     """Check if the repo on which the API call will be made is private or not.
 
     Result is cached to avoid multiple `repo_info` API calls.
     """
+    # HEAD call to url without headers to check if private or not
+    if url is not None:
+        try:
+            hf_raise_for_status(requests.head(url))
+            return False
+        except RepositoryNotFoundError:
+            return True
+
+    # Should not happen
+    if endpoint is None:
+        raise ValueError("Either `url` or `endpoint` must be not `None`!")
+
+    # Means it is a generic action -> public
     if repo_id is None:
-        # Means it is a generic API -> public
         return False
 
+    # If action on a repo, is it a private one ?
     if repo_type is None:
         repo_type = "model"
-    r = requests.get(f"{endpoint}/api/{repo_type}s/{repo_id}")
     try:
-        hf_raise_for_status(r)
+        hf_raise_for_status(requests.head(f"{endpoint}/api/{repo_type}s/{repo_id}"))
         return False
     except RepositoryNotFoundError:
         return True

--- a/src/huggingface_hub/utils/_hf_folder.py
+++ b/src/huggingface_hub/utils/_hf_folder.py
@@ -1,0 +1,64 @@
+# coding=utf-8
+# Copyright 2022-present, the HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Contain helper class to retrieve/store token from/to local cache."""
+import os
+from pathlib import Path
+from typing import Optional
+
+
+class HfFolder:
+    path_token = Path("~/.huggingface/token").expanduser()
+
+    @classmethod
+    def save_token(cls, token: str) -> None:
+        """
+        Save token, creating folder as needed.
+
+        Args:
+            token (`str`):
+                The token to save to the [`HfFolder`]
+        """
+        cls.path_token.parent.mkdir(exist_ok=True)
+        with cls.path_token.open("w+") as f:
+            f.write(token)
+
+    @classmethod
+    def get_token(cls) -> Optional[str]:
+        """
+        Get token or None if not existent.
+
+        Note that a token can be also provided using the
+        `HUGGING_FACE_HUB_TOKEN` environment variable.
+
+        Returns:
+            `str` or `None`: The token, `None` if it doesn't exist.
+        """
+        token: Optional[str] = os.environ.get("HUGGING_FACE_HUB_TOKEN")
+        if token is None:
+            try:
+                return cls.path_token.read_text()
+            except FileNotFoundError:
+                pass
+        return token
+
+    @classmethod
+    def delete_token(cls) -> None:
+        """
+        Deletes the token from storage. Does not fail if token does not exist.
+        """
+        try:
+            cls.path_token.unlink()
+        except FileNotFoundError:
+            pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+import pytest
+
+from huggingface_hub.utils._headers import _is_private, _is_valid_token
+
+
+@pytest.fixture(autouse=True)
+def disable_lru_cache_in_all_tests() -> None:
+    """Clean lru_cache between each test to ensure independence between them."""
+    _is_private.cache_clear()
+    _is_valid_token.cache_clear()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,8 @@
+from typing import Generator
+
 import pytest
 
+from huggingface_hub import HfFolder
 from huggingface_hub.utils._headers import _is_private, _is_valid_token
 
 
@@ -8,3 +11,20 @@ def disable_lru_cache_in_all_tests() -> None:
     """Clean lru_cache between each test to ensure independence between them."""
     _is_private.cache_clear()
     _is_valid_token.cache_clear()
+
+
+@pytest.fixture(autouse=True, scope="session")
+def clean_hf_folder_token_for_tests() -> Generator:
+    """Clean token stored on machine before all tests and reset it back at the end.
+
+    Useful to avoid token deletion when running tests locally.
+    """
+    # Remove registered token
+    token = HfFolder().get_token()
+    HfFolder().delete_token()
+
+    yield  # Run all tests
+
+    # Set back token once all tests have passed
+    if token is not None:
+        HfFolder().save_token(token)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,14 +3,6 @@ from typing import Generator
 import pytest
 
 from huggingface_hub import HfFolder
-from huggingface_hub.utils._headers import _is_private, _is_valid_token
-
-
-@pytest.fixture(autouse=True)
-def disable_lru_cache_in_all_tests() -> None:
-    """Clean lru_cache between each test to ensure independence between them."""
-    _is_private.cache_clear()
-    _is_valid_token.cache_clear()
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -43,7 +43,6 @@ from huggingface_hub.hf_api import (
     DatasetInfo,
     DatasetSearchArguments,
     HfApi,
-    HfFolder,
     MetricInfo,
     ModelInfo,
     ModelSearchArguments,
@@ -53,7 +52,7 @@ from huggingface_hub.hf_api import (
     read_from_credential_store,
     repo_type_and_id_from_hf_id,
 )
-from huggingface_hub.utils import RepositoryNotFoundError, logging
+from huggingface_hub.utils import HfFolder, RepositoryNotFoundError, logging
 from huggingface_hub.utils.endpoint_helpers import (
     DatasetFilter,
     ModelFilter,

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -23,6 +23,7 @@ import warnings
 from functools import partial
 from io import BytesIO
 from typing import List
+from unittest.mock import Mock, patch
 from urllib.parse import quote
 
 import pytest
@@ -180,13 +181,20 @@ def test_repo_id_no_warning():
 
 
 class HfApiEndpointsTest(HfApiCommonTestWithLogin):
-    def test_whoami(self):
+    def test_whoami_with_passing_token(self):
         info = self._api.whoami(token=self._token)
         self.assertEqual(info["name"], USER)
         self.assertEqual(info["fullname"], FULL_NAME)
         self.assertIsInstance(info["orgs"], list)
         valid_org = [org for org in info["orgs"] if org["name"] == "valid_org"][0]
         self.assertIsInstance(valid_org["apiToken"], str)
+
+    @patch("huggingface_hub.utils._headers.HfFolder")
+    def test_whoami_with_implicit_token_from_login(self, mock_HfFolder: Mock) -> None:
+        """Test using `whoami` after a `huggingface-cli login`."""
+        mock_HfFolder().get_token.return_value  = self._token
+        info = self._api.whoami()
+        self.assertEqual(info["name"], USER)
 
     @retry_endpoint
     def test_delete_repo_error_message(self):

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -192,7 +192,7 @@ class HfApiEndpointsTest(HfApiCommonTestWithLogin):
     @patch("huggingface_hub.utils._headers.HfFolder")
     def test_whoami_with_implicit_token_from_login(self, mock_HfFolder: Mock) -> None:
         """Test using `whoami` after a `huggingface-cli login`."""
-        mock_HfFolder().get_token.return_value  = self._token
+        mock_HfFolder().get_token.return_value = self._token
         info = self._api.whoami()
         self.assertEqual(info["name"], USER)
 

--- a/tests/test_inference_api.py
+++ b/tests/test_inference_api.py
@@ -11,11 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import unittest
 
-import datasets
-
+from huggingface_hub import hf_hub_download
 from huggingface_hub.inference_api import InferenceApi
 
 from .testing_utils import with_production_testing
@@ -67,13 +65,12 @@ class InferenceApiTest(unittest.TestCase):
     @with_production_testing
     def test_inference_with_audio(self):
         api = InferenceApi("facebook/wav2vec2-base-960h")
-        with self.assertWarns(FutureWarning):
-            dataset = datasets.load_dataset(
-                "patrickvonplaten/librispeech_asr_dummy",
-                "clean",
-                split="validation",
-            )
-        data = self.read(dataset["file"][0])
+        file = hf_hub_download(
+            repo_id="hf-internal-testing/dummy-flac-single-example",
+            repo_type="dataset",
+            filename="example.flac",
+        )
+        data = self.read(file)
         result = api(data=data)
         self.assertIsInstance(result, dict)
         self.assertTrue("text" in result, f"We received {result} instead")
@@ -81,13 +78,10 @@ class InferenceApiTest(unittest.TestCase):
     @with_production_testing
     def test_inference_with_image(self):
         api = InferenceApi("google/vit-base-patch16-224")
-        with self.assertWarns(FutureWarning):
-            dataset = datasets.load_dataset(
-                "Narsil/image_dummy",
-                "image",
-                split="test",
-            )
-        data = self.read(dataset["file"][0])
+        file = hf_hub_download(
+            repo_id="Narsil/image_dummy", repo_type="dataset", filename="lena.png"
+        )
+        data = self.read(file)
         result = api(data=data)
         self.assertIsInstance(result, list)
         for classification in result:

--- a/tests/test_snapshot_download.py
+++ b/tests/test_snapshot_download.py
@@ -8,8 +8,7 @@ import pytest
 
 import requests
 from huggingface_hub import HfApi, Repository, snapshot_download
-from huggingface_hub.hf_api import HfFolder
-from huggingface_hub.utils import logging
+from huggingface_hub.utils import HfFolder, logging
 
 from .testing_constants import ENDPOINT_STAGING, TOKEN, USER
 from .testing_utils import (

--- a/tests/test_utils_deprecation.py
+++ b/tests/test_utils_deprecation.py
@@ -52,6 +52,9 @@ class TestDeprecationUtils(unittest.TestCase):
 
             dummy_b_c_deprecated("A")
 
+            dummy_b_c_deprecated("A", b="b")
+            dummy_b_c_deprecated("A", b="b", c="c")
+
         with pytest.warns(FutureWarning):
             dummy_c_deprecated("A", "B", "C")
 
@@ -79,7 +82,7 @@ class TestDeprecationUtils(unittest.TestCase):
 
         # Default message
         with pytest.warns(FutureWarning) as record:
-            dummy_deprecated_default_message(a="a")
+            dummy_deprecated_default_message(a="A")
         self.assertEqual(len(record), 1)
         self.assertEqual(
             record[0].message.args[0],
@@ -100,7 +103,7 @@ class TestDeprecationUtils(unittest.TestCase):
 
         # Custom message
         with pytest.warns(FutureWarning) as record:
-            dummy_deprecated_custom_message(a="a")
+            dummy_deprecated_custom_message(a="A")
         self.assertEqual(len(record), 1)
         self.assertEqual(
             record[0].message.args[0],

--- a/tests/test_utils_headers.py
+++ b/tests/test_utils_headers.py
@@ -1,0 +1,389 @@
+import unittest
+from unittest.mock import Mock, patch
+
+from huggingface_hub.utils import RepositoryNotFoundError
+from huggingface_hub.utils._headers import (
+    _get_token_to_send,
+    _is_private,
+    _is_valid_token,
+    _validate_token_to_send,
+    build_hf_headers,
+)
+
+from .testing_utils import handle_injection_in_test
+
+
+FAKE_URL = "FAKE_URL"
+FAKE_ENDPOINT = "hf.co/fake_endpoint"
+FAKE_TOKEN = "123456789"
+FAKE_TOKEN_2 = "987654321"
+
+
+class TestHeadersUtilsBuildHeaders(unittest.TestCase):
+    @patch("huggingface_hub.utils._headers._get_token_to_send")
+    @patch("huggingface_hub.utils._headers._validate_token_to_send")
+    @handle_injection_in_test
+    def test_build_hf_headers(
+        self, mock__get_token_to_send: Mock, mock__validate_token_to_send: Mock
+    ) -> None:
+        # Mock all args (sub-helpers are unit-tested afterwards)
+        mock__get_token_to_send.return_value = FAKE_TOKEN
+        mock_token = Mock()
+        mock_use_auth_token = Mock()
+        mock_is_write_action = Mock()
+        mock_url = Mock()
+        mock_endpoint = Mock()
+        mock_repo_id = Mock()
+        mock_repo_type = Mock()
+
+        # Make call
+        headers = build_hf_headers(
+            token=mock_token,
+            use_auth_token=mock_use_auth_token,
+            is_write_action=mock_is_write_action,
+            url=mock_url,
+            endpoint=mock_endpoint,
+            repo_id=mock_repo_id,
+            repo_type=mock_repo_type,
+        )
+
+        # `_get_token_to_send` called
+        mock__get_token_to_send.assert_called_once_with(
+            token=mock_token,
+            use_auth_token=mock_use_auth_token,
+            is_write_action=mock_is_write_action,
+            url=mock_url,
+            endpoint=mock_endpoint,
+            repo_id=mock_repo_id,
+            repo_type=mock_repo_type,
+        )
+
+        # `_validate_token_to_send` called on result
+        mock__validate_token_to_send.assert_called_once_with(
+            FAKE_TOKEN, endpoint=mock_endpoint, is_write_action=mock_is_write_action
+        )
+
+        # Returned the header with auth
+        self.assertEqual(headers, {"authorization": f"Bearer {FAKE_TOKEN}"})
+
+
+class TestHeadersUtilsGetTokenToSend(unittest.TestCase):
+    def test_get_token_to_send_on_token(self) -> None:
+        self.assertEqual(
+            _get_token_to_send(
+                token=FAKE_TOKEN,
+                use_auth_token=None,
+                is_write_action=False,
+                repo_id=None,
+                repo_type=None,
+                endpoint=None,
+                url=None,
+            ),
+            FAKE_TOKEN,
+        )
+
+    def test_get_token_to_send_on_use_auth_token_str(self) -> None:
+        self.assertEqual(
+            _get_token_to_send(
+                token=None,
+                use_auth_token=FAKE_TOKEN,
+                is_write_action=False,
+                repo_id=None,
+                repo_type=None,
+                endpoint=None,
+                url=None,
+            ),
+            FAKE_TOKEN,
+        )
+
+    def test_get_token_to_send_on_both_tokens_args(self) -> None:
+        self.assertEqual(
+            _get_token_to_send(
+                token=FAKE_TOKEN,  # has priority
+                use_auth_token=FAKE_TOKEN_2,
+                is_write_action=False,
+                repo_id=None,
+                repo_type=None,
+                endpoint=None,
+                url=None,
+            ),
+            FAKE_TOKEN,
+        )
+
+    def test_get_token_to_send_on_use_auth_token_false(self) -> None:
+        self.assertIsNone(
+            _get_token_to_send(
+                token=None,
+                use_auth_token=False,  # explicit
+                is_write_action=False,
+                repo_id=None,
+                repo_type=None,
+                endpoint=None,
+                url=None,
+            )
+        )
+
+    @patch("huggingface_hub.utils._headers.HfFolder")
+    def test_get_token_to_send_on_use_auth_token_true_and_cached_token(
+        self, mock_HfFolder: Mock
+    ) -> None:
+        mock_HfFolder().get_token.return_value = FAKE_TOKEN
+        self.assertEqual(
+            _get_token_to_send(
+                token=None,
+                use_auth_token=True,  # explicit
+                is_write_action=False,
+                repo_id=None,
+                repo_type=None,
+                endpoint=None,
+                url=None,
+            ),
+            FAKE_TOKEN,
+        )
+
+    @patch("huggingface_hub.utils._headers.HfFolder")
+    def test_get_token_to_send_on_use_auth_token_true_and_no_cached_token(
+        self, mock_HfFolder: Mock
+    ) -> None:
+        mock_HfFolder().get_token.return_value = None
+        with self.assertRaises(EnvironmentError):
+            _get_token_to_send(
+                token=None,
+                use_auth_token=True,  # explicit but token not found in cache
+                is_write_action=False,
+                repo_id=None,
+                repo_type=None,
+                endpoint=None,
+                url=None,
+            )
+
+    @patch("huggingface_hub.utils._headers._is_private")
+    def test_get_token_to_send_on_use_auth_token_none_and_not_private(
+        self, mock__is_private: Mock
+    ) -> None:
+        mock__is_private.return_value = False
+        # Not found -> no need to send the token
+        self.assertIsNone(
+            _get_token_to_send(
+                token=None,
+                use_auth_token=None,
+                is_write_action=False,
+                repo_id=None,
+                repo_type=None,
+                endpoint=None,
+                url=None,
+            )
+        )
+
+    @patch("huggingface_hub.utils._headers._is_private")
+    @patch("huggingface_hub.utils._headers.HfFolder")
+    @handle_injection_in_test
+    def test_get_token_to_send_on_use_auth_token_none_and_private_and_no_token(
+        self, mock__is_private: Mock, mock_HfFolder: Mock
+    ) -> None:
+        mock_HfFolder().get_token.return_value = None
+        mock__is_private.return_value = True
+        with self.assertRaises(EnvironmentError):
+            # Private repo and token not found
+            _get_token_to_send(
+                token=None,
+                use_auth_token=True,
+                is_write_action=False,
+                repo_id=None,
+                repo_type=None,
+                endpoint=None,
+                url=None,
+            )
+
+    @patch("huggingface_hub.utils._headers._is_private")
+    @patch("huggingface_hub.utils._headers.HfFolder")
+    @handle_injection_in_test
+    def test_get_token_to_send_on_use_auth_token_none_and_private_and_token_found(
+        self, mock__is_private: Mock, mock_HfFolder: Mock
+    ) -> None:
+        mock_HfFolder().get_token.return_value = FAKE_TOKEN
+        mock__is_private.return_value = True
+
+        # Private repo and token found
+        self.assertEqual(
+            _get_token_to_send(
+                token=None,
+                use_auth_token=True,
+                is_write_action=False,
+                repo_id=None,
+                repo_type=None,
+                endpoint=None,
+                url=None,
+            ),
+            FAKE_TOKEN,
+        )
+
+    @patch("huggingface_hub.utils._headers._is_private")
+    @patch("huggingface_hub.utils._headers.HfFolder")
+    @handle_injection_in_test
+    def test_get_token_to_send_on_use_auth_token_none_and_public_and_write_action(
+        self, mock__is_private: Mock, mock_HfFolder: Mock
+    ) -> None:
+        mock_HfFolder().get_token.return_value = FAKE_TOKEN
+        mock__is_private.return_value = False
+
+        # Public repo, write access required and token found
+        self.assertEqual(
+            _get_token_to_send(
+                token=None,
+                use_auth_token=True,
+                is_write_action=True,  # Token required !
+                repo_id=None,
+                repo_type=None,
+                endpoint=None,
+                url=None,
+            ),
+            FAKE_TOKEN,
+        )
+
+
+class TestHeadersUtilsValidateTokenToSend(unittest.TestCase):
+    def test_validate_token_to_send_on_org_token_and_write_access_required(
+        self,
+    ) -> None:
+        with self.assertRaises(ValueError):
+            _validate_token_to_send(
+                token="api_org_123456789", endpoint=None, is_write_action=True
+            )
+
+    def test_validate_token_to_send_on_user_token_and_write_access_required(
+        self,
+    ) -> None:
+        _validate_token_to_send(
+            token="hf_123456789", endpoint=None, is_write_action=True
+        )
+
+    @patch("huggingface_hub.utils._headers._is_valid_token")
+    def test_validate_token_to_send_check_token_validity(
+        self, mock__is_valid_token: Mock
+    ) -> None:
+        mock__is_valid_token.return_value = True
+        _validate_token_to_send(
+            token=FAKE_TOKEN, endpoint=FAKE_ENDPOINT, is_write_action=False
+        )
+        mock__is_valid_token.assert_called_once_with(FAKE_ENDPOINT, FAKE_TOKEN)
+
+    @patch("huggingface_hub.utils._headers._is_valid_token")
+    def test_validate_token_to_send_check_token_validity_not_valid(
+        self, mock__is_valid_token: Mock
+    ) -> None:
+        mock__is_valid_token.return_value = False
+        with self.assertRaises(ValueError):
+            _validate_token_to_send(
+                token=FAKE_TOKEN, endpoint=FAKE_ENDPOINT, is_write_action=False
+            )
+        mock__is_valid_token.assert_called_once_with(FAKE_ENDPOINT, FAKE_TOKEN)
+
+
+class TestHeadersUtilsIsPrivate(unittest.TestCase):
+    def test_is_private_all_none(self) -> None:
+        with self.assertRaises(ValueError):
+            _is_private(url=None, endpoint=None, repo_id=None, repo_type=None)
+
+    @patch("huggingface_hub.utils._headers.requests.head")
+    def test_is_private_url_public_repo(self, mock_head: Mock) -> None:
+        mock_head.status_code = 200
+        self.assertFalse(
+            _is_private(url=FAKE_URL, endpoint=None, repo_id=None, repo_type=None)
+        )
+        mock_head.assert_called_once_with(FAKE_URL)
+
+    @patch("huggingface_hub.utils._headers.requests.head")
+    @patch("huggingface_hub.utils._headers.hf_raise_for_status")
+    @handle_injection_in_test
+    def test_is_private_url_private_repo(self, mock_hf_raise_for_status: Mock) -> None:
+        mock_hf_raise_for_status.side_effect = RepositoryNotFoundError(
+            "repo not found", response=None
+        )
+        self.assertTrue(
+            _is_private(url=FAKE_URL, endpoint=None, repo_id=None, repo_type=None)
+        )
+
+    @patch("huggingface_hub.utils._headers.requests.head")
+    @patch("huggingface_hub.utils._headers.hf_raise_for_status")
+    @handle_injection_in_test
+    def test_is_private_on_url_any_error(self, mock_hf_raise_for_status: Mock) -> None:
+        mock_hf_raise_for_status.side_effect = Exception()
+        self.assertFalse(
+            _is_private(url=FAKE_URL, endpoint=None, repo_id=None, repo_type=None)
+        )
+
+    def test_is_private_generic_api_call(self) -> None:
+        self.assertFalse(
+            _is_private(url=None, endpoint=FAKE_ENDPOINT, repo_id=None, repo_type=None)
+        )
+
+    @patch("huggingface_hub.utils._headers.requests.head")
+    @handle_injection_in_test
+    def test_is_private_on_public_model(self, mock_head: Mock) -> None:
+        mock_head.status_code = 200
+        self.assertFalse(
+            _is_private(
+                url=None, endpoint=FAKE_ENDPOINT, repo_id="model_1", repo_type=None
+            )
+        )
+        mock_head.assert_called_once_with(f"{FAKE_ENDPOINT}/api/models/model_1")
+
+    @patch("huggingface_hub.utils._headers.requests.head")
+    @handle_injection_in_test
+    def test_is_private_on_public_dataset(self, mock_head: Mock) -> None:
+        mock_head.status_code = 200
+        self.assertFalse(
+            _is_private(
+                url=None,
+                endpoint=FAKE_ENDPOINT,
+                repo_id="dataset_1",
+                repo_type="dataset",
+            )
+        )
+        mock_head.assert_called_once_with(f"{FAKE_ENDPOINT}/api/datasets/dataset_1")
+
+    @patch("huggingface_hub.utils._headers.requests.head")
+    @patch("huggingface_hub.utils._headers.hf_raise_for_status")
+    @handle_injection_in_test
+    def test_is_private_on_private_model(self, mock_hf_raise_for_status: Mock) -> None:
+        mock_hf_raise_for_status.side_effect = RepositoryNotFoundError(
+            "repo not found", response=None
+        )
+        self.assertTrue(
+            _is_private(
+                url=None, endpoint=FAKE_ENDPOINT, repo_id="model_1", repo_type=None
+            )
+        )
+
+    @patch("huggingface_hub.utils._headers.requests.head")
+    @patch("huggingface_hub.utils._headers.hf_raise_for_status")
+    @handle_injection_in_test
+    def test_is_private_on_repo_any_error(self, mock_hf_raise_for_status: Mock) -> None:
+        mock_hf_raise_for_status.side_effect = Exception("not found")
+        self.assertFalse(
+            _is_private(
+                url=None, endpoint=FAKE_ENDPOINT, repo_id="model_1", repo_type=None
+            )
+        )
+
+
+class TestHeadersUtilsIsValid(unittest.TestCase):
+    @patch("huggingface_hub.utils._headers.requests.get")
+    def test_token_is_valid_on_valid_token(self, mock_get: Mock) -> None:
+        mock_get.status_code = 200
+        self.assertTrue(_is_valid_token(endpoint=FAKE_ENDPOINT, token=FAKE_TOKEN))
+
+        mock_get.assert_called_once_with(
+            f"{FAKE_ENDPOINT}/api/whoami-v2",
+            headers={"authorization": f"Bearer {FAKE_TOKEN}"},
+        )
+
+    @patch("huggingface_hub.utils._headers.requests.get")
+    @patch("huggingface_hub.utils._headers.hf_raise_for_status")
+    @handle_injection_in_test
+    def test_token_is_valid_on_not_valid_token(
+        self, mock_hf_raise_for_status: Mock
+    ) -> None:
+        mock_hf_raise_for_status.side_effect = Exception
+        self.assertFalse(_is_valid_token(endpoint=FAKE_ENDPOINT, token=FAKE_TOKEN))

--- a/tests/test_utils_headers.py
+++ b/tests/test_utils_headers.py
@@ -51,12 +51,12 @@ class TestAuthHeadersUtil(unittest.TestCase):
         with self.assertRaises(ValueError):
             build_hf_headers(use_auth_token=False, is_write_action=True)
 
-    @patch.dict("os.environ", {"DISABLE_IMPLICIT_HF_TOKEN": "1"})
+    @patch.dict("os.environ", {"HF_HUB_DISABLE_IMPLICIT_TOKEN": "1"})
     def test_implicit_use_disabled(self, mock_HfFolder: Mock) -> None:
         mock_HfFolder().get_token.return_value = FAKE_TOKEN
         self.assertEqual(build_hf_headers(), {})  # token is not sent
 
-    @patch.dict("os.environ", {"DISABLE_IMPLICIT_HF_TOKEN": "1"})
+    @patch.dict("os.environ", {"HF_HUB_DISABLE_IMPLICIT_TOKEN": "1"})
     def test_implicit_use_disabled_but_explicit_use(self, mock_HfFolder: Mock) -> None:
         mock_HfFolder().get_token.return_value = FAKE_TOKEN
 

--- a/tests/test_utils_headers.py
+++ b/tests/test_utils_headers.py
@@ -13,7 +13,7 @@ FAKE_TOKEN_HEADER = {"authorization": f"Bearer {FAKE_TOKEN}"}
 
 @patch("huggingface_hub.utils._headers.HfFolder")
 @handle_injection
-class TestHeadersUtilsBuildHeadersNew(unittest.TestCase):
+class TestAuthHeadersUtil(unittest.TestCase):
     def test_use_auth_token_str(self) -> None:
         self.assertEqual(build_hf_headers(use_auth_token=FAKE_TOKEN), FAKE_TOKEN_HEADER)
 
@@ -50,3 +50,15 @@ class TestHeadersUtilsBuildHeadersNew(unittest.TestCase):
     def test_write_action_use_auth_token_false(self) -> None:
         with self.assertRaises(ValueError):
             build_hf_headers(use_auth_token=False, is_write_action=True)
+
+    @patch.dict("os.environ", {"DISABLE_IMPLICIT_HF_TOKEN": "1"})
+    def test_implicit_use_disabled(self, mock_HfFolder: Mock) -> None:
+        mock_HfFolder().get_token.return_value = FAKE_TOKEN
+        self.assertEqual(build_hf_headers(), {})  # token is not sent
+
+    @patch.dict("os.environ", {"DISABLE_IMPLICIT_HF_TOKEN": "1"})
+    def test_implicit_use_disabled(self, mock_HfFolder: Mock) -> None:
+        mock_HfFolder().get_token.return_value = FAKE_TOKEN
+
+        # This is not an implicit use so we still send it
+        self.assertEqual(build_hf_headers(use_auth_token=True), FAKE_TOKEN_HEADER)

--- a/tests/test_utils_headers.py
+++ b/tests/test_utils_headers.py
@@ -57,7 +57,7 @@ class TestAuthHeadersUtil(unittest.TestCase):
         self.assertEqual(build_hf_headers(), {})  # token is not sent
 
     @patch.dict("os.environ", {"DISABLE_IMPLICIT_HF_TOKEN": "1"})
-    def test_implicit_use_disabled(self, mock_HfFolder: Mock) -> None:
+    def test_implicit_use_disabled_but_explicit_use(self, mock_HfFolder: Mock) -> None:
         mock_HfFolder().get_token.return_value = FAKE_TOKEN
 
         # This is not an implicit use so we still send it

--- a/tests/test_utils_headers.py
+++ b/tests/test_utils_headers.py
@@ -1,389 +1,52 @@
 import unittest
 from unittest.mock import Mock, patch
 
-from huggingface_hub.utils import RepositoryNotFoundError
-from huggingface_hub.utils._headers import (
-    _get_token_to_send,
-    _is_private,
-    _is_valid_token,
-    _validate_token_to_send,
-    build_hf_headers,
-)
+from huggingface_hub.utils._headers import build_hf_headers
 
-from .testing_utils import handle_injection_in_test
+from .testing_utils import handle_injection
 
 
-FAKE_URL = "FAKE_URL"
-FAKE_ENDPOINT = "hf.co/fake_endpoint"
 FAKE_TOKEN = "123456789"
-FAKE_TOKEN_2 = "987654321"
+FAKE_TOKEN_ORG = "api_org_123456789"
+FAKE_TOKEN_HEADER = {"authorization": f"Bearer {FAKE_TOKEN}"}
 
 
-class TestHeadersUtilsBuildHeaders(unittest.TestCase):
-    @patch("huggingface_hub.utils._headers._get_token_to_send")
-    @patch("huggingface_hub.utils._headers._validate_token_to_send")
-    @handle_injection_in_test
-    def test_build_hf_headers(
-        self, mock__get_token_to_send: Mock, mock__validate_token_to_send: Mock
-    ) -> None:
-        # Mock all args (sub-helpers are unit-tested afterwards)
-        mock__get_token_to_send.return_value = FAKE_TOKEN
-        mock_token = Mock()
-        mock_use_auth_token = Mock()
-        mock_is_write_action = Mock()
-        mock_url = Mock()
-        mock_endpoint = Mock()
-        mock_repo_id = Mock()
-        mock_repo_type = Mock()
+@patch("huggingface_hub.utils._headers.HfFolder")
+@handle_injection
+class TestHeadersUtilsBuildHeadersNew(unittest.TestCase):
+    def test_use_auth_token_str(self) -> None:
+        self.assertEqual(build_hf_headers(use_auth_token=FAKE_TOKEN), FAKE_TOKEN_HEADER)
 
-        # Make call
-        headers = build_hf_headers(
-            token=mock_token,
-            use_auth_token=mock_use_auth_token,
-            is_write_action=mock_is_write_action,
-            url=mock_url,
-            endpoint=mock_endpoint,
-            repo_id=mock_repo_id,
-            repo_type=mock_repo_type,
-        )
-
-        # `_get_token_to_send` called
-        mock__get_token_to_send.assert_called_once_with(
-            token=mock_token,
-            use_auth_token=mock_use_auth_token,
-            is_write_action=mock_is_write_action,
-            url=mock_url,
-            endpoint=mock_endpoint,
-            repo_id=mock_repo_id,
-            repo_type=mock_repo_type,
-        )
-
-        # `_validate_token_to_send` called on result
-        mock__validate_token_to_send.assert_called_once_with(
-            FAKE_TOKEN, endpoint=mock_endpoint, is_write_action=mock_is_write_action
-        )
-
-        # Returned the header with auth
-        self.assertEqual(headers, {"authorization": f"Bearer {FAKE_TOKEN}"})
-
-
-class TestHeadersUtilsGetTokenToSend(unittest.TestCase):
-    def test_get_token_to_send_on_token(self) -> None:
-        self.assertEqual(
-            _get_token_to_send(
-                token=FAKE_TOKEN,
-                use_auth_token=None,
-                is_write_action=False,
-                repo_id=None,
-                repo_type=None,
-                endpoint=None,
-                url=None,
-            ),
-            FAKE_TOKEN,
-        )
-
-    def test_get_token_to_send_on_use_auth_token_str(self) -> None:
-        self.assertEqual(
-            _get_token_to_send(
-                token=None,
-                use_auth_token=FAKE_TOKEN,
-                is_write_action=False,
-                repo_id=None,
-                repo_type=None,
-                endpoint=None,
-                url=None,
-            ),
-            FAKE_TOKEN,
-        )
-
-    def test_get_token_to_send_on_both_tokens_args(self) -> None:
-        self.assertEqual(
-            _get_token_to_send(
-                token=FAKE_TOKEN,  # has priority
-                use_auth_token=FAKE_TOKEN_2,
-                is_write_action=False,
-                repo_id=None,
-                repo_type=None,
-                endpoint=None,
-                url=None,
-            ),
-            FAKE_TOKEN,
-        )
-
-    def test_get_token_to_send_on_use_auth_token_false(self) -> None:
-        self.assertIsNone(
-            _get_token_to_send(
-                token=None,
-                use_auth_token=False,  # explicit
-                is_write_action=False,
-                repo_id=None,
-                repo_type=None,
-                endpoint=None,
-                url=None,
-            )
-        )
-
-    @patch("huggingface_hub.utils._headers.HfFolder")
-    def test_get_token_to_send_on_use_auth_token_true_and_cached_token(
-        self, mock_HfFolder: Mock
-    ) -> None:
-        mock_HfFolder().get_token.return_value = FAKE_TOKEN
-        self.assertEqual(
-            _get_token_to_send(
-                token=None,
-                use_auth_token=True,  # explicit
-                is_write_action=False,
-                repo_id=None,
-                repo_type=None,
-                endpoint=None,
-                url=None,
-            ),
-            FAKE_TOKEN,
-        )
-
-    @patch("huggingface_hub.utils._headers.HfFolder")
-    def test_get_token_to_send_on_use_auth_token_true_and_no_cached_token(
-        self, mock_HfFolder: Mock
-    ) -> None:
+    def test_use_auth_token_true_no_cached_token(self, mock_HfFolder: Mock) -> None:
         mock_HfFolder().get_token.return_value = None
         with self.assertRaises(EnvironmentError):
-            _get_token_to_send(
-                token=None,
-                use_auth_token=True,  # explicit but token not found in cache
-                is_write_action=False,
-                repo_id=None,
-                repo_type=None,
-                endpoint=None,
-                url=None,
-            )
+            build_hf_headers(use_auth_token=True)
 
-    @patch("huggingface_hub.utils._headers._is_private")
-    def test_get_token_to_send_on_use_auth_token_none_and_not_private(
-        self, mock__is_private: Mock
-    ) -> None:
-        mock__is_private.return_value = False
-        # Not found -> no need to send the token
-        self.assertIsNone(
-            _get_token_to_send(
-                token=None,
-                use_auth_token=None,
-                is_write_action=False,
-                repo_id=None,
-                repo_type=None,
-                endpoint=None,
-                url=None,
-            )
-        )
+    def test_use_auth_token_true_has_cached_token(self, mock_HfFolder: Mock) -> None:
+        mock_HfFolder().get_token.return_value = FAKE_TOKEN
+        self.assertEqual(build_hf_headers(use_auth_token=True), FAKE_TOKEN_HEADER)
 
-    @patch("huggingface_hub.utils._headers._is_private")
-    @patch("huggingface_hub.utils._headers.HfFolder")
-    @handle_injection_in_test
-    def test_get_token_to_send_on_use_auth_token_none_and_private_and_no_token(
-        self, mock__is_private: Mock, mock_HfFolder: Mock
-    ) -> None:
+    def test_use_auth_token_false(self, mock_HfFolder: Mock) -> None:
+        mock_HfFolder().get_token.return_value = FAKE_TOKEN
+        self.assertEqual(build_hf_headers(use_auth_token=False), {})
+
+    def test_use_auth_token_none_no_cached_token(self, mock_HfFolder: Mock) -> None:
         mock_HfFolder().get_token.return_value = None
-        mock__is_private.return_value = True
-        with self.assertRaises(EnvironmentError):
-            # Private repo and token not found
-            _get_token_to_send(
-                token=None,
-                use_auth_token=True,
-                is_write_action=False,
-                repo_id=None,
-                repo_type=None,
-                endpoint=None,
-                url=None,
-            )
+        self.assertEqual(build_hf_headers(), {})
 
-    @patch("huggingface_hub.utils._headers._is_private")
-    @patch("huggingface_hub.utils._headers.HfFolder")
-    @handle_injection_in_test
-    def test_get_token_to_send_on_use_auth_token_none_and_private_and_token_found(
-        self, mock__is_private: Mock, mock_HfFolder: Mock
-    ) -> None:
+    def test_use_auth_token_none_has_cached_token(self, mock_HfFolder: Mock) -> None:
         mock_HfFolder().get_token.return_value = FAKE_TOKEN
-        mock__is_private.return_value = True
+        self.assertEqual(build_hf_headers(), FAKE_TOKEN_HEADER)
 
-        # Private repo and token found
-        self.assertEqual(
-            _get_token_to_send(
-                token=None,
-                use_auth_token=True,
-                is_write_action=False,
-                repo_id=None,
-                repo_type=None,
-                endpoint=None,
-                url=None,
-            ),
-            FAKE_TOKEN,
-        )
-
-    @patch("huggingface_hub.utils._headers._is_private")
-    @patch("huggingface_hub.utils._headers.HfFolder")
-    @handle_injection_in_test
-    def test_get_token_to_send_on_use_auth_token_none_and_public_and_write_action(
-        self, mock__is_private: Mock, mock_HfFolder: Mock
-    ) -> None:
-        mock_HfFolder().get_token.return_value = FAKE_TOKEN
-        mock__is_private.return_value = False
-
-        # Public repo, write access required and token found
-        self.assertEqual(
-            _get_token_to_send(
-                token=None,
-                use_auth_token=True,
-                is_write_action=True,  # Token required !
-                repo_id=None,
-                repo_type=None,
-                endpoint=None,
-                url=None,
-            ),
-            FAKE_TOKEN,
-        )
-
-
-class TestHeadersUtilsValidateTokenToSend(unittest.TestCase):
-    def test_validate_token_to_send_on_org_token_and_write_access_required(
-        self,
-    ) -> None:
+    def test_write_action_org_token(self) -> None:
         with self.assertRaises(ValueError):
-            _validate_token_to_send(
-                token="api_org_123456789", endpoint=None, is_write_action=True
-            )
+            build_hf_headers(use_auth_token=FAKE_TOKEN_ORG, is_write_action=True)
 
-    def test_validate_token_to_send_on_user_token_and_write_access_required(
-        self,
-    ) -> None:
-        _validate_token_to_send(
-            token="hf_123456789", endpoint=None, is_write_action=True
-        )
-
-    @patch("huggingface_hub.utils._headers._is_valid_token")
-    def test_validate_token_to_send_check_token_validity(
-        self, mock__is_valid_token: Mock
-    ) -> None:
-        mock__is_valid_token.return_value = True
-        _validate_token_to_send(
-            token=FAKE_TOKEN, endpoint=FAKE_ENDPOINT, is_write_action=False
-        )
-        mock__is_valid_token.assert_called_once_with(FAKE_ENDPOINT, FAKE_TOKEN)
-
-    @patch("huggingface_hub.utils._headers._is_valid_token")
-    def test_validate_token_to_send_check_token_validity_not_valid(
-        self, mock__is_valid_token: Mock
-    ) -> None:
-        mock__is_valid_token.return_value = False
+    def test_write_action_none_token(self, mock_HfFolder: Mock) -> None:
+        mock_HfFolder().get_token.return_value = None
         with self.assertRaises(ValueError):
-            _validate_token_to_send(
-                token=FAKE_TOKEN, endpoint=FAKE_ENDPOINT, is_write_action=False
-            )
-        mock__is_valid_token.assert_called_once_with(FAKE_ENDPOINT, FAKE_TOKEN)
+            build_hf_headers(is_write_action=True)
 
-
-class TestHeadersUtilsIsPrivate(unittest.TestCase):
-    def test_is_private_all_none(self) -> None:
+    def test_write_action_use_auth_token_false(self) -> None:
         with self.assertRaises(ValueError):
-            _is_private(url=None, endpoint=None, repo_id=None, repo_type=None)
-
-    @patch("huggingface_hub.utils._headers.requests.head")
-    def test_is_private_url_public_repo(self, mock_head: Mock) -> None:
-        mock_head.status_code = 200
-        self.assertFalse(
-            _is_private(url=FAKE_URL, endpoint=None, repo_id=None, repo_type=None)
-        )
-        mock_head.assert_called_once_with(FAKE_URL)
-
-    @patch("huggingface_hub.utils._headers.requests.head")
-    @patch("huggingface_hub.utils._headers.hf_raise_for_status")
-    @handle_injection_in_test
-    def test_is_private_url_private_repo(self, mock_hf_raise_for_status: Mock) -> None:
-        mock_hf_raise_for_status.side_effect = RepositoryNotFoundError(
-            "repo not found", response=None
-        )
-        self.assertTrue(
-            _is_private(url=FAKE_URL, endpoint=None, repo_id=None, repo_type=None)
-        )
-
-    @patch("huggingface_hub.utils._headers.requests.head")
-    @patch("huggingface_hub.utils._headers.hf_raise_for_status")
-    @handle_injection_in_test
-    def test_is_private_on_url_any_error(self, mock_hf_raise_for_status: Mock) -> None:
-        mock_hf_raise_for_status.side_effect = Exception()
-        self.assertFalse(
-            _is_private(url=FAKE_URL, endpoint=None, repo_id=None, repo_type=None)
-        )
-
-    def test_is_private_generic_api_call(self) -> None:
-        self.assertFalse(
-            _is_private(url=None, endpoint=FAKE_ENDPOINT, repo_id=None, repo_type=None)
-        )
-
-    @patch("huggingface_hub.utils._headers.requests.head")
-    @handle_injection_in_test
-    def test_is_private_on_public_model(self, mock_head: Mock) -> None:
-        mock_head.status_code = 200
-        self.assertFalse(
-            _is_private(
-                url=None, endpoint=FAKE_ENDPOINT, repo_id="model_1", repo_type=None
-            )
-        )
-        mock_head.assert_called_once_with(f"{FAKE_ENDPOINT}/api/models/model_1")
-
-    @patch("huggingface_hub.utils._headers.requests.head")
-    @handle_injection_in_test
-    def test_is_private_on_public_dataset(self, mock_head: Mock) -> None:
-        mock_head.status_code = 200
-        self.assertFalse(
-            _is_private(
-                url=None,
-                endpoint=FAKE_ENDPOINT,
-                repo_id="dataset_1",
-                repo_type="dataset",
-            )
-        )
-        mock_head.assert_called_once_with(f"{FAKE_ENDPOINT}/api/datasets/dataset_1")
-
-    @patch("huggingface_hub.utils._headers.requests.head")
-    @patch("huggingface_hub.utils._headers.hf_raise_for_status")
-    @handle_injection_in_test
-    def test_is_private_on_private_model(self, mock_hf_raise_for_status: Mock) -> None:
-        mock_hf_raise_for_status.side_effect = RepositoryNotFoundError(
-            "repo not found", response=None
-        )
-        self.assertTrue(
-            _is_private(
-                url=None, endpoint=FAKE_ENDPOINT, repo_id="model_1", repo_type=None
-            )
-        )
-
-    @patch("huggingface_hub.utils._headers.requests.head")
-    @patch("huggingface_hub.utils._headers.hf_raise_for_status")
-    @handle_injection_in_test
-    def test_is_private_on_repo_any_error(self, mock_hf_raise_for_status: Mock) -> None:
-        mock_hf_raise_for_status.side_effect = Exception("not found")
-        self.assertFalse(
-            _is_private(
-                url=None, endpoint=FAKE_ENDPOINT, repo_id="model_1", repo_type=None
-            )
-        )
-
-
-class TestHeadersUtilsIsValid(unittest.TestCase):
-    @patch("huggingface_hub.utils._headers.requests.get")
-    def test_token_is_valid_on_valid_token(self, mock_get: Mock) -> None:
-        mock_get.status_code = 200
-        self.assertTrue(_is_valid_token(endpoint=FAKE_ENDPOINT, token=FAKE_TOKEN))
-
-        mock_get.assert_called_once_with(
-            f"{FAKE_ENDPOINT}/api/whoami-v2",
-            headers={"authorization": f"Bearer {FAKE_TOKEN}"},
-        )
-
-    @patch("huggingface_hub.utils._headers.requests.get")
-    @patch("huggingface_hub.utils._headers.hf_raise_for_status")
-    @handle_injection_in_test
-    def test_token_is_valid_on_not_valid_token(
-        self, mock_hf_raise_for_status: Mock
-    ) -> None:
-        mock_hf_raise_for_status.side_effect = Exception
-        self.assertFalse(_is_valid_token(endpoint=FAKE_ENDPOINT, token=FAKE_TOKEN))
+            build_hf_headers(use_auth_token=False, is_write_action=True)

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -383,6 +383,17 @@ def handle_injection(cls: T) -> T:
 def handle_injection_in_test(fn: Callable) -> Callable:
     """
     Handle injections at a test level. See `handle_injection` for more details.
+
+    Example:
+    ```py
+    def TestHelloWorld(unittest.TestCase):
+
+        @patch("something.foo")
+        @patch("something_else.foo.bar") # order doesn't matter
+        @handle_injection_in_test # after @patch calls
+        def test_hello_foo(self, mock_foo: Mock) -> None:
+            (...)
+    ```
     """
     signature = inspect.signature(fn)
     parameters = signature.parameters

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -370,49 +370,52 @@ def handle_injection(cls: T) -> T:
 
     NOTE: this decorator is inspired from the fixture system from pytest.
     """
-
-    def _test_decorator(fn: Callable) -> Callable:
-        signature = inspect.signature(fn)
-        parameters = signature.parameters
-
-        @wraps(fn)
-        def _inner(*args, **kwargs):
-            assert kwargs == {}
-
-            # Initialize new dict at least with `self`.
-            assert len(args) > 0
-            assert len(parameters) > 0
-            new_kwargs = {"self": args[0]}
-
-            # Check which mocks have been injected
-            mocks = {}
-            for value in args[1:]:
-                assert isinstance(value, Mock)
-                mock_name = "mock_" + value._extract_mock_name()
-                mocks[mock_name] = value
-
-            # Check which mocks are expected
-            for name, parameter in parameters.items():
-                if name == "self":
-                    continue
-                assert parameter.annotation is Mock
-                assert name in mocks, (
-                    f"Mock `{name}` not found for test `{fn.__name__}`. Available:"
-                    f" {', '.join(sorted(mocks.keys()))}"
-                )
-                new_kwargs[name] = mocks[name]
-
-            # Run test only with a subset of mocks
-            return fn(**new_kwargs)
-
-        return _inner
-
     # Iterate over class functions and decorate tests
     # Taken from https://stackoverflow.com/a/3467879
     #        and https://stackoverflow.com/a/30764825
     for name, fn in inspect.getmembers(cls):
         if name.startswith("test_"):
-            setattr(cls, name, _test_decorator(fn))
+            setattr(cls, name, handle_injection_in_test(fn))
 
     # Return decorated class
     return cls
+
+
+def handle_injection_in_test(fn: Callable) -> Callable:
+    """
+    Handle injections at a test level. See `handle_injection` for more details.
+    """
+    signature = inspect.signature(fn)
+    parameters = signature.parameters
+
+    @wraps(fn)
+    def _inner(*args, **kwargs):
+        assert kwargs == {}
+
+        # Initialize new dict at least with `self`.
+        assert len(args) > 0
+        assert len(parameters) > 0
+        new_kwargs = {"self": args[0]}
+
+        # Check which mocks have been injected
+        mocks = {}
+        for value in args[1:]:
+            assert isinstance(value, Mock)
+            mock_name = "mock_" + value._extract_mock_name()
+            mocks[mock_name] = value
+
+        # Check which mocks are expected
+        for name, parameter in parameters.items():
+            if name == "self":
+                continue
+            assert parameter.annotation is Mock
+            assert name in mocks, (
+                f"Mock `{name}` not found for test `{fn.__name__}`. Available:"
+                f" {', '.join(sorted(mocks.keys()))}"
+            )
+            new_kwargs[name] = mocks[name]
+
+        # Run test only with a subset of mocks
+        return fn(**new_kwargs)
+
+    return _inner


### PR DESCRIPTION
TLDR; this works with this PR:

```py
# Using cached token from `huggingface-cli login`
file = hf_hub_download("CompVis/stable-diffusion-v1-4", "README.md")
```

---
(cc @julien-c @osanseviero @LysandreJik @apolinario @patrickvonplaten @Pierrci)
Fix https://github.com/huggingface/huggingface_hub/issues/926.

(related to [this discussion](https://huggingface.slack.com/archives/C03V11RNS7P/p1663331447986929) (internal link), [this discussion](https://huggingface.slack.com/archives/C02EMARJ65P/p1663771575035239) and [this discussion](https://docs.google.com/document/d/1ZE0pM8kry56Qtob5mIAYuGi5ZKpR8zTNnekEvPHtDgU/edit) as well (internal link))

The goal is to have a centralized way to handle tokens in `huggingface_hub` (and downstream libraries) that causes as low friction as possible for the users.

~The idea here is to keep the rule "if token is not explicitly set and is not required then do not pass it in header so that the user is cannot be tracked on public repos". This PR aims to solve that by making a HEAD call to the Hub (without auth) to check if a repo is public or private. In case of a private repo, the token is then automatically sent to the Hub in all subsequent calls (the "private" property of a repo is cached).~

## EDIT: strategy has been revisited

The problem that has been formulated is that if a user wants to download files from a gated/private repos, they currently need to pass `use_auth_token=True` even though the user is logged in. This PR solves that by always sending the cached token if the user is logged in. This is a big change compared to the previous rule that was "don't send the token if not explicitly needed".  Hope is to reduce as much friction as possible.

This PR and the `build_hf_headers` helper aims also to harmonize how tokens are handled and validated across the platform.

**Examples:**
```py
# Get auth header
headers = build_hf_headers(use_auth_token="hf_***") # explicit token
headers = build_hf_headers(use_auth_token=True) # explicitly use cached token
headers = build_hf_headers(use_auth_token=False) # explicitly don't use cached token
headers = build_hf_headers() # implicit use of the cached token

DISABLE_IMPLICIT_HF_TOKEN=True # to set as env variable
headers = build_hf_headers() # token is not sent
```

```py
# Cannot use api_org tokens on write calls
headers = build_hf_headers(use_auth_token="api_org_***")
headers = build_hf_headers(use_auth_token="api_org_***", is_write_action=True) # throws an error !
```

(note: this PR also gets rid of the `datasets` dependency in the tests but that kinda unrelated. I got an issue with it that I reported [in this PR](https://github.com/huggingface/datasets/issues/4990))

(edit: once that's reviewed and merged, implementing https://github.com/huggingface/huggingface_hub/issues/1018 should be straightforward)