### PR TITLE
Add request id to message in ConnectionError

### DIFF
--- a/tests/test_utils_http.py
+++ b/tests/test_utils_http.py
@@ -220,21 +220,21 @@ class TestUniqueRequestId(unittest.TestCase):
     def test_request_id_is_used_by_server(self):
         response = get_session().get(self.api_endpoint)
 
-        request_id = response.request.headers.get("x-request-id")
+        request_id = response.request.headers.get("X-Amzn-Trace-Id")
         response_id = response.headers.get("x-request-id")
-        self.assertEqual(request_id, response_id)
-        self.assertTrue(_is_uuid(response_id))
+        self.assertIn(request_id, response_id)
+        self.assertTrue(_is_uuid(request_id))
 
     def test_request_id_is_unique(self):
         response_1 = get_session().get(self.api_endpoint)
         response_2 = get_session().get(self.api_endpoint)
 
-        response_id_1 = response_1.headers["x-request-id"]
-        response_id_2 = response_2.headers["x-request-id"]
-        self.assertNotEqual(response_id_1, response_id_2)
+        request_id_1 = response_1.request.headers["X-Amzn-Trace-Id"]
+        request_id_2 = response_2.request.headers["X-Amzn-Trace-Id"]
+        self.assertNotEqual(request_id_1, request_id_2)
 
-        self.assertTrue(_is_uuid(response_id_1))
-        self.assertTrue(_is_uuid(response_id_2))
+        self.assertTrue(_is_uuid(request_id_1))
+        self.assertTrue(_is_uuid(request_id_2))
 
     def test_request_id_not_overwritten(self):
         response = get_session().get(self.api_endpoint, headers={"x-request-id": "custom-id"})


### PR DESCRIPTION
Related to https://github.com/huggingface/huggingface_hub/pull/1518. A `x-request-id` header is added to every request made to the Hub and is printed in the error message in case of error 4XX or 5XX.

In this PR, I also catch _any_ `RequestException` to add the request_id to the debug message. In particular any TimeoutError or ConnectionError will be easier to investigate.