### PR TITLE
[Feat] Add `sleep_time` for Spaces

### DIFF
--- a/docs/source/guides/manage-spaces.mdx
+++ b/docs/source/guides/manage-spaces.mdx
@@ -108,6 +108,41 @@ Upgraded hardware will be automatically assigned to your Space once it's built.
 ... )
 ```
 
+**5. Pause and restart your Space**
+
+By default if your Space is running on an upgraded hardware, it will never be stopped. However to avoid getting billed,
+you might want to pause it when you are not using it. This is possible using [`pause_space`]. A paused Space will be
+inactive until the owner of the Space restarts it, either with the UI or via API using [`restart_space`].
+For more details about paused mode, please refer to [this section](https://huggingface.co/docs/hub/spaces-gpus#pause)
+
+```py
+# Pause your Space to avoid getting billed
+>>> api.pause_space(repo_id=repo_id)
+# (...)
+# Restart it when you need it
+>>> api.restart_space(repo_id=repo_id)
+```
+
+Another possibility is to set a timeout for your Space. If your Space is inactive for more than the timeout duration,
+it will go to sleep. Any visitor landing on your Space will start it back up. You can set a timeout using
+[`set_space_sleep_time`]. For more details about sleeping mode, please refer to [this section](https://huggingface.co/docs/hub/spaces-gpus#sleep-time).
+
+```py
+# Put your Space to sleep after 1h of inactivity
+>>> api.set_space_sleep_time(repo_id=repo_id, sleep_time=3600)
+```
+
+Note: if you are using a 'cpu-basic' hardware, you cannot configure a custom sleep time. Your Space will automatically
+be paused after 48h of inactivity.
+
+**Bonus: set a sleep time while requesting hardware**
+
+Upgraded hardware will be automatically assigned to your Space once it's built.
+
+```py
+>>> api.request_space_hardware(repo_id=repo_id, hardware=SpaceHardware.T4_MEDIUM, sleep_time=3600)
+```
+
 ## More advanced: temporarily upgrade your Space !
 
 Spaces allow for a lot of different use cases. Sometimes, you might want

--- a/docs/source/package_reference/space_runtime.mdx
+++ b/docs/source/package_reference/space_runtime.mdx
@@ -1,12 +1,12 @@
 # Managing your Space runtime
 
-Check the [`HfApi`] documentation page for the reference of methods to manage Space
-runtime on the Hub.
+Check the [`HfApi`] documentation page for the reference of methods to manage your Space on the Hub.
 
-- [`add_space_secret`]
-- [`delete_space_secret`]
-- [`get_space_runtime`]
-- [`request_space_hardware`]
+- Duplicate a Space: [`duplicate_space`]
+- Fetch current runtime: [`get_space_runtime`]
+- Manage secrets: [`add_space_secret`] and [`delete_space_secret`]
+- Manage hardware: [`request_space_hardware`]
+- Manage state: [`pause_space`], [`restart_space`], [`set_space_sleep_time`]
 
 ## Data structures
 

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -155,6 +155,7 @@ _SUBMOD_ATTRS = {
         "repo_type_and_id_from_hf_id",
         "request_space_hardware",
         "restart_space",
+        "set_space_sleep_time",
         "space_info",
         "unlike",
         "update_repo_visibility",
@@ -419,6 +420,7 @@ if TYPE_CHECKING:  # pragma: no cover
         repo_type_and_id_from_hf_id,  # noqa: F401
         request_space_hardware,  # noqa: F401
         restart_space,  # noqa: F401
+        set_space_sleep_time,  # noqa: F401
         space_info,  # noqa: F401
         unlike,  # noqa: F401
         update_repo_visibility,  # noqa: F401

--- a/src/huggingface_hub/_space_api.py
+++ b/src/huggingface_hub/_space_api.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Dict, Optional
 
+
 # Taken from https://huggingface.co/docs/hub/spaces-gpus#sleep-time
 # This value might change in the future. It is only used to trigger a warning if the user tries to set a different value
 # on a free Space.

--- a/src/huggingface_hub/_space_api.py
+++ b/src/huggingface_hub/_space_api.py
@@ -17,12 +17,6 @@ from enum import Enum
 from typing import Dict, Optional
 
 
-# Taken from https://huggingface.co/docs/hub/spaces-gpus#sleep-time
-# This value might change in the future. It is only used to trigger a warning if the user tries to set a different value
-# on a free Space.
-CPU_BASIC_SLEEP_TIME = 48 * 3600  # 48 hours
-
-
 class SpaceStage(str, Enum):
     """
     Enumeration of possible stage of a Space on the Hub.

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -878,7 +878,13 @@ def _create_symlink(src: str, dst: str, new_blob: bool = False) -> None:
         relative_src = None
 
     try:
-        _support_symlinks = are_symlinks_supported(os.path.dirname(os.path.commonpath([abs_src, abs_dst])))
+        try:
+            commonpath = os.path.commonpath([abs_src, abs_dst])
+            _support_symlinks = are_symlinks_supported(os.path.dirname(commonpath))
+        except ValueError:
+            # Raised if src and dst are not on the same volume. Symlinks will still work on Linux/Macos.
+            # See https://docs.python.org/3/library/os.path.html#os.path.commonpath
+            _support_symlinks = os.name != "nt"
     except PermissionError:
         # Permission error means src and dst are not in the same volume (e.g. destination path has been provided
         # by the user via `local_dir`. Let's test symlink support there)

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -38,7 +38,7 @@ from ._commit_api import (
     upload_lfs_files,
     warn_on_overwriting_operations,
 )
-from ._space_api import SpaceHardware, SpaceRuntime, CPU_BASIC_SLEEP_TIME
+from ._space_api import CPU_BASIC_SLEEP_TIME, SpaceHardware, SpaceRuntime
 from .community import (
     Discussion,
     DiscussionComment,
@@ -4021,7 +4021,7 @@ class HfApi:
                 ),
                 UserWarning,
             )
-        payload = {"flavor": hardware}
+        payload: Dict[str, Any] = {"flavor": hardware}
         if sleep_time is not None:
             payload["sleepTimeSeconds"] = sleep_time
         r = get_session().post(

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -38,7 +38,7 @@ from ._commit_api import (
     upload_lfs_files,
     warn_on_overwriting_operations,
 )
-from ._space_api import CPU_BASIC_SLEEP_TIME, SpaceHardware, SpaceRuntime
+from ._space_api import SpaceHardware, SpaceRuntime
 from .community import (
     Discussion,
     DiscussionComment,
@@ -4012,7 +4012,7 @@ class HfApi:
 
         </Tip>
         """
-        if sleep_time is not None and sleep_time != CPU_BASIC_SLEEP_TIME and hardware == SpaceHardware.CPU_BASIC:
+        if sleep_time is not None and hardware == SpaceHardware.CPU_BASIC:
             warnings.warn(
                 (
                     "If your Space runs on the default 'cpu-basic' hardware, it will go to sleep if inactive for more"
@@ -4069,7 +4069,7 @@ class HfApi:
         runtime = SpaceRuntime(r.json())
 
         hardware = runtime.requested_hardware or runtime.hardware
-        if hardware == SpaceHardware.CPU_BASIC and sleep_time != CPU_BASIC_SLEEP_TIME:
+        if hardware == SpaceHardware.CPU_BASIC:
             warnings.warn(
                 (
                     "If your Space runs on the default 'cpu-basic' hardware, it will go to sleep if inactive for more"

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -38,7 +38,7 @@ from ._commit_api import (
     upload_lfs_files,
     warn_on_overwriting_operations,
 )
-from ._space_api import SpaceHardware, SpaceRuntime
+from ._space_api import SpaceHardware, SpaceRuntime, CPU_BASIC_SLEEP_TIME
 from .community import (
     Discussion,
     DiscussionComment,
@@ -3981,7 +3981,14 @@ class HfApi:
         return SpaceRuntime(r.json())
 
     @validate_hf_hub_args
-    def request_space_hardware(self, repo_id: str, hardware: SpaceHardware, *, token: Optional[str] = None) -> None:
+    def request_space_hardware(
+        self,
+        repo_id: str,
+        hardware: SpaceHardware,
+        *,
+        token: Optional[str] = None,
+        sleep_time: Optional[int] = None,
+    ) -> SpaceRuntime:
         """Request new hardware for a Space.
 
         Args:
@@ -3991,6 +3998,11 @@ class HfApi:
                 Hardware on which to run the Space. Example: `"t4-medium"`.
             token (`str`, *optional*):
                 Hugging Face token. Will default to the locally saved token if not provided.
+            sleep_time (`int`, *optional*):
+                Number of seconds of inactivity to wait before a Space is put to sleep. Set to `-1` if you don't want
+                your Space to sleep (default behavior for upgraded hardware). For free hardware, you can't configure
+                the sleep time (value is fixed to 48 hours of inactivity).
+                See https://huggingface.co/docs/hub/spaces-gpus#sleep-time for more details.
 
         <Tip>
 
@@ -3998,19 +4010,78 @@ class HfApi:
 
         </Tip>
         """
+        if sleep_time is not None and sleep_time != CPU_BASIC_SLEEP_TIME and hardware == SpaceHardware.CPU_BASIC:
+            warnings.warn(
+                (
+                    "If your Space runs on the default 'cpu-basic' hardware, it will go to sleep if inactive for more"
+                    " than 48 hours. This value is not configurable. If you don't want your Space to deactivate or if"
+                    " you want to set a custom sleep time, you need to upgrade to a paid Hardware."
+                ),
+                UserWarning,
+            )
+        payload = {"flavor": hardware}
+        if sleep_time is not None:
+            payload["sleepTimeSeconds"] = sleep_time
         r = get_session().post(
             f"{self.endpoint}/api/spaces/{repo_id}/hardware",
             headers=self._build_hf_headers(token=token),
-            json={"flavor": hardware},
+            json=payload,
         )
         hf_raise_for_status(r)
+        return SpaceRuntime(r.json())
+
+    @validate_hf_hub_args
+    def set_space_sleep_time(self, repo_id: str, sleep_time: int, *, token: Optional[str] = None) -> SpaceRuntime:
+        """Set a custom sleep time for a Space running on upgraded hardware..
+
+        Your Space will go to sleep after X seconds of inactivity. You are not billed when your Space is in "sleep"
+        mode. If a new visitor lands on your Space, it will "wake it up". Only upgraded hardware can have a
+        configurable sleep time. To know more about the sleep stage, please refer to
+        https://huggingface.co/docs/hub/spaces-gpus#sleep-time.
+
+        Args:
+            repo_id (`str`):
+                ID of the repo to update. Example: `"bigcode/in-the-stack"`.
+            sleep_time (`int`, *optional*):
+                Number of seconds of inactivity to wait before a Space is put to sleep. Set to `-1` if you don't want
+                your Space to pause (default behavior for upgraded hardware). For free hardware, you can't configure
+                the sleep time (value is fixed to 48 hours of inactivity).
+                See https://huggingface.co/docs/hub/spaces-gpus#sleep-time for more details.
+            token (`str`, *optional*):
+                Hugging Face token. Will default to the locally saved token if not provided.
+
+        <Tip>
+
+        It is also possible to set a custom sleep time when requesting hardware with [`request_space_hardware`].
+
+        </Tip>
+        """
+        r = get_session().post(
+            f"{self.endpoint}/api/spaces/{repo_id}/sleeptime",
+            headers=self._build_hf_headers(token=token),
+            json={"seconds": sleep_time},
+        )
+        hf_raise_for_status(r)
+        runtime = SpaceRuntime(r.json())
+
+        hardware = runtime.requested_hardware or runtime.hardware
+        if hardware == SpaceHardware.CPU_BASIC and sleep_time != CPU_BASIC_SLEEP_TIME:
+            warnings.warn(
+                (
+                    "If your Space runs on the default 'cpu-basic' hardware, it will go to sleep if inactive for more"
+                    " than 48 hours. This value is not configurable. If you don't want your Space to deactivate or if"
+                    " you want to set a custom sleep time, you need to upgrade to a paid Hardware."
+                ),
+                UserWarning,
+            )
+        return runtime
 
     @validate_hf_hub_args
     def pause_space(self, repo_id: str, *, token: Optional[str] = None) -> SpaceRuntime:
         """Pause your Space.
 
         A paused Space stops executing until manually restarted by its owner. This is different from the sleeping
-        state in which free Spaces go after 72h of inactivity. Paused time is not billed to your account, no matter the
+        state in which free Spaces go after 48h of inactivity. Paused time is not billed to your account, no matter the
         hardware you've selected. To restart your Space, use [`restart_space`] and go to your Space settings page.
 
         For more details, please visit [the docs](https://huggingface.co/docs/hub/spaces-gpus#pause).
@@ -4086,7 +4157,7 @@ class HfApi:
         private: Optional[bool] = None,
         token: Optional[str] = None,
         exist_ok: bool = False,
-    ) -> str:
+    ) -> RepoUrl:
         """Duplicate a Space.
 
         Programmatically duplicate a Space. The new Space will be created in your account and will be in the same state
@@ -4338,6 +4409,7 @@ add_space_secret = api.add_space_secret
 delete_space_secret = api.delete_space_secret
 get_space_runtime = api.get_space_runtime
 request_space_hardware = api.request_space_hardware
+set_space_sleep_time = api.set_space_sleep_time
 pause_space = api.pause_space
 restart_space = api.restart_space
 duplicate_space = api.duplicate_space

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -4003,6 +4003,8 @@ class HfApi:
                 your Space to sleep (default behavior for upgraded hardware). For free hardware, you can't configure
                 the sleep time (value is fixed to 48 hours of inactivity).
                 See https://huggingface.co/docs/hub/spaces-gpus#sleep-time for more details.
+        Returns:
+            [`SpaceRuntime`]: Runtime information about a Space including Space stage and hardware.
 
         <Tip>
 
@@ -4049,6 +4051,8 @@ class HfApi:
                 See https://huggingface.co/docs/hub/spaces-gpus#sleep-time for more details.
             token (`str`, *optional*):
                 Hugging Face token. Will default to the locally saved token if not provided.
+        Returns:
+            [`SpaceRuntime`]: Runtime information about a Space including Space stage and hardware.
 
         <Tip>
 


### PR DESCRIPTION
This PR adds a new `set_space_sleep_time` method to set a custom sleeping time for Spaces. By default, a (paid) upgraded hardware will never go to sleep while a cpu-basic goes to sleep after 48h. Only upgraded hardware can be configured.

TODO:
- [x] implement `set_space_sleep_time`
- [x] adapt the existing `request_space_hardware` (it's possible to request hardware + set timeout in a single call)
- [x] add `sleep_time` to the returned `SpaceRuntime` data structure
- [x] add tests and docs
- [ ] set sleep_time at repo creation? (not possible yet server-side - see internal issue https://github.com/huggingface/moon-landing/issues/6017)

cc @abidlabs will be helpful for https://github.com/gradio-app/gradio/pull/3809