### PR TITLE
docs: Add Docker images section for UV scripts in Jobs guide

### DIFF
--- a/docs/source/en/guides/jobs.md
+++ b/docs/source/en/guides/jobs.md
@@ -352,7 +352,7 @@ hf jobs uv run \
 ...
 ```
 
-The above command will run using the `vllm/vllm-openai:latest` image. This approach could be useful, for example if you are using vllm for synthetic data generation.
+The above command will run using the `vllm/vllm-openai:latest` image. This approach could be useful if you are using vLLM for synthetic data generation.
 
 <Tip>
 


### PR DESCRIPTION
Small addition to docs for uv run 

- Document default Docker image (astral-sh/uv:python3.12-bookworm)
- Explain how to specify custom images with --image flag