### PR TITLE
Resolve broken link to 'filesystem'

### DIFF
--- a/docs/source/guides/overview.mdx
+++ b/docs/source/guides/overview.mdx
@@ -43,7 +43,7 @@ Take a look at these guides to learn how to use huggingface_hub to solve real-wo
     </a>
 
     <a class="!no-underline border dark:border-gray-700 p-5 rounded-lg shadow hover:shadow-lg"
-       href="./filesystem">
+       href="./hf_file_system">
       <div class="w-full text-center bg-gradient-to-br from-indigo-400 to-indigo-500 rounded-lg py-1.5 font-semibold mb-5 text-white text-lg leading-relaxed">
         HfFileSystem
       </div><p class="text-gray-700">


### PR DESCRIPTION
Hello again!

### Pull Request overview
* Resolve broken link to `filesystem` instead of `hf_file_system`.

## Details
On https://huggingface.co/docs/huggingface_hub/guides/overview, click the `HfFileSystem` option and it'll break. 

This originates from a slight error in https://github.com/huggingface/huggingface_hub/pull/1420/files#diff-e8d4686d1d8a67d6970c799e668524f40ab243af1900c378687822cb3ccd9e0cR46

Apologies for the EOF change, I quickly made this patch via the GitHub web interface, and it decided to make that change for me...

- Tom Aarsen