### PR TITLE
FIX displayed filename in LFS download (+default response None in HfHubHTTPError)

### DIFF
--- a/src/huggingface_hub/utils/_errors.py
+++ b/src/huggingface_hub/utils/_errors.py
@@ -39,7 +39,7 @@ class HfHubHTTPError(HTTPError):
     request_id: Optional[str] = None
     server_message: Optional[str] = None
 
-    def __init__(self, message: str, response: Optional[Response]):
+    def __init__(self, message: str, response: Optional[Response] = None):
         # Parse server information if any.
         if response is not None:
             self.request_id = response.headers.get("X-Request-Id")


### PR DESCRIPTION
FIX https://github.com/huggingface/huggingface_hub/issues/1318 by parsing correctly the "Content-disposition" header with a regex (cc @sijunhe).

Previous was:
```
Downloading (…)del_state.pdparams";:   2%|██▋
```
and now:
```bash
Downloading model_state.pdparams:   2%|██▋
# or
Downloading (…)del_state.pdparams:   2%|██▋
# depending on filename length
```

**EDIT:** also made a fix for https://github.com/huggingface/huggingface_hub/issues/1319. It was not really a bug but I agree that have a default value is more convenient.

```py
# It's now possible to do:
HfHubHTTPError(message="something happened")
# instead of 
HfHubHTTPError(message="something happened", response=None)
# which is stricly equivalent. A `None` response is already correctly handled by `hfh`
```
