### PR TITLE
Remove link to unmaintained model card app Space

### DIFF
--- a/docs/source/en/guides/model-cards.md
+++ b/docs/source/en/guides/model-cards.md
@@ -8,12 +8,6 @@ The `huggingface_hub` library provides a Python interface to create, share, and 
 Visit [the dedicated documentation page](https://huggingface.co/docs/hub/models-cards)
 for a deeper view of what Model Cards on the Hub are, and how they work under the hood.
 
-<Tip>
-
-[New (beta)! Try our experimental Model Card Creator App](https://huggingface.co/spaces/huggingface/Model_Cards_Writing_Tool)
-
-</Tip>
-
 ## Load a Model Card from the Hub
 
 To load an existing card from the Hub, you can use the [`ModelCard.load`] function. Here, we'll load the card from [`nateraw/vit-base-beans`](https://huggingface.co/nateraw/vit-base-beans).


### PR DESCRIPTION
This Space linked to here isn't maintained AFAIK, and seems to not work reliably currently. Maybe better to remove the link for now? cc @Wauplin @julien-c 
<img width="673" alt="Screenshot 2025-03-03 at 11 38 19" src="https://github.com/user-attachments/assets/f8600a1a-95cf-4232-967d-fe9d59af3446" />
