### PR TITLE
Fix ModelHubMixin: save config only if doesn't exist

### DIFF
--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -254,7 +254,10 @@ class ModelHubMixin:
         if config is not None:
             if is_dataclass(config):
                 config = asdict(config)  # type: ignore[arg-type]
-            (save_directory / CONFIG_NAME).write_text(json.dumps(config, sort_keys=True, indent=2))
+            config_path = save_directory / CONFIG_NAME
+            if not config_path.exists():
+                config_str = json.dumps(config, sort_keys=True, indent=2)
+                config_path.write_text(config_str)
 
         # save model card
         model_card_path = save_directory / "README.md"

--- a/tests/test_hub_mixin_pytorch.py
+++ b/tests/test_hub_mixin_pytorch.py
@@ -290,6 +290,7 @@ class PytorchHubMixinTest(unittest.TestCase):
         assert reloaded_with_default.state == "other"
         assert reloaded_with_default.config == {"num_classes": 50, "state": "other"}
 
+        config_file.unlink()  # Remove config file
         reloaded_with_default.save_pretrained(self.cache_dir)
         assert json.loads(config_file.read_text()) == {"num_classes": 50, "state": "other"}
 
@@ -307,6 +308,7 @@ class PytorchHubMixinTest(unittest.TestCase):
         assert "not_jsonable" not in model.config
 
         # If jsonable value passed by user, it's saved in the config
+        (self.cache_dir / "config.json").unlink()
         new_model = DummyModelNoConfig(not_jsonable=123)
         new_model.save_pretrained(self.cache_dir)
         assert new_model.config["not_jsonable"] == 123


### PR DESCRIPTION
Fix a recent breaking change in `ModelHubMixing` that overwrites the config.json file generated by `_save_pretrained` if the class implements it. With this update, `config.json` is saved only if it doesn't exist already.

cc @natooz, this is a fix for https://github.com/huggingface/huggingface_hub/issues/2102. Thanks again for reporting :)  