### PR TITLE
[CLI] print help if no command provided

### DIFF
--- a/src/huggingface_hub/cli/auth.py
+++ b/src/huggingface_hub/cli/auth.py
@@ -62,6 +62,9 @@ class AuthCommands(BaseHuggingfaceCLICommand):
         auth_parser = parser.add_parser("auth", help="Manage authentication (login, logout, etc.).")
         auth_subparsers = auth_parser.add_subparsers(help="Authentication subcommands")
 
+        # Show help if no subcommand is provided
+        auth_parser.set_defaults(func=lambda args: auth_parser.print_help())
+
         # Add 'login' as a subcommand of 'auth'
         login_parser = auth_subparsers.add_parser(
             "login", help="Log in using a token from huggingface.co/settings/tokens"

--- a/src/huggingface_hub/cli/cache.py
+++ b/src/huggingface_hub/cli/cache.py
@@ -65,6 +65,10 @@ class CacheCommand(BaseHuggingfaceCLICommand):
     def register_subcommand(parser: _SubParsersAction):
         cache_parser = parser.add_parser("cache", help="Manage local cache directory.")
         cache_subparsers = cache_parser.add_subparsers(dest="cache_command", help="Cache subcommands")
+
+        # Show help if no subcommand is provided
+        cache_parser.set_defaults(func=lambda args: cache_parser.print_help())
+
         # Scan subcommand
         scan_parser = cache_subparsers.add_parser("scan", help="Scan cache directory.")
         scan_parser.add_argument(

--- a/src/huggingface_hub/cli/hf.py
+++ b/src/huggingface_hub/cli/hf.py
@@ -47,10 +47,6 @@ def main():
     # LFS commands (hidden in --help)
     LfsCommands.register_subcommand(commands_parser)
 
-    # Legacy commands
-
-    # Experimental
-
     # Let's go
     args = parser.parse_args()
     if not hasattr(args, "func"):
@@ -59,7 +55,8 @@ def main():
 
     # Run
     service = args.func(args)
-    service.run()
+    if service is not None:
+        service.run()
 
 
 if __name__ == "__main__":

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -58,6 +58,9 @@ class JobsCommands(BaseHuggingfaceCLICommand):
         jobs_parser = parser.add_parser("jobs", help="Run and manage Jobs on the Hub.")
         jobs_subparsers = jobs_parser.add_subparsers(help="huggingface.co jobs related commands")
 
+        # Show help if no subcommand is provided
+        jobs_parser.set_defaults(func=lambda args: jobs_parser.print_help())
+
         # Register commands
         InspectCommand.register_subcommand(jobs_subparsers)
         LogsCommand.register_subcommand(jobs_subparsers)

--- a/src/huggingface_hub/cli/repo.py
+++ b/src/huggingface_hub/cli/repo.py
@@ -43,6 +43,10 @@ class RepoCommands(BaseHuggingfaceCLICommand):
     def register_subcommand(parser: _SubParsersAction):
         repo_parser = parser.add_parser("repo", help="Manage repos on the Hub.")
         repo_subparsers = repo_parser.add_subparsers(help="huggingface.co repos related commands")
+
+        # Show help if no subcommand is provided
+        repo_parser.set_defaults(func=lambda args: repo_parser.print_help())
+
         # CREATE
         repo_create_parser = repo_subparsers.add_parser("create", help="Create a new repo on huggingface.co")
         repo_create_parser.add_argument(


### PR DESCRIPTION
From feedback of @gary149 [in DMs](https://huggingface.slack.com/archives/C07KX53FZTK/p1753450909686329?thread_ts=1753447417.509539&cid=C07KX53FZTK) (private)

With the PR, if a CLI command is not complete, the corresponding help section will be printed to the terminal. Before that, only the root `hf --help` was printed.

Example with `hf auth`: 

```
> hf auth
usage: hf <command> [<args>] auth [-h] {login,logout,whoami,switch,list} ...

positional arguments:
  {login,logout,whoami,switch,list}
                        Authentication subcommands
    login               Log in using a token from huggingface.co/settings/tokens
    logout              Log out
    whoami              Find out which huggingface.co account you are logged in as.
    switch              Switch between access tokens
    list                List all stored access tokens

options:
  -h, --help            show this help message and exit
```

(same for hf repo, hf cache and hf hobs)