### PR TITLE
Apply fsspec config in HfFileSystem metaclass

### DIFF
--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -16,6 +16,7 @@ from urllib.parse import quote, unquote
 import fsspec
 import httpx
 from fsspec.callbacks import _DEFAULT_CALLBACK, NoOpCallback, TqdmCallback
+from fsspec.config import apply_config
 from fsspec.utils import isfilelike
 
 from . import constants
@@ -121,6 +122,9 @@ class _Cached(_cached_base):
 
     def __call__(cls, *args, **kwargs):
         # Hack: override https://github.com/fsspec/filesystem_spec/blob/dcb167e8f50e6273d4cfdfc4cab8fc5aa4c958bf/fsspec/spec.py#L65
+        # Apply fsspec config (env vars / config files) before tokenizing so that
+        # HfFileSystem picks up defaults the same way other fsspec filesystems do.
+        kwargs = apply_config(cls, kwargs)
         skip = kwargs.pop("skip_instance_cache", False)
         fs_token = cls._tokenize(cls, threading.get_ident(), *args, **kwargs)
         fs_token_main_thread = cls._tokenize(cls, threading.main_thread().ident, *args, **kwargs)


### PR DESCRIPTION
HfFileSystem's `_Cached` metaclass overrides `fsspec.spec._Cached.__call__` but skips the `apply_config` call that upstream fsspec uses to read config values from environment variables and config files. As a result, `HfFileSystem` silently ignores fsspec config that works on every other filesystem backend.

This patch calls `apply_config(cls, kwargs)` at the start of `__call__`, matching upstream fsspec behavior.

Fixes #3996

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `HfFileSystem` instantiation/caching by applying fsspec env/config defaults before tokenization, which can alter cache keys and runtime options for existing users relying on implicit defaults.
> 
> **Overview**
> Ensures `HfFileSystem` honors standard fsspec configuration (env vars / config files) by calling `apply_config` in the custom `_Cached.__call__` before computing the instance cache token.
> 
> This aligns `HfFileSystem` behavior with upstream fsspec filesystems so default options from config are applied consistently when creating/reusing cached filesystem instances.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d89bbf8be0d95c89d66379e49d1fe1fce8d28fc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->