### PR TITLE
Retry with requests.exceptions.ConnectionError in http_backoff

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -445,7 +445,7 @@ def _request_wrapper(
         max_retries=max_retries,
         base_wait_time=base_wait_time,
         max_wait_time=max_wait_time,
-        retry_on_exceptions=(Timeout, ProxyError),
+        retry_on_exceptions=(Timeout, ProxyError, requests.exceptions.ConnectionError),
         retry_on_status_codes=(),
         timeout=timeout,
         **params,


### PR DESCRIPTION
The GFW will send RST packet to the server and client randomly when create TCP connection in some region to huggingface, this will cause a `requests.exceptions.ConnectionError` in requests.

As #1533 mentioned, users should specify reties and timeout locally, but the `retry_on_exceptions` is hard coded here, so just add `requests.exceptions.ConnectionError` on it.