### PR TITLE
More robust stream to stdout in hf cp command

### DIFF
--- a/src/huggingface_hub/cli/buckets.py
+++ b/src/huggingface_hub/cli/buckets.py
@@ -17,7 +17,6 @@
 import json
 import os
 import sys
-import tempfile
 from datetime import datetime
 from typing import Annotated, Optional, Union
 


### PR DESCRIPTION
2 things:
- read from tmp file by chunks (avoid loading entire file in memory)
- use `SoftTemporaryDirectory` which tries different methods to remove the tmp directory (and give up if not possible)


The best approach would be to directly pipe from hf-xet to the stdout but this is not yet possible (coming soon)

(related internal [slack thread](https://huggingface.slack.com/archives/C0737MXJ26A/p1774364636949359))


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is limited to the `hf buckets cp ... -` download path and mainly affects memory usage and temp cleanup behavior; primary risk is subtle stdout/progress-bar behavior changes for large downloads.
> 
> **Overview**
> Makes `hf buckets cp` downloads to stdout more robust by replacing `tempfile.TemporaryDirectory` with `SoftTemporaryDirectory` for best-effort cleanup.
> 
> When piping a bucket file to `-`, it now writes the downloaded temp file to `stdout` in 32MB chunks instead of reading the entire file into memory.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a422b56547051f4380710c9486b4de9f5741cf9d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->