### PR TITLE
Xet upload workflow

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -153,7 +153,7 @@ jobs:
             ;;
 
             "Xet only")
-              PYTEST="$PYTEST ../tests -k 'test_xet_upload' -n 4"
+              PYTEST="$PYTEST ../tests -k 'test_xet' -n 4"
               echo $PYTEST
               eval $PYTEST
             ;;

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -153,7 +153,7 @@ jobs:
             ;;
 
             "Xet only")
-              PYTEST="$PYTEST ../tests -k 'test_xet' -n 4"
+              PYTEST="$PYTEST ../tests -k 'test_xet_download' -n 4"
               echo $PYTEST
               eval $PYTEST
             ;;

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -153,7 +153,7 @@ jobs:
             ;;
 
             "Xet only")
-              PYTEST="$PYTEST ../tests -k 'test_xet_download' -n 4"
+              PYTEST="$PYTEST ../tests -k 'test_xet_upload' -n 4"
               echo $PYTEST
               eval $PYTEST
             ;;

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -198,7 +198,11 @@ jobs:
 
       # Install dependencies
       - name: Install dependencies
-        run: uv pip install "huggingface_hub[testing] @ ."
+        run: |
+          uv pip install "huggingface_hub[testing] @ ."
+          if ("${{ matrix.test_name }}" -eq "Xet only") {
+            uv pip install "huggingface_hub[hf_xet] @ ."
+          }
 
       # Run tests
       - name: Run tests

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -153,7 +153,7 @@ jobs:
             ;;
 
             "Xet only")
-              PYTEST="$PYTEST ../tests -k 'test_xet' -n 4"
+              PYTEST="$PYTEST ../tests -k 'test_xet' -n 4 --tb=long -v"
               echo $PYTEST
               eval $PYTEST
             ;;

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -153,7 +153,7 @@ jobs:
             ;;
 
             "Xet only")
-              PYTEST="$PYTEST ../tests -k 'test_xet' -n 4 --tb=long -v"
+              PYTEST="$PYTEST ../tests -k 'test_xet' --tb=long -v"
               echo $PYTEST
               eval $PYTEST
             ;;

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -180,6 +180,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8"]
+        test_name: ["Everything else", "Xet only"]
 
     steps:
       - uses: actions/checkout@v2
@@ -197,14 +198,23 @@ jobs:
 
       # Install dependencies
       - name: Install dependencies
-        run: uv pip install "huggingface_hub[testing, hf_xet] @ ."
+        run: uv pip install "huggingface_hub[testing] @ ."
 
       # Run tests
       - name: Run tests
         working-directory: ./src # For code coverage to work
         run: |
           ..\.venv\Scripts\activate
-          python -m pytest -n 4 --cov=./huggingface_hub --cov-report=xml:../coverage.xml --vcr-record=none --reruns 8 --reruns-delay 2 --only-rerun '(OSError|Timeout|HTTPError.*502|HTTPError.*504|not less than or equal to 0.01)' ../tests
+          $PYTEST = "python -m pytest -n 4 --cov=./huggingface_hub --cov-report=xml:../coverage.xml --vcr-record=none --reruns 8 --reruns-delay 2 --only-rerun '(OSError|Timeout|HTTPError.*502|HTTPError.*504|not less than or equal to 0.01)'"
+
+          switch ("${{ matrix.test_name }}") {
+            "Xet only" {
+              & $PYTEST "../tests -k 'test_xet'"
+            }
+            "Everything else" {
+              & $PYTEST "../tests -k 'not test_xet'"
+            }
+          }
 
       # Upload code coverage
       - name: Upload coverage reports to Codecov with GitHub Action

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -205,14 +205,24 @@ jobs:
         working-directory: ./src # For code coverage to work
         run: |
           ..\.venv\Scripts\activate
-          $PYTEST = "python -m pytest -n 4 --cov=./huggingface_hub --cov-report=xml:../coverage.xml --vcr-record=none --reruns 8 --reruns-delay 2 --only-rerun '(OSError|Timeout|HTTPError.*502|HTTPError.*504|not less than or equal to 0.01)'"
+          $PYTEST_ARGS = @(
+            "-m", "pytest",
+            "-n", "4",
+            "--cov=./huggingface_hub",
+            "--cov-report=xml:../coverage.xml",
+            "--vcr-record=none",
+            "--reruns", "8",
+            "--reruns-delay", "2",
+            "--only-rerun", "(OSError|Timeout|HTTPError.*502|HTTPError.*504|not less than or equal to 0.01)",
+            "../tests"
+          )
 
           switch ("${{ matrix.test_name }}") {
             "Xet only" {
-              & $PYTEST "../tests -k 'test_xet'"
+              python $PYTEST_ARGS -k "test_xet"
             }
             "Everything else" {
-              & $PYTEST "../tests -k 'not test_xet'"
+              python $PYTEST_ARGS -k "not test_xet"
             }
           }
 

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -153,7 +153,7 @@ jobs:
             ;;
 
             "Xet only")
-              PYTEST="$PYTEST ../tests -k 'test_xet' --tb=long -v"
+              PYTEST="$PYTEST ../tests -k 'test_xet' -n 4 --tb=long -v"
               echo $PYTEST
               eval $PYTEST
             ;;

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -153,7 +153,7 @@ jobs:
             ;;
 
             "Xet only")
-              PYTEST="$PYTEST ../tests -k 'test_xet' --tb=long -v"
+              PYTEST="$PYTEST ../tests -k 'test_xet' -n 4"
               echo $PYTEST
               eval $PYTEST
             ;;

--- a/docs/source/en/package_reference/environment_variables.md
+++ b/docs/source/en/package_reference/environment_variables.md
@@ -36,6 +36,12 @@ spaces).
 
 Defaults to `"$HF_HOME/hub"` (e.g. `"~/.cache/huggingface/hub"` by default).
 
+### HF_XET_CACHE
+
+To configure where Xet Storage chunks will be cached locally.
+
+Defaults to `"$HF_HOME/xet"` (e.g. `"~/.cache/huggingface/xet"` by default).
+
 ### HF_ASSETS_CACHE
 
 To configure where [assets](../guides/manage-cache#caching-assets) created by downstream libraries

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ env = [
     "HF_TOKEN=",
     "HUGGINGFACE_CO_STAGING=1",
     "HUGGING_FACE_HUB_TOKEN=",
+    "HF_DEBUG=1",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ env = [
     "HF_TOKEN=",
     "HUGGINGFACE_CO_STAGING=1",
     "HUGGING_FACE_HUB_TOKEN=",
-    "HF_DEBUG=1",
 ]
 
 [tool.ruff]

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ extras["testing"] = (
         "pytest-asyncio",  # for AsyncInferenceClient
         "pytest-rerunfailures",  # to rerun flaky tests in CI
         "pytest-mock",
+        "pytest-timeout",
         "urllib3<2.0",  # VCR.py broken with urllib3 2.0 (see https://urllib3.readthedocs.io/en/stable/v2-migration-guide.html)
         "soundfile",
         "Pillow",

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ extras["tensorflow-testing"] = [
     "keras<3.0",
 ]
 
-extras["hf_xet"] = ["hf_xet"]
+extras["hf_xet"] = ["hf_xet>=0.1.4"]
 
 extras["testing"] = (
     extras["cli"]

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,6 @@ extras["testing"] = (
         "pytest-asyncio",  # for AsyncInferenceClient
         "pytest-rerunfailures",  # to rerun flaky tests in CI
         "pytest-mock",
-        "pytest-timeout",
         "urllib3<2.0",  # VCR.py broken with urllib3 2.0 (see https://urllib3.readthedocs.io/en/stable/v2-migration-guide.html)
         "soundfile",
         "Pillow",

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ extras["tensorflow-testing"] = [
     "keras<3.0",
 ]
 
+extras["hf_xet"] = ["hf_xet"]
 
 extras["testing"] = (
     extras["cli"]

--- a/src/huggingface_hub/_commit_api.py
+++ b/src/huggingface_hub/_commit_api.py
@@ -33,6 +33,7 @@ from .utils import (
     validate_hf_hub_args,
 )
 from .utils import tqdm as hf_tqdm
+from .utils.tqdm import _get_progress_bar_context
 
 
 if TYPE_CHECKING:
@@ -570,18 +571,15 @@ def _upload_xet_files(
             description = f"Uploading Batch [{str(i + 1).zfill(num_chunks_num_digits)}/{num_chunks}]..."
         else:
             description = "Uploading..."
-        progress_cm: hf_tqdm = hf_tqdm(
-            unit="B",
-            unit_scale=True,
+        progress_cm = _get_progress_bar_context(
+            desc=description,
             total=expected_size,
             initial=0,
-            desc=description,
-            disable=True if (logger.getEffectiveLevel() == logging.NOTSET) else None,
-            # ^ set `disable=None` rather than `disable=False` by default to disable progress bar when no TTY attached
-            # see https://github.com/huggingface/huggingface_hub/pull/2000
+            unit="B",
+            unit_scale=True,
             name="huggingface_hub.xet_put",
+            log_level=logger.getEffectiveLevel(),
         )
-
         with progress_cm as progress:
 
             def update_progress(increment: int):

--- a/src/huggingface_hub/_commit_api.py
+++ b/src/huggingface_hub/_commit_api.py
@@ -550,6 +550,8 @@ def _upload_xet_files(
             ) from e
         else:
             raise e
+    except Exception as e:
+        raise e
 
     xet_endpoint = xet_metadata.endpoint
     access_token_info = (xet_metadata.access_token, xet_metadata.expiration_unix_epoch)

--- a/src/huggingface_hub/_commit_api.py
+++ b/src/huggingface_hub/_commit_api.py
@@ -51,7 +51,7 @@ UploadMode = Literal["lfs", "regular"]
 # See https://github.com/huggingface/huggingface_hub/issues/1503
 FETCH_LFS_BATCH_SIZE = 500
 
-XET_UPLOAD_BATCH_MAX_NUM_FILES = 256
+UPLOAD_BATCH_MAX_NUM_FILES = 256
 
 
 @dataclass
@@ -397,7 +397,7 @@ def _upload_lfs_files(
     #         Upload instructions are retrieved by chunk of 256 files to avoid reaching
     #         the payload limit.
     batch_actions: List[Dict] = []
-    for chunk in chunk_iterable(additions, chunk_size=XET_UPLOAD_BATCH_MAX_NUM_FILES):
+    for chunk in chunk_iterable(additions, chunk_size=UPLOAD_BATCH_MAX_NUM_FILES):
         batch_actions_chunk, batch_errors_chunk = post_lfs_batch_info(
             upload_infos=[op.upload_info for op in chunk],
             repo_id=repo_id,
@@ -560,9 +560,9 @@ def _upload_xet_files(
             raise ValueError("Failed to refresh xet token")
         return new_xet_metadata.access_token, new_xet_metadata.expiration_unix_epoch
 
-    num_chunks = math.ceil(len(additions) / XET_UPLOAD_BATCH_MAX_NUM_FILES)
+    num_chunks = math.ceil(len(additions) / UPLOAD_BATCH_MAX_NUM_FILES)
     num_chunks_num_digits = int(math.log10(num_chunks)) + 1
-    for i, chunk in enumerate(chunk_iterable(additions, chunk_size=XET_UPLOAD_BATCH_MAX_NUM_FILES)):
+    for i, chunk in enumerate(chunk_iterable(additions, chunk_size=UPLOAD_BATCH_MAX_NUM_FILES)):
         _chunk = [op for op in chunk]
         paths = [str(op.path_or_fileobj) for op in _chunk]
         expected_size = sum([os.path.getsize(path) for path in paths])

--- a/src/huggingface_hub/_commit_api.py
+++ b/src/huggingface_hub/_commit_api.py
@@ -51,9 +51,7 @@ UploadMode = Literal["lfs", "regular"]
 # See https://github.com/huggingface/huggingface_hub/issues/1503
 FETCH_LFS_BATCH_SIZE = 500
 
-# number of files to upload at a time via xet upload
-# original usage to batch lfs uploads
-UPLOAD_BATCH_MAX_NUM_FILES = 256
+XET_UPLOAD_BATCH_MAX_NUM_FILES = 256
 
 
 @dataclass
@@ -399,7 +397,7 @@ def _upload_lfs_files(
     #         Upload instructions are retrieved by chunk of 256 files to avoid reaching
     #         the payload limit.
     batch_actions: List[Dict] = []
-    for chunk in chunk_iterable(additions, chunk_size=UPLOAD_BATCH_MAX_NUM_FILES):
+    for chunk in chunk_iterable(additions, chunk_size=XET_UPLOAD_BATCH_MAX_NUM_FILES):
         batch_actions_chunk, batch_errors_chunk = post_lfs_batch_info(
             upload_infos=[op.upload_info for op in chunk],
             repo_id=repo_id,
@@ -494,6 +492,8 @@ def _upload_xet_files(
             The endpoint to use for the xetcas service. Defaults to `constants.ENDPOINT`.
         revision (`str`, *optional*):
             The git revision to upload to.
+        create_pr (`bool`, *optional*):
+            Whether or not to create a Pull Request with that commit.
     Raises:
         [`EnvironmentError`](https://docs.python.org/3/library/exceptions.html#EnvironmentError)
             If an upload failed for any reason
@@ -560,9 +560,9 @@ def _upload_xet_files(
             raise ValueError("Failed to refresh xet token")
         return new_xet_metadata.access_token, new_xet_metadata.expiration_unix_epoch
 
-    num_chunks = math.ceil(len(additions) / UPLOAD_BATCH_MAX_NUM_FILES)
+    num_chunks = math.ceil(len(additions) / XET_UPLOAD_BATCH_MAX_NUM_FILES)
     num_chunks_num_digits = int(math.log10(num_chunks)) + 1
-    for i, chunk in enumerate(chunk_iterable(additions, chunk_size=UPLOAD_BATCH_MAX_NUM_FILES)):
+    for i, chunk in enumerate(chunk_iterable(additions, chunk_size=XET_UPLOAD_BATCH_MAX_NUM_FILES)):
         _chunk = [op for op in chunk]
         paths = [str(op.path_or_fileobj) for op in _chunk]
         expected_size = sum([os.path.getsize(path) for path in paths])

--- a/src/huggingface_hub/_upload_large_folder.py
+++ b/src/huggingface_hub/_upload_large_folder.py
@@ -25,6 +25,7 @@ from datetime import datetime
 from pathlib import Path
 from threading import Lock
 from typing import TYPE_CHECKING, List, Optional, Tuple, Union
+from urllib.parse import quote
 
 from . import constants
 from ._commit_api import CommitOperationAdd, UploadInfo, _fetch_upload_modes
@@ -497,7 +498,7 @@ def _get_upload_mode(items: List[JOB_ITEM_T], api: "HfApi", repo_id: str, repo_t
         repo_type=repo_type,
         repo_id=repo_id,
         headers=api._build_hf_headers(),
-        revision=revision,
+        revision=quote(revision, safe=""),
     )
     for item, addition in zip(items, additions):
         paths, metadata = item

--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -233,3 +233,15 @@ ALL_INFERENCE_API_FRAMEWORKS = MAIN_INFERENCE_API_FRAMEWORKS + [
     "stanza",
     "timm",
 ]
+
+# Xet constants
+
+# TODO: xetpoc - change this to the production endpoint
+_XET_CAS_DEFAULT_SANDBOX_ENDPOINT = "http://cas-server.us.dev.moon.huggingface.tech/"
+XET_ENDPOINT = os.getenv("HF_XET_CAS_ENDPOINT") or _XET_CAS_DEFAULT_SANDBOX_ENDPOINT
+
+HUGGINGFACE_HEADER_X_XET_ENDPOINT = "X-Xet-Cas-Url"
+HUGGINGFACE_HEADER_X_XET_ACCESS_TOKEN = "X-Xet-Access-Token"
+HUGGINGFACE_HEADER_X_XET_EXPIRATION = "X-Xet-Token-Expiration"
+HUGGINGFACE_HEADER_X_XET_HASH = "X-Xet-Hash"
+HUGGINGFACE_HEADER_X_XET_REFRESH_ROUTE = "X-Xet-Refresh-Route"

--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -245,3 +245,6 @@ HUGGINGFACE_HEADER_X_XET_ACCESS_TOKEN = "X-Xet-Access-Token"
 HUGGINGFACE_HEADER_X_XET_EXPIRATION = "X-Xet-Token-Expiration"
 HUGGINGFACE_HEADER_X_XET_HASH = "X-Xet-Hash"
 HUGGINGFACE_HEADER_X_XET_REFRESH_ROUTE = "X-Xet-Refresh-Route"
+
+default_xet_cache_path = os.path.join(HF_HOME, "xet")
+HF_XET_CACHE = os.getenv("HF_XET_CACHE", default_xet_cache_path)

--- a/src/huggingface_hub/errors.py
+++ b/src/huggingface_hub/errors.py
@@ -327,3 +327,22 @@ class DDUFExportError(DDUFError):
 
 class DDUFInvalidEntryNameError(DDUFExportError):
     """Exception thrown when the entry name is invalid."""
+
+
+# XET ERRORS
+
+
+class XetError(Exception):
+    """Base exception for errors related to Xet Storage."""
+
+
+class XetAuthorizationError(XetError):
+    """Exception thrown when the user does not have the right authorization to use Xet Storage."""
+
+
+class XetRefreshTokenError(XetError):
+    """Exception thrown when the refresh token is invalid."""
+
+
+class XetDownloadError(Exception):
+    """Exception thrown when the download from Xet Storage fails."""

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -4282,14 +4282,8 @@ class HfApi:
             logger.info("Uploading files using Xet Storage..")
             _upload_xet_files(**upload_kwargs, create_pr=create_pr)  # type: ignore [arg-type]
         else:
-            if xet_enabled:
-                if not is_xet_available():
-                    logger.warning(
-                        "Repository is configured for Xet Storage but `hf_xet` package is not installed. "
-                        "Falling back to HTTP upload. Run `pip install hf_xet` or `pip install huggingface-hub[hf_xet]` "
-                        "to enable Xet Storage."
-                    )
-                elif has_binary_data:
+            if xet_enabled and is_xet_available():
+                if has_binary_data:
                     logger.warning(
                         "Uploading files as bytes or binary IO objects is not supported by Xet Storage. "
                         "Falling back to HTTP upload."

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -42,7 +42,7 @@ from typing import (
     Union,
     overload,
 )
-from urllib.parse import quote
+from urllib.parse import quote, unquote
 
 import requests
 from requests.exceptions import HTTPError
@@ -4272,7 +4272,10 @@ class HfApi:
         # - the library is installed.
         # Otherwise, default back to LFS.
         xet_enabled = self.repo_info(
-            repo_id=repo_id, repo_type=repo_type, revision=revision, expand="xetEnabled"
+            repo_id=repo_id,
+            repo_type=repo_type,
+            revision=unquote(revision) if revision is not None else revision,
+            expand="xetEnabled",
         ).xet_enabled
         has_binary_data = any(
             isinstance(addition.path_or_fileobj, (bytes, io.BufferedIOBase))

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -4276,6 +4276,7 @@ class HfApi:
             repo_type=repo_type,
             revision=unquote(revision) if revision is not None else revision,
             expand="xetEnabled",
+            token=token,
         ).xet_enabled
         has_binary_data = any(
             isinstance(addition.path_or_fileobj, (bytes, io.BufferedIOBase))

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -4266,7 +4266,10 @@ class HfApi:
             # PR (i.e. `revision`).
             "revision": revision if not create_pr else None,
         }
-        # Upload files using Xet protocol if: xet is enabled for the repo, the files are provided as str or paths objects and the library is installed.
+        # Upload files using Xet protocol if all of the following are true:
+        # - xet is enabled for the repo,
+        # - the files are provided as str or paths objects,
+        # - the library is installed.
         # Otherwise, default back to LFS.
         xet_enabled = self.repo_info(
             repo_id=repo_id, repo_type=repo_type, revision=revision, expand="xetEnabled"

--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -107,4 +107,5 @@ from ._subprocess import capture_output, run_interactive_subprocess, run_subproc
 from ._telemetry import send_telemetry
 from ._typing import is_jsonable, is_simple_optional_type, unwrap_simple_optional_type
 from ._validators import smoothly_deprecate_use_auth_token, validate_hf_hub_args, validate_repo_id
+from ._xet import XetMetadata, XetTokenType, fetch_xet_metadata_from_repo_info, parse_xet_headers
 from .tqdm import are_progress_bars_disabled, disable_progress_bars, enable_progress_bars, tqdm, tqdm_stream_file

--- a/src/huggingface_hub/utils/_runtime.py
+++ b/src/huggingface_hub/utils/_runtime.py
@@ -151,6 +151,15 @@ def get_hf_transfer_version() -> str:
     return _get_version("hf_transfer")
 
 
+# xet
+def is_xet_available() -> bool:
+    return is_package_available("hf_xet")
+
+
+def get_xet_version() -> str:
+    return _get_version("hf_xet")
+
+
 # keras
 def is_keras_available() -> bool:
     return is_package_available("keras")
@@ -357,6 +366,7 @@ def dump_environment_info() -> Dict[str, Any]:
     info["numpy"] = get_numpy_version()
     info["pydantic"] = get_pydantic_version()
     info["aiohttp"] = get_aiohttp_version()
+    info["hf_xet"] = get_xet_version()
 
     # Environment variables
     info["ENDPOINT"] = constants.ENDPOINT

--- a/src/huggingface_hub/utils/_runtime.py
+++ b/src/huggingface_hub/utils/_runtime.py
@@ -36,6 +36,7 @@ _CANDIDATES = {
     "gradio": {"gradio"},
     "graphviz": {"graphviz"},
     "hf_transfer": {"hf_transfer"},
+    "hf_xet": {"hf_xet"},
     "jinja": {"Jinja2"},
     "keras": {"keras"},
     "numpy": {"numpy"},

--- a/src/huggingface_hub/utils/_xet.py
+++ b/src/huggingface_hub/utils/_xet.py
@@ -1,0 +1,120 @@
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict, Optional
+
+from .. import constants
+from . import get_session, hf_raise_for_status, validate_hf_hub_args
+
+
+class XetTokenType(str, Enum):
+    READ = "read"
+    WRITE = "write"
+
+
+@dataclass(frozen=True)
+class XetMetadata:
+    endpoint: str
+    access_token: str
+    expiration_unix_epoch: int
+    refresh_route: Optional[str] = None
+    file_hash: Optional[str] = None
+
+
+def parse_xet_headers(headers: Dict[str, str]) -> Optional[XetMetadata]:
+    """
+    Parse XET metadata from the HTTP headers or return None if not found.
+    Args:
+        headers (`Dict`):
+           HTTP headers to extract the XET metadata from.
+    Returns:
+        `XetMetadata` or `None`:
+            The metadata needed to make the request to the xet storage service.
+            Returns `None` if the headers do not contain the XET metadata.
+    """
+    # endpoint, access_token and expiration are required
+    try:
+        endpoint = headers[constants.HUGGINGFACE_HEADER_X_XET_ENDPOINT]
+        access_token = headers[constants.HUGGINGFACE_HEADER_X_XET_ACCESS_TOKEN]
+        expiration_unix_epoch = int(headers[constants.HUGGINGFACE_HEADER_X_XET_EXPIRATION])
+    except (KeyError, ValueError, TypeError):
+        return None
+
+    return XetMetadata(
+        endpoint=endpoint,
+        access_token=access_token,
+        expiration_unix_epoch=expiration_unix_epoch,
+        refresh_route=headers.get(constants.HUGGINGFACE_HEADER_X_XET_REFRESH_ROUTE),
+        file_hash=headers.get(constants.HUGGINGFACE_HEADER_X_XET_HASH),
+    )
+
+
+@validate_hf_hub_args
+def fetch_xet_metadata_from_repo_info(
+    *,
+    token_type: XetTokenType,
+    repo_id: str,
+    repo_type: str,
+    revision: Optional[str] = None,
+    headers: Dict[str, str],
+    endpoint: Optional[str] = None,
+    params: Optional[Dict[str, str]] = None,
+) -> XetMetadata:
+    """
+    Uses the repo info to request a xet access token from Hub.
+    Args:
+        token_type (`XetTokenType`):
+            Type of the token to request: `"read"` or `"write"`.
+        repo_id (`str`):
+            A namespace (user or an organization) and a repo name separated by a `/`.
+        repo_type (`str`):
+            Type of the repo to upload to: `"model"`, `"dataset"` or `"space"`.
+        revision (`str`, `optional`):
+            The revision of the repo to get the token for.
+        headers (`Dict[str, str]`):
+            Headers to use for the request, including authorization headers and user agent.
+        endpoint (`str`, `optional`):
+            The endpoint to use for the request. Defaults to the Hub endpoint.
+        params (`Dict[str, str]`, `optional`):
+            Additional parameters to pass with the request.
+    Returns:
+        `XetMetadata`: The metadata needed to make the request to the xet storage service.
+    Raises:
+        [`~utils.HfHubHTTPError`]
+            If the Hub API returned an error.
+        [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
+            If the Hub API response is improperly formatted.
+    """
+    endpoint = endpoint if endpoint is not None else constants.ENDPOINT
+    url = f"{endpoint}/api/{repo_type}s/{repo_id}/xet-{token_type.value}-token/{revision}"
+    return _fetch_xet_metadata_with_url(url, headers, params)
+
+
+@validate_hf_hub_args
+def _fetch_xet_metadata_with_url(
+    url: str,
+    headers: Dict[str, str],
+    params: Optional[Dict[str, str]] = None,
+) -> XetMetadata:
+    """
+    Requests the xet access token from the supplied URL.
+    Args:
+        url: (`str`):
+            The access token endpoint URL.
+        headers (`Dict[str, str]`):
+            Headers to use for the request, including authorization headers and user agent.
+    Returns:
+        `XetMetadata`:
+            The metadata needed to make the request to the xet storage service.
+    Raises:
+        [`~utils.HfHubHTTPError`]
+            If the Hub API returned an error.
+        [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
+            If the Hub API response is improperly formatted.
+    """
+    resp = get_session().get(headers=headers, url=url, params=params)
+    hf_raise_for_status(resp)
+
+    metadata = parse_xet_headers(resp.headers)  # type: ignore
+    if metadata is None:
+        raise ValueError("Xet headers have not been correctly set by the server.")
+    return metadata

--- a/src/huggingface_hub/utils/_xet.py
+++ b/src/huggingface_hub/utils/_xet.py
@@ -49,6 +49,37 @@ def parse_xet_headers(headers: Dict[str, str]) -> Optional[XetMetadata]:
 
 
 @validate_hf_hub_args
+def refresh_xet_metadata(
+    *,
+    xet_metadata: XetMetadata,
+    headers: Dict[str, str],
+    endpoint: Optional[str] = None,
+) -> XetMetadata:
+    """
+    Utilizes the information in the parsed metadata to request the Hub xet access token.
+    Args:
+        xet_metadata: (`XetMetadata`):
+            The xet metadata provided by the Hub API.
+        headers (`Dict[str, str]`):
+            Headers to use for the request, including authorization headers and user agent.
+        endpoint (`str`, `optional`):
+            The endpoint to use for the request. Defaults to the Hub endpoint.
+    Returns:
+        `XetMetadata`: The metadata needed to make the request to the xet storage service.
+    Raises:
+        [`~utils.HfHubHTTPError`]
+            If the Hub API returned an error.
+        [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
+            If the Hub API response is improperly formatted.
+    """
+    if xet_metadata.refresh_route is None:
+        raise ValueError("The provided xet metadata does not contain a refresh endpoint.")
+    endpoint = endpoint if endpoint is not None else constants.ENDPOINT
+    url = f"{endpoint}{xet_metadata.refresh_route}"
+    return _fetch_xet_metadata_with_url(url, headers)
+
+
+@validate_hf_hub_args
 def fetch_xet_metadata_from_repo_info(
     *,
     token_type: XetTokenType,

--- a/src/huggingface_hub/utils/_xet.py
+++ b/src/huggingface_hub/utils/_xet.py
@@ -133,6 +133,8 @@ def _fetch_xet_metadata_with_url(
             The access token endpoint URL.
         headers (`Dict[str, str]`):
             Headers to use for the request, including authorization headers and user agent.
+        params (`Dict[str, str]`, `optional`):
+            Additional parameters to pass with the request.
     Returns:
         `XetMetadata`:
             The metadata needed to make the request to the xet storage service.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ def patch_constants(mocker):
     with SoftTemporaryDirectory() as cache_dir:
         mocker.patch.object(constants, "HF_HOME", cache_dir)
         mocker.patch.object(constants, "HF_HUB_CACHE", os.path.join(cache_dir, "hub"))
+        mocker.patch.object(constants, "HF_XET_CACHE", os.path.join(cache_dir, "xet"))
         mocker.patch.object(constants, "HUGGINGFACE_HUB_CACHE", os.path.join(cache_dir, "hub"))
         mocker.patch.object(constants, "HF_ASSETS_CACHE", os.path.join(cache_dir, "assets"))
         mocker.patch.object(constants, "HF_TOKEN_PATH", os.path.join(cache_dir, "token"))

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -191,7 +191,7 @@ class CachedDownloadTests(unittest.TestCase):
                 )
 
     def test_private_repo_and_file_cached_locally(self):
-        api = HfApi(endpoint=ENDPOINT_STAGING)
+        api = HfApi(endpoint=ENDPOINT_STAGING, token=TOKEN)
         repo_id = api.create_repo(repo_id=repo_name(), private=True, token=TOKEN).repo_id
         api.upload_file(path_or_fileobj=b"content", path_in_repo="config.json", repo_id=repo_id, token=TOKEN)
 

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -191,7 +191,7 @@ class CachedDownloadTests(unittest.TestCase):
                 )
 
     def test_private_repo_and_file_cached_locally(self):
-        api = HfApi(endpoint=ENDPOINT_STAGING, token=TOKEN)
+        api = HfApi(endpoint=ENDPOINT_STAGING)
         repo_id = api.create_repo(repo_id=repo_name(), private=True, token=TOKEN).repo_id
         api.upload_file(path_or_fileobj=b"content", path_in_repo="config.json", repo_id=repo_id, token=TOKEN)
 

--- a/tests/test_inference_endpoints.py
+++ b/tests/test_inference_endpoints.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timezone
-from unittest.mock import Mock, patch
+from itertools import chain, repeat
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
@@ -109,6 +110,39 @@ MOCK_FAILED = {
         "targetReplica": 1,
     },
 }
+# added for test_wait_update function
+MOCK_UPDATE = {
+    "name": "my-endpoint-name",
+    "type": "protected",
+    "accountId": None,
+    "provider": {"vendor": "aws", "region": "us-east-1"},
+    "compute": {
+        "accelerator": "cpu",
+        "instanceType": "intel-icl",
+        "instanceSize": "x2",
+        "scaling": {"minReplica": 0, "maxReplica": 1},
+    },
+    "model": {
+        "repository": "gpt2",
+        "revision": "11c5a3d5811f50298f278a704980280950aedb10",
+        "task": "text-generation",
+        "framework": "pytorch",
+        "image": {"huggingface": {}},
+        "secret": {"token": "my-token"},
+    },
+    "status": {
+        "createdAt": "2023-10-26T12:41:53.263078506Z",
+        "createdBy": {"id": "6273f303f6d63a28483fde12", "name": "Wauplin"},
+        "updatedAt": "2023-10-26T12:41:53.263079138Z",
+        "updatedBy": {"id": "6273f303f6d63a28483fde12", "name": "Wauplin"},
+        "private": None,
+        "state": "updating",
+        "url": "https://vksrvs8pc1xnifhq.us-east-1.aws.endpoints.huggingface.cloud",
+        "message": "Endpoint waiting for the update",
+        "readyReplica": 0,
+        "targetReplica": 1,
+    },
+}
 
 
 def test_from_raw_initialization():
@@ -189,7 +223,7 @@ def test_fetch(mock_get: Mock):
 @patch("huggingface_hub._inference_endpoints.get_session")
 @patch("huggingface_hub.hf_api.HfApi.get_inference_endpoint")
 def test_wait_until_running(mock_get: Mock, mock_session: Mock):
-    """Test waits waits until the endpoint is ready."""
+    """Test waits until the endpoint is ready."""
     endpoint = InferenceEndpoint.from_raw(MOCK_INITIALIZING, namespace="foo")
 
     mock_get.side_effect = [
@@ -242,6 +276,27 @@ def test_wait_failed(mock_get: Mock):
     ]
     with pytest.raises(InferenceEndpointError, match=".*failed to deploy.*"):
         endpoint.wait(refresh_every=0.001)
+
+
+@patch("huggingface_hub.hf_api.HfApi.get_inference_endpoint")
+@patch("huggingface_hub._inference_endpoints.get_session")
+def test_wait_update(mock_get_session, mock_get_inference_endpoint):
+    """Test that wait() returns when the endpoint transitions to running."""
+    endpoint = InferenceEndpoint.from_raw(MOCK_INITIALIZING, namespace="foo")
+    # Create an iterator that yields three MOCK_UPDATE responses,and then infinitely yields MOCK_RUNNING responses.
+    responses = chain(
+        [InferenceEndpoint.from_raw(MOCK_UPDATE, namespace="foo")] * 3,
+        repeat(InferenceEndpoint.from_raw(MOCK_RUNNING, namespace="foo")),
+    )
+    mock_get_inference_endpoint.side_effect = lambda *args, **kwargs: next(responses)
+
+    # Patch the get_session().get() call to always return a fake response with status_code 200.
+    fake_response = MagicMock()
+    fake_response.status_code = 200
+    mock_get_session.return_value.get.return_value = fake_response
+
+    endpoint.wait(refresh_every=0.05)
+    assert endpoint.status == "running"
 
 
 @patch("huggingface_hub.hf_api.HfApi.pause_inference_endpoint")

--- a/tests/test_xet_upload.py
+++ b/tests/test_xet_upload.py
@@ -57,6 +57,7 @@ def repo_url(api, repo_type: str = "model"):
 
 
 @requires("hf_xet")
+@pytest.mark.timeout(60)
 class TestXetUpload:
     @pytest.fixture(autouse=True)
     def setup(self, tmp_path):
@@ -162,6 +163,7 @@ class TestXetUpload:
                         repo_id=repo_id,
                     )
 
+    @pytest.mark.timeout(6)
     def test_upload_folder(self, api, repo_url):
         repo_id = repo_url.repo_id
         folder_in_repo = "temp"
@@ -188,6 +190,7 @@ class TestXetUpload:
             filepath = hf_hub_download(repo_id=repo_id, filename=rpath)
             assert Path(local_path).read_bytes() == Path(filepath).read_bytes()
 
+    @pytest.mark.timeout(6)
     def test_upload_folder_create_pr(self, api, repo_url) -> None:
         repo_id = repo_url.repo_id
         folder_in_repo = "temp_create_pr"

--- a/tests/test_xet_upload.py
+++ b/tests/test_xet_upload.py
@@ -162,7 +162,6 @@ class TestXetUpload:
                         repo_id=repo_id,
                     )
 
-    @pytest.mark.timeout(6)
     def test_upload_folder(self, api, repo_url):
         repo_id = repo_url.repo_id
         folder_in_repo = "temp"
@@ -189,7 +188,6 @@ class TestXetUpload:
             filepath = hf_hub_download(repo_id=repo_id, filename=rpath)
             assert Path(local_path).read_bytes() == Path(filepath).read_bytes()
 
-    @pytest.mark.timeout(6)
     def test_upload_folder_create_pr(self, api, repo_url) -> None:
         repo_id = repo_url.repo_id
         folder_in_repo = "temp_create_pr"
@@ -212,7 +210,6 @@ class TestXetUpload:
 
 
 @requires("hf_xet")
-@pytest.mark.skip("Skipping large upload to debug")
 class TestXetLargeUpload:
     def test_upload_large_folder(self, api, tmp_path, repo_url: RepoUrl) -> None:
         N_FILES_PER_FOLDER = 4

--- a/tests/test_xet_upload.py
+++ b/tests/test_xet_upload.py
@@ -57,7 +57,6 @@ def repo_url(api, repo_type: str = "model"):
 
 
 @requires("hf_xet")
-@pytest.mark.timeout(60)
 class TestXetUpload:
     @pytest.fixture(autouse=True)
     def setup(self, tmp_path):

--- a/tests/test_xet_upload.py
+++ b/tests/test_xet_upload.py
@@ -137,6 +137,31 @@ class TestXetUpload:
                         repo_id=repo_id,
                     )
 
+    def test_upload_based_on_xet_enabled_setting(self, api, repo_url):
+        repo_id = repo_url.repo_id
+
+        # Test when xet is enabled -> use Xet upload
+        with patch("huggingface_hub.hf_api.HfApi.repo_info") as mock_repo_info:
+            mock_repo_info.return_value.xet_enabled = True
+            with assert_xet_upload_used(should_be_called=True):
+                with assert_lfs_upload_used(should_be_called=False):
+                    api.upload_file(
+                        path_or_fileobj=self.bin_file,
+                        path_in_repo="xet_enabled.bin",
+                        repo_id=repo_id,
+                    )
+
+        # Test when xet is disabled -> use LFS upload
+        with patch("huggingface_hub.hf_api.HfApi.repo_info") as mock_repo_info:
+            mock_repo_info.return_value.xet_enabled = False
+            with assert_xet_upload_used(should_be_called=False):
+                with assert_lfs_upload_used(should_be_called=True):
+                    api.upload_file(
+                        path_or_fileobj=self.bin_file,
+                        path_in_repo="xet_disabled.bin",
+                        repo_id=repo_id,
+                    )
+
     def test_upload_folder(self, api, repo_url):
         repo_id = repo_url.repo_id
         folder_in_repo = "temp"

--- a/tests/test_xet_upload.py
+++ b/tests/test_xet_upload.py
@@ -185,7 +185,7 @@ class TestXetUpload:
 
 
 @requires("hf_xet")
-@pytest.skip("Skipping large upload to debug")
+@pytest.mark.skip("Skipping large upload to debug")
 class TestXetLargeUpload:
     def test_upload_large_folder(self, api, tmp_path, repo_url: RepoUrl) -> None:
         N_FILES_PER_FOLDER = 4

--- a/tests/test_xet_upload.py
+++ b/tests/test_xet_upload.py
@@ -32,13 +32,15 @@ def assert_upload_mode(mode: str):
     if mode not in ("xet", "lfs"):
         raise ValueError("Mode must be either 'xet' or 'lfs'")
 
-    with (
-        patch("huggingface_hub.hf_api._upload_xet_files", wraps=_upload_xet_files) as mock_xet,
-        patch("huggingface_hub.hf_api._upload_lfs_files", wraps=_upload_lfs_files) as mock_lfs,
-    ):
-        yield
-        assert mock_xet.called == (mode == "xet"), f"Expected {'XET' if mode == 'xet' else 'LFS'} upload to be used"
-        assert mock_lfs.called == (mode == "lfs"), f"Expected {'LFS' if mode == 'lfs' else 'XET'} upload to be used"
+    with patch("huggingface_hub.hf_api._upload_xet_files", wraps=_upload_xet_files) as mock_xet:
+        with patch("huggingface_hub.hf_api._upload_lfs_files", wraps=_upload_lfs_files) as mock_lfs:
+            yield
+            assert mock_xet.called == (mode == "xet"), (
+                f"Expected {'XET' if mode == 'xet' else 'LFS'} upload to be used"
+            )
+            assert mock_lfs.called == (mode == "lfs"), (
+                f"Expected {'LFS' if mode == 'lfs' else 'XET'} upload to be used"
+            )
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_xet_upload.py
+++ b/tests/test_xet_upload.py
@@ -185,6 +185,7 @@ class TestXetUpload:
 
 
 @requires("hf_xet")
+@pytest.skip("Skipping large upload to debug")
 class TestXetLargeUpload:
     def test_upload_large_folder(self, api, tmp_path, repo_url: RepoUrl) -> None:
         N_FILES_PER_FOLDER = 4

--- a/tests/test_xet_utils.py
+++ b/tests/test_xet_utils.py
@@ -113,6 +113,7 @@ def test_refresh_metadata_success(mocker) -> None:
     mock_session.get.assert_called_once_with(
         headers=headers,
         url=expected_url,
+        params=None,
     )
 
     assert refreshed_metadata.endpoint == "https://example.xethub.hf.co"
@@ -154,6 +155,7 @@ def test_refresh_metadata_custom_endpoint(mocker) -> None:
     mock_session.get.assert_called_once_with(
         headers=headers,
         url=expected_url,
+        params=None,
     )
 
 
@@ -198,6 +200,7 @@ def test_fetch_xet_metadata_with_url(mocker) -> None:
     mock_session.get.assert_called_once_with(
         headers=headers,
         url=url,
+        params=None,
     )
 
     # Verify returned metadata

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -445,6 +445,9 @@ def use_tmp_repo(repo_type: str = "model") -> Callable[[T], T]:
             repo_url = self._api.create_repo(
                 repo_id=repo_name(prefix=repo_type), repo_type=repo_type, **create_repo_kwargs
             )
+            # We need to disable Xet Storage to avoid issues with the parsing of the warning logs in some tests
+            # TODO: remove this when Xet Storage is enabled by default for all users
+            self._api.update_repo_settings(repo_id=repo_url.repo_id, xet_enabled=False)
             try:
                 return test_fn(*args, **kwargs, repo_url=repo_url)
             finally:

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -445,9 +445,6 @@ def use_tmp_repo(repo_type: str = "model") -> Callable[[T], T]:
             repo_url = self._api.create_repo(
                 repo_id=repo_name(prefix=repo_type), repo_type=repo_type, **create_repo_kwargs
             )
-            # We need to disable Xet Storage to avoid issues with the parsing of the warning logs in some tests
-            # TODO: remove this when Xet Storage is enabled by default for all users
-            self._api.update_repo_settings(repo_id=repo_url.repo_id, xet_enabled=False)
             try:
                 return test_fn(*args, **kwargs, repo_url=repo_url)
             finally:


### PR DESCRIPTION
Partially resolves #2713 

This PR contains **only** the Xet upload workflow implemented in [xetpoc_huggingface_hub](https://github.com/huggingface-internal/xetpoc_huggingface_hub) (internal).

The main branch for xet storage integration is [xet-integration](https://github.com/huggingface/huggingface_hub/tree/xet-integration).

Main changes:

- [x] Make hf_xet available as an optional dependency via pip install huggingface_hub[hf_xet]
Note: since it's a common part for download and upload, this has been pushed directly into the [xet-integration](https://github.com/huggingface/huggingface_hub/tree/xet-integration) branch.
 - [x] Integrate changes from the xet poc for the download workflow only.
 - [x] Add tests.


to try it in from this branch:
```bash
pip install -e ".[dev,hf_xet]"
export HF_DEBUG=1 #  if you want to set huggingface_hub logger to debug level
huggingface-cli upload --repo-type model rajatarya/xet-enable-test ~/data/yelp_sample
```