### PR TITLE
Fix test_create_commit_conflict test

### DIFF
--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -784,7 +784,7 @@ class CommitApiTest(HfApiCommonTest):
         self.assertEqual(exc_ctx.exception.response.status_code, 412)
         self.assertIn(
             # Check the server message is added to the exception
-            "A commit has happened since. Please refresh and try again.",
+            "The branch was updated since you opened this page. Please refresh and try again.",
             str(exc_ctx.exception),
         )
 


### PR DESCRIPTION
Message seems to have changed server-side.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only updates a test expectation to match a server-side error message change, with no production code changes.
> 
> **Overview**
> Updates `test_create_commit_conflict` in `tests/test_hf_api.py` to assert the new server-provided HTTP 412 conflict message (branch updated) when `create_commit` is called with a stale `parent_commit`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7bdd2c6e4c6395057c4ba736abe5732569b1d99e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->