### PR TITLE
Fix stuck uploads/downloads on network interruptions by adding timeouts and unified retries

### DIFF
--- a/src/huggingface_hub/_commit_api.py
+++ b/src/huggingface_hub/_commit_api.py
@@ -755,6 +755,7 @@ def _fetch_upload_modes(
             json=payload,
             headers=headers,
             params={"create_pr": "1"} if create_pr else None,
+            timeout=constants.HF_HUB_DOWNLOAD_TIMEOUT,
         )
         hf_raise_for_status(resp)
         preupload_info = _validate_preupload_info(resp.json())

--- a/src/huggingface_hub/_hot_reload/client.py
+++ b/src/huggingface_hub/_hot_reload/client.py
@@ -19,6 +19,7 @@ from typing import Iterator, Literal, Optional, TypedDict, Union
 
 import httpx
 
+from .. import constants
 from ..utils._headers import build_hf_headers
 from ..utils._http import hf_raise_for_status
 from .sse_client import SSEClient
@@ -56,6 +57,7 @@ class ReloadClient:
         self.client = httpx.Client(
             base_url=f"{base_host}/--replicas/+{replica_hash}",
             headers=build_hf_headers(token=token),
+            timeout=constants.DEFAULT_REQUEST_TIMEOUT,
         )
 
     def get_reload(self, reload_id: str) -> Iterator[ApiGetReloadEventSourceData]:

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -416,7 +416,7 @@ def http_get(
                         new_resume_size += len(chunk)
                         # Some data has been downloaded from the server so we reset the number of retries.
                         _nb_retries = 5
-            except (httpx.ConnectError, httpx.TimeoutException) as e:
+            except _DEFAULT_RETRY_ON_EXCEPTIONS as e:
                 # If ConnectionError (SSLError) or ReadTimeout happen while streaming data from the server, it is most likely
                 # a transient error (network outage?). We log a warning message and try to resume the download a few times
                 # before giving up. Tre retry mechanism is basic but should be enough in most cases.

--- a/src/huggingface_hub/lfs.py
+++ b/src/huggingface_hub/lfs.py
@@ -162,7 +162,13 @@ def post_lfs_batch_info(
         **build_hf_headers(token=token),
         **(headers or {}),
     }
-    resp = http_backoff("POST", batch_url, headers=headers, json=payload)
+    resp = http_backoff(
+        "POST",
+        batch_url,
+        headers=headers,
+        json=payload,
+        timeout=constants.HF_HUB_DOWNLOAD_TIMEOUT,
+    )
     hf_raise_for_status(resp)
     batch_info = resp.json()
 
@@ -258,6 +264,7 @@ def lfs_upload(
             verify_url,
             headers=build_hf_headers(token=token, headers=headers),
             json={"oid": operation.upload_info.sha256.hex(), "size": operation.upload_info.size},
+            timeout=constants.HF_HUB_DOWNLOAD_TIMEOUT,
         )
         hf_raise_for_status(verify_resp)
     logger.debug(f"{operation.path_in_repo}: Upload successful")
@@ -317,7 +324,12 @@ def _upload_single_part(operation: "CommitOperationAdd", upload_url: str) -> Non
     """
     with operation.as_file(with_tqdm=True) as fileobj:
         # S3 might raise a transient 500 error -> let's retry if that happens
-        response = http_backoff("PUT", upload_url, data=fileobj)
+        response = http_backoff(
+            "PUT",
+            upload_url,
+            data=fileobj,
+            timeout=constants.HF_HUB_DOWNLOAD_TIMEOUT,
+        )
         hf_raise_for_status(response)
 
 
@@ -340,6 +352,7 @@ def _upload_multi_part(operation: "CommitOperationAdd", header: dict, chunk_size
         upload_url,
         json=_get_completion_payload(response_headers, operation.upload_info.sha256.hex()),
         headers=LFS_HEADERS,
+        timeout=constants.HF_HUB_DOWNLOAD_TIMEOUT,
     )
     hf_raise_for_status(completion_res)
 
@@ -389,7 +402,12 @@ def _upload_parts_iteratively(
                 read_limit=chunk_size,
             ) as fileobj_slice:
                 # S3 might raise a transient 500 error -> let's retry if that happens
-                part_upload_res = http_backoff("PUT", part_upload_url, data=fileobj_slice)
+                part_upload_res = http_backoff(
+                    "PUT",
+                    part_upload_url,
+                    data=fileobj_slice,
+                    timeout=constants.HF_HUB_DOWNLOAD_TIMEOUT,
+                )
                 hf_raise_for_status(part_upload_res)
                 headers.append(part_upload_res.headers)
     return headers  # type: ignore


### PR DESCRIPTION
在不稳定的网络条件下，使用 `huggingface_hub CLI` 的上传和下载在连接中断时，最后一个HTTP请求会被卡住，而不是超时（并重试）。这似乎是由于部分HTTP调用缺少显式超时。该PR在缺失的HTTP调用中添加显式超时（`HF_HUB_DOWNLOAD_TIMEOUT` / `DEFAULT_REQUEST_TIMEOUT`），并将流式下载逻辑切换为使用共享 `_DEFAULT_RETRY_ON_EXCEPTIONS`。这使上传和下载更稳健，通过定时处理停顿连接并自动恢复，而不是无限期卡住。


Under unstable network conditions, uploads and downloads using the `huggingface_hub CLI` would stall—specifically, the final HTTP request would hang indefinitely rather than timing out (and retrying) when the connection was interrupted. This appears to be caused by the absence of explicit timeouts in certain HTTP calls. This PR adds explicit timeouts (`HF_HUB_DOWNLOAD_TIMEOUT` / `DEFAULT_REQUEST_TIMEOUT`) to these missing HTTP calls and switches the streaming download logic to utilize the shared `_DEFAULT_RETRY_ON_EXCEPTIONS` set. This makes uploads and downloads more robust by ensuring that stalled connections are properly timed out and automatically resumed, rather than remaining stuck indefinitely.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core upload/download HTTP paths by adding explicit timeouts and broadening the retry exception set, which could change behavior for slow connections or previously non-retried errors. Main risk is unintended timeouts/retries impacting large transfers, but changes are small and scoped to request configuration.
> 
> **Overview**
> Prevents Hub transfers from hanging indefinitely under flaky networks by adding explicit request timeouts to previously unbounded calls.
> 
> Applies `HF_HUB_DOWNLOAD_TIMEOUT` to commit preupload negotiation and multiple LFS batch/verify/upload requests (single-part, multipart parts, and completion), and sets `DEFAULT_REQUEST_TIMEOUT` on the hot-reload `httpx.Client`. Also updates streaming download (`http_get`) to retry on the shared `_DEFAULT_RETRY_ON_EXCEPTIONS` set instead of a narrower exception list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26694bdbf38b8db321c00d3da11304d8c19c6628. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->