### PR TITLE
Add list_repo_likers method to HfApi

### DIFF
--- a/docs/source/en/package_reference/hf_api.md
+++ b/docs/source/en/package_reference/hf_api.md
@@ -71,6 +71,10 @@ models = hf_api.list_models()
 
 [[autodoc]] huggingface_hub.hf_api.SpaceInfo
 
+### User
+
+[[autodoc]] huggingface_hub.hf_api.User
+
 ### UserLikes
 
 [[autodoc]] huggingface_hub.hf_api.UserLikes

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -143,6 +143,7 @@ _SUBMOD_ATTRS = {
         "HfApi",
         "ModelSearchArguments",
         "RepoUrl",
+        "User",
         "UserLikes",
         "add_collection_item",
         "add_space_secret",
@@ -188,6 +189,7 @@ _SUBMOD_ATTRS = {
         "list_models",
         "list_repo_commits",
         "list_repo_files",
+        "list_repo_likers",
         "list_repo_refs",
         "list_spaces",
         "merge_pull_request",
@@ -462,6 +464,7 @@ if TYPE_CHECKING:  # pragma: no cover
         HfApi,  # noqa: F401
         ModelSearchArguments,  # noqa: F401
         RepoUrl,  # noqa: F401
+        User,  # noqa: F401
         UserLikes,  # noqa: F401
         add_collection_item,  # noqa: F401
         add_space_secret,  # noqa: F401
@@ -507,6 +510,7 @@ if TYPE_CHECKING:  # pragma: no cover
         list_models,  # noqa: F401
         list_repo_commits,  # noqa: F401
         list_repo_files,  # noqa: F401
+        list_repo_likers,  # noqa: F401
         list_repo_refs,  # noqa: F401
         list_spaces,  # noqa: F401
         merge_pull_request,  # noqa: F401

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -1798,9 +1798,7 @@ class HfApi:
 
         # Parse the results into User objects
         likers_data = response.json()
-        likers = [User(**user_data) for user_data in likers_data]
-
-        return likers
+        return [User(**user_data) for user_data in likers_data]
 
     @validate_hf_hub_args
     def model_info(

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -1766,7 +1766,7 @@ class HfApi:
         token: Optional[str] = None,
     ) -> List[User]:
         """
-        List all users who liked a given repo on huggingface.co.
+        List all users who liked a given repo on the hugging Face Hub.
 
         See also [`like`] and [`list_liked_repos`].
 

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2467,6 +2467,22 @@ class ActivityApiTest(unittest.TestCase):
         likes = self.api.list_liked_repos(user="__DUMMY_DATASETS_SERVER_USER__", token=TOKEN)
         self.assertEqual(likes.user, "__DUMMY_DATASETS_SERVER_USER__")
 
+    def test_list_repo_likers(self) -> None:
+        # Create a repo + like
+        repo_id = self.api.create_repo(repo_name(), token=TOKEN).repo_id
+        self.api.like(repo_id, token=TOKEN)
+
+        # Use list_repo_likers to get the list of users who liked this repo
+        likers = self.api.list_repo_likers(repo_id, token=TOKEN)
+
+        # Check if the test user is in the list of likers
+        liker_usernames = [user.name for user in likers]
+        self.assertGreater(len(likers), 0)
+        self.assertIn(USER, liker_usernames)
+
+        # Cleanup
+        self.api.delete_repo(repo_id, token=TOKEN)
+
     @with_production_testing
     def test_list_likes_on_production(self) -> None:
         # Test julien-c likes a lot of repos !
@@ -3134,8 +3150,10 @@ class RepoUrlTest(unittest.TestCase):
         # __repr__ is modified for debugging purposes
         self.assertEqual(
             repr(url),
-            "RepoUrl('https://huggingface.co/gpt2',"
-            " endpoint='https://huggingface.co', repo_type='model', repo_id='gpt2')",
+            (
+                "RepoUrl('https://huggingface.co/gpt2',"
+                " endpoint='https://huggingface.co', repo_type='model', repo_id='gpt2')"
+            ),
         )
 
     def test_repo_url_endpoint(self):

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2476,7 +2476,7 @@ class ActivityApiTest(unittest.TestCase):
         likers = self.api.list_repo_likers(repo_id, token=TOKEN)
 
         # Check if the test user is in the list of likers
-        liker_usernames = [user.name for user in likers]
+        liker_usernames = [user.username for user in likers]
         self.assertGreater(len(likers), 0)
         self.assertIn(USER, liker_usernames)
 
@@ -3150,10 +3150,8 @@ class RepoUrlTest(unittest.TestCase):
         # __repr__ is modified for debugging purposes
         self.assertEqual(
             repr(url),
-            (
-                "RepoUrl('https://huggingface.co/gpt2',"
-                " endpoint='https://huggingface.co', repo_type='model', repo_id='gpt2')"
-            ),
+            "RepoUrl('https://huggingface.co/gpt2',"
+            " endpoint='https://huggingface.co', repo_type='model', repo_id='gpt2')",
         )
 
     def test_repo_url_endpoint(self):


### PR DESCRIPTION
### Summary
This PR introduces the `list_repo_likers` method to the `HfApi` class, allowing users to retrieve a list of likers for a given model repository on the Hugging Face Hub.

### Changes
- Implemented `list_repo_likers` method in `HfApi`.
- Added corresponding dataclass `User` to represent users who liked a repo.
- Integrated a new API endpoint to fetch likers for a given model repository.
- Added unit tests to ensure the correctness of the method.

### Motivation
- Fixes #1705 - Return the liked users for a Hugging Face model
- Users will now have the ability to see who liked their models, fostering community interactions and recognition.
