### PR TITLE
Remove `maxdepth` param from `HfFileSystem.glob`

### DIFF
--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -376,10 +376,10 @@ class HfFileSystem(fsspec.AbstractFileSystem):
                 out.append(cache_path_info)
         return out
 
-    def glob(self, path, maxdepth=None, **kwargs):
+    def glob(self, path, **kwargs):
         # Set expand_info=False by default to get a x10 speed boost
         kwargs = {"expand_info": kwargs.get("detail", False), **kwargs}
-        return super().glob(path, maxdepth=maxdepth, **kwargs)
+        return super().glob(path, **kwargs)
 
     def find(
         self,


### PR DESCRIPTION
`maxdepth` was added to the default `fsspec`'s `glob` in version `2023.9.0`, so this PR removes `maxdepth` from the `HfFileSystem.glob`'s signature to avoid an error in the older `fsspec` versions.


Fix https://github.com/huggingface/huggingface_hub/issues/1872