### PR TITLE
Pin `fsspec` to use default `expand_path`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def get_version() -> str:
 
 install_requires = [
     "filelock",
-    "fsspec",
+    "fsspec>=2023.5.0",
     "requests",
     "tqdm>=4.42.1",
     "pyyaml>=5.1",

--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -377,8 +377,7 @@ class HfFileSystem(fsspec.AbstractFileSystem):
         return super().info(path, **kwargs)
 
     if version.parse(fsspec.__version__) < version.parse("2023.5.0"):
-        # The default implementation does not allow passing custom kwargs (e.g., we use these kwargs to propagate the `revision`)
-        # until version 2023.5.0
+        # The default implementation in fsspec<2023.5.0 does not allow passing custom kwargs (e.g., we use these kwargs to propagate the `revision`)
         def expand_path(
             self, path: Union[str, List[str]], recursive: bool = False, maxdepth: Optional[int] = None, **kwargs
         ) -> List[str]:

--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -3,12 +3,10 @@ import os
 import tempfile
 from dataclasses import dataclass
 from datetime import datetime
-from glob import has_magic
 from typing import Any, Dict, List, Optional, Tuple, Union
 from urllib.parse import quote, unquote
 
 import fsspec
-from packaging import version
 
 from ._commit_api import CommitOperationCopy, CommitOperationDelete
 from .constants import DEFAULT_REVISION, ENDPOINT, REPO_TYPE_MODEL, REPO_TYPES_MAPPING, REPO_TYPES_URL_PREFIXES
@@ -375,36 +373,6 @@ class HfFileSystem(fsspec.AbstractFileSystem):
             name = name.replace(revision_in_path, "", 1) if not has_revision_in_path else name
             return {"name": name, "size": 0, "type": "directory"}
         return super().info(path, **kwargs)
-
-    if version.parse(fsspec.__version__) < version.parse("2023.5.0"):
-        # The default implementation in fsspec<2023.5.0 does not allow passing custom kwargs (e.g., we use these kwargs to propagate the `revision`)
-        def expand_path(
-            self, path: Union[str, List[str]], recursive: bool = False, maxdepth: Optional[int] = None, **kwargs
-        ) -> List[str]:
-            if maxdepth is not None and maxdepth < 1:
-                raise ValueError("maxdepth must be at least 1")
-
-            if isinstance(path, str):
-                return self.expand_path([path], recursive, maxdepth)
-
-            out = set()
-            path = [self._strip_protocol(p) for p in path]
-            for p in path:
-                if has_magic(p):
-                    bit = set(self.glob(p, **kwargs))
-                    out |= bit
-                    if recursive:
-                        out |= set(self.expand_path(list(bit), recursive=recursive, maxdepth=maxdepth, **kwargs))
-                    continue
-                elif recursive:
-                    rec = set(self.find(p, maxdepth=maxdepth, withdirs=True, detail=False, **kwargs))
-                    out |= rec
-                if p not in out and (recursive is False or self.exists(p)):
-                    # should only check once, for the root
-                    out.add(p)
-            if not out:
-                raise FileNotFoundError(path)
-            return list(sorted(out))
 
 
 class HfFileSystemFile(fsspec.spec.AbstractBufferedFile):


### PR DESCRIPTION
... to avoid having to update `HfFileSystem.expand_path` when new changes are made to the default implementation (e.g., the latest `fsspec` release (`2023.9.0`) added a `maxdepth` param to the signature ([PR](https://github.com/fsspec/filesystem_spec/pull/1329)))