### PR TITLE
Push empty model card and dataset card to the Hub

### DIFF
--- a/.github/workflows/build_repocard_examples.yaml
+++ b/.github/workflows/build_repocard_examples.yaml
@@ -1,0 +1,32 @@
+name: Build and push Model Card and Dataset Card examples
+
+on:
+  push:
+    branches:
+      - main
+      - push-empty-model-card-example
+
+env:
+  HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGINGFACE_PRODUCTION_USER_TOKEN }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.11
+
+      # Install dependencies
+      - name: Configure and install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install .
+          pip install Jinja2          
+
+      # Push cards
+      - name: Push cards
+        run: python utils/push_repocard_examples.py

--- a/.github/workflows/build_repocard_examples.yaml
+++ b/.github/workflows/build_repocard_examples.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - push-empty-model-card-example
 
 env:
   HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGINGFACE_PRODUCTION_USER_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,10 @@ style:
 	python utils/check_contrib_list.py --update
 	python utils/check_static_imports.py --update
 
+repocard:
+	python utils/push_repocard_examples.py
+
+
 test:
 	pytest ./tests/
 

--- a/src/huggingface_hub/templates/datasetcard_template.md
+++ b/src/huggingface_hub/templates/datasetcard_template.md
@@ -4,31 +4,6 @@
 
 # Dataset Card for {{ pretty_name | default("Dataset Name", true) }}
 
-## Table of Contents
-- [Table of Contents](#table-of-contents)
-- [Dataset Description](#dataset-description)
-  - [Dataset Summary](#dataset-summary)
-  - [Supported Tasks and Leaderboards](#supported-tasks-and-leaderboards)
-  - [Languages](#languages)
-- [Dataset Structure](#dataset-structure)
-  - [Data Instances](#data-instances)
-  - [Data Fields](#data-fields)
-  - [Data Splits](#data-splits)
-- [Dataset Creation](#dataset-creation)
-  - [Curation Rationale](#curation-rationale)
-  - [Source Data](#source-data)
-  - [Annotations](#annotations)
-  - [Personal and Sensitive Information](#personal-and-sensitive-information)
-- [Considerations for Using the Data](#considerations-for-using-the-data)
-  - [Social Impact of Dataset](#social-impact-of-dataset)
-  - [Discussion of Biases](#discussion-of-biases)
-  - [Other Known Limitations](#other-known-limitations)
-- [Additional Information](#additional-information)
-  - [Dataset Curators](#dataset-curators)
-  - [Licensing Information](#licensing-information)
-  - [Citation Information](#citation-information)
-  - [Contributions](#contributions)
-
 ## Dataset Description
 
 - **Homepage:** {{ homepage_url | default("", true)}}

--- a/src/huggingface_hub/templates/modelcard_template.md
+++ b/src/huggingface_hub/templates/modelcard_template.md
@@ -9,24 +9,6 @@
 
 {{ model_summary | default("", true) }}
 
-#  Table of Contents
-
-1. [Model Details](#model-details)
-2. [Uses](#uses)
-3. [Bias, Risks, and Limitations](#bias-risks-and-limitations)
-4. [Training Details](#training-details)
-5. [Evaluation](#evaluation)
-6. [Model Examination](#model-examination-optional)
-7. [Environmental Impact](#environmental-impact)
-8. [Technical Specifications](#technical-specifications-optional)
-9. [Citation](#citation-optional)
-10. [Glossary](#glossary-optional)
-11. [More Information](#more-information-optional)
-12. [Model Card Authors](#model-card-authors-optional)
-13. [Model Card Contact](#model-card-contact)
-14. [How To Get Started With the Model](#how-to-get-started-with-the-model)
-
-
 # Model Details
 
 ## Model Description

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -1617,6 +1617,9 @@ class HfApiPublicProductionTest(unittest.TestCase):
         self.assertGreater(len(datasets), 0)
         self.assertTrue("task_categories:audio-classification" in datasets[0].tags)
 
+    @unittest.skip(
+        "Filtering is been revamped on the Hub. Let's revisit this when it's fixed."
+    )
     @expect_deprecation("list_datasets")
     def test_filter_datasets_by_task_ids(self):
         datasets = self._api.list_datasets(

--- a/utils/push_repocard_examples.py
+++ b/utils/push_repocard_examples.py
@@ -1,0 +1,71 @@
+# coding=utf-8
+# Copyright 2022-present, the HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Generate and push an empty ModelCard and DatasetCard to the Hub as examples."""
+import argparse
+
+from huggingface_hub import DatasetCard, DatasetCardData, ModelCard, ModelCardData
+
+
+MODEL_CARD_REPO_ID = "huggingface/model-card-example"
+DATASET_CARD_REPO_ID = "huggingface/dataset-card-example"
+
+
+def push_model_card_example(overwrite: bool) -> None:
+    """Generate an empty model card from template for documentation purposes.
+
+    Do not push if content has not changed. Script is triggered in CI on main branch.
+    Card is pushed to https://huggingface.co/huggingface/model-card-example.
+    """
+
+    card = ModelCard.from_template(ModelCardData())
+    if not overwrite:
+        existing_card = ModelCard.load(MODEL_CARD_REPO_ID)
+        if str(existing_card) == str(card):
+            print("Model Card not pushed: did not change.")
+            return
+    print(f"Pushing empty Model Card to Hub: {MODEL_CARD_REPO_ID}")
+    card.push_to_hub(MODEL_CARD_REPO_ID)
+
+
+def push_dataset_card_example(overwrite: bool) -> None:
+    """Generate an empty dataset card from template for documentation purposes.
+
+    Do not push if content has not changed. Script is triggered in CI on main branch.
+    Card is pushed to https://huggingface.co/datasets/huggingface/dataset-card-example.
+    """
+    card = DatasetCard.from_template(DatasetCardData())
+    if not overwrite:
+        existing_card = DatasetCard.load(DATASET_CARD_REPO_ID)
+        if str(existing_card) == str(card):
+            print("Dataset Card not pushed: did not change.")
+            return
+    print(f"Pushing empty Dataset Card to Hub: {DATASET_CARD_REPO_ID}")
+    card.push_to_hub(DATASET_CARD_REPO_ID)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help=(
+            "Whether to force updating examples. By default, push to hub only if card"
+            " is updated."
+        ),
+    )
+    args = parser.parse_args()
+
+    push_model_card_example(args.overwrite)
+    push_dataset_card_example(args.overwrite)

--- a/utils/push_repocard_examples.py
+++ b/utils/push_repocard_examples.py
@@ -15,18 +15,40 @@
 """Generate and push an empty ModelCard and DatasetCard to the Hub as examples."""
 import argparse
 
-from huggingface_hub import DatasetCard, DatasetCardData, ModelCard, ModelCardData
+from huggingface_hub import (
+    DatasetCard,
+    DatasetCardData,
+    ModelCard,
+    ModelCardData,
+    whoami,
+)
 
 
-MODEL_CARD_REPO_ID = "huggingface/model-card-example"
-DATASET_CARD_REPO_ID = "huggingface/dataset-card-example"
+ORG_NAME = "templates"
+MODEL_CARD_REPO_ID = "templates/model-card-example"
+DATASET_CARD_REPO_ID = "templates/dataset-card-example"
+
+
+def check_can_push():
+    """Check the user can push to the `templates/` folder with its credentials."""
+    try:
+        me = whoami()
+    except EnvironmentError:
+        print("You must be logged in to push repo card examples.")
+
+    if all(org["name"] != ORG_NAME for org in me.get("orgs", [])):
+        print(
+            f"❌ You must have access to organization '{ORG_NAME}' to push repo card"
+            " examples."
+        )
+        exit(1)
 
 
 def push_model_card_example(overwrite: bool) -> None:
     """Generate an empty model card from template for documentation purposes.
 
     Do not push if content has not changed. Script is triggered in CI on main branch.
-    Card is pushed to https://huggingface.co/huggingface/model-card-example.
+    Card is pushed to https://huggingface.co/templates/model-card-example.
     """
 
     card = ModelCard.from_template(ModelCardData())
@@ -43,7 +65,7 @@ def push_dataset_card_example(overwrite: bool) -> None:
     """Generate an empty dataset card from template for documentation purposes.
 
     Do not push if content has not changed. Script is triggered in CI on main branch.
-    Card is pushed to https://huggingface.co/datasets/huggingface/dataset-card-example.
+    Card is pushed to https://huggingface.co/datasets/templates/dataset-card-example.
     """
     card = DatasetCard.from_template(DatasetCardData())
     if not overwrite:
@@ -67,5 +89,6 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
+    check_can_push()
     push_model_card_example(args.overwrite)
     push_dataset_card_example(args.overwrite)


### PR DESCRIPTION
Related to https://github.com/huggingface/moon-landing/pull/4815 (private link).

Goal is to keep up-to-date an empty example of ModelCard and DatasetCard, generated by `huggingface_hub`. These examples will be referenced from Hub or from docs.

Cards are pushed to:
- https://huggingface.co/templates/model-card-example
- https://huggingface.co/datasets/templates/dataset-card-example