### PR TITLE
Do not raise if branch exists and no write permission

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -5760,7 +5760,7 @@ class HfApi:
         try:
             hf_raise_for_status(response)
         except HfHubHTTPError as e:
-            if e.response.status_code == 409 and exist_ok:
+            if exist_ok and e.response.status_code == 409:
                 return
             elif exist_ok and e.response.status_code == 403:
                 # No write permission on the namespace but branch might already exist

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -5760,8 +5760,18 @@ class HfApi:
         try:
             hf_raise_for_status(response)
         except HfHubHTTPError as e:
-            if not (e.response.status_code == 409 and exist_ok):
-                raise
+            if e.response.status_code == 409 and exist_ok:
+                return
+            elif exist_ok and e.response.status_code == 403:
+                # No write permission on the namespace but branch might already exist
+                try:
+                    refs = self.list_repo_refs(repo_id=repo_id, repo_type=repo_type, token=token)
+                    for branch_ref in refs.branches:
+                        if branch_ref.name == branch:
+                            return  # Branch already exists => do not raise
+                except HfHubHTTPError:
+                    pass  # We raise the original error if the branch does not exist
+            raise
 
     @validate_hf_hub_args
     def delete_branch(


### PR DESCRIPTION
Fix https://github.com/huggingface/huggingface_hub/issues/2419 (and https://github.com/huggingface/datasets/issues/7067 / https://github.com/huggingface/datasets/pull/7069).

When creating a repo with `exists_ok=True`, if the user do not have permission to create it but the repo already exists, an HTTP 403 is returned by the server. We catch this error client-side and ignore it since the repo exists. This PR adds the same logic for `create_branch`.

cc @albertvillanova @lhoestq 