### PR TITLE
Make tests more robust (no pre-existing repo on staging Hub)

### DIFF
--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -82,6 +82,7 @@ from .testing_constants import (
     ENDPOINT_STAGING,
     ENDPOINT_STAGING_BASIC_AUTH,
     FULL_NAME,
+    OTHER_TOKEN,
     TOKEN,
     USER,
 )
@@ -833,8 +834,11 @@ class CommitApiTest(HfApiCommonTestWithLogin):
 
     @retry_endpoint
     def test_create_commit_create_pr_on_foreign_repo(self):
-        # Repo on which we don't have right
+        # Create a repo with another user. The normal CI user don't have rights on it.
         # We must be able to create a PR on it
+        foreign_api = HfApi(token=OTHER_TOKEN)
+        foreign_repo_url = foreign_api.create_repo(repo_id=repo_name("repo-for-hfh-ci"))
+
         self._api.create_commit(
             operations=[
                 CommitOperationAdd(
@@ -845,9 +849,11 @@ class CommitApiTest(HfApiCommonTestWithLogin):
                 ),
             ],
             commit_message="PR on foreign repo",
-            repo_id="datasets_server_org/repo_for_huggingface_hub_ci_with_prs",
+            repo_id=foreign_repo_url.repo_id,
             create_pr=True,
         )
+
+        foreign_api.delete_repo(repo_id=foreign_repo_url.repo_id)
 
     @retry_endpoint
     def test_create_commit(self):

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2405,12 +2405,18 @@ class ActivityApiTest(unittest.TestCase):
         self.api.delete_repo(repo_id, token=TOKEN)
 
     def test_list_liked_repos_no_auth(self) -> None:
+        # Create a list 1 liked repo
+        liked_repo_name = "repo-that-is-liked-public"
+        repo_url = self.api.create_repo(liked_repo_name, exist_ok=True, token=TOKEN)
+        self.api.like(repo_url.repo_id, token=TOKEN)
+
+        # Fetch liked repos without auth
         likes = self.api.list_liked_repos(USER)
         self.assertEqual(likes.user, USER)
         self.assertGreater(
             len(likes.models) + len(likes.datasets) + len(likes.spaces), 0
         )
-        self.assertIn(f"{USER}/repo-that-is-liked-public", likes.models)
+        self.assertIn(repo_url.repo_id, likes.models)
 
     def test_list_likes_repos_auth_and_implicit_user(self) -> None:
         # User is implicit

--- a/tests/test_utils_cache.py
+++ b/tests/test_utils_cache.py
@@ -203,7 +203,7 @@ class TestValidCacheUtils(unittest.TestCase):
         report = scan_cache_dir(self.cache_dir)
 
         # Check general information about downloaded snapshots
-        self.assertEqual(report.size_on_disk, 6258)
+        self.assertEqual(report.size_on_disk, 6728)
         self.assertEqual(len(report.repos), 2)  # Model and dataset
         self.assertEqual(len(report.warnings), 0)  # Repos are valid
 
@@ -223,12 +223,12 @@ class TestValidCacheUtils(unittest.TestCase):
         )
 
         # Repo size on disk is equal to the sum of revisions (no symlinks)
-        self.assertEqual(repo_a.size_on_disk, 4102)  # Windows-specific
-        self.assertEqual(sum(rev.size_on_disk for rev in repo_a.revisions), 4102)
+        self.assertEqual(repo_a.size_on_disk, 4463)  # Windows-specific
+        self.assertEqual(sum(rev.size_on_disk for rev in repo_a.revisions), 4463)
 
         # Repo nb files is equal to the sum of revisions !
-        self.assertEqual(repo_a.nb_files, 8)  # Windows-specific
-        self.assertEqual(sum(rev.nb_files for rev in repo_a.revisions), 8)
+        self.assertEqual(repo_a.nb_files, 6)  # Windows-specific
+        self.assertEqual(sum(rev.nb_files for rev in repo_a.revisions), 6)
 
         # 2 REFS in the repo: "main" and "refs/pr/1"
         # We could have add a tag as well

--- a/tests/test_utils_cache.py
+++ b/tests/test_utils_cache.py
@@ -527,7 +527,7 @@ class TestCorruptedCacheUtils(unittest.TestCase):
             file for file in revision_1.files if file.file_name == "README.md"
         ][0]
         another_file_1 = [
-            file for file in revision_1.files if file.file_name == "Another file.md"
+            file for file in revision_1.files if file.file_name == ".gitattributes"
         ][0]
 
         # Comparison of last_accessed/last_modified between file and repo
@@ -555,7 +555,7 @@ class TestCorruptedCacheUtils(unittest.TestCase):
             file for file in revision_2.files if file.file_name == "README.md"
         ][0]
         another_file_2 = [
-            file for file in revision_1.files if file.file_name == "Another file.md"
+            file for file in revision_1.files if file.file_name == ".gitattributes"
         ][0]
 
         # Report 1 is not updated when cache changes

--- a/tests/testing_constants.py
+++ b/tests/testing_constants.py
@@ -8,6 +8,11 @@ PASS = "__DUMMY_TRANSFORMERS_PASS__"
 # Not critical, only usable on the sandboxed CI instance.
 TOKEN = "hf_94wBhPGp6KrrTH3KDchhKpRxZwd6dmHWLL"
 
+# Used to create repos that we don't own (example: for gated repo)
+# Token is not critical. Also public in https://github.com/huggingface/datasets-server
+OTHER_USER = "__DUMMY_DATASETS_SERVER_USER__"
+OTHER_TOKEN = "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"
+
 ENDPOINT_PRODUCTION = "https://huggingface.co"
 ENDPOINT_STAGING = "https://hub-ci.huggingface.co"
 ENDPOINT_STAGING_BASIC_AUTH = f"https://{USER}:{PASS}@hub-ci.huggingface.co"


### PR DESCRIPTION
In a few cases, `hfh` tests were relying on existing repos on the staging Hub. That's a bit annoying when staging database got wiped-off for cleanup. See [related slack thread](https://huggingface.slack.com/archives/C02EMARJ65P/p1674140535316159) (internal link) (cc @coyotte508 @severo)

This PR remove the use of any pre-existing repo on staging:
- https://hub-ci.huggingface.co/datasets_server_org/gated_repo_for_huggingface_hub_ci -> now creating a gated repo on the fly
- https://hub-ci.huggingface.co//datasets_server_org/repo_for_huggingface_hub_ci_with_prs -> now creating a foreign repo with prs on the fly, using DATASET_SERVER user (cc @severo)
- https://hub-ci.huggingface.co/valid_org/repo_with_awful_filename -> there was no need to be an existing repo
- https://hub-ci.huggingface.co/valid_org/test_scan_repo_a -> this is still convenient to have "persistent" as commit hash/refs are hard-coded. I moved it to production under the hf-testing-internal org. (see https://huggingface.co/hf-internal-testing/hfh_ci_scan_repo_a and https://huggingface.co/datasets/hf-internal-testing/hfh_ci_scan_dataset_b)
- `"repo-that-is-liked-public"` -> a liked repo. We can like it on the fly as well

**Note:** This PR adds a token for the dataset_server user but it is not critical (only sandboxed to staging on already public in [dataset-server repo](https://github.com/huggingface/datasets-server/blob/31067d3c643719c4a3331261d4a34ee00cdccd65/workers/datasets_based/tests/constants.py#L6).

**EDIT:** also made the snapshot download tests faster in https://github.com/huggingface/huggingface_hub/pull/1302/commits/fd9b43802c6d862e4cc20590d9c8111055df8b4f by initializing the repo only once instead of once per test.