### PR TITLE
rm unnecessary early makedirs in file_download.py::hf_hub_download()

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1211,7 +1211,6 @@ def hf_hub_download(
         raise ValueError(f"Invalid repo type: {repo_type}. Accepted repo types are: {str(REPO_TYPES)}")
 
     storage_folder = os.path.join(cache_dir, repo_folder_name(repo_id=repo_id, repo_type=repo_type))
-    os.makedirs(storage_folder, exist_ok=True)
 
     # cross platform transcription of filename, to be used as a local file path.
     relative_filename = os.path.join(*filename.split("/"))


### PR DESCRIPTION
This helps to avoid early directory creation for model names that are not found in the HF hub.
For valid model names the directory gets created below. 
see https://github.com/huggingface/huggingface_hub/issues/2091 for discussion