### PR TITLE
Fix caching error when offline and no refs dir

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1177,18 +1177,24 @@ def hf_hub_download(
                 "We have no connection or you passed local_files_only, so"
                 " force_download is not an accepted option."
             )
+
+        # Try to get "commit_hash" from "revision"
+        commit_hash = None
         if REGEX_COMMIT_HASH.match(revision):
             commit_hash = revision
         else:
             ref_path = os.path.join(storage_folder, "refs", revision)
-            with open(ref_path) as f:
-                commit_hash = f.read()
+            if os.path.isfile(ref_path):
+                with open(ref_path) as f:
+                    commit_hash = f.read()
 
-        pointer_path = os.path.join(
-            storage_folder, "snapshots", commit_hash, relative_filename
-        )
-        if os.path.exists(pointer_path):
-            return pointer_path
+        # Return pointer file if exists
+        if commit_hash is not None:
+            pointer_path = os.path.join(
+                storage_folder, "snapshots", commit_hash, relative_filename
+            )
+            if os.path.exists(pointer_path):
+                return pointer_path
 
         # If we couldn't find an appropriate file on disk,
         # raise an error.

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -318,6 +318,24 @@ class CachedDownloadTests(unittest.TestCase):
         self.assertEqual(filepath.name, CONFIG_NAME)
         self.assertEqual(Path(filepath).parent.parent.name, "snapshots")
 
+    def test_hf_hub_download_offline_no_refs(self):
+        """Regression test for #1305.
+
+        If "refs/" dir did not exists on "local_files_only" (or connection broken), a
+        non-explicit `FileNotFoundError` was raised (for the "/refs/revision" file) instead
+        of the documented `LocalEntryNotFoundError` (for the actual searched file).
+
+        See https://github.com/huggingface/huggingface_hub/issues/1305.
+        """
+        with SoftTemporaryDirectory() as cache_dir:
+            with self.assertRaises(LocalEntryNotFoundError):
+                hf_hub_download(
+                    DUMMY_MODEL_ID,
+                    filename=CONFIG_NAME,
+                    local_files_only=True,
+                    cache_dir=cache_dir,
+                )
+
     def test_hf_hub_url_with_empty_subfolder(self):
         """
         Check subfolder arg is processed correctly when empty string is passed to


### PR DESCRIPTION
Will not fix the root issue of https://github.com/huggingface/huggingface_hub/issues/1305 but fixes the non-explicit `FileNotFoundError` that was raised (in favor of the documented and expected `LocalEntryNotFoundError`).

cc @NielsRogge for some reason downloading a file in your space failed due to a connection issue (infra issue ? `HF_HUB_OFFLINE` set ?). Instead of the proper `LocalEntryNotFoundError` (that is handled nicely in `transformers`) you had a `FlieNotFoundError` because the cache in your space was not initialized yet. This also explains why it's working locally on your computer (since I guess cache structure is already good). This PR should fix it.