### PR TITLE
Warn about truncation when listing collections

### DIFF
--- a/docs/source/en/guides/collections.md
+++ b/docs/source/en/guides/collections.md
@@ -76,6 +76,12 @@ Number of upvotes: 1
 Number of upvotes: 5
 ```
 
+<Tip warning={true}>
+
+When listing collections, the item list per collection is truncated to 4 items maximum. To retrieve all items from a collection, you must use [`get_collection`].
+
+</Tip>
+
 It is possible to do more advanced filtering. Let's get all collections containing the model [TheBloke/OpenHermes-2.5-Mistral-7B-GGUF](https://huggingface.co/TheBloke/OpenHermes-2.5-Mistral-7B-GGUF), sorted by trending, and limit the count to 5.
 ```py
 >>> collections = list_collections(item="models/TheBloke/OpenHermes-2.5-Mistral-7B-GGUF", sort="trending", limit=5):

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -7270,6 +7270,13 @@ class HfApi:
     ) -> Iterable[Collection]:
         """List collections on the Huggingface Hub, given some filters.
 
+        <Tip warning={true}>
+
+        When listing collections, the item list per collection is truncated to 4 items maximum. To retrieve all items
+        from a collection, you must use [`get_collection`].
+
+        </Tip>
+
         Args:
             owner (`List[str]` or `str`, *optional*):
                 Filter by owner's username.


### PR DESCRIPTION
Related to [slack thread](https://huggingface.slack.com/archives/C02EMARJ65P/p1701172683580399) (internal).

`GET /api/collections` do not return complete objects. Collections are truncated to keep only 4 items for performance reasons. This PR adds a warning in the `api.md` documentation.

(related PR for hub docs: https://github.com/huggingface/hub-docs/pull/1146)