### PR TITLE
Fix set_space_volume / delete_space_volume return types

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -8160,23 +8160,6 @@ class HfApi:
         hf_raise_for_status(r)
         return SpaceRuntime(r.json())
 
-    def _space_runtime_after_mutation(
-        self,
-        repo_id: str,
-        response: httpx.Response,
-        *,
-        token: bool | str | None = None,
-    ) -> SpaceRuntime:
-        if not response.content:
-            return self.get_space_runtime(repo_id, token=token)
-        data = response.json()
-        if isinstance(data, dict):
-            try:
-                return SpaceRuntime(data)
-            except (KeyError, TypeError, ValueError):
-                pass
-        return self.get_space_runtime(repo_id, token=token)
-
     @validate_hf_hub_args
     def set_space_volumes(
         self,
@@ -8184,7 +8167,7 @@ class HfApi:
         volumes: list[Volume],
         *,
         token: bool | str | None = None,
-    ) -> SpaceRuntime:
+    ) -> None:
         """Set volumes for a Space.
 
         Sets (or replaces) the list of volumes mounted in the Space. Each volume gives the Space's container access
@@ -8202,9 +8185,6 @@ class HfApi:
                 token, which is the recommended method for authentication (see
                 https://huggingface.co/docs/huggingface_hub/quick-start#authentication).
                 To disable authentication, pass `False`.
-
-        Returns:
-            [`SpaceRuntime`]: Runtime information about a Space including Space stage and hardware.
 
         Raises:
             [`BadRequestError`]:
@@ -8230,7 +8210,6 @@ class HfApi:
             json=payload,
         )
         hf_raise_for_status(r)
-        return self._space_runtime_after_mutation(repo_id, r, token=token)
 
     @validate_hf_hub_args
     def delete_space_volumes(
@@ -8238,7 +8217,7 @@ class HfApi:
         repo_id: str,
         *,
         token: bool | str | None = None,
-    ) -> SpaceRuntime:
+    ) -> None:
         """Remove all volumes from a Space.
 
         Args:
@@ -8249,9 +8228,6 @@ class HfApi:
                 token, which is the recommended method for authentication (see
                 https://huggingface.co/docs/huggingface_hub/quick-start#authentication).
                 To disable authentication, pass `False`.
-
-        Returns:
-            [`SpaceRuntime`]: Runtime information about a Space including Space stage and hardware.
 
         Raises:
             [`BadRequestError`]:
@@ -8269,7 +8245,6 @@ class HfApi:
             headers=self._build_hf_headers(token=token),
         )
         hf_raise_for_status(r)
-        return self._space_runtime_after_mutation(repo_id, r, token=token)
 
     #######################
     # Inference Endpoints #

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -29,10 +29,9 @@ from typing import Optional, Union, get_args
 from unittest.mock import Mock, patch
 from urllib.parse import urlparse
 
-import httpx
 import pytest
 
-from huggingface_hub import HfApi, SpaceHardware, SpaceStage, SpaceStorage, Volume, constants
+from huggingface_hub import HfApi, SpaceHardware, SpaceStage, SpaceStorage, constants
 from huggingface_hub._commit_api import (
     CommitOperationAdd,
     CommitOperationCopy,
@@ -3452,25 +3451,6 @@ iface.launch()
         time.sleep(0.5)
         runtime_after_restart = self.api.get_space_runtime(self.repo_id)
         self.assertNotEqual(runtime_after_restart.stage, SpaceStage.PAUSED)
-
-
-class TestSpaceVolumesRuntimeResponse(HfApiCommonTest):
-    @patch("huggingface_hub.hf_api.HfApi.get_space_runtime")
-    @patch("huggingface_hub.hf_api.get_session")
-    def test_set_space_volumes_non_runtime_json_fetches_runtime(
-        self, mock_get_session: Mock, mock_get_runtime: Mock
-    ) -> None:
-        put_req = httpx.Request("PUT", "https://huggingface.co/api/spaces/user/space/volumes")
-        mock_get_session.return_value.put.return_value = httpx.Response(200, json={"volumes": []}, request=put_req)
-        mock_runtime = Mock(spec=SpaceRuntime)
-        mock_get_runtime.return_value = mock_runtime
-
-        out = self._api.set_space_volumes(
-            "user/space",
-            [Volume(type="bucket", source="user/b", mount_path="/data")],
-        )
-        self.assertIs(out, mock_runtime)
-        mock_get_runtime.assert_called_once_with("user/space", token=None)
 
 
 @pytest.mark.usefixtures("fx_cache_dir")


### PR DESCRIPTION
### 🚨 This PR removes the returned value of both `set_space_volumes` and `delete_space_volumes`. This is a breaking change but in practice it never worked so it's more of a fix ^^

Not sure if this is a problem with Hub server or library, but basically I've noticed that `PUT` / `DELETE` `/api/spaces/{repo_id}/volumes` can return a JSON body that is **not** a full Space runtime document (e.g. only volume-related fields, no top-level `stage`). The client always did `return SpaceRuntime(r.json())`, which raises when `stage` is missing:

```text
KeyError: 'stage'
```



Now working correctly with

```python
from huggingface_hub import Volume, create_repo, delete_space_volumes, set_space_volumes

repo_id = create_repo(repo_id="my-cool-training-space", repo_type="space", space_sdk="gradio", exist_ok=True).repo_id
set_space_volumes(
    repo_id=repo_id,
    volumes=[Volume(type="model", source="openai-community/gpt2", mount_path="/gpt2", read_only=True)],
)
delete_space_volumes(repo_id=repo_id)

```

Noticed while testing the latest version of `huggingface_hub` (1.9.1) with `trackio`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a behavior/signature change for two public client methods and may break callers relying on the returned `SpaceRuntime`, though the logic change itself is small and localized.
> 
> **Overview**
> Adjusts Space volume mutation APIs to no longer parse and return `SpaceRuntime` from `PUT`/`DELETE /api/spaces/{repo_id}/volumes` responses.
> 
> `HfApi.set_space_volumes` and `HfApi.delete_space_volumes` now return `None` and drop the documented return value, preventing `SpaceRuntime(r.json())` failures when the server returns a partial body.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 029beddf5a07ed8f9eebbf779680172f887a64c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->