### PR TITLE
Serialization: take into account meta tensor when splitting the `state_dict`

### DIFF
--- a/src/huggingface_hub/serialization/_base.py
+++ b/src/huggingface_hub/serialization/_base.py
@@ -106,7 +106,8 @@ def split_state_dict_into_shards_factory(
 
         # If a `tensor` shares the same underlying storage as another tensor, we put `tensor` in the same `block`
         storage_id = get_storage_id(tensor)
-        if storage_id is not None:
+        # We skip tensors on meta, otherwise it will skip the tensor
+        if storage_id is not None and storage_id[0].type!='meta':
             if storage_id in storage_id_to_tensors:
                 # We skip this tensor for now and will reassign to correct shard later
                 storage_id_to_tensors[storage_id].append(key)

--- a/src/huggingface_hub/serialization/_base.py
+++ b/src/huggingface_hub/serialization/_base.py
@@ -107,7 +107,7 @@ def split_state_dict_into_shards_factory(
         # If a `tensor` shares the same underlying storage as another tensor, we put `tensor` in the same `block`
         storage_id = get_storage_id(tensor)
         # We skip tensors on meta, otherwise it will skip the tensor
-        if storage_id is not None and storage_id[0].type!='meta':
+        if storage_id is not None and getattr(storage_id[0],"type", None) != 'meta':
             if storage_id in storage_id_to_tensors:
                 # We skip this tensor for now and will reassign to correct shard later
                 storage_id_to_tensors[storage_id].append(key)


### PR DESCRIPTION
# What does this PR do ? 

Fixes https://github.com/huggingface/transformers/issues/33209

When a meta tensor is in the state dict, it will be assigned to the same shard file as the other meta tensor since they all share the same storage_id. Hence this creates a big file when using transformers cpu offload saving functionality. 
If we have meta tensor in the `state_dict`, we should consider that they do not share the same storage.
