### PR TITLE
Retry metadata fetch with longer timeout when no local file exists

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1333,7 +1333,7 @@ def _hf_hub_download_to_local_dir(
                     repo_type=repo_type,
                     revision=revision,
                     endpoint=endpoint,
-                    etag_timeout=constants.HF_HUB_ETAG_TIMEOUT_RETRY,
+                    etag_timeout=_ETAG_RETRY_TIMEOUT,
                     headers=headers,
                     token=token,
                     local_files_only=local_files_only,


### PR DESCRIPTION
Discussed internally with @Wauplin. If the `HEAD` call we make to fetch metadata when downloading files times out (10s), it falls back to locally cached files. if there's no cached file and the network is just slow, the download fails immediately, so this PR adds a retry mechanism with a longer timeout (60s) when no local file is found. The flow is like this:
```
1) HEAD request (10s timeout)
2) If timeout:
   - Check local cache -> return if found 
   - No local file -> retry with 60s timeout
   - Still fails -> raise error
```
