### PR TITLE
Keep-alive connection between requests

### DIFF
--- a/docs/source/package_reference/utilities.mdx
+++ b/docs/source/package_reference/utilities.mdx
@@ -49,6 +49,24 @@ Using these shouldn't be necessary if you use `huggingface_hub` and you don't mo
 
 [[autodoc]] logging.get_logger
 
+## Configure HTTP backend
+
+In some environments, you might want to configure how HTTP calls are made, for example if you are using a proxy.
+`huggingface_hub` let you configure this globally using [`configure_http_backend`]. All requests made to the Hub will
+then use your settings. Under the hood, `huggingface_hub` uses `requests.Session` so you might want to refer to the
+[`requests` documentation](https://requests.readthedocs.io/en/latest/user/advanced) to learn more about the parameters
+available.
+
+Since `requests.Session` is not guaranteed to be thread-safe, `huggingface_hub` creates one session instance per thread.
+Using sessions allows us to keep the connection open between HTTP calls and ultimately save time. If you are
+integrating `huggingface_hub` in a third-party library and wants to make a custom call to the Hub, use [`get_session`]
+to get a Session configured by your users (i.e. replace any `requests.get(...)` call by `get_session().get(...)`).
+
+[[autodoc]] configure_http_backend
+
+[[autodoc]] get_session
+
+
 ## Handle HTTP errors
 
 `huggingface_hub` defines its own HTTP errors to refine the `HTTPError` raised by

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -207,7 +207,9 @@ _SUBMOD_ATTRS = {
         "HFCacheInfo",
         "HfFolder",
         "cached_assets_path",
+        "configure_http_backend",
         "dump_environment_info",
+        "get_session",
         "logging",
         "scan_cache_dir",
     ],
@@ -462,7 +464,9 @@ if TYPE_CHECKING:  # pragma: no cover
         HFCacheInfo,  # noqa: F401
         HfFolder,  # noqa: F401
         cached_assets_path,  # noqa: F401
+        configure_http_backend,  # noqa: F401
         dump_environment_info,  # noqa: F401
+        get_session,  # noqa: F401
         logging,  # noqa: F401
         scan_cache_dir,  # noqa: F401
     )

--- a/src/huggingface_hub/_commit_api.py
+++ b/src/huggingface_hub/_commit_api.py
@@ -11,8 +11,9 @@ from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
 from typing import Any, BinaryIO, Dict, Iterable, Iterator, List, Optional, Union
 
-import requests
 from tqdm.contrib.concurrent import thread_map
+
+from huggingface_hub import get_session
 
 from .constants import ENDPOINT
 from .lfs import UploadInfo, _validate_batch_actions, lfs_upload, post_lfs_batch_info
@@ -468,7 +469,7 @@ def fetch_upload_modes(
             ]
         }
 
-        resp = requests.post(
+        resp = get_session().post(
             f"{endpoint}/api/{repo_type}s/{repo_id}/preupload/{revision}",
             json=payload,
             headers=headers,

--- a/src/huggingface_hub/commands/lfs.py
+++ b/src/huggingface_hub/commands/lfs.py
@@ -23,12 +23,10 @@ import sys
 from argparse import _SubParsersAction
 from typing import Dict, List, Optional
 
-import requests
-
 from huggingface_hub.commands import BaseHuggingfaceCLICommand
 from huggingface_hub.lfs import LFS_MULTIPART_UPLOAD_COMMAND, SliceFileObj
 
-from ..utils import hf_raise_for_status, logging
+from ..utils import get_session, hf_raise_for_status, logging
 
 
 logger = logging.get_logger(__name__)
@@ -172,7 +170,7 @@ class LfsUploadCommand:
                         seek_from=i * chunk_size,
                         read_limit=chunk_size,
                     ) as data:
-                        r = requests.put(presigned_url, data=data)
+                        r = get_session().put(presigned_url, data=data)
                         hf_raise_for_status(r)
                         parts.append(
                             {
@@ -192,7 +190,7 @@ class LfsUploadCommand:
                         )
                         # Not precise but that's ok.
 
-            r = requests.post(
+            r = get_session().post(
                 completion_url,
                 json={
                     "oid": oid,

--- a/src/huggingface_hub/inference_api.py
+++ b/src/huggingface_hub/inference_api.py
@@ -1,11 +1,9 @@
 import io
 from typing import Any, Dict, List, Optional, Union
 
-import requests
-
 from .constants import INFERENCE_ENDPOINT
 from .hf_api import HfApi
-from .utils import build_hf_headers, is_pillow_available, logging, validate_hf_hub_args
+from .utils import build_hf_headers, get_session, is_pillow_available, logging, validate_hf_hub_args
 
 
 logger = logging.get_logger(__name__)
@@ -179,7 +177,7 @@ class InferenceApi:
             payload["parameters"] = params
 
         # Make API call
-        response = requests.post(self.api_url, headers=self.headers, json=payload, data=data)
+        response = get_session().post(self.api_url, headers=self.headers, json=payload, data=data)
 
         # Let the user handle the response
         if raw_response:

--- a/src/huggingface_hub/lfs.py
+++ b/src/huggingface_hub/lfs.py
@@ -22,10 +22,10 @@ from math import ceil
 from os.path import getsize
 from typing import BinaryIO, Iterable, List, Optional, Tuple
 
-import requests
 from requests.auth import HTTPBasicAuth
 
 from huggingface_hub.constants import ENDPOINT, REPO_TYPES_URL_PREFIXES
+from huggingface_hub.utils import get_session
 
 from .utils import (
     get_token_to_send,
@@ -167,7 +167,7 @@ def post_lfs_batch_info(
     if repo_type in REPO_TYPES_URL_PREFIXES:
         url_prefix = REPO_TYPES_URL_PREFIXES[repo_type]
     batch_url = f"{endpoint}/{url_prefix}{repo_id}.git/info/lfs/objects/batch"
-    resp = requests.post(
+    resp = get_session().post(
         batch_url,
         headers={
             "Accept": "application/vnd.git-lfs+json",
@@ -264,7 +264,7 @@ def lfs_upload(
             fileobj=fileobj,
         )
     if verify_action is not None:
-        verify_resp = requests.post(
+        verify_resp = get_session().post(
             verify_action["href"],
             auth=HTTPBasicAuth(
                 username="USER",
@@ -377,7 +377,7 @@ def _upload_multi_part(
                 raise ValueError(f"Invalid etag (`{etag}`) returned for part {part_idx +1} of {num_parts}")
             completion_payload["parts"][part_idx]["etag"] = etag
 
-    completion_res = requests.post(
+    completion_res = get_session().post(
         completion_url,
         json=completion_payload,
         headers=LFS_HEADERS,

--- a/src/huggingface_hub/repocard.py
+++ b/src/huggingface_hub/repocard.py
@@ -17,7 +17,7 @@ from huggingface_hub.repocard_data import (
     eval_results_to_model_index,
     model_index_to_eval_results,
 )
-from huggingface_hub.utils import is_jinja_available, yaml_dump
+from huggingface_hub.utils import get_session, is_jinja_available, yaml_dump
 
 from .constants import REPOCARD_NAME
 from .utils import EntryNotFoundError, SoftTemporaryDirectory, validate_hf_hub_args
@@ -216,7 +216,7 @@ class RepoCard:
         headers = {"Accept": "text/plain"}
 
         try:
-            r = requests.post("https://huggingface.co/api/validate-yaml", body, headers=headers)
+            r = get_session().post("https://huggingface.co/api/validate-yaml", body, headers=headers)
             r.raise_for_status()
         except requests.exceptions.HTTPError as exc:
             if r.status_code == 400:

--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -50,7 +50,7 @@ from ._git_credential import (
 )
 from ._headers import build_hf_headers, get_token_to_send
 from ._hf_folder import HfFolder
-from ._http import http_backoff
+from ._http import configure_http_backend, get_session, http_backoff
 from ._paths import filter_repo_objects
 from ._runtime import (
     dump_environment_info,

--- a/src/huggingface_hub/utils/_errors.py
+++ b/src/huggingface_hub/utils/_errors.py
@@ -20,9 +20,9 @@ class HfHubHTTPError(HTTPError):
     Example:
     ```py
         import requests
-        from huggingface_hub.utils import hf_raise_for_status, HfHubHTTPError
+        from huggingface_hub.utils import get_session, hf_raise_for_status, HfHubHTTPError
 
-        response = requests.post(...)
+        response = get_session().post(...)
         try:
             hf_raise_for_status(response)
         except HfHubHTTPError as e:
@@ -211,9 +211,9 @@ def hf_raise_for_status(response: Response, endpoint_name: Optional[str] = None)
     Example:
     ```py
         import requests
-        from huggingface_hub.utils import hf_raise_for_status, HfHubHTTPError
+        from huggingface_hub.utils import get_session, hf_raise_for_status, HfHubHTTPError
 
-        response = requests.post(...)
+        response = get_session().post(...)
         try:
             hf_raise_for_status(response)
         except HfHubHTTPError as e:

--- a/src/huggingface_hub/utils/_http.py
+++ b/src/huggingface_hub/utils/_http.py
@@ -253,6 +253,7 @@ def http_backoff(
     if "data" in kwargs and isinstance(kwargs["data"], io.IOBase):
         io_obj_initial_pos = kwargs["data"].tell()
 
+    session = get_session()
     while True:
         nb_tries += 1
         try:
@@ -262,7 +263,7 @@ def http_backoff(
                 kwargs["data"].seek(io_obj_initial_pos)
 
             # Perform request and return if status_code is not in the retry list.
-            response = requests.request(method=method, url=url, **kwargs)
+            response = session.request(method=method, url=url, **kwargs)
             if response.status_code not in retry_on_status_codes:
                 return response
 

--- a/src/huggingface_hub/utils/_http.py
+++ b/src/huggingface_hub/utils/_http.py
@@ -14,9 +14,12 @@
 # limitations under the License.
 """Contains utilities to handle HTTP requests in Huggingface Hub."""
 import io
+import threading
 import time
+from dataclasses import dataclass
+from functools import lru_cache
 from http import HTTPStatus
-from typing import Tuple, Type, Union
+from typing import Any, Dict, Optional, Tuple, Type, Union
 
 import requests
 from requests import Response
@@ -27,6 +30,139 @@ from ._typing import HTTP_METHOD_T
 
 
 logger = logging.get_logger(__name__)
+
+
+@dataclass
+class SessionParameters:
+    """Data structure containing configuration for `requests.Session`.
+
+    Visit the [`requests` documentation](https://requests.readthedocs.io/en/latest/user/advanced) for a description of
+    each parameter.
+    """
+
+    headers: Optional[Dict[str, Any]] = None
+    auth: Optional[Any] = None
+    proxies: Optional[Dict[str, Any]] = None
+    hooks: Optional[Dict[str, list]] = None
+    verify: Optional[bool] = None
+    cert: Optional[Union[str, Tuple[str, str]]] = None
+    max_redirects: Optional[int] = None
+    trust_env: Optional[bool] = None
+
+
+_GLOBAL_SESSION_PARAMETERS = SessionParameters()
+
+
+def configure_http_backend(
+    headers: Optional[Dict[str, Any]] = None,
+    auth: Optional[Any] = None,
+    proxies: Optional[Dict[str, Any]] = None,
+    hooks: Optional[Dict[str, list]] = None,
+    verify: Optional[bool] = None,
+    cert: Optional[Union[str, Tuple[str, str]]] = None,
+    max_redirects: Optional[int] = None,
+    trust_env: Optional[bool] = None,
+) -> None:
+    """
+    Configure the HTTP backend. All HTTP calls from `huggingface_hub` will use these settings. This can be useful if
+    you are running your scripts in a specific environment requiring custom configuration (e.g. custom proxy or
+    certifications).
+
+    To get a list of all available parameters, you can refer to the official [`requests` documentation](https://requests.readthedocs.io/en/latest/user/advanced).
+    Any parameter left to `None` will default to the default value from `requests`.
+
+    Use [`get_session`] to get a configured Session. Since `requests.Session` is not guaranteed to be thread-safe,
+    `huggingface_hub` creates 1 Session instance per thread. They all share the same initial configuration set in
+    [`configure_http_backend`]. A LRU cache is used to cache the created sessions (and connections) between calls. Max
+    size is 128 to avoid memory leaks if thousands of threads are spawned.
+
+    See [this issue](https://github.com/psf/requests/issues/2766) to know more about thread-safety in `requests`.
+
+    Example:
+    ```py
+    from huggingface_hub import configure_http_backend, get_session
+
+    # Configure proxy
+    configure_http_backend(
+        proxies={"http": "http://10.10.1.10:3128", "https": "https://10.10.1.11:1080"},
+    )
+
+    # In practice, this is mostly done internally in `huggingface_hub`
+    session = get_session().get("https://huggingface.co/api/models/gpt2")
+    ```
+    """
+    global _GLOBAL_SESSION_PARAMETERS
+    _GLOBAL_SESSION_PARAMETERS = SessionParameters(
+        headers=headers,
+        auth=auth,
+        proxies=proxies,
+        hooks=hooks,
+        verify=verify,
+        cert=cert,
+        max_redirects=max_redirects,
+        trust_env=trust_env,
+    )
+    _get_session_from_cache.cache_clear()
+
+
+def get_http_backend_configuration() -> SessionParameters:
+    return _GLOBAL_SESSION_PARAMETERS
+
+
+def get_session() -> requests.Session:
+    """
+    Get a `requests.Session` object, using configuration from the user.
+
+    Use [`get_session`] to get a configured Session. Since `requests.Session` is not guaranteed to be thread-safe,
+    `huggingface_hub` creates 1 Session instance per thread. They all share the same initial configuration set in
+    [`configure_http_backend`]. A LRU cache is used to cache the created sessions (and connections) between calls. Max
+    size is 128 to avoid memory leaks if thousands of threads are spawned.
+
+    See [this issue](https://github.com/psf/requests/issues/2766) to know more about thread-safety in `requests`.
+
+    Example:
+    ```py
+    from huggingface_hub import configure_http_backend, get_session
+
+    # Configure proxy
+    configure_http_backend(
+        proxies={"http": "http://10.10.1.10:3128", "https": "https://10.10.1.11:1080"},
+    )
+
+    # In practice, this is mostly done internally in `huggingface_hub`
+    session = get_session().get("https://huggingface.co/api/models/gpt2")
+    ```
+    """
+    return _get_session_from_cache(thread_ident=threading.get_ident())
+
+
+@lru_cache
+def _get_session_from_cache(thread_ident: int) -> requests.Session:
+    """
+    Create a new session per thread using global parameters. Using LRU cache (maxsize 128) to avoid memory leaks when
+    using thousands of threads. Cache is cleared when `configure_http_backend` is called.
+    """
+    session = requests.Session()
+    parameters = _GLOBAL_SESSION_PARAMETERS
+
+    if parameters.headers is not None:
+        session.headers.update(parameters.headers)
+    if parameters.auth is not None:
+        session.auth = parameters.auth
+    if parameters.proxies is not None:
+        session.proxies.update(parameters.proxies)
+    if parameters.hooks is not None:
+        session.hooks.update(parameters.hooks)
+    if parameters.verify is not None:
+        session.verify = parameters.verify
+    if parameters.cert is not None:
+        session.cert = parameters.cert
+    if parameters.max_redirects is not None:
+        session.max_redirects = parameters.max_redirects
+    if parameters.trust_env is not None:
+        session.trust_env = parameters.trust_env
+
+    return session
 
 
 def http_backoff(

--- a/src/huggingface_hub/utils/_http.py
+++ b/src/huggingface_hub/utils/_http.py
@@ -136,7 +136,7 @@ def get_session() -> requests.Session:
     return _get_session_from_cache(thread_ident=threading.get_ident())
 
 
-@lru_cache
+@lru_cache(maxsize=128)  # default value for Python>=3.8. Let's keep the same for Python3.7
 def _get_session_from_cache(thread_ident: int) -> requests.Session:
     """
     Create a new session per thread using global parameters. Using LRU cache (maxsize 128) to avoid memory leaks when

--- a/src/huggingface_hub/utils/_pagination.py
+++ b/src/huggingface_hub/utils/_pagination.py
@@ -17,7 +17,7 @@ from typing import Dict, Iterable, Optional
 
 import requests
 
-from . import hf_raise_for_status, logging
+from . import get_session, hf_raise_for_status, logging
 
 
 logger = logging.get_logger(__name__)
@@ -31,7 +31,8 @@ def paginate(path: str, params: Dict, headers: Dict) -> Iterable:
     - https://requests.readthedocs.io/en/latest/api/#requests.Response.links
     - https://docs.github.com/en/rest/guides/traversing-with-pagination#link-header
     """
-    r = requests.get(path, params=params, headers=headers)
+    session = get_session()
+    r = session.get(path, params=params, headers=headers)
     hf_raise_for_status(r)
     yield from r.json()
 
@@ -40,7 +41,7 @@ def paginate(path: str, params: Dict, headers: Dict) -> Iterable:
     next_page = _get_next_page(r)
     while next_page is not None:
         logger.debug(f"Pagination detected. Requesting next page: {next_page}")
-        r = requests.get(next_page, headers=headers)
+        r = session.get(next_page, headers=headers)
         hf_raise_for_status(r)
         yield from r.json()
         next_page = _get_next_page(r)

--- a/src/huggingface_hub/utils/_telemetry.py
+++ b/src/huggingface_hub/utils/_telemetry.py
@@ -3,10 +3,8 @@ from threading import Lock, Thread
 from typing import Dict, Optional, Union
 from urllib.parse import quote
 
-import requests
-
 from .. import constants, logging
-from . import build_hf_headers, hf_raise_for_status
+from . import build_hf_headers, get_session, hf_raise_for_status
 
 
 logger = logging.get_logger(__name__)
@@ -105,7 +103,7 @@ def _send_telemetry_in_thread(
     """Contains the actual data sending data to the Hub."""
     path = "/".join(quote(part) for part in topic.split("/") if len(part) > 0)
     try:
-        r = requests.head(
+        r = get_session().head(
             f"{constants.ENDPOINT}/api/telemetry/{path}",
             headers=build_hf_headers(
                 token=False,  # no need to send a token for telemetry

--- a/tests/test_inference_api.py
+++ b/tests/test_inference_api.py
@@ -89,20 +89,20 @@ class InferenceApiTest(unittest.TestCase):
 
     def test_text_to_image(self):
         api = InferenceApi("stabilityai/stable-diffusion-2-1")
-        with patch("huggingface_hub.inference_api.requests") as mock:
-            mock.post.return_value.headers = {"Content-Type": "image/jpeg"}
-            mock.post.return_value.content = self.read(self.image_file)
+        with patch("huggingface_hub.inference_api.get_session") as mock:
+            mock().post.return_value.headers = {"Content-Type": "image/jpeg"}
+            mock().post.return_value.content = self.read(self.image_file)
             output = api("cat")
         self.assertIsInstance(output, Image.Image)
 
     def test_text_to_image_raw_response(self):
         api = InferenceApi("stabilityai/stable-diffusion-2-1")
-        with patch("huggingface_hub.inference_api.requests") as mock:
-            mock.post.return_value.headers = {"Content-Type": "image/jpeg"}
-            mock.post.return_value.content = self.read(self.image_file)
+        with patch("huggingface_hub.inference_api.get_session") as mock:
+            mock().post.return_value.headers = {"Content-Type": "image/jpeg"}
+            mock().post.return_value.content = self.read(self.image_file)
             output = api("cat", raw_response=True)
         # Raw response is returned
-        self.assertEqual(output, mock.post.return_value)
+        self.assertEqual(output, mock().post.return_value)
 
     def test_inference_overriding_task(self):
         api = InferenceApi(

--- a/tests/test_utils_http.py
+++ b/tests/test_utils_http.py
@@ -143,6 +143,11 @@ class TestConfigureSession(unittest.TestCase):
         # Reconfigure + clear session cache between each test
         configure_http_backend()
 
+    @classmethod
+    def tearDownClass(cls) -> None:
+        # Clear all sessions after tests
+        configure_http_backend()
+
     def test_default_configuration(self) -> None:
         session = get_session()
         self.assertEqual(session.headers["connection"], "keep-alive")  # keep connection alive by default

--- a/tests/test_utils_pagination.py
+++ b/tests/test_utils_pagination.py
@@ -7,10 +7,11 @@ from .testing_utils import handle_injection_in_test
 
 
 class TestPagination(unittest.TestCase):
-    @patch("huggingface_hub.utils._pagination.requests.get")
+    @patch("huggingface_hub.utils._pagination.get_session")
     @patch("huggingface_hub.utils._pagination.hf_raise_for_status")
     @handle_injection_in_test
-    def test_mocked_paginate(self, mock_get: Mock, mock_hf_raise_for_status: Mock) -> None:
+    def test_mocked_paginate(self, mock_get_session: Mock, mock_hf_raise_for_status: Mock) -> None:
+        mock_get = mock_get_session().get
         mock_params = Mock()
         mock_headers = Mock()
 
@@ -62,11 +63,7 @@ class TestPagination(unittest.TestCase):
         # Real test: paginate over huggingface repos on Github
         # Use enumerate and stop after first page to avoid loading all repos
         for num, _ in enumerate(
-            paginate(
-                "https://api.github.com/orgs/huggingface/repos?limit=4",
-                params={},
-                headers={},
-            )
+            paginate("https://api.github.com/orgs/huggingface/repos?limit=4", params={}, headers={})
         ):
             if num == 6:
                 break

--- a/tests/test_utils_telemetry.py
+++ b/tests/test_utils_telemetry.py
@@ -7,65 +7,83 @@ from huggingface_hub.utils._telemetry import send_telemetry
 from .testing_constants import ENDPOINT_STAGING
 
 
-@patch("huggingface_hub.utils._telemetry.requests.head")
 @patch("huggingface_hub.utils._telemetry._TELEMETRY_QUEUE", new_callable=Queue)
 @patch("huggingface_hub.utils._telemetry._TELEMETRY_THREAD", None)
 class TestSendTelemetry(unittest.TestCase):
-    def test_topic_normal(self, queue: Queue, mock_request: Mock) -> None:
+    def setUp(self) -> None:
+        get_session_mock = Mock()
+        self.mock_head = get_session_mock().head
+
+        self.patcher = patch("huggingface_hub.utils._telemetry.get_session", get_session_mock)
+        self.patcher.start()
+
+    def tearDown(self) -> None:
+        self.patcher.stop()
+
+    def test_topic_normal(self, queue: Queue) -> None:
         send_telemetry(topic="examples")
         queue.join()  # Wait for the telemetry tasks to be completed
-        mock_request.assert_called_once()
-        self.assertEqual(mock_request.call_args[0][0], f"{ENDPOINT_STAGING}/api/telemetry/examples")
+        self.mock_head.assert_called_once()
+        self.assertEqual(self.mock_head.call_args[0][0], f"{ENDPOINT_STAGING}/api/telemetry/examples")
 
-    def test_topic_multiple(self, queue: Queue, mock_request: Mock) -> None:
+    def test_topic_multiple(self, queue: Queue) -> None:
         send_telemetry(topic="example1")
         send_telemetry(topic="example2")
         send_telemetry(topic="example3")
         queue.join()  # Wait for the telemetry tasks to be completed
 
-        self.assertEqual(mock_request.call_count, 3)  # 3 calls and order is preserved
-        self.assertEqual(mock_request.call_args_list[0][0][0], f"{ENDPOINT_STAGING}/api/telemetry/example1")
-        self.assertEqual(mock_request.call_args_list[1][0][0], f"{ENDPOINT_STAGING}/api/telemetry/example2")
-        self.assertEqual(mock_request.call_args_list[2][0][0], f"{ENDPOINT_STAGING}/api/telemetry/example3")
+        self.assertEqual(self.mock_head.call_count, 3)  # 3 calls and order is preserved
+        self.assertEqual(self.mock_head.call_args_list[0][0][0], f"{ENDPOINT_STAGING}/api/telemetry/example1")
+        self.assertEqual(self.mock_head.call_args_list[1][0][0], f"{ENDPOINT_STAGING}/api/telemetry/example2")
+        self.assertEqual(self.mock_head.call_args_list[2][0][0], f"{ENDPOINT_STAGING}/api/telemetry/example3")
 
-    def test_topic_with_subtopic(self, queue: Queue, mock_request: Mock) -> None:
+    def test_topic_with_subtopic(self, queue: Queue) -> None:
         send_telemetry(topic="gradio/image/this_one")
         queue.join()  # Wait for the telemetry tasks to be completed
-        mock_request.assert_called_once()
-        self.assertEqual(mock_request.call_args[0][0], f"{ENDPOINT_STAGING}/api/telemetry/gradio/image/this_one")
+        self.mock_head.assert_called_once()
+        self.assertEqual(self.mock_head.call_args[0][0], f"{ENDPOINT_STAGING}/api/telemetry/gradio/image/this_one")
 
-    def test_topic_quoted(self, queue: Queue, mock_request: Mock) -> None:
+    def test_topic_quoted(self, queue: Queue) -> None:
         send_telemetry(topic="foo bar")
         queue.join()  # Wait for the telemetry tasks to be completed
-        mock_request.assert_called_once()
-        self.assertEqual(mock_request.call_args[0][0], f"{ENDPOINT_STAGING}/api/telemetry/foo%20bar")
+        self.mock_head.assert_called_once()
+        self.assertEqual(self.mock_head.call_args[0][0], f"{ENDPOINT_STAGING}/api/telemetry/foo%20bar")
 
     @patch("huggingface_hub.utils._telemetry.constants.HF_HUB_OFFLINE", True)
-    def test_hub_offline(self, queue: Queue, mock_request: Mock) -> None:
+    def test_hub_offline(self, queue: Queue) -> None:
         send_telemetry(topic="topic")
         self.assertTrue(queue.empty())  # no tasks
-        mock_request.assert_not_called()
+        self.mock_head.assert_not_called()
 
     @patch("huggingface_hub.utils._telemetry.constants.HF_HUB_DISABLE_TELEMETRY", True)
-    def test_telemetry_disabled(self, queue: Queue, mock_request: Mock) -> None:
+    def test_telemetry_disabled(self, queue: Queue) -> None:
         send_telemetry(topic="topic")
         self.assertTrue(queue.empty())  # no tasks
-        mock_request.assert_not_called()
+        self.mock_head.assert_not_called()
 
     @patch("huggingface_hub.utils._telemetry.build_hf_headers")
-    def test_telemetry_use_build_hf_headers(self, mock_headers: Mock, queue: Queue, mock_request: Mock) -> None:
+    def test_telemetry_use_build_hf_headers(self, mock_headers: Mock, queue: Queue) -> None:
         send_telemetry(topic="topic")
         queue.join()  # Wait for the telemetry tasks to be completed
-        mock_request.assert_called_once()
+        self.mock_head.assert_called_once()
         mock_headers.assert_called_once()
-        self.assertEqual(mock_request.call_args[1]["headers"], mock_headers.return_value)
+        self.assertEqual(self.mock_head.call_args[1]["headers"], mock_headers.return_value)
 
 
-@patch("huggingface_hub.utils._telemetry.requests.head", side_effect=Exception("whatever"))
 @patch("huggingface_hub.utils._telemetry._TELEMETRY_QUEUE", new_callable=Queue)
 @patch("huggingface_hub.utils._telemetry._TELEMETRY_THREAD", None)
 class TestSendTelemetryConnectionError(unittest.TestCase):
-    def test_telemetry_exception_silenced(self, queue: Queue, mock_request: Mock) -> None:
+    def setUp(self) -> None:
+        get_session_mock = Mock()
+        get_session_mock().head.side_effect = Exception("whatever")
+
+        self.patcher = patch("huggingface_hub.utils._telemetry.get_session", get_session_mock)
+        self.patcher.start()
+
+    def tearDown(self) -> None:
+        self.patcher.stop()
+
+    def test_telemetry_exception_silenced(self, queue: Queue) -> None:
         with self.assertLogs(logger="huggingface_hub.utils._telemetry", level="DEBUG") as captured:
             send_telemetry(topic="topic")
             queue.join()

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -15,6 +15,7 @@ from typing import Callable, Generator, Optional, Type, TypeVar, Union
 from unittest.mock import Mock, patch
 
 import pytest
+import requests
 from requests.exceptions import HTTPError
 
 from huggingface_hub.utils import logging
@@ -169,7 +170,9 @@ def offline(mode=OfflineSimulationMode.CONNECTION_FAILS, timeout=1e-16):
     if mode is OfflineSimulationMode.CONNECTION_FAILS:
         # inspired from https://stackoverflow.com/a/18601897
         with patch("socket.socket", offline_socket):
-            yield
+            with patch("huggingface_hub.utils._http.get_session") as get_session_mock:
+                get_session_mock.return_value = requests.Session()  # not an existing one
+                yield
     elif mode is OfflineSimulationMode.CONNECTION_TIMES_OUT:
         # inspired from https://stackoverflow.com/a/904609
         with patch("requests.request", timeout_request):

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -173,7 +173,9 @@ def offline(mode=OfflineSimulationMode.CONNECTION_FAILS, timeout=1e-16):
     elif mode is OfflineSimulationMode.CONNECTION_TIMES_OUT:
         # inspired from https://stackoverflow.com/a/904609
         with patch("requests.request", timeout_request):
-            yield
+            with patch("huggingface_hub.utils._http.get_session") as get_session_mock:
+                get_session_mock().request = timeout_request
+                yield
     elif mode is OfflineSimulationMode.HF_HUB_OFFLINE_SET_TO_1:
         with patch("huggingface_hub.constants.HF_HUB_OFFLINE", True):
             yield


### PR DESCRIPTION
Related to https://github.com/huggingface/huggingface_hub/issues/1368.

The goal of this PR is to speed-up `huggingface_hub` by keeping the connection alive between HTTP calls. This can be done using `requests.Session` objects. Since sessions [are not guaranteed to be thread-safe](https://github.com/psf/requests/issues/2766), I am creating 1 session object per thread. For most users it will be an invisible change -except the speed-up-. Third-party libraries can also benefit from it by using `get_session()` if they make custom calls to the Hub:

```py
# Change from this
import requests
requests.post(...)

# to this
from huggingface_hub import get_session
get_session().post(...)
``` 

In addition to this, this PR adds a `configure_http_backend` method to let the user configure the session parameters. It is useful on particular to set proxies. At the moment proxies are only handled in `snapshot_download` and `hf_hub_download`. Now the user will be able to globally set how these for all HTTP calls.

```py
from huggingface_hub import configure_http_backend, get_session

# Configure proxy and disable verify. All HTTP calls will use these parameters.
configure_http_backend(
    proxies={"http": "http://10.10.1.10:3128", "https": "https://10.10.1.11:1080"},
    verify=False,
)
```

**Notes:**
- A counterpart of using sessions is the memory footprint. To avoid memory leaks, I'm storing sessions is a LRU cache (maximum 128)
- As a side effect, this PR solves https://github.com/huggingface/huggingface_hub/issues/1271 (being able to pass `verify=False` in all HTTP calls)
- As another side effect, the CI is way faster than before (~6min vs ~11min). This is quite expected since the connection is kept alive for hundreds of calls.

**Small benchmark:**

I've made a very small benchmark on a few tasks that users might do with huggingface_hub. All snippets have been repeated 10x and I took the average duration. Made the the benchmark at home on an average connection (~40ms ping).

| code | without sessions | with sessions |
|---|:---:|:---:|
| `StableDiffusionPipeline.from_pretrained("CompVis/stable-diffusion-v1-4", torch_dtype=torch.float16` | 6.63s | 4.17s |
| `snapshot_download("CompVis/stable-diffusion-v1-4", ignore_patterns="*.bin")` | 1.26s | 1.19s |
| `metadata_update(repo_id, metadata={"tags": [str(uuid.uuid4())]}, overwrite=True)` | 5.70s | 3.36s |
| `[model_info(model.id) for model in list_models(limit=50)]` | 49.2s | 20.7s |
| `thread_map(model_info, (model.id for model in list_models(limit=50)))` | 7.24s | 4.50s |

- `snapshot_download` was run with the files already cached. It is normal to not see a different as only 1 HTTP call is made.
- `metadata_upadte` makes 1 download + 1 commit
- `StableDiffusionPipeline` loading is before the optimization from @patrickvonplaten

**TODO:**
- [x] implementation
- [x] tests
- [x] documentation
- [x] small benchmarks