### PR TITLE
Fix multi user cache lock permissions

### DIFF
--- a/src/huggingface_hub/utils/_fixes.py
+++ b/src/huggingface_hub/utils/_fixes.py
@@ -82,6 +82,8 @@ def WeakFileLock(
     This filelock is weaker than the default filelock in that:
     1. It won't raise an exception if release fails.
     2. It will default to a SoftFileLock if the filesystem does not support flock.
+    3. Lock files are created with mode 0o664 (group-writable) instead of the default 0o644.
+       This allows multiple users sharing a cache directory to wait for locks.
 
     An INFO log message is emitted every 10 seconds if the lock is not acquired immediately.
     If a timeout is provided, a `filelock.Timeout` exception is raised if the lock is not acquired within the timeout.


### PR DESCRIPTION
Reported [here](https://huggingface.slack.com/archives/C05RS9YKZUH/p1766584618705879) and [here](https://huggingface.slack.com/archives/C09AT0185PT/p1766165492947929) (private links).

This PR fixes `PermissionError` when multiple Unix users share a single `HF_HUB_CACHE` dir. 
On unix, when multiple users in the same group share a cache dir:
1. User A downloads a model -> lock file created with mode `0o644` (rw-r--r--)
2. User B downloads the same model -> tries to wait for the lock
3. User B gets `PermissionError` instead of waiting
```
PermissionError: [Errno 13] Permission denied: '.locks/models--deepseek-ai--DeepSeek-R1-0528/6e2501...lock'
```
The `filelock` library requires write permission to wait for a lock, but lock files are created with `0o644` which only gives group members read permission.
