### PR TITLE
Bump to hf-xet 1.4.3 and add regression test

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def get_version() -> str:
 
 
 # hf-xet version used in both install_requires and extras["hf_xet"]
-HF_XET_VERSION = "hf-xet>=1.4.2,<2.0.0"
+HF_XET_VERSION = "hf-xet>=1.4.3,<2.0.0"
 
 install_requires = [
     "filelock>=3.10.0",

--- a/tests/test_buckets.py
+++ b/tests/test_buckets.py
@@ -333,3 +333,24 @@ def test_bucket_add_file_content_type(source, destination, expected_content_type
 
     entry = _BucketAddFile(source=source, destination=destination)
     assert entry.content_type == expected_content_type
+
+
+@requires("hf_xet")
+def test_download_file_should_truncate_existing_one(api: HfApi, bucket_write: str, tmp_path):
+    """Regression test for  https://github.com/huggingface/huggingface_hub/issues/3995.
+
+    Before this change if the local file was large than the remote one, only the first bytes of the local
+    file were updated, leaving a corrupted file.
+    """
+    file_path = tmp_path / "file.txt"
+    file_path.write_text("1234567890")
+
+    # Upload local file by path
+    api.batch_bucket_files(bucket_write, add=[(file_path, "file.txt")])
+
+    # Overwrite local file with larger content
+    file_path.write_text("a" * 40)
+
+    # Download from bucket should restore original content
+    api.download_bucket_files(bucket_write, files=[("file.txt", str(file_path))])
+    assert file_path.read_text() == "1234567890"


### PR DESCRIPTION
Fix https://github.com/huggingface/huggingface_hub/issues/3995 cc @dtcxzyw

The bug has been solved in `hf-xet` directly. This PR bumps its minimal version + adds a regression test for the use case that was previously failing. 

See https://github.com/huggingface/xet-core/pull/764 for more details on the fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only a patch-level dependency minimum bump plus an additional test; no production logic changes in this repo.
> 
> **Overview**
> Updates the pinned `hf-xet` minimum version to `>=1.4.3` (still `<2.0.0`) to pick up an upstream fix.
> 
> Adds a new `tests/test_buckets.py` regression test ensuring `download_bucket_files` properly truncates an existing local file when the remote version is smaller, preventing corrupted downloads.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4bac8d1797e3bc1b166bae83d6ac9f82a287613. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->