### PR TITLE
deduplicate repo folder name generation logic

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1486,8 +1486,7 @@ def try_to_load_from_cache(
     if cache_dir is None:
         cache_dir = constants.HF_HUB_CACHE
 
-    object_id = repo_id.replace("/", "--")
-    repo_cache = os.path.join(cache_dir, f"{repo_type}s--{object_id}")
+    repo_cache = os.path.join(cache_dir, repo_folder_name(repo_id=repo_id, repo_type=repo_type))
     if not os.path.isdir(repo_cache):
         # No cache for this model
         return None


### PR DESCRIPTION
try_to_load_cache() duplicates some logic present in repo_folder_name()

make try_to_load_cache() call into repo_folder_name() instead of generating
the path locally.

This should deduplicate code to make it cleaner and more maintainable
without changing functionality.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only changes how the cache directory path is constructed, delegating to existing `repo_folder_name` logic. Main concern is any subtle mismatch in folder-name serialization, but behavior should remain equivalent.
> 
> **Overview**
> `try_to_load_from_cache()` now builds the per-repo cache directory via `repo_folder_name(repo_id, repo_type)` instead of duplicating the repo-id serialization logic inline.
> 
> This is a small **deduplication/refactor** intended to keep cache path generation consistent across the codebase, without changing the cache lookup behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e2d481ff109134f1ba674030cc3f73aa9a865158. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->