### PR TITLE
Parse file size in get_hf_file_metadata

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1392,4 +1392,4 @@ def _int_or_none(value: Optional[str]) -> Optional[int]:
     try:
         return int(value)  # type: ignore
     except (TypeError, ValueError):
-        pass
+        return None

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -145,11 +145,14 @@ class HfFileMetadata:
             Etag of the file on the server.
         location (`str`):
             Location where to download the file. Can be a Hub url or not (CDN).
+        size (`size`):
+            Size of the file.
     """
 
     commit_hash: Optional[str]
     etag: Optional[str]
     location: str
+    size: Optional[int]
 
 
 @validate_hf_hub_args
@@ -1351,7 +1354,7 @@ def get_hf_file_metadata(
             How many seconds to wait for the server to send metadata before giving up.
 
     Returns:
-        A [`HfFileMetadata`] object containing metadata such as location, etag and
+        A [`HfFileMetadata`] object containing metadata such as location, etag, size and
         commit_hash.
     """
     headers = build_hf_headers(token=token)
@@ -1381,4 +1384,12 @@ def get_hf_file_metadata(
         # Do not use directly `url`, as `_request_wrapper` might have followed relative
         # redirects.
         location=r.headers.get("Location") or r.request.url,  # type: ignore
+        size=_int_or_none(r.headers.get("Content-Length")),
     )
+
+
+def _int_or_none(value: Optional[str]) -> Optional[int]:
+    try:
+        return int(value)  # type: ignore
+    except (TypeError, ValueError):
+        pass

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -359,6 +359,7 @@ class CachedDownloadTests(unittest.TestCase):
         )
         self.assertIsNotNone(metadata.etag)  # example: "85c2fc2dcdd86563aaa85ef4911..."
         self.assertEqual(metadata.location, url)  # no redirect
+        self.assertEqual(metadata.size, 851)
 
     def test_get_hf_file_metadata_from_a_renamed_repo(self) -> None:
         """Test getting metadata from a file in a renamed repo on the Hub."""


### PR DESCRIPTION
Resolve https://github.com/huggingface/huggingface_hub/issues/1158.

This PR adds a `size` attribute to the output of `get_hf_file_metadata`.

`RepoFile` and `HfFileMetadata` are still 2 different objects doing related stuff (getting file info from API or from HEAD request on the file itself) but this PR is not meant to harmonize this.

(cc @Narsil who were requesting it)