### PR TITLE
[InferenceClient] Keep `generate_kwargs` instead of `generation_parameters`

### DIFF
--- a/src/huggingface_hub/inference/_generated/types/automatic_speech_recognition.py
+++ b/src/huggingface_hub/inference/_generated/types/automatic_speech_recognition.py
@@ -80,6 +80,9 @@ class AutomaticSpeechRecognitionParameters(BaseInferenceType):
     """Parametrization of the text generation process"""
     return_timestamps: Optional[bool] = None
     """Whether to output corresponding timestamps with the generated text"""
+    # Will be deprecated in the future
+    generate_kwargs: Optional[AutomaticSpeechRecognitionGenerationParameters] = None
+    """(Deprecated) Parametrization of the text generation process"""
 
 
 @dataclass

--- a/src/huggingface_hub/inference/_generated/types/automatic_speech_recognition.py
+++ b/src/huggingface_hub/inference/_generated/types/automatic_speech_recognition.py
@@ -76,8 +76,6 @@ class AutomaticSpeechRecognitionGenerationParameters(BaseInferenceType):
 class AutomaticSpeechRecognitionParameters(BaseInferenceType):
     """Additional inference parameters for Automatic Speech Recognition"""
 
-    generation_parameters: Optional[AutomaticSpeechRecognitionGenerationParameters] = None
-    """Parametrization of the text generation process"""
     return_timestamps: Optional[bool] = None
     """Whether to output corresponding timestamps with the generated text"""
     # Will be deprecated in the future

--- a/src/huggingface_hub/inference/_generated/types/automatic_speech_recognition.py
+++ b/src/huggingface_hub/inference/_generated/types/automatic_speech_recognition.py
@@ -78,9 +78,9 @@ class AutomaticSpeechRecognitionParameters(BaseInferenceType):
 
     return_timestamps: Optional[bool] = None
     """Whether to output corresponding timestamps with the generated text"""
-    # Will be deprecated in the future
+    # Will be deprecated in the future when the renaming to `generation_parameters` is implemented in transformers
     generate_kwargs: Optional[AutomaticSpeechRecognitionGenerationParameters] = None
-    """(Deprecated) Parametrization of the text generation process"""
+    """Parametrization of the text generation process"""
 
 
 @dataclass

--- a/src/huggingface_hub/inference/_generated/types/image_to_text.py
+++ b/src/huggingface_hub/inference/_generated/types/image_to_text.py
@@ -80,6 +80,9 @@ class ImageToTextParameters(BaseInferenceType):
     """Parametrization of the text generation process"""
     max_new_tokens: Optional[int] = None
     """The amount of maximum tokens to generate."""
+    # Will be deprecated in the future
+    generate_kwargs: Optional[ImageToTextGenerationParameters] = None
+    """(Deprecated) Parametrization of the text generation process"""
 
 
 @dataclass

--- a/src/huggingface_hub/inference/_generated/types/image_to_text.py
+++ b/src/huggingface_hub/inference/_generated/types/image_to_text.py
@@ -78,9 +78,9 @@ class ImageToTextParameters(BaseInferenceType):
 
     max_new_tokens: Optional[int] = None
     """The amount of maximum tokens to generate."""
-    # Will be deprecated in the future
+    # Will be deprecated in the future when the renaming to `generation_parameters` is implemented in transformers
     generate_kwargs: Optional[ImageToTextGenerationParameters] = None
-    """(Deprecated) Parametrization of the text generation process"""
+    """Parametrization of the text generation process"""
 
 
 @dataclass

--- a/src/huggingface_hub/inference/_generated/types/image_to_text.py
+++ b/src/huggingface_hub/inference/_generated/types/image_to_text.py
@@ -76,8 +76,6 @@ class ImageToTextGenerationParameters(BaseInferenceType):
 class ImageToTextParameters(BaseInferenceType):
     """Additional inference parameters for Image To Text"""
 
-    generation_parameters: Optional[ImageToTextGenerationParameters] = None
-    """Parametrization of the text generation process"""
     max_new_tokens: Optional[int] = None
     """The amount of maximum tokens to generate."""
     # Will be deprecated in the future

--- a/src/huggingface_hub/inference/_generated/types/text_to_audio.py
+++ b/src/huggingface_hub/inference/_generated/types/text_to_audio.py
@@ -76,7 +76,8 @@ class TextToAudioGenerationParameters(BaseInferenceType):
 class TextToAudioParameters(BaseInferenceType):
     """Additional inference parameters for Text To Audio"""
 
-    generation_parameters: Optional[TextToAudioGenerationParameters] = None
+    # Will be deprecated in the future when the renaming to `generation_parameters` is implemented in transformers
+    generate_kwargs: Optional[TextToAudioGenerationParameters] = None
     """Parametrization of the text generation process"""
 
 

--- a/src/huggingface_hub/inference/_generated/types/text_to_speech.py
+++ b/src/huggingface_hub/inference/_generated/types/text_to_speech.py
@@ -76,7 +76,8 @@ class TextToSpeechGenerationParameters(BaseInferenceType):
 class TextToSpeechParameters(BaseInferenceType):
     """Additional inference parameters for Text To Speech"""
 
-    generation_parameters: Optional[TextToSpeechGenerationParameters] = None
+    # Will be deprecated in the future when the renaming to `generation_parameters` is implemented in transformers
+    generate_kwargs: Optional[TextToSpeechGenerationParameters] = None
     """Parametrization of the text generation process"""
 
 


### PR DESCRIPTION
Following up on the failing test in transformers related to Hub spec compliance for pipelines (see the related test [here](https://github.com/huggingface/transformers/blob/66531a1ec3e2aafe7ffb23a9ca715cfb67b9fea0/tests/test_pipeline_mixin.py#L932)). The test failure occurs because there's a mismatch between `generate_kwargs` (current name in transformers) and `generation_parameters` (name in huggingface.js specs).
For now, we'll maintain the use of `generate_kwargs` since the renaming hasn't been implemented in transformers. This is purely a naming convention issue, and we'll update it to `generation_parameters` when we do the full rename in `transformers`.

Note that in huggingface.js, this field was originally named `generate` (not `generate_kwargs`). It was later renamed to `generation_parameters` (see this issue: https://github.com/huggingface/huggingface.js/issues/923). This rename was safe to do since InferenceAPI and Inference Endpoints do not support `generate` or `generate_kwargs` anyways.