### PR TITLE
Point out that the token must have write scope

### DIFF
--- a/src/huggingface_hub/utils/_errors.py
+++ b/src/huggingface_hub/utils/_errors.py
@@ -357,6 +357,17 @@ def hf_raise_for_status(response: Response, endpoint_name: Optional[str] = None)
             )
             raise BadRequestError(message, response=response) from e
 
+        elif response.status_code == 403:
+            message = (
+                    f"{response.status_code} Client Error."
+                    + "\n\n"
+                    + f"Bad request for {endpoint_name} endpoint:" if endpoint_name is not None else "Bad request:"
+                    + "\nPlease make sure you specified the correct `repo_id` and `repo_type`."
+                    + "\nIf you are trying to create or update content,"
+                    + "make sure you have a token with the `write` role."
+            )
+            raise BadRequestError(message, response=response) from e
+
         # Convert `HTTPError` into a `HfHubHTTPError` to display request information
         # as well (request id and/or server error message)
         raise HfHubHTTPError(str(e), response=response) from e

--- a/tests/test_utils_errors.py
+++ b/tests/test_utils_errors.py
@@ -49,6 +49,19 @@ class TestErrorUtils(unittest.TestCase):
         self.assertEqual(context.exception.response.status_code, 401)
         self.assertIn("Request ID: 123", str(context.exception))
 
+    def test_hf_raise_for_status_403_wrong_token_scope(self) -> None:
+        response = Response()
+        response.headers = {"X-Request-Id": 123}
+        response.status_code = 403
+        response.request = PreparedRequest()
+        response.request.url = "https://huggingface.co/api/repos/create"
+        expected_message_part = "make sure you have a token with the `write` role"
+        with self.assertRaisesRegex(BadRequestError, expected_message_part) as context:
+            hf_raise_for_status(response)
+
+        self.assertEqual(context.exception.response.status_code, 403)
+        self.assertIn("Request ID: 123", str(context.exception))
+
     def test_hf_raise_for_status_401_not_repo_url(self) -> None:
         response = Response()
         response.headers = {"X-Request-Id": 123}


### PR DESCRIPTION
In case of an HTTP 403, inform the user that their token might not have the right scope for the action.
As things are today, the HF Hub API only returns `'X-Error-Message': "You don't have the rights to create a model under this namespace"` in that case so we have to rely on the HTTP error. 

I think a better solution would be for the API to return a proper `X-Error-Code` in case of entity creation/update + a read-only scoped token but that requires server-side changes first.

Fixes #1653