### PR TITLE
Add expanduser and expandvars to path envvars

### DIFF
--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -128,22 +128,8 @@ default_cache_path = os.path.join(HF_HOME, "hub")
 default_assets_cache_path = os.path.join(HF_HOME, "assets")
 
 # Legacy env variables
-HUGGINGFACE_HUB_CACHE = os.path.expandvars(
-    os.path.expanduser(
-        os.getenv(
-            "HUGGINGFACE_HUB_CACHE",
-            default_cache_path,
-        )
-    )
-)
-HUGGINGFACE_ASSETS_CACHE = os.path.expandvars(
-    os.path.expanduser(
-        os.getenv(
-            "HUGGINGFACE_ASSETS_CACHE",
-            default_assets_cache_path,
-        )
-    )
-)
+HUGGINGFACE_HUB_CACHE = os.getenv("HUGGINGFACE_HUB_CACHE", default_cache_path)
+HUGGINGFACE_ASSETS_CACHE = os.getenv("HUGGINGFACE_ASSETS_CACHE", default_assets_cache_path)
 
 # New env variables
 HF_HUB_CACHE = os.path.expandvars(

--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -114,10 +114,12 @@ WEBHOOK_DOMAIN_T = Literal["repo", "discussions"]
 
 # default cache
 default_home = os.path.join(os.path.expanduser("~"), ".cache")
-HF_HOME = os.path.expanduser(
-    os.getenv(
-        "HF_HOME",
-        os.path.join(os.getenv("XDG_CACHE_HOME", default_home), "huggingface"),
+HF_HOME = os.path.expandvars(
+    os.path.expanduser(
+        os.getenv(
+            "HF_HOME",
+            os.path.join(os.getenv("XDG_CACHE_HOME", default_home), "huggingface"),
+        )
     )
 )
 hf_cache_home = HF_HOME  # for backward compatibility. TODO: remove this in 1.0.0
@@ -126,12 +128,40 @@ default_cache_path = os.path.join(HF_HOME, "hub")
 default_assets_cache_path = os.path.join(HF_HOME, "assets")
 
 # Legacy env variables
-HUGGINGFACE_HUB_CACHE = os.getenv("HUGGINGFACE_HUB_CACHE", default_cache_path)
-HUGGINGFACE_ASSETS_CACHE = os.getenv("HUGGINGFACE_ASSETS_CACHE", default_assets_cache_path)
+HUGGINGFACE_HUB_CACHE = os.path.expandvars(
+    os.path.expanduser(
+        os.getenv(
+            "HUGGINGFACE_HUB_CACHE",
+            default_cache_path,
+        )
+    )
+)
+HUGGINGFACE_ASSETS_CACHE = os.path.expandvars(
+    os.path.expanduser(
+        os.getenv(
+            "HUGGINGFACE_ASSETS_CACHE",
+            default_assets_cache_path,
+        )
+    )
+)
 
 # New env variables
-HF_HUB_CACHE = os.getenv("HF_HUB_CACHE", HUGGINGFACE_HUB_CACHE)
-HF_ASSETS_CACHE = os.getenv("HF_ASSETS_CACHE", HUGGINGFACE_ASSETS_CACHE)
+HF_HUB_CACHE = os.path.expandvars(
+    os.path.expanduser(
+        os.getenv(
+            "HF_HUB_CACHE",
+            HUGGINGFACE_HUB_CACHE,
+        )
+    )
+)
+HF_ASSETS_CACHE = os.path.expandvars(
+    os.path.expanduser(
+        os.getenv(
+            "HF_ASSETS_CACHE",
+            HUGGINGFACE_ASSETS_CACHE,
+        )
+    )
+)
 
 HF_HUB_OFFLINE = _is_true(os.environ.get("HF_HUB_OFFLINE") or os.environ.get("TRANSFORMERS_OFFLINE"))
 
@@ -146,7 +176,14 @@ HF_HUB_DISABLE_TELEMETRY = (
     or _is_true(os.environ.get("DO_NOT_TRACK"))  # https://consoledonottrack.com/
 )
 
-HF_TOKEN_PATH = os.environ.get("HF_TOKEN_PATH", os.path.join(HF_HOME, "token"))
+HF_TOKEN_PATH = os.path.expandvars(
+    os.path.expanduser(
+        os.getenv(
+            "HF_TOKEN_PATH",
+            os.path.join(HF_HOME, "token"),
+        )
+    )
+)
 HF_STORED_TOKENS_PATH = os.path.join(os.path.dirname(HF_TOKEN_PATH), "stored_tokens")
 
 if _staging_mode:


### PR DESCRIPTION
This pull request includes changes to the `src/huggingface_hub/constants.py` file to improve environment variable handling by expanding user variables and environment variables. The most important changes include modifications to the way paths are set for various cache and token-related environment variables.

Improvements to environment variable handling:

* [`HF_HOME`](diffhunk://#diff-b9ea02465324089a58bcb914a78b6c50143dfa0aadf772cef27478581f1346bcL117-R164): Changed to use `os.path.expandvars` and `os.path.expanduser` to ensure environment variables and user home directory are properly expanded.
* `HUGGINGFACE_HUB_CACHE` and `HUGGINGFACE_ASSETS_CACHE`: Updated to use `os.path.expandvars` and `os.path.expanduser` for better handling of environment variables and user paths.
* `HF_HUB_CACHE` and `HF_ASSETS_CACHE`: Modified to use `os.path.expandvars` and `os.path.expanduser` to ensure correct path expansion.
* [`HF_TOKEN_PATH`](diffhunk://#diff-b9ea02465324089a58bcb914a78b6c50143dfa0aadf772cef27478581f1346bcL149-R186): Adjusted to use `os.path.expandvars` and `os.path.expanduser` for consistent handling of environment variables and user paths.