### PR TITLE
Respect `.gitignore` file in commits

### DIFF
--- a/docs/source/en/guides/upload.md
+++ b/docs/source/en/guides/upload.md
@@ -73,12 +73,15 @@ folder to. Depending on your repository type, you can optionally set the reposit
 ... )
 ```
 
-Use the `allow_patterns` and `ignore_patterns` arguments to specify which files to upload. These parameters accept either a single pattern or a list of patterns.
-Patterns are Standard Wildcards (globbing patterns) as documented [here](https://tldp.org/LDP/GNU-Linux-Tools-Summary/html/x11655.htm).
-If both `allow_patterns` and `ignore_patterns` are provided, both constraints apply. By default, all files from the folder are uploaded.
+By default, the `.gitignore` file will be taken into account to know which files should
+be committed or not. By default we check if a `.gitignore` file is present in a commit, and if not, we check if it exists on the Hub. If you want to force the upload no matter
+the `.gitignore` file, you can pass `respect_gitignore=False`. Please be aware that only
+a `.gitignore` file present at the root of the directory with be used. We do not check
+for `.gitignore` files in subdirectories.
 
-Any `.git/` folder present in any subdirectory will be ignored. However, please be aware that the `.gitignore` file is not taken into account.
-This means you must use `allow_patterns` and `ignore_patterns` to specify which files to upload instead.
+If you don't want to use an hardcoded `.gitignore` file, you can use the `allow_patterns` and `ignore_patterns` arguments to filter which files to upload. These parameters accept either a single pattern or a list of patterns. Patterns are Standard Wildcards (globbing patterns) as documented [here](https://tldp.org/LDP/GNU-Linux-Tools-Summary/html/x11655.htm). If both `allow_patterns` and `ignore_patterns` are provided, both constraints apply.
+
+Beside the `.gitignore` file and allow/ignore patterns, any `.git/` folder present in any subdirectory will be ignored.
 
 ```py
 >>> api.upload_folder(

--- a/src/huggingface_hub/_commit_api.py
+++ b/src/huggingface_hub/_commit_api.py
@@ -137,13 +137,19 @@ class CommitOperationAdd:
     upload_info: UploadInfo = field(init=False, repr=False)
 
     # Internal attributes
-    _upload_mode: Optional[UploadMode] = field(
-        init=False, repr=False, default=None
-    )  # set to "lfs" or "regular" once known
-    _is_uploaded: bool = field(
-        init=False, repr=False, default=False
-    )  # set to True once the file has been uploaded as LFS
-    _is_committed: bool = field(init=False, repr=False, default=False)  # set to True once the file has been committed
+
+    # set to "lfs" or "regular" once known
+    _upload_mode: Optional[UploadMode] = field(init=False, repr=False, default=None)
+
+    # set to True if .gitignore rules prevent the file from being uploaded as LFS
+    # (server-side check)
+    _should_ignore: Optional[bool] = field(init=False, repr=False, default=None)
+
+    # set to True once the file has been uploaded as LFS
+    _is_uploaded: bool = field(init=False, repr=False, default=False)
+
+    # set to True once the file has been committed
+    _is_committed: bool = field(init=False, repr=False, default=False)
 
     def __post_init__(self) -> None:
         """Validates `path_or_fileobj` and compute `upload_info`."""
@@ -439,6 +445,7 @@ def _fetch_upload_modes(
     revision: str,
     endpoint: Optional[str] = None,
     create_pr: bool = False,
+    gitignore_content: Optional[str] = None,
 ) -> None:
     """
     Requests the Hub "preupload" endpoint to determine whether each input file should be uploaded as a regular git blob
@@ -457,7 +464,11 @@ def _fetch_upload_modes(
             An authentication token ( See https://huggingface.co/settings/tokens )
         revision (`str`):
             The git revision to upload the files to. Can be any valid git revision.
-
+        gitignore_content (`str`, *optional*):
+            The content of the `.gitignore` file to know which files should be ignored. The order of priority
+            is to first check if `gitignore_content` is passed, then check if the `.gitignore` file is present
+            in the list of files to commit and finally default to the `.gitignore` file already hosted on the Hub
+            (if any).
     Raises:
         [`~utils.HfHubHTTPError`]
             If the Hub API returned an error.
@@ -469,8 +480,10 @@ def _fetch_upload_modes(
 
     # Fetch upload mode (LFS or regular) chunk by chunk.
     upload_modes: Dict[str, UploadMode] = {}
+    should_ignore_info: Dict[str, bool] = {}
+
     for chunk in chunk_iterable(additions, 256):
-        payload = {
+        payload: Dict = {
             "files": [
                 {
                     "path": op.path_in_repo,
@@ -481,6 +494,8 @@ def _fetch_upload_modes(
                 for op in chunk
             ]
         }
+        if gitignore_content is not None:
+            payload["gitIgnore"] = gitignore_content
 
         resp = get_session().post(
             f"{endpoint}/api/{repo_type}s/{repo_id}/preupload/{revision}",
@@ -491,10 +506,12 @@ def _fetch_upload_modes(
         hf_raise_for_status(resp)
         preupload_info = _validate_preupload_info(resp.json())
         upload_modes.update(**{file["path"]: file["uploadMode"] for file in preupload_info["files"]})
+        should_ignore_info.update(**{file["path"]: file["shouldIgnore"] for file in preupload_info["files"]})
 
     # Set upload mode for each addition operation
     for addition in additions:
         addition._upload_mode = upload_modes[addition.path_in_repo]
+        addition._should_ignore = should_ignore_info[addition.path_in_repo]
 
     # Empty files cannot be uploaded as LFS (S3 would fail with a 501 Not Implemented)
     # => empty files are uploaded as "regular" to still allow users to commit them.
@@ -571,6 +588,7 @@ def _prepare_commit_payload(
     commit_message: str,
     commit_description: Optional[str] = None,
     parent_commit: Optional[str] = None,
+    respect_gitignore: bool = True,
 ) -> Iterable[Dict[str, Any]]:
     """
     Builds the payload to POST to the `/commit` API of the Hub.
@@ -590,8 +608,16 @@ def _prepare_commit_payload(
         header_value["parentCommit"] = parent_commit
     yield {"key": "header", "value": header_value}
 
+    nb_ignored_files = 0
+
     # 2. Send operations, one per line
     for operation in operations:
+        # Skip ignored files
+        if respect_gitignore and isinstance(operation, CommitOperationAdd) and operation._should_ignore:
+            logger.debug(f"Skipping file '{operation.path_in_repo}' in commit (ignored by gitignore file).")
+            nb_ignored_files += 1
+            continue
+
         # 2.a. Case adding a regular file
         if isinstance(operation, CommitOperationAdd) and operation._upload_mode == "regular":
             yield {
@@ -638,3 +664,6 @@ def _prepare_commit_payload(
                 f"Unknown operation to commit. Operation: {operation}. Upload mode:"
                 f" {getattr(operation, '_upload_mode', None)}"
             )
+
+    if nb_ignored_files > 0:
+        logger.info(f"Skipped {nb_ignored_files} file(s) in commit (ignored by gitignore file).")

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -4026,6 +4026,8 @@ class HfApi:
                     f"Skipped upload for {len(new_lfs_additions) - len(new_lfs_additions_to_upload)} LFS file(s) "
                     "(ignored by gitignore file)."
                 )
+        else:
+            new_lfs_additions_to_upload = new_lfs_additions
 
         # Upload new LFS files
         _upload_lfs_files(

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -4229,6 +4229,7 @@ class HfApi:
             revision=revision,
             create_pr=create_pr,
             parent_commit=parent_commit,
+            respect_gitignore=False,  # force upload when uploading a single file
         )
 
         if commit_info.pr_url is not None:

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -4098,6 +4098,7 @@ class HfApi:
         commit_description: Optional[str] = None,
         create_pr: Optional[bool] = None,
         parent_commit: Optional[str] = None,
+        respect_gitignore: bool = True,
         run_as_future: bool = False,
     ) -> Union[str, Future[str]]:
         """
@@ -4140,6 +4141,8 @@ class HfApi:
                 If specified and `create_pr` is `True`, the pull request will be created from `parent_commit`.
                 Specifying `parent_commit` ensures the repo has not changed before committing the changes, and can be
                 especially useful if the repo is updated / committed to concurrently.
+            respect_gitignore (`bool`, *optional*):
+                Whether or not to respect the `.gitignore` file in the repo. Defaults to `True`.
             run_as_future (`bool`, *optional*):
                 Whether or not to run this method in the background. Background jobs are run sequentially without
                 blocking the main thread. Passing `run_as_future=True` will return a [Future](https://docs.python.org/3/library/concurrent.futures.html#future-objects)
@@ -4229,7 +4232,7 @@ class HfApi:
             revision=revision,
             create_pr=create_pr,
             parent_commit=parent_commit,
-            respect_gitignore=False,  # force upload when uploading a single file
+            respect_gitignore=respect_gitignore,
         )
 
         if commit_info.pr_url is not None:


### PR DESCRIPTION
Solves #1826 and follow-up after server-side change (https://github.com/huggingface/moon-landing/pull/8007 - private link).

I have now added a `respect_gitignore: bool = True` parameter to `create_commit` and `upload_folder` to respect the gitignore file, if it exists.

By default we check if a .gitignore file is present in the commit itself. Otherwise the one hosted on the Hub is used. Only the gitignore file at root is respected (not in subdirectories).

I have adapted the documentation and added a few tests for it.

**Note:** as mentioned by @julien-c in https://github.com/huggingface/huggingface_hub/issues/1826#issuecomment-1810934088, let's consider this as a "bug-fix" and not a "breaking change" as we can expect that no-one was intentionally uploading ignored files on purpose. 

---

```sh
# Test to upload my `huggingface_hub/` folder to the Hub
>>> huggingface-cli upload test_tmp_upload ../huggingface_hub
Skipped upload for 53 LFS file(s) (ignored by gitignore file).
Skipped 597 file(s) in commit (ignored by gitignore file).
https://huggingface.co/Wauplin/test_tmp_upload/tree/main/.
```