### PR TITLE
Fix commonpath in read-only filesystem

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1,4 +1,5 @@
 import copy
+import errno
 import fnmatch
 import inspect
 import io
@@ -913,6 +914,12 @@ def _create_symlink(src: str, dst: str, new_blob: bool = False) -> None:
         # Permission error means src and dst are not in the same volume (e.g. destination path has been provided
         # by the user via `local_dir`. Let's test symlink support there)
         _support_symlinks = are_symlinks_supported(abs_dst_folder)
+    except OSError as e:
+        # OS error (errno=30) means that the commonpath is readonly on Linux/MacOS.
+        if e.errno == errno.EROFS:
+            _support_symlinks = are_symlinks_supported(abs_dst_folder)
+        else:
+            raise
 
     # Symlinks are supported => let's create a symlink.
     if _support_symlinks:


### PR DESCRIPTION
## Description

When downloading a model, commonpath is defined as the LCA (Lowest Common Ancestor) of huggingface's cachedir and target output directory. When this ends-up being a directory that is not read-only (e.g. /), an OSError (errno: 30) is thrown.

This PR catches that error and tries to check symlink creation in the destination directory.

## To reproduce

```python
model_path = snapshot_download(repo_id=model,
                               local_dir='/tmp',
                               cache_dir=None, # TRANSFORMERS_CACHE default (i.e. ~/.cache/huggingface/hub/)
                               token=os.environ.get('HF_TOKEN', None))
```

### Original behaviour

Tested on MacOS 14.1.2 and python 3.11.4, the output was:

```
OSError: [Errno 30] Read-only file system: '/tmpzeu59eox'
```

### New behaviour

The model is persisted as intended.