### PR TITLE
Add reminder for model card consistency

### DIFF
--- a/.github/workflows/model_card_consistency_reminder.yml
+++ b/.github/workflows/model_card_consistency_reminder.yml
@@ -1,0 +1,30 @@
+name: Model and Dataset Card consistency reminder
+
+on:
+  pull_request:
+    paths:
+      - src/huggingface_hub/repocard.py
+      - src/huggingface_hub/templates/modelcard_template.md
+      - src/huggingface_hub/templates/datasetcard_template.md
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: maintain-comment
+        uses: actions-cool/maintain-one-comment@v3
+        with:
+          body: |
+            It looks like you've updated code related to model or dataset cards in this PR.
+
+            Some content is duplicated among the following files. Please make sure that everything stays consistent.
+              - [src/.../repocard.py](https://github.com/huggingface/huggingface_hub/blob/main/src/huggingface_hub/repocard.py)
+              - [src/.../datasetcard_template.md](https://github.com/huggingface/huggingface_hub/blob/main/src/huggingface_hub/templates/modelcard_template.md)
+              - [src/.../modelcard_template.md](https://github.com/huggingface/huggingface_hub/blob/main/src/huggingface_hub/templates/modelcard_template.md)
+              - [modelcard.md](https://github.com/huggingface/hub-docs/blob/main/modelcard.md) (`hub-docs` repo)
+              - [docs/hub/model-cards.md](https://github.com/huggingface/hub-docs/blob/main/docs/hub/model-cards.md) (`hub-docs` repo)
+              - [docs/hub/model-card-annotated.md](https://github.com/huggingface/hub-docs/blob/main/docs/hub/model-card-annotated.md) (`hub-docs` repo)
+              - [datasetcard.md](https://github.com/huggingface/hub-docs/blob/main/datasetcard.md) (`hub-docs` repo)
+              - [docs/hub/datasets-cards.md](https://github.com/huggingface/hub-docs/blob/main/docs/hub/datasets-cards.md) (`hub-docs` repo)
+          token: ${{ secrets.comment_bot_token }}
+          body-include: '<!-- Created by actions-cool/maintain-one-comment -->'


### PR DESCRIPTION
PR related to https://github.com/huggingface/hub-docs/pull/1186.

If any modelcard/datasetcard content is modified, let's post a warning on the PR to remind the author/reviewers to also check the equivalent files in `hub-docs`. More details on https://github.com/huggingface/hub-docs/pull/1186#issue-2076837057.