### PR TITLE
Fix symlinks on different volumes on Windows

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -878,7 +878,13 @@ def _create_symlink(src: str, dst: str, new_blob: bool = False) -> None:
         relative_src = None
 
     try:
-        _support_symlinks = are_symlinks_supported(os.path.dirname(os.path.commonpath([abs_src, abs_dst])))
+        try:
+            commonpath = os.path.commonpath([abs_src, abs_dst])
+            _support_symlinks = are_symlinks_supported(os.path.dirname(commonpath))
+        except ValueError:
+            # Raised if src and dst are not on the same volume.
+            # See https://docs.python.org/3/library/os.path.html#os.path.commonpath
+            _support_symlinks = False
     except PermissionError:
         # Permission error means src and dst are not in the same volume (e.g. destination path has been provided
         # by the user via `local_dir`. Let's test symlink support there)

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -882,9 +882,9 @@ def _create_symlink(src: str, dst: str, new_blob: bool = False) -> None:
             commonpath = os.path.commonpath([abs_src, abs_dst])
             _support_symlinks = are_symlinks_supported(os.path.dirname(commonpath))
         except ValueError:
-            # Raised if src and dst are not on the same volume.
+            # Raised if src and dst are not on the same volume. Symlinks will still work on Linux/Macos.
             # See https://docs.python.org/3/library/os.path.html#os.path.commonpath
-            _support_symlinks = False
+            _support_symlinks = os.name != "nt"
     except PermissionError:
         # Permission error means src and dst are not in the same volume (e.g. destination path has been provided
         # by the user via `local_dir`. Let's test symlink support there)


### PR DESCRIPTION
Related to https://github.com/huggingface/huggingface_hub/issues/1385. See [CI logs](https://github.com/deepset-ai/haystack/actions/runs/4619482614/jobs/8232850199?pr=4607) in dependent library.

If we try to create a symlink between 2 volumes, `common_path` will fail with `ValueError("Paths don't have the same drive")`. Let's not create symlinks in such a case on Windows (still ok on Linux/MacOS). 

cc @mayankjobanputra can you please try to run your test suite with this fix (`pip install git+https://github.com/huggingface/huggingface_hub@1385-fix-symlinks-on-different-volumes`) and report here if it definitely fixed your issue? Thanks in advance.