### PR TITLE
fix cache invalidation caused by repo_id capitalization issues

### DIFF
--- a/src/huggingface_hub/commands/huggingface_cli.py
+++ b/src/huggingface_hub/commands/huggingface_cli.py
@@ -39,7 +39,9 @@ def main():
 
     # Let's go
     args = parser.parse_args()
-
+    # Convert repo_id to lower case. fix case issues causing cache invalidation
+    if hasattr(args, "repo_id"):
+        args.repo_id = args.repo_id.lower()
     if not hasattr(args, "func"):
         parser.print_help()
         exit(1)


### PR DESCRIPTION
Convert repo_id to lower case. fix issues causing cache invalidation