### PR TITLE
Fix document link for manage-cache

### DIFF
--- a/docs/source/en/package_reference/file_download.md
+++ b/docs/source/en/package_reference/file_download.md
@@ -34,5 +34,5 @@ The methods displayed above are designed to work with a caching system that prev
 re-downloading files. The caching system was updated in v0.8.0 to become the central
 cache-system shared across libraries that depend on the Hub.
 
-Read the [cache-system guide](../how-to-cache) for a detailed presentation of caching at
+Read the [cache-system guide](../guides/manage-cache) for a detailed presentation of caching at
 at HF.

--- a/docs/source/en/package_reference/file_download.md
+++ b/docs/source/en/package_reference/file_download.md
@@ -34,5 +34,5 @@ The methods displayed above are designed to work with a caching system that prev
 re-downloading files. The caching system was updated in v0.8.0 to become the central
 cache-system shared across libraries that depend on the Hub.
 
-Read the [cache-system guide](../manage-cache) for a detailed presentation of caching at
+Read the [cache-system guide](../guides/manage-cache) for a detailed presentation of caching at
 at HF.

--- a/docs/source/en/package_reference/file_download.md
+++ b/docs/source/en/package_reference/file_download.md
@@ -34,5 +34,5 @@ The methods displayed above are designed to work with a caching system that prev
 re-downloading files. The caching system was updated in v0.8.0 to become the central
 cache-system shared across libraries that depend on the Hub.
 
-Read the [cache-system guide](../guides/manage-cache) for a detailed presentation of caching at
+Read the [cache-system guide](../how-to-cache) for a detailed presentation of caching at
 at HF.


### PR DESCRIPTION
The link for the `cache-system` [here](https://huggingface.co/docs/huggingface_hub/main/en/package_reference/file_download#caching) is broken.


> Read the [cache-system guide](https://huggingface.co/docs/huggingface_hub/main/en/manage-cache) for a detailed presentation of caching at at HF.
