### PR TITLE
Support `expand` parameter in `xxx_info` and `list_xxxs` (model/dataset/Space)

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -166,6 +166,26 @@ ExpandModelProperty_T = Literal[
     "widgetData",
 ]
 
+ExpandDatasetProperty_T = Literal[
+    "author",
+    "cardData",
+    "citation",
+    "createdAt",
+    "disabled",
+    "description",
+    "downloads",
+    "downloadsAllTime",
+    "gated",
+    "gitalyUid",
+    "lastModified",
+    "likes",
+    "paperswithcode_id",
+    "private",
+    "siblings",
+    "sha",
+    "tags",
+]
+
 USERNAME_PLACEHOLDER = "hf_user"
 _REGEX_DISCUSSION_URL = re.compile(r".*/discussions/(\d+)$")
 
@@ -827,6 +847,8 @@ class DatasetInfo:
             If so, whether there is manual or automatic approval.
         downloads (`int`):
             Number of downloads of the dataset over the last 30 days.
+        downloads_all_time (`int`):
+            Cumulated number of downloads of the model since its creation.
         likes (`int`):
             Number of likes of the dataset.
         tags (`List[str]`):
@@ -842,13 +864,14 @@ class DatasetInfo:
     sha: Optional[str]
     created_at: Optional[datetime]
     last_modified: Optional[datetime]
-    private: bool
+    private: Optional[bool]
     gated: Optional[Literal["auto", "manual", False]]
     disabled: Optional[bool]
-    downloads: int
-    likes: int
+    downloads: Optional[int]
+    downloads_all_time: Optional[int]
+    likes: Optional[int]
     paperswithcode_id: Optional[str]
-    tags: List[str]
+    tags: Optional[List[str]]
     card_data: Optional[DatasetCardData]
     siblings: Optional[List[RepoSibling]]
 
@@ -860,13 +883,14 @@ class DatasetInfo:
         self.created_at = parse_datetime(created_at) if created_at else None
         last_modified = kwargs.pop("lastModified", None) or kwargs.pop("last_modified", None)
         self.last_modified = parse_datetime(last_modified) if last_modified else None
-        self.private = kwargs.pop("private")
+        self.private = kwargs.pop("private", None)
         self.gated = kwargs.pop("gated", None)
         self.disabled = kwargs.pop("disabled", None)
-        self.downloads = kwargs.pop("downloads")
-        self.likes = kwargs.pop("likes")
+        self.downloads = kwargs.pop("downloads", None)
+        self.downloads_all_time = kwargs.pop("downloadsAllTime", None)
+        self.likes = kwargs.pop("likes", None)
         self.paperswithcode_id = kwargs.pop("paperswithcode_id", None)
-        self.tags = kwargs.pop("tags")
+        self.tags = kwargs.pop("tags", None)
         card_data = kwargs.pop("cardData", None) or kwargs.pop("card_data", None)
         self.card_data = (
             DatasetCardData(**card_data, ignore_metadata_errors=True) if isinstance(card_data, dict) else card_data
@@ -1717,6 +1741,7 @@ class HfApi:
     def list_datasets(
         self,
         *,
+        # Search-query parameter
         filter: Union[str, Iterable[str], None] = None,
         author: Optional[str] = None,
         benchmark: Optional[Union[str, List[str]]] = None,
@@ -1729,9 +1754,12 @@ class HfApi:
         task_categories: Optional[Union[str, List[str]]] = None,
         task_ids: Optional[Union[str, List[str]]] = None,
         search: Optional[str] = None,
+        # Sorting and pagination parameters
         sort: Optional[Union[Literal["last_modified"], str]] = None,
         direction: Optional[Literal[-1]] = None,
         limit: Optional[int] = None,
+        # Additional data to fetch
+        expand: Optional[List[ExpandDatasetProperty_T]] = None,
         full: Optional[bool] = None,
         token: Union[bool, str, None] = None,
     ) -> Iterable[DatasetInfo]:
@@ -1784,6 +1812,10 @@ class HfApi:
             limit (`int`, *optional*):
                 The limit on the number of datasets fetched. Leaving this option
                 to `None` fetches all datasets.
+            expand (`List[ExpandDatasetProperty_T]`, *optional*):
+                List properties to return in the response. When used, only the properties in the list will be returned.
+                This parameter cannot be used if `full` is passed.
+                Possible values are `"author"`, `"cardData"`, `"citation"`, `"createdAt"`, `"disabled"`, `"description"`, `"downloads"`, `"downloadsAllTime"`, `"gated"`, `"gitalyUid"`, `"lastModified"`, `"likes"`, `"paperswithcode_id"`, `"private"`, `"siblings"`, `"sha"` and `"tags"`.
             full (`bool`, *optional*):
                 Whether to fetch all dataset data, including the `last_modified`,
                 the `card_data` and  the files. Can contain useful information such as the
@@ -1835,6 +1867,9 @@ class HfApi:
         >>> api.list_datasets(search="text", author="google")
         ```
         """
+        if expand and full:
+            raise ValueError("`expand` cannot be used if `full` is passed.")
+
         path = f"{self.endpoint}/api/datasets"
         headers = self._build_hf_headers(token=token)
         params: Dict[str, Any] = {}
@@ -1883,6 +1918,10 @@ class HfApi:
             params["direction"] = direction
         if limit is not None:
             params["limit"] = limit
+
+        # Request additional data
+        if expand:
+            params["expand"] = expand
         if full:
             params["full"] = True
 
@@ -2310,6 +2349,7 @@ class HfApi:
         revision: Optional[str] = None,
         timeout: Optional[float] = None,
         files_metadata: bool = False,
+        expand: Optional[List[ExpandDatasetProperty_T]] = None,
         token: Union[bool, str, None] = None,
     ) -> DatasetInfo:
         """
@@ -2329,6 +2369,10 @@ class HfApi:
             files_metadata (`bool`, *optional*):
                 Whether or not to retrieve metadata for files in the repository
                 (size, LFS metadata, etc). Defaults to `False`.
+            expand (`List[ExpandDatasetProperty_T]`, *optional*):
+                List properties to return in the response. When used, only the properties in the list will be returned.
+                This parameter cannot be used if `files_metadata` is passed.
+                Possible values are `"author"`, `"cardData"`, `"citation"`, `"createdAt"`, `"disabled"`, `"description"`, `"downloads"`, `"downloadsAllTime"`, `"gated"`, `"gitalyUid"`, `"lastModified"`, `"likes"`, `"paperswithcode_id"`, `"private"`, `"siblings"`, `"sha"` and `"tags"`.
             token (Union[bool, str, None], optional):
                 A valid user access token (string). Defaults to the locally saved
                 token, which is the recommended method for authentication (see
@@ -2350,15 +2394,20 @@ class HfApi:
 
         </Tip>
         """
+        if expand and files_metadata:
+            raise ValueError("`expand` cannot be used if `files_metadata` is set.")
+
         headers = self._build_hf_headers(token=token)
         path = (
             f"{self.endpoint}/api/datasets/{repo_id}"
             if revision is None
             else (f"{self.endpoint}/api/datasets/{repo_id}/revision/{quote(revision, safe='')}")
         )
-        params = {}
+        params: Dict = {}
         if files_metadata:
             params["blobs"] = True
+        if expand:
+            params["expand"] = expand
 
         r = get_session().get(path, headers=headers, timeout=timeout, params=params)
         hf_raise_for_status(r)
@@ -2437,6 +2486,7 @@ class HfApi:
         repo_type: Optional[str] = None,
         timeout: Optional[float] = None,
         files_metadata: bool = False,
+        expand: Optional[Union[ExpandModelProperty_T, ExpandDatasetProperty_T]] = None,
         token: Union[bool, str, None] = None,
     ) -> Union[ModelInfo, DatasetInfo, SpaceInfo]:
         """
@@ -2454,6 +2504,10 @@ class HfApi:
                 `None` or `"model"` if getting repository info from a model. Default is `None`.
             timeout (`float`, *optional*):
                 Whether to set a timeout for the request to the Hub.
+            expand (`ExpandModelProperty_T` or `ExpandDatasetProperty_T`, *optional*):
+                List properties to return in the response. When used, only the properties in the list will be returned.
+                This parameter cannot be used if `files_metadata` is passed.
+                For an exhaustive list of available properties, check out [`model_info`], [`dataset_info`] or [`space_info`].
             files_metadata (`bool`, *optional*):
                 Whether or not to retrieve metadata for files in the repository
                 (size, LFS metadata, etc). Defaults to `False`.
@@ -2493,6 +2547,7 @@ class HfApi:
             revision=revision,
             token=token,
             timeout=timeout,
+            expand=expand,
             files_metadata=files_metadata,
         )
 

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -55,6 +55,7 @@ from huggingface_hub.hf_api import (
     Collection,
     CommitInfo,
     DatasetInfo,
+    ExpandDatasetProperty_T,
     ExpandModelProperty_T,
     MetricInfo,
     ModelInfo,
@@ -1807,6 +1808,36 @@ class HfApiPublicProductionTest(unittest.TestCase):
         for dataset in datasets:
             assert "wikipedia" in dataset.id.lower()
 
+    def test_list_datasets_expand_author(self):
+        # Only the selected field is returned
+        datasets = list(self._api.list_datasets(expand=["author"], limit=5))
+        for dataset in datasets:
+            assert dataset.author is not None
+            assert dataset.id is not None
+            assert dataset.downloads is None
+            assert dataset.created_at is None
+            assert dataset.last_modified is None
+
+    def test_list_datasets_expand_multiple(self):
+        # Only the selected fields are returned
+        datasets = list(self._api.list_datasets(expand=["author", "downloadsAllTime", "gitalyUid"], limit=5))
+        for dataset in datasets:
+            assert dataset.author is not None
+            assert dataset.downloads_all_time is not None
+            assert dataset.downloads is None
+            assert dataset.gitalyUid is not None  # not a field except if requested explicitly
+
+    def test_list_datasets_expand_unexpected_value(self):
+        # Unexpected value => HTTP 400
+        with self.assertRaises(HfHubHTTPError) as cm:
+            list(self._api.list_datasets(expand=["foo"]))
+        assert cm.exception.response.status_code == 400
+
+    def test_list_datasets_expand_cannot_be_used_with_full(self):
+        # `expand` cannot be used with `full`
+        with self.assertRaises(ValueError):
+            next(self._api.list_datasets(expand=["author"], full=True))
+
     def test_filter_datasets_with_card_data(self):
         assert any(dataset.card_data is not None for dataset in self._api.list_datasets(full=True, limit=50))
         assert all(dataset.card_data is None for dataset in self._api.list_datasets(full=False, limit=50))
@@ -1841,13 +1872,44 @@ class HfApiPublicProductionTest(unittest.TestCase):
         """Check requested metadata has been received from the server."""
         at_least_one_lfs = False
         for file in files:
-            self.assertTrue(isinstance(file.blob_id, str))
-            self.assertTrue(isinstance(file.size, int))
+            assert isinstance(file.blob_id, str)
+            assert isinstance(file.size, int)
             if file.lfs is not None:
                 at_least_one_lfs = True
-                self.assertTrue(isinstance(file.lfs, dict))
-                self.assertTrue("sha256" in file.lfs)
-        self.assertTrue(at_least_one_lfs)
+                assert isinstance(file.lfs, dict)
+                assert "sha256" in file.lfs
+        assert at_least_one_lfs
+
+    def test_dataset_info_expand_author(self):
+        # Only the selected field is returned
+        dataset = self._api.dataset_info(repo_id="HuggingFaceH4/no_robots", expand=["author"])
+        assert dataset.author == "HuggingFaceH4"
+        assert dataset.downloads is None
+        assert dataset.created_at is None
+        assert dataset.last_modified is None
+
+    def test_dataset_info_expand_multiple(self):
+        # Only the selected fields are returned
+        dataset = self._api.dataset_info(
+            repo_id="HuggingFaceH4/no_robots", expand=["author", "downloadsAllTime", "gitalyUid"]
+        )
+        assert dataset.author == "HuggingFaceH4"
+        assert dataset.downloads is None
+        assert dataset.downloads_all_time is not None
+        assert dataset.gitalyUid is not None  # not a field except if requested explicitly
+        assert dataset.created_at is None
+        assert dataset.last_modified is None
+
+    def test_dataset_info_expand_unexpected_value(self):
+        # Unexpected value => HTTP 400
+        with self.assertRaises(HfHubHTTPError) as cm:
+            self._api.dataset_info("HuggingFaceH4/no_robots", expand=["foo"])
+        assert cm.exception.response.status_code == 400
+
+    def test_dataset_info_expand_cannot_be_used_with_files_metadata(self):
+        # `expand` cannot be used with other `files_metadata`
+        with self.assertRaises(ValueError):
+            self._api.dataset_info("HuggingFaceH4/no_robots", expand=["author"], files_metadata=True)
 
     def test_space_info(self) -> None:
         space = self._api.space_info(repo_id="HuggingFaceH4/zephyr-chat")
@@ -3843,28 +3905,40 @@ class WebhookApiTest(HfApiCommonTest):
 
 
 class TestExpandPropertyType(HfApiCommonTest):
-    @use_tmp_repo()
+    @use_tmp_repo(repo_type="model")
     def test_expand_model_property_type_is_up_to_date(self, repo_url: RepoUrl):
+        self._check_expand_property_is_up_to_date(repo_url)
+
+    @use_tmp_repo(repo_type="dataset")
+    def test_expand_dataset_property_type_is_up_to_date(self, repo_url: RepoUrl):
+        self._check_expand_property_is_up_to_date(repo_url)
+
+    def _check_expand_property_is_up_to_date(self, repo_url: RepoUrl):
+        repo_id = repo_url.repo_id
+        repo_type = repo_url.repo_type
+        property_type = ExpandModelProperty_T if repo_type == "model" else ExpandDatasetProperty_T
+        property_type_name = "ExpandModelProperty_T" if repo_type == "model" else "ExpandDatasetProperty_T"
+
         try:
-            self._api.model_info(repo_id=repo_url.repo_id, expand=["does_not_exist"])
+            self._api.repo_info(repo_id=repo_id, repo_type=repo_type, expand=["does_not_exist"])
             raise Exception("Should have raised an exception")
         except HfHubHTTPError as e:
             assert e.response.status_code == 400
             message = e.response.json()["error"]
 
         assert message.startswith('"expand" must be one of ')
-        defined_args = set(get_args(ExpandModelProperty_T))
+        defined_args = set(get_args(property_type))
         expected_args = set(message.replace('"expand" must be one of ', "").strip("[]").split(", "))
 
         if defined_args != expected_args:
             should_be_removed = defined_args - expected_args
             should_be_added = expected_args - defined_args
 
-            msg = "Literal `ExpandModelProperty_T` is outdated! This is probably due to a server-side update."
+            msg = f"Literal `{property_type_name}` is outdated! This is probably due to a server-side update."
             if should_be_removed:
                 msg += f"\nArg(s) not supported anymore: {', '.join(should_be_removed)}"
             if should_be_added:
                 msg += f"\nNew arg(s) to support: {', '.join(should_be_added)}"
-            msg += "\nPlease open a PR to update `./src/huggingface_hub/hf_api.py` accordingly. `ExpandModelProperty_T` should be updated as well as `model_info` and `list_models` docstrings."
+            msg += f"\nPlease open a PR to update `./src/huggingface_hub/hf_api.py` accordingly. `{property_type_name}` should be updated as well as `{repo_type}_info` and `list_{repo_type}s` docstrings."
             msg += "\nThanks you in advance!"
             raise ValueError(msg)

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -436,8 +436,13 @@ def use_tmp_repo(repo_type: str = "model") -> Callable[[T], T]:
         def _inner(*args, **kwargs):
             self = args[0]
             assert isinstance(self, unittest.TestCase)
+            create_repo_kwargs = {}
+            if repo_type == "space":
+                create_repo_kwargs["space_sdk"] = "gradio"
 
-            repo_url = self._api.create_repo(repo_id=repo_name(prefix=repo_type), repo_type=repo_type)
+            repo_url = self._api.create_repo(
+                repo_id=repo_name(prefix=repo_type), repo_type=repo_type, **create_repo_kwargs
+            )
             try:
                 return test_fn(*args, **kwargs, repo_url=repo_url)
             finally:


### PR DESCRIPTION
Solve https://github.com/huggingface/huggingface_hub/issues/2325.

**EDIT:** added support for `model_info`/`dataset_info`/`space_info` as well as `list_models`/`list_datasets`/`list_spaces`. Added tests and docstrings for all of them.

---

First draft of what we discussed in https://github.com/huggingface/huggingface_hub/issues/2325#issuecomment-2162407468 cc @osanseviero @julien-c . In the end I went for "put everything in `ModelInfo` and have all attributes optional". For now I only implemented `expand` for models helpers but it can be easily extended to datasets/spaces.

In order to better document the available parameters, I used a `Literal` type annotations listing all valid keys. Since it's "just" a type annotation, passing any string will still be backward compatible in the future as long as the server handles it. The cons is that the list has to be manually maintained to stay up to date with server changes (not happening very often). I have added a test for that. At least an update is pushed server-side, we will notice it in our CI runs. 

@osanseviero @julien-c let me know if you are opinionated on something, otherwise I'll continue with it :)