### PR TITLE
Fix cannot create pr on foreign repo

### DIFF
--- a/src/huggingface_hub/_commit_api.py
+++ b/src/huggingface_hub/_commit_api.py
@@ -400,6 +400,7 @@ def fetch_upload_modes(
     token: Optional[str],
     revision: str,
     endpoint: Optional[str] = None,
+    create_pr: bool = False,
 ) -> Dict[str, UploadMode]:
     """
     Requests the Hub "preupload" endpoint to determine wether each input file
@@ -450,6 +451,7 @@ def fetch_upload_modes(
             f"{endpoint}/api/{repo_type}s/{repo_id}/preupload/{revision}",
             json=payload,
             headers=headers,
+            params={"create_pr": "1"} if create_pr else None,
         )
         hf_raise_for_status(resp)
         preupload_info = _validate_preupload_info(resp.json())

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -1887,6 +1887,7 @@ class HfApi:
                 token=token or self.token,
                 revision=revision,
                 endpoint=self.endpoint,
+                create_pr=create_pr,
             )
         except RepositoryNotFoundError as e:
             e.append_to_message(_CREATE_COMMIT_NO_REPO_ERROR_MESSAGE)

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -809,6 +809,24 @@ class CommitApiTest(HfApiCommonTestWithLogin):
         self._api.delete_repo(repo_id=repo_id)
 
     @retry_endpoint
+    def test_create_commit_create_pr_on_foreign_repo(self):
+        # Repo on which we don't have right
+        # We must be able to create a PR on it
+        self._api.create_commit(
+            operations=[
+                CommitOperationAdd(
+                    path_in_repo="regular.txt", path_or_fileobj=b"File content"
+                ),
+                CommitOperationAdd(
+                    path_in_repo="lfs.pkl", path_or_fileobj=b"File content"
+                ),
+            ],
+            commit_message="PR on foreign repo",
+            repo_id="datasets_server_org/repo_for_huggingface_hub_ci_with_prs",
+            create_pr=True,
+        )
+
+    @retry_endpoint
     def test_create_commit(self):
         for private in (False, True):
             visibility = "private" if private else "public"


### PR DESCRIPTION
Fix https://github.com/huggingface/huggingface_hub/issues/1182.

Users were not able to push files and create a PR on a repo where they don't own write permissions. Was due to an auth rule changed in `/endpoint`. 