### PR TITLE
Add support for `createdAt` field

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -443,6 +443,9 @@ class ModelInfo:
             Author of the dataset.
         sha (`str`, *optional*):
             Repo SHA at this particular revision.
+        created_at (`datetime`, *optional*):
+            Date of creation of the repo on the Hub. Note that the lowest value is `2022-03-02T23:29:04.000Z`,
+            corresponding to the date when we began to store creation dates.
         last_modified (`datetime`, *optional*):
             Date of last commit to the repo.
         private (`bool`):
@@ -485,6 +488,7 @@ class ModelInfo:
     id: str
     author: Optional[str]
     sha: Optional[str]
+    created_at: Optional[datetime]
     last_modified: Optional[datetime]
     private: bool
     gated: Optional[bool]
@@ -510,6 +514,8 @@ class ModelInfo:
         self.sha = kwargs.pop("sha", None)
         last_modified = kwargs.pop("lastModified", None) or kwargs.pop("last_modified", None)
         self.last_modified = parse_datetime(last_modified) if last_modified else None
+        created_at = kwargs.pop("createdAt", None) or kwargs.pop("created_at", None)
+        self.created_at = parse_datetime(created_at) if created_at else None
         self.private = kwargs.pop("private")
         self.gated = kwargs.pop("gated", None)
         self.disabled = kwargs.pop("disabled", None)
@@ -574,6 +580,9 @@ class DatasetInfo:
             Author of the dataset.
         sha (`str`):
             Repo SHA at this particular revision.
+        created_at (`datetime`, *optional*):
+            Date of creation of the repo on the Hub. Note that the lowest value is `2022-03-02T23:29:04.000Z`,
+            corresponding to the date when we began to store creation dates.
         last_modified (`datetime`, *optional*):
             Date of last commit to the repo.
         private (`bool`):
@@ -597,6 +606,7 @@ class DatasetInfo:
     id: str
     author: Optional[str]
     sha: Optional[str]
+    created_at: Optional[datetime]
     last_modified: Optional[datetime]
     private: bool
     gated: Optional[bool]
@@ -612,6 +622,8 @@ class DatasetInfo:
         self.id = kwargs.pop("id")
         self.author = kwargs.pop("author", None)
         self.sha = kwargs.pop("sha", None)
+        created_at = kwargs.pop("createdAt", None) or kwargs.pop("created_at", None)
+        self.created_at = parse_datetime(created_at) if created_at else None
         last_modified = kwargs.pop("lastModified", None) or kwargs.pop("last_modified", None)
         self.last_modified = parse_datetime(last_modified) if last_modified else None
         self.private = kwargs.pop("private")
@@ -666,6 +678,9 @@ class SpaceInfo:
             Author of the Space.
         sha (`str`, *optional*):
             Repo SHA at this particular revision.
+        created_at (`datetime`, *optional*):
+            Date of creation of the repo on the Hub. Note that the lowest value is `2022-03-02T23:29:04.000Z`,
+            corresponding to the date when we began to store creation dates.
         last_modified (`datetime`, *optional*):
             Date of last commit to the repo.
         private (`bool`):
@@ -699,6 +714,7 @@ class SpaceInfo:
     id: str
     author: Optional[str]
     sha: Optional[str]
+    created_at: Optional[datetime]
     last_modified: Optional[datetime]
     private: bool
     gated: Optional[bool]
@@ -718,6 +734,8 @@ class SpaceInfo:
         self.id = kwargs.pop("id")
         self.author = kwargs.pop("author", None)
         self.sha = kwargs.pop("sha", None)
+        created_at = kwargs.pop("createdAt", None) or kwargs.pop("created_at", None)
+        self.created_at = parse_datetime(created_at) if created_at else None
         last_modified = kwargs.pop("lastModified", None) or kwargs.pop("last_modified", None)
         self.last_modified = parse_datetime(last_modified) if last_modified else None
         self.private = kwargs.pop("private")

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import datetime
 import os
 import re
 import shutil
@@ -1538,6 +1539,8 @@ class HfApiPublicProductionTest(unittest.TestCase):
         model = self._api.model_info(repo_id=DUMMY_MODEL_ID)
         self.assertIsInstance(model, ModelInfo)
         self.assertNotEqual(model.sha, DUMMY_MODEL_ID_REVISION_ONE_SPECIFIC_COMMIT)
+        self.assertEqual(model.created_at, datetime.datetime(2022, 3, 2, 23, 29, 5, tzinfo=datetime.timezone.utc))
+
         # One particular commit (not the top of `main`)
         model = self._api.model_info(repo_id=DUMMY_MODEL_ID, revision=DUMMY_MODEL_ID_REVISION_ONE_SPECIFIC_COMMIT)
         self.assertIsInstance(model, ModelInfo)


### PR DESCRIPTION
Followup PR after https://github.com/huggingface/hub-docs/pull/1091/ (private). 

A new field `createdAt` is now returned by the server for every model/dataset/repo. This PR adds it as an official property for `ModelInfo`, `DatasetInfo` and `SpaceInfo`. Note that the lowest value is `2022-03-02T23:29:04.000Z`, corresponding to the date when we began to store creation dates (as documented [here](https://huggingface.co/docs/hub/api#repo-listing-api)).

```py
>>> from huggingface_hub import HfApi 
>>> api = HfApi()

>>> api.model_info("gpt2").created_at
datetime.datetime(2022, 3, 2, 23, 29, 4, tzinfo=datetime.timezone.utc)
>>> api.dataset_info("bigcode/the-stack").created_at
datetime.datetime(2022, 10, 3, 2, 34, 54, tzinfo=datetime.timezone.utc)
>>> api.space_info("FaceOnLive/Face-Recognition-SDK").created_at
datetime.datetime(2023, 11, 2, 14, 51, 11, tzinfo=datetime.timezone.utc)

>>> list(api.list_models(limit=5))[0].created_at
datetime.datetime(2022, 3, 2, 23, 29, 4, tzinfo=datetime.timezone.utc)
>>> list(api.list_datasets(limit=5))[0].created_at
datetime.datetime(2022, 3, 2, 23, 29, 22, tzinfo=datetime.timezone.utc)
>>> list(api.list_spaces(limit=5))[0].created_at
datetime.datetime(2022, 3, 2, 23, 29, 35, tzinfo=datetime.timezone.utc)
```

**EDIT:** failing tests are unrelated