### PR TITLE
Write Mixins/Integration guide

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -29,7 +29,7 @@
     - local: guides/manage-spaces
       title: Manage your Space
     - local: guides/integrations
-      title: Integrate your library
+      title: Integrate a library
 - title: "Conceptual guides"
   sections:
     - local: concepts/git_vs_http

--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -28,6 +28,8 @@
       title: Model Cards
     - local: guides/manage-spaces
       title: Manage your Space
+    - local: guides/integrations
+      title: Integrate your library
 - title: "Conceptual guides"
   sections:
     - local: concepts/git_vs_http

--- a/docs/source/guides/integrations.mdx
+++ b/docs/source/guides/integrations.mdx
@@ -263,3 +263,17 @@ class PyTorchModelHubMixin(ModelHubMixin):
 ```
 
 And that's it! Your library now enables users to upload and download files to and from the Hub.
+
+## Quick comparison
+
+Let's quickly sum up the two approaches we saw with their advantages and drawbacks. The table below is only indicative.
+Your framework might have some specificities that you need to address. This guide is only here to give guidelines and
+ideas on how to handle integration. In any case, feel free to contact us if you have any questions!
+
+<!-- Generated using https://www.tablesgenerator.com/markdown_tables -->
+| Integration | Using helpers | Using [`ModelHubMixin`] |
+|:---:|:---:|:---:|
+| User experience | Good.<br><br>`model = load_from_hub(...)`<br>`push_to_hub(model, ...)` | Good.<br><br>`model = MyModel.from_pretrained(...)`<br>`model.push_to_hub(...)` |
+| Flexibility | Very flexible.<br>You fully control the implementation. | Less flexible.<br>Your framework must have a model class. |
+| Maintenance | More maintenance to add support for configuration,<br>new features,... Might also requires to fix issues<br>reported by users. | Less maintenance as most of the interactions with<br>the Hub are implemented in `huggingface_hub`. |
+| Documentation /<br>Type annotation | To be written manually. | Partially handled by `huggingface_hub`. |

--- a/docs/source/guides/integrations.mdx
+++ b/docs/source/guides/integrations.mdx
@@ -1,0 +1,86 @@
+# Integrate any framework to the Hub
+
+The Huggingface Hub makes it easy to host and share models with the community. It already has support for
+[dozens of libraries](https://huggingface.co/docs/hub/models-libraries) in the Open Source ecosystem. We are always
+working on expanding this support to push Machine Learning forward. The `huggingface_hub` library plays a key role in
+this process, allowing any Python script to easily push and load files.
+
+When talking about integrating a library to the Hub, we have 4 main topics:
+1. **Push to Hub:** implement a `push_to_hub()`-like method to upload a model to the Hub.
+   This includes the model weights as well as the modelcard and any other relevant information/data necessary to run the model (example: logs from training).
+2. **Download from Hub:** implement a `from_pretrained`-like method to load a model from the Hub.
+   Takes care of downloading the model configuration/weights and instantiating it.
+3. **Inference API:** collaborate with the HF Team to make it possible to run inference on our servers, using your library.
+4. **Widgets:** collaborate with the HF Team to display a widget on the landing page of your models on the Hub. It allows users to quickly try a model from the browser.
+
+In this guide, we will focus on topic 1 and 2. If you are interested in Inference and Widgets, please let us know!
+You can also reach out to us if you are integrating your library with the Hub and want to be listed [in our docs](https://huggingface.co/docs/hub/models-libraries).
+
+## The recommended way: use class inheritance
+
+
+As we saw above, we are interested in having 2 methods: one to upload files (`push_to_hub`) and one to download files (`from_pretrained`).
+In most cases, a library will implement its model using a Python class. The class contains the properties of the model
+and methods to load, run, train, evaluate,... it. It would be nice to extend the class with the 2 new methods!
+
+The recommended approach to do so is to use inheritance, and more precisely mixins. A [Mixin](https://stackoverflow.com/a/547714)
+is a class that is meant to extend an existing class with a set of specific features using multiple inheritance.
+`huggingface_hub` defined its own mixin [`ModelHubMixin`]. The key here is to understand its behavior and how to customize it.
+
+### A bit of theory
+
+The [`ModelHubMixin`] class defines 3 *public* methods (`push_to_hub`, `save_pretrained` and `from_pretrained`) and 2
+*private* ones (`_save_pretrained` and `_from_pretrained`). Let's see how to use them!
+
+1. Make your Model class inherit from [`ModelHubMixin`].
+2. Implement the private methods:
+    - `_save_pretrained`: method taking as input a path to a directory and saving the model to it. You must write all the logic to
+    dump your model in this method: model weights, model card, configuration files, training logs and figures,... Any
+    information that is relevant for this model must be handled by this method.
+    - `_from_pretrained`: class method taking as input a model_id and returning an instantiate model. The method must download the
+    relevant files and load them.
+3. You are done!
+
+The advantage of using [`ModelHubMixin`] is that you only take care of the serialization/loading of the files and you are ready to
+go. In particular, you don't need to care about stuff like repo creation, commits, PRs, revisions,... All of this is handled by
+the mixin and available for your user.
+
+### A concrete example: PyTorch
+
+A good example of what we saw above is [`PyTorchModelHubMixin`], our integration for the PyTorch framework.
+This is a ready-to-use integration. Here is how to use it:
+
+```python
+>>> import torch
+>>> import torch.nn as nn
+>>> from huggingface_hub import PyTorchModelHubMixin
+
+# 1. Define your Pytorch model exactly the same way you are used to
+>>> class MyModel(nn.Module, PyTorchModelHubMixin): # multiple inheritance
+...     def __init__(self):
+...         super().__init__() 
+...         self.param = nn.Parameter(torch.rand(3, 4))
+...         self.linear = nn.Linear(4, 5)
+
+...     def forward(self, x):
+...         return self.linear(x + self.param)
+>>> model = MyModel()
+
+# 2. (optional) Save model to local directory
+>>> model.save_pretrained("path/to/my-awesome-model")
+
+# 3. Push model weights to the Hub
+>>> model.push_to_hub("my-awesome-model")
+
+# 4. Initialize model from the Hub
+>>> model = MyModel.from_pretrained("username/my-awesome-model")
+```
+
+How easy is that? Now, we are interested in how it is implemented under the hood.
+
+## The other way: write functions
+
+### Example: FastAI
+
+
+

--- a/docs/source/guides/integrations.mdx
+++ b/docs/source/guides/integrations.mdx
@@ -2,32 +2,39 @@
 
 The Hugging Face Hub makes hosting and sharing models with the community easy. It supports
 [dozens of libraries](https://huggingface.co/docs/hub/models-libraries) in the Open Source ecosystem. We are always
-working on expanding this support to push collaborative Machine Learning forward. The `huggingface_hub` library plays a key role in
-this process, allowing any Python script to easily push and load files.
+working on expanding this support to push collaborative Machine Learning forward. The `huggingface_hub` library plays a
+key role in this process, allowing any Python script to easily push and load files.
 
 There are four main ways to integrate a library with the Hub:
-1. **Push to Hub:** implement a `push_to_hub()`-like method to upload a model to the Hub.
-   This includes the model weights, as well as [the model card](https://huggingface.co/docs/huggingface_hub/how-to-model-cards) and any other relevant information or data necessary to run the model (for example, training logs).
-2. **Download from Hub:** implement a `from_pretrained`-like method to load a model from the Hub.
-   The method should download the model configuration/weights and load the model.
+1. **Push to Hub:** implement a method to upload a model to the Hub. This includes the model weights, as well as
+   [the model card](https://huggingface.co/docs/huggingface_hub/how-to-model-cards) and any other relevant information
+   or data necessary to run the model (for example, training logs). This method is often called `push_to_hub()`.
+2. **Download from Hub:** implement a method to load a model from the Hub. The method should download the model
+   configuration/weights and load the model. This method is often called `from_pretrained`. 
 3. **Inference API:** use our servers to run inference on models supported by your library for free.
-4. **Widgets:** collaborate with the HF Team to display a widget on the landing page of your models on the Hub. It allows users to quickly try a model from the browser.
+4. **Widgets:** display a widget on the landing page of your models on the Hub. It allows users to quickly try a model
+   from the browser.
 
-In this guide, we will focus on the first two topics. If you are interested in Inference and Widgets, please let us know!
-You can also reach out to us if you are integrating your library with the Hub and want to be listed [in our docs](https://huggingface.co/docs/hub/models-libraries).
+In this guide, we will focus on the first two topics. If you are interested in Inference and Widgets, you can follow
+[this guide](https://huggingface.co/docs/hub/models-adding-libraries#set-up-the-inference-api). In both cases, you can
+reach out to us if you are integrating your library with the Hub and want to be listed [in our docs](https://huggingface.co/docs/hub/models-libraries). 
 
 ## A bit of theory: use class inheritance
 
-As we saw above, there are two main methods to include in your library to integrate it with the Hub: upload files (`push_to_hub`) and download files (`from_pretrained`).
-In most cases, a library already implements its model using a Python class. The class contains the properties of the model
-and methods to load, run, train, and evaluate it. You can extend the class to include functionality for uploading and downloading files to the Hub!
+As we saw above, there are two main methods to include in your library to integrate it with the Hub: upload files
+(`push_to_hub`) and download files (`from_pretrained`). In most cases, a library already implements its model using a
+Python class. The class contains the properties of the model and methods to load, run, train, and evaluate it. You can
+extend the class to include functionality for uploading and downloading files to the Hub!
 
 The best way to do this is by using inheritance, specifically mixins. A [Mixin](https://stackoverflow.com/a/547714)
 is a class that is meant to extend an existing class with a set of specific features using multiple inheritance.
-`huggingface_hub` provides its own mixin, the [`ModelHubMixin`]. The key here is to understand its behavior and how to customize it.
+`huggingface_hub` provides its own mixin, the [`ModelHubMixin`]. The key here is to understand its behavior and how to
+customize it.
 
-The [`ModelHubMixin`] class defines 3 *public* methods (`push_to_hub`, `save_pretrained` and `from_pretrained`) and 2
-*private* ones (`_save_pretrained` and `_from_pretrained`). To integrate it, you should:
+The [`ModelHubMixin`] class implements 3 *public* methods (`push_to_hub`, `save_pretrained` and `from_pretrained`). Those
+are the methods that your users will call to load/save models with your library. [`ModelHubMixin`] also defines 2
+*private* methods (`_save_pretrained` and `_from_pretrained`). Those are the ones you must implement. So to integrate
+your library, you should:
 
 1. Make your Model class inherit from [`ModelHubMixin`].
 2. Implement the private methods:

--- a/docs/source/guides/integrations.mdx
+++ b/docs/source/guides/integrations.mdx
@@ -16,39 +16,38 @@ When talking about integrating a library to the Hub, we have 4 main topics:
 In this guide, we will focus on topic 1 and 2. If you are interested in Inference and Widgets, please let us know!
 You can also reach out to us if you are integrating your library with the Hub and want to be listed [in our docs](https://huggingface.co/docs/hub/models-libraries).
 
-## The recommended way: use class inheritance
-
+## A bit of theory: use class inheritance
 
 As we saw above, we are interested in having 2 methods: one to upload files (`push_to_hub`) and one to download files (`from_pretrained`).
-In most cases, a library will implement its model using a Python class. The class contains the properties of the model
+In most cases, a library already implements its model using a Python class. The class contains the properties of the model
 and methods to load, run, train, evaluate,... it. It would be nice to extend the class with the 2 new methods!
 
 The recommended approach to do so is to use inheritance, and more precisely mixins. A [Mixin](https://stackoverflow.com/a/547714)
 is a class that is meant to extend an existing class with a set of specific features using multiple inheritance.
 `huggingface_hub` defined its own mixin [`ModelHubMixin`]. The key here is to understand its behavior and how to customize it.
 
-### A bit of theory
-
 The [`ModelHubMixin`] class defines 3 *public* methods (`push_to_hub`, `save_pretrained` and `from_pretrained`) and 2
-*private* ones (`_save_pretrained` and `_from_pretrained`). Let's see how to use them!
+*private* ones (`_save_pretrained` and `_from_pretrained`). To integrate it, you should:
 
 1. Make your Model class inherit from [`ModelHubMixin`].
 2. Implement the private methods:
-    - `_save_pretrained`: method taking as input a path to a directory and saving the model to it. You must write all the logic to
-    dump your model in this method: model weights, model card, configuration files, training logs and figures,... Any
-    information that is relevant for this model must be handled by this method.
-    - `_from_pretrained`: class method taking as input a model_id and returning an instantiate model. The method must download the
-    relevant files and load them.
+    - [`~ModelHubMixin._save_pretrained`]: method taking as input a path to a directory and saving the model to it.
+    You must write all the logic to dump your model in this method: model card, model weights, configuration files,
+    training logs and figures,... Any information that is relevant for this model must be handled by this method.
+    [Model Cards](https://huggingface.co/docs/hub/model-cards) are particularly important to describe your model. Check
+    out [our implementation guide](./model-cards) for more details.
+    - [`~ModelHubMixin._from_pretrained`]: **class method** taking as input a model_id and returning an instantiated
+    model. The method must download the relevant files and load them.
 3. You are done!
 
-The advantage of using [`ModelHubMixin`] is that you only take care of the serialization/loading of the files and you are ready to
-go. In particular, you don't need to care about stuff like repo creation, commits, PRs, revisions,... All of this is handled by
-the mixin and available for your user.
+The advantage of using [`ModelHubMixin`] is that you only take care of the serialization/loading of the files and you
+are ready to go. In particular, you don't need to care about stuff like repo creation, commits, PRs, revisions,... All
+of this is handled by the mixin and available to your users.
 
-### A concrete example: PyTorch
+## A concrete example: PyTorch
 
-A good example of what we saw above is [`PyTorchModelHubMixin`], our integration for the PyTorch framework.
-This is a ready-to-use integration. Here is how to use it:
+A good example of what we saw above is [`PyTorchModelHubMixin`], our integration for the PyTorch framework. This is a
+ready-to-use integration. Here is how to use it:
 
 ```python
 >>> import torch
@@ -76,11 +75,90 @@ This is a ready-to-use integration. Here is how to use it:
 >>> model = MyModel.from_pretrained("username/my-awesome-model")
 ```
 
-How easy is that? Now, we are interested in how it is implemented under the hood.
+How easy is that? Now, we are interested in how it is implemented under the hood. Full implementation can be found
+[here](https://github.com/huggingface/huggingface_hub/blob/main/src/huggingface_hub/hub_mixin.py).
 
-## The other way: write functions
+1. First, inherit your class from `ModelHubMixin`:
 
-### Example: FastAI
+```python
+from huggingface_hub import ModelHubMixin
+
+class PyTorchModelHubMixin(ModelHubMixin):
+   (...)
+```
+
+2. Implement the `_save_pretrained` method:
+
+```py
+from huggingface_hub import ModelCard, ModelCardData
+
+class PyTorchModelHubMixin(ModelHubMixin):
+   (...)
+
+   def _save_pretrained(self, save_directory: Path):
+      """Generate Model Card and save weights from a Pytorch model to a local directory."""
+      model_card = ModelCard.from_template(
+         card_data=ModelCardData(
+            license='mit',
+            library_name="pytorch",
+            ...
+         ),
+         model_summary=...,
+         model_type=...,
+         ...
+      )
+      (save_directory / "README.md").write_text(str(model))
+      torch.save(obj=self.module.state_dict(), f=save_directory / "pytorch_model.bin")
+```
+
+3. Implement the `_from_pretrained` method:
+
+```python
+class PyTorchModelHubMixin(ModelHubMixin):
+   (...)
+
+   @classmethod # Must be a classmethod!
+   def _from_pretrained(
+      cls,
+      *,
+      model_id: str,
+      revision: str,
+      cache_dir: str,
+      force_download: bool,
+      proxies: Optional[Dict],
+      resume_download: bool,
+      local_files_only: bool,
+      token: Union[str, bool, None],
+      map_location: str = "cpu", # additional argument
+      strict: bool = False, # additional argument
+      **model_kwargs,
+   ):
+      """Load Pytorch pretrained weights and return the loaded model."""
+      if os.path.isdir(model_id): # Can either be a local directory
+         print("Loading weights from local directory")
+         model_file = os.path.join(model_id, "pytorch_model.bin")
+      else: # Or a model on the Hub
+         model_file = hf_hub_download( # Download from the hub, passing same input args
+            repo_id=model_id,
+            filename="pytorch_model.bin",
+            revision=revision,
+            cache_dir=cache_dir,
+            force_download=force_download,
+            proxies=proxies,
+            resume_download=resume_download,
+            token=token,
+            local_files_only=local_files_only,
+         )
+
+      # Load model and return - custom logic depending on your framework
+      model = cls(**model_kwargs)
+      state_dict = torch.load(model_file, map_location=torch.device(map_location))
+      model.load_state_dict(state_dict, strict=strict)
+      model.eval()
+      return model
+```
+
+And that's it!
 
 
 

--- a/docs/source/guides/integrations.mdx
+++ b/docs/source/guides/integrations.mdx
@@ -273,7 +273,7 @@ ideas on how to handle integration. In any case, feel free to contact us if you 
 <!-- Generated using https://www.tablesgenerator.com/markdown_tables -->
 | Integration | Using helpers | Using [`ModelHubMixin`] |
 |:---:|:---:|:---:|
-| User experience | Good.<br><br>`model = load_from_hub(...)`<br>`push_to_hub(model, ...)` | Good.<br><br>`model = MyModel.from_pretrained(...)`<br>`model.push_to_hub(...)` |
+| User experience | Good.<br>`model = load_from_hub(...)`<br>`push_to_hub(model, ...)` | Good.<br>`model = MyModel.from_pretrained(...)`<br>`model.push_to_hub(...)` |
 | Flexibility | Very flexible.<br>You fully control the implementation. | Less flexible.<br>Your framework must have a model class. |
-| Maintenance | More maintenance to add support for configuration,<br>new features,... Might also requires to fix issues<br>reported by users. | Less maintenance as most of the interactions with<br>the Hub are implemented in `huggingface_hub`. |
-| Documentation /<br>Type annotation | To be written manually. | Partially handled by `huggingface_hub`. |
+| Maintenance | More maintenance to add support for configuration, new features,... Might also requires to fix issues reported by users. | Less maintenance as most of the interactions with the Hub are implemented in `huggingface_hub`. |
+| Documentation / Type annotation | To be written manually. | Partially handled by `huggingface_hub`. |

--- a/docs/source/guides/integrations.mdx
+++ b/docs/source/guides/integrations.mdx
@@ -10,7 +10,7 @@ There are four main ways to integrate a library with the Hub:
    [the model card](https://huggingface.co/docs/huggingface_hub/how-to-model-cards) and any other relevant information
    or data necessary to run the model (for example, training logs). This method is often called `push_to_hub()`.
 2. **Download from Hub:** implement a method to load a model from the Hub. The method should download the model
-   configuration/weights and load the model. This method is often called `from_pretrained`. 
+   configuration/weights and load the model. This method is often called `from_pretrained` or `load_from_hub()`.
 3. **Inference API:** use our servers to run inference on models supported by your library for free.
 4. **Widgets:** display a widget on the landing page of your models on the Hub. It allows users to quickly try a model
    from the browser.
@@ -19,17 +19,108 @@ In this guide, we will focus on the first two topics. If you are interested in I
 [this guide](https://huggingface.co/docs/hub/models-adding-libraries#set-up-the-inference-api). In both cases, you can
 reach out to us if you are integrating your library with the Hub and want to be listed [in our docs](https://huggingface.co/docs/hub/models-libraries). 
 
-## A bit of theory: use class inheritance
+## A first approach: helpers
+
+The first approach to integrate a library to the Hub is to actually implement the `push_to_hub` and `from_pretrained`
+methods by yourself. This gives you full flexibility on which files you need to upload/download and how to handle inputs
+specific to your framework. You can refers to the two [upload files](./upload) and [download files](./download) guides
+to learn more on how to do that. This is for example how FastAI integration is implemented (see [`push_to_hub_fastai`]
+and [`from_pretrained_fastai`]).
+
+Implementation can defer between libraries but the workflow is often similar.
+
+### from_pretrained
+
+This is how a `from_pretrained` method usually look like:
+
+```python
+def from_pretrained(model_id: str):
+   # Download model from Hub
+   cached_model = hf_hub_download(
+      repo_id=repo_id,
+      filename="model.pkl",
+      library_name="fastai",
+      library_version=get_fastai_version(),
+   )
+
+   # Load model
+    return load_model(cached_model)
+```
+
+### push_to_hub
+
+The `push_to_hub` often require a bit more complexity to handle repo creation, generate the model card and save weights.
+A common approach is to save all of these files in a temporary folder, upload it and then delete it.
+
+```python
+def push_to_hub(model, repo_name: str) -> None:
+   api = HfApi()
+
+   # Create repo if not existing yet and get the associated repo_id
+   repo_id = api.create_repo(repo_name, exist_ok=True)
+
+   # Save all files in a temporary directory and push them in a single commit
+   with TemporaryDirectory() as tmpdir:
+      tmpdir = Path(tmpdir)
+
+      # Save weights
+      save_model(model, tmpdir / "model.safetensors")
+
+      # Generate model card
+      card = generate_model_card(model)
+      (tmpdir / "README.md").write_text(card)
+
+      # Save logs
+      # Save figures
+      # Save evaluation metrics
+      # ...
+
+      # Push to hub
+      return api.upload_folder(repo_id=repo_id, folder_path=tmpdir)
+```
+
+This is of course only an example. If you are interested in more complex manipulations (delete remote files, upload
+weights on the fly, persist weights locally,...) please refer to the [upload files](./upload) guide.
+
+### Limitations
+
+While being flexible, this approach has some drawbacks, especially in term of maintenance. Huggingface users are often
+used to additional features when working with `huggingface_hub`. For example, when load files from the Hub, it is
+common to offer parameters like
+- `token`: to download from a private repo
+- `revision`: to download from a specific branch
+- `cache_dir`: to cache files in a specific directory
+- `force_download`/`resume_download`/`local_files_only`: to reuse the cache or not
+- `api_endpoint`/`proxies`: configure HTTP session
+
+When pushing models, similar parameters are supported:
+- `commit_message`: custom commit message
+- `private`: create a private repo if missing
+- `create_pr`: create a PR instead of pushing to `main`
+- `branch`: push to a branch instead of the `main` branch
+- `allow_patterns`/`ignore_patterns`: filter which files to upload
+- `token`
+- `api_endpoint`
+- ...
+
+All of these parameters can be added to the implementations we saw above and passed to the `huggingface_hub` methods.
+However, if a parameter changes or a new feature is added, you will need to update your package. Supporting those
+parameters also means more documentation to maintain on your side. To see how to mitigate these limitations, let's jump
+to our next section **class inheritance**.
+
+## A more complex approach: class inheritance
+
+### A bit of theory
 
 As we saw above, there are two main methods to include in your library to integrate it with the Hub: upload files
-(`push_to_hub`) and download files (`from_pretrained`). In most cases, a library already implements its model using a
-Python class. The class contains the properties of the model and methods to load, run, train, and evaluate it. You can
-extend the class to include functionality for uploading and downloading files to the Hub!
+(`push_to_hub`) and download files (`from_pretrained`). You can implement those methods by yourself but it comes with
+caveats. To tackle this, `huggingface_hub` provides a tool that uses class inheritance. Let's see how it works!
 
-The best way to do this is by using inheritance, specifically mixins. A [Mixin](https://stackoverflow.com/a/547714)
-is a class that is meant to extend an existing class with a set of specific features using multiple inheritance.
-`huggingface_hub` provides its own mixin, the [`ModelHubMixin`]. The key here is to understand its behavior and how to
-customize it.
+In a lot of cases, a library already implements its model using a Python class. The class contains the properties of
+the model and methods to load, run, train, and evaluate it. Our approach is to extend this class to include upload and
+download features using mixins. A [Mixin](https://stackoverflow.com/a/547714) is a class that is meant to extend an
+existing class with a set of specific features using multiple inheritance. `huggingface_hub` provides its own mixin,
+the [`ModelHubMixin`]. The key here is to understand its behavior and how to customize it.
 
 The [`ModelHubMixin`] class implements 3 *public* methods (`push_to_hub`, `save_pretrained` and `from_pretrained`). Those
 are the methods that your users will call to load/save models with your library. [`ModelHubMixin`] also defines 2
@@ -49,14 +140,15 @@ your library, you should:
 
 The advantage of using [`ModelHubMixin`] is that once you take care of the serialization/loading of the files, you
 are ready to go. You don't need to worry about stuff like repo creation, commits, PRs, or revisions. All
-of this is handled by the mixin and is available to your users.
+of this is handled by the mixin and is available to your users. The Mixin also ensures that public methods are well
+documented and type annotated.
 
-## A concrete example: PyTorch
+### A concrete example: PyTorch
 
 A good example of what we saw above is [`PyTorchModelHubMixin`], our integration for the PyTorch framework. This is a
 ready-to-use integration.
 
-### How to use it?
+#### How to use it?
 
 Here is how any user can load/save a PyTorch model from/to the Hub:
 
@@ -86,7 +178,7 @@ Here is how any user can load/save a PyTorch model from/to the Hub:
 >>> model = MyModel.from_pretrained("username/my-awesome-model")
 ```
 
-### Implementation
+#### Implementation
 
 The implementation is actually very straightforward, and the full implementation can be found [here](https://github.com/huggingface/huggingface_hub/blob/main/src/huggingface_hub/hub_mixin.py).
 
@@ -171,6 +263,3 @@ class PyTorchModelHubMixin(ModelHubMixin):
 ```
 
 And that's it! Your library now enables users to upload and download files to and from the Hub.
-
-
-

--- a/docs/source/guides/integrations.mdx
+++ b/docs/source/guides/integrations.mdx
@@ -20,11 +20,11 @@ You can also reach out to us if you are integrating your library with the Hub an
 
 As we saw above, there are two main methods to include in your library to integrate it with the Hub: upload files (`push_to_hub`) and download files (`from_pretrained`).
 In most cases, a library already implements its model using a Python class. The class contains the properties of the model
-and methods to load, run, train, evaluate,... it. It would be nice to extend the class with the 2 new methods!
+and methods to load, run, train, and evaluate it. You can extend the class to include functionality for uploading and downloading files to the Hub!
 
-The recommended approach to do so is to use inheritance, and more precisely mixins. A [Mixin](https://stackoverflow.com/a/547714)
+The best way to do this is by using inheritance, specifically mixins. A [Mixin](https://stackoverflow.com/a/547714)
 is a class that is meant to extend an existing class with a set of specific features using multiple inheritance.
-`huggingface_hub` defined its own mixin [`ModelHubMixin`]. The key here is to understand its behavior and how to customize it.
+`huggingface_hub` provides its own mixin, the [`ModelHubMixin`]. The key here is to understand its behavior and how to customize it.
 
 The [`ModelHubMixin`] class defines 3 *public* methods (`push_to_hub`, `save_pretrained` and `from_pretrained`) and 2
 *private* ones (`_save_pretrained` and `_from_pretrained`). To integrate it, you should:
@@ -33,16 +33,16 @@ The [`ModelHubMixin`] class defines 3 *public* methods (`push_to_hub`, `save_pre
 2. Implement the private methods:
     - [`~ModelHubMixin._save_pretrained`]: method taking as input a path to a directory and saving the model to it.
     You must write all the logic to dump your model in this method: model card, model weights, configuration files,
-    training logs and figures,... Any information that is relevant for this model must be handled by this method.
+    training logs, and figures. Any relevant information for this model must be handled by this method.
     [Model Cards](https://huggingface.co/docs/hub/model-cards) are particularly important to describe your model. Check
     out [our implementation guide](./model-cards) for more details.
-    - [`~ModelHubMixin._from_pretrained`]: **class method** taking as input a model_id and returning an instantiated
+    - [`~ModelHubMixin._from_pretrained`]: **class method** taking as input a `model_id` and returning an instantiated
     model. The method must download the relevant files and load them.
 3. You are done!
 
-The advantage of using [`ModelHubMixin`] is that you only take care of the serialization/loading of the files and you
-are ready to go. In particular, you don't need to care about stuff like repo creation, commits, PRs, revisions,... All
-of this is handled by the mixin and available to your users.
+The advantage of using [`ModelHubMixin`] is that once you take care of the serialization/loading of the files, you
+are ready to go. You don't need to worry about stuff like repo creation, commits, PRs, or revisions. All
+of this is handled by the mixin and is available to your users.
 
 ## A concrete example: PyTorch
 
@@ -51,7 +51,7 @@ ready-to-use integration.
 
 ### How to use it?
 
-Here is how any user can load/save a Pytorch model from/to the Hub:
+Here is how any user can load/save a PyTorch model from/to the Hub:
 
 ```python
 >>> import torch
@@ -81,8 +81,7 @@ Here is how any user can load/save a Pytorch model from/to the Hub:
 
 ### Implementation
 
-How easy was that? Now, we are interested in how it is implemented under the hood. It is very straightforward.
-Full implementation can be found [here](https://github.com/huggingface/huggingface_hub/blob/main/src/huggingface_hub/hub_mixin.py).
+The implementation is actually very straightforward, and the full implementation can be found [here](https://github.com/huggingface/huggingface_hub/blob/main/src/huggingface_hub/hub_mixin.py).
 
 1. First, inherit your class from `ModelHubMixin`:
 
@@ -164,7 +163,7 @@ class PyTorchModelHubMixin(ModelHubMixin):
       return model
 ```
 
-And that's it!
+And that's it! Your library now enables users to upload and download files to and from the Hub.
 
 
 

--- a/docs/source/guides/integrations.mdx
+++ b/docs/source/guides/integrations.mdx
@@ -1,4 +1,4 @@
-# Integrate any framework to the Hub
+# Integrate any ML framework with the Hub
 
 The Huggingface Hub makes it easy to host and share models with the community. It already has support for
 [dozens of libraries](https://huggingface.co/docs/hub/models-libraries) in the Open Source ecosystem. We are always

--- a/docs/source/guides/integrations.mdx
+++ b/docs/source/guides/integrations.mdx
@@ -47,7 +47,11 @@ of this is handled by the mixin and available to your users.
 ## A concrete example: PyTorch
 
 A good example of what we saw above is [`PyTorchModelHubMixin`], our integration for the PyTorch framework. This is a
-ready-to-use integration. Here is how to use it:
+ready-to-use integration.
+
+### How to use it?
+
+Here is how any user can load/save a Pytorch model from/to the Hub:
 
 ```python
 >>> import torch
@@ -75,8 +79,10 @@ ready-to-use integration. Here is how to use it:
 >>> model = MyModel.from_pretrained("username/my-awesome-model")
 ```
 
-How easy is that? Now, we are interested in how it is implemented under the hood. Full implementation can be found
-[here](https://github.com/huggingface/huggingface_hub/blob/main/src/huggingface_hub/hub_mixin.py).
+### Implementation
+
+How easy was that? Now, we are interested in how it is implemented under the hood. It is very straightforward.
+Full implementation can be found [here](https://github.com/huggingface/huggingface_hub/blob/main/src/huggingface_hub/hub_mixin.py).
 
 1. First, inherit your class from `ModelHubMixin`:
 

--- a/docs/source/guides/integrations.mdx
+++ b/docs/source/guides/integrations.mdx
@@ -1,13 +1,13 @@
 # Integrate any ML framework with the Hub
 
-The Huggingface Hub makes it easy to host and share models with the community. It already has support for
+The Hugging Face Hub makes hosting and sharing models with the community easy. It supports
 [dozens of libraries](https://huggingface.co/docs/hub/models-libraries) in the Open Source ecosystem. We are always
-working on expanding this support to push Machine Learning forward. The `huggingface_hub` library plays a key role in
+working on expanding this support to push collaborative Machine Learning forward. The `huggingface_hub` library plays a key role in
 this process, allowing any Python script to easily push and load files.
 
-When talking about integrating a library to the Hub, we have 4 main topics:
+There are four main ways to integrate a library with the Hub:
 1. **Push to Hub:** implement a `push_to_hub()`-like method to upload a model to the Hub.
-   This includes the model weights as well as the modelcard and any other relevant information/data necessary to run the model (example: logs from training).
+   This includes the model weights, as well as [the model card](https://huggingface.co/docs/huggingface_hub/how-to-model-cards) and any other relevant information or data necessary to run the model (for example, training logs).
 2. **Download from Hub:** implement a `from_pretrained`-like method to load a model from the Hub.
    Takes care of downloading the model configuration/weights and instantiating it.
 3. **Inference API:** collaborate with the HF Team to make it possible to run inference on our servers, using your library.

--- a/docs/source/guides/integrations.mdx
+++ b/docs/source/guides/integrations.mdx
@@ -9,16 +9,16 @@ There are four main ways to integrate a library with the Hub:
 1. **Push to Hub:** implement a `push_to_hub()`-like method to upload a model to the Hub.
    This includes the model weights, as well as [the model card](https://huggingface.co/docs/huggingface_hub/how-to-model-cards) and any other relevant information or data necessary to run the model (for example, training logs).
 2. **Download from Hub:** implement a `from_pretrained`-like method to load a model from the Hub.
-   Takes care of downloading the model configuration/weights and instantiating it.
-3. **Inference API:** collaborate with the HF Team to make it possible to run inference on our servers, using your library.
+   The method should download the model configuration/weights and load the model.
+3. **Inference API:** use our servers to run inference on models supported by your library for free.
 4. **Widgets:** collaborate with the HF Team to display a widget on the landing page of your models on the Hub. It allows users to quickly try a model from the browser.
 
-In this guide, we will focus on topic 1 and 2. If you are interested in Inference and Widgets, please let us know!
+In this guide, we will focus on the first two topics. If you are interested in Inference and Widgets, please let us know!
 You can also reach out to us if you are integrating your library with the Hub and want to be listed [in our docs](https://huggingface.co/docs/hub/models-libraries).
 
 ## A bit of theory: use class inheritance
 
-As we saw above, we are interested in having 2 methods: one to upload files (`push_to_hub`) and one to download files (`from_pretrained`).
+As we saw above, there are two main methods to include in your library to integrate it with the Hub: upload files (`push_to_hub`) and download files (`from_pretrained`).
 In most cases, a library already implements its model using a Python class. The class contains the properties of the model
 and methods to load, run, train, evaluate,... it. It would be nice to extend the class with the 2 new methods!
 

--- a/docs/source/guides/integrations.mdx
+++ b/docs/source/guides/integrations.mdx
@@ -23,11 +23,11 @@ reach out to us if you are integrating your library with the Hub and want to be 
 
 The first approach to integrate a library to the Hub is to actually implement the `push_to_hub` and `from_pretrained`
 methods by yourself. This gives you full flexibility on which files you need to upload/download and how to handle inputs
-specific to your framework. You can refers to the two [upload files](./upload) and [download files](./download) guides
-to learn more on how to do that. This is for example how FastAI integration is implemented (see [`push_to_hub_fastai`]
+specific to your framework. You can refer to the two [upload files](./upload) and [download files](./download) guides
+to learn more about how to do that. This is, for example how the FastAI integration is implemented (see [`push_to_hub_fastai`]
 and [`from_pretrained_fastai`]).
 
-Implementation can defer between libraries but the workflow is often similar.
+Implementation can differ between libraries, but the workflow is often similar.
 
 ### from_pretrained
 
@@ -49,7 +49,7 @@ def from_pretrained(model_id: str):
 
 ### push_to_hub
 
-The `push_to_hub` often require a bit more complexity to handle repo creation, generate the model card and save weights.
+The `push_to_hub` method often requires a bit more complexity to handle repo creation, generate the model card and save weights.
 A common approach is to save all of these files in a temporary folder, upload it and then delete it.
 
 ```python
@@ -80,13 +80,13 @@ def push_to_hub(model, repo_name: str) -> None:
 ```
 
 This is of course only an example. If you are interested in more complex manipulations (delete remote files, upload
-weights on the fly, persist weights locally,...) please refer to the [upload files](./upload) guide.
+weights on the fly, persist weights locally, etc.) please refer to the [upload files](./upload) guide.
 
 ### Limitations
 
-While being flexible, this approach has some drawbacks, especially in term of maintenance. Huggingface users are often
-used to additional features when working with `huggingface_hub`. For example, when load files from the Hub, it is
-common to offer parameters like
+While being flexible, this approach has some drawbacks, especially in terms of maintenance. Hugging Face users are often
+used to additional features when working with `huggingface_hub`. For example, when loading files from the Hub, it is
+common to offer parameters like:
 - `token`: to download from a private repo
 - `revision`: to download from a specific branch
 - `cache_dir`: to cache files in a specific directory
@@ -275,5 +275,5 @@ ideas on how to handle integration. In any case, feel free to contact us if you 
 |:---:|:---:|:---:|
 | User experience | Good.<br>`model = load_from_hub(...)`<br>`push_to_hub(model, ...)` | Good.<br>`model = MyModel.from_pretrained(...)`<br>`model.push_to_hub(...)` |
 | Flexibility | Very flexible.<br>You fully control the implementation. | Less flexible.<br>Your framework must have a model class. |
-| Maintenance | More maintenance to add support for configuration, new features,... Might also requires to fix issues reported by users. | Less maintenance as most of the interactions with the Hub are implemented in `huggingface_hub`. |
+| Maintenance | More maintenance to add support for configuration, and new features. Might also require fixing issues reported by users. | Less maintenance as most of the interactions with the Hub are implemented in `huggingface_hub`. |
 | Documentation / Type annotation | To be written manually. | Partially handled by `huggingface_hub`. |

--- a/docs/source/guides/integrations.mdx
+++ b/docs/source/guides/integrations.mdx
@@ -15,11 +15,15 @@ There are four main ways to integrate a library with the Hub:
 4. **Widgets:** display a widget on the landing page of your models on the Hub. It allows users to quickly try a model
    from the browser.
 
-In this guide, we will focus on the first two topics. If you are interested in Inference and Widgets, you can follow
-[this guide](https://huggingface.co/docs/hub/models-adding-libraries#set-up-the-inference-api). In both cases, you can
-reach out to us if you are integrating your library with the Hub and want to be listed [in our docs](https://huggingface.co/docs/hub/models-libraries). 
+In this guide, we will focus on the first two topics. We will present the two main approaches you can use to integrate
+a library, with their advantages and drawbacks. Everything is summarized at the end of the guide to help you choose
+between the two. Please keep in mind that these are only guidelines that you are free to adapt to you requirements.
 
-## A first approach: helpers
+If you are interested in Inference and Widgets, you can follow [this guide](https://huggingface.co/docs/hub/models-adding-libraries#set-up-the-inference-api).
+In both cases, you can reach out to us if you are integrating a library with the Hub and want to be listed
+[in our docs](https://huggingface.co/docs/hub/models-libraries).
+
+## A flexible approach: helpers
 
 The first approach to integrate a library to the Hub is to actually implement the `push_to_hub` and `from_pretrained`
 methods by yourself. This gives you full flexibility on which files you need to upload/download and how to handle inputs
@@ -34,7 +38,7 @@ Implementation can differ between libraries, but the workflow is often similar.
 This is how a `from_pretrained` method usually look like:
 
 ```python
-def from_pretrained(model_id: str):
+def from_pretrained(model_id: str) -> MyModelClass:
    # Download model from Hub
    cached_model = hf_hub_download(
       repo_id=repo_id,
@@ -53,7 +57,7 @@ The `push_to_hub` method often requires a bit more complexity to handle repo cre
 A common approach is to save all of these files in a temporary folder, upload it and then delete it.
 
 ```python
-def push_to_hub(model, repo_name: str) -> None:
+def push_to_hub(model: MyModelClass, repo_name: str) -> None:
    api = HfApi()
 
    # Create repo if not existing yet and get the associated repo_id
@@ -109,8 +113,6 @@ parameters also means more documentation to maintain on your side. To see how to
 to our next section **class inheritance**.
 
 ## A more complex approach: class inheritance
-
-### A bit of theory
 
 As we saw above, there are two main methods to include in your library to integrate it with the Hub: upload files
 (`push_to_hub`) and download files (`from_pretrained`). You can implement those methods by yourself but it comes with
@@ -273,7 +275,7 @@ ideas on how to handle integration. In any case, feel free to contact us if you 
 <!-- Generated using https://www.tablesgenerator.com/markdown_tables -->
 | Integration | Using helpers | Using [`ModelHubMixin`] |
 |:---:|:---:|:---:|
-| User experience | Good.<br>`model = load_from_hub(...)`<br>`push_to_hub(model, ...)` | Good.<br>`model = MyModel.from_pretrained(...)`<br>`model.push_to_hub(...)` |
+| User experience | `model = load_from_hub(...)`<br>`push_to_hub(model, ...)` | `model = MyModel.from_pretrained(...)`<br>`model.push_to_hub(...)` |
 | Flexibility | Very flexible.<br>You fully control the implementation. | Less flexible.<br>Your framework must have a model class. |
 | Maintenance | More maintenance to add support for configuration, and new features. Might also require fixing issues reported by users. | Less maintenance as most of the interactions with the Hub are implemented in `huggingface_hub`. |
 | Documentation / Type annotation | To be written manually. | Partially handled by `huggingface_hub`. |

--- a/docs/source/package_reference/mixins.mdx
+++ b/docs/source/package_reference/mixins.mdx
@@ -3,7 +3,8 @@
 ## Mixins
 
 The `huggingface_hub` library offers a range of mixins that can be used as a parent class for your
-objects, in order to provide simple uploading and downloading functions.
+objects, in order to provide simple uploading and downloading functions. Check out our [integration guide](../guides/integrations)
+to learn how to integrate any ML framework with the Hub.
 
 ### Generic
 

--- a/docs/source/package_reference/mixins.mdx
+++ b/docs/source/package_reference/mixins.mdx
@@ -2,9 +2,9 @@
 
 ## Mixins
 
-The `huggingface_hub` library offers a range of mixins that can be used as a parent class for your
-objects, in order to provide simple uploading and downloading functions. Check out our [integration guide](../guides/integrations)
-to learn how to integrate any ML framework with the Hub.
+The `huggingface_hub` library offers a range of mixins that can be used as a parent class for your objects, in order to
+provide simple uploading and downloading functions. Check out our [integration guide](../guides/integrations) to learn
+how to integrate any ML framework with the Hub.
 
 ### Generic
 

--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -24,11 +24,11 @@ T = TypeVar("T", bound="ModelHubMixin")
 
 class ModelHubMixin:
     """
-    A generic Hub mixin for machine learning models. Define your own mixin for any framework
-    by inheriting from this class and overwriting the [`_from_pretrained`] and [`_save_pretrained`]
-    methods to define custom logic for saving and loading your classes.
+    A generic mixin to integrate ANY machine learning framework with the Hub.
 
-    See [`PyTorchModelHubMixin`] for an example.
+    To integrate your framework, your model class must inherit from this class. Custom logic for saving/loading models
+    have to be overwritten in  [`_from_pretrained`] and [`_save_pretrained`]. [`PyTorchModelHubMixin`] is a good example
+    of mixin integration with the Hub. Check out our [integration guide](../guides/integrations) for more instructions.
     """
 
     @_deprecate_positional_args(version="0.16")
@@ -44,7 +44,7 @@ class ModelHubMixin:
         """
         Save weights in local directory.
 
-        Parameters:
+        Args:
             save_directory (`str` or `Path`):
                 Path to directory in which the model weights and configuration will be saved.
             config (`dict`, *optional*):
@@ -52,38 +52,38 @@ class ModelHubMixin:
             push_to_hub (`bool`, *optional*, defaults to `False`):
                 Whether or not to push your model to the Huggingface Hub after saving it.
             repo_id (`str`, *optional*):
-                ID of your repository on the Hub. Used only if `push_to_hub=True`. Will
-                default to the folder name if not provided.
+                ID of your repository on the Hub. Used only if `push_to_hub=True`. Will default to the folder name if
+                not provided.
             kwargs:
-                Additional key word arguments passed along to the
-                [`~utils.PushToHubMixin.push_to_hub`] method.
+                Additional key word arguments passed along to the [`~ModelHubMixin._from_pretrained`] method.
         """
-        os.makedirs(save_directory, exist_ok=True)
+        save_directory = Path(save_directory)
+        save_directory.mkdir(parents=True, exist_ok=True)
 
         # saving model weights/files
         self._save_pretrained(save_directory)
 
         # saving config
         if isinstance(config, dict):
-            path = os.path.join(save_directory, CONFIG_NAME)
-            with open(path, "w") as f:
-                json.dump(config, f)
+            (save_directory / CONFIG_NAME).write_text(json.dumps(config))
 
         if push_to_hub:
             kwargs = kwargs.copy()  # soft-copy to avoid mutating input
             if config is not None:  # kwarg for `push_to_hub`
                 kwargs["config"] = config
-
             if repo_id is None:
-                # Repo name defaults to `save_directory` name
-                repo_id = Path(save_directory).name
-
+                repo_id = save_directory.name  # Defaults to `save_directory` name
             return self.push_to_hub(repo_id=repo_id, **kwargs)
         return None
 
-    def _save_pretrained(self, save_directory: Union[str, Path]) -> None:
+    def _save_pretrained(self, save_directory: Path) -> None:
         """
         Overwrite this method in subclass to define how to save your model.
+        Check out our [integration guide](../guides/integrations) for instructions.
+
+        Args:
+            save_directory (`str` or `Path`):
+                Path to directory in which the model weights and configuration will be saved.
         """
         raise NotImplementedError
 
@@ -106,7 +106,7 @@ class ModelHubMixin:
         """
         Download a model from the Huggingface Hub and instantiate it.
 
-        Parameters:
+        Args:
             pretrained_model_name_or_path (`str`, `Path`):
                 - Either the `model_id` (string) of a model hosted on the Hub, e.g. `bigscience/bloom`.
                 - Or a path to a `directory` containing model weights saved using
@@ -115,22 +115,20 @@ class ModelHubMixin:
                 Revision of the model on the Hub. Can be a branch name, a git tag or any commit id.
                 Defaults to the latest commit on `main` branch.
             force_download (`bool`, *optional*, defaults to `False`):
-                Whether to force (re-)downloading the model weights and configuration
-                files from the Hub, overriding the existing cache.
+                Whether to force (re-)downloading the model weights and configuration files from the Hub, overriding
+                the existing cache.
             resume_download (`bool`, *optional*, defaults to `False`):
-                Whether to delete incompletely received files. Will attempt to resume the
-                download if such a file exists.
+                Whether to delete incompletely received files. Will attempt to resume the download if such a file exists.
             proxies (`Dict[str, str]`, *optional*):
                 A dictionary of proxy servers to use by protocol or endpoint, e.g., `{'http': 'foo.bar:3128',
                 'http://hostname': 'foo.bar:4012'}`. The proxies are used on every request.
             token (`str` or `bool`, *optional*):
-                The token to use as HTTP bearer authorization for remote files. By default,
-                it will use the token cached when running `huggingface-cli login`.
+                The token to use as HTTP bearer authorization for remote files. By default, it will use the token
+                cached when running `huggingface-cli login`.
             cache_dir (`str`, `Path`, *optional*):
                 Path to the folder where cached files are stored.
             local_files_only (`bool`, *optional*, defaults to `False`):
-                If `True`, avoid downloading the file and return the path to the
-                local cached file if it exists.
+                If `True`, avoid downloading the file and return the path to the local cached file if it exists.
             model_kwargs (`Dict`, *optional*):
                 Additional kwargs to pass to the model during initialization.
         """
@@ -192,17 +190,48 @@ class ModelHubMixin:
         cls,
         *,
         model_id: str,
-        revision: str,
-        cache_dir: str,
+        revision: Optional[str],
+        cache_dir: Optional[Union[str, Path]],
         force_download: bool,
         proxies: Optional[Dict],
         resume_download: bool,
         local_files_only: bool,
-        token: Union[str, bool, None],
+        token: Optional[Union[str, bool]],
         **model_kwargs,
-    ):
-        """Overwrite this method in subclass to define how to load your model from
-        pretrained"""
+    ) -> T:
+        """Overwrite this method in subclass to define how to load your model from pretrained.
+
+        Use [`hf_hub_download`] or [`snapshot_download`] to download files from the Hub before loading them. Most
+        args taken as input can be directly passed to those 2 methods. If needed, you can add more arguments to this
+        method using "model_kwargs". For example [`PyTorchModelHubMixin._from_pretrained`] takes as input a `map_location`
+        parameter to set on which device the model should be loaded.
+
+        Check out our [integration guide](../guides/integrations) for more instructions.
+
+        Args:
+            model_id (`str`):
+                ID of the model to load from the Huggingface Hub (e.g. `bigscience/bloom`).
+            revision (`str`, *optional*):
+                Revision of the model on the Hub. Can be a branch name, a git tag or any commit id. Defaults to the
+                latest commit on `main` branch.
+            force_download (`bool`, *optional*, defaults to `False`):
+                Whether to force (re-)downloading the model weights and configuration files from the Hub, overriding
+                the existing cache.
+            resume_download (`bool`, *optional*, defaults to `False`):
+                Whether to delete incompletely received files. Will attempt to resume the download if such a file exists.
+            proxies (`Dict[str, str]`, *optional*):
+                A dictionary of proxy servers to use by protocol or endpoint (e.g., `{'http': 'foo.bar:3128',
+                'http://hostname': 'foo.bar:4012'}`).
+            token (`str` or `bool`, *optional*):
+                The token to use as HTTP bearer authorization for remote files. By default, it will use the token
+                cached when running `huggingface-cli login`.
+            cache_dir (`str`, `Path`, *optional*):
+                Path to the folder where cached files are stored.
+            local_files_only (`bool`, *optional*, defaults to `False`):
+                If `True`, avoid downloading the file and return the path to the local cached file if it exists.
+            model_kwargs:
+                Additional keyword arguments passed along to the [`~ModelHubMixin._from_pretrained`] method.
+        """
         raise NotImplementedError
 
     @validate_hf_hub_args
@@ -223,10 +252,10 @@ class ModelHubMixin:
         """
         Upload model checkpoint to the Hub.
 
-        Use `allow_patterns` and `ignore_patterns` to precisely filter which files
-        should be pushed to the hub. See [`upload_folder`] reference for more details.
+        Use `allow_patterns` and `ignore_patterns` to precisely filter which files should be pushed to the hub. See
+        [`upload_folder`] reference for more details.
 
-        Parameters:
+        Args:
             repo_id (`str`):
                 Repository name to which push.
             config (`dict`, *optional*):
@@ -238,16 +267,12 @@ class ModelHubMixin:
             api_endpoint (`str`, *optional*):
                 The API endpoint to use when pushing the model to the hub.
             token (`str`, *optional*):
-                The token to use as HTTP bearer authorization for remote files.
-                If not set, will use the token set when logging in with
-                `transformers-cli login` (stored in `~/.huggingface`).
+                The token to use as HTTP bearer authorization for remote files. By default, it will use the token
+                cached when running `huggingface-cli login`.
             branch (`str`, *optional*):
-                The git branch on which to push the model. This defaults to
-                the default branch as specified in your repository, which
-                defaults to `"main"`.
+                The git branch on which to push the model. This defaults to `"main"`.
             create_pr (`boolean`, *optional*):
-                Whether or not to create a Pull Request from `branch` with that commit.
-                Defaults to `False`.
+                Whether or not to create a Pull Request from `branch` with that commit. Defaults to `False`.
             allow_patterns (`List[str]` or `str`, *optional*):
                 If provided, only files matching at least one pattern are pushed.
             ignore_patterns (`List[str]` or `str`, *optional*):
@@ -277,11 +302,9 @@ class ModelHubMixin:
 
 class PyTorchModelHubMixin(ModelHubMixin):
     """
-    Implementation of [`ModelHubMixin`] to provide model Hub upload/download
-    capabilities to PyTorch models. The model is set in evaluation mode by
-    default using `model.eval()` (dropout modules are deactivated). To train
-    the model, you should first set it back in training mode with
-    `model.train()`.
+    Implementation of [`ModelHubMixin`] to provide model Hub upload/download capabilities to PyTorch models. The model
+    is set in evaluation mode by default using `model.eval()` (dropout modules are deactivated). To train the model,
+    you should first set it back in training mode with `model.train()`.
 
     Example:
 
@@ -311,11 +334,10 @@ class PyTorchModelHubMixin(ModelHubMixin):
     ```
     """
 
-    def _save_pretrained(self, save_directory: Union[str, Path]):
+    def _save_pretrained(self, save_directory: Path) -> None:
         """Save weights from a Pytorch model to a local directory."""
-        path = os.path.join(save_directory, PYTORCH_WEIGHTS_NAME)
         model_to_save = self.module if hasattr(self, "module") else self  # type: ignore
-        torch.save(model_to_save.state_dict(), path)
+        torch.save(model_to_save.state_dict(), save_directory / PYTORCH_WEIGHTS_NAME)
 
     @classmethod
     @_deprecate_positional_args(version="0.16")

--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -187,7 +187,7 @@ class ModelHubMixin:
     @classmethod
     @_deprecate_positional_args(version="0.16")
     def _from_pretrained(
-        cls,
+        cls: Type[T],
         *,
         model_id: str,
         revision: Optional[str],

--- a/src/huggingface_hub/keras_mixin.py
+++ b/src/huggingface_hub/keras_mixin.py
@@ -221,7 +221,7 @@ def from_pretrained_keras(*args, **kwargs) -> "KerasModelHubMixin":
     Instantiate a pretrained Keras model from a pre-trained model from the Hub.
     The model is expected to be in `SavedModel` format.
 
-    Parameters:
+    Args:
         pretrained_model_name_or_path (`str` or `os.PathLike`):
             Can be either:
                 - A string, the `model id` of a pretrained model hosted inside a
@@ -302,11 +302,10 @@ def push_to_hub_keras(
     Use `allow_patterns` and `ignore_patterns` to precisely filter which files should be
     pushed to the hub. See [`upload_folder`] reference for more details.
 
-    Parameters:
+    Args:
         model (`Keras.Model`):
-            The [Keras
-            model](`https://www.tensorflow.org/api_docs/python/tf/keras/Model`)
-            you'd like to push to the Hub. The model must be compiled and built.
+            The [Keras model](`https://www.tensorflow.org/api_docs/python/tf/keras/Model`) you'd like to push to the
+            Hub. The model must be compiled and built.
         repo_id (`str`):
             Repository name to which push
         commit_message (`str`, *optional*, defaults to "Add Keras model"):

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -246,7 +246,7 @@ def expect_deprecation(function_name: str):
     """
     Decorator to flag tests that we expect to use deprecated arguments.
 
-    Parameters:
+    Args:
         function_name (`str`):
             Name of the function that we expect to use in a deprecated way.
 
@@ -303,7 +303,7 @@ def xfail_on_windows(reason: str, raises: Optional[Type[Exception]] = None):
     Will not raise an error if the expected error happens while running on Windows machine.
     If error is expected but does not happen, the test fails as well.
 
-    Parameters:
+    Args:
         reason (`str`):
             Reason why it should fail.
         raises (`Type[Exception]`):


### PR DESCRIPTION
Resolve #1333 (from @NielsRogge 's suggestion [in private slack](https://huggingface.slack.com/archives/C01BWJU0YKW/p1675086727579739)).

This PR adds a new guide page "Integrate any ML framework with the Hub". Contains:
1. what is an integration?
2. what is the `ModelHubMixin`. How to use it?
3. concrete example with `PyTorchHubMixin`: how to use it and how has it been implemented

(+ edited some docstrings)

Writing this guide made me realize we can even improve further the `ModelHubMixin` class, especially for cases where we want to delete files from the Hub (when pushing multiple times). This is done separately in the Keras integration to replace training logs. I think we update change this once #1352 is implemented.


(Note: failing tests are unrelated to this PR)