### PR TITLE
Expose `RepoUrl` info in `CommitInfo` object

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -406,7 +406,7 @@ class CommitInfo(str):
     pr_url: Optional[str] = None
 
     # Computed from `commit_url` in `__post_init__`
-    repo_url: Optional[RepoUrl] = field(init=False)
+    repo_url: RepoUrl = field(init=False)
 
     # Computed from `pr_url` in `__post_init__`
     pr_revision: Optional[str] = field(init=False)
@@ -424,7 +424,7 @@ class CommitInfo(str):
         See https://docs.python.org/3.10/library/dataclasses.html#post-init-processing.
         """
         # Repo info
-        self.repo_url = RepoUrl(self.commit_url.split("/commit/")[0]) if "/commit/" in self.commit_url else None
+        self.repo_url = RepoUrl(self.commit_url.split("/commit/")[0])
 
         # PR info
         if self.pr_url is not None:

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -389,6 +389,9 @@ class CommitInfo(str):
             `create_pr=True` is passed. Can be passed as `discussion_num` in
             [`get_discussion_details`]. Example: `1`.
 
+        repo_url (`RepoUrl`):
+            Repo URL of the commit containing info like repo_id, repo_type, etc.
+
         _url (`str`, *optional*):
             Legacy url for `str` compatibility. Can be the url to the uploaded file on the Hub (if returned by
             [`upload_file`]), to the uploaded folder on the Hub (if returned by [`upload_folder`]) or to the commit on
@@ -401,6 +404,9 @@ class CommitInfo(str):
     commit_description: str
     oid: str
     pr_url: Optional[str] = None
+
+    # Computed from `commit_url` in `__post_init__`
+    repo_url: Optional[RepoUrl] = field(init=False)
 
     # Computed from `pr_url` in `__post_init__`
     pr_revision: Optional[str] = field(init=False)
@@ -417,6 +423,10 @@ class CommitInfo(str):
 
         See https://docs.python.org/3.10/library/dataclasses.html#post-init-processing.
         """
+        # Repo info
+        self.repo_url = RepoUrl(self.commit_url.split("/commit/")[0]) if "/commit/" in self.commit_url else None
+
+        # PR info
         if self.pr_url is not None:
             self.pr_revision = _parse_revision_from_pr_url(self.pr_url)
             self.pr_num = int(self.pr_revision.split("/")[-1])

--- a/src/huggingface_hub/utils/_errors.py
+++ b/src/huggingface_hub/utils/_errors.py
@@ -147,8 +147,7 @@ def hf_raise_for_status(response: Response, endpoint_name: Optional[str] = None)
             message = (
                 f"\n\n{response.status_code} Forbidden: {error_message}."
                 + f"\nCannot access content at: {response.url}."
-                + "\nIf you are trying to create or update content, "
-                + "make sure your token has the correct permissions."
+                + "\nMake sure your token has the correct permissions."
             )
             raise HfHubHTTPError(message, response=response) from e
 

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -3751,6 +3751,19 @@ class RepoUrlTest(unittest.TestCase):
                 self.assertEqual(url.repo_id, "squad")
                 self.assertEqual(url.repo_type, "dataset")
 
+    def test_repo_url_in_commit_info(self):
+        info = CommitInfo(
+            commit_url="https://huggingface.co/Wauplin/test-repo-id-mixin/commit/52d172a8b276e529d5260d6f3f76c85be5889dee",
+            commit_message="Dummy message",
+            commit_description="Dummy description",
+            oid="52d172a8b276e529d5260d6f3f76c85be5889dee",
+            pr_url=None,
+        )
+        assert isinstance(info.repo_url, RepoUrl)
+        assert info.repo_url.endpoint == "https://huggingface.co"
+        assert info.repo_url.repo_id == "Wauplin/test-repo-id-mixin"
+        assert info.repo_url.repo_type == "model"
+
 
 class HfApiDuplicateSpaceTest(HfApiCommonTest):
     @unittest.skip("Duplicating Space doesn't work on staging.")

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2480,6 +2480,7 @@ class UploadFolderMockedTest(unittest.TestCase):
         self.api.list_repo_files = self.repo_files_mock
 
         self.create_commit_mock = Mock()
+        self.create_commit_mock.return_value.commit_url = f"{ENDPOINT_STAGING}/username/repo_id/commit/dummy_sha"
         self.create_commit_mock.return_value.pr_url = None
         self.api.create_commit = self.create_commit_mock
 

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -98,6 +98,7 @@ from .testing_utils import (
     DUMMY_DATASET_ID_REVISION_ONE_SPECIFIC_COMMIT,
     DUMMY_MODEL_ID,
     DUMMY_MODEL_ID_REVISION_ONE_SPECIFIC_COMMIT,
+    ENDPOINT_PRODUCTION,
     SAMPLE_DATASET_IDENTIFIER,
     repo_name,
     require_git_lfs,
@@ -2699,7 +2700,7 @@ class ParseHFUrlTest(unittest.TestCase):
 
         for key, value in possible_values.items():
             self.assertEqual(
-                repo_type_and_id_from_hf_id(key, hub_url="https://huggingface.co"),
+                repo_type_and_id_from_hf_id(key, hub_url=ENDPOINT_PRODUCTION),
                 tuple(value),
             )
 
@@ -2712,7 +2713,7 @@ class ParseHFUrlTest(unittest.TestCase):
             "spaeces/user/id",  # with typo in repo type
         ]:
             with self.assertRaises(ValueError):
-                repo_type_and_id_from_hf_id(hub_id, hub_url="https://huggingface.co")
+                repo_type_and_id_from_hf_id(hub_id, hub_url=ENDPOINT_PRODUCTION)
 
 
 class HfApiDiscussionsTest(HfApiCommonTest):
@@ -3042,12 +3043,13 @@ iface = gr.Interface(fn=greet, inputs="text", outputs="text")
 iface.launch()
 """.encode()
 
+    @with_production_testing
     def setUp(self):
         super().setUp()
 
         # If generating new VCR => use personal token and REMOVE IT from the VCR
         self.repo_id = "user/tmp_test_space"  # no need to be unique as it's a VCRed test
-        self.api = HfApi(token="hf_fake_token", endpoint="https://huggingface.co")
+        self.api = HfApi(token="hf_fake_token", endpoint=ENDPOINT_PRODUCTION)
 
         # Create a Space
         self.api.create_repo(repo_id=self.repo_id, repo_type="space", space_sdk="gradio", private=True)
@@ -3133,6 +3135,7 @@ iface.launch()
         runtime = self.api.get_space_runtime("victor/static-space")
         self.assertIsInstance(runtime.raw, dict)
 
+    @with_production_testing
     def test_pause_and_restart_space(self) -> None:
         # Upload a fake app.py file
         self.api.upload_file(path_or_fileobj=b"", path_in_repo="app.py", repo_id=self.repo_id, repo_type="space")
@@ -3672,7 +3675,7 @@ class HfApiTokenAttributeTest(unittest.TestCase):
         self.assertEqual(mock_build_hf_headers.call_args[1]["user_agent"], {"A": "B"})
 
 
-@patch("huggingface_hub.constants.ENDPOINT", "https://huggingface.co")
+@patch("huggingface_hub.constants.ENDPOINT", ENDPOINT_PRODUCTION)
 class RepoUrlTest(unittest.TestCase):
     def test_repo_url_class(self):
         url = RepoUrl("https://huggingface.co/gpt2")
@@ -3698,7 +3701,7 @@ class RepoUrlTest(unittest.TestCase):
     def test_repo_url_endpoint(self):
         # Implicit endpoint
         url = RepoUrl("https://huggingface.co/gpt2")
-        self.assertEqual(url.endpoint, "https://huggingface.co")
+        self.assertEqual(url.endpoint, ENDPOINT_PRODUCTION)
 
         # Explicit endpoint
         url = RepoUrl("https://example.com/gpt2", endpoint="https://example.com")


### PR DESCRIPTION
This small PR exposes `repo_url` info in the `CommitInfo` class. This will make it easier to retrieve the repo_id of a commit, typically when `Model.push_to_hub` creates the repo + create a commit and returns only the commit info and not the repo info (requested by @not-lain [on Slack](https://huggingface.slack.com/archives/C06MW6VMZHS/p1724542935213179) -internal- + makes sense to expose it).

**Note:** `self.commit_url.split("/commit/")[0]` is guaranteed to succeed given [this](https://github.com/huggingface-internal/moon-landing/blob/43e11853fcc52163a0c61cf777fd0685eeaddbf0/server/app/gitViewerRoutes.ts#L1489) (private repo), [this](https://github.com/huggingface/huggingface_hub/blob/6438044cd2e47f757089b728bf9c796e5a462018/src/huggingface_hub/hf_api.py#L3856) and [this](https://github.com/huggingface/huggingface_hub/blob/6438044cd2e47f757089b728bf9c796e5a462018/src/huggingface_hub/hf_api.py#L3877) are the only occurrences where the commit url is computed.