### PR TITLE
Update file_download.py

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1506,7 +1506,8 @@ def get_hf_file_metadata(
         etag=_normalize_etag(
             # We favor a custom header indicating the etag of the linked resource, and
             # we fallback to the regular etag header.
-            r.headers.get(HUGGINGFACE_HEADER_X_LINKED_ETAG) or r.headers.get("ETag")
+            r.headers.get(HUGGINGFACE_HEADER_X_LINKED_ETAG)
+            or r.headers.get("ETag")
         ),
         # Either from response headers (if redirected) or defaults to request url
         # Do not use directly `url`, as `_request_wrapper` might have followed relative

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1506,8 +1506,7 @@ def get_hf_file_metadata(
         etag=_normalize_etag(
             # We favor a custom header indicating the etag of the linked resource, and
             # we fallback to the regular etag header.
-            r.headers.get("ETag")
-            or r.headers.get(HUGGINGFACE_HEADER_X_LINKED_ETAG)
+            r.headers.get(HUGGINGFACE_HEADER_X_LINKED_ETAG) or r.headers.get("ETag")
         ),
         # Either from response headers (if redirected) or defaults to request url
         # Do not use directly `url`, as `_request_wrapper` might have followed relative


### PR DESCRIPTION
Related to https://github.com/huggingface/moon-landing/issues/5801#issuecomment-1479898977 (cc @coyotte508 @Pierrci)

To be consistent between `cached_download` (legacy) and `hf_hub_download`.

Should be transparent for the user (as discussed [in slack](https://huggingface.slack.com/archives/C03UMD3NYHL/p1679579002593009) -private link-) since `Etag` and `X-Linked-Tag` are never returned together.