### PR TITLE
Fix logo in README when dark mode is on 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 <p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/huggingface/documentation-images/raw/main/huggingface_hub-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://huggingface.co/datasets/huggingface/documentation-images/raw/main/huggingface_hub.svg">
+    <img alt="huggingface_hub library logo" src="https://huggingface.co/datasets/huggingface/documentation-images/raw/main/huggingface_hub.svg" width="352" height="59" style="max-width: 100%;">
+  </picture>
   <br/>
-    <img alt="huggingface_hub library logo" src="https://huggingface.co/datasets/huggingface/documentation-images/raw/main/huggingface_hub.svg" width="376" height="59" style="max-width: 100%;">
   <br/>
-</p>
+</p> 
 
 <p align="center">
     <i>The official Python client for the Huggingface Hub.</i>

--- a/i18n/README_cn.md
+++ b/i18n/README_cn.md
@@ -1,8 +1,12 @@
 <p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/huggingface/documentation-images/raw/main/huggingface_hub-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://huggingface.co/datasets/huggingface/documentation-images/raw/main/huggingface_hub.svg">
+    <img alt="huggingface_hub library logo" src="https://huggingface.co/datasets/huggingface/documentation-images/raw/main/huggingface_hub.svg" width="352" height="59" style="max-width: 100%;">
+  </picture>
   <br/>
-    <img alt="huggingface_hub library logo" src="https://huggingface.co/datasets/huggingface/documentation-images/raw/main/huggingface_hub.svg" width="376" height="59" style="max-width: 100%;">
   <br/>
-</p>
+</p> 
 
 <p align="center">
     <i>Hugging Face Hub Python 客户端</i>

--- a/i18n/README_de.md
+++ b/i18n/README_de.md
@@ -1,8 +1,12 @@
 <p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/huggingface/documentation-images/raw/main/huggingface_hub-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://huggingface.co/datasets/huggingface/documentation-images/raw/main/huggingface_hub.svg">
+    <img alt="huggingface_hub library logo" src="https://huggingface.co/datasets/huggingface/documentation-images/raw/main/huggingface_hub.svg" width="352" height="59" style="max-width: 100%;">
+  </picture>
   <br/>
-    <img alt="huggingface_hub library logo" src="https://huggingface.co/datasets/huggingface/documentation-images/raw/main/huggingface_hub.svg" width="376" height="59" style="max-width: 100%;">
   <br/>
-</p>
+</p> 
 
 <p align="center">
     <i>Der offizielle Python-Client für den Huggingface Hub.</i>

--- a/i18n/README_hi.md
+++ b/i18n/README_hi.md
@@ -1,8 +1,12 @@
 <p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/huggingface/documentation-images/raw/main/huggingface_hub-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://huggingface.co/datasets/huggingface/documentation-images/raw/main/huggingface_hub.svg">
+    <img alt="huggingface_hub library logo" src="https://huggingface.co/datasets/huggingface/documentation-images/raw/main/huggingface_hub.svg" width="352" height="59" style="max-width: 100%;">
+  </picture>
   <br/>
-    <img alt="huggingface_hub library logo" src="https://huggingface.co/datasets/huggingface/documentation-images/raw/main/huggingface_hub.svg" width="376" height="59" style="max-width: 100%;">
   <br/>
-</p>
+</p> 
 
 <p align="center">
     <i>Huggingface Hub के लिए आधिकारिक पायथन क्लाइंट।</i>

--- a/i18n/README_ko.md
+++ b/i18n/README_ko.md
@@ -1,8 +1,12 @@
 <p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/huggingface/documentation-images/raw/main/huggingface_hub-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://huggingface.co/datasets/huggingface/documentation-images/raw/main/huggingface_hub.svg">
+    <img alt="huggingface_hub library logo" src="https://huggingface.co/datasets/huggingface/documentation-images/raw/main/huggingface_hub.svg" width="352" height="59" style="max-width: 100%;">
+  </picture>
   <br/>
-    <img alt="huggingface_hub library logo" src="https://huggingface.co/datasets/huggingface/documentation-images/raw/main/huggingface_hub.svg" width="376" height="59" style="max-width: 100%;">
   <br/>
-</p>
+</p> 
 
 <p align="center">
     <i>공식 Huggingface Hub 파이썬 클라이언트</i>


### PR DESCRIPTION
Tiny PR to fix the logo when dark mode is on. A dark mode compatible logo has been added in https://huggingface.co/datasets/huggingface/documentation-images/blob/main/huggingface_hub-dark.svg 

before:
<img width="1069" alt="Screenshot 2024-11-21 at 14 15 50" src="https://github.com/user-attachments/assets/d4e99669-0fb1-43d1-b735-e390df5981ab">

now:
<img width="890" alt="Screenshot 2024-11-21 at 14 36 53" src="https://github.com/user-attachments/assets/fdeade8d-623b-44f6-b397-e291f249f9b9">


