### PR TITLE
Fix Incomplete File Not found on windows systems

### DIFF
--- a/src/huggingface_hub/_local_folder.py
+++ b/src/huggingface_hub/_local_folder.py
@@ -86,7 +86,13 @@ class LocalDownloadFilePaths:
 
     def incomplete_path(self, etag: str) -> Path:
         """Return the path where a file will be temporarily downloaded before being moved to `file_path`."""
-        return self.metadata_path.parent / f"{_short_hash(self.metadata_path.name)}.{etag}.incomplete"
+        path = self.metadata_path.parent / f"{_short_hash(self.metadata_path.name)}.{etag}.incomplete"
+        resolved_path = str(path.resolve())
+        # Some Windows versions do not allow for paths longer than 255 characters.
+        # In this case, we must specify it as an extended path by using the "\\?\" prefix.
+        if len(resolved_path) > 255 and not resolved_path.startswith("\\\\?\\"):
+            path = Path("\\\\?\\"+resolved_path)
+        return path
 
 
 @dataclass(frozen=True)

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1136,10 +1136,10 @@ def _hf_hub_download_to_cache_dir(
 
     # Some Windows versions do not allow for paths longer than 255 characters.
     # In this case, we must specify it as an extended path by using the "\\?\" prefix.
-    if os.name == "nt" and len(os.path.abspath(lock_path)) > 255:
+    if os.name == "nt" and len(os.path.abspath(lock_path)) > 255 and not os.path.abspath(lock_path).startswith("\\\\?\\"):
         lock_path = "\\\\?\\" + os.path.abspath(lock_path)
 
-    if os.name == "nt" and len(os.path.abspath(blob_path)) > 255:
+    if os.name == "nt" and len(os.path.abspath(blob_path)) > 255 not os.path.abspath(blob_path).startswith("\\\\?\\"):
         blob_path = "\\\\?\\" + os.path.abspath(blob_path)
 
     Path(lock_path).parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Paths longer than 256 characters are invalid on certain Windows versions. Adding the prefix "\\?\" should solve the issue. The implementation did not check for incomplete files during the path creation process. And in case the path already had the prefix, the last implementation added the prefix again, making the path invalid.

