### PR TITLE
Add DatasetLeaderboardEntry and EvalResultEntry to docs reference

### DIFF
--- a/docs/source/en/package_reference/hf_api.md
+++ b/docs/source/en/package_reference/hf_api.md
@@ -53,6 +53,14 @@ models = hf_api.list_models()
 
 [[autodoc]] huggingface_hub.hf_api.BucketUrl
 
+### DatasetLeaderboardEntry
+
+[[autodoc]] huggingface_hub.hf_api.DatasetLeaderboardEntry
+
+### EvalResultEntry
+
+[[autodoc]] huggingface_hub.hf_api.EvalResultEntry
+
 ### SyncOperation
 
 [[autodoc]] huggingface_hub.SyncOperation


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change that adds autodoc references for two existing dataclasses, with no runtime behavior impact.
> 
> **Overview**
> Updates the `HfApi` docs reference (`docs/source/en/package_reference/hf_api.md`) to include autodoc sections for `DatasetLeaderboardEntry` and `EvalResultEntry` in the API dataclasses list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4039acdb24c4d464d56dfe485c84fb4e97805c86. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->