### PR TITLE
Set 30s timeout on downloads (instead of 10s)

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -362,7 +362,7 @@ def _request_wrapper(
     max_retries: int = 0,
     base_wait_time: float = 0.5,
     max_wait_time: float = 2,
-    timeout: float = 10.0,
+    timeout: Optional[float] = None,
     follow_relative_redirects: bool = False,
     **params,
 ) -> requests.Response:
@@ -388,9 +388,9 @@ def _request_wrapper(
             `max_wait_time`.
         max_wait_time (`float`, *optional*, defaults to `2`):
             Maximum amount of time between two retries, in seconds.
-        timeout (`float`, *optional*, defaults to `10`):
+        timeout (`float`, *optional*):
             How many seconds to wait for the server to send data before
-            giving up which is passed to `requests.request`.
+            giving up which is passed to `requests.request`. Defaults to no timeouts.
         follow_relative_redirects (`bool`, *optional*, defaults to `False`)
             If True, relative redirection (redirection to the same site) will be
             resolved even when `allow_redirection` kwarg is set to False. Useful when we
@@ -465,10 +465,10 @@ def http_get(
     temp_file: BinaryIO,
     *,
     proxies=None,
-    resume_size=0,
+    resume_size: float = 0,
     headers: Optional[Dict[str, str]] = None,
-    timeout=10.0,
-    max_retries=0,
+    timeout: Optional[float] = None,
+    max_retries: int = 0,
     expected_size: Optional[int] = None,
 ):
     """
@@ -1502,7 +1502,7 @@ def get_hf_file_metadata(
     url: str,
     token: Union[bool, str, None] = None,
     proxies: Optional[Dict] = None,
-    timeout: float = 10,
+    timeout: Optional[float] = None,
 ) -> HfFileMetadata:
     """Fetch metadata of a file versioned on the Hub for a given url.
 

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -362,7 +362,7 @@ def _request_wrapper(
     max_retries: int = 0,
     base_wait_time: float = 0.5,
     max_wait_time: float = 2,
-    timeout: Optional[float] = None,
+    timeout: Optional[float] = 30.0,
     follow_relative_redirects: bool = False,
     **params,
 ) -> requests.Response:
@@ -388,9 +388,9 @@ def _request_wrapper(
             `max_wait_time`.
         max_wait_time (`float`, *optional*, defaults to `2`):
             Maximum amount of time between two retries, in seconds.
-        timeout (`float`, *optional*):
+        timeout (`float`, *optional*, defaults to `30`):
             How many seconds to wait for the server to send data before
-            giving up which is passed to `requests.request`. Defaults to no timeouts.
+            giving up which is passed to `requests.request`.
         follow_relative_redirects (`bool`, *optional*, defaults to `False`)
             If True, relative redirection (redirection to the same site) will be
             resolved even when `allow_redirection` kwarg is set to False. Useful when we
@@ -467,7 +467,7 @@ def http_get(
     proxies=None,
     resume_size: float = 0,
     headers: Optional[Dict[str, str]] = None,
-    timeout: Optional[float] = None,
+    timeout: Optional[float] = 30.0,
     max_retries: int = 0,
     expected_size: Optional[int] = None,
 ):
@@ -1502,7 +1502,7 @@ def get_hf_file_metadata(
     url: str,
     token: Union[bool, str, None] = None,
     proxies: Optional[Dict] = None,
-    timeout: Optional[float] = None,
+    timeout: Optional[float] = 30.0,
 ) -> HfFileMetadata:
     """Fetch metadata of a file versioned on the Hub for a given url.
 


### PR DESCRIPTION
Related to [internal slack thread](https://huggingface.slack.com/archives/C02EMARJ65P/p1686829213703489). The default timeout when downloading a file (`hf_hub_download`) is 10s. This is far enough in most cases but in a very few cases it causes a ConnectionError (especially in `transformers`'s CI recently). Except if this 10s limit is really useful, I suggest to remove it. In the worst case, there is a 60s timeout on cloudfront.

Note: I am not talking about the 10s `etag_timeout` that is used when making the HEAD call to the file. For this one I think it's good to keep it and default early (10s) to the local cache.

Thanks @ydshieh @rtrompier for debugging this one! I hope it'll solve transformers's issues :)

@julien-c @Pierrci @LysandreJik since it's about the `/resolve/` endpoint, please let me know your opinion on this one :pray: 

**EDIT:** reverted to 30s in https://github.com/huggingface/huggingface_hub/pull/1514/commits/8e16055a35d53cbde236f91c0bcb5b9ae75498e8 (see https://github.com/huggingface/huggingface_hub/pull/1514#discussion_r1232321424)