### PR TITLE
[Docs] Fix broken link in CLI guide documentation

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -232,7 +232,7 @@ A `.cache/huggingface/` folder is created at the root of your local directory co
 
 <Tip>
 
-For more details on how downloading to a local file works, check out the [download](./download.md#download-files-to-a-local-folder) guide.
+For more details on how downloading to a local file works, check out the [download](./download#download-files-to-a-local-folder) guide.
 
 </Tip>
 

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -282,7 +282,7 @@ To mitigate this issue, you can set the `HF_HUB_DOWNLOAD_TIMEOUT` environment va
 export HF_HUB_DOWNLOAD_TIMEOUT=30
 ```
 
-For more details, check out the [environment variables reference](../package_reference/environment_variables#hfhubdownloadtimeout).And rerun your download command.
+For more details, check out the [environment variables reference](../package_reference/environment_variables#hfhubdownloadtimeout). And rerun your download command.
 
 ## huggingface-cli upload
 


### PR DESCRIPTION
reported by @BramVanroy in this slack [message](https://huggingface.slack.com/archives/C039P47V1L5/p1738070885457699) (private).