### PR TITLE
Update mypy to 1.15.0 (current latest)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,5 @@
 [tool.mypy]
 ignore_missing_imports = true
-no_implicit_optional = true
-scripts_are_modules = true
 
 [tool.pytest.ini_options]
 # Add the specified `OPTS` to the set of command line arguments as if they had

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,8 @@ extras["typing"] = [
 
 extras["quality"] = [
     "ruff>=0.9.0",
-    "mypy==1.5.1",
+    "mypy>=1.14.1,<1.15.0; python_version=='3.8'",
+    "mypy==1.15.0; python_version>='3.9'",
     "libcst==1.4.0",
 ]
 

--- a/src/huggingface_hub/_oauth.py
+++ b/src/huggingface_hub/_oauth.py
@@ -310,7 +310,7 @@ def _add_oauth_routes(app: "fastapi.FastAPI", route_prefix: str) -> None:
             target_url = request.query_params.get("_target_url")
 
             # Build redirect URI with the same query params as before and bump nb_redirects count
-            query_params: dict[str, Union[int, str]] = {"_nb_redirects": nb_redirects + 1}
+            query_params: Dict[str, Union[int, str]] = {"_nb_redirects": nb_redirects + 1}
             if target_url:
                 query_params["_target_url"] = target_url
 

--- a/src/huggingface_hub/dataclasses.py
+++ b/src/huggingface_hub/dataclasses.py
@@ -269,8 +269,8 @@ def validated_field(
         metadata = {}
     metadata["validator"] = validator
     return field(  # type: ignore
-        default=default,
-        default_factory=default_factory,
+        default=default,  # type: ignore [arg-type]
+        default_factory=default_factory,  # type: ignore [arg-type]
         init=init,
         repr=repr,
         hash=hash,

--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -353,7 +353,7 @@ class ModelHubMixin:
     def _encode_arg(cls, arg: Any) -> Any:
         """Encode an argument into a JSON serializable format."""
         if is_dataclass(arg):
-            return asdict(arg)
+            return asdict(arg)  # type: ignore[arg-type]
         for type_, (encoder, _) in cls._hub_mixin_coders.items():
             if isinstance(arg, type_):
                 if arg is None:
@@ -767,7 +767,7 @@ class PyTorchModelHubMixin(ModelHubMixin):
     def _save_pretrained(self, save_directory: Path) -> None:
         """Save weights from a Pytorch model to a local directory."""
         model_to_save = self.module if hasattr(self, "module") else self  # type: ignore
-        save_model_as_safetensor(model_to_save, str(save_directory / constants.SAFETENSORS_SINGLE_FILE))
+        save_model_as_safetensor(model_to_save, str(save_directory / constants.SAFETENSORS_SINGLE_FILE))  # type: ignore [arg-type]
 
     @classmethod
     def _from_pretrained(

--- a/src/huggingface_hub/utils/insecure_hashlib.py
+++ b/src/huggingface_hub/utils/insecure_hashlib.py
@@ -29,6 +29,11 @@ import sys
 
 
 _kwargs = {"usedforsecurity": False} if sys.version_info >= (3, 9) else {}
-md5 = functools.partial(hashlib.md5, **_kwargs)
-sha1 = functools.partial(hashlib.sha1, **_kwargs)
-sha256 = functools.partial(hashlib.sha256, **_kwargs)
+if sys.version_info >= (3, 9):
+    md5 = functools.partial(hashlib.md5, usedforsecurity=False)
+    sha1 = functools.partial(hashlib.sha1, usedforsecurity=False)
+    sha256 = functools.partial(hashlib.sha256, usedforsecurity=False)
+else:
+    md5 = hashlib.md5
+    sha1 = hashlib.sha1
+    sha256 = hashlib.sha256

--- a/src/huggingface_hub/utils/insecure_hashlib.py
+++ b/src/huggingface_hub/utils/insecure_hashlib.py
@@ -28,7 +28,6 @@ import hashlib
 import sys
 
 
-_kwargs = {"usedforsecurity": False} if sys.version_info >= (3, 9) else {}
 if sys.version_info >= (3, 9):
     md5 = functools.partial(hashlib.md5, usedforsecurity=False)
     sha1 = functools.partial(hashlib.sha1, usedforsecurity=False)


### PR DESCRIPTION
For the record, mypy version is pinned to avoid unexpectedly breaking the CI on an update. But it has been quite some time now that we haven't updated it manually so let's do it (also, I need [`typing.Unpack`](https://docs.python.org/3/library/typing.html#typing.Unpack) for another PR which current mypy complains about). 

Since 1.15.0 does not support Python 3.8 anymore, I pinned the version to the latest available (1.14.1). No big deal anyway, we will surely remove Python 3.8 soon-ish.