### PR TITLE
Fix ModelStatus compute type

### DIFF
--- a/src/huggingface_hub/inference/_common.py
+++ b/src/huggingface_hub/inference/_common.py
@@ -84,8 +84,9 @@ class ModelStatus:
             backend. Loadable models are automatically loaded when the user first
             requests inference on the endpoint. This means it is transparent for the
             user to load a model, except that the first call takes longer to complete.
-        compute_type (`str`):
-            The type of compute resource the model is using or will use, such as 'gpu' or 'cpu'.
+        compute_type (`Dict`):
+            Information about the compute resource the model is using or will use, such as 'gpu' type and number of
+            replicas.
         framework (`str`):
             The name of the framework that the model was built with, such as 'transformers'
             or 'text-generation-inference'.
@@ -93,7 +94,7 @@ class ModelStatus:
 
     loaded: bool
     state: str
-    compute_type: str
+    compute_type: Dict
     framework: str
 
 

--- a/tests/test_inference_async_client.py
+++ b/tests/test_inference_async_client.py
@@ -216,7 +216,7 @@ async def test_get_status_loaded_model() -> None:
     model_status = await AsyncInferenceClient().get_model_status("bigscience/bloom")
     assert model_status.loaded is True
     assert model_status.state == "Loaded"
-    assert model_status.compute_type == "gpu"
+    assert isinstance(model_status.compute_type, dict)  # e.g. {'gpu': {'gpu': 'a100', 'count': 8}}
     assert model_status.framework == "text-generation-inference"
 
 

--- a/tests/test_inference_client.py
+++ b/tests/test_inference_client.py
@@ -553,10 +553,10 @@ class TestModelStatus(unittest.TestCase):
     def test_loaded_model(self) -> None:
         client = InferenceClient()
         model_status = client.get_model_status("bigscience/bloom")
-        self.assertTrue(model_status.loaded)
-        self.assertEqual(model_status.state, "Loaded")
-        self.assertEqual(model_status.compute_type, "gpu")
-        self.assertEqual(model_status.framework, "text-generation-inference")
+        assert model_status.loaded
+        assert model_status.state == "Loaded"
+        assert isinstance(model_status.compute_type, dict)  # e.g. {'gpu': {'gpu': 'a100', 'count': 8}}
+        assert model_status.framework == "text-generation-inference"
 
     def test_unknown_model(self) -> None:
         client = InferenceClient()


### PR DESCRIPTION
Following the "compute type" revampt in API Inference ([here](https://github.com/huggingface/api-inference/pull/1785) - internal PR) cc @Narsil. Now the expected `compute_type` is not a string anymore but a dictionary. Example: `gpu` becomes `{'gpu': {'gpu': 'a100', 'count': 8}}`. 

Not problematic for `huggingface_hub` (I don't expect anyone to have used this) but let's fix the test/docstrings.