### PR TITLE
Fix resolve chat completion URL

### DIFF
--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -829,7 +829,7 @@ class PyTorchModelHubMixin(ModelHubMixin):
 
     @classmethod
     def _load_as_safetensor(cls, model: T, model_file: str, map_location: str, strict: bool) -> T:
-        if packaging.version.parse(safetensors.__version__) < packaging.version.parse("0.4.3"):
+        if packaging.version.parse(safetensors.__version__) < packaging.version.parse("0.4.3"):  # type: ignore [attr-defined]
             load_model_as_safetensor(model, model_file, strict=strict)  # type: ignore [arg-type]
             if map_location != "cpu":
                 logger.warning(
@@ -840,7 +840,7 @@ class PyTorchModelHubMixin(ModelHubMixin):
                 )
                 model.to(map_location)  # type: ignore [attr-defined]
         else:
-            safetensors.torch.load_model(model, model_file, strict=strict, device=map_location)
+            safetensors.torch.load_model(model, model_file, strict=strict, device=map_location)  # type: ignore [arg-type]
         return model
 
 

--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -847,26 +847,27 @@ class InferenceClient:
         return ChatCompletionOutput.parse_obj_as_instance(data)  # type: ignore[arg-type]
 
     def _resolve_chat_completion_url(self, model: Optional[str] = None) -> str:
-        # Determine model
-        # `self.xxx` takes precedence over the method argument only in `chat_completion`
-        # since `chat_completion(..., model=xxx)` is also a payload parameter for the
-        # server, we need to handle it differently
+        # Since `chat_completion(..., model=xxx)` is also a payload parameter for the server, we need to handle 'model' differently.
+        # `self.base_url` and `self.model` takes precedence over 'model' argument only in `chat_completion`.
         model_id_or_url = self.base_url or self.model or model or self.get_recommended_model("text-generation")
-        is_url = model_id_or_url.startswith(("http://", "https://"))
 
-        # First, resolve the model chat completions URL
-        if model_id_or_url == self.base_url:
-            # base_url passed => add server route
-            model_url = model_id_or_url.rstrip("/")
-            if not model_url.endswith("/v1"):
-                model_url += "/v1"
+        # Resolve URL if it's a model ID
+        model_url = (
+            model_id_or_url
+            if model_id_or_url.startswith(("http://", "https://"))
+            else self._resolve_url(model_id_or_url, task="text-generation")
+        )
+
+        # Strip trailing /
+        model_url = model_url.rstrip("/")
+
+        # Append /chat/completions if not already present
+        if model_url.endswith("/v1"):
             model_url += "/chat/completions"
-        elif is_url:
-            # model is a URL => use it directly
-            model_url = model_id_or_url
-        else:
-            # model is a model ID => resolve it + add server route
-            model_url = self._resolve_url(model_id_or_url).rstrip("/") + "/v1/chat/completions"
+
+        # Append /v1/chat/completions if not already present
+        if not model_url.endswith("/chat/completions"):
+            model_url += "/v1/chat/completions"
 
         return model_url
 

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -850,26 +850,7 @@ class AsyncInferenceClient:
         '{\n\n"activity": "bike ride",\n"animals": ["puppy", "cat", "raccoon"],\n"animals_seen": 3,\n"location": "park"}'
         ```
         """
-        # Determine model
-        # `self.xxx` takes precedence over the method argument only in `chat_completion`
-        # since `chat_completion(..., model=xxx)` is also a payload parameter for the
-        # server, we need to handle it differently
-        model_id_or_url = self.base_url or self.model or model or self.get_recommended_model("text-generation")
-        is_url = model_id_or_url.startswith(("http://", "https://"))
-
-        # First, resolve the model chat completions URL
-        if model_id_or_url == self.base_url:
-            # base_url passed => add server route
-            model_url = model_id_or_url.rstrip("/")
-            if not model_url.endswith("/v1"):
-                model_url += "/v1"
-            model_url += "/chat/completions"
-        elif is_url:
-            # model is a URL => use it directly
-            model_url = model_id_or_url
-        else:
-            # model is a model ID => resolve it + add server route
-            model_url = self._resolve_url(model_id_or_url).rstrip("/") + "/v1/chat/completions"
+        model_url = self._resolve_chat_completion_url(model)
 
         # `model` is sent in the payload. Not used by the server but can be useful for debugging/routing.
         # If it's a ID on the Hub => use it. Otherwise, we use a random string.
@@ -904,6 +885,30 @@ class AsyncInferenceClient:
             return _async_stream_chat_completion_response(data)  # type: ignore[arg-type]
 
         return ChatCompletionOutput.parse_obj_as_instance(data)  # type: ignore[arg-type]
+
+    def _resolve_chat_completion_url(self, model: Optional[str] = None) -> str:
+        # Determine model
+        # `self.xxx` takes precedence over the method argument only in `chat_completion`
+        # since `chat_completion(..., model=xxx)` is also a payload parameter for the
+        # server, we need to handle it differently
+        model_id_or_url = self.base_url or self.model or model or self.get_recommended_model("text-generation")
+        is_url = model_id_or_url.startswith(("http://", "https://"))
+
+        # First, resolve the model chat completions URL
+        if model_id_or_url == self.base_url:
+            # base_url passed => add server route
+            model_url = model_id_or_url.rstrip("/")
+            if not model_url.endswith("/v1"):
+                model_url += "/v1"
+            model_url += "/chat/completions"
+        elif is_url:
+            # model is a URL => use it directly
+            model_url = model_id_or_url
+        else:
+            # model is a model ID => resolve it + add server route
+            model_url = self._resolve_url(model_id_or_url).rstrip("/") + "/v1/chat/completions"
+
+        return model_url
 
     async def document_question_answering(
         self,

--- a/src/huggingface_hub/utils/_http.py
+++ b/src/huggingface_hub/utils/_http.py
@@ -473,7 +473,7 @@ def hf_raise_for_status(response: Response, endpoint_name: Optional[str] = None)
 
         # Convert `HTTPError` into a `HfHubHTTPError` to display request information
         # as well (request id and/or server error message)
-        raise _format(HfHubHTTPError, "", response) from e
+        raise _format(HfHubHTTPError, str(e), response) from e
 
 
 def _format(error_type: Type[HfHubHTTPError], custom_message: str, response: Response) -> HfHubHTTPError:


### PR DESCRIPTION
Fix https://github.com/huggingface/huggingface_hub/issues/2484.

With the introduction of `base_url` in https://github.com/huggingface/huggingface_hub/pull/2384 and a refacto in https://github.com/huggingface/huggingface_hub/pull/2410, some bugs have been introduced on the logic to resolve the chat completion URL. This PR fixes definitely this with a dedicated `_resolve_chat_completion_url` method. I added a bunch of parametrized tests to check every possible cases. It is now possible to:
- pass a model id as `InferenceClient(model=...)`
- pass a model id as `InferenceClient().chat_completion(model=...)`
- pass a url as `InferenceClient(model=...)`, `InferenceClient(base_url=...)` or `InferenceClient().chat_completion(model=...)`
    - the URL can have a trailing `/` or not
    - the URL can end with `/v1` or not (for OpenAI compatibility)
    - the URL can end with `/v1/chat/completions` or not
    - the URL can be a local TGI instance or an Inference Endpoint url
- pass a url to `InferenceClient` and a model_id in `chat_completion` (already the case before)

With all of these use cases tested and working, I think this is fixed for good :)


----
Two minor unrelated changes:
1. some typing: ignore to fix CI (after https://github.com/huggingface/huggingface_hub/pull/2532)
2. Better error in  `src/huggingface_hub/utils/_http.py` (after oversight in https://github.com/huggingface/huggingface_hub/pull/2474)

Failing test is unrelated.