### PR TITLE
Do not fetch /preupload if already done in upload-large-folder

### DIFF
--- a/src/huggingface_hub/_local_folder.py
+++ b/src/huggingface_hub/_local_folder.py
@@ -149,6 +149,7 @@ class LocalUploadFileMetadata:
     should_ignore: Optional[bool] = None
     sha256: Optional[str] = None
     upload_mode: Optional[str] = None
+    remote_oid: Optional[str] = None
     is_uploaded: bool = False
     is_committed: bool = False
 
@@ -172,6 +173,9 @@ class LocalUploadFileMetadata:
 
                 if self.upload_mode is not None:
                     f.write(self.upload_mode)
+
+                if self.remote_oid is not None:
+                    f.write(self.remote_oid)
                 f.write("\n")
 
                 f.write(str(int(self.is_uploaded)) + "\n")
@@ -346,6 +350,9 @@ def read_upload_metadata(local_dir: Path, filename: str) -> LocalUploadFileMetad
                     if upload_mode not in (None, "regular", "lfs"):
                         raise ValueError(f"Invalid upload mode in metadata {paths.path_in_repo}: {upload_mode}")
 
+                    _remote_oid = f.readline().strip()
+                    remote_oid = None if _remote_oid == "" else _remote_oid
+
                     is_uploaded = bool(int(f.readline().strip()))
                     is_committed = bool(int(f.readline().strip()))
 
@@ -355,6 +362,7 @@ def read_upload_metadata(local_dir: Path, filename: str) -> LocalUploadFileMetad
                         should_ignore=should_ignore,
                         sha256=sha256,
                         upload_mode=upload_mode,
+                        remote_oid=remote_oid,
                         is_uploaded=is_uploaded,
                         is_committed=is_committed,
                     )

--- a/src/huggingface_hub/_local_folder.py
+++ b/src/huggingface_hub/_local_folder.py
@@ -56,9 +56,13 @@ import os
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from .utils import WeakFileLock
+
+
+if TYPE_CHECKING:
+    from ._commit_api import UploadMode
 
 
 logger = logging.getLogger(__name__)
@@ -148,7 +152,7 @@ class LocalUploadFileMetadata:
     timestamp: Optional[float] = None
     should_ignore: Optional[bool] = None
     sha256: Optional[str] = None
-    upload_mode: Optional[str] = None
+    upload_mode: Optional["UploadMode"] = None
     remote_oid: Optional[str] = None
     is_uploaded: bool = False
     is_committed: bool = False

--- a/src/huggingface_hub/_local_folder.py
+++ b/src/huggingface_hub/_local_folder.py
@@ -56,13 +56,9 @@ import os
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional
+from typing import Optional
 
 from .utils import WeakFileLock
-
-
-if TYPE_CHECKING:
-    from ._commit_api import UploadMode
 
 
 logger = logging.getLogger(__name__)
@@ -152,7 +148,7 @@ class LocalUploadFileMetadata:
     timestamp: Optional[float] = None
     should_ignore: Optional[bool] = None
     sha256: Optional[str] = None
-    upload_mode: Optional["UploadMode"] = None
+    upload_mode: Optional[str] = None
     remote_oid: Optional[str] = None
     is_uploaded: bool = False
     is_committed: bool = False

--- a/src/huggingface_hub/_upload_large_folder.py
+++ b/src/huggingface_hub/_upload_large_folder.py
@@ -582,7 +582,7 @@ def _build_hacky_operation(item: JOB_ITEM_T) -> HackyCommitOperationAdd:
     if metadata.sha256 is None:
         raise ValueError("sha256 must have been computed by now!")
     operation.upload_info = UploadInfo(sha256=bytes.fromhex(metadata.sha256), size=metadata.size, sample=sample)
-    operation._upload_mode = metadata.upload_mode
+    operation._upload_mode = metadata.upload_mode  # type: ignore[assignment]
     operation._should_ignore = metadata.should_ignore
     operation._remote_oid = metadata.remote_oid
     return operation

--- a/src/huggingface_hub/_upload_large_folder.py
+++ b/src/huggingface_hub/_upload_large_folder.py
@@ -354,16 +354,17 @@ def _worker_job(
                 status.nb_workers_get_upload_mode -= 1
 
         elif job == WorkerJob.PREUPLOAD_LFS:
-            item = items[0]  # single item
             try:
-                _preupload_lfs(item, api=api, repo_id=repo_id, repo_type=repo_type, revision=revision)
-                status.queue_commit.put(item)
+                _preupload_lfs(items, api=api, repo_id=repo_id, repo_type=repo_type, revision=revision)
+                for item in items:
+                    status.queue_commit.put(item)
             except KeyboardInterrupt:
                 raise
             except Exception as e:
                 logger.error(f"Failed to preupload LFS: {e}")
                 traceback.format_exc()
-                status.queue_preupload_lfs.put(item)
+                for item in items:
+                    status.queue_preupload_lfs.put(item)
 
             with status.lock:
                 status.nb_workers_preupload_lfs -= 1
@@ -422,7 +423,7 @@ def _determine_next_job(status: LargeUploadStatus) -> Optional[Tuple[WorkerJob, 
         elif status.queue_preupload_lfs.qsize() > 0 and status.nb_workers_preupload_lfs == 0:
             status.nb_workers_preupload_lfs += 1
             logger.debug("Job: preupload LFS (no other worker preuploading LFS)")
-            return (WorkerJob.PREUPLOAD_LFS, _get_one(status.queue_preupload_lfs))
+            return (WorkerJob.PREUPLOAD_LFS, _get_n(status.queue_preupload_lfs, 100))
 
         # 5. Compute sha256 if at least 1 file and no worker is computing sha256
         elif status.queue_sha256.qsize() > 0 and status.nb_workers_sha256 == 0:
@@ -443,7 +444,7 @@ def _determine_next_job(status: LargeUploadStatus) -> Optional[Tuple[WorkerJob, 
         ):
             status.nb_workers_preupload_lfs += 1
             logger.debug("Job: preupload LFS")
-            return (WorkerJob.PREUPLOAD_LFS, _get_one(status.queue_preupload_lfs))
+            return (WorkerJob.PREUPLOAD_LFS, _get_n(status.queue_preupload_lfs, 100))
 
         # 8. Compute sha256 if at least 1 file
         elif status.queue_sha256.qsize() > 0:
@@ -531,19 +532,20 @@ def _get_upload_mode(items: List[JOB_ITEM_T], api: "HfApi", repo_id: str, repo_t
         metadata.save(paths)
 
 
-def _preupload_lfs(item: JOB_ITEM_T, api: "HfApi", repo_id: str, repo_type: str, revision: str) -> None:
+def _preupload_lfs(items: List[JOB_ITEM_T], api: "HfApi", repo_id: str, repo_type: str, revision: str) -> None:
     """Preupload LFS file and update metadata."""
-    paths, metadata = item
-    addition = _build_hacky_operation(item)
+    additions = [_build_hacky_operation(item) for item in items]
     api.preupload_lfs_files(
         repo_id=repo_id,
         repo_type=repo_type,
         revision=revision,
-        additions=[addition],
+        additions=additions,
     )
 
-    metadata.is_uploaded = True
-    metadata.save(paths)
+    for item in items:
+        paths, metadata = item
+        metadata.is_uploaded = True
+        metadata.save(paths)
 
 
 def _commit(items: List[JOB_ITEM_T], api: "HfApi", repo_id: str, repo_type: str, revision: str) -> None:

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -4421,20 +4421,23 @@ class HfApi:
         new_additions = [addition for addition in additions if not addition._is_uploaded]
 
         # Check which new files are LFS
-        try:
-            _fetch_upload_modes(
-                additions=new_additions,
-                repo_type=repo_type,
-                repo_id=repo_id,
-                headers=headers,
-                revision=revision,
-                endpoint=self.endpoint,
-                create_pr=create_pr or False,
-                gitignore_content=gitignore_content,
-            )
-        except RepositoryNotFoundError as e:
-            e.append_to_message(_CREATE_COMMIT_NO_REPO_ERROR_MESSAGE)
-            raise
+        # For some items, we might have already fetched the upload mode (in case of upload_large_folder)
+        additions_no_upload_mode = [addition for addition in new_additions if addition._upload_mode is None]
+        if len(additions_no_upload_mode) > 0:
+            try:
+                _fetch_upload_modes(
+                    additions=additions_no_upload_mode,
+                    repo_type=repo_type,
+                    repo_id=repo_id,
+                    headers=headers,
+                    revision=revision,
+                    endpoint=self.endpoint,
+                    create_pr=create_pr or False,
+                    gitignore_content=gitignore_content,
+                )
+            except RepositoryNotFoundError as e:
+                e.append_to_message(_CREATE_COMMIT_NO_REPO_ERROR_MESSAGE)
+                raise
 
         # Filter out regular files
         new_lfs_additions = [addition for addition in new_additions if addition._upload_mode == "lfs"]


### PR DESCRIPTION
_Originally from @Kakulukian on [slack](https://huggingface.slack.com/archives/C02V5EA0A95/p1747837459269209) (private):_

> From the end of last weekend until yesterday, we experienced increased latency on the hub. This appears to be connected to how the upload_large_folder method works. I've identified that one user uploaded approximately ~200,000 files using this method.
According to my understanding of the code, uploading via this method requires a call to the preupload endpoint for each file (right?). The issue is that as a repository grows more significant (commits or files), this method becomes progressively slower, particularly when the calls aren't batched
Would it be possible to also implement file batching for this endpoint with a minimum threshold?

