### PR TITLE
Handle file-like and IO objects in `_curlify()`

### DIFF
--- a/src/huggingface_hub/utils/_http.py
+++ b/src/huggingface_hub/utils/_http.py
@@ -578,6 +578,8 @@ def _curlify(request: requests.PreparedRequest) -> str:
         body = request.body
         if isinstance(body, bytes):
             body = body.decode("utf-8", errors="ignore")
+        elif hasattr(body, "read"):
+            body = "<file-like object>"  # Don't try to read it to avoid consuming the stream
         if len(body) > 1000:
             body = body[:1000] + " ... [truncated]"
         parts += [("-d", body.replace("\n", ""))]


### PR DESCRIPTION
This PR fixes a bug I ran into with `_curlify`: when the body request contains a `BytesIO` object, `_curlify()` attempts to get the length of this object, and obviously it fails because it doesn't have a __len__ method and we don't handle the case when the body contains file-like objects. 
