### PR TITLE
fix: correct inverted `skip_if_logged_in` logic in interpreter_login/notebook_login

### DIFF
--- a/src/huggingface_hub/_login.py
+++ b/src/huggingface_hub/_login.py
@@ -246,7 +246,7 @@ def interpreter_login(*, skip_if_logged_in: bool = False) -> None:
         skip_if_logged_in (`bool`, defaults to `False`):
             If `True`, do not prompt for token if user is already logged in.
     """
-    if not skip_if_logged_in and get_token() is not None:
+    if skip_if_logged_in and get_token() is not None:
         logger.info("User is already logged in.")
         return
 
@@ -316,7 +316,7 @@ def notebook_login(*, skip_if_logged_in: bool = False) -> None:
             "The `notebook_login` function can only be used in a notebook (Jupyter or"
             " Colab) and you need the `ipywidgets` module: `pip install ipywidgets`."
         )
-    if not skip_if_logged_in and get_token() is not None:
+    if skip_if_logged_in and get_token() is not None:
         logger.info("User is already logged in.")
         return
 


### PR DESCRIPTION
## Summary

Fix inverted boolean condition in `interpreter_login()` and `notebook_login()` that caused `hf auth login` to silently skip when already logged in.

## Root cause

Both functions had:
```python
if not skip_if_logged_in and get_token() is not None:
    logger.info("User is already logged in.")
    return
```

Since the default is `skip_if_logged_in=False`, `not False` = `True`, so the early return always triggered when a token existed — making it impossible to add a second token interactively.

## Fix

```python
if skip_if_logged_in and get_token() is not None:
```

Now the early return only triggers when `skip_if_logged_in=True` **and** a token exists, matching the docstring: *"If True, do not prompt for token if user is already logged in."*

## Changes

| File | Line | Change |
|---|---|---|
| `_login.py:249` | `interpreter_login()` | `not skip_if_logged_in` → `skip_if_logged_in` |
| `_login.py:319` | `notebook_login()` | `not skip_if_logged_in` → `skip_if_logged_in` |

Fixes #3917

## Test plan

- [ ] `hf auth login` with existing token → should now prompt for new token
- [ ] `hf auth login` with `skip_if_logged_in=True` and existing token → should skip
- [ ] `hf auth login` without existing token → should prompt regardless

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized logic fix to login prompting behavior; no changes to token validation/storage paths beyond when the prompt is shown.
> 
> **Overview**
> Fixes an inverted boolean condition in `interpreter_login()` and `notebook_login()` so the login UI is no longer skipped by default when an existing token is present.
> 
> With the corrected check (`if skip_if_logged_in and get_token() is not None`), users can re-authenticate interactively to replace an existing token, while still being able to suppress prompting when `skip_if_logged_in=True`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 260e92bf3bfb8108f6a99bbcf2a91dfea14390b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->