### PR TITLE
Deprecate `legacy_cache_layout` parameter in `hf_hub_download`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ extras["testing"] = (
     + [
         "jedi",
         "Jinja2",
-        "pytest",
+        "pytest>=8.1.1",
         "pytest-cov",
         "pytest-env",
         "pytest-xdist",

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -274,6 +274,7 @@ def hf_hub_url(
     return url
 
 
+@_deprecate_method(version="0.26", message="Use `hf_hub_download` to benefit from the new cache layout.")
 def url_to_filename(url: str, etag: Optional[str] = None) -> str:
     """Generate a local filename from a url.
 
@@ -582,6 +583,7 @@ def http_get(
 
 
 @validate_hf_hub_args
+@_deprecate_method(version="0.26", message="Use `hf_hub_download` instead.")
 def cached_download(
     url: str,
     *,

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -77,6 +77,7 @@ from .utils import (
     tqdm,
     validate_hf_hub_args,
 )
+from .utils._deprecation import _deprecate_arguments
 from .utils._runtime import _PY_VERSION  # noqa: F401 # for backward compatibility
 from .utils._typing import HTTP_METHOD_T
 from .utils.insecure_hashlib import sha256
@@ -994,6 +995,14 @@ def _check_disk_space(expected_size: int, target_dir: Union[str, Path]) -> None:
             pass
 
 
+@_deprecate_arguments(
+    version="0.26.0",
+    deprecated_args=["legacy_cache_layout"],
+    custom_message=(
+        "Legacy cache layout has been deprecated since August 2022 and will soon be removed. "
+        "See https://huggingface.co/docs/huggingface_hub/guides/manage-cache for more details."
+    ),
+)
 @validate_hf_hub_args
 def hf_hub_download(
     repo_id: str,

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -77,7 +77,7 @@ from .utils import (
     tqdm,
     validate_hf_hub_args,
 )
-from .utils._deprecation import _deprecate_arguments
+from .utils._deprecation import _deprecate_arguments, _deprecate_method
 from .utils._runtime import _PY_VERSION  # noqa: F401 # for backward compatibility
 from .utils._typing import HTTP_METHOD_T
 from .utils.insecure_hashlib import sha256
@@ -305,6 +305,7 @@ def url_to_filename(url: str, etag: Optional[str] = None) -> str:
     return filename
 
 
+@_deprecate_method(version="0.26", message="Use `hf_hub_url` instead.")
 def filename_to_url(
     filename,
     cache_dir: Optional[str] = None,

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -311,12 +311,14 @@ class CachedDownloadTests(unittest.TestCase):
         ):
             _ = cached_download(url, legacy_cache_layout=True)
 
+    @expect_deprecation("filename_to_url")
     def test_standard_object(self):
         url = hf_hub_url(DUMMY_MODEL_ID, filename=CONFIG_NAME, revision=REVISION_ID_DEFAULT)
         filepath = cached_download(url, force_download=True, legacy_cache_layout=True)
         metadata = filename_to_url(filepath, legacy_cache_layout=True)
         self.assertEqual(metadata, (url, f'"{DUMMY_MODEL_ID_PINNED_SHA1}"'))
 
+    @expect_deprecation("filename_to_url")
     def test_standard_object_rev(self):
         # Same object, but different revision
         url = hf_hub_url(
@@ -329,12 +331,14 @@ class CachedDownloadTests(unittest.TestCase):
         self.assertNotEqual(metadata[1], f'"{DUMMY_MODEL_ID_PINNED_SHA1}"')
         # Caution: check that the etag is *not* equal to the one from `test_standard_object`
 
+    @expect_deprecation("filename_to_url")
     def test_lfs_object(self):
         url = hf_hub_url(DUMMY_MODEL_ID, filename=PYTORCH_WEIGHTS_NAME, revision=REVISION_ID_DEFAULT)
         filepath = cached_download(url, force_download=True, legacy_cache_layout=True)
         metadata = filename_to_url(filepath, legacy_cache_layout=True)
         self.assertEqual(metadata, (url, f'"{DUMMY_MODEL_ID_PINNED_SHA256}"'))
 
+    @expect_deprecation("filename_to_url")
     def test_dataset_standard_object_rev(self):
         url = hf_hub_url(
             DATASET_ID,
@@ -347,6 +351,7 @@ class CachedDownloadTests(unittest.TestCase):
         metadata = filename_to_url(filepath, legacy_cache_layout=True)
         self.assertNotEqual(metadata[1], f'"{DUMMY_MODEL_ID_PINNED_SHA1}"')
 
+    @expect_deprecation("filename_to_url")
     def test_dataset_lfs_object(self):
         url = hf_hub_url(
             DATASET_ID,
@@ -524,6 +529,7 @@ class CachedDownloadTests(unittest.TestCase):
         )
 
     @expect_deprecation("hf_hub_download")
+    @expect_deprecation("filename_to_url")
     def test_hf_hub_download_legacy(self):
         filepath = hf_hub_download(
             DUMMY_MODEL_ID,

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -318,7 +318,6 @@ class CachedDownloadTests(unittest.TestCase):
             _ = cached_download(url, legacy_cache_layout=True)
 
     @expect_deprecation("cached_download")
-    @expect_deprecation("filename_to_url")
     def test_standard_object(self):
         url = hf_hub_url(DUMMY_MODEL_ID, filename=CONFIG_NAME, revision=REVISION_ID_DEFAULT)
         filepath = cached_download(url, force_download=True, legacy_cache_layout=True)
@@ -326,7 +325,6 @@ class CachedDownloadTests(unittest.TestCase):
         self.assertEqual(metadata, (url, f'"{DUMMY_MODEL_ID_PINNED_SHA1}"'))
 
     @expect_deprecation("cached_download")
-    @expect_deprecation("filename_to_url")
     def test_standard_object_rev(self):
         # Same object, but different revision
         url = hf_hub_url(
@@ -340,7 +338,6 @@ class CachedDownloadTests(unittest.TestCase):
         # Caution: check that the etag is *not* equal to the one from `test_standard_object`
 
     @expect_deprecation("cached_download")
-    @expect_deprecation("filename_to_url")
     def test_lfs_object(self):
         url = hf_hub_url(DUMMY_MODEL_ID, filename=PYTORCH_WEIGHTS_NAME, revision=REVISION_ID_DEFAULT)
         filepath = cached_download(url, force_download=True, legacy_cache_layout=True)
@@ -348,7 +345,6 @@ class CachedDownloadTests(unittest.TestCase):
         self.assertEqual(metadata, (url, f'"{DUMMY_MODEL_ID_PINNED_SHA256}"'))
 
     @expect_deprecation("cached_download")
-    @expect_deprecation("filename_to_url")
     def test_dataset_standard_object_rev(self):
         url = hf_hub_url(
             DATASET_ID,
@@ -362,7 +358,6 @@ class CachedDownloadTests(unittest.TestCase):
         self.assertNotEqual(metadata[1], f'"{DUMMY_MODEL_ID_PINNED_SHA1}"')
 
     @expect_deprecation("cached_download")
-    @expect_deprecation("filename_to_url")
     def test_dataset_lfs_object(self):
         url = hf_hub_url(
             DATASET_ID,

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -190,11 +190,13 @@ class StagingDownloadTests(unittest.TestCase):
 
 @with_production_testing
 class CachedDownloadTests(unittest.TestCase):
+    @expect_deprecation("cached_download")
     def test_bogus_url(self):
         url = "https://bogus"
         with self.assertRaisesRegex(ValueError, "Connection error"):
             _ = cached_download(url, legacy_cache_layout=True)
 
+    @expect_deprecation("cached_download")
     def test_no_connection(self):
         invalid_url = hf_hub_url(
             DUMMY_MODEL_ID,
@@ -211,6 +213,7 @@ class CachedDownloadTests(unittest.TestCase):
                     _ = cached_download(valid_url, force_download=True, legacy_cache_layout=True)
                 self.assertIsNotNone(cached_download(valid_url, legacy_cache_layout=True))
 
+    @expect_deprecation("cached_download")
     def test_file_not_found_on_repo(self):
         # Valid revision (None) but missing file on repo.
         url = hf_hub_url(DUMMY_MODEL_ID, filename="missing.bin")
@@ -243,6 +246,7 @@ class CachedDownloadTests(unittest.TestCase):
                     local_files_only=True,
                 )
 
+    @expect_deprecation("cached_download")
     def test_file_not_found_locally_and_network_disabled_legacy(self):
         # Valid file but missing locally and network is disabled.
         url = hf_hub_url(DUMMY_MODEL_ID, filename=CONFIG_NAME)
@@ -289,6 +293,7 @@ class CachedDownloadTests(unittest.TestCase):
             # Set permission back for cleanup
             _recursive_chmod(tmpdir, 0o777)
 
+    @expect_deprecation("cached_download")
     def test_revision_not_found(self):
         # Valid file but missing revision
         url = hf_hub_url(
@@ -302,6 +307,7 @@ class CachedDownloadTests(unittest.TestCase):
         ):
             _ = cached_download(url, legacy_cache_layout=True)
 
+    @expect_deprecation("cached_download")
     def test_repo_not_found(self):
         # Invalid model file.
         url = hf_hub_url("bert-base", filename="pytorch_model.bin")
@@ -311,6 +317,7 @@ class CachedDownloadTests(unittest.TestCase):
         ):
             _ = cached_download(url, legacy_cache_layout=True)
 
+    @expect_deprecation("cached_download")
     @expect_deprecation("filename_to_url")
     def test_standard_object(self):
         url = hf_hub_url(DUMMY_MODEL_ID, filename=CONFIG_NAME, revision=REVISION_ID_DEFAULT)
@@ -318,6 +325,7 @@ class CachedDownloadTests(unittest.TestCase):
         metadata = filename_to_url(filepath, legacy_cache_layout=True)
         self.assertEqual(metadata, (url, f'"{DUMMY_MODEL_ID_PINNED_SHA1}"'))
 
+    @expect_deprecation("cached_download")
     @expect_deprecation("filename_to_url")
     def test_standard_object_rev(self):
         # Same object, but different revision
@@ -331,6 +339,7 @@ class CachedDownloadTests(unittest.TestCase):
         self.assertNotEqual(metadata[1], f'"{DUMMY_MODEL_ID_PINNED_SHA1}"')
         # Caution: check that the etag is *not* equal to the one from `test_standard_object`
 
+    @expect_deprecation("cached_download")
     @expect_deprecation("filename_to_url")
     def test_lfs_object(self):
         url = hf_hub_url(DUMMY_MODEL_ID, filename=PYTORCH_WEIGHTS_NAME, revision=REVISION_ID_DEFAULT)
@@ -338,6 +347,7 @@ class CachedDownloadTests(unittest.TestCase):
         metadata = filename_to_url(filepath, legacy_cache_layout=True)
         self.assertEqual(metadata, (url, f'"{DUMMY_MODEL_ID_PINNED_SHA256}"'))
 
+    @expect_deprecation("cached_download")
     @expect_deprecation("filename_to_url")
     def test_dataset_standard_object_rev(self):
         url = hf_hub_url(
@@ -351,6 +361,7 @@ class CachedDownloadTests(unittest.TestCase):
         metadata = filename_to_url(filepath, legacy_cache_layout=True)
         self.assertNotEqual(metadata[1], f'"{DUMMY_MODEL_ID_PINNED_SHA1}"')
 
+    @expect_deprecation("cached_download")
     @expect_deprecation("filename_to_url")
     def test_dataset_lfs_object(self):
         url = hf_hub_url(
@@ -394,6 +405,7 @@ class CachedDownloadTests(unittest.TestCase):
             filepath = hf_hub_download(DUMMY_RENAMED_OLD_MODEL_ID, "config.json", cache_dir=tmpdir)
             self.assertTrue(os.path.exists(filepath))
 
+    @expect_deprecation("cached_download")
     def test_download_from_a_renamed_repo_with_cached_download(self):
         """Checks `cached_download` works also on a renamed repo.
 

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -191,12 +191,14 @@ class StagingDownloadTests(unittest.TestCase):
 @with_production_testing
 class CachedDownloadTests(unittest.TestCase):
     @expect_deprecation("cached_download")
+    @expect_deprecation("url_to_filename")
     def test_bogus_url(self):
         url = "https://bogus"
         with self.assertRaisesRegex(ValueError, "Connection error"):
             _ = cached_download(url, legacy_cache_layout=True)
 
     @expect_deprecation("cached_download")
+    @expect_deprecation("url_to_filename")
     def test_no_connection(self):
         invalid_url = hf_hub_url(
             DUMMY_MODEL_ID,
@@ -247,6 +249,7 @@ class CachedDownloadTests(unittest.TestCase):
                 )
 
     @expect_deprecation("cached_download")
+    @expect_deprecation("url_to_filename")
     def test_file_not_found_locally_and_network_disabled_legacy(self):
         # Valid file but missing locally and network is disabled.
         url = hf_hub_url(DUMMY_MODEL_ID, filename=CONFIG_NAME)
@@ -318,6 +321,8 @@ class CachedDownloadTests(unittest.TestCase):
             _ = cached_download(url, legacy_cache_layout=True)
 
     @expect_deprecation("cached_download")
+    @expect_deprecation("url_to_filename")
+    @expect_deprecation("filename_to_url")
     def test_standard_object(self):
         url = hf_hub_url(DUMMY_MODEL_ID, filename=CONFIG_NAME, revision=REVISION_ID_DEFAULT)
         filepath = cached_download(url, force_download=True, legacy_cache_layout=True)
@@ -325,6 +330,8 @@ class CachedDownloadTests(unittest.TestCase):
         self.assertEqual(metadata, (url, f'"{DUMMY_MODEL_ID_PINNED_SHA1}"'))
 
     @expect_deprecation("cached_download")
+    @expect_deprecation("url_to_filename")
+    @expect_deprecation("filename_to_url")
     def test_standard_object_rev(self):
         # Same object, but different revision
         url = hf_hub_url(
@@ -338,6 +345,8 @@ class CachedDownloadTests(unittest.TestCase):
         # Caution: check that the etag is *not* equal to the one from `test_standard_object`
 
     @expect_deprecation("cached_download")
+    @expect_deprecation("url_to_filename")
+    @expect_deprecation("filename_to_url")
     def test_lfs_object(self):
         url = hf_hub_url(DUMMY_MODEL_ID, filename=PYTORCH_WEIGHTS_NAME, revision=REVISION_ID_DEFAULT)
         filepath = cached_download(url, force_download=True, legacy_cache_layout=True)
@@ -345,6 +354,8 @@ class CachedDownloadTests(unittest.TestCase):
         self.assertEqual(metadata, (url, f'"{DUMMY_MODEL_ID_PINNED_SHA256}"'))
 
     @expect_deprecation("cached_download")
+    @expect_deprecation("url_to_filename")
+    @expect_deprecation("filename_to_url")
     def test_dataset_standard_object_rev(self):
         url = hf_hub_url(
             DATASET_ID,
@@ -358,6 +369,8 @@ class CachedDownloadTests(unittest.TestCase):
         self.assertNotEqual(metadata[1], f'"{DUMMY_MODEL_ID_PINNED_SHA1}"')
 
     @expect_deprecation("cached_download")
+    @expect_deprecation("url_to_filename")
+    @expect_deprecation("filename_to_url")
     def test_dataset_lfs_object(self):
         url = hf_hub_url(
             DATASET_ID,
@@ -535,6 +548,9 @@ class CachedDownloadTests(unittest.TestCase):
         )
 
     @expect_deprecation("hf_hub_download")
+    @expect_deprecation("cached_download")
+    @expect_deprecation("filename_to_url")
+    @expect_deprecation("url_to_filename")
     def test_hf_hub_download_legacy(self):
         filepath = hf_hub_download(
             DUMMY_MODEL_ID,
@@ -727,6 +743,7 @@ class CachedDownloadTests(unittest.TestCase):
                     hf_hub_download(DUMMY_MODEL_ID, filename="pytorch_model.bin", cache_dir=cache_dir)
 
     @expect_deprecation("cached_download")
+    @expect_deprecation("url_to_filename")
     def test_cached_download_from_github(self):
         """Regression test for #1449.
 

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -523,6 +523,7 @@ class CachedDownloadTests(unittest.TestCase):
             "https://hf-ci.co/julien-c/dummy-unknown/resolve/main/config.json",
         )
 
+    @expect_deprecation("hf_hub_download")
     def test_hf_hub_download_legacy(self):
         filepath = hf_hub_download(
             DUMMY_MODEL_ID,

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -400,7 +400,6 @@ class CachedDownloadTests(unittest.TestCase):
             filepath = hf_hub_download(DUMMY_RENAMED_OLD_MODEL_ID, "config.json", cache_dir=tmpdir)
             self.assertTrue(os.path.exists(filepath))
 
-    @expect_deprecation("cached_download")
     def test_download_from_a_renamed_repo_with_cached_download(self):
         """Checks `cached_download` works also on a renamed repo.
 
@@ -536,7 +535,6 @@ class CachedDownloadTests(unittest.TestCase):
         )
 
     @expect_deprecation("hf_hub_download")
-    @expect_deprecation("filename_to_url")
     def test_hf_hub_download_legacy(self):
         filepath = hf_hub_download(
             DUMMY_MODEL_ID,


### PR DESCRIPTION
From a suggestion from @julien-c. It's not used since Aug 2022 so time to remove it for real I think? :) 

This PR deprecates:
- `filename_to_url`
- `url_to_filename`
- `cached_download`
- `legacy_cache_layout` parameter

Deprecation is expected for release 0.26.

I took care of fixing HF libraries that had remaining occurrences. None of them were in highly-used part of the code anyway.
- https://github.com/huggingface/tokenizers/pull/1547
- https://github.com/huggingface/transformers/pull/31284
- https://github.com/huggingface/diffusers/pull/8419