### PR TITLE
Supporting `pydantic<3`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ extras["cli"] = [
 
 extras["inference"] = [
     "aiohttp",  # for AsyncInferenceClient
-    "pydantic<2.0",  # for text-generation-inference
+    "pydantic>1.1,<3.0",  # match text-generation-inference v1.1.0
 ]
 
 extras["torch"] = [

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ extras["typing"] = [
     "types-toml",
     "types-tqdm",
     "types-urllib3",
-    "pydantic<2.0",  # for text-generation dataclasses
+    "pydantic>1.1,<3.0",  # for text-generation-interface dataclasses
 ]
 
 extras["quality"] = [


### PR DESCRIPTION
Closes https://github.com/huggingface/huggingface_hub/issues/1726

I manually and locally tested with pydantic v2 using Python 3.11.4:

```bash
> pip install -e .[testing]
> pip list | grep pydantic
pydantic                  2.4.2
pydantic_core             2.10.1
> pytest tests/test_inference*.py
...
83 passed, 6 skipped, 16 warnings in 5.73s
```