### PR TITLE
Fix 416 requested range not satisfiable

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -427,6 +427,10 @@ def http_get(
             The filename of the file that is being downloaded. Value is used only to display a nice progress bar. If
             not set, the filename is guessed from the URL or the `Content-Disposition` header.
     """
+    if expected_size is not None and resume_size == expected_size:
+        # If the file is already fully downloaded, we don't need to download it again.
+        return
+
     hf_transfer = None
     if constants.HF_HUB_ENABLE_HF_TRANSFER:
         if resume_size != 0:

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -741,9 +741,9 @@ class CachedDownloadTests(unittest.TestCase):
                     hf_hub_download(DUMMY_MODEL_ID, filename="pytorch_model.bin", cache_dir=cache_dir)
 
     def test_hf_hub_download_when_tmp_file_is_complete(self):
-        """Regression test for #1000.
+        """Regression test for #2511.
 
-        See https://github.com/huggingface/huggingface_hub/issues/1000.
+        See https://github.com/huggingface/huggingface_hub/issues/2511.
 
         When downloading a file, we first download to a temporary file and then move it to the final location.
         If the temporary file is already partially downloaded, we resume from where we left off.


### PR DESCRIPTION
This PR aims at fixing an issue raised several times (last time [here](https://discuss.huggingface.co/t/unable-to-download-microsoft-phi-3-small-8k-instruct-completely/103882)) where a `HTTP 416 Range Not Satisfiable` is raised server-side. After investigation, this seems to happen when:
1. a first download of the file has been made
2. this download was completed in the ".incomplete" file
3. once the download is complete, this file is supposed to be moved to the correct location. This step fails for some reason.
4. a second download is triggered and resumes where it stopped
5. `huggingface_hub` sends an HTTP call with a `Range` header that is not satisfiable (empty range)

This PR fixes this by preventing the HTTP call if the tmp file is already fully downloaded. It is likely that the user's script will continue to fail when moving the incomplete file to its destination (since it happened once) but at least the real exception will be raised.