### PR TITLE
Fix canonical dataset create_branch with exist_ok=True

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -5595,7 +5595,7 @@ class HfApi:
         try:
             hf_raise_for_status(response)
         except HfHubHTTPError as e:
-            if not (e.response.status_code == 409 and exist_ok):
+            if not (e.response.status_code in (400, 409) and exist_ok):
                 raise
 
     @validate_hf_hub_args


### PR DESCRIPTION
Fix this error in a canonical dataset.push_to_hub when trying to create a branch PR that already exists:
```
  File "/home/user/.local/lib/python3.10/site-packages/huggingface_hub/hf_api.py", line 5416, in create_branch
    hf_raise_for_status(response)
  File "/home/user/.local/lib/python3.10/site-packages/huggingface_hub/utils/_errors.py", line 329, in hf_raise_for_status
    raise BadRequestError(message, response=response) from e
huggingface_hub.utils._errors.BadRequestError:  (Request ID: Root=1-65d74c67-3f304fac07a4d9b845066abf;10de298a-63e2-4ead-bba6-cb527e80d563)

Bad request:
Invalid reference for a branch: refs/pr/9
```

Not sure this should be merged since it's a behavior that may only concern canonical datasets.
Anyway I'm using this branch to run my code 😬 