### PR TITLE
[MCP] add support for SSE + HTTP

### DIFF
--- a/src/huggingface_hub/inference/_mcp/mcp_client.py
+++ b/src/huggingface_hub/inference/_mcp/mcp_client.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 # Type alias for tool names
 ToolName: TypeAlias = str
 
-ServerType: TypeAlias = Literal["stdio", "sse", "streamablehttp"]
+ServerType: TypeAlias = Literal["stdio", "sse", "http"]
 
 
 class StdioServerParameters_T(TypedDict):
@@ -96,12 +96,17 @@ class MCPClient:
     async def add_mcp_server(self, type: Literal["sse"], **params: Unpack[SSEServerParameters_T]): ...
 
     @overload
-    async def add_mcp_server(self, type: Literal["streamablehttp"], **params: Unpack[StreamableHTTPParameters_T]): ...
+    async def add_mcp_server(self, type: Literal["http"], **params: Unpack[StreamableHTTPParameters_T]): ...
 
     async def add_mcp_server(self, type: ServerType, **params: Any):
         """Connect to an MCP server
 
         Args:
+            type (`str`):
+                Type of the server to connect to. Can be one of:
+                - "stdio": Standard input/output server (local)
+                - "sse": Server-sent events (SSE) server
+                - "http": StreamableHTTP server
             **params: Server parameters that can be either:
                 - For stdio servers:
                     - command (str): The command to run the MCP server
@@ -147,7 +152,7 @@ class MCPClient:
                 if params.get(key) is not None:
                     client_kwargs[key] = params[key]
             read, write = await self.exit_stack.enter_async_context(sse_client(**client_kwargs))
-        elif type == "streamablehttp":
+        elif type == "http":
             # Handle StreamableHTTP server
             from mcp.client.streamable_http import streamablehttp_client
 

--- a/src/huggingface_hub/inference/_mcp/mcp_client.py
+++ b/src/huggingface_hub/inference/_mcp/mcp_client.py
@@ -1,10 +1,11 @@
 import json
 import logging
 from contextlib import AsyncExitStack
+from datetime import timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING, AsyncIterable, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, AsyncIterable, Dict, List, Literal, Optional, Union, overload
 
-from typing_extensions import TypeAlias
+from typing_extensions import NotRequired, TypeAlias, TypedDict, Unpack
 
 from ...utils._runtime import get_hf_hub_version
 from .._generated._async_client import AsyncInferenceClient
@@ -25,6 +26,30 @@ logger = logging.getLogger(__name__)
 
 # Type alias for tool names
 ToolName: TypeAlias = str
+
+ServerType: TypeAlias = Literal["stdio", "sse", "streamablehttp"]
+
+
+class StdioServerParameters_T(TypedDict):
+    command: str
+    args: NotRequired[List[str]]
+    env: NotRequired[Dict[str, str]]
+    cwd: NotRequired[Union[str, Path, None]]
+
+
+class SSEServerParameters_T(TypedDict):
+    url: str
+    headers: NotRequired[Dict[str, Any]]
+    timeout: NotRequired[float]
+    sse_read_timeout: NotRequired[float]
+
+
+class StreamableHTTPParameters_T(TypedDict):
+    url: str
+    headers: NotRequired[dict[str, Any]]
+    timeout: NotRequired[timedelta]
+    sse_read_timeout: NotRequired[timedelta]
+    terminate_on_close: NotRequired[bool]
 
 
 class MCPClient:
@@ -64,39 +89,79 @@ class MCPClient:
         await self.client.__aexit__(exc_type, exc_val, exc_tb)
         await self.cleanup()
 
-    async def add_mcp_server(
-        self,
-        *,
-        command: str,
-        args: Optional[List[str]] = None,
-        env: Optional[Dict[str, str]] = None,
-        cwd: Union[str, Path, None] = None,
-    ):
+    @overload
+    async def add_mcp_server(self, type: Literal["stdio"], **params: Unpack[StdioServerParameters_T]): ...
+
+    @overload
+    async def add_mcp_server(self, type: Literal["sse"], **params: Unpack[SSEServerParameters_T]): ...
+
+    @overload
+    async def add_mcp_server(self, type: Literal["streamablehttp"], **params: Unpack[StreamableHTTPParameters_T]): ...
+
+    async def add_mcp_server(self, type: ServerType, **params: Any):
         """Connect to an MCP server
 
         Args:
-            command (str):
-                The command to run the MCP server.
-            args (List[str], optional):
-                Arguments for the command.
-            env (Dict[str, str], optional):
-                Environment variables for the command. Default is to inherit the parent environment.
-            cwd (Union[str, Path, None], optional):
-                Working directory for the command. Default to current directory.
+            **params: Server parameters that can be either:
+                - For stdio servers:
+                    - command (str): The command to run the MCP server
+                    - args (List[str], optional): Arguments for the command
+                    - env (Dict[str, str], optional): Environment variables for the command
+                    - cwd (Union[str, Path, None], optional): Working directory for the command
+                - For SSE servers:
+                    - url (str): The URL of the SSE server
+                    - headers (Dict[str, Any], optional): Headers for the SSE connection
+                    - timeout (float, optional): Connection timeout
+                    - sse_read_timeout (float, optional): SSE read timeout
+                - For StreamableHTTP servers:
+                    - url (str): The URL of the StreamableHTTP server
+                    - headers (Dict[str, Any], optional): Headers for the StreamableHTTP connection
+                    - timeout (timedelta, optional): Connection timeout
+                    - sse_read_timeout (timedelta, optional): SSE read timeout
+                    - terminate_on_close (bool, optional): Whether to terminate on close
         """
         from mcp import ClientSession, StdioServerParameters
         from mcp import types as mcp_types
-        from mcp.client.stdio import stdio_client
 
-        logger.info(f"Connecting to MCP server with command: {command} {args}")
-        server_params = StdioServerParameters(
-            command=command,
-            args=args if args is not None else [],
-            env=env,
-            cwd=cwd,
-        )
+        # Determine server type and create appropriate parameters
+        if type == "stdio":
+            # Handle stdio server
+            from mcp.client.stdio import stdio_client
 
-        read, write = await self.exit_stack.enter_async_context(stdio_client(server_params))
+            logger.info(f"Connecting to stdio MCP server with command: {params['command']} {params.get('args', [])}")
+
+            client_kwargs = {"command": params["command"]}
+            for key in ["args", "env", "cwd"]:
+                if params.get(key) is not None:
+                    client_kwargs[key] = params[key]
+            server_params = StdioServerParameters(**client_kwargs)
+            read, write = await self.exit_stack.enter_async_context(stdio_client(server_params))
+        elif type == "sse":
+            # Handle SSE server
+            from mcp.client.sse import sse_client
+
+            logger.info(f"Connecting to SSE MCP server at: {params['url']}")
+
+            client_kwargs = {"url": params["url"]}
+            for key in ["headers", "timeout", "sse_read_timeout"]:
+                if params.get(key) is not None:
+                    client_kwargs[key] = params[key]
+            read, write = await self.exit_stack.enter_async_context(sse_client(**client_kwargs))
+        elif type == "streamablehttp":
+            # Handle StreamableHTTP server
+            from mcp.client.streamable_http import streamablehttp_client
+
+            logger.info(f"Connecting to StreamableHTTP MCP server at: {params['url']}")
+
+            client_kwargs = {"url": params["url"]}
+            for key in ["headers", "timeout", "sse_read_timeout", "terminate_on_close"]:
+                if params.get(key) is not None:
+                    client_kwargs[key] = params[key]
+            read, write, _ = await self.exit_stack.enter_async_context(streamablehttp_client(**client_kwargs))
+            # ^ TODO: should be handle `get_session_id_callback`? (function to retrieve the current session ID)
+        else:
+            raise ValueError(f"Unsupported server type: {type}")
+
         session = await self.exit_stack.enter_async_context(
             ClientSession(
                 read_stream=read,


### PR DESCRIPTION
Followed implementation from https://github.com/huggingface/huggingface.js/pull/1422

cc @evalstate if you can have a look at it

### How to test

```py
import os

from huggingface_hub import ChatCompletionInputMessage, ChatCompletionStreamOutput, MCPClient


async def main():
    async with MCPClient(
        provider="nebius",
        model="Qwen/Qwen2.5-72B-Instruct",
        api_key=os.environ["HF_TOKEN"],
    ) as client:
        await client.add_mcp_server(type="sse", url="https://evalstate-flux1-schnell.hf.space/gradio_api/mcp/sse")

        messages = [
            {
                "role": "user",
                "content": "Generate a picture of a cat on the moon",
            }
        ]

        async for chunk in client.process_single_turn_with_tools(messages):
            # Log messages
            if isinstance(chunk, ChatCompletionStreamOutput):
                delta = chunk.choices[0].delta
                if delta.content:
                    print(delta.content, end="")

            # Or tool calls
            elif isinstance(chunk, ChatCompletionInputMessage):
                print(
                    f"\nCalled tool '{chunk.name}'. Result: '{chunk.content if len(chunk.content) < 1000 else chunk.content[:1000] + '...'}'"
                )


if __name__ == "__main__":
    import asyncio

    asyncio.run(main())
```

### Output

```
Called tool 'evalstate_flux1_schnell_infer'. Result: '[Binary Content: Image image/webp, 38474 bytes]
The task is complete and the content accessible to the User
Image URL: https://evalstate-flux1-schnell.hf.space/gradio_api/file=/tmp/gradio/c178b5c1aae663d896b21cf6d0090e8e868e8a87e2d89b272243a9f135faf3ad/image.webp
42'
```

<img src="https://github.com/user-attachments/assets/dbab17f3-1bcb-4b64-a4bb-2045ee79a457" width="256">

