### PR TITLE
[HfApi] remove `like` endpoint

### DIFF
--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -202,7 +202,6 @@ _SUBMOD_ATTRS = {
         "get_user_overview",
         "get_webhook",
         "grant_access",
-        "like",
         "list_accepted_access_requests",
         "list_collections",
         "list_datasets",
@@ -742,7 +741,6 @@ if TYPE_CHECKING:  # pragma: no cover
         get_user_overview,  # noqa: F401
         get_webhook,  # noqa: F401
         grant_access,  # noqa: F401
-        like,  # noqa: F401
         list_accepted_access_requests,  # noqa: F401
         list_collections,  # noqa: F401
         list_datasets,  # noqa: F401

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -2247,57 +2247,6 @@ class HfApi:
             yield SpaceInfo(**item)
 
     @validate_hf_hub_args
-    def like(
-        self,
-        repo_id: str,
-        *,
-        token: Union[bool, str, None] = None,
-        repo_type: Optional[str] = None,
-    ) -> None:
-        """
-        Like a given repo on the Hub (e.g. set as favorite).
-
-        See also [`unlike`] and [`list_liked_repos`].
-
-        Args:
-            repo_id (`str`):
-                The repository to like. Example: `"user/my-cool-model"`.
-
-            token (Union[bool, str, None], optional):
-                A valid user access token (string). Defaults to the locally saved
-                token, which is the recommended method for authentication (see
-                https://huggingface.co/docs/huggingface_hub/quick-start#authentication).
-                To disable authentication, pass `False`.
-
-            repo_type (`str`, *optional*):
-                Set to `"dataset"` or `"space"` if liking a dataset or space, `None` or
-                `"model"` if liking a model. Default is `None`.
-
-        Raises:
-            [`~utils.RepositoryNotFoundError`]:
-                If repository is not found (error 404): wrong repo_id/repo_type, private
-                but not authenticated or repo does not exist.
-
-        Example:
-        ```python
-        >>> from huggingface_hub import like, list_liked_repos, unlike
-        >>> like("gpt2")
-        >>> "gpt2" in list_liked_repos().models
-        True
-        >>> unlike("gpt2")
-        >>> "gpt2" in list_liked_repos().models
-        False
-        ```
-        """
-        if repo_type is None:
-            repo_type = constants.REPO_TYPE_MODEL
-        response = get_session().post(
-            url=f"{self.endpoint}/api/{repo_type}s/{repo_id}/like",
-            headers=self._build_hf_headers(token=token),
-        )
-        hf_raise_for_status(response)
-
-    @validate_hf_hub_args
     def unlike(
         self,
         repo_id: str,
@@ -2308,7 +2257,7 @@ class HfApi:
         """
         Unlike a given repo on the Hub (e.g. remove from favorite list).
 
-        See also [`like`] and [`list_liked_repos`].
+        See also [`list_liked_repos`].
 
         Args:
             repo_id (`str`):
@@ -2331,9 +2280,8 @@ class HfApi:
 
         Example:
         ```python
-        >>> from huggingface_hub import like, list_liked_repos, unlike
-        >>> like("gpt2")
-        >>> "gpt2" in list_liked_repos().models
+        >>> from huggingface_hub import list_liked_repos, unlike
+        >>> "gpt2" in list_liked_repos().models # we assume you have already liked gpt2
         True
         >>> unlike("gpt2")
         >>> "gpt2" in list_liked_repos().models
@@ -2360,7 +2308,7 @@ class HfApi:
         This list is public so token is optional. If `user` is not passed, it defaults to
         the logged in user.
 
-        See also [`like`] and [`unlike`].
+        See also [`unlike`].
 
         Args:
             user (`str`, *optional*):
@@ -2434,7 +2382,7 @@ class HfApi:
         """
         List all users who liked a given repo on the hugging Face Hub.
 
-        See also [`like`] and [`list_liked_repos`].
+        See also [`list_liked_repos`].
 
         Args:
             repo_id (`str`):
@@ -9562,7 +9510,6 @@ run_as_future = api.run_as_future
 # Activity API
 list_liked_repos = api.list_liked_repos
 list_repo_likers = api.list_repo_likers
-like = api.like
 unlike = api.unlike
 
 # Community API

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -2257,6 +2257,8 @@ class HfApi:
         """
         Unlike a given repo on the Hub (e.g. remove from favorite list).
 
+        To prevent spam usage, it is not possible to `like` a repository from a script.
+
         See also [`list_liked_repos`].
 
         Args:

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2943,72 +2943,9 @@ class ActivityApiTest(unittest.TestCase):
     def setUpClass(cls) -> None:
         cls.api = HfApi()  # no auth!
 
-    def test_like_and_unlike_repo(self) -> None:
-        # Create and like a private and a public repo
-        repo_id_private = self.api.create_repo(repo_name(), token=TOKEN, private=True).repo_id
-        self.api.like(repo_id_private, token=TOKEN)
-
-        repo_id_public = self.api.create_repo(repo_name(), token=TOKEN, private=False).repo_id
-        self.api.like(repo_id_public, token=TOKEN)
-
-        # Get likes as public and authenticated
-        likes = self.api.list_liked_repos(USER)
-        likes_with_auth = self.api.list_liked_repos(USER, token=TOKEN)
-
-        # Public repo is shown in liked repos
-        self.assertIn(repo_id_public, likes.models)
-        self.assertIn(repo_id_public, likes_with_auth.models)
-
-        # Private repo is NOT shown in liked repos, even when authenticated
-        # This is by design. See https://github.com/huggingface/moon-landing/pull/4879 (internal link)
-        self.assertNotIn(repo_id_private, likes.models)
-        self.assertNotIn(repo_id_private, likes_with_auth.models)
-
-        # Unlike repo and check not in liked list
-        self.api.unlike(repo_id_public, token=TOKEN)
-        self.api.unlike(repo_id_private, token=TOKEN)
-        likes_after_unlike = self.api.list_liked_repos(USER)
-        self.assertNotIn(repo_id_public, likes_after_unlike.models)  # Unliked
-
-        # Cleanup
-        self.api.delete_repo(repo_id_public, token=TOKEN)
-        self.api.delete_repo(repo_id_private, token=TOKEN)
-
-    def test_like_missing_repo(self) -> None:
-        with self.assertRaises(RepositoryNotFoundError):
-            self.api.like("missing_repo_id", token=TOKEN)
-
+    def test_unlike_missing_repo(self) -> None:
         with self.assertRaises(RepositoryNotFoundError):
             self.api.unlike("missing_repo_id", token=TOKEN)
-
-    def test_like_twice(self) -> None:
-        # Create and like repo
-        repo_id = self.api.create_repo(repo_name(), token=TOKEN, private=True).repo_id
-
-        # Can like twice
-        self.api.like(repo_id, token=TOKEN)
-        self.api.like(repo_id, token=TOKEN)
-
-        # Can unlike twice
-        self.api.unlike(repo_id, token=TOKEN)
-        self.api.unlike(repo_id, token=TOKEN)
-
-        # Cleanup
-        self.api.delete_repo(repo_id, token=TOKEN)
-
-    def test_list_liked_repos_no_auth(self) -> None:
-        # Create a repo + like
-        repo_id = self.api.create_repo(repo_name(), exist_ok=True, token=TOKEN).repo_id
-        self.api.like(repo_id, token=TOKEN)
-
-        # Fetch liked repos without auth
-        likes = self.api.list_liked_repos(USER, token=False)
-        self.assertEqual(likes.user, USER)
-        self.assertGreater(len(likes.models) + len(likes.datasets) + len(likes.spaces), 0)
-        self.assertIn(repo_id, likes.models)
-
-        # Cleanup
-        self.api.delete_repo(repo_id, token=TOKEN)
 
     def test_list_likes_repos_auth_and_implicit_user(self) -> None:
         # User is implicit
@@ -3254,9 +3191,12 @@ class TestCommitInBackground(HfApiCommonTest):
     @use_tmp_repo()
     def test_run_as_future(self, repo_url: RepoUrl) -> None:
         repo_id = repo_url.repo_id
-        self._api.run_as_future(self._api.like, repo_id)
+        # update repo visibility to private
+        self._api.run_as_future(self._api.update_repo_settings, repo_id=repo_id, private=True)
         future_1 = self._api.run_as_future(self._api.model_info, repo_id=repo_id)
-        self._api.run_as_future(self._api.unlike, repo_id)
+
+        # update repo visibility to public
+        self._api.run_as_future(self._api.update_repo_settings, repo_id=repo_id, private=False)
         future_2 = self._api.run_as_future(self._api.model_info, repo_id=repo_id)
 
         self.assertIsInstance(future_1, Future)
@@ -3271,8 +3211,8 @@ class TestCommitInBackground(HfApiCommonTest):
         assert future_2.done()
 
         # Like/unlike is correct
-        self.assertEqual(info_1.likes, 1)
-        self.assertEqual(info_2.likes, 0)
+        self.assertEqual(info_1.private, True)
+        self.assertEqual(info_2.private, False)
 
 
 class TestDownloadHfApiAlias(unittest.TestCase):


### PR DESCRIPTION
This PR removes the support for the `like` endpoint which is being removed server-side. `unlike` is kept for the same reason mentioned in [moon-landing#12147](https://github.com/huggingface-internal/moon-landing/pull/12147) (private link).

Given the low usage of this endpoint, there is no need for a full deprecation cycle. This will be included in the next `huggingface_hub` release.

