### PR TITLE
Update `SpaceHardware` enum

### DIFF
--- a/src/huggingface_hub/_space_api.py
+++ b/src/huggingface_hub/_space_api.py
@@ -61,8 +61,11 @@ class SpaceHardware(str, Enum):
     CPU_UPGRADE = "cpu-upgrade"
     T4_SMALL = "t4-small"
     T4_MEDIUM = "t4-medium"
+    ZERO_A10G = "zero-a10g"
     A10G_SMALL = "a10g-small"
     A10G_LARGE = "a10g-large"
+    A10G_LARGEX2 = "a10g-largex2"
+    A10G_LARGEX4 = "a10g-largex4"
     A100_LARGE = "a100-large"
 
 


### PR DESCRIPTION
(raised on [slack](https://huggingface.slack.com/archives/C02V5EA0A95/p1699011619458609) -internal link- by @abhishekkrthakur)

Current `SpaceHardware` enum is outdated. This PR updates it with `"zero-a10g"`, `"a10g-largex2"` and `"a10g-largex4"`. Note: even when not added to the enum, users can still sets them using a simple string.

I chose to add the `zero-a10g` (cc @cbensimon) even though it is still in restricted access. Shouldn't be much of a problem (I don't think this API is much used by non-HF users) and at least it will be forward compatible.

cc @christophe-rannou who updated this list in the backend recently.
