### PR TITLE
Add `huggingface_hub` as dependency for `hf`

### DIFF
--- a/utils/hf/setup.py
+++ b/utils/hf/setup.py
@@ -14,16 +14,7 @@ def get_version() -> str:
 
 
 install_requires = [
-    "filelock",
-    "fsspec>=2023.5.0",
-    "hf-xet>=1.2.0,<2.0.0; platform_machine=='x86_64' or platform_machine=='amd64' or platform_machine=='AMD64' or platform_machine=='arm64' or platform_machine=='aarch64'",
-    "httpx>=0.23.0, <1",
-    "packaging>=20.9",
-    "pyyaml>=5.1",
-    "shellingham",
-    "tqdm>=4.42.1",
-    "typer-slim",
-    "typing-extensions>=3.7.4.3",  # to be able to import TypeAlias
+    f"huggingface_hub=={get_version()}",
 ]
 
 setup(


### PR DESCRIPTION
Thanks @hanouticelina for finding the fix!

Currently the `hf` CLI fails with

```sh
➜  ~ uvx hf version
Installed 19 packages in 3ms
Traceback (most recent call last):
  File "/home/wauplin/.cache/uv/archive-v0/KsiEG5CUPfFzLpsf5KBJr/bin/hf", line 6, in <module>
    from huggingface_hub.cli.hf import main
ModuleNotFoundError: No module named 'huggingface_hub'
```

To be shipped in `v1.1.1`.