### PR TITLE
Alias transformers CLI

### DIFF
--- a/docs/source/en/installation.md
+++ b/docs/source/en/installation.md
@@ -113,10 +113,23 @@ On macOS and Linux:
 curl -LsSf https://hf.co/cli/install.sh | bash
 ```
 
+To install with `transformers[serving]`:
+
+```bash
+curl -LsSf https://hf.co/cli/install.sh | bash -s -- --with-transformers
+```
+
 On Windows:
 
 ```powershell
 powershell -ExecutionPolicy ByPass -c "irm https://hf.co/cli/install.ps1 | iex"
+```
+
+To install with `transformers[serving]`, download the script first:
+
+```powershell
+irm https://hf.co/cli/install.ps1 -OutFile install.ps1
+.\install.ps1 -WithTransformers
 ```
 
 ## Install with conda

--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,10 @@ extras["quality"] = [
     "ty",
 ]
 
+extras["transformers-cli"] = [
+    "transformers[serving]",
+]
+
 extras["all"] = extras["testing"] + extras["quality"] + extras["typing"]
 
 extras["dev"] = extras["all"]

--- a/src/huggingface_hub/cli/hf.py
+++ b/src/huggingface_hub/cli/hf.py
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
 from huggingface_hub import constants
 from huggingface_hub.cli._cli_utils import check_cli_update, typer_factory
 from huggingface_hub.cli.auth import auth_cli
@@ -24,9 +22,10 @@ from huggingface_hub.cli.lfs import lfs_enable_largefiles, lfs_multipart_upload
 from huggingface_hub.cli.repo import repo_cli
 from huggingface_hub.cli.repo_files import repo_files_cli
 from huggingface_hub.cli.system import env, version
+from huggingface_hub.cli.transformers import lazy_transformers
 from huggingface_hub.cli.upload import upload
 from huggingface_hub.cli.upload_large_folder import upload_large_folder
-from huggingface_hub.utils import logging
+from huggingface_hub.utils import is_transformers_available, logging
 
 
 app = typer_factory(help="Hugging Face Hub CLI")
@@ -49,6 +48,9 @@ app.add_typer(repo_cli, name="repo")
 app.add_typer(repo_files_cli, name="repo-files")
 app.add_typer(jobs_cli, name="jobs")
 app.add_typer(ie_cli, name="endpoints")
+
+# add external CLIs
+app.add_typer(lazy_transformers, name="transformers")
 
 
 def main():

--- a/src/huggingface_hub/cli/transformers.py
+++ b/src/huggingface_hub/cli/transformers.py
@@ -1,0 +1,45 @@
+import typer
+from click import Context
+from typer.core import TyperGroup
+
+from huggingface_hub.utils import is_transformers_available
+
+
+class LazyTransformersGroup(TyperGroup):
+    """Lazy loading group for transformers CLI.
+
+    TODO: if we add more lazy loaded CLIs we should generalize this class.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._real_group = None
+
+    def _load_real_group(self):
+        if self._real_group is None:
+            if not is_transformers_available():
+                raise ImportError("Transformers is not installed. Please install it with: pip install transformers")
+            from transformers.cli.transformers import app as real_transformers_cli
+            from typer.main import get_group
+
+            self._real_group = get_group(real_transformers_cli)
+        return self._real_group
+
+    def list_commands(self, ctx: Context):
+        try:
+            real_group = self._load_real_group()
+            return real_group.list_commands(ctx)
+        except ImportError:
+            return []
+
+    def get_command(self, ctx: Context, cmd_name: str):
+        try:
+            real_group = self._load_real_group()
+            return real_group.get_command(ctx, cmd_name)
+        except ImportError as e:
+            ctx.fail(str(e))
+
+
+lazy_transformers = typer.Typer(
+    cls=LazyTransformersGroup, help="Alias for Transformers CLI. Only available if `transformers` is installed."
+)

--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -86,6 +86,7 @@ from ._runtime import (
     get_tensorboard_version,
     get_tf_version,
     get_torch_version,
+    get_transformers_version,
     installation_method,
     is_aiohttp_available,
     is_colab_enterprise,
@@ -106,6 +107,7 @@ from ._runtime import (
     is_tensorboard_available,
     is_tf_available,
     is_torch_available,
+    is_transformers_available,
 )
 from ._safetensors import SafetensorsFileMetadata, SafetensorsRepoMetadata, TensorInfo
 from ._subprocess import capture_output, run_interactive_subprocess, run_subprocess

--- a/src/huggingface_hub/utils/_runtime.py
+++ b/src/huggingface_hub/utils/_runtime.py
@@ -59,6 +59,7 @@ _CANDIDATES = {
         "tensorflow-macos",
     ),
     "torch": {"torch"},
+    "transformers": {"transformers"},
 }
 
 # Check once at runtime
@@ -267,6 +268,15 @@ def get_torch_version() -> str:
     return _get_version("torch")
 
 
+# Transformers
+def is_transformers_available() -> bool:
+    return is_package_available("transformers")
+
+
+def get_transformers_version() -> str:
+    return _get_version("transformers")
+
+
 # Safetensors
 def is_safetensors_available() -> bool:
     return is_package_available("safetensors")
@@ -408,6 +418,7 @@ def dump_environment_info() -> dict[str, Any]:
     info["hf_xet"] = get_xet_version()
     info["gradio"] = get_gradio_version()
     info["tensorboard"] = get_tensorboard_version()
+    info["transformers"] = get_transformers_version()
 
     # Environment variables
     info["ENDPOINT"] = constants.ENDPOINT


### PR DESCRIPTION
(discussed [internally](https://huggingface.slack.com/archives/C07KX53FZTK/p1759937771290149))

Now that `transformers` is also shipped with a Typer CLI, it would be great to centralize it in the `hf` command. It has a few benefits, especially the installer script and auto-update feature (checks for new versions).

### In practice

1. `hf transformers` is shown in the `hf --help` even if `transformers` is not installed
2. if not installed `hf transformers ...` will fail with an import error inviting user to install it (better for discoverability)
3. `hf transformers` is lazy-loaded meaning that e.g. `hf download ...` will not import transformers even if available (saves some time)

### Example

```
➜  hf transformers version
5.0.0rc0
➜  hf transformers --help 
Usage: hf transformers [OPTIONS] COMMAND [ARGS]...

  Alias for Transformers CLI. Only available if `transformers` is installed.

Options:
  --help  Show this message and exit.

Commands:
  add-fast-image-processor  Add a fast image processor to a model.
  add-new-model-like        Add a new model to the library, based on an...
  chat                      Chat with a model from the command line.
  download                  Download a model and its tokenizer from the Hub.
  env                       Print information about the environment.
  serve                     Run a FastAPI server to serve models...
  version                   Print CLI version.
```

### TODO
- [ ] adapt `install.sh` and `install.ps1` to add support for `--with-transformers` 
- [ ] adapt `install.sh` and `install.ps1` to auto update transformers if already exists
- [ ] auto-detect transformers updates (for now, only `huggingface_hub` ones are checked)
- [ ] gracefully fail if transformers <5.x (should never happen, but you never know^^)
- [ ] install message should depend on the install method (e.g. when installed with the installer, user don't know where to pip install)
- [ ] will it work with brew? :confused: (check that)
- [ ] [CLI reference](https://huggingface.co/docs/huggingface_hub/package_reference/cli) should contain transformers CLI (make sure it's the case in CI)