### PR TITLE
[Internal] make `hf-xet` optional

### DIFF
--- a/.github/conda/meta.yaml
+++ b/.github/conda/meta.yaml
@@ -21,7 +21,6 @@ requirements:
     - typing-extensions
     - packaging
     - pyyaml
-    - hf-xet >=1.1.1,<2.0.0
   run:
     - python
     - pip
@@ -31,7 +30,6 @@ requirements:
     - typing-extensions
     - packaging
     - pyyaml
-    - hf-xet >=1.1.1,<2.0.0
 
 test:
   imports:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -94,14 +94,13 @@ jobs:
               sudo apt install -y graphviz
               uv pip install "huggingface_hub[tensorflow-testing] @ ."
               ;;
+            
+            "Xet only")
+              uv pip install "huggingface_hub[hf_xet] @ ."
+              ;;
 
           esac
 
-          # If not "Xet only", we want to test upload/download with regular LFS workflow
-          # => uninstall hf_xet to make sure we are not using it.
-          if [[ "${{ matrix.test_name }}" != "Xet only" ]]; then
-            uv pip uninstall hf_xet
-          fi
       # Run tests
       - name: Run tests
         working-directory: ./src # For code coverage to work

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ def get_version() -> str:
 install_requires = [
     "filelock",
     "fsspec>=2023.5.0",
-    "hf-xet>=1.1.1,<2.0.0; platform_machine=='x86_64' or platform_machine=='amd64' or platform_machine=='arm64' or platform_machine=='aarch64'",
     "packaging>=20.9",
     "pyyaml>=5.1",
     "requests",


### PR DESCRIPTION
follow-up PR after #3078. Let's make `hf-xet` optional for now until the package size is further reduced. This shouldn’t break anything. 

cc @bpronan @rajatarya 