### PR TITLE
Correction to confusing error message on failing name validation.

### DIFF
--- a/src/huggingface_hub/utils/_validators.py
+++ b/src/huggingface_hub/utils/_validators.py
@@ -158,8 +158,8 @@ def validate_repo_id(repo_id: str) -> None:
 
     if not REPO_ID_REGEX.match(repo_id):
         raise HFValidationError(
-            "Repo id must use alphanumeric chars or '-', '_', '.', '--' and '..' are"
-            " forbidden, '-' and '.' cannot start or end the name, max length is 96:"
+            "Repo id must use alphanumeric chars, '-', '_' or '.'."
+            " The name cannot start or end with '-' or '.' and the maximum length is 96:"
             f" '{repo_id}'."
         )
 


### PR DESCRIPTION
"Repo id must use alphanumeric chars or '-', '_', '.', '--' and '..' are forbidden"

did not make sense.

This change will display a clear and correct message for the REGEX check being made. '--' / '..' is a later check.
