### PR TITLE
Rename 'hf discussions view' to 'hf discussions info'

### DIFF
--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -1089,11 +1089,11 @@ $ hf discussions [OPTIONS] COMMAND [ARGS]...
 * `comment`: Comment on a discussion or pull request.
 * `create`: Create a new discussion or pull request on...
 * `diff`: Show the diff of a pull request.
+* `info`: Get info about a discussion or pull request.
 * `list`: List discussions and pull requests on a repo. [alias: ls]
 * `merge`: Merge a pull request.
 * `rename`: Rename a discussion or pull request.
 * `reopen`: Reopen a closed discussion or pull request.
-* `view`: View a discussion or pull request.
 
 ### `hf discussions close`
 
@@ -1217,6 +1217,42 @@ $ hf discussions diff [OPTIONS] REPO_ID NUM
 
 Examples
   $ hf discussions diff username/my-model 5
+
+Learn more
+  Use `hf <command> --help` for more information about a command.
+  Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
+
+
+### `hf discussions info`
+
+Get info about a discussion or pull request.
+
+**Usage**:
+
+```console
+$ hf discussions info [OPTIONS] REPO_ID NUM
+```
+
+**Arguments**:
+
+* `REPO_ID`: The ID of the repo (e.g. `username/repo-name`).  [required]
+* `NUM`: The discussion or pull request number.  [required]
+
+**Options**:
+
+* `--comments`: Show all comments.
+* `--diff`: Show the diff (for pull requests).
+* `--no-color`: Disable colored output.
+* `--type, --repo-type [model|dataset|space]`: The type of repository (model, dataset, or space).  [default: model]
+* `--format [text|json]`: Output format (text or json).  [default: text]
+* `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
+* `--help`: Show this message and exit.
+
+Examples
+  $ hf discussions info username/my-model 5
+  $ hf discussions info username/my-model 5 --comments
+  $ hf discussions info username/my-model 5 --diff
+  $ hf discussions info username/my-model 5 --format json
 
 Learn more
   Use `hf <command> --help` for more information about a command.
@@ -1348,42 +1384,6 @@ $ hf discussions reopen [OPTIONS] REPO_ID NUM
 Examples
   $ hf discussions reopen username/my-model 5
   $ hf discussions reopen username/my-model 5 --comment "Reopening for further investigation."
-
-Learn more
-  Use `hf <command> --help` for more information about a command.
-  Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
-
-
-### `hf discussions view`
-
-View a discussion or pull request.
-
-**Usage**:
-
-```console
-$ hf discussions view [OPTIONS] REPO_ID NUM
-```
-
-**Arguments**:
-
-* `REPO_ID`: The ID of the repo (e.g. `username/repo-name`).  [required]
-* `NUM`: The discussion or pull request number.  [required]
-
-**Options**:
-
-* `--comments`: Show all comments.
-* `--diff`: Show the diff (for pull requests).
-* `--no-color`: Disable colored output.
-* `--type, --repo-type [model|dataset|space]`: The type of repository (model, dataset, or space).  [default: model]
-* `--format [text|json]`: Output format (text or json).  [default: text]
-* `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
-* `--help`: Show this message and exit.
-
-Examples
-  $ hf discussions view username/my-model 5
-  $ hf discussions view username/my-model 5 --comments
-  $ hf discussions view username/my-model 5 --diff
-  $ hf discussions view username/my-model 5 --format json
 
 Learn more
   Use `hf <command> --help` for more information about a command.

--- a/src/huggingface_hub/cli/discussions.py
+++ b/src/huggingface_hub/cli/discussions.py
@@ -57,8 +57,8 @@ class DiscussionKind(str, enum.Enum):
     pull_request = "pull_request"
 
 
-class ViewFormat(str, enum.Enum):
-    """Output format for the view command."""
+class InfoFormat(str, enum.Enum):
+    """Output format for the info command."""
 
     text = "text"
     json = "json"
@@ -103,7 +103,7 @@ def _read_body(body: Optional[str], body_file: Optional[Path]) -> Optional[str]:
     return body
 
 
-def _print_discussion_view(details: DiscussionWithDetails, show_comments: bool = False) -> None:
+def _print_discussion_info(details: DiscussionWithDetails, show_comments: bool = False) -> None:
     kind = "Pull Request" if details.is_pull_request else "Discussion"
 
     print(f"{ANSI.bold(details.title)} {ANSI.gray(f'#{details.num}')}")
@@ -235,15 +235,15 @@ def discussion_list(
 
 
 @discussions_cli.command(
-    "view",
+    "info",
     examples=[
-        "hf discussions view username/my-model 5",
-        "hf discussions view username/my-model 5 --comments",
-        "hf discussions view username/my-model 5 --diff",
-        "hf discussions view username/my-model 5 --format json",
+        "hf discussions info username/my-model 5",
+        "hf discussions info username/my-model 5 --comments",
+        "hf discussions info username/my-model 5 --diff",
+        "hf discussions info username/my-model 5 --format json",
     ],
 )
-def discussion_view(
+def discussion_info(
     repo_id: RepoIdArg,
     num: DiscussionNumArg,
     comments: Annotated[
@@ -269,14 +269,14 @@ def discussion_view(
     ] = False,
     repo_type: RepoTypeOpt = RepoType.model,
     format: Annotated[
-        ViewFormat,
+        InfoFormat,
         typer.Option(
             help="Output format (text or json).",
         ),
-    ] = ViewFormat.text,
+    ] = InfoFormat.text,
     token: TokenOpt = None,
 ) -> None:
-    """View a discussion or pull request."""
+    """Get info about a discussion or pull request."""
     import os
 
     if no_color:
@@ -289,14 +289,14 @@ def discussion_view(
         repo_type=repo_type.value,
     )
 
-    if format == ViewFormat.json:
+    if format == InfoFormat.json:
         result = api_object_to_dict(details)
         if not diff:
             result.pop("diff", None)
         print(json.dumps(result, indent=2))
         return
 
-    _print_discussion_view(details, show_comments=comments)
+    _print_discussion_info(details, show_comments=comments)
 
     if diff and details.diff:
         print()

--- a/tests/test_cli_discussions.py
+++ b/tests/test_cli_discussions.py
@@ -132,39 +132,39 @@ def test_list_filter_status_closed(repo_with_discussion: tuple):
 
 
 # =============================================================================
-# View
+# Info
 # =============================================================================
 
 
-def test_view_discussion(repo_with_discussion: tuple):
+def test_info_discussion(repo_with_discussion: tuple):
     repo_id, disc_num, _ = repo_with_discussion
-    result = cli(f"hf discussions view {repo_id} {disc_num}")
+    result = cli(f"hf discussions info {repo_id} {disc_num}")
     assert result.exit_code == 0, result.output
     assert "Test discussion" in result.output
     assert f"#{disc_num}" in result.output
     assert "View on Hub:" in result.output
 
 
-def test_view_pr(repo_with_discussion: tuple):
+def test_info_pr(repo_with_discussion: tuple):
     repo_id, _, pr_num = repo_with_discussion
-    result = cli(f"hf discussions view {repo_id} {pr_num}")
+    result = cli(f"hf discussions info {repo_id} {pr_num}")
     assert result.exit_code == 0, result.output
     assert "Test PR" in result.output
     assert "Pull Request" in result.output
 
 
-def test_view_json(repo_with_discussion: tuple):
+def test_info_json(repo_with_discussion: tuple):
     repo_id, disc_num, _ = repo_with_discussion
-    result = cli(f"hf discussions view {repo_id} {disc_num} --format json")
+    result = cli(f"hf discussions info {repo_id} {disc_num} --format json")
     assert result.exit_code == 0, result.output
     data = json.loads(result.output)
     assert data["num"] == disc_num
     assert data["title"] == "Test discussion"
 
 
-def test_view_no_color(repo_with_discussion: tuple):
+def test_info_no_color(repo_with_discussion: tuple):
     repo_id, disc_num, _ = repo_with_discussion
-    result = cli(f"hf discussions view {repo_id} {disc_num} --no-color")
+    result = cli(f"hf discussions info {repo_id} {disc_num} --no-color")
     assert result.exit_code == 0, result.output
     assert "\u001b[" not in result.output
 


### PR DESCRIPTION
Follow up PR after https://github.com/huggingface/huggingface_hub/pull/3855.

I think it's best to rename `hf discussions view` to `hf discussions info`. This is much more consistent with the `hf` CLI even though it diverges from the `gh` one.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit a8f0440d8112da6596793192ecae7dc5b889a57f. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->