### PR TITLE
Update .github workflow to build cn docs on PRs

### DIFF
--- a/.github/workflows/build_documentation.yaml
+++ b/.github/workflows/build_documentation.yaml
@@ -13,6 +13,6 @@ jobs:
     with:
       commit_sha: ${{ github.sha }}
       package: huggingface_hub
-      languages: en de hi ko cn
+      languages: cn de en hi ko
     secrets:
       hf_token: ${{ secrets.HF_DOC_BUILD_PUSH }}

--- a/.github/workflows/build_pr_documentation.yaml
+++ b/.github/workflows/build_pr_documentation.yaml
@@ -14,4 +14,4 @@ jobs:
       commit_sha: ${{ github.event.pull_request.head.sha }}
       pr_number: ${{ github.event.number }}
       package: huggingface_hub
-      languages: en de hi ko
+      languages: cn de en hi ko


### PR DESCRIPTION
Follow-up after https://github.com/huggingface/huggingface_hub/pull/1916 cc @2404589803 

I realized we forgot to update `.github/workflows/build_pr_documentation.yaml` to build the `"cn"` documentation when someone opens a PR. Should be fixed by this PR (I've also ordered alphabetically the languages).