### PR TITLE
Prevent committing Windows newline encoding

### DIFF
--- a/src/huggingface_hub/_commit_api.py
+++ b/src/huggingface_hub/_commit_api.py
@@ -244,7 +244,7 @@ class CommitOperationAdd:
         Returns: `bytes`
         """
         with self.as_file() as file:
-            return base64.b64encode(file.read())
+            return base64.b64encode(file.read().replace(b"\r\n", b"\n"))
 
 
 def _validate_path_in_repo(path_in_repo: str) -> str:


### PR DESCRIPTION
This PR makes sure to always normalize line endings to `\n` when committing text files (instead of `\r\n` on Windows). That was previously ensured served-side but https://gitlab.com/gitlab-org/gitaly/-/issues/4425 made Gitaly line-ending agnostic. This should now be enforced client-side which this PR does.

Related to recent gitaly update that broke `datasets` CI (see https://github.com/huggingface/datasets/issues/6856).

Note that text files uploaded as LFS are not impacted by this PR nor the gitaly update. They were and are still uploaded as binary files (i.e. with OS-dependent encoding) 

(see [slack channel](https://huggingface.slack.com/archives/C02EMARJ65P/p1714648984717189) -internal-)