### PR TITLE
Handle Rate Limits in Pagination with Automatic Retries

### DIFF
--- a/src/huggingface_hub/utils/_pagination.py
+++ b/src/huggingface_hub/utils/_pagination.py
@@ -18,7 +18,7 @@ from typing import Dict, Iterable, Optional
 
 import requests
 
-from . import get_session, hf_raise_for_status, logging
+from . import get_session, hf_raise_for_status, http_backoff, logging
 
 
 logger = logging.get_logger(__name__)

--- a/src/huggingface_hub/utils/_pagination.py
+++ b/src/huggingface_hub/utils/_pagination.py
@@ -42,7 +42,7 @@ def paginate(path: str, params: Dict, headers: Dict) -> Iterable:
     next_page = _get_next_page(r)
     while next_page is not None:
         logger.debug(f"Pagination detected. Requesting next page: {next_page}")
-        r = session.get(next_page, headers=headers)
+        r = http_backoff("GET", next_page, max_retries=20, retry_on_status_codes=429, headers=headers)
         hf_raise_for_status(r)
         yield from r.json()
         next_page = _get_next_page(r)

--- a/tests/test_utils_pagination.py
+++ b/tests/test_utils_pagination.py
@@ -8,9 +8,12 @@ from .testing_utils import handle_injection_in_test
 
 class TestPagination(unittest.TestCase):
     @patch("huggingface_hub.utils._pagination.get_session")
+    @patch("huggingface_hub.utils._pagination.http_backoff")
     @patch("huggingface_hub.utils._pagination.hf_raise_for_status")
     @handle_injection_in_test
-    def test_mocked_paginate(self, mock_get_session: Mock, mock_hf_raise_for_status: Mock) -> None:
+    def test_mocked_paginate(
+        self, mock_get_session: Mock, mock_http_backoff: Mock, mock_hf_raise_for_status: Mock
+    ) -> None:
         mock_get = mock_get_session().get
         mock_params = Mock()
         mock_headers = Mock()
@@ -33,6 +36,8 @@ class TestPagination(unittest.TestCase):
         # Mock response
         mock_get.side_effect = [
             mock_response_page_1,
+        ]
+        mock_http_backoff.side_effect = [
             mock_response_page_2,
             mock_response_page_3,
         ]
@@ -40,24 +45,23 @@ class TestPagination(unittest.TestCase):
         results = paginate("url", params=mock_params, headers=mock_headers)
 
         # Requests are made only when generator is yielded
-        self.assertEqual(mock_get.call_count, 0)
+        assert mock_get.call_count == 0
 
         # Results after concatenating pages
-        self.assertListEqual(list(results), [1, 2, 3, 4, 5, 6, 7, 8])
+        assert list(results) == [1, 2, 3, 4, 5, 6, 7, 8]
 
         # All pages requested: 3 requests, 3 raise for status
-        self.assertEqual(mock_get.call_count, 3)
-        self.assertEqual(mock_hf_raise_for_status.call_count, 3)
+        # First request with `get_session.get` (we want at least 1 request to succeed correctly) and 2 with `http_backoff`
+        assert mock_get.call_count == 1
+        assert mock_http_backoff.call_count == 2
+        assert mock_hf_raise_for_status.call_count == 3
 
         # Params not passed to next pages
-        self.assertListEqual(
-            mock_get.call_args_list,
-            [
-                call("url", params=mock_params, headers=mock_headers),
-                call("url_p2", headers=mock_headers),
-                call("url_p3", headers=mock_headers),
-            ],
-        )
+        assert mock_get.call_args_list == [call("url", params=mock_params, headers=mock_headers)]
+        assert mock_http_backoff.call_args_list == [
+            call("GET", "url_p2", max_retries=20, retry_on_status_codes=429, headers=mock_headers),
+            call("GET", "url_p3", max_retries=20, retry_on_status_codes=429, headers=mock_headers),
+        ]
 
     def test_paginate_github_api(self) -> None:
         # Real test: paginate over huggingface repos on Github


### PR DESCRIPTION
This PR enhances the `paginate` function in `src/huggingface_hub/utils/_pagination.py/_pagination.py` by implementing automatic retries using the `http_backoff` function. Previously, when attempting to list all models via `api.list_models()`, the process would fail due to rate limiting (HTTP 429) after approximately 500K models (this number depends on many factors). This led to data loss and required restarting the process from the beginning. Additionally, after restarting, the process would hit the rate limit again after another 500K models, making it impossible to scrape all models in a single run.  

#### **Changes & Improvements:**  
- **Replaced `session.get` with `http_backoff`** to enable automatic retries.  
- **Configured `max_retries=20` and `retry_on_status_codes=429`** to handle API rate limits gracefully.  
- **Generalized solution** so that all API calls using `paginate` benefit from improved stability (though this rate limiting is most likely to occur only when listing >1.5M models).  

#### **Why This Change?**  
- **Prevents failures & data loss** when paginating through large queries.  
- **Ensures uninterrupted API calls** by retrying when rate limits are hit.  
- **Enhances pagination reliability** for all functions using `paginate`, not just model listing.  

This PR was initially planned to implement retry logic directly within `_pagination.py` instead of using the `http_backoff` function. However, thanks to @Wauplin's great guidance in pointing out that `http_backoff` already exists and is highly stable, this approach is now much better! 🙂  

Thanks, @Wauplin! 🚀

----

Below screenshot shows the behavior before this PR. As seen in the screenshot, an exception was thrown when the rate limit was hit, and restarting the process would only result in the same issue occurring again. As stated earlier, this made it impossible to access the remaining models in a simple way. 🙂

![image](https://github.com/user-attachments/assets/eeb75893-deba-4d12-8177-460afd5f07a5)


