### PR TITLE
Add `revision_exists` helper

### DIFF
--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -227,6 +227,7 @@ _SUBMOD_ATTRS = {
         "request_space_storage",
         "restart_space",
         "resume_inference_endpoint",
+        "revision_exists",
         "run_as_future",
         "scale_to_zero_inference_endpoint",
         "set_space_sleep_time",
@@ -582,6 +583,7 @@ if TYPE_CHECKING:  # pragma: no cover
         request_space_storage,  # noqa: F401
         restart_space,  # noqa: F401
         resume_inference_endpoint,  # noqa: F401
+        revision_exists,  # noqa: F401
         run_as_future,  # noqa: F401
         scale_to_zero_inference_endpoint,  # noqa: F401
         set_space_sleep_time,  # noqa: F401

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -2457,24 +2457,67 @@ class HfApi:
         Returns:
             True if the repository exists, False otherwise.
 
-        <Tip>
-
         Examples:
             ```py
             >>> from huggingface_hub import repo_exists
-            >>> repo_exists("huggingface/transformers")
+            >>> repo_exists("google/gemma-7b")
             True
-            >>> repo_exists("huggingface/not-a-repo")
+            >>> repo_exists("google/not-a-repo")
             False
             ```
-
-        </Tip>
         """
         try:
             self.repo_info(repo_id=repo_id, repo_type=repo_type, token=token)
             return True
         except GatedRepoError:
             return True  # we don't have access but it exists
+        except RepositoryNotFoundError:
+            return False
+
+    @validate_hf_hub_args
+    def revision_exists(
+        self,
+        repo_id: str,
+        revision: str,
+        *,
+        repo_type: Optional[str] = None,
+        token: Optional[str] = None,
+    ) -> bool:
+        """
+        Checks if a specific revision exists on a repo on the Hugging Face Hub.
+
+        Args:
+            repo_id (`str`):
+                A namespace (user or an organization) and a repo name separated
+                by a `/`.
+            revision (`str`):
+                The revision of the repository to check.
+            repo_type (`str`, *optional*):
+                Set to `"dataset"` or `"space"` if getting repository info from a dataset or a space,
+                `None` or `"model"` if getting repository info from a model. Default is `None`.
+            token (`bool` or `str`, *optional*):
+                A valid authentication token (see https://huggingface.co/settings/token).
+                If `None` or `True` and machine is logged in (through `huggingface-cli login`
+                or [`~huggingface_hub.login`]), token will be retrieved from the cache.
+                If `False`, token is not sent in the request header.
+
+        Returns:
+            True if the repository and the revision exists, False otherwise.
+
+        Examples:
+            ```py
+            >>> from huggingface_hub import revision_exists
+            >>> revision_exists("google/gemma-7b", "float16")
+            True
+            >>> revision_exists("google/gemma-7b", "not-a-revision")
+            False
+            ```
+        """
+        try:
+            self.repo_info(repo_id=repo_id, revision=revision, repo_type=repo_type, token=token)
+            return True
+        except RevisionNotFoundError:
+            return False
         except RepositoryNotFoundError:
             return False
 
@@ -2512,8 +2555,6 @@ class HfApi:
         Returns:
             True if the file exists, False otherwise.
 
-        <Tip>
-
         Examples:
             ```py
             >>> from huggingface_hub import file_exists
@@ -2524,8 +2565,6 @@ class HfApi:
             >>> file_exists("bigcode/not-a-repo", "config.json")
             False
             ```
-
-        </Tip>
         """
         url = hf_hub_url(
             repo_id=repo_id, repo_type=repo_type, revision=revision, filename=filename, endpoint=self.endpoint
@@ -8493,6 +8532,7 @@ list_spaces = api.list_spaces
 space_info = api.space_info
 
 repo_exists = api.repo_exists
+revision_exists = api.revision_exists
 file_exists = api.file_exists
 repo_info = api.repo_info
 list_repo_files = api.list_repo_files

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -170,6 +170,12 @@ class HfApiRepoFileExistsTest(HfApiCommonTest):
         self.assertFalse(self._api.repo_exists(self.repo_id, token=False))  # private repo
         self.assertFalse(self._api.repo_exists("repo-that-does-not-exist"))  # missing repo
 
+    def test_revision_exists(self):
+        assert self._api.revision_exists(self.repo_id, "main")
+        assert not self._api.revision_exists(self.repo_id, "revision-that-does-not-exist")  # missing revision
+        assert not self._api.revision_exists(self.repo_id, "main", token=False)  # private repo
+        assert not self._api.revision_exists("repo-that-does-not-exist", "main")  # missing repo
+
     @patch("huggingface_hub.file_download.ENDPOINT", "https://hub-ci.huggingface.co")
     @patch(
         "huggingface_hub.file_download.HUGGINGFACE_CO_URL_TEMPLATE",


### PR DESCRIPTION
Related to https://github.com/huggingface/huggingface_hub/pull/2040.

This PR adds a new helper `revision_exists`, similar to the existing `repo_exists` and `file_exists`.
Returns True if the repo + revision exist, False otherwise.

I also fixed some docstrings (removed <Tip> section around the "examples" part)