### PR TITLE
Fix test `test_list_models_search`

### DIFF
--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -1166,7 +1166,10 @@ class HfApiPublicTest(unittest.TestCase):
         models = _api.list_models(search="bert")
         self.assertGreater(len(models), 10)
         self.assertIsInstance(models[0], ModelInfo)
-        for model in models:
+        for model in models[:10]:
+            # Rough rule: at least first 10 will have "bert" in the name
+            # Not optimal since it is dependent on how the Hub implements the search
+            # (and changes it in the future) but for now it should do the trick.
             self.assertTrue("bert" in model.modelId.lower())
 
     @with_production_testing


### PR DESCRIPTION
This test is not ideal anyway as we are more testing the Hub behavior than `huggingface_hub` but I guess it is still a good test to keep for now. Hub search rules have recently changed to include more than the model id. Previous implementation of the test was checking that all returned models contained `bert` in there name which is not necesarly the case anymore.

A ok-ish solution is to test only the first 10 models that are returned and assume the search is not completely broken if it works for those ones :)