### PR TITLE
Fix test_dataset_info (missing dummy dataset)

### DIFF
--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2164,20 +2164,17 @@ class HfApiPublicProductionTest(unittest.TestCase):
         dataset = self._api.dataset_info(repo_id=DUMMY_DATASET_ID)
         assert isinstance(dataset.card_data, DatasetCardData) and len(dataset.card_data) > 0
         assert isinstance(dataset.siblings, list) and len(dataset.siblings) > 0
-        self.assertIsInstance(dataset, DatasetInfo)
-        self.assertNotEqual(dataset.sha, DUMMY_DATASET_ID_REVISION_ONE_SPECIFIC_COMMIT)
+        assert isinstance(dataset, DatasetInfo)
+        assert dataset.sha != DUMMY_DATASET_ID_REVISION_ONE_SPECIFIC_COMMIT
         dataset = self._api.dataset_info(
             repo_id=DUMMY_DATASET_ID,
             revision=DUMMY_DATASET_ID_REVISION_ONE_SPECIFIC_COMMIT,
         )
-        self.assertIsInstance(dataset, DatasetInfo)
-        self.assertEqual(dataset.sha, DUMMY_DATASET_ID_REVISION_ONE_SPECIFIC_COMMIT)
+        assert isinstance(dataset, DatasetInfo)
+        assert dataset.sha == DUMMY_DATASET_ID_REVISION_ONE_SPECIFIC_COMMIT
 
     def test_dataset_info_with_file_metadata(self):
-        dataset = self._api.dataset_info(
-            repo_id=SAMPLE_DATASET_IDENTIFIER,
-            files_metadata=True,
-        )
+        dataset = self._api.dataset_info(repo_id=SAMPLE_DATASET_IDENTIFIER, files_metadata=True)
         files = dataset.siblings
         assert files is not None
         self._check_siblings_metadata(files)

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -47,8 +47,8 @@ DUMMY_RENAMED_NEW_MODEL_ID = "hf-internal-testing/dummy-renamed"
 
 SAMPLE_DATASET_IDENTIFIER = "lhoestq/custom_squad"
 # Example dataset ids
-DUMMY_DATASET_ID = "lhoestq/test"
-DUMMY_DATASET_ID_REVISION_ONE_SPECIFIC_COMMIT = "81d06f998585f8ee10e6e3a2ea47203dc75f2a16"  # on branch "test-branch"
+DUMMY_DATASET_ID = "gaia-benchmark/GAIA"
+DUMMY_DATASET_ID_REVISION_ONE_SPECIFIC_COMMIT = "c603981e170e9e333934a39781d2ae3a2677e81f"  # on branch "test-branch"
 
 YES = ("y", "yes", "t", "true", "on", "1")
 NO = ("n", "no", "f", "false", "off", "0")


### PR DESCRIPTION
This PR fixes the CI. Currently `test_dataset_info` tries to read info from https://huggingface.co/datasets/lhoestq/test which doesn't exist anymore. I've replaced it with https://huggingface.co/datasets/gaia-benchmark/GAIA which should be future-proof :) 

Fun fact: this test has been added 4 years ago :smile: https://github.com/huggingface/huggingface_hub/pull/164