### PR TITLE
Add http proxies for HfApi

### DIFF
--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -151,6 +151,7 @@ def snapshot_download(
                 user_agent=user_agent,
                 endpoint=endpoint,
                 headers=headers,
+                proxies=proxies,
             )
             repo_info = api.repo_info(repo_id=repo_id, repo_type=repo_type, revision=revision, token=token)
         except (requests.exceptions.SSLError, requests.exceptions.ProxyError):


### PR DESCRIPTION
Add http proxies for HfApi.__init__, and pass proxies from snapshot_download to HfApi.

* The default value of proxies is None, which means no proxy(keep the previous action).
* If proxies is set, all http requests to the endpoint will go through proxies.
* Pass proxies from snapshot_download() to HfApi.__init__.