### PR TITLE
[Inference Providers] update polling interval for fal-ai

### DIFF
--- a/src/huggingface_hub/inference/_providers/fal_ai.py
+++ b/src/huggingface_hub/inference/_providers/fal_ai.py
@@ -12,7 +12,7 @@ from huggingface_hub.utils.logging import get_logger
 logger = get_logger(__name__)
 
 # Arbitrary polling interval
-_POLLING_INTERVAL = 2.0
+_POLLING_INTERVAL = 0.5
 
 
 class FalAITask(TaskProviderHelper, ABC):


### PR DESCRIPTION
Related to this discussion : https://github.com/huggingface/huggingface.js/pull/1292#discussion_r2000759123

Let's use the same interval polling for our clients. 0.5s should be smaller enough to fetch updates frequently enough and larger enough to avoid querying the API too often (hopefully).