### PR TITLE
Support deploy Inference Endpoint from model catalog

### DIFF
--- a/docs/source/en/guides/inference_endpoints.md
+++ b/docs/source/en/guides/inference_endpoints.md
@@ -6,6 +6,15 @@ In this guide, we will learn how to programmatically manage Inference Endpoints 
 This guide assumes `huggingface_hub` is correctly installed and that your machine is logged in. Check out the [Quick Start guide](https://huggingface.co/docs/huggingface_hub/quick-start#quickstart) if that's not the case yet. The minimal version supporting Inference Endpoints API is `v0.19.0`.
 
 
+<Tip>
+
+**New:** it is now possible to deploy an Inference Endpoint from the [HF model catalog](https://endpoints.huggingface.co/catalog) with a simple API call. The catalog is a carefully curated list of models that can be deployed with optimized settings. You don't need to configure anything, we take all the heavy stuff on us! All models and settings are guaranteed to have been tested to provide best cost/performance balance.  [`create_inference_endpoint_from_catalog`] works the same as [`create_inference_endpoint`], with much less parameters to pass. You can use [`list_inference_catalog`] to programmatically retrieve the catalog.
+
+Note that this is still an experimental feature. Let us know what you think if you use it!
+
+</Tip>
+
+
 ## Create an Inference Endpoint
 
 The first step is to create an Inference Endpoint using [`create_inference_endpoint`]:

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -165,6 +165,7 @@ _SUBMOD_ATTRS = {
         "create_commit",
         "create_discussion",
         "create_inference_endpoint",
+        "create_inference_endpoint_from_catalog",
         "create_pull_request",
         "create_repo",
         "create_tag",
@@ -205,6 +206,7 @@ _SUBMOD_ATTRS = {
         "list_accepted_access_requests",
         "list_collections",
         "list_datasets",
+        "list_inference_catalog",
         "list_inference_endpoints",
         "list_liked_repos",
         "list_models",
@@ -769,6 +771,7 @@ __all__ = [
     "create_commit",
     "create_discussion",
     "create_inference_endpoint",
+    "create_inference_endpoint_from_catalog",
     "create_pull_request",
     "create_repo",
     "create_tag",
@@ -823,6 +826,7 @@ __all__ = [
     "list_accepted_access_requests",
     "list_collections",
     "list_datasets",
+    "list_inference_catalog",
     "list_inference_endpoints",
     "list_liked_repos",
     "list_models",
@@ -1107,6 +1111,7 @@ if TYPE_CHECKING:  # pragma: no cover
         create_commit,  # noqa: F401
         create_discussion,  # noqa: F401
         create_inference_endpoint,  # noqa: F401
+        create_inference_endpoint_from_catalog,  # noqa: F401
         create_pull_request,  # noqa: F401
         create_repo,  # noqa: F401
         create_tag,  # noqa: F401
@@ -1147,6 +1152,7 @@ if TYPE_CHECKING:  # pragma: no cover
         list_accepted_access_requests,  # noqa: F401
         list_collections,  # noqa: F401
         list_datasets,  # noqa: F401
+        list_inference_catalog,  # noqa: F401
         list_inference_endpoints,  # noqa: F401
         list_liked_repos,  # noqa: F401
         list_models,  # noqa: F401

--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -78,6 +78,7 @@ INFERENCE_ENDPOINT = os.environ.get("HF_INFERENCE_ENDPOINT", "https://api-infere
 
 # See https://huggingface.co/docs/inference-endpoints/index
 INFERENCE_ENDPOINTS_ENDPOINT = "https://api.endpoints.huggingface.cloud/v2"
+INFERENCE_CATALOG_ENDPOINT = "https://endpoints.huggingface.co/api/catalog"
 
 # Proxy for third-party providers
 INFERENCE_PROXY_TEMPLATE = "https://router.huggingface.co/{provider}"

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -16,9 +16,7 @@ from __future__ import annotations
 
 import inspect
 import json
-import random
 import re
-import string
 import struct
 import warnings
 from collections import defaultdict
@@ -7526,8 +7524,9 @@ class HfApi:
 
         </Tip>
         """
+        token = token or self.token or get_token()
         payload: Dict = {
-            "accessToken": token or self.token or get_token(),
+            "accessToken": token,
             "namespace": namespace or self._get_namespace(token=token),
             "repoId": repo_id,
         }
@@ -7540,7 +7539,8 @@ class HfApi:
             json=payload,
         )
         hf_raise_for_status(response)
-        return InferenceEndpoint.from_raw(response.json()["endpoint"], namespace=namespace, token=token)
+        data = response.json()["endpoint"]
+        return InferenceEndpoint.from_raw(data, namespace=data[name], token=token)
 
     @experimental
     @validate_hf_hub_args

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -16,7 +16,9 @@ from __future__ import annotations
 
 import inspect
 import json
+import random
 import re
+import string
 import struct
 import warnings
 from collections import defaultdict
@@ -112,6 +114,7 @@ from .utils import (
     SafetensorsRepoMetadata,
     TensorInfo,
     build_hf_headers,
+    experimental,
     filter_repo_objects,
     fix_hf_endpoint_in_url,
     get_session,
@@ -7485,6 +7488,93 @@ class HfApi:
 
         return InferenceEndpoint.from_raw(response.json(), namespace=namespace, token=token)
 
+    @experimental
+    @validate_hf_hub_args
+    def create_inference_endpoint_from_catalog(
+        self,
+        repo_id: str,
+        *,
+        name: Optional[str] = None,
+        token: Union[bool, str, None] = None,
+        namespace: Optional[str] = None,
+    ) -> InferenceEndpoint:
+        """Create a new Inference Endpoint from a model in the Hugging Face Inference Catalog.
+
+        The goal of the Inference Catalog is to provide a curated list of models that are optimized for inference
+        and for which default configurations have been tested. See https://endpoints.huggingface.co/catalog for a list
+        of available models in the catalog.
+
+        Args:
+            repo_id (`str`):
+                The ID of the model in the catalog to deploy as an Inference Endpoint.
+            name (`str`, *optional*):
+                The unique name for the new Inference Endpoint. If not provided, a random name will be generated.
+            token (Union[bool, str, None], optional):
+                A valid user access token (string). Defaults to the locally saved
+                token, which is the recommended method for authentication (see
+                https://huggingface.co/docs/huggingface_hub/quick-start#authentication).
+            namespace (`str`, *optional*):
+                The namespace where the Inference Endpoint will be created. Defaults to the current user's namespace.
+
+        Returns:
+            [`InferenceEndpoint`]: information about the new Inference Endpoint.
+
+        <Tip warning={true}>
+
+        `create_inference_endpoint_from_catalog` is experimental. Its API is subject to change in the future. Please provide feedback
+        if you have any suggestions or requests.
+
+        </Tip>
+        """
+        payload: Dict = {
+            "accessToken": token or self.token or get_token(),
+            "namespace": namespace or self._get_namespace(token=token),
+            "repoId": repo_id,
+        }
+        if name is not None:
+            payload["endpointName"] = name
+
+        response = get_session().post(
+            f"{constants.INFERENCE_CATALOG_ENDPOINT}/deploy",
+            headers=self._build_hf_headers(token=False),
+            json=payload,
+        )
+        hf_raise_for_status(response)
+        return InferenceEndpoint.from_raw(response.json()["endpoint"], namespace=namespace, token=token)
+
+    @experimental
+    @validate_hf_hub_args
+    def list_inference_catalog(self, *, token: Union[bool, str, None] = None) -> List[str]:
+        """List models available in the Hugging Face Inference Catalog.
+
+        The goal of the Inference Catalog is to provide a curated list of models that are optimized for inference
+        and for which default configurations have been tested. See https://endpoints.huggingface.co/catalog for a list
+        of available models in the catalog.
+
+        Use [`create_inference_endpoint_from_catalog`] to deploy a model from the catalog.
+
+        Args:
+            token (Union[bool, str, None], optional):
+                A valid user access token (string). Defaults to the locally saved
+                token, which is the recommended method for authentication (see
+                https://huggingface.co/docs/huggingface_hub/quick-start#authentication).
+
+        Returns:
+            List[`str`]: A list of model IDs available in the catalog.
+        <Tip warning={true}>
+
+        `list_inference_catalog` is experimental. Its API is subject to change in the future. Please provide feedback
+        if you have any suggestions or requests.
+
+        </Tip>
+        """
+        response = get_session().get(
+            f"{constants.INFERENCE_CATALOG_ENDPOINT}/repo-list",
+            headers=self._build_hf_headers(token=token),
+        )
+        hf_raise_for_status(response)
+        return response.json()["models"]
+
     def get_inference_endpoint(
         self, name: str, *, namespace: Optional[str] = None, token: Union[bool, str, None] = None
     ) -> InferenceEndpoint:
@@ -9607,6 +9697,8 @@ delete_inference_endpoint = api.delete_inference_endpoint
 pause_inference_endpoint = api.pause_inference_endpoint
 resume_inference_endpoint = api.resume_inference_endpoint
 scale_to_zero_inference_endpoint = api.scale_to_zero_inference_endpoint
+create_inference_endpoint_from_catalog = api.create_inference_endpoint_from_catalog
+list_inference_catalog = api.list_inference_catalog
 
 # Collections API
 get_collection = api.get_collection

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -7526,7 +7526,6 @@ class HfApi:
         """
         token = token or self.token or get_token()
         payload: Dict = {
-            "accessToken": token,
             "namespace": namespace or self._get_namespace(token=token),
             "repoId": repo_id,
         }
@@ -7535,12 +7534,12 @@ class HfApi:
 
         response = get_session().post(
             f"{constants.INFERENCE_CATALOG_ENDPOINT}/deploy",
-            headers=self._build_hf_headers(token=False),
+            headers=self._build_hf_headers(token=token),
             json=payload,
         )
         hf_raise_for_status(response)
         data = response.json()["endpoint"]
-        return InferenceEndpoint.from_raw(data, namespace=data[name], token=token)
+        return InferenceEndpoint.from_raw(data, namespace=data["name"], token=token)
 
     @experimental
     @validate_hf_hub_args

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -59,6 +59,7 @@ from huggingface_hub.hf_api import (
     ExpandDatasetProperty_T,
     ExpandModelProperty_T,
     ExpandSpaceProperty_T,
+    InferenceEndpoint,
     ModelInfo,
     RepoSibling,
     RepoUrl,
@@ -4363,3 +4364,69 @@ class TestHfApiAuthCheck(HfApiCommonTest):
 
         with self.assertRaises(GatedRepoError):
             self._api.auth_check(repo_id=repo_id, token=OTHER_TOKEN)
+
+
+class HfApiInferenceCatalogTest(HfApiCommonTest):
+    def test_list_inference_catalog(self) -> None:
+        models = self._api.list_inference_catalog()  # note: @experimental api
+        # Check that server returns a list[str] => at least if it changes in the future, we'll notice
+        assert isinstance(models, List)
+        assert len(models) > 0
+        assert all(isinstance(model, str) for model in models)
+
+    @patch("huggingface_hub.hf_api.get_session")
+    def test_create_inference_endpoint_from_catalog(self, mock_get_session: Mock) -> None:
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "endpoint": {
+                "compute": {
+                    "accelerator": "gpu",
+                    "id": "aws-us-east-1-nvidia-l4-x1",
+                    "instanceSize": "x1",
+                    "instanceType": "nvidia-l4",
+                    "scaling": {
+                        "maxReplica": 1,
+                        "measure": {"hardwareUsage": None},
+                        "metric": "hardwareUsage",
+                        "minReplica": 0,
+                        "scaleToZeroTimeout": 15,
+                    },
+                },
+                "model": {
+                    "env": {},
+                    "framework": "pytorch",
+                    "image": {
+                        "tgi": {
+                            "disableCustomKernels": False,
+                            "healthRoute": "/health",
+                            "port": 80,
+                            "url": "ghcr.io/huggingface/text-generation-inference:3.1.1",
+                        }
+                    },
+                    "repository": "meta-llama/Llama-3.2-3B-Instruct",
+                    "revision": "0cb88a4f764b7a12671c53f0838cd831a0843b95",
+                    "secrets": {},
+                    "task": "text-generation",
+                },
+                "name": "llama-3-2-3b-instruct-eey",
+                "provider": {"region": "us-east-1", "vendor": "aws"},
+                "status": {
+                    "createdAt": "2025-03-07T15:30:13.949Z",
+                    "createdBy": {"id": "6273f303f6d63a28483fde12", "name": "Wauplin"},
+                    "message": "Endpoint waiting to be scheduled",
+                    "readyReplica": 0,
+                    "state": "pending",
+                    "targetReplica": 1,
+                    "updatedAt": "2025-03-07T15:30:13.949Z",
+                    "updatedBy": {"id": "6273f303f6d63a28483fde12", "name": "Wauplin"},
+                },
+                "type": "protected",
+            }
+        }
+        mock_get_session.return_value.post.return_value = mock_response
+
+        endpoint = self._api.create_inference_endpoint_from_catalog(
+            repo_id="meta-llama/Llama-3.2-3B-Instruct", namespace="Wauplin"
+        )
+        assert isinstance(endpoint, InferenceEndpoint)
+        assert endpoint.name == "llama-3-2-3b-instruct-eey"


### PR DESCRIPTION
solves https://github.com/huggingface/huggingface_hub/issues/2880 cc @ErikKaum 

This PR adds `list_inference_catalog` and `create_inference_endpoint_from_catalog` to list the HF Model Catalog (https://endpoints.huggingface.co/catalog) and create an Inference Endpoint from any of the listed models. Both methods are flagged as experimental as we might want to update the format in the future. This should be a low hanging fruit to allow people to quickly deploy a model.