### PR TITLE
decrease number of files before falling back to `list_repo_tree` in `snapshot_download`

### DIFF
--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -23,7 +23,7 @@ from .utils import tqdm as hf_tqdm
 
 logger = logging.get_logger(__name__)
 
-VERY_LARGE_REPO_THRESHOLD = 1000  # After this limit, we don't consider `repo_info.siblings` to be reliable enough
+LARGE_REPO_THRESHOLD = 1000  # After this limit, we don't consider `repo_info.siblings` to be reliable enough
 
 
 @overload
@@ -335,9 +335,7 @@ def snapshot_download(
     # In that case, we need to use the `list_repo_tree` method to prevent caching issues.
     repo_files: Iterable[str] = [f.rfilename for f in repo_info.siblings] if repo_info.siblings is not None else []
     unreliable_nb_files = (
-        repo_info.siblings is None
-        or len(repo_info.siblings) == 0
-        or len(repo_info.siblings) > VERY_LARGE_REPO_THRESHOLD
+        repo_info.siblings is None or len(repo_info.siblings) == 0 or len(repo_info.siblings) > LARGE_REPO_THRESHOLD
     )
     if unreliable_nb_files:
         logger.info(


### PR DESCRIPTION
follow-up PR after #3122.
Discussed through DMs with @Wauplin, we think the current `VERY_LARGE_REPO_THRESHOLD` (50000) is maybe a bit too optimistic. the Hub may truncate the siblings list well before 50k files when server-side caching issues happen. This PR fixes the threshold to 1000 to fallback to `list_repo_tree` sooner (which is more reliable). 
