### PR TITLE
[Inference Providers] Async calls for fal.ai

### DIFF
--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -2617,7 +2617,7 @@ class InferenceClient:
             api_key=self.token,
         )
         response = self._inner_post(request_parameters)
-        response = provider_helper.get_response(response)
+        response = provider_helper.get_response(response, request_parameters)
         return response
 
     def text_to_speech(

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -2674,7 +2674,7 @@ class AsyncInferenceClient:
             api_key=self.token,
         )
         response = await self._inner_post(request_parameters)
-        response = provider_helper.get_response(response)
+        response = provider_helper.get_response(response, request_parameters)
         return response
 
     async def text_to_speech(

--- a/src/huggingface_hub/inference/_providers/_common.py
+++ b/src/huggingface_hub/inference/_providers/_common.py
@@ -101,7 +101,8 @@ class TaskProviderHelper:
             raise ValueError(
                 f"You must provide an api_key to work with {self.provider} API or log in with `huggingface-cli login`."
             )
-        return api_key
+        self.api_key = api_key
+        return self.api_key
 
     def _prepare_mapped_model(self, model: Optional[str]) -> str:
         """Return the mapped model ID to use for the request.
@@ -135,7 +136,8 @@ class TaskProviderHelper:
 
         Override this method in subclasses for customized headers.
         """
-        return {**build_hf_headers(token=api_key), **headers}
+        self.headers = {**build_hf_headers(token=api_key), **headers}
+        return self.headers
 
     def _prepare_url(self, api_key: str, mapped_model: str) -> str:
         """Return the URL to use for the request.
@@ -143,7 +145,8 @@ class TaskProviderHelper:
         Usually not overwritten in subclasses."""
         base_url = self._prepare_base_url(api_key)
         route = self._prepare_route(mapped_model)
-        return f"{base_url.rstrip('/')}/{route.lstrip('/')}"
+        self.url = f"{base_url.rstrip('/')}/{route.lstrip('/')}"
+        return self.url
 
     def _prepare_base_url(self, api_key: str) -> str:
         """Return the base URL to use for the request.

--- a/src/huggingface_hub/inference/_providers/_common.py
+++ b/src/huggingface_hub/inference/_providers/_common.py
@@ -161,7 +161,7 @@ class TaskProviderHelper:
             logger.info(f"Calling '{self.provider}' provider directly.")
             return self.base_url
 
-    def _prepare_route(self, mapped_model: str, api_key: Optional[str] = None) -> str:
+    def _prepare_route(self, mapped_model: str, api_key: str) -> str:
         """Return the route to use for the request.
 
         Override this method in subclasses for customized routes.
@@ -196,7 +196,7 @@ class BaseConversationalTask(TaskProviderHelper):
     def __init__(self, provider: str, base_url: str):
         super().__init__(provider=provider, base_url=base_url, task="conversational")
 
-    def _prepare_route(self, mapped_model: str, api_key: Optional[str] = None) -> str:
+    def _prepare_route(self, mapped_model: str, api_key: str) -> str:
         return "/v1/chat/completions"
 
     def _prepare_payload_as_dict(self, inputs: Any, parameters: Dict, mapped_model: str) -> Optional[Dict]:
@@ -212,7 +212,7 @@ class BaseTextGenerationTask(TaskProviderHelper):
     def __init__(self, provider: str, base_url: str):
         super().__init__(provider=provider, base_url=base_url, task="text-generation")
 
-    def _prepare_route(self, mapped_model: str, api_key: Optional[str] = None) -> str:
+    def _prepare_route(self, mapped_model: str, api_key: str) -> str:
         return "/v1/completions"
 
     def _prepare_payload_as_dict(self, inputs: Any, parameters: Dict, mapped_model: str) -> Optional[Dict]:

--- a/src/huggingface_hub/inference/_providers/black_forest_labs.py
+++ b/src/huggingface_hub/inference/_providers/black_forest_labs.py
@@ -1,7 +1,7 @@
 import time
 from typing import Any, Dict, Optional, Union
 
-from huggingface_hub.inference._common import _as_dict
+from huggingface_hub.inference._common import RequestParameters, _as_dict
 from huggingface_hub.inference._providers._common import TaskProviderHelper, filter_none
 from huggingface_hub.utils import logging
 from huggingface_hub.utils._http import get_session
@@ -24,7 +24,7 @@ class BlackForestLabsTextToImageTask(TaskProviderHelper):
             headers["X-Key"] = api_key
         return headers
 
-    def _prepare_route(self, mapped_model: str) -> str:
+    def _prepare_route(self, mapped_model: str, api_key: Optional[str] = None) -> str:
         return f"/v1/{mapped_model}"
 
     def _prepare_payload_as_dict(self, inputs: Any, parameters: Dict, mapped_model: str) -> Optional[Dict]:
@@ -36,7 +36,7 @@ class BlackForestLabsTextToImageTask(TaskProviderHelper):
 
         return {"prompt": inputs, **parameters}
 
-    def get_response(self, response: Union[bytes, Dict]) -> Any:
+    def get_response(self, response: Union[bytes, Dict], request_params: Optional[RequestParameters] = None) -> Any:
         """
         Polling mechanism for Black Forest Labs since the API is asynchronous.
         """

--- a/src/huggingface_hub/inference/_providers/black_forest_labs.py
+++ b/src/huggingface_hub/inference/_providers/black_forest_labs.py
@@ -24,7 +24,7 @@ class BlackForestLabsTextToImageTask(TaskProviderHelper):
             headers["X-Key"] = api_key
         return headers
 
-    def _prepare_route(self, mapped_model: str, api_key: Optional[str] = None) -> str:
+    def _prepare_route(self, mapped_model: str, api_key: str) -> str:
         return f"/v1/{mapped_model}"
 
     def _prepare_payload_as_dict(self, inputs: Any, parameters: Dict, mapped_model: str) -> Optional[Dict]:

--- a/src/huggingface_hub/inference/_providers/cohere.py
+++ b/src/huggingface_hub/inference/_providers/cohere.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from huggingface_hub.inference._providers._common import (
     BaseConversationalTask,
 )
@@ -11,5 +13,5 @@ class CohereConversationalTask(BaseConversationalTask):
     def __init__(self):
         super().__init__(provider=_PROVIDER, base_url=_BASE_URL)
 
-    def _prepare_route(self, mapped_model: str) -> str:
+    def _prepare_route(self, mapped_model: str, api_key: Optional[str] = None) -> str:
         return "/compatibility/v1/chat/completions"

--- a/src/huggingface_hub/inference/_providers/cohere.py
+++ b/src/huggingface_hub/inference/_providers/cohere.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from huggingface_hub.inference._providers._common import (
     BaseConversationalTask,
 )
@@ -13,5 +11,5 @@ class CohereConversationalTask(BaseConversationalTask):
     def __init__(self):
         super().__init__(provider=_PROVIDER, base_url=_BASE_URL)
 
-    def _prepare_route(self, mapped_model: str, api_key: Optional[str] = None) -> str:
+    def _prepare_route(self, mapped_model: str, api_key: str) -> str:
         return "/compatibility/v1/chat/completions"

--- a/src/huggingface_hub/inference/_providers/fal_ai.py
+++ b/src/huggingface_hub/inference/_providers/fal_ai.py
@@ -132,9 +132,9 @@ class FalAITextToVideoTask(FalAITask):
         logger.info("Generating the video.. this can take several minutes.")
         while status != "COMPLETED":
             time.sleep(_POLLING_INTERVAL)
-            response = get_session().get(status_url, headers=request_params.headers)  # type: ignore
-            hf_raise_for_status(response)  # type: ignore
-            response_dict = _as_dict(response.json())  # type: ignore
+            status_response = get_session().get(status_url, headers=request_params.headers)
+            hf_raise_for_status(status_response)
+            status = status_response.json().get("status")
             status = response_dict.get("status")
 
         response = get_session().get(result_url, headers=request_params.headers).json()

--- a/src/huggingface_hub/inference/_providers/fal_ai.py
+++ b/src/huggingface_hub/inference/_providers/fal_ai.py
@@ -135,7 +135,6 @@ class FalAITextToVideoTask(FalAITask):
             status_response = get_session().get(status_url, headers=request_params.headers)
             hf_raise_for_status(status_response)
             status = status_response.json().get("status")
-            status = response_dict.get("status")
 
         response = get_session().get(result_url, headers=request_params.headers).json()
         url = _as_dict(response)["video"]["url"]

--- a/src/huggingface_hub/inference/_providers/fal_ai.py
+++ b/src/huggingface_hub/inference/_providers/fal_ai.py
@@ -27,9 +27,6 @@ class FalAITask(TaskProviderHelper, ABC):
         return headers
 
     def _prepare_route(self, mapped_model: str) -> str:
-        if self.api_key.startswith("hf_"):
-            # Use the queue subdomain for HF routing
-            return f"/{mapped_model}?_subdomain=queue"
         return f"/{mapped_model}"
 
 
@@ -93,6 +90,12 @@ class FalAITextToSpeechTask(FalAITask):
 class FalAITextToVideoTask(FalAITask):
     def __init__(self):
         super().__init__("text-to-video")
+
+    def _prepare_route(self, mapped_model: str) -> str:
+        if self.api_key.startswith("hf_"):
+            # Use the queue subdomain for HF routing
+            return f"/{mapped_model}?_subdomain=queue"
+        return f"/{mapped_model}"
 
     def _prepare_payload_as_dict(self, inputs: Any, parameters: Dict, mapped_model: str) -> Optional[Dict]:
         return {"prompt": inputs, **filter_none(parameters)}

--- a/src/huggingface_hub/inference/_providers/fal_ai.py
+++ b/src/huggingface_hub/inference/_providers/fal_ai.py
@@ -98,7 +98,7 @@ class FalAITextToVideoTask(FalAITask):
             return "https://queue.fal.run"
 
     def _prepare_route(self, mapped_model: str, api_key: str) -> str:
-        if api_key and api_key.startswith("hf_"):
+        if api_key.startswith("hf_"):
             # Use the queue subdomain for HF routing
             return f"/{mapped_model}?_subdomain=queue"
         return f"/{mapped_model}"

--- a/src/huggingface_hub/inference/_providers/fal_ai.py
+++ b/src/huggingface_hub/inference/_providers/fal_ai.py
@@ -111,9 +111,11 @@ class FalAITextToVideoTask(FalAITask):
         if not request_id:
             raise ValueError("No request ID found in the response")
         if request_params is None:
-            raise ValueError("Request parameters should be provided to get text-to-video responses with Fal AI.")
-        # extract the base url and query params
+            raise ValueError(
+                "A `RequestParameters` object should be provided to get text-to-video responses with Fal AI."
+            )
 
+        # extract the base url and query params
         parsed = urlparse(request_params.url)
         base_url = request_params.url.split("?")[0]  # or parsed.scheme + "://" + parsed.netloc + parsed.path ?
         query = "?" + parsed.query if parsed.query else ""

--- a/src/huggingface_hub/inference/_providers/fal_ai.py
+++ b/src/huggingface_hub/inference/_providers/fal_ai.py
@@ -127,9 +127,9 @@ class FalAITextToVideoTask(FalAITask):
         logger.info("Generating the video.. this can take several minutes.")
         while status != "COMPLETED":
             time.sleep(_POLLING_INTERVAL)
-            response = get_session().get(status_url, headers=request_params.headers).json()
+            response = get_session().get(status_url, headers=request_params.headers)  # type: ignore
             hf_raise_for_status(response)  # type: ignore
-            response_dict = _as_dict(response)
+            response_dict = _as_dict(response.json())  # type: ignore
             status = response_dict.get("status")
 
         response = get_session().get(result_url, headers=request_params.headers).json()

--- a/src/huggingface_hub/inference/_providers/fal_ai.py
+++ b/src/huggingface_hub/inference/_providers/fal_ai.py
@@ -127,9 +127,9 @@ class FalAITextToVideoTask(FalAITask):
         logger.info("Generating the video.. this can take several minutes.")
         while status != "COMPLETED":
             time.sleep(_POLLING_INTERVAL)
-            response = get_session().get(status_url, headers=request_params.headers)
-            hf_raise_for_status(response)
-            response_dict = _as_dict(response.json())
+            response = get_session().get(status_url, headers=request_params.headers).json()
+            hf_raise_for_status(response)  # type: ignore
+            response_dict = _as_dict(response)
             status = response_dict.get("status")
 
         response = get_session().get(result_url, headers=request_params.headers).json()

--- a/src/huggingface_hub/inference/_providers/fireworks_ai.py
+++ b/src/huggingface_hub/inference/_providers/fireworks_ai.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from ._common import BaseConversationalTask
 
 
@@ -5,5 +7,5 @@ class FireworksAIConversationalTask(BaseConversationalTask):
     def __init__(self):
         super().__init__(provider="fireworks-ai", base_url="https://api.fireworks.ai")
 
-    def _prepare_route(self, mapped_model: str) -> str:
+    def _prepare_route(self, mapped_model: str, api_key: Optional[str] = None) -> str:
         return "/inference/v1/chat/completions"

--- a/src/huggingface_hub/inference/_providers/fireworks_ai.py
+++ b/src/huggingface_hub/inference/_providers/fireworks_ai.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from ._common import BaseConversationalTask
 
 
@@ -7,5 +5,5 @@ class FireworksAIConversationalTask(BaseConversationalTask):
     def __init__(self):
         super().__init__(provider="fireworks-ai", base_url="https://api.fireworks.ai")
 
-    def _prepare_route(self, mapped_model: str, api_key: Optional[str] = None) -> str:
+    def _prepare_route(self, mapped_model: str, api_key: str) -> str:
         return "/inference/v1/chat/completions"

--- a/src/huggingface_hub/inference/_providers/hyperbolic.py
+++ b/src/huggingface_hub/inference/_providers/hyperbolic.py
@@ -1,7 +1,7 @@
 import base64
 from typing import Any, Dict, Optional, Union
 
-from huggingface_hub.inference._common import _as_dict
+from huggingface_hub.inference._common import RequestParameters, _as_dict
 from huggingface_hub.inference._providers._common import BaseConversationalTask, TaskProviderHelper, filter_none
 
 
@@ -9,7 +9,7 @@ class HyperbolicTextToImageTask(TaskProviderHelper):
     def __init__(self):
         super().__init__(provider="hyperbolic", base_url="https://api.hyperbolic.xyz", task="text-to-image")
 
-    def _prepare_route(self, mapped_model: str) -> str:
+    def _prepare_route(self, mapped_model: str, api_key: Optional[str] = None) -> str:
         return "/v1/images/generations"
 
     def _prepare_payload_as_dict(self, inputs: Any, parameters: Dict, mapped_model: str) -> Optional[Dict]:
@@ -25,7 +25,7 @@ class HyperbolicTextToImageTask(TaskProviderHelper):
             parameters["height"] = 512
         return {"prompt": inputs, "model_name": mapped_model, **parameters}
 
-    def get_response(self, response: Union[bytes, Dict]) -> Any:
+    def get_response(self, response: Union[bytes, Dict], request_params: Optional[RequestParameters] = None) -> Any:
         response_dict = _as_dict(response)
         return base64.b64decode(response_dict["images"][0]["image"])
 

--- a/src/huggingface_hub/inference/_providers/hyperbolic.py
+++ b/src/huggingface_hub/inference/_providers/hyperbolic.py
@@ -9,7 +9,7 @@ class HyperbolicTextToImageTask(TaskProviderHelper):
     def __init__(self):
         super().__init__(provider="hyperbolic", base_url="https://api.hyperbolic.xyz", task="text-to-image")
 
-    def _prepare_route(self, mapped_model: str, api_key: Optional[str] = None) -> str:
+    def _prepare_route(self, mapped_model: str, api_key: str) -> str:
         return "/v1/images/generations"
 
     def _prepare_payload_as_dict(self, inputs: Any, parameters: Dict, mapped_model: str) -> Optional[Dict]:

--- a/src/huggingface_hub/inference/_providers/nebius.py
+++ b/src/huggingface_hub/inference/_providers/nebius.py
@@ -1,7 +1,7 @@
 import base64
 from typing import Any, Dict, Optional, Union
 
-from huggingface_hub.inference._common import _as_dict
+from huggingface_hub.inference._common import RequestParameters, _as_dict
 from huggingface_hub.inference._providers._common import (
     BaseConversationalTask,
     BaseTextGenerationTask,
@@ -24,7 +24,7 @@ class NebiusTextToImageTask(TaskProviderHelper):
     def __init__(self):
         super().__init__(task="text-to-image", provider="nebius", base_url="https://api.studio.nebius.ai")
 
-    def _prepare_route(self, mapped_model: str) -> str:
+    def _prepare_route(self, mapped_model: str, api_key: Optional[str] = None) -> str:
         return "/v1/images/generations"
 
     def _prepare_payload_as_dict(self, inputs: Any, parameters: Dict, mapped_model: str) -> Optional[Dict]:
@@ -36,6 +36,6 @@ class NebiusTextToImageTask(TaskProviderHelper):
 
         return {"prompt": inputs, **parameters, "model": mapped_model}
 
-    def get_response(self, response: Union[bytes, Dict]) -> Any:
+    def get_response(self, response: Union[bytes, Dict], request_params: Optional[RequestParameters] = None) -> Any:
         response_dict = _as_dict(response)
         return base64.b64decode(response_dict["data"][0]["b64_json"])

--- a/src/huggingface_hub/inference/_providers/nebius.py
+++ b/src/huggingface_hub/inference/_providers/nebius.py
@@ -24,7 +24,7 @@ class NebiusTextToImageTask(TaskProviderHelper):
     def __init__(self):
         super().__init__(task="text-to-image", provider="nebius", base_url="https://api.studio.nebius.ai")
 
-    def _prepare_route(self, mapped_model: str, api_key: Optional[str] = None) -> str:
+    def _prepare_route(self, mapped_model: str, api_key: str) -> str:
         return "/v1/images/generations"
 
     def _prepare_payload_as_dict(self, inputs: Any, parameters: Dict, mapped_model: str) -> Optional[Dict]:

--- a/src/huggingface_hub/inference/_providers/novita.py
+++ b/src/huggingface_hub/inference/_providers/novita.py
@@ -18,7 +18,7 @@ class NovitaTextGenerationTask(BaseTextGenerationTask):
     def __init__(self):
         super().__init__(provider=_PROVIDER, base_url=_BASE_URL)
 
-    def _prepare_route(self, mapped_model: str, api_key: Optional[str] = None) -> str:
+    def _prepare_route(self, mapped_model: str, api_key: str) -> str:
         # there is no v1/ route for novita
         return "/v3/openai/completions"
 
@@ -27,7 +27,7 @@ class NovitaConversationalTask(BaseConversationalTask):
     def __init__(self):
         super().__init__(provider=_PROVIDER, base_url=_BASE_URL)
 
-    def _prepare_route(self, mapped_model: str, api_key: Optional[str] = None) -> str:
+    def _prepare_route(self, mapped_model: str, api_key: str) -> str:
         # there is no v1/ route for novita
         return "/v3/openai/chat/completions"
 
@@ -36,7 +36,7 @@ class NovitaTextToVideoTask(TaskProviderHelper):
     def __init__(self):
         super().__init__(provider=_PROVIDER, base_url=_BASE_URL, task="text-to-video")
 
-    def _prepare_route(self, mapped_model: str, api_key: Optional[str] = None) -> str:
+    def _prepare_route(self, mapped_model: str, api_key: str) -> str:
         return f"/v3/hf/{mapped_model}"
 
     def _prepare_payload_as_dict(self, inputs: Any, parameters: Dict, mapped_model: str) -> Optional[Dict]:

--- a/src/huggingface_hub/inference/_providers/novita.py
+++ b/src/huggingface_hub/inference/_providers/novita.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Optional, Union
 
-from huggingface_hub.inference._common import _as_dict
+from huggingface_hub.inference._common import RequestParameters, _as_dict
 from huggingface_hub.inference._providers._common import (
     BaseConversationalTask,
     BaseTextGenerationTask,
@@ -18,7 +18,7 @@ class NovitaTextGenerationTask(BaseTextGenerationTask):
     def __init__(self):
         super().__init__(provider=_PROVIDER, base_url=_BASE_URL)
 
-    def _prepare_route(self, mapped_model: str) -> str:
+    def _prepare_route(self, mapped_model: str, api_key: Optional[str] = None) -> str:
         # there is no v1/ route for novita
         return "/v3/openai/completions"
 
@@ -27,7 +27,7 @@ class NovitaConversationalTask(BaseConversationalTask):
     def __init__(self):
         super().__init__(provider=_PROVIDER, base_url=_BASE_URL)
 
-    def _prepare_route(self, mapped_model: str) -> str:
+    def _prepare_route(self, mapped_model: str, api_key: Optional[str] = None) -> str:
         # there is no v1/ route for novita
         return "/v3/openai/chat/completions"
 
@@ -36,13 +36,13 @@ class NovitaTextToVideoTask(TaskProviderHelper):
     def __init__(self):
         super().__init__(provider=_PROVIDER, base_url=_BASE_URL, task="text-to-video")
 
-    def _prepare_route(self, mapped_model: str) -> str:
+    def _prepare_route(self, mapped_model: str, api_key: Optional[str] = None) -> str:
         return f"/v3/hf/{mapped_model}"
 
     def _prepare_payload_as_dict(self, inputs: Any, parameters: Dict, mapped_model: str) -> Optional[Dict]:
         return {"prompt": inputs, **filter_none(parameters)}
 
-    def get_response(self, response: Union[bytes, Dict]) -> Any:
+    def get_response(self, response: Union[bytes, Dict], request_params: Optional[RequestParameters] = None) -> Any:
         response_dict = _as_dict(response)
         if not (
             isinstance(response_dict, dict)

--- a/src/huggingface_hub/inference/_providers/replicate.py
+++ b/src/huggingface_hub/inference/_providers/replicate.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Optional, Union
 
-from huggingface_hub.inference._common import _as_dict
+from huggingface_hub.inference._common import RequestParameters, _as_dict
 from huggingface_hub.inference._providers._common import TaskProviderHelper, filter_none
 from huggingface_hub.utils import get_session
 
@@ -18,7 +18,7 @@ class ReplicateTask(TaskProviderHelper):
         headers["Prefer"] = "wait"
         return headers
 
-    def _prepare_route(self, mapped_model: str) -> str:
+    def _prepare_route(self, mapped_model: str, api_key: Optional[str] = None) -> str:
         if ":" in mapped_model:
             return "/v1/predictions"
         return f"/v1/models/{mapped_model}/predictions"
@@ -30,7 +30,7 @@ class ReplicateTask(TaskProviderHelper):
             payload["version"] = version
         return payload
 
-    def get_response(self, response: Union[bytes, Dict]) -> Any:
+    def get_response(self, response: Union[bytes, Dict], request_params: Optional[RequestParameters] = None) -> Any:
         response_dict = _as_dict(response)
         if response_dict.get("output") is None:
             raise TimeoutError(

--- a/src/huggingface_hub/inference/_providers/replicate.py
+++ b/src/huggingface_hub/inference/_providers/replicate.py
@@ -18,7 +18,7 @@ class ReplicateTask(TaskProviderHelper):
         headers["Prefer"] = "wait"
         return headers
 
-    def _prepare_route(self, mapped_model: str, api_key: Optional[str] = None) -> str:
+    def _prepare_route(self, mapped_model: str, api_key: str) -> str:
         if ":" in mapped_model:
             return "/v1/predictions"
         return f"/v1/models/{mapped_model}/predictions"

--- a/src/huggingface_hub/inference/_providers/together.py
+++ b/src/huggingface_hub/inference/_providers/together.py
@@ -2,7 +2,7 @@ import base64
 from abc import ABC
 from typing import Any, Dict, Optional, Union
 
-from huggingface_hub.inference._common import _as_dict
+from huggingface_hub.inference._common import RequestParameters, _as_dict
 from huggingface_hub.inference._providers._common import (
     BaseConversationalTask,
     BaseTextGenerationTask,
@@ -21,7 +21,7 @@ class TogetherTask(TaskProviderHelper, ABC):
     def __init__(self, task: str):
         super().__init__(provider=_PROVIDER, base_url=_BASE_URL, task=task)
 
-    def _prepare_route(self, mapped_model: str) -> str:
+    def _prepare_route(self, mapped_model: str, api_key: Optional[str] = None) -> str:
         if self.task == "text-to-image":
             return "/v1/images/generations"
         elif self.task == "conversational":
@@ -54,6 +54,6 @@ class TogetherTextToImageTask(TogetherTask):
 
         return {"prompt": inputs, "response_format": "base64", **parameters, "model": mapped_model}
 
-    def get_response(self, response: Union[bytes, Dict]) -> Any:
+    def get_response(self, response: Union[bytes, Dict], request_params: Optional[RequestParameters] = None) -> Any:
         response_dict = _as_dict(response)
         return base64.b64decode(response_dict["data"][0]["b64_json"])

--- a/src/huggingface_hub/inference/_providers/together.py
+++ b/src/huggingface_hub/inference/_providers/together.py
@@ -21,7 +21,7 @@ class TogetherTask(TaskProviderHelper, ABC):
     def __init__(self, task: str):
         super().__init__(provider=_PROVIDER, base_url=_BASE_URL, task=task)
 
-    def _prepare_route(self, mapped_model: str, api_key: Optional[str] = None) -> str:
+    def _prepare_route(self, mapped_model: str, api_key: str) -> str:
         if self.task == "text-to-image":
             return "/v1/images/generations"
         elif self.task == "conversational":

--- a/tests/test_inference_providers.py
+++ b/tests/test_inference_providers.py
@@ -233,9 +233,8 @@ class TestFalAIProvider:
 
     def test_prepare_url(self):
         helper = FalAITextToImageTask()
-        api_key = helper._prepare_api_key("hf_token")
-        url = helper._prepare_url(api_key, "username/repo_name")
-        assert url == "https://router.huggingface.co/fal-ai/username/repo_name?_subdomain=queue"
+        url = helper._prepare_url("hf_token", "username/repo_name")
+        assert url == "https://router.huggingface.co/fal-ai/username/repo_name"
 
     def test_automatic_speech_recognition_payload(self):
         helper = FalAIAutomaticSpeechRecognitionTask()

--- a/tests/test_inference_providers.py
+++ b/tests/test_inference_providers.py
@@ -147,7 +147,7 @@ class TestBlackForestLabsProvider:
     def test_prepare_route(self):
         """Test route preparation."""
         helper = BlackForestLabsTextToImageTask()
-        assert helper._prepare_route("username/repo_name") == "/v1/username/repo_name"
+        assert helper._prepare_route("username/repo_name", "hf_token") == "/v1/username/repo_name"
 
     def test_prepare_url(self):
         helper = BlackForestLabsTextToImageTask()
@@ -505,13 +505,13 @@ class TestHyperbolicProvider:
     def test_prepare_route(self):
         """Test route preparation for different tasks."""
         helper = HyperbolicTextToImageTask()
-        assert helper._prepare_route("username/repo_name") == "/v1/images/generations"
+        assert helper._prepare_route("username/repo_name", "hf_token") == "/v1/images/generations"
 
         helper = HyperbolicTextGenerationTask("text-generation")
-        assert helper._prepare_route("username/repo_name") == "/v1/chat/completions"
+        assert helper._prepare_route("username/repo_name", "hf_token") == "/v1/chat/completions"
 
         helper = HyperbolicTextGenerationTask("conversational")
-        assert helper._prepare_route("username/repo_name") == "/v1/chat/completions"
+        assert helper._prepare_route("username/repo_name", "hf_token") == "/v1/chat/completions"
 
     def test_prepare_payload_conversational(self):
         """Test payload preparation for conversational task."""
@@ -560,7 +560,7 @@ class TestHyperbolicProvider:
 class TestNebiusProvider:
     def test_prepare_route_text_to_image(self):
         helper = NebiusTextToImageTask()
-        assert helper._prepare_route("username/repo_name") == "/v1/images/generations"
+        assert helper._prepare_route("username/repo_name", "hf_token") == "/v1/images/generations"
 
     def test_prepare_payload_as_dict_text_to_image(self):
         helper = NebiusTextToImageTask()
@@ -607,11 +607,11 @@ class TestReplicateProvider:
         helper = ReplicateTask("text-to-image")
 
         # No model version
-        url = helper._prepare_route("black-forest-labs/FLUX.1-schnell")
+        url = helper._prepare_route("black-forest-labs/FLUX.1-schnell", "hf_token")
         assert url == "/v1/models/black-forest-labs/FLUX.1-schnell/predictions"
 
         # Model with specific version
-        url = helper._prepare_route("black-forest-labs/FLUX.1-schnell:1944af04d098ef")
+        url = helper._prepare_route("black-forest-labs/FLUX.1-schnell:1944af04d098ef", "hf_token")
         assert url == "/v1/predictions"
 
     def test_prepare_payload_as_dict(self):
@@ -667,7 +667,7 @@ class TestSambanovaProvider:
 class TestTogetherProvider:
     def test_prepare_route_text_to_image(self):
         helper = TogetherTextToImageTask()
-        assert helper._prepare_route("username/repo_name") == "/v1/images/generations"
+        assert helper._prepare_route("username/repo_name", "hf_token") == "/v1/images/generations"
 
     def test_prepare_payload_as_dict_text_to_image(self):
         helper = TogetherTextToImageTask()
@@ -695,7 +695,7 @@ class TestTogetherProvider:
 class TestBaseConversationalTask:
     def test_prepare_route(self):
         helper = BaseConversationalTask(provider="test-provider", base_url="https://api.test.com")
-        assert helper._prepare_route("dummy-model") == "/v1/chat/completions"
+        assert helper._prepare_route("dummy-model", "hf_token") == "/v1/chat/completions"
         assert helper.task == "conversational"
 
     def test_prepare_payload(self):
@@ -720,7 +720,7 @@ class TestBaseConversationalTask:
 class TestBaseTextGenerationTask:
     def test_prepare_route(self):
         helper = BaseTextGenerationTask(provider="test-provider", base_url="https://api.test.com")
-        assert helper._prepare_route("dummy-model") == "/v1/completions"
+        assert helper._prepare_route("dummy-model", "hf_token") == "/v1/completions"
         assert helper.task == "text-generation"
 
     def test_prepare_payload(self):

--- a/tests/test_inference_providers.py
+++ b/tests/test_inference_providers.py
@@ -232,8 +232,7 @@ class TestFalAIProvider:
         assert headers["authorization"] == "Bearer hf_token"
 
     def test_prepare_url(self):
-        helper = FalAITextToImageTask()
-        url = helper._prepare_url("hf_token", "username/repo_name")
+        url = FalAITextToImageTask()._prepare_url("hf_token", "username/repo_name")
         assert url == "https://router.huggingface.co/fal-ai/username/repo_name"
 
     def test_automatic_speech_recognition_payload(self):


### PR DESCRIPTION
This PR adds asynchronous polling to the fal.ai `text-to-video` implementation. This allows running inference with large models that may take > 2 min to generate results.

**Main Changes**
- Implemented a polling mechanism in `FalAITextToVideoTask.get_response` that periodically checks generation status.
- URL, headers and API key are stored as class attributes for use during polling instead of passing these values as argument to `get_response`. Not 100% sure if this is the best solution.
- Updated fal.ai tests.

Once the structure is approved, we can add async calls for replicate (directly in this PR?), which should be straightforward.

I've tested locally the generation with models that take more than 2min and it works fine. 