### PR TITLE
Fix 2609 - Import packaging by default

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ extras["testing"] = (
         "urllib3<2.0",  # VCR.py broken with urllib3 2.0 (see https://urllib3.readthedocs.io/en/stable/v2-migration-guide.html)
         "soundfile",
         "Pillow",
-        "gradio",  # to test webhooks
+        "gradio>=5.1.0",  # to test webhooks # pin to avoid issue on Python3.12
         "numpy",  # for embeddings
         "fastapi",  # To build the documentation
     ]

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ extras["testing"] = (
         "urllib3<2.0",  # VCR.py broken with urllib3 2.0 (see https://urllib3.readthedocs.io/en/stable/v2-migration-guide.html)
         "soundfile",
         "Pillow",
-        "gradio>=5.1.0",  # to test webhooks # pin to avoid issue on Python3.12
+        "gradio>=4.0.0",  # to test webhooks # pin to avoid issue on Python3.12
         "numpy",  # for embeddings
         "fastapi",  # To build the documentation
     ]

--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -17,6 +17,8 @@ from typing import (
     Union,
 )
 
+import packaging.version
+
 from . import constants
 from .errors import EntryNotFoundError, HfHubHTTPError
 from .file_download import hf_hub_download
@@ -41,7 +43,6 @@ if is_torch_available():
     import torch  # type: ignore
 
 if is_safetensors_available():
-    import packaging.version
     import safetensors
     from safetensors.torch import load_model as load_model_as_safetensor
     from safetensors.torch import save_model as save_model_as_safetensor


### PR DESCRIPTION
Fix https://github.com/huggingface/huggingface_hub/issues/2609.

It's not the first time I see this so let's fix it. It's not really an error, just some IDEs that might yell because of how the import is made.
`packaging` is a package [installed by default](https://github.com/huggingface/huggingface_hub/blob/9bb6bd680d507223fef6e40c99ef087086194b58/setup.py#L17) with `huggingface_hub`.