### PR TITLE
Define cache errors in errors.py

### DIFF
--- a/src/huggingface_hub/errors.py
+++ b/src/huggingface_hub/errors.py
@@ -1,8 +1,24 @@
 """Contains all custom errors."""
 
-from typing import Optional
+from pathlib import Path
+from typing import Optional, Union
 
 from requests import HTTPError, Response
+
+
+# CACHE ERRORS
+class CacheNotFound(Exception):
+    """Exception thrown when the Huggingface cache is not found."""
+
+    cache_dir: Union[str, Path]
+
+    def __init__(self, msg: str, cache_dir: Union[str, Path], *args, **kwargs):
+        super().__init__(msg, *args, **kwargs)
+        self.cache_dir = cache_dir
+
+
+class CorruptedCacheException(Exception):
+    """Exception for any unexpected structure in the Huggingface cache-system."""
 
 
 # HEADERS ERRORS

--- a/src/huggingface_hub/errors.py
+++ b/src/huggingface_hub/errors.py
@@ -7,6 +7,8 @@ from requests import HTTPError, Response
 
 
 # CACHE ERRORS
+
+
 class CacheNotFound(Exception):
     """Exception thrown when the Huggingface cache is not found."""
 

--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -17,6 +17,8 @@
 
 from huggingface_hub.errors import (
     BadRequestError,
+    CacheNotFound,
+    CorruptedCacheException,
     DisabledRepoError,
     EntryNotFoundError,
     FileMetadataError,
@@ -38,8 +40,6 @@ from ._cache_manager import (
     CachedFileInfo,
     CachedRepoInfo,
     CachedRevisionInfo,
-    CacheNotFound,
-    CorruptedCacheException,
     DeleteCacheStrategy,
     HFCacheInfo,
     scan_cache_dir,

--- a/src/huggingface_hub/utils/_cache_manager.py
+++ b/src/huggingface_hub/utils/_cache_manager.py
@@ -22,6 +22,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, FrozenSet, List, Literal, Optional, Set, Union
 
+from huggingface_hub.errors import CacheNotFound, CorruptedCacheException
+
 from ..commands._cli_utils import tabulate
 from ..constants import HF_HUB_CACHE
 from . import logging
@@ -33,20 +35,6 @@ REPO_TYPE_T = Literal["model", "dataset", "space"]
 
 # List of OS-created helper files that need to be ignored
 FILES_TO_IGNORE = [".DS_Store"]
-
-
-class CacheNotFound(Exception):
-    """Exception thrown when the Huggingface cache is not found."""
-
-    cache_dir: Union[str, Path]
-
-    def __init__(self, msg: str, cache_dir: Union[str, Path], *args, **kwargs):
-        super().__init__(msg, *args, **kwargs)
-        self.cache_dir = cache_dir
-
-
-class CorruptedCacheException(Exception):
-    """Exception for any unexpected structure in the Huggingface cache-system."""
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Below is the list of descriptions for this PR.

1. Defined two errors (CacheNotFound, CorruptedCacheExcpetion) in errors.py
- imported typing and pathlib package to keep the original definition of CacheNotFound

2. Adjusted the import paths in init.py

3. Removed the original definitions of the errors in _cache_manager.py
- added "from huggingface_hub.errors import CacheNotFound, CorruptedCacheException" for API support

4. Passed Ruff check

#2069 

Duplicate on https://github.com/huggingface/huggingface_hub/pull/2456