### PR TITLE
Change external dependency from `typer-slim` to `typer`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ install_requires = [
     "pyyaml>=5.1",
     "shellingham",
     "tqdm>=4.42.1",
-    "typer-slim",
+    "typer",
     "typing-extensions>=4.1.0",  # to be able to import TypeAlias, dataclass_transform
 ]
 


### PR DESCRIPTION
Hi 👋  Typer maintainer here.

I saw that you switched to using Typer a few months ago (🎉), and decided to go with `typer-slim` at the time. We offered this to have a more light-weight package, specifically without `rich` and `shellingham`. Unfortuntately, the way it was set up meant that we ran into issues with package managers (e.g. https://github.com/fastapi/typer/issues/1503). We ran a user survey and eventually decided to drop support for `typer-slim` altogether (since [0.22.0](https://github.com/fastapi/typer/releases/tag/0.22.0)). Going forward, it's better to just use `typer` as dependency.

What this means for this repo:
- `shellingham` was already an explicit requirement of `huggingface_hub` so no influence on that front
- `rich` will now be installed by default (about 12MB). This means that any Typer app will automatically set `rich_markup_mode` to `"rich"` by default (it was `None` when Rich wasn't installed). This can be overwritten when creating `Typer()`, which you already do in this repo: `cli.py:L16` sets it to `"rich"`, the default for `HFCliApp.command` is `None` and `typer_factory` also specifically disables Rich. So that looks all great to me.

Just FYI, we also introduced a new environment variable `TYPER_USE_RICH` that you can set to `False` to disable Rich entirely everywhere and always, but I don't think you need/want this, given that you allow fine-grained control of it per app.

Let me know if there's any concerns/questions!