### PR TITLE
Bump to 0.34.0.dev0

### DIFF
--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -46,7 +46,7 @@ import sys
 from typing import TYPE_CHECKING
 
 
-__version__ = "0.33.0.dev0"
+__version__ = "0.34.0.dev0"
 
 # Alphabetical order of definitions is ensured in tests
 # WARNING: any comment added in this dictionary definition will be lost when


### PR DESCRIPTION
Seems like we forgot to do it ^^ No deprecation or changes planned 