### PR TITLE
Rerun flaky tests in CI

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Run tests
         working-directory: ./src # For code coverage to work
         run: |
-          PYTEST="python -m pytest --cov=./huggingface_hub --cov-report=xml:../coverage.xml --vcr-record=none"
+          PYTEST="python -m pytest --cov=./huggingface_hub --cov-report=xml:../coverage.xml --vcr-record=none --reruns 5 --reruns-delay 1 --only-rerun "(OSError|Timeout|HTTPError.*502|HTTPError.*504)""
 
           case "${{ matrix.test_name }}" in
 
@@ -166,7 +166,8 @@ jobs:
         run: python -m pytest \
                --cov=./huggingface_hub --cov-report=xml:../coverage.xml \
                --vcr-record=none \
-               --reruns 5 --reruns-delay 1 --only-rerun "(OSError|Timeout|HTTPError.*502|HTTPError.*504)" ../tests
+               --reruns 5 --reruns-delay 1 --only-rerun "(OSError|Timeout|HTTPError.*502|HTTPError.*504)" \
+               ../tests
 
       # Upload code coverage
       - name: Upload coverage reports to Codecov with GitHub Action

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -163,7 +163,10 @@ jobs:
       # Run tests
       - name: Run tests
         working-directory: ./src # For code coverage to work
-        run: python -m pytest --cov=./huggingface_hub --cov-report=xml:../coverage.xml --vcr-record=none ../tests
+        run: python -m pytest \
+               --cov=./huggingface_hub --cov-report=xml:../coverage.xml \
+               --vcr-record=none \
+               --reruns 5 --reruns-delay 1 --only-rerun "(OSError|Timeout|HTTPError.*502|HTTPError.*504)" ../tests
 
       # Upload code coverage
       - name: Upload coverage reports to Codecov with GitHub Action

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -163,11 +163,7 @@ jobs:
       # Run tests
       - name: Run tests
         working-directory: ./src # For code coverage to work
-        run: python -m pytest \
-               --cov=./huggingface_hub --cov-report=xml:../coverage.xml \
-               --vcr-record=none \
-               --reruns 5 --reruns-delay 1 --only-rerun '(OSError|Timeout|HTTPError.*502|HTTPError.*504)' \
-               ../tests
+        run: python -m pytest --cov=./huggingface_hub --cov-report=xml:../coverage.xml --vcr-record=none --reruns 5 --reruns-delay 1 --only-rerun '(OSError|Timeout|HTTPError.*502|HTTPError.*504)' ../tests
 
       # Upload code coverage
       - name: Upload coverage reports to Codecov with GitHub Action

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Run tests
         working-directory: ./src # For code coverage to work
         run: |
-          PYTEST="python -m pytest --cov=./huggingface_hub --cov-report=xml:../coverage.xml --vcr-record=none --reruns 5 --reruns-delay 1 --only-rerun "(OSError|Timeout|HTTPError.*502|HTTPError.*504)""
+          PYTEST="python -m pytest --cov=./huggingface_hub --cov-report=xml:../coverage.xml --vcr-record=none --reruns 5 --reruns-delay 1 --only-rerun '(OSError|Timeout|HTTPError.*502|HTTPError.*504)'"
 
           case "${{ matrix.test_name }}" in
 
@@ -166,7 +166,7 @@ jobs:
         run: python -m pytest \
                --cov=./huggingface_hub --cov-report=xml:../coverage.xml \
                --vcr-record=none \
-               --reruns 5 --reruns-delay 1 --only-rerun "(OSError|Timeout|HTTPError.*502|HTTPError.*504)" \
+               --reruns 5 --reruns-delay 1 --only-rerun '(OSError|Timeout|HTTPError.*502|HTTPError.*504)' \
                ../tests
 
       # Upload code coverage

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,6 +60,13 @@ max-line-length = 119
 # --log-cli-level=INFO   -> log level
 # --durations=0          -> print execution time of each test
 addopts = -Werror::FutureWarning --log-cli-level=INFO -sv --durations=0
+# /!\ Other addopts not used locally but only in CI:
+#     - pytest-cov: no need for coverage report locally
+#        --cov=... --cov-report=...
+#     - pytest-rerunfailures: not compatible with `--pdb`
+#        --reruns 5 --reruns-delay 1 --only-rerun "(OSError|Timeout|HTTPError.*502|HTTPError.*504)"
+#     - pytest-vcr: we want to record cassettes locally but not in CI
+#        --vcr-record=none
 env =
     HF_TOKEN=
     HUGGING_FACE_HUB_TOKEN=

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ extras["testing"] = (
         "pytest-xdist",
         "pytest-vcr",  # to mock Inference
         "pytest-asyncio",  # for AsyncInferenceClient
+        "pytest-rerunfailures",  # to rerun flaky tests in CI
         "urllib3<2.0",  # VCR.py broken with urllib3 2.0 (see https://urllib3.readthedocs.io/en/stable/v2-migration-guide.html)
         "soundfile",
         "Pillow",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,20 +1,14 @@
 import os
 import shutil
-import time
-from functools import wraps
 from pathlib import Path
-from typing import Generator, List
+from typing import Generator
 
 import pytest
-import requests
 from _pytest.fixtures import SubRequest
-from _pytest.python import Function as PytestFunction
-from requests.exceptions import HTTPError
 
 import huggingface_hub
 from huggingface_hub import HfApi
 from huggingface_hub.utils import SoftTemporaryDirectory, logging
-from huggingface_hub.utils._typing import CallableT
 
 from .testing_constants import ENDPOINT_PRODUCTION, PRODUCTION_TOKEN
 from .testing_utils import repo_name, set_write_permission_and_retry
@@ -65,64 +59,6 @@ def disable_symlinks_on_windows_ci(monkeypatch: pytest.MonkeyPatch) -> None:
 @pytest.fixture(autouse=True)
 def disable_experimental_warnings(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(huggingface_hub.constants, "HF_HUB_DISABLE_EXPERIMENTAL_WARNING", True)
-
-
-def retry_on_transient_error(fn: CallableT) -> CallableT:
-    """
-    Retry test if failure because of unavailable service, bad gateway or race condition.
-
-    Tests are retried up to 10 times, waiting 5s between each try.
-    """
-    NUMBER_OF_TRIES = 10
-    WAIT_TIME = 5
-    HTTP_ERRORS = (502, 504)  # 502 Bad gateway (repo creation) or 504 Gateway timeout
-
-    @wraps(fn)
-    def _inner(*args, **kwargs):
-        retry_count = 0
-        while True:
-            try:
-                return fn(*args, **kwargs)
-            except HTTPError as e:
-                if retry_count >= NUMBER_OF_TRIES:
-                    raise
-                if e.response.status_code in HTTP_ERRORS:
-                    logger.info(
-                        f"Attempt {retry_count} failed with a {e.response.status_code} error. Retrying new execution"
-                        f" in {WAIT_TIME} second(s)..."
-                    )
-                else:
-                    raise
-            except requests.Timeout:
-                if retry_count >= NUMBER_OF_TRIES:
-                    raise
-                logger.info(
-                    f"HTTP Timeout while interacting with the Hub. Retrying new execution in {WAIT_TIME} second(s)..."
-                )
-            except OSError:
-                if retry_count >= NUMBER_OF_TRIES:
-                    raise
-                logger.info(
-                    "Race condition met where we tried to `clone` before fully deleting a repository. Retrying new"
-                    f" execution in {WAIT_TIME} second(s)..."
-                )
-            time.sleep(WAIT_TIME)
-            retry_count += 1
-
-    return _inner
-
-
-def pytest_collection_modifyitems(items: List[PytestFunction]):
-    """Alter all tests to retry on transient errors.
-
-    Note: equivalent to the previously used `@retry_endpoint` decorator, but tests do
-          not have to be decorated individually anymore.
-    """
-    # called after collection is completed
-    # you can modify the ``items`` list
-    # see https://docs.pytest.org/en/7.3.x/how-to/writing_hook_functions.html
-    for item in items:
-        item.obj = retry_on_transient_error(item.obj)
 
 
 @pytest.fixture


### PR DESCRIPTION
Tests in CI are quite flaky lately. We have a `retry_on_transient_errors` wrapper to retry on OSError (git clone failed), TimeoutError or HTTP 502/504. But this wrapper just doesn't work (sorry I introduced it 2mo ago in https://github.com/huggingface/huggingface_hub/pull/1725 :roll_eyes:). This PR fixes this by using [`pytest-rerunfailures`](https://github.com/pytest-dev/pytest-rerunfailures) which seems to be far more robust and tested that doing it manually^^.

Note that only tests run in CI are rerun on failure. I did not make it a default locally as it's not compatible with `--pdb`. (+flaky tests are never failing locally in my experience).