### PR TITLE
Custom headers/cookies in InferenceClient

### DIFF
--- a/docs/source/guides/inference.mdx
+++ b/docs/source/guides/inference.mdx
@@ -198,7 +198,7 @@ You can catch it and handle it in your code:
 Some tasks require binary inputs, for example, when dealing with images or audio files. In this case, [`InferenceClient`]
 tries to be as permissive as possible and accept different types:
 - raw `bytes`
-- a file-like object, opened as binary (`with open("audio.wav", "rb") as f: ...`)
+- a file-like object, opened as binary (`with open("audio.flac", "rb") as f: ...`)
 - a path (`str` or `Path`) pointing to a local file
 - a URL (`str`) pointing to a remote file (e.g. `https://...`). In this case, the file will be downloaded locally before
 sending it to the Inference API.


### PR DESCRIPTION
Related to https://github.com/huggingface/api-inference-community/pull/287 (and especially https://github.com/huggingface/api-inference-community/pull/287#issuecomment-1584578637) cc @StephenHodgson @Narsil 

With this PR, user can set custom headers and cookies to the `InferenceClient` session. This can prove useful when using custom endpoints. If set, custom headers overwrite the default user-agent and authorization headers.

(+fix documentation => save audio as .flac instead of .wav)