### PR TITLE
Fix contrib CI for timm

### DIFF
--- a/.github/workflows/contrib-tests.yml
+++ b/.github/workflows/contrib-tests.yml
@@ -7,6 +7,10 @@ on:
   push:
     branches:
       - ci_contrib_*
+  pull_request:
+    types: [assigned, opened, synchronize, reopened]
+    paths:
+      - contrib/**
 
 jobs:
   build:

--- a/contrib/timm/requirements.txt
+++ b/contrib/timm/requirements.txt
@@ -1,2 +1,3 @@
 # Timm
 git+https://github.com/rwightman/pytorch-image-models.git#egg=timm
+safetensors

--- a/contrib/timm/test_timm.py
+++ b/contrib/timm/test_timm.py
@@ -3,18 +3,18 @@ import timm
 from ..utils import production_endpoint
 
 
-MODEL_ID = "nateraw/timm-resnet50-beans"
+MODEL_ID = "timm/mobilenetv3_large_100.ra_in1k"
 
 
 @production_endpoint()
 def test_load_from_hub() -> None:
     # Test load only config
-    _ = timm.models.hub.load_model_config_from_hf(MODEL_ID)
+    _ = timm.models.load_model_config_from_hf(MODEL_ID)
 
     # Load entire model from Hub
     _ = timm.create_model("hf_hub:" + MODEL_ID, pretrained=True)
 
 
 def test_push_to_hub(repo_name: str, cleanup_repo: None) -> None:
-    model = timm.create_model("resnet18")
-    timm.models.hub.push_to_hf_hub(model, repo_name)
+    model = timm.create_model("mobilenetv3_rw")
+    timm.models.push_to_hf_hub(model, repo_name)


### PR DESCRIPTION
Fix #1324.

HF helpers location changed in `timm` packages. This PR just changes the import (+test on smaller models to save bandwidth).