### PR TITLE
Accept pathlib.Path in upload_file

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -1976,7 +1976,7 @@ class HfApi:
     def upload_file(
         self,
         *,
-        path_or_fileobj: Union[str, bytes, BinaryIO],
+        path_or_fileobj: Union[str, Path, bytes, BinaryIO],
         path_in_repo: str,
         repo_id: str,
         token: Optional[str] = None,
@@ -1993,7 +1993,7 @@ class HfApi:
         installed.
 
         Args:
-            path_or_fileobj (`str`, `bytes`, or `IO`):
+            path_or_fileobj (`str`, `Path`, `bytes`, or `IO`):
                 Path to a file on the local machine or binary data stream /
                 fileobj / buffer.
             path_in_repo (`str`):

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -431,7 +431,7 @@ class CommitApiTest(HfApiCommonTestWithLogin):
     @retry_endpoint
     def test_upload_file_pathlib_path(self):
         """Regression test for https://github.com/huggingface/huggingface_hub/issues/1246."""
-        repo_id=f"{USER}/{repo_name()}"
+        repo_id = f"{USER}/{repo_name()}"
         self._api.create_repo(repo_id=repo_id)
         self._api.upload_file(
             path_or_fileobj=Path(self.tmp_file),


### PR DESCRIPTION
Fix https://github.com/huggingface/huggingface_hub/issues/1246.

This PR adds support of `pathlib.Path` type for `path_or_fileobj` in `upload_file` method (also in `CommitOperationAdd`). Add a regression test.