### PR TITLE
Fix LFS tests after password auth deprecation

### DIFF
--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -27,7 +27,7 @@ from io import BytesIO
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 from unittest.mock import Mock, patch
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 
 import pytest
 import requests
@@ -81,7 +81,6 @@ from huggingface_hub.utils.endpoint_helpers import (
 
 from .testing_constants import (
     ENDPOINT_STAGING,
-    ENDPOINT_STAGING_BASIC_AUTH,
     FULL_NAME,
     OTHER_TOKEN,
     OTHER_USER,
@@ -2132,9 +2131,11 @@ class HfLargefilesTest(HfApiCommonTest):
         self._api.delete_repo(repo_id=self.repo_id)
 
     def setup_local_clone(self) -> None:
-        REMOTE_URL_AUTH = self.repo_url.replace(ENDPOINT_STAGING, ENDPOINT_STAGING_BASIC_AUTH)
+        scheme = urlparse(self.repo_url).scheme
+        repo_url_auth = self.repo_url.replace(f"{scheme}://", f"{scheme}://user:{TOKEN}@")
+
         subprocess.run(
-            ["git", "clone", REMOTE_URL_AUTH, str(self.cache_dir)],
+            ["git", "clone", repo_url_auth, str(self.cache_dir)],
             check=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,

--- a/tests/test_repocard.py
+++ b/tests/test_repocard.py
@@ -23,7 +23,6 @@ import yaml
 from huggingface_hub import (
     DatasetCard,
     DatasetCardData,
-    EntryNotFoundError,
     EvalResult,
     ModelCard,
     ModelCardData,
@@ -42,7 +41,7 @@ from huggingface_hub.file_download import hf_hub_download
 from huggingface_hub.hf_api import HfApi
 from huggingface_hub.repocard import REGEX_YAML_BLOCK
 from huggingface_hub.repocard_data import CardData
-from huggingface_hub.utils import SoftTemporaryDirectory, is_jinja_available, logging
+from huggingface_hub.utils import EntryNotFoundError, SoftTemporaryDirectory, is_jinja_available, logging
 
 from .testing_constants import (
     ENDPOINT_STAGING,

--- a/tests/testing_constants.py
+++ b/tests/testing_constants.py
@@ -15,7 +15,6 @@ OTHER_TOKEN = "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"
 
 ENDPOINT_PRODUCTION = "https://huggingface.co"
 ENDPOINT_STAGING = "https://hub-ci.huggingface.co"
-ENDPOINT_STAGING_BASIC_AUTH = f"https://{USER}:{PASS}@hub-ci.huggingface.co"
 
 ENDPOINT_PRODUCTION_URL_SCHEME = ENDPOINT_PRODUCTION + "/{repo_id}/resolve/{revision}/{filename}"
 


### PR DESCRIPTION
This PR should fix the current CI failure (LFS tests not passing).

LFS tests were using password authenticating when cloning/pushing a git repo. This is now deprecated in favor of SSH or token-based auth (see [blog article](https://huggingface.co/blog/password-git-deprecation)). For those tests, let's use token-based instead. 

cc @Pierrci @coyotte508 

(I also refactored a bit the repocard tests that were using password-auth URLs as well -not wrong but a bit old and dirty :grimacing:)