### PR TITLE
Fix error message if invalid token on file download

### DIFF
--- a/src/huggingface_hub/utils/_http.py
+++ b/src/huggingface_hub/utils/_http.py
@@ -437,6 +437,7 @@ def hf_raise_for_status(response: Response, endpoint_name: Optional[str] = None)
 
         elif error_code == "RepoNotFound" or (
             response.status_code == 401
+            and error_message != "Invalid credentials in Authorization header"
             and response.request is not None
             and response.request.url is not None
             and REPO_API_REGEX.search(response.request.url) is not None


### PR DESCRIPTION
Related to https://github.com/huggingface/transformers/issues/36104.

Since recently, when a user tries to download a file with an invalid token, the download fails with a 401 error `"Invalid credentials in Authorization header"` **even if the repo is public**. At the moment, this results in a `RepoNotFound` error raised in huggingface_hub, similar to if the repo is private or gated. With this PR, the error message should be less confusing.

**Previously:**
```
(...)
  File "/home/wauplin/projects/huggingface_hub/src/huggingface_hub/file_download.py", line 302, in _request_wrapper
    hf_raise_for_status(response)
  File "/home/wauplin/projects/huggingface_hub/src/huggingface_hub/utils/_http.py", line 457, in hf_raise_for_status
    raise _format(RepositoryNotFoundError, message, response) from e
huggingface_hub.errors.RepositoryNotFoundError: 401 Client Error. (Request ID: Root=1-67aa2e37-20b8c3033faef2da3677b130;875cea10-0550-4ba6-8c74-87fd52d8880f)

Repository Not Found for url: https://huggingface.co/openai-community/gpt2/resolve/main/config.json.
Please make sure you specified the correct `repo_id` and `repo_type`.
If you are trying to access a private or gated repo, make sure you are authenticated.
Invalid credentials in Authorization header
```

**With this PR:**

```
(...)
  File "/home/wauplin/projects/huggingface_hub/src/huggingface_hub/file_download.py", line 303, in _request_wrapper
    hf_raise_for_status(response)
  File "/home/wauplin/projects/huggingface_hub/src/huggingface_hub/utils/_http.py", line 481, in hf_raise_for_status
    raise _format(HfHubHTTPError, str(e), response) from e
huggingface_hub.errors.HfHubHTTPError: 401 Client Error: Unauthorized for url: https://huggingface.co/openai-community/gpt2/resolve/main/config.json (Request ID: Root=1-67aa2e15-52cc487054e9c9942e946343;b5eb54d7-cf40-49ca-a69d-8da35d4c5e4a)

Invalid credentials in Authorization header
```