### PR TITLE
Add autcompletion to huggingface-cli (fix #1206, #1197)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     rev: 22.3.0
     hooks:
       - id: black
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: 4.0.1
     hooks:
       - id: flake8

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,11 @@ install_requires = [
 
 extras = {}
 
-extras["cli"] = [
+extras["completion"] = [
+    "shtab",
+]
+
+extras["cli"] = extras["completion"] + [
     "InquirerPy==0.3.4",
     # Note: installs `prompt-toolkit` in the background
 ]

--- a/src/huggingface_hub/commands/_shtab.py
+++ b/src/huggingface_hub/commands/_shtab.py
@@ -2,8 +2,14 @@
 from argparse import Action, ArgumentParser
 
 
+_WARNING_MESSAGE = (
+    "You first need to install `shtab` to use autocompletion. Please run `pip install"
+    " 'huggingface_hub[completion]'`"
+)
+
+
 class PrintCompletionAction(Action):
-    """Print completion action.
+    """Fake `PrintCompletionAction` when shtab is not installed.
 
     See <https://github.com/iterative/shtab/blob/95b0e3092cd4dcf1ac2871d44cebda01a89992df/shtab/__init__.py#L786-L789>
     """
@@ -16,7 +22,7 @@ class PrintCompletionAction(Action):
         :param values:
         :param option_string:
         """
-        print("Please install shtab firstly!")
+        print(_WARNING_MESSAGE)
         parser.exit(0)
 
 
@@ -33,9 +39,6 @@ def add_argument_to(parser: ArgumentParser, *args, **kwargs):
         "--print-completion",
         choices=["bash", "zsh", "tcsh"],
         action=PrintCompletionAction,
-        help=(
-            "You first need to install `shtab` to use autocompletion. "
-            "Please run `pip install 'huggingface_hub[typing]'`"
-        ),
+        help=_WARNING_MESSAGE,
     )
     return parser

--- a/src/huggingface_hub/commands/_shtab.py
+++ b/src/huggingface_hub/commands/_shtab.py
@@ -1,0 +1,41 @@
+"""Fake shtab."""
+from argparse import Action, ArgumentParser
+
+
+class PrintCompletionAction(Action):
+    """Print completion action.
+
+    See <https://github.com/iterative/shtab/blob/95b0e3092cd4dcf1ac2871d44cebda01a89992df/shtab/__init__.py#L786-L789>
+    """
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        """Warn when shtab is not installed.
+
+        :param parser:
+        :param namespace:
+        :param values:
+        :param option_string:
+        """
+        print("Please install shtab firstly!")
+        parser.exit(0)
+
+
+def add_argument_to(parser: ArgumentParser, *args, **kwargs):
+    """Add completion argument to parser.
+
+    :param parser:
+    :type parser: ArgumentParser
+    :param args:
+    :param kwargs:
+    """
+    Action.complete = None  # type: ignore
+    parser.add_argument(
+        "--print-completion",
+        choices=["bash", "zsh", "tcsh"],
+        action=PrintCompletionAction,
+        help=(
+            "You first need to install `shtab` to use autocompletion. "
+            "Please run `pip install 'huggingface_hub[typing]'`"
+        ),
+    )
+    return parser

--- a/src/huggingface_hub/commands/huggingface_cli.py
+++ b/src/huggingface_hub/commands/huggingface_cli.py
@@ -25,7 +25,7 @@ from huggingface_hub.commands.user import UserCommands
 try:
     import shtab
 except ImportError:
-    from . import _shtab as shtab
+    from . import _shtab as shtab  # type: ignore
 
 
 def main():

--- a/src/huggingface_hub/commands/huggingface_cli.py
+++ b/src/huggingface_hub/commands/huggingface_cli.py
@@ -22,10 +22,17 @@ from huggingface_hub.commands.scan_cache import ScanCacheCommand
 from huggingface_hub.commands.user import UserCommands
 
 
+try:
+    import shtab
+except ImportError:
+    from . import _shtab as shtab
+
+
 def main():
     parser = ArgumentParser(
         "huggingface-cli", usage="huggingface-cli <command> [<args>]"
     )
+    shtab.add_argument_to(parser)
     commands_parser = parser.add_subparsers(help="huggingface-cli command helpers")
 
     # Register commands


### PR DESCRIPTION
```
$ huggingface-cli repo create -<TAB>
Name for your repo. Will be namespaced under your username to build the repo id.
option
--help           show this help message and exit
-h               show this help message and exit
--organization   Optional: organization namespace.
--space_sdk      Optional: Hugging Face Spaces SDK type. Required when --type is set to "space".
--type           Optional: repo_type: set to "dataset" or "space" if creating a dataset or space, default is model.
--yes            Optional: answer Yes to the prompt
-y               Optional: answer Yes to the prompt
```
