### PR TITLE
fixes: URL fixes

### DIFF
--- a/docs/source/en/package_reference/environment_variables.md
+++ b/docs/source/en/package_reference/environment_variables.md
@@ -20,7 +20,7 @@ and their meaning.
 To configure the inference api base url. You might want to set this variable if your organization
 is pointing at an API Gateway rather than directly at the inference api.
 
-Defaults to `"https://api-inference.huggingface.com"`.
+Defaults to `"https://api-inference.huggingface.co"`.
 
 ### HF_HOME
 

--- a/docs/source/ko/package_reference/environment_variables.md
+++ b/docs/source/ko/package_reference/environment_variables.md
@@ -17,7 +17,7 @@ rendered properly in your Markdown viewer.
 
 추론 API 기본 URL을 구성합니다. 조직에서 추론 API를 직접 가리키는 것이 아니라 API 게이트웨이를 가리키는 경우 이 변수를 설정할 수 있습니다.
 
-기본값은 `"https://api-inference.huggingface.com"`입니다.
+기본값은 `"https://api-inference.huggingface.co"`입니다.
 
 ### HF_HOME[[hfhome]]
 


### PR DESCRIPTION
`https://api-inference.huggingface.com` --> `https://api-inference.huggingface.co`

It seems like our shiny new `huggingface.com` might have made an early cameo in this document—though we haven’t unleashed any new subdomains yet. So, let’s update the domain to .co for now 🤗 