### PR TITLE
Remove org tokens related tests

### DIFF
--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -442,17 +442,6 @@ class CommitApiTest(HfApiCommonTest):
         self.assertEqual(url.repo_id, f"{USER}/{REPO_NAME}")
         self._api.delete_repo(repo_id=url.repo_id)
 
-    def test_create_repo_org_token_fail(self):
-        REPO_NAME = repo_name("org")
-        with pytest.raises(HfHubHTTPError, match="Invalid username or password"):
-            self._api.create_repo(repo_id=REPO_NAME, token="api_org_dummy_token")
-
-    @patch("huggingface_hub.utils._headers.get_token", return_value="api_org_dummy_token")
-    def test_create_repo_org_token_none_fail(self, mock_get_token: Mock):
-        with pytest.raises(HfHubHTTPError, match="Invalid username or password"):
-            with patch.object(self._api, "token", None):  # no default token
-                self._api.create_repo(repo_id=repo_name("org"))
-
     def test_create_repo_already_exists_but_no_write_permission(self):
         # Create under other user namespace
         repo_id = self._api.create_repo(repo_id=repo_name(), token=OTHER_TOKEN).repo_id


### PR DESCRIPTION
this PR removes org tokens related test cases that are no longer relevant. This should fix some of the failing tests in the CI.