### PR TITLE
Fix windows tests (git security update)

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -143,6 +143,7 @@ jobs:
     env:
       DISABLE_SYMLINKS_IN_WINDOWS_TESTS: 1
       UV_HTTP_TIMEOUT: 600 # max 10min to install deps
+      GIT_CLONE_PROTECTION_ACTIVE: false # See https://github.com/git-lfs/git-lfs/issues/5754
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
3 git tests are currently failing on the Windows CI with error:
```
fatal: active post-checkout hook found during git clone:
```

I seems to be due to a recent git security update that is not yet handled by git+lfs. See:
- https://github.com/git-lfs/git-lfs/issues/5749
- https://github.com/git-lfs/git-lfs/issues/5754

In the meantime a solution is to disable this new security feature by setting `GIT_CLONE_PROTECTION_ACTIVE=false` in the Windows test env. **This only affects the CI, not the package itself.**


### Expectation

CI should be green :) 