### PR TITLE
skills publish script run in action to sync up descriptions etc.

### DIFF
--- a/.github/workflows/sync-hf-cli-skill.yml
+++ b/.github/workflows/sync-hf-cli-skill.yml
@@ -53,8 +53,15 @@ jobs:
           token: ${{ steps.app_token.outputs.token }}
           path: skills-repo
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+
       - name: Copy generated files
         run: cp /tmp/hf-cli-skill/SKILL.md skills-repo/skills/hf-cli/
+
+      - name: Regenerate skills repo artifacts
+        working-directory: skills-repo
+        run: ./scripts/publish.sh
 
       - name: Check for changes
         id: check_changes


### PR DESCRIPTION
Related : https://github.com/huggingface/skills/pull/111

Runs the publish script to update descriptions etc. in marketplace/agents files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release-tag sync workflow to run `./scripts/publish.sh` in the downstream `huggingface/skills` repo, which can modify additional generated artifacts and affect automated PR contents. Risk is limited to CI automation, but failures or unexpected diffs could disrupt the sync process.
> 
> **Overview**
> Updates the `sync-hf-cli-skill` GitHub Actions workflow to also regenerate downstream `huggingface/skills` repository artifacts after copying the generated `SKILL.md`.
> 
> The workflow now installs `uv` and runs `./scripts/publish.sh` before checking for diffs and opening the automated PR, ensuring marketplace/agent metadata stays in sync alongside the doc update.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bfd84bad6ee8f7e1fca32b596e34f6f4de18b622. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->