### PR TITLE
Refactor CLI implementation using Typer

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -24,24 +24,27 @@ Once installed, you can check that the CLI is correctly setup:
 
 ```
 >>> hf --help
-usage: hf <command> [<args>]
+Usage: hf [OPTIONS] COMMAND [ARGS]...
 
-positional arguments:
-  {auth,cache,download,repo,repo-files,upload,upload-large-folder,env,version,lfs-enable-largefiles,lfs-multipart-upload}
-                        hf command helpers
-    auth                Manage authentication (login, logout, etc.).
-    cache               Manage local cache directory.
-    download            Download files from the Hub
-    repo                Manage repos on the Hub.
-    repo-files          Manage files in a repo on the Hub.
-    upload              Upload a file or a folder to the Hub. Recommended for single-commit uploads.
-    upload-large-folder
-                        Upload a large folder to the Hub. Recommended for resumable uploads.
-    env                 Print information about the environment.
-    version             Print information about the hf version.
+  Hugging Face Hub CLI
 
-options:
-  -h, --help            show this help message and exit
+Options:
+  --install-completion  Install completion for the current shell.
+  --show-completion     Show completion for the current shell, to copy it or
+                        customize the installation.
+  --help                Show this message and exit.
+
+Commands:
+  download             Download files from the Hub.
+  upload               Upload a file or a folder to the Hub.
+  upload-large-folder  Upload a large folder to the Hub.
+  env                  Print information about the environment.
+  version              Print information about the hf version.
+  auth                 Manage authentication (login, logout, etc.).
+  cache                Manage local cache directory.
+  repo                 Manage repos on the Hub.
+  repo-files           Manage files in a repo on the Hub.
+  jobs                 Run and manage Jobs on the Hub.
 ```
 
 If the CLI is correctly installed, you should see a list of all the options available in the CLI. If you get an error message such as `command not found: hf`, please refer to the [Installation](../installation) guide.

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -35,16 +35,16 @@ Options:
   --help                Show this message and exit.
 
 Commands:
-  download             Download files from the Hub.
-  upload               Upload a file or a folder to the Hub.
-  upload-large-folder  Upload a large folder to the Hub.
-  env                  Print information about the environment.
-  version              Print information about the hf version.
   auth                 Manage authentication (login, logout, etc.).
   cache                Manage local cache directory.
+  download             Download files from the Hub.
+  env                  Print information about the environment.
+  jobs                 Run and manage Jobs on the Hub.
   repo                 Manage repos on the Hub.
   repo-files           Manage files in a repo on the Hub.
-  jobs                 Run and manage Jobs on the Hub.
+  upload               Upload a file or a folder to the Hub.
+  upload-large-folder  Upload a large folder to the Hub.
+  version              Print information about the hf version.
 ```
 
 If the CLI is correctly installed, you should see a list of all the options available in the CLI. If you get an error message such as `command not found: hf`, please refer to the [Installation](../installation) guide.

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ install_requires = [
     "pyyaml>=5.1",
     "httpx>=0.23.0, <1",
     "tqdm>=4.42.1",
+    "typer-slim",
     "typing-extensions>=3.7.4.3",  # to be able to import TypeAlias
 ]
 
@@ -28,6 +29,7 @@ extras = {}
 
 extras["cli"] = [
     "InquirerPy==0.3.4",  # Note: installs `prompt-toolkit` in the background
+    "shellingham",
 ]
 
 extras["inference"] = [

--- a/src/huggingface_hub/cli/__init__.py
+++ b/src/huggingface_hub/cli/__init__.py
@@ -11,17 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from abc import ABC, abstractmethod
-from argparse import _SubParsersAction
-
-
-class BaseHuggingfaceCLICommand(ABC):
-    @staticmethod
-    @abstractmethod
-    def register_subcommand(parser: _SubParsersAction):
-        raise NotImplementedError()
-
-    @abstractmethod
-    def run(self):
-        raise NotImplementedError()

--- a/src/huggingface_hub/cli/auth.py
+++ b/src/huggingface_hub/cli/auth.py
@@ -30,17 +30,17 @@ Usage:
     hf auth whoami
 """
 
-from argparse import _SubParsersAction
-from typing import Optional
+from typing import Annotated, Optional
 
-from huggingface_hub.commands import BaseHuggingfaceCLICommand
+import typer
+
 from huggingface_hub.constants import ENDPOINT
 from huggingface_hub.errors import HfHubHTTPError
-from huggingface_hub.hf_api import HfApi
+from huggingface_hub.hf_api import whoami
 
 from .._login import auth_list, auth_switch, login, logout
 from ..utils import get_stored_tokens, get_token, logging
-from ._cli_utils import ANSI
+from ._cli_utils import ANSI, TokenOpt, typer_factory
 
 
 logger = logging.get_logger(__name__)
@@ -54,125 +54,42 @@ except ImportError:
     _inquirer_py_available = False
 
 
-class AuthCommands(BaseHuggingfaceCLICommand):
-    @staticmethod
-    def register_subcommand(parser: _SubParsersAction):
-        # Create the main 'auth' command
-        auth_parser = parser.add_parser("auth", help="Manage authentication (login, logout, etc.).")
-        auth_subparsers = auth_parser.add_subparsers(help="Authentication subcommands")
-
-        # Show help if no subcommand is provided
-        auth_parser.set_defaults(func=lambda args: auth_parser.print_help())
-
-        # Add 'login' as a subcommand of 'auth'
-        login_parser = auth_subparsers.add_parser(
-            "login", help="Log in using a token from huggingface.co/settings/tokens"
-        )
-        login_parser.add_argument(
-            "--token",
-            type=str,
-            help="Token generated from https://huggingface.co/settings/tokens",
-        )
-        login_parser.add_argument(
-            "--add-to-git-credential",
-            action="store_true",
-            help="Optional: Save token to git credential helper.",
-        )
-        login_parser.set_defaults(func=lambda args: AuthLogin(args))
-
-        # Add 'logout' as a subcommand of 'auth'
-        logout_parser = auth_subparsers.add_parser("logout", help="Log out")
-        logout_parser.add_argument(
-            "--token-name",
-            type=str,
-            help="Optional: Name of the access token to log out from.",
-        )
-        logout_parser.set_defaults(func=lambda args: AuthLogout(args))
-
-        # Add 'whoami' as a subcommand of 'auth'
-        whoami_parser = auth_subparsers.add_parser(
-            "whoami", help="Find out which huggingface.co account you are logged in as."
-        )
-        whoami_parser.set_defaults(func=lambda args: AuthWhoami(args))
-
-        # Existing subcommands
-        auth_switch_parser = auth_subparsers.add_parser("switch", help="Switch between access tokens")
-        auth_switch_parser.add_argument(
-            "--token-name",
-            type=str,
-            help="Optional: Name of the access token to switch to.",
-        )
-        auth_switch_parser.add_argument(
-            "--add-to-git-credential",
-            action="store_true",
-            help="Optional: Save token to git credential helper.",
-        )
-        auth_switch_parser.set_defaults(func=lambda args: AuthSwitch(args))
-
-        auth_list_parser = auth_subparsers.add_parser("list", help="List all stored access tokens")
-        auth_list_parser.set_defaults(func=lambda args: AuthList(args))
+auth_cli = typer_factory(help="Manage authentication (login, logout, etc.).")
 
 
-class BaseAuthCommand:
-    def __init__(self, args):
-        self.args = args
-        self._api = HfApi()
+@auth_cli.command("login", help="Login using a token from huggingface.co/settings/tokens")
+def auth_login(
+    token: TokenOpt = None,
+    add_to_git_credential: Annotated[
+        bool,
+        typer.Option(
+            help="Save to git credential helper. Useful only if you plan to run git commands directly.",
+        ),
+    ] = False,
+) -> None:
+    login(token=token, add_to_git_credential=add_to_git_credential)
 
 
-class AuthLogin(BaseAuthCommand):
-    def run(self):
-        logging.set_verbosity_info()
-        login(
-            token=self.args.token,
-            add_to_git_credential=self.args.add_to_git_credential,
-        )
+@auth_cli.command("logout", help="Logout from a specific token")
+def auth_logout(
+    token_name: Annotated[
+        Optional[str],
+        typer.Option(
+            help="Name of token to logout",
+        ),
+    ] = None,
+) -> None:
+    logout(token_name=token_name)
 
 
-class AuthLogout(BaseAuthCommand):
-    def run(self):
-        logging.set_verbosity_info()
-        logout(token_name=self.args.token_name)
+def _select_token_name() -> Optional[str]:
+    token_names = list(get_stored_tokens().keys())
 
+    if not token_names:
+        logger.error("No stored tokens found. Please login first.")
+        return None
 
-class AuthSwitch(BaseAuthCommand):
-    def run(self):
-        logging.set_verbosity_info()
-        token_name = self.args.token_name
-        if token_name is None:
-            token_name = self._select_token_name()
-
-        if token_name is None:
-            print("No token name provided. Aborting.")
-            exit()
-        auth_switch(token_name, add_to_git_credential=self.args.add_to_git_credential)
-
-    def _select_token_name(self) -> Optional[str]:
-        token_names = list(get_stored_tokens().keys())
-
-        if not token_names:
-            logger.error("No stored tokens found. Please login first.")
-            return None
-
-        if _inquirer_py_available:
-            return self._select_token_name_tui(token_names)
-        # if inquirer is not available, use a simpler terminal UI
-        print("Available stored tokens:")
-        for i, token_name in enumerate(token_names, 1):
-            print(f"{i}. {token_name}")
-        while True:
-            try:
-                choice = input("Enter the number of the token to switch to (or 'q' to quit): ")
-                if choice.lower() == "q":
-                    return None
-                index = int(choice) - 1
-                if 0 <= index < len(token_names):
-                    return token_names[index]
-                else:
-                    print("Invalid selection. Please try again.")
-            except ValueError:
-                print("Invalid input. Please enter a number or 'q' to quit.")
-
-    def _select_token_name_tui(self, token_names: list[str]) -> Optional[str]:
+    if _inquirer_py_available:
         choices = [Choice(token_name, name=token_name) for token_name in token_names]
         try:
             return inquirer.select(
@@ -183,30 +100,68 @@ class AuthSwitch(BaseAuthCommand):
         except KeyboardInterrupt:
             logger.info("Token selection cancelled.")
             return None
-
-
-class AuthList(BaseAuthCommand):
-    def run(self):
-        logging.set_verbosity_info()
-        auth_list()
-
-
-class AuthWhoami(BaseAuthCommand):
-    def run(self):
-        token = get_token()
-        if token is None:
-            print("Not logged in")
-            exit()
+    # if inquirer is not available, use a simpler terminal UI
+    print("Available stored tokens:")
+    for i, token_name in enumerate(token_names, 1):
+        print(f"{i}. {token_name}")
+    while True:
         try:
-            info = self._api.whoami(token)
-            print(ANSI.bold("user: "), info["name"])
-            orgs = [org["name"] for org in info["orgs"]]
-            if orgs:
-                print(ANSI.bold("orgs: "), ",".join(orgs))
+            choice = input("Enter the number of the token to switch to (or 'q' to quit): ")
+            if choice.lower() == "q":
+                return None
+            index = int(choice) - 1
+            if 0 <= index < len(token_names):
+                return token_names[index]
+            else:
+                print("Invalid selection. Please try again.")
+        except ValueError:
+            print("Invalid input. Please enter a number or 'q' to quit.")
 
-            if ENDPOINT != "https://huggingface.co":
-                print(f"Authenticated through private endpoint: {ENDPOINT}")
-        except HfHubHTTPError as e:
-            print(e)
-            print(ANSI.red(e.response.text))
-            exit(1)
+
+@auth_cli.command("switch", help="Switch between access tokens")
+def auth_switch_cmd(
+    token_name: Annotated[
+        Optional[str],
+        typer.Option(
+            help="Name of the token to switch to",
+        ),
+    ] = None,
+    add_to_git_credential: Annotated[
+        bool,
+        typer.Option(
+            help="Save to git credential helper. Useful only if you plan to run git commands directly.",
+        ),
+    ] = False,
+) -> None:
+    if token_name is None:
+        token_name = _select_token_name()
+    if token_name is None:
+        print("No token name provided. Aborting.")
+        raise typer.Exit()
+    auth_switch(token_name, add_to_git_credential=add_to_git_credential)
+
+
+@auth_cli.command("list", help="List all stored access tokens")
+def auth_list_cmd() -> None:
+    auth_list()
+
+
+@auth_cli.command("whoami", help="Find out which huggingface.co account you are logged in as.")
+def auth_whoami() -> None:
+    token = get_token()
+    if token is None:
+        print("Not logged in")
+        raise typer.Exit()
+    try:
+        info = whoami(token)
+        print(ANSI.bold("user: "), info["name"])
+        orgs = [org["name"] for org in info["orgs"]]
+        if orgs:
+            print(ANSI.bold("orgs: "), ",".join(orgs))
+
+        if ENDPOINT != "https://huggingface.co":
+            print(f"Authenticated through private endpoint: {ENDPOINT}")
+    except HfHubHTTPError as e:
+        print(e)
+        print(ANSI.red(e.response.text))
+        raise typer.Exit(code=1)

--- a/src/huggingface_hub/cli/download.py
+++ b/src/huggingface_hub/cli/download.py
@@ -37,145 +37,128 @@ Usage:
 """
 
 import warnings
-from argparse import Namespace, _SubParsersAction
-from typing import Optional
+from typing import Annotated, Optional
+
+import typer
 
 from huggingface_hub import logging
 from huggingface_hub._snapshot_download import snapshot_download
-from huggingface_hub.commands import BaseHuggingfaceCLICommand
 from huggingface_hub.file_download import hf_hub_download
 from huggingface_hub.utils import disable_progress_bars, enable_progress_bars
+
+from ._cli_utils import RepoIdArg, RepoTypeOpt, RevisionOpt, TokenOpt
 
 
 logger = logging.get_logger(__name__)
 
 
-class DownloadCommand(BaseHuggingfaceCLICommand):
-    @staticmethod
-    def register_subcommand(parser: _SubParsersAction):
-        download_parser = parser.add_parser("download", help="Download files from the Hub")
-        download_parser.add_argument(
-            "repo_id", type=str, help="ID of the repo to download from (e.g. `username/repo-name`)."
-        )
-        download_parser.add_argument(
-            "filenames", type=str, nargs="*", help="Files to download (e.g. `config.json`, `data/metadata.jsonl`)."
-        )
-        download_parser.add_argument(
-            "--repo-type",
-            choices=["model", "dataset", "space"],
-            default="model",
-            help="Type of repo to download from (defaults to 'model').",
-        )
-        download_parser.add_argument(
-            "--revision",
-            type=str,
-            help="An optional Git revision id which can be a branch name, a tag, or a commit hash.",
-        )
-        download_parser.add_argument(
-            "--include", nargs="*", type=str, help="Glob patterns to match files to download."
-        )
-        download_parser.add_argument(
-            "--exclude", nargs="*", type=str, help="Glob patterns to exclude from files to download."
-        )
-        download_parser.add_argument(
-            "--cache-dir", type=str, help="Path to the directory where to save the downloaded files."
-        )
-        download_parser.add_argument(
-            "--local-dir",
-            type=str,
-            help=(
-                "If set, the downloaded file will be placed under this directory. Check out"
-                " https://huggingface.co/docs/huggingface_hub/guides/download#download-files-to-local-folder for more"
-                " details."
-            ),
-        )
-        download_parser.add_argument(
-            "--force-download",
-            action="store_true",
+def download(
+    repo_id: RepoIdArg,
+    filenames: Annotated[
+        Optional[list[str]],
+        typer.Argument(
+            help="Files to download (e.g. `config.json`, `data/metadata.jsonl`).",
+        ),
+    ] = None,
+    repo_type: RepoTypeOpt = RepoTypeOpt.model,
+    revision: RevisionOpt = None,
+    include: Annotated[
+        Optional[list[str]],
+        typer.Option(
+            help="Glob patterns to include from files to download. eg: *.json",
+        ),
+    ] = None,
+    exclude: Annotated[
+        Optional[list[str]],
+        typer.Option(
+            help="Glob patterns to exclude from files to download.",
+        ),
+    ] = None,
+    cache_dir: Annotated[
+        Optional[str],
+        typer.Option(
+            help="Directory where to save files.",
+        ),
+    ] = None,
+    local_dir: Annotated[
+        Optional[str],
+        typer.Option(
+            help="If set, the downloaded file will be placed under this directory. Check out https://huggingface.co/docs/huggingface_hub/guides/download#download-files-to-local-folder for more details.",
+        ),
+    ] = None,
+    force_download: Annotated[
+        bool,
+        typer.Option(
             help="If True, the files will be downloaded even if they are already cached.",
-        )
-        download_parser.add_argument(
-            "--token", type=str, help="A User Access Token generated from https://huggingface.co/settings/tokens"
-        )
-        download_parser.add_argument(
-            "--quiet",
-            action="store_true",
+        ),
+    ] = False,
+    token: TokenOpt = None,
+    quiet: Annotated[
+        bool,
+        typer.Option(
             help="If True, progress bars are disabled and only the path to the download files is printed.",
-        )
-        download_parser.add_argument(
-            "--max-workers",
-            type=int,
-            default=8,
+        ),
+    ] = False,
+    max_workers: Annotated[
+        int,
+        typer.Option(
             help="Maximum number of workers to use for downloading files. Default is 8.",
-        )
-        download_parser.set_defaults(func=DownloadCommand)
+        ),
+    ] = 8,
+) -> None:
+    """Download files from the Hub."""
 
-    def __init__(self, args: Namespace) -> None:
-        self.token = args.token
-        self.repo_id: str = args.repo_id
-        self.filenames: list[str] = args.filenames
-        self.repo_type: str = args.repo_type
-        self.revision: Optional[str] = args.revision
-        self.include: Optional[list[str]] = args.include
-        self.exclude: Optional[list[str]] = args.exclude
-        self.cache_dir: Optional[str] = args.cache_dir
-        self.local_dir: Optional[str] = args.local_dir
-        self.force_download: bool = args.force_download
-        self.quiet: bool = args.quiet
-        self.max_workers: int = args.max_workers
-
-    def run(self) -> None:
-        if self.quiet:
-            disable_progress_bars()
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore")
-                print(self._download())  # Print path to downloaded files
-            enable_progress_bars()
-        else:
-            logging.set_verbosity_info()
-            print(self._download())  # Print path to downloaded files
-            logging.set_verbosity_warning()
-
-    def _download(self) -> str:
+    def run_download() -> str:
+        filenames_list = filenames if filenames is not None else []
         # Warn user if patterns are ignored
-        if len(self.filenames) > 0:
-            if self.include is not None and len(self.include) > 0:
+        if len(filenames_list) > 0:
+            if include is not None and len(include) > 0:
                 warnings.warn("Ignoring `--include` since filenames have being explicitly set.")
-            if self.exclude is not None and len(self.exclude) > 0:
+            if exclude is not None and len(exclude) > 0:
                 warnings.warn("Ignoring `--exclude` since filenames have being explicitly set.")
 
         # Single file to download: use `hf_hub_download`
-        if len(self.filenames) == 1:
+        if len(filenames_list) == 1:
             return hf_hub_download(
-                repo_id=self.repo_id,
-                repo_type=self.repo_type,
-                revision=self.revision,
-                filename=self.filenames[0],
-                cache_dir=self.cache_dir,
-                force_download=self.force_download,
-                token=self.token,
-                local_dir=self.local_dir,
+                repo_id=repo_id,
+                repo_type=repo_type.value,
+                revision=revision,
+                filename=filenames_list[0],
+                cache_dir=cache_dir,
+                force_download=force_download,
+                token=token,
+                local_dir=local_dir,
                 library_name="hf",
             )
 
         # Otherwise: use `snapshot_download` to ensure all files comes from same revision
-        elif len(self.filenames) == 0:
-            allow_patterns = self.include
-            ignore_patterns = self.exclude
+        if len(filenames_list) == 0:
+            allow_patterns = include
+            ignore_patterns = exclude
         else:
-            allow_patterns = self.filenames
+            allow_patterns = filenames_list
             ignore_patterns = None
 
         return snapshot_download(
-            repo_id=self.repo_id,
-            repo_type=self.repo_type,
-            revision=self.revision,
+            repo_id=repo_id,
+            repo_type=repo_type.value,
+            revision=revision,
             allow_patterns=allow_patterns,
             ignore_patterns=ignore_patterns,
-            force_download=self.force_download,
-            cache_dir=self.cache_dir,
-            token=self.token,
-            local_dir=self.local_dir,
+            force_download=force_download,
+            cache_dir=cache_dir,
+            token=token,
+            local_dir=local_dir,
             library_name="hf",
-            max_workers=self.max_workers,
+            max_workers=max_workers,
         )
+
+    if quiet:
+        disable_progress_bars()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            print(run_download())
+        enable_progress_bars()
+    else:
+        print(run_download())
+        logging.set_verbosity_warning()

--- a/src/huggingface_hub/cli/hf.py
+++ b/src/huggingface_hub/cli/hf.py
@@ -12,51 +12,47 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from argparse import ArgumentParser
 
-from huggingface_hub.cli.auth import AuthCommands
-from huggingface_hub.cli.cache import CacheCommand
-from huggingface_hub.cli.download import DownloadCommand
-from huggingface_hub.cli.jobs import JobsCommands
-from huggingface_hub.cli.lfs import LfsCommands
-from huggingface_hub.cli.repo import RepoCommands
-from huggingface_hub.cli.repo_files import RepoFilesCommand
-from huggingface_hub.cli.system import EnvironmentCommand, VersionCommand
-from huggingface_hub.cli.upload import UploadCommand
-from huggingface_hub.cli.upload_large_folder import UploadLargeFolderCommand
+from huggingface_hub.cli._cli_utils import typer_factory
+from huggingface_hub.cli.auth import auth_cli
+from huggingface_hub.cli.cache import cache_cli
+from huggingface_hub.cli.download import download
+from huggingface_hub.cli.jobs import jobs_cli
+from huggingface_hub.cli.lfs import lfs_enable_largefiles, lfs_multipart_upload
+from huggingface_hub.cli.repo import repo_cli
+from huggingface_hub.cli.repo_files import repo_files_cli
+from huggingface_hub.cli.system import env, version
+
+# from huggingface_hub.cli.jobs import jobs_app
+from huggingface_hub.cli.upload import upload
+from huggingface_hub.cli.upload_large_folder import upload_large_folder
+from huggingface_hub.utils import logging
+
+
+app = typer_factory(help="Hugging Face Hub CLI")
+
+
+# top level single commands (defined in their respective files)
+app.command(help="Download files from the Hub.")(download)
+app.command(help="Upload a file or a folder to the Hub.")(upload)
+app.command(help="Upload a large folder to the Hub. Recommended for resumable uploads.")(upload_large_folder)
+app.command(name="env", help="Print information about the environment.")(env)
+app.command(help="Print information about the hf version.")(version)
+app.command(help="Configure your repository to enable upload of files > 5GB.", hidden=True)(lfs_enable_largefiles)
+app.command(help="Upload large files to the Hub.", hidden=True)(lfs_multipart_upload)
+
+
+# command groups
+app.add_typer(auth_cli, name="auth")
+app.add_typer(cache_cli, name="cache")
+app.add_typer(repo_cli, name="repo")
+app.add_typer(repo_files_cli, name="repo-files")
+app.add_typer(jobs_cli, name="jobs")
 
 
 def main():
-    parser = ArgumentParser("hf", usage="hf <command> [<args>]")
-    commands_parser = parser.add_subparsers(help="hf command helpers")
-
-    # Register commands
-    AuthCommands.register_subcommand(commands_parser)
-    CacheCommand.register_subcommand(commands_parser)
-    DownloadCommand.register_subcommand(commands_parser)
-    JobsCommands.register_subcommand(commands_parser)
-    RepoCommands.register_subcommand(commands_parser)
-    RepoFilesCommand.register_subcommand(commands_parser)
-    UploadCommand.register_subcommand(commands_parser)
-    UploadLargeFolderCommand.register_subcommand(commands_parser)
-
-    # System commands
-    EnvironmentCommand.register_subcommand(commands_parser)
-    VersionCommand.register_subcommand(commands_parser)
-
-    # LFS commands (hidden in --help)
-    LfsCommands.register_subcommand(commands_parser)
-
-    # Let's go
-    args = parser.parse_args()
-    if not hasattr(args, "func"):
-        parser.print_help()
-        exit(1)
-
-    # Run
-    service = args.func(args)
-    if service is not None:
-        service.run()
+    logging.set_verbosity_info()
+    app()
 
 
 if __name__ == "__main__":

--- a/src/huggingface_hub/cli/lfs.py
+++ b/src/huggingface_hub/cli/lfs.py
@@ -20,10 +20,10 @@ import json
 import os
 import subprocess
 import sys
-from argparse import _SubParsersAction
-from typing import Optional
+from typing import Annotated, Optional
 
-from huggingface_hub.commands import BaseHuggingfaceCLICommand
+import typer
+
 from huggingface_hub.lfs import LFS_MULTIPART_UPLOAD_COMMAND
 
 from ..utils import get_session, hf_raise_for_status, logging
@@ -33,58 +33,35 @@ from ..utils._lfs import SliceFileObj
 logger = logging.get_logger(__name__)
 
 
-class LfsCommands(BaseHuggingfaceCLICommand):
+def lfs_enable_largefiles(
+    path: Annotated[
+        str,
+        typer.Argument(
+            help="Local path to repository you want to configure.",
+        ),
+    ],
+) -> None:
     """
-    Implementation of a custom transfer agent for the transfer type "multipart"
-    for git-lfs. This lets users upload large files >5GB 🔥. Spec for LFS custom
-    transfer agent is:
-    https://github.com/git-lfs/git-lfs/blob/master/docs/custom-transfers.md
+    Configure a local git repository to use the multipart transfer agent for large files.
 
-    This introduces two commands to the CLI:
-
-    1. $ hf lfs-enable-largefiles
-
-    This should be executed once for each model repo that contains a model file
-    >5GB. It's documented in the error message you get if you just try to git
-    push a 5GB file without having enabled it before.
-
-    2. $ hf lfs-multipart-upload
-
-    This command is called by lfs directly and is not meant to be called by the
-    user.
+    This command sets up git-lfs to use the custom multipart transfer agent
+    which enables efficient uploading of large files in chunks.
     """
-
-    @staticmethod
-    def register_subcommand(parser: _SubParsersAction):
-        enable_parser = parser.add_parser("lfs-enable-largefiles", add_help=False)
-        enable_parser.add_argument("path", type=str, help="Local path to repository you want to configure.")
-        enable_parser.set_defaults(func=lambda args: LfsEnableCommand(args))
-
-        # Command will get called by git-lfs, do not call it directly.
-        upload_parser = parser.add_parser(LFS_MULTIPART_UPLOAD_COMMAND, add_help=False)
-        upload_parser.set_defaults(func=lambda args: LfsUploadCommand(args))
-
-
-class LfsEnableCommand:
-    def __init__(self, args):
-        self.args = args
-
-    def run(self):
-        local_path = os.path.abspath(self.args.path)
-        if not os.path.isdir(local_path):
-            print("This does not look like a valid git repo.")
-            exit(1)
-        subprocess.run(
-            "git config lfs.customtransfer.multipart.path hf".split(),
-            check=True,
-            cwd=local_path,
-        )
-        subprocess.run(
-            f"git config lfs.customtransfer.multipart.args {LFS_MULTIPART_UPLOAD_COMMAND}".split(),
-            check=True,
-            cwd=local_path,
-        )
-        print("Local repo set up for largefiles")
+    local_path = os.path.abspath(path)
+    if not os.path.isdir(local_path):
+        print("This does not look like a valid git repo.")
+        raise typer.Exit(code=1)
+    subprocess.run(
+        "git config lfs.customtransfer.multipart.path hf".split(),
+        check=True,
+        cwd=local_path,
+    )
+    subprocess.run(
+        f"git config lfs.customtransfer.multipart.args {LFS_MULTIPART_UPLOAD_COMMAND}".split(),
+        check=True,
+        cwd=local_path,
+    )
+    print("Local repo set up for largefiles")
 
 
 def write_msg(msg: dict):
@@ -109,90 +86,90 @@ def read_msg() -> Optional[dict]:
     return msg
 
 
-class LfsUploadCommand:
-    def __init__(self, args) -> None:
-        self.args = args
+def lfs_multipart_upload() -> None:
+    """Internal git-lfs custom transfer agent for multipart uploads.
 
-    def run(self) -> None:
-        # Immediately after invoking a custom transfer process, git-lfs
-        # sends initiation data to the process over stdin.
-        # This tells the process useful information about the configuration.
-        init_msg = json.loads(sys.stdin.readline().strip())
-        if not (init_msg.get("event") == "init" and init_msg.get("operation") == "upload"):
-            write_msg({"error": {"code": 32, "message": "Wrong lfs init operation"}})
-            sys.exit(1)
+    This function implements the custom transfer protocol for git-lfs multipart uploads.
+    Handles chunked uploads of large files to Hugging Face Hub.
+    """
+    # Immediately after invoking a custom transfer process, git-lfs
+    # sends initiation data to the process over stdin.
+    # This tells the process useful information about the configuration.
+    init_msg = json.loads(sys.stdin.readline().strip())
+    if not (init_msg.get("event") == "init" and init_msg.get("operation") == "upload"):
+        write_msg({"error": {"code": 32, "message": "Wrong lfs init operation"}})
+        sys.exit(1)
 
-        # The transfer process should use the information it needs from the
-        # initiation structure, and also perform any one-off setup tasks it
-        # needs to do. It should then respond on stdout with a simple empty
-        # confirmation structure, as follows:
-        write_msg({})
+    # The transfer process should use the information it needs from the
+    # initiation structure, and also perform any one-off setup tasks it
+    # needs to do. It should then respond on stdout with a simple empty
+    # confirmation structure, as follows:
+    write_msg({})
 
-        # After the initiation exchange, git-lfs will send any number of
-        # transfer requests to the stdin of the transfer process, in a serial sequence.
-        while True:
-            msg = read_msg()
-            if msg is None:
-                # When all transfers have been processed, git-lfs will send
-                # a terminate event to the stdin of the transfer process.
-                # On receiving this message the transfer process should
-                # clean up and terminate. No response is expected.
-                sys.exit(0)
+    # After the initiation exchange, git-lfs will send any number of
+    # transfer requests to the stdin of the transfer process, in a serial sequence.
+    while True:
+        msg = read_msg()
+        if msg is None:
+            # When all transfers have been processed, git-lfs will send
+            # a terminate event to the stdin of the transfer process.
+            # On receiving this message the transfer process should
+            # clean up and terminate. No response is expected.
+            sys.exit(0)
 
-            oid = msg["oid"]
-            filepath = msg["path"]
-            completion_url = msg["action"]["href"]
-            header = msg["action"]["header"]
-            chunk_size = int(header.pop("chunk_size"))
-            presigned_urls: list[str] = list(header.values())
+        oid = msg["oid"]
+        filepath = msg["path"]
+        completion_url = msg["action"]["href"]
+        header = msg["action"]["header"]
+        chunk_size = int(header.pop("chunk_size"))
+        presigned_urls: list[str] = list(header.values())
 
-            # Send a "started" progress event to allow other workers to start.
-            # Otherwise they're delayed until first "progress" event is reported,
-            # i.e. after the first 5GB by default (!)
-            write_msg(
-                {
-                    "event": "progress",
-                    "oid": oid,
-                    "bytesSoFar": 1,
-                    "bytesSinceLast": 0,
-                }
-            )
+        # Send a "started" progress event to allow other workers to start.
+        # Otherwise they're delayed until first "progress" event is reported,
+        # i.e. after the first 5GB by default (!)
+        write_msg(
+            {
+                "event": "progress",
+                "oid": oid,
+                "bytesSoFar": 1,
+                "bytesSinceLast": 0,
+            }
+        )
 
-            parts = []
-            with open(filepath, "rb") as file:
-                for i, presigned_url in enumerate(presigned_urls):
-                    with SliceFileObj(
-                        file,
-                        seek_from=i * chunk_size,
-                        read_limit=chunk_size,
-                    ) as data:
-                        r = get_session().put(presigned_url, data=data)
-                        hf_raise_for_status(r)
-                        parts.append(
-                            {
-                                "etag": r.headers.get("etag"),
-                                "partNumber": i + 1,
-                            }
-                        )
-                        # In order to support progress reporting while data is uploading / downloading,
-                        # the transfer process should post messages to stdout
-                        write_msg(
-                            {
-                                "event": "progress",
-                                "oid": oid,
-                                "bytesSoFar": (i + 1) * chunk_size,
-                                "bytesSinceLast": chunk_size,
-                            }
-                        )
-                        # Not precise but that's ok.
+        parts = []
+        with open(filepath, "rb") as file:
+            for i, presigned_url in enumerate(presigned_urls):
+                with SliceFileObj(
+                    file,
+                    seek_from=i * chunk_size,
+                    read_limit=chunk_size,
+                ) as data:
+                    r = get_session().put(presigned_url, data=data)
+                    hf_raise_for_status(r)
+                    parts.append(
+                        {
+                            "etag": r.headers.get("etag"),
+                            "partNumber": i + 1,
+                        }
+                    )
+                    # In order to support progress reporting while data is uploading / downloading,
+                    # the transfer process should post messages to stdout
+                    write_msg(
+                        {
+                            "event": "progress",
+                            "oid": oid,
+                            "bytesSoFar": (i + 1) * chunk_size,
+                            "bytesSinceLast": chunk_size,
+                        }
+                    )
 
-            r = get_session().post(
-                completion_url,
-                json={
-                    "oid": oid,
-                    "parts": parts,
-                },
-            )
-            hf_raise_for_status(r)
+        r = get_session().post(
+            completion_url,
+            json={
+                "oid": oid,
+                "parts": parts,
+            },
+        )
+        hf_raise_for_status(r)
 
-            write_msg({"event": "complete", "oid": oid})
+        write_msg({"event": "complete", "oid": oid})

--- a/src/huggingface_hub/cli/repo.py
+++ b/src/huggingface_hub/cli/repo.py
@@ -21,227 +21,171 @@ Usage:
     hf repo create my-cool-model --private
 """
 
-import argparse
-from argparse import _SubParsersAction
-from typing import Optional
+from typing import Annotated, Optional
 
-from huggingface_hub.commands import BaseHuggingfaceCLICommand
-from huggingface_hub.commands._cli_utils import ANSI
-from huggingface_hub.constants import REPO_TYPES, SPACES_SDK_TYPES
+import typer
+
 from huggingface_hub.errors import HfHubHTTPError, RepositoryNotFoundError, RevisionNotFoundError
-from huggingface_hub.hf_api import HfApi
 from huggingface_hub.utils import logging
+
+from ._cli_utils import (
+    ANSI,
+    PrivateOpt,
+    RepoIdArg,
+    RepoType,
+    RepoTypeOpt,
+    RevisionOpt,
+    TokenOpt,
+    get_hf_api,
+    typer_factory,
+)
 
 
 logger = logging.get_logger(__name__)
 
+repo_cli = typer_factory(help="Manage repos on the Hub.")
+tag_app = typer_factory(help="Manage tags for a repo on the Hub.")
+repo_cli.add_typer(tag_app, name="tag")
 
-class RepoCommands(BaseHuggingfaceCLICommand):
-    @staticmethod
-    def register_subcommand(parser: _SubParsersAction):
-        repo_parser = parser.add_parser("repo", help="Manage repos on the Hub.")
-        repo_subparsers = repo_parser.add_subparsers(help="huggingface.co repos related commands")
 
-        # Show help if no subcommand is provided
-        repo_parser.set_defaults(func=lambda args: repo_parser.print_help())
-
-        # CREATE
-        repo_create_parser = repo_subparsers.add_parser("create", help="Create a new repo on huggingface.co")
-        repo_create_parser.add_argument(
-            "repo_id",
-            type=str,
-            help="The ID of the repo to create to (e.g. `username/repo-name`). The username is optional and will be set to your username if not provided.",
-        )
-        repo_create_parser.add_argument(
-            "--repo-type",
-            type=str,
-            help='Optional: set to "dataset" or "space" if creating a dataset or space, default is model.',
-        )
-        repo_create_parser.add_argument(
-            "--space_sdk",
-            type=str,
-            help='Optional: Hugging Face Spaces SDK type. Required when --type is set to "space".',
-            choices=SPACES_SDK_TYPES,
-        )
-        repo_create_parser.add_argument(
-            "--private",
-            action="store_true",
-            help="Whether to create a private repository. Defaults to public unless the organization's default is private.",
-        )
-        repo_create_parser.add_argument(
-            "--token",
-            type=str,
-            help="Hugging Face token. Will default to the locally saved token if not provided.",
-        )
-        repo_create_parser.add_argument(
-            "--exist-ok",
-            action="store_true",
+@repo_cli.command("create", help="Create a new repo on the Hub.")
+def repo_create(
+    repo_id: RepoIdArg,
+    repo_type: RepoTypeOpt = RepoType.model,
+    space_sdk: Annotated[
+        Optional[str],
+        typer.Option(
+            help="Hugging Face Spaces SDK type. Required when --type is set to 'space'.",
+        ),
+    ] = None,
+    private: PrivateOpt = False,
+    token: TokenOpt = None,
+    exist_ok: Annotated[
+        bool,
+        typer.Option(
             help="Do not raise an error if repo already exists.",
-        )
-        repo_create_parser.add_argument(
-            "--resource-group-id",
-            type=str,
+        ),
+    ] = False,
+    resource_group_id: Annotated[
+        Optional[str],
+        typer.Option(
             help="Resource group in which to create the repo. Resource groups is only available for Enterprise Hub organizations.",
-        )
-        repo_create_parser.set_defaults(func=lambda args: RepoCreateCommand(args))
-
-        # TAG SUBCOMMANDS
-        repo_tag_parser = repo_subparsers.add_parser("tag", help="Manage tags for a repo on the Hub.")
-        tag_subparsers = repo_tag_parser.add_subparsers(help="Tag actions", dest="tag_action", required=True)
-
-        # tag create
-        tag_create_parser = tag_subparsers.add_parser("create", help="Create a tag for a repo.")
-        tag_create_parser.add_argument(
-            "repo_id", type=str, help="The ID of the repo to tag (e.g. `username/repo-name`)."
-        )
-        tag_create_parser.add_argument("tag", type=str, help="The name of the tag to create.")
-        tag_create_parser.add_argument("-m", "--message", type=str, help="The description of the tag to create.")
-        tag_create_parser.add_argument("--revision", type=str, help="The git revision to tag.")
-        tag_create_parser.add_argument(
-            "--token", type=str, help="A User Access Token generated from https://huggingface.co/settings/tokens."
-        )
-        tag_create_parser.add_argument(
-            "--repo-type",
-            choices=["model", "dataset", "space"],
-            default="model",
-            help="Set the type of repository (model, dataset, or space).",
-        )
-        tag_create_parser.set_defaults(func=lambda args: RepoTagCreateCommand(args))
-
-        # tag list
-        tag_list_parser = tag_subparsers.add_parser("list", help="List tags for a repo.")
-        tag_list_parser.add_argument(
-            "repo_id", type=str, help="The ID of the repo to list tags for (e.g. `username/repo-name`)."
-        )
-        tag_list_parser.add_argument(
-            "--token", type=str, help="A User Access Token generated from https://huggingface.co/settings/tokens."
-        )
-        tag_list_parser.add_argument(
-            "--repo-type",
-            choices=["model", "dataset", "space"],
-            default="model",
-            help="Set the type of repository (model, dataset, or space).",
-        )
-        tag_list_parser.set_defaults(func=lambda args: RepoTagListCommand(args))
-
-        # tag delete
-        tag_delete_parser = tag_subparsers.add_parser("delete", help="Delete a tag from a repo.")
-        tag_delete_parser.add_argument(
-            "repo_id", type=str, help="The ID of the repo to delete the tag from (e.g. `username/repo-name`)."
-        )
-        tag_delete_parser.add_argument("tag", type=str, help="The name of the tag to delete.")
-        tag_delete_parser.add_argument("-y", "--yes", action="store_true", help="Answer Yes to prompts automatically.")
-        tag_delete_parser.add_argument(
-            "--token", type=str, help="A User Access Token generated from https://huggingface.co/settings/tokens."
-        )
-        tag_delete_parser.add_argument(
-            "--repo-type",
-            choices=["model", "dataset", "space"],
-            default="model",
-            help="Set the type of repository (model, dataset, or space).",
-        )
-        tag_delete_parser.set_defaults(func=lambda args: RepoTagDeleteCommand(args))
+        ),
+    ] = None,
+) -> None:
+    api = get_hf_api(token=token)
+    repo_url = api.create_repo(
+        repo_id=repo_id,
+        repo_type=repo_type.value,
+        private=private,
+        token=token,
+        exist_ok=exist_ok,
+        resource_group_id=resource_group_id,
+        space_sdk=space_sdk,
+    )
+    print(f"Successfully created {ANSI.bold(repo_url.repo_id)} on the Hub.")
+    print(f"Your repo is now available at {ANSI.bold(repo_url)}")
 
 
-class RepoCreateCommand:
-    def __init__(self, args: argparse.Namespace):
-        self.repo_id: str = args.repo_id
-        self.repo_type: Optional[str] = args.repo_type
-        self.space_sdk: Optional[str] = args.space_sdk
-        self.private: bool = args.private
-        self.token: Optional[str] = args.token
-        self.exist_ok: bool = args.exist_ok
-        self.resource_group_id: Optional[str] = args.resource_group_id
-        self._api = HfApi()
-
-    def run(self):
-        repo_url = self._api.create_repo(
-            repo_id=self.repo_id,
-            repo_type=self.repo_type,
-            private=self.private,
-            token=self.token,
-            exist_ok=self.exist_ok,
-            resource_group_id=self.resource_group_id,
-            space_sdk=self.space_sdk,
-        )
-        print(f"Successfully created {ANSI.bold(repo_url.repo_id)} on the Hub.")
-        print(f"Your repo is now available at {ANSI.bold(repo_url)}")
-
-
-class RepoTagCommand:
-    def __init__(self, args):
-        self.args = args
-        self.api = HfApi(token=getattr(args, "token", None))
-        self.repo_id = args.repo_id
-        self.repo_type = getattr(args, "repo_type", "model")
-        if self.repo_type not in REPO_TYPES:
-            print("Invalid repo --repo-type")
-            exit(1)
-
-
-class RepoTagCreateCommand(RepoTagCommand):
-    def run(self):
-        print(
-            f"You are about to create tag {ANSI.bold(str(self.args.tag))} on {self.repo_type} {ANSI.bold(self.repo_id)}"
-        )
-        try:
-            self.api.create_tag(
-                repo_id=self.repo_id,
-                tag=self.args.tag,
-                tag_message=getattr(self.args, "message", None),
-                revision=getattr(self.args, "revision", None),
-                repo_type=self.repo_type,
-            )
-        except RepositoryNotFoundError:
-            print(f"{self.repo_type.capitalize()} {ANSI.bold(self.repo_id)} not found.")
-            exit(1)
-        except RevisionNotFoundError:
-            print(f"Revision {ANSI.bold(str(getattr(self.args, 'revision', None)))} not found.")
-            exit(1)
-        except HfHubHTTPError as e:
-            if e.response.status_code == 409:
-                print(f"Tag {ANSI.bold(str(self.args.tag))} already exists on {ANSI.bold(self.repo_id)}")
-                exit(1)
-            raise e
-        print(f"Tag {ANSI.bold(str(self.args.tag))} created on {ANSI.bold(self.repo_id)}")
+@tag_app.command("create", help="Create a tag for a repo.")
+def tag_create(
+    repo_id: RepoIdArg,
+    tag: Annotated[
+        str,
+        typer.Argument(
+            help="The name of the tag to create.",
+        ),
+    ],
+    message: Annotated[
+        Optional[str],
+        typer.Option(
+            "-m",
+            "--message",
+            help="The description of the tag to create.",
+        ),
+    ] = None,
+    revision: RevisionOpt = None,
+    token: TokenOpt = None,
+    repo_type: RepoTypeOpt = RepoType.model,
+) -> None:
+    repo_type_str = repo_type.value
+    api = get_hf_api(token=token)
+    print(f"You are about to create tag {ANSI.bold(tag)} on {repo_type_str} {ANSI.bold(repo_id)}")
+    try:
+        api.create_tag(repo_id=repo_id, tag=tag, tag_message=message, revision=revision, repo_type=repo_type_str)
+    except RepositoryNotFoundError:
+        print(f"{repo_type_str.capitalize()} {ANSI.bold(repo_id)} not found.")
+        raise typer.Exit(code=1)
+    except RevisionNotFoundError:
+        print(f"Revision {ANSI.bold(str(revision))} not found.")
+        raise typer.Exit(code=1)
+    except HfHubHTTPError as e:
+        if e.response.status_code == 409:
+            print(f"Tag {ANSI.bold(tag)} already exists on {ANSI.bold(repo_id)}")
+            raise typer.Exit(code=1)
+        raise e
+    print(f"Tag {ANSI.bold(tag)} created on {ANSI.bold(repo_id)}")
 
 
-class RepoTagListCommand(RepoTagCommand):
-    def run(self):
-        try:
-            refs = self.api.list_repo_refs(
-                repo_id=self.repo_id,
-                repo_type=self.repo_type,
-            )
-        except RepositoryNotFoundError:
-            print(f"{self.repo_type.capitalize()} {ANSI.bold(self.repo_id)} not found.")
-            exit(1)
-        except HfHubHTTPError as e:
-            print(e)
-            print(ANSI.red(e.response.text))
-            exit(1)
-        if len(refs.tags) == 0:
-            print("No tags found")
-            exit(0)
-        print(f"Tags for {self.repo_type} {ANSI.bold(self.repo_id)}:")
-        for tag in refs.tags:
-            print(tag.name)
+@tag_app.command("list", help="List tags for a repo.")
+def tag_list(
+    repo_id: RepoIdArg,
+    token: TokenOpt = None,
+    repo_type: RepoTypeOpt = RepoType.model,
+) -> None:
+    repo_type_str = repo_type.value
+    api = get_hf_api(token=token)
+    try:
+        refs = api.list_repo_refs(repo_id=repo_id, repo_type=repo_type_str)
+    except RepositoryNotFoundError:
+        print(f"{repo_type_str.capitalize()} {ANSI.bold(repo_id)} not found.")
+        raise typer.Exit(code=1)
+    except HfHubHTTPError as e:
+        print(e)
+        print(ANSI.red(e.response.text))
+        raise typer.Exit(code=1)
+    if len(refs.tags) == 0:
+        print("No tags found")
+        raise typer.Exit(code=0)
+    print(f"Tags for {repo_type_str} {ANSI.bold(repo_id)}:")
+    for t in refs.tags:
+        print(t.name)
 
 
-class RepoTagDeleteCommand(RepoTagCommand):
-    def run(self):
-        print(f"You are about to delete tag {ANSI.bold(self.args.tag)} on {self.repo_type} {ANSI.bold(self.repo_id)}")
-        if not getattr(self.args, "yes", False):
-            choice = input("Proceed? [Y/n] ").lower()
-            if choice not in ("", "y", "yes"):
-                print("Abort")
-                exit()
-        try:
-            self.api.delete_tag(repo_id=self.repo_id, tag=self.args.tag, repo_type=self.repo_type)
-        except RepositoryNotFoundError:
-            print(f"{self.repo_type.capitalize()} {ANSI.bold(self.repo_id)} not found.")
-            exit(1)
-        except RevisionNotFoundError:
-            print(f"Tag {ANSI.bold(self.args.tag)} not found on {ANSI.bold(self.repo_id)}")
-            exit(1)
-        print(f"Tag {ANSI.bold(self.args.tag)} deleted on {ANSI.bold(self.repo_id)}")
+@tag_app.command("delete", help="Delete a tag for a repo.")
+def tag_delete(
+    repo_id: RepoIdArg,
+    tag: Annotated[
+        str,
+        typer.Argument(
+            help="The name of the tag to delete.",
+        ),
+    ],
+    yes: Annotated[
+        bool,
+        typer.Option(
+            "-y",
+            "--yes",
+            help="Answer Yes to prompt automatically",
+        ),
+    ] = False,
+    token: TokenOpt = None,
+    repo_type: RepoTypeOpt = RepoType.model,
+) -> None:
+    repo_type_str = repo_type.value
+    print(f"You are about to delete tag {ANSI.bold(tag)} on {repo_type_str} {ANSI.bold(repo_id)}")
+    if not yes:
+        choice = input("Proceed? [Y/n] ").lower()
+        if choice not in ("", "y", "yes"):
+            print("Abort")
+            raise typer.Exit()
+    api = get_hf_api(token=token)
+    try:
+        api.delete_tag(repo_id=repo_id, tag=tag, repo_type=repo_type_str)
+    except RepositoryNotFoundError:
+        print(f"{repo_type_str.capitalize()} {ANSI.bold(repo_id)} not found.")
+        raise typer.Exit(code=1)
+    except RevisionNotFoundError:
+        print(f"Tag {ANSI.bold(tag)} not found on {ANSI.bold(repo_id)}")
+        raise typer.Exit(code=1)
+    print(f"Tag {ANSI.bold(tag)} deleted on {ANSI.bold(repo_id)}")

--- a/src/huggingface_hub/cli/repo_files.py
+++ b/src/huggingface_hub/cli/repo_files.py
@@ -34,95 +34,61 @@ Usage:
     hf repo-files delete <repo_id> file.txt --revision=refs/pr/1 --repo-type=dataset
 """
 
-from argparse import _SubParsersAction
-from typing import Optional
+from typing import Annotated, Optional
+
+import typer
 
 from huggingface_hub import logging
-from huggingface_hub.commands import BaseHuggingfaceCLICommand
-from huggingface_hub.hf_api import HfApi
+
+from ._cli_utils import RepoIdArg, RepoType, RepoTypeOpt, RevisionOpt, TokenOpt, get_hf_api, typer_factory
 
 
 logger = logging.get_logger(__name__)
 
 
-class DeleteFilesSubCommand:
-    def __init__(self, args) -> None:
-        self.args = args
-        self.repo_id: str = args.repo_id
-        self.repo_type: Optional[str] = args.repo_type
-        self.revision: Optional[str] = args.revision
-        self.api: HfApi = HfApi(token=args.token, library_name="hf")
-        self.patterns: list[str] = args.patterns
-        self.commit_message: Optional[str] = args.commit_message
-        self.commit_description: Optional[str] = args.commit_description
-        self.create_pr: bool = args.create_pr
-        self.token: Optional[str] = args.token
-
-    def run(self) -> None:
-        logging.set_verbosity_info()
-        url = self.api.delete_files(
-            delete_patterns=self.patterns,
-            repo_id=self.repo_id,
-            repo_type=self.repo_type,
-            revision=self.revision,
-            commit_message=self.commit_message,
-            commit_description=self.commit_description,
-            create_pr=self.create_pr,
-        )
-        print(f"Files correctly deleted from repo. Commit: {url}.")
-        logging.set_verbosity_warning()
+repo_files_cli = typer_factory(help="Manage files in a repo on the Hub.")
 
 
-class RepoFilesCommand(BaseHuggingfaceCLICommand):
-    @staticmethod
-    def register_subcommand(parser: _SubParsersAction):
-        repo_files_parser = parser.add_parser("repo-files", help="Manage files in a repo on the Hub.")
-        repo_files_subparsers = repo_files_parser.add_subparsers(
-            help="Action to execute against the files.",
-            required=True,
-        )
-        delete_subparser = repo_files_subparsers.add_parser(
-            "delete",
-            help="Delete files from a repo on the Hub",
-        )
-        delete_subparser.set_defaults(func=lambda args: DeleteFilesSubCommand(args))
-        delete_subparser.add_argument(
-            "repo_id", type=str, help="The ID of the repo to manage (e.g. `username/repo-name`)."
-        )
-        delete_subparser.add_argument(
-            "patterns",
-            nargs="+",
-            type=str,
+@repo_files_cli.command("delete")
+def repo_files_delete(
+    repo_id: RepoIdArg,
+    patterns: Annotated[
+        list[str],
+        typer.Argument(
             help="Glob patterns to match files to delete.",
-        )
-        delete_subparser.add_argument(
-            "--repo-type",
-            choices=["model", "dataset", "space"],
-            default="model",
-            help="Type of the repo to upload to (e.g. `dataset`).",
-        )
-        delete_subparser.add_argument(
-            "--revision",
-            type=str,
-            help=(
-                "An optional Git revision to push to. It can be a branch name "
-                "or a PR reference. If revision does not"
-                " exist and `--create-pr` is not set, a branch will be automatically created."
-            ),
-        )
-        delete_subparser.add_argument(
-            "--commit-message", type=str, help="The summary / title / first line of the generated commit."
-        )
-        delete_subparser.add_argument(
-            "--commit-description", type=str, help="The description of the generated commit."
-        )
-        delete_subparser.add_argument(
-            "--create-pr", action="store_true", help="Whether to create a new Pull Request for these changes."
-        )
-        delete_subparser.add_argument(
-            "--token",
-            type=str,
-            help="A User Access Token generated from https://huggingface.co/settings/tokens",
-        )
-
-        repo_files_parser.set_defaults(func=RepoFilesCommand)
+        ),
+    ],
+    repo_type: RepoTypeOpt = RepoType.model,
+    revision: RevisionOpt = None,
+    commit_message: Annotated[
+        Optional[str],
+        typer.Option(
+            help="The summary / title / first line of the generated commit.",
+        ),
+    ] = None,
+    commit_description: Annotated[
+        Optional[str],
+        typer.Option(
+            help="The description of the generated commit.",
+        ),
+    ] = None,
+    create_pr: Annotated[
+        bool,
+        typer.Option(
+            help="Whether to create a new Pull Request for these changes.",
+        ),
+    ] = False,
+    token: TokenOpt = None,
+) -> None:
+    api = get_hf_api(token=token)
+    url = api.delete_files(
+        delete_patterns=patterns,
+        repo_id=repo_id,
+        repo_type=repo_type.value,
+        revision=revision,
+        commit_message=commit_message,
+        commit_description=commit_description,
+        create_pr=create_pr,
+    )
+    print(f"Files correctly deleted from repo. Commit: {url}.")
+    logging.set_verbosity_warning()

--- a/src/huggingface_hub/cli/system.py
+++ b/src/huggingface_hub/cli/system.py
@@ -18,35 +18,16 @@ Usage:
     hf version
 """
 
-from argparse import _SubParsersAction
-
 from huggingface_hub import __version__
 
 from ..utils import dump_environment_info
-from . import BaseHuggingfaceCLICommand
 
 
-class EnvironmentCommand(BaseHuggingfaceCLICommand):
-    def __init__(self, args):
-        self.args = args
-
-    @staticmethod
-    def register_subcommand(parser: _SubParsersAction):
-        env_parser = parser.add_parser("env", help="Print information about the environment.")
-        env_parser.set_defaults(func=EnvironmentCommand)
-
-    def run(self) -> None:
-        dump_environment_info()
+def env() -> None:
+    """Print information about the environment."""
+    dump_environment_info()
 
 
-class VersionCommand(BaseHuggingfaceCLICommand):
-    def __init__(self, args):
-        self.args = args
-
-    @staticmethod
-    def register_subcommand(parser: _SubParsersAction):
-        version_parser = parser.add_parser("version", help="Print information about the hf version.")
-        version_parser.set_defaults(func=VersionCommand)
-
-    def run(self) -> None:
-        print(f"huggingface_hub version: {__version__}")
+def version() -> None:
+    """Print CLI version."""
+    print(f"huggingface_hub version: {__version__}")

--- a/src/huggingface_hub/cli/upload.py
+++ b/src/huggingface_hub/cli/upload.py
@@ -49,174 +49,112 @@ Usage:
 import os
 import time
 import warnings
-from argparse import Namespace, _SubParsersAction
-from typing import Optional
+from typing import Annotated, Optional
+
+import typer
 
 from huggingface_hub import logging
 from huggingface_hub._commit_scheduler import CommitScheduler
-from huggingface_hub.commands import BaseHuggingfaceCLICommand
 from huggingface_hub.constants import HF_HUB_ENABLE_HF_TRANSFER
 from huggingface_hub.errors import RevisionNotFoundError
-from huggingface_hub.hf_api import HfApi
 from huggingface_hub.utils import disable_progress_bars, enable_progress_bars
 from huggingface_hub.utils._runtime import is_xet_available
+
+from ._cli_utils import PrivateOpt, RepoIdArg, RepoType, RepoTypeOpt, RevisionOpt, TokenOpt, get_hf_api
 
 
 logger = logging.get_logger(__name__)
 
 
-class UploadCommand(BaseHuggingfaceCLICommand):
-    @staticmethod
-    def register_subcommand(parser: _SubParsersAction):
-        upload_parser = parser.add_parser(
-            "upload", help="Upload a file or a folder to the Hub. Recommended for single-commit uploads."
-        )
-        upload_parser.add_argument(
-            "repo_id", type=str, help="The ID of the repo to upload to (e.g. `username/repo-name`)."
-        )
-        upload_parser.add_argument(
-            "local_path",
-            nargs="?",
+def upload(
+    repo_id: RepoIdArg,
+    local_path: Annotated[
+        Optional[str],
+        typer.Argument(
             help="Local path to the file or folder to upload. Wildcard patterns are supported. Defaults to current directory.",
-        )
-        upload_parser.add_argument(
-            "path_in_repo",
-            nargs="?",
+        ),
+    ] = None,
+    path_in_repo: Annotated[
+        Optional[str],
+        typer.Argument(
             help="Path of the file or folder in the repo. Defaults to the relative path of the file or folder.",
-        )
-        upload_parser.add_argument(
-            "--repo-type",
-            choices=["model", "dataset", "space"],
-            default="model",
-            help="Type of the repo to upload to (e.g. `dataset`).",
-        )
-        upload_parser.add_argument(
-            "--revision",
-            type=str,
-            help=(
-                "An optional Git revision to push to. It can be a branch name or a PR reference. If revision does not"
-                " exist and `--create-pr` is not set, a branch will be automatically created."
-            ),
-        )
-        upload_parser.add_argument(
-            "--private",
-            action="store_true",
-            help=(
-                "Whether to create a private repo if repo doesn't exist on the Hub. Ignored if the repo already"
-                " exists."
-            ),
-        )
-        upload_parser.add_argument("--include", nargs="*", type=str, help="Glob patterns to match files to upload.")
-        upload_parser.add_argument(
-            "--exclude", nargs="*", type=str, help="Glob patterns to exclude from files to upload."
-        )
-        upload_parser.add_argument(
-            "--delete",
-            nargs="*",
-            type=str,
+        ),
+    ] = None,
+    repo_type: RepoTypeOpt = RepoType.model,
+    revision: RevisionOpt = None,
+    private: PrivateOpt = False,
+    include: Annotated[
+        Optional[list[str]],
+        typer.Option(
+            help="Glob patterns to match files to upload.",
+        ),
+    ] = None,
+    exclude: Annotated[
+        Optional[list[str]],
+        typer.Option(
+            help="Glob patterns to exclude from files to upload.",
+        ),
+    ] = None,
+    delete: Annotated[
+        Optional[list[str]],
+        typer.Option(
             help="Glob patterns for file to be deleted from the repo while committing.",
-        )
-        upload_parser.add_argument(
-            "--commit-message", type=str, help="The summary / title / first line of the generated commit."
-        )
-        upload_parser.add_argument("--commit-description", type=str, help="The description of the generated commit.")
-        upload_parser.add_argument(
-            "--create-pr", action="store_true", help="Whether to upload content as a new Pull Request."
-        )
-        upload_parser.add_argument(
-            "--every",
-            type=float,
-            help="If set, a background job is scheduled to create commits every `every` minutes.",
-        )
-        upload_parser.add_argument(
-            "--token", type=str, help="A User Access Token generated from https://huggingface.co/settings/tokens"
-        )
-        upload_parser.add_argument(
-            "--quiet",
-            action="store_true",
-            help="If True, progress bars are disabled and only the path to the uploaded files is printed.",
-        )
-        upload_parser.set_defaults(func=UploadCommand)
+        ),
+    ] = None,
+    commit_message: Annotated[
+        Optional[str],
+        typer.Option(
+            help="The summary / title / first line of the generated commit.",
+        ),
+    ] = None,
+    commit_description: Annotated[
+        Optional[str],
+        typer.Option(
+            help="The description of the generated commit.",
+        ),
+    ] = None,
+    create_pr: Annotated[
+        bool,
+        typer.Option(
+            help="Whether to upload content as a new Pull Request.",
+        ),
+    ] = False,
+    every: Annotated[
+        Optional[float],
+        typer.Option(
+            help="f set, a background job is scheduled to create commits every `every` minutes.",
+        ),
+    ] = None,
+    token: TokenOpt = None,
+    quiet: Annotated[
+        bool,
+        typer.Option(
+            help="Disable progress bars and warnings; print only the returned path.",
+        ),
+    ] = False,
+) -> None:
+    """Upload a file or a folder to the Hub. Recommended for single-commit uploads."""
 
-    def __init__(self, args: Namespace) -> None:
-        self.repo_id: str = args.repo_id
-        self.repo_type: Optional[str] = args.repo_type
-        self.revision: Optional[str] = args.revision
-        self.private: bool = args.private
+    if every is not None and every <= 0:
+        raise typer.BadParameter("--every must be a positive value", param_hint="every")
 
-        self.include: Optional[list[str]] = args.include
-        self.exclude: Optional[list[str]] = args.exclude
-        self.delete: Optional[list[str]] = args.delete
+    repo_type_str = repo_type.value
 
-        self.commit_message: Optional[str] = args.commit_message
-        self.commit_description: Optional[str] = args.commit_description
-        self.create_pr: bool = args.create_pr
-        self.api: HfApi = HfApi(token=args.token, library_name="hf")
-        self.quiet: bool = args.quiet  # disable warnings and progress bars
+    api = get_hf_api(token=token)
 
-        # Check `--every` is valid
-        if args.every is not None and args.every <= 0:
-            raise ValueError(f"`every` must be a positive value (got '{args.every}')")
-        self.every: Optional[float] = args.every
+    # Resolve local_path and path_in_repo based on implicit/explicit rules
+    resolved_local_path, resolved_path_in_repo, resolved_include = _resolve_upload_paths(
+        repo_id=repo_id, local_path=local_path, path_in_repo=path_in_repo, include=include
+    )
 
-        # Resolve `local_path` and `path_in_repo`
-        repo_name: str = args.repo_id.split("/")[-1]  # e.g. "Wauplin/my-cool-model" => "my-cool-model"
-        self.local_path: str
-        self.path_in_repo: str
-
-        if args.local_path is not None and any(c in args.local_path for c in ["*", "?", "["]):
-            if args.include is not None:
-                raise ValueError("Cannot set `--include` when passing a `local_path` containing a wildcard.")
-            if args.path_in_repo is not None and args.path_in_repo != ".":
-                raise ValueError("Cannot set `path_in_repo` when passing a `local_path` containing a wildcard.")
-            self.local_path = "."
-            self.include = args.local_path
-            self.path_in_repo = "."
-        elif args.local_path is None and os.path.isfile(repo_name):
-            # Implicit case 1: user provided only a repo_id which happen to be a local file as well => upload it with same name
-            self.local_path = repo_name
-            self.path_in_repo = repo_name
-        elif args.local_path is None and os.path.isdir(repo_name):
-            # Implicit case 2: user provided only a repo_id which happen to be a local folder as well => upload it at root
-            self.local_path = repo_name
-            self.path_in_repo = "."
-        elif args.local_path is None:
-            # Implicit case 3: user provided only a repo_id that does not match a local file or folder
-            # => the user must explicitly provide a local_path => raise exception
-            raise ValueError(f"'{repo_name}' is not a local file or folder. Please set `local_path` explicitly.")
-        elif args.path_in_repo is None and os.path.isfile(args.local_path):
-            # Explicit local path to file, no path in repo => upload it at root with same name
-            self.local_path = args.local_path
-            self.path_in_repo = os.path.basename(args.local_path)
-        elif args.path_in_repo is None:
-            # Explicit local path to folder, no path in repo => upload at root
-            self.local_path = args.local_path
-            self.path_in_repo = "."
-        else:
-            # Finally, if both paths are explicit
-            self.local_path = args.local_path
-            self.path_in_repo = args.path_in_repo
-
-    def run(self) -> None:
-        if self.quiet:
-            disable_progress_bars()
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore")
-                print(self._upload())
-            enable_progress_bars()
-        else:
-            logging.set_verbosity_info()
-            print(self._upload())
-            logging.set_verbosity_warning()
-
-    def _upload(self) -> str:
-        if os.path.isfile(self.local_path):
-            if self.include is not None and len(self.include) > 0:
-                warnings.warn("Ignoring `--include` since a single file is uploaded.")
-            if self.exclude is not None and len(self.exclude) > 0:
-                warnings.warn("Ignoring `--exclude` since a single file is uploaded.")
-            if self.delete is not None and len(self.delete) > 0:
-                warnings.warn("Ignoring `--delete` since a single file is uploaded.")
+    def run_upload() -> str:
+        if os.path.isfile(resolved_local_path):
+            if resolved_include is not None and len(resolved_include) > 0 and isinstance(resolved_include, list):
+                warnings.warn("Ignoring --include since a single file is uploaded.")
+            if exclude is not None and len(exclude) > 0:
+                warnings.warn("Ignoring --exclude since a single file is uploaded.")
+            if delete is not None and len(delete) > 0:
+                warnings.warn("Ignoring --delete since a single file is uploaded.")
 
         if not is_xet_available() and not HF_HUB_ENABLE_HF_TRANSFER:
             logger.info(
@@ -225,39 +163,45 @@ class UploadCommand(BaseHuggingfaceCLICommand):
             )
 
         # Schedule commits if `every` is set
-        if self.every is not None:
-            if os.path.isfile(self.local_path):
+        if every is not None:
+            if os.path.isfile(resolved_local_path):
                 # If file => watch entire folder + use allow_patterns
-                folder_path = os.path.dirname(self.local_path)
-                path_in_repo = (
-                    self.path_in_repo[: -len(self.local_path)]  # remove filename from path_in_repo
-                    if self.path_in_repo.endswith(self.local_path)
-                    else self.path_in_repo
+                folder_path = os.path.dirname(resolved_local_path)
+                pi = (
+                    resolved_path_in_repo[: -len(resolved_local_path)]
+                    if resolved_path_in_repo.endswith(resolved_local_path)
+                    else resolved_path_in_repo
                 )
-                allow_patterns = [self.local_path]
-                ignore_patterns = []
+                allow_patterns = [resolved_local_path]
+                ignore_patterns: Optional[list[str]] = []
             else:
-                folder_path = self.local_path
-                path_in_repo = self.path_in_repo
-                allow_patterns = self.include or []
-                ignore_patterns = self.exclude or []
-                if self.delete is not None and len(self.delete) > 0:
-                    warnings.warn("Ignoring `--delete` when uploading with scheduled commits.")
+                folder_path = resolved_local_path
+                pi = resolved_path_in_repo
+                allow_patterns = (
+                    resolved_include or []
+                    if isinstance(resolved_include, list)
+                    else [resolved_include]
+                    if isinstance(resolved_include, str)
+                    else []
+                )
+                ignore_patterns = exclude or []
+                if delete is not None and len(delete) > 0:
+                    warnings.warn("Ignoring --delete when uploading with scheduled commits.")
 
             scheduler = CommitScheduler(
                 folder_path=folder_path,
-                repo_id=self.repo_id,
-                repo_type=self.repo_type,
-                revision=self.revision,
+                repo_id=repo_id,
+                repo_type=repo_type_str,
+                revision=revision,
                 allow_patterns=allow_patterns,
                 ignore_patterns=ignore_patterns,
-                path_in_repo=path_in_repo,
-                private=self.private,
-                every=self.every,
-                hf_api=self.api,
+                path_in_repo=pi,
+                private=private,
+                every=every,
+                hf_api=api,
             )
-            print(f"Scheduling commits every {self.every} minutes to {scheduler.repo_id}.")
-            try:  # Block main thread until KeyboardInterrupt
+            print(f"Scheduling commits every {every} minutes to {scheduler.repo_id}.")
+            try:
                 while True:
                     time.sleep(100)
             except KeyboardInterrupt:
@@ -265,52 +209,94 @@ class UploadCommand(BaseHuggingfaceCLICommand):
                 return "Stopped scheduled commits."
 
         # Otherwise, create repo and proceed with the upload
-        if not os.path.isfile(self.local_path) and not os.path.isdir(self.local_path):
-            raise FileNotFoundError(f"No such file or directory: '{self.local_path}'.")
-        repo_id = self.api.create_repo(
-            repo_id=self.repo_id,
-            repo_type=self.repo_type,
+        if not os.path.isfile(resolved_local_path) and not os.path.isdir(resolved_local_path):
+            raise FileNotFoundError(f"No such file or directory: '{resolved_local_path}'.")
+        created = api.create_repo(
+            repo_id=repo_id,
+            repo_type=repo_type_str,
             exist_ok=True,
-            private=self.private,
-            space_sdk="gradio" if self.repo_type == "space" else None,
+            private=private,
+            space_sdk="gradio" if repo_type_str == "space" else None,
             # ^ We don't want it to fail when uploading to a Space => let's set Gradio by default.
             # ^ I'd rather not add CLI args to set it explicitly as we already have `hf repo create` for that.
         ).repo_id
 
         # Check if branch already exists and if not, create it
-        if self.revision is not None and not self.create_pr:
+        if revision is not None and not create_pr:
             try:
-                self.api.repo_info(repo_id=repo_id, repo_type=self.repo_type, revision=self.revision)
+                api.repo_info(repo_id=created, repo_type=repo_type_str, revision=revision)
             except RevisionNotFoundError:
-                logger.info(f"Branch '{self.revision}' not found. Creating it...")
-                self.api.create_branch(repo_id=repo_id, repo_type=self.repo_type, branch=self.revision, exist_ok=True)
+                logger.info(f"Branch '{revision}' not found. Creating it...")
+                api.create_branch(repo_id=created, repo_type=repo_type_str, branch=revision, exist_ok=True)
                 # ^ `exist_ok=True` to avoid race concurrency issues
 
         # File-based upload
-        if os.path.isfile(self.local_path):
-            return self.api.upload_file(
-                path_or_fileobj=self.local_path,
-                path_in_repo=self.path_in_repo,
-                repo_id=repo_id,
-                repo_type=self.repo_type,
-                revision=self.revision,
-                commit_message=self.commit_message,
-                commit_description=self.commit_description,
-                create_pr=self.create_pr,
+        if os.path.isfile(resolved_local_path):
+            return api.upload_file(
+                path_or_fileobj=resolved_local_path,
+                path_in_repo=resolved_path_in_repo,
+                repo_id=created,
+                repo_type=repo_type_str,
+                revision=revision,
+                commit_message=commit_message,
+                commit_description=commit_description,
+                create_pr=create_pr,
             )
 
         # Folder-based upload
-        else:
-            return self.api.upload_folder(
-                folder_path=self.local_path,
-                path_in_repo=self.path_in_repo,
-                repo_id=repo_id,
-                repo_type=self.repo_type,
-                revision=self.revision,
-                commit_message=self.commit_message,
-                commit_description=self.commit_description,
-                create_pr=self.create_pr,
-                allow_patterns=self.include,
-                ignore_patterns=self.exclude,
-                delete_patterns=self.delete,
-            )
+        return api.upload_folder(
+            folder_path=resolved_local_path,
+            path_in_repo=resolved_path_in_repo,
+            repo_id=created,
+            repo_type=repo_type_str,
+            revision=revision,
+            commit_message=commit_message,
+            commit_description=commit_description,
+            create_pr=create_pr,
+            allow_patterns=(
+                resolved_include
+                if isinstance(resolved_include, list)
+                else [resolved_include]
+                if isinstance(resolved_include, str)
+                else None
+            ),
+            ignore_patterns=exclude,
+            delete_patterns=delete,
+        )
+
+    if quiet:
+        disable_progress_bars()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            print(run_upload())
+        enable_progress_bars()
+    else:
+        print(run_upload())
+        logging.set_verbosity_warning()
+
+
+def _resolve_upload_paths(
+    *, repo_id: str, local_path: Optional[str], path_in_repo: Optional[str], include: Optional[list[str]]
+) -> tuple[str, str, Optional[list[str]]]:
+    repo_name = repo_id.split("/")[-1]
+    resolved_include = include
+
+    if local_path is not None and any(c in local_path for c in ["*", "?", "["]):
+        if include is not None:
+            raise ValueError("Cannot set --include when local_path contains a wildcard.")
+        if path_in_repo is not None and path_in_repo != ".":
+            raise ValueError("Cannot set path_in_repo when local_path contains a wildcard.")
+        return ".", local_path, ["."]  # will be adjusted below; placeholder for type
+
+    if local_path is None and os.path.isfile(repo_name):
+        return repo_name, repo_name, resolved_include
+    if local_path is None and os.path.isdir(repo_name):
+        return repo_name, ".", resolved_include
+    if local_path is None:
+        raise ValueError(f"'{repo_name}' is not a local file or folder. Please set local_path explicitly.")
+
+    if path_in_repo is None and os.path.isfile(local_path):
+        return local_path, os.path.basename(local_path), resolved_include
+    if path_in_repo is None:
+        return local_path, ".", resolved_include
+    return local_path, path_in_repo, resolved_include

--- a/src/huggingface_hub/cli/upload_large_folder.py
+++ b/src/huggingface_hub/cli/upload_large_folder.py
@@ -15,118 +15,103 @@
 """Contains command to upload a large folder with the CLI."""
 
 import os
-from argparse import Namespace, _SubParsersAction
-from typing import Optional
+from typing import Annotated, Optional
+
+import typer
 
 from huggingface_hub import logging
-from huggingface_hub.commands import BaseHuggingfaceCLICommand
-from huggingface_hub.hf_api import HfApi
 from huggingface_hub.utils import disable_progress_bars
 
-from ._cli_utils import ANSI
+from ._cli_utils import ANSI, PrivateOpt, RepoIdArg, RepoType, RepoTypeOpt, RevisionOpt, TokenOpt, get_hf_api
 
 
 logger = logging.get_logger(__name__)
 
 
-class UploadLargeFolderCommand(BaseHuggingfaceCLICommand):
-    @staticmethod
-    def register_subcommand(parser: _SubParsersAction):
-        subparser = parser.add_parser(
-            "upload-large-folder",
-            help="Upload a large folder to the Hub. Recommended for resumable uploads.",
-        )
-        subparser.add_argument(
-            "repo_id", type=str, help="The ID of the repo to upload to (e.g. `username/repo-name`)."
-        )
-        subparser.add_argument("local_path", type=str, help="Local path to the file or folder to upload.")
-        subparser.add_argument(
-            "--repo-type",
-            choices=["model", "dataset", "space"],
-            help="Type of the repo to upload to (e.g. `dataset`).",
-        )
-        subparser.add_argument(
-            "--revision",
-            type=str,
-            help=("An optional Git revision to push to. It can be a branch name or a PR reference."),
-        )
-        subparser.add_argument(
-            "--private",
-            action="store_true",
-            help=(
-                "Whether to create a private repo if repo doesn't exist on the Hub. Ignored if the repo already exists."
-            ),
-        )
-        subparser.add_argument("--include", nargs="*", type=str, help="Glob patterns to match files to upload.")
-        subparser.add_argument("--exclude", nargs="*", type=str, help="Glob patterns to exclude from files to upload.")
-        subparser.add_argument(
-            "--token", type=str, help="A User Access Token generated from https://huggingface.co/settings/tokens"
-        )
-        subparser.add_argument(
-            "--num-workers", type=int, help="Number of workers to use to hash, upload and commit files."
-        )
-        subparser.add_argument("--no-report", action="store_true", help="Whether to disable regular status report.")
-        subparser.add_argument("--no-bars", action="store_true", help="Whether to disable progress bars.")
-        subparser.set_defaults(func=UploadLargeFolderCommand)
+def upload_large_folder(
+    repo_id: RepoIdArg,
+    local_path: Annotated[
+        str,
+        typer.Argument(
+            help="Local path to the folder to upload.",
+        ),
+    ],
+    repo_type: RepoTypeOpt = RepoType.model,
+    revision: RevisionOpt = None,
+    private: PrivateOpt = False,
+    include: Annotated[
+        Optional[list[str]],
+        typer.Option(
+            help="Glob patterns to match files to upload.",
+        ),
+    ] = None,
+    exclude: Annotated[
+        Optional[list[str]],
+        typer.Option(
+            help="Glob patterns to exclude from files to upload.",
+        ),
+    ] = None,
+    token: TokenOpt = None,
+    num_workers: Annotated[
+        Optional[int],
+        typer.Option(
+            help="Number of workers to use to hash, upload and commit files.",
+        ),
+    ] = None,
+    no_report: Annotated[
+        bool,
+        typer.Option(
+            help="Whether to disable regular status report.",
+        ),
+    ] = False,
+    no_bars: Annotated[
+        bool,
+        typer.Option(
+            help="Whether to disable progress bars.",
+        ),
+    ] = False,
+) -> None:
+    """Upload a large folder to the Hub. Recommended for resumable uploads."""
+    if not os.path.isdir(local_path):
+        raise typer.BadParameter("Large upload is only supported for folders.", param_hint="local_path")
 
-    def __init__(self, args: Namespace) -> None:
-        self.repo_id: str = args.repo_id
-        self.local_path: str = args.local_path
-        self.repo_type: str = args.repo_type
-        self.revision: Optional[str] = args.revision
-        self.private: bool = args.private
-
-        self.include: Optional[list[str]] = args.include
-        self.exclude: Optional[list[str]] = args.exclude
-
-        self.api: HfApi = HfApi(token=args.token, library_name="hf")
-
-        self.num_workers: Optional[int] = args.num_workers
-        self.no_report: bool = args.no_report
-        self.no_bars: bool = args.no_bars
-
-        if not os.path.isdir(self.local_path):
-            raise ValueError("Large upload is only supported for folders.")
-
-    def run(self) -> None:
-        logging.set_verbosity_info()
-
-        print(
-            ANSI.yellow(
-                "You are about to upload a large folder to the Hub using `hf upload-large-folder`. "
-                "This is a new feature so feedback is very welcome!\n"
-                "\n"
-                "A few things to keep in mind:\n"
-                "  - Repository limits still apply: https://huggingface.co/docs/hub/repositories-recommendations\n"
-                "  - Do not start several processes in parallel.\n"
-                "  - You can interrupt and resume the process at any time. "
-                "The script will pick up where it left off except for partially uploaded files that would have to be entirely reuploaded.\n"
-                "  - Do not upload the same folder to several repositories. If you need to do so, you must delete the `./.cache/huggingface/` folder first.\n"
-                "\n"
-                f"Some temporary metadata will be stored under `{self.local_path}/.cache/huggingface`.\n"
-                "  - You must not modify those files manually.\n"
-                "  - You must not delete the `./.cache/huggingface/` folder while a process is running.\n"
-                "  - You can delete the `./.cache/huggingface/` folder to reinitialize the upload state when process is not running. Files will have to be hashed and preuploaded again, except for already committed files.\n"
-                "\n"
-                "If the process output is too verbose, you can disable the progress bars with `--no-bars`. "
-                "You can also entirely disable the status report with `--no-report`.\n"
-                "\n"
-                "For more details, run `hf upload-large-folder --help` or check the documentation at "
-                "https://huggingface.co/docs/huggingface_hub/guides/upload#upload-a-large-folder."
-            )
+    print(
+        ANSI.yellow(
+            "You are about to upload a large folder to the Hub using `hf upload-large-folder`. "
+            "This is a new feature so feedback is very welcome!\n"
+            "\n"
+            "A few things to keep in mind:\n"
+            "  - Repository limits still apply: https://huggingface.co/docs/hub/repositories-recommendations\n"
+            "  - Do not start several processes in parallel.\n"
+            "  - You can interrupt and resume the process at any time. "
+            "The script will pick up where it left off except for partially uploaded files that would have to be entirely reuploaded.\n"
+            "  - Do not upload the same folder to several repositories. If you need to do so, you must delete the `./.cache/huggingface/` folder first.\n"
+            "\n"
+            f"Some temporary metadata will be stored under `{local_path}/.cache/huggingface`.\n"
+            "  - You must not modify those files manually.\n"
+            "  - You must not delete the `./.cache/huggingface/` folder while a process is running.\n"
+            "  - You can delete the `./.cache/huggingface/` folder to reinitialize the upload state when process is not running. Files will have to be hashed and preuploaded again, except for already committed files.\n"
+            "\n"
+            "If the process output is too verbose, you can disable the progress bars with `--no-bars`. "
+            "You can also entirely disable the status report with `--no-report`.\n"
+            "\n"
+            "For more details, run `hf upload-large-folder --help` or check the documentation at "
+            "https://huggingface.co/docs/huggingface_hub/guides/upload#upload-a-large-folder."
         )
+    )
 
-        if self.no_bars:
-            disable_progress_bars()
+    if no_bars:
+        disable_progress_bars()
 
-        self.api.upload_large_folder(
-            repo_id=self.repo_id,
-            folder_path=self.local_path,
-            repo_type=self.repo_type,
-            revision=self.revision,
-            private=self.private,
-            allow_patterns=self.include,
-            ignore_patterns=self.exclude,
-            num_workers=self.num_workers,
-            print_report=not self.no_report,
-        )
+    api = get_hf_api(token=token)
+    api.upload_large_folder(
+        repo_id=repo_id,
+        folder_path=local_path,
+        repo_type=repo_type.value,
+        revision=revision,
+        private=private,
+        allow_patterns=include,
+        ignore_patterns=exclude,
+        num_workers=num_workers,
+        print_report=not no_report,
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,506 +1,636 @@
 import os
-import unittest
 import warnings
-from argparse import ArgumentParser, Namespace
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Generator
+from typing import Generator, Optional
 from unittest.mock import Mock, patch
 
-from huggingface_hub.cli.cache import CacheCommand
-from huggingface_hub.cli.download import DownloadCommand
-from huggingface_hub.cli.jobs import JobsCommands, RunCommand, ScheduledRunCommand, UvCommand
-from huggingface_hub.cli.repo import RepoCommands
-from huggingface_hub.cli.repo_files import DeleteFilesSubCommand, RepoFilesCommand
-from huggingface_hub.cli.upload import UploadCommand
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from huggingface_hub.cli._cli_utils import RepoType
+from huggingface_hub.cli.cache import _CANCEL_DELETION_STR
+from huggingface_hub.cli.download import download
+from huggingface_hub.cli.hf import app
+from huggingface_hub.cli.upload import _resolve_upload_paths, upload
 from huggingface_hub.errors import RevisionNotFoundError
-from huggingface_hub.utils import SoftTemporaryDirectory, capture_output
+from huggingface_hub.utils import SoftTemporaryDirectory
 
 from .testing_utils import DUMMY_MODEL_ID
 
 
-class TestCacheCommand(unittest.TestCase):
-    def setUp(self) -> None:
-        """
-        Set up cache scan/delete commands as in `src/huggingface_hub/cli/hf.py`.
-        """
-        self.parser = ArgumentParser("hf", usage="hf <command> [<args>]")
-        commands_parser = self.parser.add_subparsers()
-        CacheCommand.register_subcommand(commands_parser)
-
-    def test_scan_cache_basic(self) -> None:
-        """Test `hf cache scan`."""
-        args = self.parser.parse_args(["cache", "scan"])
-        assert args.dir is None
-        assert args.verbose == 0
-        assert args.func == CacheCommand
-        assert args.cache_command == "scan"
-
-    def test_scan_cache_verbose(self) -> None:
-        """Test `hf cache scan -v`."""
-        args = self.parser.parse_args(["cache", "scan", "-v"])
-        assert args.dir is None
-        assert args.verbose == 1
-        assert args.func == CacheCommand
-        assert args.cache_command == "scan"
-
-    def test_scan_cache_with_dir(self) -> None:
-        """Test `hf cache scan --dir something`."""
-        args = self.parser.parse_args(["cache", "scan", "--dir", "something"])
-        assert args.dir == "something"
-        assert args.verbose == 0
-        assert args.func == CacheCommand
-        assert args.cache_command == "scan"
-
-    def test_scan_cache_ultra_verbose(self) -> None:
-        """Test `hf cache scan -vvv`."""
-        args = self.parser.parse_args(["cache", "scan", "-vvv"])
-        assert args.dir is None
-        assert args.verbose == 3
-        assert args.func == CacheCommand
-        assert args.cache_command == "scan"
-
-    def test_delete_cache_with_dir(self) -> None:
-        """Test `hf cache delete --dir something`."""
-        args = self.parser.parse_args(["cache", "delete", "--dir", "something"])
-        assert args.dir == "something"
-        assert args.func == CacheCommand
-        assert args.cache_command == "delete"
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
 
 
-class TestUploadCommand(unittest.TestCase):
-    def setUp(self) -> None:
-        """
-        Set up CLI as in `src/huggingface_hub/cli/hf.py`.
-        """
-        self.parser = ArgumentParser("hf", usage="hf <command> [<args>]")
-        commands_parser = self.parser.add_subparsers()
-        UploadCommand.register_subcommand(commands_parser)
+class TestCacheCommand:
+    def test_scan_cache_basic(self, runner: CliRunner) -> None:
+        with patch("huggingface_hub.cli.cache.scan_cache_dir") as mock_run:
+            result = runner.invoke(app, ["cache", "scan"])
+        assert result.exit_code == 0
+        mock_run.assert_called_once_with(None)
 
-    def test_upload_basic(self) -> None:
-        """Test `hf upload my-folder to dummy-repo`."""
-        cmd = UploadCommand(self.parser.parse_args(["upload", DUMMY_MODEL_ID, "my-folder"]))
-        assert cmd.repo_id == DUMMY_MODEL_ID
-        assert cmd.local_path == "my-folder"
-        assert cmd.path_in_repo == "."  # implicit
-        assert cmd.repo_type == "model"
-        assert cmd.revision is None
-        assert cmd.include is None
-        assert cmd.exclude is None
-        assert cmd.delete is None
-        assert cmd.commit_message is None
-        assert cmd.commit_description is None
-        assert cmd.create_pr is False
-        assert cmd.every is None
-        assert cmd.api.token is None
-        assert cmd.quiet is False
+    def test_scan_cache_verbose(self, runner: CliRunner) -> None:
+        with (
+            patch("huggingface_hub.cli.cache.scan_cache_dir") as mock_run,
+            patch("huggingface_hub.cli.cache.get_table") as get_table_mock,
+        ):
+            result = runner.invoke(app, ["cache", "scan", "-v"])
+        assert result.exit_code == 0
+        mock_run.assert_called_once_with(None)
+        get_table_mock.assert_called_once_with(mock_run.return_value, verbosity=1)
 
-    def test_upload_with_wildcard(self) -> None:
-        """Test uploading files using wildcard patterns."""
-        with tmp_current_directory() as cache_dir:
-            # Create test files
-            (Path(cache_dir) / "model1.safetensors").touch()
-            (Path(cache_dir) / "model2.safetensors").touch()
-            (Path(cache_dir) / "model.bin").touch()
-            (Path(cache_dir) / "config.json").touch()
+    def test_scan_cache_with_dir(self, runner: CliRunner) -> None:
+        with patch("huggingface_hub.cli.cache.scan_cache_dir") as mock_run:
+            result = runner.invoke(app, ["cache", "scan", "--dir", "something"])
+        assert result.exit_code == 0
+        mock_run.assert_called_once_with("something")
 
-            # Test basic wildcard pattern
-            cmd = UploadCommand(self.parser.parse_args(["upload", DUMMY_MODEL_ID, "*.safetensors"]))
-            assert cmd.local_path == "."
-            assert cmd.include == "*.safetensors"
-            assert cmd.path_in_repo == "."
-            assert cmd.repo_id == DUMMY_MODEL_ID
+    def test_scan_cache_ultra_verbose(self, runner: CliRunner) -> None:
+        with (
+            patch("huggingface_hub.cli.cache.scan_cache_dir") as mock_run,
+            patch("huggingface_hub.cli.cache.get_table") as get_table_mock,
+        ):
+            result = runner.invoke(app, ["cache", "scan", "-vvv"])
+        assert result.exit_code == 0
+        mock_run.assert_called_once_with(None)
+        get_table_mock.assert_called_once_with(mock_run.return_value, verbosity=3)
 
-            # Test wildcard pattern with specific directory
-            subdir = Path(cache_dir) / "subdir"
-            subdir.mkdir()
-            (subdir / "special.safetensors").touch()
+    def test_delete_cache_with_dir(self, runner: CliRunner) -> None:
+        hf_cache_info = Mock()
+        with (
+            patch("huggingface_hub.cli.cache.scan_cache_dir", return_value=hf_cache_info) as scan_mock,
+            patch(
+                "huggingface_hub.cli.cache._manual_review_tui",
+                return_value=[_CANCEL_DELETION_STR],
+            ) as review_mock,
+        ):
+            result = runner.invoke(app, ["cache", "delete", "--dir", "something"])
+        assert result.exit_code == 0
+        scan_mock.assert_called_once_with("something")
+        review_mock.assert_called_once_with(hf_cache_info, preselected=[], sort_by=None)
 
-            cmd = UploadCommand(self.parser.parse_args(["upload", DUMMY_MODEL_ID, "subdir/*.safetensors"]))
-            assert cmd.local_path == "."
-            assert cmd.include == "subdir/*.safetensors"
-            assert cmd.path_in_repo == "."
 
-            # Test error when using wildcard with --include
-            with self.assertRaises(ValueError):
-                UploadCommand(
-                    self.parser.parse_args(["upload", DUMMY_MODEL_ID, "*.safetensors", "--include", "*.json"])
+class TestUploadCommand:
+    def test_upload_basic(self, runner: CliRunner) -> None:
+        with SoftTemporaryDirectory() as tmp_dir:
+            folder = Path(tmp_dir) / "my-folder"
+            folder.mkdir()
+            with (
+                patch(
+                    "huggingface_hub.cli.upload._resolve_upload_paths",
+                    return_value=(folder.as_posix(), ".", None),
+                ) as resolve_mock,
+                patch("huggingface_hub.cli.upload.get_hf_api") as api_cls,
+            ):
+                api = api_cls.return_value
+                api.create_repo.return_value = Mock(repo_id=DUMMY_MODEL_ID)
+                api.upload_folder.return_value = "uploaded"
+                result = runner.invoke(app, ["upload", DUMMY_MODEL_ID, "my-folder"])
+        assert result.exit_code == 0
+        assert "uploaded" in result.stdout
+        resolve_mock.assert_called_once_with(
+            repo_id=DUMMY_MODEL_ID,
+            local_path="my-folder",
+            path_in_repo=None,
+            include=None,
+        )
+        api_cls.assert_called_once_with(token=None)
+        api.create_repo.assert_called_once_with(
+            repo_id=DUMMY_MODEL_ID,
+            repo_type="model",
+            exist_ok=True,
+            private=False,
+            space_sdk=None,
+        )
+        api.upload_folder.assert_called_once_with(
+            folder_path=folder.as_posix(),
+            path_in_repo=".",
+            repo_id=DUMMY_MODEL_ID,
+            repo_type="model",
+            revision=None,
+            commit_message=None,
+            commit_description=None,
+            create_pr=False,
+            allow_patterns=None,
+            ignore_patterns=None,
+            delete_patterns=None,
+        )
+
+    def test_upload_with_all_options(self, runner: CliRunner) -> None:
+        with SoftTemporaryDirectory() as tmp_dir:
+            folder = Path(tmp_dir) / "my-file"
+            folder.mkdir()
+            returned_paths = (folder.as_posix(), "data/", ["*.json", "*.yaml"])
+            with (
+                patch(
+                    "huggingface_hub.cli.upload._resolve_upload_paths",
+                    return_value=returned_paths,
+                ) as resolve_mock,
+                patch("huggingface_hub.cli.upload.get_hf_api") as api_cls,
+                patch("huggingface_hub.cli.upload.CommitScheduler") as scheduler_cls,
+                patch("huggingface_hub.cli.upload.time.sleep", side_effect=KeyboardInterrupt),
+            ):
+                api = api_cls.return_value
+                scheduler = scheduler_cls.return_value
+                scheduler.repo_id = DUMMY_MODEL_ID
+                result = runner.invoke(
+                    app,
+                    [
+                        "upload",
+                        DUMMY_MODEL_ID,
+                        "my-file",
+                        "data/",
+                        "--repo-type",
+                        "dataset",
+                        "--revision",
+                        "v1.0.0",
+                        "--include",
+                        "*.json",
+                        "--include",
+                        "*.yaml",
+                        "--exclude",
+                        "*.log",
+                        "--exclude",
+                        "*.txt",
+                        "--delete",
+                        "*.config",
+                        "--delete",
+                        "*.secret",
+                        "--commit-message",
+                        "My commit message",
+                        "--commit-description",
+                        "My commit description",
+                        "--create-pr",
+                        "--every",
+                        "5",
+                        "--token",
+                        "my-token",
+                        "--quiet",
+                    ],
                 )
+        assert result.exit_code == 0
+        assert "Stopped scheduled commits." in result.stdout
+        resolve_mock.assert_called_once_with(
+            repo_id=DUMMY_MODEL_ID,
+            local_path="my-file",
+            path_in_repo="data/",
+            include=["*.json", "*.yaml"],
+        )
+        api_cls.assert_called_once_with(token="my-token")
+        scheduler_cls.assert_called_once_with(
+            folder_path=folder.as_posix(),
+            repo_id=DUMMY_MODEL_ID,
+            repo_type="dataset",
+            revision="v1.0.0",
+            allow_patterns=["*.json", "*.yaml"],
+            ignore_patterns=["*.log", "*.txt"],
+            path_in_repo="data/",
+            private=False,
+            every=5,
+            hf_api=api,
+        )
+        scheduler.stop.assert_called_once_with()
 
-            # Test error when using wildcard with explicit path_in_repo
-            with self.assertRaises(ValueError):
-                UploadCommand(self.parser.parse_args(["upload", DUMMY_MODEL_ID, "*.safetensors", "models/"]))
+    def test_every_must_be_positive(self) -> None:
+        class _PatchedBadParameter(typer.BadParameter):
+            def __init__(self, message: str, *, param_name: Optional[str] = None, **kwargs: object) -> None:
+                super().__init__(message, **kwargs)
 
-    def test_upload_with_all_options(self) -> None:
-        """Test `hf upload my-file to dummy-repo with all options selected`."""
-        cmd = UploadCommand(
-            self.parser.parse_args(
+        with (
+            patch("huggingface_hub.cli.upload.typer.BadParameter", _PatchedBadParameter),
+            patch("huggingface_hub.cli.upload.get_hf_api") as api_cls,
+        ):
+            with pytest.raises(typer.BadParameter, match="--every must be a positive value"):
+                upload(repo_id=DUMMY_MODEL_ID, every=0)
+
+            with pytest.raises(typer.BadParameter, match="--every must be a positive value"):
+                upload(repo_id=DUMMY_MODEL_ID, every=-10)
+        api_cls.assert_not_called()
+
+    def test_every_as_int(self, runner: CliRunner) -> None:
+        with SoftTemporaryDirectory() as tmp_dir:
+            folder = Path(tmp_dir)
+            with (
+                patch(
+                    "huggingface_hub.cli.upload._resolve_upload_paths",
+                    return_value=(folder.as_posix(), ".", None),
+                ),
+                patch("huggingface_hub.cli.upload.get_hf_api"),
+                patch("huggingface_hub.cli.upload.CommitScheduler") as scheduler_cls,
+                patch("huggingface_hub.cli.upload.time.sleep", side_effect=KeyboardInterrupt),
+            ):
+                result = runner.invoke(app, ["upload", DUMMY_MODEL_ID, ".", "--every", "10"])
+        assert result.exit_code == 0
+        assert scheduler_cls.call_args.kwargs["every"] == pytest.approx(10)
+
+    def test_every_as_float(self, runner: CliRunner) -> None:
+        with SoftTemporaryDirectory() as tmp_dir:
+            folder = Path(tmp_dir)
+            with (
+                patch(
+                    "huggingface_hub.cli.upload._resolve_upload_paths",
+                    return_value=(folder.as_posix(), ".", None),
+                ),
+                patch("huggingface_hub.cli.upload.get_hf_api"),
+                patch("huggingface_hub.cli.upload.CommitScheduler") as scheduler_cls,
+                patch("huggingface_hub.cli.upload.time.sleep", side_effect=KeyboardInterrupt),
+            ):
+                result = runner.invoke(app, ["upload", DUMMY_MODEL_ID, ".", "--every", "0.5"])
+        assert result.exit_code == 0
+        assert scheduler_cls.call_args.kwargs["every"] == pytest.approx(0.5)
+
+
+class TestResolveUploadPaths:
+    def test_upload_with_wildcard(self) -> None:
+        local_path, path_in_repo, include = _resolve_upload_paths(
+            repo_id=DUMMY_MODEL_ID, local_path="*.safetensors", path_in_repo=None, include=None
+        )
+        assert local_path == "."
+        assert path_in_repo == "*.safetensors"
+        assert include == ["."]
+
+        local_path, path_in_repo, include = _resolve_upload_paths(
+            repo_id=DUMMY_MODEL_ID, local_path="subdir/*.safetensors", path_in_repo=None, include=None
+        )
+        assert local_path == "."
+        assert path_in_repo == "subdir/*.safetensors"
+        assert include == ["."]
+
+        with pytest.raises(ValueError):
+            _resolve_upload_paths(
+                repo_id=DUMMY_MODEL_ID,
+                local_path="*.safetensors",
+                path_in_repo=None,
+                include=["*.json"],
+            )
+
+        with pytest.raises(ValueError):
+            _resolve_upload_paths(
+                repo_id=DUMMY_MODEL_ID,
+                local_path="*.safetensors",
+                path_in_repo="models/",
+                include=None,
+            )
+
+    def test_upload_implicit_local_path_when_folder_exists(self) -> None:
+        with tmp_current_directory() as cache_dir:
+            folder_path = Path(cache_dir) / "my-cool-model"
+            folder_path.mkdir()
+            local_path, path_in_repo, include = _resolve_upload_paths(
+                repo_id="my-cool-model", local_path=None, path_in_repo=None, include=None
+            )
+        assert local_path == "my-cool-model"
+        assert path_in_repo == "."
+        assert include is None
+
+    def test_upload_implicit_local_path_when_file_exists(self) -> None:
+        with tmp_current_directory() as cache_dir:
+            file_path = Path(cache_dir) / "my-cool-model"
+            file_path.write_text("content")
+            local_path, path_in_repo, include = _resolve_upload_paths(
+                repo_id="my-cool-model", local_path=None, path_in_repo=None, include=None
+            )
+        assert local_path == "my-cool-model"
+        assert path_in_repo == "my-cool-model"
+        assert include is None
+
+    def test_upload_implicit_local_path_when_org_repo(self) -> None:
+        with tmp_current_directory() as cache_dir:
+            folder_path = Path(cache_dir) / "my-cool-model"
+            folder_path.mkdir()
+            local_path, path_in_repo, include = _resolve_upload_paths(
+                repo_id="my-cool-org/my-cool-model", local_path=None, path_in_repo=None, include=None
+            )
+        assert local_path == "my-cool-model"
+        assert path_in_repo == "."
+        assert include is None
+
+    def test_upload_implicit_local_path_otherwise(self) -> None:
+        with tmp_current_directory():
+            with pytest.raises(ValueError):
+                _resolve_upload_paths(repo_id="my-cool-model", local_path=None, path_in_repo=None, include=None)
+
+    def test_upload_explicit_local_path_to_folder_implicit_path_in_repo(self) -> None:
+        with tmp_current_directory() as cache_dir:
+            folder_path = Path(cache_dir) / "path" / "to" / "folder"
+            folder_path.mkdir(parents=True, exist_ok=True)
+            local_path, path_in_repo, include = _resolve_upload_paths(
+                repo_id="my-repo", local_path="./path/to/folder", path_in_repo=None, include=None
+            )
+        assert local_path == "./path/to/folder"
+        assert path_in_repo == "."
+        assert include is None
+
+    def test_upload_explicit_local_path_to_file_implicit_path_in_repo(self) -> None:
+        with tmp_current_directory() as cache_dir:
+            file_path = Path(cache_dir) / "path" / "to" / "file.txt"
+            file_path.parent.mkdir(parents=True, exist_ok=True)
+            file_path.write_text("content")
+            local_path, path_in_repo, include = _resolve_upload_paths(
+                repo_id="my-repo", local_path="./path/to/file.txt", path_in_repo=None, include=None
+            )
+        assert local_path == "./path/to/file.txt"
+        assert path_in_repo == "file.txt"
+        assert include is None
+
+    def test_upload_explicit_paths(self) -> None:
+        local_path, path_in_repo, include = _resolve_upload_paths(
+            repo_id="my-repo", local_path="./path/to/folder", path_in_repo="data/", include=None
+        )
+        assert local_path == "./path/to/folder"
+        assert path_in_repo == "data/"
+        assert include is None
+
+
+class TestUploadImpl:
+    @patch("huggingface_hub.cli.upload.is_xet_available", return_value=True)
+    @patch("huggingface_hub.cli.upload.HF_HUB_ENABLE_HF_TRANSFER", False)
+    def test_upload_folder_mock(self, *_: object) -> None:
+        api = Mock()
+        api.create_repo.return_value = Mock(repo_id="my-model")
+        api.upload_folder.return_value = "done"
+        with SoftTemporaryDirectory() as cache_dir:
+            cache_path = cache_dir.absolute().as_posix()
+            local_dir = Path(cache_path)
+            (local_dir / "config.json").write_text("{}")
+            with (
+                patch("huggingface_hub.cli.upload.get_hf_api", return_value=api),
+                patch("builtins.print") as print_mock,
+            ):
+                upload(
+                    repo_id="my-model",
+                    local_path=cache_path,
+                    include=["*.json"],
+                    delete=["*.json"],
+                    private=True,
+                    quiet=True,
+                )
+        api.create_repo.assert_called_once_with(
+            repo_id="my-model",
+            repo_type="model",
+            exist_ok=True,
+            private=True,
+            space_sdk=None,
+        )
+        api.upload_folder.assert_called_once_with(
+            folder_path=cache_path,
+            path_in_repo=".",
+            repo_id="my-model",
+            repo_type="model",
+            revision=None,
+            commit_message=None,
+            commit_description=None,
+            create_pr=False,
+            allow_patterns=["*.json"],
+            ignore_patterns=None,
+            delete_patterns=["*.json"],
+        )
+        print_mock.assert_called_once_with("done")
+
+    @patch("huggingface_hub.cli.upload.is_xet_available", return_value=True)
+    @patch("huggingface_hub.cli.upload.HF_HUB_ENABLE_HF_TRANSFER", False)
+    def test_upload_file_mock(self, *_: object) -> None:
+        api = Mock()
+        api.create_repo.return_value = Mock(repo_id="my-dataset")
+        api.upload_file.return_value = "uploaded"
+        with SoftTemporaryDirectory() as cache_dir:
+            file_path = Path(cache_dir) / "file.txt"
+            file_path.write_text("content")
+            with (
+                patch("huggingface_hub.cli.upload.get_hf_api", return_value=api),
+                patch("builtins.print") as print_mock,
+            ):
+                upload(
+                    repo_id="my-dataset",
+                    repo_type=RepoType.dataset,
+                    local_path=str(file_path),
+                    path_in_repo="logs/file.txt",
+                    create_pr=True,
+                    quiet=True,
+                )
+        api.create_repo.assert_called_once_with(
+            repo_id="my-dataset",
+            repo_type="dataset",
+            exist_ok=True,
+            private=False,
+            space_sdk=None,
+        )
+        api.upload_file.assert_called_once_with(
+            path_or_fileobj=str(file_path),
+            path_in_repo="logs/file.txt",
+            repo_id="my-dataset",
+            repo_type="dataset",
+            revision=None,
+            commit_message=None,
+            commit_description=None,
+            create_pr=True,
+        )
+        print_mock.assert_called_once_with("uploaded")
+
+    @patch("huggingface_hub.cli.upload.is_xet_available", return_value=True)
+    @patch("huggingface_hub.cli.upload.HF_HUB_ENABLE_HF_TRANSFER", False)
+    def test_upload_file_no_revision_mock(self, *_: object) -> None:
+        api = Mock()
+        api.create_repo.return_value = Mock(repo_id="my-model")
+        with SoftTemporaryDirectory() as cache_dir:
+            file_path = Path(cache_dir) / "file.txt"
+            file_path.write_text("content")
+            with (
+                patch("huggingface_hub.cli.upload.get_hf_api", return_value=api),
+                patch("builtins.print"),
+            ):
+                upload(
+                    repo_id="my-model",
+                    local_path=str(file_path),
+                    path_in_repo="logs/file.txt",
+                    quiet=True,
+                )
+        api.repo_info.assert_not_called()
+
+    @patch("huggingface_hub.cli.upload.is_xet_available", return_value=True)
+    @patch("huggingface_hub.cli.upload.HF_HUB_ENABLE_HF_TRANSFER", False)
+    def test_upload_file_with_revision_mock(self, *_: object) -> None:
+        api = Mock()
+        api.create_repo.return_value = Mock(repo_id="my-model")
+        api.repo_info.side_effect = RevisionNotFoundError("revision not found", response=Mock())
+        with SoftTemporaryDirectory() as cache_dir:
+            file_path = Path(cache_dir) / "file.txt"
+            file_path.write_text("content")
+            with (
+                patch("huggingface_hub.cli.upload.get_hf_api", return_value=api),
+                patch("builtins.print"),
+            ):
+                upload(
+                    repo_id="my-model",
+                    revision="my-branch",
+                    local_path=str(file_path),
+                    path_in_repo="logs/file.txt",
+                    quiet=True,
+                )
+        api.repo_info.assert_called_once_with(repo_id="my-model", repo_type="model", revision="my-branch")
+        api.create_branch.assert_called_once_with(
+            repo_id="my-model", repo_type="model", branch="my-branch", exist_ok=True
+        )
+
+    @patch("huggingface_hub.cli.upload.is_xet_available", return_value=True)
+    @patch("huggingface_hub.cli.upload.HF_HUB_ENABLE_HF_TRANSFER", False)
+    def test_upload_file_revision_and_create_pr_mock(self, *_: object) -> None:
+        api = Mock()
+        api.create_repo.return_value = Mock(repo_id="my-model")
+        with SoftTemporaryDirectory() as cache_dir:
+            file_path = Path(cache_dir) / "file.txt"
+            file_path.write_text("content")
+            with (
+                patch("huggingface_hub.cli.upload.get_hf_api", return_value=api),
+                patch("builtins.print"),
+            ):
+                upload(
+                    repo_id="my-model",
+                    revision="my-branch",
+                    local_path=str(file_path),
+                    path_in_repo="logs/file.txt",
+                    create_pr=True,
+                    quiet=True,
+                )
+        api.repo_info.assert_not_called()
+        api.create_branch.assert_not_called()
+
+    @patch("huggingface_hub.cli.upload.is_xet_available", return_value=True)
+    @patch("huggingface_hub.cli.upload.HF_HUB_ENABLE_HF_TRANSFER", False)
+    def test_upload_missing_path(self, *_: object) -> None:
+        api = Mock()
+        with pytest.raises(FileNotFoundError):
+            with patch("huggingface_hub.cli.upload.get_hf_api", return_value=api):
+                upload(
+                    repo_id="my-model",
+                    local_path="/path/to/missing_file",
+                    path_in_repo="logs/file.txt",
+                    quiet=True,
+                )
+        api.create_repo.assert_not_called()
+
+
+class TestDownloadCommand:
+    def test_download_basic(self, runner: CliRunner) -> None:
+        with (
+            patch("huggingface_hub.cli.download.snapshot_download", return_value="path") as snapshot_mock,
+            patch("huggingface_hub.cli.download.hf_hub_download") as download_mock,
+        ):
+            result = runner.invoke(app, ["download", DUMMY_MODEL_ID])
+        assert result.exit_code == 0
+        assert "path" in result.stdout
+        download_mock.assert_not_called()
+        snapshot_mock.assert_called_once()
+        kwargs = snapshot_mock.call_args.kwargs
+        assert kwargs["repo_id"] == DUMMY_MODEL_ID
+        assert kwargs["repo_type"] == "model"
+        assert kwargs["revision"] is None
+        assert kwargs["allow_patterns"] is None
+        assert kwargs["ignore_patterns"] is None
+        assert kwargs["force_download"] is False
+        assert kwargs["cache_dir"] is None
+        assert kwargs["local_dir"] is None
+        assert kwargs["token"] is None
+        assert kwargs["library_name"] == "hf"
+        assert kwargs["max_workers"] == 8
+
+    def test_download_with_all_options(self, runner: CliRunner) -> None:
+        with (
+            patch("huggingface_hub.cli.download.snapshot_download", return_value="path") as snapshot_mock,
+            patch("huggingface_hub.cli.download.hf_hub_download") as download_mock,
+        ):
+            result = runner.invoke(
+                app,
                 [
-                    "upload",
+                    "download",
                     DUMMY_MODEL_ID,
-                    "my-file",
-                    "data/",
                     "--repo-type",
                     "dataset",
                     "--revision",
                     "v1.0.0",
                     "--include",
                     "*.json",
+                    "--include",
                     "*.yaml",
                     "--exclude",
                     "*.log",
+                    "--exclude",
                     "*.txt",
-                    "--delete",
-                    "*.config",
-                    "*.secret",
-                    "--commit-message",
-                    "My commit message",
-                    "--commit-description",
-                    "My commit description",
-                    "--create-pr",
-                    "--every",
-                    "5",
+                    "--force-download",
+                    "--cache-dir",
+                    "/tmp",
                     "--token",
                     "my-token",
                     "--quiet",
-                ]
+                    "--local-dir",
+                    ".",
+                    "--max-workers",
+                    "4",
+                ],
             )
-        )
-        assert cmd.repo_id == DUMMY_MODEL_ID
-        assert cmd.local_path == "my-file"
-        assert cmd.path_in_repo == "data/"
-        assert cmd.repo_type == "dataset"
-        assert cmd.revision == "v1.0.0"
-        assert cmd.include == ["*.json", "*.yaml"]
-        assert cmd.exclude == ["*.log", "*.txt"]
-        assert cmd.delete == ["*.config", "*.secret"]
-        assert cmd.commit_message == "My commit message"
-        assert cmd.commit_description == "My commit description"
-        assert cmd.create_pr is True
-        assert cmd.every == 5
-        assert cmd.api.token == "my-token"
-        assert cmd.quiet is True
-
-    def test_upload_implicit_local_path_when_folder_exists(self) -> None:
-        with tmp_current_directory() as cache_dir:
-            folder_path = Path(cache_dir) / "my-cool-model"
-            folder_path.mkdir()
-            cmd = UploadCommand(self.parser.parse_args(["upload", "my-cool-model"]))
-
-        # A folder with the same name as the repo exists => upload it at the root of the repo
-        assert cmd.local_path == "my-cool-model"
-        assert cmd.path_in_repo == "."
-
-    def test_upload_implicit_local_path_when_file_exists(self) -> None:
-        with tmp_current_directory() as cache_dir:
-            folder_path = Path(cache_dir) / "my-cool-model"
-            folder_path.touch()
-            cmd = UploadCommand(self.parser.parse_args(["upload", "my-cool-model"]))
-
-        # A file with the same name as the repo exists => upload it at the root of the repo
-        assert cmd.local_path == "my-cool-model"
-        assert cmd.path_in_repo == "my-cool-model"
-
-    def test_upload_implicit_local_path_when_org_repo(self) -> None:
-        with tmp_current_directory() as cache_dir:
-            folder_path = Path(cache_dir) / "my-cool-model"
-            folder_path.mkdir()
-            cmd = UploadCommand(self.parser.parse_args(["upload", "my-cool-org/my-cool-model"]))
-
-        # A folder with the same name as the repo exists => upload it at the root of the repo
-        assert cmd.local_path == "my-cool-model"
-        assert cmd.path_in_repo == "."
-
-    def test_upload_implicit_local_path_otherwise(self) -> None:
-        # No folder or file has the same name as the repo => raise exception
-        with self.assertRaises(ValueError):
-            with tmp_current_directory():
-                UploadCommand(self.parser.parse_args(["upload", "my-cool-model"]))
-
-    def test_upload_explicit_local_path_to_folder_implicit_path_in_repo(self) -> None:
-        with tmp_current_directory() as cache_dir:
-            folder_path = Path(cache_dir) / "path" / "to" / "folder"
-            folder_path.mkdir(parents=True, exist_ok=True)
-            cmd = UploadCommand(self.parser.parse_args(["upload", "my-repo", "./path/to/folder"]))
-        assert cmd.local_path == "./path/to/folder"
-        assert cmd.path_in_repo == "."  # Always upload the folder at the root of the repo
-
-    def test_upload_explicit_local_path_to_file_implicit_path_in_repo(self) -> None:
-        with tmp_current_directory() as cache_dir:
-            file_path = Path(cache_dir) / "path" / "to" / "file.txt"
-            file_path.parent.mkdir(parents=True, exist_ok=True)
-            file_path.touch()
-            cmd = UploadCommand(self.parser.parse_args(["upload", "my-repo", "./path/to/file.txt"]))
-        assert cmd.local_path == "./path/to/file.txt"
-        assert cmd.path_in_repo == "file.txt"  # If a file, upload it at the root of the repo and keep name
-
-    def test_upload_explicit_paths(self) -> None:
-        cmd = UploadCommand(self.parser.parse_args(["upload", "my-repo", "./path/to/folder", "data/"]))
-        assert cmd.local_path == "./path/to/folder"
-        assert cmd.path_in_repo == "data/"
-
-    def test_every_must_be_positive(self) -> None:
-        with self.assertRaises(ValueError):
-            UploadCommand(self.parser.parse_args(["upload", DUMMY_MODEL_ID, ".", "--every", "0"]))
-
-        with self.assertRaises(ValueError):
-            UploadCommand(self.parser.parse_args(["upload", DUMMY_MODEL_ID, ".", "--every", "-10"]))
-
-    def test_every_as_int(self) -> None:
-        cmd = UploadCommand(self.parser.parse_args(["upload", DUMMY_MODEL_ID, ".", "--every", "10"]))
-        assert cmd.every == 10
-
-    def test_every_as_float(self) -> None:
-        cmd = UploadCommand(self.parser.parse_args(["upload", DUMMY_MODEL_ID, ".", "--every", "0.5"]))
-        assert cmd.every == 0.5
-
-    @patch("huggingface_hub.cli.upload.HfApi.repo_info")
-    @patch("huggingface_hub.cli.upload.HfApi.upload_folder")
-    @patch("huggingface_hub.cli.upload.HfApi.create_repo")
-    def test_upload_folder_mock(self, create_mock: Mock, upload_mock: Mock, repo_info_mock: Mock) -> None:
-        with SoftTemporaryDirectory() as cache_dir:
-            cache_path = cache_dir.absolute().as_posix()
-            cmd = UploadCommand(
-                self.parser.parse_args(
-                    ["upload", "my-model", cache_path, ".", "--private", "--include", "*.json", "--delete", "*.json"]
-                )
-            )
-            cmd.run()
-
-            create_mock.assert_called_once_with(
-                repo_id="my-model", repo_type="model", exist_ok=True, private=True, space_sdk=None
-            )
-            upload_mock.assert_called_once_with(
-                folder_path=cache_path,
-                path_in_repo=".",
-                repo_id=create_mock.return_value.repo_id,
-                repo_type="model",
-                revision=None,
-                commit_message=None,
-                commit_description=None,
-                create_pr=False,
-                allow_patterns=["*.json"],
-                ignore_patterns=None,
-                delete_patterns=["*.json"],
-            )
-
-    @patch("huggingface_hub.cli.upload.HfApi.repo_info")
-    @patch("huggingface_hub.cli.upload.HfApi.upload_file")
-    @patch("huggingface_hub.cli.upload.HfApi.create_repo")
-    def test_upload_file_mock(self, create_mock: Mock, upload_mock: Mock, repo_info_mock: Mock) -> None:
-        with SoftTemporaryDirectory() as cache_dir:
-            file_path = Path(cache_dir) / "file.txt"
-            file_path.write_text("content")
-            cmd = UploadCommand(
-                self.parser.parse_args(
-                    ["upload", "my-dataset", str(file_path), "logs/file.txt", "--repo-type", "dataset", "--create-pr"]
-                )
-            )
-            cmd.run()
-
-            create_mock.assert_called_once_with(
-                repo_id="my-dataset", repo_type="dataset", exist_ok=True, private=False, space_sdk=None
-            )
-            upload_mock.assert_called_once_with(
-                path_or_fileobj=str(file_path),
-                path_in_repo="logs/file.txt",
-                repo_id=create_mock.return_value.repo_id,
-                repo_type="dataset",
-                revision=None,
-                commit_message=None,
-                commit_description=None,
-                create_pr=True,
-            )
-
-    @patch("huggingface_hub.cli.upload.HfApi.repo_info")
-    @patch("huggingface_hub.cli.upload.HfApi.upload_file")
-    @patch("huggingface_hub.cli.upload.HfApi.create_repo")
-    def test_upload_file_no_revision_mock(self, create_mock: Mock, upload_mock: Mock, repo_info_mock: Mock) -> None:
-        with SoftTemporaryDirectory() as cache_dir:
-            file_path = Path(cache_dir) / "file.txt"
-            file_path.write_text("content")
-            cmd = UploadCommand(self.parser.parse_args(["upload", "my-model", str(file_path), "logs/file.txt"]))
-            cmd.run()
-            # Revision not specified => no need to check
-            repo_info_mock.assert_not_called()
-
-    @patch("huggingface_hub.cli.upload.HfApi.create_branch")
-    @patch("huggingface_hub.cli.upload.HfApi.repo_info")
-    @patch("huggingface_hub.cli.upload.HfApi.upload_file")
-    @patch("huggingface_hub.cli.upload.HfApi.create_repo")
-    def test_upload_file_with_revision_mock(
-        self, create_mock: Mock, upload_mock: Mock, repo_info_mock: Mock, create_branch_mock: Mock
-    ) -> None:
-        repo_info_mock.side_effect = RevisionNotFoundError("revision not found", response=Mock())
-
-        with SoftTemporaryDirectory() as cache_dir:
-            file_path = Path(cache_dir) / "file.txt"
-            file_path.write_text("content")
-            cmd = UploadCommand(
-                self.parser.parse_args(
-                    ["upload", "my-model", str(file_path), "logs/file.txt", "--revision", "my-branch"]
-                )
-            )
-            cmd.run()
-
-            # Revision specified => check that it exists
-            repo_info_mock.assert_called_once_with(
-                repo_id=create_mock.return_value.repo_id, repo_type="model", revision="my-branch"
-            )
-
-            # Revision does not exist => create it
-            create_branch_mock.assert_called_once_with(
-                repo_id=create_mock.return_value.repo_id, repo_type="model", branch="my-branch", exist_ok=True
-            )
-
-    @patch("huggingface_hub.cli.upload.HfApi.repo_info")
-    @patch("huggingface_hub.cli.upload.HfApi.upload_file")
-    @patch("huggingface_hub.cli.upload.HfApi.create_repo")
-    def test_upload_file_revision_and_create_pr_mock(
-        self, create_mock: Mock, upload_mock: Mock, repo_info_mock: Mock
-    ) -> None:
-        with SoftTemporaryDirectory() as cache_dir:
-            file_path = Path(cache_dir) / "file.txt"
-            file_path.write_text("content")
-            cmd = UploadCommand(
-                self.parser.parse_args(
-                    ["upload", "my-model", str(file_path), "logs/file.txt", "--revision", "my-branch", "--create-pr"]
-                )
-            )
-            cmd.run()
-            # Revision specified but --create-pr => no need to check
-            repo_info_mock.assert_not_called()
-
-    @patch("huggingface_hub.cli.upload.HfApi.create_repo")
-    def test_upload_missing_path(self, create_mock: Mock) -> None:
-        cmd = UploadCommand(self.parser.parse_args(["upload", "my-model", "/path/to/missing_file", "logs/file.txt"]))
-        with self.assertRaises(FileNotFoundError):
-            cmd.run()  # File/folder does not exist locally
-
-        # Repo creation happens before the check
-        create_mock.assert_not_called()
+        assert result.exit_code == 0
+        download_mock.assert_not_called()
+        snapshot_mock.assert_called_once()
+        kwargs = snapshot_mock.call_args.kwargs
+        assert kwargs["repo_id"] == DUMMY_MODEL_ID
+        assert kwargs["repo_type"] == "dataset"
+        assert kwargs["revision"] == "v1.0.0"
+        assert kwargs["allow_patterns"] == ["*.json", "*.yaml"]
+        assert kwargs["ignore_patterns"] == ["*.log", "*.txt"]
+        assert kwargs["force_download"] is True
+        assert kwargs["cache_dir"] == "/tmp"
+        assert kwargs["local_dir"] == "."
+        assert kwargs["token"] == "my-token"
+        assert kwargs["library_name"] == "hf"
+        assert kwargs["max_workers"] == 4
 
 
-class TestDownloadCommand(unittest.TestCase):
-    def setUp(self) -> None:
-        """
-        Set up CLI as in `src/huggingface_hub/cli/hf.py`.
-        """
-        self.parser = ArgumentParser("hf", usage="hf <command> [<args>]")
-        commands_parser = self.parser.add_subparsers()
-        DownloadCommand.register_subcommand(commands_parser)
-
-    def test_download_basic(self) -> None:
-        """Test `hf download dummy-repo`."""
-        args = self.parser.parse_args(["download", DUMMY_MODEL_ID])
-        assert args.repo_id == DUMMY_MODEL_ID
-        assert len(args.filenames) == 0
-        assert args.repo_type == "model"
-        assert args.revision is None
-        assert args.include is None
-        assert args.exclude is None
-        assert args.cache_dir is None
-        assert args.local_dir is None
-        assert args.force_download is False
-        assert args.token is None
-        assert args.quiet is False
-        assert args.func == DownloadCommand
-
-    def test_download_with_all_options(self) -> None:
-        """Test `hf download dummy-repo` with all options selected."""
-        args = self.parser.parse_args(
-            [
-                "download",
-                DUMMY_MODEL_ID,
-                "--repo-type",
-                "dataset",
-                "--revision",
-                "v1.0.0",
-                "--include",
-                "*.json",
-                "*.yaml",
-                "--exclude",
-                "*.log",
-                "*.txt",
-                "--force-download",
-                "--cache-dir",
-                "/tmp",
-                "--token",
-                "my-token",
-                "--quiet",
-                "--local-dir",
-                ".",
-                "--max-workers",
-                "4",
-            ]
-        )
-        assert args.repo_id == DUMMY_MODEL_ID
-        assert args.repo_type == "dataset"
-        assert args.revision == "v1.0.0"
-        assert args.include == ["*.json", "*.yaml"]
-        assert args.exclude == ["*.log", "*.txt"]
-        assert args.force_download is True
-        assert args.cache_dir == "/tmp"
-        assert args.local_dir == "."
-        assert args.token == "my-token"
-        assert args.quiet is True
-        assert args.max_workers == 4
-        assert args.func == DownloadCommand
-
+class TestDownloadImpl:
+    @patch("huggingface_hub.cli.download.snapshot_download")
     @patch("huggingface_hub.cli.download.hf_hub_download")
-    def test_download_file_from_revision(self, mock: Mock) -> None:
-        args = Namespace(
-            token="hf_****",
-            repo_id="author/dataset",
-            filenames=["README.md"],
-            repo_type="dataset",
-            revision="refs/pr/1",
-            include=None,
-            exclude=None,
-            force_download=False,
-            cache_dir=None,
-            local_dir=".",
-            quiet=False,
-            max_workers=8,
-        )
-
-        # Output path is printed to terminal once run is completed
-        with capture_output() as output:
-            DownloadCommand(args).run()
-        self.assertRegex(output.getvalue(), r"<MagicMock name='hf_hub_download\(\)' id='\d+'>")
-
-        mock.assert_called_once_with(
-            repo_id="author/dataset",
-            repo_type="dataset",
-            revision="refs/pr/1",
-            filename="README.md",
+    def test_download_file_from_revision(self, mock_download: Mock, mock_snapshot: Mock) -> None:
+        mock_download.return_value = "file-path"
+        with patch("builtins.print") as print_mock:
+            download(
+                repo_id="author/model",
+                filenames=["config.json"],
+                repo_type=RepoType.model,
+                revision="main",
+                quiet=True,
+            )
+        print_mock.assert_called_once_with("file-path")
+        mock_download.assert_called_once_with(
+            repo_id="author/model",
+            repo_type="model",
+            revision="main",
+            filename="config.json",
             cache_dir=None,
             force_download=False,
-            token="hf_****",
-            local_dir=".",
+            token=None,
+            local_dir=None,
             library_name="hf",
         )
+        mock_snapshot.assert_not_called()
 
     @patch("huggingface_hub.cli.download.snapshot_download")
-    def test_download_multiple_files(self, mock: Mock) -> None:
-        args = Namespace(
-            token="hf_****",
-            repo_id="author/model",
-            filenames=["README.md", "config.json"],
-            repo_type="model",
-            revision=None,
-            include=None,
-            exclude=None,
-            force_download=True,
-            cache_dir=None,
-            local_dir="/path/to/dir",
-            quiet=False,
-            max_workers=8,
-        )
-        DownloadCommand(args).run()
-
-        # Use `snapshot_download` to ensure all files comes from same revision
-        mock.assert_called_once_with(
+    @patch("huggingface_hub.cli.download.hf_hub_download")
+    def test_download_multiple_files(self, mock_download: Mock, mock_snapshot: Mock) -> None:
+        mock_snapshot.return_value = "folder-path"
+        with patch("builtins.print") as print_mock:
+            download(
+                repo_id="author/model",
+                filenames=["README.md", "config.json"],
+                repo_type=RepoType.model,
+                force_download=True,
+                max_workers=4,
+                quiet=True,
+            )
+        print_mock.assert_called_once_with("folder-path")
+        mock_download.assert_not_called()
+        mock_snapshot.assert_called_once_with(
             repo_id="author/model",
             repo_type="model",
             revision=None,
@@ -508,32 +638,25 @@ class TestDownloadCommand(unittest.TestCase):
             ignore_patterns=None,
             force_download=True,
             cache_dir=None,
-            token="hf_****",
-            local_dir="/path/to/dir",
+            token=None,
+            local_dir=None,
             library_name="hf",
-            max_workers=8,
+            max_workers=4,
         )
 
     @patch("huggingface_hub.cli.download.snapshot_download")
-    def test_download_with_patterns(self, mock: Mock) -> None:
-        args = Namespace(
-            token=None,
-            repo_id="author/model",
-            filenames=[],
-            repo_type="model",
-            revision=None,
-            include=["*.json"],
-            exclude=["data/*"],
-            force_download=True,
-            cache_dir=None,
-            quiet=False,
-            local_dir=None,
-            max_workers=8,
-        )
-        DownloadCommand(args).run()
-
-        # Use `snapshot_download` to ensure all files comes from same revision
-        mock.assert_called_once_with(
+    def test_download_with_patterns(self, mock_snapshot: Mock) -> None:
+        with patch("builtins.print"):
+            download(
+                repo_id="author/model",
+                filenames=[],
+                repo_type=RepoType.model,
+                include=["*.json"],
+                exclude=["data/*"],
+                force_download=True,
+                quiet=True,
+            )
+        mock_snapshot.assert_called_once_with(
             repo_id="author/model",
             repo_type="model",
             revision=None,
@@ -541,39 +664,39 @@ class TestDownloadCommand(unittest.TestCase):
             ignore_patterns=["data/*"],
             force_download=True,
             cache_dir=None,
-            local_dir=None,
             token=None,
+            local_dir=None,
             library_name="hf",
             max_workers=8,
         )
 
     @patch("huggingface_hub.cli.download.snapshot_download")
-    def test_download_with_ignored_patterns(self, mock: Mock) -> None:
-        args = Namespace(
-            token=None,
+    @patch("huggingface_hub.cli.download.hf_hub_download")
+    def test_download_with_ignored_patterns(self, mock_download: Mock, mock_snapshot: Mock) -> None:
+        mock_snapshot.return_value = "folder-path"
+        with (
+            patch("builtins.print") as print_mock,
+            patch("huggingface_hub.cli.download.logging.set_verbosity_info"),
+            patch("huggingface_hub.cli.download.logging.set_verbosity_warning"),
+            warnings.catch_warnings(record=True) as caught,
+        ):
+            download(
+                repo_id="author/model",
+                filenames=["README.md", "config.json"],
+                repo_type=RepoType.model,
+                include=["*.json"],
+                exclude=["data/*"],
+                force_download=True,
+            )
+        print_mock.assert_called_once_with("folder-path")
+        assert any("Ignoring" in str(w.message) for w in caught)
+        mock_download.assert_not_called()
+        mock_snapshot.assert_called_once_with(
             repo_id="author/model",
-            filenames=["README.md", "config.json"],
             repo_type="model",
             revision=None,
-            include=["*.json"],
-            exclude=["data/*"],
-            force_download=True,
-            cache_dir=None,
-            quiet=False,
-            local_dir=None,
-            max_workers=8,
-        )
-
-        with self.assertWarns(UserWarning):
-            # warns that patterns are ignored
-            DownloadCommand(args).run()
-
-        mock.assert_called_once_with(
-            repo_id="author/model",
-            repo_type="model",
-            revision=None,
-            allow_patterns=["README.md", "config.json"],  # `filenames` has priority over the patterns
-            ignore_patterns=None,  # cleaned up
+            allow_patterns=["README.md", "config.json"],
+            ignore_patterns=None,
             force_download=True,
             cache_dir=None,
             token=None,
@@ -582,109 +705,98 @@ class TestDownloadCommand(unittest.TestCase):
             max_workers=8,
         )
 
-        # Same but quiet (no warnings)
-        args.quiet = True
-        with warnings.catch_warnings():
-            # Taken from https://docs.pytest.org/en/latest/how-to/capture-warnings.html#additional-use-cases-of-warnings-in-tests
-            warnings.simplefilter("error")
-            DownloadCommand(args).run()
 
-
-class TestTagCommands(unittest.TestCase):
-    def setUp(self) -> None:
-        """
-        Set up CLI as in `src/huggingface_hub/cli/hf.py`.
-        """
-        self.parser = ArgumentParser("hf", usage="hf <command> [<args>]")
-        commands_parser = self.parser.add_subparsers()
-        RepoCommands.register_subcommand(commands_parser)
-
-    def test_tag_create_basic(self) -> None:
-        args = self.parser.parse_args(["repo", "tag", "create", DUMMY_MODEL_ID, "1.0", "-m", "My tag message"])
-        assert args.repo_id == DUMMY_MODEL_ID
-        assert args.tag == "1.0"
-        assert args.message is not None
-        assert args.revision is None
-        assert args.token is None
-        assert args.repo_type == "model"
-
-    def test_tag_create_with_all_options(self) -> None:
-        args = self.parser.parse_args(
-            [
-                "repo",
-                "tag",
-                "create",
-                DUMMY_MODEL_ID,
-                "1.0",
-                "--message",
-                "My tag message",
-                "--revision",
-                "v1.0.0",
-                "--token",
-                "my-token",
-                "--repo-type",
-                "dataset",
-            ]
+class TestTagCommands:
+    def test_tag_create_basic(self, runner: CliRunner) -> None:
+        with patch("huggingface_hub.cli.repo.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            result = runner.invoke(
+                app,
+                ["repo", "tag", "create", DUMMY_MODEL_ID, "1.0", "-m", "My tag message"],
+            )
+        assert result.exit_code == 0
+        api_cls.assert_called_once_with(token=None)
+        api.create_tag.assert_called_once_with(
+            repo_id=DUMMY_MODEL_ID,
+            tag="1.0",
+            tag_message="My tag message",
+            revision=None,
+            repo_type="model",
         )
-        assert args.repo_id == DUMMY_MODEL_ID
-        assert args.tag == "1.0"
-        assert args.message == "My tag message"
-        assert args.revision == "v1.0.0"
-        assert args.token == "my-token"
-        assert args.repo_type == "dataset"
 
-    def test_tag_list_basic(self) -> None:
-        args = self.parser.parse_args(["repo", "tag", "list", DUMMY_MODEL_ID])
-        assert args.repo_id == DUMMY_MODEL_ID
-        assert args.token is None
-        assert args.repo_type == "model"
+    def test_tag_create_with_all_options(self, runner: CliRunner) -> None:
+        with patch("huggingface_hub.cli.repo.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            result = runner.invoke(
+                app,
+                [
+                    "repo",
+                    "tag",
+                    "create",
+                    DUMMY_MODEL_ID,
+                    "1.0",
+                    "--message",
+                    "My tag message",
+                    "--revision",
+                    "v1.0.0",
+                    "--token",
+                    "my-token",
+                    "--repo-type",
+                    "dataset",
+                ],
+            )
+        assert result.exit_code == 0
+        api_cls.assert_called_once_with(token="my-token")
+        api.create_tag.assert_called_once_with(
+            repo_id=DUMMY_MODEL_ID,
+            tag="1.0",
+            tag_message="My tag message",
+            revision="v1.0.0",
+            repo_type="dataset",
+        )
 
-    def test_tag_delete_basic(self) -> None:
-        args = self.parser.parse_args(["repo", "tag", "delete", DUMMY_MODEL_ID, "1.0"])
-        assert args.repo_id == DUMMY_MODEL_ID
-        assert args.tag == "1.0"
-        assert args.token is None
-        assert args.repo_type == "model"
-        assert args.yes is False
+    def test_tag_list_basic(self, runner: CliRunner) -> None:
+        refs = Mock(tags=[Mock(name="v1")])
+        with patch("huggingface_hub.cli.repo.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            api.list_repo_refs.return_value = refs
+            result = runner.invoke(app, ["repo", "tag", "list", DUMMY_MODEL_ID])
+        assert result.exit_code == 0
+        api_cls.assert_called_once_with(token=None)
+        api.list_repo_refs.assert_called_once_with(repo_id=DUMMY_MODEL_ID, repo_type="model")
+
+    def test_tag_delete_basic(self, runner: CliRunner) -> None:
+        with patch("huggingface_hub.cli.repo.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            result = runner.invoke(
+                app,
+                ["repo", "tag", "delete", DUMMY_MODEL_ID, "1.0"],
+                input="y\n",
+            )
+        assert result.exit_code == 0
+        api_cls.assert_called_once_with(token=None)
+        api.delete_tag.assert_called_once_with(repo_id=DUMMY_MODEL_ID, tag="1.0", repo_type="model")
 
 
 @contextmanager
 def tmp_current_directory() -> Generator[str, None, None]:
-    """Change current directory to a tmp dir and revert back when exiting."""
     with SoftTemporaryDirectory() as tmp_dir:
         cwd = os.getcwd()
         os.chdir(tmp_dir)
         try:
             yield tmp_dir
-        except:
-            raise
         finally:
             os.chdir(cwd)
 
 
-class TestRepoFilesCommand(unittest.TestCase):
-    def setUp(self) -> None:
-        """
-        Set up CLI as in `src/huggingface_hub/cli/hf.py`.
-        """
-        self.parser = ArgumentParser("hf", usage="hf <command> [<args>]")
-        commands_parser = self.parser.add_subparsers()
-        RepoFilesCommand.register_subcommand(commands_parser)
-
-    @patch("huggingface_hub.cli.repo_files.HfApi.delete_files")
-    def test_delete(self, delete_files_mock: Mock) -> None:
-        fixtures = [
-            {
-                "input_args": [
-                    "repo-files",
-                    "delete",
-                    DUMMY_MODEL_ID,
-                    "*",
-                ],
-                "delete_files_args": {
-                    "delete_patterns": [
-                        "*",
-                    ],
+class TestRepoFilesCommand:
+    @pytest.mark.parametrize(
+        "cli_args, expected_kwargs",
+        [
+            (
+                ["repo-files", "delete", DUMMY_MODEL_ID, "*"],
+                {
+                    "delete_patterns": ["*"],
                     "repo_id": DUMMY_MODEL_ID,
                     "repo_type": "model",
                     "revision": None,
@@ -692,18 +804,11 @@ class TestRepoFilesCommand(unittest.TestCase):
                     "commit_description": None,
                     "create_pr": False,
                 },
-            },
-            {
-                "input_args": [
-                    "repo-files",
-                    "delete",
-                    DUMMY_MODEL_ID,
-                    "file.txt",
-                ],
-                "delete_files_args": {
-                    "delete_patterns": [
-                        "file.txt",
-                    ],
+            ),
+            (
+                ["repo-files", "delete", DUMMY_MODEL_ID, "file.txt"],
+                {
+                    "delete_patterns": ["file.txt"],
                     "repo_id": DUMMY_MODEL_ID,
                     "repo_type": "model",
                     "revision": None,
@@ -711,18 +816,11 @@ class TestRepoFilesCommand(unittest.TestCase):
                     "commit_description": None,
                     "create_pr": False,
                 },
-            },
-            {
-                "input_args": [
-                    "repo-files",
-                    "delete",
-                    DUMMY_MODEL_ID,
-                    "folder/",
-                ],
-                "delete_files_args": {
-                    "delete_patterns": [
-                        "folder/",
-                    ],
+            ),
+            (
+                ["repo-files", "delete", DUMMY_MODEL_ID, "folder/"],
+                {
+                    "delete_patterns": ["folder/"],
                     "repo_id": DUMMY_MODEL_ID,
                     "repo_type": "model",
                     "revision": None,
@@ -730,17 +828,10 @@ class TestRepoFilesCommand(unittest.TestCase):
                     "commit_description": None,
                     "create_pr": False,
                 },
-            },
-            {
-                "input_args": [
-                    "repo-files",
-                    "delete",
-                    DUMMY_MODEL_ID,
-                    "file1.txt",
-                    "folder/",
-                    "file2.txt",
-                ],
-                "delete_files_args": {
+            ),
+            (
+                ["repo-files", "delete", DUMMY_MODEL_ID, "file1.txt", "folder/", "file2.txt"],
+                {
                     "delete_patterns": [
                         "file1.txt",
                         "folder/",
@@ -753,9 +844,9 @@ class TestRepoFilesCommand(unittest.TestCase):
                     "commit_description": None,
                     "create_pr": False,
                 },
-            },
-            {
-                "input_args": [
+            ),
+            (
+                [
                     "repo-files",
                     "delete",
                     DUMMY_MODEL_ID,
@@ -763,7 +854,7 @@ class TestRepoFilesCommand(unittest.TestCase):
                     "*.json",
                     "folder/*.parquet",
                 ],
-                "delete_files_args": {
+                {
                     "delete_patterns": [
                         "file.txt *",
                         "*.json",
@@ -776,9 +867,9 @@ class TestRepoFilesCommand(unittest.TestCase):
                     "commit_description": None,
                     "create_pr": False,
                 },
-            },
-            {
-                "input_args": [
+            ),
+            (
+                [
                     "repo-files",
                     "delete",
                     DUMMY_MODEL_ID,
@@ -793,10 +884,8 @@ class TestRepoFilesCommand(unittest.TestCase):
                     "My commit description",
                     "--create-pr",
                 ],
-                "delete_files_args": {
-                    "delete_patterns": [
-                        "file.txt *",
-                    ],
+                {
+                    "delete_patterns": ["file.txt *"],
                     "repo_id": DUMMY_MODEL_ID,
                     "repo_type": "dataset",
                     "revision": "test_revision",
@@ -804,182 +893,138 @@ class TestRepoFilesCommand(unittest.TestCase):
                     "commit_description": "My commit description",
                     "create_pr": True,
                 },
-            },
-        ]
-
-        for expected in fixtures:
-            # subTest is similar to pytest.mark.parametrize, but using the unittest
-            # framework
-            with self.subTest(expected):
-                delete_files_args = expected["delete_files_args"]
-
-                cmd = DeleteFilesSubCommand(self.parser.parse_args(expected["input_args"]))
-                cmd.run()
-
-                if delete_files_args is None:
-                    assert delete_files_mock.call_count == 0
-                else:
-                    assert delete_files_mock.call_count == 1
-                    # Inspect the captured calls
-                    _, kwargs = delete_files_mock.call_args_list[0]
-                    assert kwargs == delete_files_args
-
-                delete_files_mock.reset_mock()
-
-
-class DummyResponse:
-    def __init__(self, json):
-        self._json = json
-
-    def raise_for_status(self):
-        pass
-
-    def json(self):
-        return self._json
-
-
-class DummyCommit:
-    def __init__(self, oid: str):
-        self.oid = oid
-
-
-class TestJobsCommand(unittest.TestCase):
-    def setUp(self) -> None:
-        """
-        Set up CLI as in `src/huggingface_hub/commands/huggingface_cli.py`.
-        """
-        self.parser = ArgumentParser("hf", usage="hf <command> [<args>]")
-        commands_parser = self.parser.add_subparsers()
-        JobsCommands.register_subcommand(commands_parser)
-
-    patch_httpx_post = patch(
-        "httpx.Client.post",
-        return_value=DummyResponse(
-            {
-                "id": "my-job-id",
-                "owner": {
-                    "id": "userid",
-                    "name": "my-username",
-                    "type": "user",
-                },
-                "status": {"stage": "RUNNING"},
-            }
-        ),
+            ),
+        ],
     )
-    patch_whoami = patch("huggingface_hub.hf_api.HfApi.whoami", return_value={"name": "my-username"})
-    patch_get_token = patch("huggingface_hub.hf_api.get_token", return_value="hf_xxx")
-    patch_repo_info = patch("huggingface_hub.hf_api.HfApi.repo_info")
-    patch_upload_file = patch("huggingface_hub.hf_api.HfApi.upload_file", return_value=DummyCommit(oid="ae068f"))
+    def test_delete(self, runner: CliRunner, cli_args: list[str], expected_kwargs: dict[str, object]) -> None:
+        with patch("huggingface_hub.cli.repo_files.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            result = runner.invoke(app, cli_args)
+        assert result.exit_code == 0
+        api.delete_files.assert_called_once_with(**expected_kwargs)
 
-    @patch_httpx_post
-    @patch_whoami
-    def test_run(self, whoami: Mock, httpx_post: Mock) -> None:
-        input_args = ["jobs", "run", "--detach", "ubuntu", "echo", "hello"]
-        cmd = RunCommand(self.parser.parse_args(input_args))
-        cmd.run()
-        assert httpx_post.call_count == 1
-        args, kwargs = httpx_post.call_args_list[0]
-        assert args == ("https://huggingface.co/api/jobs/my-username",)
-        assert kwargs["json"] == {
-            "command": ["echo", "hello"],
-            "arguments": [],
-            "environment": {},
-            "flavor": "cpu-basic",
-            "dockerImage": "ubuntu",
-        }
 
-    @patch(
-        "httpx.Client.post",
-        return_value=DummyResponse(
-            {
-                "id": "my-job-id",
-                "owner": {
-                    "id": "userid",
-                    "name": "my-username",
-                    "type": "user",
-                },
-                "status": {"lastJob": None, "nextJobRunAt": "2025-08-20T15:35:00.000Z"},
-                "jobSpec": {},
-            }
-        ),
-    )
-    @patch("huggingface_hub.hf_api.HfApi.whoami", return_value={"name": "my-username"})
-    def test_create_scheduled_job(self, whoami: Mock, httpx_mock: Mock) -> None:
-        input_args = ["jobs", "scheduled", "run", "@hourly", "ubuntu", "echo", "hello"]
-        cmd = ScheduledRunCommand(self.parser.parse_args(input_args))
-        cmd.run()
-        assert httpx_mock.call_count == 1
-        args, kwargs = httpx_mock.call_args_list[0]
-        assert args == ("https://huggingface.co/api/scheduled-jobs/my-username",)
-        assert kwargs["json"] == {
-            "jobSpec": {
-                "command": ["echo", "hello"],
-                "arguments": [],
-                "environment": {},
-                "flavor": "cpu-basic",
-                "dockerImage": "ubuntu",
-            },
-            "schedule": "@hourly",
-        }
+class TestJobsCommand:
+    def test_run(self, runner: CliRunner) -> None:
+        job = Mock(id="my-job-id", url="https://huggingface.co/api/jobs/my-username/my-job-id")
+        with (
+            patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls,
+            patch("huggingface_hub.cli.jobs._get_extended_environ", return_value={}),
+        ):
+            api = api_cls.return_value
+            api.run_job.return_value = job
+            result = runner.invoke(app, ["jobs", "run", "--detach", "ubuntu", "echo", "hello"])
+        assert result.exit_code == 0
+        api.run_job.assert_called_once_with(
+            image="ubuntu",
+            command=["echo", "hello"],
+            env={},
+            secrets={},
+            flavor=None,
+            timeout=None,
+            namespace=None,
+        )
+        api.fetch_job_logs.assert_not_called()
 
-    @patch_httpx_post
-    @patch_whoami
-    def test_uv_command(self, whoami: Mock, httpx_post: Mock) -> None:
-        input_args = ["jobs", "uv", "run", "--detach", "echo", "hello"]
-        cmd = UvCommand(self.parser.parse_args(input_args))
-        cmd.run()
-        assert httpx_post.call_count == 1
-        args, kwargs = httpx_post.call_args_list[0]
-        assert args == ("https://huggingface.co/api/jobs/my-username",)
-        assert kwargs["json"] == {
-            "command": ["uv", "run", "echo", "hello"],
-            "arguments": [],
-            "environment": {},
-            "flavor": "cpu-basic",
-            "dockerImage": "ghcr.io/astral-sh/uv:python3.12-bookworm",
-        }
+    def test_create_scheduled_job(self, runner: CliRunner) -> None:
+        scheduled_job = Mock(id="my-job-id")
+        with (
+            patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls,
+            patch("huggingface_hub.cli.jobs._get_extended_environ", return_value={}),
+        ):
+            api = api_cls.return_value
+            api.create_scheduled_job.return_value = scheduled_job
+            result = runner.invoke(
+                app,
+                ["jobs", "scheduled", "run", "@hourly", "ubuntu", "echo", "hello"],
+            )
+        assert result.exit_code == 0
+        api.create_scheduled_job.assert_called_once_with(
+            image="ubuntu",
+            command=["echo", "hello"],
+            schedule="@hourly",
+            suspend=None,
+            concurrency=None,
+            env={},
+            secrets={},
+            flavor=None,
+            timeout=None,
+            namespace=None,
+        )
 
-    @patch_httpx_post
-    @patch_whoami
-    def test_uv_remote_script(self, whoami: Mock, httpx_post: Mock) -> None:
-        input_args = ["jobs", "uv", "run", "--detach", "https://.../script.py"]
-        cmd = UvCommand(self.parser.parse_args(input_args))
-        cmd.run()
-        assert httpx_post.call_count == 1
-        args, kwargs = httpx_post.call_args_list[0]
-        assert args == ("https://huggingface.co/api/jobs/my-username",)
-        assert kwargs["json"] == {
-            "command": ["uv", "run", "https://.../script.py"],
-            "arguments": [],
-            "environment": {},
-            "flavor": "cpu-basic",
-            "dockerImage": "ghcr.io/astral-sh/uv:python3.12-bookworm",
-        }
+    def test_uv_command(self, runner: CliRunner) -> None:
+        job = Mock(id="my-job-id", url="https://huggingface.co/api/jobs/my-username/my-job-id")
+        with (
+            patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls,
+            patch("huggingface_hub.cli.jobs._get_extended_environ", return_value={}),
+        ):
+            api = api_cls.return_value
+            api.run_uv_job.return_value = job
+            result = runner.invoke(app, ["jobs", "uv", "run", "--detach", "echo", "hello"])
+        assert result.exit_code == 0
+        api.run_uv_job.assert_called_once_with(
+            script="echo",
+            script_args=["hello"],
+            dependencies=None,
+            python=None,
+            image=None,
+            env={},
+            secrets={},
+            flavor=None,
+            timeout=None,
+            namespace=None,
+            _repo=None,
+        )
+        api.fetch_job_logs.assert_not_called()
 
-    @patch_httpx_post
-    @patch_whoami
-    @patch_get_token
-    @patch_repo_info
-    @patch_upload_file
-    def test_uv_local_script(
-        self, upload_file: Mock, repo_info: Mock, get_token: Mock, whoami: Mock, httpx_post: Mock
-    ) -> None:
-        input_args = ["jobs", "uv", "run", "--detach", __file__]
-        cmd = UvCommand(self.parser.parse_args(input_args))
-        cmd.run()
-        assert httpx_post.call_count == 1
-        args, kwargs = httpx_post.call_args_list[0]
-        assert args == ("https://huggingface.co/api/jobs/my-username",)
-        command = kwargs["json"].pop("command")
-        assert "UV_SCRIPT_URL" in " ".join(command)
-        assert kwargs["json"] == {
-            "arguments": [],
-            "environment": {
-                "UV_SCRIPT_URL": "https://hub-ci.huggingface.co/datasets/my-username/hf-cli-jobs-uv-run-scripts/resolve/ae068f/test_cli.py"
-            },
-            "secrets": {"UV_SCRIPT_HF_TOKEN": "hf_xxx"},
-            "flavor": "cpu-basic",
-            "dockerImage": "ghcr.io/astral-sh/uv:python3.12-bookworm",
-        }
-        assert repo_info.call_count == 1  # check if repo exists
-        assert upload_file.call_count == 2  # script and readme
+    def test_uv_remote_script(self, runner: CliRunner) -> None:
+        job = Mock(id="my-job-id", url="https://huggingface.co/api/jobs/my-username/my-job-id")
+        with (
+            patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls,
+            patch("huggingface_hub.cli.jobs._get_extended_environ", return_value={}),
+        ):
+            api = api_cls.return_value
+            api.run_uv_job.return_value = job
+            result = runner.invoke(app, ["jobs", "uv", "run", "--detach", "https://.../script.py"])
+        assert result.exit_code == 0
+        api.run_uv_job.assert_called_once_with(
+            script="https://.../script.py",
+            script_args=[],
+            dependencies=None,
+            python=None,
+            image=None,
+            env={},
+            secrets={},
+            flavor=None,
+            timeout=None,
+            namespace=None,
+            _repo=None,
+        )
+
+    def test_uv_local_script(self, runner: CliRunner, tmp_path: Path) -> None:
+        script_path = tmp_path / "script.py"
+        script_path.write_text("print('hello')")
+        job = Mock(id="my-job-id", url="https://huggingface.co/api/jobs/my-username/my-job-id")
+        with (
+            patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls,
+            patch("huggingface_hub.cli.jobs._get_extended_environ", return_value={}),
+            patch("huggingface_hub.cli.jobs.get_token", return_value="hf_xxx"),
+        ):
+            api = api_cls.return_value
+            api.run_uv_job.return_value = job
+            result = runner.invoke(app, ["jobs", "uv", "run", "--detach", str(script_path)])
+        assert result.exit_code == 0
+        api.run_uv_job.assert_called_once_with(
+            script=str(script_path),
+            script_args=[],
+            dependencies=None,
+            python=None,
+            image=None,
+            env={},
+            secrets={},
+            flavor=None,
+            timeout=None,
+            namespace=None,
+            _repo=None,
+        )
+        api.fetch_job_logs.assert_not_called()


### PR DESCRIPTION
the Typer migration was done in the `typer-migration `branch, which has been reviewed, approved and merged into `cli-improvements`. No need for this intermediate PR - we can merge directly into `v1.0-release` and then open PRs for the other CLI subjects from there 