### PR TITLE
Skip list_models(inference=...) tests in CI

### DIFF
--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -1917,10 +1917,12 @@ class HfApiPublicProductionTest(unittest.TestCase):
         for model in self._api.list_models(expand=["gated"], gated=False, limit=5):
             assert model.gated is False
 
+    @pytest.mark.skip("Inference parameter is being revamped")
     def test_list_models_inference_warm(self):
         for model in self._api.list_models(inference=["warm"], expand="inference", limit=5):
             assert model.inference == "warm"
 
+    @pytest.mark.skip("Inference parameter is being revamped")
     def test_list_models_inference_cold(self):
         for model in self._api.list_models(inference=["cold"], expand="inference", limit=5):
             assert model.inference == "cold"


### PR DESCRIPTION
Let's skip the tests while the API is being refactored.

Related to server-side updated (https://github.com/huggingface-internal/moon-landing/pull/12485, private link) and https://github.com/huggingface/huggingface.js/pull/1198 