### PR TITLE
Add skills to quickstart

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -70,6 +70,18 @@ If the CLI is correctly installed, you should see a list of all the options avai
 > [!TIP]
 > The `--help` option is very convenient for getting more details about a command. You can use it anytime to list all available options and their details. For example, `hf upload --help` provides more information on how to upload files using the CLI.
 
+
+## Skills
+
+Once installed hf CLI, install CLI skill to give your coding agent tools to interact with Hub. Here's the shortcut to install CLI Skill for different coding agents.
+
+```bash
+hf skills add --claude
+hf skills add --codex
+hf skills add --cursor
+hf skills add --opencode
+```
+
 ### Using uv
 
 The easiest way to use the `hf` CLI is with [`uvx`](https://docs.astral.sh/uv/concepts/tools/). It always runs the latest version in an isolated environment - no installation needed!

--- a/docs/source/en/quick-start.md
+++ b/docs/source/en/quick-start.md
@@ -53,10 +53,6 @@ For more details and options, see the API reference for [`hf_hub_download`].
 
 <a id="login"></a> <!-- backward compatible anchor -->
 
-## hf CLI
-
-Hugging Face offers a [CLI](../guides/cli#command-line-interface-cli) to interact with Hub through terminal. You can install by following the instructions [here](https://huggingface.co/docs/huggingface_hub/guides/cli#standalone-installer-recommended).
-
 ## Authentication
 
 In a lot of cases, you must be authenticated with a Hugging Face account to interact with
@@ -128,17 +124,6 @@ This is usually discouraged except in an environment where you don't want to sto
 > [!WARNING]
 > Please be careful when passing tokens as a parameter. It is always best practice to load the token from a secure vault instead of hardcoding it in your codebase or notebook. Hardcoded tokens present a major leak risk if you share your code inadvertently.
 
-## Skills
-
-Once installed hf CLI, install CLI skill to give your coding agent tools to interact with Hub. Here's the shortcut to install CLI Skill for different coding agents.
-
-```bash
-hf skills add --claude
-hf skills add --codex
-hf skills add --cursor
-hf skills add --opencode
-```
-Skills aren't limited to CLI but also allow agents to accomplish a variety of tasks from training a model to building a demo. 
 
 ## Create a repository
 


### PR DESCRIPTION
@hanouticelina this is a bit unprompted PR, but we had a small discussion [here](https://huggingface.slack.com/archives/C027NLU6CE9/p1774340145349439) and thought it would be a good idea to add HF skills on quickstart from the get-go


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates; no runtime or API behavior changes, so risk is low aside from potential minor confusion if commands/flags change.
> 
> **Overview**
> Adds a new **Skills** section to the CLI guide that shows how to install the `hf` CLI “skills” integration for common coding agents via `hf skills add` shortcuts.
> 
> Also applies a minor formatting tweak in `quick-start.md` (extra spacing before the “Create a repository” section).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05e8f5fcceb0650aa089de9b4559a40d7b1d705b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->