### PR TITLE
Fix pagination when listing discussions

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -41,7 +41,7 @@ from typing import (
     Union,
     overload,
 )
-from urllib.parse import quote, urlencode
+from urllib.parse import quote
 
 import requests
 from requests.exceptions import HTTPError
@@ -5688,18 +5688,19 @@ class HfApi:
             raise ValueError(f"Invalid discussion_status, must be one of {DISCUSSION_STATUS}")
 
         headers = self._build_hf_headers(token=token)
-        query_dict: Dict[str, str] = {}
+        path = f"{self.endpoint}/api/{repo_type}s/{repo_id}/discussions"
+
+        params: Dict[str, Union[str, int]] = {}
         if discussion_type is not None:
-            query_dict["type"] = discussion_type
+            params["type"] = discussion_type
         if discussion_status is not None:
-            query_dict["status"] = discussion_status
+            params["status"] = discussion_status
         if author is not None:
-            query_dict["author"] = author
+            params["author"] = author
 
         def _fetch_discussion_page(page_index: int):
-            query_string = urlencode({**query_dict, "page_index": page_index})
-            path = f"{self.endpoint}/api/{repo_type}s/{repo_id}/discussions?{query_string}"
-            resp = get_session().get(path, headers=headers)
+            params["p"] = page_index
+            resp = get_session().get(path, headers=headers, params=params)
             hf_raise_for_status(resp)
             paginated_discussions = resp.json()
             total = paginated_discussions["count"]

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2470,6 +2470,13 @@ class HfApiDiscussionsTest(HfApiCommonTest):
             list([d.num for d in discussions_generator]), [self.discussion.num, self.pull_request.num]
         )
 
+    @with_production_testing
+    def test_get_repo_discussion_pagination(self):
+        discussions = list(
+            HfApi().get_repo_discussions(repo_id="HuggingFaceH4/open_llm_leaderboard", repo_type="space")
+        )
+        assert len(discussions) > 50
+
     def test_get_discussion_details(self):
         retrieved = self._api.get_discussion_details(repo_id=self.repo_id, discussion_num=2)
         self.assertEqual(retrieved, self.discussion)


### PR DESCRIPTION
Pagination in `get_repo_discussions` is broken which leads to an infinite loop on repos with more than 50 discussions. This PR fixes this. Pagination is page-based (not cursor-based as other listing APIs) and the page parameter is named `"p"` server-side, not `"page_index"` (see in [moon-landing](https://github.com/huggingface/moon-landing/blob/dd3ae19a54e471ddf1392cb47eb13faf324ac974/server/app/discussionRoutes.ts#L298) -private repo-).

I encountered this issue while listing discussions on the Open LLM Leaderboard (cc @clefourrier).

```py
# infinite loop before, now fixed by this PR
for d in get_repo_discussions(repo_id="HuggingFaceH4/open_llm_leaderboard", repo_type="space"):
    print(d.title)
``` 

I also made a small change to use `requests.get(..., params=...)` instead of `urlencode`.