### PR TITLE
[FIX] Catch TypeError when parsing card data from ModelInfo

### DIFF
--- a/src/huggingface_hub/repocard.py
+++ b/src/huggingface_hub/repocard.py
@@ -1,5 +1,6 @@
 import os
 import re
+import warnings
 from pathlib import Path
 from typing import Any, Dict, Literal, Optional, Type, Union
 
@@ -21,7 +22,6 @@ from huggingface_hub.utils import get_session, is_jinja_available, yaml_dump
 
 from .constants import REPOCARD_NAME
 from .utils import EntryNotFoundError, SoftTemporaryDirectory, validate_hf_hub_args
-from .utils.logging import get_logger
 
 
 TEMPLATE_MODELCARD_PATH = Path(__file__).parent / "templates" / "modelcard_template.md"
@@ -30,8 +30,6 @@ TEMPLATE_DATASETCARD_PATH = Path(__file__).parent / "templates" / "datasetcard_t
 # exact same regex as in the Hub server. Please keep in sync.
 # See https://github.com/huggingface/moon-landing/blob/main/server/lib/ViewMarkdown.ts#L18
 REGEX_YAML_BLOCK = re.compile(r"^(\s*---[\r\n]+)([\S\s]*?)([\r\n]+---(\r\n|\n|$))")
-
-logger = get_logger(__name__)
 
 
 class RepoCard:
@@ -104,7 +102,7 @@ class RepoCard:
                 raise ValueError("repo card metadata block should be a dict")
         else:
             # Model card without metadata... create empty metadata
-            logger.warning("Repo card metadata block was not found. Setting CardData to empty.")
+            warnings.warn("Repo card metadata block was not found. Setting CardData to empty.")
             data_dict = {}
             self.text = content
 

--- a/src/huggingface_hub/repocard_data.py
+++ b/src/huggingface_hub/repocard_data.py
@@ -1,14 +1,10 @@
 import copy
+import warnings
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from huggingface_hub.utils import yaml_dump
-
-from .utils.logging import get_logger
-
-
-logger = get_logger(__name__)
 
 
 @dataclass
@@ -305,12 +301,12 @@ class ModelCardData(CardData):
                 model_name, eval_results = model_index_to_eval_results(model_index)
                 self.model_name = model_name
                 self.eval_results = eval_results
-            except KeyError as error:
+            except (KeyError, TypeError) as error:
                 if ignore_metadata_errors:
-                    logger.warning("Invalid model-index. Not loading eval results into CardData.")
+                    warnings.warn("Invalid model-index. Not loading eval results into CardData.")
                 else:
                     raise ValueError(
-                        f"Invalid `model_index` in metadata cannot be parsed: KeyError {error}. Pass"
+                        f"Invalid `model_index` in metadata cannot be parsed: {error.__class__} {error}. Pass"
                         " `ignore_metadata_errors=True` to ignore this error while loading a Model Card. Warning:"
                         " some information will be lost. Use it at your own risk."
                     )

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -1685,6 +1685,48 @@ class HfApiPublicProductionTest(unittest.TestCase):
         assert files is not None
         self._check_siblings_metadata(files)
 
+    def test_model_info_corrupted_model_index(self) -> None:
+        """Loading model info from a model with corrupted data card should still work.
+
+        Here we use a model with a "model-index" that is not an array. Git hook should prevent this from happening
+        on the server, but models uploaded before we implemented the check might have this issue.
+
+        Example data from https://huggingface.co/Waynehillsdev/Waynehills-STT-doogie-server.
+        """
+        with self.assertWarnsRegex(UserWarning, "Invalid model-index"):
+            model = ModelInfo(
+                **{
+                    "_id": "621ffdc036468d709f1751d8",
+                    "id": "Waynehillsdev/Waynehills-STT-doogie-server",
+                    "cardData": {
+                        "license": "apache-2.0",
+                        "tags": ["generated_from_trainer"],
+                        "model-index": {"name": "Waynehills-STT-doogie-server"},
+                    },
+                    "gitalyUid": "53c57f29a007fc728c968127061b7b740dcf2b1ad401d907f703b27658559413",
+                    "likes": 0,
+                    "private": False,
+                    "config": {"architectures": ["Wav2Vec2ForCTC"], "model_type": "wav2vec2"},
+                    "downloads": 1,
+                    "tags": [
+                        "transformers",
+                        "pytorch",
+                        "tensorboard",
+                        "wav2vec2",
+                        "automatic-speech-recognition",
+                        "generated_from_trainer",
+                        "license:apache-2.0",
+                        "endpoints_compatible",
+                        "region:us",
+                    ],
+                    "pipeline_tag": "automatic-speech-recognition",
+                    "createdAt": "2022-03-02T23:29:04.000Z",
+                    "modelId": "Waynehillsdev/Waynehills-STT-doogie-server",
+                    "siblings": None,
+                }
+            )
+            self.assertIsNone(model.card_data.eval_results)
+
     def test_list_repo_files(self):
         files = self._api.list_repo_files(repo_id=DUMMY_MODEL_ID)
         expected_files = [

--- a/tests/test_repocard.py
+++ b/tests/test_repocard.py
@@ -333,7 +333,7 @@ class RepocardMetadataUpdateTest(unittest.TestCase):
             metadata_update(self.repo_id, new_metadata, token=self.token, overwrite=False)
 
     def test_update_existing_field_without_overwrite(self):
-        new_datasets_data = {"datasets": "['test/test_dataset']"}
+        new_datasets_data = {"datasets": ["Open-Orca/OpenOrca"]}
         metadata_update(self.repo_id, new_datasets_data, token=self.token)
 
         with pytest.raises(
@@ -343,7 +343,7 @@ class RepocardMetadataUpdateTest(unittest.TestCase):
                 " Set `overwrite=True` to overwrite existing metadata."
             ),
         ):
-            new_datasets_data = {"datasets": "['test/test_dataset_2']"}
+            new_datasets_data = {"datasets": ["HuggingFaceH4/no_robots"]}
             metadata_update(self.repo_id, new_datasets_data, token=self.token, overwrite=False)
 
     def test_update_new_result_existing_dataset(self):


### PR DESCRIPTION
Fix #1817.

The problem was that for models with a corrupted model-index in their data card (i.e. created before we added the check server-side), the error was not caught if a `TypeError` is raised. We were only ignoring `KeyError`. This PR fixes this and adds a regression test.

Thanks @ademait for reporting!

**Note:** this is a regression introduced by https://github.com/huggingface/huggingface_hub/pull/1788. Once this is merged, I'll ship a hot-fix release as it was working correctly in `v0.18.0` (since server data was not parsed into a Python object).

---

**EDIT:** I also fixed 2 CardData-related tests that were broken due to server-side update.
**EDIT 2:** also switched from `logger.warnings` to `warning.warn` in repocard module for consistency with the rest of the library