### PR TITLE
Fix payload model name when model id is a URL

### DIFF
--- a/src/huggingface_hub/inference/_providers/hf_inference.py
+++ b/src/huggingface_hub/inference/_providers/hf_inference.py
@@ -84,10 +84,11 @@ class HFInferenceConversational(HFInferenceTask):
         super().__init__("text-generation")
 
     def _prepare_payload_as_dict(self, inputs: Any, parameters: Dict, mapped_model: str) -> Optional[Dict]:
-        if mapped_model.startswith(("http://", "https://")):
-            payload_model = parameters.get("model") or "dummy"
-        else:
-            payload_model = mapped_model
+        payload_model = parameters.get("model") or mapped_model
+
+        if payload_model is None or payload_model.startswith(("http://", "https://")):
+            payload_model = "dummy"
+
         return {**filter_none(parameters), "model": payload_model, "messages": inputs}
 
     def _prepare_url(self, api_key: str, mapped_model: str) -> str:

--- a/src/huggingface_hub/inference/_providers/hf_inference.py
+++ b/src/huggingface_hub/inference/_providers/hf_inference.py
@@ -84,7 +84,10 @@ class HFInferenceConversational(HFInferenceTask):
         super().__init__("text-generation")
 
     def _prepare_payload_as_dict(self, inputs: Any, parameters: Dict, mapped_model: str) -> Optional[Dict]:
-        payload_model = "tgi" if mapped_model.startswith(("http://", "https://")) else mapped_model
+        if mapped_model.startswith(("http://", "https://")):
+            payload_model = parameters.get("model") or "dummy"
+        else:
+            payload_model = mapped_model
         return {**filter_none(parameters), "model": payload_model, "messages": inputs}
 
     def _prepare_url(self, api_key: str, mapped_model: str) -> str:

--- a/tests/test_inference_providers.py
+++ b/tests/test_inference_providers.py
@@ -334,7 +334,7 @@ class TestHFInferenceProvider:
             ),
             # URL endpoint with model in parameters - use model from parameters
             (
-                "https://localhost:8000/v1/chat/completions",
+                "http://localhost:8000/v1/chat/completions",
                 {"model": "username/repo_name"},
                 "username/repo_name",
             ),

--- a/tests/test_inference_providers.py
+++ b/tests/test_inference_providers.py
@@ -324,6 +324,53 @@ class TestHFInferenceProvider:
             "messages": [{"role": "user", "content": "dummy text input"}],
         }
 
+    @pytest.mark.parametrize(
+        "mapped_model,parameters,expected_model",
+        [
+            (
+                "username/repo_name",
+                {},
+                "username/repo_name",
+            ),
+            # URL endpoint with model in parameters - use model from parameters
+            (
+                "https://localhost:8000/v1/chat/completions",
+                {"model": "username/repo_name"},
+                "username/repo_name",
+            ),
+            # URL endpoint without model - fallback to dummy
+            (
+                "http://localhost:8000/v1/chat/completions",
+                {},
+                "dummy",
+            ),
+            # HTTPS endpoint with model in parameters
+            (
+                "https://api.example.com/v1/chat/completions",
+                {"model": "username/repo_name"},
+                "username/repo_name",
+            ),
+            # URL endpoint with other parameters - should still use dummy
+            (
+                "http://localhost:8000/v1/chat/completions",
+                {"temperature": 0.7, "max_tokens": 100},
+                "dummy",
+            ),
+        ],
+    )
+    def test_prepare_payload_as_dict_conversational(self, mapped_model, parameters, expected_model):
+        helper = HFInferenceConversational()
+        messages = [{"role": "user", "content": "Hello!"}]
+
+        payload = helper._prepare_payload_as_dict(
+            inputs=messages,
+            parameters=parameters,
+            mapped_model=mapped_model,
+        )
+
+        assert payload["model"] == expected_model
+        assert payload["messages"] == messages
+
 
 class TestHyperbolicProvider:
     def test_prepare_route(self):


### PR DESCRIPTION
Fixes #2908 
a bug was introduced in #2836 where the payload model was set to "tgi" if the model ID is a URL, regardless of the model name passed in parameters. This causes issues with vLLM endpoints (as reported in #2908) which require the actual model name to be passed.

Note that "tgi" was previously used as a default value since the payload model is required in TGI's API but not actually used. `InferenceClient`/`AsyncInferenceClient` are compatible to other frameworks like vLLM, so let's fallback to "dummy" instead of "tgi" to avoid any confusion.

cc @Spycsh