### PR TITLE
Fix `InferenceClient` for HF Nvidia NIM API

### DIFF
--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -824,51 +824,51 @@ class AsyncInferenceClient:
         # `self.xxx` takes precedence over the method argument only in `chat_completion`
         # since `chat_completion(..., model=xxx)` is also a payload parameter for the
         # server, we need to handle it differently
-        model = self.base_url or self.model or model or self.get_recommended_model("text-generation")
-        is_url = model.startswith(("http://", "https://"))
+        model_id_or_url = self.base_url or self.model or model or self.get_recommended_model("text-generation")
+        is_url = model_id_or_url.startswith(("http://", "https://"))
 
         # First, resolve the model chat completions URL
-        if model == self.base_url:
+        if model_id_or_url == self.base_url:
             # base_url passed => add server route
-            model_url = model.rstrip("/")
+            model_url = model_id_or_url.rstrip("/")
             if not model_url.endswith("/v1"):
                 model_url += "/v1"
             model_url += "/chat/completions"
         elif is_url:
             # model is a URL => use it directly
-            model_url = model
+            model_url = model_id_or_url
         else:
             # model is a model ID => resolve it + add server route
-            model_url = self._resolve_url(model).rstrip("/") + "/v1/chat/completions"
+            model_url = self._resolve_url(model_id_or_url).rstrip("/") + "/v1/chat/completions"
 
         # `model` is sent in the payload. Not used by the server but can be useful for debugging/routing.
         # If it's a ID on the Hub => use it. Otherwise, we use a random string.
-        model_id = model if not is_url and model.count("/") == 1 else "tgi"
+        model_id = model or self.model
+        if model_id.startswith(("http://", "https://")):
+            model_id = "tgi"  # dummy value
 
-        data = await self.post(
-            model=model_url,
-            json=dict(
-                model=model_id,
-                messages=messages,
-                frequency_penalty=frequency_penalty,
-                logit_bias=logit_bias,
-                logprobs=logprobs,
-                max_tokens=max_tokens,
-                n=n,
-                presence_penalty=presence_penalty,
-                response_format=response_format,
-                seed=seed,
-                stop=stop,
-                temperature=temperature,
-                tool_choice=tool_choice,
-                tool_prompt=tool_prompt,
-                tools=tools,
-                top_logprobs=top_logprobs,
-                top_p=top_p,
-                stream=stream,
-            ),
+        payload = dict(
+            model=model_id,
+            messages=messages,
+            frequency_penalty=frequency_penalty,
+            logit_bias=logit_bias,
+            logprobs=logprobs,
+            max_tokens=max_tokens,
+            n=n,
+            presence_penalty=presence_penalty,
+            response_format=response_format,
+            seed=seed,
+            stop=stop,
+            temperature=temperature,
+            tool_choice=tool_choice,
+            tool_prompt=tool_prompt,
+            tools=tools,
+            top_logprobs=top_logprobs,
+            top_p=top_p,
             stream=stream,
         )
+        payload = {key: value for key, value in payload.items() if value is not None}
+        data = await self.post(model=model_url, json=payload, stream=stream)
 
         if stream:
             return _async_stream_chat_completion_response(data)  # type: ignore[arg-type]


### PR DESCRIPTION
Fix https://github.com/huggingface/huggingface_hub/issues/2480.

Two things in this PR (for `chat_completion`):
- the `model` value was not set correctly in the payload. This is now fixed.
- `None` values are not sent to the server anymore. Only values from the user are forwarded.

With this, it is now possible to use the HF Nvidia NIM API using `InferenceClient`:

```py
from huggingface_hub import InferenceClient


# instead of `client = OpenAI(...)`
client = InferenceClient(
    base_url="https://huggingface.co/api/integrations/dgx/v1",
    api_key="MY_FINEGRAINED_TOKEN"
)

output = client.chat.completions.create(
    model="meta-llama/Meta-Llama-3-8B-Instruct",
    messages=[
        {"role": "system", "content": "You are a helpful assistant."},
        {"role": "user", "content": "Count to 10"},
    ],
    stream=True,
    max_tokens=1024,
)

for chunk in output:
    print(chunk.choices[0].delta.content, end="")
```

```
Here it goes:

1, 2, 3, 4, 5, 6, 7, 8, 9, 10!
```