### PR TITLE
[WiP] Fix dataset tags

### DIFF
--- a/src/huggingface_hub/utils/endpoint_helpers.py
+++ b/src/huggingface_hub/utils/endpoint_helpers.py
@@ -300,9 +300,9 @@ class GeneralTags(AttributeDictionary):
             self._unpack_and_assign_dictionary(key)
 
     def _unpack_and_assign_dictionary(self, key: str):
-        "Assignes nested attributes to `self.key` containing information as an `AttributeDictionary`"
+        "Assigns nested attributes to `self.key` containing information as an `AttributeDictionary`"
         setattr(self, key, AttributeDictionary())
-        for item in self._tag_dictionary[key]:
+        for item in self._tag_dictionary.get(key, []):
             ref = getattr(self, key)
             item["label"] = (
                 item["label"].replace(" ", "").replace("-", "_").replace(".", "_")


### PR DESCRIPTION
`benchmark` is not a part of https://huggingface.co/api/datasets-tags-by-type anymore which raises an issue when loading `DatasetTags`. Means all existing versions of `huggingface_hub` are broken (+ CI is also failing).
~Since it's not a very used feature anyway, I just made a quick fix here. Would be good to think about removing this part completely.~

**EDIT:** this PR is not fixing anything (see discussion). Let's figure out a better way of handling this. In the meantime https://github.com/huggingface/huggingface_hub/pull/1251 should skip the failing tests.