### PR TITLE
Set `usedforsecurity=False` in hashlib methods (FIPS compliance)

### DIFF
--- a/src/huggingface_hub/_multi_commits.py
+++ b/src/huggingface_hub/_multi_commits.py
@@ -15,13 +15,13 @@
 """Contains utilities to multi-commits (i.e. push changes iteratively on a PR)."""
 import re
 from dataclasses import dataclass, field
-from hashlib import sha256
 from typing import TYPE_CHECKING, Iterable, List, Optional, Set, Tuple, Union
 
 from ._commit_api import CommitOperationAdd, CommitOperationDelete
 from .community import DiscussionWithDetails
 from .utils import experimental
 from .utils._cache_manager import _format_size
+from .utils.insecure_hashlib import sha256
 
 
 if TYPE_CHECKING:

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -13,7 +13,6 @@ import warnings
 from contextlib import contextmanager
 from dataclasses import dataclass
 from functools import partial
-from hashlib import sha256
 from pathlib import Path
 from typing import Any, BinaryIO, Dict, Generator, Literal, Optional, Tuple, Union
 from urllib.parse import quote, urlparse
@@ -75,6 +74,7 @@ from .utils import (
 from .utils._headers import _http_user_agent
 from .utils._runtime import _PY_VERSION  # noqa: F401 # for backward compatibility
 from .utils._typing import HTTP_METHOD_T
+from .utils.insecure_hashlib import sha256
 
 
 logger = logging.get_logger(__name__)

--- a/src/huggingface_hub/utils/insecure_hashlib.py
+++ b/src/huggingface_hub/utils/insecure_hashlib.py
@@ -1,0 +1,34 @@
+# Taken from https://github.com/mlflow/mlflow/pull/10119
+#
+# DO NOT use this function for security purposes (e.g., password hashing).
+#
+# In Python >= 3.9, insecure hashing algorithms such as MD5 fail in FIPS-compliant
+# environments unless `usedforsecurity=False` is explicitly passed.
+#
+# References:
+# - https://github.com/mlflow/mlflow/issues/9905
+# - https://github.com/mlflow/mlflow/pull/10119
+# - https://docs.python.org/3/library/hashlib.html
+# - https://github.com/huggingface/transformers/pull/27038
+#
+# Usage:
+#     ```python
+#     # Use
+#     from huggingface_hub.utils.insecure_hashlib import sha256
+#     # instead of
+#     from hashlib import sha256
+#
+#     # Use
+#     from huggingface_hub.utils import insecure_hashlib
+#     # instead of
+#     import hashlib
+#     ```
+import functools
+import hashlib
+import sys
+
+
+_kwargs = {"usedforsecurity": False} if sys.version_info >= (3, 9) else {}
+md5 = functools.partial(hashlib.md5, **_kwargs)
+sha1 = functools.partial(hashlib.sha1, **_kwargs)
+sha256 = functools.partial(hashlib.sha256, **_kwargs)

--- a/src/huggingface_hub/utils/sha.py
+++ b/src/huggingface_hub/utils/sha.py
@@ -1,6 +1,7 @@
 """Utilities to efficiently compute the SHA 256 hash of a bunch of bytes."""
-from hashlib import sha256
 from typing import BinaryIO, Optional
+
+from .insecure_hashlib import sha256
 
 
 def sha_fileobj(fileobj: BinaryIO, chunk_size: Optional[int] = None) -> bytes:


### PR DESCRIPTION
This PR aims to make `huggingface_hub` (and then other libraries from HF-ecosystem) FIPS-compliant.

Issue was first raised by @DueViktor in https://github.com/huggingface/transformers/pull/27034 and https://github.com/huggingface/transformers/pull/27038.

_Quoting @DueViktor:_

> Transformers use MD5 from hashlib, which is not a secure algorithm, but are not specifying that it is for other purposes than security. This is causing issues for organisations following certain security standard. FIPS compliance could be an example.

_From https://docs.python.org/3/library/hashlib.html:_

> Changed in version 3.9: All hashlib constructors take a keyword-only argument usedforsecurity with default value True. A false value allows the use of insecure and blocked hashing algorithms in restricted environments. False indicates that the hashing algorithm is not used in a security context, e.g. as a non-cryptographic one-way compression function.


This PR copies what has been done in https://github.com/mlflow/mlflow/issues/10106 and  https://github.com/mlflow/mlflow/pull/10119. We define a `insecure_hashlib` module that sets `usedforsecurity=False` by default in their hash methods. Usage is pretty much the same as `hashlib`:

```python
# Use
from huggingface_hub.utils.insecure_hashlib import sha256
# instead of
from hashlib import sha256

# Use
from huggingface_hub.utils import insecure_hashlib
# instead of
import hashlib
```

---

Once this is merged, the plan is to make a release and then integrate in third-party libraries from the HF-ecosystem (starting by `transformers`, `diffusers`, `datasets` and `evaluate`). Thanks a lot @DueViktor for raising the question :+1: :pray: 