### PR TITLE
Default to `base_url` if provided

### DIFF
--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -179,7 +179,7 @@ class AsyncInferenceClient:
                 " It has the exact same behavior as `token`."
             )
 
-        self.model: Optional[str] = model
+        self.model: Optional[str] = base_url or model
         self.token: Optional[str] = token if token is not None else api_key
         self.headers = headers if headers is not None else {}
 
@@ -190,9 +190,6 @@ class AsyncInferenceClient:
         self.timeout = timeout
         self.trust_env = trust_env
         self.proxies = proxies
-
-        # OpenAI compatibility
-        self.base_url = base_url
 
         # Keep track of the sessions to close them properly
         self._sessions: Dict["ClientSession", Set["ClientResponse"]] = dict()
@@ -977,9 +974,9 @@ class AsyncInferenceClient:
         provider_helper = get_provider_helper(self.provider, task="conversational")
 
         # Since `chat_completion(..., model=xxx)` is also a payload parameter for the server, we need to handle 'model' differently.
-        # `self.base_url` and `self.model` takes precedence over 'model' argument for building URL.
+        # `self.model` takes precedence over 'model' argument for building URL.
         # `model` takes precedence for payload value.
-        model_id_or_url = self.base_url or self.model or model
+        model_id_or_url = self.model or model
         payload_model = model or self.model
 
         # Prepare the payload

--- a/tests/test_inference_client.py
+++ b/tests/test_inference_client.py
@@ -1186,3 +1186,12 @@ LOCAL_TGI_URL = "http://0.0.0.0:8080"
 def test_resolve_chat_completion_url(model_url: str, expected_url: str):
     url = _build_chat_completion_url(model_url)
     assert url == expected_url
+
+
+def test_pass_url_as_base_url():
+    client = InferenceClient(base_url="http://localhost:8082/v1/")
+    provider = get_provider_helper("hf-inference", "text-generation")
+    request = provider.prepare_request(
+        inputs="The huggingface_hub library is ", parameters={}, headers={}, model=client.model, api_key=None
+    )
+    assert request.url == "http://localhost:8082/v1/"


### PR DESCRIPTION
Fix https://github.com/huggingface/huggingface_hub/issues/2804.

`base_url` was first introduced to match OpenAI chat completion API. It has the exact same behavior as `self.model` when using `client.chat_completion`. However, since it's a public parameter also for other tasks, I do think it makes sense to use it if provided. The problem in https://github.com/huggingface/huggingface_hub/issues/2804 was that user provided a URL as `base_url` and expected it to be used in `text_generation` (which seems fair) but wasn't. Therefore it defaults to Inference API with default model which in not intended. This small PR should prevent this. 

---
Not related at all but I took the opportunity to rephrase a bit the error raised in case of a 422 unprocessable entity. Usually the response body provides information about what's missing/not valid. Let's add it to the error message as a string.