### PR TITLE
Extracting the refresh route from the link header

### DIFF
--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -245,6 +245,7 @@ HUGGINGFACE_HEADER_X_XET_ACCESS_TOKEN = "X-Xet-Access-Token"
 HUGGINGFACE_HEADER_X_XET_EXPIRATION = "X-Xet-Token-Expiration"
 HUGGINGFACE_HEADER_X_XET_HASH = "X-Xet-Hash"
 HUGGINGFACE_HEADER_X_XET_REFRESH_ROUTE = "X-Xet-Refresh-Route"
+HUGGINGFACE_HEADER_LINK_XET_AUTH_KEY = "xet-auth"
 
 default_xet_cache_path = os.path.join(HF_HOME, "xet")
 HF_XET_CACHE = os.getenv("HF_XET_CACHE", default_xet_cache_path)

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -56,7 +56,7 @@ from .utils import (
     is_tf_available,  # noqa: F401 # for backward compatibility
     is_torch_available,  # noqa: F401 # for backward compatibility
     logging,
-    parse_xet_file_data_from_headers,
+    parse_xet_file_data_from_headers_and_links,
     refresh_xet_connection_info,
     reset_sessions,
     tqdm,
@@ -1422,7 +1422,7 @@ def get_hf_file_metadata(
         size=_int_or_none(
             r.headers.get(constants.HUGGINGFACE_HEADER_X_LINKED_SIZE) or r.headers.get("Content-Length")
         ),
-        xet_file_data=parse_xet_file_data_from_headers(r.headers),  # type: ignore
+        xet_file_data=parse_xet_file_data_from_headers_and_links(r.headers, r.links),  # type: ignore
     )
 
 

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -56,7 +56,7 @@ from .utils import (
     is_tf_available,  # noqa: F401 # for backward compatibility
     is_torch_available,  # noqa: F401 # for backward compatibility
     logging,
-    parse_xet_file_data_from_headers_and_links,
+    parse_xet_file_data_from_response,
     refresh_xet_connection_info,
     reset_sessions,
     tqdm,
@@ -1422,7 +1422,7 @@ def get_hf_file_metadata(
         size=_int_or_none(
             r.headers.get(constants.HUGGINGFACE_HEADER_X_LINKED_SIZE) or r.headers.get("Content-Length")
         ),
-        xet_file_data=parse_xet_file_data_from_headers_and_links(r.headers, r.links),  # type: ignore
+        xet_file_data=parse_xet_file_data_from_response(r),  # type: ignore
     )
 
 

--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -112,7 +112,7 @@ from ._xet import (
     XetFileData,
     XetTokenType,
     fetch_xet_connection_info_from_repo_info,
-    parse_xet_file_data_from_headers_and_links,
+    parse_xet_file_data_from_response,
     refresh_xet_connection_info,
 )
 from .tqdm import are_progress_bars_disabled, disable_progress_bars, enable_progress_bars, tqdm, tqdm_stream_file

--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -112,7 +112,7 @@ from ._xet import (
     XetFileData,
     XetTokenType,
     fetch_xet_connection_info_from_repo_info,
-    parse_xet_file_data_from_headers,
+    parse_xet_file_data_from_headers_and_links,
     refresh_xet_connection_info,
 )
 from .tqdm import are_progress_bars_disabled, disable_progress_bars, enable_progress_bars, tqdm, tqdm_stream_file

--- a/src/huggingface_hub/utils/_xet.py
+++ b/src/huggingface_hub/utils/_xet.py
@@ -24,12 +24,16 @@ class XetConnectionInfo:
     endpoint: str
 
 
-def parse_xet_file_data_from_headers(headers: Dict[str, str]) -> Optional[XetFileData]:
+def parse_xet_file_data_from_headers_and_links(
+    headers: Dict[str, str], links: Dict[str, Dict[str, str]]
+) -> Optional[XetFileData]:
     """
     Parse XET file info from the HTTP headers or return None if not found.
     Args:
         headers (`Dict`):
            HTTP headers to extract the XET metadata from.
+        links (`Dict`):
+           HTTP reponse links parameter to extract the XET metadata from.
     Returns:
         `XetFileData` or `None`:
             The metadata needed for a file download.
@@ -37,7 +41,11 @@ def parse_xet_file_data_from_headers(headers: Dict[str, str]) -> Optional[XetFil
     """
     try:
         file_hash = headers[constants.HUGGINGFACE_HEADER_X_XET_HASH]
-        refresh_route = headers[constants.HUGGINGFACE_HEADER_X_XET_REFRESH_ROUTE]
+
+        if constants.HUGGINGFACE_HEADER_LINK_XET_AUTH_KEY in links:
+            refresh_route = links[constants.HUGGINGFACE_HEADER_LINK_XET_AUTH_KEY]["url"]
+        else:
+            refresh_route = headers[constants.HUGGINGFACE_HEADER_X_XET_REFRESH_ROUTE]
     except KeyError:
         return None
 

--- a/src/huggingface_hub/utils/_xet.py
+++ b/src/huggingface_hub/utils/_xet.py
@@ -37,7 +37,7 @@ def parse_xet_file_data_from_response(response: requests.Response) -> Optional[X
         response (`requests.Response`):
             The HTTP response object containing headers dict and links dict to extract the XET metadata from.
     Returns:
-        `Optional[XetFileData]` or None:
+        `Optional[XetFileData]`:
             An instance of `XetFileData` containing the file hash and refresh route if the metadata
             is found. Returns `None` if the required metadata is missing.
     """

--- a/src/huggingface_hub/utils/_xet.py
+++ b/src/huggingface_hub/utils/_xet.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Dict, Optional
 
+import requests
+
 from .. import constants
 from . import get_session, hf_raise_for_status, validate_hf_hub_args
 
@@ -24,28 +26,30 @@ class XetConnectionInfo:
     endpoint: str
 
 
-def parse_xet_file_data_from_headers_and_links(
-    headers: Dict[str, str], links: Dict[str, Dict[str, str]]
-) -> Optional[XetFileData]:
+def parse_xet_file_data_from_response(response: requests.Response) -> Optional[XetFileData]:
     """
-    Parse XET file info from the HTTP headers or return None if not found.
-    Args:
-        headers (`Dict`):
-           HTTP headers to extract the XET metadata from.
-        links (`Dict`):
-           HTTP reponse links parameter to extract the XET metadata from.
-    Returns:
-        `XetFileData` or `None`:
-            The metadata needed for a file download.
-            Returns `None` if the headers do not contain the xet file metadata.
-    """
-    try:
-        file_hash = headers[constants.HUGGINGFACE_HEADER_X_XET_HASH]
+    Parse XET file metadata from an HTTP response.
 
-        if constants.HUGGINGFACE_HEADER_LINK_XET_AUTH_KEY in links:
-            refresh_route = links[constants.HUGGINGFACE_HEADER_LINK_XET_AUTH_KEY]["url"]
+    This function extracts XET file metadata from the HTTP headers or HTTP links
+    of a given response object. If the required metadata is not found, it returns `None`.
+
+    Args:
+        response (`requests.Response`):
+            The HTTP response object containing headers dict and links dict to extract the XET metadata from.
+    Returns:
+        `Optional[XetFileData]` or None:
+            An instance of `XetFileData` containing the file hash and refresh route if the metadata
+            is found. Returns `None` if the required metadata is missing.
+    """
+    if response is None:
+        return None
+    try:
+        file_hash = response.headers[constants.HUGGINGFACE_HEADER_X_XET_HASH]
+
+        if constants.HUGGINGFACE_HEADER_LINK_XET_AUTH_KEY in response.links:
+            refresh_route = response.links[constants.HUGGINGFACE_HEADER_LINK_XET_AUTH_KEY]["url"]
         else:
-            refresh_route = headers[constants.HUGGINGFACE_HEADER_X_XET_REFRESH_ROUTE]
+            refresh_route = response.headers[constants.HUGGINGFACE_HEADER_X_XET_REFRESH_ROUTE]
     except KeyError:
         return None
 

--- a/tests/test_xet_utils.py
+++ b/tests/test_xet_utils.py
@@ -7,7 +7,7 @@ from huggingface_hub.utils._xet import (
     XetFileData,
     _fetch_xet_connection_info_with_url,
     parse_xet_connection_info_from_headers,
-    parse_xet_file_data_from_headers,
+    parse_xet_file_data_from_headers_and_links,
     refresh_xet_connection_info,
 )
 
@@ -17,8 +17,24 @@ def test_parse_valid_headers_file_info() -> None:
         "X-Xet-Hash": "sha256:abcdef",
         "X-Xet-Refresh-Route": "/api/refresh",
     }
+    links = {}
 
-    file_data = parse_xet_file_data_from_headers(headers)
+    file_data = parse_xet_file_data_from_headers_and_links(headers, links)
+
+    assert file_data is not None
+    assert file_data.refresh_route == "/api/refresh"
+    assert file_data.file_hash == "sha256:abcdef"
+
+
+def test_parse_valid_headers_file_info_with_link() -> None:
+    headers = {
+        "X-Xet-Hash": "sha256:abcdef",
+    }
+    links = {
+        "xet-auth": {"url": "/api/refresh"},
+    }
+
+    file_data = parse_xet_file_data_from_headers_and_links(headers, links)
 
     assert file_data is not None
     assert file_data.refresh_route == "/api/refresh"
@@ -26,7 +42,7 @@ def test_parse_valid_headers_file_info() -> None:
 
 
 def test_parse_invalid_headers_file_info() -> None:
-    assert parse_xet_file_data_from_headers({"X-foo": "bar"}) is None
+    assert parse_xet_file_data_from_headers_and_links({"X-foo": "bar"}, {}) is None
 
 
 def test_parse_valid_headers_connection_info() -> None:
@@ -53,7 +69,7 @@ def test_parse_valid_headers_full() -> None:
         "X-Xet-Hash": "sha256:abcdef",
     }
 
-    file_metadata = parse_xet_file_data_from_headers(headers)
+    file_metadata = parse_xet_file_data_from_headers_and_links(headers, {})
     connection_info = parse_xet_connection_info_from_headers(headers)
 
     assert file_metadata is not None

--- a/tests/test_xet_utils.py
+++ b/tests/test_xet_utils.py
@@ -7,19 +7,20 @@ from huggingface_hub.utils._xet import (
     XetFileData,
     _fetch_xet_connection_info_with_url,
     parse_xet_connection_info_from_headers,
-    parse_xet_file_data_from_headers_and_links,
+    parse_xet_file_data_from_response,
     refresh_xet_connection_info,
 )
 
 
 def test_parse_valid_headers_file_info() -> None:
-    headers = {
+    mock_response = MagicMock()
+    mock_response.headers = {
         "X-Xet-Hash": "sha256:abcdef",
         "X-Xet-Refresh-Route": "/api/refresh",
     }
-    links = {}
+    mock_response.links = {}
 
-    file_data = parse_xet_file_data_from_headers_and_links(headers, links)
+    file_data = parse_xet_file_data_from_response(mock_response)
 
     assert file_data is not None
     assert file_data.refresh_route == "/api/refresh"
@@ -27,14 +28,15 @@ def test_parse_valid_headers_file_info() -> None:
 
 
 def test_parse_valid_headers_file_info_with_link() -> None:
-    headers = {
+    mock_response = MagicMock()
+    mock_response.headers = {
         "X-Xet-Hash": "sha256:abcdef",
     }
-    links = {
+    mock_response.links = {
         "xet-auth": {"url": "/api/refresh"},
     }
 
-    file_data = parse_xet_file_data_from_headers_and_links(headers, links)
+    file_data = parse_xet_file_data_from_response(mock_response)
 
     assert file_data is not None
     assert file_data.refresh_route == "/api/refresh"
@@ -42,7 +44,10 @@ def test_parse_valid_headers_file_info_with_link() -> None:
 
 
 def test_parse_invalid_headers_file_info() -> None:
-    assert parse_xet_file_data_from_headers_and_links({"X-foo": "bar"}, {}) is None
+    mock_response = MagicMock()
+    mock_response.headers = {"X-foo": "bar"}
+    mock_response.links = {}
+    assert parse_xet_file_data_from_response(mock_response) is None
 
 
 def test_parse_valid_headers_connection_info() -> None:
@@ -61,16 +66,18 @@ def test_parse_valid_headers_connection_info() -> None:
 
 
 def test_parse_valid_headers_full() -> None:
-    headers = {
+    mock_response = MagicMock()
+    mock_response.headers = {
         "X-Xet-Cas-Url": "https://xet.example.com",
         "X-Xet-Access-Token": "xet_token_abc",
         "X-Xet-Token-Expiration": "1234567890",
         "X-Xet-Refresh-Route": "/api/refresh",
         "X-Xet-Hash": "sha256:abcdef",
     }
+    mock_response.links = {}
 
-    file_metadata = parse_xet_file_data_from_headers_and_links(headers, {})
-    connection_info = parse_xet_connection_info_from_headers(headers)
+    file_metadata = parse_xet_file_data_from_response(mock_response)
+    connection_info = parse_xet_connection_info_from_headers(mock_response.headers)
 
     assert file_metadata is not None
     assert file_metadata.refresh_route == "/api/refresh"


### PR DESCRIPTION
Based on [the discussion here](https://github.com/huggingface/huggingface_hub/pull/2920#issuecomment-2749373899), we are using the link header to extract the xet refresh route from the response headers.