### PR TITLE
`ModelHubMixin`: more metadata + arbitrary config types + proper guide

### DIFF
--- a/docs/source/en/guides/integrations.md
+++ b/docs/source/en/guides/integrations.md
@@ -143,7 +143,7 @@ your library, you should:
     model. The method must download the relevant files and load them.
 3. You are done!
 
-The advantage of using [`ModelHubMixin`] is that once you take care of the serialization/loading of the files, you are ready to go. You don't need to worry about stuff like repo creation, commits, PRs, or revisions. All of this is handled by the mixin and is available to your users. The Mixin also ensures that public methods are well documented and type annotated. Finally, the download count on the Hub will also work out of the box.
+The advantage of using [`ModelHubMixin`] is that once you take care of the serialization/loading of the files, you are ready to go. You don't need to worry about stuff like repo creation, commits, PRs, or revisions. The [`ModelHubMixin`] also ensures public methods are documented and type annotated, and you'll be able to view your model's download count on the Hub. All of this is handled by the [`ModelHubMixin`] and available to your users.
 
 ### A concrete example: PyTorch
 
@@ -278,13 +278,13 @@ And that's it! Your library now enables users to upload and download files to an
 
 ### Advanced usage
 
-In the section above, we quickly discussed how the [`ModelHubMixin`] works. In this section, we will see some more advanced features the mixin offers to improve the integration of your library with the Hugging Face Hub.
+In the section above, we quickly discussed how the [`ModelHubMixin`] works. In this section, we will see some of its more advanced features to improve your library integration with the Hugging Face Hub.
 
 #### Model card
 
-[`ModelHubMixin`] generates the model card for you. Model cards are files that accompany the models and provide handy information. Under the hood, model cards are simple Markdown files with additional metadata. Model cards are essential for discoverability, reproducibility, and sharing! Check-out the [Model Cards guide](https://huggingface.co/docs/hub/model-cards) for more details.
+[`ModelHubMixin`] generates the model card for you. Model cards are files that accompany the models and provide important information about them. Under the hood, model cards are simple Markdown files with additional metadata. Model cards are essential for discoverability, reproducibility, and sharing! Check out the [Model Cards guide](https://huggingface.co/docs/hub/model-cards) for more details.
 
-Generating models cards semi-automatically is a good way to ensure that all models pushed with your library will share common metadata: `library_name`, `tags`, `license`, `pipeline_tag`, etc. This is very practical to make all models using your library easily searchable on the Hub and to provide some resource links for users landing on the Hub. You can define them directly when inheriting from [`ModelHubMixin`]:
+Generating model cards semi-automatically is a good way to ensure that all models pushed with your library will share common metadata: `library_name`, `tags`, `license`, `pipeline_tag`, etc. This makes all models backed by your library easily searchable on the Hub and provides some resource links for users landing on the Hub. You can define the metadata directly when inheriting from [`ModelHubMixin`]:
 
 ```py
 class UniDepthV1(
@@ -352,11 +352,11 @@ class UniDepthV1(nn.Module, PyTorchModelHubMixin, ...):
 
 #### Config
 
-[`ModelHubMixin`] handles the model configuration for you. It automatically checks the input values when you instantiate the model and serialize them in a `config.json` file. This files has 2 advantages:
+[`ModelHubMixin`] handles the model configuration for you. It automatically checks the input values when you instantiate the model and serializes them in a `config.json` file. This provides 2 benefits:
 1. Users will be able to reload the model with the exact same parameters as you.
 2. Having a `config.json` file automatically enables analytics on the Hub (i.e. the "downloads" count).
 
-But how does it work in practice? There are several rules applied to make the process as smooth as possible from a user perspective:
+But how does it work in practice? Several rules make the process as smooth as possible from a user perspective:
 - if your `__init__` method expects a `config` input, it will be automatically saved in the repo as `config.json`.
 - if the `config` input parameter is annotated with a dataclass type (e.g. `config: Optional[MyConfigClass] = None`), then the `config` value will be correctly deserialized for you.
 - all values passed at initialization will also be stored in the config file. This means you don't necessarily have to expect a `config` input to benefit from it.
@@ -378,7 +378,7 @@ model.save_pretrained(...)
 {"value": "my_value", "size": 3}
 ```
 
-But what if a value cannot be serialized as JSON? By default, the value will be ignored when saving the config file. However, in some cases your library already expects a custom object as input that cannot be serialized and you don't want to update your internal logic to update its type. No worries! You can pass custom encoders/decoders for any type when inheriting from [`ModelHubMixin`]. This is a bit more work but ensures to keep your internal logic untouched when integrating your library with the Hub.
+But what if a value cannot be serialized as JSON? By default, the value will be ignored when saving the config file. However, in some cases your library already expects a custom object as input that cannot be serialized, and you don't want to update your internal logic to update its type. No worries! You can pass custom encoders/decoders for any type when inheriting from [`ModelHubMixin`]. This is a bit more work but ensures your internal logic is untouched when integrating your library with the Hub.
 
 Here is a concrete example where a class expects a `argparse.Namespace` config as input:
 
@@ -414,11 +414,11 @@ class VoiceCraft(
 ```
 
 In the snippet above, both the internal logic and the `__init__` signature of the class did not change. This means all existing code snippets for your library will continue to work. To achieve this, we had to:
-1. Inherit from the mixin (`PytorchModelHubMixin` in this case)
+1. Inherit from the mixin (`PytorchModelHubMixin` in this case).
 2. Pass a `coders` parameter in the inheritance. This is a dictionary where keys are custom types you want to process. Values are a tuple `(encoder, decoder)`.
-   1. The encoder expects as input an object of the specified type and returns a jsonable value. This will be used when saving a model with `save_pretrained`.
-   2. The decoder expects as input raw data (typically a dictionary) and reconstruct the initial object. This will be used when loading the model with `from_pretrained`.
-3. Add a type annotation to the `__init__` signature. This is important to let the mixin know which type is expected by the class (and therefore which decoder to use).
+   - The encoder expects an object of the specified type as input and returns a jsonable value. This will be used when saving a model with `save_pretrained`.
+   - The decoder expects raw data (typically a dictionary) as input and reconstructs the initial object. This will be used when loading the model with `from_pretrained`.
+3. Add a type annotation to the `__init__` signature. This is important to let the mixin know which type is expected by the class and, therefore, which decoder to use.
 
 For the sake of simplicity, the encoder/decoder functions in the example above are not robust. For a concrete implementation, you would most likely have to handle corner cases properly.
 

--- a/docs/source/en/guides/integrations.md
+++ b/docs/source/en/guides/integrations.md
@@ -295,7 +295,7 @@ class UniDepthV1(
    docs_url=...,
    pipeline_tag="depth-estimation",
    license="cc-by-nc-4.0",
-   tags=["monocular-metric-depth-estimation"]
+   tags=["monocular-metric-depth-estimation", "arxiv:1234.56789"]
 ):
    ...
 ```
@@ -420,6 +420,7 @@ In the snippet above, both the internal logic and the `__init__` signature of th
    2. The decoder expects as input raw data (typically a dictionary) and reconstruct the initial object. This will be used when loading the model with `from_pretrained`.
 3. Add a type annotation to the `__init__` signature. This is important to let the mixin know which type is expected by the class (and therefore which decoder to use).
 
+For the sake of simplicity, the encoder/decoder functions in the example above are not robust. For a concrete implementation, you would most likely have to handle corner cases properly.
 
 ## Quick comparison
 

--- a/docs/source/en/guides/integrations.md
+++ b/docs/source/en/guides/integrations.md
@@ -332,7 +332,7 @@ class VoiceCraft(
    ...
 ```
 
-In this example, all models pushed with the `VoiceCraft` class will automatically include a citation section and license details. For more details on how to define a model card template, please check the [Model Cards guide](./model-cards.md).
+In this example, all models pushed with the `VoiceCraft` class will automatically include a citation section and license details. For more details on how to define a model card template, please check the [Model Cards guide](./model-cards).
 
 
 Finally, if you want to extend the model card generation process with dynamic values, you can override the [`~ModelHubMixin.generate_model_card`] method:

--- a/docs/source/en/guides/integrations.md
+++ b/docs/source/en/guides/integrations.md
@@ -302,6 +302,8 @@ class UniDepthV1(
 
 By default, a generic model card will be generated with the info you've provided (example: [pyp1/VoiceCraft_giga830M](https://huggingface.co/pyp1/VoiceCraft_giga830M)). But you can define your own model card template as well!
 
+In this example, all models pushed with the `VoiceCraft` class will automatically include a citation section and license details. For more details on how to define a model card template, please check the [Model Cards guide](./model-cards).
+
 ```py
 MODEL_CARD_TEMPLATE = """
 ---
@@ -331,8 +333,6 @@ class VoiceCraft(
 ):
    ...
 ```
-
-In this example, all models pushed with the `VoiceCraft` class will automatically include a citation section and license details. For more details on how to define a model card template, please check the [Model Cards guide](./model-cards).
 
 
 Finally, if you want to extend the model card generation process with dynamic values, you can override the [`~ModelHubMixin.generate_model_card`] method:

--- a/docs/source/en/guides/integrations.md
+++ b/docs/source/en/guides/integrations.md
@@ -143,11 +143,7 @@ your library, you should:
     model. The method must download the relevant files and load them.
 3. You are done!
 
-The advantage of using [`ModelHubMixin`] is that once you take care of the serialization/loading of the files, you are ready to go. You don't need to worry about stuff like repo creation, commits, PRs, or revisions. All of this is handled by the mixin and is available to your users. The Mixin also ensures that public methods are well documented and type annotated.
-
-As a bonus, [`ModelHubMixin`] handles the model configuration for you. If your `__init__` method expects a `config` input, it will be automatically saved in the repo when calling `save_pretrained` and reloaded correctly by `load_pretrained`. Moreover, if the `config` input parameter is annotated with dataclass type (e.g. `config: Optional[MyConfigClass] = None`), then the `config` value will be correctly deserialized for you. Finally, all jsonable values passed at initialization will be also stored in the config file. This means you don't necessarily have to expect a `config` input to benefit from it. The big advantage of having a `config.json` file in your model repository is that it automatically enables the analytics on the Hub (e.g. the "downloads" count).
-
-Finally, [`ModelHubMixin`] handles generating a model card for you. When inheriting from [`ModelHubMixin`], you can define metadata such as `library_name`, `tags`, `repo_url` and `docs_url`. Those fields will be reused to populate the modelcard of any model that use your class. This is very practical to make all models using your library easily searchable on the Hub and to provide some resource links for users landing on the Hub. If you want to extend the modelcard template, you can override the [`~ModelHubMixin.generate_model_card`] method.
+The advantage of using [`ModelHubMixin`] is that once you take care of the serialization/loading of the files, you are ready to go. You don't need to worry about stuff like repo creation, commits, PRs, or revisions. All of this is handled by the mixin and is available to your users. The Mixin also ensures that public methods are well documented and type annotated. Finally, the download count on the Hub will also work out of the box.
 
 ### A concrete example: PyTorch
 
@@ -279,6 +275,151 @@ class PyTorchModelHubMixin(ModelHubMixin):
 ```
 
 And that's it! Your library now enables users to upload and download files to and from the Hub.
+
+### Advanced usage
+
+In the section above, we quickly discussed how the [`ModelHubMixin`] works. In this section, we will see some more advanced features the mixin offers to improve the integration of your library with the Hugging Face Hub.
+
+#### Model card
+
+[`ModelHubMixin`] handles generating a model card for you. Model cards are files that accompany the models and provide handy information. Under the hood, model cards are simple Markdown files with additional metadata. Model cards are essential for discoverability, reproducibility, and sharing! Check-out the [Model Cards guide](https://huggingface.co/docs/hub/model-cards) for more details.
+
+Generating models cards semi-automatically is a good way to ensure that all models pushed with your library will share common metadata: `library_name`, `tags`, `license`, `pipeline_tag`, etc. This is very practical to make all models using your library easily searchable on the Hub and to provide some resource links for users landing on the Hub. You can define them directly when inheriting from [`ModelHubMixin`]:
+
+```py
+class UniDepthV1(
+   nn.Module,
+   PyTorchModelHubMixin,
+   library_name="unidepth",
+   repo_url="https://github.com/lpiccinelli-eth/UniDepth",
+   docs_url=...,
+   pipeline_tag="depth-estimation",
+   license="cc-by-nc-4.0",
+   tags=["monocular-metric-depth-estimation"]
+):
+   ...
+```
+
+By default, a generic model card will be generated with the info you've provided (example: [pyp1/VoiceCraft_giga830M](https://huggingface.co/pyp1/VoiceCraft_giga830M)). But you can define your own model card template as well!
+
+```py
+MODEL_CARD_TEMPLATE = """
+---
+# For reference on model card metadata, see the spec: https://github.com/huggingface/hub-docs/blob/main/modelcard.md?plain=1
+# Doc / guide: https://huggingface.co/docs/hub/model-cards
+{{ card_data }}
+---
+
+This is a VoiceCraft model. For more details, please check out the official Github repo: https://github.com/jasonppy/VoiceCraft. This model is shared under a Attribution-NonCommercial-ShareAlike 4.0 International license.
+
+## Citation
+
+@article{peng2024voicecraft,
+  author    = {Peng, Puyuan and Huang, Po-Yao and Li, Daniel and Mohamed, Abdelrahman and Harwath, David},
+  title     = {VoiceCraft: Zero-Shot Speech Editing and Text-to-Speech in the Wild},
+  journal   = {arXiv},
+  year      = {2024},
+}
+"""
+
+class VoiceCraft(
+   nn.Module,
+   PyTorchModelHubMixin,
+   library_name="voicecraft",
+   model_card_template=MODEL_CARD_TEMPLATE,
+   ...
+):
+   ...
+```
+
+In this example, all models pushed with the `VoiceCraft` class will automatically include a citation section and license details. For more details on how to define a model card template, please check the [Model Cards guide](./model-cards.md).
+
+
+Finally, if you want to extend the model card generation process with dynamic values, you can override the [`~ModelHubMixin.generate_model_card`] method:
+
+```py
+from huggingface_hub import ModelCard, PyTorchModelHubMixin
+
+class UniDepthV1(nn.Module, PyTorchModelHubMixin, ...):
+   (...)
+
+   def generate_model_card(self, *args, **kwargs) -> ModelCard:
+      card = super().generate_model_card(*args, **kwargs)
+      card.data.metrics = ...  # add metrics to the metadata
+      card.text += ... # append section to the modelcard
+      return card
+```
+
+#### Config
+
+[`ModelHubMixin`] handles the model configuration for you. It automatically checks the input values when you instantiate the model and serialize them in a `config.json` file. This files has 2 advantages:
+1. Users will be able to reload the model with the exact same parameters as you.
+2. Having a `config.json` file automatically enables analytics on the Hub (i.e. the "downloads" count).
+
+But how does it work in practice? There are several rules applied to make the process as smooth as possible from a user perspective:
+- if your `__init__` method expects a `config` input, it will be automatically saved in the repo as `config.json`.
+- if the `config` input parameter is annotated with a dataclass type (e.g. `config: Optional[MyConfigClass] = None`), then the `config` value will be correctly deserialized for you.
+- all values passed at initialization will also be stored in the config file. This means you don't necessarily have to expect a `config` input to benefit from it.
+
+Example:
+
+```py
+class MyModel(ModelHubMixin):
+   def __init__(value: str, size: int = 3):
+      self.value = value
+      self.size = size
+
+   (...) # implement _save_pretrained / _from_pretrained
+
+model = MyModel(value="my_value")
+model.save_pretrained(...)
+
+# config.json contains passed and default values
+{"value": "my_value", "size": 3}
+```
+
+But what if a value cannot be serialized as JSON? By default, the value will be ignored when saving the config file. However, in some cases your library already expects a custom object as input that cannot be serialized and you don't want to update your internal logic to update its type. No worries! You can pass custom encoders/decoders for any type when inheriting from [`ModelHubMixin`]. This is a bit more work but ensures to keep your internal logic untouched when integrating your library with the Hub.
+
+Here is a concrete example where a class expects a `argparse.Namespace` config as input:
+
+```py
+class VoiceCraft(nn.Module):
+    def __init__(self, args):
+      self.pattern = self.args.pattern
+      self.hidden_size = self.args.hidden_size
+      ...
+```
+
+One solution can be to update the `__init__` signature to `def __init__(self, pattern: str, hidden_size: int)` and update all snippets that instantiates your class. This is a perfectly valid way to fix it but it might break downstream applications using your library.
+
+Another solution is to provide a simple encoder/decoder to convert `argparse.Namespace` to a dictionary.
+
+```py
+from argparse import Namespace
+
+class VoiceCraft(
+   nn.Module,
+   PytorchModelHubMixin,  # inherit from mixin
+   coders: {
+      Namespace = (
+         lambda x: vars(x),  # Encoder: how to convert a `Namespace` to a valid jsonable value?
+         lambda data: Namespace(**data),  # Decoder: how to reconstruct a `Namespace` from a dictionary?
+      )
+   }
+):
+    def __init__(self, args: Namespace): # annotate `args`
+      self.pattern = self.args.pattern
+      self.hidden_size = self.args.hidden_size
+      ...
+```
+
+In the snippet above, both the internal logic and the `__init__` signature of the class did not change. This means all existing code snippets for your library will continue to work. To achieve this, we had to:
+1. Inherit from the mixin (`PytorchModelHubMixin` in this case)
+2. Pass a `coders` parameter in the inheritance. This is a dictionary where keys are custom types you want to process. Values are a tuple `(encoder, decoder)`.
+   1. The encoder expects as input an object of the specified type and returns a jsonable value. This will be used when saving a model with `save_pretrained`.
+   2. The decoder expects as input raw data (typically a dictionary) and reconstruct the initial object. This will be used when loading the model with `from_pretrained`.
+3. Add a type annotation to the `__init__` signature. This is important to let the mixin know which type is expected by the class (and therefore which decoder to use).
+
 
 ## Quick comparison
 

--- a/docs/source/en/guides/integrations.md
+++ b/docs/source/en/guides/integrations.md
@@ -282,7 +282,7 @@ In the section above, we quickly discussed how the [`ModelHubMixin`] works. In t
 
 #### Model card
 
-[`ModelHubMixin`] handles generating a model card for you. Model cards are files that accompany the models and provide handy information. Under the hood, model cards are simple Markdown files with additional metadata. Model cards are essential for discoverability, reproducibility, and sharing! Check-out the [Model Cards guide](https://huggingface.co/docs/hub/model-cards) for more details.
+[`ModelHubMixin`] generates the model card for you. Model cards are files that accompany the models and provide handy information. Under the hood, model cards are simple Markdown files with additional metadata. Model cards are essential for discoverability, reproducibility, and sharing! Check-out the [Model Cards guide](https://huggingface.co/docs/hub/model-cards) for more details.
 
 Generating models cards semi-automatically is a good way to ensure that all models pushed with your library will share common metadata: `library_name`, `tags`, `license`, `pipeline_tag`, etc. This is very practical to make all models using your library easily searchable on the Hub and to provide some resource links for users landing on the Hub. You can define them directly when inheriting from [`ModelHubMixin`]:
 

--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -76,6 +76,8 @@ class ModelHubMixin:
     `__init__` but to the class definition itself. This is useful to define metadata about the library integrating
     [`ModelHubMixin`].
 
+    For more details on how to integrate the mixin with your library, checkout the [integration guide](../guides/integrations).
+
     Args:
         repo_url (`str`, *optional*):
             URL of the library repository. Used to generate model card.
@@ -658,6 +660,8 @@ class PyTorchModelHubMixin(ModelHubMixin):
     Implementation of [`ModelHubMixin`] to provide model Hub upload/download capabilities to PyTorch models. The model
     is set in evaluation mode by default using `model.eval()` (dropout modules are deactivated). To train the model,
     you should first set it back in training mode with `model.train()`.
+
+    See [`ModelHubMixin`] for more details on how to use the mixin.
 
     Example:
 

--- a/tests/test_hub_mixin.py
+++ b/tests/test_hub_mixin.py
@@ -121,6 +121,37 @@ class DummyModelThatIsAlsoADataclass(ModelHubMixin):
         return cls(**model_kwargs)
 
 
+class CustomType:
+    def __init__(self, value: str):
+        self.value = value
+
+
+class DummyModelWithCustomTypes(
+    ModelHubMixin,
+    coders={
+        CustomType: (
+            lambda x: {"value": x.value},
+            lambda x: CustomType(x["value"]),
+        )
+    },
+):
+    def __init__(
+        self, foo: int, bar: str, custom: CustomType, custom_default: CustomType = CustomType("default"), **kwargs
+    ):
+        self.foo = foo
+        self.bar = bar
+        self.custom = custom
+        self.custom_default = custom_default
+
+    @classmethod
+    def _from_pretrained(cls, **kwargs):
+        return cls(**kwargs)
+
+    @classmethod
+    def _save_pretrained(cls, save_directory: Path):
+        return
+
+
 @pytest.mark.usefixtures("fx_cache_dir")
 class HubMixinTest(unittest.TestCase):
     cache_dir: Path
@@ -365,3 +396,21 @@ class HubMixinTest(unittest.TestCase):
         assert model.foo == 42
         assert model.bar == "baz"
         assert not hasattr(model, "other")
+
+    def test_from_cls_with_custom_type(self):
+        model = DummyModelWithCustomTypes(1, bar="bar", custom=CustomType("custom"))
+        model.save_pretrained(self.cache_dir)
+
+        config = json.loads((self.cache_dir / "config.json").read_text())
+        assert config == {
+            "foo": 1,
+            "bar": "bar",
+            "custom": {"value": "custom"},
+            "custom_default": {"value": "default"},
+        }
+
+        model_reloaded = DummyModelWithCustomTypes.from_pretrained(self.cache_dir)
+        assert model_reloaded.foo == 1
+        assert model_reloaded.bar == "bar"
+        assert model_reloaded.custom.value == "custom"
+        assert model_reloaded.custom_default.value == "default"

--- a/tests/test_hub_mixin_pytorch.py
+++ b/tests/test_hub_mixin_pytorch.py
@@ -19,6 +19,15 @@ from .testing_utils import repo_name, requires
 
 DUMMY_OBJECT = object()
 
+DUMMY_MODEL_CARD_TEMPLATE = """
+---
+{{ card_data }}
+---
+
+This is a dummy model card.
+Arxiv ID: 1234.56789
+"""
+
 if is_torch_available():
     import torch
     import torch.nn as nn
@@ -34,12 +43,15 @@ if is_torch_available():
         def forward(self, x):
             return self.l1(x)
 
-    class DummyModelWithTags(
+    class DummyModelWithModelCard(
         nn.Module,
         PyTorchModelHubMixin,
+        model_card_template=DUMMY_MODEL_CARD_TEMPLATE,
+        languages=["en", "zh"],
+        library_name="my-dummy-lib",
+        license="apache-2.0",
         tags=["tag1", "tag2"],
         pipeline_tag="text-classification",
-        library_name="my-dummy-lib",
     ):
         def __init__(self, linear_layer: int = 4):
             super().__init__()
@@ -66,7 +78,7 @@ if is_torch_available():
 
 else:
     DummyModel = None
-    DummyModelWithTags = None
+    DummyModelWithModelCard = None
     DummyModelNoConfig = None
     DummyModelWithConfigAndKwargs = None
 
@@ -268,10 +280,16 @@ class PytorchHubMixinTest(unittest.TestCase):
         self._api.delete_repo(repo_id=repo_id)
 
     def test_generate_model_card(self):
-        model = DummyModelWithTags()
+        model = DummyModelWithModelCard()
         card = model.generate_model_card()
-        assert card.data.tags == ["tag1", "tag2", "pytorch_model_hub_mixin", "model_hub_mixin"]
+        assert card.data.languages == ["en", "zh"]
+        assert card.data.library_name == "my-dummy-lib"
+        assert card.data.license == "apache-2.0"
         assert card.data.pipeline_tag == "text-classification"
+        assert card.data.tags == ["tag1", "tag2", "pytorch_model_hub_mixin", "model_hub_mixin"]
+
+        # Model card template has been used
+        assert "This is a dummy model card." in str(card)
 
         model.save_pretrained(self.cache_dir)
         card_reloaded = ModelCard.load(self.cache_dir / "README.md")


### PR DESCRIPTION
This PR adds some improvement to the `ModelHubMixin` class and in particular:
1. Possibility to define more metadata for a library; `license`, `license_link`, `license_name`, `pipeline_tag`, `languages`.
2. Possibility to define a custom model card template. Useful if somehow wants to add a citation section in all model cards for instance. It's also possible to dynamically generate the model card, for example to store metrics at runtime.
3. Possibility to handle arbitrary input types. Very useful when trying to integrate with libraries that instantiate models with custom values. Typically happened for [`VoiceCraft`](https://github.com/jasonppy/VoiceCraft) (expects a `argparse.Namespace`) or  [MichelAngelo](https://github.com/NeuralCarver/Michelangelo) (expects a `OmegaConf` see [#2212](https://github.com/huggingface/huggingface_hub/issues/2212)). It is currently possible to mitigate this (see [VoiceCraft#90](https://github.com/jasonppy/VoiceCraft/pull/90)) but solution is quite hacky/unintuitive. Instead of manually adding support for more types in `huggingface_hub`, this PR adds a way to define a custom encoder/decoder for the type. For example, the voicecraft integration would become:
```py
from argparse import Namespace

class VoiceCraft(
   nn.Module,
   PytorchModelHubMixin,  # inherit from mixin
   coders: {
      Namespace = (
         lambda x: vars(x),  # Encoder: how to convert a `Namespace` to a valid jsonable value?
         lambda data: Namespace(**data),  # Decoder: how to reconstruct a `Namespace` from a dictionary?
      )
   }
):
    def __init__(self, args: Namespace): # annotate `args`
      self.pattern = self.args.pattern
      self.hidden_size = self.args.hidden_size
      ...
```


In addition to this, I have update the `Integration` guide to explain in details how to use the advanced features of the mixin (metadata, model card template, config, custom encoders, etc.)


cc @NielsRogge @not-lain 

**EDIT:** link to [updated guide](https://moon-ci-docs.huggingface.co/docs/huggingface_hub/pr_2230/en/guides/integrations#advanced-usage) + [package reference](https://moon-ci-docs.huggingface.co/docs/huggingface_hub/pr_2230/en/package_reference/mixins#mixins--serialization-methods).