### PR TITLE
Add `-h` as short alias for `--help` in CLI

### DIFF
--- a/src/huggingface_hub/cli/_cli_utils.py
+++ b/src/huggingface_hub/cli/_cli_utils.py
@@ -210,6 +210,7 @@ def typer_factory(help: str, epilog: Optional[str] = None) -> "HFCliApp":
         # Increase max content width for better readability
         context_settings={
             "max_content_width": 120,
+            "help_option_names": ["-h", "--help"],
         },
     )
 


### PR DESCRIPTION
Edit/tl;dr I would like to make the `hf` cli accept shorthand `-h` for help. If this is not desired close this PR.

## Summary
- Adds `-h` as a short alias for `--help` across all CLI commands and subcommands
- Configured via `help_option_names` in Typer's `context_settings`, which propagates to all commands via Click's context inheritance

## Test plan
- [x] Verify `hf -h` shows help
- [x] Verify `hf <subcommand> -h` shows help (e.g. `hf download -h`, `hf cache -h`)
- [x] Verify `--help` still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)