### PR TITLE
Add user agent to all requests with `huggingface_hub` version (and other)

### DIFF
--- a/src/huggingface_hub/fastai_utils.py
+++ b/src/huggingface_hub/fastai_utils.py
@@ -18,6 +18,7 @@ from huggingface_hub.utils import (
 
 from .utils import logging, validate_hf_hub_args
 from .utils._deprecation import _deprecate_arguments, _deprecate_positional_args
+from .utils._runtime import _PY_VERSION  # noqa: F401 # for backward compatibility...
 
 
 logger = logging.get_logger(__name__)

--- a/src/huggingface_hub/fastai_utils.py
+++ b/src/huggingface_hub/fastai_utils.py
@@ -9,12 +9,12 @@ from packaging import version
 
 from huggingface_hub import snapshot_download
 from huggingface_hub.constants import CONFIG_NAME
-from huggingface_hub.file_download import (
-    _PY_VERSION,
+from huggingface_hub.hf_api import HfApi
+from huggingface_hub.utils import (
     get_fastai_version,
     get_fastcore_version,
+    get_python_version,
 )
-from huggingface_hub.hf_api import HfApi
 
 from .utils import logging, validate_hf_hub_args
 from .utils._deprecation import _deprecate_arguments, _deprecate_positional_args
@@ -214,7 +214,7 @@ More information needed
 """
 
 PYPROJECT_TEMPLATE = f"""[build-system]
-requires = ["setuptools>=40.8.0", "wheel", "python={_PY_VERSION}", "fastai={get_fastai_version()}", "fastcore={get_fastcore_version()}"]
+requires = ["setuptools>=40.8.0", "wheel", "python={get_python_version()}", "fastai={get_fastai_version()}", "fastcore={get_fastcore_version()}"]
 build-backend = "setuptools.build_meta:__legacy__"
 """
 

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -20,7 +20,7 @@ from filelock import FileLock
 from huggingface_hub import constants
 from requests.exceptions import ConnectTimeout, ProxyError
 
-from . import __version__  # noqa: F401
+from . import __version__  # noqa: F401 # for backward compatibility
 from .constants import (
     DEFAULT_REVISION,
     HUGGINGFACE_CO_URL_TEMPLATE,
@@ -56,6 +56,7 @@ from .utils import (
     validate_hf_hub_args,
 )
 from .utils._headers import _http_user_agent
+from .utils._runtime import _PY_VERSION  # noqa: F401 # for backward compatibility
 
 
 logger = logging.get_logger(__name__)

--- a/src/huggingface_hub/keras_mixin.py
+++ b/src/huggingface_hub/keras_mixin.py
@@ -10,7 +10,7 @@ from urllib.parse import quote
 
 import yaml
 from huggingface_hub import CommitOperationDelete, ModelHubMixin, snapshot_download
-from huggingface_hub.file_download import (
+from huggingface_hub.utils import (
     get_tf_version,
     is_graphviz_available,
     is_pydot_available,

--- a/src/huggingface_hub/repocard.py
+++ b/src/huggingface_hub/repocard.py
@@ -13,7 +13,7 @@ else:
 
 import requests
 import yaml
-from huggingface_hub.file_download import hf_hub_download, is_jinja_available
+from huggingface_hub.file_download import hf_hub_download
 from huggingface_hub.hf_api import upload_file
 from huggingface_hub.repocard_data import (
     CardData,
@@ -23,6 +23,7 @@ from huggingface_hub.repocard_data import (
     eval_results_to_model_index,
     model_index_to_eval_results,
 )
+from huggingface_hub.utils import is_jinja_available
 
 from .constants import REPOCARD_NAME
 from .utils import validate_hf_hub_args

--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -39,6 +39,24 @@ from ._headers import build_hf_headers
 from ._hf_folder import HfFolder
 from ._http import http_backoff
 from ._paths import filter_repo_objects
+from ._runtime import (
+    get_fastai_version,
+    get_fastcore_version,
+    get_graphviz_version,
+    get_hf_hub_version,
+    get_jinja_version,
+    get_pydot_version,
+    get_python_version,
+    get_tf_version,
+    get_torch_version,
+    is_fastai_available,
+    is_fastcore_available,
+    is_graphviz_available,
+    is_jinja_available,
+    is_pydot_available,
+    is_tf_available,
+    is_torch_available,
+)
 from ._subprocess import run_subprocess
 from ._validators import HFValidationError, validate_hf_hub_args, validate_repo_id
 from .tqdm import (

--- a/src/huggingface_hub/utils/_headers.py
+++ b/src/huggingface_hub/utils/_headers.py
@@ -66,10 +66,10 @@ def build_hf_headers(
             Set to True if the API call requires a write access. If `True`, the token
             will be validated (cannot be `None`, cannot start by `"api_org***"`).
         library_name (`str`, *optional*):
-            The name of the library that his making the HTTP request. Will be added to
+            The name of the library that is making the HTTP request. Will be added to
             the user-agent header.
         library_version (`str`, *optional*):
-            The version of the library that his making the HTTP request. Will be added
+            The version of the library that is making the HTTP request. Will be added
             to the user-agent header.
         user_agent (`str`, `dict`, *optional*):
             The user agent info in the form of a dictionary or a single string. It will
@@ -187,9 +187,9 @@ def _http_user_agent(
 
     Args:
         library_name (`str`, *optional*):
-            The name of the library that his making the HTTP request.
+            The name of the library that is making the HTTP request.
         library_version (`str`, *optional*):
-            The version of the library that his making the HTTP request.
+            The version of the library that is making the HTTP request.
         user_agent (`str`, `dict`, *optional*):
             The user agent info in the form of a dictionary or a single string.
 

--- a/src/huggingface_hub/utils/_headers.py
+++ b/src/huggingface_hub/utils/_headers.py
@@ -100,7 +100,7 @@ def build_hf_headers(
         ValueError: You must use your personal account token for write-access methods.
 
         >>> build_hf_headers(library_name="transformers", library_version="1.2.3")
-        {"user-agent": "transformers/1.2.3; hf_hub/0.10.2; python/3.10.4; tensorflow/1.55"}
+        {"authorization": ..., "user-agent": "transformers/1.2.3; hf_hub/0.10.2; python/3.10.4; tensorflow/1.55"}
     ```
 
     Raises:

--- a/src/huggingface_hub/utils/_headers.py
+++ b/src/huggingface_hub/utils/_headers.py
@@ -17,10 +17,27 @@ import os
 from typing import Dict, Optional, Union
 
 from ._hf_folder import HfFolder
+from ._runtime import (
+    get_fastai_version,
+    get_fastcore_version,
+    get_hf_hub_version,
+    get_python_version,
+    get_tf_version,
+    get_torch_version,
+    is_fastai_available,
+    is_fastcore_available,
+    is_tf_available,
+    is_torch_available,
+)
 
 
 def build_hf_headers(
-    *, use_auth_token: Optional[Union[bool, str]] = None, is_write_action: bool = False
+    *,
+    use_auth_token: Optional[Union[bool, str]] = None,
+    is_write_action: bool = False,
+    library_name: Optional[str] = None,
+    library_version: Optional[str] = None,
+    user_agent: Union[Dict, str, None] = None,
 ) -> Dict[str, str]:
     """
     Build headers dictionary to send in a HF Hub call.
@@ -33,6 +50,10 @@ def build_hf_headers(
     In case of an API call that requires write access, an error is thrown if token is
     `None` or token is an organization token (starting with `"api_org***"`).
 
+    In addition to the auth header, a user-agent is added to provide information about
+    the installed packages (versions of python, huggingface_hub, torch, tensorflow,
+    fastai and fastcore).
+
     Args:
         use_auth_token (`str`, `bool`, *optional*):
             The token to be sent in authorization header for the Hub call:
@@ -44,6 +65,15 @@ def build_hf_headers(
         is_write_action (`bool`, default to `False`):
             Set to True if the API call requires a write access. If `True`, the token
             will be validated (cannot be `None`, cannot start by `"api_org***"`).
+        library_name (`str`, *optional*):
+            The name of the library that his making the HTTP request. Will be added to
+            the user-agent header.
+        library_version (`str`, *optional*):
+            The version of the library that his making the HTTP request. Will be added
+            to the user-agent header.
+        user_agent (`str`, `dict`, *optional*):
+            The user agent info in the form of a dictionary or a single string. It will
+            be completed with information about the installed packages.
 
     Returns:
         A `Dict` of headers to pass in your API call.
@@ -51,20 +81,20 @@ def build_hf_headers(
     Example:
     ```py
         >>> build_hf_headers(use_auth_token="hf_***") # explicit token
-        {"authorization": "Bearer hf_***"}
+        {"authorization": "Bearer hf_***", "user-agent": ""}
 
         >>> build_hf_headers(use_auth_token=True) # explicitly use cached token
-        {"authorization": "Bearer hf_***"}
+        {"authorization": "Bearer hf_***",...}
 
         >>> build_hf_headers(use_auth_token=False) # explicitly don't use cached token
-        {}
+        {"user-agent": ...}
 
         >>> build_hf_headers() # implicit use of the cached token
-        {"authorization": "Bearer hf_***"}
+        {"authorization": "Bearer hf_***",...}
 
         # HF_HUB_DISABLE_IMPLICIT_TOKEN=True # to set as env variable
         >>> build_hf_headers() # token is not sent
-        {}
+        {"user-agent": ...}
 
         >>> build_hf_headers(use_auth_token="api_org_***", is_write_action=True)
         ValueError: You must use your personal account token for write-access methods.
@@ -83,10 +113,15 @@ def build_hf_headers(
     _validate_token_to_send(token_to_send, is_write_action=is_write_action)
 
     # Combine headers
-    headers = {}
+    headers = {
+        "user-agent": _http_user_agent(
+            library_name=library_name,
+            library_version=library_version,
+            user_agent=user_agent,
+        )
+    }
     if token_to_send is not None:
         headers["authorization"] = f"Bearer {token_to_send}"
-    # TODO: add user agent in headers
     return headers
 
 
@@ -137,3 +172,43 @@ def _validate_token_to_send(token: Optional[str], is_write_action: bool) -> None
                 " generate a write-access token, go to"
                 " https://huggingface.co/settings/tokens"
             )
+
+
+def _http_user_agent(
+    *,
+    library_name: Optional[str] = None,
+    library_version: Optional[str] = None,
+    user_agent: Union[Dict, str, None] = None,
+) -> str:
+    """Format a user-agent string containing information about the installed packages.
+
+    Args:
+        library_name (`str`, *optional*):
+            The name of the library that his making the HTTP request.
+        library_version (`str`, *optional*):
+            The version of the library that his making the HTTP request.
+        user_agent (`str`, `dict`, *optional*):
+            The user agent info in the form of a dictionary or a single string.
+
+    Returns:
+        The formatted user-agent string.
+    """
+    if library_name is not None:
+        ua = f"{library_name}/{library_version}"
+    else:
+        ua = "unknown/None"
+    ua += f"; hf_hub/{get_hf_hub_version()}"
+    ua += f"; python/{get_python_version()}"
+    if is_torch_available():
+        ua += f"; torch/{get_torch_version()}"
+    if is_tf_available():
+        ua += f"; tensorflow/{get_tf_version()}"
+    if is_fastai_available():
+        ua += f"; fastai/{get_fastai_version()}"
+    if is_fastcore_available():
+        ua += f"; fastcore/{get_fastcore_version()}"
+    if isinstance(user_agent, dict):
+        ua += "; " + "; ".join(f"{k}/{v}" for k, v in user_agent.items())
+    elif isinstance(user_agent, str):
+        ua += "; " + user_agent
+    return ua

--- a/src/huggingface_hub/utils/_headers.py
+++ b/src/huggingface_hub/utils/_headers.py
@@ -98,6 +98,9 @@ def build_hf_headers(
 
         >>> build_hf_headers(use_auth_token="api_org_***", is_write_action=True)
         ValueError: You must use your personal account token for write-access methods.
+
+        >>> build_hf_headers(library_name="transformers", library_version="1.2.3")
+        {"user-agent": "transformers/1.2.3; hf_hub/0.10.2; python/3.10.4; tensorflow/1.55"}
     ```
 
     Raises:

--- a/src/huggingface_hub/utils/_runtime.py
+++ b/src/huggingface_hub/utils/_runtime.py
@@ -1,0 +1,129 @@
+import sys
+from typing import Optional
+
+import packaging.version
+
+from .. import __version__
+
+
+_PY_VERSION: str = sys.version.split()[0].rstrip("+")
+
+if packaging.version.Version(_PY_VERSION) < packaging.version.Version("3.8.0"):
+    import importlib_metadata
+else:
+    import importlib.metadata as importlib_metadata
+
+
+_package_versions = {}
+
+_CANDIDATES = {
+    "torch": {"torch"},
+    "pydot": {"pydot"},
+    "graphviz": {"graphviz"},
+    "tensorflow": (
+        "tensorflow",
+        "tensorflow-cpu",
+        "tensorflow-gpu",
+        "tf-nightly",
+        "tf-nightly-cpu",
+        "tf-nightly-gpu",
+        "intel-tensorflow",
+        "intel-tensorflow-avx512",
+        "tensorflow-rocm",
+        "tensorflow-macos",
+    ),
+    "fastai": {"fastai"},
+    "fastcore": {"fastcore"},
+    "jinja": {"Jinja2"},
+}
+
+# Check once at runtime
+for candidate_name, package_names in _CANDIDATES.items():
+    _package_versions[candidate_name] = "N/A"
+    for name in package_names:
+        try:
+            _package_versions[candidate_name] = importlib_metadata.version(name)
+            break
+        except importlib_metadata.PackageNotFoundError:
+            pass
+
+
+def _get_version(package_name: str) -> Optional[str]:
+    return _package_versions.get(package_name, "N/A")
+
+
+def _is_available(package_name: str) -> bool:
+    return _get_version(package_name) != "N/A"
+
+
+# Python
+def get_python_version() -> str:
+    return _PY_VERSION
+
+
+# Huggingface Hub
+def get_hf_hub_version() -> str:
+    return __version__
+
+
+# FastAI
+def is_fastai_available() -> bool:
+    return _is_available("fastai")
+
+
+def get_fastai_version() -> str:
+    return _get_version("fastai")
+
+
+# Fastcore
+def is_fastcore_available() -> bool:
+    return _is_available("fastcore")
+
+
+def get_fastcore_version() -> str:
+    return _get_version("fastcore")
+
+
+# Graphviz
+def is_graphviz_available() -> bool:
+    return _is_available("graphviz")
+
+
+def get_graphviz_version() -> str:
+    return _get_version("graphviz")
+
+
+# Jinja
+def is_jinja_available() -> bool:
+    return _is_available("jinja")
+
+
+def get_jinja_version() -> str:
+    return _get_version("jinja")
+
+
+# Pydot
+def is_pydot_available() -> bool:
+    return _is_available("pydot")
+
+
+def get_pydot_version() -> str:
+    return _get_version("pydot")
+
+
+# Tensorflow
+def is_tf_available() -> bool:
+    return _is_available("tensorflow")
+
+
+def get_tf_version() -> str:
+    return _get_version("tensorflow")
+
+
+# Torch
+def is_torch_available() -> bool:
+    return _is_available("torch")
+
+
+def get_torch_version() -> str:
+    return _get_version("torch")

--- a/src/huggingface_hub/utils/_runtime.py
+++ b/src/huggingface_hub/utils/_runtime.py
@@ -1,3 +1,18 @@
+# coding=utf-8
+# Copyright 2022-present, the HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Check presence of installed packages at runtime."""
 import sys
 from typing import Optional
 

--- a/tests/test_fastai_integration.py
+++ b/tests/test_fastai_integration.py
@@ -8,7 +8,7 @@ from huggingface_hub.fastai_utils import (
     from_pretrained_fastai,
     push_to_hub_fastai,
 )
-from huggingface_hub.file_download import (
+from huggingface_hub.utils import (
     is_fastai_available,
     is_fastcore_available,
     is_torch_available,

--- a/tests/test_hubmixin.py
+++ b/tests/test_hubmixin.py
@@ -6,10 +6,9 @@ import unittest
 from unittest.mock import Mock
 
 from huggingface_hub import HfApi, hf_hub_download
-from huggingface_hub.file_download import is_torch_available
 from huggingface_hub.hub_mixin import PyTorchModelHubMixin
 from huggingface_hub.repository import Repository
-from huggingface_hub.utils import logging
+from huggingface_hub.utils import is_torch_available, logging
 
 from .testing_constants import ENDPOINT_STAGING, TOKEN, USER
 from .testing_utils import expect_deprecation, repo_name, set_write_permission_and_retry

--- a/tests/test_keras_integration.py
+++ b/tests/test_keras_integration.py
@@ -8,11 +8,6 @@ import unittest
 import pytest
 
 from huggingface_hub import HfApi, hf_hub_download
-from huggingface_hub.file_download import (
-    is_graphviz_available,
-    is_pydot_available,
-    is_tf_available,
-)
 from huggingface_hub.keras_mixin import (
     KerasModelHubMixin,
     from_pretrained_keras,
@@ -20,7 +15,12 @@ from huggingface_hub.keras_mixin import (
     save_pretrained_keras,
 )
 from huggingface_hub.repository import Repository
-from huggingface_hub.utils import logging
+from huggingface_hub.utils import (
+    is_graphviz_available,
+    is_pydot_available,
+    is_tf_available,
+    logging,
+)
 
 from .testing_constants import ENDPOINT_STAGING, TOKEN, USER
 from .testing_utils import (

--- a/tests/test_repocard.py
+++ b/tests/test_repocard.py
@@ -36,12 +36,12 @@ from huggingface_hub import (
     metadata_update,
 )
 from huggingface_hub.constants import REPOCARD_NAME
-from huggingface_hub.file_download import hf_hub_download, is_jinja_available
+from huggingface_hub.file_download import hf_hub_download
 from huggingface_hub.hf_api import HfApi
 from huggingface_hub.repocard import RepoCard
 from huggingface_hub.repocard_data import CardData
 from huggingface_hub.repository import Repository
-from huggingface_hub.utils import logging
+from huggingface_hub.utils import is_jinja_available, logging
 
 from .testing_constants import (
     ENDPOINT_STAGING,

--- a/tests/test_tf_import.py
+++ b/tests/test_tf_import.py
@@ -1,7 +1,7 @@
 import sys
 import unittest
 
-from huggingface_hub.file_download import is_tf_available
+from huggingface_hub.utils import is_tf_available
 
 
 def require_tf(test_case):

--- a/tests/test_utils_headers.py
+++ b/tests/test_utils_headers.py
@@ -1,14 +1,29 @@
 import unittest
 from unittest.mock import Mock, patch
 
-from huggingface_hub.utils._headers import build_hf_headers
+from huggingface_hub.utils import (
+    get_fastai_version,
+    get_fastcore_version,
+    get_hf_hub_version,
+    get_python_version,
+    get_tf_version,
+    get_torch_version,
+)
+from huggingface_hub.utils._headers import _http_user_agent, build_hf_headers
 
-from .testing_utils import handle_injection
+from .testing_utils import handle_injection, handle_injection_in_test
 
+
+# Only for tests that are not related to user agent
+DEFAULT_USER_AGENT = _http_user_agent()
 
 FAKE_TOKEN = "123456789"
 FAKE_TOKEN_ORG = "api_org_123456789"
-FAKE_TOKEN_HEADER = {"authorization": f"Bearer {FAKE_TOKEN}"}
+FAKE_TOKEN_HEADER = {
+    "authorization": f"Bearer {FAKE_TOKEN}",
+    "user-agent": DEFAULT_USER_AGENT,
+}
+NO_AUTH_HEADER = {"user-agent": DEFAULT_USER_AGENT}
 
 
 @patch("huggingface_hub.utils._headers.HfFolder")
@@ -28,11 +43,11 @@ class TestAuthHeadersUtil(unittest.TestCase):
 
     def test_use_auth_token_false(self, mock_HfFolder: Mock) -> None:
         mock_HfFolder().get_token.return_value = FAKE_TOKEN
-        self.assertEqual(build_hf_headers(use_auth_token=False), {})
+        self.assertEqual(build_hf_headers(use_auth_token=False), NO_AUTH_HEADER)
 
     def test_use_auth_token_none_no_cached_token(self, mock_HfFolder: Mock) -> None:
         mock_HfFolder().get_token.return_value = None
-        self.assertEqual(build_hf_headers(), {})
+        self.assertEqual(build_hf_headers(), NO_AUTH_HEADER)
 
     def test_use_auth_token_none_has_cached_token(self, mock_HfFolder: Mock) -> None:
         mock_HfFolder().get_token.return_value = FAKE_TOKEN
@@ -54,7 +69,7 @@ class TestAuthHeadersUtil(unittest.TestCase):
     @patch.dict("os.environ", {"HF_HUB_DISABLE_IMPLICIT_TOKEN": "1"})
     def test_implicit_use_disabled(self, mock_HfFolder: Mock) -> None:
         mock_HfFolder().get_token.return_value = FAKE_TOKEN
-        self.assertEqual(build_hf_headers(), {})  # token is not sent
+        self.assertEqual(build_hf_headers(), NO_AUTH_HEADER)  # token is not sent
 
     @patch.dict("os.environ", {"HF_HUB_DISABLE_IMPLICIT_TOKEN": "1"})
     def test_implicit_use_disabled_but_explicit_use(self, mock_HfFolder: Mock) -> None:
@@ -62,3 +77,60 @@ class TestAuthHeadersUtil(unittest.TestCase):
 
         # This is not an implicit use so we still send it
         self.assertEqual(build_hf_headers(use_auth_token=True), FAKE_TOKEN_HEADER)
+
+
+class TestUserAgentHeadersUtil(unittest.TestCase):
+    def _get_user_agent(self, **kwargs) -> str:
+        return build_hf_headers(**kwargs)["user-agent"]
+
+    def test_default_user_agent(self) -> None:
+        self.assertEqual(
+            self._get_user_agent(),
+            f"unknown/None; hf_hub/{get_hf_hub_version()};"
+            f" python/{get_python_version()}; torch/{get_torch_version()};"
+            f" tensorflow/{get_tf_version()}; fastai/{get_fastai_version()};"
+            f" fastcore/{get_fastcore_version()}",
+        )
+
+    def test_user_agent_with_library_name_and_version(self) -> None:
+        self.assertTrue(
+            self._get_user_agent(
+                library_name="foo",
+                library_version="bar",
+            ).startswith("foo/bar;")
+        )
+
+    def test_user_agent_with_library_name_no_version(self) -> None:
+        self.assertTrue(
+            self._get_user_agent(library_name="foo").startswith("foo/None;")
+        )
+
+    def test_user_agent_with_custom_agent_string(self) -> None:
+        self.assertTrue(
+            self._get_user_agent(user_agent="this is a custom agent").endswith(
+                "this is a custom agent"
+            )
+        )
+
+    def test_user_agent_with_custom_agent_dict(self) -> None:
+        self.assertTrue(
+            self._get_user_agent(user_agent={"a": "b", "c": "d"}).endswith("a/b; c/d")
+        )
+
+    @patch("huggingface_hub.utils._headers.is_torch_available")
+    def test_user_agent_with_library_name_no_torch(
+        self, mock_is_torch_available: Mock
+    ) -> None:
+        mock_is_torch_available.return_value = False
+        self.assertNotIn("torch", self._get_user_agent())
+
+    @patch("huggingface_hub.utils._headers.is_torch_available")
+    @patch("huggingface_hub.utils._headers.is_tf_available")
+    @handle_injection_in_test
+    def test_user_agent_with_library_name_multiple_missing(
+        self, mock_is_torch_available: Mock, mock_is_tf_available: Mock
+    ) -> None:
+        mock_is_torch_available.return_value = False
+        mock_is_tf_available.return_value = False
+        self.assertNotIn("torch", self._get_user_agent())
+        self.assertNotIn("tensorflow", self._get_user_agent())

--- a/tests/test_utils_headers.py
+++ b/tests/test_utils_headers.py
@@ -1,14 +1,7 @@
 import unittest
 from unittest.mock import Mock, patch
 
-from huggingface_hub.utils import (
-    get_fastai_version,
-    get_fastcore_version,
-    get_hf_hub_version,
-    get_python_version,
-    get_tf_version,
-    get_torch_version,
-)
+from huggingface_hub.utils import get_hf_hub_version, get_python_version
 from huggingface_hub.utils._headers import _http_user_agent, build_hf_headers
 
 from .testing_utils import handle_injection, handle_injection_in_test
@@ -83,14 +76,52 @@ class TestUserAgentHeadersUtil(unittest.TestCase):
     def _get_user_agent(self, **kwargs) -> str:
         return build_hf_headers(**kwargs)["user-agent"]
 
-    def test_default_user_agent(self) -> None:
+    @patch("huggingface_hub.utils._headers.get_fastai_version")
+    @patch("huggingface_hub.utils._headers.get_fastcore_version")
+    @patch("huggingface_hub.utils._headers.get_tf_version")
+    @patch("huggingface_hub.utils._headers.get_torch_version")
+    @patch("huggingface_hub.utils._headers.is_fastai_available")
+    @patch("huggingface_hub.utils._headers.is_fastcore_available")
+    @patch("huggingface_hub.utils._headers.is_tf_available")
+    @patch("huggingface_hub.utils._headers.is_torch_available")
+    @handle_injection_in_test
+    def test_default_user_agent(
+        self,
+        mock_get_fastai_version: Mock,
+        mock_get_fastcore_version: Mock,
+        mock_get_tf_version: Mock,
+        mock_get_torch_version: Mock,
+        mock_is_fastai_available: Mock,
+        mock_is_fastcore_available: Mock,
+        mock_is_tf_available: Mock,
+        mock_is_torch_available: Mock,
+    ) -> None:
+        mock_get_fastai_version.return_value = "fastai_version"
+        mock_get_fastcore_version.return_value = "fastcore_version"
+        mock_get_tf_version.return_value = "tf_version"
+        mock_get_torch_version.return_value = "torch_version"
+        mock_is_fastai_available.return_value = True
+        mock_is_fastcore_available.return_value = True
+        mock_is_tf_available.return_value = True
+        mock_is_torch_available.return_value = True
         self.assertEqual(
             self._get_user_agent(),
             f"unknown/None; hf_hub/{get_hf_hub_version()};"
-            f" python/{get_python_version()}; torch/{get_torch_version()};"
-            f" tensorflow/{get_tf_version()}; fastai/{get_fastai_version()};"
-            f" fastcore/{get_fastcore_version()}",
+            f" python/{get_python_version()}; torch/torch_version;"
+            " tensorflow/tf_version; fastai/fastai_version;"
+            " fastcore/fastcore_version",
         )
+
+    @patch("huggingface_hub.utils._headers.is_torch_available")
+    @patch("huggingface_hub.utils._headers.is_tf_available")
+    @handle_injection_in_test
+    def test_user_agent_with_library_name_multiple_missing(
+        self, mock_is_torch_available: Mock, mock_is_tf_available: Mock
+    ) -> None:
+        mock_is_torch_available.return_value = False
+        mock_is_tf_available.return_value = False
+        self.assertNotIn("torch", self._get_user_agent())
+        self.assertNotIn("tensorflow", self._get_user_agent())
 
     def test_user_agent_with_library_name_and_version(self) -> None:
         self.assertTrue(
@@ -116,21 +147,3 @@ class TestUserAgentHeadersUtil(unittest.TestCase):
         self.assertTrue(
             self._get_user_agent(user_agent={"a": "b", "c": "d"}).endswith("a/b; c/d")
         )
-
-    @patch("huggingface_hub.utils._headers.is_torch_available")
-    def test_user_agent_with_library_name_no_torch(
-        self, mock_is_torch_available: Mock
-    ) -> None:
-        mock_is_torch_available.return_value = False
-        self.assertNotIn("torch", self._get_user_agent())
-
-    @patch("huggingface_hub.utils._headers.is_torch_available")
-    @patch("huggingface_hub.utils._headers.is_tf_available")
-    @handle_injection_in_test
-    def test_user_agent_with_library_name_multiple_missing(
-        self, mock_is_torch_available: Mock, mock_is_tf_available: Mock
-    ) -> None:
-        mock_is_torch_available.return_value = False
-        mock_is_tf_available.return_value = False
-        self.assertNotIn("torch", self._get_user_agent())
-        self.assertNotIn("tensorflow", self._get_user_agent())

--- a/tests/test_utils_runtime.py
+++ b/tests/test_utils_runtime.py
@@ -1,0 +1,5 @@
+import unittest
+
+
+class TestUtilsRuntime(unittest.TestCase):
+    pass

--- a/tests/test_utils_runtime.py
+++ b/tests/test_utils_runtime.py
@@ -1,5 +1,0 @@
-import unittest
-
-
-class TestUtilsRuntime(unittest.TestCase):
-    pass


### PR DESCRIPTION
Fix https://github.com/huggingface/huggingface_hub/issues/1018.

For the user agent, I took the same implementation as before (custom library name/version, python, huggingface_hub, tensorflow, torch, fastai, fastcore). This is only a first version, we can iterate afterwards if we want to update this rule.

I also moved all imports to a `_runtime.py` utility trying to keep backward compatibility everywhere for non private methods/attributes.

(cc @Kakulukian @Pierrci who where interested in having this)