### PR TITLE
[Internal] Use `match`/`case` statements where appropriate

### DIFF
--- a/src/huggingface_hub/_buckets.py
+++ b/src/huggingface_hub/_buckets.py
@@ -837,19 +837,20 @@ def _execute_plan(plan: SyncPlan, api: "HfApi", verbose: bool = False, status: A
         delete_paths: list[str] = []
 
         for op in plan.operations:
-            if op.action == "upload":
-                local_file = os.path.join(local_path, op.path)
-                remote_path = f"{prefix}/{op.path}" if prefix else op.path
-                if verbose:
-                    print(f"  Uploading: {op.path} ({op.reason})")
-                add_files.append((local_file, remote_path))
-            elif op.action == "delete":
-                remote_path = f"{prefix}/{op.path}" if prefix else op.path
-                if verbose:
-                    print(f"  Deleting: {op.path} ({op.reason})")
-                delete_paths.append(remote_path)
-            elif op.action == "skip" and verbose:
-                print(f"  Skipping: {op.path} ({op.reason})")
+            match op.action:
+                case "upload":
+                    local_file = os.path.join(local_path, op.path)
+                    remote_path = f"{prefix}/{op.path}" if prefix else op.path
+                    if verbose:
+                        print(f"  Uploading: {op.path} ({op.reason})")
+                    add_files.append((local_file, remote_path))
+                case "delete":
+                    remote_path = f"{prefix}/{op.path}" if prefix else op.path
+                    if verbose:
+                        print(f"  Deleting: {op.path} ({op.reason})")
+                    delete_paths.append(remote_path)
+                case "skip" if verbose:
+                    print(f"  Skipping: {op.path} ({op.reason})")
 
         # Execute batch operations
         if add_files or delete_paths:

--- a/src/huggingface_hub/_upload_large_folder.py
+++ b/src/huggingface_hub/_upload_large_folder.py
@@ -444,88 +444,90 @@ def _worker_job(
         job, items = next_job
 
         # Perform task
-        if job == WorkerJob.SHA256:
-            item = items[0]  # single item
-            try:
-                _compute_sha256(item)
-                status.queue_get_upload_mode.put(item)
-            except KeyboardInterrupt:
-                raise
-            except Exception as e:
-                logger.error(f"Failed to compute sha256: {e}")
-                traceback.format_exc()
-                status.queue_sha256.put(item)
-
-            with status.lock:
-                status.nb_workers_sha256 -= 1
-
-        elif job == WorkerJob.GET_UPLOAD_MODE:
-            try:
-                _get_upload_mode(items, api=api, repo_id=repo_id, repo_type=repo_type, revision=revision)
-            except KeyboardInterrupt:
-                raise
-            except Exception as e:
-                logger.error(f"Failed to get upload mode: {e}")
-                traceback.format_exc()
-
-            # Items are either:
-            # - dropped (if should_ignore)
-            # - put in LFS queue (if LFS)
-            # - put in commit queue (if regular)
-            # - or put back (if error occurred).
-            for item in items:
-                _, metadata = item
-                if metadata.should_ignore:
-                    continue
-                if metadata.upload_mode == "lfs":
-                    status.queue_preupload_lfs.put(item)
-                elif metadata.upload_mode == "regular":
-                    status.queue_commit.put(item)
-                else:
+        match job:
+            case WorkerJob.SHA256:
+                item = items[0]  # single item
+                try:
+                    _compute_sha256(item)
                     status.queue_get_upload_mode.put(item)
+                except KeyboardInterrupt:
+                    raise
+                except Exception as e:
+                    logger.error(f"Failed to compute sha256: {e}")
+                    traceback.format_exc()
+                    status.queue_sha256.put(item)
 
-            with status.lock:
-                status.nb_workers_get_upload_mode -= 1
+                with status.lock:
+                    status.nb_workers_sha256 -= 1
 
-        elif job == WorkerJob.PREUPLOAD_LFS:
-            try:
-                _preupload_lfs(items, api=api, repo_id=repo_id, repo_type=repo_type, revision=revision)
+            case WorkerJob.GET_UPLOAD_MODE:
+                try:
+                    _get_upload_mode(items, api=api, repo_id=repo_id, repo_type=repo_type, revision=revision)
+                except KeyboardInterrupt:
+                    raise
+                except Exception as e:
+                    logger.error(f"Failed to get upload mode: {e}")
+                    traceback.format_exc()
+
+                # Items are either:
+                # - dropped (if should_ignore)
+                # - put in LFS queue (if LFS)
+                # - put in commit queue (if regular)
+                # - or put back (if error occurred).
                 for item in items:
-                    status.queue_commit.put(item)
-            except KeyboardInterrupt:
-                raise
-            except Exception as e:
-                logger.error(f"Failed to preupload LFS: {e}")
-                traceback.format_exc()
-                for item in items:
-                    status.queue_preupload_lfs.put(item)
+                    _, metadata = item
+                    if metadata.should_ignore:
+                        continue
+                    match metadata.upload_mode:
+                        case "lfs":
+                            status.queue_preupload_lfs.put(item)
+                        case "regular":
+                            status.queue_commit.put(item)
+                        case _:
+                            status.queue_get_upload_mode.put(item)
 
-            with status.lock:
-                status.nb_workers_preupload_lfs -= 1
+                with status.lock:
+                    status.nb_workers_get_upload_mode -= 1
 
-        elif job == WorkerJob.COMMIT:
-            start_ts = time.time()
-            success = True
-            try:
-                _commit(items, api=api, repo_id=repo_id, repo_type=repo_type, revision=revision)
-            except KeyboardInterrupt:
-                raise
-            except Exception as e:
-                logger.error(f"Failed to commit: {e}")
-                traceback.format_exc()
-                for item in items:
-                    status.queue_commit.put(item)
-                success = False
-            duration = time.time() - start_ts
-            status.update_chunk(success, len(items), duration)
-            with status.lock:
-                status.last_commit_attempt = time.time()
-                status.nb_workers_commit -= 1
+            case WorkerJob.PREUPLOAD_LFS:
+                try:
+                    _preupload_lfs(items, api=api, repo_id=repo_id, repo_type=repo_type, revision=revision)
+                    for item in items:
+                        status.queue_commit.put(item)
+                except KeyboardInterrupt:
+                    raise
+                except Exception as e:
+                    logger.error(f"Failed to preupload LFS: {e}")
+                    traceback.format_exc()
+                    for item in items:
+                        status.queue_preupload_lfs.put(item)
 
-        elif job == WorkerJob.WAIT:
-            time.sleep(WAITING_TIME_IF_NO_TASKS)
-            with status.lock:
-                status.nb_workers_waiting -= 1
+                with status.lock:
+                    status.nb_workers_preupload_lfs -= 1
+
+            case WorkerJob.COMMIT:
+                start_ts = time.time()
+                success = True
+                try:
+                    _commit(items, api=api, repo_id=repo_id, repo_type=repo_type, revision=revision)
+                except KeyboardInterrupt:
+                    raise
+                except Exception as e:
+                    logger.error(f"Failed to commit: {e}")
+                    traceback.format_exc()
+                    for item in items:
+                        status.queue_commit.put(item)
+                    success = False
+                duration = time.time() - start_ts
+                status.update_chunk(success, len(items), duration)
+                with status.lock:
+                    status.last_commit_attempt = time.time()
+                    status.nb_workers_commit -= 1
+
+            case WorkerJob.WAIT:
+                time.sleep(WAITING_TIME_IF_NO_TASKS)
+                with status.lock:
+                    status.nb_workers_waiting -= 1
 
 
 def _determine_next_job(status: LargeUploadStatus) -> tuple[WorkerJob, list[JOB_ITEM_T]] | None:

--- a/src/huggingface_hub/cli/_cli_utils.py
+++ b/src/huggingface_hub/cli/_cli_utils.py
@@ -842,30 +842,32 @@ def _prompt_autoupdate(
 
 def _get_huggingface_hub_update_command() -> list[str] | None:
     """Return the command to update huggingface_hub as an argv list, or None if the installation method is unknown."""
-    method = installation_method()
-    if method == "brew":
-        return ["brew", "upgrade", "hf"]
-    elif method == "hf_installer" and os.name == "nt":
-        return ["powershell", "-NoProfile", "-Command", "iwr -useb https://hf.co/cli/install.ps1 | iex"]
-    elif method == "hf_installer":
-        return ["bash", "-c", "curl -LsSf https://hf.co/cli/install.sh | bash -"]
-    elif method == "pip":
-        return [sys.executable, "-m", "pip", "install", "-U", "huggingface_hub"]
-    return None
+    match installation_method():
+        case "brew":
+            return ["brew", "upgrade", "hf"]
+        case "hf_installer" if os.name == "nt":
+            return ["powershell", "-NoProfile", "-Command", "iwr -useb https://hf.co/cli/install.ps1 | iex"]
+        case "hf_installer":
+            return ["bash", "-c", "curl -LsSf https://hf.co/cli/install.sh | bash -"]
+        case "pip":
+            return [sys.executable, "-m", "pip", "install", "-U", "huggingface_hub"]
+        case _:
+            return None
 
 
 def _get_transformers_update_command() -> list[str] | None:
     """Return the command to update transformers as an argv list, or None if the installation method is unknown."""
-    method = installation_method()
-    if method == "hf_installer" and os.name == "nt":
-        return [
-            "powershell",
-            "-NoProfile",
-            "-Command",
-            "iwr -useb https://hf.co/cli/install.ps1 | iex -WithTransformers",
-        ]
-    elif method == "hf_installer":
-        return ["bash", "-c", "curl -LsSf https://hf.co/cli/install.sh | bash -s -- --with-transformers"]
-    elif method == "pip":
-        return [sys.executable, "-m", "pip", "install", "-U", "transformers"]
-    return None
+    match installation_method():
+        case "hf_installer" if os.name == "nt":
+            return [
+                "powershell",
+                "-NoProfile",
+                "-Command",
+                "iwr -useb https://hf.co/cli/install.ps1 | iex -WithTransformers",
+            ]
+        case "hf_installer":
+            return ["bash", "-c", "curl -LsSf https://hf.co/cli/install.sh | bash -s -- --with-transformers"]
+        case "pip":
+            return [sys.executable, "-m", "pip", "install", "-U", "transformers"]
+        case _:
+            return None

--- a/src/huggingface_hub/cli/discussions.py
+++ b/src/huggingface_hub/cli/discussions.py
@@ -81,15 +81,17 @@ DiscussionNumArg = Annotated[
 
 
 def _format_status(status: str) -> str:
-    if status == "open":
-        return ANSI.green("open")
-    elif status == "closed":
-        return ANSI.red("closed")
-    elif status == "merged":
-        return ANSI.blue("merged")
-    elif status == "draft":
-        return ANSI.yellow("draft")
-    return status
+    match status:
+        case "open":
+            return ANSI.green("open")
+        case "closed":
+            return ANSI.red("closed")
+        case "merged":
+            return ANSI.blue("merged")
+        case "draft":
+            return ANSI.yellow("draft")
+        case _:
+            return status
 
 
 def _read_body(body: str | None, body_file: Path | None) -> str | None:

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -3268,14 +3268,15 @@ class HfApi:
         >     - [`~utils.RevisionNotFoundError`]
         >       If the revision to download from cannot be found.
         """
-        if repo_type is None or repo_type == "model":
-            method = self.model_info
-        elif repo_type == "dataset":
-            method = self.dataset_info  # type: ignore
-        elif repo_type == "space":
-            method = self.space_info  # type: ignore
-        else:
-            raise ValueError("Unsupported repo type.")
+        match repo_type:
+            case None | "model":
+                method = self.model_info
+            case "dataset":
+                method = self.dataset_info  # type: ignore
+            case "space":
+                method = self.space_info  # type: ignore
+            case _:
+                raise ValueError("Unsupported repo type.")
         return method(
             repo_id,
             revision=revision,

--- a/src/huggingface_hub/inference/_mcp/utils.py
+++ b/src/huggingface_hub/inference/_mcp/utils.py
@@ -39,32 +39,34 @@ def format_result(result: "mcp_types.CallToolResult") -> str:
     formatted_parts: list[str] = []
 
     for item in content:
-        if item.type == "text":
-            formatted_parts.append(item.text)
+        match item.type:
+            case "text":
+                formatted_parts.append(item.text)
 
-        elif item.type == "image":
-            formatted_parts.append(
-                f"[Binary Content: Image {item.mimeType}, {_get_base64_size(item.data)} bytes]\n"
-                f"The task is complete and the content accessible to the User"
-            )
-
-        elif item.type == "audio":
-            formatted_parts.append(
-                f"[Binary Content: Audio {item.mimeType}, {_get_base64_size(item.data)} bytes]\n"
-                f"The task is complete and the content accessible to the User"
-            )
-
-        elif item.type == "resource":
-            resource = item.resource
-
-            if hasattr(resource, "text") and isinstance(resource.text, str):
-                formatted_parts.append(resource.text)
-
-            elif hasattr(resource, "blob") and isinstance(resource.blob, str):
+            case "image":
                 formatted_parts.append(
-                    f"[Binary Content ({resource.uri}): {resource.mimeType}, {_get_base64_size(resource.blob)} bytes]\n"
+                    f"[Binary Content: Image {item.mimeType}, {_get_base64_size(item.data)} bytes]\n"
                     f"The task is complete and the content accessible to the User"
                 )
+
+            case "audio":
+                formatted_parts.append(
+                    f"[Binary Content: Audio {item.mimeType}, {_get_base64_size(item.data)} bytes]\n"
+                    f"The task is complete and the content accessible to the User"
+                )
+
+            case "resource":
+                resource = item.resource
+
+                if hasattr(resource, "text") and isinstance(resource.text, str):
+                    formatted_parts.append(resource.text)
+
+                elif hasattr(resource, "blob") and isinstance(resource.blob, str):
+                    formatted_parts.append(
+                        f"[Binary Content ({resource.uri}): {resource.mimeType},"
+                        f" {_get_base64_size(resource.blob)} bytes]\n"
+                        f"The task is complete and the content accessible to the User"
+                    )
 
     return "\n".join(formatted_parts)
 


### PR DESCRIPTION
Follow-up to #4008 (Python 3.10 migration).

this PR converts clear dispatch-on-value `if`/`elif` chains to `match`/`case`.

_Note_: the big diff in `upload_large_folder.py` is due to too much indentation churn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly mechanical refactors, but it touches the large-folder upload worker loop and queue routing, where subtle control-flow mistakes could affect upload reliability/concurrency.
> 
> **Overview**
> Refactors several value-dispatch `if`/`elif` chains to Python 3.10 `match`/`case` across bucket sync plan execution, large-folder upload worker job handling, CLI update-command selection, discussion status formatting, MCP result formatting, and `HfApi` repo-type dispatch.
> 
> Behavior is intended to be unchanged; the main diff in `_upload_large_folder.py` is indentation/control-flow reshaping around the worker job switch and upload-mode routing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75e09bbdf668fb8f8735b86fa4b64c5d80615e50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->