### PR TITLE
Fix hf-xet version mismatch between install_requires and extras

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,11 +12,13 @@ def get_version() -> str:
                 return line.split(delim)[1]
     raise RuntimeError("Unable to find version string.")
 
+# hf-xet version used in both install_requires and extras["hf_xet"]
+HF_XET_VERSION = "hf-xet>=1.2.0,<2.0.0"
 
 install_requires = [
     "filelock",
     "fsspec>=2023.5.0",
-    "hf-xet>=1.2.0,<2.0.0; platform_machine=='x86_64' or platform_machine=='amd64' or platform_machine=='AMD64' or platform_machine=='arm64' or platform_machine=='aarch64'",
+    f"{HF_XET_VERSION}; platform_machine=='x86_64' or platform_machine=='amd64' or platform_machine=='AMD64' or platform_machine=='arm64' or platform_machine=='aarch64'",
     "httpx>=0.23.0, <1",
     "packaging>=20.9",
     "pyyaml>=5.1",
@@ -45,7 +47,7 @@ extras["fastai"] = [
     "fastcore>=1.3.27",
 ]
 
-extras["hf_xet"] = ["hf-xet>=1.1.3,<2.0.0"]
+extras["hf_xet"] = [HF_XET_VERSION]
 
 extras["mcp"] = ["mcp>=1.8.0"]
 


### PR DESCRIPTION
## Fixes #3239

### Problem
The `hf-xet` package had mismatched version requirements between base dependencies and the optional extra:
- `install_requires`: `hf-xet>=1.2.0,<2.0.0`
- `extras["hf_xet"]`: `hf-xet>=1.1.3,<2.0.0` ❌

This caused `pkg_resources.VersionConflict` errors when users installed `huggingface-hub[hf_xet]`.

### Solution
Following @Wauplin's suggestion in https://github.com/huggingface/huggingface_hub/issues/3239#issuecomment-XXXXX, implemented the DRY (Don't Repeat Yourself) principle by:

1. Creating a `HF_XET_VERSION` variable to store the version string
2. Using it in both `install_requires` (with platform check) and `extras["hf_xet"]`

This ensures:
- ✅ Single source of truth for the version
- ✅ Consistency across both declarations
- ✅ Future-proof against similar issues

### Testing
Verified with both installation methods:
```bash
pip install -e .              # ✅ No conflicts, installs hf-xet 1.2.0
pip install -e ".[hf_xet]"    # ✅ No conflicts, installs hf-xet 1.2.0