### PR TITLE
Remove py.typed - FIX linter issues

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,2 @@
-include src/huggingface_hub/py.typed
 include src/huggingface_hub/templates/modelcard_template.md
 include src/huggingface_hub/templates/datasetcard_template.md


### PR DESCRIPTION
See [discussion](https://github.com/huggingface/datasets/issues/3841) happening in `datasets`.

To fix the `reportPrivateImportUsage` issue reported by Pyright, let's just delete `py.typed` file. It's not compliant with [PEP-561](https://peps.python.org/pep-0561/#packaging-type-information) but at least it will be consistent with other huggingface libraries.

Just to mention it, it would be possible to hard-code the `__all__` variable by statically generating the file (same as what we are doing in the `if TYPE_CHECKING` section). But let's keep it simple :)

cc @mariosasko @lhoestq @LysandreJik 