### PR TITLE
Make `requests.Session` truly unique

### DIFF
--- a/src/huggingface_hub/utils/_http.py
+++ b/src/huggingface_hub/utils/_http.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """Contains utilities to handle HTTP requests in Huggingface Hub."""
 import io
+import os
 import threading
 import time
 import uuid
@@ -144,11 +145,11 @@ def get_session() -> requests.Session:
     session = get_session()
     ```
     """
-    return _get_session_from_cache(thread_ident=threading.get_ident())
+    return _get_session_from_cache(process_id=os.getpid(), thread_id=threading.get_ident())
 
 
 @lru_cache
-def _get_session_from_cache(thread_ident: int) -> requests.Session:
+def _get_session_from_cache(process_id: int, thread_id: int) -> requests.Session:
     """
     Create a new session per thread using global factory. Using LRU cache (maxsize 128) to avoid memory leaks when
     using thousands of threads. Cache is cleared when `configure_http_backend` is called.


### PR DESCRIPTION
Found a bug in `huggingface_hub` while investigating why CI in https://github.com/huggingface/lighteval-harness/pull/113 was failing (private repo). 

The triggered error was:
```
HTTPSConnectionPool(host='huggingface.co', port=443): Read timed out. (read timeout=10)' thrown while requesting HEAD https://huggingface.co/gpt2/resolve/main/config.json
```

It turns out that the error happens because a `request.Session` is shared between processes and somehow the session gets broken when forked. Sharing the session was not intended and is due to a bug in [`./utils/_http.py`](https://github.com/huggingface/huggingface_hub/blob/main/src/huggingface_hub/utils/_http.py). To avoid sharing a session object, I was only checking the thread ID. This PR fixes the issue by checking the process ID as well. 

This PR fixes the lighteval repo CI and should also make `huggingface_hub` more stable (hopefully fix random ConnectionErrors like in https://github.com/huggingface/huggingface_hub/pull/1538 or https://github.com/huggingface/huggingface_hub/issues/1542).

cc @XciD @clefourrier @thomwolf 