### PR TITLE
Login/authentication enhancements

### DIFF
--- a/contrib/conftest.py
+++ b/contrib/conftest.py
@@ -1,9 +1,9 @@
+import os
 import time
 import uuid
 from typing import Generator
 
 import pytest
-from _pytest.monkeypatch import MonkeyPatch
 
 from huggingface_hub import delete_repo
 
@@ -20,9 +20,13 @@ def user() -> str:
 
 
 @pytest.fixture(autouse=True, scope="session")
-def login_as_dummy_user(token: str, monkeypatch: MonkeyPatch) -> Generator:
+def login_as_dummy_user(token: str) -> Generator:
     """Login with dummy user token."""
-    monkeypatch.setenv("HF_TOKEN", token)
+    # Cannot use `monkeypatch` fixture since we want it to be "session-scoped"
+    old_token = os.environ["HF_TOKEN"]
+    os.environ["HF_TOKEN"] = token
+    yield
+    os.environ["HF_TOKEN"] = old_token
 
 
 @pytest.fixture

--- a/contrib/conftest.py
+++ b/contrib/conftest.py
@@ -3,8 +3,9 @@ import uuid
 from typing import Generator
 
 import pytest
+from _pytest.monkeypatch import MonkeyPatch
 
-from huggingface_hub import HfFolder, delete_repo
+from huggingface_hub import delete_repo
 
 
 @pytest.fixture(scope="session")
@@ -19,19 +20,9 @@ def user() -> str:
 
 
 @pytest.fixture(autouse=True, scope="session")
-def login_as_dummy_user(token: str) -> Generator:
-    """Login with dummy user token on machine
-
-    Once all tests are completed, set back previous token."""
-    # Remove registered token
-    old_token = HfFolder().get_token()
-    HfFolder().save_token(token)
-
-    yield  # Run all tests
-
-    # Set back token once all tests have passed
-    if old_token is not None:
-        HfFolder().save_token(old_token)
+def login_as_dummy_user(token: str, monkeypatch: MonkeyPatch) -> Generator:
+    """Login with dummy user token."""
+    monkeypatch.setenv("HF_TOKEN", token)
 
 
 @pytest.fixture

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -92,6 +92,8 @@ Your token has been saved to /home/wauplin/.cache/huggingface/token
 Login successful
 ```
 
+For more details about authentication, check out [this section](../quick-start#authentication).
+
 ## huggingface-cli whoami
 
 If you want to know if you are logged in, you can use `huggingface-cli whoami`. This command doesn't have any options and simply prints your username and the organizations you are a part of on the Hub:

--- a/docs/source/en/guides/hf_file_system.md
+++ b/docs/source/en/guides/hf_file_system.md
@@ -97,7 +97,7 @@ The same workflow can also be used for [Dask](https://docs.dask.org/en/stable/ho
 
 ## Authentication
 
-In many cases, you must be logged in with a Hugging Face account to interact with the Hub. Refer to the [Login](../quick-start#login) section of the documentation to learn more about authentication methods on the Hub. 
+In many cases, you must be logged in with a Hugging Face account to interact with the Hub. Refer to the [Authentication](../quick-start#authentication) section of the documentation to learn more about authentication methods on the Hub.
 
 It is also possible to login programmatically by passing your `token` as an argument to [`HfFileSystem`]:
 

--- a/docs/source/en/guides/inference.md
+++ b/docs/source/en/guides/inference.md
@@ -97,7 +97,7 @@ code as before, changing only the `model` parameter:
 
 Calls made with the [`InferenceClient`] can be authenticated using a [User Access Token](https://huggingface.co/docs/hub/security-tokens).
 By default, it will use the token saved on your machine if you are logged in (check out
-[how to login](https://huggingface.co/docs/huggingface_hub/quick-start#login)). If you are not logged in, you can pass
+[how to authenticate](https://huggingface.co/docs/huggingface_hub/quick-start#authentication)). If you are not logged in, you can pass
 your token as an instance parameter:
 
 ```python

--- a/docs/source/en/guides/repository.md
+++ b/docs/source/en/guides/repository.md
@@ -27,7 +27,7 @@ explanation page for more details.
 </Tip>
 
 If you want to create and manage a repository on the Hub, your machine must be logged in. If you are not, please refer to
-[this section](../quick-start#login). In the rest of this guide, we will assume that your machine is logged in.
+[this section](../quick-start#authentication). In the rest of this guide, we will assume that your machine is logged in.
 
 ## Repo creation and deletion
 

--- a/docs/source/en/guides/upload.md
+++ b/docs/source/en/guides/upload.md
@@ -11,31 +11,7 @@ Sharing your files and work is an important aspect of the Hub. The `huggingface_
 - with the `commit` context manager.
 - with the [`~Repository.push_to_hub`] function.
 
-Whenever you want to upload files to the Hub, you need to log in to your Hugging Face account:
-
-- Log in to your Hugging Face account with the following command:
-
-  ```bash
-  huggingface-cli login
-  # or using an environment variable
-  huggingface-cli login --token $HUGGINGFACE_TOKEN
-  ```
-
-- Alternatively, you can programmatically login using [`login`] in a notebook or a script:
-
-  ```python
-  >>> from huggingface_hub import login
-  >>> login()
-  ```
-
-  If ran in a Jupyter or Colaboratory notebook, [`login`] will launch a widget from
-  which you can enter your Hugging Face access token. Otherwise, a message will be
-  prompted in the terminal.
-
-  It is also possible to login programmatically without the widget by directly passing
-  the token to [`login`]. If you do so, be careful when sharing your notebook. It is
-  best practice to load the token from a secure vault instead of saving it in plain in
-  your Colaboratory notebook.
+Whenever you want to upload files to the Hub, you need to log in to your Hugging Face account. For more details about authentication, check out [this section](../quick-start#authentication).
 
 ## Upload a file
 

--- a/docs/source/en/package_reference/environment_variables.md
+++ b/docs/source/en/package_reference/environment_variables.md
@@ -49,7 +49,7 @@ Defaults to `"$HF_HOME/assets"` (e.g. `"~/.cache/huggingface/assets"` by default
 To configure the User Access Token to authenticate to the Hub. If set, this value will
 overwrite the token stored on the machine (in `"$HF_HOME/token"`).
 
-See [login reference](../package_reference/login) for more details.
+For more details about authentication, check out [this section](../quick-start#authentication).
 
 ### HF_HUB_VERBOSITY
 

--- a/docs/source/en/package_reference/hf_api.md
+++ b/docs/source/en/package_reference/hf_api.md
@@ -109,15 +109,6 @@ Below are the supported values for [`CommitOperation`]:
 
 [[autodoc]] CommitScheduler
 
-## Token helper
-
-`huggingface_hub` stores the authentication information locally so that it may be re-used in subsequent
-methods.
-
-It does this using the [`HfFolder`] utility, which saves data at the root of the user.
-
-[[autodoc]] HfFolder
-
 ## Search helpers
 
 Some helpers to filter repositories on the Hub are available in the `huggingface_hub` package.

--- a/docs/source/en/package_reference/login.md
+++ b/docs/source/en/package_reference/login.md
@@ -4,8 +4,9 @@ rendered properly in your Markdown viewer.
 
 # Login and logout
 
-The `huggingface_hub` library allows users to programmatically login and logout the
-machine to the Hub.
+The `huggingface_hub` library allows users to programmatically login and logout the machine to the Hub.
+
+For more details about authentication, check out [this section](../quick-start#authentication).
 
 ## login
 

--- a/docs/source/en/quick-start.md
+++ b/docs/source/en/quick-start.md
@@ -107,7 +107,15 @@ Authentication via an environment variable or a secret has priority over the tok
 
 ### Method parameters
 
-Finally, it is also possible to authenticate programmatically by passing your token to any method that accepts `token` as parameter. This is usually discouraged except in an environment where you don't want to store your token permanently or if you need to handle several tokens at once.
+Finally, it is also possible to authenticate by passing your token to any method that accepts `token` as a parameter.
+
+```
+from transformers import whoami
+
+user = whoami(token=...)
+```
+
+This is usually discouraged except in an environment where you don't want to store your token permanently or if you need to handle several tokens at once.
 
 <Tip warning={true}>
 

--- a/docs/source/en/quick-start.md
+++ b/docs/source/en/quick-start.md
@@ -64,19 +64,19 @@ used to authenticate your identity to the Hub.
 
 <Tip>
 
-Tokens can have `read` or `write` permissions. Make sure to have a `write` access token if you want to create or edit a repository. Otherwise, it's best to generate a `read` token to reduce risks in case you leak your token inadvertently.
+Tokens can have `read` or `write` permissions. Make sure to have a `write` access token if you want to create or edit a repository. Otherwise, it's best to generate a `read` token to reduce risk in case your token is inadvertently leaked.
 
 </Tip>
 
 ### Login command
 
-The easiest way to authenticate is to save the token on your machine. You can do that from the terminal using the `login` command:
+The easiest way to authenticate is to save the token on your machine. You can do that from the terminal using the [`login`] command:
 
 ```bash
 huggingface-cli login
 ```
 
-The command will tell you if you are already logged in and prompt you for your token. The token is then validated and saved in your `HF_HOME` directory (default to `~/.cache/huggingface/token`). Any script or library interacting with the Hub will use this token when sending requests.
+The command will tell you if you are already logged in and prompt you for your token. The token is then validated and saved in your `HF_HOME` directory (defaults to `~/.cache/huggingface/token`). Any script or library interacting with the Hub will use this token when sending requests.
 
 Alternatively, you can programmatically login using [`login`] in a notebook or a script:
 
@@ -85,33 +85,33 @@ Alternatively, you can programmatically login using [`login`] in a notebook or a
 >>> login()
 ```
 
-You can only be logged into one account at a time. Logging into a new account will automatically log you out of the previous one. To determine your currently active account, simply run the huggingface-cli whoami command.
+You can only be logged in to one account at a time. Logging in to a new account will automatically log you out of the previous one. To determine your currently active account, simply run the `huggingface-cli whoami` command.
 
 <Tip warning={true}>
 
-Once you are logged in, all requests to the Hub -even methods that don't necessarily require authentication- will use your access token by default. If you want to disable implicit use of your token, you should set `HF_HUB_DISABLE_IMPLICIT_TOKEN=1` as environment variable (see [reference](../package_reference/environment_variables#hfhubdisableimplicittoken)).
+Once logged in, all requests to the Hub - even methods that don't necessarily require authentication - will use your access token by default. If you want to disable the implicit use of your token, you should set `HF_HUB_DISABLE_IMPLICIT_TOKEN=1` as an environment variable (see [reference](../package_reference/environment_variables#hfhubdisableimplicittoken)).
 
 </Tip>
 
 ### Environment variable
 
-Another possibility to authenticate is to set the environment variable `HF_TOKEN` with your access token. This is especially useful in Spaces where you can set `HF_TOKEN` as a [Space secret](https://huggingface.co/docs/hub/spaces-overview#managing-secrets).
+The environment variable `HF_TOKEN` can also be used to authenticate yourself. This is especially useful in a Space where you can set `HF_TOKEN` as a [Space secret](https://huggingface.co/docs/hub/spaces-overview#managing-secrets).
 
 <Tip>
 
-**NEW:** Google Colaboratory let you [define private keys](https://twitter.com/GoogleColab/status/1719798406195867814) for your notebooks. Define a `HF_TOKEN` secret to be automatically authenticated!
+**NEW:** Google Colaboratory lets you define [private keys](https://twitter.com/GoogleColab/status/1719798406195867814) for your notebooks. Define a `HF_TOKEN` secret to be automatically authenticated!
 
 </Tip>
 
 Authentication via an environment variable or a secret has priority over the token stored on your machine.
 
-### Programmatically
+### Method parameters
 
 Finally, it is also possible to authenticate programmatically by passing your token to any method that accepts `token` as parameter. This is usually discouraged except in an environment where you don't want to store your token permanently or if you need to handle several tokens at once.
 
 <Tip warning={true}>
 
-Please be careful when passing tokens as parameter. It is always best practice to load the token from a secure vault instead of hardcoding it in your codebase or notebook. Hardcoded tokens present a major risk of leak if you share your code inadvertently.
+Please be careful when passing tokens as a parameter. It is always best practice to load the token from a secure vault instead of hardcoding it in your codebase or notebook. Hardcoded tokens present a major leak risk if you share your code inadvertently.
 
 </Tip>
 

--- a/docs/source/en/quick-start.md
+++ b/docs/source/en/quick-start.md
@@ -51,22 +51,32 @@ full-length hash instead of the shorter 7-character commit hash:
 
 For more details and options, see the API reference for [`hf_hub_download`].
 
-## Login
+<a id="login"></a> <!-- backward compatible anchor -->
 
-In a lot of cases, you must be logged in with a Hugging Face account to interact with
+## Authentication
+
+In a lot of cases, you must be authenticated with a Hugging Face account to interact with
 the Hub: download private repos, upload files, create PRs,...
 [Create an account](https://huggingface.co/join) if you don't already have one, and then sign in
 to get your [User Access Token](https://huggingface.co/docs/hub/security-tokens) from
 your [Settings page](https://huggingface.co/settings/tokens). The User Access Token is
 used to authenticate your identity to the Hub.
 
-Once you have your User Access Token, run the following command in your terminal:
+<Tip>
+
+Tokens can have `read` or `write` permissions. Make sure to have a `write` access token if you want to create or edit a repository. Otherwise, it's best to generate a `read` token to reduce risks in case you leak your token inadvertently.
+
+</Tip>
+
+### Login command
+
+The easiest way to authenticate is to save the token on your machine. You can do that from the terminal using the `login` command:
 
 ```bash
 huggingface-cli login
-# or using an environment variable
-huggingface-cli login --token $HUGGINGFACE_TOKEN
 ```
+
+The command will tell you if you are already logged in and prompt you for your token. The token is then validated and saved in your `HF_HOME` directory (default to `~/.cache/huggingface/token`). Any script or library interacting with the Hub will use this token when sending requests.
 
 Alternatively, you can programmatically login using [`login`] in a notebook or a script:
 
@@ -75,21 +85,33 @@ Alternatively, you can programmatically login using [`login`] in a notebook or a
 >>> login()
 ```
 
-It is also possible to login programmatically without being prompted to enter your token by directly
-passing the token to [`login`] like `login(token="hf_xxx")`. If you do so, be careful when
-sharing your source code. It is a best practice to load the token from a secure vault instead
-of saving it explicitly in your codebase/notebook.
-
-You can be logged in only to 1 account at a time. If you login your machine to a new account, you will get logged out
-from the previous. Make sure to always which account you are using with the command `huggingface-cli whoami`.
-If you want to handle several accounts in the same script, you can provide your token when calling each method. This
-is also useful if you don't want to store any token on your machine.
+You can only be logged into one account at a time. Logging into a new account will automatically log you out of the previous one. To determine your currently active account, simply run the huggingface-cli whoami command.
 
 <Tip warning={true}>
 
-Once you are logged in, all requests to the Hub -even methods that don't necessarily require authentication- will use your
-access token by default. If you want to disable implicit use of your token, you should set the
-`HF_HUB_DISABLE_IMPLICIT_TOKEN` environment variable.
+Once you are logged in, all requests to the Hub -even methods that don't necessarily require authentication- will use your access token by default. If you want to disable implicit use of your token, you should set `HF_HUB_DISABLE_IMPLICIT_TOKEN=1` as environment variable (see [reference](../package_reference/environment_variables#hfhubdisableimplicittoken)).
+
+</Tip>
+
+### Environment variable
+
+Another possibility to authenticate is to set the environment variable `HF_TOKEN` with your access token. This is especially useful in Spaces where you can set `HF_TOKEN` as a [Space secret](https://huggingface.co/docs/hub/spaces-overview#managing-secrets).
+
+<Tip>
+
+**NEW:** Google Colaboratory let you [define private keys](https://twitter.com/GoogleColab/status/1719798406195867814) for your notebooks. Define a `HF_TOKEN` secret to be automatically authenticated!
+
+</Tip>
+
+Authentication via an environment variable or a secret has priority over the token stored on your machine.
+
+### Programmatically
+
+Finally, it is also possible to authenticate programmatically by passing your token to any method that accepts `token` as parameter. This is usually discouraged except in an environment where you don't want to store your token permanently or if you need to handle several tokens at once.
+
+<Tip warning={true}>
+
+Please be careful when passing tokens as parameter. It is always best practice to load the token from a secure vault instead of hardcoding it in your codebase or notebook. Hardcoded tokens present a major risk of leak if you share your code inadvertently.
 
 </Tip>
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,5 +61,7 @@ max-line-length = 119
 # --durations=0          -> print execution time of each test
 addopts = -Werror::FutureWarning --log-cli-level=INFO -sv --durations=0
 env =
+    HF_TOKEN=
+    HUGGING_FACE_HUB_TOKEN=
     HUGGINGFACE_CO_STAGING=1
     DISABLE_SYMLINKS_IN_WINDOWS_TESTS=1

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -63,6 +63,7 @@ _SUBMOD_ATTRS = {
         "InferenceEndpointType",
     ],
     "_login": [
+        "get_token",
         "interpreter_login",
         "login",
         "logout",
@@ -406,6 +407,7 @@ if TYPE_CHECKING:  # pragma: no cover
         InferenceEndpointType,  # noqa: F401
     )
     from ._login import (
+        get_token,  # noqa: F401
         interpreter_login,  # noqa: F401
         login,  # noqa: F401
         logout,  # noqa: F401

--- a/src/huggingface_hub/_login.py
+++ b/src/huggingface_hub/_login.py
@@ -14,6 +14,7 @@
 """Contains methods to login to the Hub."""
 import os
 import subprocess
+import warnings
 from functools import partial
 from getpass import getpass
 from pathlib import Path
@@ -36,6 +37,8 @@ _HF_LOGO_ASCII = """
     _|    _|  _|    _|  _|    _|  _|    _|    _|    _|    _|_|  _|    _|      _|        _|    _|  _|        _|
     _|    _|    _|_|      _|_|_|    _|_|_|  _|_|_|  _|      _|    _|_|_|      _|        _|    _|    _|_|_|  _|_|_|_|
 """
+
+_CHECK_GOOGLE_COLAB_SECRET = True
 
 
 def login(
@@ -307,12 +310,47 @@ def _get_token_from_google_colab() -> Optional[str]:
     if not is_google_colab():
         return None
 
+    global _CHECK_GOOGLE_COLAB_SECRET
+    if not _CHECK_GOOGLE_COLAB_SECRET:  # request access only once
+        return None
+
     try:
         from google.colab import userdata
+        from google.colab.errors import Error as ColabError
     except ImportError:
         return None
 
-    return _clean_token(userdata.get("HF_TOKEN"))
+    try:
+        token = userdata.get("HF_TOKEN")
+    except userdata.NotebookAccessError:
+        # Means the user has a secret call `HF_TOKEN` and got a popup "please grand access to HF_TOKEN" and refused it
+        # => warn user but ignore error => do not re-request access to user
+        warnings.warn(
+            "Access to the secret `HF_TOKEN` has not been granted on this notebook. You will not be requested again. "
+            "Please restart the session if you want to be prompted again."
+        )
+        _CHECK_GOOGLE_COLAB_SECRET = False
+        return None
+    except ColabError as e:
+        if "does not exist" in str(e):
+            # Means the user did not define a `HF_TOKEN` secret => warn
+            warnings.warn(
+                "The secret `HF_TOKEN` does not exist in your Colab secrets. To authenticate with the Huggingface "
+                "Hub, create a token in your settings tab (https://huggingface.co/settings/tokens), set it as secret "
+                "in your Google Colab and restart your session. You will be able to reuse this secret in all of your "
+                "notebook. Please note that authentication is recommended but still optional to access public models "
+                "or datasets."
+            )
+        else:
+            # Something happen but we don't know what => recommend to open a GitHub issue
+            warnings.warn(
+                f"Error while fetching `HF_TOKEN` secret value from your vault: '{str(e)}'. You are not authenticated "
+                "with the Huggingface Hub in this notebook. If the error persists, please let us know by opening an "
+                "issue on GitHub (https://github.com/huggingface/huggingface_hub/issues/new)."
+            )
+        return None
+
+    return _clean_token(token)
 
 
 def _get_token_from_environment() -> Optional[str]:

--- a/src/huggingface_hub/commands/user.py
+++ b/src/huggingface_hub/commands/user.py
@@ -29,11 +29,11 @@ from .._login import (  # noqa: F401 # for backward compatibility  # noqa: F401 
     NOTEBOOK_LOGIN_PASSWORD_HTML,
     NOTEBOOK_LOGIN_TOKEN_HTML_END,
     NOTEBOOK_LOGIN_TOKEN_HTML_START,
+    get_token,
     login,
     logout,
     notebook_login,
 )
-from ..utils import HfFolder
 from ._cli_utils import ANSI
 
 
@@ -105,7 +105,7 @@ class LogoutCommand(BaseUserCommand):
 
 class WhoamiCommand(BaseUserCommand):
     def run(self):
-        token = HfFolder.get_token()
+        token = get_token()
         if token is None:
             print("Not logged in")
             exit()
@@ -126,7 +126,7 @@ class WhoamiCommand(BaseUserCommand):
 
 class RepoCreateCommand(BaseUserCommand):
     def run(self):
-        token = HfFolder.get_token()
+        token = get_token()
         if token is None:
             print("Not logged in")
             exit(1)

--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -128,6 +128,7 @@ if _staging_mode:
     # In staging mode, we use a different cache to ensure we don't mix up production and staging data or tokens
     _staging_home = os.path.join(os.path.expanduser("~"), ".cache", "huggingface_staging")
     HUGGINGFACE_HUB_CACHE = os.path.join(_staging_home, "hub")
+    _OLD_HF_TOKEN_PATH = os.path.join(_staging_home, "_old_token")
     HF_TOKEN_PATH = os.path.join(_staging_home, "token")
 
 # Here, `True` will disable progress bars globally without possibility of enabling it

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -12,10 +12,10 @@ from urllib.parse import urlparse
 from huggingface_hub.constants import REPO_TYPES_URL_PREFIXES, REPOCARD_NAME
 from huggingface_hub.repocard import metadata_load, metadata_save
 
+from ._login import get_token
 from .hf_api import HfApi, repo_type_and_id_from_hf_id
 from .lfs import LFS_MULTIPART_UPLOAD_COMMAND
 from .utils import (
-    HfFolder,
     SoftTemporaryDirectory,
     logging,
     run_subprocess,
@@ -527,7 +527,7 @@ class Repository:
         else:
             # if `True` -> explicit use of the cached token
             # if `None` -> implicit use of the cached token
-            self.huggingface_token = HfFolder.get_token()
+            self.huggingface_token = get_token()
 
         if clone_from is not None:
             self.clone_from(repo_url=clone_from)

--- a/src/huggingface_hub/utils/_headers.py
+++ b/src/huggingface_hub/utils/_headers.py
@@ -16,7 +16,7 @@
 from typing import Dict, Optional, Union
 
 from .. import constants
-from ._hf_folder import HfFolder
+from .._login import get_token
 from ._runtime import (
     get_fastai_version,
     get_fastcore_version,
@@ -145,7 +145,7 @@ def get_token_to_send(token: Optional[Union[bool, str]]) -> Optional[str]:
         return None
 
     # Token is not provided: we get it from local cache
-    cached_token = HfFolder().get_token()
+    cached_token = get_token()
 
     # Case token is explicitly required
     if token is True:

--- a/src/huggingface_hub/utils/_hf_folder.py
+++ b/src/huggingface_hub/utils/_hf_folder.py
@@ -26,6 +26,8 @@ class HfFolder:
     # Private attribute. Will be removed in v0.15
     _old_path_token = Path(constants._OLD_HF_TOKEN_PATH)
 
+    # TODO: deprecate when adapted in transformers/datasets/gradio
+    # @_deprecate_method(version="1.0", message="Use `huggingface_hub.login` instead.")
     @classmethod
     def save_token(cls, token: str) -> None:
         """
@@ -41,6 +43,8 @@ class HfFolder:
         cls.path_token.parent.mkdir(parents=True, exist_ok=True)
         cls.path_token.write_text(token)
 
+    # TODO: deprecate when adapted in transformers/datasets/gradio
+    # @_deprecate_method(version="1.0", message="Use `huggingface_hub.get_token` instead.")
     @classmethod
     def get_token(cls) -> Optional[str]:
         """
@@ -68,6 +72,7 @@ class HfFolder:
             token = os.environ.get("HUGGING_FACE_HUB_TOKEN")
         if token is not None:
             token = token.replace("\r", "").replace("\n", "").strip()
+        if token != "":
             return token
 
         # 2. Is it set in token path ?
@@ -78,6 +83,8 @@ class HfFolder:
         except FileNotFoundError:
             return None
 
+    # TODO: deprecate when adapted in transformers/datasets/gradio
+    # @_deprecate_method(version="1.0", message="Use `huggingface_hub.logout` instead.")
     @classmethod
     def delete_token(cls) -> None:
         """

--- a/src/huggingface_hub/utils/_runtime.py
+++ b/src/huggingface_hub/utils/_runtime.py
@@ -273,10 +273,10 @@ def dump_environment_info() -> Dict[str, Any]:
     - `diffusers` (https://github.com/huggingface/diffusers/blob/main/src/diffusers/commands/env.py)
     - `transformers` (https://github.com/huggingface/transformers/blob/main/src/transformers/commands/env.py)
     """
-    from huggingface_hub import HfFolder, whoami
+    from huggingface_hub import get_token, whoami
     from huggingface_hub.utils import list_credential_helpers
 
-    token = HfFolder().get_token()
+    token = get_token()
 
     # Generic machine info
     info: Dict[str, Any] = {
@@ -296,7 +296,7 @@ def dump_environment_info() -> Dict[str, Any]:
     info["Running in Google Colab ?"] = "Yes" if is_google_colab() else "No"
 
     # Login info
-    info["Token path ?"] = HfFolder().path_token
+    info["Token path ?"] = constants.HF_TOKEN_PATH
     info["Has saved token ?"] = token is not None
     if token is not None:
         try:

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2140,10 +2140,6 @@ class HfApiPrivateTest(HfApiCommonTest):
         self._api.delete_repo(repo_id=self.REPO_NAME)
         self._api.delete_repo(repo_id=self.REPO_NAME, repo_type="dataset")
 
-    def test_whoami_with_implicit_token_from_login(self, mock_get_token: Mock) -> None:
-        """Test using `whoami` after a `huggingface-cli login`."""
-        mock_get_token.return_value = self._token
-
     @patch("huggingface_hub.utils._headers.get_token", return_value=None)
     def test_model_info(self, mock_get_token: Mock) -> None:
         with patch.object(self._api, "token", None):  # no default token
@@ -2864,9 +2860,9 @@ class TestSpaceAPIProduction(unittest.TestCase):
 
         # Restart
         self.api.restart_space(self.repo_id)
-        time.sleep(1.0)
+        time.sleep(5.0)
         runtime_after_restart = self.api.get_space_runtime(self.repo_id)
-        self.assertIn(runtime_after_restart.stage, (SpaceStage.BUILDING, SpaceStage.RUNNING_BUILDING))
+        self.assertNotEqual(runtime_after_restart.stage, SpaceStage.PAUSED)
 
 
 @pytest.mark.usefixtures("fx_cache_dir")

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -181,7 +181,7 @@ class HfApiEndpointsTest(HfApiCommonTest):
         self.assertEqual(info["fullname"], FULL_NAME)
         self.assertIsInstance(info["orgs"], list)
         valid_org = [org for org in info["orgs"] if org["name"] == "valid_org"][0]
-        self.assertIsInstance(valid_org["apiToken"], str)
+        self.assertEqual(valid_org["fullname"], "Dummy Org")
 
     @patch("huggingface_hub.utils._headers.get_token", return_value=TOKEN)
     def test_whoami_with_implicit_token_from_login(self, mock_get_token: Mock) -> None:

--- a/tests/test_snapshot_download.py
+++ b/tests/test_snapshot_download.py
@@ -105,7 +105,7 @@ class SnapshotDownloadTests(unittest.TestCase):
                 _ = snapshot_download(self.repo_id, revision="main", cache_dir=tmpdir)
 
         # Test we can download with token from cache
-        with patch("huggingface_hub.utils._headers.get_token", return_value=None):
+        with patch("huggingface_hub.utils._headers.get_token", return_value=TOKEN):
             with SoftTemporaryDirectory() as tmpdir:
                 storage_folder = snapshot_download(self.repo_id, revision="main", cache_dir=tmpdir)
                 self.assertTrue(self.second_commit_hash in storage_folder)

--- a/tests/test_snapshot_download.py
+++ b/tests/test_snapshot_download.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 import requests
 
 from huggingface_hub import CommitOperationAdd, HfApi, snapshot_download
-from huggingface_hub.utils import HfFolder, SoftTemporaryDirectory
+from huggingface_hub.utils import SoftTemporaryDirectory
 
 from .testing_constants import TOKEN
 from .testing_utils import repo_name
@@ -105,10 +105,10 @@ class SnapshotDownloadTests(unittest.TestCase):
                 _ = snapshot_download(self.repo_id, revision="main", cache_dir=tmpdir)
 
         # Test we can download with token from cache
-        with SoftTemporaryDirectory() as tmpdir:
-            HfFolder.save_token(TOKEN)
-            storage_folder = snapshot_download(self.repo_id, revision="main", cache_dir=tmpdir)
-            self.assertTrue(self.second_commit_hash in storage_folder)
+        with patch("huggingface_hub.utils._headers.get_token", return_value=None):
+            with SoftTemporaryDirectory() as tmpdir:
+                storage_folder = snapshot_download(self.repo_id, revision="main", cache_dir=tmpdir)
+                self.assertTrue(self.second_commit_hash in storage_folder)
 
         # Test we can download with explicit token
         with SoftTemporaryDirectory() as tmpdir:

--- a/tests/test_testing_configuration.py
+++ b/tests/test_testing_configuration.py
@@ -1,0 +1,6 @@
+from huggingface_hub import get_token
+
+
+def test_no_token_in_staging_environment():
+    """Make sure no token is set in test environment."""
+    assert get_token() is None


### PR DESCRIPTION
This PR do various things related to authentication. I started it to support Google Colab secrets and ended up rewriting some docs and deprecating some legacy code.

**List of changes:**
1. New authentication section in the quick-start guide. Especially:
    - document how to login via CLI
    - encourage login with env variable for Google Colab and Spaces
    - discourage hardcoded tokens
    - warnings about token permission and leaks
    - => this section is in the quick-start guide. I hesitated to have a dedicated guide/page for it but I don't think it's worth it (not much content + we would still have some "authentication" content in the quick start so let's keep everything together)
2. **Automatically read `HF_TOKEN` secret when running in a colab notebook**! :fire: 
3. `logout` now raises an error if token is deleted but user was logged in via environment variable / secret value. I think this is important otherwise a user can think they are completely logged out of a machine when it's not the case.
4. Started to deprecate `HfFolder` in favor of `get_token`, `login` and `logout`.
    - `huggingface_hub.get_token` feels much more intuitive `huggingface_hub.Hffolder.get_token`
    - `login` in favor of `HfFolder.save_token` => saves token but also checks token validity. I don't think an external lib should save the token without checks.
    - `logout` in favor of `HfFolder.delete_token`  => deletes token but also checks if the user is really logged out (i.e. no env variable)
    - => for now, `HfFolder` is not officially deprecated. I will first release this, then adapt `transformers`/`datasets`/`gradio` codebase and then deprecate it officially in the next release (and most likely remove in `v1.0`).
5. ignore token if empty string (`""`) and consider as None
6. adapt tests

**TODO:**
- [ ] check documentation in other languages
- [ ] fix remaining tests

![image](https://github.com/huggingface/huggingface_hub/assets/11801849/60206997-64c1-4e8f-9127-a343f091cd68)
