### PR TITLE
Pass namespace parameter to fetch job logs in jobs CLI

### DIFF
--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -291,7 +291,7 @@ def jobs_run(
     if detach:
         return
     # Now let's stream the logs
-    for log in api.fetch_job_logs(job_id=job.id, namespace=namespace or job.owner.name):
+    for log in api.fetch_job_logs(job_id=job.id, namespace=job.owner.name):
         print(log)
 
 
@@ -648,7 +648,7 @@ def jobs_uv_run(
     if detach:
         return
     # Now let's stream the logs
-    for log in api.fetch_job_logs(job_id=job.id, namespace=namespace or job.owner.name):
+    for log in api.fetch_job_logs(job_id=job.id, namespace=job.owner.name):
         print(log)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1921,25 +1921,11 @@ class TestJobsCommand:
         )
         api.fetch_job_logs.assert_not_called()
 
-    def test_run_fetches_logs_with_namespace(self, runner: CliRunner) -> None:
-        """Test that fetch_job_logs is called with the correct namespace parameter."""
-        from huggingface_hub._jobs_api import JobOwner
+    def test_run_fetches_logs_with_correct_namespace(self, runner: CliRunner) -> None:
+        """Test that fetch_job_logs uses job.owner.name.
 
-        job_owner = JobOwner(id="org-id", name="my-org", type="org")
-        job = Mock(id="my-job-id", owner=job_owner, url="https://huggingface.co/jobs/my-org/my-job-id")
-        with (
-            patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls,
-            patch("huggingface_hub.cli.jobs._get_extended_environ", return_value={}),
-        ):
-            api = api_cls.return_value
-            api.run_job.return_value = job
-            api.fetch_job_logs.return_value = iter(["log line 1"])
-            result = runner.invoke(app, ["jobs", "run", "ubuntu", "echo", "hello", "--namespace", "my-org"])
-        assert result.exit_code == 0
-        api.fetch_job_logs.assert_called_once_with(job_id="my-job-id", namespace="my-org")
-
-    def test_run_fetches_logs_with_job_owner_name_when_namespace_not_provided(self, runner: CliRunner) -> None:
-        """Test that fetch_job_logs uses job.owner.name when namespace is not provided."""
+        Regression test for https://github.com/huggingface/huggingface_hub/pull/3736.
+        """
         from huggingface_hub._jobs_api import JobOwner
 
         job_owner = JobOwner(id="user-id", name="my-username", type="user")


### PR DESCRIPTION
Fixes #3728 
Passed in the namespace param to fetch job logs, else defaults to job owner name