### PR TITLE
Updates to Xet upload/download docs

### DIFF
--- a/docs/source/en/guides/download.md
+++ b/docs/source/en/guides/download.md
@@ -168,7 +168,7 @@ For more details about the CLI download command, please refer to the [CLI guide]
 
 There are two options to speed up downloads. Both involve installing a Python package written in Rust.
 
-* `hf_xet` is newer and uses the Xet storage backend for upload/download. It is available in production, but is in the process of being rolled out to all users, so join the [waitlist](https://huggingface.co/join/xet) to get onboarded soon!
+* `hf_xet` is newer and uses the Xet storage backend for upload/download. Xet storage is the [default for all new Hub users and organizations](https://huggingface.co/changelog/xet-default-for-new-users), and is in the process of being rolled out to all users. If you don't have access, join the [waitlist](https://huggingface.co/join/xet) to make Xet the default for all your repositories!
 * `hf_transfer` is a power-tool to download and upload to our LFS storage backend (note: this is less future-proof than Xet). It is thoroughly tested and has been in production for a long time, but it has some limitations. 
 
 ### hf_xet
@@ -178,11 +178,13 @@ chunk-based deduplication for faster downloads and uploads. `hf_xet` integrates 
 
 `hf_xet` uses the Xet storage system, which breaks files down into immutable chunks, storing collections of these chunks (called blocks or xorbs) remotely and retrieving them to reassemble the file when requested. When downloading, after confirming the user is authorized to access the files, `hf_xet` will query the Xet content-addressable service (CAS) with the LFS SHA256 hash for this file to receive the reconstruction metadata (ranges within xorbs) to assemble these files, along with presigned URLs to download the xorbs directly. Then `hf_xet` will efficiently download the xorb ranges necessary and will write out the files on disk. `hf_xet` uses a local disk cache to only download chunks once, learn more in the [Chunk-based caching(Xet)](./manage-cache#chunk-based-caching-xet) section.
 
-To enable it, specify the `hf_xet` package when installing `huggingface_hub`:
+To enable it, simply install the latest version of `huggingface_hub`:
 
 ```bash
-pip install -U "huggingface_hub[hf_xet]"
+pip install -U "huggingface_hub"
 ```
+
+As of `huggingface_hub` 0.32.0, this will also install `hf_xet`.
 
 Note: `hf_xet` will only be utilized when the files being downloaded are being stored with Xet Storage.
 

--- a/docs/source/en/guides/upload.md
+++ b/docs/source/en/guides/upload.md
@@ -191,7 +191,7 @@ Take advantage of faster uploads through `hf_xet`, the Python binding to the [`x
 
 <Tip warning={true}>
 
-Xet storage is being rolled out to Hugging Face Hub users at this time, so xet uploads may need to be enabled for your repo for `hf_xet` to actually upload to the Xet backend. Join the [waitlist](https://huggingface.co/join/xet) to get onboarded soon! Also, `hf_xet` today only works with files on the file system, so cannot be used with file-like objects (byte-arrays, buffers).
+As of May 23rd, 2025, Xet-enabled repositories are the default for all new Hugging Face Hub users and organizations. If your user or organization was created before then, you may need Xet enabled on your repo for `hf_xet` to actually upload to the Xet backend. Join the [waitlist](https://huggingface.co/join/xet) to make Xet the default for all your repositories. Also, note that while `hf_xet` works with in-memory bytes or bytearray data support for BinaryIO streams is still pending.
 
 </Tip>
 

--- a/docs/source/en/guides/upload.md
+++ b/docs/source/en/guides/upload.md
@@ -191,17 +191,19 @@ Take advantage of faster uploads through `hf_xet`, the Python binding to the [`x
 
 <Tip warning={true}>
 
-As of May 23rd, 2025, Xet-enabled repositories are the default for all new Hugging Face Hub users and organizations. If your user or organization was created before then, you may need Xet enabled on your repo for `hf_xet` to actually upload to the Xet backend. Join the [waitlist](https://huggingface.co/join/xet) to make Xet the default for all your repositories. Also, note that while `hf_xet` works with in-memory bytes or bytearray data support for BinaryIO streams is still pending.
+As of May 23rd, 2025, Xet-enabled repositories [are the default for all new Hugging Face Hub users and organizations](https://huggingface.co/changelog/xet-default-for-new-users). If your user or organization was created before then, you may need Xet enabled on your repo for `hf_xet` to actually upload to the Xet backend. Join the [waitlist](https://huggingface.co/join/xet) to make Xet the default for all your repositories. Also, note that while `hf_xet` works with in-memory bytes or bytearray data support for BinaryIO streams is still pending.
 
 </Tip>
 
 `hf_xet` uses the Xet storage system, which breaks files down into immutable chunks, storing collections of these chunks (called blocks or xorbs) remotely and retrieving them to reassemble the file when requested. When uploading, after confirming the user is authorized to write to this repo, `hf_xet` will scan the files, breaking them down into their chunks and collecting those chunks into xorbs (and deduplicating across known chunks), and then will be upload these xorbs to the Xet content-addressable service (CAS), which will verify the integrity of the xorbs, register the xorb metadata along with the LFS SHA256 hash (to support lookup/download), and write the xorbs to remote storage.
 
-To enable it, specify the `hf_xet` extra when installing `huggingface_hub`:
+To enable it, simply install the latest version of `huggingface_hub`:
 
 ```bash
-pip install -U "huggingface_hub[hf_xet]"
+pip install -U "huggingface_hub"
 ```
+
+As of `huggingface_hub` 0.32.0, this will also install `hf_xet`. 
 
 All other `huggingface_hub` APIs will continue to work without any modification. To learn more about the benefits of Xet storage and `hf_xet`, refer to this [section](https://huggingface.co/docs/hub/storage-backends).
 


### PR DESCRIPTION
Minor updates to Xet sections of upload and download documentation now that: 
* Xet is the default for new users and orgs
* `hf_xet` is a required dependency in `huggingface_hub` as of 0.32.0 in https://github.com/huggingface/huggingface_hub/pull/3103
