### PR TITLE
update HFValidationError error message

### DIFF
--- a/src/huggingface_hub/utils/_validators.py
+++ b/src/huggingface_hub/utils/_validators.py
@@ -156,8 +156,8 @@ def validate_repo_id(repo_id: str) -> None:
 
     if repo_id.count("/") > 1:
         raise HFValidationError(
-            "Repo id must be in the form 'repo_name' or 'namespace/repo_name':"
-            f" '{repo_id}'. Use `repo_type` argument if needed."
+            "Repo id must be in the form 'repo_name', 'namespace/repo_name' or '/path/to/repo' :"
+            f" '{repo_id}'."
         )
 
     if not REPO_ID_REGEX.match(repo_id):


### PR DESCRIPTION
The repo_id field is reused for path to local cache of repo. Also remove the obsolete repo_type field.

Re #5110