### PR TITLE
Set correct permissions on blob file

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -5,6 +5,7 @@ import json
 import os
 import re
 import shutil
+import stat
 import tempfile
 import warnings
 from contextlib import contextmanager
@@ -747,7 +748,7 @@ def cached_download(
             )
 
         logger.info("storing %s in cache at %s", url, cache_path)
-        os.replace(temp_file.name, cache_path)
+        _chmod_and_replace(temp_file.name, cache_path)
 
         if force_filename is None:
             logger.info("creating metadata file for %s", cache_path)
@@ -1246,7 +1247,7 @@ def hf_hub_download(
             )
 
         logger.info("storing %s in cache at %s", url, blob_path)
-        os.replace(temp_file.name, blob_path)
+        _chmod_and_replace(temp_file.name, blob_path)
 
         logger.info("creating pointer to %s from %s", blob_path, pointer_path)
         _create_relative_symlink(blob_path, pointer_path, new_blob=True)
@@ -1398,3 +1399,21 @@ def _int_or_none(value: Optional[str]) -> Optional[int]:
         return int(value)  # type: ignore
     except (TypeError, ValueError):
         return None
+
+
+def _chmod_and_replace(src: str, dst: str) -> None:
+    """Set correct permission before moving a blob from tmp directory to cache dir.
+
+    Do not take into account the `umask` from the process as there is no convenient way
+    to get it that is thread-safe.
+
+    See:
+    - About umask: https://docs.python.org/3/library/os.html#os.umask
+    - Thread-safety: https://stackoverflow.com/a/70343066
+    - Fix issue: https://github.com/huggingface/huggingface_hub/issues/1141
+    - Fix issue: https://github.com/huggingface/huggingface_hub/issues/1215
+    """
+    # Get `blobs/` directory permission
+    cache_dir_mode = Path(dst).parent.stat().st_mode
+    os.chmod(src, stat.S_IMODE(cache_dir_mode))
+    os.replace(src, dst)

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -251,13 +251,14 @@ class CachedDownloadTests(unittest.TestCase):
         https://github.com/huggingface/huggingface_hub/issues/1215
         """
         with TemporaryDirectory() as tmpdir:
-            previous_umask = os.umask(0o017)
+            # Equivalent to umask u=rwx,g=r,o=
+            previous_umask = os.umask(0o037)
             try:
                 filepath = hf_hub_download(
                     DUMMY_RENAMED_OLD_MODEL_ID, "config.json", cache_dir=tmpdir
                 )
-                # Permission is respected
-                self.assertEqual(stat.S_IMODE(os.stat(filepath).st_mode), 0o760)
+                # Permissions are honored (640: u=rw,g=r,o=)
+                self.assertEqual(stat.S_IMODE(os.stat(filepath).st_mode), 0o640)
             finally:
                 os.umask(previous_umask)
 


### PR DESCRIPTION
Fix #1141 #1215.

Workaround I used is to infer umask from the permission set on the `blobs/` folder. This is not optimal (not getting the umask from the user directly) but good enough as at least all folders/files in cache folder will have same permissions.

```py
    # src is a tmp file, dst is the blob path
    cache_dir_mode = Path(dst).parent.stat().st_mode
    os.chmod(src, stat.S_IMODE(cache_dir_mode))
    os.replace(src, dst)
```

The reason behind it that [getting the umask](https://docs.python.org/3/library/os.html#os.umask) from the user is risky. The python implementation consists in changing the value while getting the old value. Can lead to weird/undesired issues in a multi-thread process. I found a [potentially thread-safe solution](https://stackoverflow.com/a/70343066) but didn't want to have to maintain/debug it on multiple platform (solution is more a hack than a proper solution).

cc @stas00 @antoche what do you think ? Looks good to you ? (Also cc @julien-c who worked on the new cache)