### PR TITLE
Testing `WEBHOOK_PAYLOAD_EXAMPLE` deserialization

### DIFF
--- a/src/huggingface_hub/_webhooks_payload.py
+++ b/src/huggingface_hub/_webhooks_payload.py
@@ -55,7 +55,7 @@ class ObjectId(BaseModel):
 
 class WebhookPayloadUrl(BaseModel):
     web: str
-    api: Optional[str]
+    api: Optional[str] = None
 
 
 class WebhookPayloadMovedTo(BaseModel):
@@ -74,7 +74,7 @@ class WebhookPayloadEvent(BaseModel):
 
 class WebhookPayloadDiscussionChanges(BaseModel):
     base: str
-    mergeCommitId: Optional[str]
+    mergeCommitId: Optional[str] = None
 
 
 class WebhookPayloadComment(ObjectId):
@@ -92,16 +92,16 @@ class WebhookPayloadDiscussion(ObjectId):
     isPullRequest: bool
     status: DiscussionStatus_T
     changes: Optional[WebhookPayloadDiscussionChanges]
-    pinned: Optional[bool]
+    pinned: Optional[bool] = None
 
 
 class WebhookPayloadRepo(ObjectId):
     owner: ObjectId
-    head_sha: Optional[str]
+    head_sha: Optional[str] = None
     name: str
     private: bool
-    subdomain: Optional[str]
-    tags: Optional[List[str]]
+    subdomain: Optional[str] = None
+    tags: Optional[List[str]] = None
     type: Literal["dataset", "model", "space"]
     url: WebhookPayloadUrl
 
@@ -112,4 +112,4 @@ class WebhookPayload(BaseModel):
     discussion: Optional[WebhookPayloadDiscussion]
     comment: Optional[WebhookPayloadComment]
     webhook: WebhookPayloadWebhook
-    movedTo: Optional[WebhookPayloadMovedTo]
+    movedTo: Optional[WebhookPayloadMovedTo] = None

--- a/tests/test_webhooks_server.py
+++ b/tests/test_webhooks_server.py
@@ -51,6 +51,12 @@ WEBHOOK_PAYLOAD_EXAMPLE = {
 }
 
 
+def test_deserialize_payload_example() -> None:
+    """Confirm that the test stub can actually be deserialized."""
+    payload = WebhookPayload.parse_obj(WEBHOOK_PAYLOAD_EXAMPLE)
+    assert payload.event.scope == WEBHOOK_PAYLOAD_EXAMPLE["event"]["scope"]
+
+
 @require_webhooks
 class TestWebhooksServerDontRun(unittest.TestCase):
     def test_add_webhook_implicit_path(self):


### PR DESCRIPTION
When deserializing with pydantic:
- v1: it didn't care about missing fields
- v2: it does care about missing fields

This PR simply defaults some test-time fields so they are no longer missing. It solves one of the CI issues hit in https://github.com/huggingface/huggingface_hub/pull/1727.