### PR TITLE
Bug - [InferenceClient] - use proxy set in var env

### DIFF
--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -146,6 +146,8 @@ class InferenceClient:
             Values in this dictionary will override the default values.
         cookies (`Dict[str, str]`, `optional`):
             Additional cookies to send to the server.
+        proxies (`Any`, `optional`):
+            Proxies to use for the request.
         base_url (`str`, `optional`):
             Base URL to run inference. This is a duplicated argument from `model` to make [`InferenceClient`]
             follow the same pattern as `openai.OpenAI` client. Cannot be used if `model` is set. Defaults to None.

--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -146,6 +146,8 @@ class InferenceClient:
             Values in this dictionary will override the default values.
         cookies (`Dict[str, str]`, `optional`):
             Additional cookies to send to the server.
+        trust_env ('bool', 'optional'):
+            Trust environment settings for proxy configuration, default
         base_url (`str`, `optional`):
             Base URL to run inference. This is a duplicated argument from `model` to make [`InferenceClient`]
             follow the same pattern as `openai.OpenAI` client. Cannot be used if `model` is set. Defaults to None.
@@ -164,6 +166,7 @@ class InferenceClient:
         headers: Optional[Dict[str, str]] = None,
         cookies: Optional[Dict[str, str]] = None,
         proxies: Optional[Any] = None,
+        trust_env: bool = True,
         # OpenAI compatibility
         base_url: Optional[str] = None,
         api_key: Optional[str] = None,
@@ -189,6 +192,7 @@ class InferenceClient:
         self.cookies = cookies
         self.timeout = timeout
         self.proxies = proxies
+        self.trust_env = trust_env
 
         # OpenAI compatibility
         self.base_url = base_url
@@ -280,10 +284,12 @@ class InferenceClient:
 
         t0 = time.time()
         timeout = self.timeout
+        session = get_session()
+        session.trust_env = self.trust_env
         while True:
             with _open_as_binary(data) as data_as_binary:
                 try:
-                    response = get_session().post(
+                    response = session.post(
                         url,
                         json=json,
                         data=data_as_binary,
@@ -1281,8 +1287,10 @@ class InferenceClient:
                 else:
                     models_by_task.setdefault(model["task"], []).append(model["model_id"])
 
+        session = get_session()
+        session.trust_env = self.trust_env
         for framework in frameworks:
-            response = get_session().get(f"{INFERENCE_ENDPOINT}/framework/{framework}", headers=self.headers)
+            response = session.get(f"{INFERENCE_ENDPOINT}/framework/{framework}", headers=self.headers)
             hf_raise_for_status(response)
             _unpack_response(framework, response.json())
 
@@ -2646,6 +2654,9 @@ class InferenceClient:
             url = f"{INFERENCE_ENDPOINT}/models/{model}/info"
 
         response = get_session().get(url, headers=self.headers)
+        session = get_session()
+        session.trust_env = self.trust_env
+        response = session.get(url, headers=self.headers)
         hf_raise_for_status(response)
         return response.json()
 
@@ -2681,6 +2692,9 @@ class InferenceClient:
         url = model.rstrip("/") + "/health"
 
         response = get_session().get(url, headers=self.headers)
+        session = get_session()
+        session.trust_env = self.trust_env
+        response = session.get(url, headers=self.headers)
         return response.status_code == 200
 
     def get_model_status(self, model: Optional[str] = None) -> ModelStatus:
@@ -2721,6 +2735,9 @@ class InferenceClient:
         url = f"{INFERENCE_ENDPOINT}/status/{model}"
 
         response = get_session().get(url, headers=self.headers)
+        session = get_session()
+        session.trust_env = self.trust_env
+        response = session.get(url, headers=self.headers)
         hf_raise_for_status(response)
         response_data = response.json()
 

--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -2652,8 +2652,6 @@ class InferenceClient:
             url = model.rstrip("/") + "/info"
         else:
             url = f"{INFERENCE_ENDPOINT}/models/{model}/info"
-
-        response = get_session().get(url, headers=self.headers)
         session = get_session()
         session.trust_env = self.trust_env
         response = session.get(url, headers=self.headers)
@@ -2690,8 +2688,6 @@ class InferenceClient:
                 "Model must be an Inference Endpoint URL. For serverless Inference API, please use `InferenceClient.get_model_status`."
             )
         url = model.rstrip("/") + "/health"
-
-        response = get_session().get(url, headers=self.headers)
         session = get_session()
         session.trust_env = self.trust_env
         response = session.get(url, headers=self.headers)
@@ -2733,8 +2729,6 @@ class InferenceClient:
         if model.startswith("https://"):
             raise NotImplementedError("Model status is only available for Inference API endpoints.")
         url = f"{INFERENCE_ENDPOINT}/status/{model}"
-
-        response = get_session().get(url, headers=self.headers)
         session = get_session()
         session.trust_env = self.trust_env
         response = session.get(url, headers=self.headers)

--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -2646,6 +2646,7 @@ class InferenceClient:
             url = model.rstrip("/") + "/info"
         else:
             url = f"{INFERENCE_ENDPOINT}/models/{model}/info"
+
         response = get_session().get(url, headers=self.headers)
         hf_raise_for_status(response)
         return response.json()
@@ -2680,6 +2681,7 @@ class InferenceClient:
                 "Model must be an Inference Endpoint URL. For serverless Inference API, please use `InferenceClient.get_model_status`."
             )
         url = model.rstrip("/") + "/health"
+
         response = get_session().get(url, headers=self.headers)
         return response.status_code == 200
 
@@ -2719,6 +2721,7 @@ class InferenceClient:
         if model.startswith("https://"):
             raise NotImplementedError("Model status is only available for Inference API endpoints.")
         url = f"{INFERENCE_ENDPOINT}/status/{model}"
+
         response = get_session().get(url, headers=self.headers)
         hf_raise_for_status(response)
         response_data = response.json()

--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -2644,8 +2644,7 @@ class InferenceClient:
             url = model.rstrip("/") + "/info"
         else:
             url = f"{INFERENCE_ENDPOINT}/models/{model}/info"
-        session = get_session()
-        response = session.get(url, headers=self.headers)
+        response = get_session().get(url, headers=self.headers)
         hf_raise_for_status(response)
         return response.json()
 

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -2702,6 +2702,7 @@ class AsyncInferenceClient:
             url = model.rstrip("/") + "/info"
         else:
             url = f"{INFERENCE_ENDPOINT}/models/{model}/info"
+
         async with self._get_client_session() as client:
             response = await client.get(url, proxy=self.proxies)
             response.raise_for_status()
@@ -2738,6 +2739,7 @@ class AsyncInferenceClient:
                 "Model must be an Inference Endpoint URL. For serverless Inference API, please use `InferenceClient.get_model_status`."
             )
         url = model.rstrip("/") + "/health"
+
         async with self._get_client_session() as client:
             response = await client.get(url, proxy=self.proxies)
             return response.status == 200
@@ -2779,6 +2781,7 @@ class AsyncInferenceClient:
         if model.startswith("https://"):
             raise NotImplementedError("Model status is only available for Inference API endpoints.")
         url = f"{INFERENCE_ENDPOINT}/status/{model}"
+
         async with self._get_client_session() as client:
             response = await client.get(url, proxy=self.proxies)
             response.raise_for_status()

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -132,6 +132,10 @@ class AsyncInferenceClient:
             Values in this dictionary will override the default values.
         cookies (`Dict[str, str]`, `optional`):
             Additional cookies to send to the server.
+        trust_env ('bool', 'optional'):
+            Trust environment settings for proxy configuration if the parameter is `True` (`False` by default).
+        proxies (`Any`, `optional`):
+            Proxies to use for the request.
         base_url (`str`, `optional`):
             Base URL to run inference. This is a duplicated argument from `model` to make [`InferenceClient`]
             follow the same pattern as `openai.OpenAI` client. Cannot be used if `model` is set. Defaults to None.

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -273,7 +273,7 @@ class AsyncInferenceClient:
                 # Do not use context manager as we don't want to close the connection immediately when returning
                 # a stream
                 client = aiohttp.ClientSession(
-                    headers=headers, cookies=self.cookies, timeout=aiohttp.ClientTimeout(self.timeout)
+                    headers=headers, cookies=self.cookies, timeout=aiohttp.ClientTimeout(self.timeout), trust_env=True
                 )
 
                 try:

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -151,7 +151,7 @@ class AsyncInferenceClient:
         headers: Optional[Dict[str, str]] = None,
         cookies: Optional[Dict[str, str]] = None,
         proxies: Optional[Any] = None,
-        trust_env: bool = True,
+        trust_env: bool = False, # Default value False documented here https://github.com/aio-libs/aiohttp/blob/v3.10.0/docs/client_reference.rst?plain=1#L195 
         # OpenAI compatibility
         base_url: Optional[str] = None,
         api_key: Optional[str] = None,

--- a/utils/generate_async_inference_client.py
+++ b/utils/generate_async_inference_client.py
@@ -481,6 +481,15 @@ def _add_get_client_session(code: str) -> str:
     code = _add_before(code, "proxies: Optional[Any] = None,", "trust_env: bool = False,")
     code = _add_before(code, "\n        self.proxies = proxies\n", "\n        self.trust_env = trust_env")
 
+    # Document `trust_env` parameter
+    code = _add_before(
+        code,
+        "\n        proxies (`Any`, `optional`):",
+        """
+        trust_env ('bool', 'optional'):
+            Trust environment settings for proxy configuration if the parameter is `True` (`False` by default).""",
+    )
+
     # insert `_get_client_session` before `_resolve_url` method
     client_session_code = """
 


### PR DESCRIPTION
The AsyncInferenceClient doesn't use proxies set in environment variables. 
It uses aiohttp but doesn't set the trust_env parameter to True.

this PR handle trust_env parameter to and set aiohttp client and request client 
issue : [AsyncInferenceClient doesn't use proxies set in environment variables #2420](https://github.com/huggingface/huggingface_hub/issues/2420)