### PR TITLE
Make snapshot_download multithreaded + customizable progress bar

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 install_requires = [
     "filelock",
     "requests",
-    "tqdm>=4.62.1",
+    "tqdm>=4.42.1",
     "pyyaml>=5.1",
     "typing-extensions>=3.7.4.3",  # to be able to import TypeAlias
     "importlib_metadata;python_version<'3.8'",

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 install_requires = [
     "filelock",
     "requests",
-    "tqdm",
+    "tqdm>=4.62.1",
     "pyyaml>=5.1",
     "typing-extensions>=3.7.4.3",  # to be able to import TypeAlias
     "importlib_metadata;python_version<'3.8'",

--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -91,6 +91,15 @@ def snapshot_download(
             If provided, only files matching at least one pattern are downloaded.
         ignore_patterns (`List[str]` or `str`, *optional*):
             If provided, files matching any of the patterns are not downloaded.
+        max_workers (`int`, *optional*):
+            Number of concurrent threads to download files (1 thread = 1 file download).
+            Defaults to 8.
+        tqdm_class (`tqdm`, *optional*):
+            If provided, overwrites the default behavior for the progress bar. Passed
+            argument must inherit from `tqdm.auto.tqdm` or at least mimic its behavior.
+            Note that the `tqdm_class` is not passed to each individual download.
+            Defaults to the custom HF progress bar that can be disabled by setting
+            `HF_HUB_DISABLE_PROGRESS_BARS` environment variable.
 
     Returns:
         Local folder path (string) of repo snapshot

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -487,7 +487,7 @@ def http_get(
         unit_scale=True,
         total=total,
         initial=resume_size,
-        desc="Downloading",
+        desc=f"Downloading (…){url[-20:]}",
         disable=bool(logger.getEffectiveLevel() == logging.NOTSET),
     )
     for chunk in r.iter_content(chunk_size=1024):

--- a/src/huggingface_hub/utils/tqdm.py
+++ b/src/huggingface_hub/utils/tqdm.py
@@ -18,9 +18,9 @@
 Example:
     1. Use `huggingface_hub.utils.tqdm` as you would use `tqdm.tqdm` or `tqdm.auto.tqdm`.
     2. To disable progress bars, either use `disable_progress_bars()` helper or set the
-       environement variable `HF_HUB_DISABLE_PROGRESS_BARS` to 1.
+       environment variable `HF_HUB_DISABLE_PROGRESS_BARS` to 1.
     3. To re-enable progress bars, use `enable_progress_bars()`.
-    4. To check weither progress bars are disabled, use `are_progress_bars_disabled()`.
+    4. To check whether progress bars are disabled, use `are_progress_bars_disabled()`.
 
 NOTE: Environment variable `HF_HUB_DISABLE_PROGRESS_BARS` has the priority.
 

--- a/src/huggingface_hub/utils/tqdm.py
+++ b/src/huggingface_hub/utils/tqdm.py
@@ -74,7 +74,7 @@ _hf_hub_progress_bars_disabled: bool = HF_HUB_DISABLE_PROGRESS_BARS or False
 def disable_progress_bars() -> None:
     """
     Disable globally progress bars used in `huggingface_hub` except if
-    `HF_HUB_DISABLE_PROGRESS_BARS` environement variable has been set.
+    `HF_HUB_DISABLE_PROGRESS_BARS` environment variable has been set.
     """
     if HF_HUB_DISABLE_PROGRESS_BARS is False:
         warnings.warn(
@@ -89,7 +89,7 @@ def disable_progress_bars() -> None:
 def enable_progress_bars() -> None:
     """
     Enable globally progress bars used in `huggingface_hub` except if
-    `HF_HUB_DISABLE_PROGRESS_BARS` environement variable has been set.
+    `HF_HUB_DISABLE_PROGRESS_BARS` environment variable has been set.
     """
     if HF_HUB_DISABLE_PROGRESS_BARS is True:
         warnings.warn(
@@ -102,7 +102,7 @@ def enable_progress_bars() -> None:
 
 
 def are_progress_bars_disabled() -> bool:
-    """Return weither progress bars are globally disabled or not."""
+    """Return whether progress bars are globally disabled or not."""
     global _hf_hub_progress_bars_disabled
     return _hf_hub_progress_bars_disabled
 


### PR DESCRIPTION
Fix https://github.com/huggingface/huggingface_hub/issues/1042 (cc @abhishekkrthakur).

Make use of `tqdm.contrib.concurrent.thread_map` to easily spawn threads. Each thread handles a single file download.
This is especially useful when downloading a lot of small files. Downloading 1 file at a time is inefficient as the download is not limited by the bandwidth. 

Also fix https://github.com/huggingface/huggingface_hub/issues/1110 (cc @nerochiaro). Now possible to provide a custom tdqm class to snapshot_download if needed. Default is the `huggingface_hub.utils.tqdm` class (the progress that can be disabled programmatically or via  `HF_HUB_DISABLE_PROGRESS_BARS` env variable).