### PR TITLE
Add HfApi.list_organization_datasets() to list organization datasets

### DIFF
--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -4198,6 +4198,12 @@ class UserApiTest(unittest.TestCase):
         assert first_follower.fullname
         assert first_follower.avatar_url
 
+    def test_list_organization_datasets(self) -> None:
+        datasets = list(self.api.list_organization_datasets("openai", sort="downloads", search="gsm"))
+        assert isinstance(datasets, list)
+        if datasets:
+            assert hasattr(datasets[0], "id")
+
     def test_user_followers(self) -> None:
         followers = self.api.list_user_followers("clem")
         assert len(list(followers)) > 500


### PR DESCRIPTION
# Problem :

There was no function to list datasets from an organization on the Hub.

# Summary :

Add HfApi.list_organization_datasets who calls /api/organizations/{organization}/datasets-json
Add a test to check the endpoint returns DatasetInfo objects.

#  Testing :

pytest -q tests/test_hf_api.py::UserApiTest::test_list_organization_datasets