### PR TITLE
Drop 'generic' in InferenceAPI framework list

### DIFF
--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -197,7 +197,6 @@ ALL_INFERENCE_API_FRAMEWORKS = MAIN_INFERENCE_API_FRAMEWORKS + [
     "fastai",
     "fasttext",
     "flair",
-    "generic",
     "k2",
     "keras",
     "mindspore",


### PR DESCRIPTION
cc @Narsil @osanseviero (see internal [slack](https://huggingface.slack.com/archives/C016D661PAN/p1713796447025809?thread_ts=1713796161.795809&cid=C016D661PAN))