### PR TITLE
Model card template: Move model usage instructions out of Bias section

### DIFF
--- a/src/huggingface_hub/templates/modelcard_template.md
+++ b/src/huggingface_hub/templates/modelcard_template.md
@@ -67,7 +67,7 @@
 
 {{ bias_recommendations | default("Users (both direct and downstream) should be made aware of the risks, biases and limitations of the model. More information needed for further recommendations.", true)}}
 
-### How to Get Started with the Model
+## How to Get Started with the Model
 
 Use the code below to get started with the model.
 


### PR DESCRIPTION
Not sure that `### How to Get Started with the Model` belongs under the `Bias, Risks, and Limitations` section, so this PR changes it from a H3 to an H2.