### PR TITLE
Add prompt in image_to_image type

### DIFF
--- a/src/huggingface_hub/inference/_generated/types/image_to_image.py
+++ b/src/huggingface_hub/inference/_generated/types/image_to_image.py
@@ -30,6 +30,8 @@ class ImageToImageParameters(BaseInferenceType):
     """For diffusion models. The number of denoising steps. More denoising steps usually lead to
     a higher quality image at the expense of slower inference.
     """
+    prompt: Optional[str] = None
+    """The text prompt to guide the image generation."""
     target_size: Optional[ImageToImageTargetSize] = None
     """The size in pixel of the output image."""
 

--- a/utils/check_task_parameters.py
+++ b/utils/check_task_parameters.py
@@ -546,6 +546,9 @@ def _check_parameters(
     updates = {}
     # Check for new and updated parameters
     for param_name, param_info in dataclass_params.items():
+        if param_name in CORE_PARAMETERS:
+            continue
+
         if param_name not in existing_params:
             # New parameter
             updates[param_name] = {**param_info, "status": "new"}
@@ -761,7 +764,7 @@ def _check_and_update_parameters(
             "❌ Mismatch between between parameters defined in tasks methods signature in "
             "`./src/huggingface_hub/inference/_client.py` and parameters defined in "
             "`./src/huggingface_hub/inference/_generated/types.py \n"
-            "Please run `make inference_update` or `python utils/generate_task_parameters.py --update"
+            "Please run `make inference_update` or `python utils/check_task_parameters.py --update"
         )
         exit(1)
     else:


### PR DESCRIPTION
Related to https://github.com/huggingface/huggingface_hub/pull/2933/files.

@hanouticelina I had to edit the `utils/check_task_parameters.py` script. In `_check_parameters` we run both the `DataclassFieldCollector` and the `MethodArgumentsCollector`. However in `MethodArgumentsCollector`, we filter out parameters that are considered `CORE_PARAMETERS`. Since `prompt` is one of them in `image_to_image`, it was discarded and therefore considered as a "new" parameter in `_check_parameters` (and therefore updating the docstring). Running multiple times the script in a row was adding the argument in the docstring over and over again. I've pushed what I think is a fix for that (at least it doesn't complain and it fixed the bug^^) but could you have a closer look to it?