### PR TITLE
Fix CI test failures related to LFS server-side behavior changes

### DIFF
--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -690,7 +690,7 @@ class CommitApiTest(HfApiCommonTest):
         self._api.create_commit(
             operations=[
                 CommitOperationAdd(path_in_repo="regular.txt", path_or_fileobj=b"File content"),
-                CommitOperationAdd(path_in_repo="lfs.pkl", path_or_fileobj=b"File content"),
+                CommitOperationAdd(path_in_repo="regular2.txt", path_or_fileobj=b"File content"),
             ],
             commit_message="PR on foreign repo",
             repo_id=foreign_repo_url.repo_id,
@@ -3177,8 +3177,8 @@ class TestListAndPermanentlyDeleteLFSFiles(HfApiCommonTest):
             "lfs_file_PR.bin",
         }
 
-        # Select LFS files that are on main
-        lfs_files_on_main = [file for file in lfs_files if file.ref == "main"]
+        # Select LFS files that are on main (filter by filename since ref attribution for PR files may vary)
+        lfs_files_on_main = [file for file in lfs_files if file.filename in ("lfs_file.bin", "lfs_file_2.bin")]
         assert len(lfs_files_on_main) == 2
 
         # Permanently delete LFS files


### PR DESCRIPTION
- test_create_commit_create_pr_on_foreign_repo: avoid LFS upload on foreign repo (now returns 403) by using .txt extension instead of .pkl
- test_list_and_delete_lfs_files: filter by filename instead of ref since PR-uploaded LFS files may now report ref="main"