### PR TITLE
1278 More robust temporary directory

### DIFF
--- a/src/huggingface_hub/fastai_utils.py
+++ b/src/huggingface_hub/fastai_utils.py
@@ -1,6 +1,5 @@
 import json
 import os
-import tempfile
 from pathlib import Path
 from pickle import DEFAULT_PROTOCOL, PicklingError
 from typing import Any, Dict, List, Optional, Union
@@ -11,6 +10,7 @@ from huggingface_hub import snapshot_download
 from huggingface_hub.constants import CONFIG_NAME
 from huggingface_hub.hf_api import HfApi
 from huggingface_hub.utils import (
+    TemporaryDirectory,
     get_fastai_version,
     get_fastcore_version,
     get_python_version,
@@ -418,7 +418,7 @@ def push_to_hub_fastai(
     )
 
     # Push the files to the repo in a single commit
-    with tempfile.TemporaryDirectory() as tmp:
+    with TemporaryDirectory() as tmp:
         saved_path = Path(tmp) / repo_id
         _save_pretrained_fastai(learner, saved_path, config=config)
         return api.upload_folder(

--- a/src/huggingface_hub/fastai_utils.py
+++ b/src/huggingface_hub/fastai_utils.py
@@ -10,7 +10,7 @@ from huggingface_hub import snapshot_download
 from huggingface_hub.constants import CONFIG_NAME
 from huggingface_hub.hf_api import HfApi
 from huggingface_hub.utils import (
-    TemporaryDirectory,
+    SoftTemporaryDirectory,
     get_fastai_version,
     get_fastcore_version,
     get_python_version,
@@ -418,7 +418,7 @@ def push_to_hub_fastai(
     )
 
     # Push the files to the repo in a single commit
-    with TemporaryDirectory() as tmp:
+    with SoftTemporaryDirectory() as tmp:
         saved_path = Path(tmp) / repo_id
         _save_pretrained_fastai(learner, saved_path, config=config)
         return api.upload_folder(

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -53,7 +53,7 @@ from .utils import is_torch_available  # noqa: F401 # for backward compatibility
 from .utils import (
     EntryNotFoundError,
     LocalEntryNotFoundError,
-    TemporaryDirectory,
+    SoftTemporaryDirectory,
     build_hf_headers,
     hf_raise_for_status,
     http_backoff,
@@ -94,7 +94,7 @@ def are_symlinks_supported(cache_dir: Union[str, Path, None] = None) -> bool:
         _are_symlinks_supported_in_dir[cache_dir] = True
 
         os.makedirs(cache_dir, exist_ok=True)
-        with TemporaryDirectory(dir=cache_dir) as tmpdir:
+        with SoftTemporaryDirectory(dir=cache_dir) as tmpdir:
             src_path = Path(tmpdir) / "dummy_file_src"
             src_path.touch()
             dst_path = Path(tmpdir) / "dummy_file_dst"

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -6,7 +6,6 @@ import os
 import re
 import shutil
 import stat
-import tempfile
 import uuid
 import warnings
 from contextlib import contextmanager
@@ -53,6 +52,7 @@ from .utils import is_torch_available  # noqa: F401 # for backward compatibility
 from .utils import (
     EntryNotFoundError,
     LocalEntryNotFoundError,
+    TemporaryDirectory,
     build_hf_headers,
     hf_raise_for_status,
     http_backoff,
@@ -93,7 +93,7 @@ def are_symlinks_supported(cache_dir: Union[str, Path, None] = None) -> bool:
         _are_symlinks_supported_in_dir[cache_dir] = True
 
         os.makedirs(cache_dir, exist_ok=True)
-        with tempfile.TemporaryDirectory(dir=cache_dir) as tmpdir:
+        with TemporaryDirectory(dir=cache_dir) as tmpdir:
             src_path = Path(tmpdir) / "dummy_file_src"
             src_path.touch()
             dst_path = Path(tmpdir) / "dummy_file_dst"

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -6,6 +6,7 @@ import os
 import re
 import shutil
 import stat
+import tempfile
 import uuid
 import warnings
 from contextlib import contextmanager

--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -1,6 +1,5 @@
 import json
 import os
-import tempfile
 from pathlib import Path
 from typing import Dict, List, Optional, Union
 
@@ -9,7 +8,7 @@ import requests
 from .constants import CONFIG_NAME, PYTORCH_WEIGHTS_NAME
 from .file_download import hf_hub_download, is_torch_available
 from .hf_api import HfApi
-from .utils import logging, validate_hf_hub_args
+from .utils import TemporaryDirectory, logging, validate_hf_hub_args
 
 
 if is_torch_available():
@@ -279,7 +278,7 @@ class ModelHubMixin:
         )
 
         # Push the files to the repo in a single commit
-        with tempfile.TemporaryDirectory() as tmp:
+        with TemporaryDirectory() as tmp:
             saved_path = Path(tmp) / repo_id
             self.save_pretrained(saved_path, config=config)
             return api.upload_folder(

--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -8,7 +8,7 @@ import requests
 from .constants import CONFIG_NAME, PYTORCH_WEIGHTS_NAME
 from .file_download import hf_hub_download, is_torch_available
 from .hf_api import HfApi
-from .utils import TemporaryDirectory, logging, validate_hf_hub_args
+from .utils import SoftTemporaryDirectory, logging, validate_hf_hub_args
 
 
 if is_torch_available():
@@ -278,7 +278,7 @@ class ModelHubMixin:
         )
 
         # Push the files to the repo in a single commit
-        with TemporaryDirectory() as tmp:
+        with SoftTemporaryDirectory() as tmp:
             saved_path = Path(tmp) / repo_id
             self.save_pretrained(saved_path, config=config)
             return api.upload_folder(

--- a/src/huggingface_hub/keras_mixin.py
+++ b/src/huggingface_hub/keras_mixin.py
@@ -19,7 +19,7 @@ from huggingface_hub.utils import (
 
 from .constants import CONFIG_NAME, DEFAULT_REVISION
 from .hf_api import HfApi, _parse_revision_from_pr_url, _prepare_upload_folder_commit
-from .utils import TemporaryDirectory, logging, validate_hf_hub_args
+from .utils import SoftTemporaryDirectory, logging, validate_hf_hub_args
 
 
 logger = logging.get_logger(__name__)
@@ -371,7 +371,7 @@ def push_to_hub_keras(
     )
 
     # Push the files to the repo in a single commit
-    with TemporaryDirectory() as tmp:
+    with SoftTemporaryDirectory() as tmp:
         saved_path = Path(tmp) / repo_id
         save_pretrained_keras(
             model,

--- a/src/huggingface_hub/keras_mixin.py
+++ b/src/huggingface_hub/keras_mixin.py
@@ -1,7 +1,6 @@
 import collections.abc as collections
 import json
 import os
-import tempfile
 import warnings
 from pathlib import Path
 from shutil import copytree
@@ -20,7 +19,7 @@ from huggingface_hub.utils import (
 
 from .constants import CONFIG_NAME, DEFAULT_REVISION
 from .hf_api import HfApi, _parse_revision_from_pr_url, _prepare_upload_folder_commit
-from .utils import logging, validate_hf_hub_args
+from .utils import TemporaryDirectory, logging, validate_hf_hub_args
 
 
 logger = logging.get_logger(__name__)
@@ -372,7 +371,7 @@ def push_to_hub_keras(
     )
 
     # Push the files to the repo in a single commit
-    with tempfile.TemporaryDirectory() as tmp:
+    with TemporaryDirectory() as tmp:
         saved_path = Path(tmp) / repo_id
         save_pretrained_keras(
             model,

--- a/src/huggingface_hub/repocard.py
+++ b/src/huggingface_hub/repocard.py
@@ -18,7 +18,7 @@ from huggingface_hub.repocard_data import (
 from huggingface_hub.utils import is_jinja_available, yaml_dump
 
 from .constants import REPOCARD_NAME
-from .utils import EntryNotFoundError, TemporaryDirectory, validate_hf_hub_args
+from .utils import EntryNotFoundError, SoftTemporaryDirectory, validate_hf_hub_args
 from .utils._typing import Literal
 from .utils.logging import get_logger
 
@@ -268,7 +268,7 @@ class RepoCard:
         # Validate card before pushing to hub
         self.validate(repo_type=repo_type)
 
-        with TemporaryDirectory() as tmpdir:
+        with SoftTemporaryDirectory() as tmpdir:
             tmp_path = Path(tmpdir) / REPOCARD_NAME
             tmp_path.write_text(str(self))
             url = upload_file(

--- a/src/huggingface_hub/repocard.py
+++ b/src/huggingface_hub/repocard.py
@@ -1,6 +1,5 @@
 import os
 import re
-import sys
 from pathlib import Path
 from typing import Any, Dict, Optional, Type, Union
 

--- a/src/huggingface_hub/repocard.py
+++ b/src/huggingface_hub/repocard.py
@@ -1,15 +1,8 @@
 import os
 import re
 import sys
-import tempfile
 from pathlib import Path
 from typing import Any, Dict, Optional, Type, Union
-
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 import requests
 import yaml
@@ -26,7 +19,8 @@ from huggingface_hub.repocard_data import (
 from huggingface_hub.utils import is_jinja_available, yaml_dump
 
 from .constants import REPOCARD_NAME
-from .utils import EntryNotFoundError, validate_hf_hub_args
+from .utils import EntryNotFoundError, TemporaryDirectory, validate_hf_hub_args
+from .utils._typing import Literal
 from .utils.logging import get_logger
 
 
@@ -275,7 +269,7 @@ class RepoCard:
         # Validate card before pushing to hub
         self.validate(repo_type=repo_type)
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with TemporaryDirectory() as tmpdir:
             tmp_path = Path(tmpdir) / REPOCARD_NAME
             tmp_path.write_text(str(self))
             url = upload_file(

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -16,7 +16,7 @@ from .hf_api import HfApi, repo_type_and_id_from_hf_id
 from .lfs import LFS_MULTIPART_UPLOAD_COMMAND
 from .utils import (
     HfFolder,
-    TemporaryDirectory,
+    SoftTemporaryDirectory,
     logging,
     run_subprocess,
     tqdm,
@@ -407,7 +407,7 @@ def _lfs_log_progress():
 
     current_lfs_progress_value = os.environ.get("GIT_LFS_PROGRESS", "")
 
-    with TemporaryDirectory() as tmpdir:
+    with SoftTemporaryDirectory() as tmpdir:
         os.environ["GIT_LFS_PROGRESS"] = os.path.join(tmpdir, "lfs_progress")
         logger.debug(f"Following progress in {os.environ['GIT_LFS_PROGRESS']}")
 

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -2,7 +2,6 @@ import atexit
 import os
 import re
 import subprocess
-import tempfile
 import threading
 import time
 from contextlib import contextmanager
@@ -15,7 +14,14 @@ from huggingface_hub.repocard import metadata_load, metadata_save
 
 from .hf_api import HfApi, repo_type_and_id_from_hf_id
 from .lfs import LFS_MULTIPART_UPLOAD_COMMAND
-from .utils import HfFolder, logging, run_subprocess, tqdm, validate_hf_hub_args
+from .utils import (
+    HfFolder,
+    TemporaryDirectory,
+    logging,
+    run_subprocess,
+    tqdm,
+    validate_hf_hub_args,
+)
 from .utils._typing import TypedDict
 
 
@@ -401,7 +407,7 @@ def _lfs_log_progress():
 
     current_lfs_progress_value = os.environ.get("GIT_LFS_PROGRESS", "")
 
-    with tempfile.TemporaryDirectory() as tmpdir:
+    with TemporaryDirectory() as tmpdir:
         os.environ["GIT_LFS_PROGRESS"] = os.path.join(tmpdir, "lfs_progress")
         logger.debug(f"Following progress in {os.environ['GIT_LFS_PROGRESS']}")
 

--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -39,7 +39,7 @@ from ._errors import (
     RevisionNotFoundError,
     hf_raise_for_status,
 )
-from ._fixes import TemporaryDirectory, yaml_dump
+from ._fixes import SoftTemporaryDirectory, yaml_dump
 from ._git_credential import (
     erase_from_credential_store,
     list_credential_helpers,

--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -39,7 +39,7 @@ from ._errors import (
     RevisionNotFoundError,
     hf_raise_for_status,
 )
-from ._fixes import yaml_dump
+from ._fixes import TemporaryDirectory, yaml_dump
 from ._git_credential import (
     erase_from_credential_store,
     list_credential_helpers,

--- a/src/huggingface_hub/utils/_fixes.py
+++ b/src/huggingface_hub/utils/_fixes.py
@@ -61,14 +61,19 @@ def TemporaryDirectory(
     try:
         # First once with normal cleanup
         shutil.rmtree(tmpdir.name)
-        tmpdir.cleanup()
     except Exception:
         # If failed, try to set write permission and retry
         try:
             shutil.rmtree(tmpdir.name, onerror=_set_write_permission_and_retry)
         except Exception:
             pass
-        # If failed again, give up but do not throw error
+
+    # And finally, cleanup the tmpdir.
+    # If it fails again, give up but do not throw error
+    try:
+        tmpdir.cleanup()
+    except Exception:
+        pass
 
 
 def _set_write_permission_and_retry(func, path, excinfo):

--- a/src/huggingface_hub/utils/_fixes.py
+++ b/src/huggingface_hub/utils/_fixes.py
@@ -37,7 +37,7 @@ yaml_dump: Callable[..., str] = partial(  # type: ignore
 
 
 @contextlib.contextmanager
-def TemporaryDirectory(
+def SoftTemporaryDirectory(
     suffix: Optional[str] = None,
     prefix: Optional[str] = None,
     dir: Optional[Union[Path, str]] = None,

--- a/src/huggingface_hub/utils/_fixes.py
+++ b/src/huggingface_hub/utils/_fixes.py
@@ -9,8 +9,14 @@ except ImportError:
     except ImportError:
         from json import JSONDecodeError  # type: ignore  # noqa: F401
 
+import contextlib
+import os
+import shutil
+import stat
+import tempfile
 from functools import partial
-from typing import Callable
+from pathlib import Path
+from typing import Callable, Generator, Optional, Union
 
 import yaml
 
@@ -28,3 +34,43 @@ import yaml
 yaml_dump: Callable[..., str] = partial(  # type: ignore
     yaml.dump, stream=None, allow_unicode=True
 )
+
+
+@contextlib.contextmanager
+def TemporaryDirectory(
+    suffix: Optional[str] = None,
+    prefix: Optional[str] = None,
+    dir: Optional[Union[Path, str]] = None,
+    **kwargs,
+) -> Generator[str, None, None]:
+    """
+    Context manager to create a temporary directory and safely delete it.
+
+    If tmp directory cannot be deleted normally, we set the WRITE permission and retry.
+    If cleanup still fails, we give up but don't raise an exception. This is equivalent
+    to  `tempfile.TemporaryDirectory(..., ignore_cleanup_errors=True)` introduced in
+    Python 3.10.
+
+    See https://www.scivision.dev/python-tempfile-permission-error-windows/.
+    """
+    tmpdir = tempfile.TemporaryDirectory(
+        prefix=prefix, suffix=suffix, dir=dir, **kwargs
+    )
+    yield tmpdir.name
+
+    try:
+        # First once with normal cleanup
+        shutil.rmtree(tmpdir.name)
+        tmpdir.cleanup()
+    except Exception:
+        # If failed, try to set write permission and retry
+        try:
+            shutil.rmtree(tmpdir.name, onerror=_set_write_permission_and_retry)
+        except Exception:
+            pass
+        # If failed again, give up but do not throw error
+
+
+def _set_write_permission_and_retry(func, path, excinfo):
+    os.chmod(path, stat.S_IWRITE)
+    func(path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import pytest
 
 from _pytest.fixtures import SubRequest
 from huggingface_hub import HfApi, HfFolder
-from huggingface_hub.utils import TemporaryDirectory
+from huggingface_hub.utils import SoftTemporaryDirectory
 
 from .testing_constants import ENDPOINT_PRODUCTION, PRODUCTION_TOKEN
 from .testing_utils import repo_name
@@ -25,7 +25,7 @@ def fx_cache_dir(request: SubRequest) -> Generator[None, None, None]:
             self.assertTrue(self.cache_dir.is_dir())
     ```
     """
-    with TemporaryDirectory() as cache_dir:
+    with SoftTemporaryDirectory() as cache_dir:
         request.cls.cache_dir = Path(cache_dir).resolve()
         yield
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,11 @@
 from pathlib import Path
-from tempfile import TemporaryDirectory
 from typing import Generator
 
 import pytest
 
 from _pytest.fixtures import SubRequest
 from huggingface_hub import HfApi, HfFolder
+from huggingface_hub.utils import TemporaryDirectory
 
 from .testing_constants import ENDPOINT_PRODUCTION, PRODUCTION_TOKEN
 from .testing_utils import repo_name

--- a/tests/test_cache_layout.py
+++ b/tests/test_cache_layout.py
@@ -4,7 +4,7 @@ import unittest
 from io import BytesIO
 
 from huggingface_hub import HfApi, hf_hub_download, snapshot_download
-from huggingface_hub.utils import TemporaryDirectory, logging
+from huggingface_hub.utils import SoftTemporaryDirectory, logging
 from huggingface_hub.utils._errors import EntryNotFoundError
 
 from .testing_constants import ENDPOINT_STAGING, TOKEN, USER
@@ -29,7 +29,7 @@ class CacheFileLayoutHfHubDownload(unittest.TestCase):
             (None, "main"),
             ("file-2", "file-2"),
         ):
-            with self.subTest(revision), TemporaryDirectory() as cache:
+            with self.subTest(revision), SoftTemporaryDirectory() as cache:
                 hf_hub_download(
                     MODEL_IDENTIFIER,
                     "file_0.txt",
@@ -80,7 +80,7 @@ class CacheFileLayoutHfHubDownload(unittest.TestCase):
         revisions = [None, "file-2"]
         expected_references = ["main", "file-2"]
         for revision, expected_reference in zip(revisions, expected_references):
-            with self.subTest(revision), TemporaryDirectory() as cache:
+            with self.subTest(revision), SoftTemporaryDirectory() as cache:
                 filename = "this_does_not_exist.txt"
                 with self.assertRaises(EntryNotFoundError):
                     # The file does not exist, so we get an exception.
@@ -125,7 +125,7 @@ class CacheFileLayoutHfHubDownload(unittest.TestCase):
     def test_file_download_happens_once(self):
         # Tests that a file is only downloaded once if it's not updated.
 
-        with TemporaryDirectory() as cache:
+        with SoftTemporaryDirectory() as cache:
             path = hf_hub_download(MODEL_IDENTIFIER, "file_0.txt", cache_dir=cache)
             creation_time_0 = os.path.getmtime(path)
 
@@ -139,7 +139,7 @@ class CacheFileLayoutHfHubDownload(unittest.TestCase):
     def test_file_download_happens_once_intra_revision(self):
         # Tests that a file is only downloaded once if it's not updated, even across different revisions.
 
-        with TemporaryDirectory() as cache:
+        with SoftTemporaryDirectory() as cache:
             path = hf_hub_download(MODEL_IDENTIFIER, "file_0.txt", cache_dir=cache)
             creation_time_0 = os.path.getmtime(path)
 
@@ -153,7 +153,7 @@ class CacheFileLayoutHfHubDownload(unittest.TestCase):
             self.assertEqual(creation_time_0, creation_time_1)
 
     def test_multiple_refs_for_same_file(self):
-        with TemporaryDirectory() as cache:
+        with SoftTemporaryDirectory() as cache:
             hf_hub_download(MODEL_IDENTIFIER, "file_0.txt", cache_dir=cache)
             hf_hub_download(
                 MODEL_IDENTIFIER, "file_0.txt", cache_dir=cache, revision="file-2"
@@ -193,7 +193,7 @@ class CacheFileLayoutHfHubDownload(unittest.TestCase):
 @with_production_testing
 class CacheFileLayoutSnapshotDownload(unittest.TestCase):
     def test_file_downloaded_in_cache(self):
-        with TemporaryDirectory() as cache:
+        with SoftTemporaryDirectory() as cache:
             snapshot_download(MODEL_IDENTIFIER, cache_dir=cache)
 
             expected_directory_name = f'models--{MODEL_IDENTIFIER.replace("/", "--")}'
@@ -231,7 +231,7 @@ class CacheFileLayoutSnapshotDownload(unittest.TestCase):
             self.assertTrue(all([os.path.isfile(l) for l in resolved_snapshot_links]))
 
     def test_file_downloaded_in_cache_several_revisions(self):
-        with TemporaryDirectory() as cache:
+        with SoftTemporaryDirectory() as cache:
             snapshot_download(MODEL_IDENTIFIER, cache_dir=cache, revision="file-3")
             snapshot_download(MODEL_IDENTIFIER, cache_dir=cache, revision="file-2")
 
@@ -326,7 +326,7 @@ class ReferenceUpdates(unittest.TestCase):
                 repo_id=repo_id,
             )
 
-            with TemporaryDirectory() as cache:
+            with SoftTemporaryDirectory() as cache:
                 hf_hub_download(repo_id, "file.txt", cache_dir=cache)
 
                 expected_directory_name = f'models--{repo_id.replace("/", "--")}'

--- a/tests/test_cache_layout.py
+++ b/tests/test_cache_layout.py
@@ -1,11 +1,10 @@
 import os
-import tempfile
 import time
 import unittest
 from io import BytesIO
 
 from huggingface_hub import HfApi, hf_hub_download, snapshot_download
-from huggingface_hub.utils import logging
+from huggingface_hub.utils import TemporaryDirectory, logging
 from huggingface_hub.utils._errors import EntryNotFoundError
 
 from .testing_constants import ENDPOINT_STAGING, TOKEN, USER
@@ -30,65 +29,58 @@ class CacheFileLayoutHfHubDownload(unittest.TestCase):
             (None, "main"),
             ("file-2", "file-2"),
         ):
-            with self.subTest(revision), tempfile.TemporaryDirectory() as cache:
-                with tempfile.TemporaryDirectory() as cache:
-                    hf_hub_download(
-                        MODEL_IDENTIFIER,
-                        "file_0.txt",
-                        cache_dir=cache,
-                        revision=revision,
-                    )
+            with self.subTest(revision), TemporaryDirectory() as cache:
+                hf_hub_download(
+                    MODEL_IDENTIFIER,
+                    "file_0.txt",
+                    cache_dir=cache,
+                    revision=revision,
+                )
 
-                    expected_directory_name = (
-                        f'models--{MODEL_IDENTIFIER.replace("/", "--")}'
-                    )
-                    expected_path = os.path.join(cache, expected_directory_name)
+                expected_directory_name = (
+                    f'models--{MODEL_IDENTIFIER.replace("/", "--")}'
+                )
+                expected_path = os.path.join(cache, expected_directory_name)
 
-                    refs = os.listdir(os.path.join(expected_path, "refs"))
-                    snapshots = os.listdir(os.path.join(expected_path, "snapshots"))
+                refs = os.listdir(os.path.join(expected_path, "refs"))
+                snapshots = os.listdir(os.path.join(expected_path, "snapshots"))
 
-                    # Only reference should be the expected one.
-                    self.assertListEqual(refs, [expected_reference])
+                # Only reference should be the expected one.
+                self.assertListEqual(refs, [expected_reference])
 
-                    with open(
-                        os.path.join(expected_path, "refs", expected_reference)
-                    ) as f:
-                        snapshot_name = f.readline().strip()
+                with open(os.path.join(expected_path, "refs", expected_reference)) as f:
+                    snapshot_name = f.readline().strip()
 
-                    # The `main` reference should point to the only snapshot we have downloaded
-                    self.assertListEqual(snapshots, [snapshot_name])
+                # The `main` reference should point to the only snapshot we have downloaded
+                self.assertListEqual(snapshots, [snapshot_name])
 
-                    snapshot_path = os.path.join(
-                        expected_path, "snapshots", snapshot_name
-                    )
-                    snapshot_content = os.listdir(snapshot_path)
+                snapshot_path = os.path.join(expected_path, "snapshots", snapshot_name)
+                snapshot_content = os.listdir(snapshot_path)
 
-                    # Only a single file in the snapshot
-                    self.assertEqual(len(snapshot_content), 1)
+                # Only a single file in the snapshot
+                self.assertEqual(len(snapshot_content), 1)
 
-                    snapshot_content_path = os.path.join(
-                        snapshot_path, snapshot_content[0]
-                    )
+                snapshot_content_path = os.path.join(snapshot_path, snapshot_content[0])
 
-                    # The snapshot content should link to a blob
-                    self.assertTrue(os.path.islink(snapshot_content_path))
+                # The snapshot content should link to a blob
+                self.assertTrue(os.path.islink(snapshot_content_path))
 
-                    resolved_blob_relative = os.readlink(snapshot_content_path)
-                    resolved_blob_absolute = os.path.normpath(
-                        os.path.join(snapshot_path, resolved_blob_relative)
-                    )
+                resolved_blob_relative = os.readlink(snapshot_content_path)
+                resolved_blob_absolute = os.path.normpath(
+                    os.path.join(snapshot_path, resolved_blob_relative)
+                )
 
-                    with open(resolved_blob_absolute) as f:
-                        blob_contents = f.readline().strip()
+                with open(resolved_blob_absolute) as f:
+                    blob_contents = f.readline().strip()
 
-                    # The contents of the file should be 'File 0'.
-                    self.assertEqual(blob_contents, "File 0")
+                # The contents of the file should be 'File 0'.
+                self.assertEqual(blob_contents, "File 0")
 
     def test_no_exist_file_is_cached(self):
         revisions = [None, "file-2"]
         expected_references = ["main", "file-2"]
         for revision, expected_reference in zip(revisions, expected_references):
-            with self.subTest(revision), tempfile.TemporaryDirectory() as cache:
+            with self.subTest(revision), TemporaryDirectory() as cache:
                 filename = "this_does_not_exist.txt"
                 with self.assertRaises(EntryNotFoundError):
                     # The file does not exist, so we get an exception.
@@ -133,7 +125,7 @@ class CacheFileLayoutHfHubDownload(unittest.TestCase):
     def test_file_download_happens_once(self):
         # Tests that a file is only downloaded once if it's not updated.
 
-        with tempfile.TemporaryDirectory() as cache:
+        with TemporaryDirectory() as cache:
             path = hf_hub_download(MODEL_IDENTIFIER, "file_0.txt", cache_dir=cache)
             creation_time_0 = os.path.getmtime(path)
 
@@ -147,7 +139,7 @@ class CacheFileLayoutHfHubDownload(unittest.TestCase):
     def test_file_download_happens_once_intra_revision(self):
         # Tests that a file is only downloaded once if it's not updated, even across different revisions.
 
-        with tempfile.TemporaryDirectory() as cache:
+        with TemporaryDirectory() as cache:
             path = hf_hub_download(MODEL_IDENTIFIER, "file_0.txt", cache_dir=cache)
             creation_time_0 = os.path.getmtime(path)
 
@@ -161,7 +153,7 @@ class CacheFileLayoutHfHubDownload(unittest.TestCase):
             self.assertEqual(creation_time_0, creation_time_1)
 
     def test_multiple_refs_for_same_file(self):
-        with tempfile.TemporaryDirectory() as cache:
+        with TemporaryDirectory() as cache:
             hf_hub_download(MODEL_IDENTIFIER, "file_0.txt", cache_dir=cache)
             hf_hub_download(
                 MODEL_IDENTIFIER, "file_0.txt", cache_dir=cache, revision="file-2"
@@ -201,7 +193,7 @@ class CacheFileLayoutHfHubDownload(unittest.TestCase):
 @with_production_testing
 class CacheFileLayoutSnapshotDownload(unittest.TestCase):
     def test_file_downloaded_in_cache(self):
-        with tempfile.TemporaryDirectory() as cache:
+        with TemporaryDirectory() as cache:
             snapshot_download(MODEL_IDENTIFIER, cache_dir=cache)
 
             expected_directory_name = f'models--{MODEL_IDENTIFIER.replace("/", "--")}'
@@ -239,7 +231,7 @@ class CacheFileLayoutSnapshotDownload(unittest.TestCase):
             self.assertTrue(all([os.path.isfile(l) for l in resolved_snapshot_links]))
 
     def test_file_downloaded_in_cache_several_revisions(self):
-        with tempfile.TemporaryDirectory() as cache:
+        with TemporaryDirectory() as cache:
             snapshot_download(MODEL_IDENTIFIER, cache_dir=cache, revision="file-3")
             snapshot_download(MODEL_IDENTIFIER, cache_dir=cache, revision="file-2")
 
@@ -334,7 +326,7 @@ class ReferenceUpdates(unittest.TestCase):
                 repo_id=repo_id,
             )
 
-            with tempfile.TemporaryDirectory() as cache:
+            with TemporaryDirectory() as cache:
                 hf_hub_download(repo_id, "file.txt", cache_dir=cache)
 
                 expected_directory_name = f'models--{repo_id.replace("/", "--")}'

--- a/tests/test_command_delete_cache.py
+++ b/tests/test_command_delete_cache.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 from pathlib import Path
-from tempfile import TemporaryDirectory, mkstemp
+from tempfile import mkstemp
 from unittest.mock import Mock, patch
 
 from huggingface_hub.commands.delete_cache import (
@@ -13,6 +13,7 @@ from huggingface_hub.commands.delete_cache import (
     _manual_review_no_tui,
     _read_manual_review_tmp_file,
 )
+from huggingface_hub.utils import TemporaryDirectory
 from InquirerPy.base.control import Choice
 from InquirerPy.separator import Separator
 

--- a/tests/test_command_delete_cache.py
+++ b/tests/test_command_delete_cache.py
@@ -13,7 +13,7 @@ from huggingface_hub.commands.delete_cache import (
     _manual_review_no_tui,
     _read_manual_review_tmp_file,
 )
-from huggingface_hub.utils import TemporaryDirectory
+from huggingface_hub.utils import SoftTemporaryDirectory
 from InquirerPy.base.control import Choice
 from InquirerPy.separator import Separator
 
@@ -122,7 +122,7 @@ class TestDeleteCacheHelpers(unittest.TestCase):
     def test_read_manual_review_tmp_file(self) -> None:
         """Test `_read_manual_review_tmp_file`."""
 
-        with TemporaryDirectory() as tmp_dir:
+        with SoftTemporaryDirectory() as tmp_dir:
             tmp_path = Path(tmp_dir) / "file.txt"
 
             with tmp_path.open("w") as f:

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -16,7 +16,6 @@ import re
 import stat
 import unittest
 from pathlib import Path
-from tempfile import TemporaryDirectory
 from unittest.mock import Mock, patch
 
 import pytest
@@ -42,6 +41,7 @@ from huggingface_hub.utils import (
     LocalEntryNotFoundError,
     RepositoryNotFoundError,
     RevisionNotFoundError,
+    TemporaryDirectory,
 )
 from tests.testing_constants import TOKEN
 

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -41,7 +41,7 @@ from huggingface_hub.utils import (
     LocalEntryNotFoundError,
     RepositoryNotFoundError,
     RevisionNotFoundError,
-    TemporaryDirectory,
+    SoftTemporaryDirectory,
 )
 from tests.testing_constants import TOKEN
 
@@ -114,7 +114,7 @@ class CachedDownloadTests(unittest.TestCase):
 
     def test_file_not_found_locally_and_network_disabled(self):
         # Valid file but missing locally and network is disabled.
-        with TemporaryDirectory() as tmpdir:
+        with SoftTemporaryDirectory() as tmpdir:
             # Download a first time to get the refs ok
             filepath = hf_hub_download(
                 DUMMY_MODEL_ID,
@@ -138,7 +138,7 @@ class CachedDownloadTests(unittest.TestCase):
     def test_file_not_found_locally_and_network_disabled_legacy(self):
         # Valid file but missing locally and network is disabled.
         url = hf_hub_url(DUMMY_MODEL_ID, filename=CONFIG_NAME)
-        with TemporaryDirectory() as tmpdir:
+        with SoftTemporaryDirectory() as tmpdir:
             # Get without network must fail
             with pytest.raises(LocalEntryNotFoundError):
                 cached_download(
@@ -154,7 +154,7 @@ class CachedDownloadTests(unittest.TestCase):
         Regression test for https://github.com/huggingface/huggingface_hub/issues/1216.
         """
         # Valid file but missing locally and network is disabled.
-        with TemporaryDirectory() as tmpdir:
+        with SoftTemporaryDirectory() as tmpdir:
             # Download a first time to get the refs ok
             hf_hub_download(DUMMY_MODEL_ID, filename=CONFIG_NAME, cache_dir=tmpdir)
 
@@ -250,7 +250,7 @@ class CachedDownloadTests(unittest.TestCase):
         https://github.com/huggingface/huggingface_hub/issues/1141
         https://github.com/huggingface/huggingface_hub/issues/1215
         """
-        with TemporaryDirectory() as tmpdir:
+        with SoftTemporaryDirectory() as tmpdir:
             # Equivalent to umask u=rwx,g=r,o=
             previous_umask = os.umask(0o037)
             try:
@@ -268,7 +268,7 @@ class CachedDownloadTests(unittest.TestCase):
         Regression test for #981.
         https://github.com/huggingface/huggingface_hub/issues/981
         """
-        with TemporaryDirectory() as tmpdir:
+        with SoftTemporaryDirectory() as tmpdir:
             filepath = hf_hub_download(
                 DUMMY_RENAMED_OLD_MODEL_ID, "config.json", cache_dir=tmpdir
             )
@@ -281,7 +281,7 @@ class CachedDownloadTests(unittest.TestCase):
         https://github.com/huggingface/huggingface_hub/issues/981
         """
         with pytest.warns(FutureWarning):
-            with TemporaryDirectory() as tmpdir:
+            with SoftTemporaryDirectory() as tmpdir:
                 filepath = cached_download(
                     hf_hub_url(
                         DUMMY_RENAMED_OLD_MODEL_ID,
@@ -434,7 +434,7 @@ class StagingCachedDownloadTest(unittest.TestCase):
         Regression test for #1121.
         https://github.com/huggingface/huggingface_hub/pull/1121
         """
-        with TemporaryDirectory() as tmpdir:
+        with SoftTemporaryDirectory() as tmpdir:
             with self.assertRaisesRegex(
                 GatedRepoError,
                 "Access to model .* is restricted and you are not in the authorized"
@@ -496,7 +496,7 @@ class CreateSymlinkTest(unittest.TestCase):
     def test_create_relative_symlink_concurrent_access(
         self, mock_are_symlinks_supported: Mock
     ) -> None:
-        with TemporaryDirectory() as tmpdir:
+        with SoftTemporaryDirectory() as tmpdir:
             src = os.path.join(tmpdir, "source")
             other = os.path.join(tmpdir, "other")
             dst = os.path.join(tmpdir, "destination")

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -15,6 +15,7 @@ import os
 import re
 import shutil
 import subprocess
+import tempfile
 import time
 import types
 import unittest

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -15,7 +15,6 @@ import os
 import re
 import shutil
 import subprocess
-import tempfile
 import time
 import types
 import unittest
@@ -68,6 +67,7 @@ from huggingface_hub.utils import (
     HfHubHTTPError,
     RepositoryNotFoundError,
     RevisionNotFoundError,
+    TemporaryDirectory,
     logging,
 )
 from huggingface_hub.utils.endpoint_helpers import (
@@ -793,7 +793,7 @@ class CommitApiTest(HfApiCommonTestWithLogin):
 
         # Create repo and create a non-main branch
         self._api.create_repo(repo_id=repo_id, exist_ok=False)
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with TemporaryDirectory() as tmpdir:
             repo = Repository(local_dir=tmpdir, clone_from=repo_id, token=TOKEN)
             repo.git_checkout("test_branch", create_branch_ok=True)
             head = repo.git_head_hash()

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -68,7 +68,7 @@ from huggingface_hub.utils import (
     HfHubHTTPError,
     RepositoryNotFoundError,
     RevisionNotFoundError,
-    TemporaryDirectory,
+    SoftTemporaryDirectory,
     logging,
 )
 from huggingface_hub.utils.endpoint_helpers import (
@@ -794,7 +794,7 @@ class CommitApiTest(HfApiCommonTestWithLogin):
 
         # Create repo and create a non-main branch
         self._api.create_repo(repo_id=repo_id, exist_ok=False)
-        with TemporaryDirectory() as tmpdir:
+        with SoftTemporaryDirectory() as tmpdir:
             repo = Repository(local_dir=tmpdir, clone_from=repo_id, token=TOKEN)
             repo.git_checkout("test_branch", create_branch_ok=True)
             head = repo.git_head_hash()

--- a/tests/test_keras_integration.py
+++ b/tests/test_keras_integration.py
@@ -2,7 +2,6 @@ import json
 import os
 import re
 import shutil
-import tempfile
 import unittest
 
 import pytest
@@ -16,6 +15,7 @@ from huggingface_hub.keras_mixin import (
 )
 from huggingface_hub.repository import Repository
 from huggingface_hub.utils import (
+    TemporaryDirectory,
     is_graphviz_available,
     is_pydot_available,
     is_tf_available,
@@ -253,7 +253,7 @@ class HubKerasSequentialTest(CommonKerasTest):
         REPO_NAME = repo_name("save")
         model = self.model_init()
         model = self.model_fit(model)
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with TemporaryDirectory() as tmpdirname:
             os.makedirs(f"{tmpdirname}/{WORKING_REPO_DIR}/{REPO_NAME}")
             with open(
                 f"{tmpdirname}/{WORKING_REPO_DIR}/{REPO_NAME}/history.json", "w+"
@@ -422,7 +422,7 @@ class HubKerasSequentialTest(CommonKerasTest):
         """Test log directory is overwritten when pushing a keras model a 2nd time."""
         REPO_NAME = repo_name("PUSH_TO_HUB_KERAS_via_http_override_tensorboard")
         repo_id = f"{USER}/{REPO_NAME}"
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with TemporaryDirectory() as tmpdirname:
             os.makedirs(f"{tmpdirname}/tb_log_dir")
             with open(f"{tmpdirname}/tb_log_dir/tensorboard.txt", "w") as fp:
                 fp.write("Keras FTW")
@@ -476,7 +476,7 @@ class HubKerasSequentialTest(CommonKerasTest):
         model_info = HfApi(endpoint=ENDPOINT_STAGING).model_info(repo_id)
         self.assertEqual(model_info.modelId, repo_id)
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with TemporaryDirectory() as tmpdirname:
             Repository(
                 local_dir=tmpdirname, clone_from=ENDPOINT_STAGING + "/" + repo_id
             )

--- a/tests/test_keras_integration.py
+++ b/tests/test_keras_integration.py
@@ -15,7 +15,7 @@ from huggingface_hub.keras_mixin import (
 )
 from huggingface_hub.repository import Repository
 from huggingface_hub.utils import (
-    TemporaryDirectory,
+    SoftTemporaryDirectory,
     is_graphviz_available,
     is_pydot_available,
     is_tf_available,
@@ -253,7 +253,7 @@ class HubKerasSequentialTest(CommonKerasTest):
         REPO_NAME = repo_name("save")
         model = self.model_init()
         model = self.model_fit(model)
-        with TemporaryDirectory() as tmpdirname:
+        with SoftTemporaryDirectory() as tmpdirname:
             os.makedirs(f"{tmpdirname}/{WORKING_REPO_DIR}/{REPO_NAME}")
             with open(
                 f"{tmpdirname}/{WORKING_REPO_DIR}/{REPO_NAME}/history.json", "w+"
@@ -422,7 +422,7 @@ class HubKerasSequentialTest(CommonKerasTest):
         """Test log directory is overwritten when pushing a keras model a 2nd time."""
         REPO_NAME = repo_name("PUSH_TO_HUB_KERAS_via_http_override_tensorboard")
         repo_id = f"{USER}/{REPO_NAME}"
-        with TemporaryDirectory() as tmpdirname:
+        with SoftTemporaryDirectory() as tmpdirname:
             os.makedirs(f"{tmpdirname}/tb_log_dir")
             with open(f"{tmpdirname}/tb_log_dir/tensorboard.txt", "w") as fp:
                 fp.write("Keras FTW")
@@ -476,7 +476,7 @@ class HubKerasSequentialTest(CommonKerasTest):
         model_info = HfApi(endpoint=ENDPOINT_STAGING).model_info(repo_id)
         self.assertEqual(model_info.modelId, repo_id)
 
-        with TemporaryDirectory() as tmpdirname:
+        with SoftTemporaryDirectory() as tmpdirname:
             Repository(
                 local_dir=tmpdirname, clone_from=ENDPOINT_STAGING + "/" + repo_id
             )

--- a/tests/test_lfs.py
+++ b/tests/test_lfs.py
@@ -2,9 +2,9 @@ import os
 import unittest
 from hashlib import sha256
 from io import BytesIO
-from tempfile import TemporaryDirectory
 
 from huggingface_hub.lfs import SliceFileObj, UploadInfo
+from huggingface_hub.utils import TemporaryDirectory
 
 
 class TestUploadInfo(unittest.TestCase):

--- a/tests/test_lfs.py
+++ b/tests/test_lfs.py
@@ -4,7 +4,7 @@ from hashlib import sha256
 from io import BytesIO
 
 from huggingface_hub.lfs import SliceFileObj, UploadInfo
-from huggingface_hub.utils import TemporaryDirectory
+from huggingface_hub.utils import SoftTemporaryDirectory
 
 
 class TestUploadInfo(unittest.TestCase):
@@ -15,7 +15,7 @@ class TestUploadInfo(unittest.TestCase):
         self.sample = self.content[:512]
 
     def test_upload_info_from_path(self):
-        with TemporaryDirectory() as tmpdir:
+        with SoftTemporaryDirectory() as tmpdir:
             filepath = os.path.join(tmpdir, "file.bin")
             with open(filepath, "wb+") as file:
                 file.write(self.content)
@@ -111,7 +111,7 @@ class TestSliceFileObj(unittest.TestCase):
     def test_slice_fileobj_file(self):
         self.content = b"RANDOM self.content uauabciabeubahveb" * 1024
 
-        with TemporaryDirectory() as tmpdir:
+        with SoftTemporaryDirectory() as tmpdir:
             filepath = os.path.join(tmpdir, "file.bin")
             with open(filepath, "wb+") as f:
                 f.write(self.content)

--- a/tests/test_repocard.py
+++ b/tests/test_repocard.py
@@ -41,7 +41,7 @@ from huggingface_hub.hf_api import HfApi
 from huggingface_hub.repocard import RepoCard
 from huggingface_hub.repocard_data import CardData
 from huggingface_hub.repository import Repository
-from huggingface_hub.utils import TemporaryDirectory, is_jinja_available, logging
+from huggingface_hub.utils import SoftTemporaryDirectory, is_jinja_available, logging
 
 from .testing_constants import (
     ENDPOINT_STAGING,
@@ -601,7 +601,7 @@ class RepoCardTest(TestCaseWithCapLog):
         card = RepoCard.load(sample_path)
         card.data.language = ["fr"]
 
-        with TemporaryDirectory() as tempdir:
+        with SoftTemporaryDirectory() as tempdir:
             updated_card_path = Path(tempdir) / "updated.md"
             card.save(updated_card_path)
 

--- a/tests/test_repocard.py
+++ b/tests/test_repocard.py
@@ -41,7 +41,7 @@ from huggingface_hub.hf_api import HfApi
 from huggingface_hub.repocard import RepoCard
 from huggingface_hub.repocard_data import CardData
 from huggingface_hub.repository import Repository
-from huggingface_hub.utils import is_jinja_available, logging
+from huggingface_hub.utils import TemporaryDirectory, is_jinja_available, logging
 
 from .testing_constants import (
     ENDPOINT_STAGING,
@@ -601,7 +601,7 @@ class RepoCardTest(TestCaseWithCapLog):
         card = RepoCard.load(sample_path)
         card.data.language = ["fr"]
 
-        with tempfile.TemporaryDirectory() as tempdir:
+        with TemporaryDirectory() as tempdir:
             updated_card_path = Path(tempdir) / "updated.md"
             card.save(updated_card_path)
 

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -29,7 +29,7 @@ from huggingface_hub.repository import (
     is_tracked_upstream,
     is_tracked_with_lfs,
 )
-from huggingface_hub.utils import TemporaryDirectory, logging
+from huggingface_hub.utils import SoftTemporaryDirectory, logging
 
 from .testing_constants import ENDPOINT_STAGING, TOKEN, USER
 from .testing_utils import (
@@ -146,7 +146,7 @@ class RepositoryTest(RepositoryCommonTest):
         repo.git_pull()
 
     def test_init_failure(self):
-        with TemporaryDirectory() as tmpdirname:
+        with SoftTemporaryDirectory() as tmpdirname:
             with self.assertRaises(ValueError):
                 _ = Repository(tmpdirname)
 
@@ -622,7 +622,7 @@ class RepositoryTest(RepositoryCommonTest):
             with open("new_file.txt", "w+") as f:
                 f.write("Ok")
 
-        with TemporaryDirectory() as tmp:
+        with SoftTemporaryDirectory() as tmp:
             clone = Repository(
                 tmp,
                 clone_from=f"{USER}/{self.REPO_NAME}",
@@ -663,7 +663,7 @@ class RepositoryTest(RepositoryCommonTest):
 
         repo.push_to_hub("Commit #2")
 
-        with TemporaryDirectory() as tmp:
+        with SoftTemporaryDirectory() as tmp:
             clone = Repository(
                 tmp,
                 clone_from=f"{USER}/{self.REPO_NAME}",
@@ -704,7 +704,7 @@ class RepositoryTest(RepositoryCommonTest):
             with open(os.path.join(repo.local_dir, "new_file-2.txt"), "w+") as f:
                 f.write("Ok")
 
-        with TemporaryDirectory() as tmp:
+        with SoftTemporaryDirectory() as tmp:
             clone = Repository(
                 tmp,
                 clone_from=f"{USER}/{self.REPO_NAME}",

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -16,7 +16,6 @@ import os
 import pathlib
 import shutil
 import subprocess
-import tempfile
 import time
 import unittest
 import uuid
@@ -30,7 +29,7 @@ from huggingface_hub.repository import (
     is_tracked_upstream,
     is_tracked_with_lfs,
 )
-from huggingface_hub.utils import logging
+from huggingface_hub.utils import TemporaryDirectory, logging
 
 from .testing_constants import ENDPOINT_STAGING, TOKEN, USER
 from .testing_utils import (
@@ -147,7 +146,7 @@ class RepositoryTest(RepositoryCommonTest):
         repo.git_pull()
 
     def test_init_failure(self):
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with TemporaryDirectory() as tmpdirname:
             with self.assertRaises(ValueError):
                 _ = Repository(tmpdirname)
 
@@ -623,7 +622,7 @@ class RepositoryTest(RepositoryCommonTest):
             with open("new_file.txt", "w+") as f:
                 f.write("Ok")
 
-        with tempfile.TemporaryDirectory() as tmp:
+        with TemporaryDirectory() as tmp:
             clone = Repository(
                 tmp,
                 clone_from=f"{USER}/{self.REPO_NAME}",
@@ -664,7 +663,7 @@ class RepositoryTest(RepositoryCommonTest):
 
         repo.push_to_hub("Commit #2")
 
-        with tempfile.TemporaryDirectory() as tmp:
+        with TemporaryDirectory() as tmp:
             clone = Repository(
                 tmp,
                 clone_from=f"{USER}/{self.REPO_NAME}",
@@ -705,7 +704,7 @@ class RepositoryTest(RepositoryCommonTest):
             with open(os.path.join(repo.local_dir, "new_file-2.txt"), "w+") as f:
                 f.write("Ok")
 
-        with tempfile.TemporaryDirectory() as tmp:
+        with TemporaryDirectory() as tmp:
             clone = Repository(
                 tmp,
                 clone_from=f"{USER}/{self.REPO_NAME}",

--- a/tests/test_snapshot_download.py
+++ b/tests/test_snapshot_download.py
@@ -7,7 +7,7 @@ from huggingface_hub import HfApi, Repository, snapshot_download
 from huggingface_hub.utils import (
     HfFolder,
     RepositoryNotFoundError,
-    TemporaryDirectory,
+    SoftTemporaryDirectory,
     logging,
 )
 
@@ -83,7 +83,7 @@ class SnapshotDownloadTests(unittest.TestCase):
 
     def test_download_model(self):
         # Test `main` branch
-        with TemporaryDirectory() as tmpdirname:
+        with SoftTemporaryDirectory() as tmpdirname:
             storage_folder = snapshot_download(
                 f"{USER}/{REPO_NAME}", revision="main", cache_dir=tmpdirname
             )
@@ -103,7 +103,7 @@ class SnapshotDownloadTests(unittest.TestCase):
             self.assertTrue(self.second_commit_hash in storage_folder)
 
         # Test with specific revision
-        with TemporaryDirectory() as tmpdirname:
+        with SoftTemporaryDirectory() as tmpdirname:
             storage_folder = snapshot_download(
                 f"{USER}/{REPO_NAME}",
                 revision=self.first_commit_hash,
@@ -127,7 +127,7 @@ class SnapshotDownloadTests(unittest.TestCase):
         self._api.update_repo_visibility(repo_id=REPO_NAME, private=True)
 
         # Test download fails without token
-        with TemporaryDirectory() as tmpdirname:
+        with SoftTemporaryDirectory() as tmpdirname:
             with self.assertRaisesRegex(
                 requests.exceptions.HTTPError, "401 Client Error"
             ):
@@ -136,7 +136,7 @@ class SnapshotDownloadTests(unittest.TestCase):
                 )
 
         # Test we can download with token from cache
-        with TemporaryDirectory() as tmpdirname:
+        with SoftTemporaryDirectory() as tmpdirname:
             HfFolder.save_token(self._token)
             storage_folder = snapshot_download(
                 f"{USER}/{REPO_NAME}",
@@ -160,7 +160,7 @@ class SnapshotDownloadTests(unittest.TestCase):
             self.assertTrue(self.second_commit_hash in storage_folder)
 
         # Test we can download with explicit token
-        with TemporaryDirectory() as tmpdirname:
+        with SoftTemporaryDirectory() as tmpdirname:
             storage_folder = snapshot_download(
                 f"{USER}/{REPO_NAME}",
                 revision="main",
@@ -186,7 +186,7 @@ class SnapshotDownloadTests(unittest.TestCase):
 
     def test_download_model_local_only(self):
         # Test no branch specified
-        with TemporaryDirectory() as tmpdirname:
+        with SoftTemporaryDirectory() as tmpdirname:
             # first download folder to cache it
             snapshot_download(f"{USER}/{REPO_NAME}", cache_dir=tmpdirname)
 
@@ -212,7 +212,7 @@ class SnapshotDownloadTests(unittest.TestCase):
             self.assertTrue(self.second_commit_hash in storage_folder)
 
         # Test with specific revision branch
-        with TemporaryDirectory() as tmpdirname:
+        with SoftTemporaryDirectory() as tmpdirname:
             # first download folder to cache it
             snapshot_download(
                 f"{USER}/{REPO_NAME}",
@@ -242,7 +242,7 @@ class SnapshotDownloadTests(unittest.TestCase):
             self.assertTrue(self.third_commit_hash in storage_folder)
 
         # Test with specific revision hash
-        with TemporaryDirectory() as tmpdirname:
+        with SoftTemporaryDirectory() as tmpdirname:
             # first download folder to cache it
             snapshot_download(
                 f"{USER}/{REPO_NAME}",
@@ -273,7 +273,7 @@ class SnapshotDownloadTests(unittest.TestCase):
 
     def test_download_model_local_only_multiple(self):
         # Test `main` branch
-        with TemporaryDirectory() as tmpdirname:
+        with SoftTemporaryDirectory() as tmpdirname:
             # download both from branch and from commit
             snapshot_download(
                 f"{USER}/{REPO_NAME}",
@@ -287,7 +287,7 @@ class SnapshotDownloadTests(unittest.TestCase):
             )
 
         # cache multiple commits and make sure correct commit is taken
-        with TemporaryDirectory() as tmpdirname:
+        with SoftTemporaryDirectory() as tmpdirname:
             # first download folder to cache it
             snapshot_download(
                 f"{USER}/{REPO_NAME}",
@@ -326,7 +326,7 @@ class SnapshotDownloadTests(unittest.TestCase):
         allow_patterns = pattern if allow else None
         ignore_patterns = pattern if not allow else None
 
-        with TemporaryDirectory() as tmpdirname:
+        with SoftTemporaryDirectory() as tmpdirname:
             storage_folder = snapshot_download(
                 f"{USER}/{REPO_NAME}",
                 revision="main",

--- a/tests/test_snapshot_download.py
+++ b/tests/test_snapshot_download.py
@@ -1,11 +1,15 @@
 import os
 import shutil
-import tempfile
 import unittest
 
 import requests
 from huggingface_hub import HfApi, Repository, snapshot_download
-from huggingface_hub.utils import HfFolder, RepositoryNotFoundError, logging
+from huggingface_hub.utils import (
+    HfFolder,
+    RepositoryNotFoundError,
+    TemporaryDirectory,
+    logging,
+)
 
 from .testing_constants import ENDPOINT_STAGING, TOKEN, USER
 from .testing_utils import (
@@ -79,7 +83,7 @@ class SnapshotDownloadTests(unittest.TestCase):
 
     def test_download_model(self):
         # Test `main` branch
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with TemporaryDirectory() as tmpdirname:
             storage_folder = snapshot_download(
                 f"{USER}/{REPO_NAME}", revision="main", cache_dir=tmpdirname
             )
@@ -99,7 +103,7 @@ class SnapshotDownloadTests(unittest.TestCase):
             self.assertTrue(self.second_commit_hash in storage_folder)
 
         # Test with specific revision
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with TemporaryDirectory() as tmpdirname:
             storage_folder = snapshot_download(
                 f"{USER}/{REPO_NAME}",
                 revision=self.first_commit_hash,
@@ -123,7 +127,7 @@ class SnapshotDownloadTests(unittest.TestCase):
         self._api.update_repo_visibility(repo_id=REPO_NAME, private=True)
 
         # Test download fails without token
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with TemporaryDirectory() as tmpdirname:
             with self.assertRaisesRegex(
                 requests.exceptions.HTTPError, "401 Client Error"
             ):
@@ -132,7 +136,7 @@ class SnapshotDownloadTests(unittest.TestCase):
                 )
 
         # Test we can download with token from cache
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with TemporaryDirectory() as tmpdirname:
             HfFolder.save_token(self._token)
             storage_folder = snapshot_download(
                 f"{USER}/{REPO_NAME}",
@@ -156,7 +160,7 @@ class SnapshotDownloadTests(unittest.TestCase):
             self.assertTrue(self.second_commit_hash in storage_folder)
 
         # Test we can download with explicit token
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with TemporaryDirectory() as tmpdirname:
             storage_folder = snapshot_download(
                 f"{USER}/{REPO_NAME}",
                 revision="main",
@@ -182,7 +186,7 @@ class SnapshotDownloadTests(unittest.TestCase):
 
     def test_download_model_local_only(self):
         # Test no branch specified
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with TemporaryDirectory() as tmpdirname:
             # first download folder to cache it
             snapshot_download(f"{USER}/{REPO_NAME}", cache_dir=tmpdirname)
 
@@ -208,7 +212,7 @@ class SnapshotDownloadTests(unittest.TestCase):
             self.assertTrue(self.second_commit_hash in storage_folder)
 
         # Test with specific revision branch
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with TemporaryDirectory() as tmpdirname:
             # first download folder to cache it
             snapshot_download(
                 f"{USER}/{REPO_NAME}",
@@ -238,7 +242,7 @@ class SnapshotDownloadTests(unittest.TestCase):
             self.assertTrue(self.third_commit_hash in storage_folder)
 
         # Test with specific revision hash
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with TemporaryDirectory() as tmpdirname:
             # first download folder to cache it
             snapshot_download(
                 f"{USER}/{REPO_NAME}",
@@ -269,7 +273,7 @@ class SnapshotDownloadTests(unittest.TestCase):
 
     def test_download_model_local_only_multiple(self):
         # Test `main` branch
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with TemporaryDirectory() as tmpdirname:
             # download both from branch and from commit
             snapshot_download(
                 f"{USER}/{REPO_NAME}",
@@ -283,7 +287,7 @@ class SnapshotDownloadTests(unittest.TestCase):
             )
 
         # cache multiple commits and make sure correct commit is taken
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with TemporaryDirectory() as tmpdirname:
             # first download folder to cache it
             snapshot_download(
                 f"{USER}/{REPO_NAME}",
@@ -322,7 +326,7 @@ class SnapshotDownloadTests(unittest.TestCase):
         allow_patterns = pattern if allow else None
         ignore_patterns = pattern if not allow else None
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with TemporaryDirectory() as tmpdirname:
             storage_folder = snapshot_download(
                 f"{USER}/{REPO_NAME}",
                 revision="main",

--- a/tests/test_utils_fixes.py
+++ b/tests/test_utils_fixes.py
@@ -1,7 +1,7 @@
 import unittest
 from pathlib import Path
 
-from huggingface_hub.utils import TemporaryDirectory, yaml_dump
+from huggingface_hub.utils import SoftTemporaryDirectory, yaml_dump
 
 
 class TestYamlDump(unittest.TestCase):
@@ -19,7 +19,7 @@ class TestYamlDump(unittest.TestCase):
 
 class TestTemporaryDirectory(unittest.TestCase):
     def test_temporary_directory(self) -> None:
-        with TemporaryDirectory(prefix="prefix", suffix="suffix") as tmpdir:
+        with SoftTemporaryDirectory(prefix="prefix", suffix="suffix") as tmpdir:
             self.assertIsInstance(tmpdir, str)
             path = Path(tmpdir)
             self.assertTrue(path.name.startswith("prefix"))

--- a/tests/test_utils_fixes.py
+++ b/tests/test_utils_fixes.py
@@ -1,6 +1,7 @@
 import unittest
+from pathlib import Path
 
-from huggingface_hub.utils import yaml_dump
+from huggingface_hub.utils import TemporaryDirectory, yaml_dump
 
 
 class TestYamlDump(unittest.TestCase):
@@ -14,3 +15,15 @@ class TestYamlDump(unittest.TestCase):
         self.assertEqual(
             yaml_dump({"emoji": "👀"}, allow_unicode=False), 'emoji: "\\U0001F440"\n'
         )
+
+
+class TestTemporaryDirectory(unittest.TestCase):
+    def test_temporary_directory(self) -> None:
+        with TemporaryDirectory(prefix="prefix", suffix="suffix") as tmpdir:
+            self.assertIsInstance(tmpdir, str)
+            path = Path(tmpdir)
+            self.assertTrue(path.name.startswith("prefix"))
+            self.assertTrue(path.name.endswith("suffix"))
+            self.assertTrue(path.is_dir())
+        # Tmpdir is deleted
+        self.assertFalse(path.is_dir())

--- a/tests/test_utils_hf_folder.py
+++ b/tests/test_utils_hf_folder.py
@@ -13,13 +13,12 @@
 # limitations under the License.
 """Contain tests for `HfFolder` utility."""
 import os
-import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import patch
 from uuid import uuid4
 
-from huggingface_hub.utils import HfFolder
+from huggingface_hub.utils import HfFolder, TemporaryDirectory
 
 
 def _generate_token() -> str:
@@ -48,7 +47,7 @@ class HfFolderTest(unittest.TestCase):
     def test_token_in_old_path(self):
         token = _generate_token()
         token2 = _generate_token()
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with TemporaryDirectory() as tmpdir:
             path_token = Path(tmpdir) / "new_token_path"
             old_path_token = Path(tmpdir) / "old_path_token"
 

--- a/tests/test_utils_hf_folder.py
+++ b/tests/test_utils_hf_folder.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from unittest.mock import patch
 from uuid import uuid4
 
-from huggingface_hub.utils import HfFolder, TemporaryDirectory
+from huggingface_hub.utils import HfFolder, SoftTemporaryDirectory
 
 
 def _generate_token() -> str:
@@ -47,7 +47,7 @@ class HfFolderTest(unittest.TestCase):
     def test_token_in_old_path(self):
         token = _generate_token()
         token2 = _generate_token()
-        with TemporaryDirectory() as tmpdir:
+        with SoftTemporaryDirectory() as tmpdir:
             path_token = Path(tmpdir) / "new_token_path"
             old_path_token = Path(tmpdir) / "old_path_token"
 

--- a/tests/test_utils_sha.py
+++ b/tests/test_utils_sha.py
@@ -2,8 +2,8 @@ import os
 import unittest
 from hashlib import sha256
 from io import BytesIO
-from tempfile import TemporaryDirectory
 
+from huggingface_hub.utils import TemporaryDirectory
 from huggingface_hub.utils.sha import sha_fileobj
 
 

--- a/tests/test_utils_sha.py
+++ b/tests/test_utils_sha.py
@@ -3,13 +3,13 @@ import unittest
 from hashlib import sha256
 from io import BytesIO
 
-from huggingface_hub.utils import TemporaryDirectory
+from huggingface_hub.utils import SoftTemporaryDirectory
 from huggingface_hub.utils.sha import sha_fileobj
 
 
 class TestShaUtils(unittest.TestCase):
     def test_sha_fileobj(self):
-        with TemporaryDirectory() as tmpdir:
+        with SoftTemporaryDirectory() as tmpdir:
             content = b"Random content" * 1000
             sha = sha256(content).digest()
 

--- a/tests/test_utils_tqdm.py
+++ b/tests/test_utils_tqdm.py
@@ -1,4 +1,3 @@
-import tempfile
 import time
 import unittest
 from pathlib import Path
@@ -8,6 +7,7 @@ import pytest
 from pytest import CaptureFixture
 
 from huggingface_hub.utils import (
+    TemporaryDirectory,
     are_progress_bars_disabled,
     disable_progress_bars,
     enable_progress_bars,
@@ -120,7 +120,7 @@ class TestTqdmUtils(unittest.TestCase):
         self.assertIn("10/10", captured.err)  # tqdm log
 
     def test_tqdm_stream_file(self) -> None:
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with TemporaryDirectory() as tmpdir:
             filepath = Path(tmpdir) / "config.json"
             with filepath.open("w") as f:
                 f.write("#" * 1000)

--- a/tests/test_utils_tqdm.py
+++ b/tests/test_utils_tqdm.py
@@ -7,7 +7,7 @@ import pytest
 from pytest import CaptureFixture
 
 from huggingface_hub.utils import (
-    TemporaryDirectory,
+    SoftTemporaryDirectory,
     are_progress_bars_disabled,
     disable_progress_bars,
     enable_progress_bars,
@@ -120,7 +120,7 @@ class TestTqdmUtils(unittest.TestCase):
         self.assertIn("10/10", captured.err)  # tqdm log
 
     def test_tqdm_stream_file(self) -> None:
-        with TemporaryDirectory() as tmpdir:
+        with SoftTemporaryDirectory() as tmpdir:
             filepath = Path(tmpdir) / "config.json"
             with filepath.open("w") as f:
                 f.write("#" * 1000)


### PR DESCRIPTION
Fix #1278.

Create a custom `TemporaryDirectory` context manager that tries harder to cleanup on exit.
If it still fails to cleanup the directory, it gives up without trowing an issue.

Tested also on Windows and it works fine. See https://www.scivision.dev/python-tempfile-permission-error-windows/ for some details.
