### PR TITLE
[HfApi] Collections in collections

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -1210,8 +1210,6 @@ class CollectionItem:
         self.position: int = position
         self.note: str = note["text"] if note is not None else None
 
-        self.__dict__.update(**kwargs)
-
 
 @dataclass
 class Collection:

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -135,7 +135,7 @@ from .utils.endpoint_helpers import _is_emission_within_threshold
 
 
 R = TypeVar("R")  # Return type
-CollectionItemType_T = Literal["model", "dataset", "space", "paper"]
+CollectionItemType_T = Literal["model", "dataset", "space", "paper", "collection"]
 
 ExpandModelProperty_T = Literal[
     "author",
@@ -1169,16 +1169,16 @@ class SpaceInfo:
 @dataclass
 class CollectionItem:
     """
-    Contains information about an item of a Collection (model, dataset, Space or paper).
+    Contains information about an item of a Collection (model, dataset, Space, paper or collection).
 
     Attributes:
         item_object_id (`str`):
             Unique ID of the item in the collection.
         item_id (`str`):
-            ID of the underlying object on the Hub. Can be either a repo_id or a paper id
-            e.g. `"jbilcke-hf/ai-comic-factory"`, `"2307.09288"`.
+            ID of the underlying object on the Hub. Can be either a repo_id, a paper id or a collection slug.
+            e.g. `"jbilcke-hf/ai-comic-factory"`, `"2307.09288"`, `"celinah/cerebras-function-calling-682607169c35fbfa98b30b9a"`.
         item_type (`str`):
-            Type of the underlying object. Can be one of `"model"`, `"dataset"`, `"space"` or `"paper"`.
+            Type of the underlying object. Can be one of `"model"`, `"dataset"`, `"space"`, `"paper"` or `"collection"`.
         position (`int`):
             Position of the item in the collection.
         note (`str`, *optional*):
@@ -1192,13 +1192,25 @@ class CollectionItem:
     note: Optional[str] = None
 
     def __init__(
-        self, _id: str, id: str, type: CollectionItemType_T, position: int, note: Optional[Dict] = None, **kwargs
+        self,
+        _id: str,
+        id: str,
+        type: CollectionItemType_T,
+        position: int,
+        note: Optional[Dict] = None,
+        **kwargs,
     ) -> None:
         self.item_object_id: str = _id  # id in database
         self.item_id: str = id  # repo_id or paper id
+        # if the item is a collection, override item_id with the slug
+        slug = kwargs.get("slug")
+        if slug is not None:
+            self.item_id = slug  # collection slug
         self.item_type: CollectionItemType_T = type
         self.position: int = position
         self.note: str = note["text"] if note is not None else None
+
+        self.__dict__.update(**kwargs)
 
 
 @dataclass

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -4130,6 +4130,13 @@ class CollectionAPITest(HfApiCommonTest):
         self._api.delete_repo(dataset_id, repo_type="dataset")
         self._api.delete_collection(collection.slug)
 
+    @with_production_testing
+    def test_collection_items_with_collections(self) -> None:
+        collection = HfApi().get_collection("celinah/inference-providers-function-calling-6826023e8ae9b24b3039ee5f")
+        assert len(collection.items) > 1
+        assert collection.items[0].item_type == "collection"
+        assert collection.items[0].item_id.startswith("celinah/")
+
 
 class AccessRequestAPITest(HfApiCommonTest):
     def setUp(self) -> None:


### PR DESCRIPTION
Originally reported by @Xeophon in [this gist](https://gist.github.com/Xeophon/8293c2f861bcd9980d891492498b8f12), it wasn't possible to access the collection slug when a collection item was itself a collection, and this was flagged internally by @Vaibhavs10 in [this Slack message](https://huggingface.slack.com/archives/C02V5EA0A95/p1748068431965789).

This PR enables proper client-side handling of collections that include collections as items. When the item type is "collection", we now set `item_id` to the collection’s slug, ensuring consistency with how other item types (model, dataset, space, paper) are handled.

```python
from huggingface_hub import get_collection

# a collection with only collection items
collection_slug = "celinah/inference-providers-function-calling-6826023e8ae9b24b3039ee5f"

print(f"Fetching collection: {collection_slug}")
collection = get_collection(collection_slug)
for i, item in enumerate(collection.items):
    print(f"Item {i + 1}:")
    print(f"  Collection Slug: {item.item_id}")
    print(f"  Object ID: {item.item_object_id}")
    print(f"  Type: {item.item_type}")
```

for reference, server-side PR [here](https://github.com/huggingface-internal/moon-landing/issues/13586) (private link).