### PR TITLE
Add validation warnings for repository limits in upload_large_folder

### DIFF
--- a/src/huggingface_hub/_upload_large_folder.py
+++ b/src/huggingface_hub/_upload_large_folder.py
@@ -24,7 +24,7 @@ import traceback
 from datetime import datetime
 from pathlib import Path
 from threading import Lock
-from typing import TYPE_CHECKING, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 from urllib.parse import quote
 
 from . import constants
@@ -85,7 +85,7 @@ def _validate_upload_limits(paths_list: List[LocalUploadFilePaths]) -> None:
     # Track immediate children (files and subdirs) for each folder
     from collections import defaultdict
 
-    entries_per_folder = defaultdict(lambda: {"files": 0, "subdirs": set()})
+    entries_per_folder: Dict[str, Any] = defaultdict(lambda: {"files": 0, "subdirs": set()})
 
     for paths in paths_list:
         path = Path(paths.path_in_repo)

--- a/src/huggingface_hub/_upload_large_folder.py
+++ b/src/huggingface_hub/_upload_large_folder.py
@@ -135,7 +135,7 @@ def upload_large_folder_internal(
             f"This exceeds the recommended limit of {MAX_FILES_PER_REPO:,} files per repository.\n"
             f"Consider:\n"
             f"  - Splitting your data into multiple repositories\n"
-            f"  - Using fewer, larger files (e.g., tar archives)\n"
+            f"  - Using fewer, larger files (e.g., parquet files)\n"
             f"  - See: https://huggingface.co/docs/hub/repositories-recommendations"
         )
 

--- a/src/huggingface_hub/_upload_large_folder.py
+++ b/src/huggingface_hub/_upload_large_folder.py
@@ -21,7 +21,6 @@ import sys
 import threading
 import time
 import traceback
-from collections import Counter
 from datetime import datetime
 from pathlib import Path
 from threading import Lock
@@ -60,10 +59,10 @@ RECOMMENDED_FILE_SIZE_GB = 20  # Recommended maximum for individual file size
 def _validate_upload_limits(paths_list: List[LocalUploadFilePaths]) -> None:
     """
     Validate upload against repository limits and warn about potential issues.
-    
+
     Args:
         paths_list: List of file paths to be uploaded
-    
+
     Warns about:
         - Too many files in the repository (>100k)
         - Too many entries (files or subdirectories) in a single folder (>10k)
@@ -86,15 +85,15 @@ def _validate_upload_limits(paths_list: List[LocalUploadFilePaths]) -> None:
     # Track immediate children (files and subdirs) for each folder
     from collections import defaultdict
     entries_per_folder = defaultdict(lambda: {"files": 0, "subdirs": set()})
-    
+
     for paths in paths_list:
         path = Path(paths.path_in_repo)
         parts = path.parts
-        
+
         # Count this file in its immediate parent directory
         parent = str(path.parent) if str(path.parent) != "." else "."
         entries_per_folder[parent]["files"] += 1
-        
+
         # Track immediate subdirectories for each parent folder
         # Walk through the path components to track parent-child relationships
         for i in range(len(parts) - 1):  # -1 because last part is the filename
@@ -106,16 +105,16 @@ def _validate_upload_limits(paths_list: List[LocalUploadFilePaths]) -> None:
                 # For nested paths, parent is everything up to index i
                 parent = str(Path(*parts[:i]))
                 child = parts[i]
-            
+
             # Track this child as a subdirectory of its parent
             entries_per_folder[parent]["subdirs"].add(child)
-    
+
     # Check limits for each folder
     for folder, data in entries_per_folder.items():
         file_count = data["files"]
         subdir_count = len(data["subdirs"])
         total_entries = file_count + subdir_count
-        
+
         if total_entries > MAX_FILES_PER_FOLDER:
             folder_display = folder if folder != "." else "root"
             details = []
@@ -124,7 +123,7 @@ def _validate_upload_limits(paths_list: List[LocalUploadFilePaths]) -> None:
             if subdir_count > 0:
                 details.append(f"{subdir_count:,} subdirectories")
             details_str = " and ".join(details)
-            
+
             logger.warning(
                 f"Folder '{folder_display}' contains {total_entries:,} entries ({details_str}). "
                 f"This exceeds the recommended limit of {MAX_FILES_PER_FOLDER:,} entries per folder.\n"
@@ -237,7 +236,7 @@ def upload_large_folder_internal(
 
     # Validate upload against repository limits
     _validate_upload_limits(paths_list)
-    
+
     logger.info("Starting upload...")
 
     # Read metadata for each file

--- a/src/huggingface_hub/_upload_large_folder.py
+++ b/src/huggingface_hub/_upload_large_folder.py
@@ -108,18 +108,12 @@ def _validate_upload_limits(paths_list: List[LocalUploadFilePaths]) -> None:
         total_entries = file_count + subdir_count
 
         if total_entries > MAX_FILES_PER_FOLDER:
-            folder_display = folder if folder != "." else "root"
-            details = []
-            if file_count > 0:
-                details.append(f"{file_count:,} files")
-            if subdir_count > 0:
-                details.append(f"{subdir_count:,} subdirectories")
-            details_str = " and ".join(details)
-
+            folder_display = "root" if folder == "." else folder
             logger.warning(
-                f"Folder '{folder_display}' contains {total_entries:,} entries ({details_str}). "
-                f"This exceeds the recommended limit of {MAX_FILES_PER_FOLDER:,} entries per folder.\n"
-                f"Consider reorganizing into subfolders."
+                f"Folder '{folder_display}' contains {total_entries:,} entries "
+                f"({file_count:,} files and {subdir_count:,} subdirectories). "
+                f"This exceeds the recommended {MAX_FILES_PER_FOLDER:,} entries per folder.\n"
+                "Consider reorganising into sub-folders."
             )
 
     # Check 3: File sizes

--- a/src/huggingface_hub/_upload_large_folder.py
+++ b/src/huggingface_hub/_upload_large_folder.py
@@ -84,6 +84,7 @@ def _validate_upload_limits(paths_list: List[LocalUploadFilePaths]) -> None:
     # Check 2: Files and subdirectories per folder
     # Track immediate children (files and subdirs) for each folder
     from collections import defaultdict
+
     entries_per_folder = defaultdict(lambda: {"files": 0, "subdirs": set()})
 
     for paths in paths_list:

--- a/src/huggingface_hub/_upload_large_folder.py
+++ b/src/huggingface_hub/_upload_large_folder.py
@@ -97,7 +97,7 @@ def _validate_upload_limits(paths_list: List[LocalUploadFilePaths]) -> None:
 
         # Track immediate subdirectories for each parent folder
         # Walk through the path components to track parent-child relationships
-        for i, child in enumerate(parts[:-1]):           
+        for i, child in enumerate(parts[:-1]):
             parent = "." if i == 0 else "/".join(parts[:i])
             entries_per_folder[parent]["subdirs"].add(child)
 

--- a/src/huggingface_hub/_upload_large_folder.py
+++ b/src/huggingface_hub/_upload_large_folder.py
@@ -141,7 +141,7 @@ def upload_large_folder_internal(
 
     # Check 2: Files per folder
     files_per_folder = Counter(str(Path(paths.path_in_repo).parent) for paths in paths_list)
-    
+
     for folder, count in files_per_folder.items():
         if count > MAX_FILES_PER_FOLDER:
             logger.warning(
@@ -157,7 +157,7 @@ def upload_large_folder_internal(
     for paths in paths_list:
         size = paths.file_path.stat().st_size
         size_gb = size / (1024**3)
-        
+
         if size_gb > MAX_FILE_SIZE_GB:
             very_large_files.append((paths.path_in_repo, size_gb))
         elif size_gb > RECOMMENDED_FILE_SIZE_GB:

--- a/src/huggingface_hub/_upload_large_folder.py
+++ b/src/huggingface_hub/_upload_large_folder.py
@@ -97,17 +97,8 @@ def _validate_upload_limits(paths_list: List[LocalUploadFilePaths]) -> None:
 
         # Track immediate subdirectories for each parent folder
         # Walk through the path components to track parent-child relationships
-        for i in range(len(parts) - 1):  # -1 because last part is the filename
-            if i == 0:
-                # First part is a direct subdirectory of root
-                parent = "."
-                child = parts[0]
-            else:
-                # For nested paths, parent is everything up to index i
-                parent = str(Path(*parts[:i]))
-                child = parts[i]
-
-            # Track this child as a subdirectory of its parent
+        for i, child in enumerate(parts[:-1]):           
+            parent = "." if i == 0 else "/".join(parts[:i])
             entries_per_folder[parent]["subdirs"].add(child)
 
     # Check limits for each folder

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -5319,14 +5319,18 @@ class HfApi:
             1. (Check parameters and setup.)
             2. Create repo if missing.
             3. List local files to upload.
-            4. Start workers. Workers can perform the following tasks:
+            4. Run validation checks and display warnings if repository limits might be exceeded:
+                - Warns if the total number of files exceeds 100k (recommended limit).
+                - Warns if any folder contains more than 10k files (recommended limit).
+                - Warns about files larger than 20GB (recommended) or 50GB (hard limit).
+            5. Start workers. Workers can perform the following tasks:
                 - Hash a file.
                 - Get upload mode (regular or LFS) for a list of files.
                 - Pre-upload an LFS file.
                 - Commit a bunch of files.
             Once a worker finishes a task, it will move on to the next task based on the priority list (see below) until
             all files are uploaded and committed.
-            5. While workers are up, regularly print a report to sys.stdout.
+            6. While workers are up, regularly print a report to sys.stdout.
 
         Order of priority:
             1. Commit if more than 5 minutes since last commit attempt (and at least 1 file).

--- a/tests/test_upload_large_folder.py
+++ b/tests/test_upload_large_folder.py
@@ -51,6 +51,7 @@ class TestValidateUploadLimits(unittest.TestCase):
 
     class MockPath:
         """Mock object to simulate LocalUploadFilePaths."""
+
         def __init__(self, path_in_repo, size_bytes=1000):
             self.path_in_repo = path_in_repo
             self.file_path = MagicMock()

--- a/tests/test_upload_large_folder.py
+++ b/tests/test_upload_large_folder.py
@@ -1,7 +1,20 @@
 # tests/test_upload_large_folder.py
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, Mock, patch
+
 import pytest
 
-from huggingface_hub._upload_large_folder import COMMIT_SIZE_SCALE, LargeUploadStatus
+from huggingface_hub._upload_large_folder import (
+    COMMIT_SIZE_SCALE,
+    LargeUploadStatus,
+    MAX_FILES_PER_REPO,
+    MAX_FILES_PER_FOLDER,
+    MAX_FILE_SIZE_GB,
+    RECOMMENDED_FILE_SIZE_GB,
+    upload_large_folder_internal,
+)
+from huggingface_hub.utils import SoftTemporaryDirectory
 
 
 @pytest.fixture
@@ -32,3 +45,86 @@ def test_update_chunk_transitions(status, start_idx, success, delta_items, durat
 
     assert status._chunk_idx == expected_idx
     assert status.target_chunk() == COMMIT_SIZE_SCALE[expected_idx]
+
+
+class UploadLargeFolderValidationTest(unittest.TestCase):
+    """Test validation warnings for upload_large_folder - focusing on file count checks."""
+
+    def setUp(self):
+        self.api = MagicMock()
+        self.api.create_repo.return_value.repo_id = "test-user/test-repo"
+        self.api.repo_info.return_value.xet_enabled = False
+        self.api._build_hf_headers.return_value = {}
+        self.api.endpoint = "https://huggingface.co"
+
+    @patch("huggingface_hub._upload_large_folder.logger")
+    def test_validation_warns_too_many_files(self, mock_logger):
+        """Test warning when total files exceed MAX_FILES_PER_REPO."""
+        with SoftTemporaryDirectory() as tmpdir:
+            folder = Path(tmpdir)
+            # Create actual test files that will be found
+            num_files = 5
+            for i in range(num_files):
+                (folder / f"file_{i}.txt").write_text("content")
+            
+            # Mock the validation check by directly calling logger.warning
+            # since we're focusing on file count validation only
+            expected_count = MAX_FILES_PER_REPO + 100
+            with patch("huggingface_hub._upload_large_folder.len") as mock_len:
+                # First call returns actual file count for initial check
+                # Second call returns our mocked large number for validation
+                mock_len.side_effect = [num_files, expected_count, expected_count]
+                
+                with patch("huggingface_hub._upload_large_folder.threading.Thread"):
+                    with patch("huggingface_hub._upload_large_folder.time.sleep"):
+                        with patch("huggingface_hub._upload_large_folder.LargeUploadStatus.is_done") as mock_done:
+                            mock_done.return_value = True
+                            
+                            upload_large_folder_internal(
+                                api=self.api,
+                                repo_id="test-repo",
+                                folder_path=folder,
+                                repo_type="dataset",
+                            )
+                
+                # Check that warning was logged
+                warning_calls = [call for call in mock_logger.warning.call_args_list]
+                assert any(
+                    f"You are about to upload {expected_count:,} files" in str(call)
+                    for call in warning_calls
+                ), f"Expected warning about too many files not found"
+
+    @patch("huggingface_hub._upload_large_folder.logger")
+    def test_validation_warns_too_many_files_per_folder(self, mock_logger):
+        """Test warning when a folder has too many files."""
+        with SoftTemporaryDirectory() as tmpdir:
+            folder = Path(tmpdir)
+            subfolder = folder / "data"
+            subfolder.mkdir()
+            # Create a couple actual files
+            (subfolder / "file1.txt").write_text("content")
+            (subfolder / "file2.txt").write_text("content")
+            
+            # Use Counter directly to simulate the file count per folder
+            with patch("huggingface_hub._upload_large_folder.Counter") as mock_counter:
+                # Mock Counter to return high file count for 'data' folder
+                mock_counter.return_value = {"data": MAX_FILES_PER_FOLDER + 100}
+                
+                with patch("huggingface_hub._upload_large_folder.threading.Thread"):
+                    with patch("huggingface_hub._upload_large_folder.time.sleep"):
+                        with patch("huggingface_hub._upload_large_folder.LargeUploadStatus.is_done") as mock_done:
+                            mock_done.return_value = True
+                            
+                            upload_large_folder_internal(
+                                api=self.api,
+                                repo_id="test-repo",
+                                folder_path=folder,
+                                repo_type="dataset",
+                            )
+                
+                # Check warning
+                warning_calls = [call for call in mock_logger.warning.call_args_list]
+                assert any(
+                    f"Folder 'data' contains {MAX_FILES_PER_FOLDER + 100:,} files" in str(call)
+                    for call in warning_calls
+                ), "Expected warning about too many files per folder"

--- a/tests/test_upload_large_folder.py
+++ b/tests/test_upload_large_folder.py
@@ -1,17 +1,15 @@
 # tests/test_upload_large_folder.py
 import unittest
 from pathlib import Path
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from huggingface_hub._upload_large_folder import (
     COMMIT_SIZE_SCALE,
-    LargeUploadStatus,
-    MAX_FILES_PER_REPO,
     MAX_FILES_PER_FOLDER,
-    MAX_FILE_SIZE_GB,
-    RECOMMENDED_FILE_SIZE_GB,
+    MAX_FILES_PER_REPO,
+    LargeUploadStatus,
     upload_large_folder_internal,
 )
 from huggingface_hub.utils import SoftTemporaryDirectory
@@ -66,7 +64,7 @@ class UploadLargeFolderValidationTest(unittest.TestCase):
             num_files = 5
             for i in range(num_files):
                 (folder / f"file_{i}.txt").write_text("content")
-            
+
             # Mock the validation check by directly calling logger.warning
             # since we're focusing on file count validation only
             expected_count = MAX_FILES_PER_REPO + 100
@@ -74,25 +72,24 @@ class UploadLargeFolderValidationTest(unittest.TestCase):
                 # First call returns actual file count for initial check
                 # Second call returns our mocked large number for validation
                 mock_len.side_effect = [num_files, expected_count, expected_count]
-                
+
                 with patch("huggingface_hub._upload_large_folder.threading.Thread"):
                     with patch("huggingface_hub._upload_large_folder.time.sleep"):
                         with patch("huggingface_hub._upload_large_folder.LargeUploadStatus.is_done") as mock_done:
                             mock_done.return_value = True
-                            
+
                             upload_large_folder_internal(
                                 api=self.api,
                                 repo_id="test-repo",
                                 folder_path=folder,
                                 repo_type="dataset",
                             )
-                
+
                 # Check that warning was logged
                 warning_calls = [call for call in mock_logger.warning.call_args_list]
                 assert any(
-                    f"You are about to upload {expected_count:,} files" in str(call)
-                    for call in warning_calls
-                ), f"Expected warning about too many files not found"
+                    f"You are about to upload {expected_count:,} files" in str(call) for call in warning_calls
+                ), "Expected warning about too many files not found"
 
     @patch("huggingface_hub._upload_large_folder.logger")
     def test_validation_warns_too_many_files_per_folder(self, mock_logger):
@@ -104,24 +101,24 @@ class UploadLargeFolderValidationTest(unittest.TestCase):
             # Create a couple actual files
             (subfolder / "file1.txt").write_text("content")
             (subfolder / "file2.txt").write_text("content")
-            
+
             # Use Counter directly to simulate the file count per folder
             with patch("huggingface_hub._upload_large_folder.Counter") as mock_counter:
                 # Mock Counter to return high file count for 'data' folder
                 mock_counter.return_value = {"data": MAX_FILES_PER_FOLDER + 100}
-                
+
                 with patch("huggingface_hub._upload_large_folder.threading.Thread"):
                     with patch("huggingface_hub._upload_large_folder.time.sleep"):
                         with patch("huggingface_hub._upload_large_folder.LargeUploadStatus.is_done") as mock_done:
                             mock_done.return_value = True
-                            
+
                             upload_large_folder_internal(
                                 api=self.api,
                                 repo_id="test-repo",
                                 folder_path=folder,
                                 repo_type="dataset",
                             )
-                
+
                 # Check warning
                 warning_calls = [call for call in mock_logger.warning.call_args_list]
                 assert any(

--- a/tests/test_upload_large_folder.py
+++ b/tests/test_upload_large_folder.py
@@ -10,6 +10,7 @@ from huggingface_hub._upload_large_folder import (
     MAX_FILES_PER_FOLDER,
     MAX_FILES_PER_REPO,
     LargeUploadStatus,
+    _validate_upload_limits,
     upload_large_folder_internal,
 )
 from huggingface_hub.utils import SoftTemporaryDirectory
@@ -43,6 +44,119 @@ def test_update_chunk_transitions(status, start_idx, success, delta_items, durat
 
     assert status._chunk_idx == expected_idx
     assert status.target_chunk() == COMMIT_SIZE_SCALE[expected_idx]
+
+
+class TestValidateUploadLimits(unittest.TestCase):
+    """Test the _validate_upload_limits function directly."""
+    
+    class MockPath:
+        """Mock object to simulate LocalUploadFilePaths."""
+        def __init__(self, path_in_repo, size_bytes=1000):
+            self.path_in_repo = path_in_repo
+            self.file_path = MagicMock()
+            self.file_path.stat.return_value.st_size = size_bytes
+    
+    @patch("huggingface_hub._upload_large_folder.logger")
+    def test_no_warnings_under_limits(self, mock_logger):
+        """Test that no warnings are issued when under all limits."""
+        paths = [
+            self.MockPath("file1.txt"),
+            self.MockPath("data/file2.txt"),
+            self.MockPath("data/sub/file3.txt"),
+        ]
+        _validate_upload_limits(paths)
+        
+        # Should only have info messages, no warnings
+        mock_logger.warning.assert_not_called()
+    
+    @patch("huggingface_hub._upload_large_folder.logger")
+    def test_warns_too_many_total_files(self, mock_logger):
+        """Test warning when total files exceed MAX_FILES_PER_REPO."""
+        # Create a list with more files than the limit
+        paths = [self.MockPath(f"file{i}.txt") for i in range(MAX_FILES_PER_REPO + 10)]
+        _validate_upload_limits(paths)
+        
+        # Check that the appropriate warning was logged
+        warning_calls = [str(call) for call in mock_logger.warning.call_args_list]
+        assert any(f"{MAX_FILES_PER_REPO + 10:,} files" in call for call in warning_calls)
+        assert any("exceeds the recommended limit" in call for call in warning_calls)
+    
+    @patch("huggingface_hub._upload_large_folder.logger")
+    def test_warns_too_many_subdirectories(self, mock_logger):
+        """Test warning when a folder has too many subdirectories."""
+        # Create files in many subdirectories under "data"
+        paths = []
+        for i in range(MAX_FILES_PER_FOLDER + 10):
+            paths.append(self.MockPath(f"data/subdir{i:05d}/file.txt"))
+        
+        _validate_upload_limits(paths)
+        
+        # Check that warning mentions subdirectories in "data" folder
+        warning_calls = [str(call) for call in mock_logger.warning.call_args_list]
+        assert any("data" in call and "subdirectories" in call for call in warning_calls)
+        assert any(f"{MAX_FILES_PER_FOLDER + 10:,} subdirectories" in call for call in warning_calls)
+    
+    @patch("huggingface_hub._upload_large_folder.logger")
+    def test_counts_files_and_subdirs_separately(self, mock_logger):
+        """Test that files and subdirectories are counted separately and correctly."""
+        # Create a structure with both files and subdirs in "data"
+        paths = []
+        # Add 5000 files directly in data/
+        for i in range(5000):
+            paths.append(self.MockPath(f"data/file{i}.txt"))
+        # Add 5100 subdirectories with files (exceeds limit when combined)
+        for i in range(5100):
+            paths.append(self.MockPath(f"data/subdir{i}/file.txt"))
+        
+        _validate_upload_limits(paths)
+        
+        # Should warn about "data" having 10,100 entries (5000 files + 5100 subdirs)
+        warning_calls = [str(call) for call in mock_logger.warning.call_args_list]
+        assert any("data" in call and "10,100 entries" in call for call in warning_calls)
+        assert any("5,000 files" in call and "5,100 subdirectories" in call for call in warning_calls)
+    
+    @patch("huggingface_hub._upload_large_folder.logger")
+    def test_file_size_decimal_gb(self, mock_logger):
+        """Test that file sizes are calculated using decimal GB (10^9 bytes)."""
+        # Create a file that's 21 GB in decimal (21 * 10^9 bytes)
+        size_bytes = 21 * 1_000_000_000
+        paths = [self.MockPath("large_file.bin", size_bytes=size_bytes)]
+        
+        _validate_upload_limits(paths)
+        
+        # Should warn about file being larger than 20GB recommended
+        warning_calls = [str(call) for call in mock_logger.warning.call_args_list]
+        assert any("21.0GB" in call or "21GB" in call for call in warning_calls)
+        assert any("20GB (recommended limit)" in call for call in warning_calls)
+    
+    @patch("huggingface_hub._upload_large_folder.logger")
+    def test_very_large_file_warning(self, mock_logger):
+        """Test warning for files exceeding hard limit (50GB)."""
+        # Create a file that's 51 GB
+        size_bytes = 51 * 1_000_000_000
+        paths = [self.MockPath("huge_file.bin", size_bytes=size_bytes)]
+        
+        _validate_upload_limits(paths)
+        
+        # Should warn about file exceeding 50GB hard limit
+        warning_calls = [str(call) for call in mock_logger.warning.call_args_list]
+        assert any("51.0GB" in call or "51GB" in call for call in warning_calls)
+        assert any("50GB hard limit" in call for call in warning_calls)
+    
+    @patch("huggingface_hub._upload_large_folder.logger")  
+    def test_nested_directory_structure(self, mock_logger):
+        """Test correct handling of deeply nested directory structures."""
+        paths = [
+            self.MockPath("a/b/c/d/e/file1.txt"),
+            self.MockPath("a/b/c/d/e/file2.txt"),
+            self.MockPath("a/b/c/d/f/file3.txt"),
+            self.MockPath("a/b/c/g/file4.txt"),
+        ]
+        
+        _validate_upload_limits(paths)
+        
+        # Should not warn - each folder has at most 2 entries
+        mock_logger.warning.assert_not_called()
 
 
 class UploadLargeFolderValidationTest(unittest.TestCase):

--- a/tests/test_upload_large_folder.py
+++ b/tests/test_upload_large_folder.py
@@ -1,6 +1,5 @@
 # tests/test_upload_large_folder.py
 import unittest
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -11,9 +10,7 @@ from huggingface_hub._upload_large_folder import (
     MAX_FILES_PER_REPO,
     LargeUploadStatus,
     _validate_upload_limits,
-    upload_large_folder_internal,
 )
-from huggingface_hub.utils import SoftTemporaryDirectory
 
 
 @pytest.fixture
@@ -158,85 +155,3 @@ class TestValidateUploadLimits(unittest.TestCase):
 
         # Should not warn - each folder has at most 2 entries
         mock_logger.warning.assert_not_called()
-
-
-class UploadLargeFolderValidationTest(unittest.TestCase):
-    """Test validation warnings for upload_large_folder - focusing on file count checks."""
-
-    def setUp(self):
-        self.api = MagicMock()
-        self.api.create_repo.return_value.repo_id = "test-user/test-repo"
-        self.api.repo_info.return_value.xet_enabled = False
-        self.api._build_hf_headers.return_value = {}
-        self.api.endpoint = "https://huggingface.co"
-
-    @patch("huggingface_hub._upload_large_folder.logger")
-    def test_validation_warns_too_many_files(self, mock_logger):
-        """Test warning when total files exceed MAX_FILES_PER_REPO."""
-        with SoftTemporaryDirectory() as tmpdir:
-            folder = Path(tmpdir)
-            # Create actual test files that will be found
-            num_files = 5
-            for i in range(num_files):
-                (folder / f"file_{i}.txt").write_text("content")
-
-            # Mock the validation check by directly calling logger.warning
-            # since we're focusing on file count validation only
-            expected_count = MAX_FILES_PER_REPO + 100
-            with patch("huggingface_hub._upload_large_folder.len") as mock_len:
-                # First call returns actual file count for initial check
-                # Second call returns our mocked large number for validation
-                mock_len.side_effect = [num_files, expected_count, expected_count]
-
-                with patch("huggingface_hub._upload_large_folder.threading.Thread"):
-                    with patch("huggingface_hub._upload_large_folder.time.sleep"):
-                        with patch("huggingface_hub._upload_large_folder.LargeUploadStatus.is_done") as mock_done:
-                            mock_done.return_value = True
-
-                            upload_large_folder_internal(
-                                api=self.api,
-                                repo_id="test-repo",
-                                folder_path=folder,
-                                repo_type="dataset",
-                            )
-
-                # Check that warning was logged
-                warning_calls = [call for call in mock_logger.warning.call_args_list]
-                assert any(
-                    f"You are about to upload {expected_count:,} files" in str(call) for call in warning_calls
-                ), "Expected warning about too many files not found"
-
-    @patch("huggingface_hub._upload_large_folder.logger")
-    def test_validation_warns_too_many_files_per_folder(self, mock_logger):
-        """Test warning when a folder has too many files."""
-        with SoftTemporaryDirectory() as tmpdir:
-            folder = Path(tmpdir)
-            subfolder = folder / "data"
-            subfolder.mkdir()
-            # Create a couple actual files
-            (subfolder / "file1.txt").write_text("content")
-            (subfolder / "file2.txt").write_text("content")
-
-            # Use Counter directly to simulate the file count per folder
-            with patch("huggingface_hub._upload_large_folder.Counter") as mock_counter:
-                # Mock Counter to return high file count for 'data' folder
-                mock_counter.return_value = {"data": MAX_FILES_PER_FOLDER + 100}
-
-                with patch("huggingface_hub._upload_large_folder.threading.Thread"):
-                    with patch("huggingface_hub._upload_large_folder.time.sleep"):
-                        with patch("huggingface_hub._upload_large_folder.LargeUploadStatus.is_done") as mock_done:
-                            mock_done.return_value = True
-
-                            upload_large_folder_internal(
-                                api=self.api,
-                                repo_id="test-repo",
-                                folder_path=folder,
-                                repo_type="dataset",
-                            )
-
-                # Check warning
-                warning_calls = [call for call in mock_logger.warning.call_args_list]
-                assert any(
-                    f"Folder 'data' contains {MAX_FILES_PER_FOLDER + 100:,} files" in str(call)
-                    for call in warning_calls
-                ), "Expected warning about too many files per folder"

--- a/tests/test_upload_large_folder.py
+++ b/tests/test_upload_large_folder.py
@@ -48,14 +48,14 @@ def test_update_chunk_transitions(status, start_idx, success, delta_items, durat
 
 class TestValidateUploadLimits(unittest.TestCase):
     """Test the _validate_upload_limits function directly."""
-    
+
     class MockPath:
         """Mock object to simulate LocalUploadFilePaths."""
         def __init__(self, path_in_repo, size_bytes=1000):
             self.path_in_repo = path_in_repo
             self.file_path = MagicMock()
             self.file_path.stat.return_value.st_size = size_bytes
-    
+
     @patch("huggingface_hub._upload_large_folder.logger")
     def test_no_warnings_under_limits(self, mock_logger):
         """Test that no warnings are issued when under all limits."""
@@ -65,22 +65,22 @@ class TestValidateUploadLimits(unittest.TestCase):
             self.MockPath("data/sub/file3.txt"),
         ]
         _validate_upload_limits(paths)
-        
+
         # Should only have info messages, no warnings
         mock_logger.warning.assert_not_called()
-    
+
     @patch("huggingface_hub._upload_large_folder.logger")
     def test_warns_too_many_total_files(self, mock_logger):
         """Test warning when total files exceed MAX_FILES_PER_REPO."""
         # Create a list with more files than the limit
         paths = [self.MockPath(f"file{i}.txt") for i in range(MAX_FILES_PER_REPO + 10)]
         _validate_upload_limits(paths)
-        
+
         # Check that the appropriate warning was logged
         warning_calls = [str(call) for call in mock_logger.warning.call_args_list]
         assert any(f"{MAX_FILES_PER_REPO + 10:,} files" in call for call in warning_calls)
         assert any("exceeds the recommended limit" in call for call in warning_calls)
-    
+
     @patch("huggingface_hub._upload_large_folder.logger")
     def test_warns_too_many_subdirectories(self, mock_logger):
         """Test warning when a folder has too many subdirectories."""
@@ -88,14 +88,14 @@ class TestValidateUploadLimits(unittest.TestCase):
         paths = []
         for i in range(MAX_FILES_PER_FOLDER + 10):
             paths.append(self.MockPath(f"data/subdir{i:05d}/file.txt"))
-        
+
         _validate_upload_limits(paths)
-        
+
         # Check that warning mentions subdirectories in "data" folder
         warning_calls = [str(call) for call in mock_logger.warning.call_args_list]
         assert any("data" in call and "subdirectories" in call for call in warning_calls)
         assert any(f"{MAX_FILES_PER_FOLDER + 10:,} subdirectories" in call for call in warning_calls)
-    
+
     @patch("huggingface_hub._upload_large_folder.logger")
     def test_counts_files_and_subdirs_separately(self, mock_logger):
         """Test that files and subdirectories are counted separately and correctly."""
@@ -107,43 +107,43 @@ class TestValidateUploadLimits(unittest.TestCase):
         # Add 5100 subdirectories with files (exceeds limit when combined)
         for i in range(5100):
             paths.append(self.MockPath(f"data/subdir{i}/file.txt"))
-        
+
         _validate_upload_limits(paths)
-        
+
         # Should warn about "data" having 10,100 entries (5000 files + 5100 subdirs)
         warning_calls = [str(call) for call in mock_logger.warning.call_args_list]
         assert any("data" in call and "10,100 entries" in call for call in warning_calls)
         assert any("5,000 files" in call and "5,100 subdirectories" in call for call in warning_calls)
-    
+
     @patch("huggingface_hub._upload_large_folder.logger")
     def test_file_size_decimal_gb(self, mock_logger):
         """Test that file sizes are calculated using decimal GB (10^9 bytes)."""
         # Create a file that's 21 GB in decimal (21 * 10^9 bytes)
         size_bytes = 21 * 1_000_000_000
         paths = [self.MockPath("large_file.bin", size_bytes=size_bytes)]
-        
+
         _validate_upload_limits(paths)
-        
+
         # Should warn about file being larger than 20GB recommended
         warning_calls = [str(call) for call in mock_logger.warning.call_args_list]
         assert any("21.0GB" in call or "21GB" in call for call in warning_calls)
         assert any("20GB (recommended limit)" in call for call in warning_calls)
-    
+
     @patch("huggingface_hub._upload_large_folder.logger")
     def test_very_large_file_warning(self, mock_logger):
         """Test warning for files exceeding hard limit (50GB)."""
         # Create a file that's 51 GB
         size_bytes = 51 * 1_000_000_000
         paths = [self.MockPath("huge_file.bin", size_bytes=size_bytes)]
-        
+
         _validate_upload_limits(paths)
-        
+
         # Should warn about file exceeding 50GB hard limit
         warning_calls = [str(call) for call in mock_logger.warning.call_args_list]
         assert any("51.0GB" in call or "51GB" in call for call in warning_calls)
         assert any("50GB hard limit" in call for call in warning_calls)
-    
-    @patch("huggingface_hub._upload_large_folder.logger")  
+
+    @patch("huggingface_hub._upload_large_folder.logger")
     def test_nested_directory_structure(self, mock_logger):
         """Test correct handling of deeply nested directory structures."""
         paths = [
@@ -152,9 +152,9 @@ class TestValidateUploadLimits(unittest.TestCase):
             self.MockPath("a/b/c/d/f/file3.txt"),
             self.MockPath("a/b/c/g/file4.txt"),
         ]
-        
+
         _validate_upload_limits(paths)
-        
+
         # Should not warn - each folder has at most 2 entries
         mock_logger.warning.assert_not_called()
 


### PR DESCRIPTION
## What does this PR do?

This PR adds "pre-flight" validation checks to `upload_large_folder` to warn users about repository limits before they start uploading. This helps users avoid discovering these limits after spending significant time uploading data.

Fixes #3278

## Implementation details

The validation checks run automatically after listing files and before starting the upload process. They check for:

- **Total file count**: Warns if uploading more than 100k files (recommended limit)
- **Files per folder**: Warns if any folder contains more than 10k files (recommended limit)
- **File sizes**: Warns about files larger than 20GB (recommended) or 50GB (hard limit)

## Example output

When limits are exceeded, users will see warnings like:

```
WARNING:huggingface_hub._upload_large_folder:You are about to upload 150,000 files. This exceeds the recommended limit of 100,000 files per repository.
  Consider:
    - Splitting your data into multiple repositories
    - Using fewer, larger files (e.g., tar archives)
    - See: https://huggingface.co/docs/hub/repositories-recommendations  
```

## Testing

Added unit tests that verify:
- Warnings are shown when file counts exceed limits
- No warnings are shown for uploads within limits

Not super sure about the tests, but probably, since we don't do anything with the checks at the moment, it's not so important? 

I'm also not sure if we want to do a check for total repo size and maybe point to https://huggingface.co/docs/hub/storage-limits + suggest Pro/Team/EH if repo > some GB value?