### PR TITLE
Fix Repository if whoami call doesn't return an email

### DIFF
--- a/src/huggingface_hub/repository.py
+++ b/src/huggingface_hub/repository.py
@@ -542,10 +542,10 @@ class Repository:
             user = self.client.whoami(self.huggingface_token)
 
             if git_email is None:
-                git_email = user["email"]
+                git_email = user.get("email")
 
             if git_user is None:
-                git_user = user["fullname"]
+                git_user = user.get("fullname")
 
         if git_user is not None or git_email is not None:
             self.git_config_username_and_email(git_user, git_email)


### PR DESCRIPTION
Better to do `whoami().get("email")` since this field is not guaranteed to be returned. It depends on token's permission which can be restricted in case of finegrained token or OAuth token.

First reported on [HF Forum](https://discuss.huggingface.co/t/why-am-i-getting-keyerror-email/89188).