### PR TITLE
Add link to Hub Jobs documentation

### DIFF
--- a/docs/source/en/guides/jobs.md
+++ b/docs/source/en/guides/jobs.md
@@ -4,6 +4,9 @@ rendered properly in your Markdown viewer.
 # Run and manage Jobs
 
 The Hugging Face Hub provides compute for AI and data workflows via Jobs.
+
+**For a general overview of Jobs and pricing, see the [Hub Jobs documentation](https://huggingface.co/docs/hub/jobs).**
+
 A job runs on Hugging Face infrastructure and are defined with a command to run (e.g. a python command), a Docker Image from Hugging Face Spaces or Docker Hub, and a hardware flavor (CPU, GPU, TPU). This guide will show you how to interact with Jobs on the Hub, especially:
 
 - Run a job.


### PR DESCRIPTION
## Summary
- Adds a bold link to the Hub Jobs documentation in the Jobs guide for users looking for a general overview and pricing

## Test plan
- [ ] Verify the link renders correctly
- [ ] Confirm the link points to the correct Hub docs page

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a prominent reference for users seeking context on Jobs.
> 
> - Inserts a bold link to `https://huggingface.co/docs/hub/jobs` near the top of `guides/jobs.md` to direct readers to the general overview and pricing
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d6b684fe153b1943ee51009c84b63749614c59c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->