### PR TITLE
Fix custom `tqdm_class` silently broken in non-TTY environments

### DIFF
--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -18,8 +18,9 @@ from .errors import (
 )
 from .file_download import REGEX_COMMIT_HASH, DryRunFileInfo, hf_hub_download, repo_folder_name
 from .hf_api import DatasetInfo, HfApi, ModelInfo, RepoFile, SpaceInfo
-from .utils import OfflineModeIsEnabled, filter_repo_objects, is_tqdm_disabled, logging, validate_hf_hub_args
-from .utils import tqdm as hf_tqdm
+from .utils import OfflineModeIsEnabled, filter_repo_objects, logging, validate_hf_hub_args
+from .utils.tqdm import _create_progress_bar
+from .utils.tqdm import tqdm as hf_tqdm
 
 
 logger = logging.get_logger(__name__)
@@ -385,14 +386,15 @@ def snapshot_download(
     # Create a progress bar for the bytes downloaded
     # This progress bar is shared across threads/files and gets updated each time we fetch
     # metadata for a file.
-    bytes_progress = tqdm_class(
+    bytes_progress = _create_progress_bar(
+        cls=tqdm_class,
+        log_level=logger.getEffectiveLevel(),
+        name="huggingface_hub.snapshot_download",
         desc="Downloading (incomplete total...)",
-        disable=is_tqdm_disabled(log_level=logger.getEffectiveLevel()),
         total=0,
         initial=0,
         unit="B",
         unit_scale=True,
-        name="huggingface_hub.snapshot_download",
     )
 
     class _AggregatedTqdm:

--- a/src/huggingface_hub/utils/tqdm.py
+++ b/src/huggingface_hub/utils/tqdm.py
@@ -323,7 +323,7 @@ def _get_progress_bar_context(
         #   Makes it easier to use the same code path for both cases but in the later
         #   case, the progress bar is not closed when exiting the context manager.
 
-    return _create_progress_bar(  # type: ignore[return-value]
+    return _create_progress_bar(  # type: ignore
         cls=tqdm_class or tqdm,
         log_level=log_level,
         name=name,

--- a/src/huggingface_hub/utils/tqdm.py
+++ b/src/huggingface_hub/utils/tqdm.py
@@ -279,6 +279,32 @@ def tqdm_stream_file(path: Path | str) -> Iterator[io.BufferedReader]:
         pbar.close()
 
 
+def _create_progress_bar(*, cls: type[old_tqdm], log_level: int, name: str | None = None, **kwargs) -> old_tqdm:
+    """Create a progress bar, handling custom vs HF subclass differences.
+
+    For our `tqdm` subclass (or subclasses of it): respects all disable signals
+    (`HF_HUB_DISABLE_PROGRESS_BARS`, `disable_progress_bars()`, log level) and uses
+    `disable=None` for TTY auto-detection (see https://github.com/huggingface/huggingface_hub/pull/2000),
+    unless `TQDM_POSITION=-1` forces bars on (https://github.com/huggingface/huggingface_hub/pull/2698).
+
+    For other classes: does not inject `disable` or `name`. the custom class is fully
+    responsible for its own behavior. Vanilla tqdm defaults to `disable=False` (bar shows).
+    Omits `name` which vanilla tqdm rejects with `TqdmKeyError`. See https://github.com/huggingface/huggingface_hub/issues/4050.
+    """
+    # issubclass() crashes on non-class callables (e.g. functools.partial), guard with isinstance.
+    if not (isinstance(cls, type) and issubclass(cls, tqdm)):
+        return cls(**kwargs)  # type: ignore[return-value]
+
+    # HF subclass: apply all disable signals + TTY auto-detection.
+    if are_progress_bars_disabled(name) or log_level == logging.NOTSET:
+        disable: bool | None = True
+    elif os.getenv("TQDM_POSITION") == "-1":
+        disable = False
+    else:
+        disable = None
+    return cls(disable=disable, name=name, **kwargs)  # type: ignore[return-value]
+
+
 def _get_progress_bar_context(
     *,
     desc: str,
@@ -297,12 +323,13 @@ def _get_progress_bar_context(
         #   Makes it easier to use the same code path for both cases but in the later
         #   case, the progress bar is not closed when exiting the context manager.
 
-    return (tqdm_class or tqdm)(  # type: ignore
+    return _create_progress_bar(  # type: ignore[return-value]
+        cls=tqdm_class or tqdm,
+        log_level=log_level,
+        name=name,
         unit=unit,
         unit_scale=unit_scale,
         total=total,
         initial=initial,
         desc=desc,
-        disable=is_tqdm_disabled(log_level=log_level),
-        name=name,
     )

--- a/src/huggingface_hub/utils/tqdm.py
+++ b/src/huggingface_hub/utils/tqdm.py
@@ -295,13 +295,9 @@ def _create_progress_bar(*, cls: type[old_tqdm], log_level: int, name: str | Non
     if not (isinstance(cls, type) and issubclass(cls, tqdm)):
         return cls(**kwargs)  # type: ignore[return-value]
 
-    # HF subclass: apply all disable signals + TTY auto-detection.
-    if are_progress_bars_disabled(name) or log_level == logging.NOTSET:
-        disable: bool | None = True
-    elif os.getenv("TQDM_POSITION") == "-1":
-        disable = False
-    else:
-        disable = None
+    # HF subclass: keep the historical log-level / TTY behavior. Group-based
+    # disabling is already handled in `tqdm.__init__`.
+    disable = is_tqdm_disabled(log_level)
     return cls(disable=disable, name=name, **kwargs)  # type: ignore[return-value]
 
 

--- a/src/huggingface_hub/utils/tqdm.py
+++ b/src/huggingface_hub/utils/tqdm.py
@@ -280,7 +280,7 @@ def tqdm_stream_file(path: Path | str) -> Iterator[io.BufferedReader]:
 
 
 def _create_progress_bar(*, cls: type[old_tqdm], log_level: int, name: str | None = None, **kwargs) -> old_tqdm:
-    """Create a progress bar, handling custom vs HF subclass differences.
+    """Create a progress bar.
 
     For our `tqdm` subclass (or subclasses of it): respects all disable signals
     (`HF_HUB_DISABLE_PROGRESS_BARS`, `disable_progress_bars()`, log level) and uses

--- a/tests/test_utils_tqdm.py
+++ b/tests/test_utils_tqdm.py
@@ -1,3 +1,6 @@
+import io
+import logging
+import sys
 import time
 import unittest
 from pathlib import Path
@@ -5,6 +8,7 @@ from unittest.mock import patch
 
 import pytest
 from pytest import CaptureFixture
+from tqdm.auto import tqdm as vanilla_tqdm
 
 from huggingface_hub.utils import (
     SoftTemporaryDirectory,
@@ -14,6 +18,7 @@ from huggingface_hub.utils import (
     tqdm,
     tqdm_stream_file,
 )
+from huggingface_hub.utils.tqdm import _get_progress_bar_context
 
 
 class CapsysBaseTest(unittest.TestCase):
@@ -235,3 +240,36 @@ class TestTqdmGroup(CapsysBaseTest):
         captured = self.capsys.readouterr()
         assert captured.out == ""
         assert "10/10" in captured.err
+
+
+class TestCreateProgressBarCustomClass:
+    """Regression tests for https://github.com/huggingface/huggingface_hub/issues/4050."""
+
+    def test_custom_tqdm_class_not_disabled_in_non_tty(self):
+        """Custom tqdm_class should not be silently disabled in non-TTY."""
+        fake_stderr = io.StringIO()
+        with patch.object(sys, "stderr", fake_stderr):
+            bar = _get_progress_bar_context(
+                desc="test",
+                log_level=logging.INFO,
+                total=100,
+                tqdm_class=vanilla_tqdm,
+                name="huggingface_hub.test",
+            )
+            with bar as pbar:
+                assert not pbar.disable
+                pbar.update(50)
+                pbar.update(50)
+                assert pbar.n == 100
+
+    def test_custom_tqdm_class_no_name_kwarg(self):
+        """Custom tqdm_class should not receive HF-specific 'name' kwarg."""
+        bar = _get_progress_bar_context(
+            desc="test",
+            log_level=logging.INFO,
+            total=10,
+            tqdm_class=vanilla_tqdm,
+            name="huggingface_hub.test",
+        )
+        with bar as pbar:
+            pbar.update(10)

--- a/tests/test_utils_tqdm.py
+++ b/tests/test_utils_tqdm.py
@@ -241,6 +241,17 @@ class TestTqdmGroup(CapsysBaseTest):
         assert captured.out == ""
         assert "10/10" in captured.err
 
+    @patch("huggingface_hub.utils._tqdm.HF_HUB_DISABLE_PROGRESS_BARS", None)
+    def test_progress_bar_context_respects_group(self) -> None:
+        disable_progress_bars("foo.bar")
+        with _get_progress_bar_context(
+            desc="test",
+            log_level=logging.INFO,
+            total=10,
+            name="foo.bar.something",
+        ) as pbar:
+            assert pbar.disable
+
 
 class TestCreateProgressBarCustomClass:
     """Regression tests for https://github.com/huggingface/huggingface_hub/issues/4050."""

--- a/tests/test_utils_tqdm.py
+++ b/tests/test_utils_tqdm.py
@@ -262,6 +262,19 @@ class TestCreateProgressBarCustomClass:
                 pbar.update(50)
                 assert pbar.n == 100
 
+    @patch("huggingface_hub.utils._tqdm.HF_HUB_DISABLE_PROGRESS_BARS", True)
+    def test_custom_tqdm_class_ignores_hf_disable_signal(self):
+        """Custom tqdm_class is not affected by HF_HUB_DISABLE_PROGRESS_BARS."""
+        bar = _get_progress_bar_context(
+            desc="test",
+            log_level=logging.INFO,
+            total=10,
+            tqdm_class=vanilla_tqdm,
+            name="huggingface_hub.test",
+        )
+        with bar as pbar:
+            assert not pbar.disable
+
     def test_custom_tqdm_class_no_name_kwarg(self):
         """Custom tqdm_class should not receive HF-specific 'name' kwarg."""
         bar = _get_progress_bar_context(


### PR DESCRIPTION
Fixes #4050.

when passing a custom `tqdm_class` to `hf_hub_download()` or `snapshot_download()`, progress tracking is broken. this is because all tqdm classes are instantiated identically. When a user passes a custom `tqdm_class`, they take full control of progress bar behavior. The library should not inject HF-specific kwargs (`name`) or override display logic (`disable`).  the custom class is responsible for its own configuration.
Here is a small reproducible:
```python
from tqdm.auto import tqdm
from huggingface_hub import hf_hub_download


class MyProgress(tqdm):
    def update(self, n=1):
        super().update(n)
        print(f"Progress: {self.n}/{self.total}")


hf_hub_download(
    repo_id="unsloth/gemma-4-26B-A4B-it-GGUF",
    filename="config.json",
    tqdm_class=MyProgress,
    force_download=True,
)
```

this causes two bugs depending on the environment:

In TTY: `disable=None` -> `isatty()` returns `True` -> tqdm continues `__init__` -> hits the unknown kwargs check → `TqdmKeyError` on `name`:

```
python reproducible.py
  ...
  File "huggingface_hub/utils/tqdm.py", line 300, in _get_progress_bar_context
    return (tqdm_class or tqdm)(
    ...
tqdm.std.TqdmKeyError: "Unknown argument(s): {'name': 'huggingface_hub.http_get'}"
```

In non-TTY: `is_tqdm_disabled()` returns `None`. Vanilla tqdm interprets `disable=None` as "check `sys.stderr.isatty()`" → `False` in non-TTY → sets `self.disable = True` → `update()` becomes a no-op. No crash, but progress is silently lost:

```
$ python reproducible.py 2>&1 | cat
Progress: 0/None
```

⚠️ BREAKING CHANGE: custom `tqdm_class` instances no longer receive the `name` kwarg or `disable` value, the custom class is fully responsible for its own configuration. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is isolated to progress bar instantiation logic and adds regression tests; main behavior change only affects callers providing a custom `tqdm_class`, especially in non-TTY environments.
> 
> **Overview**
> Fixes progress reporting when callers pass a custom `tqdm_class` by centralizing progress-bar creation in `_create_progress_bar` and only applying Hugging Face–specific kwargs (`name`) and disable/TTY logic for the HF `tqdm` subclass.
> 
> Updates both `_get_progress_bar_context` and `snapshot_download` to use this helper, and adds regression tests to ensure group-based disabling still works for HF bars while vanilla/custom tqdm classes are neither force-disabled in non-TTY nor passed the unsupported `name` kwarg.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5d3eba80b862b84f16f3118bec3a25ba49852dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->