### PR TITLE
[Internal] Fix conda release workflow

### DIFF
--- a/.github/conda/meta.yaml
+++ b/.github/conda/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - typing-extensions
     - packaging
     - pyyaml
+    - hf-xet >=1.1.0,<2.0.0
   run:
     - python
     - pip
@@ -30,6 +31,7 @@ requirements:
     - typing-extensions
     - packaging
     - pyyaml
+    - hf-xet >=1.1.0,<2.0.0
 
 test:
   imports:


### PR DESCRIPTION
Fixes the failing conda release [workflow](https://github.com/huggingface/huggingface_hub/actions/runs/14885625698) job. 
The failure was due to `hf-xet` (required dependency) being missing in `meta.yaml`.