### PR TITLE
make repocard content a property

### DIFF
--- a/src/huggingface_hub/repocard.py
+++ b/src/huggingface_hub/repocard.py
@@ -79,7 +79,22 @@ class RepoCard:
 
         </Tip>
         """
+
+        # Set the content of the RepoCard, as well as underlying .data and .text attributes.
+        # See the `content` property setter for more details.
         self.content = content
+
+    @property
+    def content(self):
+        """The content of the RepoCard, including the YAML block and the Markdown body."""
+        line_break = _detect_line_ending(self._content) or "\n"
+        return f"---{line_break}{self.data.to_yaml(line_break=line_break)}{line_break}---{line_break}{self.text}"
+
+    @content.setter
+    def content(self, content: str):
+        """Set the content of the RepoCard."""
+        self._content = content
+
         match = REGEX_YAML_BLOCK.search(content)
         if match:
             # Metadata found in the YAML block
@@ -101,8 +116,7 @@ class RepoCard:
         self.data = self.card_data_class(**data_dict)
 
     def __str__(self):
-        line_break = _detect_line_ending(self.content) or "\n"
-        return f"---{line_break}{self.data.to_yaml(line_break=line_break)}{line_break}---{line_break}{self.text}"
+        return self.content
 
     def save(self, filepath: Union[Path, str]):
         r"""Save a RepoCard to a file.

--- a/tests/test_repocard.py
+++ b/tests/test_repocard.py
@@ -656,6 +656,14 @@ class RepoCardTest(TestCaseWithCapLog):
         card = RepoCard.load(card_path)
         self.assertIn("\r\n", str(card))
 
+    def test_updating_text_updates_content(self):
+        sample_path = SAMPLE_CARDS_DIR / "sample_simple.md"
+        card = RepoCard.load(sample_path)
+        card.text = "Hello, world!"
+        self.assertEqual(
+            card.content, f"---\n{card.data.to_yaml()}\n---\nHello, world!"
+        )
+
 
 class ModelCardTest(TestCaseWithCapLog):
     def test_model_card_with_invalid_model_index(self):


### PR DESCRIPTION
Resolves #1144 by turning `RepoCard.content` into a property with an accompanying setter fn. The setter handles setting `.data` and `.text` attributes accordingly. 

This way, when you update the card text or data, the card's content will be updated as well. As an added bonus, if you update `card.content`, it will update the card data and text as well. 