### PR TITLE
[InferenceClient] Update `max_tokens` and `max_new_tokens` default value in docstring

### DIFF
--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -584,7 +584,7 @@ class InferenceClient:
                 Whether to return log probabilities of the output tokens or not. If true, returns the log
                 probabilities of each output token returned in the content of message.
             max_tokens (`int`, *optional*):
-                Maximum number of tokens allowed in the response. Defaults to 20.
+                Maximum number of tokens allowed in the response. Defaults to 100.
             n (`int`, *optional*):
                 UNUSED.
             presence_penalty (`float`, *optional*):
@@ -2075,7 +2075,7 @@ class InferenceClient:
             grammar ([`TextGenerationInputGrammarType`], *optional*):
                 Grammar constraints. Can be either a JSONSchema or a regex.
             max_new_tokens (`int`, *optional*):
-                Maximum number of generated tokens
+                Maximum number of generated tokens. Defaults to 100.
             repetition_penalty (`float`, *optional*):
                 The parameter for repetition penalty. 1.0 means no penalty. See [this
                 paper](https://arxiv.org/pdf/1909.05858.pdf) for more details.

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -620,7 +620,7 @@ class AsyncInferenceClient:
                 Whether to return log probabilities of the output tokens or not. If true, returns the log
                 probabilities of each output token returned in the content of message.
             max_tokens (`int`, *optional*):
-                Maximum number of tokens allowed in the response. Defaults to 20.
+                Maximum number of tokens allowed in the response. Defaults to 100.
             n (`int`, *optional*):
                 UNUSED.
             presence_penalty (`float`, *optional*):
@@ -2138,7 +2138,7 @@ class AsyncInferenceClient:
             grammar ([`TextGenerationInputGrammarType`], *optional*):
                 Grammar constraints. Can be either a JSONSchema or a regex.
             max_new_tokens (`int`, *optional*):
-                Maximum number of generated tokens
+                Maximum number of generated tokens. Defaults to 100.
             repetition_penalty (`float`, *optional*):
                 The parameter for repetition penalty. 1.0 means no penalty. See [this
                 paper](https://arxiv.org/pdf/1909.05858.pdf) for more details.


### PR DESCRIPTION
fixes #2652.

tiny PR to fix incorrect default value of `max_tokens` and `max_new_tokens` in `InferenceClient.text_generation()` and `InferenceClient.chat_completion()` docstrings, reflecting the default values in [text-generation-inference/lib.rs](https://github.com/huggingface/text-generation-inference/blob/main/router/src/lib.rs). 
The default value in `InferenceClient.chat_completion()` was incorrectly documented as 20 instead of 100. The `max_new_tokens` parameter default value was also added in `InferenceClient.text_generation()` docstring, given that it's an important generation parameter.