### PR TITLE
Eval results synchronization

### DIFF
--- a/src/huggingface_hub/_eval_results.py
+++ b/src/huggingface_hub/_eval_results.py
@@ -23,10 +23,10 @@ class EvalResultEntry:
     Args:
         dataset_id (`str`):
             Benchmark dataset ID from the Hub. Example: "cais/hle", "Idavidrein/gpqa".
-        value (`Any`):
-            The metric value. Example: 20.90.
         task_id (`str`):
             Task identifier within the benchmark. Example: "gpqa_diamond".
+        value (`Any`):
+            The metric value. Example: 20.90.
         dataset_revision (`str`, *optional*):
             Git SHA of the benchmark dataset.
         verify_token (`str`, *optional*):
@@ -48,14 +48,14 @@ class EvalResultEntry:
         >>> # Minimal example with required fields only
         >>> result = EvalResultEntry(
         ...     dataset_id="Idavidrein/gpqa",
-        ...     value=0.412,
         ...     task_id="gpqa_diamond",
+        ...     value=0.412,
         ... )
         >>> # Full example with all fields
         >>> result = EvalResultEntry(
         ...     dataset_id="cais/hle",
-        ...     value=20.90,
         ...     task_id="default",
+        ...     value=20.90,
         ...     dataset_revision="5503434ddd753f426f4b38109466949a1217c2bb",
         ...     verify_token="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
         ...     date="2025-01-15T10:30:00Z",
@@ -68,8 +68,8 @@ class EvalResultEntry:
     """
 
     dataset_id: str
-    value: Any
     task_id: str
+    value: Any
     dataset_revision: Optional[str] = None
     verify_token: Optional[str] = None
     date: Optional[str] = None
@@ -103,8 +103,8 @@ def eval_result_entries_to_yaml(entries: list[EvalResultEntry]) -> list[dict[str
         ```python
         >>> from huggingface_hub import EvalResultEntry, eval_result_entries_to_yaml
         >>> entries = [
-        ...     EvalResultEntry(dataset_id="cais/hle", value=20.90, task_id="default"),
-        ...     EvalResultEntry(dataset_id="Idavidrein/gpqa", value=0.412, task_id="gpqa_diamond"),
+        ...     EvalResultEntry(dataset_id="cais/hle", task_id="default", value=20.90),
+        ...     EvalResultEntry(dataset_id="Idavidrein/gpqa", task_id="gpqa_diamond", value=0.412),
         ... ]
         >>> yaml_data = eval_result_entries_to_yaml(entries)
         >>> yaml_data[0]
@@ -117,7 +117,7 @@ def eval_result_entries_to_yaml(entries: list[EvalResultEntry]) -> list[dict[str
         >>> import yaml
         >>> from huggingface_hub import upload_file, EvalResultEntry, eval_result_entries_to_yaml
         >>> entries = [
-        ...     EvalResultEntry(dataset_id="cais/hle", value=20.90, task_id="default"),
+        ...     EvalResultEntry(dataset_id="cais/hle", task_id="default", value=20.90),
         ... ]
         >>> yaml_content = yaml.dump(eval_result_entries_to_yaml(entries))
         >>> upload_file(

--- a/tests/test_eval_results.py
+++ b/tests/test_eval_results.py
@@ -4,7 +4,7 @@ from huggingface_hub import EvalResultEntry, eval_result_entries_to_yaml, parse_
 
 
 def test_eval_result_entry_minimal():
-    entry = EvalResultEntry(dataset_id="cais/hle", value=20.90, task_id="default")
+    entry = EvalResultEntry(dataset_id="cais/hle", task_id="default", value=20.90)
     assert entry.dataset_id == "cais/hle"
     assert entry.value == 20.90
     assert entry.task_id == "default"
@@ -12,13 +12,13 @@ def test_eval_result_entry_minimal():
 
 def test_eval_result_entry_source_requires_url():
     with pytest.raises(ValueError):
-        EvalResultEntry(dataset_id="test", value=1.0, task_id="main", source_name="Test")
+        EvalResultEntry(dataset_id="test", task_id="main", value=1.0, source_name="Test")
     with pytest.raises(ValueError):
-        EvalResultEntry(dataset_id="test", value=1.0, task_id="main", source_org="test-org")
+        EvalResultEntry(dataset_id="test", task_id="main", value=1.0, source_org="test-org")
 
 
 def test_eval_result_entries_to_yaml():
-    entries = [EvalResultEntry(dataset_id="cais/hle", value=20.90, task_id="default")]
+    entries = [EvalResultEntry(dataset_id="cais/hle", task_id="default", value=20.90)]
     result = eval_result_entries_to_yaml(entries)
     assert result == [{"dataset": {"id": "cais/hle", "task_id": "default"}, "value": 20.90}]
 


### PR DESCRIPTION
Make `task_id` a required field in `EvalResultEntry` and update examples/tests to align with `hub-docs` PR #2179.

---
[Slack Thread](https://huggingface.slack.com/archives/C03V11RNS7P/p1769159945937789?thread_ts=1769159945.937789&cid=C03V11RNS7P)

<a href="https://cursor.com/background-agent?bcId=bc-6049dede-7504-42de-b0fd-a0de4363450e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6049dede-7504-42de-b0fd-a0de4363450e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

