### PR TITLE
Client library implementation

### DIFF
--- a/docs/source/en/guides/inference.md
+++ b/docs/source/en/guides/inference.md
@@ -464,6 +464,9 @@ For even simpler development, we offer a higher-level [`Agent`] class. This 'Tin
 # install latest version of huggingface_hub with the mcp extra
 pip install -U huggingface_hub[mcp]
 # Run an agent that uses the Flux image generation tool
+hf agent run julien-c/flux-schnell-generator
+
+# alternatively, you can use the standalone command:
 tiny-agents run julien-c/flux-schnell-generator
 
 ```

--- a/src/huggingface_hub/cli/hf.py
+++ b/src/huggingface_hub/cli/hf.py
@@ -31,6 +31,13 @@ from huggingface_hub.cli.upload import upload
 from huggingface_hub.cli.upload_large_folder import upload_large_folder
 from huggingface_hub.utils import logging
 
+try:
+    from huggingface_hub.inference._mcp.cli import app as agent_cli
+
+    _agent_cli_available = True
+except ImportError:
+    _agent_cli_available = False
+
 
 app = typer_factory(help="Hugging Face Hub CLI")
 
@@ -55,6 +62,10 @@ app.add_typer(repo_cli, name="repo")
 app.add_typer(repo_files_cli, name="repo-files")
 app.add_typer(spaces_cli, name="spaces")
 app.add_typer(ie_cli, name="endpoints")
+
+# Add agent CLI if mcp extra is installed
+if _agent_cli_available:
+    app.add_typer(agent_cli, name="agent")
 
 
 def main():

--- a/src/huggingface_hub/inference/_mcp/__init__.py
+++ b/src/huggingface_hub/inference/_mcp/__init__.py
@@ -1,0 +1,6 @@
+# MCP Client and Agent exports
+from .agent import Agent
+from .mcp_client import MCPClient
+
+
+__all__ = ["Agent", "MCPClient"]


### PR DESCRIPTION
Integrate the MCP Agent CLI into the main `hf` CLI and expose `Agent`/`MCPClient` for better accessibility and user experience.

This change allows users to access agent functionality through the familiar `hf` CLI interface, centralizing tools while maintaining backward compatibility with the existing `tiny-agents` command. It also provides cleaner imports for the `Agent` and `MCPClient` classes.

---
[Slack Thread](https://huggingface.slack.com/archives/C03V11RNS7P/p1769422102818059?thread_ts=1769422102.818059&cid=C03V11RNS7P)

<a href="https://cursor.com/background-agent?bcId=bc-d6bddadc-ead9-431b-8b4d-0c35c5ef8ba9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d6bddadc-ead9-431b-8b4d-0c35c5ef8ba9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

