### PR TITLE
[HfFileSystem] fix hffs glob in missing subdir

### DIFF
--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -539,7 +539,10 @@ class HfFileSystem(fsspec.AbstractFileSystem, metaclass=_Cached):
             # Path could be a file
             if not resolved_path.path:
                 _raise_file_not_found(path, None)
-            out = self._ls_tree(self._parent(path), refresh=refresh, revision=revision, **kwargs)
+            try:
+                out = self._ls_tree(self._parent(path), refresh=refresh, revision=revision, **kwargs)
+            except EntryNotFoundError:
+                out = []
             out = [o for o in out if o["name"] == path]
             if len(out) == 0:
                 _raise_file_not_found(path, None)

--- a/tests/test_hf_file_system.py
+++ b/tests/test_hf_file_system.py
@@ -89,6 +89,14 @@ class _HfFileSystemBaseROTests(_HfFileSystemBaseTests):
             sorted(self.hffs.glob(self.hf_path + "/*")),
             sorted([self.readme_file, self.hf_path + "/data"]),
         )
+        self.assertEqual(
+            sorted(self.hffs.glob(self.hf_path + "/doesnt-exist/*")),
+            [],
+        )
+        self.assertEqual(
+            sorted(self.hffs.glob(self.hf_path + "/doesnt/exist/at/all/*")),
+            [],
+        )
 
     def test_url(self):
         self.assertEqual(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to `ls` error handling plus added regression tests; behavior only changes for missing-parent-path cases.
> 
> **Overview**
> Fixes `HfFileSystem.ls()` to gracefully handle the case where a *file path is queried but its parent directory doesn’t exist*, treating the parent listing as empty rather than propagating `EntryNotFoundError`.
> 
> Adds regression coverage ensuring `hffs.glob()` returns `[]` for patterns rooted in non-existent subdirectories (including nested missing paths) instead of failing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f3fe565414e0f81b6942e02ce2e7f994ad3a877a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->