### PR TITLE
Hot-fix: do not share tags between `ModelHubMixin` siblings

### DIFF
--- a/tests/test_hub_mixin_pytorch.py
+++ b/tests/test_hub_mixin_pytorch.py
@@ -111,12 +111,20 @@ if is_torch_available():
             super().__init__()
             self.config = config
 
+    class DummyModelWithTag1(nn.Module, PyTorchModelHubMixin, tags=["tag1"]):
+        """Used to test tags not shared between sibling classes (only inheritance)."""
+
+    class DummyModelWithTag2(nn.Module, PyTorchModelHubMixin, tags=["tag2"]):
+        """Used to test tags not shared between sibling classes (only inheritance)."""
+
 else:
     DummyModel = None
     DummyModelWithModelCard = None
     DummyModelNoConfig = None
     DummyModelWithConfigAndKwargs = None
     DummyModelWithModelCardAndCustomKwargs = None
+    DummyModelWithTag1 = None
+    DummyModelWithTag2 = None
 
 
 @requires("torch")
@@ -451,3 +459,20 @@ class PytorchHubMixinTest(unittest.TestCase):
         assert isinstance(reloaded.config, Namespace)
         assert reloaded.config.a == 1
         assert reloaded.config.b == 2
+
+    def test_inheritance_and_sibling_classes(self):
+        """
+        Test tags are not shared between sibling classes.
+
+        Regression test.
+        """
+        assert DummyModelWithTag1._hub_mixin_info.model_card_data.tags == [
+            "model_hub_mixin",
+            "pytorch_model_hub_mixin",
+            "tag1",
+        ]
+        assert DummyModelWithTag2._hub_mixin_info.model_card_data.tags == [
+            "model_hub_mixin",
+            "pytorch_model_hub_mixin",
+            "tag2",
+        ]

--- a/tests/test_hub_mixin_pytorch.py
+++ b/tests/test_hub_mixin_pytorch.py
@@ -464,7 +464,8 @@ class PytorchHubMixinTest(unittest.TestCase):
         """
         Test tags are not shared between sibling classes.
 
-        Regression test.
+        Regression test for #2394.
+        See https://github.com/huggingface/huggingface_hub/pull/2394.
         """
         assert DummyModelWithTag1._hub_mixin_info.model_card_data.tags == [
             "model_hub_mixin",


### PR DESCRIPTION
This PR fixes a quite major issue with tags/metadata being shared between classes that inherit from `PyTorchModelHubMixin`. It has most likely been introduced in https://github.com/huggingface/huggingface_hub/pull/2305 which was fixing attributes lost in inheritance. This time we should be fine!

I also made a modification so that tags are now deduplicated and sorted.

Realized this while working on https://github.com/state-spaces/mamba/pull/471. I'll make a hot-fix release once merged as it's quite problematic. If a user has several classes inheriting from `PyTorchModelHubMixin` (typically several packages using it installed in a venv), then the pushed models will have incorrect metadata on the Hub. I realized this while pushing [6d4b46a](https://huggingface.co/state-spaces/mamba-130m/commit/6d4b46a5f1db9552f507dfbeb09de5df9597e340).

**EDIT:** failing tests are unrelated