### PR TITLE
Skip failing test in ci

### DIFF
--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -267,7 +267,11 @@ class HfApiEndpointsTest(HfApiCommonTestWithLogin):
         self.assertFalse(res["private"])
         self._api.delete_repo(repo_id=DATASET_REPO_NAME, repo_type=REPO_TYPE_DATASET)
 
-    @unittest.skip("Create repo fails on staging endpoint. See https://huggingface.slack.com/archives/C02EMARJ65P/p1666795928977419 (internal link).")
+    @unittest.skip(
+        "Create repo fails on staging endpoint. See"
+        " https://huggingface.slack.com/archives/C02EMARJ65P/p1666795928977419"
+        " (internal link)."
+    )
     @retry_endpoint
     def test_create_update_and_delete_space_repo(self):
         SPACE_REPO_NAME = space_repo_name("failing")

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -267,6 +267,7 @@ class HfApiEndpointsTest(HfApiCommonTestWithLogin):
         self.assertFalse(res["private"])
         self._api.delete_repo(repo_id=DATASET_REPO_NAME, repo_type=REPO_TYPE_DATASET)
 
+    @unittest.skip("Create repo fails on staging endpoint. See https://huggingface.slack.com/archives/C02EMARJ65P/p1666795928977419 (internal link).")
     @retry_endpoint
     def test_create_update_and_delete_space_repo(self):
         SPACE_REPO_NAME = space_repo_name("failing")


### PR DESCRIPTION
Related to [slack thread](https://huggingface.slack.com/archives/C02EMARJ65P/p1666795928977419) (internal link). Easiest solution is to skip the test for now.

_Original message_:

> Creating spaces on the staging environments is broken. This broke the CI in huggingface_hub. I tried on production ( [hf.co](http://hf.co/) ) and it works fine.  Problem is not so critical as it affects only 1 test.