### PR TITLE
Enable `python-xdist` on all tests

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -91,13 +91,13 @@ jobs:
 
             "Repository only")
               # Run repo tests concurrently
-              PYTEST="$PYTEST ../tests -k 'TestRepository' -n4"
+              PYTEST="$PYTEST ../tests -k 'TestRepository' -n auto"
               echo $PYTEST
               eval $PYTEST
             ;;
 
             "Everything else")
-              PYTEST="$PYTEST ../tests -k 'not TestRepository'"
+              PYTEST="$PYTEST ../tests -k 'not TestRepository' -n auto"
               echo $PYTEST
               eval $PYTEST
             ;;
@@ -156,7 +156,6 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install .[testing]
-        # sudo apt install -y libsndfile1-dev
 
       # Easy debugging if CI is broken
       - name: Pip freeze
@@ -165,7 +164,7 @@ jobs:
       # Run tests
       - name: Run tests
         working-directory: ./src # For code coverage to work
-        run: python -m pytest --cov=./huggingface_hub --cov-report=xml:../coverage.xml --vcr-record=none --reruns 5 --reruns-delay 1 --only-rerun '(OSError|Timeout|HTTPError.*502|HTTPError.*504|not less than or equal to 0.01)' ../tests
+        run: python -m pytest -n auto --cov=./huggingface_hub --cov-report=xml:../coverage.xml --vcr-record=none --reruns 5 --reruns-delay 1 --only-rerun '(OSError|Timeout|HTTPError.*502|HTTPError.*504|not less than or equal to 0.01)' ../tests
 
       # Upload code coverage
       - name: Upload coverage reports to Codecov with GitHub Action

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -91,13 +91,13 @@ jobs:
 
             "Repository only")
               # Run repo tests concurrently
-              PYTEST="$PYTEST ../tests -k 'TestRepository' -n auto"
+              PYTEST="$PYTEST ../tests -k 'TestRepository' -n 4"
               echo $PYTEST
               eval $PYTEST
             ;;
 
             "Everything else")
-              PYTEST="$PYTEST ../tests -k 'not TestRepository' -n auto"
+              PYTEST="$PYTEST ../tests -k 'not TestRepository' -n 4"
               echo $PYTEST
               eval $PYTEST
             ;;
@@ -164,7 +164,7 @@ jobs:
       # Run tests
       - name: Run tests
         working-directory: ./src # For code coverage to work
-        run: python -m pytest -n auto --cov=./huggingface_hub --cov-report=xml:../coverage.xml --vcr-record=none --reruns 5 --reruns-delay 1 --only-rerun '(OSError|Timeout|HTTPError.*502|HTTPError.*504|not less than or equal to 0.01)' ../tests
+        run: python -m pytest -n 4 --cov=./huggingface_hub --cov-report=xml:../coverage.xml --vcr-record=none --reruns 5 --reruns-delay 1 --only-rerun '(OSError|Timeout|HTTPError.*502|HTTPError.*504|not less than or equal to 0.01)' ../tests
 
       # Upload code coverage
       - name: Upload coverage reports to Codecov with GitHub Action


### PR DESCRIPTION
Enable `python-xdist` on all tests. This reduces overall test execution by 55% on CI down to a around 6min (from 12min).
After experimenting, using 4 instead of `auto` processes seems to avoid too much context trashing. 

|                 | Total duration |  | Comment                    |  
|----------|---------------|-|----------------------|
| Baseline        | 12m 13s        | [Workflow](https://github.com/huggingface/huggingface_hub/actions/runs/8083119316)         |                                           |
| xdist `-n auto` | 6m 33s         | [Workflow](https://github.com/huggingface/huggingface_hub/actions/runs/8086882581?pr=2059) | ubuntu a bit slower, windows a lot faster | 
| xdist `-n 4`    | 5m 46s            |  [Workflow](https://github.com/huggingface/huggingface_hub/actions/runs/8087001450) |

Open questions:
- [ ] The combinations that do work, can they be folded into a single test matrix configurarion (essentially whether there is still a need for Repository only/Everything else/torch; the others like lfs/fastai/tensorflow are still required as they need specific python versions. Even though this can be improved, it's likely not worth it as the windows configuration will be the dominating factor for overall CI time. 
- [x] Do Windows tests pass at all through xdist?
- [x] Should the `"Repository only"` tests keep using `-n 4` vs `-n auto` (rate limit concerns)