### PR TITLE
[docs] Update docstring for repo_id in push_to_hub

### DIFF
--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -260,7 +260,7 @@ class ModelHubMixin:
 
         Args:
             repo_id (`str`):
-                Repository name to push to.
+                ID of the repository to push to (example: `"username/my-model"`).
             config (`dict`, *optional*):
                 Configuration object to be saved alongside the model weights.
             commit_message (`str`, *optional*):

--- a/src/huggingface_hub/keras_mixin.py
+++ b/src/huggingface_hub/keras_mixin.py
@@ -306,7 +306,7 @@ def push_to_hub_keras(
             The [Keras model](`https://www.tensorflow.org/api_docs/python/tf/keras/Model`) you'd like to push to the
             Hub. The model must be compiled and built.
         repo_id (`str`):
-            Repository name to push to
+                ID of the repository to push to (example: `"username/my-model"`).
         commit_message (`str`, *optional*, defaults to "Add Keras model"):
             Message to commit while pushing.
         private (`bool`, *optional*, defaults to `False`):


### PR DESCRIPTION
Hello!

## Pull Request overview
* Update docstring for `repo_id` in `push_to_hub`.

## Details
This PR speaks for itself - the old text was a bit nonsensical. I think the new one is an improvement, but I'm open to alternatives, too.

- Tom Aarsen