### PR TITLE
Disable rich in CLI

### DIFF
--- a/src/huggingface_hub/cli/_cli_utils.py
+++ b/src/huggingface_hub/cli/_cli_utils.py
@@ -58,9 +58,12 @@ def typer_factory(help: str) -> typer.Typer:
     return typer.Typer(
         help=help,
         add_completion=True,
-        rich_markup_mode=None,
         no_args_is_help=True,
         cls=AlphabeticalMixedGroup,
+        # Disable rich completely for consistent experience
+        rich_markup_mode=None,
+        rich_help_panel=None,
+        pretty_exceptions_enable=False,
     )
 
 


### PR DESCRIPTION
Completely turn off `rich` formatting in CLI for consistency. This means `hf` cli offers the same UX no matter if `rich` is installed in local environment or not.