### PR TITLE
snapshot_download operation raises the generic exception even when actual error is different.

### DIFF
--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -322,7 +322,8 @@ def snapshot_download(
         else:
             # Otherwise: most likely a connection issue or Hub downtime => let's warn the user
             raise LocalEntryNotFoundError(
-                "An error happened while trying to locate the files on the Hub and we cannot find the appropriate"
+                f"Got: {api_call_error.__class__.__name__}: {api_call_error}"
+                "\nAn error happened while trying to locate the files on the Hub and we cannot find the appropriate"
                 " snapshot folder for the specified revision on the local disk. Please check your internet connection"
                 " and try again."
             ) from api_call_error


### PR DESCRIPTION
snapshot_download operation raises the generic exception even when actual error is due to the cleint connection to the custom sontype repository.

this is related to following issue:
https://github.com/huggingface/huggingface_hub/issues/3913

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts the `LocalEntryNotFoundError` message to include the original exception type/message when `snapshot_download` falls back to local cache and fails; no behavior or control-flow changes.
> 
> **Overview**
> Improves `snapshot_download` error reporting when the Hub cannot be reached and no cached snapshot is available by prepending the raised `LocalEntryNotFoundError` with the original `api_call_error` class and message.
> 
> This makes connection/proxy/custom-endpoint failures easier to diagnose while keeping the existing exception type and branching logic unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67fa67cb3503ec7bf848fa5026c77c44c96acfc3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->