### PR TITLE
Remove black formatter to use only ruff

### DIFF
--- a/.github/workflows/python-quality.yml
+++ b/.github/workflows/python-quality.yml
@@ -27,7 +27,6 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install .[dev]
-      - run: black --check tests src contrib
       - run: ruff tests src contrib
       - run: python utils/check_contrib_list.py
       - run: python utils/check_static_imports.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,11 +8,7 @@ repos:
       - id: trailing-whitespace
       - id: check-case-conflict
       - id: check-merge-conflict
-  - repo: https://github.com/psf/black
-    rev: 23.1.0
-    hooks:
-      - id: black
   - repo: https://github.com/charliermarsh/ruff-pre-commit # https://github.com/charliermarsh/ruff#usage
-    rev: 'v0.0.243'
+    rev: 'v0.1.3'
     hooks:
       - id: ruff

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,9 +145,8 @@ Follow these steps to start contributing:
 
 7. Format your code.
 
-   `hugginface_hub` relies on [`black`](https://github.com/psf/black) and [`ruff`](https://github.com/astral-sh/ruff)
-   to format its source code consistently. You can apply automatic style corrections and code verifications
-   with the following command:
+   `hugginface_hub` relies on [`ruff`](https://github.com/astral-sh/ruff) to format its source code consistently. You
+   can apply automatic style corrections and code verifications with the following command:
 
    ```bash
    $ make style

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ check_dirs := contrib src tests utils setup.py
 
 
 quality:
-	black --check $(check_dirs)
 	ruff $(check_dirs)
 	mypy src
 	python utils/check_contrib_list.py
@@ -13,8 +12,7 @@ quality:
 	python utils/generate_async_inference_client.py
 
 style:
-	black $(check_dirs)
-	ruff $(check_dirs) --fix
+	ruff --fix $(check_dirs)
 	python utils/check_contrib_list.py --update
 	python utils/check_static_imports.py --update
 	python utils/generate_async_inference_client.py --update

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,3 @@
-[tool.black]
-line-length = 119
-target_version = ['py37', 'py38', 'py39', 'py310']
-preview = true
-
 [tool.mypy]
 ignore_missing_imports = true
 no_implicit_optional = true
@@ -14,11 +9,31 @@ plugins = [
 [tool.ruff]
 # Ignored rules:
 #   "E501" -> line length violation
-#   "F821" -> undefined named in type annotation (e.g. Literal["something"])
-ignore = ["E501", "F821"]
+ignore = ["E501"]
 select = ["E", "F", "I", "W"]
 line-length = 119
+exclude = [
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".venv*",
+    "__pypackages__",
+    "_build",
+    "build",
+    "dist",
+    "venv",
+]
 
 [tool.ruff.isort]
 lines-after-imports = 2
 known-first-party = ["huggingface_hub"]
+

--- a/setup.py
+++ b/setup.py
@@ -80,8 +80,7 @@ extras["typing"] = [
 ]
 
 extras["quality"] = [
-    "black==23.7",
-    "ruff>=0.0.241",
+    "ruff>=0.1.3",
     "mypy==1.5.1",
 ]
 

--- a/src/huggingface_hub/_login.py
+++ b/src/huggingface_hub/_login.py
@@ -36,6 +36,14 @@ from .utils import (
 
 logger = logging.get_logger(__name__)
 
+_HF_LOGO_ASCII = """
+    _|    _|  _|    _|    _|_|_|    _|_|_|  _|_|_|  _|      _|    _|_|_|      _|_|_|_|    _|_|      _|_|_|  _|_|_|_|
+    _|    _|  _|    _|  _|        _|          _|    _|_|    _|  _|            _|        _|    _|  _|        _|
+    _|_|_|_|  _|    _|  _|  _|_|  _|  _|_|    _|    _|  _|  _|  _|  _|_|      _|_|_|    _|_|_|_|  _|        _|_|_|
+    _|    _|  _|    _|  _|    _|  _|    _|    _|    _|    _|_|  _|    _|      _|        _|    _|  _|        _|
+    _|    _|    _|_|      _|_|_|    _|_|_|  _|_|_|  _|      _|    _|_|_|      _|        _|    _|    _|_|_|  _|_|_|_|
+"""
+
 
 def login(
     token: Optional[str] = None,
@@ -144,13 +152,7 @@ def interpreter_login(new_session: bool = True, write_permission: bool = False) 
         print("User is already logged in.")
         return
 
-    print("""
-    _|    _|  _|    _|    _|_|_|    _|_|_|  _|_|_|  _|      _|    _|_|_|      _|_|_|_|    _|_|      _|_|_|  _|_|_|_|
-    _|    _|  _|    _|  _|        _|          _|    _|_|    _|  _|            _|        _|    _|  _|        _|
-    _|_|_|_|  _|    _|  _|  _|_|  _|  _|_|    _|    _|  _|  _|  _|  _|_|      _|_|_|    _|_|_|_|  _|        _|_|_|
-    _|    _|  _|    _|  _|    _|  _|    _|    _|    _|    _|_|  _|    _|      _|        _|    _|  _|        _|
-    _|    _|    _|_|      _|_|_|    _|_|_|  _|_|_|  _|      _|    _|_|_|      _|        _|    _|    _|_|_|  _|_|_|_|
-    """)
+    print(_HF_LOGO_ASCII)
     if HfFolder.get_token() is not None:
         print(
             "    A token is already saved on your machine. Run `huggingface-cli"

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1606,12 +1606,9 @@ def get_hf_file_metadata(
     # Return
     return HfFileMetadata(
         commit_hash=r.headers.get(HUGGINGFACE_HEADER_X_REPO_COMMIT),
-        etag=_normalize_etag(
-            # We favor a custom header indicating the etag of the linked resource, and
-            # we fallback to the regular etag header.
-            r.headers.get(HUGGINGFACE_HEADER_X_LINKED_ETAG)
-            or r.headers.get("ETag")
-        ),
+        # We favor a custom header indicating the etag of the linked resource, and
+        # we fallback to the regular etag header.
+        etag=_normalize_etag(r.headers.get(HUGGINGFACE_HEADER_X_LINKED_ETAG) or r.headers.get("ETag")),
         # Either from response headers (if redirected) or defaults to request url
         # Do not use directly `url`, as `_request_wrapper` might have followed relative
         # redirects.

--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -11,6 +11,7 @@ import fsspec
 
 from ._commit_api import CommitOperationCopy, CommitOperationDelete
 from .constants import DEFAULT_REVISION, ENDPOINT, REPO_TYPE_MODEL, REPO_TYPES_MAPPING, REPO_TYPES_URL_PREFIXES
+from .file_download import hf_hub_url
 from .hf_api import HfApi
 from .utils import (
     EntryNotFoundError,
@@ -45,10 +46,8 @@ class HfFileSystemResolvedPath:
     path_in_repo: str
 
     def unresolve(self) -> str:
-        return (
-            f"{REPO_TYPES_URL_PREFIXES.get(self.repo_type, '') + self.repo_id}@{safe_revision(self.revision)}/{self.path_in_repo}"
-            .rstrip("/")
-        )
+        repo_path = REPO_TYPES_URL_PREFIXES.get(self.repo_type, "") + self.repo_id
+        return f"{repo_path}@{safe_revision(self.revision)}/{self.path_in_repo}".rstrip("/")
 
 
 class HfFileSystem(fsspec.AbstractFileSystem):
@@ -421,8 +420,11 @@ class HfFileSystemFile(fsspec.spec.AbstractBufferedFile):
             "range": f"bytes={start}-{end - 1}",
             **self.fs._api._build_hf_headers(),
         }
-        url = (
-            f"{self.fs.endpoint}/{REPO_TYPES_URL_PREFIXES.get(self.resolved_path.repo_type, '') + self.resolved_path.repo_id}/resolve/{safe_quote(self.resolved_path.revision)}/{safe_quote(self.resolved_path.path_in_repo)}"
+        url = hf_hub_url(
+            repo_id=self.resolved_path.repo_id,
+            revision=self.resolved_path.revision,
+            filename=self.resolved_path.path_in_repo,
+            endpoint=self.fs.endpoint,
         )
         r = http_backoff("GET", url, headers=headers)
         hf_raise_for_status(r)

--- a/utils/_legacy_check_future_compatible_signatures.py
+++ b/utils/_legacy_check_future_compatible_signatures.py
@@ -35,7 +35,6 @@ import tempfile
 from pathlib import Path
 from typing import Callable, NoReturn
 
-import black
 from ruff.__main__ import find_ruff_bin
 
 from huggingface_hub.hf_api import HfApi
@@ -173,17 +172,14 @@ def generate_hf_api_module() -> str:
     # Generate code with stubs
     generated_code = STUBS_SECTION_TEMPLATE_REGEX.sub(STUBS_SECTION_TEMPLATE.format(stubs=all_stubs_source), raw_code)
 
-    # Format (black+ruff)
+    # Format (ruff)
     return format_generated_code(generated_code)
 
 
 def format_generated_code(code: str) -> str:
     """
-    Format some code with black+ruff. Cannot be done "on the fly" so we first save the code in a temporary file.
+    Format some code with ruff. Cannot be done "on the fly" so we first save the code in a temporary file.
     """
-    # Format with black
-    code = black.format_file_contents(code, fast=False, mode=black.FileMode(line_length=119))
-
     # Format with ruff
     with tempfile.TemporaryDirectory() as tmpdir:
         filepath = Path(tmpdir) / "__init__.py"


### PR DESCRIPTION
Following https://astral.sh/blog/the-ruff-formatter, I suggest we remove `black` formatter completely. It was already not very used anyway. Made a few changes so that current code is formatted the same with both `black` and `ruff` to reduce inconveniences for existing contributors.
N°1 argument IMO is speed. N°2 is that it's convenient to have everything handled by the same tool.