### PR TITLE
Fix documentation link formatting in README_cn

### DIFF
--- a/i18n/README_cn.md
+++ b/i18n/README_cn.md
@@ -25,11 +25,12 @@
         <b>中文（简体）</b>
     <p>
 </h4>
+
 ---
 
-**文档**: `<a href="https://hf.co/docs/huggingface_hub" target="_blank">`https://hf.co/docs/huggingface_hub `</a>`
+**文档**: <a href="https://hf.co/docs/huggingface_hub" target="_blank">https://hf.co/docs/huggingface_hub </a>
 
-**源代码**: `<a href="https://github.com/huggingface/huggingface_hub" target="_blank">`https://github.com/huggingface/huggingface_hub `</a>`
+**源代码**: <a href="https://github.com/huggingface/huggingface_hub" target="_blank">https://github.com/huggingface/huggingface_hub </a>
 
 ---
 


### PR DESCRIPTION
This PR fixes the formatting of documentation and source code links in the README.

Current issue:
The links are enclosed in backticks, which causes them to be displayed as code instead of clickable links.

Changes made:
- Removed backticks surrounding the documentation and source code links
- Kept the HTML <a> tags to maintain the "target="_blank" functionality

Reason for change:
This formatting error affects the usability of the README, as users cannot directly click on the links. The fix improves navigation and overall user experience when viewing the project's GitHub page.

Related files:
- README.md