### PR TITLE
Do not promote `HF_ENDPOINT` environment variable

### DIFF
--- a/docs/source/en/package_reference/environment_variables.md
+++ b/docs/source/en/package_reference/environment_variables.md
@@ -15,13 +15,6 @@ and their meaning.
 
 ## Generic
 
-### HF_ENDPOINT
-
-To configure the Hub base url. You might want to set this variable if your organization
-is using a [Private Hub](https://huggingface.co/platform).
-
-Defaults to `"https://huggingface.co"`.
-
 ### HF_INFERENCE_ENDPOINT
 
 To configure the inference api base url. You might want to set this variable if your organization

--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -27,7 +27,6 @@ def snapshot_download(
     *,
     repo_type: Optional[str] = None,
     revision: Optional[str] = None,
-    endpoint: Optional[str] = None,
     cache_dir: Union[str, Path, None] = None,
     local_dir: Union[str, Path, None] = None,
     local_dir_use_symlinks: Union[bool, Literal["auto"]] = "auto",
@@ -44,6 +43,7 @@ def snapshot_download(
     ignore_patterns: Optional[Union[List[str], str]] = None,
     max_workers: int = 8,
     tqdm_class: Optional[base_tqdm] = None,
+    endpoint: Optional[str] = None,
 ) -> str:
     """Download repo files.
 

--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -79,9 +79,6 @@ def snapshot_download(
         revision (`str`, *optional*):
             An optional Git revision id which can be a branch name, a tag, or a
             commit hash.
-        endpoint (`str`, *optional*):
-            Hugging Face Hub base url. Will default to https://huggingface.co/. Otherwise, one can set the `HF_ENDPOINT`
-            environment variable.
         cache_dir (`str`, `Path`, *optional*):
             Path to the folder where cached files are stored.
         local_dir (`str` or `Path`, *optional*):

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -206,9 +206,6 @@ def hf_hub_url(
         revision (`str`, *optional*):
             An optional Git revision id which can be a branch name, a tag, or a
             commit hash.
-        endpoint (`str`, *optional*):
-            Hugging Face Hub base url. Will default to https://huggingface.co/. Otherwise, one can set the `HF_ENDPOINT`
-            environment variable.
 
     Example:
 
@@ -1052,9 +1049,6 @@ def hf_hub_download(
         revision (`str`, *optional*):
             An optional Git revision id which can be a branch name, a tag, or a
             commit hash.
-        endpoint (`str`, *optional*):
-            Hugging Face Hub base url. Will default to https://huggingface.co/. Otherwise, one can set the `HF_ENDPOINT`
-            environment variable.
         library_name (`str`, *optional*):
             The name of the library to which the object corresponds.
         library_version (`str`, *optional*):

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -975,7 +975,6 @@ def hf_hub_download(
     subfolder: Optional[str] = None,
     repo_type: Optional[str] = None,
     revision: Optional[str] = None,
-    endpoint: Optional[str] = None,
     library_name: Optional[str] = None,
     library_version: Optional[str] = None,
     cache_dir: Union[str, Path, None] = None,
@@ -990,6 +989,7 @@ def hf_hub_download(
     token: Union[bool, str, None] = None,
     local_files_only: bool = False,
     legacy_cache_layout: bool = False,
+    endpoint: Optional[str] = None,
 ) -> str:
     """Download a given file if it's not already present in the local cache.
 

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -1065,9 +1065,6 @@ class HfApi:
         directly at the root of `huggingface_hub`.
 
         Args:
-            endpoint (`str`, *optional*):
-                Hugging Face Hub base url. Will default to https://huggingface.co/. Otherwise,
-                one can set the `HF_ENDPOINT` environment variable.
             token (`str`, *optional*):
                 Hugging Face token. Will default to the locally saved token if
                 not provided.
@@ -4391,9 +4388,6 @@ class HfApi:
             revision (`str`, *optional*):
                 An optional Git revision id which can be a branch name, a tag, or a
                 commit hash.
-            endpoint (`str`, *optional*):
-                Hugging Face Hub base url. Will default to https://huggingface.co/. Otherwise, one can set the `HF_ENDPOINT`
-                environment variable.
             cache_dir (`str`, `Path`, *optional*):
                 Path to the folder where cached files are stored.
             local_dir (`str` or `Path`, *optional*):

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -208,16 +208,8 @@ def rmtree_with_retry(path: Union[str, Path]) -> None:
 
 
 def with_production_testing(func):
-    file_download = patch(
-        "huggingface_hub.file_download.HUGGINGFACE_CO_URL_TEMPLATE",
-        ENDPOINT_PRODUCTION_URL_SCHEME,
-    )
-
-    hf_api = patch(
-        "huggingface_hub.hf_api.ENDPOINT",
-        ENDPOINT_PRODUCTION,
-    )
-
+    file_download = patch("huggingface_hub.file_download.HUGGINGFACE_CO_URL_TEMPLATE", ENDPOINT_PRODUCTION_URL_SCHEME)
+    hf_api = patch("huggingface_hub.hf_api.ENDPOINT", ENDPOINT_PRODUCTION)
     return hf_api(file_download(func))
 
 


### PR DESCRIPTION
Since the Private Hub experiment has been shut down, having a `HF_ENDPOINT` env variable or `endpoint` parameter is useless. Its only purpose now is to redirect to the staging platform in tests. This PR updates the documentation and function signatures to lower down the importance of this environment variable. It does not introduce any breaking change, meaning it is still possible to use it.

cc @julien-c @LysandreJik  