### PR TITLE
[Inference Client] fix `zero_shot_image_classification`'s parameters

### DIFF
--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -2913,10 +2913,11 @@ class InferenceClient:
         # Raise ValueError if input is less than 2 labels
         if len(labels) < 2:
             raise ValueError("You must specify at least 2 classes to compare.")
-
-        inputs = {"image": _b64_encode(image), "candidateLabels": ",".join(labels)}
-        parameters = {"hypothesis_template": hypothesis_template}
-        payload = _prepare_payload(inputs, parameters=parameters)
+        parameters = {
+            "candidate_labels": labels,
+            "hypothesis_template": hypothesis_template,
+        }
+        payload = _prepare_payload(image, parameters=parameters)
         response = self.post(
             **payload,
             model=model,

--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -2917,7 +2917,7 @@ class InferenceClient:
             "candidate_labels": labels,
             "hypothesis_template": hypothesis_template,
         }
-        payload = _prepare_payload(image, parameters=parameters)
+        payload = _prepare_payload(image, parameters=parameters, expect_binary=True)
         response = self.post(
             **payload,
             model=model,

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -2985,10 +2985,11 @@ class AsyncInferenceClient:
         # Raise ValueError if input is less than 2 labels
         if len(labels) < 2:
             raise ValueError("You must specify at least 2 classes to compare.")
-
-        inputs = {"image": _b64_encode(image), "candidateLabels": ",".join(labels)}
-        parameters = {"hypothesis_template": hypothesis_template}
-        payload = _prepare_payload(inputs, parameters=parameters)
+        parameters = {
+            "candidate_labels": labels,
+            "hypothesis_template": hypothesis_template,
+        }
+        payload = _prepare_payload(image, parameters=parameters)
         response = await self.post(
             **payload,
             model=model,

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -2989,7 +2989,7 @@ class AsyncInferenceClient:
             "candidate_labels": labels,
             "hypothesis_template": hypothesis_template,
         }
-        payload = _prepare_payload(image, parameters=parameters)
+        payload = _prepare_payload(image, parameters=parameters, expect_binary=True)
         response = await self.post(
             **payload,
             model=model,


### PR DESCRIPTION
This PR fixes `InferenceClient.zero_shot_image_classification` to accept `candidate_labels` as a parameter rather than an input. See this [internal slack message](https://huggingface.slack.com/archives/C069KSP486B/p1731923978189269) for more context.
