### PR TITLE
Bump version to 0.19

### DIFF
--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -46,7 +46,7 @@ import sys
 from typing import TYPE_CHECKING
 
 
-__version__ = "0.18.0.dev0"
+__version__ = "0.19.0.dev0"
 
 # Alphabetical order of definitions is ensured in tests
 # WARNING: any comment added in this dictionary definition will be lost when

--- a/src/huggingface_hub/inference_api.py
+++ b/src/huggingface_hub/inference_api.py
@@ -92,7 +92,7 @@ class InferenceApi:
 
     @validate_hf_hub_args
     @_deprecate_method(
-        version="0.19.0",
+        version="1.0",
         message=(
             "`InferenceApi` client is deprecated in favor of the more feature-complete `InferenceClient`. Check out"
             " this guide to learn how to convert your script to use it:"


### PR DESCRIPTION
Follow-up after 0.18 release.

`InferenceAPI` was announced to be removed by now but I don't think it's wise. Given how much it has being used in external libraries and scripts I think it's wiser to deprecate it with no real deadline (I've set `v1.0` but not sure it'll happen someday^^).