### PR TITLE
Return more information in create_commit output

### DIFF
--- a/docs/source/package_reference/hf_api.mdx
+++ b/docs/source/package_reference/hf_api.mdx
@@ -25,15 +25,29 @@ models = hf_api.list_models()
 
 Using the `HfApi` class directly enables you to set a different endpoint to that of the Hugging Face's Hub.
 
+### HfApi
+
 [[autodoc]] HfApi
+
+### ModelInfo
 
 [[autodoc]] huggingface_hub.hf_api.ModelInfo
 
+### DatasetInfo
+
 [[autodoc]] huggingface_hub.hf_api.DatasetInfo
+
+### SpaceInfo
 
 [[autodoc]] huggingface_hub.hf_api.SpaceInfo
 
+### RepoFile
+
 [[autodoc]] huggingface_hub.hf_api.RepoFile
+
+### CommitInfo
+
+[[autodoc]] huggingface_hub.hf_api.CommitInfo
 
 ## `create_commit` API
 
@@ -56,10 +70,18 @@ It does this using the [`HfFolder`] utility, which saves data at the root of the
 
 Some helpers to filter repositories on the Hub are available in the `huggingface_hub` package.
 
+### DatasetFilter
+
 [[autodoc]] DatasetFilter
+
+### ModelFilter
 
 [[autodoc]] ModelFilter
 
+### DatasetSearchArguments
+
 [[autodoc]] DatasetSearchArguments
+
+### ModelSearchArguments
 
 [[autodoc]] ModelSearchArguments

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -103,6 +103,7 @@ _SUBMOD_ATTRS = {
         "change_discussion_status",
         "comment_discussion",
         "create_commit",
+        "CommitInfo",
         "create_discussion",
         "create_pull_request",
         "create_repo",

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -16,6 +16,7 @@ import os
 import re
 import subprocess
 import warnings
+from dataclasses import dataclass
 from os.path import expanduser
 from typing import BinaryIO, Dict, Iterable, Iterator, List, Optional, Tuple, Union
 from urllib.parse import quote
@@ -168,6 +169,37 @@ def repo_type_and_id_from_hf_id(
 class BlobLfsInfo(TypedDict, total=False):
     size: int
     sha256: str
+
+
+@dataclass
+class CommitInfo:
+    """Data structure containing information about a newly created commit.
+
+    Returned by `create_commit(...)`.
+
+    Args:
+        commit_url (str):
+            Url where to find the commit.
+
+        commit_message (str):
+            The summary (first line) of the commit that has been created.
+
+        commit_description (str):
+            Description of the commit that has been created. Can be empty.
+
+        oid (str):
+            Commit hash id. Example: `"91c54ad1727ee830252e457677f467be0bfd8a57"`.
+
+        pr_url (str, *optional*):
+            Url to the PR that has been created, if any. Populated when `create_pr=True`
+            is passed.
+    """
+
+    commit_url: str
+    commit_message: str
+    commit_description: str
+    oid: str
+    pr_url: Optional[str] = None
 
 
 class RepoFile:
@@ -1953,7 +1985,7 @@ class HfApi:
         create_pr: Optional[bool] = None,
         num_threads: int = 5,
         parent_commit: Optional[str] = None,
-    ) -> Optional[str]:
+    ) -> CommitInfo:
         """
         Creates a commit in the given repo, deleting & uploading files as needed.
 
@@ -2005,9 +2037,9 @@ class HfApi:
                 if the repo is updated / committed to concurrently.
 
         Returns:
-            `str` or `None`:
-                If `create_pr` is `True`, returns the URL to the newly created Pull Request
-                on the Hub. Otherwise returns `None`.
+            [`CommitInfo`]:
+                Instance of [`CommitInfo`] containing information about the newly
+                created commit (commit hash, commit url, pr url, commit message,...).
 
         Raises:
             [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
@@ -2118,7 +2150,14 @@ class HfApi:
             params={"create_pr": "1"} if create_pr else None,
         )
         hf_raise_for_status(commit_resp, endpoint_name="commit")
-        return commit_resp.json().get("pullRequestUrl", None)
+        commit_data = commit_resp.json()
+        return CommitInfo(
+            commit_url=commit_data["commitUrl"],
+            commit_message=commit_message,
+            commit_description=commit_description,
+            oid=commit_data["commitOid"],
+            pr_url=commit_data["pullRequestUrl"] if create_pr else None,
+        )
 
     @validate_hf_hub_args
     def upload_file(
@@ -2260,7 +2299,7 @@ class HfApi:
             path_in_repo=path_in_repo,
         )
 
-        pr_url = self.create_commit(
+        commit_info = self.create_commit(
             repo_id=repo_id,
             repo_type=repo_type,
             operations=[operation],
@@ -2272,8 +2311,8 @@ class HfApi:
             parent_commit=parent_commit,
         )
 
-        if pr_url is not None:
-            revision = quote(_parse_revision_from_pr_url(pr_url), safe="")
+        if commit_info.pr_url is not None:
+            revision = quote(_parse_revision_from_pr_url(commit_info.pr_url), safe="")
         if repo_type in REPO_TYPES_URL_PREFIXES:
             repo_id = REPO_TYPES_URL_PREFIXES[repo_type] + repo_id
         revision = revision if revision is not None else DEFAULT_REVISION
@@ -2420,7 +2459,7 @@ class HfApi:
             ignore_patterns=ignore_patterns,
         )
 
-        pr_url = self.create_commit(
+        commit_info = self.create_commit(
             repo_type=repo_type,
             repo_id=repo_id,
             operations=files_to_add,
@@ -2432,8 +2471,8 @@ class HfApi:
             parent_commit=parent_commit,
         )
 
-        if pr_url is not None:
-            revision = quote(_parse_revision_from_pr_url(pr_url), safe="")
+        if commit_info.pr_url is not None:
+            revision = quote(_parse_revision_from_pr_url(commit_info.pr_url), safe="")
         if repo_type in REPO_TYPES_URL_PREFIXES:
             repo_id = REPO_TYPES_URL_PREFIXES[repo_type] + repo_id
         revision = revision if revision is not None else DEFAULT_REVISION
@@ -2453,7 +2492,7 @@ class HfApi:
         commit_description: Optional[str] = None,
         create_pr: Optional[bool] = None,
         parent_commit: Optional[str] = None,
-    ):
+    ) -> CommitInfo:
         """
         Deletes a file in the given repo.
 

--- a/src/huggingface_hub/keras_mixin.py
+++ b/src/huggingface_hub/keras_mixin.py
@@ -458,7 +458,7 @@ def push_to_hub_keras(
                 allow_patterns=allow_patterns,
                 ignore_patterns=ignore_patterns,
             )
-            pr_url = api.create_commit(
+            commit_info = api.create_commit(
                 repo_type="model",
                 repo_id=repo_id,
                 operations=operations,
@@ -470,8 +470,8 @@ def push_to_hub_keras(
             revision = branch
             if revision is None:
                 revision = (
-                    quote(_parse_revision_from_pr_url(pr_url), safe="")
-                    if pr_url is not None
+                    quote(_parse_revision_from_pr_url(commit_info.pr_url), safe="")
+                    if commit_info.pr_url is not None
                     else DEFAULT_REVISION
                 )
             return f"{api.endpoint}/{repo_id}/tree/{revision}/"

--- a/src/huggingface_hub/utils/_validators.py
+++ b/src/huggingface_hub/utils/_validators.py
@@ -17,7 +17,7 @@ import inspect
 import re
 from functools import wraps
 from itertools import chain
-from typing import Callable
+from typing import Callable, TypeVar
 
 
 REPO_ID_REGEX = re.compile(
@@ -40,7 +40,11 @@ class HFValidationError(ValueError):
     """
 
 
-def validate_hf_hub_args(fn: Callable) -> Callable:
+# type hint meaning "function signature not changed by decorator"
+CT = TypeVar("CT")  # callable type
+
+
+def validate_hf_hub_args(fn: CT) -> CT:
     """Validate values received as argument for any public method of `huggingface_hub`.
 
     The goal of this decorator is to harmonize validation of arguments reused


### PR DESCRIPTION
Fix https://github.com/huggingface/huggingface_hub/issues/1037.

Now `create_commit` returns a `CommitInfo` data structure containing commit hash, commit url, commit message, commit description and eventually pr url. This way the return type is more consistent than returning only `pr_url` (string) or `None` depending on the `create_pr` parameter.

⚠️⚠️⚠️ This is a breaking change compared to previous behavior ⚠️⚠️⚠️
The hope is that `create_commit` is already used in downstream libraries but the return value is not. Better to change it now than later.
@sgugger there is one implication in `transformers` [here](https://github.com/huggingface/transformers/blob/main/src/transformers/commands/pt_to_tf.py#L370). It only changes a logger message so it's not critical and can be quite easily changed.

**Note:** `upload_file`, `upload_folder` and `push_to_hub` return types have not been changed as they were not returning the pr_url but a URL to either a file or a folder. 