### PR TITLE
Fix fsspec tests in ci

### DIFF
--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -130,7 +130,7 @@ class HfFileSystem(fsspec.AbstractFileSystem):
         elif path.split("/")[0] + "/" in REPO_TYPES_URL_PREFIXES.values():
             if "/" not in path:
                 # can't list repositories at the repository type level
-                raise NotImplementedError("Acces to repositories lists is not implemented.")
+                raise NotImplementedError("Access to repositories lists is not implemented.")
             repo_type, path = path.split("/", 1)
             repo_type = REPO_TYPES_MAPPING[repo_type]
         else:
@@ -173,7 +173,7 @@ class HfFileSystem(fsspec.AbstractFileSystem):
                 revision = _align_revision_in_path_with_revision(revision_in_path, revision)
             repo_and_revision_exist, _ = self._repo_and_revision_exist(repo_type, repo_id, revision)
             if not repo_and_revision_exist:
-                raise NotImplementedError("Acces to repositories lists is not implemented.")
+                raise NotImplementedError("Access to repositories lists is not implemented.")
 
         revision = revision if revision is not None else DEFAULT_REVISION
         return HfFileSystemResolvedPath(repo_type, repo_id, revision, path_in_repo)

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -794,7 +794,7 @@ class HfHubDownloadToLocalDir(unittest.TestCase):
                 local_dir_use_symlinks=False,
             )
             self.assertFalse(config_path.is_symlink())
-            self.assertNotEquals(config_path.read_text(), "this will be overwritten")
+            self.assertNotEqual(config_path.read_text(), "this will be overwritten")
 
 
 @pytest.mark.usefixtures("fx_cache_dir")

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2474,7 +2474,7 @@ class TestSpaceAPIProduction(unittest.TestCase):
 
         # Returning all variables created
         variables = self.api.get_space_variables(self.repo_id)
-        self.assertEquals(len(variables), 3)
+        self.assertEqual(len(variables), 3)
 
     def test_space_runtime(self) -> None:
         runtime = self.api.get_space_runtime(self.repo_id)
@@ -2827,14 +2827,14 @@ class ListGitCommitsTest(unittest.TestCase):
         commits = self.api.list_repo_commits(self.repo_id)
 
         # "on_pr" commit not returned
-        self.assertEquals(len(commits), 3)
+        self.assertEqual(len(commits), 3)
         self.assertTrue(all("on_pr" not in commit.title for commit in commits))
 
         # USER is always the author
         self.assertTrue(all(commit.authors == [USER] for commit in commits))
 
         # latest commit first
-        self.assertEquals(commits[0].title, "Upload on_main.txt with huggingface_hub")
+        self.assertEqual(commits[0].title, "Upload on_main.txt with huggingface_hub")
 
         # Formatted field not returned by default
         for commit in commits:
@@ -2845,9 +2845,9 @@ class ListGitCommitsTest(unittest.TestCase):
         commits = self.api.list_repo_commits(self.repo_id, revision="refs/pr/1")
 
         # "on_pr" commit returned but not the "on_main" one
-        self.assertEquals(len(commits), 3)
+        self.assertEqual(len(commits), 3)
         self.assertTrue(all("on_main" not in commit.title for commit in commits))
-        self.assertEquals(commits[0].title, "Upload on_pr.txt with huggingface_hub")
+        self.assertEqual(commits[0].title, "Upload on_pr.txt with huggingface_hub")
 
     def test_list_commits_include_formatted(self) -> None:
         for commit in self.api.list_repo_commits(self.repo_id, formatted=True):

--- a/tests/test_hf_file_system.py
+++ b/tests/test_hf_file_system.py
@@ -277,6 +277,8 @@ def test_resolve_path_with_non_matching_revisions():
 def test_access_repositories_lists(not_supported_path):
     fs = HfFileSystem()
     with pytest.raises(NotImplementedError):
+        fs.info(not_supported_path)
+    with pytest.raises(NotImplementedError):
         fs.ls(not_supported_path)
     with pytest.raises(NotImplementedError):
         fs.glob(not_supported_path + "/")

--- a/tests/test_hf_file_system.py
+++ b/tests/test_hf_file_system.py
@@ -280,8 +280,7 @@ def test_access_repositories_lists(not_supported_path):
         fs.info(not_supported_path)
     with pytest.raises(NotImplementedError):
         fs.ls(not_supported_path)
-    # Skip in test for now (see https://github.com/huggingface/huggingface_hub/pull/1635)
-    # with pytest.raises(NotImplementedError):
-    #     fs.glob(not_supported_path + "/")
+    with pytest.raises(NotImplementedError):
+        fs.glob(not_supported_path + "/")
     with pytest.raises(NotImplementedError):
         fs.open(not_supported_path)


### PR DESCRIPTION
`fsspec.exists` logic catches ALL exceptions which can lead to unexpected behaviors. For example, we raise a `NotImplementedError` when trying to list repositories (which is not supported). This PR adapts the logic to raise on any exception except the `NotImplementedError`.

First discovered about it since `fsspec.glob()` logic has been changed in https://github.com/fsspec/filesystem_spec/pull/1329 (released in [2023.9.0](https://filesystem-spec.readthedocs.io/en/latest/changelog.html#id1)). It now relies on [`.exists()`](https://github.com/fsspec/filesystem_spec/pull/1329/files#diff-02a7ab40d6026e60bf52f78d93fc7146e53bc2455a8cb4073838297feaa090fbR576) instead of `.find()` which catch all exceptions, including the NotImplementedError (making the CI fail)

cc @mariosasko please let me know if you think such a change will lead to unexpected behavior as it's a quite low-level method. I happy to revisit this PR if you have a better idea. I found catching all exceptions quite unnatural in general but maybe I'm wrong. 