### PR TITLE
Migrate to `logger.warning` usage

### DIFF
--- a/src/huggingface_hub/_upload_large_folder.py
+++ b/src/huggingface_hub/_upload_large_folder.py
@@ -209,7 +209,7 @@ class LargeUploadStatus:
     def update_chunk(self, success: bool, nb_items: int, duration: float) -> None:
         with self._chunk_lock:
             if not success:
-                logger.warn(f"Failed to commit {nb_items} files at once. Will retry with less files in next batch.")
+                logger.warning(f"Failed to commit {nb_items} files at once. Will retry with less files in next batch.")
                 self._chunk_idx -= 1
             elif nb_items >= COMMIT_SIZE_SCALE[self._chunk_idx] and duration < 40:
                 logger.info(f"Successfully committed {nb_items} at once. Increasing the limit for next batch.")


### PR DESCRIPTION
# PR Summary
This small PR resolves the `logger.warn()` deprecation warnings:
```python
D:\a\huggingface_hub\huggingface_hub\src\huggingface_hub\_upload_large_folder.py:212: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```
See [CI logs](https://github.com/huggingface/huggingface_hub/actions/runs/14861309262/job/41726632111) for more information.
