### PR TITLE
Progress bar when uploading LFS files

### DIFF
--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -85,4 +85,5 @@ from .tqdm import (
     disable_progress_bars,
     enable_progress_bars,
     tqdm,
+    tqdm_stream_file,
 )

--- a/src/huggingface_hub/utils/tqdm.py
+++ b/src/huggingface_hub/utils/tqdm.py
@@ -54,7 +54,11 @@ Example:
        do_something()
     ```
 """
+import io
 import warnings
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator, Optional, Union
 
 from tqdm.auto import tqdm as old_tqdm
 
@@ -118,3 +122,52 @@ class tqdm(old_tqdm):
         if are_progress_bars_disabled():
             kwargs["disable"] = True
         super().__init__(*args, **kwargs)
+
+
+@contextmanager
+def tqdm_stream_file(path: Union[Path, str]) -> Iterator[io.BufferedReader]:
+    """
+    Open a file as binary and wrap the `read` method to display a progress bar when it's
+    streamed.
+
+    First implemented in `transformers` in 2019 but removed when switched to git-lfs.
+    Today used in `huggingface_hub` to show progress bar when uploading an LFS file to
+    the Hub. See github.com/huggingface/transformers/pull/2078#discussion_r354739608 for
+    implementation details.
+
+    Note: currently implementation handles only files stored on disk as it is the most
+          common use case. Could be extended to stream any `BinaryIO` object but we might
+          have to debug some corner cases.
+
+    Example:
+    ```py
+    >>> with tqdm_stream_file("config.json") as f:
+    >>>     requests.put(url, data=f)
+    config.json: 100%|█████████████████████████| 8.19k/8.19k [00:02<00:00, 3.72kB/s]
+    ```
+    """
+    if isinstance(path, str):
+        path = Path(path)
+
+    with path.open("rb") as f:
+        total_size = path.stat().st_size
+        pbar = tqdm(
+            unit="B",
+            unit_scale=True,
+            total=total_size,
+            initial=0,
+            desc=path.name,
+        )
+
+        f_read = f.read
+
+        def _inner_read(size: Optional[int] = -1) -> bytes:
+            data = f_read(size)
+            pbar.update(len(data))
+            return data
+
+        f.read = _inner_read  # type: ignore
+
+        yield f
+
+        pbar.close()


### PR DESCRIPTION
Resolve #1244 (cc @sijunhe).

Add 2 progress bars when creating a commit. A "main" one showing how much LFS files must be uploaded + 1 progress for each individual LFS file. Progress bars can be disabled by setting `HF_HUB_DISABLE_PROGRESS_BARS=1` as environment variable.  Example:
```text
8b.arrow: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2.00/2.00 [00:03<00:00, 1.54s/B]
8kb.arrow: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2.05k/2.05k [00:03<00:00, 655B/s]
8mb.arrow: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2.10M/2.10M [00:22<00:00, 94.8kB/s]
Upload 3 LFS files: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:22<00:00,  7.38s/it]
```

I based the implementation on @julien-c 's implementation from `transformers` back in 2019 (https://github.com/huggingface/transformers/pull/2078).
I kept it as minimal as possible. Especially, files that are passed as a filepath have a progress bar. Should cover 95% of the cases. I'm not against making it more flexible but it could bring more problems/corner cases to debug.

Also refactored the code to upload files in parallel to use `thread_map`.