### PR TITLE
Import SummaryWriter from either tensorboardX or torch.utils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ extras["testing"] = (
         "Pillow",
         "gradio",  # to test webhooks
         "numpy",  # for embeddings
-        "fastapi", # To build the documentation
+        "fastapi",  # To build the documentation
     ]
 )
 

--- a/src/huggingface_hub/_tensorboard_logger.py
+++ b/src/huggingface_hub/_tensorboard_logger.py
@@ -18,16 +18,26 @@ from typing import TYPE_CHECKING, List, Optional, Union
 
 from huggingface_hub._commit_scheduler import CommitScheduler
 
-from .utils import experimental, is_tensorboard_available
+from .utils import experimental
 
 
-if is_tensorboard_available():
+# Depending on user's setup, SummaryWriter can come either from 'tensorboardX'
+# or from 'torch.utils.tensorboard'. Both are compatible so let's try to load
+# from either of them.
+try:
     from tensorboardX import SummaryWriter
 
-    # TODO: clarify: should we import from torch.utils.tensorboard ?
+    is_summary_writer_available = True
 
-else:
-    SummaryWriter = object  # Dummy class to avoid failing at import. Will raise on instance creation.
+except ImportError:
+    try:
+        from torch.utils.tensorboard import SummaryWriter
+
+        is_summary_writer_available = False
+    except ImportError:
+        # Dummy class to avoid failing at import. Will raise on instance creation.
+        SummaryWriter = object
+        is_summary_writer_available = False
 
 if TYPE_CHECKING:
     from tensorboardX import SummaryWriter
@@ -106,7 +116,7 @@ class HFSummaryWriter(SummaryWriter):
 
     @experimental
     def __new__(cls, *args, **kwargs) -> "HFSummaryWriter":
-        if not is_tensorboard_available():
+        if not is_summary_writer_available:
             raise ImportError(
                 "You must have `tensorboard` installed to use `HFSummaryWriter`. Please run `pip install --upgrade"
                 " tensorboardX` first."


### PR DESCRIPTION
Related to https://github.com/huggingface/lighteval/pull/150 and also discussed on [slack](https://huggingface.slack.com/archives/C02V5EA0A95/p1712590950104289) (internal) cc @clefourrier.

Tensorboard's `SummaryWriter` can be either retrieved from `tensorboardX` or `torch.utils.tensorboard`. In any case, we don't need to check for `tensorboard` package itself. This PR should make it easier to work with  `HFSummaryWriter` in different setups. 

(note: `HFSummaryWriter` is still flag as an experimental feature. If it gets more and more used in `lighteval` we should think of making it official)
(note2: failing CI is unrelated) 