### PR TITLE
Fix set_space_volumes sending bare array instead of object

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -8206,7 +8206,7 @@ class HfApi:
             ... )
             ```
         """
-        payload = [vol.to_dict() for vol in volumes]
+        payload = {"volumes": [vol.to_dict() for vol in volumes]}
         r = get_session().put(
             f"{self.endpoint}/api/spaces/{repo_id}/volumes",
             headers=self._build_hf_headers(token=token),


### PR DESCRIPTION
## What does this PR do?

Fixes `set_space_volumes` which currently sends a bare JSON array to `PUT /api/spaces/{repo_id}/volumes`, but the endpoint expects a JSON object with a `"volumes"` key.

**Before (fails with 400):**
```python
payload = [vol.to_dict() for vol in volumes]
# Sends: [{"type": "bucket", "source": "...", "mountPath": "...", ...}]
```

**After (works):**
```python
payload = {"volumes": [vol.to_dict() for vol in volumes]}
# Sends: {"volumes": [{"type": "bucket", "source": "...", "mountPath": "...", ...}]}
```

## How was this found?

Calling `api.set_space_volumes()` returns:
```
huggingface_hub.errors.BadRequestError: Invalid input: expected object, received array
```

## How was the fix verified?

I tested both payload formats directly against the production endpoint:

```python
# Bare array → 400 Bad Request
session.put(url, headers=headers, json=[{...}])

# Wrapped object → 200 OK, volume mounted successfully
session.put(url, headers=headers, json={"volumes": [{...}]})
```

## Caveat

I inferred the expected payload format from the error message and empirical testing. I didn't check the server-side API spec, so it's possible the fix should be on the server side (accepting arrays) rather than the client side. Happy to adjust if the intended contract is different from what I've assumed here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, single-request payload shape change to match the server contract for `PUT /api/spaces/{repo_id}/volumes`. Main risk is compatibility if any server deployment previously accepted a bare array.
> 
> **Overview**
> Fixes `HfApi.set_space_volumes` to wrap the serialized volumes list in a JSON object (`{"volumes": [...]}`) instead of sending a bare array, aligning the client payload with what `PUT /api/spaces/{repo_id}/volumes` expects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22690f6f29897645850217369e42561ef464b85d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->