### PR TITLE
Add hidden `--version` flag to `hf` CLI

### DIFF
--- a/src/huggingface_hub/cli/hf.py
+++ b/src/huggingface_hub/cli/hf.py
@@ -14,8 +14,11 @@
 
 import sys
 import traceback
+from typing import Annotated, Optional
 
-from huggingface_hub import constants
+import typer
+
+from huggingface_hub import __version__, constants
 from huggingface_hub.cli._cli_utils import check_cli_update, typer_factory
 from huggingface_hub.cli._errors import format_known_exception
 from huggingface_hub.cli.auth import auth_cli
@@ -40,6 +43,21 @@ from huggingface_hub.utils import ANSI, logging
 
 
 app = typer_factory(help="Hugging Face Hub CLI")
+
+
+def _version_callback(value: bool) -> None:
+    if value:
+        print(__version__)
+        raise typer.Exit()
+
+
+@app.callback(invoke_without_command=True)
+def app_callback(
+    version: Annotated[
+        Optional[bool], typer.Option("--version", callback=_version_callback, is_eager=True, hidden=True)
+    ] = None,
+) -> None:
+    pass
 
 
 # top level single commands (defined in their respective files)


### PR DESCRIPTION
For lazy people preferring `hf --version` instead of `hf version`. Both are working but `hf --version` stays undocumented.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI-only change that adds a new flag and early-exit path; minimal impact beyond argument parsing/dispatch.
> 
> **Overview**
> Adds a hidden `hf --version` option by introducing a Typer `@app.callback` with an eager `--version` flag that prints `__version__` and exits.
> 
> This supplements (but does not replace) the existing `hf version` command, and updates imports/types to support the new callback-based option handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ce01785abbb1238dfb8a9784323c416422431ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->