### PR TITLE
Small fix in style bot GH action

### DIFF
--- a/.github/workflows/style-bot-action.yml
+++ b/.github/workflows/style-bot-action.yml
@@ -123,11 +123,11 @@ jobs:
           chmod +x pre_commit_script.sh
           ./pre_commit_script.sh
 
-      - name: Run make style and make quality
+      - name: Run style command
         env:
           style_command: ${{ inputs.style_command }}
         run: |
-          $style_command
+          bash -c "$style_command"
 
       - name: Commit and push changes
         id: commit_and_push


### PR DESCRIPTION
small fix: wrapping the style command in `bash -c` which ensures that the shell properly interprets the && operator in the command string.