### PR TITLE
Just print server warning without hardcoded client-side addition

### DIFF
--- a/src/huggingface_hub/utils/_http.py
+++ b/src/huggingface_hub/utils/_http.py
@@ -776,7 +776,7 @@ def _warn_on_warning_headers(response: httpx.Response) -> None:
             message = message.strip()
             if message:
                 _WARNED_TOPICS.add(topic)
-                logger.warning("WARNING: %s", message)
+                logger.warning(message)
 
 
 def _format(error_type: type[HfHubHTTPError], custom_message: str, response: httpx.Response) -> HfHubHTTPError:

--- a/tests/test_utils_http.py
+++ b/tests/test_utils_http.py
@@ -583,11 +583,11 @@ class TestWarnOnWarningHeaders:
 
         assert _WARNED_TOPICS == {"Topic1", "Topic2", ""}
         warnings = [record.message for record in caplog.records if record.levelname == "WARNING"]
-        assert "WARNING: This is the first warning message." in warnings
-        assert "WARNING: This is the second warning message." in warnings
-        assert "WARNING: This is a repeated warning message for Topic1." not in warnings
-        assert "WARNING: This is a warning without a topic." in warnings
-        assert "WARNING: This is another warning without a topic." not in warnings
+        assert "This is the first warning message." in warnings
+        assert "This is the second warning message." in warnings
+        assert "This is a repeated warning message for Topic1." not in warnings
+        assert "This is a warning without a topic." in warnings
+        assert "This is another warning without a topic." not in warnings
         # Request #2 (exact same warnings, should not warn again)
         caplog.clear()
         with caplog.at_level("WARNING"):
@@ -602,5 +602,5 @@ class TestWarnOnWarningHeaders:
             _warn_on_warning_headers(response)
         warnings = [record.message for record in caplog.records if record.levelname == "WARNING"]
         assert len(warnings) == 1
-        assert warnings == ["WARNING: Another warning."]
+        assert warnings == ["Another warning."]
         assert "Topic4" in _WARNED_TOPICS


### PR DESCRIPTION
Follow-up PR after https://github.com/huggingface/huggingface_hub/pull/3589.

Thinking twice about it, I don't think we should print 

```py
logger.warning("WARNING: %s", message)
```

but only the server message. This gives us maximum flexibility server-side since nothing is hardcoded client-side. If we still want to print `"WARNING:"`, we just have to send it in the header as well.


(not a big change, but I fear it hits us back in the future if we keep it as it is now)