### PR TITLE
[Internal] Fix docstring param spacing check and `libcst` incompatibility with Python 3.13

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,7 @@ extras["quality"] = [
     "ruff>=0.9.0",
     "mypy>=1.14.1,<1.15.0; python_version=='3.8'",
     "mypy==1.15.0; python_version>='3.9'",
-    "libcst==1.4.0",
+    "libcst>=1.4.0",
 ]
 
 extras["all"] = extras["testing"] + extras["quality"] + extras["typing"]

--- a/utils/check_inference_input_params.py
+++ b/utils/check_inference_input_params.py
@@ -80,7 +80,7 @@ def check_method(method_name: str, method: Any):
             continue
         if param_name in PARAMETERS_TO_SKIP[method_name]:
             continue
-        if f"            {param_name} (" not in docstring:
+        if f"    {param_name} (" not in docstring:
             logs.append(f"Parameter {param_name} is not documented")
 
     return logs

--- a/utils/check_inference_input_params.py
+++ b/utils/check_inference_input_params.py
@@ -80,7 +80,7 @@ def check_method(method_name: str, method: Any):
             continue
         if param_name in PARAMETERS_TO_SKIP[method_name]:
             continue
-        if f"    {param_name} (" not in docstring:
+        if f"{param_name} (" not in docstring:
             logs.append(f"Parameter {param_name} is not documented")
 
     return logs


### PR DESCRIPTION
this PR fixes two internal issues:

- `make quality` fails on Python 3.13 because `utils/check_inference_input_params.py` looks for the literal fragment
"            {param_name} (" in every docstring., not 100% sure but maybe it's related to CPython 3.13 stripping the common indentation of docstrings, see: https://docs.python.org/3/whatsnew/3.13.html#other-language-changes. 

- `libcst` (used to update python files) installation failure on (at least) Python 3.13: when setting up the repo locally with newer Python versions (e.g., 3.13), the installation of `libcst` fails.