### PR TITLE
Fix concurrent create_repo with exist_ok=True

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -3754,7 +3754,9 @@ class HfApi:
         except HTTPError as err:
             if exist_ok and err.response.status_code == 409:
                 # Repo already exists and `exist_ok=True`
-                pass
+                if repo_type is None or repo_type == constants.REPO_TYPE_MODEL:
+                    return RepoUrl(f"{self.endpoint}/{repo_id}")
+                return RepoUrl(f"{self.endpoint}/{repo_type}/{repo_id}")
             elif exist_ok and err.response.status_code == 403:
                 # No write permission on the namespace but repo might already exist
                 try:


### PR DESCRIPTION
`create_repo(..., exist_ok=True)` may fail if called concurrently.

If the repo already exists it generally succeeds (server returns 409 and the repo url).
But when called concurrently the server returns 409 but with an error message:
```
{'error': 'A repository with this name already exists'}
```
Since it doesn't contain url , create_repo(..., exist_ok=True) raises an error
```
KeyError: 'url'
```

internal discussion to know whether this should be fixed client side or server side: https://huggingface.slack.com/archives/C02EMARJ65P/p1753959403168719?thread_ts=1753799202.135049&cid=C02EMARJ65P