### PR TITLE
Add a `create_tag` method to create tags from the HTTP endpoint

### DIFF
--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -106,6 +106,7 @@ _SUBMOD_ATTRS = {
         "create_discussion",
         "create_pull_request",
         "create_repo",
+        "create_tag",
         "dataset_info",
         "delete_file",
         "delete_repo",
@@ -320,6 +321,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from .hf_api import create_discussion  # noqa: F401
     from .hf_api import create_pull_request  # noqa: F401
     from .hf_api import create_repo  # noqa: F401
+    from .hf_api import create_tag  # noqa: F401
     from .hf_api import dataset_info  # noqa: F401
     from .hf_api import delete_file  # noqa: F401
     from .hf_api import delete_repo  # noqa: F401

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -2528,17 +2528,11 @@ class HfApi:
                 `None`.
 
         Raises:
-            [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
-                If commit message is empty.
-            [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
-                If parent commit is not a valid commit OID.
-            [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
-                If the Hub API returns an HTTP 400 error (bad request)
-            [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
-                If `create_pr` is `True` and revision is neither `None` nor `"main"`.
             [`~utils.RepositoryNotFoundError`]:
                 If repository is not found (error 404): wrong repo_id/repo_type, private
                 but not authenticated or repo does not exist.
+            [`~utils.RepositoryNotFoundError`]:
+                If revision is not found (error 404) on the repo.
         """
         if repo_type is None:
             repo_type = REPO_TYPE_MODEL

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -2489,6 +2489,74 @@ class HfApi:
             parent_commit=parent_commit,
         )
 
+    @validate_hf_hub_args
+    def create_tag(
+        self,
+        repo_id: str,
+        *,
+        tag: str,
+        tag_message: Optional[str] = None,
+        revision: Optional[str] = None,
+        token: Optional[str] = None,
+        repo_type: Optional[str] = None,
+    ) -> None:
+        """
+        Tag a given commit of a repo on the Hub.
+
+        Args:
+            repo_id (`str`):
+                The repository in which a commit will be tagged.
+                Example: `"user/my-cool-model"`.
+
+            tag (`str`):
+                The name of the tag to create.
+
+            tag_message (`str`, *optional*):
+                The description of the tag to create.
+
+            revision (`str`, *optional*):
+                The git revision to tag. It can be a branch name or the OID/SHA of a
+                commit, as a hexadecimal string. Shorthands (7 first characters) are
+                also supported. Defaults to the head of the `"main"` branch.
+
+            token (`str`, *optional*):
+                Authentication token. Will default to the stored token.
+
+            repo_type (`str`, *optional*):
+                Set to `"dataset"` or `"space"` if uploading to a dataset or
+                space, `None` or `"model"` if uploading to a model. Default is
+                `None`.
+
+        Raises:
+            [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
+                If commit message is empty.
+            [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
+                If parent commit is not a valid commit OID.
+            [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
+                If the Hub API returns an HTTP 400 error (bad request)
+            [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
+                If `create_pr` is `True` and revision is neither `None` nor `"main"`.
+            [`~utils.RepositoryNotFoundError`]:
+                If repository is not found (error 404): wrong repo_id/repo_type, private
+                but not authenticated or repo does not exist.
+        """
+        if repo_type is None:
+            repo_type = REPO_TYPE_MODEL
+        revision = (
+            quote(revision, safe="") if revision is not None else DEFAULT_REVISION
+        )
+
+        # Prepare request
+        tag_url = f"{self.endpoint}/api/{repo_type}s/{repo_id}/tag/{revision}"
+        headers = build_hf_headers(use_auth_token=token, is_write_action=True)
+        payload = {"tag": tag}
+        if tag_message is not None:
+            payload["message"] = tag_message
+
+        # Tag
+        response = requests.post(url=tag_url, headers=headers, json=payload)
+        hf_raise_for_status(response)
+
     def get_full_repo_name(
         self,
         model_id: str,
@@ -3352,6 +3420,7 @@ move_repo = api.move_repo
 upload_file = api.upload_file
 upload_folder = api.upload_folder
 delete_file = api.delete_file
+create_tag = api.create_tag
 get_full_repo_name = api.get_full_repo_name
 
 get_discussion_details = api.get_discussion_details

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -1129,7 +1129,7 @@ class HfApiTagEndpointTest(HfApiCommonTestWithLogin):
     @retry_endpoint
     @use_tmp_repo("model")
     def test_create_tag_on_missing_revision(self) -> None:
-        """Check `create_tag` with an invalid tag name."""
+        """Check `create_tag` on a missing revision."""
         with self.assertRaises(RevisionNotFoundError):
             self._api.create_tag(
                 self._repo_id, tag="invalid tag", token=self._token, revision="foobar"

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -1015,7 +1015,10 @@ class HfApiTagEndpointTest(HfApiCommonTestWithLogin):
     def test_create_tag_on_main(self) -> None:
         """Check `create_tag` on default main branch works."""
         self._api.create_tag(
-            self._repo_id, tag="v0", message="This is a tag message.", token=self._token
+            self._repo_id,
+            tag="v0",
+            tag_message="This is a tag message.",
+            token=self._token,
         )
 
         # Check tag  is on `main`

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -54,7 +54,12 @@ from huggingface_hub.hf_api import (
     read_from_credential_store,
     repo_type_and_id_from_hf_id,
 )
-from huggingface_hub.utils import HfFolder, RepositoryNotFoundError, logging
+from huggingface_hub.utils import (
+    HfFolder,
+    RepositoryNotFoundError,
+    RevisionNotFoundError,
+    logging,
+)
 from huggingface_hub.utils.endpoint_helpers import (
     DatasetFilter,
     ModelFilter,
@@ -79,6 +84,7 @@ from .testing_utils import (
     require_git_lfs,
     retry_endpoint,
     set_write_permission_and_retry,
+    use_tmp_repo,
     with_production_testing,
 )
 
@@ -998,6 +1004,136 @@ class CommitApiTest(HfApiCommonTestWithLogin):
 
             # Delete repo
             self._api.delete_repo(repo_id=REPO_NAME, token=self._token)
+
+
+class HfApiTagEndpointTest(HfApiCommonTestWithLogin):
+    _user = USER
+    _repo_id: str
+
+    @retry_endpoint
+    @use_tmp_repo("model")
+    def test_create_tag_on_main(self) -> None:
+        """Check `create_tag` on default main branch works."""
+        self._api.create_tag(
+            self._repo_id, tag="v0", message="This is a tag message.", token=self._token
+        )
+
+        # Check tag  is on `main`
+        tag_info = self._api.model_info(
+            self._repo_id, revision="v0", use_auth_token=self._token
+        )
+        main_info = self._api.model_info(
+            self._repo_id, revision="main", use_auth_token=self._token
+        )
+        self.assertEqual(tag_info.sha, main_info.sha)
+
+    @retry_endpoint
+    @use_tmp_repo("model")
+    def test_create_tag_on_pr(self) -> None:
+        """Check `create_tag` on a PR ref works."""
+        # Create a PR with a readme
+        commit_info: CommitInfo = self._api.create_commit(
+            repo_id=self._repo_id,
+            token=self._token,
+            create_pr=True,
+            commit_message="upload readme",
+            operations=[
+                CommitOperationAdd(
+                    path_or_fileobj=b"this is a file content", path_in_repo="readme.md"
+                )
+            ],
+        )
+
+        # Tag the PR
+        self._api.create_tag(
+            self._repo_id, tag="v0", token=self._token, revision=commit_info.pr_revision
+        )
+
+        # Check tag  is on `refs/pr/1`
+        tag_info = self._api.model_info(
+            self._repo_id, revision="v0", use_auth_token=self._token
+        )
+        pr_info = self._api.model_info(
+            self._repo_id, revision=commit_info.pr_revision, use_auth_token=self._token
+        )
+        main_info = self._api.model_info(self._repo_id, use_auth_token=self._token)
+
+        self.assertEqual(tag_info.sha, pr_info.sha)
+        self.assertNotEqual(tag_info.sha, main_info.sha)
+
+    @retry_endpoint
+    @use_tmp_repo("dataset")
+    def test_create_tag_on_commit_oid(self) -> None:
+        """Check `create_tag` on specific commit oid works (both long and shorthands).
+
+        Test it on a `dataset` repo.
+        """
+        # Create a PR with a readme
+        commit_info_1: CommitInfo = self._api.create_commit(
+            repo_id=self._repo_id,
+            repo_type="dataset",
+            token=self._token,
+            commit_message="upload readme",
+            operations=[
+                CommitOperationAdd(
+                    path_or_fileobj=b"this is a file content", path_in_repo="readme.md"
+                )
+            ],
+        )
+        commit_info_2: CommitInfo = self._api.create_commit(
+            repo_id=self._repo_id,
+            repo_type="dataset",
+            token=self._token,
+            commit_message="upload config",
+            operations=[
+                CommitOperationAdd(
+                    path_or_fileobj=b"{'hello': 'world'}", path_in_repo="config.json"
+                )
+            ],
+        )
+
+        # Tag commits
+        self._api.create_tag(
+            self._repo_id,
+            tag="commit_1",
+            repo_type="dataset",
+            token=self._token,
+            revision=commit_info_1.oid,  # long version
+        )
+        self._api.create_tag(
+            self._repo_id,
+            tag="commit_2",
+            repo_type="dataset",
+            token=self._token,
+            revision=commit_info_2.oid[:7],  # use shorthand !
+        )
+
+        # Check tags
+        tag_1_info = self._api.dataset_info(
+            self._repo_id, revision="commit_1", use_auth_token=self._token
+        )
+        tag_2_info = self._api.dataset_info(
+            self._repo_id, revision="commit_2", use_auth_token=self._token
+        )
+
+        self.assertEqual(tag_1_info.sha, commit_info_1.oid)
+        self.assertEqual(tag_2_info.sha, commit_info_2.oid)
+
+    @retry_endpoint
+    @use_tmp_repo("model")
+    def test_invalid_tag_name(self) -> None:
+        """Check `create_tag` with an invalid tag name."""
+        with self.assertRaises(HTTPError):
+            self._api.create_tag(self._repo_id, tag="invalid tag", token=self._token)
+
+    @retry_endpoint
+    @use_tmp_repo("model")
+    def test_create_tag_on_missing_revision(self) -> None:
+        """Check `create_tag` with an invalid tag name."""
+        with self.assertRaises(RevisionNotFoundError):
+            self._api.create_tag(
+                self._repo_id, tag="invalid tag", token=self._token, revision="foobar"
+            )
 
 
 class HfApiPublicTest(unittest.TestCase):


### PR DESCRIPTION
Will close https://github.com/huggingface/huggingface_hub/issues/1014. Follow `moon-landing` implementation https://github.com/huggingface/moon-landing/pull/3846 (internal link).
Related to 2 new issues on `moon-landing` https://github.com/huggingface/moon-landing/issues/3987 and https://github.com/huggingface/moon-landing/issues/3990 (internal links).

Adds a `create_tag` method to `HfApi`.

Todo:
- [x] implementation
- [x] tests