### PR TITLE
[Fix] [CI] Slack-message reads draft release from GitHub directly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -299,8 +299,6 @@ jobs:
     needs: prepare
     if: ${{ !inputs.dry_run }}
     runs-on: ubuntu-latest
-    outputs:
-      drafted_prerelease: ${{ steps.check_draft.outputs.skip == 'false' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:


### PR DESCRIPTION
Remove the artifact upload/download dependency between release-notes and slack-message jobs. Instead, slack-message fetches the draft release body via `gh release view`, making it resilient to release-notes failures and re-runnable after manual edits to the draft.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the release GitHub Actions workflow and changes job dependencies/conditions, which can impact automated releases if misconfigured. However, changes are localized to Slack-message note sourcing and should be straightforward to validate in CI.
> 
> **Overview**
> Decouples the prerelease `slack-message` job from the `release-notes` job’s artifact outputs by removing the upload/download of `.release-notes` artifacts.
> 
> `slack-message` now always runs for prereleases when `prepare` succeeds (even if `release-notes` fails), fetches the current draft release body directly from GitHub via `gh release list/view`, and feeds it to `generate_slack_message` via a new `--input notes.md` path (creating `.release-notes/` as needed).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 344558f05a5348e6d82edbf1107a02d49fe5b724. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->