### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/build_repocard_examples.yaml
+++ b/.github/workflows/build_repocard_examples.yaml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: 3.13
 

--- a/.github/workflows/check-installers.yml
+++ b/.github/workflows/check-installers.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run installer
         shell: bash
@@ -49,7 +49,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run installer
         shell: pwsh

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,7 +25,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/python-prerelease.yml
+++ b/.github/workflows/python-prerelease.yml
@@ -31,7 +31,7 @@ jobs:
           fi
 
       - name: Checkout target repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: huggingface/${{ matrix.target-repo }}
           path: ${{ matrix.target-repo }}

--- a/.github/workflows/python-quality.yml
+++ b/.github/workflows/python-quality.yml
@@ -20,9 +20,9 @@ jobs:
       UV_HTTP_TIMEOUT: 600 # max 10min to install deps
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: 3.9
 

--- a/.github/workflows/python-release-hf.yml
+++ b/.github/workflows/python-release-hf.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Set up Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: 3.9
       - name: Install dependencies

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -37,9 +37,9 @@ jobs:
           - python-version: "3.13" # gradio not supported on 3.14 -> test it on 3.13
             test_name: "gradio"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -162,9 +162,9 @@ jobs:
         test_name: ["Everything else", "Xet only"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/release-conda.yml
+++ b/.github/workflows/release-conda.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v6
 
       - name: Install miniconda
         uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/style-bot-action.yml
+++ b/.github/workflows/style-bot-action.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - name: Check user permission
         id: check_user_permission
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           script: |
 
@@ -63,7 +63,7 @@ jobs:
     steps:
       - name: Extract PR details
         id: pr_info
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           script: |
             const prNumber = context.payload.issue.number;
@@ -89,7 +89,7 @@ jobs:
             });
         
       - name: Check out PR branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         env:
           HEADREPOFULLNAME: ${{ steps.pr_info.outputs.headRepoFullName }}
           HEADREF: ${{ steps.pr_info.outputs.headRef }}
@@ -134,7 +134,7 @@ jobs:
 
       - name: Comment on PR with workflow run link
         id: init_comment
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           script: |
             const prNumber = parseInt(process.env.prNumber, 10);
@@ -151,7 +151,7 @@ jobs:
           prNumber: ${{ steps.pr_info.outputs.prNumber }}
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.python_version }}
 
@@ -226,7 +226,7 @@ jobs:
           fi
 
       - name: Comment on PR
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           script: |
             const prNumber = parseInt(process.env.prNumber, 10);

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
     - name: Secret Scanning

--- a/.github/workflows/update-inference-types.yaml
+++ b/.github/workflows/update-inference-types.yaml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Setup Python
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
            repository: huggingface/huggingface_hub
            path: ./huggingface_hub
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
       - name: Setup uv
@@ -30,11 +30,11 @@ jobs:
         working-directory: ./huggingface_hub
 
       # Setup JS
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
             repository: huggingface/huggingface.js
             path: huggingface.js
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
       - name: Install pnpm


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/checkout` | [`v1`](https://github.com/actions/checkout/releases/tag/v1), [`v2`](https://github.com/actions/checkout/releases/tag/v2), [`v3`](https://github.com/actions/checkout/releases/tag/v3), [`v4`](https://github.com/actions/checkout/releases/tag/v4), [`v5`](https://github.com/actions/checkout/releases/tag/v5) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) | build_repocard_examples.yaml, check-installers.yml, claude.yml, python-prerelease.yml, python-quality.yml, python-release-hf.yml, python-release.yml, python-tests.yml, release-conda.yml, style-bot-action.yml, trufflehog.yml, update-inference-types.yaml |
| `actions/github-script` | [`v6`](https://github.com/actions/github-script/releases/tag/v6) | [`v8`](https://github.com/actions/github-script/releases/tag/v8) | [Release](https://github.com/actions/github-script/releases/tag/v8) | style-bot-action.yml |
| `actions/setup-node` | [`v3`](https://github.com/actions/setup-node/releases/tag/v3) | [`v6`](https://github.com/actions/setup-node/releases/tag/v6) | [Release](https://github.com/actions/setup-node/releases/tag/v6) | update-inference-types.yaml |
| `actions/setup-python` | [`v2`](https://github.com/actions/setup-python/releases/tag/v2), [`v4`](https://github.com/actions/setup-python/releases/tag/v4) | [`v6`](https://github.com/actions/setup-python/releases/tag/v6) | [Release](https://github.com/actions/setup-python/releases/tag/v6) | build_repocard_examples.yaml, python-quality.yml, python-release.yml, python-tests.yml, style-bot-action.yml, update-inference-types.yaml |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
