### PR TITLE
Deprecate `Repository` class

### DIFF
--- a/docs/source/en/concepts/git_vs_http.md
+++ b/docs/source/en/concepts/git_vs_http.md
@@ -33,6 +33,12 @@ this may not always be necessary as users may only need to download weights for 
 or convert weights from one format to another without the need to clone the entire
 repository.
 
+<Tip warning={true}>
+
+[`Repository`] is now deprecated in favor of the http-based alternatives. Given its large adoption in legacy code, the complete removal of [`Repository`] will only happen in release `v1.0`.
+
+</Tip>
+
 ## HfApi: a flexible and convenient HTTP client
 
 The [`HfApi`] class was developed to provide an alternative to local git repositories, which
@@ -49,16 +55,8 @@ discussions, PRs, and comments, and configure Spaces hardware and secrets.
 ## What should I use ? And when ?
 
 Overall, the **HTTP-based approach is the recommended way to use** `huggingface_hub`
-in most cases. However, there are a few situations where maintaining a local git clone
-(using [`Repository`]) may be more beneficial:
-- If you are training a model on your machine, it may be more efficient to use a traditional
-git-based workflow, pushing regular updates. [`Repository`] is optimized for this type of
-situation with its ability to work in the background.
-- If you need to manually edit large files, `git` is the best option as it only sends the
-diff to the server. With the [`HfAPI`] client, the entire file is uploaded with each edit.
-Do keep in mind that most large files are binary so do not benefit from git diffs anyway.
+in all cases. [`HfApi`] allows to pull and push changes, work with PRs, tags and branches, interact with discussions and much more. Since the `0.16` release, the http-based methods can also run in the background, which was the last major advantage of the [`Repository`] class.
 
-Not all git commands are available through [`HfApi`]. Some may never be implemented, but
-we are always trying to improve and close the gap. If you don't see your use case covered,
-please open [an issue on Github](https://github.com/huggingface/huggingface_hub)! We
-welcome feedback to help build the 🤗 ecosystem with and for our users.
+However, not all git commands are available through [`HfApi`]. Some may never be implemented, but we are always trying to improve and close the gap. If you don't see your use case covered, please open [an issue on Github](https://github.com/huggingface/huggingface_hub)! We welcome feedback to help build the 🤗 ecosystem with and for our users.
+
+This preference of the http-based [`HfApi`] over the git-based [`Repository`] does not mean that git versioning will disappear from the Hugging Face Hub anytime soon. It will always be possible to use `git` commands locally in workflows where it makes sense.

--- a/docs/source/en/guides/repository.md
+++ b/docs/source/en/guides/repository.md
@@ -165,9 +165,13 @@ that you should be aware of. For example, you can't transfer your repo to anothe
 All the actions described above can be done using HTTP requests. However, in some cases you might be interested in having
 a local copy of your repository and interact with it using the Git commands you are familiar with.
 
-The [`Repository`] class allows you to interact with files and repositories on the Hub with functions similar to Git commands.
-It is a wrapper over Git and Git-LFS methods to use the Git commands you already know and love. Before starting, please make
-sure you have Git-LFS installed (see [here](https://git-lfs.github.com/) for installation instructions).
+The [`Repository`] class allows you to interact with files and repositories on the Hub with functions similar to Git commands. It is a wrapper over Git and Git-LFS methods to use the Git commands you already know and love. Before starting, please make sure you have Git-LFS installed (see [here](https://git-lfs.github.com/) for installation instructions).
+
+<Tip warning={true}>
+
+[`Repository`] is deprecated in favor of the http-based alternatives implemented in [`HfApi`]. Given its large adoption in legacy code, the complete removal of [`Repository`] will only happen in release `v1.0`. For more details, please read [this explanation page](./concepts/git_vs_http).
+
+</Tip>
 
 ### Use a local repository
 

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -22,6 +22,7 @@ from .utils import (
     tqdm,
     validate_hf_hub_args,
 )
+from .utils._deprecation import _deprecate_method
 
 
 logger = logging.get_logger(__name__)
@@ -421,6 +422,14 @@ def _lfs_log_progress():
             os.environ["GIT_LFS_PROGRESS"] = current_lfs_progress_value
 
 
+@_deprecate_method(
+    version="1.0",
+    message=(
+        "Please prefer the http-based alternatives instead. Given its large adoption in legacy code, the complete"
+        " removal is only planned on next major release.\nFor more details, please read"
+        " https://huggingface.co/docs/huggingface_hub/concepts/git_vs_http."
+    ),
+)
 class Repository:
     """
     Helper class to wrap the git and git-lfs commands.
@@ -428,6 +437,15 @@ class Repository:
     The aim is to facilitate interacting with huggingface.co hosted model or
     dataset repos, though not a lot here (if any) is actually specific to
     huggingface.co.
+
+    <Tip warning={true}>
+
+    [`Repository`] is deprecated in favor of the http-based alternatives implemented in
+    [`HfApi`]. Given its large adoption in legacy code, the complete removal of
+    [`Repository`] will only happen in release `v1.0`. For more details, please read
+    https://huggingface.co/docs/huggingface_hub/concepts/git_vs_http.
+
+    </Tip>
     """
 
     command_queue: List[CommandInProgress]

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -902,6 +902,7 @@ class TestRepositoryDataset(RepositoryTestAbstract):
         self.assertTrue((self.repo_path / "file.txt").exists())
 
     @retry_endpoint
+    @expect_deprecation("Repository")
     def test_clone_dataset_no_ci_user_and_email(self):
         Repository(self.repo_path, clone_from=self.repo_id, repo_type="dataset")
         self.assertTrue((self.repo_path / "file.txt").exists())

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -104,6 +104,7 @@ class TestRepositoryShared(RepositoryTestAbstract):
     def test_clone_from_repo_id(self):
         Repository(self.repo_path, clone_from=self.repo_id)
 
+    @expect_deprecation("Repository")
     def test_clone_from_repo_name_no_namespace_fails(self):
         with self.assertRaises(EnvironmentError):
             Repository(self.repo_path, clone_from=self.repo_id.split("/")[1], token=TOKEN)


### PR DESCRIPTION
@julien-c @LysandreJik @osanseviero WDYT of deprecating `Repository` with a link to the ["Git vs HTTP"](https://huggingface.co/docs/huggingface_hub/concepts/git_vs_http) page?

The main feature that was missing at some point was the ability to push changes in the background, which is now doable using `HfApi.run_as_future(...)`. Also, the Trainer implementation in `transformers` has already switched to the http-based approach 3 months ago (https://github.com/huggingface/transformers/pull/25095) without any reported issue.

Given how used `Repository` has been, I think it's good to deprecate it but with a long deprecation cycle (I've set `v1.0` and I'm not even sure it will happen one day :smile:). I still think it's better to have a warning message even if no deadline than nothing.

---

**EDIT:** it would allow better discoverability IMO, for example to avoid https://github.com/huggingface/huggingface_hub/issues/1721#issuecomment-1759381037.