### PR TITLE
Allow 'hf skills add' default directory

### DIFF
--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -3121,6 +3121,9 @@ $ hf skills [OPTIONS] COMMAND [ARGS]...
 
 Download a skill and install it for an AI assistant.
 
+Default location is in the current directory (.agents/skills) or user-level (~/.agents/skills).
+If custom agents are specified (e.g. --claude --codex --cursor --opencode, etc), the skill will be symlinked to the agent's skills directory.
+
 **Usage**:
 
 ```console
@@ -3139,10 +3142,10 @@ $ hf skills add [OPTIONS]
 * `--help`: Show this message and exit.
 
 Examples
-  $ hf skills add --claude
-  $ hf skills add --cursor
-  $ hf skills add --claude --global
-  $ hf skills add --codex --opencode --cursor
+  $ hf skills add
+  $ hf skills add --global
+  $ hf skills add --claude --cursor
+  $ hf skills add --codex --opencode --cursor --global
 
 Learn more
   Use `hf <command> --help` for more information about a command.

--- a/src/huggingface_hub/cli/skills.py
+++ b/src/huggingface_hub/cli/skills.py
@@ -14,6 +14,10 @@
 """Contains commands to manage skills for AI assistants.
 
 Usage:
+    # install the hf-cli skill in common .agents/skills directory (either in current directory or user-level)
+    hf skills add
+    hf skills add --global
+
     # install the hf-cli skill for Claude (project-level, in current directory)
     hf skills add --claude
 
@@ -41,8 +45,6 @@ from typing import Annotated, Optional
 import typer
 from click import Context, Group
 from typer.main import get_command
-
-from huggingface_hub.errors import CLIError
 
 from ._cli_utils import typer_factory
 
@@ -200,10 +202,10 @@ def skills_preview() -> None:
 @skills_cli.command(
     "add",
     examples=[
-        "hf skills add --claude",
-        "hf skills add --cursor",
-        "hf skills add --claude --global",
-        "hf skills add --codex --opencode --cursor",
+        "hf skills add",
+        "hf skills add --global",
+        "hf skills add --claude --cursor",
+        "hf skills add --codex --opencode --cursor --global",
     ],
 )
 def skills_add(
@@ -233,10 +235,11 @@ def skills_add(
         ),
     ] = False,
 ) -> None:
-    """Download a skill and install it for an AI assistant."""
-    if not (claude or codex or cursor or opencode or dest):
-        raise CLIError("Pick a destination via --claude, --codex, --cursor, --opencode, or --dest.")
+    """Download a skill and install it for an AI assistant.
 
+    Default location is in the current directory (.agents/skills) or user-level (~/.agents/skills).
+    If custom agents are specified (e.g. --claude --codex --cursor --opencode, etc), the skill will be symlinked to the agent's skills directory.
+    """
     if dest:
         if claude or codex or cursor or opencode or global_:
             print("--dest cannot be combined with --claude, --codex, --cursor, --opencode, or --global.")
@@ -245,6 +248,12 @@ def skills_add(
         print(f"Installed '{DEFAULT_SKILL_ID}' to {skill_dest}")
         return
 
+    # Install to central location
+    central_path = CENTRAL_GLOBAL if global_ else CENTRAL_LOCAL
+    central_skill_path = _install_to(central_path, force)
+    print(f"Installed '{DEFAULT_SKILL_ID}' to central location: {central_skill_path}")
+
+    # Create symlinks in agent directories
     targets_dict = GLOBAL_TARGETS if global_ else LOCAL_TARGETS
     agent_targets: list[Path] = []
     if claude:
@@ -255,10 +264,6 @@ def skills_add(
         agent_targets.append(targets_dict["cursor"])
     if opencode:
         agent_targets.append(targets_dict["opencode"])
-
-    central_path = CENTRAL_GLOBAL if global_ else CENTRAL_LOCAL
-    central_skill_path = _install_to(central_path, force)
-    print(f"Installed '{DEFAULT_SKILL_ID}' to central location: {central_skill_path}")
 
     for agent_target in agent_targets:
         link_path = _create_symlink(agent_target, central_skill_path, force)


### PR DESCRIPTION
Since https://github.com/huggingface/huggingface_hub/pull/3755, skill is installed in either `.agents/skills` or `~/.agents/skills` (if --global is set), and then symlinked to specific directories for claude, cursor, etc. This PR allows to do `hf skills add` to install to default agents directory without having to specify to destination. 

This PR makes https://github.com/huggingface/huggingface_hub/pull/3904 unrelevant.

```
✗ hf skills add
Installed 'hf-cli' to central location: /home/wauplin/projects/huggingface_hub/.agents/skills/hf-cli
```

```
✗ hf skills add --global
Installed 'hf-cli' to central location: /home/wauplin/.agents/skills/hf-cli
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavior change limited to the `hf skills add` CLI default install path; risk is mainly unintended installs to the central directory when users previously expected an error.
> 
> **Overview**
> `hf skills add` no longer requires an explicit destination flag; it now installs the `hf-cli` skill into the default central skills directory (`.agents/skills` or `~/.agents/skills` with `--global`) and only creates agent-specific symlinks when agent flags are provided.
> 
> Updates the command help/docs and examples accordingly, and removes the prior `CLIError` guard that forced users to pick `--claude/--codex/--cursor/--opencode` or `--dest`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13c5979c1f618123646891039f2245fe53aad936. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->