### PR TITLE
Check pydantic correct installation

### DIFF
--- a/src/huggingface_hub/utils/_runtime.py
+++ b/src/huggingface_hub/utils/_runtime.py
@@ -168,13 +168,15 @@ def get_pillow_version() -> str:
 def is_pydantic_available() -> bool:
     if not _is_available("pydantic"):
         return False
-    # For Pydantic, we add an extra check to test whether it is correctly installed. If pydantic 2.x is installed
-    # but typing_extensions<=4.5.0 is installed, then pydantic will fail to import. This should not happen when
+    # For Pydantic, we add an extra check to test whether it is correctly installed or not. If both pydantic 2.x and
+    # typing_extensions<=4.5.0 are installed, then pydantic will fail at import time. This should not happen when
     # it is installed with `pip install huggingface_hub[inference]` but it can happen when it is installed manually
     # by the user in an environment that we don't control.
     #
     # Usually we won't need to do this kind of check on optional dependencies. However, pydantic is a special case
-    # has it is automatically imported when doing `from huggingface_hub import ...` even if the user doesn't use it.
+    # as it is automatically imported when doing `from huggingface_hub import ...` even if the user doesn't use it.
+    #
+    # See https://github.com/huggingface/huggingface_hub/pull/1829 for more details.
     try:
         from pydantic import validator  # noqa: F401
     except ImportError:

--- a/src/huggingface_hub/utils/_runtime.py
+++ b/src/huggingface_hub/utils/_runtime.py
@@ -16,6 +16,7 @@
 import importlib.metadata
 import platform
 import sys
+import warnings
 from typing import Any, Dict
 
 from .. import __version__, constants
@@ -165,7 +166,25 @@ def get_pillow_version() -> str:
 
 # Pydantic
 def is_pydantic_available() -> bool:
-    return _is_available("pydantic")
+    if not _is_available("pydantic"):
+        return False
+    # For Pydantic, we add an extra check to test whether it is correctly installed. If pydantic 2.x is installed
+    # but typing_extensions<=4.5.0 is installed, then pydantic will fail to import. This should not happen when
+    # it is installed with `pip install huggingface_hub[inference]` but it can happen when it is installed manually
+    # by the user in an environment that we don't control.
+    #
+    # Usually we won't need to do this kind of check on optional dependencies. However, pydantic is a special case
+    # has it is automatically imported when doing `from huggingface_hub import ...` even if the user doesn't use it.
+    try:
+        from pydantic import validator  # noqa: F401
+    except ImportError:
+        # Example: "ImportError: cannot import name 'TypeAliasType' from 'typing_extensions'"
+        warnings.warn(
+            "Pydantic is installed but cannot be imported. Please check your installation. `huggingface_hub` will "
+            "default to not using Pydantic. Error message: '{e}'"
+        )
+        return False
+    return True
 
 
 def get_pydantic_version() -> str:


### PR DESCRIPTION
This PR adds an extra check for pydantic to test whether it is correctly installed or not. If `pydantic 2.x` is installed but `typing_extensions<=4.5.0` is installed, then pydantic at import time. This should not happen when it is installed with `pip install huggingface_hub[inference]` but it can happen when it is installed manually by the user in an environment that we don't control.

Usually we won't need to do this kind of check on optional dependencies. However, pydantic is a special case
has it is automatically imported when doing `from huggingface_hub import ...` even if the user doesn't use it.

For more context see:
- [internal slack thread](https://huggingface.slack.com/archives/C014N4749J9/p1700069962026839)
- https://github.com/huggingface/datasets/pull/6411
- https://github.com/huggingface/transformers/pull/27483