### PR TITLE
added will not echo message to the login token message

### DIFF
--- a/src/huggingface_hub/_login.py
+++ b/src/huggingface_hub/_login.py
@@ -186,7 +186,7 @@ def interpreter_login(new_session: bool = True, write_permission: bool = False) 
     print("    To login, `huggingface_hub` requires a token generated from https://huggingface.co/settings/tokens .")
     if os.name == "nt":
         print("Token can be pasted using 'Right-Click'.")
-    token = getpass("Token (will not echo): ")
+    token = getpass("Enter your token (input will not be visible): ")
     add_to_git_credential = _ask_for_confirmation_no_tui("Add token as git credential?")
 
     _login(token=token, add_to_git_credential=add_to_git_credential, write_permission=write_permission)

--- a/src/huggingface_hub/_login.py
+++ b/src/huggingface_hub/_login.py
@@ -181,7 +181,7 @@ def interpreter_login(new_session: bool = True, write_permission: bool = False) 
     print("    To login, `huggingface_hub` requires a token generated from https://huggingface.co/settings/tokens .")
     if os.name == "nt":
         print("Token can be pasted using 'Right-Click'.")
-    token = getpass("Token: ")
+    token = getpass("Token (will not echo): ")
     add_to_git_credential = _ask_for_confirmation_no_tui("Add token as git credential?")
 
     _login(token=token, add_to_git_credential=add_to_git_credential, write_permission=write_permission)


### PR DESCRIPTION
I embarrassingly hit my head on this  when I was setting up hugging face. The token doesn't echo so I thought something was wrong. having it not echo is probably a good security practice so I just added a note to help out folks like me that get confused by this.
The change in this PR is this:
"Token: " -> "Enter your token (input will not be visible): "

Fixes #1924
Thanks!