### PR TITLE
Document `base_model` in modelcard metadata

### DIFF
--- a/src/huggingface_hub/repocard_data.py
+++ b/src/huggingface_hub/repocard_data.py
@@ -253,6 +253,10 @@ class ModelCardData(CardData):
         tags (`List[str]`, *optional*):
             List of tags to add to your model that can be used when filtering on the Hugging
             Face Hub. Defaults to None.
+        base_model (`str` or `List[str]`, *optional*):
+            The name of the base model from which the model derives. This is applicable for example if your model is a
+            fine-tune or adapter of an existing model. The value must be the ID of a model on the Hub (or a list of IDs
+            if your model derives from multiple models). Defaults to None.
         datasets (`List[str]`, *optional*):
             List of datasets that were used to train this model. Should be a dataset ID
             found on https://hf.co/datasets. Defaults to None.
@@ -295,6 +299,7 @@ class ModelCardData(CardData):
         license: Optional[str] = None,
         library_name: Optional[str] = None,
         tags: Optional[List[str]] = None,
+        base_model: Optional[Union[str, List[str]]] = None,
         datasets: Optional[List[str]] = None,
         metrics: Optional[List[str]] = None,
         eval_results: Optional[List[EvalResult]] = None,
@@ -306,6 +311,7 @@ class ModelCardData(CardData):
         self.license = license
         self.library_name = library_name
         self.tags = tags
+        self.base_model = base_model
         self.datasets = datasets
         self.metrics = metrics
         self.eval_results = eval_results

--- a/src/huggingface_hub/repocard_data.py
+++ b/src/huggingface_hub/repocard_data.py
@@ -254,7 +254,7 @@ class ModelCardData(CardData):
             List of tags to add to your model that can be used when filtering on the Hugging
             Face Hub. Defaults to None.
         base_model (`str` or `List[str]`, *optional*):
-            The name of the base model from which the model derives. This is applicable for example if your model is a
+            The identifier of the base model from which the model derives. This is applicable for example if your model is a
             fine-tune or adapter of an existing model. The value must be the ID of a model on the Hub (or a list of IDs
             if your model derives from multiple models). Defaults to None.
         datasets (`List[str]`, *optional*):


### PR DESCRIPTION
cc @davanstrien 

Officially document the `base_model` key in `ModelCardData`. Value can be either a model_id or a list of model_id. Note that this PR is not necessary to support `base_model` as a key since any `kwargs` is passed to the modelcard. But adding it to the official parameters + document is still beneficial.