### PR TITLE
[Docs] Link to Hub local cache docs from manage-cache guide

### DIFF
--- a/docs/source/en/guides/manage-cache.md
+++ b/docs/source/en/guides/manage-cache.md
@@ -6,6 +6,9 @@ rendered properly in your Markdown viewer.
 
 `huggingface_hub` utilizes the local disk as two caches, which avoid re-downloading items again. The first cache is a file-based cache, which caches individual files downloaded from the Hub and ensures that the same file is not downloaded again when a repo gets updated. The second cache is a chunk cache, where each chunk represents a byte range from a file and ensures that chunks that are shared across files are only downloaded once.
 
+> [!TIP]
+> This guide covers the Python-specific cache management tools provided by `huggingface_hub`. For a language-agnostic overview of how the Hugging Face Hub cache system works, see the [Hub documentation on local caching](https://huggingface.co/docs/hub/local-cache).
+
 ## File-based caching
 
 The Hugging Face Hub cache-system is designed to be the central cache shared across libraries


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The [manage-cache guide](https://huggingface.co/docs/huggingface_hub/guides/manage-cache) is the Python-specific documentation for cache management in `huggingface_hub`. The Hub docs also have a language-agnostic page on [local caching](https://huggingface.co/docs/hub/local-cache).

This PR adds a tip box near the top of the manage-cache guide linking to the Hub local cache docs, making it easy for readers to discover the language-agnostic overview.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://huggingface.slack.com/archives/D0A9313SS3G/p1774610193236009?thread_ts=1774610193.236009&cid=D0A9313SS3G)

<div><a href="https://cursor.com/agents/bc-ed03ab9a-acc3-55b4-a903-5145b6c06c08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed03ab9a-acc3-55b4-a903-5145b6c06c08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

