### PR TITLE
Suggest to check firewall/proxy settings + default to local file

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1246,7 +1246,11 @@ def hf_hub_download(
             # Commit hash must exist
             commit_hash = metadata.commit_hash
             if commit_hash is None:
-                raise OSError("Distant resource does not seem to be on huggingface.co (missing commit header).")
+                raise OSError(
+                    "Distant resource does not seem to be on huggingface.co. It is possible that a configuration issue"
+                    " prevents you from downloading resources from https://huggingface.co. Please check your firewall"
+                    " and proxy settings and make sure your SSL certificates are updated."
+                )
 
             # Etag must exist
             etag = metadata.etag

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -40,6 +40,7 @@ from .constants import (
 )
 from .utils import (
     EntryNotFoundError,
+    FileMetadataError,
     GatedRepoError,
     LocalEntryNotFoundError,
     RepositoryNotFoundError,
@@ -700,7 +701,7 @@ def cached_download(
             # we fallback to the regular etag header.
             # If we don't have any of those, raise an error.
             if etag is None:
-                raise OSError(
+                raise FileMetadataError(
                     "Distant resource does not have an ETag, we won't be able to reliably ensure reproducibility."
                 )
             # We get the expected size of the file, to check the download went well.
@@ -1246,7 +1247,7 @@ def hf_hub_download(
             # Commit hash must exist
             commit_hash = metadata.commit_hash
             if commit_hash is None:
-                raise OSError(
+                raise FileMetadataError(
                     "Distant resource does not seem to be on huggingface.co. It is possible that a configuration issue"
                     " prevents you from downloading resources from https://huggingface.co. Please check your firewall"
                     " and proxy settings and make sure your SSL certificates are updated."
@@ -1258,7 +1259,7 @@ def hf_hub_download(
             # we fallback to the regular etag header.
             # If we don't have any of those, raise an error.
             if etag is None:
-                raise OSError(
+                raise FileMetadataError(
                     "Distant resource does not have an ETag, we won't be able to reliably ensure reproducibility."
                 )
 
@@ -1297,12 +1298,21 @@ def hf_hub_download(
             #    (if it's not the case, the error will be re-raised)
             head_call_error = error
             pass
+        except FileMetadataError as error:
+            # Multiple reasons for a FileMetadataError:
+            # - Wrong network configuration (proxy, firewall, SSL certificates)
+            # - Inconsistency on the Hub
+            # => let's switch to 'local_files_only=True' to check if the files are already cached.
+            #    (if it's not the case, the error will be re-raised)
+            head_call_error = error
+            pass
 
     # etag can be None for several reasons:
     # 1. we passed local_files_only.
     # 2. we don't have a connection
     # 3. Hub is down (HTTP 500 or 504)
     # 4. repo is not found -for example private or gated- and invalid/missing token sent
+    # 5. Hub is blocked by a firewall or proxy is not set correctly.
     # => Try to get the last downloaded one from the specified revision.
     #
     # If the specified revision is a commit hash, look inside "snapshots".

--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -32,6 +32,7 @@ from ._datetime import parse_datetime
 from ._errors import (
     BadRequestError,
     EntryNotFoundError,
+    FileMetadataError,
     GatedRepoError,
     HfHubHTTPError,
     LocalEntryNotFoundError,

--- a/src/huggingface_hub/utils/_errors.py
+++ b/src/huggingface_hub/utils/_errors.py
@@ -5,6 +5,13 @@ from requests import HTTPError, Response
 from ._fixes import JSONDecodeError
 
 
+class FileMetadataError(OSError):
+    """Error triggered when the metadata of a file on the Hub cannot be retrieved (missing ETag or commit_hash).
+
+    Inherits from `OSError` for backward compatibility.
+    """
+
+
 class HfHubHTTPError(HTTPError):
     """
     HTTPError to inherit from for any custom HTTP Error raised in HF Hub.


### PR DESCRIPTION
Several users reported getting stuck with an OSError _"Distant resource does not seem to be on huggingface.co"_ when trying to download files from the Hub. It turned out this can be caused by a wrong configuration on the client network (firewall or proxy) (example: https://github.com/huggingface/huggingface_hub/issues/1600#issuecomment-1684391061 and https://github.com/huggingface/huggingface_hub/issues/1600#issuecomment-1689782396).

This PR adds a better error message suggesting to check the config in case that happen. This might help some users getting unblocked. It also tries to fallback to a locally saved file if available. That would help users that works with different networks depending on their location.

Closes https://github.com/huggingface/huggingface_hub/issues/1600.