### PR TITLE
use constant of default revision instead of empty root

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -2760,7 +2760,7 @@ class HfApi:
 
         headers = self._build_hf_headers(token=token)
         path = (
-            f"{self.endpoint}/api/models/{repo_id}"
+            f"{self.endpoint}/api/models/{repo_id}/revision/{quote(constants.DEFAULT_REVISION, safe='')}"
             if revision is None
             else (f"{self.endpoint}/api/models/{repo_id}/revision/{quote(revision, safe='')}")
         )

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -2759,7 +2759,9 @@ class HfApi:
             raise ValueError("`expand` cannot be used if `securityStatus` or `files_metadata` are set.")
 
         headers = self._build_hf_headers(token=token)
-        path = f"{self.endpoint}/api/models/{repo_id}/revision/{quote(revision or constants.DEFAULT_REVISION, safe='')}"
+        path = (
+            f"{self.endpoint}/api/models/{repo_id}/revision/{quote(revision or constants.DEFAULT_REVISION, safe='')}"
+        )
         params: dict = {}
         if securityStatus:
             params["securityStatus"] = True
@@ -2826,7 +2828,9 @@ class HfApi:
             raise ValueError("`expand` cannot be used if `files_metadata` is set.")
 
         headers = self._build_hf_headers(token=token)
-        path = f"{self.endpoint}/api/datasets/{repo_id}/revision/{quote(revision or constants.DEFAULT_REVISION, safe='')}"
+        path = (
+            f"{self.endpoint}/api/datasets/{repo_id}/revision/{quote(revision or constants.DEFAULT_REVISION, safe='')}"
+        )
         params: dict = {}
         if files_metadata:
             params["blobs"] = True
@@ -2892,7 +2896,9 @@ class HfApi:
             raise ValueError("`expand` cannot be used if `files_metadata` is set.")
 
         headers = self._build_hf_headers(token=token)
-        path = f"{self.endpoint}/api/spaces/{repo_id}/revision/{quote(revision or constants.DEFAULT_REVISION, safe='')}"
+        path = (
+            f"{self.endpoint}/api/spaces/{repo_id}/revision/{quote(revision or constants.DEFAULT_REVISION, safe='')}"
+        )
         params: dict = {}
         if files_metadata:
             params["blobs"] = True

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -2759,11 +2759,7 @@ class HfApi:
             raise ValueError("`expand` cannot be used if `securityStatus` or `files_metadata` are set.")
 
         headers = self._build_hf_headers(token=token)
-        path = (
-            f"{self.endpoint}/api/models/{repo_id}/revision/{quote(constants.DEFAULT_REVISION, safe='')}"
-            if revision is None
-            else (f"{self.endpoint}/api/models/{repo_id}/revision/{quote(revision, safe='')}")
-        )
+        path = f"{self.endpoint}/api/models/{repo_id}/revision/{quote(revision or constants.DEFAULT_REVISION, safe='')}"
         params: dict = {}
         if securityStatus:
             params["securityStatus"] = True
@@ -2830,11 +2826,7 @@ class HfApi:
             raise ValueError("`expand` cannot be used if `files_metadata` is set.")
 
         headers = self._build_hf_headers(token=token)
-        path = (
-            f"{self.endpoint}/api/datasets/{repo_id}"
-            if revision is None
-            else (f"{self.endpoint}/api/datasets/{repo_id}/revision/{quote(revision, safe='')}")
-        )
+        path = f"{self.endpoint}/api/datasets/{repo_id}/revision/{quote(revision or constants.DEFAULT_REVISION, safe='')}"
         params: dict = {}
         if files_metadata:
             params["blobs"] = True
@@ -2900,11 +2892,7 @@ class HfApi:
             raise ValueError("`expand` cannot be used if `files_metadata` is set.")
 
         headers = self._build_hf_headers(token=token)
-        path = (
-            f"{self.endpoint}/api/spaces/{repo_id}"
-            if revision is None
-            else (f"{self.endpoint}/api/spaces/{repo_id}/revision/{quote(revision, safe='')}")
-        )
+        path = f"{self.endpoint}/api/spaces/{repo_id}/revision/{quote(revision or constants.DEFAULT_REVISION, safe='')}"
         params: dict = {}
         if files_metadata:
             params["blobs"] = True


### PR DESCRIPTION
Fixes #3681 

As mentioned in the issue, since Transformers' latest compatible non-prerelease manifest specifies < 1.0 for huggingface_hub, I believe this should be applied to the minor versions below that as well. 