### PR TITLE
Add quotes for better shell compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ If you prefer, you can also install it with [conda](https://huggingface.co/docs/
 In order to keep the package minimal by default, `huggingface_hub` comes with optional dependencies useful for some use cases. For example, if you want have a complete experience for Inference, run:
 
 ```bash
-pip install huggingface_hub[inference]
+pip install "huggingface_hub[inference]"
 ```
 
 To learn more installation and optional dependencies, check out the [installation guide](https://huggingface.co/docs/huggingface_hub/en/installation).


### PR DESCRIPTION
In README file, the original command `pip install huggingface_hub[inference]` does not work correctly in zsh. Adding quotes like `pip install "huggingface_hub[inference]"` improves shell compatibility.