### PR TITLE
Add overload decorators to `HfApi.snapshot_download` for dry_run typing

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -5630,6 +5630,46 @@ class HfApi:
             dry_run=dry_run,
         )
 
+    @overload
+    def snapshot_download(
+        self,
+        repo_id: str,
+        *,
+        repo_type: Optional[str] = None,
+        revision: Optional[str] = None,
+        cache_dir: Union[str, Path, None] = None,
+        local_dir: Union[str, Path, None] = None,
+        etag_timeout: float = constants.DEFAULT_ETAG_TIMEOUT,
+        force_download: bool = False,
+        token: Union[bool, str, None] = None,
+        local_files_only: bool = False,
+        allow_patterns: Optional[Union[list[str], str]] = None,
+        ignore_patterns: Optional[Union[list[str], str]] = None,
+        max_workers: int = 8,
+        tqdm_class: Optional[type[base_tqdm]] = None,
+        dry_run: Literal[False] = False,
+    ) -> str: ...
+
+    @overload
+    def snapshot_download(
+        self,
+        repo_id: str,
+        *,
+        repo_type: Optional[str] = None,
+        revision: Optional[str] = None,
+        cache_dir: Union[str, Path, None] = None,
+        local_dir: Union[str, Path, None] = None,
+        etag_timeout: float = constants.DEFAULT_ETAG_TIMEOUT,
+        force_download: bool = False,
+        token: Union[bool, str, None] = None,
+        local_files_only: bool = False,
+        allow_patterns: Optional[Union[list[str], str]] = None,
+        ignore_patterns: Optional[Union[list[str], str]] = None,
+        max_workers: int = 8,
+        tqdm_class: Optional[type[base_tqdm]] = None,
+        dry_run: Literal[True],
+    ) -> list[DryRunFileInfo]: ...
+
     @validate_hf_hub_args
     def snapshot_download(
         self,


### PR DESCRIPTION
The `snapshot_download` method in `HfApi` was missing `@overload` decorators to properly type the return value based on the `dry_run` parameter, unlike its standalone counterpart and `HfApi.hf_hub_download` which already had them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-hint-only change (adds overloads) with no functional logic changes, so runtime risk is minimal.
> 
> **Overview**
> Adds missing `@overload` signatures to `HfApi.snapshot_download` so static typing reflects the `dry_run` flag: returning a `str` path when `dry_run=False` and `list[DryRunFileInfo]` when `dry_run=True`.
> 
> This aligns the method’s typing behavior with the standalone `snapshot_download` helper and improves IDE/type-checker accuracy without changing runtime behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4fd1aa30566d444a3866cb36e078dc81c87a9921. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->