### PR TITLE
[cleanup] Unique constants in tests + env variable for inference tests 

### DIFF
--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -63,9 +63,7 @@ _staging_mode = _is_true(os.environ.get("HUGGINGFACE_CO_STAGING"))
 
 _HF_DEFAULT_ENDPOINT = "https://huggingface.co"
 _HF_DEFAULT_STAGING_ENDPOINT = "https://hub-ci.huggingface.co"
-ENDPOINT = os.getenv("HF_ENDPOINT", "").rstrip("/") or (
-    _HF_DEFAULT_STAGING_ENDPOINT if _staging_mode else _HF_DEFAULT_ENDPOINT
-)
+ENDPOINT = os.getenv("HF_ENDPOINT", _HF_DEFAULT_ENDPOINT).rstrip("/")
 
 HUGGINGFACE_CO_URL_TEMPLATE = ENDPOINT + "/{repo_id}/resolve/{revision}/{filename}"
 HUGGINGFACE_HEADER_X_REPO_COMMIT = "X-Repo-Commit"
@@ -143,18 +141,14 @@ HF_HUB_DISABLE_TELEMETRY = (
     or _is_true(os.environ.get("DO_NOT_TRACK"))  # https://consoledonottrack.com/
 )
 
-# In the past, token was stored in a hardcoded location
-# `_OLD_HF_TOKEN_PATH` is deprecated and will be removed "at some point".
-# See https://github.com/huggingface/huggingface_hub/issues/1232
-_OLD_HF_TOKEN_PATH = os.path.expanduser("~/.huggingface/token")
 HF_TOKEN_PATH = os.environ.get("HF_TOKEN_PATH", os.path.join(HF_HOME, "token"))
 HF_STORED_TOKENS_PATH = os.path.join(os.path.dirname(HF_TOKEN_PATH), "stored_tokens")
 
 if _staging_mode:
+    ENDPOINT = _HF_DEFAULT_STAGING_ENDPOINT
     # In staging mode, we use a different cache to ensure we don't mix up production and staging data or tokens
     _staging_home = os.path.join(os.path.expanduser("~"), ".cache", "huggingface_staging")
     HUGGINGFACE_HUB_CACHE = os.path.join(_staging_home, "hub")
-    _OLD_HF_TOKEN_PATH = os.path.join(_staging_home, "_old_token")
     HF_TOKEN_PATH = os.path.join(_staging_home, "token")
 
 # Here, `True` will disable progress bars globally without possibility of enabling it

--- a/src/huggingface_hub/utils/_hf_folder.py
+++ b/src/huggingface_hub/utils/_hf_folder.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 """Contain helper class to retrieve/store token from/to local cache."""
 
-import warnings
 from pathlib import Path
 from typing import Optional
 
@@ -24,8 +23,6 @@ from ._auth import get_token
 
 class HfFolder:
     path_token = Path(constants.HF_TOKEN_PATH)
-    # Private attribute. Will be removed in v0.15
-    _old_path_token = Path(constants._OLD_HF_TOKEN_PATH)
 
     # TODO: deprecate when adapted in transformers/datasets/gradio
     # @_deprecate_method(version="1.0", message="Use `huggingface_hub.login` instead.")
@@ -57,12 +54,6 @@ class HfFolder:
         Returns:
             `str` or `None`: The token, `None` if it doesn't exist.
         """
-        # 0. Check if token exist in old path but not new location
-        try:
-            cls._copy_to_new_path_and_warn()
-        except Exception:  # if not possible (e.g. PermissionError), do not raise
-            pass
-
         return get_token()
 
     # TODO: deprecate when adapted in transformers/datasets/gradio
@@ -76,21 +67,3 @@ class HfFolder:
             cls.path_token.unlink()
         except FileNotFoundError:
             pass
-
-        try:
-            cls._old_path_token.unlink()
-        except FileNotFoundError:
-            pass
-
-    @classmethod
-    def _copy_to_new_path_and_warn(cls):
-        if cls._old_path_token.exists() and not cls.path_token.exists():
-            cls.save_token(cls._old_path_token.read_text())
-            warnings.warn(
-                f"A token has been found in `{cls._old_path_token}`. This is the old"
-                " path where tokens were stored. The new location is"
-                f" `{cls.path_token}` which is configurable using `HF_HOME` environment"
-                " variable. Your token has been copied to this new location. You can"
-                " now safely delete the old token file manually or use"
-                " `huggingface-cli logout`."
-            )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,9 +6,22 @@ import pytest
 from _pytest.fixtures import SubRequest
 
 import huggingface_hub
+from huggingface_hub import constants
 from huggingface_hub.utils import SoftTemporaryDirectory, logging
 
 from .testing_utils import set_write_permission_and_retry
+
+
+@pytest.fixture(autouse=True, scope="function")
+def patch_constants(mocker):
+    with SoftTemporaryDirectory() as cache_dir:
+        mocker.patch.object(constants, "HF_HOME", cache_dir)
+        mocker.patch.object(constants, "HF_HUB_CACHE", os.path.join(cache_dir, "hub"))
+        mocker.patch.object(constants, "HUGGINGFACE_HUB_CACHE", os.path.join(cache_dir, "hub"))
+        mocker.patch.object(constants, "HF_ASSETS_CACHE", os.path.join(cache_dir, "assets"))
+        mocker.patch.object(constants, "HF_TOKEN_PATH", os.path.join(cache_dir, "token"))
+        mocker.patch.object(constants, "HF_STORED_TOKENS_PATH", os.path.join(cache_dir, "stored_tokens"))
+        yield
 
 
 logger = logging.get_logger(__name__)

--- a/tests/test_inference_client.py
+++ b/tests/test_inference_client.py
@@ -106,9 +106,9 @@ _RECOMMENDED_MODELS_FOR_VCR = {
     },
 }
 API_KEY_ENV_VARIABLES = {
-    "hf-inference": "HF_TOKEN",
+    "hf-inference": "HF_INFERENCE_TEST_TOKEN",
     "fal-ai": "FAL_AI_KEY",
-    "fireworks-ai": "HF_TOKEN",
+    "fireworks-ai": "HF_INFERENCE_TEST_TOKEN",
     "replicate": "REPLICATE_KEY",
     "sambanova": "SAMBANOVA_API_KEY",
     "together": "TOGETHER_API_KEY",

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -15,11 +15,7 @@ from unittest.mock import Mock, patch
 import pytest
 import requests
 
-from huggingface_hub.utils import (
-    is_package_available,
-    logging,
-    reset_sessions,
-)
+from huggingface_hub.utils import is_package_available, logging, reset_sessions
 from tests.testing_constants import ENDPOINT_PRODUCTION, ENDPOINT_PRODUCTION_URL_SCHEME
 
 


### PR DESCRIPTION
In this PR:
- Adds an autouse function-scoped fixture that overwrites the default HF_HOME with a temporary directory for each single test => all tests are made independent + it won't mess-up with local cache at all anymore. Let's check it doesn't break anything in CI.
- Sets the tokens for inference tests to `HF_INFERENCE_TEST_TOKEN` instead of `HF_TOKEN`. The problem of `HF_TOKEN` is that it is overwritten in `pyproject.toml` to `""`, making it ineffective. To update VCR tests locally, one has to manually edit `pyproject.toml` which is annoying.
  - => in practice, VCR tests seem to be skipped in CI because no token is set => this is independent from this PR and @hanouticelina is working on it (right?)
- Removes deprecated `_old_token_path`. Used only internally and deprecated since Nov. 2022 https://github.com/huggingface/huggingface_hub/issues/1232

