### PR TITLE
Add uv support to installation scripts for faster package installation

### DIFF
--- a/utils/installers/install.sh
+++ b/utils/installers/install.sh
@@ -287,41 +287,39 @@ install_hf_hub() {
         log_info "Installing The Hugging Face CLI (latest)..."
     fi
 
+    local extra_pip_args="${HF_CLI_PIP_ARGS:-${HF_PIP_ARGS:-}}"
+    local verbose="${HF_CLI_VERBOSE_PIP:-}"
+
+    if [ -n "$extra_pip_args" ]; then
+        log_info "Passing extra arguments: $extra_pip_args"
+    fi
+
+    if [ "$verbose" != "1" ]; then
+        log_info "Installation output suppressed; set HF_CLI_VERBOSE_PIP=1 for full logs"
+    fi
+
     # Check if uv is available and use it for faster installation
     if command_exists uv; then
         log_info "Using uv for faster installation"
         local -a uv_flags
-        if [ "${HF_CLI_VERBOSE_PIP:-}" = "1" ]; then
-            uv_flags=()
-        else
+        if [ "$verbose" != "1" ]; then
             uv_flags=(--quiet)
+        else
+            uv_flags=()
         fi
 
-        run_command "Failed to install $package_spec" uv pip install --python "$VENV_DIR/bin/python" ${uv_flags[*]} "$package_spec"
+        # shellcheck disable=SC2086
+        run_command "Failed to install $package_spec" uv pip install --python "$VENV_DIR/bin/python" --upgrade ${uv_flags[*]} "$package_spec" $extra_pip_args
     else
-        local extra_pip_args="${HF_CLI_PIP_ARGS:-${HF_PIP_ARGS:-}}"
         local -a pip_flags
-        if [ "${HF_CLI_VERBOSE_PIP:-}" = "1" ]; then
-            pip_flags=()
-        else
+        if [ "$verbose" != "1" ]; then
             pip_flags=(--quiet --progress-bar off --disable-pip-version-check)
-        fi
-
-        if [ -n "$extra_pip_args" ]; then
-            log_info "Passing extra pip arguments: $extra_pip_args"
-        fi
-
-        if [ "${HF_CLI_VERBOSE_PIP:-}" != "1" ]; then
-            log_info "pip output suppressed; set HF_CLI_VERBOSE_PIP=1 for full logs"
-        fi
-
-        if [ -n "$extra_pip_args" ]; then
-            # shellcheck disable=SC2086
-            run_command "Failed to install $package_spec" "$VENV_DIR/bin/python" -m pip install --upgrade "$package_spec" ${pip_flags[*]} $extra_pip_args
         else
-            # shellcheck disable=SC2086
-            run_command "Failed to install $package_spec" "$VENV_DIR/bin/python" -m pip install --upgrade "$package_spec" ${pip_flags[*]}
+            pip_flags=()
         fi
+
+        # shellcheck disable=SC2086
+        run_command "Failed to install $package_spec" "$VENV_DIR/bin/python" -m pip install --upgrade "$package_spec" ${pip_flags[*]} $extra_pip_args
     fi
 }
 


### PR DESCRIPTION
## Summary
Adds support for the `uv` package manager to both Unix and Windows installation scripts, providing 10-100x faster package installation while maintaining full backwards compatibility with pip.

## Changes
- **Unix (install.sh)**: Added `ensure_uv()` function and uv-based venv/package installation
- **Windows (install.ps1)**: Added `Install-Uv` function and uv-based installation flow
- Both scripts gracefully fall back to pip if uv installation fails
- Added `--no-uv` flag (Unix) and `-NoUv` parameter (Windows) to explicitly use pip
- Added `HF_CLI_USE_UV` environment variable (defaults to `true`)

## Benefits
- Significantly faster installation times (10-100x speedup in package resolution and installation)
- Better dependency resolution
- Zero breaking changes - existing workflows continue to work
- Automatic fallback ensures reliability

## Testing
Tested on:
- ✅ Windows (local)
- ✅ Linux server (local)

Both platforms work correctly with uv enabled and fall back gracefully to pip when needed.

## Backwards Compatibility
- All existing flags, parameters, and environment variables work unchanged
- Users who don't have uv will automatically use pip
- Explicit opt-out available via `--no-uv` / `-NoUv` or environment variable