### PR TITLE
Fix --delete in huggingface-cli upload command

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -8437,7 +8437,7 @@ class HfApi:
         filenames = self.list_repo_files(repo_id=repo_id, revision=revision, repo_type=repo_type, token=token)
 
         # Compute relative path in repo
-        if path_in_repo:
+        if path_in_repo and path_in_repo not in (".", "./"):
             path_in_repo = path_in_repo.strip("/") + "/"  # harmonize
             relpath_to_abspath = {
                 file[len(path_in_repo) :]: file for file in filenames if file.startswith(path_in_repo)

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2318,6 +2318,7 @@ class UploadFolderMockedTest(unittest.TestCase):
         self.assertEqual(deleted_files, {"sub/file1.txt", "sub/file.txt"})
 
     def test_delete_if_path_in_repo(self):
+        # Regression test for https://github.com/huggingface/huggingface_hub/pull/2129
         operations = self._upload_folder_alias(path_in_repo=".", folder_path=self.cache_dir, delete_patterns="*")
         deleted_files = {op.path_in_repo for op in operations if isinstance(op, CommitOperationDelete)}
         assert deleted_files == {"file1.txt", "sub/file1.txt"}  # all the 'old' files

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2317,6 +2317,11 @@ class UploadFolderMockedTest(unittest.TestCase):
         self.assertEqual(added_files, {"sub/lfs_in_sub.bin"})  # no "sub/file.txt"
         self.assertEqual(deleted_files, {"sub/file1.txt", "sub/file.txt"})
 
+    def test_delete_if_path_in_repo(self):
+        operations = self._upload_folder_alias(path_in_repo=".", folder_path=self.cache_dir, delete_patterns="*")
+        deleted_files = {op.path_in_repo for op in operations if isinstance(op, CommitOperationDelete)}
+        assert deleted_files == {"file1.txt", "sub/file1.txt"}  # all the 'old' files
+
 
 @pytest.mark.usefixtures("fx_cache_dir")
 class HfLargefilesTest(HfApiCommonTest):


### PR DESCRIPTION
This PR fixes a bug when `path_in_repo="."` or `path_in_repo="./"` is passed along `delete_patterns` in `upload_folder`. In particular it fixes the `--delete` flag when running `huggingface-cli upload` command.

First reported by @Cadene. 