### PR TITLE
Fix ReprMixin for python3.7 + test

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -97,7 +97,7 @@ class ReprMixin:
     """Mixin to create the __repr__ for a class"""
 
     def __repr__(self):
-        formatted_value = pprint.pformat(self.__dict__, width=119, compact=True, sort_dicts=False)
+        formatted_value = pprint.pformat(self.__dict__, width=119, compact=True)
         if "\n" in formatted_value:
             return f"{self.__class__.__name__}: {{ \n{textwrap.indent(formatted_value, '  ')}\n}}"
         else:

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -23,7 +23,7 @@ import warnings
 from functools import partial
 from io import BytesIO
 from pathlib import Path
-from typing import List, Union
+from typing import Any, Dict, List, Union
 from unittest.mock import Mock, patch
 from urllib.parse import quote
 
@@ -57,6 +57,7 @@ from huggingface_hub.hf_api import (
     ModelSearchArguments,
     RepoFile,
     RepoUrl,
+    ReprMixin,
     SpaceInfo,
     erase_from_credential_store,
     read_from_credential_store,
@@ -2736,3 +2737,15 @@ class HfApiDuplicateSpaceTest(HfApiCommonTestWithLogin):
 
         with self.assertRaises(RepositoryNotFoundError):
             self._api.duplicate_space(f"{OTHER_USER}/repo_that_does_not_exist")
+
+
+class ReprMixinTest(unittest.TestCase):
+    def test_repr_mixin(self) -> None:
+        class MyClass(ReprMixin):
+            def __init__(self, **kwargs: Dict[str, Any]) -> None:
+                self.__dict__.update(kwargs)
+
+        self.assertEqual(
+            repr(MyClass(foo="foo", bar="bar")),
+            "MyClass: {'bar': 'bar', 'foo': 'foo'}",  # keys are sorted
+        )


### PR DESCRIPTION
`sort_dicts` is not supported in Python 3.7. Let's remove it (not so problematic IMO if keys are sorted).

Has been reported by [`transformers` CI](https://github.com/huggingface/transformers/pull/22021) when testing the pre-release.

cc @davanstrien 