### PR TITLE
Daily Papers API

### DIFF
--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -216,6 +216,7 @@ _SUBMOD_ATTRS = {
         "list_metrics",
         "list_models",
         "list_organization_members",
+        "list_papers",
         "list_pending_access_requests",
         "list_rejected_access_requests",
         "list_repo_commits",
@@ -230,6 +231,7 @@ _SUBMOD_ATTRS = {
         "merge_pull_request",
         "model_info",
         "move_repo",
+        "paper_info",
         "parse_safetensors_file_metadata",
         "pause_inference_endpoint",
         "pause_space",
@@ -733,6 +735,7 @@ if TYPE_CHECKING:  # pragma: no cover
         list_metrics,  # noqa: F401
         list_models,  # noqa: F401
         list_organization_members,  # noqa: F401
+        list_papers,  # noqa: F401
         list_pending_access_requests,  # noqa: F401
         list_rejected_access_requests,  # noqa: F401
         list_repo_commits,  # noqa: F401
@@ -747,6 +750,7 @@ if TYPE_CHECKING:  # pragma: no cover
         merge_pull_request,  # noqa: F401
         model_info,  # noqa: F401
         move_repo,  # noqa: F401
+        paper_info,  # noqa: F401
         parse_safetensors_file_metadata,  # noqa: F401
         pause_inference_endpoint,  # noqa: F401
         pause_space,  # noqa: F401

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -9740,38 +9740,18 @@ class HfApi:
     def list_papers(
         self,
         *,
-        date: Optional[str] = None,
         query: Optional[str] = None,
+        token: Union[bool, str, None] = None,
     ) -> Iterable[PaperInfo]:
         """
         List daily papers on the Hugging Face Hub, given a date or a search query.
 
         Args:
-            date (`str`, *optional*):
-                The date to retrieve papers for, in the format 'YYYY-MM-DD'.
-                If provided, returns papers submitted on this date.
             query (`str`, *optional*):
                 A search query string to find papers.
                 If provided, returns papers that match the query.
         Returns:
             `Iterable[PaperInfo]`: an iterable of [`huggingface_hub.hf_api.PaperInfo`] objects.
-
-        Raises:
-            [`HTTPError`](https://requests.readthedocs.io/en/latest/api/#requests.HTTPError):
-                HTTP 400 if the date is invalid.
-            [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError):
-                If neither `date` nor `query` is provided.
-
-        Example usage with the `date` argument:
-
-        ```python
-        >>> from huggingface_hub import HfApi
-
-        >>> api = HfApi()
-
-        # List all papers submitted on a specific date
-        >>> api.list_papers(date="2024-09-17")
-        ```
 
         Example usage with the `query` argument:
 
@@ -9784,19 +9764,14 @@ class HfApi:
         >>> api.list_papers(query="attention")
         ```
         """
-        if date is None and query is None:
-            raise ValueError("Provide one of `date` or `query`.")
         path = f"{self.endpoint}/api/papers/search"
         params = {}
-        if date:
-            params["date"] = date
         if query:
             params["q"] = query
         r = get_session().get(
             path,
             params=params,
-          
-  headers=self._build_hf_headers(token=token),
+            headers=self._build_hf_headers(token=token),
         )
         hf_raise_for_status(r)
         for paper in r.json():

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -9744,16 +9744,22 @@ class HfApi:
         token: Union[bool, str, None] = None,
     ) -> Iterable[PaperInfo]:
         """
-        List daily papers on the Hugging Face Hub, given a date or a search query.
+        List daily papers on the Hugging Face Hub given a search query.
 
         Args:
             query (`str`, *optional*):
                 A search query string to find papers.
                 If provided, returns papers that match the query.
+            token (Union[bool, str, None], *optional*):
+                A valid user access token (string). Defaults to the locally saved
+                token, which is the recommended method for authentication (see
+                https://huggingface.co/docs/huggingface_hub/quick-start#authentication).
+                To disable authentication, pass `False`.
+
         Returns:
             `Iterable[PaperInfo]`: an iterable of [`huggingface_hub.hf_api.PaperInfo`] objects.
 
-        Example usage with the `query` argument:
+        Example:
 
         ```python
         >>> from huggingface_hub import HfApi

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -9812,7 +9812,8 @@ class HfApi:
             [`HTTPError`](https://requests.readthedocs.io/en/latest/api/#requests.HTTPError):
                 HTTP 404 If the paper does not exist on the Hub.
         """
-        r = get_session().get(f"{self.endpoint}/api/papers/{id}")
+        path = f"{self.endpoint}/api/papers/{id}"
+        r = get_session().get(path)
         hf_raise_for_status(r)
         return PaperInfo(**r.json())
 

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -9786,13 +9786,18 @@ class HfApi:
         """
         if date is None and query is None:
             raise ValueError("Provide one of `date` or `query`.")
-        path = f"{self.endpoint}/api/daily_papers"
+        path = f"{self.endpoint}/api/papers/search"
         params = {}
         if date:
             params["date"] = date
         if query:
             params["q"] = query
-        r = get_session().get(path, params=params)
+        r = get_session().get(
+            path,
+            params=params,
+          
+  headers=self._build_hf_headers(token=token),
+        )
         hf_raise_for_status(r)
         for paper in r.json():
             yield PaperInfo(**paper)

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -9754,7 +9754,7 @@ class HfApi:
                 A search query string to find papers.
                 If provided, returns papers that match the query.
         Returns:
-            `Iterable[PaperInfo]`: A list of [`PaperInfo`] objects.
+            `Iterable[PaperInfo]`: an iterable of [`huggingface_hub.hf_api.PaperInfo`] objects.
 
         Raises:
             [`HTTPError`](https://requests.readthedocs.io/en/latest/api/#requests.HTTPError):
@@ -9786,10 +9786,13 @@ class HfApi:
         """
         if date is None and query is None:
             raise ValueError("Provide one of `date` or `query`.")
+        path = f"{self.endpoint}/api/daily_papers"
+        params = {}
         if date:
-            r = get_session().get(f"{constants.ENDPOINT}/api/daily_papers?date={date}")
-        elif query:
-            r = get_session().get(f"{constants.ENDPOINT}/api/papers/search?q={query}")
+            params["date"] = date
+        if query:
+            params["q"] = query
+        r = get_session().get(path, params=params)
         hf_raise_for_status(r)
         for paper in r.json():
             yield PaperInfo(**paper)
@@ -9809,7 +9812,7 @@ class HfApi:
             [`HTTPError`](https://requests.readthedocs.io/en/latest/api/#requests.HTTPError):
                 HTTP 404 If the paper does not exist on the Hub.
         """
-        r = get_session().get(f"{constants.ENDPOINT}/api/papers/{id}")
+        r = get_session().get(f"{self.endpoint}/api/papers/{id}")
         hf_raise_for_status(r)
         return PaperInfo(**r.json())
 

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -4106,6 +4106,26 @@ class UserApiTest(unittest.TestCase):
         assert len(list(following)) > 500
 
 
+@with_production_testing
+class DailyPaperApiTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.api = HfApi()  # no auth!
+
+    def test_papers_by_date(self) -> None:
+        papers = self.api.list_papers(date="2024-09-18")
+        assert len(list(papers)) > 1
+
+    def test_papers_by_query(self) -> None:
+        papers = self.api.list_papers(query="attention")
+        assert len(list(papers)) > 0
+
+    def test_get_paper_by_id(self) -> None:
+        paper_id = "1706.03762"
+        paper = self.api.paper_info(paper_id=paper_id)
+        assert paper.title == "Attention Is All You Need"
+
+
 class WebhookApiTest(HfApiCommonTest):
     def setUp(self) -> None:
         super().setUp()

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -4106,11 +4106,12 @@ class UserApiTest(unittest.TestCase):
         assert len(list(following)) > 500
 
 
-@with_production_testing
 class DailyPaperApiTest(unittest.TestCase):
     @classmethod
+    @with_production_testing
     def setUpClass(cls) -> None:
-        cls.api = HfApi()  # no auth!
+        cls.api = HfApi()
+        return super().setUpClass()
 
     def test_papers_by_date(self) -> None:
         papers = self.api.list_papers(date="2024-09-18")
@@ -4120,9 +4121,10 @@ class DailyPaperApiTest(unittest.TestCase):
         papers = self.api.list_papers(query="attention")
         assert len(list(papers)) > 0
 
+    @with_production_testing
     def test_get_paper_by_id(self) -> None:
         paper_id = "1706.03762"
-        paper = self.api.paper_info(id=paper_id)
+        paper = self.api.paper_info(paper_id)
         assert paper.title == "Attention Is All You Need"
 
 

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -4107,24 +4107,20 @@ class UserApiTest(unittest.TestCase):
 
 
 class DailyPaperApiTest(unittest.TestCase):
-    @classmethod
     @with_production_testing
-    def setUpClass(cls) -> None:
-        cls.api = HfApi()
-        return super().setUpClass()
-
     def test_papers_by_date(self) -> None:
-        papers = self.api.list_papers(date="2024-09-18")
+        papers = HfApi().list_papers(date="2024-09-18")
         assert len(list(papers)) > 1
 
+    @with_production_testing
     def test_papers_by_query(self) -> None:
-        papers = self.api.list_papers(query="attention")
+        papers = HfApi().list_papers(query="attention")
         assert len(list(papers)) > 0
 
     @with_production_testing
     def test_get_paper_by_id(self) -> None:
         paper_id = "1706.03762"
-        paper = self.api.paper_info(paper_id)
+        paper = HfApi().paper_info(paper_id)
         assert paper.title == "Attention Is All You Need"
 
 

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -4122,6 +4122,11 @@ class PaperApiTest(unittest.TestCase):
         paper = self.api.paper_info("2407.21783")
         assert paper.title == "The Llama 3 Herd of Models"
 
+    def test_get_paper_by_id_not_found(self) -> None:
+        with self.assertRaises(HfHubHTTPError) as context:
+            self.api.paper_info("1234.56789")
+        assert context.exception.response.status_code == 404
+
 
 class WebhookApiTest(HfApiCommonTest):
     def setUp(self) -> None:

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -4122,7 +4122,7 @@ class DailyPaperApiTest(unittest.TestCase):
 
     def test_get_paper_by_id(self) -> None:
         paper_id = "1706.03762"
-        paper = self.api.paper_info(paper_id=paper_id)
+        paper = self.api.paper_info(id=paper_id)
         assert paper.title == "Attention Is All You Need"
 
 

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -4106,22 +4106,21 @@ class UserApiTest(unittest.TestCase):
         assert len(list(following)) > 500
 
 
-class DailyPaperApiTest(unittest.TestCase):
+class PaperApiTest(unittest.TestCase):
+    @classmethod
     @with_production_testing
-    def test_papers_by_date(self) -> None:
-        papers = HfApi().list_papers(date="2024-09-18")
-        assert len(list(papers)) > 1
+    def setUpClass(cls) -> None:
+        cls.api = HfApi()
+        return super().setUpClass()
 
-    @with_production_testing
     def test_papers_by_query(self) -> None:
-        papers = HfApi().list_papers(query="attention")
-        assert len(list(papers)) > 0
+        papers = list(self.api.list_papers(query="llama"))
+        assert len(papers) > 0
+        assert "The Llama 3 Herd of Models" in [paper.title for paper in papers]
 
-    @with_production_testing
-    def test_get_paper_by_id(self) -> None:
-        paper_id = "1706.03762"
-        paper = HfApi().paper_info(paper_id)
-        assert paper.title == "Attention Is All You Need"
+    def test_get_paper_by_id_success(self) -> None:
+        paper = self.api.paper_info("2407.21783")
+        assert paper.title == "The Llama 3 Herd of Models"
 
 
 class WebhookApiTest(HfApiCommonTest):


### PR DESCRIPTION
Fixes #2553 

This PR introduces `list_papers` using the [Daily Papers API](https://huggingface.co/docs/hub/en/api#get-apidailypapers), `search_papers` using the `papers/search` endpoint and `get_paper` using `papers/{paper_id}` endpoint.

We add `DailyPaper` dataclass, containing `Paper` and associated metadata.

`Paper` dataclass containing metadata about the paper itself.

`PaperAuthor` dataclass containing metadata about the paper's author.

`PaperAuthor`'s `user` and `DailyPaper`'s `submitted_by` use existing `User` dataclass, although these contain fewer fields than `User` itself so could have their own dataclasses.

We add `list_papers` to `HfApi` which accepts `date` as `str`, `YYYY-MM-DD` is the expected format, this could also accept datetime as a parameter. The endpoint itself also accepts a full datetime in format `%Y-%m-%dT%H:%M:%S.%fZ`. Invalid dates will return `HTTP 400`.

We add `PaperSearchInfo` dataclass, containing minimal metadata, returned by `search_papers`.

We add `search_papers` to `HfApi` which accepts `query` as `str`, this can be a text query or arXiv paper ID.

We add `get_paper` to `HfApi` which accepts either `paper_id` as `str` or a `PaperSearchInfo` object with `paper_search`. Due to slight differences between the data returned from `papers/{paper_id}` and Daily Papers endpoint we add a static method `from_get_paper` to `DailyPaper`. Some fields are unavailable from `papers/{paper_id}`, namely `thumbnail` and `numComments`, when providing a `PaperSearchInfo` we copy `thumbnail` into the `DailyPaper` object.

We add tests `test_papers_by_date`, `test_search_papers`, `test_get_paper_by_id`, `test_get_paper_by_paper_search_info` under `DailyPaperApiTest`.