### PR TITLE
Fix test_comment_discussion

### DIFF
--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2227,7 +2227,7 @@ class HfApiDiscussionsTest(HfApiCommonTestWithLogin):
             repo_id=self.repo_name, discussion_num=self.discussion.num
         )
         self.assertEqual(len(retrieved.events), 2)
-        self.assertIn(new_comment, retrieved.events)
+        self.assertIn(new_comment.id, {event.id for event in retrieved.events})
 
     def test_rename_discussion(self):
         rename_event = self._api.rename_discussion(


### PR DESCRIPTION
Related to [slack thread](https://huggingface.slack.com/archives/C02EMARJ65P/p1673970528365839) (internal link) and [issue in CI](https://github.com/huggingface/huggingface_hub/actions/runs/3940685279/jobs/6742108306#step:5:1888).

`test_comment_discussion` is comparing entire events (full raw data). Seems that some css styling is applied to the comment when listed from the API. This is not really our concern as long as the comment IDs stays the same. This PR fixes the test.