### PR TITLE
Update to use only summary bars for uploads when in notebooks

### DIFF
--- a/src/huggingface_hub/utils/tqdm.py
+++ b/src/huggingface_hub/utils/tqdm.py
@@ -89,7 +89,6 @@ from pathlib import Path
 from typing import ContextManager, Dict, Iterator, Optional, Union
 
 from tqdm.auto import tqdm as old_tqdm
-from tqdm.std import tqdm as std_tqdm
 
 from ..constants import HF_HUB_DISABLE_PROGRESS_BARS
 


### PR DESCRIPTION
Currently, the progress of uploading files to a Xet enabled repo does both per-file and summary reporting of the progress.  However, the per-file progress may not be communicated to gui or notebook environments in a useful way as different bars are repurposed for different files to display a scrolling list of in-progress files with completed files removed.  This PR disables the scrolling per-file reporting for gui and notebook environments, showing only the two summary bars. 