### PR TITLE
Create branch if missing in hugginface-cli upload

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -332,6 +332,8 @@ By default, files are uploaded to the `main` branch. If you want to upload files
 ...
 ```
 
+**Note:** if `revision` does not exist and `--create-pr` is not set, a branch will be created automatically from the `main` branch.
+
 ### Upload and create a PR
 
 If you don't have the permission to push to a repo, you must open a PR and let the authors know about the changes you want to make. This can be done by setting the `--create-pr` option:

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -524,8 +524,9 @@ class ModelInfo:
             Is the repo private.
         disabled (`bool`, *optional*):
             Is the repo disabled.
-        gated (`bool`, *optional*):
+        gated (`Literal["auto", "manual", False]`, *optional*):
             Is the repo gated.
+            If so, whether there is manual or automatic approval.
         downloads (`int`):
             Number of downloads of the dataset.
         likes (`int`):
@@ -563,7 +564,7 @@ class ModelInfo:
     created_at: Optional[datetime]
     last_modified: Optional[datetime]
     private: bool
-    gated: Optional[bool]
+    gated: Optional[Literal["auto", "manual", False]]
     disabled: Optional[bool]
     downloads: int
     likes: int
@@ -669,8 +670,9 @@ class DatasetInfo:
             Is the repo private.
         disabled (`bool`, *optional*):
             Is the repo disabled.
-        gated (`bool`, *optional*):
+        gated (`Literal["auto", "manual", False]`, *optional*):
             Is the repo gated.
+            If so, whether there is manual or automatic approval.
         downloads (`int`):
             Number of downloads of the dataset.
         likes (`int`):
@@ -689,7 +691,7 @@ class DatasetInfo:
     created_at: Optional[datetime]
     last_modified: Optional[datetime]
     private: bool
-    gated: Optional[bool]
+    gated: Optional[Literal["auto", "manual", False]]
     disabled: Optional[bool]
     downloads: int
     likes: int
@@ -773,8 +775,9 @@ class SpaceInfo:
             Date of last commit to the repo.
         private (`bool`):
             Is the repo private.
-        gated (`bool`, *optional*):
+        gated (`Literal["auto", "manual", False]`, *optional*):
             Is the repo gated.
+            If so, whether there is manual or automatic approval.
         disabled (`bool`, *optional*):
             Is the Space disabled.
         host (`str`, *optional*):
@@ -805,7 +808,7 @@ class SpaceInfo:
     created_at: Optional[datetime]
     last_modified: Optional[datetime]
     private: bool
-    gated: Optional[bool]
+    gated: Optional[Literal["auto", "manual", False]]
     disabled: Optional[bool]
     host: Optional[str]
     subdomain: Optional[str]

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -1563,12 +1563,12 @@ class HfApiBranchEndpointTest(HfApiCommonTest):
         """Test `create_branch` from a different revision than main HEAD."""
         # Create commit and remember initial/latest commit
         initial_commit = self._api.model_info(repo_url.repo_id).sha
-        self._api.create_commit(
+        commit = self._api.create_commit(
             repo_url.repo_id,
             operations=[CommitOperationAdd(path_in_repo="app.py", path_or_fileobj=b"content")],
             commit_message="test commit",
         )
-        latest_commit = self._api.model_info(repo_url.repo_id).sha
+        latest_commit = commit.oid
 
         # Create branches
         self._api.create_branch(repo_url.repo_id, branch="from-head")


### PR DESCRIPTION
Solves https://github.com/huggingface/huggingface_hub/issues/1841 and https://github.com/huggingface/huggingface_hub/issues/1657 cc @AlpinDale

With this PR, running `huggingface-cli upload ... ... --revision=my-branch` will automatically create the branch if it does not exist yet. I added some tests and adapted the docs.

**Note:**
- it is similar to repo creation if repo doesn't exist yet
- branch is created from the latest main
- does not apply if `--create-pr`