### PR TITLE
[CLI] use `uv` Python extension installation when available

### DIFF
--- a/src/huggingface_hub/cli/extensions.py
+++ b/src/huggingface_hub/cli/extensions.py
@@ -350,24 +350,37 @@ def _install_python_extension(
         if extension_dir.exists():
             shutil.rmtree(extension_dir, ignore_errors=True)
         extension_dir.mkdir(parents=True, exist_ok=False)
-        venv.EnvBuilder(with_pip=True).create(str(venv_dir))
-        status.done(f"Virtual environment created in {venv_dir}")
 
-        status.update(f"Installing package from {source_url}")
+        uv_path = shutil.which("uv")
         venv_python = _get_venv_python_path(venv_dir)
-        subprocess.run(
-            [
-                str(venv_python),
-                "-m",
-                "pip",
-                "install",
-                "--disable-pip-version-check",
-                "--no-input",
-                source_url,
-            ],
-            check=True,
-            timeout=_EXTENSIONS_PIP_INSTALL_TIMEOUT,
-        )
+        if uv_path:
+            subprocess.run([uv_path, "venv", str(venv_dir)], check=True)
+            status.done(f"Virtual environment created in {venv_dir}")
+
+            status.update(f"Installing package from {source_url}")
+            subprocess.run(
+                [uv_path, "pip", "install", "--python", str(venv_python), source_url],
+                check=True,
+                timeout=_EXTENSIONS_PIP_INSTALL_TIMEOUT,
+            )
+        else:
+            venv.EnvBuilder(with_pip=True).create(str(venv_dir))
+            status.done(f"Virtual environment created in {venv_dir}")
+
+            status.update(f"Installing package from {source_url}")
+            subprocess.run(
+                [
+                    str(venv_python),
+                    "-m",
+                    "pip",
+                    "install",
+                    "--disable-pip-version-check",
+                    "--no-input",
+                    source_url,
+                ],
+                check=True,
+                timeout=_EXTENSIONS_PIP_INSTALL_TIMEOUT,
+            )
         status.done(f"Package installed from {source_url}")
 
         executable_name = _get_executable_name(short_name)


### PR DESCRIPTION
Flagged by @freddyaboulton in this [internal slack message](https://huggingface.slack.com/archives/C02V5EA0A95/p1773928900810729).

`hf extensions install` crashes on uv-managed Python installations. This happens because `venv.EnvBuilder(with_pip=True)` calls `ensurepip` under the hood, and uv's Python distributions don't ship the pip wheel.

This PR detects `uv` on `PATH` and uses it for both venv creation and package installation, falling back to the existing stdlib behavior when `uv` is not available.

Using `uv` when available also makes extension installation faster.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how `hf extensions install` creates virtualenvs and installs packages, which can vary across platforms and Python distributions. Fallback behavior remains unchanged when `uv` is not present.
> 
> **Overview**
> Fixes `hf extensions install` on uv-managed Python distributions by detecting `uv` on `PATH` and using it to create the extension virtualenv and install the extension package.
> 
> When `uv` is unavailable, it falls back to the previous stdlib `venv.EnvBuilder(with_pip=True)` + `pip install` flow, keeping existing behavior intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d13abbd2412d729f34cf6a103ceed38dcaaad850. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->