### PR TITLE
Fix test: rename to open-llm-leaderboard + some cleaning

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -6919,7 +6919,7 @@ class HfApi:
 
         Args:
             repo_id (`str`):
-                ID of the Space to update. Example: `"HuggingFaceH4/open_llm_leaderboard"`.
+                ID of the Space to update. Example: `"open-llm-leaderboard/open_llm_leaderboard"`.
             storage (`str` or [`SpaceStorage`]):
                Storage tier. Either 'small', 'medium', or 'large'.
             token (Union[bool, str, None], optional):
@@ -6957,7 +6957,7 @@ class HfApi:
 
         Args:
             repo_id (`str`):
-                ID of the Space to update. Example: `"HuggingFaceH4/open_llm_leaderboard"`.
+                ID of the Space to update. Example: `"open-llm-leaderboard/open_llm_leaderboard"`.
             token (Union[bool, str, None], optional):
                 A valid user access token (string). Defaults to the locally saved
                 token, which is the recommended method for authentication (see

--- a/src/huggingface_hub/repocard_data.py
+++ b/src/huggingface_hub/repocard_data.py
@@ -55,7 +55,7 @@ class EvalResult:
         source_name (`str`, *optional*):
             The name of the source of the evaluation result. Example: "Open LLM Leaderboard".
         source_url (`str`, *optional*):
-            The URL of the source of the evaluation result. Example: "https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard".
+            The URL of the source of the evaluation result. Example: "https://huggingface.co/spaces/open-llm-leaderboard/open_llm_leaderboard".
     """
 
     # Required
@@ -128,7 +128,7 @@ class EvalResult:
     source_name: Optional[str] = None
 
     # The URL of the source of the evaluation result.
-    # Example: https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard
+    # Example: https://huggingface.co/spaces/open-llm-leaderboard/open_llm_leaderboard
     source_url: Optional[str] = None
 
     @property

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -140,18 +140,12 @@ def test_repo_id_no_warning():
     # tests that passing repo_id as positional arg doesn't raise any warnings
     # for {create, delete}_repo and update_repo_visibility
     api = HfApi(endpoint=ENDPOINT_STAGING, token=TOKEN)
-    REPO_NAME = repo_name("crud")
 
-    args = [
-        ("create_repo", {}),
-        ("update_repo_visibility", {"private": False}),
-        ("delete_repo", {}),
-    ]
-
-    for method, kwargs in args:
-        with warnings.catch_warnings(record=True) as record:
-            getattr(api, method)(REPO_NAME, repo_type=REPO_TYPE_MODEL, **kwargs)
-        assert not len(record)
+    with warnings.catch_warnings(record=True) as record:
+        repo_id = api.create_repo(repo_name()).repo_id
+        api.update_repo_visibility(repo_id, private=True)
+        api.delete_repo(repo_id)
+    assert not len(record)
 
 
 class HfApiRepoFileExistsTest(HfApiCommonTest):
@@ -229,31 +223,28 @@ class HfApiEndpointsTest(HfApiCommonTest):
         self._api.delete_repo("repo-that-does-not-exist", missing_ok=True)
 
     def test_create_update_and_delete_repo(self):
-        REPO_NAME = repo_name("crud")
-        self._api.create_repo(repo_id=REPO_NAME)
-        res = self._api.update_repo_visibility(repo_id=REPO_NAME, private=True)
-        self.assertTrue(res["private"])
-        res = self._api.update_repo_visibility(repo_id=REPO_NAME, private=False)
-        self.assertFalse(res["private"])
-        self._api.delete_repo(repo_id=REPO_NAME)
+        repo_id = self._api.create_repo(repo_id=repo_name()).repo_id
+        res = self._api.update_repo_visibility(repo_id=repo_id, private=True)
+        assert res["private"]
+        res = self._api.update_repo_visibility(repo_id=repo_id, private=False)
+        assert not res["private"]
+        self._api.delete_repo(repo_id=repo_id)
 
     def test_create_update_and_delete_model_repo(self):
-        REPO_NAME = repo_name("crud")
-        self._api.create_repo(repo_id=REPO_NAME, repo_type=REPO_TYPE_MODEL)
-        res = self._api.update_repo_visibility(repo_id=REPO_NAME, private=True, repo_type=REPO_TYPE_MODEL)
-        self.assertTrue(res["private"])
-        res = self._api.update_repo_visibility(repo_id=REPO_NAME, private=False, repo_type=REPO_TYPE_MODEL)
-        self.assertFalse(res["private"])
-        self._api.delete_repo(repo_id=REPO_NAME, repo_type=REPO_TYPE_MODEL)
+        repo_id = self._api.create_repo(repo_id=repo_name(), repo_type=REPO_TYPE_MODEL).repo_id
+        res = self._api.update_repo_visibility(repo_id=repo_id, private=True, repo_type=REPO_TYPE_MODEL)
+        assert res["private"]
+        res = self._api.update_repo_visibility(repo_id=repo_id, private=False, repo_type=REPO_TYPE_MODEL)
+        assert not res["private"]
+        self._api.delete_repo(repo_id=repo_id, repo_type=REPO_TYPE_MODEL)
 
     def test_create_update_and_delete_dataset_repo(self):
-        DATASET_REPO_NAME = dataset_repo_name("crud")
-        self._api.create_repo(repo_id=DATASET_REPO_NAME, repo_type=REPO_TYPE_DATASET)
-        res = self._api.update_repo_visibility(repo_id=DATASET_REPO_NAME, private=True, repo_type=REPO_TYPE_DATASET)
-        self.assertTrue(res["private"])
-        res = self._api.update_repo_visibility(repo_id=DATASET_REPO_NAME, private=False, repo_type=REPO_TYPE_DATASET)
-        self.assertFalse(res["private"])
-        self._api.delete_repo(repo_id=DATASET_REPO_NAME, repo_type=REPO_TYPE_DATASET)
+        repo_id = self._api.create_repo(repo_id=repo_name(), repo_type=REPO_TYPE_DATASET).repo_id
+        res = self._api.update_repo_visibility(repo_id=repo_id, private=True, repo_type=REPO_TYPE_DATASET)
+        assert res["private"]
+        res = self._api.update_repo_visibility(repo_id=repo_id, private=False, repo_type=REPO_TYPE_DATASET)
+        assert not res["private"]
+        self._api.delete_repo(repo_id=repo_id, repo_type=REPO_TYPE_DATASET)
 
     @unittest.skip(
         "Create repo fails on staging endpoint. See"

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -1876,14 +1876,13 @@ class HfApiPublicProductionTest(unittest.TestCase):
         assert "wikipedia" in spaces[0].datasets
 
     def test_list_spaces_linked(self):
-        space_id = "HuggingFaceH4/open_llm_leaderboard"
+        space_id = "open-llm-leaderboard/open_llm_leaderboard"
 
         spaces = list(self._api.list_spaces(search=space_id))
         assert spaces[0].models is None
         assert spaces[0].datasets is None
 
         spaces = list(self._api.list_spaces(search=space_id, linked=True))
-        assert len(spaces) == 1
         assert spaces[0].models is not None
         assert spaces[0].datasets is not None
 
@@ -2392,7 +2391,7 @@ class HfApiDiscussionsTest(HfApiCommonTest):
     @with_production_testing
     def test_get_repo_discussion_pagination(self):
         discussions = list(
-            HfApi().get_repo_discussions(repo_id="HuggingFaceH4/open_llm_leaderboard", repo_type="space")
+            HfApi().get_repo_discussions(repo_id="open-llm-leaderboard/open_llm_leaderboard", repo_type="space")
         )
         assert len(discussions) > 50
 

--- a/tests/test_repocard_data.py
+++ b/tests/test_repocard_data.py
@@ -14,7 +14,7 @@ from huggingface_hub.repocard_data import (
 )
 
 
-OPEN_LLM_LEADERBOARD_URL = "https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard"
+OPEN_LLM_LEADERBOARD_URL = "https://huggingface.co/spaces/open-llm-leaderboard/open_llm_leaderboard"
 DUMMY_METADATA_WITH_MODEL_INDEX = """
 language: en
 license: mit
@@ -39,7 +39,7 @@ model-index:
       value: 0.9
     source:
       name: Open LLM Leaderboard
-      url: https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard
+      url: https://huggingface.co/spaces/open-llm-leaderboard/open_llm_leaderboard
 """
 
 


### PR DESCRIPTION
The Open LLM Leaderboard has been moved to a new org: https://huggingface.co/spaces/open-llm-leaderboard/open_llm_leaderboard. This PR updates examples and tests that were relying on it which should fix a few errors in the CIs (no big deal, it's just that we need some examples for demo sometimes).


**EDIT:** fixed also some more tests related to the fact that `repo_update_visibility` don't handle implicit repo ids anymore. This is a breaking change server-side but that's for the best (more consistent with all other endpoints).

**EDIT 2:** made some more cleaning + re-enabled some Space tests that were not supported in staging before.