### PR TITLE
Store token in configurable HF_HOME (in HfFolder)

### DIFF
--- a/docs/source/package_reference/environment_variables.mdx
+++ b/docs/source/package_reference/environment_variables.mdx
@@ -43,7 +43,7 @@ Defaults to `"$HF_HOME/assets"` (e.g. `"~/.cache/huggingface/assets"` by default
 ### HUGGING_FACE_HUB_TOKEN
 
 To configure the User Access Token to authenticate to the Hub. If set, this value will
-overwrite the token stored on the machine (under `"~/huggingface/token"`).
+overwrite the token stored on the machine (in `"$HF_HOME/token"`).
 
 See [login reference](package_reference/login) for more details.
 

--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -89,6 +89,9 @@ HUGGINGFACE_ASSETS_CACHE = os.getenv(
 
 HF_HUB_OFFLINE = _is_true(os.environ.get("HF_HUB_OFFLINE"))
 
+OLD_HF_TOKEN_PATH = os.path.expanduser("~/.huggingface/token")
+HF_TOKEN_PATH = os.path.join(hf_cache_home, "token")
+
 
 # Here, `True` will disable progress bars globally without possibility of enabling it
 # programmatically. `False` will enable them without possibility of disabling them.

--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -89,7 +89,10 @@ HUGGINGFACE_ASSETS_CACHE = os.getenv(
 
 HF_HUB_OFFLINE = _is_true(os.environ.get("HF_HUB_OFFLINE"))
 
-OLD_HF_TOKEN_PATH = os.path.expanduser("~/.huggingface/token")
+# In the past, token was stored in a hardcoded location
+# `_OLD_HF_TOKEN_PATH` is deprecated and will be removed "at some point".
+# See https://github.com/huggingface/huggingface_hub/issues/1232
+_OLD_HF_TOKEN_PATH = os.path.expanduser("~/.huggingface/token")
 HF_TOKEN_PATH = os.path.join(hf_cache_home, "token")
 
 

--- a/src/huggingface_hub/utils/_hf_folder.py
+++ b/src/huggingface_hub/utils/_hf_folder.py
@@ -68,7 +68,7 @@ class HfFolder:
         try:
             return cls.path_token.read_text()
         except FileNotFoundError:
-            pass
+            return None
 
     @classmethod
     def delete_token(cls) -> None:

--- a/src/huggingface_hub/utils/_hf_folder.py
+++ b/src/huggingface_hub/utils/_hf_folder.py
@@ -24,7 +24,7 @@ from .. import constants
 class HfFolder:
     path_token = Path(constants.HF_TOKEN_PATH)
     # Private attribute. Will be removed in v0.15
-    _old_path_token = Path(constants.OLD_HF_TOKEN_PATH)
+    _old_path_token = Path(constants._OLD_HF_TOKEN_PATH)
 
     @classmethod
     def save_token(cls, token: str) -> None:

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -1955,26 +1955,6 @@ class HfApiPrivateTest(HfApiCommonTestWithLogin):
         self.assertGreaterEqual(new, orig)
 
 
-class HfFolderTest(unittest.TestCase):
-    def test_token_workflow(self):
-        """
-        Test the whole token save/get/delete workflow,
-        with the desired behavior with respect to non-existent tokens.
-        """
-        token = "token-{}".format(int(time.time()))
-        HfFolder.save_token(token)
-        self.assertEqual(HfFolder.get_token(), token)
-        HfFolder.delete_token()
-        HfFolder.delete_token()
-        # ^^ not an error, we test that the
-        # second call does not fail.
-        self.assertEqual(HfFolder.get_token(), None)
-        # test TOKEN in env
-        self.assertEqual(HfFolder.get_token(), None)
-        with unittest.mock.patch.dict(os.environ, {"HUGGING_FACE_HUB_TOKEN": token}):
-            self.assertEqual(HfFolder.get_token(), token)
-
-
 @require_git_lfs
 class HfLargefilesTest(HfApiCommonTest):
     @classmethod

--- a/tests/test_utils_hf_folder.py
+++ b/tests/test_utils_hf_folder.py
@@ -77,10 +77,9 @@ class HfFolderTest(unittest.TestCase):
             self.assertFalse(old_path_token.exists())
             self.assertEqual(path_token.read_text(), token)
 
-            # Read -> new path has priority
+            # Read -> new path has priority. No warning message.
             old_path_token.write_text(token2)
-            with self.assertWarns(UserWarning):
-                self.assertEqual(HfFolder.get_token(), token)
+            self.assertEqual(HfFolder.get_token(), token)
 
             # Un-patch
             new_patcher.stop()

--- a/tests/test_utils_hf_folder.py
+++ b/tests/test_utils_hf_folder.py
@@ -1,0 +1,87 @@
+# Copyright 2020 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Contain tests for `HfFolder` utility."""
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+from uuid import uuid4
+
+from huggingface_hub.utils import HfFolder
+
+
+def _generate_token() -> str:
+    return f"token-{uuid4()}"
+
+
+class HfFolderTest(unittest.TestCase):
+    def test_token_workflow(self):
+        """
+        Test the whole token save/get/delete workflow,
+        with the desired behavior with respect to non-existent tokens.
+        """
+        token = _generate_token()
+        HfFolder.save_token(token)
+        self.assertEqual(HfFolder.get_token(), token)
+        HfFolder.delete_token()
+        HfFolder.delete_token()
+        # ^^ not an error, we test that the
+        # second call does not fail.
+        self.assertEqual(HfFolder.get_token(), None)
+        # test TOKEN in env
+        self.assertEqual(HfFolder.get_token(), None)
+        with unittest.mock.patch.dict(os.environ, {"HUGGING_FACE_HUB_TOKEN": token}):
+            self.assertEqual(HfFolder.get_token(), token)
+
+    def test_token_in_old_path(self):
+        token = _generate_token()
+        token2 = _generate_token()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path_token = Path(tmpdir) / "new_token_path"
+            old_path_token = Path(tmpdir) / "old_path_token"
+
+            # Use dummy paths
+            new_patcher = patch.object(HfFolder, "path_token", path_token)
+            old_patcher = patch.object(HfFolder, "_old_path_token", old_path_token)
+            new_patcher.start()
+            old_patcher.start()
+
+            # Reads from old path -> works but warn
+            old_path_token.write_text(token)
+            with self.assertWarns(UserWarning):
+                self.assertEqual(HfFolder.get_token(), token)
+            # Old path still exists
+            self.assertEqual(old_path_token.read_text(), token)
+            # New path is created
+            self.assertEqual(path_token.read_text(), token)
+
+            # Delete -> works, doesn't warn, delete both paths
+            HfFolder.delete_token()
+            self.assertFalse(old_path_token.exists())
+            self.assertFalse(path_token.exists())
+
+            # Write -> only to new path
+            HfFolder.save_token(token)
+            self.assertFalse(old_path_token.exists())
+            self.assertEqual(path_token.read_text(), token)
+
+            # Read -> new path has priority
+            old_path_token.write_text(token2)
+            with self.assertWarns(UserWarning):
+                self.assertEqual(HfFolder.get_token(), token)
+
+            # Un-patch
+            new_patcher.stop()
+            old_patcher.stop()


### PR DESCRIPTION
Fix https://github.com/huggingface/huggingface_hub/issues/1232. Read issue description for more details.

Basically token will now be stored under the `HF_HOME` directory and not in a hard-coded place. Should not break anything (only get user warnings).