### PR TITLE
Warn if user tries to upload a parquet file to a model repo

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -3733,6 +3733,15 @@ class HfApi:
                     " new CommitOperationAdd object if you want to create a new commit."
                 )
 
+        if repo_type != "dataset":
+            for addition in additions:
+                if addition.path_in_repo.endswith((".arrow", ".parquet")):
+                    warnings.warn(
+                        f"It seems that you are about to commit a data file ({addition.path_in_repo}) to a {repo_type}"
+                        " repository. You are sure this is intended? If you are trying to upload a dataset, please"
+                        " set `repo_type='dataset'` or `--repo-type=dataset` in a CLI."
+                    )
+
         logger.debug(
             f"About to commit to the hub: {len(additions)} addition(s), {len(copies)} copie(s) and"
             f" {nb_deletions} deletion(s)."


### PR DESCRIPTION
Little QoL suggested by @coyotte508  on slack.

We've had several users reporting that they've pushed their dataset to a model repo. It is then impossible to convert the repo to dataset on the Hub, forcing them to entirely re-upload everything. This PR tries to prevent this kind of mistake by raising a warning when user does upload an arrow or a parquet file to a non-dataset repo. If the user don't stop the process, the files are still correctly uploaded since we don't want to forbid the upload.