### PR TITLE
Consider `Retry-After` header for delay

### DIFF
--- a/src/huggingface_hub/utils/_http.py
+++ b/src/huggingface_hub/utils/_http.py
@@ -278,7 +278,16 @@ def http_backoff(
 
             # Perform request and return if status_code is not in the retry list.
             response = session.request(method=method, url=url, **kwargs)
-            if response.status_code not in retry_on_status_codes:
+
+            # Handle Retry-After header for 429 status code
+            if response.status_code == 429:
+                retry_after = response.headers.get("Retry-After")
+                if retry_after is not None:
+                    try:
+                        sleep_time += float(retry_after)
+                    except ValueError:
+                        pass
+            elif response.status_code not in retry_on_status_codes:
                 return response
 
             # Wrong status code returned (HTTP 503 for instance)


### PR DESCRIPTION
Adds support for `Retry-After` header to be considered for delay. This header is used to indicate how long the user agent should wait before making a follow-up request.

Implemented as part of the existing backoff strategy as it nicely integrated there instead of adding it as a separate adapter [as suggested](https://github.com/huggingface/huggingface_hub/issues/2360#issuecomment-2203049048).

## Discussion item
Should we include handling HTTP 429 by default in the backoff strategy? Or should we require callers to explicitly opt-in using `retry_on_status_codes`? Right now, I decided to opt-in by default as its how HTTP spec suggest to handle this whereas `retry_on_status_codes` should only be used for the "I know the server and I know that we want to retry in those special cases".

Fixes #2360 
