### PR TITLE
Some cleaning

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -12,9 +12,6 @@ on:
     paths-ignore:
       - "docs/**"
 
-env:
-  HUGGINGFACE_PRODUCTION_USER_TOKEN: ${{ secrets.HUGGINGFACE_PRODUCTION_USER_TOKEN }}
-
 jobs:
   build-ubuntu:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -265,14 +265,3 @@ And the following will only run the tests that include `tag` in their name:
 ```bash
 $ python -m pytest ./tests -k tag
 ```
-
-#### A corner case: testing Spaces
-
-Fully testing Spaces is not possible on staging. We need to use the production environment
- for it (e.g huggingface.co). To do so, a personal User Access Token has to be set as
- `HUGGINGFACE_PRODUCTION_USER_TOKEN` environment variable, specifically for these tests.
- This value is configured in the Github CI but you need to set it on your machine to run
- the tests locally. The token requires write permission and a credit card must be set on
- your account.
-
- Note that if the token is not find, the related tests are skipped.

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2766,9 +2766,7 @@ class TestSquashHistory(HfApiCommonTest):
 @pytest.mark.vcr
 class TestSpaceAPIProduction(unittest.TestCase):
     """
-    Testing Space API is not possible on staging. Tests are run against production
-    server using a token stored under `HUGGINGFACE_PRODUCTION_USER_TOKEN` environment
-    variable. Tests requiring hardware are mocked to spare some resources.
+    Testing Space API is not possible on staging. We use VCR-ed to mimic server requests.
     """
 
     repo_id: str


### PR DESCRIPTION
cc @LysandreJik we don't use `HUGGINGFACE_PRODUCTION_USER_TOKEN` in the test CI anymore.
It is still used in `push_repocard_examples.py` to we still need to keep the GH secret.