### PR TITLE
[CLI] add "user:" prefix only for `hf auth whoami` output

### DIFF
--- a/src/huggingface_hub/cli/auth.py
+++ b/src/huggingface_hub/cli/auth.py
@@ -200,7 +200,7 @@ class AuthWhoami(BaseAuthCommand):
             exit()
         try:
             info = self._api.whoami(token)
-            print(info["name"])
+            print(ANSI.bold("user: "), info["name"])
             orgs = [org["name"] for org in info["orgs"]]
             if orgs:
                 print(ANSI.bold("orgs: "), ",".join(orgs))

--- a/src/huggingface_hub/commands/user.py
+++ b/src/huggingface_hub/commands/user.py
@@ -195,7 +195,7 @@ class WhoamiCommand(BaseUserCommand):
             exit()
         try:
             info = self._api.whoami(token)
-            print(ANSI.bold("user: "), info["name"])
+            print(info["name"])
             orgs = [org["name"] for org in info["orgs"]]
             if orgs:
                 print(ANSI.bold("orgs: "), ",".join(orgs))


### PR DESCRIPTION
Follow-up PR after https://github.com/huggingface/huggingface_hub/pull/3267. We added the prefix `user:` to the deprecated `huggingface-cli whoami` command instead of only updating `hf auth whoami`. 

This PR fixes that by restoring the original output for the deprecated command and adding the user: prefix only to `hf auth whoami`.