### PR TITLE
[HfFileSystem] minor fix

### DIFF
--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -445,7 +445,7 @@ class HfFileSystem(fsspec.AbstractFileSystem):
                     common_path_depth = common_path[len(path) :].count("/")
                     maxdepth -= common_path_depth
                 out = [o for o in out if not o["name"].startswith(common_path + "/")]
-                for cached_path in self.dircache:
+                for cached_path in list(self.dircache):
                     if cached_path.startswith(common_path + "/"):
                         self.dircache.pop(cached_path, None)
                 self.dircache.pop(common_path, None)


### PR DESCRIPTION
this could happen when listing a parent directory of an already explored directory:

```python
  File "/Users/quentinlhoest/.pyenv/versions/hf-datasets/lib/python3.12/site-packages/fsspec/spec.py", line 637, in glob
    allpaths = self.find(root, maxdepth=depth, withdirs=True, detail=True, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/quentinlhoest/hf/huggingface_hub/src/huggingface_hub/hf_file_system.py", line 567, in find
    out = self._ls_tree(
          ^^^^^^^^^^^^^^
  File "/Users/quentinlhoest/hf/huggingface_hub/src/huggingface_hub/hf_file_system.py", line 448, in _ls_tree
RuntimeError: dictionary changed size during iteration
``` 