### PR TITLE
Add retry for preupload endpoint

### DIFF
--- a/src/huggingface_hub/_commit_api.py
+++ b/src/huggingface_hub/_commit_api.py
@@ -27,6 +27,7 @@ from .utils import (
     fetch_xet_connection_info_from_repo_info,
     get_session,
     hf_raise_for_status,
+    http_backoff,
     logging,
     sha,
     tqdm_stream_file,
@@ -739,7 +740,8 @@ def _fetch_upload_modes(
         if gitignore_content is not None:
             payload["gitIgnore"] = gitignore_content
 
-        resp = get_session().post(
+        resp = http_backoff(
+            "POST",
             f"{endpoint}/api/{repo_type}s/{repo_id}/preupload/{revision}",
             json=payload,
             headers=headers,


### PR DESCRIPTION
The `/preupload/` endpoint is called in chunks of 256 files when uploading to the Hub. for large uploads, this means multiple sequential API calls, making it more likely to hit rate limits. Also, thanks to @Wauplin's [dashboard](https://kibana.elastic.huggingface.tech/app/dashboards#/view/9a82c330-6004-11ed-8df6-710c0793fc20?_g=(refreshInterval:(pause:!t,value:60000),time:(from:now-24h%2Fh,to:now))) (private link), we can see quite a lot of 429 errors on this endpoint in the last 24h.
let's take advantage of the rate limit header parsing to introduce smart retry handling. the PR also introduces backoff retry for transient errors (5xx).