### PR TITLE
[Internal] Fix ty invalid assignment in `CollectionItem`

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -1233,7 +1233,8 @@ class CollectionItem:
             self.item_id = slug  # collection slug
         self.item_type: CollectionItemType_T = type
         self.position: int = position
-        self.note: str = note["text"] if note is not None else None
+        note_text = note.get("text") if note is not None else None
+        self.note = note_text if isinstance(note_text, str) else None
 
 
 @dataclass


### PR DESCRIPTION
This PR fixes a `ty` type-check error in `CollectionItem` init (hf_api.py) by safely narrowing `note["text"]` before assigning to `self.note`.