### PR TITLE
Print correct webhook url when running in Spaces

### DIFF
--- a/src/huggingface_hub/_webhooks_server.py
+++ b/src/huggingface_hub/_webhooks_server.py
@@ -184,10 +184,8 @@ class WebhooksServer:
             self.fastapi_app.post(path)(func)
 
         # Print instructions and block main thread
-        if os.environ.get("SPACE_HOST") is not None:
-            url = "https://" + os.environ.get("SPACE_HOST")
-        else:
-            url = ui.share_url or ui.local_url
+        space_host = os.environ.get("SPACE_HOST")
+        url = "https://" + space_host if space_host is not None else (ui.share_url or ui.local_url)
         url = url.strip("/")
         message = "\nWebhooks are correctly setup and ready to use:"
         message += "\n" + "\n".join(f"  - POST {url}{webhook}" for webhook in self.registered_webhooks)

--- a/src/huggingface_hub/_webhooks_server.py
+++ b/src/huggingface_hub/_webhooks_server.py
@@ -184,7 +184,11 @@ class WebhooksServer:
             self.fastapi_app.post(path)(func)
 
         # Print instructions and block main thread
-        url = (ui.share_url or ui.local_url).strip("/")
+        if os.environ.get("SPACE_HOST") is not None:
+            url = "https://" + os.environ.get("SPACE_HOST")
+        else:
+            url = ui.share_url or ui.local_url
+        url = url.strip("/")
         message = "\nWebhooks are correctly setup and ready to use:"
         message += "\n" + "\n".join(f"  - POST {url}{webhook}" for webhook in self.registered_webhooks)
         message += "\nGo to https://huggingface.co/settings/webhooks to setup your webhooks."


### PR DESCRIPTION
When using `WebhooksServer`, the webhook URLs are printed in the logs so that users can configure them in their settings. However, when running in a Space the URL looks like this:
```
Webhooks are correctly setup and ready to use:
  - POST http://localhost:7860/webhooks/update_leaderboard
  - POST http://localhost:7860/webhooks/update_queue
Go to https://huggingface.co/settings/webhooks to setup your webhooks.
```

This PR fixes this by looking at the `SPACE_HOST` variable (if running in a Space). Logs should now show something like
```
Webhooks are correctly setup and ready to use:
  - POST http://open-llm-leaderboard-open-llm-leaderboard.hf.space/webhooks/update_leaderboard
  - POST http://open-llm-leaderboard-open-llm-leaderboard.hf.space/webhooks/update_queue
Go to https://huggingface.co/settings/webhooks to setup your webhooks.
```

cc @clefourrier who's using it for the [Open LLM Leaderboard](https://huggingface.co/spaces/open-llm-leaderboard/open_llm_leaderboard)