### PR TITLE
Removes redundant (?) More Information section.

### DIFF
--- a/src/huggingface_hub/templates/modelcard_template.md
+++ b/src/huggingface_hub/templates/modelcard_template.md
@@ -39,7 +39,6 @@
 - **Language(s) (NLP):** {{ language | default("[More Information Needed]", true)}}
 - **License:** {{ license | default("[More Information Needed]", true)}}
 - **Finetuned from model [optional]:** {{ finetuned_from | default("[More Information Needed]", true)}}
-- **Resources for more information:** {{ more_resources | default("[More Information Needed]", true)}}
 
 # Uses
 


### PR DESCRIPTION
Note that this *also* removes a jinja template variable -- `more_resources` -- in favor of just the `more_information`