### PR TITLE
Add `api.endpoint` to arguments for `_get_upload_mode`

### DIFF
--- a/src/huggingface_hub/_upload_large_folder.py
+++ b/src/huggingface_hub/_upload_large_folder.py
@@ -522,6 +522,7 @@ def _get_upload_mode(items: List[JOB_ITEM_T], api: "HfApi", repo_id: str, repo_t
         repo_id=repo_id,
         headers=api._build_hf_headers(),
         revision=quote(revision, safe=""),
+        endpoint=api.endpoint,
     )
     for item, addition in zip(items, additions):
         paths, metadata = item


### PR DESCRIPTION
When calling `hf_api.upload_large_folder`, we aren't properly threading through the `endpoint` all the way to the network request. This means that even if we end up creating a `hf_api(endpoint="http://localhost:3000/v1/hf")`, calls to `upload_large_folder` will still try to make call to `https://huggingface.co`, via this line of code:

https://github.com/matthewgrossman/huggingface_hub/blob/57b927c6858e45d3301100961b0e52fb57acf9dc/src/huggingface_hub/_commit_api.py#L672

The quickest workaround is to just make sure you `export HF_ENDPOINT="http://localhost:3000/v1/hf"`, but given that the `api` has that information already, we should just pass it explicitly to the call.

---

Assuming this change seems reasonable, happy to add a test!
