### PR TITLE
Add basic retry logic to get_hf_file_metadata

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1257,7 +1257,7 @@ def get_hf_file_metadata(
 ) -> HfFileMetadata:
     """Fetch metadata of a file versioned on the Hub for a given url.
 
-    If a ReadTimeout happens while connecting to the server, it is most likely a
+    If ConnectionError (SSLError) or ReadTimeout happens while connecting to the server, it is most likely a
     transient error (network outage?). We log a warning message and try to a few times before
     giving up. The method gives up after 5 attempts.
 


### PR DESCRIPTION
This PR adds retry logic to `get_hf_file_metadata()` to handle transient network errors.

Background:
- PR #1529 refactored the internal `_request_wrapper` to move retry logic to the caller level
- While retry logic was implemented for `http_get()` (most network errors occur here), `get_hf_file_metadata()` was left without retry