### PR TITLE
[CLI] Accept `spaces/user/repo` as repo ID prefix shorthand

### DIFF
--- a/src/huggingface_hub/cli/_cli_utils.py
+++ b/src/huggingface_hub/cli/_cli_utils.py
@@ -290,17 +290,46 @@ class RepoType(str, Enum):
 RepoIdArg = Annotated[
     str,
     typer.Argument(
-        help="The ID of the repo (e.g. `username/repo-name`).",
+        help="The ID of the repo (e.g. `username/repo-name` or `spaces/username/repo-name`).",
     ),
 ]
 
+# Mapping from URL-style plural prefixes to repo type values
+_REPO_TYPE_PREFIXES = {
+    "spaces": "space",
+    "datasets": "dataset",
+    "models": "model",
+}
+
+
+def resolve_repo_id_and_type(repo_id: str, repo_type: Optional[RepoType] = None) -> tuple[str, str]:
+    """Parse an optional type prefix from a repo_id.
+
+    Accepts repo IDs like ``spaces/org/repo`` as shorthand for
+    ``org/repo --type space``.
+
+    Raises :class:`typer.BadParameter` when both a prefix *and* an
+    explicit ``--type`` flag are provided (ambiguous).
+
+    Returns ``(repo_id, repo_type_value)`` ready for API calls.
+    """
+    parts = repo_id.split("/", 2)
+    if len(parts) == 3 and parts[0] in _REPO_TYPE_PREFIXES:
+        if repo_type is not None:
+            raise typer.BadParameter(
+                f"Ambiguous repo type: got prefix '{parts[0]}/' in repo ID"
+                f" and --type {repo_type.value}. Use one or the other."
+            )
+        return f"{parts[1]}/{parts[2]}", _REPO_TYPE_PREFIXES[parts[0]]
+    return repo_id, (repo_type or RepoType.model).value
+
 
 RepoTypeOpt = Annotated[
-    RepoType,
+    Optional[RepoType],
     typer.Option(
         "--type",
         "--repo-type",
-        help="The type of repository (model, dataset, or space).",
+        help="The type of repository (model, dataset, or space). Inferred from repo ID prefix (e.g. spaces/) when omitted.",
     ),
 ]
 

--- a/src/huggingface_hub/cli/cache.py
+++ b/src/huggingface_hub/cli/cache.py
@@ -41,6 +41,7 @@ from ..utils._parsing import parse_duration, parse_size
 from ._cli_utils import (
     OutputFormat,
     RepoIdArg,
+    RepoType,
     RepoTypeOpt,
     RevisionOpt,
     TokenOpt,
@@ -711,7 +712,7 @@ def prune(
 )
 def verify(
     repo_id: RepoIdArg,
-    repo_type: RepoTypeOpt = RepoTypeOpt.model,
+    repo_type: RepoTypeOpt = RepoType.model,
     revision: RevisionOpt = None,
     cache_dir: Annotated[
         Optional[str],

--- a/src/huggingface_hub/cli/discussions.py
+++ b/src/huggingface_hub/cli/discussions.py
@@ -32,13 +32,13 @@ from ._cli_utils import (
     OutputFormat,
     QuietOpt,
     RepoIdArg,
-    RepoType,
     RepoTypeOpt,
     TokenOpt,
     _format_cell,
     api_object_to_dict,
     get_hf_api,
     print_list_output,
+    resolve_repo_id_and_type,
     typer_factory,
 )
 
@@ -153,8 +153,8 @@ discussions_cli = typer_factory(help="Manage discussions and pull requests on th
     "list | ls",
     examples=[
         "hf discussions list username/my-model",
+        "hf discussions list datasets/username/my-dataset --status closed",
         "hf discussions list username/my-model --kind pull_request --status merged",
-        "hf discussions list username/my-dataset --type dataset --status closed",
         "hf discussions list username/my-model --author alice --format json",
     ],
 )
@@ -178,12 +178,13 @@ def discussion_list(
     ] = DiscussionKind.all,
     author: AuthorOpt = None,
     limit: LimitOpt = 30,
-    repo_type: RepoTypeOpt = RepoType.model,
+    repo_type: RepoTypeOpt = None,
     format: FormatOpt = OutputFormat.table,
     quiet: QuietOpt = False,
     token: TokenOpt = None,
 ) -> None:
     """List discussions and pull requests on a repo."""
+    repo_id, repo_type_str = resolve_repo_id_and_type(repo_id, repo_type)
     api = get_hf_api(token=token)
 
     api_status: Optional[constants.DiscussionStatusFilter]
@@ -206,7 +207,7 @@ def discussion_list(
         author=author,
         discussion_type=api_discussion_type,
         discussion_status=api_status,
-        repo_type=repo_type.value,
+        repo_type=repo_type_str,
     ):
         if status.value in _CLIENT_SIDE_STATUSES and d.status != status.value:
             continue
@@ -238,8 +239,8 @@ def discussion_list(
     "info",
     examples=[
         "hf discussions info username/my-model 5",
+        "hf discussions info spaces/username/my-space 5",
         "hf discussions info username/my-model 5 --comments",
-        "hf discussions info username/my-model 5 --diff",
         "hf discussions info username/my-model 5 --format json",
     ],
 )
@@ -267,7 +268,7 @@ def discussion_info(
             help="Disable colored output.",
         ),
     ] = False,
-    repo_type: RepoTypeOpt = RepoType.model,
+    repo_type: RepoTypeOpt = None,
     format: Annotated[
         InfoFormat,
         typer.Option(
@@ -279,6 +280,8 @@ def discussion_info(
     """Get info about a discussion or pull request."""
     import os
 
+    repo_id, repo_type_str = resolve_repo_id_and_type(repo_id, repo_type)
+
     if no_color:
         os.environ["NO_COLOR"] = "1"
 
@@ -286,7 +289,7 @@ def discussion_info(
     details = api.get_discussion_details(
         repo_id=repo_id,
         discussion_num=num,
-        repo_type=repo_type.value,
+        repo_type=repo_type_str,
     )
 
     if format == InfoFormat.json:
@@ -310,7 +313,7 @@ def discussion_info(
         'hf discussions create username/my-model --title "Bug report"',
         'hf discussions create username/my-model --title "Feature request" --body "Please add X"',
         'hf discussions create username/my-model --title "Fix typo" --pull-request',
-        'hf discussions create username/my-dataset --type dataset --title "Data quality issue"',
+        'hf discussions create datasets/username/my-dataset --title "Data quality issue"',
     ],
 )
 def discussion_create(
@@ -344,17 +347,18 @@ def discussion_create(
             help="Create a pull request instead of a discussion.",
         ),
     ] = False,
-    repo_type: RepoTypeOpt = RepoType.model,
+    repo_type: RepoTypeOpt = None,
     token: TokenOpt = None,
 ) -> None:
     """Create a new discussion or pull request on a repo."""
+    repo_id, repo_type_str = resolve_repo_id_and_type(repo_id, repo_type)
     description = _read_body(body, body_file)
     api = get_hf_api(token=token)
     discussion = api.create_discussion(
         repo_id=repo_id,
         title=title,
         description=description,
-        repo_type=repo_type.value,
+        repo_type=repo_type_str,
         pull_request=pull_request,
     )
     kind = "pull request" if pull_request else "discussion"
@@ -388,10 +392,11 @@ def discussion_comment(
             help="Read the comment from a file. Use '-' for stdin.",
         ),
     ] = None,
-    repo_type: RepoTypeOpt = RepoType.model,
+    repo_type: RepoTypeOpt = None,
     token: TokenOpt = None,
 ) -> None:
     """Comment on a discussion or pull request."""
+    repo_id, repo_type_str = resolve_repo_id_and_type(repo_id, repo_type)
     comment = _read_body(body, body_file)
     if comment is None:
         raise typer.BadParameter("Either --body or --body-file is required.")
@@ -400,7 +405,7 @@ def discussion_comment(
         repo_id=repo_id,
         discussion_num=num,
         comment=comment,
-        repo_type=repo_type.value,
+        repo_type=repo_type_str,
     )
     print(f"Commented on #{num} in {ANSI.bold(repo_id)}")
 
@@ -430,10 +435,11 @@ def discussion_close(
             help="Skip confirmation prompt.",
         ),
     ] = False,
-    repo_type: RepoTypeOpt = RepoType.model,
+    repo_type: RepoTypeOpt = None,
     token: TokenOpt = None,
 ) -> None:
     """Close a discussion or pull request."""
+    repo_id, repo_type_str = resolve_repo_id_and_type(repo_id, repo_type)
     if not yes:
         confirm = typer.confirm(f"Close #{num} on '{repo_id}'?")
         if not confirm:
@@ -445,7 +451,7 @@ def discussion_close(
         discussion_num=num,
         new_status="closed",
         comment=comment,
-        repo_type=repo_type.value,
+        repo_type=repo_type_str,
     )
     print(f"Closed #{num} in {ANSI.bold(repo_id)}")
 
@@ -475,10 +481,11 @@ def discussion_reopen(
             help="Skip confirmation prompt.",
         ),
     ] = False,
-    repo_type: RepoTypeOpt = RepoType.model,
+    repo_type: RepoTypeOpt = None,
     token: TokenOpt = None,
 ) -> None:
     """Reopen a closed discussion or pull request."""
+    repo_id, repo_type_str = resolve_repo_id_and_type(repo_id, repo_type)
     if not yes:
         confirm = typer.confirm(f"Reopen #{num} on '{repo_id}'?")
         if not confirm:
@@ -490,7 +497,7 @@ def discussion_reopen(
         discussion_num=num,
         new_status="open",
         comment=comment,
-        repo_type=repo_type.value,
+        repo_type=repo_type_str,
     )
     print(f"Reopened #{num} in {ANSI.bold(repo_id)}")
 
@@ -510,16 +517,17 @@ def discussion_rename(
             help="The new title.",
         ),
     ],
-    repo_type: RepoTypeOpt = RepoType.model,
+    repo_type: RepoTypeOpt = None,
     token: TokenOpt = None,
 ) -> None:
     """Rename a discussion or pull request."""
+    repo_id, repo_type_str = resolve_repo_id_and_type(repo_id, repo_type)
     api = get_hf_api(token=token)
     api.rename_discussion(
         repo_id=repo_id,
         discussion_num=num,
         new_title=new_title,
-        repo_type=repo_type.value,
+        repo_type=repo_type_str,
     )
     print(f"Renamed #{num} to {ANSI.bold(new_title)} in {ANSI.bold(repo_id)}")
 
@@ -549,10 +557,11 @@ def discussion_merge(
             help="Skip confirmation prompt.",
         ),
     ] = False,
-    repo_type: RepoTypeOpt = RepoType.model,
+    repo_type: RepoTypeOpt = None,
     token: TokenOpt = None,
 ) -> None:
     """Merge a pull request."""
+    repo_id, repo_type_str = resolve_repo_id_and_type(repo_id, repo_type)
     if not yes:
         confirm = typer.confirm(f"Merge #{num} on '{repo_id}'?")
         if not confirm:
@@ -563,7 +572,7 @@ def discussion_merge(
         repo_id=repo_id,
         discussion_num=num,
         comment=comment,
-        repo_type=repo_type.value,
+        repo_type=repo_type_str,
     )
     print(f"Merged #{num} in {ANSI.bold(repo_id)}")
 
@@ -577,15 +586,16 @@ def discussion_merge(
 def discussion_diff(
     repo_id: RepoIdArg,
     num: DiscussionNumArg,
-    repo_type: RepoTypeOpt = RepoType.model,
+    repo_type: RepoTypeOpt = None,
     token: TokenOpt = None,
 ) -> None:
     """Show the diff of a pull request."""
+    repo_id, repo_type_str = resolve_repo_id_and_type(repo_id, repo_type)
     api = get_hf_api(token=token)
     details = api.get_discussion_details(
         repo_id=repo_id,
         discussion_num=num,
-        repo_type=repo_type.value,
+        repo_type=repo_type_str,
     )
     if details.diff:
         print(details.diff)

--- a/src/huggingface_hub/cli/download.py
+++ b/src/huggingface_hub/cli/download.py
@@ -50,7 +50,7 @@ from huggingface_hub.errors import CLIError
 from huggingface_hub.file_download import DryRunFileInfo, hf_hub_download
 from huggingface_hub.utils import _format_size, disable_progress_bars, enable_progress_bars, tabulate
 
-from ._cli_utils import RepoIdArg, RepoTypeOpt, RevisionOpt, TokenOpt
+from ._cli_utils import RepoIdArg, RepoType, RepoTypeOpt, RevisionOpt, TokenOpt
 
 
 DOWNLOAD_EXAMPLES = [
@@ -73,7 +73,7 @@ def download(
             help="Files to download (e.g. `config.json`, `data/metadata.jsonl`).",
         ),
     ] = None,
-    repo_type: RepoTypeOpt = RepoTypeOpt.model,
+    repo_type: RepoTypeOpt = RepoType.model,
     revision: RevisionOpt = None,
     include: Annotated[
         Optional[list[str]],


### PR DESCRIPTION
## Summary

- Accept repo IDs like `spaces/user/repo`, `datasets/user/repo`, `models/user/repo` as shorthand for `user/repo --type space` etc.
- Add `resolve_repo_id_and_type()` helper in `_cli_utils.py` that parses the prefix
- Error if both a prefix and explicit `--type` flag are provided (ambiguous)
- Prototyped for the `hf discussions` commands (all 9 subcommands)

```
# before
hf discussions list safetensors/convert --type space

# after
hf discussions list spaces/safetensors/convert
```

## Test plan
- [ ] Smoke-test `hf discussions list spaces/safetensors/convert`
- [ ] Verify error on `hf discussions list spaces/safetensors/convert --type dataset`
- [ ] Existing tests still pass