### PR TITLE
Do not throw error on utf-8 error in run_subprocess

### DIFF
--- a/src/huggingface_hub/utils/_subprocess.py
+++ b/src/huggingface_hub/utils/_subprocess.py
@@ -64,6 +64,7 @@ def run_subprocess(
         stdout=subprocess.PIPE,
         check=check,
         encoding="utf-8",
+        errors="replace",  # if not utf-8, replace char by �
         cwd=folder or os.getcwd(),
         **kwargs,
     )
@@ -110,6 +111,7 @@ def run_interactive_subprocess(
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         encoding="utf-8",
+        errors="replace",  # if not utf-8, replace char by �
         cwd=folder or os.getcwd(),
         **kwargs,
     ) as process:


### PR DESCRIPTION
Should fix #1209. If character cannot be encoded in output, it is replaced by a utf-8 `�` char.