### PR TITLE
Fix`CardData.get()` to respect default values when `None`

### DIFF
--- a/src/huggingface_hub/repocard_data.py
+++ b/src/huggingface_hub/repocard_data.py
@@ -222,7 +222,6 @@ class CardData:
     def get(self, key: str, default: Any = None) -> Any:
         """Get value for a given metadata key."""
         value = self.__dict__.get(key)
-        #
         return default if value is None else value
 
     def pop(self, key: str, default: Any = None) -> Any:

--- a/src/huggingface_hub/repocard_data.py
+++ b/src/huggingface_hub/repocard_data.py
@@ -221,7 +221,9 @@ class CardData:
 
     def get(self, key: str, default: Any = None) -> Any:
         """Get value for a given metadata key."""
-        return self.__dict__.get(key, default)
+        value = self.__dict__.get(key)
+        #
+        return default if value is None else value
 
     def pop(self, key: str, default: Any = None) -> Any:
         """Pop value for a given metadata key."""

--- a/tests/test_repocard_data.py
+++ b/tests/test_repocard_data.py
@@ -63,6 +63,13 @@ class BaseCardDataTest(unittest.TestCase):
         self.assertTrue("foo" in metadata)
         self.assertFalse("FOO" in metadata)
 
+        # default value
+        self.assertEqual(metadata.get("FOO", "default"), "default")
+        # Should return default when key is in metadata but value is None
+        metadata.FOO = None
+        self.assertEqual(metadata.get("FOO", "default"), "default")
+        # Should return default when key is not in metadata
+        self.assertEqual(metadata.get("BAR", "default"), "default")
         # export
         self.assertEqual(str(metadata), "foo: BAR")
 

--- a/tests/test_repocard_data.py
+++ b/tests/test_repocard_data.py
@@ -64,12 +64,11 @@ class BaseCardDataTest(unittest.TestCase):
         self.assertFalse("FOO" in metadata)
 
         # default value
+        # Should return default when key is not in metadata
         self.assertEqual(metadata.get("FOO", "default"), "default")
         # Should return default when key is in metadata but value is None
         metadata.FOO = None
         self.assertEqual(metadata.get("FOO", "default"), "default")
-        # Should return default when key is not in metadata
-        self.assertEqual(metadata.get("BAR", "default"), "default")
         # export
         self.assertEqual(str(metadata), "foo: BAR")
 


### PR DESCRIPTION
fixes #2769 

Fix inconsistent behavior in `CardData.get()` where `get(key, default_value)` returns `None` even when a default is provided. 
The fix makes `get()` handle `None` values consistently with `to_dict()` behavior by returning the default value both when the key doesn't exist AND when its value is `None`:

```python
card = CardData()
card.key = None
card.to_dict()  # Returns {} - None values are filtered out
card.to_dict().get("key", "default")  # Returns "default" because key doesn't exist
```
So with the fix in this PR, `card.get("key", "default")` will return "default".