### PR TITLE
Add CLI guide to documentation

### DIFF
--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -14,6 +14,8 @@
       title: Download files
     - local: guides/upload
       title: Upload files
+    - local: guides/cli
+      title: Use the CLI
     - local: guides/hf_file_system
       title: HfFileSystem
     - local: guides/repository

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -38,8 +38,6 @@ positional arguments:
     download            Download files from the Hub
     lfs-enable-largefiles
                         Configure your repository to enable upload of files > 5GB.
-    lfs-multipart-upload
-                        Command will get called by git-lfs, do not call it directly.
     scan-cache          Scan cache directory.
     delete-cache        Delete revisions from the cache directory.
 

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -1,0 +1,445 @@
+<!--⚠️ Note that this file is in Markdown but contain specific syntax for our doc-builder (similar to MDX) that may not be
+rendered properly in your Markdown viewer.
+-->
+
+# Command Line Interface (CLI)
+
+The `huggingface_hub` Python package comes with a built-in CLI called `huggingface-cli`. This tool allows you to interact with the Hugging Face Hub directly from a terminal. For example, you can login to your account, create a repository, upload and download files, etc. It also comes with handy features to configure your machine or manage your cache. In this guide, we will have a look at the main features of the CLI and how to use them.
+
+## Getting started
+
+First of all, let's install the CLI:
+
+```
+>>> pip install -U "huggingface_hub[cli]"
+```
+
+<Tip>
+
+In the snippet above, we also installed the `[cli]` extra dependencies. These are not mandatory to use the CLI but will make the user experience better, especially when using the `delete-cache` command.
+
+</Tip>
+
+Once installed, you can check that the CLI is correctly setup:
+
+```
+>>> huggingface-cli --help
+usage: huggingface-cli <command> [<args>]
+
+positional arguments:
+  {env,login,whoami,logout,repo,upload,download,lfs-enable-largefiles,lfs-multipart-upload,scan-cache,delete-cache}
+                        huggingface-cli command helpers
+    env                 Print information about the environment.
+    login               Log in using a token from huggingface.co/settings/tokens
+    whoami              Find out which huggingface.co account you are logged in as.
+    logout              Log out
+    repo                {create} Commands to interact with your huggingface.co repos.
+    upload              Upload a file or a folder to a repo on the Hub
+    download            Download files from the Hub
+    lfs-enable-largefiles
+                        Configure your repository to enable upload of files > 5GB.
+    lfs-multipart-upload
+                        Command will get called by git-lfs, do not call it directly.
+    scan-cache          Scan cache directory.
+    delete-cache        Delete revisions from the cache directory.
+
+options:
+  -h, --help            show this help message and exit
+```
+
+If the CLI is correctly installed, you should see a list of all the options available in the CLI. If you get an error message such as `command not found: huggingface-cli`, please refer to the [Installation](../installation) guide. 
+
+<Tip>
+
+The option `--help` we used above is very convenient to get more details about a command. You can use it at any time if you want to list all options available and get their details. For example, `huggingface-cli upload --help` provides more information on how to upload files using the CLI.
+
+</Tip>
+
+## huggingface-cli login
+
+In a lot of cases, you must be logged in to a Hugging Face account to interact with the Hub: download private repos, upload files, create PRs,... To do so, you need a [User Access Token](https://huggingface.co/docs/hub/security-tokens) from your [Settings page](https://huggingface.co/settings/tokens). The User Access Token is used to authenticate your identity to the Hub.
+
+Once you have your token, run the following command in your terminal:
+
+```bash
+>>> huggingface-cli login
+```
+
+This command will prompt you for a token. Copy-paste yours and press *Enter*. Then you'll be ask if the token should also be saved as a git credential. Press *Enter* again (default to yes) if you plan to use `git` locally. Finally, it will call the Hub to check that your token is valid and save it locally.
+
+```
+_|    _|  _|    _|    _|_|_|    _|_|_|  _|_|_|  _|      _|    _|_|_|      _|_|_|_|    _|_|      _|_|_|  _|_|_|_|
+_|    _|  _|    _|  _|        _|          _|    _|_|    _|  _|            _|        _|    _|  _|        _|
+_|_|_|_|  _|    _|  _|  _|_|  _|  _|_|    _|    _|  _|  _|  _|  _|_|      _|_|_|    _|_|_|_|  _|        _|_|_|
+_|    _|  _|    _|  _|    _|  _|    _|    _|    _|    _|_|  _|    _|      _|        _|    _|  _|        _|
+_|    _|    _|_|      _|_|_|    _|_|_|  _|_|_|  _|      _|    _|_|_|      _|        _|    _|    _|_|_|  _|_|_|_|
+
+To login, `huggingface_hub` requires a token generated from https://huggingface.co/settings/tokens .
+Token: 
+Add token as git credential? (Y/n) 
+Token is valid (permission: write).
+Your token has been saved in your configured git credential helpers (store).
+Your token has been saved to /home/wauplin/.cache/huggingface/token
+Login successful
+```
+
+Alternatively if you want to login without being prompt, you can pass the token from the command line. It is recommended to use an environment variable when doing so to avoid having your token pasted in your command history.
+
+```bash
+# Or using an environment variable
+>>> huggingface-cli login --token $HUGGINGFACE_TOKEN --add-to-git-credential 
+Token is valid (permission: write).
+Your token has been saved in your configured git credential helpers (store).
+Your token has been saved to /home/wauplin/.cache/huggingface/token
+Login successful
+```
+
+## huggingface-cli whoami
+
+If you want to know if you are logged in, you can use `huggingface-cli whoami`. This command doesn't have any option and will simply print your username and the organizations you are part of on the Hub:
+
+```bash
+huggingface-cli whoami                                                                     
+Wauplin
+orgs:  huggingface,eu-test,OAuthTesters,hf-accelerate,HFSmolCluster
+```
+
+If you are not logged in, an error message will be printed.
+
+## huggingface-cli logout
+
+This commands logs you out. In practice, it will delete the token saved on your machine.
+
+<Tip warning={true}>
+
+This command will not log you out if you are logged in using the `HF_TOKEN` environment variable (see [reference](../package_reference/environment_variables#hftoken)). If that is the case, you must unset the environment variable in your machine configuration.
+
+</Tip>
+
+## huggingface-cli download
+
+
+Use the `huggingface-cli download` command from the terminal to directly download files from the Hub. Internally, it uses the same [`hf_hub_download`] and [`snapshot_download`] helpers described in the [Download](./download) guide and prints the returned path to the terminal. In the examples below, we will walk through the most common use cases. For a full list of available options, you can run:
+
+```bash
+huggingface-cli download --help
+```
+
+### Download a single file
+
+To download a single file from a repo, simply provide the repo_id and filename as follow:
+
+```bash
+>>> huggingface-cli download gpt2 config.json
+downloading https://huggingface.co/gpt2/resolve/main/config.json to /home/wauplin/.cache/huggingface/hub/tmpwrq8dm5o
+(…)ingface.co/gpt2/resolve/main/config.json: 100%|██████████████████████████████████| 665/665 [00:00<00:00, 2.49MB/s]
+/home/wauplin/.cache/huggingface/hub/models--gpt2/snapshots/11c5a3d5811f50298f278a704980280950aedb10/config.json
+```
+
+The command will always print on the last line the path to the file on your local machine.
+
+### Download an entire repository
+
+In some cases, you just want to download all the files from a repository. This can be done by not specifying any filename:
+
+```bash
+>>> huggingface-cli download HuggingFaceH4/zephyr-7b-beta
+Fetching 23 files:   0%|                                                | 0/23 [00:00<?, ?it/s]
+...
+...
+/home/wauplin/.cache/huggingface/hub/models--HuggingFaceH4--zephyr-7b-beta/snapshots/3bac358730f8806e5c3dc7c7e19eb36e045bf720
+```
+
+### Download multiple files
+
+You can also download a subset of the files from a repository in a single command. This can be done in two ways. If you already have a precise list of the files you want to download, you can simply provide them as a sequence:
+
+```bash
+>>> huggingface-cli download gpt2 config.json model.safetensors
+Fetching 2 files:   0%|                                                                        | 0/2 [00:00<?, ?it/s]
+downloading https://huggingface.co/gpt2/resolve/11c5a3d5811f50298f278a704980280950aedb10/model.safetensors to /home/wauplin/.cache/huggingface/hub/tmpdachpl3o
+(…)8f278a7049802950aedb10/model.safetensors: 100%|██████████████████████████████| 8.09k/8.09k [00:00<00:00, 40.5MB/s]
+Fetching 2 files: 100%|████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00,  3.76it/s]
+/home/wauplin/.cache/huggingface/hub/models--gpt2/snapshots/11c5a3d5811f50298f278a704980280950aedb10
+```
+
+The other approach is to provide patterns to filter which files you want to download using `--include` and `--exclude`. For example if you want to download all safetensors files from [stabilityai/stable-diffusion-xl-base-1.0](https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0), except the files in FP16 precision, you can do it like this:
+
+```bash
+>>> huggingface-cli download stabilityai/stable-diffusion-xl-base-1.0 --include "*.safetensors" --exclude "*.fp16.*"*
+Fetching 8 files:   0%|                                                                         | 0/8 [00:00<?, ?it/s]
+...
+...
+Fetching 8 files: 100%|█████████████████████████████████████████████████████████████████████████| 8/8 (...)
+/home/wauplin/.cache/huggingface/hub/models--stabilityai--stable-diffusion-xl-base-1.0/snapshots/462165984030d82259a11f4367a4eed129e94a7b
+```
+
+### Download a dataset or a Space
+
+The examples above show how to download from a model repository. To download a dataset or a Space, use the `--repo-type` option:
+
+```bash
+>>> huggingface-cli download HuggingFaceH4/ultrachat_200k --repo-type dataset
+...
+```
+
+### Download a specific revision
+
+The examples above show how to download from the latest commit on the main branch. To download from a specific revision (commit hash, branch name or tag), use the `--revision` option:
+
+```bash
+>>> huggingface-cli download bigcode/the-stack --repo-type dataset --revision v1.1
+...
+```
+
+### Download to a local folder
+
+The recommended (and default) way to download files from the Hub is to use the cache-system. However, in some cases you want to download files and move them to a specific folder. This is useful to get a workflow closer to what git commands offer. You can do that using the `--local_dir` option.
+
+<Tip warning="true">
+
+Downloading to a local directory comes with some downsides. Please check out the limitations in the [Download](./download#download-files-to-local-folder) guide before using `--local-dir`.
+
+</Tip>
+
+```bash
+>>> huggingface-cli download adept/fuyu-8b model-00001-of-00002.safetensors --local-dir .
+...
+./model-00001-of-00002.safetensors
+```
+
+### Specify cache directory
+
+By default, all files will be download to the cache directory defined by the `HF_HOME` [environment variable](../package_reference/environment_variables#hfhome). You can also specify a custom cache using `--cache-dir`:
+
+```bash
+>>> huggingface-cli download adept/fuyu-8b --cache-dir ./path/to/cache
+...
+./path/to/cache/models--adept--fuyu-8b/snapshots/ddcacbcf5fdf9cc59ff01f6be6d6662624d9c745
+```
+
+### Specify a token
+
+To access private or gated repositories, you must use a token. By default, the token saved locally (using `huggingface-cli login`) will be used. If you want to authenticate explicitly, use the `--token` option:
+
+```bash
+>>> huggingface-cli download gpt2 config.json --token=hf_****
+/home/wauplin/.cache/huggingface/hub/models--gpt2/snapshots/11c5a3d5811f50298f278a704980280950aedb10/config.json
+```
+
+### Quiet mode
+
+By default, the `huggingface-cli download` command will be verbose. It will print details such as warning messages, information about the downloaded files, and progress bars. If you want to silence all of this, use the `--quiet` option. Only the last line (i.e. the path to the downloaded files) is printed. This can prove useful if you want to pass the output to another command in a script.
+
+```bash
+>>> huggingface-cli download gpt2 --quiet
+/home/wauplin/.cache/huggingface/hub/models--gpt2/snapshots/11c5a3d5811f50298f278a704980280950aedb10
+```
+
+## huggingface-cli upload
+
+Use the `huggingface-cli upload` command from the terminal to directly upload files to the Hub. Internally it uses the same [`upload_file`] and [`upload_folder`] helpers described in the [Upload](./upload) guide. In the examples below, we will walk through the most common use cases. For a full list of available options, you can run:
+
+```bash
+>>> huggingface-cli upload --help
+```
+
+### Upload an entire folder
+
+The default usage for this command is:
+
+```bash
+# Usage:  huggingface-cli upload [repo_id] [local_path] [path_in_repo]
+```
+
+To upload the current directory at the root of the repo, use:
+
+```bash
+>>> huggingface-cli my-cool-model . .
+https://huggingface.co/Wauplin/my-cool-model/tree/main/
+```
+
+<Tip>
+
+If the repo doesn't exist yet, it will be created automatically.
+
+</Tip>
+
+You can also upload a specific folder:
+
+```bash
+>>> huggingface-cli my-cool-model ./models .
+https://huggingface.co/Wauplin/my-cool-model/tree/main/
+```
+
+Finally, you can upload a folder to a specific destination on the repo:
+
+```bash
+>>> huggingface-cli my-cool-model ./path/to/curated/data /data/train
+https://huggingface.co/Wauplin/my-cool-model/tree/main/data/train
+```
+
+### Upload a single file
+
+We saw above how to upload an entire folder. You can also upload a single file by setting `local_path` to point to a file on your machine. If that's the case, `path_in_repo` is optional and will default to the name of your local file:
+
+```bash
+>>> huggingface-cli upload Wauplin/my-cool-model ./models/model.safetensors
+https://huggingface.co/Wauplin/my-cool-model/blob/main/model.safetensors
+```
+
+If you want to upload a single file to a specific directory, set `path_in_repo` accordingly:
+
+```bash
+>>> huggingface-cli upload Wauplin/my-cool-model ./models/model.safetensors /vae/model.safetensors
+https://huggingface.co/Wauplin/my-cool-model/blob/main/vae/model.safetensors
+```
+
+### Upload multiple files
+
+To upload multiple files from a folder at once without uploading the entire folder, use the `--include` and `--exclude` patterns. It can also be combined with the `--delete` option to delete files on the repo while uploading new ones. In the example below, we sync the local Space by deleting remote files and uploading all files, except the ones in `/logs` and 
+
+```bash
+# Sync local Space with Hub (upload new files except from logs/, delete removed files)
+>>> huggingface-cli upload Wauplin/space-example --repo-type=space --exclude="/logs/*" --delete="*" --commit-message="Sync local Space with Hub"
+...
+```
+
+### Upload to a dataset or Space
+
+To upload to a dataset or a Space, use the `--repo-type` option:
+
+```bash
+>>> huggingface-cli upload Wauplin/my-cool-dataset ./data /train --repo-type=dataset
+...
+```
+
+### Upload to a specific revision
+
+The examples above show how to upload to the `main` branch. If you want to upload files to another branch or reference, use the `--revision` option:
+
+```bash
+# Upload files to a PR
+>>> huggingface-cli upload bigcode/the-stack . . --repo-type dataset --revision refs/pr/104
+...
+```
+
+### Upload and create a PR
+
+If you don't have the permission to push to a repo, you must open a PR and let the authors know about the changes you want to make. This can be done by setting the `--create-pr` option:
+
+```bash
+# Create a PR and upload the files to it
+>>> huggingface-cli upload bigcode/the-stack . . --repo-type dataset --revision refs/pr/104
+https://huggingface.co/datasets/bigcode/the-stack/blob/refs%2Fpr%2F104/
+```
+
+### Upload at regular intervals
+
+In some cases, you might want to push regular updates to a repo. For example, this is useful when training a model if you want to upload the logs folder every 10 minutes. You can do this using the `--every` option:
+
+```bash
+# Upload new logs every 10 minutes
+huggingface-cli upload training-model logs/ --every=10
+```
+
+### Specify a commit message
+
+Use the `--commit-message` and `--commit-description` to set a custom message and description for your commit instead of the default one
+
+```bash
+>>> huggingface-cli upload Wauplin/my-cool-model ./models . --commit-message "Epoch 34/50" --commit-description "Val accuracy: 68%. Check tensorboard for more details."
+...
+https://huggingface.co/Wauplin/my-cool-model/tree/main
+```
+
+### Specify a token
+
+To upload files, you must use a token. By default, the token saved locally (using `huggingface-cli login`) will be used. If you want to authenticate explicitly, use the `--token` option:
+
+```bash
+>>> huggingface-cli upload Wauplin/my-cool-model ./models . --token=hf_****
+...
+https://huggingface.co/Wauplin/my-cool-model/tree/main
+```
+
+### Quiet mode
+
+By default, the `huggingface-cli upload` command will be verbose. It will print details such as warning messages, information about the uploaded files, and progress bars. If you want to silence all of this, use the `--quiet` option. Only the last line (i.e. the URL to the uploaded files) is printed. This can prove useful if you want to pass the output to another command in a script.
+
+```bash
+>>> huggingface-cli upload Wauplin/my-cool-model ./models . --quiet
+https://huggingface.co/Wauplin/my-cool-model/tree/main
+```
+
+## huggingface-cli scan-cache
+
+Scanning your cache directory is useful if you want to know which repos you have downloaded and how much space it takes on your disk. You can do that from the terminal by running `huggingface-cli scan-cache`:
+
+```bash
+>>> huggingface-cli scan-cache
+REPO ID                     REPO TYPE SIZE ON DISK NB FILES LAST_ACCESSED LAST_MODIFIED REFS                LOCAL PATH
+--------------------------- --------- ------------ -------- ------------- ------------- ------------------- -------------------------------------------------------------------------
+glue                        dataset         116.3K       15 4 days ago    4 days ago    2.4.0, main, 1.17.0 /home/wauplin/.cache/huggingface/hub/datasets--glue
+google/fleurs               dataset          64.9M        6 1 week ago    1 week ago    refs/pr/1, main     /home/wauplin/.cache/huggingface/hub/datasets--google--fleurs
+Jean-Baptiste/camembert-ner model           441.0M        7 2 weeks ago   16 hours ago  main                /home/wauplin/.cache/huggingface/hub/models--Jean-Baptiste--camembert-ner
+bert-base-cased             model             1.9G       13 1 week ago    2 years ago                       /home/wauplin/.cache/huggingface/hub/models--bert-base-cased
+t5-base                     model            10.1K        3 3 months ago  3 months ago  main                /home/wauplin/.cache/huggingface/hub/models--t5-base
+t5-small                    model           970.7M       11 3 days ago    3 days ago    refs/pr/1, main     /home/wauplin/.cache/huggingface/hub/models--t5-small
+
+Done in 0.0s. Scanned 6 repo(s) for a total of 3.4G.
+Got 1 warning(s) while scanning. Use -vvv to print details.
+```
+
+For more details about how to scan your cache directory, please refer to the [Manage your cache](./manage-cache#scan-cache-from-the-terminal) guide.
+
+## huggingface-cli delete-cache
+
+`huggingface-cli delete-cache` is a tool that helps you delete parts of your cache that you don't use anymore. This is useful to save disk space. To learn more on how to use this command, please refer to the [Manage your cache](./manage-cache#clean-cache-from-the-terminal) guide.
+
+## huggingface-cli env
+
+The `huggingface-cli env` command is a command to print details about your machine setup. This is useful when you open an issue on [GitHub](https://github.com/huggingface/huggingface_hub) to help the maintainers investigate your problem.
+
+```bash
+>>> huggingface-cli env
+
+Copy-and-paste the text below in your GitHub issue.
+
+- huggingface_hub version: 0.19.0.dev0
+- Platform: Linux-6.2.0-36-generic-x86_64-with-glibc2.35
+- Python version: 3.10.12
+- Running in iPython ?: No
+- Running in notebook ?: No
+- Running in Google Colab ?: No
+- Token path ?: /home/wauplin/.cache/huggingface/token
+- Has saved token ?: True
+- Who am I ?: Wauplin
+- Configured git credential helpers: store
+- FastAI: N/A
+- Tensorflow: 2.11.0
+- Torch: 1.12.1
+- Jinja2: 3.1.2
+- Graphviz: 0.20.1
+- Pydot: 1.4.2
+- Pillow: 9.2.0
+- hf_transfer: 0.1.3
+- gradio: 4.0.2
+- tensorboard: 2.6
+- numpy: 1.23.2
+- pydantic: 2.4.2
+- aiohttp: 3.8.4
+- ENDPOINT: https://huggingface.co
+- HF_HUB_CACHE: /home/wauplin/.cache/huggingface/hub
+- HF_ASSETS_CACHE: /home/wauplin/.cache/huggingface/assets
+- HF_TOKEN_PATH: /home/wauplin/.cache/huggingface/token
+- HF_HUB_OFFLINE: False
+- HF_HUB_DISABLE_TELEMETRY: False
+- HF_HUB_DISABLE_PROGRESS_BARS: None
+- HF_HUB_DISABLE_SYMLINKS_WARNING: False
+- HF_HUB_DISABLE_EXPERIMENTAL_WARNING: False
+- HF_HUB_DISABLE_IMPLICIT_TOKEN: False
+- HF_HUB_ENABLE_HF_TRANSFER: False
+- HF_HUB_ETAG_TIMEOUT: 10
+- HF_HUB_DOWNLOAD_TIMEOUT: 10
+```

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -57,7 +57,7 @@ The `--help` option is very convenient for getting more details about a command.
 
 ## huggingface-cli login
 
-In many cases, you must be logged in to a Hugging Face account to interact with the Hub (download private repos, upload files, create PRs, etc.). To do so, you need a [User Access Token](https://huggingface.co/docs/hub/security-tokens) from your [Settings page](https://huggingface.co/settings/tokens). The User Access Token is used to authenticate your identity to the Hub.
+In many cases, you must be logged in to a Hugging Face account to interact with the Hub (download private repos, upload files, create PRs, etc.). To do so, you need a [User Access Token](https://huggingface.co/docs/hub/security-tokens) from your [Settings page](https://huggingface.co/settings/tokens). The User Access Token is used to authenticate your identity to the Hub. Make sure to set a token with write access if you want to upload or modify content.
 
 Once you have your token, run the following command in your terminal:
 

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -256,7 +256,7 @@ The default usage for this command is:
 To upload the current directory at the root of the repo, use:
 
 ```bash
->>> huggingface-cli my-cool-model . .
+>>> huggingface-cli upload my-cool-model . .
 https://huggingface.co/Wauplin/my-cool-model/tree/main/
 ```
 
@@ -269,14 +269,14 @@ If the repo doesn't exist yet, it will be created automatically.
 You can also upload a specific folder:
 
 ```bash
->>> huggingface-cli my-cool-model ./models .
+>>> huggingface-cli upload my-cool-model ./models .
 https://huggingface.co/Wauplin/my-cool-model/tree/main/
 ```
 
 Finally, you can upload a folder to a specific destination on the repo:
 
 ```bash
->>> huggingface-cli my-cool-model ./path/to/curated/data /data/train
+>>> huggingface-cli upload my-cool-model ./path/to/curated/data /data/train
 https://huggingface.co/Wauplin/my-cool-model/tree/main/data/train
 ```
 
@@ -313,6 +313,15 @@ To upload to a dataset or a Space, use the `--repo-type` option:
 ```bash
 >>> huggingface-cli upload Wauplin/my-cool-dataset ./data /train --repo-type=dataset
 ...
+```
+
+### Upload to an organization
+
+To upload content to a repo owned by an organization instead of a personal repo, you must explicitly specify it in the `repo_id`:
+
+```bash
+>>> huggingface-cli upload MyCoolOrganization/my-cool-model . .
+https://huggingface.co/MyCoolOrganization/my-cool-model/tree/main/
 ```
 
 ### Upload to a specific revision

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -110,11 +110,7 @@ If you are not logged in, an error message will be printed.
 
 This commands logs you out. In practice, it will delete the token saved on your machine.
 
-<Tip warning={true}>
-
 This command will not log you out if you are logged in using the `HF_TOKEN` environment variable (see [reference](../package_reference/environment_variables#hftoken)). If that is the case, you must unset the environment variable in your machine configuration.
-
-</Tip>
 
 ## huggingface-cli download
 

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -16,7 +16,7 @@ First of all, let's install the CLI:
 
 <Tip>
 
-In the snippet above, we also installed the `[cli]` extra dependencies. These are not mandatory to use the CLI but will make the user experience better, especially when using the `delete-cache` command.
+In the snippet above, we also installed the `[cli]` extra dependencies to make the user experience better, especially when using the `delete-cache` command.
 
 </Tip>
 
@@ -51,13 +51,13 @@ If the CLI is correctly installed, you should see a list of all the options avai
 
 <Tip>
 
-The option `--help` we used above is very convenient to get more details about a command. You can use it at any time if you want to list all options available and get their details. For example, `huggingface-cli upload --help` provides more information on how to upload files using the CLI.
+The `--help` option is very convenient for getting more details about a command. You can use it anytime to list all available options and their details. For example, `huggingface-cli upload --help` provides more information on how to upload files using the CLI.
 
 </Tip>
 
 ## huggingface-cli login
 
-In a lot of cases, you must be logged in to a Hugging Face account to interact with the Hub: download private repos, upload files, create PRs,... To do so, you need a [User Access Token](https://huggingface.co/docs/hub/security-tokens) from your [Settings page](https://huggingface.co/settings/tokens). The User Access Token is used to authenticate your identity to the Hub.
+In many cases, you must be logged in to a Hugging Face account to interact with the Hub (download private repos, upload files, create PRs, etc.). To do so, you need a [User Access Token](https://huggingface.co/docs/hub/security-tokens) from your [Settings page](https://huggingface.co/settings/tokens). The User Access Token is used to authenticate your identity to the Hub.
 
 Once you have your token, run the following command in your terminal:
 
@@ -65,7 +65,7 @@ Once you have your token, run the following command in your terminal:
 >>> huggingface-cli login
 ```
 
-This command will prompt you for a token. Copy-paste yours and press *Enter*. Then you'll be ask if the token should also be saved as a git credential. Press *Enter* again (default to yes) if you plan to use `git` locally. Finally, it will call the Hub to check that your token is valid and save it locally.
+This command will prompt you for a token. Copy-paste yours and press *Enter*. Then you'll be asked if the token should also be saved as a git credential. Press *Enter* again (default to yes) if you plan to use `git` locally. Finally, it will call the Hub to check that your token is valid and save it locally.
 
 ```
 _|    _|  _|    _|    _|_|_|    _|_|_|  _|_|_|  _|      _|    _|_|_|      _|_|_|_|    _|_|      _|_|_|  _|_|_|_|
@@ -83,7 +83,7 @@ Your token has been saved to /home/wauplin/.cache/huggingface/token
 Login successful
 ```
 
-Alternatively if you want to login without being prompt, you can pass the token from the command line. It is recommended to use an environment variable when doing so to avoid having your token pasted in your command history.
+Alternatively, if you want to log-in without being prompted, you can pass the token directly from the command line. To be more secure, we recommend passing your token as an environment variable to avoid pasting it in your command history.
 
 ```bash
 # Or using an environment variable
@@ -96,7 +96,7 @@ Login successful
 
 ## huggingface-cli whoami
 
-If you want to know if you are logged in, you can use `huggingface-cli whoami`. This command doesn't have any option and will simply print your username and the organizations you are part of on the Hub:
+If you want to know if you are logged in, you can use `huggingface-cli whoami`. This command doesn't have any options and simply prints your username and the organizations you are a part of on the Hub:
 
 ```bash
 huggingface-cli whoami                                                                     
@@ -119,7 +119,7 @@ This command will not log you out if you are logged in using the `HF_TOKEN` envi
 ## huggingface-cli download
 
 
-Use the `huggingface-cli download` command from the terminal to directly download files from the Hub. Internally, it uses the same [`hf_hub_download`] and [`snapshot_download`] helpers described in the [Download](./download) guide and prints the returned path to the terminal. In the examples below, we will walk through the most common use cases. For a full list of available options, you can run:
+Use the `huggingface-cli download` command to download files from the Hub directly. Internally, it uses the same [`hf_hub_download`] and [`snapshot_download`] helpers described in the [Download](./download) guide and prints the returned path to the terminal. In the examples below, we will walk through the most common use cases. For a full list of available options, you can run:
 
 ```bash
 huggingface-cli download --help
@@ -140,7 +140,7 @@ The command will always print on the last line the path to the file on your loca
 
 ### Download an entire repository
 
-In some cases, you just want to download all the files from a repository. This can be done by not specifying any filename:
+In some cases, you just want to download all the files from a repository. This can be done by just specifying the repo id:
 
 ```bash
 >>> huggingface-cli download HuggingFaceH4/zephyr-7b-beta
@@ -152,7 +152,7 @@ Fetching 23 files:   0%|                                                | 0/23 [
 
 ### Download multiple files
 
-You can also download a subset of the files from a repository in a single command. This can be done in two ways. If you already have a precise list of the files you want to download, you can simply provide them as a sequence:
+You can also download a subset of the files from a repository with a single command. This can be done in two ways. If you already have a precise list of the files you want to download, you can simply provide them sequentially:
 
 ```bash
 >>> huggingface-cli download gpt2 config.json model.safetensors
@@ -163,7 +163,7 @@ Fetching 2 files: 100%|███████████████████
 /home/wauplin/.cache/huggingface/hub/models--gpt2/snapshots/11c5a3d5811f50298f278a704980280950aedb10
 ```
 
-The other approach is to provide patterns to filter which files you want to download using `--include` and `--exclude`. For example if you want to download all safetensors files from [stabilityai/stable-diffusion-xl-base-1.0](https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0), except the files in FP16 precision, you can do it like this:
+The other approach is to provide patterns to filter which files you want to download using `--include` and `--exclude`. For example, if you want to download all safetensors files from [stabilityai/stable-diffusion-xl-base-1.0](https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0), except the files in FP16 precision:
 
 ```bash
 >>> huggingface-cli download stabilityai/stable-diffusion-xl-base-1.0 --include "*.safetensors" --exclude "*.fp16.*"*
@@ -238,7 +238,7 @@ By default, the `huggingface-cli download` command will be verbose. It will prin
 
 ## huggingface-cli upload
 
-Use the `huggingface-cli upload` command from the terminal to directly upload files to the Hub. Internally it uses the same [`upload_file`] and [`upload_folder`] helpers described in the [Upload](./upload) guide. In the examples below, we will walk through the most common use cases. For a full list of available options, you can run:
+Use the `huggingface-cli upload` command to upload files to the Hub directly. Internally, it uses the same [`upload_file`] and [`upload_folder`] helpers described in the [Upload](./upload) guide. In the examples below, we will walk through the most common use cases. For a full list of available options, you can run:
 
 ```bash
 >>> huggingface-cli upload --help
@@ -281,7 +281,7 @@ https://huggingface.co/Wauplin/my-cool-model/tree/main/data/train
 
 ### Upload a single file
 
-We saw above how to upload an entire folder. You can also upload a single file by setting `local_path` to point to a file on your machine. If that's the case, `path_in_repo` is optional and will default to the name of your local file:
+You can also upload a single file by setting `local_path` to point to a file on your machine. If that's the case, `path_in_repo` is optional and will default to the name of your local file:
 
 ```bash
 >>> huggingface-cli upload Wauplin/my-cool-model ./models/model.safetensors
@@ -297,7 +297,7 @@ https://huggingface.co/Wauplin/my-cool-model/blob/main/vae/model.safetensors
 
 ### Upload multiple files
 
-To upload multiple files from a folder at once without uploading the entire folder, use the `--include` and `--exclude` patterns. It can also be combined with the `--delete` option to delete files on the repo while uploading new ones. In the example below, we sync the local Space by deleting remote files and uploading all files, except the ones in `/logs` and 
+To upload multiple files from a folder at once without uploading the entire folder, use the `--include` and `--exclude` patterns. It can also be combined with the `--delete` option to delete files on the repo while uploading new ones. In the example below, we sync the local Space by deleting remote files and uploading all files except the ones in `/logs`: 
 
 ```bash
 # Sync local Space with Hub (upload new files except from logs/, delete removed files)
@@ -316,7 +316,7 @@ To upload to a dataset or a Space, use the `--repo-type` option:
 
 ### Upload to a specific revision
 
-The examples above show how to upload to the `main` branch. If you want to upload files to another branch or reference, use the `--revision` option:
+By default, files are uploaded to the `main` branch. If you want to upload files to another branch or reference, use the `--revision` option:
 
 ```bash
 # Upload files to a PR
@@ -336,7 +336,7 @@ https://huggingface.co/datasets/bigcode/the-stack/blob/refs%2Fpr%2F104/
 
 ### Upload at regular intervals
 
-In some cases, you might want to push regular updates to a repo. For example, this is useful when training a model if you want to upload the logs folder every 10 minutes. You can do this using the `--every` option:
+In some cases, you might want to push regular updates to a repo. For example, this is useful if you're training a model and you want to upload the logs folder every 10 minutes. You can do this using the `--every` option:
 
 ```bash
 # Upload new logs every 10 minutes
@@ -348,7 +348,7 @@ huggingface-cli upload training-model logs/ --every=10
 Use the `--commit-message` and `--commit-description` to set a custom message and description for your commit instead of the default one
 
 ```bash
->>> huggingface-cli upload Wauplin/my-cool-model ./models . --commit-message "Epoch 34/50" --commit-description "Val accuracy: 68%. Check tensorboard for more details."
+>>> huggingface-cli upload Wauplin/my-cool-model ./models . --commit-message="Epoch 34/50" --commit-description="Val accuracy: 68%. Check tensorboard for more details."
 ...
 https://huggingface.co/Wauplin/my-cool-model/tree/main
 ```
@@ -374,7 +374,7 @@ https://huggingface.co/Wauplin/my-cool-model/tree/main
 
 ## huggingface-cli scan-cache
 
-Scanning your cache directory is useful if you want to know which repos you have downloaded and how much space it takes on your disk. You can do that from the terminal by running `huggingface-cli scan-cache`:
+Scanning your cache directory is useful if you want to know which repos you have downloaded and how much space it takes on your disk. You can do that by running `huggingface-cli scan-cache`:
 
 ```bash
 >>> huggingface-cli scan-cache
@@ -395,11 +395,11 @@ For more details about how to scan your cache directory, please refer to the [Ma
 
 ## huggingface-cli delete-cache
 
-`huggingface-cli delete-cache` is a tool that helps you delete parts of your cache that you don't use anymore. This is useful to save disk space. To learn more on how to use this command, please refer to the [Manage your cache](./manage-cache#clean-cache-from-the-terminal) guide.
+`huggingface-cli delete-cache` is a tool that helps you delete parts of your cache that you don't use anymore. This is useful for saving and freeing disk space. To learn more about using this command, please refer to the [Manage your cache](./manage-cache#clean-cache-from-the-terminal) guide.
 
 ## huggingface-cli env
 
-The `huggingface-cli env` command is a command to print details about your machine setup. This is useful when you open an issue on [GitHub](https://github.com/huggingface/huggingface_hub) to help the maintainers investigate your problem.
+The `huggingface-cli env` command prints details about your machine setup. This is useful when you open an issue on [GitHub](https://github.com/huggingface/huggingface_hub) to help the maintainers investigate your problem.
 
 ```bash
 >>> huggingface-cli env

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -175,7 +175,12 @@ Fetching 8 files: 100%|███████████████████
 The examples above show how to download from a model repository. To download a dataset or a Space, use the `--repo-type` option:
 
 ```bash
+# https://huggingface.co/datasets/HuggingFaceH4/ultrachat_200k
 >>> huggingface-cli download HuggingFaceH4/ultrachat_200k --repo-type dataset
+
+# https://huggingface.co/spaces/HuggingFaceH4/zephyr-chat
+>>> huggingface-cli download HuggingFaceH4/zephyr-chat --repo-type space
+
 ...
 ```
 

--- a/docs/source/en/guides/download.md
+++ b/docs/source/en/guides/download.md
@@ -167,18 +167,10 @@ symlinks. Check out the [cache limitations](../guides/manage-cache#limitations) 
 
 You can use the `huggingface-cli download` command from the terminal to directly download files from the Hub.
 Internally, it uses the same [`hf_hub_download`] and [`snapshot_download`] helpers described above and prints the
-returned path to the terminal:
+returned path to the terminal.
 
 ```bash
 >>> huggingface-cli download gpt2 config.json
-/home/wauplin/.cache/huggingface/hub/models--gpt2/snapshots/11c5a3d5811f50298f278a704980280950aedb10/config.json
-```
-
-By default, the token saved locally (using `huggingface-cli login`) will be used. If you want to authenticate explicitly,
-use the `--token` option:
-
-```bash
->>> huggingface-cli download gpt2 config.json --token=hf_****
 /home/wauplin/.cache/huggingface/hub/models--gpt2/snapshots/11c5a3d5811f50298f278a704980280950aedb10/config.json
 ```
 
@@ -191,47 +183,7 @@ Fetching 2 files: 100%|███████████████████
 /home/wauplin/.cache/huggingface/hub/models--gpt2/snapshots/11c5a3d5811f50298f278a704980280950aedb10
 ```
 
-If you want to silence the progress bars and potential warnings, use the `--quiet` option. This can prove useful if you
-want to pass the output to another command in a script.
-
-```bash
->>> huggingface-cli download gpt2 config.json model.safetensors
-/home/wauplin/.cache/huggingface/hub/models--gpt2/snapshots/11c5a3d5811f50298f278a704980280950aedb10
-```
-
-By default, files are downloaded to the cache directory defined by `HF_HOME` environment variable (or `~/.cache/huggingface/hub` if not specified). You
-can override this by using the `--cache-dir` option:
-
-```bash
->>> huggingface-cli download gpt2 config.json --cache-dir=./cache
-./cache/models--gpt2/snapshots/11c5a3d5811f50298f278a704980280950aedb10/config.json
-```
-
-If you want to download files to a local folder, without the cache directory structure, you can use `--local-dir`.
-Downloading to a local folder comes with its limitations which are listed in this [table](https://huggingface.co/docs/huggingface_hub/guides/download#download-files-to-local-folder).
-
-
-```bash
->>> huggingface-cli download gpt2 config.json --local-dir=./models/gpt2
-./models/gpt2/config.json
-```
-
-
-There are more arguments you can specify to download from different repo types or revisions and to include/exclude files to download using
-glob patterns:
-
-```bash
->>> huggingface-cli download bigcode/the-stack --repo-type=dataset --revision=v1.2 --include="data/python/*" --exclu
-de="*.json" --exclude="*.zip"
-Fetching 206 files:   100%|████████████████████████████████████████████| 206/206 [02:31<2:31, ?it/s]
-/home/wauplin/.cache/huggingface/hub/datasets--bigcode--the-stack/snapshots/9ca8fa6acdbc8ce920a0cb58adcdafc495818ae7
-```
-
-For a full list of the arguments, you can run:
-
-```bash
-huggingface-cli download --help
-```
+For more details about the CLI download command, please refer to the [CLI guide](./cli#huggingface-cli-download).
 
 ## Faster downloads
 

--- a/docs/source/en/guides/upload.md
+++ b/docs/source/en/guides/upload.md
@@ -108,8 +108,7 @@ but before that, all previous logs on the repo on deleted. All of this in a sing
 
 ## Upload from the CLI
 
-You can use the `huggingface-cli upload` command from the terminal to directly upload files to the Hub. Internally
-it uses the same [`upload_file`] and [`upload_folder`] helpers described above.
+You can use the `huggingface-cli upload` command from the terminal to directly upload files to the Hub. Internally it uses the same [`upload_file`] and [`upload_folder`] helpers described above.
 
 You can either upload a single file or an entire folder:
 
@@ -127,38 +126,7 @@ check if a local folder or file has the same name as the `repo_id`. If that's th
 Otherwise, an exception is raised asking the user to explicitly set `local_path`. In any case, if `path_in_repo` is not
 set, files are uploaded at the root of the repo.
 
-```bash
-# Upload file at root
-huggingface-cli upload my-cool-model model.safetensors
-
-# Upload directory at root
-huggingface-cli upload my-cool-model ./models
-
-# Upload `my-cool-model/` directory if it exist, raise otherwise
-huggingface-cli upload my-cool-model
-```
-
-By default, the token saved locally (using `huggingface-cli login`) will be used. If you want to authenticate explicitly,
-use the `--token` option:
-
-```bash
-huggingface-cli upload my-cool-model --token=hf_****
-```
-
-When uploading a folder, you can use the `--include` and `--exclude` arguments to filter the files to upload. You can
-also use `--delete` to delete existing files on the Hub.
-
-```bash
-# Sync local Space with Hub (upload new files except from logs/, delete removed files)
-huggingface-cli upload Wauplin/space-example --repo-type=space --exclude="/logs/*" --delete="*" --commit-message="Sync local Space with Hub"
-```
-
-Finally, you can also schedule a job that will upload your files regularly (see [scheduled uploads](#scheduled-uploads)).
-
-```bash
-# Upload new logs every 10 minutes
-huggingface-cli upload training-model logs/ --every=10
-```
+For more details about the CLI upload command, please refer to the [CLI guide](./cli#huggingface-cli-upload).
 
 ## Advanced features
 

--- a/src/huggingface_hub/commands/lfs.py
+++ b/src/huggingface_hub/commands/lfs.py
@@ -56,16 +56,13 @@ class LfsCommands(BaseHuggingfaceCLICommand):
     @staticmethod
     def register_subcommand(parser: _SubParsersAction):
         enable_parser = parser.add_parser(
-            "lfs-enable-largefiles",
-            help="Configure your repository to enable upload of files > 5GB.",
+            "lfs-enable-largefiles", help="Configure your repository to enable upload of files > 5GB."
         )
         enable_parser.add_argument("path", type=str, help="Local path to repository you want to configure.")
         enable_parser.set_defaults(func=lambda args: LfsEnableCommand(args))
 
-        upload_parser = parser.add_parser(
-            LFS_MULTIPART_UPLOAD_COMMAND,
-            help="Command will get called by git-lfs, do not call it directly.",
-        )
+        # Command will get called by git-lfs, do not call it directly.
+        upload_parser = parser.add_parser(LFS_MULTIPART_UPLOAD_COMMAND, add_help=False)
         upload_parser.set_defaults(func=lambda args: LfsUploadCommand(args))
 
 

--- a/src/huggingface_hub/commands/user.py
+++ b/src/huggingface_hub/commands/user.py
@@ -60,7 +60,7 @@ class UserCommands(BaseHuggingfaceCLICommand):
         # new system: git-based repo system
         repo_parser = parser.add_parser(
             "repo",
-            help="{create, ls-files} Commands to interact with your huggingface.co repos.",
+            help="{create} Commands to interact with your huggingface.co repos.",
         )
         repo_subparsers = repo_parser.add_subparsers(help="huggingface.co repos related commands")
         repo_create_parser = repo_subparsers.add_parser("create", help="Create a new repo on huggingface.co")

--- a/src/huggingface_hub/commands/user.py
+++ b/src/huggingface_hub/commands/user.py
@@ -58,10 +58,7 @@ class UserCommands(BaseHuggingfaceCLICommand):
         logout_parser.set_defaults(func=lambda args: LogoutCommand(args))
 
         # new system: git-based repo system
-        repo_parser = parser.add_parser(
-            "repo",
-            help="{create} Commands to interact with your huggingface.co repos.",
-        )
+        repo_parser = parser.add_parser("repo", help="{create} Commands to interact with your huggingface.co repos.")
         repo_subparsers = repo_parser.add_subparsers(help="huggingface.co repos related commands")
         repo_create_parser = repo_subparsers.add_parser("create", help="Create a new repo on huggingface.co")
         repo_create_parser.add_argument(


### PR DESCRIPTION
Close https://github.com/huggingface/huggingface_hub/issues/1778 (cc @apolinario)

This PR adds a page to explain the main features of the CLI. The most detailed part is about `huggingface-cli download` and `huggingface-cli upload` that were not very well documented until now. Some commands are not documented in the PR on purpose (some are legacy, some are not very important).

Guide to review: https://moon-ci-docs.huggingface.co/docs/huggingface_hub/pr_1797/en/guides/cli

(failing tests are unrelated to this PR)