### PR TITLE
Reset `_nb_retries` if data has been received from the server

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -441,7 +441,7 @@ def http_get(
 
     If ConnectionError (SSLError) or ReadTimeout happen while streaming data from the server, it is most likely a
     transient error (network outage?). We log a warning message and try to resume the download a few times before
-    giving up.
+    giving up. The method gives up after 5 attempts if no new data has being received from the server.
     """
     if not resume_size:
         if HF_HUB_ENABLE_HF_TRANSFER:
@@ -510,6 +510,8 @@ def http_get(
                 progress.update(len(chunk))
                 temp_file.write(chunk)
                 new_resume_size += len(chunk)
+                # Some data has been downloaded from the server so we reset the number of retries.
+                _nb_retries = 5
     except (requests.ConnectionError, requests.ReadTimeout) as e:
         # If ConnectionError (SSLError) or ReadTimeout happen while streaming data from the server, it is most likely
         # a transient error (network outage?). We log a warning message and try to resume the download a few times


### PR DESCRIPTION
In https://github.com/huggingface/huggingface_hub/issues/1766, I have introduced a retry mechanism in the download process if a `ConnectionError` or `ReadTimeout` error happens. The mechanism is quite simple: retry up to 5 times, wait 1s in between.

This PR modifies this mechanism to reset the number of retries each time new data is received from the server. This is because (IMO) we should not assume before-hand how many retries will be needed to download a huge file on a slow connection. The only thing we want to avoid is to end up in an infinite loop, which cannot be the case here. Worst case is we retry 5 times between each chunk of data (very unlikely :smile:)


(Failing tests are unrelated. I'm trying to fix them separately)