### PR TITLE
Remove respect_gitignore parameter

### DIFF
--- a/docs/source/en/guides/upload.md
+++ b/docs/source/en/guides/upload.md
@@ -73,11 +73,7 @@ folder to. Depending on your repository type, you can optionally set the reposit
 ... )
 ```
 
-By default, the `.gitignore` file will be taken into account to know which files should
-be committed or not. By default we check if a `.gitignore` file is present in a commit, and if not, we check if it exists on the Hub. If you want to force the upload no matter
-the `.gitignore` file, you can pass `respect_gitignore=False`. Please be aware that only
-a `.gitignore` file present at the root of the directory with be used. We do not check
-for `.gitignore` files in subdirectories.
+By default, the `.gitignore` file will be taken into account to know which files should be committed or not. By default we check if a `.gitignore` file is present in a commit, and if not, we check if it exists on the Hub. Please be aware that only a `.gitignore` file present at the root of the directory with be used. We do not check for `.gitignore` files in subdirectories.
 
 If you don't want to use an hardcoded `.gitignore` file, you can use the `allow_patterns` and `ignore_patterns` arguments to filter which files to upload. These parameters accept either a single pattern or a list of patterns. Patterns are Standard Wildcards (globbing patterns) as documented [here](https://tldp.org/LDP/GNU-Linux-Tools-Summary/html/x11655.htm). If both `allow_patterns` and `ignore_patterns` are provided, both constraints apply.
 

--- a/src/huggingface_hub/_commit_api.py
+++ b/src/huggingface_hub/_commit_api.py
@@ -588,7 +588,6 @@ def _prepare_commit_payload(
     commit_message: str,
     commit_description: Optional[str] = None,
     parent_commit: Optional[str] = None,
-    respect_gitignore: bool = True,
 ) -> Iterable[Dict[str, Any]]:
     """
     Builds the payload to POST to the `/commit` API of the Hub.
@@ -613,7 +612,7 @@ def _prepare_commit_payload(
     # 2. Send operations, one per line
     for operation in operations:
         # Skip ignored files
-        if respect_gitignore and isinstance(operation, CommitOperationAdd) and operation._should_ignore:
+        if isinstance(operation, CommitOperationAdd) and operation._should_ignore:
             logger.debug(f"Skipping file '{operation.path_in_repo}' in commit (ignored by gitignore file).")
             nb_ignored_files += 1
             continue

--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -379,6 +379,7 @@ class HfFileSystem(fsspec.AbstractFileSystem):
     def glob(self, path, **kwargs):
         # Set expand_info=False by default to get a x10 speed boost
         kwargs = {"expand_info": kwargs.get("detail", False), **kwargs}
+        path = self.resolve_path(path).unresolve()
         return super().glob(path, **kwargs)
 
     def find(

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -584,17 +584,6 @@ class CommitApiTest(HfApiCommonTest):
         # Check nested file not uploaded
         assert not self._api.file_exists(repo_url.repo_id, "nested/file.bin")
 
-    @use_tmp_repo()
-    def test_upload_folder_ignore_gitignore(self, repo_url: RepoUrl) -> None:
-        # Create .gitignore file locally
-        (Path(self.tmp_dir) / ".gitignore").write_text("nested/*\n")
-
-        # Upload folder with `respect_gitignore=False`
-        self._api.upload_folder(folder_path=self.tmp_dir, repo_id=repo_url.repo_id, respect_gitignore=False)
-
-        # Check nested file is uploaded
-        assert self._api.file_exists(repo_url.repo_id, "nested/file.bin")
-
     def test_create_commit_create_pr(self):
         REPO_NAME = repo_name("create_commit_create_pr")
         self._api.create_repo(repo_id=REPO_NAME, exist_ok=False)


### PR DESCRIPTION
Followup after https://github.com/huggingface/huggingface_hub/pull/1868#issuecomment-1832705457.

Let's remove the `respect_gitignore: bool` parameter completely as we don't expect users would want to force commit files.