### PR TITLE
[InferenceClient] Renaming `extra_parameters` to `extra_body` 

### DIFF
--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -617,7 +617,7 @@ class InferenceClient:
         </Tip>
 
         <Tip>
-        You can pass provider-specific parameters to the model by using the `extra_body` parameter.
+        You can pass provider-specific parameters to the model by using the `extra_body` argument.
         </Tip>
 
         Args:
@@ -2410,7 +2410,7 @@ class InferenceClient:
         </Tip>
 
         <Tip>
-        You can pass provider-specific parameters to the model by using the `extra_body` parameter.
+        You can pass provider-specific parameters to the model by using the `extra_body` argument.
         </Tip>
 
         Args:
@@ -2544,7 +2544,7 @@ class InferenceClient:
         Generate a video based on a given text.
 
         <Tip>
-        You can pass provider-specific parameters to the model by using the `extra_body` parameter.
+        You can pass provider-specific parameters to the model by using the `extra_body` argument.
         </Tip>
 
         Args:
@@ -2651,7 +2651,7 @@ class InferenceClient:
         Synthesize an audio of a voice pronouncing a given text.
 
         <Tip>
-        You can pass provider-specific parameters to the model by using the `extra_body` parameter.
+        You can pass provider-specific parameters to the model by using the `extra_body` argument.
         </Tip>
 
         Args:

--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -524,6 +524,7 @@ class InferenceClient:
         tools: Optional[List[ChatCompletionInputTool]] = None,
         top_logprobs: Optional[int] = None,
         top_p: Optional[float] = None,
+        extra_body: Optional[Dict] = None,
     ) -> ChatCompletionOutput: ...
 
     @overload
@@ -549,6 +550,7 @@ class InferenceClient:
         tools: Optional[List[ChatCompletionInputTool]] = None,
         top_logprobs: Optional[int] = None,
         top_p: Optional[float] = None,
+        extra_body: Optional[Dict] = None,
     ) -> Iterable[ChatCompletionStreamOutput]: ...
 
     @overload
@@ -574,6 +576,7 @@ class InferenceClient:
         tools: Optional[List[ChatCompletionInputTool]] = None,
         top_logprobs: Optional[int] = None,
         top_p: Optional[float] = None,
+        extra_body: Optional[Dict] = None,
     ) -> Union[ChatCompletionOutput, Iterable[ChatCompletionStreamOutput]]: ...
 
     def chat_completion(
@@ -599,6 +602,7 @@ class InferenceClient:
         tools: Optional[List[ChatCompletionInputTool]] = None,
         top_logprobs: Optional[int] = None,
         top_p: Optional[float] = None,
+        extra_body: Optional[Dict] = None,
     ) -> Union[ChatCompletionOutput, Iterable[ChatCompletionStreamOutput]]:
         """
         A method for completing conversations using a specified language model.
@@ -613,7 +617,7 @@ class InferenceClient:
         </Tip>
 
         <Tip>
-        Some parameters might not be supported by some providers.
+        You can pass provider-specific parameters to the model by using the `extra_body` parameter.
         </Tip>
 
         Args:
@@ -668,7 +672,9 @@ class InferenceClient:
             tools (List of [`ChatCompletionInputTool`], *optional*):
                 A list of tools the model may call. Currently, only functions are supported as a tool. Use this to
                 provide a list of functions the model may generate JSON inputs for.
-
+            extra_body (`Dict`, *optional*):
+                Additional provider-specific parameters to pass to the model. Refer to the provider's documentation
+                for supported parameters.
         Returns:
             [`ChatCompletionOutput`] or Iterable of [`ChatCompletionStreamOutput`]:
             Generated text returned from the server:
@@ -753,7 +759,7 @@ class InferenceClient:
             print(chunk.choices[0].delta.content)
         ```
 
-        Example using a third-party provider directly. Usage will be billed on your Together AI account.
+        Example using a third-party provider directly with extra (provider-specific) parameters. Usage will be billed on your Together AI account.
         ```py
         >>> from huggingface_hub import InferenceClient
         >>> client = InferenceClient(
@@ -763,6 +769,7 @@ class InferenceClient:
         >>> client.chat_completion(
         ...     model="meta-llama/Meta-Llama-3-8B-Instruct",
         ...     messages=[{"role": "user", "content": "What is the capital of France?"}],
+        ...     extra_body={"safety_model": "Meta-Llama/Llama-Guard-7b"},
         ... )
         ```
 
@@ -956,6 +963,7 @@ class InferenceClient:
             "top_p": top_p,
             "stream": stream,
             "stream_options": stream_options,
+            **(extra_body or {}),
         }
         request_parameters = provider_helper.prepare_request(
             inputs=messages,
@@ -2401,6 +2409,10 @@ class InferenceClient:
 
         </Tip>
 
+        <Tip>
+        You can pass provider-specific parameters to the model by using the `extra_body` parameter.
+        </Tip>
+
         Args:
             prompt (`str`):
                 The prompt to generate an image from.
@@ -2531,6 +2543,10 @@ class InferenceClient:
         """
         Generate a video based on a given text.
 
+        <Tip>
+        You can pass provider-specific parameters to the model by using the `extra_body` parameter.
+        </Tip>
+
         Args:
             prompt (`str`):
                 The prompt to generate a video from.
@@ -2633,6 +2649,10 @@ class InferenceClient:
     ) -> bytes:
         """
         Synthesize an audio of a voice pronouncing a given text.
+
+        <Tip>
+        You can pass provider-specific parameters to the model by using the `extra_body` parameter.
+        </Tip>
 
         Args:
             text (`str`):

--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -2390,7 +2390,7 @@ class InferenceClient:
         model: Optional[str] = None,
         scheduler: Optional[str] = None,
         seed: Optional[int] = None,
-        extra_parameters: Optional[Dict[str, Any]] = None,
+        extra_body: Optional[Dict[str, Any]] = None,
     ) -> "Image":
         """
         Generate an image based on a given text using a specified model.
@@ -2424,7 +2424,7 @@ class InferenceClient:
                 Override the scheduler with a compatible one.
             seed (`int`, *optional*):
                 Seed for the random number generator.
-            extra_parameters (`Dict[str, Any]`, *optional*):
+            extra_body (`Dict[str, Any]`, *optional*):
                 Additional provider-specific parameters to pass to the model. Refer to the provider's documentation
                 for supported parameters.
 
@@ -2490,7 +2490,7 @@ class InferenceClient:
         >>> image = client.text_to_image(
         ...     "An astronaut riding a horse on the moon.",
         ...     model="black-forest-labs/FLUX.1-schnell",
-        ...     extra_parameters={"output_quality": 100},
+        ...     extra_body={"output_quality": 100},
         ... )
         >>> image.save("astronaut.png")
         ```
@@ -2506,7 +2506,7 @@ class InferenceClient:
                 "guidance_scale": guidance_scale,
                 "scheduler": scheduler,
                 "seed": seed,
-                **(extra_parameters or {}),
+                **(extra_body or {}),
             },
             headers=self.headers,
             model=model or self.model,
@@ -2526,7 +2526,7 @@ class InferenceClient:
         num_frames: Optional[float] = None,
         num_inference_steps: Optional[int] = None,
         seed: Optional[int] = None,
-        extra_parameters: Optional[Dict[str, Any]] = None,
+        extra_body: Optional[Dict[str, Any]] = None,
     ) -> bytes:
         """
         Generate a video based on a given text.
@@ -2550,7 +2550,7 @@ class InferenceClient:
                 expense of slower inference.
             seed (`int`, *optional*):
                 Seed for the random number generator.
-            extra_parameters (`Dict[str, Any]`, *optional*):
+            extra_body (`Dict[str, Any]`, *optional*):
                 Additional provider-specific parameters to pass to the model. Refer to the provider's documentation
                 for supported parameters.
 
@@ -2598,7 +2598,7 @@ class InferenceClient:
                 "num_frames": num_frames,
                 "num_inference_steps": num_inference_steps,
                 "seed": seed,
-                **(extra_parameters or {}),
+                **(extra_body or {}),
             },
             headers=self.headers,
             model=model or self.model,
@@ -2629,7 +2629,7 @@ class InferenceClient:
         top_p: Optional[float] = None,
         typical_p: Optional[float] = None,
         use_cache: Optional[bool] = None,
-        extra_parameters: Optional[Dict[str, Any]] = None,
+        extra_body: Optional[Dict[str, Any]] = None,
     ) -> bytes:
         """
         Synthesize an audio of a voice pronouncing a given text.
@@ -2687,7 +2687,7 @@ class InferenceClient:
                 paper](https://hf.co/papers/2202.00666) for more details.
             use_cache (`bool`, *optional*):
                 Whether the model should use the past last key/values attentions to speed up decoding
-            extra_parameters (`Dict[str, Any]`, *optional*):
+            extra_body (`Dict[str, Any]`, *optional*):
                 Additional provider-specific parameters to pass to the model. Refer to the provider's documentation
                 for supported parameters.
         Returns:
@@ -2746,7 +2746,7 @@ class InferenceClient:
         >>> audio = client.text_to_speech(
         ...     "Hello, my name is Kororo, an awesome text-to-speech model.",
         ...     model="hexgrad/Kokoro-82M",
-        ...     extra_parameters={"voice": "af_nicole"},
+        ...     extra_body={"voice": "af_nicole"},
         ... )
         >>> Path("hello.flac").write_bytes(audio)
         ```
@@ -2777,7 +2777,7 @@ class InferenceClient:
         ...     model="m-a-p/YuE-s1-7B-anneal-en-cot",
         ...     api_key=...,
         ... )
-        >>> audio = client.text_to_speech(lyrics, extra_parameters={"genres": genres})
+        >>> audio = client.text_to_speech(lyrics, extra_body={"genres": genres})
         >>> with open("output.mp3", "wb") as f:
         ...     f.write(audio)
         ```
@@ -2802,7 +2802,7 @@ class InferenceClient:
                 "top_p": top_p,
                 "typical_p": typical_p,
                 "use_cache": use_cache,
-                **(extra_parameters or {}),
+                **(extra_body or {}),
             },
             headers=self.headers,
             model=model or self.model,

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -558,6 +558,7 @@ class AsyncInferenceClient:
         tools: Optional[List[ChatCompletionInputTool]] = None,
         top_logprobs: Optional[int] = None,
         top_p: Optional[float] = None,
+        extra_body: Optional[Dict] = None,
     ) -> ChatCompletionOutput: ...
 
     @overload
@@ -583,6 +584,7 @@ class AsyncInferenceClient:
         tools: Optional[List[ChatCompletionInputTool]] = None,
         top_logprobs: Optional[int] = None,
         top_p: Optional[float] = None,
+        extra_body: Optional[Dict] = None,
     ) -> AsyncIterable[ChatCompletionStreamOutput]: ...
 
     @overload
@@ -608,6 +610,7 @@ class AsyncInferenceClient:
         tools: Optional[List[ChatCompletionInputTool]] = None,
         top_logprobs: Optional[int] = None,
         top_p: Optional[float] = None,
+        extra_body: Optional[Dict] = None,
     ) -> Union[ChatCompletionOutput, AsyncIterable[ChatCompletionStreamOutput]]: ...
 
     async def chat_completion(
@@ -633,6 +636,7 @@ class AsyncInferenceClient:
         tools: Optional[List[ChatCompletionInputTool]] = None,
         top_logprobs: Optional[int] = None,
         top_p: Optional[float] = None,
+        extra_body: Optional[Dict] = None,
     ) -> Union[ChatCompletionOutput, AsyncIterable[ChatCompletionStreamOutput]]:
         """
         A method for completing conversations using a specified language model.
@@ -647,7 +651,7 @@ class AsyncInferenceClient:
         </Tip>
 
         <Tip>
-        Some parameters might not be supported by some providers.
+        You can pass provider-specific parameters to the model by using the `extra_body` parameter.
         </Tip>
 
         Args:
@@ -702,7 +706,9 @@ class AsyncInferenceClient:
             tools (List of [`ChatCompletionInputTool`], *optional*):
                 A list of tools the model may call. Currently, only functions are supported as a tool. Use this to
                 provide a list of functions the model may generate JSON inputs for.
-
+            extra_body (`Dict`, *optional*):
+                Additional provider-specific parameters to pass to the model. Refer to the provider's documentation
+                for supported parameters.
         Returns:
             [`ChatCompletionOutput`] or Iterable of [`ChatCompletionStreamOutput`]:
             Generated text returned from the server:
@@ -790,7 +796,7 @@ class AsyncInferenceClient:
             print(chunk.choices[0].delta.content)
         ```
 
-        Example using a third-party provider directly. Usage will be billed on your Together AI account.
+        Example using a third-party provider directly with extra (provider-specific) parameters. Usage will be billed on your Together AI account.
         ```py
         >>> from huggingface_hub import InferenceClient
         >>> client = InferenceClient(
@@ -800,6 +806,7 @@ class AsyncInferenceClient:
         >>> client.chat_completion(
         ...     model="meta-llama/Meta-Llama-3-8B-Instruct",
         ...     messages=[{"role": "user", "content": "What is the capital of France?"}],
+        ...     extra_body={"safety_model": "Meta-Llama/Llama-Guard-7b"},
         ... )
         ```
 
@@ -996,6 +1003,7 @@ class AsyncInferenceClient:
             "top_p": top_p,
             "stream": stream,
             "stream_options": stream_options,
+            **(extra_body or {}),
         }
         request_parameters = provider_helper.prepare_request(
             inputs=messages,
@@ -2457,6 +2465,10 @@ class AsyncInferenceClient:
 
         </Tip>
 
+        <Tip>
+        You can pass provider-specific parameters to the model by using the `extra_body` parameter.
+        </Tip>
+
         Args:
             prompt (`str`):
                 The prompt to generate an image from.
@@ -2588,6 +2600,10 @@ class AsyncInferenceClient:
         """
         Generate a video based on a given text.
 
+        <Tip>
+        You can pass provider-specific parameters to the model by using the `extra_body` parameter.
+        </Tip>
+
         Args:
             prompt (`str`):
                 The prompt to generate a video from.
@@ -2690,6 +2706,10 @@ class AsyncInferenceClient:
     ) -> bytes:
         """
         Synthesize an audio of a voice pronouncing a given text.
+
+        <Tip>
+        You can pass provider-specific parameters to the model by using the `extra_body` parameter.
+        </Tip>
 
         Args:
             text (`str`):

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -2446,7 +2446,7 @@ class AsyncInferenceClient:
         model: Optional[str] = None,
         scheduler: Optional[str] = None,
         seed: Optional[int] = None,
-        extra_parameters: Optional[Dict[str, Any]] = None,
+        extra_body: Optional[Dict[str, Any]] = None,
     ) -> "Image":
         """
         Generate an image based on a given text using a specified model.
@@ -2480,7 +2480,7 @@ class AsyncInferenceClient:
                 Override the scheduler with a compatible one.
             seed (`int`, *optional*):
                 Seed for the random number generator.
-            extra_parameters (`Dict[str, Any]`, *optional*):
+            extra_body (`Dict[str, Any]`, *optional*):
                 Additional provider-specific parameters to pass to the model. Refer to the provider's documentation
                 for supported parameters.
 
@@ -2547,7 +2547,7 @@ class AsyncInferenceClient:
         >>> image = client.text_to_image(
         ...     "An astronaut riding a horse on the moon.",
         ...     model="black-forest-labs/FLUX.1-schnell",
-        ...     extra_parameters={"output_quality": 100},
+        ...     extra_body={"output_quality": 100},
         ... )
         >>> image.save("astronaut.png")
         ```
@@ -2563,7 +2563,7 @@ class AsyncInferenceClient:
                 "guidance_scale": guidance_scale,
                 "scheduler": scheduler,
                 "seed": seed,
-                **(extra_parameters or {}),
+                **(extra_body or {}),
             },
             headers=self.headers,
             model=model or self.model,
@@ -2583,7 +2583,7 @@ class AsyncInferenceClient:
         num_frames: Optional[float] = None,
         num_inference_steps: Optional[int] = None,
         seed: Optional[int] = None,
-        extra_parameters: Optional[Dict[str, Any]] = None,
+        extra_body: Optional[Dict[str, Any]] = None,
     ) -> bytes:
         """
         Generate a video based on a given text.
@@ -2607,7 +2607,7 @@ class AsyncInferenceClient:
                 expense of slower inference.
             seed (`int`, *optional*):
                 Seed for the random number generator.
-            extra_parameters (`Dict[str, Any]`, *optional*):
+            extra_body (`Dict[str, Any]`, *optional*):
                 Additional provider-specific parameters to pass to the model. Refer to the provider's documentation
                 for supported parameters.
 
@@ -2655,7 +2655,7 @@ class AsyncInferenceClient:
                 "num_frames": num_frames,
                 "num_inference_steps": num_inference_steps,
                 "seed": seed,
-                **(extra_parameters or {}),
+                **(extra_body or {}),
             },
             headers=self.headers,
             model=model or self.model,
@@ -2686,7 +2686,7 @@ class AsyncInferenceClient:
         top_p: Optional[float] = None,
         typical_p: Optional[float] = None,
         use_cache: Optional[bool] = None,
-        extra_parameters: Optional[Dict[str, Any]] = None,
+        extra_body: Optional[Dict[str, Any]] = None,
     ) -> bytes:
         """
         Synthesize an audio of a voice pronouncing a given text.
@@ -2744,7 +2744,7 @@ class AsyncInferenceClient:
                 paper](https://hf.co/papers/2202.00666) for more details.
             use_cache (`bool`, *optional*):
                 Whether the model should use the past last key/values attentions to speed up decoding
-            extra_parameters (`Dict[str, Any]`, *optional*):
+            extra_body (`Dict[str, Any]`, *optional*):
                 Additional provider-specific parameters to pass to the model. Refer to the provider's documentation
                 for supported parameters.
         Returns:
@@ -2804,7 +2804,7 @@ class AsyncInferenceClient:
         >>> audio = client.text_to_speech(
         ...     "Hello, my name is Kororo, an awesome text-to-speech model.",
         ...     model="hexgrad/Kokoro-82M",
-        ...     extra_parameters={"voice": "af_nicole"},
+        ...     extra_body={"voice": "af_nicole"},
         ... )
         >>> Path("hello.flac").write_bytes(audio)
         ```
@@ -2835,7 +2835,7 @@ class AsyncInferenceClient:
         ...     model="m-a-p/YuE-s1-7B-anneal-en-cot",
         ...     api_key=...,
         ... )
-        >>> audio = client.text_to_speech(lyrics, extra_parameters={"genres": genres})
+        >>> audio = client.text_to_speech(lyrics, extra_body={"genres": genres})
         >>> with open("output.mp3", "wb") as f:
         ...     f.write(audio)
         ```
@@ -2860,7 +2860,7 @@ class AsyncInferenceClient:
                 "top_p": top_p,
                 "typical_p": typical_p,
                 "use_cache": use_cache,
-                **(extra_parameters or {}),
+                **(extra_body or {}),
             },
             headers=self.headers,
             model=model or self.model,

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -651,7 +651,7 @@ class AsyncInferenceClient:
         </Tip>
 
         <Tip>
-        You can pass provider-specific parameters to the model by using the `extra_body` parameter.
+        You can pass provider-specific parameters to the model by using the `extra_body` argument.
         </Tip>
 
         Args:
@@ -2466,7 +2466,7 @@ class AsyncInferenceClient:
         </Tip>
 
         <Tip>
-        You can pass provider-specific parameters to the model by using the `extra_body` parameter.
+        You can pass provider-specific parameters to the model by using the `extra_body` argument.
         </Tip>
 
         Args:
@@ -2601,7 +2601,7 @@ class AsyncInferenceClient:
         Generate a video based on a given text.
 
         <Tip>
-        You can pass provider-specific parameters to the model by using the `extra_body` parameter.
+        You can pass provider-specific parameters to the model by using the `extra_body` argument.
         </Tip>
 
         Args:
@@ -2708,7 +2708,7 @@ class AsyncInferenceClient:
         Synthesize an audio of a voice pronouncing a given text.
 
         <Tip>
-        You can pass provider-specific parameters to the model by using the `extra_body` parameter.
+        You can pass provider-specific parameters to the model by using the `extra_body` argument.
         </Tip>
 
         Args:

--- a/utils/check_task_parameters.py
+++ b/utils/check_task_parameters.py
@@ -90,7 +90,7 @@ CORE_PARAMETERS = {
     "question",  # For QA tasks
     "context",  # For QA tasks
     "labels",  # For classification tasks
-    "extra_parameters",  # For extra parameters
+    "extra_body",  # For extra parameters
 }
 
 #### NODE VISITORS (READING THE CODE)


### PR DESCRIPTION
Originally suggested by @julien-c [here](https://github.com/huggingface/huggingface_hub/pull/2812#pullrequestreview-2587806170). This way we maintain consistency with OpenAI's python sdk. I took the opportunity to add this argument to chat_completion as well.