### PR TITLE
Rely on SPACE_ID to check if app is local or in a Space

### DIFF
--- a/src/huggingface_hub/_webhooks_server.py
+++ b/src/huggingface_hub/_webhooks_server.py
@@ -36,7 +36,7 @@ else:
 
 
 _global_app: Optional["WebhooksServer"] = None
-_is_local = os.getenv("SYSTEM") != "spaces"
+_is_local = os.environ.get("SPACE_ID") is None
 
 
 @experimental


### PR DESCRIPTION
...in Webhooks Server.

We were previously relying on the `SYSTEM` environment variable which is not set for Docker Spaces. See related convo [on slack](https://huggingface.slack.com/archives/C02EMARJ65P/p1723640229716009?thread_ts=1723621029.478759&cid=C02EMARJ65P) (private). Better to use `SPACE_ID` which is officially documented [here](https://huggingface.co/docs/hub/en/spaces-overview#helper-environment-variables).