### PR TITLE
Prepare for 0.21.0

### DIFF
--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -46,7 +46,7 @@ import sys
 from typing import TYPE_CHECKING
 
 
-__version__ = "0.20.0.dev0"
+__version__ = "0.21.0.dev0"
 
 # Alphabetical order of definitions is ensured in tests
 # WARNING: any comment added in this dictionary definition will be lost when


### PR DESCRIPTION
Follow up PR on the recent release of [`huggingface_hub` 0.20.0](https://huggingface.co/spaces/Wauplin/huggingface_hub/discussions/3) :tada: 

Nothing deprecated to remove.