### PR TITLE
Fix HF_ENDPOINT not handled correctly

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -185,11 +185,6 @@ def repo_type_and_id_from_hf_id(hf_id: str, hub_url: Optional[str] = None) -> Tu
     """
     input_hf_id = hf_id
 
-    # check if a proxy has been set => if yes, update the returned URL to use the proxy
-    if ENDPOINT not in (_HF_DEFAULT_ENDPOINT, _HF_DEFAULT_STAGING_ENDPOINT):
-        hf_id = hf_id.replace(_HF_DEFAULT_ENDPOINT, ENDPOINT)
-        hf_id = hf_id.replace(_HF_DEFAULT_STAGING_ENDPOINT, ENDPOINT)
-
     hub_url = re.sub(r"https?://", "", hub_url if hub_url is not None else ENDPOINT)
     is_hf_url = hub_url in hf_id and "@" not in hf_id
 
@@ -436,6 +431,11 @@ class RepoUrl(str):
     """
 
     def __new__(cls, url: Any, endpoint: Optional[str] = None):
+        # check if a proxy has been set => if yes, update the returned URL to use the proxy
+        if ENDPOINT not in (_HF_DEFAULT_ENDPOINT, _HF_DEFAULT_STAGING_ENDPOINT):
+            url = url.replace(_HF_DEFAULT_ENDPOINT, ENDPOINT)
+            url = url.replace(_HF_DEFAULT_STAGING_ENDPOINT, ENDPOINT)
+
         return super(RepoUrl, cls).__new__(cls, url)
 
     def __init__(self, url: Any, endpoint: Optional[str] = None) -> None:


### PR DESCRIPTION
Fix https://github.com/huggingface/huggingface_hub/issues/2152. Related to https://github.com/huggingface/huggingface_hub/pull/2120 and to this [internal slack thread](https://huggingface.slack.com/archives/C0626AL5AR4/p1711370113894589).

Uploading an LFS file fails because RepoUrl(...).endpoint was not correctly overwritten with HF_ENDPOINT. We were only overwriting `RepoUrl(...).endpoint` but not the inner value `str(RepoUrl(...))`. This PR definitely fixes this by replacing it before parsing the string value. cc @padeoe.

---

Tips from @padeoe to reproduce the issue:
1. Add this line to `/etc/hosts` or `` to deactivate traffic to huggingace.co
```
127.0.0.1 [huggingface.co](http://huggingface.co/)
```

2. Run this script
```py
import os


os.environ['HF_ENDPOINT'] = "https://hf-mirror.com"

from huggingface_hub import HfApi


api = HfApi() # optionally add your token here
repo_url = api.create_repo("tmp_test_mir", exist_ok=True)
repo_id = repo_url.repo_id
api.upload_file(repo_id=repo_id, path_or_fileobj=b"content", path_in_repo="file.txt")
api.upload_file(repo_id=repo_id, path_or_fileobj=b"content", path_in_repo="lfs.bin")
```

