### PR TITLE
Set back feature to create a repo when using clone_from

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -75,11 +75,11 @@ jobs:
           case "${{ matrix.test_name }}" in
 
             "Repository only")
-              eval "$PYTEST ../tests -k 'RepositoryTest'"
+              eval "$PYTEST ../tests -k 'RepositoryTest or RepositoryDatasetTest'"
               ;;
 
             "Everything else")
-              eval "$PYTEST ../tests -k 'not RepositoryTest'"
+              eval "$PYTEST ../tests -k 'not RepositoryTest and not RepositoryDatasetTest'"
               ;;
 
             lfs)

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -692,9 +692,10 @@ class Repository:
         if hub_url in repo_url or (
             "http" not in repo_url and len(repo_url.split("/")) <= 2
         ):
-            repo_type, namespace, repo_id = repo_type_and_id_from_hf_id(
+            repo_type, namespace, repo_name = repo_type_and_id_from_hf_id(
                 repo_url, hub_url=hub_url
             )
+            repo_id = f"{namespace}/{repo_name}" if namespace is not None else repo_name
 
             if repo_type is not None:
                 self._repo_type = repo_type
@@ -709,8 +710,6 @@ class Repository:
                 scheme = urlparse(repo_url).scheme
                 repo_url = repo_url.replace(f"{scheme}://", f"{scheme}://user:{token}@")
 
-            if namespace is not None:
-                repo_url += f"{namespace}/"
             repo_url += repo_id
 
             # To be removed: check if repo exists. If not, create it first.

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -481,6 +481,7 @@ class RepositoryTest(RepositoryCommonTest):
         self.assertTrue("model.bin" in files)
 
     @retry_endpoint
+    @expect_deprecation("clone_from")
     def test_clone_with_repo_name_and_no_namespace(self):
         with self.assertRaises(EnvironmentError):
             Repository(
@@ -1742,6 +1743,7 @@ class RepositoryDatasetTest(RepositoryCommonTest):
         self.assertTrue("test.py" in files)
 
     @retry_endpoint
+    @expect_deprecation("clone_from")
     def test_clone_with_repo_name_and_no_namespace(self):
         self.assertRaises(
             OSError,

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -22,8 +22,6 @@ import unittest
 import uuid
 from io import BytesIO
 
-import pytest
-
 import requests
 from huggingface_hub._login import _currently_setup_credential_helpers
 from huggingface_hub.hf_api import HfApi
@@ -118,17 +116,16 @@ class RepositoryTest(RepositoryCommonTest):
             repo_id=f"{USER}/{self.REPO_NAME}-temp", repo_type="space"
         )
 
+    @expect_deprecation("clone_from")
     def test_clone_from_missing_repo(self):
         """
-        If the repo does not exist, it is not created automatically. This behavior
-        was possible before but has been deprecated and removed.
+        If the repo does not exist, it is created automatically.
+
+        This behavior is deprecated and will be removed in v0.12.
         """
-        with pytest.raises(EnvironmentError, match=".*remote: Repository not found.*"):
-            Repository(
-                WORKING_REPO_DIR,
-                clone_from=f"{USER}/{uuid.uuid4()}",
-                use_auth_token=self._token,
-            )
+        Repository(
+            WORKING_REPO_DIR, clone_from=f"{USER}/{uuid.uuid4()}", token=self._token
+        )
 
     def test_clone_from_model(self):
         temp_repo_url = self._api.create_repo(


### PR DESCRIPTION
Deprecation cycle is kept for one more version. See [slack discussion](https://huggingface.slack.com/archives/C02V5EA0A95/p1668427994770019) (internal link).

Still used (reported by @osanseviero)
https://github.com/huggingface/diffusers/blob/main/src/diffusers/hub_utils.py#L112 

From @osanseviero :
> I think this would also break transformers PushToHubCallback https://github.com/huggingface/transformers/blob/main/src/transformers/keras_callbacks.py#L342

From @nateraw :
https://github.com/rwightman/pytorch-image-models/issues/1546
https://github.com/rwightman/pytorch-image-models/blob/8ff45e41f7a6aba4d5fdadee7dc3b7f2733df045/timm/models/hub.py#L153