### PR TITLE
update CLI installers paths

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -22,13 +22,13 @@ Alternatively, you can install the `hf` CLI with a single command:
 On macOS and Linux:
 
 ```bash
->>> curl -LsSf https://hf.co/install.sh | sh
+>>> curl -LsSf https://hf.co/cli/install.sh | sh
 ```
 
 On Windows:
 
 ```powershell
->>> powershell -c "irm https://hf.co/install.ps1 | iex"
+>>> powershell -c "irm https://hf.co/cli/install.ps1 | iex"
 ```
 
 Once installed, you can check that the CLI is correctly setup:

--- a/docs/source/en/installation.md
+++ b/docs/source/en/installation.md
@@ -110,13 +110,13 @@ Use our one-liner installers to set up the `hf` CLI without touching your Python
 On macOS and Linux:
 
 ```bash
-curl -LsSf https://hf.co/install.sh | sh
+curl -LsSf https://hf.co/cli/install.sh | sh
 ```
 
 On Windows:
 
 ```powershell
-powershell -c "irm https://hf.co/install.ps1 | iex"
+powershell -c "irm https://hf.co/cli/install.ps1 | iex"
 ```
 
 ## Install with conda

--- a/utils/installers/install.ps1
+++ b/utils/installers/install.ps1
@@ -1,6 +1,6 @@
 # Hugging Face CLI Installer for Windows
-# Usage: powershell -c "irm https://hf.co/install.ps1 | iex"
-# Or: curl -LsSf https://hf.co/install.ps1 | pwsh -
+# Usage: powershell -c "irm https://hf.co/cli/install.ps1 | iex"
+# Or: curl -LsSf https://hf.co/cli/install.ps1 | pwsh -
 
 <#
 .SYNOPSIS
@@ -19,7 +19,7 @@ Enables verbose output, including detailed pip logs.
 Skips PATH modifications; `hf` must be invoked via its full path unless you add it manually.
 
 .EXAMPLE
-powershell -c "irm https://hf.co/install.ps1 | iex"
+powershell -c "irm https://hf.co/cli/install.ps1 | iex"
 #>
 
 <#

--- a/utils/installers/install.sh
+++ b/utils/installers/install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Hugging Face CLI Installer for Linux/MacOS
-# Usage: curl -LsSf https://hf.co/install.sh | sh -s -- [OPTIONS]
+# Usage: curl -LsSf https://hf.co/cli/install.sh | sh -s -- [OPTIONS]
 
 
 if [ -z "$BASH_VERSION" ]; then
@@ -87,7 +87,7 @@ run_command() {
 
 usage() {
     cat <<'EOF'
-Usage: curl -LsSf https://hf.co/install.sh | sh -s -- [OPTIONS]
+Usage: curl -LsSf https://hf.co/cli/install.sh | sh -s -- [OPTIONS]
 
 Options:
   --force           Recreate the Hugging Face CLI virtual environment if it exists


### PR DESCRIPTION
This PR updates the docs to cover adding `/cli` to the install scripts paths.