### PR TITLE
[Internal] bump `hf-xet` min version

### DIFF
--- a/.github/conda/meta.yaml
+++ b/.github/conda/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - typing-extensions
     - packaging
     - pyyaml
-    - hf-xet >=1.1.0,<2.0.0
+    - hf-xet >=1.1.1,<2.0.0
   run:
     - python
     - pip
@@ -31,7 +31,7 @@ requirements:
     - typing-extensions
     - packaging
     - pyyaml
-    - hf-xet >=1.1.0,<2.0.0
+    - hf-xet >=1.1.1,<2.0.0
 
 test:
   imports:

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 install_requires = [
     "filelock",
     "fsspec>=2023.5.0",
-    "hf-xet>=1.1.0,<2.0.0; platform_machine=='x86_64' or platform_machine=='amd64' or platform_machine=='arm64' or platform_machine=='aarch64'",
+    "hf-xet>=1.1.1,<2.0.0; platform_machine=='x86_64' or platform_machine=='amd64' or platform_machine=='arm64' or platform_machine=='aarch64'",
     "packaging>=20.9",
     "pyyaml>=5.1",
     "requests",
@@ -56,7 +56,7 @@ extras["tensorflow-testing"] = [
     "keras<3.0",
 ]
 
-extras["hf_xet"] = ["hf_xet>=1.1.0,<2.0.0"]
+extras["hf_xet"] = ["hf-xet>=1.1.1,<2.0.0"]
 
 extras["testing"] = (
     extras["cli"]


### PR DESCRIPTION
Related to #3073 and #3067 
more context in this internal slack [thread](https://huggingface.slack.com/archives/C087TU2FE3G/p1747038120179199).