### PR TITLE
[Inference Providers] Support for LoRAs

### DIFF
--- a/src/huggingface_hub/inference/_providers/black_forest_labs.py
+++ b/src/huggingface_hub/inference/_providers/black_forest_labs.py
@@ -2,7 +2,7 @@ import time
 from typing import Any, Dict, Optional, Union
 
 from huggingface_hub.inference._common import RequestParameters, _as_dict
-from huggingface_hub.inference._providers._common import TaskProviderHelper, filter_none
+from huggingface_hub.inference._providers._common import ProviderMappingInfo, TaskProviderHelper, filter_none
 from huggingface_hub.utils import logging
 from huggingface_hub.utils._http import get_session
 
@@ -27,7 +27,9 @@ class BlackForestLabsTextToImageTask(TaskProviderHelper):
     def _prepare_route(self, mapped_model: str, api_key: str) -> str:
         return f"/v1/{mapped_model}"
 
-    def _prepare_payload_as_dict(self, inputs: Any, parameters: Dict, mapped_model: str) -> Optional[Dict]:
+    def _prepare_payload_as_dict(
+        self, inputs: Any, parameters: Dict, provider_mapping_info: ProviderMappingInfo
+    ) -> Optional[Dict]:
         parameters = filter_none(parameters)
         if "num_inference_steps" in parameters:
             parameters["steps"] = parameters.pop("num_inference_steps")

--- a/src/huggingface_hub/inference/_providers/fal_ai.py
+++ b/src/huggingface_hub/inference/_providers/fal_ai.py
@@ -4,8 +4,9 @@ from abc import ABC
 from typing import Any, Dict, Optional, Union
 from urllib.parse import urlparse
 
+from huggingface_hub.constants import ENDPOINT
 from huggingface_hub.inference._common import RequestParameters, _as_dict
-from huggingface_hub.inference._providers._common import TaskProviderHelper, filter_none
+from huggingface_hub.inference._providers._common import ProviderMappingInfo, TaskProviderHelper, filter_none
 from huggingface_hub.utils import get_session, hf_raise_for_status
 from huggingface_hub.utils.logging import get_logger
 
@@ -34,7 +35,9 @@ class FalAIAutomaticSpeechRecognitionTask(FalAITask):
     def __init__(self):
         super().__init__("automatic-speech-recognition")
 
-    def _prepare_payload_as_dict(self, inputs: Any, parameters: Dict, mapped_model: str) -> Optional[Dict]:
+    def _prepare_payload_as_dict(
+        self, inputs: Any, parameters: Dict, provider_mapping_info: ProviderMappingInfo
+    ) -> Optional[Dict]:
         if isinstance(inputs, str) and inputs.startswith(("http://", "https://")):
             # If input is a URL, pass it directly
             audio_url = inputs
@@ -61,14 +64,29 @@ class FalAITextToImageTask(FalAITask):
     def __init__(self):
         super().__init__("text-to-image")
 
-    def _prepare_payload_as_dict(self, inputs: Any, parameters: Dict, mapped_model: str) -> Optional[Dict]:
-        parameters = filter_none(parameters)
-        if "width" in parameters and "height" in parameters:
-            parameters["image_size"] = {
-                "width": parameters.pop("width"),
-                "height": parameters.pop("height"),
+    def _prepare_payload_as_dict(
+        self, inputs: Any, parameters: Dict, provider_mapping_info: ProviderMappingInfo
+    ) -> Optional[Dict]:
+        payload: Dict[str, Any] = {
+            "prompt": inputs,
+            **filter_none(parameters),
+        }
+        if "width" in payload and "height" in payload:
+            payload["image_size"] = {
+                "width": payload.pop("width"),
+                "height": payload.pop("height"),
             }
-        return {"prompt": inputs, **parameters}
+        if provider_mapping_info.adapter_weights_path is not None:
+            lora_path = (
+                f"{ENDPOINT}/"
+                f"{provider_mapping_info.hf_model_id}/resolve/main/"
+                f"{provider_mapping_info.adapter_weights_path}"
+            )
+            payload["loras"] = [{"path": lora_path, "scale": 1}]
+            if provider_mapping_info.provider_id == "fal-ai/lora":
+                payload["model_name"] = "stabilityai/stable-diffusion-xl-base-1.0"
+
+        return payload
 
     def get_response(self, response: Union[bytes, Dict], request_params: Optional[RequestParameters] = None) -> Any:
         url = _as_dict(response)["images"][0]["url"]
@@ -79,7 +97,9 @@ class FalAITextToSpeechTask(FalAITask):
     def __init__(self):
         super().__init__("text-to-speech")
 
-    def _prepare_payload_as_dict(self, inputs: Any, parameters: Dict, mapped_model: str) -> Optional[Dict]:
+    def _prepare_payload_as_dict(
+        self, inputs: Any, parameters: Dict, provider_mapping_info: ProviderMappingInfo
+    ) -> Optional[Dict]:
         return {"lyrics": inputs, **filter_none(parameters)}
 
     def get_response(self, response: Union[bytes, Dict], request_params: Optional[RequestParameters] = None) -> Any:
@@ -104,7 +124,9 @@ class FalAITextToVideoTask(FalAITask):
             return f"/{mapped_model}?_subdomain=queue"
         return f"/{mapped_model}"
 
-    def _prepare_payload_as_dict(self, inputs: Any, parameters: Dict, mapped_model: str) -> Optional[Dict]:
+    def _prepare_payload_as_dict(
+        self, inputs: Any, parameters: Dict, provider_mapping_info: ProviderMappingInfo
+    ) -> Optional[Dict]:
         return {"prompt": inputs, **filter_none(parameters)}
 
     def get_response(

--- a/src/huggingface_hub/inference/_providers/hf_inference.py
+++ b/src/huggingface_hub/inference/_providers/hf_inference.py
@@ -86,7 +86,7 @@ class HFInferenceBinaryInputTask(HFInferenceTask):
 
 class HFInferenceConversational(HFInferenceTask):
     def __init__(self):
-        super().__init__("text-generation")
+        super().__init__("conversational")
 
     def _prepare_payload_as_dict(
         self, inputs: Any, parameters: Dict, provider_mapping_info: ProviderMappingInfo

--- a/src/huggingface_hub/inference/_providers/hyperbolic.py
+++ b/src/huggingface_hub/inference/_providers/hyperbolic.py
@@ -2,7 +2,12 @@ import base64
 from typing import Any, Dict, Optional, Union
 
 from huggingface_hub.inference._common import RequestParameters, _as_dict
-from huggingface_hub.inference._providers._common import BaseConversationalTask, TaskProviderHelper, filter_none
+from huggingface_hub.inference._providers._common import (
+    BaseConversationalTask,
+    ProviderMappingInfo,
+    TaskProviderHelper,
+    filter_none,
+)
 
 
 class HyperbolicTextToImageTask(TaskProviderHelper):
@@ -12,7 +17,10 @@ class HyperbolicTextToImageTask(TaskProviderHelper):
     def _prepare_route(self, mapped_model: str, api_key: str) -> str:
         return "/v1/images/generations"
 
-    def _prepare_payload_as_dict(self, inputs: Any, parameters: Dict, mapped_model: str) -> Optional[Dict]:
+    def _prepare_payload_as_dict(
+        self, inputs: Any, parameters: Dict, provider_mapping_info: ProviderMappingInfo
+    ) -> Optional[Dict]:
+        mapped_model = provider_mapping_info.provider_id
         parameters = filter_none(parameters)
         if "num_inference_steps" in parameters:
             parameters["steps"] = parameters.pop("num_inference_steps")

--- a/src/huggingface_hub/inference/_providers/nebius.py
+++ b/src/huggingface_hub/inference/_providers/nebius.py
@@ -5,6 +5,7 @@ from huggingface_hub.inference._common import RequestParameters, _as_dict
 from huggingface_hub.inference._providers._common import (
     BaseConversationalTask,
     BaseTextGenerationTask,
+    ProviderMappingInfo,
     TaskProviderHelper,
     filter_none,
 )
@@ -37,7 +38,10 @@ class NebiusTextToImageTask(TaskProviderHelper):
     def _prepare_route(self, mapped_model: str, api_key: str) -> str:
         return "/v1/images/generations"
 
-    def _prepare_payload_as_dict(self, inputs: Any, parameters: Dict, mapped_model: str) -> Optional[Dict]:
+    def _prepare_payload_as_dict(
+        self, inputs: Any, parameters: Dict, provider_mapping_info: ProviderMappingInfo
+    ) -> Optional[Dict]:
+        mapped_model = provider_mapping_info.provider_id
         parameters = filter_none(parameters)
         if "guidance_scale" in parameters:
             parameters.pop("guidance_scale")

--- a/src/huggingface_hub/inference/_providers/novita.py
+++ b/src/huggingface_hub/inference/_providers/novita.py
@@ -4,6 +4,7 @@ from huggingface_hub.inference._common import RequestParameters, _as_dict
 from huggingface_hub.inference._providers._common import (
     BaseConversationalTask,
     BaseTextGenerationTask,
+    ProviderMappingInfo,
     TaskProviderHelper,
     filter_none,
 )
@@ -49,7 +50,9 @@ class NovitaTextToVideoTask(TaskProviderHelper):
     def _prepare_route(self, mapped_model: str, api_key: str) -> str:
         return f"/v3/hf/{mapped_model}"
 
-    def _prepare_payload_as_dict(self, inputs: Any, parameters: Dict, mapped_model: str) -> Optional[Dict]:
+    def _prepare_payload_as_dict(
+        self, inputs: Any, parameters: Dict, provider_mapping_info: ProviderMappingInfo
+    ) -> Optional[Dict]:
         return {"prompt": inputs, **filter_none(parameters)}
 
     def get_response(self, response: Union[bytes, Dict], request_params: Optional[RequestParameters] = None) -> Any:

--- a/src/huggingface_hub/inference/_providers/openai.py
+++ b/src/huggingface_hub/inference/_providers/openai.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from huggingface_hub.inference._providers._common import BaseConversationalTask
+from huggingface_hub.inference._providers._common import BaseConversationalTask, ProviderMappingInfo
 
 
 class OpenAIConversationalTask(BaseConversationalTask):
@@ -16,7 +16,7 @@ class OpenAIConversationalTask(BaseConversationalTask):
             )
         return api_key
 
-    def _prepare_mapped_model(self, model: Optional[str]) -> str:
+    def _prepare_mapped_model(self, model: Optional[str]) -> ProviderMappingInfo:
         if model is None:
             raise ValueError("Please provide an OpenAI model ID, e.g. `gpt-4o` or `o1`.")
-        return model
+        return ProviderMappingInfo(provider_id=model)

--- a/src/huggingface_hub/inference/_providers/replicate.py
+++ b/src/huggingface_hub/inference/_providers/replicate.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, Optional, Union
 
 from huggingface_hub.inference._common import RequestParameters, _as_dict
-from huggingface_hub.inference._providers._common import TaskProviderHelper, filter_none
+from huggingface_hub.inference._providers._common import ProviderMappingInfo, TaskProviderHelper, filter_none
 from huggingface_hub.utils import get_session
 
 
@@ -23,7 +23,10 @@ class ReplicateTask(TaskProviderHelper):
             return "/v1/predictions"
         return f"/v1/models/{mapped_model}/predictions"
 
-    def _prepare_payload_as_dict(self, inputs: Any, parameters: Dict, mapped_model: str) -> Optional[Dict]:
+    def _prepare_payload_as_dict(
+        self, inputs: Any, parameters: Dict, provider_mapping_info: ProviderMappingInfo
+    ) -> Optional[Dict]:
+        mapped_model = provider_mapping_info.provider_id
         payload: Dict[str, Any] = {"input": {"prompt": inputs, **filter_none(parameters)}}
         if ":" in mapped_model:
             version = mapped_model.split(":", 1)[1]
@@ -47,7 +50,9 @@ class ReplicateTextToSpeechTask(ReplicateTask):
     def __init__(self):
         super().__init__("text-to-speech")
 
-    def _prepare_payload_as_dict(self, inputs: Any, parameters: Dict, mapped_model: str) -> Optional[Dict]:
-        payload: Dict = super()._prepare_payload_as_dict(inputs, parameters, mapped_model)  # type: ignore[assignment]
+    def _prepare_payload_as_dict(
+        self, inputs: Any, parameters: Dict, provider_mapping_info: ProviderMappingInfo
+    ) -> Optional[Dict]:
+        payload: Dict = super()._prepare_payload_as_dict(inputs, parameters, provider_mapping_info)  # type: ignore[assignment]
         payload["input"]["text"] = payload["input"].pop("prompt")  # rename "prompt" to "text" for TTS
         return payload

--- a/src/huggingface_hub/inference/_providers/together.py
+++ b/src/huggingface_hub/inference/_providers/together.py
@@ -6,6 +6,7 @@ from huggingface_hub.inference._common import RequestParameters, _as_dict
 from huggingface_hub.inference._providers._common import (
     BaseConversationalTask,
     BaseTextGenerationTask,
+    ProviderMappingInfo,
     TaskProviderHelper,
     filter_none,
 )
@@ -55,7 +56,10 @@ class TogetherTextToImageTask(TogetherTask):
     def __init__(self):
         super().__init__("text-to-image")
 
-    def _prepare_payload_as_dict(self, inputs: Any, parameters: Dict, mapped_model: str) -> Optional[Dict]:
+    def _prepare_payload_as_dict(
+        self, inputs: Any, parameters: Dict, provider_mapping_info: ProviderMappingInfo
+    ) -> Optional[Dict]:
+        mapped_model = provider_mapping_info.provider_id
         parameters = filter_none(parameters)
         if "num_inference_steps" in parameters:
             parameters["steps"] = parameters.pop("num_inference_steps")


### PR DESCRIPTION
This work mirrors the PR in the js client (see [huggingface.js#1347](https://github.com/huggingface/huggingface.js/pull/1347)).

This PR introduces the support of LoRAs for fal-ai, this should not be merged until the server-side [PR](https://github.com/huggingface-internal/moon-landing/pull/13246) is merged (private).

## Changes
- update `_prepare_mapped_model` to return a `ProviderMappingInfo` object. This object returns the provider id, the hf model id (optional) and the lora weights path (optional) that is expected to be sent in the payload. 
- update `_prepare_payload_as_dict` and `_prepare_payload_as_bytes` signatures to accept a `ProviderMappingInfo` object as an argument. 

the logic is implemented within the `TaskProviderHelper` base class, to avoid duplicating similar logic when we support LoRAs for the other providers. Note that LoRAs can also be used with other tasks like `text-to-video` as instance. 
