### PR TITLE
Fix: Restore sys.stdout in notebook_login after error

### DIFF
--- a/src/huggingface_hub/utils/_subprocess.py
+++ b/src/huggingface_hub/utils/_subprocess.py
@@ -44,8 +44,10 @@ def capture_output() -> Generator[StringIO, None, None]:
     output = StringIO()
     previous_output = sys.stdout
     sys.stdout = output
-    yield output
-    sys.stdout = previous_output
+    try:
+        yield output
+    finally:
+        sys.stdout = previous_output
 
 
 def run_subprocess(


### PR DESCRIPTION
## Issue
In `notebook_login`, when using `capture_output`, `sys.stdout` is redirected to `StringIO`, 
but if an error occurs, it is not restored, causing issues in `ipykernel`.

## Fix
- Ensure `sys.stdout` is restored using a `finally` block.
