### PR TITLE
Fix flaky LFS test: retry git clone with backoff in setup_local_clone

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -90,7 +90,7 @@ jobs:
         working-directory: ./src # For code coverage to work
         run: |
           source ../.venv/bin/activate
-          PYTEST="python -m pytest --cov=./huggingface_hub --cov-report=xml:../coverage.xml --vcr-record=none --reruns 8 --reruns-delay 2 --only-rerun '(OSError|Timeout|HTTPError.*502|HTTPError.*504||not less than or equal to 0.01)'"
+          PYTEST="python -m pytest --cov=./huggingface_hub --cov-report=xml:../coverage.xml --vcr-record=none --reruns 8 --reruns-delay 2 --only-rerun '(OSError|Timeout|HTTPError.*502|HTTPError.*504|CalledProcessError|not less than or equal to 0.01)'"
 
           case "${{ matrix.test_name }}" in
 

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -14,6 +14,7 @@
 import datetime
 import os
 import re
+import shutil
 import subprocess
 import tempfile
 import time
@@ -2804,12 +2805,22 @@ class HfLargefilesTest(HfApiCommonTest):
         scheme = urlparse(self.repo_url).scheme
         repo_url_auth = self.repo_url.replace(f"{scheme}://", f"{scheme}://user:{TOKEN}@")
 
-        subprocess.run(
-            ["git", "clone", repo_url_auth, str(self.cache_dir)],
-            check=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
+        # Retry clone with backoff: the git server may not have the repo available
+        # immediately after the API returns from create_repo.
+        for attempt in range(5):
+            result = subprocess.run(
+                ["git", "clone", repo_url_auth, str(self.cache_dir)],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            if result.returncode == 0:
+                break
+            if self.cache_dir.exists():
+                shutil.rmtree(self.cache_dir)
+            time.sleep(2**attempt)
+        else:
+            result.check_returncode()
+
         subprocess.run(["git", "lfs", "track", "*.pdf"], check=True, cwd=self.cache_dir)
         subprocess.run(["git", "lfs", "track", "*.epub"], check=True, cwd=self.cache_dir)
 


### PR DESCRIPTION
Goal: will merge if CI gets green.

Looking forward to removing `git` tests altogether :smile: 


----

The HfLargefilesTest::test_git_push_end_to_end test fails when the git server hasn't made a newly created repo available for clone yet. The pytest --reruns mechanism doesn't help because each rerun creates a NEW repo and immediately tries to clone it, hitting the same race condition.

Fix by adding retry logic with exponential backoff (1s, 2s, 4s, 8s, 16s) directly in setup_local_clone, so the SAME repo is retried until the git server is ready.

Also fix a typo in the --only-rerun regex: '||' (empty alternative that matches everything) -> add CalledProcessError to the explicit list, matching the Windows CI config that already has the correct single '|'.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit fff3286401e67c1cf3cb1706b7546e5f3426bebd. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->