### PR TITLE
Remove PRODUCTION_TOKEN from all tests

### DIFF
--- a/tests/cassettes/TestSpaceAPIProduction.test_manage_secrets.yaml
+++ b/tests/cassettes/TestSpaceAPIProduction.test_manage_secrets.yaml
@@ -1,0 +1,698 @@
+interactions:
+- request:
+    body: '{"name": "tmp_test_space", "organization": "user",
+      "private": true, "type": "space", "sdk": "gradio"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '126'
+      Content-Type:
+      - application/json
+      X-Amzn-Trace-Id:
+      - e66b0377-bc64-4006-9739-ef25917703b5
+      authorization:
+      - Bearer hf_fake_token
+      user-agent:
+      - unknown/None; hf_hub/0.21.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: POST
+    uri: https://huggingface.co/api/repos/create
+  response:
+    body:
+      string: '{"url":"https://huggingface.co/spaces/user/tmp_test_space","name":"user/tmp_test_space"}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://huggingface.co
+      Access-Control-Expose-Headers:
+      - X-Repo-Commit,X-Request-Id,X-Error-Code,X-Error-Message,ETag,Link,Accept-Ranges,Content-Range
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '138'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Dec 2023 15:48:08 GMT
+      ETag:
+      - W/"8a-WEP7JYyATKrcvT8FcoqNgk44G0c"
+      Vary:
+      - Origin
+      Via:
+      - 1.1 a799a2015a613685dbaf214eb2f38aa8.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - NOVPRYqzLUCTU8KJvktNzEti3tkVe_MgyxCqErKDtvvHjI8pUmyxTw==
+      X-Amz-Cf-Pop:
+      - MRS52-P4
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - huggingface-moon
+      X-Request-Id:
+      - Root=1-65845e38-12d10c3374cb321f7d288e89;e66b0377-bc64-4006-9739-ef25917703b5
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"files": [{"path": "app.py", "sample": "CmltcG9ydCBncmFkaW8gYXMgZ3IKCgpkZWYgZ3JlZXQobmFtZSk6CiAgICByZXR1cm4gIkhlbGxvICIgKyBuYW1lICsgIiEhIgoKaWZhY2UgPSBnci5JbnRlcmZhY2UoZm49Z3JlZXQsIGlucHV0cz0idGV4dCIsIG91dHB1dHM9InRleHQiKQppZmFjZS5sYXVuY2goKQo=",
+      "size": 152, "sha": "cf0d1d937f3c0dbe0d626e10da89ddd32c89c13cbbec8e5a665bb13c8abf19d4"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '337'
+      Content-Type:
+      - application/json
+      X-Amzn-Trace-Id:
+      - 5cd55563-d5f7-4b82-9ef0-2644ecd149a2
+      authorization:
+      - Bearer hf_fake_token
+      user-agent:
+      - unknown/None; hf_hub/0.21.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: POST
+    uri: https://huggingface.co/api/spaces/user/tmp_test_space/preupload/main
+  response:
+    body:
+      string: '{"files":[{"path":"app.py","uploadMode":"regular","shouldIgnore":false}]}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://huggingface.co
+      Access-Control-Expose-Headers:
+      - X-Repo-Commit,X-Request-Id,X-Error-Code,X-Error-Message,ETag,Link,Accept-Ranges,Content-Range
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '73'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Dec 2023 15:48:08 GMT
+      ETag:
+      - W/"49-nCeVdVg3Vd8tCoIYVmhKsYvl0Vs"
+      Vary:
+      - Origin
+      Via:
+      - 1.1 a799a2015a613685dbaf214eb2f38aa8.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - pZ5ltWojeacjtXqVxiL8e4Vj8DOuzN3FMYGKQayPMgQ1Y5Yq15WrXg==
+      X-Amz-Cf-Pop:
+      - MRS52-P4
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - huggingface-moon
+      X-Request-Id:
+      - Root=1-65845e38-214ac59413362cac4ec2ff37;5cd55563-d5f7-4b82-9ef0-2644ecd149a2
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"key": "header", "value": {"summary": "Upload app.py with huggingface_hub",
+      "description": ""}}
+
+      {"key": "file", "value": {"content": "CmltcG9ydCBncmFkaW8gYXMgZ3IKCgpkZWYgZ3JlZXQobmFtZSk6CiAgICByZXR1cm4gIkhlbGxvICIgKyBuYW1lICsgIiEhIgoKaWZhY2UgPSBnci5JbnRlcmZhY2UoZm49Z3JlZXQsIGlucHV0cz0idGV4dCIsIG91dHB1dHM9InRleHQiKQppZmFjZS5sYXVuY2goKQo=",
+      "path": "app.py", "encoding": "base64"}}
+
+      '
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '383'
+      Content-Type:
+      - application/x-ndjson
+      X-Amzn-Trace-Id:
+      - 1594e403-6e69-4e0f-b5fe-96eaa0c1cf2f
+      authorization:
+      - Bearer hf_fake_token
+      user-agent:
+      - unknown/None; hf_hub/0.21.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: POST
+    uri: https://huggingface.co/api/spaces/user/tmp_test_space/commit/main
+  response:
+    body:
+      string: '{"success":true,"commitOid":"bbc3b307a356c99b0b2901e150b980e55ba5093b","commitUrl":"https://huggingface.co/spaces/user/tmp_test_space/commit/bbc3b307a356c99b0b2901e150b980e55ba5093b","hookOutput":""}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://huggingface.co
+      Access-Control-Expose-Headers:
+      - X-Repo-Commit,X-Request-Id,X-Error-Code,X-Error-Message,ETag,Link,Accept-Ranges,Content-Range
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '224'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Dec 2023 15:48:09 GMT
+      ETag:
+      - W/"e0-rybzVXm4FehyjfvwKj66LUUzuxA"
+      Vary:
+      - Origin
+      Via:
+      - 1.1 a799a2015a613685dbaf214eb2f38aa8.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - QuePsrsqum26l7qBr-y5YqgngKnAs-AT9MGEa2liAW8pbjxqs8iDXw==
+      X-Amz-Cf-Pop:
+      - MRS52-P4
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - huggingface-moon
+      X-Request-Id:
+      - Root=1-65845e39-5abda3f92ceb373546c77521;1594e403-6e69-4e0f-b5fe-96eaa0c1cf2f
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"key": "foo", "value": "123"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      X-Amzn-Trace-Id:
+      - 0794318e-2c47-4e56-b684-47a12939b00c
+      authorization:
+      - Bearer hf_fake_token
+      user-agent:
+      - unknown/None; hf_hub/0.21.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: POST
+    uri: https://huggingface.co/api/spaces/user/tmp_test_space/secrets
+  response:
+    body:
+      string: '{}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Dec 2023 15:48:09 GMT
+      ETag:
+      - W/"2-vyGp6PvFo4RvsFtPoIWeCReyIC8"
+      Via:
+      - 1.1 a799a2015a613685dbaf214eb2f38aa8.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - IP-jFwlRuY90UE67bZYJpjd198zjz_KSCCF8ae92BpZBdayuKsjycA==
+      X-Amz-Cf-Pop:
+      - MRS52-P4
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - huggingface-moon
+      X-Request-Id:
+      - Root=1-65845e39-02e160dc25f8969a23ffcc6d;0794318e-2c47-4e56-b684-47a12939b00c
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"key": "token", "value": "hf_api_123456"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '42'
+      Content-Type:
+      - application/json
+      X-Amzn-Trace-Id:
+      - 876691c3-8429-4db4-8aba-2763cb351c1c
+      authorization:
+      - Bearer hf_fake_token
+      user-agent:
+      - unknown/None; hf_hub/0.21.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: POST
+    uri: https://huggingface.co/api/spaces/user/tmp_test_space/secrets
+  response:
+    body:
+      string: '{}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Dec 2023 15:48:09 GMT
+      ETag:
+      - W/"2-vyGp6PvFo4RvsFtPoIWeCReyIC8"
+      Via:
+      - 1.1 a799a2015a613685dbaf214eb2f38aa8.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 9jdxxQkjiKiAO4nbtl9TQmZXi6Ht5D009pNjaMq6vJxIlIxC3pCAtg==
+      X-Amz-Cf-Pop:
+      - MRS52-P4
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - huggingface-moon
+      X-Request-Id:
+      - Root=1-65845e39-3900d5750a6792ac2e34464a;876691c3-8429-4db4-8aba-2763cb351c1c
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"key": "gh_api_key", "value": "******"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '40'
+      Content-Type:
+      - application/json
+      X-Amzn-Trace-Id:
+      - 5c7bfe2c-a905-4dbd-88c9-9e95dc15ddbf
+      authorization:
+      - Bearer hf_fake_token
+      user-agent:
+      - unknown/None; hf_hub/0.21.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: POST
+    uri: https://huggingface.co/api/spaces/user/tmp_test_space/secrets
+  response:
+    body:
+      string: '{}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Dec 2023 15:48:09 GMT
+      ETag:
+      - W/"2-vyGp6PvFo4RvsFtPoIWeCReyIC8"
+      Via:
+      - 1.1 a799a2015a613685dbaf214eb2f38aa8.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - ybIMsWFOtj3rc4Xaq5s0YbGfeNKZm3Q9K1KCWGMEVigKyobNkGz_0g==
+      X-Amz-Cf-Pop:
+      - MRS52-P4
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - huggingface-moon
+      X-Request-Id:
+      - Root=1-65845e39-486eb42553feb8d256ab8c29;5c7bfe2c-a905-4dbd-88c9-9e95dc15ddbf
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"key": "bar", "value": "123", "description": "This is a secret"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '65'
+      Content-Type:
+      - application/json
+      X-Amzn-Trace-Id:
+      - f3da584b-9af8-4f32-9c82-571d19944adf
+      authorization:
+      - Bearer hf_fake_token
+      user-agent:
+      - unknown/None; hf_hub/0.21.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: POST
+    uri: https://huggingface.co/api/spaces/user/tmp_test_space/secrets
+  response:
+    body:
+      string: '{}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Dec 2023 15:48:09 GMT
+      ETag:
+      - W/"2-vyGp6PvFo4RvsFtPoIWeCReyIC8"
+      Via:
+      - 1.1 a799a2015a613685dbaf214eb2f38aa8.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - -dUBTWoOEFxITdM3fyNlVHPcDisisu1iFk4avqVRcXYk8_S0SfbHww==
+      X-Amz-Cf-Pop:
+      - MRS52-P4
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - huggingface-moon
+      X-Request-Id:
+      - Root=1-65845e39-44c34ffd0e58ece67040e164;f3da584b-9af8-4f32-9c82-571d19944adf
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"key": "foo", "value": "456"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      X-Amzn-Trace-Id:
+      - ee7a0e7a-6fe9-494c-99a7-a2fdcfa4713d
+      authorization:
+      - Bearer hf_fake_token
+      user-agent:
+      - unknown/None; hf_hub/0.21.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: POST
+    uri: https://huggingface.co/api/spaces/user/tmp_test_space/secrets
+  response:
+    body:
+      string: '{}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Dec 2023 15:48:10 GMT
+      ETag:
+      - W/"2-vyGp6PvFo4RvsFtPoIWeCReyIC8"
+      Via:
+      - 1.1 a799a2015a613685dbaf214eb2f38aa8.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - EFGNLe_3yJnCXNfUdTDDyQ1sCX3CnYdnHna0dlMSLRVidEzBl5n3vw==
+      X-Amz-Cf-Pop:
+      - MRS52-P4
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - huggingface-moon
+      X-Request-Id:
+      - Root=1-65845e39-550c439578f387fe7cfe149e;ee7a0e7a-6fe9-494c-99a7-a2fdcfa4713d
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"key": "foo", "value": "789", "description": "This is a secret"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '65'
+      Content-Type:
+      - application/json
+      X-Amzn-Trace-Id:
+      - 28eaf3ba-060c-490a-abb5-9021b0f1e8b6
+      authorization:
+      - Bearer hf_fake_token
+      user-agent:
+      - unknown/None; hf_hub/0.21.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: POST
+    uri: https://huggingface.co/api/spaces/user/tmp_test_space/secrets
+  response:
+    body:
+      string: '{}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Dec 2023 15:48:10 GMT
+      ETag:
+      - W/"2-vyGp6PvFo4RvsFtPoIWeCReyIC8"
+      Via:
+      - 1.1 a799a2015a613685dbaf214eb2f38aa8.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - rSdCXpn4gdXEg1SapFI8hOz3FXxKqJqgUZXYyImPqtiMp44AeQhIjA==
+      X-Amz-Cf-Pop:
+      - MRS52-P4
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - huggingface-moon
+      X-Request-Id:
+      - Root=1-65845e3a-78efd20f31816e237250105a;28eaf3ba-060c-490a-abb5-9021b0f1e8b6
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"key": "bar", "value": "456", "description": "This is another secret"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json
+      X-Amzn-Trace-Id:
+      - 468881f1-d952-4f13-8886-771df62ad785
+      authorization:
+      - Bearer hf_fake_token
+      user-agent:
+      - unknown/None; hf_hub/0.21.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: POST
+    uri: https://huggingface.co/api/spaces/user/tmp_test_space/secrets
+  response:
+    body:
+      string: '{}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Dec 2023 15:48:10 GMT
+      ETag:
+      - W/"2-vyGp6PvFo4RvsFtPoIWeCReyIC8"
+      Via:
+      - 1.1 a799a2015a613685dbaf214eb2f38aa8.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - OwLxa0n4Lh0YNMB5HJq9zx8QU7fSdpvp9XpHKAoOy67YQkrdVdCBvQ==
+      X-Amz-Cf-Pop:
+      - MRS52-P4
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - huggingface-moon
+      X-Request-Id:
+      - Root=1-65845e3a-53ca4bdf1af99d7c0a2f0474;468881f1-d952-4f13-8886-771df62ad785
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"key": "gh_api_key"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '21'
+      Content-Type:
+      - application/json
+      X-Amzn-Trace-Id:
+      - 377022dc-bca1-45c1-89f6-3590f28e693f
+      authorization:
+      - Bearer hf_fake_token
+      user-agent:
+      - unknown/None; hf_hub/0.21.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: DELETE
+    uri: https://huggingface.co/api/spaces/user/tmp_test_space/secrets
+  response:
+    body:
+      string: '{}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Dec 2023 15:48:10 GMT
+      ETag:
+      - W/"2-vyGp6PvFo4RvsFtPoIWeCReyIC8"
+      Via:
+      - 1.1 a799a2015a613685dbaf214eb2f38aa8.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 2QEFaTfyxUznbs9-zreXCj4IkSM-G3GNA4bkVtwIpvII0h5n5Mx8xg==
+      X-Amz-Cf-Pop:
+      - MRS52-P4
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - huggingface-moon
+      X-Request-Id:
+      - Root=1-65845e3a-1265a5d15339f3363893e2e3;377022dc-bca1-45c1-89f6-3590f28e693f
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"key": "missing_key"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '22'
+      Content-Type:
+      - application/json
+      X-Amzn-Trace-Id:
+      - 539cbd61-e68b-4d0b-89b5-72b1cd9a6039
+      authorization:
+      - Bearer hf_fake_token
+      user-agent:
+      - unknown/None; hf_hub/0.21.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: DELETE
+    uri: https://huggingface.co/api/spaces/user/tmp_test_space/secrets
+  response:
+    body:
+      string: '{}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Dec 2023 15:48:10 GMT
+      ETag:
+      - W/"2-vyGp6PvFo4RvsFtPoIWeCReyIC8"
+      Via:
+      - 1.1 a799a2015a613685dbaf214eb2f38aa8.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - IbQ4czJrC-TguMo2PXUIVYL-FGOtAhLQAO5c8hiB3x8maQu4ido_uQ==
+      X-Amz-Cf-Pop:
+      - MRS52-P4
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - huggingface-moon
+      X-Request-Id:
+      - Root=1-65845e3a-57447a4971791c4b6c721515;539cbd61-e68b-4d0b-89b5-72b1cd9a6039
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_test_space", "organization": "user",
+      "type": "space"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '92'
+      Content-Type:
+      - application/json
+      X-Amzn-Trace-Id:
+      - d6f98ff9-6ca0-46f1-8abe-527ce3fc9cdf
+      authorization:
+      - Bearer hf_fake_token
+      user-agent:
+      - unknown/None; hf_hub/0.21.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: DELETE
+    uri: https://huggingface.co/api/repos/delete
+  response:
+    body:
+      string: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - https://huggingface.co
+      Access-Control-Expose-Headers:
+      - X-Repo-Commit,X-Request-Id,X-Error-Code,X-Error-Message,ETag,Link,Accept-Ranges,Content-Range
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Thu, 21 Dec 2023 15:48:11 GMT
+      ETag:
+      - W/"2-nOO9QiTIwXgNtWtBJezz8kv3SLc"
+      Vary:
+      - Origin
+      Via:
+      - 1.1 a799a2015a613685dbaf214eb2f38aa8.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - NaAwsKoKWUYZYSlBUsRb0sxdCwdwVmEZhWtgQFLW7CdmhndEzV03Vg==
+      X-Amz-Cf-Pop:
+      - MRS52-P4
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - huggingface-moon
+      X-Request-Id:
+      - Root=1-65845e3b-525f29b64d2be09e68f1d236;d6f98ff9-6ca0-46f1-8abe-527ce3fc9cdf
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/TestSpaceAPIProduction.test_manage_variables.yaml
+++ b/tests/cassettes/TestSpaceAPIProduction.test_manage_variables.yaml
@@ -1,0 +1,750 @@
+interactions:
+- request:
+    body: '{"name": "tmp_test_space", "organization": "user",
+      "private": true, "type": "space", "sdk": "gradio"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '126'
+      Content-Type:
+      - application/json
+      X-Amzn-Trace-Id:
+      - e263f1bc-b926-41b1-a10a-1e187a1b96b0
+      authorization:
+      - Bearer hf_fake_token
+      user-agent:
+      - unknown/None; hf_hub/0.21.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: POST
+    uri: https://huggingface.co/api/repos/create
+  response:
+    body:
+      string: '{"url":"https://huggingface.co/spaces/user/tmp_test_space","name":"user/tmp_test_space"}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://huggingface.co
+      Access-Control-Expose-Headers:
+      - X-Repo-Commit,X-Request-Id,X-Error-Code,X-Error-Message,ETag,Link,Accept-Ranges,Content-Range
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '138'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Dec 2023 15:48:12 GMT
+      ETag:
+      - W/"8a-yeooLdmcHdMQlRR0P3uy5ToctjY"
+      Vary:
+      - Origin
+      Via:
+      - 1.1 05320c9e938aca851d2d618f965d8882.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - o04mAFqWbRWcCtCNZAYa_VJ_yePomft9skCuEZrbW3FqdADsHi-62g==
+      X-Amz-Cf-Pop:
+      - MRS52-P4
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - huggingface-moon
+      X-Request-Id:
+      - Root=1-65845e3c-4d3eb62915ab70197e341895;e263f1bc-b926-41b1-a10a-1e187a1b96b0
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"files": [{"path": "app.py", "sample": "CmltcG9ydCBncmFkaW8gYXMgZ3IKCgpkZWYgZ3JlZXQobmFtZSk6CiAgICByZXR1cm4gIkhlbGxvICIgKyBuYW1lICsgIiEhIgoKaWZhY2UgPSBnci5JbnRlcmZhY2UoZm49Z3JlZXQsIGlucHV0cz0idGV4dCIsIG91dHB1dHM9InRleHQiKQppZmFjZS5sYXVuY2goKQo=",
+      "size": 152, "sha": "cf0d1d937f3c0dbe0d626e10da89ddd32c89c13cbbec8e5a665bb13c8abf19d4"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '337'
+      Content-Type:
+      - application/json
+      X-Amzn-Trace-Id:
+      - a7926e1d-25d2-4c7c-8729-3eb036c1096a
+      authorization:
+      - Bearer hf_fake_token
+      user-agent:
+      - unknown/None; hf_hub/0.21.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: POST
+    uri: https://huggingface.co/api/spaces/user/tmp_test_space/preupload/main
+  response:
+    body:
+      string: '{"files":[{"path":"app.py","uploadMode":"regular","shouldIgnore":false}]}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://huggingface.co
+      Access-Control-Expose-Headers:
+      - X-Repo-Commit,X-Request-Id,X-Error-Code,X-Error-Message,ETag,Link,Accept-Ranges,Content-Range
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '73'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Dec 2023 15:48:12 GMT
+      ETag:
+      - W/"49-nCeVdVg3Vd8tCoIYVmhKsYvl0Vs"
+      Vary:
+      - Origin
+      Via:
+      - 1.1 05320c9e938aca851d2d618f965d8882.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 0MN4imDQcJBrkrL_4lDI_zAZ7QApmZkbfLmBzfwxO4WtFvFx0mUY9A==
+      X-Amz-Cf-Pop:
+      - MRS52-P4
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - huggingface-moon
+      X-Request-Id:
+      - Root=1-65845e3c-2a4abb84674dc7cd7ff15d7f;a7926e1d-25d2-4c7c-8729-3eb036c1096a
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"key": "header", "value": {"summary": "Upload app.py with huggingface_hub",
+      "description": ""}}
+
+      {"key": "file", "value": {"content": "CmltcG9ydCBncmFkaW8gYXMgZ3IKCgpkZWYgZ3JlZXQobmFtZSk6CiAgICByZXR1cm4gIkhlbGxvICIgKyBuYW1lICsgIiEhIgoKaWZhY2UgPSBnci5JbnRlcmZhY2UoZm49Z3JlZXQsIGlucHV0cz0idGV4dCIsIG91dHB1dHM9InRleHQiKQppZmFjZS5sYXVuY2goKQo=",
+      "path": "app.py", "encoding": "base64"}}
+
+      '
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '383'
+      Content-Type:
+      - application/x-ndjson
+      X-Amzn-Trace-Id:
+      - 13ebbfcb-6c8a-4533-8911-eb05cf4fb202
+      authorization:
+      - Bearer hf_fake_token
+      user-agent:
+      - unknown/None; hf_hub/0.21.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: POST
+    uri: https://huggingface.co/api/spaces/user/tmp_test_space/commit/main
+  response:
+    body:
+      string: '{"success":true,"commitOid":"918c918d44286d17e278947c4156bc9eb572818f","commitUrl":"https://huggingface.co/spaces/user/tmp_test_space/commit/918c918d44286d17e278947c4156bc9eb572818f","hookOutput":""}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://huggingface.co
+      Access-Control-Expose-Headers:
+      - X-Repo-Commit,X-Request-Id,X-Error-Code,X-Error-Message,ETag,Link,Accept-Ranges,Content-Range
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '224'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Dec 2023 15:48:13 GMT
+      ETag:
+      - W/"e0-oCi/rVVyj2vxQIYnO3haPQq31I0"
+      Vary:
+      - Origin
+      Via:
+      - 1.1 05320c9e938aca851d2d618f965d8882.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 6jXvo6JfrsWRfWYYwnhhBHA-BprgPMLllMH6934C8qr3CPzR4tfnxQ==
+      X-Amz-Cf-Pop:
+      - MRS52-P4
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - huggingface-moon
+      X-Request-Id:
+      - Root=1-65845e3d-562f580743de14ef2eeb0141;13ebbfcb-6c8a-4533-8911-eb05cf4fb202
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      X-Amzn-Trace-Id:
+      - f2d60c50-ceeb-43bd-9990-9ce30dc90c5a
+      authorization:
+      - Bearer hf_fake_token
+      user-agent:
+      - unknown/None; hf_hub/0.21.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: GET
+    uri: https://huggingface.co/api/spaces/user/tmp_test_space/variables
+  response:
+    body:
+      string: '{}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://huggingface.co
+      Access-Control-Expose-Headers:
+      - X-Repo-Commit,X-Request-Id,X-Error-Code,X-Error-Message,ETag,Link,Accept-Ranges,Content-Range
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Dec 2023 15:48:13 GMT
+      ETag:
+      - W/"2-vyGp6PvFo4RvsFtPoIWeCReyIC8"
+      Vary:
+      - Origin
+      Via:
+      - 1.1 05320c9e938aca851d2d618f965d8882.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - dIFAfXDtDY8gZEtMAvzCrS_WjECBl5kDBteBICvzcO8LHHCCPx2p1g==
+      X-Amz-Cf-Pop:
+      - MRS52-P4
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - huggingface-moon
+      X-Request-Id:
+      - Root=1-65845e3d-3d2f306e0651867647f39b3d;f2d60c50-ceeb-43bd-9990-9ce30dc90c5a
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"key": "foo", "value": "123"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      X-Amzn-Trace-Id:
+      - 565727c9-b0f4-4a58-a185-ef9283781161
+      authorization:
+      - Bearer hf_fake_token
+      user-agent:
+      - unknown/None; hf_hub/0.21.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: POST
+    uri: https://huggingface.co/api/spaces/user/tmp_test_space/variables
+  response:
+    body:
+      string: '{"foo":{"value":"123","updatedAt":"2023-12-21T15:48:13.527Z"}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://huggingface.co
+      Access-Control-Expose-Headers:
+      - X-Repo-Commit,X-Request-Id,X-Error-Code,X-Error-Message,ETag,Link,Accept-Ranges,Content-Range
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '62'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Dec 2023 15:48:13 GMT
+      ETag:
+      - W/"3e-u9dSYwYuGnQSUupsXnXHKy5CS3Y"
+      Vary:
+      - Origin
+      Via:
+      - 1.1 05320c9e938aca851d2d618f965d8882.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - GOULsBKNg-LHnKPjSmf8ZKhu7gCiJdqUsmJz0xTuvu_qqMzJgEaeiA==
+      X-Amz-Cf-Pop:
+      - MRS52-P4
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - huggingface-moon
+      X-Request-Id:
+      - Root=1-65845e3d-03d4b3175291565d3572913a;565727c9-b0f4-4a58-a185-ef9283781161
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"key": "MODEL_REPO_ID", "value": "user/repo"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '46'
+      Content-Type:
+      - application/json
+      X-Amzn-Trace-Id:
+      - 239c6622-afc2-4b56-a424-37d135c17397
+      authorization:
+      - Bearer hf_fake_token
+      user-agent:
+      - unknown/None; hf_hub/0.21.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: POST
+    uri: https://huggingface.co/api/spaces/user/tmp_test_space/variables
+  response:
+    body:
+      string: '{"foo":{"value":"123","updatedAt":"2023-12-21T15:48:13.527Z"},"MODEL_REPO_ID":{"value":"user/repo","updatedAt":"2023-12-21T15:48:13.741Z"}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://huggingface.co
+      Access-Control-Expose-Headers:
+      - X-Repo-Commit,X-Request-Id,X-Error-Code,X-Error-Message,ETag,Link,Accept-Ranges,Content-Range
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '139'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Dec 2023 15:48:13 GMT
+      ETag:
+      - W/"8b-Erh57N2QrJTXScPDn0usd2+hKVA"
+      Vary:
+      - Origin
+      Via:
+      - 1.1 05320c9e938aca851d2d618f965d8882.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - G9vPRHS501FGbVnt-jX-YZhP3qTBnBcdqCpkbvBReoYrnA7d2w83aA==
+      X-Amz-Cf-Pop:
+      - MRS52-P4
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - huggingface-moon
+      X-Request-Id:
+      - Root=1-65845e3d-78dfdace542398e000b597cb;239c6622-afc2-4b56-a424-37d135c17397
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"key": "MODEL_PAPER", "value": "arXiv", "description": "found it there"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '73'
+      Content-Type:
+      - application/json
+      X-Amzn-Trace-Id:
+      - b07050bc-e41a-4907-b392-d313241fca70
+      authorization:
+      - Bearer hf_fake_token
+      user-agent:
+      - unknown/None; hf_hub/0.21.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: POST
+    uri: https://huggingface.co/api/spaces/user/tmp_test_space/variables
+  response:
+    body:
+      string: '{"foo":{"value":"123","updatedAt":"2023-12-21T15:48:13.527Z"},"MODEL_REPO_ID":{"value":"user/repo","updatedAt":"2023-12-21T15:48:13.741Z"},"MODEL_PAPER":{"value":"arXiv","description":"found
+        it there","updatedAt":"2023-12-21T15:48:13.939Z"}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://huggingface.co
+      Access-Control-Expose-Headers:
+      - X-Repo-Commit,X-Request-Id,X-Error-Code,X-Error-Message,ETag,Link,Accept-Ranges,Content-Range
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '241'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Dec 2023 15:48:14 GMT
+      ETag:
+      - W/"f1-fknyIuU+4blGP8iV5xMN0U4cKmQ"
+      Vary:
+      - Origin
+      Via:
+      - 1.1 05320c9e938aca851d2d618f965d8882.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - rkSfQSSxvZIoyX-LaUdxbNYblxxVycUXuvICTWt4fVPI7BEO6ohBSQ==
+      X-Amz-Cf-Pop:
+      - MRS52-P4
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - huggingface-moon
+      X-Request-Id:
+      - Root=1-65845e3d-756ee9f82037502912405d25;b07050bc-e41a-4907-b392-d313241fca70
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"key": "foo", "value": "456"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      X-Amzn-Trace-Id:
+      - 737103b9-a707-429f-a916-fb4f7bb71d4e
+      authorization:
+      - Bearer hf_fake_token
+      user-agent:
+      - unknown/None; hf_hub/0.21.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: POST
+    uri: https://huggingface.co/api/spaces/user/tmp_test_space/variables
+  response:
+    body:
+      string: '{"foo":{"value":"456","updatedAt":"2023-12-21T15:48:14.247Z"},"MODEL_REPO_ID":{"value":"user/repo","updatedAt":"2023-12-21T15:48:13.741Z"},"MODEL_PAPER":{"value":"arXiv","description":"found
+        it there","updatedAt":"2023-12-21T15:48:13.939Z"}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://huggingface.co
+      Access-Control-Expose-Headers:
+      - X-Repo-Commit,X-Request-Id,X-Error-Code,X-Error-Message,ETag,Link,Accept-Ranges,Content-Range
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '241'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Dec 2023 15:48:14 GMT
+      ETag:
+      - W/"f1-KcLZie0mbYdNRJqVBPTJAHWnJ0Q"
+      Vary:
+      - Origin
+      Via:
+      - 1.1 05320c9e938aca851d2d618f965d8882.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - HBj75X7PY822iCia0I2sANWYc9GBE0izd_5tpZ8BY2AjbRpL7Ml5iA==
+      X-Amz-Cf-Pop:
+      - MRS52-P4
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - huggingface-moon
+      X-Request-Id:
+      - Root=1-65845e3e-3f0d85cd42d5004e577bb5d3;737103b9-a707-429f-a916-fb4f7bb71d4e
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"key": "foo", "value": "456", "description": "updated description"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '68'
+      Content-Type:
+      - application/json
+      X-Amzn-Trace-Id:
+      - c7e4e72e-3cff-4ba0-9864-66dbbae3466f
+      authorization:
+      - Bearer hf_fake_token
+      user-agent:
+      - unknown/None; hf_hub/0.21.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: POST
+    uri: https://huggingface.co/api/spaces/user/tmp_test_space/variables
+  response:
+    body:
+      string: '{"foo":{"value":"456","description":"updated description","updatedAt":"2023-12-21T15:48:14.457Z"},"MODEL_REPO_ID":{"value":"user/repo","updatedAt":"2023-12-21T15:48:13.741Z"},"MODEL_PAPER":{"value":"arXiv","description":"found
+        it there","updatedAt":"2023-12-21T15:48:13.939Z"}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://huggingface.co
+      Access-Control-Expose-Headers:
+      - X-Repo-Commit,X-Request-Id,X-Error-Code,X-Error-Message,ETag,Link,Accept-Ranges,Content-Range
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '277'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Dec 2023 15:48:14 GMT
+      ETag:
+      - W/"115-HEcATrIdAN3+CPVS5n8Xm62NNl8"
+      Vary:
+      - Origin
+      Via:
+      - 1.1 05320c9e938aca851d2d618f965d8882.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - fiSge1PfRo2RDaAbTUFF--jO4urM2ve8cC7HoasExmSjoc0xZRsLHA==
+      X-Amz-Cf-Pop:
+      - MRS52-P4
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - huggingface-moon
+      X-Request-Id:
+      - Root=1-65845e3e-4bf8ebf71ff75cf732eba175;c7e4e72e-3cff-4ba0-9864-66dbbae3466f
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"key": "gh_api_key"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '21'
+      Content-Type:
+      - application/json
+      X-Amzn-Trace-Id:
+      - d2717516-02c5-40e2-b6e1-38e73e858231
+      authorization:
+      - Bearer hf_fake_token
+      user-agent:
+      - unknown/None; hf_hub/0.21.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: DELETE
+    uri: https://huggingface.co/api/spaces/user/tmp_test_space/variables
+  response:
+    body:
+      string: '{"foo":{"value":"456","description":"updated description","updatedAt":"2023-12-21T15:48:14.457Z"},"MODEL_REPO_ID":{"value":"user/repo","updatedAt":"2023-12-21T15:48:13.741Z"},"MODEL_PAPER":{"value":"arXiv","description":"found
+        it there","updatedAt":"2023-12-21T15:48:13.939Z"}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://huggingface.co
+      Access-Control-Expose-Headers:
+      - X-Repo-Commit,X-Request-Id,X-Error-Code,X-Error-Message,ETag,Link,Accept-Ranges,Content-Range
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '277'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Dec 2023 15:48:14 GMT
+      ETag:
+      - W/"115-HEcATrIdAN3+CPVS5n8Xm62NNl8"
+      Vary:
+      - Origin
+      Via:
+      - 1.1 05320c9e938aca851d2d618f965d8882.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - Xny6r_ROKdWejuoemFqEntf9eynrcJi2en2HLLwmlCm4isNS4ScCzA==
+      X-Amz-Cf-Pop:
+      - MRS52-P4
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - huggingface-moon
+      X-Request-Id:
+      - Root=1-65845e3e-7fc17ef02bf2580a68b08d28;d2717516-02c5-40e2-b6e1-38e73e858231
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"key": "missing_key"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '22'
+      Content-Type:
+      - application/json
+      X-Amzn-Trace-Id:
+      - b585f008-e682-40c1-93e0-6fdb53518492
+      authorization:
+      - Bearer hf_fake_token
+      user-agent:
+      - unknown/None; hf_hub/0.21.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: DELETE
+    uri: https://huggingface.co/api/spaces/user/tmp_test_space/variables
+  response:
+    body:
+      string: '{"foo":{"value":"456","description":"updated description","updatedAt":"2023-12-21T15:48:14.457Z"},"MODEL_REPO_ID":{"value":"user/repo","updatedAt":"2023-12-21T15:48:13.741Z"},"MODEL_PAPER":{"value":"arXiv","description":"found
+        it there","updatedAt":"2023-12-21T15:48:13.939Z"}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://huggingface.co
+      Access-Control-Expose-Headers:
+      - X-Repo-Commit,X-Request-Id,X-Error-Code,X-Error-Message,ETag,Link,Accept-Ranges,Content-Range
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '277'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Dec 2023 15:48:14 GMT
+      ETag:
+      - W/"115-HEcATrIdAN3+CPVS5n8Xm62NNl8"
+      Vary:
+      - Origin
+      Via:
+      - 1.1 05320c9e938aca851d2d618f965d8882.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - -Ljx6qdQSnOsOmVPvTp0Oz-_dzueF-4Y3D_8KiupU3RbeQ8jNlehKQ==
+      X-Amz-Cf-Pop:
+      - MRS52-P4
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - huggingface-moon
+      X-Request-Id:
+      - Root=1-65845e3e-35dfc3973fbd6af053c23a0c;b585f008-e682-40c1-93e0-6fdb53518492
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      X-Amzn-Trace-Id:
+      - 1d9a2c03-4686-4375-b245-05945c68897f
+      authorization:
+      - Bearer hf_fake_token
+      user-agent:
+      - unknown/None; hf_hub/0.21.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: GET
+    uri: https://huggingface.co/api/spaces/user/tmp_test_space/variables
+  response:
+    body:
+      string: '{"foo":{"value":"456","description":"updated description","updatedAt":"2023-12-21T15:48:14.457Z"},"MODEL_REPO_ID":{"value":"user/repo","updatedAt":"2023-12-21T15:48:13.741Z"},"MODEL_PAPER":{"value":"arXiv","description":"found
+        it there","updatedAt":"2023-12-21T15:48:13.939Z"}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://huggingface.co
+      Access-Control-Expose-Headers:
+      - X-Repo-Commit,X-Request-Id,X-Error-Code,X-Error-Message,ETag,Link,Accept-Ranges,Content-Range
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '277'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Dec 2023 15:48:15 GMT
+      ETag:
+      - W/"115-HEcATrIdAN3+CPVS5n8Xm62NNl8"
+      Vary:
+      - Origin
+      Via:
+      - 1.1 05320c9e938aca851d2d618f965d8882.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 08oJqBu3NeLxqexVhmKKUaXS1ryTZfCXUF0qDv3BAf0HU1BWXG4IQg==
+      X-Amz-Cf-Pop:
+      - MRS52-P4
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - huggingface-moon
+      X-Request-Id:
+      - Root=1-65845e3f-4075a801327f9e41296fa682;1d9a2c03-4686-4375-b245-05945c68897f
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_test_space", "organization": "user",
+      "type": "space"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '92'
+      Content-Type:
+      - application/json
+      X-Amzn-Trace-Id:
+      - f5e9b3b3-e0e4-4890-bb0f-b33b7d190abb
+      authorization:
+      - Bearer hf_fake_token
+      user-agent:
+      - unknown/None; hf_hub/0.21.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: DELETE
+    uri: https://huggingface.co/api/repos/delete
+  response:
+    body:
+      string: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - https://huggingface.co
+      Access-Control-Expose-Headers:
+      - X-Repo-Commit,X-Request-Id,X-Error-Code,X-Error-Message,ETag,Link,Accept-Ranges,Content-Range
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Thu, 21 Dec 2023 15:48:15 GMT
+      ETag:
+      - W/"2-nOO9QiTIwXgNtWtBJezz8kv3SLc"
+      Vary:
+      - Origin
+      Via:
+      - 1.1 05320c9e938aca851d2d618f965d8882.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 9me6HlhyQ8oHK08FPgJJddO0f9rLrkULF4X0lJhU1rj9tG5gLk9JoA==
+      X-Amz-Cf-Pop:
+      - MRS52-P4
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - huggingface-moon
+      X-Request-Id:
+      - Root=1-65845e3f-7dcf897f7dad29340e7ec577;f5e9b3b3-e0e4-4890-bb0f-b33b7d190abb
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/TestSpaceAPIProduction.test_pause_and_restart_space.yaml
+++ b/tests/cassettes/TestSpaceAPIProduction.test_pause_and_restart_space.yaml
@@ -1,0 +1,574 @@
+interactions:
+- request:
+    body: '{"name": "tmp_test_space", "organization": "user",
+      "private": true, "type": "space", "sdk": "gradio"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '126'
+      Content-Type:
+      - application/json
+      X-Amzn-Trace-Id:
+      - c8665da6-190c-44f5-97a9-657aa2970e7f
+      authorization:
+      - Bearer hf_fake_token
+      user-agent:
+      - unknown/None; hf_hub/0.21.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: POST
+    uri: https://huggingface.co/api/repos/create
+  response:
+    body:
+      string: '{"url":"https://huggingface.co/spaces/user/tmp_test_space","name":"user/tmp_test_space"}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://huggingface.co
+      Access-Control-Expose-Headers:
+      - X-Repo-Commit,X-Request-Id,X-Error-Code,X-Error-Message,ETag,Link,Accept-Ranges,Content-Range
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '138'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Dec 2023 15:48:16 GMT
+      ETag:
+      - W/"8a-cX1tp8KZ9AbSjjAv7Ea81tUl/o0"
+      Vary:
+      - Origin
+      Via:
+      - 1.1 c0ec38d1888eee986b8ba3b8834111c6.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 9WC2pIXZRijNtgbWWJWNyUTnZooErgMTYSYana_9oBTi4_Y375JyHg==
+      X-Amz-Cf-Pop:
+      - MRS52-P4
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - huggingface-moon
+      X-Request-Id:
+      - Root=1-65845e40-0971def90d16c23148e749c0;c8665da6-190c-44f5-97a9-657aa2970e7f
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"files": [{"path": "app.py", "sample": "CmltcG9ydCBncmFkaW8gYXMgZ3IKCgpkZWYgZ3JlZXQobmFtZSk6CiAgICByZXR1cm4gIkhlbGxvICIgKyBuYW1lICsgIiEhIgoKaWZhY2UgPSBnci5JbnRlcmZhY2UoZm49Z3JlZXQsIGlucHV0cz0idGV4dCIsIG91dHB1dHM9InRleHQiKQppZmFjZS5sYXVuY2goKQo=",
+      "size": 152, "sha": "cf0d1d937f3c0dbe0d626e10da89ddd32c89c13cbbec8e5a665bb13c8abf19d4"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '337'
+      Content-Type:
+      - application/json
+      X-Amzn-Trace-Id:
+      - 55b87731-52c0-4d26-b3f9-74de40980261
+      authorization:
+      - Bearer hf_fake_token
+      user-agent:
+      - unknown/None; hf_hub/0.21.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: POST
+    uri: https://huggingface.co/api/spaces/user/tmp_test_space/preupload/main
+  response:
+    body:
+      string: '{"files":[{"path":"app.py","uploadMode":"regular","shouldIgnore":false}]}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://huggingface.co
+      Access-Control-Expose-Headers:
+      - X-Repo-Commit,X-Request-Id,X-Error-Code,X-Error-Message,ETag,Link,Accept-Ranges,Content-Range
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '73'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Dec 2023 15:48:17 GMT
+      ETag:
+      - W/"49-nCeVdVg3Vd8tCoIYVmhKsYvl0Vs"
+      Vary:
+      - Origin
+      Via:
+      - 1.1 c0ec38d1888eee986b8ba3b8834111c6.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - ItAaH1jzx1zN7PL5qBoV0bnV_TWkMAw-Yg8ySTlDFlGtSaRwbCHAmg==
+      X-Amz-Cf-Pop:
+      - MRS52-P4
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - huggingface-moon
+      X-Request-Id:
+      - Root=1-65845e40-4d9d511a5f9386bc4b3fe3f0;55b87731-52c0-4d26-b3f9-74de40980261
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"key": "header", "value": {"summary": "Upload app.py with huggingface_hub",
+      "description": ""}}
+
+      {"key": "file", "value": {"content": "CmltcG9ydCBncmFkaW8gYXMgZ3IKCgpkZWYgZ3JlZXQobmFtZSk6CiAgICByZXR1cm4gIkhlbGxvICIgKyBuYW1lICsgIiEhIgoKaWZhY2UgPSBnci5JbnRlcmZhY2UoZm49Z3JlZXQsIGlucHV0cz0idGV4dCIsIG91dHB1dHM9InRleHQiKQppZmFjZS5sYXVuY2goKQo=",
+      "path": "app.py", "encoding": "base64"}}
+
+      '
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '383'
+      Content-Type:
+      - application/x-ndjson
+      X-Amzn-Trace-Id:
+      - eddaadbb-269b-47de-b30e-dbabe129b5fa
+      authorization:
+      - Bearer hf_fake_token
+      user-agent:
+      - unknown/None; hf_hub/0.21.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: POST
+    uri: https://huggingface.co/api/spaces/user/tmp_test_space/commit/main
+  response:
+    body:
+      string: '{"success":true,"commitOid":"2f2dcda7439e7451aedac474325b0f37afbeccaf","commitUrl":"https://huggingface.co/spaces/user/tmp_test_space/commit/2f2dcda7439e7451aedac474325b0f37afbeccaf","hookOutput":""}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://huggingface.co
+      Access-Control-Expose-Headers:
+      - X-Repo-Commit,X-Request-Id,X-Error-Code,X-Error-Message,ETag,Link,Accept-Ranges,Content-Range
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '224'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Dec 2023 15:48:17 GMT
+      ETag:
+      - W/"e0-HUwkMh4OiEaF2bP3Aj9ujLvPgOo"
+      Vary:
+      - Origin
+      Via:
+      - 1.1 c0ec38d1888eee986b8ba3b8834111c6.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - pEi67vjgaYXn0LghY4hL9FeKBH4Fd5yJOql1MkoDhGz5Weax1JAofw==
+      X-Amz-Cf-Pop:
+      - MRS52-P4
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - huggingface-moon
+      X-Request-Id:
+      - Root=1-65845e41-1393b1cf1b2d840634cec973;eddaadbb-269b-47de-b30e-dbabe129b5fa
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"files": [{"path": "app.py", "sample": "", "size": 0, "sha": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '131'
+      Content-Type:
+      - application/json
+      X-Amzn-Trace-Id:
+      - 31afebbb-3722-4d9b-aeff-eb3c3fd914a9
+      authorization:
+      - Bearer hf_fake_token
+      user-agent:
+      - unknown/None; hf_hub/0.21.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: POST
+    uri: https://huggingface.co/api/spaces/user/tmp_test_space/preupload/main
+  response:
+    body:
+      string: '{"files":[{"path":"app.py","uploadMode":"regular","shouldIgnore":false}]}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://huggingface.co
+      Access-Control-Expose-Headers:
+      - X-Repo-Commit,X-Request-Id,X-Error-Code,X-Error-Message,ETag,Link,Accept-Ranges,Content-Range
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '73'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Dec 2023 15:48:17 GMT
+      ETag:
+      - W/"49-nCeVdVg3Vd8tCoIYVmhKsYvl0Vs"
+      Vary:
+      - Origin
+      Via:
+      - 1.1 c0ec38d1888eee986b8ba3b8834111c6.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - gn0KT92R8SMOy8A_iQjflvCyHBybj2kwKZTHutkOGY_6jb7-9NDzfw==
+      X-Amz-Cf-Pop:
+      - MRS52-P4
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - huggingface-moon
+      X-Request-Id:
+      - Root=1-65845e41-267edc4170245e015a43e12b;31afebbb-3722-4d9b-aeff-eb3c3fd914a9
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"key": "header", "value": {"summary": "Upload app.py with huggingface_hub",
+      "description": ""}}
+
+      {"key": "file", "value": {"content": "", "path": "app.py", "encoding": "base64"}}
+
+      '
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '179'
+      Content-Type:
+      - application/x-ndjson
+      X-Amzn-Trace-Id:
+      - 069fb2f6-4b9a-474a-81f5-312d591b39bb
+      authorization:
+      - Bearer hf_fake_token
+      user-agent:
+      - unknown/None; hf_hub/0.21.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: POST
+    uri: https://huggingface.co/api/spaces/user/tmp_test_space/commit/main
+  response:
+    body:
+      string: '{"success":true,"commitOid":"3bc6e8cd08f81f9052b34d39022e397731acbe14","commitUrl":"https://huggingface.co/spaces/user/tmp_test_space/commit/3bc6e8cd08f81f9052b34d39022e397731acbe14","hookOutput":""}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://huggingface.co
+      Access-Control-Expose-Headers:
+      - X-Repo-Commit,X-Request-Id,X-Error-Code,X-Error-Message,ETag,Link,Accept-Ranges,Content-Range
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '224'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Dec 2023 15:48:17 GMT
+      ETag:
+      - W/"e0-nW44QSoFe6DhLvkkH0JnsFTrCB8"
+      Vary:
+      - Origin
+      Via:
+      - 1.1 c0ec38d1888eee986b8ba3b8834111c6.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - zSgGac00h4Ym_xw2qj65C7ptvNLt_LuqfbuL91BSY9c6blX-gMVyPw==
+      X-Amz-Cf-Pop:
+      - MRS52-P4
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - huggingface-moon
+      X-Request-Id:
+      - Root=1-65845e41-255e6ea827c256b93689ec06;069fb2f6-4b9a-474a-81f5-312d591b39bb
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      X-Amzn-Trace-Id:
+      - 11a94de5-d46a-45c0-87bb-058605bd035e
+      authorization:
+      - Bearer hf_fake_token
+      user-agent:
+      - unknown/None; hf_hub/0.21.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: GET
+    uri: https://huggingface.co/api/spaces/user/tmp_test_space/runtime
+  response:
+    body:
+      string: '{"stage":"BUILDING","hardware":{"current":null,"requested":"cpu-basic"},"storage":null,"gcTimeout":172800,"replicas":{"current":1,"requested":1}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://huggingface.co
+      Access-Control-Expose-Headers:
+      - X-Repo-Commit,X-Request-Id,X-Error-Code,X-Error-Message,ETag,Link,Accept-Ranges,Content-Range
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '145'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Dec 2023 15:48:17 GMT
+      ETag:
+      - W/"91-j1NQfsXE5fy1h/qeo4p+DhhJGr8"
+      Vary:
+      - Origin
+      Via:
+      - 1.1 c0ec38d1888eee986b8ba3b8834111c6.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 5LXoJ0wtvQapkrpniR6YpWBcnlQWW2sfZ3n7AHfnFypDEla9hc23yg==
+      X-Amz-Cf-Pop:
+      - MRS52-P4
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - huggingface-moon
+      X-Request-Id:
+      - Root=1-65845e41-0ef1595e4f0538bc008107a8;11a94de5-d46a-45c0-87bb-058605bd035e
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      X-Amzn-Trace-Id:
+      - bfa7f96a-b56c-4cba-85b3-240973e1fe23
+      authorization:
+      - Bearer hf_fake_token
+      user-agent:
+      - unknown/None; hf_hub/0.21.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: POST
+    uri: https://huggingface.co/api/spaces/user/tmp_test_space/pause
+  response:
+    body:
+      string: '{"stage":"PAUSED","hardware":{"current":null,"requested":"cpu-basic"},"storage":null,"gcTimeout":172800,"replicas":{"current":1,"requested":1}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://huggingface.co
+      Access-Control-Expose-Headers:
+      - X-Repo-Commit,X-Request-Id,X-Error-Code,X-Error-Message,ETag,Link,Accept-Ranges,Content-Range
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '143'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Dec 2023 15:48:18 GMT
+      ETag:
+      - W/"8f-EUVoDox+oD2Y+qurpiOKauzrpms"
+      Vary:
+      - Origin
+      Via:
+      - 1.1 c0ec38d1888eee986b8ba3b8834111c6.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - QK4J1JFKiaHiRjtsFAK0NqeYEFU2ndhZ8Er-qd-AP8tTdvR1-9RzkA==
+      X-Amz-Cf-Pop:
+      - MRS52-P4
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - huggingface-moon
+      X-Request-Id:
+      - Root=1-65845e42-6094295a7dfcef531bb3dadb;bfa7f96a-b56c-4cba-85b3-240973e1fe23
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      X-Amzn-Trace-Id:
+      - 68a13ffb-0e0a-4e83-8cfa-d14e781d57df
+      authorization:
+      - Bearer hf_fake_token
+      user-agent:
+      - unknown/None; hf_hub/0.21.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: POST
+    uri: https://huggingface.co/api/spaces/user/tmp_test_space/restart
+  response:
+    body:
+      string: '{"stage":"BUILDING","hardware":{"current":null,"requested":"cpu-basic"},"storage":null,"gcTimeout":172800,"replicas":{"current":1,"requested":1}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://huggingface.co
+      Access-Control-Expose-Headers:
+      - X-Repo-Commit,X-Request-Id,X-Error-Code,X-Error-Message,ETag,Link,Accept-Ranges,Content-Range
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '145'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Dec 2023 15:48:18 GMT
+      ETag:
+      - W/"91-j1NQfsXE5fy1h/qeo4p+DhhJGr8"
+      Vary:
+      - Origin
+      Via:
+      - 1.1 c0ec38d1888eee986b8ba3b8834111c6.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - XuscfanQbg3kgh7t8ZYD0ICI-PmVIhEy6THfHCcFnukRRTAPQ6ruSA==
+      X-Amz-Cf-Pop:
+      - MRS52-P4
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - huggingface-moon
+      X-Request-Id:
+      - Root=1-65845e42-25554a84326ba39e4b250d36;68a13ffb-0e0a-4e83-8cfa-d14e781d57df
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      X-Amzn-Trace-Id:
+      - 473e46a8-d98c-4f45-893e-61a6ff42a6ea
+      authorization:
+      - Bearer hf_fake_token
+      user-agent:
+      - unknown/None; hf_hub/0.21.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: GET
+    uri: https://huggingface.co/api/spaces/user/tmp_test_space/runtime
+  response:
+    body:
+      string: '{"stage":"BUILDING","hardware":{"current":null,"requested":"cpu-basic"},"storage":null,"gcTimeout":172800,"replicas":{"current":1,"requested":1}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://huggingface.co
+      Access-Control-Expose-Headers:
+      - X-Repo-Commit,X-Request-Id,X-Error-Code,X-Error-Message,ETag,Link,Accept-Ranges,Content-Range
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '145'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Dec 2023 15:48:23 GMT
+      ETag:
+      - W/"91-j1NQfsXE5fy1h/qeo4p+DhhJGr8"
+      Vary:
+      - Origin
+      Via:
+      - 1.1 c0ec38d1888eee986b8ba3b8834111c6.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 8tK5pIK1ktOM5wdNboopObtl2TkzcpjBKdD9DRWvigbdSQpeqI0wbA==
+      X-Amz-Cf-Pop:
+      - MRS52-P4
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - huggingface-moon
+      X-Request-Id:
+      - Root=1-65845e47-326f4c40440c694f37cccf70;473e46a8-d98c-4f45-893e-61a6ff42a6ea
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_test_space", "organization": "user",
+      "type": "space"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '92'
+      Content-Type:
+      - application/json
+      X-Amzn-Trace-Id:
+      - 2ec5ed59-87c7-4eb1-bd89-b6fe1ff05d80
+      authorization:
+      - Bearer hf_fake_token
+      user-agent:
+      - unknown/None; hf_hub/0.21.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: DELETE
+    uri: https://huggingface.co/api/repos/delete
+  response:
+    body:
+      string: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - https://huggingface.co
+      Access-Control-Expose-Headers:
+      - X-Repo-Commit,X-Request-Id,X-Error-Code,X-Error-Message,ETag,Link,Accept-Ranges,Content-Range
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Thu, 21 Dec 2023 15:48:24 GMT
+      ETag:
+      - W/"2-nOO9QiTIwXgNtWtBJezz8kv3SLc"
+      Vary:
+      - Origin
+      Via:
+      - 1.1 c0ec38d1888eee986b8ba3b8834111c6.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - DRxwCPR7JUsMnEE2QOvIU5NM9dQgBUgYqwQRiTUVAj-hVf9nWKwBpA==
+      X-Amz-Cf-Pop:
+      - MRS52-P4
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - huggingface-moon
+      X-Request-Id:
+      - Root=1-65845e47-4ea4c30647bb7a412e4bc76d;2ec5ed59-87c7-4eb1-bd89-b6fe1ff05d80
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/TestSpaceAPIProduction.test_space_runtime.yaml
+++ b/tests/cassettes/TestSpaceAPIProduction.test_space_runtime.yaml
@@ -1,0 +1,292 @@
+interactions:
+- request:
+    body: '{"name": "tmp_test_space", "organization": "user",
+      "private": true, "type": "space", "sdk": "gradio"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '126'
+      Content-Type:
+      - application/json
+      X-Amzn-Trace-Id:
+      - b9f6dc11-3021-4a3b-9656-7e1fe8db22a5
+      authorization:
+      - Bearer hf_fake_token
+      user-agent:
+      - unknown/None; hf_hub/0.21.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: POST
+    uri: https://huggingface.co/api/repos/create
+  response:
+    body:
+      string: '{"url":"https://huggingface.co/spaces/user/tmp_test_space","name":"user/tmp_test_space"}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://huggingface.co
+      Access-Control-Expose-Headers:
+      - X-Repo-Commit,X-Request-Id,X-Error-Code,X-Error-Message,ETag,Link,Accept-Ranges,Content-Range
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '138'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Dec 2023 15:48:25 GMT
+      ETag:
+      - W/"8a-VViltcPMYxf/HQ1ZzLQ3ALxA9NQ"
+      Vary:
+      - Origin
+      Via:
+      - 1.1 12462511bf75e25d997040c6b0156390.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - XCLyREqfkctChMi5tt7_KAUqB2-LVZL6RGFZee2GV-ibgppNsk2btg==
+      X-Amz-Cf-Pop:
+      - MRS52-P4
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - huggingface-moon
+      X-Request-Id:
+      - Root=1-65845e48-5d44a2300f982a3a64cc147a;b9f6dc11-3021-4a3b-9656-7e1fe8db22a5
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"files": [{"path": "app.py", "sample": "CmltcG9ydCBncmFkaW8gYXMgZ3IKCgpkZWYgZ3JlZXQobmFtZSk6CiAgICByZXR1cm4gIkhlbGxvICIgKyBuYW1lICsgIiEhIgoKaWZhY2UgPSBnci5JbnRlcmZhY2UoZm49Z3JlZXQsIGlucHV0cz0idGV4dCIsIG91dHB1dHM9InRleHQiKQppZmFjZS5sYXVuY2goKQo=",
+      "size": 152, "sha": "cf0d1d937f3c0dbe0d626e10da89ddd32c89c13cbbec8e5a665bb13c8abf19d4"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '337'
+      Content-Type:
+      - application/json
+      X-Amzn-Trace-Id:
+      - 62521671-ac25-46ca-a453-f28ab57dd0b7
+      authorization:
+      - Bearer hf_fake_token
+      user-agent:
+      - unknown/None; hf_hub/0.21.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: POST
+    uri: https://huggingface.co/api/spaces/user/tmp_test_space/preupload/main
+  response:
+    body:
+      string: '{"files":[{"path":"app.py","uploadMode":"regular","shouldIgnore":false}]}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://huggingface.co
+      Access-Control-Expose-Headers:
+      - X-Repo-Commit,X-Request-Id,X-Error-Code,X-Error-Message,ETag,Link,Accept-Ranges,Content-Range
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '73'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Dec 2023 15:48:25 GMT
+      ETag:
+      - W/"49-nCeVdVg3Vd8tCoIYVmhKsYvl0Vs"
+      Vary:
+      - Origin
+      Via:
+      - 1.1 12462511bf75e25d997040c6b0156390.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 4qCRcqViywkR9HsiUza6qa3n409VOEqhrSzoTa-Vp7q9SRy1IbKKRA==
+      X-Amz-Cf-Pop:
+      - MRS52-P4
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - huggingface-moon
+      X-Request-Id:
+      - Root=1-65845e49-18cabb494fc3868a7ecbba0a;62521671-ac25-46ca-a453-f28ab57dd0b7
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"key": "header", "value": {"summary": "Upload app.py with huggingface_hub",
+      "description": ""}}
+
+      {"key": "file", "value": {"content": "CmltcG9ydCBncmFkaW8gYXMgZ3IKCgpkZWYgZ3JlZXQobmFtZSk6CiAgICByZXR1cm4gIkhlbGxvICIgKyBuYW1lICsgIiEhIgoKaWZhY2UgPSBnci5JbnRlcmZhY2UoZm49Z3JlZXQsIGlucHV0cz0idGV4dCIsIG91dHB1dHM9InRleHQiKQppZmFjZS5sYXVuY2goKQo=",
+      "path": "app.py", "encoding": "base64"}}
+
+      '
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '383'
+      Content-Type:
+      - application/x-ndjson
+      X-Amzn-Trace-Id:
+      - 176b59ef-c65c-49e6-8f17-485d6c3c5f5d
+      authorization:
+      - Bearer hf_fake_token
+      user-agent:
+      - unknown/None; hf_hub/0.21.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: POST
+    uri: https://huggingface.co/api/spaces/user/tmp_test_space/commit/main
+  response:
+    body:
+      string: '{"success":true,"commitOid":"b85ff0939b7b063079febb7718a33b196a093640","commitUrl":"https://huggingface.co/spaces/user/tmp_test_space/commit/b85ff0939b7b063079febb7718a33b196a093640","hookOutput":""}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://huggingface.co
+      Access-Control-Expose-Headers:
+      - X-Repo-Commit,X-Request-Id,X-Error-Code,X-Error-Message,ETag,Link,Accept-Ranges,Content-Range
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '224'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Dec 2023 15:48:25 GMT
+      ETag:
+      - W/"e0-tCspvOpu7Kpet4dJF3/VUMp0yJo"
+      Vary:
+      - Origin
+      Via:
+      - 1.1 12462511bf75e25d997040c6b0156390.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - s46f7yN6Wg3LpQt-BtELoQvAsK4s2CyHGfqvp5gyJ79qZax3K5JAdA==
+      X-Amz-Cf-Pop:
+      - MRS52-P4
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - huggingface-moon
+      X-Request-Id:
+      - Root=1-65845e49-7357e41a03cb529504a77478;176b59ef-c65c-49e6-8f17-485d6c3c5f5d
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      X-Amzn-Trace-Id:
+      - 98fe3aa8-af57-4a84-bfe1-242ae8fa777a
+      authorization:
+      - Bearer hf_fake_token
+      user-agent:
+      - unknown/None; hf_hub/0.21.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: GET
+    uri: https://huggingface.co/api/spaces/user/tmp_test_space/runtime
+  response:
+    body:
+      string: '{"stage":"NO_APP_FILE","hardware":{"current":null,"requested":"cpu-basic"},"storage":null,"gcTimeout":172800,"replicas":{"current":1,"requested":1}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://huggingface.co
+      Access-Control-Expose-Headers:
+      - X-Repo-Commit,X-Request-Id,X-Error-Code,X-Error-Message,ETag,Link,Accept-Ranges,Content-Range
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '148'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Dec 2023 15:48:25 GMT
+      ETag:
+      - W/"94-92DORcTD91w77YbtjBk7RAgry5I"
+      Vary:
+      - Origin
+      Via:
+      - 1.1 12462511bf75e25d997040c6b0156390.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 2Z0ZunWAb_tIqURyQSuF5GzPJbC-yG1GyoRqRNBCabzsiZ3hos4c6g==
+      X-Amz-Cf-Pop:
+      - MRS52-P4
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - huggingface-moon
+      X-Request-Id:
+      - Root=1-65845e49-61de2f940c7f3c29471409d5;98fe3aa8-af57-4a84-bfe1-242ae8fa777a
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_test_space", "organization": "user",
+      "type": "space"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '92'
+      Content-Type:
+      - application/json
+      X-Amzn-Trace-Id:
+      - 15a04646-60a2-42df-a3ff-3e17990903d2
+      authorization:
+      - Bearer hf_fake_token
+      user-agent:
+      - unknown/None; hf_hub/0.21.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: DELETE
+    uri: https://huggingface.co/api/repos/delete
+  response:
+    body:
+      string: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - https://huggingface.co
+      Access-Control-Expose-Headers:
+      - X-Repo-Commit,X-Request-Id,X-Error-Code,X-Error-Message,ETag,Link,Accept-Ranges,Content-Range
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Thu, 21 Dec 2023 15:48:26 GMT
+      ETag:
+      - W/"2-nOO9QiTIwXgNtWtBJezz8kv3SLc"
+      Vary:
+      - Origin
+      Via:
+      - 1.1 12462511bf75e25d997040c6b0156390.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 6vZojaY85KCqmK1ANwPkPgcVjo_1c8xc2qQQo5qQYgME_f3c3Xt9uw==
+      X-Amz-Cf-Pop:
+      - MRS52-P4
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - huggingface-moon
+      X-Request-Id:
+      - Root=1-65845e4a-7e064f31264770a26808abc3;15a04646-60a2-42df-a3ff-3e17990903d2
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/TestSpaceAPIProduction.test_static_space_runtime.yaml
+++ b/tests/cassettes/TestSpaceAPIProduction.test_static_space_runtime.yaml
@@ -1,0 +1,292 @@
+interactions:
+- request:
+    body: '{"name": "tmp_test_space", "organization": "user",
+      "private": true, "type": "space", "sdk": "gradio"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '126'
+      Content-Type:
+      - application/json
+      X-Amzn-Trace-Id:
+      - 12990993-69d3-4062-8f0d-c830400832e8
+      authorization:
+      - Bearer hf_fake_token
+      user-agent:
+      - unknown/None; hf_hub/0.21.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: POST
+    uri: https://huggingface.co/api/repos/create
+  response:
+    body:
+      string: '{"url":"https://huggingface.co/spaces/user/tmp_test_space","name":"user/tmp_test_space"}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://huggingface.co
+      Access-Control-Expose-Headers:
+      - X-Repo-Commit,X-Request-Id,X-Error-Code,X-Error-Message,ETag,Link,Accept-Ranges,Content-Range
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '138'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Dec 2023 15:48:28 GMT
+      ETag:
+      - W/"8a-e1HOQQY6+79xs9xeAyCIvmdd5pY"
+      Vary:
+      - Origin
+      Via:
+      - 1.1 05320c9e938aca851d2d618f965d8882.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 3eFE9LqicIiIuJwFjEmiUAx3KE6KvFVgs7BlIjS1nMAubIZMasvG0A==
+      X-Amz-Cf-Pop:
+      - MRS52-P4
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - huggingface-moon
+      X-Request-Id:
+      - Root=1-65845e4b-3376a5f55c117b9f3e2507af;12990993-69d3-4062-8f0d-c830400832e8
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"files": [{"path": "app.py", "sample": "CmltcG9ydCBncmFkaW8gYXMgZ3IKCgpkZWYgZ3JlZXQobmFtZSk6CiAgICByZXR1cm4gIkhlbGxvICIgKyBuYW1lICsgIiEhIgoKaWZhY2UgPSBnci5JbnRlcmZhY2UoZm49Z3JlZXQsIGlucHV0cz0idGV4dCIsIG91dHB1dHM9InRleHQiKQppZmFjZS5sYXVuY2goKQo=",
+      "size": 152, "sha": "cf0d1d937f3c0dbe0d626e10da89ddd32c89c13cbbec8e5a665bb13c8abf19d4"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '337'
+      Content-Type:
+      - application/json
+      X-Amzn-Trace-Id:
+      - b559bc5b-5c75-4673-92da-cc368eb78d79
+      authorization:
+      - Bearer hf_fake_token
+      user-agent:
+      - unknown/None; hf_hub/0.21.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: POST
+    uri: https://huggingface.co/api/spaces/user/tmp_test_space/preupload/main
+  response:
+    body:
+      string: '{"files":[{"path":"app.py","uploadMode":"regular","shouldIgnore":false}]}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://huggingface.co
+      Access-Control-Expose-Headers:
+      - X-Repo-Commit,X-Request-Id,X-Error-Code,X-Error-Message,ETag,Link,Accept-Ranges,Content-Range
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '73'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Dec 2023 15:48:28 GMT
+      ETag:
+      - W/"49-nCeVdVg3Vd8tCoIYVmhKsYvl0Vs"
+      Vary:
+      - Origin
+      Via:
+      - 1.1 05320c9e938aca851d2d618f965d8882.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - P1dzYc8fO82sIlZKM_lN-BQEFnm5Q4OnxZ8Mh80lxGmZGnwFQvyMQA==
+      X-Amz-Cf-Pop:
+      - MRS52-P4
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - huggingface-moon
+      X-Request-Id:
+      - Root=1-65845e4c-53fccd270fffacd5162826de;b559bc5b-5c75-4673-92da-cc368eb78d79
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"key": "header", "value": {"summary": "Upload app.py with huggingface_hub",
+      "description": ""}}
+
+      {"key": "file", "value": {"content": "CmltcG9ydCBncmFkaW8gYXMgZ3IKCgpkZWYgZ3JlZXQobmFtZSk6CiAgICByZXR1cm4gIkhlbGxvICIgKyBuYW1lICsgIiEhIgoKaWZhY2UgPSBnci5JbnRlcmZhY2UoZm49Z3JlZXQsIGlucHV0cz0idGV4dCIsIG91dHB1dHM9InRleHQiKQppZmFjZS5sYXVuY2goKQo=",
+      "path": "app.py", "encoding": "base64"}}
+
+      '
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '383'
+      Content-Type:
+      - application/x-ndjson
+      X-Amzn-Trace-Id:
+      - ce7bba7a-ee75-4e1b-ae82-9b3a74b486c1
+      authorization:
+      - Bearer hf_fake_token
+      user-agent:
+      - unknown/None; hf_hub/0.21.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: POST
+    uri: https://huggingface.co/api/spaces/user/tmp_test_space/commit/main
+  response:
+    body:
+      string: '{"success":true,"commitOid":"f3b8983b4d51ad1cf54254c99ab89d5d76098af8","commitUrl":"https://huggingface.co/spaces/user/tmp_test_space/commit/f3b8983b4d51ad1cf54254c99ab89d5d76098af8","hookOutput":""}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://huggingface.co
+      Access-Control-Expose-Headers:
+      - X-Repo-Commit,X-Request-Id,X-Error-Code,X-Error-Message,ETag,Link,Accept-Ranges,Content-Range
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '224'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Dec 2023 15:48:28 GMT
+      ETag:
+      - W/"e0-jdLcTIOo/3SI1GrlFN0Hu/1ZGFs"
+      Vary:
+      - Origin
+      Via:
+      - 1.1 05320c9e938aca851d2d618f965d8882.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - ULXd5h388BjvEuySgGqjUXkfz7muM3SK5uyf0eRdcZNo5rp_EEnSYQ==
+      X-Amz-Cf-Pop:
+      - MRS52-P4
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - huggingface-moon
+      X-Request-Id:
+      - Root=1-65845e4c-638878385fcbe9b502750b13;ce7bba7a-ee75-4e1b-ae82-9b3a74b486c1
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      X-Amzn-Trace-Id:
+      - b2b8b3a5-599c-487b-a4a5-0a95ae9ab424
+      authorization:
+      - Bearer hf_fake_token
+      user-agent:
+      - unknown/None; hf_hub/0.21.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: GET
+    uri: https://huggingface.co/api/spaces/victor/static-space/runtime
+  response:
+    body:
+      string: '{"stage":"RUNNING","hardware":{"current":null,"requested":null},"storage":null,"replicas":{"requested":1,"current":1}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://huggingface.co
+      Access-Control-Expose-Headers:
+      - X-Repo-Commit,X-Request-Id,X-Error-Code,X-Error-Message,ETag,Link,Accept-Ranges,Content-Range
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '118'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Dec 2023 15:48:29 GMT
+      ETag:
+      - W/"76-P0FPsIJ0y4/N4wjDHf89CLxBVFg"
+      Vary:
+      - Origin
+      Via:
+      - 1.1 05320c9e938aca851d2d618f965d8882.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - xe8wqd-q6c_Ok74vOaYja8dW--qOD-dXiPnci-06IR7xEN1u-jElRw==
+      X-Amz-Cf-Pop:
+      - MRS52-P4
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - huggingface-moon
+      X-Request-Id:
+      - Root=1-65845e4c-7dfdcd292597ff90047c30b4;b2b8b3a5-599c-487b-a4a5-0a95ae9ab424
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_test_space", "organization": "user",
+      "type": "space"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '92'
+      Content-Type:
+      - application/json
+      X-Amzn-Trace-Id:
+      - d5d8bddc-a78c-4682-a454-b24d9749a683
+      authorization:
+      - Bearer hf_fake_token
+      user-agent:
+      - unknown/None; hf_hub/0.21.0.dev0; python/3.10.12; torch/1.12.1; tensorflow/2.11.0;
+        fastcore/1.5.23
+    method: DELETE
+    uri: https://huggingface.co/api/repos/delete
+  response:
+    body:
+      string: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - https://huggingface.co
+      Access-Control-Expose-Headers:
+      - X-Repo-Commit,X-Request-Id,X-Error-Code,X-Error-Message,ETag,Link,Accept-Ranges,Content-Range
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Thu, 21 Dec 2023 15:48:29 GMT
+      ETag:
+      - W/"2-nOO9QiTIwXgNtWtBJezz8kv3SLc"
+      Vary:
+      - Origin
+      Via:
+      - 1.1 05320c9e938aca851d2d618f965d8882.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - IHulcaS-HJSPubMYQEA15Hv1bypEYs7eKuI599_7qduxeu0p_vlW2A==
+      X-Amz-Cf-Pop:
+      - MRS52-P4
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - huggingface-moon
+      X-Request-Id:
+      - Root=1-65845e4d-2c6f965215a1d20873500f4d;d5d8bddc-a78c-4682-a454-b24d9749a683
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -27,7 +27,7 @@ import requests
 from requests import Response
 
 import huggingface_hub.file_download
-from huggingface_hub import HfApi
+from huggingface_hub import HfApi, RepoUrl
 from huggingface_hub.constants import (
     CONFIG_NAME,
     HUGGINGFACE_HEADER_X_LINKED_ETAG,
@@ -58,9 +58,11 @@ from huggingface_hub.utils import (
     RepositoryNotFoundError,
     RevisionNotFoundError,
     SoftTemporaryDirectory,
+    get_session,
+    hf_raise_for_status,
 )
 
-from .testing_constants import ENDPOINT_STAGING, PRODUCTION_TOKEN, TOKEN
+from .testing_constants import ENDPOINT_STAGING, OTHER_TOKEN, TOKEN
 from .testing_utils import (
     DUMMY_MODEL_ID,
     DUMMY_MODEL_ID_PINNED_SHA1,
@@ -74,6 +76,7 @@ from .testing_utils import (
     expect_deprecation,
     offline,
     repo_name,
+    use_tmp_repo,
     with_production_testing,
     xfail_on_windows,
 )
@@ -130,6 +133,36 @@ class TestDiskUsageWarning(unittest.TestCase):
             warnings.simplefilter("always")
             _check_disk_space(expected_size=self.expected_size, target_dir="/path/to/not_existent_path")
             assert len(w) == 0
+
+
+class StagingDownloadTests(unittest.TestCase):
+    _api = HfApi(endpoint=ENDPOINT_STAGING, token=TOKEN)
+
+    @use_tmp_repo()
+    def test_download_from_a_gated_repo_with_hf_hub_download(self, repo_url: RepoUrl) -> None:
+        """Checks `hf_hub_download` outputs error on gated repo.
+
+        Regression test for #1121.
+        https://github.com/huggingface/huggingface_hub/pull/1121
+
+        Cannot test on staging as dynamically setting a gated repo doesn't work there.
+        """
+        # Set repo as gated
+        response = get_session().put(
+            f"{self._api.endpoint}/api/models/{repo_url.repo_id}/settings",
+            json={"gated": "auto"},
+            headers=self._api._build_hf_headers(),
+        )
+        hf_raise_for_status(response)
+
+        # Cannot download file as repo is gated
+        with SoftTemporaryDirectory() as tmpdir:
+            with self.assertRaisesRegex(
+                GatedRepoError, "Access to model .* is restricted and you are not in the authorized list"
+            ):
+                hf_hub_download(
+                    repo_id=repo_url.repo_id, filename=".gitattributes", token=OTHER_TOKEN, cache_dir=tmpdir
+                )
 
 
 @with_production_testing
@@ -675,31 +708,6 @@ class CachedDownloadTests(unittest.TestCase):
                 token=None,
                 cache_dir=cache_dir,
             )
-
-    @with_production_testing
-    def test_download_from_a_gated_repo_with_hf_hub_download(self):
-        """Checks `hf_hub_download` outputs error on gated repo.
-
-        Regression test for #1121.
-        https://github.com/huggingface/huggingface_hub/pull/1121
-
-        Cannot test on staging as dynamically setting a gated repo doesn't work there.
-        """
-        if not PRODUCTION_TOKEN:  # No need to test in contrib PRs (when secret is not set)
-            return
-        # Cannot download file as repo is gated
-        with SoftTemporaryDirectory() as tmpdir:
-            with self.assertRaisesRegex(
-                GatedRepoError,
-                "Access to model .* is restricted and you are not in the authorized list",
-            ):
-                hf_hub_download(
-                    # Starcoder is gated on production
-                    repo_id="bigcode/starcoder",
-                    filename=".gitattributes",
-                    token=PRODUCTION_TOKEN,
-                    cache_dir=tmpdir,
-                )
 
     @unittest.skipIf(os.name == "nt", "Lock files are always deleted on Windows.")
     def test_keep_lock_file(self):

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -36,7 +36,7 @@ import requests
 from requests.exceptions import HTTPError
 
 import huggingface_hub.lfs
-from huggingface_hub import SpaceHardware, SpaceStage, SpaceStorage
+from huggingface_hub import HfApi, SpaceHardware, SpaceStage, SpaceStorage
 from huggingface_hub._commit_api import (
     CommitOperationAdd,
     CommitOperationCopy,
@@ -56,7 +56,6 @@ from huggingface_hub.hf_api import (
     Collection,
     CommitInfo,
     DatasetInfo,
-    HfApi,
     MetricInfo,
     ModelInfo,
     RepoSibling,
@@ -2687,7 +2686,7 @@ class TestSquashHistory(HfApiCommonTest):
         self.assertEqual(squashed_branch_commits[0].title, "Super-squash branch 'v0.1' using huggingface_hub")
 
 
-@pytest.mark.usefixtures("fx_production_space")
+@pytest.mark.vcr
 class TestSpaceAPIProduction(unittest.TestCase):
     """
     Testing Space API is not possible on staging. Tests are run against production
@@ -2697,6 +2696,37 @@ class TestSpaceAPIProduction(unittest.TestCase):
 
     repo_id: str
     api: HfApi
+
+    _BASIC_APP_PY_TEMPLATE = """
+import gradio as gr
+
+
+def greet(name):
+    return "Hello " + name + "!!"
+
+iface = gr.Interface(fn=greet, inputs="text", outputs="text")
+iface.launch()
+""".encode()
+
+    def setUp(self):
+        super().setUp()
+
+        # If generating new VCR => use personal token and REMOVE IT from the VCR
+        self.repo_id = "user/tmp_test_space"  # no need to be unique as it's a VCRed test
+        self.api = HfApi(token="hf_fake_token", endpoint="https://huggingface.co")
+
+        # Create a Space
+        self.api.create_repo(repo_id=self.repo_id, repo_type="space", space_sdk="gradio", private=True)
+        self.api.upload_file(
+            path_or_fileobj=self._BASIC_APP_PY_TEMPLATE,
+            repo_id=self.repo_id,
+            repo_type="space",
+            path_in_repo="app.py",
+        )
+
+    def tearDown(self):
+        self.api.delete_repo(repo_id=self.repo_id, repo_type="space")
+        super().tearDown()
 
     def test_manage_secrets(self) -> None:
         # Add 3 secrets
@@ -2769,7 +2799,6 @@ class TestSpaceAPIProduction(unittest.TestCase):
         runtime = self.api.get_space_runtime("victor/static-space")
         self.assertIsInstance(runtime.raw, dict)
 
-    @unittest.skip("Too flaky to run in CI")
     def test_pause_and_restart_space(self) -> None:
         # Upload a fake app.py file
         self.api.upload_file(path_or_fileobj=b"", path_in_repo="app.py", repo_id=self.repo_id, repo_type="space")
@@ -2790,7 +2819,7 @@ class TestSpaceAPIProduction(unittest.TestCase):
 
         # Restart
         self.api.restart_space(self.repo_id)
-        time.sleep(5.0)
+        time.sleep(0.5)
         runtime_after_restart = self.api.get_space_runtime(self.repo_id)
         self.assertNotEqual(runtime_after_restart.stage, SpaceStage.PAUSED)
 

--- a/tests/testing_constants.py
+++ b/tests/testing_constants.py
@@ -1,6 +1,3 @@
-import os
-
-
 USER = "__DUMMY_TRANSFORMERS_USER__"
 FULL_NAME = "Dummy User"
 PASS = "__DUMMY_TRANSFORMERS_PASS__"
@@ -17,15 +14,3 @@ ENDPOINT_PRODUCTION = "https://huggingface.co"
 ENDPOINT_STAGING = "https://hub-ci.huggingface.co"
 
 ENDPOINT_PRODUCTION_URL_SCHEME = ENDPOINT_PRODUCTION + "/{repo_id}/resolve/{revision}/{filename}"
-
-# Token to be set as environment variable.
-# Almost all features are tested on staging environment. However, Spaces are not supported
-# there which makes it impossible to test secrets/hardware requests.
-#
-# Value is set as a secret in Github actions. To make this test work locally, set
-# `HUGGINGFACE_HUB_PRODUCTION_TEST` environment variable on your machine with a personal
-# token (see https://huggingface.co/settings/tokens). The test pipeline will only create
-# private spaces (and delete them afterwards).
-#
-# See `fx_production_space` fixture. Goal is to limit its usage as much as possible.
-PRODUCTION_TOKEN = os.environ.get("HUGGINGFACE_PRODUCTION_USER_TOKEN")


### PR DESCRIPTION
In our CI tests we use a production token in two cases:
1. for Spaces tests => those are flaky and always brake one way or the other (recently because of quotas). This is quite annoying and not very useful as we are more testing the Space infra rather than the `huggingface_hub` API). This PR updates these tests to use VCR tests instead (requests are replayed without hitting the Hub).  
2. for a gated repo test => this can be done programmatically on staging => updated in this PR

After this PR, we should be able to remove the `HUGGINGFACE_PRODUCTION_USER_TOKEN` token from Github secrets.