### PR TITLE
Support DO_NOT_TRACK env variable

### DIFF
--- a/docs/source/en/package_reference/environment_variables.md
+++ b/docs/source/en/package_reference/environment_variables.md
@@ -157,6 +157,10 @@ In order to standardize all environment variables within the Hugging Face ecosys
 
 Some environment variables are not specific to `huggingface_hub` but are still taken into account when they are set.
 
+### DO_NOT_TRACK
+
+Boolean value. Equivalent to `HF_HUB_DISABLE_TELEMETRY`. When set to true, telemetry is globally disabled in the Hugging Face Python ecosystem (`transformers`, `diffusers`, `gradio`, etc.). See https://consoledonottrack.com/ for more details.
+
 ### NO_COLOR
 
 Boolean value. When set, `huggingface-cli` tool will not print any ANSI color.

--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -115,7 +115,11 @@ HF_ASSETS_CACHE = os.getenv("HF_ASSETS_CACHE", HUGGINGFACE_ASSETS_CACHE)
 HF_HUB_OFFLINE = _is_true(os.environ.get("HF_HUB_OFFLINE") or os.environ.get("TRANSFORMERS_OFFLINE"))
 
 # Opt-out from telemetry requests
-HF_HUB_DISABLE_TELEMETRY = _is_true(os.environ.get("HF_HUB_DISABLE_TELEMETRY") or os.environ.get("DISABLE_TELEMETRY"))
+HF_HUB_DISABLE_TELEMETRY = (
+    _is_true(os.environ.get("HF_HUB_DISABLE_TELEMETRY"))  # HF-specific env variable
+    or _is_true(os.environ.get("DISABLE_TELEMETRY"))
+    or _is_true(os.environ.get("DO_NOT_TRACK"))  # https://consoledonottrack.com/
+)
 
 # In the past, token was stored in a hardcoded location
 # `_OLD_HF_TOKEN_PATH` is deprecated and will be removed "at some point".


### PR DESCRIPTION
See https://github.com/huggingface/huggingface_hub/issues/1917 for more details.

**TL;DR:** let's respect `DO_NOT_TRACK` to disable telemetry globally (same as `HF_HUB_DISABLE_TELEMETRY` but not specific to huggingface_hub). And we keep respecting `DISABLE_TELEMTRY` -as a legacy config value- but let's not document it.

cc @allo-