### PR TITLE
Remove Authorization header when following redirects

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -683,6 +683,7 @@ def cached_download(
             # Useful for lfs blobs that are stored on a CDN.
             if 300 <= r.status_code <= 399:
                 url_to_download = r.headers["Location"]
+                headers.pop("authorization", None)
         except (requests.exceptions.SSLError, requests.exceptions.ProxyError):
             # Actually raise for those subclasses of ConnectionError
             raise


### PR DESCRIPTION
I thought that https://github.com/huggingface/huggingface_hub/blob/21a1e370f54e0af188d3ec8cbfd638b96917ab9e/src/huggingface_hub/file_download.py#L1137 was enough

Seems like we have multiple path for the same end