### PR TITLE
Limit to `pydantic<2.x` on `python3.8`

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -73,7 +73,6 @@ jobs:
               sudo apt update
               sudo apt install -y graphviz
               pip install .[tensorflow]
-              pip install typing_extensions>=4.8.0
               ;;
 
           esac

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,11 @@ extras["cli"] = [
 
 extras["inference"] = [
     "aiohttp",  # for AsyncInferenceClient
-    "pydantic>1.1,<3.0",  # match text-generation-inference v1.1.0
+    # On Python 3.8, Pydantic 2.x and tensorflow don't play well together
+    # Let's limit pydantic to 1.x for now. Since Tensorflow 2.14, Python3.8 is not supported anyway so impact should be
+    # limited. We still trigger some CIs on Python 3.8 so we need this workaround.
+    "pydantic>1.1,<3.0;python_version>3.8"
+    "pydantic>1.1,<2.0;python_version==3.8"
 ]
 
 extras["torch"] = [
@@ -76,7 +80,6 @@ extras["typing"] = [
     "types-toml",
     "types-tqdm",
     "types-urllib3",
-    "pydantic>1.1,<3.0",  # for text-generation-interface dataclasses
 ]
 
 extras["quality"] = [

--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,8 @@ extras["inference"] = [
     # On Python 3.8, Pydantic 2.x and tensorflow don't play well together
     # Let's limit pydantic to 1.x for now. Since Tensorflow 2.14, Python3.8 is not supported anyway so impact should be
     # limited. We still trigger some CIs on Python 3.8 so we need this workaround.
-    "pydantic>1.1,<3.0;python_version>3.8"
-    "pydantic>1.1,<2.0;python_version==3.8"
+    "pydantic>1.1,<3.0; python_version>'3.8'",
+    "pydantic>1.1,<2.0; python_version=='3.8'",
 ]
 
 extras["torch"] = [

--- a/src/huggingface_hub/keras_mixin.py
+++ b/src/huggingface_hub/keras_mixin.py
@@ -92,13 +92,18 @@ def _create_model_card(
 ):
     """
     Creates a model card for the repository.
+
+    Do not overwrite an existing README.md file.
     """
+    readme_path = repo_dir / "README.md"
+    if readme_path.exists():
+        return
+
     hyperparameters = _create_hyperparameter_table(model)
     if plot_model and is_graphviz_available() and is_pydot_available():
         _plot_network(model, repo_dir)
     if metadata is None:
         metadata = {}
-    readme_path = f"{repo_dir}/README.md"
     metadata["library_name"] = "keras"
     model_card: str = "---\n"
     model_card += yaml_dump(metadata, default_flow_style=False)
@@ -120,13 +125,7 @@ def _create_model_card(
         model_card += f"\n![Model Image]({path_to_plot})\n"
         model_card += "\n</details>"
 
-    if os.path.exists(readme_path):
-        with open(readme_path, "r", encoding="utf8") as f:
-            readme = f.read()
-    else:
-        readme = model_card
-    with open(readme_path, "w", encoding="utf-8") as f:
-        f.write(readme)
+    readme_path.write_text(model_card)
 
 
 def save_pretrained_keras(


### PR DESCRIPTION
Since we allowed pydantic>=2.x in `v0.19.0` release, we got some issues in the CI. The problem comes from the fact that on Python3.8, Pydantic>=2.x and tensorflow don't seem to be compatible. Tensorflow depends on `typing_extension<=4.5.0` while pydantic 2.x requires `typing_extensions>=4.6`. This causes a `ImportError: cannot import name 'TypeAliasType' from 'typing_extensions'`.

Examples of failed CIs:
- in [transformers "build docs" CI](https://github.com/huggingface/transformers/actions/runs/6875619848/job/18699571340?pr=27483)
- in [huggingface_hub "tensorflow 3.8" CI](https://github.com/huggingface/huggingface_hub/actions/runs/6875677790/job/18699755513) 

---

My plan is to make a new patch release `0.19.3` if that works since it's a bit of a regression right now (compared to huggingface_hub 0.18).


**EDIT:** adding related [slack convo](https://huggingface.slack.com/archives/C03V11RNS7P/p1700057878264729) (internal)

**EDIT 2:** I made some cleaning in the keras integration and especially the tests (see https://github.com/huggingface/huggingface_hub/pull/1828/commits/079cc540f60d5c42971370d76eac9c3804fdb65d). I kept it iso-feature so that I can still cherry-pick it for a release. We might want to do a more in-depth review of the keras integration at some point but that's not the goal of this PR.