### PR TITLE
Whoami: custom message only on unauthorized

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -1781,18 +1781,20 @@ class HfApi:
         try:
             hf_raise_for_status(r)
         except HTTPError as e:
-            error_message = "Invalid user token."
-            # Check which token is the effective one and generate the error message accordingly
-            if effective_token == _get_token_from_google_colab():
-                error_message += " The token from Google Colab vault is invalid. Please update it from the UI."
-            elif effective_token == _get_token_from_environment():
-                error_message += (
-                    " The token from HF_TOKEN environment variable is invalid. "
-                    "Note that HF_TOKEN takes precedence over `hf auth login`."
-                )
-            elif effective_token == _get_token_from_file():
-                error_message += " The token stored is invalid. Please run `hf auth login` to update it."
-            raise HTTPError(error_message, request=e.request, response=e.response) from e
+            if e.response.status_code == 401:
+                error_message = "Invalid user token."
+                # Check which token is the effective one and generate the error message accordingly
+                if effective_token == _get_token_from_google_colab():
+                    error_message += " The token from Google Colab vault is invalid. Please update it from the UI."
+                elif effective_token == _get_token_from_environment():
+                    error_message += (
+                        " The token from HF_TOKEN environment variable is invalid. "
+                        "Note that HF_TOKEN takes precedence over `hf auth login`."
+                    )
+                elif effective_token == _get_token_from_file():
+                    error_message += " The token stored is invalid. Please run `hf auth login` to update it."
+                raise HTTPError(error_message, request=e.request, response=e.response) from e
+            raise
         return r.json()
 
     @_deprecate_method(


### PR DESCRIPTION
(follow up on https://github.com/huggingface/huggingface_hub/pull/362 :smile:)

Currently on a `whoami` call, we print a `Invalid token` message if any `HTTPError` happens.

This is not correct as many errors can lead to a HTTP Error, not just an invalid token. This PR fixes this by setting the custom message only on a HTTP 401 unauthorized.

Here is an example of a HTTP 429 with current `main` branch (see private [slack thread](https://huggingface.slack.com/archives/C07RD3RVD5W/p1753854604683449))
```
---------------------------------------------------------------------------
HTTPError                                 Traceback (most recent call last)
/usr/local/lib/python3.11/dist-packages/huggingface_hub/utils/_http.py in hf_raise_for_status(response, endpoint_name)
    408     try:
--> 409         response.raise_for_status()
    410     except HTTPError as e:

6 frames
HTTPError: 429 Client Error: Too Many Requests for url: https://huggingface.co/api/whoami-v2

The above exception was the direct cause of the following exception:

HfHubHTTPError                            Traceback (most recent call last)
HfHubHTTPError: 429 Client Error: Too Many Requests for url: https://huggingface.co/api/whoami-v2

The above exception was the direct cause of the following exception:

HTTPError                                 Traceback (most recent call last)
/usr/local/lib/python3.11/dist-packages/huggingface_hub/hf_api.py in whoami(self, token)
   1789             elif effective_token == _get_token_from_file():
   1790                 error_message += " The token stored is invalid. Please run `hf auth login` to update it."
-> 1791             raise HTTPError(error_message, request=e.request, response=e.response) from e
   1792         return r.json()
   1793 

HTTPError: Invalid user token. The token from Google Colab vault is invalid. Please update it from the UI.
```