### PR TITLE
ModelHubMixn: Fix attributes lost in inheritance

### DIFF
--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -212,20 +212,39 @@ class ModelHubMixin:
         # Will be reused when creating modelcard
         tags = tags or []
         tags.append("model_hub_mixin")
-        cls._hub_mixin_info = MixinInfo(
-            model_card_template=model_card_template,
-            repo_url=repo_url,
-            docs_url=docs_url,
-            model_card_data=ModelCardData(
-                languages=languages,
-                library_name=library_name,
-                license=license,
-                license_name=license_name,
-                license_link=license_link,
-                pipeline_tag=pipeline_tag,
-                tags=tags,
-            ),
-        )
+
+        # Initialize MixinInfo if not existent
+        if getattr(cls, "_hub_mixin_info", None) is None:
+            cls._hub_mixin_info = MixinInfo(
+                model_card_template=model_card_template,
+                model_card_data=ModelCardData(),
+            )
+        info = cls._hub_mixin_info
+
+        # Update MixinInfo with metadata
+        if model_card_template is not None and model_card_template != DEFAULT_MODEL_CARD:
+            info.model_card_template = model_card_template
+        if repo_url is not None:
+            info.repo_url = repo_url
+        if docs_url is not None:
+            info.docs_url = docs_url
+        if languages is not None:
+            info.model_card_data.languages = languages
+        if library_name is not None:
+            info.model_card_data.library_name = library_name
+        if license is not None:
+            info.model_card_data.license = license
+        if license_name is not None:
+            info.model_card_data.license_name = license_name
+        if license_link is not None:
+            info.model_card_data.license_link = license_link
+        if pipeline_tag is not None:
+            info.model_card_data.pipeline_tag = pipeline_tag
+        if tags is not None:
+            if info.model_card_data.tags is not None:
+                info.model_card_data.tags.extend(tags)
+            else:
+                info.model_card_data.tags = tags
 
         # Handle encoders/decoders for args
         cls._hub_mixin_coders = coders or {}

--- a/tests/test_hub_mixin.py
+++ b/tests/test_hub_mixin.py
@@ -90,6 +90,14 @@ class DummyModelFromPretrainedExpectsConfig(ModelHubMixin):
         return cls(**kwargs)
 
 
+class BaseModelForInheritance(ModelHubMixin, repo_url="https://hf.co/my-repo", library_name="my-cool-library"):
+    pass
+
+
+class DummyModelInherited(BaseModelForInheritance):
+    pass
+
+
 class DummyModelSavingConfig(ModelHubMixin):
     def _save_pretrained(self, save_directory: Path) -> None:
         """Implementation that uses `config.json` to serialize the config.
@@ -414,3 +422,9 @@ class HubMixinTest(unittest.TestCase):
         assert model_reloaded.bar == "bar"
         assert model_reloaded.custom.value == "custom"
         assert model_reloaded.custom_default.value == "default"
+
+    def test_inherited_class(self):
+        """Test MixinInfo attributes are inherited from the parent class."""
+        model = DummyModelInherited()
+        assert model._hub_mixin_info.repo_url == "https://hf.co/my-repo"
+        assert model._hub_mixin_info.model_card_data.library_name == "my-cool-library"

--- a/tests/test_hub_mixin_pytorch.py
+++ b/tests/test_hub_mixin_pytorch.py
@@ -286,7 +286,7 @@ class PytorchHubMixinTest(unittest.TestCase):
         assert card.data.library_name == "my-dummy-lib"
         assert card.data.license == "apache-2.0"
         assert card.data.pipeline_tag == "text-classification"
-        assert card.data.tags == ["tag1", "tag2", "pytorch_model_hub_mixin", "model_hub_mixin"]
+        assert card.data.tags == ["model_hub_mixin", "pytorch_model_hub_mixin", "tag1", "tag2"]
 
         # Model card template has been used
         assert "This is a dummy model card." in str(card)


### PR DESCRIPTION
Fix https://github.com/huggingface/huggingface_hub/issues/2300.

Instead of recreating the `MixinInfo` object, we should complete its information as mentioned by @qubvel. Thanks for reporting this!