### PR TITLE
[Inference] Let's use lowercase left/right truncation direction parameter

### DIFF
--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -1029,7 +1029,7 @@ class InferenceClient:
         normalize: Optional[bool] = None,
         prompt_name: Optional[str] = None,
         truncate: Optional[bool] = None,
-        truncation_direction: Optional[Literal["Left", "Right"]] = None,
+        truncation_direction: Optional[Literal["left", "right"]] = None,
         model: Optional[str] = None,
     ) -> "np.ndarray":
         """
@@ -1054,7 +1054,7 @@ class InferenceClient:
             truncate (`bool`, *optional*):
                 Whether to truncate the embeddings or not.
                 Only available on server powered by Text-Embedding-Inference.
-            truncation_direction (`Literal["Left", "Right"]`, *optional*):
+            truncation_direction (`Literal["left", "right"]`, *optional*):
                 Which side of the input should be truncated when `truncate=True` is passed.
 
         Returns:

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -1056,7 +1056,7 @@ class AsyncInferenceClient:
         normalize: Optional[bool] = None,
         prompt_name: Optional[str] = None,
         truncate: Optional[bool] = None,
-        truncation_direction: Optional[Literal["Left", "Right"]] = None,
+        truncation_direction: Optional[Literal["left", "right"]] = None,
         model: Optional[str] = None,
     ) -> "np.ndarray":
         """
@@ -1081,7 +1081,7 @@ class AsyncInferenceClient:
             truncate (`bool`, *optional*):
                 Whether to truncate the embeddings or not.
                 Only available on server powered by Text-Embedding-Inference.
-            truncation_direction (`Literal["Left", "Right"]`, *optional*):
+            truncation_direction (`Literal["left", "right"]`, *optional*):
                 Which side of the input should be truncated when `truncate=True` is passed.
 
         Returns:

--- a/src/huggingface_hub/inference/_generated/types/feature_extraction.py
+++ b/src/huggingface_hub/inference/_generated/types/feature_extraction.py
@@ -8,7 +8,7 @@ from typing import Literal, Optional, Union
 from .base import BaseInferenceType, dataclass_with_extra
 
 
-FeatureExtractionInputTruncationDirection = Literal["Left", "Right"]
+FeatureExtractionInputTruncationDirection = Literal["left", "right"]
 
 
 @dataclass_with_extra


### PR DESCRIPTION
Counterpart of https://github.com/huggingface/huggingface.js/pull/1841 (related to [internal slack thread](https://huggingface.slack.com/archives/C064Z3GRU3U/p1762871481747849?thread_ts=1743434022.621759&cid=C064Z3GRU3U)).

The `FeatureExtractionInputTruncationDirection` parameter defined in the feature-extraction specs currently have capitalized values Left / Right. This comes from TEI implementation from which we pulled the specs. Let's switch it to lowercase values for consistency with all other specs.