### PR TITLE
[Internal] fix curlify when debug logging is enabled for streaming requests

### DIFF
--- a/src/huggingface_hub/utils/_http.py
+++ b/src/huggingface_hub/utils/_http.py
@@ -884,11 +884,12 @@ def _curlify(request: httpx.Request) -> str:
         parts += [("-H", f"{k}: {v}")]
 
     body: Optional[str] = None
-    if request.content is not None:
-        body = request.content.decode("utf-8", errors="ignore")
-        if len(body) > 1000:
-            body = f"{body[:1000]} ... [truncated]"
-    elif request.stream is not None:
+    try:
+        if request.content is not None:
+            body = request.content.decode("utf-8", errors="ignore")
+            if len(body) > 1000:
+                body = f"{body[:1000]} ... [truncated]"
+    except httpx.RequestNotRead:
         body = "<streaming body>"
     if body is not None:
         parts += [("-d", body.replace("\n", ""))]


### PR DESCRIPTION
When `HF_DEBUG=1`, the `_curlify` function crashes when logging streaming requests:
```bash
httpx.RequestNotRead: Attempted to access streaming request content, without having called `read()`.
```
This happens because `request.content` raises `RequestNotRead` for streaming requests that haven't been read yet. the solution is to wrap the `request.content` access in a try/except to catch `RequestNotRead` and fall back to `"<streaming body>"`.