### PR TITLE
Hffs misc improvements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,10 @@ setup(
     package_dir={"": "src"},
     packages=find_packages("src"),
     extras_require=extras,
-    entry_points={"console_scripts": ["huggingface-cli=huggingface_hub.commands.huggingface_cli:main"]},
+    entry_points={
+        "console_scripts": ["huggingface-cli=huggingface_hub.commands.huggingface_cli:main"],
+        "fsspec.specs": "hf=huggingface_hub.HfFileSystem",
+    },
     python_requires=">=3.7.0",
     install_requires=install_requires,
     classifiers=[

--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -376,7 +376,7 @@ class HfFileSystem(fsspec.AbstractFileSystem):
         path = [self._strip_protocol(p) for p in path]
         for p in path:
             if has_magic(p):
-                bit = set(self.glob(p))
+                bit = set(self.glob(p, **kwargs))
                 out |= bit
                 if recursive:
                     out |= set(self.expand_path(list(bit), recursive=recursive, maxdepth=maxdepth, **kwargs))


### PR DESCRIPTION
Improvements:
* pass the `ls` kwargs to `glob` in `expand_path`
* register `hf` as a `fsspec` protocol via the `entry_points` (explained [here](https://filesystem-spec.readthedocs.io/en/latest/developer.html#implementing-a-backend)).`fsspec.register_implementation("hf", huggingface_hub.HfFileSystem)` before using the HF filesystem with `fsspec` integrations is no longer required after this change