### PR TITLE
Add `delete_tag` method to `HfApi`

### DIFF
--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -113,6 +113,7 @@ _SUBMOD_ATTRS = {
         "dataset_info",
         "delete_file",
         "delete_repo",
+        "delete_tag",
         "edit_discussion_comment",
         "get_dataset_tags",
         "get_discussion_details",
@@ -333,6 +334,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from .hf_api import dataset_info  # noqa: F401
     from .hf_api import delete_file  # noqa: F401
     from .hf_api import delete_repo  # noqa: F401
+    from .hf_api import delete_tag  # noqa: F401
     from .hf_api import edit_discussion_comment  # noqa: F401
     from .hf_api import get_dataset_tags  # noqa: F401
     from .hf_api import get_discussion_details  # noqa: F401

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -2429,15 +2429,15 @@ class HfApi:
                 Authentication token. Will default to the stored token.
 
             repo_type (`str`, *optional*):
-                Set to `"dataset"` or `"space"` if uploading to a dataset or
-                space, `None` or `"model"` if uploading to a model. Default is
+                Set to `"dataset"` or `"space"` if tagging a dataset or
+                space, `None` or `"model"` if tagging a model. Default is
                 `None`.
 
         Raises:
             [`~utils.RepositoryNotFoundError`]:
                 If repository is not found (error 404): wrong repo_id/repo_type, private
                 but not authenticated or repo does not exist.
-            [`~utils.RepositoryNotFoundError`]:
+            [`~utils.RevisionNotFoundError`]:
                 If revision is not found (error 404) on the repo.
         """
         if repo_type is None:
@@ -2455,6 +2455,53 @@ class HfApi:
 
         # Tag
         response = requests.post(url=tag_url, headers=headers, json=payload)
+        hf_raise_for_status(response)
+
+    @validate_hf_hub_args
+    def delete_tag(
+        self,
+        repo_id: str,
+        *,
+        tag: str,
+        token: Optional[str] = None,
+        repo_type: Optional[str] = None,
+    ) -> None:
+        """
+        Delete a tag from a repo on the Hub.
+
+        Args:
+            repo_id (`str`):
+                The repository in which a commit will be deleted.
+                Example: `"user/my-cool-model"`.
+
+            tag (`str`):
+                The name of the tag to delete.
+
+            token (`str`, *optional*):
+                Authentication token. Will default to the stored token.
+
+            repo_type (`str`, *optional*):
+                Set to `"dataset"` or `"space"` if tagging a dataset or
+                space, `None` or `"model"` if tagging a model. Default is
+                `None`.
+
+        Raises:
+            [`~utils.RepositoryNotFoundError`]:
+                If repository is not found (error 404): wrong repo_id/repo_type, private
+                but not authenticated or repo does not exist.
+            [`~utils.RevisionNotFoundError`]:
+                If tag is not found.
+
+        """
+        if repo_type is None:
+            repo_type = REPO_TYPE_MODEL
+
+        # Prepare request
+        tag_url = f"{self.endpoint}/api/{repo_type}s/{repo_id}/tag/{tag}"
+        headers = self._build_hf_headers(use_auth_token=token, is_write_action=True)
+
+        # Un-tag
+        response = requests.delete(url=tag_url, headers=headers)
         hf_raise_for_status(response)
 
     def get_full_repo_name(
@@ -3343,6 +3390,7 @@ upload_file = api.upload_file
 upload_folder = api.upload_folder
 delete_file = api.delete_file
 create_tag = api.create_tag
+delete_tag = api.delete_tag
 get_full_repo_name = api.get_full_repo_name
 
 get_discussion_details = api.get_discussion_details

--- a/src/huggingface_hub/utils/_errors.py
+++ b/src/huggingface_hub/utils/_errors.py
@@ -277,7 +277,7 @@ def hf_raise_for_status(
 
         # Convert `HTTPError` into a `HfHubHTTPError` to display request information
         # as well (request id and/or server error message)
-        raise HfHubHTTPError(str(HTTPError), response=response) from e
+        raise HfHubHTTPError(str(e), response=response) from e
 
 
 @_deprecate_method(version="0.13", message="Use `hf_raise_for_status` instead.")

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -1100,6 +1100,35 @@ class HfApiTagEndpointTest(HfApiCommonTestWithLogin):
         with self.assertRaises(RevisionNotFoundError):
             self._api.create_tag(self._repo_id, tag="invalid tag", revision="foobar")
 
+    @retry_endpoint
+    @use_tmp_repo("model")
+    def test_delete_tag_create_and_delete_tag(self) -> None:
+        """Check `delete_tag` deletes the tag."""
+        self._api.create_tag(self._repo_id, tag="v0")
+        self._api.model_info(self._repo_id, revision="v0")
+
+        self._api.delete_tag(self._repo_id, tag="v0")
+        with self.assertRaises(RevisionNotFoundError):
+            self._api.model_info(self._repo_id, revision="v0")
+
+    @retry_endpoint
+    @use_tmp_repo("model")
+    def test_delete_tag_missing_tag(self) -> None:
+        """Check cannot `delete_tag` if tag doesn't exist."""
+        with self.assertRaises(RevisionNotFoundError):
+            self._api.delete_tag(self._repo_id, tag="v0")
+
+    @retry_endpoint
+    @use_tmp_repo("model")
+    def test_delete_tag_with_branch_name(self) -> None:
+        """Try to `delete_tag` if tag is a branch name.
+
+        Currently getting a HTTP 500.
+        See https://github.com/huggingface/moon-landing/issues/4223.
+        """
+        with self.assertRaises(HTTPError):
+            self._api.delete_tag(self._repo_id, tag="main")
+
 
 class HfApiPublicTest(unittest.TestCase):
     def test_staging_list_models(self):

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -60,6 +60,7 @@ from huggingface_hub.hf_api import (
 )
 from huggingface_hub.utils import (
     HfFolder,
+    HfHubHTTPError,
     RepositoryNotFoundError,
     RevisionNotFoundError,
     logging,
@@ -1102,7 +1103,14 @@ class HfApiTagEndpointTest(HfApiCommonTestWithLogin):
 
     @retry_endpoint
     @use_tmp_repo("model")
-    def test_delete_tag_create_and_delete_tag(self) -> None:
+    def test_create_tag_twice(self) -> None:
+        """Check `create_tag` called twice on same tag should not fail."""
+        self._api.create_tag(self._repo_id, tag="tag_1")
+        self._api.create_tag(self._repo_id, tag="tag_1")
+
+    @retry_endpoint
+    @use_tmp_repo("model")
+    def test_create_and_delete_tag(self) -> None:
         """Check `delete_tag` deletes the tag."""
         self._api.create_tag(self._repo_id, tag="v0")
         self._api.model_info(self._repo_id, revision="v0")
@@ -1126,7 +1134,7 @@ class HfApiTagEndpointTest(HfApiCommonTestWithLogin):
         Currently getting a HTTP 500.
         See https://github.com/huggingface/moon-landing/issues/4223.
         """
-        with self.assertRaises(HTTPError):
+        with self.assertRaises(HfHubHTTPError):
             self._api.delete_tag(self._repo_id, tag="main")
 
 


### PR DESCRIPTION
Fix https://github.com/huggingface/huggingface_hub/issues/1095.
I created 2 issues in moon-landing while working on it (https://github.com/huggingface/moon-landing/issues/4219 and https://github.com/huggingface/moon-landing/issues/4223 -internal links-).

Simply adds a method to wraps the `https://huggingface.co/api/models/gpt2/tag/this_is_a_tag` endpoint introduced by https://github.com/huggingface/moon-landing/pull/4005 (internal link).