### PR TITLE
Limit to inferior fsspec version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def get_version() -> str:
 
 install_requires = [
     "filelock",
-    "fsspec>=2023.5.0",
+    "fsspec>=2023.5.0,<2023.10.0",
     "requests",
     "tqdm>=4.42.1",
     "pyyaml>=5.1",


### PR DESCRIPTION
The newly released fsspec version breaks the implementation in transformers' CI, see the following error:

```
"/home/circleci/.pyenv/versions/3.8.12/lib/python3.8/site-packages/datasets/builder.py", line 1173, in as_dataset
    raise NotImplementedError(f"Loading a dataset cached in a {type(self._fs).__name__} is not supported.")
NotImplementedError: Loading a dataset cached in a LocalFileSystem is not supported.
/home/circleci/transformers/src/transformers/models/beit/modeling_beit.py:737: UnexpectedException
```

Additionally:
https://github.com/huggingface/datasets/pull/6331