### PR TITLE
Fix Space variable when updatedAt is missing

### DIFF
--- a/src/huggingface_hub/_space_api.py
+++ b/src/huggingface_hub/_space_api.py
@@ -138,8 +138,8 @@ class SpaceVariable:
             Variable value. Example: `"the_model_repo_id"`.
         description (`str` or None):
             Description of the variable. Example: `"Model Repo ID of the implemented model"`.
-        updatedAt (`datetime`):
-            datetime of the last update of the variable (if any).
+        updatedAt (`datetime` or None):
+            datetime of the last update of the variable (if the variable has been updated at least once).
     """
 
     key: str

--- a/src/huggingface_hub/_space_api.py
+++ b/src/huggingface_hub/_space_api.py
@@ -139,16 +139,17 @@ class SpaceVariable:
         description (`str` or None):
             Description of the variable. Example: `"Model Repo ID of the implemented model"`.
         updatedAt (`datetime`):
-            datetime of the last update of the variable.
+            datetime of the last update of the variable (if any).
     """
 
     key: str
     value: str
     description: Optional[str]
-    updated_at: datetime
+    updated_at: Optional[datetime]
 
     def __init__(self, key: str, values: Dict) -> None:
         self.key = key
         self.value = values["value"]
         self.description = values.get("description")
-        self.updated_at = parse_datetime(values["updatedAt"])
+        updated_at = values.get("updatedAt")
+        self.updated_at = parse_datetime(updated_at) if updated_at is not None else None


### PR DESCRIPTION
In [moon-landing](https://github.com/huggingface/moon-landing/blob/main/server/app/spacesHandlers.ts#L68) (private repo), the `updatedAt` field is optional for Space variables. Never noticed before but it brakes the date parsing in that case. This PR fixes this by making the field optional in Python as well.

Encountered this bug while investigating an issue on https://huggingface.co/spaces/Wauplin/gradio-space-ci 