### PR TITLE
[CLI] Make `SKILL.md` token-efficient

### DIFF
--- a/src/huggingface_hub/cli/skills.py
+++ b/src/huggingface_hub/cli/skills.py
@@ -69,7 +69,6 @@ _SKILL_TIPS = """
 - Use `--format json` for machine-readable output on list commands
 - Use `-q` / `--quiet` to print only IDs
 - Authenticate with `HF_TOKEN` env var (recommended) or with `--token`
-- Use `--repo-type dataset` or `--repo-type space` for non-model repos
 """
 
 CENTRAL_LOCAL = Path(".agents/skills")


### PR DESCRIPTION
Flagged by @xeophon on [X](https://x.com/xeophon/status/2019404214137757994?s=20). thanks again for the feedback and the ideas!

when an agent loads the `hf-cli` skill, it was injecting ~12k tokens into its context window. After taking a look at @xeophon's recommendation and experimenting a bit with other Skills, i think Skills should be compact and self contained (see [mitsuhiko/agent-stuff/skills](https://github.com/mitsuhiko/agent-stuff/tree/main/skills) for examples). The auto generated `SKILL.md` already lists every command with its usage and description.  Also, The most important thing  the skill needs to convey (for now) is that `huggingface-cli` is deprecated and replaced by `hf`. Most LLMs still think that `huggingface-cli` still exists (comes from the training data) and will default to it. The rest is just a compact command reference, the agent cann always run `--help` for details.


One solution i found effective to generate `SKILL.md` - both token wise and for keeping the skill automatically in sync with the CLI - is introspecting the typer CLI app. It walks the Click command tree to extract **command names**, **help strings**, and **required parameters**, then assembles a compact markdown document.


Token count comparison 

```python
import os, sys
from openai import OpenAI

client = OpenAI(
    base_url="https://router.huggingface.co/v1",
    api_key=os.environ["HF_TOKEN"],
)
content = open(sys.argv[1]).read()
r = client.chat.completions.create(
    model="moonshotai/Kimi-K2.5",
    messages=[{"role": "user", "content": content + "\n\nreply with OK."}],
    max_tokens=1,
)
print(f"{r.usage.prompt_tokens:,} tokens ({len(content):,} bytes)")
```

Before:
```
# Before
docs/source/en/guides/cli.md:            12,214 tokens 
# After
.agents/skills/hf-cli/SKILL.md:          1,269 tokens
```