### PR TITLE
Respect HF_HUB_OFFLINE for every http call

### DIFF
--- a/docs/source/en/package_reference/environment_variables.md
+++ b/docs/source/en/package_reference/environment_variables.md
@@ -83,13 +83,11 @@ as `True` if its value is one of `{"1", "ON", "YES", "TRUE"}` (case-insensitive)
 
 ### HF_HUB_OFFLINE
 
-If set, no HTTP calls will me made when trying to fetch files. Only files that are already
-cached will be accessed. This is useful in case your network is slow and you don't care
-about having absolutely the latest version of a file.
+If set, no HTTP calls will me made to the Hugging Face Hub. If you try to download files, only the cached files will be accessed. If no cache file is detected, an error is raised This is useful in case your network is slow and you don't care about having the latest version of a file.
 
-**Note:** even if the latest version of a file is cached, calling `hf_hub_download` still triggers
-a HTTP request to check that a new version is not available. Setting `HF_HUB_OFFLINE=1` will
-skip this call which speeds up your loading time.
+If `HF_HUB_OFFLINE=1` is set as environment variable and you call any method of [`HfApi`], an [`~huggingface_hub.utils.OfflineModeIsEnabled`] exception will be raised.
+
+**Note:** even if the latest version of a file is cached, calling `hf_hub_download` still triggers a HTTP request to check that a new version is not available. Setting `HF_HUB_OFFLINE=1` will skip this call which speeds up your loading time.
 
 ### HF_HUB_DISABLE_IMPLICIT_TOKEN
 

--- a/docs/source/en/package_reference/utilities.md
+++ b/docs/source/en/package_reference/utilities.md
@@ -176,6 +176,10 @@ user as possible.
 
 [[autodoc]] huggingface_hub.utils.LocalEntryNotFoundError
 
+#### OfflineModeIsEnabled
+
+[[autodoc]] huggingface_hub.utils.OfflineModeIsEnabled
+
 ## Telemetry
 
 `huggingface_hub` includes an helper to send telemetry data. This information helps us debug issues and prioritize new features.

--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -10,6 +10,7 @@ from .constants import (
     DEFAULT_REVISION,
     HF_HUB_CACHE,
     HF_HUB_ENABLE_HF_TRANSFER,
+    HF_HUB_OFFLINE,
     REPO_TYPES,
 )
 from .file_download import REGEX_COMMIT_HASH, hf_hub_download, repo_folder_name
@@ -161,7 +162,7 @@ def snapshot_download(
     # appropriate folder in the cache
     # If the specified revision is a commit hash, look inside "snapshots".
     # If the specified revision is a branch or tag, look inside "refs".
-    if local_files_only:
+    if local_files_only or HF_HUB_OFFLINE:
         if REGEX_COMMIT_HASH.match(revision):
             commit_hash = revision
         else:

--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -44,7 +44,7 @@ from ._fixes import SoftTemporaryDirectory, yaml_dump
 from ._git_credential import list_credential_helpers, set_git_credential, unset_git_credential
 from ._headers import build_hf_headers, get_token_to_send, LocalTokenNotFoundError
 from ._hf_folder import HfFolder
-from ._http import configure_http_backend, get_session, http_backoff, reset_sessions
+from ._http import configure_http_backend, get_session, http_backoff, reset_sessions, OfflineModeIsEnabled
 from ._pagination import paginate
 from ._paths import filter_repo_objects, IGNORE_GIT_FOLDER_PATTERNS
 from ._experimental import experimental

--- a/tests/test_utils_http.py
+++ b/tests/test_utils_http.py
@@ -11,7 +11,13 @@ import requests
 from requests import ConnectTimeout, HTTPError
 
 from huggingface_hub.constants import ENDPOINT
-from huggingface_hub.utils._http import configure_http_backend, get_session, http_backoff
+from huggingface_hub.utils._http import (
+    OfflineModeIsEnabled,
+    configure_http_backend,
+    get_session,
+    http_backoff,
+    reset_sessions,
+)
 
 
 URL = "https://www.google.com"
@@ -232,6 +238,19 @@ class TestConfigureSession(unittest.TestCase):
 
         # Check sessions are different
         self.assertNotEqual(repr(main_session), child_session)
+
+
+class OfflineModeSessionTest(unittest.TestCase):
+    def tearDown(self) -> None:
+        reset_sessions()
+        return super().tearDown()
+
+    @patch("huggingface_hub.constants.HF_HUB_OFFLINE", True)
+    def test_offline_mode(self):
+        configure_http_backend()
+        session = get_session()
+        with self.assertRaises(OfflineModeIsEnabled):
+            session.get("https://huggingface.co")
 
 
 class TestUniqueRequestId(unittest.TestCase):

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -15,7 +15,7 @@ from unittest.mock import Mock, patch
 import pytest
 import requests
 
-from huggingface_hub.utils import is_gradio_available, logging
+from huggingface_hub.utils import is_gradio_available, logging, reset_sessions
 from tests.testing_constants import ENDPOINT_PRODUCTION, ENDPOINT_PRODUCTION_URL_SCHEME
 
 
@@ -193,7 +193,9 @@ def offline(mode=OfflineSimulationMode.CONNECTION_FAILS, timeout=1e-16):
                     yield
     elif mode is OfflineSimulationMode.HF_HUB_OFFLINE_SET_TO_1:
         with patch("huggingface_hub.constants.HF_HUB_OFFLINE", True):
+            reset_sessions()
             yield
+        reset_sessions()
     else:
         raise ValueError("Please use a value from the OfflineSimulationMode enum.")
 


### PR DESCRIPTION
At the moment `HF_HUB_OFFLINE` is only respected when downloading files. This PR makes it used globally for any call to the Hub.

Not respecting it makes it harder to debug things in some cases. For example:
- `snapshot_download` should not make the HTTP call to list the repo files
- `diffusers` should not make a `model_info` call => see https://github.com/huggingface/diffusers/issues/6089 which would have been easier to investigate

With this PR, any unintended call to the Hub will raise a `OfflineModeIsEnabled` error. Either the dependent libraries chose to catch it explicitly and default back to another solution or the user gets an explicit error -which is easier when reporting an issue.

cc @sayakpaul as well