### PR TITLE
Fix inconstent `warnings.warn`  in repocard.py

### DIFF
--- a/src/huggingface_hub/repocard.py
+++ b/src/huggingface_hub/repocard.py
@@ -1,6 +1,5 @@
 import os
 import re
-import warnings
 from pathlib import Path
 from typing import Any, Dict, Literal, Optional, Type, Union
 
@@ -21,7 +20,10 @@ from huggingface_hub.repocard_data import (
 from huggingface_hub.utils import get_session, is_jinja_available, yaml_dump
 
 from .constants import REPOCARD_NAME
-from .utils import EntryNotFoundError, SoftTemporaryDirectory, validate_hf_hub_args
+from .utils import EntryNotFoundError, SoftTemporaryDirectory, logging, validate_hf_hub_args
+
+
+logger = logging.get_logger(__name__)
 
 
 TEMPLATE_MODELCARD_PATH = Path(__file__).parent / "templates" / "modelcard_template.md"
@@ -102,7 +104,7 @@ class RepoCard:
                 raise ValueError("repo card metadata block should be a dict")
         else:
             # Model card without metadata... create empty metadata
-            warnings.warn("Repo card metadata block was not found. Setting CardData to empty.")
+            logger.warning("Repo card metadata block was not found. Setting CardData to empty.")
             data_dict = {}
             self.text = content
 

--- a/src/huggingface_hub/repocard_data.py
+++ b/src/huggingface_hub/repocard_data.py
@@ -1,10 +1,12 @@
 import copy
-import warnings
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from huggingface_hub.utils import yaml_dump
+from huggingface_hub.utils import logging, yaml_dump
+
+
+logger = logging.get_logger(__name__)
 
 
 @dataclass
@@ -325,7 +327,7 @@ class ModelCardData(CardData):
                 self.eval_results = eval_results
             except (KeyError, TypeError) as error:
                 if ignore_metadata_errors:
-                    warnings.warn("Invalid model-index. Not loading eval results into CardData.")
+                    logger.warning("Invalid model-index. Not loading eval results into CardData.")
                 else:
                     raise ValueError(
                         f"Invalid `model_index` in metadata cannot be parsed: {error.__class__} {error}. Pass"


### PR DESCRIPTION
Fix https://github.com/huggingface/huggingface_hub/issues/1978 cc @osanseviero 

Let's stick to the rule from the [Python official documentation](https://docs.python.org/3/howto/logging.html#when-to-use-logging):

> [warnings.warn()](https://docs.python.org/3/library/warnings.html#warnings.warn) in library code if the issue is avoidable and the client application should be modified to eliminate the warning
> [logging.warning()](https://docs.python.org/3/library/logging.html#logging.warning) if there is nothing the client application can do about the situation, but the event should still be noted

=> those 2 warnings are clearly not user's fault (incorrect readme)