### PR TITLE
[Docs] More explicit spaces hot-reload docs

### DIFF
--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -3239,8 +3239,8 @@ This command patches the live Python process using https://github.com/breuleux/j
 (meaning that Gradio demo object changes are reflected in the UI)
 
 The command creates a remote commit.
-Use `git pull --autostash` if you are working from a local clone
-in order to bring the commit back and keep your local git state in sync
+If you are working from a local clone, run `git pull --autostash` afterwards
+to bring the commit back and keep your local git state in sync.
 
 **Usage**:
 

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -262,8 +262,8 @@ def spaces_hot_reload(
     (meaning that Gradio demo object changes are reflected in the UI)
 
     The command creates a remote commit.
-    Use `git pull --autostash` if you are working from a local clone
-    in order to bring the commit back and keep your local git state in sync
+    If you are working from a local clone, run `git pull --autostash` afterwards
+    to bring the commit back and keep your local git state in sync.
     """
 
     typer.secho("This feature is experimental and subject to change", fg=typer.colors.BRIGHT_BLACK)


### PR DESCRIPTION
cc @gary149 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to CLI help text and generated reference; no runtime behavior changes. Low risk aside from potential doc regen drift if Typer output changes again.
> 
> **Overview**
> Clarifies `hf spaces hot-reload` behavior by explicitly stating it **creates a remote commit** and advising local-clone users to run `git pull --autostash` to sync changes back.
> 
> Updates the `hot-reload` command examples in both `spaces.py` (Typer help) and the generated `docs/.../cli.md` to match the clarified wording.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ec04600d252854d2ca588e81216370c33701c0d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->