### PR TITLE
Rename languages to langage + remove duplicate code in tests

### DIFF
--- a/docs/source/searching-the-hub.mdx
+++ b/docs/source/searching-the-hub.mdx
@@ -187,8 +187,8 @@ Available Attributes or Keys:
  * benchmark
  * dataset_name
  * language_creators
- * languages
- * licenses
+ * language
+ * license
  * multilinguality
  * size_categories
  * task_categories
@@ -283,11 +283,11 @@ Available Attributes or Keys:
 
 There you will find `text_classification`, so you should use `dataset_args.task_categories.text_classification`.
 
-Next we need to find the proper language. There is a `languages` property we can check. These are two-letter language codes, so you should check if it has `en`:
+Next we need to find the proper language. There is a `language` property we can check. These are two-letter language codes, so you should check if it has `en`:
 
 
 ```python
->>> "en" in dataset_args.languages
+>>> "en" in dataset_args.language
 True
 ```
 
@@ -296,7 +296,7 @@ Now that the pieces are found, you can write a filter:
 
 ```python
 >>> filt = DatasetFilter(
-...    languages=dataset_args.languages.en,
+...    language=dataset_args.language.en,
 ...    task_categories=dataset_args.task_categories.text_classification
 ... )
 ```
@@ -309,7 +309,7 @@ And search the API!
 DatasetInfo: {
     id: Abirate/english_quotes
     lastModified: None
-    tags: ['annotations_creators:expert-generated', 'language_creators:expert-generated', 'language_creators:crowdsourced', 'languages:en', 'multilinguality:monolingual', 'source_datasets:original', 'task_categories:text-classification', 'task_ids:multi-label-classification']
+    tags: ['annotations_creators:expert-generated', 'language_creators:expert-generated', 'language_creators:crowdsourced', 'language:en', 'multilinguality:monolingual', 'source_datasets:original', 'task_categories:text-classification', 'task_ids:multi-label-classification']
     private: False
     author: Abirate
     description: None

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -504,8 +504,8 @@ class ModelSearchArguments(AttributeDictionary):
     ```
     """
 
-    def __init__(self):
-        self._api = HfApi()
+    def __init__(self, api: Optional["HfApi"] = None):
+        self._api = api if api is not None else HfApi()
         tags = self._api.get_model_tags()
         super().__init__(tags)
         self._process_models()
@@ -542,8 +542,8 @@ class DatasetSearchArguments(AttributeDictionary):
     ```
     """
 
-    def __init__(self):
-        self._api = HfApi()
+    def __init__(self, api: Optional["HfApi"] = None):
+        self._api = api if api is not None else HfApi()
         tags = self._api.get_dataset_tags()
         super().__init__(tags)
         self._process_models()
@@ -961,13 +961,13 @@ class HfApi:
 
         >>> # List only the datasets in russian for language modeling
         >>> api.list_datasets(
-        ...     filter=("languages:ru", "task_ids:language-modeling")
+        ...     filter=("language:ru", "task_ids:language-modeling")
         ... )
         >>> # Using the `DatasetFilter`
-        >>> filt = DatasetFilter(languages="ru", task_ids="language-modeling")
+        >>> filt = DatasetFilter(language="ru", task_ids="language-modeling")
         >>> # With `DatasetSearchArguments`
         >>> filt = DatasetFilter(
-        ...     languages=args.languages.ru,
+        ...     language=args.language.ru,
         ...     task_ids=args.task_ids.language_modeling,
         ... )
         >>> api.list_datasets(filter=filt)
@@ -1030,7 +1030,7 @@ class HfApi:
         data_attributes = [
             "benchmark",
             "language_creators",
-            "languages",
+            "language",
             "multilinguality",
             "size_categories",
             "task_categories",

--- a/src/huggingface_hub/utils/endpoint_helpers.py
+++ b/src/huggingface_hub/utils/endpoint_helpers.py
@@ -84,7 +84,7 @@ class DatasetFilter:
             A string or list of strings that can be used to identify datasets on
             the Hub with how the data was curated, such as `crowdsourced` or
             `machine_generated`.
-        languages (`str` or `List`, *optional*):
+        language (`str` or `List`, *optional*):
             A string or list of strings representing a two-character language to
             filter datasets by on the Hub.
         multilinguality (`str` or `List`, *optional*):
@@ -141,7 +141,7 @@ class DatasetFilter:
     benchmark: Optional[Union[str, List[str]]] = None
     dataset_name: Optional[str] = None
     language_creators: Optional[Union[str, List[str]]] = None
-    languages: Optional[Union[str, List[str]]] = None
+    language: Optional[Union[str, List[str]]] = None
     multilinguality: Optional[Union[str, List[str]]] = None
     size_categories: Optional[Union[str, List[str]]] = None
     task_categories: Optional[Union[str, List[str]]] = None
@@ -355,13 +355,13 @@ class DatasetTags(GeneralTags):
 
     def __init__(self, dataset_tag_dictionary: dict):
         keys = [
-            "languages",
+            "language",
             "multilinguality",
             "language_creators",
             "task_categories",
             "size_categories",
             "benchmark",
             "task_ids",
-            "licenses",
+            "license",
         ]
         super().__init__(dataset_tag_dictionary, keys)

--- a/tests/test_endpoint_helpers.py
+++ b/tests/test_endpoint_helpers.py
@@ -100,10 +100,10 @@ class AttributeDictionaryTest(AttributeDictionaryCommonTest):
 
 class GeneralTagsCommonTest(unittest.TestCase):
     # Similar to the output from /api/***-tags-by-type
-    # id = how we can search hfapi, such as `'id': 'languages:en'`
+    # id = how we can search hfapi, such as `'id': 'language:en'`
     # label = A human readable version assigned to everything, such as `"label":"en"`
     _tag_dictionary = {
-        "languages": [
+        "language": [
             {"id": "itemA", "label": "Item A"},
             {"id": "itemB", "label": "1Item-B"},
         ],
@@ -117,8 +117,7 @@ class GeneralTagsCommonTest(unittest.TestCase):
 class GeneralTagsTest(GeneralTagsCommonTest):
     def test_init(self):
         _tags = GeneralTags(self._tag_dictionary)
-        self.assertTrue(all(hasattr(_tags, kind) for kind in ["languages", "license"]))
-        languages = _tags.languages
+        languages = _tags.language
         licenses = _tags.license
         # Ensure they have the right bits
 
@@ -165,13 +164,13 @@ class DatasetTagsTest(unittest.TestCase):
         d = r.json()
         o = DatasetTags(d)
         for kind in [
-            "languages",
+            "language",
             "multilinguality",
             "language_creators",
             "task_categories",
             "size_categories",
             "benchmark",
             "task_ids",
-            "licenses",
+            "license",
         ]:
             self.assertTrue(len(getattr(o, kind).keys()) > 0)

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -56,7 +56,6 @@ from huggingface_hub.hf_api import (
     RepoFile,
     SpaceInfo,
     erase_from_credential_store,
-    list_datasets,
     read_from_credential_store,
     repo_type_and_id_from_hf_id,
 )


### PR DESCRIPTION
Fix CI (currently broken). Also fix https://github.com/huggingface/huggingface_hub/issues/1130.
And also updated tests/documentation + tried to remove some duplicate code in tests.

For context, it seems that most datasets have now a `language` tag instead of `languages`:
```text
List datasets with language:en
1750
List datasets with language:fr
196
List datasets with languages:en
7
List datasets with languages:fr
1
```

(cc @zaidalyafeai in the end I worked on this issue as our CI was broken because of it)