### PR TITLE
Fix timezone in datetime parsing

### DIFF
--- a/src/huggingface_hub/utils/_datetime.py
+++ b/src/huggingface_hub/utils/_datetime.py
@@ -13,13 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Contains utilities to handle datetimes in Huggingface Hub."""
-from datetime import datetime, timedelta, timezone
-
-
-# Local machine offset compared to UTC.
-# Taken from https://stackoverflow.com/a/3168394.
-# `utcoffset()` returns `None` if no offset -> empty timedelta.
-UTC_OFFSET = datetime.now(timezone.utc).astimezone().utcoffset() or timedelta()
+from datetime import datetime, timezone
 
 
 def parse_datetime(date_string: str) -> datetime:
@@ -51,16 +45,15 @@ def parse_datetime(date_string: str) -> datetime:
             If `date_string` cannot be parsed.
     """
     try:
-        # Datetime ending with a Z means "UTC". Here we parse the date as local machine
-        # timezone and then move it to the appropriate UTC timezone.
+        # Datetime ending with a Z means "UTC". We parse the date and then explicitly
+        # set the timezone to UTC.
         # See https://en.wikipedia.org/wiki/ISO_8601#Coordinated_Universal_Time_(UTC)
         # Taken from https://stackoverflow.com/a/3168394.
         if len(date_string) == 30:
             # Means timezoned-timestamp with nanoseconds precision. We need to truncate the last 3 digits.
             date_string = date_string[:-4] + "Z"
         dt = datetime.strptime(date_string, "%Y-%m-%dT%H:%M:%S.%fZ")
-        dt += UTC_OFFSET  # By default, datetime is not timezoned -> move to UTC time
-        return dt.astimezone(timezone.utc)  # Set explicit timezone
+        return dt.replace(tzinfo=timezone.utc)  # Set explicit timezone
     except ValueError as e:
         raise ValueError(
             f"Cannot parse '{date_string}' as a datetime. Date string is expected to"


### PR DESCRIPTION
Fix https://github.com/huggingface/huggingface_hub/issues/1976.

As reported by @jamesbraza in https://github.com/huggingface/huggingface_hub/issues/1976, our datetime parsing method is not correct. The string returned by the server is timezoned to UTC. In the current code, we use `astimezone` to explicitly set the timezone when parsing the datetime. However this method is dependent on the local machine time. This PR fixes this by assigning explicitly the UTC timezone, without updating to local time.

We didn't catch the error earlier most likely due to servers already been in UTC. Thanks @jamesbraza for reporting!