### PR TITLE
Adding Brand Assets Functionality

### DIFF
--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -257,3 +257,6 @@ HUGGINGFACE_HEADER_LINK_XET_AUTH_KEY = "xet-auth"
 default_xet_cache_path = os.path.join(HF_HOME, "xet")
 HF_XET_CACHE = os.getenv("HF_XET_CACHE", default_xet_cache_path)
 HF_HUB_DISABLE_XET: bool = _is_true(os.environ.get("HF_HUB_DISABLE_XET"))
+
+# Brand assets
+ASSET_REPO = "huggingface/brand-assets"

--- a/src/huggingface_hub/hf_assets.py
+++ b/src/huggingface_hub/hf_assets.py
@@ -1,0 +1,121 @@
+import re
+from typing import Dict, Optional
+
+from .constants import ASSET_REPO
+from .file_download import get_hf_file_metadata, hf_hub_url, hf_hub_download
+from .utils import validate_hf_hub_args
+
+
+def _get_brand_assets() -> Dict[str, Dict[str, str]]:
+    """Fetch and parse the list of brand assets from the huggingface/brand-assets repo.
+
+    Returns a dict where keys are asset names (e.g. "hf-logo") and values are dicts
+    mapping file extensions to filenames.
+    """
+    from .hf_api import HfApi
+
+    api = HfApi()
+    files = api.list_repo_files(ASSET_REPO, repo_type="dataset")
+
+    assets = {}
+    for filename in files:
+        if not filename or filename.startswith(".") or "/" in filename:
+            continue  # Skip hidden files, directories, etc.
+        match = re.match(r"^(.+)\.([a-z]+)$", filename)
+        if match:
+            name, ext = match.groups()
+            if ext in ("svg", "png", "ai"):
+                assets.setdefault(name, {})[ext] = filename
+    return assets
+
+
+@validate_hf_hub_args
+def list_brand_assets() -> Dict[str, Dict[str, str]]:
+    """List all available brand assets from the huggingface/brand-assets dataset.
+
+    Returns:
+        Dict[str, Dict[str, str]]: A dictionary where keys are asset names and values
+        are dictionaries mapping file extensions to filenames.
+
+    Example:
+        >>> from huggingface_hub import list_brand_assets
+        >>> assets = list_brand_assets()
+        >>> print(assets["hf-logo"])
+        {'svg': 'hf-logo.svg', 'png': 'hf-logo.png', 'ai': 'hf-logo.ai'}
+    """
+    return _get_brand_assets()
+
+
+def _pick_filename(name_or_filename: str, file_type: Optional[str]) -> str:
+    """Resolve an asset logical name and optional type to a filename in the asset repo.
+
+    Accepts either a logical asset key (e.g. "hf-logo") or a direct filename
+    (e.g. "hf-logo.svg"). If a type is provided it will be used when available.
+    """
+    # If the user passed an explicit filename, use it as-is
+    if "." in name_or_filename and name_or_filename.split(".")[-1] in ("svg", "png", "ai"):
+        return name_or_filename
+
+    assets = _get_brand_assets()
+    if name_or_filename not in assets:
+        raise ValueError(f"Unknown asset '{name_or_filename}'. Known keys: {sorted(assets.keys())}")
+
+    formats = assets[name_or_filename]
+    if file_type:
+        file_type = file_type.lower()
+        if file_type in formats:
+            return formats[file_type]
+
+    # Default preference order: svg, png, ai
+    for preferred in ("svg", "png", "ai"):
+        if preferred in formats:
+            return formats[preferred]
+
+    # As a last resort, return the first available file
+    return next(iter(formats.values()))
+
+
+def get_brand_asset_url(
+    name_or_filename: str, *, file_type: Optional[str] = None, revision: str = "main", token: Optional[str] = None, endpoint: Optional[str] = None
+) -> str:
+    """Return a final (possibly CDN-signed) URL for an asset hosted in the
+    `huggingface/brand-assets` dataset.
+
+    This builds the hub `resolve` URL and then performs a HEAD request to
+    retrieve the final `Location` (or the request URL) so callers get the
+    direct link they can use in HTML/CSS or pass to other tools.
+    """
+    filename = _pick_filename(name_or_filename, file_type)
+    url = hf_hub_url(repo_id=ASSET_REPO, filename=filename, repo_type="dataset", revision=revision, endpoint=endpoint)
+    meta = get_hf_file_metadata(url, token=token, endpoint=endpoint)
+    return meta.location
+
+
+def download_brand_asset(
+    name_or_filename: str,
+    *,
+    file_type: Optional[str] = None,
+    revision: str = "main",
+    token: Optional[str] = None,
+    repo_type: str = "dataset",
+    cache_dir: Optional[str] = None,
+    force_download: bool = False,
+):
+    """Download the requested brand asset into the local cache and return
+    the local path. This delegates to the existing `hf_hub_download` helper to
+    preserve the library's caching and authentication behavior.
+    """
+    filename = _pick_filename(name_or_filename, file_type)
+    # Delegate to hf_hub_download which implements caching and xet handling.
+    return hf_hub_download(
+        repo_id=ASSET_REPO,
+        filename=filename,
+        repo_type=repo_type,
+        revision=revision,
+        token=token,
+        force_download=force_download,
+        local_dir=cache_dir,
+    )
+
+
+__all__ = ["ASSET_REPO", "get_brand_asset_url", "download_brand_asset"]

--- a/tests/test_hf_assets.py
+++ b/tests/test_hf_assets.py
@@ -1,0 +1,188 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from huggingface_hub.hf_assets import (
+    _get_brand_assets,
+    _pick_filename,
+    list_brand_assets,
+    get_brand_asset_url,
+    download_brand_asset,
+    ASSET_REPO,
+)
+
+
+class HfAssetsListUnitTest(unittest.TestCase):
+    @patch("huggingface_hub.hf_api.HfApi")
+    def test_list_brand_assets_basic(self, mock_hf_api_class):
+        mock_api = Mock()
+        mock_hf_api_class.return_value = mock_api
+        mock_api.list_repo_files.return_value = [
+            "hf-logo.svg",
+            "hf-logo.png",
+            "hf-logo.ai",
+            "another-asset.svg",
+            ".hidden_file",
+            "folder/file.txt",
+            "invalid.ext",
+        ]
+
+        assets = list_brand_assets()
+
+        assert isinstance(assets, dict)
+        assert set(assets.keys()) == {"hf-logo", "another-asset"}
+        assert assets["hf-logo"] == {"svg": "hf-logo.svg", "png": "hf-logo.png", "ai": "hf-logo.ai"}
+        assert assets["another-asset"] == {"svg": "another-asset.svg"}
+
+        mock_hf_api_class.assert_called_once()
+        mock_api.list_repo_files.assert_called_once_with(ASSET_REPO, repo_type="dataset")
+
+
+class HfAssetsGetBrandAssetsUnitTest(unittest.TestCase):
+    @patch("huggingface_hub.hf_api.HfApi")
+    def test_get_brand_assets_filters_and_merges(self, mock_hf_api_class):
+        mock_api = Mock()
+        mock_hf_api_class.return_value = mock_api
+        mock_api.list_repo_files.return_value = [
+            "hf-logo.svg",
+            "hf-logo.png",
+            "hf-logo.ai",
+            "duplicate.svg",
+            "duplicate.png",
+            ".ignored.svg",
+            "dir/file.svg",
+            "not-an-asset.txt",
+        ]
+
+        assets = _get_brand_assets()
+
+        assert "hf-logo" in assets
+        assert assets["hf-logo"] == {"svg": "hf-logo.svg", "png": "hf-logo.png", "ai": "hf-logo.ai"}
+        assert ".ignored" not in assets
+        assert "dir" not in assets
+        assert "not-an-asset" not in assets
+        assert "duplicate" in assets
+        assert set(assets["duplicate"].keys()) == {"svg", "png"}
+
+
+class HfAssetsPickFilenameUnitTest(unittest.TestCase):
+    def test_explicit_filename_passthrough(self):
+        assert _pick_filename("hf-logo.svg", None) == "hf-logo.svg"
+        assert _pick_filename("hf-logo.png", None) == "hf-logo.png"
+        assert _pick_filename("hf-logo.ai", None) == "hf-logo.ai"
+
+    @patch("huggingface_hub.hf_assets._get_brand_assets")
+    def test_asset_name_default_preference_and_type(self, mock_get_assets):
+        mock_get_assets.return_value = {
+            "hf-logo": {"png": "hf-logo.png", "svg": "hf-logo.svg"},
+            "wordmark": {"ai": "wordmark.ai"},
+            "icon": {"png": "icon.png"},
+        }
+
+        assert _pick_filename("hf-logo", None) == "hf-logo.svg"
+        assert _pick_filename("icon", None) == "icon.png"
+        assert _pick_filename("wordmark", None) == "wordmark.ai"
+        assert _pick_filename("hf-logo", "png") == "hf-logo.png"
+        assert _pick_filename("hf-logo", "SVG") == "hf-logo.svg"
+
+        with self.assertRaises(ValueError):
+            _pick_filename("unknown", None)
+
+
+class HfAssetsUrlUnitTest(unittest.TestCase):
+    @patch("huggingface_hub.hf_assets.get_hf_file_metadata")
+    @patch("huggingface_hub.hf_assets.hf_hub_url")
+    @patch("huggingface_hub.hf_assets._pick_filename")
+    def test_get_brand_asset_url_resolves_redirect(self, mock_pick, mock_hub_url, mock_meta):
+        mock_pick.return_value = "hf-logo.svg"
+        mock_hub_url.return_value = "https://example.com/resolve/main/hf-logo.svg"
+        fake_meta = Mock()
+        fake_meta.location = "https://cdn.example.com/hf-logo.svg"
+        mock_meta.return_value = fake_meta
+
+        url = get_brand_asset_url(
+            "hf-logo",
+            file_type="svg",
+            revision="main",
+            token="fake_token",
+            endpoint="https://hub-ci.huggingface.co",
+        )
+
+        assert url == "https://cdn.example.com/hf-logo.svg"
+        mock_pick.assert_called_once_with("hf-logo", "svg")
+        mock_hub_url.assert_called_once_with(
+            repo_id=ASSET_REPO,
+            filename="hf-logo.svg",
+            repo_type="dataset",
+            revision="main",
+            endpoint="https://hub-ci.huggingface.co",
+        )
+        mock_meta.assert_called_once_with(
+            "https://example.com/resolve/main/hf-logo.svg",
+            token="fake_token",
+            endpoint="https://hub-ci.huggingface.co",
+        )
+
+
+class HfAssetsDownloadUnitTest(unittest.TestCase):
+    @patch("huggingface_hub.hf_assets.hf_hub_download")
+    @patch("huggingface_hub.hf_assets._pick_filename")
+    def test_download_brand_asset_delegates_to_hf_hub_download(self, mock_pick, mock_download):
+        mock_pick.return_value = "hf-logo.png"
+        mock_download.return_value = "/tmp/cache/hf-logo.png"
+
+        path = download_brand_asset(
+            "hf-logo",
+            file_type="png",
+            revision="v1",
+            token="token",
+            repo_type="dataset",
+            cache_dir="/tmp/cache",
+            force_download=True,
+        )
+
+        assert path == "/tmp/cache/hf-logo.png"
+        mock_pick.assert_called_once_with("hf-logo", "png")
+        mock_download.assert_called_once_with(
+            repo_id=ASSET_REPO,
+            filename="hf-logo.png",
+            repo_type="dataset",
+            revision="v1",
+            token="token",
+            force_download=True,
+            local_dir="/tmp/cache",
+        )
+
+
+class HfAssetsProductionTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        pass
+
+    def test_list_brand_assets_overview(self) -> None:
+        assets = list_brand_assets()
+        assert isinstance(assets, dict)
+        assert "hf-logo" in assets
+        assert "svg" in assets["hf-logo"]
+        assert assets["hf-logo"]["svg"].endswith(".svg")
+
+    def test_get_asset_url_svg(self) -> None:
+        url = get_brand_asset_url("hf-logo", file_type="svg")
+        assert isinstance(url, str)
+        assert url.startswith("http")
+        assert "hf-logo.svg" in url
+
+    def test_download_png(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            path = download_brand_asset("hf-logo", file_type="png", cache_dir=d)
+            p = Path(path)
+            assert p.exists()
+            assert p.stat().st_size > 0
+            assert p.name.endswith(".png")
+            assert str(p).startswith(d)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# **Problem:**  
Currently, the `huggingface_hub` library does not provide an easy way to access brand assets (logos, etc.) from the `huggingface/brand-assets` dataset. Users must know the exact URL. This complicates integration for developers who want to use these assets in their applications or websites.

# **Summary:**  
I created a new module `hf_assets.py` in huggingface_hub to handle brand assets. This module includes functions to list available assets, resolve asset names to final URLs, and download files locally.  

I chose to place it in a separate file rather than integrating directly into `hf_api.py` for several reasons:  
- **Separation of concerns**: `hf_api.py` is already large and primarily handles Hub API interactions (models, datasets, etc.). Assets are a more specialized feature.  
- **Future support for static files**: By keeping this module separate, it will be easier to add functionalities for serving these assets as static file, without cluttering the main API code.  
- **Maintainability**: This allows independent evolution of the assets module without impacting other parts of the library.  

Tell me if you want me to put it in hf_api.

Main functions added:  
- `list_brand_assets()`: Lists all assets with their available formats.  
- `get_brand_asset_url()`: Returns the final URL (with redirect : xethub) for a given asset.  
- `download_brand_asset()`: Downloads an asset. 
- Internal functions for parsing and resolving asset names.  

# **Testing:**  
I created a test file test_hf_assets.py with unit and production tests:  
- **Unit tests**: Mock API calls to verify logic (parsing, resolution, dependency calls).  
- **Production tests**: Real tests against the Hub API to validate behavior in real conditions (asset listing, downloading, URL resolution).  

