### PR TITLE
[CLI] Print first example only in group command --help

### DIFF
--- a/src/huggingface_hub/cli/_cli_utils.py
+++ b/src/huggingface_hub/cli/_cli_utils.py
@@ -146,14 +146,16 @@ class HFCliTyperGroup(typer.core.TyperGroup):
                 formatter.write_dl(topics[topic])
 
     def format_epilog(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
-        # Collect examples from all commands
+        # Collect only the first example from each command (to keep group help concise)
+        # Full examples are shown in individual subcommand help (e.g. `hf buckets sync --help`)
         all_examples: list[str] = []
         for name in self.list_commands(ctx):
             cmd = self.get_command(ctx, name)
             if cmd is None or cmd.hidden:
                 continue
             cmd_examples = getattr(cmd, "examples", [])
-            all_examples.extend(cmd_examples)
+            if cmd_examples:
+                all_examples.append(cmd_examples[0])
 
         if all_examples:
             epilog = generate_epilog(all_examples)


### PR DESCRIPTION
Limit CLI group-level help to show only the first example per subcommand to reduce bloat.

Related to https://github.com/huggingface/huggingface_hub/pull/3840#issuecomment-3957928567

---
[Slack Thread](https://huggingface.slack.com/archives/D0A9313SS3G/p1772012002358539?thread_ts=1772012002.358539&cid=D0A9313SS3G)

<p><a href="https://cursor.com/agents/bc-364b06bc-0436-58b5-9bf4-c3a011330023"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-364b06bc-0436-58b5-9bf4-c3a011330023"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Help-text-only behavior change with minimal logic change and no impact on core CLI execution paths.
> 
> **Overview**
> Reduces `hf --help` output bloat by changing group-level help epilog generation to include **only the first `examples` entry per subcommand**, instead of all examples.
> 
> Individual subcommand `--help` output is unchanged and still shows the full example list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eaebec2f181fa93ec62756adc8fa23ae59e8b7e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->