### PR TITLE
Update "move_repo" doc url + fix Bigcode test in CI

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -2091,7 +2091,7 @@ class HfApi:
 
         Note there are certain limitations. For more information about moving
         repositories, please see
-        https://hf.co/docs/hub/main#how-can-i-rename-or-transfer-a-repo.
+        https://hf.co/docs/hub/repositories-settings#renaming-or-transferring-a-repo.
 
         Args:
             from_id (`str`):
@@ -2142,7 +2142,7 @@ class HfApi:
         except HfHubHTTPError as e:
             e.append_to_message(
                 "\nFor additional documentation please see"
-                " https://hf.co/docs/hub/main#how-can-i-rename-or-transfer-a-repo."
+                " https://hf.co/docs/hub/repositories-settings#renaming-or-transferring-a-repo."
             )
             raise
 

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2478,7 +2478,7 @@ class ListGitRefsTest(unittest.TestCase):
         self.api.repo_info("gpt2", revision=main_branch.target_commit)
 
     def test_list_refs_bigcode(self) -> None:
-        refs = self.api.list_repo_refs("bigcode/evaluation", repo_type="dataset")
+        refs = self.api.list_repo_refs("bigcode/admin", repo_type="dataset")
         self.assertGreater(len(refs.branches), 0)
         self.assertGreater(len(refs.converts), 0)
         main_branch = [branch for branch in refs.branches if branch.name == "main"][0]
@@ -2491,7 +2491,7 @@ class ListGitRefsTest(unittest.TestCase):
 
         # Can get info by convert revision
         self.api.repo_info(
-            "bigcode/evaluation",
+            "bigcode/admin",
             repo_type="dataset",
             revision=convert_branch.target_commit,
         )


### PR DESCRIPTION
1. `move_repo` documentation URL was invalid
2. A test is failing in the CI because a repo has been removed. Repo itself doesn't matter too much (it just need to have a convert/parquet reference) so I changed it.