### PR TITLE
[Serialization] Add `is_main_process` argument to `save_torch_state_dict()`

### DIFF
--- a/src/huggingface_hub/serialization/_torch.py
+++ b/src/huggingface_hub/serialization/_torch.py
@@ -91,7 +91,7 @@ def save_torch_model(
             in a future version.
         is_main_process (`bool`, *optional*):
             Whether the process calling this is the main process or not. Useful when in distributed training like
-            TPUs and need to call this function on all processes. In this case, set `is_main_process=True` only on
+            TPUs and need to call this function from all processes. In this case, set `is_main_process=True` only on
             the main process to avoid race conditions. Defaults to True.
 
     Example:
@@ -180,7 +180,7 @@ def save_torch_state_dict(
             in a future version.
         is_main_process (`bool`, *optional*):
             Whether the process calling this is the main process or not. Useful when in distributed training like
-            TPUs and need to call this function on all processes. In this case, set `is_main_process=True` only on
+            TPUs and need to call this function from all processes. In this case, set `is_main_process=True` only on
             the main process to avoid race conditions. Defaults to True.
     Example:
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -479,11 +479,11 @@ def test_save_torch_state_dict_not_main_process(
     torch_state_dict: Dict[str, "torch.Tensor"],
 ) -> None:
     """
-    Test that files are not deleted when is_main_process=False.
-    When is_main_process=True, files should be deleted,
+    Test that previous files in the directory are not deleted when is_main_process=False.
+    When is_main_process=True, previous files should be deleted,
     this is already tested in `test_save_torch_state_dict_delete_existing_files`.
     """
-    # Create some .safetensors files
+    # Create some .safetensors files before saving a new state dict.
     (tmp_path / "model.safetensors").touch()
     (tmp_path / "model-00001-of-00002.safetensors").touch()
     (tmp_path / "model-00002-of-00002.safetensors").touch()
@@ -491,7 +491,7 @@ def test_save_torch_state_dict_not_main_process(
     # Save with is_main_process=False
     save_torch_state_dict(torch_state_dict, tmp_path, is_main_process=False)
 
-    # Files should still exist (not deleted)
+    # Previous files should still exist (not deleted)
     assert (tmp_path / "model.safetensors").is_file()
     assert (tmp_path / "model-00001-of-00002.safetensors").is_file()
     assert (tmp_path / "model-00002-of-00002.safetensors").is_file()

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -264,6 +264,7 @@ def test_save_torch_model(mocker: MockerFixture, tmp_path: Path) -> None:
         max_shard_size="3GB",
         metadata={"foo": "bar"},
         safe_serialization=True,
+        is_main_process=True,
     )
     safe_state_dict_mock.assert_called_once_with(
         state_dict=model_mock.state_dict.return_value,
@@ -273,6 +274,7 @@ def test_save_torch_model(mocker: MockerFixture, tmp_path: Path) -> None:
         max_shard_size="3GB",
         metadata={"foo": "bar"},
         safe_serialization=True,
+        is_main_process=True,
     )
 
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -472,3 +472,27 @@ def test_save_torch_state_dict_delete_existing_files(
     assert (tmp_path / "pytorch_model-00001-of-00003.bin").is_file()
     assert (tmp_path / "pytorch_model-00002-of-00003.bin").is_file()
     assert (tmp_path / "pytorch_model-00003-of-00003.bin").is_file()
+
+
+def test_save_torch_state_dict_not_main_process(
+    tmp_path: Path,
+    torch_state_dict: Dict[str, "torch.Tensor"],
+) -> None:
+    """
+    Test that files are not deleted when is_main_process=False.
+    When is_main_process=True, files should be deleted,
+    this is already tested in `test_save_torch_state_dict_delete_existing_files`.
+    """
+    # Create some .safetensors files
+    (tmp_path / "model.safetensors").touch()
+    (tmp_path / "model-00001-of-00002.safetensors").touch()
+    (tmp_path / "model-00002-of-00002.safetensors").touch()
+    (tmp_path / "model.safetensors.index.json").touch()
+    # Save with is_main_process=False
+    save_torch_state_dict(torch_state_dict, tmp_path, is_main_process=False)
+
+    # Files should still exist (not deleted)
+    assert (tmp_path / "model.safetensors").is_file()
+    assert (tmp_path / "model-00001-of-00002.safetensors").is_file()
+    assert (tmp_path / "model-00002-of-00002.safetensors").is_file()
+    assert (tmp_path / "model.safetensors.index.json").is_file()


### PR DESCRIPTION
This small PR adds `is_main_process` parameter to `save_torch_state_dict()` to prevent race conditions during distributed environment. This aligns with accelerate's, transformers' and diffusers' implementations and will enable standardization of model saving across these libraries. See #2314 and this [internal slack message](https://huggingface.slack.com/archives/C01Q6JPP6NA/p1730370857167919) for more context.

Once this is released in huggingface_hub==0.27.0, PRs will be opened to update accelerate's [save_model()](https://github.com/huggingface/accelerate/blob/b0e5fd353c884d443aacffa18328971db9dd728a/src/accelerate/accelerator.py#L2814), transformers' [save_pretrained()](https://github.com/huggingface/transformers/blob/b5919e12f74190a5f50a47f07cb708ceb029244d/src/transformers/modeling_utils.py#L2677) and diffusers' [save_pretrained()](https://github.com/huggingface/diffusers/blob/41e4779d988ead99e7acd78dc8e752de88777d0f/src/diffusers/models/modeling_utils.py#L270) to use `save_torch_state_dict()` directly.


## Main changes: 
(Following existing implementations in accelerate, transformers and diffusers)
- Condition removing the files from the previous save on `is_main_process=True` to avoid race conditions during distributed environment.
- Add `is_main_process=True` as default parameter.
- Add a simple unit test for that.


cc @muellerzr, @SunMarc and @sayakpaul for visibility. 
