### PR TITLE
Make hf-xet more silent

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1706,7 +1706,7 @@ def _download_to_tmp_and_move(
             _check_disk_space(expected_size, destination_path.parent)
 
         if xet_file_data is not None and is_xet_available():
-            logger.info("Xet Storage is enabled for this repo. Downloading file from Xet Storage..")
+            logger.debug("Xet Storage is enabled for this repo. Downloading file from Xet Storage..")
             xet_get(
                 incomplete_path=incomplete_path,
                 xet_file_data=xet_file_data,

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -4482,7 +4482,7 @@ class HfApi:
             isinstance(addition.path_or_fileobj, io.BufferedIOBase) for addition in new_lfs_additions_to_upload
         )
         if xet_enabled and not has_buffered_io_data and is_xet_available():
-            logger.info("Uploading files using Xet Storage..")
+            logger.debug("Uploading files using Xet Storage..")
             _upload_xet_files(**upload_kwargs, create_pr=create_pr)  # type: ignore [arg-type]
         else:
             if xet_enabled and is_xet_available():


### PR DESCRIPTION
This PR switches the `we are using Xet` log message from `INFO` to `DEBUG`. Now that Xet is installed by default and enabled in many repos, I don't think it's _that_ special anymore. And on the contrary I find the output of `huggingface-cli download` veeery verbose with all these messages been printed out to the output.


(still relevant to keep them as `DEBUG` for debug purposes :smile:)