### PR TITLE
Propagate error messages when multiple on BadRequest

### DIFF
--- a/tests/test_utils_cache.py
+++ b/tests/test_utils_cache.py
@@ -459,15 +459,15 @@ class TestCorruptedCacheUtils(unittest.TestCase):
         # Readme.md has been modified and then accessed more recently
         self.assertGreaterEqual(
             readme_file_2.blob_last_modified - readme_file_1.blob_last_modified,
-            TIME_GAP * 0.999,  # 0.999 factor because not exactly precise
+            TIME_GAP * 0.9,  # 0.9 factor because not exactly precise
         )
         self.assertGreaterEqual(
             readme_file_2.blob_last_accessed - readme_file_1.blob_last_accessed,
-            2 * TIME_GAP * 0.999,  # 0.999 factor because not exactly precise
+            2 * TIME_GAP * 0.9,  # 0.9 factor because not exactly precise
         )
         self.assertGreaterEqual(
             readme_file_2.blob_last_accessed - readme_file_2.blob_last_modified,
-            TIME_GAP * 0.999,  # 0.999 factor because not exactly precise
+            TIME_GAP * 0.9,  # 0.9 factor because not exactly precise
         )
 
         # Comparison of last_accessed/last_modified between file and repo

--- a/tests/test_utils_errors.py
+++ b/tests/test_utils_errors.py
@@ -204,6 +204,25 @@ class TestHfHubHTTPError(unittest.TestCase):
             " server",
         )
 
+    def test_hf_hub_http_error_init_with_multiple_server_errors(
+        self,
+    ) -> None:
+        """Test server errors are added to the error message after the details.
+
+        Regression test for https://github.com/huggingface/huggingface_hub/issues/1114.
+        """
+        self.response._content = (
+            b'{"httpStatusCode": 400, "errors": [{"message": "this is error 1", "type":'
+            b' "error"}, {"message": "this is error 2", "type": "error"}]}'
+        )
+        error = HfHubHTTPError(
+            "this is a message\n\nSome details.", response=self.response
+        )
+        self.assertEqual(
+            str(error),
+            "this is a message\n\nSome details.\nthis is error 1\nthis is error 2",
+        )
+
     def test_hf_hub_http_error_init_with_server_error_already_in_message(
         self,
     ) -> None:


### PR DESCRIPTION
Fix https://github.com/huggingface/huggingface_hub/issues/1114.

@Narsil exception will now be raised as such:

```
huggingface_hub.utils._errors.BadRequestError:  (Request ID: A83RPh8Orl5DA0S92qTVX)

Bad request for commit endpoint:
You can't have a key with a "." or "$" character in your YAML metadata
```