### PR TITLE
Add AGENTS.md with dev setup and codebase guide for AI agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,8 +94,16 @@ Entry point: `hf.py` (Typer app). Subcommands split into modules: `auth.py`, `re
 
 - Max line length: 119 chars.
 - Linter/formatter: `ruff`.
-- Type checker: `ty` (+ mypy in CI).
 - Imports sorted by `ruff` (isort-compatible).
+
+### Type checking: local vs CI
+
+Locally, `make quality` runs `ty check src` using whatever version of `ty` is installed in the virtualenv. CI (`.github/workflows/python-quality.yml`) runs `uvx ty check src` (always the latest `ty` release) **and** `mypy src`. This means CI may flag errors that do not appear locally — this is intentional.
+
+- **`ty`**: The local version is whatever the developer has installed — it won't update on its own, so new `ty` releases don't unexpectedly break the workflow. Developers can update it at will. CI always uses the latest version to catch issues early.
+- **`mypy`**: Historically the project's type checker. It is kept in CI (until `ty` reaches a stable release) but not run locally via `make quality` because it takes 1–2 minutes, which slows down the development loop.
+
+If CI fails on type checks that pass locally, the likely cause is a newer `ty` version or a `mypy`-only diagnostic. Fix the reported errors rather than downgrading the checker.
 
 ## Testing notes
 


### PR DESCRIPTION
Provides essential context for AI coding agents (Claude Code, Open Code, etc.): virtualenv location, make style/quality workflow, code structure overview, style rules, and testing notes.

Code structure was generated automatically but the most important part IMO is the "use this venv", "use make style / make quality", "this is how to run a test", etc. Can be improved iteratively. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition with no runtime or behavioral code changes.
> 
> **Overview**
> Adds a new `AGENTS.md` guide aimed at AI coding agents and contributors, documenting the expected local dev setup (`.venv`) and the standard workflow commands (`make style`, `make quality`, and targeted `pytest` runs).
> 
> The doc also provides a curated map of the repository’s major modules (core, inference, utils, CLI, tests, dev scripts), plus style conventions and notes on local vs CI type-checking and testing constraints (staging Hub, `HF_TOKEN`, no new VCR cassettes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c8a8ca159c42af2d3ac8ee431d8a75385f443ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->