### PR TITLE
Make requests decode content

### DIFF
--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -1092,6 +1092,7 @@ class HfFileSystemStreamFile(fsspec.spec.AbstractBufferedFile):
             )
             hf_raise_for_status(self.response)
             try:
+                self.response.raw.decode_content = True
                 out = self.response.raw.read(*read_args)
             except Exception:
                 self.response.close()

--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -1069,7 +1069,7 @@ class HfFileSystemStreamFile(fsspec.spec.AbstractBufferedFile):
             )
             hf_raise_for_status(self.response)
         try:
-            self.response.decode_content = True
+            self.response.raw.decode_content = True
             out = self.response.raw.read(*read_args)
         except Exception:
             self.response.close()

--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -1069,6 +1069,7 @@ class HfFileSystemStreamFile(fsspec.spec.AbstractBufferedFile):
             )
             hf_raise_for_status(self.response)
         try:
+            self.response.decode_content = True
             out = self.response.raw.read(*read_args)
         except Exception:
             self.response.close()

--- a/tests/test_hf_file_system.py
+++ b/tests/test_hf_file_system.py
@@ -20,7 +20,7 @@ from huggingface_hub.hf_file_system import (
 )
 
 from .testing_constants import ENDPOINT_STAGING, TOKEN
-from .testing_utils import repo_name
+from .testing_utils import repo_name, with_production_testing
 
 
 class HfFileSystemTests(unittest.TestCase):
@@ -618,6 +618,7 @@ def test_exists_after_repo_deletion():
     assert not hffs.exists(repo_id, refresh=True)
 
 
+@with_production_testing
 def test_hf_file_system_file_can_handle_gzipped_file():
     """Test that HfFileSystemStreamFile.read() can handle gzipped files."""
     fs = HfFileSystem(endpoint=constants.ENDPOINT)

--- a/tests/test_hf_file_system.py
+++ b/tests/test_hf_file_system.py
@@ -16,7 +16,7 @@ from huggingface_hub.errors import RepositoryNotFoundError, RevisionNotFoundErro
 from huggingface_hub.hf_file_system import HfFileSystem, HfFileSystemFile, HfFileSystemStreamFile
 
 from .testing_constants import ENDPOINT_STAGING, TOKEN
-from .testing_utils import repo_name
+from .testing_utils import repo_name, with_production_testing
 
 
 class HfFileSystemTests(unittest.TestCase):
@@ -612,3 +612,13 @@ def test_exists_after_repo_deletion():
     api.delete_repo(repo_id=repo_id, repo_type="model")
     # Verify that the repo no longer exists.
     assert not hffs.exists(repo_id, refresh=True)
+
+
+@with_production_testing
+def test_hf_file_system_file_can_handle_gzipped_file():
+    """Test that HfFileSystemStreamFile.read() can handle gzipped files."""
+    fs = HfFileSystem()
+    # As of July 2025, the math_qa.py file is gzipped when queried from production:
+    with fs.open(f"datasets/math_qa/math_qa.py", "r", encoding="utf-8") as f:
+        out = f.read()
+    assert "class MathQa" in out

--- a/tests/test_hf_file_system.py
+++ b/tests/test_hf_file_system.py
@@ -11,12 +11,16 @@ from unittest.mock import patch
 import fsspec
 import pytest
 
-from huggingface_hub import hf_file_system
+from huggingface_hub import constants, hf_file_system
 from huggingface_hub.errors import RepositoryNotFoundError, RevisionNotFoundError
-from huggingface_hub.hf_file_system import HfFileSystem, HfFileSystemFile, HfFileSystemStreamFile
+from huggingface_hub.hf_file_system import (
+    HfFileSystem,
+    HfFileSystemFile,
+    HfFileSystemStreamFile,
+)
 
 from .testing_constants import ENDPOINT_STAGING, TOKEN
-from .testing_utils import repo_name, with_production_testing
+from .testing_utils import repo_name
 
 
 class HfFileSystemTests(unittest.TestCase):
@@ -614,10 +618,9 @@ def test_exists_after_repo_deletion():
     assert not hffs.exists(repo_id, refresh=True)
 
 
-@with_production_testing
 def test_hf_file_system_file_can_handle_gzipped_file():
     """Test that HfFileSystemStreamFile.read() can handle gzipped files."""
-    fs = HfFileSystem()
+    fs = HfFileSystem(endpoint=constants.ENDPOINT)
     # As of July 2025, the math_qa.py file is gzipped when queried from production:
     with fs.open("datasets/allenai/math_qa/math_qa.py", "r", encoding="utf-8") as f:
         out = f.read()

--- a/tests/test_hf_file_system.py
+++ b/tests/test_hf_file_system.py
@@ -619,6 +619,6 @@ def test_hf_file_system_file_can_handle_gzipped_file():
     """Test that HfFileSystemStreamFile.read() can handle gzipped files."""
     fs = HfFileSystem()
     # As of July 2025, the math_qa.py file is gzipped when queried from production:
-    with fs.open("datasets/math_qa/math_qa.py", "r", encoding="utf-8") as f:
+    with fs.open("datasets/allenai/math_qa/math_qa.py", "r", encoding="utf-8") as f:
         out = f.read()
     assert "class MathQa" in out

--- a/tests/test_hf_file_system.py
+++ b/tests/test_hf_file_system.py
@@ -619,6 +619,6 @@ def test_hf_file_system_file_can_handle_gzipped_file():
     """Test that HfFileSystemStreamFile.read() can handle gzipped files."""
     fs = HfFileSystem()
     # As of July 2025, the math_qa.py file is gzipped when queried from production:
-    with fs.open(f"datasets/math_qa/math_qa.py", "r", encoding="utf-8") as f:
+    with fs.open("datasets/math_qa/math_qa.py", "r", encoding="utf-8") as f:
         out = f.read()
     assert "class MathQa" in out


### PR DESCRIPTION
If the response is gzipped, we should decode the content.

Fixes #3269 