### PR TITLE
Refactor CLI implementation using Typer

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -24,24 +24,24 @@ Once installed, you can check that the CLI is correctly setup:
 
 ```
 >>> hf --help
-usage: hf <command> [<args>]
+Usage: hf [OPTIONS] COMMAND [ARGS]...
 
-positional arguments:
-  {auth,cache,download,repo,repo-files,upload,upload-large-folder,env,version,lfs-enable-largefiles,lfs-multipart-upload}
-                        hf command helpers
-    auth                Manage authentication (login, logout, etc.).
-    cache               Manage local cache directory.
-    download            Download files from the Hub
-    repo                Manage repos on the Hub.
-    repo-files          Manage files in a repo on the Hub.
-    upload              Upload a file or a folder to the Hub. Recommended for single-commit uploads.
-    upload-large-folder
-                        Upload a large folder to the Hub. Recommended for resumable uploads.
-    env                 Print information about the environment.
-    version             Print information about the hf version.
+  Hugging Face Hub CLI
 
-options:
-  -h, --help            show this help message and exit
+Options:
+  --help  Show this message and exit.
+
+Commands:
+  download             Download files from the Hub.
+  upload               Upload a file or a folder to the Hub.
+  upload-large-folder  Upload a large folder to the Hub.
+  env                  Print information about the environment.
+  version              Print information about the hf version.
+  auth                 Manage authentication (login, logout, etc.).
+  cache                Manage local cache directory.
+  repo                 Manage repos on the Hub.
+  repo-files           Manage files in a repo on the Hub.
+  jobs                 Run and manage Jobs on the Hub.
 ```
 
 If the CLI is correctly installed, you should see a list of all the options available in the CLI. If you get an error message such as `command not found: hf`, please refer to the [Installation](../installation) guide.

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -29,7 +29,10 @@ Usage: hf [OPTIONS] COMMAND [ARGS]...
   Hugging Face Hub CLI
 
 Options:
-  --help  Show this message and exit.
+  --install-completion  Install completion for the current shell.
+  --show-completion     Show completion for the current shell, to copy it or
+                        customize the installation.
+  --help                Show this message and exit.
 
 Commands:
   download             Download files from the Hub.

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ extras = {}
 
 extras["cli"] = [
     "InquirerPy==0.3.4",  # Note: installs `prompt-toolkit` in the background
+    "typer",
 ]
 
 extras["inference"] = [

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ extras = {}
 
 extras["cli"] = [
     "InquirerPy==0.3.4",  # Note: installs `prompt-toolkit` in the background
+    "shellingham",
 ]
 
 extras["inference"] = [

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ install_requires = [
     "pyyaml>=5.1",
     "httpx>=0.23.0, <1",
     "tqdm>=4.42.1",
+    "typer-slim",
     "typing-extensions>=3.7.4.3",  # to be able to import TypeAlias
 ]
 
@@ -28,7 +29,6 @@ extras = {}
 
 extras["cli"] = [
     "InquirerPy==0.3.4",  # Note: installs `prompt-toolkit` in the background
-    "typer",
 ]
 
 extras["inference"] = [

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -46,7 +46,7 @@ import sys
 from typing import TYPE_CHECKING
 
 
-__version__ = "1.0.0.dev0"
+__version__ = "1.0.0.rc0"
 
 # Alphabetical order of definitions is ensured in tests
 # WARNING: any comment added in this dictionary definition will be lost when

--- a/src/huggingface_hub/cli/__init__.py
+++ b/src/huggingface_hub/cli/__init__.py
@@ -11,17 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from abc import ABC, abstractmethod
-from argparse import _SubParsersAction
-
-
-class BaseHuggingfaceCLICommand(ABC):
-    @staticmethod
-    @abstractmethod
-    def register_subcommand(parser: _SubParsersAction):
-        raise NotImplementedError()
-
-    @abstractmethod
-    def run(self):
-        raise NotImplementedError()

--- a/src/huggingface_hub/cli/_cli_utils.py
+++ b/src/huggingface_hub/cli/_cli_utils.py
@@ -78,7 +78,7 @@ def tabulate(rows: list[list[Union[str, int]]], headers: list[str]) -> str:
 def typer_factory(help: str) -> typer.Typer:
     return typer.Typer(
         help=help,
-        add_completion=False,
+        add_completion=True,
         rich_markup_mode=None,
         no_args_is_help=True,
     )

--- a/src/huggingface_hub/cli/_cli_utils.py
+++ b/src/huggingface_hub/cli/_cli_utils.py
@@ -20,6 +20,9 @@ from typing import Annotated, Optional, Union
 import click
 import typer
 
+from huggingface_hub import __version__
+from huggingface_hub.hf_api import HfApi
+
 
 class ANSI:
     """
@@ -137,3 +140,7 @@ RevisionOpt = Annotated[
         help="Git revision id which can be a branch name, a tag, or a commit hash.",
     ),
 ]
+
+
+def get_hf_api(token: Optional[str] = None) -> HfApi:
+    return HfApi(token=token, library_name="hf", library_version=__version__)

--- a/src/huggingface_hub/cli/_cli_utils.py
+++ b/src/huggingface_hub/cli/_cli_utils.py
@@ -20,7 +20,7 @@ from typing import Union
 import typer
 
 
-class RepoType(str, Enum):
+class RepoTypeOpt(str, Enum):
     model = "model"
     dataset = "dataset"
     space = "space"

--- a/src/huggingface_hub/cli/_cli_utils.py
+++ b/src/huggingface_hub/cli/_cli_utils.py
@@ -82,5 +82,5 @@ def validate_repo_type(value: Optional[str], param_name: str = "repo_type") -> O
         return value
     raise typer.BadParameter(
         "Invalid value for '--repo-type': must be one of 'model', 'dataset', 'space'.",
-        param_name=param_name,
+        param_hint=param_name,
     )

--- a/src/huggingface_hub/cli/_cli_utils.py
+++ b/src/huggingface_hub/cli/_cli_utils.py
@@ -14,9 +14,14 @@
 """Contains CLI utilities (styling, helpers)."""
 
 import os
-from typing import Optional, Union
+from enum import Enum
+from typing import Union
 
-import typer
+
+class RepoType(str, Enum):
+    model = "model"
+    dataset = "dataset"
+    space = "space"
 
 
 class ANSI:
@@ -69,18 +74,3 @@ def tabulate(rows: list[list[Union[str, int]]], headers: list[str]) -> str:
     for row in rows:
         lines.append(row_format.format(*row))
     return "\n".join(lines)
-
-
-def validate_repo_type(value: Optional[str], param_name: str = "repo_type") -> Optional[str]:
-    """Validate repo type is one of model|dataset|space when provided.
-
-    Returns the value if valid or None. Raises a Typer BadParameter otherwise.
-    """
-    if value is None:
-        return None
-    if value in ("model", "dataset", "space"):
-        return value
-    raise typer.BadParameter(
-        "Invalid value for '--repo-type': must be one of 'model', 'dataset', 'space'.",
-        param_hint=param_name,
-    )

--- a/src/huggingface_hub/cli/_cli_utils.py
+++ b/src/huggingface_hub/cli/_cli_utils.py
@@ -17,6 +17,8 @@ import os
 from enum import Enum
 from typing import Union
 
+import typer
+
 
 class RepoType(str, Enum):
     model = "model"
@@ -74,3 +76,12 @@ def tabulate(rows: list[list[Union[str, int]]], headers: list[str]) -> str:
     for row in rows:
         lines.append(row_format.format(*row))
     return "\n".join(lines)
+
+
+def typer_factory(help: str) -> typer.Typer:
+    return typer.Typer(
+        help=help,
+        add_completion=False,
+        rich_markup_mode=None,
+        no_args_is_help=True,
+    )

--- a/src/huggingface_hub/cli/_cli_utils.py
+++ b/src/huggingface_hub/cli/_cli_utils.py
@@ -20,7 +20,7 @@ from typing import Union
 import typer
 
 
-class RepoTypeOpt(str, Enum):
+class RepoType(str, Enum):
     model = "model"
     dataset = "dataset"
     space = "space"

--- a/src/huggingface_hub/cli/_cli_utils.py
+++ b/src/huggingface_hub/cli/_cli_utils.py
@@ -11,10 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Contains a utility for good-looking prints."""
+"""Contains CLI utilities (styling, helpers)."""
 
 import os
-from typing import Union
+from typing import Optional, Union
+
+import typer
 
 
 class ANSI:
@@ -67,3 +69,18 @@ def tabulate(rows: list[list[Union[str, int]]], headers: list[str]) -> str:
     for row in rows:
         lines.append(row_format.format(*row))
     return "\n".join(lines)
+
+
+def validate_repo_type(value: Optional[str], param_name: str = "repo_type") -> Optional[str]:
+    """Validate repo type is one of model|dataset|space when provided.
+
+    Returns the value if valid or None. Raises a Typer BadParameter otherwise.
+    """
+    if value is None:
+        return None
+    if value in ("model", "dataset", "space"):
+        return value
+    raise typer.BadParameter(
+        "Invalid value for '--repo-type': must be one of 'model', 'dataset', 'space'.",
+        param_name=param_name,
+    )

--- a/src/huggingface_hub/cli/_cli_utils.py
+++ b/src/huggingface_hub/cli/_cli_utils.py
@@ -15,15 +15,9 @@
 
 import os
 from enum import Enum
-from typing import Union
+from typing import Annotated, Optional, Union
 
 import typer
-
-
-class RepoType(str, Enum):
-    model = "model"
-    dataset = "dataset"
-    space = "space"
 
 
 class ANSI:
@@ -78,6 +72,9 @@ def tabulate(rows: list[list[Union[str, int]]], headers: list[str]) -> str:
     return "\n".join(lines)
 
 
+#### TYPER UTILS
+
+
 def typer_factory(help: str) -> typer.Typer:
     return typer.Typer(
         help=help,
@@ -85,3 +82,46 @@ def typer_factory(help: str) -> typer.Typer:
         rich_markup_mode=None,
         no_args_is_help=True,
     )
+
+
+class RepoType(str, Enum):
+    model = "model"
+    dataset = "dataset"
+    space = "space"
+
+
+RepoIdArg = Annotated[
+    str,
+    typer.Argument(
+        help="The ID of the repo (e.g. `username/repo-name`).",
+    ),
+]
+
+
+RepoTypeOpt = Annotated[
+    RepoType,
+    typer.Option(
+        help="The type of repository (model, dataset, or space).",
+    ),
+]
+
+TokenOpt = Annotated[
+    Optional[str],
+    typer.Option(
+        help="A User Access Token generated from https://huggingface.co/settings/tokens.",
+    ),
+]
+
+PrivateOpt = Annotated[
+    bool,
+    typer.Option(
+        help="Whether to create a private repo if repo doesn't exist on the Hub. Ignored if the repo already exists.",
+    ),
+]
+
+RevisionOpt = Annotated[
+    Optional[str],
+    typer.Option(
+        help="Git revision id which can be a branch name, a tag, or a commit hash.",
+    ),
+]

--- a/src/huggingface_hub/cli/_cli_utils.py
+++ b/src/huggingface_hub/cli/_cli_utils.py
@@ -17,6 +17,7 @@ import os
 from enum import Enum
 from typing import Annotated, Optional, Union
 
+import click
 import typer
 
 
@@ -75,12 +76,23 @@ def tabulate(rows: list[list[Union[str, int]]], headers: list[str]) -> str:
 #### TYPER UTILS
 
 
+class AlphabeticalMixedGroup(typer.core.TyperGroup):
+    """
+    Typer Group that lists commands and sub-apps mixed and alphabetically.
+    """
+
+    def list_commands(self, ctx: click.Context) -> list[str]:  # type: ignore[name-defined]
+        # click.Group stores both commands and sub-groups in `self.commands`
+        return sorted(self.commands.keys())
+
+
 def typer_factory(help: str) -> typer.Typer:
     return typer.Typer(
         help=help,
         add_completion=True,
         rich_markup_mode=None,
         no_args_is_help=True,
+        cls=AlphabeticalMixedGroup,
     )
 
 

--- a/src/huggingface_hub/cli/auth.py
+++ b/src/huggingface_hub/cli/auth.py
@@ -55,14 +55,14 @@ except ImportError:
     _inquirer_py_available = False
 
 
-auth_app = typer.Typer(help="Manage authentication (login, logout, etc.)", rich_markup_mode=None)
+auth_cli = typer.Typer(help="Manage authentication (login, logout, etc.)", rich_markup_mode=None)
 
 
 def _api() -> HfApi:
     return HfApi()
 
 
-@auth_app.command("login", help="Login using a token from huggingface.co/settings/tokens")
+@auth_cli.command("login", help="Login using a token from huggingface.co/settings/tokens")
 def auth_login(
     token: Annotated[
         Optional[str],
@@ -81,10 +81,7 @@ def auth_login(
     login(token=token, add_to_git_credential=add_to_git_credential)
 
 
-@auth_app.command(
-    "logout",
-    help="Logout from a specific token",
-)
+@auth_cli.command("logout", help="Logout from a specific token")
 def auth_logout(
     token_name: Annotated[
         Optional[str],
@@ -133,7 +130,7 @@ def _select_token_name() -> Optional[str]:
             print("Invalid input. Please enter a number or 'q' to quit.")
 
 
-@auth_app.command("switch", help="Switch between accesstokens")
+@auth_cli.command("switch", help="Switch between access tokens")
 def auth_switch_cmd(
     token_name: Annotated[
         Optional[str],
@@ -157,13 +154,13 @@ def auth_switch_cmd(
     auth_switch(token_name, add_to_git_credential=add_to_git_credential)
 
 
-@auth_app.command("list", help="List all stored access tokens")
+@auth_cli.command("list", help="List all stored access tokens")
 def auth_list_cmd() -> None:
     logging.set_verbosity_info()
     auth_list()
 
 
-@auth_app.command("whoami", help="Find out which huggingface.co account you are logged in as.")
+@auth_cli.command("whoami", help="Find out which huggingface.co account you are logged in as.")
 def auth_whoami() -> None:
     token = get_token()
     if token is None:

--- a/src/huggingface_hub/cli/auth.py
+++ b/src/huggingface_hub/cli/auth.py
@@ -30,10 +30,10 @@ Usage:
     hf auth whoami
 """
 
-from argparse import _SubParsersAction
 from typing import Optional
 
-from huggingface_hub.commands import BaseHuggingfaceCLICommand
+import typer
+
 from huggingface_hub.constants import ENDPOINT
 from huggingface_hub.errors import HfHubHTTPError
 from huggingface_hub.hf_api import HfApi
@@ -54,125 +54,53 @@ except ImportError:
     _inquirer_py_available = False
 
 
-class AuthCommands(BaseHuggingfaceCLICommand):
-    @staticmethod
-    def register_subcommand(parser: _SubParsersAction):
-        # Create the main 'auth' command
-        auth_parser = parser.add_parser("auth", help="Manage authentication (login, logout, etc.).")
-        auth_subparsers = auth_parser.add_subparsers(help="Authentication subcommands")
-
-        # Show help if no subcommand is provided
-        auth_parser.set_defaults(func=lambda args: auth_parser.print_help())
-
-        # Add 'login' as a subcommand of 'auth'
-        login_parser = auth_subparsers.add_parser(
-            "login", help="Log in using a token from huggingface.co/settings/tokens"
-        )
-        login_parser.add_argument(
-            "--token",
-            type=str,
-            help="Token generated from https://huggingface.co/settings/tokens",
-        )
-        login_parser.add_argument(
-            "--add-to-git-credential",
-            action="store_true",
-            help="Optional: Save token to git credential helper.",
-        )
-        login_parser.set_defaults(func=lambda args: AuthLogin(args))
-
-        # Add 'logout' as a subcommand of 'auth'
-        logout_parser = auth_subparsers.add_parser("logout", help="Log out")
-        logout_parser.add_argument(
-            "--token-name",
-            type=str,
-            help="Optional: Name of the access token to log out from.",
-        )
-        logout_parser.set_defaults(func=lambda args: AuthLogout(args))
-
-        # Add 'whoami' as a subcommand of 'auth'
-        whoami_parser = auth_subparsers.add_parser(
-            "whoami", help="Find out which huggingface.co account you are logged in as."
-        )
-        whoami_parser.set_defaults(func=lambda args: AuthWhoami(args))
-
-        # Existing subcommands
-        auth_switch_parser = auth_subparsers.add_parser("switch", help="Switch between access tokens")
-        auth_switch_parser.add_argument(
-            "--token-name",
-            type=str,
-            help="Optional: Name of the access token to switch to.",
-        )
-        auth_switch_parser.add_argument(
-            "--add-to-git-credential",
-            action="store_true",
-            help="Optional: Save token to git credential helper.",
-        )
-        auth_switch_parser.set_defaults(func=lambda args: AuthSwitch(args))
-
-        auth_list_parser = auth_subparsers.add_parser("list", help="List all stored access tokens")
-        auth_list_parser.set_defaults(func=lambda args: AuthList(args))
+auth_app = typer.Typer(help="Manage authentication (login, logout, etc.)")
 
 
-class BaseAuthCommand:
-    def __init__(self, args):
-        self.args = args
-        self._api = HfApi()
+def _api() -> HfApi:
+    return HfApi()
 
 
-class AuthLogin(BaseAuthCommand):
-    def run(self):
-        logging.set_verbosity_info()
-        login(
-            token=self.args.token,
-            add_to_git_credential=self.args.add_to_git_credential,
-        )
+@auth_app.command("login", help="Login using a token from huggingface.co/settings/tokens")
+def auth_login(
+    token: Optional[str] = typer.Option(
+        None,
+        "--token",
+        help="Token from https://huggingface.co/settings/tokens",
+    ),
+    add_to_git_credential: bool = typer.Option(
+        False,
+        "--add-to-git-credential",
+        help="Save to git credential helper",
+    ),
+) -> None:
+    logging.set_verbosity_info()
+    login(token=token, add_to_git_credential=add_to_git_credential)
 
 
-class AuthLogout(BaseAuthCommand):
-    def run(self):
-        logging.set_verbosity_info()
-        logout(token_name=self.args.token_name)
+@auth_app.command(
+    "logout",
+    help="Logout from a specific token",
+)
+def auth_logout(
+    token_name: Optional[str] = typer.Option(
+        None,
+        "--token-name",
+        help="Name of token to logout",
+    ),
+) -> None:
+    logging.set_verbosity_info()
+    logout(token_name=token_name)
 
 
-class AuthSwitch(BaseAuthCommand):
-    def run(self):
-        logging.set_verbosity_info()
-        token_name = self.args.token_name
-        if token_name is None:
-            token_name = self._select_token_name()
+def _select_token_name() -> Optional[str]:
+    token_names = list(get_stored_tokens().keys())
 
-        if token_name is None:
-            print("No token name provided. Aborting.")
-            exit()
-        auth_switch(token_name, add_to_git_credential=self.args.add_to_git_credential)
+    if not token_names:
+        logger.error("No stored tokens found. Please login first.")
+        return None
 
-    def _select_token_name(self) -> Optional[str]:
-        token_names = list(get_stored_tokens().keys())
-
-        if not token_names:
-            logger.error("No stored tokens found. Please login first.")
-            return None
-
-        if _inquirer_py_available:
-            return self._select_token_name_tui(token_names)
-        # if inquirer is not available, use a simpler terminal UI
-        print("Available stored tokens:")
-        for i, token_name in enumerate(token_names, 1):
-            print(f"{i}. {token_name}")
-        while True:
-            try:
-                choice = input("Enter the number of the token to switch to (or 'q' to quit): ")
-                if choice.lower() == "q":
-                    return None
-                index = int(choice) - 1
-                if 0 <= index < len(token_names):
-                    return token_names[index]
-                else:
-                    print("Invalid selection. Please try again.")
-            except ValueError:
-                print("Invalid input. Please enter a number or 'q' to quit.")
-
-    def _select_token_name_tui(self, token_names: list[str]) -> Optional[str]:
+    if _inquirer_py_available:
         choices = [Choice(token_name, name=token_name) for token_name in token_names]
         try:
             return inquirer.select(
@@ -183,30 +111,68 @@ class AuthSwitch(BaseAuthCommand):
         except KeyboardInterrupt:
             logger.info("Token selection cancelled.")
             return None
-
-
-class AuthList(BaseAuthCommand):
-    def run(self):
-        logging.set_verbosity_info()
-        auth_list()
-
-
-class AuthWhoami(BaseAuthCommand):
-    def run(self):
-        token = get_token()
-        if token is None:
-            print("Not logged in")
-            exit()
+    # if inquirer is not available, use a simpler terminal UI
+    print("Available stored tokens:")
+    for i, token_name in enumerate(token_names, 1):
+        print(f"{i}. {token_name}")
+    while True:
         try:
-            info = self._api.whoami(token)
-            print(ANSI.bold("user: "), info["name"])
-            orgs = [org["name"] for org in info["orgs"]]
-            if orgs:
-                print(ANSI.bold("orgs: "), ",".join(orgs))
+            choice = input("Enter the number of the token to switch to (or 'q' to quit): ")
+            if choice.lower() == "q":
+                return None
+            index = int(choice) - 1
+            if 0 <= index < len(token_names):
+                return token_names[index]
+            else:
+                print("Invalid selection. Please try again.")
+        except ValueError:
+            print("Invalid input. Please enter a number or 'q' to quit.")
 
-            if ENDPOINT != "https://huggingface.co":
-                print(f"Authenticated through private endpoint: {ENDPOINT}")
-        except HfHubHTTPError as e:
-            print(e)
-            print(ANSI.red(e.response.text))
-            exit(1)
+
+@auth_app.command("switch", help="Switch between accesstokens")
+def auth_switch_cmd(
+    token_name: Optional[str] = typer.Option(
+        None,
+        "--token-name",
+        help="Name of the token to switch to",
+    ),
+    add_to_git_credential: bool = typer.Option(
+        False,
+        "--add-to-git-credential",
+        help="Save to git credential",
+    ),
+) -> None:
+    logging.set_verbosity_info()
+    if token_name is None:
+        token_name = _select_token_name()
+    if token_name is None:
+        print("No token name provided. Aborting.")
+        raise typer.Exit()
+    auth_switch(token_name, add_to_git_credential=add_to_git_credential)
+
+
+@auth_app.command("list", help="List all stored access tokens")
+def auth_list_cmd() -> None:
+    logging.set_verbosity_info()
+    auth_list()
+
+
+@auth_app.command("whoami", help="Find out which huggingface.co account you are logged in as.")
+def auth_whoami() -> None:
+    token = get_token()
+    if token is None:
+        print("Not logged in")
+        raise typer.Exit()
+    try:
+        info = _api().whoami(token)
+        print(ANSI.bold("user: "), info["name"])
+        orgs = [org["name"] for org in info["orgs"]]
+        if orgs:
+            print(ANSI.bold("orgs: "), ",".join(orgs))
+
+        if ENDPOINT != "https://huggingface.co":
+            print(f"Authenticated through private endpoint: {ENDPOINT}")
+    except HfHubHTTPError as e:
+        print(e)
+        print(ANSI.red(e.response.text))
+        raise typer.Exit(code=1)

--- a/src/huggingface_hub/cli/auth.py
+++ b/src/huggingface_hub/cli/auth.py
@@ -54,7 +54,7 @@ except ImportError:
     _inquirer_py_available = False
 
 
-auth_app = typer.Typer(help="Manage authentication (login, logout, etc.)")
+auth_app = typer.Typer(help="Manage authentication (login, logout, etc.)", rich_markup_mode=None)
 
 
 def _api() -> HfApi:

--- a/src/huggingface_hub/cli/auth.py
+++ b/src/huggingface_hub/cli/auth.py
@@ -55,7 +55,7 @@ except ImportError:
     _inquirer_py_available = False
 
 
-auth_cli = typer.Typer(help="Manage authentication (login, logout, etc.)", rich_markup_mode=None)
+auth_cli = typer.Typer(help="Manage authentication (login, logout, etc.).", rich_markup_mode=None)
 
 
 def _api() -> HfApi:

--- a/src/huggingface_hub/cli/auth.py
+++ b/src/huggingface_hub/cli/auth.py
@@ -33,6 +33,7 @@ Usage:
 from typing import Optional
 
 import typer
+from typing_extensions import Annotated
 
 from huggingface_hub.constants import ENDPOINT
 from huggingface_hub.errors import HfHubHTTPError
@@ -63,16 +64,18 @@ def _api() -> HfApi:
 
 @auth_app.command("login", help="Login using a token from huggingface.co/settings/tokens")
 def auth_login(
-    token: Optional[str] = typer.Option(
-        None,
-        "--token",
-        help="Token from https://huggingface.co/settings/tokens",
-    ),
-    add_to_git_credential: bool = typer.Option(
-        False,
-        "--add-to-git-credential",
-        help="Save to git credential helper",
-    ),
+    token: Annotated[
+        str,
+        typer.Option(
+            help="Token from https://huggingface.co/settings/tokens",
+        ),
+    ] = None,
+    add_to_git_credential: Annotated[
+        bool,
+        typer.Option(
+            help="Save to git credential helper",
+        ),
+    ] = False,
 ) -> None:
     logging.set_verbosity_info()
     login(token=token, add_to_git_credential=add_to_git_credential)
@@ -83,11 +86,12 @@ def auth_login(
     help="Logout from a specific token",
 )
 def auth_logout(
-    token_name: Optional[str] = typer.Option(
-        None,
-        "--token-name",
-        help="Name of token to logout",
-    ),
+    token_name: Annotated[
+        str,
+        typer.Option(
+            help="Name of token to logout",
+        ),
+    ] = None,
 ) -> None:
     logging.set_verbosity_info()
     logout(token_name=token_name)
@@ -131,16 +135,18 @@ def _select_token_name() -> Optional[str]:
 
 @auth_app.command("switch", help="Switch between accesstokens")
 def auth_switch_cmd(
-    token_name: Optional[str] = typer.Option(
-        None,
-        "--token-name",
-        help="Name of the token to switch to",
-    ),
-    add_to_git_credential: bool = typer.Option(
-        False,
-        "--add-to-git-credential",
-        help="Save to git credential",
-    ),
+    token_name: Annotated[
+        str,
+        typer.Option(
+            help="Name of the token to switch to",
+        ),
+    ] = None,
+    add_to_git_credential: Annotated[
+        bool,
+        typer.Option(
+            help="Save to git credential",
+        ),
+    ] = False,
 ) -> None:
     logging.set_verbosity_info()
     if token_name is None:

--- a/src/huggingface_hub/cli/auth.py
+++ b/src/huggingface_hub/cli/auth.py
@@ -30,10 +30,9 @@ Usage:
     hf auth whoami
 """
 
-from typing import Optional
+from typing import Annotated, Optional
 
 import typer
-from typing_extensions import Annotated
 
 from huggingface_hub.constants import ENDPOINT
 from huggingface_hub.errors import HfHubHTTPError

--- a/src/huggingface_hub/cli/auth.py
+++ b/src/huggingface_hub/cli/auth.py
@@ -65,7 +65,7 @@ def _api() -> HfApi:
 @auth_app.command("login", help="Login using a token from huggingface.co/settings/tokens")
 def auth_login(
     token: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="Token from https://huggingface.co/settings/tokens",
         ),
@@ -87,7 +87,7 @@ def auth_login(
 )
 def auth_logout(
     token_name: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="Name of token to logout",
         ),
@@ -136,7 +136,7 @@ def _select_token_name() -> Optional[str]:
 @auth_app.command("switch", help="Switch between accesstokens")
 def auth_switch_cmd(
     token_name: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="Name of the token to switch to",
         ),

--- a/src/huggingface_hub/cli/auth.py
+++ b/src/huggingface_hub/cli/auth.py
@@ -37,7 +37,7 @@ from typing_extensions import Annotated
 
 from huggingface_hub.constants import ENDPOINT
 from huggingface_hub.errors import HfHubHTTPError
-from huggingface_hub.hf_api import HfApi
+from huggingface_hub.hf_api import whoami
 
 from .._login import auth_list, auth_switch, login, logout
 from ..utils import get_stored_tokens, get_token, logging
@@ -56,10 +56,6 @@ except ImportError:
 
 
 auth_cli = typer.Typer(help="Manage authentication (login, logout, etc.).", rich_markup_mode=None)
-
-
-def _api() -> HfApi:
-    return HfApi()
 
 
 @auth_cli.command("login", help="Login using a token from huggingface.co/settings/tokens")
@@ -167,7 +163,7 @@ def auth_whoami() -> None:
         print("Not logged in")
         raise typer.Exit()
     try:
-        info = _api().whoami(token)
+        info = whoami(token)
         print(ANSI.bold("user: "), info["name"])
         orgs = [org["name"] for org in info["orgs"]]
         if orgs:

--- a/src/huggingface_hub/cli/auth.py
+++ b/src/huggingface_hub/cli/auth.py
@@ -72,7 +72,6 @@ def auth_login(
         ),
     ] = False,
 ) -> None:
-    logging.set_verbosity_info()
     login(token=token, add_to_git_credential=add_to_git_credential)
 
 
@@ -85,7 +84,6 @@ def auth_logout(
         ),
     ] = None,
 ) -> None:
-    logging.set_verbosity_info()
     logout(token_name=token_name)
 
 
@@ -140,7 +138,6 @@ def auth_switch_cmd(
         ),
     ] = False,
 ) -> None:
-    logging.set_verbosity_info()
     if token_name is None:
         token_name = _select_token_name()
     if token_name is None:
@@ -151,7 +148,6 @@ def auth_switch_cmd(
 
 @auth_cli.command("list", help="List all stored access tokens")
 def auth_list_cmd() -> None:
-    logging.set_verbosity_info()
     auth_list()
 
 

--- a/src/huggingface_hub/cli/auth.py
+++ b/src/huggingface_hub/cli/auth.py
@@ -40,7 +40,7 @@ from huggingface_hub.hf_api import whoami
 
 from .._login import auth_list, auth_switch, login, logout
 from ..utils import get_stored_tokens, get_token, logging
-from ._cli_utils import ANSI, typer_factory
+from ._cli_utils import ANSI, TokenOpt, typer_factory
 
 
 logger = logging.get_logger(__name__)
@@ -59,12 +59,7 @@ auth_cli = typer_factory(help="Manage authentication (login, logout, etc.).")
 
 @auth_cli.command("login", help="Login using a token from huggingface.co/settings/tokens")
 def auth_login(
-    token: Annotated[
-        Optional[str],
-        typer.Option(
-            help="Token from https://huggingface.co/settings/tokens",
-        ),
-    ] = None,
+    token: TokenOpt = None,
     add_to_git_credential: Annotated[
         bool,
         typer.Option(

--- a/src/huggingface_hub/cli/auth.py
+++ b/src/huggingface_hub/cli/auth.py
@@ -40,7 +40,7 @@ from huggingface_hub.hf_api import whoami
 
 from .._login import auth_list, auth_switch, login, logout
 from ..utils import get_stored_tokens, get_token, logging
-from ._cli_utils import ANSI
+from ._cli_utils import ANSI, typer_factory
 
 
 logger = logging.get_logger(__name__)
@@ -54,7 +54,7 @@ except ImportError:
     _inquirer_py_available = False
 
 
-auth_cli = typer.Typer(help="Manage authentication (login, logout, etc.).", rich_markup_mode=None)
+auth_cli = typer_factory(help="Manage authentication (login, logout, etc.).")
 
 
 @auth_cli.command("login", help="Login using a token from huggingface.co/settings/tokens")

--- a/src/huggingface_hub/cli/cache.py
+++ b/src/huggingface_hub/cli/cache.py
@@ -63,10 +63,10 @@ def require_inquirer_py(fn: Callable) -> Callable:
     return _inner
 
 
-cache_app = typer.Typer(help="Manage local cache directory.", rich_markup_mode=None)
+cache_cli = typer.Typer(help="Manage local cache directory.", rich_markup_mode=None)
 
 
-@cache_app.command("scan", help="Scan the cache directory")
+@cache_cli.command("scan", help="Scan the cache directory")
 def cache_scan(
     dir: Annotated[
         Optional[str],
@@ -110,7 +110,7 @@ def _run_scan(cache_dir: Optional[str], verbosity: int) -> None:
             print(ANSI.gray(message + " Use -vvv to print details."))
 
 
-@cache_app.command("delete", help="Delete revisions from the cache directory")
+@cache_cli.command("delete", help="Delete revisions from the cache directory")
 def cache_delete(
     dir: Annotated[
         Optional[str],

--- a/src/huggingface_hub/cli/cache.py
+++ b/src/huggingface_hub/cli/cache.py
@@ -16,13 +16,13 @@
 
 import os
 import time
-from argparse import Namespace, _SubParsersAction
 from functools import wraps
 from tempfile import mkstemp
 from typing import Any, Callable, Iterable, Literal, Optional, Union
 
+import typer
+
 from ..utils import CachedRepoInfo, CachedRevisionInfo, CacheNotFound, HFCacheInfo, scan_cache_dir
-from . import BaseHuggingfaceCLICommand
 from ._cli_utils import ANSI, tabulate
 
 
@@ -40,6 +40,14 @@ SortingOption_T = Literal["alphabetical", "lastUpdated", "lastUsed", "size"]
 _CANCEL_DELETION_STR = "CANCEL_DELETION"
 
 
+def _validate_sort_option(sort: Optional[str]) -> Optional[str]:
+    if sort is None:
+        return None
+    if sort not in SortingOption_T:
+        raise typer.BadParameter(f"Invalid sort option: {sort}", param_name="sort")
+    return sort
+
+
 def require_inquirer_py(fn: Callable) -> Callable:
     @wraps(fn)
     def _inner(*args, **kwargs):
@@ -54,122 +62,93 @@ def require_inquirer_py(fn: Callable) -> Callable:
     return _inner
 
 
-class CacheCommand(BaseHuggingfaceCLICommand):
-    @staticmethod
-    def register_subcommand(parser: _SubParsersAction):
-        cache_parser = parser.add_parser("cache", help="Manage local cache directory.")
-        cache_subparsers = cache_parser.add_subparsers(dest="cache_command", help="Cache subcommands")
+cache_app = typer.Typer(help="Manage local cache directory.")
 
-        # Show help if no subcommand is provided
-        cache_parser.set_defaults(func=lambda args: cache_parser.print_help())
 
-        # Scan subcommand
-        scan_parser = cache_subparsers.add_parser("scan", help="Scan cache directory.")
-        scan_parser.add_argument(
-            "--dir",
-            type=str,
-            default=None,
-            help="cache directory to scan (optional). Default to the default HuggingFace cache.",
-        )
-        scan_parser.add_argument(
-            "-v",
-            "--verbose",
-            action="count",
-            default=0,
-            help="show a more verbose output",
-        )
-        scan_parser.set_defaults(func=CacheCommand, cache_command="scan")
-        # Delete subcommand
-        delete_parser = cache_subparsers.add_parser("delete", help="Delete revisions from the cache directory.")
-        delete_parser.add_argument(
-            "--dir",
-            type=str,
-            default=None,
-            help="cache directory (optional). Default to the default HuggingFace cache.",
-        )
-        delete_parser.add_argument(
-            "--disable-tui",
-            action="store_true",
-            help=(
-                "Disable Terminal User Interface (TUI) mode. Useful if your platform/terminal doesn't support the multiselect menu."
-            ),
-        )
-        delete_parser.add_argument(
-            "--sort",
-            nargs="?",
-            choices=["alphabetical", "lastUpdated", "lastUsed", "size"],
-            help=(
-                "Sort repositories by the specified criteria. Options: "
-                "'alphabetical' (A-Z), "
-                "'lastUpdated' (newest first), "
-                "'lastUsed' (most recent first), "
-                "'size' (largest first)."
-            ),
-        )
-        delete_parser.set_defaults(func=CacheCommand, cache_command="delete")
+@cache_app.command("scan", help="Scan the cache directory")
+def cache_scan(
+    dir: Optional[str] = typer.Option(
+        None,
+        "--dir",
+        help="Cache directory to scan (defaults to Hugging Face cache).",
+    ),
+    verbose: int = typer.Option(
+        0,
+        "-v",
+        "--verbose",
+        count=True,
+        help="Increase verbosity (-v, -vv, -vvv).",
+    ),
+) -> None:
+    _run_scan(cache_dir=dir, verbosity=verbose)
 
-    def __init__(self, args: Namespace) -> None:
-        self.args = args
-        self.verbosity: int = getattr(args, "verbose", 0)
-        self.cache_dir: Optional[str] = getattr(args, "dir", None)
-        self.disable_tui: bool = getattr(args, "disable_tui", False)
-        self.sort_by: Optional[SortingOption_T] = getattr(args, "sort", None)
-        self.cache_command: Optional[str] = getattr(args, "cache_command", None)
 
-    def run(self):
-        if self.cache_command == "scan":
-            self._run_scan()
-        elif self.cache_command == "delete":
-            self._run_delete()
+def _run_scan(cache_dir: Optional[str], verbosity: int) -> None:
+    try:
+        t0 = time.time()
+        hf_cache_info = scan_cache_dir(cache_dir)
+        t1 = time.time()
+    except CacheNotFound as exc:
+        cache_dir = exc.cache_dir
+        print(f"Cache directory not found: {cache_dir}")
+        return
+    print(get_table(hf_cache_info, verbosity=verbosity))
+    print(
+        f"\nDone in {round(t1 - t0, 1)}s. Scanned {len(hf_cache_info.repos)} repo(s)"
+        f" for a total of {ANSI.red(hf_cache_info.size_on_disk_str)}."
+    )
+    if len(hf_cache_info.warnings) > 0:
+        message = f"Got {len(hf_cache_info.warnings)} warning(s) while scanning."
+        if verbosity >= 3:
+            print(ANSI.gray(message))
+            for warning in hf_cache_info.warnings:
+                print(ANSI.gray(str(warning)))
         else:
-            print("Please specify a cache subcommand (scan or delete). Use -h for help.")
+            print(ANSI.gray(message + " Use -vvv to print details."))
 
-    def _run_scan(self):
-        try:
-            t0 = time.time()
-            hf_cache_info = scan_cache_dir(self.cache_dir)
-            t1 = time.time()
-        except CacheNotFound as exc:
-            cache_dir = exc.cache_dir
-            print(f"Cache directory not found: {cache_dir}")
+
+@cache_app.command("delete", help="Delete revisions from the cache directory")
+def cache_delete(
+    dir: Optional[str] = typer.Option(
+        None,
+        "--dir",
+        help="Cache directory (defaults to Hugging Face cache).",
+    ),
+    disable_tui: bool = typer.Option(
+        False,
+        "--disable-tui",
+        help="Disable Terminal User Interface (TUI) mode. Useful if your platform/terminal doesn't support the multiselect menu.",
+    ),
+    sort: Optional[str] = typer.Option(
+        None,
+        "--sort",
+        help="Sort repositories by the specified criteria. Options: 'alphabetical' (A-Z), 'lastUpdated' (newest first), 'lastUsed' (most recent first), 'size' (largest first).",
+        case_sensitive=False,
+    ),
+) -> None:
+    sort = _validate_sort_option(sort)
+    hf_cache_info = scan_cache_dir(dir)
+    if disable_tui:
+        selected_hashes = _manual_review_no_tui(hf_cache_info, preselected=[], sort_by=sort)
+    else:
+        selected_hashes = _manual_review_tui(hf_cache_info, preselected=[], sort_by=sort)
+    if len(selected_hashes) > 0 and _CANCEL_DELETION_STR not in selected_hashes:
+        confirm_message = _get_expectations_str(hf_cache_info, selected_hashes) + " Confirm deletion ?"
+        if disable_tui:
+            confirmed = _ask_for_confirmation_no_tui(confirm_message)
+        else:
+            confirmed = _ask_for_confirmation_tui(confirm_message)
+        if confirmed:
+            strategy = hf_cache_info.delete_revisions(*selected_hashes)
+            print("Start deletion.")
+            strategy.execute()
+            print(
+                f"Done. Deleted {len(strategy.repos)} repo(s) and"
+                f" {len(strategy.snapshots)} revision(s) for a total of"
+                f" {strategy.expected_freed_size_str}."
+            )
             return
-        print(get_table(hf_cache_info, verbosity=self.verbosity))
-        print(
-            f"\nDone in {round(t1 - t0, 1)}s. Scanned {len(hf_cache_info.repos)} repo(s)"
-            f" for a total of {ANSI.red(hf_cache_info.size_on_disk_str)}."
-        )
-        if len(hf_cache_info.warnings) > 0:
-            message = f"Got {len(hf_cache_info.warnings)} warning(s) while scanning."
-            if self.verbosity >= 3:
-                print(ANSI.gray(message))
-                for warning in hf_cache_info.warnings:
-                    print(ANSI.gray(str(warning)))
-            else:
-                print(ANSI.gray(message + " Use -vvv to print details."))
-
-    def _run_delete(self):
-        hf_cache_info = scan_cache_dir(self.cache_dir)
-        if self.disable_tui:
-            selected_hashes = _manual_review_no_tui(hf_cache_info, preselected=[], sort_by=self.sort_by)
-        else:
-            selected_hashes = _manual_review_tui(hf_cache_info, preselected=[], sort_by=self.sort_by)
-        if len(selected_hashes) > 0 and _CANCEL_DELETION_STR not in selected_hashes:
-            confirm_message = _get_expectations_str(hf_cache_info, selected_hashes) + " Confirm deletion ?"
-            if self.disable_tui:
-                confirmed = _ask_for_confirmation_no_tui(confirm_message)
-            else:
-                confirmed = _ask_for_confirmation_tui(confirm_message)
-            if confirmed:
-                strategy = hf_cache_info.delete_revisions(*selected_hashes)
-                print("Start deletion.")
-                strategy.execute()
-                print(
-                    f"Done. Deleted {len(strategy.repos)} repo(s) and"
-                    f" {len(strategy.snapshots)} revision(s) for a total of"
-                    f" {strategy.expected_freed_size_str}."
-                )
-                return
-        print("Deletion is cancelled. Do nothing.")
+    print("Deletion is cancelled. Do nothing.")
 
 
 def get_table(hf_cache_info: HFCacheInfo, *, verbosity: int = 0) -> str:

--- a/src/huggingface_hub/cli/cache.py
+++ b/src/huggingface_hub/cli/cache.py
@@ -45,7 +45,7 @@ def _validate_sort_option(sort: Optional[str]) -> Optional[str]:
     if sort is None:
         return None
     if sort not in SortingOption_T:
-        raise typer.BadParameter(f"Invalid sort option: {sort}", param_name="sort")
+        raise typer.BadParameter(f"Invalid sort option: {sort}", param_hint="sort")
     return sort
 
 
@@ -69,7 +69,7 @@ cache_app = typer.Typer(help="Manage local cache directory.", rich_markup_mode=N
 @cache_app.command("scan", help="Scan the cache directory")
 def cache_scan(
     dir: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="Cache directory to scan (defaults to Hugging Face cache).",
         ),
@@ -93,8 +93,7 @@ def _run_scan(cache_dir: Optional[str], verbosity: int) -> None:
         hf_cache_info = scan_cache_dir(cache_dir)
         t1 = time.time()
     except CacheNotFound as exc:
-        cache_dir = exc.cache_dir
-        print(f"Cache directory not found: {cache_dir}")
+        print(f"Cache directory not found: {str(exc.cache_dir)}")
         return
     print(get_table(hf_cache_info, verbosity=verbosity))
     print(
@@ -114,7 +113,7 @@ def _run_scan(cache_dir: Optional[str], verbosity: int) -> None:
 @cache_app.command("delete", help="Delete revisions from the cache directory")
 def cache_delete(
     dir: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="Cache directory (defaults to Hugging Face cache).",
         ),
@@ -126,7 +125,7 @@ def cache_delete(
         ),
     ] = False,
     sort: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="Sort repositories by the specified criteria. Options: 'alphabetical' (A-Z), 'lastUpdated' (newest first), 'lastUsed' (most recent first), 'size' (largest first).",
             case_sensitive=False,

--- a/src/huggingface_hub/cli/cache.py
+++ b/src/huggingface_hub/cli/cache.py
@@ -62,7 +62,7 @@ def require_inquirer_py(fn: Callable) -> Callable:
     return _inner
 
 
-cache_app = typer.Typer(help="Manage local cache directory.")
+cache_app = typer.Typer(help="Manage local cache directory.", rich_markup_mode=None)
 
 
 @cache_app.command("scan", help="Scan the cache directory")

--- a/src/huggingface_hub/cli/cache.py
+++ b/src/huggingface_hub/cli/cache.py
@@ -21,6 +21,7 @@ from tempfile import mkstemp
 from typing import Any, Callable, Iterable, Literal, Optional, Union
 
 import typer
+from typing_extensions import Annotated
 
 from ..utils import CachedRepoInfo, CachedRevisionInfo, CacheNotFound, HFCacheInfo, scan_cache_dir
 from ._cli_utils import ANSI, tabulate
@@ -67,18 +68,21 @@ cache_app = typer.Typer(help="Manage local cache directory.", rich_markup_mode=N
 
 @cache_app.command("scan", help="Scan the cache directory")
 def cache_scan(
-    dir: Optional[str] = typer.Option(
-        None,
-        "--dir",
-        help="Cache directory to scan (defaults to Hugging Face cache).",
-    ),
-    verbose: int = typer.Option(
-        0,
-        "-v",
-        "--verbose",
-        count=True,
-        help="Increase verbosity (-v, -vv, -vvv).",
-    ),
+    dir: Annotated[
+        str,
+        typer.Option(
+            help="Cache directory to scan (defaults to Hugging Face cache).",
+        ),
+    ] = None,
+    verbose: Annotated[
+        int,
+        typer.Option(
+            "-v",
+            "--verbose",
+            count=True,
+            help="Increase verbosity (-v, -vv, -vvv).",
+        ),
+    ] = 0,
 ) -> None:
     _run_scan(cache_dir=dir, verbosity=verbose)
 
@@ -109,22 +113,25 @@ def _run_scan(cache_dir: Optional[str], verbosity: int) -> None:
 
 @cache_app.command("delete", help="Delete revisions from the cache directory")
 def cache_delete(
-    dir: Optional[str] = typer.Option(
-        None,
-        "--dir",
-        help="Cache directory (defaults to Hugging Face cache).",
-    ),
-    disable_tui: bool = typer.Option(
-        False,
-        "--disable-tui",
-        help="Disable Terminal User Interface (TUI) mode. Useful if your platform/terminal doesn't support the multiselect menu.",
-    ),
-    sort: Optional[str] = typer.Option(
-        None,
-        "--sort",
-        help="Sort repositories by the specified criteria. Options: 'alphabetical' (A-Z), 'lastUpdated' (newest first), 'lastUsed' (most recent first), 'size' (largest first).",
-        case_sensitive=False,
-    ),
+    dir: Annotated[
+        str,
+        typer.Option(
+            help="Cache directory (defaults to Hugging Face cache).",
+        ),
+    ] = None,
+    disable_tui: Annotated[
+        bool,
+        typer.Option(
+            help="Disable Terminal User Interface (TUI) mode. Useful if your platform/terminal doesn't support the multiselect menu.",
+        ),
+    ] = False,
+    sort: Annotated[
+        str,
+        typer.Option(
+            help="Sort repositories by the specified criteria. Options: 'alphabetical' (A-Z), 'lastUpdated' (newest first), 'lastUsed' (most recent first), 'size' (largest first).",
+            case_sensitive=False,
+        ),
+    ] = None,
 ) -> None:
     sort = _validate_sort_option(sort)
     hf_cache_info = scan_cache_dir(dir)

--- a/src/huggingface_hub/cli/cache.py
+++ b/src/huggingface_hub/cli/cache.py
@@ -18,10 +18,9 @@ import os
 import time
 from functools import wraps
 from tempfile import mkstemp
-from typing import Any, Callable, Iterable, Literal, Optional, Union, cast, get_args
+from typing import Annotated, Any, Callable, Iterable, Literal, Optional, Union, cast, get_args
 
 import typer
-from typing_extensions import Annotated
 
 from ..utils import CachedRepoInfo, CachedRevisionInfo, CacheNotFound, HFCacheInfo, scan_cache_dir
 from ._cli_utils import ANSI, tabulate

--- a/src/huggingface_hub/cli/cache.py
+++ b/src/huggingface_hub/cli/cache.py
@@ -24,7 +24,7 @@ from typing import Annotated, Any, Callable, Iterable, Optional, Union
 import typer
 
 from ..utils import CachedRepoInfo, CachedRevisionInfo, CacheNotFound, HFCacheInfo, scan_cache_dir
-from ._cli_utils import ANSI, tabulate
+from ._cli_utils import ANSI, tabulate, typer_factory
 
 
 # --- DELETE helpers (from delete_cache.py) ---
@@ -61,7 +61,7 @@ def require_inquirer_py(fn: Callable) -> Callable:
     return _inner
 
 
-cache_cli = typer.Typer(help="Manage local cache directory.", rich_markup_mode=None)
+cache_cli = typer_factory(help="Manage local cache directory.")
 
 
 @cache_cli.command("scan", help="Scan the cache directory")

--- a/src/huggingface_hub/cli/cache.py
+++ b/src/huggingface_hub/cli/cache.py
@@ -82,25 +82,21 @@ def cache_scan(
         ),
     ] = 0,
 ) -> None:
-    _run_scan(cache_dir=dir, verbosity=verbose)
-
-
-def _run_scan(cache_dir: Optional[str], verbosity: int) -> None:
     try:
         t0 = time.time()
-        hf_cache_info = scan_cache_dir(cache_dir)
+        hf_cache_info = scan_cache_dir(dir)
         t1 = time.time()
     except CacheNotFound as exc:
         print(f"Cache directory not found: {str(exc.cache_dir)}")
         return
-    print(get_table(hf_cache_info, verbosity=verbosity))
+    print(get_table(hf_cache_info, verbosity=verbose))
     print(
         f"\nDone in {round(t1 - t0, 1)}s. Scanned {len(hf_cache_info.repos)} repo(s)"
         f" for a total of {ANSI.red(hf_cache_info.size_on_disk_str)}."
     )
     if len(hf_cache_info.warnings) > 0:
         message = f"Got {len(hf_cache_info.warnings)} warning(s) while scanning."
-        if verbosity >= 3:
+        if verbose >= 3:
             print(ANSI.gray(message))
             for warning in hf_cache_info.warnings:
                 print(ANSI.gray(str(warning)))

--- a/src/huggingface_hub/cli/download.py
+++ b/src/huggingface_hub/cli/download.py
@@ -46,7 +46,7 @@ from huggingface_hub._snapshot_download import snapshot_download
 from huggingface_hub.file_download import hf_hub_download
 from huggingface_hub.utils import disable_progress_bars, enable_progress_bars
 
-from ._cli_utils import validate_repo_type
+from ._cli_utils import RepoType
 
 
 logger = logging.get_logger(__name__)
@@ -67,11 +67,11 @@ def download(
         ),
     ] = None,
     repo_type: Annotated[
-        str,
+        RepoType,
         typer.Option(
             help="Type of repo to download from.",
         ),
-    ] = "model",
+    ] = RepoType.model,
     revision: Annotated[
         Optional[str],
         typer.Option(
@@ -128,8 +128,6 @@ def download(
     ] = 8,
 ) -> None:
     """Download files from the Hub."""
-    # Validate repo_type if provided
-    repo_type = validate_repo_type(repo_type) or "model"
 
     def run_download() -> str:
         filenames_list = filenames if filenames is not None else []
@@ -144,7 +142,7 @@ def download(
         if len(filenames_list) == 1:
             return hf_hub_download(
                 repo_id=repo_id,
-                repo_type=repo_type,
+                repo_type=repo_type.value,
                 revision=revision,
                 filename=filenames_list[0],
                 cache_dir=cache_dir,
@@ -164,7 +162,7 @@ def download(
 
         return snapshot_download(
             repo_id=repo_id,
-            repo_type=repo_type,
+            repo_type=repo_type.value,
             revision=revision,
             allow_patterns=allow_patterns,
             ignore_patterns=ignore_patterns,

--- a/src/huggingface_hub/cli/download.py
+++ b/src/huggingface_hub/cli/download.py
@@ -40,6 +40,7 @@ import warnings
 from typing import Optional
 
 import typer
+from typing_extensions import Annotated
 
 from huggingface_hub import logging
 from huggingface_hub._snapshot_download import snapshot_download
@@ -53,64 +54,79 @@ logger = logging.get_logger(__name__)
 
 
 def download(
-    repo_id: str = typer.Argument(
-        ...,
-        help="ID of the repo to download from (e.g. `username/repo-name`).",
-    ),
-    filenames: Optional[list[str]] = typer.Argument(
-        None,
-        help="Files to download (e.g. `config.json`, `data/metadata.jsonl`).",
-    ),
-    repo_type: Optional[str] = typer.Option(
-        "model",
-        "--repo-type",
-        help="Type of repo to download from.",
-    ),
-    revision: Optional[str] = typer.Option(
-        None,
-        "--revision",
-        help="Git revision id which can be a branch name, a tag, or a commit hash.",
-    ),
-    include: Optional[list[str]] = typer.Option(
-        None,
-        "--include",
-        help="Glob patterns to include from files to download. eg: *.json",
-    ),
-    exclude: Optional[list[str]] = typer.Option(
-        None,
-        "--exclude",
-        help="Glob patterns to exclude from files to download.",
-    ),
-    cache_dir: Optional[str] = typer.Option(
-        None,
-        "--cache-dir",
-        help="Directory where to save files.",
-    ),
-    local_dir: Optional[str] = typer.Option(
-        None,
-        "--local-dir",
-        help="If set, the downloaded file will be placed under this directory. Check out https://huggingface.co/docs/huggingface_hub/guides/download#download-files-to-local-folder for more details.",
-    ),
-    force_download: Optional[bool] = typer.Option(
-        False,
-        "--force-download",
-        help="If True, the files will be downloaded even if they are already cached.",
-    ),
-    token: Optional[str] = typer.Option(
-        None,
-        "--token",
-        help="A User Access Token generated from https://huggingface.co/settings/tokens",
-    ),
-    quiet: Optional[bool] = typer.Option(
-        False,
-        "--quiet",
-        help="If True, progress bars are disabled and only the path to the download files is printed.",
-    ),
-    max_workers: Optional[int] = typer.Option(
-        8,
-        "--max-workers",
-        help="Maximum number of workers to use for downloading files. Default is 8.",
-    ),
+    repo_id: Annotated[
+        str,
+        typer.Argument(
+            ...,
+            help="ID of the repo to download from (e.g. `username/repo-name`).",
+        ),
+    ],
+    filenames: Annotated[
+        list[str],
+        typer.Argument(
+            help="Files to download (e.g. `config.json`, `data/metadata.jsonl`).",
+        ),
+    ] = None,
+    repo_type: Annotated[
+        str,
+        typer.Option(
+            help="Type of repo to download from.",
+        ),
+    ] = "model",
+    revision: Annotated[
+        str,
+        typer.Option(
+            help="Git revision id which can be a branch name, a tag, or a commit hash.",
+        ),
+    ] = None,
+    include: Annotated[
+        list[str],
+        typer.Option(
+            help="Glob patterns to include from files to download. eg: *.json",
+        ),
+    ] = None,
+    exclude: Annotated[
+        list[str],
+        typer.Option(
+            help="Glob patterns to exclude from files to download.",
+        ),
+    ] = None,
+    cache_dir: Annotated[
+        str,
+        typer.Option(
+            help="Directory where to save files.",
+        ),
+    ] = None,
+    local_dir: Annotated[
+        str,
+        typer.Option(
+            help="If set, the downloaded file will be placed under this directory. Check out https://huggingface.co/docs/huggingface_hub/guides/download#download-files-to-local-folder for more details.",
+        ),
+    ] = None,
+    force_download: Annotated[
+        bool,
+        typer.Option(
+            help="If True, the files will be downloaded even if they are already cached.",
+        ),
+    ] = False,
+    token: Annotated[
+        str,
+        typer.Option(
+            help="A User Access Token generated from https://huggingface.co/settings/tokens",
+        ),
+    ] = None,
+    quiet: Annotated[
+        bool,
+        typer.Option(
+            help="If True, progress bars are disabled and only the path to the download files is printed.",
+        ),
+    ] = False,
+    max_workers: Annotated[
+        int,
+        typer.Option(
+            help="Maximum number of workers to use for downloading files. Default is 8.",
+        ),
+    ] = 8,
 ) -> None:
     """Download files from the Hub."""
     # Validate repo_type if provided

--- a/src/huggingface_hub/cli/download.py
+++ b/src/huggingface_hub/cli/download.py
@@ -37,10 +37,9 @@ Usage:
 """
 
 import warnings
-from typing import Optional
+from typing import Annotated, Optional
 
 import typer
-from typing_extensions import Annotated
 
 from huggingface_hub import logging
 from huggingface_hub._snapshot_download import snapshot_download

--- a/src/huggingface_hub/cli/download.py
+++ b/src/huggingface_hub/cli/download.py
@@ -37,7 +37,7 @@ Usage:
 """
 
 import warnings
-from typing import Optional
+from typing import List, Optional
 
 import typer
 from typing_extensions import Annotated
@@ -62,7 +62,7 @@ def download(
         ),
     ],
     filenames: Annotated[
-        list[str],
+        Optional[List[str]],
         typer.Argument(
             help="Files to download (e.g. `config.json`, `data/metadata.jsonl`).",
         ),
@@ -74,31 +74,31 @@ def download(
         ),
     ] = "model",
     revision: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="Git revision id which can be a branch name, a tag, or a commit hash.",
         ),
     ] = None,
     include: Annotated[
-        list[str],
+        Optional[List[str]],
         typer.Option(
             help="Glob patterns to include from files to download. eg: *.json",
         ),
     ] = None,
     exclude: Annotated[
-        list[str],
+        Optional[List[str]],
         typer.Option(
             help="Glob patterns to exclude from files to download.",
         ),
     ] = None,
     cache_dir: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="Directory where to save files.",
         ),
     ] = None,
     local_dir: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="If set, the downloaded file will be placed under this directory. Check out https://huggingface.co/docs/huggingface_hub/guides/download#download-files-to-local-folder for more details.",
         ),
@@ -110,7 +110,7 @@ def download(
         ),
     ] = False,
     token: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="A User Access Token generated from https://huggingface.co/settings/tokens",
         ),
@@ -130,7 +130,7 @@ def download(
 ) -> None:
     """Download files from the Hub."""
     # Validate repo_type if provided
-    repo_type = validate_repo_type(repo_type)
+    repo_type = validate_repo_type(repo_type)  # ty: ignore[invalid-assignment]
 
     if quiet:
         disable_progress_bars()

--- a/src/huggingface_hub/cli/download.py
+++ b/src/huggingface_hub/cli/download.py
@@ -130,7 +130,7 @@ def download(
 ) -> None:
     """Download files from the Hub."""
     # Validate repo_type if provided
-    repo_type = validate_repo_type(repo_type)  # ty: ignore[invalid-assignment]
+    repo_type = validate_repo_type(repo_type) or "model"
 
     def run_download() -> str:
         filenames_list = filenames if filenames is not None else []

--- a/src/huggingface_hub/cli/download.py
+++ b/src/huggingface_hub/cli/download.py
@@ -181,6 +181,5 @@ def download(
             print(run_download())
         enable_progress_bars()
     else:
-        logging.set_verbosity_info()
         print(run_download())
         logging.set_verbosity_warning()

--- a/src/huggingface_hub/cli/download.py
+++ b/src/huggingface_hub/cli/download.py
@@ -37,7 +37,7 @@ Usage:
 """
 
 import warnings
-from typing import List, Optional
+from typing import Optional
 
 import typer
 from typing_extensions import Annotated
@@ -62,7 +62,7 @@ def download(
         ),
     ],
     filenames: Annotated[
-        Optional[List[str]],
+        Optional[list[str]],
         typer.Argument(
             help="Files to download (e.g. `config.json`, `data/metadata.jsonl`).",
         ),
@@ -80,13 +80,13 @@ def download(
         ),
     ] = None,
     include: Annotated[
-        Optional[List[str]],
+        Optional[list[str]],
         typer.Option(
             help="Glob patterns to include from files to download. eg: *.json",
         ),
     ] = None,
     exclude: Annotated[
-        Optional[List[str]],
+        Optional[list[str]],
         typer.Option(
             help="Glob patterns to exclude from files to download.",
         ),

--- a/src/huggingface_hub/cli/download.py
+++ b/src/huggingface_hub/cli/download.py
@@ -46,7 +46,7 @@ from huggingface_hub._snapshot_download import snapshot_download
 from huggingface_hub.file_download import hf_hub_download
 from huggingface_hub.utils import disable_progress_bars, enable_progress_bars
 
-from ._cli_utils import RepoTypeOpt
+from ._cli_utils import RepoType
 
 
 logger = logging.get_logger(__name__)
@@ -66,11 +66,11 @@ def download(
         ),
     ] = None,
     repo_type: Annotated[
-        RepoTypeOpt,
+        RepoType,
         typer.Option(
             help="Type of repo to download from.",
         ),
-    ] = RepoTypeOpt.model,
+    ] = RepoType.model,
     revision: Annotated[
         Optional[str],
         typer.Option(

--- a/src/huggingface_hub/cli/download.py
+++ b/src/huggingface_hub/cli/download.py
@@ -56,7 +56,6 @@ def download(
     repo_id: Annotated[
         str,
         typer.Argument(
-            ...,
             help="ID of the repo to download from (e.g. `username/repo-name`).",
         ),
     ],

--- a/src/huggingface_hub/cli/download.py
+++ b/src/huggingface_hub/cli/download.py
@@ -46,37 +46,22 @@ from huggingface_hub._snapshot_download import snapshot_download
 from huggingface_hub.file_download import hf_hub_download
 from huggingface_hub.utils import disable_progress_bars, enable_progress_bars
 
-from ._cli_utils import RepoType
+from ._cli_utils import RepoIdArg, RepoTypeOpt, RevisionOpt, TokenOpt
 
 
 logger = logging.get_logger(__name__)
 
 
 def download(
-    repo_id: Annotated[
-        str,
-        typer.Argument(
-            help="ID of the repo to download from (e.g. `username/repo-name`).",
-        ),
-    ],
+    repo_id: RepoIdArg,
     filenames: Annotated[
         Optional[list[str]],
         typer.Argument(
             help="Files to download (e.g. `config.json`, `data/metadata.jsonl`).",
         ),
     ] = None,
-    repo_type: Annotated[
-        RepoType,
-        typer.Option(
-            help="Type of repo to download from.",
-        ),
-    ] = RepoType.model,
-    revision: Annotated[
-        Optional[str],
-        typer.Option(
-            help="Git revision id which can be a branch name, a tag, or a commit hash.",
-        ),
-    ] = None,
+    repo_type: RepoTypeOpt = RepoTypeOpt.model,
+    revision: RevisionOpt = None,
     include: Annotated[
         Optional[list[str]],
         typer.Option(
@@ -107,12 +92,7 @@ def download(
             help="If True, the files will be downloaded even if they are already cached.",
         ),
     ] = False,
-    token: Annotated[
-        Optional[str],
-        typer.Option(
-            help="A User Access Token generated from https://huggingface.co/settings/tokens",
-        ),
-    ] = None,
+    token: TokenOpt = None,
     quiet: Annotated[
         bool,
         typer.Option(

--- a/src/huggingface_hub/cli/download.py
+++ b/src/huggingface_hub/cli/download.py
@@ -46,7 +46,7 @@ from huggingface_hub._snapshot_download import snapshot_download
 from huggingface_hub.file_download import hf_hub_download
 from huggingface_hub.utils import disable_progress_bars, enable_progress_bars
 
-from ._cli_utils import RepoType
+from ._cli_utils import RepoTypeOpt
 
 
 logger = logging.get_logger(__name__)
@@ -66,11 +66,11 @@ def download(
         ),
     ] = None,
     repo_type: Annotated[
-        RepoType,
+        RepoTypeOpt,
         typer.Option(
             help="Type of repo to download from.",
         ),
-    ] = RepoType.model,
+    ] = RepoTypeOpt.model,
     revision: Annotated[
         Optional[str],
         typer.Option(

--- a/src/huggingface_hub/cli/hf.py
+++ b/src/huggingface_hub/cli/hf.py
@@ -34,11 +34,11 @@ app = typer.Typer(add_completion=False, no_args_is_help=True, help="Hugging Face
 # top level single commands (defined in their respective files)
 app.command(
     name="download",
-    help="Download files from the Hub",
+    help="Download files from the Hub.",
 )(download)
 app.command(
     name="upload",
-    help="Upload a file or a folder to the Hub",
+    help="Upload a file or a folder to the Hub.",
 )(upload)
 app.command(
     name="upload-large-folder",

--- a/src/huggingface_hub/cli/hf.py
+++ b/src/huggingface_hub/cli/hf.py
@@ -14,13 +14,13 @@
 
 import typer
 
-from huggingface_hub.cli.auth import auth_app
-from huggingface_hub.cli.cache import cache_app
+from huggingface_hub.cli.auth import auth_cli
+from huggingface_hub.cli.cache import cache_cli
 from huggingface_hub.cli.download import download
-from huggingface_hub.cli.jobs import jobs_app
+from huggingface_hub.cli.jobs import jobs_cli
 from huggingface_hub.cli.lfs import lfs_enable_largefiles, lfs_multipart_upload
-from huggingface_hub.cli.repo import repo_app
-from huggingface_hub.cli.repo_files import repo_files_app
+from huggingface_hub.cli.repo import repo_cli
+from huggingface_hub.cli.repo_files import repo_files_cli
 from huggingface_hub.cli.system import env, version
 
 # from huggingface_hub.cli.jobs import jobs_app
@@ -65,11 +65,11 @@ app.command(
 
 
 # command groups
-app.add_typer(auth_app, name="auth")
-app.add_typer(cache_app, name="cache")
-app.add_typer(repo_app, name="repo")
-app.add_typer(repo_files_app, name="repo-files")
-app.add_typer(jobs_app, name="jobs")
+app.add_typer(auth_cli, name="auth")
+app.add_typer(cache_cli, name="cache")
+app.add_typer(repo_cli, name="repo")
+app.add_typer(repo_files_cli, name="repo-files")
+app.add_typer(jobs_cli, name="jobs")
 
 
 def main():

--- a/src/huggingface_hub/cli/hf.py
+++ b/src/huggingface_hub/cli/hf.py
@@ -33,36 +33,13 @@ app = typer_factory(help="Hugging Face Hub CLI")
 
 
 # top level single commands (defined in their respective files)
-app.command(
-    name="download",
-    help="Download files from the Hub.",
-)(download)
-app.command(
-    name="upload",
-    help="Upload a file or a folder to the Hub.",
-)(upload)
-app.command(
-    name="upload-large-folder",
-    help="Upload a large folder to the Hub. Recommended for resumable uploads.",
-)(upload_large_folder)
-app.command(
-    name="env",
-    help="Print information about the environment.",
-)(env)
-app.command(
-    name="version",
-    help="Print information about the hf version.",
-)(version)
-app.command(
-    name="lfs-enable-largefiles",
-    help="Configure your repository to enable upload of files > 5GB.",
-    hidden=True,
-)(lfs_enable_largefiles)
-app.command(
-    name="lfs-multipart-upload",
-    help="Upload large files to the Hub.",
-    hidden=True,
-)(lfs_multipart_upload)
+app.command(help="Download files from the Hub.")(download)
+app.command(help="Upload a file or a folder to the Hub.")(upload)
+app.command(help="Upload a large folder to the Hub. Recommended for resumable uploads.")(upload_large_folder)
+app.command(name="env", help="Print information about the environment.")(env)
+app.command(help="Print information about the hf version.")(version)
+app.command(help="Configure your repository to enable upload of files > 5GB.", hidden=True)(lfs_enable_largefiles)
+app.command(help="Upload large files to the Hub.", hidden=True)(lfs_multipart_upload)
 
 
 # command groups

--- a/src/huggingface_hub/cli/hf.py
+++ b/src/huggingface_hub/cli/hf.py
@@ -26,6 +26,7 @@ from huggingface_hub.cli.system import env, version
 # from huggingface_hub.cli.jobs import jobs_app
 from huggingface_hub.cli.upload import upload
 from huggingface_hub.cli.upload_large_folder import upload_large_folder
+from huggingface_hub.utils import logging
 
 
 app = typer.Typer(add_completion=False, no_args_is_help=True, help="Hugging Face Hub CLI", rich_markup_mode=None)
@@ -73,6 +74,7 @@ app.add_typer(jobs_cli, name="jobs")
 
 
 def main():
+    logging.set_verbosity_info()
     app()
 
 

--- a/src/huggingface_hub/cli/hf.py
+++ b/src/huggingface_hub/cli/hf.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import typer
 
+from huggingface_hub.cli._cli_utils import typer_factory
 from huggingface_hub.cli.auth import auth_cli
 from huggingface_hub.cli.cache import cache_cli
 from huggingface_hub.cli.download import download
@@ -29,7 +29,7 @@ from huggingface_hub.cli.upload_large_folder import upload_large_folder
 from huggingface_hub.utils import logging
 
 
-app = typer.Typer(add_completion=False, no_args_is_help=True, help="Hugging Face Hub CLI", rich_markup_mode=None)
+app = typer_factory(help="Hugging Face Hub CLI")
 
 
 # top level single commands (defined in their respective files)

--- a/src/huggingface_hub/cli/hf.py
+++ b/src/huggingface_hub/cli/hf.py
@@ -29,7 +29,7 @@ from huggingface_hub.cli.upload import upload
 from huggingface_hub.cli.upload_large_folder import upload_large_folder
 
 
-app = typer.Typer(add_completion=False, no_args_is_help=True, help="Hugging Face Hub CLI")
+app = typer.Typer(add_completion=False, no_args_is_help=True, help="Hugging Face Hub CLI", rich_markup_mode=None)
 
 
 # top level single commands (defined in their respective files)

--- a/src/huggingface_hub/cli/hf.py
+++ b/src/huggingface_hub/cli/hf.py
@@ -18,13 +18,12 @@ from huggingface_hub.cli.auth import auth_app
 from huggingface_hub.cli.cache import cache_app
 from huggingface_hub.cli.download import download
 from huggingface_hub.cli.jobs import jobs_app
-
-# from huggingface_hub.cli.jobs import jobs_app
 from huggingface_hub.cli.lfs import lfs_enable_largefiles, lfs_multipart_upload
 from huggingface_hub.cli.repo import repo_app
 from huggingface_hub.cli.repo_files import repo_files_app
-from huggingface_hub.cli.system import env as env_command
-from huggingface_hub.cli.system import version as version_command
+from huggingface_hub.cli.system import env, version
+
+# from huggingface_hub.cli.jobs import jobs_app
 from huggingface_hub.cli.upload import upload
 from huggingface_hub.cli.upload_large_folder import upload_large_folder
 
@@ -48,11 +47,11 @@ app.command(
 app.command(
     name="env",
     help="Print information about the environment.",
-)(env_command)
+)(env)
 app.command(
     name="version",
     help="Print information about the hf version.",
-)(version_command)
+)(version)
 app.command(
     name="lfs-enable-largefiles",
     help="Configure your repository to enable upload of files > 5GB.",

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -66,7 +66,7 @@ from huggingface_hub.errors import HfHubHTTPError
 from huggingface_hub.utils import logging
 from huggingface_hub.utils._dotenv import load_dotenv
 
-from ._cli_utils import typer_factory
+from ._cli_utils import TokenOpt, typer_factory
 
 
 logger = logging.get_logger(__name__)
@@ -150,13 +150,7 @@ def jobs_run(
             help="The namespace where the Job will be created. Defaults to the current user's namespace.",
         ),
     ] = None,
-    token: Annotated[
-        Optional[str],
-        typer.Option(
-            "--token",
-            help="A User Access Token generated from https://huggingface.co/settings/tokens",
-        ),
-    ] = None,
+    token: TokenOpt = None,
 ) -> None:
     env_map: dict[str, Optional[str]] = {}
     if env_file:
@@ -207,13 +201,7 @@ def jobs_logs(
             help="The namespace where the job is running. Defaults to the current user's namespace.",
         ),
     ] = None,
-    token: Annotated[
-        Optional[str],
-        typer.Option(
-            "--token",
-            help="A User Access Token generated from https://huggingface.co/settings/tokens",
-        ),
-    ] = None,
+    token: TokenOpt = None,
 ) -> None:
     api = HfApi(token=token)
     for log in api.fetch_job_logs(job_id=job_id, namespace=namespace):
@@ -271,12 +259,7 @@ def jobs_ps(
             help="The namespace from where it lists the jobs. Defaults to the current user's namespace.",
         ),
     ] = None,
-    token: Annotated[
-        Optional[str],
-        typer.Option(
-            help="A User Access Token generated from https://huggingface.co/settings/tokens",
-        ),
-    ] = None,
+    token: TokenOpt = None,
     filter: Annotated[
         Optional[list[str]],
         typer.Option(
@@ -367,12 +350,7 @@ def jobs_inspect(
             help="The namespace where the job is running. Defaults to the current user's namespace.",
         ),
     ] = None,
-    token: Annotated[
-        Optional[str],
-        typer.Option(
-            help="A User Access Token generated from https://huggingface.co/settings/tokens",
-        ),
-    ] = None,
+    token: TokenOpt = None,
 ) -> None:
     api = HfApi(token=token)
     jobs = [api.inspect_job(job_id=job_id, namespace=namespace) for job_id in job_ids]
@@ -393,12 +371,7 @@ def jobs_cancel(
             help="The namespace where the job is running. Defaults to the current user's namespace.",
         ),
     ] = None,
-    token: Annotated[
-        Optional[str],
-        typer.Option(
-            help="A User Access Token generated from https://huggingface.co/settings/tokens",
-        ),
-    ] = None,
+    token: TokenOpt = None,
 ) -> None:
     api = HfApi(token=token)
     api.cancel_job(job_id=job_id, namespace=namespace)
@@ -492,13 +465,7 @@ def jobs_uv_run(
             help="The namespace where the Job will be created. Defaults to the current user's namespace.",
         ),
     ] = None,
-    token: Annotated[
-        Optional[str],
-        typer.Option(
-            "--token",
-            help="HF token",
-        ),
-    ] = None,
+    token: TokenOpt = None,
     with_: Annotated[
         Optional[list[str]],
         typer.Option(
@@ -634,12 +601,7 @@ def scheduled_run(
             help="The namespace where the scheduled Job will be created. Defaults to the current user's namespace.",
         ),
     ] = None,
-    token: Annotated[
-        Optional[str],
-        typer.Option(
-            help="A User Access Token generated from https://huggingface.co/settings/tokens",
-        ),
-    ] = None,
+    token: TokenOpt = None,
 ) -> None:
     env_map: dict[str, Optional[str]] = {}
     if env_file:
@@ -685,12 +647,7 @@ def scheduled_ps(
             help="The namespace from where it lists the jobs. Defaults to the current user's namespace.",
         ),
     ] = None,
-    token: Annotated[
-        Optional[str],
-        typer.Option(
-            help="A User Access Token generated from https://huggingface.co/settings/tokens",
-        ),
-    ] = None,
+    token: TokenOpt = None,
     filter: Annotated[
         Optional[list[str]],
         typer.Option(
@@ -775,13 +732,7 @@ def scheduled_inspect(
             help="The namespace where the scheduled job is. Defaults to the current user's namespace.",
         ),
     ] = None,
-    token: Annotated[
-        Optional[str],
-        typer.Option(
-            "--token",
-            help="A User Access Token generated from https://huggingface.co/settings/tokens",
-        ),
-    ] = None,
+    token: TokenOpt = None,
 ) -> None:
     api = HfApi(token=token)
     scheduled_jobs = [
@@ -805,12 +756,7 @@ def scheduled_delete(
             help="The namespace where the scheduled job is. Defaults to the current user's namespace.",
         ),
     ] = None,
-    token: Annotated[
-        Optional[str],
-        typer.Option(
-            help="A User Access Token generated from https://huggingface.co/settings/tokens",
-        ),
-    ] = None,
+    token: TokenOpt = None,
 ) -> None:
     api = HfApi(token=token)
     api.delete_scheduled_job(scheduled_job_id=scheduled_job_id, namespace=namespace)
@@ -831,13 +777,7 @@ def scheduled_suspend(
             help="The namespace where the scheduled job is. Defaults to the current user's namespace.",
         ),
     ] = None,
-    token: Annotated[
-        Optional[str],
-        typer.Option(
-            "--token",
-            help="A User Access Token generated from https://huggingface.co/settings/tokens",
-        ),
-    ] = None,
+    token: TokenOpt = None,
 ) -> None:
     api = HfApi(token=token)
     api.suspend_scheduled_job(scheduled_job_id=scheduled_job_id, namespace=namespace)
@@ -858,13 +798,7 @@ def scheduled_resume(
             help="The namespace where the scheduled job is. Defaults to the current user's namespace.",
         ),
     ] = None,
-    token: Annotated[
-        Optional[str],
-        typer.Option(
-            "--token",
-            help="A User Access Token generated from https://huggingface.co/settings/tokens",
-        ),
-    ] = None,
+    token: TokenOpt = None,
 ) -> None:
     api = HfApi(token=token)
     api.resume_scheduled_job(scheduled_job_id=scheduled_job_id, namespace=namespace)
@@ -968,12 +902,7 @@ def scheduled_uv_run(
             help="The namespace where the Job will be created. Defaults to the current user's namespace.",
         ),
     ] = None,
-    token: Annotated[
-        Optional[str],
-        typer.Option(
-            help="HF token",
-        ),
-    ] = None,
+    token: TokenOpt = None,
     with_: Annotated[
         Optional[list[str]],
         typer.Option(

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -66,13 +66,15 @@ from huggingface_hub.errors import HfHubHTTPError
 from huggingface_hub.utils import logging
 from huggingface_hub.utils._dotenv import load_dotenv
 
+from ._cli_utils import typer_factory
+
 
 logger = logging.get_logger(__name__)
 
 SUGGESTED_FLAVORS = [item.value for item in SpaceHardware if item.value != "zero-a10g"]
 
 
-jobs_cli = typer.Typer(help="Run and manage Jobs on the Hub.", rich_markup_mode=None)
+jobs_cli = typer_factory(help="Run and manage Jobs on the Hub.")
 
 
 @jobs_cli.command("run", help="Run a Job")
@@ -407,9 +409,7 @@ def jobs_cancel(
     api.cancel_job(job_id=job_id, namespace=namespace)
 
 
-uv_app = typer.Typer(
-    help="Run UV scripts (Python with inline dependencies) on HF infrastructure", rich_markup_mode=None
-)
+uv_app = typer_factory(help="Run UV scripts (Python with inline dependencies) on HF infrastructure")
 jobs_cli.add_typer(uv_app, name="uv")
 
 
@@ -558,7 +558,7 @@ def jobs_uv_run(
         print(log)
 
 
-scheduled_app = typer.Typer(help="Create and manage scheduled Jobs on the Hub.", rich_markup_mode=None)
+scheduled_app = typer_factory(help="Create and manage scheduled Jobs on the Hub.")
 jobs_cli.add_typer(scheduled_app, name="scheduled")
 
 
@@ -883,9 +883,7 @@ def scheduled_resume(
     api.resume_scheduled_job(scheduled_job_id=scheduled_job_id, namespace=namespace)
 
 
-scheduled_uv_app = typer.Typer(
-    help="Schedule UV scripts (Python with inline dependencies) on HF infrastructure", rich_markup_mode=None
-)
+scheduled_uv_app = typer_factory(help="Schedule UV scripts (Python with inline dependencies) on HF infrastructure")
 scheduled_app.add_typer(scheduled_uv_app, name="uv")
 
 

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -72,7 +72,7 @@ logger = logging.get_logger(__name__)
 SUGGESTED_FLAVORS = [item.value for item in SpaceHardware if item.value != "zero-a10g"]
 
 
-jobs_app = typer.Typer(help="Run and manage Jobs on the Hub.")
+jobs_app = typer.Typer(help="Run and manage Jobs on the Hub.", rich_markup_mode=None)
 
 
 @jobs_app.command("run", help="Run a Job")
@@ -359,7 +359,9 @@ def jobs_cancel(
     api.cancel_job(job_id=job_id, namespace=namespace)
 
 
-uv_app = typer.Typer(help="Run UV scripts (Python with inline dependencies) on HF infrastructure")
+uv_app = typer.Typer(
+    help="Run UV scripts (Python with inline dependencies) on HF infrastructure", rich_markup_mode=None
+)
 jobs_app.add_typer(uv_app, name="uv")
 
 
@@ -480,7 +482,7 @@ def jobs_uv_run(
         print(log)
 
 
-scheduled_app = typer.Typer(help="Create and manage scheduled Jobs on the Hub.")
+scheduled_app = typer.Typer(help="Create and manage scheduled Jobs on the Hub.", rich_markup_mode=None)
 jobs_app.add_typer(scheduled_app, name="scheduled")
 
 
@@ -750,7 +752,9 @@ def scheduled_resume(
     api.resume_scheduled_job(scheduled_job_id=scheduled_job_id, namespace=namespace)
 
 
-scheduled_uv_app = typer.Typer(help="Schedule UV scripts (Python with inline dependencies) on HF infrastructure")
+scheduled_uv_app = typer.Typer(
+    help="Schedule UV scripts (Python with inline dependencies) on HF infrastructure", rich_markup_mode=None
+)
 scheduled_app.add_typer(scheduled_uv_app, name="uv")
 
 

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -482,7 +482,6 @@ def jobs_uv_run(
         ),
     ] = None,
 ) -> None:
-    logging.set_verbosity(logging.INFO)
     env_map: dict[str, Optional[str]] = {}
     if env_file:
         env_map.update(load_dotenv(Path(env_file).read_text(), environ=os.environ.copy()))
@@ -919,7 +918,6 @@ def scheduled_uv_run(
         ),
     ] = None,
 ) -> None:
-    logging.set_verbosity(logging.INFO)
     env_map: dict[str, Optional[str]] = {}
     if env_file:
         env_map.update(load_dotenv(Path(env_file).read_text(), environ=os.environ.copy()))

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -57,7 +57,7 @@ import os
 import re
 from dataclasses import asdict
 from pathlib import Path
-from typing import Dict, Optional, Union
+from typing import Dict, List, Optional, Union
 
 import typer
 from typing_extensions import Annotated
@@ -93,7 +93,7 @@ def jobs_run(
         ),
     ],
     env: Annotated[
-        list[str],
+        Optional[List[str]],
         typer.Option(
             "-e",
             "--env",
@@ -101,7 +101,7 @@ def jobs_run(
         ),
     ] = None,
     secrets: Annotated[
-        list[str],
+        Optional[List[str]],
         typer.Option(
             "-s",
             "--secrets",
@@ -109,28 +109,28 @@ def jobs_run(
         ),
     ] = None,
     env_file: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             "--env-file",
             help="Read in a file of environment variables.",
         ),
     ] = None,
     secrets_file: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             "--secrets-file",
             help="Read in a file of secret environment variables.",
         ),
     ] = None,
     flavor: Annotated[
-        str,
+        Optional[SpaceHardware],
         typer.Option(
             "--flavor",
             help=f"Flavor for the hardware, as in HF Spaces. Defaults to `cpu-basic`. Possible values: {', '.join(SUGGESTED_FLAVORS)}.",
         ),
     ] = None,
     timeout: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             "--timeout",
             help="Max duration: int/float with s (seconds, default), m (minutes), h (hours) or d (days).",
@@ -145,14 +145,14 @@ def jobs_run(
         ),
     ] = False,
     namespace: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             "--namespace",
             help="The namespace where the Job will be created. Defaults to the current user's namespace.",
         ),
     ] = None,
     token: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             "--token",
             help="A User Access Token generated from https://huggingface.co/settings/tokens",
@@ -203,14 +203,14 @@ def jobs_logs(
         ),
     ],
     namespace: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             "--namespace",
             help="The namespace where the job is running. Defaults to the current user's namespace.",
         ),
     ] = None,
     token: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             "--token",
             help="A User Access Token generated from https://huggingface.co/settings/tokens",
@@ -268,19 +268,19 @@ def jobs_ps(
         ),
     ] = False,
     namespace: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="The namespace from where it lists the jobs. Defaults to the current user's namespace.",
         ),
     ] = None,
     token: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="A User Access Token generated from https://huggingface.co/settings/tokens",
         ),
     ] = None,
     filter: Annotated[
-        list[str],
+        Optional[List[str]],
         typer.Option(
             "-f",
             "--filter",
@@ -288,7 +288,7 @@ def jobs_ps(
         ),
     ] = None,
     format: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="Format output using a custom template",
         ),
@@ -365,13 +365,13 @@ def jobs_inspect(
         ),
     ],
     namespace: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="The namespace where the job is running. Defaults to the current user's namespace.",
         ),
     ] = None,
     token: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="A User Access Token generated from https://huggingface.co/settings/tokens",
         ),
@@ -392,13 +392,13 @@ def jobs_cancel(
         ),
     ],
     namespace: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="The namespace where the job is running. Defaults to the current user's namespace.",
         ),
     ] = None,
     token: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="A User Access Token generated from https://huggingface.co/settings/tokens",
         ),
@@ -424,31 +424,31 @@ def jobs_uv_run(
         ),
     ],
     script_args: Annotated[
-        list[str],
+        Optional[List[str]],
         typer.Argument(
             help="Arguments for the script",
         ),
     ] = None,
     image: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="Use a custom Docker image with `uv` installed.",
         ),
     ] = None,
     repo: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="Repository name for the script (creates ephemeral if not specified)",
         ),
     ] = None,
     flavor: Annotated[
-        str,
+        Optional[SpaceHardware],
         typer.Option(
             help=f"Flavor for the hardware, as in HF Spaces. Defaults to `cpu-basic`. Possible values: {', '.join(SUGGESTED_FLAVORS)}.",
         ),
     ] = None,
     env: Annotated[
-        list[str],
+        Optional[List[str]],
         typer.Option(
             "-e",
             "--env",
@@ -456,7 +456,7 @@ def jobs_uv_run(
         ),
     ] = None,
     secrets: Annotated[
-        list[str],
+        Optional[List[str]],
         typer.Option(
             "-s",
             "--secrets",
@@ -464,21 +464,21 @@ def jobs_uv_run(
         ),
     ] = None,
     env_file: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             "--env-file",
             help="Read in a file of environment variables.",
         ),
     ] = None,
     secrets_file: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             "--secrets-file",
             help="Read in a file of secret environment variables.",
         ),
     ] = None,
     timeout: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             "--timeout",
             help="Max duration (e.g., 30s, 5m, 1h)",
@@ -493,28 +493,28 @@ def jobs_uv_run(
         ),
     ] = False,
     namespace: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             "--namespace",
             help="The namespace where the Job will be created. Defaults to the current user's namespace.",
         ),
     ] = None,
     token: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             "--token",
             help="HF token",
         ),
     ] = None,
     with_: Annotated[
-        list[str],
+        Optional[List[str]],
         typer.Option(
             "--with",
             help="Run with the given packages installed",
         ),
     ] = None,
     python: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             "-p",
             "--python",
@@ -580,26 +580,26 @@ def scheduled_run(
         ),
     ],
     command: Annotated[
-        list[str],
+        List[str],
         typer.Argument(
             ...,
             help="The command to run.",
         ),
     ],
     suspend: Annotated[
-        bool,
+        Optional[bool],
         typer.Option(
             help="Suspend (pause) the scheduled Job",
         ),
     ] = None,
     concurrency: Annotated[
-        bool,
+        Optional[bool],
         typer.Option(
             help="Allow multiple instances of this Job to run concurrently",
         ),
     ] = None,
     env: Annotated[
-        list[str],
+        Optional[List[str]],
         typer.Option(
             "-e",
             "--env",
@@ -607,7 +607,7 @@ def scheduled_run(
         ),
     ] = None,
     secrets: Annotated[
-        list[str],
+        Optional[List[str]],
         typer.Option(
             "-s",
             "--secrets",
@@ -615,37 +615,37 @@ def scheduled_run(
         ),
     ] = None,
     env_file: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="Read in a file of environment variables.",
         ),
     ] = None,
     secrets_file: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="Read in a file of secret environment variables.",
         ),
     ] = None,
     flavor: Annotated[
-        str,
+        Optional[SpaceHardware],
         typer.Option(
             help=f"Flavor for the hardware, as in HF Spaces. Defaults to `cpu-basic`. Possible values: {', '.join(SUGGESTED_FLAVORS)}.",
         ),
     ] = None,
     timeout: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="Max duration: int/float with s (seconds, default), m (minutes), h (hours) or d (days).",
         ),
     ] = None,
     namespace: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="The namespace where the scheduled Job will be created. Defaults to the current user's namespace.",
         ),
     ] = None,
     token: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="A User Access Token generated from https://huggingface.co/settings/tokens",
         ),
@@ -690,19 +690,19 @@ def scheduled_ps(
         ),
     ] = False,
     namespace: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="The namespace from where it lists the jobs. Defaults to the current user's namespace.",
         ),
     ] = None,
     token: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="A User Access Token generated from https://huggingface.co/settings/tokens",
         ),
     ] = None,
     filter: Annotated[
-        list[str],
+        Optional[List[str]],
         typer.Option(
             "-f",
             "--filter",
@@ -710,7 +710,7 @@ def scheduled_ps(
         ),
     ] = None,
     format: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             "--format",
             help="Format output using a custom template",
@@ -773,21 +773,21 @@ def scheduled_ps(
 @scheduled_app.command("inspect", help="Display detailed information on one or more scheduled Jobs")
 def scheduled_inspect(
     scheduled_job_ids: Annotated[
-        list[str],
+        List[str],
         typer.Argument(
             ...,
             help="The scheduled jobs to inspect",
         ),
     ],
     namespace: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             "--namespace",
             help="The namespace where the scheduled job is. Defaults to the current user's namespace.",
         ),
     ] = None,
     token: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             "--token",
             help="A User Access Token generated from https://huggingface.co/settings/tokens",
@@ -812,13 +812,13 @@ def scheduled_delete(
         ),
     ],
     namespace: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="The namespace where the scheduled job is. Defaults to the current user's namespace.",
         ),
     ] = None,
     token: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="A User Access Token generated from https://huggingface.co/settings/tokens",
         ),
@@ -838,14 +838,14 @@ def scheduled_suspend(
         ),
     ],
     namespace: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             "--namespace",
             help="The namespace where the scheduled job is. Defaults to the current user's namespace.",
         ),
     ] = None,
     token: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             "--token",
             help="A User Access Token generated from https://huggingface.co/settings/tokens",
@@ -866,14 +866,14 @@ def scheduled_resume(
         ),
     ],
     namespace: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             "--namespace",
             help="The namespace where the scheduled job is. Defaults to the current user's namespace.",
         ),
     ] = None,
     token: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             "--token",
             help="A User Access Token generated from https://huggingface.co/settings/tokens",
@@ -907,46 +907,46 @@ def scheduled_uv_run(
         ),
     ],
     script_args: Annotated[
-        list[str],
+        Optional[List[str]],
         typer.Argument(
             help="Arguments for the script",
         ),
     ] = None,
     suspend: Annotated[
-        bool,
+        Optional[bool],
         typer.Option(
             help="Suspend (pause) the scheduled Job",
         ),
     ] = None,
     concurrency: Annotated[
-        bool,
+        Optional[bool],
         typer.Option(
             help="Allow multiple instances of this Job to run concurrently",
         ),
     ] = None,
     image: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             "--image",
             help="Use a custom Docker image with `uv` installed.",
         ),
     ] = None,
     repo: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             "--repo",
             help="Repository name for the script (creates ephemeral if not specified)",
         ),
     ] = None,
     flavor: Annotated[
-        str,
+        Optional[SpaceHardware],
         typer.Option(
             "--flavor",
             help=f"Flavor for the hardware, as in HF Spaces. Defaults to `cpu-basic`. Possible values: {', '.join(SUGGESTED_FLAVORS)}. ",
         ),
     ] = None,
     env: Annotated[
-        list[str],
+        Optional[List[str]],
         typer.Option(
             "-e",
             "--env",
@@ -954,7 +954,7 @@ def scheduled_uv_run(
         ),
     ] = None,
     secrets: Annotated[
-        list[str],
+        Optional[List[str]],
         typer.Option(
             "-s",
             "--secrets",
@@ -962,45 +962,45 @@ def scheduled_uv_run(
         ),
     ] = None,
     env_file: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             "--env-file",
             help="Read in a file of environment variables.",
         ),
     ] = None,
     secrets_file: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="Read in a file of secret environment variables.",
         ),
     ] = None,
     timeout: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="Max duration (e.g., 30s, 5m, 1h)",
         ),
     ] = None,
     namespace: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="The namespace where the Job will be created. Defaults to the current user's namespace.",
         ),
     ] = None,
     token: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="HF token",
         ),
     ] = None,
     with_: Annotated[
-        list[str],
+        Optional[List[str]],
         typer.Option(
             "--with",
             help="Run with the given packages installed",
         ),
     ] = None,
     python: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             "-p",
             "--python",

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -61,7 +61,7 @@ from typing import Annotated, Dict, Optional, Union
 
 import typer
 
-from huggingface_hub import HfApi, SpaceHardware, get_token
+from huggingface_hub import HfApi, SpaceHardware, __version__, get_token
 from huggingface_hub.errors import HfHubHTTPError
 from huggingface_hub.utils import logging
 from huggingface_hub.utils._dotenv import load_dotenv
@@ -165,7 +165,7 @@ def jobs_run(
     for secret in secrets or []:
         secrets_map.update(load_dotenv(secret, environ=extended_environ))
 
-    api = HfApi(token=token)
+    api = HfApi(token=token, library_name="hf", library_version=__version__)
     job = api.run_job(
         image=image,
         command=command,
@@ -203,7 +203,7 @@ def jobs_logs(
     ] = None,
     token: TokenOpt = None,
 ) -> None:
-    api = HfApi(token=token)
+    api = HfApi(token=token, library_name="hf", library_version=__version__)
     for log in api.fetch_job_logs(job_id=job_id, namespace=namespace):
         print(log)
 
@@ -276,7 +276,7 @@ def jobs_ps(
     ] = None,
 ) -> None:
     try:
-        api = HfApi(token=token)
+        api = HfApi(token=token, library_name="hf", library_version=__version__)
         # Fetch jobs data
         jobs = api.list_jobs(namespace=namespace)
         # Define table headers
@@ -352,7 +352,7 @@ def jobs_inspect(
     ] = None,
     token: TokenOpt = None,
 ) -> None:
-    api = HfApi(token=token)
+    api = HfApi(token=token, library_name="hf", library_version=__version__)
     jobs = [api.inspect_job(job_id=job_id, namespace=namespace) for job_id in job_ids]
     print(json.dumps([asdict(job) for job in jobs], indent=4, default=str))
 
@@ -373,7 +373,7 @@ def jobs_cancel(
     ] = None,
     token: TokenOpt = None,
 ) -> None:
-    api = HfApi(token=token)
+    api = HfApi(token=token, library_name="hf", library_version=__version__)
     api.cancel_job(job_id=job_id, namespace=namespace)
 
 
@@ -495,7 +495,7 @@ def jobs_uv_run(
     for secret in secrets or []:
         secrets_map.update(load_dotenv(secret, environ=extended_environ))
 
-    api = HfApi(token=token)
+    api = HfApi(token=token, library_name="hf", library_version=__version__)
     job = api.run_uv_job(
         script=script,
         script_args=script_args or [],
@@ -615,7 +615,7 @@ def scheduled_run(
     for secret in secrets or []:
         secrets_map.update(load_dotenv(secret, environ=extended_environ))
 
-    api = HfApi(token=token)
+    api = HfApi(token=token, library_name="hf", library_version=__version__)
     scheduled_job = api.create_scheduled_job(
         image=image,
         command=command,
@@ -665,7 +665,7 @@ def scheduled_ps(
     ] = None,
 ) -> None:
     try:
-        api = HfApi(token=token)
+        api = HfApi(token=token, library_name="hf", library_version=__version__)
         scheduled_jobs = api.list_scheduled_jobs(namespace=namespace)
         table_headers = ["ID", "SCHEDULE", "IMAGE/SPACE", "COMMAND", "LAST RUN", "NEXT RUN", "SUSPEND"]
         rows: list[list[Union[str, int]]] = []
@@ -734,7 +734,7 @@ def scheduled_inspect(
     ] = None,
     token: TokenOpt = None,
 ) -> None:
-    api = HfApi(token=token)
+    api = HfApi(token=token, library_name="hf", library_version=__version__)
     scheduled_jobs = [
         api.inspect_scheduled_job(scheduled_job_id=scheduled_job_id, namespace=namespace)
         for scheduled_job_id in scheduled_job_ids
@@ -758,7 +758,7 @@ def scheduled_delete(
     ] = None,
     token: TokenOpt = None,
 ) -> None:
-    api = HfApi(token=token)
+    api = HfApi(token=token, library_name="hf", library_version=__version__)
     api.delete_scheduled_job(scheduled_job_id=scheduled_job_id, namespace=namespace)
 
 
@@ -779,7 +779,7 @@ def scheduled_suspend(
     ] = None,
     token: TokenOpt = None,
 ) -> None:
-    api = HfApi(token=token)
+    api = HfApi(token=token, library_name="hf", library_version=__version__)
     api.suspend_scheduled_job(scheduled_job_id=scheduled_job_id, namespace=namespace)
 
 
@@ -800,7 +800,7 @@ def scheduled_resume(
     ] = None,
     token: TokenOpt = None,
 ) -> None:
-    api = HfApi(token=token)
+    api = HfApi(token=token, library_name="hf", library_version=__version__)
     api.resume_scheduled_job(scheduled_job_id=scheduled_job_id, namespace=namespace)
 
 
@@ -932,7 +932,7 @@ def scheduled_uv_run(
     for secret in secrets or []:
         secrets_map.update(load_dotenv(secret, environ=extended_environ))
 
-    api = HfApi(token=token)
+    api = HfApi(token=token, library_name="hf", library_version=__version__)
     job = api.create_scheduled_uv_job(
         script=script,
         script_args=script_args or [],

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -731,11 +731,11 @@ def scheduled_ps(
                 print(f"Warning: Ignoring invalid filter format '{f}'. Use key=value format.")
 
         for scheduled_job in scheduled_jobs:
-            suspend = scheduled_job.suspend
+            suspend = scheduled_job.suspend or False
             if not all and suspend:
                 continue
             sj_id = scheduled_job.id
-            schedule = scheduled_job.schedule
+            schedule = scheduled_job.schedule or "N/A"
             image_or_space = scheduled_job.job_spec.docker_image or "N/A"
             cmd = scheduled_job.job_spec.command or []
             command_str = " ".join(cmd) if cmd else "N/A"

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -82,14 +82,12 @@ def jobs_run(
     image: Annotated[
         str,
         typer.Argument(
-            ...,
             help="The Docker image to use.",
         ),
     ],
     command: Annotated[
         list[str],
         typer.Argument(
-            ...,
             help="The command to run.",
         ),
     ],
@@ -199,7 +197,6 @@ def jobs_logs(
     job_id: Annotated[
         str,
         typer.Argument(
-            ...,
             help="Job ID",
         ),
     ],
@@ -361,7 +358,6 @@ def jobs_inspect(
     job_ids: Annotated[
         list[str],
         typer.Argument(
-            ...,
             help="The jobs to inspect",
         ),
     ],
@@ -388,7 +384,6 @@ def jobs_cancel(
     job_id: Annotated[
         str,
         typer.Argument(
-            ...,
             help="Job ID",
         ),
     ],
@@ -418,7 +413,6 @@ def jobs_uv_run(
     script: Annotated[
         str,
         typer.Argument(
-            ...,
             help="UV script to run (local file or URL)",
         ),
     ],
@@ -567,21 +561,18 @@ def scheduled_run(
     schedule: Annotated[
         str,
         typer.Argument(
-            ...,
             help="One of annually, yearly, monthly, weekly, daily, hourly, or a CRON schedule expression.",
         ),
     ],
     image: Annotated[
         str,
         typer.Argument(
-            ...,
             help="The Docker image to use.",
         ),
     ],
     command: Annotated[
         list[str],
         typer.Argument(
-            ...,
             help="The command to run.",
         ),
     ],
@@ -774,7 +765,6 @@ def scheduled_inspect(
     scheduled_job_ids: Annotated[
         list[str],
         typer.Argument(
-            ...,
             help="The scheduled jobs to inspect",
         ),
     ],
@@ -806,7 +796,6 @@ def scheduled_delete(
     scheduled_job_id: Annotated[
         str,
         typer.Argument(
-            ...,
             help="Scheduled Job ID",
         ),
     ],
@@ -832,7 +821,6 @@ def scheduled_suspend(
     scheduled_job_id: Annotated[
         str,
         typer.Argument(
-            ...,
             help="Scheduled Job ID",
         ),
     ],
@@ -860,7 +848,6 @@ def scheduled_resume(
     scheduled_job_id: Annotated[
         str,
         typer.Argument(
-            ...,
             help="Scheduled Job ID",
         ),
     ],
@@ -892,14 +879,12 @@ def scheduled_uv_run(
     schedule: Annotated[
         str,
         typer.Argument(
-            ...,
             help="One of annually, yearly, monthly, weekly, daily, hourly, or a CRON schedule expression.",
         ),
     ],
     script: Annotated[
         str,
         typer.Argument(
-            ...,
             help="UV script to run (local file or URL)",
         ),
     ],

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -73,10 +73,10 @@ logger = logging.get_logger(__name__)
 SUGGESTED_FLAVORS = [item.value for item in SpaceHardware if item.value != "zero-a10g"]
 
 
-jobs_app = typer.Typer(help="Run and manage Jobs on the Hub.", rich_markup_mode=None)
+jobs_cli = typer.Typer(help="Run and manage Jobs on the Hub.", rich_markup_mode=None)
 
 
-@jobs_app.command("run", help="Run a Job")
+@jobs_cli.command("run", help="Run a Job")
 def jobs_run(
     image: Annotated[
         str,
@@ -193,7 +193,7 @@ def jobs_run(
         print(log)
 
 
-@jobs_app.command("logs", help="Fetch the logs of a Job")
+@jobs_cli.command("logs", help="Fetch the logs of a Job")
 def jobs_logs(
     job_id: Annotated[
         str,
@@ -257,7 +257,7 @@ def _print_output(rows: list[list[Union[str, int]]], headers: list[str], fmt: Op
         print(_tabulate(rows, headers=headers))
 
 
-@jobs_app.command("ps", help="List Jobs")
+@jobs_cli.command("ps", help="List Jobs")
 def jobs_ps(
     all: Annotated[
         bool,
@@ -355,7 +355,7 @@ def jobs_ps(
         print(f"Unexpected error - {type(e).__name__}: {e}")
 
 
-@jobs_app.command("inspect", help="Display detailed information on one or more Jobs")
+@jobs_cli.command("inspect", help="Display detailed information on one or more Jobs")
 def jobs_inspect(
     job_ids: Annotated[
         list[str],
@@ -382,7 +382,7 @@ def jobs_inspect(
     print(json.dumps([asdict(job) for job in jobs], indent=4, default=str))
 
 
-@jobs_app.command("cancel", help="Cancel a Job")
+@jobs_cli.command("cancel", help="Cancel a Job")
 def jobs_cancel(
     job_id: Annotated[
         str,
@@ -411,7 +411,7 @@ def jobs_cancel(
 uv_app = typer.Typer(
     help="Run UV scripts (Python with inline dependencies) on HF infrastructure", rich_markup_mode=None
 )
-jobs_app.add_typer(uv_app, name="uv")
+jobs_cli.add_typer(uv_app, name="uv")
 
 
 @uv_app.command("run", help="Run a UV script (local file or URL) on HF infrastructure")
@@ -560,7 +560,7 @@ def jobs_uv_run(
 
 
 scheduled_app = typer.Typer(help="Create and manage scheduled Jobs on the Hub.", rich_markup_mode=None)
-jobs_app.add_typer(scheduled_app, name="scheduled")
+jobs_cli.add_typer(scheduled_app, name="scheduled")
 
 
 @scheduled_app.command("run", help="Schedule a Job")

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -57,10 +57,9 @@ import os
 import re
 from dataclasses import asdict
 from pathlib import Path
-from typing import Dict, Optional, Union
+from typing import Annotated, Dict, Optional, Union
 
 import typer
-from typing_extensions import Annotated
 
 from huggingface_hub import HfApi, SpaceHardware, get_token
 from huggingface_hub.errors import HfHubHTTPError

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -57,7 +57,7 @@ import os
 import re
 from dataclasses import asdict
 from pathlib import Path
-from typing import Dict, List, Optional, Union
+from typing import Dict, Optional, Union
 
 import typer
 from typing_extensions import Annotated
@@ -93,7 +93,7 @@ def jobs_run(
         ),
     ],
     env: Annotated[
-        Optional[List[str]],
+        Optional[list[str]],
         typer.Option(
             "-e",
             "--env",
@@ -101,7 +101,7 @@ def jobs_run(
         ),
     ] = None,
     secrets: Annotated[
-        Optional[List[str]],
+        Optional[list[str]],
         typer.Option(
             "-s",
             "--secrets",
@@ -280,7 +280,7 @@ def jobs_ps(
         ),
     ] = None,
     filter: Annotated[
-        Optional[List[str]],
+        Optional[list[str]],
         typer.Option(
             "-f",
             "--filter",
@@ -424,7 +424,7 @@ def jobs_uv_run(
         ),
     ],
     script_args: Annotated[
-        Optional[List[str]],
+        Optional[list[str]],
         typer.Argument(
             help="Arguments for the script",
         ),
@@ -448,7 +448,7 @@ def jobs_uv_run(
         ),
     ] = None,
     env: Annotated[
-        Optional[List[str]],
+        Optional[list[str]],
         typer.Option(
             "-e",
             "--env",
@@ -456,7 +456,7 @@ def jobs_uv_run(
         ),
     ] = None,
     secrets: Annotated[
-        Optional[List[str]],
+        Optional[list[str]],
         typer.Option(
             "-s",
             "--secrets",
@@ -507,7 +507,7 @@ def jobs_uv_run(
         ),
     ] = None,
     with_: Annotated[
-        Optional[List[str]],
+        Optional[list[str]],
         typer.Option(
             "--with",
             help="Run with the given packages installed",
@@ -580,7 +580,7 @@ def scheduled_run(
         ),
     ],
     command: Annotated[
-        List[str],
+        list[str],
         typer.Argument(
             ...,
             help="The command to run.",
@@ -599,7 +599,7 @@ def scheduled_run(
         ),
     ] = None,
     env: Annotated[
-        Optional[List[str]],
+        Optional[list[str]],
         typer.Option(
             "-e",
             "--env",
@@ -607,7 +607,7 @@ def scheduled_run(
         ),
     ] = None,
     secrets: Annotated[
-        Optional[List[str]],
+        Optional[list[str]],
         typer.Option(
             "-s",
             "--secrets",
@@ -702,7 +702,7 @@ def scheduled_ps(
         ),
     ] = None,
     filter: Annotated[
-        Optional[List[str]],
+        Optional[list[str]],
         typer.Option(
             "-f",
             "--filter",
@@ -773,7 +773,7 @@ def scheduled_ps(
 @scheduled_app.command("inspect", help="Display detailed information on one or more scheduled Jobs")
 def scheduled_inspect(
     scheduled_job_ids: Annotated[
-        List[str],
+        list[str],
         typer.Argument(
             ...,
             help="The scheduled jobs to inspect",
@@ -907,7 +907,7 @@ def scheduled_uv_run(
         ),
     ],
     script_args: Annotated[
-        Optional[List[str]],
+        Optional[list[str]],
         typer.Argument(
             help="Arguments for the script",
         ),
@@ -946,7 +946,7 @@ def scheduled_uv_run(
         ),
     ] = None,
     env: Annotated[
-        Optional[List[str]],
+        Optional[list[str]],
         typer.Option(
             "-e",
             "--env",
@@ -954,7 +954,7 @@ def scheduled_uv_run(
         ),
     ] = None,
     secrets: Annotated[
-        Optional[List[str]],
+        Optional[list[str]],
         typer.Option(
             "-s",
             "--secrets",
@@ -993,7 +993,7 @@ def scheduled_uv_run(
         ),
     ] = None,
     with_: Annotated[
-        Optional[List[str]],
+        Optional[list[str]],
         typer.Option(
             "--with",
             help="Run with the given packages installed",

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -60,6 +60,7 @@ from pathlib import Path
 from typing import Dict, Optional, Union
 
 import typer
+from typing_extensions import Annotated
 
 from huggingface_hub import HfApi, SpaceHardware, get_token
 from huggingface_hub.errors import HfHubHTTPError
@@ -77,62 +78,86 @@ jobs_app = typer.Typer(help="Run and manage Jobs on the Hub.", rich_markup_mode=
 
 @jobs_app.command("run", help="Run a Job")
 def jobs_run(
-    image: str = typer.Argument(
-        ...,
-        help="The Docker image to use.",
-    ),
-    command: list[str] = typer.Argument(
-        ...,
-        help="The command to run.",
-    ),
-    env: Optional[list[str]] = typer.Option(
-        None,
-        "-e",
-        "--env",
-        help="Set environment variables. E.g. --env ENV=value",
-    ),
-    secrets: Optional[list[str]] = typer.Option(
-        None,
-        "-s",
-        "--secrets",
-        help="Set secret environment variables. E.g. --secrets SECRET=value or `--secrets HF_TOKEN` to pass your Hugging Face token.",
-    ),
-    env_file: Optional[str] = typer.Option(
-        None,
-        "--env-file",
-        help="Read in a file of environment variables.",
-    ),
-    secrets_file: Optional[str] = typer.Option(
-        None,
-        "--secrets-file",
-        help="Read in a file of secret environment variables.",
-    ),
-    flavor: Optional[str] = typer.Option(
-        None,
-        "--flavor",
-        help=f"Flavor for the hardware, as in HF Spaces. Defaults to `cpu-basic`. Possible values: {', '.join(SUGGESTED_FLAVORS)}.",
-    ),
-    timeout: Optional[str] = typer.Option(
-        None,
-        "--timeout",
-        help="Max duration: int/float with s (seconds, default), m (minutes), h (hours) or d (days).",
-    ),
-    detach: bool = typer.Option(
-        False,
-        "-d",
-        "--detach",
-        help="Run the Job in the background and print the Job ID.",
-    ),
-    namespace: Optional[str] = typer.Option(
-        None,
-        "--namespace",
-        help="The namespace where the Job will be created. Defaults to the current user's namespace.",
-    ),
-    token: Optional[str] = typer.Option(
-        None,
-        "--token",
-        help="A User Access Token generated from https://huggingface.co/settings/tokens",
-    ),
+    image: Annotated[
+        str,
+        typer.Argument(
+            ...,
+            help="The Docker image to use.",
+        ),
+    ],
+    command: Annotated[
+        list[str],
+        typer.Argument(
+            ...,
+            help="The command to run.",
+        ),
+    ],
+    env: Annotated[
+        list[str],
+        typer.Option(
+            "-e",
+            "--env",
+            help="Set environment variables. E.g. --env ENV=value",
+        ),
+    ] = None,
+    secrets: Annotated[
+        list[str],
+        typer.Option(
+            "-s",
+            "--secrets",
+            help="Set secret environment variables. E.g. --secrets SECRET=value or `--secrets HF_TOKEN` to pass your Hugging Face token.",
+        ),
+    ] = None,
+    env_file: Annotated[
+        str,
+        typer.Option(
+            "--env-file",
+            help="Read in a file of environment variables.",
+        ),
+    ] = None,
+    secrets_file: Annotated[
+        str,
+        typer.Option(
+            "--secrets-file",
+            help="Read in a file of secret environment variables.",
+        ),
+    ] = None,
+    flavor: Annotated[
+        str,
+        typer.Option(
+            "--flavor",
+            help=f"Flavor for the hardware, as in HF Spaces. Defaults to `cpu-basic`. Possible values: {', '.join(SUGGESTED_FLAVORS)}.",
+        ),
+    ] = None,
+    timeout: Annotated[
+        str,
+        typer.Option(
+            "--timeout",
+            help="Max duration: int/float with s (seconds, default), m (minutes), h (hours) or d (days).",
+        ),
+    ] = None,
+    detach: Annotated[
+        bool,
+        typer.Option(
+            "-d",
+            "--detach",
+            help="Run the Job in the background and print the Job ID.",
+        ),
+    ] = False,
+    namespace: Annotated[
+        str,
+        typer.Option(
+            "--namespace",
+            help="The namespace where the Job will be created. Defaults to the current user's namespace.",
+        ),
+    ] = None,
+    token: Annotated[
+        str,
+        typer.Option(
+            "--token",
+            help="A User Access Token generated from https://huggingface.co/settings/tokens",
+        ),
+    ] = None,
 ) -> None:
     env_map: dict[str, Optional[str]] = {}
     if env_file:
@@ -170,20 +195,27 @@ def jobs_run(
 
 @jobs_app.command("logs", help="Fetch the logs of a Job")
 def jobs_logs(
-    job_id: str = typer.Argument(
-        ...,
-        help="Job ID",
-    ),
-    namespace: Optional[str] = typer.Option(
-        None,
-        "--namespace",
-        help="The namespace where the job is running. Defaults to the current user's namespace.",
-    ),
-    token: Optional[str] = typer.Option(
-        None,
-        "--token",
-        help="A User Access Token generated from https://huggingface.co/settings/tokens",
-    ),
+    job_id: Annotated[
+        str,
+        typer.Argument(
+            ...,
+            help="Job ID",
+        ),
+    ],
+    namespace: Annotated[
+        str,
+        typer.Option(
+            "--namespace",
+            help="The namespace where the job is running. Defaults to the current user's namespace.",
+        ),
+    ] = None,
+    token: Annotated[
+        str,
+        typer.Option(
+            "--token",
+            help="A User Access Token generated from https://huggingface.co/settings/tokens",
+        ),
+    ] = None,
 ) -> None:
     api = HfApi(token=token)
     for log in api.fetch_job_logs(job_id=job_id, namespace=namespace):
@@ -227,33 +259,40 @@ def _print_output(rows: list[list[Union[str, int]]], headers: list[str], fmt: Op
 
 @jobs_app.command("ps", help="List Jobs")
 def jobs_ps(
-    all: bool = typer.Option(
-        False,
-        "-a",
-        "--all",
-        help="Show all Jobs (default shows just running)",
-    ),
-    namespace: Optional[str] = typer.Option(
-        None,
-        "--namespace",
-        help="The namespace from where it lists the jobs. Defaults to the current user's namespace.",
-    ),
-    token: Optional[str] = typer.Option(
-        None,
-        "--token",
-        help="A User Access Token generated from https://huggingface.co/settings/tokens",
-    ),
-    filter: Optional[list[str]] = typer.Option(
-        None,
-        "-f",
-        "--filter",
-        help="Filter output based on conditions provided (format: key=value)",
-    ),
-    format: Optional[str] = typer.Option(
-        None,
-        "--format",
-        help="Format output using a custom template",
-    ),
+    all: Annotated[
+        bool,
+        typer.Option(
+            "-a",
+            "--all",
+            help="Show all Jobs (default shows just running)",
+        ),
+    ] = False,
+    namespace: Annotated[
+        str,
+        typer.Option(
+            help="The namespace from where it lists the jobs. Defaults to the current user's namespace.",
+        ),
+    ] = None,
+    token: Annotated[
+        str,
+        typer.Option(
+            help="A User Access Token generated from https://huggingface.co/settings/tokens",
+        ),
+    ] = None,
+    filter: Annotated[
+        list[str],
+        typer.Option(
+            "-f",
+            "--filter",
+            help="Filter output based on conditions provided (format: key=value)",
+        ),
+    ] = None,
+    format: Annotated[
+        str,
+        typer.Option(
+            help="Format output using a custom template",
+        ),
+    ] = None,
 ) -> None:
     try:
         api = HfApi(token=token)
@@ -318,20 +357,25 @@ def jobs_ps(
 
 @jobs_app.command("inspect", help="Display detailed information on one or more Jobs")
 def jobs_inspect(
-    job_ids: list[str] = typer.Argument(
-        ...,
-        help="The jobs to inspect",
-    ),
-    namespace: Optional[str] = typer.Option(
-        None,
-        "--namespace",
-        help="The namespace where the job is running. Defaults to the current user's namespace.",
-    ),
-    token: Optional[str] = typer.Option(
-        None,
-        "--token",
-        help="A User Access Token generated from https://huggingface.co/settings/tokens",
-    ),
+    job_ids: Annotated[
+        list[str],
+        typer.Argument(
+            ...,
+            help="The jobs to inspect",
+        ),
+    ],
+    namespace: Annotated[
+        str,
+        typer.Option(
+            help="The namespace where the job is running. Defaults to the current user's namespace.",
+        ),
+    ] = None,
+    token: Annotated[
+        str,
+        typer.Option(
+            help="A User Access Token generated from https://huggingface.co/settings/tokens",
+        ),
+    ] = None,
 ) -> None:
     api = HfApi(token=token)
     jobs = [api.inspect_job(job_id=job_id, namespace=namespace) for job_id in job_ids]
@@ -340,20 +384,25 @@ def jobs_inspect(
 
 @jobs_app.command("cancel", help="Cancel a Job")
 def jobs_cancel(
-    job_id: str = typer.Argument(
-        ...,
-        help="Job ID",
-    ),
-    namespace: Optional[str] = typer.Option(
-        None,
-        "--namespace",
-        help="The namespace where the job is running. Defaults to the current user's namespace.",
-    ),
-    token: Optional[str] = typer.Option(
-        None,
-        "--token",
-        help="A User Access Token generated from https://huggingface.co/settings/tokens",
-    ),
+    job_id: Annotated[
+        str,
+        typer.Argument(
+            ...,
+            help="Job ID",
+        ),
+    ],
+    namespace: Annotated[
+        str,
+        typer.Option(
+            help="The namespace where the job is running. Defaults to the current user's namespace.",
+        ),
+    ] = None,
+    token: Annotated[
+        str,
+        typer.Option(
+            help="A User Access Token generated from https://huggingface.co/settings/tokens",
+        ),
+    ] = None,
 ) -> None:
     api = HfApi(token=token)
     api.cancel_job(job_id=job_id, namespace=namespace)
@@ -367,83 +416,111 @@ jobs_app.add_typer(uv_app, name="uv")
 
 @uv_app.command("run", help="Run a UV script (local file or URL) on HF infrastructure")
 def jobs_uv_run(
-    script: str = typer.Argument(
-        ...,
-        help="UV script to run (local file or URL)",
-    ),
-    script_args: Optional[list[str]] = typer.Argument(
-        None,
-        help="Arguments for the script",
-    ),
-    image: Optional[str] = typer.Option(
-        None,
-        "--image",
-        help="Use a custom Docker image with `uv` installed.",
-    ),
-    repo: Optional[str] = typer.Option(
-        None,
-        "--repo",
-        help="Repository name for the script (creates ephemeral if not specified)",
-    ),
-    flavor: Optional[str] = typer.Option(
-        None,
-        "--flavor",
-        help=f"Flavor for the hardware, as in HF Spaces. Defaults to `cpu-basic`. Possible values: {', '.join(SUGGESTED_FLAVORS)}.",
-    ),
-    env: Optional[list[str]] = typer.Option(
-        None,
-        "-e",
-        "--env",
-        help="Environment variables",
-    ),
-    secrets: Optional[list[str]] = typer.Option(
-        None,
-        "-s",
-        "--secrets",
-        help="Set secret environment variables. E.g. --secrets SECRET=value or `--secrets HF_TOKEN` to pass your Hugging Face token.",
-    ),
-    env_file: Optional[str] = typer.Option(
-        None,
-        "--env-file",
-        help="Read in a file of environment variables.",
-    ),
-    secrets_file: Optional[str] = typer.Option(
-        None,
-        "--secrets-file",
-        help="Read in a file of secret environment variables.",
-    ),
-    timeout: Optional[str] = typer.Option(
-        None,
-        "--timeout",
-        help="Max duration (e.g., 30s, 5m, 1h)",
-    ),
-    detach: bool = typer.Option(
-        False,
-        "-d",
-        "--detach",
-        help="Run in background",
-    ),
-    namespace: Optional[str] = typer.Option(
-        None,
-        "--namespace",
-        help="The namespace where the Job will be created. Defaults to the current user's namespace.",
-    ),
-    token: Optional[str] = typer.Option(
-        None,
-        "--token",
-        help="HF token",
-    ),
-    with_: Optional[list[str]] = typer.Option(
-        None,
-        "--with",
-        help="Run with the given packages installed",
-    ),
-    python: Optional[str] = typer.Option(
-        None,
-        "-p",
-        "--python",
-        help="The Python interpreter to use for the run environment",
-    ),
+    script: Annotated[
+        str,
+        typer.Argument(
+            ...,
+            help="UV script to run (local file or URL)",
+        ),
+    ],
+    script_args: Annotated[
+        list[str],
+        typer.Argument(
+            help="Arguments for the script",
+        ),
+    ] = None,
+    image: Annotated[
+        str,
+        typer.Option(
+            help="Use a custom Docker image with `uv` installed.",
+        ),
+    ] = None,
+    repo: Annotated[
+        str,
+        typer.Option(
+            help="Repository name for the script (creates ephemeral if not specified)",
+        ),
+    ] = None,
+    flavor: Annotated[
+        str,
+        typer.Option(
+            help=f"Flavor for the hardware, as in HF Spaces. Defaults to `cpu-basic`. Possible values: {', '.join(SUGGESTED_FLAVORS)}.",
+        ),
+    ] = None,
+    env: Annotated[
+        list[str],
+        typer.Option(
+            "-e",
+            "--env",
+            help="Environment variables",
+        ),
+    ] = None,
+    secrets: Annotated[
+        list[str],
+        typer.Option(
+            "-s",
+            "--secrets",
+            help="Set secret environment variables. E.g. --secrets SECRET=value or `--secrets HF_TOKEN` to pass your Hugging Face token.",
+        ),
+    ] = None,
+    env_file: Annotated[
+        str,
+        typer.Option(
+            "--env-file",
+            help="Read in a file of environment variables.",
+        ),
+    ] = None,
+    secrets_file: Annotated[
+        str,
+        typer.Option(
+            "--secrets-file",
+            help="Read in a file of secret environment variables.",
+        ),
+    ] = None,
+    timeout: Annotated[
+        str,
+        typer.Option(
+            "--timeout",
+            help="Max duration (e.g., 30s, 5m, 1h)",
+        ),
+    ] = None,
+    detach: Annotated[
+        bool,
+        typer.Option(
+            "-d",
+            "--detach",
+            help="Run in background",
+        ),
+    ] = False,
+    namespace: Annotated[
+        str,
+        typer.Option(
+            "--namespace",
+            help="The namespace where the Job will be created. Defaults to the current user's namespace.",
+        ),
+    ] = None,
+    token: Annotated[
+        str,
+        typer.Option(
+            "--token",
+            help="HF token",
+        ),
+    ] = None,
+    with_: Annotated[
+        list[str],
+        typer.Option(
+            "--with",
+            help="Run with the given packages installed",
+        ),
+    ] = None,
+    python: Annotated[
+        str,
+        typer.Option(
+            "-p",
+            "--python",
+            help="The Python interpreter to use for the run environment",
+        ),
+    ] = None,
 ) -> None:
     logging.set_verbosity(logging.INFO)
     env_map: dict[str, Optional[str]] = {}
@@ -488,70 +565,91 @@ jobs_app.add_typer(scheduled_app, name="scheduled")
 
 @scheduled_app.command("run", help="Schedule a Job")
 def scheduled_run(
-    schedule: str = typer.Argument(
-        ...,
-        help="One of annually, yearly, monthly, weekly, daily, hourly, or a CRON schedule expression.",
-    ),
-    image: str = typer.Argument(
-        ...,
-        help="The Docker image to use.",
-    ),
-    command: list[str] = typer.Argument(
-        ...,
-        help="The command to run.",
-    ),
-    suspend: Optional[bool] = typer.Option(
-        None,
-        "--suspend",
-        help="Suspend (pause) the scheduled Job",
-    ),
-    concurrency: Optional[bool] = typer.Option(
-        None,
-        "--concurrency",
-        help="Allow multiple instances of this Job to run concurrently",
-    ),
-    env: Optional[list[str]] = typer.Option(
-        None,
-        "-e",
-        "--env",
-        help="Set environment variables. E.g. --env ENV=value",
-    ),
-    secrets: Optional[list[str]] = typer.Option(
-        None,
-        "-s",
-        "--secrets",
-        help="Set secret environment variables. E.g. --secrets SECRET=value or `--secrets HF_TOKEN` to pass your Hugging Face token.",
-    ),
-    env_file: Optional[str] = typer.Option(
-        None,
-        "--env-file",
-        help="Read in a file of environment variables.",
-    ),
-    secrets_file: Optional[str] = typer.Option(
-        None,
-        "--secrets-file",
-        help="Read in a file of secret environment variables.",
-    ),
-    flavor: Optional[str] = typer.Option(
-        None,
-        "--flavor",
-        help=f"Flavor for the hardware, as in HF Spaces. Defaults to `cpu-basic`. Possible values: {', '.join(SUGGESTED_FLAVORS)}.",
-    ),
-    timeout: Optional[str] = typer.Option(
-        None,
-        "--timeout",
-        help="Max duration: int/float with s (seconds, default), m (minutes), h (hours) or d (days).",
-    ),
-    namespace: Optional[str] = typer.Option(
-        None,
-        "--namespace",
-        help="The namespace where the scheduled Job will be created. Defaults to the current user's namespace.",
-    ),
-    token: Optional[str] = typer.Option(
-        None,
-        "--token",
-        help="A User Access Token generated from https://huggingface.co/settings/tokens",
-    ),
+    schedule: Annotated[
+        str,
+        typer.Argument(
+            ...,
+            help="One of annually, yearly, monthly, weekly, daily, hourly, or a CRON schedule expression.",
+        ),
+    ],
+    image: Annotated[
+        str,
+        typer.Argument(
+            ...,
+            help="The Docker image to use.",
+        ),
+    ],
+    command: Annotated[
+        list[str],
+        typer.Argument(
+            ...,
+            help="The command to run.",
+        ),
+    ],
+    suspend: Annotated[
+        bool,
+        typer.Option(
+            help="Suspend (pause) the scheduled Job",
+        ),
+    ] = None,
+    concurrency: Annotated[
+        bool,
+        typer.Option(
+            help="Allow multiple instances of this Job to run concurrently",
+        ),
+    ] = None,
+    env: Annotated[
+        list[str],
+        typer.Option(
+            "-e",
+            "--env",
+            help="Set environment variables. E.g. --env ENV=value",
+        ),
+    ] = None,
+    secrets: Annotated[
+        list[str],
+        typer.Option(
+            "-s",
+            "--secrets",
+            help="Set secret environment variables. E.g. --secrets SECRET=value or `--secrets HF_TOKEN` to pass your Hugging Face token.",
+        ),
+    ] = None,
+    env_file: Annotated[
+        str,
+        typer.Option(
+            help="Read in a file of environment variables.",
+        ),
+    ] = None,
+    secrets_file: Annotated[
+        str,
+        typer.Option(
+            help="Read in a file of secret environment variables.",
+        ),
+    ] = None,
+    flavor: Annotated[
+        str,
+        typer.Option(
+            help=f"Flavor for the hardware, as in HF Spaces. Defaults to `cpu-basic`. Possible values: {', '.join(SUGGESTED_FLAVORS)}.",
+        ),
+    ] = None,
+    timeout: Annotated[
+        str,
+        typer.Option(
+            help="Max duration: int/float with s (seconds, default), m (minutes), h (hours) or d (days).",
+        ),
+    ] = None,
+    namespace: Annotated[
+        str,
+        typer.Option(
+            help="The namespace where the scheduled Job will be created. Defaults to the current user's namespace.",
+        ),
+    ] = None,
+    token: Annotated[
+        str,
+        typer.Option(
+            help="A User Access Token generated from https://huggingface.co/settings/tokens",
+        ),
+    ] = None,
 ) -> None:
     env_map: dict[str, Optional[str]] = {}
     if env_file:
@@ -583,33 +681,41 @@ def scheduled_run(
 
 @scheduled_app.command("ps", help="List scheduled Jobs")
 def scheduled_ps(
-    all: bool = typer.Option(
-        False,
-        "-a",
-        "--all",
-        help="Show all scheduled Jobs (default hides suspended)",
-    ),
-    namespace: Optional[str] = typer.Option(
-        None,
-        "--namespace",
-        help="The namespace from where it lists the jobs. Defaults to the current user's namespace.",
-    ),
-    token: Optional[str] = typer.Option(
-        None,
-        "--token",
-        help="A User Access Token generated from https://huggingface.co/settings/tokens",
-    ),
-    filter: Optional[list[str]] = typer.Option(
-        None,
-        "-f",
-        "--filter",
-        help="Filter output based on conditions provided (format: key=value)",
-    ),
-    format: Optional[str] = typer.Option(
-        None,
-        "--format",
-        help="Format output using a custom template",
-    ),
+    all: Annotated[
+        bool,
+        typer.Option(
+            "-a",
+            "--all",
+            help="Show all scheduled Jobs (default hides suspended)",
+        ),
+    ] = False,
+    namespace: Annotated[
+        str,
+        typer.Option(
+            help="The namespace from where it lists the jobs. Defaults to the current user's namespace.",
+        ),
+    ] = None,
+    token: Annotated[
+        str,
+        typer.Option(
+            help="A User Access Token generated from https://huggingface.co/settings/tokens",
+        ),
+    ] = None,
+    filter: Annotated[
+        list[str],
+        typer.Option(
+            "-f",
+            "--filter",
+            help="Filter output based on conditions provided (format: key=value)",
+        ),
+    ] = None,
+    format: Annotated[
+        str,
+        typer.Option(
+            "--format",
+            help="Format output using a custom template",
+        ),
+    ] = None,
 ) -> None:
     try:
         api = HfApi(token=token)
@@ -666,20 +772,27 @@ def scheduled_ps(
 
 @scheduled_app.command("inspect", help="Display detailed information on one or more scheduled Jobs")
 def scheduled_inspect(
-    scheduled_job_ids: list[str] = typer.Argument(
-        ...,
-        help="The scheduled jobs to inspect",
-    ),
-    namespace: Optional[str] = typer.Option(
-        None,
-        "--namespace",
-        help="The namespace where the scheduled job is. Defaults to the current user's namespace.",
-    ),
-    token: Optional[str] = typer.Option(
-        None,
-        "--token",
-        help="A User Access Token generated from https://huggingface.co/settings/tokens",
-    ),
+    scheduled_job_ids: Annotated[
+        list[str],
+        typer.Argument(
+            ...,
+            help="The scheduled jobs to inspect",
+        ),
+    ],
+    namespace: Annotated[
+        str,
+        typer.Option(
+            "--namespace",
+            help="The namespace where the scheduled job is. Defaults to the current user's namespace.",
+        ),
+    ] = None,
+    token: Annotated[
+        str,
+        typer.Option(
+            "--token",
+            help="A User Access Token generated from https://huggingface.co/settings/tokens",
+        ),
+    ] = None,
 ) -> None:
     api = HfApi(token=token)
     scheduled_jobs = [
@@ -691,20 +804,25 @@ def scheduled_inspect(
 
 @scheduled_app.command("delete", help="Delete a scheduled Job")
 def scheduled_delete(
-    scheduled_job_id: str = typer.Argument(
-        ...,
-        help="Scheduled Job ID",
-    ),
-    namespace: Optional[str] = typer.Option(
-        None,
-        "--namespace",
-        help="The namespace where the scheduled job is. Defaults to the current user's namespace.",
-    ),
-    token: Optional[str] = typer.Option(
-        None,
-        "--token",
-        help="A User Access Token generated from https://huggingface.co/settings/tokens",
-    ),
+    scheduled_job_id: Annotated[
+        str,
+        typer.Argument(
+            ...,
+            help="Scheduled Job ID",
+        ),
+    ],
+    namespace: Annotated[
+        str,
+        typer.Option(
+            help="The namespace where the scheduled job is. Defaults to the current user's namespace.",
+        ),
+    ] = None,
+    token: Annotated[
+        str,
+        typer.Option(
+            help="A User Access Token generated from https://huggingface.co/settings/tokens",
+        ),
+    ] = None,
 ) -> None:
     api = HfApi(token=token)
     api.delete_scheduled_job(scheduled_job_id=scheduled_job_id, namespace=namespace)
@@ -712,20 +830,27 @@ def scheduled_delete(
 
 @scheduled_app.command("suspend", help="Suspend (pause) a scheduled Job")
 def scheduled_suspend(
-    scheduled_job_id: str = typer.Argument(
-        ...,
-        help="Scheduled Job ID",
-    ),
-    namespace: Optional[str] = typer.Option(
-        None,
-        "--namespace",
-        help="The namespace where the scheduled job is. Defaults to the current user's namespace.",
-    ),
-    token: Optional[str] = typer.Option(
-        None,
-        "--token",
-        help="A User Access Token generated from https://huggingface.co/settings/tokens",
-    ),
+    scheduled_job_id: Annotated[
+        str,
+        typer.Argument(
+            ...,
+            help="Scheduled Job ID",
+        ),
+    ],
+    namespace: Annotated[
+        str,
+        typer.Option(
+            "--namespace",
+            help="The namespace where the scheduled job is. Defaults to the current user's namespace.",
+        ),
+    ] = None,
+    token: Annotated[
+        str,
+        typer.Option(
+            "--token",
+            help="A User Access Token generated from https://huggingface.co/settings/tokens",
+        ),
+    ] = None,
 ) -> None:
     api = HfApi(token=token)
     api.suspend_scheduled_job(scheduled_job_id=scheduled_job_id, namespace=namespace)
@@ -733,20 +858,27 @@ def scheduled_suspend(
 
 @scheduled_app.command("resume", help="Resume (unpause) a scheduled Job")
 def scheduled_resume(
-    scheduled_job_id: str = typer.Argument(
-        ...,
-        help="Scheduled Job ID",
-    ),
-    namespace: Optional[str] = typer.Option(
-        None,
-        "--namespace",
-        help="The namespace where the scheduled job is. Defaults to the current user's namespace.",
-    ),
-    token: Optional[str] = typer.Option(
-        None,
-        "--token",
-        help="A User Access Token generated from https://huggingface.co/settings/tokens",
-    ),
+    scheduled_job_id: Annotated[
+        str,
+        typer.Argument(
+            ...,
+            help="Scheduled Job ID",
+        ),
+    ],
+    namespace: Annotated[
+        str,
+        typer.Option(
+            "--namespace",
+            help="The namespace where the scheduled job is. Defaults to the current user's namespace.",
+        ),
+    ] = None,
+    token: Annotated[
+        str,
+        typer.Option(
+            "--token",
+            help="A User Access Token generated from https://huggingface.co/settings/tokens",
+        ),
+    ] = None,
 ) -> None:
     api = HfApi(token=token)
     api.resume_scheduled_job(scheduled_job_id=scheduled_job_id, namespace=namespace)
@@ -760,65 +892,121 @@ scheduled_app.add_typer(scheduled_uv_app, name="uv")
 
 @scheduled_uv_app.command("run", help="Run a UV script (local file or URL) on HF infrastructure")
 def scheduled_uv_run(
-    schedule: str = typer.Argument(
-        ...,
-        help="One of annually, yearly, monthly, weekly, daily, hourly, or a CRON schedule expression.",
-    ),
-    script: str = typer.Argument(
-        ...,
-        help="UV script to run (local file or URL)",
-    ),
-    script_args: Optional[list[str]] = typer.Argument(
-        None,
-        help="Arguments for the script",
-    ),
-    suspend: Optional[bool] = typer.Option(
-        None,
-        "--suspend",
-        help="Suspend (pause) the scheduled Job",
-    ),
-    concurrency: Optional[bool] = typer.Option(
-        None,
-        "--concurrency",
-        help="Allow multiple instances of this Job to run concurrently",
-    ),
-    image: Optional[str] = typer.Option(
-        None,
-        "--image",
-        help="Use a custom Docker image with `uv` installed.",
-    ),
-    repo: Optional[str] = typer.Option(
-        None,
-        "--repo",
-        help="Repository name for the script (creates ephemeral if not specified)",
-    ),
-    flavor: Optional[str] = typer.Option(
-        None,
-        "--flavor",
-        help=f"Flavor for the hardware, as in HF Spaces. Defaults to `cpu-basic`. Possible values: {', '.join(SUGGESTED_FLAVORS)}. ",
-    ),
-    env: Optional[list[str]] = typer.Option(None, "-e", "--env", help="Environment variables"),
-    secrets: Optional[list[str]] = typer.Option(
-        None,
-        "-s",
-        "--secrets",
-        help="Set secret environment variables. E.g. --secrets SECRET=value or `--secrets HF_TOKEN` to pass your Hugging Face token.",
-    ),
-    env_file: Optional[str] = typer.Option(None, "--env-file", help="Read in a file of environment variables."),
-    secrets_file: Optional[str] = typer.Option(
-        None, "--secrets-file", help="Read in a file of secret environment variables."
-    ),
-    timeout: Optional[str] = typer.Option(None, "--timeout", help="Max duration (e.g., 30s, 5m, 1h)"),
-    namespace: Optional[str] = typer.Option(
-        None,
-        "--namespace",
-        help="The namespace where the Job will be created. Defaults to the current user's namespace.",
-    ),
-    token: Optional[str] = typer.Option(None, "--token", help="HF token"),
-    with_: Optional[list[str]] = typer.Option(None, "--with", help="Run with the given packages installed"),
-    python: Optional[str] = typer.Option(
-        None, "-p", "--python", help="The Python interpreter to use for the run environment"
-    ),
+    schedule: Annotated[
+        str,
+        typer.Argument(
+            ...,
+            help="One of annually, yearly, monthly, weekly, daily, hourly, or a CRON schedule expression.",
+        ),
+    ],
+    script: Annotated[
+        str,
+        typer.Argument(
+            ...,
+            help="UV script to run (local file or URL)",
+        ),
+    ],
+    script_args: Annotated[
+        list[str],
+        typer.Argument(
+            help="Arguments for the script",
+        ),
+    ] = None,
+    suspend: Annotated[
+        bool,
+        typer.Option(
+            help="Suspend (pause) the scheduled Job",
+        ),
+    ] = None,
+    concurrency: Annotated[
+        bool,
+        typer.Option(
+            help="Allow multiple instances of this Job to run concurrently",
+        ),
+    ] = None,
+    image: Annotated[
+        str,
+        typer.Option(
+            "--image",
+            help="Use a custom Docker image with `uv` installed.",
+        ),
+    ] = None,
+    repo: Annotated[
+        str,
+        typer.Option(
+            "--repo",
+            help="Repository name for the script (creates ephemeral if not specified)",
+        ),
+    ] = None,
+    flavor: Annotated[
+        str,
+        typer.Option(
+            "--flavor",
+            help=f"Flavor for the hardware, as in HF Spaces. Defaults to `cpu-basic`. Possible values: {', '.join(SUGGESTED_FLAVORS)}. ",
+        ),
+    ] = None,
+    env: Annotated[
+        list[str],
+        typer.Option(
+            "-e",
+            "--env",
+            help="Environment variables",
+        ),
+    ] = None,
+    secrets: Annotated[
+        list[str],
+        typer.Option(
+            "-s",
+            "--secrets",
+            help="Set secret environment variables. E.g. --secrets SECRET=value or `--secrets HF_TOKEN` to pass your Hugging Face token.",
+        ),
+    ] = None,
+    env_file: Annotated[
+        str,
+        typer.Option(
+            "--env-file",
+            help="Read in a file of environment variables.",
+        ),
+    ] = None,
+    secrets_file: Annotated[
+        str,
+        typer.Option(
+            help="Read in a file of secret environment variables.",
+        ),
+    ] = None,
+    timeout: Annotated[
+        str,
+        typer.Option(
+            help="Max duration (e.g., 30s, 5m, 1h)",
+        ),
+    ] = None,
+    namespace: Annotated[
+        str,
+        typer.Option(
+            help="The namespace where the Job will be created. Defaults to the current user's namespace.",
+        ),
+    ] = None,
+    token: Annotated[
+        str,
+        typer.Option(
+            help="HF token",
+        ),
+    ] = None,
+    with_: Annotated[
+        list[str],
+        typer.Option(
+            "--with",
+            help="Run with the given packages installed",
+        ),
+    ] = None,
+    python: Annotated[
+        str,
+        typer.Option(
+            "-p",
+            "--python",
+            help="The Python interpreter to use for the run environment",
+        ),
+    ] = None,
 ) -> None:
     logging.set_verbosity(logging.INFO)
     env_map: dict[str, Optional[str]] = {}

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -28,22 +28,43 @@ Usage:
 
     # Cancel a running job
     hf jobs cancel <job-id>
+
+    # Run a UV script
+    hf jobs uv run <script>
+
+    # Schedule a job
+    hf jobs scheduled run <schedule> <image> <command>
+
+    # List scheduled jobs
+    hf jobs scheduled ps [-a] [-f key=value] [--format TEMPLATE]
+
+    # Inspect a scheduled job
+    hf jobs scheduled inspect <scheduled_job_id>
+
+    # Suspend a scheduled job
+    hf jobs scheduled suspend <scheduled_job_id>
+
+    # Resume a scheduled job
+    hf jobs scheduled resume <scheduled_job_id>
+
+    # Delete a scheduled job
+    hf jobs scheduled delete <scheduled_job_id>
+
 """
 
 import json
 import os
 import re
-from argparse import Namespace, _SubParsersAction
 from dataclasses import asdict
 from pathlib import Path
-from typing import Optional, Union
+from typing import Dict, Optional, Union
+
+import typer
 
 from huggingface_hub import HfApi, SpaceHardware, get_token
 from huggingface_hub.errors import HfHubHTTPError
 from huggingface_hub.utils import logging
 from huggingface_hub.utils._dotenv import load_dotenv
-
-from . import BaseHuggingfaceCLICommand
 
 
 logger = logging.get_logger(__name__)
@@ -51,138 +72,784 @@ logger = logging.get_logger(__name__)
 SUGGESTED_FLAVORS = [item.value for item in SpaceHardware if item.value != "zero-a10g"]
 
 
-class JobsCommands(BaseHuggingfaceCLICommand):
-    @staticmethod
-    def register_subcommand(parser: _SubParsersAction):
-        jobs_parser = parser.add_parser("jobs", help="Run and manage Jobs on the Hub.")
-        jobs_subparsers = jobs_parser.add_subparsers(help="huggingface.co jobs related commands")
-
-        # Show help if no subcommand is provided
-        jobs_parser.set_defaults(func=lambda args: jobs_parser.print_help())
-
-        # Register commands
-        InspectCommand.register_subcommand(jobs_subparsers)
-        LogsCommand.register_subcommand(jobs_subparsers)
-        PsCommand.register_subcommand(jobs_subparsers)
-        RunCommand.register_subcommand(jobs_subparsers)
-        CancelCommand.register_subcommand(jobs_subparsers)
-        UvCommand.register_subcommand(jobs_subparsers)
-        ScheduledJobsCommands.register_subcommand(jobs_subparsers)
+jobs_app = typer.Typer(help="Run and manage Jobs on the Hub.")
 
 
-class RunCommand(BaseHuggingfaceCLICommand):
-    @staticmethod
-    def register_subcommand(parser: _SubParsersAction) -> None:
-        run_parser = parser.add_parser("run", help="Run a Job")
-        run_parser.add_argument("image", type=str, help="The Docker image to use.")
-        run_parser.add_argument("-e", "--env", action="append", help="Set environment variables. E.g. --env ENV=value")
-        run_parser.add_argument(
-            "-s",
-            "--secrets",
-            action="append",
-            help=(
-                "Set secret environment variables. E.g. --secrets SECRET=value "
-                "or `--secrets HF_TOKEN` to pass your Hugging Face token."
-            ),
-        )
-        run_parser.add_argument("--env-file", type=str, help="Read in a file of environment variables.")
-        run_parser.add_argument("--secrets-file", type=str, help="Read in a file of secret environment variables.")
-        run_parser.add_argument(
-            "--flavor",
-            type=str,
-            help=f"Flavor for the hardware, as in HF Spaces. Defaults to `cpu-basic`. Possible values: {', '.join(SUGGESTED_FLAVORS)}.",
-        )
-        run_parser.add_argument(
-            "--timeout",
-            type=str,
-            help="Max duration: int/float with s (seconds, default), m (minutes), h (hours) or d (days).",
-        )
-        run_parser.add_argument(
-            "-d",
-            "--detach",
-            action="store_true",
-            help="Run the Job in the background and print the Job ID.",
-        )
-        run_parser.add_argument(
-            "--namespace",
-            type=str,
-            help="The namespace where the Job will be created. Defaults to the current user's namespace.",
-        )
-        run_parser.add_argument(
-            "--token",
-            type=str,
-            help="A User Access Token generated from https://huggingface.co/settings/tokens",
-        )
-        run_parser.add_argument("command", nargs="...", help="The command to run.")
-        run_parser.set_defaults(func=RunCommand)
+@jobs_app.command("run", help="Run a Job")
+def jobs_run(
+    image: str = typer.Argument(
+        ...,
+        help="The Docker image to use.",
+    ),
+    command: list[str] = typer.Argument(
+        ...,
+        help="The command to run.",
+    ),
+    env: Optional[list[str]] = typer.Option(
+        None,
+        "-e",
+        "--env",
+        help="Set environment variables. E.g. --env ENV=value",
+    ),
+    secrets: Optional[list[str]] = typer.Option(
+        None,
+        "-s",
+        "--secrets",
+        help="Set secret environment variables. E.g. --secrets SECRET=value or `--secrets HF_TOKEN` to pass your Hugging Face token.",
+    ),
+    env_file: Optional[str] = typer.Option(
+        None,
+        "--env-file",
+        help="Read in a file of environment variables.",
+    ),
+    secrets_file: Optional[str] = typer.Option(
+        None,
+        "--secrets-file",
+        help="Read in a file of secret environment variables.",
+    ),
+    flavor: Optional[str] = typer.Option(
+        None,
+        "--flavor",
+        help=f"Flavor for the hardware, as in HF Spaces. Defaults to `cpu-basic`. Possible values: {', '.join(SUGGESTED_FLAVORS)}.",
+    ),
+    timeout: Optional[str] = typer.Option(
+        None,
+        "--timeout",
+        help="Max duration: int/float with s (seconds, default), m (minutes), h (hours) or d (days).",
+    ),
+    detach: bool = typer.Option(
+        False,
+        "-d",
+        "--detach",
+        help="Run the Job in the background and print the Job ID.",
+    ),
+    namespace: Optional[str] = typer.Option(
+        None,
+        "--namespace",
+        help="The namespace where the Job will be created. Defaults to the current user's namespace.",
+    ),
+    token: Optional[str] = typer.Option(
+        None,
+        "--token",
+        help="A User Access Token generated from https://huggingface.co/settings/tokens",
+    ),
+) -> None:
+    env_map: dict[str, Optional[str]] = {}
+    if env_file:
+        env_map.update(load_dotenv(Path(env_file).read_text(), environ=os.environ.copy()))
+    for env_value in env or []:
+        env_map.update(load_dotenv(env_value, environ=os.environ.copy()))
 
-    def __init__(self, args: Namespace) -> None:
-        self.image: str = args.image
-        self.command: list[str] = args.command
-        self.env: dict[str, Optional[str]] = {}
-        if args.env_file:
-            self.env.update(load_dotenv(Path(args.env_file).read_text(), environ=os.environ.copy()))
-        for env_value in args.env or []:
-            self.env.update(load_dotenv(env_value, environ=os.environ.copy()))
-        self.secrets: dict[str, Optional[str]] = {}
-        extended_environ = _get_extended_environ()
-        if args.secrets_file:
-            self.secrets.update(load_dotenv(Path(args.secrets_file).read_text(), environ=extended_environ))
-        for secret in args.secrets or []:
-            self.secrets.update(load_dotenv(secret, environ=extended_environ))
-        self.flavor: Optional[SpaceHardware] = args.flavor
-        self.timeout: Optional[str] = args.timeout
-        self.detach: bool = args.detach
-        self.namespace: Optional[str] = args.namespace
-        self.token: Optional[str] = args.token
+    secrets_map: dict[str, Optional[str]] = {}
+    extended_environ = _get_extended_environ()
+    if secrets_file:
+        secrets_map.update(load_dotenv(Path(secrets_file).read_text(), environ=extended_environ))
+    for secret in secrets or []:
+        secrets_map.update(load_dotenv(secret, environ=extended_environ))
 
-    def run(self) -> None:
-        api = HfApi(token=self.token)
-        job = api.run_job(
-            image=self.image,
-            command=self.command,
-            env=self.env,
-            secrets=self.secrets,
-            flavor=self.flavor,
-            timeout=self.timeout,
-            namespace=self.namespace,
-        )
-        # Always print the job ID to the user
-        print(f"Job started with ID: {job.id}")
-        print(f"View at: {job.url}")
+    api = HfApi(token=token)
+    job = api.run_job(
+        image=image,
+        command=command,
+        env=env_map,
+        secrets=secrets_map,
+        flavor=flavor,
+        timeout=timeout,
+        namespace=namespace,
+    )
+    # Always print the job ID to the user
+    print(f"Job started with ID: {job.id}")
+    print(f"View at: {job.url}")
 
-        if self.detach:
+    if detach:
+        return
+    # Now let's stream the logs
+    for log in api.fetch_job_logs(job_id=job.id):
+        print(log)
+
+
+@jobs_app.command("logs", help="Fetch the logs of a Job")
+def jobs_logs(
+    job_id: str = typer.Argument(
+        ...,
+        help="Job ID",
+    ),
+    namespace: Optional[str] = typer.Option(
+        None,
+        "--namespace",
+        help="The namespace where the job is running. Defaults to the current user's namespace.",
+    ),
+    token: Optional[str] = typer.Option(
+        None,
+        "--token",
+        help="A User Access Token generated from https://huggingface.co/settings/tokens",
+    ),
+) -> None:
+    api = HfApi(token=token)
+    for log in api.fetch_job_logs(job_id=job_id, namespace=namespace):
+        print(log)
+
+
+def _matches_filters(job_properties: dict[str, str], filters: dict[str, str]) -> bool:
+    """Check if scheduled job matches all specified filters."""
+    for key, pattern in filters.items():
+        # Check if property exists
+        if key not in job_properties:
+            return False
+        # Support pattern matching with wildcards
+        if "*" in pattern or "?" in pattern:
+            # Convert glob pattern to regex
+            regex_pattern = pattern.replace("*", ".*").replace("?", ".")
+            if not re.search(f"^{regex_pattern}$", job_properties[key], re.IGNORECASE):
+                return False
+        # Simple substring matching
+        elif pattern.lower() not in job_properties[key].lower():
+            return False
+    return True
+
+
+def _print_output(rows: list[list[Union[str, int]]], headers: list[str], fmt: Optional[str]) -> None:
+    """Print output according to the chosen format."""
+    if fmt:
+        # Use custom template if provided
+        template = fmt
+        for row in rows:
+            line = template
+            for i, field in enumerate(["id", "image", "command", "created", "status"]):
+                placeholder = f"{{{{.{field}}}}}"
+                if placeholder in line:
+                    line = line.replace(placeholder, str(row[i]))
+            print(line)
+    else:
+        # Default tabular format
+        print(_tabulate(rows, headers=headers))
+
+
+@jobs_app.command("ps", help="List Jobs")
+def jobs_ps(
+    all: bool = typer.Option(
+        False,
+        "-a",
+        "--all",
+        help="Show all Jobs (default shows just running)",
+    ),
+    namespace: Optional[str] = typer.Option(
+        None,
+        "--namespace",
+        help="The namespace from where it lists the jobs. Defaults to the current user's namespace.",
+    ),
+    token: Optional[str] = typer.Option(
+        None,
+        "--token",
+        help="A User Access Token generated from https://huggingface.co/settings/tokens",
+    ),
+    filter: Optional[list[str]] = typer.Option(
+        None,
+        "-f",
+        "--filter",
+        help="Filter output based on conditions provided (format: key=value)",
+    ),
+    format: Optional[str] = typer.Option(
+        None,
+        "--format",
+        help="Format output using a custom template",
+    ),
+) -> None:
+    try:
+        api = HfApi(token=token)
+        # Fetch jobs data
+        jobs = api.list_jobs(namespace=namespace)
+        # Define table headers
+        table_headers = ["JOB ID", "IMAGE/SPACE", "COMMAND", "CREATED", "STATUS"]
+        rows: list[list[Union[str, int]]] = []
+
+        filters: dict[str, str] = {}
+        for f in filter or []:
+            if "=" in f:
+                key, value = f.split("=", 1)
+                filters[key.lower()] = value
+            else:
+                print(f"Warning: Ignoring invalid filter format '{f}'. Use key=value format.")
+        # Process jobs data
+        for job in jobs:
+            # Extract job data for filtering
+            status = job.status.stage if job.status else "UNKNOWN"
+            if not all and status not in ("RUNNING", "UPDATING"):
+                # Skip job if not all jobs should be shown and status doesn't match criteria
+                continue
+            # Extract job data for output
+            job_id = job.id
+
+            # Extract image or space information
+            image_or_space = job.docker_image or "N/A"
+
+            # Extract and format command
+            cmd = job.command or []
+            command_str = " ".join(cmd) if cmd else "N/A"
+
+            # Extract creation time
+            created_at = job.created_at.strftime("%Y-%m-%d %H:%M:%S") if job.created_at else "N/A"
+
+            # Create a dict with all job properties for filtering
+            props = {"id": job_id, "image": image_or_space, "status": status.lower(), "command": command_str}
+            if not _matches_filters(props, filters):
+                continue
+
+            # Create row
+            rows.append([job_id, image_or_space, command_str, created_at, status])
+
+        # Handle empty results
+        if not rows:
+            filters_msg = (
+                f" matching filters: {', '.join([f'{k}={v}' for k, v in filters.items()])}" if filters else ""
+            )
+            print(f"No jobs found{filters_msg}")
             return
+        # Apply custom format if provided or use default tabular format
+        _print_output(rows, table_headers, format)
 
-        # Now let's stream the logs
-        for log in api.fetch_job_logs(job_id=job.id):
-            print(log)
+    except HfHubHTTPError as e:
+        print(f"Error fetching jobs data: {e}")
+    except (KeyError, ValueError, TypeError) as e:
+        print(f"Error processing jobs data: {e}")
+    except Exception as e:
+        print(f"Unexpected error - {type(e).__name__}: {e}")
 
 
-class LogsCommand(BaseHuggingfaceCLICommand):
-    @staticmethod
-    def register_subcommand(parser: _SubParsersAction) -> None:
-        run_parser = parser.add_parser("logs", help="Fetch the logs of a Job")
-        run_parser.add_argument("job_id", type=str, help="Job ID")
-        run_parser.add_argument(
-            "--namespace",
-            type=str,
-            help="The namespace where the job is running. Defaults to the current user's namespace.",
-        )
-        run_parser.add_argument(
-            "--token", type=str, help="A User Access Token generated from https://huggingface.co/settings/tokens"
-        )
-        run_parser.set_defaults(func=LogsCommand)
+@jobs_app.command("inspect", help="Display detailed information on one or more Jobs")
+def jobs_inspect(
+    job_ids: list[str] = typer.Argument(
+        ...,
+        help="The jobs to inspect",
+    ),
+    namespace: Optional[str] = typer.Option(
+        None,
+        "--namespace",
+        help="The namespace where the job is running. Defaults to the current user's namespace.",
+    ),
+    token: Optional[str] = typer.Option(
+        None,
+        "--token",
+        help="A User Access Token generated from https://huggingface.co/settings/tokens",
+    ),
+) -> None:
+    api = HfApi(token=token)
+    jobs = [api.inspect_job(job_id=job_id, namespace=namespace) for job_id in job_ids]
+    print(json.dumps([asdict(job) for job in jobs], indent=4, default=str))
 
-    def __init__(self, args: Namespace) -> None:
-        self.job_id: str = args.job_id
-        self.namespace: Optional[str] = args.namespace
-        self.token: Optional[str] = args.token
 
-    def run(self) -> None:
-        api = HfApi(token=self.token)
-        for log in api.fetch_job_logs(job_id=self.job_id, namespace=self.namespace):
-            print(log)
+@jobs_app.command("cancel", help="Cancel a Job")
+def jobs_cancel(
+    job_id: str = typer.Argument(
+        ...,
+        help="Job ID",
+    ),
+    namespace: Optional[str] = typer.Option(
+        None,
+        "--namespace",
+        help="The namespace where the job is running. Defaults to the current user's namespace.",
+    ),
+    token: Optional[str] = typer.Option(
+        None,
+        "--token",
+        help="A User Access Token generated from https://huggingface.co/settings/tokens",
+    ),
+) -> None:
+    api = HfApi(token=token)
+    api.cancel_job(job_id=job_id, namespace=namespace)
+
+
+uv_app = typer.Typer(help="Run UV scripts (Python with inline dependencies) on HF infrastructure")
+jobs_app.add_typer(uv_app, name="uv")
+
+
+@uv_app.command("run", help="Run a UV script (local file or URL) on HF infrastructure")
+def jobs_uv_run(
+    script: str = typer.Argument(
+        ...,
+        help="UV script to run (local file or URL)",
+    ),
+    script_args: Optional[list[str]] = typer.Argument(
+        None,
+        help="Arguments for the script",
+    ),
+    image: Optional[str] = typer.Option(
+        None,
+        "--image",
+        help="Use a custom Docker image with `uv` installed.",
+    ),
+    repo: Optional[str] = typer.Option(
+        None,
+        "--repo",
+        help="Repository name for the script (creates ephemeral if not specified)",
+    ),
+    flavor: Optional[str] = typer.Option(
+        None,
+        "--flavor",
+        help=f"Flavor for the hardware, as in HF Spaces. Defaults to `cpu-basic`. Possible values: {', '.join(SUGGESTED_FLAVORS)}.",
+    ),
+    env: Optional[list[str]] = typer.Option(
+        None,
+        "-e",
+        "--env",
+        help="Environment variables",
+    ),
+    secrets: Optional[list[str]] = typer.Option(
+        None,
+        "-s",
+        "--secrets",
+        help="Set secret environment variables. E.g. --secrets SECRET=value or `--secrets HF_TOKEN` to pass your Hugging Face token.",
+    ),
+    env_file: Optional[str] = typer.Option(
+        None,
+        "--env-file",
+        help="Read in a file of environment variables.",
+    ),
+    secrets_file: Optional[str] = typer.Option(
+        None,
+        "--secrets-file",
+        help="Read in a file of secret environment variables.",
+    ),
+    timeout: Optional[str] = typer.Option(
+        None,
+        "--timeout",
+        help="Max duration (e.g., 30s, 5m, 1h)",
+    ),
+    detach: bool = typer.Option(
+        False,
+        "-d",
+        "--detach",
+        help="Run in background",
+    ),
+    namespace: Optional[str] = typer.Option(
+        None,
+        "--namespace",
+        help="The namespace where the Job will be created. Defaults to the current user's namespace.",
+    ),
+    token: Optional[str] = typer.Option(
+        None,
+        "--token",
+        help="HF token",
+    ),
+    with_: Optional[list[str]] = typer.Option(
+        None,
+        "--with",
+        help="Run with the given packages installed",
+    ),
+    python: Optional[str] = typer.Option(
+        None,
+        "-p",
+        "--python",
+        help="The Python interpreter to use for the run environment",
+    ),
+) -> None:
+    logging.set_verbosity(logging.INFO)
+    env_map: dict[str, Optional[str]] = {}
+    if env_file:
+        env_map.update(load_dotenv(Path(env_file).read_text(), environ=os.environ.copy()))
+    for env_value in env or []:
+        env_map.update(load_dotenv(env_value, environ=os.environ.copy()))
+    secrets_map: dict[str, Optional[str]] = {}
+    extended_environ = _get_extended_environ()
+    if secrets_file:
+        secrets_map.update(load_dotenv(Path(secrets_file).read_text(), environ=extended_environ))
+    for secret in secrets or []:
+        secrets_map.update(load_dotenv(secret, environ=extended_environ))
+
+    api = HfApi(token=token)
+    job = api.run_uv_job(
+        script=script,
+        script_args=script_args or [],
+        dependencies=with_,
+        python=python,
+        image=image,
+        env=env_map,
+        secrets=secrets_map,
+        flavor=flavor,  # type: ignore[arg-type]
+        timeout=timeout,
+        namespace=namespace,
+        _repo=repo,
+    )
+    # Always print the job ID to the user
+    print(f"Job started with ID: {job.id}")
+    print(f"View at: {job.url}")
+    if detach:
+        return
+    # Now let's stream the logs
+    for log in api.fetch_job_logs(job_id=job.id):
+        print(log)
+
+
+scheduled_app = typer.Typer(help="Create and manage scheduled Jobs on the Hub.")
+jobs_app.add_typer(scheduled_app, name="scheduled")
+
+
+@scheduled_app.command("run", help="Schedule a Job")
+def scheduled_run(
+    schedule: str = typer.Argument(
+        ...,
+        help="One of annually, yearly, monthly, weekly, daily, hourly, or a CRON schedule expression.",
+    ),
+    image: str = typer.Argument(
+        ...,
+        help="The Docker image to use.",
+    ),
+    command: list[str] = typer.Argument(
+        ...,
+        help="The command to run.",
+    ),
+    suspend: Optional[bool] = typer.Option(
+        None,
+        "--suspend",
+        help="Suspend (pause) the scheduled Job",
+    ),
+    concurrency: Optional[bool] = typer.Option(
+        None,
+        "--concurrency",
+        help="Allow multiple instances of this Job to run concurrently",
+    ),
+    env: Optional[list[str]] = typer.Option(
+        None,
+        "-e",
+        "--env",
+        help="Set environment variables. E.g. --env ENV=value",
+    ),
+    secrets: Optional[list[str]] = typer.Option(
+        None,
+        "-s",
+        "--secrets",
+        help="Set secret environment variables. E.g. --secrets SECRET=value or `--secrets HF_TOKEN` to pass your Hugging Face token.",
+    ),
+    env_file: Optional[str] = typer.Option(
+        None,
+        "--env-file",
+        help="Read in a file of environment variables.",
+    ),
+    secrets_file: Optional[str] = typer.Option(
+        None,
+        "--secrets-file",
+        help="Read in a file of secret environment variables.",
+    ),
+    flavor: Optional[str] = typer.Option(
+        None,
+        "--flavor",
+        help=f"Flavor for the hardware, as in HF Spaces. Defaults to `cpu-basic`. Possible values: {', '.join(SUGGESTED_FLAVORS)}.",
+    ),
+    timeout: Optional[str] = typer.Option(
+        None,
+        "--timeout",
+        help="Max duration: int/float with s (seconds, default), m (minutes), h (hours) or d (days).",
+    ),
+    namespace: Optional[str] = typer.Option(
+        None,
+        "--namespace",
+        help="The namespace where the scheduled Job will be created. Defaults to the current user's namespace.",
+    ),
+    token: Optional[str] = typer.Option(
+        None,
+        "--token",
+        help="A User Access Token generated from https://huggingface.co/settings/tokens",
+    ),
+) -> None:
+    env_map: dict[str, Optional[str]] = {}
+    if env_file:
+        env_map.update(load_dotenv(Path(env_file).read_text(), environ=os.environ.copy()))
+    for env_value in env or []:
+        env_map.update(load_dotenv(env_value, environ=os.environ.copy()))
+    secrets_map: dict[str, Optional[str]] = {}
+    extended_environ = _get_extended_environ()
+    if secrets_file:
+        secrets_map.update(load_dotenv(Path(secrets_file).read_text(), environ=extended_environ))
+    for secret in secrets or []:
+        secrets_map.update(load_dotenv(secret, environ=extended_environ))
+
+    api = HfApi(token=token)
+    scheduled_job = api.create_scheduled_job(
+        image=image,
+        command=command,
+        schedule=schedule,
+        suspend=suspend,
+        concurrency=concurrency,
+        env=env_map,
+        secrets=secrets_map,
+        flavor=flavor,
+        timeout=timeout,
+        namespace=namespace,
+    )
+    print(f"Scheduled Job created with ID: {scheduled_job.id}")
+
+
+@scheduled_app.command("ps", help="List scheduled Jobs")
+def scheduled_ps(
+    all: bool = typer.Option(
+        False,
+        "-a",
+        "--all",
+        help="Show all scheduled Jobs (default hides suspended)",
+    ),
+    namespace: Optional[str] = typer.Option(
+        None,
+        "--namespace",
+        help="The namespace from where it lists the jobs. Defaults to the current user's namespace.",
+    ),
+    token: Optional[str] = typer.Option(
+        None,
+        "--token",
+        help="A User Access Token generated from https://huggingface.co/settings/tokens",
+    ),
+    filter: Optional[list[str]] = typer.Option(
+        None,
+        "-f",
+        "--filter",
+        help="Filter output based on conditions provided (format: key=value)",
+    ),
+    format: Optional[str] = typer.Option(
+        None,
+        "--format",
+        help="Format output using a custom template",
+    ),
+) -> None:
+    try:
+        api = HfApi(token=token)
+        scheduled_jobs = api.list_scheduled_jobs(namespace=namespace)
+        table_headers = ["ID", "SCHEDULE", "IMAGE/SPACE", "COMMAND", "LAST RUN", "NEXT RUN", "SUSPEND"]
+        rows: list[list[Union[str, int]]] = []
+        filters: dict[str, str] = {}
+        for f in filter or []:
+            if "=" in f:
+                key, value = f.split("=", 1)
+                filters[key.lower()] = value
+            else:
+                print(f"Warning: Ignoring invalid filter format '{f}'. Use key=value format.")
+
+        for scheduled_job in scheduled_jobs:
+            suspend = scheduled_job.suspend
+            if not all and suspend:
+                continue
+            sj_id = scheduled_job.id
+            schedule = scheduled_job.schedule
+            image_or_space = scheduled_job.job_spec.docker_image or "N/A"
+            cmd = scheduled_job.job_spec.command or []
+            command_str = " ".join(cmd) if cmd else "N/A"
+            last_job_at = (
+                scheduled_job.status.last_job.at.strftime("%Y-%m-%d %H:%M:%S")
+                if scheduled_job.status.last_job
+                else "N/A"
+            )
+            next_job_run_at = (
+                scheduled_job.status.next_job_run_at.strftime("%Y-%m-%d %H:%M:%S")
+                if scheduled_job.status.next_job_run_at
+                else "N/A"
+            )
+            props = {"id": sj_id, "image": image_or_space, "suspend": str(suspend), "command": command_str}
+            if not _matches_filters(props, filters):
+                continue
+            rows.append([sj_id, schedule, image_or_space, command_str, last_job_at, next_job_run_at, suspend])
+
+        if not rows:
+            filters_msg = (
+                f" matching filters: {', '.join([f'{k}={v}' for k, v in filters.items()])}" if filters else ""
+            )
+            print(f"No scheduled jobs found{filters_msg}")
+            return
+        _print_output(rows, table_headers, format)
+
+    except HfHubHTTPError as e:
+        print(f"Error fetching scheduled jobs data: {e}")
+    except (KeyError, ValueError, TypeError) as e:
+        print(f"Error processing scheduled jobs data: {e}")
+    except Exception as e:
+        print(f"Unexpected error - {type(e).__name__}: {e}")
+
+
+@scheduled_app.command("inspect", help="Display detailed information on one or more scheduled Jobs")
+def scheduled_inspect(
+    scheduled_job_ids: list[str] = typer.Argument(
+        ...,
+        help="The scheduled jobs to inspect",
+    ),
+    namespace: Optional[str] = typer.Option(
+        None,
+        "--namespace",
+        help="The namespace where the scheduled job is. Defaults to the current user's namespace.",
+    ),
+    token: Optional[str] = typer.Option(
+        None,
+        "--token",
+        help="A User Access Token generated from https://huggingface.co/settings/tokens",
+    ),
+) -> None:
+    api = HfApi(token=token)
+    scheduled_jobs = [
+        api.inspect_scheduled_job(scheduled_job_id=scheduled_job_id, namespace=namespace)
+        for scheduled_job_id in scheduled_job_ids
+    ]
+    print(json.dumps([asdict(scheduled_job) for scheduled_job in scheduled_jobs], indent=4, default=str))
+
+
+@scheduled_app.command("delete", help="Delete a scheduled Job")
+def scheduled_delete(
+    scheduled_job_id: str = typer.Argument(
+        ...,
+        help="Scheduled Job ID",
+    ),
+    namespace: Optional[str] = typer.Option(
+        None,
+        "--namespace",
+        help="The namespace where the scheduled job is. Defaults to the current user's namespace.",
+    ),
+    token: Optional[str] = typer.Option(
+        None,
+        "--token",
+        help="A User Access Token generated from https://huggingface.co/settings/tokens",
+    ),
+) -> None:
+    api = HfApi(token=token)
+    api.delete_scheduled_job(scheduled_job_id=scheduled_job_id, namespace=namespace)
+
+
+@scheduled_app.command("suspend", help="Suspend (pause) a scheduled Job")
+def scheduled_suspend(
+    scheduled_job_id: str = typer.Argument(
+        ...,
+        help="Scheduled Job ID",
+    ),
+    namespace: Optional[str] = typer.Option(
+        None,
+        "--namespace",
+        help="The namespace where the scheduled job is. Defaults to the current user's namespace.",
+    ),
+    token: Optional[str] = typer.Option(
+        None,
+        "--token",
+        help="A User Access Token generated from https://huggingface.co/settings/tokens",
+    ),
+) -> None:
+    api = HfApi(token=token)
+    api.suspend_scheduled_job(scheduled_job_id=scheduled_job_id, namespace=namespace)
+
+
+@scheduled_app.command("resume", help="Resume (unpause) a scheduled Job")
+def scheduled_resume(
+    scheduled_job_id: str = typer.Argument(
+        ...,
+        help="Scheduled Job ID",
+    ),
+    namespace: Optional[str] = typer.Option(
+        None,
+        "--namespace",
+        help="The namespace where the scheduled job is. Defaults to the current user's namespace.",
+    ),
+    token: Optional[str] = typer.Option(
+        None,
+        "--token",
+        help="A User Access Token generated from https://huggingface.co/settings/tokens",
+    ),
+) -> None:
+    api = HfApi(token=token)
+    api.resume_scheduled_job(scheduled_job_id=scheduled_job_id, namespace=namespace)
+
+
+scheduled_uv_app = typer.Typer(help="Schedule UV scripts (Python with inline dependencies) on HF infrastructure")
+scheduled_app.add_typer(scheduled_uv_app, name="uv")
+
+
+@scheduled_uv_app.command("run", help="Run a UV script (local file or URL) on HF infrastructure")
+def scheduled_uv_run(
+    schedule: str = typer.Argument(
+        ...,
+        help="One of annually, yearly, monthly, weekly, daily, hourly, or a CRON schedule expression.",
+    ),
+    script: str = typer.Argument(
+        ...,
+        help="UV script to run (local file or URL)",
+    ),
+    script_args: Optional[list[str]] = typer.Argument(
+        None,
+        help="Arguments for the script",
+    ),
+    suspend: Optional[bool] = typer.Option(
+        None,
+        "--suspend",
+        help="Suspend (pause) the scheduled Job",
+    ),
+    concurrency: Optional[bool] = typer.Option(
+        None,
+        "--concurrency",
+        help="Allow multiple instances of this Job to run concurrently",
+    ),
+    image: Optional[str] = typer.Option(
+        None,
+        "--image",
+        help="Use a custom Docker image with `uv` installed.",
+    ),
+    repo: Optional[str] = typer.Option(
+        None,
+        "--repo",
+        help="Repository name for the script (creates ephemeral if not specified)",
+    ),
+    flavor: Optional[str] = typer.Option(
+        None,
+        "--flavor",
+        help=f"Flavor for the hardware, as in HF Spaces. Defaults to `cpu-basic`. Possible values: {', '.join(SUGGESTED_FLAVORS)}. ",
+    ),
+    env: Optional[list[str]] = typer.Option(None, "-e", "--env", help="Environment variables"),
+    secrets: Optional[list[str]] = typer.Option(
+        None,
+        "-s",
+        "--secrets",
+        help="Set secret environment variables. E.g. --secrets SECRET=value or `--secrets HF_TOKEN` to pass your Hugging Face token.",
+    ),
+    env_file: Optional[str] = typer.Option(None, "--env-file", help="Read in a file of environment variables."),
+    secrets_file: Optional[str] = typer.Option(
+        None, "--secrets-file", help="Read in a file of secret environment variables."
+    ),
+    timeout: Optional[str] = typer.Option(None, "--timeout", help="Max duration (e.g., 30s, 5m, 1h)"),
+    namespace: Optional[str] = typer.Option(
+        None,
+        "--namespace",
+        help="The namespace where the Job will be created. Defaults to the current user's namespace.",
+    ),
+    token: Optional[str] = typer.Option(None, "--token", help="HF token"),
+    with_: Optional[list[str]] = typer.Option(None, "--with", help="Run with the given packages installed"),
+    python: Optional[str] = typer.Option(
+        None, "-p", "--python", help="The Python interpreter to use for the run environment"
+    ),
+) -> None:
+    logging.set_verbosity(logging.INFO)
+    env_map: dict[str, Optional[str]] = {}
+    if env_file:
+        env_map.update(load_dotenv(Path(env_file).read_text(), environ=os.environ.copy()))
+    for env_value in env or []:
+        env_map.update(load_dotenv(env_value, environ=os.environ.copy()))
+    secrets_map: dict[str, Optional[str]] = {}
+    extended_environ = _get_extended_environ()
+    if secrets_file:
+        secrets_map.update(load_dotenv(Path(secrets_file).read_text(), environ=extended_environ))
+    for secret in secrets or []:
+        secrets_map.update(load_dotenv(secret, environ=extended_environ))
+
+    api = HfApi(token=token)
+    job = api.create_scheduled_uv_job(
+        script=script,
+        script_args=script_args or [],
+        schedule=schedule,
+        suspend=suspend,
+        concurrency=concurrency,
+        dependencies=with_,
+        python=python,
+        image=image,
+        env=env_map,
+        secrets=secrets_map,
+        flavor=flavor,  # type: ignore[arg-type]
+        timeout=timeout,
+        namespace=namespace,
+        _repo=repo,
+    )
+    print(f"Scheduled Job created with ID: {job.id}")
+
+
+### UTILS
 
 
 def _tabulate(rows: list[list[Union[str, int]]], headers: list[str]) -> str:
@@ -212,888 +879,8 @@ def _tabulate(rows: list[list[Union[str, int]]], headers: list[str]) -> str:
     return "\n".join(lines)
 
 
-class PsCommand(BaseHuggingfaceCLICommand):
-    @staticmethod
-    def register_subcommand(parser: _SubParsersAction) -> None:
-        run_parser = parser.add_parser("ps", help="List Jobs")
-        run_parser.add_argument(
-            "-a",
-            "--all",
-            action="store_true",
-            help="Show all Jobs (default shows just running)",
-        )
-        run_parser.add_argument(
-            "--namespace",
-            type=str,
-            help="The namespace from where it lists the jobs. Defaults to the current user's namespace.",
-        )
-        run_parser.add_argument(
-            "--token",
-            type=str,
-            help="A User Access Token generated from https://huggingface.co/settings/tokens",
-        )
-        # Add Docker-style filtering argument
-        run_parser.add_argument(
-            "-f",
-            "--filter",
-            action="append",
-            default=[],
-            help="Filter output based on conditions provided (format: key=value)",
-        )
-        # Add option to format output
-        run_parser.add_argument(
-            "--format",
-            type=str,
-            help="Format output using a custom template",
-        )
-        run_parser.set_defaults(func=PsCommand)
-
-    def __init__(self, args: Namespace) -> None:
-        self.all: bool = args.all
-        self.namespace: Optional[str] = args.namespace
-        self.token: Optional[str] = args.token
-        self.format: Optional[str] = args.format
-        self.filters: dict[str, str] = {}
-
-        # Parse filter arguments (key=value pairs)
-        for f in args.filter:
-            if "=" in f:
-                key, value = f.split("=", 1)
-                self.filters[key.lower()] = value
-            else:
-                print(f"Warning: Ignoring invalid filter format '{f}'. Use key=value format.")
-
-    def run(self) -> None:
-        """
-        Fetch and display job information for the current user.
-        Uses Docker-style filtering with -f/--filter flag and key=value pairs.
-        """
-        try:
-            api = HfApi(token=self.token)
-
-            # Fetch jobs data
-            jobs = api.list_jobs(namespace=self.namespace)
-
-            # Define table headers
-            table_headers = ["JOB ID", "IMAGE/SPACE", "COMMAND", "CREATED", "STATUS"]
-
-            # Process jobs data
-            rows = []
-
-            for job in jobs:
-                # Extract job data for filtering
-                status = job.status.stage if job.status else "UNKNOWN"
-
-                # Skip job if not all jobs should be shown and status doesn't match criteria
-                if not self.all and status not in ("RUNNING", "UPDATING"):
-                    continue
-
-                # Extract job ID
-                job_id = job.id
-
-                # Extract image or space information
-                image_or_space = job.docker_image or "N/A"
-
-                # Extract and format command
-                command = job.command or []
-                command_str = " ".join(command) if command else "N/A"
-
-                # Extract creation time
-                created_at = job.created_at.strftime("%Y-%m-%d %H:%M:%S") if job.created_at else "N/A"
-
-                # Create a dict with all job properties for filtering
-                job_properties = {
-                    "id": job_id,
-                    "image": image_or_space,
-                    "status": status.lower(),
-                    "command": command_str,
-                }
-
-                # Check if job matches all filters
-                if not self._matches_filters(job_properties):
-                    continue
-
-                # Create row
-                rows.append([job_id, image_or_space, command_str, created_at, status])
-
-            # Handle empty results
-            if not rows:
-                filters_msg = ""
-                if self.filters:
-                    filters_msg = f" matching filters: {', '.join([f'{k}={v}' for k, v in self.filters.items()])}"
-
-                print(f"No jobs found{filters_msg}")
-                return
-
-            # Apply custom format if provided or use default tabular format
-            self._print_output(rows, table_headers)
-
-        except HfHubHTTPError as e:
-            print(f"Error fetching jobs data: {e}")
-        except (KeyError, ValueError, TypeError) as e:
-            print(f"Error processing jobs data: {e}")
-        except Exception as e:
-            print(f"Unexpected error - {type(e).__name__}: {e}")
-
-    def _matches_filters(self, job_properties: dict[str, str]) -> bool:
-        """Check if job matches all specified filters."""
-        for key, pattern in self.filters.items():
-            # Check if property exists
-            if key not in job_properties:
-                return False
-
-            # Support pattern matching with wildcards
-            if "*" in pattern or "?" in pattern:
-                # Convert glob pattern to regex
-                regex_pattern = pattern.replace("*", ".*").replace("?", ".")
-                if not re.search(f"^{regex_pattern}$", job_properties[key], re.IGNORECASE):
-                    return False
-            # Simple substring matching
-            elif pattern.lower() not in job_properties[key].lower():
-                return False
-
-        return True
-
-    def _print_output(self, rows, headers):
-        """Print output according to the chosen format."""
-        if self.format:
-            # Custom template formatting (simplified)
-            template = self.format
-            for row in rows:
-                line = template
-                for i, field in enumerate(["id", "image", "command", "created", "status"]):
-                    placeholder = f"{{{{.{field}}}}}"
-                    if placeholder in line:
-                        line = line.replace(placeholder, str(row[i]))
-                print(line)
-        else:
-            # Default tabular format
-            print(
-                _tabulate(
-                    rows,
-                    headers=headers,
-                )
-            )
-
-
-class InspectCommand(BaseHuggingfaceCLICommand):
-    @staticmethod
-    def register_subcommand(parser: _SubParsersAction) -> None:
-        run_parser = parser.add_parser("inspect", help="Display detailed information on one or more Jobs")
-        run_parser.add_argument(
-            "--namespace",
-            type=str,
-            help="The namespace where the job is running. Defaults to the current user's namespace.",
-        )
-        run_parser.add_argument(
-            "--token", type=str, help="A User Access Token generated from https://huggingface.co/settings/tokens"
-        )
-        run_parser.add_argument("job_ids", nargs="...", help="The jobs to inspect")
-        run_parser.set_defaults(func=InspectCommand)
-
-    def __init__(self, args: Namespace) -> None:
-        self.namespace: Optional[str] = args.namespace
-        self.token: Optional[str] = args.token
-        self.job_ids: list[str] = args.job_ids
-
-    def run(self) -> None:
-        api = HfApi(token=self.token)
-        jobs = [api.inspect_job(job_id=job_id, namespace=self.namespace) for job_id in self.job_ids]
-        print(json.dumps([asdict(job) for job in jobs], indent=4, default=str))
-
-
-class CancelCommand(BaseHuggingfaceCLICommand):
-    @staticmethod
-    def register_subcommand(parser: _SubParsersAction) -> None:
-        run_parser = parser.add_parser("cancel", help="Cancel a Job")
-        run_parser.add_argument("job_id", type=str, help="Job ID")
-        run_parser.add_argument(
-            "--namespace",
-            type=str,
-            help="The namespace where the job is running. Defaults to the current user's namespace.",
-        )
-        run_parser.add_argument(
-            "--token", type=str, help="A User Access Token generated from https://huggingface.co/settings/tokens"
-        )
-        run_parser.set_defaults(func=CancelCommand)
-
-    def __init__(self, args: Namespace) -> None:
-        self.job_id: str = args.job_id
-        self.namespace = args.namespace
-        self.token: Optional[str] = args.token
-
-    def run(self) -> None:
-        api = HfApi(token=self.token)
-        api.cancel_job(job_id=self.job_id, namespace=self.namespace)
-
-
-class UvCommand(BaseHuggingfaceCLICommand):
-    """Run UV scripts on Hugging Face infrastructure."""
-
-    @staticmethod
-    def register_subcommand(parser):
-        """Register UV run subcommand."""
-        uv_parser = parser.add_parser(
-            "uv",
-            help="Run UV scripts (Python with inline dependencies) on HF infrastructure",
-        )
-
-        subparsers = uv_parser.add_subparsers(dest="uv_command", help="UV commands", required=True)
-
-        # Run command only
-        run_parser = subparsers.add_parser(
-            "run",
-            help="Run a UV script (local file or URL) on HF infrastructure",
-        )
-        run_parser.add_argument("script", help="UV script to run (local file or URL)")
-        run_parser.add_argument("script_args", nargs="...", help="Arguments for the script", default=[])
-        run_parser.add_argument("--image", type=str, help="Use a custom Docker image with `uv` installed.")
-        run_parser.add_argument(
-            "--repo",
-            help="Repository name for the script (creates ephemeral if not specified)",
-        )
-        run_parser.add_argument(
-            "--flavor",
-            type=str,
-            help=f"Flavor for the hardware, as in HF Spaces. Defaults to `cpu-basic`. Possible values: {', '.join(SUGGESTED_FLAVORS)}.",
-        )
-        run_parser.add_argument("-e", "--env", action="append", help="Environment variables")
-        run_parser.add_argument(
-            "-s",
-            "--secrets",
-            action="append",
-            help=(
-                "Set secret environment variables. E.g. --secrets SECRET=value "
-                "or `--secrets HF_TOKEN` to pass your Hugging Face token."
-            ),
-        )
-        run_parser.add_argument("--env-file", type=str, help="Read in a file of environment variables.")
-        run_parser.add_argument(
-            "--secrets-file",
-            type=str,
-            help="Read in a file of secret environment variables.",
-        )
-        run_parser.add_argument("--timeout", type=str, help="Max duration (e.g., 30s, 5m, 1h)")
-        run_parser.add_argument("-d", "--detach", action="store_true", help="Run in background")
-        run_parser.add_argument(
-            "--namespace",
-            type=str,
-            help="The namespace where the Job will be created. Defaults to the current user's namespace.",
-        )
-        run_parser.add_argument("--token", type=str, help="HF token")
-        # UV options
-        run_parser.add_argument("--with", action="append", help="Run with the given packages installed", dest="with_")
-        run_parser.add_argument(
-            "-p", "--python", type=str, help="The Python interpreter to use for the run environment"
-        )
-        run_parser.set_defaults(func=UvCommand)
-
-    def __init__(self, args: Namespace) -> None:
-        """Initialize the command with parsed arguments."""
-        self.script = args.script
-        self.script_args = args.script_args
-        self.dependencies = args.with_
-        self.python = args.python
-        self.image = args.image
-        self.env: dict[str, Optional[str]] = {}
-        if args.env_file:
-            self.env.update(load_dotenv(Path(args.env_file).read_text(), environ=os.environ.copy()))
-        for env_value in args.env or []:
-            self.env.update(load_dotenv(env_value, environ=os.environ.copy()))
-        self.secrets: dict[str, Optional[str]] = {}
-        extended_environ = _get_extended_environ()
-        if args.secrets_file:
-            self.secrets.update(load_dotenv(Path(args.secrets_file).read_text(), environ=extended_environ))
-        for secret in args.secrets or []:
-            self.secrets.update(load_dotenv(secret, environ=extended_environ))
-        self.flavor: Optional[SpaceHardware] = args.flavor
-        self.timeout: Optional[str] = args.timeout
-        self.detach: bool = args.detach
-        self.namespace: Optional[str] = args.namespace
-        self.token: Optional[str] = args.token
-        self._repo = args.repo
-
-    def run(self) -> None:
-        """Execute UV command."""
-        logging.set_verbosity(logging.INFO)
-        api = HfApi(token=self.token)
-        job = api.run_uv_job(
-            script=self.script,
-            script_args=self.script_args,
-            dependencies=self.dependencies,
-            python=self.python,
-            image=self.image,
-            env=self.env,
-            secrets=self.secrets,
-            flavor=self.flavor,
-            timeout=self.timeout,
-            namespace=self.namespace,
-            _repo=self._repo,
-        )
-
-        # Always print the job ID to the user
-        print(f"Job started with ID: {job.id}")
-        print(f"View at: {job.url}")
-
-        if self.detach:
-            return
-
-        # Now let's stream the logs
-        for log in api.fetch_job_logs(job_id=job.id):
-            print(log)
-
-
-def _get_extended_environ() -> dict[str, str]:
+def _get_extended_environ() -> Dict[str, str]:
     extended_environ = os.environ.copy()
     if (token := get_token()) is not None:
         extended_environ["HF_TOKEN"] = token
     return extended_environ
-
-
-class ScheduledJobsCommands(BaseHuggingfaceCLICommand):
-    @staticmethod
-    def register_subcommand(parser: _SubParsersAction):
-        scheduled_jobs_parser = parser.add_parser("scheduled", help="Create and manage scheduled Jobs on the Hub.")
-        scheduled_jobs_subparsers = scheduled_jobs_parser.add_subparsers(
-            help="huggingface.co scheduled jobs related commands"
-        )
-
-        # Show help if no subcommand is provided
-        scheduled_jobs_parser.set_defaults(func=lambda args: scheduled_jobs_subparsers.print_help())
-
-        # Register commands
-        ScheduledRunCommand.register_subcommand(scheduled_jobs_subparsers)
-        ScheduledPsCommand.register_subcommand(scheduled_jobs_subparsers)
-        ScheduledInspectCommand.register_subcommand(scheduled_jobs_subparsers)
-        ScheduledDeleteCommand.register_subcommand(scheduled_jobs_subparsers)
-        ScheduledSuspendCommand.register_subcommand(scheduled_jobs_subparsers)
-        ScheduledResumeCommand.register_subcommand(scheduled_jobs_subparsers)
-        ScheduledUvCommand.register_subcommand(scheduled_jobs_subparsers)
-
-
-class ScheduledRunCommand(BaseHuggingfaceCLICommand):
-    @staticmethod
-    def register_subcommand(parser: _SubParsersAction) -> None:
-        run_parser = parser.add_parser("run", help="Schedule a Job")
-        run_parser.add_argument(
-            "schedule",
-            type=str,
-            help="One of annually, yearly, monthly, weekly, daily, hourly, or a CRON schedule expression.",
-        )
-        run_parser.add_argument("image", type=str, help="The Docker image to use.")
-        run_parser.add_argument(
-            "--suspend",
-            action="store_true",
-            help="Suspend (pause) the scheduled Job",
-            default=None,
-        )
-        run_parser.add_argument(
-            "--concurrency",
-            action="store_true",
-            help="Allow multiple instances of this Job to run concurrently",
-            default=None,
-        )
-        run_parser.add_argument("-e", "--env", action="append", help="Set environment variables. E.g. --env ENV=value")
-        run_parser.add_argument(
-            "-s",
-            "--secrets",
-            action="append",
-            help=(
-                "Set secret environment variables. E.g. --secrets SECRET=value "
-                "or `--secrets HF_TOKEN` to pass your Hugging Face token."
-            ),
-        )
-        run_parser.add_argument("--env-file", type=str, help="Read in a file of environment variables.")
-        run_parser.add_argument("--secrets-file", type=str, help="Read in a file of secret environment variables.")
-        run_parser.add_argument(
-            "--flavor",
-            type=str,
-            help=f"Flavor for the hardware, as in HF Spaces. Defaults to `cpu-basic`. Possible values: {', '.join(SUGGESTED_FLAVORS)}.",
-        )
-        run_parser.add_argument(
-            "--timeout",
-            type=str,
-            help="Max duration: int/float with s (seconds, default), m (minutes), h (hours) or d (days).",
-        )
-        run_parser.add_argument(
-            "--namespace",
-            type=str,
-            help="The namespace where the scheduled Job will be created. Defaults to the current user's namespace.",
-        )
-        run_parser.add_argument(
-            "--token",
-            type=str,
-            help="A User Access Token generated from https://huggingface.co/settings/tokens",
-        )
-        run_parser.add_argument("command", nargs="...", help="The command to run.")
-        run_parser.set_defaults(func=ScheduledRunCommand)
-
-    def __init__(self, args: Namespace) -> None:
-        self.schedule: str = args.schedule
-        self.image: str = args.image
-        self.command: list[str] = args.command
-        self.suspend: Optional[bool] = args.suspend
-        self.concurrency: Optional[bool] = args.concurrency
-        self.env: dict[str, Optional[str]] = {}
-        if args.env_file:
-            self.env.update(load_dotenv(Path(args.env_file).read_text(), environ=os.environ.copy()))
-        for env_value in args.env or []:
-            self.env.update(load_dotenv(env_value, environ=os.environ.copy()))
-        self.secrets: dict[str, Optional[str]] = {}
-        extended_environ = _get_extended_environ()
-        if args.secrets_file:
-            self.secrets.update(load_dotenv(Path(args.secrets_file).read_text(), environ=extended_environ))
-        for secret in args.secrets or []:
-            self.secrets.update(load_dotenv(secret, environ=extended_environ))
-        self.flavor: Optional[SpaceHardware] = args.flavor
-        self.timeout: Optional[str] = args.timeout
-        self.namespace: Optional[str] = args.namespace
-        self.token: Optional[str] = args.token
-
-    def run(self) -> None:
-        api = HfApi(token=self.token)
-        scheduled_job = api.create_scheduled_job(
-            image=self.image,
-            command=self.command,
-            schedule=self.schedule,
-            suspend=self.suspend,
-            concurrency=self.concurrency,
-            env=self.env,
-            secrets=self.secrets,
-            flavor=self.flavor,
-            timeout=self.timeout,
-            namespace=self.namespace,
-        )
-        # Always print the scheduled job ID to the user
-        print(f"Scheduled Job created with ID: {scheduled_job.id}")
-
-
-class ScheduledPsCommand(BaseHuggingfaceCLICommand):
-    @staticmethod
-    def register_subcommand(parser: _SubParsersAction) -> None:
-        run_parser = parser.add_parser("ps", help="List scheduled Jobs")
-        run_parser.add_argument(
-            "-a",
-            "--all",
-            action="store_true",
-            help="Show all scheduled Jobs (default hides suspended)",
-        )
-        run_parser.add_argument(
-            "--namespace",
-            type=str,
-            help="The namespace from where it lists the jobs. Defaults to the current user's namespace.",
-        )
-        run_parser.add_argument(
-            "--token",
-            type=str,
-            help="A User Access Token generated from https://huggingface.co/settings/tokens",
-        )
-        # Add Docker-style filtering argument
-        run_parser.add_argument(
-            "-f",
-            "--filter",
-            action="append",
-            default=[],
-            help="Filter output based on conditions provided (format: key=value)",
-        )
-        # Add option to format output
-        run_parser.add_argument(
-            "--format",
-            type=str,
-            help="Format output using a custom template",
-        )
-        run_parser.set_defaults(func=ScheduledPsCommand)
-
-    def __init__(self, args: Namespace) -> None:
-        self.all: bool = args.all
-        self.namespace: Optional[str] = args.namespace
-        self.token: Optional[str] = args.token
-        self.format: Optional[str] = args.format
-        self.filters: dict[str, str] = {}
-
-        # Parse filter arguments (key=value pairs)
-        for f in args.filter:
-            if "=" in f:
-                key, value = f.split("=", 1)
-                self.filters[key.lower()] = value
-            else:
-                print(f"Warning: Ignoring invalid filter format '{f}'. Use key=value format.")
-
-    def run(self) -> None:
-        """
-        Fetch and display scheduked job information for the current user.
-        Uses Docker-style filtering with -f/--filter flag and key=value pairs.
-        """
-        try:
-            api = HfApi(token=self.token)
-
-            # Fetch jobs data
-            scheduled_jobs = api.list_scheduled_jobs(namespace=self.namespace)
-
-            # Define table headers
-            table_headers = [
-                "ID",
-                "SCHEDULE",
-                "IMAGE/SPACE",
-                "COMMAND",
-                "LAST RUN",
-                "NEXT RUN",
-                "SUSPEND",
-            ]
-
-            # Process jobs data
-            rows = []
-
-            for scheduled_job in scheduled_jobs:
-                # Extract job data for filtering
-                suspend = scheduled_job.suspend
-
-                # Skip job if not all jobs should be shown and status doesn't match criteria
-                if not self.all and suspend:
-                    continue
-
-                # Extract job ID
-                scheduled_job_id = scheduled_job.id
-
-                # Extract schedule
-                schedule = scheduled_job.schedule
-
-                # Extract image or space information
-                image_or_space = scheduled_job.job_spec.docker_image or "N/A"
-
-                # Extract and format command
-                command = scheduled_job.job_spec.command or []
-                command_str = " ".join(command) if command else "N/A"
-
-                # Extract status
-                last_job_at = (
-                    scheduled_job.status.last_job.at.strftime("%Y-%m-%d %H:%M:%S")
-                    if scheduled_job.status.last_job
-                    else "N/A"
-                )
-                next_job_run_at = (
-                    scheduled_job.status.next_job_run_at.strftime("%Y-%m-%d %H:%M:%S")
-                    if scheduled_job.status.next_job_run_at
-                    else "N/A"
-                )
-
-                # Create a dict with all job properties for filtering
-                job_properties = {
-                    "id": scheduled_job_id,
-                    "image": image_or_space,
-                    "suspend": str(suspend),
-                    "command": command_str,
-                }
-
-                # Check if job matches all filters
-                if not self._matches_filters(job_properties):
-                    continue
-
-                # Create row
-                rows.append(
-                    [
-                        scheduled_job_id,
-                        schedule,
-                        image_or_space,
-                        command_str,
-                        last_job_at,
-                        next_job_run_at,
-                        suspend,
-                    ]
-                )
-
-            # Handle empty results
-            if not rows:
-                filters_msg = ""
-                if self.filters:
-                    filters_msg = f" matching filters: {', '.join([f'{k}={v}' for k, v in self.filters.items()])}"
-
-                print(f"No scheduled jobs found{filters_msg}")
-                return
-
-            # Apply custom format if provided or use default tabular format
-            self._print_output(rows, table_headers)
-
-        except HfHubHTTPError as e:
-            print(f"Error fetching scheduled jobs data: {e}")
-        except (KeyError, ValueError, TypeError) as e:
-            print(f"Error processing scheduled jobs data: {e}")
-        except Exception as e:
-            print(f"Unexpected error - {type(e).__name__}: {e}")
-
-    def _matches_filters(self, job_properties: dict[str, str]) -> bool:
-        """Check if scheduled job matches all specified filters."""
-        for key, pattern in self.filters.items():
-            # Check if property exists
-            if key not in job_properties:
-                return False
-
-            # Support pattern matching with wildcards
-            if "*" in pattern or "?" in pattern:
-                # Convert glob pattern to regex
-                regex_pattern = pattern.replace("*", ".*").replace("?", ".")
-                if not re.search(f"^{regex_pattern}$", job_properties[key], re.IGNORECASE):
-                    return False
-            # Simple substring matching
-            elif pattern.lower() not in job_properties[key].lower():
-                return False
-
-        return True
-
-    def _print_output(self, rows, headers):
-        """Print output according to the chosen format."""
-        if self.format:
-            # Custom template formatting (simplified)
-            template = self.format
-            for row in rows:
-                line = template
-                for i, field in enumerate(
-                    ["id", "schedule", "image", "command", "last_job_at", "next_job_run_at", "suspend"]
-                ):
-                    placeholder = f"{{{{.{field}}}}}"
-                    if placeholder in line:
-                        line = line.replace(placeholder, str(row[i]))
-                print(line)
-        else:
-            # Default tabular format
-            print(
-                _tabulate(
-                    rows,
-                    headers=headers,
-                )
-            )
-
-
-class ScheduledInspectCommand(BaseHuggingfaceCLICommand):
-    @staticmethod
-    def register_subcommand(parser: _SubParsersAction) -> None:
-        run_parser = parser.add_parser("inspect", help="Display detailed information on one or more scheduled Jobs")
-        run_parser.add_argument(
-            "--namespace",
-            type=str,
-            help="The namespace where the scheduled job is. Defaults to the current user's namespace.",
-        )
-        run_parser.add_argument(
-            "--token", type=str, help="A User Access Token generated from https://huggingface.co/settings/tokens"
-        )
-        run_parser.add_argument("scheduled_job_ids", nargs="...", help="The scheduled jobs to inspect")
-        run_parser.set_defaults(func=ScheduledInspectCommand)
-
-    def __init__(self, args: Namespace) -> None:
-        self.namespace: Optional[str] = args.namespace
-        self.token: Optional[str] = args.token
-        self.scheduled_job_ids: list[str] = args.scheduled_job_ids
-
-    def run(self) -> None:
-        api = HfApi(token=self.token)
-        scheduled_jobs = [
-            api.inspect_scheduled_job(scheduled_job_id=scheduled_job_id, namespace=self.namespace)
-            for scheduled_job_id in self.scheduled_job_ids
-        ]
-        print(json.dumps([asdict(scheduled_job) for scheduled_job in scheduled_jobs], indent=4, default=str))
-
-
-class ScheduledDeleteCommand(BaseHuggingfaceCLICommand):
-    @staticmethod
-    def register_subcommand(parser: _SubParsersAction) -> None:
-        run_parser = parser.add_parser("delete", help="Delete a scheduled Job")
-        run_parser.add_argument("scheduled_job_id", type=str, help="Scheduled Job ID")
-        run_parser.add_argument(
-            "--namespace",
-            type=str,
-            help="The namespace where the scheduled job is. Defaults to the current user's namespace.",
-        )
-        run_parser.add_argument(
-            "--token", type=str, help="A User Access Token generated from https://huggingface.co/settings/tokens"
-        )
-        run_parser.set_defaults(func=ScheduledDeleteCommand)
-
-    def __init__(self, args: Namespace) -> None:
-        self.scheduled_job_id: str = args.scheduled_job_id
-        self.namespace = args.namespace
-        self.token: Optional[str] = args.token
-
-    def run(self) -> None:
-        api = HfApi(token=self.token)
-        api.delete_scheduled_job(scheduled_job_id=self.scheduled_job_id, namespace=self.namespace)
-
-
-class ScheduledSuspendCommand(BaseHuggingfaceCLICommand):
-    @staticmethod
-    def register_subcommand(parser: _SubParsersAction) -> None:
-        run_parser = parser.add_parser("suspend", help="Suspend (pause) a scheduled Job")
-        run_parser.add_argument("scheduled_job_id", type=str, help="Scheduled Job ID")
-        run_parser.add_argument(
-            "--namespace",
-            type=str,
-            help="The namespace where the scheduled job is. Defaults to the current user's namespace.",
-        )
-        run_parser.add_argument(
-            "--token", type=str, help="A User Access Token generated from https://huggingface.co/settings/tokens"
-        )
-        run_parser.set_defaults(func=ScheduledSuspendCommand)
-
-    def __init__(self, args: Namespace) -> None:
-        self.scheduled_job_id: str = args.scheduled_job_id
-        self.namespace = args.namespace
-        self.token: Optional[str] = args.token
-
-    def run(self) -> None:
-        api = HfApi(token=self.token)
-        api.suspend_scheduled_job(scheduled_job_id=self.scheduled_job_id, namespace=self.namespace)
-
-
-class ScheduledResumeCommand(BaseHuggingfaceCLICommand):
-    @staticmethod
-    def register_subcommand(parser: _SubParsersAction) -> None:
-        run_parser = parser.add_parser("resume", help="Resume (unpause) a scheduled Job")
-        run_parser.add_argument("scheduled_job_id", type=str, help="Scheduled Job ID")
-        run_parser.add_argument(
-            "--namespace",
-            type=str,
-            help="The namespace where the scheduled job is. Defaults to the current user's namespace.",
-        )
-        run_parser.add_argument(
-            "--token", type=str, help="A User Access Token generated from https://huggingface.co/settings/tokens"
-        )
-        run_parser.set_defaults(func=ScheduledResumeCommand)
-
-    def __init__(self, args: Namespace) -> None:
-        self.scheduled_job_id: str = args.scheduled_job_id
-        self.namespace = args.namespace
-        self.token: Optional[str] = args.token
-
-    def run(self) -> None:
-        api = HfApi(token=self.token)
-        api.resume_scheduled_job(scheduled_job_id=self.scheduled_job_id, namespace=self.namespace)
-
-
-class ScheduledUvCommand(BaseHuggingfaceCLICommand):
-    """Schedule UV scripts on Hugging Face infrastructure."""
-
-    @staticmethod
-    def register_subcommand(parser):
-        """Register UV run subcommand."""
-        uv_parser = parser.add_parser(
-            "uv",
-            help="Schedule UV scripts (Python with inline dependencies) on HF infrastructure",
-        )
-
-        subparsers = uv_parser.add_subparsers(dest="uv_command", help="UV commands", required=True)
-
-        # Run command only
-        run_parser = subparsers.add_parser(
-            "run",
-            help="Run a UV script (local file or URL) on HF infrastructure",
-        )
-        run_parser.add_argument(
-            "schedule",
-            type=str,
-            help="One of annually, yearly, monthly, weekly, daily, hourly, or a CRON schedule expression.",
-        )
-        run_parser.add_argument("script", help="UV script to run (local file or URL)")
-        run_parser.add_argument("script_args", nargs="...", help="Arguments for the script", default=[])
-        run_parser.add_argument(
-            "--suspend",
-            action="store_true",
-            help="Suspend (pause) the scheduled Job",
-            default=None,
-        )
-        run_parser.add_argument(
-            "--concurrency",
-            action="store_true",
-            help="Allow multiple instances of this Job to run concurrently",
-            default=None,
-        )
-        run_parser.add_argument("--image", type=str, help="Use a custom Docker image with `uv` installed.")
-        run_parser.add_argument(
-            "--repo",
-            help="Repository name for the script (creates ephemeral if not specified)",
-        )
-        run_parser.add_argument(
-            "--flavor",
-            type=str,
-            help=f"Flavor for the hardware, as in HF Spaces. Defaults to `cpu-basic`. Possible values: {', '.join(SUGGESTED_FLAVORS)}.",
-        )
-        run_parser.add_argument("-e", "--env", action="append", help="Environment variables")
-        run_parser.add_argument(
-            "-s",
-            "--secrets",
-            action="append",
-            help=(
-                "Set secret environment variables. E.g. --secrets SECRET=value "
-                "or `--secrets HF_TOKEN` to pass your Hugging Face token."
-            ),
-        )
-        run_parser.add_argument("--env-file", type=str, help="Read in a file of environment variables.")
-        run_parser.add_argument(
-            "--secrets-file",
-            type=str,
-            help="Read in a file of secret environment variables.",
-        )
-        run_parser.add_argument("--timeout", type=str, help="Max duration (e.g., 30s, 5m, 1h)")
-        run_parser.add_argument("-d", "--detach", action="store_true", help="Run in background")
-        run_parser.add_argument(
-            "--namespace",
-            type=str,
-            help="The namespace where the Job will be created. Defaults to the current user's namespace.",
-        )
-        run_parser.add_argument("--token", type=str, help="HF token")
-        # UV options
-        run_parser.add_argument("--with", action="append", help="Run with the given packages installed", dest="with_")
-        run_parser.add_argument(
-            "-p", "--python", type=str, help="The Python interpreter to use for the run environment"
-        )
-        run_parser.set_defaults(func=ScheduledUvCommand)
-
-    def __init__(self, args: Namespace) -> None:
-        """Initialize the command with parsed arguments."""
-        self.schedule: str = args.schedule
-        self.script = args.script
-        self.script_args = args.script_args
-        self.suspend: Optional[bool] = args.suspend
-        self.concurrency: Optional[bool] = args.concurrency
-        self.dependencies = args.with_
-        self.python = args.python
-        self.image = args.image
-        self.env: dict[str, Optional[str]] = {}
-        if args.env_file:
-            self.env.update(load_dotenv(Path(args.env_file).read_text(), environ=os.environ.copy()))
-        for env_value in args.env or []:
-            self.env.update(load_dotenv(env_value, environ=os.environ.copy()))
-        self.secrets: dict[str, Optional[str]] = {}
-        extended_environ = _get_extended_environ()
-        if args.secrets_file:
-            self.secrets.update(load_dotenv(Path(args.secrets_file).read_text(), environ=extended_environ))
-        for secret in args.secrets or []:
-            self.secrets.update(load_dotenv(secret, environ=extended_environ))
-        self.flavor: Optional[SpaceHardware] = args.flavor
-        self.timeout: Optional[str] = args.timeout
-        self.detach: bool = args.detach
-        self.namespace: Optional[str] = args.namespace
-        self.token: Optional[str] = args.token
-        self._repo = args.repo
-
-    def run(self) -> None:
-        """Schedule UV command."""
-        logging.set_verbosity(logging.INFO)
-        api = HfApi(token=self.token)
-        job = api.create_scheduled_uv_job(
-            script=self.script,
-            script_args=self.script_args,
-            schedule=self.schedule,
-            suspend=self.suspend,
-            concurrency=self.concurrency,
-            dependencies=self.dependencies,
-            python=self.python,
-            image=self.image,
-            env=self.env,
-            secrets=self.secrets,
-            flavor=self.flavor,
-            timeout=self.timeout,
-            namespace=self.namespace,
-            _repo=self._repo,
-        )
-
-        # Always print the job ID to the user
-        print(f"Scheduled Job created with ID: {job.id}")

--- a/src/huggingface_hub/cli/lfs.py
+++ b/src/huggingface_hub/cli/lfs.py
@@ -46,7 +46,6 @@ def lfs_enable_largefiles(
     path: Annotated[
         str,
         typer.Argument(
-            ...,
             help="Local path to repository you want to configure.",
         ),
     ],

--- a/src/huggingface_hub/cli/lfs.py
+++ b/src/huggingface_hub/cli/lfs.py
@@ -20,10 +20,10 @@ import json
 import os
 import subprocess
 import sys
-from argparse import _SubParsersAction
 from typing import Optional
 
-from huggingface_hub.commands import BaseHuggingfaceCLICommand
+import typer
+
 from huggingface_hub.lfs import LFS_MULTIPART_UPLOAD_COMMAND
 
 from ..utils import get_session, hf_raise_for_status, logging
@@ -33,58 +33,33 @@ from ..utils._lfs import SliceFileObj
 logger = logging.get_logger(__name__)
 
 
-class LfsCommands(BaseHuggingfaceCLICommand):
-    """
-    Implementation of a custom transfer agent for the transfer type "multipart"
-    for git-lfs. This lets users upload large files >5GB 🔥. Spec for LFS custom
-    transfer agent is:
-    https://github.com/git-lfs/git-lfs/blob/master/docs/custom-transfers.md
+"""
+Implementation of a custom transfer agent for the transfer type "multipart" for git-lfs.
 
-    This introduces two commands to the CLI:
-
-    1. $ hf lfs-enable-largefiles
-
-    This should be executed once for each model repo that contains a model file
-    >5GB. It's documented in the error message you get if you just try to git
-    push a 5GB file without having enabled it before.
-
-    2. $ hf lfs-multipart-upload
-
-    This command is called by lfs directly and is not meant to be called by the
-    user.
-    """
-
-    @staticmethod
-    def register_subcommand(parser: _SubParsersAction):
-        enable_parser = parser.add_parser("lfs-enable-largefiles", add_help=False)
-        enable_parser.add_argument("path", type=str, help="Local path to repository you want to configure.")
-        enable_parser.set_defaults(func=lambda args: LfsEnableCommand(args))
-
-        # Command will get called by git-lfs, do not call it directly.
-        upload_parser = parser.add_parser(LFS_MULTIPART_UPLOAD_COMMAND, add_help=False)
-        upload_parser.set_defaults(func=lambda args: LfsUploadCommand(args))
+Commands:
+- hf lfs-enable-largefiles
+- hf lfs-multipart-upload (internal; called by git-lfs)
+"""
 
 
-class LfsEnableCommand:
-    def __init__(self, args):
-        self.args = args
-
-    def run(self):
-        local_path = os.path.abspath(self.args.path)
-        if not os.path.isdir(local_path):
-            print("This does not look like a valid git repo.")
-            exit(1)
-        subprocess.run(
-            "git config lfs.customtransfer.multipart.path hf".split(),
-            check=True,
-            cwd=local_path,
-        )
-        subprocess.run(
-            f"git config lfs.customtransfer.multipart.args {LFS_MULTIPART_UPLOAD_COMMAND}".split(),
-            check=True,
-            cwd=local_path,
-        )
-        print("Local repo set up for largefiles")
+def lfs_enable_largefiles(
+    path: str = typer.Argument(..., help="Local path to repository you want to configure."),
+) -> None:
+    local_path = os.path.abspath(path)
+    if not os.path.isdir(local_path):
+        print("This does not look like a valid git repo.")
+        raise typer.Exit(code=1)
+    subprocess.run(
+        "git config lfs.customtransfer.multipart.path hf".split(),
+        check=True,
+        cwd=local_path,
+    )
+    subprocess.run(
+        f"git config lfs.customtransfer.multipart.args {LFS_MULTIPART_UPLOAD_COMMAND}".split(),
+        check=True,
+        cwd=local_path,
+    )
+    print("Local repo set up for largefiles")
 
 
 def write_msg(msg: dict):
@@ -109,90 +84,85 @@ def read_msg() -> Optional[dict]:
     return msg
 
 
-class LfsUploadCommand:
-    def __init__(self, args) -> None:
-        self.args = args
+def lfs_multipart_upload() -> None:
+    # Immediately after invoking a custom transfer process, git-lfs
+    # sends initiation data to the process over stdin.
+    # This tells the process useful information about the configuration.
+    init_msg = json.loads(sys.stdin.readline().strip())
+    if not (init_msg.get("event") == "init" and init_msg.get("operation") == "upload"):
+        write_msg({"error": {"code": 32, "message": "Wrong lfs init operation"}})
+        sys.exit(1)
 
-    def run(self) -> None:
-        # Immediately after invoking a custom transfer process, git-lfs
-        # sends initiation data to the process over stdin.
-        # This tells the process useful information about the configuration.
-        init_msg = json.loads(sys.stdin.readline().strip())
-        if not (init_msg.get("event") == "init" and init_msg.get("operation") == "upload"):
-            write_msg({"error": {"code": 32, "message": "Wrong lfs init operation"}})
-            sys.exit(1)
+    # The transfer process should use the information it needs from the
+    # initiation structure, and also perform any one-off setup tasks it
+    # needs to do. It should then respond on stdout with a simple empty
+    # confirmation structure, as follows:
+    write_msg({})
 
-        # The transfer process should use the information it needs from the
-        # initiation structure, and also perform any one-off setup tasks it
-        # needs to do. It should then respond on stdout with a simple empty
-        # confirmation structure, as follows:
-        write_msg({})
+    # After the initiation exchange, git-lfs will send any number of
+    # transfer requests to the stdin of the transfer process, in a serial sequence.
+    while True:
+        msg = read_msg()
+        if msg is None:
+            # When all transfers have been processed, git-lfs will send
+            # a terminate event to the stdin of the transfer process.
+            # On receiving this message the transfer process should
+            # clean up and terminate. No response is expected.
+            sys.exit(0)
 
-        # After the initiation exchange, git-lfs will send any number of
-        # transfer requests to the stdin of the transfer process, in a serial sequence.
-        while True:
-            msg = read_msg()
-            if msg is None:
-                # When all transfers have been processed, git-lfs will send
-                # a terminate event to the stdin of the transfer process.
-                # On receiving this message the transfer process should
-                # clean up and terminate. No response is expected.
-                sys.exit(0)
+        oid = msg["oid"]
+        filepath = msg["path"]
+        completion_url = msg["action"]["href"]
+        header = msg["action"]["header"]
+        chunk_size = int(header.pop("chunk_size"))
+        presigned_urls: list[str] = list(header.values())
 
-            oid = msg["oid"]
-            filepath = msg["path"]
-            completion_url = msg["action"]["href"]
-            header = msg["action"]["header"]
-            chunk_size = int(header.pop("chunk_size"))
-            presigned_urls: list[str] = list(header.values())
+        # Send a "started" progress event to allow other workers to start.
+        # Otherwise they're delayed until first "progress" event is reported,
+        # i.e. after the first 5GB by default (!)
+        write_msg(
+            {
+                "event": "progress",
+                "oid": oid,
+                "bytesSoFar": 1,
+                "bytesSinceLast": 0,
+            }
+        )
 
-            # Send a "started" progress event to allow other workers to start.
-            # Otherwise they're delayed until first "progress" event is reported,
-            # i.e. after the first 5GB by default (!)
-            write_msg(
-                {
-                    "event": "progress",
-                    "oid": oid,
-                    "bytesSoFar": 1,
-                    "bytesSinceLast": 0,
-                }
-            )
+        parts = []
+        with open(filepath, "rb") as file:
+            for i, presigned_url in enumerate(presigned_urls):
+                with SliceFileObj(
+                    file,
+                    seek_from=i * chunk_size,
+                    read_limit=chunk_size,
+                ) as data:
+                    r = get_session().put(presigned_url, data=data)
+                    hf_raise_for_status(r)
+                    parts.append(
+                        {
+                            "etag": r.headers.get("etag"),
+                            "partNumber": i + 1,
+                        }
+                    )
+                    # In order to support progress reporting while data is uploading / downloading,
+                    # the transfer process should post messages to stdout
+                    write_msg(
+                        {
+                            "event": "progress",
+                            "oid": oid,
+                            "bytesSoFar": (i + 1) * chunk_size,
+                            "bytesSinceLast": chunk_size,
+                        }
+                    )
 
-            parts = []
-            with open(filepath, "rb") as file:
-                for i, presigned_url in enumerate(presigned_urls):
-                    with SliceFileObj(
-                        file,
-                        seek_from=i * chunk_size,
-                        read_limit=chunk_size,
-                    ) as data:
-                        r = get_session().put(presigned_url, data=data)
-                        hf_raise_for_status(r)
-                        parts.append(
-                            {
-                                "etag": r.headers.get("etag"),
-                                "partNumber": i + 1,
-                            }
-                        )
-                        # In order to support progress reporting while data is uploading / downloading,
-                        # the transfer process should post messages to stdout
-                        write_msg(
-                            {
-                                "event": "progress",
-                                "oid": oid,
-                                "bytesSoFar": (i + 1) * chunk_size,
-                                "bytesSinceLast": chunk_size,
-                            }
-                        )
-                        # Not precise but that's ok.
+        r = get_session().post(
+            completion_url,
+            json={
+                "oid": oid,
+                "parts": parts,
+            },
+        )
+        hf_raise_for_status(r)
 
-            r = get_session().post(
-                completion_url,
-                json={
-                    "oid": oid,
-                    "parts": parts,
-                },
-            )
-            hf_raise_for_status(r)
-
-            write_msg({"event": "complete", "oid": oid})
+        write_msg({"event": "complete", "oid": oid})

--- a/src/huggingface_hub/cli/lfs.py
+++ b/src/huggingface_hub/cli/lfs.py
@@ -33,15 +33,6 @@ from ..utils._lfs import SliceFileObj
 logger = logging.get_logger(__name__)
 
 
-"""
-Implementation of a custom transfer agent for the transfer type "multipart" for git-lfs.
-
-Commands:
-- hf lfs-enable-largefiles
-- hf lfs-multipart-upload (internal; called by git-lfs)
-"""
-
-
 def lfs_enable_largefiles(
     path: Annotated[
         str,
@@ -50,6 +41,12 @@ def lfs_enable_largefiles(
         ),
     ],
 ) -> None:
+    """
+    Configure a local git repository to use the multipart transfer agent for large files.
+
+    This command sets up git-lfs to use the custom multipart transfer agent
+    which enables efficient uploading of large files in chunks.
+    """
     local_path = os.path.abspath(path)
     if not os.path.isdir(local_path):
         print("This does not look like a valid git repo.")
@@ -90,6 +87,11 @@ def read_msg() -> Optional[dict]:
 
 
 def lfs_multipart_upload() -> None:
+    """Internal git-lfs custom transfer agent for multipart uploads.
+
+    This function implements the custom transfer protocol for git-lfs multipart uploads.
+    Handles chunked uploads of large files to Hugging Face Hub.
+    """
     # Immediately after invoking a custom transfer process, git-lfs
     # sends initiation data to the process over stdin.
     # This tells the process useful information about the configuration.

--- a/src/huggingface_hub/cli/lfs.py
+++ b/src/huggingface_hub/cli/lfs.py
@@ -23,6 +23,7 @@ import sys
 from typing import Optional
 
 import typer
+from typing_extensions import Annotated
 
 from huggingface_hub.lfs import LFS_MULTIPART_UPLOAD_COMMAND
 
@@ -43,7 +44,13 @@ Commands:
 
 
 def lfs_enable_largefiles(
-    path: str = typer.Argument(..., help="Local path to repository you want to configure."),
+    path: Annotated[
+        str,
+        typer.Argument(
+            ...,
+            help="Local path to repository you want to configure.",
+        ),
+    ],
 ) -> None:
     local_path = os.path.abspath(path)
     if not os.path.isdir(local_path):

--- a/src/huggingface_hub/cli/lfs.py
+++ b/src/huggingface_hub/cli/lfs.py
@@ -20,10 +20,9 @@ import json
 import os
 import subprocess
 import sys
-from typing import Optional
+from typing import Annotated, Optional
 
 import typer
-from typing_extensions import Annotated
 
 from huggingface_hub.lfs import LFS_MULTIPART_UPLOAD_COMMAND
 

--- a/src/huggingface_hub/cli/repo.py
+++ b/src/huggingface_hub/cli/repo.py
@@ -58,7 +58,6 @@ def repo_create(
         Optional[str],
         typer.Option(
             help="Hugging Face Spaces SDK type. Required when --type is set to 'space'.",
-            rich_help_panel=None,
         ),
     ] = None,
     private: Annotated[

--- a/src/huggingface_hub/cli/repo.py
+++ b/src/huggingface_hub/cli/repo.py
@@ -34,8 +34,8 @@ from huggingface_hub.utils import logging
 
 logger = logging.get_logger(__name__)
 
-repo_app = typer.Typer(help="Manage repos on the Hub.")
-tag_app = typer.Typer(help="Manage tags for a repo on the Hub.")
+repo_app = typer.Typer(help="Manage repos on the Hub.", rich_markup_mode=None)
+tag_app = typer.Typer(help="Manage tags for a repo on the Hub.", rich_markup_mode=None)
 repo_app.add_typer(tag_app, name="tag")
 
 

--- a/src/huggingface_hub/cli/repo.py
+++ b/src/huggingface_hub/cli/repo.py
@@ -44,7 +44,6 @@ def repo_create(
     repo_id: Annotated[
         str,
         typer.Argument(
-            ...,
             help="Repo ID to create (e.g. username/repo-name). Username defaults to current user if omitted.",
         ),
     ],
@@ -105,14 +104,12 @@ def tag_create(
     repo_id: Annotated[
         str,
         typer.Argument(
-            ...,
             help="The ID of the repo to tag (e.g. `username/repo-name`).",
         ),
     ],
     tag: Annotated[
         str,
         typer.Argument(
-            ...,
             help="The name of the tag to create.",
         ),
     ],
@@ -167,7 +164,6 @@ def tag_list(
     repo_id: Annotated[
         str,
         typer.Argument(
-            ...,
             help="The ID of the repo to list tags for (e.g. `username/repo-name`",
         ),
     ],
@@ -208,13 +204,14 @@ def tag_delete(
     repo_id: Annotated[
         str,
         typer.Argument(
-            ...,
             help="The ID of the repo to delete the tag from (e.g. `username/repo-name`).",
         ),
     ],
     tag: Annotated[
         str,
-        typer.Argument(..., help="The name of the tag to delete."),
+        typer.Argument(
+            help="The name of the tag to delete.",
+        ),
     ],
     yes: Annotated[
         bool,

--- a/src/huggingface_hub/cli/repo.py
+++ b/src/huggingface_hub/cli/repo.py
@@ -21,6 +21,8 @@ Usage:
     hf repo create my-cool-model --private
 """
 
+from typing import Optional
+
 import typer
 from typing_extensions import Annotated
 
@@ -48,13 +50,13 @@ def repo_create(
         ),
     ],
     repo_type: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="set to dataset' or 'space' if creating a dataset or space, default is 'model'.",
         ),
     ] = None,
     space_sdk: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="Hugging Face Spaces SDK type. Required when --type is set to 'space'.",
             rich_help_panel=None,
@@ -68,7 +70,7 @@ def repo_create(
         ),
     ] = False,
     token: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="Hugging Face token. Will default to the locally saved token if not provided.",
         ),
@@ -80,7 +82,7 @@ def repo_create(
         ),
     ] = False,
     resource_group_id: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="Resource group in which to create the repo. Resource groups is only available for Enterprise Hub organizations.",
         ),
@@ -118,7 +120,7 @@ def tag_create(
         ),
     ],
     message: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             "-m",
             "--message",
@@ -126,19 +128,19 @@ def tag_create(
         ),
     ] = None,
     revision: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="Git revision to tag",
         ),
     ] = None,
     token: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="A User Access Token generated from https://huggingface.co/settings/tokens.",
         ),
     ] = None,
     repo_type: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="Set the type of repository (model, dataset, or space).",
         ),
@@ -173,13 +175,13 @@ def tag_list(
         ),
     ],
     token: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="A User Access Token generated from https://huggingface.co/settings/tokens.",
         ),
     ] = None,
     repo_type: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="Set the type of repository (model, dataset, or space).",
         ),
@@ -226,13 +228,13 @@ def tag_delete(
         ),
     ] = False,
     token: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="A User Access Token generated from https://huggingface.co/settings/tokens.",
         ),
     ] = None,
     repo_type: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="Set the type of repository (model, dataset, or space).",
         ),

--- a/src/huggingface_hub/cli/repo.py
+++ b/src/huggingface_hub/cli/repo.py
@@ -29,7 +29,7 @@ from huggingface_hub.errors import HfHubHTTPError, RepositoryNotFoundError, Revi
 from huggingface_hub.hf_api import HfApi
 from huggingface_hub.utils import logging
 
-from ._cli_utils import ANSI, RepoType, typer_factory
+from ._cli_utils import ANSI, PrivateOpt, RepoIdArg, RepoType, RepoTypeOpt, RevisionOpt, TokenOpt, typer_factory
 
 
 logger = logging.get_logger(__name__)
@@ -41,37 +41,16 @@ repo_cli.add_typer(tag_app, name="tag")
 
 @repo_cli.command("create", help="Create a new repo on the Hub.")
 def repo_create(
-    repo_id: Annotated[
-        str,
-        typer.Argument(
-            help="Repo ID to create (e.g. username/repo-name). Username defaults to current user if omitted.",
-        ),
-    ],
-    repo_type: Annotated[
-        RepoType,
-        typer.Option(
-            help="set to dataset' or 'space' if creating a dataset or space, default is 'model'.",
-        ),
-    ] = RepoType.model,
+    repo_id: RepoIdArg,
+    repo_type: RepoTypeOpt = RepoType.model,
     space_sdk: Annotated[
         Optional[str],
         typer.Option(
             help="Hugging Face Spaces SDK type. Required when --type is set to 'space'.",
         ),
     ] = None,
-    private: Annotated[
-        bool,
-        typer.Option(
-            "--private",
-            help="Whether to create a private repository. Defaults to public unless the organization's default is private.",
-        ),
-    ] = False,
-    token: Annotated[
-        Optional[str],
-        typer.Option(
-            help="Hugging Face token. Will default to the locally saved token if not provided.",
-        ),
-    ] = None,
+    private: PrivateOpt = False,
+    token: TokenOpt = None,
     exist_ok: Annotated[
         bool,
         typer.Option(
@@ -101,12 +80,7 @@ def repo_create(
 
 @tag_app.command("create", help="Create a tag for a repo.")
 def tag_create(
-    repo_id: Annotated[
-        str,
-        typer.Argument(
-            help="The ID of the repo to tag (e.g. `username/repo-name`).",
-        ),
-    ],
+    repo_id: RepoIdArg,
     tag: Annotated[
         str,
         typer.Argument(
@@ -121,24 +95,9 @@ def tag_create(
             help="The description of the tag to create.",
         ),
     ] = None,
-    revision: Annotated[
-        Optional[str],
-        typer.Option(
-            help="Git revision to tag",
-        ),
-    ] = None,
-    token: Annotated[
-        Optional[str],
-        typer.Option(
-            help="A User Access Token generated from https://huggingface.co/settings/tokens.",
-        ),
-    ] = None,
-    repo_type: Annotated[
-        RepoType,
-        typer.Option(
-            help="Set the type of repository (model, dataset, or space).",
-        ),
-    ] = RepoType.model,
+    revision: RevisionOpt = None,
+    token: TokenOpt = None,
+    repo_type: RepoTypeOpt = RepoType.model,
 ) -> None:
     repo_type_str = repo_type.value
     api = HfApi(token=token)
@@ -161,24 +120,9 @@ def tag_create(
 
 @tag_app.command("list", help="List tags for a repo.")
 def tag_list(
-    repo_id: Annotated[
-        str,
-        typer.Argument(
-            help="The ID of the repo to list tags for (e.g. `username/repo-name`",
-        ),
-    ],
-    token: Annotated[
-        Optional[str],
-        typer.Option(
-            help="A User Access Token generated from https://huggingface.co/settings/tokens.",
-        ),
-    ] = None,
-    repo_type: Annotated[
-        RepoType,
-        typer.Option(
-            help="Set the type of repository (model, dataset, or space).",
-        ),
-    ] = RepoType.model,
+    repo_id: RepoIdArg,
+    token: TokenOpt = None,
+    repo_type: RepoTypeOpt = RepoType.model,
 ) -> None:
     repo_type_str = repo_type.value
     api = HfApi(token=token)
@@ -201,12 +145,7 @@ def tag_list(
 
 @tag_app.command("delete", help="Delete a tag for a repo.")
 def tag_delete(
-    repo_id: Annotated[
-        str,
-        typer.Argument(
-            help="The ID of the repo to delete the tag from (e.g. `username/repo-name`).",
-        ),
-    ],
+    repo_id: RepoIdArg,
     tag: Annotated[
         str,
         typer.Argument(
@@ -221,18 +160,8 @@ def tag_delete(
             help="Answer Yes to prompt automatically",
         ),
     ] = False,
-    token: Annotated[
-        Optional[str],
-        typer.Option(
-            help="A User Access Token generated from https://huggingface.co/settings/tokens.",
-        ),
-    ] = None,
-    repo_type: Annotated[
-        RepoType,
-        typer.Option(
-            help="Set the type of repository (model, dataset, or space).",
-        ),
-    ] = RepoType.model,
+    token: TokenOpt = None,
+    repo_type: RepoTypeOpt = RepoType.model,
 ) -> None:
     repo_type_str = repo_type.value
     print(f"You are about to delete tag {ANSI.bold(tag)} on {repo_type_str} {ANSI.bold(repo_id)}")

--- a/src/huggingface_hub/cli/repo.py
+++ b/src/huggingface_hub/cli/repo.py
@@ -29,7 +29,7 @@ from huggingface_hub.errors import HfHubHTTPError, RepositoryNotFoundError, Revi
 from huggingface_hub.hf_api import HfApi
 from huggingface_hub.utils import logging
 
-from ._cli_utils import ANSI, RepoTypeOpt, typer_factory
+from ._cli_utils import ANSI, RepoType, typer_factory
 
 
 logger = logging.get_logger(__name__)
@@ -48,11 +48,11 @@ def repo_create(
         ),
     ],
     repo_type: Annotated[
-        RepoTypeOpt,
+        RepoType,
         typer.Option(
             help="set to dataset' or 'space' if creating a dataset or space, default is 'model'.",
         ),
-    ] = RepoTypeOpt.model,
+    ] = RepoType.model,
     space_sdk: Annotated[
         Optional[str],
         typer.Option(
@@ -134,11 +134,11 @@ def tag_create(
         ),
     ] = None,
     repo_type: Annotated[
-        RepoTypeOpt,
+        RepoType,
         typer.Option(
             help="Set the type of repository (model, dataset, or space).",
         ),
-    ] = RepoTypeOpt.model,
+    ] = RepoType.model,
 ) -> None:
     repo_type_str = repo_type.value
     api = HfApi(token=token)
@@ -174,11 +174,11 @@ def tag_list(
         ),
     ] = None,
     repo_type: Annotated[
-        RepoTypeOpt,
+        RepoType,
         typer.Option(
             help="Set the type of repository (model, dataset, or space).",
         ),
-    ] = RepoTypeOpt.model,
+    ] = RepoType.model,
 ) -> None:
     repo_type_str = repo_type.value
     api = HfApi(token=token)
@@ -228,11 +228,11 @@ def tag_delete(
         ),
     ] = None,
     repo_type: Annotated[
-        RepoTypeOpt,
+        RepoType,
         typer.Option(
             help="Set the type of repository (model, dataset, or space).",
         ),
-    ] = RepoTypeOpt.model,
+    ] = RepoType.model,
 ) -> None:
     repo_type_str = repo_type.value
     print(f"You are about to delete tag {ANSI.bold(tag)} on {repo_type_str} {ANSI.bold(repo_id)}")

--- a/src/huggingface_hub/cli/repo.py
+++ b/src/huggingface_hub/cli/repo.py
@@ -146,7 +146,7 @@ def tag_create(
         ),
     ] = "model",
 ) -> None:
-    repo_type = validate_repo_type(repo_type)
+    repo_type = validate_repo_type(repo_type) or "model"
     api = HfApi(token=token)
     print(f"You are about to create tag {ANSI.bold(tag)} on {repo_type} {ANSI.bold(repo_id)}")
     try:
@@ -187,7 +187,7 @@ def tag_list(
         ),
     ] = "model",
 ) -> None:
-    repo_type = validate_repo_type(repo_type)
+    repo_type = validate_repo_type(repo_type) or "model"
     api = HfApi(token=token)
     try:
         refs = api.list_repo_refs(repo_id=repo_id, repo_type=repo_type)
@@ -240,7 +240,7 @@ def tag_delete(
         ),
     ] = "model",
 ) -> None:
-    repo_type = validate_repo_type(repo_type)
+    repo_type = validate_repo_type(repo_type) or "model"
     print(f"You are about to delete tag {ANSI.bold(tag)} on {repo_type} {ANSI.bold(repo_id)}")
     if not yes:
         choice = input("Proceed? [Y/n] ").lower()

--- a/src/huggingface_hub/cli/repo.py
+++ b/src/huggingface_hub/cli/repo.py
@@ -29,7 +29,7 @@ from huggingface_hub.errors import HfHubHTTPError, RepositoryNotFoundError, Revi
 from huggingface_hub.hf_api import HfApi
 from huggingface_hub.utils import logging
 
-from ._cli_utils import ANSI, RepoType, typer_factory
+from ._cli_utils import ANSI, RepoTypeOpt, typer_factory
 
 
 logger = logging.get_logger(__name__)
@@ -48,11 +48,11 @@ def repo_create(
         ),
     ],
     repo_type: Annotated[
-        RepoType,
+        RepoTypeOpt,
         typer.Option(
             help="set to dataset' or 'space' if creating a dataset or space, default is 'model'.",
         ),
-    ] = RepoType.model,
+    ] = RepoTypeOpt.model,
     space_sdk: Annotated[
         Optional[str],
         typer.Option(
@@ -134,11 +134,11 @@ def tag_create(
         ),
     ] = None,
     repo_type: Annotated[
-        RepoType,
+        RepoTypeOpt,
         typer.Option(
             help="Set the type of repository (model, dataset, or space).",
         ),
-    ] = RepoType.model,
+    ] = RepoTypeOpt.model,
 ) -> None:
     repo_type_str = repo_type.value
     api = HfApi(token=token)
@@ -174,11 +174,11 @@ def tag_list(
         ),
     ] = None,
     repo_type: Annotated[
-        RepoType,
+        RepoTypeOpt,
         typer.Option(
             help="Set the type of repository (model, dataset, or space).",
         ),
-    ] = RepoType.model,
+    ] = RepoTypeOpt.model,
 ) -> None:
     repo_type_str = repo_type.value
     api = HfApi(token=token)
@@ -228,11 +228,11 @@ def tag_delete(
         ),
     ] = None,
     repo_type: Annotated[
-        RepoType,
+        RepoTypeOpt,
         typer.Option(
             help="Set the type of repository (model, dataset, or space).",
         ),
-    ] = RepoType.model,
+    ] = RepoTypeOpt.model,
 ) -> None:
     repo_type_str = repo_type.value
     print(f"You are about to delete tag {ANSI.bold(tag)} on {repo_type_str} {ANSI.bold(repo_id)}")

--- a/src/huggingface_hub/cli/repo.py
+++ b/src/huggingface_hub/cli/repo.py
@@ -21,13 +21,12 @@ Usage:
     hf repo create my-cool-model --private
 """
 
-import argparse
-from argparse import _SubParsersAction
 from typing import Optional
 
-from huggingface_hub.commands import BaseHuggingfaceCLICommand
+import typer
+
+from huggingface_hub.cli._cli_utils import validate_repo_type
 from huggingface_hub.commands._cli_utils import ANSI
-from huggingface_hub.constants import REPO_TYPES, SPACES_SDK_TYPES
 from huggingface_hub.errors import HfHubHTTPError, RepositoryNotFoundError, RevisionNotFoundError
 from huggingface_hub.hf_api import HfApi
 from huggingface_hub.utils import logging
@@ -35,213 +34,189 @@ from huggingface_hub.utils import logging
 
 logger = logging.get_logger(__name__)
 
-
-class RepoCommands(BaseHuggingfaceCLICommand):
-    @staticmethod
-    def register_subcommand(parser: _SubParsersAction):
-        repo_parser = parser.add_parser("repo", help="Manage repos on the Hub.")
-        repo_subparsers = repo_parser.add_subparsers(help="huggingface.co repos related commands")
-
-        # Show help if no subcommand is provided
-        repo_parser.set_defaults(func=lambda args: repo_parser.print_help())
-
-        # CREATE
-        repo_create_parser = repo_subparsers.add_parser("create", help="Create a new repo on huggingface.co")
-        repo_create_parser.add_argument(
-            "repo_id",
-            type=str,
-            help="The ID of the repo to create to (e.g. `username/repo-name`). The username is optional and will be set to your username if not provided.",
-        )
-        repo_create_parser.add_argument(
-            "--repo-type",
-            type=str,
-            help='Optional: set to "dataset" or "space" if creating a dataset or space, default is model.',
-        )
-        repo_create_parser.add_argument(
-            "--space_sdk",
-            type=str,
-            help='Optional: Hugging Face Spaces SDK type. Required when --type is set to "space".',
-            choices=SPACES_SDK_TYPES,
-        )
-        repo_create_parser.add_argument(
-            "--private",
-            action="store_true",
-            help="Whether to create a private repository. Defaults to public unless the organization's default is private.",
-        )
-        repo_create_parser.add_argument(
-            "--token",
-            type=str,
-            help="Hugging Face token. Will default to the locally saved token if not provided.",
-        )
-        repo_create_parser.add_argument(
-            "--exist-ok",
-            action="store_true",
-            help="Do not raise an error if repo already exists.",
-        )
-        repo_create_parser.add_argument(
-            "--resource-group-id",
-            type=str,
-            help="Resource group in which to create the repo. Resource groups is only available for Enterprise Hub organizations.",
-        )
-        repo_create_parser.set_defaults(func=lambda args: RepoCreateCommand(args))
-
-        # TAG SUBCOMMANDS
-        repo_tag_parser = repo_subparsers.add_parser("tag", help="Manage tags for a repo on the Hub.")
-        tag_subparsers = repo_tag_parser.add_subparsers(help="Tag actions", dest="tag_action", required=True)
-
-        # tag create
-        tag_create_parser = tag_subparsers.add_parser("create", help="Create a tag for a repo.")
-        tag_create_parser.add_argument(
-            "repo_id", type=str, help="The ID of the repo to tag (e.g. `username/repo-name`)."
-        )
-        tag_create_parser.add_argument("tag", type=str, help="The name of the tag to create.")
-        tag_create_parser.add_argument("-m", "--message", type=str, help="The description of the tag to create.")
-        tag_create_parser.add_argument("--revision", type=str, help="The git revision to tag.")
-        tag_create_parser.add_argument(
-            "--token", type=str, help="A User Access Token generated from https://huggingface.co/settings/tokens."
-        )
-        tag_create_parser.add_argument(
-            "--repo-type",
-            choices=["model", "dataset", "space"],
-            default="model",
-            help="Set the type of repository (model, dataset, or space).",
-        )
-        tag_create_parser.set_defaults(func=lambda args: RepoTagCreateCommand(args))
-
-        # tag list
-        tag_list_parser = tag_subparsers.add_parser("list", help="List tags for a repo.")
-        tag_list_parser.add_argument(
-            "repo_id", type=str, help="The ID of the repo to list tags for (e.g. `username/repo-name`)."
-        )
-        tag_list_parser.add_argument(
-            "--token", type=str, help="A User Access Token generated from https://huggingface.co/settings/tokens."
-        )
-        tag_list_parser.add_argument(
-            "--repo-type",
-            choices=["model", "dataset", "space"],
-            default="model",
-            help="Set the type of repository (model, dataset, or space).",
-        )
-        tag_list_parser.set_defaults(func=lambda args: RepoTagListCommand(args))
-
-        # tag delete
-        tag_delete_parser = tag_subparsers.add_parser("delete", help="Delete a tag from a repo.")
-        tag_delete_parser.add_argument(
-            "repo_id", type=str, help="The ID of the repo to delete the tag from (e.g. `username/repo-name`)."
-        )
-        tag_delete_parser.add_argument("tag", type=str, help="The name of the tag to delete.")
-        tag_delete_parser.add_argument("-y", "--yes", action="store_true", help="Answer Yes to prompts automatically.")
-        tag_delete_parser.add_argument(
-            "--token", type=str, help="A User Access Token generated from https://huggingface.co/settings/tokens."
-        )
-        tag_delete_parser.add_argument(
-            "--repo-type",
-            choices=["model", "dataset", "space"],
-            default="model",
-            help="Set the type of repository (model, dataset, or space).",
-        )
-        tag_delete_parser.set_defaults(func=lambda args: RepoTagDeleteCommand(args))
+repo_app = typer.Typer(help="Manage repos on the Hub.")
+tag_app = typer.Typer(help="Manage tags for a repo on the Hub.")
+repo_app.add_typer(tag_app, name="tag")
 
 
-class RepoCreateCommand:
-    def __init__(self, args: argparse.Namespace):
-        self.repo_id: str = args.repo_id
-        self.repo_type: Optional[str] = args.repo_type
-        self.space_sdk: Optional[str] = args.space_sdk
-        self.private: bool = args.private
-        self.token: Optional[str] = args.token
-        self.exist_ok: bool = args.exist_ok
-        self.resource_group_id: Optional[str] = args.resource_group_id
-        self._api = HfApi()
-
-    def run(self):
-        repo_url = self._api.create_repo(
-            repo_id=self.repo_id,
-            repo_type=self.repo_type,
-            private=self.private,
-            token=self.token,
-            exist_ok=self.exist_ok,
-            resource_group_id=self.resource_group_id,
-            space_sdk=self.space_sdk,
-        )
-        print(f"Successfully created {ANSI.bold(repo_url.repo_id)} on the Hub.")
-        print(f"Your repo is now available at {ANSI.bold(repo_url)}")
-
-
-class RepoTagCommand:
-    def __init__(self, args):
-        self.args = args
-        self.api = HfApi(token=getattr(args, "token", None))
-        self.repo_id = args.repo_id
-        self.repo_type = getattr(args, "repo_type", "model")
-        if self.repo_type not in REPO_TYPES:
-            print("Invalid repo --repo-type")
-            exit(1)
-
-
-class RepoTagCreateCommand(RepoTagCommand):
-    def run(self):
-        print(
-            f"You are about to create tag {ANSI.bold(str(self.args.tag))} on {self.repo_type} {ANSI.bold(self.repo_id)}"
-        )
-        try:
-            self.api.create_tag(
-                repo_id=self.repo_id,
-                tag=self.args.tag,
-                tag_message=getattr(self.args, "message", None),
-                revision=getattr(self.args, "revision", None),
-                repo_type=self.repo_type,
-            )
-        except RepositoryNotFoundError:
-            print(f"{self.repo_type.capitalize()} {ANSI.bold(self.repo_id)} not found.")
-            exit(1)
-        except RevisionNotFoundError:
-            print(f"Revision {ANSI.bold(str(getattr(self.args, 'revision', None)))} not found.")
-            exit(1)
-        except HfHubHTTPError as e:
-            if e.response.status_code == 409:
-                print(f"Tag {ANSI.bold(str(self.args.tag))} already exists on {ANSI.bold(self.repo_id)}")
-                exit(1)
-            raise e
-        print(f"Tag {ANSI.bold(str(self.args.tag))} created on {ANSI.bold(self.repo_id)}")
+@repo_app.command("create", help="Create a new repo on the Hub.")
+def repo_create(
+    repo_id: str = typer.Argument(
+        ...,
+        help="Repo ID to create (e.g. username/repo-name). Username defaults to current user if omitted.",
+    ),
+    repo_type: Optional[str] = typer.Option(
+        None,
+        "--repo-type",
+        help="set to dataset' or 'space' if creating a dataset or space, default is 'model'.",
+    ),
+    space_sdk: Optional[str] = typer.Option(
+        None,
+        "--space_sdk",
+        help="Hugging Face Spaces SDK type. Required when --type is set to 'space'.",
+        rich_help_panel=None,
+    ),
+    private: bool = typer.Option(
+        False,
+        "--private",
+        help="Whether to create a private repository. Defaults to public unless the organization's default is private.",
+    ),
+    token: Optional[str] = typer.Option(
+        None,
+        "--token",
+        help="Hugging Face token. Will default to the locally saved token if not provided.",
+    ),
+    exist_ok: bool = typer.Option(
+        False,
+        "--exist-ok",
+        help="Do not raise an error if repo already exists.",
+    ),
+    resource_group_id: Optional[str] = typer.Option(
+        None,
+        "--resource-group-id",
+        help="Resource group in which to create the repo. Resource groups is only available for Enterprise Hub organizations.",
+    ),
+) -> None:
+    repo_type = validate_repo_type(repo_type)
+    api = HfApi()
+    repo_url = api.create_repo(
+        repo_id=repo_id,
+        repo_type=repo_type,
+        private=private,
+        token=token,
+        exist_ok=exist_ok,
+        resource_group_id=resource_group_id,
+        space_sdk=space_sdk,
+    )
+    print(f"Successfully created {ANSI.bold(repo_url.repo_id)} on the Hub.")
+    print(f"Your repo is now available at {ANSI.bold(repo_url)}")
 
 
-class RepoTagListCommand(RepoTagCommand):
-    def run(self):
-        try:
-            refs = self.api.list_repo_refs(
-                repo_id=self.repo_id,
-                repo_type=self.repo_type,
-            )
-        except RepositoryNotFoundError:
-            print(f"{self.repo_type.capitalize()} {ANSI.bold(self.repo_id)} not found.")
-            exit(1)
-        except HfHubHTTPError as e:
-            print(e)
-            print(ANSI.red(e.response.text))
-            exit(1)
-        if len(refs.tags) == 0:
-            print("No tags found")
-            exit(0)
-        print(f"Tags for {self.repo_type} {ANSI.bold(self.repo_id)}:")
-        for tag in refs.tags:
-            print(tag.name)
+@tag_app.command("create", help="Create a tag for a repo.")
+def tag_create(
+    repo_id: str = typer.Argument(
+        ...,
+        help="The ID of the repo to tag (e.g. `username/repo-name`).",
+    ),
+    tag: str = typer.Argument(
+        ...,
+        help="The name of the tag to create.",
+    ),
+    message: Optional[str] = typer.Option(
+        None,
+        "-m",
+        "--message",
+        help="The description of the tag to create.",
+    ),
+    revision: Optional[str] = typer.Option(
+        None,
+        "--revision",
+        help="Git revision to tag",
+    ),
+    token: Optional[str] = typer.Option(
+        None,
+        "--token",
+        help="A User Access Token generated from https://huggingface.co/settings/tokens.",
+    ),
+    repo_type: Optional[str] = typer.Option(
+        "model",
+        "--repo-type",
+        help="Set the type of repository (model, dataset, or space).",
+    ),
+) -> None:
+    repo_type = validate_repo_type(repo_type)
+    api = HfApi(token=token)
+    print(f"You are about to create tag {ANSI.bold(tag)} on {repo_type} {ANSI.bold(repo_id)}")
+    try:
+        api.create_tag(repo_id=repo_id, tag=tag, tag_message=message, revision=revision, repo_type=repo_type)
+    except RepositoryNotFoundError:
+        print(f"{repo_type.capitalize()} {ANSI.bold(repo_id)} not found.")
+        raise typer.Exit(code=1)
+    except RevisionNotFoundError:
+        print(f"Revision {ANSI.bold(str(revision))} not found.")
+        raise typer.Exit(code=1)
+    except HfHubHTTPError as e:
+        if e.response.status_code == 409:
+            print(f"Tag {ANSI.bold(tag)} already exists on {ANSI.bold(repo_id)}")
+            raise typer.Exit(code=1)
+        raise e
+    print(f"Tag {ANSI.bold(tag)} created on {ANSI.bold(repo_id)}")
 
 
-class RepoTagDeleteCommand(RepoTagCommand):
-    def run(self):
-        print(f"You are about to delete tag {ANSI.bold(self.args.tag)} on {self.repo_type} {ANSI.bold(self.repo_id)}")
-        if not getattr(self.args, "yes", False):
-            choice = input("Proceed? [Y/n] ").lower()
-            if choice not in ("", "y", "yes"):
-                print("Abort")
-                exit()
-        try:
-            self.api.delete_tag(repo_id=self.repo_id, tag=self.args.tag, repo_type=self.repo_type)
-        except RepositoryNotFoundError:
-            print(f"{self.repo_type.capitalize()} {ANSI.bold(self.repo_id)} not found.")
-            exit(1)
-        except RevisionNotFoundError:
-            print(f"Tag {ANSI.bold(self.args.tag)} not found on {ANSI.bold(self.repo_id)}")
-            exit(1)
-        print(f"Tag {ANSI.bold(self.args.tag)} deleted on {ANSI.bold(self.repo_id)}")
+@tag_app.command("list", help="List tags for a repo.")
+def tag_list(
+    repo_id: str = typer.Argument(
+        ...,
+        help="The ID of the repo to list tags for (e.g. `username/repo-name`",
+    ),
+    token: Optional[str] = typer.Option(
+        None,
+        "--token",
+        help="A User Access Token generated from https://huggingface.co/settings/tokens.",
+    ),
+    repo_type: Optional[str] = typer.Option(
+        "model",
+        "--repo-type",
+        help="Set the type of repository (model, dataset, or space).",
+    ),
+) -> None:
+    repo_type = validate_repo_type(repo_type)
+    api = HfApi(token=token)
+    try:
+        refs = api.list_repo_refs(repo_id=repo_id, repo_type=repo_type)
+    except RepositoryNotFoundError:
+        print(f"{repo_type.capitalize()} {ANSI.bold(repo_id)} not found.")
+        raise typer.Exit(code=1)
+    except HfHubHTTPError as e:
+        print(e)
+        print(ANSI.red(e.response.text))
+        raise typer.Exit(code=1)
+    if len(refs.tags) == 0:
+        print("No tags found")
+        raise typer.Exit(code=0)
+    print(f"Tags for {repo_type} {ANSI.bold(repo_id)}:")
+    for t in refs.tags:
+        print(t.name)
+
+
+@tag_app.command("delete", help="Delete a tag for a repo.")
+def tag_delete(
+    repo_id: str = typer.Argument(
+        ...,
+        help="The ID of the repo to delete the tag from (e.g. `username/repo-name`).",
+    ),
+    tag: str = typer.Argument(..., help="The name of the tag to delete."),
+    yes: bool = typer.Option(
+        False,
+        "-y",
+        "--yes",
+        help="Answer Yes to prompt automatically",
+    ),
+    token: Optional[str] = typer.Option(
+        None,
+        "--token",
+        help="A User Access Token generated from https://huggingface.co/settings/tokens.",
+    ),
+    repo_type: Optional[str] = typer.Option(
+        "model",
+        "--repo-type",
+        help="Set the type of repository (model, dataset, or space).",
+    ),
+) -> None:
+    repo_type = validate_repo_type(repo_type)
+    print(f"You are about to delete tag {ANSI.bold(tag)} on {repo_type} {ANSI.bold(repo_id)}")
+    if not yes:
+        choice = input("Proceed? [Y/n] ").lower()
+        if choice not in ("", "y", "yes"):
+            print("Abort")
+            raise typer.Exit()
+    api = HfApi(token=token)
+    try:
+        api.delete_tag(repo_id=repo_id, tag=tag, repo_type=repo_type)
+    except RepositoryNotFoundError:
+        print(f"{repo_type.capitalize()} {ANSI.bold(repo_id)} not found.")
+        raise typer.Exit(code=1)
+    except RevisionNotFoundError:
+        print(f"Tag {ANSI.bold(tag)} not found on {ANSI.bold(repo_id)}")
+        raise typer.Exit(code=1)
+    print(f"Tag {ANSI.bold(tag)} deleted on {ANSI.bold(repo_id)}")

--- a/src/huggingface_hub/cli/repo.py
+++ b/src/huggingface_hub/cli/repo.py
@@ -25,6 +25,7 @@ from typing import Annotated, Optional
 
 import typer
 
+from huggingface_hub import __version__
 from huggingface_hub.errors import HfHubHTTPError, RepositoryNotFoundError, RevisionNotFoundError
 from huggingface_hub.hf_api import HfApi
 from huggingface_hub.utils import logging
@@ -64,7 +65,7 @@ def repo_create(
         ),
     ] = None,
 ) -> None:
-    api = HfApi()
+    api = HfApi(token=token, library_name="hf", library_version=__version__)
     repo_url = api.create_repo(
         repo_id=repo_id,
         repo_type=repo_type.value,
@@ -100,7 +101,7 @@ def tag_create(
     repo_type: RepoTypeOpt = RepoType.model,
 ) -> None:
     repo_type_str = repo_type.value
-    api = HfApi(token=token)
+    api = HfApi(token=token, library_name="hf", library_version=__version__)
     print(f"You are about to create tag {ANSI.bold(tag)} on {repo_type_str} {ANSI.bold(repo_id)}")
     try:
         api.create_tag(repo_id=repo_id, tag=tag, tag_message=message, revision=revision, repo_type=repo_type_str)
@@ -125,7 +126,7 @@ def tag_list(
     repo_type: RepoTypeOpt = RepoType.model,
 ) -> None:
     repo_type_str = repo_type.value
-    api = HfApi(token=token)
+    api = HfApi(token=token, library_name="hf", library_version=__version__)
     try:
         refs = api.list_repo_refs(repo_id=repo_id, repo_type=repo_type_str)
     except RepositoryNotFoundError:
@@ -170,7 +171,7 @@ def tag_delete(
         if choice not in ("", "y", "yes"):
             print("Abort")
             raise typer.Exit()
-    api = HfApi(token=token)
+    api = HfApi(token=token, library_name="hf", library_version=__version__)
     try:
         api.delete_tag(repo_id=repo_id, tag=tag, repo_type=repo_type_str)
     except RepositoryNotFoundError:

--- a/src/huggingface_hub/cli/repo.py
+++ b/src/huggingface_hub/cli/repo.py
@@ -29,13 +29,13 @@ from huggingface_hub.errors import HfHubHTTPError, RepositoryNotFoundError, Revi
 from huggingface_hub.hf_api import HfApi
 from huggingface_hub.utils import logging
 
-from ._cli_utils import ANSI, RepoType
+from ._cli_utils import ANSI, RepoType, typer_factory
 
 
 logger = logging.get_logger(__name__)
 
-repo_cli = typer.Typer(help="Manage repos on the Hub.", rich_markup_mode=None)
-tag_app = typer.Typer(help="Manage tags for a repo on the Hub.", rich_markup_mode=None)
+repo_cli = typer_factory(help="Manage repos on the Hub.")
+tag_app = typer_factory(help="Manage tags for a repo on the Hub.")
 repo_cli.add_typer(tag_app, name="tag")
 
 

--- a/src/huggingface_hub/cli/repo.py
+++ b/src/huggingface_hub/cli/repo.py
@@ -21,9 +21,8 @@ Usage:
     hf repo create my-cool-model --private
 """
 
-from typing import Optional
-
 import typer
+from typing_extensions import Annotated
 
 from huggingface_hub.cli._cli_utils import validate_repo_type
 from huggingface_hub.commands._cli_utils import ANSI
@@ -41,41 +40,51 @@ repo_app.add_typer(tag_app, name="tag")
 
 @repo_app.command("create", help="Create a new repo on the Hub.")
 def repo_create(
-    repo_id: str = typer.Argument(
-        ...,
-        help="Repo ID to create (e.g. username/repo-name). Username defaults to current user if omitted.",
-    ),
-    repo_type: Optional[str] = typer.Option(
-        None,
-        "--repo-type",
-        help="set to dataset' or 'space' if creating a dataset or space, default is 'model'.",
-    ),
-    space_sdk: Optional[str] = typer.Option(
-        None,
-        "--space_sdk",
-        help="Hugging Face Spaces SDK type. Required when --type is set to 'space'.",
-        rich_help_panel=None,
-    ),
-    private: bool = typer.Option(
-        False,
-        "--private",
-        help="Whether to create a private repository. Defaults to public unless the organization's default is private.",
-    ),
-    token: Optional[str] = typer.Option(
-        None,
-        "--token",
-        help="Hugging Face token. Will default to the locally saved token if not provided.",
-    ),
-    exist_ok: bool = typer.Option(
-        False,
-        "--exist-ok",
-        help="Do not raise an error if repo already exists.",
-    ),
-    resource_group_id: Optional[str] = typer.Option(
-        None,
-        "--resource-group-id",
-        help="Resource group in which to create the repo. Resource groups is only available for Enterprise Hub organizations.",
-    ),
+    repo_id: Annotated[
+        str,
+        typer.Argument(
+            ...,
+            help="Repo ID to create (e.g. username/repo-name). Username defaults to current user if omitted.",
+        ),
+    ],
+    repo_type: Annotated[
+        str,
+        typer.Option(
+            help="set to dataset' or 'space' if creating a dataset or space, default is 'model'.",
+        ),
+    ] = None,
+    space_sdk: Annotated[
+        str,
+        typer.Option(
+            help="Hugging Face Spaces SDK type. Required when --type is set to 'space'.",
+            rich_help_panel=None,
+        ),
+    ] = None,
+    private: Annotated[
+        bool,
+        typer.Option(
+            "--private",
+            help="Whether to create a private repository. Defaults to public unless the organization's default is private.",
+        ),
+    ] = False,
+    token: Annotated[
+        str,
+        typer.Option(
+            help="Hugging Face token. Will default to the locally saved token if not provided.",
+        ),
+    ] = None,
+    exist_ok: Annotated[
+        bool,
+        typer.Option(
+            help="Do not raise an error if repo already exists.",
+        ),
+    ] = False,
+    resource_group_id: Annotated[
+        str,
+        typer.Option(
+            help="Resource group in which to create the repo. Resource groups is only available for Enterprise Hub organizations.",
+        ),
+    ] = None,
 ) -> None:
     repo_type = validate_repo_type(repo_type)
     api = HfApi()
@@ -94,35 +103,46 @@ def repo_create(
 
 @tag_app.command("create", help="Create a tag for a repo.")
 def tag_create(
-    repo_id: str = typer.Argument(
-        ...,
-        help="The ID of the repo to tag (e.g. `username/repo-name`).",
-    ),
-    tag: str = typer.Argument(
-        ...,
-        help="The name of the tag to create.",
-    ),
-    message: Optional[str] = typer.Option(
-        None,
-        "-m",
-        "--message",
-        help="The description of the tag to create.",
-    ),
-    revision: Optional[str] = typer.Option(
-        None,
-        "--revision",
-        help="Git revision to tag",
-    ),
-    token: Optional[str] = typer.Option(
-        None,
-        "--token",
-        help="A User Access Token generated from https://huggingface.co/settings/tokens.",
-    ),
-    repo_type: Optional[str] = typer.Option(
-        "model",
-        "--repo-type",
-        help="Set the type of repository (model, dataset, or space).",
-    ),
+    repo_id: Annotated[
+        str,
+        typer.Argument(
+            ...,
+            help="The ID of the repo to tag (e.g. `username/repo-name`).",
+        ),
+    ],
+    tag: Annotated[
+        str,
+        typer.Argument(
+            ...,
+            help="The name of the tag to create.",
+        ),
+    ],
+    message: Annotated[
+        str,
+        typer.Option(
+            "-m",
+            "--message",
+            help="The description of the tag to create.",
+        ),
+    ] = None,
+    revision: Annotated[
+        str,
+        typer.Option(
+            help="Git revision to tag",
+        ),
+    ] = None,
+    token: Annotated[
+        str,
+        typer.Option(
+            help="A User Access Token generated from https://huggingface.co/settings/tokens.",
+        ),
+    ] = None,
+    repo_type: Annotated[
+        str,
+        typer.Option(
+            help="Set the type of repository (model, dataset, or space).",
+        ),
+    ] = "model",
 ) -> None:
     repo_type = validate_repo_type(repo_type)
     api = HfApi(token=token)
@@ -145,20 +165,25 @@ def tag_create(
 
 @tag_app.command("list", help="List tags for a repo.")
 def tag_list(
-    repo_id: str = typer.Argument(
-        ...,
-        help="The ID of the repo to list tags for (e.g. `username/repo-name`",
-    ),
-    token: Optional[str] = typer.Option(
-        None,
-        "--token",
-        help="A User Access Token generated from https://huggingface.co/settings/tokens.",
-    ),
-    repo_type: Optional[str] = typer.Option(
-        "model",
-        "--repo-type",
-        help="Set the type of repository (model, dataset, or space).",
-    ),
+    repo_id: Annotated[
+        str,
+        typer.Argument(
+            ...,
+            help="The ID of the repo to list tags for (e.g. `username/repo-name`",
+        ),
+    ],
+    token: Annotated[
+        str,
+        typer.Option(
+            help="A User Access Token generated from https://huggingface.co/settings/tokens.",
+        ),
+    ] = None,
+    repo_type: Annotated[
+        str,
+        typer.Option(
+            help="Set the type of repository (model, dataset, or space).",
+        ),
+    ] = "model",
 ) -> None:
     repo_type = validate_repo_type(repo_type)
     api = HfApi(token=token)
@@ -181,27 +206,37 @@ def tag_list(
 
 @tag_app.command("delete", help="Delete a tag for a repo.")
 def tag_delete(
-    repo_id: str = typer.Argument(
-        ...,
-        help="The ID of the repo to delete the tag from (e.g. `username/repo-name`).",
-    ),
-    tag: str = typer.Argument(..., help="The name of the tag to delete."),
-    yes: bool = typer.Option(
-        False,
-        "-y",
-        "--yes",
-        help="Answer Yes to prompt automatically",
-    ),
-    token: Optional[str] = typer.Option(
-        None,
-        "--token",
-        help="A User Access Token generated from https://huggingface.co/settings/tokens.",
-    ),
-    repo_type: Optional[str] = typer.Option(
-        "model",
-        "--repo-type",
-        help="Set the type of repository (model, dataset, or space).",
-    ),
+    repo_id: Annotated[
+        str,
+        typer.Argument(
+            ...,
+            help="The ID of the repo to delete the tag from (e.g. `username/repo-name`).",
+        ),
+    ],
+    tag: Annotated[
+        str,
+        typer.Argument(..., help="The name of the tag to delete."),
+    ],
+    yes: Annotated[
+        bool,
+        typer.Option(
+            "-y",
+            "--yes",
+            help="Answer Yes to prompt automatically",
+        ),
+    ] = False,
+    token: Annotated[
+        str,
+        typer.Option(
+            help="A User Access Token generated from https://huggingface.co/settings/tokens.",
+        ),
+    ] = None,
+    repo_type: Annotated[
+        str,
+        typer.Option(
+            help="Set the type of repository (model, dataset, or space).",
+        ),
+    ] = "model",
 ) -> None:
     repo_type = validate_repo_type(repo_type)
     print(f"You are about to delete tag {ANSI.bold(tag)} on {repo_type} {ANSI.bold(repo_id)}")

--- a/src/huggingface_hub/cli/repo.py
+++ b/src/huggingface_hub/cli/repo.py
@@ -35,12 +35,12 @@ from huggingface_hub.utils import logging
 
 logger = logging.get_logger(__name__)
 
-repo_app = typer.Typer(help="Manage repos on the Hub.", rich_markup_mode=None)
+repo_cli = typer.Typer(help="Manage repos on the Hub.", rich_markup_mode=None)
 tag_app = typer.Typer(help="Manage tags for a repo on the Hub.", rich_markup_mode=None)
-repo_app.add_typer(tag_app, name="tag")
+repo_cli.add_typer(tag_app, name="tag")
 
 
-@repo_app.command("create", help="Create a new repo on the Hub.")
+@repo_cli.command("create", help="Create a new repo on the Hub.")
 def repo_create(
     repo_id: Annotated[
         str,

--- a/src/huggingface_hub/cli/repo.py
+++ b/src/huggingface_hub/cli/repo.py
@@ -25,12 +25,20 @@ from typing import Annotated, Optional
 
 import typer
 
-from huggingface_hub import __version__
 from huggingface_hub.errors import HfHubHTTPError, RepositoryNotFoundError, RevisionNotFoundError
-from huggingface_hub.hf_api import HfApi
 from huggingface_hub.utils import logging
 
-from ._cli_utils import ANSI, PrivateOpt, RepoIdArg, RepoType, RepoTypeOpt, RevisionOpt, TokenOpt, typer_factory
+from ._cli_utils import (
+    ANSI,
+    PrivateOpt,
+    RepoIdArg,
+    RepoType,
+    RepoTypeOpt,
+    RevisionOpt,
+    TokenOpt,
+    get_hf_api,
+    typer_factory,
+)
 
 
 logger = logging.get_logger(__name__)
@@ -65,7 +73,7 @@ def repo_create(
         ),
     ] = None,
 ) -> None:
-    api = HfApi(token=token, library_name="hf", library_version=__version__)
+    api = get_hf_api(token=token)
     repo_url = api.create_repo(
         repo_id=repo_id,
         repo_type=repo_type.value,
@@ -101,7 +109,7 @@ def tag_create(
     repo_type: RepoTypeOpt = RepoType.model,
 ) -> None:
     repo_type_str = repo_type.value
-    api = HfApi(token=token, library_name="hf", library_version=__version__)
+    api = get_hf_api(token=token)
     print(f"You are about to create tag {ANSI.bold(tag)} on {repo_type_str} {ANSI.bold(repo_id)}")
     try:
         api.create_tag(repo_id=repo_id, tag=tag, tag_message=message, revision=revision, repo_type=repo_type_str)
@@ -126,7 +134,7 @@ def tag_list(
     repo_type: RepoTypeOpt = RepoType.model,
 ) -> None:
     repo_type_str = repo_type.value
-    api = HfApi(token=token, library_name="hf", library_version=__version__)
+    api = get_hf_api(token=token)
     try:
         refs = api.list_repo_refs(repo_id=repo_id, repo_type=repo_type_str)
     except RepositoryNotFoundError:
@@ -171,7 +179,7 @@ def tag_delete(
         if choice not in ("", "y", "yes"):
             print("Abort")
             raise typer.Exit()
-    api = HfApi(token=token, library_name="hf", library_version=__version__)
+    api = get_hf_api(token=token)
     try:
         api.delete_tag(repo_id=repo_id, tag=tag, repo_type=repo_type_str)
     except RepositoryNotFoundError:

--- a/src/huggingface_hub/cli/repo.py
+++ b/src/huggingface_hub/cli/repo.py
@@ -21,10 +21,9 @@ Usage:
     hf repo create my-cool-model --private
 """
 
-from typing import Optional
+from typing import Annotated, Optional
 
 import typer
-from typing_extensions import Annotated
 
 from huggingface_hub.cli._cli_utils import validate_repo_type
 from huggingface_hub.commands._cli_utils import ANSI

--- a/src/huggingface_hub/cli/repo_files.py
+++ b/src/huggingface_hub/cli/repo_files.py
@@ -34,10 +34,9 @@ Usage:
     hf repo-files delete <repo_id> file.txt --revision=refs/pr/1 --repo-type=dataset
 """
 
-from typing import Optional
+from typing import Annotated, Optional
 
 import typer
-from typing_extensions import Annotated
 
 from huggingface_hub import logging
 from huggingface_hub.hf_api import HfApi

--- a/src/huggingface_hub/cli/repo_files.py
+++ b/src/huggingface_hub/cli/repo_files.py
@@ -91,14 +91,12 @@ def repo_files_delete(
     create_pr: Annotated[
         bool,
         typer.Option(
-            "--create-pr",
             help="Whether to create a new Pull Request for these changes.",
         ),
     ] = False,
     token: Annotated[
         Optional[str],
         typer.Option(
-            "--token",
             help="A User Access Token generated from https://huggingface.co/settings/tokens",
         ),
     ] = None,

--- a/src/huggingface_hub/cli/repo_files.py
+++ b/src/huggingface_hub/cli/repo_files.py
@@ -55,14 +55,12 @@ def repo_files_delete(
     repo_id: Annotated[
         str,
         typer.Argument(
-            ...,
             help="The ID of the repo (e.g. username/repo-name).",
         ),
     ],
     patterns: Annotated[
         list[str],
         typer.Argument(
-            ...,
             help="Glob patterns to match files to delete.",
         ),
     ],

--- a/src/huggingface_hub/cli/repo_files.py
+++ b/src/huggingface_hub/cli/repo_files.py
@@ -47,7 +47,7 @@ from ._cli_utils import validate_repo_type
 logger = logging.get_logger(__name__)
 
 
-repo_files_app = typer.Typer(help="Manage files in a repo on the Hub.")
+repo_files_app = typer.Typer(help="Manage files in a repo on the Hub.", rich_markup_mode=None)
 
 
 @repo_files_app.command("delete")

--- a/src/huggingface_hub/cli/repo_files.py
+++ b/src/huggingface_hub/cli/repo_files.py
@@ -41,13 +41,13 @@ import typer
 from huggingface_hub import logging
 from huggingface_hub.hf_api import HfApi
 
-from ._cli_utils import RepoType
+from ._cli_utils import RepoType, typer_factory
 
 
 logger = logging.get_logger(__name__)
 
 
-repo_files_cli = typer.Typer(help="Manage files in a repo on the Hub.", rich_markup_mode=None)
+repo_files_cli = typer_factory(help="Manage files in a repo on the Hub.")
 
 
 @repo_files_cli.command("delete")

--- a/src/huggingface_hub/cli/repo_files.py
+++ b/src/huggingface_hub/cli/repo_files.py
@@ -34,95 +34,66 @@ Usage:
     hf repo-files delete <repo_id> file.txt --revision=refs/pr/1 --repo-type=dataset
 """
 
-from argparse import _SubParsersAction
 from typing import Optional
 
+import typer
+
 from huggingface_hub import logging
-from huggingface_hub.commands import BaseHuggingfaceCLICommand
 from huggingface_hub.hf_api import HfApi
+
+from ._cli_utils import validate_repo_type
 
 
 logger = logging.get_logger(__name__)
 
 
-class DeleteFilesSubCommand:
-    def __init__(self, args) -> None:
-        self.args = args
-        self.repo_id: str = args.repo_id
-        self.repo_type: Optional[str] = args.repo_type
-        self.revision: Optional[str] = args.revision
-        self.api: HfApi = HfApi(token=args.token, library_name="hf")
-        self.patterns: list[str] = args.patterns
-        self.commit_message: Optional[str] = args.commit_message
-        self.commit_description: Optional[str] = args.commit_description
-        self.create_pr: bool = args.create_pr
-        self.token: Optional[str] = args.token
-
-    def run(self) -> None:
-        logging.set_verbosity_info()
-        url = self.api.delete_files(
-            delete_patterns=self.patterns,
-            repo_id=self.repo_id,
-            repo_type=self.repo_type,
-            revision=self.revision,
-            commit_message=self.commit_message,
-            commit_description=self.commit_description,
-            create_pr=self.create_pr,
-        )
-        print(f"Files correctly deleted from repo. Commit: {url}.")
-        logging.set_verbosity_warning()
+repo_files_app = typer.Typer(help="Manage files in a repo on the Hub.")
 
 
-class RepoFilesCommand(BaseHuggingfaceCLICommand):
-    @staticmethod
-    def register_subcommand(parser: _SubParsersAction):
-        repo_files_parser = parser.add_parser("repo-files", help="Manage files in a repo on the Hub.")
-        repo_files_subparsers = repo_files_parser.add_subparsers(
-            help="Action to execute against the files.",
-            required=True,
-        )
-        delete_subparser = repo_files_subparsers.add_parser(
-            "delete",
-            help="Delete files from a repo on the Hub",
-        )
-        delete_subparser.set_defaults(func=lambda args: DeleteFilesSubCommand(args))
-        delete_subparser.add_argument(
-            "repo_id", type=str, help="The ID of the repo to manage (e.g. `username/repo-name`)."
-        )
-        delete_subparser.add_argument(
-            "patterns",
-            nargs="+",
-            type=str,
-            help="Glob patterns to match files to delete.",
-        )
-        delete_subparser.add_argument(
-            "--repo-type",
-            choices=["model", "dataset", "space"],
-            default="model",
-            help="Type of the repo to upload to (e.g. `dataset`).",
-        )
-        delete_subparser.add_argument(
-            "--revision",
-            type=str,
-            help=(
-                "An optional Git revision to push to. It can be a branch name "
-                "or a PR reference. If revision does not"
-                " exist and `--create-pr` is not set, a branch will be automatically created."
-            ),
-        )
-        delete_subparser.add_argument(
-            "--commit-message", type=str, help="The summary / title / first line of the generated commit."
-        )
-        delete_subparser.add_argument(
-            "--commit-description", type=str, help="The description of the generated commit."
-        )
-        delete_subparser.add_argument(
-            "--create-pr", action="store_true", help="Whether to create a new Pull Request for these changes."
-        )
-        delete_subparser.add_argument(
-            "--token",
-            type=str,
-            help="A User Access Token generated from https://huggingface.co/settings/tokens",
-        )
-
-        repo_files_parser.set_defaults(func=RepoFilesCommand)
+@repo_files_app.command("delete")
+def repo_files_delete(
+    repo_id: str = typer.Argument(
+        ...,
+        help="The ID of the repo (e.g. username/repo-name).",
+    ),
+    patterns: list[str] = typer.Argument(
+        ...,
+        help="Glob patterns to match files to delete.",
+    ),
+    repo_type: Optional[str] = typer.Option(
+        "model",
+        "--repo-type",
+        help="Type of the repo to upload to (e.g. `dataset`).",
+    ),
+    revision: Optional[str] = typer.Option(
+        None,
+        "--revision",
+        help="An optional Git revision to push to. It can be a branch name or a PR reference. If revision does not exist and `--create-pr` is not set, a branch will be automatically created.",
+    ),
+    commit_message: Optional[str] = typer.Option(
+        None, "--commit-message", help="The summary / title / first line of the generated commit."
+    ),
+    commit_description: Optional[str] = typer.Option(
+        None, "--commit-description", help="The description of the generated commit."
+    ),
+    create_pr: bool = typer.Option(
+        False, "--create-pr", help="Whether to create a new Pull Request for these changes."
+    ),
+    token: Optional[str] = typer.Option(
+        None, "--token", help="A User Access Token generated from https://huggingface.co/settings/tokens"
+    ),
+) -> None:
+    logging.set_verbosity_info()
+    repo_type = validate_repo_type(repo_type)
+    api = HfApi(token=token, library_name="hf")
+    url = api.delete_files(
+        delete_patterns=patterns,
+        repo_id=repo_id,
+        repo_type=repo_type,
+        revision=revision,
+        commit_message=commit_message,
+        commit_description=commit_description,
+        create_pr=create_pr,
+    )
+    print(f"Files correctly deleted from repo. Commit: {url}.")
+    logging.set_verbosity_warning()

--- a/src/huggingface_hub/cli/repo_files.py
+++ b/src/huggingface_hub/cli/repo_files.py
@@ -105,7 +105,6 @@ def repo_files_delete(
         ),
     ] = None,
 ) -> None:
-    logging.set_verbosity_info()
     api = HfApi(token=token, library_name="hf")
     url = api.delete_files(
         delete_patterns=patterns,

--- a/src/huggingface_hub/cli/repo_files.py
+++ b/src/huggingface_hub/cli/repo_files.py
@@ -41,7 +41,7 @@ import typer
 from huggingface_hub import logging
 from huggingface_hub.hf_api import HfApi
 
-from ._cli_utils import RepoType, typer_factory
+from ._cli_utils import RepoIdArg, RepoType, RepoTypeOpt, RevisionOpt, TokenOpt, typer_factory
 
 
 logger = logging.get_logger(__name__)
@@ -52,30 +52,15 @@ repo_files_cli = typer_factory(help="Manage files in a repo on the Hub.")
 
 @repo_files_cli.command("delete")
 def repo_files_delete(
-    repo_id: Annotated[
-        str,
-        typer.Argument(
-            help="The ID of the repo (e.g. username/repo-name).",
-        ),
-    ],
+    repo_id: RepoIdArg,
     patterns: Annotated[
         list[str],
         typer.Argument(
             help="Glob patterns to match files to delete.",
         ),
     ],
-    repo_type: Annotated[
-        RepoType,
-        typer.Option(
-            help="Type of the repo to upload to (e.g. `dataset`).",
-        ),
-    ] = RepoType.model,
-    revision: Annotated[
-        Optional[str],
-        typer.Option(
-            help="An optional Git revision to push to. It can be a branch name or a PR reference. If revision does not exist and `--create-pr` is not set, a branch will be automatically created.",
-        ),
-    ] = None,
+    repo_type: RepoTypeOpt = RepoType.model,
+    revision: RevisionOpt = None,
     commit_message: Annotated[
         Optional[str],
         typer.Option(
@@ -94,12 +79,7 @@ def repo_files_delete(
             help="Whether to create a new Pull Request for these changes.",
         ),
     ] = False,
-    token: Annotated[
-        Optional[str],
-        typer.Option(
-            help="A User Access Token generated from https://huggingface.co/settings/tokens",
-        ),
-    ] = None,
+    token: TokenOpt = None,
 ) -> None:
     api = HfApi(token=token, library_name="hf")
     url = api.delete_files(

--- a/src/huggingface_hub/cli/repo_files.py
+++ b/src/huggingface_hub/cli/repo_files.py
@@ -48,10 +48,10 @@ from ._cli_utils import validate_repo_type
 logger = logging.get_logger(__name__)
 
 
-repo_files_app = typer.Typer(help="Manage files in a repo on the Hub.", rich_markup_mode=None)
+repo_files_cli = typer.Typer(help="Manage files in a repo on the Hub.", rich_markup_mode=None)
 
 
-@repo_files_app.command("delete")
+@repo_files_cli.command("delete")
 def repo_files_delete(
     repo_id: Annotated[
         str,

--- a/src/huggingface_hub/cli/repo_files.py
+++ b/src/huggingface_hub/cli/repo_files.py
@@ -41,7 +41,7 @@ import typer
 from huggingface_hub import logging
 from huggingface_hub.hf_api import HfApi
 
-from ._cli_utils import RepoType, typer_factory
+from ._cli_utils import RepoTypeOpt, typer_factory
 
 
 logger = logging.get_logger(__name__)
@@ -65,11 +65,11 @@ def repo_files_delete(
         ),
     ],
     repo_type: Annotated[
-        RepoType,
+        RepoTypeOpt,
         typer.Option(
             help="Type of the repo to upload to (e.g. `dataset`).",
         ),
-    ] = RepoType.model,
+    ] = RepoTypeOpt.model,
     revision: Annotated[
         Optional[str],
         typer.Option(

--- a/src/huggingface_hub/cli/repo_files.py
+++ b/src/huggingface_hub/cli/repo_files.py
@@ -38,10 +38,9 @@ from typing import Annotated, Optional
 
 import typer
 
-from huggingface_hub import __version__, logging
-from huggingface_hub.hf_api import HfApi
+from huggingface_hub import logging
 
-from ._cli_utils import RepoIdArg, RepoType, RepoTypeOpt, RevisionOpt, TokenOpt, typer_factory
+from ._cli_utils import RepoIdArg, RepoType, RepoTypeOpt, RevisionOpt, TokenOpt, get_hf_api, typer_factory
 
 
 logger = logging.get_logger(__name__)
@@ -81,7 +80,7 @@ def repo_files_delete(
     ] = False,
     token: TokenOpt = None,
 ) -> None:
-    api = HfApi(token=token, library_name="hf", library_version=__version__)
+    api = get_hf_api(token=token)
     url = api.delete_files(
         delete_patterns=patterns,
         repo_id=repo_id,

--- a/src/huggingface_hub/cli/repo_files.py
+++ b/src/huggingface_hub/cli/repo_files.py
@@ -34,6 +34,8 @@ Usage:
     hf repo-files delete <repo_id> file.txt --revision=refs/pr/1 --repo-type=dataset
 """
 
+from typing import List, Optional
+
 import typer
 from typing_extensions import Annotated
 
@@ -59,32 +61,32 @@ def repo_files_delete(
         ),
     ],
     patterns: Annotated[
-        list[str],
+        List[str],
         typer.Argument(
             ...,
             help="Glob patterns to match files to delete.",
         ),
     ],
     repo_type: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="Type of the repo to upload to (e.g. `dataset`).",
         ),
     ] = "model",
     revision: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="An optional Git revision to push to. It can be a branch name or a PR reference. If revision does not exist and `--create-pr` is not set, a branch will be automatically created.",
         ),
     ] = None,
     commit_message: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="The summary / title / first line of the generated commit.",
         ),
     ] = None,
     commit_description: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="The description of the generated commit.",
         ),
@@ -97,7 +99,7 @@ def repo_files_delete(
         ),
     ] = False,
     token: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             "--token",
             help="A User Access Token generated from https://huggingface.co/settings/tokens",

--- a/src/huggingface_hub/cli/repo_files.py
+++ b/src/huggingface_hub/cli/repo_files.py
@@ -38,7 +38,7 @@ from typing import Annotated, Optional
 
 import typer
 
-from huggingface_hub import logging
+from huggingface_hub import __version__, logging
 from huggingface_hub.hf_api import HfApi
 
 from ._cli_utils import RepoIdArg, RepoType, RepoTypeOpt, RevisionOpt, TokenOpt, typer_factory
@@ -81,7 +81,7 @@ def repo_files_delete(
     ] = False,
     token: TokenOpt = None,
 ) -> None:
-    api = HfApi(token=token, library_name="hf")
+    api = HfApi(token=token, library_name="hf", library_version=__version__)
     url = api.delete_files(
         delete_patterns=patterns,
         repo_id=repo_id,

--- a/src/huggingface_hub/cli/repo_files.py
+++ b/src/huggingface_hub/cli/repo_files.py
@@ -34,7 +34,7 @@ Usage:
     hf repo-files delete <repo_id> file.txt --revision=refs/pr/1 --repo-type=dataset
 """
 
-from typing import List, Optional
+from typing import Optional
 
 import typer
 from typing_extensions import Annotated
@@ -61,7 +61,7 @@ def repo_files_delete(
         ),
     ],
     patterns: Annotated[
-        List[str],
+        list[str],
         typer.Argument(
             ...,
             help="Glob patterns to match files to delete.",

--- a/src/huggingface_hub/cli/repo_files.py
+++ b/src/huggingface_hub/cli/repo_files.py
@@ -41,7 +41,7 @@ import typer
 from huggingface_hub import logging
 from huggingface_hub.hf_api import HfApi
 
-from ._cli_utils import RepoTypeOpt, typer_factory
+from ._cli_utils import RepoType, typer_factory
 
 
 logger = logging.get_logger(__name__)
@@ -65,11 +65,11 @@ def repo_files_delete(
         ),
     ],
     repo_type: Annotated[
-        RepoTypeOpt,
+        RepoType,
         typer.Option(
             help="Type of the repo to upload to (e.g. `dataset`).",
         ),
-    ] = RepoTypeOpt.model,
+    ] = RepoType.model,
     revision: Annotated[
         Optional[str],
         typer.Option(

--- a/src/huggingface_hub/cli/repo_files.py
+++ b/src/huggingface_hub/cli/repo_files.py
@@ -41,7 +41,7 @@ import typer
 from huggingface_hub import logging
 from huggingface_hub.hf_api import HfApi
 
-from ._cli_utils import validate_repo_type
+from ._cli_utils import RepoType
 
 
 logger = logging.get_logger(__name__)
@@ -67,11 +67,11 @@ def repo_files_delete(
         ),
     ],
     repo_type: Annotated[
-        Optional[str],
+        RepoType,
         typer.Option(
             help="Type of the repo to upload to (e.g. `dataset`).",
         ),
-    ] = "model",
+    ] = RepoType.model,
     revision: Annotated[
         Optional[str],
         typer.Option(
@@ -106,12 +106,11 @@ def repo_files_delete(
     ] = None,
 ) -> None:
     logging.set_verbosity_info()
-    repo_type = validate_repo_type(repo_type)
     api = HfApi(token=token, library_name="hf")
     url = api.delete_files(
         delete_patterns=patterns,
         repo_id=repo_id,
-        repo_type=repo_type,
+        repo_type=repo_type.value,
         revision=revision,
         commit_message=commit_message,
         commit_description=commit_description,

--- a/src/huggingface_hub/cli/repo_files.py
+++ b/src/huggingface_hub/cli/repo_files.py
@@ -34,9 +34,8 @@ Usage:
     hf repo-files delete <repo_id> file.txt --revision=refs/pr/1 --repo-type=dataset
 """
 
-from typing import Optional
-
 import typer
+from typing_extensions import Annotated
 
 from huggingface_hub import logging
 from huggingface_hub.hf_api import HfApi
@@ -52,36 +51,58 @@ repo_files_app = typer.Typer(help="Manage files in a repo on the Hub.", rich_mar
 
 @repo_files_app.command("delete")
 def repo_files_delete(
-    repo_id: str = typer.Argument(
-        ...,
-        help="The ID of the repo (e.g. username/repo-name).",
-    ),
-    patterns: list[str] = typer.Argument(
-        ...,
-        help="Glob patterns to match files to delete.",
-    ),
-    repo_type: Optional[str] = typer.Option(
-        "model",
-        "--repo-type",
-        help="Type of the repo to upload to (e.g. `dataset`).",
-    ),
-    revision: Optional[str] = typer.Option(
-        None,
-        "--revision",
-        help="An optional Git revision to push to. It can be a branch name or a PR reference. If revision does not exist and `--create-pr` is not set, a branch will be automatically created.",
-    ),
-    commit_message: Optional[str] = typer.Option(
-        None, "--commit-message", help="The summary / title / first line of the generated commit."
-    ),
-    commit_description: Optional[str] = typer.Option(
-        None, "--commit-description", help="The description of the generated commit."
-    ),
-    create_pr: bool = typer.Option(
-        False, "--create-pr", help="Whether to create a new Pull Request for these changes."
-    ),
-    token: Optional[str] = typer.Option(
-        None, "--token", help="A User Access Token generated from https://huggingface.co/settings/tokens"
-    ),
+    repo_id: Annotated[
+        str,
+        typer.Argument(
+            ...,
+            help="The ID of the repo (e.g. username/repo-name).",
+        ),
+    ],
+    patterns: Annotated[
+        list[str],
+        typer.Argument(
+            ...,
+            help="Glob patterns to match files to delete.",
+        ),
+    ],
+    repo_type: Annotated[
+        str,
+        typer.Option(
+            help="Type of the repo to upload to (e.g. `dataset`).",
+        ),
+    ] = "model",
+    revision: Annotated[
+        str,
+        typer.Option(
+            help="An optional Git revision to push to. It can be a branch name or a PR reference. If revision does not exist and `--create-pr` is not set, a branch will be automatically created.",
+        ),
+    ] = None,
+    commit_message: Annotated[
+        str,
+        typer.Option(
+            help="The summary / title / first line of the generated commit.",
+        ),
+    ] = None,
+    commit_description: Annotated[
+        str,
+        typer.Option(
+            help="The description of the generated commit.",
+        ),
+    ] = None,
+    create_pr: Annotated[
+        bool,
+        typer.Option(
+            "--create-pr",
+            help="Whether to create a new Pull Request for these changes.",
+        ),
+    ] = False,
+    token: Annotated[
+        str,
+        typer.Option(
+            "--token",
+            help="A User Access Token generated from https://huggingface.co/settings/tokens",
+        ),
+    ] = None,
 ) -> None:
     logging.set_verbosity_info()
     repo_type = validate_repo_type(repo_type)

--- a/src/huggingface_hub/cli/system.py
+++ b/src/huggingface_hub/cli/system.py
@@ -29,5 +29,5 @@ def env() -> None:
 
 
 def version() -> None:
-    """Print information about the hf version."""
+    """Print CLI version."""
     print(f"huggingface_hub version: {__version__}")

--- a/src/huggingface_hub/cli/system.py
+++ b/src/huggingface_hub/cli/system.py
@@ -18,35 +18,16 @@ Usage:
     hf version
 """
 
-from argparse import _SubParsersAction
-
 from huggingface_hub import __version__
 
 from ..utils import dump_environment_info
-from . import BaseHuggingfaceCLICommand
 
 
-class EnvironmentCommand(BaseHuggingfaceCLICommand):
-    def __init__(self, args):
-        self.args = args
-
-    @staticmethod
-    def register_subcommand(parser: _SubParsersAction):
-        env_parser = parser.add_parser("env", help="Print information about the environment.")
-        env_parser.set_defaults(func=EnvironmentCommand)
-
-    def run(self) -> None:
-        dump_environment_info()
+def env() -> None:
+    """Print information about the environment."""
+    dump_environment_info()
 
 
-class VersionCommand(BaseHuggingfaceCLICommand):
-    def __init__(self, args):
-        self.args = args
-
-    @staticmethod
-    def register_subcommand(parser: _SubParsersAction):
-        version_parser = parser.add_parser("version", help="Print information about the hf version.")
-        version_parser.set_defaults(func=VersionCommand)
-
-    def run(self) -> None:
-        print(f"huggingface_hub version: {__version__}")
+def version() -> None:
+    """Print information about the hf version."""
+    print(f"huggingface_hub version: {__version__}")

--- a/src/huggingface_hub/cli/upload.py
+++ b/src/huggingface_hub/cli/upload.py
@@ -49,10 +49,9 @@ Usage:
 import os
 import time
 import warnings
-from typing import Optional
+from typing import Annotated, Optional
 
 import typer
-from typing_extensions import Annotated
 
 from huggingface_hub import logging
 from huggingface_hub._commit_scheduler import CommitScheduler

--- a/src/huggingface_hub/cli/upload.py
+++ b/src/huggingface_hub/cli/upload.py
@@ -298,7 +298,6 @@ def upload(
             print(run_upload())
         enable_progress_bars()
     else:
-        logging.set_verbosity_info()
         print(run_upload())
         logging.set_verbosity_warning()
 

--- a/src/huggingface_hub/cli/upload.py
+++ b/src/huggingface_hub/cli/upload.py
@@ -71,7 +71,6 @@ def upload(
     repo_id: Annotated[
         str,
         typer.Argument(
-            ...,
             help="The ID of the repo to upload to (e.g. `username/repo-name`).",
         ),
     ],

--- a/src/huggingface_hub/cli/upload.py
+++ b/src/huggingface_hub/cli/upload.py
@@ -49,7 +49,7 @@ Usage:
 import os
 import time
 import warnings
-from typing import Optional
+from typing import List, Optional, Tuple
 
 import typer
 from typing_extensions import Annotated
@@ -77,25 +77,25 @@ def upload(
         ),
     ],
     local_path: Annotated[
-        str,
+        Optional[str],
         typer.Argument(
             help="Local path to the file or folder to upload. Wildcard patterns are supported. Defaults to current directory.",
         ),
     ] = None,
     path_in_repo: Annotated[
-        str,
+        Optional[str],
         typer.Argument(
             help="Path of the file or folder in the repo. Defaults to the relative path of the file or folder.",
         ),
     ] = None,
     repo_type: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="Type of the repo (model, dataset, space).",
         ),
     ] = "model",
     revision: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="An optional Git revision to push to. It can be a branch name or a PR reference. If revision does not An optional Git revision to push to. It can be a branch name or a PR reference. If revision does not exist and `--create-pr` is not set, a branch will be automatically created.",
         ),
@@ -107,31 +107,31 @@ def upload(
         ),
     ] = False,
     include: Annotated[
-        list[str],
+        Optional[List[str]],
         typer.Option(
             help="Glob patterns to match files to upload.",
         ),
     ] = None,
     exclude: Annotated[
-        list[str],
+        Optional[List[str]],
         typer.Option(
             help="Glob patterns to exclude from files to upload.",
         ),
     ] = None,
     delete: Annotated[
-        list[str],
+        Optional[List[str]],
         typer.Option(
             help="Glob patterns for file to be deleted from the repo while committing.",
         ),
     ] = None,
     commit_message: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="The summary / title / first line of the generated commit.",
         ),
     ] = None,
     commit_description: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="The description of the generated commit.",
         ),
@@ -143,13 +143,13 @@ def upload(
         ),
     ] = False,
     every: Annotated[
-        float,
+        Optional[float],
         typer.Option(
             help="f set, a background job is scheduled to create commits every `every` minutes.",
         ),
     ] = None,
     token: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="A User Access Token generated from https://huggingface.co/settings/tokens",
         ),
@@ -164,7 +164,7 @@ def upload(
     """Upload a file or a folder to the Hub. Recommended for single-commit uploads."""
 
     if every is not None and every <= 0:
-        raise typer.BadParameter("--every must be a positive value", param_name="every")
+        raise typer.BadParameter("--every must be a positive value", param_hint="every")
 
     # Validate repo_type if provided
     repo_type = validate_repo_type(repo_type)
@@ -224,7 +224,7 @@ def upload(
 
 def _resolve_upload_paths(
     *, repo_id: str, local_path: Optional[str], path_in_repo: Optional[str], include: Optional[list[str]]
-) -> tuple[str, str, Optional[list[str]]]:
+) -> Tuple[str, str, Optional[List[str]]]:
     repo_name = repo_id.split("/")[-1]
     resolved_include = include
 
@@ -233,7 +233,7 @@ def _resolve_upload_paths(
             raise ValueError("Cannot set --include when local_path contains a wildcard.")
         if path_in_repo is not None and path_in_repo != ".":
             raise ValueError("Cannot set path_in_repo when local_path contains a wildcard.")
-        return ".", local_path, "."  # will be adjusted below; placeholder for type
+        return ".", local_path, ["."]  # will be adjusted below; placeholder for type
 
     if local_path is None and os.path.isfile(repo_name):
         return repo_name, repo_name, resolved_include

--- a/src/huggingface_hub/cli/upload.py
+++ b/src/huggingface_hub/cli/upload.py
@@ -61,19 +61,14 @@ from huggingface_hub.hf_api import HfApi
 from huggingface_hub.utils import disable_progress_bars, enable_progress_bars
 from huggingface_hub.utils._runtime import is_xet_available
 
-from ._cli_utils import RepoType
+from ._cli_utils import PrivateOpt, RepoIdArg, RepoType, RepoTypeOpt, RevisionOpt, TokenOpt
 
 
 logger = logging.get_logger(__name__)
 
 
 def upload(
-    repo_id: Annotated[
-        str,
-        typer.Argument(
-            help="The ID of the repo to upload to (e.g. `username/repo-name`).",
-        ),
-    ],
+    repo_id: RepoIdArg,
     local_path: Annotated[
         Optional[str],
         typer.Argument(
@@ -86,24 +81,9 @@ def upload(
             help="Path of the file or folder in the repo. Defaults to the relative path of the file or folder.",
         ),
     ] = None,
-    repo_type: Annotated[
-        RepoType,
-        typer.Option(
-            help="Type of the repo (model, dataset, space).",
-        ),
-    ] = RepoType.model,
-    revision: Annotated[
-        Optional[str],
-        typer.Option(
-            help="An optional Git revision to push to. It can be a branch name or a PR reference. If revision does not An optional Git revision to push to. It can be a branch name or a PR reference. If revision does not exist and `--create-pr` is not set, a branch will be automatically created.",
-        ),
-    ] = None,
-    private: Annotated[
-        bool,
-        typer.Option(
-            help="Whether to create a private repo if repo doesn't exist on the Hub. Ignored if the repo already exists.",
-        ),
-    ] = False,
+    repo_type: RepoTypeOpt = RepoType.model,
+    revision: RevisionOpt = None,
+    private: PrivateOpt = False,
     include: Annotated[
         Optional[list[str]],
         typer.Option(
@@ -146,12 +126,7 @@ def upload(
             help="f set, a background job is scheduled to create commits every `every` minutes.",
         ),
     ] = None,
-    token: Annotated[
-        Optional[str],
-        typer.Option(
-            help="A User Access Token generated from https://huggingface.co/settings/tokens",
-        ),
-    ] = None,
+    token: TokenOpt = None,
     quiet: Annotated[
         bool,
         typer.Option(

--- a/src/huggingface_hub/cli/upload.py
+++ b/src/huggingface_hub/cli/upload.py
@@ -61,7 +61,7 @@ from huggingface_hub.hf_api import HfApi
 from huggingface_hub.utils import disable_progress_bars, enable_progress_bars
 from huggingface_hub.utils._runtime import is_xet_available
 
-from ._cli_utils import RepoTypeOpt
+from ._cli_utils import RepoType
 
 
 logger = logging.get_logger(__name__)
@@ -87,11 +87,11 @@ def upload(
         ),
     ] = None,
     repo_type: Annotated[
-        RepoTypeOpt,
+        RepoType,
         typer.Option(
             help="Type of the repo (model, dataset, space).",
         ),
-    ] = RepoTypeOpt.model,
+    ] = RepoType.model,
     revision: Annotated[
         Optional[str],
         typer.Option(

--- a/src/huggingface_hub/cli/upload.py
+++ b/src/huggingface_hub/cli/upload.py
@@ -53,15 +53,14 @@ from typing import Annotated, Optional
 
 import typer
 
-from huggingface_hub import __version__, logging
+from huggingface_hub import logging
 from huggingface_hub._commit_scheduler import CommitScheduler
 from huggingface_hub.constants import HF_HUB_ENABLE_HF_TRANSFER
 from huggingface_hub.errors import RevisionNotFoundError
-from huggingface_hub.hf_api import HfApi
 from huggingface_hub.utils import disable_progress_bars, enable_progress_bars
 from huggingface_hub.utils._runtime import is_xet_available
 
-from ._cli_utils import PrivateOpt, RepoIdArg, RepoType, RepoTypeOpt, RevisionOpt, TokenOpt
+from ._cli_utils import PrivateOpt, RepoIdArg, RepoType, RepoTypeOpt, RevisionOpt, TokenOpt, get_hf_api
 
 
 logger = logging.get_logger(__name__)
@@ -141,7 +140,7 @@ def upload(
 
     repo_type_str = repo_type.value
 
-    api = HfApi(token=token, library_name="hf", library_version=__version__)
+    api = get_hf_api(token=token)
 
     # Resolve local_path and path_in_repo based on implicit/explicit rules
     resolved_local_path, resolved_path_in_repo, resolved_include = _resolve_upload_paths(

--- a/src/huggingface_hub/cli/upload.py
+++ b/src/huggingface_hub/cli/upload.py
@@ -53,7 +53,7 @@ from typing import Annotated, Optional
 
 import typer
 
-from huggingface_hub import logging
+from huggingface_hub import __version__, logging
 from huggingface_hub._commit_scheduler import CommitScheduler
 from huggingface_hub.constants import HF_HUB_ENABLE_HF_TRANSFER
 from huggingface_hub.errors import RevisionNotFoundError
@@ -141,7 +141,7 @@ def upload(
 
     repo_type_str = repo_type.value
 
-    api = HfApi(token=token, library_name="hf")
+    api = HfApi(token=token, library_name="hf", library_version=__version__)
 
     # Resolve local_path and path_in_repo based on implicit/explicit rules
     resolved_local_path, resolved_path_in_repo, resolved_include = _resolve_upload_paths(

--- a/src/huggingface_hub/cli/upload.py
+++ b/src/huggingface_hub/cli/upload.py
@@ -52,6 +52,7 @@ import warnings
 from typing import Optional
 
 import typer
+from typing_extensions import Annotated
 
 from huggingface_hub import logging
 from huggingface_hub._commit_scheduler import CommitScheduler
@@ -68,78 +69,97 @@ logger = logging.get_logger(__name__)
 
 
 def upload(
-    repo_id: str = typer.Argument(
-        ...,
-        help="The ID of the repo to upload to (e.g. `username/repo-name`).",
-    ),
-    local_path: Optional[str] = typer.Argument(
-        None,
-        help="Local path to the file or folder to upload. Wildcard patterns are supported. Defaults to current directory.",
-    ),
-    path_in_repo: Optional[str] = typer.Argument(
-        None,
-        help="Path of the file or folder in the repo. Defaults to the relative path of the file or folder.",
-    ),
-    repo_type: Optional[str] = typer.Option(
-        "model",
-        "--repo-type",
-        help="Type of the repo (model, dataset, space).",
-    ),
-    revision: Optional[str] = typer.Option(
-        None,
-        "--revision",
-        help="An optional Git revision to push to. It can be a branch name or a PR reference. If revision does not An optional Git revision to push to. It can be a branch name or a PR reference. If revision does not exist and `--create-pr` is not set, a branch will be automatically created.",
-    ),
-    private: bool = typer.Option(
-        False,
-        "--private",
-        help="Whether to create a private repo if repo doesn't exist on the Hub. Ignored if the repo already exists.",
-    ),
-    include: Optional[list[str]] = typer.Option(
-        None,
-        "--include",
-        help="Glob patterns to match files to upload.",
-    ),
-    exclude: Optional[list[str]] = typer.Option(
-        None,
-        "--exclude",
-        help="Glob patterns to exclude from files to upload.",
-    ),
-    delete: Optional[list[str]] = typer.Option(
-        None,
-        "--delete",
-        help="Glob patterns for file to be deleted from the repo while committing.",
-    ),
-    commit_message: Optional[str] = typer.Option(
-        None,
-        "--commit-message",
-        help="The summary / title / first line of the generated commit.",
-    ),
-    commit_description: Optional[str] = typer.Option(
-        None,
-        "--commit-description",
-        help="The description of the generated commit.",
-    ),
-    create_pr: bool = typer.Option(
-        False,
-        "--create-pr",
-        help="Whether to upload content as a new Pull Request.",
-    ),
-    every: Optional[float] = typer.Option(
-        None,
-        "--every",
-        help="f set, a background job is scheduled to create commits every `every` minutes.",
-    ),
-    token: Optional[str] = typer.Option(
-        None,
-        "--token",
-        help="A User Access Token generated from https://huggingface.co/settings/tokens",
-    ),
-    quiet: bool = typer.Option(
-        False,
-        "--quiet",
-        help="Disable progress bars and warnings; print only the returned path.",
-    ),
+    repo_id: Annotated[
+        str,
+        typer.Argument(
+            ...,
+            help="The ID of the repo to upload to (e.g. `username/repo-name`).",
+        ),
+    ],
+    local_path: Annotated[
+        str,
+        typer.Argument(
+            help="Local path to the file or folder to upload. Wildcard patterns are supported. Defaults to current directory.",
+        ),
+    ] = None,
+    path_in_repo: Annotated[
+        str,
+        typer.Argument(
+            help="Path of the file or folder in the repo. Defaults to the relative path of the file or folder.",
+        ),
+    ] = None,
+    repo_type: Annotated[
+        str,
+        typer.Option(
+            help="Type of the repo (model, dataset, space).",
+        ),
+    ] = "model",
+    revision: Annotated[
+        str,
+        typer.Option(
+            help="An optional Git revision to push to. It can be a branch name or a PR reference. If revision does not An optional Git revision to push to. It can be a branch name or a PR reference. If revision does not exist and `--create-pr` is not set, a branch will be automatically created.",
+        ),
+    ] = None,
+    private: Annotated[
+        bool,
+        typer.Option(
+            help="Whether to create a private repo if repo doesn't exist on the Hub. Ignored if the repo already exists.",
+        ),
+    ] = False,
+    include: Annotated[
+        list[str],
+        typer.Option(
+            help="Glob patterns to match files to upload.",
+        ),
+    ] = None,
+    exclude: Annotated[
+        list[str],
+        typer.Option(
+            help="Glob patterns to exclude from files to upload.",
+        ),
+    ] = None,
+    delete: Annotated[
+        list[str],
+        typer.Option(
+            help="Glob patterns for file to be deleted from the repo while committing.",
+        ),
+    ] = None,
+    commit_message: Annotated[
+        str,
+        typer.Option(
+            help="The summary / title / first line of the generated commit.",
+        ),
+    ] = None,
+    commit_description: Annotated[
+        str,
+        typer.Option(
+            help="The description of the generated commit.",
+        ),
+    ] = None,
+    create_pr: Annotated[
+        bool,
+        typer.Option(
+            help="Whether to upload content as a new Pull Request.",
+        ),
+    ] = False,
+    every: Annotated[
+        float,
+        typer.Option(
+            help="f set, a background job is scheduled to create commits every `every` minutes.",
+        ),
+    ] = None,
+    token: Annotated[
+        str,
+        typer.Option(
+            help="A User Access Token generated from https://huggingface.co/settings/tokens",
+        ),
+    ] = None,
+    quiet: Annotated[
+        bool,
+        typer.Option(
+            help="Disable progress bars and warnings; print only the returned path.",
+        ),
+    ] = False,
 ) -> None:
     """Upload a file or a folder to the Hub. Recommended for single-commit uploads."""
 

--- a/src/huggingface_hub/cli/upload.py
+++ b/src/huggingface_hub/cli/upload.py
@@ -49,7 +49,7 @@ Usage:
 import os
 import time
 import warnings
-from typing import List, Optional, Tuple
+from typing import Optional
 
 import typer
 from typing_extensions import Annotated
@@ -107,19 +107,19 @@ def upload(
         ),
     ] = False,
     include: Annotated[
-        Optional[List[str]],
+        Optional[list[str]],
         typer.Option(
             help="Glob patterns to match files to upload.",
         ),
     ] = None,
     exclude: Annotated[
-        Optional[List[str]],
+        Optional[list[str]],
         typer.Option(
             help="Glob patterns to exclude from files to upload.",
         ),
     ] = None,
     delete: Annotated[
-        Optional[List[str]],
+        Optional[list[str]],
         typer.Option(
             help="Glob patterns for file to be deleted from the repo while committing.",
         ),
@@ -307,7 +307,7 @@ def upload(
 
 def _resolve_upload_paths(
     *, repo_id: str, local_path: Optional[str], path_in_repo: Optional[str], include: Optional[list[str]]
-) -> Tuple[str, str, Optional[List[str]]]:
+) -> tuple[str, str, Optional[list[str]]]:
     repo_name = repo_id.split("/")[-1]
     resolved_include = include
 

--- a/src/huggingface_hub/cli/upload.py
+++ b/src/huggingface_hub/cli/upload.py
@@ -61,7 +61,7 @@ from huggingface_hub.hf_api import HfApi
 from huggingface_hub.utils import disable_progress_bars, enable_progress_bars
 from huggingface_hub.utils._runtime import is_xet_available
 
-from ._cli_utils import RepoType
+from ._cli_utils import RepoTypeOpt
 
 
 logger = logging.get_logger(__name__)
@@ -87,11 +87,11 @@ def upload(
         ),
     ] = None,
     repo_type: Annotated[
-        RepoType,
+        RepoTypeOpt,
         typer.Option(
             help="Type of the repo (model, dataset, space).",
         ),
-    ] = RepoType.model,
+    ] = RepoTypeOpt.model,
     revision: Annotated[
         Optional[str],
         typer.Option(

--- a/src/huggingface_hub/cli/upload.py
+++ b/src/huggingface_hub/cli/upload.py
@@ -202,7 +202,7 @@ def upload(
                     else resolved_path_in_repo
                 )
                 allow_patterns = [resolved_local_path]
-                ignore_patterns: list[str] | None = []
+                ignore_patterns: Optional[list[str]] = []
             else:
                 folder_path = resolved_local_path
                 pi = resolved_path_in_repo

--- a/src/huggingface_hub/cli/upload.py
+++ b/src/huggingface_hub/cli/upload.py
@@ -49,268 +49,305 @@ Usage:
 import os
 import time
 import warnings
-from argparse import Namespace, _SubParsersAction
 from typing import Optional
+
+import typer
 
 from huggingface_hub import logging
 from huggingface_hub._commit_scheduler import CommitScheduler
-from huggingface_hub.commands import BaseHuggingfaceCLICommand
 from huggingface_hub.constants import HF_HUB_ENABLE_HF_TRANSFER
 from huggingface_hub.errors import RevisionNotFoundError
 from huggingface_hub.hf_api import HfApi
 from huggingface_hub.utils import disable_progress_bars, enable_progress_bars
 from huggingface_hub.utils._runtime import is_xet_available
 
+from ._cli_utils import validate_repo_type
+
 
 logger = logging.get_logger(__name__)
 
 
-class UploadCommand(BaseHuggingfaceCLICommand):
-    @staticmethod
-    def register_subcommand(parser: _SubParsersAction):
-        upload_parser = parser.add_parser(
-            "upload", help="Upload a file or a folder to the Hub. Recommended for single-commit uploads."
-        )
-        upload_parser.add_argument(
-            "repo_id", type=str, help="The ID of the repo to upload to (e.g. `username/repo-name`)."
-        )
-        upload_parser.add_argument(
-            "local_path",
-            nargs="?",
-            help="Local path to the file or folder to upload. Wildcard patterns are supported. Defaults to current directory.",
-        )
-        upload_parser.add_argument(
-            "path_in_repo",
-            nargs="?",
-            help="Path of the file or folder in the repo. Defaults to the relative path of the file or folder.",
-        )
-        upload_parser.add_argument(
-            "--repo-type",
-            choices=["model", "dataset", "space"],
-            default="model",
-            help="Type of the repo to upload to (e.g. `dataset`).",
-        )
-        upload_parser.add_argument(
-            "--revision",
-            type=str,
-            help=(
-                "An optional Git revision to push to. It can be a branch name or a PR reference. If revision does not"
-                " exist and `--create-pr` is not set, a branch will be automatically created."
-            ),
-        )
-        upload_parser.add_argument(
-            "--private",
-            action="store_true",
-            help=(
-                "Whether to create a private repo if repo doesn't exist on the Hub. Ignored if the repo already"
-                " exists."
-            ),
-        )
-        upload_parser.add_argument("--include", nargs="*", type=str, help="Glob patterns to match files to upload.")
-        upload_parser.add_argument(
-            "--exclude", nargs="*", type=str, help="Glob patterns to exclude from files to upload."
-        )
-        upload_parser.add_argument(
-            "--delete",
-            nargs="*",
-            type=str,
-            help="Glob patterns for file to be deleted from the repo while committing.",
-        )
-        upload_parser.add_argument(
-            "--commit-message", type=str, help="The summary / title / first line of the generated commit."
-        )
-        upload_parser.add_argument("--commit-description", type=str, help="The description of the generated commit.")
-        upload_parser.add_argument(
-            "--create-pr", action="store_true", help="Whether to upload content as a new Pull Request."
-        )
-        upload_parser.add_argument(
-            "--every",
-            type=float,
-            help="If set, a background job is scheduled to create commits every `every` minutes.",
-        )
-        upload_parser.add_argument(
-            "--token", type=str, help="A User Access Token generated from https://huggingface.co/settings/tokens"
-        )
-        upload_parser.add_argument(
-            "--quiet",
-            action="store_true",
-            help="If True, progress bars are disabled and only the path to the uploaded files is printed.",
-        )
-        upload_parser.set_defaults(func=UploadCommand)
+def upload(
+    repo_id: str = typer.Argument(
+        ...,
+        help="The ID of the repo to upload to (e.g. `username/repo-name`).",
+    ),
+    local_path: Optional[str] = typer.Argument(
+        None,
+        help="Local path to the file or folder to upload. Wildcard patterns are supported. Defaults to current directory.",
+    ),
+    path_in_repo: Optional[str] = typer.Argument(
+        None,
+        help="Path of the file or folder in the repo. Defaults to the relative path of the file or folder.",
+    ),
+    repo_type: Optional[str] = typer.Option(
+        "model",
+        "--repo-type",
+        help="Type of the repo (model, dataset, space).",
+    ),
+    revision: Optional[str] = typer.Option(
+        None,
+        "--revision",
+        help="An optional Git revision to push to. It can be a branch name or a PR reference. If revision does not An optional Git revision to push to. It can be a branch name or a PR reference. If revision does not exist and `--create-pr` is not set, a branch will be automatically created.",
+    ),
+    private: bool = typer.Option(
+        False,
+        "--private",
+        help="Whether to create a private repo if repo doesn't exist on the Hub. Ignored if the repo already exists.",
+    ),
+    include: Optional[list[str]] = typer.Option(
+        None,
+        "--include",
+        help="Glob patterns to match files to upload.",
+    ),
+    exclude: Optional[list[str]] = typer.Option(
+        None,
+        "--exclude",
+        help="Glob patterns to exclude from files to upload.",
+    ),
+    delete: Optional[list[str]] = typer.Option(
+        None,
+        "--delete",
+        help="Glob patterns for file to be deleted from the repo while committing.",
+    ),
+    commit_message: Optional[str] = typer.Option(
+        None,
+        "--commit-message",
+        help="The summary / title / first line of the generated commit.",
+    ),
+    commit_description: Optional[str] = typer.Option(
+        None,
+        "--commit-description",
+        help="The description of the generated commit.",
+    ),
+    create_pr: bool = typer.Option(
+        False,
+        "--create-pr",
+        help="Whether to upload content as a new Pull Request.",
+    ),
+    every: Optional[float] = typer.Option(
+        None,
+        "--every",
+        help="f set, a background job is scheduled to create commits every `every` minutes.",
+    ),
+    token: Optional[str] = typer.Option(
+        None,
+        "--token",
+        help="A User Access Token generated from https://huggingface.co/settings/tokens",
+    ),
+    quiet: bool = typer.Option(
+        False,
+        "--quiet",
+        help="Disable progress bars and warnings; print only the returned path.",
+    ),
+) -> None:
+    """Upload a file or a folder to the Hub. Recommended for single-commit uploads."""
 
-    def __init__(self, args: Namespace) -> None:
-        self.repo_id: str = args.repo_id
-        self.repo_type: Optional[str] = args.repo_type
-        self.revision: Optional[str] = args.revision
-        self.private: bool = args.private
+    if every is not None and every <= 0:
+        raise typer.BadParameter("--every must be a positive value", param_name="every")
 
-        self.include: Optional[list[str]] = args.include
-        self.exclude: Optional[list[str]] = args.exclude
-        self.delete: Optional[list[str]] = args.delete
+    # Validate repo_type if provided
+    repo_type = validate_repo_type(repo_type)
 
-        self.commit_message: Optional[str] = args.commit_message
-        self.commit_description: Optional[str] = args.commit_description
-        self.create_pr: bool = args.create_pr
-        self.api: HfApi = HfApi(token=args.token, library_name="hf")
-        self.quiet: bool = args.quiet  # disable warnings and progress bars
+    api = HfApi(token=token, library_name="hf")
 
-        # Check `--every` is valid
-        if args.every is not None and args.every <= 0:
-            raise ValueError(f"`every` must be a positive value (got '{args.every}')")
-        self.every: Optional[float] = args.every
+    # Resolve local_path and path_in_repo based on implicit/explicit rules
+    resolved_local_path, resolved_path_in_repo, resolved_include = _resolve_upload_paths(
+        repo_id=repo_id, local_path=local_path, path_in_repo=path_in_repo, include=include
+    )
 
-        # Resolve `local_path` and `path_in_repo`
-        repo_name: str = args.repo_id.split("/")[-1]  # e.g. "Wauplin/my-cool-model" => "my-cool-model"
-        self.local_path: str
-        self.path_in_repo: str
-
-        if args.local_path is not None and any(c in args.local_path for c in ["*", "?", "["]):
-            if args.include is not None:
-                raise ValueError("Cannot set `--include` when passing a `local_path` containing a wildcard.")
-            if args.path_in_repo is not None and args.path_in_repo != ".":
-                raise ValueError("Cannot set `path_in_repo` when passing a `local_path` containing a wildcard.")
-            self.local_path = "."
-            self.include = args.local_path
-            self.path_in_repo = "."
-        elif args.local_path is None and os.path.isfile(repo_name):
-            # Implicit case 1: user provided only a repo_id which happen to be a local file as well => upload it with same name
-            self.local_path = repo_name
-            self.path_in_repo = repo_name
-        elif args.local_path is None and os.path.isdir(repo_name):
-            # Implicit case 2: user provided only a repo_id which happen to be a local folder as well => upload it at root
-            self.local_path = repo_name
-            self.path_in_repo = "."
-        elif args.local_path is None:
-            # Implicit case 3: user provided only a repo_id that does not match a local file or folder
-            # => the user must explicitly provide a local_path => raise exception
-            raise ValueError(f"'{repo_name}' is not a local file or folder. Please set `local_path` explicitly.")
-        elif args.path_in_repo is None and os.path.isfile(args.local_path):
-            # Explicit local path to file, no path in repo => upload it at root with same name
-            self.local_path = args.local_path
-            self.path_in_repo = os.path.basename(args.local_path)
-        elif args.path_in_repo is None:
-            # Explicit local path to folder, no path in repo => upload at root
-            self.local_path = args.local_path
-            self.path_in_repo = "."
-        else:
-            # Finally, if both paths are explicit
-            self.local_path = args.local_path
-            self.path_in_repo = args.path_in_repo
-
-    def run(self) -> None:
-        if self.quiet:
-            disable_progress_bars()
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore")
-                print(self._upload())
-            enable_progress_bars()
-        else:
-            logging.set_verbosity_info()
-            print(self._upload())
-            logging.set_verbosity_warning()
-
-    def _upload(self) -> str:
-        if os.path.isfile(self.local_path):
-            if self.include is not None and len(self.include) > 0:
-                warnings.warn("Ignoring `--include` since a single file is uploaded.")
-            if self.exclude is not None and len(self.exclude) > 0:
-                warnings.warn("Ignoring `--exclude` since a single file is uploaded.")
-            if self.delete is not None and len(self.delete) > 0:
-                warnings.warn("Ignoring `--delete` since a single file is uploaded.")
-
-        if not is_xet_available() and not HF_HUB_ENABLE_HF_TRANSFER:
-            logger.info(
-                "Consider using `hf_transfer` for faster uploads. This solution comes with some limitations. See"
-                " https://huggingface.co/docs/huggingface_hub/hf_transfer for more details."
-            )
-
-        # Schedule commits if `every` is set
-        if self.every is not None:
-            if os.path.isfile(self.local_path):
-                # If file => watch entire folder + use allow_patterns
-                folder_path = os.path.dirname(self.local_path)
-                path_in_repo = (
-                    self.path_in_repo[: -len(self.local_path)]  # remove filename from path_in_repo
-                    if self.path_in_repo.endswith(self.local_path)
-                    else self.path_in_repo
+    if quiet:
+        disable_progress_bars()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            print(
+                _upload_impl(
+                    api=api,
+                    repo_id=repo_id,
+                    repo_type=repo_type,
+                    revision=revision,
+                    private=private,
+                    include=resolved_include,
+                    exclude=exclude,
+                    delete=delete,
+                    commit_message=commit_message,
+                    commit_description=commit_description,
+                    create_pr=create_pr,
+                    every=every,
+                    local_path=resolved_local_path,
+                    path_in_repo=resolved_path_in_repo,
                 )
-                allow_patterns = [self.local_path]
-                ignore_patterns = []
-            else:
-                folder_path = self.local_path
-                path_in_repo = self.path_in_repo
-                allow_patterns = self.include or []
-                ignore_patterns = self.exclude or []
-                if self.delete is not None and len(self.delete) > 0:
-                    warnings.warn("Ignoring `--delete` when uploading with scheduled commits.")
-
-            scheduler = CommitScheduler(
-                folder_path=folder_path,
-                repo_id=self.repo_id,
-                repo_type=self.repo_type,
-                revision=self.revision,
-                allow_patterns=allow_patterns,
-                ignore_patterns=ignore_patterns,
-                path_in_repo=path_in_repo,
-                private=self.private,
-                every=self.every,
-                hf_api=self.api,
             )
-            print(f"Scheduling commits every {self.every} minutes to {scheduler.repo_id}.")
-            try:  # Block main thread until KeyboardInterrupt
-                while True:
-                    time.sleep(100)
-            except KeyboardInterrupt:
-                scheduler.stop()
-                return "Stopped scheduled commits."
-
-        # Otherwise, create repo and proceed with the upload
-        if not os.path.isfile(self.local_path) and not os.path.isdir(self.local_path):
-            raise FileNotFoundError(f"No such file or directory: '{self.local_path}'.")
-        repo_id = self.api.create_repo(
-            repo_id=self.repo_id,
-            repo_type=self.repo_type,
-            exist_ok=True,
-            private=self.private,
-            space_sdk="gradio" if self.repo_type == "space" else None,
-            # ^ We don't want it to fail when uploading to a Space => let's set Gradio by default.
-            # ^ I'd rather not add CLI args to set it explicitly as we already have `hf repo create` for that.
-        ).repo_id
-
-        # Check if branch already exists and if not, create it
-        if self.revision is not None and not self.create_pr:
-            try:
-                self.api.repo_info(repo_id=repo_id, repo_type=self.repo_type, revision=self.revision)
-            except RevisionNotFoundError:
-                logger.info(f"Branch '{self.revision}' not found. Creating it...")
-                self.api.create_branch(repo_id=repo_id, repo_type=self.repo_type, branch=self.revision, exist_ok=True)
-                # ^ `exist_ok=True` to avoid race concurrency issues
-
-        # File-based upload
-        if os.path.isfile(self.local_path):
-            return self.api.upload_file(
-                path_or_fileobj=self.local_path,
-                path_in_repo=self.path_in_repo,
+        enable_progress_bars()
+    else:
+        logging.set_verbosity_info()
+        print(
+            _upload_impl(
+                api=api,
                 repo_id=repo_id,
-                repo_type=self.repo_type,
-                revision=self.revision,
-                commit_message=self.commit_message,
-                commit_description=self.commit_description,
-                create_pr=self.create_pr,
+                repo_type=repo_type,
+                revision=revision,
+                private=private,
+                include=resolved_include,
+                exclude=exclude,
+                delete=delete,
+                commit_message=commit_message,
+                commit_description=commit_description,
+                create_pr=create_pr,
+                every=every,
+                local_path=resolved_local_path,
+                path_in_repo=resolved_path_in_repo,
             )
+        )
+        logging.set_verbosity_warning()
 
-        # Folder-based upload
+
+def _resolve_upload_paths(
+    *, repo_id: str, local_path: Optional[str], path_in_repo: Optional[str], include: Optional[list[str]]
+) -> tuple[str, str, Optional[list[str]]]:
+    repo_name = repo_id.split("/")[-1]
+    resolved_include = include
+
+    if local_path is not None and any(c in local_path for c in ["*", "?", "["]):
+        if include is not None:
+            raise ValueError("Cannot set --include when local_path contains a wildcard.")
+        if path_in_repo is not None and path_in_repo != ".":
+            raise ValueError("Cannot set path_in_repo when local_path contains a wildcard.")
+        return ".", local_path, "."  # will be adjusted below; placeholder for type
+
+    if local_path is None and os.path.isfile(repo_name):
+        return repo_name, repo_name, resolved_include
+    if local_path is None and os.path.isdir(repo_name):
+        return repo_name, ".", resolved_include
+    if local_path is None:
+        raise ValueError(f"'{repo_name}' is not a local file or folder. Please set local_path explicitly.")
+
+    if path_in_repo is None and os.path.isfile(local_path):
+        return local_path, os.path.basename(local_path), resolved_include
+    if path_in_repo is None:
+        return local_path, ".", resolved_include
+    return local_path, path_in_repo, resolved_include
+
+
+def _upload_impl(
+    *,
+    api: HfApi,
+    repo_id: str,
+    repo_type: Optional[str],
+    revision: Optional[str],
+    private: bool,
+    include: Optional[list[str]] | str,
+    exclude: Optional[list[str]],
+    delete: Optional[list[str]],
+    commit_message: Optional[str],
+    commit_description: Optional[str],
+    create_pr: bool,
+    every: Optional[float],
+    local_path: str,
+    path_in_repo: str,
+) -> str:
+    # Adjust include when wildcard case was used (we temporarily returned ".", local_path, ".")
+    if local_path == "." and isinstance(include, str):
+        include = include  # keep mypy happy; already str
+
+    if os.path.isfile(local_path):
+        if include is not None and len(include) > 0 and isinstance(include, list):
+            warnings.warn("Ignoring --include since a single file is uploaded.")
+        if exclude is not None and len(exclude) > 0:
+            warnings.warn("Ignoring --exclude since a single file is uploaded.")
+        if delete is not None and len(delete) > 0:
+            warnings.warn("Ignoring --delete since a single file is uploaded.")
+
+    if not is_xet_available() and not HF_HUB_ENABLE_HF_TRANSFER:
+        logger.info(
+            "Consider using `hf_transfer` for faster uploads. This solution comes with some limitations. See"
+            " https://huggingface.co/docs/huggingface_hub/hf_transfer for more details."
+        )
+
+    # Schedule commits if `every` is set
+    if every is not None:
+        if os.path.isfile(local_path):
+            # If file => watch entire folder + use allow_patterns
+            folder_path = os.path.dirname(local_path)
+            pi = path_in_repo[: -len(local_path)] if path_in_repo.endswith(local_path) else path_in_repo
+            allow_patterns = [local_path]
+            ignore_patterns = []
         else:
-            return self.api.upload_folder(
-                folder_path=self.local_path,
-                path_in_repo=self.path_in_repo,
-                repo_id=repo_id,
-                repo_type=self.repo_type,
-                revision=self.revision,
-                commit_message=self.commit_message,
-                commit_description=self.commit_description,
-                create_pr=self.create_pr,
-                allow_patterns=self.include,
-                ignore_patterns=self.exclude,
-                delete_patterns=self.delete,
+            folder_path = local_path
+            pi = path_in_repo
+            allow_patterns = (
+                include or [] if isinstance(include, list) else [include] if isinstance(include, str) else []
             )
+            ignore_patterns = exclude or []
+            if delete is not None and len(delete) > 0:
+                warnings.warn("Ignoring --delete when uploading with scheduled commits.")
+
+        scheduler = CommitScheduler(
+            folder_path=folder_path,
+            repo_id=repo_id,
+            repo_type=repo_type,
+            revision=revision,
+            allow_patterns=allow_patterns,
+            ignore_patterns=ignore_patterns,
+            path_in_repo=pi,
+            private=private,
+            every=every,
+            hf_api=api,
+        )
+        print(f"Scheduling commits every {every} minutes to {scheduler.repo_id}.")
+        try:
+            while True:
+                time.sleep(100)
+        except KeyboardInterrupt:
+            scheduler.stop()
+            return "Stopped scheduled commits."
+
+    # Otherwise, create repo and proceed with the upload
+    if not os.path.isfile(local_path) and not os.path.isdir(local_path):
+        raise FileNotFoundError(f"No such file or directory: '{local_path}'.")
+    created = api.create_repo(
+        repo_id=repo_id,
+        repo_type=repo_type,
+        exist_ok=True,
+        private=private,
+        space_sdk="gradio" if repo_type == "space" else None,
+        # ^ We don't want it to fail when uploading to a Space => let's set Gradio by default.
+        # ^ I'd rather not add CLI args to set it explicitly as we already have `hf repo create` for that.
+    ).repo_id
+
+    # Check if branch already exists and if not, create it
+    if revision is not None and not create_pr:
+        try:
+            api.repo_info(repo_id=created, repo_type=repo_type, revision=revision)
+        except RevisionNotFoundError:
+            logger.info(f"Branch '{revision}' not found. Creating it...")
+            api.create_branch(repo_id=created, repo_type=repo_type, branch=revision, exist_ok=True)
+            # ^ `exist_ok=True` to avoid race concurrency issues
+
+    # File-based upload
+    if os.path.isfile(local_path):
+        return api.upload_file(
+            path_or_fileobj=local_path,
+            path_in_repo=path_in_repo,
+            repo_id=created,
+            repo_type=repo_type,
+            revision=revision,
+            commit_message=commit_message,
+            commit_description=commit_description,
+            create_pr=create_pr,
+        )
+
+    # Folder-based upload
+    return api.upload_folder(
+        folder_path=local_path,
+        path_in_repo=path_in_repo,
+        repo_id=created,
+        repo_type=repo_type,
+        revision=revision,
+        commit_message=commit_message,
+        commit_description=commit_description,
+        create_pr=create_pr,
+        allow_patterns=include if isinstance(include, list) else [include] if isinstance(include, str) else None,
+        ignore_patterns=exclude,
+        delete_patterns=delete,
+    )

--- a/src/huggingface_hub/cli/upload_large_folder.py
+++ b/src/huggingface_hub/cli/upload_large_folder.py
@@ -33,14 +33,12 @@ def upload_large_folder(
     repo_id: Annotated[
         str,
         typer.Argument(
-            ...,
             help="The ID of the repo to upload to (e.g. `username/repo-name`).",
         ),
     ],
     local_path: Annotated[
         str,
         typer.Argument(
-            ...,
             help="Local path to the folder to upload.",
         ),
     ],

--- a/src/huggingface_hub/cli/upload_large_folder.py
+++ b/src/huggingface_hub/cli/upload_large_folder.py
@@ -23,7 +23,7 @@ from huggingface_hub import logging
 from huggingface_hub.hf_api import HfApi
 from huggingface_hub.utils import disable_progress_bars
 
-from ._cli_utils import ANSI, RepoTypeOpt
+from ._cli_utils import ANSI, RepoType
 
 
 logger = logging.get_logger(__name__)
@@ -43,11 +43,11 @@ def upload_large_folder(
         ),
     ],
     repo_type: Annotated[
-        RepoTypeOpt,
+        RepoType,
         typer.Option(
             help="Type of the repo to upload to (model, dataset, space).",
         ),
-    ] = RepoTypeOpt.model,
+    ] = RepoType.model,
     revision: Annotated[
         Optional[str],
         typer.Option(

--- a/src/huggingface_hub/cli/upload_large_folder.py
+++ b/src/huggingface_hub/cli/upload_large_folder.py
@@ -15,9 +15,9 @@
 """Contains command to upload a large folder with the CLI."""
 
 import os
-from typing import Optional
 
 import typer
+from typing_extensions import Annotated
 
 from huggingface_hub import logging
 from huggingface_hub.hf_api import HfApi
@@ -30,59 +30,74 @@ logger = logging.get_logger(__name__)
 
 
 def upload_large_folder(
-    repo_id: str = typer.Argument(
-        ...,
-        help="The ID of the repo to upload to (e.g. `username/repo-name`).",
-    ),
-    local_path: str = typer.Argument(
-        ...,
-        help="Local path to the folder to upload.",
-    ),
-    repo_type: Optional[str] = typer.Option(
-        None,
-        "--repo-type",
-        help="Type of the repo to upload to (model, dataset, space).",
-    ),
-    revision: Optional[str] = typer.Option(
-        None,
-        "--revision",
-        help="Git revision to push to. It can be a branch name or a PR reference.",
-    ),
-    private: bool = typer.Option(
-        False,
-        "--private",
-        help="Whether to create a private repo if repo doesn't exist on the Hub. Ignored if the repo already exists.",
-    ),
-    include: Optional[list[str]] = typer.Option(
-        None,
-        "--include",
-        help="Glob patterns to match files to upload.",
-    ),
-    exclude: Optional[list[str]] = typer.Option(
-        None,
-        "--exclude",
-        help="Glob patterns to exclude from files to upload.",
-    ),
-    token: Optional[str] = typer.Option(
-        None,
-        "--token",
-        help="User Access Token generated from https://huggingface.co/settings/tokens",
-    ),
-    num_workers: Optional[int] = typer.Option(
-        None,
-        "--num-workers",
-        help="Number of workers to use to hash, upload and commit files.",
-    ),
-    no_report: bool = typer.Option(
-        False,
-        "--no-report",
-        help="Whether to disable regular status report.",
-    ),
-    no_bars: bool = typer.Option(
-        False,
-        "--no-bars",
-        help="Whether to disable progress bars.",
-    ),
+    repo_id: Annotated[
+        str,
+        typer.Argument(
+            ...,
+            help="The ID of the repo to upload to (e.g. `username/repo-name`).",
+        ),
+    ],
+    local_path: Annotated[
+        str,
+        typer.Argument(
+            ...,
+            help="Local path to the folder to upload.",
+        ),
+    ],
+    repo_type: Annotated[
+        str,
+        typer.Option(
+            help="Type of the repo to upload to (model, dataset, space).",
+        ),
+    ] = None,
+    revision: Annotated[
+        str,
+        typer.Option(
+            help="Git revision to push to. It can be a branch name or a PR reference.",
+        ),
+    ] = None,
+    private: Annotated[
+        bool,
+        typer.Option(
+            help="Whether to create a private repo if repo doesn't exist on the Hub. Ignored if the repo already exists.",
+        ),
+    ] = False,
+    include: Annotated[
+        list[str],
+        typer.Option(
+            help="Glob patterns to match files to upload.",
+        ),
+    ] = None,
+    exclude: Annotated[
+        list[str],
+        typer.Option(
+            help="Glob patterns to exclude from files to upload.",
+        ),
+    ] = None,
+    token: Annotated[
+        str,
+        typer.Option(
+            help="User Access Token generated from https://huggingface.co/settings/tokens",
+        ),
+    ] = None,
+    num_workers: Annotated[
+        int,
+        typer.Option(
+            help="Number of workers to use to hash, upload and commit files.",
+        ),
+    ] = None,
+    no_report: Annotated[
+        bool,
+        typer.Option(
+            help="Whether to disable regular status report.",
+        ),
+    ] = False,
+    no_bars: Annotated[
+        bool,
+        typer.Option(
+            help="Whether to disable progress bars.",
+        ),
+    ] = False,
 ) -> None:
     """Upload a large folder to the Hub. Recommended for resumable uploads."""
     if not os.path.isdir(local_path):

--- a/src/huggingface_hub/cli/upload_large_folder.py
+++ b/src/huggingface_hub/cli/upload_large_folder.py
@@ -15,7 +15,7 @@
 """Contains command to upload a large folder with the CLI."""
 
 import os
-from typing import List, Optional
+from typing import Optional
 
 import typer
 from typing_extensions import Annotated
@@ -64,13 +64,13 @@ def upload_large_folder(
         ),
     ] = False,
     include: Annotated[
-        Optional[List[str]],
+        Optional[list[str]],
         typer.Option(
             help="Glob patterns to match files to upload.",
         ),
     ] = None,
     exclude: Annotated[
-        Optional[List[str]],
+        Optional[list[str]],
         typer.Option(
             help="Glob patterns to exclude from files to upload.",
         ),

--- a/src/huggingface_hub/cli/upload_large_folder.py
+++ b/src/huggingface_hub/cli/upload_large_folder.py
@@ -23,7 +23,7 @@ from huggingface_hub import logging
 from huggingface_hub.hf_api import HfApi
 from huggingface_hub.utils import disable_progress_bars
 
-from ._cli_utils import ANSI, validate_repo_type
+from ._cli_utils import ANSI, RepoType
 
 
 logger = logging.get_logger(__name__)
@@ -45,11 +45,11 @@ def upload_large_folder(
         ),
     ],
     repo_type: Annotated[
-        Optional[str],
+        RepoType,
         typer.Option(
             help="Type of the repo to upload to (model, dataset, space).",
         ),
-    ] = None,
+    ] = RepoType.model,
     revision: Annotated[
         Optional[str],
         typer.Option(
@@ -104,7 +104,6 @@ def upload_large_folder(
         raise typer.BadParameter("Large upload is only supported for folders.", param_hint="local_path")
 
     logging.set_verbosity_info()
-    repo_type = validate_repo_type(repo_type)
 
     print(
         ANSI.yellow(
@@ -138,7 +137,7 @@ def upload_large_folder(
     api.upload_large_folder(
         repo_id=repo_id,
         folder_path=local_path,
-        repo_type=repo_type or "model",
+        repo_type=repo_type.value,
         revision=revision,
         private=private,
         allow_patterns=include,

--- a/src/huggingface_hub/cli/upload_large_folder.py
+++ b/src/huggingface_hub/cli/upload_large_folder.py
@@ -103,8 +103,6 @@ def upload_large_folder(
     if not os.path.isdir(local_path):
         raise typer.BadParameter("Large upload is only supported for folders.", param_hint="local_path")
 
-    logging.set_verbosity_info()
-
     print(
         ANSI.yellow(
             "You are about to upload a large folder to the Hub using `hf upload-large-folder`. "

--- a/src/huggingface_hub/cli/upload_large_folder.py
+++ b/src/huggingface_hub/cli/upload_large_folder.py
@@ -15,10 +15,9 @@
 """Contains command to upload a large folder with the CLI."""
 
 import os
-from typing import Optional
+from typing import Annotated, Optional
 
 import typer
-from typing_extensions import Annotated
 
 from huggingface_hub import logging
 from huggingface_hub.hf_api import HfApi

--- a/src/huggingface_hub/cli/upload_large_folder.py
+++ b/src/huggingface_hub/cli/upload_large_folder.py
@@ -23,7 +23,7 @@ from huggingface_hub import logging
 from huggingface_hub.hf_api import HfApi
 from huggingface_hub.utils import disable_progress_bars
 
-from ._cli_utils import ANSI, RepoType
+from ._cli_utils import ANSI, RepoTypeOpt
 
 
 logger = logging.get_logger(__name__)
@@ -43,11 +43,11 @@ def upload_large_folder(
         ),
     ],
     repo_type: Annotated[
-        RepoType,
+        RepoTypeOpt,
         typer.Option(
             help="Type of the repo to upload to (model, dataset, space).",
         ),
-    ] = RepoType.model,
+    ] = RepoTypeOpt.model,
     revision: Annotated[
         Optional[str],
         typer.Option(

--- a/src/huggingface_hub/cli/upload_large_folder.py
+++ b/src/huggingface_hub/cli/upload_large_folder.py
@@ -23,43 +23,23 @@ from huggingface_hub import logging
 from huggingface_hub.hf_api import HfApi
 from huggingface_hub.utils import disable_progress_bars
 
-from ._cli_utils import ANSI, RepoType
+from ._cli_utils import ANSI, PrivateOpt, RepoIdArg, RepoType, RepoTypeOpt, RevisionOpt, TokenOpt
 
 
 logger = logging.get_logger(__name__)
 
 
 def upload_large_folder(
-    repo_id: Annotated[
-        str,
-        typer.Argument(
-            help="The ID of the repo to upload to (e.g. `username/repo-name`).",
-        ),
-    ],
+    repo_id: RepoIdArg,
     local_path: Annotated[
         str,
         typer.Argument(
             help="Local path to the folder to upload.",
         ),
     ],
-    repo_type: Annotated[
-        RepoType,
-        typer.Option(
-            help="Type of the repo to upload to (model, dataset, space).",
-        ),
-    ] = RepoType.model,
-    revision: Annotated[
-        Optional[str],
-        typer.Option(
-            help="Git revision to push to. It can be a branch name or a PR reference.",
-        ),
-    ] = None,
-    private: Annotated[
-        bool,
-        typer.Option(
-            help="Whether to create a private repo if repo doesn't exist on the Hub. Ignored if the repo already exists.",
-        ),
-    ] = False,
+    repo_type: RepoTypeOpt = RepoType.model,
+    revision: RevisionOpt = None,
+    private: PrivateOpt = False,
     include: Annotated[
         Optional[list[str]],
         typer.Option(
@@ -72,12 +52,7 @@ def upload_large_folder(
             help="Glob patterns to exclude from files to upload.",
         ),
     ] = None,
-    token: Annotated[
-        Optional[str],
-        typer.Option(
-            help="User Access Token generated from https://huggingface.co/settings/tokens",
-        ),
-    ] = None,
+    token: TokenOpt = None,
     num_workers: Annotated[
         Optional[int],
         typer.Option(

--- a/src/huggingface_hub/cli/upload_large_folder.py
+++ b/src/huggingface_hub/cli/upload_large_folder.py
@@ -15,118 +15,119 @@
 """Contains command to upload a large folder with the CLI."""
 
 import os
-from argparse import Namespace, _SubParsersAction
 from typing import Optional
 
+import typer
+
 from huggingface_hub import logging
-from huggingface_hub.commands import BaseHuggingfaceCLICommand
 from huggingface_hub.hf_api import HfApi
 from huggingface_hub.utils import disable_progress_bars
 
-from ._cli_utils import ANSI
+from ._cli_utils import ANSI, validate_repo_type
 
 
 logger = logging.get_logger(__name__)
 
 
-class UploadLargeFolderCommand(BaseHuggingfaceCLICommand):
-    @staticmethod
-    def register_subcommand(parser: _SubParsersAction):
-        subparser = parser.add_parser(
-            "upload-large-folder",
-            help="Upload a large folder to the Hub. Recommended for resumable uploads.",
-        )
-        subparser.add_argument(
-            "repo_id", type=str, help="The ID of the repo to upload to (e.g. `username/repo-name`)."
-        )
-        subparser.add_argument("local_path", type=str, help="Local path to the file or folder to upload.")
-        subparser.add_argument(
-            "--repo-type",
-            choices=["model", "dataset", "space"],
-            help="Type of the repo to upload to (e.g. `dataset`).",
-        )
-        subparser.add_argument(
-            "--revision",
-            type=str,
-            help=("An optional Git revision to push to. It can be a branch name or a PR reference."),
-        )
-        subparser.add_argument(
-            "--private",
-            action="store_true",
-            help=(
-                "Whether to create a private repo if repo doesn't exist on the Hub. Ignored if the repo already exists."
-            ),
-        )
-        subparser.add_argument("--include", nargs="*", type=str, help="Glob patterns to match files to upload.")
-        subparser.add_argument("--exclude", nargs="*", type=str, help="Glob patterns to exclude from files to upload.")
-        subparser.add_argument(
-            "--token", type=str, help="A User Access Token generated from https://huggingface.co/settings/tokens"
-        )
-        subparser.add_argument(
-            "--num-workers", type=int, help="Number of workers to use to hash, upload and commit files."
-        )
-        subparser.add_argument("--no-report", action="store_true", help="Whether to disable regular status report.")
-        subparser.add_argument("--no-bars", action="store_true", help="Whether to disable progress bars.")
-        subparser.set_defaults(func=UploadLargeFolderCommand)
+def upload_large_folder(
+    repo_id: str = typer.Argument(
+        ...,
+        help="The ID of the repo to upload to (e.g. `username/repo-name`).",
+    ),
+    local_path: str = typer.Argument(
+        ...,
+        help="Local path to the folder to upload.",
+    ),
+    repo_type: Optional[str] = typer.Option(
+        None,
+        "--repo-type",
+        help="Type of the repo to upload to (model, dataset, space).",
+    ),
+    revision: Optional[str] = typer.Option(
+        None,
+        "--revision",
+        help="Git revision to push to. It can be a branch name or a PR reference.",
+    ),
+    private: bool = typer.Option(
+        False,
+        "--private",
+        help="Whether to create a private repo if repo doesn't exist on the Hub. Ignored if the repo already exists.",
+    ),
+    include: Optional[list[str]] = typer.Option(
+        None,
+        "--include",
+        help="Glob patterns to match files to upload.",
+    ),
+    exclude: Optional[list[str]] = typer.Option(
+        None,
+        "--exclude",
+        help="Glob patterns to exclude from files to upload.",
+    ),
+    token: Optional[str] = typer.Option(
+        None,
+        "--token",
+        help="User Access Token generated from https://huggingface.co/settings/tokens",
+    ),
+    num_workers: Optional[int] = typer.Option(
+        None,
+        "--num-workers",
+        help="Number of workers to use to hash, upload and commit files.",
+    ),
+    no_report: bool = typer.Option(
+        False,
+        "--no-report",
+        help="Whether to disable regular status report.",
+    ),
+    no_bars: bool = typer.Option(
+        False,
+        "--no-bars",
+        help="Whether to disable progress bars.",
+    ),
+) -> None:
+    """Upload a large folder to the Hub. Recommended for resumable uploads."""
+    if not os.path.isdir(local_path):
+        raise typer.BadParameter("Large upload is only supported for folders.", param_name="local_path")
 
-    def __init__(self, args: Namespace) -> None:
-        self.repo_id: str = args.repo_id
-        self.local_path: str = args.local_path
-        self.repo_type: str = args.repo_type
-        self.revision: Optional[str] = args.revision
-        self.private: bool = args.private
+    logging.set_verbosity_info()
+    repo_type = validate_repo_type(repo_type)
 
-        self.include: Optional[list[str]] = args.include
-        self.exclude: Optional[list[str]] = args.exclude
-
-        self.api: HfApi = HfApi(token=args.token, library_name="hf")
-
-        self.num_workers: Optional[int] = args.num_workers
-        self.no_report: bool = args.no_report
-        self.no_bars: bool = args.no_bars
-
-        if not os.path.isdir(self.local_path):
-            raise ValueError("Large upload is only supported for folders.")
-
-    def run(self) -> None:
-        logging.set_verbosity_info()
-
-        print(
-            ANSI.yellow(
-                "You are about to upload a large folder to the Hub using `hf upload-large-folder`. "
-                "This is a new feature so feedback is very welcome!\n"
-                "\n"
-                "A few things to keep in mind:\n"
-                "  - Repository limits still apply: https://huggingface.co/docs/hub/repositories-recommendations\n"
-                "  - Do not start several processes in parallel.\n"
-                "  - You can interrupt and resume the process at any time. "
-                "The script will pick up where it left off except for partially uploaded files that would have to be entirely reuploaded.\n"
-                "  - Do not upload the same folder to several repositories. If you need to do so, you must delete the `./.cache/huggingface/` folder first.\n"
-                "\n"
-                f"Some temporary metadata will be stored under `{self.local_path}/.cache/huggingface`.\n"
-                "  - You must not modify those files manually.\n"
-                "  - You must not delete the `./.cache/huggingface/` folder while a process is running.\n"
-                "  - You can delete the `./.cache/huggingface/` folder to reinitialize the upload state when process is not running. Files will have to be hashed and preuploaded again, except for already committed files.\n"
-                "\n"
-                "If the process output is too verbose, you can disable the progress bars with `--no-bars`. "
-                "You can also entirely disable the status report with `--no-report`.\n"
-                "\n"
-                "For more details, run `hf upload-large-folder --help` or check the documentation at "
-                "https://huggingface.co/docs/huggingface_hub/guides/upload#upload-a-large-folder."
-            )
+    print(
+        ANSI.yellow(
+            "You are about to upload a large folder to the Hub using `hf upload-large-folder`. "
+            "This is a new feature so feedback is very welcome!\n"
+            "\n"
+            "A few things to keep in mind:\n"
+            "  - Repository limits still apply: https://huggingface.co/docs/hub/repositories-recommendations\n"
+            "  - Do not start several processes in parallel.\n"
+            "  - You can interrupt and resume the process at any time. "
+            "The script will pick up where it left off except for partially uploaded files that would have to be entirely reuploaded.\n"
+            "  - Do not upload the same folder to several repositories. If you need to do so, you must delete the `./.cache/huggingface/` folder first.\n"
+            "\n"
+            f"Some temporary metadata will be stored under `{local_path}/.cache/huggingface`.\n"
+            "  - You must not modify those files manually.\n"
+            "  - You must not delete the `./.cache/huggingface/` folder while a process is running.\n"
+            "  - You can delete the `./.cache/huggingface/` folder to reinitialize the upload state when process is not running. Files will have to be hashed and preuploaded again, except for already committed files.\n"
+            "\n"
+            "If the process output is too verbose, you can disable the progress bars with `--no-bars`. "
+            "You can also entirely disable the status report with `--no-report`.\n"
+            "\n"
+            "For more details, run `hf upload-large-folder --help` or check the documentation at "
+            "https://huggingface.co/docs/huggingface_hub/guides/upload#upload-a-large-folder."
         )
+    )
 
-        if self.no_bars:
-            disable_progress_bars()
+    if no_bars:
+        disable_progress_bars()
 
-        self.api.upload_large_folder(
-            repo_id=self.repo_id,
-            folder_path=self.local_path,
-            repo_type=self.repo_type,
-            revision=self.revision,
-            private=self.private,
-            allow_patterns=self.include,
-            ignore_patterns=self.exclude,
-            num_workers=self.num_workers,
-            print_report=not self.no_report,
-        )
+    api = HfApi(token=token, library_name="hf")
+    api.upload_large_folder(
+        repo_id=repo_id,
+        folder_path=local_path,
+        repo_type=repo_type,
+        revision=revision,
+        private=private,
+        allow_patterns=include,
+        ignore_patterns=exclude,
+        num_workers=num_workers,
+        print_report=not no_report,
+    )

--- a/src/huggingface_hub/cli/upload_large_folder.py
+++ b/src/huggingface_hub/cli/upload_large_folder.py
@@ -19,7 +19,7 @@ from typing import Annotated, Optional
 
 import typer
 
-from huggingface_hub import logging
+from huggingface_hub import __version__, logging
 from huggingface_hub.hf_api import HfApi
 from huggingface_hub.utils import disable_progress_bars
 
@@ -104,7 +104,7 @@ def upload_large_folder(
     if no_bars:
         disable_progress_bars()
 
-    api = HfApi(token=token, library_name="hf")
+    api = HfApi(token=token, library_name="hf", library_version=__version__)
     api.upload_large_folder(
         repo_id=repo_id,
         folder_path=local_path,

--- a/src/huggingface_hub/cli/upload_large_folder.py
+++ b/src/huggingface_hub/cli/upload_large_folder.py
@@ -19,11 +19,10 @@ from typing import Annotated, Optional
 
 import typer
 
-from huggingface_hub import __version__, logging
-from huggingface_hub.hf_api import HfApi
+from huggingface_hub import logging
 from huggingface_hub.utils import disable_progress_bars
 
-from ._cli_utils import ANSI, PrivateOpt, RepoIdArg, RepoType, RepoTypeOpt, RevisionOpt, TokenOpt
+from ._cli_utils import ANSI, PrivateOpt, RepoIdArg, RepoType, RepoTypeOpt, RevisionOpt, TokenOpt, get_hf_api
 
 
 logger = logging.get_logger(__name__)
@@ -104,7 +103,7 @@ def upload_large_folder(
     if no_bars:
         disable_progress_bars()
 
-    api = HfApi(token=token, library_name="hf", library_version=__version__)
+    api = get_hf_api(token=token)
     api.upload_large_folder(
         repo_id=repo_id,
         folder_path=local_path,

--- a/src/huggingface_hub/cli/upload_large_folder.py
+++ b/src/huggingface_hub/cli/upload_large_folder.py
@@ -15,6 +15,7 @@
 """Contains command to upload a large folder with the CLI."""
 
 import os
+from typing import List, Optional
 
 import typer
 from typing_extensions import Annotated
@@ -45,13 +46,13 @@ def upload_large_folder(
         ),
     ],
     repo_type: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="Type of the repo to upload to (model, dataset, space).",
         ),
     ] = None,
     revision: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="Git revision to push to. It can be a branch name or a PR reference.",
         ),
@@ -63,25 +64,25 @@ def upload_large_folder(
         ),
     ] = False,
     include: Annotated[
-        list[str],
+        Optional[List[str]],
         typer.Option(
             help="Glob patterns to match files to upload.",
         ),
     ] = None,
     exclude: Annotated[
-        list[str],
+        Optional[List[str]],
         typer.Option(
             help="Glob patterns to exclude from files to upload.",
         ),
     ] = None,
     token: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             help="User Access Token generated from https://huggingface.co/settings/tokens",
         ),
     ] = None,
     num_workers: Annotated[
-        int,
+        Optional[int],
         typer.Option(
             help="Number of workers to use to hash, upload and commit files.",
         ),
@@ -101,7 +102,7 @@ def upload_large_folder(
 ) -> None:
     """Upload a large folder to the Hub. Recommended for resumable uploads."""
     if not os.path.isdir(local_path):
-        raise typer.BadParameter("Large upload is only supported for folders.", param_name="local_path")
+        raise typer.BadParameter("Large upload is only supported for folders.", param_hint="local_path")
 
     logging.set_verbosity_info()
     repo_type = validate_repo_type(repo_type)
@@ -138,7 +139,7 @@ def upload_large_folder(
     api.upload_large_folder(
         repo_id=repo_id,
         folder_path=local_path,
-        repo_type=repo_type,
+        repo_type=repo_type or "model",
         revision=revision,
         private=private,
         allow_patterns=include,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import os
 import warnings
 from contextlib import contextmanager

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,7 @@ import os
 import warnings
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Generator
+from typing import Generator, Optional
 from unittest.mock import Mock, patch
 
 import pytest
@@ -196,7 +196,7 @@ class TestUploadCommand:
 
     def test_every_must_be_positive(self) -> None:
         class _PatchedBadParameter(typer.BadParameter):
-            def __init__(self, message: str, *, param_name: str | None = None, **kwargs: object) -> None:
+            def __init__(self, message: str, *, param_name: Optional[str] = None, **kwargs: object) -> None:
                 super().__init__(message, **kwargs)
 
         with (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,28 +29,36 @@ def runner() -> CliRunner:
 
 class TestCacheCommand:
     def test_scan_cache_basic(self, runner: CliRunner) -> None:
-        with patch("huggingface_hub.cli.cache._run_scan") as mock_run:
+        with patch("huggingface_hub.cli.cache.scan_cache_dir") as mock_run:
             result = runner.invoke(app, ["cache", "scan"])
         assert result.exit_code == 0
-        mock_run.assert_called_once_with(cache_dir=None, verbosity=0)
+        mock_run.assert_called_once_with(None)
 
     def test_scan_cache_verbose(self, runner: CliRunner) -> None:
-        with patch("huggingface_hub.cli.cache._run_scan") as mock_run:
+        with (
+            patch("huggingface_hub.cli.cache.scan_cache_dir") as mock_run,
+            patch("huggingface_hub.cli.cache.get_table") as get_table_mock,
+        ):
             result = runner.invoke(app, ["cache", "scan", "-v"])
         assert result.exit_code == 0
-        mock_run.assert_called_once_with(cache_dir=None, verbosity=1)
+        mock_run.assert_called_once_with(None)
+        get_table_mock.assert_called_once_with(mock_run.return_value, verbosity=1)
 
     def test_scan_cache_with_dir(self, runner: CliRunner) -> None:
-        with patch("huggingface_hub.cli.cache._run_scan") as mock_run:
+        with patch("huggingface_hub.cli.cache.scan_cache_dir") as mock_run:
             result = runner.invoke(app, ["cache", "scan", "--dir", "something"])
         assert result.exit_code == 0
-        mock_run.assert_called_once_with(cache_dir="something", verbosity=0)
+        mock_run.assert_called_once_with("something")
 
     def test_scan_cache_ultra_verbose(self, runner: CliRunner) -> None:
-        with patch("huggingface_hub.cli.cache._run_scan") as mock_run:
+        with (
+            patch("huggingface_hub.cli.cache.scan_cache_dir") as mock_run,
+            patch("huggingface_hub.cli.cache.get_table") as get_table_mock,
+        ):
             result = runner.invoke(app, ["cache", "scan", "-vvv"])
         assert result.exit_code == 0
-        mock_run.assert_called_once_with(cache_dir=None, verbosity=3)
+        mock_run.assert_called_once_with(None)
+        get_table_mock.assert_called_once_with(mock_run.return_value, verbosity=3)
 
     def test_delete_cache_with_dir(self, runner: CliRunner) -> None:
         hf_cache_info = Mock()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,6 +11,7 @@ import pytest
 import typer
 from typer.testing import CliRunner
 
+from huggingface_hub.cli._cli_utils import RepoType
 from huggingface_hub.cli.cache import _CANCEL_DELETION_STR
 from huggingface_hub.cli.download import download
 from huggingface_hub.cli.hf import app
@@ -398,7 +399,7 @@ class TestUploadImpl:
             ):
                 upload(
                     repo_id="my-dataset",
-                    repo_type="dataset",
+                    repo_type=RepoType.dataset,
                     local_path=str(file_path),
                     path_in_repo="logs/file.txt",
                     create_pr=True,
@@ -590,7 +591,7 @@ class TestDownloadImpl:
             download(
                 repo_id="author/model",
                 filenames=["config.json"],
-                repo_type="model",
+                repo_type=RepoType.model,
                 revision="main",
                 quiet=True,
             )
@@ -616,7 +617,7 @@ class TestDownloadImpl:
             download(
                 repo_id="author/model",
                 filenames=["README.md", "config.json"],
-                repo_type="model",
+                repo_type=RepoType.model,
                 force_download=True,
                 max_workers=4,
                 quiet=True,
@@ -643,7 +644,7 @@ class TestDownloadImpl:
             download(
                 repo_id="author/model",
                 filenames=[],
-                repo_type="model",
+                repo_type=RepoType.model,
                 include=["*.json"],
                 exclude=["data/*"],
                 force_download=True,
@@ -676,7 +677,7 @@ class TestDownloadImpl:
             download(
                 repo_id="author/model",
                 filenames=["README.md", "config.json"],
-                repo_type="model",
+                repo_type=RepoType.model,
                 include=["*.json"],
                 exclude=["data/*"],
                 force_download=True,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,7 +11,7 @@ import pytest
 import typer
 from typer.testing import CliRunner
 
-from huggingface_hub.cli._cli_utils import RepoTypeOpt
+from huggingface_hub.cli._cli_utils import RepoType
 from huggingface_hub.cli.cache import _CANCEL_DELETION_STR
 from huggingface_hub.cli.download import download
 from huggingface_hub.cli.hf import app
@@ -407,7 +407,7 @@ class TestUploadImpl:
             ):
                 upload(
                     repo_id="my-dataset",
-                    repo_type=RepoTypeOpt.dataset,
+                    repo_type=RepoType.dataset,
                     local_path=str(file_path),
                     path_in_repo="logs/file.txt",
                     create_pr=True,
@@ -599,7 +599,7 @@ class TestDownloadImpl:
             download(
                 repo_id="author/model",
                 filenames=["config.json"],
-                repo_type=RepoTypeOpt.model,
+                repo_type=RepoType.model,
                 revision="main",
                 quiet=True,
             )
@@ -625,7 +625,7 @@ class TestDownloadImpl:
             download(
                 repo_id="author/model",
                 filenames=["README.md", "config.json"],
-                repo_type=RepoTypeOpt.model,
+                repo_type=RepoType.model,
                 force_download=True,
                 max_workers=4,
                 quiet=True,
@@ -652,7 +652,7 @@ class TestDownloadImpl:
             download(
                 repo_id="author/model",
                 filenames=[],
-                repo_type=RepoTypeOpt.model,
+                repo_type=RepoType.model,
                 include=["*.json"],
                 exclude=["data/*"],
                 force_download=True,
@@ -685,7 +685,7 @@ class TestDownloadImpl:
             download(
                 repo_id="author/model",
                 filenames=["README.md", "config.json"],
-                repo_type=RepoTypeOpt.model,
+                repo_type=RepoType.model,
                 include=["*.json"],
                 exclude=["data/*"],
                 force_download=True,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,140 +1,117 @@
+from __future__ import annotations
+
 import os
-import unittest
 import warnings
-from argparse import ArgumentParser, Namespace
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Generator
 from unittest.mock import Mock, patch
 
-from huggingface_hub.cli.cache import CacheCommand
-from huggingface_hub.cli.download import DownloadCommand
-from huggingface_hub.cli.jobs import JobsCommands, RunCommand, ScheduledRunCommand, UvCommand
-from huggingface_hub.cli.repo import RepoCommands
-from huggingface_hub.cli.repo_files import DeleteFilesSubCommand, RepoFilesCommand
-from huggingface_hub.cli.upload import UploadCommand
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from huggingface_hub.cli.cache import _CANCEL_DELETION_STR
+from huggingface_hub.cli.download import _download_impl
+from huggingface_hub.cli.hf import app
+from huggingface_hub.cli.upload import _resolve_upload_paths, _upload_impl, upload
 from huggingface_hub.errors import RevisionNotFoundError
-from huggingface_hub.utils import SoftTemporaryDirectory, capture_output
+from huggingface_hub.utils import SoftTemporaryDirectory
 
 from .testing_utils import DUMMY_MODEL_ID
 
 
-class TestCacheCommand(unittest.TestCase):
-    def setUp(self) -> None:
-        """
-        Set up cache scan/delete commands as in `src/huggingface_hub/cli/hf.py`.
-        """
-        self.parser = ArgumentParser("hf", usage="hf <command> [<args>]")
-        commands_parser = self.parser.add_subparsers()
-        CacheCommand.register_subcommand(commands_parser)
-
-    def test_scan_cache_basic(self) -> None:
-        """Test `hf cache scan`."""
-        args = self.parser.parse_args(["cache", "scan"])
-        assert args.dir is None
-        assert args.verbose == 0
-        assert args.func == CacheCommand
-        assert args.cache_command == "scan"
-
-    def test_scan_cache_verbose(self) -> None:
-        """Test `hf cache scan -v`."""
-        args = self.parser.parse_args(["cache", "scan", "-v"])
-        assert args.dir is None
-        assert args.verbose == 1
-        assert args.func == CacheCommand
-        assert args.cache_command == "scan"
-
-    def test_scan_cache_with_dir(self) -> None:
-        """Test `hf cache scan --dir something`."""
-        args = self.parser.parse_args(["cache", "scan", "--dir", "something"])
-        assert args.dir == "something"
-        assert args.verbose == 0
-        assert args.func == CacheCommand
-        assert args.cache_command == "scan"
-
-    def test_scan_cache_ultra_verbose(self) -> None:
-        """Test `hf cache scan -vvv`."""
-        args = self.parser.parse_args(["cache", "scan", "-vvv"])
-        assert args.dir is None
-        assert args.verbose == 3
-        assert args.func == CacheCommand
-        assert args.cache_command == "scan"
-
-    def test_delete_cache_with_dir(self) -> None:
-        """Test `hf cache delete --dir something`."""
-        args = self.parser.parse_args(["cache", "delete", "--dir", "something"])
-        assert args.dir == "something"
-        assert args.func == CacheCommand
-        assert args.cache_command == "delete"
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
 
 
-class TestUploadCommand(unittest.TestCase):
-    def setUp(self) -> None:
-        """
-        Set up CLI as in `src/huggingface_hub/cli/hf.py`.
-        """
-        self.parser = ArgumentParser("hf", usage="hf <command> [<args>]")
-        commands_parser = self.parser.add_subparsers()
-        UploadCommand.register_subcommand(commands_parser)
+class TestCacheCommand:
+    def test_scan_cache_basic(self, runner: CliRunner) -> None:
+        with patch("huggingface_hub.cli.cache._run_scan") as mock_run:
+            result = runner.invoke(app, ["cache", "scan"])
+        assert result.exit_code == 0
+        mock_run.assert_called_once_with(cache_dir=None, verbosity=0)
 
-    def test_upload_basic(self) -> None:
-        """Test `hf upload my-folder to dummy-repo`."""
-        cmd = UploadCommand(self.parser.parse_args(["upload", DUMMY_MODEL_ID, "my-folder"]))
-        assert cmd.repo_id == DUMMY_MODEL_ID
-        assert cmd.local_path == "my-folder"
-        assert cmd.path_in_repo == "."  # implicit
-        assert cmd.repo_type == "model"
-        assert cmd.revision is None
-        assert cmd.include is None
-        assert cmd.exclude is None
-        assert cmd.delete is None
-        assert cmd.commit_message is None
-        assert cmd.commit_description is None
-        assert cmd.create_pr is False
-        assert cmd.every is None
-        assert cmd.api.token is None
-        assert cmd.quiet is False
+    def test_scan_cache_verbose(self, runner: CliRunner) -> None:
+        with patch("huggingface_hub.cli.cache._run_scan") as mock_run:
+            result = runner.invoke(app, ["cache", "scan", "-v"])
+        assert result.exit_code == 0
+        mock_run.assert_called_once_with(cache_dir=None, verbosity=1)
 
-    def test_upload_with_wildcard(self) -> None:
-        """Test uploading files using wildcard patterns."""
-        with tmp_current_directory() as cache_dir:
-            # Create test files
-            (Path(cache_dir) / "model1.safetensors").touch()
-            (Path(cache_dir) / "model2.safetensors").touch()
-            (Path(cache_dir) / "model.bin").touch()
-            (Path(cache_dir) / "config.json").touch()
+    def test_scan_cache_with_dir(self, runner: CliRunner) -> None:
+        with patch("huggingface_hub.cli.cache._run_scan") as mock_run:
+            result = runner.invoke(app, ["cache", "scan", "--dir", "something"])
+        assert result.exit_code == 0
+        mock_run.assert_called_once_with(cache_dir="something", verbosity=0)
 
-            # Test basic wildcard pattern
-            cmd = UploadCommand(self.parser.parse_args(["upload", DUMMY_MODEL_ID, "*.safetensors"]))
-            assert cmd.local_path == "."
-            assert cmd.include == "*.safetensors"
-            assert cmd.path_in_repo == "."
-            assert cmd.repo_id == DUMMY_MODEL_ID
+    def test_scan_cache_ultra_verbose(self, runner: CliRunner) -> None:
+        with patch("huggingface_hub.cli.cache._run_scan") as mock_run:
+            result = runner.invoke(app, ["cache", "scan", "-vvv"])
+        assert result.exit_code == 0
+        mock_run.assert_called_once_with(cache_dir=None, verbosity=3)
 
-            # Test wildcard pattern with specific directory
-            subdir = Path(cache_dir) / "subdir"
-            subdir.mkdir()
-            (subdir / "special.safetensors").touch()
+    def test_delete_cache_with_dir(self, runner: CliRunner) -> None:
+        hf_cache_info = Mock()
+        with (
+            patch("huggingface_hub.cli.cache.scan_cache_dir", return_value=hf_cache_info) as scan_mock,
+            patch(
+                "huggingface_hub.cli.cache._manual_review_tui",
+                return_value=[_CANCEL_DELETION_STR],
+            ) as review_mock,
+        ):
+            result = runner.invoke(app, ["cache", "delete", "--dir", "something"])
+        assert result.exit_code == 0
+        scan_mock.assert_called_once_with("something")
+        review_mock.assert_called_once_with(hf_cache_info, preselected=[], sort_by=None)
 
-            cmd = UploadCommand(self.parser.parse_args(["upload", DUMMY_MODEL_ID, "subdir/*.safetensors"]))
-            assert cmd.local_path == "."
-            assert cmd.include == "subdir/*.safetensors"
-            assert cmd.path_in_repo == "."
 
-            # Test error when using wildcard with --include
-            with self.assertRaises(ValueError):
-                UploadCommand(
-                    self.parser.parse_args(["upload", DUMMY_MODEL_ID, "*.safetensors", "--include", "*.json"])
-                )
+class TestUploadCommand:
+    def test_upload_basic(self, runner: CliRunner) -> None:
+        with (
+            patch(
+                "huggingface_hub.cli.upload._resolve_upload_paths", return_value=("my-folder", ".", None)
+            ) as resolve_mock,
+            patch("huggingface_hub.cli.upload._upload_impl", return_value="uploaded") as upload_mock,
+            patch("huggingface_hub.cli.upload.HfApi") as api_cls,
+        ):
+            api = api_cls.return_value
+            result = runner.invoke(app, ["upload", DUMMY_MODEL_ID, "my-folder"])
+        assert result.exit_code == 0
+        assert "uploaded" in result.stdout
+        resolve_mock.assert_called_once_with(
+            repo_id=DUMMY_MODEL_ID,
+            local_path="my-folder",
+            path_in_repo=None,
+            include=None,
+        )
+        upload_mock.assert_called_once()
+        kwargs = upload_mock.call_args.kwargs
+        assert kwargs["repo_id"] == DUMMY_MODEL_ID
+        assert kwargs["local_path"] == "my-folder"
+        assert kwargs["path_in_repo"] == "."
+        assert kwargs["repo_type"] == "model"
+        assert kwargs["revision"] is None
+        assert kwargs["include"] is None
+        assert kwargs["exclude"] is None
+        assert kwargs["delete"] is None
+        assert kwargs["commit_message"] is None
+        assert kwargs["commit_description"] is None
+        assert kwargs["create_pr"] is False
+        assert kwargs["every"] is None
+        assert kwargs["api"] is api
+        api_cls.assert_called_once_with(token=None, library_name="hf")
 
-            # Test error when using wildcard with explicit path_in_repo
-            with self.assertRaises(ValueError):
-                UploadCommand(self.parser.parse_args(["upload", DUMMY_MODEL_ID, "*.safetensors", "models/"]))
-
-    def test_upload_with_all_options(self) -> None:
-        """Test `hf upload my-file to dummy-repo with all options selected`."""
-        cmd = UploadCommand(
-            self.parser.parse_args(
+    def test_upload_with_all_options(self, runner: CliRunner) -> None:
+        returned_paths = ("my-file", "data/", ["*.json", "*.yaml"])
+        with (
+            patch("huggingface_hub.cli.upload._resolve_upload_paths", return_value=returned_paths) as resolve_mock,
+            patch("huggingface_hub.cli.upload._upload_impl", return_value="done") as upload_mock,
+            patch("huggingface_hub.cli.upload.HfApi") as api_cls,
+        ):
+            api = api_cls.return_value
+            result = runner.invoke(
+                app,
                 [
                     "upload",
                     DUMMY_MODEL_ID,
@@ -146,12 +123,15 @@ class TestUploadCommand(unittest.TestCase):
                     "v1.0.0",
                     "--include",
                     "*.json",
+                    "--include",
                     "*.yaml",
                     "--exclude",
                     "*.log",
+                    "--exclude",
                     "*.txt",
                     "--delete",
                     "*.config",
+                    "--delete",
                     "*.secret",
                     "--commit-message",
                     "My commit message",
@@ -163,344 +143,484 @@ class TestUploadCommand(unittest.TestCase):
                     "--token",
                     "my-token",
                     "--quiet",
-                ]
+                ],
             )
+        assert result.exit_code == 0
+        assert "done" in result.stdout
+        resolve_mock.assert_called_once_with(
+            repo_id=DUMMY_MODEL_ID,
+            local_path="my-file",
+            path_in_repo="data/",
+            include=["*.json", "*.yaml"],
         )
-        assert cmd.repo_id == DUMMY_MODEL_ID
-        assert cmd.local_path == "my-file"
-        assert cmd.path_in_repo == "data/"
-        assert cmd.repo_type == "dataset"
-        assert cmd.revision == "v1.0.0"
-        assert cmd.include == ["*.json", "*.yaml"]
-        assert cmd.exclude == ["*.log", "*.txt"]
-        assert cmd.delete == ["*.config", "*.secret"]
-        assert cmd.commit_message == "My commit message"
-        assert cmd.commit_description == "My commit description"
-        assert cmd.create_pr is True
-        assert cmd.every == 5
-        assert cmd.api.token == "my-token"
-        assert cmd.quiet is True
+        kwargs = upload_mock.call_args.kwargs
+        assert kwargs["repo_id"] == DUMMY_MODEL_ID
+        assert kwargs["local_path"] == "my-file"
+        assert kwargs["path_in_repo"] == "data/"
+        assert kwargs["repo_type"] == "dataset"
+        assert kwargs["revision"] == "v1.0.0"
+        assert kwargs["include"] == ["*.json", "*.yaml"]
+        assert kwargs["exclude"] == ["*.log", "*.txt"]
+        assert kwargs["delete"] == ["*.config", "*.secret"]
+        assert kwargs["commit_message"] == "My commit message"
+        assert kwargs["commit_description"] == "My commit description"
+        assert kwargs["create_pr"] is True
+        assert kwargs["every"] == 5
+        assert kwargs["api"] is api
+        api_cls.assert_called_once_with(token="my-token", library_name="hf")
+
+    def test_every_must_be_positive(self) -> None:
+        class _PatchedBadParameter(typer.BadParameter):
+            def __init__(self, message: str, *, param_name: str | None = None, **kwargs: object) -> None:
+                super().__init__(message, param_hint=param_name, **kwargs)
+
+        with (
+            patch("huggingface_hub.cli.upload.typer.BadParameter", _PatchedBadParameter),
+            patch("huggingface_hub.cli.upload.HfApi") as api_cls,
+        ):
+            with pytest.raises(typer.BadParameter, match="--every must be a positive value"):
+                upload(repo_id=DUMMY_MODEL_ID, every=0)
+
+            with pytest.raises(typer.BadParameter, match="--every must be a positive value"):
+                upload(repo_id=DUMMY_MODEL_ID, every=-10)
+        api_cls.assert_not_called()
+
+    def test_every_as_int(self, runner: CliRunner) -> None:
+        with (
+            patch("huggingface_hub.cli.upload._resolve_upload_paths", return_value=(".", ".", None)),
+            patch("huggingface_hub.cli.upload._upload_impl", return_value="ok") as upload_mock,
+            patch("huggingface_hub.cli.upload.HfApi"),
+        ):
+            result = runner.invoke(app, ["upload", DUMMY_MODEL_ID, ".", "--every", "10"])
+        assert result.exit_code == 0
+        kwargs = upload_mock.call_args.kwargs
+        assert kwargs["every"] == pytest.approx(10)
+
+    def test_every_as_float(self, runner: CliRunner) -> None:
+        with (
+            patch("huggingface_hub.cli.upload._resolve_upload_paths", return_value=(".", ".", None)),
+            patch("huggingface_hub.cli.upload._upload_impl", return_value="ok") as upload_mock,
+            patch("huggingface_hub.cli.upload.HfApi"),
+        ):
+            result = runner.invoke(app, ["upload", DUMMY_MODEL_ID, ".", "--every", "0.5"])
+        assert result.exit_code == 0
+        kwargs = upload_mock.call_args.kwargs
+        assert kwargs["every"] == pytest.approx(0.5)
+
+
+class TestResolveUploadPaths:
+    def test_upload_with_wildcard(self) -> None:
+        local_path, path_in_repo, include = _resolve_upload_paths(
+            repo_id=DUMMY_MODEL_ID, local_path="*.safetensors", path_in_repo=None, include=None
+        )
+        assert local_path == "."
+        assert path_in_repo == "*.safetensors"
+        assert include == "."
+
+        local_path, path_in_repo, include = _resolve_upload_paths(
+            repo_id=DUMMY_MODEL_ID, local_path="subdir/*.safetensors", path_in_repo=None, include=None
+        )
+        assert local_path == "."
+        assert path_in_repo == "subdir/*.safetensors"
+        assert include == "."
+
+        with pytest.raises(ValueError):
+            _resolve_upload_paths(
+                repo_id=DUMMY_MODEL_ID,
+                local_path="*.safetensors",
+                path_in_repo=None,
+                include=["*.json"],
+            )
+
+        with pytest.raises(ValueError):
+            _resolve_upload_paths(
+                repo_id=DUMMY_MODEL_ID,
+                local_path="*.safetensors",
+                path_in_repo="models/",
+                include=None,
+            )
 
     def test_upload_implicit_local_path_when_folder_exists(self) -> None:
         with tmp_current_directory() as cache_dir:
             folder_path = Path(cache_dir) / "my-cool-model"
             folder_path.mkdir()
-            cmd = UploadCommand(self.parser.parse_args(["upload", "my-cool-model"]))
-
-        # A folder with the same name as the repo exists => upload it at the root of the repo
-        assert cmd.local_path == "my-cool-model"
-        assert cmd.path_in_repo == "."
+            local_path, path_in_repo, include = _resolve_upload_paths(
+                repo_id="my-cool-model", local_path=None, path_in_repo=None, include=None
+            )
+        assert local_path == "my-cool-model"
+        assert path_in_repo == "."
+        assert include is None
 
     def test_upload_implicit_local_path_when_file_exists(self) -> None:
         with tmp_current_directory() as cache_dir:
-            folder_path = Path(cache_dir) / "my-cool-model"
-            folder_path.touch()
-            cmd = UploadCommand(self.parser.parse_args(["upload", "my-cool-model"]))
-
-        # A file with the same name as the repo exists => upload it at the root of the repo
-        assert cmd.local_path == "my-cool-model"
-        assert cmd.path_in_repo == "my-cool-model"
+            file_path = Path(cache_dir) / "my-cool-model"
+            file_path.write_text("content")
+            local_path, path_in_repo, include = _resolve_upload_paths(
+                repo_id="my-cool-model", local_path=None, path_in_repo=None, include=None
+            )
+        assert local_path == "my-cool-model"
+        assert path_in_repo == "my-cool-model"
+        assert include is None
 
     def test_upload_implicit_local_path_when_org_repo(self) -> None:
         with tmp_current_directory() as cache_dir:
             folder_path = Path(cache_dir) / "my-cool-model"
             folder_path.mkdir()
-            cmd = UploadCommand(self.parser.parse_args(["upload", "my-cool-org/my-cool-model"]))
-
-        # A folder with the same name as the repo exists => upload it at the root of the repo
-        assert cmd.local_path == "my-cool-model"
-        assert cmd.path_in_repo == "."
+            local_path, path_in_repo, include = _resolve_upload_paths(
+                repo_id="my-cool-org/my-cool-model", local_path=None, path_in_repo=None, include=None
+            )
+        assert local_path == "my-cool-model"
+        assert path_in_repo == "."
+        assert include is None
 
     def test_upload_implicit_local_path_otherwise(self) -> None:
-        # No folder or file has the same name as the repo => raise exception
-        with self.assertRaises(ValueError):
-            with tmp_current_directory():
-                UploadCommand(self.parser.parse_args(["upload", "my-cool-model"]))
+        with tmp_current_directory():
+            with pytest.raises(ValueError):
+                _resolve_upload_paths(repo_id="my-cool-model", local_path=None, path_in_repo=None, include=None)
 
     def test_upload_explicit_local_path_to_folder_implicit_path_in_repo(self) -> None:
         with tmp_current_directory() as cache_dir:
             folder_path = Path(cache_dir) / "path" / "to" / "folder"
             folder_path.mkdir(parents=True, exist_ok=True)
-            cmd = UploadCommand(self.parser.parse_args(["upload", "my-repo", "./path/to/folder"]))
-        assert cmd.local_path == "./path/to/folder"
-        assert cmd.path_in_repo == "."  # Always upload the folder at the root of the repo
+            local_path, path_in_repo, include = _resolve_upload_paths(
+                repo_id="my-repo", local_path="./path/to/folder", path_in_repo=None, include=None
+            )
+        assert local_path == "./path/to/folder"
+        assert path_in_repo == "."
+        assert include is None
 
     def test_upload_explicit_local_path_to_file_implicit_path_in_repo(self) -> None:
         with tmp_current_directory() as cache_dir:
             file_path = Path(cache_dir) / "path" / "to" / "file.txt"
             file_path.parent.mkdir(parents=True, exist_ok=True)
-            file_path.touch()
-            cmd = UploadCommand(self.parser.parse_args(["upload", "my-repo", "./path/to/file.txt"]))
-        assert cmd.local_path == "./path/to/file.txt"
-        assert cmd.path_in_repo == "file.txt"  # If a file, upload it at the root of the repo and keep name
+            file_path.write_text("content")
+            local_path, path_in_repo, include = _resolve_upload_paths(
+                repo_id="my-repo", local_path="./path/to/file.txt", path_in_repo=None, include=None
+            )
+        assert local_path == "./path/to/file.txt"
+        assert path_in_repo == "file.txt"
+        assert include is None
 
     def test_upload_explicit_paths(self) -> None:
-        cmd = UploadCommand(self.parser.parse_args(["upload", "my-repo", "./path/to/folder", "data/"]))
-        assert cmd.local_path == "./path/to/folder"
-        assert cmd.path_in_repo == "data/"
+        local_path, path_in_repo, include = _resolve_upload_paths(
+            repo_id="my-repo", local_path="./path/to/folder", path_in_repo="data/", include=None
+        )
+        assert local_path == "./path/to/folder"
+        assert path_in_repo == "data/"
+        assert include is None
 
-    def test_every_must_be_positive(self) -> None:
-        with self.assertRaises(ValueError):
-            UploadCommand(self.parser.parse_args(["upload", DUMMY_MODEL_ID, ".", "--every", "0"]))
 
-        with self.assertRaises(ValueError):
-            UploadCommand(self.parser.parse_args(["upload", DUMMY_MODEL_ID, ".", "--every", "-10"]))
-
-    def test_every_as_int(self) -> None:
-        cmd = UploadCommand(self.parser.parse_args(["upload", DUMMY_MODEL_ID, ".", "--every", "10"]))
-        assert cmd.every == 10
-
-    def test_every_as_float(self) -> None:
-        cmd = UploadCommand(self.parser.parse_args(["upload", DUMMY_MODEL_ID, ".", "--every", "0.5"]))
-        assert cmd.every == 0.5
-
-    @patch("huggingface_hub.cli.upload.HfApi.repo_info")
-    @patch("huggingface_hub.cli.upload.HfApi.upload_folder")
-    @patch("huggingface_hub.cli.upload.HfApi.create_repo")
-    def test_upload_folder_mock(self, create_mock: Mock, upload_mock: Mock, repo_info_mock: Mock) -> None:
+class TestUploadImpl:
+    @patch("huggingface_hub.cli.upload.is_xet_available", return_value=True)
+    @patch("huggingface_hub.cli.upload.HF_HUB_ENABLE_HF_TRANSFER", False)
+    def test_upload_folder_mock(self, *_: object) -> None:
+        api = Mock()
+        api.create_repo.return_value = Mock(repo_id="my-model")
         with SoftTemporaryDirectory() as cache_dir:
             cache_path = cache_dir.absolute().as_posix()
-            cmd = UploadCommand(
-                self.parser.parse_args(
-                    ["upload", "my-model", cache_path, ".", "--private", "--include", "*.json", "--delete", "*.json"]
-                )
-            )
-            cmd.run()
-
-            create_mock.assert_called_once_with(
-                repo_id="my-model", repo_type="model", exist_ok=True, private=True, space_sdk=None
-            )
-            upload_mock.assert_called_once_with(
-                folder_path=cache_path,
-                path_in_repo=".",
-                repo_id=create_mock.return_value.repo_id,
+            local_dir = Path(cache_path)
+            (local_dir / "config.json").write_text("{}")
+            result = _upload_impl(
+                api=api,
+                repo_id="my-model",
                 repo_type="model",
                 revision=None,
+                private=True,
+                include=["*.json"],
+                exclude=None,
+                delete=["*.json"],
                 commit_message=None,
                 commit_description=None,
                 create_pr=False,
-                allow_patterns=["*.json"],
-                ignore_patterns=None,
-                delete_patterns=["*.json"],
+                every=None,
+                local_path=cache_path,
+                path_in_repo=".",
             )
+        api.create_repo.assert_called_once_with(
+            repo_id="my-model",
+            repo_type="model",
+            exist_ok=True,
+            private=True,
+            space_sdk=None,
+        )
+        api.upload_folder.assert_called_once_with(
+            folder_path=cache_path,
+            path_in_repo=".",
+            repo_id="my-model",
+            repo_type="model",
+            revision=None,
+            commit_message=None,
+            commit_description=None,
+            create_pr=False,
+            allow_patterns=["*.json"],
+            ignore_patterns=None,
+            delete_patterns=["*.json"],
+        )
+        assert result == api.upload_folder.return_value
 
-    @patch("huggingface_hub.cli.upload.HfApi.repo_info")
-    @patch("huggingface_hub.cli.upload.HfApi.upload_file")
-    @patch("huggingface_hub.cli.upload.HfApi.create_repo")
-    def test_upload_file_mock(self, create_mock: Mock, upload_mock: Mock, repo_info_mock: Mock) -> None:
+    @patch("huggingface_hub.cli.upload.is_xet_available", return_value=True)
+    @patch("huggingface_hub.cli.upload.HF_HUB_ENABLE_HF_TRANSFER", False)
+    def test_upload_file_mock(self, *_: object) -> None:
+        api = Mock()
+        api.create_repo.return_value = Mock(repo_id="my-dataset")
         with SoftTemporaryDirectory() as cache_dir:
             file_path = Path(cache_dir) / "file.txt"
             file_path.write_text("content")
-            cmd = UploadCommand(
-                self.parser.parse_args(
-                    ["upload", "my-dataset", str(file_path), "logs/file.txt", "--repo-type", "dataset", "--create-pr"]
-                )
-            )
-            cmd.run()
-
-            create_mock.assert_called_once_with(
-                repo_id="my-dataset", repo_type="dataset", exist_ok=True, private=False, space_sdk=None
-            )
-            upload_mock.assert_called_once_with(
-                path_or_fileobj=str(file_path),
-                path_in_repo="logs/file.txt",
-                repo_id=create_mock.return_value.repo_id,
+            result = _upload_impl(
+                api=api,
+                repo_id="my-dataset",
                 repo_type="dataset",
                 revision=None,
+                private=False,
+                include=None,
+                exclude=None,
+                delete=None,
                 commit_message=None,
                 commit_description=None,
                 create_pr=True,
+                every=None,
+                local_path=str(file_path),
+                path_in_repo="logs/file.txt",
             )
-
-    @patch("huggingface_hub.cli.upload.HfApi.repo_info")
-    @patch("huggingface_hub.cli.upload.HfApi.upload_file")
-    @patch("huggingface_hub.cli.upload.HfApi.create_repo")
-    def test_upload_file_no_revision_mock(self, create_mock: Mock, upload_mock: Mock, repo_info_mock: Mock) -> None:
-        with SoftTemporaryDirectory() as cache_dir:
-            file_path = Path(cache_dir) / "file.txt"
-            file_path.write_text("content")
-            cmd = UploadCommand(self.parser.parse_args(["upload", "my-model", str(file_path), "logs/file.txt"]))
-            cmd.run()
-            # Revision not specified => no need to check
-            repo_info_mock.assert_not_called()
-
-    @patch("huggingface_hub.cli.upload.HfApi.create_branch")
-    @patch("huggingface_hub.cli.upload.HfApi.repo_info")
-    @patch("huggingface_hub.cli.upload.HfApi.upload_file")
-    @patch("huggingface_hub.cli.upload.HfApi.create_repo")
-    def test_upload_file_with_revision_mock(
-        self, create_mock: Mock, upload_mock: Mock, repo_info_mock: Mock, create_branch_mock: Mock
-    ) -> None:
-        repo_info_mock.side_effect = RevisionNotFoundError("revision not found", response=Mock())
-
-        with SoftTemporaryDirectory() as cache_dir:
-            file_path = Path(cache_dir) / "file.txt"
-            file_path.write_text("content")
-            cmd = UploadCommand(
-                self.parser.parse_args(
-                    ["upload", "my-model", str(file_path), "logs/file.txt", "--revision", "my-branch"]
-                )
-            )
-            cmd.run()
-
-            # Revision specified => check that it exists
-            repo_info_mock.assert_called_once_with(
-                repo_id=create_mock.return_value.repo_id, repo_type="model", revision="my-branch"
-            )
-
-            # Revision does not exist => create it
-            create_branch_mock.assert_called_once_with(
-                repo_id=create_mock.return_value.repo_id, repo_type="model", branch="my-branch", exist_ok=True
-            )
-
-    @patch("huggingface_hub.cli.upload.HfApi.repo_info")
-    @patch("huggingface_hub.cli.upload.HfApi.upload_file")
-    @patch("huggingface_hub.cli.upload.HfApi.create_repo")
-    def test_upload_file_revision_and_create_pr_mock(
-        self, create_mock: Mock, upload_mock: Mock, repo_info_mock: Mock
-    ) -> None:
-        with SoftTemporaryDirectory() as cache_dir:
-            file_path = Path(cache_dir) / "file.txt"
-            file_path.write_text("content")
-            cmd = UploadCommand(
-                self.parser.parse_args(
-                    ["upload", "my-model", str(file_path), "logs/file.txt", "--revision", "my-branch", "--create-pr"]
-                )
-            )
-            cmd.run()
-            # Revision specified but --create-pr => no need to check
-            repo_info_mock.assert_not_called()
-
-    @patch("huggingface_hub.cli.upload.HfApi.create_repo")
-    def test_upload_missing_path(self, create_mock: Mock) -> None:
-        cmd = UploadCommand(self.parser.parse_args(["upload", "my-model", "/path/to/missing_file", "logs/file.txt"]))
-        with self.assertRaises(FileNotFoundError):
-            cmd.run()  # File/folder does not exist locally
-
-        # Repo creation happens before the check
-        create_mock.assert_not_called()
-
-
-class TestDownloadCommand(unittest.TestCase):
-    def setUp(self) -> None:
-        """
-        Set up CLI as in `src/huggingface_hub/cli/hf.py`.
-        """
-        self.parser = ArgumentParser("hf", usage="hf <command> [<args>]")
-        commands_parser = self.parser.add_subparsers()
-        DownloadCommand.register_subcommand(commands_parser)
-
-    def test_download_basic(self) -> None:
-        """Test `hf download dummy-repo`."""
-        args = self.parser.parse_args(["download", DUMMY_MODEL_ID])
-        assert args.repo_id == DUMMY_MODEL_ID
-        assert len(args.filenames) == 0
-        assert args.repo_type == "model"
-        assert args.revision is None
-        assert args.include is None
-        assert args.exclude is None
-        assert args.cache_dir is None
-        assert args.local_dir is None
-        assert args.force_download is False
-        assert args.token is None
-        assert args.quiet is False
-        assert args.func == DownloadCommand
-
-    def test_download_with_all_options(self) -> None:
-        """Test `hf download dummy-repo` with all options selected."""
-        args = self.parser.parse_args(
-            [
-                "download",
-                DUMMY_MODEL_ID,
-                "--repo-type",
-                "dataset",
-                "--revision",
-                "v1.0.0",
-                "--include",
-                "*.json",
-                "*.yaml",
-                "--exclude",
-                "*.log",
-                "*.txt",
-                "--force-download",
-                "--cache-dir",
-                "/tmp",
-                "--token",
-                "my-token",
-                "--quiet",
-                "--local-dir",
-                ".",
-                "--max-workers",
-                "4",
-            ]
-        )
-        assert args.repo_id == DUMMY_MODEL_ID
-        assert args.repo_type == "dataset"
-        assert args.revision == "v1.0.0"
-        assert args.include == ["*.json", "*.yaml"]
-        assert args.exclude == ["*.log", "*.txt"]
-        assert args.force_download is True
-        assert args.cache_dir == "/tmp"
-        assert args.local_dir == "."
-        assert args.token == "my-token"
-        assert args.quiet is True
-        assert args.max_workers == 4
-        assert args.func == DownloadCommand
-
-    @patch("huggingface_hub.cli.download.hf_hub_download")
-    def test_download_file_from_revision(self, mock: Mock) -> None:
-        args = Namespace(
-            token="hf_****",
-            repo_id="author/dataset",
-            filenames=["README.md"],
+        api.create_repo.assert_called_once_with(
+            repo_id="my-dataset",
             repo_type="dataset",
-            revision="refs/pr/1",
+            exist_ok=True,
+            private=False,
+            space_sdk=None,
+        )
+        api.upload_file.assert_called_once_with(
+            path_or_fileobj=str(file_path),
+            path_in_repo="logs/file.txt",
+            repo_id="my-dataset",
+            repo_type="dataset",
+            revision=None,
+            commit_message=None,
+            commit_description=None,
+            create_pr=True,
+        )
+        assert result == api.upload_file.return_value
+
+    @patch("huggingface_hub.cli.upload.is_xet_available", return_value=True)
+    @patch("huggingface_hub.cli.upload.HF_HUB_ENABLE_HF_TRANSFER", False)
+    def test_upload_file_no_revision_mock(self, *_: object) -> None:
+        api = Mock()
+        api.create_repo.return_value = Mock(repo_id="my-model")
+        with SoftTemporaryDirectory() as cache_dir:
+            file_path = Path(cache_dir) / "file.txt"
+            file_path.write_text("content")
+            _upload_impl(
+                api=api,
+                repo_id="my-model",
+                repo_type="model",
+                revision=None,
+                private=False,
+                include=None,
+                exclude=None,
+                delete=None,
+                commit_message=None,
+                commit_description=None,
+                create_pr=False,
+                every=None,
+                local_path=str(file_path),
+                path_in_repo="logs/file.txt",
+            )
+        api.repo_info.assert_not_called()
+
+    @patch("huggingface_hub.cli.upload.is_xet_available", return_value=True)
+    @patch("huggingface_hub.cli.upload.HF_HUB_ENABLE_HF_TRANSFER", False)
+    def test_upload_file_with_revision_mock(self, *_: object) -> None:
+        api = Mock()
+        api.create_repo.return_value = Mock(repo_id="my-model")
+        api.repo_info.side_effect = RevisionNotFoundError("revision not found", response=Mock())
+        with SoftTemporaryDirectory() as cache_dir:
+            file_path = Path(cache_dir) / "file.txt"
+            file_path.write_text("content")
+            _upload_impl(
+                api=api,
+                repo_id="my-model",
+                repo_type="model",
+                revision="my-branch",
+                private=False,
+                include=None,
+                exclude=None,
+                delete=None,
+                commit_message=None,
+                commit_description=None,
+                create_pr=False,
+                every=None,
+                local_path=str(file_path),
+                path_in_repo="logs/file.txt",
+            )
+        api.repo_info.assert_called_once_with(repo_id="my-model", repo_type="model", revision="my-branch")
+        api.create_branch.assert_called_once_with(
+            repo_id="my-model", repo_type="model", branch="my-branch", exist_ok=True
+        )
+
+    @patch("huggingface_hub.cli.upload.is_xet_available", return_value=True)
+    @patch("huggingface_hub.cli.upload.HF_HUB_ENABLE_HF_TRANSFER", False)
+    def test_upload_file_revision_and_create_pr_mock(self, *_: object) -> None:
+        api = Mock()
+        api.create_repo.return_value = Mock(repo_id="my-model")
+        with SoftTemporaryDirectory() as cache_dir:
+            file_path = Path(cache_dir) / "file.txt"
+            file_path.write_text("content")
+            _upload_impl(
+                api=api,
+                repo_id="my-model",
+                repo_type="model",
+                revision="my-branch",
+                private=False,
+                include=None,
+                exclude=None,
+                delete=None,
+                commit_message=None,
+                commit_description=None,
+                create_pr=True,
+                every=None,
+                local_path=str(file_path),
+                path_in_repo="logs/file.txt",
+            )
+        api.repo_info.assert_not_called()
+        api.create_branch.assert_not_called()
+
+    @patch("huggingface_hub.cli.upload.is_xet_available", return_value=True)
+    @patch("huggingface_hub.cli.upload.HF_HUB_ENABLE_HF_TRANSFER", False)
+    def test_upload_missing_path(self, *_: object) -> None:
+        api = Mock()
+        with pytest.raises(FileNotFoundError):
+            _upload_impl(
+                api=api,
+                repo_id="my-model",
+                repo_type="model",
+                revision=None,
+                private=False,
+                include=None,
+                exclude=None,
+                delete=None,
+                commit_message=None,
+                commit_description=None,
+                create_pr=False,
+                every=None,
+                local_path="/path/to/missing_file",
+                path_in_repo="logs/file.txt",
+            )
+        api.create_repo.assert_not_called()
+
+
+class TestDownloadCommand:
+    def test_download_basic(self, runner: CliRunner) -> None:
+        with patch("huggingface_hub.cli.download._download_impl", return_value="path") as impl_mock:
+            result = runner.invoke(app, ["download", DUMMY_MODEL_ID])
+        assert result.exit_code == 0
+        assert "path" in result.stdout
+        impl_mock.assert_called_once()
+        kwargs = impl_mock.call_args.kwargs
+        assert kwargs["repo_id"] == DUMMY_MODEL_ID
+        assert kwargs["filenames"] == []
+        assert kwargs["repo_type"] == "model"
+        assert kwargs["revision"] is None
+        assert kwargs["include"] is None
+        assert kwargs["exclude"] is None
+        assert kwargs["cache_dir"] is None
+        assert kwargs["local_dir"] is None
+        assert kwargs["force_download"] is False
+        assert kwargs["token"] is None
+        assert kwargs["max_workers"] == 8
+
+    def test_download_with_all_options(self, runner: CliRunner) -> None:
+        with patch("huggingface_hub.cli.download._download_impl", return_value="path") as impl_mock:
+            result = runner.invoke(
+                app,
+                [
+                    "download",
+                    DUMMY_MODEL_ID,
+                    "--repo-type",
+                    "dataset",
+                    "--revision",
+                    "v1.0.0",
+                    "--include",
+                    "*.json",
+                    "--include",
+                    "*.yaml",
+                    "--exclude",
+                    "*.log",
+                    "--exclude",
+                    "*.txt",
+                    "--force-download",
+                    "--cache-dir",
+                    "/tmp",
+                    "--token",
+                    "my-token",
+                    "--quiet",
+                    "--local-dir",
+                    ".",
+                    "--max-workers",
+                    "4",
+                ],
+            )
+        assert result.exit_code == 0
+        kwargs = impl_mock.call_args.kwargs
+        assert kwargs["repo_id"] == DUMMY_MODEL_ID
+        assert kwargs["repo_type"] == "dataset"
+        assert kwargs["revision"] == "v1.0.0"
+        assert kwargs["include"] == ["*.json", "*.yaml"]
+        assert kwargs["exclude"] == ["*.log", "*.txt"]
+        assert kwargs["force_download"] is True
+        assert kwargs["cache_dir"] == "/tmp"
+        assert kwargs["local_dir"] == "."
+        assert kwargs["token"] == "my-token"
+        assert kwargs["max_workers"] == 4
+
+
+class TestDownloadImpl:
+    @patch("huggingface_hub.cli.download.hf_hub_download")
+    def test_download_file_from_revision(self, mock_download: Mock) -> None:
+        mock_download.return_value = "file-path"
+        result = _download_impl(
+            repo_id="author/model",
+            filenames=["config.json"],
+            repo_type="model",
+            revision="main",
             include=None,
             exclude=None,
-            force_download=False,
             cache_dir=None,
-            local_dir=".",
-            quiet=False,
+            local_dir=None,
+            force_download=False,
+            token=None,
             max_workers=8,
         )
-
-        # Output path is printed to terminal once run is completed
-        with capture_output() as output:
-            DownloadCommand(args).run()
-        self.assertRegex(output.getvalue(), r"<MagicMock name='hf_hub_download\(\)' id='\d+'>")
-
-        mock.assert_called_once_with(
-            repo_id="author/dataset",
-            repo_type="dataset",
-            revision="refs/pr/1",
-            filename="README.md",
+        assert result == "file-path"
+        mock_download.assert_called_once_with(
+            repo_id="author/model",
+            repo_type="model",
+            revision="main",
+            filename="config.json",
             cache_dir=None,
             force_download=False,
-            token="hf_****",
-            local_dir=".",
+            token=None,
+            local_dir=None,
             library_name="hf",
         )
 
     @patch("huggingface_hub.cli.download.snapshot_download")
-    def test_download_multiple_files(self, mock: Mock) -> None:
-        args = Namespace(
-            token="hf_****",
+    def test_download_multiple_files(self, mock_snapshot: Mock) -> None:
+        mock_snapshot.return_value = "folder-path"
+        result = _download_impl(
             repo_id="author/model",
             filenames=["README.md", "config.json"],
             repo_type="model",
             revision=None,
             include=None,
             exclude=None,
-            force_download=True,
             cache_dir=None,
-            local_dir="/path/to/dir",
-            quiet=False,
-            max_workers=8,
+            local_dir=None,
+            force_download=True,
+            token=None,
+            max_workers=4,
         )
-        DownloadCommand(args).run()
-
-        # Use `snapshot_download` to ensure all files comes from same revision
-        mock.assert_called_once_with(
+        assert result == "folder-path"
+        mock_snapshot.assert_called_once_with(
             repo_id="author/model",
             repo_type="model",
             revision=None,
@@ -508,32 +628,28 @@ class TestDownloadCommand(unittest.TestCase):
             ignore_patterns=None,
             force_download=True,
             cache_dir=None,
-            token="hf_****",
-            local_dir="/path/to/dir",
+            token=None,
+            local_dir=None,
             library_name="hf",
-            max_workers=8,
+            max_workers=4,
         )
 
     @patch("huggingface_hub.cli.download.snapshot_download")
-    def test_download_with_patterns(self, mock: Mock) -> None:
-        args = Namespace(
-            token=None,
+    def test_download_with_patterns(self, mock_snapshot: Mock) -> None:
+        _download_impl(
             repo_id="author/model",
             filenames=[],
             repo_type="model",
             revision=None,
             include=["*.json"],
             exclude=["data/*"],
-            force_download=True,
             cache_dir=None,
-            quiet=False,
             local_dir=None,
+            force_download=True,
+            token=None,
             max_workers=8,
         )
-        DownloadCommand(args).run()
-
-        # Use `snapshot_download` to ensure all files comes from same revision
-        mock.assert_called_once_with(
+        mock_snapshot.assert_called_once_with(
             repo_id="author/model",
             repo_type="model",
             revision=None,
@@ -541,39 +657,35 @@ class TestDownloadCommand(unittest.TestCase):
             ignore_patterns=["data/*"],
             force_download=True,
             cache_dir=None,
-            local_dir=None,
             token=None,
+            local_dir=None,
             library_name="hf",
             max_workers=8,
         )
 
     @patch("huggingface_hub.cli.download.snapshot_download")
-    def test_download_with_ignored_patterns(self, mock: Mock) -> None:
-        args = Namespace(
-            token=None,
-            repo_id="author/model",
-            filenames=["README.md", "config.json"],
-            repo_type="model",
-            revision=None,
-            include=["*.json"],
-            exclude=["data/*"],
-            force_download=True,
-            cache_dir=None,
-            quiet=False,
-            local_dir=None,
-            max_workers=8,
-        )
-
-        with self.assertWarns(UserWarning):
-            # warns that patterns are ignored
-            DownloadCommand(args).run()
-
-        mock.assert_called_once_with(
+    def test_download_with_ignored_patterns(self, mock_snapshot: Mock) -> None:
+        with warnings.catch_warnings(record=True) as caught:
+            _download_impl(
+                repo_id="author/model",
+                filenames=["README.md", "config.json"],
+                repo_type="model",
+                revision=None,
+                include=["*.json"],
+                exclude=["data/*"],
+                cache_dir=None,
+                local_dir=None,
+                force_download=True,
+                token=None,
+                max_workers=8,
+            )
+        assert any("Ignoring" in str(w.message) for w in caught)
+        mock_snapshot.assert_called_once_with(
             repo_id="author/model",
             repo_type="model",
             revision=None,
-            allow_patterns=["README.md", "config.json"],  # `filenames` has priority over the patterns
-            ignore_patterns=None,  # cleaned up
+            allow_patterns=["README.md", "config.json"],
+            ignore_patterns=None,
             force_download=True,
             cache_dir=None,
             token=None,
@@ -582,109 +694,98 @@ class TestDownloadCommand(unittest.TestCase):
             max_workers=8,
         )
 
-        # Same but quiet (no warnings)
-        args.quiet = True
-        with warnings.catch_warnings():
-            # Taken from https://docs.pytest.org/en/latest/how-to/capture-warnings.html#additional-use-cases-of-warnings-in-tests
-            warnings.simplefilter("error")
-            DownloadCommand(args).run()
 
-
-class TestTagCommands(unittest.TestCase):
-    def setUp(self) -> None:
-        """
-        Set up CLI as in `src/huggingface_hub/cli/hf.py`.
-        """
-        self.parser = ArgumentParser("hf", usage="hf <command> [<args>]")
-        commands_parser = self.parser.add_subparsers()
-        RepoCommands.register_subcommand(commands_parser)
-
-    def test_tag_create_basic(self) -> None:
-        args = self.parser.parse_args(["repo", "tag", "create", DUMMY_MODEL_ID, "1.0", "-m", "My tag message"])
-        assert args.repo_id == DUMMY_MODEL_ID
-        assert args.tag == "1.0"
-        assert args.message is not None
-        assert args.revision is None
-        assert args.token is None
-        assert args.repo_type == "model"
-
-    def test_tag_create_with_all_options(self) -> None:
-        args = self.parser.parse_args(
-            [
-                "repo",
-                "tag",
-                "create",
-                DUMMY_MODEL_ID,
-                "1.0",
-                "--message",
-                "My tag message",
-                "--revision",
-                "v1.0.0",
-                "--token",
-                "my-token",
-                "--repo-type",
-                "dataset",
-            ]
+class TestTagCommands:
+    def test_tag_create_basic(self, runner: CliRunner) -> None:
+        with patch("huggingface_hub.cli.repo.HfApi") as api_cls:
+            api = api_cls.return_value
+            result = runner.invoke(
+                app,
+                ["repo", "tag", "create", DUMMY_MODEL_ID, "1.0", "-m", "My tag message"],
+            )
+        assert result.exit_code == 0
+        api_cls.assert_called_once_with(token=None)
+        api.create_tag.assert_called_once_with(
+            repo_id=DUMMY_MODEL_ID,
+            tag="1.0",
+            tag_message="My tag message",
+            revision=None,
+            repo_type="model",
         )
-        assert args.repo_id == DUMMY_MODEL_ID
-        assert args.tag == "1.0"
-        assert args.message == "My tag message"
-        assert args.revision == "v1.0.0"
-        assert args.token == "my-token"
-        assert args.repo_type == "dataset"
 
-    def test_tag_list_basic(self) -> None:
-        args = self.parser.parse_args(["repo", "tag", "list", DUMMY_MODEL_ID])
-        assert args.repo_id == DUMMY_MODEL_ID
-        assert args.token is None
-        assert args.repo_type == "model"
+    def test_tag_create_with_all_options(self, runner: CliRunner) -> None:
+        with patch("huggingface_hub.cli.repo.HfApi") as api_cls:
+            api = api_cls.return_value
+            result = runner.invoke(
+                app,
+                [
+                    "repo",
+                    "tag",
+                    "create",
+                    DUMMY_MODEL_ID,
+                    "1.0",
+                    "--message",
+                    "My tag message",
+                    "--revision",
+                    "v1.0.0",
+                    "--token",
+                    "my-token",
+                    "--repo-type",
+                    "dataset",
+                ],
+            )
+        assert result.exit_code == 0
+        api_cls.assert_called_once_with(token="my-token")
+        api.create_tag.assert_called_once_with(
+            repo_id=DUMMY_MODEL_ID,
+            tag="1.0",
+            tag_message="My tag message",
+            revision="v1.0.0",
+            repo_type="dataset",
+        )
 
-    def test_tag_delete_basic(self) -> None:
-        args = self.parser.parse_args(["repo", "tag", "delete", DUMMY_MODEL_ID, "1.0"])
-        assert args.repo_id == DUMMY_MODEL_ID
-        assert args.tag == "1.0"
-        assert args.token is None
-        assert args.repo_type == "model"
-        assert args.yes is False
+    def test_tag_list_basic(self, runner: CliRunner) -> None:
+        refs = Mock(tags=[Mock(name="v1")])
+        with patch("huggingface_hub.cli.repo.HfApi") as api_cls:
+            api = api_cls.return_value
+            api.list_repo_refs.return_value = refs
+            result = runner.invoke(app, ["repo", "tag", "list", DUMMY_MODEL_ID])
+        assert result.exit_code == 0
+        api_cls.assert_called_once_with(token=None)
+        api.list_repo_refs.assert_called_once_with(repo_id=DUMMY_MODEL_ID, repo_type="model")
+
+    def test_tag_delete_basic(self, runner: CliRunner) -> None:
+        with patch("huggingface_hub.cli.repo.HfApi") as api_cls:
+            api = api_cls.return_value
+            result = runner.invoke(
+                app,
+                ["repo", "tag", "delete", DUMMY_MODEL_ID, "1.0"],
+                input="y\n",
+            )
+        assert result.exit_code == 0
+        api_cls.assert_called_once_with(token=None)
+        api.delete_tag.assert_called_once_with(repo_id=DUMMY_MODEL_ID, tag="1.0", repo_type="model")
 
 
 @contextmanager
 def tmp_current_directory() -> Generator[str, None, None]:
-    """Change current directory to a tmp dir and revert back when exiting."""
     with SoftTemporaryDirectory() as tmp_dir:
         cwd = os.getcwd()
         os.chdir(tmp_dir)
         try:
             yield tmp_dir
-        except:
-            raise
         finally:
             os.chdir(cwd)
 
 
-class TestRepoFilesCommand(unittest.TestCase):
-    def setUp(self) -> None:
-        """
-        Set up CLI as in `src/huggingface_hub/cli/hf.py`.
-        """
-        self.parser = ArgumentParser("hf", usage="hf <command> [<args>]")
-        commands_parser = self.parser.add_subparsers()
-        RepoFilesCommand.register_subcommand(commands_parser)
-
-    @patch("huggingface_hub.cli.repo_files.HfApi.delete_files")
-    def test_delete(self, delete_files_mock: Mock) -> None:
-        fixtures = [
-            {
-                "input_args": [
-                    "repo-files",
-                    "delete",
-                    DUMMY_MODEL_ID,
-                    "*",
-                ],
-                "delete_files_args": {
-                    "delete_patterns": [
-                        "*",
-                    ],
+class TestRepoFilesCommand:
+    @pytest.mark.parametrize(
+        "cli_args, expected_kwargs",
+        [
+            (
+                ["repo-files", "delete", DUMMY_MODEL_ID, "*"],
+                {
+                    "delete_patterns": ["*"],
                     "repo_id": DUMMY_MODEL_ID,
                     "repo_type": "model",
                     "revision": None,
@@ -692,18 +793,11 @@ class TestRepoFilesCommand(unittest.TestCase):
                     "commit_description": None,
                     "create_pr": False,
                 },
-            },
-            {
-                "input_args": [
-                    "repo-files",
-                    "delete",
-                    DUMMY_MODEL_ID,
-                    "file.txt",
-                ],
-                "delete_files_args": {
-                    "delete_patterns": [
-                        "file.txt",
-                    ],
+            ),
+            (
+                ["repo-files", "delete", DUMMY_MODEL_ID, "file.txt"],
+                {
+                    "delete_patterns": ["file.txt"],
                     "repo_id": DUMMY_MODEL_ID,
                     "repo_type": "model",
                     "revision": None,
@@ -711,18 +805,11 @@ class TestRepoFilesCommand(unittest.TestCase):
                     "commit_description": None,
                     "create_pr": False,
                 },
-            },
-            {
-                "input_args": [
-                    "repo-files",
-                    "delete",
-                    DUMMY_MODEL_ID,
-                    "folder/",
-                ],
-                "delete_files_args": {
-                    "delete_patterns": [
-                        "folder/",
-                    ],
+            ),
+            (
+                ["repo-files", "delete", DUMMY_MODEL_ID, "folder/"],
+                {
+                    "delete_patterns": ["folder/"],
                     "repo_id": DUMMY_MODEL_ID,
                     "repo_type": "model",
                     "revision": None,
@@ -730,17 +817,10 @@ class TestRepoFilesCommand(unittest.TestCase):
                     "commit_description": None,
                     "create_pr": False,
                 },
-            },
-            {
-                "input_args": [
-                    "repo-files",
-                    "delete",
-                    DUMMY_MODEL_ID,
-                    "file1.txt",
-                    "folder/",
-                    "file2.txt",
-                ],
-                "delete_files_args": {
+            ),
+            (
+                ["repo-files", "delete", DUMMY_MODEL_ID, "file1.txt", "folder/", "file2.txt"],
+                {
                     "delete_patterns": [
                         "file1.txt",
                         "folder/",
@@ -753,9 +833,9 @@ class TestRepoFilesCommand(unittest.TestCase):
                     "commit_description": None,
                     "create_pr": False,
                 },
-            },
-            {
-                "input_args": [
+            ),
+            (
+                [
                     "repo-files",
                     "delete",
                     DUMMY_MODEL_ID,
@@ -763,7 +843,7 @@ class TestRepoFilesCommand(unittest.TestCase):
                     "*.json",
                     "folder/*.parquet",
                 ],
-                "delete_files_args": {
+                {
                     "delete_patterns": [
                         "file.txt *",
                         "*.json",
@@ -776,9 +856,9 @@ class TestRepoFilesCommand(unittest.TestCase):
                     "commit_description": None,
                     "create_pr": False,
                 },
-            },
-            {
-                "input_args": [
+            ),
+            (
+                [
                     "repo-files",
                     "delete",
                     DUMMY_MODEL_ID,
@@ -793,10 +873,8 @@ class TestRepoFilesCommand(unittest.TestCase):
                     "My commit description",
                     "--create-pr",
                 ],
-                "delete_files_args": {
-                    "delete_patterns": [
-                        "file.txt *",
-                    ],
+                {
+                    "delete_patterns": ["file.txt *"],
                     "repo_id": DUMMY_MODEL_ID,
                     "repo_type": "dataset",
                     "revision": "test_revision",
@@ -804,182 +882,138 @@ class TestRepoFilesCommand(unittest.TestCase):
                     "commit_description": "My commit description",
                     "create_pr": True,
                 },
-            },
-        ]
-
-        for expected in fixtures:
-            # subTest is similar to pytest.mark.parametrize, but using the unittest
-            # framework
-            with self.subTest(expected):
-                delete_files_args = expected["delete_files_args"]
-
-                cmd = DeleteFilesSubCommand(self.parser.parse_args(expected["input_args"]))
-                cmd.run()
-
-                if delete_files_args is None:
-                    assert delete_files_mock.call_count == 0
-                else:
-                    assert delete_files_mock.call_count == 1
-                    # Inspect the captured calls
-                    _, kwargs = delete_files_mock.call_args_list[0]
-                    assert kwargs == delete_files_args
-
-                delete_files_mock.reset_mock()
-
-
-class DummyResponse:
-    def __init__(self, json):
-        self._json = json
-
-    def raise_for_status(self):
-        pass
-
-    def json(self):
-        return self._json
-
-
-class DummyCommit:
-    def __init__(self, oid: str):
-        self.oid = oid
-
-
-class TestJobsCommand(unittest.TestCase):
-    def setUp(self) -> None:
-        """
-        Set up CLI as in `src/huggingface_hub/commands/huggingface_cli.py`.
-        """
-        self.parser = ArgumentParser("hf", usage="hf <command> [<args>]")
-        commands_parser = self.parser.add_subparsers()
-        JobsCommands.register_subcommand(commands_parser)
-
-    patch_httpx_post = patch(
-        "httpx.Client.post",
-        return_value=DummyResponse(
-            {
-                "id": "my-job-id",
-                "owner": {
-                    "id": "userid",
-                    "name": "my-username",
-                    "type": "user",
-                },
-                "status": {"stage": "RUNNING"},
-            }
-        ),
+            ),
+        ],
     )
-    patch_whoami = patch("huggingface_hub.hf_api.HfApi.whoami", return_value={"name": "my-username"})
-    patch_get_token = patch("huggingface_hub.hf_api.get_token", return_value="hf_xxx")
-    patch_repo_info = patch("huggingface_hub.hf_api.HfApi.repo_info")
-    patch_upload_file = patch("huggingface_hub.hf_api.HfApi.upload_file", return_value=DummyCommit(oid="ae068f"))
+    def test_delete(self, runner: CliRunner, cli_args: list[str], expected_kwargs: dict[str, object]) -> None:
+        with patch("huggingface_hub.cli.repo_files.HfApi") as api_cls:
+            api = api_cls.return_value
+            result = runner.invoke(app, cli_args)
+        assert result.exit_code == 0
+        api.delete_files.assert_called_once_with(**expected_kwargs)
 
-    @patch_httpx_post
-    @patch_whoami
-    def test_run(self, whoami: Mock, httpx_post: Mock) -> None:
-        input_args = ["jobs", "run", "--detach", "ubuntu", "echo", "hello"]
-        cmd = RunCommand(self.parser.parse_args(input_args))
-        cmd.run()
-        assert httpx_post.call_count == 1
-        args, kwargs = httpx_post.call_args_list[0]
-        assert args == ("https://huggingface.co/api/jobs/my-username",)
-        assert kwargs["json"] == {
-            "command": ["echo", "hello"],
-            "arguments": [],
-            "environment": {},
-            "flavor": "cpu-basic",
-            "dockerImage": "ubuntu",
-        }
 
-    @patch(
-        "httpx.Client.post",
-        return_value=DummyResponse(
-            {
-                "id": "my-job-id",
-                "owner": {
-                    "id": "userid",
-                    "name": "my-username",
-                    "type": "user",
-                },
-                "status": {"lastJob": None, "nextJobRunAt": "2025-08-20T15:35:00.000Z"},
-                "jobSpec": {},
-            }
-        ),
-    )
-    @patch("huggingface_hub.hf_api.HfApi.whoami", return_value={"name": "my-username"})
-    def test_create_scheduled_job(self, whoami: Mock, httpx_mock: Mock) -> None:
-        input_args = ["jobs", "scheduled", "run", "@hourly", "ubuntu", "echo", "hello"]
-        cmd = ScheduledRunCommand(self.parser.parse_args(input_args))
-        cmd.run()
-        assert httpx_mock.call_count == 1
-        args, kwargs = httpx_mock.call_args_list[0]
-        assert args == ("https://huggingface.co/api/scheduled-jobs/my-username",)
-        assert kwargs["json"] == {
-            "jobSpec": {
-                "command": ["echo", "hello"],
-                "arguments": [],
-                "environment": {},
-                "flavor": "cpu-basic",
-                "dockerImage": "ubuntu",
-            },
-            "schedule": "@hourly",
-        }
+class TestJobsCommand:
+    def test_run(self, runner: CliRunner) -> None:
+        job = Mock(id="my-job-id", url="https://huggingface.co/api/jobs/my-username/my-job-id")
+        with (
+            patch("huggingface_hub.cli.jobs.HfApi") as api_cls,
+            patch("huggingface_hub.cli.jobs._get_extended_environ", return_value={}),
+        ):
+            api = api_cls.return_value
+            api.run_job.return_value = job
+            result = runner.invoke(app, ["jobs", "run", "--detach", "ubuntu", "echo", "hello"])
+        assert result.exit_code == 0
+        api.run_job.assert_called_once_with(
+            image="ubuntu",
+            command=["echo", "hello"],
+            env={},
+            secrets={},
+            flavor=None,
+            timeout=None,
+            namespace=None,
+        )
+        api.fetch_job_logs.assert_not_called()
 
-    @patch_httpx_post
-    @patch_whoami
-    def test_uv_command(self, whoami: Mock, httpx_post: Mock) -> None:
-        input_args = ["jobs", "uv", "run", "--detach", "echo", "hello"]
-        cmd = UvCommand(self.parser.parse_args(input_args))
-        cmd.run()
-        assert httpx_post.call_count == 1
-        args, kwargs = httpx_post.call_args_list[0]
-        assert args == ("https://huggingface.co/api/jobs/my-username",)
-        assert kwargs["json"] == {
-            "command": ["uv", "run", "echo", "hello"],
-            "arguments": [],
-            "environment": {},
-            "flavor": "cpu-basic",
-            "dockerImage": "ghcr.io/astral-sh/uv:python3.12-bookworm",
-        }
+    def test_create_scheduled_job(self, runner: CliRunner) -> None:
+        scheduled_job = Mock(id="my-job-id")
+        with (
+            patch("huggingface_hub.cli.jobs.HfApi") as api_cls,
+            patch("huggingface_hub.cli.jobs._get_extended_environ", return_value={}),
+        ):
+            api = api_cls.return_value
+            api.create_scheduled_job.return_value = scheduled_job
+            result = runner.invoke(
+                app,
+                ["jobs", "scheduled", "run", "@hourly", "ubuntu", "echo", "hello"],
+            )
+        assert result.exit_code == 0
+        api.create_scheduled_job.assert_called_once_with(
+            image="ubuntu",
+            command=["echo", "hello"],
+            schedule="@hourly",
+            suspend=None,
+            concurrency=None,
+            env={},
+            secrets={},
+            flavor=None,
+            timeout=None,
+            namespace=None,
+        )
 
-    @patch_httpx_post
-    @patch_whoami
-    def test_uv_remote_script(self, whoami: Mock, httpx_post: Mock) -> None:
-        input_args = ["jobs", "uv", "run", "--detach", "https://.../script.py"]
-        cmd = UvCommand(self.parser.parse_args(input_args))
-        cmd.run()
-        assert httpx_post.call_count == 1
-        args, kwargs = httpx_post.call_args_list[0]
-        assert args == ("https://huggingface.co/api/jobs/my-username",)
-        assert kwargs["json"] == {
-            "command": ["uv", "run", "https://.../script.py"],
-            "arguments": [],
-            "environment": {},
-            "flavor": "cpu-basic",
-            "dockerImage": "ghcr.io/astral-sh/uv:python3.12-bookworm",
-        }
+    def test_uv_command(self, runner: CliRunner) -> None:
+        job = Mock(id="my-job-id", url="https://huggingface.co/api/jobs/my-username/my-job-id")
+        with (
+            patch("huggingface_hub.cli.jobs.HfApi") as api_cls,
+            patch("huggingface_hub.cli.jobs._get_extended_environ", return_value={}),
+        ):
+            api = api_cls.return_value
+            api.run_uv_job.return_value = job
+            result = runner.invoke(app, ["jobs", "uv", "run", "--detach", "echo", "hello"])
+        assert result.exit_code == 0
+        api.run_uv_job.assert_called_once_with(
+            script="echo",
+            script_args=["hello"],
+            dependencies=None,
+            python=None,
+            image=None,
+            env={},
+            secrets={},
+            flavor=None,
+            timeout=None,
+            namespace=None,
+            _repo=None,
+        )
+        api.fetch_job_logs.assert_not_called()
 
-    @patch_httpx_post
-    @patch_whoami
-    @patch_get_token
-    @patch_repo_info
-    @patch_upload_file
-    def test_uv_local_script(
-        self, upload_file: Mock, repo_info: Mock, get_token: Mock, whoami: Mock, httpx_post: Mock
-    ) -> None:
-        input_args = ["jobs", "uv", "run", "--detach", __file__]
-        cmd = UvCommand(self.parser.parse_args(input_args))
-        cmd.run()
-        assert httpx_post.call_count == 1
-        args, kwargs = httpx_post.call_args_list[0]
-        assert args == ("https://huggingface.co/api/jobs/my-username",)
-        command = kwargs["json"].pop("command")
-        assert "UV_SCRIPT_URL" in " ".join(command)
-        assert kwargs["json"] == {
-            "arguments": [],
-            "environment": {
-                "UV_SCRIPT_URL": "https://hub-ci.huggingface.co/datasets/my-username/hf-cli-jobs-uv-run-scripts/resolve/ae068f/test_cli.py"
-            },
-            "secrets": {"UV_SCRIPT_HF_TOKEN": "hf_xxx"},
-            "flavor": "cpu-basic",
-            "dockerImage": "ghcr.io/astral-sh/uv:python3.12-bookworm",
-        }
-        assert repo_info.call_count == 1  # check if repo exists
-        assert upload_file.call_count == 2  # script and readme
+    def test_uv_remote_script(self, runner: CliRunner) -> None:
+        job = Mock(id="my-job-id", url="https://huggingface.co/api/jobs/my-username/my-job-id")
+        with (
+            patch("huggingface_hub.cli.jobs.HfApi") as api_cls,
+            patch("huggingface_hub.cli.jobs._get_extended_environ", return_value={}),
+        ):
+            api = api_cls.return_value
+            api.run_uv_job.return_value = job
+            result = runner.invoke(app, ["jobs", "uv", "run", "--detach", "https://.../script.py"])
+        assert result.exit_code == 0
+        api.run_uv_job.assert_called_once_with(
+            script="https://.../script.py",
+            script_args=[],
+            dependencies=None,
+            python=None,
+            image=None,
+            env={},
+            secrets={},
+            flavor=None,
+            timeout=None,
+            namespace=None,
+            _repo=None,
+        )
+
+    def test_uv_local_script(self, runner: CliRunner, tmp_path: Path) -> None:
+        script_path = tmp_path / "script.py"
+        script_path.write_text("print('hello')")
+        job = Mock(id="my-job-id", url="https://huggingface.co/api/jobs/my-username/my-job-id")
+        with (
+            patch("huggingface_hub.cli.jobs.HfApi") as api_cls,
+            patch("huggingface_hub.cli.jobs._get_extended_environ", return_value={}),
+            patch("huggingface_hub.cli.jobs.get_token", return_value="hf_xxx"),
+        ):
+            api = api_cls.return_value
+            api.run_uv_job.return_value = job
+            result = runner.invoke(app, ["jobs", "uv", "run", "--detach", str(script_path)])
+        assert result.exit_code == 0
+        api.run_uv_job.assert_called_once_with(
+            script=str(script_path),
+            script_args=[],
+            dependencies=None,
+            python=None,
+            image=None,
+            env={},
+            secrets={},
+            flavor=None,
+            timeout=None,
+            namespace=None,
+            _repo=None,
+        )
+        api.fetch_job_logs.assert_not_called()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,6 +11,7 @@ import pytest
 import typer
 from typer.testing import CliRunner
 
+from huggingface_hub import __version__
 from huggingface_hub.cli._cli_utils import RepoType
 from huggingface_hub.cli.cache import _CANCEL_DELETION_STR
 from huggingface_hub.cli.download import download
@@ -99,7 +100,7 @@ class TestUploadCommand:
             path_in_repo=None,
             include=None,
         )
-        api_cls.assert_called_once_with(token=None, library_name="hf")
+        api_cls.assert_called_once_with(token=None, library_name="hf", library_version=__version__)
         api.create_repo.assert_called_once_with(
             repo_id=DUMMY_MODEL_ID,
             repo_type="model",
@@ -181,7 +182,7 @@ class TestUploadCommand:
             path_in_repo="data/",
             include=["*.json", "*.yaml"],
         )
-        api_cls.assert_called_once_with(token="my-token", library_name="hf")
+        api_cls.assert_called_once_with(token="my-token", library_name="hf", library_version=__version__)
         scheduler_cls.assert_called_once_with(
             folder_path=folder.as_posix(),
             repo_id=DUMMY_MODEL_ID,
@@ -717,7 +718,7 @@ class TestTagCommands:
                 ["repo", "tag", "create", DUMMY_MODEL_ID, "1.0", "-m", "My tag message"],
             )
         assert result.exit_code == 0
-        api_cls.assert_called_once_with(token=None)
+        api_cls.assert_called_once_with(token=None, library_name="hf", library_version=__version__)
         api.create_tag.assert_called_once_with(
             repo_id=DUMMY_MODEL_ID,
             tag="1.0",
@@ -748,7 +749,7 @@ class TestTagCommands:
                 ],
             )
         assert result.exit_code == 0
-        api_cls.assert_called_once_with(token="my-token")
+        api_cls.assert_called_once_with(token="my-token", library_name="hf", library_version=__version__)
         api.create_tag.assert_called_once_with(
             repo_id=DUMMY_MODEL_ID,
             tag="1.0",
@@ -764,7 +765,7 @@ class TestTagCommands:
             api.list_repo_refs.return_value = refs
             result = runner.invoke(app, ["repo", "tag", "list", DUMMY_MODEL_ID])
         assert result.exit_code == 0
-        api_cls.assert_called_once_with(token=None)
+        api_cls.assert_called_once_with(token=None, library_name="hf", library_version=__version__)
         api.list_repo_refs.assert_called_once_with(repo_id=DUMMY_MODEL_ID, repo_type="model")
 
     def test_tag_delete_basic(self, runner: CliRunner) -> None:
@@ -776,7 +777,7 @@ class TestTagCommands:
                 input="y\n",
             )
         assert result.exit_code == 0
-        api_cls.assert_called_once_with(token=None)
+        api_cls.assert_called_once_with(token=None, library_name="hf", library_version=__version__)
         api.delete_tag.assert_called_once_with(repo_id=DUMMY_MODEL_ID, tag="1.0", repo_type="model")
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -172,7 +172,7 @@ class TestUploadCommand:
     def test_every_must_be_positive(self) -> None:
         class _PatchedBadParameter(typer.BadParameter):
             def __init__(self, message: str, *, param_name: str | None = None, **kwargs: object) -> None:
-                super().__init__(message, param_hint=param_name, **kwargs)
+                super().__init__(message, **kwargs)
 
         with (
             patch("huggingface_hub.cli.upload.typer.BadParameter", _PatchedBadParameter),
@@ -215,14 +215,14 @@ class TestResolveUploadPaths:
         )
         assert local_path == "."
         assert path_in_repo == "*.safetensors"
-        assert include == "."
+        assert include == ["."]
 
         local_path, path_in_repo, include = _resolve_upload_paths(
             repo_id=DUMMY_MODEL_ID, local_path="subdir/*.safetensors", path_in_repo=None, include=None
         )
         assert local_path == "."
         assert path_in_repo == "subdir/*.safetensors"
-        assert include == "."
+        assert include == ["."]
 
         with pytest.raises(ValueError):
             _resolve_upload_paths(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,7 +11,7 @@ import pytest
 import typer
 from typer.testing import CliRunner
 
-from huggingface_hub.cli._cli_utils import RepoType
+from huggingface_hub.cli._cli_utils import RepoTypeOpt
 from huggingface_hub.cli.cache import _CANCEL_DELETION_STR
 from huggingface_hub.cli.download import download
 from huggingface_hub.cli.hf import app
@@ -407,7 +407,7 @@ class TestUploadImpl:
             ):
                 upload(
                     repo_id="my-dataset",
-                    repo_type=RepoType.dataset,
+                    repo_type=RepoTypeOpt.dataset,
                     local_path=str(file_path),
                     path_in_repo="logs/file.txt",
                     create_pr=True,
@@ -599,7 +599,7 @@ class TestDownloadImpl:
             download(
                 repo_id="author/model",
                 filenames=["config.json"],
-                repo_type=RepoType.model,
+                repo_type=RepoTypeOpt.model,
                 revision="main",
                 quiet=True,
             )
@@ -625,7 +625,7 @@ class TestDownloadImpl:
             download(
                 repo_id="author/model",
                 filenames=["README.md", "config.json"],
-                repo_type=RepoType.model,
+                repo_type=RepoTypeOpt.model,
                 force_download=True,
                 max_workers=4,
                 quiet=True,
@@ -652,7 +652,7 @@ class TestDownloadImpl:
             download(
                 repo_id="author/model",
                 filenames=[],
-                repo_type=RepoType.model,
+                repo_type=RepoTypeOpt.model,
                 include=["*.json"],
                 exclude=["data/*"],
                 force_download=True,
@@ -685,7 +685,7 @@ class TestDownloadImpl:
             download(
                 repo_id="author/model",
                 filenames=["README.md", "config.json"],
-                repo_type=RepoType.model,
+                repo_type=RepoTypeOpt.model,
                 include=["*.json"],
                 exclude=["data/*"],
                 force_download=True,


### PR DESCRIPTION
Resolves #3363 and #3364.

This PR migrates the `hf` CLI from built-in `argparse` to [`Typer`](https://typer.tiangolo.com) using idiomatic, function based commands. this significantly reduces boilerplate, making the CLI easier to maintain, less error prone, and faster to extend with new `HfApi` features.

## What changed
- new dependencies: 
   - [`typer`](https://github.com/fastapi/typer), latest version is 0.17.4,  it should be stable enough and it's widely adopted.
   - [click](https://github.com/pallets/click), typer s foundation, pure Python, should be stable too. latest version is 8.2.2.
   - ⚠️ rich has been disabled in all cases in commit [(#3364) disable rich in all cases](https://github.com/huggingface/huggingface_hub/commit/93136efe5f4a3f7fd5c096579259ed77d9e189bc) to keep a consistent UI regardless of having `rich` installed or not.
 
- Main entrypoint: `cli/hf.py` now uses typer.Typer and mounts:
  - Top level single commands: `download`, `upload`, `upload-large-folder`, `env`, `version` (all defined in their respective files).
  - Groups: `auth`, `cache`, `repo` (with `tag` subgroup),` repo-files`, `jobs` (with `scheduled` and `uv` subgroups).
  - LFS helpers are still available but hidden in help: `lfs-enable-largefiles`,` lfs-multipart-upload`.
  - All argparse classes removed and replaced by Typer commands.

```bash                                                                                                                         
> hf --help
Usage: hf [OPTIONS] COMMAND [ARGS]...

  Hugging Face Hub CLI

Options:
  --install-completion  Install completion for the current shell.
  --show-completion     Show completion for the current shell, to copy it or
                        customize the installation.
  --help                Show this message and exit.

Commands:
  auth                 Manage authentication (login, logout, etc.).
  cache                Manage local cache directory.
  download             Download files from the Hub.
  env                  Print information about the environment.
  jobs                 Run and manage Jobs on the Hub.
  repo                 Manage repos on the Hub.
  repo-files           Manage files in a repo on the Hub.
  upload               Upload a file or a folder to the Hub.
  upload-large-folder  Upload a large folder to the Hub.
  version              Print information about the hf version.
```
- `tests/test_cli.py` has been updated accordingly. cf the documentation to write tests for typer cli: https://typer.tiangolo.com/tutorial/testing/#about-the-appcommand-decorator.