### PR TITLE
Unlist TPUs from SpaceHardware

### DIFF
--- a/src/huggingface_hub/_space_api.py
+++ b/src/huggingface_hub/_space_api.py
@@ -81,11 +81,6 @@ class SpaceHardware(str, Enum):
     H100 = "h100"
     H100X8 = "h100x8"
 
-    # TPU
-    V5E_1X1 = "v5e-1x1"
-    V5E_2X2 = "v5e-2x2"
-    V5E_2X4 = "v5e-2x4"
-
 
 class SpaceStorage(str, Enum):
     """


### PR DESCRIPTION
cc @XciD @julien-c 

It's a breaking change since we are modifying the enum but I don't expect any usage of it.
And users are still able to pass a string instead of using the enum if they really want to set a TPU (and if Spaces allows it)