### PR TITLE
Add default user-agent to huggingface-cli

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -85,7 +85,7 @@ class TestUploadCommand(unittest.TestCase):
         self.assertEqual(cmd.commit_description, None)
         self.assertEqual(cmd.create_pr, False)
         self.assertEqual(cmd.every, None)
-        self.assertEqual(cmd.token, None)
+        self.assertEqual(cmd.api.token, None)
         self.assertEqual(cmd.quiet, False)
 
     def test_upload_with_all_options(self) -> None:
@@ -135,7 +135,7 @@ class TestUploadCommand(unittest.TestCase):
         self.assertEqual(cmd.commit_description, "My commit description")
         self.assertEqual(cmd.create_pr, True)
         self.assertEqual(cmd.every, 5)
-        self.assertEqual(cmd.token, "my-token")
+        self.assertEqual(cmd.api.token, "my-token")
         self.assertEqual(cmd.quiet, True)
 
     def test_upload_implicit_local_path_when_folder_exists(self) -> None:
@@ -211,8 +211,8 @@ class TestUploadCommand(unittest.TestCase):
         cmd = UploadCommand(self.parser.parse_args(["upload", DUMMY_MODEL_ID, ".", "--every", "0.5"]))
         self.assertEqual(cmd.every, 0.5)
 
-    @patch("huggingface_hub.commands.upload.upload_folder")
-    @patch("huggingface_hub.commands.upload.create_repo")
+    @patch("huggingface_hub.commands.upload.HfApi.upload_folder")
+    @patch("huggingface_hub.commands.upload.HfApi.create_repo")
     def test_upload_folder_mock(self, create_mock: Mock, upload_mock: Mock) -> None:
         with SoftTemporaryDirectory() as cache_dir:
             cmd = UploadCommand(
@@ -222,16 +222,13 @@ class TestUploadCommand(unittest.TestCase):
             )
             cmd.run()
 
-            create_mock.assert_called_once_with(
-                repo_id="my-model", repo_type="model", exist_ok=True, private=True, token=None
-            )
+            create_mock.assert_called_once_with(repo_id="my-model", repo_type="model", exist_ok=True, private=True)
             upload_mock.assert_called_once_with(
                 folder_path=cache_dir,
                 path_in_repo=".",
                 repo_id=create_mock.return_value.repo_id,
                 repo_type="model",
                 revision=None,
-                token=None,
                 commit_message=None,
                 commit_description=None,
                 create_pr=False,
@@ -240,8 +237,8 @@ class TestUploadCommand(unittest.TestCase):
                 delete_patterns=["*.json"],
             )
 
-    @patch("huggingface_hub.commands.upload.upload_file")
-    @patch("huggingface_hub.commands.upload.create_repo")
+    @patch("huggingface_hub.commands.upload.HfApi.upload_file")
+    @patch("huggingface_hub.commands.upload.HfApi.create_repo")
     def test_upload_file_mock(self, create_mock: Mock, upload_mock: Mock) -> None:
         with SoftTemporaryDirectory() as cache_dir:
             file_path = Path(cache_dir) / "file.txt"
@@ -254,7 +251,7 @@ class TestUploadCommand(unittest.TestCase):
             cmd.run()
 
             create_mock.assert_called_once_with(
-                repo_id="my-dataset", repo_type="dataset", exist_ok=True, private=False, token=None
+                repo_id="my-dataset", repo_type="dataset", exist_ok=True, private=False
             )
             upload_mock.assert_called_once_with(
                 path_or_fileobj=str(file_path),
@@ -262,13 +259,12 @@ class TestUploadCommand(unittest.TestCase):
                 repo_id=create_mock.return_value.repo_id,
                 repo_type="dataset",
                 revision=None,
-                token=None,
                 commit_message=None,
                 commit_description=None,
                 create_pr=True,
             )
 
-    @patch("huggingface_hub.commands.upload.create_repo")
+    @patch("huggingface_hub.commands.upload.HfApi.create_repo")
     def test_upload_missing_path(self, create_mock: Mock) -> None:
         cmd = UploadCommand(self.parser.parse_args(["upload", "my-model", "/path/to/missing_file", "logs/file.txt"]))
         with self.assertRaises(FileNotFoundError):


### PR DESCRIPTION
This PR sets `library_name="huggingface-cli"` in the upload CLI command (similar to the [download command](https://github.com/huggingface/huggingface_hub/blob/49cbeb78d3d87b22a40d04ef8a733855e82d17ef/src/huggingface_hub/commands/download.py#L180)). The goal is to be able to track usage of CLI vs script to upload files.