### PR TITLE
Use default `model_name` in `metadata_update`

### DIFF
--- a/src/huggingface_hub/repocard.py
+++ b/src/huggingface_hub/repocard.py
@@ -775,7 +775,7 @@ def metadata_update(
         if key == "model-index":
             # if the new metadata doesn't include a name, either use existing one or repo name
             if "name" not in value[0]:
-                value[0]["name"] = getattr(card, "model_name", repo_id.split("/")[-1])
+                value[0]["name"] = getattr(card, "model_name", repo_id)
             model_name, new_results = model_index_to_eval_results(value)
             if card.data.eval_results is None:
                 card.data.eval_results = new_results

--- a/src/huggingface_hub/repocard.py
+++ b/src/huggingface_hub/repocard.py
@@ -759,6 +759,9 @@ def metadata_update(
 
     for key, value in metadata.items():
         if key == "model-index":
+            # if the new metadata doesn't include a name, either use existing one or repo name
+            if "name" not in value[0]:
+                value[0]["name"] = getattr(card, "model_name", repo_id.split("/")[-1])
             model_name, new_results = model_index_to_eval_results(value)
             if card.data.eval_results is None:
                 card.data.eval_results = new_results

--- a/src/huggingface_hub/repocard_data.py
+++ b/src/huggingface_hub/repocard_data.py
@@ -183,11 +183,12 @@ class ModelCardData(CardData):
             at https://hf.co/metrics. Example: 'accuracy'. Defaults to None.
         eval_results (`Union[List[EvalResult], EvalResult]`, *optional*):
             List of `huggingface_hub.EvalResult` that define evaluation results of the model. If provided,
-            `model_name` kwarg must be provided. Defaults to `None`.
+            `model_name` is used to as a name on PapersWithCode's leaderboards. Defaults to `None`.
         model_name (`str`, *optional*):
-            A name for this model. Required if you provide `eval_results`. It is used along with
+            A name for this model. It is used along with
             `eval_results` to construct the `model-index` within the card's metadata. The name
-            you supply here is what will be used on PapersWithCode's leaderboards. Defaults to None.
+            you supply here is what will be used on PapersWithCode's leaderboards. If None is provided
+            then the repo name is used as a default. Defaults to None.
         kwargs (`dict`, *optional*):
             Additional metadata that will be added to the model card. Defaults to None.
 


### PR DESCRIPTION
As reported by a user, the `metadata_update` does not work anymore (likely introduced in #940) if no `"name"` field in the `"model-index"` is provided. This breaks for example `evaluate.push_to_hub` where evaluation results are pushed to the hub. 

With this PR the following behaviour is supported:
- if `"model-index"` of new metadata has a `"name"` it is used (1)
- if there is no `"name"`
    - if the existing repo card has one use this one (2)
    - else use the repo name as default (3)

Since the `"name"` is I think a little known feature of the PwC integration and providing a model name when pushing the results to a model repo seems a bit redundant I feel like having good defaults and not bother the user with it is a good idea. If you think this is a bad idea, we can throw an error in case (3).

cc @julien-c 