### PR TITLE
Added `[[autodoc]]` for `ModelStatus`

### DIFF
--- a/docs/source/en/package_reference/inference_client.md
+++ b/docs/source/en/package_reference/inference_client.md
@@ -33,25 +33,37 @@ pip install --upgrade huggingface_hub[inference]
 
 [[autodoc]] AsyncInferenceClient
 
-### InferenceTimeoutError
+## InferenceTimeoutError
 
 [[autodoc]] InferenceTimeoutError
 
-### Return types
+## Return types
 
 For most tasks, the return value has a built-in type (string, list, image...). Here is a list for the more complex types.
 
+### ClassificationOutput
+
 [[autodoc]] huggingface_hub.inference._types.ClassificationOutput
+
+### ConversationalOutputConversation
 
 [[autodoc]] huggingface_hub.inference._types.ConversationalOutputConversation
 
+### ConversationalOutput
+
 [[autodoc]] huggingface_hub.inference._types.ConversationalOutput
+
+### ImageSegmentationOutput
 
 [[autodoc]] huggingface_hub.inference._types.ImageSegmentationOutput
 
-[[autodoc]] huggingface_hub.inference._types.TokenClassificationOutput
+### ModelStatus
 
 [[autodoc]] huggingface_hub.inference._common.ModelStatus
+
+### TokenClassificationOutput
+
+[[autodoc]] huggingface_hub.inference._types.TokenClassificationOutput
 
 ### Text generation types
 

--- a/docs/source/en/package_reference/inference_client.md
+++ b/docs/source/en/package_reference/inference_client.md
@@ -51,6 +51,8 @@ For most tasks, the return value has a built-in type (string, list, image...). H
 
 [[autodoc]] huggingface_hub.inference._types.TokenClassificationOutput
 
+[[autodoc]] huggingface_hub.inference._common.ModelStatus
+
 ### Text generation types
 
 [`~InferenceClient.text_generation`] task has a greater support than other tasks in `InferenceClient`. In


### PR DESCRIPTION
Attempting to bring back @Wauplin's docs fix to `ModelStatus` linking, that I clobbered in https://github.com/huggingface/huggingface_hub/pull/1740