### PR TITLE
Fix snapshot download when `local_dir` is provided.

### DIFF
--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -210,7 +210,9 @@ def snapshot_download(
         if local_dir is not None:
             local_dir = Path(local_dir)
             if local_dir.is_dir() and any(local_dir.iterdir()):
-                logger.warning(f"Returning existing local_dir `{local_dir}`as it exists and is not empty.")
+                logger.warning(
+                    f"Returning existing local_dir `{local_dir}` as remote repo cannot be accessed in `snapshot_download` ({api_call_error})."
+                )
                 return str(local_dir.resolve())
         # If we couldn't find the appropriate folder on disk, raise an error.
         if local_files_only:

--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -10,12 +10,7 @@ from . import constants
 from .errors import GatedRepoError, LocalEntryNotFoundError, RepositoryNotFoundError, RevisionNotFoundError
 from .file_download import REGEX_COMMIT_HASH, hf_hub_download, repo_folder_name
 from .hf_api import DatasetInfo, HfApi, ModelInfo, SpaceInfo
-from .utils import (
-    OfflineModeIsEnabled,
-    filter_repo_objects,
-    logging,
-    validate_hf_hub_args,
-)
+from .utils import OfflineModeIsEnabled, filter_repo_objects, logging, validate_hf_hub_args
 from .utils import tqdm as hf_tqdm
 
 
@@ -191,6 +186,7 @@ def snapshot_download(
     # => let's look if we can find the appropriate folder in the cache:
     #    - if the specified revision is a commit hash, look inside "snapshots".
     #    - f the specified revision is a branch or tag, look inside "refs".
+    # => if local_dir is not None, we will return the path to the local folder if it exists.
     if repo_info is None:
         # Try to get which commit hash corresponds to the specified revision
         commit_hash = None
@@ -211,6 +207,11 @@ def snapshot_download(
                 # (but we can't check if all the files are actually there)
                 return snapshot_folder
 
+        if local_dir is not None:
+            local_dir = Path(local_dir)
+            if local_dir.is_dir() and any(local_dir.iterdir()):
+                logger.warning(f"Returning existing local_dir `{local_dir}`as it exists and is not empty.")
+                return str(local_dir.resolve())
         # If we couldn't find the appropriate folder on disk, raise an error.
         if local_files_only:
             raise LocalEntryNotFoundError(

--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -206,7 +206,7 @@ def snapshot_download(
                 # Snapshot folder exists => let's return it
                 # (but we can't check if all the files are actually there)
                 return snapshot_folder
-
+        # If local_dir is not None, return it if it exists and is not empty
         if local_dir is not None:
             local_dir = Path(local_dir)
             if local_dir.is_dir() and any(local_dir.iterdir()):

--- a/tests/test_snapshot_download.py
+++ b/tests/test_snapshot_download.py
@@ -150,9 +150,9 @@ class SnapshotDownloadTests(unittest.TestCase):
             snapshot_download(self.repo_id, local_dir=tmpdir)
             # now load from local_dir
             storage_folder = snapshot_download(self.repo_id, local_dir=tmpdir, local_files_only=True)
-            self.assertTrue(str(tmpdir) in storage_folder)  # has expected revision
+            self.assertEquals(str(tmpdir), storage_folder)
 
-    def test_download_model_offline_mode_not_in_local(self):
+    def test_download_model_to_local_dir_with_offline_mode(self):
         """Test that an already downloaded folder is returned when there is a connection error"""
         # first download folder to local_dir
         with SoftTemporaryDirectory() as tmpdir:
@@ -161,7 +161,7 @@ class SnapshotDownloadTests(unittest.TestCase):
             for offline_mode in OfflineSimulationMode:
                 with offline(mode=offline_mode):
                     storage_folder = snapshot_download(self.repo_id, local_dir=tmpdir)
-                    self.assertTrue(str(tmpdir) in storage_folder)
+                    self.assertEquals(str(tmpdir), storage_folder)
 
     def test_download_model_offline_mode_not_in_local_dir(self):
         """Test when connection error but local_dir is empty."""

--- a/tests/test_snapshot_download.py
+++ b/tests/test_snapshot_download.py
@@ -144,6 +144,37 @@ class SnapshotDownloadTests(unittest.TestCase):
             )
             self.assertTrue(self.first_commit_hash in storage_folder)  # has expected revision
 
+        # Test with local_dir
+        with SoftTemporaryDirectory() as tmpdir:
+            # first download folder to local_dir
+            snapshot_download(self.repo_id, local_dir=tmpdir)
+            # now load from local_dir
+            storage_folder = snapshot_download(self.repo_id, local_dir=tmpdir, local_files_only=True)
+            self.assertTrue(str(tmpdir) in storage_folder)  # has expected revision
+
+    def test_download_model_offline_mode_not_in_local(self):
+        """Test when connection error but cache is empty."""
+        # first download folder to local_dir
+        with SoftTemporaryDirectory() as tmpdir:
+            snapshot_download(self.repo_id, local_dir=tmpdir)
+            # Test that an already downloaded folder is returned when there is a connection error
+            for offline_mode in OfflineSimulationMode:
+                with offline(mode=offline_mode):
+                    storage_folder = snapshot_download(self.repo_id, local_dir=tmpdir)
+                    self.assertTrue(str(tmpdir) in storage_folder)
+
+    def test_download_model_offline_mode_not_in_local_dir(self):
+        """Test when connection error but local_dir is empty."""
+        with SoftTemporaryDirectory() as tmpdir:
+            with self.assertRaises(LocalEntryNotFoundError):
+                snapshot_download(self.repo_id, local_dir=tmpdir, local_files_only=True)
+
+        for offline_mode in OfflineSimulationMode:
+            with offline(mode=offline_mode):
+                with SoftTemporaryDirectory() as tmpdir:
+                    with self.assertRaises(LocalEntryNotFoundError):
+                        snapshot_download(self.repo_id, local_dir=tmpdir)
+
     def test_download_model_offline_mode_not_cached(self):
         """Test when connection error but cache is empty."""
         with SoftTemporaryDirectory() as tmpdir:

--- a/tests/test_snapshot_download.py
+++ b/tests/test_snapshot_download.py
@@ -153,11 +153,11 @@ class SnapshotDownloadTests(unittest.TestCase):
             self.assertTrue(str(tmpdir) in storage_folder)  # has expected revision
 
     def test_download_model_offline_mode_not_in_local(self):
-        """Test when connection error but cache is empty."""
+        """Test that an already downloaded folder is returned when there is a connection error"""
         # first download folder to local_dir
         with SoftTemporaryDirectory() as tmpdir:
             snapshot_download(self.repo_id, local_dir=tmpdir)
-            # Test that an already downloaded folder is returned when there is a connection error
+            # Check that the folder is returned when there is a connection error
             for offline_mode in OfflineSimulationMode:
                 with offline(mode=offline_mode):
                     storage_folder = snapshot_download(self.repo_id, local_dir=tmpdir)


### PR DESCRIPTION
This PR fixes a bug reported internally in this private [slack message](https://huggingface.slack.com/archives/C02V5EA0A95/p1728304375203759).

## Issue
The issue comes from `huggingface_hub.snapshot_download()` which does not return the folder that already contains the downloaded files if:
- `local_dir` is provided.
-  we are in offline mode, i.e. no internet connection, hub down, or internet connection is deactivated (`local_files_only=True` or `HF_HUB_OFFLINE=True`).

## Fix
When `local_dir` is provided, we should check if it exists and contains files, as it's expected to have the latest version of the repo replicated there rather than in a snapshot folder.