### PR TITLE
Update error message when a stored token is invalid

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -2091,7 +2091,9 @@ class HfApi:
                         "Note that HF_TOKEN takes precedence over `hf auth login`."
                     )
                 elif token == _get_token_from_file():
-                    error_message += " The token stored is invalid. Please run `hf auth login` to update it."
+                    error_message += (
+                        " The token stored is invalid. Please run `hf auth login --force` to set a new token."
+                    )
                 raise HfHubHTTPError(error_message, response=e.response) from e
             if e.response.status_code == 429:
                 error_message = (


### PR DESCRIPTION
follow-up to #3920 and related to this internal slack [message](https://huggingface.slack.com/archives/C02V5EA0A95/p1773335839066729).

