### PR TITLE
Properly configures `every` in `test_sync_and_squash_history`

### DIFF
--- a/tests/test_commit_scheduler.py
+++ b/tests/test_commit_scheduler.py
@@ -145,7 +145,7 @@ class TestCommitScheduler(unittest.TestCase):
         self.scheduler = CommitScheduler(
             folder_path=watched_folder,
             repo_id=self.repo_name,
-            every=1 / 60,  # every 0.1s
+            every=1 / 60 / 10,  # every 0.1s
             hf_api=self.api,
             squash_history=True,
         )


### PR DESCRIPTION
I discovered `test_sync_and_squash_history` was improperly configured:
- `every` was set at 1-sec, but its comment said 0.1-sec
- A `time.sleep` below was set for 0.5-sec

This led to a race condition.  This solves one of the CI issues hit in https://github.com/huggingface/huggingface_hub/pull/1727.