### PR TITLE
docs: Add link to uv-scripts organization in Jobs guide

### DIFF
--- a/docs/source/en/guides/jobs.md
+++ b/docs/source/en/guides/jobs.md
@@ -309,6 +309,12 @@ You can pass environment variables to your job using `env` and `secrets`:
 
 ### UV Scripts (Experimental)
 
+<Tip>
+
+Looking for ready-to-use UV scripts? Check out the [uv-scripts organization](https://huggingface.co/uv-scripts) on the Hugging Face Hub, which provides a community collection of UV scripts for common tasks like model training, data processing, and more.
+
+</Tip>
+
 Run UV scripts (Python scripts with inline dependencies) on HF infrastructure:
 
 ```python


### PR DESCRIPTION
Added a tip box in the UV Scripts section pointing users to the uv-scripts organization on Hugging Face Hub as a resource for ready-to-use UV scripts for common tasks.