### PR TITLE
Add translation to inference client

### DIFF
--- a/docs/source/guides/inference.md
+++ b/docs/source/guides/inference.md
@@ -142,7 +142,7 @@ has a simple API that supports the most common tasks. Here is a list of the curr
 | | [Text Classification](https://huggingface.co/tasks/text-classification)            | |  |
 | | [Text Generation](https://huggingface.co/tasks/text-generation)   | ✅ | [`~InferenceClient.text_generation`] |
 | | [Token Classification](https://huggingface.co/tasks/token-classification)           | |  |
-| | [Translation](https://huggingface.co/tasks/translation)       | |  |
+| | [Translation](https://huggingface.co/tasks/translation)       | ✅ | [`~InferenceClient.translation`] |
 | | [Zero Shot Classification](https://huggingface.co/tasks/zero-shot-image-classification)       | |  |
 | Tabular | [Tabular Classification](https://huggingface.co/tasks/tabular-classification)         | |  |
 | | [Tabular Regression](https://huggingface.co/tasks/tabular-regression)             | |  |

--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -80,6 +80,7 @@ from huggingface_hub.inference._types import (
     ConversationalOutput,
     ImageSegmentationOutput,
     ObjectDetectionOutput,
+    TranslationOutput,
 )
 from huggingface_hub.utils import (
     BadRequestError,
@@ -1237,6 +1238,51 @@ class InferenceClient:
         ```
         """
         return self.post(json={"inputs": text}, model=model, task="text-to-speech")
+
+    def translation(
+        self, text: List[str], *, parameters: Optional[Dict[str, Any]] = None, model: Optional[str] = None
+    ) -> List[TranslationOutput]:
+        """
+        Convert text from one language to another.
+
+        Args:
+            text (`str`):
+                A list of strings to be translated.
+            parameters (`Dict[str, Any]`, *optional*):
+                Additional parameters for the translation task. Defaults to None. For more details about the available
+                parameters, please refer to [this page](https://huggingface.co/docs/api-inference/detailed_parameters#translation-task)
+            model (`str`, *optional*):
+                The model to use for the translation task. Can be a model ID hosted on the Hugging Face Hub or a URL to
+                a deployed Inference Endpoint. If not provided, the default recommended translation model will be used.
+                Defaults to None.
+
+        Returns:
+            `List[Dict]`: a list of dictionaries containing the translated text.
+
+        Raises:
+            [`InferenceTimeoutError`]:
+                If the model is unavailable or the request times out.
+            `HTTPError`:
+                If the request fails with an HTTP error status code other than HTTP 503.
+
+        Example:
+        ```py
+        >>> from huggingface_hub import InferenceClient
+        >>> client = InferenceClient()
+        >>> output = client.translation("My name is Wolfgang and I live in Berlin")
+        >>> output
+        [{'translation_text': 'Mein Name ist Wolfgang und ich lebe in Berlin.'}]
+        ```
+        """
+        payload: Dict[str, Any] = {"inputs": text}
+        if parameters is not None:
+            payload["parameters"] = parameters
+        response = self.post(
+            json=payload,
+            model=model,
+            task="translation",
+        )
+        return _bytes_to_dict(response)
 
     def zero_shot_image_classification(
         self, image: ContentT, labels: List[str], *, model: Optional[str] = None

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -64,6 +64,7 @@ from huggingface_hub.inference._types import (
     ConversationalOutput,
     ImageSegmentationOutput,
     ObjectDetectionOutput,
+    TranslationOutput,
 )
 from huggingface_hub.utils import (
     build_hf_headers,
@@ -1248,6 +1249,52 @@ class AsyncInferenceClient:
         ```
         """
         return await self.post(json={"inputs": text}, model=model, task="text-to-speech")
+
+    async def translation(
+        self, text: List[str], *, parameters: Optional[Dict[str, Any]] = None, model: Optional[str] = None
+    ) -> List[TranslationOutput]:
+        """
+        Convert text from one language to another.
+
+        Args:
+            text (`str`):
+                A list of strings to be translated.
+            parameters (`Dict[str, Any]`, *optional*):
+                Additional parameters for the translation task. Defaults to None. For more details about the available
+                parameters, please refer to [this page](https://huggingface.co/docs/api-inference/detailed_parameters#translation-task)
+            model (`str`, *optional*):
+                The model to use for the translation task. Can be a model ID hosted on the Hugging Face Hub or a URL to
+                a deployed Inference Endpoint. If not provided, the default recommended translation model will be used.
+                Defaults to None.
+
+        Returns:
+            `List[Dict]`: a list of dictionaries containing the translated text.
+
+        Raises:
+            [`InferenceTimeoutError`]:
+                If the model is unavailable or the request times out.
+            `aiohttp.ClientResponseError`:
+                If the request fails with an HTTP error status code other than HTTP 503.
+
+        Example:
+        ```py
+        # Must be run in an async context
+        >>> from huggingface_hub import AsyncInferenceClient
+        >>> client = AsyncInferenceClient()
+        >>> output = await client.translation("My name is Wolfgang and I live in Berlin")
+        >>> output
+        [{'translation_text': 'Mein Name ist Wolfgang und ich lebe in Berlin.'}]
+        ```
+        """
+        payload: Dict[str, Any] = {"inputs": text}
+        if parameters is not None:
+            payload["parameters"] = parameters
+        response = await self.post(
+            json=payload,
+            model=model,
+            task="translation",
+        )
+        return _bytes_to_dict(response)
 
     async def zero_shot_image_classification(
         self, image: ContentT, labels: List[str], *, model: Optional[str] = None

--- a/src/huggingface_hub/inference/_types.py
+++ b/src/huggingface_hub/inference/_types.py
@@ -98,3 +98,14 @@ class ObjectDetectionOutput(TypedDict):
     label: str
     box: dict
     score: float
+
+
+class TranslationOutput(TypedDict):
+    """Dictionary containing information about a [`~InferenceClient.translation`] task.
+
+    Args:
+        translation_text (`str`):
+            The translated text.
+    """
+
+    trasnlation_text: str

--- a/tests/cassettes/InferenceClientVCRTest.test_translation.yaml
+++ b/tests/cassettes/InferenceClientVCRTest.test_translation.yaml
@@ -1,0 +1,48 @@
+interactions:
+- request:
+    body: '{"inputs": "Hello world"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '25'
+      Content-Type:
+      - application/json
+      X-Amzn-Trace-Id:
+      - 4a43b00f-51f2-4e1a-86ba-92e4606509be
+      user-agent:
+      - unknown/None; hf_hub/0.17.0.dev0; python/3.10.12
+    method: POST
+    uri: https://api-inference.huggingface.co/models/t5-small
+  response:
+    body:
+      string: '[{"translation_text":"Hallo Welt"}]'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '35'
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 20 Aug 2023 14:32:31 GMT
+      access-control-allow-credentials:
+      - 'true'
+      vary:
+      - Origin, Access-Control-Request-Method, Access-Control-Request-Headers
+      x-compute-time:
+      - '0.084'
+      x-compute-type:
+      - cache
+      x-request-id:
+      - FcgAtoJb-BUKbk49I4_Km
+      x-sha:
+      - df1b051c49625cf57a3d0d8d3863ed4d13564fe4
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_inference_client.py
+++ b/tests/test_inference_client.py
@@ -219,6 +219,14 @@ class InferenceClientVCRTest(InferenceClientTest):
         audio = self.client.text_to_speech("Hello world")
         self.assertIsInstance(audio, bytes)
 
+    def test_translation(self) -> None:
+        model = "t5-small"
+        output = self.client.translation("Hello world", model=model)
+        self.assertIsInstance(output, list)
+        self.assertGreater(len(output), 0)
+        for item in output:
+            self.assertIsInstance(item["translation_text"], str)
+
     def test_zero_shot_image_classification(self) -> None:
         output = self.client.zero_shot_image_classification(self.image_file, ["tree", "woman", "cat"])
         self.assertIsInstance(output, list)


### PR DESCRIPTION
**Add translation to HuggingFace🤗 Hub**

References https://github.com/huggingface/huggingface_hub/issues/1539

This is an ongoing list of model tasks to implement in the Hugging Face Hub inference client. Each task is planned to be its own PR. The task for this is [translation](https://huggingface.co/tasks/translation).

**Key Features**

- Modifies _client.py to call a translation model.
- Modifies testing and documentation to reflect changes.