### PR TITLE
update name of dummy dataset user

### DIFF
--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2674,8 +2674,8 @@ class ActivityApiTest(unittest.TestCase):
 
     def test_list_likes_repos_auth_and_explicit_user(self) -> None:
         # User is explicit even if auth
-        likes = self.api.list_liked_repos(user="__DUMMY_DATASETS_SERVER_USER__", token=TOKEN)
-        self.assertEqual(likes.user, "__DUMMY_DATASETS_SERVER_USER__")
+        likes = self.api.list_liked_repos(user=OTHER_USER, token=TOKEN)
+        self.assertEqual(likes.user, OTHER_USER)
 
     def test_list_repo_likers(self) -> None:
         # Create a repo + like

--- a/tests/testing_constants.py
+++ b/tests/testing_constants.py
@@ -7,7 +7,7 @@ TOKEN = "hf_94wBhPGp6KrrTH3KDchhKpRxZwd6dmHWLL"
 
 # Used to create repos that we don't own (example: for gated repo)
 # Token is not critical. Also public in https://github.com/huggingface/datasets-server
-OTHER_USER = "__DUMMY_DATASETS_SERVER_USER__"
+OTHER_USER = "DSSUser"
 OTHER_TOKEN = "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"
 
 ENDPOINT_PRODUCTION = "https://huggingface.co"


### PR DESCRIPTION
Should fix the CI. 

Looks like `__DUMMY_DATASETS_SERVER_USER__` has been replaced by `DSSUser` on staging. I'll merge if CI gets green.