### PR TITLE
fix: improve job owner to handle AuthorData response type

### DIFF
--- a/src/huggingface_hub/_jobs_api.py
+++ b/src/huggingface_hub/_jobs_api.py
@@ -51,11 +51,31 @@ class JobStatus:
         self.stage = kwargs["stage"]
         self.message = kwargs.get("message")
 
-
 @dataclass
 class JobOwner:
-    id: str
     name: str
+    id: Optional[str] = None
+    fullname: Optional[str] = None
+    avatar_url: Optional[str] = None
+    type: Optional[str] = None
+    is_pro: Optional[bool] = None
+    is_hf: Optional[bool] = None
+    is_enterprise: Optional[bool] = None
+    follower_count: Optional[int] = None
+
+    @classmethod
+    def from_dict(cls, data: dict) -> 'JobOwner':
+        return cls(
+            id=data.get('_id'),
+            name=data.get('name'),
+            fullname=data.get('fullname'),
+            avatar_url=data.get('avatarUrl'),
+            type=data.get('type'),
+            is_pro=data.get('isPro'),
+            is_hf=data.get('isHf'),
+            is_enterprise=data.get('isEnterprise'),
+            follower_count=data.get('followerCount')
+        )
 
 
 @dataclass
@@ -132,7 +152,7 @@ class JobInfo:
         self.created_at = parse_datetime(created_at) if created_at else None
         self.docker_image = kwargs.get("dockerImage") or kwargs.get("docker_image")
         self.space_id = kwargs.get("spaceId") or kwargs.get("space_id")
-        self.owner = JobOwner(**(kwargs["owner"] if isinstance(kwargs.get("owner"), dict) else {}))
+        self.owner = JobOwner.from_dict(kwargs["owner"]) if isinstance(kwargs.get("owner"), dict) else None
         self.command = kwargs.get("command")
         self.arguments = kwargs.get("arguments")
         self.environment = kwargs.get("environment")


### PR DESCRIPTION
This PR fixes the issues parsing the new job owner response type from the changes in https://github.com/huggingface-internal/moon-landing/pull/14644

Specifically the current hf jobs `JobOwner` expects and id and name. This fails with the latest owner type that looks like the following

job from a user
```json
{
  "_id": "6452d5ba3f80ad88c77b2f05",
  "avatarUrl": "https://cdn-avatars.huggingface.co/v1/production/uploads/6452d5ba3f80ad88c77b2f05/Elc2R5dvn-iQlgROdRikX.png",
  "fullname": "David Holtz",
  "name": "drbh",
  "type": "user",
  "isPro": false,
  "isHf": true,
  "isHfAdmin": false,
  "isMod": false,
  "followerCount": 51
}
```

job from an org
```json
{
  "avatarUrl": "https://cdn-avatars.huggingface.co/v1/production/uploads/6452d5ba3f80ad88c77b2f05/0J-xey5Z1dh9ZOyTyyTge.png",
  "fullname": "kernels-community",
  "name": "kernels-community",
  "type": "org",
  "isHf": false,
  "isHfAdmin": false,
  "isMod": false,
  "isEnterprise": true,
  "followerCount": 130
}
```

 these changes update the `JobOwner` to parse the full [AuthorData](https://github.com/huggingface-internal/moon-landing/blob/7b28cb3a83956b19aaabf2aa2bd03bd51dcc9663/server/lib/FrontDataSchemas.ts#L284) object and correctly handle both cases
