### PR TITLE
Suppress xet install WARN if HF_HUB_DISABLE_XET

### DIFF
--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -291,3 +291,4 @@ HUGGINGFACE_HEADER_LINK_XET_AUTH_KEY = "xet-auth"
 
 default_xet_cache_path = os.path.join(HF_HOME, "xet")
 HF_XET_CACHE = os.getenv("HF_XET_CACHE", default_xet_cache_path)
+HF_HUB_DISABLE_XET: bool = _is_true(os.environ.get("HF_HUB_DISABLE_XET"))

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -62,7 +62,7 @@ from .utils import (
     validate_hf_hub_args,
 )
 from .utils._http import _adjust_range_header, http_backoff
-from .utils._runtime import _PY_VERSION, is_xet_available, is_xet_disabled  # noqa: F401 # for backward compatibility
+from .utils._runtime import _PY_VERSION, is_xet_available  # noqa: F401 # for backward compatibility
 from .utils._typing import HTTP_METHOD_T
 from .utils.sha import sha_fileobj
 from .utils.tqdm import _get_progress_bar_context
@@ -1718,7 +1718,7 @@ def _download_to_tmp_and_move(
                 displayed_filename=filename,
             )
         else:
-            if xet_file_data is not None and not is_xet_disabled():
+            if xet_file_data is not None and not constants._is_true(os.environ.get("HF_HUB_DISABLE_XET")):
                 logger.warning(
                     "Xet Storage is enabled for this repo, but the 'hf_xet' package is not installed. "
                     "Falling back to regular HTTP download. "

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -62,7 +62,7 @@ from .utils import (
     validate_hf_hub_args,
 )
 from .utils._http import _adjust_range_header, http_backoff
-from .utils._runtime import _PY_VERSION, is_xet_available  # noqa: F401 # for backward compatibility
+from .utils._runtime import _PY_VERSION, is_xet_available, is_xet_disabled  # noqa: F401 # for backward compatibility
 from .utils._typing import HTTP_METHOD_T
 from .utils.sha import sha_fileobj
 from .utils.tqdm import _get_progress_bar_context
@@ -1718,7 +1718,7 @@ def _download_to_tmp_and_move(
                 displayed_filename=filename,
             )
         else:
-            if xet_file_data is not None:
+            if xet_file_data is not None and not is_xet_disabled():
                 logger.warning(
                     "Xet Storage is enabled for this repo, but the 'hf_xet' package is not installed. "
                     "Falling back to regular HTTP download. "

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1718,7 +1718,7 @@ def _download_to_tmp_and_move(
                 displayed_filename=filename,
             )
         else:
-            if xet_file_data is not None and not constants._is_true(os.environ.get("HF_HUB_DISABLE_XET")):
+            if xet_file_data is not None and not constants.HF_HUB_DISABLE_XET:
                 logger.warning(
                     "Xet Storage is enabled for this repo, but the 'hf_xet' package is not installed. "
                     "Falling back to regular HTTP download. "

--- a/src/huggingface_hub/utils/_runtime.py
+++ b/src/huggingface_hub/utils/_runtime.py
@@ -155,7 +155,7 @@ def get_hf_transfer_version() -> str:
 # xet
 def is_xet_available() -> bool:
     # since hf_xet is automatically used if available, allow explicit disabling via environment variable
-    if constants._is_true(os.environ.get("HF_HUB_DISABLE_XET")):  # type: ignore
+    if constants.HF_HUB_DISABLE_XET:
         return False
 
     return is_package_available("hf_xet")

--- a/src/huggingface_hub/utils/_runtime.py
+++ b/src/huggingface_hub/utils/_runtime.py
@@ -154,15 +154,11 @@ def get_hf_transfer_version() -> str:
 
 # xet
 def is_xet_available() -> bool:
-    if is_xet_disabled():
+    # since hf_xet is automatically used if available, allow explicit disabling via environment variable
+    if constants._is_true(os.environ.get("HF_HUB_DISABLE_XET")):  # type: ignore
         return False
 
     return is_package_available("hf_xet")
-
-
-def is_xet_disabled() -> bool:
-    # since hf_xet is automatically used if available, allow explicit disabling via environment variable
-    return constants._is_true(os.environ.get("HF_HUB_DISABLE_XET"))  # type: ignore
 
 
 def get_xet_version() -> str:

--- a/src/huggingface_hub/utils/_runtime.py
+++ b/src/huggingface_hub/utils/_runtime.py
@@ -154,11 +154,15 @@ def get_hf_transfer_version() -> str:
 
 # xet
 def is_xet_available() -> bool:
-    # since hf_xet is automatically used if available, allow explicit disabling via environment variable
-    if constants._is_true(os.environ.get("HF_HUB_DISABLE_XET")):  # type: ignore
+    if is_xet_disabled():
         return False
 
     return is_package_available("hf_xet")
+
+
+def is_xet_disabled() -> bool:
+    # since hf_xet is automatically used if available, allow explicit disabling via environment variable
+    return constants._is_true(os.environ.get("HF_HUB_DISABLE_XET"))  # type: ignore
 
 
 def get_xet_version() -> str:

--- a/tests/test_xet_utils.py
+++ b/tests/test_xet_utils.py
@@ -288,5 +288,6 @@ def test_env_var_hf_hub_disable_xet() -> None:
     from huggingface_hub.utils._runtime import is_xet_available
 
     monkeypatch = MonkeyPatch()
-    monkeypatch.setenv("HF_HUB_DISABLE_XET", "1")
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_DISABLE_XET", True)
+
     assert not is_xet_available()


### PR DESCRIPTION
Suppresses the WARN message to install `hf-xet` if `hf-xet` has been disabled (using `HF_HUB_DISABLE_XET` env variable).

See image below of WARN message.
![image](https://github.com/user-attachments/assets/549c223a-430f-4fa6-a834-98221bccb7a6)
