### PR TITLE
Remove deprecated code in v0.12

### DIFF
--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -6,17 +6,11 @@ from .constants import DEFAULT_REVISION, HUGGINGFACE_HUB_CACHE, REPO_TYPES
 from .file_download import REGEX_COMMIT_HASH, hf_hub_download, repo_folder_name
 from .hf_api import HfApi
 from .utils import filter_repo_objects, logging, tqdm, validate_hf_hub_args
-from .utils._deprecation import _deprecate_arguments
 
 
 logger = logging.get_logger(__name__)
 
 
-@_deprecate_arguments(
-    version="0.12",
-    deprecated_args={"allow_regex", "ignore_regex"},
-    custom_message="Please use `allow_patterns` and `ignore_patterns` instead.",
-)
 @validate_hf_hub_args
 def snapshot_download(
     repo_id: str,
@@ -32,8 +26,6 @@ def snapshot_download(
     resume_download: bool = False,
     token: Optional[Union[bool, str]] = None,
     local_files_only: bool = False,
-    allow_regex: Optional[Union[List[str], str]] = None,
-    ignore_regex: Optional[Union[List[str], str]] = None,
     allow_patterns: Optional[Union[List[str], str]] = None,
     ignore_patterns: Optional[Union[List[str], str]] = None,
 ) -> str:
@@ -119,13 +111,6 @@ def snapshot_download(
     storage_folder = os.path.join(
         cache_dir, repo_folder_name(repo_id=repo_id, repo_type=repo_type)
     )
-
-    # TODO: remove these 4 lines in version 0.12
-    #       Deprecated code to ensure backward compatibility.
-    if allow_regex is not None:
-        allow_patterns = allow_regex
-    if ignore_regex is not None:
-        ignore_patterns = ignore_regex
 
     # if we have no internet connection we will look for an
     # appropriate folder in the cache

--- a/src/huggingface_hub/fastai_utils.py
+++ b/src/huggingface_hub/fastai_utils.py
@@ -17,7 +17,6 @@ from huggingface_hub.utils import (
 )
 
 from .utils import logging, validate_hf_hub_args
-from .utils._deprecation import _deprecate_arguments, _deprecate_positional_args
 from .utils._runtime import _PY_VERSION  # noqa: F401 # for backward compatibility...
 
 
@@ -353,21 +352,12 @@ def from_pretrained_fastai(
     return load_learner(os.path.join(storage_folder, "model.pkl"))
 
 
-@_deprecate_positional_args(version="0.12")
-@_deprecate_arguments(
-    version="0.12",
-    deprecated_args={
-        "git_user",
-        "git_email",
-    },
-)
 @validate_hf_hub_args
 def push_to_hub_fastai(
-    # NOTE: New arguments since 0.9
     learner,
     *,
     repo_id: str,
-    commit_message: str = "Add model",
+    commit_message: str = "Push FastAI model using huggingface_hub.",
     private: bool = False,
     token: Optional[str] = None,
     config: Optional[dict] = None,
@@ -376,21 +366,6 @@ def push_to_hub_fastai(
     allow_patterns: Optional[Union[List[str], str]] = None,
     ignore_patterns: Optional[Union[List[str], str]] = None,
     api_endpoint: Optional[str] = None,
-    # NOTE: deprecated signature that will change in 0.12
-    git_user: Optional[str] = None,
-    git_email: Optional[str] = None,
-    # TODO (release 0.12): signature must be the following
-    # learner,
-    # repo_id: Optional[str] = None,  # optional only until 0.12
-    # commit_message: str = "Add model",
-    # private: Optional[bool] = None,
-    # token: Optional[str] = None,
-    # config: Optional[dict] = None,
-    # branch: Optional[str] = None,
-    # create_pr: Optional[bool] = None,
-    # allow_patterns: Optional[Union[List[str], str]] = None,
-    # ignore_patterns: Optional[Union[List[str], str]] = None,
-    # api_endpoint: Optional[str] = None,
 ):
     """
     Upload learner checkpoint files to the Hub.
@@ -436,15 +411,10 @@ def push_to_hub_fastai(
 
     </Tip>
     """
-
     _check_fastai_fastcore_versions()
     api = HfApi(endpoint=api_endpoint)
     api.create_repo(
-        repo_id=repo_id,
-        repo_type="model",
-        token=token,
-        private=private,
-        exist_ok=True,
+        repo_id=repo_id, repo_type="model", token=token, private=private, exist_ok=True
     )
 
     # Push the files to the repo in a single commit

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -70,7 +70,6 @@ from .utils._deprecation import (
     _deprecate_arguments,
     _deprecate_list_output,
     _deprecate_method,
-    _deprecate_positional_args,
 )
 from .utils._pagination import paginate
 from .utils._typing import Literal, TypedDict
@@ -1475,7 +1474,6 @@ class HfApi:
         return [f.rfilename for f in repo_info.siblings]
 
     @validate_hf_hub_args
-    @_deprecate_positional_args(version="0.12")
     def create_repo(
         self,
         repo_id: str,

--- a/src/huggingface_hub/keras_mixin.py
+++ b/src/huggingface_hub/keras_mixin.py
@@ -4,7 +4,7 @@ import os
 import tempfile
 import warnings
 from pathlib import Path
-from shutil import copytree, rmtree
+from shutil import copytree
 from typing import Any, Dict, List, Optional, Union
 from urllib.parse import quote
 
@@ -20,9 +20,7 @@ from huggingface_hub.utils import (
 
 from .constants import CONFIG_NAME, DEFAULT_REVISION
 from .hf_api import HfApi, _parse_revision_from_pr_url, _prepare_upload_folder_commit
-from .repository import Repository
-from .utils import HfFolder, logging, validate_hf_hub_args
-from .utils._deprecation import _deprecate_arguments, _deprecate_positional_args
+from .utils import logging, validate_hf_hub_args
 
 
 logger = logging.get_logger(__name__)
@@ -288,61 +286,25 @@ def from_pretrained_keras(*args, **kwargs):
     return KerasModelHubMixin.from_pretrained(*args, **kwargs)
 
 
-@_deprecate_positional_args(version="0.12")
-@_deprecate_arguments(
-    version="0.12",
-    deprecated_args={
-        "repo_path_or_name",
-        "repo_url",
-        "organization",
-        "git_user",
-        "git_email",
-    },
-)
 @validate_hf_hub_args
 def push_to_hub_keras(
-    # NOTE: deprecated signature that will change in 0.12
     model,
+    repo_id: str,
     *,
-    repo_path_or_name: Optional[str] = None,
-    repo_url: Optional[str] = None,
-    log_dir: Optional[str] = None,
-    commit_message: str = "Add Keras model",
-    organization: Optional[str] = None,
+    config: Optional[dict] = None,
+    commit_message: str = "Push Keras model using huggingface_hub.",
     private: bool = False,
     api_endpoint: Optional[str] = None,
-    git_user: Optional[str] = None,
-    git_email: Optional[str] = None,
-    config: Optional[dict] = None,
-    include_optimizer: bool = False,
-    tags: Optional[Union[list, str]] = None,
-    plot_model: bool = True,
-    # NOTE: New arguments since 0.9
     token: Optional[str] = None,
-    repo_id: Optional[str] = None,  # optional only until 0.12
     branch: Optional[str] = None,
     create_pr: Optional[bool] = None,
     allow_patterns: Optional[Union[List[str], str]] = None,
     ignore_patterns: Optional[Union[List[str], str]] = None,
+    log_dir: Optional[str] = None,
+    include_optimizer: bool = False,
+    tags: Optional[Union[list, str]] = None,
+    plot_model: bool = True,
     **model_save_kwargs,
-    # TODO (release 0.12): signature must be the following
-    # model,
-    # repo_id: str,
-    # *,
-    # commit_message: str = "Add model",
-    # private: bool = None,
-    # api_endpoint: Optional[str] = None,
-    # token: Optional[str] = True,
-    # branch: Optional[str] = None,
-    # create_pr: Optional[bool] = None,
-    # config: Optional[dict] = None,
-    # allow_patterns: Optional[Union[List[str], str]] = None,
-    # ignore_patterns: Optional[Union[List[str], str]] = None,
-    # log_dir: Optional[str] = None,
-    # include_optimizer: bool = False,
-    # tags: Optional[Union[list, str]] = None,
-    # plot_model: Optional[bool] = True,
-    # **model_save_kwargs,
 ):
     """
     Upload model checkpoint or tokenizer files to the Hub while synchronizing a
@@ -400,135 +362,68 @@ def push_to_hub_keras(
     Returns:
         The url of the commit of your model in the given repository.
     """
-    if repo_id is not None:
-        api = HfApi(endpoint=api_endpoint)
-        api.create_repo(
-            repo_id=repo_id,
-            repo_type="model",
-            token=token,
-            private=private,
-            exist_ok=True,
-        )
-
-        # Push the files to the repo in a single commit
-        with tempfile.TemporaryDirectory() as tmp:
-            saved_path = Path(tmp) / repo_id
-            save_pretrained_keras(
-                model,
-                saved_path,
-                config=config,
-                include_optimizer=include_optimizer,
-                tags=tags,
-                plot_model=plot_model,
-                **model_save_kwargs,
-            )
-
-            # If log dir is provided, delete old logs + add new ones
-            operations: List[CommitOperation] = []
-            if log_dir is not None:
-                # Delete previous log files from Hub
-                operations += [
-                    CommitOperationDelete(path_in_repo=file)
-                    for file in api.list_repo_files(repo_id=repo_id, token=token)
-                    if file.startswith("logs/")
-                ]
-
-                # Copy new log files
-                copytree(log_dir, saved_path / "logs")
-
-            # NOTE: `_prepare_upload_folder_commit` and `create_commit` calls are
-            #       duplicate code from `upload_folder`. We are not directly using
-            #       `upload_folder` since we want to add delete operations to the
-            #       commit as well.
-            operations += _prepare_upload_folder_commit(
-                saved_path,
-                path_in_repo="",
-                allow_patterns=allow_patterns,
-                ignore_patterns=ignore_patterns,
-            )
-            commit_info = api.create_commit(
-                repo_type="model",
-                repo_id=repo_id,
-                operations=operations,
-                commit_message=commit_message,
-                token=token,
-                revision=branch,
-                create_pr=create_pr,
-            )
-            revision = branch
-            if revision is None:
-                revision = (
-                    quote(_parse_revision_from_pr_url(commit_info.pr_url), safe="")
-                    if commit_info.pr_url is not None
-                    else DEFAULT_REVISION
-                )
-            return f"{api.endpoint}/{repo_id}/tree/{revision}/"
-
-    # Repo id is None means we use the deprecated version using Git
-    # TODO: remove code between here and `return repo.git_push()` in release 0.12
-    if repo_path_or_name is None and repo_url is None:
-        raise ValueError("You need to specify a `repo_path_or_name` or a `repo_url`.")
-
-    if isinstance(token, bool) and token:
-        token = HfFolder.get_token()
-    elif isinstance(token, str):
-        token = token
-    else:
-        token = None
-
-    if token is None:
-        raise ValueError(
-            "You must login to the Hugging Face hub on this computer by typing"
-            " `huggingface-cli login` and entering your credentials to use"
-            " `token=True`. Alternatively, you can pass your own token as the"
-            " `token` argument."
-        )
-
-    if repo_path_or_name is None:
-        assert repo_url is not None, "A `None` repo URL would have raised above"
-        repo_path_or_name = repo_url.split("/")[-1]
-
-    # If no URL is passed and there's no path to a directory containing files, create a repo
-    if repo_url is None and not os.path.exists(repo_path_or_name):
-        repo_id = Path(repo_path_or_name).name
-        if organization:
-            repo_id = f"{organization}/{repo_id}"
-        repo_url = HfApi(endpoint=api_endpoint).create_repo(
-            repo_id=repo_id,
-            token=token,
-            private=private,
-            repo_type=None,
-            exist_ok=True,
-        )
-
-    repo = Repository(
-        repo_path_or_name,
-        clone_from=repo_url,
+    api = HfApi(endpoint=api_endpoint)
+    api.create_repo(
+        repo_id=repo_id,
+        repo_type="model",
         token=token,
-        git_user=git_user,
-        git_email=git_email,
-    )
-    repo.git_pull(rebase=True)
-
-    save_pretrained_keras(
-        model,
-        repo_path_or_name,
-        config=config,
-        include_optimizer=include_optimizer,
-        tags=tags,
-        plot_model=plot_model,
-        **model_save_kwargs,
+        private=private,
+        exist_ok=True,
     )
 
-    if log_dir is not None:
-        if os.path.exists(f"{repo_path_or_name}/logs"):
-            rmtree(f"{repo_path_or_name}/logs")
-        copytree(log_dir, f"{repo_path_or_name}/logs")
+    # Push the files to the repo in a single commit
+    with tempfile.TemporaryDirectory() as tmp:
+        saved_path = Path(tmp) / repo_id
+        save_pretrained_keras(
+            model,
+            saved_path,
+            config=config,
+            include_optimizer=include_optimizer,
+            tags=tags,
+            plot_model=plot_model,
+            **model_save_kwargs,
+        )
 
-    # Commit and push!
-    repo.git_add(auto_lfs_track=True)
-    repo.git_commit(commit_message)
-    return repo.git_push()
+        # If log dir is provided, delete old logs + add new ones
+        operations: List[CommitOperation] = []
+        if log_dir is not None:
+            # Delete previous log files from Hub
+            operations += [
+                CommitOperationDelete(path_in_repo=file)
+                for file in api.list_repo_files(repo_id=repo_id, token=token)
+                if file.startswith("logs/")
+            ]
+
+            # Copy new log files
+            copytree(log_dir, saved_path / "logs")
+
+        # NOTE: `_prepare_upload_folder_commit` and `create_commit` calls are
+        #       duplicate code from `upload_folder`. We are not directly using
+        #       `upload_folder` since we want to add delete operations to the
+        #       commit as well.
+        operations += _prepare_upload_folder_commit(
+            saved_path,
+            path_in_repo="",
+            allow_patterns=allow_patterns,
+            ignore_patterns=ignore_patterns,
+        )
+        commit_info = api.create_commit(
+            repo_type="model",
+            repo_id=repo_id,
+            operations=operations,
+            commit_message=commit_message,
+            token=token,
+            revision=branch,
+            create_pr=create_pr,
+        )
+        revision = branch
+        if revision is None:
+            revision = (
+                quote(_parse_revision_from_pr_url(commit_info.pr_url), safe="")
+                if commit_info.pr_url is not None
+                else DEFAULT_REVISION
+            )
+        return f"{api.endpoint}/{repo_id}/tree/{revision}/"
 
 
 class KerasModelHubMixin(ModelHubMixin):

--- a/src/huggingface_hub/repocard.py
+++ b/src/huggingface_hub/repocard.py
@@ -27,7 +27,6 @@ from huggingface_hub.utils import is_jinja_available, yaml_dump
 
 from .constants import REPOCARD_NAME
 from .utils import EntryNotFoundError, validate_hf_hub_args
-from .utils._deprecation import _deprecate_positional_args
 from .utils.logging import get_logger
 
 
@@ -548,7 +547,6 @@ def metadata_save(local_path: Union[str, Path], data: Dict) -> None:
         readme.close()
 
 
-@_deprecate_positional_args(version="0.12")
 def metadata_eval_result(
     *,
     model_pretty_name: str,

--- a/tests/test_hubmixin.py
+++ b/tests/test_hubmixin.py
@@ -113,35 +113,6 @@ class HubMixingTest(HubMixingCommonTest):
         mocked_model.save_pretrained(save_directory, push_to_hub=True, config=config)
         mocked_model.push_to_hub.assert_called_with(repo_id=REPO_NAME, config=config)
 
-        # Push to hub with deprecated kwargs (git-based)
-        mocked_model.save_pretrained(
-            save_directory,
-            push_to_hub=True,
-            config=config,
-            repo_path_or_name="custom_repo_name",
-            git_email="myemail",
-            git_user="gituser",
-        )
-        mocked_model.push_to_hub.assert_called_with(
-            repo_path_or_name="custom_repo_name",
-            config=config,
-            git_email="myemail",
-            git_user="gituser",
-        )
-
-        # Push to hub with deprecated kwargs + use default repo_name + no config
-        mocked_model.save_pretrained(
-            save_directory,
-            push_to_hub=True,
-            git_email="myemail",
-            git_user="gituser",
-        )
-        mocked_model.push_to_hub.assert_called_with(
-            repo_path_or_name=save_directory,
-            git_email="myemail",
-            git_user="gituser",
-        )
-
     def test_rel_path_from_pretrained(self):
         model = DummyModel()
         model.save_pretrained(

--- a/tests/test_hubmixin.py
+++ b/tests/test_hubmixin.py
@@ -1,13 +1,11 @@
 import json
 import os
 import shutil
-import tempfile
 import unittest
 from unittest.mock import Mock
 
 from huggingface_hub import HfApi, hf_hub_download
 from huggingface_hub.hub_mixin import PyTorchModelHubMixin
-from huggingface_hub.repository import Repository
 from huggingface_hub.utils import is_torch_available, logging
 
 from .testing_constants import ENDPOINT_STAGING, TOKEN, USER
@@ -192,52 +190,3 @@ class HubMixingTest(HubMixingCommonTest):
         # Delete tmp file and repo
         os.remove(tmp_config_path)
         self._api.delete_repo(repo_id=repo_id)
-
-    @expect_deprecation("push_to_hub")
-    def test_push_to_hub_via_git_deprecated(self):
-        # TODO: remove in 0.12 when git method will be removed
-        REPO_NAME = repo_name("PUSH_TO_HUB_via_git")
-        repo_id = f"{USER}/{REPO_NAME}"
-
-        DummyModel().push_to_hub(
-            repo_path_or_name=f"{WORKING_REPO_DIR}/{REPO_NAME}",
-            api_endpoint=ENDPOINT_STAGING,
-            use_auth_token=self._token,
-        )
-
-        model_info = self._api.model_info(repo_id)
-        self.assertEqual(model_info.modelId, repo_id)
-        self._api.delete_repo(repo_id=repo_id)
-
-    @expect_deprecation("push_to_hub")
-    def test_push_to_hub_via_git_use_lfs_by_default(self):
-        # TODO: remove in 0.12 when git method will be removed
-        REPO_NAME = repo_name("PUSH_TO_HUB_with_lfs_file")
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            os.makedirs(f"{tmpdirname}/{WORKING_REPO_DIR}/{REPO_NAME}")
-            self._repo_url = self._api.create_repo(repo_id=REPO_NAME)
-            Repository(
-                local_dir=f"{tmpdirname}/{WORKING_REPO_DIR}/{REPO_NAME}",
-                clone_from=self._repo_url,
-                use_auth_token=self._token,
-            )
-
-            model = DummyModel()
-            large_file = [100] * int(4e6)
-            with open(
-                f"{tmpdirname}/{WORKING_REPO_DIR}/{REPO_NAME}/large_file.txt", "w+"
-            ) as f:
-                f.write(json.dumps(large_file))
-
-            model.push_to_hub(
-                f"{tmpdirname}/{WORKING_REPO_DIR}/{REPO_NAME}",
-                api_endpoint=ENDPOINT_STAGING,
-                use_auth_token=self._token,
-                git_user="ci",
-                git_email="ci@dummy.com",
-            )
-
-        model_info = self._api.model_info(f"{USER}/{REPO_NAME}")
-
-        self.assertTrue("large_file.txt" in [f.rfilename for f in model_info.siblings])
-        self._api.delete_repo(repo_id=f"{REPO_NAME}")

--- a/tests/test_keras_integration.py
+++ b/tests/test_keras_integration.py
@@ -189,27 +189,6 @@ class HubMixingTestKeras(CommonKerasTest):
         os.remove(tmp_config_path)
         self._api.delete_repo(repo_id=repo_id)
 
-    @retry_endpoint
-    @expect_deprecation("push_to_hub")
-    def test_push_to_hub_keras_mixin_via_git_deprecated(self):
-        REPO_NAME = repo_name("PUSH_TO_HUB_KERAS_via_git")
-        repo_id = f"{USER}/{REPO_NAME}"
-        model = DummyModel()
-        model(model.dummy_inputs)
-
-        model.push_to_hub(
-            repo_path_or_name=f"{WORKING_REPO_DIR}/{REPO_NAME}",
-            api_endpoint=ENDPOINT_STAGING,
-            use_auth_token=self._token,
-            git_user="ci",
-            git_email="ci@dummy.com",
-            config={"num": 7, "act": "gelu_fast"},
-        )
-
-        model_info = self._api.model_info(repo_id)
-        self.assertEqual(model_info.modelId, repo_id)
-        self._api.delete_repo(repo_id=repo_id)
-
 
 @require_tf
 class HubKerasSequentialTest(CommonKerasTest):

--- a/tests/test_keras_integration.py
+++ b/tests/test_keras_integration.py
@@ -439,30 +439,6 @@ class HubKerasSequentialTest(CommonKerasTest):
         self._api.delete_repo(repo_id=repo_id)
 
     @retry_endpoint
-    @expect_deprecation("push_to_hub_keras")
-    def test_push_to_hub_keras_sequential_via_git_deprecated(self):
-        REPO_NAME = repo_name("PUSH_TO_HUB_KERAS_sequential_via_git")
-        model = self.model_init()
-        model.build((None, 2))
-
-        push_to_hub_keras(
-            model,
-            repo_path_or_name=f"{WORKING_REPO_DIR}/{REPO_NAME}",
-            api_endpoint=ENDPOINT_STAGING,
-            use_auth_token=self._token,
-            git_user="ci",
-            git_email="ci@dummy.com",
-            config={"num": 7, "act": "gelu_fast"},
-            include_optimizer=False,
-        )
-
-        model_info = self._api.model_info(f"{USER}/{REPO_NAME}")
-        self.assertEqual(model_info.modelId, f"{USER}/{REPO_NAME}")
-        self.assertTrue("README.md" in [f.rfilename for f in model_info.siblings])
-        self.assertTrue("model.png" in [f.rfilename for f in model_info.siblings])
-        self._api.delete_repo(repo_id=f"{REPO_NAME}")
-
-    @retry_endpoint
     def test_push_to_hub_keras_via_http_override_tensorboard(self):
         """Test log directory is overwritten when pushing a keras model a 2nd time."""
         REPO_NAME = repo_name("PUSH_TO_HUB_KERAS_via_http_override_tensorboard")

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1582,34 +1582,6 @@ class RepositoryOfflineTest(RepositoryCommonTest):
 
         self.assertFalse(repo.is_repo_clean())
 
-    @expect_deprecation("__init__")
-    def test_private_deprecation_on_init(self):
-        Repository(
-            WORKING_REPO_DIR,
-            private=True,
-            git_user="RANDOM_USER",
-            git_email="EMAIL@EMAIL.EMAIL",
-        )
-
-    @expect_deprecation("private")
-    def test_private_deprecation_on_attribute(self):
-        repo = Repository(
-            WORKING_REPO_DIR,
-            git_user="RANDOM_USER",
-            git_email="EMAIL@EMAIL.EMAIL",
-        )
-        self.assertFalse(repo.private)
-
-    @expect_deprecation("repo_type")
-    def test_repo_type_deprecation_on_attribute(self):
-        repo = Repository(
-            WORKING_REPO_DIR,
-            git_user="RANDOM_USER",
-            git_email="EMAIL@EMAIL.EMAIL",
-            repo_type="toto",
-        )
-        self.assertEqual(repo.repo_type, "toto")
-
 
 class RepositoryDatasetTest(RepositoryCommonTest):
     @classmethod

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -116,16 +116,12 @@ class RepositoryTest(RepositoryCommonTest):
             repo_id=f"{USER}/{self.REPO_NAME}-temp", repo_type="space"
         )
 
-    @expect_deprecation("clone_from")
     def test_clone_from_missing_repo(self):
-        """
-        If the repo does not exist, it is created automatically.
-
-        This behavior is deprecated and will be removed in v0.12.
-        """
-        Repository(
-            WORKING_REPO_DIR, clone_from=f"{USER}/{uuid.uuid4()}", token=self._token
-        )
+        """If the repo does not exist an EnvironmentError is raised."""
+        with self.assertRaises(EnvironmentError):
+            Repository(
+                WORKING_REPO_DIR, clone_from=f"{USER}/{uuid.uuid4()}", token=self._token
+            )
 
     def test_clone_from_model(self):
         temp_repo_url = self._api.create_repo(
@@ -481,7 +477,6 @@ class RepositoryTest(RepositoryCommonTest):
         self.assertTrue("model.bin" in files)
 
     @retry_endpoint
-    @expect_deprecation("clone_from")
     def test_clone_with_repo_name_and_no_namespace(self):
         with self.assertRaises(EnvironmentError):
             Repository(
@@ -1743,18 +1738,16 @@ class RepositoryDatasetTest(RepositoryCommonTest):
         self.assertTrue("test.py" in files)
 
     @retry_endpoint
-    @expect_deprecation("clone_from")
     def test_clone_with_repo_name_and_no_namespace(self):
-        self.assertRaises(
-            OSError,
-            Repository,
-            f"{WORKING_DATASET_DIR}/{self.REPO_NAME}",
-            clone_from=self.REPO_NAME,
-            repo_type="dataset",
-            use_auth_token=self._token,
-            git_user="ci",
-            git_email="ci@dummy.com",
-        )
+        with self.assertRaises(EnvironmentError):
+            Repository(
+                f"{WORKING_DATASET_DIR}/{self.REPO_NAME}",
+                clone_from=self.REPO_NAME,
+                repo_type="dataset",
+                use_auth_token=self._token,
+                git_user="ci",
+                git_email="ci@dummy.com",
+            )
 
     @retry_endpoint
     def test_clone_with_repo_name_user_and_no_auth_token(self):

--- a/tests/test_snapshot_download.py
+++ b/tests/test_snapshot_download.py
@@ -317,18 +317,18 @@ class SnapshotDownloadTests(unittest.TestCase):
             # folder name contains the 2nd commit sha and not the 3rd
             self.assertTrue(self.second_commit_hash in storage_folder)
 
-    def check_download_model_with_regex(self, regex, allow=True):
+    def check_download_model_with_pattern(self, pattern, allow=True):
         # Test `main` branch
-        allow_regex = regex if allow else None
-        ignore_regex = regex if not allow else None
+        allow_patterns = pattern if allow else None
+        ignore_patterns = pattern if not allow else None
 
         with tempfile.TemporaryDirectory() as tmpdirname:
             storage_folder = snapshot_download(
                 f"{USER}/{REPO_NAME}",
                 revision="main",
                 cache_dir=tmpdirname,
-                allow_regex=allow_regex,
-                ignore_regex=ignore_regex,
+                allow_patterns=allow_patterns,
+                ignore_patterns=ignore_patterns,
             )
 
             # folder contains the two files contributed and the .gitattributes
@@ -345,22 +345,14 @@ class SnapshotDownloadTests(unittest.TestCase):
             # folder name contains the revision's commit sha.
             self.assertTrue(self.second_commit_hash in storage_folder)
 
-    # TODO: from version 0.12, replace `regex` by 'patterns` and remove expected
-    #       deprecation. Could be possible to already do tests with `allow_patterns` and
-    #       `ignore_patterns` but current test implementation is convenient since it
-    #       covers both old and new naming + check deprecation.
-    @expect_deprecation("snapshot_download")
-    def test_download_model_with_allow_regex(self):
-        self.check_download_model_with_regex("*.txt")
+    def test_download_model_with_allow_pattern(self):
+        self.check_download_model_with_pattern("*.txt")
 
-    @expect_deprecation("snapshot_download")
-    def test_download_model_with_allow_regex_list(self):
-        self.check_download_model_with_regex(["dummy_file.txt", "dummy_file_2.txt"])
+    def test_download_model_with_allow_pattern_list(self):
+        self.check_download_model_with_pattern(["dummy_file.txt", "dummy_file_2.txt"])
 
-    @expect_deprecation("snapshot_download")
-    def test_download_model_with_ignore_regex(self):
-        self.check_download_model_with_regex(".gitattributes", allow=False)
+    def test_download_model_with_ignore_pattern(self):
+        self.check_download_model_with_pattern(".gitattributes", allow=False)
 
-    @expect_deprecation("snapshot_download")
-    def test_download_model_with_ignore_regex_list(self):
-        self.check_download_model_with_regex(["*.git*", "*.pt"], allow=False)
+    def test_download_model_with_ignore_pattern_list(self):
+        self.check_download_model_with_pattern(["*.git*", "*.pt"], allow=False)

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -6,7 +6,6 @@ import time
 import unittest
 import uuid
 from contextlib import contextmanager
-from distutils.util import strtobool
 from enum import Enum
 from functools import wraps
 from io import StringIO
@@ -51,6 +50,9 @@ DUMMY_DATASET_ID_REVISION_ONE_SPECIFIC_COMMIT = (  # on branch "test-branch"
     "81d06f998585f8ee10e6e3a2ea47203dc75f2a16"
 )
 
+YES = ("y", "yes", "t", "true", "on", "1")
+NO = ("n", "no", "f", "false", "off", "0")
+
 
 def repo_name(id: Optional[str] = None, prefix: str = "repo") -> str:
     """
@@ -70,20 +72,21 @@ def repo_name(id: Optional[str] = None, prefix: str = "repo") -> str:
     return f"{prefix}-{id}-{ts}"
 
 
-def parse_flag_from_env(key, default=False):
+def parse_flag_from_env(key: str, default: bool = False) -> bool:
     try:
         value = os.environ[key]
     except KeyError:
         # KEY isn't set, default to `default`.
-        _value = default
+        return default
+
+    # KEY is set, convert it to True or False.
+    if value.lower() in YES:
+        return True
+    elif value.lower() in NO:
+        return False
     else:
-        # KEY is set, convert it to True or False.
-        try:
-            _value = strtobool(value)
-        except ValueError:
-            # More values are supported, but let's keep the message simple.
-            raise ValueError("If set, {} must be yes or no.".format(key))
-    return _value
+        # More values are supported, but let's keep the message simple.
+        raise ValueError(f"If set, '{key}' must be one of {YES+NO}. Got '{value}'.")
 
 
 def parse_int_from_env(key, default=None):


### PR DESCRIPTION
@julien-c you favorite PR is back :smile: 

This PR removes all code that was deprecated and planned to be removed in v0.12. In particular, all `push_to_hub` methods are now HTTP-based only, no more Git-based :)