### PR TITLE
Install doc-builder from source

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,8 @@ extras["all"] = extras["testing"] + extras["quality"] + extras["typing"]
 extras["dev"] = extras["all"]
 
 extras["docs"] = extras["all"] + [
-    "hf-doc-builder",
+    # CI builds documentation using doc builder from source
+    "hf-doc-builder @ git+https://github.com/huggingface/doc-builder@main",
     "watchdog",
 ]
 


### PR DESCRIPTION
Fix https://github.com/huggingface/huggingface_hub/issues/1830#issuecomment-1817534362 cc @ademait

CI is building documentation using `hf-doc-builder` installed from source. This PR updates `setup.py` so that users wanting to build the docs locally have the same setup. For the record, the last "released version" of `hf-doc-builder` dates back to [Aug. 2022](https://pypi.org/project/hf-doc-builder/), hence producing the errors.