### PR TITLE
More robust uploads

### DIFF
--- a/src/huggingface_hub/utils/_http.py
+++ b/src/huggingface_hub/utils/_http.py
@@ -25,7 +25,7 @@ from typing import Callable, Tuple, Type, Union
 import requests
 from requests import Response
 from requests.adapters import HTTPAdapter
-from requests.exceptions import ProxyError, Timeout
+from requests.exceptions import Timeout
 from requests.models import PreparedRequest
 
 from . import logging
@@ -173,10 +173,7 @@ def http_backoff(
     max_retries: int = 5,
     base_wait_time: float = 1,
     max_wait_time: float = 8,
-    retry_on_exceptions: Union[Type[Exception], Tuple[Type[Exception], ...]] = (
-        Timeout,
-        ProxyError,
-    ),
+    retry_on_exceptions: Union[Type[Exception], Tuple[Type[Exception], ...]] = (Timeout, ConnectionError),
     retry_on_status_codes: Union[int, Tuple[int, ...]] = HTTPStatus.SERVICE_UNAVAILABLE,
     **kwargs,
 ) -> Response:
@@ -203,10 +200,9 @@ def http_backoff(
             `max_wait_time`.
         max_wait_time (`float`, *optional*, defaults to `8`):
             Maximum duration (in seconds) to wait before retrying.
-        retry_on_exceptions (`Type[Exception]` or `Tuple[Type[Exception]]`, *optional*, defaults to `(Timeout, ProxyError,)`):
-            Define which exceptions must be caught to retry the request. Can be a single
-            type or a tuple of types.
-            By default, retry on `Timeout` and `ProxyError`.
+        retry_on_exceptions (`Type[Exception]` or `Tuple[Type[Exception]]`, *optional*, defaults to `(Timeout, ConnectionError,)`):
+            Define which exceptions must be caught to retry the request. Can be a single type or a tuple of types.
+            By default, retry on `Timeout` and `ConnectionError`.
         retry_on_status_codes (`int` or `Tuple[int]`, *optional*, defaults to `503`):
             Define on which status codes the request must be retried. By default, only
             HTTP 503 Service Unavailable is retried.
@@ -278,6 +274,9 @@ def http_backoff(
 
         except retry_on_exceptions as err:
             logger.warning(f"'{err}' thrown while requesting {method} {url}")
+
+            if isinstance(err, ConnectionError):
+                reset_sessions()  # In case of SSLError it's best to reset the shared requests.Session objects
 
             if nb_tries > max_retries:
                 raise err


### PR DESCRIPTION
This PR aims to make the upload process more robust to transient errors:
- Retry on`requests.ConnectionError` -e.g. connection temporarily lost or connection reset by peer-. Before this was the case only for `requests.ProxyError` (not sure why :thinking:).
- Retry on HTTP 500. It seems that sometimes S3 raises a transient HTTP 500 error (see https://github.com/huggingface/datasets/issues/6392#issuecomment-1806059794). Not sure why but retrying when it's the case doesn't cost mush.
- Retry on `requests.Timeout` instead of `Timeout` as I just found out that `requests.Timeout` is not inheriting from `Timeout` (meaning we were not retrying on timeouts before...)

---

The retry mechanism is the same as before, implemented in `http_backoff` (up to 5 retries, backoff after 1s, 2s , 4s and 8s). Once this is merged, the upload process will retry on:
- `requests.ConnectionError`
- `requests.TimeoutError`
- HTTP 500
- HTTP 503


**Note:** this  "retry on error" mechanism does not apply to uploads using `hf_transfer` (and is not planned to be).