### PR TITLE
Fix PyTorch & Keras mixin doc

### DIFF
--- a/docs/source/package_reference/mixins.mdx
+++ b/docs/source/package_reference/mixins.mdx
@@ -12,6 +12,7 @@ objects, in order to provide simple uploading and downloading functions.
 ### PyTorch
 
 [[autodoc]] PyTorchModelHubMixin
+    - all
 
 ### Keras
 

--- a/docs/source/package_reference/mixins.mdx
+++ b/docs/source/package_reference/mixins.mdx
@@ -5,9 +5,13 @@
 The `huggingface_hub` library offers a range of mixins that can be used as a parent class for your
 objects, in order to provide simple uploading and downloading functions.
 
-### PyTorch
+### Generic
 
 [[autodoc]] ModelHubMixin
+
+### PyTorch
+
+[[autodoc]] PyTorchModelHubMixin
 
 ### Keras
 

--- a/docs/source/package_reference/mixins.mdx
+++ b/docs/source/package_reference/mixins.mdx
@@ -13,6 +13,9 @@ objects, in order to provide simple uploading and downloading functions.
 
 [[autodoc]] PyTorchModelHubMixin
     - all
+    - __init__
+    - _save_pretrained
+    - _from_pretrained
 
 ### Keras
 

--- a/docs/source/package_reference/mixins.mdx
+++ b/docs/source/package_reference/mixins.mdx
@@ -8,14 +8,13 @@ objects, in order to provide simple uploading and downloading functions.
 ### Generic
 
 [[autodoc]] ModelHubMixin
+    - all
+    - _save_pretrained
+    - _from_pretrained
 
 ### PyTorch
 
 [[autodoc]] PyTorchModelHubMixin
-    - all
-    - __init__
-    - _save_pretrained
-    - _from_pretrained
 
 ### Keras
 

--- a/docs/source/package_reference/mixins.mdx
+++ b/docs/source/package_reference/mixins.mdx
@@ -18,13 +18,13 @@ objects, in order to provide simple uploading and downloading functions.
 
 ### Keras
 
+[[autodoc]] KerasModelHubMixin
+
 [[autodoc]] from_pretrained_keras
 
 [[autodoc]] push_to_hub_keras
 
 [[autodoc]] save_pretrained_keras
-
-[[autodoc]] KerasModelHubMixin
 
 ### Fastai
 

--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -25,7 +25,7 @@ class ModelHubMixin:
     A Generic Base Model Hub Mixin. Define your own mixin for anything by
     inheriting from this class and overwriting `_from_pretrained` and
     `_save_pretrained` to define custom logic for saving/loading your classes.
-    See `huggingface_hub.PyTorchModelHubMixin` for an example.
+    See [`PyTorchModelHubMixin`] for an example.
     """
 
     def save_pretrained(

--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -438,9 +438,6 @@ class PyTorchModelHubMixin(ModelHubMixin):
     ```
     """
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     def _save_pretrained(self, save_directory):
         """
         Overwrite this method if you wish to save specific layers instead of the

--- a/src/huggingface_hub/keras_mixin.py
+++ b/src/huggingface_hub/keras_mixin.py
@@ -232,7 +232,7 @@ def save_pretrained_keras(
 def from_pretrained_keras(*args, **kwargs):
     r"""
     Instantiate a pretrained Keras model from a pre-trained model from the Hub.
-    The model is expected to be in SavedModel format.```
+    The model is expected to be in `SavedModel` format.
 
     Parameters:
         pretrained_model_name_or_path (`str` or `os.PathLike`):
@@ -533,51 +533,42 @@ def push_to_hub_keras(
 
 class KerasModelHubMixin(ModelHubMixin):
     """
-    Mixin to provide model Hub upload/download capabilities to Keras models.
-    Override this class to obtain the following internal methods:
-    - `_from_pretrained`, to load a model from the Hub or from local files.
-    - `_save_pretrained`, to save a model in the `SavedModel` format.
+    Implementation of [`ModelHubMixin`] to provide model Hub upload/download
+    capabilities to Keras models.
+
+
+    ```python
+    >>> import tensorflow as tf
+    >>> from huggingface_hub import KerasModelHubMixin
+
+
+    >>> class MyModel(tf.keras.Model, KerasModelHubMixin):
+    ...     def __init__(self, **kwargs):
+    ...         super().__init__()
+    ...         self.config = kwargs.pop("config", None)
+    ...         self.dummy_inputs = ...
+    ...         self.layer = ...
+
+    ...     def call(self, *args):
+    ...         return ...
+
+
+    >>> # Initialize and compile the model as you normally would
+    >>> model = MyModel()
+    >>> model.compile(...)
+    >>> # Build the graph by training it or passing dummy inputs
+    >>> _ = model(model.dummy_inputs)
+    >>> # Save model weights to local directory
+    >>> model.save_pretrained("my-awesome-model")
+    >>> # Push model weights to the Hub
+    >>> model.push_to_hub("my-awesome-model")
+    >>> # Download and initialize weights from the Hub
+    >>> model = MyModel.from_pretrained("username/super-cool-model")
+    ```
     """
 
     def __init__(self, *args, **kwargs):
-        """
-        Mix this class with your keras-model class for ease process of saving &
-        loading from huggingface-hub.
-
-
-        ```python
-        >>> from huggingface_hub import KerasModelHubMixin
-
-
-        >>> class MyModel(tf.keras.Model, KerasModelHubMixin):
-        ...     def __init__(self, **kwargs):
-        ...         super().__init__()
-        ...         self.config = kwargs.pop("config", None)
-        ...         self.dummy_inputs = ...
-        ...         self.layer = ...
-
-        ...     def call(self, *args):
-        ...         return ...
-
-
-        >>> # Init and compile the model as you normally would
-        >>> model = MyModel()
-        >>> model.compile(...)
-        >>> # Build the graph by training it or passing dummy inputs
-        >>> _ = model(model.dummy_inputs)
-        >>> # You can save your model like this
-        >>> model.save_pretrained("local_model_dir/", push_to_hub=False)
-        >>> # Or, you can push to a new public model repo like this
-        >>> model.push_to_hub(
-        ...     "super-cool-model",
-        ...     git_user="your-hf-username",
-        ...     git_email="you@somesite.com",
-        ... )
-
-        >>> # Downloading weights from hf-hub & model will be initialized from those weights
-        >>> model = MyModel.from_pretrained("username/mymodel@main")
-        ```
-        """
+        super().__init__(*args, **kwargs)
 
     def _save_pretrained(self, save_directory):
         save_pretrained_keras(self, save_directory)

--- a/src/huggingface_hub/keras_mixin.py
+++ b/src/huggingface_hub/keras_mixin.py
@@ -567,9 +567,6 @@ class KerasModelHubMixin(ModelHubMixin):
     ```
     """
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     def _save_pretrained(self, save_directory):
         save_pretrained_keras(self, save_directory)
 
@@ -586,7 +583,7 @@ class KerasModelHubMixin(ModelHubMixin):
         token,
         **model_kwargs,
     ):
-        """Here we just call from_pretrained_keras function so both the mixin and
+        """Here we just call [`from_pretrained_keras`] function so both the mixin and
         functional APIs stay in sync.
 
                 TODO - Some args above aren't used since we are calling
@@ -596,7 +593,7 @@ class KerasModelHubMixin(ModelHubMixin):
             import tensorflow as tf
         else:
             raise ImportError(
-                "Called a Tensorflow-specific function but could not import it."
+                "Called a TensorFlow-specific function but could not import it."
             )
 
         # TODO - Figure out what to do about these config values. Config is not going to be needed to load model


### PR DESCRIPTION
The docs for the PyTorch Hub mixin pointed to the generic one instead of the PyTorch one. This PR fixes that and adds new section for the generic class