### PR TITLE
Skip failing tests related to DatasetFilter

### DIFF
--- a/tests/test_endpoint_helpers.py
+++ b/tests/test_endpoint_helpers.py
@@ -155,6 +155,11 @@ class ModelTagsTest(unittest.TestCase):
 
 
 class DatasetTagsTest(unittest.TestCase):
+    @unittest.skip(
+        "DatasetTags is currently broken. See"
+        " https://github.com/huggingface/huggingface_hub/pull/1250. Skip test until"
+        " it's fixed."
+    )
     @with_production_testing
     def test_tags(self):
         _api = HfApi()

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -1555,6 +1555,11 @@ class HfApiPublicProductionTest(unittest.TestCase):
         self.assertTrue("huggingface" in datasets[0].author)
         self.assertTrue("DataMeasurementsFiles" in datasets[0].id)
 
+    @unittest.skip(
+        "DatasetFilter is currently broken. See"
+        " https://github.com/huggingface/huggingface_hub/pull/1250. Skip test until"
+        " it's fixed."
+    )
     @expect_deprecation("list_datasets")
     def test_filter_datasets_by_benchmark(self):
         f = DatasetFilter(benchmark="raft")
@@ -1569,6 +1574,11 @@ class HfApiPublicProductionTest(unittest.TestCase):
         self.assertGreater(len(datasets), 0)
         self.assertTrue("language_creators:crowdsourced" in datasets[0].tags)
 
+    @unittest.skip(
+        "DatasetFilter is currently broken. See"
+        " https://github.com/huggingface/huggingface_hub/pull/1250. Skip test until"
+        " it's fixed."
+    )
     @expect_deprecation("list_datasets")
     def test_filter_datasets_by_language_only(self):
         datasets = self._api.list_datasets(filter=DatasetFilter(language="en"))


### PR DESCRIPTION
Related to https://github.com/huggingface/huggingface_hub/pull/1250.

For now and until we fix that, let's skip the failing tests. It's annoying in CI checks.