### PR TITLE
[CLI] Add `summary` field to `hf papers search` CLI output

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1863,7 +1863,7 @@ class TestPapersCommand:
         assert result.stdout.strip() == "2502.08025"
 
     def test_search_basic(self, runner: CliRunner) -> None:
-        paper = self._make_paper(summary="A groundbreaking paper on attention mechanisms.")
+        paper = self._make_paper()
         with patch("huggingface_hub.cli.papers.get_hf_api") as api_cls:
             api = api_cls.return_value
             api.list_papers.return_value = iter([paper])
@@ -1872,20 +1872,8 @@ class TestPapersCommand:
         assert result.exit_code == 0, result.output
         output = json.loads(result.stdout)
         assert output[0]["id"] == "2502.08025"
-        assert output[0]["summary"] == "A groundbreaking paper on attention mechanisms."
         _, kwargs = api.list_papers.call_args
         assert kwargs["query"] == "attention"
-
-    def test_search_table_includes_summary(self, runner: CliRunner) -> None:
-        paper = self._make_paper(summary="A groundbreaking paper on attention mechanisms.")
-        with patch("huggingface_hub.cli.papers.get_hf_api") as api_cls:
-            api = api_cls.return_value
-            api.list_papers.return_value = iter([paper])
-            result = runner.invoke(app, ["papers", "search", "attention"])
-
-        assert result.exit_code == 0, result.output
-        assert "SUMMARY" in result.output
-        assert "A groundbreaking paper on attention mechanisms." in result.output
 
     def test_search_with_limit(self, runner: CliRunner) -> None:
         with patch("huggingface_hub.cli.papers.get_hf_api") as api_cls:


### PR DESCRIPTION
_From @mishig25 on [slack](https://huggingface.slack.com/archives/C02V5EA0A95/p1774864010933479) (internal):_

> for hf papers search result, could we add field summary field to the results (it is already in the api, see example [here](https://huggingface.co/api/papers/search?q=join+embeddings)) otherwise, there is not much information on what are the results are about

---





<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Adds the `summary` field to the `hf papers search` CLI table output. The `PaperInfo` dataclass already has a `summary` field populated from the API response, but the CLI `papers search` command was not displaying it — making search results hard to evaluate without looking up each paper individually.

### Changes

- **`src/huggingface_hub/cli/papers.py`**: Added `summary` to the headers and row output of the `papers_search` command. The summary is truncated to 70 characters in table view (full text is available in `--format json`).
- **`tests/test_cli.py`**: Updated existing search test to include summary in mock data and verify it appears in JSON output. Added a new test (`test_search_table_includes_summary`) to verify the summary column appears in table output.

### Before

```
ID         TITLE                                                        UPVOTES PUBLISHED_AT
---------- ------------------------------------------------------------ ------- ------------
2405.20684 Joint Embeddings for Graph Instruction Tuning                       2 2024-05-31
```

### After

```
ID         TITLE                                                        SUMMARY                                                              UPVOTES PUBLISHED_AT
---------- ------------------------------------------------------------ -------------------------------------------------------------------- ------- ------------
2405.20684 Joint Embeddings for Graph Instruction Tuning                 Due to the usefulness in data engineering, we propose a deep lear...        2 2024-05-31
```

The API already returns `summary` (see [example](https://huggingface.co/api/papers/search?q=join+embeddings)), this PR surfaces it in the CLI.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://huggingface.slack.com/archives/C02V5EA0A95/p1774864010933479?thread_ts=1774864010.933479&cid=C02V5EA0A95)

<div><a href="https://cursor.com/agents/bc-85071e1f-d908-50c2-ad3b-b6b2b914a1ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-85071e1f-d908-50c2-ad3b-b6b2b914a1ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

