### PR TITLE
(patch): return entire list

### DIFF
--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -1710,7 +1710,7 @@ class InferenceClient:
             api_key=self.token,
         )
         response = self._inner_post(request_parameters)
-        return SummarizationOutput.parse_obj_as_list(response)[0]
+        return SummarizationOutput.parse_obj_as_list(response)
 
     def table_question_answering(
         self,
@@ -3033,7 +3033,7 @@ class InferenceClient:
             api_key=self.token,
         )
         response = self._inner_post(request_parameters)
-        return TranslationOutput.parse_obj_as_list(response)[0]
+        return TranslationOutput.parse_obj_as_list(response)
 
     def visual_question_answering(
         self,

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -1748,7 +1748,7 @@ class AsyncInferenceClient:
             api_key=self.token,
         )
         response = await self._inner_post(request_parameters)
-        return SummarizationOutput.parse_obj_as_list(response)[0]
+        return SummarizationOutput.parse_obj_as_list(response)
 
     async def table_question_answering(
         self,
@@ -1977,7 +1977,7 @@ class AsyncInferenceClient:
             api_key=self.token,
         )
         response = await self._inner_post(request_parameters)
-        return TextClassificationOutputElement.parse_obj_as_list(response)[0]  # type: ignore [return-value]
+        return TextClassificationOutputElement.parse_obj_as_list(response)  # type: ignore [return-value]
 
     @overload
     async def text_generation(


### PR DESCRIPTION
Issue reported by a user. Calling text classification like so:

```python
        result = client.text_classification(
            text="I love this product! It works great and exceeded my expectations",
            model=model,
            top_k=2,
        )
```
returns only 1 result despite setting `top_k` to 2. I think top_k is sent in correctly but the result is truncated to return only the first result.

I notice that a few other tasks had the same pattern so I omitted the `[0]` as well.

Note that I'm not 100% sure that this is the correct fix, especially since the async client is auto generated. Maybe you would prefer not to edit it directly? 

Lemme know 🙌