### PR TITLE
Fix code formatting issues

### DIFF
--- a/src/huggingface_hub/cli/_errors.py
+++ b/src/huggingface_hub/cli/_errors.py
@@ -26,7 +26,9 @@ from huggingface_hub.errors import (
 
 
 CLI_ERROR_MAPPINGS: dict[type[Exception], Callable[[Exception], str]] = {
-    RepositoryNotFoundError: lambda e: "Repository not found. Check the `repo_id` and `repo_type` parameters. If the repo is private, make sure you are authenticated.",
+    RepositoryNotFoundError: lambda e: (
+        "Repository not found. Check the `repo_id` and `repo_type` parameters. If the repo is private, make sure you are authenticated."
+    ),
     RevisionNotFoundError: lambda e: "Revision not found. Check the `revision` parameter.",
     GatedRepoError: lambda e: "Access denied. This repository requires approval.",
     LocalTokenNotFoundError: lambda e: "Not logged in. Run 'hf auth login' first.",

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -223,7 +223,7 @@ def test_tensor_same_storage():
             "layer_4": [2],
             "layer_5": [1],
         },
-        get_storage_id=lambda x: (x[0]),  # dummy for test: storage id based on first element
+        get_storage_id=lambda x: x[0],  # dummy for test: storage id based on first element
         get_storage_size=_dummy_get_storage_size,
         max_shard_size=1,
         filename_pattern="model{suffix}.safetensors",


### PR DESCRIPTION
This commit addresses code formatting inconsistencies found by ruff:
- Wrap long line in CLI error mappings for better readability
- Remove unnecessary parentheses in lambda function

Changes:
- src/huggingface_hub/cli/_errors.py: Split long error message across multiple lines
- tests/test_serialization.py: Remove redundant parentheses in lambda expression

All tests pass successfully.