### PR TITLE
Disable tqdm progress bar if no TTY attached

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -505,7 +505,9 @@ def http_get(
         total=total,
         initial=resume_size,
         desc=displayed_filename,
-        disable=bool(logger.getEffectiveLevel() == logging.NOTSET),
+        disable=True if (logger.getEffectiveLevel() == logging.NOTSET) else None,
+        # ^ set `disable=None` rather than `disable=False` by default to disable progress bar when no TTY attached
+        # see https://github.com/huggingface/huggingface_hub/pull/2000
     ) as progress:
         if hf_transfer and total is not None and total > 5 * DOWNLOAD_CHUNK_SIZE:
             supports_callback = "callback" in inspect.signature(hf_transfer.download).parameters

--- a/src/huggingface_hub/lfs.py
+++ b/src/huggingface_hub/lfs.py
@@ -409,7 +409,10 @@ def _upload_parts_hf_transfer(
     desc = operation.path_in_repo
     if len(desc) > 40:
         desc = f"(…){desc[-40:]}"
-    disable = bool(logger.getEffectiveLevel() == logging.NOTSET)
+
+    # set `disable=None` rather than `disable=False` by default to disable progress bar when no TTY attached
+    # see https://github.com/huggingface/huggingface_hub/pull/2000
+    disable = True if (logger.getEffectiveLevel() == logging.NOTSET) else None
 
     with tqdm(unit="B", unit_scale=True, total=total, initial=0, desc=desc, disable=disable) as progress:
         try:


### PR DESCRIPTION
When dockerized applications write to STDOUT/STDERR, the applications can block due to logging back pressure (see
https://docs.docker.com/config/containers/logging/configure/#configure-the-delivery-mode-of-log-messages-from-container-to-log-driver6

HuggingFace's TGI container is one such example (see https://github.com/huggingface/text-generation-inference/issues/1186).

Setting tqdm's `disable=None` will disable the progress bar if no tty is attached and help to resolve TGI's issue #1186.

References:
    https://github.com/huggingface/text-generation-inference/issues/1186#issuecomment-1906809624
    https://github.com/huggingface/text-generation-inference/issues/1186#issuecomment-1908278377