### PR TITLE
Document more `HfFilesyStem` Methods

### DIFF
--- a/docs/source/en/package_reference/hf_file_system.md
+++ b/docs/source/en/package_reference/hf_file_system.md
@@ -10,7 +10,6 @@ The `HfFileSystem` class provides a pythonic file interface to the Hugging Face 
 
 `HfFileSystem` is based on [fsspec](https://filesystem-spec.readthedocs.io/en/latest/), so it is compatible with most of the APIs that it offers. For more details, check out [our guide](../guides/hf_file_system) and fsspec's [API Reference](https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem).
 
-[[autodoc]] HfFileSystem
+[[autodoc]] HfFileSystem 
     - __init__
-    - resolve_path
-    - ls
+    - all

--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -901,7 +901,7 @@ for name, function in inspect.getmembers(HfFileSystem, predicate=inspect.isfunct
         function.__doc__ = (
             (
                 "\n_Docstring taken from "
-                f"[fsspec documentation](https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.{name})_"
+                f"[fsspec documentation](https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.{name})._"
             )
             + "\n\n"
             + parent_doc

--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -896,11 +896,13 @@ def reopen(fs: HfFileSystem, path: str, mode: str, block_size: int, cache_type: 
 for name, function in inspect.getmembers(HfFileSystem, predicate=inspect.isfunction):
     parent = getattr(fsspec.AbstractFileSystem, name, None)
     if parent is not None and parent.__doc__ is not None:
+        parent_doc = parent.__doc__
+        parent_doc.replace("-" * 10, "\n").replace("-" * 7, "\n")
         function.__doc__ = (
             (
                 "\n_Docstring taken from "
                 f"[fsspec documentation](https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.{name})_"
             )
             + "\n\n"
-            + parent.__doc__
+            + parent_doc
         )

--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -897,7 +897,8 @@ for name, function in inspect.getmembers(HfFileSystem, predicate=inspect.isfunct
     parent = getattr(fsspec.AbstractFileSystem, name, None)
     if parent is not None and parent.__doc__ is not None:
         parent_doc = parent.__doc__
-        parent_doc.replace("-" * 10, "\n").replace("-" * 7, "\n")
+        parent_doc = parent_doc.replace("Parameters\n        ----------\n", "Args:\n")
+        parent_doc = parent_doc.replace("Returns\n        -------\n", "Return:\n")
         function.__doc__ = (
             (
                 "\n_Docstring taken from "

--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -1,3 +1,4 @@
+import inspect
 import os
 import re
 import tempfile
@@ -889,3 +890,17 @@ def _raise_file_not_found(path: str, err: Optional[Exception]) -> NoReturn:
 
 def reopen(fs: HfFileSystem, path: str, mode: str, block_size: int, cache_type: str):
     return fs.open(path, mode=mode, block_size=block_size, cache_type=cache_type)
+
+
+# Add docstrings to the methods of HfFileSystem from fsspec.AbstractFileSystem
+for name, function in inspect.getmembers(HfFileSystem, predicate=inspect.isfunction):
+    parent = getattr(fsspec.AbstractFileSystem, name, None)
+    if parent is not None and parent.__doc__ is not None:
+        function.__doc__ = (
+            (
+                "\n_Docstring taken from "
+                f"[fsspec documentation](https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.{name})_"
+            )
+            + "\n\n"
+            + parent.__doc__
+        )


### PR DESCRIPTION
Automate and expand `HfFileSystem` documentation

- Generates comprehensive docs for all `HfFileSystem` methods
- Fetches `fsspec` docs and adds HuggingFace-specific notes
- Updates main docs [[autodoc]] to use `all` for full method listing

Closes #2100

Cc @severo 
