### PR TITLE
Add support for progress bars in hf_transfer uploads

### DIFF
--- a/docs/source/en/guides/download.md
+++ b/docs/source/en/guides/download.md
@@ -191,7 +191,7 @@ If you are running on a machine with high bandwidth, you can increase your downl
 
 <Tip>
 
-Progress bars are supported when downloading with `hf_transfer` starting from version `0.1.4`. Consider upgrading (`pip install -U hf-transfer`) if you plan to enable faster downloads.
+Progress bars are supported in `hf_transfer` starting from version `0.1.4`. Consider upgrading (`pip install -U hf-transfer`) if you plan to enable faster downloads.
 
 </Tip>
 

--- a/docs/source/en/guides/upload.md
+++ b/docs/source/en/guides/upload.md
@@ -460,8 +460,13 @@ be re-uploaded twice but checking it client-side can still save some time.
 - **Use `hf_transfer`**: this is a Rust-based [library](https://github.com/huggingface/hf_transfer) meant to speed up
 uploads on machines with very high bandwidth. To use it, you must install it (`pip install hf_transfer`) and enable it
 by setting `HF_HUB_ENABLE_HF_TRANSFER=1` as an environment variable. You can then use `huggingface_hub` normally.
-Disclaimer: this is a power user tool. It is tested and production-ready but lacks user-friendly features like progress
-bars or advanced error handling. For more details, please refer to this [section](https://huggingface.co/docs/huggingface_hub/hf_transfer).
+Disclaimer: this is a power user tool. It is tested and production-ready but lacks user-friendly features like advanced error handling or proxies. For more details, please refer to this [section](https://huggingface.co/docs/huggingface_hub/hf_transfer).
+
+<Tip>
+
+Progress bars are supported in `hf_transfer` starting from version `0.1.4`. Consider upgrading (`pip install -U hf-transfer`) if you plan to enable faster uploads.
+
+</Tip>
 
 ## (legacy) Upload files with Git LFS
 

--- a/src/huggingface_hub/lfs.py
+++ b/src/huggingface_hub/lfs.py
@@ -413,15 +413,14 @@ def _upload_parts_hf_transfer(
                 max_retries=5,
                 **({"callback": progress.update} if supports_callback else {}),
             )
-            if not supports_callback:
-                progress.update(total)
-            return output
         except Exception as e:
             raise RuntimeError(
                 "An error occurred while uploading using `hf_transfer`. Consider disabling HF_HUB_ENABLE_HF_TRANSFER for"
                 " better error handling."
             ) from e
-
+        if not supports_callback:
+            progress.update(total)
+        return output
 
 class SliceFileObj(AbstractContextManager):
     """


### PR DESCRIPTION
Following `hf_transfer` update (see https://github.com/huggingface/hf_transfer/pull/18) and related to https://github.com/huggingface/huggingface_hub/pull/1792 (progress bars while downloading).

Progress bars are now enabled in `hf_transfer`. This PR add support for it when uploading files. Implementation is still backward compatible with previous versions.

Kudos to @cbensimon for the Rust implementation.