### PR TITLE
Check symlinks support per directory instead of globally

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -200,8 +200,11 @@ def are_symlinks_supported(cache_dir: Union[str, Path, None] = None) -> bool:
             src_path = Path(tmpdir) / "dummy_file_src"
             src_path.touch()
             dst_path = Path(tmpdir) / "dummy_file_dst"
+
+            # Relative source path as in `_create_relative_symlink``
+            relative_src = os.path.relpath(src_path, start=os.path.dirname(dst_path))
             try:
-                os.symlink(src_path, dst_path)
+                os.symlink(relative_src, dst_path)
             except OSError:
                 # Likely running on Windows
                 _are_symlinks_supported_in_dir[cache_dir] = False

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -196,6 +196,7 @@ def are_symlinks_supported(cache_dir: Union[str, Path, None] = None) -> bool:
     if cache_dir not in _are_symlinks_supported_in_dir:
         _are_symlinks_supported_in_dir[cache_dir] = True
 
+        os.makedirs(cache_dir, exist_ok=True)
         with tempfile.TemporaryDirectory(dir=cache_dir) as tmpdir:
             src_path = Path(tmpdir) / "dummy_file_src"
             src_path.touch()

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -172,17 +172,31 @@ def get_jinja_version():
     return _jinja_version
 
 
-_are_symlinks_supported: Optional[bool] = None
+_are_symlinks_supported_in_dir: Dict[str, bool] = {}
 
 
-def are_symlinks_supported() -> bool:
-    # Check symlink compatibility only once at first time use
-    global _are_symlinks_supported
+def are_symlinks_supported(cache_dir: Union[str, Path, None] = None) -> bool:
+    """Return whether the symlinks are supported on the machine.
 
-    if _are_symlinks_supported is None:
-        _are_symlinks_supported = True
+    Since symlinks support can change depending on the mounted disk, we need to check
+    on the precise cache folder. By default, the default HF cache directory is checked.
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+    Args:
+        cache_dir (`str`, `Path`, *optional*):
+            Path to the folder where cached files are stored.
+
+    Returns: [bool] Whether symlinks are supported in the directory.
+    """
+    # Defaults to HF cache
+    if cache_dir is None:
+        cache_dir = HUGGINGFACE_HUB_CACHE
+    cache_dir = str(Path(cache_dir).expanduser().resolve())  # make it unique
+
+    # Check symlink compatibility only once (per cache directory) at first time use
+    if cache_dir not in _are_symlinks_supported_in_dir:
+        _are_symlinks_supported_in_dir[cache_dir] = True
+
+        with tempfile.TemporaryDirectory(dir=cache_dir) as tmpdir:
             src_path = Path(tmpdir) / "dummy_file_src"
             src_path.touch()
             dst_path = Path(tmpdir) / "dummy_file_dst"
@@ -190,15 +204,15 @@ def are_symlinks_supported() -> bool:
                 os.symlink(src_path, dst_path)
             except OSError:
                 # Likely running on Windows
-                _are_symlinks_supported = False
+                _are_symlinks_supported_in_dir[cache_dir] = False
 
                 if not os.environ.get("DISABLE_SYMLINKS_WARNING"):
                     message = (
                         "`huggingface_hub` cache-system uses symlinks by default to"
-                        " efficiently store duplicated files but your machine doesn't"
-                        " support them. Caching files will still work but in a degraded"
-                        " version that might require more space on your disk. This"
-                        " warning can be disabled by setting the"
+                        " efficiently store duplicated files but your machine does not"
+                        f" support them in {cache_dir}. Caching files will still work"
+                        " but in a degraded version that might require more space on"
+                        " your disk. This warning can be disabled by setting the"
                         " `DISABLE_SYMLINKS_WARNING` environment variable. For more"
                         " details, see"
                         " https://huggingface.co/docs/huggingface_hub/how-to-cache#limitations."
@@ -213,7 +227,7 @@ def are_symlinks_supported() -> bool:
                         )
                     warnings.warn(message)
 
-    return _are_symlinks_supported
+    return _are_symlinks_supported_in_dir[cache_dir]
 
 
 # Return value when trying to load a file from cache but the file does not exist in the distant repo.
@@ -920,7 +934,8 @@ def _create_relative_symlink(src: str, dst: str, new_blob: bool = False) -> None
     except OSError:
         pass
 
-    if are_symlinks_supported():
+    cache_dir = os.path.dirname(os.path.commonpath([src, dst]))
+    if are_symlinks_supported(cache_dir=cache_dir):
         os.symlink(relative_src, dst)
     elif new_blob:
         os.replace(src, dst)


### PR DESCRIPTION
Related to https://github.com/huggingface/huggingface_hub/issues/1062#issuecomment-1255719962.

Issue is that we were checking the support of symlinks globally (in `/tmp`) instead of a per-folder check. This can be an used if the cache dir and the tmp dir are mounted on different volumes with different rules. This implementation should not be safer.

Also, warning message is displayed once per cache dir in use. In a vast majority of cases this means once per runtime since cache directory usually don't change.