### PR TITLE
Fix huggingface filesystem repo_type not forwarded

### DIFF
--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -424,6 +424,7 @@ class HfFileSystemFile(fsspec.spec.AbstractBufferedFile):
             repo_id=self.resolved_path.repo_id,
             revision=self.resolved_path.revision,
             filename=self.resolved_path.path_in_repo,
+            repo_type=self.resolved_path.repo_type,
             endpoint=self.fs.endpoint,
         )
         r = http_backoff("GET", url, headers=headers)


### PR DESCRIPTION
Fixing a bug introduced in https://github.com/huggingface/huggingface_hub/pull/1783 (merged yesterday).

Since a refacto, I did not realize that `repo_type` was not forwarded in `_fetch_range` anymore. This PR fixes it.

