### PR TITLE
Remove `get_space_secrets` endpoint

### DIFF
--- a/docs/source/guides/manage_spaces.mdx
+++ b/docs/source/guides/manage_spaces.mdx
@@ -40,9 +40,9 @@ For example, an HF token to upload an image dataset to the Hub once generated fr
 >>> api.add_space_secret(repo_id=repo_id, key="HF_TOKEN", value="hf_api_***")
 ```
 
-Secrets can be listed from the API as well:
+Secrets can be deleted as well:
 ```py
->>> api.get_space_secrets(repo_id=repo_id)
+>>> api.delete_space_secret(repo_id=repo_id, key="HF_TOKEN")
 ```
 
 <Tip>

--- a/docs/source/package_reference/space_runtime.mdx
+++ b/docs/source/package_reference/space_runtime.mdx
@@ -5,7 +5,6 @@ runtime on the Hub.
 
 - [`add_space_secret`]
 - [`delete_space_secret`]
-- [`get_space_secrets`]
 - [`get_space_runtime`]
 - [`request_space_hardware`]
 

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -131,7 +131,6 @@ _SUBMOD_ATTRS = {
         "get_model_tags",
         "get_repo_discussions",
         "get_space_runtime",
-        "get_space_secrets",
         "list_datasets",
         "list_metrics",
         "list_models",
@@ -365,7 +364,6 @@ if TYPE_CHECKING:  # pragma: no cover
     from .hf_api import get_model_tags  # noqa: F401
     from .hf_api import get_repo_discussions  # noqa: F401
     from .hf_api import get_space_runtime  # noqa: F401
-    from .hf_api import get_space_secrets  # noqa: F401
     from .hf_api import list_datasets  # noqa: F401
     from .hf_api import list_metrics  # noqa: F401
     from .hf_api import list_models  # noqa: F401

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -3493,29 +3493,6 @@ class HfApi:
         )
         hf_raise_for_status(r)
 
-    def get_space_secrets(
-        self, repo_id: str, *, token: Optional[str] = None
-    ) -> Dict[str, str]:
-        """Gets all secrets from a Space.
-
-        Secrets allow to set secret keys or tokens to a Space without hardcoding them.
-        More for details, see https://huggingface.co/docs/hub/spaces-overview#managing-secrets.
-
-        Args:
-            repo_id (`str`):
-                ID of the repo to update. Example: `"bigcode/in-the-stack"`.
-            token (`str`, *optional*):
-                Hugging Face token. Will default to the locally saved token if not provided.
-        Returns:
-            `Dict[str, str]`: dictionary containing all key/value pairs.
-        """
-        r = requests.get(
-            f"{self.endpoint}/api/spaces/{repo_id}/secrets",
-            headers=self._build_hf_headers(token=token),
-        )
-        hf_raise_for_status(r)
-        return r.json()
-
     def get_space_runtime(
         self, repo_id: str, *, token: Optional[str] = None
     ) -> SpaceRuntime:
@@ -3704,6 +3681,5 @@ merge_pull_request = api.merge_pull_request
 # Space API
 add_space_secret = api.add_space_secret
 delete_space_secret = api.delete_space_secret
-get_space_secrets = api.get_space_secrets
 get_space_runtime = api.get_space_runtime
 request_space_hardware = api.request_space_hardware

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2302,12 +2302,6 @@ class TestSpaceAPIProduction(unittest.TestCase):
         # Doesn't fail on missing key
         self.api.delete_space_secret(self.repo_id, "missing_key")
 
-        # Get all
-        self.assertEqual(
-            self.api.get_space_secrets(repo_id=self.repo_id),
-            {"foo": "456", "token": "hf_api_123456"},
-        )
-
     def test_space_runtime(self) -> None:
         runtime = self.api.get_space_runtime(self.repo_id)
 
@@ -2317,7 +2311,7 @@ class TestSpaceAPIProduction(unittest.TestCase):
 
         # Space is either "BUILDING" (if not yet done) or "NO_APP_FILE" (if building failed)
         self.assertIn(runtime.stage, (SpaceStage.NO_APP_FILE, SpaceStage.BUILDING))
-        self.assertIn(runtime.stage, ("NO_APP_FILE", "BUILDING")) # str works as well
+        self.assertIn(runtime.stage, ("NO_APP_FILE", "BUILDING"))  # str works as well
 
         # Raw response from Hub
         self.assertIsInstance(runtime.raw, dict)

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2332,23 +2332,31 @@ class TestSpaceAPIMocked(unittest.TestCase):
     def test_create_space_with_hardware(self, post_mock: Mock) -> None:
         self.api.create_repo(
             self.repo_id,
-            private=True,
             repo_type="space",
             space_sdk="gradio",
             space_hardware=SpaceHardware.T4_MEDIUM,
         )
-        kwargs = post_mock.call_args.kwargs
-        self.assertIn("json", kwargs)
-        self.assertIn("hardware", kwargs["json"])
-        self.assertEqual(kwargs["json"]["hardware"], "t4-medium")
+        post_mock.assert_called_once_with(
+            f"{self.api.endpoint}/api/repos/create",
+            headers=self.api._build_hf_headers(),
+            json={
+                "name": self.repo_id,
+                "organization": None,
+                "private": False,
+                "type": "space",
+                "sdk": "gradio",
+                "hardware": "t4-medium",
+            },
+        )
 
     @patch("huggingface_hub.hf_api.requests.post")
     def test_request_space_hardware(self, post_mock: Mock) -> None:
         self.api.request_space_hardware(self.repo_id, SpaceHardware.T4_MEDIUM)
-        kwargs = post_mock.call_args.kwargs
-        self.assertIn("json", kwargs)
-        self.assertIn("flavor", kwargs["json"])
-        self.assertEqual(kwargs["json"]["flavor"], "t4-medium")
+        post_mock.assert_called_once_with(
+            f"{self.api.endpoint}/api/spaces/{self.repo_id}/hardware",
+            headers=self.api._build_hf_headers(),
+            json={"flavor": "t4-medium"},
+        )
 
 
 @patch("huggingface_hub.hf_api.build_hf_headers")


### PR DESCRIPTION
For security the GET `/secrets` endpoint is not exposed ([see discussion](https://huggingface.slack.com/archives/C02EMARJ65P/p1670921311847139) -internal link-).

Let's remove the `get_space_secrets(...)` method for now since it's not a requested feature and not so important for now.