### PR TITLE
Fix broken tips in login reference

### DIFF
--- a/src/huggingface_hub/_login.py
+++ b/src/huggingface_hub/_login.py
@@ -54,15 +54,19 @@ def login(
     a cli command that wraps [`login`].
 
     <Tip>
+
     [`login`] is a drop-in replacement method for [`notebook_login`] as it wraps and
     extends its capabilities.
+
     </Tip>
 
     <Tip>
+
     When the token is not passed, [`login`] will automatically detect if the script runs
     in a notebook or not. However, this detection might not be accurate due to the
     variety of notebooks that exists nowadays. If that is the case, you can always force
     the UI by using [`notebook_login`] or [`interpreter_login`].
+
     </Tip>
 
     Args:


### PR DESCRIPTION
The `<Tip>` section doesn't look great in [login package reference](https://huggingface.co/docs/huggingface_hub/v0.17.1/en/package_reference/login#huggingface_hub.login) cc @osanseviero 