### PR TITLE
Use `huggingface-hub-bot` for post-release PR creation in `release.yml`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,15 +15,18 @@
 # For a patch release, cherry-pick fixes to the release branch first, then trigger a "patch-release" run. This increments
 # the patch version (e.g., 1.6.1), publishes to PyPI, and creates a GitHub release.
 #
-# The workflow uses GITHUB_TOKEN for all git operations (branch creation, tag push, PR creation). Since events triggered
-# by GITHUB_TOKEN do not cascade, the existing tag-triggered workflows (python-release.yml, python-release-hf.yml)
-# will not fire and can serve as a manual fallback if needed.
+# The workflow uses GITHUB_TOKEN for most git operations (branch creation, tag push) and a GitHub App token
+# (huggingface-hub-bot) for PR creation in the post-release job. Since events triggered by GITHUB_TOKEN do not
+# cascade, the existing tag-triggered workflows (python-release.yml, python-release-hf.yml) will not fire and
+# can serve as a manual fallback if needed.
 #
 # Required secrets:
 # - PYPI_TOKEN_DIST_HUGGINGFACE_HUB      : publish `huggingface_hub` package to PyPI
 # - PYPI_TOKEN_DIST_HF                   : publish `hf` package to PyPI
 # - HUGGINGFACE_HUB_AUTOMATIC_RC_TESTING : open PRs for automatic RC testing in downstream repositories
 # - RELEASE_NOTES_HF_TOKEN               : HF TOKEN scoped to Inference Providers used for automated release notes generation
+# - APP_ID_HUGGINGFACE_HUB_BOT           : GitHub App ID for huggingface-hub-bot (PRs, issues, releases)
+# - APP_SECRET_PEM_HUGGINGFACE_HUB_BOT   : GitHub App private key for huggingface-hub-bot
 # - APP_ID_HUB_SKILLS_REPO               : GitHub App ID for creating tokens to access the skills repo
 # - APP_SECRET_PREM_HUB_SKILLS_REPO      : GitHub App private key for the skills repo
 # 
@@ -513,18 +516,26 @@ jobs:
     if: ${{ inputs.release_type == 'minor-release' && !inputs.dry_run }}
     runs-on: ubuntu-latest
     steps:
+      - name: Create GitHub App token
+        id: app_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID_HUGGINGFACE_HUB_BOT }}
+          private-key: ${{ secrets.APP_SECRET_PEM_HUGGINGFACE_HUB_BOT }}
+
       - uses: actions/checkout@v6
         with:
           ref: main
+          token: ${{ steps.app_token.outputs.token }}
 
       - name: Configure Git
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "huggingface-hub-bot[bot]"
+          git config user.email "huggingface-hub-bot[bot]@users.noreply.github.com"
 
       - name: Create version bump PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
         run: |
           VERSION="${{ needs.prepare.outputs.version }}"
           MAJOR=$(echo "$VERSION" | cut -d. -f1)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Replaces `GITHUB_TOKEN` with the `huggingface-hub-bot` GitHub App token in the **post-release** job of the release workflow. This fixes the permission issues encountered when the workflow tries to open the version-bump PR after a minor release (see [failing job](https://github.com/huggingface/huggingface_hub/actions/runs/23043275096/job/66926311723)).

## Changes

- **`post-release` job**: Added a `create-github-app-token` step using `APP_ID_HUGGINGFACE_HUB_BOT` / `APP_SECRET_PEM_HUGGINGFACE_HUB_BOT` secrets
  - Passes the bot token to `actions/checkout` so `git push` uses the app credentials
  - Uses the bot token for `gh pr create` via `GH_TOKEN`
  - Updates the git user identity to `huggingface-hub-bot[bot]`
- **Workflow header**: Documented the two new required secrets and updated the description of token usage

## Required secrets

The following secrets must be configured on the repo (already done by @music-lover):
- `APP_ID_HUGGINGFACE_HUB_BOT` — GitHub App ID for huggingface-hub-bot
- `APP_SECRET_PEM_HUGGINGFACE_HUB_BOT` — GitHub App private key for huggingface-hub-bot
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://huggingface.slack.com/archives/CTKK32GE8/p1773400556088659?thread_ts=1773400556.088659&cid=CTKK32GE8)

<div><a href="https://cursor.com/agents/bc-bff3e3fb-7d64-5b2b-9d77-3d6ef292953b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bff3e3fb-7d64-5b2b-9d77-3d6ef292953b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

