### PR TITLE
Fix upload CLI when pushing to Space

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -56,6 +56,7 @@ jobs:
           case "${{ matrix.test_name }}" in
 
             "Repository only" | "Everything else")
+              sudo apt update
               sudo apt install -y libsndfile1-dev
               ;;
 
@@ -69,6 +70,7 @@ jobs:
               ;;
 
             tensorflow)
+              sudo apt update
               sudo apt install -y graphviz
               pip install .[tensorflow]
               ;;

--- a/src/huggingface_hub/commands/upload.py
+++ b/src/huggingface_hub/commands/upload.py
@@ -236,7 +236,13 @@ class UploadCommand(BaseHuggingfaceCLICommand):
         if not os.path.isfile(self.local_path) and not os.path.isdir(self.local_path):
             raise FileNotFoundError(f"No such file or directory: '{self.local_path}'.")
         repo_id = self.api.create_repo(
-            repo_id=self.repo_id, repo_type=self.repo_type, exist_ok=True, private=self.private
+            repo_id=self.repo_id,
+            repo_type=self.repo_type,
+            exist_ok=True,
+            private=self.private,
+            space_sdk="gradio" if self.repo_type == "space" else None,
+            # ^ We don't want it to fail when uploading to a Space => let's set Gradio by default.
+            # ^ I'd rather not add CLI args to set it explicitly as we already have `huggingface-cli repo create` for that.
         ).repo_id
 
         # File-based upload


### PR DESCRIPTION
In `huggingface-cli upload` command, we create the repo for the user if it doesn't exist yet. When pushing to a `Space`, the upload command fails because `space_sdk` is not set. It fails client-side no matter if the Space already exists or not. This PR fixes this by setting `space_sdk="gradio"` by default.

The reason why I prefer not to add a `--space-sdk` option is that the `upload` command is not really meant to configure how the Space should be configured (in comparison to `huggingface-cli repo create`). The fact that the repo is created by default is more a "nice to have".

```bash
# This cmd currently fails
huggingface-cli upload my-cool-space README.md --repo-type=space
```

I'm planning to do a **hot-fix release** after this PR is merged as the upload command is currently unusable without it (for Spaces)

---

Tests are flaky at the moment. I'll fix that in a later PR.