### PR TITLE
Fix Space runtime on static Space

### DIFF
--- a/src/huggingface_hub/_space_api.py
+++ b/src/huggingface_hub/_space_api.py
@@ -116,10 +116,10 @@ class SpaceRuntime:
 
     def __init__(self, data: Dict) -> None:
         self.stage = data["stage"]
-        self.hardware = data["hardware"]["current"]
-        self.requested_hardware = data["hardware"]["requested"]
-        self.sleep_time = data["gcTimeout"]
-        self.storage = data["storage"]
+        self.hardware = data.get("hardware", {}).get("current")
+        self.requested_hardware = data.get("hardware", {}).get("requested")
+        self.sleep_time = data.get("gcTimeout")
+        self.storage = data.get("storage")
         self.raw = data
 
 

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2540,6 +2540,13 @@ class TestSpaceAPIProduction(unittest.TestCase):
         # Raw response from Hub
         self.assertIsInstance(runtime.raw, dict)
 
+    def test_static_space_runtime(self) -> None:
+        """
+        Regression test.
+        """
+        runtime = self.api.get_space_runtime("victor/static-space")
+        self.assertIsInstance(runtime.raw, dict)
+
     def test_pause_and_restart_space(self) -> None:
         # Upload a fake app.py file
         self.api.upload_file(path_or_fileobj=b"", path_in_repo="app.py", repo_id=self.repo_id, repo_type="space")

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2542,7 +2542,8 @@ class TestSpaceAPIProduction(unittest.TestCase):
 
     def test_static_space_runtime(self) -> None:
         """
-        Regression test.
+        Regression test for static Spaces.
+        See https://github.com/huggingface/huggingface_hub/pull/1754.
         """
         runtime = self.api.get_space_runtime("victor/static-space")
         self.assertIsInstance(runtime.raw, dict)


### PR DESCRIPTION
`huggingface_hub.get_space_runtime` was previously raising an exception on Static Space because hardware is not returned by the server. This PR fixes it by setting hardware to None.

cc @clefourrier @hysts (from internal [slack](https://huggingface.slack.com/archives/C048K60MPNF/p1697547803117469?thread_ts=1697544510.248379&cid=C048K60MPNF))