### PR TITLE
Remove deprecated code + adapt tests

### DIFF
--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -46,7 +46,7 @@ import sys
 from typing import TYPE_CHECKING
 
 
-__version__ = "0.14.0.dev0"
+__version__ = "0.15.0.dev0"
 
 # Alphabetical order of definitions is ensured in tests
 # WARNING: any comment added in this dictionary definition will be lost when

--- a/src/huggingface_hub/utils/endpoint_helpers.py
+++ b/src/huggingface_hub/utils/endpoint_helpers.py
@@ -16,20 +16,23 @@ with the aim for a user-friendly interface.
 import math
 import re
 from dataclasses import dataclass
-from typing import List, Optional, Union
+from typing import TYPE_CHECKING, Iterable, List, Optional, Union
+
+
+if TYPE_CHECKING:
+    from ..hf_api import ModelInfo
 
 
 def _filter_emissions(
-    models,
+    models: Iterable["ModelInfo"],
     minimum_threshold: Optional[float] = None,
     maximum_threshold: Optional[float] = None,
-):
-    """Filters a list of models for those that include an emission tag
-    and limit them to between two thresholds
+) -> Iterable["ModelInfo"]:
+    """Filters a list of models for those that include an emission tag and limit them to between two thresholds
 
     Args:
-        models (`ModelInfo` or `List`):
-            A list of `ModelInfo`'s to filter by.
+        models (Iterable of `ModelInfo`):
+            A list of models to filter.
         minimum_threshold (`float`, *optional*):
             A minimum carbon threshold to filter by, such as 1.
         maximum_threshold (`float`, *optional*):
@@ -41,23 +44,28 @@ def _filter_emissions(
         minimum_threshold = -1
     if maximum_threshold is None:
         maximum_threshold = math.inf
-    emissions = []
-    for i, model in enumerate(models):
-        if hasattr(model, "cardData"):
-            if isinstance(model.cardData, dict):
-                emission = model.cardData.get("co2_eq_emissions", None)
-                if isinstance(emission, dict):
-                    emission = emission["emissions"]
-                if emission:
-                    emission = str(emission)
-                    matched = re.search(r"\d+\.\d+|\d+", emission)
-                    if matched is not None:
-                        emissions.append((i, float(matched.group(0))))
-    filtered_results = []
-    for idx, emission in emissions:
-        if emission >= minimum_threshold and emission <= maximum_threshold:
-            filtered_results.append(models[idx])
-    return filtered_results
+
+    for model in models:
+        # Check ModelInfo format
+        if not hasattr(model, "cardData"):
+            continue
+        if not isinstance(model.cardData, dict):
+            continue
+
+        # Get CO2 emission metadata
+        emission = model.cardData.get("co2_eq_emissions", None)
+        if isinstance(emission, dict):
+            emission = emission["emissions"]
+        if not emission:
+            continue
+
+        matched = re.search(r"\d+\.\d+|\d+", str(emission))
+        if matched is None:
+            continue
+
+        emission_value = float(matched.group(0))
+        if emission_value >= minimum_threshold and emission_value <= maximum_threshold:
+            yield model
 
 
 @dataclass

--- a/src/huggingface_hub/utils/endpoint_helpers.py
+++ b/src/huggingface_hub/utils/endpoint_helpers.py
@@ -46,19 +46,18 @@ def _filter_emissions(
         maximum_threshold = math.inf
 
     for model in models:
-        # Check ModelInfo format
-        if not hasattr(model, "cardData"):
-            continue
-        if not isinstance(model.cardData, dict):
+        card_data = getattr(model, "cardData", None)
+        if card_data is None or not isinstance(card_data, dict):
             continue
 
         # Get CO2 emission metadata
-        emission = model.cardData.get("co2_eq_emissions", None)
+        emission = card_data.get("co2_eq_emissions", None)
         if isinstance(emission, dict):
             emission = emission["emissions"]
         if not emission:
             continue
 
+        # Filter out if value is missing or out of range
         matched = re.search(r"\d+\.\d+|\d+", str(emission))
         if matched is None:
             continue

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -1545,7 +1545,7 @@ class HfApiPublicProductionTest(unittest.TestCase):
         self.assertIsInstance(datasets[0], DatasetInfo)
 
     def test_filter_datasets_with_cardData(self):
-        datasets = list(self._api.list_datasets(cardData=True, limit=500))
+        datasets = list(self._api.list_datasets(full=True, limit=500))
         self.assertGreater(
             sum([getattr(dataset, "cardData", None) is not None for dataset in datasets]),
             0,


### PR DESCRIPTION
Following 0.14 release.

Breaking changes:
- `list_models`, `list_datasets` and `list_spaces` return an iterable instead of a list (lazy-loading of paginated results)
- cannot use `cardData` in `list_datasets`. Should use `full` instead.
Both changes should have been removed in 0.14 already but I forgot :innocent:. Since they were deprecated I hope the change will not brake too much warnings. I'll still advertise internally, just in case.

(I also modified some tests to stop listing all models/datasets/spaces from the Hub just to check it returns more than 100 results. This should save 2-3min on the overall CI :exploding_head:)