### PR TITLE
Support `bill_to` in InferenceClient

### DIFF
--- a/docs/source/en/guides/inference.md
+++ b/docs/source/en/guides/inference.md
@@ -349,7 +349,7 @@ As an HF user, you get monthly credits to run the HF Inference API. The amount o
 >>> image.save("lion.png")
 ```
 
-Note that it is NOT possible to charge another user or an organization you are not part of. If you want to grant someone else some credits, you must create a joined organization with them.
+Note that it is NOT possible to charge another user or an organization you are not part of. If you want to grant someone else some credits, you must create a joint organization with them.
 
 
 ### Timeout

--- a/docs/source/en/guides/inference.md
+++ b/docs/source/en/guides/inference.md
@@ -337,7 +337,7 @@ In the above section, we saw the main aspects of [`InferenceClient`]. Let's dive
 
 ### Billing
 
-As an HF user, you get monthly credits to run the HF Inference API. The amount of credits you get depends on your type of account (Free or PRO or Enterprise Hub). You get charged for every inference request, depending on the provider's pricing table. By default, the requests are billed to your personal account. However, it is possible to set the billing so that requests are charged to an organization you are part of by simply passing `bill_to="<your_org_name>"` to `InferenceClient`. For this to work, your organization must be subscribed to Enterprise Hub. For more details about billing, check out [this guide](https://huggingface.co/docs/api-inference/pricing#features-using-inference-providers).
+As an HF user, you get monthly credits to run inference through various providers on the Hub. The amount of credits you get depends on your type of account (Free or PRO or Enterprise Hub). You get charged for every inference request, depending on the provider's pricing table. By default, the requests are billed to your personal account. However, it is possible to set the billing so that requests are charged to an organization you are part of by simply passing `bill_to="<your_org_name>"` to `InferenceClient`. For this to work, your organization must be subscribed to Enterprise Hub. For more details about billing, check out [this guide](https://huggingface.co/docs/api-inference/pricing#features-using-inference-providers).
 
 ```py
 >>> from huggingface_hub import InferenceClient

--- a/docs/source/en/guides/inference.md
+++ b/docs/source/en/guides/inference.md
@@ -337,7 +337,7 @@ In the above section, we saw the main aspects of [`InferenceClient`]. Let's dive
 
 ### Billing
 
-As an HF user, you get monthly credits to run the HF Inference API. The amount of credits you get depends on your type of account (Free or PRO or Enterprise Hub). You get charged for every inference request, depending on the provider's pricing table. By default, the requests are billed to your personal account. However, it is possible to set the billing so that requests are charged to an organization you are part of by simply passing `bill_to="<your_org_name>"` to `InferenceClient`. For this to work, your organization must have their billing enabled. For more details about billing, check out [this guide](https://huggingface.co/docs/api-inference/pricing#features-using-inference-providers).
+As an HF user, you get monthly credits to run the HF Inference API. The amount of credits you get depends on your type of account (Free or PRO or Enterprise Hub). You get charged for every inference request, depending on the provider's pricing table. By default, the requests are billed to your personal account. However, it is possible to set the billing so that requests are charged to an organization you are part of by simply passing `bill_to="<your_org_name>"` to `InferenceClient`. For this to work, your organization must be subscribed to Enterprise Hub. For more details about billing, check out [this guide](https://huggingface.co/docs/api-inference/pricing#features-using-inference-providers).
 
 ```py
 >>> from huggingface_hub import InferenceClient

--- a/docs/source/en/guides/inference.md
+++ b/docs/source/en/guides/inference.md
@@ -335,6 +335,23 @@ For more information about the `asyncio` module, please refer to the [official d
 
 In the above section, we saw the main aspects of [`InferenceClient`]. Let's dive into some more advanced tips.
 
+### Billing
+
+As an HF user, you get monthly credits to run the HF Inference API. The amount of credits you get depends on your type of account (Free or PRO or Enterprise Hub). You get charged for every inference request, depending on the provider's pricing table. By default, the requests are billed to your personal account. However, it is possible to set the billing so that requests are charged to an organization you are part of by simply passing `bill_to="<your_org_name>"` to `InferenceClient`. For this to work, your organization must have their billing enabled. For more details about billing, check out [this guide](https://huggingface.co/docs/api-inference/pricing#features-using-inference-providers).
+
+```py
+>>> from huggingface_hub import InferenceClient
+>>> client = InferenceClient(provider="fal-ai", bill_to="openai")
+>>> image = client.text_to_image(
+...     "A majestic lion in a fantasy forest",
+...     model="black-forest-labs/FLUX.1-schnell",
+... )
+>>> image.save("lion.png")
+```
+
+Note that it is NOT possible to charge another user or an organization you are not part of. If you want to grant someone else some credits, you must create a joined organization with them.
+
+
 ### Timeout
 
 When doing inference, there are two main causes for a timeout:

--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -73,6 +73,7 @@ if _staging_mode:
 HUGGINGFACE_HEADER_X_REPO_COMMIT = "X-Repo-Commit"
 HUGGINGFACE_HEADER_X_LINKED_ETAG = "X-Linked-Etag"
 HUGGINGFACE_HEADER_X_LINKED_SIZE = "X-Linked-Size"
+HUGGINGFACE_HEADER_X_BILL_TO = "X-HF-Bill-To"
 
 INFERENCE_ENDPOINT = os.environ.get("HF_INFERENCE_ENDPOINT", "https://api-inference.huggingface.co")
 

--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -146,6 +146,10 @@ class InferenceClient:
         headers (`Dict[str, str]`, `optional`):
             Additional headers to send to the server. By default only the authorization and user-agent headers are sent.
             Values in this dictionary will override the default values.
+        bill_to (`str`, `optional`):
+            The billing account to use for the request. By default the request will be billed to the user's account.
+            Request can be billed to any organization the user is a member of (e.g. `bill_to="huggingface"`) as long as
+            billing is enabled for that organization.
         cookies (`Dict[str, str]`, `optional`):
             Additional cookies to send to the server.
         proxies (`Any`, `optional`):
@@ -168,6 +172,7 @@ class InferenceClient:
         headers: Optional[Dict[str, str]] = None,
         cookies: Optional[Dict[str, str]] = None,
         proxies: Optional[Any] = None,
+        bill_to: Optional[str] = None,
         # OpenAI compatibility
         base_url: Optional[str] = None,
         api_key: Optional[str] = None,
@@ -203,7 +208,18 @@ class InferenceClient:
 
         self.model: Optional[str] = base_url or model
         self.token: Optional[str] = token
-        self.headers = headers if headers is not None else {}
+
+        self.headers = {**headers} if headers is not None else {}
+        if bill_to is not None:
+            if (
+                constants.HUGGINGFACE_HEADER_X_BILL_TO in self.headers
+                and self.headers[constants.HUGGINGFACE_HEADER_X_BILL_TO] != bill_to
+            ):
+                warnings.warn(
+                    f"Overriding existing '{self.headers[constants.HUGGINGFACE_HEADER_X_BILL_TO]}' value in headers with '{bill_to}'.",
+                    UserWarning,
+                )
+            self.headers[constants.HUGGINGFACE_HEADER_X_BILL_TO] = bill_to
 
         # Configure provider
         self.provider = provider if provider is not None else "hf-inference"

--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -220,6 +220,13 @@ class InferenceClient:
                 )
             self.headers[constants.HUGGINGFACE_HEADER_X_BILL_TO] = bill_to
 
+            if token is not None and not token.startswith("hf_"):
+                warnings.warn(
+                    "You've provided an external provider's API key, so requests will be billed directly by the provider. "
+                    "The `bill_to` parameter is only applicable for Hugging Face billing and will be ignored.",
+                    UserWarning,
+                )
+
         # Configure provider
         self.provider = provider if provider is not None else "hf-inference"
 

--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -148,7 +148,7 @@ class InferenceClient:
             Values in this dictionary will override the default values.
         bill_to (`str`, `optional`):
             The billing account to use for the requests. By default the requests are billed on the user's account.
-            Requests can be billed to any organization the user is a member of as long as billing is enabled for that organization.
+            Requests can only be billed to an organization the user is a member of, and the billing should be enabled for that organization.
         cookies (`Dict[str, str]`, `optional`):
             Additional cookies to send to the server.
         proxies (`Any`, `optional`):

--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -148,7 +148,7 @@ class InferenceClient:
             Values in this dictionary will override the default values.
         bill_to (`str`, `optional`):
             The billing account to use for the requests. By default the requests are billed on the user's account.
-            Requests can only be billed to an organization the user is a member of, and billing should be enabled for that organization.
+            Requests can only be billed to an organization the user is a member of, and which has subscribed to Enterprise Hub.
         cookies (`Dict[str, str]`, `optional`):
             Additional cookies to send to the server.
         proxies (`Any`, `optional`):

--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -148,7 +148,7 @@ class InferenceClient:
             Values in this dictionary will override the default values.
         bill_to (`str`, `optional`):
             The billing account to use for the requests. By default the requests are billed on the user's account.
-            Requests can only be billed to an organization the user is a member of, and the billing should be enabled for that organization.
+            Requests can only be billed to an organization the user is a member of, and billing should be enabled for that organization.
         cookies (`Dict[str, str]`, `optional`):
             Additional cookies to send to the server.
         proxies (`Any`, `optional`):

--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -147,9 +147,8 @@ class InferenceClient:
             Additional headers to send to the server. By default only the authorization and user-agent headers are sent.
             Values in this dictionary will override the default values.
         bill_to (`str`, `optional`):
-            The billing account to use for the request. By default the request will be billed to the user's account.
-            Request can be billed to any organization the user is a member of (e.g. `bill_to="huggingface"`) as long as
-            billing is enabled for that organization.
+            The billing account to use for the requests. By default the requests are billed on the user's account.
+            Requests can be billed to any organization the user is a member of as long as billing is enabled for that organization.
         cookies (`Dict[str, str]`, `optional`):
             Additional cookies to send to the server.
         proxies (`Any`, `optional`):

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -136,7 +136,7 @@ class AsyncInferenceClient:
             Values in this dictionary will override the default values.
         bill_to (`str`, `optional`):
             The billing account to use for the requests. By default the requests are billed on the user's account.
-            Requests can only be billed to an organization the user is a member of, and billing should be enabled for that organization.
+            Requests can only be billed to an organization the user is a member of, and which has subscribed to Enterprise Hub.
         cookies (`Dict[str, str]`, `optional`):
             Additional cookies to send to the server.
         trust_env ('bool', 'optional'):

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -136,7 +136,7 @@ class AsyncInferenceClient:
             Values in this dictionary will override the default values.
         bill_to (`str`, `optional`):
             The billing account to use for the requests. By default the requests are billed on the user's account.
-            Requests can be billed to any organization the user is a member of as long as billing is enabled for that organization.
+            Requests can only be billed to an organization the user is a member of, and billing should be enabled for that organization.
         cookies (`Dict[str, str]`, `optional`):
             Additional cookies to send to the server.
         trust_env ('bool', 'optional'):

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -211,6 +211,13 @@ class AsyncInferenceClient:
                 )
             self.headers[constants.HUGGINGFACE_HEADER_X_BILL_TO] = bill_to
 
+            if token is not None and not token.startswith("hf_"):
+                warnings.warn(
+                    "You've provided an external provider's API key, so requests will be billed directly by the provider. "
+                    "The `bill_to` parameter is only applicable for Hugging Face billing and will be ignored.",
+                    UserWarning,
+                )
+
         # Configure provider
         self.provider = provider if provider is not None else "hf-inference"
 

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -135,9 +135,8 @@ class AsyncInferenceClient:
             Additional headers to send to the server. By default only the authorization and user-agent headers are sent.
             Values in this dictionary will override the default values.
         bill_to (`str`, `optional`):
-            The billing account to use for the request. By default the request will be billed to the user's account.
-            Request can be billed to any organization the user is a member of (e.g. `bill_to="huggingface"`) as long as
-            billing is enabled for that organization.
+            The billing account to use for the requests. By default the requests are billed on the user's account.
+            Requests can be billed to any organization the user is a member of as long as billing is enabled for that organization.
         cookies (`Dict[str, str]`, `optional`):
             Additional cookies to send to the server.
         trust_env ('bool', 'optional'):

--- a/tests/test_inference_client.py
+++ b/tests/test_inference_client.py
@@ -1071,3 +1071,23 @@ def test_cannot_pass_token_false():
     """
     with pytest.raises(ValueError):
         InferenceClient(token=False)
+
+
+class TestBillToOrganization:
+    def test_bill_to_added_to_new_headers(self):
+        client = InferenceClient(bill_to="huggingface_hub")
+        assert client.headers["X-HF-Bill-To"] == "huggingface_hub"
+
+    def test_bill_to_added_to_existing_headers(self):
+        headers = {"foo": "bar"}
+        client = InferenceClient(bill_to="huggingface_hub", headers=headers)
+        assert client.headers["X-HF-Bill-To"] == "huggingface_hub"
+        assert client.headers["foo"] == "bar"
+        assert headers == {"foo": "bar"}  # do not mutate the original headers
+
+    def test_warning_if_bill_to_already_set(self):
+        headers = {"X-HF-Bill-To": "huggingface"}
+        with pytest.warns(UserWarning, match="Overriding existing 'huggingface' value in headers with 'openai'."):
+            client = InferenceClient(bill_to="openai", headers=headers)
+        assert client.headers["X-HF-Bill-To"] == "openai"
+        assert headers == {"X-HF-Bill-To": "huggingface"}  # do not mutate the original headers

--- a/tests/test_inference_client.py
+++ b/tests/test_inference_client.py
@@ -1091,3 +1091,10 @@ class TestBillToOrganization:
             client = InferenceClient(bill_to="openai", headers=headers)
         assert client.headers["X-HF-Bill-To"] == "openai"
         assert headers == {"X-HF-Bill-To": "huggingface"}  # do not mutate the original headers
+
+    def test_warning_if_bill_to_with_direct_calls(self):
+        with pytest.warns(
+            UserWarning,
+            match="You've provided an external provider's API key, so requests will be billed directly by the provider.",
+        ):
+            InferenceClient(bill_to="openai", token="replicate_key", provider="replicate")


### PR DESCRIPTION
Related to https://github.com/huggingface/huggingface.js/pull/1297. Discussed in [DMs](https://huggingface.slack.com/archives/C07KX53FZTK/p1741882879007139) (private link)

Basically adds a parameter allowing a user to charge all their requests on their organization account instead of personal account.

PR to merge only once `"X-HF-Bill-To"` header is supported server side cc @SBrandeis 

```py
from huggingface_hub import InferenceClient
client = InferenceClient(provider="fal-ai", bill_to="openai")
image = client.text_to_image(
    "A majestic lion in a fantasy forest",
    model="black-forest-labs/FLUX.1-schnell",
)
image.save("lion.png")
```