### PR TITLE
Fix timestamp parsing to always include milliseconds

### DIFF
--- a/src/huggingface_hub/utils/_datetime.py
+++ b/src/huggingface_hub/utils/_datetime.py
@@ -46,18 +46,20 @@ def parse_datetime(date_string: str) -> datetime:
             If `date_string` cannot be parsed.
     """
     try:
-        # Datetime ending with a Z means "UTC". We parse the date and then explicitly
-        # set the timezone to UTC.
-        # See https://en.wikipedia.org/wiki/ISO_8601#Coordinated_Universal_Time_(UTC)
-        # Taken from https://stackoverflow.com/a/3168394.
-        if len(date_string) == 30:
-            # Means timezoned-timestamp with nanoseconds precision. We need to truncate the last 3 digits.
-            date_string = date_string[:-4] + "Z"
-        if len(date_string) == 20:
-            # Means timezoned-timestamp without milliseconds precision. We need to add ".000Z" to the end.
-            date_string = date_string[:-1] + ".000Z"
-        dt = datetime.strptime(date_string, "%Y-%m-%dT%H:%M:%S.%fZ")
-        return dt.replace(tzinfo=timezone.utc)  # Set explicit timezone
+        # Normalize the string to always have 6 digits of fractional seconds
+        if date_string.endswith("Z"):
+            # Case 1: No decimal point (e.g., "2024-11-16T00:27:02Z")
+            if "." not in date_string:
+                # No fractional seconds - insert .000000
+                date_string = date_string[:-1] + ".000000Z"
+            # Case 2: Has decimal point (e.g., "2022-08-19T07:19:38.123456789Z")
+            else:
+                # Get the fractional and base parts
+                base, fraction = date_string[:-1].split(".")
+                # fraction[:6] takes first 6 digits and :0<6 pads with zeros if less than 6 digits
+                date_string = f"{base}.{fraction[:6]:0<6}Z"
+
+        return datetime.strptime(date_string, "%Y-%m-%dT%H:%M:%S.%fZ").replace(tzinfo=timezone.utc)
     except ValueError as e:
         raise ValueError(
             f"Cannot parse '{date_string}' as a datetime. Date string is expected to"

--- a/src/huggingface_hub/utils/_datetime.py
+++ b/src/huggingface_hub/utils/_datetime.py
@@ -53,6 +53,9 @@ def parse_datetime(date_string: str) -> datetime:
         if len(date_string) == 30:
             # Means timezoned-timestamp with nanoseconds precision. We need to truncate the last 3 digits.
             date_string = date_string[:-4] + "Z"
+        if len(date_string) == 20:
+            # Means timezoned-timestamp without milliseconds precision. We need to add ".000Z" to the end.
+            date_string = date_string[:-1] + ".000Z"
         dt = datetime.strptime(date_string, "%Y-%m-%dT%H:%M:%S.%fZ")
         return dt.replace(tzinfo=timezone.utc)  # Set explicit timezone
     except ValueError as e:

--- a/tests/test_utils_datetime.py
+++ b/tests/test_utils_datetime.py
@@ -20,6 +20,12 @@ class TestDatetimeUtils(unittest.TestCase):
             datetime(2022, 8, 19, 7, 19, 38, 123456, tzinfo=timezone.utc),
         )
 
+        # Test without milliseconds (should add .000)
+        self.assertEqual(
+            parse_datetime("2024-11-16T00:27:02Z"),
+            datetime(2024, 11, 16, 0, 27, 2, 0, tzinfo=timezone.utc),
+        )
+
         with pytest.raises(ValueError, match=r".*Cannot parse '2022-08-19T07:19:38' as a datetime.*"):
             parse_datetime("2022-08-19T07:19:38")
 


### PR DESCRIPTION
fixes #2671.

See the original [slack thread](https://huggingface.slack.com/archives/C03E4DQ9LAJ/p1729806188701489) (internal) for more context.

The client expects timestamps to follow the pattern `%Y-%m-%dT%H:%M:%S.%fZ`, but the server was inconsistently returning timestamps without milliseconds when they were zero (e.g. "2024-11-20T20:01:58Z"). This causes the parsing error reported in the issue mentioned above. 
we're handling this client-side as it's intentional behavior in the API to reduce precision, see[ this comment](https://github.com/huggingface-internal/workloads/pull/2524#discussion_r1860758864) (private).

this is fixed by a small refactoring of `parse_datetime()` function and adding a normalization to ensure it has six digits of microseconds by padding with zeros or truncating. This approach handles inputs with or without milliseconds and nanoseconds.

cc @ErikKaum 