### PR TITLE
Fix broken link in docs to hf_file_system guide

### DIFF
--- a/docs/source/package_reference/hf_file_system.mdx
+++ b/docs/source/package_reference/hf_file_system.mdx
@@ -4,7 +4,7 @@ The `HfFileSystem` class provides a pythonic file interface to the Hugging Face 
 
 ## HfFileSystem
 
-`HfFileSystem` is based on [fsspec](https://filesystem-spec.readthedocs.io/en/latest/), so it is compatible with most of the APIs that it offers. For more details, check out [our guide](../guides/filesystem) and the fsspec's [API Reference](https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem).
+`HfFileSystem` is based on [fsspec](https://filesystem-spec.readthedocs.io/en/latest/), so it is compatible with most of the APIs that it offers. For more details, check out [our guide](../guides/hf_file_system) and the fsspec's [API Reference](https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem).
 
 [[autodoc]] HfFileSystem
     - __init__


### PR DESCRIPTION
Fix broken link in docs to `guides/hf_file_system` from `package_reference/hf_file_system`:
- From: `../guides/filesystem`
- To: `../guides/hf_file_system`

Related to:
- #1461