### PR TITLE
Fix race-condition issue when downloading from multiple threads

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1388,7 +1388,8 @@ def _hf_hub_download_to_cache_dir(
             filename=filename,
             force_download=force_download,
         )
-        _create_symlink(blob_path, pointer_path, new_blob=True)
+        if not os.path.exists(blob_path):
+            _create_symlink(blob_path, pointer_path, new_blob=True)
 
     return pointer_path
 

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1388,7 +1388,7 @@ def _hf_hub_download_to_cache_dir(
             filename=filename,
             force_download=force_download,
         )
-        if not os.path.exists(blob_path):
+        if not os.path.exists(pointer_path):
             _create_symlink(blob_path, pointer_path, new_blob=True)
 
     return pointer_path


### PR DESCRIPTION
This PR fixes an issue that has been introduced in https://github.com/huggingface/huggingface_hub/pull/2223.
It has been reported at least in https://github.com/huggingface/transformers/issues/27421 and https://github.com/huggingface/huggingface_hub/pull/2223 but also on slack (private, [here](https://huggingface.slack.com/archives/C02V5EA0A95/p1725961634325309) and [here](https://huggingface.slack.com/archives/C043JTYE1MJ/p1724233191843019)).

### Current process

The issue comes from the process to download a file to the cache directory. The process is
1. fetch the metadata
2. check if file is already in cache (if yes, return)
3. acquire a lock
    1. check if the file has already been downloaded to the `./blobs/` folder
       1. download the file to a temporary file
       2. if not, download it and move to `./blobs/` destination
    2. create a symlink between the `./blobs/` folder and the correct destination in the `./snapshot/` folder
    3. release the lock and return


### Issue

The problem is that when the download process is triggered by multiple processes or threads at once, we can have:
1. thread A checks for file => doesn't exist
2. thread B checks for file => doesn't exist
3. thread A acquire lock, thread B wait
6. thread A download the file, move it, creates the symlink and release the lock
7. thread B, do not re-download the `./blobs/` file
8. thread B creates a symlink to the correct destination **without checking if the pointer file has been created while waiting for the lock**

The problem is that if thread A tries to read to file just when thread B is (re-)creating the symlink, then we have a race-condition error and more specifically a `RuntimeError: unable to open file (<path/to/cached/file>) in read-only mode: No such file or directory (2)`.

### Fix

This PR fixes the issue by adding a simple check before creating the symlink. If the pointer file already exists, no need to recreate it.

---

Many many thanks to @regisss who helped me reproduce the error in a reliable way by providing me with the correct setup. The issue has not been easy to track down and having a consistent way to reproduce it solved everything! :pray:   

(For info, I was able to reproduce the error with a script once every 3-4 runs maximum (thanks to @regisss!). With this PR I ran it 50 times in a raw without a single incident!)