### PR TITLE
FIX Create_commit on lowercased repo_id failing with confusing message.

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -2426,14 +2426,11 @@ class HfApi:
             "Content-Type": "application/x-ndjson",
             **self._build_hf_headers(token=token, is_write_action=True),
         }
+        data = b"".join(_payload_as_ndjson())
+        params = {"create_pr": "1"} if create_pr else None
 
         try:
-            commit_resp = requests.post(
-                url=commit_url,
-                headers=headers,
-                data=_payload_as_ndjson(),  # type: ignore
-                params={"create_pr": "1"} if create_pr else None,
-            )
+            commit_resp = requests.post(url=commit_url, headers=headers, data=data, params=params)
             hf_raise_for_status(commit_resp, endpoint_name="commit")
         except RepositoryNotFoundError as e:
             e.append_to_message(_CREATE_COMMIT_NO_REPO_ERROR_MESSAGE)


### PR DESCRIPTION
FIX https://github.com/huggingface/huggingface_hub/issues/1371.

Hub API is already case insensitive. Somehow the issue was with the `requests` streaming implementation when generating the ndjson payload "on the fly". It seems that the server was receiving only the first line which causes a very confusing `"400 Bad Request - Add a line with the key 'lfsFile', 'file' or 'deletedFile'"`.

Passing raw bytes instead of a generator fixes the problem. I added a regression issue for that.

(note: I wouldn't find it too problematic to get an error when creating a commit with a case-issue in the repo_id. The problem here was more that the displayed error was completely unrelated).

cc @coyotte508 