### PR TITLE
Fast download in hf file system

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -404,6 +404,7 @@ def http_get(
     expected_size: Optional[int] = None,
     displayed_filename: Optional[str] = None,
     _nb_retries: int = 5,
+    _tqdm_bar: Optional[tqdm] = None,
 ) -> None:
     """
     Download a remote file. Do not gobble up errors, and will return errors tailored to the Hugging Face Hub.
@@ -483,84 +484,90 @@ def http_get(
     )
 
     # Stream file to buffer
-    with tqdm(
-        unit="B",
-        unit_scale=True,
-        total=total,
-        initial=resume_size,
-        desc=displayed_filename,
-        disable=True if (logger.getEffectiveLevel() == logging.NOTSET) else None,
-        # ^ set `disable=None` rather than `disable=False` by default to disable progress bar when no TTY attached
-        # see https://github.com/huggingface/huggingface_hub/pull/2000
-    ) as progress:
-        if hf_transfer and total is not None and total > 5 * DOWNLOAD_CHUNK_SIZE:
-            supports_callback = "callback" in inspect.signature(hf_transfer.download).parameters
-            if not supports_callback:
-                warnings.warn(
-                    "You are using an outdated version of `hf_transfer`. "
-                    "Consider upgrading to latest version to enable progress bars "
-                    "using `pip install -U hf_transfer`."
-                )
-            try:
-                hf_transfer.download(
-                    url=url,
-                    filename=temp_file.name,
-                    max_files=HF_TRANSFER_CONCURRENCY,
-                    chunk_size=DOWNLOAD_CHUNK_SIZE,
-                    headers=headers,
-                    parallel_failures=3,
-                    max_retries=5,
-                    **({"callback": progress.update} if supports_callback else {}),
-                )
-            except Exception as e:
-                raise RuntimeError(
-                    "An error occurred while downloading using `hf_transfer`. Consider"
-                    " disabling HF_HUB_ENABLE_HF_TRANSFER for better error handling."
-                ) from e
-            if not supports_callback:
-                progress.update(total)
-            if expected_size is not None and expected_size != os.path.getsize(temp_file.name):
-                raise EnvironmentError(
-                    consistency_error_message.format(
-                        actual_size=os.path.getsize(temp_file.name),
-                    )
-                )
-            return
-        new_resume_size = resume_size
-        try:
-            for chunk in r.iter_content(chunk_size=DOWNLOAD_CHUNK_SIZE):
-                if chunk:  # filter out keep-alive new chunks
-                    progress.update(len(chunk))
-                    temp_file.write(chunk)
-                    new_resume_size += len(chunk)
-                    # Some data has been downloaded from the server so we reset the number of retries.
-                    _nb_retries = 5
-        except (requests.ConnectionError, requests.ReadTimeout) as e:
-            # If ConnectionError (SSLError) or ReadTimeout happen while streaming data from the server, it is most likely
-            # a transient error (network outage?). We log a warning message and try to resume the download a few times
-            # before giving up. Tre retry mechanism is basic but should be enough in most cases.
-            if _nb_retries <= 0:
-                logger.warning("Error while downloading from %s: %s\nMax retries exceeded.", url, str(e))
-                raise
-            logger.warning("Error while downloading from %s: %s\nTrying to resume download...", url, str(e))
-            time.sleep(1)
-            reset_sessions()  # In case of SSLError it's best to reset the shared requests.Session objects
-            return http_get(
-                url=url,
-                temp_file=temp_file,
-                proxies=proxies,
-                resume_size=new_resume_size,
-                headers=initial_headers,
-                expected_size=expected_size,
-                _nb_retries=_nb_retries - 1,
-            )
+    progress = _tqdm_bar
+    if progress is None:
+        progress = tqdm(
+            unit="B",
+            unit_scale=True,
+            total=total,
+            initial=resume_size,
+            desc=displayed_filename,
+            disable=True if (logger.getEffectiveLevel() == logging.NOTSET) else None,
+            # ^ set `disable=None` rather than `disable=False` by default to disable progress bar when no TTY attached
+            # see https://github.com/huggingface/huggingface_hub/pull/2000
+        )
 
-        if expected_size is not None and expected_size != temp_file.tell():
+    if hf_transfer and total is not None and total > 5 * DOWNLOAD_CHUNK_SIZE:
+        supports_callback = "callback" in inspect.signature(hf_transfer.download).parameters
+        if not supports_callback:
+            warnings.warn(
+                "You are using an outdated version of `hf_transfer`. "
+                "Consider upgrading to latest version to enable progress bars "
+                "using `pip install -U hf_transfer`."
+            )
+        try:
+            hf_transfer.download(
+                url=url,
+                filename=temp_file.name,
+                max_files=HF_TRANSFER_CONCURRENCY,
+                chunk_size=DOWNLOAD_CHUNK_SIZE,
+                headers=headers,
+                parallel_failures=3,
+                max_retries=5,
+                **({"callback": progress.update} if supports_callback else {}),
+            )
+        except Exception as e:
+            raise RuntimeError(
+                "An error occurred while downloading using `hf_transfer`. Consider"
+                " disabling HF_HUB_ENABLE_HF_TRANSFER for better error handling."
+            ) from e
+        if not supports_callback:
+            progress.update(total)
+        if expected_size is not None and expected_size != os.path.getsize(temp_file.name):
             raise EnvironmentError(
                 consistency_error_message.format(
-                    actual_size=temp_file.tell(),
+                    actual_size=os.path.getsize(temp_file.name),
                 )
             )
+        return
+    new_resume_size = resume_size
+    try:
+        for chunk in r.iter_content(chunk_size=DOWNLOAD_CHUNK_SIZE):
+            if chunk:  # filter out keep-alive new chunks
+                progress.update(len(chunk))
+                temp_file.write(chunk)
+                new_resume_size += len(chunk)
+                # Some data has been downloaded from the server so we reset the number of retries.
+                _nb_retries = 5
+    except (requests.ConnectionError, requests.ReadTimeout) as e:
+        # If ConnectionError (SSLError) or ReadTimeout happen while streaming data from the server, it is most likely
+        # a transient error (network outage?). We log a warning message and try to resume the download a few times
+        # before giving up. Tre retry mechanism is basic but should be enough in most cases.
+        if _nb_retries <= 0:
+            logger.warning("Error while downloading from %s: %s\nMax retries exceeded.", url, str(e))
+            raise
+        logger.warning("Error while downloading from %s: %s\nTrying to resume download...", url, str(e))
+        time.sleep(1)
+        reset_sessions()  # In case of SSLError it's best to reset the shared requests.Session objects
+        return http_get(
+            url=url,
+            temp_file=temp_file,
+            proxies=proxies,
+            resume_size=new_resume_size,
+            headers=initial_headers,
+            expected_size=expected_size,
+            _nb_retries=_nb_retries - 1,
+            _tqdm_bar=_tqdm_bar,
+        )
+
+    progress.close()
+
+    if expected_size is not None and expected_size != temp_file.tell():
+        raise EnvironmentError(
+            consistency_error_message.format(
+                actual_size=temp_file.tell(),
+            )
+        )
 
 
 @validate_hf_hub_args

--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -601,7 +601,7 @@ class HfFileSystem(fsspec.AbstractFileSystem):
             url = url.replace("/resolve/", "/tree/", 1)
         return url
 
-    def get_file(self, rpath, lpath, callback=_DEFAULT_CALLBACK, outfile=None, **kwargs):
+    def get_file(self, rpath, lpath, callback=_DEFAULT_CALLBACK, outfile=None, **kwargs) -> None:
         """Copy single remote file to local."""
         unhandled_kwargs = set(kwargs.keys()) - {"revision"}
         if not isinstance(callback, (NoOpCallback, TqdmCallback)) or len(unhandled_kwargs) > 0:

--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -737,7 +737,7 @@ class HfFileSystemFile(fsspec.spec.AbstractBufferedFile):
         temporary file and read from there.
         """
         if self.mode == "rb" and (length is None or length == -1) and self.loc == 0:
-            with self.fs.open(self.path, "rb", block_size=0) as f:
+            with self.fs.open(self.path, "rb", block_size=0) as f:  # block_size=0 enables fast streaming
                 return f.read()
         return super().read(length)
 

--- a/tests/test_hf_file_system.py
+++ b/tests/test_hf_file_system.py
@@ -419,7 +419,7 @@ class HfFileSystemTests(unittest.TestCase):
         # If partial read => should not download whole file
         with patch.object(self.hffs, "get_file") as mock:
             with self.hffs.open(self.text_file, "r") as f:
-                self.assertEqual(f.read(length=5), "dummy")
+                self.assertEqual(f.read(5), "dummy")
             mock.assert_not_called()
 
     def test_get_file_with_temporary_file(self):

--- a/tests/test_hf_file_system.py
+++ b/tests/test_hf_file_system.py
@@ -1,12 +1,15 @@
 import datetime
 import io
+import tempfile
 import unittest
+from pathlib import Path
 from typing import Optional
 from unittest.mock import patch
 
 import fsspec
 import pytest
 
+from huggingface_hub import hf_file_system
 from huggingface_hub.hf_file_system import HfFileSystem, HfFileSystemFile, HfFileSystemStreamFile
 from huggingface_hub.utils import RepositoryNotFoundError, RevisionNotFoundError
 
@@ -51,6 +54,8 @@ class HfFileSystemTests(unittest.TestCase):
             repo_type="dataset",
         )
 
+        self.text_file = self.hf_path + "/data/text_data.txt"
+
     def tearDown(self):
         self.api.delete_repo(self.repo_id, repo_type="dataset")
 
@@ -68,7 +73,7 @@ class HfFileSystemTests(unittest.TestCase):
         self.assertIsNotNone(data_dir["last_commit"])
         self.assertIsNotNone(data_dir["tree_id"])
 
-        text_data_file = self.hffs.info(self.hf_path + "/data/text_data.txt")
+        text_data_file = self.hffs.info(self.text_file)
         self.assertEqual(text_data_file["type"], "file")
         self.assertGreater(text_data_file["size"], 0)  # not empty
         self.assertTrue(text_data_file["name"].endswith("/data/text_data.txt"))
@@ -78,7 +83,7 @@ class HfFileSystemTests(unittest.TestCase):
         self.assertIn("security", text_data_file)  # the staging endpoint does not run security checks
 
         # cached info
-        self.assertEqual(self.hffs.info(self.hf_path + "/data/text_data.txt"), text_data_file)
+        self.assertEqual(self.hffs.info(self.text_file), text_data_file)
 
     def test_glob(self):
         self.assertEqual(
@@ -137,7 +142,7 @@ class HfFileSystemTests(unittest.TestCase):
 
     def test_url(self):
         self.assertEqual(
-            self.hffs.url(self.hf_path + "/data/text_data.txt"),
+            self.hffs.url(self.text_file),
             f"{ENDPOINT_STAGING}/datasets/{self.repo_id}/resolve/main/data/text_data.txt",
         )
         self.assertEqual(
@@ -149,12 +154,10 @@ class HfFileSystemTests(unittest.TestCase):
         self.assertTrue(
             self.hffs.isdir(self.hf_path + "/data") and not self.hffs.isdir(self.hf_path + "/.gitattributes")
         )
-        self.assertTrue(
-            self.hffs.isfile(self.hf_path + "/data/text_data.txt") and not self.hffs.isfile(self.hf_path + "/data")
-        )
+        self.assertTrue(self.hffs.isfile(self.text_file) and not self.hffs.isfile(self.hf_path + "/data"))
 
     def test_remove_file(self):
-        self.hffs.rm_file(self.hf_path + "/data/text_data.txt")
+        self.hffs.rm_file(self.text_file)
         self.assertEqual(self.hffs.glob(self.hf_path + "/data/*"), [self.hf_path + "/data/binary_data.bin"])
         self.hffs.rm_file(self.hf_path + "@refs/pr/1" + "/data/binary_data_for_pr.bin")
         self.assertEqual(self.hffs.glob(self.hf_path + "@refs/pr/1" + "/data/*"), [])
@@ -166,7 +169,7 @@ class HfFileSystemTests(unittest.TestCase):
         self.assertNotIn(self.hf_path + "@refs/pr/1" + "/data", self.hffs.ls(self.hf_path))
 
     def test_read_file(self):
-        with self.hffs.open(self.hf_path + "/data/text_data.txt", "r") as f:
+        with self.hffs.open(self.text_file, "r") as f:
             self.assertIsInstance(f, io.TextIOWrapper)
             self.assertIsInstance(f.buffer, HfFileSystemFile)
             self.assertEqual(f.read(), "dummy text data")
@@ -210,16 +213,16 @@ class HfFileSystemTests(unittest.TestCase):
 
     @unittest.skip("Not implemented yet")
     def test_append_file(self):
-        with self.hffs.open(self.hf_path + "/data/text_data.txt", "a") as f:
+        with self.hffs.open(self.text_file, "a") as f:
             f.write(" appended text")
 
-        with self.hffs.open(self.hf_path + "/data/text_data.txt", "r") as f:
+        with self.hffs.open(self.text_file, "r") as f:
             self.assertEqual(f.read(), "dummy text data appended text")
 
     def test_copy_file(self):
         # Non-LFS file
-        self.assertIsNone(self.hffs.info(self.hf_path + "/data/text_data.txt")["lfs"])
-        self.hffs.cp_file(self.hf_path + "/data/text_data.txt", self.hf_path + "/data/text_data_copy.txt")
+        self.assertIsNone(self.hffs.info(self.text_file)["lfs"])
+        self.hffs.cp_file(self.text_file, self.hf_path + "/data/text_data_copy.txt")
         with self.hffs.open(self.hf_path + "/data/text_data_copy.txt", "r") as f:
             self.assertEqual(f.read(), "dummy text data")
         self.assertIsNone(self.hffs.info(self.hf_path + "/data/text_data_copy.txt")["lfs"])
@@ -231,11 +234,20 @@ class HfFileSystemTests(unittest.TestCase):
         self.assertIsNotNone(self.hffs.info(self.hf_path + "/data/binary_data_copy.bin")["lfs"])
 
     def test_modified_time(self):
-        self.assertIsInstance(self.hffs.modified(self.hf_path + "/data/text_data.txt"), datetime.datetime)
+        self.assertIsInstance(self.hffs.modified(self.text_file), datetime.datetime)
         self.assertIsInstance(self.hffs.modified(self.hf_path + "/data"), datetime.datetime)
         # should fail on a non-existing file
         with self.assertRaises(FileNotFoundError):
             self.hffs.modified(self.hf_path + "/data/not_existing_file.txt")
+
+    def test_open_if_not_found(self):
+        # Regression test: opening a missing file should raise a FileNotFoundError. This was not the case before when
+        # opening a file in read mode.
+        with self.assertRaises(FileNotFoundError):
+            self.hffs.open("hf://missing/repo/not_existing_file.txt", mode="r")
+
+        with self.assertRaises(FileNotFoundError):
+            self.hffs.open("hf://missing/repo/not_existing_file.txt", mode="w")
 
     def test_initialize_from_fsspec(self):
         fs, _, paths = fsspec.get_fs_token_paths(
@@ -248,7 +260,7 @@ class HfFileSystemTests(unittest.TestCase):
         self.assertIsInstance(fs, HfFileSystem)
         self.assertEqual(fs._api.endpoint, ENDPOINT_STAGING)
         self.assertEqual(fs.token, TOKEN)
-        self.assertEqual(paths, [self.hf_path + "/data/text_data.txt"])
+        self.assertEqual(paths, [self.text_file])
 
         fs, _, paths = fsspec.get_fs_token_paths(f"hf://{self.repo_id}/data/text_data.txt")
         self.assertIsInstance(fs, HfFileSystem)
@@ -295,7 +307,7 @@ class HfFileSystemTests(unittest.TestCase):
         self.assertIn("security", files[1])  # the staging endpoint does not run security checks
 
     def test_list_data_file_no_revision(self):
-        files = self.hffs.ls(self.hf_path + "/data/text_data.txt")
+        files = self.hffs.ls(self.text_file)
         self.assertEqual(len(files), 1)
 
         self.assertEqual(files[0]["type"], "file")
@@ -388,8 +400,58 @@ class HfFileSystemTests(unittest.TestCase):
         self.assertEqual(out, files)
 
     def test_find_data_file_no_revision(self):
-        files = self.hffs.find(self.hf_path + "/data/text_data.txt", detail=False)
-        self.assertEqual(files, [self.hf_path + "/data/text_data.txt"])
+        files = self.hffs.find(self.text_file, detail=False)
+        self.assertEqual(files, [self.text_file])
+
+    def test_read_bytes(self):
+        data = self.hffs.read_bytes(self.text_file)
+        self.assertEqual(data, b"dummy text data")
+
+    def test_read_text(self):
+        data = self.hffs.read_text(self.text_file)
+        self.assertEqual(data, "dummy text data")
+
+    def test_open_and_read(self):
+        with self.hffs.open(self.text_file, "r") as f:
+            self.assertEqual(f.read(), "dummy text data")
+
+    def test_partial_read(self):
+        # If partial read => should not download whole file
+        with patch.object(self.hffs, "get_file") as mock:
+            with self.hffs.open(self.text_file, "r") as f:
+                self.assertEqual(f.read(length=5), "dummy")
+            mock.assert_not_called()
+
+    def test_get_file_with_temporary_file(self):
+        with tempfile.TemporaryFile() as temp_file:
+            self.hffs.get_file(self.text_file, temp_file)
+            temp_file.seek(0)
+            assert temp_file.read() == b"dummy text data"
+
+    def test_get_file_with_named_temporary_file(self):
+        # Test passing a file path works => compatible with hf_transfer
+        with tempfile.NamedTemporaryFile() as temp_file:
+            self.hffs.get_file(self.text_file, temp_file.name)
+            with open(temp_file.name, "rb") as f:
+                assert f.read() == b"dummy text data"
+
+    def test_get_file_with_kwargs(self):
+        # If custom kwargs are passed, the function should still work but defaults to base implementation
+        with patch.object(hf_file_system, "http_get") as mock:
+            with tempfile.NamedTemporaryFile() as temp_file:
+                self.hffs.get_file(self.text_file, temp_file.name, custom_kwarg=123)
+            mock.assert_not_called()
+
+            with tempfile.NamedTemporaryFile() as temp_file:
+                self.hffs.get_file(self.text_file, temp_file.name)
+            mock.assert_called_once()
+
+    def test_get_file_on_folder(self):
+        # Test it works with custom kwargs
+        with tempfile.TemporaryDirectory() as temp_dir:
+            assert not (Path(temp_dir) / "data").exists()
+            self.hffs.get_file(self.hf_path + "/data", temp_dir + "/data")
+            assert (Path(temp_dir) / "data").exists()
 
 
 @pytest.mark.parametrize("path_in_repo", ["", "file.txt", "path/to/file"])


### PR DESCRIPTION
Should fix the current regression in file download speed. When downloading an entire file, let's rely on `hf_hub_download` which is faster, has retry mechanism and can be speed-up with `hf_transfer` (on-demand). 

```py
import time
from tempfile import TemporaryDirectory
from datasets import Dataset

repo_id = "Open-Orca/OpenOrca"
filename = "3_5M-GPT3_5-Augmented.parquet"

parquet = f"hf://datasets/{repo_id}/{filename}"

t0 = time.time()
with TemporaryDirectory() as temp_dir:
    Dataset.from_parquet(parquet, cache_dir=temp_dir)
t1 = time.time()
print(t1 - t0)
```
=> on my local setup, speed went from ~15MB/s to 45MB/s (on wifi, no hf_transfer) which is strictly the same speed as a normal `hf_hub_download`.

cc @lhoestq @julien-c (related to https://twitter.com/ashvardanian/status/1769964480086024203)

For the review, it's best to select `Hide whitespace` on Github.

---

TODO:
- [x] add proper test in hfh
- [x] test in datasets? (cc @lhoestq)
- [x] fix what if `callback.tqdm` doesn't exist? 