### PR TITLE
Remove raw HTML from error message content 

### DIFF
--- a/src/huggingface_hub/errors.py
+++ b/src/huggingface_hub/errors.py
@@ -45,7 +45,7 @@ class HfHubHTTPError(HTTPError):
     sent back by the server, it will be added to the error message.
 
     Added details:
-    - Request id from "X-Request-Id" header if exists.
+    - Request id from "X-Request-Id" header if exists. If not, fallback to "X-Amzn-Trace-Id" header if exists.
     - Server error message from the header "X-Error-Message".
     - Server error message if we can found one in the response body.
 
@@ -68,7 +68,11 @@ class HfHubHTTPError(HTTPError):
     """
 
     def __init__(self, message: str, response: Optional[Response] = None, *, server_message: Optional[str] = None):
-        self.request_id = response.headers.get("x-request-id") if response is not None else None
+        self.request_id = (
+            response.headers.get("x-request-id") or response.headers.get("X-Amzn-Trace-Id")
+            if response is not None
+            else None
+        )
         self.server_message = server_message
 
         super().__init__(


### PR DESCRIPTION
fixes #2583 
This PR addresses error formatting issues from #2583.

**Main changes**:
- added fallback to capture request ID from `X-Amzn-Trace-Id` header if `x-request-id` does not exist.
- labels each ID type separately in the error message for easier log searching.
- fixed issue with raw HTML being included in error messages by only appending non-HTML content.
- added tests.