### PR TITLE
Commit empty files as regular and warn user

### DIFF
--- a/src/huggingface_hub/_commit_api.py
+++ b/src/huggingface_hub/_commit_api.py
@@ -457,6 +457,22 @@ def fetch_upload_modes(
             **{file["path"]: file["uploadMode"] for file in preupload_info["files"]}
         )
 
+    # If a file is empty, it is most likely a mistake.
+    # => a warning message is triggered to warn the user.
+    #    => except if `.gitkeep` as it is a legit use case for an empty file.
+    #
+    # Empty files cannot be uploaded as LFS (S3 would fail with a 501 Not Implemented)
+    # => empty files are uploaded as "regular" to still allow users to commit them.
+    for addition in additions:
+        if addition.upload_info.size == 0:
+            path = addition.path_in_repo
+            if not path.endswith(".gitkeep"):
+                warnings.warn(
+                    f"About to commit an empty file: '{path}'. Are you sure this is"
+                    " intended ?"
+                )
+            upload_modes[path] = "regular"
+
     return upload_modes
 
 


### PR DESCRIPTION
Resolve https://github.com/huggingface/huggingface_hub/issues/946.

With this PR:
1. Empty files are always uploaded as "regular" (LFS/S3 doesn't work for empty files)
1. A warning message is triggered when user commits an empty file (cc @adrinjalali: once this is released, no need to warn in `skops` anymore - except if you want a more detailed message)
   1. Except for `.gitkeep` files (legit use case)

(cc @SBrandeis who created in issue)