### PR TITLE
Fix the error caused by reading `.DS_Store` when running the `scan-cache` command.

### DIFF
--- a/src/huggingface_hub/utils/_cache_manager.py
+++ b/src/huggingface_hub/utils/_cache_manager.py
@@ -742,7 +742,7 @@ def _scan_cached_repo(repo_path: Path) -> CachedRepoInfo:
 
         for ref_path in refs_path.glob("**/*"):
             # glob("**/*") iterates over all files and directories -> skip directories
-            if ref_path.is_dir():
+            if ref_path.is_dir() or ref_path.name in FILES_TO_IGNORE:
                 continue
 
             ref_name = str(ref_path.relative_to(refs_path))


### PR DESCRIPTION
As title. 

Same as #2112

![iTerm2 2024-11-11 17 42 11](https://github.com/user-attachments/assets/057d719c-726b-4bac-a057-38129f30ae4e)
