### PR TITLE
[BUG] Fix 404 NOT FOUND issue caused by endpoint tail slash

### DIFF
--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -2,7 +2,7 @@ import os
 import re
 import typing
 from typing import Literal, Optional, Tuple
-form urllib.parse import urljoin
+from urllib.parse import urljoin
 
 # Possible values for env variables
 

--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -63,7 +63,9 @@ _staging_mode = _is_true(os.environ.get("HUGGINGFACE_CO_STAGING"))
 
 _HF_DEFAULT_ENDPOINT = "https://huggingface.co"
 _HF_DEFAULT_STAGING_ENDPOINT = "https://hub-ci.huggingface.co"
-ENDPOINT = os.getenv("HF_ENDPOINT") or (_HF_DEFAULT_STAGING_ENDPOINT if _staging_mode else _HF_DEFAULT_ENDPOINT)
+ENDPOINT = os.getenv("HF_ENDPOINT", "").rstrip("/") or (
+    _HF_DEFAULT_STAGING_ENDPOINT if _staging_mode else _HF_DEFAULT_ENDPOINT
+)
 
 HUGGINGFACE_CO_URL_TEMPLATE = urljoin(ENDPOINT, "/{repo_id}/resolve/{revision}/{filename}")
 HUGGINGFACE_HEADER_X_REPO_COMMIT = "X-Repo-Commit"

--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -2,7 +2,7 @@ import os
 import re
 import typing
 from typing import Literal, Optional, Tuple
-
+form urllib.parse import urljoin
 
 # Possible values for env variables
 
@@ -65,7 +65,7 @@ _HF_DEFAULT_ENDPOINT = "https://huggingface.co"
 _HF_DEFAULT_STAGING_ENDPOINT = "https://hub-ci.huggingface.co"
 ENDPOINT = os.getenv("HF_ENDPOINT") or (_HF_DEFAULT_STAGING_ENDPOINT if _staging_mode else _HF_DEFAULT_ENDPOINT)
 
-HUGGINGFACE_CO_URL_TEMPLATE = ENDPOINT + "/{repo_id}/resolve/{revision}/{filename}"
+HUGGINGFACE_CO_URL_TEMPLATE = urljoin(ENDPOINT, "/{repo_id}/resolve/{revision}/{filename}")
 HUGGINGFACE_HEADER_X_REPO_COMMIT = "X-Repo-Commit"
 HUGGINGFACE_HEADER_X_LINKED_ETAG = "X-Linked-Etag"
 HUGGINGFACE_HEADER_X_LINKED_SIZE = "X-Linked-Size"

--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -4,6 +4,7 @@ import typing
 from typing import Literal, Optional, Tuple
 from urllib.parse import urljoin
 
+
 # Possible values for env variables
 
 

--- a/src/huggingface_hub/utils/_http.py
+++ b/src/huggingface_hub/utils/_http.py
@@ -338,7 +338,7 @@ def fix_hf_endpoint_in_url(url: str, endpoint: Optional[str]) -> str:
 
     This is useful when using a proxy and the Hugging Face Hub returns a URL with the default endpoint.
     """
-    endpoint = endpoint or constants.ENDPOINT
+    endpoint = endpoint.rstrip("/") if endpoint else constants.ENDPOINT
     # check if a proxy has been set => if yes, update the returned URL to use the proxy
     if endpoint not in (None, constants._HF_DEFAULT_ENDPOINT, constants._HF_DEFAULT_STAGING_ENDPOINT):
         endpoint.rstrip('/')

--- a/src/huggingface_hub/utils/_http.py
+++ b/src/huggingface_hub/utils/_http.py
@@ -340,8 +340,7 @@ def fix_hf_endpoint_in_url(url: str, endpoint: Optional[str]) -> str:
     """
     endpoint = endpoint.rstrip("/") if endpoint else constants.ENDPOINT
     # check if a proxy has been set => if yes, update the returned URL to use the proxy
-    if endpoint not in (None, constants._HF_DEFAULT_ENDPOINT, constants._HF_DEFAULT_STAGING_ENDPOINT):
-        endpoint.rstrip('/')
+    if endpoint not in (constants._HF_DEFAULT_ENDPOINT, constants._HF_DEFAULT_STAGING_ENDPOINT):
         url = url.replace(constants._HF_DEFAULT_ENDPOINT, endpoint)
         url = url.replace(constants._HF_DEFAULT_STAGING_ENDPOINT, endpoint)
     return url

--- a/src/huggingface_hub/utils/_http.py
+++ b/src/huggingface_hub/utils/_http.py
@@ -341,6 +341,7 @@ def fix_hf_endpoint_in_url(url: str, endpoint: Optional[str]) -> str:
     endpoint = endpoint or constants.ENDPOINT
     # check if a proxy has been set => if yes, update the returned URL to use the proxy
     if endpoint not in (None, constants._HF_DEFAULT_ENDPOINT, constants._HF_DEFAULT_STAGING_ENDPOINT):
+        endpoint.rstrip('/')
         url = url.replace(constants._HF_DEFAULT_ENDPOINT, endpoint)
         url = url.replace(constants._HF_DEFAULT_STAGING_ENDPOINT, endpoint)
     return url


### PR DESCRIPTION
The issue was triggered when user added a **tail slash '/'** in `HF_ENDPOINT`, like `$set HF_ENDPOINT=https://hf-mirror.com/`. 

Then it's interesting (stupid?) to visit a link like - [https://hf-mirror.com//api/models/sentence-transformers/all-MiniLM-L6-v2/revision/main](https://hf-mirror.com/api/models/sentence-transformers/all-MiniLM-L6-v2/revision/main) by huggingface.

Okay then you got 404 and don't know why. Bad experience and you should take care of them in the code with urljoin and carefully strip.


