### PR TITLE
Torch: test on 2.0 and latest versions + explicitly load with `weights_only=True`

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -26,8 +26,7 @@ jobs:
           [
             "Repository only",
             "Everything else",
-            "torch_1.12",
-            "torch_1.13",
+            "torch_1.11",
             "torch_latest",
           ]
         include:
@@ -82,14 +81,9 @@ jobs:
               uv pip install --upgrade torch
               ;;
 
-            torch_1.12)
+            torch_1.11)
               uv pip install "huggingface_hub[torch] @ ."
-              uv pip install torch~=1.12
-              ;;
-
-            torch_1.13)
-              uv pip install "huggingface_hub[torch] @ ."
-              uv pip install torch~=1.13
+              uv pip install torch~=1.11
               ;;
 
             tensorflow)
@@ -138,7 +132,7 @@ jobs:
               eval "$PYTEST ../tests/test_serialization.py"
             ;;
 
-            torch_1.12 | torch_1.13 | torch_latest)
+            torch_1.11 | torch_latest)
             eval "$PYTEST ../tests/test_hub_mixin*"
             eval "$PYTEST ../tests/test_serialization.py"
             ;;

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -26,7 +26,8 @@ jobs:
           [
             "Repository only",
             "Everything else",
-            "torch_1.11",
+            "torch_1.12",
+            "torch_1.13",
             "torch_latest",
           ]
         include:
@@ -81,9 +82,14 @@ jobs:
               uv pip install --upgrade torch
               ;;
 
-            torch_1.11)
+            torch_1.12)
               uv pip install "huggingface_hub[torch] @ ."
-              uv pip install torch~=1.11
+              uv pip install torch~=1.12
+              ;;
+
+            torch_1.13)
+              uv pip install "huggingface_hub[torch] @ ."
+              uv pip install torch~=1.13
               ;;
 
             tensorflow)
@@ -132,7 +138,7 @@ jobs:
               eval "$PYTEST ../tests/test_serialization.py"
             ;;
 
-            torch_1.11 | torch_latest)
+            torch_1.12 | torch_1.13 | torch_latest)
             eval "$PYTEST ../tests/test_hub_mixin*"
             eval "$PYTEST ../tests/test_serialization.py"
             ;;

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -26,7 +26,7 @@ jobs:
           [
             "Repository only",
             "Everything else",
-            "torch_2.0",
+            "torch_1.11",
             "torch_latest",
           ]
         include:
@@ -81,9 +81,9 @@ jobs:
               uv pip install --upgrade torch
               ;;
 
-            torch_2.0)
+            torch_1.11)
               uv pip install "huggingface_hub[torch] @ ."
-              uv pip install torch~=2.0
+              uv pip install torch~=1.11
               ;;
 
             tensorflow)
@@ -132,7 +132,7 @@ jobs:
               eval "$PYTEST ../tests/test_serialization.py"
             ;;
 
-            torch_2.0 | torch_latest)
+            torch_1.11 | torch_latest)
             eval "$PYTEST ../tests/test_hub_mixin*"
             eval "$PYTEST ../tests/test_serialization.py"
             ;;

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -26,7 +26,8 @@ jobs:
           [
             "Repository only",
             "Everything else",
-            "torch",
+            "torch_2.0",
+            "torch_latest",
           ]
         include:
           - python-version: "3.11" # LFS not ran on 3.8
@@ -71,8 +72,18 @@ jobs:
               git config --global user.name "ci"
               ;;
 
-            fastai | torch)
-              uv pip install "huggingface_hub[${{ matrix.test_name }}] @ ."
+            fastai)
+              uv pip install "huggingface_hub[fastai] @ ."
+              ;;
+
+            torch_latest)
+              uv pip install "huggingface_hub[torch] @ ."
+              uv pip install --upgrade torch
+              ;;
+
+            torch_2.0)
+              uv pip install "huggingface_hub[torch] @ ."
+              uv pip install torch~=2.0
               ;;
 
             tensorflow)
@@ -121,7 +132,7 @@ jobs:
               eval "$PYTEST ../tests/test_serialization.py"
             ;;
 
-            torch)
+            torch_2.0 | torch_latest)
             eval "$PYTEST ../tests/test_hub_mixin*"
             eval "$PYTEST ../tests/test_serialization.py"
             ;;

--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -820,7 +820,7 @@ class PyTorchModelHubMixin(ModelHubMixin):
 
     @classmethod
     def _load_as_pickle(cls, model: T, model_file: str, map_location: str, strict: bool) -> T:
-        state_dict = torch.load(model_file, map_location=torch.device(map_location))
+        state_dict = torch.load(model_file, map_location=torch.device(map_location), weights_only=True)
         model.load_state_dict(state_dict, strict=strict)  # type: ignore
         model.eval()  # type: ignore
         return model

--- a/tests/test_hub_mixin_pytorch.py
+++ b/tests/test_hub_mixin_pytorch.py
@@ -13,6 +13,7 @@ from huggingface_hub import HfApi, ModelCard, hf_hub_download
 from huggingface_hub.constants import PYTORCH_WEIGHTS_NAME
 from huggingface_hub.errors import EntryNotFoundError, HfHubHTTPError
 from huggingface_hub.hub_mixin import ModelHubMixin, PyTorchModelHubMixin
+from huggingface_hub.serialization._torch import storage_ptr
 from huggingface_hub.utils import SoftTemporaryDirectory, is_torch_available
 
 from .testing_constants import ENDPOINT_STAGING, TOKEN, USER
@@ -415,10 +416,10 @@ class PytorchHubMixinTest(unittest.TestCase):
 
         # Linear layers should share weights and biases in memory
         state_dict = reloaded.state_dict()
-        a_weight_ptr = state_dict["a.weight"].untyped_storage().data_ptr()
-        b_weight_ptr = state_dict["b.weight"].untyped_storage().data_ptr()
-        a_bias_ptr = state_dict["a.bias"].untyped_storage().data_ptr()
-        b_bias_ptr = state_dict["b.bias"].untyped_storage().data_ptr()
+        a_weight_ptr = storage_ptr(state_dict["a.weight"])
+        b_weight_ptr = storage_ptr(state_dict["b.weight"])
+        a_bias_ptr = storage_ptr(state_dict["a.bias"])
+        b_bias_ptr = storage_ptr(state_dict["b.bias"])
         assert a_weight_ptr == b_weight_ptr
         assert a_bias_ptr == b_bias_ptr
 


### PR DESCRIPTION
To merge before https://github.com/huggingface/huggingface_hub/pull/2440 (needed to test it). Two things in this PR:

1. we are now running the torch-test CI with `torch~=2.0` and `torch=="latest"`. This is to ensure a sense of backward-compatibility and still testing on latest updates. `2.0` was chosen arbitrarily. It has been released ~15 months ago. It doesn't mean `huggingface_hub` does not support `torch 1.0` (we would have received reports^^), just that we are not guaranteeing it.

2. Pytorch tests are currently failing in CI with this `FutureWarning`:

> _FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature._

This is actually a good opportunity to add `weights_only=True` explicitly in the Pytorch hub mixin when loading from an unsafe pickle. Note that the default file type is still `.safetensors` when saving / loading weights.

Expectations: a green CI and relaxed users!