### PR TITLE
Fix question_answering

### DIFF
--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -1502,7 +1502,7 @@ class InferenceClient:
         model_id = model or self.model
         provider_helper = get_provider_helper(self.provider, task="question-answering", model=model_id)
         request_parameters = provider_helper.prepare_request(
-            inputs=None,
+            inputs={"question": question, "context": context},
             parameters={
                 "align_to_words": align_to_words,
                 "doc_stride": doc_stride,


### PR DESCRIPTION
Fix [#3131](https://github.com/huggingface/huggingface_hub/issues/3131).

PR fixes raising 400 HTTP error while you call HF inference API for [question answering model](https://huggingface.co/tasks/question-answering).