### PR TITLE
Make raises sections consistent in docstrings

### DIFF
--- a/src/huggingface_hub/_commit_api.py
+++ b/src/huggingface_hub/_commit_api.py
@@ -345,13 +345,13 @@ def _upload_lfs_files(
         revision (`str`, *optional*):
             The git revision to upload to.
 
-    Raises: `RuntimeError` if an upload failed for any reason
-
-    Raises: `ValueError` if the server returns malformed responses
-
-    Raises: `requests.HTTPError` if the LFS batch endpoint returned an HTTP
-        error
-
+    Raises:
+        [`EnvironmentError`](https://docs.python.org/3/library/exceptions.html#EnvironmentError)
+            If an upload failed for any reason
+        [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
+            If the server returns malformed responses
+        [`HTTPError`](https://requests.readthedocs.io/en/latest/api/#requests.HTTPError)
+            If the LFS batch endpoint returned an HTTP error.
     """
     # Step 1: retrieve upload instructions from the LFS batch endpoint.
     #         Upload instructions are retrieved by chunk of 256 files to avoid reaching

--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -127,12 +127,17 @@ def snapshot_download(
         `str`: folder path of the repo snapshot.
 
     Raises:
-        - [`EnvironmentError`](https://docs.python.org/3/library/exceptions.html#EnvironmentError)
-        if `token=True` and the token cannot be found.
-        - [`OSError`](https://docs.python.org/3/library/exceptions.html#OSError) if
-        ETag cannot be determined.
-        - [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
-        if some parameter value is invalid
+        [`~utils.RepositoryNotFoundError`]
+            If the repository to download from cannot be found. This may be because it doesn't exist,
+            or because it is set to `private` and you do not have access.
+        [`~utils.RevisionNotFoundError`]
+            If the revision to download from cannot be found.
+        [`EnvironmentError`](https://docs.python.org/3/library/exceptions.html#EnvironmentError)
+            If `token=True` and the token cannot be found.
+        [`OSError`](https://docs.python.org/3/library/exceptions.html#OSError) if
+            ETag cannot be determined.
+        [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
+            if some parameter value is invalid.
     """
     if cache_dir is None:
         cache_dir = HF_HUB_CACHE

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1106,21 +1106,22 @@ def hf_hub_download(
         `str`: Local path of file or if networking is off, last version of file cached on disk.
 
     Raises:
-        - [`EnvironmentError`](https://docs.python.org/3/library/exceptions.html#EnvironmentError)
-        if `token=True` and the token cannot be found.
-        - [`OSError`](https://docs.python.org/3/library/exceptions.html#OSError)
-        if ETag cannot be determined.
-        - [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
-        if some parameter value is invalid
-        - [`~utils.RepositoryNotFoundError`]
-        If the repository to download from cannot be found. This may be because it doesn't exist,
-        or because it is set to `private` and you do not have access.
-        - [`~utils.RevisionNotFoundError`]
-        If the revision to download from cannot be found.
-        - [`~utils.EntryNotFoundError`]
-        If the file to download cannot be found.
-        - [`~utils.LocalEntryNotFoundError`]
-        If network is disabled or unavailable and file is not found in cache.
+        [`~utils.RepositoryNotFoundError`]
+            If the repository to download from cannot be found. This may be because it doesn't exist,
+            or because it is set to `private` and you do not have access.
+        [`~utils.RevisionNotFoundError`]
+            If the revision to download from cannot be found.
+        [`~utils.EntryNotFoundError`]
+            If the file to download cannot be found.
+        [`~utils.LocalEntryNotFoundError`]
+            If network is disabled or unavailable and file is not found in cache.
+        [`EnvironmentError`](https://docs.python.org/3/library/exceptions.html#EnvironmentError)
+            If `token=True` but the token cannot be found.
+        [`OSError`](https://docs.python.org/3/library/exceptions.html#OSError)
+            If ETag cannot be determined.
+        [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
+            If some parameter value is invalid.
+
     """
     if HF_HUB_ETAG_TIMEOUT != DEFAULT_ETAG_TIMEOUT:
         # Respect environment variable above user value

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -175,9 +175,9 @@ def repo_type_and_id_from_hf_id(hf_id: str, hub_url: Optional[str] = None) -> Tu
         `None`) and repo_id (`str`).
 
     Raises:
-        - [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
+        [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
             If URL cannot be parsed.
-        - [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
+        [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
             If `repo_type` is unknown.
     """
     input_hf_id = hf_id
@@ -463,9 +463,9 @@ class RepoUrl(str):
     ```
 
     Raises:
-        - [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
+        [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
             If URL cannot be parsed.
-        - [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
+        [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
             If `repo_type` is unknown.
     """
 
@@ -3246,7 +3246,7 @@ class HfApi:
                 If `True`, do not raise an error if repo does not exist.
 
         Raises:
-            - [`~utils.RepositoryNotFoundError`]
+            [`~utils.RepositoryNotFoundError`]
               If the repository to delete from cannot be found and `missing_ok` is set to False (default).
         """
         organization, name = repo_id.split("/") if "/" in repo_id else (None, repo_id)
@@ -5053,21 +5053,21 @@ class HfApi:
             `str`: Local path of file or if networking is off, last version of file cached on disk.
 
         Raises:
-            - [`EnvironmentError`](https://docs.python.org/3/library/exceptions.html#EnvironmentError)
-            if `token=True` and the token cannot be found.
-            - [`OSError`](https://docs.python.org/3/library/exceptions.html#OSError)
-            if ETag cannot be determined.
-            - [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
-            if some parameter value is invalid
-            - [`~utils.RepositoryNotFoundError`]
-            If the repository to download from cannot be found. This may be because it doesn't exist,
-            or because it is set to `private` and you do not have access.
-            - [`~utils.RevisionNotFoundError`]
-            If the revision to download from cannot be found.
-            - [`~utils.EntryNotFoundError`]
-            If the file to download cannot be found.
-            - [`~utils.LocalEntryNotFoundError`]
-            If network is disabled or unavailable and file is not found in cache.
+            [`~utils.RepositoryNotFoundError`]
+                If the repository to download from cannot be found. This may be because it doesn't exist,
+                or because it is set to `private` and you do not have access.
+            [`~utils.RevisionNotFoundError`]
+                If the revision to download from cannot be found.
+            [`~utils.EntryNotFoundError`]
+                If the file to download cannot be found.
+            [`~utils.LocalEntryNotFoundError`]
+                If network is disabled or unavailable and file is not found in cache.
+            [`EnvironmentError`](https://docs.python.org/3/library/exceptions.html#EnvironmentError)
+                If `token=True` but the token cannot be found.
+            [`OSError`](https://docs.python.org/3/library/exceptions.html#OSError)
+                If ETag cannot be determined.
+            [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
+                If some parameter value is invalid.
         """
         from .file_download import hf_hub_download
 
@@ -5183,12 +5183,17 @@ class HfApi:
             `str`: folder path of the repo snapshot.
 
         Raises:
-            - [`EnvironmentError`](https://docs.python.org/3/library/exceptions.html#EnvironmentError)
-            if `token=True` and the token cannot be found.
-            - [`OSError`](https://docs.python.org/3/library/exceptions.html#OSError) if
-            ETag cannot be determined.
-            - [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
-            if some parameter value is invalid
+            [`~utils.RepositoryNotFoundError`]
+                If the repository to download from cannot be found. This may be because it doesn't exist,
+                or because it is set to `private` and you do not have access.
+            [`~utils.RevisionNotFoundError`]
+                If the revision to download from cannot be found.
+            [`EnvironmentError`](https://docs.python.org/3/library/exceptions.html#EnvironmentError)
+                If `token=True` and the token cannot be found.
+            [`OSError`](https://docs.python.org/3/library/exceptions.html#OSError) if
+                ETag cannot be determined.
+            [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
+                if some parameter value is invalid.
         """
         from ._snapshot_download import snapshot_download
 
@@ -5259,9 +5264,11 @@ class HfApi:
             [`SafetensorsRepoMetadata`]: information related to safetensors repo.
 
         Raises:
-            - [`NotASafetensorsRepoError`]: if the repo is not a safetensors repo i.e. doesn't have either a
+            [`NotASafetensorsRepoError`]
+                If the repo is not a safetensors repo i.e. doesn't have either a
               `model.safetensors` or a `model.safetensors.index.json` file.
-            - [`SafetensorsParsingError`]: if a safetensors file header couldn't be parsed correctly.
+            [`SafetensorsParsingError`]
+                If a safetensors file header couldn't be parsed correctly.
 
         Example:
             ```py
@@ -5378,9 +5385,11 @@ class HfApi:
             [`SafetensorsFileMetadata`]: information related to a safetensors file.
 
         Raises:
-            - [`NotASafetensorsRepoError`]: if the repo is not a safetensors repo i.e. doesn't have either a
+            [`NotASafetensorsRepoError`]:
+                If the repo is not a safetensors repo i.e. doesn't have either a
               `model.safetensors` or a `model.safetensors.index.json` file.
-            - [`SafetensorsParsingError`]: if a safetensors file header couldn't be parsed correctly.
+            [`SafetensorsParsingError`]:
+                If a safetensors file header couldn't be parsed correctly.
         """
         url = hf_hub_url(
             repo_id=repo_id, filename=filename, repo_type=repo_type, revision=revision, endpoint=self.endpoint
@@ -6921,11 +6930,11 @@ class HfApi:
             attributes like `endpoint`, `repo_type` and `repo_id`.
 
         Raises:
-            - [`HTTPError`](https://requests.readthedocs.io/en/latest/api/#requests.HTTPError)
-              if the HuggingFace API returned an error
-            - [`~utils.RepositoryNotFoundError`]
+            [`~utils.RepositoryNotFoundError`]:
               If one of `from_id` or `to_id` cannot be found. This may be because it doesn't exist,
               or because it is set to `private` and you do not have access.
+            [`HTTPError`](https://requests.readthedocs.io/en/latest/api/#requests.HTTPError):
+              If the HuggingFace API returned an error
 
         Example:
         ```python
@@ -7862,12 +7871,12 @@ class HfApi:
         Returns: [`Collection`]
 
         Raises:
-            `HTTPError`:
+            [`HTTPError`](https://requests.readthedocs.io/en/latest/api/#requests.HTTPError):
                 HTTP 403 if you only have read-only access to the repo. This can be the case if you don't have `write`
                 or `admin` role in the organization the repo belongs to or if you passed a `read` token.
-            `HTTPError`:
+            [`HTTPError`](https://requests.readthedocs.io/en/latest/api/#requests.HTTPError):
                 HTTP 404 if the item you try to add to the collection does not exist on the Hub.
-            `HTTPError`:
+            [`HTTPError`](https://requests.readthedocs.io/en/latest/api/#requests.HTTPError):
                 HTTP 409 if the item you try to add to the collection is already in the collection (and exists_ok=False)
 
         Example:
@@ -8051,9 +8060,9 @@ class HfApi:
             be populated with user's answers.
 
         Raises:
-            `HTTPError`:
+            [`HTTPError`](https://requests.readthedocs.io/en/latest/api/#requests.HTTPError):
                 HTTP 400 if the repo is not gated.
-            `HTTPError`:
+            [`HTTPError`](https://requests.readthedocs.io/en/latest/api/#requests.HTTPError):
                 HTTP 403 if you only have read-only access to the repo. This can be the case if you don't have `write`
                 or `admin` role in the organization the repo belongs to or if you passed a `read` token.
 
@@ -8117,9 +8126,9 @@ class HfApi:
             be populated with user's answers.
 
         Raises:
-            `HTTPError`:
+            [`HTTPError`](https://requests.readthedocs.io/en/latest/api/#requests.HTTPError):
                 HTTP 400 if the repo is not gated.
-            `HTTPError`:
+            [`HTTPError`](https://requests.readthedocs.io/en/latest/api/#requests.HTTPError):
                 HTTP 403 if you only have read-only access to the repo. This can be the case if you don't have `write`
                 or `admin` role in the organization the repo belongs to or if you passed a `read` token.
 
@@ -8179,9 +8188,9 @@ class HfApi:
             be populated with user's answers.
 
         Raises:
-            `HTTPError`:
+            [`HTTPError`](https://requests.readthedocs.io/en/latest/api/#requests.HTTPError):
                 HTTP 400 if the repo is not gated.
-            `HTTPError`:
+            [`HTTPError`](https://requests.readthedocs.io/en/latest/api/#requests.HTTPError):
                 HTTP 403 if you only have read-only access to the repo. This can be the case if you don't have `write`
                 or `admin` role in the organization the repo belongs to or if you passed a `read` token.
 
@@ -8263,16 +8272,16 @@ class HfApi:
                 To disable authentication, pass `False`.
 
         Raises:
-            `HTTPError`:
+            [`HTTPError`](https://requests.readthedocs.io/en/latest/api/#requests.HTTPError):
                 HTTP 400 if the repo is not gated.
-            `HTTPError`:
+            [`HTTPError`](https://requests.readthedocs.io/en/latest/api/#requests.HTTPError):
                 HTTP 403 if you only have read-only access to the repo. This can be the case if you don't have `write`
                 or `admin` role in the organization the repo belongs to or if you passed a `read` token.
-            `HTTPError`:
+            [`HTTPError`](https://requests.readthedocs.io/en/latest/api/#requests.HTTPError):
                 HTTP 404 if the user does not exist on the Hub.
-            `HTTPError`:
+            [`HTTPError`](https://requests.readthedocs.io/en/latest/api/#requests.HTTPError):
                 HTTP 404 if the user access request cannot be found.
-            `HTTPError`:
+            [`HTTPError`](https://requests.readthedocs.io/en/latest/api/#requests.HTTPError):
                 HTTP 404 if the user access request is already in the pending list.
         """
         self._handle_access_request(repo_id, user, "pending", repo_type=repo_type, token=token)
@@ -8305,16 +8314,16 @@ class HfApi:
                 To disable authentication, pass `False`.
 
         Raises:
-            `HTTPError`:
+            [`HTTPError`](https://requests.readthedocs.io/en/latest/api/#requests.HTTPError):
                 HTTP 400 if the repo is not gated.
-            `HTTPError`:
+            [`HTTPError`](https://requests.readthedocs.io/en/latest/api/#requests.HTTPError):
                 HTTP 403 if you only have read-only access to the repo. This can be the case if you don't have `write`
                 or `admin` role in the organization the repo belongs to or if you passed a `read` token.
-            `HTTPError`:
+            [`HTTPError`](https://requests.readthedocs.io/en/latest/api/#requests.HTTPError):
                 HTTP 404 if the user does not exist on the Hub.
-            `HTTPError`:
+            [`HTTPError`](https://requests.readthedocs.io/en/latest/api/#requests.HTTPError):
                 HTTP 404 if the user access request cannot be found.
-            `HTTPError`:
+            [`HTTPError`](https://requests.readthedocs.io/en/latest/api/#requests.HTTPError):
                 HTTP 404 if the user access request is already in the accepted list.
         """
         self._handle_access_request(repo_id, user, "accepted", repo_type=repo_type, token=token)
@@ -8347,16 +8356,16 @@ class HfApi:
                 To disable authentication, pass `False`.
 
         Raises:
-            `HTTPError`:
+            [`HTTPError`](https://requests.readthedocs.io/en/latest/api/#requests.HTTPError):
                 HTTP 400 if the repo is not gated.
-            `HTTPError`:
+            [`HTTPError`](https://requests.readthedocs.io/en/latest/api/#requests.HTTPError):
                 HTTP 403 if you only have read-only access to the repo. This can be the case if you don't have `write`
                 or `admin` role in the organization the repo belongs to or if you passed a `read` token.
-            `HTTPError`:
+            [`HTTPError`](https://requests.readthedocs.io/en/latest/api/#requests.HTTPError):
                 HTTP 404 if the user does not exist on the Hub.
-            `HTTPError`:
+            [`HTTPError`](https://requests.readthedocs.io/en/latest/api/#requests.HTTPError):
                 HTTP 404 if the user access request cannot be found.
-            `HTTPError`:
+            [`HTTPError`](https://requests.readthedocs.io/en/latest/api/#requests.HTTPError):
                 HTTP 404 if the user access request is already in the rejected list.
         """
         self._handle_access_request(repo_id, user, "rejected", repo_type=repo_type, token=token)
@@ -8410,14 +8419,14 @@ class HfApi:
                 To disable authentication, pass `False`.
 
         Raises:
-            `HTTPError`:
+            [`HTTPError`](https://requests.readthedocs.io/en/latest/api/#requests.HTTPError):
                 HTTP 400 if the repo is not gated.
-            `HTTPError`:
+            [`HTTPError`](https://requests.readthedocs.io/en/latest/api/#requests.HTTPError):
                 HTTP 400 if the user already has access to the repo.
-            `HTTPError`:
+            [`HTTPError`](https://requests.readthedocs.io/en/latest/api/#requests.HTTPError):
                 HTTP 403 if you only have read-only access to the repo. This can be the case if you don't have `write`
                 or `admin` role in the organization the repo belongs to or if you passed a `read` token.
-            `HTTPError`:
+            [`HTTPError`](https://requests.readthedocs.io/en/latest/api/#requests.HTTPError):
                 HTTP 404 if the user does not exist on the Hub.
         """
         if repo_type not in REPO_TYPES:
@@ -8899,7 +8908,7 @@ class HfApi:
             `User`: A [`User`] object with the user's overview.
 
         Raises:
-            `HTTPError`:
+            [`HTTPError`](https://requests.readthedocs.io/en/latest/api/#requests.HTTPError):
                 HTTP 404 If the user does not exist on the Hub.
         """
         r = get_session().get(f"{ENDPOINT}/api/users/{username}/overview")
@@ -8919,7 +8928,7 @@ class HfApi:
             `Iterable[User]`: A list of [`User`] objects with the members of the organization.
 
         Raises:
-            `HTTPError`:
+            [`HTTPError`](https://requests.readthedocs.io/en/latest/api/#requests.HTTPError):
                 HTTP 404 If the organization does not exist on the Hub.
 
         """
@@ -8943,7 +8952,7 @@ class HfApi:
             `Iterable[User]`: A list of [`User`] objects with the followers of the user.
 
         Raises:
-            `HTTPError`:
+            [`HTTPError`](https://requests.readthedocs.io/en/latest/api/#requests.HTTPError):
                 HTTP 404 If the user does not exist on the Hub.
 
         """
@@ -8967,7 +8976,7 @@ class HfApi:
             `Iterable[User]`: A list of [`User`] objects with the users followed by the user.
 
         Raises:
-            `HTTPError`:
+            [`HTTPError`](https://requests.readthedocs.io/en/latest/api/#requests.HTTPError):
                 HTTP 404 If the user does not exist on the Hub.
 
         """

--- a/src/huggingface_hub/lfs.py
+++ b/src/huggingface_hub/lfs.py
@@ -134,9 +134,10 @@ def post_lfs_batch_info(
             - Second element is an list of errors, if any
 
     Raises:
-        `ValueError`: If an argument is invalid or the server response is malformed
-
-        `HTTPError`: If the server returned an error
+        [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
+            If an argument is invalid or the server response is malformed.
+        [`HTTPError`](https://requests.readthedocs.io/en/latest/api/#requests.HTTPError)
+            If the server returned an error.
     """
     endpoint = endpoint if endpoint is not None else ENDPOINT
     url_prefix = ""
@@ -211,8 +212,10 @@ def lfs_upload(
             Headers to include in the request, including authentication and user agent headers.
 
     Raises:
-        - `ValueError` if `lfs_batch_action` is improperly formatted
-        - `HTTPError` if the upload resulted in an error
+        [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
+            If `lfs_batch_action` is improperly formatted
+        [`HTTPError`](https://requests.readthedocs.io/en/latest/api/#requests.HTTPError)
+            If the upload resulted in an error
     """
     # 0. If LFS file is already present, skip upload
     _validate_batch_actions(lfs_batch_action)
@@ -307,7 +310,9 @@ def _upload_single_part(operation: "CommitOperationAdd", upload_url: str) -> Non
 
     Returns: `requests.Response`
 
-    Raises: `requests.HTTPError` if the upload resulted in an error
+    Raises:
+     [`HTTPError`](https://requests.readthedocs.io/en/latest/api/#requests.HTTPError)
+        If the upload resulted in an error.
     """
     with operation.as_file(with_tqdm=True) as fileobj:
         # S3 might raise a transient 500 error -> let's retry if that happens

--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -507,8 +507,8 @@ class Repository:
                 instance will be created if this is left to `None`.
 
         Raises:
-            - [`EnvironmentError`](https://docs.python.org/3/library/exceptions.html#EnvironmentError)
-              if the remote repository set in `clone_from` does not exist.
+            [`EnvironmentError`](https://docs.python.org/3/library/exceptions.html#EnvironmentError)
+                If the remote repository set in `clone_from` does not exist.
         """
         if isinstance(local_dir, Path):
             local_dir = str(local_dir)
@@ -580,8 +580,8 @@ class Repository:
         Checks that `git` and `git-lfs` can be run.
 
         Raises:
-            - [`EnvironmentError`](https://docs.python.org/3/library/exceptions.html#EnvironmentError)
-              if `git` or `git-lfs` are not installed.
+            [`EnvironmentError`](https://docs.python.org/3/library/exceptions.html#EnvironmentError)
+                If `git` or `git-lfs` are not installed.
         """
         try:
             git_version = run_subprocess("git --version", self.local_dir).stdout.strip()


### PR DESCRIPTION
Make all `raises` sections consistent in docstrings in `huggingface_hub`. Format looks like this:

```md
    Raises:
        [`EnvironmentError`](https://docs.python.org/3/library/exceptions.html#EnvironmentError)
            If an upload failed for any reason
        [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
            If the server returns malformed responses
        [`HTTPError`](https://requests.readthedocs.io/en/latest/api/#requests.HTTPError)
            If the LFS batch endpoint returned an HTTP error.
```

Made after a report from @mfuntowicz on [slack](https://huggingface.slack.com/archives/C02GLJ5S0E9/p1717505105221149) (private) that docs don't always looks good (hf_hub_download example) 
![image](https://github.com/huggingface/huggingface_hub/assets/11801849/dfef12de-2c75-4738-a434-62fda8b21c47) 
