### PR TITLE
[MCP] Add local/remote endpoint inference support 

### DIFF
--- a/src/huggingface_hub/inference/_mcp/agent.py
+++ b/src/huggingface_hub/inference/_mcp/agent.py
@@ -20,7 +20,7 @@ class Agent(MCPClient):
     </Tip>
 
     Args:
-        model (`str`):
+        model (`str`, *optional*):
             The model to run inference with. Can be a model id hosted on the Hugging Face Hub, e.g. `meta-llama/Meta-Llama-3-8B-Instruct`
             or a URL to a deployed Inference Endpoint or other local or remote endpoint.
         servers (`Iterable[Dict]`):
@@ -28,6 +28,8 @@ class Agent(MCPClient):
         provider (`str`, *optional*):
             Name of the provider to use for inference. Defaults to "auto" i.e. the first of the providers available for the model, sorted by the user's order in https://hf.co/settings/inference-providers.
             If model is a URL or `base_url` is passed, then `provider` is not used.
+        base_url (`str`, *optional*):
+            The base URL to run inference. Defaults to None.
         api_key (`str`, *optional*):
             Token to use for authentication. Will default to the locally Hugging Face saved token if not provided. You can also use your own provider API key to interact directly with the provider's service.
         prompt (`str`, *optional*):
@@ -37,13 +39,14 @@ class Agent(MCPClient):
     def __init__(
         self,
         *,
-        model: str,
+        model: Optional[str] = None,
         servers: Iterable[Dict],
         provider: Optional[PROVIDER_OR_POLICY_T] = None,
+        base_url: Optional[str] = None,
         api_key: Optional[str] = None,
         prompt: Optional[str] = None,
     ):
-        super().__init__(model=model, provider=provider, api_key=api_key)
+        super().__init__(model=model, provider=provider, base_url=base_url, api_key=api_key)
         self._servers_cfg = list(servers)
         self.messages: List[Union[Dict, ChatCompletionInputMessage]] = [
             {"role": "system", "content": prompt or DEFAULT_SYSTEM_PROMPT}

--- a/src/huggingface_hub/inference/_mcp/mcp_client.py
+++ b/src/huggingface_hub/inference/_mcp/mcp_client.py
@@ -69,6 +69,8 @@ class MCPClient:
         provider (`str`, *optional*):
             Name of the provider to use for inference. Defaults to "auto" i.e. the first of the providers available for the model, sorted by the user's order in https://hf.co/settings/inference-providers.
             If model is a URL or `base_url` is passed, then `provider` is not used.
+        base_url (`str`, *optional*):
+            The base URL to run inference. Defaults to None.
         api_key (`str`, `optional`):
             Token to use for authentication. Will default to the locally Hugging Face saved token if not provided. You can also use your own provider API key to interact directly with the provider's service.
     """
@@ -76,17 +78,23 @@ class MCPClient:
     def __init__(
         self,
         *,
-        model: str,
+        model: Optional[str] = None,
         provider: Optional[PROVIDER_OR_POLICY_T] = None,
+        base_url: Optional[str] = None,
         api_key: Optional[str] = None,
     ):
         # Initialize MCP sessions as a dictionary of ClientSession objects
         self.sessions: Dict[ToolName, "ClientSession"] = {}
         self.exit_stack = AsyncExitStack()
         self.available_tools: List[ChatCompletionInputTool] = []
-
-        # Initialize the AsyncInferenceClient
-        self.client = AsyncInferenceClient(model=model, provider=provider, api_key=api_key)
+        # To be able to send the model in the payload if `base_url`` is provided
+        self.payload_model = model
+        self.client = AsyncInferenceClient(
+            model=None if base_url is not None else model,
+            provider=provider,
+            api_key=api_key,
+            base_url=base_url,
+        )
 
     async def __aenter__(self):
         """Enter the context manager"""
@@ -244,6 +252,7 @@ class MCPClient:
 
         # Create the streaming request
         response = await self.client.chat.completions.create(
+            model=self.payload_model,
             messages=messages,
             tools=tools,
             tool_choice="auto",

--- a/src/huggingface_hub/inference/_mcp/mcp_client.py
+++ b/src/huggingface_hub/inference/_mcp/mcp_client.py
@@ -87,7 +87,7 @@ class MCPClient:
         self.sessions: Dict[ToolName, "ClientSession"] = {}
         self.exit_stack = AsyncExitStack()
         self.available_tools: List[ChatCompletionInputTool] = []
-        # To be able to send the model in the payload if `base_url`` is provided
+        # To be able to send the model in the payload if `base_url` is provided
         self.payload_model = model
         self.client = AsyncInferenceClient(
             model=None if base_url is not None else model,

--- a/src/huggingface_hub/inference/_mcp/mcp_client.py
+++ b/src/huggingface_hub/inference/_mcp/mcp_client.py
@@ -88,6 +88,8 @@ class MCPClient:
         self.exit_stack = AsyncExitStack()
         self.available_tools: List[ChatCompletionInputTool] = []
         # To be able to send the model in the payload if `base_url` is provided
+        if model is None and base_url is None:
+            raise ValueError("At least one of `model` or `base_url` should be set in `MCPClient`.")
         self.payload_model = model
         self.client = AsyncInferenceClient(
             model=None if base_url is not None else model,


### PR DESCRIPTION
This PR adds support for local/remote endpoint inference with `tiny-agents`. 

Tested the PR with @Vaibhavs10's [experiments-with-mcp](https://github.com/Vaibhavs10/experiments-with-mcp) and a remote endpoint (e.g. https://router.huggingface.co/nebius/v1/chat/completions) ✅ 