### PR TITLE
Use uv in CI to speed-up requirements install

### DIFF
--- a/.github/workflows/python-quality.yml
+++ b/.github/workflows/python-quality.yml
@@ -25,25 +25,25 @@ jobs:
           python-version: 3.9
 
       # Setup venv
+      # TODO: remove this once uv is available in the default environment
+      # See https://github.com/astral-sh/uv/pull/2000
       - name: Setup venv + uv
         run: |
           pip install --upgrade uv
           uv venv
 
       - name: Install dependencies
-        # Hack: set VIRTUAL_ENV= to trick uv. TODO: remove this at some point.
-        # See https://github.com/astral-sh/uv/pull/2000
-        run: VIRTUAL_ENV= uv pip install "huggingface_hub[dev] @ ."
-      - run: ruff check tests src contrib # linter
-      - run: ruff format --check tests src contrib # formatter
-      - run: python utils/check_contrib_list.py
-      - run: python utils/check_static_imports.py
-      - run: python utils/generate_async_inference_client.py
-      - run: python utils/generate_inference_types.py
+        run: uv pip install "huggingface_hub[dev] @ ."
+      - run: .venv/bin/ruff check tests src contrib # linter
+      - run: .venv/bin/ruff format --check tests src contrib # formatter
+      - run: .venv/bin/python utils/check_contrib_list.py
+      - run: .venv/bin/python utils/check_static_imports.py
+      - run: .venv/bin/python utils/generate_async_inference_client.py
+      - run: .venv/bin/python utils/generate_inference_types.py
 
       # Run type checking at least on huggingface_hub root file to check all modules
       # that can be lazy-loaded actually exist.
-      - run: mypy src/huggingface_hub/__init__.py --follow-imports=silent --show-traceback
+      - run: .venv/bin/mypy src/huggingface_hub/__init__.py --follow-imports=silent --show-traceback
 
       # Run mypy on full package
-      - run: mypy src
+      - run: .venv/bin/mypy src

--- a/.github/workflows/python-quality.yml
+++ b/.github/workflows/python-quality.yml
@@ -23,10 +23,16 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
-      - name: Install dependencies
+
+      # Setup venv
+      - name: Setup venv + uv
         run: |
           pip install --upgrade uv
-          uv pip install "huggingface_hub[dev] @ ."
+          uv venv
+          source .venv/bin/activate
+
+      - name: Install dependencies
+        run: uv pip install "huggingface_hub[dev] @ ."
       - run: ruff check tests src contrib # linter
       - run: ruff format --check tests src contrib # formatter
       - run: python utils/check_contrib_list.py

--- a/.github/workflows/python-quality.yml
+++ b/.github/workflows/python-quality.yml
@@ -30,6 +30,7 @@ jobs:
           pip install --upgrade uv
           uv venv
           source .venv/bin/activate
+          echo PATH=$PATH >> $GITHUB_ENV  # See https://stackoverflow.com/a/74669486
 
       - name: Install dependencies
         run: uv pip install "huggingface_hub[dev] @ ."

--- a/.github/workflows/python-quality.yml
+++ b/.github/workflows/python-quality.yml
@@ -25,8 +25,8 @@ jobs:
           python-version: 3.9
       - name: Install dependencies
         run: |
-          pip install --upgrade pip
-          pip install .[dev]
+          pip install --upgrade uv
+          uv pip install ".[dev]"
       - run: ruff check tests src contrib # linter
       - run: ruff format --check tests src contrib # formatter
       - run: python utils/check_contrib_list.py

--- a/.github/workflows/python-quality.yml
+++ b/.github/workflows/python-quality.yml
@@ -31,17 +31,19 @@ jobs:
           uv venv
 
       - name: Install dependencies
-        run: uv pip install "huggingface_hub[dev] @ ."
-      - run: .venv/bin/ruff check tests src contrib # linter
-      - run: .venv/bin/ruff format --check tests src contrib # formatter
-      - run: .venv/bin/python utils/check_contrib_list.py
-      - run: .venv/bin/python utils/check_static_imports.py
-      - run: .venv/bin/python utils/generate_async_inference_client.py
-      - run: .venv/bin/python utils/generate_inference_types.py
+        # Hack: set VIRTUAL_ENV= to trick uv. TODO: remove this at some point.
+        # See https://github.com/astral-sh/uv/pull/2000
+        run: VIRTUAL_ENV= uv pip install "huggingface_hub[dev] @ ."
+      - run: ruff check tests src contrib # linter
+      - run: ruff format --check tests src contrib # formatter
+      - run: python utils/check_contrib_list.py
+      - run: python utils/check_static_imports.py
+      - run: python utils/generate_async_inference_client.py
+      - run: python utils/generate_inference_types.py
 
       # Run type checking at least on huggingface_hub root file to check all modules
       # that can be lazy-loaded actually exist.
-      - run: .venv/bin/mypy src/huggingface_hub/__init__.py --follow-imports=silent --show-traceback
+      - run: mypy src/huggingface_hub/__init__.py --follow-imports=silent --show-traceback
 
       # Run mypy on full package
-      - run: .venv/bin/mypy src
+      - run: mypy src

--- a/.github/workflows/python-quality.yml
+++ b/.github/workflows/python-quality.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade uv
-          uv pip install ".[dev]"
+          uv pip install "huggingface_hub[dev] @ ."
       - run: ruff check tests src contrib # linter
       - run: ruff format --check tests src contrib # formatter
       - run: python utils/check_contrib_list.py

--- a/.github/workflows/python-quality.yml
+++ b/.github/workflows/python-quality.yml
@@ -25,8 +25,7 @@ jobs:
           python-version: 3.9
 
       # Setup venv
-      # TODO: remove this once uv is available in the default environment
-      # See https://github.com/astral-sh/uv/pull/2000
+      # TODO: revisit when https://github.com/astral-sh/uv/issues/1526 is addressed.
       - name: Setup venv + uv
         run: |
           pip install --upgrade uv

--- a/.github/workflows/python-quality.yml
+++ b/.github/workflows/python-quality.yml
@@ -29,21 +29,19 @@ jobs:
         run: |
           pip install --upgrade uv
           uv venv
-          source .venv/bin/activate
-          echo PATH=$PATH >> $GITHUB_ENV  # See https://stackoverflow.com/a/74669486
 
       - name: Install dependencies
         run: uv pip install "huggingface_hub[dev] @ ."
-      - run: ruff check tests src contrib # linter
-      - run: ruff format --check tests src contrib # formatter
-      - run: python utils/check_contrib_list.py
-      - run: python utils/check_static_imports.py
-      - run: python utils/generate_async_inference_client.py
-      - run: python utils/generate_inference_types.py
+      - run: .venv/bin/ruff check tests src contrib # linter
+      - run: .venv/bin/ruff format --check tests src contrib # formatter
+      - run: .venv/bin/python utils/check_contrib_list.py
+      - run: .venv/bin/python utils/check_static_imports.py
+      - run: .venv/bin/python utils/generate_async_inference_client.py
+      - run: .venv/bin/python utils/generate_inference_types.py
 
       # Run type checking at least on huggingface_hub root file to check all modules
       # that can be lazy-loaded actually exist.
-      - run: mypy src/huggingface_hub/__init__.py --follow-imports=silent --show-traceback
+      - run: .venv/bin/mypy src/huggingface_hub/__init__.py --follow-imports=silent --show-traceback
 
       # Run mypy on full package
-      - run: mypy src
+      - run: .venv/bin/mypy src

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -47,8 +47,8 @@ jobs:
       # Install dependencies
       - name: Configure and install dependencies
         run: |
-          pip install --upgrade pip
-          pip install .[testing]
+          pip install --upgrade uv
+          uv pip install ".[testing]"
 
           case "${{ matrix.test_name }}" in
 
@@ -63,13 +63,13 @@ jobs:
               ;;
 
             fastai | torch)
-              pip install .[${{ matrix.test_name }}]
+              uv pip install .[${{ matrix.test_name }}]
               ;;
 
             tensorflow)
               sudo apt update
               sudo apt install -y graphviz
-              pip install .[tensorflow]
+              uv pip install .[tensorflow]
               ;;
 
           esac
@@ -151,8 +151,8 @@ jobs:
       # Install dependencies
       - name: Configure and install dependencies
         run: |
-          pip install --upgrade pip
-          pip install .[testing]
+          pip install --upgrade uv
+          uv pip install ".[testing]"
 
       # Easy debugging if CI is broken
       - name: Pip freeze

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Configure and install dependencies
         run: |
           pip install --upgrade uv
-          uv pip install ".[testing]"
+          uv pip install "huggingface_hub[testing] @ ."
 
           case "${{ matrix.test_name }}" in
 
@@ -63,13 +63,13 @@ jobs:
               ;;
 
             fastai | torch)
-              uv pip install .[${{ matrix.test_name }}]
+              uv pip install "huggingface_hub[${{ matrix.test_name }}] @ ."
               ;;
 
             tensorflow)
               sudo apt update
               sudo apt install -y graphviz
-              uv pip install .[tensorflow]
+              uv pip install "huggingface_hub[tensorflow] @ ."
               ;;
 
           esac
@@ -152,7 +152,7 @@ jobs:
       - name: Configure and install dependencies
         run: |
           pip install --upgrade uv
-          uv pip install ".[testing]"
+          uv pip install "huggingface_hub[testing] @ ."
 
       # Easy debugging if CI is broken
       - name: Pip freeze

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -85,7 +85,8 @@ jobs:
       - name: Run tests
         working-directory: ./src # For code coverage to work
         run: |
-          PYTEST="../.venv/bin/python -m pytest --cov=./huggingface_hub --cov-report=xml:../coverage.xml --vcr-record=none --reruns 5 --reruns-delay 1 --only-rerun '(OSError|Timeout|HTTPError.*502|HTTPError.*504||not less than or equal to 0.01)'"
+          source ../venv/bin/activate
+          PYTEST="python -m pytest --cov=./huggingface_hub --cov-report=xml:../coverage.xml --vcr-record=none --reruns 5 --reruns-delay 1 --only-rerun '(OSError|Timeout|HTTPError.*502|HTTPError.*504||not less than or equal to 0.01)'"
 
           case "${{ matrix.test_name }}" in
 
@@ -166,7 +167,9 @@ jobs:
       # Run tests
       - name: Run tests
         working-directory: ./src # For code coverage to work
-        run: .venv\Scripts\python -m pytest -n 4 --cov=./huggingface_hub --cov-report=xml:../coverage.xml --vcr-record=none --reruns 5 --reruns-delay 1 --only-rerun '(OSError|Timeout|HTTPError.*502|HTTPError.*504|not less than or equal to 0.01)' ../tests
+        run: |
+          .venv\Scripts\activate
+          python -m pytest -n 4 --cov=./huggingface_hub --cov-report=xml:../coverage.xml --vcr-record=none --reruns 5 --reruns-delay 1 --only-rerun '(OSError|Timeout|HTTPError.*502|HTTPError.*504|not less than or equal to 0.01)' ../tests
 
       # Upload code coverage
       - name: Upload coverage reports to Codecov with GitHub Action

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -166,7 +166,7 @@ jobs:
       - name: Run tests
         working-directory: ./src # For code coverage to work
         run: |
-          .venv/bin/activate
+          ..\.venv\Scripts\activate
           python -m pytest -n 4 --cov=./huggingface_hub --cov-report=xml:../coverage.xml --vcr-record=none --reruns 5 --reruns-delay 1 --only-rerun '(OSError|Timeout|HTTPError.*502|HTTPError.*504|not less than or equal to 0.01)' ../tests
 
       # Upload code coverage

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Run tests
         working-directory: ./src # For code coverage to work
         run: |
-          PYTEST=".venv/bin/python -m pytest --cov=./huggingface_hub --cov-report=xml:../coverage.xml --vcr-record=none --reruns 5 --reruns-delay 1 --only-rerun '(OSError|Timeout|HTTPError.*502|HTTPError.*504||not less than or equal to 0.01)'"
+          PYTEST="../.venv/bin/python -m pytest --cov=./huggingface_hub --cov-report=xml:../coverage.xml --vcr-record=none --reruns 5 --reruns-delay 1 --only-rerun '(OSError|Timeout|HTTPError.*502|HTTPError.*504||not less than or equal to 0.01)'"
 
           case "${{ matrix.test_name }}" in
 

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Run tests
         working-directory: ./src # For code coverage to work
         run: |
-          source ../venv/bin/activate
+          source ../.venv/bin/activate
           PYTEST="python -m pytest --cov=./huggingface_hub --cov-report=xml:../coverage.xml --vcr-record=none --reruns 5 --reruns-delay 1 --only-rerun '(OSError|Timeout|HTTPError.*502|HTTPError.*504||not less than or equal to 0.01)'"
 
           case "${{ matrix.test_name }}" in
@@ -168,7 +168,7 @@ jobs:
       - name: Run tests
         working-directory: ./src # For code coverage to work
         run: |
-          .venv\Scripts\activate
+          .venv/bin/activate
           python -m pytest -n 4 --cov=./huggingface_hub --cov-report=xml:../coverage.xml --vcr-record=none --reruns 5 --reruns-delay 1 --only-rerun '(OSError|Timeout|HTTPError.*502|HTTPError.*504|not less than or equal to 0.01)' ../tests
 
       # Upload code coverage

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -45,12 +45,12 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       # Setup venv
+      # TODO: remove this once uv is available in the default environment
+      # See https://github.com/astral-sh/uv/pull/2000
       - name: Setup venv + uv
         run: |
           pip install --upgrade uv
           uv venv
-          source .venv/bin/activate
-          echo PATH=$PATH >> $GITHUB_ENV  # See https://stackoverflow.com/a/74669486
 
       # Install dependencies
       - name: Install dependencies
@@ -83,13 +83,13 @@ jobs:
 
       # Easy debugging if CI is broken
       - name: Pip freeze
-        run: pip freeze
+        run: .venv/bin/pip freeze
 
       # Run tests
       - name: Run tests
         working-directory: ./src # For code coverage to work
         run: |
-          PYTEST="python -m pytest --cov=./huggingface_hub --cov-report=xml:../coverage.xml --vcr-record=none --reruns 5 --reruns-delay 1 --only-rerun '(OSError|Timeout|HTTPError.*502|HTTPError.*504||not less than or equal to 0.01)'"
+          PYTEST=".venv/bin/python -m pytest --cov=./huggingface_hub --cov-report=xml:../coverage.xml --vcr-record=none --reruns 5 --reruns-delay 1 --only-rerun '(OSError|Timeout|HTTPError.*502|HTTPError.*504||not less than or equal to 0.01)'"
 
           case "${{ matrix.test_name }}" in
 
@@ -156,12 +156,12 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       # Setup venv
+      # TODO: remove this once uv is available in the default environment
+      # See https://github.com/astral-sh/uv/pull/2000
       - name: Setup venv + uv
         run: |
           pip install --upgrade uv
           uv venv
-          .venv\Scripts\activate
-          echo PATH=$PATH >> $env:GITHUB_ENV  # See https://stackoverflow.com/a/74669486
 
       # Install dependencies
       - name: Install dependencies
@@ -169,12 +169,12 @@ jobs:
 
       # Easy debugging if CI is broken
       - name: Pip freeze
-        run: pip freeze
+        run: .venv\Scripts\pip freeze
 
       # Run tests
       - name: Run tests
         working-directory: ./src # For code coverage to work
-        run: python -m pytest -n 4 --cov=./huggingface_hub --cov-report=xml:../coverage.xml --vcr-record=none --reruns 5 --reruns-delay 1 --only-rerun '(OSError|Timeout|HTTPError.*502|HTTPError.*504|not less than or equal to 0.01)' ../tests
+        run: .venv\Scripts\python -m pytest -n 4 --cov=./huggingface_hub --cov-report=xml:../coverage.xml --vcr-record=none --reruns 5 --reruns-delay 1 --only-rerun '(OSError|Timeout|HTTPError.*502|HTTPError.*504|not less than or equal to 0.01)' ../tests
 
       # Upload code coverage
       - name: Upload coverage reports to Codecov with GitHub Action

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -81,10 +81,6 @@ jobs:
 
           esac
 
-      # Easy debugging if CI is broken
-      - name: Pip freeze
-        run: .venv/bin/pip freeze
-
       # Run tests
       - name: Run tests
         working-directory: ./src # For code coverage to work
@@ -166,10 +162,6 @@ jobs:
       # Install dependencies
       - name: Install dependencies
         run: uv pip install "huggingface_hub[testing] @ ."
-
-      # Easy debugging if CI is broken
-      - name: Pip freeze
-        run: .venv\Scripts\pip freeze
 
       # Run tests
       - name: Run tests

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -44,10 +44,16 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      # Install dependencies
-      - name: Configure and install dependencies
+      # Setup venv
+      - name: Setup venv + uv
         run: |
           pip install --upgrade uv
+          uv venv
+          source .venv/bin/activate
+
+      # Install dependencies
+      - name: Install dependencies
+        run: |
           uv pip install "huggingface_hub[testing] @ ."
 
           case "${{ matrix.test_name }}" in
@@ -148,11 +154,16 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      # Install dependencies
-      - name: Configure and install dependencies
+      # Setup venv
+      - name: Setup venv + uv
         run: |
           pip install --upgrade uv
-          uv pip install "huggingface_hub[testing] @ ."
+          uv venv
+          .venv\Scripts\activate
+
+      # Install dependencies
+      - name: Install dependencies
+        run: uv pip install "huggingface_hub[testing] @ ."
 
       # Easy debugging if CI is broken
       - name: Pip freeze

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -45,8 +45,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       # Setup venv
-      # TODO: remove this once uv is available in the default environment
-      # See https://github.com/astral-sh/uv/pull/2000
+      # TODO: revisit when https://github.com/astral-sh/uv/issues/1526 is addressed.
       - name: Setup venv + uv
         run: |
           pip install --upgrade uv
@@ -153,8 +152,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       # Setup venv
-      # TODO: remove this once uv is available in the default environment
-      # See https://github.com/astral-sh/uv/pull/2000
+      # TODO: revisit when https://github.com/astral-sh/uv/issues/1526 is addressed.
       - name: Setup venv + uv
         run: |
           pip install --upgrade uv

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -50,6 +50,7 @@ jobs:
           pip install --upgrade uv
           uv venv
           source .venv/bin/activate
+          echo PATH=$PATH >> $GITHUB_ENV  # See https://stackoverflow.com/a/74669486
 
       # Install dependencies
       - name: Install dependencies
@@ -160,6 +161,7 @@ jobs:
           pip install --upgrade uv
           uv venv
           .venv\Scripts\activate
+          echo PATH=$PATH >> $env:GITHUB_ENV  # See https://stackoverflow.com/a/74669486
 
       # Install dependencies
       - name: Install dependencies


### PR DESCRIPTION
Quick benchmarks show it saves around 30s-40s per workflow (both for code quality and CI tests)

**Note:** running `uv` instead of `pip` in Github CI is not yet a first-class citizen but should be the case once https://github.com/astral-sh/uv/issues/1526 is addressed. This is why we need to source env in each step.