### PR TITLE
[Docs] Note that environment variables are read at import time

### DIFF
--- a/docs/source/en/package_reference/environment_variables.md
+++ b/docs/source/en/package_reference/environment_variables.md
@@ -13,6 +13,11 @@ and on [Windows](https://phoenixnap.com/kb/windows-set-environment-variable).
 This page will guide you through all environment variables specific to `huggingface_hub`
 and their meaning.
 
+> [!TIP]
+> All environment variables are read at import time of `huggingface_hub`. Any modification
+> made afterwards will not be taken into account. Make sure to set your environment variables
+> before importing `huggingface_hub`.
+
 ## Generic
 
 ### HF_INFERENCE_ENDPOINT


### PR DESCRIPTION

### Context:
We get reports from time to time about reading env variables at import time "being a bug". Let's document it officially so that at least we can point users that it's an "intended behavior". 


----

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a TIP block at the top of the [Environment variables](https://huggingface.co/docs/huggingface_hub/package_reference/environment_variables) documentation page noting that all environment variables are read at import time, so any modifications made after importing `huggingface_hub` will not take effect.

This is a common gotcha that is worth surfacing prominently.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://huggingface.slack.com/archives/D0A9313SS3G/p1774609156970519?thread_ts=1774609156.970519&cid=D0A9313SS3G)

<div><a href="https://cursor.com/agents/bc-47caf349-a545-4445-8f03-ae12e1238ed2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47caf349-a545-4445-8f03-ae12e1238ed2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

