### PR TITLE
fix: read consolidated safetensors index if model safetensors index n…

### DIFF
--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -47,6 +47,7 @@ TF2_WEIGHTS_FILE_PATTERN = "tf_model{suffix}.h5"
 
 SAFETENSORS_SINGLE_FILE = "model.safetensors"
 SAFETENSORS_INDEX_FILE = "model.safetensors.index.json"
+CONSOLIDATED_SAFETENSORS_INDEX_FILE = "consolidated.safetensors.index.json"
 SAFETENSORS_MAX_HEADER_LENGTH = 25_000_000
 
 # Timeout of aquiring file lock and logging the attempt


### PR DESCRIPTION
Hello  🎁 

while trying to serve this [model](https://huggingface.co/mistralai/Mistral-Large-3-675B-Instruct-2512-NVFP4) with vLLM v0.12.0, I get these errors 

```
(APIServer pid=1) ERROR 12-24 13:41:28 [transformers_utils/repo_utils.py:65] Error retrieving safetensors: 'mistralai/Mistral-Large-3-675B-Instruct-2512-NVFP4' is not a safetensors repo. Couldn't find 'model.safetensors.index.json' or 'model.safetensors' files., retrying 1 of 2
(APIServer pid=1) ERROR 12-24 13:41:30 [transformers_utils/repo_utils.py:63] Error retrieving safetensors: 'mistralai/Mistral-Large-3-675B-Instruct-2512-NVFP4' is not a safetensors repo. Couldn't find 'model.safetensors.index.json' or 'model.safetensors' files.
```

and the model seems to never fit into the vRAM

I tried locally with a fix to read this one instead `consolidated.safetensors.index.json` (this is the only one shipped with this model) and it works like a charm !
```
(APIServer pid=703) INFO 12-24 15:01:53 [config/model.py:638] Resolved architecture: PixtralForConditionalGeneration
Parse safetensors files: 100%|████████████████████████████████████████████████████████████████████████████████| 273/273 [00:05<00:00, 46.46it/s]
```

vllm args `-gpu-memory-utilization 0.95 --model mistralai/Mistral-Large-3-675B-Instruct-2512-NVFP4  --tokenizer-mode mistral --tool-call-parser mistral --config-format mistral --load-format mistral --enable-auto-tool-choice --max-model-len 1000 --tensor-parallel-size 8
`



I am not familiar with this concept of consolidated versus non consolidated safetensors, I would be glad to get your insights 

I notified the model maintainer [here](https://huggingface.co/mistralai/Mistral-Large-3-675B-Instruct-2512-NVFP4/discussions/5) too 

Cheers !   

  
 

 