### PR TITLE
Bump `hf_xet` minimal package version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 
 
 # hf-xet version used in both install_requires and extras["hf_xet"]
-HF_XET_VERSION = "hf-xet>=1.3.1,<2.0.0"
+HF_XET_VERSION = "hf-xet>=1.3.2,<2.0.0"
 
 install_requires = [
     "filelock>=3.10.0",


### PR DESCRIPTION
Bump `hf_xet` to `>=1.3.2` to resolve issue #3859.

This should allow much higher throughput on machines with a large bandwidth.

---
[Slack Thread](https://huggingface.slack.com/archives/D0A9313SS3G/p1772457386016549?thread_ts=1772457386.016549&cid=D0A9313SS3G)

<p><a href="https://cursor.com/agents/bc-e560e721-018e-5785-9466-ba97cfa3ec52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e560e721-018e-5785-9466-ba97cfa3ec52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk packaging-only change, but it can affect installations by pulling a newer `hf-xet` with potentially different runtime behavior/performance on supported architectures.
> 
> **Overview**
> Updates dependency constraints to require `hf-xet>=1.3.2,<2.0.0` (previously `>=1.3.1`) in both `install_requires` and the `hf_xet` extra, ensuring installs pick up the newer `hf-xet` release on supported platforms.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 069d5812f58e4c2d009a0d120eef8a6e304706d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->