### PR TITLE
Fix prerelease CI

### DIFF
--- a/.github/workflows/python-prerelease.yml
+++ b/.github/workflows/python-prerelease.yml
@@ -6,7 +6,7 @@ on:
       - "v*.rc*"
 
 jobs:
-  test_on_transformers:
+  trigger_rc_testing:
     runs-on: ubuntu-latest
 
     strategy:
@@ -32,6 +32,15 @@ jobs:
           git config user.name "Hugging Face Bot (RC Testing)"
           git config user.email "bot@huggingface.co"
 
+      - name: Wait for prerelease to be out on PyPI
+        run: |
+          VERSION=${{ steps.get-version.outputs.VERSION }}
+          echo "Waiting for huggingface-hub==${VERSION} to be available on PyPI"
+          while ! pip install huggingface-hub==${VERSION}; do
+            echo "huggingface-hub==${VERSION} not available yet, retrying in 15s"
+            sleep 15
+          done
+
       - name: Create test branch and update dependencies
         id: create-pr
         run: |
@@ -43,20 +52,24 @@ jobs:
           git checkout -b $BRANCH_NAME
 
           # Update dependencies using sed
-          sed -i -E 's/"huggingface-hub>=0.*"/"huggingface-hub==${VERSION}"/' setup.py
+          sed -i -E "s/\"huggingface-hub>=0.*\"/\"huggingface-hub==${VERSION}\"/" setup.py
           git add setup.py
 
           # Only if the target repo is transformers
           if [ "${{ matrix.target-repo }}" = "transformers" ]; then
-            sed -i -E 's/"huggingface-hub>=0.*"/"huggingface-hub==${VERSION}"/' src/transformers/dependency_versions_table.py
+            sed -i -E "s/\"huggingface-hub>=0.*\"/\"huggingface-hub==${VERSION}\"/" src/transformers/dependency_versions_table.py
             git add src/transformers/dependency_versions_table.py
           fi
 
           # Only if the target repo is diffusers
           if [ "${{ matrix.target-repo }}" = "diffusers" ]; then
-            sed -i -E 's/"huggingface-hub":.*/"huggingface-hub": "huggingface-hub==${VERSION}",/' src/diffusers/dependency_versions_table.py
+            sed -i -E "s/\"huggingface-hub\":.*/\"huggingface-hub\": \"huggingface-hub==${VERSION}\",/" src/diffusers/dependency_versions_table.py
             git add src/diffusers/dependency_versions_table.py
           fi
+
+          # Any line with `uv pip install --prerelease=allow` in the `.github/` folder must be updated with `--prerelease=allow` flag
+          find .github/workflows/ -type f -exec sed -i 's/uv pip install /uv pip install --prerelease=allow /g' {} +
+          git add .github/workflows/
 
           # Commit and push changes
           git --no-pager diff --staged


### PR DESCRIPTION
Took me some time to debug this yesterday but we now have a working workflow file (hence the v0.29.0 **.rc7** 
:see_no_evil:  :grimacing:). The goal of the `python-prerelease.yml` is to trigger CIs on datasets/diffusers/transformers repos when a prerelease is made on PyPI. This saves us some manual work when making a release.

Changes made:
- before pushing to external repos, we need to make sure the prerelease is available on PyPI
- fixed some char escape in sed commands
- all `uv pip install` commands in workflows file of external repos must be updated to allow prereleases (with `--prerelease=allow`)

Note that this is still failing for `datasets` due to permission issues. See https://github.com/huggingface/huggingface_hub/actions/runs/13395895366/job/37414702549: 
```
To https://github.com/huggingface/datasets
 ! [remote rejected] ci-test-huggingface-hub-v0.29.0.rc7 -> ci-test-huggingface-hub-v0.29.0.rc7
(refusing to allow a Personal Access Token to create or update workflow `.github/workflows/ci.yml` without `workflow` scope)
error: failed to push some refs to 'https://github.com/huggingface/datasets'
```
This issue is unrelated to this PR.