### PR TITLE
[Inference providers] Root-only base URLs

### DIFF
--- a/src/huggingface_hub/inference/_providers/black_forest_labs.py
+++ b/src/huggingface_hub/inference/_providers/black_forest_labs.py
@@ -15,7 +15,7 @@ POLLING_INTERVAL = 1.0
 
 class BlackForestLabsTextToImageTask(TaskProviderHelper):
     def __init__(self):
-        super().__init__(provider="black-forest-labs", base_url="https://api.us1.bfl.ai/v1", task="text-to-image")
+        super().__init__(provider="black-forest-labs", base_url="https://api.us1.bfl.ai", task="text-to-image")
 
     def _prepare_headers(self, headers: Dict, api_key: str) -> Dict:
         headers = super()._prepare_headers(headers, api_key)
@@ -25,7 +25,7 @@ class BlackForestLabsTextToImageTask(TaskProviderHelper):
         return headers
 
     def _prepare_route(self, mapped_model: str) -> str:
-        return mapped_model
+        return f"/v1/{mapped_model}"
 
     def _prepare_payload_as_dict(self, inputs: Any, parameters: Dict, mapped_model: str) -> Optional[Dict]:
         parameters = filter_none(parameters)

--- a/src/huggingface_hub/inference/_providers/fireworks_ai.py
+++ b/src/huggingface_hub/inference/_providers/fireworks_ai.py
@@ -3,4 +3,7 @@ from ._common import BaseConversationalTask
 
 class FireworksAIConversationalTask(BaseConversationalTask):
     def __init__(self):
-        super().__init__(provider="fireworks-ai", base_url="https://api.fireworks.ai/inference")
+        super().__init__(provider="fireworks-ai", base_url="https://api.fireworks.ai")
+
+    def _prepare_route(self, mapped_model: str) -> str:
+        return "/inference/v1/chat/completions"

--- a/src/huggingface_hub/inference/_providers/novita.py
+++ b/src/huggingface_hub/inference/_providers/novita.py
@@ -5,7 +5,7 @@ from huggingface_hub.inference._providers._common import (
 
 
 _PROVIDER = "novita"
-_BASE_URL = "https://api.novita.ai/v3/openai"
+_BASE_URL = "https://api.novita.ai"
 
 
 class NovitaTextGenerationTask(BaseTextGenerationTask):
@@ -14,7 +14,7 @@ class NovitaTextGenerationTask(BaseTextGenerationTask):
 
     def _prepare_route(self, mapped_model: str) -> str:
         # there is no v1/ route for novita
-        return "/completions"
+        return "/v3/openai/completions"
 
 
 class NovitaConversationalTask(BaseConversationalTask):
@@ -23,4 +23,4 @@ class NovitaConversationalTask(BaseConversationalTask):
 
     def _prepare_route(self, mapped_model: str) -> str:
         # there is no v1/ route for novita
-        return "/chat/completions"
+        return "/v3/openai/chat/completions"


### PR DESCRIPTION
Related to https://github.com/huggingface-internal/moon-landing/pull/12849 and https://github.com/huggingface-internal/moon-landing/pull/12855 (private repo).

It is best if all base URLs for inference providers are "root-domain-only" i.e. without subpaths. This PR updates Black Forest Labs, Fireworks AI and Novita providers.

Note that this change requires a server-side update to make things backward compatible (i.e. legacy clients using a subpath are still working). This fix is already handled. 