### PR TITLE
Explicit true value for environment variables

### DIFF
--- a/docs/source/how-to-cache.mdx
+++ b/docs/source/how-to-cache.mdx
@@ -126,7 +126,7 @@ or to run Python as an administrator.
 
 When symlinks are not supported, a warning message is displayed to the user to alert
 them they are using a degraded version of the cache-system. This warning can be disabled
-by setting the `DISABLE_SYMLINKS_WARNING` environment variable to true.
+by setting the `HF_HUB_DISABLE_SYMLINKS_WARNING` environment variable to true.
 
 ## Scan your cache
 

--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -86,7 +86,7 @@ HF_HUB_OFFLINE = _is_true(os.environ.get("HF_HUB_OFFLINE"))
 
 # Here, `True` will disable progress bars globally without possibility of enabling it
 # programatically. `False` will enable them without possibility of disabling them.
-# If environement variable is not set (None), then the user is free to enable/disable
+# If environment variable is not set (None), then the user is free to enable/disable
 # them programmatically.
 # TL;DR: env variable has priority over code
 HF_HUB_DISABLE_PROGRESS_BARS: Optional[bool] = os.environ.get(
@@ -94,3 +94,13 @@ HF_HUB_DISABLE_PROGRESS_BARS: Optional[bool] = os.environ.get(
 )
 if HF_HUB_DISABLE_PROGRESS_BARS is not None:
     HF_HUB_DISABLE_PROGRESS_BARS = _is_true(HF_HUB_DISABLE_PROGRESS_BARS)
+
+# Disable warning on machines that do not support symlinks (e.g. Windows non-developer)
+HF_HUB_DISABLE_SYMLINKS_WARNING: bool = _is_true(
+    os.environ.get("HF_HUB_DISABLE_SYMLINKS_WARNING")
+)
+
+# Disable sending the cached token by default is all HTTP requests to the Hub
+HF_HUB_DISABLE_IMPLICIT_TOKEN: bool = _is_true(
+    os.environ.get("HF_HUB_DISABLE_IMPLICIT_TOKEN")
+)

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -23,6 +23,7 @@ from requests.exceptions import ConnectTimeout, ProxyError
 from . import __version__  # noqa: F401 # for backward compatibility
 from .constants import (
     DEFAULT_REVISION,
+    HF_HUB_DISABLE_SYMLINKS_WARNING,
     HUGGINGFACE_CO_URL_TEMPLATE,
     HUGGINGFACE_HEADER_X_LINKED_ETAG,
     HUGGINGFACE_HEADER_X_REPO_COMMIT,
@@ -100,15 +101,15 @@ def are_symlinks_supported(cache_dir: Union[str, Path, None] = None) -> bool:
                 # Likely running on Windows
                 _are_symlinks_supported_in_dir[cache_dir] = False
 
-                if not os.environ.get("DISABLE_SYMLINKS_WARNING"):
+                if not HF_HUB_DISABLE_SYMLINKS_WARNING:
                     message = (
                         "`huggingface_hub` cache-system uses symlinks by default to"
                         " efficiently store duplicated files but your machine does not"
                         f" support them in {cache_dir}. Caching files will still work"
                         " but in a degraded version that might require more space on"
                         " your disk. This warning can be disabled by setting the"
-                        " `DISABLE_SYMLINKS_WARNING` environment variable. For more"
-                        " details, see"
+                        " `HF_HUB_DISABLE_SYMLINKS_WARNING` environment variable. For"
+                        " more details, see"
                         " https://huggingface.co/docs/huggingface_hub/how-to-cache#limitations."
                     )
                     if os.name == "nt":

--- a/src/huggingface_hub/utils/_headers.py
+++ b/src/huggingface_hub/utils/_headers.py
@@ -16,6 +16,7 @@
 import os
 from typing import Dict, Optional, Union
 
+from ..constants import HF_HUB_DISABLE_IMPLICIT_TOKEN
 from ._hf_folder import HfFolder
 from ._runtime import (
     get_fastai_version,
@@ -153,7 +154,7 @@ def _get_token_to_send(use_auth_token: Optional[Union[bool, str]]) -> Optional[s
         return cached_token
 
     # Case implicit use of the token is forbidden by env variable
-    if os.environ.get("HF_HUB_DISABLE_IMPLICIT_TOKEN"):
+    if HF_HUB_DISABLE_IMPLICIT_TOKEN:
         return None
 
     # Otherwise: we use the cached token as the user has not explicitly forbidden it

--- a/src/huggingface_hub/utils/_headers.py
+++ b/src/huggingface_hub/utils/_headers.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Contains utilities to handle headers to send in calls to Huggingface Hub."""
-import os
 from typing import Dict, Optional, Union
 
 from ..constants import HF_HUB_DISABLE_IMPLICIT_TOKEN

--- a/tests/test_utils_headers.py
+++ b/tests/test_utils_headers.py
@@ -59,17 +59,21 @@ class TestAuthHeadersUtil(unittest.TestCase):
         with self.assertRaises(ValueError):
             build_hf_headers(use_auth_token=False, is_write_action=True)
 
-    @patch.dict("os.environ", {"HF_HUB_DISABLE_IMPLICIT_TOKEN": "1"})
     def test_implicit_use_disabled(self, mock_HfFolder: Mock) -> None:
-        mock_HfFolder().get_token.return_value = FAKE_TOKEN
-        self.assertEqual(build_hf_headers(), NO_AUTH_HEADER)  # token is not sent
+        with patch(  # not as decorator to avoid friction with @handle_injection
+            "huggingface_hub.utils._headers.HF_HUB_DISABLE_IMPLICIT_TOKEN", True
+        ):
+            mock_HfFolder().get_token.return_value = FAKE_TOKEN
+            self.assertEqual(build_hf_headers(), NO_AUTH_HEADER)  # token is not sent
 
-    @patch.dict("os.environ", {"HF_HUB_DISABLE_IMPLICIT_TOKEN": "1"})
     def test_implicit_use_disabled_but_explicit_use(self, mock_HfFolder: Mock) -> None:
-        mock_HfFolder().get_token.return_value = FAKE_TOKEN
+        with patch(  # not as decorator to avoid friction with @handle_injection
+            "huggingface_hub.utils._headers.HF_HUB_DISABLE_IMPLICIT_TOKEN", True
+        ):
+            mock_HfFolder().get_token.return_value = FAKE_TOKEN
 
-        # This is not an implicit use so we still send it
-        self.assertEqual(build_hf_headers(use_auth_token=True), FAKE_TOKEN_HEADER)
+            # This is not an implicit use so we still send it
+            self.assertEqual(build_hf_headers(use_auth_token=True), FAKE_TOKEN_HEADER)
 
 
 class TestUserAgentHeadersUtil(unittest.TestCase):


### PR DESCRIPTION
Following recent comment from @lhoestq in https://github.com/huggingface/huggingface_hub/pull/1064#discussion_r979801597.

This way `HF_HUB_DISABLE_SYMLINKS_WARNING=0` would not be considered as true. If that's fine, I'll cherry-pick it for the v0.10 release (once merged).