### PR TITLE
[HfFileSystem] Fix glob with pattern without wildcards

### DIFF
--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -557,7 +557,7 @@ class HfFileSystem(fsspec.AbstractFileSystem):
     def exists(self, path, **kwargs):
         """Is there a file at the given path"""
         try:
-            self.info(path, expand_info=False, **kwargs)
+            self.info(path, **{**kwargs, "expand_info": False})
             return True
         except:  # noqa: E722
             # any exception allowed bar FileNotFoundError?

--- a/tests/test_hf_file_system.py
+++ b/tests/test_hf_file_system.py
@@ -82,6 +82,10 @@ class HfFileSystemTests(unittest.TestCase):
 
     def test_glob(self):
         self.assertEqual(
+            self.hffs.glob(self.hf_path + "/.gitattributes"),
+            [self.hf_path + "/.gitattributes"],
+        )
+        self.assertEqual(
             sorted(self.hffs.glob(self.hf_path + "/*")),
             sorted([self.hf_path + "/.gitattributes", self.hf_path + "/data"]),
         )


### PR DESCRIPTION
It was reported in https://github.com/huggingface/datasets/pull/6687

This is currently impacting `datasets` and DVC folks so it would be great to have a patch release once it's merged