### PR TITLE
Raise on failed inference endpoint in `InferenceEndpoint.wait()`

### DIFF
--- a/src/huggingface_hub/_inference_endpoints.py
+++ b/src/huggingface_hub/_inference_endpoints.py
@@ -192,6 +192,12 @@ class InferenceEndpoint:
 
         Returns:
             [`InferenceEndpoint`]: the same Inference Endpoint, mutated in place with the latest data.
+
+        Raises:
+            [`InferenceEndpointError`]
+                If the Inference Endpoint ended up in a failed state.
+            [`InferenceEndpointTimeoutError`]
+                If the Inference Endpoint is not deployed after `timeout` seconds.
         """
         if self.url is not None:  # Means the endpoint is deployed
             logger.info("Inference Endpoint is ready to be used.")
@@ -208,6 +214,10 @@ class InferenceEndpoint:
             if self.url is not None:  # Means the endpoint is deployed
                 logger.info("Inference Endpoint is ready to be used.")
                 return self
+            if self.status == InferenceEndpointStatus.FAILED:
+                raise InferenceEndpointError(
+                    f"Inference Endpoint {self.name} failed to deploy. Please check the logs for more information."
+                )
             if timeout is not None:
                 if time.time() - start > timeout:
                     raise InferenceEndpointTimeoutError("Timeout while waiting for Inference Endpoint to be deployed.")


### PR DESCRIPTION
_Originally from @philschmid [on slack](https://huggingface.slack.com/archives/C02V5EA0A95/p1703081113214549) (internal):_

> i am working on a IE example with the new version of huggingface_hub which supports custom container image configs. I noticed that .wait will not break if the endpoint failed.
I made a mistake an the endpoint is in the "failed" status through the UI but the endpoint.wait() is still "blocking".

We now raise an error if the inference endpoint gets into a `failed` state instead of waiting forever.