### PR TITLE
[CLI] Fix private should default to None, not False

### DIFF
--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -1088,7 +1088,7 @@ $ hf repo create [OPTIONS] REPO_ID
 
 * `--repo-type [model|dataset|space]`: The type of repository (model, dataset, or space).  [default: model]
 * `--space-sdk TEXT`: Hugging Face Spaces SDK type. Required when --type is set to 'space'.
-* `--private / --no-private`: Whether to create a private repo if repo doesn't exist on the Hub. Ignored if the repo already exists.  [default: no-private]
+* `--private / --no-private`: Whether to create a private repo if repo doesn't exist on the Hub. Ignored if the repo already exists.
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `--exist-ok / --no-exist-ok`: Do not raise an error if repo already exists.  [default: no-exist-ok]
 * `--resource-group-id TEXT`: Resource group in which to create the repo. Resource groups is only available for Enterprise Hub organizations.
@@ -1304,7 +1304,7 @@ $ hf upload [OPTIONS] REPO_ID [LOCAL_PATH] [PATH_IN_REPO]
 
 * `--repo-type [model|dataset|space]`: The type of repository (model, dataset, or space).  [default: model]
 * `--revision TEXT`: Git revision id which can be a branch name, a tag, or a commit hash.
-* `--private / --no-private`: Whether to create a private repo if repo doesn't exist on the Hub. Ignored if the repo already exists.  [default: no-private]
+* `--private / --no-private`: Whether to create a private repo if repo doesn't exist on the Hub. Ignored if the repo already exists.
 * `--include TEXT`: Glob patterns to match files to upload.
 * `--exclude TEXT`: Glob patterns to exclude from files to upload.
 * `--delete TEXT`: Glob patterns for file to be deleted from the repo while committing.
@@ -1335,7 +1335,7 @@ $ hf upload-large-folder [OPTIONS] REPO_ID LOCAL_PATH
 
 * `--repo-type [model|dataset|space]`: The type of repository (model, dataset, or space).  [default: model]
 * `--revision TEXT`: Git revision id which can be a branch name, a tag, or a commit hash.
-* `--private / --no-private`: Whether to create a private repo if repo doesn't exist on the Hub. Ignored if the repo already exists.  [default: no-private]
+* `--private / --no-private`: Whether to create a private repo if repo doesn't exist on the Hub. Ignored if the repo already exists.
 * `--include TEXT`: Glob patterns to match files to upload.
 * `--exclude TEXT`: Glob patterns to exclude from files to upload.
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.

--- a/src/huggingface_hub/cli/_cli_utils.py
+++ b/src/huggingface_hub/cli/_cli_utils.py
@@ -96,7 +96,7 @@ TokenOpt = Annotated[
 ]
 
 PrivateOpt = Annotated[
-    bool,
+    Optional[bool],
     typer.Option(
         help="Whether to create a private repo if repo doesn't exist on the Hub. Ignored if the repo already exists.",
     ),

--- a/src/huggingface_hub/cli/repo.py
+++ b/src/huggingface_hub/cli/repo.py
@@ -66,7 +66,7 @@ def repo_create(
             help="Hugging Face Spaces SDK type. Required when --type is set to 'space'.",
         ),
     ] = None,
-    private: PrivateOpt = False,
+    private: PrivateOpt = None,
     token: TokenOpt = None,
     exist_ok: Annotated[
         bool,

--- a/src/huggingface_hub/cli/upload.py
+++ b/src/huggingface_hub/cli/upload.py
@@ -80,7 +80,7 @@ def upload(
     ] = None,
     repo_type: RepoTypeOpt = RepoType.model,
     revision: RevisionOpt = None,
-    private: PrivateOpt = False,
+    private: PrivateOpt = None,
     include: Annotated[
         Optional[list[str]],
         typer.Option(

--- a/src/huggingface_hub/cli/upload_large_folder.py
+++ b/src/huggingface_hub/cli/upload_large_folder.py
@@ -38,7 +38,7 @@ def upload_large_folder(
     ],
     repo_type: RepoTypeOpt = RepoType.model,
     revision: RevisionOpt = None,
-    private: PrivateOpt = False,
+    private: PrivateOpt = None,
     include: Annotated[
         Optional[list[str]],
         typer.Option(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -397,7 +397,7 @@ class TestUploadCommand:
             repo_id=DUMMY_MODEL_ID,
             repo_type="model",
             exist_ok=True,
-            private=False,
+            private=None,
             space_sdk=None,
         )
         api.upload_folder.assert_called_once_with(
@@ -483,7 +483,7 @@ class TestUploadCommand:
             allow_patterns=["*.json", "*.yaml"],
             ignore_patterns=["*.log", "*.txt"],
             path_in_repo="data/",
-            private=False,
+            private=None,
             every=5,
             hf_api=api,
         )
@@ -706,7 +706,7 @@ class TestUploadImpl:
             repo_id="my-dataset",
             repo_type="dataset",
             exist_ok=True,
-            private=False,
+            private=None,
             space_sdk=None,
         )
         api.upload_file.assert_called_once_with(


### PR DESCRIPTION
When creating a new repo, we should default to `private=None` instead of `private=False`. This is already the case when using the API but not when using the CLI. This is a bug likely introduced when switching to Typer. When defaulting to `None`, the repo visibility will default to `False` except if the organization has configured repos to be "private by default" (the check happens server-side, so it shouldn't be hardcoded client-side). 


Issue reported in internal slack [thread](https://huggingface.slack.com/archives/C02EMARJ65P/p1765549874745019) cc @eliebak @merveenoyan 


Let's make a patch release once this is shipped.