### PR TITLE
[Internal] Replace style bot token

### DIFF
--- a/.github/workflows/style-bot.yml
+++ b/.github/workflows/style-bot.yml
@@ -15,4 +15,4 @@ jobs:
       python_quality_dependencies: "[quality]"
       style_command_type: "style_only"
     secrets:
-      bot_token: ${{ secrets.GITHUB_TOKEN }}
+      bot_token: ${{ secrets.HF_STYLE_BOT_ACTION }}


### PR DESCRIPTION
Thanks to @ydshieh and @glegendre01, we can now trigger (with approval) the CI after the style bot pushes changes to a PR branch. More context in this internal slack [thread](https://huggingface.slack.com/archives/CTKK32GE8/p1749638853606179).