### PR TITLE
Make sure all expand attributes are official ModelInfo/DatasetInfo/SpaceInfo

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -814,21 +814,25 @@ class ModelInfo:
             ID of model.
         author (`str`, *optional*):
             Author of the model.
-        sha (`str`, *optional*):
-            Repo SHA at this particular revision.
+        base_models (`list[str]`, *optional*):
+            List of base models this model is derived from.
+        card_data (`ModelCardData`, *optional*):
+            Model Card Metadata  as a [`huggingface_hub.repocard_data.ModelCardData`] object.
+        children_model_count (`int`, *optional*):
+            Number of children models derived from this model.
+        config (`dict`, *optional*):
+            Model configuration.
         created_at (`datetime`, *optional*):
             Date of creation of the repo on the Hub. Note that the lowest value is `2022-03-02T23:29:04.000Z`,
             corresponding to the date when we began to store creation dates.
-        last_modified (`datetime`, *optional*):
-            Date of last commit to the repo.
-        private (`bool`):
-            Is the repo private.
         disabled (`bool`, *optional*):
             Is the repo disabled.
         downloads (`int`):
             Number of downloads of the model over the last 30 days.
         downloads_all_time (`int`):
             Cumulated number of downloads of the model since its creation.
+        eval_results (`list[EvalResultEntry]`, *optional*):
+            Model's evaluation results.
         gated (`Literal["auto", "manual", False]`, *optional*):
             Is the repo gated.
             If so, whether there is manual or automatic approval.
@@ -838,73 +842,78 @@ class ModelInfo:
             Status of the model on Inference Providers. Warm if the model is served by at least one provider.
         inference_provider_mapping (`list[InferenceProviderMapping]`, *optional*):
             A list of [`InferenceProviderMapping`] ordered after the user's provider order.
-        likes (`int`):
-            Number of likes of the model.
+        last_modified (`datetime`, *optional*):
+            Date of last commit to the repo.
         library_name (`str`, *optional*):
             Library associated with the model.
+        likes (`int`):
+            Number of likes of the model.
+        mask_token (`str`, *optional*):
+            Mask token used by the model.
+        model_index (`dict`, *optional*):
+            Model index for evaluation.
+        pipeline_tag (`str`, *optional*):
+            Pipeline tag associated with the model.
+        private (`bool`):
+            Is the repo private.
+        resource_group (`dict`, *optional*):
+            Resource group information for the model.
+        safetensors (`SafeTensorsInfo`, *optional*):
+            Model's safetensors information.
+        security_repo_status (`dict`, *optional*):
+            Model's security scan status.
+        sha (`str`, *optional*):
+            Repo SHA at this particular revision.
+        siblings (`list[RepoSibling]`):
+            List of [`huggingface_hub.hf_api.RepoSibling`] objects that constitute the model.
+        spaces (`list[str]`, *optional*):
+            List of spaces using the model.
         tags (`list[str]`):
             List of tags of the model. Compared to `card_data.tags`, contains extra tags computed by the Hub
             (e.g. supported libraries, model's arXiv).
-        pipeline_tag (`str`, *optional*):
-            Pipeline tag associated with the model.
-        mask_token (`str`, *optional*):
-            Mask token used by the model.
-        widget_data (`Any`, *optional*):
-            Widget data associated with the model.
-        model_index (`dict`, *optional*):
-            Model index for evaluation.
-        config (`dict`, *optional*):
-            Model configuration.
         transformers_info (`TransformersInfo`, *optional*):
             Transformers-specific info (auto class, processor, etc.) associated with the model.
         trending_score (`int`, *optional*):
             Trending score of the model.
         used_storage (`int`, *optional*):
             Size in bytes of the model on the Hub.
-        card_data (`ModelCardData`, *optional*):
-            Model Card Metadata  as a [`huggingface_hub.repocard_data.ModelCardData`] object.
-        siblings (`list[RepoSibling]`):
-            List of [`huggingface_hub.hf_api.RepoSibling`] objects that constitute the model.
-        spaces (`list[str]`, *optional*):
-            List of spaces using the model.
-        safetensors (`SafeTensorsInfo`, *optional*):
-            Model's safetensors information.
-        security_repo_status (`dict`, *optional*):
-            Model's security scan status.
-        eval_results (`list[EvalResultEntry]`, *optional*):
-            Model's evaluation results.
+        widget_data (`Any`, *optional*):
+            Widget data associated with the model.
     """
 
     id: str
     author: Optional[str]
-    sha: Optional[str]
+    base_models: Optional[list[str]]
+    card_data: Optional[ModelCardData]
+    children_model_count: Optional[int]
+    config: Optional[dict]
     created_at: Optional[datetime]
-    last_modified: Optional[datetime]
-    private: Optional[bool]
     disabled: Optional[bool]
     downloads: Optional[int]
     downloads_all_time: Optional[int]
+    eval_results: Optional[list[EvalResultEntry]]
     gated: Optional[Literal["auto", "manual", False]]
     gguf: Optional[dict]
     inference: Optional[Literal["warm"]]
     inference_provider_mapping: Optional[list[InferenceProviderMapping]]
-    likes: Optional[int]
+    last_modified: Optional[datetime]
     library_name: Optional[str]
-    tags: Optional[list[str]]
-    pipeline_tag: Optional[str]
+    likes: Optional[int]
     mask_token: Optional[str]
-    card_data: Optional[ModelCardData]
-    widget_data: Optional[Any]
     model_index: Optional[dict]
-    config: Optional[dict]
+    pipeline_tag: Optional[str]
+    private: Optional[bool]
+    resource_group: Optional[dict]
+    safetensors: Optional[SafeTensorsInfo]
+    security_repo_status: Optional[dict]
+    sha: Optional[str]
+    siblings: Optional[list[RepoSibling]]
+    spaces: Optional[list[str]]
+    tags: Optional[list[str]]
     transformers_info: Optional[TransformersInfo]
     trending_score: Optional[int]
     used_storage: Optional[int]
-    siblings: Optional[list[RepoSibling]]
-    spaces: Optional[list[str]]
-    safetensors: Optional[SafeTensorsInfo]
-    security_repo_status: Optional[dict]
-    eval_results: Optional[list[EvalResultEntry]]
+    widget_data: Optional[Any]
 
     def __init__(self, **kwargs):
         self.id = kwargs.pop("id")
@@ -995,6 +1004,9 @@ class ModelInfo:
         self.security_repo_status = kwargs.pop("securityRepoStatus", None)
         eval_results = kwargs.pop("evalResults", None)
         self.eval_results = parse_eval_result_entries(eval_results) if eval_results else None
+        self.base_models = kwargs.pop("baseModels", None)
+        self.children_model_count = kwargs.pop("childrenModelCount", None)
+        self.resource_group = kwargs.pop("resourceGroup", None)
         # backwards compatibility
         self.lastModified = self.last_modified
         self.cardData = self.card_data
@@ -1017,34 +1029,40 @@ class DatasetInfo:
             ID of dataset.
         author (`str`):
             Author of the dataset.
-        sha (`str`):
-            Repo SHA at this particular revision.
+        card_data (`DatasetCardData`, *optional*):
+            Dataset Card Metadata  as a [`huggingface_hub.repocard_data.DatasetCardData`] object.
+        citation (`str`, *optional*):
+            Citation information for the dataset.
         created_at (`datetime`, *optional*):
             Date of creation of the repo on the Hub. Note that the lowest value is `2022-03-02T23:29:04.000Z`,
             corresponding to the date when we began to store creation dates.
-        last_modified (`datetime`, *optional*):
-            Date of last commit to the repo.
-        private (`bool`):
-            Is the repo private.
+        description (`str`, *optional*):
+            Description of the dataset.
         disabled (`bool`, *optional*):
             Is the repo disabled.
-        gated (`Literal["auto", "manual", False]`, *optional*):
-            Is the repo gated.
-            If so, whether there is manual or automatic approval.
         downloads (`int`):
             Number of downloads of the dataset over the last 30 days.
         downloads_all_time (`int`):
-            Cumulated number of downloads of the model since its creation.
+            Cumulated number of downloads of the dataset since its creation.
+        gated (`Literal["auto", "manual", False]`, *optional*):
+            Is the repo gated.
+            If so, whether there is manual or automatic approval.
+        last_modified (`datetime`, *optional*):
+            Date of last commit to the repo.
         likes (`int`):
             Number of likes of the dataset.
-        tags (`list[str]`):
-            List of tags of the dataset.
-        card_data (`DatasetCardData`, *optional*):
-            Model Card Metadata  as a [`huggingface_hub.repocard_data.DatasetCardData`] object.
-        siblings (`list[RepoSibling]`):
-            List of [`huggingface_hub.hf_api.RepoSibling`] objects that constitute the dataset.
         paperswithcode_id (`str`, *optional*):
             Papers with code ID of the dataset.
+        private (`bool`):
+            Is the repo private.
+        resource_group (`dict`, *optional*):
+            Resource group information for the dataset.
+        sha (`str`):
+            Repo SHA at this particular revision.
+        siblings (`list[RepoSibling]`):
+            List of [`huggingface_hub.hf_api.RepoSibling`] objects that constitute the dataset.
+        tags (`list[str]`):
+            List of tags of the dataset.
         trending_score (`int`, *optional*):
             Trending score of the dataset.
         used_storage (`int`, *optional*):
@@ -1053,21 +1071,24 @@ class DatasetInfo:
 
     id: str
     author: Optional[str]
-    sha: Optional[str]
+    card_data: Optional[DatasetCardData]
+    citation: Optional[str]
     created_at: Optional[datetime]
-    last_modified: Optional[datetime]
-    private: Optional[bool]
-    gated: Optional[Literal["auto", "manual", False]]
+    description: Optional[str]
     disabled: Optional[bool]
     downloads: Optional[int]
     downloads_all_time: Optional[int]
+    gated: Optional[Literal["auto", "manual", False]]
+    last_modified: Optional[datetime]
     likes: Optional[int]
     paperswithcode_id: Optional[str]
+    private: Optional[bool]
+    resource_group: Optional[dict]
+    sha: Optional[str]
+    siblings: Optional[list[RepoSibling]]
     tags: Optional[list[str]]
     trending_score: Optional[int]
     used_storage: Optional[int]
-    card_data: Optional[DatasetCardData]
-    siblings: Optional[list[RepoSibling]]
 
     def __init__(self, **kwargs):
         self.id = kwargs.pop("id")
@@ -1114,6 +1135,9 @@ class DatasetInfo:
             if siblings is not None
             else None
         )
+        self.citation = kwargs.pop("citation", None)
+        self.description = kwargs.pop("description", None)
+        self.resource_group = kwargs.pop("resourceGroup", None)
         # backwards compatibility
         self.lastModified = self.last_modified
         self.cardData = self.card_data
@@ -1135,40 +1159,42 @@ class SpaceInfo:
             ID of the Space.
         author (`str`, *optional*):
             Author of the Space.
-        sha (`str`, *optional*):
-            Repo SHA at this particular revision.
+        card_data (`SpaceCardData`, *optional*):
+            Space Card Metadata  as a [`huggingface_hub.repocard_data.SpaceCardData`] object.
         created_at (`datetime`, *optional*):
             Date of creation of the repo on the Hub. Note that the lowest value is `2022-03-02T23:29:04.000Z`,
             corresponding to the date when we began to store creation dates.
-        last_modified (`datetime`, *optional*):
-            Date of last commit to the repo.
-        private (`bool`):
-            Is the repo private.
+        datasets (`list[str]`, *optional*):
+            List of datasets used by the Space.
+        disabled (`bool`, *optional*):
+            Is the Space disabled.
         gated (`Literal["auto", "manual", False]`, *optional*):
             Is the repo gated.
             If so, whether there is manual or automatic approval.
-        disabled (`bool`, *optional*):
-            Is the Space disabled.
         host (`str`, *optional*):
             Host URL of the Space.
-        subdomain (`str`, *optional*):
-            Subdomain of the Space.
+        last_modified (`datetime`, *optional*):
+            Date of last commit to the repo.
         likes (`int`):
             Number of likes of the Space.
-        tags (`list[str]`):
-            List of tags of the Space.
-        siblings (`list[RepoSibling]`):
-            List of [`huggingface_hub.hf_api.RepoSibling`] objects that constitute the Space.
-        card_data (`SpaceCardData`, *optional*):
-            Space Card Metadata  as a [`huggingface_hub.repocard_data.SpaceCardData`] object.
+        models (`list[str]`, *optional*):
+            List of models used by the Space.
+        private (`bool`):
+            Is the repo private.
+        resource_group (`dict`, *optional*):
+            Resource group information for the Space.
         runtime (`SpaceRuntime`, *optional*):
             Space runtime information as a [`huggingface_hub.hf_api.SpaceRuntime`] object.
         sdk (`str`, *optional*):
             SDK used by the Space.
-        models (`list[str]`, *optional*):
-            List of models used by the Space.
-        datasets (`list[str]`, *optional*):
-            List of datasets used by the Space.
+        sha (`str`, *optional*):
+            Repo SHA at this particular revision.
+        siblings (`list[RepoSibling]`):
+            List of [`huggingface_hub.hf_api.RepoSibling`] objects that constitute the Space.
+        subdomain (`str`, *optional*):
+            Subdomain of the Space.
+        tags (`list[str]`):
+            List of tags of the Space.
         trending_score (`int`, *optional*):
             Trending score of the Space.
         used_storage (`int`, *optional*):
@@ -1177,24 +1203,25 @@ class SpaceInfo:
 
     id: str
     author: Optional[str]
-    sha: Optional[str]
+    card_data: Optional[SpaceCardData]
     created_at: Optional[datetime]
-    last_modified: Optional[datetime]
-    private: Optional[bool]
-    gated: Optional[Literal["auto", "manual", False]]
+    datasets: Optional[list[str]]
     disabled: Optional[bool]
+    gated: Optional[Literal["auto", "manual", False]]
     host: Optional[str]
-    subdomain: Optional[str]
+    last_modified: Optional[datetime]
     likes: Optional[int]
+    models: Optional[list[str]]
+    private: Optional[bool]
+    resource_group: Optional[dict]
+    runtime: Optional[SpaceRuntime]
     sdk: Optional[str]
-    tags: Optional[list[str]]
+    sha: Optional[str]
     siblings: Optional[list[RepoSibling]]
+    subdomain: Optional[str]
+    tags: Optional[list[str]]
     trending_score: Optional[int]
     used_storage: Optional[int]
-    card_data: Optional[SpaceCardData]
-    runtime: Optional[SpaceRuntime]
-    models: Optional[list[str]]
-    datasets: Optional[list[str]]
 
     def __init__(self, **kwargs):
         self.id = kwargs.pop("id")
@@ -1244,6 +1271,7 @@ class SpaceInfo:
         self.runtime = SpaceRuntime(runtime) if runtime else None
         self.models = kwargs.pop("models", None)
         self.datasets = kwargs.pop("datasets", None)
+        self.resource_group = kwargs.pop("resourceGroup", None)
         # backwards compatibility
         self.lastModified = self.last_modified
         self.cardData = self.card_data

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2072,6 +2072,21 @@ class HfApiPublicProductionTest(unittest.TestCase):
             self._api.model_info("HuggingFaceH4/zephyr-7b-beta", expand=["foo"])
         assert cm.exception.response.status_code == 400
 
+    def test_model_info_expand_all_are_official_attributes(self):
+        """All expand properties should be official ModelInfo attributes, not just __dict__ extras."""
+        all_expand_values = list(get_args(ExpandModelProperty_T))
+
+        dataclass_fields = {f.name for f in ModelInfo.__dataclass_fields__.values()}
+        missing_attrs = []
+        for expand_param in all_expand_values:
+            attr_name = _to_snake_case(expand_param)
+            if attr_name not in dataclass_fields:
+                missing_attrs.append(f"{expand_param!r} -> {attr_name!r}")
+        assert not missing_attrs, (
+            f"The following expand parameters are not official ModelInfo attributes "
+            f"(they fall through to __dict__.update): {missing_attrs}"
+        )
+
     def test_model_info_expand_cannot_be_used_with_other_params(self):
         # `expand` cannot be used with other params
         with self.assertRaises(ValueError):
@@ -2290,6 +2305,21 @@ class HfApiPublicProductionTest(unittest.TestCase):
             self._api.dataset_info("HuggingFaceH4/no_robots", expand=["foo"])
         assert cm.exception.response.status_code == 400
 
+    def test_dataset_info_expand_all_are_official_attributes(self):
+        """All expand properties should be official DatasetInfo attributes, not just __dict__ extras."""
+        all_expand_values = list(get_args(ExpandDatasetProperty_T))
+
+        dataclass_fields = {f.name for f in DatasetInfo.__dataclass_fields__.values()}
+        missing_attrs = []
+        for expand_param in all_expand_values:
+            attr_name = _to_snake_case(expand_param)
+            if attr_name not in dataclass_fields:
+                missing_attrs.append(f"{expand_param!r} -> {attr_name!r}")
+        assert not missing_attrs, (
+            f"The following expand parameters are not official DatasetInfo attributes "
+            f"(they fall through to __dict__.update): {missing_attrs}"
+        )
+
     def test_dataset_info_expand_cannot_be_used_with_files_metadata(self):
         # `expand` cannot be used with other `files_metadata`
         with self.assertRaises(ValueError):
@@ -2321,6 +2351,21 @@ class HfApiPublicProductionTest(unittest.TestCase):
         with self.assertRaises(HfHubHTTPError) as cm:
             self._api.space_info("HuggingFaceH4/zephyr-chat", expand=["foo"])
         assert cm.exception.response.status_code == 400
+
+    def test_space_info_expand_all_are_official_attributes(self):
+        """All expand properties should be official SpaceInfo attributes, not just __dict__ extras."""
+        all_expand_values = list(get_args(ExpandSpaceProperty_T))
+
+        dataclass_fields = {f.name for f in SpaceInfo.__dataclass_fields__.values()}
+        missing_attrs = []
+        for expand_param in all_expand_values:
+            attr_name = _to_snake_case(expand_param)
+            if attr_name not in dataclass_fields:
+                missing_attrs.append(f"{expand_param!r} -> {attr_name!r}")
+        assert not missing_attrs, (
+            f"The following expand parameters are not official SpaceInfo attributes "
+            f"(they fall through to __dict__.update): {missing_attrs}"
+        )
 
     def test_space_info_expand_cannot_be_used_with_files_metadata(self):
         # `expand` cannot be used with other files_metadata
@@ -4822,3 +4867,10 @@ class HfApiVerifyChecksumsTest(HfApiCommonTest):
 
         res = self._api.verify_repo_checksums(repo_id=repo_id, revision=commit, cache_dir=storage.parent)
         assert res.revision == commit and res.checked_count == 1 and not res.mismatches
+
+
+def _to_snake_case(name: str) -> str:
+    """Convert camelCase to snake_case (e.g. 'downloadsAllTime' -> 'downloads_all_time', 'model-index' -> 'model_index')."""
+    import re
+
+    return re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", name).replace("-", "_").lower()


### PR DESCRIPTION
Follow-up after https://github.com/huggingface/huggingface_hub/pull/3911 which made `used_storage` an official attribute.

This was not the only missing field. This PR adds a test to check that all `expand` parameters are official attributes of the Info objects. A few ones were missing:

```
  ModelInfo — 4 missing:                                                                                               
  - base_models (baseModels) — list of base models this model is derived from
  - children_model_count (childrenModelCount) — number of children models                                              
  - model_index (model-index) — already handled in __init__ but the test's _to_snake_case didn't convert hyphens to
  underscores, so I fixed the helper                                                                                   
  - resource_group (resourceGroup) — resource group information                                                        
                                                                                                                       
  DatasetInfo — 3 missing:                                                                                             
  - citation (citation) — citation information                                                                         
  - description (description) — description of the dataset                                                             
  - resource_group (resourceGroup) — resource group information                                                        
                                                                                                                       
  SpaceInfo — 1 missing:                                    
  - resource_group (resourceGroup) — resource group information 
```

This PR adds them officially + reorders attributes alphabetically (was mostly the case already but not completely)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly additive typing/metadata changes plus tests; behavior should be unchanged aside from exposing a few additional response fields as official attributes.
> 
> **Overview**
> Ensures `expand` parameters for `model_info`, `dataset_info`, and `space_info` always map to *official* dataclass attributes (rather than silently falling through to `__dict__.update`) by adding new tests that validate `Expand*Property_T` values against each Info class’ dataclass fields.
> 
> Promotes several previously “extra” response keys to first-class attributes: `ModelInfo` gains `base_models`, `children_model_count`, and `resource_group`; `DatasetInfo` gains `citation`, `description`, and `resource_group`; `SpaceInfo` gains `resource_group`. A small helper is added in tests to convert camelCase and hyphenated expand values (e.g. `model-index`) to snake_case for the validation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92531396e3dfa8810b0074f7dd59017e641f7c22. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->