### PR TITLE
Fix intolerance for new field in TGI stream response: 'index'

### DIFF
--- a/src/huggingface_hub/inference/_text_generation.py
+++ b/src/huggingface_hub/inference/_text_generation.py
@@ -451,6 +451,8 @@ class TextGenerationStreamResponse:
     Args:
         token (`Token`):
             The generated token.
+        index (`Optional[int]`, *optional*):
+            The token index within the stream. Optional to support older clients that omit it.
         generated_text (`Optional[str]`, *optional*):
             The complete generated text. Only available when the generation is finished.
         details (`Optional[StreamDetails]`, *optional*):
@@ -459,6 +461,9 @@ class TextGenerationStreamResponse:
 
     # Generated token
     token: Token
+    # The token index within the stream
+    # Optional to support  older clients that omit it.
+    index: Optional[int] = None
     # Complete generated text
     # Only available when the generation is finished
     generated_text: Optional[str] = None

--- a/tests/test_inference_text_generation.py
+++ b/tests/test_inference_text_generation.py
@@ -109,14 +109,22 @@ class TestTextGenerationTypes(unittest.TestCase):
 
     # https://github.com/huggingface/huggingface_hub/issues/2005
     def test_streaming_response_validation(self):
-        json_payload_latest = {"index":97,"token":{"id":264,"text":" a","logprob":-0.0003259182,"special":False},"generated_text":None,"details":None}
+        json_payload_latest = {
+            "index": 97,
+            "token": {"id": 264, "text": " a", "logprob": -0.0003259182, "special": False},
+            "generated_text": None,
+            "details": None,
+        }
         TextGenerationStreamResponse(**json_payload_latest)
-        json_payload_older_had_no_index = {"token":{"id":264,"text":" a","logprob":-0.0003259182,"special":False},"generated_text":None,"details":None}
+        json_payload_older_had_no_index = {
+            "token": {"id": 264, "text": " a", "logprob": -0.0003259182, "special": False},
+            "generated_text": None,
+            "details": None,
+        }
         TextGenerationStreamResponse(**json_payload_older_had_no_index)
-        json_payload_without_required_field_token = {"index":97,"generated_text":None,"details":None}
+        json_payload_without_required_field_token = {"index": 97, "generated_text": None, "details": None}
         with self.assertRaises(ValidationError):
             TextGenerationStreamResponse(**json_payload_without_required_field_token)
-
 
 
 class TestTextGenerationErrors(unittest.TestCase):

--- a/tests/test_inference_text_generation.py
+++ b/tests/test_inference_text_generation.py
@@ -20,6 +20,7 @@ from huggingface_hub.inference._text_generation import (
     OverloadedError,
     TextGenerationParameters,
     TextGenerationRequest,
+    TextGenerationStreamResponse,
     raise_text_generation_error,
 )
 from huggingface_hub.inference._text_generation import (
@@ -105,6 +106,17 @@ class TestTextGenerationTypes(unittest.TestCase):
             TextGenerationRequest(
                 inputs="test", parameters=TextGenerationParameters(best_of=2, do_sample=True), stream=True
             )
+
+    # https://github.com/huggingface/huggingface_hub/issues/2005
+    def test_streaming_response_validation(self):
+        json_payload_latest = {"index":97,"token":{"id":264,"text":" a","logprob":-0.0003259182,"special":False},"generated_text":None,"details":None}
+        TextGenerationStreamResponse(**json_payload_latest)
+        json_payload_older_had_no_index = {"token":{"id":264,"text":" a","logprob":-0.0003259182,"special":False},"generated_text":None,"details":None}
+        TextGenerationStreamResponse(**json_payload_older_had_no_index)
+        json_payload_without_required_field_token = {"index":97,"generated_text":None,"details":None}
+        with self.assertRaises(ValidationError):
+            TextGenerationStreamResponse(**json_payload_without_required_field_token)
+
 
 
 class TestTextGenerationErrors(unittest.TestCase):

--- a/tests/test_inference_text_generation.py
+++ b/tests/test_inference_text_generation.py
@@ -107,8 +107,12 @@ class TestTextGenerationTypes(unittest.TestCase):
                 inputs="test", parameters=TextGenerationParameters(best_of=2, do_sample=True), stream=True
             )
 
-    # https://github.com/huggingface/huggingface_hub/issues/2005
     def test_streaming_response_validation(self):
+        """
+        Regression test for #2005.
+
+        See https://github.com/huggingface/huggingface_hub/issues/2005
+        """
         json_payload_latest = {
             "index": 97,
             "token": {"id": 264, "text": " a", "logprob": -0.0003259182, "special": False},
@@ -116,14 +120,20 @@ class TestTextGenerationTypes(unittest.TestCase):
             "details": None,
         }
         TextGenerationStreamResponse(**json_payload_latest)
+
         json_payload_older_had_no_index = {
             "token": {"id": 264, "text": " a", "logprob": -0.0003259182, "special": False},
             "generated_text": None,
             "details": None,
         }
         TextGenerationStreamResponse(**json_payload_older_had_no_index)
-        json_payload_without_required_field_token = {"index": 97, "generated_text": None, "details": None}
-        with self.assertRaises(ValidationError):
+
+        json_payload_without_required_field_token = {
+            "index": 97,
+            "generated_text": None,
+            "details": None,
+        }
+        with self.assertRaises((ValidationError, TypeError)):
             TextGenerationStreamResponse(**json_payload_without_required_field_token)
 
 


### PR DESCRIPTION
Fixes https://github.com/huggingface/huggingface_hub/issues/2005

This PR adds tolerance for an `index` field in the TextGenerationStreamResponse.

The latest version of HuggingFace Text Generation Inference added an `index` field to the streaming response to be compatible with OpenAI clients, but the HuggingFace InferenceClient wasn't updated to accept it.

https://github.com/huggingface/text-generation-inference/commit/0eabc83541225979209ff7183b4b4442e47adf92#diff-c3259a23eb2e9e4e39f9a5226354b99508e42b05a158036dc482397410becd52R501