### PR TITLE
[Serialization] add argument to pass shared tensors names to drop when saving

### DIFF
--- a/src/huggingface_hub/serialization/_torch.py
+++ b/src/huggingface_hub/serialization/_torch.py
@@ -42,6 +42,7 @@ def save_torch_model(
     metadata: Optional[Dict[str, str]] = None,
     safe_serialization: bool = True,
     is_main_process: bool = True,
+    shared_tensors_to_discard: Optional[List[str]] = None,
 ):
     """
     Saves a given torch model to disk, handling sharding and shared tensors issues.
@@ -62,6 +63,12 @@ def save_torch_model(
 
     If one of the model's tensor is bigger than `max_shard_size`, it will end up in its own shard which will have a
     size greater than `max_shard_size`.
+
+    </Tip>
+
+    <Tip warning={true}>
+
+    If your model is a `transformers.PreTrainedModel`, you should pass `model._tied_weights_keys` as `shared_tensors_to_discard` to properly handle shared tensors saving. This ensures the correct duplicate tensors are discarded during saving.
 
     </Tip>
 
@@ -93,6 +100,9 @@ def save_torch_model(
             Whether the process calling this is the main process or not. Useful when in distributed training like
             TPUs and need to call this function from all processes. In this case, set `is_main_process=True` only on
             the main process to avoid race conditions. Defaults to True.
+        shared_tensors_to_discard (`List[str]`, *optional*):
+            List of tensor names to drop when saving shared tensors. If not provided and shared tensors are
+            detected, it will drop the first name alphabetically.
 
     Example:
 
@@ -118,6 +128,7 @@ def save_torch_model(
         safe_serialization=safe_serialization,
         save_directory=save_directory,
         is_main_process=is_main_process,
+        shared_tensors_to_discard=shared_tensors_to_discard,
     )
 
 
@@ -131,6 +142,7 @@ def save_torch_state_dict(
     metadata: Optional[Dict[str, str]] = None,
     safe_serialization: bool = True,
     is_main_process: bool = True,
+    shared_tensors_to_discard: Optional[List[str]] = None,
 ) -> None:
     """
     Save a model state dictionary to the disk, handling sharding and shared tensors issues.
@@ -151,6 +163,12 @@ def save_torch_state_dict(
 
     If one of the model's tensor is bigger than `max_shard_size`, it will end up in its own shard which will have a
     size greater than `max_shard_size`.
+
+    </Tip>
+
+    <Tip warning={true}>
+
+    If your model is a `transformers.PreTrainedModel`, you should pass `model._tied_weights_keys` as `shared_tensors_to_discard` to properly handle shared tensors saving. This ensures the correct duplicate tensors are discarded during saving.
 
     </Tip>
 
@@ -182,6 +200,10 @@ def save_torch_state_dict(
             Whether the process calling this is the main process or not. Useful when in distributed training like
             TPUs and need to call this function from all processes. In this case, set `is_main_process=True` only on
             the main process to avoid race conditions. Defaults to True.
+        shared_tensors_to_discard (`List[str]`, *optional*):
+            List of tensor names to drop when saving shared tensors. If not provided and shared tensors are
+            detected, it will drop the first name alphabetically.
+
     Example:
 
     ```py
@@ -202,7 +224,8 @@ def save_torch_state_dict(
             else constants.PYTORCH_WEIGHTS_FILE_PATTERN
         )
 
-    # Imports correct library
+    if metadata is None:
+        metadata = {}
     if safe_serialization:
         try:
             from safetensors.torch import save_file as save_file_fn
@@ -211,7 +234,13 @@ def save_torch_state_dict(
                 "Please install `safetensors` to use safe serialization. "
                 "You can install it with `pip install safetensors`."
             ) from e
-
+        # Clean state dict for safetensors
+        state_dict = _clean_state_dict_for_safetensors(
+            state_dict,
+            metadata,
+            force_contiguous=force_contiguous,
+            shared_tensors_to_discard=shared_tensors_to_discard,
+        )
     else:
         from torch import save as save_file_fn  # type: ignore[assignment]
 
@@ -220,13 +249,6 @@ def save_torch_state_dict(
             "pickled models from untrusted sources. If you intend to share your model, we strongly recommend "
             "using safe serialization by installing `safetensors` with `pip install safetensors`."
         )
-
-    # Clean state dict for safetensors
-    if metadata is None:
-        metadata = {}
-    if safe_serialization:
-        state_dict = _clean_state_dict_for_safetensors(state_dict, metadata, force_contiguous=force_contiguous)
-
     # Split dict
     state_dict_split = split_torch_state_dict_into_shards(
         state_dict, filename_pattern=filename_pattern, max_shard_size=max_shard_size
@@ -472,7 +494,10 @@ def storage_ptr(tensor: "torch.Tensor") -> Union[int, Tuple[Any, ...]]:
 
 
 def _clean_state_dict_for_safetensors(
-    state_dict: Dict[str, "torch.Tensor"], metadata: Dict[str, str], force_contiguous: bool = True
+    state_dict: Dict[str, "torch.Tensor"],
+    metadata: Dict[str, str],
+    force_contiguous: bool = True,
+    shared_tensors_to_discard: Optional[List[str]] = None,
 ):
     """Remove shared tensors from state_dict and update metadata accordingly (for reloading).
 
@@ -480,7 +505,7 @@ def _clean_state_dict_for_safetensors(
 
     Taken from https://github.com/huggingface/safetensors/blob/079781fd0dc455ba0fe851e2b4507c33d0c0d407/bindings/python/py_src/safetensors/torch.py#L155.
     """
-    to_removes = _remove_duplicate_names(state_dict)
+    to_removes = _remove_duplicate_names(state_dict, discard_names=shared_tensors_to_discard)
     for kept_name, to_remove_group in to_removes.items():
         for to_remove in to_remove_group:
             if metadata is None:

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -265,6 +265,7 @@ def test_save_torch_model(mocker: MockerFixture, tmp_path: Path) -> None:
         metadata={"foo": "bar"},
         safe_serialization=True,
         is_main_process=True,
+        shared_tensors_to_discard=None,
     )
     safe_state_dict_mock.assert_called_once_with(
         state_dict=model_mock.state_dict.return_value,
@@ -275,6 +276,7 @@ def test_save_torch_model(mocker: MockerFixture, tmp_path: Path) -> None:
         metadata={"foo": "bar"},
         safe_serialization=True,
         is_main_process=True,
+        shared_tensors_to_discard=None,
     )
 
 
@@ -414,6 +416,55 @@ def test_save_torch_state_dict_shared_layers_sharded(
     for filename in index["weight_map"].values():
         state_dict = load_file(tmp_path / filename)
         assert "shared_2" not in state_dict
+
+
+def test_save_torch_state_dict_discard_selected_sharded(
+    tmp_path: Path, torch_state_dict_shared_layers: Dict[str, "torch.Tensor"]
+) -> None:
+    from safetensors.torch import load_file
+
+    save_torch_state_dict(
+        torch_state_dict_shared_layers,
+        tmp_path,
+        max_shard_size=2,
+        safe_serialization=True,
+        shared_tensors_to_discard=["shared_1"],
+    )
+    index_file = tmp_path / "model.safetensors.index.json"
+    index = json.loads(index_file.read_text())
+
+    assert index["metadata"]["shared_1"] == "shared_2"
+
+    for filename in index["weight_map"].values():
+        state_dict = load_file(tmp_path / filename)
+        assert "shared_1" not in state_dict
+
+
+def test_save_torch_state_dict_discard_selected_not_sharded(
+    tmp_path: Path, torch_state_dict_shared_layers: Dict[str, "torch.Tensor"]
+) -> None:
+    from safetensors.torch import load_file
+
+    save_torch_state_dict(
+        torch_state_dict_shared_layers,
+        tmp_path,
+        safe_serialization=True,
+        shared_tensors_to_discard=["shared_1"],
+    )
+    safetensors_file = tmp_path / "model.safetensors"
+    assert safetensors_file.is_file()
+
+    # Check shared layer not duplicated in file
+    state_dict = load_file(safetensors_file)
+    assert "shared_1" not in state_dict
+    assert "shared_2" in state_dict
+
+    # Check shared layer info in metadata
+    file_bytes = safetensors_file.read_bytes()
+    metadata_str = file_bytes[
+        8 : struct.unpack("<Q", file_bytes[:8])[0] + 8
+    ].decode()  # TODO: next time add helper for this
+    assert json.loads(metadata_str)["__metadata__"]["shared_1"] == "shared_2"
 
 
 def test_split_torch_state_dict_into_shards(


### PR DESCRIPTION
Related to [transformers#35080](https://github.com/huggingface/transformers/issues/35080).

Currently, when saving a torch state dict with shared tensors, the key to keep is chosen alphabetically which might not be the desired behavior. This PR simply adds an optional `state_dict_keys_to_discard` argument to both `save_torch_state_dict()` and `save_torch_model()` that allows users to specify which keys should be discarded in priority when duplicates are found.
_Note_ : The logic behind choosing which key should be discarded in priority is framework/model-specific and should be handled by the user. For example, for `transformers.PreTrainedModel` models, this is specified in the `_tied_weights_keys` attribute, example usage:

```python
model = ... # A model inheriting from PreTrainedModel
save_torch_model(
    model,
    "path/to/folder",
    state_dict_keys_to_discard=model._tied_weights_keys,
)
```
or with `save_torch_state_dict()`
```python
model = ... # A model inheriting from PreTrainedModel
save_torch_state_dict(
    model.state_dict(),
    "path/to/folder",
    state_dict_keys_to_discard=model._tied_weights_keys,
)
```