### PR TITLE
Add helpers to handle OAuth in a FastAPI app

### DIFF
--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -86,3 +86,5 @@
       title: Webhooks server
     - local: package_reference/serialization
       title: Serialization
+    - local: package_reference/oauth
+      title: OAuth

--- a/docs/source/en/package_reference/oauth.md
+++ b/docs/source/en/package_reference/oauth.md
@@ -1,0 +1,22 @@
+## TO BE COMPLETED
+
+### attach_huggingface_oauth
+
+[[autodoc]] attach_huggingface_oauth
+
+### parse_huggingface_oauth
+
+[[autodoc]] parse_huggingface_oauth
+
+### OAuthOrgInfo
+
+[[autodoc]] OAuthOrgInfo
+
+### OAuthUserInfo
+
+[[autodoc]] OAuthUserInfo
+
+### OAuthInfo
+
+[[autodoc]] OAuthInfo
+

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ extras["inference"] = [
 extras["oauth"] = [
     "authlib>=1.3.2",  # minimum version to include https://github.com/lepture/authlib/pull/644
     "fastapi",
+    "httpx",  # required for authlib but not included in its dependencies
     "itsdangerous",  # required for starlette SessionMiddleware
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,12 @@ extras["inference"] = [
     "aiohttp",  # for AsyncInferenceClient
 ]
 
+extras["oauth"] = [
+    "authlib>=1.3.2",  # minimum version to include https://github.com/lepture/authlib/pull/644
+    "fastapi",
+    "itsdangerous",  # required for starlette SessionMiddleware
+]
+
 extras["torch"] = [
     "torch",
     "safetensors[torch]",
@@ -59,6 +65,7 @@ extras["tensorflow-testing"] = [
 extras["testing"] = (
     extras["cli"]
     + extras["inference"]
+    + extras["oauth"]
     + [
         "jedi",
         "Jinja2",

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -70,6 +70,13 @@ _SUBMOD_ATTRS = {
         "logout",
         "notebook_login",
     ],
+    "_oauth": [
+        "OAuthInfo",
+        "OAuthOrgInfo",
+        "OAuthUserInfo",
+        "attach_huggingface_oauth",
+        "parse_huggingface_oauth",
+    ],
     "_snapshot_download": [
         "snapshot_download",
     ],
@@ -605,6 +612,13 @@ if TYPE_CHECKING:  # pragma: no cover
         login,  # noqa: F401
         logout,  # noqa: F401
         notebook_login,  # noqa: F401
+    )
+    from ._oauth import (
+        OAuthInfo,  # noqa: F401
+        OAuthOrgInfo,  # noqa: F401
+        OAuthUserInfo,  # noqa: F401
+        attach_huggingface_oauth,  # noqa: F401
+        parse_huggingface_oauth,  # noqa: F401
     )
     from ._snapshot_download import snapshot_download  # noqa: F401
     from ._space_api import (

--- a/src/huggingface_hub/_oauth.py
+++ b/src/huggingface_hub/_oauth.py
@@ -1,0 +1,436 @@
+import datetime
+import hashlib
+import logging
+import os
+import time
+import urllib.parse
+import warnings
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+
+from .hf_api import whoami
+from .utils import experimental, get_token
+
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    import fastapi
+    from fastapi.responses import RedirectResponse
+
+# If OAuth didn't work after 2 redirects, there's likely a third-party cookie issue in the Space iframe view.
+# In this case, we redirect the user to the non-iframe view.
+OAUTH_MAX_REDIRECTS = 2
+
+# OAuth-related environment variables injected by the Space
+OAUTH_CLIENT_ID = os.environ.get("OAUTH_CLIENT_ID")
+OAUTH_CLIENT_SECRET = os.environ.get("OAUTH_CLIENT_SECRET")
+OAUTH_SCOPES = os.environ.get("OAUTH_SCOPES")
+OPENID_PROVIDER_URL = os.environ.get("OPENID_PROVIDER_URL")
+
+
+@dataclass
+class OAuthOrgInfo:
+    """
+    Information about an organization linked to a user logged in with OAuth.
+
+    Attributes:
+        sub (`str`):
+            Unique identifier for the org. OpenID Connect field.
+        name (`str`):
+            The org's full name. OpenID Connect field.
+        preferred_username (`str`):
+            The org's username. OpenID Connect field.
+        picture (`str`):
+            The org's profile picture URL. OpenID Connect field.
+        is_enterprise (`bool`):
+            Whether the org is an enterprise org. Hugging Face field.
+        can_pay (`Optional[bool]`, *optional*):
+            Whether the org has a payment method set up. Hugging Face field.
+        role_in_org (`Optional[str]`, *optional*):
+            The user's role in the org. Hugging Face field.
+        pending_sso (`Optional[bool]`, *optional*):
+            Indicates if the user granted the OAuth app access to the org but didn't complete SSO. Hugging Face field.
+        missing_mfa (`Optional[bool]`, *optional*):
+            Indicates if the user granted the OAuth app access to the org but didn't complete MFA. Hugging Face field.
+    """
+
+    sub: str
+    name: str
+    preferred_username: str
+    picture: str
+    is_enterprise: bool
+    can_pay: Optional[bool] = None
+    role_in_org: Optional[str] = None
+    pending_sso: Optional[bool] = None
+    missing_mfa: Optional[bool] = None
+
+
+@dataclass
+class OAuthUserInfo:
+    """
+    Information about a user logged in with OAuth.
+
+    Attributes:
+        sub (`str`):
+            Unique identifier for the user, even in case of rename. OpenID Connect field.
+        name (`str`):
+            The user's full name. OpenID Connect field.
+        preferred_username (`str`):
+            The user's username. OpenID Connect field.
+        email_verified (`Optional[bool]`, *optional*):
+            Indicates if the user's email is verified. OpenID Connect field.
+        email (`Optional[str]`, *optional*):
+            The user's email address. OpenID Connect field.
+        picture (`str`):
+            The user's profile picture URL. OpenID Connect field.
+        profile (`str`):
+            The user's profile URL. OpenID Connect field.
+        website (`Optional[str]`, *optional*):
+            The user's website URL. OpenID Connect field.
+        is_pro (`bool`):
+            Whether the user is a pro user. Hugging Face field.
+        can_pay (`Optional[bool]`, *optional*):
+            Whether the user has a payment method set up. Hugging Face field.
+        orgs (`Optional[List[OrgInfo]]`, *optional*):
+            List of organizations the user is part of. Hugging Face field.
+    """
+
+    sub: str
+    name: str
+    preferred_username: str
+    email_verified: Optional[bool]
+    email: Optional[str]
+    picture: str
+    profile: str
+    website: Optional[str]
+    is_pro: bool
+    can_pay: Optional[bool]
+    orgs: Optional[List[OAuthOrgInfo]]
+
+
+@dataclass
+class OAuthInfo:
+    """
+    Information about the OAuth login.
+
+    Attributes:
+        access_token (`str`):
+            The access token.
+        access_token_expires_at (`datetime.datetime`):
+            The expiration date of the access token.
+        user_info ([`OAuthUserInfo`]):
+            The user information.
+        state (`str`, *optional*):
+            State passed to the OAuth provider in the original request to the OAuth provider.
+        scope (`str`):
+            Granted scope.
+    """
+
+    access_token: str
+    access_token_expires_at: datetime.datetime
+    user_info: OAuthUserInfo
+    state: Optional[str]
+    scope: str
+
+
+@experimental
+def attach_huggingface_oauth(app: "fastapi.FastAPI", route_prefix: str = "/"):
+    # TODO: handle generic case (handling OAuth in a non-Space environment with custom dev values) (low priority)
+
+    # Add SessionMiddleware to the FastAPI app to store the OAuth info in the session.
+    # Session Middleware requires a secret key to sign the cookies. Let's use a hash
+    # of the OAuth secret key to make it unique to the Space + updated in case OAuth
+    # config gets updated. When ran locally, we use an empty string as a secret key.
+    try:
+        from starlette.middleware.sessions import SessionMiddleware
+    except ImportError as e:
+        raise ImportError(
+            "Cannot initialize OAuth to due a missing library. Please run `pip install huggingface_hub[oauth]` or add "
+            "`huggingface_hub[oauth]` to your requirements.txt file in order to install the required dependencies."
+        ) from e
+    session_secret = (OAUTH_CLIENT_SECRET or "") + "-v1"
+    app.add_middleware(
+        SessionMiddleware,
+        secret_key=hashlib.sha256(session_secret.encode()).hexdigest(),
+        same_site="none",
+        https_only=True,
+    )
+
+    # Add OAuth endpoints to the FastAPI app:
+    #   - {route_prefix}/oauth/huggingface/login
+    #   - {route_prefix}/oauth/huggingface/callback
+    #   - {route_prefix}/oauth/huggingface/logout
+    # If the app is running in a Space, OAuth is enabled normally.
+    # Otherwise, we mock the endpoints to make the user log in with a fake user profile - without any calls to hf.co.
+    route_prefix = route_prefix.strip("/")
+    if os.getenv("SYSTEM") == "spaces":
+        logger.info("OAuth is enabled in the Space. Adding OAuth routes.")
+        _add_oauth_routes(app, route_prefix=route_prefix)
+    else:
+        logger.info("App is not running in a Space. Adding mocked OAuth routes.")
+        _add_mocked_oauth_routes(app, route_prefix=route_prefix)
+
+
+def parse_huggingface_oauth(request: "fastapi.Request") -> Optional[OAuthInfo]:
+    """
+    Returns the information from a logged in user as a [`OAuthInfo`] object.
+
+    For flexibility and future-proofing, this method is very lax in its parsing and does not raise errors.
+    Missing fields are set to `None` without a warning.
+
+    Return `None`, if the user is not logged in (no info in session cookie).
+    """
+    if "oauth_info" not in request.session:
+        logger.debug("No OAuth info in session.")
+        return None
+    print(request.session["oauth_info"])
+
+    logger.debug("Parsing OAuth info from session.")
+    data = request.session["oauth_info"]
+
+    orgs_data = data.get("orgs", [])
+    orgs = (
+        [
+            OAuthOrgInfo(
+                sub=org.get("sub"),
+                name=org.get("name"),
+                preferred_username=org.get("preferred_username"),
+                picture=org.get("picture"),
+                is_enterprise=org.get("isEnterprise"),
+                can_pay=org.get("canPay"),
+                role_in_org=org.get("roleInOrg"),
+                pending_sso=org.get("pendingSSO"),
+                missing_mfa=org.get("missingMFA"),
+            )
+            for org in orgs_data
+        ]
+        if orgs_data
+        else None
+    )
+
+    return OAuthInfo(
+        access_token=data.get("access_token"),
+        access_token_expires_at=datetime.datetime.fromtimestamp(data.get("expires_at")),
+        user_info=OAuthUserInfo(
+            sub=data.get("sub"),
+            name=data.get("name"),
+            preferred_username=data.get("preferred_username"),
+            email_verified=data.get("email_verified"),
+            email=data.get("email"),
+            picture=data.get("picture"),
+            profile=data.get("profile"),
+            website=data.get("website"),
+            is_pro=data.get("isPro"),
+            can_pay=data.get("canPay"),
+            orgs=orgs,
+        ),
+        state=data.get("state"),
+        scope=data.get("scope"),
+    )
+
+
+def _add_oauth_routes(app: "fastapi.FastAPI", route_prefix: str) -> None:
+    """Add OAuth routes to the FastAPI app (login, callback handler and logout)."""
+    try:
+        from authlib.integrations.base_client.errors import MismatchingStateError
+        from authlib.integrations.starlette_client import OAuth
+        from fastapi.responses import RedirectResponse
+    except ImportError as e:
+        raise ImportError(
+            "Cannot initialize OAuth to due a missing library. Please run `pip install huggingface_hub[oauth]` or add "
+            "`huggingface_hub[oauth]` to your requirements.txt file."
+        ) from e
+
+    # Check environment variables
+    msg = (
+        "OAuth is required but '{}' environment variable is not set. Make sure you've enabled OAuth in your Space by"
+        " setting `hf_oauth: true` in the Space metadata."
+    )
+    if OAUTH_CLIENT_ID is None:
+        raise ValueError(msg.format("OAUTH_CLIENT_ID"))
+    if OAUTH_CLIENT_SECRET is None:
+        raise ValueError(msg.format("OAUTH_CLIENT_SECRET"))
+    if OAUTH_SCOPES is None:
+        raise ValueError(msg.format("OAUTH_SCOPES"))
+    if OPENID_PROVIDER_URL is None:
+        raise ValueError(msg.format("OPENID_PROVIDER_URL"))
+
+    # Register OAuth server
+    oauth = OAuth()
+    oauth.register(
+        name="huggingface",
+        client_id=OAUTH_CLIENT_ID,
+        client_secret=OAUTH_CLIENT_SECRET,
+        client_kwargs={"scope": OAUTH_SCOPES},
+        server_metadata_url=OPENID_PROVIDER_URL + "/.well-known/openid-configuration",
+    )
+
+    login_uri, callback_uri, logout_uri = _get_oauth_uris(route_prefix)
+
+    # Register OAuth endpoints
+    @app.get(login_uri)
+    async def oauth_login(request: "fastapi.Request"):
+        """Endpoint that redirects to HF OAuth page."""
+        redirect_uri = _generate_redirect_uri(request)
+        return await oauth.huggingface.authorize_redirect(request, redirect_uri)  # type: ignore
+
+    @app.get(callback_uri)
+    async def oauth_redirect_callback(request: "fastapi.Request") -> "RedirectResponse":
+        """Endpoint that handles the OAuth callback."""
+        try:
+            oauth_info = await oauth.huggingface.authorize_access_token(request)  # type: ignore
+        except MismatchingStateError:
+            # Parse query params
+            nb_redirects = int(request.query_params.get("_nb_redirects", 0))
+            target_url = request.query_params.get("_target_url")
+
+            # Build redirect URI with the same query params as before and bump nb_redirects count
+            query_params: dict[str, str | int] = {"_nb_redirects": nb_redirects + 1}
+            if target_url:
+                query_params["_target_url"] = target_url
+
+            redirect_uri = f"{login_uri}?{urllib.parse.urlencode(query_params)}"
+
+            # If the user is redirected more than 3 times, it is very likely that the cookie is not working properly.
+            # (e.g. browser is blocking third-party cookies in iframe). In this case, redirect the user in the
+            # non-iframe view.
+            if nb_redirects > OAUTH_MAX_REDIRECTS:
+                host = os.environ.get("SPACE_HOST")
+                if host is None:  # cannot happen in a Space
+                    raise RuntimeError(
+                        "App is not running in a Space (SPACE_HOST environment variable is not set). Cannot redirect to non-iframe view."
+                    ) from None
+                host_url = "https://" + host.rstrip("/")
+                return RedirectResponse(host_url + redirect_uri)
+
+            # Redirect the user to the login page again
+            return RedirectResponse(redirect_uri)
+
+        # OAuth login worked => store the user info in the session and redirect
+        logger.debug("Successfully logged in with OAuth. Storing user info in session.")
+        request.session["oauth_info"] = oauth_info
+        return RedirectResponse(_get_redirect_target(request))
+
+    @app.get(logout_uri)
+    async def oauth_logout(request: "fastapi.Request") -> "RedirectResponse":
+        """Endpoint that logs out the user (e.g. delete info from cookie session)."""
+        logger.debug("Logged out with OAuth. Removing user info from session.")
+        request.session.pop("oauth_info", None)
+        return RedirectResponse(_get_redirect_target(request))
+
+
+def _add_mocked_oauth_routes(app: "fastapi.FastAPI", route_prefix: str = "/") -> None:
+    """Add fake oauth routes if app is run locally and OAuth is enabled.
+
+    Using OAuth will have the same behavior as in a Space but instead of authenticating with HF, a mocked user profile
+    is added to the session.
+    """
+    try:
+        from fastapi.responses import RedirectResponse
+        from starlette.datastructures import URL
+    except ImportError as e:
+        raise ImportError(
+            "Cannot initialize OAuth to due a missing library. Please run `pip install huggingface_hub[oauth]` or add "
+            "`huggingface_hub[oauth]` to your requirements.txt file."
+        ) from e
+
+    warnings.warn(
+        "OAuth is not supported outside of a Space environment. To help you debug your app locally, the oauth endpoints"
+        " are mocked to return your profile and token. To make it work, your machine must be logged in to Huggingface."
+    )
+    mocked_oauth_info = _get_mocked_oauth_info()
+
+    login_uri, callback_uri, logout_uri = _get_oauth_uris(route_prefix)
+
+    # Define OAuth routes
+    @app.get(login_uri)
+    async def oauth_login(request: "fastapi.Request"):  # noqa: ARG001
+        """Fake endpoint that redirects to HF OAuth page."""
+        # Define target (where to redirect after login)
+        redirect_uri = _generate_redirect_uri(request)
+        return RedirectResponse(callback_uri + "?" + urllib.parse.urlencode({"_target_url": redirect_uri}))
+
+    @app.get(callback_uri)
+    async def oauth_redirect_callback(request: "fastapi.Request") -> "RedirectResponse":
+        """Endpoint that handles the OAuth callback."""
+        request.session["oauth_info"] = mocked_oauth_info
+        return RedirectResponse(_get_redirect_target(request))
+
+    @app.get(logout_uri)
+    async def oauth_logout(request: "fastapi.Request") -> "RedirectResponse":
+        """Endpoint that logs out the user (e.g. delete cookie session)."""
+        request.session.pop("oauth_info", None)
+        logout_url = URL("/").include_query_params(**request.query_params)
+        return RedirectResponse(url=logout_url, status_code=302)  # see https://github.com/gradio-app/gradio/pull/9659
+
+
+def _generate_redirect_uri(request: "fastapi.Request") -> str:
+    if "_target_url" in request.query_params:
+        # if `_target_url` already in query params => respect it
+        target = request.query_params["_target_url"]
+    else:
+        # otherwise => keep query params
+        target = "/?" + urllib.parse.urlencode(request.query_params)
+
+    redirect_uri = request.url_for("oauth_redirect_callback").include_query_params(_target_url=target)
+    redirect_uri_as_str = str(redirect_uri)
+    if redirect_uri.netloc.endswith(".hf.space"):
+        # In Space, FastAPI redirect as http but we want https
+        redirect_uri_as_str = redirect_uri_as_str.replace("http://", "https://")
+    return redirect_uri_as_str
+
+
+def _get_redirect_target(request: "fastapi.Request", default_target: str = "/") -> str:
+    return request.query_params.get("_target_url", default_target)
+
+
+def _get_mocked_oauth_info() -> Dict:
+    token = get_token()
+    if token is None:
+        raise ValueError(
+            "Your machine must be logged in to HF to debug an OAuth app locally. Please"
+            " run `huggingface-cli login` or set `HF_TOKEN` as environment variable "
+            "with one of your access token. You can generate a new token in your "
+            "settings page (https://huggingface.co/settings/tokens)."
+        )
+
+    user = whoami()
+    if user["type"] != "user":
+        raise ValueError(
+            "Your machine is not logged in with a personal account. Please use a "
+            "personal access token. You can generate a new token in your settings page"
+            " (https://huggingface.co/settings/tokens)."
+        )
+
+    return {
+        "access_token": token,
+        "token_type": "bearer",
+        "expires_in": 3600,
+        "id_token": "AAAAAAAAAAAAAAAAAAAAAAAAAA",
+        "scope": "openid profile",
+        "expires_at": int(time.time()) + 8 * 60 * 60,  # 8 hours
+        "userinfo": {
+            "sub": "11111111111111111111111",
+            "name": user["fullname"],
+            "preferred_username": user["name"],
+            "profile": f"https://huggingface.co/{user['name']}",
+            "picture": user["avatarUrl"],
+            "website": "",
+            "aud": "00000000-0000-0000-0000-000000000000",
+            "auth_time": 1691672844,
+            "nonce": "aaaaaaaaaaaaaaaaaaa",
+            "iat": 1691672844,
+            "exp": 1691676444,
+            "iss": "https://huggingface.co",
+        },
+    }
+
+
+def _get_oauth_uris(route_prefix: str) -> Tuple[str, str, str]:
+    route_prefix = route_prefix.strip("/")
+    return (
+        f"{route_prefix}/oauth/huggingface/login",
+        f"{route_prefix}/oauth/huggingface/callback",
+        f"{route_prefix}/oauth/huggingface/logout",
+    )

--- a/src/huggingface_hub/_oauth.py
+++ b/src/huggingface_hub/_oauth.py
@@ -126,6 +126,35 @@ class OAuthInfo:
 
 @experimental
 def attach_huggingface_oauth(app: "fastapi.FastAPI", route_prefix: str = "/"):
+    """
+    Add OAuth endpoints to a FastAPI app to enable OAuth login with Hugging Face.
+
+    How to use:
+    - Call this method on your FastAPI app to add the OAuth endpoints.
+    - Inside your route handlers, call `parse_huggingface_oauth(request)` to retrieve the OAuth info.
+    - If user is logged in, an [`OAuthInfo`] object is returned with the user's info. If not, `None` is returned.
+    - In your app, make sure to add links to `/oauth/huggingface/login` and `/oauth/huggingface/logout` for the user to log in and out.
+
+    Example:
+    ```py
+    from huggingface_hub import attach_huggingface_oauth, parse_huggingface_oauth
+
+    # Create a FastAPI app
+    app = FastAPI()
+
+    # Add OAuth endpoints to the FastAPI app
+    attach_huggingface_oauth(app)
+
+    # Add a route that greets the user if they are logged in
+    @app.get("/")
+    def greet_json(request: Request):
+        # Retrieve the OAuth info from the request
+        oauth_info = parse_huggingface_oauth(request)  # e.g. OAuthInfo dataclass
+        if oauth_info is None:
+            return {"msg": "Not logged in!"}
+        return {"msg": f"Hello, {oauth_info.user_info.preferred_username}!"}
+    ```
+    """
     # TODO: handle generic case (handling OAuth in a non-Space environment with custom dev values) (low priority)
 
     # Add SessionMiddleware to the FastAPI app to store the OAuth info in the session.
@@ -170,6 +199,8 @@ def parse_huggingface_oauth(request: "fastapi.Request") -> Optional[OAuthInfo]:
     Missing fields are set to `None` without a warning.
 
     Return `None`, if the user is not logged in (no info in session cookie).
+
+    See [`attach_huggingface_oauth`] for an example on how to use this method.
     """
     if "oauth_info" not in request.session:
         logger.debug("No OAuth info in session.")

--- a/src/huggingface_hub/_oauth.py
+++ b/src/huggingface_hub/_oauth.py
@@ -164,7 +164,7 @@ def attach_huggingface_oauth(app: "fastapi.FastAPI", route_prefix: str = "/"):
     # If the app is running in a Space, OAuth is enabled normally.
     # Otherwise, we mock the endpoints to make the user log in with a fake user profile - without any calls to hf.co.
     route_prefix = route_prefix.strip("/")
-    if os.getenv("SYSTEM") == "spaces":
+    if os.getenv("SPACE_ID") is not None:
         logger.info("OAuth is enabled in the Space. Adding OAuth routes.")
         _add_oauth_routes(app, route_prefix=route_prefix)
     else:

--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -223,3 +223,13 @@ ALL_INFERENCE_API_FRAMEWORKS = MAIN_INFERENCE_API_FRAMEWORKS + [
     "stanza",
     "timm",
 ]
+
+# If OAuth didn't work after 2 redirects, there's likely a third-party cookie issue in the Space iframe view.
+# In this case, we redirect the user to the non-iframe view.
+OAUTH_MAX_REDIRECTS = 2
+
+# OAuth-related environment variables injected by the Space
+OAUTH_CLIENT_ID = os.environ.get("OAUTH_CLIENT_ID")
+OAUTH_CLIENT_SECRET = os.environ.get("OAUTH_CLIENT_SECRET")
+OAUTH_SCOPES = os.environ.get("OAUTH_SCOPES")
+OPENID_PROVIDER_URL = os.environ.get("OPENID_PROVIDER_URL")

--- a/src/huggingface_hub/utils/_experimental.py
+++ b/src/huggingface_hub/utils/_experimental.py
@@ -24,8 +24,10 @@ from .. import constants
 def experimental(fn: Callable) -> Callable:
     """Decorator to flag a feature as experimental.
 
-    An experimental feature trigger a warning when used as it might be subject to breaking changes in the future.
-    Warnings can be disabled by setting the environment variable `HF_EXPERIMENTAL_WARNING` to `0`.
+    An experimental feature triggers a warning when used as it might be subject to breaking changes without prior notice
+    in the future.
+
+    Warnings can be disabled by setting `HF_HUB_DISABLE_EXPERIMENTAL_WARNING=1` as environment variable.
 
     Args:
         fn (`Callable`):
@@ -44,8 +46,8 @@ def experimental(fn: Callable) -> Callable:
     ...     print("Hello world!")
 
     >>> my_function()
-    UserWarning: 'my_function' is experimental and might be subject to breaking changes in the future. You can disable
-    this warning by setting `HF_HUB_DISABLE_EXPERIMENTAL_WARNING=1` as environment variable.
+    UserWarning: 'my_function' is experimental and might be subject to breaking changes in the future without prior
+    notice. You can disable this warning by setting `HF_HUB_DISABLE_EXPERIMENTAL_WARNING=1` as environment variable.
     Hello world!
     ```
     """
@@ -56,7 +58,7 @@ def experimental(fn: Callable) -> Callable:
     def _inner_fn(*args, **kwargs):
         if not constants.HF_HUB_DISABLE_EXPERIMENTAL_WARNING:
             warnings.warn(
-                f"'{name}' is experimental and might be subject to breaking changes in the future."
+                f"'{name}' is experimental and might be subject to breaking changes in the future without prior notice."
                 " You can disable this warning by setting `HF_HUB_DISABLE_EXPERIMENTAL_WARNING=1` as environment"
                 " variable.",
                 UserWarning,

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -1,0 +1,169 @@
+# coding=utf-8
+# Copyright 2024-present, the HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Contains tests for the OAuth integration."""
+
+import time
+from dataclasses import asdict
+from unittest.mock import patch
+
+import pytest
+import requests
+import starlette.datastructures
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from huggingface_hub._oauth import (
+    _get_mocked_oauth_info,
+    _get_oauth_uris,
+    attach_huggingface_oauth,
+    parse_huggingface_oauth,
+)
+
+from .testing_constants import TOKEN, USER
+
+
+@pytest.fixture
+def oauth_app(monkeypatch):
+    """Defines a simple FastAPI app with OAuth integration."""
+    # Mock the fact the FastAPI app is running inside a Space
+    monkeypatch.setenv("SPACE_ID", "test_space/test_repo")
+
+    app = FastAPI()
+
+    @app.get("/")
+    def greet_json(request: Request):
+        oauth_info = parse_huggingface_oauth(request)
+        if oauth_info is None:
+            return {"msg": "Not logged in!"}
+        return {
+            "msg": f"Hello, {oauth_info.user_info.preferred_username}!",
+            "oauth_info": asdict(oauth_info),
+        }
+
+    # path constants.OAUTH_LOGIN_PATH
+    with patch.multiple(
+        "huggingface_hub.constants",
+        OAUTH_CLIENT_ID="dummy-app",
+        OAUTH_CLIENT_SECRET="dummy-secret",
+        OAUTH_SCOPES="openid profile email",
+        OPENID_PROVIDER_URL="https://hub-ci.huggingface.co",
+    ):
+        attach_huggingface_oauth(app)
+
+    # Little hack for the tests to work
+    # On staging, the redirect_url can be only "http://localhost:3000". Here I'm simply mocking the URL to work and
+    # remove any query parameters from the URL. In the test after the Hub call, we will replace back the URL with the
+    # correct one.
+    monkeypatch.setattr(
+        "starlette.requests.Request.url_for", lambda *args: starlette.datastructures.URL("http://localhost:3000")
+    )
+    monkeypatch.setattr("starlette.datastructures.URL.include_query_params", lambda *args, **kwargs: args[0])
+    return app
+
+
+@pytest.fixture
+def client(oauth_app):
+    return TestClient(oauth_app)
+
+
+def test_oauth_not_logged_in(client: TestClient):
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json() == {"msg": "Not logged in!"}
+
+
+def test_oauth_workflow(client: TestClient):
+    # Make call to login
+    response = client.get("/oauth/huggingface/login", follow_redirects=False)
+    assert response.status_code == 302
+    assert "location" in response.headers
+    assert "set-cookie" in response.headers
+    location = response.headers["location"]
+    session_cookie = response.headers["set-cookie"]
+    assert session_cookie.startswith("session=")
+    session_cookie = session_cookie.split(";")[0]
+
+    # Make call to HF Hub
+    assert location.startswith("https://hub-ci.huggingface.co/oauth/authorize")
+    location_authorize = location
+    response_authorize = requests.get(
+        location_authorize, headers={"cookie": "token=huggingface-hub.js-cookie"}, allow_redirects=False
+    )
+    assert response_authorize.status_code == 303
+    assert "location" in response_authorize.headers
+
+    # Make call to callback
+    location_callback = response_authorize.headers["location"].replace(
+        "http://localhost:3000/", "http://testserver/oauth/huggingface/callback"
+    )
+    response_callback = client.get(location_callback, headers={"cookie": session_cookie}, follow_redirects=False)
+    assert response_callback.status_code == 307
+    assert response_callback.headers["location"] == "/"
+    assert "set-cookie" in response_callback.headers
+    new_session_cookie = response_callback.headers["set-cookie"].split(";")[0]
+    assert len(session_cookie) < len(new_session_cookie)  # oauth data has been added to the cookie
+
+    # Finally make a call to the root
+    response_hello = client.get("/", headers={"cookie": new_session_cookie}, follow_redirects=False)
+    assert response_hello.status_code == 200
+    data = response_hello.json()
+    assert data["msg"] == "Hello, hub.js!"
+    assert data["oauth_info"]["access_token"] is not None
+    assert data["oauth_info"]["scope"] == "openid profile email"
+    assert data["oauth_info"]["user_info"] == {
+        "sub": "62f264b9f3c90f4b6514a269",
+        "name": "@huggingface/hub CI bot",
+        "preferred_username": "hub.js",
+        "email_verified": True,
+        "email": "eliott@huggingface.co",
+        "picture": "https://hub-ci.huggingface.co/avatars/934b830e9fdaa879487852f79eef7165.svg",
+        "profile": "https://hub-ci.huggingface.co/hub.js",
+        "website": "https://github.com/huggingface/hub.js",
+        "is_pro": None,
+        "can_pay": None,
+        "orgs": None,
+    }
+
+
+def test_get_oauth_uris_default():
+    login_uri, callback_uri, logout_uri = _get_oauth_uris()
+    assert login_uri == "/oauth/huggingface/login"
+    assert callback_uri == "/oauth/huggingface/callback"
+    assert logout_uri == "/oauth/huggingface/logout"
+
+
+def test_get_oauth_uris_with_prefix_stripped():
+    login_uri, callback_uri, logout_uri = _get_oauth_uris("my/custom/router")
+    assert login_uri == "/my/custom/router/oauth/huggingface/login"
+    assert callback_uri == "/my/custom/router/oauth/huggingface/callback"
+    assert logout_uri == "/my/custom/router/oauth/huggingface/logout"
+
+
+def test_get_oauth_uris_with_prefix_not_stripped():
+    login_uri, callback_uri, logout_uri = _get_oauth_uris("/my/custom/router/")
+    assert login_uri == "/my/custom/router/oauth/huggingface/login"
+    assert callback_uri == "/my/custom/router/oauth/huggingface/callback"
+    assert logout_uri == "/my/custom/router/oauth/huggingface/logout"
+
+
+def test_get_mocked_oauth_info():
+    oauth_info = _get_mocked_oauth_info()
+
+    # Test mock data with logged in user/token
+    assert oauth_info["access_token"] == TOKEN
+    assert oauth_info["userinfo"]["preferred_username"] == USER
+    assert oauth_info["expires_in"] == 28800  # 8 hours
+    assert oauth_info["expires_at"] <= time.time() + oauth_info["expires_in"]
+    assert oauth_info["expires_at"] + 2 > time.time() + oauth_info["expires_in"]  # 2 seconds of margin


### PR DESCRIPTION
This PR imports the code to handle OAuth in gradio to `huggingface_hub`. Goal is to make it available for non-Gradio apps (say autotrain-advanced for instance @abhishekkrthakur).

I also added tests to make sure the workflow still works correctly. Thanks @coyotte508 for https://github.com/huggingface/huggingface.js/pull/1050 and advices :)

Missing parts:
- docstrings and documentation

I have flagged this feature as "experimental" to be able to introduce breaking changes in the future.
Note that for now, the integration only works for Spaces integrations but the same codebase could be tweaked to handle any kind of websites. That's lower priority though (the JS integration is much better for that). 