### PR TITLE
Warn about upload_large_folder if really large folder

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -9217,7 +9217,8 @@ class HfApi:
                 token=token,
             )
         if len(filtered_repo_objects) > 30:
-            logger.info(
+            log = logger.warning if len(filtered_repo_objects) > 200 else logger.info
+            log(
                 "It seems you are trying to upload a large folder at once. This might take some time and then fail if "
                 "the folder is too large. For such cases, it is recommended to upload in smaller batches or to use "
                 "`HfApi().upload_large_folder(...)`/`huggingface-cli upload-large-folder` instead. For more details, "


### PR DESCRIPTION
Fix https://github.com/huggingface/huggingface_hub/issues/2650.

Based on https://github.com/huggingface/huggingface_hub/issues/2650?notification_referrer_id=NT_kwDOALQU-bQxMzE2MzIwMzkxNDoxMTgwMTg0OQ#issuecomment-2455925337.

If large folder (>30), we log an INFO message to suggest using `upload_large_folder`. With this PR if the folder is >200 files, we log as a WARNING to be sure the user knows about it (200+ files at files is likely to fail anyway...).


cc @yoinked-h