### PR TITLE
Specific message for unauthorized errors

### DIFF
--- a/src/huggingface_hub/utils/_errors.py
+++ b/src/huggingface_hub/utils/_errors.py
@@ -256,22 +256,21 @@ def hf_raise_for_status(
             )
             raise EntryNotFoundError(message, response) from e
 
-        elif error_code == "RepoNotFound":
+        elif error_code == "RepoNotFound" or response.status_code == 401:
+            # 401 is misleading as it is returned for:
+            #    - private and gated repos if user is not authenticated
+            #    - missing repos
+            # => for now, we process them as `RepoNotFound` anyway.
+            # See https://gist.github.com/Wauplin/46c27ad266b15998ce56a6603796f0b9
             message = (
                 f"{response.status_code} Client Error."
                 + "\n\n"
                 + f"Repository Not Found for url: {response.url}."
                 + "\nPlease make sure you specified the correct `repo_id` and"
-                " `repo_type`."
+                " `repo_type`.\nIf you try to access a private or gated repo, make"
+                " sure you are authenticated."
             )
             raise RepositoryNotFoundError(message, response) from e
-
-        elif response.status_code == 401:
-            message = (
-                f"{e}\n\nIf you try to access a private or gated repo, make sure you"
-                " are authenticated."
-            )
-            raise RepositoryNotFoundError(message, response=response) from e
 
         elif response.status_code == 400:
             message = (

--- a/src/huggingface_hub/utils/_errors.py
+++ b/src/huggingface_hub/utils/_errors.py
@@ -267,7 +267,7 @@ def hf_raise_for_status(
                 + "\n\n"
                 + f"Repository Not Found for url: {response.url}."
                 + "\nPlease make sure you specified the correct `repo_id` and"
-                " `repo_type`.\nIf you try to access a private or gated repo, make"
+                " `repo_type`.\nIf you are trying to access a private or gated repo, make"
                 " sure you are authenticated."
             )
             raise RepositoryNotFoundError(message, response) from e

--- a/src/huggingface_hub/utils/_errors.py
+++ b/src/huggingface_hub/utils/_errors.py
@@ -256,16 +256,22 @@ def hf_raise_for_status(
             )
             raise EntryNotFoundError(message, response) from e
 
-        elif error_code == "RepoNotFound" or response.status_code == 401:
+        elif error_code == "RepoNotFound":
             message = (
                 f"{response.status_code} Client Error."
                 + "\n\n"
                 + f"Repository Not Found for url: {response.url}."
                 + "\nPlease make sure you specified the correct `repo_id` and"
                 " `repo_type`."
-                + "\nIf the repo is private, make sure you are authenticated."
             )
             raise RepositoryNotFoundError(message, response) from e
+
+        elif response.status_code == 401:
+            message = (
+                f"{e}\n\nIf you try to access a private or gated repo, make sure you"
+                " are authenticated."
+            )
+            raise RepositoryNotFoundError(message, response=response) from e
 
         elif response.status_code == 400:
             message = (

--- a/src/huggingface_hub/utils/_errors.py
+++ b/src/huggingface_hub/utils/_errors.py
@@ -267,8 +267,8 @@ def hf_raise_for_status(
                 + "\n\n"
                 + f"Repository Not Found for url: {response.url}."
                 + "\nPlease make sure you specified the correct `repo_id` and"
-                " `repo_type`.\nIf you are trying to access a private or gated repo, make"
-                " sure you are authenticated."
+                " `repo_type`.\nIf you are trying to access a private or gated repo,"
+                " make sure you are authenticated."
             )
             raise RepositoryNotFoundError(message, response) from e
 

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -954,10 +954,10 @@ class CommitApiTest(HfApiCommonTestWithLogin):
                     " Found for url:"
                     f" {self._api.endpoint}/api/models/{USER}/repo_that_do_not_exist/{route}/main.\nPlease"
                     " make sure you specified the correct `repo_id` and"
-                    " `repo_type`.\nIf the repo is private, make sure you are"
-                    " authenticated.\nNote: Creating a commit assumes that the repo"
-                    " already exists on the Huggingface Hub. Please use `create_repo`"
-                    " if it's not the case."
+                    " `repo_type`.\nIf you try to access a private or gated repo, make"
+                    " sure you are authenticated.\nNote: Creating a commit assumes"
+                    " that the repo already exists on the Huggingface Hub. Please use"
+                    " `create_repo` if it's not the case."
                 )
 
                 self.assertEqual(str(context.exception), expected_message)

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -954,7 +954,7 @@ class CommitApiTest(HfApiCommonTestWithLogin):
                     " Found for url:"
                     f" {self._api.endpoint}/api/models/{USER}/repo_that_do_not_exist/{route}/main.\nPlease"
                     " make sure you specified the correct `repo_id` and"
-                    " `repo_type`.\nIf you try to access a private or gated repo, make"
+                    " `repo_type`.\nIf you are trying to access a private or gated repo, make"
                     " sure you are authenticated.\nNote: Creating a commit assumes"
                     " that the repo already exists on the Huggingface Hub. Please use"
                     " `create_repo` if it's not the case."

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -954,10 +954,10 @@ class CommitApiTest(HfApiCommonTestWithLogin):
                     " Found for url:"
                     f" {self._api.endpoint}/api/models/{USER}/repo_that_do_not_exist/{route}/main.\nPlease"
                     " make sure you specified the correct `repo_id` and"
-                    " `repo_type`.\nIf you are trying to access a private or gated repo, make"
-                    " sure you are authenticated.\nNote: Creating a commit assumes"
-                    " that the repo already exists on the Huggingface Hub. Please use"
-                    " `create_repo` if it's not the case."
+                    " `repo_type`.\nIf you are trying to access a private or gated"
+                    " repo, make sure you are authenticated.\nNote: Creating a commit"
+                    " assumes that the repo already exists on the Huggingface Hub."
+                    " Please use `create_repo` if it's not the case."
                 )
 
                 self.assertEqual(str(context.exception), expected_message)


### PR DESCRIPTION
Currently any HTTP 401 Unauthorized is processed as "Repository not found" with an error message quite unhelpful for gated repos. This PR mentions the fact that you must authenticate if a repo is gated.

See https://github.com/huggingface/moon-landing/issues/3903#issuecomment-1320137948 (internal link) and [this gist](https://gist.github.com/Wauplin/46c27ad266b15998ce56a6603796f0b9).

(cc @julien-c: realized that when making a local test for https://github.com/huggingface/huggingface_hub/issues/1198)