### PR TITLE
Omit `parameters` in default tools of `tiny-agent`

### DIFF
--- a/src/huggingface_hub/inference/_mcp/constants.py
+++ b/src/huggingface_hub/inference/_mcp/constants.py
@@ -54,7 +54,6 @@ TASK_COMPLETE_TOOL: ChatCompletionInputTool = ChatCompletionInputTool.parse_obj(
         "function": {
             "name": "task_complete",
             "description": "Call this tool when the task given by the user is complete",
-            "parameters": {"type": "object", "properties": {}},
         },
     }
 )
@@ -65,7 +64,6 @@ ASK_QUESTION_TOOL: ChatCompletionInputTool = ChatCompletionInputTool.parse_obj( 
         "function": {
             "name": "ask_question",
             "description": "Ask the user for more info required to solve or clarify their problem.",
-            "parameters": {"type": "object", "properties": {}},
         },
     }
 )


### PR DESCRIPTION
Fixes #3213.
OpenAI validates every function -> parameters object as a full json schema, if the schema contains a "properties" field, at least one property has to be defined. according to OpenAI’s specs, omitting parameters is the correct way to express a function that takes no arguments:

<img width="672" height="491" alt="Screenshot 2025-07-11 at 11 21 24" src="https://github.com/user-attachments/assets/2aa1da75-f57c-4cc9-b655-0bd4c5447fbc" />
