### PR TITLE
Normalize both forms of ETag

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -813,8 +813,6 @@ def _normalize_etag(etag: Optional[str]) -> Optional[str]:
       ETag: W/"<etag_value>"
       ETag: "<etag_value>"
 
-    The hf.co hub guarantees to only send the second form.
-
     Args:
         etag (`str`, *optional*): HTTP header
 
@@ -824,7 +822,7 @@ def _normalize_etag(etag: Optional[str]) -> Optional[str]:
     """
     if etag is None:
         return None
-    return etag.strip('"')
+    return etag.lstrip('W/').strip('"')
 
 
 def _create_relative_symlink(src: str, dst: str, new_blob: bool = False) -> None:


### PR DESCRIPTION
As per #1423, currently some hf servers are returning the alternative variant of ETags which is leading to invalid filenames on Windows.