### PR TITLE
Fix pydantic deprecation warning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ extras["inference"] = [
     # On Python 3.8, Pydantic 2.x and tensorflow don't play well together
     # Let's limit pydantic to 1.x for now. Since Tensorflow 2.14, Python3.8 is not supported anyway so impact should be
     # limited. We still trigger some CIs on Python 3.8 so we need this workaround.
+    # NOTE: when relaxing constraint to support v3.x, make sure to adapt `src/huggingface_hub/inference/_text_generation.py`.
     "pydantic>1.1,<3.0; python_version>'3.8'",
     "pydantic>1.1,<2.0; python_version=='3.8'",
 ]

--- a/src/huggingface_hub/inference/_text_generation.py
+++ b/src/huggingface_hub/inference/_text_generation.py
@@ -33,7 +33,10 @@ from ..utils import is_pydantic_available
 
 
 if is_pydantic_available():
-    from pydantic import validator
+    try:
+        from pydantic import field_validator as validator
+    except ImportError:
+        from pydantic import validator
     from pydantic.dataclasses import dataclass
 else:
     # No validation if Pydantic is not installed

--- a/src/huggingface_hub/inference/_text_generation.py
+++ b/src/huggingface_hub/inference/_text_generation.py
@@ -36,7 +36,7 @@ if is_pydantic_available():
     try:
         from pydantic import field_validator as validator
     except ImportError:
-        from pydantic import validator
+        from pydantic import validator  # type: ignore
     from pydantic.dataclasses import dataclass
 else:
     # No validation if Pydantic is not installed


### PR DESCRIPTION
Fix https://github.com/huggingface/huggingface_hub/issues/1836.

In pydantic >= 2.0, `@validator` has been replaced by `@field_validator` with a deprecation warning (until pydantic 3.x). There are some differences between the legacy and the new @validator ~but they do not impact our usage (see [migration guide](https://docs.pydantic.dev/latest/migration/#changes-to-validators)).~. For now let's silent the warning and we'll update when (and if) we want to add support for pydantic v3.x in the future.

Thanks @mattf for the heads up!

**EDIT:** converting to draft.

**EDIT 2:** reworked the PR to use same logic as currently on `main` and silent the warning. We'll reassess if and when pydantic v3.x is out.