### PR TITLE
Fix `FileNotFoundError` in CLI update check

### DIFF
--- a/src/huggingface_hub/cli/_cli_utils.py
+++ b/src/huggingface_hub/cli/_cli_utils.py
@@ -144,7 +144,7 @@ def _check_cli_update() -> None:
             return
 
     # Touch the file to mark that we did the check now
-    Path(constants.CHECK_FOR_UPDATE_DONE_PATH).parent.mkdir(parents=True, exists_ok=True)
+    Path(constants.CHECK_FOR_UPDATE_DONE_PATH).parent.mkdir(parents=True, exist_ok=True)
     Path(constants.CHECK_FOR_UPDATE_DONE_PATH).touch()
 
     # Check latest version from PyPI


### PR DESCRIPTION
The CLI update check fails with `FileNotFoundError` when the cache directory doesn't exist