### PR TITLE
Do not remove None values in RepoCardData serialization

### DIFF
--- a/src/huggingface_hub/repocard_data.py
+++ b/src/huggingface_hub/repocard_data.py
@@ -185,7 +185,7 @@ class CardData:
 
         data_dict = copy.deepcopy(self.__dict__)
         self._to_dict(data_dict)
-        return _remove_none(data_dict)
+        return {key: value for key, value in data_dict.items() if value is not None}
 
     def _to_dict(self, data_dict):
         """Use this method in child classes to alter the dict representation of the data. Alter the dict in-place.

--- a/tests/test_repocard_data.py
+++ b/tests/test_repocard_data.py
@@ -237,6 +237,20 @@ class ModelCardDataTest(unittest.TestCase):
         data = ModelCardData(tags=["tag2", "tag1", "tag2", "tag3"])
         assert data.tags == ["tag2", "tag1", "tag3"]
 
+    def test_remove_top_level_none_values(self):
+        as_obj = ModelCardData(tags=["tag1", None], foo={"bar":3, "baz": None}, pipeline_tag=None)
+        as_dict = as_obj.to_dict()
+
+
+        assert as_obj.tags == ["tag1", None]
+        assert as_dict["tags"] == ["tag1", None] # none value inside list should be kept
+
+        assert as_obj.foo == {"bar":3, "baz": None}
+        assert as_dict["foo"] == {"bar":3, "baz": None} # none value inside dict should be kept
+
+        assert as_obj.pipeline_tag is None
+        assert "pipeline_tag" not in as_dict # top level none value should be removed
+
 
 class DatasetCardDataTest(unittest.TestCase):
     def test_train_eval_index_keys_updated(self):

--- a/tests/test_repocard_data.py
+++ b/tests/test_repocard_data.py
@@ -238,18 +238,17 @@ class ModelCardDataTest(unittest.TestCase):
         assert data.tags == ["tag2", "tag1", "tag3"]
 
     def test_remove_top_level_none_values(self):
-        as_obj = ModelCardData(tags=["tag1", None], foo={"bar":3, "baz": None}, pipeline_tag=None)
+        as_obj = ModelCardData(tags=["tag1", None], foo={"bar": 3, "baz": None}, pipeline_tag=None)
         as_dict = as_obj.to_dict()
 
-
         assert as_obj.tags == ["tag1", None]
-        assert as_dict["tags"] == ["tag1", None] # none value inside list should be kept
+        assert as_dict["tags"] == ["tag1", None]  # none value inside list should be kept
 
-        assert as_obj.foo == {"bar":3, "baz": None}
-        assert as_dict["foo"] == {"bar":3, "baz": None} # none value inside dict should be kept
+        assert as_obj.foo == {"bar": 3, "baz": None}
+        assert as_dict["foo"] == {"bar": 3, "baz": None}  # none value inside dict should be kept
 
         assert as_obj.pipeline_tag is None
-        assert "pipeline_tag" not in as_dict # top level none value should be removed
+        assert "pipeline_tag" not in as_dict  # top level none value should be removed
 
 
 class DatasetCardDataTest(unittest.TestCase):


### PR DESCRIPTION
More details in https://github.com/huggingface/datasets/issues/7243#issuecomment-2427121987 and especially https://github.com/huggingface/datasets/issues/7243#issuecomment-2429286597.

When serializing repo cards metadata, we are currently removing any none values from any dictionary, set, list or tuple. This is done since the module has been introduced in https://github.com/huggingface/huggingface_hub/pull/940 and never caused problems until https://github.com/huggingface/datasets/issues/7243 was reported. I do find automatically removing None values inside values to be pretty clunky as it is values set by the user and not default ones.

This PR updates this behavior to remove only top-level None values, i.e. values that are None by default and that therefore shouldn't be serialized (as not set by the users themselves). The `_remove_none` helper is still kept to remove None values from the model-index (where it's rightfully necessary), but that's all.

:warning: this is a breaking change. In practice, I don't expect it to break anything in the wild. 