### PR TITLE
fix(#2806): revert use of urljoin for HF_ENDPOINT paths

### DIFF
--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -2,7 +2,6 @@ import os
 import re
 import typing
 from typing import Literal, Optional, Tuple
-from urllib.parse import urljoin
 
 
 # Possible values for env variables
@@ -68,7 +67,7 @@ ENDPOINT = os.getenv("HF_ENDPOINT", "").rstrip("/") or (
     _HF_DEFAULT_STAGING_ENDPOINT if _staging_mode else _HF_DEFAULT_ENDPOINT
 )
 
-HUGGINGFACE_CO_URL_TEMPLATE = urljoin(ENDPOINT, "/{repo_id}/resolve/{revision}/{filename}")
+HUGGINGFACE_CO_URL_TEMPLATE = ENDPOINT + "/{repo_id}/resolve/{revision}/{filename}"
 HUGGINGFACE_HEADER_X_REPO_COMMIT = "X-Repo-Commit"
 HUGGINGFACE_HEADER_X_LINKED_ETAG = "X-Linked-Etag"
 HUGGINGFACE_HEADER_X_LINKED_SIZE = "X-Linked-Size"
@@ -79,7 +78,7 @@ INFERENCE_ENDPOINT = os.environ.get("HF_INFERENCE_ENDPOINT", "https://api-infere
 INFERENCE_ENDPOINTS_ENDPOINT = "https://api.endpoints.huggingface.cloud/v2"
 
 # Proxy for third-party providers
-INFERENCE_PROXY_TEMPLATE = urljoin(ENDPOINT, "/api/inference-proxy/{provider}")
+INFERENCE_PROXY_TEMPLATE = ENDPOINT + "/api/inference-proxy/{provider}"
 
 REPO_ID_SEPARATOR = "--"
 # ^ this substring is not allowed in repo_ids on hf.co


### PR DESCRIPTION
Revert the use of `urljoin` to join `HF_ENDPOINT` and path. 

fixes #2806