### PR TITLE
Increase the chunk size for faster download

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -492,7 +492,7 @@ def http_get(
         desc=f"Downloading (…){url[-20:]}",
         disable=bool(logger.getEffectiveLevel() == logging.NOTSET),
     )
-    for chunk in r.iter_content(chunk_size=1024):
+    for chunk in r.iter_content(chunk_size=10 * 1024 * 1024):
         if chunk:  # filter out keep-alive new chunks
             progress.update(len(chunk))
             temp_file.write(chunk)

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -484,12 +484,19 @@ def http_get(
     hf_raise_for_status(r)
     content_length = r.headers.get("Content-Length")
     total = resume_size + int(content_length) if content_length is not None else None
+
+    displayed_name = url
+    content_disposition = r.headers.get("Content-Disposition")
+    if content_disposition is not None and "filename=" in content_disposition:
+        # Means file is on CDN
+        displayed_name = content_disposition.split("filename=")[-1]
+
     progress = tqdm(
         unit="B",
         unit_scale=True,
         total=total,
         initial=resume_size,
-        desc=f"Downloading (…){url[-20:]}",
+        desc=f"Downloading (…){displayed_name[-20:]}",
         disable=bool(logger.getEffectiveLevel() == logging.NOTSET),
     )
     for chunk in r.iter_content(chunk_size=10 * 1024 * 1024):


### PR DESCRIPTION
- Larger chunk help reduce overhead
- Not too large chunks so resume still works

In my very small testing I get much better download speeds already with cloudfront.

Download times go for `gpt2` from ~5s+ to ~2s- (tested both on AWS and dgx).

Testing setup:

```python
from huggingface_hub import hf_hub_download

filename = hf_hub_download("gpt2", "pytorch_model.bin", force_download=True, cache_dir="/mnt/ramdisk/")
print(filename)
```

Using a tmpfs part of the disk avoids actually writing to disk and taking it into account.