### PR TITLE
Fix ReadTimeout crash in no-follow job logs

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -10310,11 +10310,7 @@ class HfApi:
             except KeyboardInterrupt:
                 break
             except (httpx.HTTPError, httpcore.TimeoutException) as err:
-                is_no_new_line_timeout = isinstance(err, (httpx.ReadTimeout, httpcore.ReadTimeout)) or (
-                    isinstance(err, httpx.NetworkError)
-                    and err.__context__
-                    and isinstance(getattr(err.__context__, "__cause__", None), TimeoutError)
-                )
+                is_no_new_line_timeout = isinstance(err, (httpx.ReadTimeout, httpcore.ReadTimeout))
                 if is_no_new_line_timeout:
                     if not follow:
                         break  # no-follow mode: got all buffered events


### PR DESCRIPTION
- hf jobs logs <id> (without --follow) crashes with `httpx.ReadTimeout` when the SSE stream pauses for longer than the 5-second timeout
 - The is_no_new_line_timeout check only recognised `httpx.NetworkError` wrapping a `TimeoutError`, but httpx actually raises `httpx.ReadTimeout`, not a `NetworkError`
- Add `httpx.ReadTimeout` / `httpcore.ReadTimeout` to the timeout detection, so the no-follow path breaks cleanly
