### PR TITLE
[Internal] Fix quality

### DIFF
--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -367,7 +367,7 @@ class ModelHubMixin:
         if is_simple_optional_type(expected_type):
             if value is None:
                 return None
-            expected_type = unwrap_simple_optional_type(expected_type)
+            expected_type = unwrap_simple_optional_type(expected_type)  # type: ignore[assignment]
         # Dataclass => handle it
         if is_dataclass(expected_type):
             return _load_dataclass(expected_type, value)  # type: ignore[return-value]


### PR DESCRIPTION
it's safe to ignore imo, since we check `is_simple_optional_type(expected_type) is True`, which means `expected_type` is `Optional[X]`. The unwrap function returns X,  which is the inner type of `ARGS_T`. 

also, a stable version of `ty` might be coming soon maybe? 👀 https://x.com/charliermarsh/status/1995153742040330467?s=20