### PR TITLE
Update token type definition and arg description in `hf_file_system.py`

### DIFF
--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -74,8 +74,11 @@ class HfFileSystem(fsspec.AbstractFileSystem):
     Access a remote Hugging Face Hub repository as if were a local file system.
 
     Args:
-        token (`str`, *optional*):
-            Authentication token, obtained with [`HfApi.login`] method. Will default to the stored token.
+        token (Union[bool, str, None], optional):
+            A valid user access token (string). Defaults to the locally saved
+            token, which is the recommended method for authentication (see
+            https://huggingface.co/docs/huggingface_hub/quick-start#authentication).
+            To disable authentication, pass `False`.
 
     Usage:
 
@@ -105,7 +108,7 @@ class HfFileSystem(fsspec.AbstractFileSystem):
         self,
         *args,
         endpoint: Optional[str] = None,
-        token: Optional[str] = None,
+        token: Union[bool, str, None] = None,
         **storage_options,
     ):
         super().__init__(*args, **storage_options)


### PR DESCRIPTION
Refactor token argument in `hf_file_system.py` for consistency across the hub.

- Standardize the type definition of the token parameter to `Union[bool, str, None] = None`
- Unify docstring descriptions for the token parameter to enhance clarity and usage guidance

See #2251 and #2252 for related discussions.

Thought i just go on and open a PR for this.
