### PR TITLE
Add download alias for `hf_hub_download` to `HfApi`

### DIFF
--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -24,8 +24,9 @@ logger = logging.get_logger(__name__)
 def snapshot_download(
     repo_id: str,
     *,
-    revision: Optional[str] = None,
     repo_type: Optional[str] = None,
+    revision: Optional[str] = None,
+    endpoint: Optional[str] = None,
     cache_dir: Union[str, Path, None] = None,
     local_dir: Union[str, Path, None] = None,
     local_dir_use_symlinks: Union[bool, Literal["auto"]] = "auto",
@@ -71,12 +72,15 @@ def snapshot_download(
     Args:
         repo_id (`str`):
             A user or an organization name and a repo name separated by a `/`.
-        revision (`str`, *optional*):
-            An optional Git revision id which can be a branch name, a tag, or a
-            commit hash.
         repo_type (`str`, *optional*):
             Set to `"dataset"` or `"space"` if downloading from a dataset or space,
             `None` or `"model"` if downloading from a model. Default is `None`.
+        revision (`str`, *optional*):
+            An optional Git revision id which can be a branch name, a tag, or a
+            commit hash.
+        endpoint (`str`, *optional*):
+            Hugging Face Hub base url. Will default to https://huggingface.co/. Otherwise, one can set the `HF_ENDPOINT`
+            environment variable.
         cache_dir (`str`, `Path`, *optional*):
             Path to the folder where cached files are stored.
         local_dir (`str` or `Path`, *optional*:
@@ -181,7 +185,7 @@ def snapshot_download(
         )
 
     # if we have internet connection we retrieve the correct folder name from the huggingface api
-    api = HfApi(library_name=library_name, library_version=library_version, user_agent=user_agent)
+    api = HfApi(library_name=library_name, library_version=library_version, user_agent=user_agent, endpoint=endpoint)
     repo_info = api.repo_info(repo_id=repo_id, repo_type=repo_type, revision=revision, token=token)
     assert repo_info.sha is not None, "Repo info returned from server must have a revision sha."
 
@@ -212,6 +216,7 @@ def snapshot_download(
             filename=repo_file,
             repo_type=repo_type,
             revision=commit_hash,
+            endpoint=endpoint,
             cache_dir=cache_dir,
             local_dir=local_dir,
             local_dir_use_symlinks=local_dir_use_symlinks,

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -26,8 +26,8 @@ from huggingface_hub import constants
 from . import __version__  # noqa: F401 # for backward compatibility
 from .constants import (
     DEFAULT_REVISION,
-    HF_HUB_DISABLE_SYMLINKS_WARNING,
     ENDPOINT,
+    HF_HUB_DISABLE_SYMLINKS_WARNING,
     HF_HUB_ENABLE_HF_TRANSFER,
     HUGGINGFACE_CO_URL_TEMPLATE,
     HUGGINGFACE_HEADER_X_LINKED_ETAG,

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -864,9 +864,8 @@ class HfApi:
 
         Args:
             endpoint (`str`, *optional*):
-                Hugging Face Hub base url. Will default to https://huggingface.co/. To
-                be set if you are using a private hub. Otherwise, one can set the
-                `HF_ENDPOINT` environment variable.
+                Hugging Face Hub base url. Will default to https://huggingface.co/. Otherwise,
+                one can set the `HF_ENDPOINT` environment variable.
             token (`str`, *optional*):
                 Hugging Face token. Will default to the locally saved token if
                 not provided.

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -361,6 +361,21 @@ class CachedDownloadTests(unittest.TestCase):
             )
         )
 
+    @patch("huggingface_hub.file_download.ENDPOINT", "https://huggingface.co")
+    @patch(
+        "huggingface_hub.file_download.HUGGINGFACE_CO_URL_TEMPLATE",
+        "https://huggingface.co/{repo_id}/resolve/{revision}/{filename}",
+    )
+    def test_hf_hub_url_with_endpoint(self):
+        self.assertEqual(
+            hf_hub_url(
+                DUMMY_MODEL_ID,
+                filename=CONFIG_NAME,
+                endpoint="https://hf-ci.co",
+            ),
+            "https://hf-ci.co/julien-c/dummy-unknown/resolve/main/config.json",
+        )
+
     def test_hf_hub_download_legacy(self):
         filepath = hf_hub_download(
             DUMMY_MODEL_ID,

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2512,6 +2512,76 @@ class TestCommitInBackground(HfApiCommonTest):
         self.assertEqual(info_2.likes, 0)
 
 
+class TestDownloadHfApiAlias(unittest.TestCase):
+    def setUp(self) -> None:
+        self.api = HfApi(
+            endpoint="https://hf.co",
+            token="user_token",
+            library_name="cool_one",
+            library_version="1.0.0",
+            user_agent="myself",
+        )
+        return super().setUp()
+
+    @patch("huggingface_hub.file_download.hf_hub_download")
+    def test_hf_hub_download_alias(self, mock: Mock) -> None:
+        self.api.hf_hub_download("my_repo_id", "file.txt")
+        mock.assert_called_once_with(
+            # Call values
+            repo_id="my_repo_id",
+            filename="file.txt",
+            # HfAPI values
+            endpoint="https://hf.co",
+            library_name="cool_one",
+            library_version="1.0.0",
+            user_agent="myself",
+            token="user_token",
+            # Default values
+            subfolder=None,
+            repo_type=None,
+            revision=None,
+            cache_dir=None,
+            local_dir=None,
+            local_dir_use_symlinks="auto",
+            force_download=False,
+            force_filename=None,
+            proxies=None,
+            etag_timeout=10,
+            resume_download=False,
+            local_files_only=False,
+            legacy_cache_layout=False,
+        )
+
+    @patch("huggingface_hub._snapshot_download.snapshot_download")
+    def test_snapshot_download_alias(self, mock: Mock) -> None:
+        self.api.snapshot_download("my_repo_id")
+        mock.assert_called_once_with(
+            # Call values
+            repo_id="my_repo_id",
+            # HfAPI values
+            endpoint="https://hf.co",
+            library_name="cool_one",
+            library_version="1.0.0",
+            user_agent="myself",
+            token="user_token",
+            # Default values
+            repo_type=None,
+            revision=None,
+            cache_dir=None,
+            local_dir=None,
+            local_dir_use_symlinks="auto",
+            proxies=None,
+            etag_timeout=10,
+            resume_download=False,
+            force_download=False,
+            local_files_only=False,
+            allow_patterns=None,
+            ignore_patterns=None,
+            max_workers=8,
+            tqdm_class=None,
+        )
+
+
 class TestSpaceAPIMocked(unittest.TestCase):
     """
     Testing Space hardware requests is resource intensive for the server (need to spawn


### PR DESCRIPTION
FIX #1573 and #1082.

- Add `endpoint` to both `hf_hub_download` and `snapshot_download`. Let's be honest, this is used only in unit tests to change to staging endpoint. At least it is aligned with other methods from huggingface_hub (was not the case before)
- Add `hf_hub_download` and `snapshot_download` as aliases in `HfApi` class. Idea has been discussed [on slack](https://huggingface.slack.com/archives/C02V5EA0A95/p1690546593081429) (internal link). The main goal is to reuse endpoint, user-agent, token,... parameters from the HfApi instance instead of passing them into each individual call (same as `upload_file` and `upload_folder` currently).   

cc @severo @mariosasko for #1082 
cc @Narsil @hysts for #1573 

(note: failing tests are unrelated)