### PR TITLE
Allow users with (at least) write permissions to run the style bot workflow

### DIFF
--- a/.github/workflows/style-bot-action.yml
+++ b/.github/workflows/style-bot-action.yml
@@ -52,7 +52,7 @@ jobs:
               username: comment_user
             });
             const authorized = ['admin', 'maintain', 'push'].includes(permission.permission);
-            console.log(`User ${comment_user} has permission level: ${permission.permission}, authorized: ${authorized} (only admins and write permissions allowed)`);
+            console.log(`User ${comment_user} has permission level: ${permission.permission}, authorized: ${authorized} (only users with at least write access are allowed to run this action)`);
             core.setOutput('has_permission', authorized);
 
   run-style-bot:

--- a/.github/workflows/style-bot-action.yml
+++ b/.github/workflows/style-bot-action.yml
@@ -51,8 +51,8 @@ jobs:
               repo: context.repo.repo,
               username: comment_user
             });
-            const authorized = permission.permission === 'admin';
-            console.log(`User ${comment_user} has permission level: ${permission.permission}, authorized: ${authorized} (only admins allowed)`);
+            const authorized = ['admin', 'maintain', 'push'].includes(permission.permission);
+            console.log(`User ${comment_user} has permission level: ${permission.permission}, authorized: ${authorized} (only admins and write permissions allowed)`);
             core.setOutput('has_permission', authorized);
 
   run-style-bot:


### PR DESCRIPTION
users with `admin` > `maintain` > `push` permissions are allowed to run the style bot. 