### PR TITLE
Fix `HfFileSystemFile` when init fails + improve error message

### DIFF
--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -423,6 +423,12 @@ class HfFileSystemFile(fsspec.spec.AbstractBufferedFile):
                     f"{e}.\nMake sure the repository and revision exist before writing data."
                 ) from e
 
+    def __del__(self):
+        if not hasattr(self, "resolved_path"):
+            # Means that the constructor failed. Nothing to do.
+            return
+        return super().__del__()
+
     def _fetch_range(self, start: int, end: int) -> bytes:
         headers = {
             "range": f"bytes={start}-{end - 1}",

--- a/src/huggingface_hub/lfs.py
+++ b/src/huggingface_hub/lfs.py
@@ -422,6 +422,7 @@ def _upload_parts_hf_transfer(
             progress.update(total)
         return output
 
+
 class SliceFileObj(AbstractContextManager):
     """
     Utility context manager to read a *slice* of a seekable file-like object as a seekable, file-like object.


### PR DESCRIPTION
Fix https://github.com/huggingface/huggingface_hub/issues/1800 (?)

This PR does 2 things:
- if `HfFileSystemFile.__init__` fails because repo/revision do not exist, `self.resolved_path` is not set. As a consequence the magic `__del__`  (called just after since init failed) also fails because the file cannot be closed. This PR fixes this by not closing the file if `resolved_path` is not set.
- The `FileNotFoundError` error message is improved to let the user know why the file is not found (either repo not found, repo_id not valid or revision not found). Also mentions to the user that the repo must exist before writing a file to it. @lhoestq please let me know what you think of the updated message.


I am not a big fan of auto-creating the repo/revision if not found. Biggest problem is that we would need to provide additional information (typically should it be created as `private`? and if it is a Space repo, which sdk to specify?). I think for now improving the error message is already a good enough solution.


```
Traceback (most recent call last):
  File "/home/wauplin/projects/huggingface_hub/duc.py", line 7, in <module>
    duckdb.sql("COPY data TO 'hf://datasets/Wauplin/tmp-duckdb-export@branch/data.parquet' (FORMAT PARQUET);")
duckdb.duckdb.Error: Invalid Error: FileNotFoundError: Wauplin/tmp-duckdb-export@branch/data.parquet (repository not found).
Make sure the repository and revision exist before writing data.

At:
  /home/wauplin/projects/huggingface_hub/src/huggingface_hub/hf_file_system.py(422): __init__
  /home/wauplin/projects/huggingface_hub/src/huggingface_hub/hf_file_system.py(234): _open
  /home/wauplin/projects/huggingface_hub/.venv310/lib/python3.10/site-packages/fsspec/spec.py(1307): open
  /home/wauplin/projects/huggingface_hub/duc.py(7): <module>

```