### PR TITLE
Add PublicAI as inference provider (conversational only)

### DIFF
--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -130,7 +130,7 @@ class InferenceClient:
             Note: for better compatibility with OpenAI's client, `model` has been aliased as `base_url`. Those 2
             arguments are mutually exclusive. If a URL is passed as `model` or `base_url` for chat completion, the `(/v1)/chat/completions` suffix path will be appended to the URL.
         provider (`str`, *optional*):
-            Name of the provider to use for inference. Can be `"black-forest-labs"`, `"cerebras"`, `"cohere"`, `"fal-ai"`, `"featherless-ai"`, `"fireworks-ai"`, `"groq"`, `"hf-inference"`, `"hyperbolic"`, `"nebius"`, `"novita"`, `"nscale"`, `"openai"`, `"replicate"`, "sambanova"` or `"together"`.
+            Name of the provider to use for inference. Can be `"black-forest-labs"`, `"cerebras"`, `"cohere"`, `"fal-ai"`, `"featherless-ai"`, `"fireworks-ai"`, `"groq"`, `"hf-inference"`, `"hyperbolic"`, `"nebius"`, `"novita"`, `"nscale"`, `"openai"`, `publicai`, `"replicate"`, "sambanova"` or `"together"`.
             Defaults to "auto" i.e. the first of the providers available for the model, sorted by the user's order in https://hf.co/settings/inference-providers.
             If model is a URL or `base_url` is passed, then `provider` is not used.
         token (`str`, *optional*):

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -118,7 +118,7 @@ class AsyncInferenceClient:
             Note: for better compatibility with OpenAI's client, `model` has been aliased as `base_url`. Those 2
             arguments are mutually exclusive. If a URL is passed as `model` or `base_url` for chat completion, the `(/v1)/chat/completions` suffix path will be appended to the URL.
         provider (`str`, *optional*):
-            Name of the provider to use for inference. Can be `"black-forest-labs"`, `"cerebras"`, `"cohere"`, `"fal-ai"`, `"featherless-ai"`, `"fireworks-ai"`, `"groq"`, `"hf-inference"`, `"hyperbolic"`, `"nebius"`, `"novita"`, `"nscale"`, `"openai"`, `"replicate"`, "sambanova"` or `"together"`.
+            Name of the provider to use for inference. Can be `"black-forest-labs"`, `"cerebras"`, `"cohere"`, `"fal-ai"`, `"featherless-ai"`, `"fireworks-ai"`, `"groq"`, `"hf-inference"`, `"hyperbolic"`, `"nebius"`, `"novita"`, `"nscale"`, `"openai"`, `publicai`, `"replicate"`, "sambanova"` or `"together"`.
             Defaults to "auto" i.e. the first of the providers available for the model, sorted by the user's order in https://hf.co/settings/inference-providers.
             If model is a URL or `base_url` is passed, then `provider` is not used.
         token (`str`, *optional*):

--- a/src/huggingface_hub/inference/_providers/__init__.py
+++ b/src/huggingface_hub/inference/_providers/__init__.py
@@ -36,6 +36,7 @@ from .nebius import (
 from .novita import NovitaConversationalTask, NovitaTextGenerationTask, NovitaTextToVideoTask
 from .nscale import NscaleConversationalTask, NscaleTextToImageTask
 from .openai import OpenAIConversationalTask
+from .publicai import PublicAIConversationalTask
 from .replicate import ReplicateImageToImageTask, ReplicateTask, ReplicateTextToImageTask, ReplicateTextToSpeechTask
 from .sambanova import SambanovaConversationalTask, SambanovaFeatureExtractionTask
 from .together import TogetherConversationalTask, TogetherTextGenerationTask, TogetherTextToImageTask
@@ -58,6 +59,7 @@ PROVIDER_T = Literal[
     "novita",
     "nscale",
     "openai",
+    "publicai",
     "replicate",
     "sambanova",
     "together",
@@ -143,6 +145,9 @@ PROVIDERS: Dict[PROVIDER_T, Dict[str, TaskProviderHelper]] = {
     },
     "openai": {
         "conversational": OpenAIConversationalTask(),
+    },
+    "publicai": {
+        "conversational": PublicAIConversationalTask(),
     },
     "replicate": {
         "image-to-image": ReplicateImageToImageTask(),

--- a/src/huggingface_hub/inference/_providers/_common.py
+++ b/src/huggingface_hub/inference/_providers/_common.py
@@ -31,6 +31,7 @@ HARDCODED_MODEL_INFERENCE_MAPPING: Dict[str, Dict[str, InferenceProviderMapping]
     "hyperbolic": {},
     "nebius": {},
     "nscale": {},
+    "publicai": {},
     "replicate": {},
     "sambanova": {},
     "together": {},

--- a/src/huggingface_hub/inference/_providers/publicai.py
+++ b/src/huggingface_hub/inference/_providers/publicai.py
@@ -1,0 +1,6 @@
+from ._common import BaseConversationalTask
+
+
+class PublicAIConversationalTask(BaseConversationalTask):
+    def __init__(self):
+        super().__init__(provider="publicai", base_url="https://api.publicai.co")

--- a/tests/test_inference_client.py
+++ b/tests/test_inference_client.py
@@ -118,6 +118,9 @@ _RECOMMENDED_MODELS_FOR_VCR = {
         "text-generation": "NousResearch/Nous-Hermes-Llama2-13b",
         "conversational": "meta-llama/Llama-3.1-8B-Instruct",
     },
+    "publicai": {
+        "conversational": "swiss-ai/Apertus-8B-Instruct-2509",
+    },
     "replicate": {
         "text-to-image": "ByteDance/SDXL-Lightning",
     },

--- a/tests/test_inference_providers.py
+++ b/tests/test_inference_providers.py
@@ -44,6 +44,7 @@ from huggingface_hub.inference._providers.nebius import NebiusFeatureExtractionT
 from huggingface_hub.inference._providers.novita import NovitaConversationalTask, NovitaTextGenerationTask
 from huggingface_hub.inference._providers.nscale import NscaleConversationalTask, NscaleTextToImageTask
 from huggingface_hub.inference._providers.openai import OpenAIConversationalTask
+from huggingface_hub.inference._providers.publicai import PublicAIConversationalTask
 from huggingface_hub.inference._providers.replicate import (
     ReplicateImageToImageTask,
     ReplicateTask,
@@ -1138,6 +1139,15 @@ class TestNscaleProvider:
         helper = NscaleTextToImageTask()
         response = helper.get_response({"data": [{"b64_json": base64.b64encode(b"image_bytes").decode()}]})
         assert response == b"image_bytes"
+
+
+class TestPublicAIProvider:
+    def test_prepare_url(self):
+        helper = PublicAIConversationalTask()
+        assert (
+            helper._prepare_url("publicai_token", "username/repo_name")
+            == "https://api.publicai.co/v1/chat/completions"
+        )
 
 
 class TestOpenAIProvider:


### PR DESCRIPTION
Related to:
- https://github.com/huggingface/huggingface.js/pull/1743
- https://github.com/huggingface-internal/moon-landing/pull/14987 (internal)
- https://github.com/huggingface/hub-docs/pull/1918


Note: not tested yet. Let's have PublicAI as staging provider so we can test it before merging this PR.