### PR TITLE
use user name from whoami when setting git credential on login

### DIFF
--- a/src/huggingface_hub/utils/_git_credential.py
+++ b/src/huggingface_hub/utils/_git_credential.py
@@ -54,18 +54,18 @@ def list_credential_helpers(folder: Optional[str] = None) -> List[str]:
         raise EnvironmentError(exc.stderr)
 
 
-def set_git_credential(token: str, username: str = "hf_user", folder: Optional[str] = None) -> None:
+def set_git_credential(token: str, username: str, folder: Optional[str] = None) -> None:
     """Save a username/token pair in git credential for HF Hub registry.
 
     Credentials are saved in all configured helpers (store, cache, macOS keychain,...).
     Calls "`git credential approve`" internally. See https://git-scm.com/docs/git-credential.
 
     Args:
-        username (`str`, defaults to `"hf_user"`):
-            A git username. Defaults to `"hf_user"`, the default user used in the Hub.
-        token (`str`, defaults to `"hf_user"`):
+        token (`str`):
             A git password. In practice, the User Access Token for the Hub.
             See https://huggingface.co/settings/tokens.
+        username (`str`):
+            A git username.
         folder (`str`, *optional*):
             The folder in which to check the configured helpers.
     """
@@ -73,7 +73,7 @@ def set_git_credential(token: str, username: str = "hf_user", folder: Optional[s
         stdin,
         _,
     ):
-        stdin.write(f"url={ENDPOINT}\nusername={username.lower()}\npassword={token}\n\n")
+        stdin.write(f"url={ENDPOINT}\nusername={username}\npassword={token}\n\n")
         stdin.flush()
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -60,19 +60,20 @@ class TestSaveToken:
 class TestSetActiveToken:
     def test_set_active_token_success(self):
         _save_token(TOKEN, "test_token")
-        _set_active_token("test_token", add_to_git_credential=False)
+        _set_active_token("test_token", add_to_git_credential=False, user_name="test_user")
         assert _get_token_from_file() == TOKEN
 
     def test_set_active_token_non_existent(self):
         non_existent_token = "non_existent"
         with pytest.raises(ValueError, match="Token non_existent not found in .*"):
-            _set_active_token(non_existent_token, add_to_git_credential=False)
+            _set_active_token(non_existent_token, add_to_git_credential=False, user_name="non_existent_test_user")
 
 
 class TestLogin:
     @patch(
         "huggingface_hub.hf_api.whoami",
         return_value={
+            "name": "test_user",
             "auth": {
                 "accessToken": {
                     "displayName": "test_token",
@@ -92,7 +93,7 @@ class TestLogin:
 class TestLogout:
     def test_logout_deletes_files(self):
         _save_token(TOKEN, "test_token")
-        _set_active_token("test_token", add_to_git_credential=False)
+        _set_active_token("test_token", add_to_git_credential=False, user_name="test_user")
 
         assert os.path.exists(constants.HF_TOKEN_PATH)
         assert os.path.exists(constants.HF_STORED_TOKENS_PATH)
@@ -117,7 +118,7 @@ class TestLogout:
 
     def test_logout_active_token(self):
         _save_token(TOKEN, "active_token")
-        _set_active_token("active_token", add_to_git_credential=False)
+        _set_active_token("active_token", add_to_git_credential=False, user_name="active_test_user")
 
         logout("active_token")
 
@@ -133,7 +134,7 @@ class TestAuthSwitch:
         _save_token(TOKEN, "test_token_1")
         _save_token(OTHER_TOKEN, "test_token_2")
         # Set `test_token_1` as the active token
-        _set_active_token("test_token_1", add_to_git_credential=False)
+        _set_active_token("test_token_1", add_to_git_credential=False, user_name="test_user_1")
 
         # Switch to `test_token_2`
         auth_switch("test_token_2", add_to_git_credential=False)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -80,7 +80,7 @@ class TestLogin:
                     "role": "write",
                     "createdAt": "2024-01-01T00:00:00.000Z",
                 }
-            }
+            },
         },
     )
     def test_login_success(self, mock_whoami):

--- a/tests/test_auth_cli.py
+++ b/tests/test_auth_cli.py
@@ -38,6 +38,7 @@ def use_tmp_file_paths():
 @pytest.fixture
 def mock_whoami_api_call():
     MOCK_WHOAMI_RESPONSE = {
+        "name": "test_user",
         "auth": {
             "accessToken": {
                 "displayName": "test_token",
@@ -126,7 +127,7 @@ def test_logout_all_tokens(mock_stored_tokens, caplog: LogCaptureFixture):
     assert_in_logs(caplog, "Successfully logged out from all access tokens")
 
 
-def test_switch_token(mock_stored_tokens, caplog: LogCaptureFixture):
+def test_switch_token(mock_whoami_api_call, mock_stored_tokens, caplog: LogCaptureFixture):
     """Test switching between tokens."""
     caplog.set_level(logging.INFO)
 

--- a/tests/test_auth_cli.py
+++ b/tests/test_auth_cli.py
@@ -45,7 +45,7 @@ def mock_whoami_api_call():
                 "role": "write",
                 "createdAt": "2024-01-01T00:00:00.000Z",
             }
-        }
+        },
     }
     with patch("huggingface_hub.hf_api.whoami", return_value=MOCK_WHOAMI_RESPONSE):
         yield


### PR DESCRIPTION
There is a bug in the `hf auth login` path and the codepath following it to set the git credential where it is always using the username `hf-user` rather than the correct username that must be the username associated with the token for git credential to be used correctly.

This PR enforces that the username is fetched (through the whoami API) and is used when setting the git credentials

CC @seanses who helped find this bug while we were testing out git-xet.