### PR TITLE
Scaffolding for xet testing

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -32,6 +32,8 @@ jobs:
         include:
           - python-version: "3.13" # LFS not ran on 3.8
             test_name: "lfs"
+          - python-version: "3.13" # xet not run on 3.8 
+            test_name: "xet"
           - python-version: "3.8"
             test_name: "fastai"
           - python-version: "3.10" # fastai not supported on 3.12 and 3.11 -> test it on 3.10
@@ -73,6 +75,10 @@ jobs:
             lfs)
               git config --global user.email "ci@dummy.com"
               git config --global user.name "ci"
+              ;;
+
+            xet)
+              uv pip install "huggingface_hub[hf_xet] @ ."
               ;;
 
             fastai)
@@ -130,6 +136,9 @@ jobs:
               eval "RUN_GIT_LFS_TESTS=1 $PYTEST ../tests -k 'HfLargefilesTest'"
             ;;
 
+            xet)
+              eval "$PYTEST ../tests/test_xet*"
+            ;;
 
             fastai)
               eval "$PYTEST ../tests/test_fastai*"

--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -101,6 +101,7 @@ from ._runtime import (
     is_tensorboard_available,
     is_tf_available,
     is_torch_available,
+    is_xet_available,
 )
 from ._safetensors import SafetensorsFileMetadata, SafetensorsRepoMetadata, TensorInfo
 from ._subprocess import capture_output, run_interactive_subprocess, run_subprocess

--- a/tests/test_xet_integration.py
+++ b/tests/test_xet_integration.py
@@ -1,16 +1,65 @@
 import os
+from typing import Dict, Optional, Union
 from unittest import TestCase, skip
-from io import BytesIO
 
 from huggingface_hub import HfApi
+from huggingface_hub.constants import REPO_TYPE_MODEL, REPO_TYPES
+from huggingface_hub.utils import get_session, is_xet_available
 
-from huggingface_hub.utils import is_xet_available
-
-from .testing_constants import ENDPOINT_STAGING, TOKEN 
+from .testing_constants import ENDPOINT_STAGING, TOKEN
 from .testing_utils import repo_name
+
 
 WORKING_REPO_SUBDIR = f"fixtures/working_repo_{__name__.split('.')[-1]}"
 WORKING_REPO_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), WORKING_REPO_SUBDIR)
+
+
+def set_xet_enabled(
+    api: HfApi,
+    repo_id: str,
+    token: Union[str, bool, None] = None,
+    repo_type: Optional[str] = None,
+) -> Dict[str, bool]:
+    """
+    Enables XET on a repo.
+
+    This is a test utility and will go away when xet is enabled for all repos by default.
+    """
+    if repo_type not in REPO_TYPES:
+        raise ValueError(f"Invalid repo type, must be one of {REPO_TYPES}")
+    if repo_type is None:
+        repo_type = REPO_TYPE_MODEL  # default repo type
+
+    r = get_session().put(
+        url=f"{api.endpoint}/api/{repo_type}s/{repo_id}/settings",
+        headers=api._build_hf_headers(token=token),
+        json={"xetEnabled": True},
+    )
+    return r.json()
+
+
+def is_xet_enabled(
+    api: HfApi,
+    repo_id: str,
+    token: Union[str, bool, None] = None,
+    repo_type: Optional[str] = None,
+) -> bool:
+    """
+    Checks if XET is enabled on a repo.
+
+    This is a test utility and will go away when xet is enabled for all repos by default.
+    """
+    if repo_type not in REPO_TYPES:
+        raise ValueError(f"Invalid repo type, must be one of {REPO_TYPES}")
+    if repo_type is None:
+        repo_type = REPO_TYPE_MODEL  # default repo type
+
+    r = get_session().get(
+        url=f"{api.endpoint}/api/{repo_type}s/{repo_id}/xet-read-repo/main",
+        headers=api._build_hf_headers(token=token),
+    )
+    return r.status_code != 501 and r.text != "XET is not enabled in this version of Hub."
+
 
 def require_hf_xet(test_case):
     """
@@ -22,19 +71,22 @@ def require_hf_xet(test_case):
     else:
         return test_case
 
+
 @require_hf_xet
-class TestHfXet(TestCase): 
+class TestHfXet(TestCase):
     def setUp(self) -> None:
-        self.content = b"RandOm Xet ConTEnT" * 1024  
+        self.content = b"RandOm Xet ConTEnT" * 1024
         self._token = TOKEN
         self._api = HfApi(endpoint=ENDPOINT_STAGING, token=self._token)
 
         self._repo_id = self._api.create_repo(repo_name()).repo_id
+        set_xet_enabled(api=self._api, repo_id=self._repo_id, token=self._token)
 
     def tearDown(self) -> None:
         self._api.delete_repo(repo_id=self._repo_id)
 
-    def test__xet_available(self):
-        # renaming to this runs first
-        self.assertTrue(is_xet_available())
+    def test__xet_enabled_on_repo(self):
+        self.assertTrue(is_xet_enabled(api=self._api, repo_id=self._repo_id, token=self._token))
 
+    def test__xet_available(self):
+        self.assertTrue(is_xet_available())

--- a/tests/test_xet_integration.py
+++ b/tests/test_xet_integration.py
@@ -1,0 +1,40 @@
+import os
+from unittest import TestCase, skip
+from io import BytesIO
+
+from huggingface_hub import HfApi
+
+from huggingface_hub.utils import is_xet_available
+
+from .testing_constants import ENDPOINT_STAGING, TOKEN 
+from .testing_utils import repo_name
+
+WORKING_REPO_SUBDIR = f"fixtures/working_repo_{__name__.split('.')[-1]}"
+WORKING_REPO_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), WORKING_REPO_SUBDIR)
+
+def require_hf_xet(test_case):
+    """
+    Decorator marking a test that requires hf_xet.
+    These tests are skipped when hf_xet is not installed.
+    """
+    if not is_xet_available():
+        return skip("Test requires hf_xet")(test_case)
+    else:
+        return test_case
+
+@require_hf_xet
+class TestHfXet(TestCase): 
+    def setUp(self) -> None:
+        self.content = b"RandOm Xet ConTEnT" * 1024  
+        self._token = TOKEN
+        self._api = HfApi(endpoint=ENDPOINT_STAGING, token=self._token)
+
+        self._repo_id = self._api.create_repo(repo_name()).repo_id
+
+    def tearDown(self) -> None:
+        self._api.delete_repo(repo_id=self._repo_id)
+
+    def test__xet_available(self):
+        # renaming to this runs first
+        self.assertTrue(is_xet_available())
+


### PR DESCRIPTION
This change prepares us for adding xet integration testing.

It includes:
- a new test file for xet integration.
- some test utilities for managing whether xet is enabled on the repo.
- github actions will run xet tests.

Test coverage will be added to the sub branches directly. 

Partially resolves https://github.com/huggingface/huggingface_hub/issues/2713.