### PR TITLE
[Inference Providers] Fix status and response URLs when polling text-to-video results with fal-ai

### DIFF
--- a/src/huggingface_hub/inference/_providers/fal_ai.py
+++ b/src/huggingface_hub/inference/_providers/fal_ai.py
@@ -124,7 +124,7 @@ class FalAITextToVideoTask(FalAITask):
 
         # extract the base url and query params
         parsed_url = urlparse(request_params.url)
-        # a bit hacky way to concatenate the provider name without parsing `parsed_url.path``
+        # a bit hacky way to concatenate the provider name without parsing `parsed_url.path`
         base_url = f"{parsed_url.scheme}://{parsed_url.netloc}{'/fal-ai' if parsed_url.netloc == 'router.huggingface.co' else ''}"
         query_param = f"?{parsed_url.query}" if parsed_url.query else ""
 

--- a/src/huggingface_hub/inference/_providers/fal_ai.py
+++ b/src/huggingface_hub/inference/_providers/fal_ai.py
@@ -129,10 +129,10 @@ class FalAITextToVideoTask(FalAITask):
         query_param = f"?{parsed_url.query}" if parsed_url.query else ""
 
         # extracting the provider model id for status and result urls
-        # from the response as it might be different from the mapped model
+        # from the response as it might be different from the mapped model in `request_params.url`
         model_id = urlparse(response_dict.get("response_url")).path
-        status_url = f"{base_url}{model_id}/status{query_param}"  # type: ignore
-        result_url = f"{base_url}{model_id}{query_param}"  # type: ignore
+        status_url = f"{base_url}{str(model_id)}/status{query_param}"
+        result_url = f"{base_url}{str(model_id)}{query_param}"
 
         status = response_dict.get("status")
         logger.info("Generating the video.. this can take several minutes.")

--- a/src/huggingface_hub/inference/_providers/fal_ai.py
+++ b/src/huggingface_hub/inference/_providers/fal_ai.py
@@ -2,6 +2,7 @@ import base64
 import time
 from abc import ABC
 from typing import Any, Dict, Optional, Union
+from urllib.parse import urlparse
 
 from huggingface_hub.inference._common import RequestParameters, _as_dict
 from huggingface_hub.inference._providers._common import TaskProviderHelper, filter_none
@@ -122,11 +123,16 @@ class FalAITextToVideoTask(FalAITask):
             )
 
         # extract the base url and query params
-        base_url = request_params.url.split("?")[0]  # or parsed.scheme + "://" + parsed.netloc + parsed.path ?
-        query = "?_subdomain=queue" if request_params.url.endswith("_subdomain=queue") else ""
+        parsed_url = urlparse(request_params.url)
+        # a bit hacky way to concatenate the provider name without parsing `parsed_url.path``
+        base_url = f"{parsed_url.scheme}://{parsed_url.netloc}{'/fal-ai' if parsed_url.netloc == 'router.huggingface.co' else ''}"
+        query_param = f"?{parsed_url.query}" if parsed_url.query else ""
 
-        status_url = f"{base_url}/requests/{request_id}/status{query}"
-        result_url = f"{base_url}/requests/{request_id}{query}"
+        # extracting the provider model id for status and result urls
+        # from the response as it might be different from the mapped model
+        model_id = urlparse(response_dict.get("response_url")).path
+        status_url = f"{base_url}{model_id}/status{query_param}"  # type: ignore
+        result_url = f"{base_url}{model_id}{query_param}"  # type: ignore
 
         status = response_dict.get("status")
         logger.info("Generating the video.. this can take several minutes.")

--- a/tests/test_inference_providers.py
+++ b/tests/test_inference_providers.py
@@ -310,18 +310,21 @@ class TestFalAIProvider:
             data=None,
             json=None,
         )
-        response = helper.get_response(b'{"request_id": "test_request_id", "status": "PROCESSING"}', request_params)
+        response = helper.get_response(
+            b'{"request_id": "test_request_id", "status": "PROCESSING", "response_url": "https://queue.fal.run/username_provider/repo_name_provider/requests/test_request_id", "status_url": "https://queue.fal.run/username_provider/repo_name_provider/requests/test_request_id/status"}',
+            request_params,
+        )
 
         # Verify the correct URLs were called
         assert mock_session.return_value.get.call_count == 3
         mock_session.return_value.get.assert_has_calls(
             [
                 mocker.call(
-                    "https://router.huggingface.co/fal-ai/username/repo_name/requests/test_request_id/status?_subdomain=queue",
+                    "https://router.huggingface.co/fal-ai/username_provider/repo_name_provider/requests/test_request_id/status?_subdomain=queue",
                     headers=request_params.headers,
                 ),
                 mocker.call(
-                    "https://router.huggingface.co/fal-ai/username/repo_name/requests/test_request_id?_subdomain=queue",
+                    "https://router.huggingface.co/fal-ai/username_provider/repo_name_provider/requests/test_request_id?_subdomain=queue",
                     headers=request_params.headers,
                 ),
                 mocker.call("video_url"),


### PR DESCRIPTION
This PR fixes an edge case where the provider model id used in the request is different from the one used to fetch the status and the result of a request. This is the case for https://huggingface.co/Wan-AI/Wan2.1-T2V-1.3B. 
The PR introduces a more robust way to construct the status and the result URLs. 
More context in this slack [message](https://huggingface.slack.com/archives/C0664PDFGSJ/p1741632564147909) (private link).

This should (will) be fixed as well in https://github.com/huggingface/huggingface.js/pull/1292.