### PR TITLE
Added best_of to non-TGI ignored parameters

### DIFF
--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -1483,7 +1483,7 @@ class InferenceClient:
         # Remove some parameters if not a TGI server
         if not _is_tgi_server(model):
             ignored_parameters = []
-            for key in "watermark", "stop", "details", "decoder_input_details":
+            for key in "watermark", "stop", "details", "decoder_input_details", "best_of":
                 if payload["parameters"][key] is not None:
                     ignored_parameters.append(key)
                 del payload["parameters"][key]


### PR DESCRIPTION
### Overview
The solution PR for the issue #1943.

While deploying an Inference Endpoint with a Default container type (non-TGI server), some parameters are ignored.
The `best_of` parameter should be ignored too.

### Solution
- Add `best_of` to ignored parameters.

### Impact
- Non-TGI servers will be able to respond when the user uses the `best_of` parameter.

### Additional Information
NA
