### PR TITLE
feat: add progress_format support for machine-readable JSON output

### DIFF
--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -125,7 +125,9 @@ from .tqdm import (
     are_progress_bars_disabled,
     disable_progress_bars,
     enable_progress_bars,
+    get_progress_format,
     is_tqdm_disabled,
+    set_progress_format,
     tqdm,
     tqdm_stream_file,
 )


### PR DESCRIPTION
## Summary

Adds `progress_format` support to `huggingface_hub`, enabling machine-readable JSON progress output similar to [huggingface/tokenizers#1921](https://github.com/huggingface/tokenizers/pull/1921) and [huggingface/datasets#7920](https://github.com/huggingface/datasets/pull/7920).

## Motivation

When using `huggingface_hub` in automated pipelines, web backends, or UI applications, it is useful to emit machine-readable progress instead of ANSI progress bars. This PR adds the same `progress_format` option that was implemented in tokenizers and datasets.

## Changes

### New Functions

- `set_progress_format(format: str)`: Set global progress format
- `get_progress_format() -> str`: Get current progress format

### Supported Formats

1. **"tqdm"** (default): Interactive progress bars (current behavior, unchanged)
2. **"json"**: Machine-readable JSON lines to stderr
3. **"silent"**: No output

### JSON Format

When `progress_format="json"`, emits JSON every 5% progress change or at completion:

```json
{"stage": "Downloading model.safetensors", "current": 1024, "total": 4096, "percent": 25.0}
```

## Usage Example

```python
from huggingface_hub import hf_hub_download
from huggingface_hub.utils import set_progress_format

# Enable JSON output
set_progress_format("json")

# Progress will now be emitted as JSON lines to stderr
hf_hub_download("gpt2", "config.json")
# Outputs: {"stage":"config.json","current":665,"total":665,"percent":100.0}
```

## Implementation Details

- Suppresses visual output using `io.StringIO()` when format is "json"
- Keeps progress tracking active (unlike `disable=True`)
- Emits JSON to stderr every 5% progress change
- Exports new functions from `huggingface_hub.utils`

## Backward Compatibility

- Default behavior is "tqdm" - identical to current behavior
- Existing code works without any changes
- New option is opt-in only

## Cross-Reference

This implementation mirrors the approach from:
- [huggingface/tokenizers#1921](https://github.com/huggingface/tokenizers/pull/1921)
- [huggingface/datasets#7920](https://github.com/huggingface/datasets/pull/7920)
