### PR TITLE
Create tag twice doesn't work

### DIFF
--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -1128,9 +1128,11 @@ class HfApiTagEndpointTest(HfApiCommonTestWithLogin):
     @retry_endpoint
     @use_tmp_repo("model")
     def test_create_tag_twice(self) -> None:
-        """Check `create_tag` called twice on same tag should not fail."""
+        """Check `create_tag` called twice on same tag should fail with HTTP 409."""
         self._api.create_tag(self._repo_id, tag="tag_1")
-        self._api.create_tag(self._repo_id, tag="tag_1")
+        with self.assertRaises(HfHubHTTPError) as err:
+            self._api.create_tag(self._repo_id, tag="tag_1")
+        self.assertEqual(err.exception.response.status_code, 409)
 
     @retry_endpoint
     @use_tmp_repo("model")


### PR DESCRIPTION
Due to an update in moon-landing, creating a tag twice on the same repo doesn't work anymore (for good reason).
This PR updates the according test in `hfh`. Create tag is now officially released yet so no big deal here.