### PR TITLE
Fix HfInference conversational

### DIFF
--- a/src/huggingface_hub/inference/_providers/hf_inference.py
+++ b/src/huggingface_hub/inference/_providers/hf_inference.py
@@ -82,7 +82,7 @@ class HFInferenceBinaryInputTask(HFInferenceTask):
 
 class HFInferenceConversational(HFInferenceTask):
     def __init__(self):
-        super().__init__("text-generation")
+        super().__init__("conversational")
 
     def _prepare_payload_as_dict(self, inputs: Any, parameters: Dict, mapped_model: str) -> Optional[Dict]:
         payload_model = parameters.get("model") or mapped_model

--- a/tests/test_inference_providers.py
+++ b/tests/test_inference_providers.py
@@ -470,7 +470,7 @@ class TestHFInferenceProvider:
         assert (
             request.url == "https://router.huggingface.co/hf-inference/models/username/repo_name/v1/chat/completions"
         )
-        assert request.task == "text-generation"
+        assert request.task == "conversational"
         assert request.model == "username/repo_name"
         assert request.json == {
             "model": "username/repo_name",


### PR DESCRIPTION
Reported by @abidlabs [on slack](https://huggingface.slack.com/archives/C02V5EA0A95/p1744076140260639) (private link)

Snippet in https://huggingface.co/google/gemma-3-27b-it?inference_api=true&inference_provider=hf-inference&language=python currently does not work. Issue is with the `task` defined for `HFInferenceConversational` which should be `"conversational"` (otherwise the `_check_supported_task` fails).


(tested it locally and it indeed fixes the issue with the snippet above)


=> once merged we should make a patch release