### PR TITLE
[hot-fix] Malicious repo can overwrite any file on disk

### DIFF
--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -819,7 +819,7 @@ class TestHfHubDownloadRelativePaths(unittest.TestCase):
         # Cannot happen because of other protections, but just in case.
         self.assertEqual(
             _get_pointer_path("path/to/storage", "abcdef", "path/to/file.txt"),
-            "path/to/storage/snapshots/abcdef/path/to/file.txt",
+            os.path.join("path/to/storage", "snapshots", "abcdef", "path/to/file.txt"),
         )
 
     def test_get_pointer_path_but_invalid_relative_filename(self) -> None:

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -32,7 +32,9 @@ from huggingface_hub.constants import (
 from huggingface_hub.file_download import (
     _CACHED_NO_EXIST,
     _create_symlink,
+    _get_pointer_path,
     _request_wrapper,
+    _to_local_dir,
     cached_download,
     filename_to_url,
     get_hf_file_metadata,
@@ -773,10 +775,13 @@ class StagingCachedDownloadOnAwfulFilenamesTest(unittest.TestCase):
 
 
 @pytest.mark.usefixtures("fx_cache_dir")
-class TestHfHubDownloadWindowsRelativePath(unittest.TestCase):
+class TestHfHubDownloadRelativePaths(unittest.TestCase):
     """Regression test for HackerOne report 1928845.
 
     Issue was that any file outside of the local dir could be overwritten (Windows only).
+
+    In the end, multiple protections have been added to prevent this (..\\ in filename forbidden on Windows, always check
+    the filepath is in local_dir/snapshot_dir).
     """
 
     cache_dir: Path
@@ -785,38 +790,51 @@ class TestHfHubDownloadWindowsRelativePath(unittest.TestCase):
     def setUpClass(cls):
         cls.api = HfApi(endpoint=ENDPOINT_STAGING, token=TOKEN)
         cls.repo_id = cls.api.create_repo(repo_id=repo_name()).repo_id
-        cls.api.upload_file(path_or_fileobj=b"content", path_in_repo="..\ddd", repo_id=cls.repo_id)
-        cls.api.upload_file(path_or_fileobj=b"content", path_in_repo="folder/..\..\..\\file", repo_id=cls.repo_id)
+        cls.api.upload_file(path_or_fileobj=b"content", path_in_repo="..\\ddd", repo_id=cls.repo_id)
+        cls.api.upload_file(path_or_fileobj=b"content", path_in_repo="folder/..\\..\\..\\file", repo_id=cls.repo_id)
 
     @classmethod
     def tearDownClass(cls) -> None:
         cls.api.delete_repo(repo_id=cls.repo_id)
 
+    @xfail_on_windows(reason="Windows paths cannot start with '..\\'.", raises=ValueError)
     def test_download_file_in_cache_dir(self) -> None:
-        # The file must be under the snapshots folder with filename "..\ddd"
-        path = Path(hf_hub_download(self.repo_id, "..\ddd", cache_dir=self.cache_dir))
-        self.assertEqual(path.name, "..\ddd")
-        self.assertEqual(path.parents[1].name, "snapshots")
+        hf_hub_download(self.repo_id, "..\\ddd", cache_dir=self.cache_dir)
 
+    @xfail_on_windows(reason="Windows paths cannot start with '..\\'.", raises=ValueError)
     def test_download_file_to_local_dir(self) -> None:
         with SoftTemporaryDirectory() as local_dir:
-            path = Path(hf_hub_download(self.repo_id, "..\ddd", cache_dir=self.cache_dir, local_dir=local_dir))
-            self.assertEqual(path.name, "..\ddd")
-            self.assertEqual(str(path.parent), local_dir)
+            hf_hub_download(self.repo_id, "..\\ddd", cache_dir=self.cache_dir, local_dir=local_dir)
 
+    @xfail_on_windows(reason="Windows paths cannot contain '\\..\\'.", raises=ValueError)
     def test_download_folder_file_in_cache_dir(self) -> None:
-        # The file must be under the snapshots folder with filename "folder/..\..\..\\file"
-        path = Path(hf_hub_download(self.repo_id, "folder/..\..\..\\file", cache_dir=self.cache_dir))
-        self.assertEqual(path.name, "..\..\..\\file")
-        self.assertEqual(path.parents[2].name, "snapshots")
+        hf_hub_download(self.repo_id, "folder/..\\..\\..\\file", cache_dir=self.cache_dir)
 
+    @xfail_on_windows(reason="Windows paths cannot contain '\\..\\'.", raises=ValueError)
     def test_download_folder_file_to_local_dir(self) -> None:
         with SoftTemporaryDirectory() as local_dir:
-            path = Path(
-                hf_hub_download(self.repo_id, "folder/..\..\..\\file", cache_dir=self.cache_dir, local_dir=local_dir)
+            hf_hub_download(self.repo_id, "folder/..\\..\\..\\file", cache_dir=self.cache_dir, local_dir=local_dir)
+
+    def test_get_pointer_path_and_valid_relative_filename(self) -> None:
+        # Cannot happen because of other protections, but just in case.
+        self.assertEqual(
+            _get_pointer_path("path/to/storage", "abcdef", "path/to/file.txt"),
+            "path/to/storage/snapshots/abcdef/path/to/file.txt",
+        )
+
+    def test_get_pointer_path_but_invalid_relative_filename(self) -> None:
+        # Cannot happen because of other protections, but just in case.
+        relative_filename = "folder\\..\\..\\..\\file.txt" if os.name == "nt" else "folder/../../../file.txt"
+        with self.assertRaises(ValueError):
+            _get_pointer_path("path/to/storage", "abcdef", relative_filename)
+
+    def test_to_local_dir_but_invalid_relative_filename(self) -> None:
+        # Cannot happen because of other protections, but just in case.
+        relative_filename = "folder\\..\\..\\..\\file.txt" if os.name == "nt" else "folder/../../../file.txt"
+        with self.assertRaises(ValueError):
+            _to_local_dir(
+                "path/to/file_to_copy", "path/to/local/dir", relative_filename=relative_filename, use_symlinks=False
             )
-            self.assertEqual(path.name, "..\..\..\\file")
-            self.assertEqual(str(path.parents[1]), local_dir)
 
 
 class CreateSymlinkTest(unittest.TestCase):

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -819,7 +819,7 @@ class TestHfHubDownloadRelativePaths(unittest.TestCase):
         # Cannot happen because of other protections, but just in case.
         self.assertEqual(
             _get_pointer_path("path/to/storage", "abcdef", "path/to/file.txt"),
-            os.path.join("path/to/storage", "snapshots", "abcdef", "path/to/file.txt"),
+            os.path.join("path", "to", "storage", "snapshots", "abcdef", "path", "to", "file.txt"),
         )
 
     def test_get_pointer_path_but_invalid_relative_filename(self) -> None:


### PR DESCRIPTION
Related to [internal slack discussion](https://huggingface.slack.com/archives/C03V11RNS7P/p1680711322113109) and [hackerone report](https://hackerone.com/reports/1928845) (internal links).

TL;DR: a malicious repo on the Hub can overwrite any file on the disk when using `hf_hub_download`/`snapshot_download`. This PR fixes it.

Several protections have been added:
1. raise an error before downloading on Windows if a filename on the Hub contains `"/../"` or starts with `../"`
2. raise an error if the pointer path (path to the file in snapshots folder) is not in the snapshots folder
3. raise an error if the local dir path (path to the file in the local dir) is not in the local dir
Cases 2. and 3. shouldn't happen if protection 1. is activated but it doesn't hurt to have them in bonus. 

cc @coyotte508 @Michellehbn 

In addition to this PR, we should prevent files with `..\` to be pushed on the Hub (see slack discussion).