### PR TITLE
Update tiny-agents example

### DIFF
--- a/src/huggingface_hub/inference/_mcp/constants.py
+++ b/src/huggingface_hub/inference/_mcp/constants.py
@@ -16,21 +16,17 @@ DEFAULT_AGENT = {
     "servers": [
         {
             "type": "stdio",
-            "config": {
-                "command": "npx",
-                "args": [
-                    "-y",
-                    "@modelcontextprotocol/server-filesystem",
-                    str(Path.home() / ("Desktop" if sys.platform == "darwin" else "")),
-                ],
-            },
+            "command": "npx",
+            "args": [
+                "-y",
+                "@modelcontextprotocol/server-filesystem",
+                str(Path.home() / ("Desktop" if sys.platform == "darwin" else "")),
+            ],
         },
         {
             "type": "stdio",
-            "config": {
-                "command": "npx",
-                "args": ["@playwright/mcp@latest"],
-            },
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"],
         },
     ],
 }


### PR DESCRIPTION
Fix https://github.com/huggingface/huggingface_hub/issues/3203.

Fix docs example after https://github.com/huggingface/huggingface_hub/pull/3166 / https://github.com/huggingface/huggingface.js/pull/1556. Since release [0.33.2](https://github.com/huggingface/huggingface_hub/releases/tag/v0.33.2) `tiny-agents` config follow VSCode format. We made the change without a proper deprecation warning as it's still experimental and we wanted to harmonize with VSCode as quickly as possible (to avoid future conflicts).  

Related PRs:
- https://github.com/huggingface/hub-docs/pull/1816
- https://github.com/huggingface/transformers/pull/39245
- https://github.com/huggingface/huggingface_hub/pull/3205
- https://github.com/huggingface/huggingface.js/pull/1599