### PR TITLE
fix: accumulate bytes with respect to time

### DIFF
--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -349,7 +349,7 @@ def jobs_stats(
         "NUM CPU",
         "MEM %",
         "MEM USAGE",
-        "NET I/O (TOTAL)",
+        "NET I/O",
         "GPU UTIL %",
         "GPU MEM %",
         "GPU MEM USAGE",


### PR DESCRIPTION
This PR adds a small change to accumulate the bps with respect to time to ensure the summation reflects the total bytes since updates may not be received at exactly 1 second intervals