### PR TITLE
Retry on both ConnectTimeout and ReadTimeout

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -19,7 +19,7 @@ from urllib.parse import quote, urlparse
 
 import requests
 from filelock import FileLock
-from requests.exceptions import ConnectTimeout, ProxyError
+from requests.exceptions import Timeout, ProxyError
 
 from huggingface_hub import constants
 
@@ -373,7 +373,7 @@ def _request_wrapper(
        If enabled, a `OfflineModeIsEnabled` exception is raised.
     2. Follow relative redirections if `follow_relative_redirects=True` even when
        `allow_redirection` kwarg is set to False.
-    3. Retry in case request fails with a `ConnectTimeout`, with exponential backoff.
+    3. Retry in case request fails with a `Timeout` or `ProxyError`, with exponential backoff.
 
     Args:
         method (`str`):
@@ -445,7 +445,7 @@ def _request_wrapper(
         max_retries=max_retries,
         base_wait_time=base_wait_time,
         max_wait_time=max_wait_time,
-        retry_on_exceptions=(ConnectTimeout, ProxyError),
+        retry_on_exceptions=(Timeout, ProxyError),
         retry_on_status_codes=(),
         timeout=timeout,
         **params,

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -19,7 +19,7 @@ from urllib.parse import quote, urlparse
 
 import requests
 from filelock import FileLock
-from requests.exceptions import Timeout, ProxyError
+from requests.exceptions import ProxyError, Timeout
 
 from huggingface_hub import constants
 

--- a/src/huggingface_hub/utils/_http.py
+++ b/src/huggingface_hub/utils/_http.py
@@ -22,7 +22,7 @@ from typing import Callable, Tuple, Type, Union
 
 import requests
 from requests import Response
-from requests.exceptions import Timeout, ProxyError
+from requests.exceptions import ProxyError, Timeout
 
 from . import logging
 from ._typing import HTTP_METHOD_T

--- a/src/huggingface_hub/utils/_http.py
+++ b/src/huggingface_hub/utils/_http.py
@@ -22,7 +22,7 @@ from typing import Callable, Tuple, Type, Union
 
 import requests
 from requests import Response
-from requests.exceptions import ConnectTimeout, ProxyError
+from requests.exceptions import Timeout, ProxyError
 
 from . import logging
 from ._typing import HTTP_METHOD_T
@@ -119,7 +119,7 @@ def http_backoff(
     base_wait_time: float = 1,
     max_wait_time: float = 8,
     retry_on_exceptions: Union[Type[Exception], Tuple[Type[Exception], ...]] = (
-        ConnectTimeout,
+        Timeout,
         ProxyError,
     ),
     retry_on_status_codes: Union[int, Tuple[int, ...]] = HTTPStatus.SERVICE_UNAVAILABLE,
@@ -148,10 +148,10 @@ def http_backoff(
             `max_wait_time`.
         max_wait_time (`float`, *optional*, defaults to `8`):
             Maximum duration (in seconds) to wait before retrying.
-        retry_on_exceptions (`Type[Exception]` or `Tuple[Type[Exception]]`, *optional*, defaults to `(ConnectTimeout, ProxyError,)`):
+        retry_on_exceptions (`Type[Exception]` or `Tuple[Type[Exception]]`, *optional*, defaults to `(Timeout, ProxyError,)`):
             Define which exceptions must be caught to retry the request. Can be a single
             type or a tuple of types.
-            By default, retry on `ConnectTimeout` and `ProxyError`.
+            By default, retry on `Timeout` and `ProxyError`.
         retry_on_status_codes (`int` or `Tuple[int]`, *optional*, defaults to `503`):
             Define on which status codes the request must be retried. By default, only
             HTTP 503 Service Unavailable is retried.


### PR DESCRIPTION
Solves https://github.com/huggingface/huggingface_hub/issues/1526 (cc @alexmojaki). Issue caused CI failures in https://github.com/huggingface/transformers/pull/24384#issuecomment-1602990696 (cc @ydshieh).

At the moment HTTP requests failing with a `ConnectTimeout` or `ProxyError` when downloading a file are retried with a  backoff strategy. This PR adds `ReadTimeout` as an exception to retry on as well. More precisely, we now retry on any `requests.exceptions.Timeout` error (meaning both connect and read timeouts).

This change does not introduce a breaking change as `ConnectTimeout` errors are still caught. It should fix downloads in some rare occasions.