### PR TITLE
Handle TGI error when streaming tokens

### DIFF
--- a/src/huggingface_hub/inference/_common.py
+++ b/src/huggingface_hub/inference/_common.py
@@ -48,9 +48,7 @@ from ..utils import (
     is_numpy_available,
     is_pillow_available,
 )
-from ._text_generation import (
-    TextGenerationStreamResponse,
-)
+from ._text_generation import TextGenerationStreamResponse, _parse_text_generation_error
 
 
 if TYPE_CHECKING:
@@ -275,7 +273,10 @@ def _stream_text_generation_response(
         if payload.startswith("data:"):
             # Decode payload
             json_payload = json.loads(payload.lstrip("data:").rstrip("/n"))
-            # Parse payload
+            # Either an error as being returned
+            if json_payload.get("error") is not None:
+                raise _parse_text_generation_error(json_payload["error"], json_payload.get("error_type"))
+            # Or parse token payload
             output = TextGenerationStreamResponse(**json_payload)
             yield output.token.text if not details else output
 
@@ -295,7 +296,10 @@ async def _async_stream_text_generation_response(
         if payload.startswith("data:"):
             # Decode payload
             json_payload = json.loads(payload.lstrip("data:").rstrip("/n"))
-            # Parse payload
+            # Either an error as being returned
+            if json_payload.get("error") is not None:
+                raise _parse_text_generation_error(json_payload["error"], json_payload.get("error_type"))
+            # Or parse token payload
             output = TextGenerationStreamResponse(**json_payload)
             yield output.token.text if not details else output
 

--- a/src/huggingface_hub/inference/_text_generation.py
+++ b/src/huggingface_hub/inference/_text_generation.py
@@ -472,7 +472,7 @@ def raise_text_generation_error(http_error: HTTPError) -> NoReturn:
     # If error_type => more information than `hf_raise_for_status`
     if error_type is not None:
         exception = _parse_text_generation_error(error, error_type)
-        raise exception from http_error  # type: ignore
+        raise exception from http_error
 
     # Otherwise, fallback to default error
     raise http_error
@@ -480,11 +480,11 @@ def raise_text_generation_error(http_error: HTTPError) -> NoReturn:
 
 def _parse_text_generation_error(error: Optional[str], error_type: Optional[str]) -> TextGenerationError:
     if error_type == "generation":
-        return GenerationError(error)
+        return GenerationError(error)  # type: ignore
     if error_type == "incomplete_generation":
-        return IncompleteGenerationError(error)
+        return IncompleteGenerationError(error)  # type: ignore
     if error_type == "overloaded":
-        return OverloadedError(error)
+        return OverloadedError(error)  # type: ignore
     if error_type == "validation":
-        return ValidationError(error)
-    return UnknownError(error)
+        return ValidationError(error)  # type: ignore
+    return UnknownError(error)  # type: ignore


### PR DESCRIPTION
Fix https://github.com/huggingface/huggingface_hub/issues/1651.

When streaming tokens from a TGI server, an error might happen and be returned in the stream of tokens. At the moment this raises a pydantic ValidationError as it's not recognized as a proper `TextGenerationStreamResponse`. This PR adds a check to parse correctly the error message + raise a custom exception whenever possible.

cc @osanseviero @OlivierDehaene 

**Note:** I couldn't really test this PR as the problem is hard to reproduce (it happened in the falcon-180b demo Space which has heavy usage -see [thread](https://huggingface.slack.com/archives/C05PZ9K0L6R/p1694091341361899?thread_ts=1694033671.072209&cid=C05PZ9K0L6R) (internal)). Shouldn't be too risky though (error/error_type being optional client-side).