### PR TITLE
Fix `sentence-similarity` model URL

### DIFF
--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -3003,6 +3003,10 @@ class InferenceClient:
 
         # If model is already a URL, ignore `task` and return directly
         if model is not None and (model.startswith("http://") or model.startswith("https://")):
+            # special case for sentence-similarity with TEI endpoints for which we need to add the `/similarity` suffix.
+            # see: https://huggingface.github.io/text-embeddings-inference/openapi.json.
+            if task == "sentence-similarity":
+                model += "/similarity"
             return model
 
         # # If no model but task is set => fetch the recommended one for this task

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -3116,6 +3116,10 @@ class AsyncInferenceClient:
 
         # If model is already a URL, ignore `task` and return directly
         if model is not None and (model.startswith("http://") or model.startswith("https://")):
+            # special case for sentence-similarity with TEI endpoints for which we need to add the `/similarity` suffix.
+            # see: https://huggingface.github.io/text-embeddings-inference/openapi.json.
+            if task == "sentence-similarity":
+                model += "/similarity"
             return model
 
         # # If no model but task is set => fetch the recommended one for this task


### PR DESCRIPTION
Fixes #2494.

This small PR fixes an issue when calling `InferenceClient.sentence_similarity()` with a model URL.
## Issue
Calling `InferenceClient.sentence_similarity()` using a deployed Inference Endpoint or a localhost URL results in `HfHubHTTPError: 422 Client Error`. 
In general, this is a result of a discrepancy between Inference API and a (local or deployed) inference endpoint. 
## Fix

adding a `/similarity` suffix to the model URL. See also TEI [OpenAPI doc](https://huggingface.github.io/text-embeddings-inference/openapi.json).
