### PR TITLE
Support image-to-image task in InferenceApi

### DIFF
--- a/src/huggingface_hub/inference_api.py
+++ b/src/huggingface_hub/inference_api.py
@@ -35,6 +35,7 @@ ALL_TASKS = [
     "object-detection",
     "image-segmentation",
     "text-to-image",
+    "image-to-image",
     # Others
     "tabular-classification",
     "tabular-regression",


### PR DESCRIPTION
Fix https://github.com/huggingface/huggingface_hub/issues/1424.
This is a temporary solution since `InferenceClient` is now the way to go for inference. `InferenceAPI` will soon be deprecated anyway.