### PR TITLE
[FIX] [CI] Fix upgrading release notes to latest release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -415,8 +415,8 @@ jobs:
           MINOR=$(echo "$VERSION" | sed -E 's/^([0-9]+\.[0-9]+).*/\1/')
 
           # Find the existing draft release for this minor version
-          EXISTING_TAG=$(gh release list --json tagName,isDraft --limit 100 \
-            | jq -r ".[] | select(.isDraft) | select(.tagName | startswith(\"v${MINOR}.\")) | .tagName" | head -1)
+          EXISTING_TAG=$(gh release list --json tagName --limit 100 \
+            | jq -r ".[] | select(.tagName | startswith(\"v${MINOR}.\")) | .tagName" | head -1)
 
           if [[ -n "$EXISTING_TAG" ]]; then
             echo "Updating existing draft release from $EXISTING_TAG to $TAG"


### PR DESCRIPTION
Currently getting 

```
Warning: No draft release found for v1.9. Creating new release with auto-generated notes.
HTTP 422: Validation Failed (https://api.github.com/repos/huggingface/huggingface_hub/releases)
body is too long (maximum is 125000 characters)
Error: Process completed with exit code 1.
```

in CI when trying to upgrade the `1.x.x.rcX` release notes to `1.x.x`. Issue is that it's looking for a draft release but between the 2 runs we usually manually moved the release notes from draft to "ready" (but as prerelease instead of release).

This PR removes the "isDraft" check

Example: https://github.com/huggingface/huggingface_hub/actions/runs/23940040924/job/69824210746

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release promotion behavior in the GitHub Actions `release.yml` workflow; incorrect matching could update the wrong release tag for a minor version and affect published release metadata.
> 
> **Overview**
> Fixes the `minor-release` promotion step in `.github/workflows/release.yml` to **stop requiring a draft GitHub release** when upgrading RC notes to the final tag.
> 
> Instead of filtering `gh release list` results by `isDraft`, the workflow now selects any existing release whose `tagName` starts with the target minor (e.g. `v1.9.`) and edits that release to retag it as the final version, avoiding fallback creation of a new release with auto-generated notes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 622003db787b2c35731ddb2c749be5ec2b1cf150. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->