### PR TITLE
Added `apps` as a parameter to `HfApi.list_models`

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -1869,6 +1869,7 @@ class HfApi:
         inference: Optional[Literal["warm"]] = None,
         inference_provider: Optional[Union[Literal["all"], "PROVIDER_T", List["PROVIDER_T"]]] = None,
         model_name: Optional[str] = None,
+        apps: Optional[Union[str, List[str]]] = None,
         trained_dataset: Optional[Union[str, List[str]]] = None,
         search: Optional[str] = None,
         pipeline_tag: Optional[str] = None,
@@ -1917,6 +1918,9 @@ class HfApi:
                 Hub, such as "bert" or "bert-base-cased"
             task (`str` or `List`, *optional*):
                 Deprecated. Pass a task in `filter` to filter models by task.
+            apps (`str` or `List`, *optional*):
+                A string or list of strings to filter models on the Hub that
+                support the specified apps. Example values include `"ollama"` or `["ollama", "vllm"]`.
             trained_dataset (`str` or `List`, *optional*):
                 A string tag or a list of string tags of the trained dataset for a
                 model on the Hub.
@@ -2022,6 +2026,10 @@ class HfApi:
             params["filter"] = filter_list
 
         # Handle other query params
+        if apps:
+            if isinstance(apps, str):
+                apps = [apps]
+            params["apps"] = apps
         if author:
             params["author"] = author
         if gated is not None:

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -1865,11 +1865,11 @@ class HfApi:
         # Search-query parameter
         filter: Union[str, Iterable[str], None] = None,
         author: Optional[str] = None,
+        apps: Optional[Union[str, List[str]]] = None,
         gated: Optional[bool] = None,
         inference: Optional[Literal["warm"]] = None,
         inference_provider: Optional[Union[Literal["all"], "PROVIDER_T", List["PROVIDER_T"]]] = None,
         model_name: Optional[str] = None,
-        apps: Optional[Union[str, List[str]]] = None,
         trained_dataset: Optional[Union[str, List[str]]] = None,
         search: Optional[str] = None,
         pipeline_tag: Optional[str] = None,
@@ -1900,6 +1900,9 @@ class HfApi:
             author (`str`, *optional*):
                 A string which identify the author (user or organization) of the
                 returned models.
+            apps (`str` or `List`, *optional*):
+                A string or list of strings to filter models on the Hub that
+                support the specified apps. Example values include `"ollama"` or `["ollama", "vllm"]`.
             gated (`bool`, *optional*):
                 A boolean to filter models on the Hub that are gated or not. By default, all models are returned.
                 If `gated=True` is passed, only gated models are returned.
@@ -1918,9 +1921,6 @@ class HfApi:
                 Hub, such as "bert" or "bert-base-cased"
             task (`str` or `List`, *optional*):
                 Deprecated. Pass a task in `filter` to filter models by task.
-            apps (`str` or `List`, *optional*):
-                A string or list of strings to filter models on the Hub that
-                support the specified apps. Example values include `"ollama"` or `["ollama", "vllm"]`.
             trained_dataset (`str` or `List`, *optional*):
                 A string tag or a list of string tags of the trained dataset for a
                 model on the Hub.
@@ -2026,12 +2026,12 @@ class HfApi:
             params["filter"] = filter_list
 
         # Handle other query params
+        if author:
+            params["author"] = author
         if apps:
             if isinstance(apps, str):
                 apps = [apps]
             params["apps"] = apps
-        if author:
-            params["author"] = author
         if gated is not None:
             params["gated"] = gated
         if inference is not None:

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -1836,7 +1836,7 @@ class HfApiPublicProductionTest(unittest.TestCase):
         models = list(self._api.list_models(apps="ollama", full=True, limit=500))
         assert len(models) > 1
         for model in models:
-        assert any(sibling.rfilename.lower().endswith(".gguf") for sibling in model.siblings)
+            assert any(sibling.rfilename.lower().endswith(".gguf") for sibling in model.siblings)
 
     def test_list_models_search(self):
         models = list(self._api.list_models(search="bert"))

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -1836,13 +1836,7 @@ class HfApiPublicProductionTest(unittest.TestCase):
         models = list(self._api.list_models(apps="ollama", full=True, limit=500))
         assert len(models) > 1
         for model in models:
-            assert "gguf" in model.tags
-            found_at_least_one_gguf = False
-            for model_sibling in model.siblings:
-                if model_sibling.rfilename.lower().endswith(".gguf"):
-                    found_at_least_one_gguf = True
-                    break
-            assert found_at_least_one_gguf, f"No .gguf file found in {model.id}"
+        assert any(sibling.rfilename.lower().endswith(".gguf") for sibling in model.siblings)
 
     def test_list_models_search(self):
         models = list(self._api.list_models(search="bert"))

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -1832,6 +1832,20 @@ class HfApiPublicProductionTest(unittest.TestCase):
         for model in models:
             assert model.id.startswith("google/")
 
+    def test_list_models_apps(self):
+        models = list(self._api.list_models(apps="ollama", full=True, limit=500))
+        assert len(models) > 1
+        assert len(models) <= 500
+        assert isinstance(models[0], ModelInfo)
+        for model in models:
+            assert "gguf" in model.tags
+            found_at_least_one_gguf = False
+            for model_sibling in model.siblings:
+                if model_sibling.rfilename.lower().endswith(".gguf"):
+                    found_at_least_one_gguf = True
+                    break
+            assert found_at_least_one_gguf, f"No .gguf file found in {model.id}"
+
     def test_list_models_search(self):
         models = list(self._api.list_models(search="bert"))
         assert len(models) > 10

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -1835,8 +1835,6 @@ class HfApiPublicProductionTest(unittest.TestCase):
     def test_list_models_apps(self):
         models = list(self._api.list_models(apps="ollama", full=True, limit=500))
         assert len(models) > 1
-        assert len(models) <= 500
-        assert isinstance(models[0], ModelInfo)
         for model in models:
             assert "gguf" in model.tags
             found_at_least_one_gguf = False


### PR DESCRIPTION
# What

This PR adds `apps` as a parameter to `HfApi.list_models` in order to retrieve models that support the specified apps, e.g., `ollama` or `vllm`.

# Why
 1. Solves issue #3319 
 
# TODOs in this WIP

1. This PR's implementation uses the `apps` parameter of the Hugging Face API instead of adding the value of `apps` to the `filter` list. This is due to the fact that a query such as https://huggingface.co/api/models?apps=ollama produces different results from https://huggingface.co/api/models?filter=ollama, with the latter listing some models that do not actually support Ollama.  Is this observation correct and tested thoroughly? Is this expected behaviour?
2. Perhaps add more exhaustive tests in `test_list_models_apps` since it only checks for Ollama supported models.
3. Is the method of checking for files ending with _.gguf_ necessary in `test_list_models_apps`?
4. Is the assert failure message `f"No .gguf file found in {model.id}"` necessary in `test_list_models_apps`?
5. Current test timings show warnings that `test_list_models_apps` is slow. Optimisation is required but this goes against TODO-(2).
   ```
   0.24s call     tests/test_hf_api.py::HfApiPublicProductionTest::test_list_models_apps
   0.00s setup    tests/test_hf_api.py::HfApiPublicProductionTest::test_list_models_apps
   0.00s teardown tests/test_hf_api.py::HfApiPublicProductionTest::test_list_models_apps
   ```
6. Add documentation with localisations.