### PR TITLE
Do not retry on 429 (only on 5xx)

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -267,7 +267,7 @@ def _request_wrapper(
     """Wrapper around requests methods to follow relative redirects if `follow_relative_redirects=True` even when
     `allow_redirection=False`.
 
-    A backoff mechanism retries the HTTP call on 429, 503 and 504 errors.
+    A backoff mechanism retries the HTTP call on 5xx errors and network errors.
 
     Args:
         method (`str`):
@@ -306,7 +306,7 @@ def _request_wrapper(
         return response
 
     # Perform request and return if status_code is not in the retry list.
-    response = http_backoff(method=method, url=url, **params, retry_on_exceptions=(), retry_on_status_codes=(429,))
+    response = http_backoff(method=method, url=url, **params, retry_on_status_codes=(500, 502, 503, 504))
     hf_raise_for_status(response)
     return response
 

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -306,7 +306,7 @@ def _request_wrapper(
         return response
 
     # Perform request and return if status_code is not in the retry list.
-    response = http_backoff(method=method, url=url, **params, retry_on_status_codes=(500, 502, 503, 504))
+    response = http_backoff(method=method, url=url, **params)
     hf_raise_for_status(response)
     return response
 

--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -958,13 +958,7 @@ class HfFileSystemFile(fsspec.spec.AbstractBufferedFile):
             repo_type=self.resolved_path.repo_type,
             endpoint=self.fs.endpoint,
         )
-        r = http_backoff(
-            "GET",
-            url,
-            headers=headers,
-            retry_on_status_codes=(500, 502, 503, 504),
-            timeout=constants.HF_HUB_DOWNLOAD_TIMEOUT,
-        )
+        r = http_backoff("GET", url, headers=headers, timeout=constants.HF_HUB_DOWNLOAD_TIMEOUT)
         hf_raise_for_status(r)
         return r.content
 
@@ -1063,7 +1057,6 @@ class HfFileSystemStreamFile(fsspec.spec.AbstractBufferedFile):
                 "GET",
                 url,
                 headers=self.fs._api._build_hf_headers(),
-                retry_on_status_codes=(500, 502, 503, 504),
                 stream=True,
                 timeout=constants.HF_HUB_DOWNLOAD_TIMEOUT,
             )
@@ -1086,7 +1079,6 @@ class HfFileSystemStreamFile(fsspec.spec.AbstractBufferedFile):
                 "GET",
                 url,
                 headers={"Range": "bytes=%d-" % self.loc, **self.fs._api._build_hf_headers()},
-                retry_on_status_codes=(500, 502, 503, 504),
                 stream=True,
                 timeout=constants.HF_HUB_DOWNLOAD_TIMEOUT,
             )

--- a/src/huggingface_hub/lfs.py
+++ b/src/huggingface_hub/lfs.py
@@ -316,7 +316,7 @@ def _upload_single_part(operation: "CommitOperationAdd", upload_url: str) -> Non
     """
     with operation.as_file(with_tqdm=True) as fileobj:
         # S3 might raise a transient 500 error -> let's retry if that happens
-        response = http_backoff("PUT", upload_url, data=fileobj, retry_on_status_codes=(500, 502, 503, 504))
+        response = http_backoff("PUT", upload_url, data=fileobj)
         hf_raise_for_status(response)
 
 
@@ -400,9 +400,7 @@ def _upload_parts_iteratively(
                 read_limit=chunk_size,
             ) as fileobj_slice:
                 # S3 might raise a transient 500 error -> let's retry if that happens
-                part_upload_res = http_backoff(
-                    "PUT", part_upload_url, data=fileobj_slice, retry_on_status_codes=(500, 502, 503, 504)
-                )
+                part_upload_res = http_backoff("PUT", part_upload_url, data=fileobj_slice)
                 hf_raise_for_status(part_upload_res)
                 headers.append(part_upload_res.headers)
     return headers  # type: ignore

--- a/src/huggingface_hub/utils/_http.py
+++ b/src/huggingface_hub/utils/_http.py
@@ -221,7 +221,7 @@ def http_backoff(
         requests.Timeout,
         requests.ConnectionError,
     ),
-    retry_on_status_codes: Union[int, Tuple[int, ...]] = HTTPStatus.SERVICE_UNAVAILABLE,
+    retry_on_status_codes: Union[int, Tuple[int, ...]] = (500, 502, 503, 504),
     **kwargs,
 ) -> Response:
     """Wrapper around requests to retry calls on an endpoint, with exponential backoff.
@@ -250,9 +250,8 @@ def http_backoff(
         retry_on_exceptions (`Type[Exception]` or `Tuple[Type[Exception]]`, *optional*):
             Define which exceptions must be caught to retry the request. Can be a single type or a tuple of types.
             By default, retry on `requests.Timeout` and `requests.ConnectionError`.
-        retry_on_status_codes (`int` or `Tuple[int]`, *optional*, defaults to `503`):
-            Define on which status codes the request must be retried. By default, only
-            HTTP 503 Service Unavailable is retried.
+        retry_on_status_codes (`int` or `Tuple[int]`, *optional*, defaults to `(500, 502, 503, 504)`):
+            Define on which status codes the request must be retried. By default, 5xx errors are retried.
         **kwargs (`dict`, *optional*):
             kwargs to pass to `requests.request`.
 

--- a/src/huggingface_hub/utils/_http.py
+++ b/src/huggingface_hub/utils/_http.py
@@ -21,7 +21,6 @@ import threading
 import time
 import uuid
 from functools import lru_cache
-from http import HTTPStatus
 from shlex import quote
 from typing import Any, Callable, List, Optional, Tuple, Type, Union
 


### PR DESCRIPTION
Partially reverting back https://github.com/huggingface/huggingface_hub/pull/2976.

This PR harmonizes the `http_backoff` default value in `huggingface_hub` by retrying on any 5xx error while downloading or fetching metadata for a file, but not on 429 rate limit error. Before this PR 5xx errors were retried when using `HfFileSystem` and `429` were retried when using `hf_hub_download`.

---

In https://github.com/huggingface/huggingface_hub/pull/2976, I've added a basic retry mechanism on 429 errors. It looks like this change coincides with a peak of 429-related issues been opened (https://github.com/huggingface/huggingface_hub/issues/3312, https://github.com/huggingface/huggingface_hub/issues/3201, https://github.com/huggingface/huggingface_hub/issues/3342). It looks like retrying on 429 error leads to being blocked for much longer, rather than solving anything. This PR won't solve all of the 429 errors but should at least streamline the user experience (i.e. fail fast + don't over-attempt). Note that in parallel to this client-side update, we are still working server-side to make the rate limits as smooth as possible while preserving our infra. 


