### PR TITLE
Fix `path_in_repo` validation when committing files

### DIFF
--- a/src/huggingface_hub/_commit_api.py
+++ b/src/huggingface_hub/_commit_api.py
@@ -96,6 +96,8 @@ class CommitOperationAdd:
     def __post_init__(self) -> None:
         """Validates `path_or_fileobj` and compute `upload_info`."""
         # Validate `path_in_repo` value to prevent a server-side issue
+        if self.path_in_repo.startswith("/"):
+            self.path_in_repo = self.path_in_repo[1:]
         if self.path_in_repo == "." or self.path_in_repo == ".." or self.path_in_repo.startswith("../"):
             raise ValueError(f"Invalid `path_in_repo` in CommitOperationAdd: '{self.path_in_repo}'")
         if self.path_in_repo.startswith("./"):

--- a/src/huggingface_hub/_commit_api.py
+++ b/src/huggingface_hub/_commit_api.py
@@ -56,6 +56,8 @@ class CommitOperationDelete:
     is_folder: Union[bool, Literal["auto"]] = "auto"
 
     def __post_init__(self):
+        self.path_in_repo = _validate_path_in_repo(self.path_in_repo)
+
         if self.is_folder == "auto":
             self.is_folder = self.path_in_repo.endswith("/")
         if not isinstance(self.is_folder, bool):
@@ -95,13 +97,7 @@ class CommitOperationAdd:
 
     def __post_init__(self) -> None:
         """Validates `path_or_fileobj` and compute `upload_info`."""
-        # Validate `path_in_repo` value to prevent a server-side issue
-        if self.path_in_repo.startswith("/"):
-            self.path_in_repo = self.path_in_repo[1:]
-        if self.path_in_repo == "." or self.path_in_repo == ".." or self.path_in_repo.startswith("../"):
-            raise ValueError(f"Invalid `path_in_repo` in CommitOperationAdd: '{self.path_in_repo}'")
-        if self.path_in_repo.startswith("./"):
-            self.path_in_repo = self.path_in_repo[2:]
+        self.path_in_repo = _validate_path_in_repo(self.path_in_repo)
 
         # Validate `path_or_fileobj` value
         if isinstance(self.path_or_fileobj, Path):
@@ -200,6 +196,17 @@ class CommitOperationAdd:
         """
         with self.as_file() as file:
             return base64.b64encode(file.read())
+
+
+def _validate_path_in_repo(path_in_repo: str) -> str:
+    # Validate `path_in_repo` value to prevent a server-side issue
+    if path_in_repo.startswith("/"):
+        path_in_repo = path_in_repo[1:]
+    if path_in_repo == "." or path_in_repo == ".." or path_in_repo.startswith("../"):
+        raise ValueError(f"Invalid `path_in_repo` in CommitOperation: '{path_in_repo}'")
+    if path_in_repo.startswith("./"):
+        path_in_repo = path_in_repo[2:]
+    return path_in_repo
 
 
 CommitOperation = Union[CommitOperationAdd, CommitOperationDelete]

--- a/src/huggingface_hub/_commit_api.py
+++ b/src/huggingface_hub/_commit_api.py
@@ -95,6 +95,12 @@ class CommitOperationAdd:
 
     def __post_init__(self) -> None:
         """Validates `path_or_fileobj` and compute `upload_info`."""
+        # Validate `path_in_repo` value to prevent a server-side issue
+        if self.path_in_repo == "." or self.path_in_repo == ".." or self.path_in_repo.startswith("../"):
+            raise ValueError(f"Invalid `path_in_repo` in CommitOperationAdd: '{self.path_in_repo}'")
+        if self.path_in_repo.startswith("./"):
+            self.path_in_repo = self.path_in_repo[2:]
+
         # Validate `path_or_fileobj` value
         if isinstance(self.path_or_fileobj, Path):
             self.path_or_fileobj = str(self.path_or_fileobj)

--- a/tests/test_commit_api.py
+++ b/tests/test_commit_api.py
@@ -32,6 +32,38 @@ class TestCommitOperationDelete(unittest.TestCase):
             CommitOperationDelete(path_in_repo="path/to/folder", is_folder="any value")
 
 
+class TestCommitOperationAdd(unittest.TestCase):
+    def test_path_in_repo_normal_path(self):
+        self.assertEqual(
+            CommitOperationAdd(path_in_repo="file.txt", path_or_fileobj=b"").path_in_repo,
+            "file.txt",
+        )
+
+    def test_path_in_repo_prefix_stripped(self):
+        self.assertEqual(
+            CommitOperationAdd(path_in_repo="./file.txt", path_or_fileobj=b"").path_in_repo,
+            "file.txt",
+        )
+
+    def test_path_in_repo_not_stripped_on_hidden_file(self):
+        self.assertEqual(
+            CommitOperationAdd(path_in_repo=".file.txt", path_or_fileobj=b"").path_in_repo,
+            ".file.txt",
+        )
+
+    def test_path_in_repo_invalid_single_dot(self):
+        with self.assertRaises(ValueError):
+            CommitOperationAdd(path_in_repo=".", path_or_fileobj=b"")
+
+    def test_path_in_repo_invalid_double_dot(self):
+        with self.assertRaises(ValueError):
+            CommitOperationAdd(path_in_repo="..", path_or_fileobj=b"")
+
+    def test_path_in_repo_invalid_double_dot_slash_prefix(self):
+        with self.assertRaises(ValueError):
+            CommitOperationAdd(path_in_repo="../file.txt", path_or_fileobj=b"")
+
+
 class TestWarnOnOverwritingOperations(unittest.TestCase):
     add_file_ab = CommitOperationAdd(path_in_repo="a/b.txt", path_or_fileobj=b"data")
     add_file_abc = CommitOperationAdd(path_in_repo="a/b/c.md", path_or_fileobj=b"data")

--- a/tests/test_commit_api.py
+++ b/tests/test_commit_api.py
@@ -32,42 +32,28 @@ class TestCommitOperationDelete(unittest.TestCase):
             CommitOperationDelete(path_in_repo="path/to/folder", is_folder="any value")
 
 
-class TestCommitOperationAdd(unittest.TestCase):
-    def test_absolute_path_in_repo_is_stripped(self):
-        self.assertEqual(
-            CommitOperationAdd(path_in_repo="/file.txt", path_or_fileobj=b"").path_in_repo,
-            "file.txt",
-        )
+class TestCommitOperationPathInRepo(unittest.TestCase):
+    valid_values = {  # key is input, value is expected validated output
+        "file.txt": "file.txt",
+        ".file.txt": ".file.txt",
+        "/file.txt": "file.txt",
+        "./file.txt": "file.txt",
+    }
+    invalid_values = [".", "..", "../file.txt"]
 
-    def test_path_in_repo_normal_path(self):
-        self.assertEqual(
-            CommitOperationAdd(path_in_repo="file.txt", path_or_fileobj=b"").path_in_repo,
-            "file.txt",
-        )
+    def test_path_in_repo_valid(self) -> None:
+        for input, expected in self.valid_values.items():
+            with self.subTest(f"Testing with valid input: '{input}'"):
+                self.assertEqual(CommitOperationAdd(path_in_repo=input, path_or_fileobj=b"").path_in_repo, expected)
+                self.assertEqual(CommitOperationDelete(path_in_repo=input).path_in_repo, expected)
 
-    def test_path_in_repo_prefix_stripped(self):
-        self.assertEqual(
-            CommitOperationAdd(path_in_repo="./file.txt", path_or_fileobj=b"").path_in_repo,
-            "file.txt",
-        )
-
-    def test_path_in_repo_not_stripped_on_hidden_file(self):
-        self.assertEqual(
-            CommitOperationAdd(path_in_repo=".file.txt", path_or_fileobj=b"").path_in_repo,
-            ".file.txt",
-        )
-
-    def test_path_in_repo_invalid_single_dot(self):
-        with self.assertRaises(ValueError):
-            CommitOperationAdd(path_in_repo=".", path_or_fileobj=b"")
-
-    def test_path_in_repo_invalid_double_dot(self):
-        with self.assertRaises(ValueError):
-            CommitOperationAdd(path_in_repo="..", path_or_fileobj=b"")
-
-    def test_path_in_repo_invalid_double_dot_slash_prefix(self):
-        with self.assertRaises(ValueError):
-            CommitOperationAdd(path_in_repo="../file.txt", path_or_fileobj=b"")
+    def test_path_in_repo_invalid(self) -> None:
+        for input in self.invalid_values:
+            with self.subTest(f"Testing with invalid input: '{input}'"):
+                with self.assertRaises(ValueError):
+                    CommitOperationAdd(path_in_repo=input, path_or_fileobj=b"")
+                with self.assertRaises(ValueError):
+                    CommitOperationDelete(path_in_repo=input)
 
 
 class TestWarnOnOverwritingOperations(unittest.TestCase):

--- a/tests/test_commit_api.py
+++ b/tests/test_commit_api.py
@@ -33,6 +33,12 @@ class TestCommitOperationDelete(unittest.TestCase):
 
 
 class TestCommitOperationAdd(unittest.TestCase):
+    def test_absolute_path_in_repo_is_stripped(self):
+        self.assertEqual(
+            CommitOperationAdd(path_in_repo="/file.txt", path_or_fileobj=b"").path_in_repo,
+            "file.txt",
+        )
+
     def test_path_in_repo_normal_path(self):
         self.assertEqual(
             CommitOperationAdd(path_in_repo="file.txt", path_or_fileobj=b"").path_in_repo,

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -1980,6 +1980,17 @@ class UploadFolderMockedTest(unittest.TestCase):
             {"sub/file.txt"},  # only .txt files, not in subdir, not at root
         )
 
+    def test_path_in_repo_dot(self):
+        """Regression test for #1382 when using `path_in_repo="."`.
+
+        Using `path_in_repo="."` or `path_in_repo=None` should be equivalent.
+        See https://github.com/huggingface/huggingface_hub/pull/1382.
+        """
+        operation_with_dot = self._upload_folder_alias(path_in_repo=".", allow_patterns=["file.txt"])[0]
+        operation_with_none = self._upload_folder_alias(path_in_repo=None, allow_patterns=["file.txt"])[0]
+        self.assertEqual(operation_with_dot.path_in_repo, "file.txt")
+        self.assertEqual(operation_with_none.path_in_repo, "file.txt")
+
     def test_delete_txt(self):
         operations = self._upload_folder_alias(delete_patterns="*.txt")
         added_files = {op.path_in_repo for op in operations if isinstance(op, CommitOperationAdd)}


### PR DESCRIPTION
A bug have been introduced in release `v0.13` when `path_in_repo="."` in `upload_folder`. I fixed that and added a few rules to make sure that `path_in_repo` will be accepted by the server. If `path_in_repo` is obviously invalid (e.g. `path_in_repo=".."`) we raise an error early.

Without this validation, server returns a HTTP 500 (instead of HTTP 400 Bad Request). [An issue](https://github.com/huggingface/moon-landing/issues/5520) is already opened for that (internal link). 

cc @BenjaminBossan as this affected [skops CI](https://github.com/skops-dev/skops/actions/runs/4374220589/jobs/7653373631) since the new release.
cc @Pierrci @coyotte508 for server-side issue

Will release a hot-fix once this is merged (hopefully quickly)