### PR TITLE
[v1.0] Remove `_deprecate_positional_args` on login methods

### DIFF
--- a/src/huggingface_hub/_login.py
+++ b/src/huggingface_hub/_login.py
@@ -41,7 +41,6 @@ from .utils._auth import (
     _save_token,
     get_stored_tokens,
 )
-from .utils._deprecation import _deprecate_positional_args
 
 
 logger = logging.get_logger(__name__)
@@ -55,7 +54,6 @@ _HF_LOGO_ASCII = """
 """
 
 
-@_deprecate_positional_args(version="1.0")
 def login(
     token: Optional[str] = None,
     *,
@@ -234,7 +232,6 @@ def auth_list() -> None:
 ###
 
 
-@_deprecate_positional_args(version="1.0")
 def interpreter_login(*, skip_if_logged_in: bool = False) -> None:
     """
     Displays a prompt to log in to the HF website and store the token.
@@ -299,7 +296,6 @@ NOTEBOOK_LOGIN_TOKEN_HTML_END = """
 notebooks. </center>"""
 
 
-@_deprecate_positional_args(version="1.0")
 def notebook_login(*, skip_if_logged_in: bool = False) -> None:
     """
     Displays a widget to log in to the HF website and store the token.


### PR DESCRIPTION
`_deprecate_positional_args` is not used anymore. I still kept it in utils/ + in the tests in case we need it in the future.