### PR TITLE
[InferenceClient] Fix token initialization and add more tests

### DIFF
--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -185,7 +185,7 @@ class InferenceClient:
                 " `api_key` is an alias for `token` to make the API compatible with OpenAI's client."
                 " It has the exact same behavior as `token`."
             )
-        token if token is not None else api_key
+        token = token if token is not None else api_key
         if isinstance(token, bool):
             # Legacy behavior: previously is was possible to pass `token=False` to disable authentication. This is not
             # supported anymore as authentication is required. Better to explicitly raise here rather than risking

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -176,7 +176,7 @@ class AsyncInferenceClient:
                 " `api_key` is an alias for `token` to make the API compatible with OpenAI's client."
                 " It has the exact same behavior as `token`."
             )
-        token if token is not None else api_key
+        token = token if token is not None else api_key
         if isinstance(token, bool):
             # Legacy behavior: previously is was possible to pass `token=False` to disable authentication. This is not
             # supported anymore as authentication is required. Better to explicitly raise here rather than risking

--- a/tests/test_auth_cli.py
+++ b/tests/test_auth_cli.py
@@ -10,6 +10,7 @@ from huggingface_hub import constants
 from huggingface_hub.commands.user import AuthListCommand, AuthSwitchCommand, LoginCommand, LogoutCommand
 
 from .testing_constants import ENDPOINT_STAGING
+from .testing_utils import assert_in_logs
 
 
 # fixtures & constants
@@ -60,12 +61,6 @@ def mock_stored_tokens():
     with patch("huggingface_hub._login.get_stored_tokens", return_value=stored_tokens):
         with patch("huggingface_hub.utils._auth.get_stored_tokens", return_value=stored_tokens):
             yield stored_tokens
-
-
-def assert_in_logs(caplog: LogCaptureFixture, expected_output):
-    """Helper to check if a message appears in logs."""
-    log_text = "\n".join(record.message for record in caplog.records)
-    assert expected_output in log_text, f"Expected '{expected_output}' not found in logs"
 
 
 def test_login_command_basic(mock_whoami_api_call, caplog: LogCaptureFixture):

--- a/tests/test_inference_client.py
+++ b/tests/test_inference_client.py
@@ -909,13 +909,35 @@ class TestOpenAICompatibility(TestBase):
         output_text = "".join(chunked_text)
         assert "1, 2, 3, 4, 5, 6, 7, 8, 9, 10" in output_text
 
-    def test_token_and_api_key_mutually_exclusive(self):
-        with pytest.raises(ValueError):
-            InferenceClient(token="my-token", api_key="my-api-key")
-
     def test_model_and_base_url_mutually_exclusive(self):
         with pytest.raises(ValueError):
             InferenceClient(model="meta-llama/Meta-Llama-3-8B-Instruct", base_url="http://127.0.0.1:8000")
+
+    def test_token_initialization(self, mocker):
+        # Test with explicit token
+        client = InferenceClient(token="my-token")
+        assert client.token == "my-token"
+
+        # Test with api_key
+        client = InferenceClient(api_key="my-api-key")
+        assert client.token == "my-api-key"
+
+        # Test with both token and api_key raises error
+        with pytest.raises(ValueError, match="Received both `token` and `api_key` arguments"):
+            InferenceClient(token="my-token", api_key="my-api-key")
+
+        # Test with token=None (default behavior)
+        client = InferenceClient()
+        assert client.token is None
+
+        # Test with token=True is deprecated but still works
+        mocker.patch("huggingface_hub.inference._client.get_token", return_value="my-token")
+        client = InferenceClient(token=True)
+        assert client.token == "my-token"
+
+        # Test with token=False raises error
+        with pytest.raises(ValueError, match="Cannot use `token=False` to disable authentication"):
+            InferenceClient(token=False)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_inference_client.py
+++ b/tests/test_inference_client.py
@@ -913,28 +913,33 @@ class TestOpenAICompatibility(TestBase):
         with pytest.raises(ValueError):
             InferenceClient(model="meta-llama/Meta-Llama-3-8B-Instruct", base_url="http://127.0.0.1:8000")
 
-    def test_token_initialization(self, mocker):
+    def test_token_initialization_from_token(self):
         # Test with explicit token
         client = InferenceClient(token="my-token")
         assert client.token == "my-token"
 
+    def test_token_initialization_from_api_key(self):
         # Test with api_key
         client = InferenceClient(api_key="my-api-key")
         assert client.token == "my-api-key"
 
+    def test_token_initialization_cannot_be_both(self):
         # Test with both token and api_key raises error
         with pytest.raises(ValueError, match="Received both `token` and `api_key` arguments"):
             InferenceClient(token="my-token", api_key="my-api-key")
 
+    def test_token_initialization_default_to_none(self):
         # Test with token=None (default behavior)
         client = InferenceClient()
         assert client.token is None
 
+    def test_token_initialization_with_token_true(self, mocker):
         # Test with token=True and token is set with get_token()
         mocker.patch("huggingface_hub.inference._client.get_token", return_value="my-token")
         client = InferenceClient(token=True)
         assert client.token == "my-token"
 
+    def test_token_initialization_cannot_be_token_false(self):
         # Test with token=False raises error
         with pytest.raises(ValueError, match="Cannot use `token=False` to disable authentication"):
             InferenceClient(token=False)

--- a/tests/test_inference_client.py
+++ b/tests/test_inference_client.py
@@ -930,7 +930,7 @@ class TestOpenAICompatibility(TestBase):
         client = InferenceClient()
         assert client.token is None
 
-        # Test with token=True is deprecated but still works
+        # Test with token=True and token is set with get_token()
         mocker.patch("huggingface_hub.inference._client.get_token", return_value="my-token")
         client = InferenceClient(token=True)
         assert client.token == "my-token"

--- a/tests/test_inference_providers.py
+++ b/tests/test_inference_providers.py
@@ -1,11 +1,15 @@
 import base64
+import logging
 from typing import Dict
+from unittest.mock import patch
 
 import pytest
+from pytest import LogCaptureFixture
 
 from huggingface_hub.inference._providers._common import (
     BaseConversationalTask,
     BaseTextGenerationTask,
+    TaskProviderHelper,
     recursive_merge,
 )
 from huggingface_hub.inference._providers.black_forest_labs import BlackForestLabsTextToImageTask
@@ -36,6 +40,92 @@ from huggingface_hub.inference._providers.sambanova import SambanovaConversation
 from huggingface_hub.inference._providers.together import (
     TogetherTextToImageTask,
 )
+
+from .testing_utils import assert_in_logs
+
+
+class TestBasicTaskProviderHelper:
+    def test_api_key_from_provider(self):
+        helper = TaskProviderHelper(provider="provider-name", base_url="https://api.provider.com", task="task-name")
+        assert helper._prepare_api_key("sk_provider_key") == "sk_provider_key"
+
+    def test_api_key_routed(self, mocker):
+        mocker.patch("huggingface_hub.inference._providers._common.get_token", return_value="hf_test_token")
+        helper = TaskProviderHelper(provider="provider-name", base_url="https://api.provider.com", task="task-name")
+        assert helper._prepare_api_key(None) == "hf_test_token"
+
+    def test_api_key_missing(self):
+        with patch("huggingface_hub.inference._providers._common.get_token", return_value=None):
+            helper = TaskProviderHelper(
+                provider="provider-name", base_url="https://api.provider.com", task="task-name"
+            )
+            with pytest.raises(ValueError, match="You must provide an api_key.*"):
+                helper._prepare_api_key(None)
+
+    def test_prepare_mapped_model(self, mocker, caplog: LogCaptureFixture):
+        helper = TaskProviderHelper(provider="provider-name", base_url="https://api.provider.com", task="task-name")
+        caplog.set_level(logging.INFO)
+
+        # Test missing model
+        with pytest.raises(ValueError, match="Please provide an HF model ID.*"):
+            helper._prepare_mapped_model(None)
+
+        # Test unsupported model
+        mocker.patch(
+            "huggingface_hub.inference._providers._common._fetch_inference_provider_mapping",
+            return_value={"other-provider": "mapping"},
+        )
+        with pytest.raises(ValueError, match="Model test-model is not supported.*"):
+            helper._prepare_mapped_model("test-model")
+
+        # Test task mismatch
+        mocker.patch(
+            "huggingface_hub.inference._providers._common._fetch_inference_provider_mapping",
+            return_value={"provider-name": mocker.Mock(task="other-task", provider_id="mapped-id", status="active")},
+        )
+        with pytest.raises(ValueError, match="Model test-model is not supported for task.*"):
+            helper._prepare_mapped_model("test-model")
+
+        # Test staging model
+        mocker.patch(
+            "huggingface_hub.inference._providers._common._fetch_inference_provider_mapping",
+            return_value={"provider-name": mocker.Mock(task="task-name", provider_id="mapped-id", status="staging")},
+        )
+        assert helper._prepare_mapped_model("test-model") == "mapped-id"
+        assert_in_logs(
+            caplog, "Model test-model is in staging mode for provider provider-name. Meant for test purposes only."
+        )
+
+        # Test successful mapping
+        caplog.clear()
+        mocker.patch(
+            "huggingface_hub.inference._providers._common._fetch_inference_provider_mapping",
+            return_value={"provider-name": mocker.Mock(task="task-name", provider_id="mapped-id", status="active")},
+        )
+        assert helper._prepare_mapped_model("test-model") == "mapped-id"
+        assert len(caplog.records) == 0
+
+    def test_prepare_headers(self):
+        helper = TaskProviderHelper(provider="provider-name", base_url="https://api.provider.com", task="task-name")
+        headers = helper._prepare_headers({"custom": "header"}, "api_key")
+        assert "user-agent" in headers  # From build_hf_headers
+        assert headers["custom"] == "header"
+        assert headers["authorization"] == "Bearer api_key"
+
+    def test_prepare_url(self, mocker):
+        helper = TaskProviderHelper(provider="provider-name", base_url="https://api.provider.com", task="task-name")
+        mocker.patch.object(helper, "_prepare_route", return_value="/v1/test-route")
+
+        # Test HF token routing
+        url = helper._prepare_url("hf_test_token", "test-model")
+        assert url == "https://router.huggingface.co/provider-name/v1/test-route"
+        helper._prepare_route.assert_called_once_with("test-model")
+
+        # Test direct API call
+        helper._prepare_route.reset_mock()
+        url = helper._prepare_url("sk_test_token", "test-model")
+        assert url == "https://api.provider.com/v1/test-route"
+        helper._prepare_route.assert_called_once_with("test-model")
 
 
 class TestBlackForestLabsProvider:

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -447,3 +447,9 @@ def use_tmp_repo(repo_type: str = "model") -> Callable[[T], T]:
         return _inner
 
     return _inner_use_tmp_repo
+
+
+def assert_in_logs(caplog: pytest.LogCaptureFixture, expected_output):
+    """Helper to check if a message appears in logs."""
+    log_text = "\n".join(record.message for record in caplog.records)
+    assert expected_output in log_text, f"Expected '{expected_output}' not found in logs"


### PR DESCRIPTION
This PR fixes a bug in the `InferenceClient`'s token initialization and adds a test for this.
Also, took the opportunity to add more unit tests for `TaskProviderHelper`'s methods 🙈 