### PR TITLE
Change serialization of model hub mixin

### DIFF
--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -186,7 +186,7 @@ class ModelHubMixin:
             if "args" not in param_names_in_descendant_init_method:
                 index = min(len(param_names_in_descendant_init_method), len(args))
                 cls._init_params.update(dict(zip(param_names_in_descendant_init_method[:index], args[:index])))
-            if "args" in param_names_in_descendant_init_method : 
+            if "args" in param_names_in_descendant_init_method:
                 index = min(param_names_in_descendant_init_method.index("args") + 1, len(args))
                 cls._init_params.update(dict(zip(param_names_in_descendant_init_method[:index], args[:index])))
                 if len(args) >= param_names_in_descendant_init_method.index("args") + 1:

--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -595,10 +595,9 @@ class PyTorchModelHubMixin(ModelHubMixin):
         **model_kwargs,
     ):
         """Load Pytorch pretrained weights and return the loaded model."""
-
-        if "hugginggface_hub_version" in model_kwargs:
+        if "huggingface_hub_version" in model_kwargs:
             # new serialization
-            model_kwargs.pop("hugginggface_hub_version")
+            model_kwargs.pop("huggingface_hub_version")
             param_names_in_descendant_init_method = cls.get_init_params_from_last_descendant()
             # case where there is only config parameter
             if param_names_in_descendant_init_method == ["config"]:


### PR DESCRIPTION
# what this pr do : 
this will change the serialization method for all new AI models.
to avoid any breaking changes, if `huggingface_hub_version` we will deserialize according to the new serialization, if the `huggingface_hub_version` is not present we will deserialize according to the previous version.

Fix https://github.com/huggingface/huggingface_hub/issues/2096

# TODO : 

- [ ] fix model card
- [ ] add tests (test models using previous serialization too **high priority** )
- [ ] use `is_jsonable` in on `__new__` parameters
- [ ] update `KerasModelHubMixin`

I know i pretty much reworked lots of stuff from the ground up and it's a little bit ruff around the edges but it should support most cases.

how to use : 
```python
from huggingface_hub import PyTorchModelHubMixin
import torch.nn as nn

class MyModel(PyTorchModelHubMixin,nn.Module):
  def __init__(self,config,a,b,*args,**kwargs): # or any other combination
    super().__init__()
    assert a =="a", f'expected a = "a" but found {a} '
    assert b =="b", f'expected b = "b" but found {b} '
    assert kwargs["c"] == "c"
    self.layer = nn.Linear(config["a"],config["b"])
    self.config = config
    self.a = a
    self.b = b
    self.kwargs = kwargs



config = {"a":2,
          "b" : 1}
model = MyModel(config = config, a="a",b="b",c="c")
model.push_to_hub("not-lain/MyModelWithParams")
model2 = MyModel.from_pretrained("not-lain/MyModelWithParams")
```



cc @Wauplin 