### PR TITLE
Make sure create_repo respect organization privacy settings

### DIFF
--- a/src/huggingface_hub/_commit_scheduler.py
+++ b/src/huggingface_hub/_commit_scheduler.py
@@ -50,8 +50,7 @@ class CommitScheduler:
         revision (`str`, *optional*):
             The revision of the repo to commit to. Defaults to `main`.
         private (`bool`, *optional*):
-            Whether to make the repo private. If `None` (default), will default to been public except if
-            the organization's default is private. This value is ignored if the repo already exist.
+            Whether to make the repo private. If `None` (default), the repo will be public unless the organization's default is private. This value is ignored if the repo already exists.
         token (`str`, *optional*):
             The token to use to commit to the repo. Defaults to the token saved on the machine.
         allow_patterns (`List[str]` or `str`, *optional*):

--- a/src/huggingface_hub/_commit_scheduler.py
+++ b/src/huggingface_hub/_commit_scheduler.py
@@ -50,7 +50,8 @@ class CommitScheduler:
         revision (`str`, *optional*):
             The revision of the repo to commit to. Defaults to `main`.
         private (`bool`, *optional*):
-            Whether to make the repo private. Defaults to `False`. This value is ignored if the repo already exist.
+            Whether to make the repo private. If `None` (default), will default to been public except if
+            the organization's default is private. This value is ignored if the repo already exist.
         token (`str`, *optional*):
             The token to use to commit to the repo. Defaults to the token saved on the machine.
         allow_patterns (`List[str]` or `str`, *optional*):
@@ -106,7 +107,7 @@ class CommitScheduler:
         path_in_repo: Optional[str] = None,
         repo_type: Optional[str] = None,
         revision: Optional[str] = None,
-        private: bool = False,
+        private: Optional[bool] = None,
         token: Optional[str] = None,
         allow_patterns: Optional[Union[List[str], str]] = None,
         ignore_patterns: Optional[Union[List[str], str]] = None,

--- a/src/huggingface_hub/_tensorboard_logger.py
+++ b/src/huggingface_hub/_tensorboard_logger.py
@@ -75,8 +75,8 @@ class HFSummaryWriter(SummaryWriter):
         repo_revision (`str`, *optional*):
             The revision of the repo to which the logs will be pushed. Defaults to "main".
         repo_private (`bool`, *optional*):
-            Whether to create a private repo or not. Defaults to False. This argument is ignored if the repo already
-            exists.
+            Whether to create a private repo or not. If `None` (default), will default to been public except if
+            the organization's default is private. This argument is ignored if the repo already exists.
         path_in_repo (`str`, *optional*):
             The path to the folder in the repo where the logs will be pushed. Defaults to "tensorboard/".
         repo_allow_patterns (`List[str]` or `str`, *optional*):
@@ -137,7 +137,7 @@ class HFSummaryWriter(SummaryWriter):
         squash_history: bool = False,
         repo_type: Optional[str] = None,
         repo_revision: Optional[str] = None,
-        repo_private: bool = False,
+        repo_private: Optional[bool] = None,
         path_in_repo: Optional[str] = "tensorboard",
         repo_allow_patterns: Optional[Union[List[str], str]] = "*.tfevents.*",
         repo_ignore_patterns: Optional[Union[List[str], str]] = None,

--- a/src/huggingface_hub/_tensorboard_logger.py
+++ b/src/huggingface_hub/_tensorboard_logger.py
@@ -75,8 +75,7 @@ class HFSummaryWriter(SummaryWriter):
         repo_revision (`str`, *optional*):
             The revision of the repo to which the logs will be pushed. Defaults to "main".
         repo_private (`bool`, *optional*):
-            Whether to create a private repo or not. If `None` (default), will default to been public except if
-            the organization's default is private. This argument is ignored if the repo already exists.
+            Whether to make the repo private. If `None` (default), the repo will be public unless the organization's default is private. This value is ignored if the repo already exists.
         path_in_repo (`str`, *optional*):
             The path to the folder in the repo where the logs will be pushed. Defaults to "tensorboard/".
         repo_allow_patterns (`List[str]` or `str`, *optional*):

--- a/src/huggingface_hub/_upload_large_folder.py
+++ b/src/huggingface_hub/_upload_large_folder.py
@@ -52,7 +52,7 @@ def upload_large_folder_internal(
     *,
     repo_type: str,  # Repo type is required!
     revision: Optional[str] = None,
-    private: bool = False,
+    private: Optional[bool] = None,
     allow_patterns: Optional[Union[List[str], str]] = None,
     ignore_patterns: Optional[Union[List[str], str]] = None,
     num_workers: Optional[int] = None,

--- a/src/huggingface_hub/fastai_utils.py
+++ b/src/huggingface_hub/fastai_utils.py
@@ -345,7 +345,7 @@ def push_to_hub_fastai(
     *,
     repo_id: str,
     commit_message: str = "Push FastAI model using huggingface_hub.",
-    private: bool = False,
+    private: Optional[bool] = None,
     token: Optional[str] = None,
     config: Optional[dict] = None,
     branch: Optional[str] = None,
@@ -369,8 +369,9 @@ def push_to_hub_fastai(
             The repository id for your model in Hub in the format of "namespace/repo_name". The namespace can be your individual account or an organization to which you have write access (for example, 'stanfordnlp/stanza-de').
         commit_message (`str`, *optional*):
             Message to commit while pushing. Will default to :obj:`"add model"`.
-        private (`bool`, *optional*, defaults to `False`):
+        private (`bool`, *optional*):
             Whether or not the repository created should be private.
+            If `None` (default), will default to been public except if the organization's default is private.
         token (`str`, *optional*):
             The Hugging Face account token to use as HTTP bearer authorization for remote files. If :obj:`None`, the token will be asked by a prompt.
         config (`dict`, *optional*):

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -3462,8 +3462,7 @@ class HfApi:
                 https://huggingface.co/docs/huggingface_hub/quick-start#authentication).
                 To disable authentication, pass `False`.
             private (`bool`, *optional*):
-                Whether the model repo should be private. If `None` (default), will default to been public except if
-                the organization's default is private.
+                Whether to make the repo private. If `None` (default), the repo will be public unless the organization's default is private. This value is ignored if the repo already exists.
             repo_type (`str`, *optional*):
                 Set to `"dataset"` or `"space"` if uploading to a dataset or
                 space, `None` or `"model"` if uploading to a model. Default is
@@ -5049,7 +5048,7 @@ class HfApi:
                 The branch to commit to. If not provided, the `main` branch will be used.
             private (`bool`, `optional`):
                 Whether the repository should be private.
-                If `None` (default), will default to been public except if the organization's default is private.
+                If `None` (default), the repo will be public unless the organization's default is private.
             allow_patterns (`List[str]` or `str`, *optional*):
                 If provided, only files matching at least one pattern are uploaded.
             ignore_patterns (`List[str]` or `str`, *optional*):

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -3439,7 +3439,7 @@ class HfApi:
         repo_id: str,
         *,
         token: Union[str, bool, None] = None,
-        private: bool = False,
+        private: Optional[bool] = None,
         repo_type: Optional[str] = None,
         exist_ok: bool = False,
         resource_group_id: Optional[str] = None,
@@ -3461,8 +3461,9 @@ class HfApi:
                 token, which is the recommended method for authentication (see
                 https://huggingface.co/docs/huggingface_hub/quick-start#authentication).
                 To disable authentication, pass `False`.
-            private (`bool`, *optional*, defaults to `False`):
-                Whether the model repo should be private.
+            private (`bool`, *optional*):
+                Whether the model repo should be private. If `None` (default), will default to been public except if
+                the organization's default is private.
             repo_type (`str`, *optional*):
                 Set to `"dataset"` or `"space"` if uploading to a dataset or
                 space, `None` or `"model"` if uploading to a model. Default is
@@ -3503,7 +3504,9 @@ class HfApi:
         if repo_type not in constants.REPO_TYPES:
             raise ValueError("Invalid repo type")
 
-        json: Dict[str, Any] = {"name": name, "organization": organization, "private": private}
+        json: Dict[str, Any] = {"name": name, "organization": organization}
+        if private is not None:
+            json["private"] = private
         if repo_type is not None:
             json["type"] = repo_type
         if repo_type == "space":
@@ -5017,7 +5020,7 @@ class HfApi:
         *,
         repo_type: str,  # Repo type is required!
         revision: Optional[str] = None,
-        private: bool = False,
+        private: Optional[bool] = None,
         allow_patterns: Optional[Union[List[str], str]] = None,
         ignore_patterns: Optional[Union[List[str], str]] = None,
         num_workers: Optional[int] = None,
@@ -5045,7 +5048,8 @@ class HfApi:
             revision (`str`, `optional`):
                 The branch to commit to. If not provided, the `main` branch will be used.
             private (`bool`, `optional`):
-                Whether the repository should be private. Defaults to False.
+                Whether the repository should be private.
+                If `None` (default), will default to been public except if the organization's default is private.
             allow_patterns (`List[str]` or `str`, *optional*):
                 If provided, only files matching at least one pattern are uploaded.
             ignore_patterns (`List[str]` or `str`, *optional*):

--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -620,7 +620,7 @@ class ModelHubMixin:
         *,
         config: Optional[Union[dict, "DataclassInstance"]] = None,
         commit_message: str = "Push model using huggingface_hub.",
-        private: bool = False,
+        private: Optional[bool] = None,
         token: Optional[str] = None,
         branch: Optional[str] = None,
         create_pr: Optional[bool] = None,
@@ -643,8 +643,9 @@ class ModelHubMixin:
                 Model configuration specified as a key/value dictionary or a dataclass instance.
             commit_message (`str`, *optional*):
                 Message to commit while pushing.
-            private (`bool`, *optional*, defaults to `False`):
+            private (`bool`, *optional*):
                 Whether the repository created should be private.
+                If `None` (default), will default to been public except if the organization's default is private.
             token (`str`, *optional*):
                 The token to use as HTTP bearer authorization for remote files. By default, it will use the token
                 cached when running `huggingface-cli login`.

--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -645,7 +645,7 @@ class ModelHubMixin:
                 Message to commit while pushing.
             private (`bool`, *optional*):
                 Whether the repository created should be private.
-                If `None` (default), will default to been public except if the organization's default is private.
+                If `None` (default), the repo will be public unless the organization's default is private.
             token (`str`, *optional*):
                 The token to use as HTTP bearer authorization for remote files. By default, it will use the token
                 cached when running `huggingface-cli login`.

--- a/src/huggingface_hub/keras_mixin.py
+++ b/src/huggingface_hub/keras_mixin.py
@@ -332,7 +332,7 @@ def push_to_hub_keras(
             Message to commit while pushing.
         private (`bool`, *optional*):
             Whether the repository created should be private.
-            If `None` (default), will default to been public except if the organization's default is private.
+            If `None` (default), the repo will be public unless the organization's default is private.
         api_endpoint (`str`, *optional*):
             The API endpoint to use when pushing the model to the hub.
         token (`str`, *optional*):

--- a/src/huggingface_hub/keras_mixin.py
+++ b/src/huggingface_hub/keras_mixin.py
@@ -301,7 +301,7 @@ def push_to_hub_keras(
     *,
     config: Optional[dict] = None,
     commit_message: str = "Push Keras model using huggingface_hub.",
-    private: bool = False,
+    private: Optional[bool] = None,
     api_endpoint: Optional[str] = None,
     token: Optional[str] = None,
     branch: Optional[str] = None,
@@ -330,8 +330,9 @@ def push_to_hub_keras(
                 ID of the repository to push to (example: `"username/my-model"`).
         commit_message (`str`, *optional*, defaults to "Add Keras model"):
             Message to commit while pushing.
-        private (`bool`, *optional*, defaults to `False`):
+        private (`bool`, *optional*):
             Whether the repository created should be private.
+            If `None` (default), will default to been public except if the organization's default is private.
         api_endpoint (`str`, *optional*):
             The API endpoint to use when pushing the model to the hub.
         token (`str`, *optional*):

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -3411,7 +3411,6 @@ class TestSpaceAPIMocked(unittest.TestCase):
             json={
                 "name": self.repo_id,
                 "organization": None,
-                "private": False,
                 "type": "space",
                 "sdk": "gradio",
                 "hardware": "t4-medium",
@@ -3432,7 +3431,6 @@ class TestSpaceAPIMocked(unittest.TestCase):
             json={
                 "name": self.repo_id,
                 "organization": None,
-                "private": False,
                 "type": "space",
                 "sdk": "gradio",
                 "hardware": "t4-medium",
@@ -3453,7 +3451,6 @@ class TestSpaceAPIMocked(unittest.TestCase):
             json={
                 "name": self.repo_id,
                 "organization": None,
-                "private": False,
                 "type": "space",
                 "sdk": "gradio",
                 "storageTier": "large",
@@ -3480,7 +3477,6 @@ class TestSpaceAPIMocked(unittest.TestCase):
             json={
                 "name": self.repo_id,
                 "organization": None,
-                "private": False,
                 "type": "space",
                 "sdk": "gradio",
                 "secrets": [

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -84,7 +84,16 @@ from huggingface_hub.utils import (
 )
 from huggingface_hub.utils.endpoint_helpers import _is_emission_within_threshold
 
-from .testing_constants import ENDPOINT_STAGING, FULL_NAME, OTHER_TOKEN, OTHER_USER, TOKEN, USER
+from .testing_constants import (
+    ENDPOINT_STAGING,
+    ENTERPRISE_ORG,
+    ENTERPRISE_TOKEN,
+    FULL_NAME,
+    OTHER_TOKEN,
+    OTHER_USER,
+    TOKEN,
+    USER,
+)
 from .testing_utils import (
     DUMMY_DATASET_ID,
     DUMMY_DATASET_ID_REVISION_ONE_SPECIFIC_COMMIT,
@@ -454,6 +463,15 @@ class CommitApiTest(HfApiCommonTest):
 
         # Clean up
         self._api.delete_repo(repo_id=repo_id, token=OTHER_TOKEN)
+
+    def test_create_repo_private_by_default(self):
+        """Enterprise Hub allows creating private repos by default. Let's test that."""
+        repo_id = f"{ENTERPRISE_ORG}/{repo_name()}"
+        self._api.create_repo(repo_id, token=ENTERPRISE_TOKEN)
+        info = self._api.model_info(repo_id, token=ENTERPRISE_TOKEN, expand="private")
+        assert info.private
+
+        self._api.delete_repo(repo_id, token=ENTERPRISE_TOKEN)
 
     @use_tmp_repo()
     def test_upload_file_create_pr(self, repo_url: RepoUrl) -> None:

--- a/tests/testing_constants.py
+++ b/tests/testing_constants.py
@@ -11,9 +11,9 @@ OTHER_USER = "DVUser"
 OTHER_TOKEN = "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"
 
 # Used to test enterprise features, typically creating private repos by default
-ENTERPRISE_USER = "DVEnterpriseUser"
-ENTERPRISE_ORG = "DVEnterpriseOrg"
-ENTERPRISE_TOKEN = "hf_enterprise_user_token"
+ENTERPRISE_USER = "EnterpriseAdmin"
+ENTERPRISE_ORG = "EnterpriseOrgPrivate"
+ENTERPRISE_TOKEN = "hf_enterprise_admin_token"
 
 ENDPOINT_PRODUCTION = "https://huggingface.co"
 ENDPOINT_STAGING = "https://hub-ci.huggingface.co"

--- a/tests/testing_constants.py
+++ b/tests/testing_constants.py
@@ -10,6 +10,11 @@ TOKEN = "hf_94wBhPGp6KrrTH3KDchhKpRxZwd6dmHWLL"
 OTHER_USER = "DVUser"
 OTHER_TOKEN = "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"
 
+# Used to test enterprise features, typically creating private repos by default
+ENTERPRISE_USER = "DVEnterpriseUser"
+ENTERPRISE_ORG = "DVEnterpriseOrg"
+ENTERPRISE_TOKEN = "hf_enterprise_user_token"
+
 ENDPOINT_PRODUCTION = "https://huggingface.co"
 ENDPOINT_STAGING = "https://hub-ci.huggingface.co"
 


### PR DESCRIPTION
see slack [thread](https://huggingface.slack.com/archives/C02EMARJ65P/p1732513068709469) (private)

Enterprise Hub allows organizations to force all repositories to be private. Since `create_repo` assumes that a repo is public when `private=True` is not explicitly passed, an error is thrown by the server 

```
403 Forbidden: org-name forbids the creation of public models.
``` 

This is because `private: False` is passed by default (since https://github.com/huggingface/huggingface_hub/pull/1001 :confused:). This PR updates this by making `None` the default value for `private` and send the value to the server only when explicitly set by the user. This should make the life of Enterprise Hub users much easier (today they need to explicitly pass `private=True` in their calls).

Note: tests are currently failing (need an update in staging org settings).
Note 2: we'll have to update many (most?) `.push_to_hub` signature in the HF ecosystem to also pass `None` whenever appropriate. I'll open PRs once that's merged.

---

TIL: better listen to the boss https://github.com/huggingface/huggingface_hub/pull/1001#issuecomment-1224436742