### PR TITLE
Add optional `truncate` and `normalize` parameters to `InferenceClient.feature_extraction()`

### DIFF
--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -481,7 +481,9 @@ class InferenceClient:
         response = self.post(json=payload, model=model, task="document-question-answering")
         return _bytes_to_list(response)
 
-    def feature_extraction(self, text: str, *, model: Optional[str] = None) -> "np.ndarray":
+    def feature_extraction(
+        self, text: str, truncate: bool = True, normalize: bool = True, *, model: Optional[str] = None
+    ) -> "np.ndarray":
         """
         Generate embeddings for a given text.
 
@@ -513,7 +515,9 @@ class InferenceClient:
         [ 0.28552425, -0.928395  , -1.2077185 , ...,  0.76810825, -2.1069427 ,  0.6236161 ]], dtype=float32)
         ```
         """
-        response = self.post(json={"inputs": text}, model=model, task="feature-extraction")
+        response = self.post(
+            json={"inputs": text, "truncate": truncate, "normalize": normalize}, model=model, task="feature-extraction"
+        )
         np = _import_numpy()
         return np.array(_bytes_to_dict(response), dtype="float32")
 

--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -482,7 +482,12 @@ class InferenceClient:
         return _bytes_to_list(response)
 
     def feature_extraction(
-        self, text: str, truncate: bool = True, normalize: bool = True, *, model: Optional[str] = None
+        self,
+        text: str,
+        truncate: Optional[bool] = True,
+        normalize: Optional[bool] = True,
+        *,
+        model: Optional[str] = None,
     ) -> "np.ndarray":
         """
         Generate embeddings for a given text.
@@ -490,6 +495,10 @@ class InferenceClient:
         Args:
             text (`str`):
                 The text to embed.
+            truncate (`bool`, *optional*):
+                If set to True, truncates inputs longer than 512 tokens. Defaults to True.
+            normalize (`bool`, *optional*):
+                If set to true, returned vectors will have length 1. Defaults to True.
             model (`str`, *optional*):
                 The model to use for the conversational task. Can be a model ID hosted on the Hugging Face Hub or a URL to
                 a deployed Inference Endpoint. If not provided, the default recommended conversational model will be used.

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -482,7 +482,12 @@ class AsyncInferenceClient:
         return _bytes_to_list(response)
 
     async def feature_extraction(
-        self, text: str, truncate: bool = True, normalize: bool = True, *, model: Optional[str] = None
+        self,
+        text: str,
+        truncate: Optional[bool] = True,
+        normalize: Optional[bool] = True,
+        *,
+        model: Optional[str] = None,
     ) -> "np.ndarray":
         """
         Generate embeddings for a given text.
@@ -490,6 +495,10 @@ class AsyncInferenceClient:
         Args:
             text (`str`):
                 The text to embed.
+            truncate (`bool`, *optional*):
+                If set to True, truncates inputs longer than 512 tokens. Defaults to True.
+            normalize (`bool`, *optional*):
+                If set to true, returned vectors will have length 1. Defaults to True.
             model (`str`, *optional*):
                 The model to use for the conversational task. Can be a model ID hosted on the Hugging Face Hub or a URL to
                 a deployed Inference Endpoint. If not provided, the default recommended conversational model will be used.

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -481,7 +481,9 @@ class AsyncInferenceClient:
         response = await self.post(json=payload, model=model, task="document-question-answering")
         return _bytes_to_list(response)
 
-    async def feature_extraction(self, text: str, *, model: Optional[str] = None) -> "np.ndarray":
+    async def feature_extraction(
+        self, text: str, truncate: bool = True, normalize: bool = True, *, model: Optional[str] = None
+    ) -> "np.ndarray":
         """
         Generate embeddings for a given text.
 
@@ -514,7 +516,9 @@ class AsyncInferenceClient:
         [ 0.28552425, -0.928395  , -1.2077185 , ...,  0.76810825, -2.1069427 ,  0.6236161 ]], dtype=float32)
         ```
         """
-        response = await self.post(json={"inputs": text}, model=model, task="feature-extraction")
+        response = await self.post(
+            json={"inputs": text, "truncate": truncate, "normalize": normalize}, model=model, task="feature-extraction"
+        )
         np = _import_numpy()
         return np.array(_bytes_to_dict(response), dtype="float32")
 


### PR DESCRIPTION
### Related Issues:
fixes #1939 

### Proposed Changes:
Adds two new optional boolean parameters parameters to `InferenceClient.feature_extraction()`:
 - `truncate`: If set to True, truncates inputs longer than 512 tokens. Defaults to True.
 - `normalize`: If set to true, returned vectors will have length 1. Defaults to True.

This enables using these parameters with endpoints set up using [text-embeddings-inference](https://github.com/huggingface/text-embeddings-inference).
