### PR TITLE
Add telemetry to CLI

### DIFF
--- a/src/huggingface_hub/cli/hf.py
+++ b/src/huggingface_hub/cli/hf.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 from huggingface_hub.cli._cli_utils import typer_factory
 from huggingface_hub.cli.auth import auth_cli
 from huggingface_hub.cli.cache import cache_cli


### PR DESCRIPTION
Using the existing `send_telemetry` utility, which is anonymous and thread-safe. 

If `HF_HUB_OFFLINE=1` or `HF_HUB_DISABLE_TELEMETRY=1` is set as environment variable, the telemetry is disabled.

Currently this is an opt-out option (as for other telemetry used in sub-libraries). Collected data doesn't contain any personal information (no user token, no local path, etc.). The only information is the command that has been typed without any options or arguments, e.g:

- `hf auth list` => collects `"hf/auth/list"`
- `hf download openai-community/gpt2` => collects `"hf/download"`
