### PR TITLE
Send model_id in ChatCompletion request

### DIFF
--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -438,6 +438,7 @@ class AsyncInferenceClient:
         tools: Optional[List[ChatCompletionInputTool]] = None,
         top_logprobs: Optional[int] = None,
         top_p: Optional[float] = None,
+        model_id: Optional[str] = None,
     ) -> ChatCompletionOutput: ...
 
     @overload
@@ -461,6 +462,7 @@ class AsyncInferenceClient:
         tools: Optional[List[ChatCompletionInputTool]] = None,
         top_logprobs: Optional[int] = None,
         top_p: Optional[float] = None,
+        model_id: Optional[str] = None,
     ) -> AsyncIterable[ChatCompletionStreamOutput]: ...
 
     @overload
@@ -484,6 +486,7 @@ class AsyncInferenceClient:
         tools: Optional[List[ChatCompletionInputTool]] = None,
         top_logprobs: Optional[int] = None,
         top_p: Optional[float] = None,
+        model_id: Optional[str] = None,
     ) -> Union[ChatCompletionOutput, AsyncIterable[ChatCompletionStreamOutput]]: ...
 
     async def chat_completion(
@@ -507,6 +510,7 @@ class AsyncInferenceClient:
         tools: Optional[List[ChatCompletionInputTool]] = None,
         top_logprobs: Optional[int] = None,
         top_p: Optional[float] = None,
+        model_id: Optional[str] = None,
     ) -> Union[ChatCompletionOutput, AsyncIterable[ChatCompletionStreamOutput]]:
         """
         A method for completing conversations using a specified language model.
@@ -571,6 +575,10 @@ class AsyncInferenceClient:
             tools (List of [`ChatCompletionInputTool`], *optional*):
                 A list of tools the model may call. Currently, only functions are supported as a tool. Use this to
                 provide a list of functions the model may generate JSON inputs for.
+            model_id (`str`, *optional*):
+                The model ID to use for chat-completion. Only used when `model` is a URL to a deployed Text Generation Inference server.
+                It is passed to the server as the `model` parameter. This parameter has no impact on the URL that will be used to
+                send the request.
 
         Returns:
             [`ChatCompletionOutput] or Iterable of [`ChatCompletionStreamOutput`]:
@@ -705,11 +713,20 @@ class AsyncInferenceClient:
             if not model_url.endswith("/chat/completions"):
                 model_url += "/v1/chat/completions"
 
+            # `model_id` sent in the payload. Not used by the server but can be useful for debugging/routing.
+            if model_id is None:
+                if not model.startswith("http") and model.count("/") == 1:
+                    # If it's a ID on the Hub => use it
+                    model_id = model
+                else:
+                    # Otherwise, we use a random string
+                    model_id = "tgi"
+
             try:
                 data = await self.post(
                     model=model_url,
                     json=dict(
-                        model="tgi",  # random string
+                        model=model_id,
                         messages=messages,
                         frequency_penalty=frequency_penalty,
                         logit_bias=logit_bias,


### PR DESCRIPTION
This PR adds a `model_id` parameter to the `InferenceClient.chat_completion` method to be sent in the request payload. Solves https://github.com/huggingface/huggingface_hub/issues/2293 cc @anubhavrana