### PR TITLE
[Internal] Fix check parameters script

### DIFF
--- a/utils/check_task_parameters.py
+++ b/utils/check_task_parameters.py
@@ -374,6 +374,7 @@ class UpdateParameters(cst.CSTTransformer):
             # When params_updated is still not empty, it means there are new parameters that are not in the docstring
             # but are in the method signature
             new_params = {**new_params, **params_updated}
+        # Add new parameters to the docstring
         if new_params:
             docstring_lines = self._add_new_params(docstring_lines, new_params, args_index, param_indent, desc_indent)
         # Join the docstring lines back into a single string


### PR DESCRIPTION
This PR addresses the issue highlighted by @Wauplin in #2956 where core parameters defined in the task dataclass were incorrectly flagged as "missing" in method docstrings. The problem occurred because we weren't filtering out core parameters from the task dataclass params. This fix ensures core parameters are properly filtered from the dataclass parameters as well (copy pasted from #2956) and fixes an unrelated issue when a parameter is only missing in the docstring and not in the method's signature.

There is some possible improvement that can be done to the script but this is not necessary (everything should be working fine now 🤞) and not prio for now, I will come back to this when I have some spare time!