### PR TITLE
✨ Add filters to HfApi.get_repo_discussions

### DIFF
--- a/docs/source/en/guides/community.md
+++ b/docs/source/en/guides/community.md
@@ -25,7 +25,7 @@ The `HfApi` class allows you to retrieve Discussions and Pull Requests on a give
 [...]
 ```
 
-`HfApi.get_repo_discussions` supports by author, type (Pull Request or Discussion) and status (`open` or `closed`):
+`HfApi.get_repo_discussions` supports filtering by author, type (Pull Request or Discussion) and status (`open` or `closed`):
 
 ```python
 >>> from huggingface_hub import get_repo_discussions

--- a/docs/source/en/guides/community.md
+++ b/docs/source/en/guides/community.md
@@ -14,7 +14,7 @@ The `HfApi` class allows you to retrieve Discussions and Pull Requests on a give
 
 ```python
 >>> from huggingface_hub import get_repo_discussions
->>> for discussion in get_repo_discussions(repo_id="bigscience/bloom-1b3"):
+>>> for discussion in get_repo_discussions(repo_id="bigscience/bloom"):
 ...     print(f"{discussion.num} - {discussion.title}, pr: {discussion.is_pull_request}")
 
 # 11 - Add Flax weights, pr: True
@@ -23,6 +23,21 @@ The `HfApi` class allows you to retrieve Discussions and Pull Requests on a give
 # 8 - Update tokenizer_config.json, pr: True
 # 7 - Slurm training script, pr: False
 [...]
+```
+
+`HfApi.get_repo_discussions` supports by author, type (Pull Request or Discussion) and status (`open` or `closed`):
+
+```python
+>>> from huggingface_hub import get_repo_discussions
+>>> for discussion in get_repo_discussions(
+...    repo_id="bigscience/bloom",
+...    author="ArthurZ",
+...    discussion_type="pull_request",
+...    discussion_status="open",
+... ):
+...     print(f"{discussion.num} - {discussion.title} by {discussion.author}, pr: {discussion.is_pull_request}")
+
+# 19 - Add Flax weights by ArthurZ, pr: True
 ```
 
 `HfApi.get_repo_discussions` returns a [generator](https://docs.python.org/3.7/howto/functional.html#generators) that yields

--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -1,6 +1,7 @@
 import os
 import re
-from typing import Optional
+from typing import Literal, Optional, Tuple
+import typing
 
 
 # Possible values for env variables
@@ -79,8 +80,10 @@ REPO_TYPES_MAPPING = {
     "models": REPO_TYPE_MODEL,
 }
 
-DISCUSSION_TYPES = ["all", "discussion", "pull_request"]
-DISCUSSION_STATUS = ["all", "open", "closed"]
+DiscussionTypeFilter = Literal["all", "discussion", "pull_request"]
+DISCUSSION_TYPES: Tuple[DiscussionTypeFilter, ...] = typing.get_args(DiscussionTypeFilter)
+DiscussionStatusFilter = Literal["all", "open", "closed"]
+DISCUSSION_STATUS: Tuple[DiscussionTypeFilter, ...] = typing.get_args(DiscussionStatusFilter)
 
 # default cache
 default_home = os.path.join(os.path.expanduser("~"), ".cache")

--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -1,7 +1,7 @@
 import os
 import re
-from typing import Literal, Optional, Tuple
 import typing
+from typing import Literal, Optional, Tuple
 
 
 # Possible values for env variables

--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -79,6 +79,8 @@ REPO_TYPES_MAPPING = {
     "models": REPO_TYPE_MODEL,
 }
 
+DISCUSSION_TYPES = ["all", "discussion", "pull_request"]
+DISCUSSION_STATUS = ["all", "open", "closed"]
 
 # default cache
 default_home = os.path.join(os.path.expanduser("~"), ".cache")

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -3677,9 +3677,7 @@ class HfApi:
         logger.info(f"Multi-commits strategy with ID {strategy.id}.")
 
         # 2. Get or create a PR with this strategy ID
-        for discussion in self.get_repo_discussions(
-            repo_id=repo_id, repo_type=repo_type, token=token, discussion_type="pull_request"
-        ):
+        for discussion in self.get_repo_discussions(repo_id=repo_id, repo_type=repo_type, token=token):
             # search for a draft PR with strategy ID
             if discussion.is_pull_request and discussion.status == "draft" and strategy.id in discussion.title:
                 pr = self.get_discussion_details(

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -3677,7 +3677,9 @@ class HfApi:
         logger.info(f"Multi-commits strategy with ID {strategy.id}.")
 
         # 2. Get or create a PR with this strategy ID
-        for discussion in self.get_repo_discussions(repo_id=repo_id, repo_type=repo_type, token=token, discussion_type="pull_request"):
+        for discussion in self.get_repo_discussions(
+            repo_id=repo_id, repo_type=repo_type, token=token, discussion_type="pull_request"
+        ):
             # search for a draft PR with strategy ID
             if discussion.is_pull_request and discussion.status == "draft" and strategy.id in discussion.title:
                 pr = self.get_discussion_details(
@@ -5254,7 +5256,7 @@ class HfApi:
             raise ValueError(f"Invalid discussion_status, must be one of {DISCUSSION_STATUS}")
 
         headers = self._build_hf_headers(token=token)
-        query_dict = { }
+        query_dict = {}
         if discussion_type is not None:
             query_dict["type"] = discussion_type
         if discussion_status is not None:
@@ -5263,7 +5265,7 @@ class HfApi:
             query_dict["author"] = author
 
         def _fetch_discussion_page(page_index: int):
-            query_string = urlencode({ **query_dict, "page_index": page_index })
+            query_string = urlencode({**query_dict, "page_index": page_index})
             path = f"{self.endpoint}/api/{repo_type}s/{repo_id}/discussions?{query_string}"
             resp = get_session().get(path, headers=headers)
             hf_raise_for_status(resp)

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -103,6 +103,8 @@ from .constants import (
     REPO_TYPES_MAPPING,
     REPO_TYPES_URL_PREFIXES,
     SPACES_SDK_TYPES,
+    DiscussionStatusFilter,
+    DiscussionTypeFilter,
 )
 from .file_download import (
     get_hf_file_metadata,
@@ -5199,8 +5201,8 @@ class HfApi:
         repo_id: str,
         *,
         author: Optional[str] = None,
-        discussion_type: Optional[str] = None,
-        discussion_status: Optional[str] = None,
+        discussion_type: Optional[DiscussionTypeFilter] = None,
+        discussion_status: Optional[DiscussionStatusFilter] = None,
         repo_type: Optional[str] = None,
         token: Optional[str] = None,
     ) -> Iterator[Discussion]:

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -5261,7 +5261,7 @@ class HfApi:
             raise ValueError(f"Invalid discussion_status, must be one of {DISCUSSION_STATUS}")
 
         headers = self._build_hf_headers(token=token)
-        query_dict = {}
+        query_dict: Dict[str, str] = {}
         if discussion_type is not None:
             query_dict["type"] = discussion_type
         if discussion_status is not None:

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2427,6 +2427,51 @@ class HfApiDiscussionsTest(HfApiCommonTest):
             list([d.num for d in discussions_generator]), [self.discussion.num, self.pull_request.num]
         )
 
+    def test_get_repo_discussion_by_type(self):
+        discussions_generator = self._api.get_repo_discussions(repo_id=self.repo_id, discussion_type="pull_request")
+        self.assertIsInstance(discussions_generator, types.GeneratorType)
+        self.assertListEqual(list([d.num for d in discussions_generator]), [self.pull_request.num])
+
+        discussions_generator = self._api.get_repo_discussions(repo_id=self.repo_id, discussion_type="discussion")
+        self.assertIsInstance(discussions_generator, types.GeneratorType)
+        self.assertListEqual(list([d.num for d in discussions_generator]), [self.discussion.num])
+
+        discussions_generator = self._api.get_repo_discussions(repo_id=self.repo_id, discussion_type="all")
+        self.assertIsInstance(discussions_generator, types.GeneratorType)
+        self.assertListEqual(list([d.num for d in discussions_generator]), [self.discussion.num, self.pull_request.num])
+
+
+    @unittest.skip("__DUMMY_TRANSFORMERS_USER__ is not a valid username anymore. This test fails the Hub input validation in consequence.")
+    def test_get_repo_discussion_by_author(self):
+        discussions_generator = self._api.get_repo_discussions(repo_id=self.repo_id, author="no-discussion")
+        self.assertIsInstance(discussions_generator, types.GeneratorType)
+        self.assertListEqual(list([d.num for d in discussions_generator]), [])
+
+        discussions_generator = self._api.get_repo_discussions(repo_id=self.repo_id, author=USER)
+        self.assertIsInstance(discussions_generator, types.GeneratorType)
+        self.assertListEqual(list([d.num for d in discussions_generator]), [self.discussion.num, self.pull_request.num])
+
+
+    def test_get_repo_discussion_by_status(self):
+        self._api.change_discussion_status(self.repo_id, self.discussion.num, "closed")
+
+        discussions_generator = self._api.get_repo_discussions(repo_id=self.repo_id, discussion_status="open")
+        self.assertIsInstance(discussions_generator, types.GeneratorType)
+        self.assertListEqual(
+            list([d.num for d in discussions_generator]), [self.pull_request.num]
+        )
+
+        discussions_generator = self._api.get_repo_discussions(repo_id=self.repo_id, discussion_status="closed")
+        self.assertIsInstance(discussions_generator, types.GeneratorType)
+        self.assertListEqual(
+            list([d.num for d in discussions_generator]), [self.discussion.num]
+        )
+
+        discussions_generator = self._api.get_repo_discussions(repo_id=self.repo_id, discussion_status="all")
+        self.assertIsInstance(discussions_generator, types.GeneratorType)
+        self.assertListEqual(list([d.num for d in discussions_generator]), [self.discussion.num, self.pull_request.num])
+
+
     def test_get_discussion_details(self):
         retrieved = self._api.get_discussion_details(repo_id=self.repo_id, discussion_num=2)
         self.assertEqual(retrieved, self.discussion)

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2442,19 +2442,10 @@ class HfApiDiscussionsTest(HfApiCommonTest):
             list([d.num for d in discussions_generator]), [self.discussion.num, self.pull_request.num]
         )
 
-    @unittest.skip(
-        "__DUMMY_TRANSFORMERS_USER__ is not a valid username anymore. This test fails the Hub input validation in consequence."
-    )
     def test_get_repo_discussion_by_author(self):
-        discussions_generator = self._api.get_repo_discussions(repo_id=self.repo_id, author="no-discussion")
+        discussions_generator = self._api.get_repo_discussions(repo_id=self.repo_id, author="unknown")
         self.assertIsInstance(discussions_generator, types.GeneratorType)
         self.assertListEqual(list([d.num for d in discussions_generator]), [])
-
-        discussions_generator = self._api.get_repo_discussions(repo_id=self.repo_id, author=USER)
-        self.assertIsInstance(discussions_generator, types.GeneratorType)
-        self.assertListEqual(
-            list([d.num for d in discussions_generator]), [self.discussion.num, self.pull_request.num]
-        )
 
     def test_get_repo_discussion_by_status(self):
         self._api.change_discussion_status(self.repo_id, self.discussion.num, "closed")

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2438,10 +2438,13 @@ class HfApiDiscussionsTest(HfApiCommonTest):
 
         discussions_generator = self._api.get_repo_discussions(repo_id=self.repo_id, discussion_type="all")
         self.assertIsInstance(discussions_generator, types.GeneratorType)
-        self.assertListEqual(list([d.num for d in discussions_generator]), [self.discussion.num, self.pull_request.num])
+        self.assertListEqual(
+            list([d.num for d in discussions_generator]), [self.discussion.num, self.pull_request.num]
+        )
 
-
-    @unittest.skip("__DUMMY_TRANSFORMERS_USER__ is not a valid username anymore. This test fails the Hub input validation in consequence.")
+    @unittest.skip(
+        "__DUMMY_TRANSFORMERS_USER__ is not a valid username anymore. This test fails the Hub input validation in consequence."
+    )
     def test_get_repo_discussion_by_author(self):
         discussions_generator = self._api.get_repo_discussions(repo_id=self.repo_id, author="no-discussion")
         self.assertIsInstance(discussions_generator, types.GeneratorType)
@@ -2449,28 +2452,26 @@ class HfApiDiscussionsTest(HfApiCommonTest):
 
         discussions_generator = self._api.get_repo_discussions(repo_id=self.repo_id, author=USER)
         self.assertIsInstance(discussions_generator, types.GeneratorType)
-        self.assertListEqual(list([d.num for d in discussions_generator]), [self.discussion.num, self.pull_request.num])
-
+        self.assertListEqual(
+            list([d.num for d in discussions_generator]), [self.discussion.num, self.pull_request.num]
+        )
 
     def test_get_repo_discussion_by_status(self):
         self._api.change_discussion_status(self.repo_id, self.discussion.num, "closed")
 
         discussions_generator = self._api.get_repo_discussions(repo_id=self.repo_id, discussion_status="open")
         self.assertIsInstance(discussions_generator, types.GeneratorType)
-        self.assertListEqual(
-            list([d.num for d in discussions_generator]), [self.pull_request.num]
-        )
+        self.assertListEqual(list([d.num for d in discussions_generator]), [self.pull_request.num])
 
         discussions_generator = self._api.get_repo_discussions(repo_id=self.repo_id, discussion_status="closed")
         self.assertIsInstance(discussions_generator, types.GeneratorType)
-        self.assertListEqual(
-            list([d.num for d in discussions_generator]), [self.discussion.num]
-        )
+        self.assertListEqual(list([d.num for d in discussions_generator]), [self.discussion.num])
 
         discussions_generator = self._api.get_repo_discussions(repo_id=self.repo_id, discussion_status="all")
         self.assertIsInstance(discussions_generator, types.GeneratorType)
-        self.assertListEqual(list([d.num for d in discussions_generator]), [self.discussion.num, self.pull_request.num])
-
+        self.assertListEqual(
+            list([d.num for d in discussions_generator]), [self.discussion.num, self.pull_request.num]
+        )
 
     def test_get_discussion_details(self):
         retrieved = self._api.get_discussion_details(repo_id=self.repo_id, discussion_num=2)


### PR DESCRIPTION
# TL;DR

Add new filters to the `HfApi.get_repo_discussions` method

This PR depends on https://github.com/huggingface/moon-landing/pull/8147 (private) for the `author` filter.

Ping @Narsil 

## How it works

```python
import huggingface_hub

discussion_generator = huggingface_hub.get_repo_discussions(
    repo_id="openai/whisper-large-v3",
    author="sanchit-gandhi",
    discussion_type="pull_request",
    discussion_status="open",
)

for discussion in discussion_generator:
    print(discussion)
    # ^ Only open pull requests authored by `sanchit-gandhi`
```