### PR TITLE
Fix few things (inference providers)

### DIFF
--- a/src/huggingface_hub/inference/_providers/fal_ai.py
+++ b/src/huggingface_hub/inference/_providers/fal_ai.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Optional, Union
 
 from huggingface_hub import constants
 from huggingface_hub.inference._common import RequestParameters, TaskProviderHelper, _as_dict
-from huggingface_hub.utils import build_hf_headers, get_session, logging
+from huggingface_hub.utils import build_hf_headers, get_session, get_token, logging
 
 
 logger = logging.get_logger(__name__)
@@ -52,7 +52,11 @@ class FalAITask(TaskProviderHelper, ABC):
         extra_payload: Optional[Dict[str, Any]] = None,
     ) -> RequestParameters:
         if api_key is None:
-            raise ValueError("You must provide an api_key to work with fal.ai API.")
+            api_key = get_token()
+        if api_key is None:
+            raise ValueError(
+                "You must provide an api_key to work with fal.ai API or log in with `huggingface-cli login`."
+            )
 
         mapped_model = self._map_model(model)
         headers = {

--- a/src/huggingface_hub/inference/_providers/replicate.py
+++ b/src/huggingface_hub/inference/_providers/replicate.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, Optional, Union
 
 from huggingface_hub import constants
 from huggingface_hub.inference._common import RequestParameters, TaskProviderHelper, _as_dict
-from huggingface_hub.utils import build_hf_headers, get_session, logging
+from huggingface_hub.utils import build_hf_headers, get_session, get_token, logging
 
 
 logger = logging.get_logger(__name__)
@@ -52,7 +52,11 @@ class ReplicateTask(TaskProviderHelper):
         extra_payload: Optional[Dict[str, Any]] = None,
     ) -> RequestParameters:
         if api_key is None:
-            raise ValueError("You must provide an api_key to work with Replicate API.")
+            api_key = get_token()
+        if api_key is None:
+            raise ValueError(
+                "You must provide an api_key to work with Replicate API or log in with `huggingface-cli login`."
+            )
 
         # Route to the proxy if the api_key is a HF TOKEN
         if api_key.startswith("hf_"):

--- a/src/huggingface_hub/inference/_providers/sambanova.py
+++ b/src/huggingface_hub/inference/_providers/sambanova.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, Optional, Union
 
 from huggingface_hub import constants
 from huggingface_hub.inference._common import RequestParameters, TaskProviderHelper
-from huggingface_hub.utils import build_hf_headers, logging
+from huggingface_hub.utils import build_hf_headers, get_token, logging
 
 
 logger = logging.get_logger(__name__)
@@ -44,7 +44,11 @@ class SambanovaConversationalTask(TaskProviderHelper):
         extra_payload: Optional[Dict[str, Any]] = None,
     ) -> RequestParameters:
         if api_key is None:
-            raise ValueError("You must provide an api_key to work with Sambanova API.")
+            api_key = get_token()
+        if api_key is None:
+            raise ValueError(
+                "You must provide an api_key to work with Sambanova API or log in with `huggingface-cli login`."
+            )
 
         # Route to the proxy if the api_key is a HF TOKEN
         if api_key.startswith("hf_"):

--- a/src/huggingface_hub/utils/_http.py
+++ b/src/huggingface_hub/utils/_http.py
@@ -513,7 +513,7 @@ def _format(error_type: Type[HfHubHTTPError], custom_message: str, response: Res
             server_errors.append(response.text)
 
     # Strip all server messages
-    server_errors = [line.strip() for line in server_errors if line.strip()]
+    server_errors = [str(line).strip() for line in server_errors if str(line).strip()]
 
     # Deduplicate server messages (keep order)
     # taken from https://stackoverflow.com/a/17016257


### PR DESCRIPTION
Few things:
- Update Meta Llama 3 8B (together). See https://github.com/huggingface/huggingface.js/pull/1145
- in `hf_raise_for_status` => convert to string to avoid parsing issues. We could parse dicts in better ways but not worth it (format can vary depending on provider)
- if `api_token` not passed in provider, use the HF one

cc @pcuenca 