### PR TITLE
Fix thread-safety when fetching user secret in Google Colab

### DIFF
--- a/src/huggingface_hub/utils/_token.py
+++ b/src/huggingface_hub/utils/_token.py
@@ -53,7 +53,7 @@ def _get_token_from_google_colab() -> Optional[str]:
     if not is_google_colab():
         return None
 
-    # `google.colab.userdata` is not thread-safe has it might trigger a popup in the UI
+    # `google.colab.userdata` is not thread-safe
     # This can lead to a deadlock if multiple threads try to access it at the same time
     # (typically when using `snapshot_download`)
     # => use a lock

--- a/src/huggingface_hub/utils/_token.py
+++ b/src/huggingface_hub/utils/_token.py
@@ -24,7 +24,6 @@ from ._runtime import is_google_colab
 
 _CHECK_GOOGLE_COLAB_SECRET = True
 _GOOGLE_COLAB_SECRET_LOCK = Lock()
-_GOOGLE_COLAB_SECRET_TOKEN: Optional[str] = None
 
 
 def get_token() -> Optional[str]:

--- a/src/huggingface_hub/utils/_token.py
+++ b/src/huggingface_hub/utils/_token.py
@@ -15,6 +15,7 @@
 import os
 import warnings
 from pathlib import Path
+from threading import Lock
 from typing import Optional
 
 from .. import constants
@@ -22,6 +23,8 @@ from ._runtime import is_google_colab
 
 
 _CHECK_GOOGLE_COLAB_SECRET = True
+_GOOGLE_COLAB_SECRET_LOCK = Lock()
+_GOOGLE_COLAB_SECRET_TOKEN: Optional[str] = None
 
 
 def get_token() -> Optional[str]:
@@ -45,47 +48,53 @@ def _get_token_from_google_colab() -> Optional[str]:
     if not is_google_colab():
         return None
 
-    global _CHECK_GOOGLE_COLAB_SECRET
-    if not _CHECK_GOOGLE_COLAB_SECRET:  # request access only once
-        return None
+    # `google.colab.userdata` is not thread-safe has it might trigger a popup in the UI
+    # This can lead to a deadlock if multiple threads try to access it at the same time
+    # (typically when using `snapshot_download`)
+    # => use a lock
+    # See https://github.com/huggingface/huggingface_hub/issues/1952 for more details.
+    with _GOOGLE_COLAB_SECRET_LOCK:
+        global _CHECK_GOOGLE_COLAB_SECRET
+        if not _CHECK_GOOGLE_COLAB_SECRET:  # request access only once
+            return None
 
-    try:
-        from google.colab import userdata
-        from google.colab.errors import Error as ColabError
-    except ImportError:
-        return None
+        try:
+            from google.colab import userdata
+            from google.colab.errors import Error as ColabError
+        except ImportError:
+            return None
 
-    try:
-        token = userdata.get("HF_TOKEN")
-    except userdata.NotebookAccessError:
-        # Means the user has a secret call `HF_TOKEN` and got a popup "please grand access to HF_TOKEN" and refused it
-        # => warn user but ignore error => do not re-request access to user
-        warnings.warn(
-            "\nAccess to the secret `HF_TOKEN` has not been granted on this notebook."
-            "\nYou will not be requested again."
-            "\nPlease restart the session if you want to be prompted again."
-        )
-        _CHECK_GOOGLE_COLAB_SECRET = False
-        return None
-    except userdata.SecretNotFoundError:
-        # Means the user did not define a `HF_TOKEN` secret => warn
-        warnings.warn(
-            "\nThe secret `HF_TOKEN` does not exist in your Colab secrets."
-            "\nTo authenticate with the Hugging Face Hub, create a token in your settings tab "
-            "(https://huggingface.co/settings/tokens), set it as secret in your Google Colab and restart your session."
-            "\nYou will be able to reuse this secret in all of your notebooks."
-            "\nPlease note that authentication is recommended but still optional to access public models or datasets."
-        )
-        return None
-    except ColabError as e:
-        # Something happen but we don't know what => recommend to open a GitHub issue
-        warnings.warn(
-            f"\nError while fetching `HF_TOKEN` secret value from your vault: '{str(e)}'."
-            "\nYou are not authenticated with the Hugging Face Hub in this notebook."
-            "\nIf the error persists, please let us know by opening an issue on GitHub "
-            "(https://github.com/huggingface/huggingface_hub/issues/new)."
-        )
-        return None
+        try:
+            token = userdata.get("HF_TOKEN")
+        except userdata.NotebookAccessError:
+            # Means the user has a secret call `HF_TOKEN` and got a popup "please grand access to HF_TOKEN" and refused it
+            # => warn user but ignore error => do not re-request access to user
+            warnings.warn(
+                "\nAccess to the secret `HF_TOKEN` has not been granted on this notebook."
+                "\nYou will not be requested again."
+                "\nPlease restart the session if you want to be prompted again."
+            )
+            _CHECK_GOOGLE_COLAB_SECRET = False
+            return None
+        except userdata.SecretNotFoundError:
+            # Means the user did not define a `HF_TOKEN` secret => warn
+            warnings.warn(
+                "\nThe secret `HF_TOKEN` does not exist in your Colab secrets."
+                "\nTo authenticate with the Hugging Face Hub, create a token in your settings tab "
+                "(https://huggingface.co/settings/tokens), set it as secret in your Google Colab and restart your session."
+                "\nYou will be able to reuse this secret in all of your notebooks."
+                "\nPlease note that authentication is recommended but still optional to access public models or datasets."
+            )
+            return None
+        except ColabError as e:
+            # Something happen but we don't know what => recommend to open a GitHub issue
+            warnings.warn(
+                f"\nError while fetching `HF_TOKEN` secret value from your vault: '{str(e)}'."
+                "\nYou are not authenticated with the Hugging Face Hub in this notebook."
+                "\nIf the error persists, please let us know by opening an issue on GitHub "
+                "(https://github.com/huggingface/huggingface_hub/issues/new)."
+            )
+            return None
 
     return _clean_token(token)
 


### PR DESCRIPTION
Should fix https://github.com/huggingface/huggingface_hub/issues/1952.

It looks like `google.colab.userdata` uses `blocking_request` under the hood which states

>   Note: this function is not thread safe, e.g. if two threads
  send blocking_request they will likely race with each other and consume
  each other responses leaving another thread deadlocked.

~I'm not 100% sure this is what caused the issue experienced by @prhbrt in #1952 but in any case it's better to fix it. The only change in this PR is to put the `userdata.get("HF_TOKEN")` call inside a global lock. This shouldn't impact much the performances/user experience given it's supposed to be much much quicker than uploading/downloading files.~ => I'm now sure this is the problem. More details in https://github.com/huggingface/huggingface_hub/pull/1953#issuecomment-1878364894.