### PR TITLE
Separate test and prod cache (+ ruff formatter)

### DIFF
--- a/.github/workflows/python-quality.yml
+++ b/.github/workflows/python-quality.yml
@@ -27,7 +27,8 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install .[dev]
-      - run: ruff tests src contrib
+      - run: ruff check tests src contrib # linter
+      - run: ruff format --check tests src contrib # formatter
       - run: python utils/check_contrib_list.py
       - run: python utils/check_static_imports.py
       - run: python utils/generate_async_inference_client.py

--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,16 @@ check_dirs := contrib src tests utils setup.py
 
 
 quality:
-	ruff $(check_dirs)
+	ruff check $(check_dirs)  # linter
+	ruff format --check $(check_dirs) # formatter
 	mypy src
 	python utils/check_contrib_list.py
 	python utils/check_static_imports.py
 	python utils/generate_async_inference_client.py
 
 style:
-	ruff --fix $(check_dirs)
+	ruff check --fix $(check_dirs) # linter
+	ruff format $(check_dirs) # formatter
 	python utils/check_contrib_list.py --update
 	python utils/check_static_imports.py --update
 	python utils/generate_async_inference_client.py --update

--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -104,6 +104,12 @@ _OLD_HF_TOKEN_PATH = os.path.expanduser("~/.huggingface/token")
 HF_TOKEN_PATH = os.path.join(hf_cache_home, "token")
 
 
+if _staging_mode:
+    # In staging mode, we use a different cache to ensure we don't mix up production and staging data or tokens
+    _staging_home = os.path.join(os.path.expanduser("~"), ".cache", "huggingface_staging")
+    HUGGINGFACE_HUB_CACHE = os.path.join(_staging_home, "hub")
+    HF_TOKEN_PATH = os.path.join(_staging_home, "token")
+
 # Here, `True` will disable progress bars globally without possibility of enabling it
 # programmatically. `False` will enable them without possibility of disabling them.
 # If environment variable is not set (None), then the user is free to enable/disable

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ from _pytest.python import Function as PytestFunction
 from requests.exceptions import HTTPError
 
 import huggingface_hub
-from huggingface_hub import HfApi, HfFolder
+from huggingface_hub import HfApi
 from huggingface_hub.utils import SoftTemporaryDirectory, logging
 from huggingface_hub.utils._typing import CallableT
 
@@ -42,23 +42,6 @@ def fx_cache_dir(request: SubRequest) -> Generator[None, None, None]:
         # TemporaryDirectory is not super robust on Windows when a git repository is
         # cloned in it. See https://www.scivision.dev/python-tempfile-permission-error-windows/.
         shutil.rmtree(cache_dir, onerror=set_write_permission_and_retry)
-
-
-@pytest.fixture(autouse=True, scope="session")
-def clean_hf_folder_token_for_tests() -> Generator:
-    """Clean token stored on machine before all tests and reset it back at the end.
-
-    Useful to avoid token deletion when running tests locally.
-    """
-    # Remove registered token
-    token = HfFolder().get_token()
-    HfFolder().delete_token()
-
-    yield  # Run all tests
-
-    # Set back token once all tests have passed
-    if token is not None:
-        HfFolder().save_token(token)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
At the moment, tests running locally can alter `huggingface_hub` cache. Two majors cases happen:
- either some "dummy" files/repos are downloaded to the cache
- either the saved token is replaced by the CI one (or simply deleted).

I previously tried to fix this problem using fixtures to use a separate cache and save/set back the registered token while running tests. But this is not really satisfying since cleanup fixtures might not be processed (if process is killed or if several pytests processed are run at once). This PR aims to definitely get rid of these problems by setting a test `HF_HOME` when running the tests. By doing so, there is no way staging and prod caches get mixed or corrupted.

Looks like something I should have done long ago. Sorry for the inconveniences @McPatate :smile: 

---

Also I've been a bit too quick when replacing `black` with `ruff` in https://github.com/huggingface/huggingface_hub/pull/1783. I fixed the makefile and github workflows in this PR to run both the linter and the formatter.