### PR TITLE
FIX `text_to_image` and `image_to_image` parameters

### DIFF
--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -1202,7 +1202,7 @@ class InferenceClient:
         }
         for key, value in parameters.items():
             if value is not None:
-                payload.setdefault("parameters", {})[key] = value
+                payload.setdefault("parameters", {})[key] = value  # type: ignore
         response = self.post(json=payload, model=model, task="text-to-image")
         return _bytes_to_image(response)
 

--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -584,7 +584,7 @@ class InferenceClient:
             payload = {"inputs": _b64_encode(image)}
             for key, value in parameters.items():
                 if value is not None:
-                    payload[key] = value
+                    payload.setdefault("parameters", {})[key] = value
 
         response = self.post(json=payload, data=data, model=model, task="image-to-image")
         return _bytes_to_image(response)
@@ -1191,8 +1191,8 @@ class InferenceClient:
         >>> image.save("better_astronaut.png")
         ```
         """
+        payload = {"inputs": prompt}
         parameters = {
-            "inputs": prompt,
             "negative_prompt": negative_prompt,
             "height": height,
             "width": width,
@@ -1200,10 +1200,9 @@ class InferenceClient:
             "guidance_scale": guidance_scale,
             **kwargs,
         }
-        payload = {}
         for key, value in parameters.items():
             if value is not None:
-                payload[key] = value
+                payload.setdefault("parameters", {})[key] = value
         response = self.post(json=payload, model=model, task="text-to-image")
         return _bytes_to_image(response)
 

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -587,7 +587,7 @@ class AsyncInferenceClient:
             payload = {"inputs": _b64_encode(image)}
             for key, value in parameters.items():
                 if value is not None:
-                    payload[key] = value
+                    payload.setdefault("parameters", {})[key] = value
 
         response = await self.post(json=payload, data=data, model=model, task="image-to-image")
         return _bytes_to_image(response)
@@ -1201,8 +1201,8 @@ class AsyncInferenceClient:
         >>> image.save("better_astronaut.png")
         ```
         """
+        payload = {"inputs": prompt}
         parameters = {
-            "inputs": prompt,
             "negative_prompt": negative_prompt,
             "height": height,
             "width": width,
@@ -1210,10 +1210,9 @@ class AsyncInferenceClient:
             "guidance_scale": guidance_scale,
             **kwargs,
         }
-        payload = {}
         for key, value in parameters.items():
             if value is not None:
-                payload[key] = value
+                payload.setdefault("parameters", {})[key] = value
         response = await self.post(json=payload, model=model, task="text-to-image")
         return _bytes_to_image(response)
 

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -1212,7 +1212,7 @@ class AsyncInferenceClient:
         }
         for key, value in parameters.items():
             if value is not None:
-                payload.setdefault("parameters", {})[key] = value
+                payload.setdefault("parameters", {})[key] = value  # type: ignore
         response = await self.post(json=payload, model=model, task="text-to-image")
         return _bytes_to_image(response)
 

--- a/tests/cassettes/InferenceClientVCRTest.test_text_to_image_with_parameters.yaml
+++ b/tests/cassettes/InferenceClientVCRTest.test_text_to_image_with_parameters.yaml
@@ -1,0 +1,85 @@
+interactions:
+- request:
+    body: '{"inputs": "An astronaut riding a horse on the moon.", "parameters": {"height":
+      256, "width": 256}}'
+    headers:
+      Accept:
+      - image/png
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '99'
+      Content-Type:
+      - application/json
+      X-Amzn-Trace-Id:
+      - 80500044-fca9-4da8-852f-cceab99d4237
+      user-agent:
+      - unknown/None; hf_hub/0.17.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: POST
+    uri: https://api-inference.huggingface.co/models/CompVis/stable-diffusion-v1-4
+  response:
+    body:
+      string: !!binary |
+        /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+        HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+        MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAEAAQADASIA
+        AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+        AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+        ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+        p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+        AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+        BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+        U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+        uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD5/ooo
+        oAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiig
+        AooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKAC
+        iiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKK
+        KKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooo
+        oAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiig
+        AooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKAC
+        iiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKK
+        KKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooo
+        oAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiig
+        AooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKAC
+        iiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKK
+        KKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooo
+        oAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiig
+        AooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKAC
+        iiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKK
+        KKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooo
+        oAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiig
+        AooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooA//2Q==
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - image/jpeg
+      Date:
+      - Tue, 08 Aug 2023 15:04:36 GMT
+      Transfer-Encoding:
+      - chunked
+      access-control-allow-credentials:
+      - 'true'
+      access-control-expose-headers:
+      - x-compute-type, x-compute-time
+      server:
+      - uvicorn
+      vary:
+      - Accept-Encoding, Origin, Access-Control-Request-Method, Access-Control-Request-Headers
+      x-compute-characters:
+      - '40'
+      x-compute-time:
+      - '7.963'
+      x-compute-type:
+      - gpu
+      x-request-id:
+      - ZoNeWSWrDPcWSjrZm6T_3
+      x-sha:
+      - b95be7d6f134c3a9e62ee616f310733567f069ce
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_inference_client.py
+++ b/tests/test_inference_client.py
@@ -203,11 +203,17 @@ class InferenceClientVCRTest(InferenceClientTest):
     def test_text_generation(self) -> None:
         """Tested separately in `test_inference_text_generation.py`."""
 
-    def test_text_to_image(self) -> None:
+    def test_text_to_image_default(self) -> None:
         image = self.client.text_to_image("An astronaut riding a horse on the moon.")
         self.assertIsInstance(image, Image.Image)
         self.assertEqual(image.height, 768)
         self.assertEqual(image.width, 768)
+
+    def test_text_to_image_with_parameters(self) -> None:
+        image = self.client.text_to_image("An astronaut riding a horse on the moon.", height=256, width=256)
+        self.assertIsInstance(image, Image.Image)
+        self.assertEqual(image.height, 256)
+        self.assertEqual(image.width, 256)
 
     def test_text_to_speech(self) -> None:
         audio = self.client.text_to_speech("Hello world")


### PR DESCRIPTION
Fix https://github.com/huggingface/huggingface_hub/issues/1581 (cc @zwx00)

Extra parameters (width, height, guidance_scale,...) are ignored by `InferenceClient` when using `text_to_image` and `image_to_image` tasks. This was due to an invalid payload being sent to the server. This PR fixes it + add a test. 