### PR TITLE
Multi-threaded snapshot download

### DIFF
--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -403,21 +403,14 @@ def snapshot_download(
             )
         )
 
-    if constants.HF_XET_HIGH_PERFORMANCE and not dry_run:
-        # when using hf_xet high performance we don't want extra parallelism
-        # from the one hf_xet provides
-        # TODO: revisit this when xet_session is implemented
-        for file in filtered_repo_files:
-            _inner_hf_hub_download(file)
-    else:
-        thread_map(
-            _inner_hf_hub_download,
-            filtered_repo_files,
-            desc=tqdm_desc,
-            max_workers=max_workers,
-            # User can use its own tqdm class or the default one from `huggingface_hub.utils`
-            tqdm_class=tqdm_class or hf_tqdm,
-        )
+    thread_map(
+        _inner_hf_hub_download,
+        filtered_repo_files,
+        desc=tqdm_desc,
+        max_workers=max_workers,
+        # User can use its own tqdm class or the default one from `huggingface_hub.utils`
+        tqdm_class=tqdm_class or hf_tqdm,
+    )
 
     if dry_run:
         assert all(isinstance(r, DryRunFileInfo) for r in results)


### PR DESCRIPTION
This PR makes `snapshot_download` download files in parallel all the time. Previously we were not doing it if `HF_XET_HIGH_PERFORMANCE=1` was set as environment variable. Goal was to avoid bloating the CPU if Xet starts N threads for each of the X files being downloaded in parallel. We had a similar logic for `hf_transfer`.  However after some discussions on [slack](https://huggingface.slack.com/archives/C087TU2FE3G/p1761668163517069?thread_ts=1745339023.634149&cid=C087TU2FE3G) (private) and following [this gist](https://gist.github.com/Wauplin/46fb6a379cae81714ad67c26cac5286f), it turns out that `hf_xet` is doing things much more carefully than `hf_transfer` by reusing the same pool of connections no matter the number of parallel calls. This means that even if `snapshot_download` starts N threads, they will all share the same Xet resources without freezing the user's machine.

Hence this PR. 


----

### Quick benchmark (not a scientific one^^):

```
HF_XET_HIGH_PERFORMANCE=1 hf download Agent-Ark/Toucan-1.5M
```

**On `main`:** 7'20

**On this PR:** 3'50
