### PR TITLE
Add 'user:' prefix to whoami command output

### DIFF
--- a/src/huggingface_hub/commands/user.py
+++ b/src/huggingface_hub/commands/user.py
@@ -185,7 +185,7 @@ class WhoamiCommand(BaseUserCommand):
             exit()
         try:
             info = self._api.whoami(token)
-            print(info["name"])
+            print(ANSI.bold("user: "), info["name"])
             orgs = [org["name"] for org in info["orgs"]]
             if orgs:
                 print(ANSI.bold("orgs: "), ",".join(orgs))


### PR DESCRIPTION
## Summary
This PR adds a 'user:' prefix to the username output of the `hf auth whoami` command for consistency with the 'orgs:' output format.

## Changes
- Modified `WhoamiCommand.run()` to print username with bold "user:" prefix, matching the formatting of the organizations list

## Before
```
victor
orgs: huggingface,google,competitions,...
```

## After
```
user: victor
orgs: huggingface,google,competitions,...
```

This improves readability and makes the output format more consistent.