### PR TITLE
update the `sentence_similarity` docstring (#3374)

### DIFF
--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -1613,7 +1613,7 @@ class InferenceClient:
                 Defaults to None.
 
         Returns:
-            `List[float]`: The embedding representing the input text.
+            `List[float]`: The similarity scores between the main sentence and the given comparison sentences.
 
         Raises:
             [`InferenceTimeoutError`]:

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -1663,7 +1663,7 @@ class AsyncInferenceClient:
                 Defaults to None.
 
         Returns:
-            `List[float]`: The embedding representing the input text.
+            `List[float]`: The similarity scores between the main sentence and the given comparison sentences.
 
         Raises:
             [`InferenceTimeoutError`]:


### PR DESCRIPTION
The following line in the docstring of `sentence_similarity` was misleading. This minimal PR updates it to reflect the actual purpose of the function. 

https://github.com/huggingface/huggingface_hub/blob/3b562cada2f031c7b265f9e0dd6ab9f7dad7f86e/src/huggingface_hub/inference/_client.py#L1631

Link to the issue: https://github.com/huggingface/huggingface_hub/issues/3374