### PR TITLE
[Internal] remove `shellingham` from the required dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ install_requires = [
     "httpx>=0.23.0, <1",
     "packaging>=20.9",
     "pyyaml>=5.1",
-    "shellingham",
     "tqdm>=4.42.1",
     "typer",
     "typing-extensions>=4.1.0",  # to be able to import TypeAlias, dataclass_transform


### PR DESCRIPTION
Remove `shellingham` from `install_requires` as it is now installed with `typer`.

After https://github.com/huggingface/huggingface_hub/pull/3797, `shellingham` is installed with `typer`, so it no longer needs to be listed in `install_requires`.

---
[Slack Thread](https://huggingface.slack.com/archives/D0A9NBN79EZ/p1770820408024409?thread_ts=1770820408.024409&cid=D0A9NBN79EZ)

<p><a href="https://cursor.com/background-agent?bcId=bc-25191bdc-e1da-55fb-9787-6c2b23ba34b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-25191bdc-e1da-55fb-9787-6c2b23ba34b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

