### PR TITLE
Raise issue if trying to upload `.git/` folder + ignore `.git/` folder in `upload_folder`

### DIFF
--- a/docs/source/guides/upload.mdx
+++ b/docs/source/guides/upload.mdx
@@ -79,6 +79,9 @@ Use the `allow_patterns` and `ignore_patterns` arguments to specify which files 
 Patterns are Standard Wildcards (globbing patterns) as documented [here](https://tldp.org/LDP/GNU-Linux-Tools-Summary/html/x11655.htm).
 If both `allow_patterns` and `ignore_patterns` are provided, both constraints apply. By default, all files from the folder are uploaded.
 
+Any `.git/` folder present in any subdirectory will be ignored. However, please be aware that the `.gitignore` file is not taken into account.
+So must use `allow_patterns` and `ignore_patterns` to specify which files to upload instead.
+
 ```py
 >>> api.upload_folder(
 ...     folder_path="/path/to/local/folder",

--- a/docs/source/guides/upload.mdx
+++ b/docs/source/guides/upload.mdx
@@ -80,7 +80,7 @@ Patterns are Standard Wildcards (globbing patterns) as documented [here](https:/
 If both `allow_patterns` and `ignore_patterns` are provided, both constraints apply. By default, all files from the folder are uploaded.
 
 Any `.git/` folder present in any subdirectory will be ignored. However, please be aware that the `.gitignore` file is not taken into account.
-So must use `allow_patterns` and `ignore_patterns` to specify which files to upload instead.
+This means you must use `allow_patterns` and `ignore_patterns` to specify which files to upload instead.
 
 ```py
 >>> api.upload_folder(

--- a/src/huggingface_hub/_commit_api.py
+++ b/src/huggingface_hub/_commit_api.py
@@ -208,7 +208,8 @@ def _validate_path_in_repo(path_in_repo: str) -> str:
         path_in_repo = path_in_repo[2:]
     if any(part == ".git" for part in path_in_repo.split("/")):
         raise ValueError(
-            f"Invalid `path_in_repo` in CommitOperation: cannot update files under a '.git/' folder ({path_in_repo})."
+            "Invalid `path_in_repo` in CommitOperation: cannot update files under a '.git/' folder (path:"
+            f" '{path_in_repo}')."
         )
     return path_in_repo
 

--- a/src/huggingface_hub/_commit_api.py
+++ b/src/huggingface_hub/_commit_api.py
@@ -206,6 +206,10 @@ def _validate_path_in_repo(path_in_repo: str) -> str:
         raise ValueError(f"Invalid `path_in_repo` in CommitOperation: '{path_in_repo}'")
     if path_in_repo.startswith("./"):
         path_in_repo = path_in_repo[2:]
+    if any(part == ".git" for part in path_in_repo.split("/")):
+        raise ValueError(
+            f"Invalid `path_in_repo` in CommitOperation: cannot update files under a '.git/' folder ({path_in_repo})."
+        )
     return path_in_repo
 
 

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -2727,7 +2727,7 @@ class HfApi:
         # Do not upload .git folder
         if ignore_patterns is None:
             ignore_patterns = []
-        if isinstance(ignore_patterns, str):
+        elif isinstance(ignore_patterns, str):
             ignore_patterns = [ignore_patterns]
         ignore_patterns += IGNORE_GIT_FOLDER_PATTERNS
 

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -2760,6 +2760,14 @@ class HfApi:
         if path_in_repo is None:
             path_in_repo = ""
 
+        # Do not upload .git folder
+        if ignore_patterns is None:
+            ignore_patterns = []
+        if isinstance(ignore_patterns, str):
+            ignore_patterns = [ignore_patterns]
+        ignore_patterns.append(".git/")
+        ignore_patterns.append(".git/**")
+
         commit_message = (
             commit_message if commit_message is not None else f"Upload {path_in_repo} with huggingface_hub"
         )

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -27,7 +27,7 @@ from urllib.parse import quote
 import requests
 from requests.exceptions import HTTPError
 
-from huggingface_hub.utils import EntryNotFoundError, RepositoryNotFoundError, get_session
+from huggingface_hub.utils import IGNORE_GIT_FOLDER_PATTERNS, EntryNotFoundError, RepositoryNotFoundError, get_session
 
 from ._commit_api import (
     CommitOperation,
@@ -85,6 +85,7 @@ from .utils.endpoint_helpers import (
 
 USERNAME_PLACEHOLDER = "hf_user"
 _REGEX_DISCUSSION_URL = re.compile(r".*/discussions/(\d+)$")
+
 
 logger = logging.get_logger(__name__)
 
@@ -2725,8 +2726,7 @@ class HfApi:
             ignore_patterns = []
         if isinstance(ignore_patterns, str):
             ignore_patterns = [ignore_patterns]
-        ignore_patterns.append(".git/")
-        ignore_patterns.append(".git/**")
+        ignore_patterns += IGNORE_GIT_FOLDER_PATTERNS
 
         commit_message = (
             commit_message if commit_message is not None else f"Upload {path_in_repo} with huggingface_hub"

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -2607,6 +2607,9 @@ class HfApi:
         will delete any remote file under `experiment/logs/`. Note that the `.gitattributes` file will not be deleted
         even if it matches the patterns.
 
+        Any `.git/` folder present in any subdirectory will be ignored. However, please be aware that the `.gitignore`
+        file is not taken into account.
+
         Uses `HfApi.create_commit` under the hood.
 
         Args:

--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -44,7 +44,7 @@ from ._git_credential import list_credential_helpers, set_git_credential, unset_
 from ._headers import build_hf_headers, get_token_to_send
 from ._hf_folder import HfFolder
 from ._http import configure_http_backend, get_session, http_backoff
-from ._paths import filter_repo_objects
+from ._paths import filter_repo_objects, IGNORE_GIT_FOLDER_PATTERNS
 from ._runtime import (
     dump_environment_info,
     get_fastai_version,

--- a/src/huggingface_hub/utils/_paths.py
+++ b/src/huggingface_hub/utils/_paths.py
@@ -20,6 +20,8 @@ from typing import Callable, Generator, Iterable, List, Optional, TypeVar, Union
 
 T = TypeVar("T")
 
+IGNORE_GIT_FOLDER_PATTERNS = [".git", ".git/*", "*/.git", "**/.git/**"]
+
 
 def filter_repo_objects(
     items: Iterable[T],

--- a/tests/test_utils_paths.py
+++ b/tests/test_utils_paths.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, List, Optional, Union
 
-from huggingface_hub.utils import filter_repo_objects
+from huggingface_hub.utils import IGNORE_GIT_FOLDER_PATTERNS, filter_repo_objects
 
 
 @dataclass
@@ -101,3 +101,27 @@ class TestPathsUtils(unittest.TestCase):
             ),
             expected_items,
         )
+
+
+class TestGitFolderExclusion(unittest.TestCase):
+    GIT_FOLDER_PATHS = [
+        ".git",
+        ".git/file.txt",
+        ".git/folder/file.txt",
+        "path/to/folder/.git",
+        "path/to/folder/.git/file.txt",
+        "path/to/.git/folder/file.txt",
+    ]
+
+    NOT_GIT_FOLDER_PATHS = [
+        ".gitignore",
+        "path/foo.git/file.txt",
+        "path/.git_bar/file.txt",
+        "path/to/file.git",
+    ]
+
+    def test_exclude_git_folder(self):
+        filtered_paths = filter_repo_objects(
+            items=self.GIT_FOLDER_PATHS + self.NOT_GIT_FOLDER_PATHS, ignore_patterns=IGNORE_GIT_FOLDER_PATTERNS
+        )
+        self.assertListEqual(list(filtered_paths), self.NOT_GIT_FOLDER_PATHS)


### PR DESCRIPTION
Fix https://github.com/huggingface/huggingface_hub/issues/1401 and https://github.com/huggingface/huggingface_hub/issues/1402 (thanks @lewtun for reporting it).

This PR:
- adds a check in `CommitOperationAdd` and `CommitOperationDelete` => it is not possible to upload/delete a file in the `.git/` folder. Server would not accept it anyway but let's raise an issue early.
- ignores the `.git/` folder when uploading with `upload_folder`
- adds tests and docs

One thing that would be cool before having a `huggingface-cli push` command would be to comply with the `.gitignore` [specification](https://git-scm.com/docs/gitignore). However this is not straightforward (cannot be converted to a list of allow_patterns/ignore_patterns that easily). I have found a [gitignore_parser](https://github.com/mherrmann/gitignore_parser) that does the trick but it would add another dependency for which I don't know much about the quality of it. Let's keep this discussion for later.

---

Note: I also refactored a few tests in `hf_api` to be more consistent with creating/deleting repos. Not exhaustive but it's still _cleaner_.