### PR TITLE
Properly close session in `AsyncInferenceClient`

### DIFF
--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -334,11 +334,31 @@ class AsyncInferenceClient:
                     await session.close()
                     raise
 
-    def __del__(self):
-        async def _close_all_sessions():
-            await asyncio.gather(*[session.close() for session in self._sessions])
+    async def __aenter__(self):
+        return self
 
-        asyncio.run(_close_all_sessions())
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        await self.close()
+
+    def __del__(self):
+        if len(self._sessions) > 0:
+            logger.warning(
+                "Deleting 'AsyncInferenceClient' client but some sessions are still open. "
+                "This can happen if you've stopped streaming data from the server before the stream was complete. "
+                "To close the client properly, you must call `await client.close()` "
+                "or use an async context (e.g. `async with AsyncInferenceClient(): ...`."
+            )
+
+    async def close(self):
+        """Close all open sessions.
+
+        By default, 'aiohttp.ClientSession' objects are closed automatically when a call is completed. However, if you
+        are streaming data from the server and you stop before the stream is complete, you must call this method to
+        close the session properly.
+
+        Another possibility is to use an async context (e.g. `async with AsyncInferenceClient(): ...`).
+        """
+        await asyncio.gather(*[session.close() for session in self._sessions])
 
     async def audio_classification(
         self,

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -342,7 +342,7 @@ class AsyncInferenceClient:
 
     def __del__(self):
         if len(self._sessions) > 0:
-            logger.warning(
+            warnings.warn(
                 "Deleting 'AsyncInferenceClient' client but some sessions are still open. "
                 "This can happen if you've stopped streaming data from the server before the stream was complete. "
                 "To close the client properly, you must call `await client.close()` "

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -32,6 +32,7 @@ from typing import (
     List,
     Literal,
     Optional,
+    Set,
     Union,
     overload,
 )
@@ -188,6 +189,9 @@ class AsyncInferenceClient:
         # OpenAI compatibility
         self.base_url = base_url
 
+        # Keep track of the sessions to close them properly
+        self._sessions: Set["ClientSession"] = set()
+
     def __repr__(self):
         return f"<InferenceClient(model='{self.model if self.model else ''}', timeout={self.timeout})>"
 
@@ -282,10 +286,10 @@ class AsyncInferenceClient:
             with _open_as_binary(data) as data_as_binary:
                 # Do not use context manager as we don't want to close the connection immediately when returning
                 # a stream
-                client = self._get_client_session(headers=headers)
+                session = self._get_client_session(headers=headers)
 
                 try:
-                    response = await client.post(url, json=json, data=data_as_binary, proxy=self.proxies)
+                    response = await session.post(url, json=json, data=data_as_binary, proxy=self.proxies)
                     response_error_payload = None
                     if response.status != 200:
                         try:
@@ -294,18 +298,18 @@ class AsyncInferenceClient:
                             pass
                     response.raise_for_status()
                     if stream:
-                        return _async_yield_from(client, response)
+                        return _async_yield_from(session, response)
                     else:
                         content = await response.read()
-                        await client.close()
+                        await session.close()
                         return content
                 except asyncio.TimeoutError as error:
-                    await client.close()
+                    await session.close()
                     # Convert any `TimeoutError` to a `InferenceTimeoutError`
                     raise InferenceTimeoutError(f"Inference call timed out: {url}") from error  # type: ignore
                 except aiohttp.ClientResponseError as error:
                     error.response_error_payload = response_error_payload
-                    await client.close()
+                    await session.close()
                     if response.status == 422 and task is not None:
                         error.message += f". Make sure '{task}' task is supported by the model."
                     if response.status == 503:
@@ -327,8 +331,14 @@ class AsyncInferenceClient:
                         continue
                     raise error
                 except Exception:
-                    await client.close()
+                    await session.close()
                     raise
+
+    def __del__(self):
+        async def _close_all_sessions():
+            await asyncio.gather(*[session.close() for session in self._sessions])
+
+        asyncio.run(_close_all_sessions())
 
     async def audio_classification(
         self,
@@ -2610,12 +2620,25 @@ class AsyncInferenceClient:
             client_headers.update(headers)
 
         # Return a new aiohttp ClientSession with correct settings.
-        return aiohttp.ClientSession(
+        session = aiohttp.ClientSession(
             headers=client_headers,
             cookies=self.cookies,
             timeout=aiohttp.ClientTimeout(self.timeout),
             trust_env=self.trust_env,
         )
+
+        # Keep track of sessions to close them later
+        self._sessions.add(session)
+
+        # Override the 'close' method to deregister the session when closed
+        session._close = session.close
+
+        async def close_session():
+            await session._close()
+            self._sessions.discard(session)
+
+        session.close = close_session
+        return session
 
     def _resolve_url(self, model: Optional[str] = None, task: Optional[str] = None) -> str:
         model = model or self.model or self.base_url

--- a/tests/cassettes/test_http_session_correctly_closed.yaml
+++ b/tests/cassettes/test_http_session_correctly_closed.yaml
@@ -1,0 +1,159 @@
+interactions:
+- request:
+    body: null
+    headers:
+      user-agent:
+      - unknown/None; hf_hub/0.25.0.dev0; python/3.10.12; torch/2.4.0; tensorflow/2.17.0;
+        fastcore/1.5.23
+    method: POST
+    uri: https://api-inference.huggingface.co/models/meta-llama/Meta-Llama-3.1-8B-Instruct
+  response:
+    body:
+      string: 'data: {"index":1,"token":{"id":279,"text":" the","logprob":-0.63378906,"special":false},"generated_text":"
+        the","details":null}
+
+
+        '
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream
+      Date:
+      - Fri, 30 Aug 2024 13:58:50 GMT
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - origin, access-control-request-method, access-control-request-headers, Origin,
+        Access-Control-Request-Method, Access-Control-Request-Headers
+      x-accel-buffering:
+      - 'no'
+      x-compute-characters:
+      - '41'
+      x-compute-type:
+      - 2-a10-g
+      x-request-id:
+      - 8ZMGhj7Cj90UK12dSJhfj
+      x-sha:
+      - 5206a32e0bd3067aef1ce90f5528ade7d866253f
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      user-agent:
+      - unknown/None; hf_hub/0.25.0.dev0; python/3.10.12; torch/2.4.0; tensorflow/2.17.0;
+        fastcore/1.5.23
+    method: POST
+    uri: https://api-inference.huggingface.co/models/meta-llama/Meta-Llama-3.1-8B-Instruct
+  response:
+    body:
+      string: 'data: {"index":1,"token":{"id":279,"text":" the","logprob":-0.63378906,"special":false},"generated_text":"
+        the","details":null}
+
+
+        '
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '129'
+      Content-Type:
+      - text/event-stream
+      Date:
+      - Fri, 30 Aug 2024 13:58:51 GMT
+      Vary:
+      - Origin, Access-Control-Request-Method, Access-Control-Request-Headers
+      x-compute-type:
+      - cache
+      x-request-id:
+      - gG5snagDwsUuzxQUSHpfs
+      x-sha:
+      - 5206a32e0bd3067aef1ce90f5528ade7d866253f
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      user-agent:
+      - unknown/None; hf_hub/0.25.0.dev0; python/3.10.12; torch/2.4.0; tensorflow/2.17.0;
+        fastcore/1.5.23
+    method: POST
+    uri: https://api-inference.huggingface.co/models/meta-llama/Meta-Llama-3.1-8B-Instruct
+  response:
+    body:
+      string: 'data: {"index":1,"token":{"id":279,"text":" the","logprob":-0.63378906,"special":false},"generated_text":"
+        the","details":null}
+
+
+        '
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '129'
+      Content-Type:
+      - text/event-stream
+      Date:
+      - Fri, 30 Aug 2024 13:58:51 GMT
+      Vary:
+      - Origin, Access-Control-Request-Method, Access-Control-Request-Headers
+      x-compute-type:
+      - cache
+      x-request-id:
+      - 8PS-J7-J2QKF0FyOb9War
+      x-sha:
+      - 5206a32e0bd3067aef1ce90f5528ade7d866253f
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      user-agent:
+      - unknown/None; hf_hub/0.25.0.dev0; python/3.10.12; torch/2.4.0; tensorflow/2.17.0;
+        fastcore/1.5.23
+    method: POST
+    uri: https://api-inference.huggingface.co/models/meta-llama/Meta-Llama-3.1-8B-Instruct
+  response:
+    body:
+      string: 'data: {"index":1,"token":{"id":279,"text":" the","logprob":-0.63378906,"special":false},"generated_text":"
+        the","details":null}
+
+
+        '
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '129'
+      Content-Type:
+      - text/event-stream
+      Date:
+      - Fri, 30 Aug 2024 13:58:52 GMT
+      Vary:
+      - Origin, Access-Control-Request-Method, Access-Control-Request-Headers
+      x-compute-type:
+      - cache
+      x-request-id:
+      - _MFpbB44jCKcoM8wai66z
+      x-sha:
+      - 5206a32e0bd3067aef1ce90f5528ade7d866253f
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/utils/generate_async_inference_client.py
+++ b/utils/generate_async_inference_client.py
@@ -256,7 +256,7 @@ ASYNC_POST_CODE = """
 
     def __del__(self):
         if len(self._sessions) > 0:
-            logger.warning(
+            warnings.warn(
                 "Deleting 'AsyncInferenceClient' client but some sessions are still open. "
                 "This can happen if you've stopped streaming data from the server before the stream was complete. "
                 "To close the client properly, you must call `await client.close()` "

--- a/utils/generate_async_inference_client.py
+++ b/utils/generate_async_inference_client.py
@@ -157,6 +157,7 @@ def _add_imports(code: str) -> str:
             r"\1"
             + "from .._common import _async_yield_from, _import_aiohttp\n"
             + "from typing import AsyncIterable\n"
+            + "from typing import Set\n"
             + "import asyncio\n"
         ),
         string=code,
@@ -199,10 +200,10 @@ ASYNC_POST_CODE = """
             with _open_as_binary(data) as data_as_binary:
                 # Do not use context manager as we don't want to close the connection immediately when returning
                 # a stream
-                client = self._get_client_session(headers=headers)
+                session = self._get_client_session(headers=headers)
 
                 try:
-                    response = await client.post(url, json=json, data=data_as_binary, proxy=self.proxies)
+                    response = await session.post(url, json=json, data=data_as_binary, proxy=self.proxies)
                     response_error_payload = None
                     if response.status != 200:
                         try:
@@ -211,18 +212,18 @@ ASYNC_POST_CODE = """
                             pass
                     response.raise_for_status()
                     if stream:
-                        return _async_yield_from(client, response)
+                        return _async_yield_from(session, response)
                     else:
                         content = await response.read()
-                        await client.close()
+                        await session.close()
                         return content
                 except asyncio.TimeoutError as error:
-                    await client.close()
+                    await session.close()
                     # Convert any `TimeoutError` to a `InferenceTimeoutError`
                     raise InferenceTimeoutError(f"Inference call timed out: {url}") from error  # type: ignore
                 except aiohttp.ClientResponseError as error:
                     error.response_error_payload = response_error_payload
-                    await client.close()
+                    await session.close()
                     if response.status == 422 and task is not None:
                         error.message += f". Make sure '{task}' task is supported by the model."
                     if response.status == 503:
@@ -244,8 +245,13 @@ ASYNC_POST_CODE = """
                         continue
                     raise error
                 except Exception:
-                    await client.close()
-                    raise"""
+                    await session.close()
+                    raise
+
+    def __del__(self):
+        async def _close_all_sessions():
+            await asyncio.gather(*[session.close() for session in self._sessions])
+        asyncio.run(_close_all_sessions())"""
 
 
 def _make_post_async(code: str) -> str:
@@ -500,15 +506,35 @@ def _add_get_client_session(code: str) -> str:
             client_headers.update(headers)
 
         # Return a new aiohttp ClientSession with correct settings.
-        return aiohttp.ClientSession(
+        session = aiohttp.ClientSession(
             headers=client_headers,
             cookies=self.cookies,
             timeout=aiohttp.ClientTimeout(self.timeout),
             trust_env=self.trust_env,
         )
 
+        # Keep track of sessions to close them later
+        self._sessions.add(session)
+
+        # Override the 'close' method to deregister the session when closed
+        session._close = session.close
+
+        async def close_session():
+            await session._close()
+            self._sessions.discard(session)
+
+        session.close = close_session
+        return session
+
 """
     code = _add_before(code, "\n    def _resolve_url(", client_session_code)
+
+    # Add self._sessions attribute in __init__
+    code = _add_before(
+        code,
+        "\n    def __repr__(self):\n",
+        "\n        # Keep track of the sessions to close them properly\n        self._sessions: Set['ClientSession']= set()",
+    )
 
     return code
 


### PR DESCRIPTION
Close https://github.com/huggingface/huggingface_hub/issues/2493.

This PR adds the possibility to properly close sessions from a `AsyncInferenceClient` object using either `close` or a context manager:

```py
import asyncio

from huggingface_hub import AsyncInferenceClient

model = ...  # NOTE: I'm using a self-hosted TGI instance

async def run():
    client = AsyncInferenceClient(model)
    answer_stream = await client.text_generation(
        "Between emacs and vim, the best editor is",
        stream=True,
    )
    await client.close()

asyncio.run(run())
```

or a context manager:

```py
async with AsyncInferenceClient():
    for token in await client.text_generation(
        "Between emacs and vim, the best editor is",
        stream=True,
    ):
        break  # no one wants the answer
```

If some sessions are still opened when a client is being deleted, a warning is emitted to the user to tell them how to properly handle things.  

Thanks @tomjorquera for the very well described issue which helped a lot building this PR :)