### PR TITLE
Fix PermissionError while creating '.no_exist/' directory in cache

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1382,8 +1382,8 @@ def _get_metadata_or_catch_error(
                     commit_hash = http_error.response.headers.get(constants.HUGGINGFACE_HEADER_X_REPO_COMMIT)
                     if commit_hash is not None:
                         no_exist_file_path = Path(storage_folder) / ".no_exist" / commit_hash / relative_filename
-                        no_exist_file_path.parent.mkdir(parents=True, exist_ok=True)
                         try:
+                            no_exist_file_path.parent.mkdir(parents=True, exist_ok=True)
                             no_exist_file_path.touch()
                         except OSError as e:
                             logger.error(


### PR DESCRIPTION
Should fix https://github.com/huggingface/transformers/issues/33897 (cc @sanketsudake).

When trying to download a file that doesn't exist on a remote repo, `huggingface_hub` caches the information locally. Next time the user tries to download this file again, we will raise an error directly instead of attempting to make an HTTP call. This saves a few HTTP calls in `transformers` since the lib is not always aware of which tokenizers files exists on a given repo. This feature exists only when revision is passed with a specific commit_hash.

Since this feature is an optimization, it should be purely optional. That's why we have a try/catch around the `file.touch()` call to store non-existence of a given file. In https://github.com/huggingface/transformers/issues/33897, @sanketsudake reported that the `mkdir` call is failing for them with a `PermissionError`. This PR fixes this by moving it inside the try/catch (`PermissionError` is a subclass of `OSError`). 