### PR TITLE
Warn user if output is truncated in `list_models`

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -809,8 +809,14 @@ class HfApi:
             params.update({"cardData": True})
         r = requests.get(path, params=params, headers=headers)
         hf_raise_for_status(r)
-        d = r.json()
-        res = [ModelInfo(**x) for x in d]
+        items = [ModelInfo(**x) for x in r.json()]
+
+        # If pagination has been enabled server-side, older versions of `huggingface_hub`
+        # are deprecated as output is truncated.
+        _warn_if_truncated(
+            items, total_count=r.headers.get("X-Total-Count"), limit=limit
+        )
+
         if emissions_thresholds is not None:
             if cardData is None:
                 raise ValueError(
@@ -818,8 +824,9 @@ class HfApi:
                     " `cardData=True`."
                 )
             else:
-                return _filter_emissions(res, *emissions_thresholds)
-        return res
+                return _filter_emissions(items, *emissions_thresholds)
+
+        return items
 
     def _unpack_model_filter(self, model_filter: ModelFilter):
         """
@@ -1009,8 +1016,15 @@ class HfApi:
             params.update({"full": True})
         r = requests.get(path, params=params, headers=headers)
         hf_raise_for_status(r)
-        d = r.json()
-        return [DatasetInfo(**x) for x in d]
+        items = [DatasetInfo(**x) for x in r.json()]
+
+        # If pagination has been enabled server-side, older versions of `huggingface_hub`
+        # are deprecated as output is truncated.
+        _warn_if_truncated(
+            items, total_count=r.headers.get("X-Total-Count"), limit=limit
+        )
+
+        return items
 
     def _unpack_dataset_filter(self, dataset_filter: DatasetFilter):
         """
@@ -1149,8 +1163,15 @@ class HfApi:
             params.update({"models": models})
         r = requests.get(path, params=params, headers=headers)
         hf_raise_for_status(r)
-        d = r.json()
-        return [SpaceInfo(**x) for x in d]
+        items = [SpaceInfo(**x) for x in r.json()]
+
+        # If pagination has been enabled server-side, older versions of `huggingface_hub`
+        # are deprecated as output is truncated.
+        _warn_if_truncated(
+            items, total_count=r.headers.get("X-Total-Count"), limit=limit
+        )
+
+        return items
 
     @validate_hf_hub_args
     def model_info(
@@ -3358,6 +3379,33 @@ def _parse_revision_from_pr_url(pr_url: str) -> str:
             f" '{pr_url}'"
         )
     return f"refs/pr/{re_match[1]}"
+
+
+def _warn_if_truncated(
+    items: List[Any], limit: Optional[int], total_count: Optional[int]
+) -> None:
+    # TODO: remove this once pagination is properly implemented in `huggingface_hub`.
+
+    if total_count is None:
+        # Total count header not implemented server-side
+        return
+
+    if len(items) == total_count:
+        # All items have been returned => not truncated
+        return
+
+    if limit is not None and len(items) == limit:
+        # `limit` is set => truncation is expected
+        return
+
+    # Otherwise, pagination has been enabled server-side and the output has been
+    # truncated by server => warn user.
+    warnings.warn(
+        "The list of repos returned by the server has been truncated. Listing repos"
+        " from the Hub using `list_models`, `list_datasets` and `list_spaces` now"
+        " requires pagination. To get the full list of repos, please consider upgrading"
+        " `huggingface_hub` to its latest version."
+    )
 
 
 api = HfApi()

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -3382,15 +3382,20 @@ def _parse_revision_from_pr_url(pr_url: str) -> str:
 
 
 def _warn_if_truncated(
-    items: List[Any], limit: Optional[int], total_count: Optional[int]
+    items: List[Any], limit: Optional[int], total_count: Optional[str]
 ) -> None:
     # TODO: remove this once pagination is properly implemented in `huggingface_hub`.
-
     if total_count is None:
-        # Total count header not implemented server-side
+        # Total count header not implemented
         return
 
-    if len(items) == total_count:
+    try:
+        total_count_int = int(total_count)
+    except ValueError:
+        # Total count header not implemented properly server-side
+        return
+
+    if len(items) == total_count_int:
         # All items have been returned => not truncated
         return
 

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2178,16 +2178,19 @@ class WarnIfTruncatedTest(unittest.TestCase):
         # Can't tell if output is truncated
         _warn_if_truncated([1, 2, 3], limit=None, total_count=None)
 
+        # Can't tell if output is truncated
+        _warn_if_truncated([1, 2, 3], limit=None, total_count="foo")
+
         # All items returned
-        _warn_if_truncated([1, 2, 3], limit=None, total_count=3)
+        _warn_if_truncated([1, 2, 3], limit=None, total_count="3")
 
         # Output is truncated (no limit, received 3)
         with self.assertWarns(UserWarning):
-            _warn_if_truncated([1, 2, 3], limit=None, total_count=5)
+            _warn_if_truncated([1, 2, 3], limit=None, total_count="5")
 
         # Output is truncated (limit is 4, received 3)
         with self.assertWarns(UserWarning):
-            _warn_if_truncated([1, 2, 3], limit=4, total_count=5)
+            _warn_if_truncated([1, 2, 3], limit=4, total_count="5")
 
         # Output is truncated by the user
-        _warn_if_truncated([1, 2, 3], limit=3, total_count=5)
+        _warn_if_truncated([1, 2, 3], limit=3, total_count="5")

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -55,6 +55,7 @@ from huggingface_hub.hf_api import (
     ModelSearchArguments,
     RepoFile,
     SpaceInfo,
+    _warn_if_truncated,
     erase_from_credential_store,
     read_from_credential_store,
     repo_type_and_id_from_hf_id,
@@ -2242,3 +2243,23 @@ class HfApiTokenAttributeTest(unittest.TestCase):
         self, mock_build_hf_headers: Mock, expected_value: str
     ) -> None:
         self.assertEqual(mock_build_hf_headers.call_args[1]["token"], expected_value)
+
+
+class WarnIfTruncatedTest(unittest.TestCase):
+    def test_warn_if_truncated(self) -> None:
+        # Can't tell if output is truncated
+        _warn_if_truncated([1, 2, 3], limit=None, total_count=None)
+
+        # All items returned
+        _warn_if_truncated([1, 2, 3], limit=None, total_count=3)
+
+        # Output is truncated (no limit, received 3)
+        with self.assertWarns(UserWarning):
+            _warn_if_truncated([1, 2, 3], limit=None, total_count=5)
+
+        # Output is truncated (limit is 4, received 3)
+        with self.assertWarns(UserWarning):
+            _warn_if_truncated([1, 2, 3], limit=4, total_count=5)
+
+        # Output is truncated by the user
+        _warn_if_truncated([1, 2, 3], limit=3, total_count=5)


### PR DESCRIPTION
If output is truncated in `list_models` but not on user's request, raise a warning to suggest upgrading `huggingface_hub`.

This will be useful when pagination will be mandatory on Hub's side. To be removed when pagination is handled client-side as well.