### PR TITLE
Improve Git Credential Helper Detection for Linux (GCM & libsecret support)

### DIFF
--- a/src/huggingface_hub/utils/_git_credential.py
+++ b/src/huggingface_hub/utils/_git_credential.py
@@ -27,7 +27,7 @@ GIT_CREDENTIAL_REGEX = re.compile(
         ^\s* # start of line
         credential\.helper # credential.helper value
         \s*=\s* # separator
-        ([\w\-]+) # the helper name (group 1)
+        ([\w\-\/]+) # the helper name or absolute path (group 1)
         (\s|$) # whitespace or end of line
     """,
     flags=re.MULTILINE | re.IGNORECASE | re.VERBOSE,

--- a/src/huggingface_hub/utils/_git_credential.py
+++ b/src/huggingface_hub/utils/_git_credential.py
@@ -27,7 +27,7 @@ GIT_CREDENTIAL_REGEX = re.compile(
         ^\s* # start of line
         credential\.helper # credential.helper value
         \s*=\s* # separator
-        (\w+) # the helper name (group 1)
+        ([\w\-]+) # the helper name (group 1)
         (\s|$) # whitespace or end of line
     """,
     flags=re.MULTILINE | re.IGNORECASE | re.VERBOSE,

--- a/tests/test_utils_git_credentials.py
+++ b/tests/test_utils_git_credentials.py
@@ -18,6 +18,7 @@ STORE_AND_CACHE_HELPERS_CONFIG = """
 [credential]
     helper = store
     helper = cache --timeout 30000
+    helper = git-credential-manager
 """
 
 
@@ -38,6 +39,7 @@ class TestGitCredentials(unittest.TestCase):
         helpers = list_credential_helpers(folder=self.cache_dir)
         self.assertIn("cache", helpers)
         self.assertIn("store", helpers)
+        self.assertIn("git-credential-manager", helpers)
 
     def test_set_and_unset_git_credential(self) -> None:
         username = "hf_test_user_" + str(round(time.time()))  # make username unique

--- a/tests/test_utils_git_credentials.py
+++ b/tests/test_utils_git_credentials.py
@@ -19,6 +19,7 @@ STORE_AND_CACHE_HELPERS_CONFIG = """
     helper = store
     helper = cache --timeout 30000
     helper = git-credential-manager
+    helper = /usr/libexec/git-core/git-credential-libsecret
 """
 
 
@@ -40,6 +41,7 @@ class TestGitCredentials(unittest.TestCase):
         self.assertIn("cache", helpers)
         self.assertIn("store", helpers)
         self.assertIn("git-credential-manager", helpers)
+        self.assertIn("/usr/libexec/git-core/git-credential-libsecret", helpers)
 
     def test_set_and_unset_git_credential(self) -> None:
         username = "hf_test_user_" + str(round(time.time()))  # make username unique


### PR DESCRIPTION
## Description

This pull request introduces improvements to the detection and handling of Git credential helpers in the Huggingface Hub client for Linux environments.

### Summary of the last two commits

1. **Support for Git Credential Manager (GCM)**
   - Updated the regex to match `git-credential-manager`.
   - Added tests to verify GCM is recognized and handled.
   - Ref: https://git-scm.com/doc/credential-helpers

2. **Support for git-credential-libsecret**
   - Extended the regex to recognize `git-credential-libsecret`, enabling integration with Secret Service-compatible keyrings (e.g., GNOME Keyring, KDE Wallet) on Linux.
   - Added unit tests to validate detection and handling of `git-credential-libsecret`.
   - Ref: https://git-scm.com/doc/credential-helpers

These changes improve compatibility with modern credential storage solutions and enhance security for Linux users.