### PR TITLE
Fix cache verify incorrectly reporting folders as missing files

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -3368,12 +3368,13 @@ class HfApi:
         )
         local_by_path = collect_local_files(root)
 
-        # get remote entries
-        remote_by_path: dict[str, Union[RepoFile, RepoFolder]] = {}
+        # get remote entries (only files, not folders)
+        remote_by_path: dict[str, RepoFile] = {}
         for entry in self.list_repo_tree(
             repo_id=repo_id, recursive=True, revision=remote_revision, repo_type=repo_type, token=token
         ):
-            remote_by_path[entry.path] = entry
+            if isinstance(entry, RepoFile):
+                remote_by_path[entry.path] = entry
 
         return verify_maps(
             remote_by_path=remote_by_path,

--- a/src/huggingface_hub/utils/_verification.py
+++ b/src/huggingface_hub/utils/_verification.py
@@ -1,7 +1,7 @@
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, Optional, TypedDict, Union
+from typing import TYPE_CHECKING, Literal, Optional, TypedDict
 
 from .. import constants
 from ..file_download import repo_folder_name
@@ -9,7 +9,7 @@ from .sha import git_hash, sha_fileobj
 
 
 if TYPE_CHECKING:
-    from ..hf_api import RepoFile, RepoFolder
+    from ..hf_api import RepoFile
 
 # using fullmatch for clarity and strictness
 _REGEX_COMMIT_HASH = re.compile(r"^[0-9a-f]{40}$")
@@ -91,7 +91,7 @@ def compute_file_hash(path: Path, algorithm: HashAlgo) -> str:
 
 def verify_maps(
     *,
-    remote_by_path: dict[str, Union["RepoFile", "RepoFolder"]],
+    remote_by_path: dict[str, "RepoFile"],
     local_by_path: dict[str, Path],
     revision: str,
     verified_path: Path,


### PR DESCRIPTION
## Summary

- Fix `hf cache verify --fail-on-missing-files` incorrectly reporting directories as missing files
- Filter out `RepoFolder` entries in `verify_repo_checksums`, only keeping `RepoFile` entries for comparison

Fixes #3706

## Root Cause

`list_repo_tree` returns both `RepoFile` and `RepoFolder` entries, but `collect_local_files` only collects files (using `p.is_file()`). This mismatch caused folders to appear in `missing_paths`.

## Test plan

- [x] Added regression test `test_api_verify_repo_checksums_ignores_folders`
- [x] All existing tests pass
- [x] Manually verified with `hf cache verify intfloat/multilingual-e5-large-instruct --fail-on-missing-files --local-dir test`

🤖 Generated with [Claude Code](https://claude.ai/code)