### PR TITLE
Skip git clone test

### DIFF
--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2793,6 +2793,10 @@ class UploadFolderMockedTest(unittest.TestCase):
         assert deleted_files == {"file1.txt", "sub/file1.txt"}  # all the 'old' files
 
 
+@pytest.mark.skip(
+    # See https://huggingface.slack.com/archives/C02EMARJ65P/p1772636713600769 for more details (private link)
+    reason="Skipping git clone test on CI."
+)
 @pytest.mark.usefixtures("fx_cache_dir")
 class HfLargefilesTest(HfApiCommonTest):
     cache_dir: Path


### PR DESCRIPTION
Goal: CI should be green.

See https://huggingface.slack.com/archives/C02EMARJ65P/p1772636713600769 for context. Basically `git clone` on new repos on staging is broken. Let's skip the test, it's not really important anyway. Prod is unaffected. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit d0baf8d6ace03ff84da526f40f8e266e0b0f26e8. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->