### PR TITLE
Add --exclude-standard argument in git ls-files command

### DIFF
--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -252,7 +252,7 @@ def files_to_be_staged(pattern: str = ".", folder: Union[str, Path, None] = None
         `List[str]`: List of files that are to be staged.
     """
     try:
-        p = run_subprocess("git ls-files -mo".split() + [pattern], folder)
+        p = run_subprocess("git ls-files --exclude-standard -mo".split() + [pattern], folder)
         if len(p.stdout.strip()):
             files = p.stdout.strip().split("\n")
         else:


### PR DESCRIPTION
This pull request introduces the `--exclude-standard` argument to the git ls-files command.

As described in [Git - git-ls-files Documentation](https://git-scm.com/docs/git-ls-files#_options), this option adds the standard Git exclusions: .git/info/exclude, .gitignore in each directory, and the user’s global exclusion file.

This change is important because the current behavior of the command can return temporary files that may be deleted during the execution, leading to a race condition. With the new option, files that match the exclusion patterns in the .gitignore file will not be returned.

Further details can be found at the https://github.com/huggingface/transformers/issues/21586