### PR TITLE
[Internal] make `hf-xet` (again) a required dependency

### DIFF
--- a/.github/conda/meta.yaml
+++ b/.github/conda/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - typing-extensions
     - packaging
     - pyyaml
+    - hf-xet
   run:
     - python
     - pip
@@ -30,7 +31,7 @@ requirements:
     - typing-extensions
     - packaging
     - pyyaml
-
+    - hf-xet
 test:
   imports:
     - huggingface_hub

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -94,12 +94,14 @@ jobs:
               sudo apt install -y graphviz
               uv pip install "huggingface_hub[tensorflow-testing] @ ."
               ;;
-            
-            "Xet only")
-              uv pip install "huggingface_hub[hf_xet] @ ."
-              ;;
 
           esac
+
+          # If not "Xet only", we want to test upload/download with regular LFS workflow
+          # => uninstall hf_xet to make sure we are not using it.
+          if [[ "${{ matrix.test_name }}" != "Xet only" ]]; then
+            uv pip uninstall hf_xet
+          fi
 
       # Run tests
       - name: Run tests

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 install_requires = [
     "filelock",
     "fsspec>=2023.5.0",
-    "hf-xet>=1.1.1,<2.0.0; platform_machine=='x86_64' or platform_machine=='amd64' or platform_machine=='arm64' or platform_machine=='aarch64'",
+    "hf-xet>=1.1.2,<2.0.0; platform_machine=='x86_64' or platform_machine=='amd64' or platform_machine=='arm64' or platform_machine=='aarch64'",
     "packaging>=20.9",
     "pyyaml>=5.1",
     "requests",
@@ -63,7 +63,7 @@ extras["tensorflow-testing"] = [
     "keras<3.0",
 ]
 
-extras["hf_xet"] = ["hf-xet>=1.1.1,<2.0.0"]
+extras["hf_xet"] = ["hf-xet>=1.1.2,<2.0.0"]
 
 extras["mcp"] = [
     "mcp>=1.8.0",

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ def get_version() -> str:
 install_requires = [
     "filelock",
     "fsspec>=2023.5.0",
+    "hf-xet>=1.1.1,<2.0.0; platform_machine=='x86_64' or platform_machine=='amd64' or platform_machine=='arm64' or platform_machine=='aarch64'",
     "packaging>=20.9",
     "pyyaml>=5.1",
     "requests",


### PR DESCRIPTION
Follow-up PR after #3079 in which we made `hf-xet` optional due to reports about the binaries being too big on Linux platform. Thanks to the Xet team, now the installed binaries of `hf-xet` are much much smaller! (eg. Linux went from ~96MB → ~14MB). Release notes: https://github.com/huggingface/xet-core/releases/tag/v1.1.2.

Given these improvements, we can now make `hf-xet` a required dependency again.


cc @Vaibhavs10 @jsulz 


