### PR TITLE
Docs: _from_pretrained -> push_to_hub

### DIFF
--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -50,7 +50,7 @@ class ModelHubMixin:
                 ID of your repository on the Hub. Used only if `push_to_hub=True`. Will default to the folder name if
                 not provided.
             kwargs:
-                Additional key word arguments passed along to the [`~ModelHubMixin._from_pretrained`] method.
+                Additional key word arguments passed along to the [`~ModelHubMixin.push_to_hub`] method.
         """
         save_directory = Path(save_directory)
         save_directory.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Hello!

## Pull Request overview
* Fixed a copy-paste error: Docs mention `_from_pretrained`, but kwargs are passed to `push_to_hub` instead.

## Details
This PR should speak for itself. :)

- Tom Aarsen