### PR TITLE
Prepare for `v0.20.0`

### DIFF
--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -46,7 +46,7 @@ import sys
 from typing import TYPE_CHECKING
 
 
-__version__ = "0.19.0.dev0"
+__version__ = "0.20.0.dev0"
 
 # Alphabetical order of definitions is ensured in tests
 # WARNING: any comment added in this dictionary definition will be lost when

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -119,9 +119,6 @@ from .utils import (  # noqa: F401 # imported for backward compatibility
     parse_datetime,
     validate_hf_hub_args,
 )
-from .utils._deprecation import (
-    _deprecate_arguments,
-)
 from .utils._typing import CallableT
 from .utils.endpoint_helpers import (
     DatasetFilter,
@@ -2426,7 +2423,6 @@ class HfApi:
                 if subpath_info["type"] == "file":
                     yield _format_as_repo_file(subpath_info)
 
-    @_deprecate_arguments(version="0.17", deprecated_args=["timeout"], custom_message="timeout is not used anymore.")
     @validate_hf_hub_args
     def list_repo_files(
         self,
@@ -2434,7 +2430,6 @@ class HfApi:
         *,
         revision: Optional[str] = None,
         repo_type: Optional[str] = None,
-        timeout: Optional[float] = None,
         token: Optional[Union[bool, str]] = None,
     ) -> List[str]:
         """


### PR DESCRIPTION
Following [`v0.19.0`](https://huggingface.co/spaces/Wauplin/huggingface_hub/discussions/2) release, let's prepare for next one :)

(this PR also removes a `timeout` parameter that should have been removed from `list_repo_files` in `0.17`... :smile:)