### PR TITLE
[Docs] Update some community CLI examples

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -903,19 +903,19 @@ For scripting, use `--format json` to get structured output, or `--quiet` to pri
 >>> hf discussions ls username/my-model --quiet
 ```
 
-### View a discussion or PR
+### Get info for a discussion or PR
 
 To inspect a specific discussion or PR, pass the repo ID and the discussion number:
 
 ```bash
->>> hf discussions view username/my-model 5
+>>> hf discussions info username/my-model 5
 ```
 
 By default, only the discussion metadata (title, status, author, etc.) is shown. Add `--comments` to include the full conversation thread, or `--diff` to display the PR diff:
 
 ```bash
->>> hf discussions view username/my-model 5 --comments
->>> hf discussions view username/my-model 5 --diff
+>>> hf discussions info username/my-model 5 --comments
+>>> hf discussions info username/my-model 5 --diff
 ```
 
 Use `--format json` for machine-readable output, and `--no-color` to strip ANSI colors when piping to other tools.

--- a/docs/source/en/guides/community.md
+++ b/docs/source/en/guides/community.md
@@ -149,8 +149,11 @@ scripting, CI pipelines, or quick interactions without writing Python code.
 # List open discussions and PRs on a repo
 hf discussions list bigscience/bloom
 
-# View a specific discussion with comments
-hf discussions view bigscience/bloom 2 --comments
+# List discussions on a dataset repo
+hf discussions list nebius/SWE-rebench-V2 --type dataset
+
+# Get info for a specific discussion with comments
+hf discussions info bigscience/bloom 2 --comments
 
 # Create a new discussion
 hf discussions create username/repo-name --title "Bug report" --body "Description here"


### PR DESCRIPTION
fixes https://github.com/huggingface/huggingface_hub/pull/3855#discussion_r2904171694 and https://github.com/huggingface/huggingface_hub/pull/3855#discussion_r2904206288

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that adjust CLI examples; no runtime or API behavior is modified.
> 
> **Overview**
> Updates the `hf discussions` documentation to use the `info` subcommand (instead of `view`) when inspecting a discussion/PR, including the `--comments` and `--diff` examples.
> 
> Refreshes the community guide CLI snippet by adding an example for listing discussions on a dataset repo (`--type dataset`) and updating the “view discussion with comments” example to `hf discussions info`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e8c8e58c9dd4802a3db60e90e9bf650e3d9d5f29. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->