### PR TITLE
[HfFileSystem] Faster `fs.walk()`

### DIFF
--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -403,6 +403,12 @@ class HfFileSystem(fsspec.AbstractFileSystem):
                 out.append(cache_path_info)
         return out
 
+    def walk(self, path, **kwargs):
+        # Set expand_info=False by default to get a x10 speed boost
+        kwargs = {"expand_info": kwargs.get("detail", False), **kwargs}
+        path = self.resolve_path(path, revision=kwargs.get("revision")).unresolve()
+        yield from super().walk(path, **kwargs)
+
     def glob(self, path, **kwargs):
         # Set expand_info=False by default to get a x10 speed boost
         kwargs = {"expand_info": kwargs.get("detail", False), **kwargs}

--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -403,11 +403,11 @@ class HfFileSystem(fsspec.AbstractFileSystem):
                 out.append(cache_path_info)
         return out
 
-    def walk(self, path, **kwargs):
+    def walk(self, path, *args, **kwargs):
         # Set expand_info=False by default to get a x10 speed boost
         kwargs = {"expand_info": kwargs.get("detail", False), **kwargs}
         path = self.resolve_path(path, revision=kwargs.get("revision")).unresolve()
-        yield from super().walk(path, **kwargs)
+        yield from super().walk(path, *args, **kwargs)
 
     def glob(self, path, **kwargs):
         # Set expand_info=False by default to get a x10 speed boost


### PR DESCRIPTION
...by using `expand_info=False` by default (same logic as `fs.glob()`)

before:

```python
In [1]: from huggingface_hub import HfFileSystem

In [2]: %time _ = list(HfFileSystem().walk("hf://datasets/allenai/c4/en"))
CPU times: user 275 ms, sys: 27.6 ms, total: 302 ms
Wall time: 11.6 s
```

after:

```python
In [1]: from huggingface_hub import HfFileSystem

In [2]: %time _ = list(HfFileSystem().walk("hf://datasets/allenai/c4/en"))
CPU times: user 176 ms, sys: 22.4 ms, total: 198 ms
Wall time: 3.25 s
```