### PR TITLE
Add `HF_DEBUG` environment variable for debugging/reproducibility

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -24,7 +24,7 @@ body:
     id: logs
     attributes:
       label: Logs
-      description: "Please include the Python logs if you can."
+      description: "Please include the Python logs if you can. If possible, run the code with `HF_DEBUG=1` as environment variable."
       render: shell
   - type: textarea
     id: system-info

--- a/docs/source/en/package_reference/environment_variables.md
+++ b/docs/source/en/package_reference/environment_variables.md
@@ -83,6 +83,10 @@ The following environment variables expect a boolean value. The variable will be
 as `True` if its value is one of `{"1", "ON", "YES", "TRUE"}` (case-insensitive). Any other value
 (or undefined) will be considered as `False`.
 
+### HF_DEBUG
+
+If set, the log level for the `huggingface_hub` logger is set to DEBUG. Additionally, all requests made by HF libraries will be logged as equivalent cURL commands for easier debugging and reproducibility.
+
 ### HF_HUB_OFFLINE
 
 If set, no HTTP calls will be made to the Hugging Face Hub. If you try to download files, only the cached files will be accessed. If no cache file is detected, an error is raised This is useful in case your network is slow and you don't care about having the latest version of a file.
@@ -159,11 +163,11 @@ Please note that using `hf_transfer` comes with certain limitations. Since it is
 In order to standardize all environment variables within the Hugging Face ecosystem, some variables have been marked as deprecated. Although they remain functional, they no longer take precedence over their replacements. The following table outlines the deprecated variables and their corresponding alternatives:
 
 
-| Deprecated Variable | Replacement |
-| --- | --- |
-| `HUGGINGFACE_HUB_CACHE` | `HF_HUB_CACHE` |
-| `HUGGINGFACE_ASSETS_CACHE` | `HF_ASSETS_CACHE` |
-| `HUGGING_FACE_HUB_TOKEN` | `HF_TOKEN` |
+| Deprecated Variable         | Replacement        |
+| --------------------------- | ------------------ |
+| `HUGGINGFACE_HUB_CACHE`     | `HF_HUB_CACHE`     |
+| `HUGGINGFACE_ASSETS_CACHE`  | `HF_ASSETS_CACHE`  |
+| `HUGGING_FACE_HUB_TOKEN`    | `HF_TOKEN`         |
 | `HUGGINGFACE_HUB_VERBOSITY` | `HF_HUB_VERBOSITY` |
 
 ## From external tools

--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -132,6 +132,10 @@ HF_ASSETS_CACHE = os.getenv("HF_ASSETS_CACHE", HUGGINGFACE_ASSETS_CACHE)
 
 HF_HUB_OFFLINE = _is_true(os.environ.get("HF_HUB_OFFLINE") or os.environ.get("TRANSFORMERS_OFFLINE"))
 
+# If set, log level will be set to DEBUG and all requests made to the Hub will be logged
+# as curl commands for reproducibility.
+HF_DEBUG = _is_true(os.environ.get("HF_DEBUG"))
+
 # Opt-out from telemetry requests
 HF_HUB_DISABLE_TELEMETRY = (
     _is_true(os.environ.get("HF_HUB_DISABLE_TELEMETRY"))  # HF-specific env variable

--- a/src/huggingface_hub/utils/_http.py
+++ b/src/huggingface_hub/utils/_http.py
@@ -23,7 +23,7 @@ import uuid
 from functools import lru_cache
 from http import HTTPStatus
 from shlex import quote
-from typing import Callable, Optional, Tuple, Type, Union
+from typing import Any, Callable, List, Optional, Tuple, Type, Union
 
 import requests
 from requests import HTTPError, Response
@@ -562,7 +562,7 @@ def _curlify(request: requests.PreparedRequest) -> str:
     Implementation vendored from https://github.com/ofw/curlify/blob/master/curlify.py.
     MIT License Copyright (c) 2016 Egor.
     """
-    parts = [
+    parts: List[Tuple[Any, Any]] = [
         ("curl", None),
         ("-X", request.method),
     ]

--- a/src/huggingface_hub/utils/logging.py
+++ b/src/huggingface_hub/utils/logging.py
@@ -28,6 +28,8 @@ from logging import (
 )
 from typing import Optional
 
+from .. import constants
+
 
 log_levels = {
     "debug": logging.DEBUG,
@@ -180,3 +182,7 @@ def enable_propagation() -> None:
 
 
 _configure_library_root_logger()
+
+if constants.HF_DEBUG:
+    # If `HF_DEBUG` environment variable is set, set the verbosity of `huggingface_hub` logger to `DEBUG`.
+    set_verbosity_debug()


### PR DESCRIPTION
I got bored of putting breakpoints to understand which requests have been sent :grimacing: :rage: 

What this PR does:
- adds a new `HF_DEBUG` environment variable
- when `HF_DEBUG=1`, `huggingface_hub` logger is set to debug level
- when `HF_DEBUG=1`,  all requests made by the lib are logged as curl commands
- update package reference + bug report template

**Example:**

```py
# script.py
from huggingface_hub import InferenceClient

client = InferenceClient(model="black-forest-labs/FLUX.1-dev", provider="fal-ai")
image = client.text_to_image("An astronaut riding a unicorn in space.")
image.save("astronaut_unicorn.png")
```

```sh
➜  HF_DEBUG=1 python script.py
Calling fal.ai provider through Hugging Face proxy.
Send: curl -X POST -H 'Accept: image/png' -H 'Accept-Encoding: gzip, deflate, br' -H 'Connection: keep-alive' -H 'Content-Length: 53' -H 'Content-Type: application/json' -H 'authorization: <TOKEN>' -H 'user-agent: unknown/None; hf_hub/0.29.0.dev0; python/3.10.12; torch/2.5.1; tensorflow/2.15.1; fastcore/1.5.23' -d '{"prompt": "An astronaut riding a unicorn in space."}' https://huggingface.co/api/inference-proxy/fal-ai/fal-ai/flux/dev
Request eff0b231-fadc-4ae4-b0ae-4dcdbe1ba68a: POST https://huggingface.co/api/inference-proxy/fal-ai/fal-ai/flux/dev (authenticated: True)
Send: curl -X GET -H 'Accept: */*' -H 'Accept-Encoding: gzip, deflate, br' -H 'Connection: keep-alive' -H 'User-Agent: python-requests/2.32.3' https://v3.fal.media/files/elephant/HcgQwILjGT7UktnuNDhNb.png
Request aaaa482a-6066-4f0b-9dc2-110beddad1c2: GET https://v3.fal.media/files/elephant/HcgQwILjGT7UktnuNDhNb.png (authenticated: False)
```