### PR TITLE
fixes 1290 - check for existing token during interpreter login

### DIFF
--- a/src/huggingface_hub/_login.py
+++ b/src/huggingface_hub/_login.py
@@ -89,7 +89,7 @@ def login(token: Optional[str] = None, add_to_git_credential: bool = False) -> N
     elif is_notebook():
         notebook_login()
     else:
-        interpreter_login(token)
+        interpreter_login()
 
 
 def logout() -> None:
@@ -111,7 +111,7 @@ def logout() -> None:
 ###
 
 
-def interpreter_login(token: Optional[str] = None) -> None:
+def interpreter_login() -> None:
     """
     Displays a prompt to login to the HF website and store the token.
 
@@ -130,16 +130,16 @@ def interpreter_login(token: Optional[str] = None) -> None:
     _|    _|    _|_|      _|_|_|    _|_|_|  _|_|_|  _|      _|    _|_|_|      _|        _|    _|    _|_|_|  _|_|_|_|
     """
     )
-    if token is not None:
+    if HfFolder.get_token() is not None:
         print(
-            "    A token is already saved on your machine. Run `huggingface - cli"
-            " whoami` to get more information or `huggingface - cli logout` if you want"
-            " to log out. Setting a new token will erase the existing one."
+            "    A token is already saved on your machine. Run `huggingface-cli"
+            " whoami` to get more information or `huggingface-cli logout` if you want"
+            " to log out."
         )
-        return
+        print("    Setting a new token will erase the existing one.")
 
     print(
-        "    To login, `huggingface_hub` now requires a token generated from"
+        "    To login, `huggingface_hub` requires a token generated from"
         " https://huggingface.co/settings/tokens ."
     )
     if os.name == "nt":

--- a/src/huggingface_hub/_login.py
+++ b/src/huggingface_hub/_login.py
@@ -89,7 +89,7 @@ def login(token: Optional[str] = None, add_to_git_credential: bool = False) -> N
     elif is_notebook():
         notebook_login()
     else:
-        interpreter_login()
+        interpreter_login(token)
 
 
 def logout() -> None:
@@ -111,7 +111,7 @@ def logout() -> None:
 ###
 
 
-def interpreter_login() -> None:
+def interpreter_login(token: Optional[str] = None) -> None:
     """
     Displays a prompt to login to the HF website and store the token.
 
@@ -128,9 +128,19 @@ def interpreter_login() -> None:
     _|_|_|_|  _|    _|  _|  _|_|  _|  _|_|    _|    _|  _|  _|  _|  _|_|      _|_|_|    _|_|_|_|  _|        _|_|_|
     _|    _|  _|    _|  _|    _|  _|    _|    _|    _|    _|_|  _|    _|      _|        _|    _|  _|        _|
     _|    _|    _|_|      _|_|_|    _|_|_|  _|_|_|  _|      _|    _|_|_|      _|        _|    _|    _|_|_|  _|_|_|_|
-
-    To login, `huggingface_hub` now requires a token generated from https://huggingface.co/settings/tokens .
     """
+    )
+    if token is not None:
+        print(
+            "    A token is already saved on your machine. Run `huggingface - cli"
+            " whoami` to get more information or `huggingface - cli logout` if you want"
+            " to log out. Setting a new token will erase the existing one."
+        )
+        return
+
+    print(
+        "    To login, `huggingface_hub` now requires a token generated from"
+        " https://huggingface.co/settings/tokens ."
     )
     if os.name == "nt":
         print("Token can be pasted using 'Right-Click'.")

--- a/src/huggingface_hub/commands/user.py
+++ b/src/huggingface_hub/commands/user.py
@@ -114,8 +114,7 @@ class BaseUserCommand:
 
 class LoginCommand(BaseUserCommand):
     def run(self):
-        token = HfFolder.get_token()
-        login(token)
+        login()
 
 
 class LogoutCommand(BaseUserCommand):

--- a/src/huggingface_hub/commands/user.py
+++ b/src/huggingface_hub/commands/user.py
@@ -114,7 +114,8 @@ class BaseUserCommand:
 
 class LoginCommand(BaseUserCommand):
     def run(self):
-        login()
+        token = HfFolder.get_token()
+        login(token)
 
 
 class LogoutCommand(BaseUserCommand):


### PR DESCRIPTION
This illustrates my suggested enhancement described in issue #1290.

This adds an optional argument to `interpreter_login()` and passes `Option(token)` to it from the outer login function. If the token exists it is interrogated, a message is displayed, and a `ValueError` is raised to exit.

I chose a `ValueError` to match the pattern that `_login()` uses in the same method when a token is provided. I also considered hoisting out a `_validate_token()` method from the `_login()` code but I thought it best to keep this concise.

The CLI tests are super anemic and I haven't added any additional tests here. I'll wait for more feedback before figuring that out.