### PR TITLE
Fix: Handle nested config dict in `add_mcp_server` to prevent KeyError: 'command'

### DIFF
--- a/src/huggingface_hub/inference/_mcp/mcp_client.py
+++ b/src/huggingface_hub/inference/_mcp/mcp_client.py
@@ -154,6 +154,9 @@ class MCPClient:
         from mcp import ClientSession, StdioServerParameters
         from mcp import types as mcp_types
 
+        # Handle nested config
+        params = params['config'] if 'config' in params else params
+
         # Determine server type and create appropriate parameters
         if type == "stdio":
             # Handle stdio server


### PR DESCRIPTION
### Description:
This PR addresses [issue #3203](https://github.com/huggingface/huggingface_hub/issues/3203) by adding support for a nested config dictionary when calling `add_mcp_server`. 
To fix the issue, added a simple fallback to unwrap the nested config. This allows both nested and flat parameter formats to work without breaking existing usage. Tested locally with agent.json of input to confirm that the function now works as expected without throwing an error. I noticed currently, there doesn't seem to be one for this path under tests.



