### PR TITLE
FIX overwriting metadata when both verified and unverified reported values

### DIFF
--- a/src/huggingface_hub/repocard.py
+++ b/src/huggingface_hub/repocard.py
@@ -802,7 +802,7 @@ def metadata_update(
                                 raise ValueError(
                                     "You passed a new value for the existing metric"
                                     f" 'name: {new_result.metric_name}, type: "
-                                    f" {new_result.metric_type}'. Set `overwrite=True`"
+                                    f"{new_result.metric_type}'. Set `overwrite=True`"
                                     " to overwrite existing metrics."
                                 )
                             result_found = True

--- a/src/huggingface_hub/repocard_data.py
+++ b/src/huggingface_hub/repocard_data.py
@@ -121,6 +121,18 @@ class EvalResult:
     # A JSON Web Token that is used to verify whether the metrics originate from Hugging Face's [evaluation service](https://huggingface.co/spaces/autoevaluate/model-evaluator) or not.
     verify_token: Optional[str] = None
 
+    def is_equal_except_value(self, other: "EvalResult") -> bool:
+        """
+        Return True if `self` and `other` describe exactly the same metric but with a
+        different value.
+        """
+        for key, _ in self.__dict__.items():
+            if key == "metric_value":
+                continue
+            if getattr(self, key) != getattr(other, key):
+                return False
+        return True
+
 
 @dataclass
 class CardData:


### PR DESCRIPTION
Should fix https://github.com/huggingface/huggingface_hub/issues/1185.

With this PR, 2 eval results are considered to describe the same object if and only if all attributes are the same except the metric value itself (see `is_equal_except_value`). Otherwise value is not overwritten.

cc @lewtun for review