### PR TITLE
Rename huggingface-cli jobs to hf jobs

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -603,28 +603,28 @@ Copy-and-paste the text below in your GitHub issue.
 - HF_HUB_DOWNLOAD_TIMEOUT: 10
 ```
 
-## huggingface-cli jobs
+## hf jobs
 
 Run compute jobs on Hugging Face infrastructure with a familiar Docker-like interface.
 
-`huggingface-cli jobs` is a command-line tool that lets you run anything on Hugging Face's infrastructure (including GPUs and TPUs!) with simple commands. Think `docker run`, but for running code on A100s.
+`hf jobs` is a command-line tool that lets you run anything on Hugging Face's infrastructure (including GPUs and TPUs!) with simple commands. Think `docker run`, but for running code on A100s.
 
 ```bash
 # Directly run Python code
->>> huggingface-cli jobs run python:3.12 python -c "print('Hello from the cloud!')"
+>>> hf jobs run python:3.12 python -c "print('Hello from the cloud!')"
 
 # Use GPUs without any setup
->>> huggingface-cli jobs run --flavor a10g-small pytorch/pytorch:2.6.0-cuda12.4-cudnn9-devel \
+>>> hf jobs run --flavor a10g-small pytorch/pytorch:2.6.0-cuda12.4-cudnn9-devel \
 ... python -c "import torch; print(torch.cuda.get_device_name())"
 
 # Run in an organization account
->>> huggingface-cli jobs run --namespace my-org-name python:3.12 python -c "print('Running in an org account')"
+>>> hf jobs run --namespace my-org-name python:3.12 python -c "print('Running in an org account')"
 
 # Run from Hugging Face Spaces
->>> huggingface-cli jobs run hf.co/spaces/lhoestq/duckdb duckdb -c "select 'hello world'"
+>>> hf jobs run hf.co/spaces/lhoestq/duckdb duckdb -c "select 'hello world'"
 
 # Run a Python script with `uv` (experimental)
->>> huggingface-cli jobs uv run my_script.py
+>>> hf jobs uv run my_script.py
 ```
 
 ### ✨ Key Features
@@ -642,7 +642,7 @@ Run compute jobs on Hugging Face infrastructure with a familiar Docker-like inte
 
 ```bash
 # Run a simple Python script
->>> huggingface-cli jobs run python:3.12 python -c "print('Hello from HF compute!')"
+>>> hf jobs run python:3.12 python -c "print('Hello from HF compute!')"
 ```
 
 This command runs the job and shows the logs. You can pass `--detach` to run the Job in the background and only print the Job ID.
@@ -651,16 +651,16 @@ This command runs the job and shows the logs. You can pass `--detach` to run the
 
 ```bash
 # List your running jobs
->>> huggingface-cli jobs ps
+>>> hf jobs ps
 
 # Inspect the status of a job
->>> huggingface-cli jobs inspect <job_id>
+>>> hf jobs inspect <job_id>
 
 # View logs from a job
->>> huggingface-cli jobs logs <job_id>
+>>> hf jobs logs <job_id>
 
 # Cancel a job
->>> huggingface-cli jobs cancel <job_id>
+>>> hf jobs cancel <job_id>
 ```
 
 #### 3. Run on GPU
@@ -669,7 +669,7 @@ You can also run jobs on GPUs or TPUs with the `--flavor` option. For example, t
 
 ```bash
 # Use an A10G GPU to check PyTorch CUDA
->>> huggingface-cli jobs run --flavor a10g-small pytorch/pytorch:2.6.0-cuda12.4-cudnn9-devel \
+>>> hf jobs run --flavor a10g-small pytorch/pytorch:2.6.0-cuda12.4-cudnn9-devel \
 ... python -c "import torch; print(f"This code ran with the following GPU: {torch.cuda.get_device_name()}")"
 ```
 
@@ -696,22 +696,22 @@ You can pass environment variables to your job using
 
 ```bash
 # Pass environment variables
->>> huggingface-cli jobs run -e FOO=foo -e BAR=bar python:3.12 python -c "import os; print(os.environ['FOO'], os.environ['BAR'])"
+>>> hf jobs run -e FOO=foo -e BAR=bar python:3.12 python -c "import os; print(os.environ['FOO'], os.environ['BAR'])"
 ```
 
 ```bash
 # Pass an environment from a local .env file
->>> huggingface-cli jobs run --env-file .env python:3.12 python -c "import os; print(os.environ['FOO'], os.environ['BAR'])"
+>>> hf jobs run --env-file .env python:3.12 python -c "import os; print(os.environ['FOO'], os.environ['BAR'])"
 ```
 
 ```bash
 # Pass secrets - they will be encrypted server side
->>> huggingface-cli jobs run -s MY_SECRET=psswrd python:3.12 python -c "import os; print(os.environ['MY_SECRET'])"
+>>> hf jobs run -s MY_SECRET=psswrd python:3.12 python -c "import os; print(os.environ['MY_SECRET'])"
 ```
 
 ```bash
 # Pass secrets from a local .env.secrets file - they will be encrypted server side
->>> huggingface-cli jobs run --secrets-file .env.secrets python:3.12 python -c "import os; print(os.environ['MY_SECRET'])"
+>>> hf jobs run --secrets-file .env.secrets python:3.12 python -c "import os; print(os.environ['MY_SECRET'])"
 ```
 
 ### Hardware
@@ -730,19 +730,19 @@ Run UV scripts (Python scripts with inline dependencies) on HF infrastructure:
 
 ```bash
 # Run a UV script (creates temporary repo)
->>> huggingface-cli jobs uv run my_script.py
+>>> hf jobs uv run my_script.py
 
 # Run with persistent repo
->>> huggingface-cli jobs uv run my_script.py --repo my-uv-scripts
+>>> hf jobs uv run my_script.py --repo my-uv-scripts
 
 # Run with GPU
->>> huggingface-cli jobs uv run ml_training.py --flavor gpu-t4-small
+>>> hf jobs uv run ml_training.py --flavor gpu-t4-small
 
 # Pass arguments to script
->>> huggingface-cli jobs uv run process.py input.csv output.parquet --repo data-scripts
+>>> hf jobs uv run process.py input.csv output.parquet --repo data-scripts
 
 # Run a script directly from a URL
->>> huggingface-cli jobs uv run https://huggingface.co/datasets/username/scripts/resolve/main/example.py
+>>> hf jobs uv run https://huggingface.co/datasets/username/scripts/resolve/main/example.py
 ```
 
 UV scripts are Python scripts that include their dependencies directly in the file using a special comment syntax. This makes them perfect for self-contained tasks that don't require complex project setups. Learn more about UV scripts in the [UV documentation](https://docs.astral.sh/uv/guides/scripts/).

--- a/docs/source/en/guides/jobs.md
+++ b/docs/source/en/guides/jobs.md
@@ -59,7 +59,7 @@ This feature is pay-as-you-go: you only pay for the seconds you use.
 
 <Tip>
 
-Use [huggingface-cli jobs](./cli#huggingface-cli-jobs) to run jobs in the command line.
+Use [hf jobs](./cli#hf-jobs) to run jobs in the command line.
 
 </Tip>
 

--- a/src/huggingface_hub/cli/hf.py
+++ b/src/huggingface_hub/cli/hf.py
@@ -17,6 +17,7 @@ from argparse import ArgumentParser
 from huggingface_hub.cli.auth import AuthCommands
 from huggingface_hub.cli.cache import CacheCommand
 from huggingface_hub.cli.download import DownloadCommand
+from huggingface_hub.cli.jobs import JobsCommands
 from huggingface_hub.cli.lfs import LfsCommands
 from huggingface_hub.cli.repo import RepoCommands
 from huggingface_hub.cli.repo_files import RepoFilesCommand
@@ -33,6 +34,7 @@ def main():
     AuthCommands.register_subcommand(commands_parser)
     CacheCommand.register_subcommand(commands_parser)
     DownloadCommand.register_subcommand(commands_parser)
+    JobsCommands.register_subcommand(commands_parser)
     RepoCommands.register_subcommand(commands_parser)
     RepoFilesCommand.register_subcommand(commands_parser)
     UploadCommand.register_subcommand(commands_parser)

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -15,7 +15,19 @@
 
 Usage:
     # run a job
-    huggingface-cli jobs run image command
+    hf jobs run <image> <command>
+
+    # List running or completed jobs
+    hf jobs ps [-a] [-f key=value] [--format TEMPLATE]
+
+    # Stream logs from a job
+    hf jobs logs <job-id>
+
+    # Inspect detailed information about a job
+    hf jobs inspect <job-id>
+
+    # Cancel a running job
+    hf jobs cancel <job-id>
 """
 
 import json
@@ -43,7 +55,7 @@ SUGGESTED_FLAVORS = [item.value for item in SpaceHardware if item.value != "zero
 class JobsCommands(BaseHuggingfaceCLICommand):
     @staticmethod
     def register_subcommand(parser: _SubParsersAction):
-        jobs_parser = parser.add_parser("jobs", help="Commands to interact with your huggingface.co jobs.")
+        jobs_parser = parser.add_parser("jobs", help="Run and manage Jobs on the Hub.")
         jobs_subparsers = jobs_parser.add_subparsers(help="huggingface.co jobs related commands")
 
         # Register commands

--- a/src/huggingface_hub/commands/huggingface_cli.py
+++ b/src/huggingface_hub/commands/huggingface_cli.py
@@ -18,7 +18,6 @@ from huggingface_hub.commands._cli_utils import show_deprecation_warning
 from huggingface_hub.commands.delete_cache import DeleteCacheCommand
 from huggingface_hub.commands.download import DownloadCommand
 from huggingface_hub.commands.env import EnvironmentCommand
-from huggingface_hub.commands.jobs import JobsCommands
 from huggingface_hub.commands.lfs import LfsCommands
 from huggingface_hub.commands.repo import RepoCommands
 from huggingface_hub.commands.repo_files import RepoFilesCommand
@@ -46,7 +45,6 @@ def main():
     DeleteCacheCommand.register_subcommand(commands_parser)
     TagCommands.register_subcommand(commands_parser)
     VersionCommand.register_subcommand(commands_parser)
-    JobsCommands.register_subcommand(commands_parser)
 
     # Experimental
     UploadLargeFolderCommand.register_subcommand(commands_parser)

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -10390,16 +10390,16 @@ class HfApi:
 
                 # UV Script: {filename}
 
-                Executed via `huggingface-cli jobs uv run` on {timestamp}
+                Executed via `hf jobs uv run` on {timestamp}
 
                 ## Run this script
 
                 ```bash
-                huggingface-cli jobs uv run {filename}
+                hf jobs uv run {filename}
                 ```
 
                 ---
-                *Created with [huggingface-cli jobs](https://github.com/huggingface/huggingface-cli jobs)*
+                *Created with [hf jobs](https://huggingface.co/docs/huggingface_hub/main/en/guides/jobs)*
                 """
             )
             self.upload_file(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,10 +9,10 @@ from unittest.mock import Mock, patch
 
 from huggingface_hub.cli.cache import CacheCommand
 from huggingface_hub.cli.download import DownloadCommand
+from huggingface_hub.cli.jobs import JobsCommands, RunCommand
 from huggingface_hub.cli.repo import RepoCommands
 from huggingface_hub.cli.repo_files import DeleteFilesSubCommand, RepoFilesCommand
 from huggingface_hub.cli.upload import UploadCommand
-from huggingface_hub.commands.jobs import JobsCommands, RunCommand
 from huggingface_hub.errors import RevisionNotFoundError
 from huggingface_hub.utils import SoftTemporaryDirectory, capture_output
 
@@ -844,7 +844,7 @@ class TestJobsCommand(unittest.TestCase):
         """
         Set up CLI as in `src/huggingface_hub/commands/huggingface_cli.py`.
         """
-        self.parser = ArgumentParser("huggingface-cli", usage="huggingface-cli <command> [<args>]")
+        self.parser = ArgumentParser("hf", usage="hf <command> [<args>]")
         commands_parser = self.parser.add_subparsers()
         JobsCommands.register_subcommand(commands_parser)
 


### PR DESCRIPTION
Follow-up PR after https://github.com/huggingface/huggingface_hub/pull/3211 and https://github.com/huggingface/huggingface_hub/pull/3229 cc @lhoestq @davanstrien @hanouticelina.

This PR moves the Jobs CLI from `huggingface-cli jobs ...` (legacy) to `hf jobs ...` CLI. I did not do it in the 2 previous PRs to avoid bloating them.


`huggingface-cli jobs ...` is **completely** removed so we don't have duplicate CLI.