### PR TITLE
fix(cache): normalize repo_id casing in repo_folder_name

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -258,6 +258,8 @@ def hf_hub_url(
     if repo_type not in constants.REPO_TYPES:
         raise ValueError("Invalid repo type")
 
+    repo_id = repo_id.lower()
+
     if repo_type in constants.REPO_TYPES_URL_PREFIXES:
         repo_id = constants.REPO_TYPES_URL_PREFIXES[repo_type] + repo_id
 


### PR DESCRIPTION
The cache directory name was previously built using the exact casing
of the provided repo_id. On case-sensitive filesystems this led to
duplicate cache folders for the same model (e.g. DeepSeek-OCR vs
deepseek-ocr).

We now normalize the repo_id to lowercase inside repo_folder_name()
for the cache path only, while keeping the original casing for Hub API
calls.