### PR TITLE
Add `delete_patterns` option to `upload_folder`

### DIFF
--- a/docs/source/guides/upload.mdx
+++ b/docs/source/guides/upload.mdx
@@ -56,23 +56,53 @@ Specify the path of the file to upload, where you want to upload the file to in 
 
 ### Upload a folder
 
-Use the [`upload_folder`] function to upload a local folder to an existing repository. Specify the path of the local folder to upload, where you want to upload the folder to in the repository, and the name of the repository you want to add the folder to. Depending on your repository type, you can optionally set the repository type as a `dataset`, `model`, or `space`.
+Use the [`upload_folder`] function to upload a local folder to an existing repository. Specify the path of the local folder
+to upload, where you want to upload the folder to in the repository, and the name of the repository you want to add the
+folder to. Depending on your repository type, you can optionally set the repository type as a `dataset`, `model`, or `space`.
+
+```py
+>>> from huggingface_hub import HfApi
+>>> api = HfApi()
+
+# Upload all the content from the local folder to your remote Space.
+# By default, files are uploaded at the root of the repo
+>>> api.upload_folder(
+...     folder_path="/path/to/local/space",
+...     repo_id="username/my-cool-space",
+...     repo_type="space",
+... )
+```
 
 Use the `allow_patterns` and `ignore_patterns` arguments to specify which files to upload. These parameters accept either a single pattern or a list of patterns.
 Patterns are Standard Wildcards (globbing patterns) as documented [here](https://tldp.org/LDP/GNU-Linux-Tools-Summary/html/x11655.htm).
 If both `allow_patterns` and `ignore_patterns` are provided, both constraints apply. By default, all files from the folder are uploaded.
 
 ```py
->>> from huggingface_hub import HfApi
->>> api = HfApi()
 >>> api.upload_folder(
 ...     folder_path="/path/to/local/folder",
-...     path_in_repo="my-dataset/train",
+...     path_in_repo="my-dataset/train", # Upload to a specific folder
 ...     repo_id="username/test-dataset",
 ...     repo_type="dataset",
-...     ignore_patterns="**/logs/*.txt",
+...     ignore_patterns="**/logs/*.txt", # Ignore all text logs
 ... )
 ```
+
+You can also use the `delete_patterns` argument to specify files you want to delete from the repo in the same commit.
+This can prove useful if you want to clean a remote folder before pushing files in it and you don't know which files
+already exists.
+
+The example below uploads the local `./logs` folder to the remote `/experiment/logs/` folder. Only txt files are uploaded
+but before that, all previous logs on the repo on deleted. All of this in a single commit.
+```py
+>>> api.upload_folder(
+...     folder_path="/path/to/local/folder/logs",
+...     repo_id="username/trained-model",
+...     path_in_repo="experiment/logs/",
+...     allow_patterns="*.txt", # Upload all local text files
+...     delete_patterns="*.txt", # Delete all remote text files before
+... )
+```
+
 
 ### create_commit
 

--- a/src/huggingface_hub/fastai_utils.py
+++ b/src/huggingface_hub/fastai_utils.py
@@ -353,13 +353,15 @@ def push_to_hub_fastai(
     create_pr: Optional[bool] = None,
     allow_patterns: Optional[Union[List[str], str]] = None,
     ignore_patterns: Optional[Union[List[str], str]] = None,
+    delete_patterns: Optional[Union[List[str], str]] = None,
     api_endpoint: Optional[str] = None,
 ):
     """
     Upload learner checkpoint files to the Hub.
 
-    Use `allow_patterns` and `ignore_patterns` to precisely filter which files should be
-    pushed to the hub. See [`upload_folder`] reference for more details.
+    Use `allow_patterns` and `ignore_patterns` to precisely filter which files should be pushed to the hub. Use
+    `delete_patterns` to delete existing remote files in the same commit. See [`upload_folder`] reference for more
+    details.
 
     Args:
         learner (`Learner`):
@@ -387,6 +389,9 @@ def push_to_hub_fastai(
             If provided, only files matching at least one pattern are pushed.
         ignore_patterns (`List[str]` or `str`, *optional*):
             If provided, files matching any of the patterns are not pushed.
+        delete_patterns (`List[str]` or `str`, *optional*):
+            If provided, remote files matching any of the patterns will be deleted from the repo.
+
     Returns:
         The url of the commit of your model in the given repository.
 
@@ -401,7 +406,7 @@ def push_to_hub_fastai(
     """
     _check_fastai_fastcore_versions()
     api = HfApi(endpoint=api_endpoint)
-    api.create_repo(repo_id=repo_id, repo_type="model", token=token, private=private, exist_ok=True)
+    repo_id = api.create_repo(repo_id=repo_id, token=token, private=private, exist_ok=True).repo_id
 
     # Push the files to the repo in a single commit
     with SoftTemporaryDirectory() as tmp:
@@ -409,7 +414,6 @@ def push_to_hub_fastai(
         _save_pretrained_fastai(learner, saved_path, config=config)
         return api.upload_folder(
             repo_id=repo_id,
-            repo_type="model",
             token=token,
             folder_path=saved_path,
             commit_message=commit_message,
@@ -417,4 +421,5 @@ def push_to_hub_fastai(
             create_pr=create_pr,
             allow_patterns=allow_patterns,
             ignore_patterns=ignore_patterns,
+            delete_patterns=delete_patterns,
         )

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -2623,7 +2623,7 @@ class HfApi:
         delete_patterns: Optional[Union[List[str], str]] = None,
     ):
         """
-        Upload a local folder to the given repo. The upload is done through a HTTP requests, and doesn't require git or
+        Upload a local folder to the given repo. The upload is done through a HTTP request and doesn't require git or
         git-lfs to be installed.
 
         The structure of the folder will be preserved. Files with the same name already present in the repository will
@@ -2637,7 +2637,7 @@ class HfApi:
         Use the `delete_patterns` argument to specify remote files you want to delete. Input type is the same as for
         `allow_patterns` (see above). If `path_in_repo` is also provided, the patterns are matched against paths
         relative to this folder. For example, `upload_folder(..., path_in_repo="experiment", delete_patterns="logs/*")`
-        will delete any remote file under `./experiment/logs/`. Note that the `.gitattributes` file will not be deleted
+        will delete any remote file under `experiment/logs/`. Note that the `.gitattributes` file will not be deleted
         even if it matches the patterns.
 
         Uses `HfApi.create_commit` under the hood.
@@ -2732,7 +2732,7 @@ class HfApi:
         ...     token="my_token",
         ...     delete_patterns="**/logs/*.txt",
         ... )
-        # "https://huggingface.co/datasets/username/my-dataset/tree/main/remote/experiment/checkpoints"
+        "https://huggingface.co/datasets/username/my-dataset/tree/main/remote/experiment/checkpoints"
 
         # Upload checkpoints folder while creating a PR
         >>> upload_folder(

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
-import os
 import pprint
 import re
 import textwrap
@@ -1855,6 +1854,7 @@ class HfApi:
         Returns:
             `List[str]`: the list of files in a given repository.
         """
+        # TODO: use https://huggingface.co/api/{repo_type}/{repo_id}/tree/{revision}/{subfolder}
         repo_info = self.repo_info(
             repo_id,
             revision=revision,
@@ -2620,21 +2620,25 @@ class HfApi:
         parent_commit: Optional[str] = None,
         allow_patterns: Optional[Union[List[str], str]] = None,
         ignore_patterns: Optional[Union[List[str], str]] = None,
+        delete_patterns: Optional[Union[List[str], str]] = None,
     ):
         """
-        Upload a local folder to the given repo. The upload is done
-        through a HTTP requests, and doesn't require git or git-lfs to be
-        installed.
+        Upload a local folder to the given repo. The upload is done through a HTTP requests, and doesn't require git or
+        git-lfs to be installed.
 
-        The structure of the folder will be preserved. Files with the same name
-        already present in the repository will be overwritten, others will be left untouched.
+        The structure of the folder will be preserved. Files with the same name already present in the repository will
+        be overwritten. Others will be left untouched.
 
-        Use the `allow_patterns` and `ignore_patterns` arguments to specify which files
-        to upload. These parameters accept either a single pattern or a list of
-        patterns. Patterns are Standard Wildcards (globbing patterns) as documented
-        [here](https://tldp.org/LDP/GNU-Linux-Tools-Summary/html/x11655.htm). If both
-        `allow_patterns` and `ignore_patterns` are provided, both constraints apply. By
-        default, all files from the folder are uploaded.
+        Use the `allow_patterns` and `ignore_patterns` arguments to specify which files to upload. These parameters
+        accept either a single pattern or a list of patterns. Patterns are Standard Wildcards (globbing patterns) as
+        documented [here](https://tldp.org/LDP/GNU-Linux-Tools-Summary/html/x11655.htm). If both `allow_patterns` and
+        `ignore_patterns` are provided, both constraints apply. By default, all files from the folder are uploaded.
+
+        Use the `delete_patterns` argument to specify remote files you want to delete. Input type is the same as for
+        `allow_patterns` (see above). If `path_in_repo` is also provided, the patterns are matched against paths
+        relative to this folder. For example, `upload_folder(..., path_in_repo="experiment", delete_patterns="logs/*")`
+        will delete any remote file under `./experiment/logs/`. Note that the `.gitattributes` file will not be deleted
+        even if it matches the patterns.
 
         Uses `HfApi.create_commit` under the hood.
 
@@ -2677,6 +2681,10 @@ class HfApi:
                 If provided, only files matching at least one pattern are uploaded.
             ignore_patterns (`List[str]` or `str`, *optional*):
                 If provided, files matching any of the patterns are not uploaded.
+            delete_patterns (`List[str]` or `str`, *optional*):
+                If provided, remote files matching any of the patterns will be deleted from the repo while committing
+                new files. This is useful if you don't know which files have already been uploaded.
+                Note: to avoid discrepancies the `.gitattributes` file is not deleted even if it matches the pattern.
 
         Returns:
             `str`: A URL to visualize the uploaded folder on the hub
@@ -2694,16 +2702,16 @@ class HfApi:
 
         <Tip warning={true}>
 
-        `upload_folder` assumes that the repo already exists on the Hub. If you get a
-        Client error 404, please make sure you are authenticated and that `repo_id` and
-        `repo_type` are set correctly. If repo does not exist, create it first using
-        [`~hf_api.create_repo`].
+        `upload_folder` assumes that the repo already exists on the Hub. If you get a Client error 404, please make
+        sure you are authenticated and that `repo_id` and `repo_type` are set correctly. If repo does not exist, create
+        it first using [`~hf_api.create_repo`].
 
         </Tip>
 
         Example:
 
         ```python
+        # Upload checkpoints folder except the log files
         >>> upload_folder(
         ...     folder_path="local/checkpoints",
         ...     path_in_repo="remote/experiment/checkpoints",
@@ -2714,6 +2722,19 @@ class HfApi:
         ... )
         # "https://huggingface.co/datasets/username/my-dataset/tree/main/remote/experiment/checkpoints"
 
+        # Upload checkpoints folder including logs while deleting existing logs from the repo
+        # Useful if you don't know exactly which log files have already being pushed
+        >>> upload_folder(
+        ...     folder_path="local/checkpoints",
+        ...     path_in_repo="remote/experiment/checkpoints",
+        ...     repo_id="username/my-dataset",
+        ...     repo_type="datasets",
+        ...     token="my_token",
+        ...     delete_patterns="**/logs/*.txt",
+        ... )
+        # "https://huggingface.co/datasets/username/my-dataset/tree/main/remote/experiment/checkpoints"
+
+        # Upload checkpoints folder while creating a PR
         >>> upload_folder(
         ...     folder_path="local/checkpoints",
         ...     path_in_repo="remote/experiment/checkpoints",
@@ -2737,17 +2758,33 @@ class HfApi:
             commit_message if commit_message is not None else f"Upload {path_in_repo} with huggingface_hub"
         )
 
-        files_to_add = _prepare_upload_folder_commit(
+        delete_operations = self._prepare_upload_folder_deletions(
+            repo_id=repo_id,
+            repo_type=repo_type,
+            revision=DEFAULT_REVISION if create_pr else revision,
+            token=token,
+            path_in_repo=path_in_repo,
+            delete_patterns=delete_patterns,
+        )
+        add_operations = _prepare_upload_folder_additions(
             folder_path,
             path_in_repo,
             allow_patterns=allow_patterns,
             ignore_patterns=ignore_patterns,
         )
 
+        # Optimize operations: if some files will be overwritten, we don't need to delete them first
+        if len(add_operations) > 0:
+            added_paths = set(op.path_in_repo for op in add_operations)
+            delete_operations = [
+                delete_op for delete_op in delete_operations if delete_op.path_in_repo not in added_paths
+            ]
+        commit_operations = delete_operations + add_operations
+
         commit_info = self.create_commit(
             repo_type=repo_type,
             repo_id=repo_id,
-            operations=files_to_add,
+            operations=commit_operations,
             commit_message=commit_message,
             commit_description=commit_description,
             token=token,
@@ -4167,8 +4204,48 @@ class HfApi:
             user_agent=user_agent or self.user_agent,
         )
 
+    def _prepare_upload_folder_deletions(
+        self,
+        repo_id: str,
+        repo_type: Optional[str],
+        revision: Optional[str],
+        token: Optional[str],
+        path_in_repo: str,
+        delete_patterns: Optional[Union[List[str], str]],
+    ) -> List[CommitOperationDelete]:
+        """Generate the list of Delete operations for a commit to delete files from a repo.
 
-def _prepare_upload_folder_commit(
+        List remote files and match them against the `delete_patterns` constraints. Returns a list of [`CommitOperationDelete`]
+        with the matching items.
+
+        Note: `.gitattributes` file is essential to make a repo work properly on the Hub. This file will always be
+              kept even if it matches the `delete_patterns` constraints.
+        """
+        if delete_patterns is None:
+            # If no delete patterns, no need to list and filter remote files
+            return []
+
+        # List remote files
+        filenames = self.list_repo_files(repo_id=repo_id, revision=revision, repo_type=repo_type, token=token)
+
+        # Compute relative path in repo
+        if path_in_repo:
+            path_in_repo = path_in_repo.strip("/") + "/"  # harmonize
+            relpath_to_abspath = {
+                file[len(path_in_repo) :]: file for file in filenames if file.startswith(path_in_repo)
+            }
+        else:
+            relpath_to_abspath = {file: file for file in filenames}
+
+        # Apply filter on relative paths and return
+        return [
+            CommitOperationDelete(path_in_repo=relpath_to_abspath[relpath], is_folder=False)
+            for relpath in filter_repo_objects(relpath_to_abspath.keys(), allow_patterns=delete_patterns)
+            if relpath_to_abspath[relpath] != ".gitattributes"
+        ]
+
+
+def _prepare_upload_folder_additions(
     folder_path: Union[str, Path],
     path_in_repo: str,
     allow_patterns: Optional[Union[List[str], str]] = None,
@@ -4179,30 +4256,29 @@ def _prepare_upload_folder_commit(
     Files not matching the `allow_patterns` (allowlist) and `ignore_patterns` (denylist)
     constraints are discarded.
     """
-    folder_path = os.path.normpath(os.path.expanduser(folder_path))
-    if not os.path.isdir(folder_path):
+    folder_path = Path(folder_path).expanduser().resolve()
+    if not folder_path.is_dir():
         raise ValueError(f"Provided path: '{folder_path}' is not a directory")
 
-    files_to_add: List[CommitOperationAdd] = []
-    for dirpath, _, filenames in os.walk(folder_path):
-        for filename in filenames:
-            abs_path = os.path.join(dirpath, filename)
-            rel_path = os.path.relpath(abs_path, folder_path)
-            files_to_add.append(
-                CommitOperationAdd(
-                    path_or_fileobj=abs_path,
-                    path_in_repo=os.path.normpath(os.path.join(path_in_repo, rel_path)).replace(os.sep, "/"),
-                )
-            )
+    # List files from folder
+    relpath_to_abspath = {
+        path.relative_to(folder_path).as_posix(): path
+        for path in sorted(folder_path.glob("**/*"))  # sorted to be deterministic
+        if path.is_file()
+    }
 
-    return list(
-        filter_repo_objects(
-            files_to_add,
-            allow_patterns=allow_patterns,
-            ignore_patterns=ignore_patterns,
-            key=lambda x: x.path_in_repo,
+    # Filter files and return
+    # Patterns are applied on the path relative to `folder_path`. `path_in_repo` is prefixed after the filtering.
+    prefix = f"{path_in_repo.strip('/')}/" if path_in_repo else ""
+    return [
+        CommitOperationAdd(
+            path_or_fileobj=relpath_to_abspath[relpath],  # absolute path on disk
+            path_in_repo=prefix + relpath,  # "absolute" path in repo
         )
-    )
+        for relpath in filter_repo_objects(
+            relpath_to_abspath.keys(), allow_patterns=allow_patterns, ignore_patterns=ignore_patterns
+        )
+    ]
 
 
 def _parse_revision_from_pr_url(pr_url: str) -> str:

--- a/src/huggingface_hub/keras_mixin.py
+++ b/src/huggingface_hub/keras_mixin.py
@@ -5,10 +5,8 @@ import warnings
 from pathlib import Path
 from shutil import copytree
 from typing import Any, Dict, List, Optional, Union
-from urllib.parse import quote
 
-from huggingface_hub import CommitOperationDelete, ModelHubMixin, snapshot_download
-from huggingface_hub._commit_api import CommitOperation
+from huggingface_hub import ModelHubMixin, snapshot_download
 from huggingface_hub.utils import (
     get_tf_version,
     is_graphviz_available,
@@ -17,8 +15,8 @@ from huggingface_hub.utils import (
     yaml_dump,
 )
 
-from .constants import CONFIG_NAME, DEFAULT_REVISION
-from .hf_api import HfApi, _parse_revision_from_pr_url, _prepare_upload_folder_commit
+from .constants import CONFIG_NAME
+from .hf_api import HfApi
 from .utils import SoftTemporaryDirectory, logging, validate_hf_hub_args
 
 
@@ -289,6 +287,7 @@ def push_to_hub_keras(
     create_pr: Optional[bool] = None,
     allow_patterns: Optional[Union[List[str], str]] = None,
     ignore_patterns: Optional[Union[List[str], str]] = None,
+    delete_patterns: Optional[Union[List[str], str]] = None,
     log_dir: Optional[str] = None,
     include_optimizer: bool = False,
     tags: Optional[Union[list, str]] = None,
@@ -296,11 +295,11 @@ def push_to_hub_keras(
     **model_save_kwargs,
 ):
     """
-    Upload model checkpoint or tokenizer files to the Hub while synchronizing a
-    local clone of the repo in `repo_path_or_name`.
+    Upload model checkpoint to the Hub.
 
-    Use `allow_patterns` and `ignore_patterns` to precisely filter which files should be
-    pushed to the hub. See [`upload_folder`] reference for more details.
+    Use `allow_patterns` and `ignore_patterns` to precisely filter which files should be pushed to the hub. Use
+    `delete_patterns` to delete existing remote files in the same commit. See [`upload_folder`] reference for more
+    details.
 
     Parameters:
         model (`Keras.Model`):
@@ -332,6 +331,8 @@ def push_to_hub_keras(
             If provided, only files matching at least one pattern are pushed.
         ignore_patterns (`List[str]` or `str`, *optional*):
             If provided, files matching any of the patterns are not pushed.
+        delete_patterns (`List[str]` or `str`, *optional*):
+            If provided, remote files matching any of the patterns will be deleted from the repo.
         log_dir (`str`, *optional*):
             TensorBoard logging directory to be pushed. The Hub automatically
             hosts and displays a TensorBoard instance if log files are included
@@ -352,13 +353,7 @@ def push_to_hub_keras(
         The url of the commit of your model in the given repository.
     """
     api = HfApi(endpoint=api_endpoint)
-    api.create_repo(
-        repo_id=repo_id,
-        repo_type="model",
-        token=token,
-        private=private,
-        exist_ok=True,
-    )
+    repo_id = api.create_repo(repo_id=repo_id, token=token, private=private, exist_ok=True).repo_id
 
     # Push the files to the repo in a single commit
     with SoftTemporaryDirectory() as tmp:
@@ -373,46 +368,32 @@ def push_to_hub_keras(
             **model_save_kwargs,
         )
 
-        # If log dir is provided, delete old logs + add new ones
-        operations: List[CommitOperation] = []
+        # If `log_dir` provided, delete remote logs and upload new ones
         if log_dir is not None:
-            # Delete previous log files from Hub
-            operations += [
-                CommitOperationDelete(path_in_repo=file)
-                for file in api.list_repo_files(repo_id=repo_id, token=token)
-                if file.startswith("logs/")
-            ]
-
-            # Copy new log files
+            delete_patterns = (
+                []
+                if delete_patterns is None
+                else (
+                    [delete_patterns]  # convert `delete_patterns` to a list
+                    if isinstance(delete_patterns, str)
+                    else delete_patterns
+                )
+            )
+            delete_patterns.append("logs/*")
             copytree(log_dir, saved_path / "logs")
 
-        # NOTE: `_prepare_upload_folder_commit` and `create_commit` calls are
-        #       duplicate code from `upload_folder`. We are not directly using
-        #       `upload_folder` since we want to add delete operations to the
-        #       commit as well.
-        operations += _prepare_upload_folder_commit(
-            saved_path,
-            path_in_repo="",
-            allow_patterns=allow_patterns,
-            ignore_patterns=ignore_patterns,
-        )
-        commit_info = api.create_commit(
+        return api.upload_folder(
             repo_type="model",
             repo_id=repo_id,
-            operations=operations,
+            folder_path=saved_path,
             commit_message=commit_message,
             token=token,
             revision=branch,
             create_pr=create_pr,
+            allow_patterns=allow_patterns,
+            ignore_patterns=ignore_patterns,
+            delete_patterns=delete_patterns,
         )
-        revision = branch
-        if revision is None:
-            revision = (
-                quote(_parse_revision_from_pr_url(commit_info.pr_url), safe="")
-                if commit_info.pr_url is not None
-                else DEFAULT_REVISION
-            )
-        return f"{api.endpoint}/{repo_id}/tree/{revision}/"
 
 
 class KerasModelHubMixin(ModelHubMixin):

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -1899,7 +1899,7 @@ class UploadFolderMockedTest(unittest.TestCase):
         if "folder_path" not in kwargs:
             kwargs["folder_path"] = self.cache_dir
         self.api.upload_folder(repo_id="repo_id", **kwargs)
-        return self.create_commit_mock.call_args_list[0].kwargs["operations"]
+        return self.create_commit_mock.call_args_list[0][1]["operations"]
 
     def test_allow_everything(self):
         operations = self._upload_folder_alias()

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -23,7 +23,7 @@ import warnings
 from functools import partial
 from io import BytesIO
 from pathlib import Path
-from typing import List
+from typing import List, Union
 from unittest.mock import Mock, patch
 from urllib.parse import quote
 
@@ -1850,6 +1850,126 @@ class HfApiPrivateTest(HfApiCommonTestWithLogin):
         orig = len(self._api.list_spaces(use_auth_token=False))
         new = len(self._api.list_spaces(use_auth_token=self._token))
         self.assertGreaterEqual(new, orig)
+
+
+@pytest.mark.usefixtures("fx_cache_dir")
+class UploadFolderMockedTest(unittest.TestCase):
+    api = HfApi()
+    cache_dir: Path
+
+    def setUp(self) -> None:
+        (self.cache_dir / "file.txt").write_text("content")
+        (self.cache_dir / "lfs.bin").write_text("content")
+
+        (self.cache_dir / "sub").mkdir()
+        (self.cache_dir / "sub" / "file.txt").write_text("content")
+        (self.cache_dir / "sub" / "lfs_in_sub.bin").write_text("content")
+
+        (self.cache_dir / "subdir").mkdir()
+        (self.cache_dir / "subdir" / "file.txt").write_text("content")
+        (self.cache_dir / "subdir" / "lfs_in_subdir.bin").write_text("content")
+
+        self.all_local_files = {
+            "lfs.bin",
+            "file.txt",
+            "sub/file.txt",
+            "sub/lfs_in_sub.bin",
+            "subdir/file.txt",
+            "subdir/lfs_in_subdir.bin",
+        }
+
+        self.repo_files_mock = Mock()
+        self.repo_files_mock.return_value = [  # all remote files
+            ".gitattributes",
+            "file.txt",
+            "file1.txt",
+            "sub/file.txt",
+            "sub/file1.txt",
+            "subdir/file.txt",
+            "subdir/lfs_in_subdir.bin",
+        ]
+        self.api.list_repo_files = self.repo_files_mock
+
+        self.create_commit_mock = Mock()
+        self.create_commit_mock.return_value.pr_url = None
+        self.api.create_commit = self.create_commit_mock
+
+    def _upload_folder_alias(self, **kwargs) -> List[Union[CommitOperationAdd, CommitOperationDelete]]:
+        """Alias to call `upload_folder` + retrieve the CommitOperation list passed to `create_commit`."""
+        if "folder_path" not in kwargs:
+            kwargs["folder_path"] = self.cache_dir
+        self.api.upload_folder(repo_id="repo_id", **kwargs)
+        return self.create_commit_mock.call_args_list[0].kwargs["operations"]
+
+    def test_allow_everything(self):
+        operations = self._upload_folder_alias()
+        self.assertTrue(all(isinstance(op, CommitOperationAdd) for op in operations))
+        self.assertEqual({op.path_in_repo for op in operations}, self.all_local_files)
+
+    def test_allow_everything_in_subdir_no_trailing_slash(self):
+        operations = self._upload_folder_alias(folder_path=self.cache_dir / "subdir", path_in_repo="subdir")
+        self.assertTrue(all(isinstance(op, CommitOperationAdd) for op in operations))
+        self.assertEqual(
+            {op.path_in_repo for op in operations},
+            {"subdir/file.txt", "subdir/lfs_in_subdir.bin"},  # correct `path_in_repo`
+        )
+
+    def test_allow_everything_in_subdir_with_trailing_slash(self):
+        operations = self._upload_folder_alias(folder_path=self.cache_dir / "subdir", path_in_repo="subdir/")
+        self.assertTrue(all(isinstance(op, CommitOperationAdd) for op in operations))
+        self.assertEqual(
+            {op.path_in_repo for op in operations},
+            {"subdir/file.txt", "subdir/lfs_in_subdir.bin"},  # correct `path_in_repo`
+        )
+
+    def test_allow_txt_ignore_subdir(self):
+        operations = self._upload_folder_alias(allow_patterns="*.txt", ignore_patterns="subdir/*")
+        self.assertTrue(all(isinstance(op, CommitOperationAdd) for op in operations))
+        self.assertEqual(
+            {op.path_in_repo for op in operations},
+            {"sub/file.txt", "file.txt"},  # only .txt files, not in subdir
+        )
+
+    def test_allow_txt_not_root_ignore_subdir(self):
+        operations = self._upload_folder_alias(allow_patterns="**/*.txt", ignore_patterns="subdir/*")
+        self.assertTrue(all(isinstance(op, CommitOperationAdd) for op in operations))
+        self.assertEqual(
+            {op.path_in_repo for op in operations},
+            {"sub/file.txt"},  # only .txt files, not in subdir, not at root
+        )
+
+    def test_delete_txt(self):
+        operations = self._upload_folder_alias(delete_patterns="*.txt")
+        added_files = {op.path_in_repo for op in operations if isinstance(op, CommitOperationAdd)}
+        deleted_files = {op.path_in_repo for op in operations if isinstance(op, CommitOperationDelete)}
+
+        self.assertEqual(added_files, self.all_local_files)
+        self.assertEqual(deleted_files, {"file1.txt", "sub/file1.txt"})
+
+        # since "file.txt" and "sub/file.txt" are overwritten, no need to delete them first
+        self.assertIn("file.txt", added_files)
+        self.assertIn("sub/file.txt", added_files)
+
+    def test_delete_txt_in_sub(self):
+        operations = self._upload_folder_alias(
+            path_in_repo="sub/", folder_path=self.cache_dir / "sub", delete_patterns="*.txt"
+        )
+        added_files = {op.path_in_repo for op in operations if isinstance(op, CommitOperationAdd)}
+        deleted_files = {op.path_in_repo for op in operations if isinstance(op, CommitOperationDelete)}
+
+        self.assertEqual(added_files, {"sub/file.txt", "sub/lfs_in_sub.bin"})  # added only in sub/
+        self.assertEqual(deleted_files, {"sub/file1.txt"})  # delete only in sub/
+
+    def test_delete_txt_in_sub_ignore_sub_file_txt(self):
+        operations = self._upload_folder_alias(
+            path_in_repo="sub", folder_path=self.cache_dir / "sub", ignore_patterns="file.txt", delete_patterns="*.txt"
+        )
+        added_files = {op.path_in_repo for op in operations if isinstance(op, CommitOperationAdd)}
+        deleted_files = {op.path_in_repo for op in operations if isinstance(op, CommitOperationDelete)}
+
+        # since "sub/file.txt" should be deleted and is not overwritten (ignore_patterns), we delete it explicitly
+        self.assertEqual(added_files, {"sub/lfs_in_sub.bin"})  # no "sub/file.txt"
+        self.assertEqual(deleted_files, {"sub/file1.txt", "sub/file.txt"})
 
 
 @require_git_lfs


### PR DESCRIPTION
Step 1 for #1352: add a `delete_patterns` parameter to `upload_folder`. It makes sense in a lot of cases to delete remote files before uploading new ones.

The workflow is:
1. if `delete_patterns` is provided, list remote files (can be optimized once https://github.com/huggingface/moon-landing/pull/5580 is deployed)
2. apply the pattern filter => create a list of CommitOperationDelete (never delete ".gitattributes")
3. if a file is both deleted and overwritten in the same commit, drop the deletion operation
4. (not done) we could optimize this in case the user deletes an entire folder. At the moment it's 1 file = 1 delete operation. Seems error-prone to try to decode the patterns manually so let's do it later if we see it's a limitation.

Included in PR:
- refactored `_prepare_upload_folder_additions` (fixed a bug) + implement `_prepare_upload_folder_deletions`
- add mocked tests for `upload_folder` to check the CommitOperation list is correct
- adapted ModelHubMixin + keras/pytorch/fastai integrations
- adapted upload docs + some docstrings

Step 2 for #1352 will be adding the possibility for automatic "chained commits" in `create_commit` using a PR if the list of operations is too big (see description there).