### PR TITLE
[CLI] make installer `zsh` compatible

### DIFF
--- a/utils/installers/install.sh
+++ b/utils/installers/install.sh
@@ -5,7 +5,7 @@
 
 if [ -z "$BASH_VERSION" ]; then
     if command -v bash >/dev/null 2>&1; then
-        if [ -f "$0" ] && [ "$0" != "sh" ]; then
+        if [ -f "$0" ] && [ "$0" != "sh" ] && [ "$0" != "bash" ]; then
             exec bash "$0" "$@"
         else
             tmp_dir=$(mktemp -d 2>/dev/null || mktemp -d -t hf-cli-install)
@@ -13,12 +13,13 @@ if [ -z "$BASH_VERSION" ]; then
             cat >"$tmp_script"
             chmod +x "$tmp_script"
             bash "$tmp_script" "$@"
-            status=$?
+            exit_code=$?
             rm -rf "$tmp_dir"
-            exit $status
+            exit $exit_code
         fi
     else
         echo "[ERROR] bash is required to run this installer." >&2
+        echo "[ERROR] Please run: curl -LsSf https://hf.co/cli/install.sh | bash" >&2
         exit 1
     fi
 fi
@@ -299,7 +300,7 @@ install_hf_hub() {
     fi
 
     if [ "${HF_CLI_VERBOSE_PIP:-}" != "1" ]; then
-        log_info "(pip output suppressed; set HF_CLI_VERBOSE_PIP=1 for full logs)"
+        log_info "pip output suppressed; set HF_CLI_VERBOSE_PIP=1 for full logs"
     fi
 
     if [ -n "$extra_pip_args" ]; then


### PR DESCRIPTION
follow-up PR to https://github.com/huggingface/huggingface_hub/pull/3498.

when running the installer with `zsh` (`curl ... | zsh`), a user can encounter an error: `zsh: read-only variable: status`.

This happened because `status` is a read only variable in `zsh` that contains the exit status of the last command. the installer script was attempting to assign to `status` to capture the exit code from the bash reexecution, which caused zsh to error.
The installer should work now with all common shells:

```bash
cat utils/installers/install.sh | bash -s -- --no-modify-path
cat utils/installers/iinstall.sh | zsh -s -- --no-modify-path  
cat utils/installers/iinstall.sh | sh -s -- --no-modify-path
```
