### PR TITLE
Correct "login" to "log in" when used as verb

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Files will be downloaded in a local cache folder. More details in [this guide](h
 
 ### Login
 
-The Hugging Face Hub uses tokens to authenticate applications (see [docs](https://huggingface.co/docs/hub/security-tokens)). To login your machine, run the following CLI:
+The Hugging Face Hub uses tokens to authenticate applications (see [docs](https://huggingface.co/docs/hub/security-tokens)). To log in your machine, run the following CLI:
 
 ```bash
 huggingface-cli login

--- a/contrib/conftest.py
+++ b/contrib/conftest.py
@@ -21,7 +21,7 @@ def user() -> str:
 
 @pytest.fixture(autouse=True, scope="session")
 def login_as_dummy_user(token: str) -> Generator:
-    """Login with dummy user token."""
+    """Log in with dummy user token."""
     # Cannot use `monkeypatch` fixture since we want it to be "session-scoped"
     old_token = os.environ["HF_TOKEN"]
     os.environ["HF_TOKEN"] = token

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -101,7 +101,7 @@ _|_|_|_|  _|    _|  _|  _|_|  _|  _|_|    _|    _|  _|  _|  _|  _|_|      _|_|_|
 _|    _|  _|    _|  _|    _|  _|    _|    _|    _|    _|_|  _|    _|      _|        _|    _|  _|        _|
 _|    _|    _|_|      _|_|_|    _|_|_|  _|_|_|  _|      _|    _|_|_|      _|        _|    _|    _|_|_|  _|_|_|_|
 
-To login, `huggingface_hub` requires a token generated from https://huggingface.co/settings/tokens .
+To log in, `huggingface_hub` requires a token generated from https://huggingface.co/settings/tokens .
 Token:
 Add token as git credential? (Y/n)
 Token is valid (permission: write).

--- a/docs/source/en/guides/hf_file_system.md
+++ b/docs/source/en/guides/hf_file_system.md
@@ -103,11 +103,11 @@ The same workflow can also be used for [Dask](https://docs.dask.org/en/stable/ho
 
 In many cases, you must be logged in with a Hugging Face account to interact with the Hub. Refer to the [Authentication](../quick-start#authentication) section of the documentation to learn more about authentication methods on the Hub.
 
-It is also possible to login programmatically by passing your `token` as an argument to [`HfFileSystem`]:
+It is also possible to log in programmatically by passing your `token` as an argument to [`HfFileSystem`]:
 
 ```python
 >>> from huggingface_hub import HfFileSystem
 >>> fs = HfFileSystem(token=token)
 ```
 
-If you login this way, be careful not to accidentally leak the token when sharing your source code!
+If you log in this way, be careful not to accidentally leak the token when sharing your source code!

--- a/docs/source/ko/guides/cli.md
+++ b/docs/source/ko/guides/cli.md
@@ -99,7 +99,7 @@ _|_|_|_|  _|    _|  _|  _|_|  _|  _|_|    _|    _|  _|  _|  _|  _|_|      _|_|_|
 _|    _|  _|    _|  _|    _|  _|    _|    _|    _|    _|_|  _|    _|      _|        _|    _|  _|        _|
 _|    _|    _|_|      _|_|_|    _|_|_|  _|_|_|  _|      _|    _|_|_|      _|        _|    _|    _|_|_|  _|_|_|_|
 
-To login, `huggingface_hub` requires a token generated from https://huggingface.co/settings/tokens .
+To log in, `huggingface_hub` requires a token generated from https://huggingface.co/settings/tokens .
 Token:
 Add token as git credential? (Y/n)
 Token is valid (permission: write).

--- a/src/huggingface_hub/_login.py
+++ b/src/huggingface_hub/_login.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Contains methods to login to the Hub."""
+"""Contains methods to log in to the Hub."""
 
 import os
 import subprocess
@@ -60,7 +60,7 @@ def login(
     components. If `token` is not provided, it will be prompted to the user either with
     a widget (in a notebook) or via the terminal.
 
-    To login from outside of a script, one can also use `huggingface-cli login` which is
+    To log in from outside of a script, one can also use `huggingface-cli login` which is
     a cli command that wraps [`login`].
 
     <Tip>
@@ -94,7 +94,7 @@ def login(
     Raises:
         [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
             If an organization token is passed. Only personal account tokens are valid
-            to login.
+            to log in.
         [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
             If token is invalid.
         [`ImportError`](https://docs.python.org/3/library/exceptions.html#ImportError)
@@ -155,7 +155,7 @@ def logout() -> None:
 
 def interpreter_login(new_session: bool = True, write_permission: bool = False) -> None:
     """
-    Displays a prompt to login to the HF website and store the token.
+    Displays a prompt to log in to the HF website and store the token.
 
     This is equivalent to [`login`] without passing a token when not run in a notebook.
     [`interpreter_login`] is useful if you want to force the use of the terminal prompt
@@ -185,7 +185,7 @@ def interpreter_login(new_session: bool = True, write_permission: bool = False) 
         )
         print("    Setting a new token will erase the existing one.")
 
-    print("    To login, `huggingface_hub` requires a token generated from https://huggingface.co/settings/tokens .")
+    print("    To log in, `huggingface_hub` requires a token generated from https://huggingface.co/settings/tokens .")
     if os.name == "nt":
         print("Token can be pasted using 'Right-Click'.")
     token = getpass("Enter your token (input will not be visible): ")
@@ -220,7 +220,7 @@ notebooks. </center>"""
 
 def notebook_login(new_session: bool = True, write_permission: bool = False) -> None:
     """
-    Displays a widget to login to the HF website and store the token.
+    Displays a widget to log in to the HF website and store the token.
 
     This is equivalent to [`login`] without passing a token when run in a notebook.
     [`notebook_login`] is useful if you want to force the use of the notebook widget


### PR DESCRIPTION
"login" is a noun, and "log in" is a verb. I've corrected instances of "login" where it is used as a verb.