### PR TITLE
Fix test_list_spaces_linked

### DIFF
--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2318,13 +2318,13 @@ class HfApiPublicProductionTest(unittest.TestCase):
         assert "wikipedia" in spaces[0].datasets
 
     def test_list_spaces_linked(self):
-        space_id = "open-llm-leaderboard/open_llm_leaderboard"
+        space_id = "stabilityai/stable-diffusion"
 
-        spaces = list(self._api.list_spaces(search=space_id))
+        spaces = [space for space in self._api.list_spaces(search=space_id) if space.id == space_id]
         assert spaces[0].models is None
         assert spaces[0].datasets is None
 
-        spaces = list(self._api.list_spaces(search=space_id, linked=True))
+        spaces = [space for space in self._api.list_spaces(search=space_id, linked=True) if space.id == space_id]
         assert spaces[0].models is not None
         assert spaces[0].datasets is not None
 


### PR DESCRIPTION
https://huggingface.co/spaces/open-llm-leaderboard/open_llm_leaderboard#/ is not linked to models/datasets on the Hub anymore (most likely due to recent update) cc @clefourrier 

We were using it in our tests so it broke. Replaced it with https://huggingface.co/spaces/stabilityai/stable-diffusion . 