### PR TITLE
Support `HF_TOKEN_PATH` as environment variable

### DIFF
--- a/docs/source/en/package_reference/environment_variables.md
+++ b/docs/source/en/package_reference/environment_variables.md
@@ -47,7 +47,7 @@ Defaults to `"$HF_HOME/assets"` (e.g. `"~/.cache/huggingface/assets"` by default
 ### HF_TOKEN
 
 To configure the User Access Token to authenticate to the Hub. If set, this value will
-overwrite the token stored on the machine (in `$HF_TOKEN_PATH` or `"$HF_HOME/token"`).
+overwrite the token stored on the machine (in either `$HF_TOKEN_PATH` or `"$HF_HOME/token"` if the former is not set).
 
 For more details about authentication, check out [this section](../quick-start#authentication).
 

--- a/docs/source/en/package_reference/environment_variables.md
+++ b/docs/source/en/package_reference/environment_variables.md
@@ -47,9 +47,14 @@ Defaults to `"$HF_HOME/assets"` (e.g. `"~/.cache/huggingface/assets"` by default
 ### HF_TOKEN
 
 To configure the User Access Token to authenticate to the Hub. If set, this value will
-overwrite the token stored on the machine (in `"$HF_HOME/token"`).
+overwrite the token stored on the machine (in `$HF_TOKEN_PATH` or `"$HF_HOME/token"`).
 
 For more details about authentication, check out [this section](../quick-start#authentication).
+
+### HF_TOKEN_PATH
+
+To configure where `huggingface_hub` should store the User Access Token. Defaults to `"$HF_HOME/token"` (e.g. `~/.cache/huggingface/token` by default).
+
 
 ### HF_HUB_VERBOSITY
 

--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -127,7 +127,7 @@ HF_HUB_DISABLE_TELEMETRY = (
 # `_OLD_HF_TOKEN_PATH` is deprecated and will be removed "at some point".
 # See https://github.com/huggingface/huggingface_hub/issues/1232
 _OLD_HF_TOKEN_PATH = os.path.expanduser("~/.huggingface/token")
-HF_TOKEN_PATH = os.path.join(HF_HOME, "token")
+HF_TOKEN_PATH = os.environ.get("HF_TOKEN_PATH", os.path.join(HF_HOME, "token"))
 
 
 if _staging_mode:


### PR DESCRIPTION
Solves https://github.com/huggingface/huggingface_hub/issues/2181 cc @stas00

I named the env variable `HF_TOKEN_PATH` (existing name in codebase).


(failing CI is unrelated)