### PR TITLE
Close HTTP sessions on fork

### DIFF
--- a/src/huggingface_hub/utils/_http.py
+++ b/src/huggingface_hub/utils/_http.py
@@ -247,7 +247,6 @@ def close_session() -> None:
 atexit.register(close_session)
 if hasattr(os, "register_at_fork"):
     os.register_at_fork(after_in_child=close_session)
-    os.register_at_fork(after_in_parent=close_session)
 
 
 def _http_backoff_base(


### PR DESCRIPTION
Related to internal issue (discussed in [internal slack](https://huggingface.slack.com/archives/C043JTYE1MJ/p1761816462510269)). It seems that forking a `httpx.Client` might have some weird side effects (causing a `'[SSL: WRONG_VERSION_NUMBER] wrong version number (_ssl.c:2580)'`). Solution is to set a callback to close the global HTTP session in the child fork at fork creation.

cc @lhoestq @andimarafioti 