### PR TITLE
Paginate followers and following endpoints

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,7 +148,7 @@ Follow these steps to start contributing:
 
 7. Format your code.
 
-   `hugginface_hub` relies on [`ruff`](https://github.com/astral-sh/ruff) to format its source code consistently. You
+   `huggingface_hub` relies on [`ruff`](https://github.com/astral-sh/ruff) to format its source code consistently. You
    can apply automatic style corrections and code verifications with the following command:
 
    ```bash

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -213,6 +213,7 @@ _SUBMOD_ATTRS = {
         "list_liked_repos",
         "list_metrics",
         "list_models",
+        "list_organization_members",
         "list_pending_access_requests",
         "list_rejected_access_requests",
         "list_repo_commits",
@@ -221,6 +222,8 @@ _SUBMOD_ATTRS = {
         "list_repo_refs",
         "list_repo_tree",
         "list_spaces",
+        "list_user_followers",
+        "list_user_following",
         "list_webhooks",
         "merge_pull_request",
         "model_info",
@@ -718,6 +721,7 @@ if TYPE_CHECKING:  # pragma: no cover
         list_liked_repos,  # noqa: F401
         list_metrics,  # noqa: F401
         list_models,  # noqa: F401
+        list_organization_members,  # noqa: F401
         list_pending_access_requests,  # noqa: F401
         list_rejected_access_requests,  # noqa: F401
         list_repo_commits,  # noqa: F401
@@ -726,6 +730,8 @@ if TYPE_CHECKING:  # pragma: no cover
         list_repo_refs,  # noqa: F401
         list_repo_tree,  # noqa: F401
         list_spaces,  # noqa: F401
+        list_user_followers,  # noqa: F401
+        list_user_following,  # noqa: F401
         list_webhooks,  # noqa: F401
         merge_pull_request,  # noqa: F401
         model_info,  # noqa: F401

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -9433,13 +9433,18 @@ class HfApi:
             message = "\n".join([f"- {error.get('message')}" for error in errors])
             raise ValueError(f"Invalid metadata in README.md.\n{message}") from e
 
-    def get_user_overview(self, username: str) -> User:
+    def get_user_overview(self, username: str, token: Union[bool, str, None] = None) -> User:
         """
         Get an overview of a user on the Hub.
 
         Args:
             username (`str`):
                 Username of the user to get an overview of.
+            token (Union[bool, str, None], optional):
+                A valid user access token (string). Defaults to the locally saved
+                token, which is the recommended method for authentication (see
+                https://huggingface.co/docs/huggingface_hub/quick-start#authentication).
+                To disable authentication, pass `False`.
 
         Returns:
             `User`: A [`User`] object with the user's overview.
@@ -9448,18 +9453,24 @@ class HfApi:
             [`HTTPError`](https://requests.readthedocs.io/en/latest/api/#requests.HTTPError):
                 HTTP 404 If the user does not exist on the Hub.
         """
-        r = get_session().get(f"{constants.ENDPOINT}/api/users/{username}/overview")
-
+        r = get_session().get(
+            f"{constants.ENDPOINT}/api/users/{username}/overview", headers=self._build_hf_headers(token=token)
+        )
         hf_raise_for_status(r)
         return User(**r.json())
 
-    def list_organization_members(self, organization: str) -> Iterable[User]:
+    def list_organization_members(self, organization: str, token: Union[bool, str, None] = None) -> Iterable[User]:
         """
         List of members of an organization on the Hub.
 
         Args:
             organization (`str`):
                 Name of the organization to get the members of.
+            token (Union[bool, str, None], optional):
+                A valid user access token (string). Defaults to the locally saved
+                token, which is the recommended method for authentication (see
+                https://huggingface.co/docs/huggingface_hub/quick-start#authentication).
+                To disable authentication, pass `False`.
 
         Returns:
             `Iterable[User]`: A list of [`User`] objects with the members of the organization.
@@ -9469,21 +9480,25 @@ class HfApi:
                 HTTP 404 If the organization does not exist on the Hub.
 
         """
-
-        r = get_session().get(f"{constants.ENDPOINT}/api/organizations/{organization}/members")
-
-        hf_raise_for_status(r)
-
-        for member in r.json():
+        for member in paginate(
+            path=f"{constants.ENDPOINT}/api/organizations/{organization}/members",
+            params={},
+            headers=self._build_hf_headers(token=token),
+        ):
             yield User(**member)
 
-    def list_user_followers(self, username: str) -> Iterable[User]:
+    def list_user_followers(self, username: str, token: Union[bool, str, None] = None) -> Iterable[User]:
         """
         Get the list of followers of a user on the Hub.
 
         Args:
             username (`str`):
                 Username of the user to get the followers of.
+            token (Union[bool, str, None], optional):
+                A valid user access token (string). Defaults to the locally saved
+                token, which is the recommended method for authentication (see
+                https://huggingface.co/docs/huggingface_hub/quick-start#authentication).
+                To disable authentication, pass `False`.
 
         Returns:
             `Iterable[User]`: A list of [`User`] objects with the followers of the user.
@@ -9493,21 +9508,25 @@ class HfApi:
                 HTTP 404 If the user does not exist on the Hub.
 
         """
-
-        r = get_session().get(f"{constants.ENDPOINT}/api/users/{username}/followers")
-
-        hf_raise_for_status(r)
-
-        for follower in r.json():
+        for follower in paginate(
+            path=f"{constants.ENDPOINT}/api/users/{username}/followers",
+            params={},
+            headers=self._build_hf_headers(token=token),
+        ):
             yield User(**follower)
 
-    def list_user_following(self, username: str) -> Iterable[User]:
+    def list_user_following(self, username: str, token: Union[bool, str, None] = None) -> Iterable[User]:
         """
         Get the list of users followed by a user on the Hub.
 
         Args:
             username (`str`):
                 Username of the user to get the users followed by.
+            token (Union[bool, str, None], optional):
+                A valid user access token (string). Defaults to the locally saved
+                token, which is the recommended method for authentication (see
+                https://huggingface.co/docs/huggingface_hub/quick-start#authentication).
+                To disable authentication, pass `False`.
 
         Returns:
             `Iterable[User]`: A list of [`User`] objects with the users followed by the user.
@@ -9517,12 +9536,11 @@ class HfApi:
                 HTTP 404 If the user does not exist on the Hub.
 
         """
-
-        r = get_session().get(f"{constants.ENDPOINT}/api/users/{username}/following")
-
-        hf_raise_for_status(r)
-
-        for followed_user in r.json():
+        for followed_user in paginate(
+            path=f"{constants.ENDPOINT}/api/users/{username}/following",
+            params={},
+            headers=self._build_hf_headers(token=token),
+        ):
             yield User(**followed_user)
 
 

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -4086,12 +4086,12 @@ class UserApiTest(unittest.TestCase):
         assert len(list(members)) > 1
 
     def test_user_followers(self) -> None:
-        followers = self.api.list_user_followers("julien-c")
-        assert len(list(followers)) > 10
+        followers = self.api.list_user_followers("clem")
+        assert len(list(followers)) > 500
 
     def test_user_following(self) -> None:
-        following = self.api.list_user_following("julien-c")
-        assert len(list(following)) > 10
+        following = self.api.list_user_following("clem")
+        assert len(list(following)) > 500
 
 
 class WebhookApiTest(HfApiCommonTest):

--- a/utils/check_static_imports.py
+++ b/utils/check_static_imports.py
@@ -56,9 +56,9 @@ def check_static_imports(update: bool) -> NoReturn:
         "_SUBMOD_ATTRS = {\n"
         + "\n".join(
             f'    "{module}": [\n'
-            + "\n".join(f'        "{attr}",' for attr in sorted(_SUBMOD_ATTRS[module]))
+            + "\n".join(f'        "{attr}",' for attr in sorted(set(_SUBMOD_ATTRS[module])))
             + "\n    ],"
-            for module in sorted(_SUBMOD_ATTRS.keys())
+            for module in sorted(set(_SUBMOD_ATTRS.keys()))
         )
         + "\n}"
     )


### PR DESCRIPTION
Follow-up after https://github.com/huggingface/huggingface_hub/pull/2147

Just noticed we were missing a few things:
- results in `list_organization_members`, `list_user_followers` and `list_user_following` must be paginated for profiles like https://huggingface.co/clem with more than 500 followers and following
- these endpoints didn't have a `token` parameter (better to have it for consistency)
- they were not exposed at the root of the package

This PR fixes all of this. I've updated the tests to check pagination works as expected.

(I also updated `utils/check_static_imports.py` script to avoid duplicates in the `__init__.py`)