### PR TITLE
Correctly check inference endpoint is ready

### DIFF
--- a/src/huggingface_hub/_inference_endpoints.py
+++ b/src/huggingface_hub/_inference_endpoints.py
@@ -8,7 +8,7 @@ from huggingface_hub.errors import InferenceEndpointError, InferenceEndpointTime
 
 from .inference._client import InferenceClient
 from .inference._generated._async_client import AsyncInferenceClient
-from .utils import logging, parse_datetime
+from .utils import get_session, logging, parse_datetime
 
 
 if TYPE_CHECKING:
@@ -194,10 +194,6 @@ class InferenceEndpoint:
             [`InferenceEndpointTimeoutError`]
                 If the Inference Endpoint is not deployed after `timeout` seconds.
         """
-        if self.url is not None:  # Means the endpoint is deployed
-            logger.info("Inference Endpoint is ready to be used.")
-            return self
-
         if timeout is not None and timeout < 0:
             raise ValueError("`timeout` cannot be negative.")
         if refresh_every <= 0:
@@ -205,10 +201,12 @@ class InferenceEndpoint:
 
         start = time.time()
         while True:
-            self.fetch()
-            if self.url is not None:  # Means the endpoint is deployed
-                logger.info("Inference Endpoint is ready to be used.")
-                return self
+            if self.url is not None:
+                # Means the URL is provisioned => check if the endpoint is reachable
+                response = get_session().get(self.url, headers=self._api._build_hf_headers(token=self._token))
+                if response.status_code == 200:
+                    logger.info("Inference Endpoint is ready to be used.")
+                    return self
             if self.status == InferenceEndpointStatus.FAILED:
                 raise InferenceEndpointError(
                     f"Inference Endpoint {self.name} failed to deploy. Please check the logs for more information."
@@ -218,6 +216,7 @@ class InferenceEndpoint:
                     raise InferenceEndpointTimeoutError("Timeout while waiting for Inference Endpoint to be deployed.")
             logger.info(f"Inference Endpoint is not deployed yet ({self.status}). Waiting {refresh_every}s...")
             time.sleep(refresh_every)
+            self.fetch()
 
     def fetch(self) -> "InferenceEndpoint":
         """Fetch latest information about the Inference Endpoint.


### PR DESCRIPTION
From @McPatate on [slack](https://huggingface.slack.com/archives/C03E4DQ9LAJ/p1712913929852529?thread_ts=1709825452.071459&cid=C03E4DQ9LAJ) (internal):

> The condition in the InferenceEndpoints::wait function isn't what I expect to mean "ready":
> ```py
>         while True:
>             self.fetch()
>             if self.url is not None:  # Means the endpoint is deployed
>                 logger.info("Inference Endpoint is ready to be used.")
>                 return self
> ```
> as the url can be provisioned before the endpoint started. Wasn't it that we made it so that huggingface_hub queries the url until status is 200?

This PR fixes this by making a GET request on the returned URL before returning (in `.wait` call).