### PR TITLE
Removing "Related Models" & just asking for "Parent Model"

### DIFF
--- a/src/huggingface_hub/templates/modelcard_template.md
+++ b/src/huggingface_hub/templates/modelcard_template.md
@@ -38,8 +38,7 @@
 - **Model type:** {{ model_type | default("[More Information Needed]", true)}}
 - **Language(s) (NLP):** {{ language | default("[More Information Needed]", true)}}
 - **License:** {{ license | default("[More Information Needed]", true)}}
-- **Related Models [optional]:** {{ related_models | default("[More Information Needed]", true)}}
-    - **Parent Model [optional]:** {{ parent_model | default("[More Information Needed]", true)}}
+- **Parent Model [optional]:** {{ parent_model | default("[More Information Needed]", true)}}
 - **Resources for more information:** {{ more_resources | default("[More Information Needed]", true)}}
 
 # Uses


### PR DESCRIPTION
"Related Models" was underspecified.
For "Parent Model", the goal is to link to the parent model's model card. This PR attempts to clean that up a bit.