### PR TITLE
add utf8 encoding when opening files for windows

### DIFF
--- a/src/huggingface_hub/repocard.py
+++ b/src/huggingface_hub/repocard.py
@@ -521,7 +521,7 @@ def metadata_save(local_path: Union[str, Path], data: Dict) -> None:
     content = ""
     # try to detect existing newline character
     if os.path.exists(local_path):
-        with open(local_path, "r", newline="") as readme:
+        with open(local_path, "r", newline="", encoding="utf8") as readme:
             content = readme.read()
             if isinstance(readme.newlines, tuple):
                 line_break = readme.newlines[0]
@@ -529,7 +529,7 @@ def metadata_save(local_path: Union[str, Path], data: Dict) -> None:
                 line_break = readme.newlines
 
     # creates a new file if it not
-    with open(local_path, "w", newline="") as readme:
+    with open(local_path, "w", newline="", encoding="utf8") as readme:
         data_yaml = yaml_dump(data, sort_keys=False, line_break=line_break)
         # sort_keys: keep dict order
         match = REGEX_YAML_BLOCK.search(content)


### PR DESCRIPTION
The `metadata_save()` method in `repocard.py` does not work on Windows when creating Spaces. The reason is that UTF-8 encoding is not assumed on Windows and the presence of emojis in Spaces README leads to a `UnicodeEncodeError`. The simple fix is to set the `encoding="utf8"` when reading and writing the file, as is done in this PR.

More info about this issue: https://discuss.python.org/t/pep-597-use-utf-8-for-default-text-file-encoding/1819