### PR TITLE
[CI] Fix warn on warning tests

### DIFF
--- a/tests/test_utils_http.py
+++ b/tests/test_utils_http.py
@@ -581,7 +581,7 @@ class TestWarnOnWarningHeaders:
         with caplog.at_level("WARNING"):
             _warn_on_warning_headers(response)
 
-        assert _WARNED_TOPICS == {"Topic1", "Topic2", ""}
+        assert {"Topic1", "Topic2", ""}.issubset(_WARNED_TOPICS)
         warnings = [record.message for record in caplog.records if record.levelname == "WARNING"]
         assert "This is the first warning message." in warnings
         assert "This is the second warning message." in warnings


### PR DESCRIPTION
CI is failing with

```py
FAILED ../tests/test_utils_http.py::TestWarnOnWarningHeaders::test_warn_on_warning_headers - AssertionError: assert {'', 'Topic1'...uthenticated'} == {'', 'Topic1', 'Topic2'}
  
  Extra items in the left set:
  'unauthenticated'
  
  Full diff:
    {
        '',
        'Topic1',
        'Topic2',
  +     'unauthenticated',
    }
```

=> @julien-c it confirms the new warnings are triggered in CI :smile: 