### PR TITLE
Document more list repos behavior

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -195,7 +195,7 @@ The examples above show how to download from the latest commit on the main branc
 
 The recommended (and default) way to download files from the Hub is to use the cache-system. However, in some cases you want to download files and move them to a specific folder. This is useful to get a workflow closer to what git commands offer. You can do that using the `--local_dir` option.
 
-<Tip warning="true">
+<Tip warning={true}>
 
 Downloading to a local directory comes with some downsides. Please check out the limitations in the [Download](./download#download-files-to-local-folder) guide before using `--local-dir`.
 

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -382,7 +382,7 @@ class RepoSibling:
 
     All attributes of this class are optional except `rfilename`. This is because only the file names are returned when
     listing repositories on the Hub (with [`list_models`], [`list_datasets`] or [`list_spaces`]). If you need more
-    information like file size, blob id or lfs details, you must request them specifically for one repo at a time
+    information like file size, blob id or lfs details, you must request them specifically from one repo at a time
     (using [`model_info`], [`dataset_info`] or [`space_info`]) as it adds more constraints on the backend server to
     retrieve these.
 

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -378,6 +378,16 @@ class RepoSibling:
     """
     Contains basic information about a repo file inside a repo on the Hub.
 
+    <Tip>
+
+    All attributes of this class are optional except `rfilename`. This is because only the file names are returned when
+    listing repositories on the Hub (with [`list_models`], [`list_datasets`] or [`list_spaces`]). If you need more
+    information like file size, blob id or lfs details, you must request them specifically for one repo at a time
+    (using [`model_info`], [`dataset_info`] or [`space_info`]) as it adds more constraints on the backend server to
+    retrieve these.
+
+    </Tip>
+
     Attributes:
         rfilename (str):
             file name, relative to the repo root.
@@ -487,6 +497,14 @@ class RepoFolder:
 class ModelInfo:
     """
     Contains information about a model on the Hub.
+
+    <Tip>
+
+    Most attributes of this class are optional. This is because the data returned by the Hub depends on the query made.
+    In general, the more specific the query, the more information is returned. On the contrary, when listing models
+    using [`list_models`] only a subset of the attributes are returned.
+
+    </Tip>
 
     Attributes:
         id (`str`):
@@ -625,6 +643,14 @@ class DatasetInfo:
     """
     Contains information about a dataset on the Hub.
 
+    <Tip>
+
+    Most attributes of this class are optional. This is because the data returned by the Hub depends on the query made.
+    In general, the more specific the query, the more information is returned. On the contrary, when listing datasets
+    using [`list_datasets`] only a subset of the attributes are returned.
+
+    </Tip>
+
     Attributes:
         id (`str`):
             ID of dataset.
@@ -722,6 +748,14 @@ class DatasetInfo:
 class SpaceInfo:
     """
     Contains information about a Space on the Hub.
+
+    <Tip>
+
+    Most attributes of this class are optional. This is because the data returned by the Hub depends on the query made.
+    In general, the more specific the query, the more information is returned. On the contrary, when listing spaces
+    using [`list_spaces`] only a subset of the attributes are returned.
+
+    </Tip>
 
     Attributes:
         id (`str`):
@@ -1341,7 +1375,7 @@ class HfApi:
 
         >>> # List only models from the AllenNLP library
         >>> api.list_models(filter="allennlp")
-
+        ```
 
         Example usage with the `search` argument:
 


### PR DESCRIPTION
Related to https://github.com/huggingface/huggingface_hub/issues/1814.

This PR updates the documentation of `ModelInfo`, `DatasetInfo`, `SpaceInfo` and `RepoSiblings` to let the users know they should not expect all attributes to exist. @ademait could you have a look and let me know what you think? I kept the wording a bit vague on purpose as I don't want to be too specific on things that we might change server-side in the future (all those objects are built in a way that is future-compatible, on purpose). (**EDIT:** I'm not saying that we will remove attributes in the future, but we might potentially add news ones and/or improve default behaviors).