### PR TITLE
`make style` using `pre-commit`

### DIFF
--- a/.github/workflows/python-quality.yml
+++ b/.github/workflows/python-quality.yml
@@ -27,11 +27,7 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install .[dev]
-      - run: ruff check tests src contrib # linter
-      - run: ruff format --check tests src contrib # formatter
-      - run: python utils/check_contrib_list.py
-      - run: python utils/check_static_imports.py
-      - run: python utils/generate_async_inference_client.py
+      - run: make style
 
       # Run type checking at least on huggingface_hub root file to check all modules
       # that can be lazy-loaded actually exist.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,7 @@
+---
+default_language_version:
+    python: python3
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
@@ -12,3 +16,25 @@ repos:
     rev: v0.1.13
     hooks:
       - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
+  - repo: local
+    hooks:
+      - id: check-contrib-list
+        name: check-contrib-list
+        entry: python utils/check_contrib_list.py --update
+        language: system
+        files: Makefile|.github/workflows/contrib-tests.yml|contrib
+        pass_filenames: false
+      - id: check-static-imports
+        name: check-static-imports
+        entry: python utils/check_static_imports.py --update
+        language: system
+        pass_filenames: false
+        always_run: true
+      - id: generate-async-inference-client
+        name: generate-async-inference-client
+        entry: python utils/generate_async_inference_client.py --update
+        language: system
+        files: src/huggingface_hub/inference/
+        pass_filenames: false

--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,7 @@ quality:
 	python utils/generate_async_inference_client.py
 
 style:
-	ruff check --fix $(check_dirs) # linter
-	ruff format $(check_dirs) # formatter
-	python utils/check_contrib_list.py --update
-	python utils/check_static_imports.py --update
-	python utils/generate_async_inference_client.py --update
+	python -m pre_commit run --all-files
 
 repocard:
 	python utils/push_repocard_examples.py

--- a/setup.py
+++ b/setup.py
@@ -74,8 +74,6 @@ extras["testing"] = (
     ]
 )
 
-# Typing extra dependencies list is duplicated in `.pre-commit-config.yaml`
-# Please make sure to update the list there when adding a new typing dependency.
 extras["typing"] = [
     "typing-extensions>=4.8.0",
     "types-PyYAML",
@@ -89,6 +87,7 @@ extras["typing"] = [
 extras["quality"] = [
     "ruff>=0.1.3",
     "mypy==1.5.1",
+    "pre-commit",
 ]
 
 extras["all"] = extras["testing"] + extras["quality"] + extras["typing"]


### PR DESCRIPTION
This PR makes a few changes for greater repo tooling synergy

- Moves CI to parity with local machines by reusing `make style`
- Expands `pre-commit` to match `make style`, then moves `make style` to invoke `pre-commit`
- Adds missing `pre-commit` to dev dependencies

Benefits:

- Brings `huggingface_hub` tooling closer to standard within Python community
- `pre-commit` will skip over unnecessary files, unlike old `make style`
- `pre-commit` config is no longer "lagging", it's sync'd with repo via CI
