### PR TITLE
1162 Reorder operations correctly in commit endpoint

### DIFF
--- a/src/huggingface_hub/_commit_api.py
+++ b/src/huggingface_hub/_commit_api.py
@@ -4,11 +4,14 @@ Type definitions and utilities for the `create_commit` API
 import base64
 import io
 import os
+import warnings
+from collections import defaultdict
 from concurrent import futures
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import Any, BinaryIO, Dict, Iterable, List, Optional, Tuple, Union
+from pathlib import PurePosixPath
+from typing import Any, BinaryIO, Dict, Iterable, List, Optional, Union
 
 import requests
 
@@ -29,8 +32,6 @@ logger = logging.get_logger(__name__)
 
 
 UploadMode = Literal["lfs", "regular"]
-
-CommitOperationT = Union["CommitOperationAdd", "CommitOperationDelete"]
 
 
 @dataclass
@@ -180,10 +181,56 @@ class CommitOperationAdd:
 CommitOperation = Union[CommitOperationAdd, CommitOperationDelete]
 
 
+def warn_on_overwriting_operations(operations: List[CommitOperation]) -> None:
+    """
+    Warn user when a list of operations is expected to overwrite itself in a single
+    commit.
+
+    Rules:
+    - If a filepath is updated by multiple `CommitOperationAdd` operations, a warning
+      message is triggered.
+    - If a filepath is updated at least once by a `CommitOperationAdd` and then deleted
+      by a `CommitOperationDelete`, a warning is triggered.
+    - If a `CommitOperationDelete` deletes a filepath that is then updated by a
+      `CommitOperationAdd`, no warning is triggered. This is usually useless (no need to
+      delete before upload) but can happen if a user deletes an entire folder and then
+      add new files to it.
+    """
+    nb_additions_per_path: Dict[str, int] = defaultdict(int)
+    for operation in operations:
+        path_in_repo = operation.path_in_repo
+        if isinstance(operation, CommitOperationAdd):
+            if nb_additions_per_path[path_in_repo] > 0:
+                warnings.warn(
+                    "About to update multiple times the same file in the same commit:"
+                    f" '{path_in_repo}'. This can cause undesired inconsistencies in"
+                    " your repo."
+                )
+            nb_additions_per_path[path_in_repo] += 1
+            for parent in PurePosixPath(path_in_repo).parents:
+                # Also keep track of number of updated files per folder
+                # => warns if deleting a folder overwrite some contained files
+                nb_additions_per_path[str(parent)] += 1
+        if isinstance(operation, CommitOperationDelete):
+            if nb_additions_per_path[str(PurePosixPath(path_in_repo))] > 0:
+                if operation.is_folder:
+                    warnings.warn(
+                        "About to delete a folder containing files that have just been"
+                        f" updated within the same commit: '{path_in_repo}'. This can"
+                        " cause undesired inconsistencies in your repo."
+                    )
+                else:
+                    warnings.warn(
+                        "About to delete a file that have just been updated within the"
+                        f" same commit: '{path_in_repo}'. This can cause undesired"
+                        " inconsistencies in your repo."
+                    )
+
+
 @validate_hf_hub_args
 def upload_lfs_files(
     *,
-    additions: Iterable[CommitOperationAdd],
+    additions: List[CommitOperationAdd],
     repo_type: str,
     repo_id: str,
     token: Optional[str],
@@ -197,7 +244,7 @@ def upload_lfs_files(
         - LFS Batch API: https://github.com/git-lfs/git-lfs/blob/main/docs/api/batch.md
 
     Args:
-        additions (`Iterable` of `CommitOperationAdd`):
+        additions (`List` of `CommitOperationAdd`):
             The files to be uploaded
         repo_type (`str`):
             Type of the repo to upload to: `"model"`, `"dataset"` or `"space"`.
@@ -295,7 +342,7 @@ def _upload_lfs_object(
     large file storage.
 
     Args:
-        operation (`CommitOprationAdd`):
+        operation (`CommitOperationAdd`):
             The add operation triggering this upload
         lfs_batch_action (`dict`):
             Upload instructions from the LFS batch endpoint for this object.
@@ -330,7 +377,7 @@ def _upload_lfs_object(
         logger.debug(f"{operation.path_in_repo}: Upload successful")
 
 
-def validate_preupload_info(preupload_info: dict):
+def _validate_preupload_info(preupload_info: dict):
     files = preupload_info.get("files")
     if not isinstance(files, list):
         raise ValueError("preupload_info is improperly formatted")
@@ -353,7 +400,7 @@ def fetch_upload_modes(
     token: Optional[str],
     revision: str,
     endpoint: Optional[str] = None,
-) -> List[Tuple[CommitOperationAdd, UploadMode]]:
+) -> Dict[str, UploadMode]:
     """
     Requests the Hub "preupload" endpoint to determine wether each input file
     should be uploaded as a regular git blob or as git LFS blob.
@@ -372,21 +419,20 @@ def fetch_upload_modes(
         revision (`str`):
             The git revision to upload the files to. Can be any valid git revision.
 
-    Returns:
-        list of 2-tuples, the first element being the add operation and
-        the second element the associated upload mode
+    Returns: `Dict[str, UploadMode]`
+        Key is the file path, value is the upload mode ("regular" or "lfs").
 
     Raises:
-        :class:`requests.HTTPError`:
-            If the Hub API returned an error
-        :class:`ValueError`:
-            If the Hub API returned an HTTP 400 error (bad request)
+        [`~utils.HfHubHTTPError`]
+            If the Hub API returned an error.
+        [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
+            If the Hub API response is improperly formatted.
     """
     endpoint = endpoint if endpoint is not None else ENDPOINT
     headers = build_hf_headers(token=token)
 
     # Fetch upload mode (LFS or regular) chunk by chunk.
-    path2mode: Dict[str, UploadMode] = {}
+    upload_modes: Dict[str, UploadMode] = {}
     for chunk in chunk_iterable(additions, 256):
         payload = {
             "files": [
@@ -406,17 +452,17 @@ def fetch_upload_modes(
             headers=headers,
         )
         hf_raise_for_status(resp)
-        preupload_info = validate_preupload_info(resp.json())
-        path2mode.update(
+        preupload_info = _validate_preupload_info(resp.json())
+        upload_modes.update(
             **{file["path"]: file["uploadMode"] for file in preupload_info["files"]}
         )
 
-    return [(op, path2mode[op.path_in_repo]) for op in additions]
+    return upload_modes
 
 
 def prepare_commit_payload(
-    additions: Iterable[Tuple[CommitOperationAdd, UploadMode]],
-    deletions: Iterable[CommitOperationDelete],
+    operations: Iterable[CommitOperation],
+    upload_modes: Dict[str, UploadMode],
     commit_message: str,
     commit_description: Optional[str] = None,
     parent_commit: Optional[str] = None,
@@ -439,40 +485,44 @@ def prepare_commit_payload(
         header_value["parentCommit"] = parent_commit
     yield {"key": "header", "value": header_value}
 
-    # 2. Send regular files, one per line
-    yield from (
-        {
-            "key": "file",
-            "value": {
-                "content": add_op.b64content().decode(),
-                "path": add_op.path_in_repo,
-                "encoding": "base64",
-            },
-        }
-        for (add_op, upload_mode) in additions
-        if upload_mode == "regular"
-    )
-
-    # 3. Send LFS files, one per line
-    yield from (
-        {
-            "key": "lfsFile",
-            "value": {
-                "path": add_op.path_in_repo,
-                "algo": "sha256",
-                "oid": add_op.upload_info.sha256.hex(),
-                "size": add_op.upload_info.size,
-            },
-        }
-        for (add_op, upload_mode) in additions
-        if upload_mode == "lfs"
-    )
-
-    # 4. Send deleted files, one per line
-    yield from (
-        {
-            "key": "deletedFolder" if del_op.is_folder else "deletedFile",
-            "value": {"path": del_op.path_in_repo},
-        }
-        for del_op in deletions
-    )
+    # 2. Send operations, one per line
+    for operation in operations:
+        # 2.a. Case adding a regular file
+        if (
+            isinstance(operation, CommitOperationAdd)
+            and upload_modes.get(operation.path_in_repo) == "regular"
+        ):
+            yield {
+                "key": "file",
+                "value": {
+                    "content": operation.b64content().decode(),
+                    "path": operation.path_in_repo,
+                    "encoding": "base64",
+                },
+            }
+        # 2.b. Case adding an LFS file
+        elif (
+            isinstance(operation, CommitOperationAdd)
+            and upload_modes.get(operation.path_in_repo) == "lfs"
+        ):
+            {
+                "key": "lfsFile",
+                "value": {
+                    "path": operation.path_in_repo,
+                    "algo": "sha256",
+                    "oid": operation.upload_info.sha256.hex(),
+                    "size": operation.upload_info.size,
+                },
+            }
+        # 2.c. Case deleting a file or folder
+        elif isinstance(operation, CommitOperationDelete):
+            yield {
+                "key": "deletedFolder" if operation.is_folder else "deletedFile",
+                "value": {"path": operation.path_in_repo},
+            }
+        # 2.d. Never expected to happen
+        else:
+            raise ValueError(
+                f"Unknown operation to commit. Operation: {operation}. Upload mode:"
+                f" {upload_modes.get(operation.path_in_repo)}"
+            )

--- a/src/huggingface_hub/_commit_api.py
+++ b/src/huggingface_hub/_commit_api.py
@@ -505,7 +505,7 @@ def prepare_commit_payload(
             isinstance(operation, CommitOperationAdd)
             and upload_modes.get(operation.path_in_repo) == "lfs"
         ):
-            {
+            yield {
                 "key": "lfsFile",
                 "value": {
                     "path": operation.path_in_repo,

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -1859,9 +1859,6 @@ class HfApi:
             f" {len(deletions)} deletion(s)."
         )
 
-        for addition in additions:
-            addition.validate()
-
         try:
             additions_with_upload_mode = fetch_upload_modes(
                 additions=additions,

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -1868,17 +1868,12 @@ class HfApi:
 
         operations = list(operations)
         additions = [op for op in operations if isinstance(op, CommitOperationAdd)]
-        deletions = [op for op in operations if isinstance(op, CommitOperationDelete)]
-
-        if len(additions) + len(deletions) != len(operations):
-            raise ValueError(
-                "Unknown operation, must be one of `CommitOperationAdd` or"
-                " `CommitOperationDelete`"
-            )
+        nb_additions = len(additions)
+        nb_deletions = len(operations) - nb_additions
 
         logger.debug(
             f"About to commit to the hub: {len(additions)} addition(s) and"
-            f" {len(deletions)} deletion(s)."
+            f" {nb_deletions} deletion(s)."
         )
 
         # If updating twice the same file or update then delete a file in a single commit
@@ -1941,7 +1936,7 @@ class HfApi:
             e.append_to_message(_CREATE_COMMIT_NO_REPO_ERROR_MESSAGE)
             raise
         except EntryNotFoundError as e:
-            if len(deletions) > 0 and "A file with this name doesn't exist" in str(e):
+            if nb_deletions > 0 and "A file with this name doesn't exist" in str(e):
                 e.append_to_message(
                     "\nMake sure to differentiate file and folder paths in delete"
                     " operations with a trailing '/' or using `is_folder=True/False`."

--- a/tests/test_commit_api.py
+++ b/tests/test_commit_api.py
@@ -1,6 +1,10 @@
 import unittest
 
-from huggingface_hub._commit_api import CommitOperationDelete
+from huggingface_hub._commit_api import (
+    CommitOperationAdd,
+    CommitOperationDelete,
+    warn_on_overwriting_operations,
+)
 
 
 class TestCommitOperationDelete(unittest.TestCase):
@@ -46,3 +50,49 @@ class TestCommitOperationDelete(unittest.TestCase):
     def test_is_folder_wrong_value(self):
         with self.assertRaises(ValueError):
             CommitOperationDelete(path_in_repo="path/to/folder", is_folder="any value")
+
+
+class TestWarnOnOverwritingOperations(unittest.TestCase):
+
+    add_file_ab = CommitOperationAdd(path_in_repo="a/b.txt", path_or_fileobj=b"data")
+    add_file_abc = CommitOperationAdd(path_in_repo="a/b/c.md", path_or_fileobj=b"data")
+    add_file_abd = CommitOperationAdd(path_in_repo="a/b/d.md", path_or_fileobj=b"data")
+    update_file_abc = CommitOperationAdd(
+        path_in_repo="a/b/c.md", path_or_fileobj=b"updated data"
+    )
+    delete_file_abc = CommitOperationDelete(path_in_repo="a/b/c.md")
+    delete_folder_a = CommitOperationDelete(path_in_repo="a/")
+    delete_folder_e = CommitOperationDelete(path_in_repo="e/")
+
+    def test_no_overwrite(self) -> None:
+        warn_on_overwriting_operations(
+            [
+                self.add_file_ab,
+                self.add_file_abc,
+                self.add_file_abd,
+                self.delete_folder_e,
+            ]
+        )
+
+    def test_add_then_update_file(self) -> None:
+        with self.assertWarns(UserWarning):
+            warn_on_overwriting_operations([self.add_file_abc, self.update_file_abc])
+
+    def test_add_then_delete_file(self) -> None:
+        with self.assertWarns(UserWarning):
+            warn_on_overwriting_operations([self.add_file_abc, self.delete_file_abc])
+
+    def test_add_then_delete_folder(self) -> None:
+        with self.assertWarns(UserWarning):
+            warn_on_overwriting_operations([self.add_file_abc, self.delete_folder_a])
+
+        with self.assertWarns(UserWarning):
+            warn_on_overwriting_operations([self.add_file_ab, self.delete_folder_a])
+
+    def test_delete_file_then_add(self) -> None:
+        warn_on_overwriting_operations([self.delete_file_abc, self.add_file_abc])
+
+    def test_delete_folder_then_add(self) -> None:
+        warn_on_overwriting_operations(
+            [self.delete_folder_a, self.add_file_ab, self.add_file_abc]
+        )

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -379,24 +379,21 @@ class CommitApiTest(HfApiCommonTestWithLogin):
 
     def test_commit_operation_validation(self):
         with open(self.tmp_file, "rt") as ftext:
-            operation = CommitOperationAdd(
-                path_or_fileobj=ftext,  # type: ignore
-                path_in_repo="README.md",
-            )
             with self.assertRaises(
                 ValueError,
                 msg="If you passed a file-like object, make sure it is in binary mode",
             ):
-                operation.validate()
+                CommitOperationAdd(
+                    path_or_fileobj=ftext, path_in_repo="README.md"  # type: ignore
+                )
 
-        operation = CommitOperationAdd(
-            path_or_fileobj=os.path.join(self.tmp_dir, "nofile.pth"),
-            path_in_repo="README.md",
-        )
         with self.assertRaises(
             ValueError, msg="path_or_fileobj is str but does not point to a file"
         ):
-            operation.validate()
+            CommitOperationAdd(
+                path_or_fileobj=os.path.join(self.tmp_dir, "nofile.pth"),
+                path_in_repo="README.md",
+            )
 
     @retry_endpoint
     def test_upload_file_path(self):

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -1061,7 +1061,7 @@ class CommitApiTest(HfApiCommonTestWithLogin):
                 endpoint=ENDPOINT_STAGING,
             )
             self.assertEqual(len(res), 1300)
-            for _, mode in res:
+            for _, mode in res.items():
                 self.assertEqual(mode, "lfs")
         except Exception as err:
             self.fail(err)

--- a/tests/test_keras_integration.py
+++ b/tests/test_keras_integration.py
@@ -526,9 +526,6 @@ class HubKerasSequentialTest(CommonKerasTest):
                 local_dir=tmpdirname, clone_from=ENDPOINT_STAGING + "/" + repo_id
             )
             from_pretrained_keras(tmpdirname)
-            self.assertRaises(
-                ValueError, msg="Exception encountered when calling layer*"
-            )
 
         self._api.delete_repo(repo_id=f"{REPO_NAME}")
 


### PR DESCRIPTION
Fix https://github.com/huggingface/huggingface_hub/issues/1162.

**With this PR:**
- Order of the operations in the commit payload is the same as the input of `create_commit(...)`. It was not the case before which causes trouble if someone wants to delete then create a file.
- If 2 operations are modifying the same file, a warning is issued. Only case without warning is "delete a file then add this file" or "delete folder then add file that would have been in this folder".
- `CommitOperationAdd` is validated at initialization (no need for `.validate()` or `._upload_info()` calls anymore)

**Warning:** I made some breaking changes in `validate_preupload_info`, `fetch_upload_modes` and `prepare_commit_payload`. I did not care too much as those 3 methods are defined in a private module and used exclusively for the in `create_commit` . I checked for safety and it's not used anywhere in `diffusers`, `transformers`, `skops` and `datasets`.

**Potential issue:** if someone adds twice the same file, once a LFS content, once a regular content then the final upload mode will be the one from the second operation. Might cause issue with request payload or gitaly. Anyway, this is a weird case so let's not care of the user has an error. A warning message is triggered before upload so the user should notice the problem. (note: this issue was already existing before this PR)


(cc @severo who raised the issue)