### PR TITLE
Fix error handling on HTTP 401

### DIFF
--- a/src/huggingface_hub/utils/_errors.py
+++ b/src/huggingface_hub/utils/_errors.py
@@ -6,7 +6,7 @@ from requests import HTTPError, Response
 from ._fixes import JSONDecodeError
 
 
-REPO_API_REGEX = re.compile(r"^https://huggingface.co/api/(models|datasets|spaces)/(.+)")
+REPO_API_REGEX = re.compile(r"^https://(hub-ci.)?huggingface.co/api/(models|datasets|spaces)/(.+)")
 
 
 class FileMetadataError(OSError):

--- a/src/huggingface_hub/utils/_errors.py
+++ b/src/huggingface_hub/utils/_errors.py
@@ -6,7 +6,20 @@ from requests import HTTPError, Response
 from ._fixes import JSONDecodeError
 
 
-REPO_API_REGEX = re.compile(r"^https://(hub-ci.)?huggingface.co/api/(models|datasets|spaces)/(.+)")
+REPO_API_REGEX = re.compile(
+    r"""
+        # staging or production endpoint
+        ^https://(hub-ci.)?huggingface.co
+        (
+            # on /api/repo_type/repo_id
+            /api/(models|datasets|spaces)/(.+)
+            |
+            # or /repo_id/resolve/revision/...
+            /(.+)/resolve/(.+)
+        )
+    """,
+    flags=re.VERBOSE,
+)
 
 
 class FileMetadataError(OSError):

--- a/src/huggingface_hub/utils/_errors.py
+++ b/src/huggingface_hub/utils/_errors.py
@@ -1,9 +1,12 @@
+import re
 from typing import Optional
 
 from requests import HTTPError, Response
 
-from ..constants import INFERENCE_ENDPOINTS_ENDPOINT
 from ._fixes import JSONDecodeError
+
+
+REPO_API_REGEX = re.compile(r"^https://huggingface.co/api/(models|datasets|spaces)/(.+)")
 
 
 class FileMetadataError(OSError):
@@ -285,25 +288,12 @@ def hf_raise_for_status(response: Response, endpoint_name: Optional[str] = None)
             )
             raise GatedRepoError(message, response) from e
 
-        elif (
+        elif error_code == "RepoNotFound" or (
             response.status_code == 401
+            and response.request is not None
             and response.request.url is not None
-            and "/api/collections" in response.request.url
+            and REPO_API_REGEX.search(response.request.url) is not None
         ):
-            # Collection not found. We don't raise a custom error for this.
-            # This prevent from raising a misleading `RepositoryNotFoundError` (see below).
-            pass
-
-        elif (
-            response.status_code == 401
-            and response.request.url is not None
-            and INFERENCE_ENDPOINTS_ENDPOINT in response.request.url
-        ):
-            # Not enough permission to list Inference Endpoints from this org. We don't raise a custom error for this.
-            # This prevent from raising a misleading `RepositoryNotFoundError` (see below).
-            pass
-
-        elif error_code == "RepoNotFound" or response.status_code == 401:
             # 401 is misleading as it is returned for:
             #    - private and gated repos if user is not authenticated
             #    - missing repos

--- a/tests/test_utils_errors.py
+++ b/tests/test_utils_errors.py
@@ -278,9 +278,9 @@ class TestHfHubHTTPError(unittest.TestCase):
         # Inference Endpoint => False
         ("https://api.endpoints.huggingface.cloud/v2/endpoint/namespace", False),
         # Staging Endpoint => True
-        ("https://huggingface.co/api/models/repo_id", True),
-        ("https://huggingface.co/api/datasets/repo_id", True),
-        ("https://huggingface.co/api/spaces/repo_id", True),
+        ("https://hub-ci.huggingface.co/api/models/repo_id", True),
+        ("https://hub-ci.huggingface.co/api/datasets/repo_id", True),
+        ("https://hub-ci.huggingface.co/api/spaces/repo_id", True),
     ],
 )
 def test_repo_api_regex(url: str, should_match: bool) -> None:

--- a/tests/test_utils_errors.py
+++ b/tests/test_utils_errors.py
@@ -281,6 +281,12 @@ class TestHfHubHTTPError(unittest.TestCase):
         ("https://hub-ci.huggingface.co/api/models/repo_id", True),
         ("https://hub-ci.huggingface.co/api/datasets/repo_id", True),
         ("https://hub-ci.huggingface.co/api/spaces/repo_id", True),
+        # /resolve Endpoint => True
+        ("https://huggingface.co/gpt2/resolve/main/README.md", True),
+        ("https://huggingface.co/datasets/google/fleurs/resolve/revision/README.md", True),
+        # Regression tests
+        ("https://huggingface.co/bert-base/resolve/main/pytorch_model.bin", True),
+        ("https://hub-ci.huggingface.co/__DUMMY_USER__/repo-1470b5/resolve/main/file.txt", True),
     ],
 )
 def test_repo_api_regex(url: str, should_match: bool) -> None:

--- a/tests/test_utils_errors.py
+++ b/tests/test_utils_errors.py
@@ -23,12 +23,25 @@ class TestErrorUtils(unittest.TestCase):
         self.assertEqual(context.exception.response.status_code, 404)
         self.assertIn("Request ID: 123", str(context.exception))
 
-    def test_hf_raise_for_status_repo_not_found_without_error_code(self) -> None:
+    def test_hf_raise_for_status_401_repo_url(self) -> None:
         response = Response()
         response.headers = {"X-Request-Id": 123}
         response.status_code = 401
         response.request = PreparedRequest()
+        response.request.url = "https://huggingface.co/api/models/username/reponame"
         with self.assertRaisesRegex(RepositoryNotFoundError, "Repository Not Found") as context:
+            hf_raise_for_status(response)
+
+        self.assertEqual(context.exception.response.status_code, 401)
+        self.assertIn("Request ID: 123", str(context.exception))
+
+    def test_hf_raise_for_status_401_not_repo_url(self) -> None:
+        response = Response()
+        response.headers = {"X-Request-Id": 123}
+        response.status_code = 401
+        response.request = PreparedRequest()
+        response.request.url = "https://huggingface.co/api/collections"
+        with self.assertRaises(HfHubHTTPError) as context:
             hf_raise_for_status(response)
 
         self.assertEqual(context.exception.response.status_code, 401)


### PR DESCRIPTION
In `huggingface_hub` we have a helper `hf_raise_for_status` used everywhere to raise custom HTTP errors when sending requests to the Hub.

One of the rule was to define any HTTP 401 error as a `RepoNotFound` error since this is the status code a user get when trying to access a gated/private/missing repo without been authenticated (no token in header). Was also kinda a legacy rule I think. Problem is that now more and more api calls are made to endpoints not related to specific repos (inference endpoints, collections, create repo, etc.). This PR fixes `hf_raise_for_status` by raising a `RepoNotFound` exception only if the uri starts with `/api/(models|datasets|spaces)/<repo_id>`.


(I finally fixed that after @davanstrien ran into a 
```
Repository Not Found for url: https://huggingface.co/api/repos/create.
Please make sure you specified the correct `repo_id` and `repo_type`.
If you are trying to access a private or gated repo, make sure you are authenticated.
Invalid username or password.
```
see [slack](https://huggingface.slack.com/archives/C02EMARJ65P/p1702495051047899?thread_ts=1702485214.619679&cid=C02EMARJ65P) -internal-)