### PR TITLE
[MCP] `asyncio.wait()` does not accept bare coroutines

### DIFF
--- a/src/huggingface_hub/inference/_mcp/_cli_hacks.py
+++ b/src/huggingface_hub/inference/_mcp/_cli_hacks.py
@@ -73,8 +73,9 @@ async def _async_prompt(exit_event: asyncio.Event, prompt: str = "» ") -> str:
 
         # Wait for user input or exit event
         # Wait until either the user hits enter or exit_event is set
+        exit_task = asyncio.create_task(exit_event.wait())
         await asyncio.wait(
-            [future, exit_event.wait()],
+            [future, exit_task],
             return_when=asyncio.FIRST_COMPLETED,
         )
 


### PR DESCRIPTION
This should fix issues reported in https://huggingface.co/blog/python-tiny-agents#683c2893453e60939f704bb4.
The bug was introduced by my _dumb_ comment in [#3125](https://github.com/huggingface/huggingface_hub/pull/3125#discussion_r2111284595) (Copilot had it right 🙄). Of course, `asyncio.wait()` refuses bare coroutines, every element should be a `Future` or a `Task`.
Disclaimer: i was testing the PR #3125 in a Python 3.10 environment where it happened to work fine, but I probably missed a `DeprecationWarning`.