### PR TITLE
[HfFileSystem] Fix end-of-file `read()`

### DIFF
--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -1009,7 +1009,9 @@ class HfFileSystemFile(fsspec.spec.AbstractBufferedFile):
         """
         if self.mode == "rb" and (length is None or length == -1) and self.loc == 0:
             with self.fs.open(self.path, "rb", block_size=0) as f:  # block_size=0 enables fast streaming
-                return f.read()
+                out = f.read()
+                self.loc += len(out)
+                return out
         return super().read(length)
 
     def url(self) -> str:


### PR DESCRIPTION
When a file is read completely, calling `read()`again should return an empty output.

This was causing issues when using pyiceberg to read files on HF