### PR TITLE
Switch datasets type in ModelCard to a list of datasets

### DIFF
--- a/src/huggingface_hub/repocard.py
+++ b/src/huggingface_hub/repocard.py
@@ -358,7 +358,7 @@ class ModelCard(RepoCard):
             ...     license='mit',
             ...     library_name='timm',
             ...     tags=['image-classification', 'resnet'],
-            ...     datasets='beans',
+            ...     datasets=['beans'],
             ...     metrics=['accuracy'],
             ... )
             >>> card = ModelCard.from_template(

--- a/src/huggingface_hub/repocard_data.py
+++ b/src/huggingface_hub/repocard_data.py
@@ -205,8 +205,8 @@ class ModelCardData(CardData):
         tags (`List[str]`, *optional*):
             List of tags to add to your model that can be used when filtering on the Hugging
             Face Hub. Defaults to None.
-        datasets (`Union[str, List[str]]`, *optional*):
-            Dataset or list of datasets that were used to train this model. Should be a dataset ID
+        datasets (`List[str]`, *optional*):
+            List of datasets that were used to train this model. Should be a dataset ID
             found on https://hf.co/datasets. Defaults to None.
         metrics (`Union[str, List[str]]`, *optional*):
             List of metrics used to evaluate this model. Should be a metric name that can be found
@@ -244,7 +244,7 @@ class ModelCardData(CardData):
         license: Optional[str] = None,
         library_name: Optional[str] = None,
         tags: Optional[List[str]] = None,
-        datasets: Optional[Union[str, List[str]]] = None,
+        datasets: Optional[List[str]] = None,
         metrics: Optional[Union[str, List[str]]] = None,
         eval_results: Optional[List[EvalResult]] = None,
         model_name: Optional[str] = None,


### PR DESCRIPTION
Following a suggestion from @julien-c to update the `datasets` tag in `ModelCardData` from `Optional[Union[str, List[str]]]` to `Optional[List[str]]` so we get a YAML block like 

```yaml
datasets:
  - "IMDB"
```

rather than 
```yaml
datasets: "IMDB"
```

The changes here are just changing the types and doc strings, and there isn't any checking of what the user passes. This is consistent with existing behaviour, but happy to add this check if we want to enforce this type on the user. 