### PR TITLE
[Inference Providers] Raise warning if provider's status is in error mode

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -716,7 +716,7 @@ class InferenceProviderMapping:
     provider: "PROVIDER_T"  # Provider name
     hf_model_id: str  # ID of the model on the Hugging Face Hub
     provider_id: str  # ID of the model on the provider's side
-    status: Literal["live", "staging"]
+    status: Literal["error", "live", "staging"]
     task: str
 
     adapter: Optional[str] = None

--- a/src/huggingface_hub/inference/_providers/_common.py
+++ b/src/huggingface_hub/inference/_providers/_common.py
@@ -146,8 +146,8 @@ class TaskProviderHelper:
             )
         if provider_mapping.status == "error":
             logger.warning(
-                f"Inference with Model {model} through Provider {self.provider} might fail. "
-                "This is related to the model's status on the Provider's side."
+                f"Our latest automated health check on model '{model}' for provider '{self.provider}' did not complete successfully.  "
+                "Inference call might fail."
             )
         return provider_mapping
 

--- a/src/huggingface_hub/inference/_providers/_common.py
+++ b/src/huggingface_hub/inference/_providers/_common.py
@@ -144,6 +144,11 @@ class TaskProviderHelper:
             logger.warning(
                 f"Model {model} is in staging mode for provider {self.provider}. Meant for test purposes only."
             )
+        if provider_mapping.status == "error":
+            logger.warning(
+                f"Inference with Model {model} through Provider {self.provider} might fail. "
+                "This is related to the model's status on the Provider's side."
+            )
         return provider_mapping
 
     def _prepare_headers(self, headers: Dict, api_key: str) -> Dict:


### PR DESCRIPTION
following server-side [update](https://github.com/huggingface-internal/moon-landing/pull/13875) (internal) which introduced automatic validation of model inference per provider, a provider can now enter an "error" state if inference fails, either due to incorrect provider mapping or because the model is no longer served by that provider.