### PR TITLE
Do not document private attributes of `ModelHubMixin`

### DIFF
--- a/docs/source/en/guides/integrations.md
+++ b/docs/source/en/guides/integrations.md
@@ -185,8 +185,8 @@ Here is how any user can load/save a PyTorch model from/to the Hub:
 >>> model = MyModel(hidden_size=128)
 
 # Config is automatically created based on input + default values
->>> model._hub_mixin_config
-{"hidden_size": 128, "vocab_size": 30000, "output_size": 4}
+>>> model.param.shape[0]
+128
 
 # 2. (optional) Save model to local directory
 >>> model.save_pretrained("path/to/my-awesome-model")
@@ -196,8 +196,8 @@ Here is how any user can load/save a PyTorch model from/to the Hub:
 
 # 4. Initialize model from the Hub => config has been preserved
 >>> model = MyModel.from_pretrained("username/my-awesome-model")
->>> model._hub_mixin_config
-{"hidden_size": 128, "vocab_size": 30000, "output_size": 4}
+>>> model.param.shape[0]
+128
 
 # Model card has been correctly populated
 >>> from huggingface_hub import ModelCard

--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -130,8 +130,8 @@ class ModelHubMixin:
 
     # Download and initialize weights from the Hub
     >>> reloaded_model = MyCustomModel.from_pretrained("username/my-awesome-model")
-    >>> reloaded_model._hub_mixin_config
-    {"size": 256, "device": "gpu"}
+    >>> reloaded_model.size
+    256
 
     # Model card has been correctly populated
     >>> from huggingface_hub import ModelCard


### PR DESCRIPTION
Better not to document `_model_hub_mixin`.