### PR TITLE
Close aiohttp client on error

### DIFF
--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -289,6 +289,9 @@ class AsyncInferenceClient:
                             timeout = max(self.timeout - (time.time() - t0), 1)  # type: ignore
                         continue
                     raise error
+                except Exception:
+                    await client.close()
+                    raise
 
     async def audio_classification(
         self,

--- a/utils/generate_async_inference_client.py
+++ b/utils/generate_async_inference_client.py
@@ -236,7 +236,10 @@ ASYNC_POST_CODE = """
                         if timeout is not None:
                             timeout = max(self.timeout - (time.time() - t0), 1)  # type: ignore
                         continue
-                    raise error"""
+                    raise error
+                except Exception:
+                    await client.close()
+                    raise"""
 
 
 def _make_post_async(code: str) -> str:


### PR DESCRIPTION
Should fix warnings in optimum CI cc @dacorvo

At the moment if an error occurs while sending a POST with `AsyncInferenceClient`, we don't catch all errors. This PR makes sure that we close the connection "no matter what" and before raising the exception. Also added a test to ensure that.