### PR TITLE
Allow notebook_login to accept token as parameter and log in without UI

### DIFF
--- a/src/huggingface_hub/commands/user.py
+++ b/src/huggingface_hub/commands/user.py
@@ -270,46 +270,52 @@ NOTEBOOK_LOGIN_TOKEN_HTML_END = """
 notebooks. </center>"""
 
 
-def notebook_login():
+def notebook_login(token=False):
     """
     Displays a widget to login to the HF website and store the token.
     """
-    try:
-        import ipywidgets.widgets as widgets
-        from IPython.display import clear_output, display
-    except ImportError:
-        raise ImportError(
-            "The `notebook_login` function can only be used in a notebook (Jupyter or"
-            " Colab) and you need the `ipywidgets` module: `pip install ipywidgets`."
-        )
 
-    box_layout = widgets.Layout(
-        display="flex", flex_flow="column", align_items="center", width="50%"
-    )
-
-    token_widget = widgets.Password(description="Token:")
-    token_finish_button = widgets.Button(description="Login")
-
-    login_token_widget = widgets.VBox(
-        [
-            widgets.HTML(NOTEBOOK_LOGIN_TOKEN_HTML_START),
-            token_widget,
-            token_finish_button,
-            widgets.HTML(NOTEBOOK_LOGIN_TOKEN_HTML_END),
-        ],
-        layout=box_layout,
-    )
-    display(login_token_widget)
-
-    # On click events
-    def login_token_event(t):
-        token = token_widget.value
-        # Erase token and clear value to make sure it's not saved in the notebook.
-        token_widget.value = ""
-        clear_output()
+    def login(token):
         _login(hf_api=HfApi(), token=token)
 
-    token_finish_button.on_click(login_token_event)
+    if token:
+        login(token)
+    else:
+        try:
+            import ipywidgets.widgets as widgets
+            from IPython.display import clear_output, display
+        except ImportError:
+            raise ImportError(
+                "The `notebook_login` function can only be used in a notebook (Jupyter or"
+                " Colab) and you need the `ipywidgets` module: `pip install ipywidgets`."
+            )
+
+        box_layout = widgets.Layout(
+            display="flex", flex_flow="column", align_items="center", width="50%"
+        )
+
+        token_widget = widgets.Password(description="Token:")
+        token_finish_button = widgets.Button(description="Login")
+
+        login_token_widget = widgets.VBox(
+            [
+                widgets.HTML(NOTEBOOK_LOGIN_TOKEN_HTML_START),
+                token_widget,
+                token_finish_button,
+                widgets.HTML(NOTEBOOK_LOGIN_TOKEN_HTML_END),
+            ],
+            layout=box_layout,
+        )
+        display(login_token_widget)
+
+        def login_token_event(t):
+            token = token_widget.value
+            # Erase token and clear value to make sure it's not saved in the notebook.
+            token_widget.value = ""
+            clear_output()
+            login(token)
+
+        token_finish_button.on_click(login_token_event)
 
 
 def _login(hf_api: HfApi, token: str) -> None:


### PR DESCRIPTION
I added a parameter `Token` to `notebook_login`.

When `Token` is `False`, behavior remains the same as it was.

When `Token` is not `False`, it will just run `_login(hf_api=HfApi(), token=token)` with that token.

With this feature, notebook users can log in with a token stored on eg. their GDrive, so they don't have to look up and manually type in their token every time their run their notebook.