### PR TITLE
Support factory reboot when restarting a Space

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -5172,7 +5172,9 @@ class HfApi:
         return SpaceRuntime(r.json())
 
     @validate_hf_hub_args
-    def restart_space(self, repo_id: str, *, token: Optional[str] = None) -> SpaceRuntime:
+    def restart_space(
+        self, repo_id: str, *, token: Optional[str] = None, factory_reboot: bool = False
+    ) -> SpaceRuntime:
         """Restart your Space.
 
         This is the only way to programmatically restart a Space if you've put it on Pause (see [`pause_space`]). You
@@ -5186,6 +5188,8 @@ class HfApi:
                 ID of the Space to restart. Example: `"Salesforce/BLIP2"`.
             token (`str`, *optional*):
                 Hugging Face token. Will default to the locally saved token if not provided.
+            factory_reboot (`bool`, *optional*):
+                If `True`, the Space will be rebuilt from scratch without caching any requirements.
 
         Returns:
             [`SpaceRuntime`]: Runtime information about your Space.
@@ -5201,8 +5205,11 @@ class HfApi:
                 If your Space is a static Space. Static Spaces are always running and never billed. If you want to hide
                 a static Space, you can set it to private.
         """
+        payload = {}
+        if factory_reboot:
+            payload["factory"] = "true"
         r = get_session().post(
-            f"{self.endpoint}/api/spaces/{repo_id}/restart", headers=self._build_hf_headers(token=token)
+            f"{self.endpoint}/api/spaces/{repo_id}/restart", headers=self._build_hf_headers(token=token), json=payload
         )
         hf_raise_for_status(r)
         return SpaceRuntime(r.json())

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -5205,11 +5205,11 @@ class HfApi:
                 If your Space is a static Space. Static Spaces are always running and never billed. If you want to hide
                 a static Space, you can set it to private.
         """
-        payload = {}
+        params = {}
         if factory_reboot:
-            payload["factory"] = "true"
+            params["factory"] = "true"
         r = get_session().post(
-            f"{self.endpoint}/api/spaces/{repo_id}/restart", headers=self._build_hf_headers(token=token), json=payload
+            f"{self.endpoint}/api/spaces/{repo_id}/restart", headers=self._build_hf_headers(token=token), params=params
         )
         hf_raise_for_status(r)
         return SpaceRuntime(r.json())

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2696,7 +2696,7 @@ class TestSpaceAPIMocked(unittest.TestCase):
         self.post_mock.assert_called_once_with(
             f"{self.api.endpoint}/api/spaces/{self.repo_id}/restart",
             headers=self.api._build_hf_headers(),
-            json={"factory": "true"},
+            params={"factory": "true"},
         )
 
 

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2691,6 +2691,14 @@ class TestSpaceAPIMocked(unittest.TestCase):
         )
         assert runtime.storage is None
 
+    def test_restart_space_factory_reboot(self) -> None:
+        self.api.restart_space(self.repo_id, factory_reboot=True)
+        self.post_mock.assert_called_once_with(
+            f"{self.api.endpoint}/api/spaces/{self.repo_id}/restart",
+            headers=self.api._build_hf_headers(),
+            json={"factory": "true"},
+        )
+
 
 class ListGitRefsTest(unittest.TestCase):
     @classmethod


### PR DESCRIPTION
Solves #1585 cc @osanseviero @christophe-rannou. 
Add support for factory reboot when restarting a Space.

```py
from huggingface_hub import restart_space

restart_space("Wauplin/bloomz.cpp-converter", factory_reboot=True)
```