### PR TITLE
Fix `ModelCardData`'s datasets typing

### DIFF
--- a/src/huggingface_hub/repocard_data.py
+++ b/src/huggingface_hub/repocard_data.py
@@ -252,8 +252,8 @@ class ModelCardData(CardData):
             The identifier of the base model from which the model derives. This is applicable for example if your model is a
             fine-tune or adapter of an existing model. The value must be the ID of a model on the Hub (or a list of IDs
             if your model derives from multiple models). Defaults to None.
-        datasets (`List[str]`, *optional*):
-            List of datasets that were used to train this model. Should be a dataset ID
+        datasets (`Union[str, List[str]]`, *optional*):
+            Dataset or list of datasets that were used to train this model. Should be a dataset ID
             found on https://hf.co/datasets. Defaults to None.
         eval_results (`Union[List[EvalResult], EvalResult]`, *optional*):
             List of `huggingface_hub.EvalResult` that define evaluation results of the model. If provided,
@@ -312,7 +312,7 @@ class ModelCardData(CardData):
         self,
         *,
         base_model: Optional[Union[str, List[str]]] = None,
-        datasets: Optional[List[str]] = None,
+        datasets: Optional[Union[str, List[str]]] = None,
         eval_results: Optional[List[EvalResult]] = None,
         language: Optional[Union[str, List[str]]] = None,
         library_name: Optional[str] = None,


### PR DESCRIPTION
Fixes #2642.

Small PR to update `ModelCardData.datasets` type from `Optional[List[str]]` to `Optional[Union[str, List[str]]]` to match server-side `ModelMetadata.datasets` type (see [here](https://github.com/huggingface-internal/moon-landing/blob/e808c999f25e584caf8d013e9defcd336beafc73/server/lib/ModelMetadata.ts#L169)).