### PR TITLE
[InferenceClient] Add content-type header whenever possible + refacto

### DIFF
--- a/src/huggingface_hub/inference/_common.py
+++ b/src/huggingface_hub/inference/_common.py
@@ -19,7 +19,6 @@ import io
 import json
 import logging
 import mimetypes
-from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import (
@@ -27,9 +26,7 @@ from typing import (
     Any,
     AsyncIterable,
     BinaryIO,
-    ContextManager,
     Dict,
-    Generator,
     Iterable,
     List,
     Literal,
@@ -61,8 +58,7 @@ if TYPE_CHECKING:
 # TYPES
 UrlT = str
 PathT = Union[str, Path]
-BinaryT = Union[bytes, BinaryIO]
-ContentT = Union[BinaryT, PathT, UrlT, "Image"]
+ContentT = Union[bytes, BinaryIO, PathT, UrlT, "Image", bytearray, memoryview]
 
 # Use to set a Accept: image/png header
 TASKS_EXPECTING_IMAGES = {"text-to-image", "image-to-image"}
@@ -76,8 +72,33 @@ class RequestParameters:
     task: str
     model: Optional[str]
     json: Optional[Union[str, Dict, List]]
-    data: Optional[ContentT]
+    data: Optional[bytes]
     headers: Dict[str, Any]
+
+
+class MimeBytes(bytes):
+    """
+    A bytes object with a mime type.
+    To be returned by `_prepare_payload_open_as_mime_bytes` in subclasses.
+
+    Example:
+    ```python
+        >>> b = MimeBytes(b"hello", "text/plain")
+        >>> isinstance(b, bytes)
+        True
+        >>> b.mime_type
+        'text/plain'
+    ```
+    """
+
+    mime_type: Optional[str]
+
+    def __new__(cls, data: bytes, mime_type: Optional[str] = None):
+        obj = super().__new__(cls, data)
+        obj.mime_type = mime_type
+        if isinstance(data, MimeBytes) and mime_type is None:
+            obj.mime_type = data.mime_type
+        return obj
 
 
 ## IMPORT UTILS
@@ -117,31 +138,46 @@ def _import_pil_image():
 
 
 @overload
-def _open_as_binary(
-    content: ContentT,
-) -> ContextManager[BinaryT]: ...  # means "if input is not None, output is not None"
+def _open_as_mime_bytes(content: ContentT) -> MimeBytes: ...  # means "if input is not None, output is not None"
 
 
 @overload
-def _open_as_binary(
-    content: Literal[None],
-) -> ContextManager[Literal[None]]: ...  # means "if input is None, output is None"
+def _open_as_mime_bytes(content: Literal[None]) -> Literal[None]: ...  # means "if input is None, output is None"
 
 
-@contextmanager  # type: ignore
-def _open_as_binary(content: Optional[ContentT]) -> Generator[Optional[BinaryT], None, None]:
+def _open_as_mime_bytes(content: Optional[ContentT]) -> Optional[MimeBytes]:
     """Open `content` as a binary file, either from a URL, a local path, raw bytes, or a PIL Image.
 
     Do nothing if `content` is None.
-
-    TODO: handle base64 as input
     """
+    # If content is None, yield None
+    if content is None:
+        return None
+
+    # If content is bytes, return it
+    if isinstance(content, bytes):
+        return MimeBytes(content)
+
+    # If content is raw binary data (bytearray, memoryview)
+    if isinstance(content, (bytearray, memoryview)):
+        return MimeBytes(bytes(content))
+
+    # If content is a binary file-like object
+    if hasattr(content, "read"):  # duck-typing instead of isinstance(content, BinaryIO)
+        logger.debug("Reading content from BinaryIO")
+        data = content.read()
+        mime_type = mimetypes.guess_type(content.name)[0] if hasattr(content, "name") else None
+        if isinstance(data, str):
+            raise TypeError("Expected binary stream (bytes), but got text stream")
+        return MimeBytes(data, mime_type=mime_type)
+
     # If content is a string => must be either a URL or a path
     if isinstance(content, str):
         if content.startswith("https://") or content.startswith("http://"):
             logger.debug(f"Downloading content from {content}")
-            yield get_session().get(content).content  # TODO: retrieve as stream and pipe to post request ?
-            return
+            response = get_session().get(content)
+            return MimeBytes(response.content, mime_type=response.headers.get("Content-Type"))
+
         content = Path(content)
         if not content.exists():
             raise FileNotFoundError(
@@ -152,9 +188,7 @@ def _open_as_binary(content: Optional[ContentT]) -> Generator[Optional[BinaryT],
     # If content is a Path => open it
     if isinstance(content, Path):
         logger.debug(f"Opening content from {content}")
-        with content.open("rb") as f:
-            yield f
-        return
+        return MimeBytes(content.read_bytes(), mime_type=mimetypes.guess_type(content)[0])
 
     # If content is a PIL Image => convert to bytes
     if is_pillow_available():
@@ -163,38 +197,37 @@ def _open_as_binary(content: Optional[ContentT]) -> Generator[Optional[BinaryT],
         if isinstance(content, Image.Image):
             logger.debug("Converting PIL Image to bytes")
             buffer = io.BytesIO()
-            content.save(buffer, format=content.format or "PNG")
-            yield buffer.getvalue()
-            return
+            format = content.format or "PNG"
+            content.save(buffer, format=format)
+            return MimeBytes(buffer.getvalue(), mime_type=f"image/{format.lower()}")
 
-    # Otherwise: already a file-like object or None
-    yield content  # type: ignore
+    # If nothing matched, raise error
+    raise TypeError(
+        f"Unsupported content type: {type(content)}. "
+        "Expected one of: bytes, BinaryIO, Path, str (URL or file path), or PIL.Image.Image."
+    )
 
 
 def _b64_encode(content: ContentT) -> str:
     """Encode a raw file (image, audio) into base64. Can be bytes, an opened file, a path or a URL."""
-    with _open_as_binary(content) as data:
-        data_as_bytes = data if isinstance(data, bytes) else data.read()
-        return base64.b64encode(data_as_bytes).decode()
+    raw_bytes = _open_as_mime_bytes(content)
+    return base64.b64encode(raw_bytes).decode()
 
 
 def _as_url(content: ContentT, default_mime_type: str) -> str:
-    if isinstance(content, str) and (content.startswith("https://") or content.startswith("http://")):
+    if isinstance(content, str) and content.startswith(("http://", "https://", "data:")):
         return content
 
-    # Handle MIME type detection for different content types
-    mime_type = None
-    if isinstance(content, (str, Path)):
-        mime_type = mimetypes.guess_type(content, strict=False)[0]
-    elif is_pillow_available():
-        from PIL import Image
+    # Convert content to bytes
+    raw_bytes = _open_as_mime_bytes(content)
 
-        if isinstance(content, Image.Image):
-            # Determine MIME type from PIL Image format, in sync with `_open_as_binary`
-            mime_type = f"image/{(content.format or 'PNG').lower()}"
+    # Get MIME type
+    mime_type = raw_bytes.mime_type or default_mime_type
 
-    mime_type = mime_type or default_mime_type
-    encoded_data = _b64_encode(content)
+    # Encode content to base64
+    encoded_data = _b64_encode(raw_bytes)
+
+    # Build data URL
     return f"data:{mime_type};base64,{encoded_data}"
 
 
@@ -237,9 +270,6 @@ def _bytes_to_image(content: bytes) -> "Image":
 
 def _as_dict(response: Union[bytes, Dict]) -> Dict:
     return json.loads(response) if isinstance(response, bytes) else response
-
-
-## PAYLOAD UTILS
 
 
 ## STREAMING UTILS

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -40,7 +40,6 @@ from huggingface_hub.inference._common import (
     _bytes_to_list,
     _get_unsupported_text_generation_kwargs,
     _import_numpy,
-    _open_as_binary,
     _set_unsupported_text_generation_kwargs,
     raise_text_generation_error,
 )
@@ -255,39 +254,38 @@ class AsyncInferenceClient:
         if request_parameters.task in TASKS_EXPECTING_IMAGES and "Accept" not in request_parameters.headers:
             request_parameters.headers["Accept"] = "image/png"
 
-        with _open_as_binary(request_parameters.data) as data_as_binary:
-            # Do not use context manager as we don't want to close the connection immediately when returning
-            # a stream
-            session = self._get_client_session(headers=request_parameters.headers)
+        # Do not use context manager as we don't want to close the connection immediately when returning
+        # a stream
+        session = self._get_client_session(headers=request_parameters.headers)
 
-            try:
-                response = await session.post(
-                    request_parameters.url, json=request_parameters.json, data=data_as_binary, proxy=self.proxies
-                )
-                response_error_payload = None
-                if response.status != 200:
-                    try:
-                        response_error_payload = await response.json()  # get payload before connection closed
-                    except Exception:
-                        pass
-                response.raise_for_status()
-                if stream:
-                    return _async_yield_from(session, response)
-                else:
-                    content = await response.read()
-                    await session.close()
-                    return content
-            except asyncio.TimeoutError as error:
+        try:
+            response = await session.post(
+                request_parameters.url, json=request_parameters.json, data=request_parameters.data, proxy=self.proxies
+            )
+            response_error_payload = None
+            if response.status != 200:
+                try:
+                    response_error_payload = await response.json()  # get payload before connection closed
+                except Exception:
+                    pass
+            response.raise_for_status()
+            if stream:
+                return _async_yield_from(session, response)
+            else:
+                content = await response.read()
                 await session.close()
-                # Convert any `TimeoutError` to a `InferenceTimeoutError`
-                raise InferenceTimeoutError(f"Inference call timed out: {request_parameters.url}") from error  # type: ignore
-            except aiohttp.ClientResponseError as error:
-                error.response_error_payload = response_error_payload
-                await session.close()
-                raise error
-            except Exception:
-                await session.close()
-                raise
+                return content
+        except asyncio.TimeoutError as error:
+            await session.close()
+            # Convert any `TimeoutError` to a `InferenceTimeoutError`
+            raise InferenceTimeoutError(f"Inference call timed out: {request_parameters.url}") from error  # type: ignore
+        except aiohttp.ClientResponseError as error:
+            error.response_error_payload = response_error_payload
+            await session.close()
+            raise error
+        except Exception:
+            await session.close()
+            raise
 
     async def __aenter__(self):
         return self

--- a/src/huggingface_hub/inference/_providers/_common.py
+++ b/src/huggingface_hub/inference/_providers/_common.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional, Union, overload
 
 from huggingface_hub import constants
 from huggingface_hub.hf_api import InferenceProviderMapping
-from huggingface_hub.inference._common import RequestParameters
+from huggingface_hub.inference._common import MimeBytes, RequestParameters
 from huggingface_hub.inference._generated.types.chat_completion import ChatCompletionInputMessage
 from huggingface_hub.utils import build_hf_headers, get_token, logging
 
@@ -108,8 +108,17 @@ class TaskProviderHelper:
             raise ValueError("Both payload and data cannot be set in the same request.")
         if payload is None and data is None:
             raise ValueError("Either payload or data must be set in the request.")
+
+        # normalize headers to lowercase and add content-type if not present
+        normalized_headers = self._normalize_headers(headers, payload, data)
+
         return RequestParameters(
-            url=url, task=self.task, model=provider_mapping_info.provider_id, json=payload, data=data, headers=headers
+            url=url,
+            task=self.task,
+            model=provider_mapping_info.provider_id,
+            json=payload,
+            data=data,
+            headers=normalized_headers,
         )
 
     def get_response(
@@ -172,7 +181,22 @@ class TaskProviderHelper:
             )
         return provider_mapping
 
-    def _prepare_headers(self, headers: Dict, api_key: str) -> Dict:
+    def _normalize_headers(
+        self, headers: Dict[str, Any], payload: Optional[Dict[str, Any]], data: Optional[MimeBytes]
+    ) -> Dict[str, Any]:
+        """Normalize the headers to use for the request.
+
+        Override this method in subclasses for customized headers.
+        """
+        normalized_headers = {key.lower(): value for key, value in headers.items() if value is not None}
+        if normalized_headers.get("content-type") is None:
+            if data is not None and data.mime_type is not None:
+                normalized_headers["content-type"] = data.mime_type
+            elif payload is not None:
+                normalized_headers["content-type"] = "application/json"
+        return normalized_headers
+
+    def _prepare_headers(self, headers: Dict, api_key: str) -> Dict[str, Any]:
         """Return the headers to use for the request.
 
         Override this method in subclasses for customized headers.
@@ -222,7 +246,7 @@ class TaskProviderHelper:
         parameters: Dict,
         provider_mapping_info: InferenceProviderMapping,
         extra_payload: Optional[Dict],
-    ) -> Optional[bytes]:
+    ) -> Optional[MimeBytes]:
         """Return the body to use for the request, as bytes.
 
         Override this method in subclasses for customized body data.

--- a/src/huggingface_hub/inference/_providers/black_forest_labs.py
+++ b/src/huggingface_hub/inference/_providers/black_forest_labs.py
@@ -18,7 +18,7 @@ class BlackForestLabsTextToImageTask(TaskProviderHelper):
     def __init__(self):
         super().__init__(provider="black-forest-labs", base_url="https://api.us1.bfl.ai", task="text-to-image")
 
-    def _prepare_headers(self, headers: Dict, api_key: str) -> Dict:
+    def _prepare_headers(self, headers: Dict, api_key: str) -> Dict[str, Any]:
         headers = super()._prepare_headers(headers, api_key)
         if not api_key.startswith("hf_"):
             _ = headers.pop("authorization")

--- a/src/huggingface_hub/inference/_providers/fal_ai.py
+++ b/src/huggingface_hub/inference/_providers/fal_ai.py
@@ -22,7 +22,7 @@ class FalAITask(TaskProviderHelper, ABC):
     def __init__(self, task: str):
         super().__init__(provider="fal-ai", base_url="https://fal.run", task=task)
 
-    def _prepare_headers(self, headers: Dict, api_key: str) -> Dict:
+    def _prepare_headers(self, headers: Dict, api_key: str) -> Dict[str, Any]:
         headers = super()._prepare_headers(headers, api_key)
         if not api_key.startswith("hf_"):
             headers["authorization"] = f"Key {api_key}"
@@ -36,7 +36,7 @@ class FalAIQueueTask(TaskProviderHelper, ABC):
     def __init__(self, task: str):
         super().__init__(provider="fal-ai", base_url="https://queue.fal.run", task=task)
 
-    def _prepare_headers(self, headers: Dict, api_key: str) -> Dict:
+    def _prepare_headers(self, headers: Dict, api_key: str) -> Dict[str, Any]:
         headers = super()._prepare_headers(headers, api_key)
         if not api_key.startswith("hf_"):
             headers["authorization"] = f"Key {api_key}"

--- a/src/huggingface_hub/inference/_providers/hf_inference.py
+++ b/src/huggingface_hub/inference/_providers/hf_inference.py
@@ -6,7 +6,13 @@ from urllib.parse import urlparse, urlunparse
 
 from huggingface_hub import constants
 from huggingface_hub.hf_api import InferenceProviderMapping
-from huggingface_hub.inference._common import RequestParameters, _b64_encode, _bytes_to_dict, _open_as_binary
+from huggingface_hub.inference._common import (
+    MimeBytes,
+    RequestParameters,
+    _b64_encode,
+    _bytes_to_dict,
+    _open_as_mime_bytes,
+)
 from huggingface_hub.inference._providers._common import TaskProviderHelper, filter_none
 from huggingface_hub.utils import build_hf_headers, get_session, get_token, hf_raise_for_status
 
@@ -75,7 +81,7 @@ class HFInferenceBinaryInputTask(HFInferenceTask):
         parameters: Dict,
         provider_mapping_info: InferenceProviderMapping,
         extra_payload: Optional[Dict],
-    ) -> Optional[bytes]:
+    ) -> Optional[MimeBytes]:
         parameters = filter_none(parameters)
         extra_payload = extra_payload or {}
         has_parameters = len(parameters) > 0 or len(extra_payload) > 0
@@ -86,12 +92,13 @@ class HFInferenceBinaryInputTask(HFInferenceTask):
 
         # Send inputs as raw content when no parameters are provided
         if not has_parameters:
-            with _open_as_binary(inputs) as data:
-                data_as_bytes = data if isinstance(data, bytes) else data.read()
-                return data_as_bytes
+            return _open_as_mime_bytes(inputs)
 
         # Otherwise encode as b64
-        return json.dumps({"inputs": _b64_encode(inputs), "parameters": parameters, **extra_payload}).encode("utf-8")
+        return MimeBytes(
+            json.dumps({"inputs": _b64_encode(inputs), "parameters": parameters, **extra_payload}).encode("utf-8"),
+            mime_type="application/json",
+        )
 
 
 class HFInferenceConversational(HFInferenceTask):

--- a/src/huggingface_hub/inference/_providers/new_provider.md
+++ b/src/huggingface_hub/inference/_providers/new_provider.md
@@ -15,7 +15,7 @@ For `text-generation` and `conversational` tasks, one can just inherit from `Bas
 ```py
 from typing import Any, Dict, Optional, Union
 
-from ._common import TaskProviderHelper
+from ._common import TaskProviderHelper, MimeBytes
 
 
 class MyNewProviderTaskProviderHelper(TaskProviderHelper):
@@ -34,7 +34,7 @@ class MyNewProviderTaskProviderHelper(TaskProviderHelper):
         Override this method in subclasses for customized response handling."""
         return super().get_response(response)
 
-    def _prepare_headers(self, headers: Dict, api_key: str) -> Dict:
+    def _prepare_headers(self, headers: Dict, api_key: str) -> Dict[str, Any]:
         """Return the headers to use for the request.
 
         Override this method in subclasses for customized headers.
@@ -58,11 +58,13 @@ class MyNewProviderTaskProviderHelper(TaskProviderHelper):
 
     def _prepare_payload_as_bytes(
         self, inputs: Any, parameters: Dict, mapped_model: str, extra_payload: Optional[Dict]
-    ) -> Optional[bytes]:
+    ) -> Optional[MimeBytes]:
         """Return the body to use for the request, as bytes.
 
         Override this method in subclasses for customized body data.
         Only one of `_prepare_payload_as_dict` and `_prepare_payload_as_bytes` should return a value.
+
+        `MimeBytes` is a subclass of `bytes` that carries a `mime_type` attribute.
         """
         return super()._prepare_payload_as_bytes(inputs, parameters, mapped_model, extra_payload)
     

--- a/src/huggingface_hub/inference/_providers/replicate.py
+++ b/src/huggingface_hub/inference/_providers/replicate.py
@@ -14,7 +14,7 @@ class ReplicateTask(TaskProviderHelper):
     def __init__(self, task: str):
         super().__init__(provider=_PROVIDER, base_url=_BASE_URL, task=task)
 
-    def _prepare_headers(self, headers: Dict, api_key: str) -> Dict:
+    def _prepare_headers(self, headers: Dict, api_key: str) -> Dict[str, Any]:
         headers = super()._prepare_headers(headers, api_key)
         headers["Prefer"] = "wait"
         return headers


### PR DESCRIPTION
**TL;DR:** content-type is now properly set in request headers when sending an image, audio, etc. as payload.

```py
from huggingface_hub import InferenceClient

client = InferenceClient(model="microsoft/resnet-50")
output = client.image_classification("https://images.pexels.com/photos/20787/pexels-photo.jpg")
print(output)
```

=> headers are `{'user-agent': 'unknown/None; hf_hub/0.35.0.dev0; python/3.11.13', 'authorization': 'Bearer hf_xxxx', 'content-type': 'image/jpeg'}`

---

Currently when we send a "binary-only" request (e.g. for ASR, image classification, image to image, etc.) we are sending raw bytes in the payload and no explicit `content-type`, even when we can easily infer it. This can cause issues if server expects a content type or tries to guess the file encoding by itself. This issue has been reported several times and currently the only workaround is to hardcode the content-type when initializing the `InferenceClient`. This PR fixes most of the issues listed above by adding `content-type` header when it can be determined. This is the case when retrieving a binary from a PIL image, from a URL or from a local file.

In practice, I've made a little refacto to handle that:
- I've added a new class `MimeBytes` extending the built-in `bytes` class. This allows me to attach a `mime_type` attribute to a `bytes` object
- `_open_as_binary` has been updated to return a `MimeBytes` instead of `bytes`. I renamed the method `_open_as_mime_bytes`
- previously `_open_as_binary` was a context manager to be able to stream the payload directly from a local file instead of loading it into memory before making the HTTP request. In the end this small optimization was mostly useless (we are only dealing with small-ish files) and added some complexity to the logic. I've reverted it to a basic method, always returning raw bytes loaded in memory (a `MimeBytes` object) 
- in `InferenceClient._inner_post` I got rid of `_open_as_binary` as I realized it was useless (we are always passing a `bytes` object to it) since body is built by each provider's helpers. Made the same to the async client.
- `_as_url` now uses `_open_as_mime_bytes`. Previously we were building the URL using `mimetype.guess_type` which is now centralized logic
- in `TaskProviderHelper`, I have added a `_normalize_headers` method that lowercase all headers keys + add a content-type when possible. This method can be overwritten by each provider but it is not recommended in practice (overwriting `_prepare_headers` is enough)
- tests have been updated + added a test for `image-classification` task (checking that `content-type` header is indeed set) 

---

Related to:
- https://github.com/huggingface/huggingface_hub/issues/2827
- [slack thread](https://huggingface.slack.com/archives/C016D661PAN/p1756114836559989) (internal) cc @ErikKaum @Michellehbn 
- forum issue https://discuss.huggingface.co/t/400-error-on-falconsai-nsfw-image-detection/167719
- another [slack thread](https://huggingface.slack.com/archives/C02V5EA0A95/p1754908992557559) (internal) cc @freddyaboulton @hanouticelina 
- (yet) another [slack thread](https://huggingface.slack.com/archives/C02V5EA0A95/p1733327444878139) (internal)
