### PR TITLE
[MCP] Fix vestigial token yield on early exit

### DIFF
--- a/src/huggingface_hub/inference/_mcp/mcp_client.py
+++ b/src/huggingface_hub/inference/_mcp/mcp_client.py
@@ -272,7 +272,6 @@ class MCPClient:
 
         # Read from stream
         async for chunk in response:
-
             num_of_chunks += 1
             delta = chunk.choices[0].delta if chunk.choices and len(chunk.choices) > 0 else None
             if not delta:

--- a/src/huggingface_hub/inference/_mcp/mcp_client.py
+++ b/src/huggingface_hub/inference/_mcp/mcp_client.py
@@ -272,8 +272,6 @@ class MCPClient:
 
         # Read from stream
         async for chunk in response:
-            # Yield each chunk to caller
-            yield chunk
 
             num_of_chunks += 1
             delta = chunk.choices[0].delta if chunk.choices and len(chunk.choices) > 0 else None
@@ -303,6 +301,9 @@ class MCPClient:
             # Optionally exit early if no tools in first chunks
             if exit_if_first_chunk_no_tool and num_of_chunks <= 2 and len(final_tool_calls) == 0:
                 return
+
+            # Yield each chunk to caller
+            yield chunk
 
         if message["content"]:
             messages.append(message)


### PR DESCRIPTION
# Description

### Overview
This PR fixes a minor issue where a vestigial token may be yielded despite the early exit mechanism being triggered.

### Detailed description
The CLI's early exit mechanism goal is to, under some circunstances, exit if the first chunk received does not contain a tool call. This behavior is desirable in some scenarios.

The only issue with the current implementation is that the early exit is triggered only after a token from the first chunk has already been yielded. As a result, a vestigial token is printed to the user's CLI.

Example: 
```
Agent loaded with 5 tools:
 • read_query
 • write_query
 • create_table
 • list_tables
 • describe_table
» Which tables are available?
[{"name": "list_tables", "arguments": {}}]<Tool ->list_tables {} 

Tool -
[
  {
    "name": "products"
  }
]

The available table is "products". [
```

As shown above, the final `[` token is displayed regardless of the early exit. 

> Note: One could definitely argue that frameworks which include the tokens corresponding to the tool call as part of the generated text should set `exit_if_first_chunk_no_tool` to `False`. That being said, we should never have vestigial tokens on early exits anyway.

### Proposed solution

Only yield tokens after checking whether we should exit early.



