### PR TITLE
Fix passing kwargs in PytorchHubMixin

### DIFF
--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -198,7 +198,7 @@ class ModelHubMixin:
         if config is not None:
             if is_dataclass(config):
                 config = asdict(config)  # type: ignore[arg-type]
-            (save_directory / CONFIG_NAME).write_text(json.dumps(config, indent=2))
+            (save_directory / CONFIG_NAME).write_text(json.dumps(config, sort_keys=True, indent=2))
 
         # push to the Hub if required
         if push_to_hub:

--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -317,7 +317,10 @@ class ModelHubMixin:
                 # Forward config to model initialization
                 model_kwargs["config"] = config
 
-            elif any(param.kind == inspect.Parameter.VAR_KEYWORD for param in cls._init_parameters.values()):
+            elif (
+                "kwargs" in cls._init_parameters
+                and cls._init_parameters["kwargs"].kind == inspect.Parameter.VAR_KEYWORD
+            ):
                 # 2. If __init__ accepts **kwargs, let's forward the config as well (as a dict)
                 model_kwargs["config"] = config
 


### PR DESCRIPTION
Fix breaking change introduced in https://github.com/huggingface/huggingface_hub/pull/2058.

If `__init__` expects a `**kwargs` parameter, we should pass the config to it. However if it expects something like `**croco_kwargs`, let's not forward it since `config` is most likely not expected by the underlying class that will receive the config. 

This will fix integration like the dust3r one (see [here](https://github.com/naver/dust3r/blob/b6cb1fc6b2aff25a9672483ff905d5cd717f9591/dust3r/model.py) + [slack thread](https://huggingface.slack.com/archives/C06MW6VMZHS/p1709785912955459?thread_ts=1709761490.148549&cid=C06MW6VMZHS) -private-).

cc @NielsRogge @not-lain 

