### PR TITLE
Support `resource_group_id` in `create_repo`

### DIFF
--- a/docs/source/en/guides/repository.md
+++ b/docs/source/en/guides/repository.md
@@ -61,6 +61,8 @@ When you create a repository, you can set your repository visibility with the `p
 
 If you want to change the repository visibility at a later time, you can use the [`update_repo_visibility`] function.
 
+If you are part of an organization with an Enterprise plan, you can create a repo in a specific resource group by passing `resource_group_id` as parameter. Resource groups are a security feature to control which members from your org can access a given resource. You can get the resource group ID by copying it from your org settings page url on the Hub (e.g. `"https://huggingface.co/organizations/huggingface/settings/resource-groups/66670e5163145ca562cb1988"` => `"66670e5163145ca562cb1988"`). For more details about resource group, check out this [guide](https://huggingface.co/docs/hub/en/security-resource-groups).
+
 ### Delete a repository
 
 Delete a repository with [`delete_repo`]. Make sure you want to delete a repository because this is an irreversible process!

--- a/docs/source/en/guides/repository.md
+++ b/docs/source/en/guides/repository.md
@@ -61,7 +61,11 @@ When you create a repository, you can set your repository visibility with the `p
 
 If you want to change the repository visibility at a later time, you can use the [`update_repo_visibility`] function.
 
-If you are part of an organization with an Enterprise plan, you can create a repo in a specific resource group by passing `resource_group_id` as parameter. Resource groups are a security feature to control which members from your org can access a given resource. You can get the resource group ID by copying it from your org settings page url on the Hub (e.g. `"https://huggingface.co/organizations/huggingface/settings/resource-groups/66670e5163145ca562cb1988"` => `"66670e5163145ca562cb1988"`). For more details about resource group, check out this [guide](https://huggingface.co/docs/hub/en/security-resource-groups).
+<Tip>
+
+If you are part of an organization with an Enterprise plan, you can create a repo in a specific resource group by passing `resource_group_id` as parameter in [`create_repo`]. Resource groups are a security feature to control which members from your org can access a given resource. You can get the resource group ID by copying it from your org settings page url on the Hub (e.g. `"https://huggingface.co/organizations/huggingface/settings/resource-groups/66670e5163145ca562cb1988"` => `"66670e5163145ca562cb1988"`). For more details about resource group, check out this [guide](https://huggingface.co/docs/hub/en/security-resource-groups).
+
+</Tip>
 
 ### Delete a repository
 

--- a/docs/source/en/guides/repository.md
+++ b/docs/source/en/guides/repository.md
@@ -63,7 +63,7 @@ If you want to change the repository visibility at a later time, you can use the
 
 <Tip>
 
-If you are part of an organization with an Enterprise plan, you can create a repo in a specific resource group by passing `resource_group_id` as parameter in [`create_repo`]. Resource groups are a security feature to control which members from your org can access a given resource. You can get the resource group ID by copying it from your org settings page url on the Hub (e.g. `"https://huggingface.co/organizations/huggingface/settings/resource-groups/66670e5163145ca562cb1988"` => `"66670e5163145ca562cb1988"`). For more details about resource group, check out this [guide](https://huggingface.co/docs/hub/en/security-resource-groups).
+If you are part of an organization with an Enterprise plan, you can create a repo in a specific resource group by passing `resource_group_id` as parameter to [`create_repo`]. Resource groups are a security feature to control which members from your org can access a given resource. You can get the resource group ID by copying it from your org settings page url on the Hub (e.g. `"https://huggingface.co/organizations/huggingface/settings/resource-groups/66670e5163145ca562cb1988"` => `"66670e5163145ca562cb1988"`). For more details about resource group, check out this [guide](https://huggingface.co/docs/hub/en/security-resource-groups).
 
 </Tip>
 

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -3089,6 +3089,7 @@ class HfApi:
         private: bool = False,
         repo_type: Optional[str] = None,
         exist_ok: bool = False,
+        resource_group_id: Optional[str] = None,
         space_sdk: Optional[str] = None,
         space_hardware: Optional[SpaceHardware] = None,
         space_storage: Optional[SpaceStorage] = None,
@@ -3115,6 +3116,11 @@ class HfApi:
                 `None`.
             exist_ok (`bool`, *optional*, defaults to `False`):
                 If `True`, do not raise an error if repo already exists.
+            resource_group_id (`str`, *optional*):
+                Resource group in which to create the repo. Resource groups is only available for organizations and
+                allow to define which members of the organization can access the resource. The ID of a resource group
+                can be found in the URL of the resource's page on the Hub (e.g. `"66670e5163145ca562cb1988"`).
+                To learn more about resource groups, see https://huggingface.co/docs/hub/en/security-resource-groups.
             space_sdk (`str`, *optional*):
                 Choice of SDK to use if repo_type is "space". Can be "streamlit", "gradio", "docker", or "static".
             space_hardware (`SpaceHardware` or `str`, *optional*):
@@ -3182,8 +3188,11 @@ class HfApi:
             # Testing purposes only.
             # See https://github.com/huggingface/huggingface_hub/pull/733/files#r820604472
             json["lfsmultipartthresh"] = self._lfsmultipartthresh  # type: ignore
-        headers = self._build_hf_headers(token=token)
 
+        if resource_group_id is not None:
+            json["resourceGroupId"] = resource_group_id
+
+        headers = self._build_hf_headers(token=token)
         while True:
             r = get_session().post(path, headers=headers, json=json)
             if r.status_code == 409 and "Cannot create repo: another conflicting operation is in progress" in r.text:


### PR DESCRIPTION
Related to [slack thread](https://huggingface.slack.com/archives/C02EMARJ65P/p1717716797309859) (private). cc @nbroad1881 @coyotte508 

Resource groups is a Enterprise feature that allows orgs to manage which members have access to a resource. This PR adds support for `resource_group_id: Optional[str]` in `create_repo`. When passed, the repo will be created inside the corresponding resource group. Check out https://huggingface.co/docs/hub/en/security-resource-groups for more details about resource groups.