### PR TITLE
Default _endpoint to None in CommitInfo, fixes tiny regression from v1.3.3

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -431,7 +431,7 @@ class CommitInfo(str):
     commit_message: str
     commit_description: str
     oid: str
-    _endpoint: Optional[str] = field(repr=False)
+    _endpoint: Optional[str] = field(default=None, repr=False)
     pr_url: Optional[str] = None
 
     # Computed from `commit_url` in `__post_init__`


### PR DESCRIPTION
Hello!

## Pull Request overview
* Default _endpoint to None in CommitInfo

## Details
This is a rather minor issue, but I stumbled upon it in my tests:
```python
from huggingface_hub import CommitInfo

commit_info = CommitInfo(
    commit_url="https://huggingface.co/sentence-transformers-testing/stsb-bert-tiny-safetensors/commit/123456",
    commit_message="Initial commit",
    commit_description="",
    oid="oid",
)
print(commit_info)
```
```
Traceback (most recent call last):
  File "[sic]demo_commit_info.py", line 3, in <module>
    commit_info = CommitInfo(
                  ^^^^^^^^^^^
TypeError: CommitInfo.__init__() missing 1 required positional argument: '_endpoint'
```
The new _endpoint from #3679 is (accidentally?) made a mandatory argument, despite being 1) private and 2) undocumented. I've got some minor failures from it in my Sentence Transformers tests here: https://github.com/huggingface/sentence-transformers/pull/3615

I can easily resolve it by setting `_endpoint` to None, which makes `RepoUrl` default it to the correct endpoint, but I think it makes more sense for hf_hub to adopt this default.

## After this PR:
The same script now returns
```
https://huggingface.co/sentence-transformers-testing/stsb-bert-tiny-safetensors/commit/123456
```

- Tom Aarsen