### PR TITLE
Send token implicitly on LFS upload

### DIFF
--- a/src/huggingface_hub/_commit_api.py
+++ b/src/huggingface_hub/_commit_api.py
@@ -166,7 +166,7 @@ def upload_lfs_files(
     additions: Iterable[CommitOperationAdd],
     repo_type: str,
     repo_id: str,
-    token: str,
+    token: Optional[str],
     endpoint: Optional[str] = None,
     num_threads: int = 5,
 ):
@@ -184,7 +184,7 @@ def upload_lfs_files(
         repo_id (`str`):
             A namespace (user or an organization) and a repo name separated
             by a `/`.
-        token (`str`):
+        token (`str`, *optional*):
             An authentication token ( See https://huggingface.co/settings/tokens )
         num_threads (`int`, *optional*):
             The number of concurrent threads to use when uploading. Defaults to 5.
@@ -256,7 +256,7 @@ def upload_lfs_files(
 
 
 def _upload_lfs_object(
-    operation: CommitOperationAdd, lfs_batch_action: dict, token: str
+    operation: CommitOperationAdd, lfs_batch_action: dict, token: Optional[str]
 ):
     """
     Handles uploading a given object to the Hub with the LFS protocol.
@@ -272,7 +272,7 @@ def _upload_lfs_object(
         lfs_batch_action (`dict`):
             Upload instructions from the LFS batch endpoint for this object.
             See [`~utils.lfs.post_lfs_batch_info`] for more details.
-        token (`str`):
+        token (`str`, *optional*):
             A [user access token](https://hf.co/settings/tokens) to authenticate requests against the Hub
 
     Raises: `ValueError` if `lfs_batch_action` is improperly formatted
@@ -321,7 +321,7 @@ def fetch_upload_modes(
     additions: Iterable[CommitOperationAdd],
     repo_type: str,
     repo_id: str,
-    token: str,
+    token: Optional[str],
     revision: str,
     endpoint: Optional[str] = None,
     create_pr: Optional[bool] = None,
@@ -339,7 +339,7 @@ def fetch_upload_modes(
         repo_id (`str`):
             A namespace (user or an organization) and a repo name separated
             by a `/`.
-        token (`str`):
+        token (`str`, *optional*):
             An authentication token ( See https://huggingface.co/settings/tokens )
         revision (`str`):
             The git revision to upload the files to. Can be any valid git revision.

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -2705,7 +2705,7 @@ class HfApi:
         repo_id: str,
         title: str,
         *,
-        token: str,
+        token: Optional[str],
         description: Optional[str] = None,
         repo_type: Optional[str] = None,
         pull_request: bool = False,
@@ -2724,7 +2724,7 @@ class HfApi:
                 The title of the discussion. It can be up to 200 characters long,
                 and must be at least 3 characters long. Leading and trailing whitespaces
                 will be stripped.
-            token (`str`):
+            token (`str`, *optional*):
                 An authentication token (See https://huggingface.co/settings/token)
             description (`str`, *optional*):
                 An optional description for the Pull Request.
@@ -2794,7 +2794,7 @@ class HfApi:
         repo_id: str,
         title: str,
         *,
-        token: str,
+        token: Optional[str],
         description: Optional[str] = None,
         repo_type: Optional[str] = None,
     ) -> DiscussionWithDetails:
@@ -2812,7 +2812,7 @@ class HfApi:
                 The title of the discussion. It can be up to 200 characters long,
                 and must be at least 3 characters long. Leading and trailing whitespaces
                 will be stripped.
-            token (`str`):
+            token (`str`, *optional*):
                 An authentication token (See https://huggingface.co/settings/token)
             description (`str`, *optional*):
                 An optional description for the Pull Request.
@@ -3096,7 +3096,7 @@ class HfApi:
         repo_id: str,
         discussion_num: int,
         *,
-        token: str,
+        token: Optional[str],
         comment: Optional[str] = None,
         repo_type: Optional[str] = None,
     ):
@@ -3207,7 +3207,7 @@ class HfApi:
         discussion_num: int,
         comment_id: str,
         *,
-        token: str,
+        token: Optional[str],
         repo_type: Optional[str] = None,
     ) -> DiscussionComment:
         """Hides a comment on a Discussion / Pull Request.

--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -36,7 +36,7 @@ from ._errors import (
     hf_raise_for_status,
 )
 from ._fixes import yaml_dump
-from ._headers import build_hf_headers
+from ._headers import build_hf_headers, get_token_to_send
 from ._hf_folder import HfFolder
 from ._http import http_backoff
 from ._paths import filter_repo_objects

--- a/src/huggingface_hub/utils/_headers.py
+++ b/src/huggingface_hub/utils/_headers.py
@@ -112,7 +112,7 @@ def build_hf_headers(
             If `use_auth_token=True` but token is not saved locally.
     """
     # Get auth token to send
-    token_to_send = _get_token_to_send(use_auth_token)
+    token_to_send = get_token_to_send(use_auth_token)
     _validate_token_to_send(token_to_send, is_write_action=is_write_action)
 
     # Combine headers
@@ -128,7 +128,7 @@ def build_hf_headers(
     return headers
 
 
-def _get_token_to_send(use_auth_token: Optional[Union[bool, str]]) -> Optional[str]:
+def get_token_to_send(use_auth_token: Optional[Union[bool, str]]) -> Optional[str]:
     """Select the token to send from either `use_auth_token` or the cache."""
     # Case token is explicitly provided
     if isinstance(use_auth_token, str):


### PR DESCRIPTION
Fix a regression when uploading a file as LFS using the `create_commit` endpoint. Token was NOT supposed to be `None` but wasn't checked. Now token is optional everywhere and retrieved just before making a HTTP call. This regression has been introduced by https://github.com/huggingface/huggingface_hub/pull/1064 (I did not see the use of `HTTPAuthToken(...)` for LFS endpoints). I added a regression test to ensure it works in the future.

Related to this [test failure](https://github.com/huggingface/datasets/actions/runs/3128657114/jobs/5076803366) in `datasets`. I tested it locally and it indeed fixes the problem.

(this bug has been found as part of the `huggingface_hub==v0.10.0.rc0` prerelease test. Will be patched as `v0.10.0.rc2`.)

(edit: this could have been avoided if mypy was run in CI - I'll try to work on that at some point)