### PR TITLE
Explicit raise on invalid model_index + add `ignore_metadata_errors` option

### DIFF
--- a/src/huggingface_hub/_commit_api.py
+++ b/src/huggingface_hub/_commit_api.py
@@ -409,7 +409,7 @@ def fetch_upload_modes(
     create_pr: bool = False,
 ) -> Dict[str, UploadMode]:
     """
-    Requests the Hub "preupload" endpoint to determine wether each input file
+    Requests the Hub "preupload" endpoint to determine whether each input file
     should be uploaded as a regular git blob or as git LFS blob.
 
     Args:

--- a/src/huggingface_hub/community.py
+++ b/src/huggingface_hub/community.py
@@ -44,7 +44,7 @@ class Discussion:
             The username of the Discussion / Pull Request author.
             Can be `"deleted"` if the user has been deleted since.
         is_pull_request (`bool`):
-            Wether or not this is a Pull Request.
+            Whether or not this is a Pull Request.
         created_at (`datetime`):
             The `datetime` of creation of the Discussion / Pull Request.
     """
@@ -96,7 +96,7 @@ class DiscussionWithDetails(Discussion):
             The username of the Discussion / Pull Request author.
             Can be `"deleted"` if the user has been deleted since.
         is_pull_request (`bool`):
-            Wether or not this is a Pull Request.
+            Whether or not this is a Pull Request.
         created_at (`datetime`):
             The `datetime` of creation of the Discussion / Pull Request.
         events (`list` of [`DiscussionEvent`])
@@ -175,7 +175,7 @@ class DiscussionComment(DiscussionEvent):
         content (`str`):
             The raw markdown content of the comment. Mentions, links and images are not rendered.
         edited (`bool`):
-            Wether or not this comment has been edited.
+            Whether or not this comment has been edited.
         hidden (`bool`):
             Whether or not this comment has been hidden.
     """

--- a/src/huggingface_hub/repocard.py
+++ b/src/huggingface_hub/repocard.py
@@ -40,7 +40,7 @@ class RepoCard:
     default_template_path = TEMPLATE_MODELCARD_PATH
     repo_type = "model"
 
-    def __init__(self, content: str):
+    def __init__(self, content: str, ignore_metadata_errors: bool = False):
         """Initialize a RepoCard from string content. The content should be a
         Markdown file with a YAML block at the beginning and a Markdown body.
 
@@ -76,6 +76,7 @@ class RepoCard:
 
         # Set the content of the RepoCard, as well as underlying .data and .text attributes.
         # See the `content` property setter for more details.
+        self.ignore_metadata_errors = ignore_metadata_errors
         self.content = content
 
     @property
@@ -105,7 +106,7 @@ class RepoCard:
             data_dict = {}
             self.text = content
 
-        self.data = self.card_data_class(**data_dict)
+        self.data = self.card_data_class(**data_dict, ignore_metadata_errors=self.ignore_metadata_errors)
 
     def __str__(self):
         return self.content
@@ -136,6 +137,7 @@ class RepoCard:
         repo_id_or_path: Union[str, Path],
         repo_type: Optional[str] = None,
         token: Optional[str] = None,
+        ignore_metadata_errors: bool = False,
     ):
         """Initialize a RepoCard from a Hugging Face Hub repo's README.md or a local filepath.
 
@@ -143,13 +145,14 @@ class RepoCard:
             repo_id_or_path (`Union[str, Path]`):
                 The repo ID associated with a Hugging Face Hub repo or a local filepath.
             repo_type (`str`, *optional*):
-                The type of Hugging Face repo to push to. Defaults to None, which will use
-                use "model". Other options are "dataset" and "space". Not used when loading from
-                a local filepath. If this is called from a child class, the default value will be
-                the child class's `repo_type`.
+                The type of Hugging Face repo to push to. Defaults to None, which will use use "model". Other options
+                are "dataset" and "space". Not used when loading from a local filepath. If this is called from a child
+                class, the default value will be the child class's `repo_type`.
             token (`str`, *optional*):
-                Authentication token, obtained with `huggingface_hub.HfApi.login` method. Will default to
-                the stored token.
+                Authentication token, obtained with `huggingface_hub.HfApi.login` method. Will default to the stored token.
+            ignore_metadata_errors (`str`):
+                If True, errors while parsing the metadata section will be ignored. Some information might be lost during
+                the process. Use it at your own risks.
 
         Returns:
             [`huggingface_hub.repocard.RepoCard`]: The RepoCard (or subclass) initialized from the repo's
@@ -178,7 +181,7 @@ class RepoCard:
 
         # Preserve newlines in the existing file.
         with Path(card_path).open(mode="r", newline="", encoding="utf-8") as f:
-            return cls(f.read())
+            return cls(f.read(), ignore_metadata_errors=ignore_metadata_errors)
 
     def validate(self, repo_type: Optional[str] = None):
         """Validates card against Hugging Face Hub's card validation logic.

--- a/src/huggingface_hub/repocard.py
+++ b/src/huggingface_hub/repocard.py
@@ -152,7 +152,7 @@ class RepoCard:
                 Authentication token, obtained with `huggingface_hub.HfApi.login` method. Will default to the stored token.
             ignore_metadata_errors (`str`):
                 If True, errors while parsing the metadata section will be ignored. Some information might be lost during
-                the process. Use it at your own risks.
+                the process. Use it at your own risk.
 
         Returns:
             [`huggingface_hub.repocard.RepoCard`]: The RepoCard (or subclass) initialized from the repo's

--- a/src/huggingface_hub/repocard_data.py
+++ b/src/huggingface_hub/repocard_data.py
@@ -248,6 +248,9 @@ class ModelCardData(CardData):
             `eval_results` to construct the `model-index` within the card's metadata. The name
             you supply here is what will be used on PapersWithCode's leaderboards. If None is provided
             then the repo name is used as a default. Defaults to None.
+        ignore_metadata_errors (`str`):
+            If True, errors while parsing the metadata section will be ignored. Some information might be lost during
+            the process. Use it at your own risks.
         kwargs (`dict`, *optional*):
             Additional metadata that will be added to the model card. Defaults to None.
 
@@ -277,6 +280,7 @@ class ModelCardData(CardData):
         metrics: Optional[List[str]] = None,
         eval_results: Optional[List[EvalResult]] = None,
         model_name: Optional[str] = None,
+        ignore_metadata_errors: bool = False,
         **kwargs,
     ):
         self.language = language
@@ -294,8 +298,15 @@ class ModelCardData(CardData):
                 model_name, eval_results = model_index_to_eval_results(model_index)
                 self.model_name = model_name
                 self.eval_results = eval_results
-            except KeyError:
-                logger.warning("Invalid model-index. Not loading eval results into CardData.")
+            except KeyError as error:
+                if ignore_metadata_errors:
+                    logger.warning("Invalid model-index. Not loading eval results into CardData.")
+                else:
+                    raise ValueError(
+                        f"Invalid `model_index` in metadata cannot be parsed: KeyError {error}. Pass"
+                        " `ignore_metadata_errors=True` to ignore this error while loading a Model Card. Warning:"
+                        " some information will be lost. Use it at your own risk."
+                    )
 
         super().__init__(**kwargs)
 
@@ -350,6 +361,9 @@ class DatasetCardData(CardData):
             If not provided, it will be gathered from the 'train-eval-index' key of the kwargs.
         configs (`Union[str, List[str]]`, *optional*):
             A list of the available dataset configs for the dataset.
+        ignore_metadata_errors (`str`):
+            If True, errors while parsing the metadata section will be ignored. Some information might be lost during
+            the process. Use it at your own risks.
     """
 
     def __init__(
@@ -368,6 +382,7 @@ class DatasetCardData(CardData):
         pretty_name: Optional[str] = None,
         train_eval_index: Optional[Dict] = None,
         configs: Optional[Union[str, List[str]]] = None,
+        ignore_metadata_errors: bool = False,
         **kwargs,
     ):
         self.annotations_creators = annotations_creators
@@ -421,6 +436,9 @@ class SpaceCardData(CardData):
             List of datasets related to this Space. Should be a dataset ID found on https://hf.co/datasets.
         tags (`List[str]`, *optional*)
             List of tags to add to your Space that can be used when filtering on the Hub.
+        ignore_metadata_errors (`str`):
+            If True, errors while parsing the metadata section will be ignored. Some information might be lost during
+            the process. Use it at your own risks.
         kwargs (`dict`, *optional*):
             Additional metadata that will be added to the space card.
 
@@ -452,6 +470,7 @@ class SpaceCardData(CardData):
         models: Optional[List[str]] = None,
         datasets: Optional[List[str]] = None,
         tags: Optional[List[str]] = None,
+        ignore_metadata_errors: bool = False,
         **kwargs,
     ):
         self.title = title

--- a/src/huggingface_hub/repocard_data.py
+++ b/src/huggingface_hub/repocard_data.py
@@ -158,7 +158,7 @@ class CardData:
     inherit from `dict` to allow this export step.
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, ignore_metadata_errors: bool = False, **kwargs):
         self.__dict__.update(kwargs)
 
     def to_dict(self) -> Dict[str, Any]:

--- a/src/huggingface_hub/repocard_data.py
+++ b/src/huggingface_hub/repocard_data.py
@@ -250,7 +250,7 @@ class ModelCardData(CardData):
             then the repo name is used as a default. Defaults to None.
         ignore_metadata_errors (`str`):
             If True, errors while parsing the metadata section will be ignored. Some information might be lost during
-            the process. Use it at your own risks.
+            the process. Use it at your own risk.
         kwargs (`dict`, *optional*):
             Additional metadata that will be added to the model card. Defaults to None.
 
@@ -363,7 +363,7 @@ class DatasetCardData(CardData):
             A list of the available dataset configs for the dataset.
         ignore_metadata_errors (`str`):
             If True, errors while parsing the metadata section will be ignored. Some information might be lost during
-            the process. Use it at your own risks.
+            the process. Use it at your own risk.
     """
 
     def __init__(
@@ -438,7 +438,7 @@ class SpaceCardData(CardData):
             List of tags to add to your Space that can be used when filtering on the Hub.
         ignore_metadata_errors (`str`):
             If True, errors while parsing the metadata section will be ignored. Some information might be lost during
-            the process. Use it at your own risks.
+            the process. Use it at your own risk.
         kwargs (`dict`, *optional*):
             Additional metadata that will be added to the space card.
 

--- a/tests/test_repocard.py
+++ b/tests/test_repocard.py
@@ -765,12 +765,19 @@ class TestRegexYamlBlock(unittest.TestCase):
 
 class ModelCardTest(TestCaseWithCapLog):
     def test_model_card_with_invalid_model_index(self):
-        """
-        Test that when loading a card that has invalid model-index, no eval_results are added + it logs a warning
+        """Test raise an error when loading a card that has invalid model-index."""
+        sample_path = SAMPLE_CARDS_DIR / "sample_invalid_model_index.md"
+        with self.assertRaises(ValueError):
+            ModelCard.load(sample_path)
+
+    def test_model_card_with_invalid_model_index_and_ignore_error(self):
+        """Test trigger a warning when loading a card that has invalid model-index and `ignore_metadata_errors=True`
+
+        Some information is lost.
         """
         sample_path = SAMPLE_CARDS_DIR / "sample_invalid_model_index.md"
         with self.caplog.at_level(logging.WARNING):
-            card = ModelCard.load(sample_path)
+            card = ModelCard.load(sample_path, ignore_metadata_errors=True)
         self.assertIn(
             "Invalid model-index. Not loading eval results into CardData.",
             self.caplog.text,

--- a/tests/test_repocard.py
+++ b/tests/test_repocard.py
@@ -188,49 +188,38 @@ def require_jinja(test_case):
         return test_case
 
 
+@pytest.mark.usefixtures("fx_cache_dir")
 class RepocardMetadataTest(unittest.TestCase):
-    def setUp(self):
-        os.makedirs(REPOCARD_DIR, exist_ok=True)
+    cache_dir: Path
 
-    def tearDown(self) -> None:
-        if os.path.exists(REPOCARD_DIR):
-            rmtree_with_retry(REPOCARD_DIR)
-        logger.info(f"Does {REPOCARD_DIR} exist: {os.path.exists(REPOCARD_DIR)}")
+    def setUp(self) -> None:
+        self.filepath = self.cache_dir / REPOCARD_NAME
 
     def test_metadata_load(self):
-        filepath = Path(REPOCARD_DIR) / REPOCARD_NAME
-        filepath.write_text(DUMMY_MODELCARD)
-        data = metadata_load(filepath)
+        self.filepath.write_text(DUMMY_MODELCARD)
+        data = metadata_load(self.filepath)
         self.assertDictEqual(data, {"license": "mit", "datasets": ["foo", "bar"]})
 
     def test_metadata_save(self):
-        filename = "dummy_target.md"
-        filepath = Path(REPOCARD_DIR) / filename
-        filepath.write_text(DUMMY_MODELCARD)
-        metadata_save(filepath, {"meaning_of_life": 42})
-        content = filepath.read_text()
+        self.filepath.write_text(DUMMY_MODELCARD)
+        metadata_save(self.filepath, {"meaning_of_life": 42})
+        content = self.filepath.read_text()
         self.assertEqual(content, DUMMY_MODELCARD_TARGET)
 
     def test_metadata_save_from_file_no_yaml(self):
-        filename = "dummy_target_2.md"
-        filepath = Path(REPOCARD_DIR) / filename
-        filepath.write_text("Hello\n")
-        metadata_save(filepath, {"meaning_of_life": 42})
-        content = filepath.read_text()
+        self.filepath.write_text("Hello\n")
+        metadata_save(self.filepath, {"meaning_of_life": 42})
+        content = self.filepath.read_text()
         self.assertEqual(content, DUMMY_MODELCARD_TARGET_NO_YAML)
 
     def test_metadata_save_new_file(self):
-        filename = "new_dummy_target.md"
-        filepath = Path(REPOCARD_DIR) / filename
-        metadata_save(filepath, {"meaning_of_life": 42})
-        content = filepath.read_text()
+        metadata_save(self.filepath, {"meaning_of_life": 42})
+        content = self.filepath.read_text()
         self.assertEqual(content, DUMMY_NEW_MODELCARD_TARGET)
 
     def test_no_metadata_returns_none(self):
-        filename = "dummy_target_3.md"
-        filepath = Path(REPOCARD_DIR) / filename
-        filepath.write_text(DUMMY_MODELCARD_TARGET_NO_TAGS)
-        data = metadata_load(filepath)
+        self.filepath.write_text(DUMMY_MODELCARD_TARGET_NO_TAGS)
+        data = metadata_load(self.filepath)
         self.assertEqual(data, None)
 
     def test_metadata_eval_result(self):
@@ -248,10 +237,8 @@ class RepocardMetadataTest(unittest.TestCase):
             dataset_config="default",
             dataset_split="test",
         )
-        filename = "eval_results.md"
-        filepath = Path(REPOCARD_DIR) / filename
-        metadata_save(filepath, data)
-        content = filepath.read_text().splitlines()
+        metadata_save(self.filepath, data)
+        content = self.filepath.read_text().splitlines()
         self.assertEqual(content, DUMMY_MODELCARD_EVAL_RESULT.splitlines())
 
 

--- a/tests/test_repocard.py
+++ b/tests/test_repocard.py
@@ -409,7 +409,7 @@ class RepocardMetadataUpdateTest(unittest.TestCase):
 
         See https://github.com/huggingface/huggingface_hub/issues/1185.
         """
-        self._api.upload_file(
+        self.api.upload_file(
             path_or_fileobj=DUMMY_MODELCARD_EVAL_RESULT_BOTH_VERIFIED_AND_UNVERIFIED.encode(),
             repo_id=self.repo_id,
             path_in_repo="README.md",

--- a/tests/test_repocard.py
+++ b/tests/test_repocard.py
@@ -14,9 +14,7 @@
 import copy
 import os
 import re
-import tempfile
 import unittest
-from functools import partial
 from pathlib import Path
 
 import pytest
@@ -42,7 +40,6 @@ from huggingface_hub.file_download import hf_hub_download
 from huggingface_hub.hf_api import HfApi
 from huggingface_hub.repocard import REGEX_YAML_BLOCK
 from huggingface_hub.repocard_data import CardData
-from huggingface_hub.repository import Repository
 from huggingface_hub.utils import SoftTemporaryDirectory, is_jinja_available, logging
 
 from .testing_constants import (
@@ -52,10 +49,8 @@ from .testing_constants import (
     USER,
 )
 from .testing_utils import (
-    expect_deprecation,
     repo_name,
     retry_endpoint,
-    rmtree_with_retry,
     with_production_testing,
 )
 
@@ -169,12 +164,6 @@ model-index:
 This is a test model card.
 """
 
-logger = logging.get_logger(__name__)
-
-REPOCARD_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "fixtures/repocard")
-
-repo_name = partial(repo_name, prefix="dummy-hf-hub")
-
 
 def require_jinja(test_case):
     """
@@ -243,49 +232,29 @@ class RepocardMetadataTest(unittest.TestCase):
 
 
 class RepocardMetadataUpdateTest(unittest.TestCase):
-    _api = HfApi(endpoint=ENDPOINT_STAGING, token=TOKEN)
-
-    @classmethod
-    @expect_deprecation("set_access_token")
-    def setUpClass(cls):
-        """
-        Share this valid token in all tests below.
-        """
-        cls._token = TOKEN
-        cls._api.set_access_token(TOKEN)
-
     @retry_endpoint
     def setUp(self) -> None:
-        self.repo_path = Path(tempfile.mkdtemp())
-        self.REPO_NAME = repo_name()
-        self.repo_id = f"{USER}/{self.REPO_NAME}"
-        self._api.create_repo(self.repo_id)
-        self._api.upload_file(
-            path_or_fileobj=DUMMY_MODELCARD_EVAL_RESULT.encode(),
-            repo_id=self.repo_id,
-            path_in_repo="README.md",
-            commit_message="Add README to main branch",
-        )
+        self.token = TOKEN
+        self.api = HfApi(token=TOKEN)
 
-        self.repo = Repository(
-            self.repo_path / self.REPO_NAME,
-            clone_from=self.repo_id,
-            use_auth_token=self._token,
-            git_user="ci",
-            git_email="ci@dummy.com",
+        self.repo_id = self.api.create_repo(repo_name()).repo_id
+        self.api.upload_file(
+            path_or_fileobj=DUMMY_MODELCARD_EVAL_RESULT.encode(), repo_id=self.repo_id, path_in_repo=REPOCARD_NAME
         )
         self.existing_metadata = yaml.safe_load(DUMMY_MODELCARD_EVAL_RESULT.strip().strip("-"))
 
     def tearDown(self) -> None:
-        self._api.delete_repo(repo_id=self.repo_id)
-        rmtree_with_retry(self.repo_path)
+        self.api.delete_repo(repo_id=self.repo_id)
+
+    def _get_remote_card(self) -> str:
+        return hf_hub_download(repo_id=self.repo_id, filename=REPOCARD_NAME)
 
     def test_update_dataset_name(self):
         new_datasets_data = {"datasets": ["test/test_dataset"]}
-        metadata_update(self.repo_id, new_datasets_data, token=self._token)
+        metadata_update(self.repo_id, new_datasets_data, token=self.token)
 
-        self.repo.git_pull()
-        updated_metadata = metadata_load(self.repo_path / self.REPO_NAME / "README.md")
+        hf_hub_download(repo_id=self.repo_id, filename=REPOCARD_NAME)
+        updated_metadata = metadata_load(self._get_remote_card())
         expected_metadata = copy.deepcopy(self.existing_metadata)
         expected_metadata.update(new_datasets_data)
         self.assertDictEqual(updated_metadata, expected_metadata)
@@ -293,10 +262,9 @@ class RepocardMetadataUpdateTest(unittest.TestCase):
     def test_update_existing_result_with_overwrite(self):
         new_metadata = copy.deepcopy(self.existing_metadata)
         new_metadata["model-index"][0]["results"][0]["metrics"][0]["value"] = 0.2862102282047272
-        metadata_update(self.repo_id, new_metadata, token=self._token, overwrite=True)
+        metadata_update(self.repo_id, new_metadata, token=self.token, overwrite=True)
 
-        self.repo.git_pull()
-        updated_metadata = metadata_load(self.repo_path / self.REPO_NAME / "README.md")
+        updated_metadata = metadata_load(self._get_remote_card())
         self.assertDictEqual(updated_metadata, new_metadata)
 
     def test_update_verify_token(self):
@@ -306,22 +274,18 @@ class RepocardMetadataUpdateTest(unittest.TestCase):
         """
         new_metadata = copy.deepcopy(self.existing_metadata)
         new_metadata["model-index"][0]["results"][0]["metrics"][0]["verifyToken"] = "1234"
-        metadata_update(self.repo_id, new_metadata, token=self._token, overwrite=True)
-        self.repo.git_pull()
-        updated_metadata = metadata_load(self.repo_path / self.REPO_NAME / "README.md")
+        metadata_update(self.repo_id, new_metadata, token=self.token, overwrite=True)
+
+        updated_metadata = metadata_load(self._get_remote_card())
         self.assertDictEqual(updated_metadata, new_metadata)
 
     def test_metadata_update_upstream(self):
         new_metadata = copy.deepcopy(self.existing_metadata)
         new_metadata["model-index"][0]["results"][0]["metrics"][0]["value"] = 0.1
 
-        path = hf_hub_download(
-            self.repo_id,
-            filename=REPOCARD_NAME,
-            use_auth_token=self._token,
-        )
-
-        metadata_update(self.repo_id, new_metadata, token=self._token, overwrite=True)
+        # download first, then update
+        path = self._get_remote_card()
+        metadata_update(self.repo_id, new_metadata, token=self.token, overwrite=True)
 
         self.assertNotEqual(metadata_load(path), new_metadata)
         self.assertEqual(metadata_load(path), self.existing_metadata)
@@ -337,11 +301,11 @@ class RepocardMetadataUpdateTest(unittest.TestCase):
                 " accuracy'. Set `overwrite=True` to overwrite existing metrics."
             ),
         ):
-            metadata_update(self.repo_id, new_metadata, token=self._token, overwrite=False)
+            metadata_update(self.repo_id, new_metadata, token=self.token, overwrite=False)
 
     def test_update_existing_field_without_overwrite(self):
         new_datasets_data = {"datasets": "['test/test_dataset']"}
-        metadata_update(self.repo_id, new_datasets_data, token=self._token)
+        metadata_update(self.repo_id, new_datasets_data, token=self.token)
 
         with pytest.raises(
             ValueError,
@@ -351,12 +315,7 @@ class RepocardMetadataUpdateTest(unittest.TestCase):
             ),
         ):
             new_datasets_data = {"datasets": "['test/test_dataset_2']"}
-            metadata_update(
-                self.repo_id,
-                new_datasets_data,
-                token=self._token,
-                overwrite=False,
-            )
+            metadata_update(self.repo_id, new_datasets_data, token=self.token, overwrite=False)
 
     def test_update_new_result_existing_dataset(self):
         new_result = metadata_eval_result(
@@ -374,15 +333,14 @@ class RepocardMetadataUpdateTest(unittest.TestCase):
             dataset_split="test",
         )
 
-        metadata_update(self.repo_id, new_result, token=self._token, overwrite=False)
+        metadata_update(self.repo_id, new_result, token=self.token, overwrite=False)
 
         expected_metadata = copy.deepcopy(self.existing_metadata)
         expected_metadata["model-index"][0]["results"][0]["metrics"].append(
             new_result["model-index"][0]["results"][0]["metrics"][0]
         )
 
-        self.repo.git_pull()
-        updated_metadata = metadata_load(self.repo_path / self.REPO_NAME / "README.md")
+        updated_metadata = metadata_load(self._get_remote_card())
         self.assertDictEqual(updated_metadata, expected_metadata)
 
     def test_update_new_result_new_dataset(self):
@@ -401,12 +359,12 @@ class RepocardMetadataUpdateTest(unittest.TestCase):
             dataset_split="test",
         )
 
-        metadata_update(self.repo_id, new_result, token=self._token, overwrite=False)
+        metadata_update(self.repo_id, new_result, token=self.token, overwrite=False)
 
         expected_metadata = copy.deepcopy(self.existing_metadata)
         expected_metadata["model-index"][0]["results"].append(new_result["model-index"][0]["results"][0])
-        self.repo.git_pull()
-        updated_metadata = metadata_load(self.repo_path / self.REPO_NAME / "README.md")
+
+        updated_metadata = metadata_load(self._get_remote_card())
         self.assertDictEqual(updated_metadata, expected_metadata)
 
     def test_update_metadata_on_empty_text_content(self) -> None:
@@ -415,14 +373,13 @@ class RepocardMetadataUpdateTest(unittest.TestCase):
         Regression test for https://github.com/huggingface/huggingface_hub/issues/1010
         """
         # Create modelcard with metadata but empty text content
-        with self.repo.commit("Add README to main branch"):
-            with open("README.md", "w") as f:
-                f.write(DUMMY_MODELCARD_NO_TEXT_CONTENT)
-        metadata_update(self.repo_id, {"tag": "test"}, token=self._token)
+        self.api.upload_file(
+            path_or_fileobj=DUMMY_MODELCARD_NO_TEXT_CONTENT.encode(), path_in_repo=REPOCARD_NAME, repo_id=self.repo_id
+        )
+        metadata_update(self.repo_id, {"tag": "test"}, token=self.token)
 
         # Check update went fine
-        self.repo.git_pull()
-        updated_metadata = metadata_load(self.repo_path / self.REPO_NAME / "README.md")
+        updated_metadata = metadata_load(self._get_remote_card())
         expected_metadata = {"license": "cc-by-sa-4.0", "tag": "test"}
         self.assertDictEqual(updated_metadata, expected_metadata)
 
@@ -430,26 +387,21 @@ class RepocardMetadataUpdateTest(unittest.TestCase):
         new_metadata = copy.deepcopy(self.existing_metadata)
         new_metadata["model-index"][0].pop("name")
         new_metadata["model-index"][0]["results"][0]["metrics"][0]["value"] = 0.2862102282047272
-        metadata_update(self.repo_id, new_metadata, token=self._token, overwrite=True)
+        metadata_update(self.repo_id, new_metadata, token=self.token, overwrite=True)
 
-        card_data = ModelCard.load(self.repo_id, token=self._token)
+        card_data = ModelCard.load(self.repo_id)
         self.assertEqual(card_data.data.model_name, self.existing_metadata["model-index"][0]["name"])
 
     def test_update_without_existing_name(self):
         # delete existing metadata
-        self._api.upload_file(
-            path_or_fileobj="# Test".encode(),
-            repo_id=self.repo_id,
-            path_in_repo="README.md",
-        )
+        self.api.upload_file(path_or_fileobj="# Test".encode(), repo_id=self.repo_id, path_in_repo="README.md")
 
         new_metadata = copy.deepcopy(self.existing_metadata)
         new_metadata["model-index"][0].pop("name")
 
-        metadata_update(self.repo_id, new_metadata, token=self._token, overwrite=True)
+        metadata_update(self.repo_id, new_metadata, token=self.token, overwrite=True)
 
-        card_data = ModelCard.load(self.repo_id, token=self._token)
-
+        card_data = ModelCard.load(self.repo_id)
         self.assertEqual(card_data.data.model_name, self.repo_id)
 
     def test_update_with_both_verified_and_unverified_metric(self):
@@ -464,13 +416,12 @@ class RepocardMetadataUpdateTest(unittest.TestCase):
         )
         card = ModelCard.load(self.repo_id)
         metadata = card.data.to_dict()
-        metadata_update(self.repo_id, metadata=metadata, overwrite=True, token=TOKEN)
+        metadata_update(self.repo_id, metadata=metadata, overwrite=True, token=self.token)
 
-        card_data = ModelCard.load(self.repo_id, token=self._token)
-
-        self.assertEqual(len(card_data.data.eval_results), 2)
-        first_result = card_data.data.eval_results[0]
-        second_result = card_data.data.eval_results[1]
+        new_card = ModelCard.load(self.repo_id)
+        self.assertEqual(len(new_card.data.eval_results), 2)
+        first_result = new_card.data.eval_results[0]
+        second_result = new_card.data.eval_results[1]
 
         # One is verified, the other not
         self.assertFalse(first_result.verified)


### PR DESCRIPTION
Fix https://github.com/huggingface/huggingface_hub/issues/1361 cc @davanstrien 

As suggested by @davanstrien we should raise an explicit issue + add an option if a user _really_ wants to ignore parsing error (=> better to fail by default than losing some information). For now option is used purely in `ModelCard` but also implemented in `DatasetCard` and `SpaceCard` as we're using inheritance.

This is a breaking change but as discussed on [slack](https://huggingface.slack.com/archives/C02V5EA0A95/p1677159836698829) (internal link), model cards with invalid metadata are already rejected by the server when pushed on the Hub. So this change should only affect invalid metadata on legacy model cards on the Hub.

Adapted the tests accordingly.
(cc @lvwerra who since I know you're using `model_index`)


**EDIT:** also refactored some tests to get rid of `Repository` (being quite slower than HfApi)