### PR TITLE
Add user agent attribute to `HfApi` client

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -570,10 +570,43 @@ class DatasetSearchArguments(AttributeDictionary):
 
 class HfApi:
     def __init__(
-        self, endpoint: Optional[str] = None, token: Optional[str] = None
+        self,
+        endpoint: Optional[str] = None,
+        token: Optional[str] = None,
+        library_name: Optional[str] = None,
+        library_version: Optional[str] = None,
+        user_agent: Union[Dict, str, None] = None,
     ) -> None:
+        """Create a HF client to interact with the Hub via HTTP.
+
+        The client is initialized with some high-level settings used in all requests
+        made to the Hub (HF endpoint, authentication, user agents...). Using the `HfApi`
+        client is preferred but not mandatory as all of its public methods are exposed
+        directly at the root of `huggingface_hub`.
+
+        Args:
+            endpoint (`str`, *optional*):
+                Hugging Face Hub base url. Will default to https://huggingface.co/. To
+                be set if you are using a private hub. Otherwise, one can set the
+                `HF_ENDPOINT` environment variable.
+            token (`str`, *optional*):
+                Hugging Face token. Will default to the locally saved token if
+                not provided.
+            library_name (`str`, *optional*):
+                The name of the library that is making the HTTP request. Will be added to
+                the user-agent header. Example: `"transformers"`.
+            library_version (`str`, *optional*):
+                The version of the library that is making the HTTP request. Will be added
+                to the user-agent header. Example: `"4.24.0"`.
+            user_agent (`str`, `dict`, *optional*):
+                The user agent info in the form of a dictionary or a single string. It will
+                be completed with information about the installed packages.
+        """
         self.endpoint = endpoint if endpoint is not None else ENDPOINT
         self.token = token
+        self.library_name = library_name
+        self.library_version = library_version
+        self.user_agent = user_agent
 
     def whoami(self, token: Optional[str] = None) -> Dict:
         """
@@ -3393,13 +3426,14 @@ class HfApi:
         when `token` is not provided.
         """
         if token is None:
+            # Cannot do `token = token or self.token` as token can be `False`.
             token = self.token
         return build_hf_headers(
             token=token,
             is_write_action=is_write_action,
-            library_name=library_name,
-            library_version=library_version,
-            user_agent=user_agent,
+            library_name=library_name or self.library_name,
+            library_version=library_version or self.library_version,
+            user_agent=user_agent or self.user_agent,
         )
 
 

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2268,31 +2268,49 @@ class HfApiDiscussionsTest(HfApiCommonTestWithLogin):
 @patch("huggingface_hub.hf_api.build_hf_headers")
 class HfApiTokenAttributeTest(unittest.TestCase):
     def test_token_passed(self, mock_build_hf_headers: Mock) -> None:
-        api = HfApi(token="default token")
-        api._build_hf_headers(token="A token")
+        HfApi(token="default token")._build_hf_headers(token="A token")
         self._assert_token_is(mock_build_hf_headers, "A token")
 
     def test_no_token_passed(self, mock_build_hf_headers: Mock) -> None:
-        api = HfApi(token="default token")
-        api._build_hf_headers()
+        HfApi(token="default token")._build_hf_headers()
         self._assert_token_is(mock_build_hf_headers, "default token")
 
     def test_token_true_passed(self, mock_build_hf_headers: Mock) -> None:
-        api = HfApi(token="default token")
-        api._build_hf_headers(token=True)
+        HfApi(token="default token")._build_hf_headers(token=True)
         self._assert_token_is(mock_build_hf_headers, True)
 
     def test_token_false_passed(self, mock_build_hf_headers: Mock) -> None:
-        api = HfApi(token="default token")
-        api._build_hf_headers(token=False)
+        HfApi(token="default token")._build_hf_headers(token=False)
         self._assert_token_is(mock_build_hf_headers, False)
 
     def test_no_token_at_all(self, mock_build_hf_headers: Mock) -> None:
-        api = HfApi()
-        api._build_hf_headers(token=None)
+        HfApi()._build_hf_headers(token=None)
         self._assert_token_is(mock_build_hf_headers, None)
 
     def _assert_token_is(
         self, mock_build_hf_headers: Mock, expected_value: str
     ) -> None:
         self.assertEqual(mock_build_hf_headers.call_args[1]["token"], expected_value)
+
+    def test_library_name_and_version_are_set(
+        self, mock_build_hf_headers: Mock
+    ) -> None:
+        HfApi(library_name="a", library_version="b")._build_hf_headers()
+        self.assertEqual(mock_build_hf_headers.call_args[1]["library_name"], "a")
+        self.assertEqual(mock_build_hf_headers.call_args[1]["library_version"], "b")
+
+    def test_library_name_and_version_are_overwritten(
+        self, mock_build_hf_headers: Mock
+    ) -> None:
+        api = HfApi(library_name="a", library_version="b")
+        api._build_hf_headers(library_name="A", library_version="B")
+        self.assertEqual(mock_build_hf_headers.call_args[1]["library_name"], "A")
+        self.assertEqual(mock_build_hf_headers.call_args[1]["library_version"], "B")
+
+    def test_user_agent_is_set(self, mock_build_hf_headers: Mock) -> None:
+        HfApi(user_agent={"a": "b"})._build_hf_headers()
+        self.assertEqual(mock_build_hf_headers.call_args[1]["user_agent"], {"a": "b"})
+
+    def test_user_agent_is_overwritten(self, mock_build_hf_headers: Mock) -> None:
+        HfApi(user_agent={"a": "b"})._build_hf_headers(user_agent={"A": "B"})
+        self.assertEqual(mock_build_hf_headers.call_args[1]["user_agent"], {"A": "B"})


### PR DESCRIPTION
First discussed [on slack](https://huggingface.slack.com/archives/C02EMARJ65P/p1668613089997919?thread_ts=1668609919.729479&cid=C02EMARJ65P) (internal link).

The idea is to be able to set a custom user agent for all requests made with `HfApi` client. Also added a docstring and some tests.

cc @ydshieh 
 