### PR TITLE
Add `chat_completion` and remove `conversational` from Inference guide

### DIFF
--- a/docs/source/en/guides/inference.md
+++ b/docs/source/en/guides/inference.md
@@ -133,7 +133,8 @@ has a simple API that supports the most common tasks. Here is a list of the curr
 | | [Zero-Shot-Image-Classification](https://huggingface.co/tasks/zero-shot-image-classification)                  | ✅ | [`~InferenceClient.zero_shot_image_classification`] |
 | Multimodal | [Documentation Question Answering](https://huggingface.co/tasks/document-question-answering) | ✅ | [`~InferenceClient.document_question_answering`]
 | | [Visual Question Answering](https://huggingface.co/tasks/visual-question-answering)      | ✅ | [`~InferenceClient.visual_question_answering`] |
-| NLP | [Conversational](https://huggingface.co/tasks/conversational)                 | ✅ | [`~InferenceClient.conversational`] |
+| NLP | Conversational                 |   | *deprecated* |
+| | [Chat Completion](https://huggingface.co/tasks/text-generation)             | ✅ | [`~InferenceClient.chat_completion`] |
 | | [Feature Extraction](https://huggingface.co/tasks/feature-extraction)             | ✅ | [`~InferenceClient.feature_extraction`] |
 | | [Fill Mask](https://huggingface.co/tasks/fill-mask)                      | ✅ | [`~InferenceClient.fill_mask`] |
 | | [Question Answering](https://huggingface.co/tasks/question-answering)             | ✅ | [`~InferenceClient.question_answering`]

--- a/docs/source/en/guides/inference.md
+++ b/docs/source/en/guides/inference.md
@@ -133,7 +133,7 @@ has a simple API that supports the most common tasks. Here is a list of the curr
 | | [Zero-Shot-Image-Classification](https://huggingface.co/tasks/zero-shot-image-classification)                  | ✅ | [`~InferenceClient.zero_shot_image_classification`] |
 | Multimodal | [Documentation Question Answering](https://huggingface.co/tasks/document-question-answering) | ✅ | [`~InferenceClient.document_question_answering`]
 | | [Visual Question Answering](https://huggingface.co/tasks/visual-question-answering)      | ✅ | [`~InferenceClient.visual_question_answering`] |
-| NLP | Conversational                 |   | *deprecated* |
+| NLP | Conversational                 |   | *deprecated*, use Chat Completion |
 | | [Chat Completion](https://huggingface.co/tasks/text-generation)             | ✅ | [`~InferenceClient.chat_completion`] |
 | | [Feature Extraction](https://huggingface.co/tasks/feature-extraction)             | ✅ | [`~InferenceClient.feature_extraction`] |
 | | [Fill Mask](https://huggingface.co/tasks/fill-mask)                      | ✅ | [`~InferenceClient.fill_mask`] |


### PR DESCRIPTION
Reported by @freddyaboulton on [slack](https://huggingface.slack.com/archives/C02V5EA0A95/p1712696508060309) (internal).

This PR marks "conversational" as deprecated in the list of supported tasks + add a line for `chat_completion`. Since we don't have a proper task for chat completion, I redirect to https://huggingface.co/tasks/text-generation which is I think the most appropriate page describing the task.