### PR TITLE
add num_papers field to Organization class

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -1426,6 +1426,8 @@ class Organization:
             Number of datasets owned by the organization.
         num_followers (`int`, *optional*):
             Number of followers of the organization.
+        num_papers (`int`, *optional*):
+            Number of papers authored by the organization.
     """
 
     avatar_url: str
@@ -1439,6 +1441,7 @@ class Organization:
     num_spaces: Optional[int] = None
     num_datasets: Optional[int] = None
     num_followers: Optional[int] = None
+    num_papers: Optional[int] = None
 
     def __init__(self, **kwargs) -> None:
         self.avatar_url = kwargs.pop("avatarUrl", "")
@@ -1452,6 +1455,7 @@ class Organization:
         self.num_spaces = kwargs.pop("numSpaces", None)
         self.num_datasets = kwargs.pop("numDatasets", None)
         self.num_followers = kwargs.pop("numFollowers", None)
+        self.num_papers = kwargs.pop("numPapers", None)
 
         # forward compatibility
         self.__dict__.update(**kwargs)

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -4271,6 +4271,7 @@ class UserApiTest(unittest.TestCase):
         assert overview.num_users is None or overview.num_users > 10
         assert overview.num_models is None or overview.num_models > 10
         assert overview.num_followers is None or overview.num_followers > 1000
+        assert overview.num_papers is None or overview.num_papers >= 0
 
     def test_organization_members(self) -> None:
         members = self.api.list_organization_members("huggingface")


### PR DESCRIPTION
Adds `num_papers` field to Organization class to match User class which already has it.

https://github.com/huggingface/huggingface_hub/blob/8d9d03a5d2449f15f0810957b3ef70e5689da601/src/huggingface_hub/hf_api.py#L1529

---

## Before
```python
from huggingface_hub import get_organization_overview

org = get_organization_overview("huggingface")
print(org.num_papers)  # None ❌ (field not mapped)
print(org.num_models)  # 18 ✅
```

## After
```python
from huggingface_hub import get_organization_overview

org = get_organization_overview("huggingface")
print(org.num_papers)  # 5 ✅
print(org.num_models)  # 18 ✅
```

---
Repro: 

```
curl -s "https://huggingface.co/api/organizations/huggingface/overview" | jq '{numPapers, numModels, numDatasets, numSpaces}'
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds paper count to organization overview returned by the Hub API.
> 
> - Extend `Organization` with `num_papers` and map `numPapers` in `__init__`
> - Update docstring to document `num_papers`
> - Adjust `test_organization_overview` to assert `num_papers` is present (or `None`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 691f4c7bf285de27655890936a5cb8557e26e4b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->