### PR TITLE
[Internal] Ignore `unused-ignore-comment` warnings in `ty` for `mypy` compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,9 @@ output-format = "concise"
 unresolved-import = "ignore"
 unresolved-attribute = "ignore"
 
+# Keep type: ignore comments for mypy compatibility
+unused-ignore-comment = "ignore"
+
 # Be tolerant with framework/typing edge-cases and runtime-validated code paths
 unsupported-base = "ignore"
 unsupported-operator = "ignore"


### PR DESCRIPTION
as of ty v0.0.11, the `unused-ignore-comment` rule is [enabled by default](https://github.com/astral-sh/ruff/pull/22474). This causes ty to warn about `# type: ignore` comments that it doesn't consider necessary, but we still need them for mypy compat. 