### PR TITLE
Add ability to enable/disable xet storage on a repo

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -3642,6 +3642,7 @@ class HfApi:
         private: Optional[bool] = None,
         token: Union[str, bool, None] = None,
         repo_type: Optional[str] = None,
+        xet_enabled: Optional[bool] = None,
     ) -> None:
         """
         Update the settings of a repository, including gated access and visibility.
@@ -3667,7 +3668,8 @@ class HfApi:
             repo_type (`str`, *optional*):
                 The type of the repository to update settings from (`"model"`, `"dataset"` or `"space"`).
                 Defaults to `"model"`.
-
+            xet_enabled (`bool`, *optional*):
+                Whether the repository should be enabled for Xet Storage.
         Raises:
             [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
                 If gated is not one of "auto", "manual", or False.
@@ -3685,9 +3687,9 @@ class HfApi:
         if repo_type is None:
             repo_type = constants.REPO_TYPE_MODEL  # default repo type
 
-        # Check if both gated and private are None
-        if gated is None and private is None:
-            raise ValueError("At least one of 'gated' or 'private' must be provided.")
+        # Check if gated, private, and xet_enabled are None
+        if gated is None and private is None and xet_enabled is None:
+            raise ValueError("At least one of 'gated', 'private' or 'xet_enabled' must be provided.")
 
         # Build headers
         headers = self._build_hf_headers(token=token)
@@ -3702,6 +3704,9 @@ class HfApi:
 
         if private is not None:
             payload["private"] = private
+
+        if xet_enabled is not None:
+            payload["xetEnabled"] = xet_enabled
 
         r = get_session().put(
             url=f"{self.endpoint}/api/{repo_type}s/{repo_id}/settings",

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -3694,13 +3694,6 @@ class HfApi:
         if repo_type is None:
             repo_type = constants.REPO_TYPE_MODEL  # default repo type
 
-        # Check if gated, private, and xet_enabled are None
-        if gated is None and private is None and xet_enabled is None:
-            raise ValueError("At least one of 'gated', 'private' or 'xet_enabled' must be provided.")
-
-        # Build headers
-        headers = self._build_hf_headers(token=token)
-
         # Prepare the JSON payload for the PUT request
         payload: Dict = {}
 
@@ -3714,6 +3707,12 @@ class HfApi:
 
         if xet_enabled is not None:
             payload["xetEnabled"] = xet_enabled
+
+        if len(payload) == 0:
+            raise ValueError("At least one setting must be updated.")
+
+        # Build headers
+        headers = self._build_hf_headers(token=token)
 
         r = get_session().put(
             url=f"{self.endpoint}/api/{repo_type}s/{repo_id}/settings",

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -273,6 +273,13 @@ class HfApiEndpointsTest(HfApiCommonTest):
                 assert info.gated == gated_value
                 assert info.private == private_value
 
+    @use_tmp_repo(repo_type="model")
+    def test_update_repo_settings_xet_enabled(self, repo_url: RepoUrl):
+        repo_id = repo_url.repo_id
+        self._api.update_repo_settings(repo_id=repo_id, xet_enabled=True)
+        info = self._api.model_info(repo_id, expand="xetEnabled")
+        assert info.xet_enabled
+
     @expect_deprecation("get_token_permission")
     def test_get_token_permission_on_oauth_token(self):
         whoami = {


### PR DESCRIPTION
This PR updates `update_repo_settings` to add the ability to enable or disable xet storage.

**Note**: No test has been added for now as xet storage is not properly integrated into the staging environment (https://hub-ci.huggingface.co/) and  we cannot test in production for an obvious reason: the CI would need to be the owner of the repo to be able to update this setting.
A proper test will be added once the staging environment supports xet storage. 
cc @bpronan 