### PR TITLE
Fix `SpaceInfo` initialization + add test

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -758,7 +758,7 @@ class SpaceInfo:
             else None
         )
         runtime = kwargs.pop("runtime", None)
-        self.runtime = SpaceRuntime(**runtime) if runtime else None
+        self.runtime = SpaceRuntime(runtime) if runtime else None
         self.models = kwargs.pop("models", None)
         self.datasets = kwargs.pop("datasets", None)
 

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -60,6 +60,7 @@ from huggingface_hub.hf_api import (
     RepoSibling,
     RepoUrl,
     SpaceInfo,
+    SpaceRuntime,
     repo_type_and_id_from_hf_id,
 )
 from huggingface_hub.repocard_data import DatasetCardData, ModelCardData
@@ -1695,6 +1696,12 @@ class HfApiPublicProductionTest(unittest.TestCase):
                 self.assertTrue(isinstance(file.lfs, dict))
                 self.assertTrue("sha256" in file.lfs)
         self.assertTrue(at_least_one_lfs)
+
+    def test_space_info(self) -> None:
+        space = self._api.space_info(repo_id="HuggingFaceH4/zephyr-chat")
+        assert space.id == "HuggingFaceH4/zephyr-chat"
+        assert space.author == "HuggingFaceH4"
+        assert isinstance(space.runtime, SpaceRuntime)
 
     def test_list_metrics(self):
         metrics = self._api.list_metrics()


### PR DESCRIPTION
This PR fixes a bug introduced in https://github.com/huggingface/huggingface_hub/pull/1788 that broke `SpaceInfo` initialization (cc @mariosasko).
Also realized `HfApi.space_info` was not unit tested (hence the fact we did not realized) so I added a test. 