### PR TITLE
Add token and git credentials to login cli command

### DIFF
--- a/src/huggingface_hub/commands/user.py
+++ b/src/huggingface_hub/commands/user.py
@@ -47,12 +47,12 @@ class UserCommands(BaseHuggingfaceCLICommand):
         login_parser.add_argument(
             "--token",
             type=str,
-            help="Token generated from https://huggingface.co/settings/tokens"
+            help="Token generated from https://huggingface.co/settings/tokens",
         )
         login_parser.add_argument(
             "--add-to-git-credential",
             action="store_true",
-            help="Optional: Save token to git credential helper."
+            help="Optional: Save token to git credential helper.",
         )
         login_parser.set_defaults(func=lambda args: LoginCommand(args))
         whoami_parser = parser.add_parser("whoami", help="Find out which huggingface.co account you are logged in as.")
@@ -101,7 +101,7 @@ class BaseUserCommand:
 
 class LoginCommand(BaseUserCommand):
     def run(self):
-        login(self.args.token, self.args.add_to_git_credential)
+        login(token=self.args.token, add_to_git_credential=self.args.add_to_git_credential)
 
 
 class LogoutCommand(BaseUserCommand):

--- a/src/huggingface_hub/commands/user.py
+++ b/src/huggingface_hub/commands/user.py
@@ -44,6 +44,16 @@ class UserCommands(BaseHuggingfaceCLICommand):
     @staticmethod
     def register_subcommand(parser: _SubParsersAction):
         login_parser = parser.add_parser("login", help="Log in using a token from huggingface.co/settings/tokens")
+        login_parser.add_argument(
+            "--token",
+            type=str,
+            help="Token generated from https://huggingface.co/settings/tokens"
+        )
+        login_parser.add_argument(
+            "--add-to-git-credential",
+            action="store_true",
+            help="Optional: Save token to git credential helper."
+        )
         login_parser.set_defaults(func=lambda args: LoginCommand(args))
         whoami_parser = parser.add_parser("whoami", help="Find out which huggingface.co account you are logged in as.")
         whoami_parser.set_defaults(func=lambda args: WhoamiCommand(args))
@@ -91,7 +101,7 @@ class BaseUserCommand:
 
 class LoginCommand(BaseUserCommand):
     def run(self):
-        login()
+        login(self.args.token, self.args.add_to_git_credential)
 
 
 class LogoutCommand(BaseUserCommand):


### PR DESCRIPTION
As of now it's not possible to login in a non interactive shell using `huggingface-cli login` as it always prompt to input the token. This makes it hard to use the CLI for automation, for example in GitHub Actions.

This PR adds `--token` and `--add-to-git-credential` args to `huggingface-cli login` command.

```
$ huggingface-cli login --help
usage: huggingface-cli <command> [<args>] login [-h] [--token TOKEN] [--add-to-git-credential]

options:
  -h, --help            show this help message and exit
  --token TOKEN         Token generated from https://huggingface.co/settings/tokens
  --add-to-git-credential
                        Optional: Save token to git credential helper.
```

Example call:

```
$ huggingface-cli login --token $HUGGING_FACE_TOKEN --add-to-git-credential
```

