### PR TITLE
fix(inference_endpoints): use GET `healthRoute` instead of GET / to check status

### DIFF
--- a/src/huggingface_hub/_inference_endpoints.py
+++ b/src/huggingface_hub/_inference_endpoints.py
@@ -220,7 +220,7 @@ class InferenceEndpoint:
                 )
             if self.status == InferenceEndpointStatus.RUNNING and self.url is not None:
                 # Verify the endpoint is actually reachable
-                response = get_session().get(self.url, headers=self._api._build_hf_headers(token=self._token))
+                response = get_session().get(f"{self.url}/health", headers=self._api._build_hf_headers(token=self._token))
                 if response.status_code == 200:
                     logger.info("Inference Endpoint is ready to be used.")
                     return self

--- a/src/huggingface_hub/_inference_endpoints.py
+++ b/src/huggingface_hub/_inference_endpoints.py
@@ -221,6 +221,9 @@ class InferenceEndpoint:
                     f"Inference Endpoint {self.name} failed to update. Please check the logs for more information."
                 )
             if self.status == InferenceEndpointStatus.RUNNING and self.url is not None:
+                # Update additional utility variables compute from the raw payload
+                self._health_url = f"{self.url.rstrip('/')}/{self.health_route.lstrip('/')}"
+
                 # Verify the endpoint is actually reachable
                 response = get_session().get(self._health_url, headers=self._api._build_hf_headers(token=self._token))
                 if response.status_code == 200:
@@ -243,9 +246,6 @@ class InferenceEndpoint:
         obj = self._api.get_inference_endpoint(name=self.name, namespace=self.namespace, token=self._token)  # type: ignore [arg-type]
         self.raw = obj.raw
         self._populate_from_raw()
-
-        # Update additional utility variables compute from the raw payload
-        self._health_url = f"{self.url.rstrip('/')}/{self.health_route.lstrip('/')}"
         return self
 
     def update(

--- a/src/huggingface_hub/_inference_endpoints.py
+++ b/src/huggingface_hub/_inference_endpoints.py
@@ -100,6 +100,7 @@ class InferenceEndpoint:
     namespace: str
     repository: str = field(init=False)
     status: InferenceEndpointStatus = field(init=False)
+    health_url: str = field(init=False)
     url: Optional[str] = field(init=False)
 
     # Other fields

--- a/src/huggingface_hub/_inference_endpoints.py
+++ b/src/huggingface_hub/_inference_endpoints.py
@@ -220,8 +220,6 @@ class InferenceEndpoint:
                     f"Inference Endpoint {self.name} failed to update. Please check the logs for more information."
                 )
             if self.status == InferenceEndpointStatus.RUNNING and self.url is not None:
-                # Update additional utility variables compute from the raw payload
-
                 # Verify the endpoint is actually reachable
                 _health_url = f"{self.url.rstrip('/')}/{self.health_route.lstrip('/')}"
                 response = get_session().get(_health_url, headers=self._api._build_hf_headers(token=self._token))

--- a/src/huggingface_hub/_inference_endpoints.py
+++ b/src/huggingface_hub/_inference_endpoints.py
@@ -220,7 +220,9 @@ class InferenceEndpoint:
                 )
             if self.status == InferenceEndpointStatus.RUNNING and self.url is not None:
                 # Verify the endpoint is actually reachable
-                response = get_session().get(f"{self.url}/health", headers=self._api._build_hf_headers(token=self._token))
+                response = get_session().get(
+                    f"{self.url}/health", headers=self._api._build_hf_headers(token=self._token)
+                )
                 if response.status_code == 200:
                     logger.info("Inference Endpoint is ready to be used.")
                     return self

--- a/src/huggingface_hub/_inference_endpoints.py
+++ b/src/huggingface_hub/_inference_endpoints.py
@@ -117,7 +117,6 @@ class InferenceEndpoint:
     # Internal fields
     _token: Union[str, bool, None] = field(repr=False, compare=False)
     _api: "HfApi" = field(repr=False, compare=False)
-    _health_url: str = field(repr=False, init=False, compare=False)
 
     @classmethod
     def from_raw(
@@ -222,10 +221,10 @@ class InferenceEndpoint:
                 )
             if self.status == InferenceEndpointStatus.RUNNING and self.url is not None:
                 # Update additional utility variables compute from the raw payload
-                self._health_url = f"{self.url.rstrip('/')}/{self.health_route.lstrip('/')}"
 
                 # Verify the endpoint is actually reachable
-                response = get_session().get(self._health_url, headers=self._api._build_hf_headers(token=self._token))
+                _health_url = f"{self.url.rstrip('/')}/{self.health_route.lstrip('/')}"
+                response = get_session().get(_health_url, headers=self._api._build_hf_headers(token=self._token))
                 if response.status_code == 200:
                     logger.info("Inference Endpoint is ready to be used.")
                     return self

--- a/src/huggingface_hub/_inference_endpoints.py
+++ b/src/huggingface_hub/_inference_endpoints.py
@@ -220,9 +220,7 @@ class InferenceEndpoint:
                 )
             if self.status == InferenceEndpointStatus.RUNNING and self.url is not None:
                 # Verify the endpoint is actually reachable
-                response = get_session().get(
-                    f"{self.url}/health", headers=self._api._build_hf_headers(token=self._token)
-                )
+                response = get_session().get(self.health_url, headers=self._api._build_hf_headers(token=self._token))
                 if response.status_code == 200:
                     logger.info("Inference Endpoint is ready to be used.")
                     return self
@@ -402,6 +400,7 @@ class InferenceEndpoint:
         self.repository = self.raw["model"]["repository"]
         self.status = self.raw["status"]["state"]
         self.url = self.raw["status"].get("url")
+        self.health_url = self.raw["healthRoute"]
 
         # Other fields
         self.framework = self.raw["model"]["framework"]

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -4521,6 +4521,7 @@ class HfApiInferenceCatalogTest(HfApiCommonTest):
                 },
                 "name": "llama-3-2-3b-instruct-eey",
                 "provider": {"region": "us-east-1", "vendor": "aws"},
+                "healthRoute": "/health",
                 "status": {
                     "createdAt": "2025-03-07T15:30:13.949Z",
                     "createdBy": {"id": "6273f303f6d63a28483fde12", "name": "Wauplin"},
@@ -4650,6 +4651,7 @@ def test_create_inference_endpoint_custom_image_payload(
         },
         "name": "llama-3-2-3b-instruct-eey",
         "provider": {"region": "us-east-1", "vendor": "aws"},
+        "healthRoute": "/health",
         "status": {
             "createdAt": "2025-03-07T15:30:13.949Z",
             "createdBy": {"id": "6273f303f6d63a28483fde12", "name": "Wauplin"},

--- a/tests/test_inference_endpoints.py
+++ b/tests/test_inference_endpoints.py
@@ -162,7 +162,7 @@ def test_from_raw_initialization():
     assert endpoint.revision == "11c5a3d5811f50298f278a704980280950aedb10"
     assert endpoint.task == "text-generation"
     assert endpoint.type == "protected"
-    assert endpoint.health_url == "/health"
+    assert endpoint.health_route == "/health"
 
     # Datetime parsed correctly
     assert endpoint.created_at == datetime(2023, 10, 26, 12, 41, 53, 263078, tzinfo=timezone.utc)
@@ -202,7 +202,7 @@ def test_get_client_ready():
     # Endpoint is ready
     assert endpoint.status == "running"
     assert endpoint.url == "https://vksrvs8pc1xnifhq.us-east-1.aws.endpoints.huggingface.cloud"
-    assert endpoint.health_url == "/health"
+    assert endpoint.health_route == "/health"
 
     # => Client available
     client = endpoint.client
@@ -224,7 +224,7 @@ def test_fetch(mock_get: Mock):
 
     assert endpoint.status == "running"
     assert endpoint.url == "https://vksrvs8pc1xnifhq.us-east-1.aws.endpoints.huggingface.cloud"
-    assert endpoint.health_url == "/health"
+    assert endpoint.health_route == "/health"
 
 
 @patch("huggingface_hub._inference_endpoints.get_session")

--- a/tests/test_inference_endpoints.py
+++ b/tests/test_inference_endpoints.py
@@ -19,6 +19,7 @@ MOCK_INITIALIZING = {
     "type": "protected",
     "accountId": None,
     "provider": {"vendor": "aws", "region": "us-east-1"},
+    "healthRoute": "/health",
     "compute": {
         "accelerator": "cpu",
         "instanceType": "intel-icl",
@@ -51,6 +52,7 @@ MOCK_RUNNING = {
     "type": "protected",
     "accountId": None,
     "provider": {"vendor": "aws", "region": "us-east-1"},
+    "healthRoute": "/health",
     "compute": {
         "accelerator": "cpu",
         "instanceType": "intel-icl",
@@ -84,6 +86,7 @@ MOCK_FAILED = {
     "type": "protected",
     "accountId": None,
     "provider": {"vendor": "aws", "region": "us-east-1"},
+    "healthRoute": "/health",
     "compute": {
         "accelerator": "cpu",
         "instanceType": "intel-icl",
@@ -116,6 +119,7 @@ MOCK_UPDATE = {
     "type": "protected",
     "accountId": None,
     "provider": {"vendor": "aws", "region": "us-east-1"},
+    "healthRoute": "/health",
     "compute": {
         "accelerator": "cpu",
         "instanceType": "intel-icl",
@@ -158,6 +162,7 @@ def test_from_raw_initialization():
     assert endpoint.revision == "11c5a3d5811f50298f278a704980280950aedb10"
     assert endpoint.task == "text-generation"
     assert endpoint.type == "protected"
+    assert endpoint.health_route == "/health"
 
     # Datetime parsed correctly
     assert endpoint.created_at == datetime(2023, 10, 26, 12, 41, 53, 263078, tzinfo=timezone.utc)
@@ -197,6 +202,7 @@ def test_get_client_ready():
     # Endpoint is ready
     assert endpoint.status == "running"
     assert endpoint.url == "https://vksrvs8pc1xnifhq.us-east-1.aws.endpoints.huggingface.cloud"
+    assert endpoint.health_route == "/health"
 
     # => Client available
     client = endpoint.client
@@ -218,6 +224,7 @@ def test_fetch(mock_get: Mock):
 
     assert endpoint.status == "running"
     assert endpoint.url == "https://vksrvs8pc1xnifhq.us-east-1.aws.endpoints.huggingface.cloud"
+    assert endpoint.health_route == "/health"
 
 
 @patch("huggingface_hub._inference_endpoints.get_session")

--- a/tests/test_inference_endpoints.py
+++ b/tests/test_inference_endpoints.py
@@ -162,7 +162,7 @@ def test_from_raw_initialization():
     assert endpoint.revision == "11c5a3d5811f50298f278a704980280950aedb10"
     assert endpoint.task == "text-generation"
     assert endpoint.type == "protected"
-    assert endpoint.health_route == "/health"
+    assert endpoint.health_url == "/health"
 
     # Datetime parsed correctly
     assert endpoint.created_at == datetime(2023, 10, 26, 12, 41, 53, 263078, tzinfo=timezone.utc)
@@ -202,7 +202,7 @@ def test_get_client_ready():
     # Endpoint is ready
     assert endpoint.status == "running"
     assert endpoint.url == "https://vksrvs8pc1xnifhq.us-east-1.aws.endpoints.huggingface.cloud"
-    assert endpoint.health_route == "/health"
+    assert endpoint.health_url == "/health"
 
     # => Client available
     client = endpoint.client

--- a/tests/test_inference_endpoints.py
+++ b/tests/test_inference_endpoints.py
@@ -252,6 +252,11 @@ def test_wait_until_running(mock_get: Mock, mock_session: Mock):
     assert endpoint.status == "running"
     assert len(mock_get.call_args_list) == 6
 
+    # Ensure the health route has been called
+    assert mock_session.return_value.get.call_count == 2
+    for call in mock_session.return_value.get.call_args_list:
+        assert call[0][0] == "https://vksrvs8pc1xnifhq.us-east-1.aws.endpoints.huggingface.cloud/health"
+
 
 @patch("huggingface_hub.hf_api.HfApi.get_inference_endpoint")
 def test_wait_timeout(mock_get: Mock):

--- a/tests/test_inference_endpoints.py
+++ b/tests/test_inference_endpoints.py
@@ -224,7 +224,7 @@ def test_fetch(mock_get: Mock):
 
     assert endpoint.status == "running"
     assert endpoint.url == "https://vksrvs8pc1xnifhq.us-east-1.aws.endpoints.huggingface.cloud"
-    assert endpoint.health_route == "/health"
+    assert endpoint.health_url == "/health"
 
 
 @patch("huggingface_hub._inference_endpoints.get_session")


### PR DESCRIPTION
This PR fixes a status handling issue with the newly introduced vLLM container on Inference Endpoint.

Currently, the library attempt to send a `GET /` to the endpoint URL and expect a `200 OK` to update the internal status to RUNNING.

While this works with TGI based container, vLLM do not expose such route and thus `GET /` leads to a `404 NOT FOUND` leaving the status in a on-going status pulling loop.

This PR proposes to move from `GET /` to `GET /health` which is exposed by both (and certainly more generally) other endpoint types.