### PR TITLE
[HfApi] Fix sorting properties in `list_models()`, `list_datasets()` and `list_spaces()`

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -1798,8 +1798,8 @@ class HfApi:
                 A tuple of two ints or floats representing a minimum and maximum
                 carbon footprint to filter the resulting models with in grams.
             sort (`Literal["last_modified"]` or `str`, *optional*):
-                The key with which to sort the resulting models. Possible values
-                are the properties of the [`huggingface_hub.hf_api.ModelInfo`] class.
+                The key with which to sort the resulting models. Possible values are "last_modified", "trending_score",
+                "created_at", "downloads" and "likes".
             direction (`Literal[-1]` or `int`, *optional*):
                 Direction in which to sort. The value `-1` sorts by descending
                 order while all other values sort by ascending order.
@@ -1911,7 +1911,15 @@ class HfApi:
         if len(search_list) > 0:
             params["search"] = search_list
         if sort is not None:
-            params["sort"] = "lastModified" if sort == "last_modified" else sort
+            params["sort"] = (
+                "lastModified"
+                if sort == "last_modified"
+                else "trendingScore"
+                if sort == "trending_score"
+                else "createdAt"
+                if sort == "created_at"
+                else sort
+            )
         if direction is not None:
             params["direction"] = direction
         if limit is not None:
@@ -2010,8 +2018,8 @@ class HfApi:
             search (`str`, *optional*):
                 A string that will be contained in the returned datasets.
             sort (`Literal["last_modified"]` or `str`, *optional*):
-                The key with which to sort the resulting datasets. Possible
-                values are the properties of the [`huggingface_hub.hf_api.DatasetInfo`] class.
+                The key with which to sort the resulting models. Possible values are "last_modified", "trending_score",
+                "created_at", "downloads" and "likes".
             direction (`Literal[-1]` or `int`, *optional*):
                 Direction in which to sort. The value `-1` sorts by descending
                 order while all other values sort by ascending order.
@@ -2121,7 +2129,15 @@ class HfApi:
         if len(search_list) > 0:
             params["search"] = search_list
         if sort is not None:
-            params["sort"] = "lastModified" if sort == "last_modified" else sort
+            params["sort"] = (
+                "lastModified"
+                if sort == "last_modified"
+                else "trendingScore"
+                if sort == "trending_score"
+                else "createdAt"
+                if sort == "created_at"
+                else sort
+            )
         if direction is not None:
             params["direction"] = direction
         if limit is not None:
@@ -2193,8 +2209,8 @@ class HfApi:
             linked (`bool`, *optional*):
                 Whether to return Spaces that make use of either a model or a dataset.
             sort (`Literal["last_modified"]` or `str`, *optional*):
-                The key with which to sort the resulting Spaces. Possible
-                values are the properties of the [`huggingface_hub.hf_api.SpaceInfo`]` class.
+                The key with which to sort the resulting models. Possible values are "last_modified", "trending_score",
+                "created_at" and "likes".
             direction (`Literal[-1]` or `int`, *optional*):
                 Direction in which to sort. The value `-1` sorts by descending
                 order while all other values sort by ascending order.
@@ -2230,7 +2246,15 @@ class HfApi:
         if search is not None:
             params["search"] = search
         if sort is not None:
-            params["sort"] = "lastModified" if sort == "last_modified" else sort
+            params["sort"] = (
+                "lastModified"
+                if sort == "last_modified"
+                else "trendingScore"
+                if sort == "trending_score"
+                else "createdAt"
+                if sort == "created_at"
+                else sort
+            )
         if direction is not None:
             params["direction"] = direction
         if limit is not None:

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -1764,6 +1764,30 @@ class HfApiPublicProductionTest(unittest.TestCase):
         assert isinstance(model, ModelInfo)
         assert all(tag in model.tags for tag in ["bert", "jax"])
 
+    def test_list_models_sort_trending_score(self):
+        models = list(self._api.list_models(sort="trending_score", limit=10))
+        assert len(models) == 10
+        assert isinstance(models[0], ModelInfo)
+        assert all(model.trending_score is not None for model in models)
+
+    def test_list_models_sort_created_at(self):
+        models = list(self._api.list_models(sort="created_at", limit=10))
+        assert len(models) == 10
+        assert isinstance(models[0], ModelInfo)
+        assert all(model.created_at is not None for model in models)
+
+    def test_list_models_sort_downloads(self):
+        models = list(self._api.list_models(sort="downloads", limit=10))
+        assert len(models) == 10
+        assert isinstance(models[0], ModelInfo)
+        assert all(model.downloads is not None for model in models)
+
+    def test_list_models_sort_likes(self):
+        models = list(self._api.list_models(sort="likes", limit=10))
+        assert len(models) == 10
+        assert isinstance(models[0], ModelInfo)
+        assert all(model.likes is not None for model in models)
+
     def test_list_models_with_config(self):
         for model in self._api.list_models(filter=("adapter-transformers", "bert"), fetch_config=True, limit=20):
             self.assertIsNotNone(model.config)


### PR DESCRIPTION
This PR fixes a bug reported in an internal [slack message](https://huggingface.slack.com/archives/C02V5EA0A95/p1730735733880359) where the `created_at` field in `ModelInfo` does not work as a valid sort parameter for listing models via the api. the correct parameter should be `createdAt` rather than `created_at`. The same issue applies to the `trending_score` field. 
I’ve restricted the list of possible sort values in the docstring to match those defined on the API side, as seen [here](https://github.com/huggingface-internal/moon-landing/blob/main/server/lib/SearchBuilder.ts) (private link). also, I'm not sure if the sorting feature is widely used, but I've added some tests just in case! 

