### PR TITLE
fix empty siblings

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -825,7 +825,7 @@ class ModelInfo:
                 )
                 for sibling in siblings
             ]
-            if siblings
+            if siblings is not None
             else None
         )
         self.spaces = kwargs.pop("spaces", None)
@@ -947,7 +947,7 @@ class DatasetInfo:
                 )
                 for sibling in siblings
             ]
-            if siblings
+            if siblings is not None
             else None
         )
 
@@ -1069,7 +1069,7 @@ class SpaceInfo:
                 )
                 for sibling in siblings
             ]
-            if siblings
+            if siblings is not None
             else None
         )
         runtime = kwargs.pop("runtime", None)


### PR DESCRIPTION
`{model,dataset,space}_info.siblings` should be `[]` if the repo is empty no ? currently it's `None` even if the Hub API returns `"sibligns": []` in the JSON response

this causes unexpected though minor errors in the Viewer

e.g. it indirectly causes the histogram filtering UI of the [laion's viewer](https://huggingface.co/datasets/laion/relaion2B-multi-research-safe) to be disabled