### PR TITLE
Add a default timeout for filelock

### DIFF
--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -49,6 +49,9 @@ SAFETENSORS_SINGLE_FILE = "model.safetensors"
 SAFETENSORS_INDEX_FILE = "model.safetensors.index.json"
 SAFETENSORS_MAX_HEADER_LENGTH = 25_000_000
 
+# Timeout of aquiring file lock and logging the attempt
+FILELOCK_LOG_EVERY_SECONDS = 10
+
 # Git-related constants
 
 DEFAULT_REVISION = "main"


### PR DESCRIPTION
File lock operations did not have an associated timeout, which could present problems when trying to debug an issue since nothing would be logged if we could not acquire the lock and would wait forever.