### PR TITLE
[Internal] remove new `unused-type-ignore-comment` warning from `ty`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ unresolved-attribute = "ignore"
 
 # Keep type: ignore comments for mypy compatibility
 unused-ignore-comment = "ignore"
+unused-type-ignore-comment = "ignore"
 
 # Be tolerant with framework/typing edge-cases and runtime-validated code paths
 unsupported-base = "ignore"


### PR DESCRIPTION
A recent `ty` release split `unused-ignore-comment` into two rules ([astral-sh/ruff#22790](https://github.com/astral-sh/ruff/pull/22790)):

- `unused-ignore-comment` - now only reports unused `ty: ignore` comments
- `unused-type-ignore-comment` (new) - reports unused `type: ignore` comments

but we need to keep these `# type: ignore` comments for `mypy` compatibility. This PR adds `unused-type-ignore-comment = "ignore"` to `[tool.ty.rules]` in `pyproject.toml`.

