### PR TITLE
Update repository.md

### DIFF
--- a/docs/source/en/guides/repository.md
+++ b/docs/source/en/guides/repository.md
@@ -108,7 +108,7 @@ You can create new branch and tags using [`create_branch`] and [`create_tag`]:
 >>> create_branch("Matthijs/speecht5-tts-demo", repo_type="space", branch="handle-dog-speaker")
 
 # Create a tag on a Dataset repo from `v0.1-release` branch
->>> create_branch("bigcode/the-stack", repo_type="dataset", revision="v0.1-release", tag="v0.1.1", tag_message="Bump release version.")
+>>> create_branch("bigcode/the-stack", repo_type="dataset", revision="v0.1-release", tag="v0.1.1")
 ```
 
 You can use the [`delete_branch`] and [`delete_tag`] functions in the same way to delete a branch or a tag.


### PR DESCRIPTION
create_branch() no longer accepts "tag_message" as well.

https://huggingface.co/docs/huggingface_hub/v0.20.3/en/package_reference/hf_api#huggingface_hub.HfApi.create_branch


---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[22], line 1
----> 1 create_branch(
      2     "mylesdyson/speecht5-tts-demo",
      3     repo_type="dataset",
      4     revision="v0.1-release",
      5     tag_message="Bump release version.",
      6     token=HF_TOKEN
      7 )

File ~/.local/lib/python3.10/site-packages/huggingface_hub/utils/_validators.py:118, in validate_hf_hub_args.<locals>._inner_fn(*args, **kwargs)
    115 if check_use_auth_token:
    116     kwargs = smoothly_deprecate_use_auth_token(fn_name=fn.__name__, has_token=has_token, kwargs=kwargs)
--> 118 return fn(*args, **kwargs)

TypeError: HfApi.create_branch() got an unexpected keyword argument 'tag_message'