### PR TITLE
Handle `refs/convert/parquet` and PR revision correctly in hffs

### DIFF
--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -27,10 +27,10 @@ from .utils import (
 # Regex used to match special revisions with "/" in them (see #1710)
 SPECIAL_REFS_REVISION_REGEX = re.compile(
     r"""
-(^refs\/convert\/parquet) # `refs/convert/parquet` revisions
-|
-(^refs\/pr\/\d+)          # PR revisions
-""",
+    (^refs\/convert\/parquet) # `refs/convert/parquet` revisions
+    |
+    (^refs\/pr\/\d+)          # PR revisions
+    """,
     re.VERBOSE,
 )
 


### PR DESCRIPTION
Solves https://github.com/huggingface/huggingface_hub/issues/1710 by processing `refs/convert/parquet` and `refs/pr/(\d)+` as special revisions when resolving a path. Also make sure that the `unresolve` counterpart works the same. Also added some tests for it.

Use case from @Hakimovich99 now works properly without having to url-encode the revision. This time I tested with [jamescalam/llama-2-arxiv-papers-chunked](https://huggingface.co/datasets/jamescalam/llama-2-arxiv-papers-chunked) dataset which doesn't have parquet files on `main` revision:

```py
>>> from dask import dataframe as dd
>>> dd.read_parquet("hf://datasets/jamescalam/llama-2-arxiv-papers-chunked@refs/convert/parquet")
# Dask DataFrame Structure:
#                  doi chunk-id   chunk      id   title summary  source authors categories comment journal_ref primary_category published updated references
# npartitions=1                                                                                                                                              
#               object   object  object  object  object  object  object  object     object  object      object           object    object  object     object
#                  ...      ...     ...     ...     ...     ...     ...     ...        ...     ...         ...              ...       ...     ...        ...
# Dask Name: read-parquet, 1 graph layer

>>> dd.read_parquet("hf://datasets/jamescalam/llama-2-arxiv-papers-chunked@refs/convert/parquet/default/train/0000.parquet")
# Dask DataFrame Structure:
#                   doi chunk-id   chunk      id   title summary  source authors categories comment journal_ref primary_category published updated references
# npartitions=1                                                                                                                                              
#                object   object  object  object  object  object  object  object     object  object      object           object    object  object     object
#                   ...      ...     ...     ...     ...     ...     ...     ...        ...     ...         ...              ...       ...     ...        ...
# Dask Name: read-parquet, 1 graph layer
```

This should be a small QOL improvements for datasets users while not degrading the experience for others.