### PR TITLE
Fix `RepoCard.load` when passing a `repo_id` that is also a dir path

### DIFF
--- a/src/huggingface_hub/repocard.py
+++ b/src/huggingface_hub/repocard.py
@@ -171,7 +171,7 @@ class RepoCard:
             ```
         """
 
-        if Path(repo_id_or_path).exists():
+        if Path(repo_id_or_path).is_file():
             card_path = Path(repo_id_or_path)
         elif isinstance(repo_id_or_path, str):
             card_path = Path(


### PR DESCRIPTION
Fix https://github.com/huggingface/huggingface_hub/issues/2768.

Simply replace `repo_id_or_path.exists()` by `repo_id_or_path.is_file()`.