### PR TITLE
Recursive filter_none in Inference Providers

### DIFF
--- a/src/huggingface_hub/inference/_providers/_common.py
+++ b/src/huggingface_hub/inference/_providers/_common.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional, Union
 from huggingface_hub import constants
 from huggingface_hub.hf_api import InferenceProviderMapping
 from huggingface_hub.inference._common import RequestParameters
+from huggingface_hub.inference._generated.types.chat_completion import ChatCompletionInputMessage
 from huggingface_hub.utils import build_hf_headers, get_token, logging
 
 
@@ -228,8 +229,12 @@ class BaseConversationalTask(TaskProviderHelper):
         return "/v1/chat/completions"
 
     def _prepare_payload_as_dict(
-        self, inputs: Any, parameters: Dict, provider_mapping_info: InferenceProviderMapping
+        self,
+        inputs: List[Union[Dict, ChatCompletionInputMessage]],
+        parameters: Dict,
+        provider_mapping_info: InferenceProviderMapping,
     ) -> Optional[Dict]:
+        inputs = [filter_none(message) for message in inputs]
         return {"messages": inputs, **filter_none(parameters), "model": provider_mapping_info.provider_id}
 
 

--- a/src/huggingface_hub/inference/_providers/_common.py
+++ b/src/huggingface_hub/inference/_providers/_common.py
@@ -37,12 +37,32 @@ HARDCODED_MODEL_INFERENCE_MAPPING: Dict[str, Dict[str, InferenceProviderMapping]
 }
 
 
-def filter_none(d: Dict[str, Any]) -> Dict[str, Any]:
-    return {
-        k: v_filtered
-        for k, v in d.items()
-        if (v_filtered := filter_none(v) if isinstance(v, dict) else v) is not None and v_filtered != {}
-    }
+def filter_none(obj: Union[Dict[str, Any], List[Any]]) -> Dict[str, Any]:
+    if isinstance(obj, dict):
+        cleaned: Dict[str, Any] = {}
+        for k, v in obj.items():
+            if v is None:
+                continue
+            if isinstance(v, (dict, list)):
+                v = filter_none(v)
+                # remove empty nested dicts
+                if isinstance(v, dict) and not v:
+                    continue
+            cleaned[k] = v
+        return cleaned
+
+    if isinstance(obj, list):
+        cleaned_list: List[Any] = []
+        for v in obj:
+            if isinstance(v, (dict, list)):
+                v = filter_none(v)
+                if isinstance(v, dict) and not v:
+                    continue
+
+            cleaned_list.append(v)
+        return cleaned_list  # type: ignore [return-value]
+
+    raise ValueError(f"Expected dict or list, got {type(obj)}")
 
 
 class TaskProviderHelper:
@@ -234,8 +254,7 @@ class BaseConversationalTask(TaskProviderHelper):
         parameters: Dict,
         provider_mapping_info: InferenceProviderMapping,
     ) -> Optional[Dict]:
-        inputs = [filter_none(message) for message in inputs]
-        return {"messages": inputs, **filter_none(parameters), "model": provider_mapping_info.provider_id}
+        return filter_none({"messages": inputs, **parameters, "model": provider_mapping_info.provider_id})
 
 
 class BaseTextGenerationTask(TaskProviderHelper):

--- a/src/huggingface_hub/inference/_providers/_common.py
+++ b/src/huggingface_hub/inference/_providers/_common.py
@@ -37,7 +37,11 @@ HARDCODED_MODEL_INFERENCE_MAPPING: Dict[str, Dict[str, InferenceProviderMapping]
 
 
 def filter_none(d: Dict[str, Any]) -> Dict[str, Any]:
-    return {k: v for k, v in d.items() if v is not None}
+    return {
+        k: v_filtered
+        for k, v in d.items()
+        if (v_filtered := filter_none(v) if isinstance(v, dict) else v) is not None and v_filtered != {}
+    }
 
 
 class TaskProviderHelper:

--- a/src/huggingface_hub/inference/_providers/_common.py
+++ b/src/huggingface_hub/inference/_providers/_common.py
@@ -1,5 +1,5 @@
 from functools import lru_cache
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union, overload
 
 from huggingface_hub import constants
 from huggingface_hub.hf_api import InferenceProviderMapping
@@ -37,7 +37,13 @@ HARDCODED_MODEL_INFERENCE_MAPPING: Dict[str, Dict[str, InferenceProviderMapping]
 }
 
 
-def filter_none(obj: Union[Dict[str, Any], List[Any]]) -> Dict[str, Any]:
+@overload
+def filter_none(obj: Dict[str, Any]) -> Dict[str, Any]: ...
+@overload
+def filter_none(obj: List[Any]) -> List[Any]: ...
+
+
+def filter_none(obj: Union[Dict[str, Any], List[Any]]) -> Union[Dict[str, Any], List[Any]]:
     if isinstance(obj, dict):
         cleaned: Dict[str, Any] = {}
         for k, v in obj.items():
@@ -52,13 +58,7 @@ def filter_none(obj: Union[Dict[str, Any], List[Any]]) -> Dict[str, Any]:
         return cleaned
 
     if isinstance(obj, list):
-        cleaned_list: List[Any] = []
-        for v in obj:
-            if isinstance(v, (dict, list)):
-                v = filter_none(v)
-
-            cleaned_list.append(v)
-        return cleaned_list  # type: ignore [return-value]
+        return [filter_none(v) if isinstance(v, (dict, list)) else v for v in obj]
 
     raise ValueError(f"Expected dict or list, got {type(obj)}")
 

--- a/src/huggingface_hub/inference/_providers/_common.py
+++ b/src/huggingface_hub/inference/_providers/_common.py
@@ -56,8 +56,6 @@ def filter_none(obj: Union[Dict[str, Any], List[Any]]) -> Dict[str, Any]:
         for v in obj:
             if isinstance(v, (dict, list)):
                 v = filter_none(v)
-                if isinstance(v, dict) and not v:
-                    continue
 
             cleaned_list.append(v)
         return cleaned_list  # type: ignore [return-value]

--- a/src/huggingface_hub/inference/_providers/hf_inference.py
+++ b/src/huggingface_hub/inference/_providers/hf_inference.py
@@ -75,7 +75,7 @@ class HFInferenceBinaryInputTask(HFInferenceTask):
         provider_mapping_info: InferenceProviderMapping,
         extra_payload: Optional[Dict],
     ) -> Optional[bytes]:
-        parameters = filter_none({k: v for k, v in parameters.items() if v is not None})
+        parameters = filter_none(parameters)
         extra_payload = extra_payload or {}
         has_parameters = len(parameters) > 0 or len(extra_payload) > 0
 

--- a/tests/test_inference_providers.py
+++ b/tests/test_inference_providers.py
@@ -1351,7 +1351,7 @@ def test_recursive_merge(dict1: Dict, dict2: Dict, expected: Dict):
             [None, {"x": None, "y": 5}, [None, 6]],
             [None, {"y": 5}, [None, 6]],
         ),
-        ({"a": [None, {"x": None}]}, {"a": [None]}),
+        ({"a": [None, {"x": None}]}, {"a": [None, {}]}),
     ],
 )
 def test_filter_none(data: Dict, expected: Dict):


### PR DESCRIPTION
`None` values in payload can lead to a BadRequest error if the Inference Provider did not expect the field and is doing input validation. This is for instance what's happening in https://github.com/huggingface/huggingface_hub/pull/3170 with groq complaining if `tool_calls` and `tool_call_id` are both set (with None values in them). Groq is complying to the OpenAI specs, this is more a problem on our side but won't be in this PR (*).

What we currently do to avoid these issues is to filter out None values using `filter_none`. However this helper only removes None values at the top-level of the dictionary. **This PR updates `filter_none` to recursively remove None values.** I added some tests to ensure that values like `""`, `0` and `[]` are not removed. This PR should fix the Groq issue and will likely avoid some other errors in the future. 

---

_(*) regarding why we don't exactly follow the OpenAI specs in our inference types is that we don't have a good way to generate Union type. If a schema is defined as "oneOf", our script will generate a class that is in fact a superset of all possible values, with all of them being optional. See https://github.com/huggingface/huggingface.js/pull/1537 or https://github.com/glideapps/quicktype/issues/1266 for more details. This issue might be annoying on the long run but there is no easy way to address it. Pydantic defines [discriminators unions](https://docs.pydantic.dev/latest/concepts/unions/#discriminated-unions) for that which we could also implement. What's harder is to have a reliable and generic `parse_obj` method extending a Union type (which doesn't seem possible). Let's see if/when it becomes for urgent to tackle it._

cc @Vaibhavs10 @burtenshaw