### PR TITLE
Fix circular import in login

### DIFF
--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -46,7 +46,7 @@ import sys
 from typing import TYPE_CHECKING
 
 
-__version__ = "0.20.0.dev0"
+__version__ = "0.21.0.dev0"
 
 # Alphabetical order of definitions is ensured in tests
 # WARNING: any comment added in this dictionary definition will be lost when

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -63,7 +63,6 @@ _SUBMOD_ATTRS = {
         "InferenceEndpointType",
     ],
     "_login": [
-        "get_token",
         "interpreter_login",
         "login",
         "logout",
@@ -300,6 +299,7 @@ _SUBMOD_ATTRS = {
         "configure_http_backend",
         "dump_environment_info",
         "get_session",
+        "get_token",
         "logging",
         "scan_cache_dir",
     ],
@@ -414,7 +414,6 @@ if TYPE_CHECKING:  # pragma: no cover
         InferenceEndpointType,  # noqa: F401
     )
     from ._login import (
-        get_token,  # noqa: F401
         interpreter_login,  # noqa: F401
         login,  # noqa: F401
         logout,  # noqa: F401
@@ -641,6 +640,7 @@ if TYPE_CHECKING:  # pragma: no cover
         configure_http_backend,  # noqa: F401
         dump_environment_info,  # noqa: F401
         get_session,  # noqa: F401
+        get_token,  # noqa: F401
         logging,  # noqa: F401
         scan_cache_dir,  # noqa: F401
     )

--- a/src/huggingface_hub/_login.py
+++ b/src/huggingface_hub/_login.py
@@ -14,7 +14,6 @@
 """Contains methods to login to the Hub."""
 import os
 import subprocess
-import warnings
 from functools import partial
 from getpass import getpass
 from pathlib import Path
@@ -22,10 +21,18 @@ from typing import Optional
 
 from . import constants
 from .commands._cli_utils import ANSI
-from .utils import logging
-from .utils._git_credential import list_credential_helpers, set_git_credential, unset_git_credential
-from .utils._runtime import is_google_colab, is_notebook
-from .utils._subprocess import capture_output, run_subprocess
+from .utils import (
+    capture_output,
+    get_token,
+    is_google_colab,
+    is_notebook,
+    list_credential_helpers,
+    logging,
+    run_subprocess,
+    set_git_credential,
+    unset_git_credential,
+)
+from .utils._token import _get_token_from_environment, _get_token_from_google_colab
 
 
 logger = logging.get_logger(__name__)
@@ -37,8 +44,6 @@ _HF_LOGO_ASCII = """
     _|    _|  _|    _|  _|    _|  _|    _|    _|    _|    _|_|  _|    _|      _|        _|    _|  _|        _|
     _|    _|    _|_|      _|_|_|    _|_|_|  _|_|_|  _|      _|    _|_|_|      _|        _|    _|    _|_|_|  _|_|_|_|
 """
-
-_CHECK_GOOGLE_COLAB_SECRET = True
 
 
 def login(
@@ -282,99 +287,6 @@ def notebook_login(new_session: bool = True, write_permission: bool = False) -> 
         login_token_widget.children = [widgets.Label(line) for line in message.split("\n") if line.strip()]
 
     token_finish_button.on_click(partial(login_token_event, write_permission=write_permission))
-
-
-###
-# Token helpers
-###
-
-
-def get_token() -> Optional[str]:
-    """
-    Get token if user is logged in.
-
-    Note: in most cases, you should use [`huggingface_hub.utils.build_hf_headers`] instead. This method is only useful
-          if you want to retrieve the token for other purposes than sending an HTTP request.
-
-    Token is retrieved in priority from the `HF_TOKEN` environment variable. Otherwise, we read the token file located
-    in the Hugging Face home folder. Returns None if user is not logged in. To log in, use [`login`] or
-    `huggingface-cli login`.
-
-    Returns:
-        `str` or `None`: The token, `None` if it doesn't exist.
-    """
-    return _get_token_from_google_colab() or _get_token_from_environment() or _get_token_from_file()
-
-
-def _get_token_from_google_colab() -> Optional[str]:
-    if not is_google_colab():
-        return None
-
-    global _CHECK_GOOGLE_COLAB_SECRET
-    if not _CHECK_GOOGLE_COLAB_SECRET:  # request access only once
-        return None
-
-    try:
-        from google.colab import userdata
-        from google.colab.errors import Error as ColabError
-    except ImportError:
-        return None
-
-    try:
-        token = userdata.get("HF_TOKEN")
-    except userdata.NotebookAccessError:
-        # Means the user has a secret call `HF_TOKEN` and got a popup "please grand access to HF_TOKEN" and refused it
-        # => warn user but ignore error => do not re-request access to user
-        warnings.warn(
-            "\nAccess to the secret `HF_TOKEN` has not been granted on this notebook."
-            "\nYou will not be requested again."
-            "\nPlease restart the session if you want to be prompted again."
-        )
-        _CHECK_GOOGLE_COLAB_SECRET = False
-        return None
-    except userdata.SecretNotFoundError:
-        # Means the user did not define a `HF_TOKEN` secret => warn
-        warnings.warn(
-            "\nThe secret `HF_TOKEN` does not exist in your Colab secrets."
-            "\nTo authenticate with the Hugging Face Hub, create a token in your settings tab "
-            "(https://huggingface.co/settings/tokens), set it as secret in your Google Colab and restart your session."
-            "\nYou will be able to reuse this secret in all of your notebooks."
-            "\nPlease note that authentication is recommended but still optional to access public models or datasets."
-        )
-        return None
-    except ColabError as e:
-        # Something happen but we don't know what => recommend to open a GitHub issue
-        warnings.warn(
-            f"\nError while fetching `HF_TOKEN` secret value from your vault: '{str(e)}'."
-            "\nYou are not authenticated with the Hugging Face Hub in this notebook."
-            "\nIf the error persists, please let us know by opening an issue on GitHub "
-            "(https://github.com/huggingface/huggingface_hub/issues/new)."
-        )
-        return None
-
-    return _clean_token(token)
-
-
-def _get_token_from_environment() -> Optional[str]:
-    # `HF_TOKEN` has priority (keep `HUGGING_FACE_HUB_TOKEN` for backward compatibility)
-    return _clean_token(os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN"))
-
-
-def _get_token_from_file() -> Optional[str]:
-    try:
-        return _clean_token(Path(constants.HF_TOKEN_PATH).read_text())
-    except FileNotFoundError:
-        return None
-
-
-def _clean_token(token: Optional[str]) -> Optional[str]:
-    """Clean token by removing trailing and leading spaces and newlines.
-
-    If token is an empty string, return None.
-    """
-    if token is None:
-        return None
-    return token.replace("\r", "").replace("\n", "").strip() or None
 
 
 ###

--- a/src/huggingface_hub/commands/user.py
+++ b/src/huggingface_hub/commands/user.py
@@ -29,11 +29,11 @@ from .._login import (  # noqa: F401 # for backward compatibility  # noqa: F401 
     NOTEBOOK_LOGIN_PASSWORD_HTML,
     NOTEBOOK_LOGIN_TOKEN_HTML_END,
     NOTEBOOK_LOGIN_TOKEN_HTML_START,
-    get_token,
     login,
     logout,
     notebook_login,
 )
+from ..utils import get_token
 from ._cli_utils import ANSI
 
 

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -12,11 +12,11 @@ from urllib.parse import urlparse
 from huggingface_hub.constants import REPO_TYPES_URL_PREFIXES, REPOCARD_NAME
 from huggingface_hub.repocard import metadata_load, metadata_save
 
-from ._login import get_token
 from .hf_api import HfApi, repo_type_and_id_from_hf_id
 from .lfs import LFS_MULTIPART_UPLOAD_COMMAND
 from .utils import (
     SoftTemporaryDirectory,
+    get_token,
     logging,
     run_subprocess,
     tqdm,

--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -40,6 +40,7 @@ from ._errors import (
     RevisionNotFoundError,
     hf_raise_for_status,
 )
+from ._token import get_token
 from ._fixes import SoftTemporaryDirectory, yaml_dump
 from ._git_credential import list_credential_helpers, set_git_credential, unset_git_credential
 from ._headers import build_hf_headers, get_token_to_send, LocalTokenNotFoundError

--- a/src/huggingface_hub/utils/_headers.py
+++ b/src/huggingface_hub/utils/_headers.py
@@ -16,7 +16,6 @@
 from typing import Dict, Optional, Union
 
 from .. import constants
-from .._login import get_token
 from ._runtime import (
     get_fastai_version,
     get_fastcore_version,
@@ -29,6 +28,7 @@ from ._runtime import (
     is_tf_available,
     is_torch_available,
 )
+from ._token import get_token
 from ._validators import validate_hf_hub_args
 
 

--- a/src/huggingface_hub/utils/_token.py
+++ b/src/huggingface_hub/utils/_token.py
@@ -1,0 +1,112 @@
+# Copyright 2023 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Contains an helper to get the token from machine (env variable, secret or config file)."""
+import os
+import warnings
+from pathlib import Path
+from typing import Optional
+
+from .. import constants
+from ._runtime import is_google_colab
+
+
+_CHECK_GOOGLE_COLAB_SECRET = True
+
+
+def get_token() -> Optional[str]:
+    """
+    Get token if user is logged in.
+
+    Note: in most cases, you should use [`huggingface_hub.utils.build_hf_headers`] instead. This method is only useful
+          if you want to retrieve the token for other purposes than sending an HTTP request.
+
+    Token is retrieved in priority from the `HF_TOKEN` environment variable. Otherwise, we read the token file located
+    in the Hugging Face home folder. Returns None if user is not logged in. To log in, use [`login`] or
+    `huggingface-cli login`.
+
+    Returns:
+        `str` or `None`: The token, `None` if it doesn't exist.
+    """
+    return _get_token_from_google_colab() or _get_token_from_environment() or _get_token_from_file()
+
+
+def _get_token_from_google_colab() -> Optional[str]:
+    if not is_google_colab():
+        return None
+
+    global _CHECK_GOOGLE_COLAB_SECRET
+    if not _CHECK_GOOGLE_COLAB_SECRET:  # request access only once
+        return None
+
+    try:
+        from google.colab import userdata
+        from google.colab.errors import Error as ColabError
+    except ImportError:
+        return None
+
+    try:
+        token = userdata.get("HF_TOKEN")
+    except userdata.NotebookAccessError:
+        # Means the user has a secret call `HF_TOKEN` and got a popup "please grand access to HF_TOKEN" and refused it
+        # => warn user but ignore error => do not re-request access to user
+        warnings.warn(
+            "\nAccess to the secret `HF_TOKEN` has not been granted on this notebook."
+            "\nYou will not be requested again."
+            "\nPlease restart the session if you want to be prompted again."
+        )
+        _CHECK_GOOGLE_COLAB_SECRET = False
+        return None
+    except userdata.SecretNotFoundError:
+        # Means the user did not define a `HF_TOKEN` secret => warn
+        warnings.warn(
+            "\nThe secret `HF_TOKEN` does not exist in your Colab secrets."
+            "\nTo authenticate with the Hugging Face Hub, create a token in your settings tab "
+            "(https://huggingface.co/settings/tokens), set it as secret in your Google Colab and restart your session."
+            "\nYou will be able to reuse this secret in all of your notebooks."
+            "\nPlease note that authentication is recommended but still optional to access public models or datasets."
+        )
+        return None
+    except ColabError as e:
+        # Something happen but we don't know what => recommend to open a GitHub issue
+        warnings.warn(
+            f"\nError while fetching `HF_TOKEN` secret value from your vault: '{str(e)}'."
+            "\nYou are not authenticated with the Hugging Face Hub in this notebook."
+            "\nIf the error persists, please let us know by opening an issue on GitHub "
+            "(https://github.com/huggingface/huggingface_hub/issues/new)."
+        )
+        return None
+
+    return _clean_token(token)
+
+
+def _get_token_from_environment() -> Optional[str]:
+    # `HF_TOKEN` has priority (keep `HUGGING_FACE_HUB_TOKEN` for backward compatibility)
+    return _clean_token(os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN"))
+
+
+def _get_token_from_file() -> Optional[str]:
+    try:
+        return _clean_token(Path(constants.HF_TOKEN_PATH).read_text())
+    except FileNotFoundError:
+        return None
+
+
+def _clean_token(token: Optional[str]) -> Optional[str]:
+    """Clean token by removing trailing and leading spaces and newlines.
+
+    If token is an empty string, return None.
+    """
+    if token is None:
+        return None
+    return token.replace("\r", "").replace("\n", "").strip() or None


### PR DESCRIPTION
In the latest release `0.20.0`, a circular import error happens if you try to import `login` or `logout`. This is because they are defined in `huggingface_hub._login.py` which is a "high-level" module that imports a lot of utilities from `.utils`. The current problem is that it only defines `get_token` that is itself used in other utils. In order to fix the circular import quickly, this PR moves the `get_token` logic to its standalone utility module `huggingface_hub.utils._token.py`. 

With this PR, this line works (which is not the case on `main` or `v0.20.0`:
```py
from huggingface_hub import login, logout
``` 

cc @osanseviero @LysandreJik I'm planning to merge this and make a hot-fix release once it's approved.

**EDIT:** failing tests are unrelated (Spaces quota reached)