### PR TITLE
Fix: notebook_login() does not update UI on Databricks

### DIFF
--- a/src/huggingface_hub/_login.py
+++ b/src/huggingface_hub/_login.py
@@ -206,10 +206,6 @@ def notebook_login() -> None:
     )
     display(login_token_widget)
 
-    def add_string_to_widget_output(*strings: str) -> None:
-        content_str = " ".join(strings)
-        login_token_widget.children = login_token_widget.children + (widgets.Label(content_str),)
-
     # On click events
     def login_token_event(t):
         token = token_widget.value
@@ -217,15 +213,15 @@ def notebook_login() -> None:
         # Erase token and clear value to make sure it's not saved in the notebook.
         token_widget.value = ""
         # Hide inputs
-        login_token_widget.children = []
+        login_token_widget.children = [widgets.Label("Connecting...")]
         try:
             with capture_output() as captured:
                 _login(token, add_to_git_credential=add_to_git_credential)
-            message = captured
+            message = captured.getvalue()
         except Exception as error:
             message = str(error)
         # Print result (success message or error)
-        login_token_widget.children = [widgets.Label(message)]
+        login_token_widget.children = [widgets.Label(line) for line in message.split("\n") if line.strip()]
 
     token_finish_button.on_click(login_token_event)
 

--- a/src/huggingface_hub/_login.py
+++ b/src/huggingface_hub/_login.py
@@ -198,6 +198,7 @@ def notebook_login() -> None:
     login_token_widget = widgets.VBox(
         [
             widgets.HTML(NOTEBOOK_LOGIN_TOKEN_HTML_START),
+            widgets.HTML("flo test"),
             token_widget,
             git_checkbox_widget,
             token_finish_button,

--- a/src/huggingface_hub/_login.py
+++ b/src/huggingface_hub/_login.py
@@ -209,7 +209,7 @@ def notebook_login() -> None:
 
     def add_string_to_widget_output(*strings: str) -> None:
         content_str = " ".join(strings)
-        login_token_widget.children = login_token_widget.children + (widgets.Label(content_str), )
+        login_token_widget.children = login_token_widget.children + (widgets.Label(content_str),)
 
     # On click events
     def login_token_event(t):
@@ -244,8 +244,8 @@ def _login(token: str, add_to_git_credential: bool, print_output: Callable[[str]
         if _is_git_credential_helper_configured():
             set_git_credential(token)
             print_output(
-                "Your token has been saved in your configured git credential helpers" +
-                f" ({','.join(list_credential_helpers())})."
+                "Your token has been saved in your configured git credential helpers"
+                + f" ({','.join(list_credential_helpers())})."
             )
         else:
             print_output("Token has not been saved to git credential helper.")

--- a/src/huggingface_hub/_login.py
+++ b/src/huggingface_hub/_login.py
@@ -218,7 +218,10 @@ def notebook_login() -> None:
         token_widget.value = ""
         # Hide inputs
         login_token_widget.children = []
-        _login(token, add_to_git_credential=add_to_git_credential, print_output=add_string_to_widget_output)
+        try:
+            _login(token, add_to_git_credential=add_to_git_credential, print_output=add_string_to_widget_output)
+        except:
+            login_token_widget.children = [widgets.HTML("error")]
 
     token_finish_button.on_click(login_token_event)
 

--- a/src/huggingface_hub/_login.py
+++ b/src/huggingface_hub/_login.py
@@ -222,8 +222,7 @@ def notebook_login() -> None:
         try:
             _login(token, add_to_git_credential=add_to_git_credential, print_output=add_string_to_widget_output)
         except Exception as error:
-            output = widgets.Label(f"{error.__class__}: {str(error)}")
-            login_token_widget.children = [output]
+            login_token_widget.children = [widgets.Label(str(error))]
 
     token_finish_button.on_click(login_token_event)
 

--- a/src/huggingface_hub/_login.py
+++ b/src/huggingface_hub/_login.py
@@ -207,7 +207,8 @@ def notebook_login() -> None:
     )
     display(login_token_widget)
 
-    def add_string_to_widget_output(string_content: str):
+    def add_string_to_widget_output(*objects):
+        string_content = " ".join([str(item) for item in objects])
         login_token_widget.children = login_token_widget.children + (widgets.Label(string_content), )
 
     # On click events

--- a/src/huggingface_hub/_login.py
+++ b/src/huggingface_hub/_login.py
@@ -198,7 +198,6 @@ def notebook_login() -> None:
     login_token_widget = widgets.VBox(
         [
             widgets.HTML(NOTEBOOK_LOGIN_TOKEN_HTML_START),
-            widgets.HTML("flo test"),
             token_widget,
             git_checkbox_widget,
             token_finish_button,

--- a/src/huggingface_hub/_login.py
+++ b/src/huggingface_hub/_login.py
@@ -15,7 +15,7 @@
 import os
 import subprocess
 from getpass import getpass
-from typing import Optional, Callable
+from typing import Callable, Optional
 
 from .commands._cli_utils import ANSI
 from .commands.delete_cache import _ask_for_confirmation_no_tui
@@ -120,15 +120,13 @@ def interpreter_login() -> None:
 
     For more details, see [`login`].
     """
-    print(  # docstyle-ignore
-        """
+    print("""
     _|    _|  _|    _|    _|_|_|    _|_|_|  _|_|_|  _|      _|    _|_|_|      _|_|_|_|    _|_|      _|_|_|  _|_|_|_|
     _|    _|  _|    _|  _|        _|          _|    _|_|    _|  _|            _|        _|    _|  _|        _|
     _|_|_|_|  _|    _|  _|  _|_|  _|  _|_|    _|    _|  _|  _|  _|  _|_|      _|_|_|    _|_|_|_|  _|        _|_|_|
     _|    _|  _|    _|  _|    _|  _|    _|    _|    _|    _|_|  _|    _|      _|        _|    _|  _|        _|
     _|    _|    _|_|      _|_|_|    _|_|_|  _|_|_|  _|      _|    _|_|_|      _|        _|    _|    _|_|_|  _|_|_|_|
-    """
-    )
+    """)  # docstyle-ignore
     if HfFolder.get_token() is not None:
         print(
             "    A token is already saved on your machine. Run `huggingface-cli"
@@ -182,7 +180,7 @@ def notebook_login() -> None:
     """
     try:
         import ipywidgets.widgets as widgets  # type: ignore
-        from IPython.display import clear_output, display  # type: ignore
+        from IPython.display import display  # type: ignore
     except ImportError:
         raise ImportError(
             "The `notebook_login` function can only be used in a notebook (Jupyter or"

--- a/src/huggingface_hub/_login.py
+++ b/src/huggingface_hub/_login.py
@@ -207,9 +207,9 @@ def notebook_login() -> None:
     )
     display(login_token_widget)
 
-    def add_string_to_widget_output(*objects):
-        string_content = " ".join([str(item) for item in objects])
-        login_token_widget.children = login_token_widget.children + (widgets.Label(string_content), )
+    def add_string_to_widget_output(*strings: str) -> None:
+        content_str = " ".join(strings)
+        login_token_widget.children = login_token_widget.children + (widgets.Label(content_str), )
 
     # On click events
     def login_token_event(t):
@@ -232,7 +232,7 @@ def notebook_login() -> None:
 ###
 
 
-def _login(token: str, add_to_git_credential: bool, print_output=print) -> None:
+def _login(token: str, add_to_git_credential: bool, print_output: Callable[[str], None] = print) -> None:
     hf_api = HfApi()
     if token.startswith("api_org"):
         raise ValueError("You must use your personal account token.")
@@ -244,14 +244,14 @@ def _login(token: str, add_to_git_credential: bool, print_output=print) -> None:
         if _is_git_credential_helper_configured():
             set_git_credential(token)
             print_output(
-                "Your token has been saved in your configured git credential helpers"
+                "Your token has been saved in your configured git credential helpers" +
                 f" ({','.join(list_credential_helpers())})."
             )
         else:
             print_output("Token has not been saved to git credential helper.")
 
     HfFolder.save_token(token)
-    print_output("Your token has been saved to", HfFolder.path_token)
+    print_output(f"Your token has been saved to {HfFolder.path_token}")
     print_output("Login successful")
 
 

--- a/src/huggingface_hub/_login.py
+++ b/src/huggingface_hub/_login.py
@@ -221,8 +221,9 @@ def notebook_login() -> None:
         login_token_widget.children = []
         try:
             _login(token, add_to_git_credential=add_to_git_credential, print_output=add_string_to_widget_output)
-        except:
-            login_token_widget.children = [widgets.HTML("error")]
+        except Exception as error:
+            output = widgets.Label(f"{error.__class__}: {str(error)}")
+            login_token_widget.children = [output]
 
     token_finish_button.on_click(login_token_event)
 

--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -45,6 +45,7 @@ from ._headers import build_hf_headers, get_token_to_send
 from ._hf_folder import HfFolder
 from ._http import configure_http_backend, get_session, http_backoff
 from ._paths import filter_repo_objects, IGNORE_GIT_FOLDER_PATTERNS
+from ._subprocess import capture_output
 from ._runtime import (
     dump_environment_info,
     get_fastai_version,

--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -45,7 +45,6 @@ from ._headers import build_hf_headers, get_token_to_send
 from ._hf_folder import HfFolder
 from ._http import configure_http_backend, get_session, http_backoff
 from ._paths import filter_repo_objects, IGNORE_GIT_FOLDER_PATTERNS
-from ._subprocess import capture_output
 from ._runtime import (
     dump_environment_info,
     get_fastai_version,
@@ -71,7 +70,7 @@ from ._runtime import (
     is_tf_available,
     is_torch_available,
 )
-from ._subprocess import run_interactive_subprocess, run_subprocess
+from ._subprocess import capture_output, run_interactive_subprocess, run_subprocess
 from ._validators import (
     HFValidationError,
     smoothly_deprecate_use_auth_token,

--- a/src/huggingface_hub/utils/_subprocess.py
+++ b/src/huggingface_hub/utils/_subprocess.py
@@ -16,7 +16,9 @@
 """Contains utilities to easily handle subprocesses in `huggingface_hub`."""
 import os
 import subprocess
+import sys
 from contextlib import contextmanager
+from io import StringIO
 from pathlib import Path
 from typing import IO, Generator, List, Optional, Tuple, Union
 
@@ -24,6 +26,26 @@ from .logging import get_logger
 
 
 logger = get_logger(__name__)
+
+
+@contextmanager
+def capture_output() -> Generator[str, None, None]:
+    """Capture output that is printed to terminal.
+
+    Taken from https://stackoverflow.com/a/34738440
+
+    Example:
+    ```py
+    >>> with capture_output() as output:
+    ...     print("hello world")
+    >>> assert output == "hello world\n"
+    ```
+    """
+    output = StringIO()
+    previous_output = sys.stdout
+    sys.stdout = output
+    yield output.getvalue()
+    sys.stdout = previous_output
 
 
 def run_subprocess(

--- a/src/huggingface_hub/utils/_subprocess.py
+++ b/src/huggingface_hub/utils/_subprocess.py
@@ -29,7 +29,7 @@ logger = get_logger(__name__)
 
 
 @contextmanager
-def capture_output() -> Generator[str, None, None]:
+def capture_output() -> Generator[StringIO, None, None]:
     """Capture output that is printed to terminal.
 
     Taken from https://stackoverflow.com/a/34738440
@@ -38,13 +38,13 @@ def capture_output() -> Generator[str, None, None]:
     ```py
     >>> with capture_output() as output:
     ...     print("hello world")
-    >>> assert output == "hello world\n"
+    >>> assert output.getvalue() == "hello world\n"
     ```
     """
     output = StringIO()
     previous_output = sys.stdout
     sys.stdout = output
-    yield output.getvalue()
+    yield output
     sys.stdout = previous_output
 
 

--- a/tests/test_command_delete_cache.py
+++ b/tests/test_command_delete_cache.py
@@ -203,8 +203,9 @@ class TestDeleteCacheHelpers(unittest.TestCase):
         self.assertListEqual(selected_hashes, ["dataset_revision_hash_id", "older_hash_id"])
 
         # Check printed instructions
-        self.assertTrue(output.startswith("TUI is disabled. In order to"))  # ...
-        self.assertIn(tmp_path, output)
+        printed = output.getvalue()
+        self.assertTrue(printed.startswith("TUI is disabled. In order to"))  # ...
+        self.assertIn(tmp_path, printed)
 
         # Check input called twice
         self.assertEqual(mock_input.call_count, 2)
@@ -230,7 +231,10 @@ class TestDeleteCacheHelpers(unittest.TestCase):
             value = _ask_for_confirmation_no_tui("custom message 3", default=False)
         mock_input.assert_called_with("custom message 3 (y/N) ")
         self.assertFalse(value)
-        self.assertEqual(output, "Invalid input. Must be one of ('y', 'yes', '1', 'n', 'no', '0', '')\n")
+        self.assertEqual(
+            output.getvalue(),
+            "Invalid input. Must be one of ('y', 'yes', '1', 'n', 'no', '0', '')\n",
+        )
 
 
 @patch("huggingface_hub.commands.delete_cache._ask_for_confirmation_no_tui")
@@ -289,7 +293,10 @@ class TestMockedDeleteCacheCommand(unittest.TestCase):
         strategy_mock.execute.assert_called_once_with()
 
         # Check output
-        self.assertEqual(output, "Start deletion.\nDone. Deleted 0 repo(s) and 0 revision(s) for a total of 5.1M.\n")
+        self.assertEqual(
+            output.getvalue(),
+            "Start deletion.\nDone. Deleted 0 repo(s) and 0 revision(s) for a total of 5.1M.\n",
+        )
 
     def test_run_nothing_selected_with_tui(self, mock__manual_review_tui: Mock) -> None:
         """Test command run but nothing is selected in manual review."""
@@ -302,7 +309,7 @@ class TestMockedDeleteCacheCommand(unittest.TestCase):
             self.command.run()
 
         # Check output
-        self.assertEqual(output, "Deletion is cancelled. Do nothing.\n")
+        self.assertEqual(output.getvalue(), "Deletion is cancelled. Do nothing.\n")
 
     def test_run_stuff_selected_but_cancel_item_as_well_with_tui(self, mock__manual_review_tui: Mock) -> None:
         """Test command run when some are selected but "cancel item" as well."""
@@ -319,7 +326,7 @@ class TestMockedDeleteCacheCommand(unittest.TestCase):
             self.command.run()
 
         # Check output
-        self.assertEqual(output, "Deletion is cancelled. Do nothing.\n")
+        self.assertEqual(output.getvalue(), "Deletion is cancelled. Do nothing.\n")
 
     def test_run_and_delete_no_tui(
         self,
@@ -357,7 +364,10 @@ class TestMockedDeleteCacheCommand(unittest.TestCase):
         strategy_mock.execute.assert_called_once_with()
 
         # Check output
-        self.assertEqual(output, "Start deletion.\nDone. Deleted 0 repo(s) and 0 revision(s) for a total of 5.1M.\n")
+        self.assertEqual(
+            output.getvalue(),
+            "Start deletion.\nDone. Deleted 0 repo(s) and 0 revision(s) for a total of 5.1M.\n",
+        )
 
 
 def _get_cache_mock() -> Mock:

--- a/tests/test_command_delete_cache.py
+++ b/tests/test_command_delete_cache.py
@@ -16,9 +16,9 @@ from huggingface_hub.commands.delete_cache import (
     _manual_review_no_tui,
     _read_manual_review_tmp_file,
 )
-from huggingface_hub.utils import SoftTemporaryDirectory
+from huggingface_hub.utils import SoftTemporaryDirectory, capture_output
 
-from .testing_utils import capture_output, handle_injection
+from .testing_utils import handle_injection
 
 
 class TestDeleteCacheHelpers(unittest.TestCase):
@@ -203,9 +203,8 @@ class TestDeleteCacheHelpers(unittest.TestCase):
         self.assertListEqual(selected_hashes, ["dataset_revision_hash_id", "older_hash_id"])
 
         # Check printed instructions
-        printed = output.getvalue()
-        self.assertTrue(printed.startswith("TUI is disabled. In order to"))  # ...
-        self.assertIn(tmp_path, printed)
+        self.assertTrue(output.startswith("TUI is disabled. In order to"))  # ...
+        self.assertIn(tmp_path, output)
 
         # Check input called twice
         self.assertEqual(mock_input.call_count, 2)
@@ -231,10 +230,7 @@ class TestDeleteCacheHelpers(unittest.TestCase):
             value = _ask_for_confirmation_no_tui("custom message 3", default=False)
         mock_input.assert_called_with("custom message 3 (y/N) ")
         self.assertFalse(value)
-        self.assertEqual(
-            output.getvalue(),
-            "Invalid input. Must be one of ('y', 'yes', '1', 'n', 'no', '0', '')\n",
-        )
+        self.assertEqual(output, "Invalid input. Must be one of ('y', 'yes', '1', 'n', 'no', '0', '')\n")
 
 
 @patch("huggingface_hub.commands.delete_cache._ask_for_confirmation_no_tui")
@@ -293,10 +289,7 @@ class TestMockedDeleteCacheCommand(unittest.TestCase):
         strategy_mock.execute.assert_called_once_with()
 
         # Check output
-        self.assertEqual(
-            output.getvalue(),
-            "Start deletion.\nDone. Deleted 0 repo(s) and 0 revision(s) for a total of 5.1M.\n",
-        )
+        self.assertEqual(output, "Start deletion.\nDone. Deleted 0 repo(s) and 0 revision(s) for a total of 5.1M.\n")
 
     def test_run_nothing_selected_with_tui(self, mock__manual_review_tui: Mock) -> None:
         """Test command run but nothing is selected in manual review."""
@@ -309,7 +302,7 @@ class TestMockedDeleteCacheCommand(unittest.TestCase):
             self.command.run()
 
         # Check output
-        self.assertEqual(output.getvalue(), "Deletion is cancelled. Do nothing.\n")
+        self.assertEqual(output, "Deletion is cancelled. Do nothing.\n")
 
     def test_run_stuff_selected_but_cancel_item_as_well_with_tui(self, mock__manual_review_tui: Mock) -> None:
         """Test command run when some are selected but "cancel item" as well."""
@@ -326,7 +319,7 @@ class TestMockedDeleteCacheCommand(unittest.TestCase):
             self.command.run()
 
         # Check output
-        self.assertEqual(output.getvalue(), "Deletion is cancelled. Do nothing.\n")
+        self.assertEqual(output, "Deletion is cancelled. Do nothing.\n")
 
     def test_run_and_delete_no_tui(
         self,
@@ -364,10 +357,7 @@ class TestMockedDeleteCacheCommand(unittest.TestCase):
         strategy_mock.execute.assert_called_once_with()
 
         # Check output
-        self.assertEqual(
-            output.getvalue(),
-            "Start deletion.\nDone. Deleted 0 repo(s) and 0 revision(s) for a total of 5.1M.\n",
-        )
+        self.assertEqual(output, "Start deletion.\nDone. Deleted 0 repo(s) and 0 revision(s) for a total of 5.1M.\n")
 
 
 def _get_cache_mock() -> Mock:

--- a/tests/test_utils_cache.py
+++ b/tests/test_utils_cache.py
@@ -9,7 +9,7 @@ import pytest
 
 from huggingface_hub._snapshot_download import snapshot_download
 from huggingface_hub.commands.scan_cache import ScanCacheCommand
-from huggingface_hub.utils import DeleteCacheStrategy, HFCacheInfo, scan_cache_dir
+from huggingface_hub.utils import DeleteCacheStrategy, HFCacheInfo, capture_output, scan_cache_dir
 from huggingface_hub.utils._cache_manager import (
     CacheNotFound,
     _format_size,
@@ -19,7 +19,6 @@ from huggingface_hub.utils._cache_manager import (
 
 from .testing_constants import TOKEN
 from .testing_utils import (
-    capture_output,
     rmtree_with_retry,
     with_production_testing,
     xfail_on_windows,

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -2,16 +2,14 @@ import inspect
 import os
 import shutil
 import stat
-import sys
 import time
 import unittest
 import uuid
 from contextlib import contextmanager
 from enum import Enum
 from functools import wraps
-from io import StringIO
 from pathlib import Path
-from typing import Callable, Generator, Optional, Type, TypeVar, Union
+from typing import Callable, Optional, Type, TypeVar, Union
 from unittest.mock import Mock, patch
 
 import pytest
@@ -319,30 +317,6 @@ def xfail_on_windows(reason: str, raises: Optional[Type[Exception]] = None):
         return pytest.mark.xfail(os.name == "nt", reason=reason, raises=raises, strict=True, run=True)(test_function)
 
     return _inner_decorator
-
-
-@contextmanager
-def capture_output() -> Generator[StringIO, None, None]:
-    """Capture output that is printed to console.
-
-    Especially useful to test CLI commands.
-
-    Taken from https://stackoverflow.com/a/34738440
-
-    Example:
-    ```py
-    class TestHelloWorld(unittest.TestCase):
-        def test_hello_world(self):
-            with capture_output() as output:
-                print("hello world")
-            self.assertEqual(output.getvalue(), "hello world\n")
-    ```
-    """
-    output = StringIO()
-    previous_output = sys.stdout
-    sys.stdout = output
-    yield output
-    sys.stdout = previous_output
 
 
 T = TypeVar("T")


### PR DESCRIPTION
Fixes [1384](https://github.com/huggingface/huggingface_hub/issues/1384)

The PR adjusts notebook_login() to use the ipywidgets Box output to print the feedback.
This enables the logic to work in all notebooks that are compatible with ipywidgets - including Databricks where `clear_output` does not work.


Examples for the code flow:
<img width="1208" alt="Screenshot 2023-03-29 at 12 08 35" src="https://user-images.githubusercontent.com/91623108/228507934-ade816bd-d134-4ebb-bb57-f7aeb2c955e5.png">

<img width="1210" alt="Screenshot 2023-03-29 at 12 08 48" src="https://user-images.githubusercontent.com/91623108/228507949-cf981d78-22a1-4051-b6c6-1a401cfbcfa6.png">

<img width="1209" alt="Screenshot 2023-03-29 at 12 09 00" src="https://user-images.githubusercontent.com/91623108/228507962-c7f3e50a-2cda-4c48-8056-9ce8acfe732f.png">

<img width="1210" alt="Screenshot 2023-03-29 at 12 16 49" src="https://user-images.githubusercontent.com/91623108/228507977-bd6f7a7b-c6b7-4086-9130-d3e9cee3a44b.png">


