### PR TITLE
Add HfApi.list_organization_spaces() to list organization spaces

### DIFF
--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -4198,6 +4198,12 @@ class UserApiTest(unittest.TestCase):
         assert first_follower.fullname
         assert first_follower.avatar_url
 
+    def test_list_organization_spaces(self) -> None:
+        spaces = list(self.api.list_organization_spaces("openai", sort="likes", search="whisper"))
+        assert isinstance(spaces, list)
+        if spaces:
+            assert hasattr(spaces[0], "id")
+
     def test_user_followers(self) -> None:
         followers = self.api.list_user_followers("clem")
         assert len(list(followers)) > 500


### PR DESCRIPTION
# Problem

There was no function to list spaces from an organization on the Hub.

# Summary

Add HfApi.list_organization_spaces who calls /api/organizations/{organization}/spaces-json
Add a test to check the endpoint returns SpaceInfo objects.

# Testing
pytest -q tests/test_hf_api.py::UserApiTest::test_list_organization_spaces