### PR TITLE
[Inference] Correctly build chat completion URL with query parameters

### DIFF
--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -130,8 +130,7 @@ class InferenceClient:
             or a URL to a deployed Inference Endpoint. Defaults to None, in which case a recommended model is
             automatically selected for the task.
             Note: for better compatibility with OpenAI's client, `model` has been aliased as `base_url`. Those 2
-            arguments are mutually exclusive. If using `base_url` for chat completion, the `/v1/chat/completions` suffix
-            path will be appended to the base URL. When passing a URL as `model`, the `/v1/chat/completions` suffix path will be appended to it.
+            arguments are mutually exclusive. If a URL is passed as `model` or `base_url` for chat completion, the `(/v1)/chat/completions` suffix path will be appended to the URL.
         provider (`str`, *optional*):
             Name of the provider to use for inference. Can be `"black-forest-labs"`, `"cerebras"`, `"cohere"`, `"fal-ai"`, `"featherless-ai"`, `"fireworks-ai"`, `"groq"`, `"hf-inference"`, `"hyperbolic"`, `"nebius"`, `"novita"`, `"nscale"`, `"openai"`, `"replicate"`, "sambanova"` or `"together"`.
             Defaults to "auto" i.e. the first of the providers available for the model, sorted by the user's order in https://hf.co/settings/inference-providers.

--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -130,9 +130,8 @@ class InferenceClient:
             or a URL to a deployed Inference Endpoint. Defaults to None, in which case a recommended model is
             automatically selected for the task.
             Note: for better compatibility with OpenAI's client, `model` has been aliased as `base_url`. Those 2
-            arguments are mutually exclusive. If using `base_url` for chat completion, the `/chat/completions` suffix
-            path will be appended to the base URL (see the [TGI Messages API](https://huggingface.co/docs/text-generation-inference/en/messages_api)
-            documentation for details). When passing a URL as `model`, the client will not append any suffix path to it.
+            arguments are mutually exclusive. If using `base_url` for chat completion, the `/v1/chat/completions` suffix
+            path will be appended to the base URL. When passing a URL as `model`, the `/v1/chat/completions` suffix path will be appended to it.
         provider (`str`, *optional*):
             Name of the provider to use for inference. Can be `"black-forest-labs"`, `"cerebras"`, `"cohere"`, `"fal-ai"`, `"featherless-ai"`, `"fireworks-ai"`, `"groq"`, `"hf-inference"`, `"hyperbolic"`, `"nebius"`, `"novita"`, `"nscale"`, `"openai"`, `"replicate"`, "sambanova"` or `"together"`.
             Defaults to "auto" i.e. the first of the providers available for the model, sorted by the user's order in https://hf.co/settings/inference-providers.

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -118,9 +118,8 @@ class AsyncInferenceClient:
             or a URL to a deployed Inference Endpoint. Defaults to None, in which case a recommended model is
             automatically selected for the task.
             Note: for better compatibility with OpenAI's client, `model` has been aliased as `base_url`. Those 2
-            arguments are mutually exclusive. If using `base_url` for chat completion, the `/chat/completions` suffix
-            path will be appended to the base URL (see the [TGI Messages API](https://huggingface.co/docs/text-generation-inference/en/messages_api)
-            documentation for details). When passing a URL as `model`, the client will not append any suffix path to it.
+            arguments are mutually exclusive. If using `base_url` for chat completion, the `/v1/chat/completions` suffix
+            path will be appended to the base URL. When passing a URL as `model`, the `/v1/chat/completions` suffix path will be appended to it.
         provider (`str`, *optional*):
             Name of the provider to use for inference. Can be `"black-forest-labs"`, `"cerebras"`, `"cohere"`, `"fal-ai"`, `"featherless-ai"`, `"fireworks-ai"`, `"groq"`, `"hf-inference"`, `"hyperbolic"`, `"nebius"`, `"novita"`, `"nscale"`, `"openai"`, `"replicate"`, "sambanova"` or `"together"`.
             Defaults to "auto" i.e. the first of the providers available for the model, sorted by the user's order in https://hf.co/settings/inference-providers.

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -118,8 +118,7 @@ class AsyncInferenceClient:
             or a URL to a deployed Inference Endpoint. Defaults to None, in which case a recommended model is
             automatically selected for the task.
             Note: for better compatibility with OpenAI's client, `model` has been aliased as `base_url`. Those 2
-            arguments are mutually exclusive. If using `base_url` for chat completion, the `/v1/chat/completions` suffix
-            path will be appended to the base URL. When passing a URL as `model`, the `/v1/chat/completions` suffix path will be appended to it.
+            arguments are mutually exclusive. If a URL is passed as `model` or `base_url` for chat completion, the `(/v1)/chat/completions` suffix path will be appended to the URL.
         provider (`str`, *optional*):
             Name of the provider to use for inference. Can be `"black-forest-labs"`, `"cerebras"`, `"cohere"`, `"fal-ai"`, `"featherless-ai"`, `"fireworks-ai"`, `"groq"`, `"hf-inference"`, `"hyperbolic"`, `"nebius"`, `"novita"`, `"nscale"`, `"openai"`, `"replicate"`, "sambanova"` or `"together"`.
             Defaults to "auto" i.e. the first of the providers available for the model, sorted by the user's order in https://hf.co/settings/inference-providers.

--- a/src/huggingface_hub/inference/_providers/hf_inference.py
+++ b/src/huggingface_hub/inference/_providers/hf_inference.py
@@ -2,6 +2,7 @@ import json
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, Optional, Union
+from urllib.parse import urlparse, urlunparse
 
 from huggingface_hub import constants
 from huggingface_hub.hf_api import InferenceProviderMapping
@@ -125,18 +126,27 @@ class HFInferenceConversational(HFInferenceTask):
 
 
 def _build_chat_completion_url(model_url: str) -> str:
-    # Strip trailing /
-    model_url = model_url.rstrip("/")
+    parsed = urlparse(model_url)
+    path = parsed.path
 
-    # Append /chat/completions if not already present
-    if model_url.endswith("/v1"):
-        model_url += "/chat/completions"
+    # If the path already ends with /chat/completions, we're done!
+    if path.endswith("/chat/completions"):
+        return model_url
 
-    # Append /v1/chat/completions if not already present
-    if not model_url.endswith("/chat/completions"):
-        model_url += "/v1/chat/completions"
+    path_stripped = path.rstrip("/")
 
-    return model_url
+    # If the path ends with /v1, just append /chat/completions.
+    if path_stripped.endswith("/v1"):
+        new_path = path_stripped + "/chat/completions"
+    # If path was empty or just "/", set the full path
+    elif not path_stripped:
+        new_path = "/v1/chat/completions"
+    # Append the full /v1/chat/completions.
+    else:
+        new_path = path_stripped + "/v1/chat/completions"
+
+    # Reconstruct the URL with the new path and original query parameters.
+    return urlunparse(parsed._replace(path=new_path))
 
 
 @lru_cache(maxsize=1)

--- a/src/huggingface_hub/inference/_providers/hf_inference.py
+++ b/src/huggingface_hub/inference/_providers/hf_inference.py
@@ -127,23 +127,22 @@ class HFInferenceConversational(HFInferenceTask):
 
 def _build_chat_completion_url(model_url: str) -> str:
     parsed = urlparse(model_url)
-    path = parsed.path
+    path = parsed.path.rstrip("/")
 
     # If the path already ends with /chat/completions, we're done!
     if path.endswith("/chat/completions"):
         return model_url
 
-    path_stripped = path.rstrip("/")
 
     # Append /chat/completions if not already present
-    if path_stripped.endswith("/v1"):
-        new_path = path_stripped + "/chat/completions"
+    if path.endswith("/v1"):
+        new_path = path + "/chat/completions"
     # If path was empty or just "/", set the full path
-    elif not path_stripped:
+    elif not path:
         new_path = "/v1/chat/completions"
     # Append /v1/chat/completions if not already present
     else:
-        new_path = path_stripped + "/v1/chat/completions"
+        new_path = path + "/v1/chat/completions"
 
     # Reconstruct the URL with the new path and original query parameters.
     return urlunparse(parsed._replace(path=new_path))

--- a/src/huggingface_hub/inference/_providers/hf_inference.py
+++ b/src/huggingface_hub/inference/_providers/hf_inference.py
@@ -133,7 +133,6 @@ def _build_chat_completion_url(model_url: str) -> str:
     if path.endswith("/chat/completions"):
         return model_url
 
-
     # Append /chat/completions if not already present
     if path.endswith("/v1"):
         new_path = path + "/chat/completions"

--- a/src/huggingface_hub/inference/_providers/hf_inference.py
+++ b/src/huggingface_hub/inference/_providers/hf_inference.py
@@ -135,13 +135,13 @@ def _build_chat_completion_url(model_url: str) -> str:
 
     path_stripped = path.rstrip("/")
 
-    # If the path ends with /v1, just append /chat/completions.
+    # Append /chat/completions if not already present
     if path_stripped.endswith("/v1"):
         new_path = path_stripped + "/chat/completions"
     # If path was empty or just "/", set the full path
     elif not path_stripped:
         new_path = "/v1/chat/completions"
-    # Append the full /v1/chat/completions.
+    # Append /v1/chat/completions if not already present
     else:
         new_path = path_stripped + "/v1/chat/completions"
 

--- a/tests/test_inference_client.py
+++ b/tests/test_inference_client.py
@@ -1034,6 +1034,23 @@ LOCAL_TGI_URL = "http://0.0.0.0:8080"
             f"{LOCAL_TGI_URL}/v1",
             f"{LOCAL_TGI_URL}/v1/chat/completions",
         ),
+        # With query parameters
+        (
+            f"{INFERENCE_ENDPOINT_URL}/v1/chat/completions?api-version=1",
+            f"{INFERENCE_ENDPOINT_URL}/v1/chat/completions?api-version=1",
+        ),
+        (
+            f"{INFERENCE_ENDPOINT_URL}?api-version=1",
+            f"{INFERENCE_ENDPOINT_URL}/v1/chat/completions?api-version=1",
+        ),
+        (
+            f"{INFERENCE_ENDPOINT_URL}/v1?api-version=1",
+            f"{INFERENCE_ENDPOINT_URL}/v1/chat/completions?api-version=1",
+        ),
+        (
+            f"{INFERENCE_ENDPOINT_URL}/?api-version=1",
+            f"{INFERENCE_ENDPOINT_URL}/v1/chat/completions?api-version=1",
+        ),
     ],
 )
 def test_resolve_chat_completion_url(model_url: str, expected_url: str):

--- a/tests/test_inference_client.py
+++ b/tests/test_inference_client.py
@@ -1040,6 +1040,10 @@ LOCAL_TGI_URL = "http://0.0.0.0:8080"
             f"{INFERENCE_ENDPOINT_URL}/v1/chat/completions?api-version=1",
         ),
         (
+            f"{INFERENCE_ENDPOINT_URL}/chat/completions?api-version=1",
+            f"{INFERENCE_ENDPOINT_URL}/chat/completions?api-version=1",
+        ),
+        (
             f"{INFERENCE_ENDPOINT_URL}?api-version=1",
             f"{INFERENCE_ENDPOINT_URL}/v1/chat/completions?api-version=1",
         ),


### PR DESCRIPTION
Fixes #3193
This PR fixes a bug in the `_build_chat_completion_url` helper function, which was incorrectly handling URLs that contained query parameters. previously, the function relied on simple string checks like `model_url.endswith("/v1")` or `model_url.endswith("/chat/completions")` to decide whether to append a path suffix. this logic failed when a URL contained a query string, as the suffix would no longer be at the very end of the string.
this led to malformed urls. for e.g.:
```python
input_url = "https://something.com/something/chat/completions?query=123"
output = _build_chat_completion_url(input_url)
# incorrect output: https://something.com/something/chat/completions?query=123/v1/chat/completions
```
the function has been refactored to use `urllib.parse`.

the `model` docstring in `InferenceClient`/`AsyncInferenceClient`  was also misleading, stating that when passing a URL, no suffix is appended, which is incorrect: the client ensures the URL path ends with `/v1/chat/completions`, regardless of whether the URL is passed via the `model` or `base_url` parameter. this has been updated as well in this PR.
