### PR TITLE
Fix kwargs not loading correctly

### DIFF
--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -390,10 +390,10 @@ class ModelHubMixin:
             elif (
                 "kwargs" in cls._init_parameters
                 and cls._init_parameters["kwargs"].kind == inspect.Parameter.VAR_KEYWORD
+                and "kwargs" not in config
             ):
-                # 2. If __init__ accepts **kwargs, let's forward the kwargs field as well (as a dict)
-                if "kwargs" in config:
-                    model_kwargs.update(config["kwargs"])
+                # 2. If __init__ accepts **kwargs, let's forward the config as well (as a dict)
+                model_kwargs["config"] = config
 
         instance = cls._from_pretrained(
             model_id=str(model_id),


### PR DESCRIPTION
Fix https://github.com/huggingface/huggingface_hub/issues/2096

this should fix the kwargs when deserializing.
**TLDR;**
it all kwargs will be moved up in config to have their seperate field, allowing for things like
```python
from huggingface_hub import PyTorchModelHubMixin
import torch.nn as nn

class MyModel(PyTorchModelHubMixin,nn.Module):
  def __init__(self,config,a,b,**kwargs):
    super().__init__()
    assert kwargs["c"] == "c"
    self.layer = nn.Linear(a,b)

model = MyModel(config={"d":"d"},a=1,b=2,c="c")
model.push_to_hub("not-lain/newkwargsserialization")
model2 = MyModel.from_pretrained("not-lain/newkwargsserialization")
```
![image](https://github.com/huggingface/huggingface_hub/assets/70411813/301173ed-699a-4da8-a818-20456fbaf8e3)


also cc @Wauplin for review