### PR TITLE
Enforce parameters as a List of Dictionaries in modelinfo.safetensors

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -358,7 +358,7 @@ class TransformersInfo(dict):
 
 @dataclass
 class SafeTensorsInfo(dict):
-    parameters: List[Dict[str, int]]
+    parameters: Dict[str, int]
     total: int
 
     def __post_init__(self):  # hack to make SafeTensorsInfo backward compatible


### PR DESCRIPTION

~This PR modifies the `model_info` method to ensure that the `SafeTensorsInfo` instance is initialized with a list of dictionaries for the `parameters` attribute, as intended by the class definition.~

This PR changes the type definition of `parameters` attribute in `SafeTensorsInfo` to be a `Dict` instead of `List[Dict[str, int]]`

The model_info response for repo_id = `allenai/Molmo-72B-0924` is of the form:

```
"safetensors": {
            "parameters": {
                "F32": 73308285952
            },
            "total": 73308285952
        },
```

which is ~not~ expected since `parameters` should be of type ~`List[Dict[str, int]]`~ `Dict[str, int]`


This PR **might** serve as an extension for #2190