### PR TITLE
[Tiny agents] Add tool call to messages

### DIFF
--- a/src/huggingface_hub/inference/_mcp/mcp_client.py
+++ b/src/huggingface_hub/inference/_mcp/mcp_client.py
@@ -319,14 +319,16 @@ class MCPClient:
             if final_tool_calls:
                 message["tool_calls"] = []
                 for tool_call in final_tool_calls.values():
-                    message["tool_calls"].append({
-                        "id": tool_call.id,
-                        "type": "function",
-                        "function": {
-                            "name": tool_call.function.name,
-                            "arguments": tool_call.function.arguments or "{}"
+                    message["tool_calls"].append(
+                        {
+                            "id": tool_call.id,
+                            "type": "function",
+                            "function": {
+                                "name": tool_call.function.name,
+                                "arguments": tool_call.function.arguments or "{}",
+                            },
                         }
-                    })
+                    )
             messages.append(message)
 
         # Process tool calls one by one

--- a/src/huggingface_hub/inference/_mcp/mcp_client.py
+++ b/src/huggingface_hub/inference/_mcp/mcp_client.py
@@ -257,15 +257,6 @@ class MCPClient:
         if exit_loop_tools is not None:
             tools = [*exit_loop_tools, *self.available_tools]
 
-        print("Number of messages: ", len(messages))
-        for message in messages:
-            print("Role:", message["role"])
-            if message["role"] == "system":
-                print("Content: ", message["content"][:50])
-            else:
-                print("Content: ", message["content"])
-            print("--------------------------------")
-
         # Create the streaming request
         response = await self.client.chat.completions.create(
             model=self.payload_model,

--- a/src/huggingface_hub/inference/_mcp/mcp_client.py
+++ b/src/huggingface_hub/inference/_mcp/mcp_client.py
@@ -266,7 +266,7 @@ class MCPClient:
             stream=True,
         )
 
-        message = {"role": "unknown", "content": ""}
+        message: Dict[str, Any] = {"role": "unknown", "content": ""}
         final_tool_calls: Dict[int, ChatCompletionStreamOutputDeltaToolCall] = {}
         num_of_chunks = 0
 
@@ -306,20 +306,24 @@ class MCPClient:
 
         # Add the assistant message with tool calls (if any) to messages
         if message["content"] or final_tool_calls:
+            # if the role is unknown, set it to assistant
+            if message.get("role") == "unknown":
+                message["role"] = "assistant"
             # Convert final_tool_calls to the format expected by OpenAI
             if final_tool_calls:
-                message["tool_calls"] = []
-                for tool_call in final_tool_calls.values():
-                    message["tool_calls"].append(
+                tool_calls_list: List[Dict[str, Any]] = []
+                for tc in final_tool_calls.values():
+                    tool_calls_list.append(
                         {
-                            "id": tool_call.id,
+                            "id": tc.id,
                             "type": "function",
                             "function": {
-                                "name": tool_call.function.name,
-                                "arguments": tool_call.function.arguments or "{}",
+                                "name": tc.function.name,
+                                "arguments": tc.function.arguments or "{}",
                             },
                         }
                     )
+                message["tool_calls"] = tool_calls_list
             messages.append(message)
 
         # Process tool calls one by one


### PR DESCRIPTION
If I understand [this guide](https://platform.openai.com/docs/guides/function-calling?api-mode=chat) by OpenAI on function calling correctly, the assistant's tool call needs to be appended to the list of messages before the tool call result. 

Simple example, for this agent: https://huggingface.co/datasets/tiny-agents/tiny-agents/tree/main/julien-c/flux-schnell-generator

Before this PR:
```
role: system, content: "You are an AI assistant"
role: user, content: "Please generate an image of a cat"
role: assistant, content: "Sure let me do that"
role: tool, content: "Image created"
role: assistant, content: "Here is your image!"
```

After this PR:
```
role: system, content: "You are an AI assistant"
role: user, content: "Please generate an image of a cat"
role: assistant, content: None, tool_calls: {function_name: "flux1_schnell_infer", args: "prompt": "a cat"}
role: tool, content: "Image created"
role: assistant, content: "Here is your image!"
```