### PR TITLE
Ensure backward compatibility for `HUGGING_FACE_HUB_TOKEN` env variable

### DIFF
--- a/src/huggingface_hub/utils/_hf_folder.py
+++ b/src/huggingface_hub/utils/_hf_folder.py
@@ -64,6 +64,8 @@ class HfFolder:
 
         # 1. Is it set by environment variable ?
         token: Optional[str] = os.environ.get("HF_TOKEN")
+        if token is None:  # Ensure backward compatibility but doesn't have priority
+            token = os.environ.get("HUGGING_FACE_HUB_TOKEN")
         if token is not None:
             token = token.replace("\r", "").replace("\n", "").strip()
             return token


### PR DESCRIPTION
Related to https://github.com/huggingface/huggingface_hub/pull/1786. I replaced `HF_TOKEN` by `HUGGING_FACE_HUB_TOKEN` but overlooked a bit the backward compatibility. This PR fixes this.

cc @cbensimon who noticed it.