### PR TITLE
Raise with more info on 416 invalid range

### DIFF
--- a/src/huggingface_hub/utils/_errors.py
+++ b/src/huggingface_hub/utils/_errors.py
@@ -366,6 +366,11 @@ def hf_raise_for_status(response: Response, endpoint_name: Optional[str] = None)
             )
             raise HfHubHTTPError(message, response=response) from e
 
+        elif response.status_code == 416:
+            range_header = response.request.headers.get("Range")
+            message = f"{e}. Requested range: {range_header}. Content-Range: {response.headers.get('Content-Range')}."
+            raise HfHubHTTPError(message, response=response) from e
+
         # Convert `HTTPError` into a `HfHubHTTPError` to display request information
         # as well (request id and/or server error message)
         raise HfHubHTTPError(str(e), response=response) from e


### PR DESCRIPTION
Should help investigate https://github.com/huggingface/huggingface_hub/issues/2248 and [this convo](https://huggingface.slack.com/archives/C02EMARJ65P/p1723632946733569) (private slack).

From time to time we get reported that a 416 Range Not Satisfiable is raised. This PR adds more information to the raised error (requested range + response content range, if any). Should help investigate the issue.

Example:
`huggingface_hub.utils._errors.HfHubHTTPError: 416 Client Error: Range Not Satisfiable for url: https://huggingface.co/datasets/open-llm-leaderboard/results/resolve/6a8ff66a20da618386689e7e7c9c76932f0c33bf/.gitattributes. Requested range: bytes=5000-10000. Content-Range: bytes */2307. (Request ID: Root=1-66bca67b-6ad70d2e5d2917ce5d09d6b4;ffa33b3a-74de-4d8b-9d96-b240d7f8ebe6)`