### PR TITLE
Add contrib CI for spacy_huggingface_hub

### DIFF
--- a/.github/workflows/contrib-tests.yml
+++ b/.github/workflows/contrib-tests.yml
@@ -16,6 +16,7 @@ jobs:
       matrix:
         contrib: [
           "sentence_transformers",
+          "spacy",
           "timm",
         ]
 

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ test:
 #	make contrib            : setup and run ALL tests
 #	make contrib_clear      : delete all virtual envs
 # Use -j4 flag to run jobs in parallel.
-CONTRIB_LIBS := sentence_transformers timm
+CONTRIB_LIBS := sentence_transformers spacy timm
 CONTRIB_JOBS := $(addprefix contrib_,${CONTRIB_LIBS})
 CONTRIB_CLEAR_JOBS := $(addprefix contrib_clear_,${CONTRIB_LIBS})
 CONTRIB_SETUP_JOBS := $(addprefix contrib_setup_,${CONTRIB_LIBS})

--- a/contrib/spacy/requirements.txt
+++ b/contrib/spacy/requirements.txt
@@ -1,0 +1,1 @@
+git+https://github.com/explosion/spacy-huggingface-hub.git#egg=spacy-huggingface-hub

--- a/contrib/spacy/test_spacy.py
+++ b/contrib/spacy/test_spacy.py
@@ -5,7 +5,7 @@ from spacy_huggingface_hub import push
 from ..utils import production_endpoint
 
 
-def test_space_push(user: str) -> None:
+def test_push_to_hub(user: str) -> None:
     """Test equivalent of `python -m spacy huggingface-hub push`.
 
     (0. Delete existing repo on the Hub (if any))

--- a/contrib/spacy/test_spacy.py
+++ b/contrib/spacy/test_spacy.py
@@ -1,0 +1,42 @@
+from huggingface_hub import delete_repo, hf_hub_download, model_info
+from huggingface_hub.utils import HfHubHTTPError
+from spacy_huggingface_hub import push
+
+from ..utils import production_endpoint
+
+
+def test_space_push(user: str) -> None:
+    """Test equivalent of `python -m spacy huggingface-hub push`.
+
+    (0. Delete existing repo on the Hub (if any))
+    1. Download an example file from production
+    2. Push the model!
+    3. Check model pushed the Hub + as spacy library
+    (4. Cleanup)
+    """
+    model_id = f"{user}/en_core_web_sm"
+    _delete_repo(model_id)
+
+    # Download example file from HF Hub (see https://huggingface.co/spacy/en_core_web_sm)
+    with production_endpoint():
+        whl_path = hf_hub_download(
+            repo_id="spacy/en_core_web_sm",
+            filename="en_core_web_sm-any-py3-none-any.whl",
+        )
+
+    # Push spacy model to Hub
+    push(whl_path)
+
+    # Check model has been pushed properly
+    model_id = f"{user}/en_core_web_sm"
+    assert model_info(model_id).library_name == "spacy"
+
+    # Cleanup
+    _delete_repo(model_id)
+
+
+def _delete_repo(model_id: str) -> None:
+    try:
+        delete_repo(model_id)
+    except HfHubHTTPError:
+        pass


### PR DESCRIPTION
Related to https://github.com/explosion/spacy-huggingface-hub/pull/14 (cc @osanseviero @adrianeboyd).

`spacy-huggingface-hub` has a single feature (push model to hub) which is untested so far. Let's add it to our Contrib CI to prevent future breaking changes. To be more precise, we might break an api somewhere in the future but at least we will detect it enough in advance. Test is run with the latest dev version of `huggingface_hub` and breaks on any `FutureWarning` that is raised. If we encounter a bug, we would report it on https://github.com/explosion/spacy-huggingface-hub.