### PR TITLE
Avoid redundant call to the Xet connection info URL

### DIFF
--- a/src/huggingface_hub/utils/_xet.py
+++ b/src/huggingface_hub/utils/_xet.py
@@ -208,8 +208,8 @@ def _fetch_xet_connection_info_with_url(
         raise ValueError("Xet headers have not been correctly set by the server.")
 
     # Delete expired cache entries
-    for k in list(XET_CONNECTION_INFO_CACHE.keys()):
-        if _is_expired(XET_CONNECTION_INFO_CACHE[k]):
+    for k, v in list(XET_CONNECTION_INFO_CACHE.items()):
+        if _is_expired(v):
             XET_CONNECTION_INFO_CACHE.pop(k, None)
 
     # Enforce cache size limit


### PR DESCRIPTION
Xet uses JWT to download from the CAS. We currently fetch this from the Hub for each and every file that we download (when using `snapshot_download`). This leads to a lot of unnecessary calls and user might end up being rate-limited. 

This PR fixes this issue by implementing a cache. Implementation is inspired by the JS client ([here](https://github.com/huggingface/huggingface.js/blob/main/packages/hub/src/utils/XetBlob.ts#L515-L530) and [here](https://github.com/huggingface/huggingface.js/blob/main/packages/hub/src/utils/XetBlob.ts#L528)). We return the cached JWT if it exists and is not expired (with a 60s safety period to avoid conflicts). We cache a maximum of 1000 keys at a time.

Related to [internal slack thread](https://huggingface.slack.com/archives/C02EMARJ65P/p1762509617301099) cc @coyotte508 @rajatarya @assafvayner @bpronan for viz'