### PR TITLE
Support custom kwargs for model card in save_pretrained

### DIFF
--- a/tests/test_hub_mixin.py
+++ b/tests/test_hub_mixin.py
@@ -274,11 +274,11 @@ class HubMixinTest(unittest.TestCase):
 
         # Push to hub with repo_id (config is pushed)
         mocked_model.save_pretrained(save_directory, push_to_hub=True, repo_id="CustomID")
-        mocked_model.push_to_hub.assert_called_with(repo_id="CustomID", config=CONFIG_AS_DICT)
+        mocked_model.push_to_hub.assert_called_with(repo_id="CustomID", config=CONFIG_AS_DICT, model_card_kwargs={})
 
         # Push to hub with default repo_id (based on dir name)
         mocked_model.save_pretrained(save_directory, push_to_hub=True)
-        mocked_model.push_to_hub.assert_called_with(repo_id=repo_id, config=CONFIG_AS_DICT)
+        mocked_model.push_to_hub.assert_called_with(repo_id=repo_id, config=CONFIG_AS_DICT, model_card_kwargs={})
 
     @patch.object(DummyModelNoConfig, "_from_pretrained")
     def test_from_pretrained_model_id_only(self, from_pretrained_mock: Mock) -> None:

--- a/tests/test_hub_mixin_pytorch.py
+++ b/tests/test_hub_mixin_pytorch.py
@@ -407,7 +407,6 @@ class PytorchHubMixinTest(unittest.TestCase):
         reloaded = DummyModelWithConfigAndKwargs.from_pretrained(self.cache_dir)
         assert reloaded._hub_mixin_config == model._hub_mixin_config
 
-
     def test_model_card_with_custom_kwargs(self):
         model_card_kwargs = {"custom_data": "This is a model custom data: 42."}
 

--- a/tests/test_hub_mixin_pytorch.py
+++ b/tests/test_hub_mixin_pytorch.py
@@ -28,6 +28,17 @@ This is a dummy model card.
 Arxiv ID: 1234.56789
 """
 
+DUMMY_MODEL_CARD_TEMPLATE_WITH_CUSTOM_KWARGS = """
+---
+{{ card_data }}
+---
+
+This is a dummy model card with kwargs.
+Arxiv ID: 1234.56789
+
+{{ custom_data }}
+"""
+
 if is_torch_available():
     import torch
     import torch.nn as nn
@@ -76,11 +87,20 @@ if is_torch_available():
         def __init__(self, num_classes: int = 42, state: str = "layernorm", config: Optional[Dict] = None, **kwargs):
             super().__init__()
 
+    class DummyModelWithModelCardAndCustomKwargs(
+        nn.Module,
+        PyTorchModelHubMixin,
+        model_card_template=DUMMY_MODEL_CARD_TEMPLATE_WITH_CUSTOM_KWARGS,
+    ):
+        def __init__(self, linear_layer: int = 4):
+            super().__init__()
+
 else:
     DummyModel = None
     DummyModelWithModelCard = None
     DummyModelNoConfig = None
     DummyModelWithConfigAndKwargs = None
+    DummyModelWithModelCardAndCustomKwargs = None
 
 
 @requires("torch")
@@ -386,3 +406,17 @@ class PytorchHubMixinTest(unittest.TestCase):
 
         reloaded = DummyModelWithConfigAndKwargs.from_pretrained(self.cache_dir)
         assert reloaded._hub_mixin_config == model._hub_mixin_config
+
+
+    def test_model_card_with_custom_kwargs(self):
+        model_card_kwargs = {"custom_data": "This is a model custom data: 42."}
+
+        # Test creating model with custom kwargs => custom data is saved in model card
+        model = DummyModelWithModelCardAndCustomKwargs()
+        card = model.generate_model_card(**model_card_kwargs)
+        assert model_card_kwargs["custom_data"] in str(card)
+
+        # Test saving card => model card is saved and restored with custom data
+        model.save_pretrained(self.cache_dir, model_card_kwargs=model_card_kwargs)
+        card_reloaded = ModelCard.load(self.cache_dir / "README.md")
+        assert str(card) == str(card_reloaded)

--- a/tests/test_hub_mixin_pytorch.py
+++ b/tests/test_hub_mixin_pytorch.py
@@ -130,11 +130,11 @@ class PytorchHubMixinTest(unittest.TestCase):
 
         # Push to hub with repo_id
         mocked_model.save_pretrained(save_directory, push_to_hub=True, repo_id="CustomID", config=config)
-        mocked_model.push_to_hub.assert_called_with(repo_id="CustomID", config=config)
+        mocked_model.push_to_hub.assert_called_with(repo_id="CustomID", config=config, model_card_kwargs={})
 
         # Push to hub with default repo_id (based on dir name)
         mocked_model.save_pretrained(save_directory, push_to_hub=True, config=config)
-        mocked_model.push_to_hub.assert_called_with(repo_id=repo_id, config=config)
+        mocked_model.push_to_hub.assert_called_with(repo_id=repo_id, config=config, model_card_kwargs={})
 
     @patch.object(DummyModel, "_from_pretrained")
     def test_from_pretrained_model_id_only(self, from_pretrained_mock: Mock) -> None:


### PR DESCRIPTION
Hi!

There is an option to customize the model card for `Mixin`s, it would be great to support custom kwargs for a card also.

Here is an example:
```python
import torch
from huggingface_hub import PyTorchModelHubMixin


MODEL_CARD_TEMPLATE = """
---
# For reference on model card metadata, see the spec: https://github.com/huggingface/hub-docs/blob/main/modelcard.md?plain=1
# Doc / guide: https://huggingface.co/docs/hub/model-cards
{{ card_data }}
---
{{ custom_data }}
"""

class Model(torch.nn.Module, PyTorchModelHubMixin, model_card_template=MODEL_CARD_TEMPLATE):
    pass
    
model = Model()
model_card_kwargs = {"custom_data": "This is an awesome model..."}
model.save_pretrained("test-model", model_card_kwargs=model_card_kwargs, push_to_hub=True)
```

Generated readme:
```
---
tags:
- pytorch_model_hub_mixin
- model_hub_mixin
---
This is awesome model...
```

Let me know what you think about this feature! If it's OK, I can add the necessary tests.