### PR TITLE
Add Job Timeout section to CLI docs

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -934,7 +934,7 @@ You can pass environment variables to your job using
 
 ### Job Timeout
 
-Jobs have a default timeout, after which they automatically stop. For long-running tasks like model training, set a custom timeout using the `--timeout` option:
+Jobs have a default timeout of 30 mins, after which they automatically stop. For long-running tasks like model training, set a custom timeout using the `--timeout` option:
 
 ```bash
 # Set timeout in seconds (default unit)


### PR DESCRIPTION
Still had a few people run into timeouts, which we document quite well in the main Jobs guide, but not in the CLI so much. @lhoestq - I will  check this in the new docs too! 