### PR TITLE
Fix incorrect syntax in `_deprecation.py` warning message for `_deprecate_list_output()`

### DIFF
--- a/src/huggingface_hub/utils/_deprecation.py
+++ b/src/huggingface_hub/utils/_deprecation.py
@@ -158,7 +158,7 @@ def _deprecate_list_output(*, version: str):
                     " to be a generator starting from version {version} in order to"
                     " implement pagination. Please avoid to use"
                     " `{f.__name__}(...).{attr_name}` or explicitly convert the output"
-                    " to a list first with `list(iter({f.__name__})(...))`.".format(
+                    " to a list first with `list(iter({f.__name__}(...)))`.".format(
                         f=f,
                         version=version,
                         # Dumb but working workaround to render `attr_name` later

--- a/src/huggingface_hub/utils/_deprecation.py
+++ b/src/huggingface_hub/utils/_deprecation.py
@@ -158,7 +158,7 @@ def _deprecate_list_output(*, version: str):
                     " to be a generator starting from version {version} in order to"
                     " implement pagination. Please avoid to use"
                     " `{f.__name__}(...).{attr_name}` or explicitly convert the output"
-                    " to a list first with `list(iter({f.__name__}(...)))`.".format(
+                    " to a list first with `[item for item in {f.__name__}(...)]`.".format(
                         f=f,
                         version=version,
                         # Dumb but working workaround to render `attr_name` later


### PR DESCRIPTION
Micro edit!

I was cleaning up some code that leverages `huggingface_hub`, specifically I was using the method `len(list_models(...))`, which gave the deprecation warning:

```
FutureWarning: 'list_models' currently returns a list of objects but is planned to be a generator starting from version 0.14 in order to implement pagination. Please avoid to use `list_models(...).__len__` or explicitly convert the output to a list first with `list(iter(list_models)(...))`.
  warnings.warn(self._deprecation_msg.format(attr_name=attr_name), FutureWarning)
```

For some reason I read `list(iter(list_models)(...))` way too literally, and thought that `iter()` worked similarly to a decorator or contained a nested function (that also took in ellipses as an arg).

I believe it is a typo, where the inside of this statement meant to express `list_models(...)` where the ellipses mean the optional function arguments to list_models. So just one misplaced parentheses haha.


Sorry for the silly nitpick, but perhaps it will save somebody the 20 minutes I spent looking at this! 😅

Please let me know if any modifications are needed, thanks!

