### PR TITLE
Fix: "UserWarning: ... sessions are still open..." when streaming with `AsyncInferenceClient`

### DIFF
--- a/src/huggingface_hub/inference/_common.py
+++ b/src/huggingface_hub/inference/_common.py
@@ -374,9 +374,12 @@ def _format_chat_completion_stream_output(
 
 
 async def _async_yield_from(client: "ClientSession", response: "ClientResponse") -> AsyncIterable[bytes]:
-    async for byte_payload in response.content:
-        yield byte_payload.strip()
-    await client.close()
+    try:
+        async for byte_payload in response.content:
+            yield byte_payload.strip()
+    finally:
+        # Always close the underlying HTTP session to avoid resource leaks
+        await client.close()
 
 
 # "TGI servers" are servers running with the `text-generation-inference` backend.


### PR DESCRIPTION
`AsyncInferenceClient` creates an `aiohttp.ClientSession` each time it makes a request. when streaming, the session is only closed after the async generator that yields the data finishes iterating:
```python
async for chunk in response.content:  
    yield chunk
await client.close()                   
```
if the user stops iteration as soon as they see the `[DONE]` event (see `_async_stream_chat_completion_response` and `_format_chat_completion_stream_output`), the `await client.close()` line is never executed. later, when the client object is garbage collected, we get this warning:
```
UserWarning: Deleting 'AsyncInferenceClient' client but some sessions are still open. This can happen if you've stopped streaming data from the server before the stream was complete. To close the client properly, you must call `await client.close()` or use an async context (e.g. `async with AsyncInferenceClient(): ...`.
Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x1026d6120>
Unclosed connector
connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x10a8a6ed0>, 91165.093372916)])']
connector: <aiohttp.connector.TCPConnector object at 0x1026d5e80>
```
the fix simply wraps the iteration in a try/finally block, regardless of how or when the caller stops consuming the stream, the finally clause guarantees the underlying session s closed.

----

repro:
```python
import asyncio
import os

from huggingface_hub import AsyncInferenceClient

client = AsyncInferenceClient(
    provider="novita",
    api_key=os.environ["HF_TOKEN"],
)


async def main():
    stream = await client.chat.completions.create(
        model="Qwen/Qwen3-Coder-480B-A35B-Instruct",
        messages=[{"role": "user", "content": "What is the capital of France?"}],
        stream=True,
    )

    async for chunk in stream:
        print(chunk.choices[0].delta.content, end="")


if __name__ == "__main__":
    asyncio.run(main())

```