### PR TITLE
FIX user agent not passed in snapshot_download

### DIFF
--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -182,14 +182,10 @@ def snapshot_download(
         )
 
     # if we have internet connection we retrieve the correct folder name from the huggingface api
-    _api = HfApi()
-    repo_info = _api.repo_info(
-        repo_id=repo_id,
-        repo_type=repo_type,
-        revision=revision,
-        token=token,
-    )
+    api = HfApi(library_name=library_name, library_version=library_version, user_agent=user_agent)
+    repo_info = api.repo_info(repo_id=repo_id, repo_type=repo_type, revision=revision, token=token)
     assert repo_info.sha is not None, "Repo info returned from server must have a revision sha."
+
     filtered_repo_files = list(
         filter_repo_objects(
             items=[f.rfilename for f in repo_info.siblings],


### PR DESCRIPTION
In `snapshot_download`, user-agent can be passed but is not taken into account for the `repo_info` call. This PR fixes this.