### PR TITLE
Remove irrelevant daily papers test

### DIFF
--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -4329,13 +4329,6 @@ class PaperApiTest(unittest.TestCase):
         assert len(papers) > 0
         assert papers[0].submitted_by.fullname == "AK"
 
-    def test_daily_papers_sort(self) -> None:
-        papers = list(self.api.list_daily_papers(date="2025-10-29", sort="trending"))
-        assert len(papers) > 0
-        first_paper = papers[0]
-        last_paper = papers[-1]
-        assert first_paper.upvotes >= last_paper.upvotes
-
     def test_daily_papers_p(self) -> None:
         papers = list(self.api.list_daily_papers(date="2025-10-29", p=100))
         assert len(papers) == 0


### PR DESCRIPTION
This test is definitely not relevant as the trending score computed to sort https://huggingface.co/papers/trending is not computed with upvotes. more details [here](https://github.com/huggingface-internal/moon-landing/blob/0230615e9b2b95c86442234bd97d152258d1dff5/server/scripts/sync-arxiv-papers-github-stars.ts#L48) (private link).