### PR TITLE
[FIX] bug "Invalid cross-device link" error when using snapshot_download to local_dir with no symlink

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1566,7 +1566,7 @@ def _chmod_and_replace(src: str, dst: str) -> None:
     finally:
         tmp_file.unlink()
 
-    os.replace(src, dst)
+    shutil.move(src, dst)
 
 
 def _get_pointer_path(storage_folder: str, revision: str, relative_filename: str) -> str:

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -906,7 +906,7 @@ def _create_symlink(src: str, dst: str, new_blob: bool = False) -> None:
                 raise
     elif new_blob:
         logger.info(f"Symlink not supported. Moving file from {abs_src} to {abs_dst}")
-        os.replace(src, dst)
+        shutil.move(src, dst)
     else:
         logger.info(f"Symlink not supported. Copying file from {abs_src} to {abs_dst}")
         shutil.copyfile(src, dst)


### PR DESCRIPTION
## Issue

When using `huggingface_hub.snapshot_download` to `local_dir` in mounted device with `local_dir_use_symlinks=False`, this error occurred:

```python
~/anaconda3/envs/thaiminhpv/lib/python3.9/site-packages/huggingface_hub/file_download.py in _chmod_and_replace(src, dst)
   1553         tmp_file.unlink()
   1554 
-> 1555     os.replace(src, dst)
   1556 
   1557 

OSError: [Errno 18] Invalid cross-device link: '/home/thaiminhpv/.cache/huggingface/hub/tmpzancmmsh' -> '/mnt/some_device/Storage/test/.gitattributes'
```

## Step to reproduce

1. Install the latest huggingface_hub library (`0.13.4` at this moment)

```python3
!pip3 install -qU huggingface_hub
>>> import huggingface_hub
>>> huggingface_hub.__version__
'0.13.4' 
```

2. Using `snapshot_download` to download to a _mounted folder_, with `local_dir_use_symlinks=False`

```python3
! mkdir -p /mnt/some_device/Storage/test/
from huggingface_hub import snapshot_download
snapshot_download(
    repo_id='bert-base-uncased',
    local_dir="/mnt/some_device/Storage/test/",
    local_dir_use_symlinks=False
)
```

### Error logs:

```python3
Downloading pytorch_model.bin: 100%
440M/440M [02:06<00:00, 3.95MB/s]
...
Downloading (…)b421b/tokenizer.json: 100%
466k/466k [00:00<00:00, 662kB/s]
---------------------------------------------------------------------------
OSError                                   Traceback (most recent call last)
<ipython-input-4-5f9de1d82345> in <module>
      1 
----> 2 snapshot_download(
      3     repo_id='bert-base-uncased',
      4     local_dir="/mnt/some_device/Storage/test/",
      5     local_dir_use_symlinks=False
...
~/anaconda3/envs/thaiminhpv/lib/python3.9/site-packages/huggingface_hub/file_download.py in hf_hub_download(repo_id, filename, subfolder, repo_type, revision, library_name, library_version, cache_dir, local_dir, local_dir_use_symlinks, user_agent, force_download, force_filename, proxies, etag_timeout, resume_download, token, local_files_only, legacy_cache_layout)
   1361             else:
   1362                 logger.info(f"Storing {url} in local_dir at {local_dir_filepath} (not cached).")
-> 1363                 _chmod_and_replace(temp_file.name, local_dir_filepath)
   1364             pointer_path = local_dir_filepath  # for return value
   1365 

~/anaconda3/envs/thaiminhpv/lib/python3.9/site-packages/huggingface_hub/file_download.py in _chmod_and_replace(src, dst)
   1553         tmp_file.unlink()
   1554 
-> 1555     os.replace(src, dst)
   1556 
   1557 

OSError: [Errno 18] Invalid cross-device link: '/home/thaiminhpv/.cache/huggingface/hub/tmpzancmmsh' -> '/mnt/some_device/Storage/test/.gitattributes'
```

## Fix

Use `shutil.move()` instead of `os.replace()`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have tested this code locally, and it is working as intended 