### PR TITLE
Address failing _check_disk_space() when path doesn't exist yet

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -973,7 +973,8 @@ def _check_disk_space(expected_size: int, target_dir: Union[str, Path]) -> None:
     """
 
     target_dir = str(target_dir)
-    target_dir_free = shutil.disk_usage(target_dir).free
+
+    target_dir_free = shutil.disk_usage(os.path.realpath(target_dir)).free
 
     has_enough_space = target_dir_free >= expected_size
 

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -972,18 +972,19 @@ def _check_disk_space(expected_size: int, target_dir: Union[str, Path]) -> None:
             The directory where the file will be stored after downloading.
     """
 
-    target_dir = str(target_dir)
-
-    target_dir_free = shutil.disk_usage(os.path.realpath(target_dir)).free
-
-    has_enough_space = target_dir_free >= expected_size
-
-    if not has_enough_space:
-        warnings.warn(
-            "Not enough free disk space to download the file. "
-            f"The expected file size is: {expected_size / 1e6:.2f} MB. "
-            f"The target location {target_dir} only has {target_dir_free / 1e6:.2f} MB free disk space."
-        )
+    target_dir = Path(target_dir)  # format as `Path`
+    for path in [target_dir] + list(target_dir.parents):  # first check target_dir, then each parents one by one
+        try:
+            target_dir_free = shutil.disk_usage(path).free
+            if target_dir_free < expected_size:
+                warnings.warn(
+                    "Not enough free disk space to download the file. "
+                    f"The expected file size is: {expected_size / 1e6:.2f} MB. "
+                    f"The target location {target_dir} only has {target_dir_free / 1e6:.2f} MB free disk space."
+                )
+            return
+        except OSError:  # raise on anything: file does not exist or space disk cannot be checked
+            pass
 
 
 @validate_hf_hub_args

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -113,18 +113,18 @@ class TestDiskUsageWarning(unittest.TestCase):
             assert len(w) == 0
 
     def test_disk_usage_warning_with_non_existent_path(self) -> None:
-        # Test for not existent path
+        # Test for not existent (absolute) path
         with warnings.catch_warnings(record=True) as w:
             # Cause all warnings to always be triggered.
             warnings.simplefilter("always")
-            _check_disk_space(expected_size=self.expected_size, target_dir="not_existent_path")
+            _check_disk_space(expected_size=self.expected_size, target_dir="path/to/not_existent_path")
             assert len(w) == 0
 
-        # Test for relative path
+        # Test for not existent (relative) path
         with warnings.catch_warnings(record=True) as w:
             # Cause all warnings to always be triggered.
             warnings.simplefilter("always")
-            _check_disk_space(expected_size=self.expected_size, target_dir="./not_existent_path")
+            _check_disk_space(expected_size=self.expected_size, target_dir="/path/to/not_existent_path")
             assert len(w) == 0
 
 

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -112,6 +112,21 @@ class TestDiskUsageWarning(unittest.TestCase):
             _check_disk_space(expected_size=self.expected_size, target_dir=disk_usage_mock)
             assert len(w) == 0
 
+    def test_disk_usage_warning_with_non_existent_path(self) -> None:
+        # Test for not existent path
+        with warnings.catch_warnings(record=True) as w:
+            # Cause all warnings to always be triggered.
+            warnings.simplefilter("always")
+            _check_disk_space(expected_size=self.expected_size, target_dir="not_existent_path")
+            assert len(w) == 0
+
+        # Test for relative path
+        with warnings.catch_warnings(record=True) as w:
+            # Cause all warnings to always be triggered.
+            warnings.simplefilter("always")
+            _check_disk_space(expected_size=self.expected_size, target_dir="./not_existent_path")
+            assert len(w) == 0
+
 
 @with_production_testing
 class CachedDownloadTests(unittest.TestCase):


### PR DESCRIPTION
Address issue #1690.

`_check_disk_space` fails when only provided with incomplete paths like `checkpoints/stabilityai/stable-diffusion-xl-base-1.0` and then tries to asses exactly this "path". 
It seems to be a regular case when `snapshot_download` and hence `hf_hub_download` is being called without the parameter `local_dir`.

`snapshot_download.py` (248:250) only performs `os.path.realpath()` when `local_dir` is not None:

```python
    if local_dir is not None:
        return str(os.path.realpath(local_dir))
    return snapshot_folder
```

My change in this PR now addresses this case and ensures that the real complete path is being used in `shutil.disk_usage().free` within `_check_disk_space()`.