### PR TITLE
Do not send staging token to production

### DIFF
--- a/tests/test_cache_no_symlinks.py
+++ b/tests/test_cache_no_symlinks.py
@@ -9,7 +9,6 @@ from huggingface_hub import hf_hub_download, scan_cache_dir
 from huggingface_hub.constants import CONFIG_NAME, HF_HUB_CACHE
 from huggingface_hub.file_download import are_symlinks_supported
 
-from .testing_constants import TOKEN
 from .testing_utils import DUMMY_MODEL_ID, with_production_testing
 
 
@@ -55,7 +54,6 @@ class TestCacheLayoutIfSymlinksNotSupported(unittest.TestCase):
                 filename=CONFIG_NAME,
                 cache_dir=self.cache_dir,
                 local_files_only=False,
-                use_auth_token=TOKEN,
             )
         )
         # Not a symlink !
@@ -74,7 +72,6 @@ class TestCacheLayoutIfSymlinksNotSupported(unittest.TestCase):
                 filename=CONFIG_NAME,
                 cache_dir=self.cache_dir,
                 local_files_only=False,
-                use_auth_token=TOKEN,
             )
         )
         self.assertTrue(filepath.is_symlink())
@@ -92,7 +89,6 @@ class TestCacheLayoutIfSymlinksNotSupported(unittest.TestCase):
                 filename=CONFIG_NAME,
                 cache_dir=self.cache_dir,
                 local_files_only=False,
-                use_auth_token=TOKEN,
             )
         )
         # File exist but is not a symlink
@@ -116,7 +112,6 @@ class TestCacheLayoutIfSymlinksNotSupported(unittest.TestCase):
             DUMMY_MODEL_ID,
             filename=CONFIG_NAME,
             cache_dir=self.cache_dir,
-            use_auth_token=TOKEN,
         )
 
         # Download README.md from main
@@ -124,7 +119,6 @@ class TestCacheLayoutIfSymlinksNotSupported(unittest.TestCase):
             DUMMY_MODEL_ID,
             filename="README.md",
             cache_dir=self.cache_dir,
-            use_auth_token=TOKEN,
         )
 
         # Download config.json from older revision
@@ -132,7 +126,6 @@ class TestCacheLayoutIfSymlinksNotSupported(unittest.TestCase):
             DUMMY_MODEL_ID,
             filename=CONFIG_NAME,
             cache_dir=self.cache_dir,
-            use_auth_token=TOKEN,
             revision=OLDER_REVISION,
         )
 
@@ -144,7 +137,6 @@ class TestCacheLayoutIfSymlinksNotSupported(unittest.TestCase):
             DUMMY_MODEL_ID,
             filename="merges.txt",
             cache_dir=self.cache_dir,
-            use_auth_token=TOKEN,
             revision=OLDER_REVISION,
         )
 

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -191,18 +191,18 @@ class CachedDownloadTests(unittest.TestCase):
                 )
 
     def test_private_repo_and_file_cached_locally(self):
-        api = HfApi(endpoint=ENDPOINT_STAGING, token=TOKEN)
-        repo_id = api.create_repo(repo_id=repo_name(), private=True).repo_id
-        api.upload_file(path_or_fileobj=b"content", path_in_repo=constants.CONFIG_NAME, repo_id=repo_id)
+        api = HfApi(endpoint=ENDPOINT_STAGING)
+        repo_id = api.create_repo(repo_id=repo_name(), private=True, token=TOKEN).repo_id
+        api.upload_file(path_or_fileobj=b"content", path_in_repo="config.json", repo_id=repo_id, token=TOKEN)
 
         with SoftTemporaryDirectory() as tmpdir:
             # Download a first time with token => file is cached
-            filepath_1 = hf_hub_download(DUMMY_MODEL_ID, filename=constants.CONFIG_NAME, cache_dir=tmpdir, token=TOKEN)
+            filepath_1 = api.hf_hub_download(repo_id, filename="config.json", cache_dir=tmpdir, token=TOKEN)
 
             # Download without token => return cached file
-            filepath_2 = hf_hub_download(DUMMY_MODEL_ID, filename=constants.CONFIG_NAME, cache_dir=tmpdir)
+            filepath_2 = api.hf_hub_download(repo_id, filename="config.json", cache_dir=tmpdir, token=False)
 
-            self.assertEqual(filepath_1, filepath_2)
+            assert filepath_1 == filepath_2
 
     def test_file_cached_and_read_only_access(self):
         """Should works if file is already cached and user has read-only permission.

--- a/tests/test_utils_cache.py
+++ b/tests/test_utils_cache.py
@@ -64,48 +64,19 @@ class TestValidCacheUtils(unittest.TestCase):
     def setUp(self) -> None:
         """Setup a clean cache for tests that will remain valid in all tests."""
         # Download latest main
-        snapshot_download(
-            repo_id=MODEL_ID,
-            repo_type="model",
-            cache_dir=self.cache_dir,
-            use_auth_token=TOKEN,
-        )
+        snapshot_download(repo_id=MODEL_ID, repo_type="model", cache_dir=self.cache_dir)
 
         # Download latest commit which is same as `main`
-        snapshot_download(
-            repo_id=MODEL_ID,
-            revision=REPO_A_MAIN_HASH,
-            repo_type="model",
-            cache_dir=self.cache_dir,
-            use_auth_token=TOKEN,
-        )
+        snapshot_download(repo_id=MODEL_ID, revision=REPO_A_MAIN_HASH, repo_type="model", cache_dir=self.cache_dir)
 
         # Download the first commit
-        snapshot_download(
-            repo_id=MODEL_ID,
-            revision=REPO_A_OTHER_HASH,
-            repo_type="model",
-            cache_dir=self.cache_dir,
-            use_auth_token=TOKEN,
-        )
+        snapshot_download(repo_id=MODEL_ID, revision=REPO_A_OTHER_HASH, repo_type="model", cache_dir=self.cache_dir)
 
         # Download from a PR
-        snapshot_download(
-            repo_id=MODEL_ID,
-            revision="refs/pr/1",
-            repo_type="model",
-            cache_dir=self.cache_dir,
-            use_auth_token=TOKEN,
-        )
+        snapshot_download(repo_id=MODEL_ID, revision="refs/pr/1", repo_type="model", cache_dir=self.cache_dir)
 
         # Download a Dataset repo from "main"
-        snapshot_download(
-            repo_id=DATASET_ID,
-            revision="main",
-            repo_type="dataset",
-            cache_dir=self.cache_dir,
-            use_auth_token=TOKEN,
-        )
+        snapshot_download(repo_id=DATASET_ID, revision="main", repo_type="dataset", cache_dir=self.cache_dir)
 
     @unittest.skipIf(os.name == "nt", "Windows cache is tested separately")
     def test_scan_cache_on_valid_cache_unix(self) -> None:
@@ -357,12 +328,7 @@ class TestCorruptedCacheUtils(unittest.TestCase):
     def setUp(self) -> None:
         """Setup a clean cache for tests that will get corrupted/modified in tests."""
         # Download latest main
-        snapshot_download(
-            repo_id=MODEL_ID,
-            repo_type="model",
-            cache_dir=self.cache_dir,
-            use_auth_token=TOKEN,
-        )
+        snapshot_download(repo_id=MODEL_ID, repo_type="model", cache_dir=self.cache_dir)
 
         self.repo_path = self.cache_dir / MODEL_PATH
         self.refs_path = self.repo_path / "refs"

--- a/tests/test_utils_cache.py
+++ b/tests/test_utils_cache.py
@@ -17,7 +17,6 @@ from huggingface_hub.utils._cache_manager import (
     _try_delete_path,
 )
 
-from .testing_constants import TOKEN
 from .testing_utils import (
     rmtree_with_retry,
     with_production_testing,


### PR DESCRIPTION
Looks like we are sending the staging token to production quite often in our tests. Wasn't a problem until recently but now invalid tokens are unauthorized even when trying to access a public repo. Let's make sure we don't do this anymore.

(still some tests to fix)

**EDIT:** all good