### PR TITLE
update hffilesystem docstring

### DIFF
--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -59,13 +59,11 @@ class HfFileSystem(fsspec.AbstractFileSystem):
     """
     Access a remote Hugging Face Hub repository as if were a local file system.
 
-    <Tip warning={true}>
+    [`HfFileSystem`] provides fsspec compatibility, which is useful for libraries that require it (e.g., reading
+    Hugging Face datasets directly with `pandas`).
 
-        [`HfFileSystem`] provides fsspec compatibility, which is useful for libraries that require it (e.g., reading
-        Hugging Face datasets directly with `pandas`). However, it introduces additional overhead due to this compatibility
-        layer. For better performance and reliability, it's recommended to use `HfApi` methods when possible.
-
-    </Tip>
+    It is a thin wrapper over `HfApi` which provides the lower level features of the Hub. Therefore it is recommended
+    to use `HfApi` methods when possible if you look for more fine-grained operations.
 
     Args:
         token (`str` or `bool`, *optional*):


### PR DESCRIPTION
it was referring to overheads that don't exist anymore

I think it was about file streaming and copying files but that have been optimized some time ago:
- https://github.com/huggingface/huggingface_hub/pull/2143
- https://github.com/huggingface/huggingface_hub/pull/1996