### PR TITLE
Tqdm windows test failure

### DIFF
--- a/tests/test_utils_tqdm.py
+++ b/tests/test_utils_tqdm.py
@@ -121,7 +121,9 @@ class TestTqdmUtils(CapsysBaseTest):
         self.assertEqual(captured.out, "")
         self.assertIn("10/10", captured.err)  # tqdm log
 
+    @patch("huggingface_hub.utils._tqdm.HF_HUB_DISABLE_PROGRESS_BARS", None)
     def test_tqdm_stream_file(self) -> None:
+        enable_progress_bars()
         with SoftTemporaryDirectory() as tmpdir:
             filepath = Path(tmpdir) / "config.json"
             with filepath.open("w") as f:


### PR DESCRIPTION
Fix flaky `test_tqdm_stream_file` on Windows CI by explicitly enabling progress bars and patching the global disable flag.

The test was failing intermittently because it relied on the global `progress_bar_states` dictionary, which could be modified by other tests running in parallel (e.g., disabling progress bars). This fix ensures the test's environment is isolated and consistent.

---
[Slack Thread](https://huggingface.slack.com/archives/D0A9313SS3G/p1772021866358829?thread_ts=1772021866.358829&cid=D0A9313SS3G)

<p><a href="https://cursor.com/agents/bc-b90aa478-3e0d-563c-a294-c31d46121776"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b90aa478-3e0d-563c-a294-c31d46121776"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that isolates progress bar state by patching the global disable flag and explicitly enabling progress bars, reducing CI flakiness without affecting library runtime behavior.
> 
> **Overview**
> Fixes a flaky Windows CI test by making `test_tqdm_stream_file` independent of shared/global progress-bar state.
> 
> The test now patches `HF_HUB_DISABLE_PROGRESS_BARS` to `None` and explicitly calls `enable_progress_bars()` before asserting `tqdm_stream_file` output, preventing interference from other tests that may disable progress bars.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b2a8fa9d9abc117cdfd708b8b1586619f7d43b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->