### PR TITLE
Use ruff formatter in check_static_imports.py

### DIFF
--- a/utils/check_static_imports.py
+++ b/utils/check_static_imports.py
@@ -80,6 +80,7 @@ def check_static_imports(update: bool) -> NoReturn:
             reordered_content_before_static_checks + IF_TYPE_CHECKING_LINE + "\n".join(static_imports) + "\n"
         )
         ruff_bin = find_ruff_bin()
+        os.spawnv(os.P_WAIT, ruff_bin, ["ruff", "format", str(filepath), "--quiet"])
         os.spawnv(os.P_WAIT, ruff_bin, ["ruff", str(filepath), "--fix", "--quiet"])
         expected_init_content = filepath.read_text()
 


### PR DESCRIPTION
Related to https://github.com/huggingface/huggingface_hub/pull/1783 (and especially https://github.com/huggingface/huggingface_hub/pull/1783#discussion_r1392285357). Thanks @ArthurZucker for noticing!

I forgot to use `ruff format` in the script to generate the static imports (in `check_static_imports.py`).