### PR TITLE
Parse safetensors metadata

### DIFF
--- a/docs/source/en/package_reference/hf_api.md
+++ b/docs/source/en/package_reference/hf_api.md
@@ -71,9 +71,21 @@ models = hf_api.list_models()
 
 [[autodoc]] huggingface_hub.hf_api.RepoUrl
 
+### SafetensorsRepoMetadata
+
+[[autodoc]] huggingface_hub.utils.SafetensorsRepoMetadata
+
+### SafetensorsFileMetadata
+
+[[autodoc]] huggingface_hub.utils.SafetensorsFileMetadata
+
 ### SpaceInfo
 
 [[autodoc]] huggingface_hub.hf_api.SpaceInfo
+
+### TensorInfo
+
+[[autodoc]] huggingface_hub.utils.TensorInfo
 
 ### User
 

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -207,7 +207,7 @@ _SUBMOD_ATTRS = {
         "merge_pull_request",
         "model_info",
         "move_repo",
-        "parse_safetensors_metadata",
+        "parse_safetensors_file_metadata",
         "pause_inference_endpoint",
         "pause_space",
         "preupload_lfs_files",
@@ -545,7 +545,7 @@ if TYPE_CHECKING:  # pragma: no cover
         merge_pull_request,  # noqa: F401
         model_info,  # noqa: F401
         move_repo,  # noqa: F401
-        parse_safetensors_metadata,  # noqa: F401
+        parse_safetensors_file_metadata,  # noqa: F401
         pause_inference_endpoint,  # noqa: F401
         pause_space,  # noqa: F401
         preupload_lfs_files,  # noqa: F401

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -187,6 +187,7 @@ _SUBMOD_ATTRS = {
         "get_model_tags",
         "get_paths_info",
         "get_repo_discussions",
+        "get_safetensors_metadata",
         "get_space_runtime",
         "get_space_variables",
         "get_token_permission",
@@ -206,6 +207,7 @@ _SUBMOD_ATTRS = {
         "merge_pull_request",
         "model_info",
         "move_repo",
+        "parse_safetensors_metadata",
         "pause_inference_endpoint",
         "pause_space",
         "preupload_lfs_files",
@@ -523,6 +525,7 @@ if TYPE_CHECKING:  # pragma: no cover
         get_model_tags,  # noqa: F401
         get_paths_info,  # noqa: F401
         get_repo_discussions,  # noqa: F401
+        get_safetensors_metadata,  # noqa: F401
         get_space_runtime,  # noqa: F401
         get_space_variables,  # noqa: F401
         get_token_permission,  # noqa: F401
@@ -542,6 +545,7 @@ if TYPE_CHECKING:  # pragma: no cover
         merge_pull_request,  # noqa: F401
         model_info,  # noqa: F401
         move_repo,  # noqa: F401
+        parse_safetensors_metadata,  # noqa: F401
         pause_inference_endpoint,  # noqa: F401
         pause_space,  # noqa: F401
         preupload_lfs_files,  # noqa: F401

--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -41,6 +41,7 @@ HF_TRANSFER_CONCURRENCY = 100
 
 SAFETENSORS_SINGLE_FILE = "model.safetensors"
 SAFETENSORS_INDEX_FILE = "model.safetensors.index.json"
+SAFETENSORS_MAX_HEADER_LENGTH = 25_000_000
 
 # Git-related constants
 

--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -37,6 +37,11 @@ DEFAULT_REQUEST_TIMEOUT = 10
 DOWNLOAD_CHUNK_SIZE = 10 * 1024 * 1024
 HF_TRANSFER_CONCURRENCY = 100
 
+# Constants for safetensors repos
+
+SAFETENSORS_SINGLE_FILE = "model.safetensors"
+SAFETENSORS_INDEX_FILE = "model.safetensors.index.json"
+
 # Git-related constants
 
 DEFAULT_REVISION = "main"

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -2330,7 +2330,9 @@ class HfApi:
 
         </Tip>
         """
-        url = hf_hub_url(repo_id=repo_id, repo_type=repo_type, revision=revision, filename=filename)
+        url = hf_hub_url(
+            repo_id=repo_id, repo_type=repo_type, revision=revision, filename=filename, endpoint=self.endpoint
+        )
         try:
             if token is None:
                 token = self.token
@@ -5045,10 +5047,9 @@ class HfApi:
             NotASafetensorsRepoError: 'runwayml/stable-diffusion-v1-5' is not a safetensors repo. Couldn't find 'model.safetensors.index.json' or 'model.safetensors' files.
             ```
         """
-        filenames = self.list_repo_files(repo_id=repo_id, repo_type=repo_type, revision=revision, token=token)
-
-        if SAFETENSORS_SINGLE_FILE in filenames:
-            # Single safetensors file => non-sharded model
+        if self.file_exists(  # Single safetensors file => non-sharded model
+            repo_id=repo_id, filename=SAFETENSORS_SINGLE_FILE, repo_type=repo_type, revision=revision, token=token
+        ):
             file_metadata = self.parse_safetensors_file_metadata(
                 repo_id=repo_id, filename=SAFETENSORS_SINGLE_FILE, repo_type=repo_type, revision=revision, token=token
             )
@@ -5058,9 +5059,9 @@ class HfApi:
                 weight_map={tensor_name: SAFETENSORS_SINGLE_FILE for tensor_name in file_metadata.tensors.keys()},
                 files_metadata={SAFETENSORS_SINGLE_FILE: file_metadata},
             )
-        elif SAFETENSORS_INDEX_FILE in filenames:
-            # Multiple safetensors files => sharded with index
-
+        elif self.file_exists(  # Multiple safetensors files => sharded with index
+            repo_id=repo_id, filename=SAFETENSORS_INDEX_FILE, repo_type=repo_type, revision=revision, token=token
+        ):
             # Fetch index
             index_file = self.hf_hub_download(
                 repo_id=repo_id, filename=SAFETENSORS_INDEX_FILE, repo_type=repo_type, revision=revision, token=token

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -5179,7 +5179,7 @@ class HfApi:
 
         try:
             return SafetensorsFileMetadata(
-                metadata=metadata_as_dict["__metadata__"],
+                metadata=metadata_as_dict.get("__metadata__", {}),
                 tensors={
                     key: TensorInfo(
                         dtype=tensor["dtype"],

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -108,6 +108,7 @@ from .utils import (  # noqa: F401 # imported for backward compatibility
     IGNORE_GIT_FOLDER_PATTERNS,
     BadRequestError,
     EntryNotFoundError,
+    GatedRepoError,
     HfFolder,
     HfHubHTTPError,
     LocalTokenNotFoundError,
@@ -2278,6 +2279,8 @@ class HfApi:
         try:
             self.repo_info(repo_id=repo_id, repo_type=repo_type, token=token)
             return True
+        except GatedRepoError:
+            return True  # we don't have access but it exists
         except RepositoryNotFoundError:
             return False
 
@@ -2338,6 +2341,8 @@ class HfApi:
                 token = self.token
             get_hf_file_metadata(url, token=token)
             return True
+        except GatedRepoError:  # raise specifically on gated repo
+            raise
         except (RepositoryNotFoundError, EntryNotFoundError, RevisionNotFoundError):
             return False
 

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -5149,9 +5149,10 @@ class HfApi:
         _headers = self._build_hf_headers(token=token)
 
         # 1. Fetch first 100kb
-        # We assume that most files will have a metadata size < 100kb. We also assume that receiving a 100kb response
-        # is faster than making 2 GET requests. Therefore we always fetch the first 100kb to avoid the 2nd GET in most
-        # cases.
+        # Empirically, 97% of safetensors files have a metadata size < 100kb (over the top 1000 models on the Hub).
+        # We assume fetching 100kb is faster than making 2 GET requests. Therefore we always fetch the first 100kb to
+        # avoid the 2nd GET in most cases.
+        # See https://github.com/huggingface/huggingface_hub/pull/1855#discussion_r1404286419.
         response = get_session().get(url, headers={**_headers, "range": "bytes=0-100000"})
         hf_raise_for_status(response)
 

--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -83,6 +83,7 @@ from ._runtime import (
     is_tf_available,
     is_torch_available,
 )
+from ._safetensors import SafetensorsFileMetadata, SafetensorsRepoMetadata, TensorInfo
 from ._subprocess import capture_output, run_interactive_subprocess, run_subprocess
 from ._validators import (
     HFValidationError,

--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -87,6 +87,7 @@ from ._safetensors import (
     SafetensorsFileMetadata,
     SafetensorsRepoMetadata,
     TensorInfo,
+    SafetensorsParsingError,
     NotASafetensorsRepoError,
 )
 from ._subprocess import capture_output, run_interactive_subprocess, run_subprocess

--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -83,7 +83,12 @@ from ._runtime import (
     is_tf_available,
     is_torch_available,
 )
-from ._safetensors import SafetensorsFileMetadata, SafetensorsRepoMetadata, TensorInfo
+from ._safetensors import (
+    SafetensorsFileMetadata,
+    SafetensorsRepoMetadata,
+    TensorInfo,
+    NotASafetensorsRepoError,
+)
 from ._subprocess import capture_output, run_interactive_subprocess, run_subprocess
 from ._validators import (
     HFValidationError,

--- a/src/huggingface_hub/utils/_safetensors.py
+++ b/src/huggingface_hub/utils/_safetensors.py
@@ -1,0 +1,41 @@
+from dataclasses import dataclass
+from typing import Dict, List, Literal, Tuple
+
+
+FILENAME_T = str
+TENSOR_NAME_T = str
+DTYPE_T = Literal["F64", "F32", "F16", "BF16", "I64", "I32", "I16", "I8", "U8", "BOOL"]
+
+
+@dataclass
+class TensorInfo:
+    dtype: DTYPE_T
+    shape: List[int]
+    data_offsets: Tuple[int, int]
+
+
+@dataclass
+class SafetensorsFileMetadata:
+    metadata: Dict
+    tensors: Dict[TENSOR_NAME_T, TensorInfo]
+
+    @classmethod
+    def from_raw(cls, data: Dict) -> "SafetensorsFileMetadata":
+        return cls(
+            metadata=data["__metadata__"],
+            tensors={
+                key: TensorInfo(
+                    dtype=tensor["dtype"], shape=tensor["shape"], data_offsets=tuple(tensor["data_offsets"])
+                )
+                for key, tensor in data.items()
+                if key != "__metadata__"
+            },
+        )
+
+
+@dataclass
+class SafetensorsRepoMetadata:
+    metadata: Dict
+    sharded: bool
+    weight_map: Dict[TENSOR_NAME_T, FILENAME_T]  # tensor name -> filename
+    files_metadata: Dict[FILENAME_T, SafetensorsFileMetadata]  # filename -> metadata

--- a/src/huggingface_hub/utils/_safetensors.py
+++ b/src/huggingface_hub/utils/_safetensors.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict, List, Literal, Tuple
+from typing import Dict, List, Literal, Optional, Tuple
 
 
 FILENAME_T = str
@@ -25,7 +25,9 @@ class SafetensorsFileMetadata:
             metadata=data["__metadata__"],
             tensors={
                 key: TensorInfo(
-                    dtype=tensor["dtype"], shape=tensor["shape"], data_offsets=tuple(tensor["data_offsets"])
+                    dtype=tensor["dtype"],
+                    shape=tensor["shape"],
+                    data_offsets=tuple(tensor["data_offsets"]),  # type: ignore
                 )
                 for key, tensor in data.items()
                 if key != "__metadata__"
@@ -35,7 +37,7 @@ class SafetensorsFileMetadata:
 
 @dataclass
 class SafetensorsRepoMetadata:
-    metadata: Dict
+    metadata: Optional[Dict]
     sharded: bool
     weight_map: Dict[TENSOR_NAME_T, FILENAME_T]  # tensor name -> filename
     files_metadata: Dict[FILENAME_T, SafetensorsFileMetadata]  # filename -> metadata

--- a/src/huggingface_hub/utils/_safetensors.py
+++ b/src/huggingface_hub/utils/_safetensors.py
@@ -1,4 +1,7 @@
-from dataclasses import dataclass
+import functools
+import operator
+from collections import defaultdict
+from dataclasses import dataclass, field
 from typing import Dict, List, Literal, Optional, Tuple
 
 
@@ -33,11 +36,18 @@ class TensorInfo:
             The shape of the tensor.
         data_offsets (`Tuple[int, int]`):
             The offsets of the data in the file as a tuple `[BEGIN, END]`.
+        parameter_count (`int`):
+            The number of parameters in the tensor.
     """
 
     dtype: DTYPE_T
     shape: List[int]
     data_offsets: Tuple[int, int]
+    parameter_count: int = field(init=False)
+
+    def __post_init__(self) -> None:
+        # Taken from https://stackoverflow.com/a/13840436
+        self.parameter_count = functools.reduce(operator.mul, self.shape)
 
 
 @dataclass
@@ -54,10 +64,20 @@ class SafetensorsFileMetadata:
         tensors (`Dict[str, TensorInfo]`):
             A map of all tensors. Keys are tensor names and values are information about the corresponding tensor, as a
             [`TensorInfo`] object.
+        parameter_count (`Dict[str, int]`):
+            A map of the number of parameters per data type. Keys are data types and values are the number of parameters
+            of that data type.
     """
 
     metadata: Dict
     tensors: Dict[TENSOR_NAME_T, TensorInfo]
+    parameter_count: Dict[DTYPE_T, int] = field(init=False)
+
+    def __post_init__(self) -> None:
+        parameter_count: Dict[DTYPE_T, int] = defaultdict(int)
+        for tensor in self.tensors.values():
+            parameter_count[tensor.dtype] += tensor.parameter_count
+        self.parameter_count = dict(parameter_count)
 
 
 @dataclass
@@ -82,9 +102,20 @@ class SafetensorsRepoMetadata:
         files_metadata (`Dict[str, SafetensorsFileMetadata]`):
             A map of all files metadata. Keys are filenames and values are the metadata of the corresponding file, as
             a [`SafetensorsFileMetadata`] object.
+        parameter_count (`Dict[str, int]`):
+            A map of the number of parameters per data type. Keys are data types and values are the number of parameters
+            of that data type.
     """
 
     metadata: Optional[Dict]
     sharded: bool
     weight_map: Dict[TENSOR_NAME_T, FILENAME_T]  # tensor name -> filename
     files_metadata: Dict[FILENAME_T, SafetensorsFileMetadata]  # filename -> metadata
+    parameter_count: Dict[DTYPE_T, int] = field(init=False)
+
+    def __post_init__(self) -> None:
+        parameter_count: Dict[DTYPE_T, int] = defaultdict(int)
+        for file_metadata in self.files_metadata.values():
+            for dtype, nb_parameters_ in file_metadata.parameter_count.items():
+                parameter_count[dtype] += nb_parameters_
+        self.parameter_count = dict(parameter_count)

--- a/src/huggingface_hub/utils/_safetensors.py
+++ b/src/huggingface_hub/utils/_safetensors.py
@@ -7,8 +7,27 @@ TENSOR_NAME_T = str
 DTYPE_T = Literal["F64", "F32", "F16", "BF16", "I64", "I32", "I16", "I8", "U8", "BOOL"]
 
 
+class NotASafetensorsRepoError(Exception):
+    """Raised when a repo is not a Safetensors repo i.e. doesn't have either a `model.safetensors` or a
+    `model.safetensors.index.json` file.
+    """
+
+
 @dataclass
 class TensorInfo:
+    """Information about a tensor.
+
+    For more details regarding the safetensors format, check out https://huggingface.co/docs/safetensors/index#format.
+
+    Attributes:
+        dtype (`str`):
+            The data type of the tensor ("F64", "F32", "F16", "BF16", "I64", "I32", "I16", "I8", "U8", "BOOL").
+        shape (`List[int]`):
+            The shape of the tensor.
+        data_offsets (`Tuple[int, int]`):
+            The offsets of the data in the file as a tuple `[BEGIN, END]`.
+    """
+
     dtype: DTYPE_T
     shape: List[int]
     data_offsets: Tuple[int, int]
@@ -16,6 +35,20 @@ class TensorInfo:
 
 @dataclass
 class SafetensorsFileMetadata:
+    """Metadata for a Safetensors file hosted on the Hub.
+
+    This class is returned by [`parse_safetensors_file_metadata`].
+
+    For more details regarding the safetensors format, check out https://huggingface.co/docs/safetensors/index#format.
+
+    Attributes:
+        metadata (`Dict`):
+            The metadata contained in the file.
+        tensors (`Dict[str, TensorInfo]`):
+            A map of all tensors. Keys are tensor names and values are information about the corresponding tensor, as a
+            [`TensorInfo`] object.
+    """
+
     metadata: Dict
     tensors: Dict[TENSOR_NAME_T, TensorInfo]
 
@@ -37,6 +70,28 @@ class SafetensorsFileMetadata:
 
 @dataclass
 class SafetensorsRepoMetadata:
+    """Metadata for a Safetensors repo.
+
+    A repo is considered to be a Safetensors repo if it contains either a 'model.safetensors' weight file (non-shared
+    model) or a 'model.safetensors.index.json' index file (sharded model) at its root.
+
+    This class is returned by [`get_safetensors_metadata`].
+
+    For more details regarding the safetensors format, check out https://huggingface.co/docs/safetensors/index#format.
+
+    Attributes:
+        metadata (`Dict`, *optional*):
+            The metadata contained in the 'model.safetensors.index.json' file, if it exists. Only populated for sharded
+            models.
+        sharded (`bool`):
+            Whether the repo contains a sharded model or not.
+        weight_map (`Dict[str, str]`):
+            A map of all weights. Keys are tensor names and values are filenames of the files containing the tensors.
+        files_metadata (`Dict[str, SafetensorsFileMetadata]`):
+            A map of all files metadata. Keys are filenames and values are the metadata of the corresponding file, as
+            a [`SafetensorsFileMetadata`] object.
+    """
+
     metadata: Optional[Dict]
     sharded: bool
     weight_map: Dict[TENSOR_NAME_T, FILENAME_T]  # tensor name -> filename

--- a/src/huggingface_hub/utils/_safetensors.py
+++ b/src/huggingface_hub/utils/_safetensors.py
@@ -47,7 +47,10 @@ class TensorInfo:
 
     def __post_init__(self) -> None:
         # Taken from https://stackoverflow.com/a/13840436
-        self.parameter_count = functools.reduce(operator.mul, self.shape)
+        try:
+            self.parameter_count = functools.reduce(operator.mul, self.shape)
+        except TypeError:
+            self.parameter_count = 1  # scalar value has no shape
 
 
 @dataclass
@@ -69,7 +72,7 @@ class SafetensorsFileMetadata:
             of that data type.
     """
 
-    metadata: Dict
+    metadata: Dict[str, str]
     tensors: Dict[TENSOR_NAME_T, TensorInfo]
     parameter_count: Dict[DTYPE_T, int] = field(init=False)
 

--- a/src/huggingface_hub/utils/_safetensors.py
+++ b/src/huggingface_hub/utils/_safetensors.py
@@ -7,6 +7,13 @@ TENSOR_NAME_T = str
 DTYPE_T = Literal["F64", "F32", "F16", "BF16", "I64", "I32", "I16", "I8", "U8", "BOOL"]
 
 
+class SafetensorsParsingError(Exception):
+    """Raised when failing to parse a safetensors file metadata.
+
+    This can be the case if the file is not a safetensors file or does not respect the specification.
+    """
+
+
 class NotASafetensorsRepoError(Exception):
     """Raised when a repo is not a Safetensors repo i.e. doesn't have either a `model.safetensors` or a
     `model.safetensors.index.json` file.
@@ -51,21 +58,6 @@ class SafetensorsFileMetadata:
 
     metadata: Dict
     tensors: Dict[TENSOR_NAME_T, TensorInfo]
-
-    @classmethod
-    def from_raw(cls, data: Dict) -> "SafetensorsFileMetadata":
-        return cls(
-            metadata=data["__metadata__"],
-            tensors={
-                key: TensorInfo(
-                    dtype=tensor["dtype"],
-                    shape=tensor["shape"],
-                    data_offsets=tuple(tensor["data_offsets"]),  # type: ignore
-                )
-                for key, tensor in data.items()
-                if key != "__metadata__"
-            },
-        )
 
 
 @dataclass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,7 +72,7 @@ def retry_on_transient_error(fn: CallableT) -> CallableT:
 
     Tests are retried up to 3 times, waiting 5s between each try.
     """
-    NUMBER_OF_TRIES = 3
+    NUMBER_OF_TRIES = 5
     WAIT_TIME = 5
     HTTP_ERRORS = (502, 504)  # 502 Bad gateway (repo creation) or 504 Gateway timeout
 

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -70,9 +70,14 @@ from huggingface_hub.utils import (
     EntryNotFoundError,
     HfFolder,
     HfHubHTTPError,
+    NotASafetensorsRepoError,
     RepositoryNotFoundError,
     RevisionNotFoundError,
+    SafetensorsFileMetadata,
+    SafetensorsParsingError,
+    SafetensorsRepoMetadata,
     SoftTemporaryDirectory,
+    TensorInfo,
     logging,
 )
 from huggingface_hub.utils.endpoint_helpers import (
@@ -2046,6 +2051,60 @@ class HfApiPublicProductionTest(unittest.TestCase):
         self.assertIsNotNone(paths_info[1].lfs)
         self.assertIsNotNone(paths_info[1].security)
         self.assertGreater(paths_info[1].size, 0)
+
+    def test_get_safetensors_metadata_single_file(self) -> None:
+        info = self._api.get_safetensors_metadata("bigscience/bloomz-560m")
+        assert isinstance(info, SafetensorsRepoMetadata)
+
+        assert not info.sharded
+        assert info.metadata is None  # Never populated on non-sharded models
+        assert len(info.files_metadata) == 1
+        assert "model.safetensors" in info.files_metadata
+
+        file_metadata = info.files_metadata["model.safetensors"]
+        assert isinstance(file_metadata, SafetensorsFileMetadata)
+        assert file_metadata.metadata == {"format": "pt"}
+        assert len(file_metadata.tensors) == 293
+
+        assert isinstance(info.weight_map, dict)
+        assert info.weight_map["h.0.input_layernorm.bias"] == "model.safetensors"
+
+    def test_get_safetensors_metadata_sharded_model(self) -> None:
+        info = self._api.get_safetensors_metadata("HuggingFaceH4/zephyr-7b-beta")
+        assert isinstance(info, SafetensorsRepoMetadata)
+
+        assert info.sharded
+        assert isinstance(info.metadata, dict)  # populated for sharded model
+        assert len(info.files_metadata) == 8
+
+        for file_metadata in info.files_metadata.values():
+            assert isinstance(file_metadata, SafetensorsFileMetadata)
+
+    def test_not_a_safetensors_repo(self) -> None:
+        with self.assertRaises(NotASafetensorsRepoError):
+            self._api.get_safetensors_metadata("huggingface-hub-ci/test_safetensors_metadata")
+
+    def test_get_safetensors_metadata_from_revision(self) -> None:
+        info = self._api.get_safetensors_metadata("huggingface-hub-ci/test_safetensors_metadata", revision="refs/pr/1")
+        assert isinstance(info, SafetensorsRepoMetadata)
+
+    def test_parse_safetensors_metadata(self) -> None:
+        info = self._api.parse_safetensors_file_metadata(
+            "HuggingFaceH4/zephyr-7b-beta", "model-00003-of-00008.safetensors"
+        )
+        assert isinstance(info, SafetensorsFileMetadata)
+
+        assert info.metadata == {"format": "pt"}
+        assert isinstance(info.tensors, dict)
+        tensor = info.tensors["model.layers.10.input_layernorm.weight"]
+
+        assert tensor == TensorInfo(dtype="BF16", shape=[4096], data_offsets=(0, 8192))
+
+    def test_not_a_safetensors_file(self) -> None:
+        with self.assertRaises(SafetensorsParsingError):
+            self._api.parse_safetensors_file_metadata(
+                "HuggingFaceH4/zephyr-7b-beta", "pytorch_model-00001-of-00008.bin"
+            )
 
 
 class HfApiPrivateTest(HfApiCommonTest):

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2069,6 +2069,8 @@ class HfApiPublicProductionTest(unittest.TestCase):
         assert isinstance(info.weight_map, dict)
         assert info.weight_map["h.0.input_layernorm.bias"] == "model.safetensors"
 
+        assert info.parameter_count == {"F16": 559214592}
+
     def test_get_safetensors_metadata_sharded_model(self) -> None:
         info = self._api.get_safetensors_metadata("HuggingFaceH4/zephyr-7b-beta")
         assert isinstance(info, SafetensorsRepoMetadata)
@@ -2079,6 +2081,8 @@ class HfApiPublicProductionTest(unittest.TestCase):
 
         for file_metadata in info.files_metadata.values():
             assert isinstance(file_metadata, SafetensorsFileMetadata)
+
+        assert info.parameter_count == {"BF16": 7241732096}
 
     def test_not_a_safetensors_repo(self) -> None:
         with self.assertRaises(NotASafetensorsRepoError):
@@ -2099,6 +2103,9 @@ class HfApiPublicProductionTest(unittest.TestCase):
         tensor = info.tensors["model.layers.10.input_layernorm.weight"]
 
         assert tensor == TensorInfo(dtype="BF16", shape=[4096], data_offsets=(0, 8192))
+
+        assert tensor.parameter_count == 4096
+        assert info.parameter_count == {"BF16": 989888512}
 
     def test_not_a_safetensors_file(self) -> None:
         with self.assertRaises(SafetensorsParsingError):


### PR DESCRIPTION
Related to https://github.com/huggingface/huggingface_hub/issues/1832 cc @LysandreJik @Narsil 

There are 2 methods:
- `parse_safetensors_file_metadata` => parses a safetensors file on the Hub => the "real" method that parses safetensors
- `get_safetensors_metadata` => takes a repo and parses all safetensors files (if sharded with a `model.safetensors.index.json` file) => more focused towards `transformers` architecture (i.e. opinionated)

I tried to follow more or less the [typescript implementation](https://github.com/huggingface/huggingface.js/blob/main/packages/hub/src/lib/parse-safetensors-metadata.ts) with similar error handling.
