### PR TITLE
1546 fix empty metadata on windows

### DIFF
--- a/src/huggingface_hub/repocard.py
+++ b/src/huggingface_hub/repocard.py
@@ -96,6 +96,9 @@ class RepoCard:
             self.text = content[match.end() :]
             data_dict = yaml.safe_load(yaml_block)
 
+            if data_dict is None:
+                data_dict = {}
+
             # The YAML block's data should be a dictionary
             if not isinstance(data_dict, dict):
                 raise ValueError("repo card metadata block should be a dict")

--- a/src/huggingface_hub/repocard.py
+++ b/src/huggingface_hub/repocard.py
@@ -501,10 +501,9 @@ def metadata_load(local_path: Union[str, Path]) -> Optional[Dict]:
     if match:
         yaml_block = match.group(2)
         data = yaml.safe_load(yaml_block)
-        if isinstance(data, dict):
+        if data is None or isinstance(data, dict):
             return data
-        else:
-            raise ValueError("repo card metadata block should be a dict")
+        raise ValueError("repo card metadata block should be a dict")
     else:
         return None
 

--- a/tests/test_repocard.py
+++ b/tests/test_repocard.py
@@ -171,6 +171,14 @@ model-index:
 This is a test model card.
 """
 
+DUMMY_MODELCARD_EMPTY_METADATA = """
+---
+---
+# Begin of markdown after an empty metadata.
+
+Some cool dataset card.
+"""
+
 
 def require_jinja(test_case):
     """
@@ -221,6 +229,11 @@ class RepocardMetadataTest(unittest.TestCase):
 
     def test_no_metadata_returns_none(self):
         self.filepath.write_text(DUMMY_MODELCARD_TARGET_NO_TAGS)
+        data = metadata_load(self.filepath)
+        self.assertEqual(data, None)
+
+    def test_empty_metadata_returns_none(self):
+        self.filepath.write_text(DUMMY_MODELCARD_EMPTY_METADATA)
         data = metadata_load(self.filepath)
         self.assertEqual(data, None)
 

--- a/tests/test_repocard.py
+++ b/tests/test_repocard.py
@@ -237,6 +237,11 @@ class RepocardMetadataTest(unittest.TestCase):
         data = metadata_load(self.filepath)
         self.assertEqual(data, None)
 
+    def test_empty_metadata_returns_none(self):
+        self.filepath.write_text(DUMMY_MODELCARD_EMPTY_METADATA)
+        self.assertIsNone(metadata_load(self.filepath))
+        self.assertEqual(RepoCard.load(self.filepath).data.to_dict(), {})
+
     def test_metadata_eval_result(self):
         data = metadata_eval_result(
             model_pretty_name="RoBERTa fine-tuned on ReactionGIF",


### PR DESCRIPTION
Following https://github.com/huggingface/huggingface_hub/issues/1546 @lhoestq 

There was an issue on Windows if a modelcard has a metadata section that was empty. This is fixed.