### PR TITLE
Fix error message on permission issue

### DIFF
--- a/src/huggingface_hub/utils/_errors.py
+++ b/src/huggingface_hub/utils/_errors.py
@@ -148,7 +148,7 @@ def hf_raise_for_status(response: Response, endpoint_name: Optional[str] = None)
                 f"\n\n{response.status_code} Forbidden: {error_message}."
                 + f"\nCannot access content at: {response.url}."
                 + "\nIf you are trying to create or update content, "
-                + "make sure you have a token with the `write` role."
+                + "make sure you have the correct permissions."
             )
             raise HfHubHTTPError(message, response=response) from e
 

--- a/src/huggingface_hub/utils/_errors.py
+++ b/src/huggingface_hub/utils/_errors.py
@@ -148,7 +148,7 @@ def hf_raise_for_status(response: Response, endpoint_name: Optional[str] = None)
                 f"\n\n{response.status_code} Forbidden: {error_message}."
                 + f"\nCannot access content at: {response.url}."
                 + "\nIf you are trying to create or update content, "
-                + "make sure you have the correct permissions."
+                + "make sure your token has the correct permissions."
             )
             raise HfHubHTTPError(message, response=response) from e
 


### PR DESCRIPTION
reported by @MoritzLaurer [on slack](https://huggingface.slack.com/archives/C02EMARJ65P/p1724144499443679) (internal)

Since we have fine-grained tokens now, the current error message `"make sure you have a token with the write role."` is not relevant anymore. This PR updates it to `"make sure your token has the correct permissions."`.