### PR TITLE
[Jobs] Support multi gpu training commands

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -11088,7 +11088,7 @@ class HfApi:
             script_content = base64.b64encode(Path(script_file).read_bytes()).decode()
             env["UV_SCRIPT_ENCODED"] = script_content
             if script == script_file:
-                script == "/tmp/script.py"
+                script = "/tmp/script.py"
             else:
                 script_args = [
                     "/tmp/script.py" if script_arg == script_file else script_arg for script_arg in script_args


### PR DESCRIPTION
Add support for these commonly-used commands for multi-gpu training:

```bash
hf jobs uv run --with torch -- torchrun train.py
hf jobs uv run --with accelerate -- accelerate launch train.py
```

cc @SunMarc you will love this

this will be pretty useful now that we have `hf jobs stats` to monitor multi-gpu usage

## Details

to make this work we needed to check for the python script in the command arguments and pass its content to the Job