### PR TITLE
Add test for check if dataclass.repr=True before wrapping

### DIFF
--- a/tests/test_utils_strict_dataclass.py
+++ b/tests/test_utils_strict_dataclass.py
@@ -520,10 +520,10 @@ def test_custom_repr_preserved_when_repr_false():
         x: int
 
         def __repr__(self):
-            return f"MyClass(x={self.x})"
+            return f"CustomRepr(x={self.x})"
 
     obj = MyClass(x=1, extra=2)
-    assert repr(obj) == "MyClass(x=1)"
+    assert repr(obj) == "CustomRepr(x=1)"
 
 
 def test_autocompletion_attribute_without_kwargs():


### PR DESCRIPTION
Add a test case to ensure `strict` decorator preserves custom `__repr__` when `dataclass(repr=False)` is used.

This addresses a comment from PR #3823, verifying that the `strict` decorator correctly handles `__repr__` when `repr=False` is explicitly set on the dataclass, preventing it from being overridden while still excluding extra kwargs from the repr output.

---
[Slack Thread](https://huggingface.slack.com/archives/D0A9313SS3G/p1772102917548619?thread_ts=1772102917.548619&cid=D0A9313SS3G)

<p><a href="https://cursor.com/agents/bc-dd46047e-8811-5d3f-9efb-2d896d51ef75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd46047e-8811-5d3f-9efb-2d896d51ef75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a regression test around `strict`’s `__repr__` wrapping behavior; no production code changes, so risk is low and limited to test expectations.
> 
> **Overview**
> Adds a new regression test ensuring the `@strict(accept_kwargs=True)` decorator **does not override a class’s custom `__repr__`** when the dataclass is declared with `@dataclass(repr=False)`, even if extra kwargs are provided at init.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c74ed2e5a6855a15fff2d9e003b2c193518b559. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->