### PR TITLE
[HfFileSystem] Fix resolve_path() with special char @

### DIFF
--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -266,7 +266,7 @@ class HfFileSystem(fsspec.AbstractFileSystem, metaclass=_Cached):
         else:
             repo_type = constants.REPO_TYPE_MODEL
         if path.count("/") > 0:
-            if "@" in path:
+            if "@" in "/".join(path.split("/")[:2]):
                 repo_id, revision_in_path = path.split("@", 1)
                 if "/" in revision_in_path:
                     match = SPECIAL_REFS_REVISION_REGEX.search(revision_in_path)

--- a/tests/test_hf_file_system.py
+++ b/tests/test_hf_file_system.py
@@ -570,7 +570,7 @@ class HfFileSystemTests(unittest.TestCase):
             assert fs.isfile(self.text_file)
 
 
-@pytest.mark.parametrize("path_in_repo", ["", "file.txt", "path/to/file"])
+@pytest.mark.parametrize("path_in_repo", ["", "file.txt", "path/to/file", "path/to/@not-a-revision.txt"])
 @pytest.mark.parametrize(
     "root_path,revision,repo_type,repo_id,resolved_revision",
     [
@@ -631,7 +631,7 @@ def test_resolve_path(
             resolved_path.revision,
             resolved_path.path_in_repo,
         ) == (repo_type, repo_id, resolved_revision, path_in_repo)
-        if "@" in path:
+        if "@" in path and "@not-a-revision" not in path:
             assert resolved_path._raw_revision in path
 
 


### PR DESCRIPTION
this was causing issues in the viewer for datasets with folders or files with names that contain the character `@`