### PR TITLE
Fix list_liked_repos (only public likes are returned)

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -1377,7 +1377,7 @@ class HfApi:
         token: Optional[str] = None,
     ) -> UserLikes:
         """
-        List all repos liked by a user on huggingface.co.
+        List all public repos liked by a user on huggingface.co.
 
         This list is public so token is optional. If `user` is not passed, it defaults to
         the logged in user.
@@ -1393,8 +1393,8 @@ class HfApi:
                 user name.
 
         Returns:
-            [`UserLikes`]: object containing the user name, the total count of likes and
-            3 lists of repo ids (1 for models, 1 for datasets and 1 for Spaces).
+            [`UserLikes`]: object containing the user name and 3 lists of repo ids (1 for
+            models, 1 for datasets and 1 for Spaces).
 
         Raises:
             [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
@@ -1443,17 +1443,17 @@ class HfApi:
             user=user,
             models=[
                 like["repo"]["name"]
-                for like in data["visibleLikes"]
+                for like in data["likes"]
                 if like["repo"]["type"] == "model"
             ],
             datasets=[
                 like["repo"]["name"]
-                for like in data["visibleLikes"]
+                for like in data["likes"]
                 if like["repo"]["type"] == "dataset"
             ],
             spaces=[
                 like["repo"]["name"]
-                for like in data["visibleLikes"]
+                for like in data["likes"]
                 if like["repo"]["type"] == "space"
             ],
         )

--- a/src/huggingface_hub/lfs.py
+++ b/src/huggingface_hub/lfs.py
@@ -195,7 +195,7 @@ def post_lfs_batch_info(
         },
         auth=HTTPBasicAuth(
             "access_token",
-            get_token_to_send(token or True),  # Token must be provided or retrieved
+            get_token_to_send(token or True),  # type: ignore  # Token must be provided or retrieved
         ),
     )
     hf_raise_for_status(resp)
@@ -280,7 +280,7 @@ def lfs_upload(
             auth=HTTPBasicAuth(
                 username="USER",
                 # Token must be provided or retrieved
-                password=get_token_to_send(token or True),
+                password=get_token_to_send(token or True),  # type: ignore
             ),
             json={"oid": upload_info.sha256.hex(), "size": upload_info.size},
         )

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2361,6 +2361,9 @@ class ActivityApiTest(unittest.TestCase):
     def test_list_likes_on_production(self) -> None:
         # Test julien-c likes a lot of repos !
         likes = HfApi().list_liked_repos("julien-c")
+        self.assertEqual(
+            len(likes.models) + len(likes.datasets) + len(likes.spaces), likes.total
+        )
         self.assertGreater(len(likes.models), 0)
         self.assertGreater(len(likes.datasets), 0)
         self.assertGreater(len(likes.spaces), 0)


### PR DESCRIPTION
Server only returns public likes. This PR adapts parsing of the data (+docstring).