### PR TITLE
Add custom `GatedRepoError` when trying to access gated repo

### DIFF
--- a/docs/source/package_reference/utilities.mdx
+++ b/docs/source/package_reference/utilities.mdx
@@ -94,6 +94,10 @@ user as possible.
 
 [[autodoc]] huggingface_hub.utils.RepositoryNotFoundError
 
+#### GatedRepoError
+
+[[autodoc]] huggingface_hub.utils.GatedRepoError
+
 #### RevisionNotFoundError
 
 [[autodoc]] huggingface_hub.utils.RevisionNotFoundError

--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -32,6 +32,7 @@ from ._datetime import parse_datetime
 from ._errors import (
     BadRequestError,
     EntryNotFoundError,
+    GatedRepoError,
     HfHubHTTPError,
     LocalEntryNotFoundError,
     RepositoryNotFoundError,

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -37,7 +37,7 @@ from huggingface_hub.file_download import (
 )
 from huggingface_hub.utils import (
     EntryNotFoundError,
-    HfHubHTTPError,
+    GatedRepoError,
     LocalEntryNotFoundError,
     RepositoryNotFoundError,
     RevisionNotFoundError,
@@ -416,7 +416,7 @@ class StagingCachedDownloadTest(unittest.TestCase):
         """
         with TemporaryDirectory() as tmpdir:
             with self.assertRaisesRegex(
-                HfHubHTTPError,
+                GatedRepoError,
                 "Access to model .* is restricted and you are not in the authorized"
                 " list",
             ):


### PR DESCRIPTION
Related to discussions happening around gated repo (example : https://github.com/huggingface/huggingface_hub/issues/1198#issuecomment-1325030852). Follow [server-side PR](https://github.com/huggingface/moon-landing/pull/4627) (internal link).

This PR takes advantage of the new "GatedRepo" error code that is returned by server when a user tries to access a repo that is gated (and user is not in authorized list). It raises a  `GatedRepoError` in python (cc @sgugger).

Note: `GatedRepoError` inherits from `RepositoryNotFoundError` to avoid breaking changes.