### PR TITLE
[CLI] Better handling of aliases in documentation

### DIFF
--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -206,7 +206,7 @@ $ hf buckets [OPTIONS] COMMAND [ARGS]...
 * `create`: Create a new bucket.
 * `delete`: Delete a bucket.
 * `info`: Get info about a bucket.
-* `list`: (alias: ls) List buckets or files in a bucket.
+* `list`: List buckets or files in a bucket. [alias: ls]
 * `sync`: Sync files between local directory and a...
 
 ### `hf buckets cp`
@@ -343,7 +343,7 @@ Learn more
 
 ### `hf buckets list`
 
-List buckets or files in a bucket. (alias: ls)
+List buckets or files in a bucket. [alias: ls]
 
 When called with no argument or a namespace, lists buckets.
 When called with a bucket ID (namespace/bucket_name), lists files in the bucket.

--- a/src/huggingface_hub/cli/_cli_utils.py
+++ b/src/huggingface_hub/cli/_cli_utils.py
@@ -133,7 +133,7 @@ class HFCliTyperGroup(typer.core.TyperGroup):
             help_text = cmd.get_short_help_str(limit=formatter.width)
             aliases = alias_map.get(name, [])
             if aliases:
-                help_text = f"(alias: {', '.join(aliases)}) {help_text}"
+                help_text = f"{help_text} [alias: {', '.join(aliases)}]"
             topic = getattr(cmd, "topic", "main")
             topics.setdefault(topic, []).append((name, help_text))
 

--- a/utils/generate_cli_reference.py
+++ b/utils/generate_cli_reference.py
@@ -56,13 +56,13 @@ def _normalize_command_aliases(content: str) -> str:
 
     Typer generates docs with pipe-separated command names (e.g. "list | ls") when
     commands have aliases. This function transforms them into a cleaner format:
-    - Command list: `* `cmd | alias`: Desc` → `* `cmd`: (alias: alias) Desc`
+    - Command list: `* `cmd | alias`: Desc` → `* `cmd`: Desc [alias: alias]`
     - Section headers: `## `hf cmd | alias`` → `## `hf cmd`` with alias in description
     - Usage examples: `$ hf cmd | alias [OPTIONS]` → `$ hf cmd [OPTIONS]`
     """
 
     def _format_aliases(aliases: list[str]) -> str:
-        return f"(alias: {', '.join(aliases)})"
+        return f"[alias: {', '.join(aliases)}]"
 
     # Transform command list items: `* `cmd | alias`: Description`
     # Only match simple command names (alphanumeric + hyphens), not options like `--format [table|json]`
@@ -73,7 +73,7 @@ def _normalize_command_aliases(content: str) -> str:
         primary = parts[0]
         aliases = parts[1:]
         if aliases:
-            return f"* `{primary}`: {_format_aliases(aliases)} {description}"
+            return f"* `{primary}`: {description} {_format_aliases(aliases)}"
         return match.group(0)
 
     content = re.sub(


### PR DESCRIPTION
Improve CLI documentation alias formatting based on feedback in #3836.

This PR addresses how command aliases are displayed in the generated CLI documentation (`cli.md`). It standardizes the format for:
- Command list items: `command | alias` becomes `command: (alias: alias)`.
- Section headers: The main command is used, with `(alias: alias)` appended to the description.
- Usage examples: Only the main command is shown.

---
[Slack Thread](https://huggingface.slack.com/archives/D0A9313SS3G/p1772010005518929?thread_ts=1772010005.518929&cid=D0A9313SS3G)

<p><a href="https://cursor.com/agents/bc-2d83ef84-2550-54f1-a09b-17a3b76daf0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d83ef84-2550-54f1-a09b-17a3b76daf0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/output formatting-only changes; main risk is regex-based normalization missing or misformatting edge-case command strings in generated docs.
> 
> **Overview**
> Improves alias presentation across the CLI reference by converting Typer’s pipe-separated alias output (e.g. `list | ls`) into a consistent `primary` command with an appended `[alias: ...]` marker, and by showing only the primary command in usage examples.
> 
> This is implemented both at runtime in `HFCliTyperGroup.format_commands` (moving alias text to the end of the short help) and in the doc generator (`utils/generate_cli_reference.py`) via a new `_normalize_command_aliases` post-processing step; `docs/source/en/package_reference/cli.md` is updated accordingly (e.g. `hf buckets list`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ffee997d716c7c7d360f3f3247ba463a60318404. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->