### PR TITLE
Keep lock files in a `/locks` folder to prevent rare concurrency issue

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1411,7 +1411,7 @@ def hf_hub_download(
             return pointer_path
 
     # Prevent parallel downloads of the same file with a lock.
-    # etag could be duplicated across repos, 
+    # etag could be duplicated across repos,
     lock_path = os.path.join(locks_dir, repo_folder_name(repo_id=repo_id, repo_type=repo_type), f"{etag}.lock")
 
     # Some Windows versions do not allow for paths longer than 255 characters.

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1197,6 +1197,7 @@ def hf_hub_download(
         cache_dir = str(cache_dir)
     if isinstance(local_dir, Path):
         local_dir = str(local_dir)
+    locks_dir = os.path.join(cache_dir, ".locks")
 
     if subfolder == "":
         subfolder = None
@@ -1410,7 +1411,8 @@ def hf_hub_download(
             return pointer_path
 
     # Prevent parallel downloads of the same file with a lock.
-    lock_path = blob_path + ".lock"
+    # etag could be duplicated across repos, 
+    lock_path = os.path.join(locks_dir, repo_folder_name(repo_id=repo_id, repo_type=repo_type), f"{etag}.lock")
 
     # Some Windows versions do not allow for paths longer than 255 characters.
     # In this case, we must specify it is an extended path by using the "\\?\" prefix.
@@ -1420,6 +1422,7 @@ def hf_hub_download(
     if os.name == "nt" and len(os.path.abspath(blob_path)) > 255:
         blob_path = "\\\\?\\" + os.path.abspath(blob_path)
 
+    Path(lock_path).parent.mkdir(parents=True, exist_ok=True)
     with FileLock(lock_path):
         # If the download just completed while the lock was activated.
         if os.path.exists(pointer_path) and not force_download:
@@ -1493,11 +1496,6 @@ def hf_hub_download(
                 logger.debug(f"Storing {url} in local_dir at {local_dir_filepath} (not cached).")
                 _chmod_and_replace(temp_file.name, local_dir_filepath)
             pointer_path = local_dir_filepath  # for return value
-
-    try:
-        os.remove(lock_path)
-    except OSError:
-        pass
 
     return pointer_path
 

--- a/src/huggingface_hub/utils/_cache_manager.py
+++ b/src/huggingface_hub/utils/_cache_manager.py
@@ -600,6 +600,8 @@ def scan_cache_dir(cache_dir: Optional[Union[str, Path]] = None) -> HFCacheInfo:
     repos: Set[CachedRepoInfo] = set()
     warnings: List[CorruptedCacheException] = []
     for repo_path in cache_dir.iterdir():
+        if repo_path.name == ".locks":  # skip './.locks/' folder
+            continue
         try:
             repos.add(_scan_cached_repo(repo_path))
         except CorruptedCacheException as e:

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -653,6 +653,20 @@ class CachedDownloadTests(unittest.TestCase):
                     cache_dir=tmpdir,
                 )
 
+    @unittest.skipIf(os.name == "nt", "Lock files are always deleted on Windows.")
+    def test_keep_lock_file(self):
+        """Lock files should not be deleted on Linux."""
+        with SoftTemporaryDirectory() as tmpdir:
+            hf_hub_download(DUMMY_MODEL_ID, filename=CONFIG_NAME, cache_dir=tmpdir)
+            lock_file_exist = False
+            locks_dir = os.path.join(tmpdir, ".locks")
+            for subdir, dirs, files in os.walk(locks_dir):
+                for file in files:
+                    if file.endswith(".lock"):
+                        lock_file_exist = True
+                        break
+            self.assertTrue(lock_file_exist, "no lock file can be found")
+
 
 @with_production_testing
 @pytest.mark.usefixtures("fx_cache_dir")


### PR DESCRIPTION
The lock file could be removed when the 2nd process gets the lock.
And then the 3rd process will lock on a different lock file handle.
Although the lock path stays the same.

1st proc gets the lock
2nd proc waits for the lock
1st proc releases the lock
1st proc removes the lock file
2nd proc gets the lock
3rd proc creates a new lock file and gets the lock

Demo code to show the problem:

```py
from filelock import FileLock
import threading
import os
import time

lock_path = "/tmp/test.lock"

def lock1():
   with FileLock(lock_path):
      print("lock acquired in thread1")
      time.sleep(1)

   print("lock released in thread1")
   time.sleep(1)
   os.remove(lock_path)
   print("lock file removed in thread1")

def lock2():
   time.sleep(1)
   with FileLock(lock_path):
      print("lock acquired in thread2")
      time.sleep(10)

   print("lock released in thread2")

def lock3():
   time.sleep(3)
   with FileLock(lock_path):
      print("lock acquired in thread3")
      time.sleep(10)


t1 = threading.Thread(target=lock1)
t2 = threading.Thread(target=lock2)
t3 = threading.Thread(target=lock3)
t1.start()
t2.start()
t3.start()
t1.join()
t2.join()
t3.join()
```

~Add ENV `HF_HUB_KEEP_LOCK_FILES` to give user option to keep the lock files to prevent concurrency issues.~

**EDIT on 2023/1014**
---

Windows doesn't have this problem.

This commit moves the lock files to a subdirectory of the hub cache,
and don't remove it after downloading.

The lock files are named with their `etag` and `.lock` extension, placed
in the `HUGGINGFACE_HUB_CACHE/.locks/repo_folder_name` directory. The
repo_folder_name is generated from `repo_id` and `repo_type`, to avoid
same `etag` in different repos.
