### PR TITLE
Fix progress bar not always closed in file_download.py

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -488,7 +488,7 @@ def http_get(
     )
 
     # Stream file to buffer
-    progress: tqdm = (
+    progress_cm: tqdm = (
         tqdm(  # type: ignore[assignment]
             unit="B",
             unit_scale=True,
@@ -507,7 +507,7 @@ def http_get(
         #   case, the progress bar is not closed when exiting the context manager.
     )
 
-    with progress:
+    with progress_cm as progress:
         if hf_transfer and total is not None and total > 5 * DOWNLOAD_CHUNK_SIZE:
             supports_callback = "callback" in inspect.signature(hf_transfer.download).parameters
             if not supports_callback:


### PR DESCRIPTION
When downloading files in `file_download.py`, we use a progress bar. This progress bar can be either passed by the user or we create a classic tqdm bar (see update in https://github.com/huggingface/huggingface_hub/pull/2143).

As @cbensimon noticed, the progress bar is not correctly closed when an error occurs or when `hf_transfer` is used. This PR fixes this by using a context manager. The progress bar is now always closed if created internally. When passed by the user, the progress bar is not closed as it is a the user's discretion to manage it.

Better to review with "hide whitespace" checked. 