### PR TITLE
Prepare for 0.29.0

### DIFF
--- a/docs/source/cn/guides/repository.md
+++ b/docs/source/cn/guides/repository.md
@@ -55,7 +55,7 @@ Hugging Face Hub是一组 Git 存储库。[Git](https://git-scm.com/)是软件�
 >>> create_repo("lysandre/test-private", private=True)
 ```
 
-如果你想在以后更改仓库的可见性，你可以使用[`update_repo_visibility`] 函数
+如果你想在以后更改仓库的可见性，你可以使用[`update_repo_settings`] 函数
 
 ### 删除一个仓库
 
@@ -142,8 +142,8 @@ GitRefs(
 请运行以下代码将存储库更改为私有：
 
 ```py
->>> from huggingface_hub import update_repo_visibility
->>> update_repo_visibility(repo_id=repo_id, private=True)
+>>> from huggingface_hub import update_repo_settings
+>>> update_repo_settings(repo_id=repo_id, private=True)
 ```
 
 ### 重命名您的存储库

--- a/docs/source/de/guides/repository.md
+++ b/docs/source/de/guides/repository.md
@@ -49,7 +49,7 @@ Wenn Sie ein Repository erstellen, können Sie mit dem Parameter `private` die S
 >>> create_repo("lysandre/test-private", private=True)
 ```
 
-Wenn Sie die Sichtbarkeit des Repositories zu einem späteren Zeitpunkt ändern möchten, können Sie die Funktion [`update_repo_visibility`] verwenden.
+Wenn Sie die Sichtbarkeit des Repositories zu einem späteren Zeitpunkt ändern möchten, können Sie die Funktion [`update_repo_settings`] verwenden.
 
 ### Ein Repository löschen
 
@@ -130,8 +130,8 @@ Einige Einstellungen sind spezifisch für Spaces (Hardware, Umgebungsvariablen,.
 Ein Repository kann öffentlich oder privat sein. Ein privates Repository ist nur für Sie oder die Mitglieder der Organisation sichtbar, in der das Repository sich befindet. Ändern Sie ein Repository wie im Folgenden gezeigt in ein privates:
 
 ```py
->>> from huggingface_hub import update_repo_visibility
->>> update_repo_visibility(repo_id=repo_id, private=True)
+>>> from huggingface_hub import update_repo_settings
+>>> update_repo_settings(repo_id=repo_id, private=True)
 ```
 
 ### Benennen Sie Ihr Repository um

--- a/docs/source/en/guides/repository.md
+++ b/docs/source/en/guides/repository.md
@@ -59,7 +59,7 @@ When you create a repository, you can set your repository visibility with the `p
 >>> create_repo("lysandre/test-private", private=True)
 ```
 
-If you want to change the repository visibility at a later time, you can use the [`update_repo_visibility`] function.
+If you want to change the repository visibility at a later time, you can use the [`update_repo_settings`] function.
 
 <Tip>
 

--- a/docs/source/ko/guides/repository.md
+++ b/docs/source/ko/guides/repository.md
@@ -49,7 +49,7 @@ Hub에 리포지토리를 생성하고 관리하려면, 로그인이 되어 있�
 >>> create_repo("lysandre/test-private", private=True)
 ```
 
-추후 리포지토리 가시성을 변경하고 싶다면, [`update_repo_visibility`] 함수를 이용해 바꿀 수 있습니다.
+추후 리포지토리 가시성을 변경하고 싶다면, [`update_repo_settings`] 함수를 이용해 바꿀 수 있습니다.
 
 ### 리포지토리 삭제[[delete-a-repository]]
 
@@ -128,8 +128,8 @@ Spaces를 위한 특정 설정들(하드웨어, 환경변수 등)을 구성하�
 리포지토리는 공개 또는 비공개로 설정할 수 있습니다. 비공개 리포지토리는 해당 저장소의 사용자 혹은 소속된 조직의 구성원만 볼 수 있습니다. 다음과 같이 리포지토리를 비공개로 변경할 수 있습니다.
 
 ```py
->>> from huggingface_hub import update_repo_visibility
->>> update_repo_visibility(repo_id=repo_id, private=True)
+>>> from huggingface_hub import update_repo_settings
+>>> update_repo_settings(repo_id=repo_id, private=True)
 ```
 
 ### 리포지토리 이름 변경[[rename-your-repository]]

--- a/src/huggingface_hub/README.md
+++ b/src/huggingface_hub/README.md
@@ -83,7 +83,7 @@ single file to a repo or listing models from the Hub, you'll find helpers in
 * `list_repo_files()`
 * `list_repo_objects()`
 * `delete_repo()`
-* `update_repo_visibility()`
+* `update_repo_settings()`
 * `create_commit()`
 * `upload_file()`
 * `delete_file()`

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -46,7 +46,7 @@ import sys
 from typing import TYPE_CHECKING
 
 
-__version__ = "0.27.0.dev0"
+__version__ = "0.29.0.dev0"
 
 # Alphabetical order of definitions is ensured in tests
 # WARNING: any comment added in this dictionary definition will be lost when

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -3548,7 +3548,7 @@ class HfApi:
             if not missing_ok:
                 raise
 
-    @_deprecate_method(version="0.29", message="Please use `update_repo_settings` instead.")
+    @_deprecate_method(version="0.32", message="Please use `update_repo_settings` instead.")
     @validate_hf_hub_args
     def update_repo_visibility(
         self,

--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -1611,19 +1611,10 @@ class InferenceClient:
         response = self._inner_post(request_parameters)
         return _bytes_to_list(response)
 
-    @_deprecate_arguments(
-        version="0.29",
-        deprecated_args=["parameters"],
-        custom_message=(
-            "The `parameters` argument is deprecated and will be removed in a future version. "
-            "Provide individual parameters instead: `clean_up_tokenization_spaces`, `generate_parameters`, and `truncation`."
-        ),
-    )
     def summarization(
         self,
         text: str,
         *,
-        parameters: Optional[Dict[str, Any]] = None,
         model: Optional[str] = None,
         clean_up_tokenization_spaces: Optional[bool] = None,
         generate_parameters: Optional[Dict[str, Any]] = None,
@@ -1635,9 +1626,6 @@ class InferenceClient:
         Args:
             text (`str`):
                 The input text to summarize.
-            parameters (`Dict[str, Any]`, *optional*):
-                Additional parameters for summarization. Check out this [page](https://huggingface.co/docs/api-inference/detailed_parameters#summarization-task)
-                for more details.
             model (`str`, *optional*):
                 The model to use for inference. Can be a model ID hosted on the Hugging Face Hub or a URL to a deployed
                 Inference Endpoint. If not provided, the default recommended model for summarization will be used.
@@ -1664,12 +1652,11 @@ class InferenceClient:
         SummarizationOutput(generated_text="The Eiffel tower is one of the most famous landmarks in the world....")
         ```
         """
-        if parameters is None:
-            parameters = {
-                "clean_up_tokenization_spaces": clean_up_tokenization_spaces,
-                "generate_parameters": generate_parameters,
-                "truncation": truncation,
-            }
+        parameters = {
+            "clean_up_tokenization_spaces": clean_up_tokenization_spaces,
+            "generate_parameters": generate_parameters,
+            "truncation": truncation,
+        }
         provider_helper = get_provider_helper(self.provider, task="summarization")
         request_parameters = provider_helper.prepare_request(
             inputs=text,

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -1664,19 +1664,10 @@ class AsyncInferenceClient:
         response = await self._inner_post(request_parameters)
         return _bytes_to_list(response)
 
-    @_deprecate_arguments(
-        version="0.29",
-        deprecated_args=["parameters"],
-        custom_message=(
-            "The `parameters` argument is deprecated and will be removed in a future version. "
-            "Provide individual parameters instead: `clean_up_tokenization_spaces`, `generate_parameters`, and `truncation`."
-        ),
-    )
     async def summarization(
         self,
         text: str,
         *,
-        parameters: Optional[Dict[str, Any]] = None,
         model: Optional[str] = None,
         clean_up_tokenization_spaces: Optional[bool] = None,
         generate_parameters: Optional[Dict[str, Any]] = None,
@@ -1688,9 +1679,6 @@ class AsyncInferenceClient:
         Args:
             text (`str`):
                 The input text to summarize.
-            parameters (`Dict[str, Any]`, *optional*):
-                Additional parameters for summarization. Check out this [page](https://huggingface.co/docs/api-inference/detailed_parameters#summarization-task)
-                for more details.
             model (`str`, *optional*):
                 The model to use for inference. Can be a model ID hosted on the Hugging Face Hub or a URL to a deployed
                 Inference Endpoint. If not provided, the default recommended model for summarization will be used.
@@ -1718,12 +1706,11 @@ class AsyncInferenceClient:
         SummarizationOutput(generated_text="The Eiffel tower is one of the most famous landmarks in the world....")
         ```
         """
-        if parameters is None:
-            parameters = {
-                "clean_up_tokenization_spaces": clean_up_tokenization_spaces,
-                "generate_parameters": generate_parameters,
-                "truncation": truncation,
-            }
+        parameters = {
+            "clean_up_tokenization_spaces": clean_up_tokenization_spaces,
+            "generate_parameters": generate_parameters,
+            "truncation": truncation,
+        }
         provider_helper = get_provider_helper(self.provider, task="summarization")
         request_parameters = provider_helper.prepare_request(
             inputs=text,

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -53,7 +53,6 @@ from .testing_utils import (
     DUMMY_RENAMED_NEW_MODEL_ID,
     DUMMY_RENAMED_OLD_MODEL_ID,
     SAMPLE_DATASET_IDENTIFIER,
-    expect_deprecation,
     repo_name,
     use_tmp_repo,
     with_production_testing,
@@ -143,7 +142,6 @@ class StagingDownloadTests(unittest.TestCase):
                     repo_id=repo_url.repo_id, filename=".gitattributes", token=OTHER_TOKEN, cache_dir=tmpdir
                 )
 
-    @expect_deprecation("update_repo_visibility")
     @use_tmp_repo()
     def test_download_regular_file_from_private_renamed_repo(self, repo_url: RepoUrl) -> None:
         """Regression test for #1999.
@@ -154,7 +152,7 @@ class StagingDownloadTests(unittest.TestCase):
         repo_id_after = repo_url.repo_id + "_renamed"
 
         # Make private + rename + upload regular file
-        self._api.update_repo_visibility(repo_id_before, private=True)
+        self._api.update_repo_settings(repo_id_before, private=True)
         self._api.upload_file(repo_id=repo_id_before, path_in_repo="file.txt", path_or_fileobj=b"content")
         self._api.move_repo(repo_id_before, repo_id_after)
 

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -206,49 +206,13 @@ class HfApiEndpointsTest(HfApiCommonTest):
     def test_delete_repo_missing_ok(self) -> None:
         self._api.delete_repo("repo-that-does-not-exist", missing_ok=True)
 
-    @expect_deprecation("update_repo_visibility")
-    def test_create_update_and_delete_repo(self):
+    def test_update_repo_visibility(self):
         repo_id = self._api.create_repo(repo_id=repo_name()).repo_id
-        res = self._api.update_repo_visibility(repo_id=repo_id, private=True)
+        res = self._api.update_repo_settings(repo_id=repo_id, private=True)
         assert res["private"]
-        res = self._api.update_repo_visibility(repo_id=repo_id, private=False)
+        res = self._api.update_repo_settings(repo_id=repo_id, private=False)
         assert not res["private"]
         self._api.delete_repo(repo_id=repo_id)
-
-    @expect_deprecation("update_repo_visibility")
-    def test_create_update_and_delete_model_repo(self):
-        repo_id = self._api.create_repo(repo_id=repo_name(), repo_type=constants.REPO_TYPE_MODEL).repo_id
-        res = self._api.update_repo_visibility(repo_id=repo_id, private=True, repo_type=constants.REPO_TYPE_MODEL)
-        assert res["private"]
-        res = self._api.update_repo_visibility(repo_id=repo_id, private=False, repo_type=constants.REPO_TYPE_MODEL)
-        assert not res["private"]
-        self._api.delete_repo(repo_id=repo_id, repo_type=constants.REPO_TYPE_MODEL)
-
-    @expect_deprecation("update_repo_visibility")
-    def test_create_update_and_delete_dataset_repo(self):
-        repo_id = self._api.create_repo(repo_id=repo_name(), repo_type=constants.REPO_TYPE_DATASET).repo_id
-        res = self._api.update_repo_visibility(repo_id=repo_id, private=True, repo_type=constants.REPO_TYPE_DATASET)
-        assert res["private"]
-        res = self._api.update_repo_visibility(repo_id=repo_id, private=False, repo_type=constants.REPO_TYPE_DATASET)
-        assert not res["private"]
-        self._api.delete_repo(repo_id=repo_id, repo_type=constants.REPO_TYPE_DATASET)
-
-    @expect_deprecation("update_repo_visibility")
-    def test_create_update_and_delete_space_repo(self):
-        with pytest.raises(ValueError, match=r"No space_sdk provided.*"):
-            self._api.create_repo(repo_id=repo_name(), repo_type=constants.REPO_TYPE_SPACE, space_sdk=None)
-        with pytest.raises(ValueError, match=r"Invalid space_sdk.*"):
-            self._api.create_repo(repo_id=repo_name(), repo_type=constants.REPO_TYPE_SPACE, space_sdk="something")
-
-        for sdk in constants.SPACES_SDK_TYPES:
-            repo_id = self._api.create_repo(
-                repo_id=repo_name(), repo_type=constants.REPO_TYPE_SPACE, space_sdk=sdk
-            ).repo_id
-            res = self._api.update_repo_visibility(repo_id=repo_id, private=True, repo_type=constants.REPO_TYPE_SPACE)
-            assert res["private"]
-            res = self._api.update_repo_visibility(repo_id=repo_id, private=False, repo_type=constants.REPO_TYPE_SPACE)
-            assert not res["private"]
-            self._api.delete_repo(repo_id=repo_id, repo_type=constants.REPO_TYPE_SPACE)
 
     def test_move_repo_normal_usage(self):
         repo_id = f"{USER}/{repo_name()}"

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -208,10 +208,13 @@ class HfApiEndpointsTest(HfApiCommonTest):
 
     def test_update_repo_visibility(self):
         repo_id = self._api.create_repo(repo_id=repo_name()).repo_id
-        res = self._api.update_repo_settings(repo_id=repo_id, private=True)
-        assert res["private"]
-        res = self._api.update_repo_settings(repo_id=repo_id, private=False)
-        assert not res["private"]
+
+        self._api.update_repo_settings(repo_id=repo_id, private=True)
+        assert self._api.model_info(repo_id).private
+
+        self._api.update_repo_settings(repo_id=repo_id, private=False)
+        assert not self._api.model_info(repo_id).private
+
         self._api.delete_repo(repo_id=repo_id)
 
     def test_move_repo_normal_usage(self):

--- a/tests/test_snapshot_download.py
+++ b/tests/test_snapshot_download.py
@@ -8,7 +8,7 @@ from huggingface_hub.errors import LocalEntryNotFoundError, RepositoryNotFoundEr
 from huggingface_hub.utils import SoftTemporaryDirectory
 
 from .testing_constants import TOKEN
-from .testing_utils import OfflineSimulationMode, expect_deprecation, offline, repo_name
+from .testing_utils import OfflineSimulationMode, offline, repo_name
 
 
 class SnapshotDownloadTests(unittest.TestCase):
@@ -95,9 +95,8 @@ class SnapshotDownloadTests(unittest.TestCase):
             # folder name contains the revision's commit sha.
             self.assertTrue(self.first_commit_hash in storage_folder)
 
-    @expect_deprecation("update_repo_visibility")
     def test_download_private_model(self):
-        self.api.update_repo_visibility(repo_id=self.repo_id, private=True)
+        self.api.update_repo_settings(repo_id=self.repo_id, private=True)
 
         # Test download fails without token
         with SoftTemporaryDirectory() as tmpdir:
@@ -115,7 +114,7 @@ class SnapshotDownloadTests(unittest.TestCase):
             storage_folder = snapshot_download(self.repo_id, revision="main", cache_dir=tmpdir, token=TOKEN)
             self.assertTrue(self.second_commit_hash in storage_folder)
 
-        self.api.update_repo_visibility(repo_id=self.repo_id, private=False)
+        self.api.update_repo_settings(repo_id=self.repo_id, private=False)
 
     def test_download_model_local_only(self):
         # Test no branch specified


### PR DESCRIPTION
Follow-up after https://github.com/huggingface/huggingface_hub/releases/tag/v0.28.0

`update_repo_visibility` was supposed to be removed but I post-poned the complete removal as it is still documented in hub-docs and used in transformers tests (:shrug:)