### PR TITLE
Remove bucket warning in docs

### DIFF
--- a/docs/source/en/guides/buckets.md
+++ b/docs/source/en/guides/buckets.md
@@ -4,13 +4,6 @@ rendered properly in your Markdown viewer.
 
 # Buckets
 
-> [!WARNING]
-> The `hf buckets` commands are currently available from the `main` branch.
-> Install `hf` from `main` with:
-> ```bash
-> uv tool install "huggingface-hub @ git+https://github.com/huggingface/huggingface_hub.git@main"
-> ```
-
 Buckets provide S3-like object storage on Hugging Face, powered by the Xet storage backend. Unlike repositories (which are git-based and track file history), buckets are remote object storage containers designed for large-scale files with content-addressable deduplication. They are designed for use cases where you need simple, fast, mutable storage such as storing training checkpoints, logs, intermediate artifacts, or any large collection of files that doesn't need version control.
 
 You can interact with buckets using the Python API ([`HfApi`]) or the CLI (`hf buckets`). In this guide, we will walk through all the operations available.


### PR DESCRIPTION
Revert https://github.com/huggingface/huggingface_hub/pull/3846 now that release imminent (cc @hanouticelina @julien-c)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change removing an outdated warning about installing `hf` from `main` to access `hf buckets` commands.
> 
> **Overview**
> Removes the top-of-page **warning** in `docs/source/en/guides/buckets.md` that stated `hf buckets` commands were only available from the `main` branch and provided install instructions from GitHub, reflecting that the feature is now expected to be generally available.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83774cbb58f77bdcec8c5e64f79f635dbb594ef7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->