### PR TITLE
[Docs] Update Homebrew install command to `hf`

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -103,7 +103,7 @@ You can also install the CLI using [Homebrew](https://brew.sh/):
 >>> brew install hf
 ```
 
-Check out the Homebrew huggingface page [here](https://formulae.brew.sh/formula/huggingface-cli) for more details.
+Check out the Homebrew huggingface page [here](https://formulae.brew.sh/formula/hf) for more details.
 
 ## hf auth login
 

--- a/docs/source/ko/guides/cli.md
+++ b/docs/source/ko/guides/cli.md
@@ -83,7 +83,7 @@ CLI가 제대로 설치되었다면 CLI에서 사용 가능한 모든 옵션 목
 >>> brew install hf
 ```
 
-Homebrew huggingface에 대한 자세한 내용은 [여기](https://formulae.brew.sh/formula/huggingface-cli)에서 확인할 수 있습니다.
+Homebrew huggingface에 대한 자세한 내용은 [여기](https://formulae.brew.sh/formula/hf)에서 확인할 수 있습니다.
 
 ## hf auth login [[hf-login]]
 


### PR DESCRIPTION
## Summary
- Update `brew install huggingface-cli` → `brew install hf` in the CLI docs (EN + KO)
- The Homebrew formula is being renamed upstream: https://github.com/Homebrew/homebrew-core/pull/271541
- Minor markdown formatting cleanups

## Test plan
- [ ] Verify docs render correctly