### PR TITLE
Send Accept: image/png as header for image tasks

### DIFF
--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -54,6 +54,7 @@ from requests.structures import CaseInsensitiveDict
 
 from huggingface_hub.constants import INFERENCE_ENDPOINT
 from huggingface_hub.inference._common import (
+    TASKS_EXPECTING_IMAGES,
     ContentT,
     InferenceTimeoutError,
     _b64_encode,
@@ -204,6 +205,11 @@ class InferenceClient:
         if data is not None and json is not None:
             warnings.warn("Ignoring `json` as `data` is passed as binary.")
 
+        # Set Accept header if relevant
+        headers = self.headers.copy()
+        if task in TASKS_EXPECTING_IMAGES and "Accept" not in headers:
+            headers["Accept"] = "image/png"
+
         t0 = time.time()
         timeout = self.timeout
         while True:
@@ -213,7 +219,7 @@ class InferenceClient:
                         url,
                         json=json,
                         data=data_as_binary,
-                        headers=self.headers,
+                        headers=headers,
                         cookies=self.cookies,
                         timeout=self.timeout,
                         stream=stream,

--- a/src/huggingface_hub/inference/_common.py
+++ b/src/huggingface_hub/inference/_common.py
@@ -62,6 +62,9 @@ PathT = Union[str, Path]
 BinaryT = Union[bytes, BinaryIO]
 ContentT = Union[BinaryT, PathT, UrlT]
 
+# Use to set a Accept: image/png header
+TASKS_EXPECTING_IMAGES = {"text-to-image", "image-to-image"}
+
 logger = logging.getLogger(__name__)
 
 

--- a/tests/test_inference_client.py
+++ b/tests/test_inference_client.py
@@ -332,3 +332,15 @@ class TestHeadersAndCookies(unittest.TestCase):
             timeout=None,
             stream=False,
         )
+
+    @patch("huggingface_hub.inference._client._bytes_to_image")
+    @patch("huggingface_hub.inference._client.get_session")
+    def test_accept_header_image(self, get_session_mock: MagicMock, bytes_to_image_mock: MagicMock) -> None:
+        """Test that Accept: image/png header is set for image tasks."""
+        client = InferenceClient()
+
+        response = client.text_to_image("An astronaut riding a horse")
+        self.assertEqual(response, bytes_to_image_mock.return_value)
+
+        headers = get_session_mock().post.call_args_list[0].kwargs["headers"]
+        self.assertEqual(headers["Accept"], "image/png")

--- a/utils/generate_async_inference_client.py
+++ b/utils/generate_async_inference_client.py
@@ -164,6 +164,11 @@ ASYNC_POST_CODE = """
         if data is not None and json is not None:
             warnings.warn("Ignoring `json` as `data` is passed as binary.")
 
+        # Set Accept header if relevant
+        headers = self.headers.copy()
+        if task in TASKS_EXPECTING_IMAGES and "Accept" not in headers:
+            headers["Accept"] = "image/png"
+
         t0 = time.time()
         timeout = self.timeout
         while True:
@@ -171,11 +176,11 @@ ASYNC_POST_CODE = """
                 # Do not use context manager as we don't want to close the connection immediately when returning
                 # a stream
                 client = aiohttp.ClientSession(
-                    headers=self.headers, cookies=self.cookies, timeout=aiohttp.ClientTimeout(self.timeout)
+                    headers=headers, cookies=self.cookies, timeout=aiohttp.ClientTimeout(self.timeout)
                 )
 
                 try:
-                    response = await client.post(url, headers=build_hf_headers(), json=json, data=data_as_binary)
+                    response = await client.post(url, json=json, data=data_as_binary)
                     response_error_payload = None
                     if response.status != 200:
                         try:


### PR DESCRIPTION
cc @philschmid 

Tasks that expect an image to be returned by the server (i.e. image-to-image and text-to-image) must send `Accept: image/png` as header by default. This value can be overwritten by the user if needed. This PR fixes a bug happening with Inference Endpoints which returns a base64-encoded image in case Accept header is not set. This doesn't change anything for InferenceAPI calls.

**EDIT:** also fixes a bug in AsyncInferenceClient where headers set by the user where not taken into account.

**NOTE:** failing tests are unrelated