### PR TITLE
Fix unbound local error when reading corrupted metadata files

### DIFF
--- a/src/huggingface_hub/_local_folder.py
+++ b/src/huggingface_hub/_local_folder.py
@@ -308,6 +308,7 @@ def read_download_metadata(local_dir: Path, filename: str) -> Optional[LocalDown
                     paths.metadata_path.unlink()
                 except Exception as e:
                     logger.warning(f"Could not remove corrupted metadata file {paths.metadata_path}: {e}")
+                return None
 
             try:
                 # check if the file exists and hasn't been modified since the metadata was saved
@@ -382,6 +383,9 @@ def read_upload_metadata(local_dir: Path, filename: str) -> LocalUploadFileMetad
                     paths.metadata_path.unlink()
                 except Exception as e:
                     logger.warning(f"Could not remove corrupted metadata file {paths.metadata_path}: {e}")
+
+                # corrupted metadata => we don't know anything expect its size
+                return LocalUploadFileMetadata(size=paths.file_path.stat().st_size)
 
             # TODO: can we do better?
             if (


### PR DESCRIPTION
Fix https://github.com/huggingface/huggingface_hub/issues/3609 cc @goulou.

When uploading or downloading to a local dir, we use some metadata files to avoid re-uploading / re-downloaded data. However we do some sanity checks on the metadata file to verify it is not outdated. If any exception occur while reading the metadata, we prefer to ignore the metadata (and therefore restart the process from scratch). However in practice, a `UnboundLocalError` exception is raised in some cases when we try to access the `metadata` variable after an error occurred. Solution is just to return early.