### PR TITLE
Fix download from private renamed repo

### DIFF
--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -165,6 +165,26 @@ class StagingDownloadTests(unittest.TestCase):
                 )
 
 
+    @use_tmp_repo()
+    def test_download_regular_file_from_private_renamed_repo(self, repo_url: RepoUrl) -> None:
+        repo_id_before = repo_url.repo_id
+        repo_id_after = repo_url.repo_id + "_renamed"
+
+        # Make private + rename + upload regular file
+        self._api.update_repo_visibility(repo_id_before, private=True)
+        self._api.upload_file(repo_id=repo_id_before, path_in_repo="file.txt", path_or_fileobj=b"content")
+        self._api.move_repo(repo_id_before, repo_id_after)
+
+        # Download from private renamed repo
+        path = self._api.hf_hub_download(repo_id_before, filename="file.txt")
+        with open(path) as f:
+            self.assertEqual(f.read(), "content")
+
+        # Move back (so that auto-cleanup works)
+        self._api.move_repo(repo_id_after, repo_id_before)
+
+
+
 @with_production_testing
 class CachedDownloadTests(unittest.TestCase):
     def test_bogus_url(self):

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -167,6 +167,10 @@ class StagingDownloadTests(unittest.TestCase):
 
     @use_tmp_repo()
     def test_download_regular_file_from_private_renamed_repo(self, repo_url: RepoUrl) -> None:
+        """Regression test for #1999.
+
+        See https://github.com/huggingface/huggingface_hub/pull/1999.
+        """
         repo_id_before = repo_url.repo_id
         repo_id_after = repo_url.repo_id + "_renamed"
 

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -164,7 +164,6 @@ class StagingDownloadTests(unittest.TestCase):
                     repo_id=repo_url.repo_id, filename=".gitattributes", token=OTHER_TOKEN, cache_dir=tmpdir
                 )
 
-
     @use_tmp_repo()
     def test_download_regular_file_from_private_renamed_repo(self, repo_url: RepoUrl) -> None:
         """Regression test for #1999.
@@ -186,7 +185,6 @@ class StagingDownloadTests(unittest.TestCase):
 
         # Move back (so that auto-cleanup works)
         self._api.move_repo(repo_id_after, repo_id_before)
-
 
 
 @with_production_testing


### PR DESCRIPTION
This PR fixes a bug when trying to download a regular file (non-LFS) from a private renamed repo. The problem came from the fact that:
1. renaming a repo induce a redirect
2. we were considering that any redirect means that we are downloading from a CDN
3. when we download from a CDN, we remove the `authorization` header since the URL is supposed to be signed
4. when making the actual GET call, the `authorization` header was not there + the url is not signed because it is still a relative redirect to huggingface.co

**=> this PR fixes this issue by keeping the `authorization` header when the redirected URL is from the same domain**


cc @LysandreJik @osanseviero who investigated the bug
cc @coyotte508 @XciD can you please review this PR as well? Just want to make sure I did not break anything (especially when downloading from a Space)