### PR TITLE
FIX: Use `_RECOMMENDED_MODELS_FOR_VCR` in `TestResolveURL`

### DIFF
--- a/tests/test_inference_client.py
+++ b/tests/test_inference_client.py
@@ -706,6 +706,7 @@ class TestOpenAsBinary(InferenceClientTest):
             self.assertEqual(content, content_bytes)
 
 
+@patch("huggingface_hub.inference._client._fetch_recommended_models", lambda: _RECOMMENDED_MODELS_FOR_VCR)
 class TestResolveURL(InferenceClientTest):
     FAKE_ENDPOINT = "https://my-endpoint.hf.co"
 


### PR DESCRIPTION
This `_RECOMMENDED_MODELS_FOR_VCR` is there to avoid been impacted by updates in the recommended models (on the Hub / huggingface.js). We already use it in `InferenceClientVCRTest` but it's also useful for `TestResolveURL` class.

Expectation: CI should pass.