### PR TITLE
Override xet refresh route's base URL with HF Endpoint

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1407,6 +1407,7 @@ def get_hf_file_metadata(
     library_version: Optional[str] = None,
     user_agent: Union[Dict, str, None] = None,
     headers: Optional[Dict[str, str]] = None,
+    endpoint: Optional[str] = None,
 ) -> HfFileMetadata:
     """Fetch metadata of a file versioned on the Hub for a given url.
 
@@ -1432,6 +1433,8 @@ def get_hf_file_metadata(
             The user-agent info in the form of a dictionary or a string.
         headers (`dict`, *optional*):
             Additional headers to be sent with the request.
+        endpoint (`str`, *optional*):
+            Endpoint of the Hub. Defaults to <https://huggingface.co>.
 
     Returns:
         A [`HfFileMetadata`] object containing metadata such as location, etag, size and
@@ -1471,7 +1474,7 @@ def get_hf_file_metadata(
         size=_int_or_none(
             r.headers.get(constants.HUGGINGFACE_HEADER_X_LINKED_SIZE) or r.headers.get("Content-Length")
         ),
-        xet_file_data=parse_xet_file_data_from_response(r),  # type: ignore
+        xet_file_data=parse_xet_file_data_from_response(r, endpoint=endpoint),  # type: ignore
     )
 
 
@@ -1531,7 +1534,7 @@ def _get_metadata_or_catch_error(
         try:
             try:
                 metadata = get_hf_file_metadata(
-                    url=url, proxies=proxies, timeout=etag_timeout, headers=headers, token=token
+                    url=url, proxies=proxies, timeout=etag_timeout, headers=headers, token=token, endpoint=endpoint
                 )
             except EntryNotFoundError as http_error:
                 if storage_folder is not None and relative_filename is not None:

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -5392,6 +5392,7 @@ class HfApi:
             library_name=self.library_name,
             library_version=self.library_version,
             user_agent=self.user_agent,
+            endpoint=self.endpoint,
         )
 
     @validate_hf_hub_args

--- a/src/huggingface_hub/utils/_xet.py
+++ b/src/huggingface_hub/utils/_xet.py
@@ -55,8 +55,7 @@ def parse_xet_file_data_from_response(
     except KeyError:
         return None
     endpoint = endpoint if endpoint is not None else constants.ENDPOINT
-    if refresh_route.startswith("https://huggingface.co"):
-        refresh_route = refresh_route.replace("https://huggingface.co", endpoint)
+    refresh_route = refresh_route.replace("https://huggingface.co", endpoint)
     return XetFileData(
         file_hash=file_hash,
         refresh_route=refresh_route,

--- a/src/huggingface_hub/utils/_xet.py
+++ b/src/huggingface_hub/utils/_xet.py
@@ -55,7 +55,8 @@ def parse_xet_file_data_from_response(
     except KeyError:
         return None
     endpoint = endpoint if endpoint is not None else constants.ENDPOINT
-    refresh_route = refresh_route.replace(constants.HUGGINGFACE_CO_URL_HOME.rstrip("/"), endpoint.rstrip("/"))
+    if refresh_route.startswith(constants.HUGGINGFACE_CO_URL_HOME):
+        refresh_route = refresh_route.replace(constants.HUGGINGFACE_CO_URL_HOME.rstrip("/"), endpoint.rstrip("/"))
     return XetFileData(
         file_hash=file_hash,
         refresh_route=refresh_route,

--- a/src/huggingface_hub/utils/_xet.py
+++ b/src/huggingface_hub/utils/_xet.py
@@ -55,7 +55,7 @@ def parse_xet_file_data_from_response(
     except KeyError:
         return None
     endpoint = endpoint if endpoint is not None else constants.ENDPOINT
-    refresh_route = refresh_route.replace("https://huggingface.co", endpoint)
+    refresh_route = refresh_route.replace(constants.HUGGINGFACE_CO_URL_HOME.rstrip("/"), endpoint.rstrip("/"))
     return XetFileData(
         file_hash=file_hash,
         refresh_route=refresh_route,

--- a/src/huggingface_hub/utils/_xet.py
+++ b/src/huggingface_hub/utils/_xet.py
@@ -26,7 +26,9 @@ class XetConnectionInfo:
     endpoint: str
 
 
-def parse_xet_file_data_from_response(response: requests.Response) -> Optional[XetFileData]:
+def parse_xet_file_data_from_response(
+    response: requests.Response, endpoint: Optional[str] = None
+) -> Optional[XetFileData]:
     """
     Parse XET file metadata from an HTTP response.
 
@@ -52,7 +54,9 @@ def parse_xet_file_data_from_response(response: requests.Response) -> Optional[X
             refresh_route = response.headers[constants.HUGGINGFACE_HEADER_X_XET_REFRESH_ROUTE]
     except KeyError:
         return None
-
+    endpoint = endpoint if endpoint is not None else constants.ENDPOINT
+    if refresh_route.startswith("https://huggingface.co"):
+        refresh_route = refresh_route.replace("https://huggingface.co", endpoint)
     return XetFileData(
         file_hash=file_hash,
         refresh_route=refresh_route,

--- a/tests/test_xet_utils.py
+++ b/tests/test_xet_utils.py
@@ -51,6 +51,34 @@ def test_parse_invalid_headers_file_info() -> None:
     assert parse_xet_file_data_from_response(mock_response) is None
 
 
+@pytest.mark.parametrize(
+    "refresh_route, expected_refresh_route",
+    [
+        (
+            "/api/refresh",
+            "/api/refresh",
+        ),
+        (
+            "https://huggingface.co/api/refresh",
+            "https://xet.example.com/api/refresh",
+        ),
+    ],
+)
+def test_parse_header_file_info_with_endpoint(refresh_route: str, expected_refresh_route: str) -> None:
+    mock_response = MagicMock()
+    mock_response.headers = {
+        "X-Xet-Hash": "sha256:abcdef",
+        "X-Xet-Refresh-Route": refresh_route,
+    }
+    mock_response.links = {}
+
+    file_data = parse_xet_file_data_from_response(mock_response, endpoint="https://xet.example.com")
+
+    assert file_data is not None
+    assert file_data.refresh_route == expected_refresh_route
+    assert file_data.file_hash == "sha256:abcdef"
+
+
 def test_parse_valid_headers_connection_info() -> None:
     headers = {
         "X-Xet-Cas-Url": "https://xet.example.com",


### PR DESCRIPTION
fixes #3168.
as mentioned by @coyotte508 in this (private) [comment](https://github.com/huggingface-internal/moon-landing/pull/14209#issuecomment-3000994756) , client-side handling is much simpler and future-proof, introducing a new server header would be overkill and doesn't really justify a change server-side.


cc @bpronan 