### PR TITLE
Fix Xet token invalid on repo recreation

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -52,7 +52,11 @@ import httpx
 from tqdm.auto import tqdm as base_tqdm
 from tqdm.contrib.concurrent import thread_map
 
-from huggingface_hub.utils._xet import XetTokenType, fetch_xet_connection_info_from_repo_info
+from huggingface_hub.utils._xet import (
+    XetTokenType,
+    fetch_xet_connection_info_from_repo_info,
+    reset_xet_connection_info_cache_for_repo,
+)
 
 from . import constants
 from ._commit_api import (
@@ -4231,6 +4235,7 @@ class HfApi:
 
         headers = self._build_hf_headers(token=token)
         r = get_session().request("DELETE", path, headers=headers, json=json)
+        reset_xet_connection_info_cache_for_repo(repo_type, repo_id)
         try:
             hf_raise_for_status(r)
         except RepositoryNotFoundError:

--- a/src/huggingface_hub/utils/_xet.py
+++ b/src/huggingface_hub/utils/_xet.py
@@ -167,7 +167,7 @@ def fetch_xet_connection_info_from_repo_info(
         # Note: when creating a PR on a git-based repo, user needs write access but they don't know the revision in advance.
         # => pass "/None" in URL and server will return a token for PR refs.
         url += f"/{revision}"
-    return _fetch_xet_connection_info_with_url(url, headers, params)
+    return _fetch_xet_connection_info_with_url(url, headers, params, cache_key_prefix=f"{repo_type}-{repo_id}")
 
 
 @validate_hf_hub_args
@@ -175,6 +175,7 @@ def _fetch_xet_connection_info_with_url(
     url: str,
     headers: dict[str, str],
     params: Optional[dict[str, str]] = None,
+    cache_key_prefix: Optional[str] = None,
 ) -> XetConnectionInfo:
     """
     Requests the xet connection info from the supplied URL. This includes the
@@ -199,7 +200,7 @@ def _fetch_xet_connection_info_with_url(
             If the Hub API response is improperly formatted.
     """
     # Check cache first
-    cache_key = _cache_key(url, headers, params)
+    cache_key = _cache_key(url, headers, params, prefix=cache_key_prefix)
     cached_info = XET_CONNECTION_INFO_CACHE.get(cache_key)
     if cached_info is not None:
         if not _is_expired(cached_info):
@@ -228,12 +229,27 @@ def _fetch_xet_connection_info_with_url(
     return metadata
 
 
-def _cache_key(url: str, headers: dict[str, str], params: Optional[dict[str, str]]) -> str:
+def reset_xet_connection_info_cache_for_repo(repo_type: Optional[str], repo_id: str) -> None:
+    """Reset the XET connection info cache for the given repo type and repo id.
+
+    Used when a repo is deleted.
+    """
+    if repo_type is None:
+        repo_type = constants.REPO_TYPE_MODEL
+    prefix = f"{repo_type}-{repo_id}|"
+    for k in list(XET_CONNECTION_INFO_CACHE.keys()):
+        if k.startswith(prefix):
+            XET_CONNECTION_INFO_CACHE.pop(k, None)
+
+
+def _cache_key(
+    url: str, headers: dict[str, str], params: Optional[dict[str, str]], prefix: Optional[str] = None
+) -> str:
     """Return a unique cache key for the given request parameters."""
     lower_headers = {k.lower(): v for k, v in headers.items()}  # casing is not guaranteed here
     auth_header = lower_headers.get("authorization", "")
     params_str = "&".join(f"{k}={v}" for k, v in sorted((params or {}).items(), key=lambda x: x[0]))
-    return f"{url}|{auth_header}|{params_str}"
+    return f"{prefix}|{url}|{auth_header}|{params_str}"
 
 
 def _is_expired(connection_info: XetConnectionInfo) -> bool:


### PR DESCRIPTION
Fix https://github.com/huggingface/huggingface_hub/pull/3829

Would prefer this solution over https://github.com/huggingface/huggingface_hub/pull/3830.

100% human-generated PR :smile: 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to Xet token caching and repo deletion cleanup; risk is mainly limited to cache-key behavior and ensuring tokens aren’t unnecessarily refetched.
> 
> **Overview**
> Fixes a stale-token bug where Xet connection info could be reused after deleting and recreating a repo with the same `repo_id`.
> 
> Xet token caching now includes a per-repo key prefix and `HfApi.delete_repo` explicitly purges cached Xet connection info for that repo via a new `reset_xet_connection_info_cache_for_repo` helper.
> 
> Adds an integration regression test that creates a repo, fetches read/write Xet tokens, deletes and recreates the repo, and asserts the new tokens differ.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f67644c4f9061e2d0fc0df1fb5f3330270ad2ae4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->