### PR TITLE
Extend create_repo return value

### DIFF
--- a/docs/source/package_reference/hf_api.mdx
+++ b/docs/source/package_reference/hf_api.mdx
@@ -42,6 +42,10 @@ hf_api = HfApi(
 
 [[autodoc]] HfApi
 
+### RepoUrl
+
+[[autodoc]] huggingface_hub.hf_api.RepoUrl
+
 ### ModelInfo
 
 [[autodoc]] huggingface_hub.hf_api.ModelInfo

--- a/docs/source/package_reference/hf_api.mdx
+++ b/docs/source/package_reference/hf_api.mdx
@@ -45,8 +45,6 @@ hf_api = HfApi(
 ### RepoUrl
 
 [[autodoc]] huggingface_hub.hf_api.RepoUrl
-    - __init__
-    - all
 
 ### ModelInfo
 

--- a/docs/source/package_reference/hf_api.mdx
+++ b/docs/source/package_reference/hf_api.mdx
@@ -45,6 +45,8 @@ hf_api = HfApi(
 ### RepoUrl
 
 [[autodoc]] huggingface_hub.hf_api.RepoUrl
+    - __init__
+    - all
 
 ### ModelInfo
 

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -108,6 +108,7 @@ _SUBMOD_ATTRS = {
         "DatasetSearchArguments",
         "HfApi",
         "ModelSearchArguments",
+        "RepoUrl",
         "UserLikes",
         "add_space_secret",
         "change_discussion_status",
@@ -345,6 +346,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from .hf_api import DatasetSearchArguments  # noqa: F401
     from .hf_api import HfApi  # noqa: F401
     from .hf_api import ModelSearchArguments  # noqa: F401
+    from .hf_api import RepoUrl  # noqa: F401
     from .hf_api import UserLikes  # noqa: F401
     from .hf_api import add_space_secret  # noqa: F401
     from .hf_api import change_discussion_status  # noqa: F401

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -232,6 +232,9 @@ class RepoUrl(str):
 
     >>> RepoUrl('https://hub-ci.huggingface.co/dataset/dummy_user/dummy_dataset', endpoint='https://hub-ci.huggingface.co')
     RepoUrl('https://hub-ci.huggingface.co/dataset/dummy_user/dummy_dataset', endpoint='https://hub-ci.huggingface.co', repo_type='dataset', repo_id='dummy_user/dummy_dataset')
+
+    >>> HfApi.create_repo("dummy_model")
+    RepoUrl('https://huggingface.co/Wauplin/dummy_model', endpoint='https://huggingface.co', repo_type='model', repo_id='Wauplin/dummy_model')
     ```
     """
 

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -215,16 +215,19 @@ class CommitInfo:
 class RepoUrl(str):
     """Subclass of `str` describing a repo URL on the Hub.
 
-    Inherits from `str` for backward compatibility.
-
-    RepoUrl adds new properties:
+    `RepoUrl` is returned by `HfApi.create_repo`. It inherits from `str` for backward
+    compatibility. At initialization, the URL is parsed to populate properties:
     - endpoint (`str`)
     - namespace (`Optional[str]`)
     - repo_id (`str`)
     - repo_type (`Literal["model", "dataset", "space"]`)
     - url (`str`)
 
-    `RepoUrl` is returned by `HfApi.create_repo`.
+    Args:
+        url (`Any`):
+            String value of the repo url.
+        endpoint (`str`, *optional*):
+            Endpoint of the Hub. Defaults to <https://huggingface.co>.
 
     Example:
     ```py
@@ -243,20 +246,6 @@ class RepoUrl(str):
         return super(RepoUrl, cls).__new__(cls, url)
 
     def __init__(self, url: Any, endpoint: Optional[str] = None) -> None:
-        """Initialize a `RepoUrl` object by parsing the input URL.
-
-        Args:
-            url (`Any`):
-                String value of the repo url.
-            endpoint (`str`, *optional*):
-                Endpoint of the Hub. Defaults to <https://huggingface.co>.
-
-        Example:
-        ```py
-        >>> RepoUrl('https://huggingface.co/gpt2')
-        RepoUrl('https://huggingface.co/gpt2', endpoint='https://huggingface.co', repo_type='model', repo_id='gpt2')
-        ```
-        """
         super().__init__()
         # Parse URL
         self.endpoint = endpoint or ENDPOINT

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -239,10 +239,24 @@ class RepoUrl(str):
     ```
     """
 
-    def __new__(cls, content: Any, endpoint: Optional[str] = None):
-        return super(RepoUrl, cls).__new__(cls, content)
+    def __new__(cls, url: Any, endpoint: Optional[str] = None):
+        return super(RepoUrl, cls).__new__(cls, url)
 
-    def __init__(self, content: Any, endpoint: Optional[str] = None) -> None:
+    def __init__(self, url: Any, endpoint: Optional[str] = None) -> None:
+        """Initialize a `RepoUrl` object by parsing the input URL.
+
+        Args:
+            url (`Any`):
+                String value of the repo url.
+            endpoint (`str`, *optional*):
+                Endpoint of the Hub. Defaults to <https://huggingface.co>.
+
+        Example:
+        ```py
+        >>> RepoUrl('https://huggingface.co/gpt2')
+        RepoUrl('https://huggingface.co/gpt2', endpoint='https://huggingface.co', repo_type='model', repo_id='gpt2')
+        ```
+        """
         super().__init__()
         # Parse URL
         self.endpoint = endpoint or ENDPOINT

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -222,6 +222,7 @@ class RepoUrl(str):
     - namespace (`Optional[str]`)
     - repo_id (`str`)
     - repo_type (`Literal["model", "dataset", "space"]`)
+    - url (`str`)
 
     `RepoUrl` is returned by `HfApi.create_repo`.
 
@@ -253,6 +254,7 @@ class RepoUrl(str):
         self.namespace = namespace
         self.repo_id = repo_name if namespace is None else f"{namespace}/{repo_name}"
         self.repo_type = repo_type or REPO_TYPE_MODEL
+        self.url = str(self)  # just in case it's needed
 
     def __repr__(self) -> str:
         return (

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2557,3 +2557,11 @@ class RepoUrlTest(unittest.TestCase):
         url = RepoUrl("https://huggingface.co/dummy_user/dummy_model")
         self.assertEqual(url.namespace, "dummy_user")
         self.assertEqual(url.repo_id, "dummy_user/dummy_model")
+
+    def test_repo_url_url_property(self):
+        # RepoUrl.url returns a pure `str` value
+        url = RepoUrl("https://huggingface.co/gpt2")
+        self.assertEqual(url, "https://huggingface.co/gpt2")
+        self.assertEqual(url.url, "https://huggingface.co/gpt2")
+        self.assertIsInstance(url, RepoUrl)
+        self.assertNotIsInstance(url.url, RepoUrl)


### PR DESCRIPTION
This PR updates the return value for `create_repo` endpoint. The current problem is that `repo_id` input can have an implicit namespace (e.g. `create_repo("my-model")` -> `"Wauplin/my-model"`). The return value of `create_repo` is currently a URL to the new repo on the Hub. This is a bit annoying for external libraries that integrates `hfh` in their pipeline as they need to parse the _explicit_ `repo_id` from the returned URL. This can be done by the helper `repo_type_and_id_from_hf_id` but to be honest it's not very easy to find for maintainers. We end up with integrations where the parsing is done manually or where it's forgotten (e.g. implicit repo_id is passed afterwards to `create_commit` which breaks).

This PR tries to solve this problem by adding a new type [RepoUrl](https://moon-ci-docs.huggingface.co/docs/huggingface_hub/pr_1268/en/package_reference/hf_api#huggingface_hub.RepoUrl) with properties like `endpoint`, `repo_type`, `repo_id` and `namespace`. To prevent backward compatibility issues, `RepoUrl` is a subclass of `str` so it shouldn't break too much things.

```py
>>> from huggingface_hub import HfApi

>>> url = HfApi.create_repo("dummy_model")
RepoUrl('https://huggingface.co/Wauplin/dummy_model', endpoint='https://huggingface.co', repo_type='model', repo_id='Wauplin/dummy_model')

>>> "New repo: " + url # RepoUrl is a subclass of `str`
'New repo: https://huggingface.co/Wauplin/dummy_model'

>>> url.repo_id # implicit namespace is there
'Wauplin/dummy_model'
```