### PR TITLE
Improve Handling of MCP Tool Call Arguments

### DIFF
--- a/src/huggingface_hub/inference/_mcp/mcp_client.py
+++ b/src/huggingface_hub/inference/_mcp/mcp_client.py
@@ -286,11 +286,14 @@ class MCPClient:
                 for tool_call in delta.tool_calls:
                     # Aggregate chunks into tool calls
                     if tool_call.index not in final_tool_calls:
-                        if tool_call.function.arguments is None:  # Corner case (depends on provider)
+                        if (
+                            tool_call.function.arguments is None
+                            or tool_call.function.arguments == "{}"
+                        ):  # Corner case (depends on provider)
                             tool_call.function.arguments = ""
                         final_tool_calls[tool_call.index] = tool_call
 
-                    if tool_call.function.arguments:
+                    elif tool_call.function.arguments:
                         final_tool_calls[tool_call.index].function.arguments += tool_call.function.arguments
 
             # Optionally exit early if no tools in first chunks


### PR DESCRIPTION
# Description

This PR handles two issues:

### Handle empty MCP tool call arguments
Some OpenAI-compatible providers may generate tool calls with empty arguments represented by an empty JSON object "{}" instead of None. This PR addresses that corner case.

### Duplicated Arguments
The code aggregates tool call chunks by index. The first `if` checks if it's the first chunk and initializes `final_tool_calls[tool_call.index]` with the current tool_call, including its arguments. The second `if` appends arguments regardless, causing duplication on the first chunk. Changing the second `if` to `elif` ensures arguments are only appended for subsequent chunks, not during initialization.