### PR TITLE
FIX url encoding in hf_hub_url

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -234,7 +234,7 @@ def hf_hub_url(
     return HUGGINGFACE_CO_URL_TEMPLATE.format(
         repo_id=repo_id,
         revision=quote(revision, safe=""),
-        filename=filename,
+        filename=quote(filename),
     )
 
 

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -408,20 +408,36 @@ class StagingCachedDownloadOnAwfulFilenamesTest(unittest.TestCase):
 
     cache_dir: Path
     repo_id = "valid_org/repo_with_awful_filename"
-    filename = "subfolder/to/awful?filename%you:should,never.give"
+    subfolder = "subfolder/to?"
+    filename = "awful?filename%you:should,never.give"
+    filepath = "subfolder/to?/awful?filename%you:should,never.give"
+    expected_url = "https://hub-ci.huggingface.co/valid_org/repo_with_awful_filename/resolve/main/subfolder/to%3F/awful%3Ffilename%25you%3Ashould%2Cnever.give"
 
-    def test_hf_hub_url_on_awful_filename(self):
+    def test_hf_hub_url_on_awful_filepath(self):
+        self.assertEqual(hf_hub_url(self.repo_id, self.filepath), self.expected_url)
+
+    def test_hf_hub_url_on_awful_subfolder_and_filename(self):
         self.assertEqual(
-            hf_hub_url(self.repo_id, self.filename),
-            "https://hub-ci.huggingface.co/valid_org/repo_with_awful_filename/resolve/main/subfolder/to/awful%3Ffilename%25you%3Ashould%2Cnever.give",
+            hf_hub_url(self.repo_id, self.filename, subfolder=self.subfolder),
+            self.expected_url,
         )
 
-    def test_hf_hub_download_on_awful_filename(self):
+    def test_hf_hub_download_on_awful_filepath(self):
         local_path = hf_hub_download(
-            self.repo_id, self.filename, cache_dir=self.cache_dir
+            self.repo_id, self.filepath, cache_dir=self.cache_dir
         )
         # Local path is not url-encoded
-        self.assertTrue(local_path.endswith(self.filename))
+        self.assertTrue(local_path.endswith(self.filepath))
+
+    def test_hf_hub_download_on_awful_subfolder_and_filename(self):
+        local_path = hf_hub_download(
+            self.repo_id,
+            self.filename,
+            subfolder=self.subfolder,
+            cache_dir=self.cache_dir,
+        )
+        # Local path is not url-encoded
+        self.assertTrue(local_path.endswith(self.filepath))
 
 
 class CreateSymlinkTest(unittest.TestCase):

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -397,6 +397,33 @@ class StagingCachedDownloadTest(unittest.TestCase):
                 )
 
 
+@pytest.mark.usefixtures("fx_cache_dir")
+class StagingCachedDownloadOnAwfulFilenamesTest(unittest.TestCase):
+    """Implement regression tests for #1161.
+
+    Issue was on filename not url encoded by `hf_hub_download` and `hf_hub_url`.
+
+    See https://github.com/huggingface/huggingface_hub/issues/1161
+    """
+
+    cache_dir: Path
+    repo_id = "valid_org/repo_with_awful_filename"
+    filename = "subfolder/to/awful?filename%you:should,never.give"
+
+    def test_hf_hub_url_on_awful_filename(self):
+        self.assertEqual(
+            hf_hub_url(self.repo_id, self.filename),
+            "https://hub-ci.huggingface.co/valid_org/repo_with_awful_filename/resolve/main/subfolder/to/awful%3Ffilename%25you%3Ashould%2Cnever.give",
+        )
+
+    def test_hf_hub_download_on_awful_filename(self):
+        local_path = hf_hub_download(
+            self.repo_id, self.filename, cache_dir=self.cache_dir
+        )
+        # Local path is not url-encoded
+        self.assertTrue(local_path.endswith(self.filename))
+
+
 class CreateSymlinkTest(unittest.TestCase):
     @patch("huggingface_hub.file_download.are_symlinks_supported")
     def test_create_relative_symlink_concurrent_access(


### PR DESCRIPTION
Fix https://github.com/huggingface/huggingface_hub/issues/1161. Bug doesn't seem to be elsewhere than in `hf_hub_url` itself.
Added 2 regression tests just to be sure. 

cc @philschmid thanks for reporting it :)

(just wondering for myself: who really thought it was a good idea to have a `?` in a filename ??? :smile:)