### PR TITLE
Use extended path on Windows when downloading to local dir

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -88,7 +88,7 @@ jobs:
         working-directory: ./src # For code coverage to work
         run: |
           source ../.venv/bin/activate
-          PYTEST="python -m pytest --cov=./huggingface_hub --cov-report=xml:../coverage.xml --vcr-record=none --reruns 5 --reruns-delay 1 --only-rerun '(OSError|Timeout|HTTPError.*502|HTTPError.*504||not less than or equal to 0.01)'"
+          PYTEST="python -m pytest --cov=./huggingface_hub --cov-report=xml:../coverage.xml --vcr-record=none --reruns 8 --reruns-delay 2 --only-rerun '(OSError|Timeout|HTTPError.*502|HTTPError.*504||not less than or equal to 0.01)'"
 
           case "${{ matrix.test_name }}" in
 
@@ -172,7 +172,7 @@ jobs:
         working-directory: ./src # For code coverage to work
         run: |
           ..\.venv\Scripts\activate
-          python -m pytest -n 4 --cov=./huggingface_hub --cov-report=xml:../coverage.xml --vcr-record=none --reruns 5 --reruns-delay 1 --only-rerun '(OSError|Timeout|HTTPError.*502|HTTPError.*504|not less than or equal to 0.01)' ../tests
+          python -m pytest -n 4 --cov=./huggingface_hub --cov-report=xml:../coverage.xml --vcr-record=none --reruns 8 --reruns-delay 2 --only-rerun '(OSError|Timeout|HTTPError.*502|HTTPError.*504|not less than or equal to 0.01)' ../tests
 
       # Upload code coverage
       - name: Upload coverage reports to Codecov with GitHub Action

--- a/docs/source/en/package_reference/serialization.md
+++ b/docs/source/en/package_reference/serialization.md
@@ -8,7 +8,11 @@ rendered properly in your Markdown viewer.
 
 ## Save torch state dict
 
-The main helper of the `serialization` module takes a state dictionary as input (e.g. a mapping between layer names and related tensors), splits it into several shards while creating a proper index in the process and save everything to disk. At the moment, only `torch` tensors are supported. Under the hood, it delegates the logic to split the state dictionary to [`split_torch_state_dict_into_shards`].
+The main helper of the `serialization` module takes a torch `nn.Module` as input and saves it to disk. It handles the logic to save shared tensors (see [safetensors explanation](https://huggingface.co/docs/safetensors/torch_shared_tensors)) as well as logic to split the state dictionary into shards, using [`split_torch_state_dict_into_shards`] under the hood. At the moment, only `torch` framework is supported.
+
+If you want to save a state dictionary (e.g. a mapping between layer names and related tensors) instead of a `nn.Module`, you can use [`save_torch_state_dict`] which provides the same features. This is useful for example if you want to apply custom logic to the state dict before saving it.
+
+[[autodoc]] huggingface_hub.save_torch_model
 
 [[autodoc]] huggingface_hub.save_torch_state_dict
 
@@ -35,3 +39,7 @@ This is the underlying factory from which each framework-specific helper is deri
 ### get_torch_storage_id
 
 [[autodoc]] huggingface_hub.get_torch_storage_id
+
+### get_torch_storage_size
+
+[[autodoc]] huggingface_hub.get_torch_storage_size

--- a/setup.py
+++ b/setup.py
@@ -63,13 +63,14 @@ extras["testing"] = (
     + [
         "jedi",
         "Jinja2",
-        "pytest>=8.1.1",
+        "pytest>=8.1.1,<8.2.2",  # at least until 8.2.3 is released with https://github.com/pytest-dev/pytest/pull/12436
         "pytest-cov",
         "pytest-env",
         "pytest-xdist",
         "pytest-vcr",  # to mock Inference
         "pytest-asyncio",  # for AsyncInferenceClient
         "pytest-rerunfailures",  # to rerun flaky tests in CI
+        "pytest-mock",
         "urllib3<2.0",  # VCR.py broken with urllib3 2.0 (see https://urllib3.readthedocs.io/en/stable/v2-migration-guide.html)
         "soundfile",
         "Pillow",

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ extras["inference"] = [
 
 extras["torch"] = [
     "torch",
-    "safetensors",
+    "safetensors[torch]",
 ]
 extras["hf_transfer"] = [
     "hf_transfer>=0.1.4",  # Pin for progress bars

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -423,7 +423,10 @@ _SUBMOD_ATTRS = {
     ],
     "serialization": [
         "StateDictSplit",
+        "get_tf_storage_size",
         "get_torch_storage_id",
+        "get_torch_storage_size",
+        "save_torch_model",
         "save_torch_state_dict",
         "split_state_dict_into_shards_factory",
         "split_tf_state_dict_into_shards",
@@ -911,7 +914,10 @@ if TYPE_CHECKING:  # pragma: no cover
     from .repository import Repository  # noqa: F401
     from .serialization import (
         StateDictSplit,  # noqa: F401
+        get_tf_storage_size,  # noqa: F401
         get_torch_storage_id,  # noqa: F401
+        get_torch_storage_size,  # noqa: F401
+        save_torch_model,  # noqa: F401
         save_torch_state_dict,  # noqa: F401
         split_state_dict_into_shards_factory,  # noqa: F401
         split_tf_state_dict_into_shards,  # noqa: F401

--- a/src/huggingface_hub/_local_folder.py
+++ b/src/huggingface_hub/_local_folder.py
@@ -182,7 +182,9 @@ def read_download_metadata(local_dir: Path, filename: str) -> Optional[LocalDown
                     )
             except Exception as e:
                 # remove the metadata file if it is corrupted / not the right format
-                logger.warning(f"Invalid metadata file {paths.metadata_path}: {e}. Removing it from disk and continue.")
+                logger.warning(
+                    f"Invalid metadata file {paths.metadata_path}: {e}. Removing it from disk and continue."
+                )
                 try:
                     paths.metadata_path.unlink()
                 except Exception as e:
@@ -191,7 +193,9 @@ def read_download_metadata(local_dir: Path, filename: str) -> Optional[LocalDown
             try:
                 # check if the file exists and hasn't been modified since the metadata was saved
                 stat = paths.file_path.stat()
-                if stat.st_mtime - 1 <= metadata.timestamp:  # allow 1s difference as stat.st_mtime might not be precise
+                if (
+                    stat.st_mtime - 1 <= metadata.timestamp
+                ):  # allow 1s difference as stat.st_mtime might not be precise
                     return metadata
                 logger.info(f"Ignored metadata for '{filename}' (outdated). Will re-compute hash.")
             except FileNotFoundError:

--- a/src/huggingface_hub/_local_folder.py
+++ b/src/huggingface_hub/_local_folder.py
@@ -142,22 +142,10 @@ def get_local_download_paths(local_dir: Path, filename: str) -> LocalDownloadFil
     # Some Windows versions do not allow for paths longer than 255 characters.
     # In this case, we must specify it as an extended path by using the "\\?\" prefix
     if os.name == "nt":
-        if len(os.path.abspath(lock_path)) > 255:
-            file_path = (
-                file_path
-                if str(file_path.absolute()).startswith("\\\\?\\")
-                else Path("\\\\?\\" + os.path.abspath(file_path))
-            )
-            lock_path = (
-                lock_path
-                if str(lock_path.absolute()).startswith("\\\\?\\")
-                else Path("\\\\?\\" + os.path.abspath(lock_path))
-            )
-            metadata_path = (
-                metadata_path
-                if str(metadata_path.absolute()).startswith("\\\\?\\")
-                else Path("\\\\?\\" + os.path.abspath(metadata_path))
-            )
+        if not str(local_dir).startswith("\\\\?\\") and len(os.path.abspath(lock_path)) > 255:
+            file_path = Path("\\\\?\\" + os.path.abspath(file_path))
+            lock_path = Path("\\\\?\\" + os.path.abspath(lock_path))
+            metadata_path = Path("\\\\?\\" + os.path.abspath(metadata_path))
 
     file_path.parent.mkdir(parents=True, exist_ok=True)
     metadata_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1425,6 +1425,10 @@ def _hf_hub_download_to_local_dir(
 
     Method should not be called directly. Please use `hf_hub_download` instead.
     """
+    # Some Windows versions do not allow for paths longer than 255 characters.
+    # In this case, we must specify it as an extended path by using the "\\?\" prefix.
+    if os.name == "nt" and len(os.path.abspath(local_dir)) > 255:
+        local_dir = "\\\\?\\" + os.path.abspath(local_dir)
     local_dir = Path(local_dir)
     paths = get_local_download_paths(local_dir=local_dir, filename=filename)
     local_metadata = read_download_metadata(local_dir=local_dir, filename=filename)

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1425,10 +1425,6 @@ def _hf_hub_download_to_local_dir(
 
     Method should not be called directly. Please use `hf_hub_download` instead.
     """
-    # Some Windows versions do not allow for paths longer than 255 characters.
-    # In this case, we must specify it as an extended path by using the "\\?\" prefix.
-    if os.name == "nt" and len(os.path.abspath(local_dir)) > 255:
-        local_dir = "\\\\?\\" + os.path.abspath(local_dir)
     local_dir = Path(local_dir)
     paths = get_local_download_paths(local_dir=local_dir, filename=filename)
     local_metadata = read_download_metadata(local_dir=local_dir, filename=filename)

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1377,7 +1377,7 @@ def _hf_hub_download_to_cache_dir(
     lock_path = os.path.join(locks_dir, repo_folder_name(repo_id=repo_id, repo_type=repo_type), f"{etag}.lock")
 
     # Some Windows versions do not allow for paths longer than 255 characters.
-    # In this case, we must specify it is an extended path by using the "\\?\" prefix.
+    # In this case, we must specify it as an extended path by using the "\\?\" prefix.
     if os.name == "nt" and len(os.path.abspath(lock_path)) > 255:
         lock_path = "\\\\?\\" + os.path.abspath(lock_path)
 
@@ -1425,6 +1425,10 @@ def _hf_hub_download_to_local_dir(
 
     Method should not be called directly. Please use `hf_hub_download` instead.
     """
+    # Some Windows versions do not allow for paths longer than 255 characters.
+    # In this case, we must specify it as an extended path by using the "\\?\" prefix.
+    if os.name == "nt" and len(os.path.abspath(local_dir)) > 255:
+        local_dir = "\\\\?\\" + os.path.abspath(local_dir)
     local_dir = Path(local_dir)
     paths = get_local_download_paths(local_dir=local_dir, filename=filename)
     local_metadata = read_download_metadata(local_dir=local_dir, filename=filename)

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1226,10 +1226,11 @@ def hf_hub_download(
             filename=filename,
             revision=revision,
             # HTTP info
-            proxies=proxies,
+            endpoint=endpoint,
             etag_timeout=etag_timeout,
             headers=headers,
-            endpoint=endpoint,
+            proxies=proxies,
+            token=token,
             # Additional options
             cache_dir=cache_dir,
             force_download=force_download,
@@ -1245,10 +1246,11 @@ def hf_hub_download(
             repo_type=repo_type,
             revision=revision,
             # HTTP info
+            endpoint=endpoint,
+            etag_timeout=etag_timeout,
             headers=headers,
             proxies=proxies,
-            etag_timeout=etag_timeout,
-            endpoint=endpoint,
+            token=token,
             # Additional options
             local_files_only=local_files_only,
             force_download=force_download,
@@ -1265,10 +1267,11 @@ def _hf_hub_download_to_cache_dir(
     repo_type: str,
     revision: str,
     # HTTP info
+    endpoint: Optional[str],
+    etag_timeout: float,
     headers: Dict[str, str],
     proxies: Optional[Dict],
-    etag_timeout: float,
-    endpoint: Optional[str],
+    token: Optional[Union[bool, str]],
     # Additional options
     local_files_only: bool,
     force_download: bool,
@@ -1306,6 +1309,7 @@ def _hf_hub_download_to_cache_dir(
         proxies=proxies,
         etag_timeout=etag_timeout,
         headers=headers,
+        token=token,
         local_files_only=local_files_only,
         storage_folder=storage_folder,
         relative_filename=relative_filename,
@@ -1407,10 +1411,11 @@ def _hf_hub_download_to_local_dir(
     filename: str,
     revision: str,
     # HTTP info
-    proxies: Optional[Dict],
+    endpoint: Optional[str],
     etag_timeout: float,
     headers: Dict[str, str],
-    endpoint: Optional[str],
+    proxies: Optional[Dict],
+    token: Union[bool, str, None],
     # Additional options
     cache_dir: str,
     force_download: bool,
@@ -1444,6 +1449,7 @@ def _hf_hub_download_to_local_dir(
         proxies=proxies,
         etag_timeout=etag_timeout,
         headers=headers,
+        token=token,
         local_files_only=local_files_only,
     )
 
@@ -1695,6 +1701,7 @@ def _get_metadata_or_catch_error(
     proxies: Optional[Dict],
     etag_timeout: Optional[float],
     headers: Dict[str, str],  # mutated inplace!
+    token: Union[bool, str, None],
     local_files_only: bool,
     relative_filename: Optional[str] = None,  # only used to store `.no_exists` in cache
     storage_folder: Optional[str] = None,  # only used to store `.no_exists` in cache
@@ -1737,7 +1744,9 @@ def _get_metadata_or_catch_error(
     if not local_files_only:
         try:
             try:
-                metadata = get_hf_file_metadata(url=url, proxies=proxies, timeout=etag_timeout, headers=headers)
+                metadata = get_hf_file_metadata(
+                    url=url, proxies=proxies, timeout=etag_timeout, headers=headers, token=token
+                )
             except EntryNotFoundError as http_error:
                 if storage_folder is not None and relative_filename is not None:
                     # Cache the non-existence of the file

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -140,6 +140,71 @@ from .utils.endpoint_helpers import (
 R = TypeVar("R")  # Return type
 CollectionItemType_T = Literal["model", "dataset", "space", "paper"]
 
+ExpandModelProperty_T = Literal[
+    "author",
+    "cardData",
+    "config",
+    "createdAt",
+    "disabled",
+    "downloads",
+    "downloadsAllTime",
+    "gated",
+    "gitalyUid",
+    "lastModified",
+    "library_name",
+    "likes",
+    "mask_token",
+    "model-index",
+    "pipeline_tag",
+    "private",
+    "safetensors",
+    "sha",
+    "siblings",
+    "spaces",
+    "tags",
+    "transformersInfo",
+    "widgetData",
+]
+
+ExpandDatasetProperty_T = Literal[
+    "author",
+    "cardData",
+    "citation",
+    "createdAt",
+    "disabled",
+    "description",
+    "downloads",
+    "downloadsAllTime",
+    "gated",
+    "gitalyUid",
+    "lastModified",
+    "likes",
+    "paperswithcode_id",
+    "private",
+    "siblings",
+    "sha",
+    "tags",
+]
+
+ExpandSpaceProperty_T = Literal[
+    "author",
+    "cardData",
+    "datasets",
+    "disabled",
+    "gitalyUid",
+    "lastModified",
+    "createdAt",
+    "likes",
+    "private",
+    "runtime",
+    "sdk",
+    "siblings",
+    "sha",
+    "subdomain",
+    "tags",
+    "models",
+]
+
 USERNAME_PLACEHOLDER = "hf_user"
 _REGEX_DISCUSSION_URL = re.compile(r".*/discussions/(\d+)$")
 
@@ -644,6 +709,8 @@ class ModelInfo:
             If so, whether there is manual or automatic approval.
         downloads (`int`):
             Number of downloads of the model over the last 30 days.
+        downloads_all_time (`int`):
+            Cumulated number of downloads of the model since its creation.
         likes (`int`):
             Number of likes of the model.
         library_name (`str`, *optional*):
@@ -678,13 +745,14 @@ class ModelInfo:
     sha: Optional[str]
     created_at: Optional[datetime]
     last_modified: Optional[datetime]
-    private: bool
+    private: Optional[bool]
     gated: Optional[Literal["auto", "manual", False]]
     disabled: Optional[bool]
-    downloads: int
-    likes: int
+    downloads: Optional[int]
+    downloads_all_time: Optional[int]
+    likes: Optional[int]
     library_name: Optional[str]
-    tags: List[str]
+    tags: Optional[List[str]]
     pipeline_tag: Optional[str]
     mask_token: Optional[str]
     card_data: Optional[ModelCardData]
@@ -704,13 +772,14 @@ class ModelInfo:
         self.last_modified = parse_datetime(last_modified) if last_modified else None
         created_at = kwargs.pop("createdAt", None) or kwargs.pop("created_at", None)
         self.created_at = parse_datetime(created_at) if created_at else None
-        self.private = kwargs.pop("private")
+        self.private = kwargs.pop("private", None)
         self.gated = kwargs.pop("gated", None)
         self.disabled = kwargs.pop("disabled", None)
-        self.downloads = kwargs.pop("downloads")
-        self.likes = kwargs.pop("likes")
+        self.downloads = kwargs.pop("downloads", None)
+        self.downloads_all_time = kwargs.pop("downloadsAllTime", None)
+        self.likes = kwargs.pop("likes", None)
         self.library_name = kwargs.pop("library_name", None)
-        self.tags = kwargs.pop("tags")
+        self.tags = kwargs.pop("tags", None)
         self.pipeline_tag = kwargs.pop("pipeline_tag", None)
         self.mask_token = kwargs.pop("mask_token", None)
         card_data = kwargs.pop("cardData", None) or kwargs.pop("card_data", None)
@@ -797,6 +866,8 @@ class DatasetInfo:
             If so, whether there is manual or automatic approval.
         downloads (`int`):
             Number of downloads of the dataset over the last 30 days.
+        downloads_all_time (`int`):
+            Cumulated number of downloads of the model since its creation.
         likes (`int`):
             Number of likes of the dataset.
         tags (`List[str]`):
@@ -812,13 +883,14 @@ class DatasetInfo:
     sha: Optional[str]
     created_at: Optional[datetime]
     last_modified: Optional[datetime]
-    private: bool
+    private: Optional[bool]
     gated: Optional[Literal["auto", "manual", False]]
     disabled: Optional[bool]
-    downloads: int
-    likes: int
+    downloads: Optional[int]
+    downloads_all_time: Optional[int]
+    likes: Optional[int]
     paperswithcode_id: Optional[str]
-    tags: List[str]
+    tags: Optional[List[str]]
     card_data: Optional[DatasetCardData]
     siblings: Optional[List[RepoSibling]]
 
@@ -830,13 +902,14 @@ class DatasetInfo:
         self.created_at = parse_datetime(created_at) if created_at else None
         last_modified = kwargs.pop("lastModified", None) or kwargs.pop("last_modified", None)
         self.last_modified = parse_datetime(last_modified) if last_modified else None
-        self.private = kwargs.pop("private")
+        self.private = kwargs.pop("private", None)
         self.gated = kwargs.pop("gated", None)
         self.disabled = kwargs.pop("disabled", None)
-        self.downloads = kwargs.pop("downloads")
-        self.likes = kwargs.pop("likes")
+        self.downloads = kwargs.pop("downloads", None)
+        self.downloads_all_time = kwargs.pop("downloadsAllTime", None)
+        self.likes = kwargs.pop("likes", None)
         self.paperswithcode_id = kwargs.pop("paperswithcode_id", None)
-        self.tags = kwargs.pop("tags")
+        self.tags = kwargs.pop("tags", None)
         card_data = kwargs.pop("cardData", None) or kwargs.pop("card_data", None)
         self.card_data = (
             DatasetCardData(**card_data, ignore_metadata_errors=True) if isinstance(card_data, dict) else card_data
@@ -929,14 +1002,14 @@ class SpaceInfo:
     sha: Optional[str]
     created_at: Optional[datetime]
     last_modified: Optional[datetime]
-    private: bool
+    private: Optional[bool]
     gated: Optional[Literal["auto", "manual", False]]
     disabled: Optional[bool]
     host: Optional[str]
     subdomain: Optional[str]
-    likes: int
+    likes: Optional[int]
     sdk: Optional[str]
-    tags: List[str]
+    tags: Optional[List[str]]
     siblings: Optional[List[RepoSibling]]
     card_data: Optional[SpaceCardData]
     runtime: Optional[SpaceRuntime]
@@ -951,14 +1024,14 @@ class SpaceInfo:
         self.created_at = parse_datetime(created_at) if created_at else None
         last_modified = kwargs.pop("lastModified", None) or kwargs.pop("last_modified", None)
         self.last_modified = parse_datetime(last_modified) if last_modified else None
-        self.private = kwargs.pop("private")
+        self.private = kwargs.pop("private", None)
         self.gated = kwargs.pop("gated", None)
         self.disabled = kwargs.pop("disabled", None)
         self.host = kwargs.pop("host", None)
         self.subdomain = kwargs.pop("subdomain", None)
-        self.likes = kwargs.pop("likes")
+        self.likes = kwargs.pop("likes", None)
         self.sdk = kwargs.pop("sdk", None)
-        self.tags = kwargs.pop("tags")
+        self.tags = kwargs.pop("tags", None)
         card_data = kwargs.pop("cardData", None) or kwargs.pop("card_data", None)
         self.card_data = (
             SpaceCardData(**card_data, ignore_metadata_errors=True) if isinstance(card_data, dict) else card_data
@@ -1489,6 +1562,7 @@ class HfApi:
     def list_models(
         self,
         *,
+        # Search-query parameter
         filter: Union[str, Iterable[str], None] = None,
         author: Optional[str] = None,
         library: Optional[Union[str, List[str]]] = None,
@@ -1498,15 +1572,18 @@ class HfApi:
         trained_dataset: Optional[Union[str, List[str]]] = None,
         tags: Optional[Union[str, List[str]]] = None,
         search: Optional[str] = None,
+        pipeline_tag: Optional[str] = None,
         emissions_thresholds: Optional[Tuple[float, float]] = None,
+        # Sorting and pagination parameters
         sort: Union[Literal["last_modified"], str, None] = None,
         direction: Optional[Literal[-1]] = None,
         limit: Optional[int] = None,
+        # Additional data to fetch
+        expand: Optional[List[ExpandModelProperty_T]] = None,
         full: Optional[bool] = None,
         cardData: bool = False,
         fetch_config: bool = False,
         token: Union[bool, str, None] = None,
-        pipeline_tag: Optional[str] = None,
     ) -> Iterable[ModelInfo]:
         """
         List models hosted on the Huggingface Hub, given some filters.
@@ -1537,6 +1614,8 @@ class HfApi:
                 as `text-generation` or `spacy`.
             search (`str`, *optional*):
                 A string that will be contained in the returned model ids.
+            pipeline_tag (`str`, *optional*):
+                A string pipeline tag to filter models on the Hub by, such as `summarization`.
             emissions_thresholds (`Tuple`, *optional*):
                 A tuple of two ints or floats representing a minimum and maximum
                 carbon footprint to filter the resulting models with in grams.
@@ -1549,6 +1628,10 @@ class HfApi:
             limit (`int`, *optional*):
                 The limit on the number of models fetched. Leaving this option
                 to `None` fetches all models.
+            expand (`List[ExpandModelProperty_T]`, *optional*):
+                List properties to return in the response. When used, only the properties in the list will be returned.
+                This parameter cannot be used if `full`, `cardData` or `fetch_config` are passed.
+                Possible values are `"author"`, `"cardData"`, `"config"`, `"createdAt"`, `"disabled"`, `"downloads"`, `"downloadsAllTime"`, `"gated"`, `"gitalyUid"`, `"lastModified"`, `"library_name"`, `"likes"`, `"mask_token"`, `"model-index"`, `"pipeline_tag"`, `"private"`, `"safetensors"`, `"sha"`, `"siblings"`, `"spaces"`, `"tags"`, `"transformersInfo"` and `"widgetData"`.
             full (`bool`, *optional*):
                 Whether to fetch all model data, including the `last_modified`,
                 the `sha`, the files and the `tags`. This is set to `True` by
@@ -1565,8 +1648,6 @@ class HfApi:
                 token, which is the recommended method for authentication (see
                 https://huggingface.co/docs/huggingface_hub/quick-start#authentication).
                 To disable authentication, pass `False`.
-            pipeline_tag (`str`, *optional*):
-                A string pipeline tag to filter models on the Hub by, such as `summarization`
 
 
         Returns:
@@ -1603,6 +1684,9 @@ class HfApi:
         >>> api.list_models(search="bert", author="google")
         ```
         """
+        if expand and (full or cardData or fetch_config):
+            raise ValueError("`expand` cannot be used if `full`, `cardData` or `fetch_config` are passed.")
+
         if emissions_thresholds is not None and cardData is None:
             raise ValueError("`emissions_thresholds` were passed without setting `cardData=True`.")
 
@@ -1635,6 +1719,8 @@ class HfApi:
         # Handle other query params
         if author:
             params["author"] = author
+        if pipeline_tag:
+            params["pipeline_tag"] = pipeline_tag
         search_list = []
         if model_name:
             search_list.append(model_name)
@@ -1648,14 +1734,16 @@ class HfApi:
             params["direction"] = direction
         if limit is not None:
             params["limit"] = limit
+
+        # Request additional data
         if full:
             params["full"] = True
         if fetch_config:
             params["config"] = True
         if cardData:
             params["cardData"] = True
-        if pipeline_tag:
-            params["pipeline_tag"] = pipeline_tag
+        if expand:
+            params["expand"] = expand
 
         # `items` is a generator
         items = paginate(path, params=params, headers=headers)
@@ -1672,6 +1760,7 @@ class HfApi:
     def list_datasets(
         self,
         *,
+        # Search-query parameter
         filter: Union[str, Iterable[str], None] = None,
         author: Optional[str] = None,
         benchmark: Optional[Union[str, List[str]]] = None,
@@ -1684,9 +1773,12 @@ class HfApi:
         task_categories: Optional[Union[str, List[str]]] = None,
         task_ids: Optional[Union[str, List[str]]] = None,
         search: Optional[str] = None,
+        # Sorting and pagination parameters
         sort: Optional[Union[Literal["last_modified"], str]] = None,
         direction: Optional[Literal[-1]] = None,
         limit: Optional[int] = None,
+        # Additional data to fetch
+        expand: Optional[List[ExpandDatasetProperty_T]] = None,
         full: Optional[bool] = None,
         token: Union[bool, str, None] = None,
     ) -> Iterable[DatasetInfo]:
@@ -1739,6 +1831,10 @@ class HfApi:
             limit (`int`, *optional*):
                 The limit on the number of datasets fetched. Leaving this option
                 to `None` fetches all datasets.
+            expand (`List[ExpandDatasetProperty_T]`, *optional*):
+                List properties to return in the response. When used, only the properties in the list will be returned.
+                This parameter cannot be used if `full` is passed.
+                Possible values are `"author"`, `"cardData"`, `"citation"`, `"createdAt"`, `"disabled"`, `"description"`, `"downloads"`, `"downloadsAllTime"`, `"gated"`, `"gitalyUid"`, `"lastModified"`, `"likes"`, `"paperswithcode_id"`, `"private"`, `"siblings"`, `"sha"` and `"tags"`.
             full (`bool`, *optional*):
                 Whether to fetch all dataset data, including the `last_modified`,
                 the `card_data` and  the files. Can contain useful information such as the
@@ -1790,6 +1886,9 @@ class HfApi:
         >>> api.list_datasets(search="text", author="google")
         ```
         """
+        if expand and full:
+            raise ValueError("`expand` cannot be used if `full` is passed.")
+
         path = f"{self.endpoint}/api/datasets"
         headers = self._build_hf_headers(token=token)
         params: Dict[str, Any] = {}
@@ -1838,6 +1937,10 @@ class HfApi:
             params["direction"] = direction
         if limit is not None:
             params["limit"] = limit
+
+        # Request additional data
+        if expand:
+            params["expand"] = expand
         if full:
             params["full"] = True
 
@@ -1866,15 +1969,19 @@ class HfApi:
     def list_spaces(
         self,
         *,
+        # Search-query parameter
         filter: Union[str, Iterable[str], None] = None,
         author: Optional[str] = None,
         search: Optional[str] = None,
-        sort: Union[Literal["last_modified"], str, None] = None,
-        direction: Optional[Literal[-1]] = None,
-        limit: Optional[int] = None,
         datasets: Union[str, Iterable[str], None] = None,
         models: Union[str, Iterable[str], None] = None,
         linked: bool = False,
+        # Sorting and pagination parameters
+        sort: Union[Literal["last_modified"], str, None] = None,
+        direction: Optional[Literal[-1]] = None,
+        limit: Optional[int] = None,
+        # Additional data to fetch
+        expand: Optional[List[ExpandSpaceProperty_T]] = None,
         full: Optional[bool] = None,
         token: Union[bool, str, None] = None,
     ) -> Iterable[SpaceInfo]:
@@ -1888,6 +1995,14 @@ class HfApi:
                 A string which identify the author of the returned Spaces.
             search (`str`, *optional*):
                 A string that will be contained in the returned Spaces.
+            datasets (`str` or `Iterable`, *optional*):
+                Whether to return Spaces that make use of a dataset.
+                The name of a specific dataset can be passed as a string.
+            models (`str` or `Iterable`, *optional*):
+                Whether to return Spaces that make use of a model.
+                The name of a specific model can be passed as a string.
+            linked (`bool`, *optional*):
+                Whether to return Spaces that make use of either a model or a dataset.
             sort (`Literal["last_modified"]` or `str`, *optional*):
                 The key with which to sort the resulting Spaces. Possible
                 values are the properties of the [`huggingface_hub.hf_api.SpaceInfo`]` class.
@@ -1897,14 +2012,10 @@ class HfApi:
             limit (`int`, *optional*):
                 The limit on the number of Spaces fetched. Leaving this option
                 to `None` fetches all Spaces.
-            datasets (`str` or `Iterable`, *optional*):
-                Whether to return Spaces that make use of a dataset.
-                The name of a specific dataset can be passed as a string.
-            models (`str` or `Iterable`, *optional*):
-                Whether to return Spaces that make use of a model.
-                The name of a specific model can be passed as a string.
-            linked (`bool`, *optional*):
-                Whether to return Spaces that make use of either a model or a dataset.
+            expand (`List[ExpandSpaceProperty_T]`, *optional*):
+                List properties to return in the response. When used, only the properties in the list will be returned.
+                This parameter cannot be used if `full` is passed.
+                Possible values are `"author"`, `"cardData"`, `"datasets"`, `"disabled"`, `"gitalyUid"`, `"lastModified"`, `"createdAt"`, `"likes"`, `"private"`, `"runtime"`, `"sdk"`, `"siblings"`, `"sha"`, `"subdomain"`, `"tags"` and `"models"`.
             full (`bool`, *optional*):
                 Whether to fetch all Spaces data, including the `last_modified`, `siblings`
                 and `card_data` fields.
@@ -1917,6 +2028,9 @@ class HfApi:
         Returns:
             `Iterable[SpaceInfo]`: an iterable of [`huggingface_hub.hf_api.SpaceInfo`] objects.
         """
+        if expand and full:
+            raise ValueError("`expand` cannot be used if `full` is passed.")
+
         path = f"{self.endpoint}/api/spaces"
         headers = self._build_hf_headers(token=token)
         params: Dict[str, Any] = {}
@@ -1932,14 +2046,18 @@ class HfApi:
             params["direction"] = direction
         if limit is not None:
             params["limit"] = limit
-        if full:
-            params["full"] = True
         if linked:
             params["linked"] = True
         if datasets is not None:
             params["datasets"] = datasets
         if models is not None:
             params["models"] = models
+
+        # Request additional data
+        if expand:
+            params["expand"] = expand
+        if full:
+            params["full"] = True
 
         items = paginate(path, params=params, headers=headers)
         if limit is not None:
@@ -2188,6 +2306,7 @@ class HfApi:
         timeout: Optional[float] = None,
         securityStatus: Optional[bool] = None,
         files_metadata: bool = False,
+        expand: Optional[List[ExpandModelProperty_T]] = None,
         token: Union[bool, str, None] = None,
     ) -> ModelInfo:
         """
@@ -2210,6 +2329,10 @@ class HfApi:
             files_metadata (`bool`, *optional*):
                 Whether or not to retrieve metadata for files in the repository
                 (size, LFS metadata, etc). Defaults to `False`.
+            expand (`List[ExpandModelProperty_T]`, *optional*):
+                List properties to return in the response. When used, only the properties in the list will be returned.
+                This parameter cannot be used if `securityStatus` or `files_metadata` are passed.
+                Possible values are `"author"`, `"cardData"`, `"config"`, `"createdAt"`, `"disabled"`, `"downloads"`, `"downloadsAllTime"`, `"gated"`, `"gitalyUid"`, `"lastModified"`, `"library_name"`, `"likes"`, `"mask_token"`, `"model-index"`, `"pipeline_tag"`, `"private"`, `"safetensors"`, `"sha"`, `"siblings"`, `"spaces"`, `"tags"`, `"transformersInfo"` and `"widgetData"`.
             token (Union[bool, str, None], optional):
                 A valid user access token (string). Defaults to the locally saved
                 token, which is the recommended method for authentication (see
@@ -2231,17 +2354,22 @@ class HfApi:
 
         </Tip>
         """
+        if expand and (securityStatus or files_metadata):
+            raise ValueError("`expand` cannot be used if `securityStatus` or `files_metadata` are set.")
+
         headers = self._build_hf_headers(token=token)
         path = (
             f"{self.endpoint}/api/models/{repo_id}"
             if revision is None
             else (f"{self.endpoint}/api/models/{repo_id}/revision/{quote(revision, safe='')}")
         )
-        params = {}
+        params: Dict = {}
         if securityStatus:
             params["securityStatus"] = True
         if files_metadata:
             params["blobs"] = True
+        if expand:
+            params["expand"] = expand
         r = get_session().get(path, headers=headers, timeout=timeout, params=params)
         hf_raise_for_status(r)
         data = r.json()
@@ -2255,6 +2383,7 @@ class HfApi:
         revision: Optional[str] = None,
         timeout: Optional[float] = None,
         files_metadata: bool = False,
+        expand: Optional[List[ExpandDatasetProperty_T]] = None,
         token: Union[bool, str, None] = None,
     ) -> DatasetInfo:
         """
@@ -2274,6 +2403,10 @@ class HfApi:
             files_metadata (`bool`, *optional*):
                 Whether or not to retrieve metadata for files in the repository
                 (size, LFS metadata, etc). Defaults to `False`.
+            expand (`List[ExpandDatasetProperty_T]`, *optional*):
+                List properties to return in the response. When used, only the properties in the list will be returned.
+                This parameter cannot be used if `files_metadata` is passed.
+                Possible values are `"author"`, `"cardData"`, `"citation"`, `"createdAt"`, `"disabled"`, `"description"`, `"downloads"`, `"downloadsAllTime"`, `"gated"`, `"gitalyUid"`, `"lastModified"`, `"likes"`, `"paperswithcode_id"`, `"private"`, `"siblings"`, `"sha"` and `"tags"`.
             token (Union[bool, str, None], optional):
                 A valid user access token (string). Defaults to the locally saved
                 token, which is the recommended method for authentication (see
@@ -2295,15 +2428,20 @@ class HfApi:
 
         </Tip>
         """
+        if expand and files_metadata:
+            raise ValueError("`expand` cannot be used if `files_metadata` is set.")
+
         headers = self._build_hf_headers(token=token)
         path = (
             f"{self.endpoint}/api/datasets/{repo_id}"
             if revision is None
             else (f"{self.endpoint}/api/datasets/{repo_id}/revision/{quote(revision, safe='')}")
         )
-        params = {}
+        params: Dict = {}
         if files_metadata:
             params["blobs"] = True
+        if expand:
+            params["expand"] = expand
 
         r = get_session().get(path, headers=headers, timeout=timeout, params=params)
         hf_raise_for_status(r)
@@ -2318,6 +2456,7 @@ class HfApi:
         revision: Optional[str] = None,
         timeout: Optional[float] = None,
         files_metadata: bool = False,
+        expand: Optional[List[ExpandModelProperty_T]] = None,
         token: Union[bool, str, None] = None,
     ) -> SpaceInfo:
         """
@@ -2337,6 +2476,10 @@ class HfApi:
             files_metadata (`bool`, *optional*):
                 Whether or not to retrieve metadata for files in the repository
                 (size, LFS metadata, etc). Defaults to `False`.
+            expand (`List[ExpandSpaceProperty_T]`, *optional*):
+                List properties to return in the response. When used, only the properties in the list will be returned.
+                This parameter cannot be used if `full` is passed.
+                Possible values are `"author"`, `"cardData"`, `"datasets"`, `"disabled"`, `"gitalyUid"`, `"lastModified"`, `"createdAt"`, `"likes"`, `"private"`, `"runtime"`, `"sdk"`, `"siblings"`, `"sha"`, `"subdomain"`, `"tags"` and `"models"`.
             token (Union[bool, str, None], optional):
                 A valid user access token (string). Defaults to the locally saved
                 token, which is the recommended method for authentication (see
@@ -2358,15 +2501,20 @@ class HfApi:
 
         </Tip>
         """
+        if expand and files_metadata:
+            raise ValueError("`expand` cannot be used if `files_metadata` is set.")
+
         headers = self._build_hf_headers(token=token)
         path = (
             f"{self.endpoint}/api/spaces/{repo_id}"
             if revision is None
             else (f"{self.endpoint}/api/spaces/{repo_id}/revision/{quote(revision, safe='')}")
         )
-        params = {}
+        params: Dict = {}
         if files_metadata:
             params["blobs"] = True
+        if expand:
+            params["expand"] = expand
 
         r = get_session().get(path, headers=headers, timeout=timeout, params=params)
         hf_raise_for_status(r)
@@ -2382,6 +2530,7 @@ class HfApi:
         repo_type: Optional[str] = None,
         timeout: Optional[float] = None,
         files_metadata: bool = False,
+        expand: Optional[Union[ExpandModelProperty_T, ExpandDatasetProperty_T, ExpandSpaceProperty_T]] = None,
         token: Union[bool, str, None] = None,
     ) -> Union[ModelInfo, DatasetInfo, SpaceInfo]:
         """
@@ -2399,6 +2548,10 @@ class HfApi:
                 `None` or `"model"` if getting repository info from a model. Default is `None`.
             timeout (`float`, *optional*):
                 Whether to set a timeout for the request to the Hub.
+            expand (`ExpandModelProperty_T` or `ExpandDatasetProperty_T` or `ExpandSpaceProperty_T`, *optional*):
+                List properties to return in the response. When used, only the properties in the list will be returned.
+                This parameter cannot be used if `files_metadata` is passed.
+                For an exhaustive list of available properties, check out [`model_info`], [`dataset_info`] or [`space_info`].
             files_metadata (`bool`, *optional*):
                 Whether or not to retrieve metadata for files in the repository
                 (size, LFS metadata, etc). Defaults to `False`.
@@ -2438,6 +2591,7 @@ class HfApi:
             revision=revision,
             token=token,
             timeout=timeout,
+            expand=expand,  # type: ignore[arg-type]
             files_metadata=files_metadata,
         )
 

--- a/src/huggingface_hub/serialization/__init__.py
+++ b/src/huggingface_hub/serialization/__init__.py
@@ -15,5 +15,11 @@
 """Contains helpers to serialize tensors."""
 
 from ._base import StateDictSplit, split_state_dict_into_shards_factory
-from ._tensorflow import split_tf_state_dict_into_shards
-from ._torch import get_torch_storage_id, save_torch_state_dict, split_torch_state_dict_into_shards
+from ._tensorflow import get_tf_storage_size, split_tf_state_dict_into_shards
+from ._torch import (
+    get_torch_storage_id,
+    get_torch_storage_size,
+    save_torch_model,
+    save_torch_state_dict,
+    split_torch_state_dict_into_shards,
+)

--- a/src/huggingface_hub/serialization/_base.py
+++ b/src/huggingface_hub/serialization/_base.py
@@ -49,7 +49,7 @@ class StateDictSplit:
 def split_state_dict_into_shards_factory(
     state_dict: Dict[str, TensorT],
     *,
-    get_tensor_size: TensorSizeFn_T,
+    get_storage_size: TensorSizeFn_T,
     filename_pattern: str,
     get_storage_id: StorageIDFn_T = lambda tensor: None,
     max_shard_size: Union[int, str] = MAX_SHARD_SIZE,
@@ -72,8 +72,8 @@ def split_state_dict_into_shards_factory(
     Args:
         state_dict (`Dict[str, Tensor]`):
             The state dictionary to save.
-        get_tensor_size (`Callable[[Tensor], int]`):
-            A function that returns the size of a tensor in bytes.
+        get_storage_size (`Callable[[Tensor], int]`):
+            A function that returns the size of a tensor when saved on disk in bytes.
         get_storage_id (`Callable[[Tensor], Optional[Any]]`, *optional*):
             A function that returns a unique identifier to a tensor storage. Multiple different tensors can share the
             same underlying storage. This identifier is guaranteed to be unique and constant for this tensor's storage
@@ -117,7 +117,7 @@ def split_state_dict_into_shards_factory(
                 storage_id_to_tensors[storage_id] = [key]
 
         # Compute tensor size
-        tensor_size = get_tensor_size(tensor)
+        tensor_size = get_storage_size(tensor)
 
         # If this tensor is bigger than the maximal size, we put it in its own shard
         if tensor_size > max_shard_size:

--- a/src/huggingface_hub/serialization/_tensorflow.py
+++ b/src/huggingface_hub/serialization/_tensorflow.py
@@ -63,11 +63,11 @@ def split_tf_state_dict_into_shards(
         state_dict,
         max_shard_size=max_shard_size,
         filename_pattern=filename_pattern,
-        get_tensor_size=get_tensor_size,
+        get_storage_size=get_tf_storage_size,
     )
 
 
-def get_tensor_size(tensor: "tf.Tensor") -> int:
+def get_tf_storage_size(tensor: "tf.Tensor") -> int:
     # Return `math.ceil` since dtype byte size can be a float (e.g., 0.125 for tf.bool).
     # Better to overestimate than underestimate.
     return math.ceil(tensor.numpy().size * _dtype_byte_size_tf(tensor.dtype))

--- a/src/huggingface_hub/serialization/_torch.py
+++ b/src/huggingface_hub/serialization/_torch.py
@@ -17,9 +17,10 @@ import importlib
 import json
 import os
 import re
+from collections import defaultdict
 from functools import lru_cache
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple, Union
 
 from .. import constants, logging
 from ._base import MAX_SHARD_SIZE, StateDictSplit, split_state_dict_into_shards_factory
@@ -29,6 +30,234 @@ logger = logging.get_logger(__file__)
 
 if TYPE_CHECKING:
     import torch
+
+
+def save_torch_model(
+    model: "torch.nn.Module",
+    save_directory: Union[str, Path],
+    *,
+    filename_pattern: Optional[str] = None,
+    force_contiguous: bool = True,
+    max_shard_size: Union[int, str] = MAX_SHARD_SIZE,
+    metadata: Optional[Dict[str, str]] = None,
+    safe_serialization: bool = True,
+):
+    """
+    Saves a given torch model to disk, handling sharding and shared tensors issues.
+
+    See also [`save_torch_state_dict`] to save a state dict with more flexibility.
+
+    For more information about tensor sharing, check out [this guide](https://huggingface.co/docs/safetensors/torch_shared_tensors).
+
+    The model state dictionary is split into shards so that each shard is smaller than a given size. The shards are
+    saved in the `save_directory` with the given `filename_pattern`. If the model is too big to fit in a single shard,
+    an index file is saved in the `save_directory` to indicate where each tensor is saved. This helper uses
+    [`split_torch_state_dict_into_shards`] under the hood. If `safe_serialization` is `True`, the shards are saved as
+    safetensors (the default). Otherwise, the shards are saved as pickle.
+
+    Before saving the model, the `save_directory` is cleaned from any previous shard files.
+
+    <Tip warning={true}>
+
+    If one of the model's tensor is bigger than `max_shard_size`, it will end up in its own shard which will have a
+    size greater than `max_shard_size`.
+
+    </Tip>
+
+    Args:
+        model (`torch.nn.Module`):
+            The model to save on disk.
+        save_directory (`str` or `Path`):
+            The directory in which the model will be saved.
+        filename_pattern (`str`, *optional*):
+            The pattern to generate the files names in which the model will be saved. Pattern must be a string that
+            can be formatted with `filename_pattern.format(suffix=...)` and must contain the keyword `suffix`
+            Defaults to `"model{suffix}.safetensors"` or `pytorch_model{suffix}.bin` depending on `safe_serialization`
+            parameter.
+        force_contiguous (`boolean`, *optional*):
+            Forcing the state_dict to be saved as contiguous tensors. This has no effect on the correctness of the
+            model, but it could potentially change performance if the layout of the tensor was chosen specifically for
+            that reason. Defaults to `True`.
+        max_shard_size (`int` or `str`, *optional*):
+            The maximum size of each shard, in bytes. Defaults to 5GB.
+        metadata (`Dict[str, str]`, *optional*):
+            Extra information to save along with the model. Some metadata will be added for each dropped tensors.
+            This information will not be enough to recover the entire shared structure but might help understanding
+            things.
+        safe_serialization (`bool`, *optional*):
+            Whether to save as safetensors, which is the default behavior. If `False`, the shards are saved as pickle.
+            Safe serialization is recommended for security reasons. Saving as pickle is deprecated and will be removed
+            in a future version.
+
+    Example:
+
+    ```py
+    >>> from huggingface_hub import save_torch_model
+    >>> model = ... # A PyTorch model
+
+    # Save state dict to "path/to/folder". The model will be split into shards of 5GB each and saved as safetensors.
+    >>> save_torch_model(model, "path/to/folder")
+
+    # Load model back
+    >>> from huggingface_hub import load_torch_model  # TODO
+    >>> load_torch_model(model, "path/to/folder")
+    >>>
+    ```
+    """
+    save_torch_state_dict(
+        state_dict=model.state_dict(),
+        filename_pattern=filename_pattern,
+        force_contiguous=force_contiguous,
+        max_shard_size=max_shard_size,
+        metadata=metadata,
+        safe_serialization=safe_serialization,
+        save_directory=save_directory,
+    )
+
+
+def save_torch_state_dict(
+    state_dict: Dict[str, "torch.Tensor"],
+    save_directory: Union[str, Path],
+    *,
+    filename_pattern: Optional[str] = None,
+    force_contiguous: bool = True,
+    max_shard_size: Union[int, str] = MAX_SHARD_SIZE,
+    metadata: Optional[Dict[str, str]] = None,
+    safe_serialization: bool = True,
+) -> None:
+    """
+    Save a model state dictionary to the disk, handling sharding and shared tensors issues.
+
+    See also [`save_torch_model`] to directly save a PyTorch model.
+
+    For more information about tensor sharing, check out [this guide](https://huggingface.co/docs/safetensors/torch_shared_tensors).
+
+    The model state dictionary is split into shards so that each shard is smaller than a given size. The shards are
+    saved in the `save_directory` with the given `filename_pattern`. If the model is too big to fit in a single shard,
+    an index file is saved in the `save_directory` to indicate where each tensor is saved. This helper uses
+    [`split_torch_state_dict_into_shards`] under the hood. If `safe_serialization` is `True`, the shards are saved as
+    safetensors (the default). Otherwise, the shards are saved as pickle.
+
+    Before saving the model, the `save_directory` is cleaned from any previous shard files.
+
+    <Tip warning={true}>
+
+    If one of the model's tensor is bigger than `max_shard_size`, it will end up in its own shard which will have a
+    size greater than `max_shard_size`.
+
+    </Tip>
+
+    Args:
+        state_dict (`Dict[str, torch.Tensor]`):
+            The state dictionary to save.
+        save_directory (`str` or `Path`):
+            The directory in which the model will be saved.
+        filename_pattern (`str`, *optional*):
+            The pattern to generate the files names in which the model will be saved. Pattern must be a string that
+            can be formatted with `filename_pattern.format(suffix=...)` and must contain the keyword `suffix`
+            Defaults to `"model{suffix}.safetensors"` or `pytorch_model{suffix}.bin` depending on `safe_serialization`
+            parameter.
+        force_contiguous (`boolean`, *optional*):
+            Forcing the state_dict to be saved as contiguous tensors. This has no effect on the correctness of the
+            model, but it could potentially change performance if the layout of the tensor was chosen specifically for
+            that reason. Defaults to `True`.
+        max_shard_size (`int` or `str`, *optional*):
+            The maximum size of each shard, in bytes. Defaults to 5GB.
+        metadata (`Dict[str, str]`, *optional*):
+            Extra information to save along with the model. Some metadata will be added for each dropped tensors.
+            This information will not be enough to recover the entire shared structure but might help understanding
+            things.
+        safe_serialization (`bool`, *optional*):
+            Whether to save as safetensors, which is the default behavior. If `False`, the shards are saved as pickle.
+            Safe serialization is recommended for security reasons. Saving as pickle is deprecated and will be removed
+            in a future version.
+
+    Example:
+
+    ```py
+    >>> from huggingface_hub import save_torch_state_dict
+    >>> model = ... # A PyTorch model
+
+    # Save state dict to "path/to/folder". The model will be split into shards of 5GB each and saved as safetensors.
+    >>> state_dict = model_to_save.state_dict()
+    >>> save_torch_state_dict(state_dict, "path/to/folder")
+    ```
+    """
+    save_directory = str(save_directory)
+
+    if filename_pattern is None:
+        filename_pattern = (
+            constants.SAFETENSORS_WEIGHTS_FILE_PATTERN
+            if safe_serialization
+            else constants.PYTORCH_WEIGHTS_FILE_PATTERN
+        )
+
+    # Imports correct library
+    if safe_serialization:
+        try:
+            from safetensors.torch import save_file as save_file_fn
+        except ImportError as e:
+            raise ImportError(
+                "Please install `safetensors` to use safe serialization. "
+                "You can install it with `pip install safetensors`."
+            ) from e
+
+    else:
+        from torch import save as save_file_fn  # type: ignore[assignment]
+
+        logger.warning(
+            "You are using unsafe serialization. Due to security reasons, it is recommended not to load "
+            "pickled models from untrusted sources. If you intend to share your model, we strongly recommend "
+            "using safe serialization by installing `safetensors` with `pip install safetensors`."
+        )
+
+    # Clean state dict for safetensors
+    if metadata is None:
+        metadata = {}
+    if safe_serialization:
+        state_dict = _clean_state_dict_for_safetensors(state_dict, metadata, force_contiguous=force_contiguous)
+
+    # Split dict
+    state_dict_split = split_torch_state_dict_into_shards(
+        state_dict, filename_pattern=filename_pattern, max_shard_size=max_shard_size
+    )
+
+    # Clean the folder from previous save
+    existing_files_regex = re.compile(filename_pattern.format(suffix=r"(-\d{5}-of-\d{5})?") + r"(\.index\.json)?")
+    for filename in os.listdir(save_directory):
+        if existing_files_regex.match(filename):
+            try:
+                logger.debug(f"Removing existing file '{filename}' from folder.")
+                os.remove(os.path.join(save_directory, filename))
+            except Exception as e:
+                logger.warning(f"Error when trying to remove existing '{filename}' from folder: {e}. Continuing...")
+
+    # Save each shard
+    per_file_metadata = {"format": "pt"}
+    if not state_dict_split.is_sharded:
+        per_file_metadata.update(metadata)
+    safe_file_kwargs = {"metadata": per_file_metadata} if safe_serialization else {}
+    for filename, tensors in state_dict_split.filename_to_tensors.items():
+        shard = {tensor: state_dict[tensor] for tensor in tensors}
+        save_file_fn(shard, os.path.join(save_directory, filename), **safe_file_kwargs)
+        logger.debug(f"Shard saved to {filename}")
+
+    # Save the index (if any)
+    if state_dict_split.is_sharded:
+        index_path = filename_pattern.format(suffix="") + ".index.json"
+        index = {
+            "metadata": {**state_dict_split.metadata, **metadata},
+            "weight_map": state_dict_split.tensor_to_filename,
+        }
+        with open(os.path.join(save_directory, index_path), "w") as f:
+            json.dump(index, f, indent=2)
+        logger.info(
+            f"The model is bigger than the maximum size per checkpoint ({max_shard_size}). "
+            f"Model weighs have been saved in {len(state_dict_split.filename_to_tensors)} checkpoint shards. "
+            f"You can find where each parameters has been saved in the index located at {index_path}."
+        )
+
+    logger.info(f"Model weights successfully saved to {save_directory}!")
 
 
 def split_torch_state_dict_into_shards(
@@ -102,128 +331,9 @@ def split_torch_state_dict_into_shards(
         state_dict,
         max_shard_size=max_shard_size,
         filename_pattern=filename_pattern,
-        get_tensor_size=get_tensor_size,
+        get_storage_size=get_torch_storage_size,
         get_storage_id=get_torch_storage_id,
     )
-
-
-def save_torch_state_dict(
-    state_dict: Dict[str, "torch.Tensor"],
-    save_directory: Union[str, Path],
-    *,
-    safe_serialization: bool = True,
-    filename_pattern: Optional[str] = None,
-    max_shard_size: Union[int, str] = MAX_SHARD_SIZE,
-) -> None:
-    """
-    Save a model state dictionary to the disk.
-
-    The model state dictionary is split into shards so that each shard is smaller than a given size. The shards are
-    saved in the `save_directory` with the given `filename_pattern`. If the model is too big to fit in a single shard,
-    an index file is saved in the `save_directory` to indicate where each tensor is saved. This helper uses
-    [`split_torch_state_dict_into_shards`] under the hood. If `safe_serialization` is `True`, the shards are saved as
-    safetensors (the default). Otherwise, the shards are saved as pickle.
-
-    Before saving the model, the `save_directory` is cleaned from any previous shard files.
-
-    <Tip warning={true}>
-
-    If one of the model's tensor is bigger than `max_shard_size`, it will end up in its own shard which will have a
-    size greater than `max_shard_size`.
-
-    </Tip>
-
-    Args:
-        state_dict (`Dict[str, torch.Tensor]`):
-            The state dictionary to save.
-        save_directory (`str` or `Path`):
-            The directory in which the model will be saved.
-        safe_serialization (`bool`, *optional*):
-            Whether to save as safetensors, which is the default behavior. If `False`, the shards are saved as pickle.
-            Safe serialization is recommended for security reasons. Saving as pickle is deprecated and will be removed
-            in a future version.
-        filename_pattern (`str`, *optional*):
-            The pattern to generate the files names in which the model will be saved. Pattern must be a string that
-            can be formatted with `filename_pattern.format(suffix=...)` and must contain the keyword `suffix`
-            Defaults to `"model{suffix}.safetensors"` or `pytorch_model{suffix}.bin` depending on `safe_serialization`
-            parameter.
-        max_shard_size (`int` or `str`, *optional*):
-            The maximum size of each shard, in bytes. Defaults to 5GB.
-
-    Example:
-
-    ```py
-    >>> from huggingface_hub import save_torch_state_dict
-    >>> model = ... # A PyTorch model
-
-    # Save state dict to "path/to/folder". The model will be split into shards of 5GB each and saved as safetensors.
-    >>> state_dict = model_to_save.state_dict()
-    >>> save_torch_state_dict(state_dict, "path/to/folder")
-    ```
-    """
-    save_directory = str(save_directory)
-
-    if filename_pattern is None:
-        filename_pattern = (
-            constants.SAFETENSORS_WEIGHTS_FILE_PATTERN
-            if safe_serialization
-            else constants.PYTORCH_WEIGHTS_FILE_PATTERN
-        )
-
-    # Imports correct library
-    if safe_serialization:
-        try:
-            from safetensors.torch import save_file as save_file_fn
-        except ImportError as e:
-            raise ImportError(
-                "Please install `safetensors` to use safe serialization. "
-                "You can install it with `pip install safetensors`."
-            ) from e
-
-    else:
-        from torch import save as save_file_fn  # type: ignore[assignment]
-
-        logger.warning(
-            "You are using unsafe serialization. Due to security reasons, it is recommended not to load "
-            "pickled models from untrusted sources. If you intend to share your model, we strongly recommend "
-            "using safe serialization by installing `safetensors` with `pip install safetensors`."
-        )
-
-    # Split dict
-    state_dict_split = split_torch_state_dict_into_shards(
-        state_dict, filename_pattern=filename_pattern, max_shard_size=max_shard_size
-    )
-
-    # Clean the folder from previous save
-    existing_files_regex = re.compile(filename_pattern.format(suffix=r"(-\d{5}-of-\d{5})?") + r"(\.index\.json)?")
-    for filename in os.listdir(save_directory):
-        if existing_files_regex.match(filename):
-            try:
-                logger.debug(f"Removing existing file '{filename}' from folder.")
-                os.remove(os.path.join(save_directory, filename))
-            except Exception as e:
-                logger.warning(f"Error when trying to remove existing '{filename}' from folder: {e}. Continuing...")
-
-    # Save each shard
-    safe_file_kwargs = {"metadata": {"format": "pt"}} if safe_serialization else {}
-    for filename, tensors in state_dict_split.filename_to_tensors.items():
-        shard = {tensor: state_dict[tensor] for tensor in tensors}
-        save_file_fn(shard, os.path.join(save_directory, filename), **safe_file_kwargs)
-        logger.debug(f"Shard saved to {filename}")
-
-    # Save the index (if any)
-    if state_dict_split.is_sharded:
-        index_path = filename_pattern.format(suffix="") + ".index.json"
-        index = {"metadata": state_dict_split.metadata, "weight_map": state_dict_split.tensor_to_filename}
-        with open(os.path.join(save_directory, index_path), "w") as f:
-            json.dump(index, f, indent=2)
-        logger.info(
-            f"The model is bigger than the maximum size per checkpoint ({max_shard_size}). "
-            f"Model weighs have been saved in {len(state_dict_split.filename_to_tensors)} checkpoint shards. "
-            f"You can find where each parameters has been saved in the index located at {index_path}."
-        )
-
-    logger.info(f"Model weights successfully saved to {save_directory}!")
 
 
 def get_torch_storage_id(tensor: "torch.Tensor") -> Tuple["torch.device", int, int]:
@@ -248,11 +358,23 @@ def get_torch_storage_id(tensor: "torch.Tensor") -> Tuple["torch.device", int, i
     else:
         unique_id = storage_ptr(tensor)
 
-    return tensor.device, unique_id, get_storage_size(tensor)
+    return tensor.device, unique_id, get_torch_storage_size(tensor)
 
 
-def get_tensor_size(tensor: "torch.Tensor") -> int:
-    return tensor.numel() * tensor.element_size()
+def get_torch_storage_size(tensor: "torch.Tensor") -> int:
+    """
+    Taken from https://github.com/huggingface/safetensors/blob/08db34094e9e59e2f9218f2df133b7b4aaff5a99/bindings/python/py_src/safetensors/torch.py#L31C1-L41C59
+    """
+    try:
+        return tensor.untyped_storage().nbytes()
+    except AttributeError:
+        # Fallback for torch==1.10
+        try:
+            return tensor.storage().size() * _get_dtype_size(tensor.dtype)
+        except NotImplementedError:
+            # Fallback for meta storage
+            # On torch >=2.0 this is the tensor size
+            return tensor.nelement() * _get_dtype_size(tensor.dtype)
 
 
 @lru_cache()
@@ -278,7 +400,7 @@ def is_torch_tpu_available(check_device=True):
 
 def storage_ptr(tensor: "torch.Tensor") -> int:
     """
-    Taken from https://github.com/huggingface/safetensors/blob/08db34094e9e59e2f9218f2df133b7b4aaff5a99/bindings/python/py_src/safetensors/torch.py#L11C1-L20C21.
+    Taken from https://github.com/huggingface/safetensors/blob/079781fd0dc455ba0fe851e2b4507c33d0c0d407/bindings/python/py_src/safetensors/torch.py#L11.
     """
     try:
         return tensor.untyped_storage().data_ptr()
@@ -291,20 +413,141 @@ def storage_ptr(tensor: "torch.Tensor") -> int:
             return 0
 
 
-def get_storage_size(tensor: "torch.Tensor") -> int:
+def _clean_state_dict_for_safetensors(
+    state_dict: Dict[str, "torch.Tensor"], metadata: Dict[str, str], force_contiguous: bool = True
+):
+    """Remove shared tensors from state_dict and update metadata accordingly (for reloading).
+
+    Warning: `state_dict` and `metadata` are mutated in-place!
+
+    Taken from https://github.com/huggingface/safetensors/blob/079781fd0dc455ba0fe851e2b4507c33d0c0d407/bindings/python/py_src/safetensors/torch.py#L155.
     """
-    Taken from https://github.com/huggingface/safetensors/blob/08db34094e9e59e2f9218f2df133b7b4aaff5a99/bindings/python/py_src/safetensors/torch.py#L31C1-L41C59
+    to_removes = _remove_duplicate_names(state_dict)
+    for kept_name, to_remove_group in to_removes.items():
+        for to_remove in to_remove_group:
+            if metadata is None:
+                metadata = {}
+
+            if to_remove not in metadata:
+                # Do not override user data
+                metadata[to_remove] = kept_name
+            del state_dict[to_remove]
+    if force_contiguous:
+        state_dict = {k: v.contiguous() for k, v in state_dict.items()}
+    return state_dict
+
+
+def _end_ptr(tensor: "torch.Tensor") -> int:
     """
-    try:
-        return tensor.untyped_storage().nbytes()
-    except AttributeError:
-        # Fallback for torch==1.10
-        try:
-            return tensor.storage().size() * _get_dtype_size(tensor.dtype)
-        except NotImplementedError:
-            # Fallback for meta storage
-            # On torch >=2.0 this is the tensor size
-            return tensor.nelement() * _get_dtype_size(tensor.dtype)
+    Taken from https://github.com/huggingface/safetensors/blob/079781fd0dc455ba0fe851e2b4507c33d0c0d407/bindings/python/py_src/safetensors/torch.py#L23.
+    """
+    if tensor.nelement():
+        stop = tensor.view(-1)[-1].data_ptr() + _get_dtype_size(tensor.dtype)
+    else:
+        stop = tensor.data_ptr()
+    return stop
+
+
+def _filter_shared_not_shared(tensors: List[Set[str]], state_dict: Dict[str, "torch.Tensor"]) -> List[Set[str]]:
+    """
+    Taken from https://github.com/huggingface/safetensors/blob/079781fd0dc455ba0fe851e2b4507c33d0c0d407/bindings/python/py_src/safetensors/torch.py#L44
+    """
+    filtered_tensors = []
+    for shared in tensors:
+        if len(shared) < 2:
+            filtered_tensors.append(shared)
+            continue
+
+        areas = []
+        for name in shared:
+            tensor = state_dict[name]
+            areas.append((tensor.data_ptr(), _end_ptr(tensor), name))
+        areas.sort()
+
+        _, last_stop, last_name = areas[0]
+        filtered_tensors.append({last_name})
+        for start, stop, name in areas[1:]:
+            if start >= last_stop:
+                filtered_tensors.append({name})
+            else:
+                filtered_tensors[-1].add(name)
+            last_stop = stop
+
+    return filtered_tensors
+
+
+def _find_shared_tensors(state_dict: Dict[str, "torch.Tensor"]) -> List[Set[str]]:
+    """
+    Taken from https://github.com/huggingface/safetensors/blob/079781fd0dc455ba0fe851e2b4507c33d0c0d407/bindings/python/py_src/safetensors/torch.py#L69.
+    """
+    import torch
+
+    tensors_dict = defaultdict(set)
+    for k, v in state_dict.items():
+        if v.device != torch.device("meta") and storage_ptr(v) != 0 and get_torch_storage_size(v) != 0:
+            # Need to add device as key because of multiple GPU.
+            tensors_dict[(v.device, storage_ptr(v), get_torch_storage_size(v))].add(k)
+    tensors = list(sorted(tensors_dict.values()))
+    tensors = _filter_shared_not_shared(tensors, state_dict)
+    return tensors
+
+
+def _is_complete(tensor: "torch.Tensor") -> bool:
+    """
+    Taken from https://github.com/huggingface/safetensors/blob/079781fd0dc455ba0fe851e2b4507c33d0c0d407/bindings/python/py_src/safetensors/torch.py#L80
+    """
+    return tensor.data_ptr() == storage_ptr(tensor) and tensor.nelement() * _get_dtype_size(
+        tensor.dtype
+    ) == get_torch_storage_size(tensor)
+
+
+def _remove_duplicate_names(
+    state_dict: Dict[str, "torch.Tensor"],
+    *,
+    preferred_names: Optional[List[str]] = None,
+    discard_names: Optional[List[str]] = None,
+) -> Dict[str, List[str]]:
+    """
+    Taken from https://github.com/huggingface/safetensors/blob/079781fd0dc455ba0fe851e2b4507c33d0c0d407/bindings/python/py_src/safetensors/torch.py#L80
+    """
+    if preferred_names is None:
+        preferred_names = []
+    unique_preferred_names = set(preferred_names)
+    if discard_names is None:
+        discard_names = []
+    unique_discard_names = set(discard_names)
+
+    shareds = _find_shared_tensors(state_dict)
+    to_remove = defaultdict(list)
+    for shared in shareds:
+        complete_names = set([name for name in shared if _is_complete(state_dict[name])])
+        if not complete_names:
+            raise RuntimeError(
+                "Error while trying to find names to remove to save state dict, but found no suitable name to keep"
+                f" for saving amongst: {shared}. None is covering the entire storage. Refusing to save/load the model"
+                " since you could be storing much more memory than needed. Please refer to"
+                " https://huggingface.co/docs/safetensors/torch_shared_tensors for more information. Or open an"
+                " issue."
+            )
+
+        keep_name = sorted(list(complete_names))[0]
+
+        # Mechanism to preferentially select keys to keep
+        # coming from the on-disk file to allow
+        # loading models saved with a different choice
+        # of keep_name
+        preferred = complete_names.difference(unique_discard_names)
+        if preferred:
+            keep_name = sorted(list(preferred))[0]
+
+        if unique_preferred_names:
+            preferred = unique_preferred_names.intersection(complete_names)
+            if preferred:
+                keep_name = sorted(list(preferred))[0]
+        for name in sorted(shared):
+            if name != keep_name:
+                to_remove[keep_name].append(name)
+    return to_remove
 
 
 @lru_cache()

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -992,6 +992,28 @@ class HfHubDownloadToLocalDir(unittest.TestCase):
         self.api.hf_hub_download(self.repo_id, filename=self.file_name, local_dir=self.local_dir, force_download=True)
         self.file_path.read_text() == "content"
 
+    @patch("huggingface_hub.file_download.build_hf_headers")
+    def test_passing_token_false_is_respected(self, mock: Mock):
+        """Regression test for #2385.
+
+        A bug introduced in 0.23.0 was causing the `token` parameter to be ignored when set to `False`.
+
+        See https://github.com/huggingface/huggingface_hub/issues/2385.
+        """
+        # Download to local dir
+        mock.reset_mock(return_value={})
+        self.api.hf_hub_download(self.repo_id, filename=self.file_name, local_dir=self.local_dir, token=False)
+        mock.assert_called()
+        for call in mock.call_args_list:
+            assert call.kwargs["token"] is False
+
+        # Download to cache dir
+        mock.reset_mock(return_value={})
+        self.api.hf_hub_download(self.repo_id, filename=self.file_name, cache_dir=self.local_dir, token=False)
+        mock.assert_called()
+        for call in mock.call_args_list:
+            assert call.kwargs["token"] is False
+
 
 @pytest.mark.usefixtures("fx_cache_dir")
 class StagingCachedDownloadOnAwfulFilenamesTest(unittest.TestCase):

--- a/tests/test_local_folder.py
+++ b/tests/test_local_folder.py
@@ -18,8 +18,9 @@ See `huggingface_hub/src/_local_folder.py` for the implementation.
 """
 
 import logging
+import os
 import time
-from pathlib import Path
+from pathlib import Path, WindowsPath
 
 import pytest
 
@@ -79,6 +80,23 @@ def test_local_download_paths_are_cached(tmp_path: Path):
     paths1 = get_local_download_paths(tmp_path, "path/in/repo.txt")
     paths2 = get_local_download_paths(tmp_path, "path/in/repo.txt")
     assert paths1 is paths2
+
+
+def test_local_download_paths_long_paths(tmp_path: Path):
+    """Test long path handling on Windows."""
+    if os.name == "nt":
+        long_file_name = "a" * 255
+        paths = get_local_download_paths(tmp_path, f"path/long/{long_file_name}.txt")
+
+        # WindowsPath on Windows platform
+        assert isinstance(paths.file_path, WindowsPath)
+        assert isinstance(paths.lock_path, WindowsPath)
+        assert isinstance(paths.metadata_path, WindowsPath)
+
+        # Correct path prefixes
+        assert str(paths.file_path).startswith("\\\\?\\")
+        assert str(paths.lock_path).startswith("\\\\?\\")
+        assert str(paths.metadata_path).startswith("\\\\?\\")
 
 
 def test_write_download_metadata(tmp_path: Path):

--- a/tests/test_local_folder.py
+++ b/tests/test_local_folder.py
@@ -85,18 +85,18 @@ def test_local_download_paths_are_cached(tmp_path: Path):
 @pytest.mark.skipif(os.name != "nt", reason="Windows-specific test.")
 def test_local_download_paths_long_paths(tmp_path: Path):
     """Test long path handling on Windows."""
-        long_file_name = "a" * 255
-        paths = get_local_download_paths(tmp_path, f"path/long/{long_file_name}.txt")
+    long_file_name = "a" * 255
+    paths = get_local_download_paths(tmp_path, f"path/long/{long_file_name}.txt")
 
-        # WindowsPath on Windows platform
-        assert isinstance(paths.file_path, WindowsPath)
-        assert isinstance(paths.lock_path, WindowsPath)
-        assert isinstance(paths.metadata_path, WindowsPath)
+    # WindowsPath on Windows platform
+    assert isinstance(paths.file_path, WindowsPath)
+    assert isinstance(paths.lock_path, WindowsPath)
+    assert isinstance(paths.metadata_path, WindowsPath)
 
-        # Correct path prefixes
-        assert str(paths.file_path).startswith("\\\\?\\")
-        assert str(paths.lock_path).startswith("\\\\?\\")
-        assert str(paths.metadata_path).startswith("\\\\?\\")
+    # Correct path prefixes
+    assert str(paths.file_path).startswith("\\\\?\\")
+    assert str(paths.lock_path).startswith("\\\\?\\")
+    assert str(paths.metadata_path).startswith("\\\\?\\")
 
 
 def test_write_download_metadata(tmp_path: Path):

--- a/tests/test_local_folder.py
+++ b/tests/test_local_folder.py
@@ -82,9 +82,9 @@ def test_local_download_paths_are_cached(tmp_path: Path):
     assert paths1 is paths2
 
 
+@pytest.mark.skipif(os.name != "nt", reason="Windows-specific test.")
 def test_local_download_paths_long_paths(tmp_path: Path):
     """Test long path handling on Windows."""
-    if os.name == "nt":
         long_file_name = "a" * 255
         paths = get_local_download_paths(tmp_path, f"path/long/{long_file_name}.txt")
 

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -436,8 +436,13 @@ def use_tmp_repo(repo_type: str = "model") -> Callable[[T], T]:
         def _inner(*args, **kwargs):
             self = args[0]
             assert isinstance(self, unittest.TestCase)
+            create_repo_kwargs = {}
+            if repo_type == "space":
+                create_repo_kwargs["space_sdk"] = "gradio"
 
-            repo_url = self._api.create_repo(repo_id=repo_name(prefix=repo_type), repo_type=repo_type)
+            repo_url = self._api.create_repo(
+                repo_id=repo_name(prefix=repo_type), repo_type=repo_type, **create_repo_kwargs
+            )
             try:
                 return test_fn(*args, **kwargs, repo_url=repo_url)
             finally:


### PR DESCRIPTION
Change the path of the local dir to an extended path by prepending "\\?\" to the absolute path, when the absolute path is longer than 255 characters on Windows.

This addresses Issue  #2374.

Also fixed a small typo.