### PR TITLE
Add error message from `x-error-message` header if exists

### DIFF
--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -37,10 +37,12 @@ from huggingface_hub.file_download import (
 )
 from huggingface_hub.utils import (
     EntryNotFoundError,
+    HfHubHTTPError,
     LocalEntryNotFoundError,
     RepositoryNotFoundError,
     RevisionNotFoundError,
 )
+from tests.testing_constants import TOKEN
 
 from .testing_utils import (
     DUMMY_MODEL_ID,
@@ -372,6 +374,27 @@ class CachedDownloadTests(unittest.TestCase):
             metadata.location,
             url.replace(DUMMY_RENAMED_OLD_MODEL_ID, DUMMY_RENAMED_NEW_MODEL_ID),
         )
+
+
+class StagingCachedDownloadTest(unittest.TestCase):
+    def test_download_from_a_gated_repo_with_hf_hub_download(self):
+        """Checks `hf_hub_download` outputs error on gated repo.
+
+        Regression test for #1121.
+        https://github.com/huggingface/huggingface_hub/pull/1121
+        """
+        with TemporaryDirectory() as tmpdir:
+            with self.assertRaisesRegex(
+                HfHubHTTPError,
+                "Access to model .* is restricted and you are not in the authorized"
+                " list",
+            ):
+                hf_hub_download(
+                    repo_id="datasets_server_org/gated_repo_for_huggingface_hub_ci",
+                    filename="config.json",
+                    use_auth_token=TOKEN,
+                    cache_dir=tmpdir,
+                )
 
 
 class CreateSymlinkTest(unittest.TestCase):

--- a/tests/test_utils_errors.py
+++ b/tests/test_utils_errors.py
@@ -260,3 +260,49 @@ class TestHfHubHTTPError(unittest.TestCase):
             ("this is a message\nthis is an additional message", 1, 2, 3),
         )
         self.assertIsNone(error.server_message)  # added message is not from server
+
+    def test_hf_hub_http_error_init_with_error_message_in_header(self) -> None:
+        """Test server error from header is added to the error message."""
+        self.response.headers = {"X-Error-Message": "Error message from headers."}
+        error = HfHubHTTPError("this is a message", response=self.response)
+        self.assertEqual(str(error), "this is a message\n\nError message from headers.")
+        self.assertEqual(error.server_message, "Error message from headers.")
+
+    def test_hf_hub_http_error_init_with_error_message_from_header_and_body(
+        self,
+    ) -> None:
+        """Test server error from header and from body are added to the error message."""
+        self.response._content = b'{"error": "Error message from body."}'
+        self.response.headers = {"X-Error-Message": "Error message from headers."}
+        error = HfHubHTTPError("this is a message", response=self.response)
+        self.assertEqual(
+            str(error),
+            "this is a message\n\nError message from headers.\nError message from"
+            " body.",
+        )
+        self.assertEqual(
+            error.server_message,
+            "Error message from headers.\nError message from body.",
+        )
+
+    def test_hf_hub_http_error_init_with_error_message_duplicated_in_header_and_body(
+        self,
+    ) -> None:
+        """Test server error from header and from body are the same.
+
+        Should not duplicate it in the raised `HfHubHTTPError`.
+        """
+        self.response._content = (
+            b'{"error": "Error message duplicated in headers and body."}'
+        )
+        self.response.headers = {
+            "X-Error-Message": "Error message duplicated in headers and body."
+        }
+        error = HfHubHTTPError("this is a message", response=self.response)
+        self.assertEqual(
+            str(error),
+            "this is a message\n\nError message duplicated in headers and body.",
+        )
+        self.assertEqual(
+            error.server_message, "Error message duplicated in headers and body."
+        )


### PR DESCRIPTION
Related to https://github.com/huggingface/huggingface_hub/issues/1119, https://github.com/huggingface/moon-landing/issues/4164 (internal repo), https://github.com/huggingface/huggingface_hub/pull/1015 and [this thread on slack](https://huggingface.slack.com/archives/C02EMARJ65P/p1666163944610829) (internal link).

A `x-error-message` is now sent back from the server in a header in case a HEAD request as having body is not allowed in such a case. This PR uses this header to enhance the `HfHubHTTPError` error message.

cc @coyotte508 ~This is not tested yet on a real case as it as just been merged on moon-landing.~ It is now tested with a regression test on the CI.

(cc @apolinario for the gated repo use case)