### PR TITLE
print actual error message when failing to load a submodule

### DIFF
--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -503,10 +503,18 @@ def _attach(package_name, submodules=None, submod_attrs=None):
 
     def __getattr__(name):
         if name in submodules:
-            return importlib.import_module(f"{package_name}.{name}")
+            try:
+                return importlib.import_module(f"{package_name}.{name}")
+            except Exception as e:
+                print(f"Error importing {package_name}.{name}: {e}")
+                raise
         elif name in attr_to_modules:
             submod_path = f"{package_name}.{attr_to_modules[name]}"
-            submod = importlib.import_module(submod_path)
+            try:
+                submod = importlib.import_module(submod_path)
+            except Exception as e:
+                print(f"Error importing {submod_path}: {e}")
+                raise
             attr = getattr(submod, name)
 
             # If the attribute lives in a file (module) with the same


### PR DESCRIPTION
Great confusion in #2089 due to the actual underlying error being hidden behind importlib catching. This PR prints the error to console to help the user figure out what is going wrong.
