### PR TITLE
bugfix huggingface-cli command execution in python3.8

### DIFF
--- a/src/huggingface_hub/commands/user.py
+++ b/src/huggingface_hub/commands/user.py
@@ -36,7 +36,7 @@ Usage:
 
 import subprocess
 from argparse import _SubParsersAction
-from typing import Optional, List
+from typing import List, Optional
 
 from requests.exceptions import HTTPError
 

--- a/src/huggingface_hub/commands/user.py
+++ b/src/huggingface_hub/commands/user.py
@@ -36,7 +36,7 @@ Usage:
 
 import subprocess
 from argparse import _SubParsersAction
-from typing import Optional
+from typing import Optional, List
 
 from requests.exceptions import HTTPError
 
@@ -200,7 +200,7 @@ class AuthSwitchCommand(BaseUserCommand):
             except ValueError:
                 print("Invalid input. Please enter a number or 'q' to quit.")
 
-    def _select_token_name_tui(self, token_names: list[str]) -> Optional[str]:
+    def _select_token_name_tui(self, token_names: List[str]) -> Optional[str]:
         choices = [Choice(token_name, name=token_name) for token_name in token_names]
         try:
             return inquirer.select(


### PR DESCRIPTION
When I logged-in with huggingface-cli command in basic ubuntu 20.04 docker image which uses python 3.8, below error occurred.

- command
```
Huggingface-cli login
huggingface-cli login --token hf_xxxx
```
- error log
```
Traceback (most recent call last):
  File "/usr/local/bin/huggingface-cli", line 5, in <module>
    from huggingface_hub.commands.huggingface_cli import main
  File "/usr/local/lib/python3.8/dist-packages/huggingface_hub/commands/huggingface_cli.py", line 26, in <module>
    from huggingface_hub.commands.user import UserCommands
  File "/usr/local/lib/python3.8/dist-packages/huggingface_hub/commands/user.py", line 165, in <module>
    class AuthSwitchCommand(BaseUserCommand):
  File "/usr/local/lib/python3.8/dist-packages/huggingface_hub/commands/user.py", line 203, in AuthSwitchCommand
    def _select_token_name_tui(self, token_names: list[str]) -> Optional[str]:
TypeError: 'type' object is not subscriptable
```

I think that this issue occurred because python3.8 does not support generic types and this leads to bugs at below points. so, I modified the below code to use `List` type within a typing alias. Because huggingface-hub still officially supports Python 3.8, this bug should be resolved. (this issue occur in version 0.26.0) 
