### PR TITLE
Fix ModelHubMixin when class is a dataclass

### DIFF
--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -403,7 +403,12 @@ class ModelHubMixin:
                 # Forward config to model initialization
                 model_kwargs["config"] = config
 
-            if any(param.kind == inspect.Parameter.VAR_KEYWORD for param in cls._hub_mixin_init_parameters.values()):
+            # Inject config if `**kwargs` are expected
+            if is_dataclass(cls):
+                for key in cls.__dataclass_fields__:
+                    if key not in model_kwargs and key in config:
+                        model_kwargs[key] = config[key]
+            elif any(param.kind == inspect.Parameter.VAR_KEYWORD for param in cls._hub_mixin_init_parameters.values()):
                 for key, value in config.items():
                     if key not in model_kwargs:
                         model_kwargs[key] = value


### PR DESCRIPTION
When the ModelHubMixin class happens to be a dataclass, `__init__` method will accept `**kwargs` when
inspecting it. However, due to how dataclasses work, we cannot forward arbitrary kwargs to the `__init__`.
This test ensures that the `from_pretrained` method does not raise an error when the class is a dataclass.

This PR fixes the SetFit integration (see https://github.com/huggingface/huggingface_hub/issues/2157). However, this is not a pattern we want to promote. Dataclasses are meant to store data. Model classes are more complex and doesn't play well with internal values.