### PR TITLE
Accelerator parameter support

### DIFF
--- a/docs/source/en/guides/inference_endpoints.md
+++ b/docs/source/en/guides/inference_endpoints.md
@@ -7,7 +7,7 @@ This guide assumes `huggingface_hub` is correctly installed and that your machin
 
 
 > [!TIP]
-> **New:** it is now possible to deploy an Inference Endpoint from the [HF model catalog](https://endpoints.huggingface.co/catalog) with a simple API call. The catalog is a carefully curated list of models that can be deployed with optimized settings. You don't need to configure anything, we take all the heavy stuff on us! All models and settings are guaranteed to have been tested to provide best cost/performance balance.  [`create_inference_endpoint_from_catalog`] works the same as [`create_inference_endpoint`], with much less parameters to pass. You can use [`list_inference_catalog`] to programmatically retrieve the catalog.
+> **New:** it is now possible to deploy an Inference Endpoint from the [HF model catalog](https://endpoints.huggingface.co/catalog) with a simple API call. The catalog is a carefully curated list of models that can be deployed with optimized settings. You don't need to configure anything, we take all the heavy stuff on us! All models and settings are guaranteed to have been tested to provide best cost/performance balance.  [`create_inference_endpoint_from_catalog`] works the same as [`create_inference_endpoint`], with much less parameters to pass. You can optionally specify an `accelerator` (`"cpu"`, `"gpu"`, or `"neuron"`) to override the default hardware selection. You can use [`list_inference_catalog`] to programmatically retrieve the catalog.
 >
 > Note that this is still an experimental feature. Let us know what you think if you use it!
 
@@ -39,7 +39,10 @@ Or via CLI:
 hf endpoints deploy my-endpoint-name --repo gpt2 --framework pytorch --accelerator cpu --vendor aws --region us-east-1 --instance-size x2 --instance-type intel-icl --task text-generation
 
 # Deploy from the catalog with a single command
-hf endpoints catalog deploy my-endpoint-name --repo openai/gpt-oss-120b
+hf endpoints catalog deploy --repo openai/gpt-oss-120b
+
+# Deploy from the catalog with a specific accelerator
+hf endpoints catalog deploy --repo openai/gpt-oss-120b --accelerator gpu
 ```
 
 

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -783,6 +783,7 @@ $ hf endpoints catalog deploy [OPTIONS]
 
 * `--repo TEXT`: The name of the model repository associated with the Inference Endpoint (e.g. 'openai/gpt-oss-120b').  [required]
 * `--name TEXT`: Endpoint name.
+* `--accelerator TEXT`: The hardware accelerator to be used for inference (e.g. 'cpu', 'gpu', 'neuron').
 * `--namespace TEXT`: The namespace associated with the Inference Endpoint. Defaults to the current user's namespace.
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `--help`: Show this message and exit.

--- a/src/huggingface_hub/cli/inference_endpoints.py
+++ b/src/huggingface_hub/cli/inference_endpoints.py
@@ -206,6 +206,12 @@ def deploy_from_catalog(
         ),
     ],
     name: NameOpt = None,
+    accelerator: Annotated[
+        Optional[str],
+        typer.Option(
+            help="The hardware accelerator to be used for inference (e.g. 'cpu', 'gpu', 'neuron').",
+        ),
+    ] = None,
     namespace: NamespaceOpt = None,
     token: TokenOpt = None,
 ) -> None:
@@ -215,6 +221,7 @@ def deploy_from_catalog(
         endpoint = api.create_inference_endpoint_from_catalog(
             repo_id=repo,
             name=name,
+            accelerator=accelerator,
             namespace=namespace,
             token=token,
         )

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -7899,6 +7899,7 @@ class HfApi:
         repo_id: str,
         *,
         name: Optional[str] = None,
+        accelerator: Union[Literal["cpu", "gpu", "neuron"], str, None] = None,
         token: Union[bool, str, None] = None,
         namespace: Optional[str] = None,
     ) -> InferenceEndpoint:
@@ -7913,6 +7914,9 @@ class HfApi:
                 The ID of the model in the catalog to deploy as an Inference Endpoint.
             name (`str`, *optional*):
                 The unique name for the new Inference Endpoint. If not provided, a random name will be generated.
+            accelerator (`str`, *optional*):
+                The hardware accelerator to be used for inference. Possible values include `"cpu"`, `"gpu"`, and
+                `"neuron"`. If not provided, the server will use a default appropriate for the model.
             token (`bool` or `str`, *optional*):
                 A valid user access token (string). Defaults to the locally saved
                 token, which is the recommended method for authentication (see
@@ -7934,6 +7938,8 @@ class HfApi:
         }
         if name is not None:
             payload["endpointName"] = name
+        if accelerator is not None:
+            payload["accelerator"] = accelerator
 
         response = get_session().post(
             f"{constants.INFERENCE_CATALOG_ENDPOINT}/deploy",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1502,6 +1502,7 @@ class TestInferenceEndpointsCommands:
         api.create_inference_endpoint_from_catalog.assert_called_once_with(
             repo_id="catalog/model",
             name=None,
+            accelerator=None,
             namespace=None,
             token=None,
         )


### PR DESCRIPTION
related to [private PR](https://github.com/huggingface/hf-endpoints/pull/2276) and private [slack convo](https://huggingface.slack.com/archives/C07QRFB1JU8/p1771231577722089)

Add `accelerator` parameter to `create_inference_endpoint_from_catalog` API and CLI, supporting `Union[Literal[...], str, None]` for future compatibility.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-81a4dc50-b098-4525-b448-a85f8409fdb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-81a4dc50-b098-4525-b448-a85f8409fdb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive API/CLI surface change that only affects catalog deployment payload construction when the new optional flag is used.
> 
> **Overview**
> Adds optional `accelerator` support when deploying Inference Endpoints **from the catalog** via both Python and CLI.
> 
> `HfApi.create_inference_endpoint_from_catalog` now accepts an `accelerator` argument (typed for `"cpu"|"gpu"|"neuron"` with forward-compatible `str`) and includes it in the deploy request payload when provided; `hf endpoints catalog deploy` exposes a matching `--accelerator` flag, with docs and CLI reference updated and tests adjusted accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d73d882b00699c4f9eecc22b5913cd80121dbb4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->