### PR TITLE
[HfApi] Remove unused parameter from method's docstring

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -5425,8 +5425,6 @@ class HfApi:
         Args:
             repo_id (`str`):
                 A user or an organization name and a repo name separated by a `/`.
-            filename (`str`):
-                The name of the file in the repo.
             repo_type (`str`, *optional*):
                 Set to `"dataset"` or `"space"` if the file is in a dataset or space, `None` or `"model"` if in a
                 model. Default is `None`.


### PR DESCRIPTION
closes #2731.
`HfApi.get_safetensors_metadata()` does not take `filename` as a parameter but it still appears in the method's docstring. This PR fixes the docstring accordingly.