### PR TITLE
Fix use other chat completion providers

### DIFF
--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -548,7 +548,9 @@ class InferenceClient:
         if _is_chat_completion_server(model):
             # First, let's consider the server has a `/v1/chat/completions` endpoint.
             # If that's the case, we don't have to render the chat template client-side.
-            model_url = self._resolve_url(model) + "/v1/chat/completions"
+            model_url = self._resolve_url(model)
+            if not model_url.endswith("/chat/completions"):
+                model_url += "/v1/chat/completions"
 
             try:
                 data = self.post(

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -548,7 +548,9 @@ class AsyncInferenceClient:
         if _is_chat_completion_server(model):
             # First, let's consider the server has a `/v1/chat/completions` endpoint.
             # If that's the case, we don't have to render the chat template client-side.
-            model_url = self._resolve_url(model) + "/v1/chat/completions"
+            model_url = self._resolve_url(model)
+            if not model_url.endswith("/chat/completions"):
+                model_url += "/v1/chat/completions"
 
             try:
                 data = await self.post(


### PR DESCRIPTION
Last minute fix thanks to @radames [comment](https://huggingface.co/spaces/Wauplin/huggingface_hub/discussions/5#65fca9e9a0d7adc40b544b61).

We should be able to use `InferenceClient` with other providers that are OpenAI-compatible. For example, `InferenceClient(model="https://api.mistral.ai/v1/chat/completions")` is valid. This PR fixes implementation for such APIs by not appending `/chat/completions` if it already exists.