### PR TITLE
Optimize `HfFileSystem.find`

### DIFF
--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -306,7 +306,7 @@ class HfFileSystem(fsspec.AbstractFileSystem):
             cached_infos = self.dircache[path]
             out.extend(cached_infos)
             # Use BFS to traverse the cache to build the "recursive "output
-            # - if the cache is incomplete, find the common prefix of the missing entries and extend the output with the result of `_ls_tree(common_prefix, recursive=True)`
+            # - if the cache is incomplete, find the common path of the missing entries and extend the output with the result of `_ls_tree(common_path, recursive=True)`
             if recursive:
                 dirs_to_visit = deque([path_info for path_info in cached_infos if path_info["type"] == "directory"])
                 dirs_not_in_cache = []
@@ -323,6 +323,7 @@ class HfFileSystem(fsspec.AbstractFileSystem):
                 if dirs_not_in_cache:
                     dirs_not_in_cache = [dir_path[len(path_prefix) :] for dir_path in dirs_not_in_cache]
                     common_path = (path_prefix + os.path.commonpath(dirs_not_in_cache)).rstrip("/")
+                    # Remove the paths prefixed with the common path to avoid duplicates after extending the output with the result of `_ls_tree(common_path, recursive=True)`
                     out = [o for o in out if not o["name"].startswith(common_path)]
                     self.dircache.pop(common_path, None)
                     out.extend(

--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -325,9 +325,8 @@ class HfFileSystem(fsspec.AbstractFileSystem):
                     common_path = (path_prefix + os.path.commonpath(dirs_not_in_cache)).rstrip("/")
                     # Remove the paths prefixed with the common path to avoid duplicates after extending the output with the result of `_ls_tree(common_path, recursive=True)`
                     out = [o for o in out if not o["name"].startswith(common_path)]
-                    self.dircache.pop(common_path, None)
                     out.extend(
-                        self._ls_tree(common_path, recursive=True, refresh=refresh, revision=resolved_path.revision)
+                        self._ls_tree(common_path, recursive=True, refresh=True, revision=resolved_path.revision)
                     )
         return out
 

--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -330,11 +330,11 @@ class HfFileSystem(fsspec.AbstractFileSystem):
 
     def find(
         self,
-        path,
-        maxdepth=None,
-        withdirs=False,
-        detail=False,
-        refresh=False,
+        path: str,
+        maxdepth: Optional[int] = None,
+        withdirs: bool = False,
+        detail: bool = False,
+        refresh: bool = False,
         revision: Optional[str] = None,
         **kwargs,
     ) -> Union[List[str], Dict[str, Dict[str, Any]]]:

--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -417,10 +417,10 @@ class HfFileSystem(fsspec.AbstractFileSystem):
         self.invalidate_cache(path=resolved_path2.unresolve())
 
     def modified(self, path: str, **kwargs) -> datetime:
-        info = self.info(path, **kwargs)
-        if "last_modified" not in info:
+        path_info = self.info(path, **kwargs)
+        if "last_modified" not in path_info:
             raise IsADirectoryError(path)
-        return info["last_modified"]
+        return path_info["last_modified"]
 
     def info(self, path: str, **kwargs) -> Dict[str, Any]:
         resolved_path = self.resolve_path(path)

--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -325,6 +325,9 @@ class HfFileSystem(fsspec.AbstractFileSystem):
                     common_path = (path_prefix + os.path.commonpath(dirs_not_in_cache)).rstrip("/")
                     # Remove the paths prefixed with the common path to avoid duplicates after extending the output with the result of `_ls_tree(common_path, recursive=True)`
                     out = [o for o in out if not o["name"].startswith(common_path)]
+                    for cached_path in self.dircache:
+                        if cached_path.startswith(common_path):
+                            self.dircache.pop(cached_path, None)
                     out.extend(
                         self._ls_tree(common_path, recursive=True, refresh=True, revision=resolved_path.revision)
                     )

--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -305,6 +305,8 @@ class HfFileSystem(fsspec.AbstractFileSystem):
         else:
             cached_infos = self.dircache[path]
             out.extend(cached_infos)
+            # Use BFS to traverse the cache to build the "recursive "output
+            # - if the cache is incomplete, find the common prefix of the missing entries and extend the output with the result of `_ls_tree(common_prefix, recursive=True)`
             if recursive:
                 dirs_to_visit = deque([path_info for path_info in cached_infos if path_info["type"] == "directory"])
                 dirs_not_in_cache = []

--- a/tests/test_hf_file_system.py
+++ b/tests/test_hf_file_system.py
@@ -212,6 +212,34 @@ class HfFileSystemTests(unittest.TestCase):
                 self.assertEqual(files[0]["type"], "file")
                 self.assertTrue(files[0]["name"].endswith("/data/binary_data_for_pr.bin"))  # PR file
 
+    @retry_endpoint
+    def test_find(self):
+        repo_files = [
+            self.hf_path + "/.gitattributes",
+            self.hf_path + "/data/binary_data.bin",
+            self.hf_path + "/data/text_data.txt",
+        ]
+
+        files = self.hffs.find(self.hf_path)
+        self.assertEqual(sorted(files), sorted(repo_files))
+
+        files_and_dirs = self.hffs.find(self.hf_path, withdirs=True)
+        self.assertEqual(sorted(files_and_dirs), sorted(repo_files + [self.hf_path + "/data"]))
+
+    @retry_endpoint
+    def test_find_no_side_effects(self):
+        files1 = self.hffs.find(self.hf_path)
+        self.assertEqual(len(files1), 3)
+
+        files2 = self.hffs.find(self.hf_path)
+        self.assertEqual(len(files2), 3)
+        self.assertEqual(files1, files2)
+
+        self.hffs.invalidate_cache(self.hf_path + "/data")
+        files3 = self.hffs.find(self.hf_path)
+        self.assertEqual(len(files2), 3)
+        self.assertEqual(files1, files3)
+
 
 @pytest.mark.parametrize("path_in_repo", ["", "foo"])
 @pytest.mark.parametrize(


### PR DESCRIPTION
Similarly to [`S3FileSystem.find`](https://github.com/fsspec/s3fs/blob/main/s3fs/core.py#L774), optimize `HfFileSystem.find` to make it faster for Hub repositories with many files. The speed-up is achieved by fetching all the "tree" entries simultaneously instead of recursively for each directory, as done in the default implementation.

These changes make fetching the [`datasets/bigcode/the-stack-dedup`](https://huggingface.co/datasets/bigcode/the-stack-dedup) data files 4x faster (30 sec. vs. 120 sec.) and the difference should become even bigger when we increase the number of returned files per page when paginating the `/tree` endpoint's response.

(Also important for https://github.com/huggingface/datasets/issues/5537)