### PR TITLE
Add = None at optional parameters

### DIFF
--- a/src/huggingface_hub/inference/_generated/types/audio_classification.py
+++ b/src/huggingface_hub/inference/_generated/types/audio_classification.py
@@ -18,8 +18,8 @@ class AudioClassificationParameters(BaseInferenceType):
     Additional inference parameters for Audio Classification
     """
 
-    function_to_apply: Optional["ClassificationOutputTransform"]
-    top_k: Optional[int]
+    function_to_apply: Optional["ClassificationOutputTransform"] = None
+    top_k: Optional[int] = None
     """When specified, limits the output to the top K most probable classes."""
 
 
@@ -29,7 +29,7 @@ class AudioClassificationInput(BaseInferenceType):
 
     inputs: Any
     """The input audio data"""
-    parameters: Optional[AudioClassificationParameters]
+    parameters: Optional[AudioClassificationParameters] = None
     """Additional inference parameters"""
 
 

--- a/src/huggingface_hub/inference/_generated/types/automatic_speech_recognition.py
+++ b/src/huggingface_hub/inference/_generated/types/automatic_speech_recognition.py
@@ -18,17 +18,17 @@ class GenerationParameters(BaseInferenceType):
     Ad-hoc parametrization of the text generation process
     """
 
-    do_sample: Optional[bool]
+    do_sample: Optional[bool] = None
     """Whether to use sampling instead of greedy decoding when generating new tokens."""
-    early_stopping: Optional[Union[bool, "EarlyStoppingEnum"]]
+    early_stopping: Optional[Union[bool, "EarlyStoppingEnum"]] = None
     """Controls the stopping condition for beam-based methods."""
-    epsilon_cutoff: Optional[float]
+    epsilon_cutoff: Optional[float] = None
     """If set to float strictly between 0 and 1, only tokens with a conditional probability
     greater than epsilon_cutoff will be sampled. In the paper, suggested values range from
     3e-4 to 9e-4, depending on the size of the model. See [Truncation Sampling as Language
     Model Desmoothing](https://hf.co/papers/2210.15191) for more details.
     """
-    eta_cutoff: Optional[float]
+    eta_cutoff: Optional[float] = None
     """Eta sampling is a hybrid of locally typical sampling and epsilon sampling. If set to
     float strictly between 0 and 1, a token is only considered if it is greater than either
     eta_cutoff or sqrt(eta_cutoff) * exp(-entropy(softmax(next_token_logits))). The latter
@@ -37,40 +37,40 @@ class GenerationParameters(BaseInferenceType):
     See [Truncation Sampling as Language Model Desmoothing](https://hf.co/papers/2210.15191)
     for more details.
     """
-    max_length: Optional[int]
+    max_length: Optional[int] = None
     """The maximum length (in tokens) of the generated text, including the input."""
-    max_new_tokens: Optional[int]
+    max_new_tokens: Optional[int] = None
     """The maximum number of tokens to generate. Takes precedence over maxLength."""
-    min_length: Optional[int]
+    min_length: Optional[int] = None
     """The minimum length (in tokens) of the generated text, including the input."""
-    min_new_tokens: Optional[int]
+    min_new_tokens: Optional[int] = None
     """The minimum number of tokens to generate. Takes precedence over maxLength."""
-    num_beam_groups: Optional[int]
+    num_beam_groups: Optional[int] = None
     """Number of groups to divide num_beams into in order to ensure diversity among different
     groups of beams. See [this paper](https://hf.co/papers/1610.02424) for more details.
     """
-    num_beams: Optional[int]
+    num_beams: Optional[int] = None
     """Number of beams to use for beam search."""
-    penalty_alpha: Optional[float]
+    penalty_alpha: Optional[float] = None
     """The value balances the model confidence and the degeneration penalty in contrastive
     search decoding.
     """
-    temperature: Optional[float]
+    temperature: Optional[float] = None
     """The value used to modulate the next token probabilities."""
-    top_k: Optional[int]
+    top_k: Optional[int] = None
     """The number of highest probability vocabulary tokens to keep for top-k-filtering."""
-    top_p: Optional[float]
+    top_p: Optional[float] = None
     """If set to float < 1, only the smallest set of most probable tokens with probabilities
     that add up to top_p or higher are kept for generation.
     """
-    typical_p: Optional[float]
+    typical_p: Optional[float] = None
     """Local typicality measures how similar the conditional probability of predicting a target
     token next is to the expected conditional probability of predicting a random token next,
     given the partial text already generated. If set to float < 1, the smallest set of the
     most locally typical tokens with probabilities that add up to typical_p or higher are
     kept for generation. See [this paper](https://hf.co/papers/2202.00666) for more details.
     """
-    use_cache: Optional[bool]
+    use_cache: Optional[bool] = None
     """Whether the model should use the past last key/values attentions to speed up decoding"""
 
 
@@ -80,9 +80,9 @@ class AutomaticSpeechRecognitionParameters(BaseInferenceType):
     Additional inference parameters for Automatic Speech Recognition
     """
 
-    generate: Optional[GenerationParameters]
+    generate: Optional[GenerationParameters] = None
     """Parametrization of the text generation process"""
-    return_timestamps: Optional[bool]
+    return_timestamps: Optional[bool] = None
     """Whether to output corresponding timestamps with the generated text"""
 
 
@@ -92,7 +92,7 @@ class AutomaticSpeechRecognitionInput(BaseInferenceType):
 
     inputs: Any
     """The input audio data"""
-    parameters: Optional[AutomaticSpeechRecognitionParameters]
+    parameters: Optional[AutomaticSpeechRecognitionParameters] = None
     """Additional inference parameters"""
 
 
@@ -110,7 +110,7 @@ class AutomaticSpeechRecognitionOutput(BaseInferenceType):
 
     text: str
     """The recognized text."""
-    chunks: Optional[List[AutomaticSpeechRecognitionOutputChunk]]
+    chunks: Optional[List[AutomaticSpeechRecognitionOutputChunk]] = None
     """When returnTimestamps is enabled, chunks contains a list of audio chunks identified by
     the model.
     """

--- a/src/huggingface_hub/inference/_generated/types/depth_estimation.py
+++ b/src/huggingface_hub/inference/_generated/types/depth_estimation.py
@@ -15,7 +15,7 @@ class DepthEstimationInput(BaseInferenceType):
 
     inputs: Any
     """The input image data"""
-    parameters: Optional[Dict[str, Any]]
+    parameters: Optional[Dict[str, Any]] = None
     """Additional inference parameters"""
 
 

--- a/src/huggingface_hub/inference/_generated/types/document_question_answering.py
+++ b/src/huggingface_hub/inference/_generated/types/document_question_answering.py
@@ -25,31 +25,31 @@ class DocumentQuestionAnsweringParameters(BaseInferenceType):
     Additional inference parameters for Document Question Answering
     """
 
-    doc_stride: Optional[int]
+    doc_stride: Optional[int] = None
     """If the words in the document are too long to fit with the question for the model, it will
     be split in several chunks with some overlap. This argument controls the size of that
     overlap.
     """
-    handle_impossible_answer: Optional[bool]
+    handle_impossible_answer: Optional[bool] = None
     """Whether to accept impossible as an answer"""
-    lang: Optional[str]
+    lang: Optional[str] = None
     """Language to use while running OCR. Defaults to english."""
-    max_answer_len: Optional[int]
+    max_answer_len: Optional[int] = None
     """The maximum length of predicted answers (e.g., only answers with a shorter length are
     considered).
     """
-    max_question_len: Optional[int]
+    max_question_len: Optional[int] = None
     """The maximum length of the question after tokenization. It will be truncated if needed."""
-    max_seq_len: Optional[int]
+    max_seq_len: Optional[int] = None
     """The maximum length of the total sentence (context + question) in tokens of each chunk
     passed to the model. The context will be split in several chunks (using doc_stride as
     overlap) if needed.
     """
-    top_k: Optional[int]
+    top_k: Optional[int] = None
     """The number of answers to return (will be chosen by order of likelihood). Can return less
     than top_k answers if there are not enough options available within the context.
     """
-    word_boxes: Optional[List[Union[List[float], str]]]
+    word_boxes: Optional[List[Union[List[float], str]]] = None
     """A list of words and bounding boxes (normalized 0->1000). If provided, the inference will
     skip the OCR step and use the provided bounding boxes instead.
     """
@@ -61,7 +61,7 @@ class DocumentQuestionAnsweringInput(BaseInferenceType):
 
     inputs: DocumentQuestionAnsweringInputData
     """One (document, question) pair to answer"""
-    parameters: Optional[DocumentQuestionAnsweringParameters]
+    parameters: Optional[DocumentQuestionAnsweringParameters] = None
     """Additional inference parameters"""
 
 

--- a/src/huggingface_hub/inference/_generated/types/feature_extraction.py
+++ b/src/huggingface_hub/inference/_generated/types/feature_extraction.py
@@ -15,5 +15,5 @@ class FeatureExtractionInput(BaseInferenceType):
 
     inputs: str
     """The text to get the embeddings of"""
-    parameters: Optional[Dict[str, Any]]
+    parameters: Optional[Dict[str, Any]] = None
     """Additional inference parameters"""

--- a/src/huggingface_hub/inference/_generated/types/fill_mask.py
+++ b/src/huggingface_hub/inference/_generated/types/fill_mask.py
@@ -15,13 +15,13 @@ class FillMaskParameters(BaseInferenceType):
     Additional inference parameters for Fill Mask
     """
 
-    targets: Optional[List[str]]
+    targets: Optional[List[str]] = None
     """When passed, the model will limit the scores to the passed targets instead of looking up
     in the whole vocabulary. If the provided targets are not in the model vocab, they will be
     tokenized and the first resulting token will be used (with a warning, and that might be
     slower).
     """
-    top_k: Optional[int]
+    top_k: Optional[int] = None
     """When passed, overrides the number of predictions to return."""
 
 
@@ -31,7 +31,7 @@ class FillMaskInput(BaseInferenceType):
 
     inputs: str
     """The text with masked tokens"""
-    parameters: Optional[FillMaskParameters]
+    parameters: Optional[FillMaskParameters] = None
     """Additional inference parameters"""
 
 
@@ -46,5 +46,5 @@ class FillMaskOutputElement(BaseInferenceType):
     token: int
     """The predicted token id (to replace the masked one)."""
     token_str: Any
-    fill_mask_output_token_str: Optional[str]
+    fill_mask_output_token_str: Optional[str] = None
     """The predicted token (to replace the masked one)."""

--- a/src/huggingface_hub/inference/_generated/types/image_classification.py
+++ b/src/huggingface_hub/inference/_generated/types/image_classification.py
@@ -18,8 +18,8 @@ class ImageClassificationParameters(BaseInferenceType):
     Additional inference parameters for Image Classification
     """
 
-    function_to_apply: Optional["ClassificationOutputTransform"]
-    top_k: Optional[int]
+    function_to_apply: Optional["ClassificationOutputTransform"] = None
+    top_k: Optional[int] = None
     """When specified, limits the output to the top K most probable classes."""
 
 
@@ -29,7 +29,7 @@ class ImageClassificationInput(BaseInferenceType):
 
     inputs: Any
     """The input image data"""
-    parameters: Optional[ImageClassificationParameters]
+    parameters: Optional[ImageClassificationParameters] = None
     """Additional inference parameters"""
 
 

--- a/src/huggingface_hub/inference/_generated/types/image_segmentation.py
+++ b/src/huggingface_hub/inference/_generated/types/image_segmentation.py
@@ -18,13 +18,13 @@ class ImageSegmentationParameters(BaseInferenceType):
     Additional inference parameters for Image Segmentation
     """
 
-    mask_threshold: Optional[float]
+    mask_threshold: Optional[float] = None
     """Threshold to use when turning the predicted masks into binary values."""
-    overlap_mask_area_threshold: Optional[float]
+    overlap_mask_area_threshold: Optional[float] = None
     """Mask overlap threshold to eliminate small, disconnected segments."""
-    subtask: Optional["ImageSegmentationSubtask"]
+    subtask: Optional["ImageSegmentationSubtask"] = None
     """Segmentation task to be performed, depending on model capabilities."""
-    threshold: Optional[float]
+    threshold: Optional[float] = None
     """Probability threshold to filter out predicted masks."""
 
 
@@ -34,7 +34,7 @@ class ImageSegmentationInput(BaseInferenceType):
 
     inputs: Any
     """The input image data"""
-    parameters: Optional[ImageSegmentationParameters]
+    parameters: Optional[ImageSegmentationParameters] = None
     """Additional inference parameters"""
 
 
@@ -48,5 +48,5 @@ class ImageSegmentationOutputElement(BaseInferenceType):
     """The label of the predicted segment"""
     mask: Any
     """The corresponding mask as a black-and-white image"""
-    score: Optional[float]
+    score: Optional[float] = None
     """The score or confidence degreee the model has"""

--- a/src/huggingface_hub/inference/_generated/types/image_to_image.py
+++ b/src/huggingface_hub/inference/_generated/types/image_to_image.py
@@ -23,17 +23,17 @@ class ImageToImageParameters(BaseInferenceType):
     Additional inference parameters for Image To Image
     """
 
-    guidance_scale: Optional[float]
+    guidance_scale: Optional[float] = None
     """For diffusion models. A higher guidance scale value encourages the model to generate
     images closely linked to the text prompt at the expense of lower image quality.
     """
-    negative_prompt: Optional[List[str]]
+    negative_prompt: Optional[List[str]] = None
     """One or several prompt to guide what NOT to include in image generation."""
-    num_inference_steps: Optional[int]
+    num_inference_steps: Optional[int] = None
     """For diffusion models. The number of denoising steps. More denoising steps usually lead to
     a higher quality image at the expense of slower inference.
     """
-    target_size: Optional[TargetSize]
+    target_size: Optional[TargetSize] = None
     """The size in pixel of the output image"""
 
 
@@ -43,7 +43,7 @@ class ImageToImageInput(BaseInferenceType):
 
     inputs: Any
     """The input image data"""
-    parameters: Optional[ImageToImageParameters]
+    parameters: Optional[ImageToImageParameters] = None
     """Additional inference parameters"""
 
 

--- a/src/huggingface_hub/inference/_generated/types/image_to_text.py
+++ b/src/huggingface_hub/inference/_generated/types/image_to_text.py
@@ -18,17 +18,17 @@ class GenerationParameters(BaseInferenceType):
     Ad-hoc parametrization of the text generation process
     """
 
-    do_sample: Optional[bool]
+    do_sample: Optional[bool] = None
     """Whether to use sampling instead of greedy decoding when generating new tokens."""
-    early_stopping: Optional[Union[bool, "EarlyStoppingEnum"]]
+    early_stopping: Optional[Union[bool, "EarlyStoppingEnum"]] = None
     """Controls the stopping condition for beam-based methods."""
-    epsilon_cutoff: Optional[float]
+    epsilon_cutoff: Optional[float] = None
     """If set to float strictly between 0 and 1, only tokens with a conditional probability
     greater than epsilon_cutoff will be sampled. In the paper, suggested values range from
     3e-4 to 9e-4, depending on the size of the model. See [Truncation Sampling as Language
     Model Desmoothing](https://hf.co/papers/2210.15191) for more details.
     """
-    eta_cutoff: Optional[float]
+    eta_cutoff: Optional[float] = None
     """Eta sampling is a hybrid of locally typical sampling and epsilon sampling. If set to
     float strictly between 0 and 1, a token is only considered if it is greater than either
     eta_cutoff or sqrt(eta_cutoff) * exp(-entropy(softmax(next_token_logits))). The latter
@@ -37,40 +37,40 @@ class GenerationParameters(BaseInferenceType):
     See [Truncation Sampling as Language Model Desmoothing](https://hf.co/papers/2210.15191)
     for more details.
     """
-    max_length: Optional[int]
+    max_length: Optional[int] = None
     """The maximum length (in tokens) of the generated text, including the input."""
-    max_new_tokens: Optional[int]
+    max_new_tokens: Optional[int] = None
     """The maximum number of tokens to generate. Takes precedence over maxLength."""
-    min_length: Optional[int]
+    min_length: Optional[int] = None
     """The minimum length (in tokens) of the generated text, including the input."""
-    min_new_tokens: Optional[int]
+    min_new_tokens: Optional[int] = None
     """The minimum number of tokens to generate. Takes precedence over maxLength."""
-    num_beam_groups: Optional[int]
+    num_beam_groups: Optional[int] = None
     """Number of groups to divide num_beams into in order to ensure diversity among different
     groups of beams. See [this paper](https://hf.co/papers/1610.02424) for more details.
     """
-    num_beams: Optional[int]
+    num_beams: Optional[int] = None
     """Number of beams to use for beam search."""
-    penalty_alpha: Optional[float]
+    penalty_alpha: Optional[float] = None
     """The value balances the model confidence and the degeneration penalty in contrastive
     search decoding.
     """
-    temperature: Optional[float]
+    temperature: Optional[float] = None
     """The value used to modulate the next token probabilities."""
-    top_k: Optional[int]
+    top_k: Optional[int] = None
     """The number of highest probability vocabulary tokens to keep for top-k-filtering."""
-    top_p: Optional[float]
+    top_p: Optional[float] = None
     """If set to float < 1, only the smallest set of most probable tokens with probabilities
     that add up to top_p or higher are kept for generation.
     """
-    typical_p: Optional[float]
+    typical_p: Optional[float] = None
     """Local typicality measures how similar the conditional probability of predicting a target
     token next is to the expected conditional probability of predicting a random token next,
     given the partial text already generated. If set to float < 1, the smallest set of the
     most locally typical tokens with probabilities that add up to typical_p or higher are
     kept for generation. See [this paper](https://hf.co/papers/2202.00666) for more details.
     """
-    use_cache: Optional[bool]
+    use_cache: Optional[bool] = None
     """Whether the model should use the past last key/values attentions to speed up decoding"""
 
 
@@ -80,9 +80,9 @@ class ImageToTextParameters(BaseInferenceType):
     Additional inference parameters for Image To Text
     """
 
-    generate: Optional[GenerationParameters]
+    generate: Optional[GenerationParameters] = None
     """Parametrization of the text generation process"""
-    max_new_tokens: Optional[int]
+    max_new_tokens: Optional[int] = None
     """The amount of maximum tokens to generate."""
 
 
@@ -92,7 +92,7 @@ class ImageToTextInput(BaseInferenceType):
 
     inputs: Any
     """The input image data"""
-    parameters: Optional[ImageToTextParameters]
+    parameters: Optional[ImageToTextParameters] = None
     """Additional inference parameters"""
 
 
@@ -101,5 +101,5 @@ class ImageToTextOutput(BaseInferenceType):
     """Outputs of inference for the Image To Text task"""
 
     generated_text: Any
-    image_to_text_output_generated_text: Optional[str]
+    image_to_text_output_generated_text: Optional[str] = None
     """The generated text."""

--- a/src/huggingface_hub/inference/_generated/types/object_detection.py
+++ b/src/huggingface_hub/inference/_generated/types/object_detection.py
@@ -15,7 +15,7 @@ class ObjectDetectionParameters(BaseInferenceType):
     Additional inference parameters for Object Detection
     """
 
-    threshold: Optional[float]
+    threshold: Optional[float] = None
     """The probability necessary to make a prediction."""
 
 
@@ -25,7 +25,7 @@ class ObjectDetectionInput(BaseInferenceType):
 
     inputs: Any
     """The input image data"""
-    parameters: Optional[ObjectDetectionParameters]
+    parameters: Optional[ObjectDetectionParameters] = None
     """Additional inference parameters"""
 
 

--- a/src/huggingface_hub/inference/_generated/types/question_answering.py
+++ b/src/huggingface_hub/inference/_generated/types/question_answering.py
@@ -25,28 +25,28 @@ class QuestionAnsweringParameters(BaseInferenceType):
     Additional inference parameters for Question Answering
     """
 
-    align_to_words: Optional[bool]
+    align_to_words: Optional[bool] = None
     """Attempts to align the answer to real words. Improves quality on space separated
     languages. Might hurt on non-space-separated languages (like Japanese or Chinese)
     """
-    doc_stride: Optional[int]
+    doc_stride: Optional[int] = None
     """If the context is too long to fit with the question for the model, it will be split in
     several chunks with some overlap. This argument controls the size of that overlap.
     """
-    handle_impossible_answer: Optional[bool]
+    handle_impossible_answer: Optional[bool] = None
     """Whether to accept impossible as an answer."""
-    max_answer_len: Optional[int]
+    max_answer_len: Optional[int] = None
     """The maximum length of predicted answers (e.g., only answers with a shorter length are
     considered).
     """
-    max_question_len: Optional[int]
+    max_question_len: Optional[int] = None
     """The maximum length of the question after tokenization. It will be truncated if needed."""
-    max_seq_len: Optional[int]
+    max_seq_len: Optional[int] = None
     """The maximum length of the total sentence (context + question) in tokens of each chunk
     passed to the model. The context will be split in several chunks (using docStride as
     overlap) if needed.
     """
-    top_k: Optional[int]
+    top_k: Optional[int] = None
     """The number of answers to return (will be chosen by order of likelihood). Note that we
     return less than topk answers if there are not enough options available within the
     context.
@@ -59,7 +59,7 @@ class QuestionAnsweringInput(BaseInferenceType):
 
     inputs: QuestionAnsweringInputData
     """One (context, question) pair to answer"""
-    parameters: Optional[QuestionAnsweringParameters]
+    parameters: Optional[QuestionAnsweringParameters] = None
     """Additional inference parameters"""
 
 

--- a/src/huggingface_hub/inference/_generated/types/sentence_similarity.py
+++ b/src/huggingface_hub/inference/_generated/types/sentence_similarity.py
@@ -24,5 +24,5 @@ class SentenceSimilarityInput(BaseInferenceType):
     """Inputs for Sentence similarity inference"""
 
     inputs: SentenceSimilarityInputData
-    parameters: Optional[Dict[str, Any]]
+    parameters: Optional[Dict[str, Any]] = None
     """Additional inference parameters"""

--- a/src/huggingface_hub/inference/_generated/types/summarization.py
+++ b/src/huggingface_hub/inference/_generated/types/summarization.py
@@ -18,11 +18,11 @@ class Text2TextGenerationParameters(BaseInferenceType):
     Additional inference parameters for Text2text Generation
     """
 
-    clean_up_tokenization_spaces: Optional[bool]
+    clean_up_tokenization_spaces: Optional[bool] = None
     """Whether to clean up the potential extra spaces in the text output."""
-    generate_parameters: Optional[Dict[str, Any]]
+    generate_parameters: Optional[Dict[str, Any]] = None
     """Additional parametrization of the text generation algorithm"""
-    truncation: Optional["Text2TextGenerationTruncationStrategy"]
+    truncation: Optional["Text2TextGenerationTruncationStrategy"] = None
     """The truncation strategy to use"""
 
 
@@ -34,7 +34,7 @@ class SummarizationInput(BaseInferenceType):
 
     inputs: str
     """The input text data"""
-    parameters: Optional[Text2TextGenerationParameters]
+    parameters: Optional[Text2TextGenerationParameters] = None
     """Additional inference parameters"""
 
 
@@ -45,5 +45,5 @@ class SummarizationOutput(BaseInferenceType):
     """
 
     summary_text: Any
-    summarization_output_summary_text: Optional[str]
+    summarization_output_summary_text: Optional[str] = None
     """The generated text."""

--- a/src/huggingface_hub/inference/_generated/types/table_question_answering.py
+++ b/src/huggingface_hub/inference/_generated/types/table_question_answering.py
@@ -25,7 +25,7 @@ class TableQuestionAnsweringInput(BaseInferenceType):
 
     inputs: TableQuestionAnsweringInputData
     """One (table, question) pair to answer"""
-    parameters: Optional[Dict[str, Any]]
+    parameters: Optional[Dict[str, Any]] = None
     """Additional inference parameters"""
 
 
@@ -41,5 +41,5 @@ class TableQuestionAnsweringOutputElement(BaseInferenceType):
     """List of strings made up of the answer cell values."""
     coordinates: List[List[int]]
     """Coordinates of the cells of the answers."""
-    aggregator: Optional[str]
+    aggregator: Optional[str] = None
     """If the model has an aggregator, this returns the aggregator."""

--- a/src/huggingface_hub/inference/_generated/types/text2text_generation.py
+++ b/src/huggingface_hub/inference/_generated/types/text2text_generation.py
@@ -18,11 +18,11 @@ class Text2TextGenerationParameters(BaseInferenceType):
     Additional inference parameters for Text2text Generation
     """
 
-    clean_up_tokenization_spaces: Optional[bool]
+    clean_up_tokenization_spaces: Optional[bool] = None
     """Whether to clean up the potential extra spaces in the text output."""
-    generate_parameters: Optional[Dict[str, Any]]
+    generate_parameters: Optional[Dict[str, Any]] = None
     """Additional parametrization of the text generation algorithm"""
-    truncation: Optional["Text2TextGenerationTruncationStrategy"]
+    truncation: Optional["Text2TextGenerationTruncationStrategy"] = None
     """The truncation strategy to use"""
 
 
@@ -32,7 +32,7 @@ class Text2TextGenerationInput(BaseInferenceType):
 
     inputs: str
     """The input text data"""
-    parameters: Optional[Text2TextGenerationParameters]
+    parameters: Optional[Text2TextGenerationParameters] = None
     """Additional inference parameters"""
 
 
@@ -41,5 +41,5 @@ class Text2TextGenerationOutput(BaseInferenceType):
     """Outputs of inference for the Text2text Generation task"""
 
     generated_text: Any
-    text2_text_generation_output_generated_text: Optional[str]
+    text2_text_generation_output_generated_text: Optional[str] = None
     """The generated text."""

--- a/src/huggingface_hub/inference/_generated/types/text_classification.py
+++ b/src/huggingface_hub/inference/_generated/types/text_classification.py
@@ -18,8 +18,8 @@ class TextClassificationParameters(BaseInferenceType):
     Additional inference parameters for Text Classification
     """
 
-    function_to_apply: Optional["ClassificationOutputTransform"]
-    top_k: Optional[int]
+    function_to_apply: Optional["ClassificationOutputTransform"] = None
+    top_k: Optional[int] = None
     """When specified, limits the output to the top K most probable classes."""
 
 
@@ -29,7 +29,7 @@ class TextClassificationInput(BaseInferenceType):
 
     inputs: str
     """The text to classify"""
-    parameters: Optional[TextClassificationParameters]
+    parameters: Optional[TextClassificationParameters] = None
     """Additional inference parameters"""
 
 

--- a/src/huggingface_hub/inference/_generated/types/text_generation.py
+++ b/src/huggingface_hub/inference/_generated/types/text_generation.py
@@ -15,43 +15,43 @@ class TextGenerationParameters(BaseInferenceType):
     Additional inference parameters for Text Generation
     """
 
-    best_of: Optional[int]
+    best_of: Optional[int] = None
     """The number of sampling queries to run. Only the best one (in terms of total logprob) will
     be returned.
     """
-    decoder_input_details: Optional[bool]
+    decoder_input_details: Optional[bool] = None
     """Whether or not to output decoder input details"""
-    details: Optional[bool]
+    details: Optional[bool] = None
     """Whether or not to output details"""
-    do_sample: Optional[bool]
+    do_sample: Optional[bool] = None
     """Whether to use logits sampling instead of greedy decoding when generating new tokens."""
-    max_new_tokens: Optional[int]
+    max_new_tokens: Optional[int] = None
     """The maximum number of tokens to generate."""
-    repetition_penalty: Optional[float]
+    repetition_penalty: Optional[float] = None
     """The parameter for repetition penalty. A value of 1.0 means no penalty. See [this
     paper](https://hf.co/papers/1909.05858) for more details.
     """
-    return_full_text: Optional[bool]
+    return_full_text: Optional[bool] = None
     """Whether to prepend the prompt to the generated text."""
-    seed: Optional[int]
+    seed: Optional[int] = None
     """The random sampling seed."""
-    stop_sequences: Optional[List[str]]
+    stop_sequences: Optional[List[str]] = None
     """Stop generating tokens if a member of `stop_sequences` is generated."""
-    temperature: Optional[float]
+    temperature: Optional[float] = None
     """The value used to modulate the logits distribution."""
-    top_k: Optional[int]
+    top_k: Optional[int] = None
     """The number of highest probability vocabulary tokens to keep for top-k-filtering."""
-    top_p: Optional[float]
+    top_p: Optional[float] = None
     """If set to < 1, only the smallest set of most probable tokens with probabilities that add
     up to `top_p` or higher are kept for generation.
     """
-    truncate: Optional[int]
+    truncate: Optional[int] = None
     """Truncate input tokens to the given size."""
-    typical_p: Optional[float]
+    typical_p: Optional[float] = None
     """Typical Decoding mass. See [Typical Decoding for Natural Language
     Generation](https://hf.co/papers/2202.00666) for more information
     """
-    watermark: Optional[bool]
+    watermark: Optional[bool] = None
     """Watermarking with [A Watermark for Large Language Models](https://hf.co/papers/2301.10226)"""
 
 
@@ -61,7 +61,7 @@ class TextGenerationInput(BaseInferenceType):
 
     inputs: str
     """The text to initialize generation with"""
-    parameters: Optional[TextGenerationParameters]
+    parameters: Optional[TextGenerationParameters] = None
     """Additional inference parameters"""
 
 
@@ -97,7 +97,7 @@ class TextGenerationSequenceDetails(BaseInferenceType):
     prefill: List[PrefillToken]
     tokens: List[Token]
     """The generated tokens and associated details"""
-    seed: Optional[int]
+    seed: Optional[int] = None
     """The random seed used for generation"""
 
 
@@ -112,9 +112,9 @@ class TextGenerationOutputDetails(BaseInferenceType):
     prefill: List[PrefillToken]
     tokens: List[Token]
     """The generated tokens and associated details"""
-    best_of_sequences: Optional[List[TextGenerationSequenceDetails]]
+    best_of_sequences: Optional[List[TextGenerationSequenceDetails]] = None
     """Details about additional sequences when best_of is provided"""
-    seed: Optional[int]
+    seed: Optional[int] = None
     """The random seed used for generation"""
 
 
@@ -124,5 +124,5 @@ class TextGenerationOutput(BaseInferenceType):
 
     generated_text: str
     """The generated text"""
-    details: Optional[TextGenerationOutputDetails]
+    details: Optional[TextGenerationOutputDetails] = None
     """When enabled, details about the generation"""

--- a/src/huggingface_hub/inference/_generated/types/text_to_audio.py
+++ b/src/huggingface_hub/inference/_generated/types/text_to_audio.py
@@ -18,17 +18,17 @@ class GenerationParameters(BaseInferenceType):
     Ad-hoc parametrization of the text generation process
     """
 
-    do_sample: Optional[bool]
+    do_sample: Optional[bool] = None
     """Whether to use sampling instead of greedy decoding when generating new tokens."""
-    early_stopping: Optional[Union[bool, "EarlyStoppingEnum"]]
+    early_stopping: Optional[Union[bool, "EarlyStoppingEnum"]] = None
     """Controls the stopping condition for beam-based methods."""
-    epsilon_cutoff: Optional[float]
+    epsilon_cutoff: Optional[float] = None
     """If set to float strictly between 0 and 1, only tokens with a conditional probability
     greater than epsilon_cutoff will be sampled. In the paper, suggested values range from
     3e-4 to 9e-4, depending on the size of the model. See [Truncation Sampling as Language
     Model Desmoothing](https://hf.co/papers/2210.15191) for more details.
     """
-    eta_cutoff: Optional[float]
+    eta_cutoff: Optional[float] = None
     """Eta sampling is a hybrid of locally typical sampling and epsilon sampling. If set to
     float strictly between 0 and 1, a token is only considered if it is greater than either
     eta_cutoff or sqrt(eta_cutoff) * exp(-entropy(softmax(next_token_logits))). The latter
@@ -37,40 +37,40 @@ class GenerationParameters(BaseInferenceType):
     See [Truncation Sampling as Language Model Desmoothing](https://hf.co/papers/2210.15191)
     for more details.
     """
-    max_length: Optional[int]
+    max_length: Optional[int] = None
     """The maximum length (in tokens) of the generated text, including the input."""
-    max_new_tokens: Optional[int]
+    max_new_tokens: Optional[int] = None
     """The maximum number of tokens to generate. Takes precedence over maxLength."""
-    min_length: Optional[int]
+    min_length: Optional[int] = None
     """The minimum length (in tokens) of the generated text, including the input."""
-    min_new_tokens: Optional[int]
+    min_new_tokens: Optional[int] = None
     """The minimum number of tokens to generate. Takes precedence over maxLength."""
-    num_beam_groups: Optional[int]
+    num_beam_groups: Optional[int] = None
     """Number of groups to divide num_beams into in order to ensure diversity among different
     groups of beams. See [this paper](https://hf.co/papers/1610.02424) for more details.
     """
-    num_beams: Optional[int]
+    num_beams: Optional[int] = None
     """Number of beams to use for beam search."""
-    penalty_alpha: Optional[float]
+    penalty_alpha: Optional[float] = None
     """The value balances the model confidence and the degeneration penalty in contrastive
     search decoding.
     """
-    temperature: Optional[float]
+    temperature: Optional[float] = None
     """The value used to modulate the next token probabilities."""
-    top_k: Optional[int]
+    top_k: Optional[int] = None
     """The number of highest probability vocabulary tokens to keep for top-k-filtering."""
-    top_p: Optional[float]
+    top_p: Optional[float] = None
     """If set to float < 1, only the smallest set of most probable tokens with probabilities
     that add up to top_p or higher are kept for generation.
     """
-    typical_p: Optional[float]
+    typical_p: Optional[float] = None
     """Local typicality measures how similar the conditional probability of predicting a target
     token next is to the expected conditional probability of predicting a random token next,
     given the partial text already generated. If set to float < 1, the smallest set of the
     most locally typical tokens with probabilities that add up to typical_p or higher are
     kept for generation. See [this paper](https://hf.co/papers/2202.00666) for more details.
     """
-    use_cache: Optional[bool]
+    use_cache: Optional[bool] = None
     """Whether the model should use the past last key/values attentions to speed up decoding"""
 
 
@@ -80,7 +80,7 @@ class TextToAudioParameters(BaseInferenceType):
     Additional inference parameters for Text To Audio
     """
 
-    generate: Optional[GenerationParameters]
+    generate: Optional[GenerationParameters] = None
     """Parametrization of the text generation process"""
 
 
@@ -90,7 +90,7 @@ class TextToAudioInput(BaseInferenceType):
 
     inputs: str
     """The input text data"""
-    parameters: Optional[TextToAudioParameters]
+    parameters: Optional[TextToAudioParameters] = None
     """Additional inference parameters"""
 
 
@@ -101,5 +101,5 @@ class TextToAudioOutput(BaseInferenceType):
     audio: Any
     """The generated audio waveform."""
     sampling_rate: Any
-    text_to_audio_output_sampling_rate: Optional[float]
+    text_to_audio_output_sampling_rate: Optional[float] = None
     """The sampling rate of the generated audio waveform."""

--- a/src/huggingface_hub/inference/_generated/types/text_to_image.py
+++ b/src/huggingface_hub/inference/_generated/types/text_to_image.py
@@ -23,19 +23,19 @@ class TextToImageParameters(BaseInferenceType):
     Additional inference parameters for Text To Image
     """
 
-    guidance_scale: Optional[float]
+    guidance_scale: Optional[float] = None
     """For diffusion models. A higher guidance scale value encourages the model to generate
     images closely linked to the text prompt at the expense of lower image quality.
     """
-    negative_prompt: Optional[List[str]]
+    negative_prompt: Optional[List[str]] = None
     """One or several prompt to guide what NOT to include in image generation."""
-    num_inference_steps: Optional[int]
+    num_inference_steps: Optional[int] = None
     """For diffusion models. The number of denoising steps. More denoising steps usually lead to
     a higher quality image at the expense of slower inference.
     """
-    scheduler: Optional[str]
+    scheduler: Optional[str] = None
     """For diffusion models. Override the scheduler with a compatible one"""
-    target_size: Optional[TargetSize]
+    target_size: Optional[TargetSize] = None
     """The size in pixel of the output image"""
 
 
@@ -45,7 +45,7 @@ class TextToImageInput(BaseInferenceType):
 
     inputs: str
     """The input text data (sometimes called "prompt\""""
-    parameters: Optional[TextToImageParameters]
+    parameters: Optional[TextToImageParameters] = None
     """Additional inference parameters"""
 
 

--- a/src/huggingface_hub/inference/_generated/types/text_to_speech.py
+++ b/src/huggingface_hub/inference/_generated/types/text_to_speech.py
@@ -18,17 +18,17 @@ class GenerationParameters(BaseInferenceType):
     Ad-hoc parametrization of the text generation process
     """
 
-    do_sample: Optional[bool]
+    do_sample: Optional[bool] = None
     """Whether to use sampling instead of greedy decoding when generating new tokens."""
-    early_stopping: Optional[Union[bool, "EarlyStoppingEnum"]]
+    early_stopping: Optional[Union[bool, "EarlyStoppingEnum"]] = None
     """Controls the stopping condition for beam-based methods."""
-    epsilon_cutoff: Optional[float]
+    epsilon_cutoff: Optional[float] = None
     """If set to float strictly between 0 and 1, only tokens with a conditional probability
     greater than epsilon_cutoff will be sampled. In the paper, suggested values range from
     3e-4 to 9e-4, depending on the size of the model. See [Truncation Sampling as Language
     Model Desmoothing](https://hf.co/papers/2210.15191) for more details.
     """
-    eta_cutoff: Optional[float]
+    eta_cutoff: Optional[float] = None
     """Eta sampling is a hybrid of locally typical sampling and epsilon sampling. If set to
     float strictly between 0 and 1, a token is only considered if it is greater than either
     eta_cutoff or sqrt(eta_cutoff) * exp(-entropy(softmax(next_token_logits))). The latter
@@ -37,40 +37,40 @@ class GenerationParameters(BaseInferenceType):
     See [Truncation Sampling as Language Model Desmoothing](https://hf.co/papers/2210.15191)
     for more details.
     """
-    max_length: Optional[int]
+    max_length: Optional[int] = None
     """The maximum length (in tokens) of the generated text, including the input."""
-    max_new_tokens: Optional[int]
+    max_new_tokens: Optional[int] = None
     """The maximum number of tokens to generate. Takes precedence over maxLength."""
-    min_length: Optional[int]
+    min_length: Optional[int] = None
     """The minimum length (in tokens) of the generated text, including the input."""
-    min_new_tokens: Optional[int]
+    min_new_tokens: Optional[int] = None
     """The minimum number of tokens to generate. Takes precedence over maxLength."""
-    num_beam_groups: Optional[int]
+    num_beam_groups: Optional[int] = None
     """Number of groups to divide num_beams into in order to ensure diversity among different
     groups of beams. See [this paper](https://hf.co/papers/1610.02424) for more details.
     """
-    num_beams: Optional[int]
+    num_beams: Optional[int] = None
     """Number of beams to use for beam search."""
-    penalty_alpha: Optional[float]
+    penalty_alpha: Optional[float] = None
     """The value balances the model confidence and the degeneration penalty in contrastive
     search decoding.
     """
-    temperature: Optional[float]
+    temperature: Optional[float] = None
     """The value used to modulate the next token probabilities."""
-    top_k: Optional[int]
+    top_k: Optional[int] = None
     """The number of highest probability vocabulary tokens to keep for top-k-filtering."""
-    top_p: Optional[float]
+    top_p: Optional[float] = None
     """If set to float < 1, only the smallest set of most probable tokens with probabilities
     that add up to top_p or higher are kept for generation.
     """
-    typical_p: Optional[float]
+    typical_p: Optional[float] = None
     """Local typicality measures how similar the conditional probability of predicting a target
     token next is to the expected conditional probability of predicting a random token next,
     given the partial text already generated. If set to float < 1, the smallest set of the
     most locally typical tokens with probabilities that add up to typical_p or higher are
     kept for generation. See [this paper](https://hf.co/papers/2202.00666) for more details.
     """
-    use_cache: Optional[bool]
+    use_cache: Optional[bool] = None
     """Whether the model should use the past last key/values attentions to speed up decoding"""
 
 
@@ -80,7 +80,7 @@ class TextToAudioParameters(BaseInferenceType):
     Additional inference parameters for Text To Audio
     """
 
-    generate: Optional[GenerationParameters]
+    generate: Optional[GenerationParameters] = None
     """Parametrization of the text generation process"""
 
 
@@ -92,7 +92,7 @@ class TextToSpeechInput(BaseInferenceType):
 
     inputs: str
     """The input text data"""
-    parameters: Optional[TextToAudioParameters]
+    parameters: Optional[TextToAudioParameters] = None
     """Additional inference parameters"""
 
 
@@ -105,5 +105,5 @@ class TextToSpeechOutput(BaseInferenceType):
     audio: Any
     """The generated audio waveform."""
     sampling_rate: Any
-    text_to_speech_output_sampling_rate: Optional[float]
+    text_to_speech_output_sampling_rate: Optional[float] = None
     """The sampling rate of the generated audio waveform."""

--- a/src/huggingface_hub/inference/_generated/types/token_classification.py
+++ b/src/huggingface_hub/inference/_generated/types/token_classification.py
@@ -18,11 +18,11 @@ class TokenClassificationParameters(BaseInferenceType):
     Additional inference parameters for Token Classification
     """
 
-    aggregation_strategy: Optional["TokenClassificationAggregationStrategy"]
+    aggregation_strategy: Optional["TokenClassificationAggregationStrategy"] = None
     """The strategy used to fuse tokens based on model predictions"""
-    ignore_labels: Optional[List[str]]
+    ignore_labels: Optional[List[str]] = None
     """A list of labels to ignore"""
-    stride: Optional[int]
+    stride: Optional[int] = None
     """The number of overlapping tokens between chunks when splitting the input text."""
 
 
@@ -32,7 +32,7 @@ class TokenClassificationInput(BaseInferenceType):
 
     inputs: str
     """The input text data"""
-    parameters: Optional[TokenClassificationParameters]
+    parameters: Optional[TokenClassificationParameters] = None
     """Additional inference parameters"""
 
 
@@ -43,11 +43,11 @@ class TokenClassificationOutputElement(BaseInferenceType):
     label: Any
     score: float
     """The associated score / probability"""
-    end: Optional[int]
+    end: Optional[int] = None
     """The character position in the input where this group ends."""
-    entity_group: Optional[str]
+    entity_group: Optional[str] = None
     """The predicted label for that group of tokens"""
-    start: Optional[int]
+    start: Optional[int] = None
     """The character position in the input where this group begins."""
-    word: Optional[str]
+    word: Optional[str] = None
     """The corresponding text"""

--- a/src/huggingface_hub/inference/_generated/types/translation.py
+++ b/src/huggingface_hub/inference/_generated/types/translation.py
@@ -18,11 +18,11 @@ class Text2TextGenerationParameters(BaseInferenceType):
     Additional inference parameters for Text2text Generation
     """
 
-    clean_up_tokenization_spaces: Optional[bool]
+    clean_up_tokenization_spaces: Optional[bool] = None
     """Whether to clean up the potential extra spaces in the text output."""
-    generate_parameters: Optional[Dict[str, Any]]
+    generate_parameters: Optional[Dict[str, Any]] = None
     """Additional parametrization of the text generation algorithm"""
-    truncation: Optional["Text2TextGenerationTruncationStrategy"]
+    truncation: Optional["Text2TextGenerationTruncationStrategy"] = None
     """The truncation strategy to use"""
 
 
@@ -34,7 +34,7 @@ class TranslationInput(BaseInferenceType):
 
     inputs: str
     """The input text data"""
-    parameters: Optional[Text2TextGenerationParameters]
+    parameters: Optional[Text2TextGenerationParameters] = None
     """Additional inference parameters"""
 
 
@@ -45,5 +45,5 @@ class TranslationOutput(BaseInferenceType):
     """
 
     translation_text: Any
-    translation_output_translation_text: Optional[str]
+    translation_output_translation_text: Optional[str] = None
     """The translated text."""

--- a/src/huggingface_hub/inference/_generated/types/video_classification.py
+++ b/src/huggingface_hub/inference/_generated/types/video_classification.py
@@ -18,12 +18,12 @@ class VideoClassificationParameters(BaseInferenceType):
     Additional inference parameters for Video Classification
     """
 
-    frame_sampling_rate: Optional[int]
+    frame_sampling_rate: Optional[int] = None
     """The sampling rate used to select frames from the video."""
-    function_to_apply: Optional["ClassificationOutputTransform"]
-    num_frames: Optional[int]
+    function_to_apply: Optional["ClassificationOutputTransform"] = None
+    num_frames: Optional[int] = None
     """The number of sampled frames to consider for classification."""
-    top_k: Optional[int]
+    top_k: Optional[int] = None
     """When specified, limits the output to the top K most probable classes."""
 
 
@@ -33,7 +33,7 @@ class VideoClassificationInput(BaseInferenceType):
 
     inputs: Any
     """The input video data"""
-    parameters: Optional[VideoClassificationParameters]
+    parameters: Optional[VideoClassificationParameters] = None
     """Additional inference parameters"""
 
 

--- a/src/huggingface_hub/inference/_generated/types/visual_question_answering.py
+++ b/src/huggingface_hub/inference/_generated/types/visual_question_answering.py
@@ -25,7 +25,7 @@ class VisualQuestionAnsweringParameters(BaseInferenceType):
     Additional inference parameters for Visual Question Answering
     """
 
-    top_k: Optional[int]
+    top_k: Optional[int] = None
     """The number of answers to return (will be chosen by order of likelihood). Note that we
     return less than topk answers if there are not enough options available within the
     context.
@@ -38,7 +38,7 @@ class VisualQuestionAnsweringInput(BaseInferenceType):
 
     inputs: VisualQuestionAnsweringInputData
     """One (image, question) pair to answer"""
-    parameters: Optional[VisualQuestionAnsweringParameters]
+    parameters: Optional[VisualQuestionAnsweringParameters] = None
     """Additional inference parameters"""
 
 
@@ -49,5 +49,5 @@ class VisualQuestionAnsweringOutputElement(BaseInferenceType):
     label: Any
     score: float
     """The associated score / probability"""
-    answer: Optional[str]
+    answer: Optional[str] = None
     """The answer to the question"""

--- a/src/huggingface_hub/inference/_generated/types/zero_shot_classification.py
+++ b/src/huggingface_hub/inference/_generated/types/zero_shot_classification.py
@@ -25,11 +25,11 @@ class ZeroShotClassificationParameters(BaseInferenceType):
     Additional inference parameters for Zero Shot Classification
     """
 
-    hypothesis_template: Optional[str]
+    hypothesis_template: Optional[str] = None
     """The sentence used in conjunction with candidateLabels to attempt the text classification
     by replacing the placeholder with the candidate labels.
     """
-    multi_label: Optional[bool]
+    multi_label: Optional[bool] = None
     """Whether multiple candidate labels can be true. If false, the scores are normalized such
     that the sum of the label likelihoods for each sequence is 1. If true, the labels are
     considered independent and probabilities are normalized for each candidate.
@@ -42,7 +42,7 @@ class ZeroShotClassificationInput(BaseInferenceType):
 
     inputs: ZeroShotClassificationInputData
     """The input text data, with candidate labels"""
-    parameters: Optional[ZeroShotClassificationParameters]
+    parameters: Optional[ZeroShotClassificationParameters] = None
     """Additional inference parameters"""
 
 

--- a/src/huggingface_hub/inference/_generated/types/zero_shot_image_classification.py
+++ b/src/huggingface_hub/inference/_generated/types/zero_shot_image_classification.py
@@ -25,7 +25,7 @@ class ZeroShotImageClassificationParameters(BaseInferenceType):
     Additional inference parameters for Zero Shot Image Classification
     """
 
-    hypothesis_template: Optional[str]
+    hypothesis_template: Optional[str] = None
     """The sentence used in conjunction with candidateLabels to attempt the text classification
     by replacing the placeholder with the candidate labels.
     """
@@ -37,7 +37,7 @@ class ZeroShotImageClassificationInput(BaseInferenceType):
 
     inputs: ZeroShotImageClassificationInputData
     """The input image data, with candidate labels"""
-    parameters: Optional[ZeroShotImageClassificationParameters]
+    parameters: Optional[ZeroShotImageClassificationParameters] = None
     """Additional inference parameters"""
 
 

--- a/src/huggingface_hub/inference/_generated/types/zero_shot_object_detection.py
+++ b/src/huggingface_hub/inference/_generated/types/zero_shot_object_detection.py
@@ -25,7 +25,7 @@ class ZeroShotObjectDetectionInput(BaseInferenceType):
 
     inputs: ZeroShotObjectDetectionInputData
     """The input image data, with candidate labels"""
-    parameters: Optional[Dict[str, Any]]
+    parameters: Optional[Dict[str, Any]] = None
     """Additional inference parameters"""
 
 

--- a/tests/test_inference_types.py
+++ b/tests/test_inference_types.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 import pytest
 
 import huggingface_hub.inference._generated.types as types
-from huggingface_hub.inference._generated.types import BaseInferenceType
+from huggingface_hub.inference._generated.types import AutomaticSpeechRecognitionParameters, BaseInferenceType
 
 from .testing_utils import expect_deprecation
 
@@ -155,3 +155,9 @@ def test_optional_are_set_to_none():
                 assert (
                     parameter.default is inspect.Parameter.empty
                 ), f"Parameter {parameter} of {_type} should not have a default"
+
+
+def test_none_inferred():
+    # Doing this should not fail with
+    # TypeError: __init__() missing 2 required positional arguments: 'generate' and 'return_timestamps'
+    AutomaticSpeechRecognitionParameters()

--- a/tests/test_inference_types.py
+++ b/tests/test_inference_types.py
@@ -158,6 +158,7 @@ def test_optional_are_set_to_none():
 
 
 def test_none_inferred():
+    """Regression test for https://github.com/huggingface/huggingface_hub/pull/2095"""
     # Doing this should not fail with
     # TypeError: __init__() missing 2 required positional arguments: 'generate' and 'return_timestamps'
     AutomaticSpeechRecognitionParameters()

--- a/tests/test_inference_types.py
+++ b/tests/test_inference_types.py
@@ -143,18 +143,13 @@ def test_normalize_keys():
 
 
 def test_optional_are_set_to_none():
-    _types = {v for v in types.__dict__.values() if inspect.isclass(v) and issubclass(v, types.BaseInferenceType)}
-    for _type in _types:
+    for _type in types.BaseInferenceType.__subclasses__:
         parameters = inspect.signature(_type).parameters
         for parameter in parameters.values():
             if "Optional" in str(parameter.annotation) or (
                 "Union" in str(parameter.annotation) and "NoneType" in str(parameter.annotation)
             ):
                 assert parameter.default is None, f"Parameter {parameter} of {_type} should be set to None"
-            else:
-                assert (
-                    parameter.default is inspect.Parameter.empty
-                ), f"Parameter {parameter} of {_type} should not have a default"
 
 
 def test_none_inferred():

--- a/utils/generate_inference_types.py
+++ b/utils/generate_inference_types.py
@@ -134,6 +134,17 @@ def _fix_naming_for_shared_classes(content: str, module_name: str) -> str:
     return content
 
 
+def _make_optional_fields_default_to_none(content: str):
+    lines = []
+    for line in content.split("\n"):
+        if "Optional[" in line and not line.endswith("None"):
+            line += " = None"
+
+        lines.append(line)
+
+    return "\n".join(lines)
+
+
 def _list_dataclasses(content: str) -> List[str]:
     """List all dataclasses defined in the module."""
     return INHERITED_DATACLASS_REGEX.findall(content)
@@ -143,6 +154,7 @@ def fix_inference_classes(content: str, module_name: str) -> str:
     content = _inherit_from_base(content)
     content = _delete_empty_lines(content)
     content = _fix_naming_for_shared_classes(content, module_name)
+    content = _make_optional_fields_default_to_none(content)
     return content
 
 


### PR DESCRIPTION
Adds `= None` to optional values so that the following can be done:

```py
from huggingface_hub import AutomaticSpeechRecognitionParameters

AutomaticSpeechRecognitionParameters()
```

without this PR, we cannot due to the following:
```
TypeError: __init__() missing 2 required positional arguments: 'generate' and 'return_timestamps'
```