### PR TITLE
Buckets doc `hf` install

### DIFF
--- a/docs/source/en/guides/buckets.md
+++ b/docs/source/en/guides/buckets.md
@@ -4,6 +4,13 @@ rendered properly in your Markdown viewer.
 
 # Buckets
 
+> [!WARNING]
+> The `hf buckets` commands are currently available from the `main` branch.
+> Install `hf` from `main` with:
+> ```bash
+> uv tool install "huggingface-hub @ git+https://github.com/huggingface/huggingface_hub.git@main"
+> ```
+
 Buckets provide S3-like object storage on Hugging Face, powered by the Xet storage backend. Unlike repositories (which are git-based and track file history), buckets are remote object storage containers designed for large-scale files with content-addressable deduplication. They are designed for use cases where you need simple, fast, mutable storage such as storing training checkpoints, logs, intermediate artifacts, or any large collection of files that doesn't need version control.
 
 You can interact with buckets using the Python API ([`HfApi`]) or the CLI (`hf buckets`). In this guide, we will walk through all the operations available.


### PR DESCRIPTION
Add a prominent note to the Buckets documentation on how to install `hf` from `main`.

---
<p><a href="https://cursor.com/agents/bc-6d5f2c63-e40e-462d-82e4-5f992eba2b7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d5f2c63-e40e-462d-82e4-5f992eba2b7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds an install note; no code or behavior changes.
> 
> **Overview**
> Adds a prominent **warning callout** at the top of the Buckets guide clarifying that `hf buckets` CLI commands are only available from the `main` branch.
> 
> Includes an explicit install command (`uv tool install "huggingface-hub @ git+https://github.com/huggingface/huggingface_hub.git@main"`) so readers can immediately install the required `hf` version.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e7d73df2379c8de84973d79e976b050b0f6729da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->