### PR TITLE
Fix getting widget_data from model_info

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -675,7 +675,7 @@ class ModelInfo:
             ModelCardData(**card_data, ignore_metadata_errors=True) if isinstance(card_data, dict) else card_data
         )
 
-        self.widget_data = kwargs.pop("widget_data", None)
+        self.widget_data = kwargs.pop("widgetData", None)
         self.model_index = kwargs.pop("model-index", None) or kwargs.pop("model_index", None)
         self.config = kwargs.pop("config", None)
         transformers_info = kwargs.pop("transformersInfo", None) or kwargs.pop("transformers_info", None)

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -1718,6 +1718,10 @@ class HfApiPublicProductionTest(unittest.TestCase):
             self.assertIsNone(model.card_data.eval_results)
         self.assertTrue(any("Invalid model-index" in log for log in warning_logs.output))
 
+    def test_model_info_with_widget_data(self):
+        info = self._api.model_info("HuggingFaceH4/zephyr-7b-beta")
+        assert info.widget_data is not None
+
     def test_list_repo_files(self):
         files = self._api.list_repo_files(repo_id=DUMMY_MODEL_ID)
         expected_files = [


### PR DESCRIPTION
When getting information about a model, we need to parse `widgetData`, not `widget_data`. It probably never worked correctly^^. Fixed it and added a test.

See for example https://huggingface.co/api/models/HuggingFaceH4/zephyr-7b-beta.