### PR TITLE
Pass kwargs to post init in dataclasses

### DIFF
--- a/src/huggingface_hub/dataclasses.py
+++ b/src/huggingface_hub/dataclasses.py
@@ -177,6 +177,16 @@ def strict(
 
             cls.__init__ = __init__  # type: ignore[method-assign]
 
+            # Define a default __post_init__ if not defined
+            if not hasattr(cls, "__post_init__"):
+
+                def __post_init__(self, **kwargs: Any) -> None:
+                    """Default __post_init__ to accept additional kwargs."""
+                    for name, value in kwargs.items():
+                        setattr(self, name, value)
+
+                cls.__post_init__ = __post_init__  # type: ignore[method-assign]
+
             # (optional) Override __repr__ to include additional kwargs
             original_repr = cls.__repr__
 

--- a/tests/test_utils_strict_dataclass.py
+++ b/tests/test_utils_strict_dataclass.py
@@ -84,6 +84,18 @@ class ConfigWithKwargs:
     vocab_size: int = validated_field(validator=positive_int, default=16)
 
 
+@strict(accept_kwargs=True)
+@dataclass
+class ConfigWithKwargsAndPostInit:
+    model_type: str
+    vocab_size: int = validated_field(validator=positive_int, default=16)
+
+    def __post_init__(self, **kwargs: Any) -> None:
+        """Custom __post_init__ that also accepts additional kwargs."""
+        for name, value in kwargs.items():
+            setattr(self, name.upper(), value)  # store additional kwargs in uppercase (just for testing)
+
+
 class DummyClass:
     pass
 
@@ -374,6 +386,13 @@ def test_do_not_accept_kwargs():
 
     with pytest.raises(TypeError):
         Config(model_type="bert", vocab_size=30000)
+
+
+def test_post_init_with_kwargs():
+    config = ConfigWithKwargsAndPostInit(model_type="bert", vocab_size=30000, extra_param="extra_value")
+    assert config.model_type == "bert"
+    assert config.vocab_size == 30000
+    assert config.EXTRA_PARAM == "extra_value"  # stored in uppercase by custom __post_init__
 
 
 def test_is_recognized_as_dataclass():


### PR DESCRIPTION

As per title, needed for https://github.com/huggingface/transformers/pull/41250. I verified that it is the easiest way to keep BC for remote code, because we can't force everyone to use `dataclasses` as configs

We don't want to set `kwargs` as attr directly, as some keys have to be popped (i.e. deprecated key) and some keys have to be transformed before setting (e.g. key `attn_implememtation` is set to private `_attn_implememtation_internal`)

While it can possibly be done in post init by manually deleting and post processing attr, imo it's cleaner to pass `kwargs`

```python
# We could do smth like this right now, personally i find it ugly
def __post_init__(self):
    if hastattr(sefl, "deprecated_arg": del self.deprecated_arg
    if hastattr(sefl, "private_arg": self.move_to_private_property(private_arg)

# But after the suggested PR we don't need to do anything, and can keep existing code in transformers
def __post_init__(self, **kwargs):
        if (torch_dtype := kwargs.pop("torch_dtype", None)) is not None:
            self.dtype = self.dtype if self.dtype is not None else torch_dtype
```