### PR TITLE
Handle extra fields in inference types

### DIFF
--- a/src/huggingface_hub/inference/_generated/types/audio_classification.py
+++ b/src/huggingface_hub/inference/_generated/types/audio_classification.py
@@ -3,16 +3,15 @@
 # See:
 #   - script: https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/scripts/inference-codegen.ts
 #   - specs:  https://github.com/huggingface/huggingface.js/tree/main/packages/tasks/src/tasks.
-from dataclasses import dataclass
 from typing import Literal, Optional
 
-from .base import BaseInferenceType
+from .base import BaseInferenceType, dataclass_with_extra
 
 
 AudioClassificationOutputTransform = Literal["sigmoid", "softmax", "none"]
 
 
-@dataclass
+@dataclass_with_extra
 class AudioClassificationParameters(BaseInferenceType):
     """Additional inference parameters for Audio Classification"""
 
@@ -22,7 +21,7 @@ class AudioClassificationParameters(BaseInferenceType):
     """When specified, limits the output to the top K most probable classes."""
 
 
-@dataclass
+@dataclass_with_extra
 class AudioClassificationInput(BaseInferenceType):
     """Inputs for Audio Classification inference"""
 
@@ -34,7 +33,7 @@ class AudioClassificationInput(BaseInferenceType):
     """Additional inference parameters for Audio Classification"""
 
 
-@dataclass
+@dataclass_with_extra
 class AudioClassificationOutputElement(BaseInferenceType):
     """Outputs for Audio Classification inference"""
 

--- a/src/huggingface_hub/inference/_generated/types/audio_to_audio.py
+++ b/src/huggingface_hub/inference/_generated/types/audio_to_audio.py
@@ -3,13 +3,12 @@
 # See:
 #   - script: https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/scripts/inference-codegen.ts
 #   - specs:  https://github.com/huggingface/huggingface.js/tree/main/packages/tasks/src/tasks.
-from dataclasses import dataclass
 from typing import Any
 
-from .base import BaseInferenceType
+from .base import BaseInferenceType, dataclass_with_extra
 
 
-@dataclass
+@dataclass_with_extra
 class AudioToAudioInput(BaseInferenceType):
     """Inputs for Audio to Audio inference"""
 
@@ -17,7 +16,7 @@ class AudioToAudioInput(BaseInferenceType):
     """The input audio data"""
 
 
-@dataclass
+@dataclass_with_extra
 class AudioToAudioOutputElement(BaseInferenceType):
     """Outputs of inference for the Audio To Audio task
     A generated audio file with its label.

--- a/src/huggingface_hub/inference/_generated/types/automatic_speech_recognition.py
+++ b/src/huggingface_hub/inference/_generated/types/automatic_speech_recognition.py
@@ -3,16 +3,15 @@
 # See:
 #   - script: https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/scripts/inference-codegen.ts
 #   - specs:  https://github.com/huggingface/huggingface.js/tree/main/packages/tasks/src/tasks.
-from dataclasses import dataclass
 from typing import List, Literal, Optional, Union
 
-from .base import BaseInferenceType
+from .base import BaseInferenceType, dataclass_with_extra
 
 
 AutomaticSpeechRecognitionEarlyStoppingEnum = Literal["never"]
 
 
-@dataclass
+@dataclass_with_extra
 class AutomaticSpeechRecognitionGenerationParameters(BaseInferenceType):
     """Parametrization of the text generation process"""
 
@@ -72,7 +71,7 @@ class AutomaticSpeechRecognitionGenerationParameters(BaseInferenceType):
     """Whether the model should use the past last key/values attentions to speed up decoding"""
 
 
-@dataclass
+@dataclass_with_extra
 class AutomaticSpeechRecognitionParameters(BaseInferenceType):
     """Additional inference parameters for Automatic Speech Recognition"""
 
@@ -83,7 +82,7 @@ class AutomaticSpeechRecognitionParameters(BaseInferenceType):
     """Parametrization of the text generation process"""
 
 
-@dataclass
+@dataclass_with_extra
 class AutomaticSpeechRecognitionInput(BaseInferenceType):
     """Inputs for Automatic Speech Recognition inference"""
 
@@ -95,7 +94,7 @@ class AutomaticSpeechRecognitionInput(BaseInferenceType):
     """Additional inference parameters for Automatic Speech Recognition"""
 
 
-@dataclass
+@dataclass_with_extra
 class AutomaticSpeechRecognitionOutputChunk(BaseInferenceType):
     text: str
     """A chunk of text identified by the model"""
@@ -103,7 +102,7 @@ class AutomaticSpeechRecognitionOutputChunk(BaseInferenceType):
     """The start and end timestamps corresponding with the text"""
 
 
-@dataclass
+@dataclass_with_extra
 class AutomaticSpeechRecognitionOutput(BaseInferenceType):
     """Outputs of inference for the Automatic Speech Recognition task"""
 

--- a/src/huggingface_hub/inference/_generated/types/base.py
+++ b/src/huggingface_hub/inference/_generated/types/base.py
@@ -34,7 +34,7 @@ def dataclass_with_extra(cls: Type[T]) -> Type[T]:
     This decorator only works with dataclasses that inherit from `BaseInferenceType`.
     """
     cls = dataclass(cls)
-    cls.__repr__ = _repr_with_extra
+    cls.__repr__ = _repr_with_extra  # type: ignore[method-assign]
     return cls
 
 

--- a/src/huggingface_hub/inference/_generated/types/base.py
+++ b/src/huggingface_hub/inference/_generated/types/base.py
@@ -22,6 +22,22 @@ from typing import Any, Dict, List, Type, TypeVar, Union, get_args
 T = TypeVar("T", bound="BaseInferenceType")
 
 
+def _repr_with_extra(self):
+    fields = list(self.__dataclass_fields__.keys())
+    other_fields = list(k for k in self.__dict__ if k not in fields)
+    return f"{self.__class__.__name__}({', '.join(f'{k}={self.__dict__[k]!r}' for k in fields + other_fields)})"
+
+
+def dataclass_with_extra(cls: Type[T]) -> Type[T]:
+    """Decorator to add a custom __repr__ method to a dataclass, showing all fields, including extra ones.
+
+    This decorator only works with dataclasses that inherit from `BaseInferenceType`.
+    """
+    cls = dataclass(cls)
+    cls.__repr__ = _repr_with_extra
+    return cls
+
+
 @dataclass
 class BaseInferenceType(dict):
     """Base class for all inference types.
@@ -115,6 +131,11 @@ class BaseInferenceType(dict):
 
         # Add remaining fields as dict attributes
         item.update(other_values)
+
+        # Add remaining fields as extra dataclass fields.
+        # They won't be part of the dataclass fields but will be accessible as attributes.
+        # Use @dataclass_with_extra to show them in __repr__.
+        item.__dict__.update(other_values)
         return item
 
     def __post_init__(self):

--- a/src/huggingface_hub/inference/_generated/types/chat_completion.py
+++ b/src/huggingface_hub/inference/_generated/types/chat_completion.py
@@ -3,13 +3,12 @@
 # See:
 #   - script: https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/scripts/inference-codegen.ts
 #   - specs:  https://github.com/huggingface/huggingface.js/tree/main/packages/tasks/src/tasks.
-from dataclasses import dataclass
 from typing import Any, List, Literal, Optional, Union
 
-from .base import BaseInferenceType
+from .base import BaseInferenceType, dataclass_with_extra
 
 
-@dataclass
+@dataclass_with_extra
 class ChatCompletionInputURL(BaseInferenceType):
     url: str
 
@@ -17,14 +16,14 @@ class ChatCompletionInputURL(BaseInferenceType):
 ChatCompletionInputMessageChunkType = Literal["text", "image_url"]
 
 
-@dataclass
+@dataclass_with_extra
 class ChatCompletionInputMessageChunk(BaseInferenceType):
     type: "ChatCompletionInputMessageChunkType"
     image_url: Optional[ChatCompletionInputURL] = None
     text: Optional[str] = None
 
 
-@dataclass
+@dataclass_with_extra
 class ChatCompletionInputMessage(BaseInferenceType):
     content: Union[List[ChatCompletionInputMessageChunk], str]
     role: str
@@ -34,7 +33,7 @@ class ChatCompletionInputMessage(BaseInferenceType):
 ChatCompletionInputGrammarTypeType = Literal["json", "regex"]
 
 
-@dataclass
+@dataclass_with_extra
 class ChatCompletionInputGrammarType(BaseInferenceType):
     type: "ChatCompletionInputGrammarTypeType"
     value: Any
@@ -44,7 +43,7 @@ class ChatCompletionInputGrammarType(BaseInferenceType):
     """
 
 
-@dataclass
+@dataclass_with_extra
 class ChatCompletionInputStreamOptions(BaseInferenceType):
     include_usage: bool
     """If set, an additional chunk will be streamed before the data: [DONE] message. The usage
@@ -54,12 +53,12 @@ class ChatCompletionInputStreamOptions(BaseInferenceType):
     """
 
 
-@dataclass
+@dataclass_with_extra
 class ChatCompletionInputFunctionName(BaseInferenceType):
     name: str
 
 
-@dataclass
+@dataclass_with_extra
 class ChatCompletionInputToolChoiceClass(BaseInferenceType):
     function: ChatCompletionInputFunctionName
 
@@ -67,20 +66,20 @@ class ChatCompletionInputToolChoiceClass(BaseInferenceType):
 ChatCompletionInputToolChoiceEnum = Literal["auto", "none", "required"]
 
 
-@dataclass
+@dataclass_with_extra
 class ChatCompletionInputFunctionDefinition(BaseInferenceType):
     arguments: Any
     name: str
     description: Optional[str] = None
 
 
-@dataclass
+@dataclass_with_extra
 class ChatCompletionInputTool(BaseInferenceType):
     function: ChatCompletionInputFunctionDefinition
     type: str
 
 
-@dataclass
+@dataclass_with_extra
 class ChatCompletionInput(BaseInferenceType):
     """Chat Completion Input.
     Auto-generated from TGI specs.
@@ -162,46 +161,46 @@ class ChatCompletionInput(BaseInferenceType):
     """
 
 
-@dataclass
+@dataclass_with_extra
 class ChatCompletionOutputTopLogprob(BaseInferenceType):
     logprob: float
     token: str
 
 
-@dataclass
+@dataclass_with_extra
 class ChatCompletionOutputLogprob(BaseInferenceType):
     logprob: float
     token: str
     top_logprobs: List[ChatCompletionOutputTopLogprob]
 
 
-@dataclass
+@dataclass_with_extra
 class ChatCompletionOutputLogprobs(BaseInferenceType):
     content: List[ChatCompletionOutputLogprob]
 
 
-@dataclass
+@dataclass_with_extra
 class ChatCompletionOutputFunctionDefinition(BaseInferenceType):
     arguments: Any
     name: str
     description: Optional[str] = None
 
 
-@dataclass
+@dataclass_with_extra
 class ChatCompletionOutputToolCall(BaseInferenceType):
     function: ChatCompletionOutputFunctionDefinition
     id: str
     type: str
 
 
-@dataclass
+@dataclass_with_extra
 class ChatCompletionOutputMessage(BaseInferenceType):
     role: str
     content: Optional[str] = None
     tool_calls: Optional[List[ChatCompletionOutputToolCall]] = None
 
 
-@dataclass
+@dataclass_with_extra
 class ChatCompletionOutputComplete(BaseInferenceType):
     finish_reason: str
     index: int
@@ -209,14 +208,14 @@ class ChatCompletionOutputComplete(BaseInferenceType):
     logprobs: Optional[ChatCompletionOutputLogprobs] = None
 
 
-@dataclass
+@dataclass_with_extra
 class ChatCompletionOutputUsage(BaseInferenceType):
     completion_tokens: int
     prompt_tokens: int
     total_tokens: int
 
 
-@dataclass
+@dataclass_with_extra
 class ChatCompletionOutput(BaseInferenceType):
     """Chat Completion Output.
     Auto-generated from TGI specs.
@@ -232,13 +231,13 @@ class ChatCompletionOutput(BaseInferenceType):
     usage: ChatCompletionOutputUsage
 
 
-@dataclass
+@dataclass_with_extra
 class ChatCompletionStreamOutputFunction(BaseInferenceType):
     arguments: str
     name: Optional[str] = None
 
 
-@dataclass
+@dataclass_with_extra
 class ChatCompletionStreamOutputDeltaToolCall(BaseInferenceType):
     function: ChatCompletionStreamOutputFunction
     id: str
@@ -246,32 +245,32 @@ class ChatCompletionStreamOutputDeltaToolCall(BaseInferenceType):
     type: str
 
 
-@dataclass
+@dataclass_with_extra
 class ChatCompletionStreamOutputDelta(BaseInferenceType):
     role: str
     content: Optional[str] = None
     tool_calls: Optional[ChatCompletionStreamOutputDeltaToolCall] = None
 
 
-@dataclass
+@dataclass_with_extra
 class ChatCompletionStreamOutputTopLogprob(BaseInferenceType):
     logprob: float
     token: str
 
 
-@dataclass
+@dataclass_with_extra
 class ChatCompletionStreamOutputLogprob(BaseInferenceType):
     logprob: float
     token: str
     top_logprobs: List[ChatCompletionStreamOutputTopLogprob]
 
 
-@dataclass
+@dataclass_with_extra
 class ChatCompletionStreamOutputLogprobs(BaseInferenceType):
     content: List[ChatCompletionStreamOutputLogprob]
 
 
-@dataclass
+@dataclass_with_extra
 class ChatCompletionStreamOutputChoice(BaseInferenceType):
     delta: ChatCompletionStreamOutputDelta
     index: int
@@ -279,14 +278,14 @@ class ChatCompletionStreamOutputChoice(BaseInferenceType):
     logprobs: Optional[ChatCompletionStreamOutputLogprobs] = None
 
 
-@dataclass
+@dataclass_with_extra
 class ChatCompletionStreamOutputUsage(BaseInferenceType):
     completion_tokens: int
     prompt_tokens: int
     total_tokens: int
 
 
-@dataclass
+@dataclass_with_extra
 class ChatCompletionStreamOutput(BaseInferenceType):
     """Chat Completion Stream Output.
     Auto-generated from TGI specs.

--- a/src/huggingface_hub/inference/_generated/types/depth_estimation.py
+++ b/src/huggingface_hub/inference/_generated/types/depth_estimation.py
@@ -3,13 +3,12 @@
 # See:
 #   - script: https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/scripts/inference-codegen.ts
 #   - specs:  https://github.com/huggingface/huggingface.js/tree/main/packages/tasks/src/tasks.
-from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
-from .base import BaseInferenceType
+from .base import BaseInferenceType, dataclass_with_extra
 
 
-@dataclass
+@dataclass_with_extra
 class DepthEstimationInput(BaseInferenceType):
     """Inputs for Depth Estimation inference"""
 
@@ -19,7 +18,7 @@ class DepthEstimationInput(BaseInferenceType):
     """Additional inference parameters for Depth Estimation"""
 
 
-@dataclass
+@dataclass_with_extra
 class DepthEstimationOutput(BaseInferenceType):
     """Outputs of inference for the Depth Estimation task"""
 

--- a/src/huggingface_hub/inference/_generated/types/document_question_answering.py
+++ b/src/huggingface_hub/inference/_generated/types/document_question_answering.py
@@ -3,13 +3,12 @@
 # See:
 #   - script: https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/scripts/inference-codegen.ts
 #   - specs:  https://github.com/huggingface/huggingface.js/tree/main/packages/tasks/src/tasks.
-from dataclasses import dataclass
 from typing import Any, List, Optional, Union
 
-from .base import BaseInferenceType
+from .base import BaseInferenceType, dataclass_with_extra
 
 
-@dataclass
+@dataclass_with_extra
 class DocumentQuestionAnsweringInputData(BaseInferenceType):
     """One (document, question) pair to answer"""
 
@@ -19,7 +18,7 @@ class DocumentQuestionAnsweringInputData(BaseInferenceType):
     """A question to ask of the document"""
 
 
-@dataclass
+@dataclass_with_extra
 class DocumentQuestionAnsweringParameters(BaseInferenceType):
     """Additional inference parameters for Document Question Answering"""
 
@@ -53,7 +52,7 @@ class DocumentQuestionAnsweringParameters(BaseInferenceType):
     """
 
 
-@dataclass
+@dataclass_with_extra
 class DocumentQuestionAnsweringInput(BaseInferenceType):
     """Inputs for Document Question Answering inference"""
 
@@ -63,7 +62,7 @@ class DocumentQuestionAnsweringInput(BaseInferenceType):
     """Additional inference parameters for Document Question Answering"""
 
 
-@dataclass
+@dataclass_with_extra
 class DocumentQuestionAnsweringOutputElement(BaseInferenceType):
     """Outputs of inference for the Document Question Answering task"""
 

--- a/src/huggingface_hub/inference/_generated/types/feature_extraction.py
+++ b/src/huggingface_hub/inference/_generated/types/feature_extraction.py
@@ -3,16 +3,15 @@
 # See:
 #   - script: https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/scripts/inference-codegen.ts
 #   - specs:  https://github.com/huggingface/huggingface.js/tree/main/packages/tasks/src/tasks.
-from dataclasses import dataclass
 from typing import List, Literal, Optional, Union
 
-from .base import BaseInferenceType
+from .base import BaseInferenceType, dataclass_with_extra
 
 
 FeatureExtractionInputTruncationDirection = Literal["Left", "Right"]
 
 
-@dataclass
+@dataclass_with_extra
 class FeatureExtractionInput(BaseInferenceType):
     """Feature Extraction Input.
     Auto-generated from TEI specs.

--- a/src/huggingface_hub/inference/_generated/types/fill_mask.py
+++ b/src/huggingface_hub/inference/_generated/types/fill_mask.py
@@ -3,13 +3,12 @@
 # See:
 #   - script: https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/scripts/inference-codegen.ts
 #   - specs:  https://github.com/huggingface/huggingface.js/tree/main/packages/tasks/src/tasks.
-from dataclasses import dataclass
 from typing import Any, List, Optional
 
-from .base import BaseInferenceType
+from .base import BaseInferenceType, dataclass_with_extra
 
 
-@dataclass
+@dataclass_with_extra
 class FillMaskParameters(BaseInferenceType):
     """Additional inference parameters for Fill Mask"""
 
@@ -23,7 +22,7 @@ class FillMaskParameters(BaseInferenceType):
     """When passed, overrides the number of predictions to return."""
 
 
-@dataclass
+@dataclass_with_extra
 class FillMaskInput(BaseInferenceType):
     """Inputs for Fill Mask inference"""
 
@@ -33,7 +32,7 @@ class FillMaskInput(BaseInferenceType):
     """Additional inference parameters for Fill Mask"""
 
 
-@dataclass
+@dataclass_with_extra
 class FillMaskOutputElement(BaseInferenceType):
     """Outputs of inference for the Fill Mask task"""
 

--- a/src/huggingface_hub/inference/_generated/types/image_classification.py
+++ b/src/huggingface_hub/inference/_generated/types/image_classification.py
@@ -3,16 +3,15 @@
 # See:
 #   - script: https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/scripts/inference-codegen.ts
 #   - specs:  https://github.com/huggingface/huggingface.js/tree/main/packages/tasks/src/tasks.
-from dataclasses import dataclass
 from typing import Literal, Optional
 
-from .base import BaseInferenceType
+from .base import BaseInferenceType, dataclass_with_extra
 
 
 ImageClassificationOutputTransform = Literal["sigmoid", "softmax", "none"]
 
 
-@dataclass
+@dataclass_with_extra
 class ImageClassificationParameters(BaseInferenceType):
     """Additional inference parameters for Image Classification"""
 
@@ -22,7 +21,7 @@ class ImageClassificationParameters(BaseInferenceType):
     """When specified, limits the output to the top K most probable classes."""
 
 
-@dataclass
+@dataclass_with_extra
 class ImageClassificationInput(BaseInferenceType):
     """Inputs for Image Classification inference"""
 
@@ -34,7 +33,7 @@ class ImageClassificationInput(BaseInferenceType):
     """Additional inference parameters for Image Classification"""
 
 
-@dataclass
+@dataclass_with_extra
 class ImageClassificationOutputElement(BaseInferenceType):
     """Outputs of inference for the Image Classification task"""
 

--- a/src/huggingface_hub/inference/_generated/types/image_segmentation.py
+++ b/src/huggingface_hub/inference/_generated/types/image_segmentation.py
@@ -3,16 +3,15 @@
 # See:
 #   - script: https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/scripts/inference-codegen.ts
 #   - specs:  https://github.com/huggingface/huggingface.js/tree/main/packages/tasks/src/tasks.
-from dataclasses import dataclass
 from typing import Literal, Optional
 
-from .base import BaseInferenceType
+from .base import BaseInferenceType, dataclass_with_extra
 
 
 ImageSegmentationSubtask = Literal["instance", "panoptic", "semantic"]
 
 
-@dataclass
+@dataclass_with_extra
 class ImageSegmentationParameters(BaseInferenceType):
     """Additional inference parameters for Image Segmentation"""
 
@@ -26,7 +25,7 @@ class ImageSegmentationParameters(BaseInferenceType):
     """Probability threshold to filter out predicted masks."""
 
 
-@dataclass
+@dataclass_with_extra
 class ImageSegmentationInput(BaseInferenceType):
     """Inputs for Image Segmentation inference"""
 
@@ -38,7 +37,7 @@ class ImageSegmentationInput(BaseInferenceType):
     """Additional inference parameters for Image Segmentation"""
 
 
-@dataclass
+@dataclass_with_extra
 class ImageSegmentationOutputElement(BaseInferenceType):
     """Outputs of inference for the Image Segmentation task
     A predicted mask / segment

--- a/src/huggingface_hub/inference/_generated/types/image_to_image.py
+++ b/src/huggingface_hub/inference/_generated/types/image_to_image.py
@@ -3,13 +3,12 @@
 # See:
 #   - script: https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/scripts/inference-codegen.ts
 #   - specs:  https://github.com/huggingface/huggingface.js/tree/main/packages/tasks/src/tasks.
-from dataclasses import dataclass
 from typing import Any, Optional
 
-from .base import BaseInferenceType
+from .base import BaseInferenceType, dataclass_with_extra
 
 
-@dataclass
+@dataclass_with_extra
 class ImageToImageTargetSize(BaseInferenceType):
     """The size in pixel of the output image."""
 
@@ -17,7 +16,7 @@ class ImageToImageTargetSize(BaseInferenceType):
     width: int
 
 
-@dataclass
+@dataclass_with_extra
 class ImageToImageParameters(BaseInferenceType):
     """Additional inference parameters for Image To Image"""
 
@@ -35,7 +34,7 @@ class ImageToImageParameters(BaseInferenceType):
     """The size in pixel of the output image."""
 
 
-@dataclass
+@dataclass_with_extra
 class ImageToImageInput(BaseInferenceType):
     """Inputs for Image To Image inference"""
 
@@ -47,7 +46,7 @@ class ImageToImageInput(BaseInferenceType):
     """Additional inference parameters for Image To Image"""
 
 
-@dataclass
+@dataclass_with_extra
 class ImageToImageOutput(BaseInferenceType):
     """Outputs of inference for the Image To Image task"""
 

--- a/src/huggingface_hub/inference/_generated/types/image_to_text.py
+++ b/src/huggingface_hub/inference/_generated/types/image_to_text.py
@@ -3,16 +3,15 @@
 # See:
 #   - script: https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/scripts/inference-codegen.ts
 #   - specs:  https://github.com/huggingface/huggingface.js/tree/main/packages/tasks/src/tasks.
-from dataclasses import dataclass
 from typing import Any, Literal, Optional, Union
 
-from .base import BaseInferenceType
+from .base import BaseInferenceType, dataclass_with_extra
 
 
 ImageToTextEarlyStoppingEnum = Literal["never"]
 
 
-@dataclass
+@dataclass_with_extra
 class ImageToTextGenerationParameters(BaseInferenceType):
     """Parametrization of the text generation process"""
 
@@ -72,7 +71,7 @@ class ImageToTextGenerationParameters(BaseInferenceType):
     """Whether the model should use the past last key/values attentions to speed up decoding"""
 
 
-@dataclass
+@dataclass_with_extra
 class ImageToTextParameters(BaseInferenceType):
     """Additional inference parameters for Image To Text"""
 
@@ -83,7 +82,7 @@ class ImageToTextParameters(BaseInferenceType):
     """Parametrization of the text generation process"""
 
 
-@dataclass
+@dataclass_with_extra
 class ImageToTextInput(BaseInferenceType):
     """Inputs for Image To Text inference"""
 
@@ -93,7 +92,7 @@ class ImageToTextInput(BaseInferenceType):
     """Additional inference parameters for Image To Text"""
 
 
-@dataclass
+@dataclass_with_extra
 class ImageToTextOutput(BaseInferenceType):
     """Outputs of inference for the Image To Text task"""
 

--- a/src/huggingface_hub/inference/_generated/types/object_detection.py
+++ b/src/huggingface_hub/inference/_generated/types/object_detection.py
@@ -3,13 +3,12 @@
 # See:
 #   - script: https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/scripts/inference-codegen.ts
 #   - specs:  https://github.com/huggingface/huggingface.js/tree/main/packages/tasks/src/tasks.
-from dataclasses import dataclass
 from typing import Optional
 
-from .base import BaseInferenceType
+from .base import BaseInferenceType, dataclass_with_extra
 
 
-@dataclass
+@dataclass_with_extra
 class ObjectDetectionParameters(BaseInferenceType):
     """Additional inference parameters for Object Detection"""
 
@@ -17,7 +16,7 @@ class ObjectDetectionParameters(BaseInferenceType):
     """The probability necessary to make a prediction."""
 
 
-@dataclass
+@dataclass_with_extra
 class ObjectDetectionInput(BaseInferenceType):
     """Inputs for Object Detection inference"""
 
@@ -29,7 +28,7 @@ class ObjectDetectionInput(BaseInferenceType):
     """Additional inference parameters for Object Detection"""
 
 
-@dataclass
+@dataclass_with_extra
 class ObjectDetectionBoundingBox(BaseInferenceType):
     """The predicted bounding box. Coordinates are relative to the top left corner of the input
     image.
@@ -45,7 +44,7 @@ class ObjectDetectionBoundingBox(BaseInferenceType):
     """The y-coordinate of the top-left corner of the bounding box."""
 
 
-@dataclass
+@dataclass_with_extra
 class ObjectDetectionOutputElement(BaseInferenceType):
     """Outputs of inference for the Object Detection task"""
 

--- a/src/huggingface_hub/inference/_generated/types/question_answering.py
+++ b/src/huggingface_hub/inference/_generated/types/question_answering.py
@@ -3,13 +3,12 @@
 # See:
 #   - script: https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/scripts/inference-codegen.ts
 #   - specs:  https://github.com/huggingface/huggingface.js/tree/main/packages/tasks/src/tasks.
-from dataclasses import dataclass
 from typing import Optional
 
-from .base import BaseInferenceType
+from .base import BaseInferenceType, dataclass_with_extra
 
 
-@dataclass
+@dataclass_with_extra
 class QuestionAnsweringInputData(BaseInferenceType):
     """One (context, question) pair to answer"""
 
@@ -19,7 +18,7 @@ class QuestionAnsweringInputData(BaseInferenceType):
     """The question to be answered"""
 
 
-@dataclass
+@dataclass_with_extra
 class QuestionAnsweringParameters(BaseInferenceType):
     """Additional inference parameters for Question Answering"""
 
@@ -51,7 +50,7 @@ class QuestionAnsweringParameters(BaseInferenceType):
     """
 
 
-@dataclass
+@dataclass_with_extra
 class QuestionAnsweringInput(BaseInferenceType):
     """Inputs for Question Answering inference"""
 
@@ -61,7 +60,7 @@ class QuestionAnsweringInput(BaseInferenceType):
     """Additional inference parameters for Question Answering"""
 
 
-@dataclass
+@dataclass_with_extra
 class QuestionAnsweringOutputElement(BaseInferenceType):
     """Outputs of inference for the Question Answering task"""
 

--- a/src/huggingface_hub/inference/_generated/types/sentence_similarity.py
+++ b/src/huggingface_hub/inference/_generated/types/sentence_similarity.py
@@ -3,13 +3,12 @@
 # See:
 #   - script: https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/scripts/inference-codegen.ts
 #   - specs:  https://github.com/huggingface/huggingface.js/tree/main/packages/tasks/src/tasks.
-from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
-from .base import BaseInferenceType
+from .base import BaseInferenceType, dataclass_with_extra
 
 
-@dataclass
+@dataclass_with_extra
 class SentenceSimilarityInputData(BaseInferenceType):
     sentences: List[str]
     """A list of strings which will be compared against the source_sentence."""
@@ -19,7 +18,7 @@ class SentenceSimilarityInputData(BaseInferenceType):
     """
 
 
-@dataclass
+@dataclass_with_extra
 class SentenceSimilarityInput(BaseInferenceType):
     """Inputs for Sentence similarity inference"""
 

--- a/src/huggingface_hub/inference/_generated/types/summarization.py
+++ b/src/huggingface_hub/inference/_generated/types/summarization.py
@@ -3,16 +3,15 @@
 # See:
 #   - script: https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/scripts/inference-codegen.ts
 #   - specs:  https://github.com/huggingface/huggingface.js/tree/main/packages/tasks/src/tasks.
-from dataclasses import dataclass
 from typing import Any, Dict, Literal, Optional
 
-from .base import BaseInferenceType
+from .base import BaseInferenceType, dataclass_with_extra
 
 
 SummarizationTruncationStrategy = Literal["do_not_truncate", "longest_first", "only_first", "only_second"]
 
 
-@dataclass
+@dataclass_with_extra
 class SummarizationParameters(BaseInferenceType):
     """Additional inference parameters for summarization."""
 
@@ -24,7 +23,7 @@ class SummarizationParameters(BaseInferenceType):
     """The truncation strategy to use."""
 
 
-@dataclass
+@dataclass_with_extra
 class SummarizationInput(BaseInferenceType):
     """Inputs for Summarization inference"""
 
@@ -34,7 +33,7 @@ class SummarizationInput(BaseInferenceType):
     """Additional inference parameters for summarization."""
 
 
-@dataclass
+@dataclass_with_extra
 class SummarizationOutput(BaseInferenceType):
     """Outputs of inference for the Summarization task"""
 

--- a/src/huggingface_hub/inference/_generated/types/table_question_answering.py
+++ b/src/huggingface_hub/inference/_generated/types/table_question_answering.py
@@ -3,13 +3,12 @@
 # See:
 #   - script: https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/scripts/inference-codegen.ts
 #   - specs:  https://github.com/huggingface/huggingface.js/tree/main/packages/tasks/src/tasks.
-from dataclasses import dataclass
 from typing import Dict, List, Literal, Optional
 
-from .base import BaseInferenceType
+from .base import BaseInferenceType, dataclass_with_extra
 
 
-@dataclass
+@dataclass_with_extra
 class TableQuestionAnsweringInputData(BaseInferenceType):
     """One (table, question) pair to answer"""
 
@@ -22,7 +21,7 @@ class TableQuestionAnsweringInputData(BaseInferenceType):
 Padding = Literal["do_not_pad", "longest", "max_length"]
 
 
-@dataclass
+@dataclass_with_extra
 class TableQuestionAnsweringParameters(BaseInferenceType):
     """Additional inference parameters for Table Question Answering"""
 
@@ -37,7 +36,7 @@ class TableQuestionAnsweringParameters(BaseInferenceType):
     """Activates and controls truncation."""
 
 
-@dataclass
+@dataclass_with_extra
 class TableQuestionAnsweringInput(BaseInferenceType):
     """Inputs for Table Question Answering inference"""
 
@@ -47,7 +46,7 @@ class TableQuestionAnsweringInput(BaseInferenceType):
     """Additional inference parameters for Table Question Answering"""
 
 
-@dataclass
+@dataclass_with_extra
 class TableQuestionAnsweringOutputElement(BaseInferenceType):
     """Outputs of inference for the Table Question Answering task"""
 

--- a/src/huggingface_hub/inference/_generated/types/text2text_generation.py
+++ b/src/huggingface_hub/inference/_generated/types/text2text_generation.py
@@ -3,16 +3,15 @@
 # See:
 #   - script: https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/scripts/inference-codegen.ts
 #   - specs:  https://github.com/huggingface/huggingface.js/tree/main/packages/tasks/src/tasks.
-from dataclasses import dataclass
 from typing import Any, Dict, Literal, Optional
 
-from .base import BaseInferenceType
+from .base import BaseInferenceType, dataclass_with_extra
 
 
 Text2TextGenerationTruncationStrategy = Literal["do_not_truncate", "longest_first", "only_first", "only_second"]
 
 
-@dataclass
+@dataclass_with_extra
 class Text2TextGenerationParameters(BaseInferenceType):
     """Additional inference parameters for Text2text Generation"""
 
@@ -24,7 +23,7 @@ class Text2TextGenerationParameters(BaseInferenceType):
     """The truncation strategy to use"""
 
 
-@dataclass
+@dataclass_with_extra
 class Text2TextGenerationInput(BaseInferenceType):
     """Inputs for Text2text Generation inference"""
 
@@ -34,7 +33,7 @@ class Text2TextGenerationInput(BaseInferenceType):
     """Additional inference parameters for Text2text Generation"""
 
 
-@dataclass
+@dataclass_with_extra
 class Text2TextGenerationOutput(BaseInferenceType):
     """Outputs of inference for the Text2text Generation task"""
 

--- a/src/huggingface_hub/inference/_generated/types/text_classification.py
+++ b/src/huggingface_hub/inference/_generated/types/text_classification.py
@@ -3,16 +3,15 @@
 # See:
 #   - script: https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/scripts/inference-codegen.ts
 #   - specs:  https://github.com/huggingface/huggingface.js/tree/main/packages/tasks/src/tasks.
-from dataclasses import dataclass
 from typing import Literal, Optional
 
-from .base import BaseInferenceType
+from .base import BaseInferenceType, dataclass_with_extra
 
 
 TextClassificationOutputTransform = Literal["sigmoid", "softmax", "none"]
 
 
-@dataclass
+@dataclass_with_extra
 class TextClassificationParameters(BaseInferenceType):
     """Additional inference parameters for Text Classification"""
 
@@ -22,7 +21,7 @@ class TextClassificationParameters(BaseInferenceType):
     """When specified, limits the output to the top K most probable classes."""
 
 
-@dataclass
+@dataclass_with_extra
 class TextClassificationInput(BaseInferenceType):
     """Inputs for Text Classification inference"""
 
@@ -32,7 +31,7 @@ class TextClassificationInput(BaseInferenceType):
     """Additional inference parameters for Text Classification"""
 
 
-@dataclass
+@dataclass_with_extra
 class TextClassificationOutputElement(BaseInferenceType):
     """Outputs of inference for the Text Classification task"""
 

--- a/src/huggingface_hub/inference/_generated/types/text_generation.py
+++ b/src/huggingface_hub/inference/_generated/types/text_generation.py
@@ -3,16 +3,15 @@
 # See:
 #   - script: https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/scripts/inference-codegen.ts
 #   - specs:  https://github.com/huggingface/huggingface.js/tree/main/packages/tasks/src/tasks.
-from dataclasses import dataclass
 from typing import Any, List, Literal, Optional
 
-from .base import BaseInferenceType
+from .base import BaseInferenceType, dataclass_with_extra
 
 
 TypeEnum = Literal["json", "regex"]
 
 
-@dataclass
+@dataclass_with_extra
 class TextGenerationInputGrammarType(BaseInferenceType):
     type: "TypeEnum"
     value: Any
@@ -22,7 +21,7 @@ class TextGenerationInputGrammarType(BaseInferenceType):
     """
 
 
-@dataclass
+@dataclass_with_extra
 class TextGenerationInputGenerateParameters(BaseInferenceType):
     adapter_id: Optional[str] = None
     """Lora adapter id"""
@@ -73,7 +72,7 @@ class TextGenerationInputGenerateParameters(BaseInferenceType):
     """
 
 
-@dataclass
+@dataclass_with_extra
 class TextGenerationInput(BaseInferenceType):
     """Text Generation Input.
     Auto-generated from TGI specs.
@@ -89,14 +88,14 @@ class TextGenerationInput(BaseInferenceType):
 TextGenerationOutputFinishReason = Literal["length", "eos_token", "stop_sequence"]
 
 
-@dataclass
+@dataclass_with_extra
 class TextGenerationOutputPrefillToken(BaseInferenceType):
     id: int
     logprob: float
     text: str
 
 
-@dataclass
+@dataclass_with_extra
 class TextGenerationOutputToken(BaseInferenceType):
     id: int
     logprob: float
@@ -104,7 +103,7 @@ class TextGenerationOutputToken(BaseInferenceType):
     text: str
 
 
-@dataclass
+@dataclass_with_extra
 class TextGenerationOutputBestOfSequence(BaseInferenceType):
     finish_reason: "TextGenerationOutputFinishReason"
     generated_text: str
@@ -115,7 +114,7 @@ class TextGenerationOutputBestOfSequence(BaseInferenceType):
     top_tokens: Optional[List[List[TextGenerationOutputToken]]] = None
 
 
-@dataclass
+@dataclass_with_extra
 class TextGenerationOutputDetails(BaseInferenceType):
     finish_reason: "TextGenerationOutputFinishReason"
     generated_tokens: int
@@ -126,7 +125,7 @@ class TextGenerationOutputDetails(BaseInferenceType):
     top_tokens: Optional[List[List[TextGenerationOutputToken]]] = None
 
 
-@dataclass
+@dataclass_with_extra
 class TextGenerationOutput(BaseInferenceType):
     """Text Generation Output.
     Auto-generated from TGI specs.
@@ -138,7 +137,7 @@ class TextGenerationOutput(BaseInferenceType):
     details: Optional[TextGenerationOutputDetails] = None
 
 
-@dataclass
+@dataclass_with_extra
 class TextGenerationStreamOutputStreamDetails(BaseInferenceType):
     finish_reason: "TextGenerationOutputFinishReason"
     generated_tokens: int
@@ -146,7 +145,7 @@ class TextGenerationStreamOutputStreamDetails(BaseInferenceType):
     seed: Optional[int] = None
 
 
-@dataclass
+@dataclass_with_extra
 class TextGenerationStreamOutputToken(BaseInferenceType):
     id: int
     logprob: float
@@ -154,7 +153,7 @@ class TextGenerationStreamOutputToken(BaseInferenceType):
     text: str
 
 
-@dataclass
+@dataclass_with_extra
 class TextGenerationStreamOutput(BaseInferenceType):
     """Text Generation Stream Output.
     Auto-generated from TGI specs.

--- a/src/huggingface_hub/inference/_generated/types/text_to_audio.py
+++ b/src/huggingface_hub/inference/_generated/types/text_to_audio.py
@@ -3,16 +3,15 @@
 # See:
 #   - script: https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/scripts/inference-codegen.ts
 #   - specs:  https://github.com/huggingface/huggingface.js/tree/main/packages/tasks/src/tasks.
-from dataclasses import dataclass
 from typing import Any, Literal, Optional, Union
 
-from .base import BaseInferenceType
+from .base import BaseInferenceType, dataclass_with_extra
 
 
 TextToAudioEarlyStoppingEnum = Literal["never"]
 
 
-@dataclass
+@dataclass_with_extra
 class TextToAudioGenerationParameters(BaseInferenceType):
     """Parametrization of the text generation process"""
 
@@ -72,7 +71,7 @@ class TextToAudioGenerationParameters(BaseInferenceType):
     """Whether the model should use the past last key/values attentions to speed up decoding"""
 
 
-@dataclass
+@dataclass_with_extra
 class TextToAudioParameters(BaseInferenceType):
     """Additional inference parameters for Text To Audio"""
 
@@ -81,7 +80,7 @@ class TextToAudioParameters(BaseInferenceType):
     """Parametrization of the text generation process"""
 
 
-@dataclass
+@dataclass_with_extra
 class TextToAudioInput(BaseInferenceType):
     """Inputs for Text To Audio inference"""
 
@@ -91,7 +90,7 @@ class TextToAudioInput(BaseInferenceType):
     """Additional inference parameters for Text To Audio"""
 
 
-@dataclass
+@dataclass_with_extra
 class TextToAudioOutput(BaseInferenceType):
     """Outputs of inference for the Text To Audio task"""
 

--- a/src/huggingface_hub/inference/_generated/types/text_to_image.py
+++ b/src/huggingface_hub/inference/_generated/types/text_to_image.py
@@ -3,13 +3,12 @@
 # See:
 #   - script: https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/scripts/inference-codegen.ts
 #   - specs:  https://github.com/huggingface/huggingface.js/tree/main/packages/tasks/src/tasks.
-from dataclasses import dataclass
 from typing import Any, Optional
 
-from .base import BaseInferenceType
+from .base import BaseInferenceType, dataclass_with_extra
 
 
-@dataclass
+@dataclass_with_extra
 class TextToImageParameters(BaseInferenceType):
     """Additional inference parameters for Text To Image"""
 
@@ -33,7 +32,7 @@ class TextToImageParameters(BaseInferenceType):
     """The width in pixels of the output image"""
 
 
-@dataclass
+@dataclass_with_extra
 class TextToImageInput(BaseInferenceType):
     """Inputs for Text To Image inference"""
 
@@ -43,7 +42,7 @@ class TextToImageInput(BaseInferenceType):
     """Additional inference parameters for Text To Image"""
 
 
-@dataclass
+@dataclass_with_extra
 class TextToImageOutput(BaseInferenceType):
     """Outputs of inference for the Text To Image task"""
 

--- a/src/huggingface_hub/inference/_generated/types/text_to_speech.py
+++ b/src/huggingface_hub/inference/_generated/types/text_to_speech.py
@@ -3,16 +3,15 @@
 # See:
 #   - script: https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/scripts/inference-codegen.ts
 #   - specs:  https://github.com/huggingface/huggingface.js/tree/main/packages/tasks/src/tasks.
-from dataclasses import dataclass
 from typing import Any, Literal, Optional, Union
 
-from .base import BaseInferenceType
+from .base import BaseInferenceType, dataclass_with_extra
 
 
 TextToSpeechEarlyStoppingEnum = Literal["never"]
 
 
-@dataclass
+@dataclass_with_extra
 class TextToSpeechGenerationParameters(BaseInferenceType):
     """Parametrization of the text generation process"""
 
@@ -72,7 +71,7 @@ class TextToSpeechGenerationParameters(BaseInferenceType):
     """Whether the model should use the past last key/values attentions to speed up decoding"""
 
 
-@dataclass
+@dataclass_with_extra
 class TextToSpeechParameters(BaseInferenceType):
     """Additional inference parameters for Text To Speech"""
 
@@ -81,7 +80,7 @@ class TextToSpeechParameters(BaseInferenceType):
     """Parametrization of the text generation process"""
 
 
-@dataclass
+@dataclass_with_extra
 class TextToSpeechInput(BaseInferenceType):
     """Inputs for Text To Speech inference"""
 
@@ -91,7 +90,7 @@ class TextToSpeechInput(BaseInferenceType):
     """Additional inference parameters for Text To Speech"""
 
 
-@dataclass
+@dataclass_with_extra
 class TextToSpeechOutput(BaseInferenceType):
     """Outputs of inference for the Text To Speech task"""
 

--- a/src/huggingface_hub/inference/_generated/types/text_to_video.py
+++ b/src/huggingface_hub/inference/_generated/types/text_to_video.py
@@ -3,13 +3,12 @@
 # See:
 #   - script: https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/scripts/inference-codegen.ts
 #   - specs:  https://github.com/huggingface/huggingface.js/tree/main/packages/tasks/src/tasks.
-from dataclasses import dataclass
 from typing import Any, List, Optional
 
-from .base import BaseInferenceType
+from .base import BaseInferenceType, dataclass_with_extra
 
 
-@dataclass
+@dataclass_with_extra
 class TextToVideoParameters(BaseInferenceType):
     """Additional inference parameters for Text To Video"""
 
@@ -29,7 +28,7 @@ class TextToVideoParameters(BaseInferenceType):
     """Seed for the random number generator."""
 
 
-@dataclass
+@dataclass_with_extra
 class TextToVideoInput(BaseInferenceType):
     """Inputs for Text To Video inference"""
 
@@ -39,7 +38,7 @@ class TextToVideoInput(BaseInferenceType):
     """Additional inference parameters for Text To Video"""
 
 
-@dataclass
+@dataclass_with_extra
 class TextToVideoOutput(BaseInferenceType):
     """Outputs of inference for the Text To Video task"""
 

--- a/src/huggingface_hub/inference/_generated/types/token_classification.py
+++ b/src/huggingface_hub/inference/_generated/types/token_classification.py
@@ -3,16 +3,15 @@
 # See:
 #   - script: https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/scripts/inference-codegen.ts
 #   - specs:  https://github.com/huggingface/huggingface.js/tree/main/packages/tasks/src/tasks.
-from dataclasses import dataclass
 from typing import List, Literal, Optional
 
-from .base import BaseInferenceType
+from .base import BaseInferenceType, dataclass_with_extra
 
 
 TokenClassificationAggregationStrategy = Literal["none", "simple", "first", "average", "max"]
 
 
-@dataclass
+@dataclass_with_extra
 class TokenClassificationParameters(BaseInferenceType):
     """Additional inference parameters for Token Classification"""
 
@@ -24,7 +23,7 @@ class TokenClassificationParameters(BaseInferenceType):
     """The number of overlapping tokens between chunks when splitting the input text."""
 
 
-@dataclass
+@dataclass_with_extra
 class TokenClassificationInput(BaseInferenceType):
     """Inputs for Token Classification inference"""
 
@@ -34,7 +33,7 @@ class TokenClassificationInput(BaseInferenceType):
     """Additional inference parameters for Token Classification"""
 
 
-@dataclass
+@dataclass_with_extra
 class TokenClassificationOutputElement(BaseInferenceType):
     """Outputs of inference for the Token Classification task"""
 

--- a/src/huggingface_hub/inference/_generated/types/translation.py
+++ b/src/huggingface_hub/inference/_generated/types/translation.py
@@ -3,16 +3,15 @@
 # See:
 #   - script: https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/scripts/inference-codegen.ts
 #   - specs:  https://github.com/huggingface/huggingface.js/tree/main/packages/tasks/src/tasks.
-from dataclasses import dataclass
 from typing import Any, Dict, Literal, Optional
 
-from .base import BaseInferenceType
+from .base import BaseInferenceType, dataclass_with_extra
 
 
 TranslationTruncationStrategy = Literal["do_not_truncate", "longest_first", "only_first", "only_second"]
 
 
-@dataclass
+@dataclass_with_extra
 class TranslationParameters(BaseInferenceType):
     """Additional inference parameters for Translation"""
 
@@ -32,7 +31,7 @@ class TranslationParameters(BaseInferenceType):
     """The truncation strategy to use."""
 
 
-@dataclass
+@dataclass_with_extra
 class TranslationInput(BaseInferenceType):
     """Inputs for Translation inference"""
 
@@ -42,7 +41,7 @@ class TranslationInput(BaseInferenceType):
     """Additional inference parameters for Translation"""
 
 
-@dataclass
+@dataclass_with_extra
 class TranslationOutput(BaseInferenceType):
     """Outputs of inference for the Translation task"""
 

--- a/src/huggingface_hub/inference/_generated/types/video_classification.py
+++ b/src/huggingface_hub/inference/_generated/types/video_classification.py
@@ -3,16 +3,15 @@
 # See:
 #   - script: https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/scripts/inference-codegen.ts
 #   - specs:  https://github.com/huggingface/huggingface.js/tree/main/packages/tasks/src/tasks.
-from dataclasses import dataclass
 from typing import Any, Literal, Optional
 
-from .base import BaseInferenceType
+from .base import BaseInferenceType, dataclass_with_extra
 
 
 VideoClassificationOutputTransform = Literal["sigmoid", "softmax", "none"]
 
 
-@dataclass
+@dataclass_with_extra
 class VideoClassificationParameters(BaseInferenceType):
     """Additional inference parameters for Video Classification"""
 
@@ -26,7 +25,7 @@ class VideoClassificationParameters(BaseInferenceType):
     """When specified, limits the output to the top K most probable classes."""
 
 
-@dataclass
+@dataclass_with_extra
 class VideoClassificationInput(BaseInferenceType):
     """Inputs for Video Classification inference"""
 
@@ -36,7 +35,7 @@ class VideoClassificationInput(BaseInferenceType):
     """Additional inference parameters for Video Classification"""
 
 
-@dataclass
+@dataclass_with_extra
 class VideoClassificationOutputElement(BaseInferenceType):
     """Outputs of inference for the Video Classification task"""
 

--- a/src/huggingface_hub/inference/_generated/types/visual_question_answering.py
+++ b/src/huggingface_hub/inference/_generated/types/visual_question_answering.py
@@ -3,13 +3,12 @@
 # See:
 #   - script: https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/scripts/inference-codegen.ts
 #   - specs:  https://github.com/huggingface/huggingface.js/tree/main/packages/tasks/src/tasks.
-from dataclasses import dataclass
 from typing import Any, Optional
 
-from .base import BaseInferenceType
+from .base import BaseInferenceType, dataclass_with_extra
 
 
-@dataclass
+@dataclass_with_extra
 class VisualQuestionAnsweringInputData(BaseInferenceType):
     """One (image, question) pair to answer"""
 
@@ -19,7 +18,7 @@ class VisualQuestionAnsweringInputData(BaseInferenceType):
     """The question to answer based on the image."""
 
 
-@dataclass
+@dataclass_with_extra
 class VisualQuestionAnsweringParameters(BaseInferenceType):
     """Additional inference parameters for Visual Question Answering"""
 
@@ -30,7 +29,7 @@ class VisualQuestionAnsweringParameters(BaseInferenceType):
     """
 
 
-@dataclass
+@dataclass_with_extra
 class VisualQuestionAnsweringInput(BaseInferenceType):
     """Inputs for Visual Question Answering inference"""
 
@@ -40,7 +39,7 @@ class VisualQuestionAnsweringInput(BaseInferenceType):
     """Additional inference parameters for Visual Question Answering"""
 
 
-@dataclass
+@dataclass_with_extra
 class VisualQuestionAnsweringOutputElement(BaseInferenceType):
     """Outputs of inference for the Visual Question Answering task"""
 

--- a/src/huggingface_hub/inference/_generated/types/zero_shot_classification.py
+++ b/src/huggingface_hub/inference/_generated/types/zero_shot_classification.py
@@ -3,13 +3,12 @@
 # See:
 #   - script: https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/scripts/inference-codegen.ts
 #   - specs:  https://github.com/huggingface/huggingface.js/tree/main/packages/tasks/src/tasks.
-from dataclasses import dataclass
 from typing import List, Optional
 
-from .base import BaseInferenceType
+from .base import BaseInferenceType, dataclass_with_extra
 
 
-@dataclass
+@dataclass_with_extra
 class ZeroShotClassificationParameters(BaseInferenceType):
     """Additional inference parameters for Zero Shot Classification"""
 
@@ -26,7 +25,7 @@ class ZeroShotClassificationParameters(BaseInferenceType):
     """
 
 
-@dataclass
+@dataclass_with_extra
 class ZeroShotClassificationInput(BaseInferenceType):
     """Inputs for Zero Shot Classification inference"""
 
@@ -36,7 +35,7 @@ class ZeroShotClassificationInput(BaseInferenceType):
     """Additional inference parameters for Zero Shot Classification"""
 
 
-@dataclass
+@dataclass_with_extra
 class ZeroShotClassificationOutputElement(BaseInferenceType):
     """Outputs of inference for the Zero Shot Classification task"""
 

--- a/src/huggingface_hub/inference/_generated/types/zero_shot_image_classification.py
+++ b/src/huggingface_hub/inference/_generated/types/zero_shot_image_classification.py
@@ -3,13 +3,12 @@
 # See:
 #   - script: https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/scripts/inference-codegen.ts
 #   - specs:  https://github.com/huggingface/huggingface.js/tree/main/packages/tasks/src/tasks.
-from dataclasses import dataclass
 from typing import List, Optional
 
-from .base import BaseInferenceType
+from .base import BaseInferenceType, dataclass_with_extra
 
 
-@dataclass
+@dataclass_with_extra
 class ZeroShotImageClassificationParameters(BaseInferenceType):
     """Additional inference parameters for Zero Shot Image Classification"""
 
@@ -21,7 +20,7 @@ class ZeroShotImageClassificationParameters(BaseInferenceType):
     """
 
 
-@dataclass
+@dataclass_with_extra
 class ZeroShotImageClassificationInput(BaseInferenceType):
     """Inputs for Zero Shot Image Classification inference"""
 
@@ -31,7 +30,7 @@ class ZeroShotImageClassificationInput(BaseInferenceType):
     """Additional inference parameters for Zero Shot Image Classification"""
 
 
-@dataclass
+@dataclass_with_extra
 class ZeroShotImageClassificationOutputElement(BaseInferenceType):
     """Outputs of inference for the Zero Shot Image Classification task"""
 

--- a/src/huggingface_hub/inference/_generated/types/zero_shot_object_detection.py
+++ b/src/huggingface_hub/inference/_generated/types/zero_shot_object_detection.py
@@ -3,13 +3,12 @@
 # See:
 #   - script: https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/scripts/inference-codegen.ts
 #   - specs:  https://github.com/huggingface/huggingface.js/tree/main/packages/tasks/src/tasks.
-from dataclasses import dataclass
 from typing import List
 
-from .base import BaseInferenceType
+from .base import BaseInferenceType, dataclass_with_extra
 
 
-@dataclass
+@dataclass_with_extra
 class ZeroShotObjectDetectionParameters(BaseInferenceType):
     """Additional inference parameters for Zero Shot Object Detection"""
 
@@ -17,7 +16,7 @@ class ZeroShotObjectDetectionParameters(BaseInferenceType):
     """The candidate labels for this image"""
 
 
-@dataclass
+@dataclass_with_extra
 class ZeroShotObjectDetectionInput(BaseInferenceType):
     """Inputs for Zero Shot Object Detection inference"""
 
@@ -27,7 +26,7 @@ class ZeroShotObjectDetectionInput(BaseInferenceType):
     """Additional inference parameters for Zero Shot Object Detection"""
 
 
-@dataclass
+@dataclass_with_extra
 class ZeroShotObjectDetectionBoundingBox(BaseInferenceType):
     """The predicted bounding box. Coordinates are relative to the top left corner of the input
     image.
@@ -39,7 +38,7 @@ class ZeroShotObjectDetectionBoundingBox(BaseInferenceType):
     ymin: int
 
 
-@dataclass
+@dataclass_with_extra
 class ZeroShotObjectDetectionOutputElement(BaseInferenceType):
     """Outputs of inference for the Zero Shot Object Detection task"""
 

--- a/utils/check_task_parameters.py
+++ b/utils/check_task_parameters.py
@@ -74,7 +74,7 @@ TASKS_TO_SKIP = [
 
 PARAMETERS_DATACLASS_REGEX = re.compile(
     r"""
-    ^@dataclass
+    ^@dataclass_with_extra
     \nclass\s(\w+Parameters)\(BaseInferenceType\):
     """,
     re.VERBOSE | re.MULTILINE,

--- a/utils/generate_inference_types.py
+++ b/utils/generate_inference_types.py
@@ -48,7 +48,7 @@ BASE_DATACLASS_REGEX = re.compile(
 
 INHERITED_DATACLASS_REGEX = re.compile(
     r"""
-    ^@dataclass
+    ^@dataclass_with_extra
     \nclass\s(\w+)\(BaseInferenceType\):
 """,
     re.VERBOSE | re.MULTILINE,
@@ -163,9 +163,10 @@ def _replace_class_name(content: str, cls: str, new_cls: str) -> str:
 
 def _inherit_from_base(content: str) -> str:
     content = content.replace(
-        "\nfrom dataclasses import", "\nfrom .base import BaseInferenceType\nfrom dataclasses import"
+        "\nfrom dataclasses import",
+        "\nfrom .base import BaseInferenceType, dataclass_with_extra\nfrom dataclasses import",
     )
-    content = BASE_DATACLASS_REGEX.sub(r"@dataclass\nclass \1(BaseInferenceType):\n", content)
+    content = BASE_DATACLASS_REGEX.sub(r"@dataclass_with_extra\nclass \1(BaseInferenceType):\n", content)
     return content
 
 


### PR DESCRIPTION
Some providers are returning more fields than the default specs. For example, @hanouticelina noticed that for `"mistralai/Mistral-7B-Instruct-v0.3"` on Together AI, if `logprobs=True` is passed, the server returns 3 extra fields that are not in the default OpenAI's chat API: `token_ids`, `token` et `token_logprobs `. Currently these values are dropped. What `openai` package does is to forward these fields to the dataclasses without validation (using pydantic).

This PR implements the same behavior. If extra fields are returned by the server:
- they are accessible as attributes (e.g. `output.choices[0].logprobs.token_logprobs == [-0.0008468628, ...]` even though `token_logprobs` is not an official field)
- autocompletion / static type check doesn't work => expected since these are extra fields
- dataclass representation (`__repr__` and `__str__`) includes the extra fields for better UX (e.g. `ChoiceLogprobs(content=None, refusal=None, token_ids=[1183, ..], tokens=[' The', ' capital', ..], token_logprobs=[-0.0008468628, ...])`) 
- other default dataclass methods (e.g. `__eq__`) are still ignoring the extra values. Not a problem IMO. 

### Example:

(taken from @hanouticelina)

```py
from huggingface_hub import InferenceClient
client = InferenceClient(provider="together")
messages = [{"role": "user", "content": "What is the capital of France?"}]
completion = client.chat.completions.create(
    model="mistralai/Mistral-7B-Instruct-v0.3", messages=messages, logprobs=True, top_logprobs=2
)
print(completion)

```

```py
ChatCompletionOutput(
    choices=[
        ChatCompletionOutputComplete(
            finish_reason='eos', 
            index=0, 
            message=ChatCompletionOutputMessage(
                role='assistant', 
                content=' The capital of France is Paris. It is one of the most famous cities in the world, known for its rich history, art, culture, and landmarks such as the Eiffel Tower, Louvre Museum, and Notre-Dame Cathedral. Paris is also the political, economic, and cultural center of France.', 
                tool_calls=[]
            ),
            logprobs=ChatCompletionOutputLogprobs(
                content=None,
                token_ids=[1183, 6333, 1070, 5611, 1117, 6233, 29491, 1429, 1117, 1392, 1070, 1040, 1848, 9144, 10013, 1065, 1040, 2294, 29493, 3419, 1122, 1639, 7476, 4108, 29493, 2292, 29493, 6447, 29493, 1072, 3301, 17949, 2027, 1158, 1040, 1181, 3496, 1069, 20663, 29493, 5873, 20233, 9538, 29493, 1072, 3048, 1035, 29501, 29525, 1201, 11526, 20517, 29491, 6233, 1117, 1603, 1040, 5123, 29493, 7406, 29493, 1072, 9700, 5750, 1070, 5611, 29491, 2],
                tokens=[' The', ' capital', ' of', ' France', ' is', ' Paris', '.', ' It', ' is', ' one', ' of', ' the', ' most', ' famous', ' cities', ' in', ' the', ' world', ',', ' known', ' for', ' its', ' rich', ' history', ',', ' art', ',', ' culture', ',', ' and', ' land', 'marks', ' such', ' as', ' the', ' E', 'iff', 'el', ' Tower', ',', ' Lou', 'vre', ' Museum', ',', ' and', ' Not', 're', '-', 'D', 'ame', ' Cat', 'hedral', '.', ' Paris', ' is', ' also', ' the', ' political', ',', ' economic', ',', ' and', ' cultural', ' center', ' of', ' France', '.', '</s>'],
                token_logprobs=[-0.0008468628, -1.3947487e-05, -0.009765625, -7.1525574e-07, -1.4305115e-06, -0.00077438354, -0.00041770935, -0.8671875, -0.58203125, -0.80859375, -6.723404e-05, -0.0014266968, -0.53125, -0.26953125, -0.076660156, -0.013427734, -0.00014686584, -2.169609e-05, -0.16503906, -0.076660156, -0.0005226135, -0.05419922, -1.3359375, -0.22265625, -6.198883e-05, -0.70703125, -0.00061416626, -0.6328125, -0.0007286072, -0.24804688, -0.69921875, -0.00062561035, -0.24023438, -1.0728836e-06, -0.00018405914, -0.0008735657, -2.026558e-06, -1.1920929e-07, -1.7166138e-05, -0.0625, -0.06542969, -1.5497208e-05, -0.0046691895, -4.553795e-05, -0.18066406, -0.0047302246, 0, -0.029785156, -0.000114917755, -4.172325e-06, -0.021362305, -7.987022e-06, -0.0011291504, -0.33398438, -0.29492188, -0.49804688, -0.8515625, -0.390625, -0.057617188, -0.48828125, -0.0011672974, -0.0115356445, -0.000869751, -0.031982422, -2.4199486e-05, -0.0068969727, -0.17675781, -0.07861328]),
                seed=5010368328685449000
            )
        ],
    created=1738865859, id='90dd23635c397fed', model='mistralai/Mistral-7B-Instruct-v0.3',
    system_fingerprint=None,vusage=ChatCompletionOutputUsage(completion_tokens=68, prompt_tokens=11, total_tokens=79), object='chat.completion', prompt=[]
)
```