### PR TITLE
Fix PyTorchModelHubMixin not calling eval() on safetensors load

### DIFF
--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -820,6 +820,7 @@ class PyTorchModelHubMixin(ModelHubMixin):
                 model.to(map_location)  # type: ignore [attr-defined]
         else:
             safetensors.torch.load_model(model, model_file, strict=strict, device=map_location)  # type: ignore [arg-type]
+        model.eval()  # type: ignore
         return model
 
 


### PR DESCRIPTION
Fixes #3981

The `_load_as_pickle` path calls `model.eval()` before returning, but the `_load_as_safetensor` path (now the default) doesn't. This means models loaded via safetensors are unexpectedly in training mode, which affects dropout, batch norm, etc.

Added `model.eval()` to `_load_as_safetensor` to match the pickle path behavior and the class docstring promise.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk one-line behavior fix that only changes the default training/eval mode of models loaded via `safetensors`. Main impact is on inference-time layers (e.g., dropout/batchnorm) now behaving as expected by default.
> 
> **Overview**
> Aligns `PyTorchModelHubMixin._load_as_safetensor` with the pickle loading path by calling `model.eval()` before returning.
> 
> This ensures models loaded from `safetensors` default to evaluation mode, avoiding accidental training-mode behavior after `from_pretrained`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e859cd88c69f78af93cc945b49b302a018d81bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->