### PR TITLE
Do not raise if chmod fails

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1964,7 +1964,7 @@ def _chmod_and_move(src: Path, dst: Path) -> None:
             # See https://github.com/huggingface/huggingface_hub/issues/2359
             pass
 
-    shutil.move(str(src), str(dst))
+    shutil.move(str(src), str(dst), copy_function=shutil.copy)
 
 
 def _get_pointer_path(storage_folder: str, revision: str, relative_filename: str) -> str:

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1964,8 +1964,13 @@ def _chmod_and_move(src: Path, dst: Path) -> None:
             # See https://github.com/huggingface/huggingface_hub/issues/2359
             pass
 
-    shutil.move(str(src), str(dst), copy_function=shutil.copy)
+    shutil.move(str(src), str(dst), copy_function=_copy_no_matter_what)
 
+def _copy_no_matter_what(src: str, dst: str) -> None:
+    try:
+        shutil.copy2(src, dst)
+    except OSError:
+        shutil.copyfile(src, dst)
 
 def _get_pointer_path(storage_folder: str, revision: str, relative_filename: str) -> str:
     # Using `os.path.abspath` instead of `Path.resolve()` to avoid resolving symlinks

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1966,11 +1966,20 @@ def _chmod_and_move(src: Path, dst: Path) -> None:
 
     shutil.move(str(src), str(dst), copy_function=_copy_no_matter_what)
 
+
 def _copy_no_matter_what(src: str, dst: str) -> None:
+    """Copy file from src to dst.
+
+    If `shutil.copy2` fails, fallback to `shutil.copyfile`.
+    """
     try:
+        # Copy file with metadata and permission
+        # Can fail e.g. if dst is an S3 mount
         shutil.copy2(src, dst)
     except OSError:
+        # Copy only file content
         shutil.copyfile(src, dst)
+
 
 def _get_pointer_path(storage_folder: str, revision: str, relative_filename: str) -> str:
     # Using `os.path.abspath` instead of `Path.resolve()` to avoid resolving symlinks

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1951,6 +1951,11 @@ def _chmod_and_move(src: Path, dst: Path) -> None:
         tmp_file.touch()
         cache_dir_mode = Path(tmp_file).stat().st_mode
         os.chmod(str(src), stat.S_IMODE(cache_dir_mode))
+    except OSError as e:
+        logger.warning(
+            f"Could not set the permissions on the file '{src}'. "
+            f"Error: {e}.\nContinuing without setting permissions."
+        )
     finally:
         try:
             tmp_file.unlink()


### PR DESCRIPTION
Fix implementation from https://github.com/huggingface/huggingface_hub/pull/1220.

When downloading a file, we set the correct permissions on it when applicable. However if it's not possible, we shouldn't raise an exception. This PR fixes this by ignoring any OSError in the process and convert them to a warning log.

Moreover, if copying a file with `shutils.copy2` cannot be done (copy file + metadata), we default to `shutils.copyfile` (copy file content). What's important is to have the file content on the destination path rather than the metadata.

cc @XciD who got this while working on an S3 mount

**EDIT:** failing test is unrelated