### PR TITLE
Allow overriding inference api endpoint

### DIFF
--- a/docs/source/package_reference/environment_variables.mdx
+++ b/docs/source/package_reference/environment_variables.mdx
@@ -18,6 +18,13 @@ is using a [Private Hub](https://huggingface.co/platform).
 
 Defaults to `"https://huggingface.co"`.
 
+### HF_INFERENCE_ENDPOINT
+
+To configure the inference api base url. You might want to set this variable if your organization
+is pointing at an API Gateway rather than directly at the inference api.
+
+Defaults to `"https://api-inference.huggingface.com"`.
+
 ### HF_HOME
 
 To configure where `huggingface_hub` will locally store data. In particular, your token

--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -46,6 +46,8 @@ HUGGINGFACE_HEADER_X_REPO_COMMIT = "X-Repo-Commit"
 HUGGINGFACE_HEADER_X_LINKED_ETAG = "X-Linked-Etag"
 HUGGINGFACE_HEADER_X_LINKED_SIZE = "X-Linked-Size"
 
+INFERENCE_ENDPOINT = os.environ.get("HF_INFERENCE_ENDPOINT", "https://api-inference.huggingface.co")
+
 REPO_ID_SEPARATOR = "--"
 # ^ this substring is not allowed in repo_ids on hf.co
 # and is the canonical one we use for serialization of repo ids elsewhere.

--- a/src/huggingface_hub/inference_api.py
+++ b/src/huggingface_hub/inference_api.py
@@ -4,14 +4,13 @@ from typing import Any, Dict, List, Optional, Union
 
 import requests
 
+from .constants import INFERENCE_ENDPOINT
 from .hf_api import HfApi
 from .utils import build_hf_headers, is_pillow_available, logging, validate_hf_hub_args
 
 
 logger = logging.get_logger(__name__)
 
-
-ENDPOINT = os.environ.get("HF_INFERENCE_ENDPOINT", "https://api-inference.huggingface.co")
 
 ALL_TASKS = [
     # NLP
@@ -143,7 +142,7 @@ class InferenceApi:
             assert model_info.pipeline_tag is not None, "Pipeline tag cannot be None"
             self.task = model_info.pipeline_tag
 
-        self.api_url = f"{ENDPOINT}/pipeline/{self.task}/{repo_id}"
+        self.api_url = f"{INFERENCE_ENDPOINT}/pipeline/{self.task}/{repo_id}"
 
     def __repr__(self):
         # Do not add headers to repr to avoid leaking token.

--- a/src/huggingface_hub/inference_api.py
+++ b/src/huggingface_hub/inference_api.py
@@ -1,4 +1,5 @@
 import io
+import os
 from typing import Any, Dict, List, Optional, Union
 
 import requests
@@ -10,7 +11,7 @@ from .utils import build_hf_headers, is_pillow_available, logging, validate_hf_h
 logger = logging.get_logger(__name__)
 
 
-ENDPOINT = "https://api-inference.huggingface.co"
+ENDPOINT = os.environ.get("HF_INFERENCE_ENDPOINT", "https://api-inference.huggingface.co")
 
 ALL_TASKS = [
     # NLP

--- a/src/huggingface_hub/inference_api.py
+++ b/src/huggingface_hub/inference_api.py
@@ -1,5 +1,4 @@
 import io
-import os
 from typing import Any, Dict, List, Optional, Union
 
 import requests


### PR DESCRIPTION
In some cases users may want to point at an api gateway or similar rather than hitting the inference api directly, allow overriding via env var.