### PR TITLE
Tips to upload large models/datasets

### DIFF
--- a/docs/source/guides/repository.md
+++ b/docs/source/guides/repository.md
@@ -71,7 +71,7 @@ Specify the `repo_id` of the repository you want to delete:
 >>> delete_repo(repo_id="lysandre/my-corrupted-dataset", repo_type="dataset")
 ```
 
-### Clone a repository (only for Spaces)
+### Duplicate a repository (only for Spaces)
 
 In some cases, you want to copy someone else's repo to adapt it to your use case.
 This is possible for Spaces using the [`duplicate_space`] method. It will duplicate the whole repository.


### PR DESCRIPTION
We've talked several times about having a section in the docs with some tips for users wanting to upload a large amount of data. I tried to sum-up everything with two distinct aspects:
- technical limitations (max size per file, max file per commit, max file per folder, max file per repo)
- practical tips (start small, use hf_transfer, expect failures)