### PR TITLE
Fix autocompletion not working with ModelHubMixin

### DIFF
--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -274,7 +274,7 @@ class ModelHubMixin:
         }
         cls._hub_mixin_inject_config = "config" in inspect.signature(cls._from_pretrained).parameters
 
-    def __new__(cls, *args, **kwargs) -> "ModelHubMixin":
+    def __new__(cls: Type[T], *args, **kwargs) -> T:
         """Create a new instance of the class and handle config.
 
         3 cases:

--- a/tests/test_hub_mixin.py
+++ b/tests/test_hub_mixin.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Dict, Optional, Union
 from unittest.mock import Mock, patch
 
+import jedi
 import pytest
 
 from huggingface_hub import HfApi, hf_hub_download
@@ -452,3 +453,24 @@ class HubMixinTest(unittest.TestCase):
         model = DummyModelInherited()
         assert model._hub_mixin_info.repo_url == "https://hf.co/my-repo"
         assert model._hub_mixin_info.model_card_data.library_name == "my-cool-library"
+
+    def test_autocomplete_works_as_expected(self):
+        """Regression test for #2694.
+
+        Ensure that autocomplete works as expected when inheriting from `ModelHubMixin`.
+
+        See https://github.com/huggingface/huggingface_hub/issues/2694.
+        """
+        source = """
+from huggingface_hub import ModelHubMixin
+
+class Dummy(ModelHubMixin):
+    def dummy_example_for_test(self, x: str) -> str:
+        return x
+
+a = Dummy()
+a.dum""".strip()
+        script = jedi.Script(source, path="example.py")
+        source_lines = source.split("\n")
+        completions = script.complete(len(source_lines), len(source_lines[-1]))
+        assert any(completion.name == "dummy_example_for_test" for completion in completions)


### PR DESCRIPTION
Fix https://github.com/huggingface/huggingface_hub/issues/2694.

Issue comes from a bad type annotation in `__new__`. Best to use type alias there (as done in other parts of the module already).

Added a quick test using `jedi` (an autocomplete tool we already use in some tests).

