### PR TITLE
fix repo-files CLI example

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -451,7 +451,7 @@ Files correctly deleted from repo. Commit: https://huggingface.co/Wauplin/my-coo
 
 Use Unix-style wildcards to delete sets of files: 
 ```bash
->>> huggingface-cli repo-files Wauplin/my-cool-model delete *.txt folder/*.bin 
+>>> huggingface-cli repo-files Wauplin/my-cool-model delete "*.txt" "folder/*.bin"
 Files correctly deleted from repo. Commit: https://huggingface.co/Wauplin/my-cool-mo...
 ```
 

--- a/src/huggingface_hub/commands/repo_files.py
+++ b/src/huggingface_hub/commands/repo_files.py
@@ -16,7 +16,7 @@
 
 Usage:
     # delete all
-    huggingface-cli repo-files <repo_id> delete *
+    huggingface-cli repo-files <repo_id> delete "*"
 
     # delete single file
     huggingface-cli repo-files <repo_id> delete file.txt
@@ -28,7 +28,7 @@ Usage:
     huggingface-cli repo-files <repo_id> delete file.txt folder/ file2.txt
 
     # delete multiple patterns
-    huggingface-cli repo-files <repo_id> delete file.txt *.json folder/*.parquet
+    huggingface-cli repo-files <repo_id> delete file.txt "*.json" "folder/*.parquet"
 
     # delete from different revision / repo-type
     huggingface-cli repo-files <repo_id> delete file.txt --revision=refs/pr/1 --repo-type=dataset


### PR DESCRIPTION
Fix https://github.com/huggingface/huggingface_hub/issues/2416

```
huggingface-cli repo-files <repo_id> delete *
```

is wrong and must be replaced by 

```
huggingface-cli repo-files <repo_id> delete "*"
```

Problem is that the shell lists all local files and add it to the executed command line. Nothing much we can do python-side unfortunately.