### PR TITLE
fix: use SPDX license identifier 'Apache-2.0' instead of ambiguous 'Apache'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,7 @@ setup(
     long_description=open("README.md", "r", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
     keywords="model-hub machine-learning models natural-language-processing deep-learning pytorch pretrained-models",
-    license="Apache",
+    license="Apache-2.0",
     url="https://github.com/huggingface/huggingface_hub",
     package_dir={"": "src"},
     packages=find_packages("src"),


### PR DESCRIPTION
## Summary

The `license` field in `setup.py` is currently set to `"Apache"`, which is not a recognized [SPDX license identifier](https://spdx.org/licenses/). PyPI surfaces this value as-is in the package JSON metadata (`https://pypi.org/pypi/huggingface-hub/json`), making it difficult for automated license compliance tools to correctly identify the project's license.

The repository's `LICENSE` file is the **Apache License, Version 2.0**, so the correct SPDX identifier is `Apache-2.0`.

## Change

```diff
- license="Apache",
+ license="Apache-2.0",
```

## Why this matters

Downstream consumers that parse PyPI metadata to build license inventories (e.g., for SBOM generation, open-source compliance audits, or dependency dashboards) receive the raw string `"Apache"` from the `info.license` field. This string is ambiguous — it could refer to Apache-1.0, Apache-1.1, or Apache-2.0. Using the precise SPDX identifier `Apache-2.0` removes this ambiguity.

## Future improvement

[PEP 639](https://peps.python.org/pep-0639/) introduces a dedicated `license-expression` field in `[project]` metadata (supported by setuptools ≥ 69.0 and pip ≥ 24.0). A follow-up could migrate to `pyproject.toml` `[project]` metadata with:

```toml
[project]
license-expression = "Apache-2.0"
```

This PR is intentionally minimal — just fixing the existing field to be unambiguous.
