### PR TITLE
Fix and deprecate get_token_permission

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -1661,9 +1661,27 @@ class HfApi:
             ) from e
         return r.json()
 
-    def get_token_permission(self, token: Union[bool, str, None] = None) -> Literal["read", "write", None]:
+    @_deprecate_method(
+        version="1.0",
+        message=(
+            "Permissions are more complex than when `get_token_permission` was first introduced. "
+            "OAuth and fine-grain tokens allows for more detailed permissions. "
+            "If you need to know the permissions associated with a token, please use `whoami` and check the `'auth'` key."
+        ),
+    )
+    def get_token_permission(
+        self, token: Union[bool, str, None] = None
+    ) -> Literal["read", "write", "fineGrained", None]:
         """
         Check if a given `token` is valid and return its permissions.
+
+        <Tip warning={true}>
+
+        This method is deprecated and will be removed in version 1.0. Permissions are more complex than when
+        `get_token_permission` was first introduced. OAuth and fine-grain tokens allows for more detailed permissions.
+        If you need to know the permissions associated with a token, please use `whoami` and check the `'auth'` key.
+
+        </Tip>
 
         For more details about tokens, please refer to https://huggingface.co/docs/hub/security-tokens#what-are-user-access-tokens.
 
@@ -1675,12 +1693,12 @@ class HfApi:
                 To disable authentication, pass `False`.
 
         Returns:
-            `Literal["read", "write", None]`: Permission granted by the token ("read" or "write"). Returns `None` if no
-            token passed or token is invalid.
+            `Literal["read", "write", "fineGrained", None]`: Permission granted by the token ("read" or "write"). Returns `None` if no
+            token passed, if token is invalid or if role is not returned by the server. This typically happens when the token is an OAuth token.
         """
         try:
             return self.whoami(token=token)["auth"]["accessToken"]["role"]
-        except (LocalTokenNotFoundError, HTTPError):
+        except (LocalTokenNotFoundError, HTTPError, KeyError):
             return None
 
     def get_model_tags(self) -> Dict:

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -298,6 +298,17 @@ class HfApiEndpointsTest(HfApiCommonTest):
                 assert info.gated == gated_value
                 assert info.private == private_value
 
+    @expect_deprecation("get_token_permission")
+    def test_get_token_permission_on_oauth_token(self):
+        whoami = {
+            "type": "user",
+            "auth": {"type": "oauth", "expiresAt": "2024-10-24T19:43:43.000Z"},
+            # ...
+            # other values are ignored as we only need to check the "auth" value
+        }
+        with patch.object(self._api, "whoami", return_value=whoami):
+            assert self._api.get_token_permission() is None
+
 
 class CommitApiTest(HfApiCommonTest):
     def setUp(self) -> None:


### PR DESCRIPTION
As reported by @CISC in https://github.com/gradio-app/gradio/issues/9820#issuecomment-2432961165, using `get_token_permission` with an OAuth token is broken:

```py
...
  File "/home/user/app/app.py", line 985, in template_data_from_model_files
    if info and oauth_token and hfapi.get_token_permission(oauth_token.token) == "write":
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/huggingface_hub/hf_api.py", line 1691, in get_token_permission
    return self.whoami(token=token)["auth"]["accessToken"]["role"]
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
KeyError: 'accessToken'
```

This is because the whoami response for an OAuth token doesn't contain the detailed permission for that token.

This PR fixes `get_token_permission` to not raise an error when a OAuth token is passed but return None instead. This is a half-satisfying fix but at least it won't break things in the wild (same output as if no token is passed). What I also did is to fully deprecate this method as it doesn't make any sense to have it anymore. Deprecation cycle runs until v1.0.0. Tokens are not just "read" or "write". OAuth and fine-grained tokens have much more complex permissions depending on the user choices.

---

In a follow-up PR, I'll make sure to remove all internal use of `get_token_permission`. This doesn't have to be done in the same PR.