### PR TITLE
Raise `DisabledRepoError` if repo is disabled

### DIFF
--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -36,6 +36,7 @@ from ._errors import (
     GatedRepoError,
     HfHubHTTPError,
     LocalEntryNotFoundError,
+    DisabledRepoError,
     RepositoryNotFoundError,
     RevisionNotFoundError,
     hf_raise_for_status,

--- a/tests/test_utils_errors.py
+++ b/tests/test_utils_errors.py
@@ -6,6 +6,7 @@ from requests.models import PreparedRequest, Response
 from huggingface_hub.utils._errors import (
     REPO_API_REGEX,
     BadRequestError,
+    DisabledRepoError,
     EntryNotFoundError,
     HfHubHTTPError,
     RepositoryNotFoundError,
@@ -23,6 +24,17 @@ class TestErrorUtils(unittest.TestCase):
             hf_raise_for_status(response)
 
         self.assertEqual(context.exception.response.status_code, 404)
+        self.assertIn("Request ID: 123", str(context.exception))
+
+    def test_hf_raise_for_status_disabled_repo(self) -> None:
+        response = Response()
+        response.headers = {"X-Error-Message": "Access to this resource is disabled.", "X-Request-Id": 123}
+
+        response.status_code = 403
+        with self.assertRaises(DisabledRepoError) as context:
+            hf_raise_for_status(response)
+
+        self.assertEqual(context.exception.response.status_code, 403)
         self.assertIn("Request ID: 123", str(context.exception))
 
     def test_hf_raise_for_status_401_repo_url(self) -> None:


### PR DESCRIPTION
After discussion with @severo. Repositories can be disabled, in which case they won't we accessible to anyone anymore. This PR adds a custom `DisabledRepoError` exception when trying to access such a repo.

```py
>>> from huggingface_hub import dataset_info
>>> dataset_info("laion/laion-art")
(...)
huggingface_hub.utils._errors.DisabledRepoError: 403 Client Error. (Request ID: Root=1-659fc3fa-3031673e0f92c71a2260dbe2;bc6f4dfb-b30a-4862-af0a-5cfe827610d8)
Cannot access repository for url https://huggingface.co/api/datasets/laion/laion-art.
Access to this resource is disabled.
```

Note: if user is not authenticated -no token sent-, a HTTP 401 is returned by the server as if the repo doesn't exist at all => translates to a `RepoNotFound` error.