### PR TITLE
Add 500 HTTP Error to retry list

### DIFF
--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -813,7 +813,7 @@ class HfFileSystemStreamFile(fsspec.spec.AbstractBufferedFile):
                 "GET",
                 url,
                 headers=self.fs._api._build_hf_headers(),
-                retry_on_status_codes=(502, 503, 504),
+                retry_on_status_codes=(500, 502, 503, 504),
                 stream=True,
                 timeout=constants.HF_HUB_DOWNLOAD_TIMEOUT,
             )
@@ -835,7 +835,7 @@ class HfFileSystemStreamFile(fsspec.spec.AbstractBufferedFile):
                 "GET",
                 url,
                 headers={"Range": "bytes=%d-" % self.loc, **self.fs._api._build_hf_headers()},
-                retry_on_status_codes=(502, 503, 504),
+                retry_on_status_codes=(500, 502, 503, 504),
                 stream=True,
                 timeout=constants.HF_HUB_DOWNLOAD_TIMEOUT,
             )

--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -714,7 +714,7 @@ class HfFileSystemFile(fsspec.spec.AbstractBufferedFile):
             "GET",
             url,
             headers=headers,
-            retry_on_status_codes=(502, 503, 504),
+            retry_on_status_codes=(500, 502, 503, 504),
             timeout=constants.HF_HUB_DOWNLOAD_TIMEOUT,
         )
         hf_raise_for_status(r)


### PR DESCRIPTION
As reported in #2559, reading from HF Hub datasets can sometimes lead to 500 Internal Server Errors, which even if they're rare, can cause issues on large training runs.

The source of this error is not yet identified, but a simple fix seems to be to add the missing 500 error code to the retry list.