### PR TITLE
upload large folder operations uses batches of files for preupload-lfs jobs for xet-enabled repositories

### DIFF
--- a/tests/test_upload_large_folder.py
+++ b/tests/test_upload_large_folder.py
@@ -6,7 +6,7 @@ from huggingface_hub._upload_large_folder import COMMIT_SIZE_SCALE, LargeUploadS
 
 @pytest.fixture
 def status():
-    return LargeUploadStatus(items=[])
+    return LargeUploadStatus(items=[], upload_batch_size=1)
 
 
 def test_target_chunk_default(status):


### PR DESCRIPTION
hf_xet upload performance and future deduplication and downloads of a repository suffer significantly when using upload-large-folder. This is because upload-large-folder (through some plumbing) calls hf_xet.upload_files() with 1 file at each call.

This PR changes upload-large-folder to hold a preupload lfs batch size and process LFS uploads in batches of files.

The batch upload size is set to:
- 256 for a xet-enabled repository
- 1 for regular LFS -> no behavior change for upload-large-folder with an LFS repository.

cc @rajatarya 