### PR TITLE
Fix common path in `_ ls_tree`

### DIFF
--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -4,6 +4,7 @@ import tempfile
 from collections import deque
 from dataclasses import dataclass
 from datetime import datetime
+from itertools import chain
 from typing import Any, Dict, List, NoReturn, Optional, Tuple, Union
 from urllib.parse import quote, unquote
 
@@ -323,7 +324,9 @@ class HfFileSystem(fsspec.AbstractFileSystem):
                 # Get the parent directory if the common prefix itself is not a directory
                 common_path = (
                     common_prefix.rstrip("/")
-                    if common_prefix.endswith("/") or common_prefix == root_path or common_prefix in (dirs_not_in_dircache + dirs_not_expanded)
+                    if common_prefix.endswith("/")
+                    or common_prefix == root_path
+                    or common_prefix in chain(dirs_not_in_dircache, dirs_not_expanded)
                     else self._parent(common_prefix)
                 )
                 out = [o for o in out if not o["name"].startswith(common_path + "/")]

--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -323,7 +323,7 @@ class HfFileSystem(fsspec.AbstractFileSystem):
                 # Get the parent directory if the common prefix itself is not a directory
                 common_path = (
                     common_prefix.rstrip("/")
-                    if common_prefix.endswith("/") or common_prefix == root_path
+                    if common_prefix.endswith("/") or common_prefix == root_path or common_prefix in (dirs_not_in_dircache + dirs_not_expanded)
                     else self._parent(common_prefix)
                 )
                 out = [o for o in out if not o["name"].startswith(common_path + "/")]


### PR DESCRIPTION
The common path can be one of the directories to refresh.

This was causing a bug where the common path was the parent directory instead, and therefore `glob` would wrongly return content from the parent directory depending on the cache content

now this code returns the correct files

```python
import fsspec
from huggingface_hub import HfFileSystem

fs: HfFileSystem
path = "hf://datasets/severo/bug-hfh-lfs/data/*"

fs = fsspec.get_fs_token_paths(path)[0]
print(fs.glob(path, detail=True))

print("=" * 100)

fs = fsspec.get_fs_token_paths(path)[0]
print(fs.glob(path, detail=True))
```

this bug was introduced in https://github.com/huggingface/huggingface_hub/pull/1809