### PR TITLE
Add a DeepWiki badge in the repo's README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
     <a href="https://github.com/huggingface/huggingface_hub"><img alt="PyPi version" src="https://img.shields.io/pypi/pyversions/huggingface_hub.svg"></a>
     <a href="https://pypi.org/project/huggingface-hub"><img alt="PyPI - Downloads" src="https://img.shields.io/pypi/dm/huggingface_hub"></a>
     <a href="https://codecov.io/gh/huggingface/huggingface_hub"><img alt="Code coverage" src="https://codecov.io/gh/huggingface/huggingface_hub/branch/main/graph/badge.svg?token=RXP95LE2XL"></a>
+    <a href="https://deepwiki.com/huggingface/huggingface_hub"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
 </p>
 
 <h4 align="center">


### PR DESCRIPTION
Add a DeepWiki badge in the repo's README to auto-refresh DeepWiki index