### PR TITLE
Remove deprecated code (0.13)

### DIFF
--- a/src/huggingface_hub/utils/_errors.py
+++ b/src/huggingface_hub/utils/_errors.py
@@ -2,7 +2,6 @@ from typing import Optional
 
 from requests import HTTPError, Response
 
-from ._deprecation import _deprecate_method
 from ._fixes import JSONDecodeError
 
 
@@ -300,28 +299,6 @@ def hf_raise_for_status(response: Response, endpoint_name: Optional[str] = None)
         # Convert `HTTPError` into a `HfHubHTTPError` to display request information
         # as well (request id and/or server error message)
         raise HfHubHTTPError(str(e), response=response) from e
-
-
-@_deprecate_method(version="0.13", message="Use `hf_raise_for_status` instead.")
-def _raise_for_status(response):
-    """Keep alias for now."""
-    hf_raise_for_status(response)
-
-
-@_deprecate_method(version="0.13", message="Use `hf_raise_for_status` instead.")
-def _raise_with_request_id(response):
-    """Keep alias for now."""
-    hf_raise_for_status(response)
-
-
-@_deprecate_method(version="0.13", message="Use `hf_raise_for_status` instead.")
-def _raise_convert_bad_request(response: Response, endpoint_name: str):
-    """
-    Calls hf_raise_for_status on resp and converts HTTP 400 errors into ValueError.
-
-    Keep alias for now.
-    """
-    hf_raise_for_status(response, endpoint_name=endpoint_name)
 
 
 def _format_error_message(message: str, request_id: Optional[str], server_message: Optional[str]) -> str:

--- a/tests/test_utils_errors.py
+++ b/tests/test_utils_errors.py
@@ -1,5 +1,4 @@
 import unittest
-from unittest.mock import Mock, patch
 
 from requests.models import Response
 
@@ -9,13 +8,8 @@ from huggingface_hub.utils._errors import (
     HfHubHTTPError,
     RepositoryNotFoundError,
     RevisionNotFoundError,
-    _raise_convert_bad_request,
-    _raise_for_status,
-    _raise_with_request_id,
     hf_raise_for_status,
 )
-
-from .testing_utils import expect_deprecation
 
 
 class TestErrorUtils(unittest.TestCase):
@@ -88,31 +82,6 @@ class TestErrorUtils(unittest.TestCase):
 
         self.assertEqual(context.exception.response.status_code, 404)
         self.assertEqual(context.exception.response.url, "test_URL")
-
-    @expect_deprecation("_raise_for_status")
-    @patch("huggingface_hub.utils._errors.hf_raise_for_status")
-    def test_raise_for_status(self, mock_hf_raise_for_status: Mock) -> None:
-        """Test `_raise_for_status` alias."""
-        response_mock = Mock()
-        _raise_for_status(response_mock)
-        mock_hf_raise_for_status.assert_called_once_with(response_mock)
-
-    @expect_deprecation("_raise_with_request_id")
-    @patch("huggingface_hub.utils._errors.hf_raise_for_status")
-    def test_raise_with_request_id(self, mock_hf_raise_for_status: Mock) -> None:
-        """Test `_raise_with_request_id` alias."""
-        response_mock = Mock()
-        _raise_with_request_id(response_mock)
-        mock_hf_raise_for_status.assert_called_once_with(response_mock)
-
-    @expect_deprecation("_raise_convert_bad_request")
-    @patch("huggingface_hub.utils._errors.hf_raise_for_status")
-    def test_raise_convert_bad_request(self, mock_hf_raise_for_status: Mock) -> None:
-        """Test `_raise_convert_bad_request` alias."""
-        response_mock = Mock()
-        endpoint_name_mock = Mock()
-        _raise_convert_bad_request(response_mock, endpoint_name_mock)
-        mock_hf_raise_for_status.assert_called_once_with(response_mock, endpoint_name=endpoint_name_mock)
 
 
 class TestHfHubHTTPError(unittest.TestCase):


### PR DESCRIPTION
Just 3 private methods (aliases for `hf_raise_for_status`).
They were used in `transformers` some versions ago but now completely removed (they were removed even before the deprecation cycle started).