### PR TITLE
`datasetcard_template`: I think linking to a GH user does not make se…

### DIFF
--- a/src/huggingface_hub/templates/datasetcard_template.md
+++ b/src/huggingface_hub/templates/datasetcard_template.md
@@ -123,4 +123,4 @@
 
 ### Contributions
 
-Thanks to [@github-username](https://github.com/<github-username>) for adding this dataset.
+{{ contributions_section | default("[More Information Needed]", true)}}


### PR DESCRIPTION
…nse anymore now that dataset repos are fully on the Hub