### PR TITLE
FIX ?? send ref in LFS endpoint

### DIFF
--- a/src/huggingface_hub/_commit_api.py
+++ b/src/huggingface_hub/_commit_api.py
@@ -314,6 +314,7 @@ def _upload_lfs_files(
     token: Optional[str],
     endpoint: Optional[str] = None,
     num_threads: int = 5,
+    ref: Optional[str] = None,
 ):
     """
     Uploads the content of `additions` to the Hub using the large file storage protocol.
@@ -333,7 +334,8 @@ def _upload_lfs_files(
             An authentication token ( See https://huggingface.co/settings/tokens )
         num_threads (`int`, *optional*):
             The number of concurrent threads to use when uploading. Defaults to 5.
-
+        ref (`str`, *optional*):
+            The git ref to upload to.
 
     Raises: `RuntimeError` if an upload failed for any reason
 
@@ -353,6 +355,7 @@ def _upload_lfs_files(
             token=token,
             repo_id=repo_id,
             repo_type=repo_type,
+            ref=ref,
             endpoint=endpoint,
         )
 

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -3965,6 +3965,7 @@ class HfApi:
             token=token or self.token,
             endpoint=self.endpoint,
             num_threads=num_threads,
+            ref=revision if revision is not None and revision.startswith("refs/") else None,
         )
         for addition in new_lfs_additions:
             addition._is_uploaded = True


### PR DESCRIPTION
cc @coyotte508 @Pierrci @severo @SBrandeis 

I only send the revision as `ref` parameter if it starts with `refs/...`.