### PR TITLE
Manage access requests programmatically

### DIFF
--- a/docs/source/en/package_reference/hf_api.md
+++ b/docs/source/en/package_reference/hf_api.md
@@ -35,6 +35,10 @@ models = hf_api.list_models()
 
 ## API Dataclasses
 
+### AccessRequest
+
+[[autodoc]] huggingface_hub.hf_api.AccessRequest
+
 ### CommitInfo
 
 [[autodoc]] huggingface_hub.hf_api.CommitInfo

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -183,7 +183,6 @@ _SUBMOD_ATTRS = {
         "duplicate_space",
         "edit_discussion_comment",
         "file_exists",
-        "get_accepted_access_requests",
         "get_collection",
         "get_dataset_tags",
         "get_discussion_details",
@@ -191,8 +190,6 @@ _SUBMOD_ATTRS = {
         "get_inference_endpoint",
         "get_model_tags",
         "get_paths_info",
-        "get_pending_access_requests",
-        "get_rejected_access_requests",
         "get_repo_discussions",
         "get_safetensors_metadata",
         "get_space_runtime",
@@ -200,6 +197,7 @@ _SUBMOD_ATTRS = {
         "get_token_permission",
         "grant_access",
         "like",
+        "list_accepted_access_requests",
         "list_collections",
         "list_datasets",
         "list_files_info",
@@ -207,6 +205,8 @@ _SUBMOD_ATTRS = {
         "list_liked_repos",
         "list_metrics",
         "list_models",
+        "list_pending_access_requests",
+        "list_rejected_access_requests",
         "list_repo_commits",
         "list_repo_files",
         "list_repo_likers",
@@ -531,7 +531,6 @@ if TYPE_CHECKING:  # pragma: no cover
         duplicate_space,  # noqa: F401
         edit_discussion_comment,  # noqa: F401
         file_exists,  # noqa: F401
-        get_accepted_access_requests,  # noqa: F401
         get_collection,  # noqa: F401
         get_dataset_tags,  # noqa: F401
         get_discussion_details,  # noqa: F401
@@ -539,8 +538,6 @@ if TYPE_CHECKING:  # pragma: no cover
         get_inference_endpoint,  # noqa: F401
         get_model_tags,  # noqa: F401
         get_paths_info,  # noqa: F401
-        get_pending_access_requests,  # noqa: F401
-        get_rejected_access_requests,  # noqa: F401
         get_repo_discussions,  # noqa: F401
         get_safetensors_metadata,  # noqa: F401
         get_space_runtime,  # noqa: F401
@@ -548,6 +545,7 @@ if TYPE_CHECKING:  # pragma: no cover
         get_token_permission,  # noqa: F401
         grant_access,  # noqa: F401
         like,  # noqa: F401
+        list_accepted_access_requests,  # noqa: F401
         list_collections,  # noqa: F401
         list_datasets,  # noqa: F401
         list_files_info,  # noqa: F401
@@ -555,6 +553,8 @@ if TYPE_CHECKING:  # pragma: no cover
         list_liked_repos,  # noqa: F401
         list_metrics,  # noqa: F401
         list_models,  # noqa: F401
+        list_pending_access_requests,  # noqa: F401
+        list_rejected_access_requests,  # noqa: F401
         list_repo_commits,  # noqa: F401
         list_repo_files,  # noqa: F401
         list_repo_likers,  # noqa: F401

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -137,7 +137,6 @@ _SUBMOD_ATTRS = {
         "try_to_load_from_cache",
     ],
     "hf_api": [
-        "AccessRequest",
         "Collection",
         "CollectionItem",
         "CommitInfo",
@@ -485,7 +484,6 @@ if TYPE_CHECKING:  # pragma: no cover
         try_to_load_from_cache,  # noqa: F401
     )
     from .hf_api import (
-        AccessRequest,  # noqa: F401
         Collection,  # noqa: F401
         CollectionItem,  # noqa: F401
         CommitInfo,  # noqa: F401

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -137,6 +137,7 @@ _SUBMOD_ATTRS = {
         "try_to_load_from_cache",
     ],
     "hf_api": [
+        "AccessRequest",
         "Collection",
         "CollectionItem",
         "CommitInfo",
@@ -151,9 +152,11 @@ _SUBMOD_ATTRS = {
         "RepoUrl",
         "User",
         "UserLikes",
+        "accept_access_request",
         "add_collection_item",
         "add_space_secret",
         "add_space_variable",
+        "cancel_access_request",
         "change_discussion_status",
         "comment_discussion",
         "create_branch",
@@ -180,6 +183,7 @@ _SUBMOD_ATTRS = {
         "duplicate_space",
         "edit_discussion_comment",
         "file_exists",
+        "get_accepted_access_requests",
         "get_collection",
         "get_dataset_tags",
         "get_discussion_details",
@@ -187,11 +191,14 @@ _SUBMOD_ATTRS = {
         "get_inference_endpoint",
         "get_model_tags",
         "get_paths_info",
+        "get_pending_access_requests",
+        "get_rejected_access_requests",
         "get_repo_discussions",
         "get_safetensors_metadata",
         "get_space_runtime",
         "get_space_variables",
         "get_token_permission",
+        "grant_access",
         "like",
         "list_collections",
         "list_datasets",
@@ -213,6 +220,7 @@ _SUBMOD_ATTRS = {
         "pause_inference_endpoint",
         "pause_space",
         "preupload_lfs_files",
+        "reject_access_request",
         "rename_discussion",
         "repo_exists",
         "repo_info",
@@ -477,6 +485,7 @@ if TYPE_CHECKING:  # pragma: no cover
         try_to_load_from_cache,  # noqa: F401
     )
     from .hf_api import (
+        AccessRequest,  # noqa: F401
         Collection,  # noqa: F401
         CollectionItem,  # noqa: F401
         CommitInfo,  # noqa: F401
@@ -491,9 +500,11 @@ if TYPE_CHECKING:  # pragma: no cover
         RepoUrl,  # noqa: F401
         User,  # noqa: F401
         UserLikes,  # noqa: F401
+        accept_access_request,  # noqa: F401
         add_collection_item,  # noqa: F401
         add_space_secret,  # noqa: F401
         add_space_variable,  # noqa: F401
+        cancel_access_request,  # noqa: F401
         change_discussion_status,  # noqa: F401
         comment_discussion,  # noqa: F401
         create_branch,  # noqa: F401
@@ -520,6 +531,7 @@ if TYPE_CHECKING:  # pragma: no cover
         duplicate_space,  # noqa: F401
         edit_discussion_comment,  # noqa: F401
         file_exists,  # noqa: F401
+        get_accepted_access_requests,  # noqa: F401
         get_collection,  # noqa: F401
         get_dataset_tags,  # noqa: F401
         get_discussion_details,  # noqa: F401
@@ -527,11 +539,14 @@ if TYPE_CHECKING:  # pragma: no cover
         get_inference_endpoint,  # noqa: F401
         get_model_tags,  # noqa: F401
         get_paths_info,  # noqa: F401
+        get_pending_access_requests,  # noqa: F401
+        get_rejected_access_requests,  # noqa: F401
         get_repo_discussions,  # noqa: F401
         get_safetensors_metadata,  # noqa: F401
         get_space_runtime,  # noqa: F401
         get_space_variables,  # noqa: F401
         get_token_permission,  # noqa: F401
+        grant_access,  # noqa: F401
         like,  # noqa: F401
         list_collections,  # noqa: F401
         list_datasets,  # noqa: F401
@@ -553,6 +568,7 @@ if TYPE_CHECKING:  # pragma: no cover
         pause_inference_endpoint,  # noqa: F401
         pause_space,  # noqa: F401
         preupload_lfs_files,  # noqa: F401
+        reject_access_request,  # noqa: F401
         rename_discussion,  # noqa: F401
         repo_exists,  # noqa: F401
         repo_info,  # noqa: F401

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -324,6 +324,35 @@ class CommitInfo:
             self.pr_num = None
 
 
+@dataclass
+class AccessRequest:
+    """Data structure containing information about a user access request.
+
+    Attributes:
+        username (`str`):
+            Username of the user who requested access.
+        fullname (`str`):
+            Fullname of the user who requested access.
+        email (`str`):
+            Email of the user who requested access.
+        timestamp (`datetime`):
+            Timestamp of the request.
+        status (`Literal["pending", "accepted", "rejected"]`):
+            Status of the request. Can be one of `["pending", "accepted", "rejected"]`.
+        fields (`Dict[str, str]`, *optional*):
+            Additional fields filled by the user in the gate form.
+    """
+
+    username: str
+    fullname: str
+    email: str
+    timestamp: datetime
+    status: Literal["pending", "accepted", "rejected"]
+
+    # Additional fields filled by the user in the gate form
+    fields: Optional[Dict[str, str]] = None
+
+
 class RepoUrl(str):
     """Subclass of `str` describing a repo URL on the Hub.
 
@@ -7655,6 +7684,355 @@ class HfApi:
             else:
                 raise
 
+    ##########################
+    # Manage access requests #
+    ##########################
+
+    @validate_hf_hub_args
+    def get_pending_access_requests(
+        self, repo_id: str, *, repo_type: Optional[str] = None, token: Optional[str] = None
+    ) -> List[AccessRequest]:
+        """
+        Get pending access requests for a given gated repo.
+
+        A pending request means the user has requested access to the repo but the request has not been processed yet.
+        If the approval mode is automatic, this list should be empty. Pending requests can be accepted or rejected
+        using [`accept_access_request`] and [`reject_access_request`].
+
+        For more info about gated repos, see https://huggingface.co/docs/hub/models-gated.
+
+        Args:
+            repo_id (`str`):
+                The id of the repo to get access requests for.
+            repo_type (`str`, *optional*):
+                The type of the repo to get access requests for. Must be one of `model`, `dataset` or `space`.
+                Defaults to `model`.
+            token (`str`, *optional*):
+                A valid authentication token (see https://huggingface.co/settings/token).
+
+        Returns:
+            `List[AccessRequest]`: a list of [`AccessRequest`] objects. Each time contains a `username`, `email`,
+            `status` and `timestamp` attribute. If the gated repo has a custom form, the `fields` attribute will
+            be populated with user's answers.
+
+        Example:
+        ```py
+        >>> from huggingface_hub import get_pending_access_requests, accept_access_request
+
+        # List pending requests
+        >>> requests = get_pending_access_requests("meta-llama/Llama-2-7b")
+        >>> len(requests)
+        411
+        >>> requests[0]
+        [
+            AccessRequest(
+                username='clem',
+                fullname='Clem 🤗',
+                email='***',
+                timestamp=datetime.datetime(2023, 11, 23, 18, 4, 53, 828000, tzinfo=datetime.timezone.utc),
+                status='pending',
+                fields=None,
+            ),
+            ...
+        ]
+
+        # Accept Clem's request
+        >>> accept_access_request("meta-llama/Llama-2-7b", "clem")
+        ```
+        """
+        return self._get_access_requests(repo_id, "pending", repo_type=repo_type, token=token)
+
+    @validate_hf_hub_args
+    def get_accepted_access_requests(
+        self, repo_id: str, *, repo_type: Optional[str] = None, token: Optional[str] = None
+    ) -> List[AccessRequest]:
+        """
+        Get accepted access requests for a given gated repo.
+
+        An accepted request means the user has requested access to the repo and the request has been accepted. The user
+        can download any file of the repo and access the community tab. If the approval mode is automatic, this list
+        should contains by default all requests. Accepted requests can be cancelled or rejected at any time using
+        [`cancel_access_request`] and [`reject_access_request`]. A cancelled request will go back to the pending list
+        while a rejected request will go to the rejected list. In both cases, the user will lose access to the repo.
+
+        For more info about gated repos, see https://huggingface.co/docs/hub/models-gated.
+
+        Args:
+            repo_id (`str`):
+                The id of the repo to get access requests for.
+            repo_type (`str`, *optional*):
+                The type of the repo to get access requests for. Must be one of `model`, `dataset` or `space`.
+                Defaults to `model`.
+            token (`str`, *optional*):
+                A valid authentication token (see https://huggingface.co/settings/token).
+
+        Returns:
+            `List[AccessRequest]`: a list of [`AccessRequest`] objects. Each time contains a `username`, `email`,
+            `status` and `timestamp` attribute. If the gated repo has a custom form, the `fields` attribute will
+            be populated with user's answers.
+
+        Example:
+        ```py
+        >>> from huggingface_hub import get_accepted_access_requests
+
+        >>> requests = get_accepted_access_requests("meta-llama/Llama-2-7b")
+        >>> len(requests)
+        411
+        >>> requests[0]
+        [
+            AccessRequest(
+                username='clem',
+                fullname='Clem 🤗',
+                email='***',
+                timestamp=datetime.datetime(2023, 11, 23, 18, 4, 53, 828000, tzinfo=datetime.timezone.utc),
+                status='accepted',
+                fields=None,
+            ),
+            ...
+        ]
+        ```
+        """
+        return self._get_access_requests(repo_id, "accepted", repo_type=repo_type, token=token)
+
+    @validate_hf_hub_args
+    def get_rejected_access_requests(
+        self, repo_id: str, *, repo_type: Optional[str] = None, token: Optional[str] = None
+    ) -> List[AccessRequest]:
+        """
+        Get rejected access requests for a given gated repo.
+
+        A rejected request means the user has requested access to the repo and the request has been explicitly rejected
+        by a repo owner (either you or another user from your organization). The user cannot download any file of the
+        repo and cannot access the community tab. Rejected requests can be accepted or cancelled at any time using
+        [`accept_access_request`] and [`cancel_access_request`]. A cancelled request will go back to the pending list
+        while an accepted request will go to the accepted list.
+
+        For more info about gated repos, see https://huggingface.co/docs/hub/models-gated.
+
+        Args:
+            repo_id (`str`):
+                The id of the repo to get access requests for.
+            repo_type (`str`, *optional*):
+                The type of the repo to get access requests for. Must be one of `model`, `dataset` or `space`.
+                Defaults to `model`.
+            token (`str`, *optional*):
+                A valid authentication token (see https://huggingface.co/settings/token).
+
+        Returns:
+            `List[AccessRequest]`: a list of [`AccessRequest`] objects. Each time contains a `username`, `email`,
+            `status` and `timestamp` attribute. If the gated repo has a custom form, the `fields` attribute will
+            be populated with user's answers.
+
+        Example:
+        ```py
+        >>> from huggingface_hub import get_rejected_access_requests
+
+        >>> requests = get_rejected_access_requests("meta-llama/Llama-2-7b")
+        >>> len(requests)
+        411
+        >>> requests[0]
+        [
+            AccessRequest(
+                username='clem',
+                fullname='Clem 🤗',
+                email='***',
+                timestamp=datetime.datetime(2023, 11, 23, 18, 4, 53, 828000, tzinfo=datetime.timezone.utc),
+                status='rejected',
+                fields=None,
+            ),
+            ...
+        ]
+        ```
+        """
+        return self._get_access_requests(repo_id, "rejected", repo_type=repo_type, token=token)
+
+    def _get_access_requests(
+        self,
+        repo_id: str,
+        status: Literal["accepted", "rejected", "pending"],
+        repo_type: Optional[str] = None,
+        token: Optional[str] = None,
+    ) -> List[AccessRequest]:
+        if repo_type not in REPO_TYPES:
+            raise ValueError(f"Invalid repo type, must be one of {REPO_TYPES}")
+        if repo_type is None:
+            repo_type = REPO_TYPE_MODEL
+
+        response = get_session().get(
+            f"{ENDPOINT}/api/{repo_type}s/{repo_id}/user-access-request/{status}",
+            headers=self._build_hf_headers(token=token),
+        )
+        hf_raise_for_status(response)
+        return [
+            AccessRequest(
+                username=request["user"]["user"],
+                fullname=request["user"]["fullname"],
+                email=request["user"]["email"],
+                status=request["status"],
+                timestamp=parse_datetime(request["timestamp"]),
+                fields=request.get("fields"),  # only if custom fields in form
+            )
+            for request in response.json()
+        ]
+
+    @validate_hf_hub_args
+    def cancel_access_request(
+        self, repo_id: str, user: str, *, repo_type: Optional[str] = None, token: Optional[str] = None
+    ) -> None:
+        """
+        Cancel an access request from a user for a given gated repo.
+
+        A cancelled request will go back to the pending list and the user will lose access to the repo.
+
+        For more info about gated repos, see https://huggingface.co/docs/hub/models-gated.
+
+        Args:
+            repo_id (`str`):
+                The id of the repo to cancel access request for.
+            user (`str`):
+                The username of the user which access request should be cancelled.
+            repo_type (`str`, *optional*):
+                The type of the repo to cancel access request for. Must be one of `model`, `dataset` or `space`.
+                Defaults to `model`.
+            token (`str`, *optional*):
+                A valid authentication token (see https://huggingface.co/settings/token).
+
+        Raises:
+            - `HTTPError`: HTTP 404 if the user does not exist on the Hub.
+            - `HTTPError`: HTTP 404 if the user access request cannot be found.
+            - `HTTPError`: HTTP 404 if the user access request is already in the pending list.
+        """
+        self._handle_access_request(repo_id, user, "pending", repo_type=repo_type, token=token)
+
+    @validate_hf_hub_args
+    def accept_access_request(
+        self, repo_id: str, user: str, *, repo_type: Optional[str] = None, token: Optional[str] = None
+    ) -> None:
+        """
+        Accept an access request from a user for a given gated repo.
+
+        Once the request is accepted, the user will be able to download any file of the repo and access the community
+        tab. If the approval mode is automatic, you don't have to accept requests manually. An accepted request can be
+        cancelled or rejected at any time using [`cancel_access_request`] and [`reject_access_request`].
+
+        For more info about gated repos, see https://huggingface.co/docs/hub/models-gated.
+
+        Args:
+            repo_id (`str`):
+                The id of the repo to accept access request for.
+            user (`str`):
+                The username of the user which access request should be accepted.
+            repo_type (`str`, *optional*):
+                The type of the repo to accept access request for. Must be one of `model`, `dataset` or `space`.
+                Defaults to `model`.
+            token (`str`, *optional*):
+                A valid authentication token (see https://huggingface.co/settings/token).
+
+        Raises:
+            - `HTTPError`: HTTP 404 if the user does not exist on the Hub.
+            - `HTTPError`: HTTP 404 if the user access request cannot be found.
+            - `HTTPError`: HTTP 404 if the user access request is already in the accepted list.
+        """
+        self._handle_access_request(repo_id, user, "accepted", repo_type=repo_type, token=token)
+
+    @validate_hf_hub_args
+    def reject_access_request(
+        self, repo_id: str, user: str, *, repo_type: Optional[str] = None, token: Optional[str] = None
+    ) -> None:
+        """
+        Reject an access request from a user for a given gated repo.
+
+        A rejected request will go to the rejected list. The user cannot download any file of the repo and cannot access
+        the community tab. Rejected requests can be accepted or cancelled at any time using [`accept_access_request`]
+        and [`cancel_access_request`]. A cancelled request will go back to the pending list while an accepted request
+        will go to the accepted list.
+
+        For more info about gated repos, see https://huggingface.co/docs/hub/models-gated.
+
+        Args:
+            repo_id (`str`):
+                The id of the repo to reject access request for.
+            user (`str`):
+                The username of the user which access request should be rejected.
+            repo_type (`str`, *optional*):
+                The type of the repo to reject access request for. Must be one of `model`, `dataset` or `space`.
+                Defaults to `model`.
+            token (`str`, *optional*):
+                A valid authentication token (see https://huggingface.co/settings/token).
+
+        Raises:
+            - `HTTPError`: HTTP 404 if the user does not exist on the Hub.
+            - `HTTPError`: HTTP 404 if the user access request cannot be found.
+            - `HTTPError`: HTTP 404 if the user access request is already in the rejected list.
+        """
+        self._handle_access_request(repo_id, user, "rejected", repo_type=repo_type, token=token)
+
+    @validate_hf_hub_args
+    def _handle_access_request(
+        self,
+        repo_id: str,
+        user: str,
+        status: Literal["accepted", "rejected", "pending"],
+        repo_type: Optional[str] = None,
+        token: Optional[str] = None,
+    ) -> None:
+        if repo_type not in REPO_TYPES:
+            raise ValueError(f"Invalid repo type, must be one of {REPO_TYPES}")
+        if repo_type is None:
+            repo_type = REPO_TYPE_MODEL
+
+        response = get_session().post(
+            f"{ENDPOINT}/api/{repo_type}s/{repo_id}/user-access-request/handle",
+            headers=self._build_hf_headers(token=token),
+            json={"user": user, "status": status},
+        )
+        hf_raise_for_status(response)
+
+    @validate_hf_hub_args
+    def grant_access(
+        self, repo_id: str, user: str, *, repo_type: Optional[str] = None, token: Optional[str] = None
+    ) -> None:
+        """
+        Grant access to a user for a given gated repo.
+
+        Granting access don't require for the user to send an access request by themselves. The user is automatically
+        added to the accepted list meaning they can download the files and access the community tab. You can revoke
+        the granted access at any time using [`cancel_access_request`] or [`reject_access_request`].
+
+        For more info about gated repos, see https://huggingface.co/docs/hub/models-gated.
+
+        Args:
+            repo_id (`str`):
+                The id of the repo to grant access to.
+            user (`str`):
+                The username of the user to grant access.
+            repo_type (`str`, *optional*):
+                The type of the repo to grant access to. Must be one of `model`, `dataset` or `space`.
+                Defaults to `model`.
+            token (`str`, *optional*):
+                A valid authentication token (see https://huggingface.co/settings/token).
+
+        Raises:
+            - `HTTPError`: HTTP 404 if the user does not exist on the Hub.
+            - `BadRequestError`: HTTP 400 if the user already has access to the repo.
+        """
+        if repo_type not in REPO_TYPES:
+            raise ValueError(f"Invalid repo type, must be one of {REPO_TYPES}")
+        if repo_type is None:
+            repo_type = REPO_TYPE_MODEL
+
+        response = get_session().post(
+            f"{ENDPOINT}/api/models/{repo_id}/user-access-request/grant",
+            headers=self._build_hf_headers(token=token),
+            json={"user": user},
+        )
+        hf_raise_for_status(response)
+        return response.json()
+
+    #############
+    # Internals #
+    #############
+
     def _build_hf_headers(
         self,
         token: Optional[Union[bool, str]] = None,
@@ -7876,3 +8254,12 @@ add_collection_item = api.add_collection_item
 update_collection_item = api.update_collection_item
 delete_collection_item = api.delete_collection_item
 delete_collection_item = api.delete_collection_item
+
+# Access requests API
+get_pending_access_requests = api.get_pending_access_requests
+get_accepted_access_requests = api.get_accepted_access_requests
+get_rejected_access_requests = api.get_rejected_access_requests
+cancel_access_request = api.cancel_access_request
+accept_access_request = api.accept_access_request
+reject_access_request = api.reject_access_request
+grant_access = api.grant_access

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -7689,7 +7689,7 @@ class HfApi:
     ##########################
 
     @validate_hf_hub_args
-    def get_pending_access_requests(
+    def list_pending_access_requests(
         self, repo_id: str, *, repo_type: Optional[str] = None, token: Optional[str] = None
     ) -> List[AccessRequest]:
         """
@@ -7715,12 +7715,15 @@ class HfApi:
             `status` and `timestamp` attribute. If the gated repo has a custom form, the `fields` attribute will
             be populated with user's answers.
 
+        Raises:
+            `HTTPError`: HTTP 400 if the repo is not gated.
+
         Example:
         ```py
-        >>> from huggingface_hub import get_pending_access_requests, accept_access_request
+        >>> from huggingface_hub import list_pending_access_requests, accept_access_request
 
         # List pending requests
-        >>> requests = get_pending_access_requests("meta-llama/Llama-2-7b")
+        >>> requests = list_pending_access_requests("meta-llama/Llama-2-7b")
         >>> len(requests)
         411
         >>> requests[0]
@@ -7740,10 +7743,10 @@ class HfApi:
         >>> accept_access_request("meta-llama/Llama-2-7b", "clem")
         ```
         """
-        return self._get_access_requests(repo_id, "pending", repo_type=repo_type, token=token)
+        return self._list_access_requests(repo_id, "pending", repo_type=repo_type, token=token)
 
     @validate_hf_hub_args
-    def get_accepted_access_requests(
+    def list_accepted_access_requests(
         self, repo_id: str, *, repo_type: Optional[str] = None, token: Optional[str] = None
     ) -> List[AccessRequest]:
         """
@@ -7771,11 +7774,14 @@ class HfApi:
             `status` and `timestamp` attribute. If the gated repo has a custom form, the `fields` attribute will
             be populated with user's answers.
 
+        Raises:
+            `HTTPError`: HTTP 400 if the repo is not gated.
+
         Example:
         ```py
-        >>> from huggingface_hub import get_accepted_access_requests
+        >>> from huggingface_hub import list_accepted_access_requests
 
-        >>> requests = get_accepted_access_requests("meta-llama/Llama-2-7b")
+        >>> requests = list_accepted_access_requests("meta-llama/Llama-2-7b")
         >>> len(requests)
         411
         >>> requests[0]
@@ -7792,10 +7798,10 @@ class HfApi:
         ]
         ```
         """
-        return self._get_access_requests(repo_id, "accepted", repo_type=repo_type, token=token)
+        return self._list_access_requests(repo_id, "accepted", repo_type=repo_type, token=token)
 
     @validate_hf_hub_args
-    def get_rejected_access_requests(
+    def list_rejected_access_requests(
         self, repo_id: str, *, repo_type: Optional[str] = None, token: Optional[str] = None
     ) -> List[AccessRequest]:
         """
@@ -7818,6 +7824,9 @@ class HfApi:
             token (`str`, *optional*):
                 A valid authentication token (see https://huggingface.co/settings/token).
 
+        Raises:
+            `HTTPError`: HTTP 400 if the repo is not gated.
+
         Returns:
             `List[AccessRequest]`: a list of [`AccessRequest`] objects. Each time contains a `username`, `email`,
             `status` and `timestamp` attribute. If the gated repo has a custom form, the `fields` attribute will
@@ -7825,9 +7834,9 @@ class HfApi:
 
         Example:
         ```py
-        >>> from huggingface_hub import get_rejected_access_requests
+        >>> from huggingface_hub import list_rejected_access_requests
 
-        >>> requests = get_rejected_access_requests("meta-llama/Llama-2-7b")
+        >>> requests = list_rejected_access_requests("meta-llama/Llama-2-7b")
         >>> len(requests)
         411
         >>> requests[0]
@@ -7844,9 +7853,9 @@ class HfApi:
         ]
         ```
         """
-        return self._get_access_requests(repo_id, "rejected", repo_type=repo_type, token=token)
+        return self._list_access_requests(repo_id, "rejected", repo_type=repo_type, token=token)
 
-    def _get_access_requests(
+    def _list_access_requests(
         self,
         repo_id: str,
         status: Literal["accepted", "rejected", "pending"],
@@ -7898,6 +7907,7 @@ class HfApi:
                 A valid authentication token (see https://huggingface.co/settings/token).
 
         Raises:
+            - `HTTPError`: HTTP 400 if the repo is not gated.
             - `HTTPError`: HTTP 404 if the user does not exist on the Hub.
             - `HTTPError`: HTTP 404 if the user access request cannot be found.
             - `HTTPError`: HTTP 404 if the user access request is already in the pending list.
@@ -7929,6 +7939,7 @@ class HfApi:
                 A valid authentication token (see https://huggingface.co/settings/token).
 
         Raises:
+            - `HTTPError`: HTTP 400 if the repo is not gated.
             - `HTTPError`: HTTP 404 if the user does not exist on the Hub.
             - `HTTPError`: HTTP 404 if the user access request cannot be found.
             - `HTTPError`: HTTP 404 if the user access request is already in the accepted list.
@@ -7961,6 +7972,7 @@ class HfApi:
                 A valid authentication token (see https://huggingface.co/settings/token).
 
         Raises:
+            - `HTTPError`: HTTP 400 if the repo is not gated.
             - `HTTPError`: HTTP 404 if the user does not exist on the Hub.
             - `HTTPError`: HTTP 404 if the user access request cannot be found.
             - `HTTPError`: HTTP 404 if the user access request is already in the rejected list.
@@ -8013,6 +8025,7 @@ class HfApi:
                 A valid authentication token (see https://huggingface.co/settings/token).
 
         Raises:
+            - `HTTPError`: HTTP 400 if the repo is not gated.
             - `HTTPError`: HTTP 404 if the user does not exist on the Hub.
             - `BadRequestError`: HTTP 400 if the user already has access to the repo.
         """
@@ -8256,9 +8269,9 @@ delete_collection_item = api.delete_collection_item
 delete_collection_item = api.delete_collection_item
 
 # Access requests API
-get_pending_access_requests = api.get_pending_access_requests
-get_accepted_access_requests = api.get_accepted_access_requests
-get_rejected_access_requests = api.get_rejected_access_requests
+list_pending_access_requests = api.list_pending_access_requests
+list_accepted_access_requests = api.list_accepted_access_requests
+list_rejected_access_requests = api.list_rejected_access_requests
 cancel_access_request = api.cancel_access_request
 accept_access_request = api.accept_access_request
 reject_access_request = api.reject_access_request

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -339,7 +339,7 @@ class AccessRequest:
             Timestamp of the request.
         status (`Literal["pending", "accepted", "rejected"]`):
             Status of the request. Can be one of `["pending", "accepted", "rejected"]`.
-        fields (`Dict[str, str]`, *optional*):
+        fields (`Dict[str, Any]`, *optional*):
             Additional fields filled by the user in the gate form.
     """
 
@@ -350,7 +350,7 @@ class AccessRequest:
     status: Literal["pending", "accepted", "rejected"]
 
     # Additional fields filled by the user in the gate form
-    fields: Optional[Dict[str, str]] = None
+    fields: Optional[Dict[str, Any]] = None
 
 
 class RepoUrl(str):
@@ -7753,10 +7753,10 @@ class HfApi:
         Get accepted access requests for a given gated repo.
 
         An accepted request means the user has requested access to the repo and the request has been accepted. The user
-        can download any file of the repo and access the community tab. If the approval mode is automatic, this list
-        should contains by default all requests. Accepted requests can be cancelled or rejected at any time using
-        [`cancel_access_request`] and [`reject_access_request`]. A cancelled request will go back to the pending list
-        while a rejected request will go to the rejected list. In both cases, the user will lose access to the repo.
+        can download any file of the repo. If the approval mode is automatic, this list should contains by default all
+        requests. Accepted requests can be cancelled or rejected at any time using [`cancel_access_request`] and
+        [`reject_access_request`]. A cancelled request will go back to the pending list while a rejected request will
+        go to the rejected list. In both cases, the user will lose access to the repo.
 
         For more info about gated repos, see https://huggingface.co/docs/hub/models-gated.
 
@@ -7809,9 +7809,9 @@ class HfApi:
 
         A rejected request means the user has requested access to the repo and the request has been explicitly rejected
         by a repo owner (either you or another user from your organization). The user cannot download any file of the
-        repo and cannot access the community tab. Rejected requests can be accepted or cancelled at any time using
-        [`accept_access_request`] and [`cancel_access_request`]. A cancelled request will go back to the pending list
-        while an accepted request will go to the accepted list.
+        repo. Rejected requests can be accepted or cancelled at any time using [`accept_access_request`] and
+        [`cancel_access_request`]. A cancelled request will go back to the pending list while an accepted request will
+        go to the accepted list.
 
         For more info about gated repos, see https://huggingface.co/docs/hub/models-gated.
 
@@ -7953,10 +7953,9 @@ class HfApi:
         """
         Reject an access request from a user for a given gated repo.
 
-        A rejected request will go to the rejected list. The user cannot download any file of the repo and cannot access
-        the community tab. Rejected requests can be accepted or cancelled at any time using [`accept_access_request`]
-        and [`cancel_access_request`]. A cancelled request will go back to the pending list while an accepted request
-        will go to the accepted list.
+        A rejected request will go to the rejected list. The user cannot download any file of the repo. Rejected
+        requests can be accepted or cancelled at any time using [`accept_access_request`] and [`cancel_access_request`].
+        A cancelled request will go back to the pending list while an accepted request will go to the accepted list.
 
         For more info about gated repos, see https://huggingface.co/docs/hub/models-gated.
 
@@ -8008,8 +8007,8 @@ class HfApi:
         Grant access to a user for a given gated repo.
 
         Granting access don't require for the user to send an access request by themselves. The user is automatically
-        added to the accepted list meaning they can download the files and access the community tab. You can revoke
-        the granted access at any time using [`cancel_access_request`] or [`reject_access_request`].
+        added to the accepted list meaning they can download the files You can revoke the granted access at any time
+        using [`cancel_access_request`] or [`reject_access_request`].
 
         For more info about gated repos, see https://huggingface.co/docs/hub/models-gated.
 

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -7711,14 +7711,16 @@ class HfApi:
                 A valid authentication token (see https://huggingface.co/settings/token).
 
         Returns:
-            `List[AccessRequest]`: a list of [`AccessRequest`] objects. Each time contains a `username`, `email`,
+            `List[AccessRequest]`: A list of [`AccessRequest`] objects. Each time contains a `username`, `email`,
             `status` and `timestamp` attribute. If the gated repo has a custom form, the `fields` attribute will
             be populated with user's answers.
 
         Raises:
-            - `HTTPError`: HTTP 403 if you only have read-only access to the repo. This can be the case if you don't have
-                           `write` or `admin` role in the organization the repo belongs to or if you passed a `read` token.
-            - `HTTPError`: HTTP 400 if the repo is not gated.
+            `HTTPError`:
+                HTTP 400 if the repo is not gated.
+            `HTTPError`:
+                HTTP 403 if you only have read-only access to the repo. This can be the case if you don't have `write`
+                or `admin` role in the organization the repo belongs to or if you passed a `read` token.
 
         Example:
         ```py
@@ -7772,14 +7774,17 @@ class HfApi:
                 A valid authentication token (see https://huggingface.co/settings/token).
 
         Returns:
-            `List[AccessRequest]`: a list of [`AccessRequest`] objects. Each time contains a `username`, `email`,
+            `List[AccessRequest]`: A list of [`AccessRequest`] objects. Each time contains a `username`, `email`,
             `status` and `timestamp` attribute. If the gated repo has a custom form, the `fields` attribute will
             be populated with user's answers.
 
         Raises:
-            - `HTTPError`: HTTP 403 if you only have read-only access to the repo. This can be the case if you don't have
-                           `write` or `admin` role in the organization the repo belongs to or if you passed a `read` token.
-            - `HTTPError`: HTTP 400 if the repo is not gated.
+            `HTTPError`:
+                HTTP 400 if the repo is not gated.
+            `HTTPError`:
+                HTTP 403 if you only have read-only access to the repo. This can be the case if you don't have `write`
+                or `admin` role in the organization the repo belongs to or if you passed a `read` token.
+
         Example:
         ```py
         >>> from huggingface_hub import list_accepted_access_requests
@@ -7827,14 +7832,17 @@ class HfApi:
             token (`str`, *optional*):
                 A valid authentication token (see https://huggingface.co/settings/token).
 
-        Raises:
-            - `HTTPError`: HTTP 403 if you only have read-only access to the repo. This can be the case if you don't have
-                           `write` or `admin` role in the organization the repo belongs to or if you passed a `read` token.
-            - `HTTPError`: HTTP 400 if the repo is not gated.
         Returns:
-            `List[AccessRequest]`: a list of [`AccessRequest`] objects. Each time contains a `username`, `email`,
+            `List[AccessRequest]`: A list of [`AccessRequest`] objects. Each time contains a `username`, `email`,
             `status` and `timestamp` attribute. If the gated repo has a custom form, the `fields` attribute will
             be populated with user's answers.
+
+        Raises:
+            `HTTPError`:
+                HTTP 400 if the repo is not gated.
+            `HTTPError`:
+                HTTP 403 if you only have read-only access to the repo. This can be the case if you don't have `write`
+                or `admin` role in the organization the repo belongs to or if you passed a `read` token.
 
         Example:
         ```py
@@ -7911,12 +7919,17 @@ class HfApi:
                 A valid authentication token (see https://huggingface.co/settings/token).
 
         Raises:
-            - `HTTPError`: HTTP 400 if the repo is not gated.
-            - `HTTPError`: HTTP 403 if you only have read-only access to the repo. This can be the case if you don't have
-                           `write` or `admin` role in the organization the repo belongs to or if you passed a `read` token.
-            - `HTTPError`: HTTP 404 if the user does not exist on the Hub.
-            - `HTTPError`: HTTP 404 if the user access request cannot be found.
-            - `HTTPError`: HTTP 404 if the user access request is already in the pending list.
+            `HTTPError`:
+                HTTP 400 if the repo is not gated.
+            `HTTPError`:
+                HTTP 403 if you only have read-only access to the repo. This can be the case if you don't have `write`
+                or `admin` role in the organization the repo belongs to or if you passed a `read` token.
+            `HTTPError`:
+                HTTP 404 if the user does not exist on the Hub.
+            `HTTPError`:
+                HTTP 404 if the user access request cannot be found.
+            `HTTPError`:
+                HTTP 404 if the user access request is already in the pending list.
         """
         self._handle_access_request(repo_id, user, "pending", repo_type=repo_type, token=token)
 
@@ -7945,12 +7958,17 @@ class HfApi:
                 A valid authentication token (see https://huggingface.co/settings/token).
 
         Raises:
-            - `HTTPError`: HTTP 400 if the repo is not gated.
-            - `HTTPError`: HTTP 403 if you only have read-only access to the repo. This can be the case if you don't have
-                           `write` or `admin` role in the organization the repo belongs to or if you passed a `read` token.
-            - `HTTPError`: HTTP 404 if the user does not exist on the Hub.
-            - `HTTPError`: HTTP 404 if the user access request cannot be found.
-            - `HTTPError`: HTTP 404 if the user access request is already in the accepted list.
+            `HTTPError`:
+                HTTP 400 if the repo is not gated.
+            `HTTPError`:
+                HTTP 403 if you only have read-only access to the repo. This can be the case if you don't have `write`
+                or `admin` role in the organization the repo belongs to or if you passed a `read` token.
+            `HTTPError`:
+                HTTP 404 if the user does not exist on the Hub.
+            `HTTPError`:
+                HTTP 404 if the user access request cannot be found.
+            `HTTPError`:
+                HTTP 404 if the user access request is already in the accepted list.
         """
         self._handle_access_request(repo_id, user, "accepted", repo_type=repo_type, token=token)
 
@@ -7979,12 +7997,17 @@ class HfApi:
                 A valid authentication token (see https://huggingface.co/settings/token).
 
         Raises:
-            - `HTTPError`: HTTP 400 if the repo is not gated.
-            - `HTTPError`: HTTP 403 if you only have read-only access to the repo. This can be the case if you don't have
-                           `write` or `admin` role in the organization the repo belongs to or if you passed a `read` token.
-            - `HTTPError`: HTTP 404 if the user does not exist on the Hub.
-            - `HTTPError`: HTTP 404 if the user access request cannot be found.
-            - `HTTPError`: HTTP 404 if the user access request is already in the rejected list.
+            `HTTPError`:
+                HTTP 400 if the repo is not gated.
+            `HTTPError`:
+                HTTP 403 if you only have read-only access to the repo. This can be the case if you don't have `write`
+                or `admin` role in the organization the repo belongs to or if you passed a `read` token.
+            `HTTPError`:
+                HTTP 404 if the user does not exist on the Hub.
+            `HTTPError`:
+                HTTP 404 if the user access request cannot be found.
+            `HTTPError`:
+                HTTP 404 if the user access request is already in the rejected list.
         """
         self._handle_access_request(repo_id, user, "rejected", repo_type=repo_type, token=token)
 
@@ -8034,11 +8057,15 @@ class HfApi:
                 A valid authentication token (see https://huggingface.co/settings/token).
 
         Raises:
-            - `BadRequestError`: HTTP 400 if the repo is not gated.
-            - `BadRequestError`: HTTP 400 if the user already has access to the repo.
-            - `HTTPError`: HTTP 403 if you only have read-only access to the repo. This can be the case if you don't have
-                           `write` or `admin` role in the organization the repo belongs to or if you passed a `read` token.
-            - `HTTPError`: HTTP 404 if the user does not exist on the Hub.
+            `HTTPError`:
+                HTTP 400 if the repo is not gated.
+            `HTTPError`:
+                HTTP 400 if the user already has access to the repo.
+            `HTTPError`:
+                HTTP 403 if you only have read-only access to the repo. This can be the case if you don't have `write`
+                or `admin` role in the organization the repo belongs to or if you passed a `read` token.
+            `HTTPError`:
+                HTTP 404 if the user does not exist on the Hub.
         """
         if repo_type not in REPO_TYPES:
             raise ValueError(f"Invalid repo type, must be one of {REPO_TYPES}")

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -7716,7 +7716,9 @@ class HfApi:
             be populated with user's answers.
 
         Raises:
-            `HTTPError`: HTTP 400 if the repo is not gated.
+            - `HTTPError`: HTTP 403 if you only have read-only access to the repo. This can be the case if you don't have
+                           `write` or `admin` role in the organization the repo belongs to or if you passed a `read` token.
+            - `HTTPError`: HTTP 400 if the repo is not gated.
 
         Example:
         ```py
@@ -7775,8 +7777,9 @@ class HfApi:
             be populated with user's answers.
 
         Raises:
-            `HTTPError`: HTTP 400 if the repo is not gated.
-
+            - `HTTPError`: HTTP 403 if you only have read-only access to the repo. This can be the case if you don't have
+                           `write` or `admin` role in the organization the repo belongs to or if you passed a `read` token.
+            - `HTTPError`: HTTP 400 if the repo is not gated.
         Example:
         ```py
         >>> from huggingface_hub import list_accepted_access_requests
@@ -7825,8 +7828,9 @@ class HfApi:
                 A valid authentication token (see https://huggingface.co/settings/token).
 
         Raises:
-            `HTTPError`: HTTP 400 if the repo is not gated.
-
+            - `HTTPError`: HTTP 403 if you only have read-only access to the repo. This can be the case if you don't have
+                           `write` or `admin` role in the organization the repo belongs to or if you passed a `read` token.
+            - `HTTPError`: HTTP 400 if the repo is not gated.
         Returns:
             `List[AccessRequest]`: a list of [`AccessRequest`] objects. Each time contains a `username`, `email`,
             `status` and `timestamp` attribute. If the gated repo has a custom form, the `fields` attribute will
@@ -7908,6 +7912,8 @@ class HfApi:
 
         Raises:
             - `HTTPError`: HTTP 400 if the repo is not gated.
+            - `HTTPError`: HTTP 403 if you only have read-only access to the repo. This can be the case if you don't have
+                           `write` or `admin` role in the organization the repo belongs to or if you passed a `read` token.
             - `HTTPError`: HTTP 404 if the user does not exist on the Hub.
             - `HTTPError`: HTTP 404 if the user access request cannot be found.
             - `HTTPError`: HTTP 404 if the user access request is already in the pending list.
@@ -7940,6 +7946,8 @@ class HfApi:
 
         Raises:
             - `HTTPError`: HTTP 400 if the repo is not gated.
+            - `HTTPError`: HTTP 403 if you only have read-only access to the repo. This can be the case if you don't have
+                           `write` or `admin` role in the organization the repo belongs to or if you passed a `read` token.
             - `HTTPError`: HTTP 404 if the user does not exist on the Hub.
             - `HTTPError`: HTTP 404 if the user access request cannot be found.
             - `HTTPError`: HTTP 404 if the user access request is already in the accepted list.
@@ -7972,6 +7980,8 @@ class HfApi:
 
         Raises:
             - `HTTPError`: HTTP 400 if the repo is not gated.
+            - `HTTPError`: HTTP 403 if you only have read-only access to the repo. This can be the case if you don't have
+                           `write` or `admin` role in the organization the repo belongs to or if you passed a `read` token.
             - `HTTPError`: HTTP 404 if the user does not exist on the Hub.
             - `HTTPError`: HTTP 404 if the user access request cannot be found.
             - `HTTPError`: HTTP 404 if the user access request is already in the rejected list.
@@ -8024,9 +8034,11 @@ class HfApi:
                 A valid authentication token (see https://huggingface.co/settings/token).
 
         Raises:
-            - `HTTPError`: HTTP 400 if the repo is not gated.
-            - `HTTPError`: HTTP 404 if the user does not exist on the Hub.
+            - `BadRequestError`: HTTP 400 if the repo is not gated.
             - `BadRequestError`: HTTP 400 if the user already has access to the repo.
+            - `HTTPError`: HTTP 403 if you only have read-only access to the repo. This can be the case if you don't have
+                           `write` or `admin` role in the organization the repo belongs to or if you passed a `read` token.
+            - `HTTPError`: HTTP 404 if the user does not exist on the Hub.
         """
         if repo_type not in REPO_TYPES:
             raise ValueError(f"Invalid repo type, must be one of {REPO_TYPES}")

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -36,7 +36,7 @@ import requests
 from requests.exceptions import HTTPError
 
 import huggingface_hub.lfs
-from huggingface_hub import SpaceHardware, SpaceStage, SpaceStorage
+from huggingface_hub import AccessRequest, SpaceHardware, SpaceStage, SpaceStorage
 from huggingface_hub._commit_api import (
     CommitOperationAdd,
     CommitOperationCopy,
@@ -77,6 +77,8 @@ from huggingface_hub.utils import (
     SafetensorsRepoMetadata,
     SoftTemporaryDirectory,
     TensorInfo,
+    get_session,
+    hf_raise_for_status,
     logging,
 )
 from huggingface_hub.utils.endpoint_helpers import (
@@ -3668,3 +3670,85 @@ class CollectionAPITest(HfApiCommonTest):
         self._api.delete_repo(model_id)
         self._api.delete_repo(dataset_id, repo_type="dataset")
         self._api.delete_collection(collection.slug)
+
+
+class AccessRequestAPITest(HfApiCommonTest):
+    def setUp(self) -> None:
+        # Setup test with a gated repo
+        super().setUp()
+        self.repo_id = self._api.create_repo(repo_name()).repo_id
+        response = get_session().put(
+            f"{self._api.endpoint}/api/models/{self.repo_id}/settings",
+            json={"gated": "auto"},
+            headers=self._api._build_hf_headers(),
+        )
+        hf_raise_for_status(response)
+
+    def tearDown(self) -> None:
+        self._api.delete_repo(self.repo_id)
+        return super().tearDown()
+
+    def test_access_requests_normal_usage(self) -> None:
+        # No access requests initially
+        requests = self._api.list_accepted_access_requests(self.repo_id)
+        assert len(requests) == 0
+        requests = self._api.list_pending_access_requests(self.repo_id)
+        assert len(requests) == 0
+        requests = self._api.list_rejected_access_requests(self.repo_id)
+        assert len(requests) == 0
+
+        # Grant access to a user
+        self._api.grant_access(self.repo_id, OTHER_USER)
+
+        # User is in accepted list
+        requests = self._api.list_accepted_access_requests(self.repo_id)
+        assert len(requests) == 1
+        request = requests[0]
+        assert isinstance(request, AccessRequest)
+        assert request.username == OTHER_USER
+        assert request.status == "accepted"
+        assert isinstance(request.timestamp, datetime.datetime)
+
+        # Cancel access
+        self._api.cancel_access_request(self.repo_id, OTHER_USER)
+        requests = self._api.list_accepted_access_requests(self.repo_id)
+        assert len(requests) == 0  # not accepted anymore
+        requests = self._api.list_pending_access_requests(self.repo_id)
+        assert len(requests) == 1
+        assert requests[0].username == OTHER_USER
+
+        # Reject access
+        self._api.reject_access_request(self.repo_id, OTHER_USER)
+        requests = self._api.list_pending_access_requests(self.repo_id)
+        assert len(requests) == 0  # not pending anymore
+        requests = self._api.list_rejected_access_requests(self.repo_id)
+        assert len(requests) == 1
+        assert requests[0].username == OTHER_USER
+
+        # Accept again
+        self._api.accept_access_request(self.repo_id, OTHER_USER)
+        requests = self._api.list_accepted_access_requests(self.repo_id)
+        assert len(requests) == 1
+        assert requests[0].username == OTHER_USER
+
+    def test_access_request_error(self):
+        # Grant access to a user
+        self._api.grant_access(self.repo_id, OTHER_USER)
+
+        # Cannot grant twice
+        with self.assertRaises(HTTPError):
+            self._api.grant_access(self.repo_id, OTHER_USER)
+
+        # Cannot accept to already accepted
+        with self.assertRaises(HTTPError):
+            self._api.accept_access_request(self.repo_id, OTHER_USER)
+
+        # Cannot reject to already rejected
+        self._api.reject_access_request(self.repo_id, OTHER_USER)
+        with self.assertRaises(HTTPError):
+            self._api.reject_access_request(self.repo_id, OTHER_USER)
+
+        # Cannot cancel to already cancelled
+        self._api.cancel_access_request(self.repo_id, OTHER_USER)
+        with self.assertRaises(HTTPError):
+            self._api.cancel_access_request(self.repo_id, OTHER_USER)

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -36,7 +36,7 @@ import requests
 from requests.exceptions import HTTPError
 
 import huggingface_hub.lfs
-from huggingface_hub import AccessRequest, SpaceHardware, SpaceStage, SpaceStorage
+from huggingface_hub import SpaceHardware, SpaceStage, SpaceStorage
 from huggingface_hub._commit_api import (
     CommitOperationAdd,
     CommitOperationCopy,
@@ -52,6 +52,7 @@ from huggingface_hub.constants import (
 )
 from huggingface_hub.file_download import hf_hub_download
 from huggingface_hub.hf_api import (
+    AccessRequest,
     Collection,
     CommitInfo,
     DatasetInfo,


### PR DESCRIPTION
Solves https://github.com/huggingface/huggingface_hub/issues/1535.

Let's add official support to programmatically manage access requests for gated repos.

The API defines a `AccessRequest` dataclass with username, email, status, timestamp and fields + 7 endpoints. I reused as much as possible the vocabulary used in the UI. We have:
- `list_pending_access_requests` => returns "pending" list
- `list_accepted_access_requests` => returns "accepted" list
- `list_rejected_access_requests` => returns "rejected" list
- `cancel_access_request` => moves request to "pending" list
- `accept_access_request` => moves request to "accepted" list  
- `reject_access_request` => moves request to "rejected" list
- `grant_access` => add a user to "accepted" list (the user doesn't have to request access first)

Methods docstrings are documented with examples. I don't think it's worth creating a guide dedicated to it in `huggingface_hub` as it would be quite redundant with the Hub docs already. I suggest to update the Hub docs instead to mention the `huggingface_hub` implementation but that's it. 

TODO:
- [ ] update https://huggingface.co/docs/hub/models-gated and https://huggingface.co/docs/hub/datasets-gated once this PR is shipped