### PR TITLE
[tiny-agents] Configure inference API key from inputs + keep empty dicts in chat completion payload

### DIFF
--- a/src/huggingface_hub/inference/_mcp/cli.py
+++ b/src/huggingface_hub/inference/_mcp/cli.py
@@ -71,6 +71,8 @@ async def run_agent(
             signal.signal(signal.SIGINT, lambda *_: _sigint_handler())
 
         # Handle inputs (i.e. env variables injection)
+        resolved_inputs: dict[str, str] = {}
+
         if len(inputs) > 0:
             print(
                 "[bold blue]Some initial inputs are required by the agent. "
@@ -79,22 +81,9 @@ async def run_agent(
             for input_item in inputs:
                 input_id = input_item["id"]
                 description = input_item["description"]
-                env_special_value = "${input:" + input_id + "}"  # Special value to indicate env variable injection
+                env_special_value = f"${{input:{input_id}}}"
 
-                # Check env variables that will use this input
-                input_vars = set()
-                for server in servers:
-                    # Check stdio's "env" and http/sse's "headers" mappings
-                    env_or_headers = server.get("env", {}) if server["type"] == "stdio" else server.get("headers", {})
-                    for key, value in env_or_headers.items():
-                        if env_special_value in value:
-                            input_vars.add(key)
-
-                if not input_vars:
-                    print(f"[yellow]Input {input_id} defined in config but not used by any server.[/yellow]")
-                    continue
-
-                # Prompt user for input
+                # Prompt user for input even if not referenced by any server – may be used for high-level config (e.g. apiKey)
                 env_variable_key = input_id.replace("-", "_").upper()
                 print(
                     f"[blue] • {input_id}[/blue]: {description}. (default: load from {env_variable_key}).",
@@ -104,30 +93,39 @@ async def run_agent(
                 if exit_event.is_set():
                     return
 
-                # Inject user input (or env variable) into stdio's env or http/sse's headers
+                # Fallback to environment variable when user left blank
+                final_value = user_input
+                if not final_value:
+                    final_value = os.getenv(env_variable_key, "")
+                    if final_value:
+                        print(f"[green]Value successfully loaded from '{env_variable_key}'[/green]")
+                    else:
+                        print(
+                            f"[yellow]No value found for '{env_variable_key}' in environment variables. Continuing.[/yellow]"
+                        )
+                resolved_inputs[input_id] = final_value
+
+                # Inject resolved value (can be empty) into stdio's env or http/sse's headers
                 for server in servers:
                     env_or_headers = server.get("env", {}) if server["type"] == "stdio" else server.get("headers", {})
                     for key, value in env_or_headers.items():
                         if env_special_value in value:
-                            if user_input:
-                                env_or_headers[key] = env_or_headers[key].replace(env_special_value, user_input)
-                            else:
-                                value_from_env = os.getenv(env_variable_key, "")
-                                env_or_headers[key] = env_or_headers[key].replace(env_special_value, value_from_env)
-                                if value_from_env:
-                                    print(f"[green]Value successfully loaded from '{env_variable_key}'[/green]")
-                                else:
-                                    print(
-                                        f"[yellow]No value found for '{env_variable_key}' in environment variables. Continuing.[/yellow]"
-                                    )
+                            env_or_headers[key] = env_or_headers[key].replace(env_special_value, final_value)
 
             print()
 
+        raw_api_key = config.get("apiKey")
+        if isinstance(raw_api_key, str):
+            substituted_api_key = raw_api_key
+            for input_id, val in resolved_inputs.items():
+                substituted_api_key = substituted_api_key.replace(f"${{input:{input_id}}}", val)
+            config["apiKey"] = substituted_api_key
         # Main agent loop
         async with Agent(
             provider=config.get("provider"),  # type: ignore[arg-type]
             model=config.get("model"),
             base_url=config.get("endpointUrl"),  # type: ignore[arg-type]
+            api_key=config.get("apiKey"),
             servers=servers,  # type: ignore[arg-type]
             prompt=prompt,
         ) as agent:

--- a/src/huggingface_hub/inference/_mcp/constants.py
+++ b/src/huggingface_hub/inference/_mcp/constants.py
@@ -56,12 +56,7 @@ TASK_COMPLETE_TOOL: ChatCompletionInputTool = ChatCompletionInputTool.parse_obj(
             "description": "Call this tool when the task given by the user is complete",
             "parameters": {
                 "type": "object",
-                "properties": {
-                    "trigger": {
-                        "type": "boolean",
-                        "description": "Set to true to trigger this function",
-                    }
-                },
+                "properties": {},
             },
         },
     }
@@ -75,12 +70,7 @@ ASK_QUESTION_TOOL: ChatCompletionInputTool = ChatCompletionInputTool.parse_obj( 
             "description": "Ask the user for more info required to solve or clarify their problem.",
             "parameters": {
                 "type": "object",
-                "properties": {
-                    "trigger": {
-                        "type": "boolean",
-                        "description": "Set to true to trigger this function",
-                    }
-                },
+                "properties": {},
             },
         },
     }

--- a/src/huggingface_hub/inference/_mcp/types.py
+++ b/src/huggingface_hub/inference/_mcp/types.py
@@ -1,5 +1,7 @@
 from typing import Dict, List, Literal, TypedDict, Union
 
+from typing_extensions import NotRequired
+
 
 class InputConfig(TypedDict, total=False):
     id: str
@@ -35,5 +37,6 @@ ServerConfig = Union[StdioServerConfig, HTTPServerConfig, SSEServerConfig]
 class AgentConfig(TypedDict):
     model: str
     provider: str
+    apiKey: NotRequired[str]
     inputs: List[InputConfig]
     servers: List[ServerConfig]

--- a/src/huggingface_hub/inference/_providers/_common.py
+++ b/src/huggingface_hub/inference/_providers/_common.py
@@ -51,9 +51,6 @@ def filter_none(obj: Union[Dict[str, Any], List[Any]]) -> Union[Dict[str, Any], 
                 continue
             if isinstance(v, (dict, list)):
                 v = filter_none(v)
-                # remove empty nested dicts
-                if isinstance(v, dict) and not v:
-                    continue
             cleaned[k] = v
         return cleaned
 

--- a/tests/test_inference_providers.py
+++ b/tests/test_inference_providers.py
@@ -1445,10 +1445,10 @@ def test_recursive_merge(dict1: Dict, dict2: Dict, expected: Dict):
         ({}, {}),  # empty dictionary remains empty
         ({"a": 1, "b": None, "c": 3}, {"a": 1, "c": 3}),  # remove None at root level
         ({"a": None, "b": {"x": None, "y": 2}}, {"b": {"y": 2}}),  # remove nested None
-        ({"a": {"b": {"c": None}}}, {}),  # remove empty nested dict
+        ({"a": {"b": {"c": None}}}, {"a": {"b": {}}}),  # remove empty nested dict
         (
             {"a": "", "b": {"x": {"y": None}, "z": 0}, "c": []},  # do not remove 0, [] and "" values
-            {"a": "", "b": {"z": 0}, "c": []},
+            {"a": "", "b": {"x": {}, "z": 0}, "c": []},
         ),
         (
             {"a": [0, 1, None]},  # do not remove None in lists


### PR DESCRIPTION
This PR introduces a way to pass an API key for the inference client by allowing it to be configured from the inputs section.

The example below shows how to configure the `apiKey` for OpenAI API. the key will be requested from the user via a password prompt if not set as an environment variable (Note: this was already implemented for server-specific credentials and env variables, this PR extends this for high-level credentials configuration).

{
	"model": "gpt-4o",
    "provider": "openai",
    "apiKey": "${input:openai_api_key}",
	"inputs": [
		{
			"type": "promptString",
			"id": "hf-token",
			"description": "Your Hugging Face Token",
			"password": true
		},
		{
            "type": "promptString",
            "id": "openai-api-key",
            "description": "OpenAI API Key",
            "password": true
        }
		
	],
	"servers": [
		{
			"type": "http",
			"url": "https://huggingface.co/mcp",
			"headers": {
				"Authorization": "Bearer ${input:hf-token}"
			}
		}
	]
}

⚠️  This PR also fixes how we filter None values in chat completion payload, it turns out we filter out empty dicts, this caused the `properties` field inside the tool `parameters` to disappear when it was empty, breaking the openai compatible schema.