### PR TITLE
[Fix] No timeout by default when using httpx

### DIFF
--- a/src/huggingface_hub/utils/_http.py
+++ b/src/huggingface_hub/utils/_http.py
@@ -219,7 +219,7 @@ def default_client_factory() -> httpx.Client:
     return httpx.Client(
         event_hooks={"request": [hf_request_event_hook]},
         follow_redirects=True,
-        timeout=httpx.Timeout(constants.HF_HUB_DOWNLOAD_TIMEOUT, write=60.0),
+        timeout=None,
     )
 
 
@@ -230,7 +230,7 @@ def default_async_client_factory() -> httpx.AsyncClient:
     return httpx.AsyncClient(
         event_hooks={"request": [async_hf_request_event_hook], "response": [async_hf_response_event_hook]},
         follow_redirects=True,
-        timeout=httpx.Timeout(constants.HF_HUB_DOWNLOAD_TIMEOUT, write=60.0),
+        timeout=None,
     )
 
 


### PR DESCRIPTION
Follow-up after https://github.com/huggingface/huggingface_hub/issues/3751.

With the `requests` -> `httpx` migration, the default timeout value went from "no timeouts" to "5s" by default. This makes the library break on slow connections or long running actions (typically a big /commit or a complex search query). We should avoid as much as possible long calls but that's more of a server-side optimization to make rather than a client-side crash by default. 

In https://github.com/huggingface/huggingface_hub/pull/3751, I've bound the default timeout value to the constant `HF_HUB_DOWNLOAD_TIMEOUT` that is configurable via environment variable. But thinking more about it and after some more tests, I feel that we should go back to our initial default, i.e the `requests` default, i.e. no timeouts by default. The only use case where we want to timeout quickly is when checking for update on file download. We do not want to wait too long before timeout since the file might already exists locally. But for all other requests, having a small default makes the tool less reliable (i.e. more errors happening) without having huge advantage. 

This is why I'm opening this PR to unset the 10s timeout and set it to "no timeouts at all by default". In practice, the timeout will be 120s which is the default timeout from server.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Alters global HTTP client behavior by removing default timeouts, which can cause requests to hang longer and change failure modes across many call sites.
> 
> **Overview**
> Restores *no client-side timeouts by default* for Hub HTTP requests by configuring the default `httpx.Client` and `httpx.AsyncClient` factories with `timeout=None` instead of an explicit `HF_HUB_DOWNLOAD_TIMEOUT`-based timeout.
> 
> Download/file-transfer codepaths that pass an explicit `timeout` (e.g. using `HF_HUB_DOWNLOAD_TIMEOUT`) are unaffected; this change primarily impacts non-download/long-running API calls that were previously failing on slow connections.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ab49ad249577d8676e3e12f3bf2c2ca55a77f89. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->