### PR TITLE
Add support for zero shot classification task

### DIFF
--- a/docs/source/en/guides/inference.md
+++ b/docs/source/en/guides/inference.md
@@ -143,13 +143,9 @@ has a simple API that supports the most common tasks. Here is a list of the curr
 | | [Text Generation](https://huggingface.co/tasks/text-generation)   | ✅ | [`~InferenceClient.text_generation`] |
 | | [Token Classification](https://huggingface.co/tasks/token-classification)           | ✅ | [`~InferenceClient.token_classification`] |
 | | [Translation](https://huggingface.co/tasks/translation)       | ✅ | [`~InferenceClient.translation`] |
-| | [Zero Shot Classification](https://huggingface.co/tasks/zero-shot-image-classification)       | |  |
+| | [Zero Shot Classification](https://huggingface.co/tasks/zero-shot-image-classification)       | ✅ | [`~InferenceClient.zero_shot_classification`] |
 | Tabular | [Tabular Classification](https://huggingface.co/tasks/tabular-classification)         | ✅ | [`~InferenceClient.tabular_classification`] |
 | | [Tabular Regression](https://huggingface.co/tasks/tabular-regression)             | ✅ | [`~InferenceClient.tabular_regression`] |
-
-
-This table is meant to be completed to support all tasks. If you are particularly interested in a task not yet supported,
-please let us know on [huggingface_hub's repo](https://github.com/huggingface/huggingface_hub).
 
 <Tip>
 

--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -1654,6 +1654,78 @@ class InferenceClient:
         response = self.post(json={"inputs": text}, model=model, task="translation")
         return _bytes_to_dict(response)[0]["translation_text"]
 
+    def zero_shot_classification(
+        self, text: str, labels: List[str], *, multi_label: bool = False, model: Optional[str] = None
+    ) -> List[ClassificationOutput]:
+        """
+        Provide as input a text and a set of candidate labels to classify the input text.
+
+        Args:
+            text (`str`):
+                The input text to classify.
+            labels (`List[str]`):
+                List of string possible labels. There must be at least 2 labels.
+            multi_label (`bool`):
+                Boolean that is set to True if classes can overlap.
+            model (`str`, *optional*):
+                The model to use for inference. Can be a model ID hosted on the Hugging Face Hub or a URL to a deployed
+                Inference Endpoint. This parameter overrides the model defined at the instance level. Defaults to None.
+
+        Returns:
+            `List[Dict]`: List of classification outputs containing the predicted labels and their confidence.
+
+        Raises:
+            [`InferenceTimeoutError`]:
+                If the model is unavailable or the request times out.
+            `HTTPError`:
+                If the request fails with an HTTP error status code other than HTTP 503.
+
+        Example:
+        ```py
+        >>> from huggingface_hub import InferenceClient
+        >>> client = InferenceClient()
+        >>> text = (
+        ...     "A new model offers an explanation for how the Galilean satellites formed around the solar system's"
+        ...     "largest world. Konstantin Batygin did not set out to solve one of the solar system's most puzzling"
+        ...     " mysteries when he went for a run up a hill in Nice, France."
+        ... )
+        >>> labels = ["space & cosmos", "scientific discovery", "microbiology", "robots", "archeology"]
+        >>> client.zero_shot_classification(text, labels)
+        [
+            {"label": "scientific discovery", "score": 0.7961668968200684},
+            {"label": "space & cosmos", "score": 0.18570658564567566},
+            {"label": "microbiology", "score": 0.00730885099619627},
+            {"label": "archeology", "score": 0.006258360575884581},
+            {"label": "robots", "score": 0.004559356719255447},
+        ]
+        >>> client.zero_shot_classification(text, labels, multi_label=True)
+        [
+            {"label": "scientific discovery", "score": 0.9829297661781311},
+            {"label": "space & cosmos", "score": 0.755190908908844},
+            {"label": "microbiology", "score": 0.0005462635890580714},
+            {"label": "archeology", "score": 0.00047131875180639327},
+            {"label": "robots", "score": 0.00030448526376858354},
+        ]
+        ```
+        """
+        # Raise ValueError if input is less than 2 labels
+        if len(labels) < 2:
+            raise ValueError("You must specify at least 2 classes to compare.")
+
+        response = self.post(
+            json={
+                "inputs": text,
+                "parameters": {
+                    "candidate_labels": ",".join(labels),
+                    "multi_label": multi_label,
+                },
+            },
+            model=model,
+            task="zero-shot-classification",
+        )
+        output = _bytes_to_dict(response)
+        return [{"label": label, "score": score} for label, score in zip(output["labels"], output["scores"])]
+
     def zero_shot_image_classification(
         self, image: ContentT, labels: List[str], *, model: Optional[str] = None
     ) -> List[ClassificationOutput]:
@@ -1664,7 +1736,7 @@ class InferenceClient:
             image (`Union[str, Path, bytes, BinaryIO]`):
                 The input image to caption. It can be raw bytes, an image file, or a URL to an online image.
             labels (`List[str]`):
-                List of string possible labels. The `len(labels)` must be greater than 1.
+                List of string possible labels. There must be at least 2 labels.
             model (`str`, *optional*):
                 The model to use for inference. Can be a model ID hosted on the Hugging Face Hub or a URL to a deployed
                 Inference Endpoint. This parameter overrides the model defined at the instance level. Defaults to None.
@@ -1690,10 +1762,9 @@ class InferenceClient:
         [{"label": "dog", "score": 0.956}, ...]
         ```
         """
-
-        # Raise valueerror if input is less than 2 labels
+        # Raise ValueError if input is less than 2 labels
         if len(labels) < 2:
-            raise ValueError("You must specify at least 2 classes to compare. Please specify more than 1 class.")
+            raise ValueError("You must specify at least 2 classes to compare.")
 
         response = self.post(
             json={"image": _b64_encode(image), "parameters": {"candidate_labels": ",".join(labels)}},

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -1675,6 +1675,79 @@ class AsyncInferenceClient:
         response = await self.post(json={"inputs": text}, model=model, task="translation")
         return _bytes_to_dict(response)[0]["translation_text"]
 
+    async def zero_shot_classification(
+        self, text: str, labels: List[str], *, multi_label: bool = False, model: Optional[str] = None
+    ) -> List[ClassificationOutput]:
+        """
+        Provide as input a text and a set of candidate labels to classify the input text.
+
+        Args:
+            text (`str`):
+                The input text to classify.
+            labels (`List[str]`):
+                List of string possible labels. There must be at least 2 labels.
+            multi_label (`bool`):
+                Boolean that is set to True if classes can overlap.
+            model (`str`, *optional*):
+                The model to use for inference. Can be a model ID hosted on the Hugging Face Hub or a URL to a deployed
+                Inference Endpoint. This parameter overrides the model defined at the instance level. Defaults to None.
+
+        Returns:
+            `List[Dict]`: List of classification outputs containing the predicted labels and their confidence.
+
+        Raises:
+            [`InferenceTimeoutError`]:
+                If the model is unavailable or the request times out.
+            `aiohttp.ClientResponseError`:
+                If the request fails with an HTTP error status code other than HTTP 503.
+
+        Example:
+        ```py
+        # Must be run in an async context
+        >>> from huggingface_hub import AsyncInferenceClient
+        >>> client = AsyncInferenceClient()
+        >>> text = (
+        ...     "A new model offers an explanation async for how the Galilean satellites formed around the solar system's"
+        ...     "largest world. Konstantin Batygin did not set out to solve one of the solar system's most puzzling"
+        ...     " mysteries when he went async for a run up a hill in Nice, France."
+        ... )
+        >>> labels = ["space & cosmos", "scientific discovery", "microbiology", "robots", "archeology"]
+        >>> await client.zero_shot_classification(text, labels)
+        [
+            {"label": "scientific discovery", "score": 0.7961668968200684},
+            {"label": "space & cosmos", "score": 0.18570658564567566},
+            {"label": "microbiology", "score": 0.00730885099619627},
+            {"label": "archeology", "score": 0.006258360575884581},
+            {"label": "robots", "score": 0.004559356719255447},
+        ]
+        >>> await client.zero_shot_classification(text, labels, multi_label=True)
+        [
+            {"label": "scientific discovery", "score": 0.9829297661781311},
+            {"label": "space & cosmos", "score": 0.755190908908844},
+            {"label": "microbiology", "score": 0.0005462635890580714},
+            {"label": "archeology", "score": 0.00047131875180639327},
+            {"label": "robots", "score": 0.00030448526376858354},
+        ]
+        ```
+        """
+        # Raise ValueError if input is less than 2 labels
+        if len(labels) < 2:
+            raise ValueError("You must specify at least 2 classes to compare.")
+
+        response = await self.post(
+            json={
+                "inputs": text,
+                "parameters": {
+                    "candidate_labels": ",".join(labels),
+                    "multi_label": multi_label,
+                },
+            },
+            model=model,
+            task="zero-shot-classification",
+        )
+        output = _bytes_to_dict(response)
+        return [{"label": label, "score": score} for label, score in zip(output["labels"], output["scores"])]
+
     async def zero_shot_image_classification(
         self, image: ContentT, labels: List[str], *, model: Optional[str] = None
     ) -> List[ClassificationOutput]:
@@ -1685,7 +1758,7 @@ class AsyncInferenceClient:
             image (`Union[str, Path, bytes, BinaryIO]`):
                 The input image to caption. It can be raw bytes, an image file, or a URL to an online image.
             labels (`List[str]`):
-                List of string possible labels. The `len(labels)` must be greater than 1.
+                List of string possible labels. There must be at least 2 labels.
             model (`str`, *optional*):
                 The model to use for inference. Can be a model ID hosted on the Hugging Face Hub or a URL to a deployed
                 Inference Endpoint. This parameter overrides the model defined at the instance level. Defaults to None.
@@ -1712,10 +1785,9 @@ class AsyncInferenceClient:
         [{"label": "dog", "score": 0.956}, ...]
         ```
         """
-
-        # Raise valueerror if input is less than 2 labels
+        # Raise ValueError if input is less than 2 labels
         if len(labels) < 2:
-            raise ValueError("You must specify at least 2 classes to compare. Please specify more than 1 class.")
+            raise ValueError("You must specify at least 2 classes to compare.")
 
         response = await self.post(
             json={"image": _b64_encode(image), "parameters": {"candidate_labels": ",".join(labels)}},

--- a/tests/cassettes/InferenceClientVCRTest.test_zero_shot_classification_multi_label.yaml
+++ b/tests/cassettes/InferenceClientVCRTest.test_zero_shot_classification_multi_label.yaml
@@ -1,0 +1,58 @@
+interactions:
+- request:
+    body: '{"inputs": "A new model offers an explanation for how the Galilean satellites
+      formed around the solar system''slargest world. Konstantin Batygin did not set
+      out to solve one of the solar system''s most puzzling mysteries when he went
+      for a run up a hill in Nice, France.", "parameters": {"candidate_labels": "space
+      & cosmos,scientific discovery,microbiology,robots,archeology", "multi_label":
+      true}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '397'
+      Content-Type:
+      - application/json
+      X-Amzn-Trace-Id:
+      - df8664ac-0706-4d53-9fab-771c94f45f9a
+      user-agent:
+      - unknown/None; hf_hub/0.17.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: POST
+    uri: https://api-inference.huggingface.co/models/facebook/bart-large-mnli
+  response:
+    body:
+      string: '{"sequence":"A new model offers an explanation for how the Galilean
+        satellites formed around the solar system''slargest world. Konstantin Batygin
+        did not set out to solve one of the solar system''s most puzzling mysteries
+        when he went for a run up a hill in Nice, France.","labels":["scientific discovery","space
+        & cosmos","microbiology","archeology","robots"],"scores":[0.9829297661781311,0.755190908908844,0.0005462635890580714,0.00047131875180639327,0.00030448526376858354]}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '475'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Sep 2023 08:19:22 GMT
+      access-control-allow-credentials:
+      - 'true'
+      vary:
+      - Origin, Access-Control-Request-Method, Access-Control-Request-Headers
+      x-compute-time:
+      - '1.856'
+      x-compute-type:
+      - cache
+      x-request-id:
+      - qqakvMkyx44bvTcn5UqfU
+      x-sha:
+      - d7645e127eaf1aefc7862fd59a17a5aa8558b8ce
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/InferenceClientVCRTest.test_zero_shot_classification_single_label.yaml
+++ b/tests/cassettes/InferenceClientVCRTest.test_zero_shot_classification_single_label.yaml
@@ -1,0 +1,58 @@
+interactions:
+- request:
+    body: '{"inputs": "A new model offers an explanation for how the Galilean satellites
+      formed around the solar system''slargest world. Konstantin Batygin did not set
+      out to solve one of the solar system''s most puzzling mysteries when he went
+      for a run up a hill in Nice, France.", "parameters": {"candidate_labels": "space
+      & cosmos,scientific discovery,microbiology,robots,archeology", "multi_label":
+      false}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '398'
+      Content-Type:
+      - application/json
+      X-Amzn-Trace-Id:
+      - 306d4dab-fd0d-4b8f-ba63-81a7264f079f
+      user-agent:
+      - unknown/None; hf_hub/0.17.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: POST
+    uri: https://api-inference.huggingface.co/models/facebook/bart-large-mnli
+  response:
+    body:
+      string: '{"sequence":"A new model offers an explanation for how the Galilean
+        satellites formed around the solar system''slargest world. Konstantin Batygin
+        did not set out to solve one of the solar system''s most puzzling mysteries
+        when he went for a run up a hill in Nice, France.","labels":["scientific discovery","space
+        & cosmos","microbiology","archeology","robots"],"scores":[0.7961668968200684,0.18570658564567566,0.00730885099619627,0.006258360575884581,0.004559356719255447]}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '471'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Sep 2023 08:19:36 GMT
+      access-control-allow-credentials:
+      - 'true'
+      vary:
+      - Origin, Access-Control-Request-Method, Access-Control-Request-Headers
+      x-compute-time:
+      - '1.200'
+      x-compute-type:
+      - cache
+      x-request-id:
+      - Ev9sLIqbGGaYLbegw_1BX
+      x-sha:
+      - d7645e127eaf1aefc7862fd59a17a5aa8558b8ce
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_inference_client.py
+++ b/tests/test_inference_client.py
@@ -49,6 +49,7 @@ _RECOMMENDED_MODELS_FOR_VCR = {
     "token-classification": "dbmdz/bert-large-cased-finetuned-conll03-english",
     "translation": "t5-small",
     "visual-question-answering": "dandelin/vilt-b32-finetuned-vqa",
+    "zero-shot-classification": "facebook/bart-large-mnli",
     "zero-shot-image-classification": "openai/clip-vit-base-patch32",
 }
 
@@ -330,6 +331,43 @@ class InferenceClientVCRTest(InferenceClientTest):
                 {"score": 0.08407749235630035, "answer": "lady"},
                 {"score": 0.0507517009973526, "answer": "female"},
                 {"score": 0.01777094043791294, "answer": "man"},
+            ],
+        )
+
+    def test_zero_shot_classification_single_label(self) -> None:
+        output = self.client.zero_shot_classification(
+            "A new model offers an explanation for how the Galilean satellites formed around the solar system's"
+            "largest world. Konstantin Batygin did not set out to solve one of the solar system's most puzzling"
+            " mysteries when he went for a run up a hill in Nice, France.",
+            labels=["space & cosmos", "scientific discovery", "microbiology", "robots", "archeology"],
+        )
+        self.assertEqual(
+            output,
+            [
+                {"label": "scientific discovery", "score": 0.7961668968200684},
+                {"label": "space & cosmos", "score": 0.18570658564567566},
+                {"label": "microbiology", "score": 0.00730885099619627},
+                {"label": "archeology", "score": 0.006258360575884581},
+                {"label": "robots", "score": 0.004559356719255447},
+            ],
+        )
+
+    def test_zero_shot_classification_multi_label(self) -> None:
+        output = self.client.zero_shot_classification(
+            "A new model offers an explanation for how the Galilean satellites formed around the solar system's"
+            "largest world. Konstantin Batygin did not set out to solve one of the solar system's most puzzling"
+            " mysteries when he went for a run up a hill in Nice, France.",
+            labels=["space & cosmos", "scientific discovery", "microbiology", "robots", "archeology"],
+            multi_label=True,
+        )
+        self.assertEqual(
+            output,
+            [
+                {"label": "scientific discovery", "score": 0.9829297661781311},
+                {"label": "space & cosmos", "score": 0.755190908908844},
+                {"label": "microbiology", "score": 0.0005462635890580714},
+                {"label": "archeology", "score": 0.00047131875180639327},
+                {"label": "robots", "score": 0.00030448526376858354},
             ],
         )
 


### PR DESCRIPTION
Last task to complete for https://github.com/huggingface/huggingface_hub/issues/1539 (I actually forgot to list it there :smile:).

InferenceClient should now support all tasks from the Hub :) (cc @martinbrose)

```py
>>> from huggingface_hub import InferenceClient
>>> client = InferenceClient()
>>> text = (
...     "A new model offers an explanation for how the Galilean satellites formed around the solar system's"
...     "largest world. Konstantin Batygin did not set out to solve one of the solar system's most puzzling"
...     " mysteries when he went for a run up a hill in Nice, France."
... )
>>> labels = ["space & cosmos", "scientific discovery", "microbiology", "robots", "archeology"]
>>> client.zero_shot_classification(text, labels)
[
    {"label": "scientific discovery", "score": 0.7961668968200684},
    {"label": "space & cosmos", "score": 0.18570658564567566},
    {"label": "microbiology", "score": 0.00730885099619627},
    {"label": "archeology", "score": 0.006258360575884581},
    {"label": "robots", "score": 0.004559356719255447},
]
>>> client.zero_shot_classification(text, labels, multi_label=True)
[
    {"label": "scientific discovery", "score": 0.9829297661781311},
    {"label": "space & cosmos", "score": 0.755190908908844},
    {"label": "microbiology", "score": 0.0005462635890580714},
    {"label": "archeology", "score": 0.00047131875180639327},
    {"label": "robots", "score": 0.00030448526376858354},
]
```