### PR TITLE
[Inference Client] fix param docstring and deprecate `labels` param in zero-shot classification tasks

### DIFF
--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -2772,11 +2772,12 @@ class InferenceClient:
     @_deprecate_arguments(
         version="0.30.0",
         deprecated_args=["labels"],
-        custom_message="Use `candidate_labels` instead.",
+        custom_message="`labels`has been renamed to `candidate_labels` and will be removed in huggingface_hub>=0.30.0.",
     )
     def zero_shot_classification(
         self,
         text: str,
+        # temporarily keeping it optional for backward compatibility.
         candidate_labels: List[str] = None,  # type: ignore
         *,
         multi_label: Optional[bool] = False,
@@ -2793,7 +2794,7 @@ class InferenceClient:
                 The input text to classify.
             candidate_labels (`List[str]`):
                 The set of possible class labels to classify the text into.
-            labels (`List[str]`):
+            labels (`List[str]`, *optional*):
                 (deprecated) List of strings. Each string is the verbalization of a possible label for the input text.
             multi_label (`bool`, *optional*):
                 Whether multiple candidate labels can be true. If false, the scores are normalized such that the sum of
@@ -2868,7 +2869,8 @@ class InferenceClient:
                     "Cannot specify both `labels` and `candidate_labels`. Use `candidate_labels` instead."
                 )
             candidate_labels = labels
-
+        elif candidate_labels is None:
+            raise ValueError("Must specify `candidate_labels`")
         parameters = {
             "candidate_labels": candidate_labels,
             "multi_label": multi_label,
@@ -2889,17 +2891,18 @@ class InferenceClient:
     @_deprecate_arguments(
         version="0.30.0",
         deprecated_args=["labels"],
-        custom_message="Use `candidate_labels` instead.",
+        custom_message="`labels`has been renamed to `candidate_labels` and will be removed in huggingface_hub>=0.30.0.",
     )
     def zero_shot_image_classification(
         self,
         image: ContentT,
-        candidate_labels: List[str] = None,  # type: ignore
+        # temporarily keeping it optional for backward compatibility.
+        candidate_labels: Optional[List[str]] = None,
         *,
         model: Optional[str] = None,
         hypothesis_template: Optional[str] = None,
         # deprecated argument
-        labels: List[str] = None,  # type: ignore
+        labels: Optional[List[str]] = None,  # type: ignore
     ) -> List[ZeroShotImageClassificationOutputElement]:
         """
         Provide input image and text labels to predict text labels for the image.
@@ -2909,7 +2912,7 @@ class InferenceClient:
                 The input image to caption. It can be raw bytes, an image file, or a URL to an online image.
             candidate_labels (`List[str]`):
                 The candidate labels for this image
-            labels (`List[str]`):
+            labels (`List[str]`, *optional*):
                 (deprecated) List of string possible labels. There must be at least 2 labels.
             model (`str`, *optional*):
                 The model to use for inference. Can be a model ID hosted on the Hugging Face Hub or a URL to a deployed
@@ -2946,6 +2949,8 @@ class InferenceClient:
                     "Cannot specify both `labels` and `candidate_labels`. Use `candidate_labels` instead."
                 )
             candidate_labels = labels
+        elif candidate_labels is None:
+            raise ValueError("Must specify `candidate_labels`")
         # Raise ValueError if input is less than 2 labels
         if len(candidate_labels) < 2:
             raise ValueError("You must specify at least 2 classes to compare.")

--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -2769,14 +2769,21 @@ class InferenceClient:
         response = self.post(json=payload, model=model, task="visual-question-answering")
         return VisualQuestionAnsweringOutputElement.parse_obj_as_list(response)
 
+    @_deprecate_arguments(
+        version="0.30.0",
+        deprecated_args=["labels"],
+        custom_message="Use `candidate_labels` instead.",
+    )
     def zero_shot_classification(
         self,
         text: str,
-        labels: List[str],
+        candidate_labels: List[str] = None,  # type: ignore
         *,
         multi_label: Optional[bool] = False,
         hypothesis_template: Optional[str] = None,
         model: Optional[str] = None,
+        # deprecated argument
+        labels: List[str] = None,  # type: ignore
     ) -> List[ZeroShotClassificationOutputElement]:
         """
         Provide as input a text and a set of candidate labels to classify the input text.
@@ -2784,8 +2791,10 @@ class InferenceClient:
         Args:
             text (`str`):
                 The input text to classify.
+            candidate_labels (`List[str]`):
+                The set of possible class labels to classify the text into.
             labels (`List[str]`):
-                List of strings. Each string is the verbalization of a possible label for the input text.
+                (deprecated) List of strings. Each string is the verbalization of a possible label for the input text.
             multi_label (`bool`, *optional*):
                 Whether multiple candidate labels can be true. If false, the scores are normalized such that the sum of
                 the label likelihoods for each sequence is 1. If true, the labels are considered independent and
@@ -2852,9 +2861,16 @@ class InferenceClient:
         ]
         ```
         """
+        # handle deprecation
+        if labels is not None:
+            if candidate_labels is not None:
+                raise ValueError(
+                    "Cannot specify both `labels` and `candidate_labels`. Use `candidate_labels` instead."
+                )
+            candidate_labels = labels
 
         parameters = {
-            "candidate_labels": labels,
+            "candidate_labels": candidate_labels,
             "multi_label": multi_label,
             "hypothesis_template": hypothesis_template,
         }
@@ -2870,13 +2886,20 @@ class InferenceClient:
             for label, score in zip(output["labels"], output["scores"])
         ]
 
+    @_deprecate_arguments(
+        version="0.30.0",
+        deprecated_args=["labels"],
+        custom_message="Use `candidate_labels` instead.",
+    )
     def zero_shot_image_classification(
         self,
         image: ContentT,
-        labels: List[str],
+        candidate_labels: List[str] = None,  # type: ignore
         *,
         model: Optional[str] = None,
         hypothesis_template: Optional[str] = None,
+        # deprecated argument
+        labels: List[str] = None,  # type: ignore
     ) -> List[ZeroShotImageClassificationOutputElement]:
         """
         Provide input image and text labels to predict text labels for the image.
@@ -2884,14 +2907,17 @@ class InferenceClient:
         Args:
             image (`Union[str, Path, bytes, BinaryIO]`):
                 The input image to caption. It can be raw bytes, an image file, or a URL to an online image.
+            candidate_labels (`List[str]`):
+                The candidate labels for this image
             labels (`List[str]`):
-                List of string possible labels. There must be at least 2 labels.
+                (deprecated) List of string possible labels. There must be at least 2 labels.
             model (`str`, *optional*):
                 The model to use for inference. Can be a model ID hosted on the Hugging Face Hub or a URL to a deployed
                 Inference Endpoint. This parameter overrides the model defined at the instance level. If not provided, the default recommended zero-shot image classification model will be used.
             hypothesis_template (`str`, *optional*):
                 The sentence used in conjunction with candidateLabels to attempt the text classification by replacing
                 the placeholder with the candidate labels.
+
         Returns:
             `List[ZeroShotImageClassificationOutputElement]`: List of [`ZeroShotImageClassificationOutputElement`] items containing the predicted labels and their confidence.
 
@@ -2913,11 +2939,18 @@ class InferenceClient:
         [ZeroShotImageClassificationOutputElement(label='dog', score=0.956),...]
         ```
         """
+        # handle deprecation
+        if labels is not None:
+            if candidate_labels is not None:
+                raise ValueError(
+                    "Cannot specify both `labels` and `candidate_labels`. Use `candidate_labels` instead."
+                )
+            candidate_labels = labels
         # Raise ValueError if input is less than 2 labels
-        if len(labels) < 2:
+        if len(candidate_labels) < 2:
             raise ValueError("You must specify at least 2 classes to compare.")
         parameters = {
-            "candidate_labels": labels,
+            "candidate_labels": candidate_labels,
             "hypothesis_template": hypothesis_template,
         }
         payload = _prepare_payload(image, parameters=parameters, expect_binary=True)

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -2863,7 +2863,7 @@ class AsyncInferenceClient:
                 The input text to classify.
             candidate_labels (`List[str]`):
                 The set of possible class labels to classify the text into.
-            labels (`List[str]`):
+            labels (`List[str]`, *optional*):
                 (deprecated) List of strings. Each string is the verbalization of a possible label for the input text.
             multi_label (`bool`, *optional*):
                 Whether multiple candidate labels can be true. If false, the scores are normalized such that the sum of
@@ -2983,7 +2983,7 @@ class AsyncInferenceClient:
                 The input image to caption. It can be raw bytes, an image file, or a URL to an online image.
             candidate_labels (`List[str]`):
                 The candidate labels for this image
-            labels (`List[str]`):
+            labels (`List[str]`, *optional*):
                 (deprecated) List of string possible labels. There must be at least 2 labels.
             model (`str`, *optional*):
                 The model to use for inference. Can be a model ID hosted on the Hugging Face Hub or a URL to a deployed

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -2841,11 +2841,12 @@ class AsyncInferenceClient:
     @_deprecate_arguments(
         version="0.30.0",
         deprecated_args=["labels"],
-        custom_message="Use `candidate_labels` instead.",
+        custom_message="`labels`has been renamed to `candidate_labels` and will be removed in huggingface_hub>=0.30.0.",
     )
     async def zero_shot_classification(
         self,
         text: str,
+        # temporarily keeping it optional for backward compatibility.
         candidate_labels: List[str] = None,  # type: ignore
         *,
         multi_label: Optional[bool] = False,
@@ -2939,7 +2940,8 @@ class AsyncInferenceClient:
                     "Cannot specify both `labels` and `candidate_labels`. Use `candidate_labels` instead."
                 )
             candidate_labels = labels
-
+        elif candidate_labels is None:
+            raise ValueError("Must specify `candidate_labels`")
         parameters = {
             "candidate_labels": candidate_labels,
             "multi_label": multi_label,
@@ -2960,17 +2962,18 @@ class AsyncInferenceClient:
     @_deprecate_arguments(
         version="0.30.0",
         deprecated_args=["labels"],
-        custom_message="Use `candidate_labels` instead.",
+        custom_message="`labels`has been renamed to `candidate_labels` and will be removed in huggingface_hub>=0.30.0.",
     )
     async def zero_shot_image_classification(
         self,
         image: ContentT,
-        candidate_labels: List[str] = None,  # type: ignore
+        # temporarily keeping it optional for backward compatibility.
+        candidate_labels: Optional[List[str]] = None,
         *,
         model: Optional[str] = None,
         hypothesis_template: Optional[str] = None,
         # deprecated argument
-        labels: List[str] = None,  # type: ignore
+        labels: Optional[List[str]] = None,  # type: ignore
     ) -> List[ZeroShotImageClassificationOutputElement]:
         """
         Provide input image and text labels to predict text labels for the image.
@@ -3018,6 +3021,8 @@ class AsyncInferenceClient:
                     "Cannot specify both `labels` and `candidate_labels`. Use `candidate_labels` instead."
                 )
             candidate_labels = labels
+        elif candidate_labels is None:
+            raise ValueError("Must specify `candidate_labels`")
         # Raise ValueError if input is less than 2 labels
         if len(candidate_labels) < 2:
             raise ValueError("You must specify at least 2 classes to compare.")

--- a/tests/test_inference_client.py
+++ b/tests/test_inference_client.py
@@ -56,7 +56,7 @@ from huggingface_hub.inference._common import (
 )
 from huggingface_hub.utils import build_hf_headers
 
-from .testing_utils import with_production_testing
+from .testing_utils import expect_deprecation, with_production_testing
 
 
 # Avoid call to hf.co/api/models in VCRed tests
@@ -636,6 +636,7 @@ class InferenceClientVCRTest(InferenceClientTest):
             VisualQuestionAnsweringOutputElement(label=None, score=0.01777094043791294, answer="man"),
         ]
 
+    @expect_deprecation("zero_shot_classification")
     def test_zero_shot_classification_single_label(self) -> None:
         output = self.client.zero_shot_classification(
             "A new model offers an explanation for how the Galilean satellites formed around the solar system's"
@@ -654,6 +655,7 @@ class InferenceClientVCRTest(InferenceClientTest):
             ],
         )
 
+    @expect_deprecation("zero_shot_classification")
     def test_zero_shot_classification_multi_label(self) -> None:
         output = self.client.zero_shot_classification(
             "A new model offers an explanation for how the Galilean satellites formed around the solar system's"


### PR DESCRIPTION
This PR does two things:
- fixes a bug in the parameter docstring formatting when it's not an optional one, see [this comment](https://github.com/huggingface/huggingface_hub/pull/2664/files#r1847893906) for more context. 
- deprecates `labels` parameter in `InferenceClient.zero_shot_classification` and `InferenceClient.zero_shot_image_classification` in favor of `candidate_labels`. 

This PR should be merged before #2664.