### PR TITLE
Prepare for 0.31.0

### DIFF
--- a/docs/source/de/guides/inference.md
+++ b/docs/source/de/guides/inference.md
@@ -125,18 +125,6 @@ Schauen Sie sich die [Aufgaben](https://huggingface.co/tasks)-Seite an, um mehr 
 
 </Tip>
 
-## Benutzerdefinierte Anfragen
-
-Es ist jedoch nicht immer möglich, alle Anwendungsfälle abzudecken. Für benutzerdefinierte Anfragen bietet die [`InferenceClient.post`] Methode Ihnen die Flexibilität, jede Anfrage an die Inferenz API zu senden. Zum Beispiel können Sie angeben, wie die Eingaben und Ausgaben geparst werden sollen. Im folgenden Beispiel wird das generierte Bild als Roh-Bytes zurückgegeben, anstatt es als `PIL Image` zu parsen. Dies kann hilfreich sein, wenn Sie `Pillow` in Ihrer Einrichtung nicht installiert haben und Ihnen nur die Binärinhalt des Bildes wichtig ist. [`InferenceClient.post`] ist auch nützlich, um Aufgaben zu behandeln, die noch nicht offiziell unterstützt werden.
-
-```python
->>> from huggingface_hub import InferenceClient
->>> client = InferenceClient()
->>> response = client.post(json={"inputs": "An astronaut riding a horse on the moon."}, model="stabilityai/stable-diffusion-2-1")
->>> response.content # raw bytes
-b'...'
-```
-
 ## Asynchroner Client
 
 Eine asynchrone Version des Clients wird ebenfalls bereitgestellt, basierend auf `asyncio` und `aiohttp`. Sie können entweder `aiohttp` direkt installieren oder das `[inference]` Extra verwenden:

--- a/docs/source/ko/guides/inference.md
+++ b/docs/source/ko/guides/inference.md
@@ -125,17 +125,7 @@ Hugging Face Hub에는 20만 개가 넘는 모델이 있습니다! [`InferenceCl
 
 </Tip>
 
-## 사용자 정의 요청[[custom-requests]]
 
-그러나 모든 경우를 항상 완벽하게 다루는 것은 어렵습니다. 사용자 정의 요청의 경우, [`InferenceClient.post`] 메소드를 사용하여 Inference API로 요청을 보낼 수 있습니다. 예를 들어, 입력 및 출력을 어떻게 파싱할지 지정할 수 있습니다. 아래 예시에서 생성된 이미지는 `PIL Image`로 파싱하는 대신 원본 바이트로 반환됩니다. 이는 설치된 `Pillow`가 없고 이미지의 이진 콘텐츠에만 관심이 있는 경우에 유용합니다. [`InferenceClient.post`]는 아직 공식적으로 지원되지 않는 작업을 처리하는 데도 유용합니다.
-
-```python
->>> from huggingface_hub import InferenceClient
->>> client = InferenceClient()
->>> response = client.post(json={"inputs": "An astronaut riding a horse on the moon."}, model="stabilityai/stable-diffusion-2-1")
->>> response.content # 원시 바이트
-b'...'
-```
 
 ## 비동기 클라이언트[[async-client]]
 
@@ -258,16 +248,6 @@ pip install --upgrade huggingface_hub[inference]
 [{'sequence': 'the goal of life is life.', 'score': 0.10933292657136917, 'token': 2166, 'token_str': 'life'}]
 ```
 
-변경 후:
-
-```python
->>> from huggingface_hub import InferenceClient
->>> client = InferenceClient()
->>> response = client.post(json={"inputs": "The goal of life is [MASK]."}, model="bert-base-uncased")
->>> response.json()
-[{'sequence': 'the goal of life is life.', 'score': 0.10933292657136917, 'token': 2166, 'token_str': 'life'}]
-```
-
 ### 매개변수와 함께 실행하기[[run-with-parameters]]
 
 변경 전:
@@ -278,17 +258,5 @@ pip install --upgrade huggingface_hub[inference]
 >>> inputs = "Hi, I recently bought a device from your company but it is not working as advertised and I would like to get reimbursed!"
 >>> params = {"candidate_labels":["refund", "legal", "faq"]}
 >>> inference(inputs, params)
-{'sequence': 'Hi, I recently bought a device from your company but it is not working as advertised and I would like to get reimbursed!', 'labels': ['refund', 'faq', 'legal'], 'scores': [0.9378499388694763, 0.04914155602455139, 0.013008488342165947]}
-```
-
-변경 후:
-
-```python
->>> from huggingface_hub import InferenceClient
->>> client = InferenceClient()
->>> inputs = "Hi, I recently bought a device from your company but it is not working as advertised and I would like to get reimbursed!"
->>> params = {"candidate_labels":["refund", "legal", "faq"]}
->>> response = client.post(json={"inputs": inputs, "parameters": params}, model="typeform/distilbert-base-uncased-mnli")
->>> response.json()
 {'sequence': 'Hi, I recently bought a device from your company but it is not working as advertised and I would like to get reimbursed!', 'labels': ['refund', 'faq', 'legal'], 'scores': [0.9378499388694763, 0.04914155602455139, 0.013008488342165947]}
 ```

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -46,7 +46,7 @@ import sys
 from typing import TYPE_CHECKING
 
 
-__version__ = "0.30.0.dev0"
+__version__ = "0.31.0.dev0"
 
 # Alphabetical order of definitions is ensured in tests
 # WARNING: any comment added in this dictionary definition will be lost when

--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -100,7 +100,7 @@ from huggingface_hub.inference._generated.types import (
     ZeroShotClassificationOutputElement,
     ZeroShotImageClassificationOutputElement,
 )
-from huggingface_hub.inference._providers import PROVIDER_T, HFInferenceTask, get_provider_helper
+from huggingface_hub.inference._providers import PROVIDER_T, get_provider_helper
 from huggingface_hub.utils import build_hf_headers, get_session, hf_raise_for_status
 from huggingface_hub.utils._auth import get_token
 from huggingface_hub.utils._deprecation import _deprecate_method
@@ -236,83 +236,6 @@ class InferenceClient:
 
     def __repr__(self):
         return f"<InferenceClient(model='{self.model if self.model else ''}', timeout={self.timeout})>"
-
-    @overload
-    def post(  # type: ignore[misc]
-        self,
-        *,
-        json: Optional[Union[str, Dict, List]] = None,
-        data: Optional[ContentT] = None,
-        model: Optional[str] = None,
-        task: Optional[str] = None,
-        stream: Literal[False] = ...,
-    ) -> bytes: ...
-
-    @overload
-    def post(  # type: ignore[misc]
-        self,
-        *,
-        json: Optional[Union[str, Dict, List]] = None,
-        data: Optional[ContentT] = None,
-        model: Optional[str] = None,
-        task: Optional[str] = None,
-        stream: Literal[True] = ...,
-    ) -> Iterable[bytes]: ...
-
-    @overload
-    def post(
-        self,
-        *,
-        json: Optional[Union[str, Dict, List]] = None,
-        data: Optional[ContentT] = None,
-        model: Optional[str] = None,
-        task: Optional[str] = None,
-        stream: bool = False,
-    ) -> Union[bytes, Iterable[bytes]]: ...
-
-    @_deprecate_method(
-        version="0.31.0",
-        message=(
-            "Making direct POST requests to the inference server is not supported anymore. "
-            "Please use task methods instead (e.g. `InferenceClient.chat_completion`). "
-            "If your use case is not supported, please open an issue in https://github.com/huggingface/huggingface_hub."
-        ),
-    )
-    def post(
-        self,
-        *,
-        json: Optional[Union[str, Dict, List]] = None,
-        data: Optional[ContentT] = None,
-        model: Optional[str] = None,
-        task: Optional[str] = None,
-        stream: bool = False,
-    ) -> Union[bytes, Iterable[bytes]]:
-        """
-        Make a POST request to the inference server.
-
-        This method is deprecated and will be removed in the future.
-        Please use task methods instead (e.g. `InferenceClient.chat_completion`).
-        """
-        if self.provider != "hf-inference":
-            raise ValueError(
-                "Cannot use `post` with another provider than `hf-inference`. "
-                "`InferenceClient.post` is deprecated and should not be used directly anymore."
-            )
-        provider_helper = HFInferenceTask(task or "unknown")
-        mapped_model = provider_helper._prepare_mapped_model(model or self.model)
-        url = provider_helper._prepare_url(self.token, mapped_model)  # type: ignore[arg-type]
-        headers = provider_helper._prepare_headers(self.headers, self.token)  # type: ignore[arg-type]
-        return self._inner_post(
-            request_parameters=RequestParameters(
-                url=url,
-                task=task or "unknown",
-                model=model or "unknown",
-                json=json,
-                data=data,
-                headers=headers,
-            ),
-            stream=stream,
-        )
 
     @overload
     def _inner_post(  # type: ignore[misc]

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -85,7 +85,7 @@ from huggingface_hub.inference._generated.types import (
     ZeroShotClassificationOutputElement,
     ZeroShotImageClassificationOutputElement,
 )
-from huggingface_hub.inference._providers import PROVIDER_T, HFInferenceTask, get_provider_helper
+from huggingface_hub.inference._providers import PROVIDER_T, get_provider_helper
 from huggingface_hub.utils import build_hf_headers, get_session, hf_raise_for_status
 from huggingface_hub.utils._auth import get_token
 from huggingface_hub.utils._deprecation import _deprecate_method
@@ -231,83 +231,6 @@ class AsyncInferenceClient:
 
     def __repr__(self):
         return f"<InferenceClient(model='{self.model if self.model else ''}', timeout={self.timeout})>"
-
-    @overload
-    async def post(  # type: ignore[misc]
-        self,
-        *,
-        json: Optional[Union[str, Dict, List]] = None,
-        data: Optional[ContentT] = None,
-        model: Optional[str] = None,
-        task: Optional[str] = None,
-        stream: Literal[False] = ...,
-    ) -> bytes: ...
-
-    @overload
-    async def post(  # type: ignore[misc]
-        self,
-        *,
-        json: Optional[Union[str, Dict, List]] = None,
-        data: Optional[ContentT] = None,
-        model: Optional[str] = None,
-        task: Optional[str] = None,
-        stream: Literal[True] = ...,
-    ) -> AsyncIterable[bytes]: ...
-
-    @overload
-    async def post(
-        self,
-        *,
-        json: Optional[Union[str, Dict, List]] = None,
-        data: Optional[ContentT] = None,
-        model: Optional[str] = None,
-        task: Optional[str] = None,
-        stream: bool = False,
-    ) -> Union[bytes, AsyncIterable[bytes]]: ...
-
-    @_deprecate_method(
-        version="0.31.0",
-        message=(
-            "Making direct POST requests to the inference server is not supported anymore. "
-            "Please use task methods instead (e.g. `InferenceClient.chat_completion`). "
-            "If your use case is not supported, please open an issue in https://github.com/huggingface/huggingface_hub."
-        ),
-    )
-    async def post(
-        self,
-        *,
-        json: Optional[Union[str, Dict, List]] = None,
-        data: Optional[ContentT] = None,
-        model: Optional[str] = None,
-        task: Optional[str] = None,
-        stream: bool = False,
-    ) -> Union[bytes, AsyncIterable[bytes]]:
-        """
-        Make a POST request to the inference server.
-
-        This method is deprecated and will be removed in the future.
-        Please use task methods instead (e.g. `InferenceClient.chat_completion`).
-        """
-        if self.provider != "hf-inference":
-            raise ValueError(
-                "Cannot use `post` with another provider than `hf-inference`. "
-                "`InferenceClient.post` is deprecated and should not be used directly anymore."
-            )
-        provider_helper = HFInferenceTask(task or "unknown")
-        mapped_model = provider_helper._prepare_mapped_model(model or self.model)
-        url = provider_helper._prepare_url(self.token, mapped_model)  # type: ignore[arg-type]
-        headers = provider_helper._prepare_headers(self.headers, self.token)  # type: ignore[arg-type]
-        return await self._inner_post(
-            request_parameters=RequestParameters(
-                url=url,
-                task=task or "unknown",
-                model=model or "unknown",
-                json=json,
-                data=data,
-                headers=headers,
-            ),
-            stream=stream,
-        )
 
     @overload
     async def _inner_post(  # type: ignore[misc]

--- a/tests/test_inference_async_client.py
+++ b/tests/test_inference_async_client.py
@@ -368,19 +368,6 @@ class CustomException(Exception):
     """Mock any exception that could happen while making a POST request."""
 
 
-@patch("aiohttp.ClientSession.post", side_effect=CustomException())
-@patch("aiohttp.ClientSession.close")
-@pytest.mark.asyncio
-async def test_close_connection_on_post_error(mock_close: Mock, mock_post: Mock) -> None:
-    async_client = AsyncInferenceClient()
-
-    with pytest.warns(FutureWarning, match=".*'post'.*"):
-        with pytest.raises(CustomException):
-            await async_client.post(model="http://127.0.0.1/api", json={})
-
-    mock_close.assert_called_once()
-
-
 @pytest.mark.vcr
 @pytest.mark.asyncio
 @with_production_testing

--- a/tests/test_inference_client.py
+++ b/tests/test_inference_client.py
@@ -53,7 +53,6 @@ from huggingface_hub.inference._common import (
 )
 from huggingface_hub.inference._providers import get_provider_helper
 from huggingface_hub.inference._providers.hf_inference import _build_chat_completion_url
-from huggingface_hub.utils import build_hf_headers
 
 from .testing_utils import expect_deprecation, with_production_testing
 
@@ -809,31 +808,6 @@ class TestHeadersAndCookies(TestBase):
         client = InferenceClient(headers={"X-My-Header": "foo"}, cookies={"my-cookie": "bar"})
         assert client.headers["X-My-Header"] == "foo"
         assert client.cookies["my-cookie"] == "bar"
-
-    @expect_deprecation("post")
-    @with_production_testing
-    @patch("huggingface_hub.inference._client.get_session")
-    @patch("huggingface_hub.inference._providers.hf_inference._check_supported_task")
-    def test_mocked_post(self, check_supported_task_mock: MagicMock, get_session_mock: MagicMock) -> None:
-        """Test that headers and cookies are correctly passed to the request."""
-
-        client = InferenceClient(
-            headers={"X-My-Header": "foo"}, cookies={"my-cookie": "bar"}, proxies="custom proxies"
-        )
-        response = client.post(data=b"content", model="username/repo_name", task="text-classification")
-        assert response == get_session_mock().post.return_value.content
-
-        expected_headers = build_hf_headers()
-        get_session_mock().post.assert_called_once_with(
-            "https://router.huggingface.co/hf-inference/models/username/repo_name",
-            json=None,
-            data=b"content",
-            headers={**expected_headers, "X-My-Header": "foo"},
-            cookies={"my-cookie": "bar"},
-            timeout=None,
-            stream=False,
-            proxies="custom proxies",
-        )
 
     @patch("huggingface_hub.inference._client._bytes_to_image")
     @patch("huggingface_hub.inference._client.get_session")


### PR DESCRIPTION
Follow-up PR after [v0.30.0 release](https://github.com/huggingface/huggingface_hub/releases/tag/v0.30.0). 

🚨 Breaking change: `InferenceClient.post` will be removed in the next release. Custom inference requests will no longer be supported — users will have to either use the task methods or use the `requests` library for which snippets are available on model pages. 
