### PR TITLE
List organizations in `get_user_overview`

### DIFF
--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -143,11 +143,14 @@ _SUBMOD_ATTRS = {
         "CommitOperationAdd",
         "CommitOperationCopy",
         "CommitOperationDelete",
+        "DatasetInfo",
         "GitCommitInfo",
         "GitRefInfo",
         "GitRefs",
         "HfApi",
+        "ModelInfo",
         "RepoUrl",
+        "SpaceInfo",
         "User",
         "UserLikes",
         "WebhookInfo",
@@ -199,6 +202,7 @@ _SUBMOD_ATTRS = {
         "get_space_runtime",
         "get_space_variables",
         "get_token_permission",
+        "get_user_overview",
         "get_webhook",
         "grant_access",
         "like",
@@ -643,11 +647,14 @@ if TYPE_CHECKING:  # pragma: no cover
         CommitOperationAdd,  # noqa: F401
         CommitOperationCopy,  # noqa: F401
         CommitOperationDelete,  # noqa: F401
+        DatasetInfo,  # noqa: F401
         GitCommitInfo,  # noqa: F401
         GitRefInfo,  # noqa: F401
         GitRefs,  # noqa: F401
         HfApi,  # noqa: F401
+        ModelInfo,  # noqa: F401
         RepoUrl,  # noqa: F401
+        SpaceInfo,  # noqa: F401
         User,  # noqa: F401
         UserLikes,  # noqa: F401
         WebhookInfo,  # noqa: F401
@@ -699,6 +706,7 @@ if TYPE_CHECKING:  # pragma: no cover
         get_space_runtime,  # noqa: F401
         get_space_variables,  # noqa: F401
         get_token_permission,  # noqa: F401
+        get_user_overview,  # noqa: F401
         get_webhook,  # noqa: F401
         grant_access,  # noqa: F401
         like,  # noqa: F401

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -1298,6 +1298,31 @@ class UserLikes:
     models: List[str]
     spaces: List[str]
 
+@dataclass
+class Organization:
+    """
+    Contains information about an organization on the Hub.
+
+    Attributes:
+        avatar_url (`str`):
+            URL of the organization's avatar.
+        name (`str`):
+            Name of the organization on the Hub (unique).
+        fullname (`str`):
+            Organization's full name.
+    """
+
+    avatar_url: str
+    name: str
+    fullname: str
+
+    def __init__(self, **kwargs) -> None:
+        self.avatar_url = kwargs.pop("avatarUrl", "")
+        self.name = kwargs.pop("name", "")
+        self.fullname = kwargs.pop("fullname", "")
+
+        # forward compatibility
+        self.__dict__.update(**kwargs)
 
 @dataclass
 class User:
@@ -1347,22 +1372,24 @@ class User:
     num_likes: Optional[int] = None
     is_following: Optional[bool] = None
     details: Optional[str] = None
+    orgs: List[Organization] = field(default_factory=list)
 
     def __init__(self, **kwargs) -> None:
-        self.avatar_url = kwargs.get("avatarUrl", "")
-        self.username = kwargs.get("user", "")
-        self.fullname = kwargs.get("fullname", "")
-        self.is_pro = kwargs.get("isPro")
-        self.num_models = kwargs.get("numModels")
-        self.num_datasets = kwargs.get("numDatasets")
-        self.num_spaces = kwargs.get("numSpaces")
-        self.num_discussions = kwargs.get("numDiscussions")
-        self.num_papers = kwargs.get("numPapers")
-        self.num_upvotes = kwargs.get("numUpvotes")
-        self.num_likes = kwargs.get("numLikes")
-        self.user_type = kwargs.get("type")
-        self.is_following = kwargs.get("isFollowing")
-        self.details = kwargs.get("details")
+        self.avatar_url = kwargs.pop("avatarUrl", "")
+        self.username = kwargs.pop("user", "")
+        self.fullname = kwargs.pop("fullname", "")
+        self.is_pro = kwargs.pop("isPro", None)
+        self.num_models = kwargs.pop("numModels", None)
+        self.num_datasets = kwargs.pop("numDatasets", None)
+        self.num_spaces = kwargs.pop("numSpaces", None)
+        self.num_discussions = kwargs.pop("numDiscussions", None)
+        self.num_papers = kwargs.pop("numPapers", None)
+        self.num_upvotes = kwargs.pop("numUpvotes", None)
+        self.num_likes = kwargs.pop("numLikes", None)
+        self.user_type = kwargs.pop("type", None)
+        self.is_following = kwargs.pop("isFollowing", None)
+        self.details = kwargs.pop("details", None)
+        self.orgs = [Organization(**org) for org in kwargs.pop("orgs", [])]
 
         # forward compatibility
         self.__dict__.update(**kwargs)

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -1298,6 +1298,7 @@ class UserLikes:
     models: List[str]
     spaces: List[str]
 
+
 @dataclass
 class Organization:
     """
@@ -1323,6 +1324,7 @@ class Organization:
 
         # forward compatibility
         self.__dict__.update(**kwargs)
+
 
 @dataclass
 class User:

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -1334,10 +1334,10 @@ class User:
     Attributes:
         username (`str`):
             Name of the user on the Hub (unique).
-        avatar_url (`str`):
-            URL of the user's avatar.
         fullname (`str`):
             User's full name.
+        avatar_url (`str`):
+            URL of the user's avatar.
         details (`str`, *optional*):
             User's details.
         is_following (`bool`, *optional*):
@@ -1364,9 +1364,9 @@ class User:
 
     # Metadata
     username: str
+    fullname: str
     avatar_url: str
     details: Optional[str] = None
-    fullname: str
     is_following: Optional[bool] = None
     is_pro: Optional[bool] = None
     num_models: Optional[int] = None
@@ -1380,8 +1380,8 @@ class User:
 
     def __init__(self, **kwargs) -> None:
         self.username = kwargs.pop("user", "")
-        self.avatar_url = kwargs.pop("avatarUrl", "")
         self.fullname = kwargs.pop("fullname", "")
+        self.avatar_url = kwargs.pop("avatarUrl", "")
         self.is_following = kwargs.pop("isFollowing", None)
         self.is_pro = kwargs.pop("isPro", None)
         self.details = kwargs.pop("details", None)

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -1332,12 +1332,16 @@ class User:
     Contains information about a user on the Hub.
 
     Attributes:
-        avatar_url (`str`):
-            URL of the user's avatar.
         username (`str`):
             Name of the user on the Hub (unique).
+        avatar_url (`str`):
+            URL of the user's avatar.
         fullname (`str`):
             User's full name.
+        details (`str`, *optional*):
+            User's details.
+        is_following (`bool`, *optional*):
+            Whether the authenticated user is following this user.
         is_pro (`bool`, *optional*):
             Whether the user is a pro user.
         num_models (`int`, *optional*):
@@ -1354,16 +1358,16 @@ class User:
             Number of upvotes received by the user.
         num_likes (`int`, *optional*):
             Number of likes given by the user.
-        is_following (`bool`, *optional*):
-            Whether the authenticated user is following this user.
-        details (`str`, *optional*):
-            User's details.
+        orgs (list of [`Organization`]):
+            List of organizations the user is part of.
     """
 
     # Metadata
-    avatar_url: str
     username: str
+    avatar_url: str
+    details: Optional[str] = None
     fullname: str
+    is_following: Optional[bool] = None
     is_pro: Optional[bool] = None
     num_models: Optional[int] = None
     num_datasets: Optional[int] = None
@@ -1372,15 +1376,15 @@ class User:
     num_papers: Optional[int] = None
     num_upvotes: Optional[int] = None
     num_likes: Optional[int] = None
-    is_following: Optional[bool] = None
-    details: Optional[str] = None
     orgs: List[Organization] = field(default_factory=list)
 
     def __init__(self, **kwargs) -> None:
-        self.avatar_url = kwargs.pop("avatarUrl", "")
         self.username = kwargs.pop("user", "")
+        self.avatar_url = kwargs.pop("avatarUrl", "")
         self.fullname = kwargs.pop("fullname", "")
+        self.is_following = kwargs.pop("isFollowing", None)
         self.is_pro = kwargs.pop("isPro", None)
+        self.details = kwargs.pop("details", None)
         self.num_models = kwargs.pop("numModels", None)
         self.num_datasets = kwargs.pop("numDatasets", None)
         self.num_spaces = kwargs.pop("numSpaces", None)
@@ -1389,8 +1393,6 @@ class User:
         self.num_upvotes = kwargs.pop("numUpvotes", None)
         self.num_likes = kwargs.pop("numLikes", None)
         self.user_type = kwargs.pop("type", None)
-        self.is_following = kwargs.pop("isFollowing", None)
-        self.details = kwargs.pop("details", None)
         self.orgs = [Organization(**org) for org in kwargs.pop("orgs", [])]
 
         # forward compatibility

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -4007,15 +4007,15 @@ class UserApiTest(unittest.TestCase):
 
     def test_organization_members(self) -> None:
         members = self.api.list_organization_members("huggingface")
-        assert len(list(members)) >  1
+        assert len(list(members)) > 1
 
     def test_user_followers(self) -> None:
         followers = self.api.list_user_followers("julien-c")
-        assert len(list(followers)) >  10
+        assert len(list(followers)) > 10
 
     def test_user_following(self) -> None:
         following = self.api.list_user_following("julien-c")
-        assert len(list(following)) >  10
+        assert len(list(following)) > 10
 
 
 class WebhookApiTest(HfApiCommonTest):

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -3998,21 +3998,24 @@ class UserApiTest(unittest.TestCase):
 
     def test_user_overview(self) -> None:
         overview = self.api.get_user_overview("julien-c")
-        self.assertEqual(overview.user_type, "user")
-        self.assertGreater(overview.num_likes, 10)
-        self.assertGreater(overview.num_upvotes, 10)
+        assert overview.user_type == "user"
+        assert overview.username == "julien-c"
+        assert overview.num_likes > 10
+        assert overview.num_upvotes > 10
+        assert len(overview.orgs) > 0
+        assert any(org.name == "huggingface" for org in overview.orgs)
 
     def test_organization_members(self) -> None:
         members = self.api.list_organization_members("huggingface")
-        self.assertGreater(len(list(members)), 1)
+        assert len(list(members)) >  1
 
     def test_user_followers(self) -> None:
         followers = self.api.list_user_followers("julien-c")
-        self.assertGreater(len(list(followers)), 10)
+        assert len(list(followers)) >  10
 
     def test_user_following(self) -> None:
         following = self.api.list_user_following("julien-c")
-        self.assertGreater(len(list(following)), 10)
+        assert len(list(following)) >  10
 
 
 class WebhookApiTest(HfApiCommonTest):


### PR DESCRIPTION
Follow-up PR after server-side update (https://github.com/huggingface-internal/moon-landing/pull/10607, private link). See also discussion [in slack](https://huggingface.slack.com/archives/C02EMARJ65P/p1720532137304479) (private link).

This PR handles `orgs` in `get_user_overview`. It is an `Organization` dataclass (newly defined) with avatar_url, name and fullname.

```py
>>> from huggingface_hub import get_user_overview
>>> omar = get_user_overview("osanseviero")
>>> omar.orgs[0]
Organization(avatar_url='https://cdn-avatars.huggingface.co/v1/production/uploads/1583856921041-5dd96eb166059660ed1ee413.png', name='huggingface', fullname='Hugging Face')
```

I also realized we forgot to expose `get_user_overview` at the root of the package. This PR fixed this. Also exposing `ModelInfo`, `DatasetInfo` and `SpaceInfo` that I wanted to add since quite some time.