### PR TITLE
fix: truncate local file in download_bucket_files when remote is shorter

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -12704,6 +12704,16 @@ class HfApi:
                 progress_updater=[progress_updater] * len(non_zero_download_infos),
             )
 
+        # Truncate files to their expected size. The xet download writes bytes
+        # starting from offset 0 but does not truncate the file, so if the local
+        # file was previously larger than the remote, stale bytes remain at the end.
+        # See https://github.com/huggingface/huggingface_hub/issues/3995
+        for download_info in non_zero_download_infos:
+            dest_path = Path(download_info.destination_path)
+            if dest_path.stat().st_size > download_info.file_size:
+                with dest_path.open("r+b") as f:
+                    f.truncate(download_info.file_size)
+
     @validate_hf_hub_args
     def sync_bucket(
         self,

--- a/tests/test_buckets.py
+++ b/tests/test_buckets.py
@@ -289,6 +289,27 @@ def test_download_bucket_files_skips_missing_first_file(api: HfApi, bucket_read:
 
 
 @requires("hf_xet")
+def test_download_bucket_files_truncates_larger_local_file(api: HfApi, bucket_read: str, tmp_path):
+    """Test that download_bucket_files truncates a local file that is larger than the remote.
+
+    Regression test for https://github.com/huggingface/huggingface_hub/issues/3995.
+    When the local file is larger than the remote version, stale bytes should not
+    remain at the end after download.
+    """
+    local_path = tmp_path / "file.txt"
+
+    # Pre-create a local file that is larger than the remote "file.txt" (which contains b"content")
+    local_path.write_bytes(b"x" * 100)
+    assert local_path.stat().st_size == 100
+
+    # Download remote file (b"content" = 7 bytes) over the larger local file
+    api.download_bucket_files(bucket_read, [("file.txt", str(local_path))])
+
+    # File should be exactly the remote content, with no trailing stale bytes
+    assert local_path.read_bytes() == b"content"
+
+
+@requires("hf_xet")
 def test_download_bucket_files_raises_on_missing_when_requested(api: HfApi, bucket_read: str, tmp_path):
     """Test that download_bucket_files raises when raise_on_missing_files=True."""
     files = [


### PR DESCRIPTION
Fix #3995.

When downloading bucket files, the xet library writes content from offset 0 but does not truncate the file. If the local file was previously larger than the remote version, stale bytes remain at the end — causing `sync_bucket` to re-download on every run.

**Fix:** After `download_files` completes, truncate each destination file to its expected size when larger than remote.

**Test:** Added regression test that pre-creates a larger local file, downloads a shorter remote file over it, and verifies no trailing bytes remain.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches bucket download I/O logic and could affect on-disk file contents if size metadata is wrong, but the change is small and covered by a regression test.
> 
> **Overview**
> Fixes `download_bucket_files` to **truncate destination files to the expected remote size** after `hf_xet` downloads, preventing leftover trailing bytes when a local file was previously larger.
> 
> Adds a regression test that pre-creates an oversized local file, downloads a shorter remote file over it, and asserts the file matches the remote content exactly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 60b6de8c7ce429c8552ba0324ae4ca605b6b2297. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->