### PR TITLE
Do not fail on `touch()` if `OSError` (to cache non existence of file)

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1748,7 +1748,10 @@ def _get_metadata_or_catch_error(
                     if commit_hash is not None:
                         no_exist_file_path = Path(storage_folder) / ".no_exist" / commit_hash / relative_filename
                         no_exist_file_path.parent.mkdir(parents=True, exist_ok=True)
-                        no_exist_file_path.touch()
+                        try:
+                            no_exist_file_path.touch()
+                        except OSError as e:
+                            logger.error(f"Could not cache non-existence of file. Will ignore error and continue. Error: {e}")
                         _cache_commit_hash_for_specific_revision(storage_folder, revision, commit_hash)
                 raise
 

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1751,7 +1751,9 @@ def _get_metadata_or_catch_error(
                         try:
                             no_exist_file_path.touch()
                         except OSError as e:
-                            logger.error(f"Could not cache non-existence of file. Will ignore error and continue. Error: {e}")
+                            logger.error(
+                                f"Could not cache non-existence of file. Will ignore error and continue. Error: {e}"
+                            )
                         _cache_commit_hash_for_specific_revision(storage_folder, revision, commit_hash)
                 raise
 


### PR DESCRIPTION
Related to [this thread](https://huggingface.slack.com/archives/C01NE71C4F7/p1725359394435419?thread_ts=1725022278.172719&cid=C01NE71C4F7) on slack (private link).

When trying to download a file, if the file does not exist on the Hub, we cache this information by creating an empty file under the `./no-exists` folder. This is used in `transformers` to avoid requesting a given file each time the pipeline is reloaded. The only purpose of this file is to save a HEAD call on initialization. @ydshieh and @glegendre01 have found out that `Path.touch()` raises a `PermissionError` when used on a S3-mounted drive if the file already exists. This PR adds a try/catch block to ignore such failures.

**EDIT:** I've checked and it's the only occurrence where we use `.touch()` on a potentially existing file.