### PR TITLE
Check local files if (RepoNotFound, GatedRepo, HTTPError) while downloading files

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -38,8 +38,10 @@ from .constants import (
     REPO_TYPES_URL_PREFIXES,
 )
 from .utils import (
+    HfFolder,
     EntryNotFoundError,
     LocalEntryNotFoundError,
+    RepositoryNotFoundError,
     SoftTemporaryDirectory,
     build_hf_headers,
     get_fastai_version,  # noqa: F401 # for backward compatibility
@@ -1245,6 +1247,12 @@ def hf_hub_download(
             # Otherwise, our Internet connection is down.
             # etag is None
             pass
+        except RepositoryNotFoundError:
+            if HfFolder.get_token() is None:
+                print('Not logged in, so should expect file to reside locally; if there are no local files, then we have a problem.')
+                pass
+            else:
+                raise
 
     # etag is None == we don't have a connection or we passed local_files_only.
     # try to get the last downloaded one from the specified revision.

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -38,10 +38,10 @@ from .constants import (
     REPO_TYPES_URL_PREFIXES,
 )
 from .utils import (
-    HfFolder,
     EntryNotFoundError,
     LocalEntryNotFoundError,
     RepositoryNotFoundError,
+    RevisionNotFoundError,
     SoftTemporaryDirectory,
     build_hf_headers,
     get_fastai_version,  # noqa: F401 # for backward compatibility
@@ -649,10 +649,8 @@ def cached_download(
     """
     if not legacy_cache_layout:
         warnings.warn(
-            (
-                "'cached_download' is the legacy way to download files from the HF hub, please consider upgrading to"
-                " 'hf_hub_download'"
-            ),
+            "'cached_download' is the legacy way to download files from the HF hub, please consider upgrading to"
+            " 'hf_hub_download'",
             FutureWarning,
         )
 
@@ -1104,10 +1102,8 @@ def hf_hub_download(
     """
     if force_filename is not None:
         warnings.warn(
-            (
-                "The `force_filename` parameter is deprecated as a new caching system, "
-                "which keeps the filenames as they are on the Hub, is now in place."
-            ),
+            "The `force_filename` parameter is deprecated as a new caching system, "
+            "which keeps the filenames as they are on the Hub, is now in place.",
             FutureWarning,
         )
         legacy_cache_layout = True
@@ -1191,6 +1187,7 @@ def hf_hub_download(
     etag = None
     commit_hash = None
     expected_size = None
+    head_call_error: Optional[Exception] = None
     if not local_files_only:
         try:
             try:
@@ -1243,19 +1240,30 @@ def hf_hub_download(
             requests.exceptions.ConnectionError,
             requests.exceptions.Timeout,
             OfflineModeIsEnabled,
-        ):
+        ) as error:
             # Otherwise, our Internet connection is down.
             # etag is None
+            head_call_error = error
             pass
-        except RepositoryNotFoundError:
-            if HfFolder.get_token() is None:
-                print('Not logged in, so should expect file to reside locally; if there are no local files, then we have a problem.')
-                pass
-            else:
-                raise
+        except (RevisionNotFoundError, EntryNotFoundError):
+            # The repo was found but the revision or entry doesn't exist on the Hub (never existed or got deleted)
+            raise
+        except requests.HTTPError as error:
+            # Multiple reasons for an http error:
+            # - Repository is private and invalid/missing token sent
+            # - Repository is gated and invalid/missing token sent
+            # - Hub is down (error 500 or 504)
+            # => let's warn the user and switch to 'local_files_only=True' to check if the files are already cached.
+            head_call_error = error
+            pass
 
-    # etag is None == we don't have a connection or we passed local_files_only.
-    # try to get the last downloaded one from the specified revision.
+    # etag can be None for several reasons:
+    # 1. we passed local_files_only.
+    # 2. we don't have a connection
+    # 3. Hub is down (HTTP 500 or 504)
+    # 4. repo is not found -for example private or gated- and invalid/missing token sent
+    # => Try to get the last downloaded one from the specified revision.
+    #
     # If the specified revision is a commit hash, look inside "snapshots".
     # If the specified revision is a branch or tag, look inside "refs".
     if etag is None:
@@ -1291,16 +1299,19 @@ def hf_hub_download(
         # Notify the user about that
         if local_files_only:
             raise LocalEntryNotFoundError(
-                "Cannot find the requested files in the disk cache and"
-                " outgoing traffic has been disabled. To enable hf.co look-ups"
-                " and downloads online, set 'local_files_only' to False."
+                "Cannot find the requested files in the disk cache and outgoing traffic has been disabled. To enable"
+                " hf.co look-ups and downloads online, set 'local_files_only' to False."
             )
+        elif isinstance(head_call_error, RepositoryNotFoundError):
+            # Repo not found => let's raise the actual error
+            raise head_call_error
         else:
+            # Otherwise: most likely a connection issue or Hub downtime => let's warn the user
             raise LocalEntryNotFoundError(
-                "Connection error, and we cannot find the requested files in"
-                " the disk cache. Please try again or make sure your Internet"
-                " connection is on."
-            )
+                "An error happened while trying to locate the file on the Hub and we cannot find the requested files"
+                " in the local cache. Please check your connection and try again or make sure your Internet connection"
+                " is on."
+            ) from head_call_error
 
     # From now on, etag and commit_hash are not None.
     assert etag is not None, "etag must have been retrieved from server"

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -39,6 +39,7 @@ from .constants import (
 )
 from .utils import (
     EntryNotFoundError,
+    GatedRepoError,
     LocalEntryNotFoundError,
     RepositoryNotFoundError,
     RevisionNotFoundError,
@@ -1253,7 +1254,8 @@ def hf_hub_download(
             # - Repository is private and invalid/missing token sent
             # - Repository is gated and invalid/missing token sent
             # - Hub is down (error 500 or 504)
-            # => let's warn the user and switch to 'local_files_only=True' to check if the files are already cached.
+            # => let's switch to 'local_files_only=True' to check if the files are already cached.
+            #    (if it's not the case, the error will be re-raised)
             head_call_error = error
             pass
 
@@ -1302,7 +1304,7 @@ def hf_hub_download(
                 "Cannot find the requested files in the disk cache and outgoing traffic has been disabled. To enable"
                 " hf.co look-ups and downloads online, set 'local_files_only' to False."
             )
-        elif isinstance(head_call_error, RepositoryNotFoundError):
+        elif isinstance(head_call_error, RepositoryNotFoundError) or isinstance(head_call_error, GatedRepoError):
             # Repo not found => let's raise the actual error
             raise head_call_error
         else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,7 +95,7 @@ def fx_production_space(request: SubRequest) -> Generator[None, None, None]:
     ```
     """
     # Check if production token exists
-    if PRODUCTION_TOKEN is None:
+    if not PRODUCTION_TOKEN:
         pytest.skip("Skip Space tests. `HUGGINGFACE_PRODUCTION_USER_TOKEN` environment variable is not set.")
 
     # Generate repo id from prod token

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -153,6 +153,20 @@ class CachedDownloadTests(unittest.TestCase):
                     cache_dir=tmpdir,
                 )
 
+    def test_private_repo_and_file_cached_locally(self):
+        api = HfApi(endpoint=ENDPOINT_STAGING, token=TOKEN)
+        repo_id = api.create_repo(repo_id=repo_name(), private=True).repo_id
+        api.upload_file(path_or_fileobj=b"content", path_in_repo=CONFIG_NAME, repo_id=repo_id)
+
+        with SoftTemporaryDirectory() as tmpdir:
+            # Download a first time with token => file is cached
+            filepath_1 = hf_hub_download(DUMMY_MODEL_ID, filename=CONFIG_NAME, cache_dir=tmpdir, token=TOKEN)
+
+            # Download without token => return cached file
+            filepath_2 = hf_hub_download(DUMMY_MODEL_ID, filename=CONFIG_NAME, cache_dir=tmpdir)
+
+            self.assertEqual(filepath_1, filepath_2)
+
     def test_file_cached_and_read_only_access(self):
         """Should works if file is already cached and user has read-only permission.
 


### PR DESCRIPTION
In certain cases, we might assume that the model files exist (like in a docker) but huggingface token is not set, and the user only needs to run the model locally. This works for diffusers with default arguments, but in transformers, a RepositoryNotFoundError is raised if `not_local_files_only` is true, but user is not logged into huggingface. 

Example code:
```
from transformers import T5EncoderModel, T5Tokenizer

tokenizer = T5Tokenizer.from_pretrained("DeepFloyd/IF-I-XL-v1.0", subfolder="tokenizer")
# tokenizer = T5Tokenizer.from_pretrained("DeepFloyd/IF-I-XL-v1.0", subfolder="tokenizer", local_files_only=True)

prompt = "something"
text_inputs = tokenizer(prompt, padding="max_length", max_length=77, truncation=True, add_special_tokens=True, return_tensors="pt")

print(text_inputs)
```

The fix is to check if there is a token or not. If there is a token, then there might be authentication issues. If not, then it might be expected behavior from the user that a local file is being used (like in production). 