### PR TITLE
Fix revision bug in _upload_large_folder.py

### DIFF
--- a/src/huggingface_hub/_upload_large_folder.py
+++ b/src/huggingface_hub/_upload_large_folder.py
@@ -25,6 +25,7 @@ from datetime import datetime
 from pathlib import Path
 from threading import Lock
 from typing import TYPE_CHECKING, List, Optional, Tuple, Union
+from urllib.parse import quote
 
 from . import constants
 from ._commit_api import CommitOperationAdd, UploadInfo, _fetch_upload_modes
@@ -497,7 +498,7 @@ def _get_upload_mode(items: List[JOB_ITEM_T], api: "HfApi", repo_id: str, repo_t
         repo_type=repo_type,
         repo_id=repo_id,
         headers=api._build_hf_headers(),
-        revision=revision,
+        revision=quote(revision, safe=""),
     )
     for item, addition in zip(items, additions):
         paths, metadata = item


### PR DESCRIPTION
When using following code to upload folders:

```python
from huggingface_hub import HfApi

api = HfApi()
api.upload_large_folder(
    repo_id="amphion/Emilia-Dataset",
    repo_type="dataset",
    folder_path="/mnt/yodas",
    revision="refs/pr/10"
)
```

We got errors like "Failed to get upload mode: 404 Client Error: Not Found for url: https://huggingface.co/api/datasets/amphion/Emilia-Dataset/preupload/refs/pr/10 (Request ID: xxx)"

But the revision is already created manually and accessible via https://huggingface.co/datasets/amphion/Emilia-Dataset/tree/refs%2Fpr%2F10.

Here we note that the revision is URL-encoded in the link above (`refs%2Fpr%2F10`), but not encoded in the error message (`refs/pr/10`). By adding a `urllib.parse.quote` function solve this problem.

Besides, I've check other function calls in the same function, which handles this correctly. Probably, the person writing this code only tested on revision that did not contain "/" symbol.
