### PR TITLE
Fix `WebhookPayload` schema + add `WebhooksServer.launch`

### DIFF
--- a/src/huggingface_hub/_webhooks_payload.py
+++ b/src/huggingface_hub/_webhooks_payload.py
@@ -80,7 +80,7 @@ class WebhookPayloadDiscussionChanges(BaseModel):
 class WebhookPayloadComment(ObjectId):
     author: ObjectId
     hidden: bool
-    content: Optional[str]
+    content: Optional[str] = None
     url: WebhookPayloadUrl
 
 
@@ -91,7 +91,7 @@ class WebhookPayloadDiscussion(ObjectId):
     title: str
     isPullRequest: bool
     status: DiscussionStatus_T
-    changes: Optional[WebhookPayloadDiscussionChanges]
+    changes: Optional[WebhookPayloadDiscussionChanges] = None
     pinned: Optional[bool] = None
 
 
@@ -109,7 +109,7 @@ class WebhookPayloadRepo(ObjectId):
 class WebhookPayload(BaseModel):
     event: WebhookPayloadEvent
     repo: WebhookPayloadRepo
-    discussion: Optional[WebhookPayloadDiscussion]
-    comment: Optional[WebhookPayloadComment]
+    discussion: Optional[WebhookPayloadDiscussion] = None
+    comment: Optional[WebhookPayloadComment] = None
     webhook: WebhookPayloadWebhook
     movedTo: Optional[WebhookPayloadMovedTo] = None

--- a/src/huggingface_hub/_webhooks_server.py
+++ b/src/huggingface_hub/_webhooks_server.py
@@ -152,7 +152,7 @@ class WebhooksServer:
 
         return _inner_post
 
-    def launch(self, prevent_thread_lock: bool = False, **launch_kwargs: Dict(str, Any)) -> None:
+    def launch(self, prevent_thread_lock: bool = False, **launch_kwargs: Any) -> None:
         """Launch the Gradio app and register webhooks to the underlying FastAPI server.
 
         Input parameters are forwarded to Gradio when launching the app.

--- a/tests/test_webhooks_server.py
+++ b/tests/test_webhooks_server.py
@@ -82,7 +82,7 @@ WEBHOOK_PAYLOAD_UPDATE_DISCUSSION = {  # valid payload but doesn't have a "comme
 
 def test_deserialize_payload_example_with_comment() -> None:
     """Confirm that the test stub can actually be deserialized."""
-    payload = WebhookPayload.model_validate(WEBHOOK_PAYLOAD_CREATE_DISCUSSION)
+    payload = WebhookPayload.parse_obj(WEBHOOK_PAYLOAD_CREATE_DISCUSSION)
     assert payload.event.scope == WEBHOOK_PAYLOAD_CREATE_DISCUSSION["event"]["scope"]
     assert payload.comment is not None
     assert payload.comment.content == "Add co2 emissions information to the model card"
@@ -90,7 +90,7 @@ def test_deserialize_payload_example_with_comment() -> None:
 
 def test_deserialize_payload_example_without_comment() -> None:
     """Confirm that the test stub can actually be deserialized."""
-    payload = WebhookPayload.model_validate(WEBHOOK_PAYLOAD_UPDATE_DISCUSSION)
+    payload = WebhookPayload.parse_obj(WEBHOOK_PAYLOAD_UPDATE_DISCUSSION)
     assert payload.event.scope == WEBHOOK_PAYLOAD_UPDATE_DISCUSSION["event"]["scope"]
     assert payload.comment is None
 

--- a/tests/test_webhooks_server.py
+++ b/tests/test_webhooks_server.py
@@ -183,7 +183,7 @@ class TestWebhooksServerRun(unittest.TestCase):
             # Run without blocking
             with patch.object(huggingface_hub._webhooks_server, "_is_local", False):
                 # Run without tunnel
-                self.app.run()
+                self.app.launch()
                 return TestClient(self.app.fastapi_app)
 
     def test_run_print_instructions(self):


### PR DESCRIPTION
This PR:
- fixes an issue with `WebhookPayload`. In Pydantic v2.0 optional fields must be explicitly set to None by default otheriwse it raises an issue. That was happening for the `comment` value that is optional in the payload. Also added a test for it.
- renames `WebhooksServer.run` to `WebhooksServer.launch` to stick to gradio naming. I also allowed users to pass parameters that are forwarded to gradio. I added a deprecation message to `.run` even though it is flagged as an "experimental feature" anyway.

(**EDIT:** failing tests are unrelated)