### PR TITLE
Do not warn in `ModelHubMixin` on missing config file

### DIFF
--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -3,12 +3,10 @@ import os
 from pathlib import Path
 from typing import Dict, List, Optional, Type, TypeVar, Union
 
-import requests
-
 from .constants import CONFIG_NAME, PYTORCH_WEIGHTS_NAME
 from .file_download import hf_hub_download, is_torch_available
 from .hf_api import HfApi
-from .utils import SoftTemporaryDirectory, logging, validate_hf_hub_args
+from .utils import HfHubHTTPError, SoftTemporaryDirectory, logging, validate_hf_hub_args
 
 
 if is_torch_available():
@@ -148,8 +146,8 @@ class ModelHubMixin:
                     token=token,
                     local_files_only=local_files_only,
                 )
-            except requests.exceptions.RequestException:
-                logger.warning(f"{CONFIG_NAME} not found in HuggingFace Hub.")
+            except HfHubHTTPError:
+                logger.info(f"{CONFIG_NAME} not found in HuggingFace Hub.")
 
         if config_file is not None:
             with open(config_file, "r", encoding="utf-8") as f:


### PR DESCRIPTION
In `ModelHubMixin` when using `from_pretrained` we check for a `config.json` in the repo. If the config file doesn't exist, we log a warning message. This is too high level IMO given that the config file should be optional as some libraries do not use it. It's still nice to fetch it by default to encourage libraries to have one but it shouldn't be mandatory. This PR sets the log level to `INFO`.

I realized about it while reviewing the MidiTok integration: https://github.com/Natooz/MidiTok/pull/87 (cc @Natooz)