### PR TITLE
Fix creating empty commit on PR

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -3853,7 +3853,7 @@ class HfApi:
             repo_type=repo_type,
             repo_id=repo_id,
             headers=headers,
-            revision=revision,
+            revision=unquoted_revision,
             endpoint=self.endpoint,
         )
         commit_payload = _prepare_commit_payload(

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -3832,7 +3832,7 @@ class HfApi:
 
             # Get latest commit info
             try:
-                info = self.repo_info(repo_id=repo_id, repo_type=repo_type, revision=revision, token=token)
+                info = self.repo_info(repo_id=repo_id, repo_type=repo_type, revision=unquoted_revision, token=token)
             except RepositoryNotFoundError as e:
                 e.append_to_message(_CREATE_COMMIT_NO_REPO_ERROR_MESSAGE)
                 raise


### PR DESCRIPTION
Fix https://github.com/huggingface/huggingface_hub/issues/2411 cc @narugo1992

When trying to create an empty commit, the commit call is not done. Instead we retrieve the information from the last commit on the revision. On a PR, the revision is quoted twice leading to a HTTP 404 error. This PR fixes it.

I also added a regression test for it.

**EDIT:** added https://github.com/huggingface/huggingface_hub/pull/2413/commits/0329085a9fd03eab33062cec30578ba0cb12a429 after https://github.com/huggingface/huggingface_hub/pull/2412