### PR TITLE
Fix typo in `--every` help text

### DIFF
--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -3389,7 +3389,7 @@ $ hf upload [OPTIONS] REPO_ID [LOCAL_PATH] [PATH_IN_REPO]
 * `--commit-message TEXT`: The summary / title / first line of the generated commit.
 * `--commit-description TEXT`: The description of the generated commit.
 * `--create-pr / --no-create-pr`: Whether to upload content as a new Pull Request.  [default: no-create-pr]
-* `--every FLOAT`: f set, a background job is scheduled to create commits every `every` minutes.
+* `--every FLOAT`: If set, a background job is scheduled to create commits every `every` minutes.
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `--quiet / --no-quiet`: Disable progress bars and warnings; print only the returned path.  [default: no-quiet]
 * `--help`: Show this message and exit.

--- a/src/huggingface_hub/cli/upload.py
+++ b/src/huggingface_hub/cli/upload.py
@@ -137,7 +137,7 @@ def upload(
     every: Annotated[
         Optional[float],
         typer.Option(
-            help="f set, a background job is scheduled to create commits every `every` minutes.",
+            help="If set, a background job is scheduled to create commits every `every` minutes.",
         ),
     ] = None,
     token: TokenOpt = None,


### PR DESCRIPTION
## Summary
- Fix typo in `hf upload --every` help text: `"f set, a background job..."` → `"If set, a background job..."`
- Updated both the source (`upload.py`) and generated docs (`cli.md`)

## Test plan
- [x] Verified the fix in both files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only fix that updates a CLI option help string and its generated reference docs, with no behavior changes.
> 
> **Overview**
> Fixes the `hf upload --every` option help text typo by changing "f set" to **"If set"** in `cli/upload.py`, and updates the generated CLI reference in `docs/.../cli.md` to match.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 870e7300d582a279e27c04b7eddba8f361fba05a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->