### PR TITLE
Respect default timeouts in `hf_file_system`

### DIFF
--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -19,6 +19,7 @@ from .constants import (
     DEFAULT_REVISION,
     ENDPOINT,
     HF_HUB_DOWNLOAD_TIMEOUT,
+    HF_HUB_ETAG_TIMEOUT,
     REPO_TYPE_MODEL,
     REPO_TYPES_MAPPING,
     REPO_TYPES_URL_PREFIXES,
@@ -123,7 +124,7 @@ class HfFileSystem(fsspec.AbstractFileSystem):
     ) -> Tuple[bool, Optional[Exception]]:
         if (repo_type, repo_id, revision) not in self._repo_and_revision_exists_cache:
             try:
-                self._api.repo_info(repo_id, revision=revision, repo_type=repo_type)
+                self._api.repo_info(repo_id, revision=revision, repo_type=repo_type, timeout=HF_HUB_ETAG_TIMEOUT)
             except (RepositoryNotFoundError, HFValidationError) as e:
                 self._repo_and_revision_exists_cache[(repo_type, repo_id, revision)] = False, e
                 self._repo_and_revision_exists_cache[(repo_type, repo_id, None)] = False, e

--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -18,6 +18,7 @@ from ._commit_api import CommitOperationCopy, CommitOperationDelete
 from .constants import (
     DEFAULT_REVISION,
     ENDPOINT,
+    HF_HUB_DOWNLOAD_TIMEOUT,
     REPO_TYPE_MODEL,
     REPO_TYPES_MAPPING,
     REPO_TYPES_URL_PREFIXES,
@@ -700,7 +701,13 @@ class HfFileSystemFile(fsspec.spec.AbstractBufferedFile):
             repo_type=self.resolved_path.repo_type,
             endpoint=self.fs.endpoint,
         )
-        r = http_backoff("GET", url, headers=headers, retry_on_status_codes=(502, 503, 504))
+        r = http_backoff(
+            "GET",
+            url,
+            headers=headers,
+            retry_on_status_codes=(502, 503, 504),
+            timeout=HF_HUB_DOWNLOAD_TIMEOUT,
+        )
         hf_raise_for_status(r)
         return r.content
 
@@ -799,6 +806,7 @@ class HfFileSystemStreamFile(fsspec.spec.AbstractBufferedFile):
                 headers=self.fs._api._build_hf_headers(),
                 retry_on_status_codes=(502, 503, 504),
                 stream=True,
+                timeout=HF_HUB_DOWNLOAD_TIMEOUT,
             )
             hf_raise_for_status(self.response)
         try:
@@ -820,6 +828,7 @@ class HfFileSystemStreamFile(fsspec.spec.AbstractBufferedFile):
                 headers={"Range": "bytes=%d-" % self.loc, **self.fs._api._build_hf_headers()},
                 retry_on_status_codes=(502, 503, 504),
                 stream=True,
+                timeout=HF_HUB_DOWNLOAD_TIMEOUT,
             )
             hf_raise_for_status(self.response)
             try:


### PR DESCRIPTION
For normal downloads (i.e. `hf_hub_download` and `snapshot_download`), we have configurable values `HF_HUB_ETAG_TIMEOUT` and `HF_HUB_DOWNLOAD_TIMEOUT`. Let's use them in the hf filesystem as well to avoid long-lasting requests (current default is to wait indefinitely, now set to 10s).

Related to https://github.com/huggingface/dataset-viewer/pull/2752.