### PR TITLE
[Jobs] Use current or stored token in a Job secrets

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -722,8 +722,9 @@ You can pass environment variables to your job using
 
 <Tip>
 
-Use the `hf_auth:` syntax to pass a local Hugging Face token.
-E.g. `HF_TOKEN=hf_auth:<token_name>` (uses the current token if `<token_name>` is empty)
+Use `-s HF_TOKEN` (equivalent to `--secrets HF_TOKEN`) to pass your Hugging Face token implicitly.
+With this syntax, the secret is retrieved from the environment variable.
+For `HF_TOKEN`, it may read the token file located in the Hugging Face home folder if the environment variable is unset.
 
 </Tip>
 

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -722,7 +722,7 @@ You can pass environment variables to your job using
 
 <Tip>
 
-Use `-s HF_TOKEN` (equivalent to `--secrets HF_TOKEN`) to pass your Hugging Face token implicitly.
+Use `--secrets HF_TOKEN` to pass your local Hugging Face token implicitly.
 With this syntax, the secret is retrieved from the environment variable.
 For `HF_TOKEN`, it may read the token file located in the Hugging Face home folder if the environment variable is unset.
 

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -720,6 +720,13 @@ You can pass environment variables to your job using
 >>> hf jobs run --secrets-file .env.secrets python:3.12 python -c "import os; print(os.environ['MY_SECRET'])"
 ```
 
+<Tip>
+
+Use the `hf_auth:` syntax to pass a local Hugging Face token.
+E.g. `HF_TOKEN=hf_auth:<token_name>` (uses the current token if `<token_name>` is empty)
+
+</Tip>
+
 ### Hardware
 
 Available `--flavor` options:

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -75,8 +75,17 @@ class RunCommand(BaseHuggingfaceCLICommand):
     def register_subcommand(parser: _SubParsersAction) -> None:
         run_parser = parser.add_parser("run", help="Run a Job")
         run_parser.add_argument("image", type=str, help="The Docker image to use.")
-        run_parser.add_argument("-e", "--env", action="append", help="Set environment variables.")
-        run_parser.add_argument("-s", "--secrets", action="append", help="Set secret environment variables.")
+        run_parser.add_argument("-e", "--env", action="append", help="Set environment variables. E.g. --env ENV=value")
+        run_parser.add_argument(
+            "-s",
+            "--secrets",
+            action="append",
+            help=(
+                "Set secret environment variables. "
+                "Use the `hf_auth:` syntax to pass a local Hugging Face token. "
+                "E.g. `--secrets HF_TOKEN=hf_auth:<token_name>` (uses the current token if `<token_name>` is empty)"
+            ),
+        )
         run_parser.add_argument("--env-file", type=str, help="Read in a file of environment variables.")
         run_parser.add_argument("--secrets-file", type=str, help="Read in a file of secret environment variables.")
         run_parser.add_argument(

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -123,6 +123,9 @@ class RunCommand(BaseHuggingfaceCLICommand):
         if args.env_file:
             self.env.update(load_dotenv(Path(args.env_file).read_text()))
         for env_value in args.env or []:
+            if "=" not in env_value:
+                # Get it from the current environment
+                env_value = f"{env_value}={os.environ[env_value]}"
             self.env.update(load_dotenv(env_value))
         self.secrets: dict[str, Optional[str]] = {}
         if args.secrets_file:
@@ -505,6 +508,9 @@ class UvCommand(BaseHuggingfaceCLICommand):
         if args.env_file:
             self.env.update(load_dotenv(Path(args.env_file).read_text()))
         for env_value in args.env or []:
+            if "=" not in env_value:
+                # Get it from the current environment
+                env_value = f"{env_value}={os.environ[env_value]}"
             self.env.update(load_dotenv(env_value))
         self.secrets: dict[str, Optional[str]] = {}
         if args.secrets_file:

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -545,6 +545,6 @@ class UvCommand(BaseHuggingfaceCLICommand):
 
 def _get_extended_environ() -> Dict[str, str]:
     extended_environ = os.environ.copy()
-    if "HF_TOKEN" not in extended_environ:
-        extended_environ["HF_TOKEN"] = get_token() or ""
+    if (token := get_token()) is not None:
+        extended_environ["HF_TOKEN"] = token
     return extended_environ

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -36,7 +36,7 @@ import re
 from argparse import Namespace, _SubParsersAction
 from dataclasses import asdict
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 import requests
 
@@ -121,9 +121,9 @@ class RunCommand(BaseHuggingfaceCLICommand):
         self.command: List[str] = args.command
         self.env: dict[str, Optional[str]] = {}
         if args.env_file:
-            self.env.update(load_dotenv(Path(args.env_file).read_text(), environ=os.environ))
+            self.env.update(load_dotenv(Path(args.env_file).read_text(), environ=os.environ.copy()))
         for env_value in args.env or []:
-            self.env.update(load_dotenv(env_value, environ=os.environ))
+            self.env.update(load_dotenv(env_value, environ=os.environ.copy()))
         self.secrets: dict[str, Optional[str]] = {}
         extended_environ = _get_extended_environ()
         if args.secrets_file:
@@ -497,9 +497,9 @@ class UvCommand(BaseHuggingfaceCLICommand):
         self.image = args.image
         self.env: dict[str, Optional[str]] = {}
         if args.env_file:
-            self.env.update(load_dotenv(Path(args.env_file).read_text(), environ=os.environ))
+            self.env.update(load_dotenv(Path(args.env_file).read_text(), environ=os.environ.copy()))
         for env_value in args.env or []:
-            self.env.update(load_dotenv(env_value, environ=os.environ))
+            self.env.update(load_dotenv(env_value, environ=os.environ.copy()))
         self.secrets: dict[str, Optional[str]] = {}
         extended_environ = _get_extended_environ()
         if args.secrets_file:
@@ -543,8 +543,8 @@ class UvCommand(BaseHuggingfaceCLICommand):
             print(log)
 
 
-def _get_extended_environ() -> Dict[str, Any]:
+def _get_extended_environ() -> Dict[str, str]:
     extended_environ = os.environ.copy()
     if "HF_TOKEN" not in extended_environ:
-        extended_environ["HF_TOKEN"] = get_token()
+        extended_environ["HF_TOKEN"] = get_token() or ""
     return extended_environ

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -133,7 +133,6 @@ from .utils import (
 )
 from .utils import tqdm as hf_tqdm
 from .utils._auth import (
-    _get_token_by_name,
     _get_token_from_environment,
     _get_token_from_file,
     _get_token_from_google_colab,
@@ -9977,8 +9976,6 @@ class HfApi:
 
             secrets (`Dict[str, Any]`, *optional*):
                 Defines the secret environment variables for the Job.
-                Use the `hf_auth:` syntax to pass a local Hugging Face token.
-                E.g. `{"HF_TOKEN": "hf_auth:<token_name>"}` (uses the current token if `<token_name>` is empty)
 
             flavor (`str`, *optional*):
                 Flavor for the hardware, as in Hugging Face Spaces. See [`SpaceHardware`] for possible values.
@@ -10026,14 +10023,6 @@ class HfApi:
         }
         # secrets are optional
         if secrets:
-            # Parse stored_tokens
-            prefix = "hf_auth:"
-            secrets = {
-                key: (get_token() if value == prefix else _get_token_by_name(value[len(prefix) :]))
-                if value.startswith(prefix)
-                else value
-                for key, value in secrets.items()
-            }
             input_json["secrets"] = secrets
         # timeout is optional
         if timeout:
@@ -10310,8 +10299,6 @@ class HfApi:
 
             secrets (`Dict[str, Any]`, *optional*):
                 Defines the secret environment variables for the Job.
-                Use the `hf_auth:` syntax to pass a local Hugging Face token.
-                E.g. `{"HF_TOKEN": "hf_auth:<token_name>"}` (uses the current token if `<token_name>` is empty)
 
             flavor (`str`, *optional*):
                 Flavor for the hardware, as in Hugging Face Spaces. See [`SpaceHardware`] for possible values.

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -132,7 +132,12 @@ from .utils import (
     validate_hf_hub_args,
 )
 from .utils import tqdm as hf_tqdm
-from .utils._auth import _get_token_from_environment, _get_token_from_file, _get_token_from_google_colab
+from .utils._auth import (
+    _get_token_by_name,
+    _get_token_from_environment,
+    _get_token_from_file,
+    _get_token_from_google_colab,
+)
 from .utils._deprecation import _deprecate_method
 from .utils._runtime import is_xet_available
 from .utils._typing import CallableT
@@ -9972,6 +9977,8 @@ class HfApi:
 
             secrets (`Dict[str, Any]`, *optional*):
                 Defines the secret environment variables for the Job.
+                Use the `hf_auth:` syntax to pass a local Hugging Face token.
+                E.g. `{"HF_TOKEN": "hf_auth:<token_name>"}` (uses the current token if `<token_name>` is empty)
 
             flavor (`str`, *optional*):
                 Flavor for the hardware, as in Hugging Face Spaces. See [`SpaceHardware`] for possible values.
@@ -10019,6 +10026,14 @@ class HfApi:
         }
         # secrets are optional
         if secrets:
+            # Parse stored_tokens
+            prefix = "hf_auth:"
+            secrets = {
+                key: (get_token() if value == prefix else _get_token_by_name(value[len(prefix) :]))
+                if value.startswith(prefix)
+                else value
+                for key, value in secrets.items()
+            }
             input_json["secrets"] = secrets
         # timeout is optional
         if timeout:
@@ -10295,6 +10310,8 @@ class HfApi:
 
             secrets (`Dict[str, Any]`, *optional*):
                 Defines the secret environment variables for the Job.
+                Use the `hf_auth:` syntax to pass a local Hugging Face token.
+                E.g. `{"HF_TOKEN": "hf_auth:<token_name>"}` (uses the current token if `<token_name>` is empty)
 
             flavor (`str`, *optional*):
                 Flavor for the hardware, as in Hugging Face Spaces. See [`SpaceHardware`] for possible values.

--- a/src/huggingface_hub/utils/_dotenv.py
+++ b/src/huggingface_hub/utils/_dotenv.py
@@ -1,6 +1,6 @@
 # AI-generated module (ChatGPT)
 import re
-from typing import Dict
+from typing import Dict, Optional
 
 
 def load_dotenv(dotenv_str: str, environ: Optional[Dict[str, str]] = None) -> Dict[str, str]:

--- a/src/huggingface_hub/utils/_dotenv.py
+++ b/src/huggingface_hub/utils/_dotenv.py
@@ -1,9 +1,9 @@
 # AI-generated module (ChatGPT)
 import re
-from typing import Any, Dict
+from typing import Dict
 
 
-def load_dotenv(dotenv_str: str, environ: Dict[str, Any]) -> Dict[str, str]:
+def load_dotenv(dotenv_str: str, environ: Dict[str, str]) -> Dict[str, str]:
     """
     Parse a DOTENV-format string and return a dictionary of key-value pairs.
     Handles quoted values, comments, export keyword, and blank lines.

--- a/src/huggingface_hub/utils/_dotenv.py
+++ b/src/huggingface_hub/utils/_dotenv.py
@@ -3,7 +3,7 @@ import re
 from typing import Dict
 
 
-def load_dotenv(dotenv_str: str, environ: Dict[str, str]) -> Dict[str, str]:
+def load_dotenv(dotenv_str: str, environ: Optional[Dict[str, str]] = None) -> Dict[str, str]:
     """
     Parse a DOTENV-format string and return a dictionary of key-value pairs.
     Handles quoted values, comments, export keyword, and blank lines.
@@ -44,7 +44,7 @@ def load_dotenv(dotenv_str: str, environ: Dict[str, str]) -> Dict[str, str]:
                 if raw_val.startswith('"'):
                     val = val.replace(r"\$", "$")  # only in double quotes
 
-        else:
+        elif environ is not None:
             # Get it from the current environment
             key, val = line, environ[line]
 

--- a/src/huggingface_hub/utils/_dotenv.py
+++ b/src/huggingface_hub/utils/_dotenv.py
@@ -35,6 +35,7 @@ def load_dotenv(dotenv_str: str, environ: Optional[Dict[str, str]] = None) -> Di
         match = line_pattern.match(line)
         if match:
             key = match.group(1)
+            val = None
             if match.group(2):  # if there is '='
                 raw_val = match.group(3) or ""
                 val = raw_val.strip()
@@ -44,12 +45,11 @@ def load_dotenv(dotenv_str: str, environ: Optional[Dict[str, str]] = None) -> Di
                     val = val.replace(r"\n", "\n").replace(r"\t", "\t").replace(r"\"", '"').replace(r"\\", "\\")
                     if raw_val.startswith('"'):
                         val = val.replace(r"\$", "$")  # only in double quotes
-            elif environ is not None and key in environ:
+            elif environ is not None:
                 # Get it from the current environment
-                val = environ[key]
-            else:
-                continue
+                val = environ.get(key)
 
-            env[key] = val
+            if val is not None:
+                env[key] = val
 
     return env

--- a/src/huggingface_hub/utils/_dotenv.py
+++ b/src/huggingface_hub/utils/_dotenv.py
@@ -1,9 +1,9 @@
 # AI-generated module (ChatGPT)
 import re
-from typing import Dict
+from typing import Any, Dict
 
 
-def load_dotenv(dotenv_str: str) -> Dict[str, str]:
+def load_dotenv(dotenv_str: str, environ: Dict[str, Any]) -> Dict[str, str]:
     """
     Parse a DOTENV-format string and return a dictionary of key-value pairs.
     Handles quoted values, comments, export keyword, and blank lines.
@@ -33,18 +33,20 @@ def load_dotenv(dotenv_str: str) -> Dict[str, str]:
             continue  # Skip comments and empty lines
 
         match = line_pattern.match(line)
-        if not match:
-            continue  # Skip malformed lines
+        if match:
+            key, raw_val = match.group(1), match.group(2) or ""
+            val = raw_val.strip()
 
-        key, raw_val = match.group(1), match.group(2) or ""
-        val = raw_val.strip()
+            # Remove surrounding quotes if quoted
+            if (val.startswith('"') and val.endswith('"')) or (val.startswith("'") and val.endswith("'")):
+                val = val[1:-1]
+                val = val.replace(r"\n", "\n").replace(r"\t", "\t").replace(r"\"", '"').replace(r"\\", "\\")
+                if raw_val.startswith('"'):
+                    val = val.replace(r"\$", "$")  # only in double quotes
 
-        # Remove surrounding quotes if quoted
-        if (val.startswith('"') and val.endswith('"')) or (val.startswith("'") and val.endswith("'")):
-            val = val[1:-1]
-            val = val.replace(r"\n", "\n").replace(r"\t", "\t").replace(r"\"", '"').replace(r"\\", "\\")
-            if raw_val.startswith('"'):
-                val = val.replace(r"\$", "$")  # only in double quotes
+        else:
+            # Get it from the current environment
+            key, val = line, environ[line]
 
         env[key] = val
 

--- a/tests/test_utils_dotenv.py
+++ b/tests/test_utils_dotenv.py
@@ -62,3 +62,15 @@ def test_multiple_lines():
     D=4
     """
     assert load_dotenv(data) == {"A": "1", "B": "two", "C": "three", "D": "4"}
+
+
+def test_environ():
+    data = """
+    A=1
+    B
+    C=3
+    MISSING
+    EMPTY
+    """
+    environ = {"A": "one", "B": "two", "D": "four", "EMPTY": ""}
+    assert load_dotenv(data, environ=environ) == {"A": "1", "B": "two", "C": "3", "EMPTY": ""}


### PR DESCRIPTION
Add the `hf_auth:` syntax to pass a local Hugging Face token.
E.g. `HF_TOKEN=hf_auth:<token_name>` (uses the current token if `<token_name>` is empty)