### PR TITLE
[docs] Remove *optional* from now-required repo_id in push_to_hub

### DIFF
--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -239,7 +239,7 @@ class ModelHubMixin:
         should be pushed to the hub. See [`upload_folder`] reference for more details.
 
         Parameters:
-            repo_id (`str`, *optional*):
+            repo_id (`str`):
                 Repository name to which push.
             config (`dict`, *optional*):
                 Configuration object to be saved alongside the model weights.


### PR DESCRIPTION
Hello!

## Pull Request overview
* Remove \*optional* from the method docstring for the now-required `repo_id` argument in in `push_to_hub`

## Details
See the relevant docs [here](https://huggingface.co/docs/huggingface_hub/v0.12.0/en/package_reference/mixins#huggingface_hub.ModelHubMixin.push_to_hub).
See the relevant function signature here:
https://github.com/huggingface/huggingface_hub/blob/df00f57105ce8fb1c923ccdb0ad4dd45600b149f/src/huggingface_hub/hub_mixin.py#L220-L234
As you can see, `repo_id` is required.
<!--Neglecting to pass it now gives the following error:
```
TypeError: ModelHubMixin.push_to_hub() missing 1 required positional argument: 'repo_id'
```-->

- Tom Aarsen