### PR TITLE
Fix `HfApi.move_repo(...)` and complete tests

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -54,6 +54,7 @@ from .constants import (
 )
 from .utils import HfFolder  # noqa: F401 # imported for backward compatibility
 from .utils import (
+    HfHubHTTPError,
     build_hf_headers,
     filter_repo_objects,
     hf_raise_for_status,
@@ -1753,6 +1754,9 @@ class HfApi:
                 " (:namespace:/:repo_name:)"
             )
 
+        if repo_type is None:
+            repo_type = REPO_TYPE_MODEL  # Hub won't accept `None`.
+
         json = {"fromRepo": from_id, "toRepo": to_id, "type": repo_type}
 
         path = f"{self.endpoint}/api/repos/move"
@@ -1760,19 +1764,12 @@ class HfApi:
         r = requests.post(path, headers=headers, json=json)
         try:
             hf_raise_for_status(r)
-        except HTTPError as e:
-            if r.text:
-                raise HTTPError(
-                    f"{r.status_code} Error Message: {r.text}. For additional"
-                    " documentation please see"
-                    " https://hf.co/docs/hub/main#how-can-i-rename-or-transfer-a-repo."
-                ) from e
-            else:
-                raise e
-        logger.info(
-            "Accepted transfer request. You will get an email once this is successfully"
-            " completed."
-        )
+        except HfHubHTTPError as e:
+            e.append_to_message(
+                f"\nFor additional documentation please see"
+                f" https://hf.co/docs/hub/main#how-can-i-rename-or-transfer-a-repo."
+            )
+            raise
 
     @validate_hf_hub_args
     def create_commit(

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -1766,8 +1766,8 @@ class HfApi:
             hf_raise_for_status(r)
         except HfHubHTTPError as e:
             e.append_to_message(
-                f"\nFor additional documentation please see"
-                f" https://hf.co/docs/hub/main#how-can-i-rename-or-transfer-a-repo."
+                "\nFor additional documentation please see"
+                " https://hf.co/docs/hub/main#how-can-i-rename-or-transfer-a-repo."
             )
             raise
 


### PR DESCRIPTION
Fix https://github.com/huggingface/huggingface_hub/issues/775.

PR includes:
- [x] remove log "email has been sent" since it's not the case anymore
- [x] fix `move_repo` when `repo_type` is not specified (`None` was raising an error)
- [x] refactored raise on status to output "rich" exceptions using server error message
- [x] add test move_repo with `None`
- [x] separate tests for wrong value on repo_id
- [x] add test for move_repo on existing repo_id

(cc @coyotte508 @Pierrci even though that issue was quite old)