### PR TITLE
Add support for pipeline_tag in ModelHubMixin

### DIFF
--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -53,6 +53,7 @@ This model has been pushed to the Hub using the [PytorchModelHubMixin](https://h
 @dataclass
 class MixinInfo:
     library_name: Optional[str] = None
+    pipeline_tag: Optional[str] = None
     tags: Optional[List[str]] = None
     repo_url: Optional[str] = None
     docs_url: Optional[str] = None
@@ -75,6 +76,8 @@ class ModelHubMixin:
             Name of the library integrating ModelHubMixin. Used to generate model card.
         tags (`List[str]`, *optional*):
             Tags to be added to the model card. Used to generate model card.
+        pipeline_tag (`str`, *optional*):
+            Tag of the pipeline. Used to generate model card. e.g. "text-classification".
         repo_url (`str`, *optional*):
             URL of the library repository. Used to generate model card.
         docs_url (`str`, *optional*):
@@ -156,6 +159,7 @@ class ModelHubMixin:
         cls,
         *,
         library_name: Optional[str] = None,
+        pipeline_tag: Optional[str] = None,
         tags: Optional[List[str]] = None,
         repo_url: Optional[str] = None,
         docs_url: Optional[str] = None,
@@ -169,6 +173,7 @@ class ModelHubMixin:
         cls._hub_mixin_info = MixinInfo(
             library_name=library_name,
             tags=tags,
+            pipeline_tag=pipeline_tag,
             repo_url=repo_url,
             docs_url=docs_url,
         )

--- a/tests/test_hub_mixin_pytorch.py
+++ b/tests/test_hub_mixin_pytorch.py
@@ -34,7 +34,13 @@ if is_torch_available():
         def forward(self, x):
             return self.l1(x)
 
-    class DummyModelWithTags(nn.Module, PyTorchModelHubMixin, tags=["tag1", "tag2"], library_name="my-dummy-lib"):
+    class DummyModelWithTags(
+        nn.Module,
+        PyTorchModelHubMixin,
+        tags=["tag1", "tag2"],
+        pipeline_tag="text-classification",
+        library_name="my-dummy-lib",
+    ):
         def __init__(self, linear_layer: int = 4):
             super().__init__()
             self.l1 = nn.Linear(linear_layer, linear_layer)
@@ -265,6 +271,7 @@ class PytorchHubMixinTest(unittest.TestCase):
         model = DummyModelWithTags()
         card = model.generate_model_card()
         assert card.data.tags == ["tag1", "tag2", "pytorch_model_hub_mixin", "model_hub_mixin"]
+        assert card.data.pipeline_tag == "text-classification"
 
         model.save_pretrained(self.cache_dir)
         card_reloaded = ModelCard.load(self.cache_dir / "README.md")


### PR DESCRIPTION
Would be good to be able to set a custom `pipeline_tag`. Mentioned by @julien-c in https://github.com/jasonppy/VoiceCraft/pull/90#discussion_r1566439191.