### PR TITLE
[Buckets] Update message when no buckets found

### DIFF
--- a/src/huggingface_hub/cli/buckets.py
+++ b/src/huggingface_hub/cli/buckets.py
@@ -378,7 +378,7 @@ def _list_buckets(
         if not quiet and format != OutputFormat.json:
             resolved_namespace = namespace if namespace is not None else api.whoami()["name"]
             print(f"No buckets found under namespace '{resolved_namespace}'.")
-        return
+            return
 
     headers = ["id", "private", "size", "total_files", "created_at"]
 


### PR DESCRIPTION
Improve the empty results message for `hf buckets list` to be more specific about the namespace.

```
✗ hf buckets list jasperai
No buckets found under namespace 'jasperai'.
```

---
[Slack Thread](https://huggingface.slack.com/archives/D0A9313SS3G/p1772098802522339?thread_ts=1772098802.522339&cid=D0A9313SS3G)

<p><a href="https://cursor.com/agents/bc-87a55e27-8924-575c-b50c-c87468d8fe78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87a55e27-8924-575c-b50c-c87468d8fe78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small CLI output change gated to non-quiet, non-JSON table output and only affects the empty-result path for bucket listing.
> 
> **Overview**
> Improves `hf buckets list` UX by emitting a clearer message when no buckets are returned, including the *resolved namespace* (explicit argument or the current user via `whoami`). The message is suppressed for `--quiet` and `--format json`, preserving machine-friendly output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f92022b08b89cc8cdfb298cc215abfd60b810d01. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->