### PR TITLE
Add `missing_ok` option in `delete_repo`

### DIFF
--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -210,6 +210,10 @@ class HfApiEndpointsTest(HfApiCommonTest):
             self._api.delete_repo("repo-that-does-not-exist")
 
     @retry_endpoint
+    def test_delete_repo_missing_ok(self)->None:
+        self._api.delete_repo("repo-that-does-not-exist", missing_ok=True)
+
+    @retry_endpoint
     def test_create_update_and_delete_repo(self):
         REPO_NAME = repo_name("crud")
         self._api.create_repo(repo_id=REPO_NAME)


### PR DESCRIPTION
Similar to `create_repo(..., exists_ok=True)`, it'd be convenient to have a `delete_ok(..., missing_ok=True)`. I get annoyed when doing local tests otherwise :smile: 