### PR TITLE
Fetch inference model for task from API

### DIFF
--- a/tests/cassettes/InferenceClientVCRTest.test_audio_classification.yaml
+++ b/tests/cassettes/InferenceClientVCRTest.test_audio_classification.yaml
@@ -1673,7 +1673,7 @@ interactions:
       - unknown/None; hf_hub/0.15.0.dev0; python/3.10.6; torch/1.12.1; tensorflow/2.11.0;
         fastcore/1.5.23
     method: POST
-    uri: https://api-inference.huggingface.co/models/superb/hubert-large-superb-er
+    uri: https://api-inference.huggingface.co/models/speechbrain/google_speech_command_xvector
   response:
     body:
       string: '[{"score":0.6658844351768494,"label":"neu"},{"score":0.1802878975868225,"label":"sad"},{"score":0.07892542332410812,"label":"hap"},{"score":0.0749022513628006,"label":"ang"}]'

--- a/tests/cassettes/InferenceClientVCRTest.test_automatic_speech_recognition.yaml
+++ b/tests/cassettes/InferenceClientVCRTest.test_automatic_speech_recognition.yaml
@@ -1673,7 +1673,7 @@ interactions:
       - unknown/None; hf_hub/0.15.0.dev0; python/3.10.6; torch/1.12.1; tensorflow/2.11.0;
         fastcore/1.5.23
     method: POST
-    uri: https://api-inference.huggingface.co/models/facebook/wav2vec2-large-960h-lv60-self
+    uri: https://api-inference.huggingface.co/models/facebook/wav2vec2-base-960h
   response:
     body:
       string: '{"text":"A MAN SAID TO THE UNIVERSE SIR I EXIST"}'

--- a/tests/cassettes/InferenceClientVCRTest.test_conversational.yaml
+++ b/tests/cassettes/InferenceClientVCRTest.test_conversational.yaml
@@ -16,7 +16,7 @@ interactions:
       - unknown/None; hf_hub/0.15.0.dev0; python/3.10.6; torch/1.12.1; tensorflow/2.11.0;
         fastcore/1.5.23
     method: POST
-    uri: https://api-inference.huggingface.co/models/microsoft/DialoGPT-large
+    uri: https://api-inference.huggingface.co/models/facebook/blenderbot-400M-distill
   response:
     body:
       string: '{"generated_text":"I am the one who knocks.","conversation":{"generated_responses":["I
@@ -64,7 +64,7 @@ interactions:
       - unknown/None; hf_hub/0.15.0.dev0; python/3.10.6; torch/1.12.1; tensorflow/2.11.0;
         fastcore/1.5.23
     method: POST
-    uri: https://api-inference.huggingface.co/models/microsoft/DialoGPT-large
+    uri: https://api-inference.huggingface.co/models/facebook/blenderbot-400M-distill
   response:
     body:
       string: '{"generated_text":"I am the one who knocks.","conversation":{"generated_responses":["I

--- a/tests/cassettes/InferenceClientVCRTest.test_summarization.yaml
+++ b/tests/cassettes/InferenceClientVCRTest.test_summarization.yaml
@@ -25,7 +25,7 @@ interactions:
       - unknown/None; hf_hub/0.15.0.dev0; python/3.10.6; torch/1.12.1; tensorflow/2.11.0;
         fastcore/1.5.23
     method: POST
-    uri: https://api-inference.huggingface.co/models/facebook/bart-large-cnn
+    uri: https://api-inference.huggingface.co/models/sshleifer/distilbart-cnn-12-6
   response:
     body:
       string: '[{"summary_text":"The tower is 324 metres (1,063 ft) tall, about the

--- a/tests/cassettes/InferenceClientVCRTest.test_text_to_image.yaml
+++ b/tests/cassettes/InferenceClientVCRTest.test_text_to_image.yaml
@@ -16,7 +16,7 @@ interactions:
       - unknown/None; hf_hub/0.15.0.dev0; python/3.10.6; torch/1.12.1; tensorflow/2.11.0;
         fastcore/1.5.23
     method: POST
-    uri: https://api-inference.huggingface.co/models/stabilityai/stable-diffusion-2-1
+    uri: https://api-inference.huggingface.co/models/CompVis/stable-diffusion-v1-4
   response:
     body:
       string: !!binary |


### PR DESCRIPTION
Use output from https://huggingface.co/api/tasks (cc @julien-c) to recommend a model per task. Output is memoized since we don't expect to change it too often (+having an outdated recommendation is never critical). 

Also cc @coyotte508 for the same kind of logic in inference.js