### PR TITLE
Make `HfHubHTTPError` error inherit from OSError

### DIFF
--- a/src/huggingface_hub/errors.py
+++ b/src/huggingface_hub/errors.py
@@ -37,7 +37,7 @@ class OfflineModeIsEnabled(ConnectionError):
     """Raised when a request is made but `HF_HUB_OFFLINE=1` is set as environment variable."""
 
 
-class HfHubHTTPError(HTTPError):
+class HfHubHTTPError(HTTPError, OSError):
     """
     HTTPError to inherit from for any custom HTTP Error raised in HF Hub.
 

--- a/tests/test_utils_errors.py
+++ b/tests/test_utils_errors.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import Mock
 
 import pytest
 from httpx import Request, Response
@@ -308,3 +309,9 @@ def test_repo_api_regex(url: str, should_match: bool) -> None:
         assert REPO_API_REGEX.match(url)
     else:
         assert REPO_API_REGEX.match(url) is None
+
+
+def test_hf_hub_http_error_inherits_from_os_error() -> None:
+    """Test HfHubHTTPError inherits from OSError."""
+    with pytest.raises(OSError):
+        raise HfHubHTTPError("this is a message", response=Mock())


### PR DESCRIPTION
Found out that `requests.HTTPError` inherits from `OSError` but `httpx.HTTPError` don't. This means that `HfHubHTTPError` do not inherit from `OSError` anymore which is a breaking change. This PR makes `HfHubHTTPError` inherit from it so that existing code don't break (happened at least once in `transformers`).

We could have also kept the breaking change and listed it in the migration guide but I don't think it's worth it. Issues caused by a failing `try ... except OSError ...` can be quite hard to locate so let's avoid that friction.