### PR TITLE
Preupload lfs files before commiting

### DIFF
--- a/docs/source/en/guides/upload.md
+++ b/docs/source/en/guides/upload.md
@@ -436,7 +436,7 @@ For more detailed information, take a look at the [`HfApi`] reference.
 In some cases, you might want to upload huge files to S3 **before** making the commit call. For example, if you are
 committing a dataset in several shards that are generated in-memory, you would need to upload the shards one by one
 to avoid a out-of-memory issue. A solution is to upload each shard as a separate commit on the repo. While being
-perfectly valid, this solution has the drawback of potentially messing the git history by generating a tens of commits.
+perfectly valid, this solution has the drawback of potentially messing the git history by generating tens of commits.
 To overcome this issue, you can upload your files one by one to S3 and then create a single commit at the end. This
 is possible using [`preupload_lfs_files`] in combination with [`create_commit`].
 

--- a/docs/source/en/guides/upload.md
+++ b/docs/source/en/guides/upload.md
@@ -443,8 +443,9 @@ is possible using [`preupload_lfs_files`] in combination with [`create_commit`].
 <Tip warning={true}>
 
 This is a power-user method. Directly using [`upload_file`], [`upload_folder`] or [`create_commit`] instead of handling
-the low-level logic of pre-uploading files is the way to go in the vast majority of cases. If you have a question,
-feel free to ping us on our Discord or in a Github issue.
+the low-level logic of pre-uploading files is the way to go in the vast majority of cases. The main caveat of
+[`preupload_lfs_files`] is that until the commit is actually made, the upload files are not accessible on the repo on
+the Hub. If you have a question, feel free to ping us on our Discord or in a Github issue.
 
 </Tip>
 
@@ -462,7 +463,7 @@ Here is a simple example illustrating how to pre-upload files:
 ...     preupload_lfs_files(repo_id, additions=[addition])
 ...     operations.append(addition)
 
-# Create commit 
+# Create commit
 >>> create_commit(repo_id, operations=operations, commit_message="Commit all shards")
 ```
 

--- a/docs/source/en/guides/upload.md
+++ b/docs/source/en/guides/upload.md
@@ -431,6 +431,49 @@ In addition to [`upload_file`] and [`upload_folder`], the following functions al
 
 For more detailed information, take a look at the [`HfApi`] reference.
 
+### Preupload LFS files before commit
+
+In some cases, you might want to upload huge files to S3 **before** making the commit call. For example, if you are
+committing a dataset in several shards that are generated in-memory, you would need to upload the shards one by one
+to avoid a out-of-memory issue. A solution is to upload each shard as a separate commit on the repo. While being
+perfectly valid, this solution has the drawback of potentially messing the git history by generating a tens of commits.
+To overcome this issue, you can upload your files one by one to S3 and then create a single commit at the end. This
+is possible using [`preupload_lfs_files`] in combination with [`create_commit`].
+
+<Tip warning={true}>
+
+This is a power-user method. Directly using [`upload_file`], [`upload_folder`] or [`create_commit`] instead of handling
+the low-level logic of pre-uploading files is the way to go in the vast majority of cases. If you have a question,
+feel free to ping us on our Discord or in a Github issue.
+
+</Tip>
+
+Here is a simple example illustrating how to pre-upload files:
+
+```py
+>>> from huggingface_hub import CommitOperationAdd, preupload_lfs_files, create_commit, create_repo
+
+>>> repo_id = create_repo("test_preupload").repo_id
+
+>>> operations = [] # List of all `CommitOperationAdd` objects that will be generated
+>>> for i in range(5):
+...     content = ... # generate binary content
+...     addition = CommitOperationAdd(path_in_repo=f"shard_{i}_of_5.bin", path_or_fileobj=content)
+...     preupload_lfs_files(repo_id, additions=[addition])
+...     operations.append(addition)
+
+# Create commit 
+>>> create_commit(repo_id, operations=operations, commit_message="Commit all shards")
+```
+
+First, we create the [`CommitOperationAdd`] objects one by one. In a real-world example, those would contain the
+generated shards. Each file is uploaded before generating the next one. During the [`preupload_lfs_files`] step, **the
+`CommitOperationAdd` object is mutated**. You should only use it to pass it to directly to [`create_commit`]. The main
+update of the object is that **the binary content is removed** from it, meaning that it will be garbage-collected if
+you don't store another reference to it. This is expected as we don't want to keep in memory the content that is
+already uploaded. Finally we create the commit by passing all the operations to [`create_commit`]. You can pass
+additional operations (add, delete or copy) that have not being processed yet and they will be handled correctly.
+
 ## Tips and tricks for large uploads
 
 There are some limitations to be aware of when dealing with a large amount of data in your repo. Given the time it takes to stream the data,

--- a/docs/source/en/guides/upload.md
+++ b/docs/source/en/guides/upload.md
@@ -435,7 +435,7 @@ For more detailed information, take a look at the [`HfApi`] reference.
 
 In some cases, you might want to upload huge files to S3 **before** making the commit call. For example, if you are
 committing a dataset in several shards that are generated in-memory, you would need to upload the shards one by one
-to avoid a out-of-memory issue. A solution is to upload each shard as a separate commit on the repo. While being
+to avoid an out-of-memory issue. A solution is to upload each shard as a separate commit on the repo. While being
 perfectly valid, this solution has the drawback of potentially messing the git history by generating tens of commits.
 To overcome this issue, you can upload your files one by one to S3 and then create a single commit at the end. This
 is possible using [`preupload_lfs_files`] in combination with [`create_commit`].
@@ -445,7 +445,7 @@ is possible using [`preupload_lfs_files`] in combination with [`create_commit`].
 This is a power-user method. Directly using [`upload_file`], [`upload_folder`] or [`create_commit`] instead of handling
 the low-level logic of pre-uploading files is the way to go in the vast majority of cases. The main caveat of
 [`preupload_lfs_files`] is that until the commit is actually made, the upload files are not accessible on the repo on
-the Hub. If you have a question, feel free to ping us on our Discord or in a Github issue.
+the Hub. If you have a question, feel free to ping us on our Discord or in a GitHub issue.
 
 </Tip>
 
@@ -463,17 +463,17 @@ Here is a simple example illustrating how to pre-upload files:
 ...     preupload_lfs_files(repo_id, additions=[addition])
 ...     operations.append(addition)
 
-# Create commit
+>>> # Create commit
 >>> create_commit(repo_id, operations=operations, commit_message="Commit all shards")
 ```
 
 First, we create the [`CommitOperationAdd`] objects one by one. In a real-world example, those would contain the
 generated shards. Each file is uploaded before generating the next one. During the [`preupload_lfs_files`] step, **the
-`CommitOperationAdd` object is mutated**. You should only use it to pass it to directly to [`create_commit`]. The main
+`CommitOperationAdd` object is mutated**. You should only use it to pass it directly to [`create_commit`]. The main
 update of the object is that **the binary content is removed** from it, meaning that it will be garbage-collected if
 you don't store another reference to it. This is expected as we don't want to keep in memory the content that is
 already uploaded. Finally we create the commit by passing all the operations to [`create_commit`]. You can pass
-additional operations (add, delete or copy) that have not being processed yet and they will be handled correctly.
+additional operations (add, delete or copy) that have not been processed yet and they will be handled correctly.
 
 ## Tips and tricks for large uploads
 

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -194,6 +194,7 @@ _SUBMOD_ATTRS = {
         "model_info",
         "move_repo",
         "pause_space",
+        "preupload_lfs_files",
         "rename_discussion",
         "repo_exists",
         "repo_info",
@@ -512,6 +513,7 @@ if TYPE_CHECKING:  # pragma: no cover
         model_info,  # noqa: F401
         move_repo,  # noqa: F401
         pause_space,  # noqa: F401
+        preupload_lfs_files,  # noqa: F401
         rename_discussion,  # noqa: F401
         repo_exists,  # noqa: F401
         repo_info,  # noqa: F401

--- a/src/huggingface_hub/_commit_api.py
+++ b/src/huggingface_hub/_commit_api.py
@@ -136,9 +136,22 @@ class CommitOperationAdd:
     path_or_fileobj: Union[str, Path, bytes, BinaryIO]
     upload_info: UploadInfo = field(init=False, repr=False)
 
+    # Internal attributes
+    _upload_mode: Optional[UploadMode] = None  # set to "lfs" or "regular" once known
+    _is_uploaded: bool = False  # set to True once the file has been upload as LFS
+    _is_committed: bool = False  # set to True once the file has been committed
+
     def __post_init__(self) -> None:
         """Validates `path_or_fileobj` and compute `upload_info`."""
         self.path_in_repo = _validate_path_in_repo(self.path_in_repo)
+
+        # Validate `_is_uploaded` and `_upload_mode` cannot be set by user
+        if self._is_uploaded is not False:
+            raise ValueError("Attribute `_is_uploaded` cannot be set manually.")
+        if self._upload_mode is not None:
+            raise ValueError("Attribute `_upload_mode` cannot be set manually.")
+        if self._is_committed is not False:
+            raise ValueError("Attribute `_is_committed` cannot be set manually.")
 
         # Validate `path_or_fileobj` value
         if isinstance(self.path_or_fileobj, Path):
@@ -427,10 +440,10 @@ def fetch_upload_modes(
     revision: str,
     endpoint: Optional[str] = None,
     create_pr: bool = False,
-) -> Dict[str, UploadMode]:
+) -> None:
     """
-    Requests the Hub "preupload" endpoint to determine whether each input file
-    should be uploaded as a regular git blob or as git LFS blob.
+    Requests the Hub "preupload" endpoint to determine whether each input file should be uploaded as a regular git blob
+    or as git LFS blob. Input `additions` are mutated in-place with the upload mode.
 
     Args:
         additions (`Iterable` of :class:`CommitOperationAdd`):
@@ -445,9 +458,6 @@ def fetch_upload_modes(
             An authentication token ( See https://huggingface.co/settings/tokens )
         revision (`str`):
             The git revision to upload the files to. Can be any valid git revision.
-
-    Returns: `Dict[str, UploadMode]`
-        Key is the file path, value is the upload mode ("regular" or "lfs").
 
     Raises:
         [`~utils.HfHubHTTPError`]
@@ -483,14 +493,15 @@ def fetch_upload_modes(
         preupload_info = _validate_preupload_info(resp.json())
         upload_modes.update(**{file["path"]: file["uploadMode"] for file in preupload_info["files"]})
 
+    # Set upload mode for each addition operation
+    for addition in additions:
+        addition._upload_mode = upload_modes[addition.path_in_repo]
+
     # Empty files cannot be uploaded as LFS (S3 would fail with a 501 Not Implemented)
     # => empty files are uploaded as "regular" to still allow users to commit them.
     for addition in additions:
         if addition.upload_info.size == 0:
-            path = addition.path_in_repo
-            upload_modes[path] = "regular"
-
-    return upload_modes
+            addition._upload_mode = "regular"
 
 
 @validate_hf_hub_args
@@ -557,7 +568,6 @@ def fetch_lfs_files_to_copy(
 
 def prepare_commit_payload(
     operations: Iterable[CommitOperation],
-    upload_modes: Dict[str, UploadMode],
     files_to_copy: Dict[Tuple[str, Optional[str]], "RepoFile"],
     commit_message: str,
     commit_description: Optional[str] = None,
@@ -584,7 +594,7 @@ def prepare_commit_payload(
     # 2. Send operations, one per line
     for operation in operations:
         # 2.a. Case adding a regular file
-        if isinstance(operation, CommitOperationAdd) and upload_modes.get(operation.path_in_repo) == "regular":
+        if isinstance(operation, CommitOperationAdd) and operation._upload_mode == "regular":
             yield {
                 "key": "file",
                 "value": {
@@ -594,7 +604,7 @@ def prepare_commit_payload(
                 },
             }
         # 2.b. Case adding an LFS file
-        elif isinstance(operation, CommitOperationAdd) and upload_modes.get(operation.path_in_repo) == "lfs":
+        elif isinstance(operation, CommitOperationAdd) and operation._upload_mode == "lfs":
             yield {
                 "key": "lfsFile",
                 "value": {
@@ -627,5 +637,5 @@ def prepare_commit_payload(
         else:
             raise ValueError(
                 f"Unknown operation to commit. Operation: {operation}. Upload mode:"
-                f" {upload_modes.get(operation.path_in_repo)}"
+                f" {getattr(operation, '_upload_mode', None)}"
             )

--- a/src/huggingface_hub/_commit_api.py
+++ b/src/huggingface_hub/_commit_api.py
@@ -263,7 +263,7 @@ def _validate_path_in_repo(path_in_repo: str) -> str:
 CommitOperation = Union[CommitOperationAdd, CommitOperationCopy, CommitOperationDelete]
 
 
-def warn_on_overwriting_operations(operations: List[CommitOperation]) -> None:
+def _warn_on_overwriting_operations(operations: List[CommitOperation]) -> None:
     """
     Warn user when a list of operations is expected to overwrite itself in a single
     commit.
@@ -310,7 +310,7 @@ def warn_on_overwriting_operations(operations: List[CommitOperation]) -> None:
 
 
 @validate_hf_hub_args
-def upload_lfs_files(
+def _upload_lfs_files(
     *,
     additions: List[CommitOperationAdd],
     repo_type: str,
@@ -432,7 +432,7 @@ def _validate_preupload_info(preupload_info: dict):
 
 
 @validate_hf_hub_args
-def fetch_upload_modes(
+def _fetch_upload_modes(
     additions: Iterable[CommitOperationAdd],
     repo_type: str,
     repo_id: str,
@@ -505,7 +505,7 @@ def fetch_upload_modes(
 
 
 @validate_hf_hub_args
-def fetch_lfs_files_to_copy(
+def _fetch_lfs_files_to_copy(
     copies: Iterable[CommitOperationCopy],
     repo_type: str,
     repo_id: str,
@@ -566,7 +566,7 @@ def fetch_lfs_files_to_copy(
     return files_to_copy
 
 
-def prepare_commit_payload(
+def _prepare_commit_payload(
     operations: Iterable[CommitOperation],
     files_to_copy: Dict[Tuple[str, Optional[str]], "RepoFile"],
     commit_message: str,

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -3459,6 +3459,20 @@ class HfApi:
 
         Example:
         ```py
+        >>> from huggingface_hub import CommitOperationAdd, preupload_lfs_files, create_commit, create_repo
+
+        >>> repo_id = create_repo("test_preupload").repo_id
+
+        # Generate and preupload LFS files one by one
+        >>> operations = [] # List of all `CommitOperationAdd` objects that will be generated
+        >>> for i in range(5):
+        ...     content = ... # generate binary content
+        ...     addition = CommitOperationAdd(path_in_repo=f"shard_{i}_of_5.bin", path_or_fileobj=content)
+        ...     preupload_lfs_files(repo_id, additions=[addition]) # upload + free memory
+        ...     operations.append(addition)
+
+        # Create commit
+        >>> create_commit(repo_id, operations=operations, commit_message="Commit all shards")
         ```
         """
         repo_type = repo_type if repo_type is not None else REPO_TYPE_MODEL

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -63,11 +63,11 @@ from ._commit_api import (
     CommitOperationAdd,
     CommitOperationCopy,
     CommitOperationDelete,
-    fetch_lfs_files_to_copy,
-    fetch_upload_modes,
-    prepare_commit_payload,
-    upload_lfs_files,
-    warn_on_overwriting_operations,
+    _fetch_lfs_files_to_copy,
+    _fetch_upload_modes,
+    _prepare_commit_payload,
+    _upload_lfs_files,
+    _warn_on_overwriting_operations,
 )
 from ._multi_commits import (
     MULTI_COMMIT_PR_CLOSE_COMMENT_FAILURE_BAD_REQUEST_TEMPLATE,
@@ -3031,7 +3031,7 @@ class HfApi:
         )
 
         # If updating twice the same file or update then delete a file in a single commit
-        warn_on_overwriting_operations(operations)
+        _warn_on_overwriting_operations(operations)
 
         self.preupload_lfs_files(
             repo_id=repo_id,
@@ -3043,7 +3043,7 @@ class HfApi:
             num_threads=num_threads,
             free_memory=False,  # do not remove `CommitOperationAdd.path_or_fileobj` on LFS files for "normal" users
         )
-        files_to_copy = fetch_lfs_files_to_copy(
+        files_to_copy = _fetch_lfs_files_to_copy(
             copies=copies,
             repo_type=repo_type,
             repo_id=repo_id,
@@ -3051,7 +3051,7 @@ class HfApi:
             revision=revision,
             endpoint=self.endpoint,
         )
-        commit_payload = prepare_commit_payload(
+        commit_payload = _prepare_commit_payload(
             operations=operations,
             files_to_copy=files_to_copy,
             commit_message=commit_message,
@@ -3472,7 +3472,7 @@ class HfApi:
 
         # Check which new files are LFS
         try:
-            fetch_upload_modes(
+            _fetch_upload_modes(
                 additions=new_additions,
                 repo_type=repo_type,
                 repo_id=repo_id,
@@ -3489,7 +3489,7 @@ class HfApi:
         new_lfs_additions = [addition for addition in new_additions if addition._upload_mode == "lfs"]
 
         # Upload new LFS files
-        upload_lfs_files(
+        _upload_lfs_files(
             additions=new_lfs_additions,
             repo_type=repo_type,
             repo_id=repo_id,

--- a/tests/test_commit_api.py
+++ b/tests/test_commit_api.py
@@ -3,7 +3,7 @@ import unittest
 from huggingface_hub._commit_api import (
     CommitOperationAdd,
     CommitOperationDelete,
-    warn_on_overwriting_operations,
+    _warn_on_overwriting_operations,
 )
 
 
@@ -104,7 +104,7 @@ class TestWarnOnOverwritingOperations(unittest.TestCase):
     delete_folder_e = CommitOperationDelete(path_in_repo="e/")
 
     def test_no_overwrite(self) -> None:
-        warn_on_overwriting_operations(
+        _warn_on_overwriting_operations(
             [
                 self.add_file_ab,
                 self.add_file_abc,
@@ -115,21 +115,21 @@ class TestWarnOnOverwritingOperations(unittest.TestCase):
 
     def test_add_then_update_file(self) -> None:
         with self.assertWarns(UserWarning):
-            warn_on_overwriting_operations([self.add_file_abc, self.update_file_abc])
+            _warn_on_overwriting_operations([self.add_file_abc, self.update_file_abc])
 
     def test_add_then_delete_file(self) -> None:
         with self.assertWarns(UserWarning):
-            warn_on_overwriting_operations([self.add_file_abc, self.delete_file_abc])
+            _warn_on_overwriting_operations([self.add_file_abc, self.delete_file_abc])
 
     def test_add_then_delete_folder(self) -> None:
         with self.assertWarns(UserWarning):
-            warn_on_overwriting_operations([self.add_file_abc, self.delete_folder_a])
+            _warn_on_overwriting_operations([self.add_file_abc, self.delete_folder_a])
 
         with self.assertWarns(UserWarning):
-            warn_on_overwriting_operations([self.add_file_ab, self.delete_folder_a])
+            _warn_on_overwriting_operations([self.add_file_ab, self.delete_folder_a])
 
     def test_delete_file_then_add(self) -> None:
-        warn_on_overwriting_operations([self.delete_file_abc, self.add_file_abc])
+        _warn_on_overwriting_operations([self.delete_file_abc, self.add_file_abc])
 
     def test_delete_folder_then_add(self) -> None:
-        warn_on_overwriting_operations([self.delete_folder_a, self.add_file_ab, self.add_file_abc])
+        _warn_on_overwriting_operations([self.delete_folder_a, self.add_file_ab, self.add_file_abc])

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -39,7 +39,7 @@ from huggingface_hub._commit_api import (
     CommitOperationAdd,
     CommitOperationCopy,
     CommitOperationDelete,
-    fetch_upload_modes,
+    _fetch_upload_modes,
 )
 from huggingface_hub.community import DiscussionComment, DiscussionWithDetails
 from huggingface_hub.constants import (
@@ -911,7 +911,7 @@ class CommitApiTest(HfApiCommonTest):
     def test_commit_preflight_on_lots_of_lfs_files(self, repo_url: RepoUrl):
         """Test committing 1300 LFS files at once.
 
-        This was not possible when `fetch_upload_modes` was not fetching metadata by
+        This was not possible when `_fetch_upload_modes` was not fetching metadata by
         chunks. We are not testing the full upload as it would require to upload 1300
         files which is unnecessary for the test. Having an overall large payload (for
         `/create-commit` endpoint) is tested in `test_create_commit_huge_regular_files`.
@@ -928,8 +928,8 @@ class CommitApiTest(HfApiCommonTest):
             for num in range(1300)
         ]
 
-        # Test `fetch_upload_modes` preflight ("are they regular or LFS files?")
-        fetch_upload_modes(
+        # Test `_fetch_upload_modes` preflight ("are they regular or LFS files?")
+        _fetch_upload_modes(
             additions=operations,
             repo_type="model",
             repo_id=repo_url.repo_id,


### PR DESCRIPTION
Related to https://github.com/huggingface/datasets/issues/6257#issuecomment-1736822023 cc @mariosasko @lhoestq.

The goal of this PR is to add the possibility to preupload files before making the `create_commit` call. This is expected to be only a power-user feature meant for users generating huge files on the fly (e.g. basically `datasets` when uploading sharded parquet files). The current problem is that each file has to be committed one by one to avoid out-of-memory issues. This strategy leads to 1. users being rate-limited (too many commits) 2. messy git history.

The solution proposed in this PR is to add a `preupload_lfs_files` methods. It takes a list of `CommitOperationAdd` and upload them to S3 (if LFS). Once all the `CommitOperationAdd` are uploaded, a single `create_commit` call is needed.

To make this work, `CommitOperationAdd` is mutated during the `create_commit` process. Some internal attributes are set to keep track of the status (`_upload_mode`, `_is_uploaded`, `_is_committed`). This is the case no matter if the user uses `preupload_lfs_files` or not.  **This is a breaking change** but I don't expect to break any current workflow. This is only a problem is a user defines a `CommitOperationAdd` object to commit to 2 different repos.

Finally `preupload_lfs_files` also mutates the `CommitOperationAdd` objects **to remove the binary content** from them. This is expected as we want to free up the memory (this is the purpose of the whole PR :smile:).

**Documentation:**
- [guide](https://moon-ci-docs.huggingface.co/docs/huggingface_hub/pr_1699/en/guides/upload#preupload-lfs-files-before-commit)
- [preupload_lfs_files](https://moon-ci-docs.huggingface.co/docs/huggingface_hub/pr_1699/en/package_reference/hf_api#huggingface_hub.HfApi.preupload_lfs_files) 
- [create_commit](https://moon-ci-docs.huggingface.co/docs/huggingface_hub/pr_1699/en/package_reference/hf_api#huggingface_hub.HfApi.create_commit) (added warnings)

---

Here is how it would look like:

```py
>>> from huggingface_hub import CommitOperationAdd, preupload_lfs_files, create_commit, create_repo

>>> repo_id = create_repo("test_preupload").repo_id

>>> operations = [] # List of all `CommitOperationAdd` objects that will be generated
>>> for i in range(5):
...     content = ... # generate binary content
...     addition = CommitOperationAdd(path_in_repo=f"shard_{i}_of_5.bin", path_or_fileobj=content)
...     preupload_lfs_files(repo_id, additions=[addition])
...     operations.append(addition)

# Create commit
>>> create_commit(repo_id, operations=operations, commit_message="Commit all shards")
```

**TODO:**
- [x] release memory after upload
- [x] documentation
- [x] tests
- [x] draft integration with `datasets` (https://github.com/huggingface/datasets/pull/6269)