### PR TITLE
Fix Repository is not a class

### DIFF
--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -422,7 +422,6 @@ def _lfs_log_progress():
             os.environ["GIT_LFS_PROGRESS"] = current_lfs_progress_value
 
 
-
 class Repository:
     """
     Helper class to wrap the git and git-lfs commands.
@@ -445,13 +444,13 @@ class Repository:
 
     @validate_hf_hub_args
     @_deprecate_method(
-    version="1.0",
-    message=(
-        "Please prefer the http-based alternatives instead. Given its large adoption in legacy code, the complete"
-        " removal is only planned on next major release.\nFor more details, please read"
-        " https://huggingface.co/docs/huggingface_hub/concepts/git_vs_http."
-    ),
-)
+        version="1.0",
+        message=(
+            "Please prefer the http-based alternatives instead. Given its large adoption in legacy code, the complete"
+            " removal is only planned on next major release.\nFor more details, please read"
+            " https://huggingface.co/docs/huggingface_hub/concepts/git_vs_http."
+        ),
+    )
     def __init__(
         self,
         local_dir: Union[str, Path],

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -422,14 +422,7 @@ def _lfs_log_progress():
             os.environ["GIT_LFS_PROGRESS"] = current_lfs_progress_value
 
 
-@_deprecate_method(
-    version="1.0",
-    message=(
-        "Please prefer the http-based alternatives instead. Given its large adoption in legacy code, the complete"
-        " removal is only planned on next major release.\nFor more details, please read"
-        " https://huggingface.co/docs/huggingface_hub/concepts/git_vs_http."
-    ),
-)
+
 class Repository:
     """
     Helper class to wrap the git and git-lfs commands.
@@ -451,6 +444,14 @@ class Repository:
     command_queue: List[CommandInProgress]
 
     @validate_hf_hub_args
+    @_deprecate_method(
+    version="1.0",
+    message=(
+        "Please prefer the http-based alternatives instead. Given its large adoption in legacy code, the complete"
+        " removal is only planned on next major release.\nFor more details, please read"
+        " https://huggingface.co/docs/huggingface_hub/concepts/git_vs_http."
+    ),
+)
     def __init__(
         self,
         local_dir: Union[str, Path],

--- a/src/huggingface_hub/utils/_deprecation.py
+++ b/src/huggingface_hub/utils/_deprecation.py
@@ -119,7 +119,7 @@ def _deprecate_method(*, version: str, message: Optional[str] = None):
     def _inner_deprecate_method(f):
         name = f.__name__
         if name == "__init__":
-            name = f.__qualname__.split('.')[0]  # class name instead of method name
+            name = f.__qualname__.split(".")[0]  # class name instead of method name
 
         @wraps(f)
         def inner_f(*args, **kwargs):

--- a/src/huggingface_hub/utils/_deprecation.py
+++ b/src/huggingface_hub/utils/_deprecation.py
@@ -117,10 +117,14 @@ def _deprecate_method(*, version: str, message: Optional[str] = None):
     """
 
     def _inner_deprecate_method(f):
+        name = f.__name__
+        if name == "__init__":
+            name = f.__qualname__.split('.')[0]  # class name instead of method name
+
         @wraps(f)
         def inner_f(*args, **kwargs):
             warning_message = (
-                f"'{f.__name__}' (from '{f.__module__}') is deprecated and will be removed from version '{version}'."
+                f"'{name}' (from '{f.__module__}') is deprecated and will be removed from version '{version}'."
             )
             if message is not None:
                 warning_message += " " + message


### PR DESCRIPTION
In https://github.com/huggingface/huggingface_hub/pull/1724 I deprecated `Repository` but the wrong way, making `Repository` a function instead of a class. This PR fixes this. The warning message stays the same:

```
/home/wauplin/projects/huggingface_hub/src/huggingface_hub/utils/_deprecation.py:131: FutureWarning: 'Repository' (from 'huggingface_hub.repository') is deprecated and will be removed from version '1.0'. Please prefer the http-based alternatives instead. Given its large adoption in legacy code, the complete removal is only planned on next major release.
For more details, please read https://huggingface.co/docs/huggingface_hub/concepts/git_vs_http.
```

Fix https://github.com/huggingface/huggingface_hub/issues/1878 (thanks @versae for reporting)