### PR TITLE
test: add type validation tests for chunk_iterable

### DIFF
--- a/tests/test_utils_chunks.py
+++ b/tests/test_utils_chunks.py
@@ -30,3 +30,17 @@ class TestUtilsCommon(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             next(chunk_iterable(range(128), -1))
+
+    def test_chunk_iterable_invalid_type(self):
+        """chunk_size must be an int — floats, strings and None should fail."""
+        # string should raise ValueError
+        with self.assertRaises(ValueError):
+            next(chunk_iterable(range(10), "4"))
+
+        # float should raise ValueError even if it looks whole
+        with self.assertRaises(ValueError):
+            next(chunk_iterable(range(10), 3.5))
+
+        # None should raise ValueError
+        with self.assertRaises(ValueError):
+            next(chunk_iterable(range(10), None))


### PR DESCRIPTION
## What does this PR do?

Adds missing test coverage for `chunk_iterable` when `chunk_size` 
is given an invalid type (string, float, or None).

The function already correctly raises `ValueError` for these inputs 
via the `isinstance(chunk_size, int)` check, but this behavior 
was not covered by any existing test.

## Tests

Added `test_chunk_iterable_invalid_type` to `tests/test_utils_chunks.py`
covering:
- `chunk_size` as string → raises `ValueError`  
- `chunk_size` as float → raises `ValueError`
- `chunk_size` as None → raises `ValueError`

All existing tests continue to pass.