### PR TITLE
Check if `dataclass.repr=True` before wrapping

### DIFF
--- a/src/huggingface_hub/dataclasses.py
+++ b/src/huggingface_hub/dataclasses.py
@@ -225,7 +225,8 @@ def strict(
                 # Combine both representations
                 return f"{standard_repr[:-1]}, {additional_repr})" if additional_kwargs else standard_repr
 
-            cls.__repr__ = __repr__  # type: ignore [method-assign]
+            if cls.__dataclass_params__.repr is True:  # type: ignore [attr-defined]
+                cls.__repr__ = __repr__  # type: ignore [method-assign]
 
         # List all public methods starting with `validate_` => class validators.
         class_validators = []


### PR DESCRIPTION
As per title, this gives me freedom to set `repr=False` and create my own `repr` by removing private attr, default values and other stuff. I don't think it's worth pretty printing additional kwargs in the hub-side because default dataclass 'repr' is also simple dict-like