### PR TITLE
Force modelcards to use utf-8 encoding

### DIFF
--- a/src/huggingface_hub/repocard.py
+++ b/src/huggingface_hub/repocard.py
@@ -120,7 +120,7 @@ class RepoCard:
         """
         filepath = Path(filepath)
         filepath.parent.mkdir(parents=True, exist_ok=True)
-        filepath.write_text(str(self))
+        filepath.write_text(str(self), encoding="utf-8")
 
     @classmethod
     def load(
@@ -167,7 +167,7 @@ class RepoCard:
             )
 
         # Preserve newlines in the existing file.
-        with Path(card_path).open(mode="r", newline="") as f:
+        with Path(card_path).open(mode="r", newline="", encoding="utf-8") as f:
             return cls(f.read())
 
     def validate(self, repo_type: Optional[str] = None):


### PR DESCRIPTION
`hfh` v0.10.0 introduced modelcards that was previously hosted on a separate repo (https://github.com/nateraw/modelcards). When moving it into `huggingface_hub`, the use of utf-8 encoding by default has been lost which cause some issues for windows users as highlighted by @BenjaminBossan in https://github.com/skops-dev/skops/pull/162#issuecomment-1263516507.

This PR forces the use of `utf-8` when loading/saving a repocard. Once that is merged, I will cherry-pick the commit in `v0.10-release` branch and bump the version to `v0.10.1` so that this inconsistency stays as little as possible in the wild :) 

@nateraw mind approving the PR ? :pray: 

cc @adrinjalali 