### PR TITLE
Fix `list_accepted_access_requests` if grant user manually

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -433,8 +433,9 @@ class AccessRequest:
             Username of the user who requested access.
         fullname (`str`):
             Fullname of the user who requested access.
-        email (`str`):
+        email (`Optional[str]`):
             Email of the user who requested access.
+            Can only be `None` in the /accepted list if the user was granted access manually.
         timestamp (`datetime`):
             Timestamp of the request.
         status (`Literal["pending", "accepted", "rejected"]`):
@@ -445,7 +446,7 @@ class AccessRequest:
 
     username: str
     fullname: str
-    email: str
+    email: Optional[str]
     timestamp: datetime
     status: Literal["pending", "accepted", "rejected"]
 
@@ -8422,7 +8423,7 @@ class HfApi:
             AccessRequest(
                 username=request["user"]["user"],
                 fullname=request["user"]["fullname"],
-                email=request["user"]["email"],
+                email=request["user"].get("email"),
                 status=request["status"],
                 timestamp=parse_datetime(request["timestamp"]),
                 fields=request.get("fields"),  # only if custom fields in form

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -3820,6 +3820,7 @@ class AccessRequestAPITest(HfApiCommonTest):
         request = requests[0]
         assert isinstance(request, AccessRequest)
         assert request.username == OTHER_USER
+        assert request.email is None  # email not shared when granted access manually
         assert request.status == "accepted"
         assert isinstance(request.timestamp, datetime.datetime)
 


### PR DESCRIPTION
If a user is granted access to a repo without asking for it, their email address should not be shared to the repo owner. This has been enforced server-side by https://github.com/huggingface-internal/moon-landing/pull/10651 (internal). This PR fixes the client logic so that `email` is not required. Currently if one user from the list has been granted access, `list_accepted_access_requests` fails with a `KeyError`.