### PR TITLE
Add `url` attribute to Collection class

### DIFF
--- a/docs/source/en/guides/collections.md
+++ b/docs/source/en/guides/collections.md
@@ -79,11 +79,13 @@ It will return a [`Collection`] object with the high-level metadata (title, desc
 
 ```py
 >>> collection.slug
-'iccv-2023-15e23b46cb98efca45'
+'owner/iccv-2023-15e23b46cb98efca45'
 >>> collection.title
 "ICCV 2023"
 >>> collection.owner
 "username"
+>>> collection.url
+'https://huggingface.co/collections/owner/iccv-2023-15e23b46cb98efca45'
 ```
 
 ## Manage items in a collection

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -663,6 +663,8 @@ class Collection(ReprMixin):
             Whether the collection is private or not.
         theme (`str`):
             Theme of the collection. E.g. `"green"`.
+        url (`str`):
+            URL of the collection on the Hub.
     """
 
     slug: str
@@ -676,7 +678,7 @@ class Collection(ReprMixin):
     private: bool
     theme: str
 
-    def __init__(self, data: Dict) -> None:
+    def __init__(self, data: Dict, endpoint: Optional[str] = None) -> None:
         # Collection info
         self.slug = data["slug"]
         self.title = data["title"]
@@ -689,6 +691,11 @@ class Collection(ReprMixin):
         self.private = data["private"]
         self.position = data["position"]
         self.theme = data["theme"]
+
+        # (internal)
+        if endpoint is None:
+            endpoint = ENDPOINT
+        self.url = f"{ENDPOINT}/collections/{self.slug}"
 
 
 class ModelSearchArguments(AttributeDictionary):
@@ -5840,7 +5847,7 @@ class HfApi:
             f"{self.endpoint}/api/collections/{collection_slug}", headers=self._build_hf_headers(token=token)
         )
         hf_raise_for_status(r)
-        return Collection(r.json())
+        return Collection(r.json(), endpoint=self.endpoint)
 
     def create_collection(
         self,
@@ -5905,7 +5912,7 @@ class HfApi:
                 return self.get_collection(slug, token=token)
             else:
                 raise
-        return Collection(r.json())
+        return Collection(r.json(), endpoint=self.endpoint)
 
     def update_collection_metadata(
         self,
@@ -5970,7 +5977,7 @@ class HfApi:
             json={key: value for key, value in payload.items() if value is not None},
         )
         hf_raise_for_status(r)
-        return Collection(r.json()["data"])
+        return Collection(r.json()["data"], endpoint=self.endpoint)
 
     def delete_collection(
         self, collection_slug: str, *, missing_ok: bool = False, token: Optional[str] = None
@@ -6078,7 +6085,7 @@ class HfApi:
                 return self.get_collection(collection_slug, token=token)
             else:
                 raise
-        return Collection(r.json())
+        return Collection(r.json(), endpoint=self.endpoint)
 
     def update_collection_item(
         self,

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -664,7 +664,7 @@ class Collection(ReprMixin):
         theme (`str`):
             Theme of the collection. E.g. `"green"`.
         url (`str`):
-            URL of the collection on the Hub.
+            URL for the collection on the Hub.
     """
 
     slug: str

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -3225,6 +3225,7 @@ class CollectionAPITest(HfApiCommonTest):
         self.assertEqual(collection.description, "Contains a lot of cool stuff")
         self.assertEqual(collection.items, [])
         self.assertTrue(collection.slug.startswith(self.slug_prefix))
+        self.assertEqual(collection.url, f"{ENDPOINT_STAGING}/collections/{collection.slug}")
 
     def test_create_collection_exists_ok(self) -> None:
         # Create collection once without description


### PR DESCRIPTION
Follow-up after https://github.com/huggingface/huggingface_hub/pull/1687. From a [comment](https://github.com/huggingface/huggingface_hub/pull/1687#issuecomment-1733459586) from @davanstrien:

> Would adding a collection_url/url attribute to the Collection object make sense? I realise this can easily be got from the slug i.e. f"https:huggingface.co/collections/{collection.slug}" but maybe it's nice to make it easier for a user to quickly access that so they can check their collection via the Hub more quickly?