### PR TITLE
Fix i18n issue template links

### DIFF
--- a/.github/ISSUE_TEMPLATE/i18n.md
+++ b/.github/ISSUE_TEMPLATE/i18n.md
@@ -37,19 +37,19 @@ Some notes:
 - [ ] [installation.md](https://github.com/huggingface/huggingface_hub/blob/main/docs/source/en/installation.md).
 
 ## Guides section
-- [ ]  [community.md](https://github.com/huggingface/huggingface_hub/blob/main/docs/source/en/community.md)
-- [ ]  [download.md](https://github.com/huggingface/huggingface_hub/blob/master/docs/source/download.md)
-- [ ]  [hf_file_system.md](https://github.com/huggingface/huggingface_hub/blob/main/docs/source/en/hf_file_system.md)
-- [ ]  [inference.md](https://github.com/huggingface/huggingface_hub/blob/main/docs/source/en/inference.md)
-- [ ]  [integrations.md](https://github.com/huggingface/huggingface_hub/blob/main/docs/source/en/integrations.md)
-- [ ]  [manage-cache.md](https://github.com/huggingface/huggingface_hub/blob/main/docs/source/en/manage-cache.md)
+- [ ]  [community.md](https://github.com/huggingface/huggingface_hub/blob/main/docs/source/en/guides/community.md)
+- [ ]  [download.md](https://github.com/huggingface/huggingface_hub/blob/master/docs/source/guides/download.md)
+- [ ]  [hf_file_system.md](https://github.com/huggingface/huggingface_hub/blob/main/docs/source/en/guides/hf_file_system.md)
+- [ ]  [inference.md](https://github.com/huggingface/huggingface_hub/blob/main/docs/source/en/guides/inference.md)
+- [ ]  [integrations.md](https://github.com/huggingface/huggingface_hub/blob/main/docs/source/en/guides/integrations.md)
+- [ ]  [manage-cache.md](https://github.com/huggingface/huggingface_hub/blob/main/docs/source/en/guides/manage-cache.md)
 - [ ]  [manage-spaces.md](https://github.com/huggingface/huggingface_hub/blob/main/docs/source/en/manage-spaces.md)
-- [ ]  [model-cards.md](https://github.com/huggingface/huggingface_hub/blob/main/docs/source/en/model-cards.md)
-- [ ]  [overview.md](https://github.com/huggingface/huggingface_hub/blob/main/docs/source/en/preprocessing.md)
-- [ ]  [repository.md](https://github.com/huggingface/huggingface_hub/blob/main/docs/source/en/repository.md)
-- [ ]  [search.md](https://github.com/huggingface/huggingface_hub/blob/main/docs/source/en/search.md)
-- [ ]  [upload.md](https://github.com/huggingface/huggingface_hub/blob/main/docs/source/en/upload.md)
-- [ ]  [webhooks_server.md](https://github.com/huggingface/huggingface_hub/blob/main/docs/source/en/webhooks_server.md)
+- [ ]  [model-cards.md](https://github.com/huggingface/huggingface_hub/blob/main/docs/source/en/guides/model-cards.md)
+- [ ]  [overview.md](https://github.com/huggingface/huggingface_hub/blob/main/docs/source/en/guides/preprocessing.md)
+- [ ]  [repository.md](https://github.com/huggingface/huggingface_hub/blob/main/docs/source/en/guides/repository.md)
+- [ ]  [search.md](https://github.com/huggingface/huggingface_hub/blob/main/docs/source/en/guides/search.md)
+- [ ]  [upload.md](https://github.com/huggingface/huggingface_hub/blob/main/docs/source/en/guides/upload.md)
+- [ ]  [webhooks_server.md](https://github.com/huggingface/huggingface_hub/blob/main/docs/source/en/guides/webhooks_server.md)
 
 <!--
 Keep on adding more as you go 🔥


### PR DESCRIPTION
Following PR https://github.com/huggingface/huggingface_hub/pull/1602 and the related issue https://github.com/huggingface/huggingface_hub/issues/1626 created by @wonhyeongseo. The URLs in the issue template are invalid. This PR fixes it.