### PR TITLE
replace ANSI helper with termcolor

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ install_requires = [
     "typing-extensions>=3.7.4.3",  # to be able to import TypeAlias
     "importlib_metadata;python_version<'3.8'",
     "packaging>=20.9",
+    "termcolor>=2.0",
 ]
 
 extras = {}

--- a/src/huggingface_hub/commands/_cli_utils.py
+++ b/src/huggingface_hub/commands/_cli_utils.py
@@ -15,33 +15,6 @@
 from typing import List, Union
 
 
-class ANSI:
-    """
-    Helper for en.wikipedia.org/wiki/ANSI_escape_code
-    """
-
-    _bold = "\u001b[1m"
-    _gray = "\u001b[90m"
-    _red = "\u001b[31m"
-    _reset = "\u001b[0m"
-
-    @classmethod
-    def bold(cls, s: str) -> str:
-        return cls._format(s, cls._bold)
-
-    @classmethod
-    def gray(cls, s: str) -> str:
-        return cls._format(s, cls._gray)
-
-    @classmethod
-    def red(cls, s: str) -> str:
-        return cls._format(s, cls._bold + cls._red)
-
-    @classmethod
-    def _format(cls, s: str, code: str) -> str:
-        return f"{code}{s}{cls._reset}"
-
-
 def tabulate(rows: List[List[Union[str, int]]], headers: List[str]) -> str:
     """
     Inspired by:

--- a/src/huggingface_hub/commands/delete_cache.py
+++ b/src/huggingface_hub/commands/delete_cache.py
@@ -60,6 +60,7 @@ from argparse import ArgumentParser
 from functools import wraps
 from tempfile import mkstemp
 from typing import Any, Callable, Iterable, List, Optional
+
 from termcolor import colored
 
 from ..utils import CachedRepoInfo, CachedRevisionInfo, HFCacheInfo, scan_cache_dir
@@ -317,12 +318,13 @@ def _manual_review_no_tui(
         f.write("\n".join(lines))
 
     # 2. Prompt instructions to user.
+    bold_tmp_path = colored(tmp_path, attrs=["bold"])
     instructions = f"""
     TUI is disabled. In other to select which revisions you want to delete, please edit
     the following file using the text editor of your choice. Instructions for manual
     editing are located at the beginning of the file. Edit the file, save it and confirm
     to continue.
-    File to edit: {colored(tmp_path, attrs=["bold"])}
+    File to edit: {bold_tmp_path}
     """
     print("\n".join(line.strip() for line in instructions.strip().split("\n")))
 

--- a/src/huggingface_hub/commands/delete_cache.py
+++ b/src/huggingface_hub/commands/delete_cache.py
@@ -60,6 +60,7 @@ from argparse import ArgumentParser
 from functools import wraps
 from tempfile import mkstemp
 from typing import Any, Callable, Iterable, List, Optional
+from termcolor import colored
 
 from ..utils import CachedRepoInfo, CachedRevisionInfo, HFCacheInfo, scan_cache_dir
 from . import BaseHuggingfaceCLICommand
@@ -321,7 +322,7 @@ def _manual_review_no_tui(
     the following file using the text editor of your choice. Instructions for manual
     editing are located at the beginning of the file. Edit the file, save it and confirm
     to continue.
-    File to edit: {ANSI.bold(tmp_path)}
+    File to edit: {colored(tmp_path, attrs=["bold"])}
     """
     print("\n".join(line.strip() for line in instructions.strip().split("\n")))
 

--- a/src/huggingface_hub/commands/scan_cache.py
+++ b/src/huggingface_hub/commands/scan_cache.py
@@ -23,7 +23,8 @@ Usage:
 import time
 from argparse import ArgumentParser
 from typing import Optional
-from termcolor import cprint, colored
+
+from termcolor import colored, cprint
 
 from ..utils import HFCacheInfo, scan_cache_dir
 from . import BaseHuggingfaceCLICommand
@@ -66,16 +67,17 @@ class ScanCacheCommand(BaseHuggingfaceCLICommand):
 
         self._print_hf_cache_info_as_table(hf_cache_info)
 
+        colored_size = colored(hf_cache_info.size_on_disk_str, "red")
         print(
             f"\nDone in {round(t1-t0,1)}s. Scanned {len(hf_cache_info.repos)} repo(s)"
-            f" for a total of {colored(hf_cache_info.size_on_disk_str, "red")}."
+            f" for a total of {colored_size}."
         )
         if len(hf_cache_info.warnings) > 0:
             message = f"Got {len(hf_cache_info.warnings)} warning(s) while scanning."
             if self.verbosity >= 3:
-                cprint(colored(message, color="grey"))
+                cprint(message, color="grey")
                 for warning in hf_cache_info.warnings:
-                    cprint(warning, color="grey"))
+                    cprint(warning, color="grey")
             else:
                 cprint(message + " Use -vvv to print details.", color="grey")
 

--- a/src/huggingface_hub/commands/scan_cache.py
+++ b/src/huggingface_hub/commands/scan_cache.py
@@ -23,6 +23,7 @@ Usage:
 import time
 from argparse import ArgumentParser
 from typing import Optional
+from termcolor import cprint, colored
 
 from ..utils import HFCacheInfo, scan_cache_dir
 from . import BaseHuggingfaceCLICommand
@@ -67,16 +68,16 @@ class ScanCacheCommand(BaseHuggingfaceCLICommand):
 
         print(
             f"\nDone in {round(t1-t0,1)}s. Scanned {len(hf_cache_info.repos)} repo(s)"
-            f" for a total of {ANSI.red(hf_cache_info.size_on_disk_str)}."
+            f" for a total of {colored(hf_cache_info.size_on_disk_str, "red")}."
         )
         if len(hf_cache_info.warnings) > 0:
             message = f"Got {len(hf_cache_info.warnings)} warning(s) while scanning."
             if self.verbosity >= 3:
-                print(ANSI.gray(message))
+                cprint(colored(message, color="grey"))
                 for warning in hf_cache_info.warnings:
-                    print(ANSI.gray(warning))
+                    cprint(warning, color="grey"))
             else:
-                print(ANSI.gray(message + " Use -vvv to print details."))
+                cprint(message + " Use -vvv to print details.", color="grey")
 
     def _print_hf_cache_info_as_table(self, hf_cache_info: HFCacheInfo) -> None:
         if self.verbosity == 0:

--- a/src/huggingface_hub/commands/user.py
+++ b/src/huggingface_hub/commands/user.py
@@ -201,8 +201,8 @@ class RepoCreateCommand(BaseUserCommand):
             cprint(
                 "Looks like you do not have git-lfs installed, please install."
                 " You can install from https://git-lfs.github.com/."
-                " Then run `git lfs install` (you only have to do this once)."
-                color="red"
+                " Then run `git lfs install` (you only have to do this once).",
+                color="red",
             )
         print("")
 
@@ -222,7 +222,8 @@ class RepoCreateCommand(BaseUserCommand):
         else:
             prefixed_repo_id = repo_id
 
-        print(f"You are about to create {colored(prefixed_repo_id, attrs=["bold"])}")
+        bold_prefixed_repo_id = colored(prefixed_repo_id, attrs=["bold"])
+        print(f"You are about to create {bold_prefixed_repo_id}")
 
         if not self.args.yes:
             choice = input("Proceed? [Y/n] ").lower()
@@ -240,8 +241,9 @@ class RepoCreateCommand(BaseUserCommand):
             print(e)
             cprint(e.response.text, color="red")
             exit(1)
+        bold_url = colored(url, attrs=["bold"])
         print("\nYour repo now lives at:")
-        print(f"  {colored(url, attrs=["bold"])}")
+        print(f"  {bold_url}")
         print(
             "\nYou can clone it locally with the command below,"
             " and commit/push as usual."
@@ -336,7 +338,7 @@ def _login(hf_api: HfApi, token: str) -> None:
             " pushing to the Hugging Face Hub. Run the following command in your"
             " terminal in case you want to set this credential helper as the"
             " default\n\ngit config --global credential.helper store",
-            color="red"
+            color="red",
         )
 
 

--- a/src/huggingface_hub/commands/user.py
+++ b/src/huggingface_hub/commands/user.py
@@ -25,6 +25,7 @@ from huggingface_hub.constants import (
 )
 from huggingface_hub.hf_api import HfApi
 from requests.exceptions import HTTPError
+from termcolor import colored, cprint
 
 from ..utils import HfFolder, run_subprocess
 from ._cli_utils import ANSI
@@ -160,13 +161,13 @@ class WhoamiCommand(BaseUserCommand):
             print(info["name"])
             orgs = [org["name"] for org in info["orgs"]]
             if orgs:
-                print(ANSI.bold("orgs: "), ",".join(orgs))
+                print(colored("orgs: ", attrs=["bold"]), ",".join(orgs))
 
             if ENDPOINT != "https://huggingface.co":
                 print(f"Authenticated through private endpoint: {ENDPOINT}")
         except HTTPError as e:
             print(e)
-            print(ANSI.red(e.response.text))
+            cprint(e.response.text, color="red")
             exit(1)
 
 
@@ -189,20 +190,19 @@ class RepoCreateCommand(BaseUserCommand):
             exit(1)
         try:
             stdout = subprocess.check_output(["git", "--version"]).decode("utf-8")
-            print(ANSI.gray(stdout.strip()))
+            cprint(stdout.strip(), color="grey")
         except FileNotFoundError:
             print("Looks like you do not have git installed, please install.")
 
         try:
             stdout = subprocess.check_output(["git-lfs", "--version"]).decode("utf-8")
-            print(ANSI.gray(stdout.strip()))
+            cprint(stdout.strip(), color="grey")
         except FileNotFoundError:
-            print(
-                ANSI.red(
-                    "Looks like you do not have git-lfs installed, please install."
-                    " You can install from https://git-lfs.github.com/."
-                    " Then run `git lfs install` (you only have to do this once)."
-                )
+            cprint(
+                "Looks like you do not have git-lfs installed, please install."
+                " You can install from https://git-lfs.github.com/."
+                " Then run `git lfs install` (you only have to do this once)."
+                color="red"
             )
         print("")
 
@@ -222,7 +222,7 @@ class RepoCreateCommand(BaseUserCommand):
         else:
             prefixed_repo_id = repo_id
 
-        print(f"You are about to create {ANSI.bold(prefixed_repo_id)}")
+        print(f"You are about to create {colored(prefixed_repo_id, attrs=["bold"])}")
 
         if not self.args.yes:
             choice = input("Proceed? [Y/n] ").lower()
@@ -238,10 +238,10 @@ class RepoCreateCommand(BaseUserCommand):
             )
         except HTTPError as e:
             print(e)
-            print(ANSI.red(e.response.text))
+            cprint(e.response.text, color="red")
             exit(1)
         print("\nYour repo now lives at:")
-        print(f"  {ANSI.bold(url)}")
+        print(f"  {colored(url, attrs=["bold"])}")
         print(
             "\nYou can clone it locally with the command below,"
             " and commit/push as usual."
@@ -330,14 +330,13 @@ def _login(hf_api: HfApi, token: str) -> None:
     helpers = currently_setup_credential_helpers()
 
     if "store" not in helpers:
-        print(
-            ANSI.red(
-                "Authenticated through git-credential store but this isn't the helper"
-                " defined on your machine.\nYou might have to re-authenticate when"
-                " pushing to the Hugging Face Hub. Run the following command in your"
-                " terminal in case you want to set this credential helper as the"
-                " default\n\ngit config --global credential.helper store"
-            )
+        cprint(
+            "Authenticated through git-credential store but this isn't the helper"
+            " defined on your machine.\nYou might have to re-authenticate when"
+            " pushing to the Hugging Face Hub. Run the following command in your"
+            " terminal in case you want to set this credential helper as the"
+            " default\n\ngit config --global credential.helper store",
+            color="red"
         )
 
 

--- a/tests/test_utils_cli.py
+++ b/tests/test_utils_cli.py
@@ -4,28 +4,6 @@ from huggingface_hub.commands._cli_utils import ANSI, tabulate
 
 
 class TestCLIUtils(unittest.TestCase):
-    def test_ansi_utils(self) -> None:
-        """Test `ANSI` works as expected."""
-        self.assertEqual(
-            ANSI.bold("this is bold"),
-            "\x1b[1mthis is bold\x1b[0m",
-        )
-
-        self.assertEqual(
-            ANSI.gray("this is gray"),
-            "\x1b[90mthis is gray\x1b[0m",
-        )
-
-        self.assertEqual(
-            ANSI.red("this is red"),
-            "\x1b[1m\x1b[31mthis is red\x1b[0m",
-        )
-
-        self.assertEqual(
-            ANSI.gray(ANSI.bold("this is bold and grey")),
-            "\x1b[90m\x1b[1mthis is bold and grey\x1b[0m\x1b[0m",
-        )
-
     def test_tabulate_utility(self) -> None:
         """Test `tabulate` works as expected."""
         rows = [[1, 2, 3], ["a very long value", "foo", "bar"], ["", 123, 456]]


### PR DESCRIPTION
There's no reason to define our own terminal color handler, when we can just use the [`termcolor`](https://github.com/termcolor/termcolor) library instead! It's better tested, better supported, and has more features -- including support for [the `NO_COLOR` env variable](https://no-color.org).