### PR TITLE
fix: use sequential read instead of seek for multipart uploads on Windows

### DIFF
--- a/src/huggingface_hub/cli/lfs.py
+++ b/src/huggingface_hub/cli/lfs.py
@@ -28,7 +28,6 @@ from huggingface_hub.errors import CLIError
 from huggingface_hub.lfs import LFS_MULTIPART_UPLOAD_COMMAND
 
 from ..utils import get_session, hf_raise_for_status, logging
-from ..utils._lfs import SliceFileObj
 
 
 logger = logging.get_logger(__name__)
@@ -139,29 +138,32 @@ def lfs_multipart_upload() -> None:
         parts = []
         with open(filepath, "rb") as file:
             for i, presigned_url in enumerate(presigned_urls):
-                with SliceFileObj(
-                    file,
-                    seek_from=i * chunk_size,
-                    read_limit=chunk_size,
-                ) as data:
-                    r = get_session().put(presigned_url, data=data)
-                    hf_raise_for_status(r)
-                    parts.append(
-                        {
-                            "etag": r.headers.get("etag"),
-                            "partNumber": i + 1,
-                        }
+                # Read chunk sequentially instead of using SliceFileObj + seek.
+                # On Windows, file.seek() with offset >= 2GB can fail due to 32-bit
+                # signed integer limits in some APIs (see issue #3871).
+                chunk_data = file.read(chunk_size)
+                if not chunk_data:
+                    raise ValueError(
+                        f"Unexpected end of file while reading part {i + 1} of multipart upload"
                     )
-                    # In order to support progress reporting while data is uploading / downloading,
-                    # the transfer process should post messages to stdout
-                    write_msg(
-                        {
-                            "event": "progress",
-                            "oid": oid,
-                            "bytesSoFar": (i + 1) * chunk_size,
-                            "bytesSinceLast": chunk_size,
-                        }
-                    )
+                r = get_session().put(presigned_url, data=chunk_data)
+                hf_raise_for_status(r)
+                parts.append(
+                    {
+                        "etag": r.headers.get("etag"),
+                        "partNumber": i + 1,
+                    }
+                )
+                # In order to support progress reporting while data is uploading / downloading,
+                # the transfer process should post messages to stdout
+                write_msg(
+                    {
+                        "event": "progress",
+                        "oid": oid,
+                        "bytesSoFar": (i + 1) * chunk_size,
+                        "bytesSinceLast": chunk_size,
+                    }
+                )
 
         r = get_session().post(
             completion_url,

--- a/src/huggingface_hub/lfs.py
+++ b/src/huggingface_hub/lfs.py
@@ -32,7 +32,6 @@ from .utils import (
     logging,
     validate_hf_hub_args,
 )
-from .utils._lfs import SliceFileObj
 from .utils.sha import sha256, sha_fileobj
 
 
@@ -383,13 +382,16 @@ def _upload_parts_iteratively(
     headers = []
     with operation.as_file(with_tqdm=True) as fileobj:
         for part_idx, part_upload_url in enumerate(sorted_parts_urls):
-            with SliceFileObj(
-                fileobj,
-                seek_from=chunk_size * part_idx,
-                read_limit=chunk_size,
-            ) as fileobj_slice:
-                # S3 might raise a transient 500 error -> let's retry if that happens
-                part_upload_res = http_backoff("PUT", part_upload_url, data=fileobj_slice)
-                hf_raise_for_status(part_upload_res)
-                headers.append(part_upload_res.headers)
+            # Read chunk sequentially instead of using SliceFileObj + seek.
+            # On Windows, file.seek() with offset >= 2GB can fail due to 32-bit
+            # signed integer limits in some APIs (see issue #3871).
+            chunk_data = fileobj.read(chunk_size)
+            if not chunk_data:
+                raise ValueError(
+                    f"Unexpected end of file while reading part {part_idx + 1} of multipart upload"
+                )
+            # S3 might raise a transient 500 error -> let's retry if that happens
+            part_upload_res = http_backoff("PUT", part_upload_url, data=chunk_data)
+            hf_raise_for_status(part_upload_res)
+            headers.append(part_upload_res.headers)
     return headers  # type: ignore


### PR DESCRIPTION
## Summary

File uploads over 2GB get stuck at ~1.98GB on Windows 11 with Python 3.12. The upload speed reduces then stops entirely.

## Root Cause

On Windows, `file.seek()` with offset >= 2GB can fail due to 32-bit signed integer limits in some C runtime APIs. The multipart LFS upload used `SliceFileObj`, which seeks to `chunk_size * part_idx` for each part. When that offset exceeds 2^31 bytes, the seek fails and the upload hangs.

## Fix

Replace `SliceFileObj` + seek with sequential reads: `file.read(chunk_size)` for each chunk. This avoids large-offset seeks entirely and works for files of any size on Windows.

Changes:
- `src/huggingface_hub/lfs.py`: `_upload_parts_iteratively` now reads chunks sequentially
- `src/huggingface_hub/cli/lfs.py`: `lfs_multipart_upload` (git-lfs custom transfer) uses the same approach

Fixes #3871

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to multipart upload chunk reading logic; primary risk is behavior differences around EOF/truncated files and memory usage per chunk.
> 
> **Overview**
> Fixes multipart LFS uploads hanging on Windows for files >2GB by **removing `SliceFileObj`/`seek()`-based chunking** and switching to sequential `read(chunk_size)` uploads in both the CLI custom transfer agent (`cli/lfs.py`) and the library uploader (`lfs._upload_parts_iteratively`).
> 
> Adds a guard that raises a `ValueError` if a chunk unexpectedly reads empty before all parts are uploaded, making truncated reads fail fast instead of stalling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 062c99bdd343ac91ea5d2f7b45220ce8d0d3563b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->