### PR TITLE
Prepare for `v0.18.0`

### DIFF
--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -46,7 +46,7 @@ import sys
 from typing import TYPE_CHECKING
 
 
-__version__ = "0.17.0.dev0"
+__version__ = "0.18.0.dev0"
 
 # Alphabetical order of definitions is ensured in tests
 # WARNING: any comment added in this dictionary definition will be lost when


### PR DESCRIPTION
Following [`0.17.0` release](https://github.com/huggingface/huggingface_hub/releases/tag/v0.17.0). No deprecation cycle ongoing for this release so nothing much to change (cc @LysandreJik)