### PR TITLE
[Internal] Fix quality issue generated from `update-inference-types` workflow

### DIFF
--- a/utils/generate_inference_types.py
+++ b/utils/generate_inference_types.py
@@ -354,7 +354,7 @@ def check_inference_types(update: bool) -> NoReturn:
     for file in INFERENCE_TYPES_FOLDER_PATH.glob("*.py"):
         if file.name in IGNORE_FILES:
             continue
-        content = file.read_text().lstrip("\r\n")
+        content = file.read_text().lstrip()
         content = _clean_deprecated_fields(content)
         fixed_content = fix_inference_classes(content, module_name=file.stem)
         fixed_content = fix_legacy_annotation(fixed_content)


### PR DESCRIPTION
this should fix the linting issue generated from #3506.

the issue comes from the `huggingface.js` generate script that adds an empty line at the top of each file it creates. most task files also have a `from typing ... import` right after that blank line and duuring formatting, this import makes the blank line disappear. the `zero_shot_object_detection` task doesn't need that typing import, it only has from `.base ....` with no typing import there to "hide" the blank line, so the empty line stays visible and the quality check fails. 

the simplest fix (i think) is to strip any empty lines at the start of each generated file.