### PR TITLE
no explicit models/ in hf:// protocol

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -1578,7 +1578,6 @@ Mount a volume on the Job's disk using `-v` or `--volume`.
 You can mount any Hugging Face Repository (model/dataset/space) or [Storage Bucket](/docs/hub/storage-buckets) using the `hf://` URL scheme. For example:
 
 * mount a model repository: `-v hf://openai/gpt-oss-120b:/model`
-* mount a model repository (explicit type): `-v hf://models/openai/gpt-oss-120b:/model`
 * mount a dataset repository: `-v hf://datasets/HuggingFaceFW/fineweb:/data`
 * mount a storage bucket: `-v hf://buckets/username/my-bucket:/mnt`
 * mount a space: `-v hf://spaces/username/my-space:/app`


### PR DESCRIPTION
just a small nit following https://github.com/huggingface/huggingface_hub/pull/3936

this is not part of the hf:// protocol so I wouldn't mention it in the docs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that removes an incorrect `hf://models/` URL example; no code paths or behavior are affected.
> 
> **Overview**
> Updates the `hf jobs` *Volumes* documentation to stop suggesting `hf://models/<repo>` as part of the `hf://` URL scheme, leaving only the canonical model mount example (`hf://<org>/<repo>`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05caeb63bfdbdbae2e5bb341195f8e173a1a7c7f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->