### PR TITLE
Retry on transient error in download workflow

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -44,7 +44,6 @@ from .utils import (
     get_graphviz_version,  # noqa: F401 # for backward compatibility
     get_jinja_version,  # noqa: F401 # for backward compatibility
     get_pydot_version,  # noqa: F401 # for backward compatibility
-    get_session,
     get_tf_version,  # noqa: F401 # for backward compatibility
     get_torch_version,  # noqa: F401 # for backward compatibility
     hf_raise_for_status,
@@ -62,7 +61,7 @@ from .utils import (
     tqdm,
     validate_hf_hub_args,
 )
-from .utils._http import _adjust_range_header
+from .utils._http import _adjust_range_header, http_backoff
 from .utils._runtime import _PY_VERSION, is_xet_available  # noqa: F401 # for backward compatibility
 from .utils._typing import HTTP_METHOD_T
 from .utils.sha import sha_fileobj
@@ -268,6 +267,8 @@ def _request_wrapper(
     """Wrapper around requests methods to follow relative redirects if `follow_relative_redirects=True` even when
     `allow_redirection=False`.
 
+    A backoff mechanism retries the HTTP call on 429, 503 and 504 errors.
+
     Args:
         method (`str`):
             HTTP method, such as 'GET' or 'HEAD'.
@@ -305,7 +306,9 @@ def _request_wrapper(
         return response
 
     # Perform request and return if status_code is not in the retry list.
-    response = get_session().request(method=method, url=url, **params)
+    response = http_backoff(
+        method=method, url=url, **params, retry_on_exceptions=(), retry_on_status_codes=(429, 503, 504)
+    )
     hf_raise_for_status(response)
     return response
 

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -306,9 +306,7 @@ def _request_wrapper(
         return response
 
     # Perform request and return if status_code is not in the retry list.
-    response = http_backoff(
-        method=method, url=url, **params, retry_on_exceptions=(), retry_on_status_codes=(429, 503, 504)
-    )
+    response = http_backoff(method=method, url=url, **params, retry_on_exceptions=(), retry_on_status_codes=(429,))
     hf_raise_for_status(response)
     return response
 

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -189,16 +189,14 @@ def offline(mode=OfflineSimulationMode.CONNECTION_FAILS, timeout=1e-16):
         # inspired from https://stackoverflow.com/a/18601897
         with patch("socket.socket", offline_socket):
             with patch("huggingface_hub.utils._http.get_session") as get_session_mock:
-                with patch("huggingface_hub.file_download.get_session") as get_session_mock:
-                    get_session_mock.return_value = requests.Session()  # not an existing one
-                    yield
+                get_session_mock.return_value = requests.Session()  # not an existing one
+                yield
     elif mode is OfflineSimulationMode.CONNECTION_TIMES_OUT:
         # inspired from https://stackoverflow.com/a/904609
         with patch("requests.request", timeout_request):
             with patch("huggingface_hub.utils._http.get_session") as get_session_mock:
-                with patch("huggingface_hub.file_download.get_session") as get_session_mock:
-                    get_session_mock().request = timeout_request
-                    yield
+                get_session_mock().request = timeout_request
+                yield
     elif mode is OfflineSimulationMode.HF_HUB_OFFLINE_SET_TO_1:
         with patch("huggingface_hub.constants.HF_HUB_OFFLINE", True):
             reset_sessions()


### PR DESCRIPTION
_Originally from @Wauplin on [Slack](https://huggingface.slack.com/archives/C07EPSS7ELX/p1743675730107059?thread_ts=1743584493.306359&cid=C07EPSS7ELX) (internal link):_
>> I'm guessing huggingface_hub doesn't have retry for 429. Should be a good thing to add?
> 
> _Well, I have no idea why we haven't spotted that before_ 🫠
> _http_get relies on `_request_wrapper` which itself has been refactored in Oct. 2023 (!!) by ... hmm... myself. I wrote in comments Perform request and return if status_code is not in the retry list. . But the implementation is a simple `response = get_session().request(method=method, url=url, **params)` without any retry mechanism :see_no_evil:   See https://github.com/huggingface/huggingface_hub/pull/1766._

So basically this PR adds a retry mechanism when downloading a file (GET /resolve) or when fetching metadata for a file (HEAD /resolve) if rate limit is reached. Retry after 1s, 2s, 4s, 8s and 8s.

---

**Comments:** 
- I'm not 100% sure about that PR. Opening it for discussion but I feel that I'm missing something - I was pretty sure until now that we had already a retry mechanism in place for 429... 
- After some checks, I remembered that `HfFileSystem` uses `http_backoff` with retries on 5xx errors but not 429 :thinking: 

@julien-c @LysandreJik @hanouticelina any obvious drawback that I missed from retrying on 429 for now?

**EDIT:** actually HTTP 429 are rare in downloads, that's why we never had one. Problem arose today because of Xet bridge that rate-limited @Vaibhavs10 