### PR TITLE
Add support for `updatedRefs` in WebhookPayload

### DIFF
--- a/src/huggingface_hub/_webhooks_payload.py
+++ b/src/huggingface_hub/_webhooks_payload.py
@@ -107,6 +107,11 @@ class WebhookPayloadRepo(ObjectId):
     url: WebhookPayloadUrl
 
 
+class WebhookPayloadUpdatedRef(BaseModel):
+    ref: str
+    oldSha: Optional[str] = None
+    newSha: Optional[str] = None
+
 class WebhookPayload(BaseModel):
     event: WebhookPayloadEvent
     repo: WebhookPayloadRepo
@@ -114,3 +119,4 @@ class WebhookPayload(BaseModel):
     comment: Optional[WebhookPayloadComment] = None
     webhook: WebhookPayloadWebhook
     movedTo: Optional[WebhookPayloadMovedTo] = None
+    updatedRefs: Optional[List[WebhookPayloadUpdatedRef]] = None

--- a/src/huggingface_hub/_webhooks_payload.py
+++ b/src/huggingface_hub/_webhooks_payload.py
@@ -112,6 +112,7 @@ class WebhookPayloadUpdatedRef(BaseModel):
     oldSha: Optional[str] = None
     newSha: Optional[str] = None
 
+
 class WebhookPayload(BaseModel):
     event: WebhookPayloadEvent
     repo: WebhookPayloadRepo

--- a/tests/test_webhooks_server.py
+++ b/tests/test_webhooks_server.py
@@ -79,10 +79,43 @@ WEBHOOK_PAYLOAD_UPDATE_DISCUSSION = {  # valid payload but doesn't have a "comme
     "webhook": {"id": "656a05348c99518820a4dd54", "version": 3},
 }
 
+WEBHOOK_PAYLOAD_WITH_UPDATED_REFS = {
+  "event": {
+    "action": "update",
+    "scope": "repo.content"
+  },
+  "repo": {
+    "type": "space",
+    "name": "Wauplin/gradio-user-history",
+    "id": "651311c46de9c503f3f34a9e",
+    "private": False,
+    "subdomain": "wauplin-gradio-user-history",
+    "url": {
+      "web": "https://huggingface.co/spaces/Wauplin/gradio-user-history",
+      "api": "https://huggingface.co/api/spaces/Wauplin/gradio-user-history"
+    },
+    "headSha": "5e7f29fffcc579cb52539fddb14a1a4f85f39e44",
+    "owner": {
+      "id": "6273f303f6d63a28483fde12"
+    }
+  },
+  "webhook": {
+    "id": "65a14fd933eca76f4639fc84",
+    "version": 3
+  },
+  "updatedRefs": [
+    {
+      "ref": "refs/pr/5",
+      "oldSha": None,
+      "newSha": "227c78346870a85e5de4fff8a585db68df975406"
+    }
+  ]
+}
+
 
 def test_deserialize_payload_example_with_comment() -> None:
     """Confirm that the test stub can actually be deserialized."""
-    payload = WebhookPayload.parse_obj(WEBHOOK_PAYLOAD_CREATE_DISCUSSION)
+    payload = WebhookPayload.model_validate(WEBHOOK_PAYLOAD_CREATE_DISCUSSION)
     assert payload.event.scope == WEBHOOK_PAYLOAD_CREATE_DISCUSSION["event"]["scope"]
     assert payload.comment is not None
     assert payload.comment.content == "Add co2 emissions information to the model card"
@@ -90,10 +123,17 @@ def test_deserialize_payload_example_with_comment() -> None:
 
 def test_deserialize_payload_example_without_comment() -> None:
     """Confirm that the test stub can actually be deserialized."""
-    payload = WebhookPayload.parse_obj(WEBHOOK_PAYLOAD_UPDATE_DISCUSSION)
+    payload = WebhookPayload.model_validate(WEBHOOK_PAYLOAD_UPDATE_DISCUSSION)
     assert payload.event.scope == WEBHOOK_PAYLOAD_UPDATE_DISCUSSION["event"]["scope"]
     assert payload.comment is None
 
+def test_deserialize_payload_example_with_updated_refs() -> None:
+    """Confirm that the test stub can actually be deserialized."""
+    payload = WebhookPayload.model_validate(WEBHOOK_PAYLOAD_WITH_UPDATED_REFS)
+    assert payload.updatedRefs is not None
+    assert payload.updatedRefs[0].ref == "refs/pr/5"
+    assert payload.updatedRefs[0].oldSha is None
+    assert payload.updatedRefs[0].newSha == "227c78346870a85e5de4fff8a585db68df975406"
 
 @requires("gradio")
 class TestWebhooksServerDontRun(unittest.TestCase):

--- a/tests/test_webhooks_server.py
+++ b/tests/test_webhooks_server.py
@@ -80,36 +80,33 @@ WEBHOOK_PAYLOAD_UPDATE_DISCUSSION = {  # valid payload but doesn't have a "comme
 }
 
 WEBHOOK_PAYLOAD_WITH_UPDATED_REFS = {
-  "event": {
-    "action": "update",
-    "scope": "repo.content"
-  },
-  "repo": {
-    "type": "space",
-    "name": "Wauplin/gradio-user-history",
-    "id": "651311c46de9c503f3f34a9e",
-    "private": False,
-    "subdomain": "wauplin-gradio-user-history",
-    "url": {
-      "web": "https://huggingface.co/spaces/Wauplin/gradio-user-history",
-      "api": "https://huggingface.co/api/spaces/Wauplin/gradio-user-history"
+    "event": {"action": "update", "scope": "repo.content"},
+    "repo": {
+        "type": "space",
+        "name": "Wauplin/gradio-user-history",
+        "id": "651311c46de9c503f3f34a9e",
+        "private": False,
+        "subdomain": "wauplin-gradio-user-history",
+        "url": {
+            "web": "https://huggingface.co/spaces/Wauplin/gradio-user-history",
+            "api": "https://huggingface.co/api/spaces/Wauplin/gradio-user-history",
+        },
+        "headSha": "5e7f29fffcc579cb52539fddb14a1a4f85f39e44",
+        "owner": {
+            "id": "6273f303f6d63a28483fde12",
+        },
     },
-    "headSha": "5e7f29fffcc579cb52539fddb14a1a4f85f39e44",
-    "owner": {
-      "id": "6273f303f6d63a28483fde12"
-    }
-  },
-  "webhook": {
-    "id": "65a14fd933eca76f4639fc84",
-    "version": 3
-  },
-  "updatedRefs": [
-    {
-      "ref": "refs/pr/5",
-      "oldSha": None,
-      "newSha": "227c78346870a85e5de4fff8a585db68df975406"
-    }
-  ]
+    "webhook": {
+        "id": "65a14fd933eca76f4639fc84",
+        "version": 3,
+    },
+    "updatedRefs": [
+        {
+            "ref": "refs/pr/5",
+            "oldSha": None,
+            "newSha": "227c78346870a85e5de4fff8a585db68df975406",
+        }
+    ],
 }
 
 
@@ -127,6 +124,7 @@ def test_deserialize_payload_example_without_comment() -> None:
     assert payload.event.scope == WEBHOOK_PAYLOAD_UPDATE_DISCUSSION["event"]["scope"]
     assert payload.comment is None
 
+
 def test_deserialize_payload_example_with_updated_refs() -> None:
     """Confirm that the test stub can actually be deserialized."""
     payload = WebhookPayload.model_validate(WEBHOOK_PAYLOAD_WITH_UPDATED_REFS)
@@ -134,6 +132,7 @@ def test_deserialize_payload_example_with_updated_refs() -> None:
     assert payload.updatedRefs[0].ref == "refs/pr/5"
     assert payload.updatedRefs[0].oldSha is None
     assert payload.updatedRefs[0].newSha == "227c78346870a85e5de4fff8a585db68df975406"
+
 
 @requires("gradio")
 class TestWebhooksServerDontRun(unittest.TestCase):


### PR DESCRIPTION
Related to https://github.com/huggingface/hub-docs/pull/1252 cc @coyotte508 

Wehbook payload now sends a list of the updated refs. This is useful to react on new commits on specific pull requests, new tags and new branches. See https://huggingface.co/docs/hub/webhooks#code-changes for more details.