### PR TITLE
Update backoff strategy

### DIFF
--- a/src/huggingface_hub/lfs.py
+++ b/src/huggingface_hub/lfs.py
@@ -295,7 +295,7 @@ def _upload_single_part(operation: "CommitOperationAdd", upload_url: str) -> Non
     """
     with operation.as_file(with_tqdm=True) as fileobj:
         # S3 might raise a transient 500 error -> let's retry if that happens
-        response = http_backoff("PUT", upload_url, data=fileobj, retry_on_status_codes=(500, 503))
+        response = http_backoff("PUT", upload_url, data=fileobj, retry_on_status_codes=(500, 502, 503, 504))
         hf_raise_for_status(response)
 
 
@@ -380,7 +380,7 @@ def _upload_parts_iteratively(
             ) as fileobj_slice:
                 # S3 might raise a transient 500 error -> let's retry if that happens
                 part_upload_res = http_backoff(
-                    "PUT", part_upload_url, data=fileobj_slice, retry_on_status_codes=(500, 503)
+                    "PUT", part_upload_url, data=fileobj_slice, retry_on_status_codes=(500, 502, 503, 504)
                 )
                 hf_raise_for_status(part_upload_res)
                 headers.append(part_upload_res.headers)


### PR DESCRIPTION
~Instead of only 504 by default. Those might be transient errors happening when downloading or uploading files. Let's retry when that happens.~

~Related to https://github.com/huggingface/datasets/issues/6577#issuecomment-1937589686 (cc @sanchit-gandhi) which most likely happened due to the outage on Saturday (so a retry wouldn't have helped) but I still reviewed the process as we were currently having different retry mechanism spread in the codebase. (+it's not the first time I've seen this kind of feedback so let's "fix it" once and for all).~

**EDIT:** Retry on any 5xx on upload. Retry on any 5xx on download except 500. (see below)