### PR TITLE
Refactor git credential handling in login workflow

### DIFF
--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -180,8 +180,6 @@ _SUBMOD_ATTRS = {
         "cached_assets_path",
         "logging",
         "scan_cache_dir",
-        "set_git_credential",
-        "unset_git_credential",
     ],
     "utils.endpoint_helpers": [
         "DatasetFilter",
@@ -390,7 +388,5 @@ if TYPE_CHECKING:  # pragma: no cover
     from .utils import cached_assets_path  # noqa: F401
     from .utils import logging  # noqa: F401
     from .utils import scan_cache_dir  # noqa: F401
-    from .utils import set_git_credential  # noqa: F401
-    from .utils import unset_git_credential  # noqa: F401
     from .utils.endpoint_helpers import DatasetFilter  # noqa: F401
     from .utils.endpoint_helpers import ModelFilter  # noqa: F401

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -180,6 +180,8 @@ _SUBMOD_ATTRS = {
         "cached_assets_path",
         "logging",
         "scan_cache_dir",
+        "set_git_credential",
+        "unset_git_credential",
     ],
     "utils.endpoint_helpers": [
         "DatasetFilter",
@@ -388,5 +390,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from .utils import cached_assets_path  # noqa: F401
     from .utils import logging  # noqa: F401
     from .utils import scan_cache_dir  # noqa: F401
+    from .utils import set_git_credential  # noqa: F401
+    from .utils import unset_git_credential  # noqa: F401
     from .utils.endpoint_helpers import DatasetFilter  # noqa: F401
     from .utils.endpoint_helpers import ModelFilter  # noqa: F401

--- a/src/huggingface_hub/_login.py
+++ b/src/huggingface_hub/_login.py
@@ -18,7 +18,15 @@ from typing import List, Optional
 
 from .commands._cli_utils import ANSI
 from .hf_api import HfApi
-from .utils import HfFolder, is_google_colab, is_notebook, logging, run_subprocess
+from .utils import (
+    HfFolder,
+    is_google_colab,
+    is_notebook,
+    list_credential_helpers,
+    logging,
+    run_subprocess,
+)
+from .utils._deprecation import _deprecate_method
 
 
 logger = logging.get_logger(__name__)
@@ -236,18 +244,8 @@ def _set_store_as_git_credential_helper_globally() -> None:
         raise EnvironmentError(exc.stderr)
 
 
-def _currently_setup_credential_helpers(directory=None) -> List[str]:
-    try:
-        output = run_subprocess(
-            "git config --list".split(),
-            directory,
-        ).stdout.split("\n")
-
-        current_credential_helpers = []
-        for line in output:
-            if "credential.helper" in line:
-                current_credential_helpers.append(line.split("=")[-1])
-    except subprocess.CalledProcessError as exc:
-        raise EnvironmentError(exc.stderr)
-
-    return current_credential_helpers
+@_deprecate_method(
+    version="0.14", message="Please use `list_credential_helpers` instead."
+)
+def _currently_setup_credential_helpers(directory: Optional[str] = None) -> List[str]:
+    return list_credential_helpers(directory)

--- a/src/huggingface_hub/_login.py
+++ b/src/huggingface_hub/_login.py
@@ -35,7 +35,7 @@ from .utils._deprecation import _deprecate_method
 logger = logging.get_logger(__name__)
 
 
-def login(token: Optional[str] = None, add_to_git_credential: bool = False) -> None:
+def login(token: Optional[str] = None, add_to_git_credential: bool = True) -> None:
     """Login the machine to access the Hub.
 
     The `token` is persisted in cache and set as a git credential. Once done, the machine

--- a/src/huggingface_hub/_login.py
+++ b/src/huggingface_hub/_login.py
@@ -17,6 +17,7 @@ from getpass import getpass
 from typing import List, Optional
 
 from .commands._cli_utils import ANSI
+from .commands.delete_cache import _ask_for_confirmation_no_tui
 from .hf_api import HfApi
 from .utils import (
     HfFolder,
@@ -25,6 +26,8 @@ from .utils import (
     list_credential_helpers,
     logging,
     run_subprocess,
+    set_git_credential,
+    unset_git_credential,
 )
 from .utils._deprecation import _deprecate_method
 
@@ -32,7 +35,7 @@ from .utils._deprecation import _deprecate_method
 logger = logging.get_logger(__name__)
 
 
-def login(token: Optional[str] = None) -> None:
+def login(token: Optional[str] = None, add_to_git_credential: bool = False) -> None:
     """Login the machine to access the Hub.
 
     The `token` is persisted in cache and set as a git credential. Once done, the machine
@@ -58,6 +61,12 @@ def login(token: Optional[str] = None) -> None:
     Args:
         token (`str`, *optional*):
             User access token to generate from https://huggingface.co/settings/token.
+        add_to_git_credential (`bool`, defaults to `False`):
+            If `True`, token will be set as git credential. If no git credential helper
+            is configured, a warning will be displayed to the user. If `token` is `None`,
+            the value of `add_to_git_credential` is ignored and will be prompted again
+            to the end user.
+
 
     Raises:
         [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
@@ -69,7 +78,13 @@ def login(token: Optional[str] = None) -> None:
             If running in a notebook but `ipywidgets` is not installed.
     """
     if token is not None:
-        _login(token)
+        if not add_to_git_credential:
+            print(
+                "Token will not been saved to git credential helper. Pass"
+                " `add_to_git_credential=True` if you want to set the git"
+                " credential as well."
+            )
+        _login(token, add_to_git_credential=add_to_git_credential)
     elif is_notebook():
         notebook_login()
     else:
@@ -86,7 +101,7 @@ def logout() -> None:
         print("Not logged in!")
         return
     HfFolder.delete_token()
-    HfApi.unset_access_token()
+    unset_git_credential()
     print("Successfully logged out.")
 
 
@@ -116,7 +131,12 @@ def interpreter_login() -> None:
     To login, `huggingface_hub` now requires a token generated from https://huggingface.co/settings/tokens .
     """
     )
-    _login(token=getpass("Token: "))
+    token = getpass("Token: ")
+    add_to_git_credential = _ask_for_confirmation_no_tui(
+        f"Add token as git credential?"
+    )
+
+    _login(token=token, add_to_git_credential=add_to_git_credential)
 
 
 ###
@@ -167,12 +187,16 @@ def notebook_login() -> None:
     )
 
     token_widget = widgets.Password(description="Token:")
+    git_checkbox_widget = widgets.Checkbox(
+        value=True, description="Add token as git credential?"
+    )
     token_finish_button = widgets.Button(description="Login")
 
     login_token_widget = widgets.VBox(
         [
             widgets.HTML(NOTEBOOK_LOGIN_TOKEN_HTML_START),
             token_widget,
+            git_checkbox_widget,
             token_finish_button,
             widgets.HTML(NOTEBOOK_LOGIN_TOKEN_HTML_END),
         ],
@@ -183,10 +207,11 @@ def notebook_login() -> None:
     # On click events
     def login_token_event(t):
         token = token_widget.value
+        add_to_git_credential = git_checkbox_widget.value
         # Erase token and clear value to make sure it's not saved in the notebook.
         token_widget.value = ""
         clear_output()
-        _login(token)
+        _login(token, add_to_git_credential=add_to_git_credential)
 
     token_finish_button.on_click(login_token_event)
 
@@ -196,34 +221,58 @@ def notebook_login() -> None:
 ###
 
 
-def _login(token: str) -> None:
+def _login(token: str, add_to_git_credential: bool) -> None:
     hf_api = HfApi()
     if token.startswith("api_org"):
         raise ValueError("You must use your personal account token.")
     if not hf_api._is_valid_token(token=token):
         raise ValueError("Invalid token passed!")
-    hf_api.set_access_token(token)
+    print("Token is valid.")
+
+    if add_to_git_credential:
+        if _is_git_credential_helper_configured():
+            set_git_credential(token)
+            print(
+                "Your token has been saved in your configured git credential helpers"
+                f" ({','.join(list_credential_helpers())})."
+            )
+        else:
+            print("Token has not been saved to git credential helper.")
+
     HfFolder.save_token(token)
-    print("Login successful")
     print("Your token has been saved to", HfFolder.path_token)
+    print("Login successful")
+
+
+def _is_git_credential_helper_configured() -> bool:
+    """Check if a git credential helper is configured.
+
+    Warns user if not the case (except for Google Colab where "store" is set by default
+    by `huggingface_hub`).
+    """
+    helpers = list_credential_helpers()
+    if len(helpers) > 0:
+        return True  # Do not warn: at least 1 helper is set
 
     # Only in Google Colab to avoid the warning message
     # See https://github.com/huggingface/huggingface_hub/issues/1043#issuecomment-1247010710
     if is_google_colab():
         _set_store_as_git_credential_helper_globally()
+        return True  # Do not warn: "store" is used by default in Google Colab
 
-    helpers = _currently_setup_credential_helpers()
-
-    if "store" not in helpers:
-        print(
-            ANSI.red(
-                "Authenticated through git-credential store but this isn't the helper"
-                " defined on your machine.\nYou might have to re-authenticate when"
-                " pushing to the Hugging Face Hub. Run the following command in your"
-                " terminal in case you want to set this credential helper as the"
-                " default\n\ngit config --global credential.helper store"
-            )
+    # Otherwise, warn user
+    print(
+        ANSI.red(
+            "Cannot authenticate through git-credential as no helper is defined on your"
+            " machine.\nYou might have to re-authenticate when pushing to the Hugging"
+            " Face Hub.\nRun the following command in your terminal in case you want to"
+            " set the 'store' credential helper as default.\n\ngit config --global"
+            " credential.helper store\n\nRead"
+            " https://git-scm.com/book/en/v2/Git-Tools-Credential-Storage for more"
+            " details."
         )
+    )
+    return False
 
 
 def _set_store_as_git_credential_helper_globally() -> None:

--- a/src/huggingface_hub/_login.py
+++ b/src/huggingface_hub/_login.py
@@ -132,9 +132,7 @@ def interpreter_login() -> None:
     """
     )
     token = getpass("Token: ")
-    add_to_git_credential = _ask_for_confirmation_no_tui(
-        f"Add token as git credential?"
-    )
+    add_to_git_credential = _ask_for_confirmation_no_tui("Add token as git credential?")
 
     _login(token=token, add_to_git_credential=add_to_git_credential)
 

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -64,7 +64,7 @@ from .utils import (  # noqa: F401 # imported for backward compatibility
     validate_hf_hub_args,
     write_to_credential_store,
 )
-from .utils._deprecation import _deprecate_positional_args
+from .utils._deprecation import _deprecate_method, _deprecate_positional_args
 from .utils._typing import Literal, TypedDict
 from .utils.endpoint_helpers import (
     AttributeDictionary,
@@ -612,6 +612,13 @@ class HfApi:
             return False
 
     @staticmethod
+    @_deprecate_method(
+        version="0.14",
+        message=(
+            "`HfApi.set_access_token` is deprecated as it is very ambiguous. Use"
+            " `login` or `set_git_credential` instead."
+        ),
+    )
     def set_access_token(access_token: str):
         """
         Saves the passed access token so git can correctly authenticate the
@@ -624,6 +631,13 @@ class HfApi:
         write_to_credential_store(USERNAME_PLACEHOLDER, access_token)
 
     @staticmethod
+    @_deprecate_method(
+        version="0.14",
+        message=(
+            "`HfApi.unset_access_token` is deprecated as it is very ambiguous. Use"
+            " `login` or `unset_git_credential` instead."
+        ),
+    )
     def unset_access_token():
         """
         Resets the user's access token.

--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -68,7 +68,7 @@ from ._runtime import (
     is_tf_available,
     is_torch_available,
 )
-from ._subprocess import run_subprocess
+from ._subprocess import run_interactive_subprocess, run_subprocess
 from ._validators import (
     HFValidationError,
     smoothly_deprecate_use_auth_token,

--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -41,10 +41,10 @@ from ._errors import (
 from ._fixes import yaml_dump
 from ._git_credential import (
     erase_from_credential_store,
-    git_credential_approve,
     git_credential_fill,
-    git_credential_reject,
     read_from_credential_store,
+    set_git_credential,
+    unset_git_credential,
     write_to_credential_store,
 )
 from ._headers import build_hf_headers, get_token_to_send

--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -41,7 +41,7 @@ from ._errors import (
 from ._fixes import yaml_dump
 from ._git_credential import (
     erase_from_credential_store,
-    git_credential_fill,
+    list_credential_helpers,
     read_from_credential_store,
     set_git_credential,
     unset_git_credential,

--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -39,6 +39,11 @@ from ._errors import (
     hf_raise_for_status,
 )
 from ._fixes import yaml_dump
+from ._git_credential import (
+    erase_from_credential_store,
+    read_from_credential_store,
+    write_to_credential_store,
+)
 from ._headers import build_hf_headers, get_token_to_send
 from ._hf_folder import HfFolder
 from ._http import http_backoff

--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -41,6 +41,9 @@ from ._errors import (
 from ._fixes import yaml_dump
 from ._git_credential import (
     erase_from_credential_store,
+    git_credential_approve,
+    git_credential_fill,
+    git_credential_reject,
     read_from_credential_store,
     write_to_credential_store,
 )

--- a/src/huggingface_hub/utils/_git_credential.py
+++ b/src/huggingface_hub/utils/_git_credential.py
@@ -200,16 +200,3 @@ def erase_from_credential_store(username: Optional[str] = None) -> None:
 #         username_match.groupdict()["username"],
 #         password_match.groupdict()["password"],
 #     )
-
-
-def _is_git_credential_helper_configured() -> bool:
-    """Return True if `git credential` has at least 1 helper configured."""
-    try:
-        output = run_subprocess("git config --list").stdout.split("\n")
-    except subprocess.CalledProcessError as exc:
-        raise EnvironmentError(exc.stderr)
-
-    for line in output:
-        if "credential.helper" in line:
-            return True
-    return False

--- a/src/huggingface_hub/utils/_git_credential.py
+++ b/src/huggingface_hub/utils/_git_credential.py
@@ -1,0 +1,83 @@
+import subprocess
+from contextlib import contextmanager
+from typing import IO, Generator, Optional, Tuple, Union
+
+from ..constants import ENDPOINT
+
+
+def write_to_credential_store(username: str, password: str) -> None:
+    with _interactive_subprocess("git credential-store store") as (stdin, _):
+        input_username = f"username={username.lower()}"
+        input_password = f"password={password}"
+
+        stdin.write(
+            f"url={ENDPOINT}\n{input_username}\n{input_password}\n\n".encode("utf-8")
+        )
+        stdin.flush()
+
+
+def read_from_credential_store(
+    username: Optional[str] = None,
+) -> Union[Tuple[str, str], Tuple[None, None]]:
+    """
+    Reads the credential store relative to huggingface.co.
+
+    Args:
+        username (`str`, *optional*):
+            A username to filter to search. If not specified, the first entry under
+            `huggingface.co` endpoint is returned.
+
+    Returns:
+        `Tuple[str, str]` or `Tuple[None, None]`: either a username/password pair or
+        None/None if credential has not been found. The returned username is always
+        lowercase.
+    """
+    with _interactive_subprocess("git credential-store get") as (stdin, stdout):
+        standard_input = f"url={ENDPOINT}\n"
+        if username is not None:
+            standard_input += f"username={username.lower()}\n"
+        standard_input += "\n"
+
+        stdin.write(standard_input.encode("utf-8"))
+        stdin.flush()
+        output = stdout.read().decode("utf-8")
+
+    if len(output) == 0:
+        return None, None
+
+    username, password = [line for line in output.split("\n") if len(line) != 0]
+    return username.split("=")[1], password.split("=")[1]
+
+
+def erase_from_credential_store(username: Optional[str] = None) -> None:
+    """
+    Erases the credential store relative to huggingface.co.
+
+    Args:
+        username (`str`, *optional*):
+            A username to filter to search. If not specified, all entries under
+            `huggingface.co` endpoint is erased.
+    """
+    with _interactive_subprocess("git credential-store erase") as (stdin, _):
+        standard_input = f"url={ENDPOINT}\n"
+        if username is not None:
+            standard_input += f"username={username.lower()}\n"
+        standard_input += "\n"
+
+        stdin.write(standard_input.encode("utf-8"))
+        stdin.flush()
+
+
+@contextmanager
+def _interactive_subprocess(
+    command: str,
+) -> Generator[Tuple[IO[bytes], IO[bytes]], None, None]:
+    with subprocess.Popen(
+        command.split(),
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    ) as process:
+        assert process.stdin is not None, "subprocess is opened as subprocess.PIPE"
+        assert process.stdout is not None, "subprocess is opened as subprocess.PIPE"
+        yield process.stdin, process.stdout

--- a/src/huggingface_hub/utils/_git_credential.py
+++ b/src/huggingface_hub/utils/_git_credential.py
@@ -13,23 +13,37 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Contains utilities to manage Git credentials."""
+import subprocess
 from typing import Optional, Tuple, Union
 
 from ..constants import ENDPOINT
-from ._subprocess import run_interactive_subprocess
+from ._deprecation import _deprecate_method
+from ._runtime import is_google_colab, is_notebook
+from ._subprocess import run_interactive_subprocess, run_subprocess
 
 
+@_deprecate_method(
+    version="0.14",
+    message=(
+        "Please use `huggingface_hub.utils.git_credential_approve` instead as it allows"
+        " the user to chose which git-credential tool to use."
+    ),
+)
 def write_to_credential_store(username: str, password: str) -> None:
     with run_interactive_subprocess("git credential-store store") as (stdin, _):
         input_username = f"username={username.lower()}"
         input_password = f"password={password}"
-
-        stdin.write(
-            f"url={ENDPOINT}\n{input_username}\n{input_password}\n\n".encode("utf-8")
-        )
+        stdin.write(f"url={ENDPOINT}\n{input_username}\n{input_password}\n\n")
         stdin.flush()
 
 
+@_deprecate_method(
+    version="0.14",
+    message=(
+        "Please use `huggingface_hub.utils.git_credential_fill` instead as it allows"
+        " the user to chose which git-credential tool to use."
+    ),
+)
 def read_from_credential_store(
     username: Optional[str] = None,
 ) -> Union[Tuple[str, str], Tuple[None, None]]:
@@ -52,9 +66,9 @@ def read_from_credential_store(
             standard_input += f"username={username.lower()}\n"
         standard_input += "\n"
 
-        stdin.write(standard_input.encode("utf-8"))
+        stdin.write(standard_input)
         stdin.flush()
-        output = stdout.read().decode("utf-8")
+        output = stdout.read()
 
     if len(output) == 0:
         return None, None
@@ -63,6 +77,13 @@ def read_from_credential_store(
     return username.split("=")[1], password.split("=")[1]
 
 
+@_deprecate_method(
+    version="0.14",
+    message=(
+        "Please use `huggingface_hub.utils.git_credential_reject` instead as it allows"
+        " the user to chose which git-credential tool to use."
+    ),
+)
 def erase_from_credential_store(username: Optional[str] = None) -> None:
     """
     Erases the credential store relative to huggingface.co.
@@ -78,5 +99,55 @@ def erase_from_credential_store(username: Optional[str] = None) -> None:
             standard_input += f"username={username.lower()}\n"
         standard_input += "\n"
 
-        stdin.write(standard_input.encode("utf-8"))
+        stdin.write(standard_input)
         stdin.flush()
+
+
+def git_credential_approve(username: str, password: str) -> None:
+    with run_interactive_subprocess("git credential approve") as (stdin, _):
+        stdin.write(
+            f"url={ENDPOINT}\nusername={username.lower()}\npassword={password}\n\n"
+        )
+        stdin.flush()
+
+
+def git_credential_fill(username: Optional[str] = None) -> None:
+    with run_interactive_subprocess("git credential fill") as (stdin, stdout):
+        standard_input = f"url={ENDPOINT}\n"
+        if username is not None:
+            standard_input += f"username={username.lower()}\n"
+        standard_input += "\n"
+
+        stdin.write(standard_input)
+        stdin.flush()
+        output = stdout.read()
+
+    if len(output) == 0:
+        return None, None
+
+    username, password = [line for line in output.split("\n") if len(line) != 0]
+    return username.split("=")[1], password.split("=")[1]
+
+
+def git_credential_reject(username: Optional[str] = None) -> None:
+    with run_interactive_subprocess("git credential reject") as (stdin, _):
+        standard_input = f"url={ENDPOINT}\n"
+        if username is not None:
+            standard_input += f"username={username.lower()}\n"
+        standard_input += "\n"
+
+        stdin.write(standard_input)
+        stdin.flush()
+
+
+def _is_git_credential_helper_configured() -> bool:
+    """Return True if `git credential` has at least 1 helper configured."""
+    try:
+        output = run_subprocess("git config --list").stdout.split("\n")
+    except subprocess.CalledProcessError as exc:
+        raise EnvironmentError(exc.stderr)
+
+    for line in output:
+        if "credential.helper" in line:
+            return True
+    return False

--- a/src/huggingface_hub/utils/_subprocess.py
+++ b/src/huggingface_hub/utils/_subprocess.py
@@ -13,10 +13,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License
+"""Contains utilities to easily handle subprocesses in `huggingface_hub`."""
 import os
 import subprocess
+from contextlib import contextmanager
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import IO, Generator, List, Optional, Tuple, Union
 
 from .logging import get_logger
 
@@ -65,3 +67,52 @@ def run_subprocess(
         cwd=folder or os.getcwd(),
         **kwargs,
     )
+
+
+@contextmanager
+def run_interactive_subprocess(
+    command: Union[str, List[str]],
+    folder: Optional[Union[str, Path]] = None,
+    **kwargs,
+) -> Generator[Tuple[IO[bytes], IO[bytes]], None, None]:
+    """Run a subprocess in an interactive mode in a context manager.
+
+    Args:
+        command (`str` or `List[str]`):
+            The command to execute as a string or list of strings.
+        folder (`str`, *optional*):
+            The folder in which to run the command. Defaults to current working
+            directory (from `os.getcwd()`).
+        kwargs (`Dict[str]`):
+            Keyword arguments to be passed to the `subprocess.run` underlying command.
+
+    Returns:
+        `Tuple[IO[bytes], IO[bytes]]`: A tuple with `stdin` and `stdout` to interact
+        with the process.
+
+    Example:
+    ```python
+    with _interactive_subprocess("git credential-store get") as (stdin, stdout):
+        # Write to stdin
+        stdin.write("url=hf.co\nusername=obama\n".encode("utf-8"))
+        stdin.flush()
+
+        # Read from stdout
+        output = stdout.read().decode("utf-8")
+    ```
+    """
+    if isinstance(command, str):
+        command = command.split()
+
+    with subprocess.Popen(
+        command,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        encoding="utf-8",
+        cwd=folder or os.getcwd(),
+        **kwargs,
+    ) as process:
+        assert process.stdin is not None, "subprocess is opened as subprocess.PIPE"
+        assert process.stdout is not None, "subprocess is opened as subprocess.PIPE"
+        yield process.stdin, process.stdout

--- a/src/huggingface_hub/utils/_subprocess.py
+++ b/src/huggingface_hub/utils/_subprocess.py
@@ -74,7 +74,7 @@ def run_interactive_subprocess(
     command: Union[str, List[str]],
     folder: Optional[Union[str, Path]] = None,
     **kwargs,
-) -> Generator[Tuple[IO[bytes], IO[bytes]], None, None]:
+) -> Generator[Tuple[IO[str], IO[str]], None, None]:
     """Run a subprocess in an interactive mode in a context manager.
 
     Args:
@@ -87,8 +87,8 @@ def run_interactive_subprocess(
             Keyword arguments to be passed to the `subprocess.run` underlying command.
 
     Returns:
-        `Tuple[IO[bytes], IO[bytes]]`: A tuple with `stdin` and `stdout` to interact
-        with the process.
+        `Tuple[IO[str], IO[str]]`: A tuple with `stdin` and `stdout` to interact
+        with the process (input and output are utf-8 encoded).
 
     Example:
     ```python

--- a/tests/test_cache_layout.py
+++ b/tests/test_cache_layout.py
@@ -9,7 +9,7 @@ from huggingface_hub.utils import logging
 from huggingface_hub.utils._errors import EntryNotFoundError
 
 from .testing_constants import ENDPOINT_STAGING, TOKEN, USER
-from .testing_utils import repo_name, with_production_testing
+from .testing_utils import expect_deprecation, repo_name, with_production_testing
 
 
 logger = logging.get_logger(__name__)
@@ -315,6 +315,7 @@ class ReferenceUpdates(unittest.TestCase):
     _api = HfApi(endpoint=ENDPOINT_STAGING, token=TOKEN)
 
     @classmethod
+    @expect_deprecation("set_access_token")
     def setUpClass(cls):
         """
         Share this valid token in all tests below.

--- a/tests/test_fastai_integration.py
+++ b/tests/test_fastai_integration.py
@@ -15,7 +15,7 @@ from huggingface_hub.utils import (
 )
 
 from .testing_constants import ENDPOINT_STAGING, TOKEN, USER
-from .testing_utils import repo_name, set_write_permission_and_retry
+from .testing_utils import expect_deprecation, repo_name, set_write_permission_and_retry
 
 
 WORKING_REPO_SUBDIR = f"fixtures/working_repo_{__name__.split('.')[-1]}"
@@ -65,6 +65,7 @@ else:
 @require_fastai_fastcore
 class TestFastaiUtils(TestCase):
     @classmethod
+    @expect_deprecation("set_access_token")
     def setUpClass(cls):
         """
         Share this valid token in all tests below.

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -34,7 +34,7 @@ from huggingface_hub._commit_api import (
     CommitOperationDelete,
     fetch_upload_modes,
 )
-from huggingface_hub._login import _login
+from huggingface_hub._login import _login, _set_store_as_git_credential_helper_globally
 from huggingface_hub.community import DiscussionComment, DiscussionWithDetails
 from huggingface_hub.constants import (
     REPO_TYPE_DATASET,
@@ -149,7 +149,8 @@ class HfApiLoginTest(HfApiCommonTest):
             read_from_credential_store(USERNAME_PLACEHOLDER), (None, None)
         )
 
-        _login(token=TOKEN, add_to_git_credential=True)
+        _set_store_as_git_credential_helper_globally()
+        _login(token=TOKEN)
         self.assertTupleEqual(
             read_from_credential_store(USERNAME_PLACEHOLDER),
             (USERNAME_PLACEHOLDER, TOKEN),

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -150,7 +150,7 @@ class HfApiLoginTest(HfApiCommonTest):
         )
 
         _set_store_as_git_credential_helper_globally()
-        _login(token=TOKEN)
+        _login(token=TOKEN, add_to_git_credential=True)
         self.assertTupleEqual(
             read_from_credential_store(USERNAME_PLACEHOLDER),
             (USERNAME_PLACEHOLDER, TOKEN),

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -149,7 +149,7 @@ class HfApiLoginTest(HfApiCommonTest):
             read_from_credential_store(USERNAME_PLACEHOLDER), (None, None)
         )
 
-        _login(token=TOKEN)
+        _login(token=TOKEN, add_to_git_credential=True)
         self.assertTupleEqual(
             read_from_credential_store(USERNAME_PLACEHOLDER),
             (USERNAME_PLACEHOLDER, TOKEN),
@@ -163,7 +163,7 @@ class HfApiLoginTest(HfApiCommonTest):
         with pytest.raises(
             ValueError, match="You must use your personal account token."
         ):
-            _login(token="api_org_dummy_token")
+            _login(token="api_org_dummy_token", add_to_git_credential=True)
 
 
 class HfApiCommonTestWithLogin(HfApiCommonTest):

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -85,6 +85,7 @@ from .testing_utils import (
     DUMMY_MODEL_ID,
     DUMMY_MODEL_ID_REVISION_ONE_SPECIFIC_COMMIT,
     SAMPLE_DATASET_IDENTIFIER,
+    expect_deprecation,
     repo_name,
     require_git_lfs,
     retry_endpoint,
@@ -112,13 +113,16 @@ class HfApiCommonTest(unittest.TestCase):
 
 
 class HfApiLoginTest(HfApiCommonTest):
+    @expect_deprecation("erase_from_credential_store")
     def setUp(self) -> None:
         erase_from_credential_store(USERNAME_PLACEHOLDER)
 
     @classmethod
+    @expect_deprecation("set_access_token")
     def tearDownClass(cls) -> None:
         cls._api.set_access_token(TOKEN)
 
+    @expect_deprecation("read_from_credential_store")
     def test_login_git_credentials(self):
         self.assertTupleEqual(
             read_from_credential_store(USERNAME_PLACEHOLDER), (None, None)
@@ -133,6 +137,7 @@ class HfApiLoginTest(HfApiCommonTest):
             read_from_credential_store(USERNAME_PLACEHOLDER), (None, None)
         )
 
+    @expect_deprecation("read_from_credential_store")
     def test_login_cli(self):
         self._api.set_access_token(TOKEN)
         self.assertTupleEqual(
@@ -163,6 +168,7 @@ class HfApiLoginTest(HfApiCommonTest):
 
 class HfApiCommonTestWithLogin(HfApiCommonTest):
     @classmethod
+    @expect_deprecation("set_access_token")
     def setUpClass(cls):
         """
         Share this valid token in all tests below.
@@ -1766,6 +1772,7 @@ class HfFolderTest(unittest.TestCase):
 @require_git_lfs
 class HfLargefilesTest(HfApiCommonTest):
     @classmethod
+    @expect_deprecation("set_access_token")
     def setUpClass(cls):
         """
         Share this valid token in all tests below.

--- a/tests/test_hubmixin.py
+++ b/tests/test_hubmixin.py
@@ -67,6 +67,7 @@ class HubMixingTest(HubMixingCommonTest):
         )
 
     @classmethod
+    @expect_deprecation("set_access_token")
     def setUpClass(cls):
         """
         Share this valid token in all tests below.

--- a/tests/test_keras_integration.py
+++ b/tests/test_keras_integration.py
@@ -85,6 +85,7 @@ class CommonKerasTest(unittest.TestCase):
         )
 
     @classmethod
+    @expect_deprecation("set_access_token")
     def setUpClass(cls):
         """
         Share this valid token in all tests below.

--- a/tests/test_repocard.py
+++ b/tests/test_repocard.py
@@ -49,7 +49,12 @@ from .testing_constants import (
     TOKEN,
     USER,
 )
-from .testing_utils import repo_name, retry_endpoint, set_write_permission_and_retry
+from .testing_utils import (
+    expect_deprecation,
+    repo_name,
+    retry_endpoint,
+    set_write_permission_and_retry,
+)
 
 
 SAMPLE_CARDS_DIR = Path(__file__).parent / "fixtures/cards"
@@ -223,6 +228,7 @@ class RepocardMetadataUpdateTest(unittest.TestCase):
     _api = HfApi(endpoint=ENDPOINT_STAGING, token=TOKEN)
 
     @classmethod
+    @expect_deprecation("set_access_token")
     def setUpClass(cls):
         """
         Share this valid token in all tests below.

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1619,6 +1619,7 @@ class RepositoryOfflineTest(RepositoryCommonTest):
 
 class RepositoryDatasetTest(RepositoryCommonTest):
     @classmethod
+    @expect_deprecation("set_access_token")
     def setUpClass(cls):
         """
         Share this valid token in all tests below.

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -65,6 +65,7 @@ class RepositoryCommonTest(unittest.TestCase):
 
 class RepositoryTest(RepositoryCommonTest):
     @classmethod
+    @expect_deprecation("set_access_token")
     def setUpClass(cls):
         """
         Share this valid token in all tests below.
@@ -1455,6 +1456,7 @@ class RepositoryOfflineTest(RepositoryCommonTest):
         files = os.listdir(current_head_repo.local_dir)
         self.assertIn("file.txt", files)
 
+    @expect_deprecation("set_access_token")
     def test_repo_user(self):
         api = HfApi(endpoint=ENDPOINT_STAGING)
         token = TOKEN
@@ -1483,6 +1485,7 @@ class RepositoryOfflineTest(RepositoryCommonTest):
         self.assertEqual(username, user["fullname"])
         self.assertEqual(email, user["email"])
 
+    @expect_deprecation("set_access_token")
     def test_repo_passed_user(self):
         api = HfApi(endpoint=ENDPOINT_STAGING)
         token = TOKEN

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1516,6 +1516,7 @@ class RepositoryOfflineTest(RepositoryCommonTest):
         self.assertEqual(username, "RANDOM_USER")
         self.assertEqual(email, "EMAIL@EMAIL.EMAIL")
 
+    @expect_deprecation("_currently_setup_credential_helpers")
     def test_correct_helper(self):
         subprocess.run(
             ["git", "config", "--global", "credential.helper", "get"],

--- a/tests/test_snapshot_download.py
+++ b/tests/test_snapshot_download.py
@@ -25,6 +25,7 @@ class SnapshotDownloadTests(unittest.TestCase):
     _api = HfApi(endpoint=ENDPOINT_STAGING, token=TOKEN)
 
     @classmethod
+    @expect_deprecation("set_access_token")
     def setUpClass(cls):
         """
         Share this valid token in all tests below.

--- a/tests/test_utils_git_credentials.py
+++ b/tests/test_utils_git_credentials.py
@@ -1,0 +1,70 @@
+import time
+import unittest
+from pathlib import Path
+
+import pytest
+
+from huggingface_hub.constants import ENDPOINT
+from huggingface_hub.utils import run_interactive_subprocess, run_subprocess
+from huggingface_hub.utils._git_credential import (
+    list_credential_helpers,
+    set_git_credential,
+    unset_git_credential,
+)
+
+
+STORE_AND_CACHE_HELPERS_CONFIG = """
+[credential]
+    helper = store
+    helper = cache --timeout 30000
+"""
+
+
+@pytest.mark.usefixtures("fx_cache_dir")
+class TestGitCredentials(unittest.TestCase):
+    cache_dir: Path
+
+    def setUp(self):
+        """Initialize and configure a local repo.
+
+        Avoid to configure git helpers globally on a contributor's machine.
+        """
+        run_subprocess("git init", folder=self.cache_dir)
+        with (self.cache_dir / ".git" / "config").open("w") as f:
+            f.write(STORE_AND_CACHE_HELPERS_CONFIG)
+
+    def test_list_credential_helpers(self) -> None:
+        helpers = list_credential_helpers(folder=self.cache_dir)
+        self.assertIn("cache", helpers)
+        self.assertIn("store", helpers)
+
+    def test_set_and_unset_git_credential(self) -> None:
+        username = "hf_test_user_" + str(round(time.time()))  # make username unique
+
+        # Set credentials
+        set_git_credential(
+            token="hf_test_token", username=username, folder=self.cache_dir
+        )
+
+        # Check credentials are stored
+        with run_interactive_subprocess(
+            "git credential fill", folder=self.cache_dir
+        ) as (stdin, stdout):
+            stdin.write(f"url={ENDPOINT}\nusername={username}\n\n")
+            stdin.flush()
+            output = stdout.read()
+        self.assertIn("password=hf_test_token", output)
+
+        # Unset credentials
+        unset_git_credential(username=username, folder=self.cache_dir)
+
+        # Check credentials are NOT stored
+        # Cannot check with `git credential fill` as it would hang forever: only
+        # checking `store` helper instead.
+        with run_interactive_subprocess(
+            "git credential-store get", folder=self.cache_dir
+        ) as (stdin, stdout):
+            stdin.write(f"url={ENDPOINT}\nusername={username}\n\n")
+            stdin.flush()
+            output = stdout.read()
+        self.assertEqual("", output)


### PR DESCRIPTION
Fix https://github.com/huggingface/huggingface_hub/issues/1051. Read entire discussion there to get more context.
Also deprecate `HfApi.set_access_token` which was ambiguous (fix https://github.com/huggingface/huggingface_hub/issues/661).

Here is the new workflow:

**1.a.** In `notebook_login` or `interpreter_login`, a checkbox/prompt asks the user if the token must be set as git credential. Default value is `True` as I expect most users don't care about it and it would avoid topics will "hey my git clone doesn't work after login, what should I do ?". Since default value is explicitly displayed to the user, it doesn't seem a problem to me.
![notebook_login](https://user-images.githubusercontent.com/11801849/198573155-e685061c-a113-4936-8337-3a269989b6bd.png)

```text
>>> from huggingface_hub import login; login()

    _|    _|  _|    _|    _|_|_|    _|_|_|  _|_|_|  _|      _|    _|_|_|      _|_|_|_|    _|_|      _|_|_|  _|_|_|_|
    _|    _|  _|    _|  _|        _|          _|    _|_|    _|  _|            _|        _|    _|  _|        _|
    _|_|_|_|  _|    _|  _|  _|_|  _|  _|_|    _|    _|  _|  _|  _|  _|_|      _|_|_|    _|_|_|_|  _|        _|_|_|
    _|    _|  _|    _|  _|    _|  _|    _|    _|    _|    _|_|  _|    _|      _|        _|    _|  _|        _|
    _|    _|    _|_|      _|_|_|    _|_|_|  _|_|_|  _|      _|    _|_|_|      _|        _|    _|    _|_|_|  _|_|_|_|

    To login, `huggingface_hub` now requires a token generated from https://huggingface.co/settings/tokens .
    
Token: 
Add token as git credential? (Y/n)
```

**1.b.** In `login`, an extra boolean argument `add_to_git_credential` allows the user to set the token in git credential in the non-blocking login process. Default value is `False` as we don't want to overwrite a value without the user knowing. A message is still printed to the user to warn about this possibility.

```py
from huggingface_hub import login

login(token="hf_***, add_to_git_credential=True)
```

**2.a** If `add_to_git_credential=False` (either programmatically or from user input), git credential stay untouched.

**2.b.** If `add_to_git_credential=True`, we check the list of git credential helpers configured on the machine (cache, store, keychain,...)

**2.b.i** If no helper is configured, we display a RED warning "hey you should configure a git credential helper". Login is successful (no error raised) but git credential is not set. Special case: in a Google Colab, we set `"store"` as the default credential helper (if not previously set) and we do not print the warning.

```
Token is valid.
Cannot authenticate through git-credential as no helper is defined on your machine.
You might have to re-authenticate when pushing to the Hugging Face Hub.
Run the following command in your terminal in case you want to set the 'store' credential helper as default.

git config --global credential.helper store

Read https://git-scm.com/book/en/v2/Git-Tools-Credential-Storage for more details.
Token has not been saved to git credential helper.
Your token has been saved to /home/wauplin/.huggingface/token
Login successful
```

**2.b.ii** If at least 1 helper is configured, the credentials are set in all helpers using `git credential approve`. A message is printed to the user to confirm it.

```
Token is valid.
Your token has been saved in your configured git credential helpers (store).
Your token has been saved to /home/wauplin/.huggingface/token
Login successful
```

cc @julien-c @LysandreJik I think this is a workflow as will be as easy as possible for the users while giving them flexibility on overwriting credentials are not. WDYT ? 

TODO:
- [x] adapt tests
- [x] adapt documentation