### PR TITLE
Parse correctly canonical URLs in RepoUrl

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -138,6 +138,10 @@ def repo_type_and_id_from_hf_id(hf_id: str, hub_url: Optional[str] = None) -> Tu
             namespace = None
         if len(url_segments) > 2 and hub_url not in url_segments[-3]:
             repo_type = url_segments[-3]
+        elif namespace in REPO_TYPES_MAPPING:
+            # Mean canonical dataset or model
+            repo_type = REPO_TYPES_MAPPING[namespace]
+            namespace = None
         else:
             repo_type = None
     elif is_hf_id:
@@ -145,9 +149,15 @@ def repo_type_and_id_from_hf_id(hf_id: str, hub_url: Optional[str] = None) -> Tu
             # Passed <repo_type>/<user>/<model_id> or <repo_type>/<org>/<model_id>
             repo_type, namespace, repo_id = url_segments[-3:]
         elif len(url_segments) == 2:
-            # Passed <user>/<model_id> or <org>/<model_id>
-            namespace, repo_id = hf_id.split("/")[-2:]
-            repo_type = None
+            if url_segments[0] in REPO_TYPES_MAPPING:
+                # Passed '<model_id>' or 'datasets/<dataset_id>' for a canonical model or dataset
+                repo_type = REPO_TYPES_MAPPING[url_segments[0]]
+                namespace = None
+                repo_id = hf_id.split("/")[-1]
+            else:
+                # Passed <user>/<model_id> or <org>/<model_id>
+                namespace, repo_id = hf_id.split("/")[-2:]
+                repo_type = None
         else:
             # Passed <model_id>
             repo_id = url_segments[0]

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2447,3 +2447,17 @@ class RepoUrlTest(unittest.TestCase):
         self.assertEqual(url.url, "https://huggingface.co/gpt2")
         self.assertIsInstance(url, RepoUrl)
         self.assertNotIsInstance(url.url, RepoUrl)
+
+    def test_repo_url_canonical_model(self):
+        for _id in ("gpt2", "hf://gpt2", "https://huggingface.co/gpt2"):
+            with self.subTest(_id):
+                url = RepoUrl(_id)
+                self.assertEqual(url.repo_id, "gpt2")
+                self.assertEqual(url.repo_type, "model")
+
+    def test_repo_url_canonical_dataset(self):
+        for _id in ("datasets/squad", "hf://datasets/squad", "https://huggingface.co/datasets/squad"):
+            with self.subTest(_id):
+                url = RepoUrl(_id)
+                self.assertEqual(url.repo_id, "squad")
+                self.assertEqual(url.repo_type, "dataset")


### PR DESCRIPTION
Resolve #1336.

Related to [`hffs` integration](https://github.com/huggingface/hffs/pull/12). Found out that canonical models/datasets are not parsed correctly. This PR fixes this.
