### PR TITLE
Documenting CLI default for `download --repo-type`

### DIFF
--- a/src/huggingface_hub/commands/download.py
+++ b/src/huggingface_hub/commands/download.py
@@ -64,7 +64,7 @@ class DownloadCommand(BaseHuggingfaceCLICommand):
             "--repo-type",
             choices=["model", "dataset", "space"],
             default="model",
-            help="Type of repo to download from (e.g. `dataset`).",
+            help="Type of repo to download from (e.g. `model`, which is the default).",
         )
         download_parser.add_argument(
             "--revision",

--- a/src/huggingface_hub/commands/download.py
+++ b/src/huggingface_hub/commands/download.py
@@ -64,7 +64,7 @@ class DownloadCommand(BaseHuggingfaceCLICommand):
             "--repo-type",
             choices=["model", "dataset", "space"],
             default="model",
-            help="Type of repo to download from (e.g. `model`, which is the default).",
+            help="Type of repo to download from (defaults to 'model').",
         )
         download_parser.add_argument(
             "--revision",


### PR DESCRIPTION
Fixes https://github.com/huggingface/huggingface_hub/issues/1963 by documenting the `DownloadCommand`'s `repo-type`'s default in the `help` message.