### PR TITLE
Mention --global in skills add error message

### DIFF
--- a/src/huggingface_hub/cli/skills.py
+++ b/src/huggingface_hub/cli/skills.py
@@ -235,7 +235,7 @@ def skills_add(
 ) -> None:
     """Download a skill and install it for an AI assistant."""
     if not (claude or codex or cursor or opencode or dest):
-        raise CLIError("Pick a destination via --claude, --codex, --cursor, --opencode, or --dest.")
+        raise CLIError("Pick a destination via --claude, --codex, --cursor, --opencode, --global or --dest.")
 
     if dest:
         if claude or codex or cursor or opencode or global_:


### PR DESCRIPTION
## Summary
- Add `--global` to the error message shown when no destination is specified in `hf skills add`, since it's arguably the most natural option to use.

## Test plan
- [ ] Run `hf skills add <skill>` without any destination flag and verify the updated error message

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates a CLI error message string and does not change control flow or installation behavior.
> 
> **Overview**
> Updates `hf skills add` to include `--global` in the “Pick a destination” error message shown when no destination/install target is provided, improving guidance for users installing skills globally.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb336e6bb8bc38248e3f09d0e7eceb98e369c519. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->