### PR TITLE
Automate release candidate testing

### DIFF
--- a/.github/workflows/python-prerelease.yml
+++ b/.github/workflows/python-prerelease.yml
@@ -1,12 +1,10 @@
 name: Python prerelease
 
 on:
-  #   push:
-  #     tags:
-  #       - v*.rc*
-  push: # TODO: remove this before merging
-    branches:
-      - automating-release-candidate-testing
+  push:
+    tags:
+      - v*.rc*
+
 jobs:
   test_on_transformers:
     runs-on: ubuntu-latest
@@ -15,8 +13,7 @@ jobs:
     steps:
       - name: Extract version from tag
         id: get-version
-        # run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
-        run: echo "VERSION=v0.27.0rc1" >> $GITHUB_OUTPUT # TODO: remove this before merging
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       - name: Checkout transformers
         uses: actions/checkout@v4

--- a/.github/workflows/python-prerelease.yml
+++ b/.github/workflows/python-prerelease.yml
@@ -1,11 +1,12 @@
 name: Python prerelease
 
 on:
-  workflow_dispatch: # TODO: remove this before merging
-#   push:
-#     tags:
-#       - v*.rc*
-
+  #   push:
+  #     tags:
+  #       - v*.rc*
+  push: # TODO: remove this before merging
+    branches:
+      - automating-release-candidate-testing
 jobs:
   test_on_transformers:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-prerelease.yml
+++ b/.github/workflows/python-prerelease.yml
@@ -1,0 +1,57 @@
+name: Python prerelease
+
+on:
+  workflow_dispatch: # TODO: remove this before merging
+#   push:
+#     tags:
+#       - v*.rc*
+
+jobs:
+  test_on_transformers:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Extract version from tag
+        id: get-version
+        # run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+        run: echo "VERSION=v0.27.0rc1" >> $GITHUB_OUTPUT # TODO: remove this before merging
+
+      - name: Checkout transformers
+        uses: actions/checkout@v4
+        with:
+          repository: huggingface/transformers
+          path: transformers
+          token: ${{ secrets.TOKEN_INFERENCE_SYNC_BOT }}
+
+      - name: Configure Git
+        run: |
+          cd transformers
+          git config user.name "Hugging Face Bot"
+          git config user.email "bot@huggingface.co"
+
+      - name: Create test branch and update dependencies
+        id: create-pr
+        run: |
+          cd transformers
+          VERSION=${{ steps.get-version.outputs.VERSION }}
+          BRANCH_NAME="ci-test-huggingface-hub-${VERSION}"
+
+          # Create and checkout new branch
+          git checkout -b $BRANCH_NAME
+
+          # Update dependencies using sed
+          sed -i -E 's/"huggingface-hub>=0.*"/"huggingface-hub=='${VERSION}'"/' setup.py
+          sed -i -E 's/"huggingface-hub>=0.*"/"huggingface-hub=='${VERSION}'"/' src/transformers/dependency_versions_table.py
+
+          # Commit and push changes
+          git --no-pager diff
+          git add setup.py src/transformers/dependency_versions_table.py
+          git commit -m "Test hfh ${VERSION}"
+          git push --set-upstream origin $BRANCH_NAME
+
+      - name: Print URLs for manual check
+        run: |
+          VERSION=${{ steps.get-version.outputs.VERSION }}
+          echo "https://github.com/huggingface/transformers/actions"
+          echo "https://github.com/huggingface/transformers/compare/main...ci-test-huggingface-hub-${VERSION}"

--- a/.github/workflows/python-prerelease.yml
+++ b/.github/workflows/python-prerelease.yml
@@ -23,12 +23,12 @@ jobs:
         with:
           repository: huggingface/transformers
           path: transformers
-          token: ${{ secrets.TOKEN_INFERENCE_SYNC_BOT }}
+          token: ${{ secrets.HUGGINGFACE_HUB_AUTOMATIC_RC_TESTING }}
 
       - name: Configure Git
         run: |
           cd transformers
-          git config user.name "Hugging Face Bot"
+          git config user.name "Hugging Face Bot (RC Testing)"
           git config user.email "bot@huggingface.co"
 
       - name: Create test branch and update dependencies


### PR DESCRIPTION
Goal is to automatically trigger CI jobs for prerelease candidates on other major libraries: transformers, datasets, diffusers, etc. 

Example created from this PR: https://github.com/huggingface/transformers/compare/main...ci-test-huggingface-hub-v0.27.0rc1.
CI run: https://github.com/huggingface/huggingface_hub/actions/runs/13009228602/job/36282963731?pr=2792