### PR TITLE
Add missing documentation

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -734,6 +734,8 @@ class ModelInfo:
         gated (`Literal["auto", "manual", False]`, *optional*):
             Is the repo gated.
             If so, whether there is manual or automatic approval.
+        gguf (`Dict`, *optional*):
+            GGUF information of the model.
         inference (`Literal["cold", "frozen", "warm"]`, *optional*):
             Status of the model on the inference API.
             Warm models are available for immediate use. Cold models will be loaded on first inference call.

--- a/src/huggingface_hub/repocard_data.py
+++ b/src/huggingface_hub/repocard_data.py
@@ -276,6 +276,8 @@ class ModelCardData(CardData):
             `eval_results` to construct the `model-index` within the card's metadata. The name
             you supply here is what will be used on PapersWithCode's leaderboards. If None is provided
             then the repo name is used as a default. Defaults to None.
+        pipeline_tag (`str`, *optional*):
+            The pipeline tag associated with the model. Example: "text-classification".
         tags (`List[str]`, *optional*):
             List of tags to add to your model that can be used when filtering on the Hugging
             Face Hub. Defaults to None.


### PR DESCRIPTION
While working with `Huggingface_hub`, I encountered two undocumented parameters. This PR updates the documentation to include them:

Added the `GGUF` parameter to the `ModelInfo` class.
Added the `pipeline_tag` parameter to the `ModelCardData` class.