### PR TITLE
Don't override 'config' in model_kwargs

### DIFF
--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -477,7 +477,7 @@ class ModelHubMixin:
                     model_kwargs[param.name] = config[param.name]
 
             # Check if `config` argument was passed at init
-            if "config" in cls._hub_mixin_init_parameters:
+            if "config" in cls._hub_mixin_init_parameters and "config" not in model_kwargs:
                 # Check if `config` argument is a dataclass
                 config_annotation = cls._hub_mixin_init_parameters["config"].annotation
                 if config_annotation is inspect.Parameter.empty:
@@ -505,7 +505,7 @@ class ModelHubMixin:
                         model_kwargs[key] = value
 
             # Finally, also inject if `_from_pretrained` expects it
-            if cls._hub_mixin_inject_config:
+            if cls._hub_mixin_inject_config and "config" not in model_kwargs:
                 model_kwargs["config"] = config
 
         instance = cls._from_pretrained(


### PR DESCRIPTION
It's possible someone wants to use `from_pretrained` but have the ability to override the config stored in the model repository (see point 2 [here](https://github.com/huggingface/lerobot/pull/146#pullrequestreview-2044816980) for an example use case). In this case, they might want to use `ModelCls.from_pretrained("hub/id", model_kwargs={"config": myconfig})`. This PR makes sure that "config" is not overriden by `from_pretrained`