### PR TITLE
feat: support title-based lookup in get_collection()

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -1943,12 +1943,10 @@ def _is_collection_slug(value: str) -> bool:
     """
     Returns True if the string looks like a real collection slug.
 
-    A slug has the form "owner/collection-name-<8hexchars>", e.g.:
-        "TheBloke/recent-models-64f9a55b"
-    A plain title would look like:
-        "TheBloke/My Favourite Models"  or  "TheBloke/recent-models"
+    Real slugs end with a MongoDB ObjectID suffix of exactly 24 hex characters.
+    E.g.: "TheBloke/recent-models-64f9a55bb3115b4f513ec026"
     """
-    return bool(re.search(r"-[0-9a-f]{8,}$", value))
+    return bool(re.search(r"-[0-9a-f]{24}$", value))
 
 
 class HfApi:

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -4264,13 +4264,13 @@ class CollectionAPITest(HfApiCommonTest):
 
         fake_col = MagicMock()
         fake_col.title = "My Cool Collection"
-        fake_col.slug = "myuser/my-cool-collection-abc12345"
+        fake_col.slug = "myuser/my-cool-collection-64f9a55bb3115b4f513ec026"
 
         with patch.object(self._api, "list_collections", return_value=iter([fake_col])) as mock_list:
             with patch("huggingface_hub.hf_api.get_session") as mock_session:
                 mock_response = MagicMock()
                 mock_response.json.return_value = {
-                    "slug": "myuser/my-cool-collection-abc12345",
+                    "slug": "myuser/my-cool-collection-64f9a55bb3115b4f513ec026",
                     "title": "My Cool Collection",
                     "owner": {"name": "myuser"},
                     "items": [],
@@ -4286,7 +4286,7 @@ class CollectionAPITest(HfApiCommonTest):
                 result = self._api.get_collection("myuser/My Cool Collection")
 
         mock_list.assert_called_once_with(owner="myuser", token=None)
-        assert result.slug == "myuser/my-cool-collection-abc12345"
+        assert result.slug == "myuser/my-cool-collection-64f9a55bb3115b4f513ec026"
 
     def test_get_collection_by_title_not_found(self) -> None:
         """Test that get_collection raises ValueError when title doesn't match any collection."""


### PR DESCRIPTION
## What this does
Extends get_collection() to accept "owner/Collection Title" format in addition to the standard slug ("owner/collection-name-hexsuffix").

When a title is passed (detected by the absence of a hex suffix), the method transparently calls list_collections(owner=...) to resolve it to a real slug before proceeding.

## Why
Users currently have no way to find a collection slug from the web UI, forcing them to write workaround code. This was raised in #3856 by @gsaltintas.

## Usage
python

# Both of these now work:
col = api.get_collection("owner/my-collection-64f9a55b")  # existing slug
col = api.get_collection("owner/My Collection Title")     # new: by title


## Changes
- Added _is_collection_slug() helper at module level in hf_api.py
- Modified get_collection() to resolve titles when no hex suffix detected
- Added two unit tests covering happy path and title-not-found case

Closes #3856

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `get_collection` behavior to perform an additional `list_collections` lookup when the input is not a canonical slug, which can affect performance and error handling for some callers.
> 
> **Overview**
> `get_collection` now accepts `owner/Collection Title` in addition to canonical slugs. When the input doesn’t end with a 24-hex ObjectID suffix, it resolves the title to a real slug by scanning `list_collections(owner=...)`, raising a `ValueError` if no match is found.
> 
> Adds `_is_collection_slug` helper for slug detection and introduces unit tests covering successful title resolution and the not-found error path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca828503ec59493f1754d826c39db60ccd454133. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->