### PR TITLE
Skip flaky Repository test

### DIFF
--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -320,7 +320,7 @@ class TestRepositoryUniqueRepos(RepositoryTestAbstract):
         self.assertEqual(repo.command_queue[-1].is_done, True)
         self.assertEqual(repo.command_queue[-1].title, "push")
 
-    @unittest.skipIf(os.name == "nt", "Killing a process on Windows works differently.")
+    @unittest.skip("This is a flaky and legacy test")
     def test_add_commit_push_non_blocking_process_killed(self):
         repo = self.clone_repo()
 


### PR DESCRIPTION
This test is flaky which is annoying for the CI. Since it's only testing an internal method of a legacy class (`Repository().git_push(blocking=False)._process.kill()`), I think it's more than ok to skip the test. We are testing how `Process` works more than anything.