### PR TITLE
Render chat-template server-side for transformers-backed models

### DIFF
--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -71,7 +71,6 @@ from huggingface_hub.inference._common import (
     _set_as_non_chat_completion_server,
     _set_unsupported_text_generation_kwargs,
     _stream_chat_completion_response_from_bytes,
-    _stream_chat_completion_response_from_text_generation,
     _stream_text_generation_response,
     raise_text_generation_error,
 )
@@ -105,7 +104,6 @@ from huggingface_hub.inference._generated.types import (
     ZeroShotImageClassificationOutputElement,
 )
 from huggingface_hub.inference._generated.types.chat_completion import ChatCompletionInputToolTypeEnum
-from huggingface_hub.inference._templating import render_chat_prompt
 from huggingface_hub.inference._types import (
     ConversationalOutput,  # soon to be removed
 )
@@ -752,44 +750,20 @@ class InferenceClient:
             return ChatCompletionOutput.parse_obj_as_instance(data)  # type: ignore[arg-type]
 
         # At this point, we know the server is not a chat completion server.
-        # We need to render the chat template client side based on the information we can fetch from
-        # the Hub API.
-
-        model_id = None
-        if model.startswith(("http://", "https://")):
-            # If URL, we need to know which model is served. This is not always possible.
-            # A workaround is to list the user Inference Endpoints and check if one of them correspond to the model URL.
-            # If not, we raise an error.
-            # TODO: fix when we have a proper API for this (at least for Inference Endpoints)
-            # TODO: what if Sagemaker URL?
-            # TODO: what if Azure URL?
-            from ..hf_api import HfApi
-
-            for endpoint in HfApi(token=self.token).list_inference_endpoints():
-                if endpoint.url == model:
-                    model_id = endpoint.repository
-                    break
-        else:
-            model_id = model
-
-        if model_id is None:
-            # If we don't have the model ID, we can't fetch the chat template.
-            # We raise an error.
+        # It means it's a transformers-backed server for which we can send a list of messages directly to the
+        # `text-generation` pipeline. We won't receive a detailed response but only the generated text.
+        if stream:
             raise ValueError(
-                "Request can't be processed as the model ID can't be inferred from model URL. "
-                "This is needed to fetch the chat template from the Hub since the model is not "
-                "served with a Chat-completion API."
+                "API endpoint/model is not served via TGI. This means it cannot return output as a stream."
+                " Please pass `stream=False` as input."
             )
-
-        # fetch chat template + tokens
-        prompt = render_chat_prompt(model_id=model_id, token=self.token, messages=messages)
 
         # generate response
         text_generation_output = self.text_generation(
-            prompt=prompt,
-            details=True,
-            stream=stream,
+            prompt=messages,  # type: ignore # Not correct type but works implicitly
             model=model,
+            stream=False,
+            details=False,
             max_new_tokens=max_tokens,
             seed=seed,
             stop_sequences=stop,
@@ -797,34 +771,20 @@ class InferenceClient:
             top_p=top_p,
         )
 
-        created = int(time.time())
-
-        if stream:
-            return _stream_chat_completion_response_from_text_generation(text_generation_output)  # type: ignore [arg-type]
-
-        if isinstance(text_generation_output, TextGenerationOutput):
-            # General use case => format ChatCompletionOutput from text generation details
-            content: str = text_generation_output.generated_text
-            finish_reason: str = text_generation_output.details.finish_reason  # type: ignore[union-attr]
-        else:
-            # Corner case: if server doesn't support details (e.g. if not a TGI server), we only receive an output string.
-            # In such a case, `finish_reason` is set to `"unk"`.
-            content = text_generation_output  # type: ignore[assignment]
-            finish_reason = "unk"
-
+        # Format as a ChatCompletionOutput with dummy values for fields we can't provide
         return ChatCompletionOutput(
             id="dummy",
             model="dummy",
             object="dummy",
             system_fingerprint="dummy",
-            usage=None,  # type: ignore # set to None as we don't want to provide fake information
-            created=created,
+            usage=None,  # type: ignore # set to `None` as we don't want to provide false information
+            created=int(time.time()),
             choices=[
                 ChatCompletionOutputComplete(
-                    finish_reason=finish_reason,  # type: ignore
+                    finish_reason="unk",  # type: ignore # set to `unk` as we don't want to provide false information
                     index=0,
                     message=ChatCompletionOutputMessage(
-                        content=content,
+                        content=text_generation_output,
                         role="assistant",
                     ),
                 )

--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -754,8 +754,13 @@ class InferenceClient:
         # `text-generation` pipeline. We won't receive a detailed response but only the generated text.
         if stream:
             raise ValueError(
-                "API endpoint/model is not served via TGI. This means it cannot return output as a stream."
-                " Please pass `stream=False` as input."
+                "Streaming token is not supported by the model. This is due to the model not been served by a "
+                "Text-Generation-Inference server. Please pass `stream=False` as input."
+            )
+        if tool_choice is not None or tool_prompt is not None or tools is not None:
+            warnings.warn(
+                "Tools are not supported by the model. This is due to the model not been served by a "
+                "Text-Generation-Inference server. The provided tool parameters will be ignored."
             )
 
         # generate response

--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -732,6 +732,9 @@ class InferenceClient:
                     # Then we call again `chat_completion` which will render the chat template client side.
                     # (can be HTTP 500, HTTP 400, HTTP 404 depending on the server)
                     _set_as_non_chat_completion_server(model)
+                    logger.warning(
+                        f"Server {model_url} does not seem to support chat completion. Falling back to text generation. Error: {e}"
+                    )
                     return self.chat_completion(
                         messages=messages,
                         model=model,

--- a/src/huggingface_hub/inference/_common.py
+++ b/src/huggingface_hub/inference/_common.py
@@ -18,7 +18,6 @@ import base64
 import io
 import json
 import logging
-import time
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
@@ -305,24 +304,6 @@ def _format_text_generation_stream_output(
     # Or parse token payload
     output = TextGenerationStreamOutput.parse_obj_as_instance(json_payload)
     return output.token.text if not details else output
-
-
-def _stream_chat_completion_response_from_text_generation(
-    text_generation_output: Iterable[TextGenerationStreamOutput],
-) -> Iterable[ChatCompletionStreamOutput]:
-    """Used in `InferenceClient.chat_completion`."""
-    created = int(time.time())
-    for item in text_generation_output:
-        yield _format_chat_completion_stream_output_from_text_generation(item, created)
-
-
-async def _async_stream_chat_completion_response_from_text_generation(
-    text_generation_output: AsyncIterable[TextGenerationStreamOutput],
-) -> AsyncIterable[ChatCompletionStreamOutput]:
-    """Used in `AsyncInferenceClient.chat_completion`."""
-    created = int(time.time())
-    async for item in text_generation_output:
-        yield _format_chat_completion_stream_output_from_text_generation(item, created)
 
 
 def _format_chat_completion_stream_output_from_text_generation(

--- a/src/huggingface_hub/inference/_common.py
+++ b/src/huggingface_hub/inference/_common.py
@@ -419,7 +419,6 @@ _NON_CHAT_COMPLETION_SERVER: Set[str] = set()
 
 
 def _set_as_non_chat_completion_server(model: str) -> None:
-    print("Set as non chat completion", model)
     _NON_CHAT_COMPLETION_SERVER.add(model)
 
 

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -754,8 +754,13 @@ class AsyncInferenceClient:
         # `text-generation` pipeline. We won't receive a detailed response but only the generated text.
         if stream:
             raise ValueError(
-                "API endpoint/model is not served via TGI. This means it cannot return output as a stream."
-                " Please pass `stream=False` as input."
+                "Streaming token is not supported by the model. This is due to the model not been served by a "
+                "Text-Generation-Inference server. Please pass `stream=False` as input."
+            )
+        if tool_choice is not None or tool_prompt is not None or tools is not None:
+            warnings.warn(
+                "Tools are not supported by the model. This is due to the model not been served by a "
+                "Text-Generation-Inference server. The provided tool parameters will be ignored."
             )
 
         # generate response

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -732,6 +732,9 @@ class AsyncInferenceClient:
                     # Then we call again `chat_completion` which will render the chat template client side.
                     # (can be HTTP 500, HTTP 400, HTTP 404 depending on the server)
                     _set_as_non_chat_completion_server(model)
+                    logger.warning(
+                        f"Server {model_url} does not seem to support chat completion. Falling back to text generation. Error: {e}"
+                    )
                     return await self.chat_completion(
                         messages=messages,
                         model=model,

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -45,7 +45,6 @@ from huggingface_hub.inference._common import (
     ContentT,
     ModelStatus,
     _async_stream_chat_completion_response_from_bytes,
-    _async_stream_chat_completion_response_from_text_generation,
     _async_stream_text_generation_response,
     _b64_encode,
     _b64_to_image,
@@ -91,7 +90,6 @@ from huggingface_hub.inference._generated.types import (
     ZeroShotImageClassificationOutputElement,
 )
 from huggingface_hub.inference._generated.types.chat_completion import ChatCompletionInputToolTypeEnum
-from huggingface_hub.inference._templating import render_chat_prompt
 from huggingface_hub.inference._types import (
     ConversationalOutput,  # soon to be removed
 )
@@ -752,44 +750,20 @@ class AsyncInferenceClient:
             return ChatCompletionOutput.parse_obj_as_instance(data)  # type: ignore[arg-type]
 
         # At this point, we know the server is not a chat completion server.
-        # We need to render the chat template client side based on the information we can fetch from
-        # the Hub API.
-
-        model_id = None
-        if model.startswith(("http://", "https://")):
-            # If URL, we need to know which model is served. This is not always possible.
-            # A workaround is to list the user Inference Endpoints and check if one of them correspond to the model URL.
-            # If not, we raise an error.
-            # TODO: fix when we have a proper API for this (at least for Inference Endpoints)
-            # TODO: what if Sagemaker URL?
-            # TODO: what if Azure URL?
-            from ..hf_api import HfApi
-
-            for endpoint in HfApi(token=self.token).list_inference_endpoints():
-                if endpoint.url == model:
-                    model_id = endpoint.repository
-                    break
-        else:
-            model_id = model
-
-        if model_id is None:
-            # If we don't have the model ID, we can't fetch the chat template.
-            # We raise an error.
+        # It means it's a transformers-backed server for which we can send a list of messages directly to the
+        # `text-generation` pipeline. We won't receive a detailed response but only the generated text.
+        if stream:
             raise ValueError(
-                "Request can't be processed as the model ID can't be inferred from model URL. "
-                "This is needed to fetch the chat template from the Hub since the model is not "
-                "served with a Chat-completion API."
+                "API endpoint/model is not served via TGI. This means it cannot return output as a stream."
+                " Please pass `stream=False` as input."
             )
-
-        # fetch chat template + tokens
-        prompt = render_chat_prompt(model_id=model_id, token=self.token, messages=messages)
 
         # generate response
         text_generation_output = await self.text_generation(
-            prompt=prompt,
-            details=True,
-            stream=stream,
+            prompt=messages,  # type: ignore # Not correct type but works implicitly
             model=model,
+            stream=False,
+            details=False,
             max_new_tokens=max_tokens,
             seed=seed,
             stop_sequences=stop,
@@ -797,34 +771,20 @@ class AsyncInferenceClient:
             top_p=top_p,
         )
 
-        created = int(time.time())
-
-        if stream:
-            return _async_stream_chat_completion_response_from_text_generation(text_generation_output)  # type: ignore [arg-type]
-
-        if isinstance(text_generation_output, TextGenerationOutput):
-            # General use case => format ChatCompletionOutput from text generation details
-            content: str = text_generation_output.generated_text
-            finish_reason: str = text_generation_output.details.finish_reason  # type: ignore[union-attr]
-        else:
-            # Corner case: if server doesn't support details (e.g. if not a TGI server), we only receive an output string.
-            # In such a case, `finish_reason` is set to `"unk"`.
-            content = text_generation_output  # type: ignore[assignment]
-            finish_reason = "unk"
-
+        # Format as a ChatCompletionOutput with dummy values for fields we can't provide
         return ChatCompletionOutput(
             id="dummy",
             model="dummy",
             object="dummy",
             system_fingerprint="dummy",
-            usage=None,  # type: ignore # set to None as we don't want to provide fake information
-            created=created,
+            usage=None,  # type: ignore # set to `None` as we don't want to provide false information
+            created=int(time.time()),
             choices=[
                 ChatCompletionOutputComplete(
-                    finish_reason=finish_reason,  # type: ignore
+                    finish_reason="unk",  # type: ignore # set to `unk` as we don't want to provide false information
                     index=0,
                     message=ChatCompletionOutputMessage(
-                        content=content,
+                        content=text_generation_output,
                         role="assistant",
                     ),
                 )

--- a/tests/cassettes/InferenceClientVCRTest.test_chat_completion_with_non_tgi.yaml
+++ b/tests/cassettes/InferenceClientVCRTest.test_chat_completion_with_non_tgi.yaml
@@ -2,8 +2,10 @@ interactions:
 - request:
     body: '{"model": "tgi", "messages": [{"role": "system", "content": "You are a
       helpful assistant."}, {"role": "user", "content": "What is deep learning?"}],
-      "max_tokens": 20, "seed": null, "stop": null, "temperature": 1.0, "top_p": null,
-      "stream": false}'
+      "frequency_penalty": null, "logit_bias": null, "logprobs": null, "max_tokens":
+      20, "n": null, "presence_penalty": null, "seed": null, "stop": null, "temperature":
+      null, "tool_choice": null, "tool_prompt": null, "tools": null, "top_logprobs":
+      null, "top_p": null, "stream": false}'
     headers:
       Accept:
       - '*/*'
@@ -12,13 +14,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '246'
+      - '428'
       Content-Type:
       - application/json
       X-Amzn-Trace-Id:
-      - 77cd3bdd-15ea-497c-917b-ca099516edb0
+      - 0f793623-22a8-48a6-834b-81b58b19b92c
       user-agent:
-      - unknown/None; hf_hub/0.22.0.dev0; python/3.10.12; torch/2.2.0; tensorflow/2.15.0.post1;
+      - unknown/None; hf_hub/0.23.0.dev0; python/3.10.12; torch/2.2.1; tensorflow/2.15.0.post1;
         fastcore/1.5.23
     method: POST
     uri: https://api-inference.huggingface.co/models/microsoft/DialoGPT-small/v1/chat/completions
@@ -32,7 +34,65 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Mar 2024 18:15:53 GMT
+      - Tue, 30 Apr 2024 10:49:22 GMT
+      Transfer-Encoding:
+      - chunked
+      access-control-allow-credentials:
+      - 'true'
+      access-control-expose-headers:
+      - x-compute-type, x-compute-time
+      server:
+      - uvicorn
+      vary:
+      - Origin, Access-Control-Request-Method, Access-Control-Request-Headers
+      x-compute-time:
+      - '0.001'
+      x-compute-type:
+      - cpu
+      x-request-id:
+      - 2-JgFiFGmvDDPzJchhq6a
+      x-sha:
+      - 49c537161a457d5256512f9d2d38a87d81ae0f0e
+    status:
+      code: 500
+      message: Internal Server Error
+- request:
+    body: '{"inputs": [{"role": "system", "content": "You are a helpful assistant."},
+      {"role": "user", "content": "What is deep learning?"}], "parameters": {"do_sample":
+      false, "max_new_tokens": 20, "return_full_text": false, "stop": []}, "stream":
+      false}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '244'
+      Content-Type:
+      - application/json
+      X-Amzn-Trace-Id:
+      - 5493238e-8215-44d9-a30d-02bbe8d8fee2
+      user-agent:
+      - unknown/None; hf_hub/0.23.0.dev0; python/3.10.12; torch/2.2.1; tensorflow/2.15.0.post1;
+        fastcore/1.5.23
+    method: POST
+    uri: https://api-inference.huggingface.co/models/microsoft/DialoGPT-small
+  response:
+    body:
+      string: '{"error":"The following `model_kwargs` are not used by the model: [''stop'']
+        (note: typos in the generate arguments will also show up in this list)","warnings":["There
+        was an inference error: The following `model_kwargs` are not used by the model:
+        [''stop''] (note: typos in the generate arguments will also show up in this
+        list)"]}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 30 Apr 2024 10:49:22 GMT
       Transfer-Encoding:
       - chunked
       access-control-allow-credentials:
@@ -48,136 +108,16 @@ interactions:
       x-compute-type:
       - cpu
       x-request-id:
-      - zht7CE9kOneA0JFdf2xSO
-      x-sha:
-      - 49c537161a457d5256512f9d2d38a87d81ae0f0e
-    status:
-      code: 500
-      message: Internal Server Error
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      X-Amzn-Trace-Id:
-      - bafe8e99-e804-4b64-a5be-3b68351678b7
-      user-agent:
-      - unknown/None; hf_hub/0.22.0.dev0; python/3.10.12; torch/2.2.0; tensorflow/2.15.0.post1;
-        fastcore/1.5.23
-    method: GET
-    uri: https://huggingface.co/api/models/microsoft/DialoGPT-small
-  response:
-    body:
-      string: '{"_id":"621ffdc136468d709f17dec4","id":"microsoft/DialoGPT-small","modelId":"microsoft/DialoGPT-small","author":"microsoft","sha":"49c537161a457d5256512f9d2d38a87d81ae0f0e","lastModified":"2024-02-29T15:48:41.000Z","private":false,"disabled":false,"gated":false,"pipeline_tag":"text-generation","tags":["transformers","pytorch","tf","jax","safetensors","gpt2","text-generation","conversational","arxiv:1911.00536","license:mit","autotrain_compatible","endpoints_compatible","has_space","text-generation-inference","region:us"],"downloads":34593,"library_name":"transformers","widgetData":[{"text":"Hey
-        my name is Julien! How are you?"},{"text":"Hey my name is Thomas! How are
-        you?"},{"text":"Hey my name is Mariama! How are you?"},{"text":"Hey my name
-        is Clara! How are you?"},{"text":"Hey my name is Julien! How are you?"},{"text":"Hi."}],"likes":78,"model-index":null,"config":{"architectures":["GPT2LMHeadModel"],"model_type":"gpt2","tokenizer_config":{"bos_token":"<|endoftext|>","chat_template":"{%
-        for message in messages %}{{ message.content }}{{ eos_token }}{% endfor %}","eos_token":"<|endoftext|>","pad_token":null,"unk_token":"<|endoftext|>"}},"cardData":{"thumbnail":"https://huggingface.co/front/thumbnails/dialogpt.png","tags":["conversational"],"license":"mit"},"transformersInfo":{"auto_model":"AutoModelForCausalLM","pipeline_tag":"text-generation","processor":"AutoTokenizer"},"spaces":["HuggingFaceH4/open_llm_leaderboard","gsaivinay/open_llm_leaderboard","GTBench/GTBench","felixz/open_llm_leaderboard","vasu0508/Meena_Chatbot","rushic24/DialoGPT-Covid-Help-Doctor","b1sheng/kg_llm_leaderboard_test","OPTML-Group/UnlearnCanvas-Benchmark","akhaliq/DialoGPT-small","mikeee/convbot","Docfile/open_llm_leaderboard","wop/test","wop/microsoft-DialoGPT-small","rodrigomasini/data_only_open_llm_leaderboard","Codermaker/microsoft-DialoGPT-small","hivemind-personalized-chat/chat-gradio","tomkr000/scottbotai","Teedossantos/microsoft-DialoGPT-small","itsarsile/microsoft-DialoGPT-small","overlordx/critic","EATHARD/chatbot","Youssefk/StoryAI","rabosh/just_deploy_experience","lilyling/Vietnam_QA","lilyling/Spain","lilyling/Italiano_QA","lilyling/Chinese_QA","wdsawdsawdadad/Chatbot_REQUIRES_OPENAI_KEY","iesir/microsoft-DialoGPT-small","fisehara/microsoft-DialoGPT-small","phenixreturn/microsoft-DialoGPT-small","hack3arma/microsoft-DialoGPT-small","rebornrulz/microsoft-DialoGPT-small","Daezi/microsoft-DialoGPT-small","pngwn/open_llm_leaderboard","pngwn/open_llm_leaderboard_two","freddyaboulton/open_llm_leaderboard_two_fix","choco9966/LeaderboardTest","Keyven/KiKi-GPT","choco9966/open-ko-llm-leaderboard","smothiki/open_llm_leaderboard","hmdsdt/microsoft-DialoGPT-small","Alfasign/Check","kevinklam/GuessWhom","Fideloub/microsoft-DialoGPT-small","JenitaChristopher/microsoft-DialoGPT-small","neubla/neubla-llm-evaluation-board","jawill/nlp_chatbot","junkim100/Self-Improving-Leaderboard"],"safetensors":{"parameters":{"F16":175620096},"total":175620096},"siblings":[{"rfilename":".gitattributes"},{"rfilename":"README.md"},{"rfilename":"config.json"},{"rfilename":"flax_model.msgpack"},{"rfilename":"generation_config.json"},{"rfilename":"generation_config_for_conversational.json"},{"rfilename":"merges.txt"},{"rfilename":"model.safetensors"},{"rfilename":"pytorch_model.bin"},{"rfilename":"tf_model.h5"},{"rfilename":"tokenizer_config.json"},{"rfilename":"vocab.json"}],"createdAt":"2022-03-02T23:29:05.000Z"}'
-    headers:
-      Access-Control-Allow-Origin:
-      - https://huggingface.co
-      Access-Control-Expose-Headers:
-      - X-Repo-Commit,X-Request-Id,X-Error-Code,X-Error-Message,ETag,Link,Accept-Ranges,Content-Range
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '3428'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 14 Mar 2024 18:15:53 GMT
-      ETag:
-      - W/"d64-atgwYMr1LyaFHkv0i0vXsUWWqTg"
-      Referrer-Policy:
-      - strict-origin-when-cross-origin
-      Vary:
-      - Origin
-      Via:
-      - 1.1 a355d8f903a0cf5525893c863fcdf216.cloudfront.net (CloudFront)
-      X-Amz-Cf-Id:
-      - A_blYo_2xR1JlGemvvnKlRCi34oDItnk2sqs88E4F_afAPXKOHZyJw==
-      X-Amz-Cf-Pop:
-      - CDG52-P4
-      X-Cache:
-      - Miss from cloudfront
-      X-Powered-By:
-      - huggingface-moon
-      X-Request-Id:
-      - Root=1-65f33ed9-56e731325d32b4f7757e6deb;bafe8e99-e804-4b64-a5be-3b68351678b7
-      cross-origin-opener-policy:
-      - same-origin
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"inputs": "You are a helpful assistant.<|endoftext|>What is deep learning?<|endoftext|>",
-      "parameters": {"best_of": null, "decoder_input_details": false, "details": true,
-      "do_sample": false, "max_new_tokens": 20, "repetition_penalty": null, "return_full_text":
-      false, "seed": null, "stop": [], "temperature": 1.0, "top_k": null, "top_p":
-      null, "truncate": null, "typical_p": null, "watermark": false}, "stream": false}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '419'
-      Content-Type:
-      - application/json
-      X-Amzn-Trace-Id:
-      - bc827a1b-0d62-4fe9-aa55-0b12e26b2f35
-      user-agent:
-      - unknown/None; hf_hub/0.22.0.dev0; python/3.10.12; torch/2.2.0; tensorflow/2.15.0.post1;
-        fastcore/1.5.23
-    method: POST
-    uri: https://api-inference.huggingface.co/models/microsoft/DialoGPT-small
-  response:
-    body:
-      string: '{"error":"The following `model_kwargs` are not used by the model: [''decoder_input_details'',
-        ''watermark'', ''details'', ''stop''] (note: typos in the generate arguments
-        will also show up in this list)","warnings":["There was an inference error:
-        The following `model_kwargs` are not used by the model: [''decoder_input_details'',
-        ''watermark'', ''details'', ''stop''] (note: typos in the generate arguments
-        will also show up in this list)"]}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 14 Mar 2024 18:15:54 GMT
-      Transfer-Encoding:
-      - chunked
-      access-control-allow-credentials:
-      - 'true'
-      access-control-expose-headers:
-      - x-compute-type, x-compute-time
-      server:
-      - uvicorn
-      vary:
-      - Origin, Access-Control-Request-Method, Access-Control-Request-Headers
-      x-compute-time:
-      - '0.003'
-      x-compute-type:
-      - cpu
-      x-request-id:
-      - TUW19mGc6wCDceqt7KLQD
+      - KBkATPrqJyS7FlCaYnrWK
       x-sha:
       - 49c537161a457d5256512f9d2d38a87d81ae0f0e
     status:
       code: 400
       message: Bad Request
 - request:
-    body: '{"inputs": "You are a helpful assistant.<|endoftext|>What is deep learning?<|endoftext|>",
-      "parameters": {"do_sample": false, "max_new_tokens": 20, "repetition_penalty":
-      null, "return_full_text": false, "seed": null, "temperature": 1.0, "top_k":
-      null, "top_p": null, "truncate": null, "typical_p": null}, "stream": false}'
+    body: '{"inputs": [{"role": "system", "content": "You are a helpful assistant."},
+      {"role": "user", "content": "What is deep learning?"}], "parameters": {"do_sample":
+      false, "max_new_tokens": 20, "return_full_text": false}, "stream": false}'
     headers:
       Accept:
       - '*/*'
@@ -186,13 +126,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '321'
+      - '232'
       Content-Type:
       - application/json
       X-Amzn-Trace-Id:
-      - 266750af-5040-46ae-8097-184c267fc4e8
+      - 5fb6d7d3-1604-4957-9111-0a737c90e69b
       user-agent:
-      - unknown/None; hf_hub/0.22.0.dev0; python/3.10.12; torch/2.2.0; tensorflow/2.15.0.post1;
+      - unknown/None; hf_hub/0.23.0.dev0; python/3.10.12; torch/2.2.1; tensorflow/2.15.0.post1;
         fastcore/1.5.23
     method: POST
     uri: https://api-inference.huggingface.co/models/microsoft/DialoGPT-small
@@ -202,28 +142,22 @@ interactions:
     headers:
       Connection:
       - keep-alive
+      Content-Length:
+      - '48'
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Mar 2024 18:15:54 GMT
-      Transfer-Encoding:
-      - chunked
+      - Tue, 30 Apr 2024 10:49:22 GMT
       access-control-allow-credentials:
       - 'true'
-      access-control-expose-headers:
-      - x-compute-type, x-compute-time
-      server:
-      - uvicorn
       vary:
       - Origin, Access-Control-Request-Method, Access-Control-Request-Headers
-      x-compute-characters:
-      - '76'
       x-compute-time:
-      - '0.179'
+      - '0.146'
       x-compute-type:
-      - cpu
+      - cache
       x-request-id:
-      - 2YOUZmqffbGsBiPEpgwBv
+      - xueA4XZTpX7lVK8Imy-Ys
       x-sha:
       - 49c537161a457d5256512f9d2d38a87d81ae0f0e
     status:

--- a/utils/generate_async_inference_client.py
+++ b/utils/generate_async_inference_client.py
@@ -407,10 +407,6 @@ def _use_async_streaming_util(code: str) -> str:
         "_async_stream_text_generation_response",
     )
     code = code.replace(
-        "_stream_chat_completion_response_from_text_generation",
-        "_async_stream_chat_completion_response_from_text_generation",
-    )
-    code = code.replace(
         "_stream_chat_completion_response_from_bytes", "_async_stream_chat_completion_response_from_bytes"
     )
     return code


### PR DESCRIPTION
cc @LysandreJik who pinged me about this.

`transformers`'s pipeline also accepts a list of messages instead of raw text when generating text. The chat template is then rendered server-side. This PR updates the `InferenceClient.chat_template` logic for when the API is not TGI-backed to use this (new?) feature. It avoid us to render client-side the chat template which was a bit annyoing/not robust.

Note: the default workflow remains optimized to work with TGI servers which provides much more detailed information. LLMs not backed by TGI are usually smaller models like the DialoGPT family which are not that good anyway :confused: 

cc @Rocketknight1 who implemented this in `transformers` I believe?

**Note:** failing tests are unrelated.

**Note:** no need to review `src/huggingface_hub/inference/_generated/_async_client.py` (auto-generated)
