### PR TITLE
Make `@retry_endpoint` a default for all test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,17 +1,25 @@
 import os
 import shutil
+import time
+from functools import wraps
 from pathlib import Path
-from typing import Generator
+from typing import Generator, List
 
 import pytest
 from _pytest.fixtures import SubRequest
+from _pytest.python import Function as PytestFunction
+from requests.exceptions import HTTPError
 
 import huggingface_hub
 from huggingface_hub import HfApi, HfFolder
-from huggingface_hub.utils import SoftTemporaryDirectory
+from huggingface_hub.utils import SoftTemporaryDirectory, logging
+from huggingface_hub.utils._typing import CallableT
 
 from .testing_constants import ENDPOINT_PRODUCTION, PRODUCTION_TOKEN
 from .testing_utils import repo_name, set_write_permission_and_retry
+
+
+logger = logging.get_logger(__name__)
 
 
 @pytest.fixture
@@ -73,6 +81,56 @@ def disable_symlinks_on_windows_ci(monkeypatch: pytest.MonkeyPatch) -> None:
 @pytest.fixture(autouse=True)
 def disable_experimental_warnings(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(huggingface_hub.constants, "HF_HUB_DISABLE_EXPERIMENTAL_WARNING", True)
+
+
+def retry_on_transient_error(fn: CallableT) -> CallableT:
+    """
+    Retry test if failure because of unavailable service or race condition.
+
+    Tests are retried up to 3 times, waiting 5s between each try.
+    """
+    NUMBER_OF_TRIES = 3
+    WAIT_TIME = 5
+
+    @wraps(fn)
+    def _inner(*args, **kwargs):
+        retry_count = 1
+        while retry_count < NUMBER_OF_TRIES:
+            try:
+                return fn(*args, **kwargs)
+            except HTTPError as e:
+                if e.response.status_code == 504:
+                    logger.info(
+                        f"Attempt {retry_count} failed with a 504 error. Retrying new  execution in"
+                        f" {WAIT_TIME} second(s)..."
+                    )
+                    time.sleep(WAIT_TIME)
+                    retry_count += 1
+            except OSError:
+                logger.info(
+                    "Race condition met where we tried to `clone` before fully deleting a repository. Retrying new"
+                    f" execution in {WAIT_TIME} second(s)..."
+                )
+                time.sleep(WAIT_TIME)
+                retry_count += 1
+
+            # Preserve original traceback
+            return fn(*args, **kwargs)
+
+    return _inner
+
+
+def pytest_collection_modifyitems(items: List[PytestFunction]):
+    """Alter all tests to retry on transient errors.
+
+    Note: equivalent to the previously used `@retry_endpoint` decorator, but tests do
+          not have to be decorated individually anymore.
+    """
+    # called after collection is completed
+    # you can modify the ``items`` list
+    # see https://docs.pytest.org/en/7.3.x/how-to/writing_hook_functions.html
+    for item in items:
+        item.obj = retry_on_transient_error(item.obj)
 
 
 @pytest.fixture

--- a/tests/test_keras_integration.py
+++ b/tests/test_keras_integration.py
@@ -23,7 +23,6 @@ from huggingface_hub.utils import (
 from .testing_constants import ENDPOINT_STAGING, TOKEN, USER
 from .testing_utils import (
     repo_name,
-    retry_endpoint,
 )
 
 
@@ -121,7 +120,6 @@ class HubMixingTestKeras(CommonKerasTest):
         model = DummyModel.from_pretrained(self.cache_dir)
         self.assertTrue(model.config == {"num": 10, "act": "gelu_fast"})
 
-    @retry_endpoint
     def test_push_to_hub_keras_mixin_via_http_basic(self):
         repo_id = f"{USER}/{repo_name()}"
 
@@ -253,7 +251,6 @@ class HubKerasSequentialTest(CommonKerasTest):
         self.assertTrue(tf.reduce_all(tf.equal(new_model.weights[0], model.weights[0])))
         self.assertTrue(new_model.config == {"num": 10, "act": "gelu_fast"})
 
-    @retry_endpoint
     def test_push_to_hub_keras_sequential_via_http_basic(self):
         repo_id = f"{USER}/{repo_name()}"
         model = self.model_init()
@@ -266,7 +263,6 @@ class HubKerasSequentialTest(CommonKerasTest):
         self.assertTrue("model.png" in [f.rfilename for f in model_info.siblings])
         self._api.delete_repo(repo_id=repo_id)
 
-    @retry_endpoint
     def test_push_to_hub_keras_sequential_via_http_plot_false(self):
         repo_id = f"{USER}/{repo_name()}"
         model = self.model_init()
@@ -277,7 +273,6 @@ class HubKerasSequentialTest(CommonKerasTest):
         self.assertFalse("model.png" in [f.rfilename for f in model_info.siblings])
         self._api.delete_repo(repo_id=repo_id)
 
-    @retry_endpoint
     def test_push_to_hub_keras_via_http_override_tensorboard(self):
         """Test log directory is overwritten when pushing a keras model a 2nd time."""
         repo_id = f"{USER}/{repo_name()}"
@@ -301,7 +296,6 @@ class HubKerasSequentialTest(CommonKerasTest):
 
         self._api.delete_repo(repo_id=repo_id)
 
-    @retry_endpoint
     def test_push_to_hub_keras_via_http_with_model_kwargs(self):
         repo_id = f"{USER}/{repo_name()}"
 

--- a/tests/test_repocard.py
+++ b/tests/test_repocard.py
@@ -50,7 +50,6 @@ from .testing_constants import (
 )
 from .testing_utils import (
     repo_name,
-    retry_endpoint,
     with_production_testing,
 )
 
@@ -263,7 +262,6 @@ class RepocardMetadataTest(unittest.TestCase):
 
 
 class RepocardMetadataUpdateTest(unittest.TestCase):
-    @retry_endpoint
     def setUp(self) -> None:
         self.token = TOKEN
         self.api = HfApi(token=TOKEN)

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -32,7 +32,6 @@ from huggingface_hub.utils import SoftTemporaryDirectory, logging, run_subproces
 from .testing_constants import ENDPOINT_STAGING, TOKEN
 from .testing_utils import (
     repo_name,
-    retry_endpoint,
     use_tmp_repo,
     with_production_testing,
 )
@@ -99,16 +98,13 @@ class TestRepositoryShared(RepositoryTestAbstract):
     def test_clone_from_repo_url(self):
         Repository(self.repo_path, clone_from=self.repo_url)
 
-    @retry_endpoint
     def test_clone_from_repo_id(self):
         Repository(self.repo_path, clone_from=self.repo_id)
 
-    @retry_endpoint
     def test_clone_from_repo_name_no_namespace_fails(self):
         with self.assertRaises(EnvironmentError):
             Repository(self.repo_path, clone_from=self.repo_id.split("/")[1], token=TOKEN)
 
-    @retry_endpoint
     def test_clone_from_not_hf_url(self):
         # Should not error out
         Repository(self.repo_path, clone_from="https://hf.co/hf-internal-testing/huggingface-hub-dummy-repository")
@@ -119,12 +115,10 @@ class TestRepositoryShared(RepositoryTestAbstract):
             Repository(self.repo_path, clone_from="missing_repo")
 
     @with_production_testing
-    @retry_endpoint
     def test_clone_from_prod_canonical_repo_id(self):
         Repository(self.repo_path, clone_from="bert-base-cased", skip_lfs_files=True)
 
     @with_production_testing
-    @retry_endpoint
     def test_clone_from_prod_canonical_repo_url(self):
         Repository(self.repo_path, clone_from="https://huggingface.co/bert-base-cased", skip_lfs_files=True)
 
@@ -140,7 +134,6 @@ class TestRepositoryShared(RepositoryTestAbstract):
         with self.assertRaises(ValueError):
             Repository(self.repo_path)
 
-    @retry_endpoint
     def test_init_clone_in_empty_folder(self):
         repo = Repository(self.repo_path, clone_from=self.repo_url)
         repo.lfs_track(["*.pdf"])
@@ -168,17 +161,14 @@ class TestRepositoryShared(RepositoryTestAbstract):
         with self.assertRaises(EnvironmentError):
             Repository(self.repo_path, clone_from=self.repo_url)
 
-    @retry_endpoint
     def test_init_clone_in_nonempty_linked_git_repo_with_token(self):
         Repository(self.repo_path, clone_from=self.repo_url, token=TOKEN)
         Repository(self.repo_path, clone_from=self.repo_url, token=TOKEN)
 
-    @retry_endpoint
     def test_is_tracked_upstream(self):
         Repository(self.repo_path, clone_from=self.repo_id)
         self.assertTrue(is_tracked_upstream(self.repo_path))
 
-    @retry_endpoint
     def test_push_errors_on_wrong_checkout(self):
         repo = Repository(self.repo_path, clone_from=self.repo_id)
 
@@ -198,7 +188,6 @@ class TestRepositoryUniqueRepos(RepositoryTestAbstract):
     These tests can push data to it.
     """
 
-    @retry_endpoint
     def setUp(self):
         super().setUp()
         self.repo_url = self._api.create_repo(repo_id=repo_name())
@@ -223,7 +212,6 @@ class TestRepositoryUniqueRepos(RepositoryTestAbstract):
             kwargs["git_email"] = "ci@dummy.com"
         return Repository(**kwargs)
 
-    @retry_endpoint
     @use_tmp_repo()
     def test_init_clone_in_nonempty_non_linked_git_repo(self, repo_url: RepoUrl):
         self.clone_repo()
@@ -233,7 +221,6 @@ class TestRepositoryUniqueRepos(RepositoryTestAbstract):
         with self.assertRaises(EnvironmentError):
             Repository(self.repo_path, clone_from=repo_url)
 
-    @retry_endpoint
     def test_init_clone_in_nonempty_linked_git_repo(self):
         # Clone the repository to disk
         self.clone_repo()
@@ -247,7 +234,6 @@ class TestRepositoryUniqueRepos(RepositoryTestAbstract):
         self.clone_repo(clone_from=self.repo_url)
         self.assertNotIn("random_file_3.txt", os.listdir(self.repo_path))
 
-    @retry_endpoint
     def test_init_clone_in_nonempty_linked_git_repo_unrelated_histories(self):
         # Clone the repository to disk
         repo = self.clone_repo()
@@ -267,7 +253,6 @@ class TestRepositoryUniqueRepos(RepositoryTestAbstract):
         # The repo should initialize correctly as the remote is the same, even with unrelated historied
         self.clone_repo()
 
-    @retry_endpoint
     def test_add_commit_push(self):
         repo = self.clone_repo()
         self._create_dummy_files()
@@ -280,7 +265,6 @@ class TestRepositoryUniqueRepos(RepositoryTestAbstract):
         r = requests.head(url)
         r.raise_for_status()
 
-    @retry_endpoint
     def test_add_commit_push_non_blocking(self):
         repo = self.clone_repo()
         self._create_dummy_files()
@@ -303,7 +287,6 @@ class TestRepositoryUniqueRepos(RepositoryTestAbstract):
         r = requests.head(url)
         r.raise_for_status()
 
-    @retry_endpoint
     def test_context_manager_non_blocking(self):
         repo = self.clone_repo()
 
@@ -337,7 +320,6 @@ class TestRepositoryUniqueRepos(RepositoryTestAbstract):
         self.assertTrue(result.is_done)
         self.assertEqual(result.status, -9)
 
-    @retry_endpoint
     def test_commit_context_manager(self):
         # Clone and commit from a first folder
         folder_1 = self.repo_path / "folder_1"
@@ -355,7 +337,6 @@ class TestRepositoryUniqueRepos(RepositoryTestAbstract):
         self.assertTrue("dummy.txt" in files)
         self.assertTrue("model.bin" in files)
 
-    @retry_endpoint
     def test_clone_skip_lfs_files(self):
         # Upload LFS file
         self._api.upload_file(path_or_fileobj=b"Bin file", path_in_repo="file.bin", repo_id=self.repo_id)
@@ -369,7 +350,6 @@ class TestRepositoryUniqueRepos(RepositoryTestAbstract):
 
         self.assertEqual(file_bin.read_text(), "Bin file")
 
-    @retry_endpoint
     def test_commits_on_correct_branch(self):
         repo = self.clone_repo()
         branch = repo.current_branch
@@ -397,7 +377,6 @@ class TestRepositoryUniqueRepos(RepositoryTestAbstract):
             self.assertFalse("file.txt" in files)
             self.assertTrue("new_file.txt" in files)
 
-    @retry_endpoint
     def test_repo_checkout_push(self):
         repo = self.clone_repo()
 
@@ -424,7 +403,6 @@ class TestRepositoryUniqueRepos(RepositoryTestAbstract):
             self.assertFalse("file.txt" in files)
             self.assertTrue("new_file.txt" in files)
 
-    @retry_endpoint
     def test_repo_checkout_commit_context_manager(self):
         repo = self.clone_repo()
 
@@ -454,13 +432,11 @@ class TestRepositoryUniqueRepos(RepositoryTestAbstract):
             self.assertFalse("new_file.txt" in files)
             self.assertFalse("new_file-2.txt" in files)
 
-    @retry_endpoint
     def test_add_tag(self):
         repo = self.clone_repo()
         repo.add_tag("v4.6.0", remote="origin")
         self.assertTrue(repo.tag_exists("v4.6.0", remote="origin"))
 
-    @retry_endpoint
     def test_add_annotated_tag(self):
         repo = self.clone_repo()
         repo.add_tag("v4.5.0", message="This is an annotated tag", remote="origin")
@@ -484,7 +460,6 @@ class TestRepositoryUniqueRepos(RepositoryTestAbstract):
         result = run_subprocess("git tag -n9", folder=self.repo_path).stdout.strip()
         self.assertIn("This is an annotated tag", result)
 
-    @retry_endpoint
     def test_delete_tag(self):
         repo = self.clone_repo()
 
@@ -498,7 +473,6 @@ class TestRepositoryUniqueRepos(RepositoryTestAbstract):
         repo.delete_tag("v4.6.0", remote="origin")
         self.assertFalse(repo.tag_exists("v4.6.0", remote="origin"))
 
-    @retry_endpoint
     def test_lfs_prune(self):
         repo = self.clone_repo()
 
@@ -518,7 +492,6 @@ class TestRepositoryUniqueRepos(RepositoryTestAbstract):
         # Size of the directory holding LFS files was reduced
         self.assertLess(post_prune_git_lfs_files_size, git_lfs_files_size)
 
-    @retry_endpoint
     def test_lfs_prune_git_push(self):
         repo = self.clone_repo()
         with repo.commit("Committing LFS file"):
@@ -861,32 +834,27 @@ class TestRepositoryDataset(RepositoryTestAbstract):
         super().tearDownClass()
         cls._api.delete_repo(repo_id=cls.repo_id, repo_type="dataset")
 
-    @retry_endpoint
     def test_clone_dataset_with_endpoint_explicit_repo_type(self):
         Repository(
             self.repo_path, clone_from=self.repo_url, repo_type="dataset", git_user="ci", git_email="ci@dummy.com"
         )
         self.assertTrue((self.repo_path / "file.txt").exists())
 
-    @retry_endpoint
     def test_clone_dataset_with_endpoint_implicit_repo_type(self):
         self.assertIn("dataset", self.repo_url)  # Implicit
         Repository(self.repo_path, clone_from=self.repo_url, git_user="ci", git_email="ci@dummy.com")
         self.assertTrue((self.repo_path / "file.txt").exists())
 
-    @retry_endpoint
     def test_clone_dataset_with_repo_id_and_repo_type(self):
         Repository(
             self.repo_path, clone_from=self.repo_id, repo_type="dataset", git_user="ci", git_email="ci@dummy.com"
         )
         self.assertTrue((self.repo_path / "file.txt").exists())
 
-    @retry_endpoint
     def test_clone_dataset_no_ci_user_and_email(self):
         Repository(self.repo_path, clone_from=self.repo_id, repo_type="dataset")
         self.assertTrue((self.repo_path / "file.txt").exists())
 
-    @retry_endpoint
     def test_clone_dataset_with_repo_name_and_repo_type_fails(self):
         with self.assertRaises(EnvironmentError):
             Repository(

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -14,7 +14,6 @@ from unittest.mock import Mock, patch
 
 import pytest
 import requests
-from requests.exceptions import HTTPError
 
 from huggingface_hub.utils import is_gradio_available, logging
 from tests.testing_constants import ENDPOINT_PRODUCTION, ENDPOINT_PRODUCTION_URL_SCHEME
@@ -218,44 +217,6 @@ def with_production_testing(func):
     )
 
     return hf_api(file_download(func))
-
-
-def retry_endpoint(function, number_of_tries: int = 3, wait_time: int = 5):
-    """
-    Retries test if failure, waiting `wait_time`.
-    Should be added to any test hitting the `moon-staging` endpoint that is
-    downloading Repositories or uploading data
-
-    Args:
-        number_of_tries: Number of tries to attempt a passing test
-        wait_time: Time to wait in-between attempts in seconds
-    """
-
-    @wraps(function)
-    def decorator(*args, **kwargs):
-        retry_count = 1
-        while retry_count < number_of_tries:
-            try:
-                return function(*args, **kwargs)
-            except HTTPError as e:
-                if e.response.status_code == 504:
-                    logger.info(
-                        f"Attempt {retry_count} failed with a 504 error. Retrying new"
-                        f" execution in {wait_time} second(s)..."
-                    )
-                    time.sleep(5)
-                    retry_count += 1
-            except OSError:
-                logger.info(
-                    "Race condition met where we tried to `clone` before fully"
-                    " deleting a repository. Retrying new execution in"
-                    f" {wait_time} second(s)..."
-                )
-                retry_count += 1
-            # Preserve original traceback
-            return function(*args, **kwargs)
-
-    return decorator
 
 
 def expect_deprecation(function_name: str):


### PR DESCRIPTION
We currently use `@retry_endpoint` on endpoint tests to retry on HTTPError 504 or OSError (git clone race condition). It has being introduced in https://github.com/huggingface/huggingface_hub/pull/682 to improve stability of the CI. What's still annoying is that it is a decorator that has to be added to every test case individually -which is prone to forgetting. **This PR updates the CI by automatically applying the retry mechanism to all tests.** 

(Note: if in the future we specifically want to opt-out some tests, it is still doable using a `pytest.mark`. But I don't see a reason to do it.).