### PR TITLE
Cache not found is not an error

### DIFF
--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -164,10 +164,10 @@ _SUBMOD_ATTRS = {
         "Repository",
     ],
     "utils": [
+        "CacheNotFound",
         "CachedFileInfo",
         "CachedRepoInfo",
         "CachedRevisionInfo",
-        "CacheNotFound",
         "CorruptedCacheException",
         "DeleteCacheStrategy",
         "HFCacheInfo",
@@ -369,6 +369,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from .utils import CachedFileInfo  # noqa: F401
     from .utils import CachedRepoInfo  # noqa: F401
     from .utils import CachedRevisionInfo  # noqa: F401
+    from .utils import CacheNotFound  # noqa: F401
     from .utils import CorruptedCacheException  # noqa: F401
     from .utils import DeleteCacheStrategy  # noqa: F401
     from .utils import HFCacheInfo  # noqa: F401

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -167,6 +167,7 @@ _SUBMOD_ATTRS = {
         "CachedFileInfo",
         "CachedRepoInfo",
         "CachedRevisionInfo",
+        "CacheNotFound",
         "CorruptedCacheException",
         "DeleteCacheStrategy",
         "HFCacheInfo",

--- a/src/huggingface_hub/commands/scan_cache.py
+++ b/src/huggingface_hub/commands/scan_cache.py
@@ -24,7 +24,7 @@ import time
 from argparse import ArgumentParser
 from typing import Optional
 
-from ..utils import HFCacheInfo, scan_cache_dir
+from ..utils import HFCacheInfo, scan_cache_dir, CacheNotFound
 from . import BaseHuggingfaceCLICommand
 from ._cli_utils import ANSI, tabulate
 
@@ -59,9 +59,14 @@ class ScanCacheCommand(BaseHuggingfaceCLICommand):
         self.cache_dir: Optional[str] = args.dir
 
     def run(self):
-        t0 = time.time()
-        hf_cache_info = scan_cache_dir(self.cache_dir)
-        t1 = time.time()
+        try:
+            t0 = time.time()
+            hf_cache_info = scan_cache_dir(self.cache_dir)
+            t1 = time.time()
+        except CacheNotFound as exc:
+            cache_dir = str(exc)
+            print(f"Cache directory not found: {cache_dir}")
+            return
 
         self._print_hf_cache_info_as_table(hf_cache_info)
 

--- a/src/huggingface_hub/commands/scan_cache.py
+++ b/src/huggingface_hub/commands/scan_cache.py
@@ -24,7 +24,7 @@ import time
 from argparse import ArgumentParser
 from typing import Optional
 
-from ..utils import HFCacheInfo, scan_cache_dir, CacheNotFound
+from ..utils import CacheNotFound, HFCacheInfo, scan_cache_dir
 from . import BaseHuggingfaceCLICommand
 from ._cli_utils import ANSI, tabulate
 
@@ -64,7 +64,7 @@ class ScanCacheCommand(BaseHuggingfaceCLICommand):
             hf_cache_info = scan_cache_dir(self.cache_dir)
             t1 = time.time()
         except CacheNotFound as exc:
-            cache_dir = str(exc)
+            cache_dir = exc.cache_dir
             print(f"Cache directory not found: {cache_dir}")
             return
 

--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -20,6 +20,7 @@ from ._cache_manager import (
     CachedFileInfo,
     CachedRepoInfo,
     CachedRevisionInfo,
+    CacheNotFound,
     CorruptedCacheException,
     DeleteCacheStrategy,
     HFCacheInfo,

--- a/src/huggingface_hub/utils/_cache_manager.py
+++ b/src/huggingface_hub/utils/_cache_manager.py
@@ -30,6 +30,8 @@ logger = logging.get_logger(__name__)
 
 REPO_TYPE_T = Literal["model", "dataset", "space"]
 
+class CacheNotFound(Exception):
+    """Exception thrown when the Huggingface cache is not found."""
 
 class CorruptedCacheException(Exception):
     """Exception for any unexpected structure in the Huggingface cache-system."""
@@ -577,10 +579,7 @@ def scan_cache_dir(cache_dir: Optional[Union[str, Path]] = None) -> HFCacheInfo:
 
     cache_dir = Path(cache_dir).expanduser().resolve()
     if not cache_dir.exists():
-        raise ValueError(
-            f"Cache directory not found: {cache_dir}. Please use `cache_dir` argument"
-            " or set `HUGGINGFACE_HUB_CACHE` environment variable."
-        )
+        raise CacheNotFound(cache_dir)
 
     if cache_dir.is_file():
         raise ValueError(

--- a/tests/test_utils_cache.py
+++ b/tests/test_utils_cache.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import tempfile
 import time
 import unittest
 from pathlib import Path
@@ -36,7 +37,9 @@ class TestMissingCacheUtils(unittest.TestCase):
 
     def test_cache_dir_is_missing(self) -> None:
         """Directory to scan does not exist raises CacheNotFound."""
-        self.assertRaises(CacheNotFound, scan_cache_dir, self.cache_dir / "does_not_exist")
+        self.assertRaises(
+            CacheNotFound, scan_cache_dir, self.cache_dir / "does_not_exist"
+        )
 
     def test_cache_dir_is_a_file(self) -> None:
         """Directory to scan is a file raises ValueError."""
@@ -227,27 +230,26 @@ class TestValidCacheUtils(unittest.TestCase):
             expected_output.replace("-", "").split(),
         )
 
-
     def test_cli_scan_missing_cache(self) -> None:
         """Test output from CLI scan cache when cache does not exist.
 
         End-to-end test just to see if output is in expected format.
         """
+        tmp_dir = tempfile.mkdtemp()
+        os.rmdir(tmp_dir)
+
         args = Mock()
         args.verbose = 0
-        args.dir = "/tmp/empty"
+        args.dir = tmp_dir
 
         with capture_output() as output:
             ScanCacheCommand(args).run()
 
         expected_output = f"""
-        Cache directory not found: /tmp/empty
+        Cache directory not found: {tmp_dir}
         """
 
-        self.assertListEqual(
-            output.getvalue().replace("-", "").split(),
-            expected_output.replace("-", "").split(),
-        )
+        self.assertListEqual(output.getvalue().split(), expected_output.split())
 
 
 @pytest.mark.usefixtures("fx_cache_dir")


### PR DESCRIPTION
If the Huggingface cache is not found, that is useful information to report, but it is not an error. The CLI should not show an error traceback in this situation.