### PR TITLE
Fix some outdated docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ pip install huggingface_hub
 
 If you prefer, you can also install it with [conda](https://huggingface.co/docs/huggingface_hub/en/installation#install-with-conda).
 
-In order to keep the package minimal by default, `huggingface_hub` comes with optional dependencies useful for some use cases. For example, if you want have a complete experience for Inference, run:
+In order to keep the package minimal by default, `huggingface_hub` comes with optional dependencies useful for some use cases. For example, if you want to use the MCP module, run:
 
 ```bash
-pip install "huggingface_hub[inference]"
+pip install "huggingface_hub[mcp]"
 ```
 
 To learn more installation and optional dependencies, check out the [installation guide](https://huggingface.co/docs/huggingface_hub/en/installation).

--- a/docs/source/en/guides/inference.md
+++ b/docs/source/en/guides/inference.md
@@ -389,17 +389,7 @@ print(completion.choices[0].message)
 
 ## Async client
 
-An async version of the client is also provided, based on `asyncio` and `aiohttp`. You can either install `aiohttp`
-directly or use the `[inference]` extra:
-
-```sh
-pip install --upgrade huggingface_hub[inference]
-# or
-# pip install aiohttp
-```
-
-After installation all async API endpoints are available via [`AsyncInferenceClient`]. Its initialization and APIs are
-strictly the same as the sync-only version.
+An async version of the client is also provided, based on `asyncio` and `httpx`. All async API endpoints are available via [`AsyncInferenceClient`]. Its initialization and APIs are strictly the same as the sync-only version.
 
 ```py
 # Code must be run in an asyncio concurrent context.

--- a/docs/source/en/package_reference/inference_client.md
+++ b/docs/source/en/package_reference/inference_client.md
@@ -20,14 +20,7 @@ for more information on how to use it.
 
 ## Async Inference Client
 
-An async version of the client is also provided, based on `asyncio` and `aiohttp`.
-To use it, you can either install `aiohttp` directly or use the `[inference]` extra:
-
-```sh
-pip install --upgrade huggingface_hub[inference]
-# or
-# pip install aiohttp
-```
+An async version of the client is also provided, based on `asyncio` and `httpx`.
 
 [[autodoc]] AsyncInferenceClient
 

--- a/i18n/README_fr.md
+++ b/i18n/README_fr.md
@@ -62,10 +62,10 @@ pip install huggingface_hub
 
 Si vous préférez, vous pouvez aussi l’installer avec [conda](https://huggingface.co/docs/huggingface_hub/en/installation#install-with-conda).
 
-Afin de garder le paquet minimal par défaut, `huggingface_hub` vient avec des dépendances optionnelles utiles pour certains cas d’usage. Par exemple, si vous voulez faire de l’inférence, exécutez :
+Afin de garder le paquet minimal par défaut, `huggingface_hub` vient avec des dépendances optionnelles utiles pour certains cas d’usage. Par exemple, si vous voulez utiliser le module MCP, exécutez :
 
 ```bash
-pip install "huggingface_hub[inference]"
+pip install "huggingface_hub[mcp]"
 ```
 
 Pour en savoir plus sur l'installation et les dépendances optionnelles, consultez le [guide d’installation](https://huggingface.co/docs/huggingface_hub/en/installation).

--- a/setup.py
+++ b/setup.py
@@ -47,10 +47,7 @@ extras["fastai"] = [
 
 extras["hf_xet"] = ["hf-xet>=1.1.3,<2.0.0"]
 
-extras["mcp"] = [
-    "mcp>=1.8.0",
-    "typer",
-]
+extras["mcp"] = ["mcp>=1.8.0"]
 
 extras["testing"] = (
     extras["oauth"]

--- a/utils/generate_async_inference_client.py
+++ b/utils/generate_async_inference_client.py
@@ -150,15 +150,6 @@ def _add_imports(code: str) -> str:
         flags=re.DOTALL,
     )
 
-    # type-checking imports
-    code = re.sub(
-        r"(\nif TYPE_CHECKING:\n)",
-        repl=r"\1    from aiohttp import ClientResponse, ClientSession\n",
-        string=code,
-        count=1,
-        flags=re.DOTALL,
-    )
-
     return code
 
 


### PR DESCRIPTION
This PR fixes some minor things:
- highlight `huggingface_hub[mcp]` instead of `huggingface_hub[inference]` in README since inference extra has been removed
- do not mention installing `aiohttp` for AsyncInferenceClient
- remove `typer` from `[mcp]` extra deps (since typer is a required dep now)
- remove useless aiohttp-related command in async client generation script