### PR TITLE
Fix unhandled filelock issue

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -20,7 +20,6 @@ from typing import Any, BinaryIO, Dict, Generator, Literal, Optional, Tuple, Uni
 from urllib.parse import quote, urlparse
 
 import requests
-from filelock import FileLock
 
 from huggingface_hub import constants
 
@@ -55,6 +54,7 @@ from .utils import (
     RepositoryNotFoundError,
     RevisionNotFoundError,
     SoftTemporaryDirectory,
+    WeakFileLock,
     build_hf_headers,
     get_fastai_version,  # noqa: F401 # for backward compatibility
     get_fastcore_version,  # noqa: F401 # for backward compatibility
@@ -778,7 +778,7 @@ def cached_download(
     if os.name == "nt" and len(os.path.abspath(cache_path)) > 255:
         cache_path = "\\\\?\\" + os.path.abspath(cache_path)
 
-    with FileLock(lock_path):
+    with WeakFileLock(lock_path):
         # If the download just completed while the lock was activated.
         if os.path.exists(cache_path) and not force_download:
             # Even if returning early like here, the lock will be released.
@@ -1437,7 +1437,7 @@ def hf_hub_download(
         blob_path = "\\\\?\\" + os.path.abspath(blob_path)
 
     Path(lock_path).parent.mkdir(parents=True, exist_ok=True)
-    with FileLock(lock_path):
+    with WeakFileLock(lock_path):
         # If the download just completed while the lock was activated.
         if os.path.exists(pointer_path) and not force_download:
             # Even if returning early like here, the lock will be released.

--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -43,7 +43,7 @@ from ._errors import (
     hf_raise_for_status,
 )
 from ._experimental import experimental
-from ._fixes import SoftTemporaryDirectory, yaml_dump
+from ._fixes import SoftTemporaryDirectory, WeakFileLock, yaml_dump
 from ._git_credential import list_credential_helpers, set_git_credential, unset_git_credential
 from ._headers import LocalTokenNotFoundError, build_hf_headers, get_token_to_send
 from ._hf_folder import HfFolder

--- a/src/huggingface_hub/utils/_fixes.py
+++ b/src/huggingface_hub/utils/_fixes.py
@@ -85,7 +85,7 @@ def WeakFileLock(lock_file: Union[str, Path]) -> Generator[BaseFileLock, None, N
     yield lock
 
     try:
-        return lock._release()
+        return lock.release()
     except OSError:
         try:
             Path(lock_file).unlink()

--- a/src/huggingface_hub/utils/_fixes.py
+++ b/src/huggingface_hub/utils/_fixes.py
@@ -8,7 +8,6 @@ except ImportError:
         from simplejson import JSONDecodeError  # type: ignore # noqa: F401
     except ImportError:
         from json import JSONDecodeError  # type: ignore  # noqa: F401
-
 import contextlib
 import os
 import shutil
@@ -19,6 +18,7 @@ from pathlib import Path
 from typing import Callable, Generator, Optional, Union
 
 import yaml
+from filelock import BaseFileLock, FileLock
 
 
 # Wrap `yaml.dump` to set `allow_unicode=True` by default.
@@ -75,3 +75,19 @@ def SoftTemporaryDirectory(
 def _set_write_permission_and_retry(func, path, excinfo):
     os.chmod(path, stat.S_IWRITE)
     func(path)
+
+
+@contextlib.contextmanager
+def WeakFileLock(lock_file: Union[str, Path]) -> Generator[BaseFileLock, None, None]:
+    lock = FileLock(lock_file)
+    lock.acquire()
+
+    yield lock
+
+    try:
+        return lock._release()
+    except OSError:
+        try:
+            Path(lock_file).unlink()
+        except OSError:
+            pass


### PR DESCRIPTION
Fix for https://github.com/huggingface/huggingface_hub/issues/2038 cc @vladmandic

If filelock release fails with OSError, let's default back to a SoftFileLock release (e.g. try to delete the file). This is not perfect but in our case it's more than enough.