### PR TITLE
Passing the headers to hf_transfer download.

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -483,7 +483,7 @@ def http_get(
                 logger.debug(f"Download {url} using HF_TRANSFER.")
                 max_files = 100
                 chunk_size = 10 * 1024 * 1024  # 10 MB
-                download(url, temp_file.name, max_files, chunk_size)
+                download(url, temp_file.name, max_files, chunk_size, headers=headers)
                 return
             except ImportError:
                 raise ValueError(


### PR DESCRIPTION
- This is necessary for private models download.
- It was enabled in `hf_transfer==0.1.3`.