### PR TITLE
FIX `create_repo` with `exists_ok` but no permission

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -2086,7 +2086,9 @@ class HfApi:
                 # No write permission on the namespace but repo might already exist
                 try:
                     self.repo_info(repo_id=repo_id, repo_type=repo_type, token=token)
-                    return RepoUrl(repo_id, endpoint=self.endpoint, repo_type=repo_type)
+                    if repo_type is None or repo_type == REPO_TYPE_MODEL:
+                        return RepoUrl(repo_id, endpoint=self.endpoint)
+                    return RepoUrl(f"{repo_type}/{repo_id}", endpoint=self.endpoint)
                 except HfHubHTTPError:
                     raise
             else:

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -2086,7 +2086,7 @@ class HfApi:
                 # No write permission on the namespace but repo might already exist
                 try:
                     self.repo_info(repo_id=repo_id, repo_type=repo_type, token=token)
-                    return RepoUrl(f"{self.endpoint}/{repo_id}")
+                    return RepoUrl(repo_id, endpoint=self.endpoint, repo_type=repo_type)
                 except HfHubHTTPError:
                     raise
             else:

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -2087,8 +2087,8 @@ class HfApi:
                 try:
                     self.repo_info(repo_id=repo_id, repo_type=repo_type, token=token)
                     if repo_type is None or repo_type == REPO_TYPE_MODEL:
-                        return RepoUrl(repo_id, endpoint=self.endpoint)
-                    return RepoUrl(f"{repo_type}/{repo_id}", endpoint=self.endpoint)
+                        return RepoUrl(f"{self.endpoint}/{repo_id}")
+                    return RepoUrl(f"{self.endpoint}/{repo_type}/{repo_id}")
                 except HfHubHTTPError:
                     raise
             else:

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -2082,6 +2082,13 @@ class HfApi:
             if exist_ok and err.response.status_code == 409:
                 # Repo already exists and `exist_ok=True`
                 pass
+            elif exist_ok and err.response.status_code == 403:
+                # No write permission on the namespace but repo might already exist
+                try:
+                    self.repo_info(repo_id=repo_id, repo_type=repo_type, token=token)
+                    return RepoUrl(f"{self.endpoint}/{repo_id}")
+                except HfHubHTTPError:
+                    raise
             else:
                 raise
 

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -478,6 +478,16 @@ class CommitApiTest(HfApiCommonTestWithLogin):
             with patch.object(self._api, "token", None):  # no default token
                 self._api.create_repo(repo_id=repo_name("org"))
 
+    def test_create_repo_already_exists_but_no_write_permission(self):
+        # Create under other user namespace
+        repo_id = self._api.create_repo(repo_id=repo_name(), token=OTHER_TOKEN).repo_id
+
+        # Try to create with our namespace -> should not fail as the repo already exists
+        self._api.create_repo(repo_id=repo_id, token=TOKEN, exist_ok=True)
+
+        # Clean up
+        self._api.delete_repo(repo_id=repo_id, token=OTHER_TOKEN)
+
     @retry_endpoint
     def test_upload_buffer(self):
         REPO_NAME = repo_name("buffer")


### PR DESCRIPTION
Corner case but used in a lot of integrations. Problem is when doing `create_repo(..., exists_ok)`. If repo already exists, it's not supposed to raise an exception. However, if the repo exists but the user do not have permission on this namespace, a HTTP 403 is thrown. Since we catch only HTTP 409 conflict, the error is not caught. 

With this PR, if we get an HTTP 403, we check if the repo exists or not before raising an exception. This is useful for third-party integrations having a "push_to_hub"-like method and `create_pr=True`. We do not want to throw an error on create repo since write permission will not be needed to create a PR.

See [related slack thread](https://huggingface.slack.com/archives/C02V5EA0A95/p1677589109007089) (internal link) cc @thomasw21 @coyotte508 