### PR TITLE
Add `list_repo_commits` to list git history of a repo

### DIFF
--- a/docs/source/package_reference/hf_api.mdx
+++ b/docs/source/package_reference/hf_api.mdx
@@ -41,6 +41,10 @@ models = hf_api.list_models()
 
 [[autodoc]] huggingface_hub.hf_api.GitRefInfo
 
+### GitCommitInfo
+
+[[autodoc]] huggingface_hub.hf_api.GitCommitInfo
+
 ### GitRefs
 
 [[autodoc]] huggingface_hub.hf_api.GitRefs

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -107,6 +107,7 @@ _SUBMOD_ATTRS = {
         "CommitOperationAdd",
         "CommitOperationDelete",
         "DatasetSearchArguments",
+        "GitCommitInfo",
         "GitRefInfo",
         "GitRefs",
         "HfApi",
@@ -122,7 +123,6 @@ _SUBMOD_ATTRS = {
         "create_pull_request",
         "create_repo",
         "create_tag",
-        "GitCommitInfo",
         "dataset_info",
         "delete_branch",
         "delete_file",
@@ -360,6 +360,7 @@ if TYPE_CHECKING:  # pragma: no cover
         CommitOperationAdd,  # noqa: F401
         CommitOperationDelete,  # noqa: F401
         DatasetSearchArguments,  # noqa: F401
+        GitCommitInfo,  # noqa: F401
         GitRefInfo,  # noqa: F401
         GitRefs,  # noqa: F401
         HfApi,  # noqa: F401

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -122,6 +122,7 @@ _SUBMOD_ATTRS = {
         "create_pull_request",
         "create_repo",
         "create_tag",
+        "GitCommitInfo",
         "dataset_info",
         "delete_branch",
         "delete_file",
@@ -141,6 +142,7 @@ _SUBMOD_ATTRS = {
         "list_liked_repos",
         "list_metrics",
         "list_models",
+        "list_repo_commits",
         "list_repo_files",
         "list_repo_refs",
         "list_spaces",
@@ -392,6 +394,7 @@ if TYPE_CHECKING:  # pragma: no cover
         list_liked_repos,  # noqa: F401
         list_metrics,  # noqa: F401
         list_models,  # noqa: F401
+        list_repo_commits,  # noqa: F401
         list_repo_files,  # noqa: F401
         list_repo_refs,  # noqa: F401
         list_spaces,  # noqa: F401

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -724,7 +724,7 @@ class GitCommitInfo:
             Description of the commit. This is a free-text value entered by the authors.
         formatted_title (`str`):
             Title of the commit formatted as HTML. Only returned if `formatted=True` is set.
-        message (`str`):
+        formatted_message (`str`):
             Description of the commit formatted as HTML. Only returned if `formatted=True` is set.
     """
 

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -1999,7 +1999,7 @@ class HfApi:
             for item in paginate(
                 f"{self.endpoint}/api/{repo_type}s/{repo_id}/commits/{revision}",
                 headers=self._build_hf_headers(token=token),
-                params={"expand[]": "formatted"} if formatted else None,
+                params={"expand[]": "formatted"} if formatted else {},
             )
         ]
 

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -15,9 +15,9 @@
 import json
 import os
 import re
-from datetime import datetime
 import warnings
 from dataclasses import dataclass, field
+from datetime import datetime
 from itertools import islice
 from pathlib import Path
 from typing import Any, BinaryIO, Dict, Iterable, Iterator, List, Optional, Tuple, Union

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -709,7 +709,7 @@ class GitRefs:
 @dataclass
 class GitCommitInfo:
     """
-    Contains information about a git commit for a repo on the Hub.
+    Contains information about a git commit for a repo on the Hub. Check out [`list_repo_commits`] for more details.
 
     Args:
         commit_id (`str`):

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -15,6 +15,7 @@
 import json
 import os
 import re
+from datetime import datetime
 import warnings
 from dataclasses import dataclass, field
 from itertools import islice
@@ -703,6 +704,49 @@ class GitRefs:
     branches: List[GitRefInfo]
     converts: List[GitRefInfo]
     tags: List[GitRefInfo]
+
+
+@dataclass
+class GitCommitInfo:
+    """
+    Contains information about a git commit for a repo on the Hub.
+
+    Args:
+        commit_id (`str`):
+            OID of the commit (e.g. `"e7da7f221d5bf496a48136c0cd264e630fe9fcc8"`)
+        authors (`List[str]`):
+            List of authors of the commit.
+        created_at (`datetime`):
+            Datetime when the commit was created.
+        title (`str`):
+            Title of the commit. This is a free-text value entered by the authors.
+        message (`str`):
+            Description of the commit. This is a free-text value entered by the authors.
+        formatted_title (`str`):
+            Title of the commit formatted as HTML. Only returned if `formatted=True` is set.
+        message (`str`):
+            Description of the commit formatted as HTML. Only returned if `formatted=True` is set.
+    """
+
+    commit_id: str
+
+    authors: List[str]
+    created_at: datetime
+    title: str
+    message: str
+
+    formatted_title: Optional[str]
+    formatted_message: Optional[str]
+
+    def __init__(self, data: Dict) -> None:
+        self.commit_id = data["id"]
+        self.authors = [author["user"] for author in data["authors"]]
+        self.created_at = parse_datetime(data["date"])
+        self.title = data["title"]
+        self.message = data["message"]
+
+        self.formatted_title = data.get("formatted", {}).get("title")
+        self.formatted_message = data.get("formatted", {}).get("message")
 
 
 @dataclass
@@ -1882,6 +1926,84 @@ class HfApi:
         )
 
     @validate_hf_hub_args
+    def list_repo_commits(
+        self,
+        repo_id: str,
+        *,
+        repo_type: Optional[str] = None,
+        token: Optional[Union[bool, str]] = None,
+        revision: Optional[str] = None,
+        formatted: bool = False,
+    ) -> List[GitCommitInfo]:
+        """
+        Get the list of commits of a given revision for a repo on the Hub.
+
+        Commits are sorted by date (last commit first).
+
+        Args:
+            repo_id (`str`):
+                A namespace (user or an organization) and a repo name separated by a `/`.
+            repo_type (`str`, *optional*):
+                Set to `"dataset"` or `"space"` if listing commits from a dataset or a Space, `None` or `"model"` if
+                listing from a model. Default is `None`.
+            token (`bool` or `str`, *optional*):
+                A valid authentication token (see https://huggingface.co/settings/token).
+                If `None` or `True` and machine is logged in (through `huggingface-cli login`
+                or [`~huggingface_hub.login`]), token will be retrieved from the cache.
+                If `False`, token is not sent in the request header.
+            revision (`str`, *optional*):
+                The git revision to commit from. Defaults to the head of the `"main"` branch.
+            formatted (`bool`):
+                Whether to return the HTML-formatted title and description of the commits. Defaults to False.
+
+        Example:
+        ```py
+        >>> from huggingface_hub import HfApi
+        >>> api = HfApi()
+
+        # Commits are sorted by date (last commit first)
+        >>> initial_commit = api.list_repo_commits("gpt2")[-1]
+
+        # Initial commit is always a system commit containing the `.gitattributes` file.
+        >>> initial_commit
+        GitCommitInfo(
+            commit_id='9b865efde13a30c13e0a33e536cf3e4a5a9d71d8',
+            authors=['system'],
+            created_at=datetime.datetime(2019, 2, 18, 10, 36, 15, tzinfo=datetime.timezone.utc),
+            title='initial commit',
+            message='',
+            formatted_title=None,
+            formatted_message=None
+        )
+
+        # Create an empty branch by deriving from initial commit
+        >>> api.create_branch("gpt2", "new_empty_branch", revision=initial_commit.commit_id)
+        ```
+
+        Returns:
+            List[[`GitCommitInfo`]]: list of objects containing information about the commits for a repo on the Hub.
+
+        Raises:
+            [`~utils.RepositoryNotFoundError`]:
+                If repository is not found (error 404): wrong repo_id/repo_type, private but not authenticated or repo
+                does not exist.
+            [`~utils.RevisionNotFoundError`]:
+                If revision is not found (error 404) on the repo.
+        """
+        repo_type = repo_type or REPO_TYPE_MODEL
+        revision = quote(revision, safe="") if revision is not None else DEFAULT_REVISION
+
+        # Paginate over results and return the list of commits.
+        return [
+            GitCommitInfo(item)
+            for item in paginate(
+                f"{self.endpoint}/api/{repo_type}s/{repo_id}/commits/{revision}",
+                headers=self._build_hf_headers(token=token),
+                params={"expand[]": "formatted"} if formatted else None,
+            )
+        ]
+
+    @validate_hf_hub_args
     def create_repo(
         self,
         repo_id: str,
@@ -2807,7 +2929,8 @@ class HfApi:
         exist_ok: bool = False,
     ) -> None:
         """
-        Create a new branch from `main` on a repo on the Hub.
+        Create a new branch for a repo on the Hub, starting from the specified revision (defaults to `main`).
+        To find a revision suiting your needs, you can use [`list_repo_refs`] or [`list_repo_commits`].
 
         Args:
             repo_id (`str`):
@@ -3972,6 +4095,7 @@ space_info = api.space_info
 repo_info = api.repo_info
 list_repo_files = api.list_repo_files
 list_repo_refs = api.list_repo_refs
+list_repo_commits = api.list_repo_commits
 
 list_metrics = api.list_metrics
 

--- a/tests/test_command_delete_cache.py
+++ b/tests/test_command_delete_cache.py
@@ -204,7 +204,7 @@ class TestDeleteCacheHelpers(unittest.TestCase):
 
         # Check printed instructions
         printed = output.getvalue()
-        self.assertTrue(printed.startswith("TUI is disabled. In other to"))  # ...
+        self.assertTrue(printed.startswith("TUI is disabled. In order to"))  # ...
         self.assertIn(tmp_path, printed)
 
         # Check input called twice

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -47,7 +47,6 @@ from huggingface_hub.constants import (
 )
 from huggingface_hub.file_download import cached_download, hf_hub_download
 from huggingface_hub.hf_api import (
-    GitCommitInfo,
     USERNAME_PLACEHOLDER,
     CommitInfo,
     DatasetInfo,

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -47,6 +47,7 @@ from huggingface_hub.constants import (
 )
 from huggingface_hub.file_download import cached_download, hf_hub_download
 from huggingface_hub.hf_api import (
+    GitCommitInfo,
     USERNAME_PLACEHOLDER,
     CommitInfo,
     DatasetInfo,
@@ -2333,6 +2334,68 @@ class ListGitRefsTest(unittest.TestCase):
             repo_type="dataset",
             revision=convert_branch.target_commit,
         )
+
+
+class ListGitCommitsTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.api = HfApi(token=TOKEN)
+        # Create repo (with initial commit)
+        cls.repo_id = cls.api.create_repo(repo_name()).repo_id
+
+        # Create a commit on `main` branch
+        cls.api.upload_file(repo_id=cls.repo_id, path_or_fileobj=b"content", path_in_repo="content.txt")
+
+        # Create a commit in a PR
+        cls.api.upload_file(repo_id=cls.repo_id, path_or_fileobj=b"on_pr", path_in_repo="on_pr.txt", create_pr=True)
+
+        # Create another commit on `main` branch
+        cls.api.upload_file(repo_id=cls.repo_id, path_or_fileobj=b"on_main", path_in_repo="on_main.txt")
+        return super().setUpClass()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.api.delete_repo(cls.repo_id)
+        return super().tearDownClass()
+
+    def test_list_commits_on_main(self) -> None:
+        commits = self.api.list_repo_commits(self.repo_id)
+
+        # "on_pr" commit not returned
+        self.assertEquals(len(commits), 3)
+        self.assertTrue(all("on_pr" not in commit.title for commit in commits))
+
+        # USER is always the author
+        self.assertTrue(all(commit.authors == [USER] for commit in commits))
+
+        # latest commit first
+        self.assertEquals(commits[0].title, "Upload on_main.txt with huggingface_hub")
+
+        # Formatted field not returned by default
+        for commit in commits:
+            self.assertIsNone(commit.formatted_title)
+            self.assertIsNone(commit.formatted_message)
+
+    def test_list_commits_on_pr(self) -> None:
+        commits = self.api.list_repo_commits(self.repo_id, revision="refs/pr/1")
+
+        # "on_pr" commit returned but not the "on_main" one
+        self.assertEquals(len(commits), 3)
+        self.assertTrue(all("on_main" not in commit.title for commit in commits))
+        self.assertEquals(commits[0].title, "Upload on_pr.txt with huggingface_hub")
+
+    def test_list_commits_include_formatted(self) -> None:
+        for commit in self.api.list_repo_commits(self.repo_id, formatted=True):
+            self.assertIsNotNone(commit.formatted_title)
+            self.assertIsNotNone(commit.formatted_message)
+
+    def test_list_commits_on_missing_repo(self) -> None:
+        with self.assertRaises(RepositoryNotFoundError):
+            self.api.list_repo_commits("missing_repo_id")
+
+    def test_list_commits_on_missing_revision(self) -> None:
+        with self.assertRaises(RevisionNotFoundError):
+            self.api.list_repo_commits(self.repo_id, revision="missing_revision")
 
 
 @patch("huggingface_hub.hf_api.build_hf_headers")


### PR DESCRIPTION
FIX https://github.com/huggingface/huggingface_hub/issues/1288 (following [server-side implementation](https://github.com/huggingface/moon-landing/pull/5301) -internal link- thanks @Kakulukian).

This PR adds a new helper `list_repo_commits` (similar to `list_repo_refs` and list_repo_files`). It lists the all history of a repository on the Hub for a given revision. Commits are sorted by date (last commit first).

@camenduru this will finally solve your problem on "how to create an empty branch?". I did not make a special parameter in `create_branch` that would use `list_repo_commits` under the hood as I thought it was a quite specific use case.

```py
>>> from huggingface_hub import HfApi
>>> api = HfApi()

# Get initial commit on a repo
>>> initial_commit = api.list_repo_commits("gpt2")[-1]

# Initial commit is always a system commit containing the `.gitattributes` file.
>>> initial_commit
GitCommitInfo(
    commit_id='9b865efde13a30c13e0a33e536cf3e4a5a9d71d8',
    authors=['system'],
    created_at=datetime.datetime(2019, 2, 18, 10, 36, 15, tzinfo=datetime.timezone.utc),
    title='initial commit',
    message='',
    formatted_title=None,
    formatted_message=None
)

# Create an "empty branch" by deriving from initial commit (branch is not entirely empty, `.gitattributes` is still there :) )
>>> api.create_branch("gpt2", "new_empty_branch", revision=initial_commit.commit_id)
```