### PR TITLE
Handle empty MCP tool call argument

### DIFF
--- a/src/huggingface_hub/inference/_mcp/mcp_client.py
+++ b/src/huggingface_hub/inference/_mcp/mcp_client.py
@@ -286,7 +286,10 @@ class MCPClient:
                 for tool_call in delta.tool_calls:
                     # Aggregate chunks into tool calls
                     if tool_call.index not in final_tool_calls:
-                        if tool_call.function.arguments is None:  # Corner case (depends on provider)
+                        if (
+                            tool_call.function.arguments is None
+                            or tool_call.function.arguments == "{}"
+                        ):  # Corner case (depends on provider)
                             tool_call.function.arguments = ""
                         final_tool_calls[tool_call.index] = tool_call
 


### PR DESCRIPTION
# Description

Some OpenAI-compatible providers may generate tool calls with empty arguments represented by an empty JSON object `"{}"` instead of `None`. This PR addresses that corner case.