### PR TITLE
Paginated results when listing user access requests

### DIFF
--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -4095,18 +4095,18 @@ class AccessRequestAPITest(HfApiCommonTest):
 
     def test_access_requests_normal_usage(self) -> None:
         # No access requests initially
-        requests = self._api.list_accepted_access_requests(self.repo_id)
+        requests = list(self._api.list_accepted_access_requests(self.repo_id))
         assert len(requests) == 0
-        requests = self._api.list_pending_access_requests(self.repo_id)
+        requests = list(self._api.list_pending_access_requests(self.repo_id))
         assert len(requests) == 0
-        requests = self._api.list_rejected_access_requests(self.repo_id)
+        requests = list(self._api.list_rejected_access_requests(self.repo_id))
         assert len(requests) == 0
 
         # Grant access to a user
         self._api.grant_access(self.repo_id, OTHER_USER)
 
         # User is in accepted list
-        requests = self._api.list_accepted_access_requests(self.repo_id)
+        requests = list(self._api.list_accepted_access_requests(self.repo_id))
         assert len(requests) == 1
         request = requests[0]
         assert isinstance(request, AccessRequest)
@@ -4117,23 +4117,23 @@ class AccessRequestAPITest(HfApiCommonTest):
 
         # Cancel access
         self._api.cancel_access_request(self.repo_id, OTHER_USER)
-        requests = self._api.list_accepted_access_requests(self.repo_id)
+        requests = list(self._api.list_accepted_access_requests(self.repo_id))
         assert len(requests) == 0  # not accepted anymore
-        requests = self._api.list_pending_access_requests(self.repo_id)
+        requests = list(self._api.list_pending_access_requests(self.repo_id))
         assert len(requests) == 1
         assert requests[0].username == OTHER_USER
 
         # Reject access
         self._api.reject_access_request(self.repo_id, OTHER_USER, rejection_reason="This is a rejection reason")
-        requests = self._api.list_pending_access_requests(self.repo_id)
+        requests = list(self._api.list_pending_access_requests(self.repo_id))
         assert len(requests) == 0  # not pending anymore
-        requests = self._api.list_rejected_access_requests(self.repo_id)
+        requests = list(self._api.list_rejected_access_requests(self.repo_id))
         assert len(requests) == 1
         assert requests[0].username == OTHER_USER
 
         # Accept again
         self._api.accept_access_request(self.repo_id, OTHER_USER)
-        requests = self._api.list_accepted_access_requests(self.repo_id)
+        requests = list(self._api.list_accepted_access_requests(self.repo_id))
         assert len(requests) == 1
         assert requests[0].username == OTHER_USER
 


### PR DESCRIPTION
Listing user access requests recurrently returns a list. However the backend API is soon to be introducing paginated results due to large number of requests for some repos resulting in memory/cpu peaks (see [internal PR](https://github.com/huggingface-internal/moon-landing/pull/15670)).

This PR updates the `list_pending_access_requests`, `list_accepted_access_requests`, and `list_rejected_access_requests` methods to return an iterator instead of a list. This allows us to lazy load requests from paginated results.

:warning: **Warning:** this is a breaking change! Not great but hopefully these methods are not much used. Let's proactively contact teams we know are using them.


cc @Kakulukian @Pierrci 