### PR TITLE
Respect `HTTPError` spec

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -956,7 +956,9 @@ class HfApi:
             raise HTTPError(
                 "Invalid user token. If you didn't pass a user token, make sure you "
                 "are properly logged in by executing `huggingface-cli login`, and "
-                "if you did pass a user token, double-check it's correct."
+                "if you did pass a user token, double-check it's correct.",
+                request=e.request,
+                response=e.response,
             ) from e
         return r.json()
 

--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -232,7 +232,7 @@ class InferenceClient:
                     )
                 except TimeoutError as error:
                     # Convert any `TimeoutError` to a `InferenceTimeoutError`
-                    raise InferenceTimeoutError(f"Inference call timed out: {url}") from error
+                    raise InferenceTimeoutError(f"Inference call timed out: {url}") from error  # type: ignore
 
             try:
                 hf_raise_for_status(response)
@@ -243,7 +243,9 @@ class InferenceClient:
                     if timeout is not None and time.time() - t0 > timeout:
                         raise InferenceTimeoutError(
                             f"Model not loaded on the server: {url}. Please retry with a higher timeout (current:"
-                            f" {self.timeout})."
+                            f" {self.timeout}).",
+                            request=error.request,
+                            response=error.response,
                         ) from error
                     # ...or wait 1s and retry
                     logger.info(f"Waiting for model to be loaded on the server: {error}")

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -231,7 +231,7 @@ class AsyncInferenceClient:
                 except asyncio.TimeoutError as error:
                     await client.close()
                     # Convert any `TimeoutError` to a `InferenceTimeoutError`
-                    raise InferenceTimeoutError(f"Inference call timed out: {url}") from error
+                    raise InferenceTimeoutError(f"Inference call timed out: {url}") from error  # type: ignore
                 except aiohttp.ClientResponseError as error:
                     error.response_error_payload = response_error_payload
                     await client.close()
@@ -240,7 +240,9 @@ class AsyncInferenceClient:
                         if timeout is not None and time.time() - t0 > timeout:
                             raise InferenceTimeoutError(
                                 f"Model not loaded on the server: {url}. Please retry with a higher timeout"
-                                f" (current: {self.timeout})."
+                                f" (current: {self.timeout}).",
+                                request=error.request,
+                                response=error.response,
                             ) from error
                         # ...or wait 1s and retry
                         logger.info(f"Waiting for model to be loaded on the server: {error}")

--- a/src/huggingface_hub/inference/_text_generation.py
+++ b/src/huggingface_hub/inference/_text_generation.py
@@ -468,15 +468,13 @@ def raise_text_generation_error(http_error: HTTPError) -> NoReturn:
     # If error_type => more information than `hf_raise_for_status`
     if error_type is not None:
         if error_type == "generation":
-            raise GenerationError(message, request=http_error.request, response=http_error.response) from http_error
+            raise GenerationError(message) from http_error  # type: ignore
         if error_type == "incomplete_generation":
-            raise IncompleteGenerationError(
-                message, request=http_error.request, response=http_error.response
-            ) from http_error
+            raise IncompleteGenerationError(message) from http_error  # type: ignore
         if error_type == "overloaded":
-            raise OverloadedError(message, request=http_error.request, response=http_error.response) from http_error
+            raise OverloadedError(message) from http_error  # type: ignore
         if error_type == "validation":
-            raise ValidationError(message, request=http_error.request, response=http_error.response) from http_error
+            raise ValidationError(message) from http_error  # type: ignore
 
     # Otherwise, fallback to default error
     raise http_error

--- a/src/huggingface_hub/inference/_text_generation.py
+++ b/src/huggingface_hub/inference/_text_generation.py
@@ -468,13 +468,15 @@ def raise_text_generation_error(http_error: HTTPError) -> NoReturn:
     # If error_type => more information than `hf_raise_for_status`
     if error_type is not None:
         if error_type == "generation":
-            raise GenerationError(message) from http_error
+            raise GenerationError(message, request=http_error.request, response=http_error.response) from http_error
         if error_type == "incomplete_generation":
-            raise IncompleteGenerationError(message) from http_error
+            raise IncompleteGenerationError(
+                message, request=http_error.request, response=http_error.response
+            ) from http_error
         if error_type == "overloaded":
-            raise OverloadedError(message) from http_error
+            raise OverloadedError(message, request=http_error.request, response=http_error.response) from http_error
         if error_type == "validation":
-            raise ValidationError(message) from http_error
+            raise ValidationError(message, request=http_error.request, response=http_error.response) from http_error
 
     # Otherwise, fallback to default error
     raise http_error

--- a/src/huggingface_hub/utils/_errors.py
+++ b/src/huggingface_hub/utils/_errors.py
@@ -85,7 +85,8 @@ class HfHubHTTPError(HTTPError):
                 request_id=self.request_id,
                 server_message=self.server_message,
             ),
-            response=response,
+            response=response,  # type: ignore
+            request=response.request if response is not None else None,  # type: ignore
         )
 
     def append_to_message(self, additional_message: str) -> None:

--- a/utils/generate_async_inference_client.py
+++ b/utils/generate_async_inference_client.py
@@ -207,7 +207,7 @@ ASYNC_POST_CODE = """
                 except asyncio.TimeoutError as error:
                     await client.close()
                     # Convert any `TimeoutError` to a `InferenceTimeoutError`
-                    raise InferenceTimeoutError(f"Inference call timed out: {url}") from error
+                    raise InferenceTimeoutError(f"Inference call timed out: {url}") from error  # type: ignore
                 except aiohttp.ClientResponseError as error:
                     error.response_error_payload = response_error_payload
                     await client.close()
@@ -216,7 +216,9 @@ ASYNC_POST_CODE = """
                         if timeout is not None and time.time() - t0 > timeout:
                             raise InferenceTimeoutError(
                                 f"Model not loaded on the server: {url}. Please retry with a higher timeout"
-                                f" (current: {self.timeout})."
+                                f" (current: {self.timeout}).",
+                                request=error.request,
+                                response=error.response,
                             ) from error
                         # ...or wait 1s and retry
                         logger.info(f"Waiting for model to be loaded on the server: {error}")


### PR DESCRIPTION
`HTTPError` has 2 attributes `request` and `response`. Both are expected by users to be not `None` but it was not really enforced at any level (typed as `Any`). Since [`types-requests==2.31.0.4`](https://github.com/typeshed-internal/stub_uploader/blob/main/data/changelogs/requests.md#23104-2023-09-23), the types are now enforced to be `requests.Request` and `response.Response`. This PR adapts the current code to set the request/response attributes correctly whenever possible. However this is not always possible due to how our errors are built (it happens in rare cases that we raise a HTTPError even though it's not *really* a HTTPError per-se). I think enforcing request/response whenever possible + ignore other errors is fine for now. Let's reassess if at any point some users complain.

See the related https://github.com/python/typeshed/pull/8989 and https://github.com/python/typeshed/pull/10740.