### PR TITLE
Collection item cleanup

### DIFF
--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -219,6 +219,7 @@ _SUBMOD_ATTRS = {
         "delete_bucket",
         "delete_collection",
         "delete_collection_item",
+        "delete_collection_items_containing_repo",
         "delete_file",
         "delete_folder",
         "delete_inference_endpoint",
@@ -909,6 +910,7 @@ __all__ = [
     "delete_bucket",
     "delete_collection",
     "delete_collection_item",
+    "delete_collection_items_containing_repo",
     "delete_file",
     "delete_folder",
     "delete_inference_endpoint",
@@ -1323,6 +1325,7 @@ if TYPE_CHECKING:  # pragma: no cover
         delete_bucket,  # noqa: F401
         delete_collection,  # noqa: F401
         delete_collection_item,  # noqa: F401
+        delete_collection_items_containing_repo,  # noqa: F401
         delete_file,  # noqa: F401
         delete_folder,  # noqa: F401
         delete_inference_endpoint,  # noqa: F401


### PR DESCRIPTION
Add functionality to remove collection items when a repository is deleted.

This prevents collection entries from persisting and becoming dangling references after their associated repository has been removed. A new `delete_from_collections` parameter is added to `delete_repo` to enable this cleanup.

---
[Slack Thread](https://huggingface.slack.com/archives/C02EMARJ65P/p1772098335524129?thread_ts=1772098335.524129&cid=C02EMARJ65P)

<p><a href="https://cursor.com/agents/bc-3b7a992c-ea6c-5401-9293-b63651491faf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b7a992c-ea6c-5401-9293-b63651491faf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

