### PR TITLE
Fix inference client tests by regenerating the cassettes

### DIFF
--- a/tests/cassettes/TestInferenceClient.test_chat_completion_with_stream[nebius,conversational].yaml
+++ b/tests/cassettes/TestInferenceClient.test_chat_completion_with_stream[nebius,conversational].yaml
@@ -1,5 +1,57 @@
 interactions:
 - request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      X-Amzn-Trace-Id:
+      - 10b02db7-19de-4cc6-af3b-1a9495ed97e5
+    method: GET
+    uri: https://huggingface.co/api/models/meta-llama/Llama-3.1-8B-Instruct?expand=inferenceProviderMapping
+  response:
+    body:
+      string: '{"_id":"6698d8a0653e4babe21e1e7d","id":"meta-llama/Llama-3.1-8B-Instruct","inferenceProviderMapping":{"fireworks-ai":{"status":"live","providerId":"accounts/fireworks/models/llama-v3p1-8b-instruct","task":"conversational"},"sambanova":{"status":"live","providerId":"Meta-Llama-3.1-8B-Instruct","task":"conversational"},"hf-inference":{"status":"live","providerId":"meta-llama/Llama-3.1-8B-Instruct","task":"conversational"},"nebius":{"status":"live","providerId":"meta-llama/Meta-Llama-3.1-8B-Instruct-fast","task":"conversational"},"novita":{"status":"live","providerId":"meta-llama/llama-3.1-8b-instruct","task":"conversational"},"hyperbolic":{"status":"staging","providerId":"meta-llama/Meta-Llama-3.1-8B-Instruct","task":"conversational"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://huggingface.co
+      Access-Control-Expose-Headers:
+      - X-Repo-Commit,X-Request-Id,X-Error-Code,X-Error-Message,X-Total-Count,ETag,Link,Accept-Ranges,Content-Range,X-Xet-Access-Token,X-Xet-Token-Expiration,X-Xet-Refresh-Route,X-Xet-Cas-Url,X-Xet-Hash
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '744'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 12 Mar 2025 15:38:37 GMT
+      ETag:
+      - W/"2e8-5aim+zb8F1xV5ILzZjQ4yWDbcrw"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Vary:
+      - Origin
+      Via:
+      - 1.1 8cea2743cbaa04c70ebc2ec4f5892fa6.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - hoUaoMIy0BzyX9Izqf35EwayYLPZlu4qMHyjP4Wh5oFoxeBWvklP0A==
+      X-Amz-Cf-Pop:
+      - CDG52-P4
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - huggingface-moon
+      X-Request-Id:
+      - Root=1-67d1aa7d-462a207368ff18c8090a1b87;10b02db7-19de-4cc6-af3b-1a9495ed97e5
+      cross-origin-opener-policy:
+      - same-origin
+    status:
+      code: 200
+      message: OK
+- request:
     body: '{"messages": [{"role": "system", "content": "You are a helpful assistant."},
       {"role": "user", "content": "What is deep learning?"}], "model": "meta-llama/Meta-Llama-3.1-8B-Instruct-fast",
       "max_tokens": 20, "stream": true}'
@@ -15,88 +67,91 @@ interactions:
       Content-Type:
       - application/json
       X-Amzn-Trace-Id:
-      - 680921f0-d15a-4e88-bdc4-5bb2453024c4
+      - a812afb0-5648-4b54-bf02-3aa0bcdab1c0
     method: POST
     uri: https://router.huggingface.co/nebius/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-c5307923a67746b2b642cd528fde10cd","choices":[{"delta":{"content":"","role":"assistant"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739809055,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct-fast","object":"chat.completion.chunk"}
+      string: 'data: {"id":"chatcmpl-f42aee3e144f465dae0cf33f04bf7c92","choices":[{"delta":{"content":"","role":"assistant"},"finish_reason":null,"index":0,"logprobs":null}],"created":1741793918,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct-fast","object":"chat.completion.chunk"}
 
 
-        data: {"id":"chatcmpl-c5307923a67746b2b642cd528fde10cd","choices":[{"delta":{"content":"Deep"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739809055,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct-fast","object":"chat.completion.chunk"}
+        data: {"id":"chatcmpl-f42aee3e144f465dae0cf33f04bf7c92","choices":[{"delta":{"content":"Deep"},"finish_reason":null,"index":0,"logprobs":null}],"created":1741793918,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct-fast","object":"chat.completion.chunk"}
 
 
-        data: {"id":"chatcmpl-c5307923a67746b2b642cd528fde10cd","choices":[{"delta":{"content":"
-        learning"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739809055,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct-fast","object":"chat.completion.chunk"}
+        data: {"id":"chatcmpl-f42aee3e144f465dae0cf33f04bf7c92","choices":[{"delta":{"content":"
+        learning"},"finish_reason":null,"index":0,"logprobs":null}],"created":1741793918,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct-fast","object":"chat.completion.chunk"}
 
 
-        data: {"id":"chatcmpl-c5307923a67746b2b642cd528fde10cd","choices":[{"delta":{"content":"
-        is"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739809055,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct-fast","object":"chat.completion.chunk"}
+        data: {"id":"chatcmpl-f42aee3e144f465dae0cf33f04bf7c92","choices":[{"delta":{"content":"
+        is"},"finish_reason":null,"index":0,"logprobs":null}],"created":1741793918,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct-fast","object":"chat.completion.chunk"}
 
 
-        data: {"id":"chatcmpl-c5307923a67746b2b642cd528fde10cd","choices":[{"delta":{"content":"
-        a"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739809055,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct-fast","object":"chat.completion.chunk"}
+        data: {"id":"chatcmpl-f42aee3e144f465dae0cf33f04bf7c92","choices":[{"delta":{"content":"
+        a"},"finish_reason":null,"index":0,"logprobs":null}],"created":1741793918,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct-fast","object":"chat.completion.chunk"}
 
 
-        data: {"id":"chatcmpl-c5307923a67746b2b642cd528fde10cd","choices":[{"delta":{"content":"
-        subset"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739809055,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct-fast","object":"chat.completion.chunk"}
+        data: {"id":"chatcmpl-f42aee3e144f465dae0cf33f04bf7c92","choices":[{"delta":{"content":"
+        subset"},"finish_reason":null,"index":0,"logprobs":null}],"created":1741793918,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct-fast","object":"chat.completion.chunk"}
 
 
-        data: {"id":"chatcmpl-c5307923a67746b2b642cd528fde10cd","choices":[{"delta":{"content":"
-        of"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739809055,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct-fast","object":"chat.completion.chunk"}
+        data: {"id":"chatcmpl-f42aee3e144f465dae0cf33f04bf7c92","choices":[{"delta":{"content":"
+        of"},"finish_reason":null,"index":0,"logprobs":null}],"created":1741793918,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct-fast","object":"chat.completion.chunk"}
 
 
-        data: {"id":"chatcmpl-c5307923a67746b2b642cd528fde10cd","choices":[{"delta":{"content":"
-        machine"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739809055,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct-fast","object":"chat.completion.chunk"}
+        data: {"id":"chatcmpl-f42aee3e144f465dae0cf33f04bf7c92","choices":[{"delta":{"content":"
+        machine"},"finish_reason":null,"index":0,"logprobs":null}],"created":1741793918,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct-fast","object":"chat.completion.chunk"}
 
 
-        data: {"id":"chatcmpl-c5307923a67746b2b642cd528fde10cd","choices":[{"delta":{"content":"
-        learning"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739809055,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct-fast","object":"chat.completion.chunk"}
+        data: {"id":"chatcmpl-f42aee3e144f465dae0cf33f04bf7c92","choices":[{"delta":{"content":"
+        learning"},"finish_reason":null,"index":0,"logprobs":null}],"created":1741793918,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct-fast","object":"chat.completion.chunk"}
 
 
-        data: {"id":"chatcmpl-c5307923a67746b2b642cd528fde10cd","choices":[{"delta":{"content":"
-        that"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739809055,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct-fast","object":"chat.completion.chunk"}
+        data: {"id":"chatcmpl-f42aee3e144f465dae0cf33f04bf7c92","choices":[{"delta":{"content":"
+        that"},"finish_reason":null,"index":0,"logprobs":null}],"created":1741793918,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct-fast","object":"chat.completion.chunk"}
 
 
-        data: {"id":"chatcmpl-c5307923a67746b2b642cd528fde10cd","choices":[{"delta":{"content":"
-        involves"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739809055,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct-fast","object":"chat.completion.chunk"}
+        data: {"id":"chatcmpl-f42aee3e144f465dae0cf33f04bf7c92","choices":[{"delta":{"content":"
+        is"},"finish_reason":null,"index":0,"logprobs":null}],"created":1741793918,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct-fast","object":"chat.completion.chunk"}
 
 
-        data: {"id":"chatcmpl-c5307923a67746b2b642cd528fde10cd","choices":[{"delta":{"content":"
-        the"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739809055,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct-fast","object":"chat.completion.chunk"}
+        data: {"id":"chatcmpl-f42aee3e144f465dae0cf33f04bf7c92","choices":[{"delta":{"content":"
+        inspired"},"finish_reason":null,"index":0,"logprobs":null}],"created":1741793918,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct-fast","object":"chat.completion.chunk"}
 
 
-        data: {"id":"chatcmpl-c5307923a67746b2b642cd528fde10cd","choices":[{"delta":{"content":"
-        use"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739809055,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct-fast","object":"chat.completion.chunk"}
+        data: {"id":"chatcmpl-f42aee3e144f465dae0cf33f04bf7c92","choices":[{"delta":{"content":"
+        by"},"finish_reason":null,"index":0,"logprobs":null}],"created":1741793918,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct-fast","object":"chat.completion.chunk"}
 
 
-        data: {"id":"chatcmpl-c5307923a67746b2b642cd528fde10cd","choices":[{"delta":{"content":"
-        of"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739809055,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct-fast","object":"chat.completion.chunk"}
+        data: {"id":"chatcmpl-f42aee3e144f465dae0cf33f04bf7c92","choices":[{"delta":{"content":"
+        the"},"finish_reason":null,"index":0,"logprobs":null}],"created":1741793918,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct-fast","object":"chat.completion.chunk"}
 
 
-        data: {"id":"chatcmpl-c5307923a67746b2b642cd528fde10cd","choices":[{"delta":{"content":"
-        artificial"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739809055,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct-fast","object":"chat.completion.chunk"}
+        data: {"id":"chatcmpl-f42aee3e144f465dae0cf33f04bf7c92","choices":[{"delta":{"content":"
+        structure"},"finish_reason":null,"index":0,"logprobs":null}],"created":1741793918,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct-fast","object":"chat.completion.chunk"}
 
 
-        data: {"id":"chatcmpl-c5307923a67746b2b642cd528fde10cd","choices":[{"delta":{"content":"
-        neural"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739809055,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct-fast","object":"chat.completion.chunk"}
+        data: {"id":"chatcmpl-f42aee3e144f465dae0cf33f04bf7c92","choices":[{"delta":{"content":"
+        and"},"finish_reason":null,"index":0,"logprobs":null}],"created":1741793918,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct-fast","object":"chat.completion.chunk"}
 
 
-        data: {"id":"chatcmpl-c5307923a67746b2b642cd528fde10cd","choices":[{"delta":{"content":"
-        networks"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739809055,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct-fast","object":"chat.completion.chunk"}
+        data: {"id":"chatcmpl-f42aee3e144f465dae0cf33f04bf7c92","choices":[{"delta":{"content":"
+        function"},"finish_reason":null,"index":0,"logprobs":null}],"created":1741793918,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct-fast","object":"chat.completion.chunk"}
 
 
-        data: {"id":"chatcmpl-c5307923a67746b2b642cd528fde10cd","choices":[{"delta":{"content":"
-        ("},"finish_reason":null,"index":0,"logprobs":null}],"created":1739809055,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct-fast","object":"chat.completion.chunk"}
+        data: {"id":"chatcmpl-f42aee3e144f465dae0cf33f04bf7c92","choices":[{"delta":{"content":"
+        of"},"finish_reason":null,"index":0,"logprobs":null}],"created":1741793918,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct-fast","object":"chat.completion.chunk"}
 
 
-        data: {"id":"chatcmpl-c5307923a67746b2b642cd528fde10cd","choices":[{"delta":{"content":"ANN"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739809055,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct-fast","object":"chat.completion.chunk"}
+        data: {"id":"chatcmpl-f42aee3e144f465dae0cf33f04bf7c92","choices":[{"delta":{"content":"
+        the"},"finish_reason":null,"index":0,"logprobs":null}],"created":1741793918,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct-fast","object":"chat.completion.chunk"}
 
 
-        data: {"id":"chatcmpl-c5307923a67746b2b642cd528fde10cd","choices":[{"delta":{"content":"s"},"finish_reason":null,"index":0,"logprobs":null}],"created":1739809055,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct-fast","object":"chat.completion.chunk"}
+        data: {"id":"chatcmpl-f42aee3e144f465dae0cf33f04bf7c92","choices":[{"delta":{"content":"
+        human"},"finish_reason":null,"index":0,"logprobs":null}],"created":1741793918,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct-fast","object":"chat.completion.chunk"}
 
 
-        data: {"id":"chatcmpl-c5307923a67746b2b642cd528fde10cd","choices":[{"delta":{"content":")"},"finish_reason":"length","index":0,"logprobs":null,"stop_reason":null}],"created":1739809055,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct-fast","object":"chat.completion.chunk"}
+        data: {"id":"chatcmpl-f42aee3e144f465dae0cf33f04bf7c92","choices":[{"delta":{"content":"
+        brain"},"finish_reason":"length","index":0,"logprobs":null,"stop_reason":null}],"created":1741793918,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct-fast","object":"chat.completion.chunk"}
 
 
         data: [DONE]
@@ -113,7 +168,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Mon, 17 Feb 2025 16:17:35 GMT
+      - Wed, 12 Mar 2025 15:38:38 GMT
       Referrer-Policy:
       - strict-origin-when-cross-origin
       Transfer-Encoding:
@@ -121,9 +176,9 @@ interactions:
       Vary:
       - Origin
       Via:
-      - 1.1 c2c9a285d2a1960107e9c187a72a9112.cloudfront.net (CloudFront)
+      - 1.1 6676a739f016238678e391e91007cc98.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - CbZ6j8fztvNALOJj97n9YQUZrxq6R-QIFKbWvytiy_3oDXtRVmHmyA==
+      - 3684bu1a8sqPwliuuQw2LjD1I1rMx10V6ysfYQ3S9MrEBrRqJOFz7A==
       X-Amz-Cf-Pop:
       - CDG55-P3
       X-Cache:
@@ -131,11 +186,13 @@ interactions:
       X-Powered-By:
       - huggingface-moon
       X-Request-Id:
-      - Root=1-67b3611f-54cf49f22c98a6532fe656c4;680921f0-d15a-4e88-bdc4-5bb2453024c4
+      - Root=1-67d1aa7d-4f4384c43a2e622827bdcdae;a812afb0-5648-4b54-bf02-3aa0bcdab1c0
+      X-Robots-Tag:
+      - none
       cross-origin-opener-policy:
       - same-origin
       strict-transport-security:
-      - max-age=15724800; includeSubDomains
+      - max-age=31536000; includeSubDomains
       x-ratelimit-limit-requests:
       - '600'
       x-ratelimit-limit-tokens:

--- a/tests/cassettes/TestInferenceClient.test_chat_completion_with_stream[novita,conversational].yaml
+++ b/tests/cassettes/TestInferenceClient.test_chat_completion_with_stream[novita,conversational].yaml
@@ -1,5 +1,57 @@
 interactions:
 - request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      X-Amzn-Trace-Id:
+      - 57f95b3d-89bb-4b6a-9212-50434305a81c
+    method: GET
+    uri: https://huggingface.co/api/models/meta-llama/Llama-3.1-8B-Instruct?expand=inferenceProviderMapping
+  response:
+    body:
+      string: '{"_id":"6698d8a0653e4babe21e1e7d","id":"meta-llama/Llama-3.1-8B-Instruct","inferenceProviderMapping":{"fireworks-ai":{"status":"live","providerId":"accounts/fireworks/models/llama-v3p1-8b-instruct","task":"conversational"},"sambanova":{"status":"live","providerId":"Meta-Llama-3.1-8B-Instruct","task":"conversational"},"hf-inference":{"status":"live","providerId":"meta-llama/Llama-3.1-8B-Instruct","task":"conversational"},"nebius":{"status":"live","providerId":"meta-llama/Meta-Llama-3.1-8B-Instruct-fast","task":"conversational"},"novita":{"status":"live","providerId":"meta-llama/llama-3.1-8b-instruct","task":"conversational"},"hyperbolic":{"status":"staging","providerId":"meta-llama/Meta-Llama-3.1-8B-Instruct","task":"conversational"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://huggingface.co
+      Access-Control-Expose-Headers:
+      - X-Repo-Commit,X-Request-Id,X-Error-Code,X-Error-Message,X-Total-Count,ETag,Link,Accept-Ranges,Content-Range,X-Xet-Access-Token,X-Xet-Token-Expiration,X-Xet-Refresh-Route,X-Xet-Cas-Url,X-Xet-Hash
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '744'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 12 Mar 2025 15:38:49 GMT
+      ETag:
+      - W/"2e8-5aim+zb8F1xV5ILzZjQ4yWDbcrw"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Vary:
+      - Origin
+      Via:
+      - 1.1 67bbe30c2f887b8968a0f0c3b05ac564.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - mb4rwm_bezvwgkiYbdz3Ivb2tMsE4_dYkjGAZ5RSGf73S2lixVZ8QA==
+      X-Amz-Cf-Pop:
+      - CDG52-P4
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - huggingface-moon
+      X-Request-Id:
+      - Root=1-67d1aa89-49623117502f78fb6705747f;57f95b3d-89bb-4b6a-9212-50434305a81c
+      cross-origin-opener-policy:
+      - same-origin
+    status:
+      code: 200
+      message: OK
+- request:
     body: '{"messages": [{"role": "system", "content": "You are a helpful assistant."},
       {"role": "user", "content": "What is deep learning?"}], "model": "meta-llama/llama-3.1-8b-instruct",
       "max_tokens": 20, "stream": true}'
@@ -15,84 +67,85 @@ interactions:
       Content-Type:
       - application/json
       X-Amzn-Trace-Id:
-      - 4f86b753-c812-4334-a0ec-614e1100972a
+      - 5cf4dfde-9f8d-4fb8-a01d-3934e8537f59
     method: POST
     uri: https://router.huggingface.co/novita/v3/openai/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-1c5665bfedca4fa1993cfeecd007dcd8","object":"chat.completion.chunk","created":1739807134,"model":"meta-llama/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null,"content_filter_results":{"hate":{"filtered":false},"self_harm":{"filtered":false},"sexual":{"filtered":false},"violence":{"filtered":false},"jailbreak":{"filtered":false,"detected":false},"profanity":{"filtered":false,"detected":false}}}],"system_fingerprint":""}
+      string: 'data: {"id":"chatcmpl-af6e9802f1554a49be4dd42048b91565","object":"chat.completion.chunk","created":1741793930,"model":"meta-llama/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null,"content_filter_results":{"hate":{"filtered":false},"self_harm":{"filtered":false},"sexual":{"filtered":false},"violence":{"filtered":false},"jailbreak":{"filtered":false,"detected":false},"profanity":{"filtered":false,"detected":false}}}],"system_fingerprint":"","usage":{"prompt_tokens":46,"completion_tokens":0,"total_tokens":46,"prompt_tokens_details":null,"completion_tokens_details":null}}
 
 
-        data: {"id":"chatcmpl-1c5665bfedca4fa1993cfeecd007dcd8","object":"chat.completion.chunk","created":1739807134,"model":"meta-llama/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{},"finish_reason":null,"content_filter_results":{"hate":{"filtered":false},"self_harm":{"filtered":false},"sexual":{"filtered":false},"violence":{"filtered":false},"jailbreak":{"filtered":false,"detected":false},"profanity":{"filtered":false,"detected":false}}}],"system_fingerprint":""}
+        data: {"id":"chatcmpl-af6e9802f1554a49be4dd42048b91565","object":"chat.completion.chunk","created":1741793930,"model":"meta-llama/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{},"finish_reason":null,"content_filter_results":{"hate":{"filtered":false},"self_harm":{"filtered":false},"sexual":{"filtered":false},"violence":{"filtered":false},"jailbreak":{"filtered":false,"detected":false},"profanity":{"filtered":false,"detected":false}}}],"system_fingerprint":"","usage":{"prompt_tokens":46,"completion_tokens":1,"total_tokens":47,"prompt_tokens_details":null,"completion_tokens_details":null}}
 
 
-        data: {"id":"chatcmpl-1c5665bfedca4fa1993cfeecd007dcd8","object":"chat.completion.chunk","created":1739807134,"model":"meta-llama/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{},"finish_reason":null,"content_filter_results":{"hate":{"filtered":false},"self_harm":{"filtered":false},"sexual":{"filtered":false},"violence":{"filtered":false},"jailbreak":{"filtered":false,"detected":false},"profanity":{"filtered":false,"detected":false}}}],"system_fingerprint":""}
+        data: {"id":"chatcmpl-af6e9802f1554a49be4dd42048b91565","object":"chat.completion.chunk","created":1741793930,"model":"meta-llama/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{},"finish_reason":null,"content_filter_results":{"hate":{"filtered":false},"self_harm":{"filtered":false},"sexual":{"filtered":false},"violence":{"filtered":false},"jailbreak":{"filtered":false,"detected":false},"profanity":{"filtered":false,"detected":false}}}],"system_fingerprint":"","usage":{"prompt_tokens":46,"completion_tokens":2,"total_tokens":48,"prompt_tokens_details":null,"completion_tokens_details":null}}
 
 
-        data: {"id":"chatcmpl-1c5665bfedca4fa1993cfeecd007dcd8","object":"chat.completion.chunk","created":1739807134,"model":"meta-llama/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{},"finish_reason":null,"content_filter_results":{"hate":{"filtered":false},"self_harm":{"filtered":false},"sexual":{"filtered":false},"violence":{"filtered":false},"jailbreak":{"filtered":false,"detected":false},"profanity":{"filtered":false,"detected":false}}}],"system_fingerprint":""}
+        data: {"id":"chatcmpl-af6e9802f1554a49be4dd42048b91565","object":"chat.completion.chunk","created":1741793930,"model":"meta-llama/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{},"finish_reason":null,"content_filter_results":{"hate":{"filtered":false},"self_harm":{"filtered":false},"sexual":{"filtered":false},"violence":{"filtered":false},"jailbreak":{"filtered":false,"detected":false},"profanity":{"filtered":false,"detected":false}}}],"system_fingerprint":"","usage":{"prompt_tokens":46,"completion_tokens":3,"total_tokens":49,"prompt_tokens_details":null,"completion_tokens_details":null}}
 
 
-        data: {"id":"chatcmpl-1c5665bfedca4fa1993cfeecd007dcd8","object":"chat.completion.chunk","created":1739807134,"model":"meta-llama/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{},"finish_reason":null,"content_filter_results":{"hate":{"filtered":false},"self_harm":{"filtered":false},"sexual":{"filtered":false},"violence":{"filtered":false},"jailbreak":{"filtered":false,"detected":false},"profanity":{"filtered":false,"detected":false}}}],"system_fingerprint":""}
+        data: {"id":"chatcmpl-af6e9802f1554a49be4dd42048b91565","object":"chat.completion.chunk","created":1741793930,"model":"meta-llama/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{},"finish_reason":null,"content_filter_results":{"hate":{"filtered":false},"self_harm":{"filtered":false},"sexual":{"filtered":false},"violence":{"filtered":false},"jailbreak":{"filtered":false,"detected":false},"profanity":{"filtered":false,"detected":false}}}],"system_fingerprint":"","usage":{"prompt_tokens":46,"completion_tokens":4,"total_tokens":50,"prompt_tokens_details":null,"completion_tokens_details":null}}
 
 
-        data: {"id":"chatcmpl-1c5665bfedca4fa1993cfeecd007dcd8","object":"chat.completion.chunk","created":1739807134,"model":"meta-llama/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"content":"Deep
-        le"},"finish_reason":null,"content_filter_results":{"hate":{"filtered":false},"self_harm":{"filtered":false},"sexual":{"filtered":false},"violence":{"filtered":false},"jailbreak":{"filtered":false,"detected":false},"profanity":{"filtered":false,"detected":false}}}],"system_fingerprint":""}
+        data: {"id":"chatcmpl-af6e9802f1554a49be4dd42048b91565","object":"chat.completion.chunk","created":1741793930,"model":"meta-llama/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"content":"Deep"},"finish_reason":null,"content_filter_results":{"hate":{"filtered":false},"self_harm":{"filtered":false},"sexual":{"filtered":false},"violence":{"filtered":false},"jailbreak":{"filtered":false,"detected":false},"profanity":{"filtered":false,"detected":false}}}],"system_fingerprint":"","usage":{"prompt_tokens":46,"completion_tokens":5,"total_tokens":51,"prompt_tokens_details":null,"completion_tokens_details":null}}
 
 
-        data: {"id":"chatcmpl-1c5665bfedca4fa1993cfeecd007dcd8","object":"chat.completion.chunk","created":1739807134,"model":"meta-llama/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"content":"arn"},"finish_reason":null,"content_filter_results":{"hate":{"filtered":false},"self_harm":{"filtered":false},"sexual":{"filtered":false},"violence":{"filtered":false},"jailbreak":{"filtered":false,"detected":false},"profanity":{"filtered":false,"detected":false}}}],"system_fingerprint":""}
+        data: {"id":"chatcmpl-af6e9802f1554a49be4dd42048b91565","object":"chat.completion.chunk","created":1741793930,"model":"meta-llama/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"content":"
+        lear"},"finish_reason":null,"content_filter_results":{"hate":{"filtered":false},"self_harm":{"filtered":false},"sexual":{"filtered":false},"violence":{"filtered":false},"jailbreak":{"filtered":false,"detected":false},"profanity":{"filtered":false,"detected":false}}}],"system_fingerprint":"","usage":{"prompt_tokens":46,"completion_tokens":6,"total_tokens":52,"prompt_tokens_details":null,"completion_tokens_details":null}}
 
 
-        data: {"id":"chatcmpl-1c5665bfedca4fa1993cfeecd007dcd8","object":"chat.completion.chunk","created":1739807134,"model":"meta-llama/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"content":"ing
-        is a"},"finish_reason":null,"content_filter_results":{"hate":{"filtered":false},"self_harm":{"filtered":false},"sexual":{"filtered":false},"violence":{"filtered":false},"jailbreak":{"filtered":false,"detected":false},"profanity":{"filtered":false,"detected":false}}}],"system_fingerprint":""}
+        data: {"id":"chatcmpl-af6e9802f1554a49be4dd42048b91565","object":"chat.completion.chunk","created":1741793930,"model":"meta-llama/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"content":"nin"},"finish_reason":null,"content_filter_results":{"hate":{"filtered":false},"self_harm":{"filtered":false},"sexual":{"filtered":false},"violence":{"filtered":false},"jailbreak":{"filtered":false,"detected":false},"profanity":{"filtered":false,"detected":false}}}],"system_fingerprint":"","usage":{"prompt_tokens":46,"completion_tokens":7,"total_tokens":53,"prompt_tokens_details":null,"completion_tokens_details":null}}
 
 
-        data: {"id":"chatcmpl-1c5665bfedca4fa1993cfeecd007dcd8","object":"chat.completion.chunk","created":1739807134,"model":"meta-llama/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"content":"
-        subset o"},"finish_reason":null,"content_filter_results":{"hate":{"filtered":false},"self_harm":{"filtered":false},"sexual":{"filtered":false},"violence":{"filtered":false},"jailbreak":{"filtered":false,"detected":false},"profanity":{"filtered":false,"detected":false}}}],"system_fingerprint":""}
+        data: {"id":"chatcmpl-af6e9802f1554a49be4dd42048b91565","object":"chat.completion.chunk","created":1741793930,"model":"meta-llama/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"content":"g
+        is a s"},"finish_reason":null,"content_filter_results":{"hate":{"filtered":false},"self_harm":{"filtered":false},"sexual":{"filtered":false},"violence":{"filtered":false},"jailbreak":{"filtered":false,"detected":false},"profanity":{"filtered":false,"detected":false}}}],"system_fingerprint":"","usage":{"prompt_tokens":46,"completion_tokens":8,"total_tokens":54,"prompt_tokens_details":null,"completion_tokens_details":null}}
 
 
-        data: {"id":"chatcmpl-1c5665bfedca4fa1993cfeecd007dcd8","object":"chat.completion.chunk","created":1739807134,"model":"meta-llama/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"content":"f
-        mac"},"finish_reason":null,"content_filter_results":{"hate":{"filtered":false},"self_harm":{"filtered":false},"sexual":{"filtered":false},"violence":{"filtered":false},"jailbreak":{"filtered":false,"detected":false},"profanity":{"filtered":false,"detected":false}}}],"system_fingerprint":""}
+        data: {"id":"chatcmpl-af6e9802f1554a49be4dd42048b91565","object":"chat.completion.chunk","created":1741793930,"model":"meta-llama/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"content":"ubfield
+        o"},"finish_reason":null,"content_filter_results":{"hate":{"filtered":false},"self_harm":{"filtered":false},"sexual":{"filtered":false},"violence":{"filtered":false},"jailbreak":{"filtered":false,"detected":false},"profanity":{"filtered":false,"detected":false}}}],"system_fingerprint":"","usage":{"prompt_tokens":46,"completion_tokens":9,"total_tokens":55,"prompt_tokens_details":null,"completion_tokens_details":null}}
 
 
-        data: {"id":"chatcmpl-1c5665bfedca4fa1993cfeecd007dcd8","object":"chat.completion.chunk","created":1739807134,"model":"meta-llama/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"content":"hine
-        lear"},"finish_reason":null,"content_filter_results":{"hate":{"filtered":false},"self_harm":{"filtered":false},"sexual":{"filtered":false},"violence":{"filtered":false},"jailbreak":{"filtered":false,"detected":false},"profanity":{"filtered":false,"detected":false}}}],"system_fingerprint":""}
+        data: {"id":"chatcmpl-af6e9802f1554a49be4dd42048b91565","object":"chat.completion.chunk","created":1741793930,"model":"meta-llama/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"content":"f
+        mac"},"finish_reason":null,"content_filter_results":{"hate":{"filtered":false},"self_harm":{"filtered":false},"sexual":{"filtered":false},"violence":{"filtered":false},"jailbreak":{"filtered":false,"detected":false},"profanity":{"filtered":false,"detected":false}}}],"system_fingerprint":"","usage":{"prompt_tokens":46,"completion_tokens":10,"total_tokens":56,"prompt_tokens_details":null,"completion_tokens_details":null}}
 
 
-        data: {"id":"chatcmpl-1c5665bfedca4fa1993cfeecd007dcd8","object":"chat.completion.chunk","created":1739807134,"model":"meta-llama/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"content":"ning"},"finish_reason":null,"content_filter_results":{"hate":{"filtered":false},"self_harm":{"filtered":false},"sexual":{"filtered":false},"violence":{"filtered":false},"jailbreak":{"filtered":false,"detected":false},"profanity":{"filtered":false,"detected":false}}}],"system_fingerprint":""}
+        data: {"id":"chatcmpl-af6e9802f1554a49be4dd42048b91565","object":"chat.completion.chunk","created":1741793930,"model":"meta-llama/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"content":"hine
+        lea"},"finish_reason":null,"content_filter_results":{"hate":{"filtered":false},"self_harm":{"filtered":false},"sexual":{"filtered":false},"violence":{"filtered":false},"jailbreak":{"filtered":false,"detected":false},"profanity":{"filtered":false,"detected":false}}}],"system_fingerprint":"","usage":{"prompt_tokens":46,"completion_tokens":11,"total_tokens":57,"prompt_tokens_details":null,"completion_tokens_details":null}}
 
 
-        data: {"id":"chatcmpl-1c5665bfedca4fa1993cfeecd007dcd8","object":"chat.completion.chunk","created":1739807134,"model":"meta-llama/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"content":"
-        tha"},"finish_reason":null,"content_filter_results":{"hate":{"filtered":false},"self_harm":{"filtered":false},"sexual":{"filtered":false},"violence":{"filtered":false},"jailbreak":{"filtered":false,"detected":false},"profanity":{"filtered":false,"detected":false}}}],"system_fingerprint":""}
+        data: {"id":"chatcmpl-af6e9802f1554a49be4dd42048b91565","object":"chat.completion.chunk","created":1741793930,"model":"meta-llama/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"content":"rni"},"finish_reason":null,"content_filter_results":{"hate":{"filtered":false},"self_harm":{"filtered":false},"sexual":{"filtered":false},"violence":{"filtered":false},"jailbreak":{"filtered":false,"detected":false},"profanity":{"filtered":false,"detected":false}}}],"system_fingerprint":"","usage":{"prompt_tokens":46,"completion_tokens":12,"total_tokens":58,"prompt_tokens_details":null,"completion_tokens_details":null}}
 
 
-        data: {"id":"chatcmpl-1c5665bfedca4fa1993cfeecd007dcd8","object":"chat.completion.chunk","created":1739807134,"model":"meta-llama/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"content":"t
-        i"},"finish_reason":null,"content_filter_results":{"hate":{"filtered":false},"self_harm":{"filtered":false},"sexual":{"filtered":false},"violence":{"filtered":false},"jailbreak":{"filtered":false,"detected":false},"profanity":{"filtered":false,"detected":false}}}],"system_fingerprint":""}
+        data: {"id":"chatcmpl-af6e9802f1554a49be4dd42048b91565","object":"chat.completion.chunk","created":1741793930,"model":"meta-llama/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"content":"ng
+        t"},"finish_reason":null,"content_filter_results":{"hate":{"filtered":false},"self_harm":{"filtered":false},"sexual":{"filtered":false},"violence":{"filtered":false},"jailbreak":{"filtered":false,"detected":false},"profanity":{"filtered":false,"detected":false}}}],"system_fingerprint":"","usage":{"prompt_tokens":46,"completion_tokens":13,"total_tokens":59,"prompt_tokens_details":null,"completion_tokens_details":null}}
 
 
-        data: {"id":"chatcmpl-1c5665bfedca4fa1993cfeecd007dcd8","object":"chat.completion.chunk","created":1739807134,"model":"meta-llama/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"content":"nvolves
-        the"},"finish_reason":null,"content_filter_results":{"hate":{"filtered":false},"self_harm":{"filtered":false},"sexual":{"filtered":false},"violence":{"filtered":false},"jailbreak":{"filtered":false,"detected":false},"profanity":{"filtered":false,"detected":false}}}],"system_fingerprint":""}
+        data: {"id":"chatcmpl-af6e9802f1554a49be4dd42048b91565","object":"chat.completion.chunk","created":1741793930,"model":"meta-llama/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"content":"hat
+        focuses "},"finish_reason":null,"content_filter_results":{"hate":{"filtered":false},"self_harm":{"filtered":false},"sexual":{"filtered":false},"violence":{"filtered":false},"jailbreak":{"filtered":false,"detected":false},"profanity":{"filtered":false,"detected":false}}}],"system_fingerprint":"","usage":{"prompt_tokens":46,"completion_tokens":14,"total_tokens":60,"prompt_tokens_details":null,"completion_tokens_details":null}}
 
 
-        data: {"id":"chatcmpl-1c5665bfedca4fa1993cfeecd007dcd8","object":"chat.completion.chunk","created":1739807134,"model":"meta-llama/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"content":"
-        use of"},"finish_reason":null,"content_filter_results":{"hate":{"filtered":false},"self_harm":{"filtered":false},"sexual":{"filtered":false},"violence":{"filtered":false},"jailbreak":{"filtered":false,"detected":false},"profanity":{"filtered":false,"detected":false}}}],"system_fingerprint":""}
+        data: {"id":"chatcmpl-af6e9802f1554a49be4dd42048b91565","object":"chat.completion.chunk","created":1741793930,"model":"meta-llama/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"content":"on
+        "},"finish_reason":null,"content_filter_results":{"hate":{"filtered":false},"self_harm":{"filtered":false},"sexual":{"filtered":false},"violence":{"filtered":false},"jailbreak":{"filtered":false,"detected":false},"profanity":{"filtered":false,"detected":false}}}],"system_fingerprint":"","usage":{"prompt_tokens":46,"completion_tokens":15,"total_tokens":61,"prompt_tokens_details":null,"completion_tokens_details":null}}
 
 
-        data: {"id":"chatcmpl-1c5665bfedca4fa1993cfeecd007dcd8","object":"chat.completion.chunk","created":1739807134,"model":"meta-llama/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"content":"
-        artifici"},"finish_reason":null,"content_filter_results":{"hate":{"filtered":false},"self_harm":{"filtered":false},"sexual":{"filtered":false},"violence":{"filtered":false},"jailbreak":{"filtered":false,"detected":false},"profanity":{"filtered":false,"detected":false}}}],"system_fingerprint":""}
+        data: {"id":"chatcmpl-af6e9802f1554a49be4dd42048b91565","object":"chat.completion.chunk","created":1741793930,"model":"meta-llama/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"content":"the
+        develop"},"finish_reason":null,"content_filter_results":{"hate":{"filtered":false},"self_harm":{"filtered":false},"sexual":{"filtered":false},"violence":{"filtered":false},"jailbreak":{"filtered":false,"detected":false},"profanity":{"filtered":false,"detected":false}}}],"system_fingerprint":"","usage":{"prompt_tokens":46,"completion_tokens":16,"total_tokens":62,"prompt_tokens_details":null,"completion_tokens_details":null}}
 
 
-        data: {"id":"chatcmpl-1c5665bfedca4fa1993cfeecd007dcd8","object":"chat.completion.chunk","created":1739807134,"model":"meta-llama/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"content":"al"},"finish_reason":null,"content_filter_results":{"hate":{"filtered":false},"self_harm":{"filtered":false},"sexual":{"filtered":false},"violence":{"filtered":false},"jailbreak":{"filtered":false,"detected":false},"profanity":{"filtered":false,"detected":false}}}],"system_fingerprint":""}
+        data: {"id":"chatcmpl-af6e9802f1554a49be4dd42048b91565","object":"chat.completion.chunk","created":1741793930,"model":"meta-llama/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"content":"ment
+        of"},"finish_reason":null,"content_filter_results":{"hate":{"filtered":false},"self_harm":{"filtered":false},"sexual":{"filtered":false},"violence":{"filtered":false},"jailbreak":{"filtered":false,"detected":false},"profanity":{"filtered":false,"detected":false}}}],"system_fingerprint":"","usage":{"prompt_tokens":46,"completion_tokens":17,"total_tokens":63,"prompt_tokens_details":null,"completion_tokens_details":null}}
 
 
-        data: {"id":"chatcmpl-1c5665bfedca4fa1993cfeecd007dcd8","object":"chat.completion.chunk","created":1739807134,"model":"meta-llama/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"content":"
-        ne"},"finish_reason":null,"content_filter_results":{"hate":{"filtered":false},"self_harm":{"filtered":false},"sexual":{"filtered":false},"violence":{"filtered":false},"jailbreak":{"filtered":false,"detected":false},"profanity":{"filtered":false,"detected":false}}}],"system_fingerprint":""}
+        data: {"id":"chatcmpl-af6e9802f1554a49be4dd42048b91565","object":"chat.completion.chunk","created":1741793930,"model":"meta-llama/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"content":"
+        artifici"},"finish_reason":null,"content_filter_results":{"hate":{"filtered":false},"self_harm":{"filtered":false},"sexual":{"filtered":false},"violence":{"filtered":false},"jailbreak":{"filtered":false,"detected":false},"profanity":{"filtered":false,"detected":false}}}],"system_fingerprint":"","usage":{"prompt_tokens":46,"completion_tokens":18,"total_tokens":64,"prompt_tokens_details":null,"completion_tokens_details":null}}
 
 
-        data: {"id":"chatcmpl-1c5665bfedca4fa1993cfeecd007dcd8","object":"chat.completion.chunk","created":1739807134,"model":"meta-llama/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"content":"u"},"finish_reason":null,"content_filter_results":{"hate":{"filtered":false},"self_harm":{"filtered":false},"sexual":{"filtered":false},"violence":{"filtered":false},"jailbreak":{"filtered":false,"detected":false},"profanity":{"filtered":false,"detected":false}}}],"system_fingerprint":""}
+        data: {"id":"chatcmpl-af6e9802f1554a49be4dd42048b91565","object":"chat.completion.chunk","created":1741793930,"model":"meta-llama/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"content":"al
+        ne"},"finish_reason":null,"content_filter_results":{"hate":{"filtered":false},"self_harm":{"filtered":false},"sexual":{"filtered":false},"violence":{"filtered":false},"jailbreak":{"filtered":false,"detected":false},"profanity":{"filtered":false,"detected":false}}}],"system_fingerprint":"","usage":{"prompt_tokens":46,"completion_tokens":19,"total_tokens":65,"prompt_tokens_details":null,"completion_tokens_details":null}}
 
 
-        data: {"id":"chatcmpl-1c5665bfedca4fa1993cfeecd007dcd8","object":"chat.completion.chunk","created":1739807134,"model":"meta-llama/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"content":"ral
-        networks (ANNs)"},"finish_reason":"length","content_filter_results":{"hate":{"filtered":false},"self_harm":{"filtered":false},"sexual":{"filtered":false},"violence":{"filtered":false},"jailbreak":{"filtered":false,"detected":false},"profanity":{"filtered":false,"detected":false}}}],"system_fingerprint":""}
+        data: {"id":"chatcmpl-af6e9802f1554a49be4dd42048b91565","object":"chat.completion.chunk","created":1741793930,"model":"meta-llama/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"content":"ural
+        networks with multiple"},"finish_reason":"length","content_filter_results":{"hate":{"filtered":false},"self_harm":{"filtered":false},"sexual":{"filtered":false},"violence":{"filtered":false},"jailbreak":{"filtered":false,"detected":false},"profanity":{"filtered":false,"detected":false}}}],"system_fingerprint":"","usage":{"prompt_tokens":46,"completion_tokens":20,"total_tokens":66,"prompt_tokens_details":null,"completion_tokens_details":null}}
 
 
         data: [DONE]
@@ -109,7 +162,7 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Mon, 17 Feb 2025 15:45:34 GMT
+      - Wed, 12 Mar 2025 15:38:50 GMT
       Referrer-Policy:
       - strict-origin-when-cross-origin
       Transfer-Encoding:
@@ -117,23 +170,27 @@ interactions:
       Vary:
       - Origin
       Via:
-      - 1.1 b7c17dda962249acad4693c264f9df0e.cloudfront.net (CloudFront)
+      - 1.1 ff7010ce6a43809a9e2df5e6441e868e.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - xKADyToDuUeV5ZKpJip3lBCk9phsxCjhr4GSeAyifwx9Q9O4sLUxhQ==
+      - 939rYihzUwZtmbx1WwxFTptCZwhMGzRO3S-xBj8GqCd5wc85xp1OBg==
       X-Amz-Cf-Pop:
       - CDG55-P3
       X-Cache:
       - Miss from cloudfront
       X-Powered-By:
       - huggingface-moon
+      X-Robots-Tag:
+      - none
       cache-control:
       - no-cache
       cross-origin-opener-policy:
       - same-origin
+      inference-id:
+      - f89d861c-6343-45e5-83c8-00aa2af36bcb
       x-request-id:
-      - Root=1-67b3599d-2bc8106f4b28ffe45c12bd8e;4f86b753-c812-4334-a0ec-614e1100972a
+      - Root=1-67d1aa89-79f056c3615557e8087c750b;5cf4dfde-9f8d-4fb8-a01d-3934e8537f59
       x-trace-id:
-      - 0b28e9eba9181da9ea0d4c4220dac6f4
+      - 40a2a7be96327f6d2f24102791558b6d
     status:
       code: 200
       message: OK


### PR DESCRIPTION
regenerating some cassettes for which the call to `https://huggingface.co/api/models/{model_id}?expand=inferenceProviderMapping` was missing. This should fix the failing tests in the CI.