### PR TITLE
[CLI] Respect `HF_DEBUG` environment variable

### DIFF
--- a/src/huggingface_hub/cli/hf.py
+++ b/src/huggingface_hub/cli/hf.py
@@ -53,7 +53,7 @@ app.add_typer(ie_cli, name="endpoints")
 
 def main():
     if not constants.HF_DEBUG:
-        logging.set_verbosity_info()        
+        logging.set_verbosity_info()
     check_cli_update()
     app()
 


### PR DESCRIPTION
Previously, `logging.set_verbosity_info()` was called unconditionally in the CLI entry point, this had the side effect of overriding the logging level to `INFO`, even if `HF_DEBUG` was set to 1. This PR fixes that. 