### PR TITLE
Align `HfFolder.get_token` with `huggingface_hub.get_token`

### DIFF
--- a/src/huggingface_hub/utils/_hf_folder.py
+++ b/src/huggingface_hub/utils/_hf_folder.py
@@ -13,12 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Contain helper class to retrieve/store token from/to local cache."""
-import os
 import warnings
 from pathlib import Path
 from typing import Optional
 
 from .. import constants
+from ._token import get_token
 
 
 class HfFolder:
@@ -50,12 +50,8 @@ class HfFolder:
         """
         Get token or None if not existent.
 
-        Note that a token can be also provided using the `HF_TOKEN` environment variable.
-
-        Token is saved in the huggingface home folder. You can configure it by setting
-        the `HF_HOME` environment variable. Previous location was `~/.huggingface/token`.
-        If token is found in old location but not in new location, it is copied there first.
-        For more details, see https://github.com/huggingface/huggingface_hub/issues/1232.
+        This method is deprecated in favor of [`huggingface_hub.get_token`] but is kept for backward compatibility.
+        Its behavior is the same as [`huggingface_hub.get_token`].
 
         Returns:
             `str` or `None`: The token, `None` if it doesn't exist.
@@ -66,22 +62,7 @@ class HfFolder:
         except Exception:  # if not possible (e.g. PermissionError), do not raise
             pass
 
-        # 1. Is it set by environment variable ?
-        token: Optional[str] = os.environ.get("HF_TOKEN")
-        if token is None:  # Ensure backward compatibility but doesn't have priority
-            token = os.environ.get("HUGGING_FACE_HUB_TOKEN")
-        if token is not None:
-            token = token.replace("\r", "").replace("\n", "").strip()
-        if token != "":
-            return token
-
-        # 2. Is it set in token path ?
-        try:
-            token = cls.path_token.read_text()
-            token = token.replace("\r", "").replace("\n", "").strip()
-            return token
-        except FileNotFoundError:
-            return None
+        return get_token()
 
     # TODO: deprecate when adapted in transformers/datasets/gradio
     # @_deprecate_method(version="1.0", message="Use `huggingface_hub.logout` instead.")


### PR DESCRIPTION
Since `0.20.x` release, `HfFolder` is planned to be deprecated in favor of `get_token`, `login` and `logout`. Deprecation warning is not thrown yet as `HfFolder` is still a widely used feature. 

@Narsil made me realize that the implementation of `HfFolder.get_token` and `get_token` are slightly different. In particular, if `HF_TOKEN` environment variable is set to an empty string and a token is saved locally, then `HfFolder.get_token` will return `None` (which is a bug) while `get_token` returns the saved token. In order to avoid any discrepancies, this PR replaces `HfFolder.get_token` implementation by a call to the more robust `get_token`.

**Note:** this change brokes `test_token_in_old_path` mocked test. I decided to remove it completely as it's quite old stuff (13 months old) and by now we can assume all users have switched from the old path to the new one. The feature is still present, I just removed the test.