### PR TITLE
[Tiny-Agent] Fix headers handling + secrets management

### DIFF
--- a/src/huggingface_hub/inference/_mcp/agent.py
+++ b/src/huggingface_hub/inference/_mcp/agent.py
@@ -7,6 +7,7 @@ from huggingface_hub import ChatCompletionInputMessage, ChatCompletionStreamOutp
 
 from .._providers import PROVIDER_OR_POLICY_T
 from .constants import DEFAULT_SYSTEM_PROMPT, EXIT_LOOP_TOOLS, MAX_NUM_TURNS
+from .types import ServerConfig
 
 
 class Agent(MCPClient):
@@ -40,7 +41,7 @@ class Agent(MCPClient):
         self,
         *,
         model: Optional[str] = None,
-        servers: Iterable[Dict],
+        servers: Iterable[ServerConfig],
         provider: Optional[PROVIDER_OR_POLICY_T] = None,
         base_url: Optional[str] = None,
         api_key: Optional[str] = None,
@@ -54,7 +55,7 @@ class Agent(MCPClient):
 
     async def load_tools(self) -> None:
         for cfg in self._servers_cfg:
-            await self.add_mcp_server(cfg["type"], **cfg["config"])
+            await self.add_mcp_server(**cfg)
 
     async def run(
         self,

--- a/src/huggingface_hub/inference/_mcp/cli.py
+++ b/src/huggingface_hub/inference/_mcp/cli.py
@@ -88,7 +88,7 @@ async def run_agent(
                     env_or_headers = (
                         server["config"].get("env", {})
                         if server["type"] == "stdio"
-                        else server["config"].get("options", {}).get("requestInit", {}).get("headers", {})
+                        else server["config"].get("headers", {})
                     )
                     for key, value in env_or_headers.items():
                         if env_special_value in value:
@@ -99,8 +99,9 @@ async def run_agent(
                     continue
 
                 # Prompt user for input
+                env_variable_key = input_id.replace(" ", "_").replace("-", "_").upper()
                 print(
-                    f"[blue] • {input_id}[/blue]: {description}. (default: load from {', '.join(sorted(input_vars))}).",
+                    f"[blue] • {input_id}[/blue]: {description}. (default: load from {env_variable_key}).",
                     end=" ",
                 )
                 user_input = (await _async_prompt(exit_event=exit_event)).strip()
@@ -112,20 +113,20 @@ async def run_agent(
                     env_or_headers = (
                         server["config"].get("env", {})
                         if server["type"] == "stdio"
-                        else server["config"].get("options", {}).get("requestInit", {}).get("headers", {})
+                        else server["config"].get("headers", {})
                     )
                     for key, value in env_or_headers.items():
                         if env_special_value in value:
                             if user_input:
                                 env_or_headers[key] = env_or_headers[key].replace(env_special_value, user_input)
                             else:
-                                value_from_env = os.getenv(key, "")
+                                value_from_env = os.getenv(env_variable_key, "")
                                 env_or_headers[key] = env_or_headers[key].replace(env_special_value, value_from_env)
                                 if value_from_env:
-                                    print(f"[green]Value successfully loaded from '{key}'[/green]")
+                                    print(f"[green]Value successfully loaded from '{env_variable_key}'[/green]")
                                 else:
                                     print(
-                                        f"[yellow]No value found for '{key}' in environment variables. Continuing.[/yellow]"
+                                        f"[yellow]No value found for '{env_variable_key}' in environment variables. Continuing.[/yellow]"
                                     )
 
             print()

--- a/src/huggingface_hub/inference/_mcp/cli.py
+++ b/src/huggingface_hub/inference/_mcp/cli.py
@@ -99,7 +99,7 @@ async def run_agent(
                     continue
 
                 # Prompt user for input
-                env_variable_key = input_id.replace(" ", "_").replace("-", "_").upper()
+                env_variable_key = input_id.replace("-", "_").upper()
                 print(
                     f"[blue] • {input_id}[/blue]: {description}. (default: load from {env_variable_key}).",
                     end=" ",

--- a/src/huggingface_hub/inference/_mcp/cli.py
+++ b/src/huggingface_hub/inference/_mcp/cli.py
@@ -85,11 +85,7 @@ async def run_agent(
                 input_vars = set()
                 for server in servers:
                     # Check stdio's "env" and http/sse's "headers" mappings
-                    env_or_headers = (
-                        server["config"].get("env", {})
-                        if server["type"] == "stdio"
-                        else server["config"].get("headers", {})
-                    )
+                    env_or_headers = server.get("env", {}) if server["type"] == "stdio" else server.get("headers", {})
                     for key, value in env_or_headers.items():
                         if env_special_value in value:
                             input_vars.add(key)
@@ -110,11 +106,7 @@ async def run_agent(
 
                 # Inject user input (or env variable) into stdio's env or http/sse's headers
                 for server in servers:
-                    env_or_headers = (
-                        server["config"].get("env", {})
-                        if server["type"] == "stdio"
-                        else server["config"].get("headers", {})
-                    )
+                    env_or_headers = server.get("env", {}) if server["type"] == "stdio" else server.get("headers", {})
                     for key, value in env_or_headers.items():
                         if env_special_value in value:
                             if user_input:

--- a/src/huggingface_hub/inference/_mcp/types.py
+++ b/src/huggingface_hub/inference/_mcp/types.py
@@ -1,7 +1,6 @@
 from typing import Dict, List, Literal, TypedDict, Union
 
 
-# Input config
 class InputConfig(TypedDict, total=False):
     id: str
     description: str
@@ -9,52 +8,27 @@ class InputConfig(TypedDict, total=False):
     password: bool
 
 
-# stdio server config
-class StdioServerConfig(TypedDict, total=False):
+class StdioServerConfig(TypedDict):
+    type: Literal["stdio"]
     command: str
     args: List[str]
     env: Dict[str, str]
     cwd: str
 
 
-class StdioServer(TypedDict):
-    type: Literal["stdio"]
-    config: StdioServerConfig
-
-
-# http server config
-class HTTPRequestInit(TypedDict, total=False):
+class HTTPServerConfig(TypedDict):
+    type: Literal["http"]
+    url: str
     headers: Dict[str, str]
 
 
-class HTTPServerOptions(TypedDict, total=False):
-    requestInit: HTTPRequestInit
-    sessionId: str
-
-
-class HTTPServerConfig(TypedDict, total=False):
-    url: str
-    options: HTTPServerOptions
-
-
-class HTTPServer(TypedDict):
-    type: Literal["http"]
-    config: HTTPServerConfig
-
-
-# sse server config
-class SSEServerOptions(TypedDict, total=False):
-    requestInit: HTTPRequestInit
-
-
 class SSEServerConfig(TypedDict):
-    url: str
-    options: SSEServerOptions
-
-
-class SSEServer(TypedDict):
     type: Literal["sse"]
-    config: SSEServerConfig
+    url: str
+    headers: Dict[str, str]
+
+
+ServerConfig = Union[StdioServerConfig, HTTPServerConfig, SSEServerConfig]
 
 
 # AgentConfig root object
@@ -62,4 +36,4 @@ class AgentConfig(TypedDict):
     model: str
     provider: str
     inputs: List[InputConfig]
-    servers: List[Union[StdioServer, HTTPServer, SSEServer]]
+    servers: List[ServerConfig]


### PR DESCRIPTION
Currently headers are configured in `tiny-agent` using `servers[].config.options.requestInit.headers` (which we inherited from JS MCP client). However it would be preferable to follow [VSCode MCP configuration](https://code.visualstudio.com/docs/copilot/chat/mcp-servers#_configuration-format) i.e. `servers[].headers`:

```json
{
  "model": "Qwen/Qwen2.5-72B-Instruct",
  "provider": "nebius",
  "inputs": [
    {
      "type": "promptString",
      "id": "hf-token",
      "description": "Token for Hugging Face API access",
      "password": true
    }
  ],
  "servers": [
    {
      "type": "http",
      "url": "https://huggingface.co/mcp",
      "headers": {
        "Authorization": "Bearer ${input:hf-token}"
      }
    }
  ]
}
```

---

I also updated the "default env variable loading" logic. Before we were loading based on the key where the value will be used (in this case `Authorization`). With the PR, we now build the ENV_VAR based on "input id" `hf-token => HF_TOKEN`. This is a breaking change but more future-proof IMO

Once approved on this side, I'll make the update in the JS client. 

---

### Note: this is orthogonal to the MCP + OAuth topic

**EDIT:** equivalent PR in JS https://github.com/huggingface/huggingface.js/pull/1556