### PR TITLE
Create branch from given revision

### DIFF
--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -1427,6 +1427,44 @@ class HfApiBranchEndpointTest(HfApiCommonTestWithLogin):
         with self.assertRaisesRegex(HfHubHTTPError, "Reference does not exist"):
             self._api.delete_branch(repo_url.repo_id, branch="cool-tag")
 
+    @retry_endpoint
+    @use_tmp_repo()
+    def test_create_branch_from_revision(self, repo_url: RepoUrl) -> None:
+        """Test `create_branch` from a different revision than main HEAD."""
+        # Create commit and remember initial/latest commit
+        initial_commit = self._api.model_info(repo_url.repo_id).sha
+        self._api.create_commit(
+            repo_url.repo_id,
+            operations=[
+                CommitOperationAdd(path_in_repo="app.py", path_or_fileobj=b"content")
+            ],
+            commit_message="test commit",
+        )
+        latest_commit = self._api.model_info(repo_url.repo_id).sha
+
+        # Create branches
+        self._api.create_branch(repo_url.repo_id, branch="from-head")
+        self._api.create_branch(
+            repo_url.repo_id, branch="from-initial", revision=initial_commit
+        )
+        self._api.create_branch(
+            repo_url.repo_id, branch="from-branch", revision="from-initial"
+        )
+
+        # Checks branches start from expected commits
+        self.assertEqual(
+            {
+                "main": latest_commit,
+                "from-head": latest_commit,
+                "from-initial": initial_commit,
+                "from-branch": initial_commit,
+            },
+            {
+                ref.name: ref.target_commit
+                for ref in self._api.list_repo_refs(repo_id=repo_url.repo_id).branches
+            },
+        )
+
 
 class HfApiPublicStagingTest(unittest.TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
Related to https://github.com/huggingface/huggingface_hub/issues/1288 (but don't solve it entirely). It is now possible to create a branch from a given revision (commit id or branch name) cc @camenduru

```py
create_branch(repo_id, branch="from-initial", revision="364a1b48ef846051cbb511c438c0e1d6f6fde7f4")
create_branch(repo_id, branch="from-branch", revision="from-initial")
```

Would be good to have a way to retrieve first commit ID to solve https://github.com/huggingface/huggingface_hub/issues/1288 but that will be done later. In the meantime, a workaround is to tag the initial commit at repo creation and retrieve it later using `HfApi.list_repo_refs`. A bit clunky but does the trick while a "`list_repo_history`-like" method is not implemented.

