### PR TITLE
Minor xet changes: HF_HUB_DISABLE_XET flag, suppress logger.info

### DIFF
--- a/docs/source/en/package_reference/environment_variables.md
+++ b/docs/source/en/package_reference/environment_variables.md
@@ -89,6 +89,7 @@ Integer value to define the number of seconds to wait for server response when d
 * [`HF_XET_CACHE`](../package_reference/environment_variables#hfxetcache)
 * [`HF_XET_HIGH_PERFORMANCE`](../package_reference/environment_variables#hfxethighperformance)
 * [`HF_XET_RECONSTRUCT_WRITE_SEQUENTIALLY`](../package_reference/environment_variables#hfxetreconstructwritesequentially)
+* [`HF_HUB_DISABLE_XET`](../package_reference/environment_variables#hfhubdisablexet)
 
 ### HF_XET_CHUNK_CACHE_SIZE_BYTES
 
@@ -163,6 +164,10 @@ By default, some data is collected by HF libraries (`transformers`, `datasets`, 
 Each library defines its own policy (i.e. which usage to monitor) but the core implementation happens in `huggingface_hub` (see [`send_telemetry`]).
 
 You can set `HF_HUB_DISABLE_TELEMETRY=1` as environment variable to globally disable telemetry.
+
+### HF_HUB_DISABLE_XET
+
+Set to disable using `hf-xet`, even if it is available in your Python environment. This is since `hf-xet` will be used automatically if it is found, this allows explicitly disabling its usage.
 
 ### HF_HUB_ENABLE_HF_TRANSFER
 

--- a/docs/source/en/package_reference/environment_variables.md
+++ b/docs/source/en/package_reference/environment_variables.md
@@ -86,10 +86,10 @@ Integer value to define the number of seconds to wait for server response when d
 ## Xet 
 
 ### Other Xet environment variables
+* [`HF_HUB_DISABLE_XET`](../package_reference/environment_variables#hfhubdisablexet)
 * [`HF_XET_CACHE`](../package_reference/environment_variables#hfxetcache)
 * [`HF_XET_HIGH_PERFORMANCE`](../package_reference/environment_variables#hfxethighperformance)
 * [`HF_XET_RECONSTRUCT_WRITE_SEQUENTIALLY`](../package_reference/environment_variables#hfxetreconstructwritesequentially)
-* [`HF_HUB_DISABLE_XET`](../package_reference/environment_variables#hfhubdisablexet)
 
 ### HF_XET_CHUNK_CACHE_SIZE_BYTES
 

--- a/src/huggingface_hub/commands/upload.py
+++ b/src/huggingface_hub/commands/upload.py
@@ -59,6 +59,7 @@ from huggingface_hub.constants import HF_HUB_ENABLE_HF_TRANSFER
 from huggingface_hub.errors import RevisionNotFoundError
 from huggingface_hub.hf_api import HfApi
 from huggingface_hub.utils import disable_progress_bars, enable_progress_bars
+from huggingface_hub.utils._runtime import is_xet_available
 
 
 logger = logging.get_logger(__name__)
@@ -215,7 +216,12 @@ class UploadCommand(BaseHuggingfaceCLICommand):
             if self.delete is not None and len(self.delete) > 0:
                 warnings.warn("Ignoring `--delete` since a single file is uploaded.")
 
-        if not HF_HUB_ENABLE_HF_TRANSFER:
+        if not is_xet_available():
+            logger.info(
+                "Consider using `hf_xet` for faster uploads. See"
+                " https://huggingface.co/docs/huggingface_hub/guides/upload#faster-uploads for more details."
+            )
+        elif not HF_HUB_ENABLE_HF_TRANSFER:
             logger.info(
                 "Consider using `hf_transfer` for faster uploads. This solution comes with some limitations. See"
                 " https://huggingface.co/docs/huggingface_hub/hf_transfer for more details."

--- a/src/huggingface_hub/commands/upload.py
+++ b/src/huggingface_hub/commands/upload.py
@@ -216,12 +216,7 @@ class UploadCommand(BaseHuggingfaceCLICommand):
             if self.delete is not None and len(self.delete) > 0:
                 warnings.warn("Ignoring `--delete` since a single file is uploaded.")
 
-        if not is_xet_available():
-            logger.info(
-                "Consider using `hf_xet` for faster uploads. See"
-                " https://huggingface.co/docs/huggingface_hub/guides/upload#faster-uploads for more details."
-            )
-        elif not HF_HUB_ENABLE_HF_TRANSFER:
+        if not is_xet_available() and not HF_HUB_ENABLE_HF_TRANSFER:
             logger.info(
                 "Consider using `hf_transfer` for faster uploads. This solution comes with some limitations. See"
                 " https://huggingface.co/docs/huggingface_hub/hf_transfer for more details."

--- a/src/huggingface_hub/utils/_runtime.py
+++ b/src/huggingface_hub/utils/_runtime.py
@@ -154,6 +154,9 @@ def get_hf_transfer_version() -> str:
 
 # xet
 def is_xet_available() -> bool:
+    # since hf_xet is automatically used if available, allow explicit disabling via environment variable
+    if constants._is_true(os.environ.get("HF_HUB_DISABLE_XET")):  # type: ignore
+        return False
     return is_package_available("hf_xet")
 
 

--- a/src/huggingface_hub/utils/_runtime.py
+++ b/src/huggingface_hub/utils/_runtime.py
@@ -21,8 +21,6 @@ import sys
 import warnings
 from typing import Any, Dict
 
-from packaging.version import Version
-
 from .. import __version__, constants
 
 
@@ -160,13 +158,7 @@ def is_xet_available() -> bool:
     if constants._is_true(os.environ.get("HF_HUB_DISABLE_XET")):  # type: ignore
         return False
 
-    is_xet = is_package_available("hf_xet")
-    if is_xet and Version(get_hf_hub_version()) < Version("0.30.0"):
-        # if hf_xet is installed but huggingface_hub is older than 0.30.0, we need to warn the user
-        # that they need to upgrade huggingface_hub
-        warnings.warn("hf_xet is installed but requires huggingface_hub>=0.30.0. Please upgrade huggingface_hub.")
-
-    return is_xet
+    return is_package_available("hf_xet")
 
 
 def get_xet_version() -> str:

--- a/src/huggingface_hub/utils/_runtime.py
+++ b/src/huggingface_hub/utils/_runtime.py
@@ -21,6 +21,8 @@ import sys
 import warnings
 from typing import Any, Dict
 
+from packaging.version import Version
+
 from .. import __version__, constants
 
 
@@ -157,7 +159,14 @@ def is_xet_available() -> bool:
     # since hf_xet is automatically used if available, allow explicit disabling via environment variable
     if constants._is_true(os.environ.get("HF_HUB_DISABLE_XET")):  # type: ignore
         return False
-    return is_package_available("hf_xet")
+
+    is_xet = is_package_available("hf_xet")
+    if is_xet and Version(get_hf_hub_version()) < Version("0.30.0"):
+        # if hf_xet is installed but huggingface_hub is older than 0.30.0, we need to warn the user
+        # that they need to upgrade huggingface_hub
+        warnings.warn("hf_xet is installed but requires huggingface_hub>=0.30.0. Please upgrade huggingface_hub.")
+
+    return is_xet
 
 
 def get_xet_version() -> str:

--- a/tests/test_xet_utils.py
+++ b/tests/test_xet_utils.py
@@ -262,12 +262,3 @@ def test_env_var_hf_hub_disable_xet() -> None:
     os.environ["HF_HUB_DISABLE_XET"] = "1"
     assert not is_xet_available()
     del os.environ["HF_HUB_DISABLE_XET"]  # Clean up after the test
-
-
-def test_old_hfhub_version_xet(mocker) -> None:
-    """Test that old hf-hub results in is_xet_available() emitting a UserWarning."""
-    from huggingface_hub.utils._runtime import is_xet_available
-
-    mocker.patch("huggingface_hub.utils._runtime.get_hf_hub_version", return_value="0.29.0")
-    with pytest.warns(UserWarning):
-        assert is_xet_available()

--- a/tests/test_xet_utils.py
+++ b/tests/test_xet_utils.py
@@ -1,7 +1,7 @@
-import os
 from unittest.mock import MagicMock
 
 import pytest
+from _pytest.monkeypatch import MonkeyPatch
 
 from huggingface_hub import constants
 from huggingface_hub.utils._xet import (
@@ -259,6 +259,6 @@ def test_env_var_hf_hub_disable_xet() -> None:
     """Test that setting HF_HUB_DISABLE_XET results in is_xet_available() returning False."""
     from huggingface_hub.utils._runtime import is_xet_available
 
-    os.environ["HF_HUB_DISABLE_XET"] = "1"
+    monkeypatch = MonkeyPatch()
+    monkeypatch.setenv("HF_HUB_DISABLE_XET", "1")
     assert not is_xet_available()
-    del os.environ["HF_HUB_DISABLE_XET"]  # Clean up after the test

--- a/tests/test_xet_utils.py
+++ b/tests/test_xet_utils.py
@@ -2,7 +2,6 @@ import os
 from unittest.mock import MagicMock
 
 import pytest
-import warnings
 
 from huggingface_hub import constants
 from huggingface_hub.utils._xet import (
@@ -263,6 +262,7 @@ def test_env_var_hf_hub_disable_xet() -> None:
     os.environ["HF_HUB_DISABLE_XET"] = "1"
     assert not is_xet_available()
     del os.environ["HF_HUB_DISABLE_XET"]  # Clean up after the test
+
 
 def test_old_hfhub_version_xet(mocker) -> None:
     """Test that old hf-hub results in is_xet_available() emitting a UserWarning."""

--- a/tests/test_xet_utils.py
+++ b/tests/test_xet_utils.py
@@ -1,5 +1,7 @@
 from unittest.mock import MagicMock
 
+import os
+
 import pytest
 
 from huggingface_hub import constants
@@ -252,3 +254,10 @@ def test_fetch_xet_metadata_with_url_invalid_response(mocker) -> None:
 
     with pytest.raises(ValueError, match="Xet headers have not been correctly set by the server."):
         _fetch_xet_connection_info_with_url(url=url, headers=headers)
+
+def test_env_var_hf_hub_disable_xet() -> None:
+    """Test that setting HF_HUB_DISABLE_XET results in is_xet_available() returning False."""
+    from huggingface_hub.utils._runtime import is_xet_available
+    os.environ["HF_HUB_DISABLE_XET"] = "1"
+    assert not is_xet_available()
+    del os.environ["HF_HUB_DISABLE_XET"]  # Clean up after the test

--- a/tests/test_xet_utils.py
+++ b/tests/test_xet_utils.py
@@ -1,8 +1,8 @@
+import os
 from unittest.mock import MagicMock
 
-import os
-
 import pytest
+import warnings
 
 from huggingface_hub import constants
 from huggingface_hub.utils._xet import (
@@ -255,9 +255,19 @@ def test_fetch_xet_metadata_with_url_invalid_response(mocker) -> None:
     with pytest.raises(ValueError, match="Xet headers have not been correctly set by the server."):
         _fetch_xet_connection_info_with_url(url=url, headers=headers)
 
+
 def test_env_var_hf_hub_disable_xet() -> None:
     """Test that setting HF_HUB_DISABLE_XET results in is_xet_available() returning False."""
     from huggingface_hub.utils._runtime import is_xet_available
+
     os.environ["HF_HUB_DISABLE_XET"] = "1"
     assert not is_xet_available()
     del os.environ["HF_HUB_DISABLE_XET"]  # Clean up after the test
+
+def test_old_hfhub_version_xet(mocker) -> None:
+    """Test that old hf-hub results in is_xet_available() emitting a UserWarning."""
+    from huggingface_hub.utils._runtime import is_xet_available
+
+    mocker.patch("huggingface_hub.utils._runtime.get_hf_hub_version", return_value="0.29.0")
+    with pytest.warns(UserWarning):
+        assert is_xet_available()


### PR DESCRIPTION
Changes:
* Adds HF_HUB_DISABLE_XET boolean environment variable to disable using hf_xet, even if installed
* Adds logger.info() if `hf-xet` is not available for cli upload, suppresses logger.info() about `hf-transfer` if `hf-xet` is available.

Fixes: XET-474, XET-492