### PR TITLE
Require filelock>=3.10.0 for `mode=` parameter support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def get_version() -> str:
 HF_XET_VERSION = "hf-xet>=1.2.0,<2.0.0"
 
 install_requires = [
-    "filelock",
+    "filelock>=3.10.0",
     "fsspec>=2023.5.0",
     f"{HF_XET_VERSION}; platform_machine=='x86_64' or platform_machine=='amd64' or platform_machine=='AMD64' or platform_machine=='arm64' or platform_machine=='aarch64'",
     "httpx>=0.23.0, <1",


### PR DESCRIPTION
The `mode=` parameter used in `WeakFileLock` was added in filelock [3.10.0](https://github.com/tox-dev/filelock/releases/tag/3.10.0) released in 03-2023. Pin the minimum version to avoid crashes with older versions.

Fixes #3777


(follow up PR after https://github.com/huggingface/huggingface_hub/pull/3714 which introduced the `mode=` kwarg)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes a dependency lower bound; risk is limited to potential compatibility impacts for environments pinned to older `filelock` versions.
> 
> **Overview**
> Prevents runtime failures on older `filelock` releases by raising the minimum required version in `setup.py` from unpinned `filelock` to `filelock>=3.10.0`, ensuring support for the `mode=` argument used by `WeakFileLock`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 80b22a223376d5c75d52e52283a0e03750931c29. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->