### PR TITLE
feat(inference): Add Latitude as inference provider

### DIFF
--- a/src/huggingface_hub/inference/_providers/__init__.py
+++ b/src/huggingface_hub/inference/_providers/__init__.py
@@ -29,6 +29,7 @@ from .hf_inference import (
     HFInferenceTask,
 )
 from .hyperbolic import HyperbolicTextGenerationTask, HyperbolicTextToImageTask
+from .latitude import LatitudeConversationalTask, LatitudeTextGenerationTask
 from .nebius import (
     NebiusConversationalTask,
     NebiusFeatureExtractionTask,
@@ -73,6 +74,7 @@ PROVIDER_T = Literal[
     "groq",
     "hf-inference",
     "hyperbolic",
+    "latitude-sh",
     "nebius",
     "novita",
     "nscale",
@@ -155,6 +157,10 @@ PROVIDERS: dict[PROVIDER_T, dict[str, TaskProviderHelper]] = {
         "text-to-image": HyperbolicTextToImageTask(),
         "conversational": HyperbolicTextGenerationTask("conversational"),
         "text-generation": HyperbolicTextGenerationTask("text-generation"),
+    },
+    "latitude-sh": {
+        "conversational": LatitudeConversationalTask(),
+        "text-generation": LatitudeTextGenerationTask(),
     },
     "nebius": {
         "text-to-image": NebiusTextToImageTask(),

--- a/src/huggingface_hub/inference/_providers/latitude.py
+++ b/src/huggingface_hub/inference/_providers/latitude.py
@@ -1,0 +1,11 @@
+from ._common import BaseConversationalTask, BaseTextGenerationTask
+
+
+class LatitudeConversationalTask(BaseConversationalTask):
+    def __init__(self):
+        super().__init__(provider="latitude-sh", base_url="https://api.lsh.ai")
+
+
+class LatitudeTextGenerationTask(BaseTextGenerationTask):
+    def __init__(self):
+        super().__init__(provider="latitude-sh", base_url="https://api.lsh.ai")


### PR DESCRIPTION
## Summary

This PR adds support for [Latitude.sh](https://latitude.sh) as an inference provider.

**About Latitude:**
- Recently **acquired by [Megaport](https://megaport.com)** (ASX: MP1), a global Network-as-a-Service leader
- Operating **10,000+ physical servers** and **1,000+ GPUs** globally
- Combined with Megaport's platform spanning **1,000+ data centers in 26 countries**
- Tier-3 data centers with 99.99% SLA

**AI Inference Platform Features:**
- OpenAI-compatible API at `https://api.lsh.ai`
- Tool calling support
- Structured output (JSON mode)
- Vision/multimodal model support
- Streaming responses
- Dedicated GPUs with consistent performance

## Changes
- Added `src/huggingface_hub/inference/_providers/latitude.py` with `LatitudeConversationalTask` and `LatitudeTextGenerationTask`
- Updated `__init__.py` to register the provider

## Related PRs
- JS Client: https://github.com/huggingface/huggingface.js/pull/1927
- Documentation: https://github.com/huggingface/hub-docs/pull/2180