### PR TITLE
[hot-fix] Handle [DONE] signal from TGI + remove logic for "non-TGI servers"

### DIFF
--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -814,12 +814,13 @@ class InferenceClient:
         # since `chat_completion(..., model=xxx)` is also a payload parameter for the
         # server, we need to handle it differently
         model = self.base_url or self.model or model or self.get_recommended_model("text-generation")
+        is_url = model.startswith(("http://", "https://"))
 
         # First, resolve the model chat completions URL
         if model == self.base_url:
             # base_url passed => add server route
             model_url = model + "/v1/chat/completions"
-        elif model.startswith(("http://", "https://")):
+        elif is_url:
             # model is a URL => use it directly
             model_url = model
         else:
@@ -828,7 +829,7 @@ class InferenceClient:
 
         # `model` is sent in the payload. Not used by the server but can be useful for debugging/routing.
         # If it's a ID on the Hub => use it. Otherwise, we use a random string.
-        model_id = model if not model.startswith("http") and model.count("/") == 1 else "tgi"
+        model_id = model if not is_url and model.count("/") == 1 else "tgi"
 
         data = self.post(
             model=model_url,

--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -66,12 +66,10 @@ from huggingface_hub.inference._common import (
     _fetch_recommended_models,
     _get_unsupported_text_generation_kwargs,
     _import_numpy,
-    _is_chat_completion_server,
     _open_as_binary,
-    _set_as_non_chat_completion_server,
     _set_unsupported_text_generation_kwargs,
-    _stream_chat_completion_response_from_bytes,
-    _stream_text_generation_response_from_bytes,
+    _stream_chat_completion_response,
+    _stream_text_generation_response,
     raise_text_generation_error,
 )
 from huggingface_hub.inference._generated.types import (
@@ -82,8 +80,6 @@ from huggingface_hub.inference._generated.types import (
     ChatCompletionInputTool,
     ChatCompletionInputToolTypeClass,
     ChatCompletionOutput,
-    ChatCompletionOutputComplete,
-    ChatCompletionOutputMessage,
     ChatCompletionStreamOutput,
     DocumentQuestionAnsweringOutputElement,
     FillMaskOutputElement,
@@ -189,7 +185,7 @@ class InferenceClient:
             )
 
         self.model: Optional[str] = model
-        self.token: Union[str, bool, None] = token or api_key
+        self.token: Union[str, bool, None] = token if token is not None else api_key
         self.headers = CaseInsensitiveDict(build_hf_headers(token=self.token))  # 'authorization' + 'user-agent'
         if headers is not None:
             self.headers.update(headers)
@@ -819,122 +815,50 @@ class InferenceClient:
         # server, we need to handle it differently
         model = self.base_url or self.model or model or self.get_recommended_model("text-generation")
 
-        if _is_chat_completion_server(model):
-            # First, let's consider the server has a `/v1/chat/completions` endpoint.
-            # If that's the case, we don't have to render the chat template client-side.
-            model_url = self._resolve_url(model)
-            if not model_url.endswith("/chat/completions"):
-                model_url += "/v1/chat/completions"
+        # First, resolve the model chat completions URL
+        if model == self.base_url:
+            # base_url passed => add server route
+            model_url = model + "/v1/chat/completions"
+        elif model.startswith(("http://", "https://")):
+            # model is a URL => use it directly
+            model_url = model
+        else:
+            # model is a model ID => resolve it + add server route
+            model_url = self._resolve_url(model) + "/v1/chat/completions"
 
-            # `model` is sent in the payload. Not used by the server but can be useful for debugging/routing.
-            if not model.startswith("http") and model.count("/") == 1:
-                # If it's a ID on the Hub => use it
-                model_id = model
-            else:
-                # Otherwise, we use a random string
-                model_id = "tgi"
+        # `model` is sent in the payload. Not used by the server but can be useful for debugging/routing.
+        # If it's a ID on the Hub => use it. Otherwise, we use a random string.
+        model_id = model if not model.startswith("http") and model.count("/") == 1 else "tgi"
 
-            try:
-                data = self.post(
-                    model=model_url,
-                    json=dict(
-                        model=model_id,
-                        messages=messages,
-                        frequency_penalty=frequency_penalty,
-                        logit_bias=logit_bias,
-                        logprobs=logprobs,
-                        max_tokens=max_tokens,
-                        n=n,
-                        presence_penalty=presence_penalty,
-                        response_format=response_format,
-                        seed=seed,
-                        stop=stop,
-                        temperature=temperature,
-                        tool_choice=tool_choice,
-                        tool_prompt=tool_prompt,
-                        tools=tools,
-                        top_logprobs=top_logprobs,
-                        top_p=top_p,
-                        stream=stream,
-                    ),
-                    stream=stream,
-                )
-            except HTTPError as e:
-                if e.response.status_code in (400, 500):
-                    # Let's consider the server is not a chat completion server.
-                    # Then we call again `chat_completion` which will render the chat template client side.
-                    # (can be HTTP 500 or HTTP 400 depending on the server)
-                    _set_as_non_chat_completion_server(model)
-                    logger.warning(
-                        f"Server {model_url} does not seem to support chat completion. Falling back to text generation. Error: {e}"
-                    )
-                    return self.chat_completion(
-                        messages=messages,
-                        model=model,
-                        stream=stream,
-                        max_tokens=max_tokens,
-                        seed=seed,
-                        stop=stop,
-                        temperature=temperature,
-                        top_p=top_p,
-                    )
-                raise
+        data = self.post(
+            model=model_url,
+            json=dict(
+                model=model_id,
+                messages=messages,
+                frequency_penalty=frequency_penalty,
+                logit_bias=logit_bias,
+                logprobs=logprobs,
+                max_tokens=max_tokens,
+                n=n,
+                presence_penalty=presence_penalty,
+                response_format=response_format,
+                seed=seed,
+                stop=stop,
+                temperature=temperature,
+                tool_choice=tool_choice,
+                tool_prompt=tool_prompt,
+                tools=tools,
+                top_logprobs=top_logprobs,
+                top_p=top_p,
+                stream=stream,
+            ),
+            stream=stream,
+        )
 
-            if stream:
-                return _stream_chat_completion_response_from_bytes(data)  # type: ignore[arg-type]
-
-            return ChatCompletionOutput.parse_obj_as_instance(data)  # type: ignore[arg-type]
-
-        # At this point, we know the server is not a chat completion server.
-        # It means it's a transformers-backed server for which we can send a list of messages directly to the
-        # `text-generation` pipeline. We won't receive a detailed response but only the generated text.
         if stream:
-            raise ValueError(
-                "Streaming token is not supported by the model. This is due to the model not been served by a "
-                "Text-Generation-Inference server. Please pass `stream=False` as input."
-            )
-        if tool_choice is not None or tool_prompt is not None or tools is not None:
-            warnings.warn(
-                "Tools are not supported by the model. This is due to the model not been served by a "
-                "Text-Generation-Inference server. The provided tool parameters will be ignored."
-            )
-        if response_format is not None:
-            warnings.warn(
-                "Response format is not supported by the model. This is due to the model not been served by a "
-                "Text-Generation-Inference server. The provided response format will be ignored."
-            )
+            return _stream_chat_completion_response(data)  # type: ignore[arg-type]
 
-        # generate response
-        text_generation_output = self.text_generation(
-            prompt=messages,  # type: ignore # Not correct type but works implicitly
-            model=model,
-            stream=False,
-            details=False,
-            max_new_tokens=max_tokens,
-            seed=seed,
-            stop_sequences=stop,
-            temperature=temperature,
-            top_p=top_p,
-        )
-
-        # Format as a ChatCompletionOutput with dummy values for fields we can't provide
-        return ChatCompletionOutput(
-            id="dummy",
-            model="dummy",
-            system_fingerprint="dummy",
-            usage=None,  # type: ignore # set to `None` as we don't want to provide false information
-            created=int(time.time()),
-            choices=[
-                ChatCompletionOutputComplete(
-                    finish_reason="unk",  # type: ignore # set to `unk` as we don't want to provide false information
-                    index=0,
-                    message=ChatCompletionOutputMessage(
-                        content=text_generation_output,
-                        role="assistant",
-                    ),
-                )
-            ],
-        )
+        return ChatCompletionOutput.parse_obj_as_instance(data)  # type: ignore[arg-type]
 
     def conversational(
         self,
@@ -2249,7 +2173,7 @@ class InferenceClient:
 
         # Parse output
         if stream:
-            return _stream_text_generation_response_from_bytes(bytes_output, details)  # type: ignore
+            return _stream_text_generation_response(bytes_output, details)  # type: ignore
 
         data = _bytes_to_dict(bytes_output)  # type: ignore[arg-type]
 

--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -860,10 +860,10 @@ class InferenceClient:
                     stream=stream,
                 )
             except HTTPError as e:
-                if e.response.status_code in (400, 404, 500):
+                if e.response.status_code in (400, 500):
                     # Let's consider the server is not a chat completion server.
                     # Then we call again `chat_completion` which will render the chat template client side.
-                    # (can be HTTP 500, HTTP 400, HTTP 404 depending on the server)
+                    # (can be HTTP 500 or HTTP 400 depending on the server)
                     _set_as_non_chat_completion_server(model)
                     logger.warning(
                         f"Server {model_url} does not seem to support chat completion. Falling back to text generation. Error: {e}"

--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -71,7 +71,7 @@ from huggingface_hub.inference._common import (
     _set_as_non_chat_completion_server,
     _set_unsupported_text_generation_kwargs,
     _stream_chat_completion_response_from_bytes,
-    _stream_text_generation_response,
+    _stream_text_generation_response_from_bytes,
     raise_text_generation_error,
 )
 from huggingface_hub.inference._generated.types import (
@@ -2249,7 +2249,7 @@ class InferenceClient:
 
         # Parse output
         if stream:
-            return _stream_text_generation_response(bytes_output, details)  # type: ignore
+            return _stream_text_generation_response_from_bytes(bytes_output, details)  # type: ignore
 
         data = _bytes_to_dict(bytes_output)  # type: ignore[arg-type]
 

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -866,10 +866,10 @@ class AsyncInferenceClient:
                     stream=stream,
                 )
             except _import_aiohttp().ClientResponseError as e:
-                if e.status in (400, 404, 500):
+                if e.status in (400, 500):
                     # Let's consider the server is not a chat completion server.
                     # Then we call again `chat_completion` which will render the chat template client side.
-                    # (can be HTTP 500, HTTP 400, HTTP 404 depending on the server)
+                    # (can be HTTP 500 or HTTP 400 depending on the server)
                     _set_as_non_chat_completion_server(model)
                     logger.warning(
                         f"Server {model_url} does not seem to support chat completion. Falling back to text generation. Error: {e}"

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -820,12 +820,13 @@ class AsyncInferenceClient:
         # since `chat_completion(..., model=xxx)` is also a payload parameter for the
         # server, we need to handle it differently
         model = self.base_url or self.model or model or self.get_recommended_model("text-generation")
+        is_url = model.startswith(("http://", "https://"))
 
         # First, resolve the model chat completions URL
         if model == self.base_url:
             # base_url passed => add server route
             model_url = model + "/v1/chat/completions"
-        elif model.startswith(("http://", "https://")):
+        elif is_url:
             # model is a URL => use it directly
             model_url = model
         else:
@@ -834,7 +835,7 @@ class AsyncInferenceClient:
 
         # `model` is sent in the payload. Not used by the server but can be useful for debugging/routing.
         # If it's a ID on the Hub => use it. Otherwise, we use a random string.
-        model_id = model if not model.startswith("http") and model.count("/") == 1 else "tgi"
+        model_id = model if not is_url and model.count("/") == 1 else "tgi"
 
         data = await self.post(
             model=model_url,

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -45,7 +45,7 @@ from huggingface_hub.inference._common import (
     ContentT,
     ModelStatus,
     _async_stream_chat_completion_response_from_bytes,
-    _async_stream_text_generation_response,
+    _async_stream_text_generation_response_from_bytes,
     _b64_encode,
     _b64_to_image,
     _bytes_to_dict,
@@ -2280,7 +2280,7 @@ class AsyncInferenceClient:
 
         # Parse output
         if stream:
-            return _async_stream_text_generation_response(bytes_output, details)  # type: ignore
+            return _async_stream_text_generation_response_from_bytes(bytes_output, details)  # type: ignore
 
         data = _bytes_to_dict(bytes_output)  # type: ignore[arg-type]
 

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -44,8 +44,8 @@ from huggingface_hub.inference._common import (
     TASKS_EXPECTING_IMAGES,
     ContentT,
     ModelStatus,
-    _async_stream_chat_completion_response_from_bytes,
-    _async_stream_text_generation_response_from_bytes,
+    _async_stream_chat_completion_response,
+    _async_stream_text_generation_response,
     _b64_encode,
     _b64_to_image,
     _bytes_to_dict,
@@ -54,9 +54,7 @@ from huggingface_hub.inference._common import (
     _fetch_recommended_models,
     _get_unsupported_text_generation_kwargs,
     _import_numpy,
-    _is_chat_completion_server,
     _open_as_binary,
-    _set_as_non_chat_completion_server,
     _set_unsupported_text_generation_kwargs,
     raise_text_generation_error,
 )
@@ -68,8 +66,6 @@ from huggingface_hub.inference._generated.types import (
     ChatCompletionInputTool,
     ChatCompletionInputToolTypeClass,
     ChatCompletionOutput,
-    ChatCompletionOutputComplete,
-    ChatCompletionOutputMessage,
     ChatCompletionStreamOutput,
     DocumentQuestionAnsweringOutputElement,
     FillMaskOutputElement,
@@ -174,7 +170,7 @@ class AsyncInferenceClient:
             )
 
         self.model: Optional[str] = model
-        self.token: Union[str, bool, None] = token or api_key
+        self.token: Union[str, bool, None] = token if token is not None else api_key
         self.headers = CaseInsensitiveDict(build_hf_headers(token=self.token))  # 'authorization' + 'user-agent'
         if headers is not None:
             self.headers.update(headers)
@@ -825,122 +821,50 @@ class AsyncInferenceClient:
         # server, we need to handle it differently
         model = self.base_url or self.model or model or self.get_recommended_model("text-generation")
 
-        if _is_chat_completion_server(model):
-            # First, let's consider the server has a `/v1/chat/completions` endpoint.
-            # If that's the case, we don't have to render the chat template client-side.
-            model_url = self._resolve_url(model)
-            if not model_url.endswith("/chat/completions"):
-                model_url += "/v1/chat/completions"
+        # First, resolve the model chat completions URL
+        if model == self.base_url:
+            # base_url passed => add server route
+            model_url = model + "/v1/chat/completions"
+        elif model.startswith(("http://", "https://")):
+            # model is a URL => use it directly
+            model_url = model
+        else:
+            # model is a model ID => resolve it + add server route
+            model_url = self._resolve_url(model) + "/v1/chat/completions"
 
-            # `model` is sent in the payload. Not used by the server but can be useful for debugging/routing.
-            if not model.startswith("http") and model.count("/") == 1:
-                # If it's a ID on the Hub => use it
-                model_id = model
-            else:
-                # Otherwise, we use a random string
-                model_id = "tgi"
+        # `model` is sent in the payload. Not used by the server but can be useful for debugging/routing.
+        # If it's a ID on the Hub => use it. Otherwise, we use a random string.
+        model_id = model if not model.startswith("http") and model.count("/") == 1 else "tgi"
 
-            try:
-                data = await self.post(
-                    model=model_url,
-                    json=dict(
-                        model=model_id,
-                        messages=messages,
-                        frequency_penalty=frequency_penalty,
-                        logit_bias=logit_bias,
-                        logprobs=logprobs,
-                        max_tokens=max_tokens,
-                        n=n,
-                        presence_penalty=presence_penalty,
-                        response_format=response_format,
-                        seed=seed,
-                        stop=stop,
-                        temperature=temperature,
-                        tool_choice=tool_choice,
-                        tool_prompt=tool_prompt,
-                        tools=tools,
-                        top_logprobs=top_logprobs,
-                        top_p=top_p,
-                        stream=stream,
-                    ),
-                    stream=stream,
-                )
-            except _import_aiohttp().ClientResponseError as e:
-                if e.status in (400, 500):
-                    # Let's consider the server is not a chat completion server.
-                    # Then we call again `chat_completion` which will render the chat template client side.
-                    # (can be HTTP 500 or HTTP 400 depending on the server)
-                    _set_as_non_chat_completion_server(model)
-                    logger.warning(
-                        f"Server {model_url} does not seem to support chat completion. Falling back to text generation. Error: {e}"
-                    )
-                    return await self.chat_completion(
-                        messages=messages,
-                        model=model,
-                        stream=stream,
-                        max_tokens=max_tokens,
-                        seed=seed,
-                        stop=stop,
-                        temperature=temperature,
-                        top_p=top_p,
-                    )
-                raise
+        data = await self.post(
+            model=model_url,
+            json=dict(
+                model=model_id,
+                messages=messages,
+                frequency_penalty=frequency_penalty,
+                logit_bias=logit_bias,
+                logprobs=logprobs,
+                max_tokens=max_tokens,
+                n=n,
+                presence_penalty=presence_penalty,
+                response_format=response_format,
+                seed=seed,
+                stop=stop,
+                temperature=temperature,
+                tool_choice=tool_choice,
+                tool_prompt=tool_prompt,
+                tools=tools,
+                top_logprobs=top_logprobs,
+                top_p=top_p,
+                stream=stream,
+            ),
+            stream=stream,
+        )
 
-            if stream:
-                return _async_stream_chat_completion_response_from_bytes(data)  # type: ignore[arg-type]
-
-            return ChatCompletionOutput.parse_obj_as_instance(data)  # type: ignore[arg-type]
-
-        # At this point, we know the server is not a chat completion server.
-        # It means it's a transformers-backed server for which we can send a list of messages directly to the
-        # `text-generation` pipeline. We won't receive a detailed response but only the generated text.
         if stream:
-            raise ValueError(
-                "Streaming token is not supported by the model. This is due to the model not been served by a "
-                "Text-Generation-Inference server. Please pass `stream=False` as input."
-            )
-        if tool_choice is not None or tool_prompt is not None or tools is not None:
-            warnings.warn(
-                "Tools are not supported by the model. This is due to the model not been served by a "
-                "Text-Generation-Inference server. The provided tool parameters will be ignored."
-            )
-        if response_format is not None:
-            warnings.warn(
-                "Response format is not supported by the model. This is due to the model not been served by a "
-                "Text-Generation-Inference server. The provided response format will be ignored."
-            )
+            return _async_stream_chat_completion_response(data)  # type: ignore[arg-type]
 
-        # generate response
-        text_generation_output = await self.text_generation(
-            prompt=messages,  # type: ignore # Not correct type but works implicitly
-            model=model,
-            stream=False,
-            details=False,
-            max_new_tokens=max_tokens,
-            seed=seed,
-            stop_sequences=stop,
-            temperature=temperature,
-            top_p=top_p,
-        )
-
-        # Format as a ChatCompletionOutput with dummy values for fields we can't provide
-        return ChatCompletionOutput(
-            id="dummy",
-            model="dummy",
-            system_fingerprint="dummy",
-            usage=None,  # type: ignore # set to `None` as we don't want to provide false information
-            created=int(time.time()),
-            choices=[
-                ChatCompletionOutputComplete(
-                    finish_reason="unk",  # type: ignore # set to `unk` as we don't want to provide false information
-                    index=0,
-                    message=ChatCompletionOutputMessage(
-                        content=text_generation_output,
-                        role="assistant",
-                    ),
-                )
-            ],
-        )
+        return ChatCompletionOutput.parse_obj_as_instance(data)  # type: ignore[arg-type]
 
     async def conversational(
         self,
@@ -2280,7 +2204,7 @@ class AsyncInferenceClient:
 
         # Parse output
         if stream:
-            return _async_stream_text_generation_response_from_bytes(bytes_output, details)  # type: ignore
+            return _async_stream_text_generation_response(bytes_output, details)  # type: ignore
 
         data = _bytes_to_dict(bytes_output)  # type: ignore[arg-type]
 

--- a/tests/cassettes/InferenceClientVCRTest.test_chat_completion_with_non_tgi.yaml
+++ b/tests/cassettes/InferenceClientVCRTest.test_chat_completion_with_non_tgi.yaml
@@ -1,11 +1,11 @@
 interactions:
 - request:
-    body: '{"model": "tgi", "messages": [{"role": "system", "content": "You are a
-      helpful assistant."}, {"role": "user", "content": "What is deep learning?"}],
+    body: '{"model": "microsoft/DialoGPT-small", "messages": [{"role": "system", "content":
+      "You are a helpful assistant."}, {"role": "user", "content": "What is deep learning?"}],
       "frequency_penalty": null, "logit_bias": null, "logprobs": null, "max_tokens":
-      20, "n": null, "presence_penalty": null, "seed": null, "stop": null, "temperature":
-      null, "tool_choice": null, "tool_prompt": null, "tools": null, "top_logprobs":
-      null, "top_p": null, "stream": false}'
+      20, "n": null, "presence_penalty": null, "response_format": null, "seed": null,
+      "stop": null, "temperature": null, "tool_choice": null, "tool_prompt": null,
+      "tools": null, "top_logprobs": null, "top_p": null, "stream": false}'
     headers:
       Accept:
       - '*/*'
@@ -14,152 +14,60 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '428'
+      - '474'
       Content-Type:
       - application/json
       X-Amzn-Trace-Id:
-      - 0f793623-22a8-48a6-834b-81b58b19b92c
+      - a45a2f60-ca49-41ee-b75e-d7164591a9f0
       user-agent:
-      - unknown/None; hf_hub/0.23.0.dev0; python/3.10.12; torch/2.2.1; tensorflow/2.15.0.post1;
+      - unknown/None; hf_hub/0.24.0.dev0; python/3.10.12; torch/2.3.1; tensorflow/2.17.0;
         fastcore/1.5.23
     method: POST
     uri: https://api-inference.huggingface.co/models/microsoft/DialoGPT-small/v1/chat/completions
   response:
     body:
-      string: '{"error":"unknown error","warnings":["There was an inference error:
-        unknown error: can only concatenate str (not \"dict\") to str"]}'
+      string: '{"object":"chat.completion","id":"","created":1721743094,"model":"microsoft/DialoGPT-small","system_fingerprint":"2.1.1-sha-4dfdb48","choices":[{"index":0,"message":{"role":"assistant","content":"What
+        does deep learning have to do with anything?"},"logprobs":null,"finish_reason":"eos_token"}],"usage":{"prompt_tokens":13,"completion_tokens":11,"total_tokens":24}}'
     headers:
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Tue, 30 Apr 2024 10:49:22 GMT
+      - Tue, 23 Jul 2024 13:58:14 GMT
       Transfer-Encoding:
       - chunked
       access-control-allow-credentials:
       - 'true'
-      access-control-expose-headers:
-      - x-compute-type, x-compute-time
-      server:
-      - uvicorn
+      access-control-allow-origin:
+      - '*'
       vary:
-      - Origin, Access-Control-Request-Method, Access-Control-Request-Headers
+      - origin, access-control-request-method, access-control-request-headers, Origin,
+        Access-Control-Request-Method, Access-Control-Request-Headers
+      x-compute-characters:
+      - '76'
       x-compute-time:
-      - '0.001'
+      - '0.280570863'
       x-compute-type:
       - cpu
+      x-generated-tokens:
+      - '11'
+      x-inference-time:
+      - '280'
+      x-prompt-tokens:
+      - '1003'
+      x-queue-time:
+      - '0'
       x-request-id:
-      - 2-JgFiFGmvDDPzJchhq6a
+      - p21wbqdpHwBb21ze7bqhQ
       x-sha:
       - 49c537161a457d5256512f9d2d38a87d81ae0f0e
-    status:
-      code: 500
-      message: Internal Server Error
-- request:
-    body: '{"inputs": [{"role": "system", "content": "You are a helpful assistant."},
-      {"role": "user", "content": "What is deep learning?"}], "parameters": {"do_sample":
-      false, "max_new_tokens": 20, "return_full_text": false, "stop": []}, "stream":
-      false}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '244'
-      Content-Type:
-      - application/json
-      X-Amzn-Trace-Id:
-      - 5493238e-8215-44d9-a30d-02bbe8d8fee2
-      user-agent:
-      - unknown/None; hf_hub/0.23.0.dev0; python/3.10.12; torch/2.2.1; tensorflow/2.15.0.post1;
-        fastcore/1.5.23
-    method: POST
-    uri: https://api-inference.huggingface.co/models/microsoft/DialoGPT-small
-  response:
-    body:
-      string: '{"error":"The following `model_kwargs` are not used by the model: [''stop'']
-        (note: typos in the generate arguments will also show up in this list)","warnings":["There
-        was an inference error: The following `model_kwargs` are not used by the model:
-        [''stop''] (note: typos in the generate arguments will also show up in this
-        list)"]}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 30 Apr 2024 10:49:22 GMT
-      Transfer-Encoding:
-      - chunked
-      access-control-allow-credentials:
-      - 'true'
-      access-control-expose-headers:
-      - x-compute-type, x-compute-time
-      server:
-      - uvicorn
-      vary:
-      - Origin, Access-Control-Request-Method, Access-Control-Request-Headers
-      x-compute-time:
-      - '0.002'
-      x-compute-type:
-      - cpu
-      x-request-id:
-      - KBkATPrqJyS7FlCaYnrWK
-      x-sha:
-      - 49c537161a457d5256512f9d2d38a87d81ae0f0e
-    status:
-      code: 400
-      message: Bad Request
-- request:
-    body: '{"inputs": [{"role": "system", "content": "You are a helpful assistant."},
-      {"role": "user", "content": "What is deep learning?"}], "parameters": {"do_sample":
-      false, "max_new_tokens": 20, "return_full_text": false}, "stream": false}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '232'
-      Content-Type:
-      - application/json
-      X-Amzn-Trace-Id:
-      - 5fb6d7d3-1604-4957-9111-0a737c90e69b
-      user-agent:
-      - unknown/None; hf_hub/0.23.0.dev0; python/3.10.12; torch/2.2.1; tensorflow/2.15.0.post1;
-        fastcore/1.5.23
-    method: POST
-    uri: https://api-inference.huggingface.co/models/microsoft/DialoGPT-small
-  response:
-    body:
-      string: '[{"generated_text":"Deep learning is a thing."}]'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '48'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 30 Apr 2024 10:49:22 GMT
-      access-control-allow-credentials:
-      - 'true'
-      vary:
-      - Origin, Access-Control-Request-Method, Access-Control-Request-Headers
-      x-compute-time:
-      - '0.146'
-      x-compute-type:
-      - cache
-      x-request-id:
-      - xueA4XZTpX7lVK8Imy-Ys
-      x-sha:
-      - 49c537161a457d5256512f9d2d38a87d81ae0f0e
+      x-time-per-token:
+      - '25'
+      x-total-time:
+      - '280'
+      x-validation-time:
+      - '0'
     status:
       code: 200
       message: OK

--- a/tests/cassettes/test_async_chat_completion_not_tgi_no_stream.yaml
+++ b/tests/cassettes/test_async_chat_completion_not_tgi_no_stream.yaml
@@ -3,187 +3,55 @@ interactions:
     body: null
     headers:
       user-agent:
-      - unknown/None; hf_hub/0.22.0.dev0; python/3.10.12; torch/2.2.0; tensorflow/2.15.0.post1;
+      - unknown/None; hf_hub/0.24.0.dev0; python/3.10.12; torch/2.3.1; tensorflow/2.17.0;
         fastcore/1.5.23
     method: POST
     uri: https://api-inference.huggingface.co/models/microsoft/DialoGPT-small/v1/chat/completions
   response:
     body:
-      string: '{"error":"unknown error","warnings":["There was an inference error:
-        unknown error: can only concatenate str (not \"dict\") to str"]}'
+      string: '{"object":"chat.completion","id":"","created":1721741143,"model":"microsoft/DialoGPT-small","system_fingerprint":"2.1.1-sha-4dfdb48","choices":[{"index":0,"message":{"role":"assistant","content":"Hello,
+        advisor."},"logprobs":null,"finish_reason":"eos_token"}],"usage":{"prompt_tokens":13,"completion_tokens":5,"total_tokens":18}}'
     headers:
       Access-Control-Allow-Credentials:
       - 'true'
-      Access-Control-Expose-Headers:
-      - x-compute-type, x-compute-time
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 15 Mar 2024 10:20:28 GMT
-      Server:
-      - uvicorn
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Origin, Access-Control-Request-Method, Access-Control-Request-Headers
-      x-compute-time:
-      - '0.002'
-      x-compute-type:
-      - cpu
-      x-request-id:
-      - e_GNvQmOIgRSusaT946Hj
-      x-sha:
-      - 49c537161a457d5256512f9d2d38a87d81ae0f0e
-    status:
-      code: 500
-      message: Internal Server Error
-    url: https://api-inference.huggingface.co/models/microsoft/DialoGPT-small/v1/chat/completions
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      X-Amzn-Trace-Id:
-      - 64f7a62f-dd29-4f75-a867-c178f7091cec
-      user-agent:
-      - unknown/None; hf_hub/0.22.0.dev0; python/3.10.12; torch/2.2.0; tensorflow/2.15.0.post1;
-        fastcore/1.5.23
-    method: GET
-    uri: https://huggingface.co/api/models/microsoft/DialoGPT-small
-  response:
-    body:
-      string: '{"_id":"621ffdc136468d709f17dec4","id":"microsoft/DialoGPT-small","modelId":"microsoft/DialoGPT-small","author":"microsoft","sha":"49c537161a457d5256512f9d2d38a87d81ae0f0e","lastModified":"2024-02-29T15:48:41.000Z","private":false,"disabled":false,"gated":false,"pipeline_tag":"text-generation","tags":["transformers","pytorch","tf","jax","safetensors","gpt2","text-generation","conversational","arxiv:1911.00536","license:mit","autotrain_compatible","endpoints_compatible","has_space","text-generation-inference","region:us"],"downloads":33570,"library_name":"transformers","widgetData":[{"text":"Hey
-        my name is Julien! How are you?"},{"text":"Hey my name is Thomas! How are
-        you?"},{"text":"Hey my name is Mariama! How are you?"},{"text":"Hey my name
-        is Clara! How are you?"},{"text":"Hey my name is Julien! How are you?"},{"text":"Hi."}],"likes":79,"model-index":null,"config":{"architectures":["GPT2LMHeadModel"],"model_type":"gpt2","tokenizer_config":{"bos_token":"<|endoftext|>","chat_template":"{%
-        for message in messages %}{{ message.content }}{{ eos_token }}{% endfor %}","eos_token":"<|endoftext|>","pad_token":null,"unk_token":"<|endoftext|>"}},"cardData":{"thumbnail":"https://huggingface.co/front/thumbnails/dialogpt.png","tags":["conversational"],"license":"mit"},"transformersInfo":{"auto_model":"AutoModelForCausalLM","pipeline_tag":"text-generation","processor":"AutoTokenizer"},"spaces":["HuggingFaceH4/open_llm_leaderboard","gsaivinay/open_llm_leaderboard","GTBench/GTBench","felixz/open_llm_leaderboard","vasu0508/Meena_Chatbot","rushic24/DialoGPT-Covid-Help-Doctor","b1sheng/kg_llm_leaderboard_test","OPTML-Group/UnlearnCanvas-Benchmark","akhaliq/DialoGPT-small","mikeee/convbot","Docfile/open_llm_leaderboard","wop/test","wop/microsoft-DialoGPT-small","rodrigomasini/data_only_open_llm_leaderboard","Codermaker/microsoft-DialoGPT-small","hivemind-personalized-chat/chat-gradio","tomkr000/scottbotai","Teedossantos/microsoft-DialoGPT-small","itsarsile/microsoft-DialoGPT-small","overlordx/critic","EATHARD/chatbot","Youssefk/StoryAI","rabosh/just_deploy_experience","lilyling/Vietnam_QA","lilyling/Spain","lilyling/Italiano_QA","lilyling/Chinese_QA","wdsawdsawdadad/Chatbot_REQUIRES_OPENAI_KEY","iesir/microsoft-DialoGPT-small","fisehara/microsoft-DialoGPT-small","phenixreturn/microsoft-DialoGPT-small","hack3arma/microsoft-DialoGPT-small","rebornrulz/microsoft-DialoGPT-small","Daezi/microsoft-DialoGPT-small","pngwn/open_llm_leaderboard","pngwn/open_llm_leaderboard_two","freddyaboulton/open_llm_leaderboard_two_fix","choco9966/LeaderboardTest","Keyven/KiKi-GPT","choco9966/open-ko-llm-leaderboard","smothiki/open_llm_leaderboard","hmdsdt/microsoft-DialoGPT-small","Alfasign/Check","kevinklam/GuessWhom","Fideloub/microsoft-DialoGPT-small","JenitaChristopher/microsoft-DialoGPT-small","neubla/neubla-llm-evaluation-board","jawill/nlp_chatbot","junkim100/Self-Improving-Leaderboard"],"safetensors":{"parameters":{"F16":175620096},"total":175620096},"siblings":[{"rfilename":".gitattributes"},{"rfilename":"README.md"},{"rfilename":"config.json"},{"rfilename":"flax_model.msgpack"},{"rfilename":"generation_config.json"},{"rfilename":"generation_config_for_conversational.json"},{"rfilename":"merges.txt"},{"rfilename":"model.safetensors"},{"rfilename":"pytorch_model.bin"},{"rfilename":"tf_model.h5"},{"rfilename":"tokenizer_config.json"},{"rfilename":"vocab.json"}],"createdAt":"2022-03-02T23:29:05.000Z"}'
-    headers:
       Access-Control-Allow-Origin:
-      - https://huggingface.co
-      Access-Control-Expose-Headers:
-      - X-Repo-Commit,X-Request-Id,X-Error-Code,X-Error-Message,ETag,Link,Accept-Ranges,Content-Range
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '3428'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 15 Mar 2024 10:20:29 GMT
-      ETag:
-      - W/"d64-QkhMKaEY+/4MIJGzLpoS4MYumYc"
-      Referrer-Policy:
-      - strict-origin-when-cross-origin
-      Vary:
-      - Origin
-      Via:
-      - 1.1 10138b7f7e9a868032a16788e533ba0e.cloudfront.net (CloudFront)
-      X-Amz-Cf-Id:
-      - L3_KSby-FamqJpVHycAHx2ERdGxh-eKzWso2-rUNLpw2IsnQsxfqDA==
-      X-Amz-Cf-Pop:
-      - CDG52-P4
-      X-Cache:
-      - Miss from cloudfront
-      X-Powered-By:
-      - huggingface-moon
-      X-Request-Id:
-      - Root=1-65f420ed-2a4cd6394ff6444f4576977a;64f7a62f-dd29-4f75-a867-c178f7091cec
-      cross-origin-opener-policy:
-      - same-origin
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      user-agent:
-      - unknown/None; hf_hub/0.22.0.dev0; python/3.10.12; torch/2.2.0; tensorflow/2.15.0.post1;
-        fastcore/1.5.23
-    method: POST
-    uri: https://api-inference.huggingface.co/models/microsoft/DialoGPT-small
-  response:
-    body:
-      string: '{"error":"The following `model_kwargs` are not used by the model: [''details'',
-        ''watermark'', ''stop'', ''decoder_input_details''] (note: typos in the generate
-        arguments will also show up in this list)","warnings":["There was an inference
-        error: The following `model_kwargs` are not used by the model: [''details'',
-        ''watermark'', ''stop'', ''decoder_input_details''] (note: typos in the generate
-        arguments will also show up in this list)"]}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - 'true'
-      Access-Control-Expose-Headers:
-      - x-compute-type, x-compute-time
+      - '*'
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Fri, 15 Mar 2024 10:20:29 GMT
-      Server:
-      - uvicorn
+      - Tue, 23 Jul 2024 13:25:43 GMT
       Transfer-Encoding:
       - chunked
       Vary:
-      - Origin, Access-Control-Request-Method, Access-Control-Request-Headers
-      x-compute-time:
-      - '0.003'
-      x-compute-type:
-      - cpu
-      x-request-id:
-      - t7qWwwa1TOJ96IXnQdrXv
-      x-sha:
-      - 49c537161a457d5256512f9d2d38a87d81ae0f0e
-    status:
-      code: 400
-      message: Bad Request
-    url: https://api-inference.huggingface.co/models/microsoft/DialoGPT-small
-- request:
-    body: null
-    headers:
-      user-agent:
-      - unknown/None; hf_hub/0.22.0.dev0; python/3.10.12; torch/2.2.0; tensorflow/2.15.0.post1;
-        fastcore/1.5.23
-    method: POST
-    uri: https://api-inference.huggingface.co/models/microsoft/DialoGPT-small
-  response:
-    body:
-      string: '[{"generated_text":"Deep learning is a thing."}]'
-    headers:
-      Access-Control-Allow-Credentials:
-      - 'true'
-      Access-Control-Expose-Headers:
-      - x-compute-type, x-compute-time
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 15 Mar 2024 10:20:30 GMT
-      Server:
-      - uvicorn
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Origin, Access-Control-Request-Method, Access-Control-Request-Headers
+      - origin, access-control-request-method, access-control-request-headers, Origin,
+        Access-Control-Request-Method, Access-Control-Request-Headers
       x-compute-characters:
       - '76'
       x-compute-time:
-      - '0.169'
+      - '0.173463809'
       x-compute-type:
       - cpu
+      x-generated-tokens:
+      - '5'
+      x-inference-time:
+      - '173'
+      x-prompt-tokens:
+      - '1013'
+      x-queue-time:
+      - '0'
       x-request-id:
-      - oDjQSzomFaFX3l8he4yhw
+      - LEQ2JaBkl2faV6UcFQzHp
       x-sha:
       - 49c537161a457d5256512f9d2d38a87d81ae0f0e
+      x-time-per-token:
+      - '34'
+      x-total-time:
+      - '173'
+      x-validation-time:
+      - '0'
     status:
       code: 200
       message: OK
-    url: https://api-inference.huggingface.co/models/microsoft/DialoGPT-small
 version: 1

--- a/tests/test_inference_async_client.py
+++ b/tests/test_inference_async_client.py
@@ -188,21 +188,19 @@ async def test_async_chat_completion_not_tgi_no_stream() -> None:
     output = await async_client.chat_completion(CHAT_COMPLETION_MESSAGES, max_tokens=10)
     assert isinstance(output.created, int)
     assert output == ChatCompletionOutput(
-        id="dummy",
-        model="dummy",
-        system_fingerprint="dummy",
-        usage=None,
         choices=[
             ChatCompletionOutputComplete(
-                finish_reason="unk",  # Non-TGI => cannot know the finish reason
+                finish_reason="eos_token",
                 index=0,
-                message=ChatCompletionOutputMessage(
-                    content="Deep learning is a thing.",
-                    role="assistant",
-                ),
+                message=ChatCompletionOutputMessage(role="assistant", content="Hello, advisor.", tool_calls=None),
+                logprobs=None,
             )
         ],
-        created=output.created,
+        created=1721741143,
+        id="",
+        model="microsoft/DialoGPT-small",
+        system_fingerprint="2.1.1-sha-4dfdb48",
+        usage=ChatCompletionOutputUsage(completion_tokens=5, prompt_tokens=13, total_tokens=18),
     )
 
 

--- a/tests/test_inference_client.py
+++ b/tests/test_inference_client.py
@@ -47,8 +47,8 @@ from huggingface_hub import (
 from huggingface_hub.constants import ALL_INFERENCE_API_FRAMEWORKS, MAIN_INFERENCE_API_FRAMEWORKS
 from huggingface_hub.inference._client import _open_as_binary
 from huggingface_hub.inference._common import (
-    _stream_chat_completion_response_from_bytes,
-    _stream_text_generation_response_from_bytes,
+    _stream_chat_completion_response,
+    _stream_text_generation_response,
 )
 from huggingface_hub.utils import HfHubHTTPError, build_hf_headers
 
@@ -952,7 +952,7 @@ class TestOpenAICompatibility(unittest.TestCase):
             InferenceClient(model="meta-llama/Meta-Llama-3-8B-Instruct", base_url="http://127.0.0.1:8000")
 
 
-def test_stream_text_generation_response_from_bytes():
+def test_stream_text_generation_response():
     data = [
         b'data: {"index":1,"token":{"id":4560,"text":" trying","logprob":-2.078125,"special":false},"generated_text":null,"details":null}',
         b"",  # Empty line is skipped
@@ -961,12 +961,12 @@ def test_stream_text_generation_response_from_bytes():
         b"data: [DONE]",  # Stop signal
         b'data: {"wont be parsed": 4}',  # Won't continue after
     ]
-    output = list(_stream_text_generation_response_from_bytes(data, details=False))
+    output = list(_stream_text_generation_response(data, details=False))
     assert len(output) == 2
     assert output == [" trying", " to"]
 
 
-def test_stream_chat_completion_response_from_bytes():
+def test_stream_chat_completion_response():
     data = [
         b'data: {"object":"chat.completion.chunk","id":"","created":1721737661,"model":"","system_fingerprint":"2.1.2-dev0-sha-5fca30e","choices":[{"index":0,"delta":{"role":"assistant","content":"Both"},"logprobs":null,"finish_reason":null}]}',
         b"",  # Empty line is skipped
@@ -975,7 +975,7 @@ def test_stream_chat_completion_response_from_bytes():
         b"data: [DONE]",  # Stop signal
         b'data: {"wont be parsed": 4}',  # Won't continue after
     ]
-    output = list(_stream_chat_completion_response_from_bytes(data))
+    output = list(_stream_chat_completion_response(data))
     assert len(output) == 2
     assert output[0].choices[0].delta.content == "Both"
     assert output[1].choices[0].delta.content == " Rust"

--- a/tests/test_inference_client.py
+++ b/tests/test_inference_client.py
@@ -813,12 +813,12 @@ class TestHeadersAndCookies(unittest.TestCase):
         response = client.post(data=b"content", model="username/repo_name")
         self.assertEqual(response, get_session_mock().post.return_value.content)
 
-        expected_user_agent = build_hf_headers()["user-agent"]
+        expected_headers = build_hf_headers()
         get_session_mock().post.assert_called_once_with(
             "https://api-inference.huggingface.co/models/username/repo_name",
             json=None,
             data=b"content",
-            headers={"user-agent": expected_user_agent, "X-My-Header": "foo"},
+            headers={**expected_headers, "X-My-Header": "foo"},
             cookies={"my-cookie": "bar"},
             timeout=None,
             stream=False,

--- a/tests/test_inference_client.py
+++ b/tests/test_inference_client.py
@@ -960,7 +960,8 @@ def test_stream_text_generation_response():
         b"\n",  # Newline is skipped
         b'data: {"index":2,"token":{"id":311,"text":" to","logprob":-0.026245117,"special":false},"generated_text":" trying to","details":null}',
         b"data: [DONE]",  # Stop signal
-        b'data: {"wont be parsed": 4}',  # Won't continue after
+        # Won't parse after
+        b'data: {"index":2,"token":{"id":311,"text":" to","logprob":-0.026245117,"special":false},"generated_text":" trying to","details":null}',
     ]
     output = list(_stream_text_generation_response(data, details=False))
     assert len(output) == 2
@@ -974,7 +975,8 @@ def test_stream_chat_completion_response():
         b"\n",  # Newline is skipped
         b'data: {"object":"chat.completion.chunk","id":"","created":1721737661,"model":"","system_fingerprint":"2.1.2-dev0-sha-5fca30e","choices":[{"index":0,"delta":{"role":"assistant","content":" Rust"},"logprobs":null,"finish_reason":null}]}',
         b"data: [DONE]",  # Stop signal
-        b'data: {"wont be parsed": 4}',  # Won't continue after
+        # Won't parse after
+        b'data: {"index":2,"token":{"id":311,"text":" to","logprob":-0.026245117,"special":false},"generated_text":" trying to","details":null}',
     ]
     output = list(_stream_chat_completion_response(data))
     assert len(output) == 2

--- a/tests/test_inference_client.py
+++ b/tests/test_inference_client.py
@@ -27,6 +27,7 @@ from huggingface_hub import (
     ChatCompletionOutput,
     ChatCompletionOutputComplete,
     ChatCompletionOutputMessage,
+    ChatCompletionOutputUsage,
     ChatCompletionStreamOutput,
     DocumentQuestionAnsweringOutputElement,
     FillMaskOutputElement,
@@ -289,21 +290,21 @@ class InferenceClientVCRTest(InferenceClientTest):
             max_tokens=20,
         )
         assert output == ChatCompletionOutput(
-            id="dummy",
-            model="dummy",
-            system_fingerprint="dummy",
-            usage=None,
             choices=[
                 ChatCompletionOutputComplete(
-                    finish_reason="unk",  # <- specific to models served with transformers (not possible to get details)
+                    finish_reason="eos_token",
                     index=0,
                     message=ChatCompletionOutputMessage(
-                        content="Deep learning is a thing.",
-                        role="assistant",
+                        role="assistant", content="What does deep learning have to do with anything?", tool_calls=None
                     ),
+                    logprobs=None,
                 )
             ],
-            created=output.created,
+            created=1721743094,
+            id="",
+            model="microsoft/DialoGPT-small",
+            system_fingerprint="2.1.1-sha-4dfdb48",
+            usage=ChatCompletionOutputUsage(completion_tokens=11, prompt_tokens=13, total_tokens=24),
         )
 
     def test_chat_completion_with_tool(self) -> None:

--- a/utils/generate_async_inference_client.py
+++ b/utils/generate_async_inference_client.py
@@ -344,14 +344,6 @@ def _adapt_text_generation_to_async(code: str) -> str:
 
 
 def _adapt_chat_completion_to_async(code: str) -> str:
-    # Catch `aiohttp` error instead of `requests` error
-    code = code.replace(
-        """            except HTTPError as e:
-                if e.response.status_code in (400, 500):""",
-        """            except _import_aiohttp().ClientResponseError as e:
-                if e.status in (400, 500):""",
-    )
-
     # Await text-generation call
     code = code.replace(
         "text_generation_output = self.text_generation(",
@@ -414,12 +406,10 @@ def _update_examples_in_public_methods(code: str) -> str:
 
 def _use_async_streaming_util(code: str) -> str:
     code = code.replace(
-        "_stream_text_generation_response_from_bytes",
-        "_async_stream_text_generation_response_from_bytes",
+        "_stream_text_generation_response",
+        "_async_stream_text_generation_response",
     )
-    code = code.replace(
-        "_stream_chat_completion_response_from_bytes", "_async_stream_chat_completion_response_from_bytes"
-    )
+    code = code.replace("_stream_chat_completion_response", "_async_stream_chat_completion_response")
     return code
 
 

--- a/utils/generate_async_inference_client.py
+++ b/utils/generate_async_inference_client.py
@@ -414,8 +414,8 @@ def _update_examples_in_public_methods(code: str) -> str:
 
 def _use_async_streaming_util(code: str) -> str:
     code = code.replace(
-        "_stream_text_generation_response",
-        "_async_stream_text_generation_response",
+        "_stream_text_generation_response_from_bytes",
+        "_async_stream_text_generation_response_from_bytes",
     )
     code = code.replace(
         "_stream_chat_completion_response_from_bytes", "_async_stream_chat_completion_response_from_bytes"

--- a/utils/generate_async_inference_client.py
+++ b/utils/generate_async_inference_client.py
@@ -347,9 +347,9 @@ def _adapt_chat_completion_to_async(code: str) -> str:
     # Catch `aiohttp` error instead of `requests` error
     code = code.replace(
         """            except HTTPError as e:
-                if e.response.status_code in (400, 404, 500):""",
+                if e.response.status_code in (400, 500):""",
         """            except _import_aiohttp().ClientResponseError as e:
-                if e.status in (400, 404, 500):""",
+                if e.status in (400, 500):""",
     )
 
     # Await text-generation call


### PR DESCRIPTION
### What's in this PR?:

1. Related to https://github.com/huggingface/text-generation-inference/pull/2221. TGI now returns a `b"data: [DONE]"` stop signal when iterating through generated tokens (stream=True). This PR adds support for this stop signal. Once this PR is merged, I'll make a hot-fix release since `InferenceClient` is currently broken on newest versions of TGI for `text_generation` and `chat_completion`.

2. I also removed all the "non-tgi" logic in `chat_completion` since every model is served by TGI now, even when it's a transformers-only model (e.g. `"microsoft/DialoGPT-small"`. This simplifies a lot the logic and will avoid hiding relevant errors to the users. In case the model is transformers-served and is not compatible with chat completion, a `422 unprocessable entity: template not found` is returned.

3. I also took the opportunity to rename some private helpers for consistency.


Better to hide whitespace changes to review this PR.