### PR TITLE
Delete legacy tests in `TestHfHubDownloadRelativePaths` + implicit delete folder is ok

### DIFF
--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -41,7 +41,6 @@ from huggingface_hub.file_download import (
     HfFileMetadata,
     _check_disk_space,
     _create_symlink,
-    _get_pointer_path,
     _normalize_etag,
     _request_wrapper,
     cached_download,
@@ -1020,61 +1019,6 @@ class StagingCachedDownloadOnAwfulFilenamesTest(unittest.TestCase):
         )
         # Local path is not url-encoded
         self.assertTrue(local_path.endswith(self.filepath))
-
-
-@pytest.mark.usefixtures("fx_cache_dir")
-class TestHfHubDownloadRelativePaths(unittest.TestCase):
-    """Regression test for HackerOne report 1928845.
-
-    Issue was that any file outside of the local dir could be overwritten (Windows only).
-
-    In the end, multiple protections have been added to prevent this (..\\ in filename forbidden on Windows, always check
-    the filepath is in local_dir/snapshot_dir).
-    """
-
-    cache_dir: Path
-
-    @classmethod
-    def setUpClass(cls):
-        cls.api = HfApi(endpoint=ENDPOINT_STAGING, token=TOKEN)
-        cls.repo_id = cls.api.create_repo(repo_id=repo_name()).repo_id
-        cls.api.upload_file(path_or_fileobj=b"content", path_in_repo="..\\ddd", repo_id=cls.repo_id)
-        cls.api.upload_file(path_or_fileobj=b"content", path_in_repo="folder/..\\..\\..\\file", repo_id=cls.repo_id)
-
-    @classmethod
-    def tearDownClass(cls) -> None:
-        cls.api.delete_repo(repo_id=cls.repo_id)
-
-    @xfail_on_windows(reason="Windows paths cannot start with '..\\'.", raises=ValueError)
-    def test_download_file_in_cache_dir(self) -> None:
-        hf_hub_download(self.repo_id, "..\\ddd", cache_dir=self.cache_dir)
-
-    @xfail_on_windows(reason="Windows paths cannot start with '..\\'.", raises=ValueError)
-    def test_download_file_to_local_dir(self) -> None:
-        with SoftTemporaryDirectory() as local_dir:
-            hf_hub_download(self.repo_id, "..\\ddd", cache_dir=self.cache_dir, local_dir=local_dir)
-
-    @xfail_on_windows(reason="Windows paths cannot contain '\\..\\'.", raises=ValueError)
-    def test_download_folder_file_in_cache_dir(self) -> None:
-        hf_hub_download(self.repo_id, "folder/..\\..\\..\\file", cache_dir=self.cache_dir)
-
-    @xfail_on_windows(reason="Windows paths cannot contain '\\..\\'.", raises=ValueError)
-    def test_download_folder_file_to_local_dir(self) -> None:
-        with SoftTemporaryDirectory() as local_dir:
-            hf_hub_download(self.repo_id, "folder/..\\..\\..\\file", cache_dir=self.cache_dir, local_dir=local_dir)
-
-    def test_get_pointer_path_and_valid_relative_filename(self) -> None:
-        # Cannot happen because of other protections, but just in case.
-        self.assertEqual(
-            _get_pointer_path("path/to/storage", "abcdef", "path/to/file.txt"),
-            os.path.join("path/to/storage", "snapshots", "abcdef", "path/to/file.txt"),
-        )
-
-    def test_get_pointer_path_but_invalid_relative_filename(self) -> None:
-        # Cannot happen because of other protections, but just in case.
-        relative_filename = "folder\\..\\..\\..\\file.txt" if os.name == "nt" else "folder/../../../file.txt"
-        with self.assertRaises(ValueError):
-            _get_pointer_path("path/to/storage", "abcdef", relative_filename)
 
 
 class TestHttpGet(unittest.TestCase):

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -41,6 +41,7 @@ from huggingface_hub.file_download import (
     HfFileMetadata,
     _check_disk_space,
     _create_symlink,
+    _get_pointer_path,
     _normalize_etag,
     _request_wrapper,
     cached_download,
@@ -1019,6 +1020,51 @@ class StagingCachedDownloadOnAwfulFilenamesTest(unittest.TestCase):
         )
         # Local path is not url-encoded
         self.assertTrue(local_path.endswith(self.filepath))
+
+
+@pytest.mark.usefixtures("fx_cache_dir")
+class TestHfHubDownloadRelativePaths(unittest.TestCase):
+    """Regression test for HackerOne report 1928845.
+
+    Issue was that any file outside of the local dir could be overwritten (Windows only).
+
+    In the end, multiple protections have been added to prevent this (..\\ in filename forbidden on Windows, always check
+    the filepath is in local_dir/snapshot_dir).
+    """
+
+    cache_dir: Path
+
+    @classmethod
+    def setUpClass(cls):
+        cls.api = HfApi(endpoint=ENDPOINT_STAGING, token=TOKEN)
+        cls.repo_id = cls.api.create_repo(repo_id=repo_name()).repo_id
+        cls.api.upload_file(path_or_fileobj=b"content", path_in_repo="folder/..\\..\\..\\file", repo_id=cls.repo_id)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.api.delete_repo(repo_id=cls.repo_id)
+
+    @xfail_on_windows(reason="Windows paths cannot contain '\\..\\'.", raises=ValueError)
+    def test_download_folder_file_in_cache_dir(self) -> None:
+        hf_hub_download(self.repo_id, "folder/..\\..\\..\\file", cache_dir=self.cache_dir)
+
+    @xfail_on_windows(reason="Windows paths cannot contain '\\..\\'.", raises=ValueError)
+    def test_download_folder_file_to_local_dir(self) -> None:
+        with SoftTemporaryDirectory() as local_dir:
+            hf_hub_download(self.repo_id, "folder/..\\..\\..\\file", cache_dir=self.cache_dir, local_dir=local_dir)
+
+    def test_get_pointer_path_and_valid_relative_filename(self) -> None:
+        # Cannot happen because of other protections, but just in case.
+        self.assertEqual(
+            _get_pointer_path("path/to/storage", "abcdef", "path/to/file.txt"),
+            os.path.join("path/to/storage", "snapshots", "abcdef", "path/to/file.txt"),
+        )
+
+    def test_get_pointer_path_but_invalid_relative_filename(self) -> None:
+        # Cannot happen because of other protections, but just in case.
+        relative_filename = "folder\\..\\..\\..\\file.txt" if os.name == "nt" else "folder/../../../file.txt"
+        with self.assertRaises(ValueError):
+            _get_pointer_path("path/to/storage", "abcdef", relative_filename)
 
 
 class TestHttpGet(unittest.TestCase):

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -1017,6 +1017,19 @@ class CommitApiTest(HfApiCommonTest):
         # Commit still happened correctly
         assert isinstance(commit, CommitInfo)
 
+    def test_create_file_with_relative_path(self):
+        """Creating a file with a relative path_in_repo is forbidden.
+
+        Previously taken from a regression test for HackerOne report 1928845. The bug enabled attackers to create files
+        outside of the local dir if users downloaded a file with a relative path_in_repo on Windows.
+
+        This is not relevant anymore as the API now forbids such paths.
+        """
+        repo_id = self._api.create_repo(repo_id=repo_name()).repo_id
+        with self.assertRaises(HfHubHTTPError) as cm:
+            self._api.upload_file(path_or_fileobj=b"content", path_in_repo="..\\ddd", repo_id=repo_id)
+        assert cm.exception.response.status_code == 422
+
 
 class HfApiUploadEmptyFileTest(HfApiCommonTest):
     @classmethod

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -1093,16 +1093,12 @@ class HfApiDeleteFolderTest(HfApiCommonTest):
         with self.assertRaises(EntryNotFoundError):
             hf_hub_download(self.repo_id, "1/file_1.md", use_auth_token=self._token)
 
-    def test_create_commit_failing_implicit_delete_folder(self):
-        with self.assertRaisesRegex(
-            EntryNotFoundError,
-            'A file with the name "1" does not exist',
-        ):
-            self._api.create_commit(
-                operations=[CommitOperationDelete(path_in_repo="1")],
-                commit_message="Failing delete folder",
-                repo_id=self.repo_id,
-            )
+    def test_create_commit_implicit_delete_folder_is_ok(self):
+        self._api.create_commit(
+            operations=[CommitOperationDelete(path_in_repo="1")],
+            commit_message="Failing delete folder",
+            repo_id=self.repo_id,
+        )
 
 
 class HfApiListFilesInfoTest(HfApiCommonTest):


### PR DESCRIPTION
It is not possible to upload a file with the name `..\\ddd`, hence reducing the need for some tests.

Also, implicitly deleting a folder is now ok.

This should fix the CI. 