### PR TITLE
Add live Slack notifications to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,7 +211,7 @@ jobs:
             patch-release)    TYPE_EMOJI="🐛" TYPE_LABEL="Patch" ;;
           esac
 
-          TEXT="${TYPE_EMOJI} *${TYPE_LABEL} \`${TAG}\` started*\n>Branch: \`${BRANCH}\` • <${RUN_URL}|View run>"
+          TEXT="${TYPE_EMOJI} *${TYPE_LABEL} \`${TAG}\` started*"$'\n'">Branch: \`${BRANCH}\` • <${RUN_URL}|View run>"
 
           RESPONSE=$(curl -s -X POST https://slack.com/api/chat.postMessage \
             -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
@@ -967,10 +967,10 @@ jobs:
           esac
 
           if [[ "$FAILED" == "true" ]]; then
-            TEXT="❌ *${TYPE_LABEL} \`${TAG}\` failed*\n>Branch: \`${BRANCH}\` • <${RUN_URL}|View run>"
+            TEXT="❌ *${TYPE_LABEL} \`${TAG}\` failed*"$'\n'">Branch: \`${BRANCH}\` • <${RUN_URL}|View run>"
             REACTION="x"
           else
-            TEXT="✅ *${TYPE_LABEL} \`${TAG}\` completed*\n>Branch: \`${BRANCH}\` • <${RUN_URL}|View run>"
+            TEXT="✅ *${TYPE_LABEL} \`${TAG}\` completed*"$'\n'">Branch: \`${BRANCH}\` • <${RUN_URL}|View run>"
             REACTION="white_check_mark"
           fi
 


### PR DESCRIPTION

#### Note from myself: follow-up on the on-going work to streamline `huggingface_hub` releases. This PR adds a Slack Bot that will send messages to `#hub-client-library-internal` with status of each step. This will make it more straightforward to retrieve URLs and generated messages.


I have added `SLACK_BOT_TOKEN` as a secret and `SLACK_CHANNEL_ID` as a variable in this repo settings.

Bot will be this one: https://api.slack.com/apps/A0AQJJYFFBM/general

-----

## Summary

- Posts a Slack message when a release starts (with type emoji: :building_construction:  pre-release, :ship:  release, 🐛 patch)
- Each sub-job posts a **threaded reply** on completion with ✅/❌ status and relevant links:
  - **PyPI** → links to [huggingface-hub](https://pypi.org/project/huggingface-hub/#history) / [hf](https://pypi.org/project/hf/#history) history
  - **Release notes** → links to GitHub releases page
  - **Slack announcement** → uploads the generated `.md` file as a thread attachment
  - **Downstream testing** → links to compare URL per repo (transformers, datasets, diffusers, sentence-transformers)
  - **Post-release** → links to the version bump PR
  - **CLI skill sync** → status
- A final `slack-complete` job updates the original message ("started" → "completed"/"failed") and adds a ✅ or ❌ reaction
- All Slack steps use `continue-on-error: true` — Slack issues never block the release
- Skipped during dry runs and when `message_ts` is empty (Slack init failed)

## Setup required

1. **Secret `SLACK_BOT_TOKEN`** — Slack Bot User OAuth Token with scopes: `chat:write`, `reactions:write`, `files:write`
2. **Repository variable `SLACK_CHANNEL_ID`** — target Slack channel ID
3. Invite the bot to the channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies the release GitHub Actions workflow to add Slack messaging and a new completion job; while Slack steps are non-blocking, changes touch the release pipeline and could affect execution flow/needs outputs if misconfigured.
> 
> **Overview**
> Adds live Slack notifications to the `release.yml` workflow: the `prepare` job now posts a “release started” message and exports its `message_ts` for threading.
> 
> Each major job (PyPI publishes, release notes, prerelease Slack announcement generation incl. file upload, downstream RC branches, post-release bump PR, and CLI skill sync) posts a ✅/❌ threaded status update, and a new `slack-complete` job updates the original message with final success/failure plus a reaction. The post-release step also captures the created PR URL for linking in Slack, and the workflow docs now list required Slack secret/variable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 91d22cd709c0d7d5dd70451670150af25bc52428. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->