### PR TITLE
Support source in EvalResult for model cards

### DIFF
--- a/src/huggingface_hub/repocard_data.py
+++ b/src/huggingface_hub/repocard_data.py
@@ -50,6 +50,10 @@ class EvalResult:
             Indicates whether the metrics originate from Hugging Face's [evaluation service](https://huggingface.co/spaces/autoevaluate/model-evaluator) or not. Automatically computed by Hugging Face, do not set.
         verify_token (`str`, *optional*):
             A JSON Web Token that is used to verify whether the metrics originate from Hugging Face's [evaluation service](https://huggingface.co/spaces/autoevaluate/model-evaluator) or not.
+        source_name (`str`, *optional*):
+            The name of the source of the evaluation result. Example: "Open LLM Leaderboard".
+        source_url (`str`, *optional*):
+            The URL of the source of the evaluation result. Example: "https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard".
     """
 
     # Required
@@ -117,6 +121,14 @@ class EvalResult:
     # A JSON Web Token that is used to verify whether the metrics originate from Hugging Face's [evaluation service](https://huggingface.co/spaces/autoevaluate/model-evaluator) or not.
     verify_token: Optional[str] = None
 
+    # The name of the source of the evaluation result.
+    # Example: Open LLM Leaderboard
+    source_name: Optional[str] = None
+
+    # The URL of the source of the evaluation result.
+    # Example: https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard
+    source_url: Optional[str] = None
+
     @property
     def unique_identifier(self) -> tuple:
         """Returns a tuple that uniquely identifies this evaluation."""
@@ -141,6 +153,12 @@ class EvalResult:
             if key != "verify_token" and getattr(self, key) != getattr(other, key):
                 return False
         return True
+
+    def __post_init__(self) -> None:
+        if self.source_name is not None and self.source_url is None:
+            raise ValueError("If `source_name` is provided, `source_url` must also be provided.")
+        if self.source_url is not None and self.source_name is None:
+            raise ValueError("If `source_url` is provided, `source_name` must also be provided.")
 
 
 @dataclass
@@ -556,6 +574,8 @@ def model_index_to_eval_results(model_index: List[Dict[str, Any]]) -> Tuple[str,
             dataset_split = result["dataset"].get("split")
             dataset_revision = result["dataset"].get("revision")
             dataset_args = result["dataset"].get("args")
+            source_name = result.get("source", {}).get("name")
+            source_url = result.get("source", {}).get("url")
 
             for metric in result["metrics"]:
                 metric_type = metric["type"]
@@ -582,6 +602,8 @@ def model_index_to_eval_results(model_index: List[Dict[str, Any]]) -> Tuple[str,
                     metric_config=metric_config,
                     verified=verified,
                     verify_token=verify_token,
+                    source_name=source_name,
+                    source_url=source_url,
                 )
                 eval_results.append(eval_result)
     return name, eval_results
@@ -636,7 +658,7 @@ def eval_results_to_model_index(model_name: str, eval_results: List[EvalResult])
 
     # Metrics are reported on a unique task-and-dataset basis.
     # Here, we make a map of those pairs and the associated EvalResults.
-    task_and_ds_types_map = defaultdict(list)
+    task_and_ds_types_map: Dict[Any, List[EvalResult]] = defaultdict(list)
     for eval_result in eval_results:
         task_and_ds_types_map[eval_result.unique_identifier].append(eval_result)
 
@@ -671,6 +693,11 @@ def eval_results_to_model_index(model_name: str, eval_results: List[EvalResult])
                 for result in results
             ],
         }
+        if sample_result.source_name is not None:
+            data["source"] = {
+                "name": sample_result.source_name,
+                "url": sample_result.source_url,
+            }
         model_index_data.append(data)
 
     # TODO - Check if there cases where this list is longer than one?

--- a/src/huggingface_hub/repocard_data.py
+++ b/src/huggingface_hub/repocard_data.py
@@ -157,8 +157,6 @@ class EvalResult:
     def __post_init__(self) -> None:
         if self.source_name is not None and self.source_url is None:
             raise ValueError("If `source_name` is provided, `source_url` must also be provided.")
-        if self.source_url is not None and self.source_name is None:
-            raise ValueError("If `source_url` is provided, `source_name` must also be provided.")
 
 
 @dataclass
@@ -693,11 +691,13 @@ def eval_results_to_model_index(model_name: str, eval_results: List[EvalResult])
                 for result in results
             ],
         }
-        if sample_result.source_name is not None:
-            data["source"] = {
-                "name": sample_result.source_name,
+        if sample_result.source_url is not None:
+            source = {
                 "url": sample_result.source_url,
             }
+            if sample_result.source_name is not None:
+                source["name"] = sample_result.source_name
+            data["source"] = source
         model_index_data.append(data)
 
     # TODO - Check if there cases where this list is longer than one?

--- a/tests/test_repocard_data.py
+++ b/tests/test_repocard_data.py
@@ -36,6 +36,9 @@ model-index:
     metrics:
     - type: acc
       value: 0.9
+    source:
+      name: Open LLM Leaderboard
+      url: https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard
 """
 
 
@@ -77,6 +80,8 @@ class ModelCardDataTest(unittest.TestCase):
                 dataset_name="Beans",
                 metric_type="acc",
                 metric_value=0.9,
+                source_name="Open LLM Leaderboard",
+                source_url="https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard",
             ),
         ]
 
@@ -124,6 +129,10 @@ class ModelCardDataTest(unittest.TestCase):
                                 "verifyToken": 1234,
                             }
                         ],
+                        "source": {
+                            "name": "Open LLM Leaderboard",
+                            "url": "https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard",
+                        },
                     },
                 ],
             }
@@ -132,13 +141,24 @@ class ModelCardDataTest(unittest.TestCase):
 
         self.assertEqual(len(eval_results), 3)
         self.assertEqual(model_name, "my-cool-model")
+
         self.assertEqual(eval_results[0].dataset_type, "cats_vs_dogs")
+        self.assertIsNone(eval_results[0].source_name)
+        self.assertIsNone(eval_results[0].source_url)
+
         self.assertEqual(eval_results[1].metric_type, "f1")
         self.assertEqual(eval_results[1].metric_value, 0.9)
+        self.assertIsNone(eval_results[1].source_name)
+        self.assertIsNone(eval_results[1].source_url)
+
         self.assertEqual(eval_results[2].task_type, "image-classification")
         self.assertEqual(eval_results[2].dataset_type, "beans")
         self.assertEqual(eval_results[2].verified, True)
         self.assertEqual(eval_results[2].verify_token, 1234)
+        self.assertEqual(eval_results[2].source_name, "Open LLM Leaderboard")
+        self.assertEqual(
+            eval_results[2].source_url, "https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard"
+        )
 
     def test_card_data_requires_model_name_for_eval_results(self):
         with pytest.raises(ValueError, match="`eval_results` requires `model_name` to be set."):
@@ -191,6 +211,27 @@ class ModelCardDataTest(unittest.TestCase):
 
         data_dict = data.to_dict()
         self.assertEqual(data_dict["some_arbitrary_kwarg"], "some_value")
+
+    def test_eval_result_without_complete_source(self):
+        with self.assertRaises(ValueError):
+            EvalResult(
+                task_type="image-classification",
+                dataset_type="beans",
+                dataset_name="Beans",
+                metric_type="acc",
+                metric_value=0.9,
+                source_url="https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard",
+            )
+
+        with self.assertRaises(ValueError):
+            EvalResult(
+                task_type="image-classification",
+                dataset_type="beans",
+                dataset_name="Beans",
+                metric_type="acc",
+                metric_value=0.9,
+                source_name="Open LLM Leaderboard",
+            )
 
 
 class DatasetCardDataTest(unittest.TestCase):

--- a/tests/test_repocard_data.py
+++ b/tests/test_repocard_data.py
@@ -14,6 +14,7 @@ from huggingface_hub.repocard_data import (
 )
 
 
+OPEN_LLM_LEADERBOARD_URL = "https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard"
 DUMMY_METADATA_WITH_MODEL_INDEX = """
 language: en
 license: mit
@@ -81,7 +82,7 @@ class ModelCardDataTest(unittest.TestCase):
                 metric_type="acc",
                 metric_value=0.9,
                 source_name="Open LLM Leaderboard",
-                source_url="https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard",
+                source_url=OPEN_LLM_LEADERBOARD_URL,
             ),
         ]
 
@@ -131,7 +132,7 @@ class ModelCardDataTest(unittest.TestCase):
                         ],
                         "source": {
                             "name": "Open LLM Leaderboard",
-                            "url": "https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard",
+                            "url": OPEN_LLM_LEADERBOARD_URL,
                         },
                     },
                 ],
@@ -156,9 +157,7 @@ class ModelCardDataTest(unittest.TestCase):
         self.assertEqual(eval_results[2].verified, True)
         self.assertEqual(eval_results[2].verify_token, 1234)
         self.assertEqual(eval_results[2].source_name, "Open LLM Leaderboard")
-        self.assertEqual(
-            eval_results[2].source_url, "https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard"
-        )
+        self.assertEqual(eval_results[2].source_url, OPEN_LLM_LEADERBOARD_URL)
 
     def test_card_data_requires_model_name_for_eval_results(self):
         with pytest.raises(ValueError, match="`eval_results` requires `model_name` to be set."):
@@ -212,17 +211,18 @@ class ModelCardDataTest(unittest.TestCase):
         data_dict = data.to_dict()
         self.assertEqual(data_dict["some_arbitrary_kwarg"], "some_value")
 
-    def test_eval_result_without_complete_source(self):
-        with self.assertRaises(ValueError):
-            EvalResult(
-                task_type="image-classification",
-                dataset_type="beans",
-                dataset_name="Beans",
-                metric_type="acc",
-                metric_value=0.9,
-                source_url="https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard",
-            )
+    def test_eval_result_with_incomplete_source(self):
+        # Source url without name: ok
+        EvalResult(
+            task_type="image-classification",
+            dataset_type="beans",
+            dataset_name="Beans",
+            metric_type="acc",
+            metric_value=0.9,
+            source_url=OPEN_LLM_LEADERBOARD_URL,
+        )
 
+        # Source name without url: not ok
         with self.assertRaises(ValueError):
             EvalResult(
                 task_type="image-classification",


### PR DESCRIPTION
Related to https://github.com/huggingface/hub-docs/pull/1144 and https://github.com/huggingface/moon-landing/pull/8232 (private repo).

We are adding a new field `source` for each eval result in the model card metadata. This PR adds support to it in the `EvalResult` object (cc @clefourrier).

**Example:**

```py
from huggingface_hub import EvalResult, ModelCard, ModelCardData

result = EvalResult(
    task_type="image-classification",
    dataset_type="beans",
    dataset_name="Beans",
    metric_type="acc",
    metric_value=0.9,
    source_name="Open LLM Leaderboard",
    source_url="https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard",
)
card = ModelCard.from_template(ModelCardData(model_name="cool_model", eval_results=[result]))
```

which translates to

```yaml
---
model-index:
- name: cool_model
  results:
  - task:
      type: image-classification
    dataset:
      name: Beans
      type: beans
    metrics:
    - type: acc
      value: 0.9
    source:
      name: Open LLM Leaderboard
      url: https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard
---
```