### PR TITLE
[Internal] Replace `huggingface-cli` with `hf` in brew upgrade command

### DIFF
--- a/src/huggingface_hub/cli/_cli_utils.py
+++ b/src/huggingface_hub/cli/_cli_utils.py
@@ -587,7 +587,7 @@ def _get_huggingface_hub_update_command() -> str:
     """Return the command to update huggingface_hub."""
     method = installation_method()
     if method == "brew":
-        return "brew upgrade huggingface-cli"
+        return "brew upgrade hf"
     elif method == "hf_installer" and os.name == "nt":
         return 'powershell -NoProfile -Command "iwr -useb https://hf.co/cli/install.ps1 | iex"'
     elif method == "hf_installer":


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Replace the outdated `huggingface-cli` homebrew formula name with `hf` in the `_get_huggingface_hub_update_command` function.

The brew command shown to users when a newer version is available now suggests `brew upgrade hf` instead of `brew upgrade huggingface-cli`.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://huggingface.slack.com/archives/D0A9NBN79EZ/p1770820408024409?thread_ts=1770820408.024409&cid=D0A9NBN79EZ)

<div><a href="https://cursor.com/agents/bc-a8a72a53-0a09-53cd-8ff3-9e59971da8b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a8a72a53-0a09-53cd-8ff3-9e59971da8b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

