### PR TITLE
Fix CI (typing-extensions minimal requirement)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ extras["testing"] = (
 # Typing extra dependencies list is duplicated in `.pre-commit-config.yaml`
 # Please make sure to update the list there when adding a new typing dependency.
 extras["typing"] = [
+    "typing-extensions>=4.8.0",
     "types-PyYAML",
     "types-requests",
     "types-simplejson",


### PR DESCRIPTION
Fix CI (see https://github.com/huggingface/huggingface_hub/actions/runs/6664387296/job/18111901923?pr=1779).
By default on Python3.8 in the CI, `typing-extensions==4.5.0` seems to be installed as a dependency of another dependency. It leads to:

```
 ImportError: cannot import name 'TypeAliasType' from 'typing_extensions' (/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/typing_extensions.py)
```

This PR adds an explicit dependency `>=4.8.0`. This shouldn't cause any problem as the `[typing]` extras is optional.