### PR TITLE
Strict dataclass sequence validation

### DIFF
--- a/src/huggingface_hub/dataclasses.py
+++ b/src/huggingface_hub/dataclasses.py
@@ -556,9 +556,13 @@ def _validate_set(name: str, value: Any, args: tuple[Any, ...]) -> None:
 
 
 def _validate_sequence(name: str, value: Any, args: tuple[Any, ...]) -> None:
-    """Validate Sequence[T] type."""
+    """Validate Sequence or Sequence[T] type."""
     if not isinstance(value, collections.abc.Sequence):
         raise TypeError(f"Field '{name}' expected a Sequence, got {type(value).__name__}")
+
+    # If no type argument is provided (i.e., just `Sequence`), skip item validation
+    if not args:
+        return
 
     # Validate each item in the sequence
     item_type = args[0]

--- a/tests/test_utils_strict_dataclass.py
+++ b/tests/test_utils_strict_dataclass.py
@@ -226,6 +226,11 @@ def test_custom_validator_must_be_callable():
         ("abc", Sequence[str]),  # str is a Sequence of str
         ([1, 2, "3"], Sequence[Union[int, str]]),
         ((1, 2, "3"), Sequence[Union[int, str]]),
+        # Sequence without type parameter (accepts any sequence)
+        ([1, 2, 3], Sequence),
+        ((1, 2, "3"), Sequence),
+        ("abc", Sequence),
+        ([], Sequence),
         # Custom classes
         (DummyClass(), DummyClass),
         # Any
@@ -293,6 +298,9 @@ def test_type_validator_valid(value, type_annotation):
         ({1, 2, 3}, Sequence[int]),  # set is not a sequence
         ([1, 2, "3"], Sequence[int]),  # wrong item type
         ((1, 2, "3"), Sequence[int]),  # wrong item type in tuple
+        # Sequence without type parameter
+        (5, Sequence),  # not a sequence
+        ({1, 2, 3}, Sequence),  # set is not a sequence
         # Custom classes
         (5, DummyClass),
         ("John", DummyClass),


### PR DESCRIPTION
Add support for validating `typing.Sequence` in the `@strict` dataclass decorator to extend type checking capabilities.

---
[Slack Thread](https://huggingface.slack.com/archives/D0A9313SS3G/p1771506614260269?thread_ts=1771506614.260269&cid=D0A9313SS3G)

<p><a href="https://cursor.com/background-agent?bcId=bc-222f594c-7e58-5061-bf39-b17d5aeaf189"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-222f594c-7e58-5061-bf39-b17d5aeaf189"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive change to validation logic with broad tests; main risk is subtle behavior differences for types that are `Sequence` (notably `str`/`bytes`) being newly validated.
> 
> **Overview**
> Adds runtime validation for `typing.Sequence` annotations in the `@strict` dataclass type checker. `type_validator` now accepts `Sequence`/`Sequence[T]` by verifying the value is a `collections.abc.Sequence` and (when parameterized) validating each element type.
> 
> Extends the strict dataclass test suite with new valid/invalid `Sequence` cases, including unparameterized `Sequence` and mixed concrete sequence types (e.g. `list`, `tuple`, `str`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e654f171bc9be6274e4e960aa3a06700167a90a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->