### PR TITLE
Paginate repo likers endpoint

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -2342,7 +2342,7 @@ class HfApi:
         *,
         repo_type: Optional[str] = None,
         token: Union[bool, str, None] = None,
-    ) -> List[User]:
+    ) -> Iterable[User]:
         """
         List all users who liked a given repo on the hugging Face Hub.
 
@@ -2364,29 +2364,15 @@ class HfApi:
                 `None`.
 
         Returns:
-            `List[User]`: a list of [`User`] objects.
+            `Iterable[User]`: an iterable of [`huggingface_hub.hf_api.User`] objects.
         """
 
         # Construct the API endpoint
         if repo_type is None:
             repo_type = constants.REPO_TYPE_MODEL
         path = f"{self.endpoint}/api/{repo_type}s/{repo_id}/likers"
-        headers = self._build_hf_headers(token=token)
-
-        # Make the request
-        response = get_session().get(path, headers=headers)
-        hf_raise_for_status(response)
-
-        # Parse the results into User objects
-        likers_data = response.json()
-        return [
-            User(
-                username=user_data["user"],
-                fullname=user_data["fullname"],
-                avatar_url=user_data["avatarUrl"],
-            )
-            for user_data in likers_data
-        ]
+        for liker in paginate(path, params={}, headers=self._build_hf_headers(token=token)):
+            yield User(username=liker["user"], fullname=liker["fullname"], avatar_url=liker["avatarUrl"])
 
     @validate_hf_hub_args
     def model_info(

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2981,8 +2981,10 @@ class ActivityApiTest(unittest.TestCase):
         likers = self.api.list_repo_likers(repo_id, token=TOKEN)
 
         # Check if the test user is in the list of likers
-        liker_usernames = [user.username for user in likers]
-        self.assertGreater(len(likers), 0)
+        likers_list = list(likers)
+        self.assertGreater(len(likers_list), 0)
+
+        liker_usernames = [user.username for user in likers_list]
         self.assertIn(USER, liker_usernames)
 
         # Cleanup


### PR DESCRIPTION
Related to #2508 and #2506.

The related test was not modified. To have a robust test, we should maybe use an existing repo with enough likers. WDYT? Do you have any suggestion of such repo we can rely on for this test? @Wauplin 