### PR TITLE
`torch`  extra requires for `safetensors` dep

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ extras["inference"] = [
 
 extras["torch"] = [
     "torch",
-    "safetensors",
+    "safetensors[torch]",
 ]
 extras["hf_transfer"] = [
     "hf_transfer>=0.1.4",  # Pin for progress bars


### PR DESCRIPTION
This change is needed, otherwise numpy won't be installed. See https://github.com/huggingface/safetensors/blob/079781fd0dc455ba0fe851e2b4507c33d0c0d407/bindings/python/pyproject.toml#L35