### PR TITLE
Add BagelNet provider for Python client integration

### DIFF
--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -134,7 +134,7 @@ class InferenceClient:
             path will be appended to the base URL (see the [TGI Messages API](https://huggingface.co/docs/text-generation-inference/en/messages_api)
             documentation for details). When passing a URL as `model`, the client will not append any suffix path to it.
         provider (`str`, *optional*):
-            Name of the provider to use for inference. Can be `"black-forest-labs"`, `"cerebras"`, `"cohere"`, `"fal-ai"`, `"featherless-ai"`, `"fireworks-ai"`, `"groq"`, `"hf-inference"`, `"hyperbolic"`, `"nebius"`, `"novita"`, `"nscale"`, `"openai"`, `"replicate"`, "sambanova"` or `"together"`.
+            Name of the provider to use for inference. Can be `"bagelnet"`, `"black-forest-labs"`, `"cerebras"`, `"cohere"`, `"fal-ai"`, `"featherless-ai"`, `"fireworks-ai"`, `"groq"`, `"hf-inference"`, `"hyperbolic"`, `"nebius"`, `"novita"`, `"nscale"`, `"openai"`, `"replicate"`, "sambanova"` or `"together"`.
             Defaults to "auto" i.e. the first of the providers available for the model, sorted by the user's order in https://hf.co/settings/inference-providers.
             If model is a URL or `base_url` is passed, then `provider` is not used.
         token (`str`, *optional*):

--- a/src/huggingface_hub/inference/_providers/__init__.py
+++ b/src/huggingface_hub/inference/_providers/__init__.py
@@ -7,6 +7,7 @@ from huggingface_hub.inference._providers.featherless_ai import (
 from huggingface_hub.utils import logging
 
 from ._common import TaskProviderHelper, _fetch_inference_provider_mapping
+from .bagelnet import BagelNetConversationalTask
 from .black_forest_labs import BlackForestLabsTextToImageTask
 from .cerebras import CerebrasConversationalTask
 from .cohere import CohereConversationalTask
@@ -43,6 +44,7 @@ logger = logging.get_logger(__name__)
 
 
 PROVIDER_T = Literal[
+    "bagelnet",
     "black-forest-labs",
     "cerebras",
     "cohere",
@@ -64,6 +66,9 @@ PROVIDER_T = Literal[
 PROVIDER_OR_POLICY_T = Union[PROVIDER_T, Literal["auto"]]
 
 PROVIDERS: Dict[PROVIDER_T, Dict[str, TaskProviderHelper]] = {
+    "bagelnet": {
+        "conversational": BagelNetConversationalTask(),
+    },
     "black-forest-labs": {
         "text-to-image": BlackForestLabsTextToImageTask(),
     },

--- a/src/huggingface_hub/inference/_providers/_common.py
+++ b/src/huggingface_hub/inference/_providers/_common.py
@@ -22,6 +22,7 @@ HARDCODED_MODEL_INFERENCE_MAPPING: Dict[str, Dict[str, InferenceProviderMapping]
     #                                    provider_id="Qwen2.5-Coder-32B-Instruct",
     #                                    task="conversational",
     #                                    status="live")
+    "bagelnet": {},
     "cerebras": {},
     "cohere": {},
     "fal-ai": {},

--- a/src/huggingface_hub/inference/_providers/bagelnet.py
+++ b/src/huggingface_hub/inference/_providers/bagelnet.py
@@ -1,0 +1,6 @@
+from ._common import BaseConversationalTask
+
+
+class BagelNetConversationalTask(BaseConversationalTask):
+    def __init__(self):
+        super().__init__(provider="bagelnet", base_url="https://api.bagel.net") 

--- a/tests/test_bagelnet_provider.py
+++ b/tests/test_bagelnet_provider.py
@@ -1,0 +1,31 @@
+import pytest
+
+from huggingface_hub.inference._providers.bagelnet import BagelNetConversationalTask
+
+
+class TestBagelNetConversationalTask:
+    def test_init(self):
+        """Test BagelNet provider initialization."""
+        task = BagelNetConversationalTask()
+        assert task.provider == "bagelnet"
+        assert task.base_url == "https://api.bagel.net"
+        assert task.task == "conversational"
+
+    def test_inheritance(self):
+        """Test BagelNet inherits from BaseConversationalTask."""
+        from huggingface_hub.inference._providers._common import BaseConversationalTask
+        
+        task = BagelNetConversationalTask()
+        assert isinstance(task, BaseConversationalTask)
+
+    def test_no_method_overrides(self):
+        """Test that BagelNet uses default implementations (no overrides needed)."""
+        task = BagelNetConversationalTask()
+        
+        # Should use default route
+        route = task._prepare_route("test_model", "test_key")
+        assert route == "/v1/chat/completions"
+        
+        # Should use default base URL behavior  
+        direct_url = task._prepare_base_url("sk-test-key")  # Non-HF key
+        assert direct_url == "https://api.bagel.net" 


### PR DESCRIPTION
## Summary
Implements Python client integration for BagelNet provider, following the HuggingFace Inference Providers integration process (Step 5).

## Changes
- Add BagelNetConversationalTask provider implementation
- Register provider in PROVIDER_T and PROVIDERS with alphabetical ordering  
- Update InferenceClient docstring to document BagelNet provider
- Add BagelNet entry to HARDCODED_MODEL_INFERENCE_MAPPING
- Add unit tests for BagelNet provider

## Implementation Details
- Provider: bagelnet
- Base URL: https://api.bagel.net 
- Task: conversational (OpenAI-compatible chat completions)
- Pattern: Follows cerebras.py minimal implementation approach

## Prerequisites Completed
- JavaScript client integration (PR submitted)
- Model mapping API access (pending HF response)
- Billing endpoint implemented  
- API infrastructure live at https://api.bagel.net

## Related Work
- JavaScript client integration: https://github.com/huggingface/huggingface.js/pull/1574

## Testing
- Unit tests included for provider initialization and inheritance
- Follows HF testing patterns for conversational providers
- No method overrides needed - uses default OpenAI-compatible behaviour