### PR TITLE
[CI] All-in-one Github Action for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
               minor-prerelease)
                 # Read dev version from __init__.py: "1.6.0.dev0" → "1.6.0"
                 DEV_VERSION=$(grep -oP '__version__ = "\K[^"]+' src/huggingface_hub/__init__.py)
-                BASE_VERSION=$(echo "$DEV_VERSION" | sed 's/.dev0//')
+                BASE_VERSION=$(echo "$DEV_VERSION" | sed 's/\.dev0//')
 
                 # Find existing RC tags for this base version to determine next RC number
                 LATEST_RC=$(git tag --sort=-v:refname | grep "^v${BASE_VERSION}\.rc" | head -1 || echo "")
@@ -112,7 +112,7 @@ jobs:
               minor-release)
                 # Read dev version from __init__.py to scope the RC lookup to this minor version
                 DEV_VERSION=$(grep -oP '__version__ = "\K[^"]+' src/huggingface_hub/__init__.py)
-                BASE_VERSION=$(echo "$DEV_VERSION" | sed 's/.dev0//')
+                BASE_VERSION=$(echo "$DEV_VERSION" | sed 's/\.dev0//')
                 LATEST_RC=$(git tag --sort=-v:refname | grep -E "^v${BASE_VERSION}\.rc[0-9]+$" | head -1 || echo "")
                 if [[ -z "$LATEST_RC" ]]; then
                   echo "::error::No RC tag found for v${BASE_VERSION}. Run a prerelease first."
@@ -563,6 +563,14 @@ jobs:
           MINOR=$(echo "$VERSION" | cut -d. -f2)
           NEXT_MINOR=$((MINOR + 1))
           DEV_VERSION="${MAJOR}.${NEXT_MINOR}.0.dev0"
+
+          # Guard: skip if main already has an equal or higher version (e.g. version_override for older minor)
+          CURRENT_VERSION=$(grep -oP '__version__ = "\K[^"]+' src/huggingface_hub/__init__.py)
+          CURRENT_MINOR=$(echo "$CURRENT_VERSION" | cut -d. -f2)
+          if [[ "$CURRENT_MINOR" -ge "$NEXT_MINOR" ]]; then
+            echo "::warning::main is already at ${CURRENT_VERSION} (>= ${DEV_VERSION}). Skipping version bump."
+            exit 0
+          fi
 
           PR_BRANCH="post-release-v${VERSION}"
           git checkout -b "$PR_BRANCH"


### PR DESCRIPTION
## Summary

Consolidate the entire release lifecycle into a single `workflow_dispatch`-based workflow (`release.yml`), replacing the scattered tag-triggered workflows.

### What's new

A single **Release** workflow with three modes, triggered manually from the Actions tab:
- **`minor-prerelease`**: create release branch, bump to RC (e.g. `1.6.0.rc0`), publish to PyPI, open test branches in downstream repos (transformers, datasets, diffusers, sentence-transformers), generate AI-powered release notes and create a draft GitHub prerelease. Subsequent prereleases for the same minor version skip note generation (one draft per minor).
- **`minor-release`**: promote RC to final (e.g. `1.6.0`), publish to PyPI + Conda, update the existing draft release to point to the final tag (removing prerelease flag), open PR to bump main to next dev version.
- **`patch-release`**: increment patch (e.g. `1.6.1`), publish to PyPI + Conda, create a draft GitHub release with auto-generated notes. **In this setup we must manually cherry-pick commits into the patch branch before triggering it.**

Additionally, on minor/patch releases we generate skill docs and opens a PR to `huggingface/skills` (logic from `sync-hf-cli-skill.yml`).

Optional:
- **`version_override`** input for manual version control.
- **`dry_run`** input to validate version detection without publishing.

### Jobs overview

| # | Job | Runs on | Note |
|---|-----|---------|------|
| 1 | `prepare` | Always — detect version, create/checkout branch, bump, commit, tag, push | New |
| 2 | `publish-pypi` | All (non-dry-run) — publish `huggingface_hub` to PyPI | From `python-release.yml` |
| 3 | `publish-hf-cli` | All (non-dry-run) — publish `hf` CLI to PyPI | From `python-release-hf.yml` |
| 4 | `publish-conda` | Stable releases only — publish to Anaconda | From `release-conda.yml` |
| 5 | `release-notes` | All (non-dry-run) — patch: auto-generated notes; prerelease: AI-generated notes (first RC only); release: promotes existing draft | New |
| 6 | `test-downstream` | Prereleases only — test RC in downstream repos | From `python-prerelease.yml` |
| 7 | `post-release` | Minor releases only — PR to bump main to next dev version | New |
| 8 | `sync-hf-cli-skill` | Stable releases only — sync skill docs to skills repo | From `sync-hf-cli-skill.yml` |

Since `release.yml` uses `GITHUB_TOKEN` for git operations (which doesn't cascade), the old tag-triggered workflows won't fire. We will keep these legacy workflows for some time until we validate this new workflow works as expected (and then let's remove them).

### Required secrets

| Secret | Purpose |
|--------|---------|
| `PYPI_TOKEN_DIST_HUGGINGFACE_HUB` | Publish `huggingface_hub` to PyPI |
| `PYPI_TOKEN_DIST_HF` | Publish `hf` CLI to PyPI |
| `ANACONDA_API_TOKEN` | Publish to Anaconda |
| `HUGGINGFACE_HUB_AUTOMATIC_RC_TESTING` | Open test branches in downstream repos |
| `RELEASE_NOTES_HF_TOKEN` | HF token for release notes generation |
| `APP_ID_HUB_SKILLS_REPO` | GitHub App ID for skills repo access |
| `APP_SECRET_PREM_HUB_SKILLS_REPO` | GitHub App private key for skills repo |

In practice `RELEASE_NOTES_HF_TOKEN` is the only new secret and I've already added it in the GitHub settings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Automates branching, tagging, and publishing to PyPI/Conda plus GitHub release/PR creation; misconfiguration could publish incorrect versions or create/modify releases across repos.
> 
> **Overview**
> Introduces a new all-in-one `workflow_dispatch` workflow, `release.yml`, that centralizes the release lifecycle: it detects/overrides the target version, creates/checks out the appropriate `vX.Y-release` branch, bumps `src/huggingface_hub/__init__.py`, creates a tag, and pushes.
> 
> For non-dry runs it publishes `huggingface_hub` and the `hf` CLI to PyPI, publishes to Conda *only for non-RC releases*, manages GitHub releases (AI-generated notes for the first RC of a minor; auto-generated notes for patch; promotes draft prerelease to final on minor release), and optionally opens downstream RC test branches in key repos.
> 
> On minor releases it also opens a PR to bump `main` to the next `*.dev0` version, and on stable (non-RC) releases it generates HF CLI skill docs and opens a PR to `huggingface/skills` to sync them.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e6ab1cff739095dae3cca868b9a1fa29c33d010. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->