### PR TITLE
Add table question answering to inference client

### DIFF
--- a/docs/source/guides/inference.md
+++ b/docs/source/guides/inference.md
@@ -138,7 +138,7 @@ has a simple API that supports the most common tasks. Here is a list of the curr
 | | [Question Answering](https://huggingface.co/tasks/question-answering)             |              |  |
 | | [Sentence Similarity](https://huggingface.co/tasks/sentence-similarity)            | ✅ | [`~InferenceClient.sentence_similarity`] |
 | | [Summarization](https://huggingface.co/tasks/summarization)                  | ✅ | [`~InferenceClient.summarization`] |
-| | [Table Question Answering](https://huggingface.co/tasks/table-question-answering)       | |  |
+| | [Table Question Answering](https://huggingface.co/tasks/table-question-answering)       | ✅ | [`~InferenceClient.table-question-answering`] |
 | | [Text Classification](https://huggingface.co/tasks/text-classification)            | |  |
 | | [Text Generation](https://huggingface.co/tasks/text-generation)   | ✅ | [`~InferenceClient.text_generation`] |
 | | [Token Classification](https://huggingface.co/tasks/token-classification)           | |  |

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -64,6 +64,7 @@ from huggingface_hub.inference._types import (
     ConversationalOutput,
     ImageSegmentationOutput,
     ObjectDetectionOutput,
+    QuestionAnsweringOutput,
 )
 from huggingface_hub.utils import (
     build_hf_headers,
@@ -769,6 +770,75 @@ class AsyncInferenceClient:
             payload["parameters"] = parameters
         response = await self.post(json=payload, model=model, task="summarization")
         return _bytes_to_dict(response)[0]["summary_text"]
+
+    async def table_question_answering(
+        self,
+        query: List[str],
+        table: Dict[str, Any],
+        model: Optional[str],
+        *,
+        parameters: Optional[Dict[str, Any]] = None,
+    ) -> List[QuestionAnsweringOutput]:
+        """
+        Retrieve the answer to a question from information given in a table.
+
+        Args:
+            query (`str`):
+                The query in plain text that you want to ask the table.
+            table (`str`):
+                A table of data represented as a dict of lists where entries are headers and the lists are all the values, all lists must have the same size.
+            model (`str`):
+                The model to use for the table-question-answering task. Can be a model ID hosted on the Hugging Face Hub or a URL to
+                a deployed Inference Endpoint.
+            parameters (`Dict[str, Any]`, *optional*):
+                Additional parameters for the table-question-answering task. Defaults to None. For more details about the available
+                parameters, please refer to [this page](https://huggingface.co/docs/api-inference/detailed_parameters#table-question-answering-task)
+
+        Returns:
+            `Dict`: a dictionary containing:
+            - answer:	    The plaintext answer.
+            - coordinates:	A list of coordinates of the cells referenced in the answer.
+            - cells:	    A list of coordinates of the cells contents.
+            - aggregator:	The aggregator used to get the answer.
+
+        Raises:
+            [`InferenceTimeoutError`]:
+                If the model is unavailable or the request times out.
+            `aiohttp.ClientResponseError`:
+                If the request fails with an HTTP error status code other than HTTP 503.
+
+        Example:
+        ```py
+        # Must be run in an async context
+        >>> from huggingface_hub import AsyncInferenceClient
+        >>> client = AsyncInferenceClient()
+        >>> query = "How many stars does the transformers repository have?"
+        >>> table = {
+            "Repository": ["Transformers", "Datasets", "Tokenizers"],
+            "Stars": ["36542", "4512", "3934"],
+        }
+        >>> output = await client.table_question_answering(query=query, table=table, model="google/tapas-base-finetuned-wtq")
+        >>> output
+        {'answer': 'AVERAGE > 36542',
+        'coordinates': [[0, 1]],
+        'cells': ['36542'],
+        'aggregator': 'AVERAGE'}
+        ```
+        """
+        if model is None:
+            raise ValueError(
+                "You must specify a model. Task table-question-answering has no recommended standard model."
+            )
+
+        payload: Dict[str, Any] = {"query": query, "table": table}
+        if parameters is not None:
+            payload["parameters"] = parameters
+        response = await self.post(
+            json=payload,
+            model=model,
+            task="table-question-answering",
+        )
+        return _bytes_to_dict(response)
 
     @overload
     async def text_generation(  # type: ignore

--- a/src/huggingface_hub/inference/_types.py
+++ b/src/huggingface_hub/inference/_types.py
@@ -98,3 +98,21 @@ class ObjectDetectionOutput(TypedDict):
     label: str
     box: dict
     score: float
+
+
+class QuestionAnsweringOutput(TypedDict):
+    """Dictionary containing information about a [`~InferenceClient.question_answering`] task.
+    Args:
+        label (`str`):
+            The label corresponding to the detected object.
+        box (`dict`):
+            A dict response of bounding box coordinates of
+            the detected object: xmin, ymin, xmax, ymax
+        score (`float`):
+            The score corresponding to the detected object.
+    """
+
+    score: float
+    start: int
+    end: int
+    answer: str

--- a/tests/test_inference_client.py
+++ b/tests/test_inference_client.py
@@ -200,6 +200,25 @@ class InferenceClientVCRTest(InferenceClientTest):
             " surpassed the Washington Monument to become the tallest man-made structure in the world.",
         )
 
+    def test_table_question_answering(self) -> None:
+        table = {
+            "Repository": ["Transformers", "Datasets", "Tokenizers"],
+            "Stars": ["36542", "4512", "3934"],
+        }
+        query = [
+            "How many stars does the transformers repository have?",
+            "What is the total of stars?",
+        ]
+        model = "google/tapas-base-finetuned-wtq"
+        output = self.client.table_question_answering(query=query, table=table, model=model)
+        self.assertEqual(type(output), list)
+        self.assertEqual(len(output[0]), 4)
+        self.assertEqual(type(output[0]), dict)
+        self.assertEqual(
+            set(k for el in output for k in el.keys()),
+            {"aggregator", "answer", "cells", "coordinates"},
+        )
+
     def test_text_generation(self) -> None:
         """Tested separately in `test_inference_text_generation.py`."""
 


### PR DESCRIPTION
**Add translation to HuggingFace🤗 Hub**

References https://github.com/huggingface/huggingface_hub/issues/1539

This is an ongoing list of model tasks to implement in the Hugging Face Hub inference client. Each task is planned to be its own PR. The task for this is [table-question-answering](https://huggingface.co/tasks/table-question-answering).

**Key Features**

- Modifies _client.py to call a table-question-answering model.
- Modifies testing and documentation to reflect changes.