### PR TITLE
Fix caching reference if permission denied

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -836,10 +836,13 @@ def _cache_commit_hash_for_specific_revision(
     Does nothing if `revision` is already a proper `commit_hash` or reference is already cached.
     """
     if revision != commit_hash:
-        ref_path = os.path.join(storage_folder, "refs", revision)
-        os.makedirs(os.path.dirname(ref_path), exist_ok=True)
-        with open(ref_path, "w") as f:
-            f.write(commit_hash)
+        ref_path = Path(storage_folder) / "refs" / revision
+        ref_path.parent.mkdir(parents=True, exist_ok=True)
+        if not ref_path.exists() or commit_hash != ref_path.read_text():
+            # Update ref only if has been updated. Could cause useless error in case
+            # repo is already cached and user doesn't have write access to cache folder.
+            # See https://github.com/huggingface/huggingface_hub/issues/1216.
+            ref_path.write_text(commit_hash)
 
 
 @validate_hf_hub_args

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -158,15 +158,13 @@ class CachedDownloadTests(unittest.TestCase):
             hf_hub_download(DUMMY_MODEL_ID, filename=CONFIG_NAME, cache_dir=tmpdir)
 
             # Set read-only permission recursively
-            # Taken from https://stackoverflow.com/a/2853934
-            for root, dirs, files in os.walk(tmpdir):
-                for d in dirs:
-                    os.chmod(os.path.join(root, d), 0o555)
-                for f in files:
-                    os.chmod(os.path.join(root, f), 0o555)
+            _recursive_chmod(tmpdir, 0o555)
 
             # Get without write-access must succeed
             hf_hub_download(DUMMY_MODEL_ID, filename=CONFIG_NAME, cache_dir=tmpdir)
+
+            # Set permission back for cleanup
+            _recursive_chmod(tmpdir, 0o777)
 
     def test_revision_not_found(self):
         # Valid file but missing revision
@@ -506,3 +504,12 @@ class CreateSymlinkTest(unittest.TestCase):
             mock_are_symlinks_supported.side_effect = _are_symlinks_supported
             with self.assertRaises(FileExistsError):
                 _create_relative_symlink(src, dst)
+
+
+def _recursive_chmod(path: str, mode: int) -> None:
+    # Taken from https://stackoverflow.com/a/2853934
+    for root, dirs, files in os.walk(path):
+        for d in dirs:
+            os.chmod(os.path.join(root, d), mode)
+        for f in files:
+            os.chmod(os.path.join(root, f), mode)


### PR DESCRIPTION
Fix https://github.com/huggingface/huggingface_hub/issues/1216 (cc @mhham).

If commit hash is the same, do not overwrite the `refs` file. This make the cache system work when user has no write permission and remote model did not change.

Note: another possibility is to set `HF_HUB_OFFLINE` environment variable when using a user that has read-only access. `huggingface_hub` will not try to sync with remote => nothing is written to cache. 