### PR TITLE
Add YuE (music gen) from fal.ai

### DIFF
--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -2614,6 +2614,7 @@ class InferenceClient:
         early_stopping: Optional[Union[bool, "TextToSpeechEarlyStoppingEnum"]] = None,
         epsilon_cutoff: Optional[float] = None,
         eta_cutoff: Optional[float] = None,
+        genres: Optional[str] = None,
         max_length: Optional[int] = None,
         max_new_tokens: Optional[int] = None,
         min_length: Optional[int] = None,
@@ -2653,6 +2654,8 @@ class InferenceClient:
                 probability, scaled by sqrt(eta_cutoff). In the paper, suggested values range from 3e-4 to 2e-3,
                 depending on the size of the model. See [Truncation Sampling as Language Model
                 Desmoothing](https://hf.co/papers/2210.15191) for more details.
+            genres (`str`, *optional*):
+                The genres to use for the music generation (if relevant for the model).
             max_length (`int`, *optional*):
                 The maximum length (in tokens) of the generated text, including the input.
             max_new_tokens (`int`, *optional*):
@@ -2739,6 +2742,7 @@ class InferenceClient:
                 "early_stopping": early_stopping,
                 "epsilon_cutoff": epsilon_cutoff,
                 "eta_cutoff": eta_cutoff,
+                "genres": genres,
                 "max_length": max_length,
                 "max_new_tokens": max_new_tokens,
                 "min_length": min_length,

--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -2617,7 +2617,6 @@ class InferenceClient:
         early_stopping: Optional[Union[bool, "TextToSpeechEarlyStoppingEnum"]] = None,
         epsilon_cutoff: Optional[float] = None,
         eta_cutoff: Optional[float] = None,
-        genres: Optional[str] = None,
         max_length: Optional[int] = None,
         max_new_tokens: Optional[int] = None,
         min_length: Optional[int] = None,
@@ -2658,8 +2657,6 @@ class InferenceClient:
                 probability, scaled by sqrt(eta_cutoff). In the paper, suggested values range from 3e-4 to 2e-3,
                 depending on the size of the model. See [Truncation Sampling as Language Model
                 Desmoothing](https://hf.co/papers/2210.15191) for more details.
-            genres (`str`, *optional*):
-                The genres to use for the music generation (if relevant for the model).
             max_length (`int`, *optional*):
                 The maximum length (in tokens) of the generated text, including the input.
             max_new_tokens (`int`, *optional*):
@@ -2753,6 +2750,37 @@ class InferenceClient:
         ... )
         >>> Path("hello.flac").write_bytes(audio)
         ```
+
+        Example music-gen using fal.ai provider
+        ```py
+        >>> from huggingface_hub import InferenceClient
+        >>> lyrics = '''
+        ... [verse]
+        ... In the town where I was born
+        ... Lived a man who sailed to sea
+        ... And he told us of his life
+        ... In the land of submarines
+        ... So we sailed on to the sun
+        ... 'Til we found a sea of green
+        ... And we lived beneath the waves
+        ... In our yellow submarine
+
+        ... [chorus]
+        ... We all live in a yellow submarine
+        ... Yellow submarine, yellow submarine
+        ... We all live in a yellow submarine
+        ... Yellow submarine, yellow submarine
+        ... '''
+        >>> genres = "pavarotti-style tenor voice"
+        >>> client = InferenceClient(
+        ...     provider="fal-ai",
+        ...     model="m-a-p/YuE-s1-7B-anneal-en-cot",
+        ...     api_key=...,
+        ... )
+        >>> audio = client.text_to_speech(lyrics, extra_parameters={"genres": genres})
+        >>> with open("output.mp3", "wb") as f:
+        ...     f.write(audio)
+        ```
         """
         provider_helper = get_provider_helper(self.provider, task="text-to-speech")
         request_parameters = provider_helper.prepare_request(
@@ -2762,7 +2790,6 @@ class InferenceClient:
                 "early_stopping": early_stopping,
                 "epsilon_cutoff": epsilon_cutoff,
                 "eta_cutoff": eta_cutoff,
-                "genres": genres,
                 "max_length": max_length,
                 "max_new_tokens": max_new_tokens,
                 "min_length": min_length,

--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -2751,7 +2751,7 @@ class InferenceClient:
         >>> Path("hello.flac").write_bytes(audio)
         ```
 
-        Example music-gen using fal.ai provider
+        Example music-gen using "YuE-s1-7B-anneal-en-cot" on fal.ai
         ```py
         >>> from huggingface_hub import InferenceClient
         >>> lyrics = '''

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -2674,7 +2674,6 @@ class AsyncInferenceClient:
         early_stopping: Optional[Union[bool, "TextToSpeechEarlyStoppingEnum"]] = None,
         epsilon_cutoff: Optional[float] = None,
         eta_cutoff: Optional[float] = None,
-        genres: Optional[str] = None,
         max_length: Optional[int] = None,
         max_new_tokens: Optional[int] = None,
         min_length: Optional[int] = None,
@@ -2715,8 +2714,6 @@ class AsyncInferenceClient:
                 probability, scaled by sqrt(eta_cutoff). In the paper, suggested values range from 3e-4 to 2e-3,
                 depending on the size of the model. See [Truncation Sampling as Language Model
                 Desmoothing](https://hf.co/papers/2210.15191) for more details.
-            genres (`str`, *optional*):
-                The genres to use for the music generation (if relevant for the model).
             max_length (`int`, *optional*):
                 The maximum length (in tokens) of the generated text, including the input.
             max_new_tokens (`int`, *optional*):
@@ -2811,6 +2808,37 @@ class AsyncInferenceClient:
         ... )
         >>> Path("hello.flac").write_bytes(audio)
         ```
+
+        Example music-gen using fal.ai provider
+        ```py
+        >>> from huggingface_hub import InferenceClient
+        >>> lyrics = '''
+        ... [verse]
+        ... In the town where I was born
+        ... Lived a man who sailed to sea
+        ... And he told us of his life
+        ... In the land of submarines
+        ... So we sailed on to the sun
+        ... 'Til we found a sea of green
+        ... And we lived beneath the waves
+        ... In our yellow submarine
+
+        ... [chorus]
+        ... We all live in a yellow submarine
+        ... Yellow submarine, yellow submarine
+        ... We all live in a yellow submarine
+        ... Yellow submarine, yellow submarine
+        ... '''
+        >>> genres = "pavarotti-style tenor voice"
+        >>> client = InferenceClient(
+        ...     provider="fal-ai",
+        ...     model="m-a-p/YuE-s1-7B-anneal-en-cot",
+        ...     api_key=...,
+        ... )
+        >>> audio = client.text_to_speech(lyrics, extra_parameters={"genres": genres})
+        >>> with open("output.mp3", "wb") as f:
+        ...     f.write(audio)
+        ```
         """
         provider_helper = get_provider_helper(self.provider, task="text-to-speech")
         request_parameters = provider_helper.prepare_request(
@@ -2820,7 +2848,6 @@ class AsyncInferenceClient:
                 "early_stopping": early_stopping,
                 "epsilon_cutoff": epsilon_cutoff,
                 "eta_cutoff": eta_cutoff,
-                "genres": genres,
                 "max_length": max_length,
                 "max_new_tokens": max_new_tokens,
                 "min_length": min_length,

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -2674,6 +2674,7 @@ class AsyncInferenceClient:
         early_stopping: Optional[Union[bool, "TextToSpeechEarlyStoppingEnum"]] = None,
         epsilon_cutoff: Optional[float] = None,
         eta_cutoff: Optional[float] = None,
+        genres: Optional[str] = None,
         max_length: Optional[int] = None,
         max_new_tokens: Optional[int] = None,
         min_length: Optional[int] = None,
@@ -2713,6 +2714,8 @@ class AsyncInferenceClient:
                 probability, scaled by sqrt(eta_cutoff). In the paper, suggested values range from 3e-4 to 2e-3,
                 depending on the size of the model. See [Truncation Sampling as Language Model
                 Desmoothing](https://hf.co/papers/2210.15191) for more details.
+            genres (`str`, *optional*):
+                The genres to use for the music generation (if relevant for the model).
             max_length (`int`, *optional*):
                 The maximum length (in tokens) of the generated text, including the input.
             max_new_tokens (`int`, *optional*):
@@ -2800,6 +2803,7 @@ class AsyncInferenceClient:
                 "early_stopping": early_stopping,
                 "epsilon_cutoff": epsilon_cutoff,
                 "eta_cutoff": eta_cutoff,
+                "genres": genres,
                 "max_length": max_length,
                 "max_new_tokens": max_new_tokens,
                 "min_length": min_length,

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -2809,7 +2809,7 @@ class AsyncInferenceClient:
         >>> Path("hello.flac").write_bytes(audio)
         ```
 
-        Example music-gen using fal.ai provider
+        Example music-gen using "YuE-s1-7B-anneal-en-cot" on fal.ai
         ```py
         >>> from huggingface_hub import InferenceClient
         >>> lyrics = '''

--- a/src/huggingface_hub/inference/_providers/__init__.py
+++ b/src/huggingface_hub/inference/_providers/__init__.py
@@ -1,7 +1,12 @@
 from typing import Dict, Literal
 
 from .._common import TaskProviderHelper
-from .fal_ai import FalAIAutomaticSpeechRecognitionTask, FalAITextToImageTask, FalAITextToVideoTask
+from .fal_ai import (
+    FalAIAutomaticSpeechRecognitionTask,
+    FalAITextToImageTask,
+    FalAITextToSpeechTask,
+    FalAITextToVideoTask,
+)
 from .hf_inference import HFInferenceBinaryInputTask, HFInferenceConversational, HFInferenceTask
 from .replicate import ReplicateTask, ReplicateTextToSpeechTask
 from .sambanova import SambanovaConversationalTask
@@ -18,8 +23,9 @@ PROVIDER_T = Literal[
 
 PROVIDERS: Dict[PROVIDER_T, Dict[str, TaskProviderHelper]] = {
     "fal-ai": {
-        "text-to-image": FalAITextToImageTask(),
         "automatic-speech-recognition": FalAIAutomaticSpeechRecognitionTask(),
+        "text-to-image": FalAITextToImageTask(),
+        "text-to-speech": FalAITextToSpeechTask(),
         "text-to-video": FalAITextToVideoTask(),
     },
     "hf-inference": {

--- a/src/huggingface_hub/inference/_providers/fal_ai.py
+++ b/src/huggingface_hub/inference/_providers/fal_ai.py
@@ -154,10 +154,9 @@ class FalAITextToSpeechTask(FalAITask):
         super().__init__("text-to-speech")
 
     def _prepare_payload(self, inputs: Any, parameters: Dict[str, Any]) -> Dict[str, Any]:
-        parameters = {k: v for k, v in parameters.items() if v is not None}
         return {
             "lyrics": inputs,
-            **parameters,
+            **{k: v for k, v in parameters.items() if v is not None},
         }
 
     def get_response(self, response: Union[bytes, Dict]) -> Any:

--- a/src/huggingface_hub/inference/_providers/fal_ai.py
+++ b/src/huggingface_hub/inference/_providers/fal_ai.py
@@ -28,6 +28,9 @@ SUPPORTED_MODELS = {
         "stabilityai/stable-diffusion-3.5-large": "fal-ai/stable-diffusion-v35-large",
         "Kwai-Kolors/Kolors": "fal-ai/kolors",
     },
+    "text-to-speech": {
+        "m-a-p/YuE-s1-7B-anneal-en-cot": "fal-ai/yue",
+    },
     "text-to-video": {
         "genmo/mochi-1-preview": "fal-ai/mochi-v1",
         "tencent/HunyuanVideo": "fal-ai/hunyuan-video",
@@ -143,6 +146,22 @@ class FalAITextToImageTask(FalAITask):
 
     def get_response(self, response: Union[bytes, Dict]) -> Any:
         url = _as_dict(response)["images"][0]["url"]
+        return get_session().get(url).content
+
+
+class FalAITextToSpeechTask(FalAITask):
+    def __init__(self):
+        super().__init__("text-to-speech")
+
+    def _prepare_payload(self, inputs: Any, parameters: Dict[str, Any]) -> Dict[str, Any]:
+        parameters = {k: v for k, v in parameters.items() if v is not None}
+        return {
+            "lyrics": inputs,
+            **parameters,
+        }
+
+    def get_response(self, response: Union[bytes, Dict]) -> Any:
+        url = _as_dict(response)["audio"]["url"]
         return get_session().get(url).content
 
 


### PR DESCRIPTION
Similar to https://github.com/huggingface/huggingface.js/pull/1148.

Will keep it as draft for now. I mostly wanted to see how that integration would work given that it doesn't use the same parameters as we have for `text_to_speech` (has an extra `"genres"` parameters). For now I added it to the signature + docstring but it's not compliant with https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/src/tasks/text-to-speech/spec/input.json. 

Another possibility is to add a `text-to-audio` or `text-to-music` but that seems premature given it's a single model, single provider and still experimental. Will have to wait more example before an harmonization.  


**Working code example:**

```py
import os
from huggingface_hub import InferenceClient

lyrics = """
[verse]
In the town where I was born
Lived a man who sailed to sea
And he told us of his life
In the land of submarines
So we sailed on to the sun
'Til we found a sea of green
And we lived beneath the waves
In our yellow submarine

[chorus]
We all live in a yellow submarine
Yellow submarine, yellow submarine
We all live in a yellow submarine
Yellow submarine, yellow submarine
"""
genres = "pavarotti-style tenor voice"

t0 = time.time()
client = InferenceClient(
    provider="fal-ai",
    model="m-a-p/YuE-s1-7B-anneal-en-cot",
    api_key=os.getenv("FAL_AI_KEY"),
)
audio = client.text_to_speech(lyrics, extra_parameters={"genres": genres})
with open("output.mp3", "wb") as f:
    f.write(audio)
```



https://github.com/user-attachments/assets/b60bb50c-b393-4c83-a4a0-3d0d877462d3



(what a masterpiece, I know)

Process took 594s (~10min) to run on fal.ai. This means it will fail if we go through HF proxy as there is a 60s timeout. For now only works when passing a FAL_AI key directly. This can be fixed using async/queuing mechanism but out of scope for this PR.
