### PR TITLE
Rename "configs" dataset card field to "config_names"

### DIFF
--- a/src/huggingface_hub/repocard_data.py
+++ b/src/huggingface_hub/repocard_data.py
@@ -361,9 +361,6 @@ class DatasetCardData(CardData):
             If not provided, it will be gathered from the 'train-eval-index' key of the kwargs.
         config_names (`Union[str, List[str]]`, *optional*):
             A list of the available dataset configs for the dataset.
-        ignore_metadata_errors (`str`):
-            If True, errors while parsing the metadata section will be ignored. Some information might be lost during
-            the process. Use it at your own risk.
     """
 
     def __init__(
@@ -382,7 +379,6 @@ class DatasetCardData(CardData):
         pretty_name: Optional[str] = None,
         train_eval_index: Optional[Dict] = None,
         config_names: Optional[Union[str, List[str]]] = None,
-        ignore_metadata_errors: bool = False,
         **kwargs,
     ):
         self.annotations_creators = annotations_creators

--- a/src/huggingface_hub/repocard_data.py
+++ b/src/huggingface_hub/repocard_data.py
@@ -359,7 +359,7 @@ class DatasetCardData(CardData):
         train_eval_index (`Dict`, *optional*):
             A dictionary that describes the necessary spec for doing evaluation on the Hub.
             If not provided, it will be gathered from the 'train-eval-index' key of the kwargs.
-        configs (`Union[str, List[str]]`, *optional*):
+        config_names (`Union[str, List[str]]`, *optional*):
             A list of the available dataset configs for the dataset.
         ignore_metadata_errors (`str`):
             If True, errors while parsing the metadata section will be ignored. Some information might be lost during
@@ -381,7 +381,7 @@ class DatasetCardData(CardData):
         paperswithcode_id: Optional[str] = None,
         pretty_name: Optional[str] = None,
         train_eval_index: Optional[Dict] = None,
-        configs: Optional[Union[str, List[str]]] = None,
+        config_names: Optional[Union[str, List[str]]] = None,
         ignore_metadata_errors: bool = False,
         **kwargs,
     ):
@@ -396,7 +396,7 @@ class DatasetCardData(CardData):
         self.task_ids = task_ids
         self.paperswithcode_id = paperswithcode_id
         self.pretty_name = pretty_name
-        self.configs = configs
+        self.config_names = config_names
 
         # TODO - maybe handle this similarly to EvalResult?
         self.train_eval_index = train_eval_index or kwargs.pop("train-eval-index", None)

--- a/src/huggingface_hub/repocard_data.py
+++ b/src/huggingface_hub/repocard_data.py
@@ -379,6 +379,7 @@ class DatasetCardData(CardData):
         pretty_name: Optional[str] = None,
         train_eval_index: Optional[Dict] = None,
         config_names: Optional[Union[str, List[str]]] = None,
+        ignore_metadata_errors: bool = False,
         **kwargs,
     ):
         self.annotations_creators = annotations_creators


### PR DESCRIPTION
In `datasets` we want to use `configs` yaml field to define custom configurations' parameters for datasets without scripts: https://github.com/huggingface/datasets/pull/5331#issuecomment-1570751476
So we decided to rename the old `configs` field to `config_names` cc @julien-c 

@lhoestq already changed `configs` to `config_names` in all canonical datasets. 