### PR TITLE
Adding "summary" variables

### DIFF
--- a/src/huggingface_hub/templates/modelcard_template.md
+++ b/src/huggingface_hub/templates/modelcard_template.md
@@ -7,6 +7,8 @@
 
 <!-- Provide a quick summary of what the model is/does. -->
 
+{{ model_summary | default("", true) }}
+
 #  Table of Contents
 
 1. [Model Details](#model-details)
@@ -131,6 +133,10 @@
 ## Results
 
 {{ results | default("[More Information Needed]", true)}}
+
+### Summary
+
+{{ results_summary | default("", true) }}
 
 # Model Examination [optional]
 


### PR DESCRIPTION
Proposes 2 new jinja variables that have been in other cards but were not yet transferred here:

`model_summary` , the short description of the model that follows the name.

`results_summary` , the tl;dr of what the results say.