### PR TITLE
[HfFileSystem] add expand_info arg

### DIFF
--- a/docs/source/en/package_reference/hf_file_system.md
+++ b/docs/source/en/package_reference/hf_file_system.md
@@ -10,6 +10,4 @@ The `HfFileSystem` class provides a pythonic file interface to the Hugging Face 
 
 `HfFileSystem` is based on [fsspec](https://filesystem-spec.readthedocs.io/en/latest/), so it is compatible with most of the APIs that it offers. For more details, check out [our guide](../guides/hf_file_system) and fsspec's [API Reference](https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem).
 
-[[autodoc]] HfFileSystem 
-    - __init__
-    - all
+[[autodoc]] HfFileSystem

--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -123,13 +123,20 @@ class HfFileSystem(fsspec.AbstractFileSystem, metaclass=_Cached):
     >     layer. For better performance and reliability, it's recommended to use `HfApi` methods when possible.
 
     Args:
-        token (`str` or `bool`, *optional*):
+        endpoint (`str`, *optional*):
+                Endpoint of the Hub. Defaults to <https://huggingface.co>.
+        token (`bool` or `str`, *optional*):
             A valid user access token (string). Defaults to the locally saved
             token, which is the recommended method for authentication (see
             https://huggingface.co/docs/huggingface_hub/quick-start#authentication).
             To disable authentication, pass `False`.
-        endpoint (`str`, *optional*):
-            Endpoint of the Hub. Defaults to <https://huggingface.co>.
+        block_size (`int`, *optional*):
+            Block size for reading and writing files.
+        expand_info (`bool`, *optional*):
+            Whether to expand the information of the files.
+        **storage_options (`dict`, *optional*):
+            Additional options for the filesystem. See [fsspec documentation](https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.__init__).
+
     Usage:
 
     ```python


### PR DESCRIPTION
this is needed for the `dlt` integration which require to use `?expand=true` to get lastCommit info

see https://github.com/dlt-hub/dlt/pull/3391