### PR TITLE
[Fix CI] Do not scan CACHEDIR.TAG file in cache

### DIFF
--- a/src/huggingface_hub/utils/_cache_manager.py
+++ b/src/huggingface_hub/utils/_cache_manager.py
@@ -657,6 +657,8 @@ def scan_cache_dir(cache_dir: str | Path | None = None) -> HFCacheInfo:
     for repo_path in cache_dir.iterdir():
         if repo_path.name == ".locks":  # skip './.locks/' folder
             continue
+        if repo_path.name == "CACHEDIR.TAG":  # skip CACHEDIR.TAG file
+            continue
         try:
             repos.add(_scan_cached_repo(repo_path))
         except CorruptedCacheException as e:


### PR DESCRIPTION
Fix bug introduced in https://github.com/huggingface/huggingface_hub/pull/4030.

In `scan_cache_dir` we should skip `CACHEDIR.TAG` file gracefully. Currently a warning is logged when we attempt to scan it (since it's not a directory)

This should fix CI errors. Sorry merging the PR to quickly :grimacing: 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change to cache scanning loop that only ignores a known marker file; behavior change is limited to reducing spurious corruption warnings.
> 
> **Overview**
> Prevents `scan_cache_dir` from attempting to scan the `CACHEDIR.TAG` marker file in the cache root by explicitly skipping it (similar to the existing `.locks` skip).
> 
> This avoids emitting `CorruptedCacheException` warnings when `CACHEDIR.TAG` exists (e.g., created by `_create_cachedir_tag`), improving CI/cache scan robustness.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1908486e9d7ee688a9afa82af05ce563e0425934. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->