### PR TITLE
[BUG FIX]: hf_hub_download crashes when stderr lacks a real file descriptor

### DIFF
--- a/src/huggingface_hub/utils/tqdm.py
+++ b/src/huggingface_hub/utils/tqdm.py
@@ -82,6 +82,7 @@ Group-based control:
 import io
 import logging
 import os
+import threading
 import warnings
 from collections.abc import Iterator
 from contextlib import contextmanager, nullcontext
@@ -295,6 +296,21 @@ def tqdm_stream_file(path: Path | str) -> Iterator[io.BufferedReader]:
         pbar.close()
 
 
+class _SafeTqdm(old_tqdm):
+    """tqdm subclass that uses a thread lock instead of a multiprocessing lock.
+
+    Used as a fallback when the standard tqdm cannot initialize its multiprocessing
+    lock (e.g. when stderr.fileno() returns -1 in Textual, Jupyter, pytest, etc.).
+    """
+
+    _lock = threading.RLock()
+
+    @classmethod
+    def get_lock(cls):
+        return cls._lock
+
+
+
 def _create_progress_bar(*, cls: type[old_tqdm], log_level: int, name: str | None = None, **kwargs) -> old_tqdm:
     """Create a progress bar.
 
@@ -309,12 +325,27 @@ def _create_progress_bar(*, cls: type[old_tqdm], log_level: int, name: str | Non
     """
     # issubclass() crashes on non-class callables (e.g. functools.partial), guard with isinstance.
     if not (isinstance(cls, type) and issubclass(cls, tqdm)):
-        return cls(**kwargs)  # type: ignore[return-value]
+        try:
+            return cls(**kwargs)
+        except (OSError, ValueError):
+            # Caller opted into custom progress; a visible fallback bar would
+            # corrupt their output (e.g. TUIs), so disable it.
+            return _SafeTqdm(disable=True, **kwargs)
 
     # HF subclass: keep the historical log-level / TTY behavior. Group-based
     # disabling is already handled in `tqdm.__init__`.
     disable = is_tqdm_disabled(log_level)
-    return cls(disable=disable, name=name, **kwargs)  # type: ignore[return-value]
+    try:
+        return cls(disable=disable, name=name, **kwargs)
+    except (OSError, ValueError):
+        warnings.warn(
+            "Progress bar could not be initialized in this environment. "
+            "Download will continue without progress reporting. "
+            "To suppress this warning, call `disable_progress_bars()` or set HF_HUB_DISABLE_PROGRESS_BARS=1.",
+            stacklevel=2,
+        )
+        # disable=None would attempt TTY auto-detect on the broken stderr.
+        return _SafeTqdm(disable=True, **kwargs)
 
 
 def _get_progress_bar_context(

--- a/src/huggingface_hub/utils/tqdm.py
+++ b/src/huggingface_hub/utils/tqdm.py
@@ -234,6 +234,13 @@ class tqdm(old_tqdm):
                 raise
 
 
+# Prevent tqdm's default multiprocessing write-lock from spawning a resource
+# tracker subprocess via fork_exec(). That path fails when stderr has an invalid
+# fd (e.g. Textual TUIs that return -1 from sys.stderr.fileno()). Inter-process
+# bar coordination on the HF subclass is not a supported use case. See #4065.
+tqdm.set_lock(threading.RLock())
+
+
 class silent_tqdm:
     """Fake tqdm object that does nothing."""
 
@@ -296,21 +303,6 @@ def tqdm_stream_file(path: Path | str) -> Iterator[io.BufferedReader]:
         pbar.close()
 
 
-class _SafeTqdm(old_tqdm):
-    """tqdm subclass that uses a thread lock instead of a multiprocessing lock.
-
-    Used as a fallback when the standard tqdm cannot initialize its multiprocessing
-    lock (e.g. when stderr.fileno() returns -1 in Textual, Jupyter, pytest, etc.).
-    """
-
-    _lock = threading.RLock()
-
-    @classmethod
-    def get_lock(cls):
-        return cls._lock
-
-
-
 def _create_progress_bar(*, cls: type[old_tqdm], log_level: int, name: str | None = None, **kwargs) -> old_tqdm:
     """Create a progress bar.
 
@@ -325,27 +317,12 @@ def _create_progress_bar(*, cls: type[old_tqdm], log_level: int, name: str | Non
     """
     # issubclass() crashes on non-class callables (e.g. functools.partial), guard with isinstance.
     if not (isinstance(cls, type) and issubclass(cls, tqdm)):
-        try:
-            return cls(**kwargs)
-        except (OSError, ValueError):
-            # Caller opted into custom progress; a visible fallback bar would
-            # corrupt their output (e.g. TUIs), so disable it.
-            return _SafeTqdm(disable=True, **kwargs)
+        return cls(**kwargs)  # type: ignore[return-value]
 
     # HF subclass: keep the historical log-level / TTY behavior. Group-based
     # disabling is already handled in `tqdm.__init__`.
     disable = is_tqdm_disabled(log_level)
-    try:
-        return cls(disable=disable, name=name, **kwargs)
-    except (OSError, ValueError):
-        warnings.warn(
-            "Progress bar could not be initialized in this environment. "
-            "Download will continue without progress reporting. "
-            "To suppress this warning, call `disable_progress_bars()` or set HF_HUB_DISABLE_PROGRESS_BARS=1.",
-            stacklevel=2,
-        )
-        # disable=None would attempt TTY auto-detect on the broken stderr.
-        return _SafeTqdm(disable=True, **kwargs)
+    return cls(disable=disable, name=name, **kwargs)  # type: ignore[return-value]
 
 
 def _get_progress_bar_context(

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -241,11 +241,8 @@ class CachedDownloadTests(unittest.TestCase):
             finally:
                 os.umask(previous_umask)
 
-    # tqdm's failed construction leaves an object without `disable` set; its destructor raises AttributeError on
-    # garbage collection. Python silently ignores exceptions in destructors, so this is only visible in pytest.
-    @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
     def test_hf_hub_download_survives_bad_fileno(self):
-        """Download must not crash when stderr.fileno() returns -1."""
+        """Download must not crash when stderr.fileno() returns -1 (e.g. Textual TUIs)."""
 
         class FakeStderr:
             def write(self, s):
@@ -261,14 +258,12 @@ class CachedDownloadTests(unittest.TestCase):
                 return -1
 
         with SoftTemporaryDirectory() as tmpdir:
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore", UserWarning)
-                with patch("sys.stderr", FakeStderr()):
-                    filepath = hf_hub_download(
-                        DUMMY_MODEL_ID,
-                        filename=constants.CONFIG_NAME,
-                        cache_dir=tmpdir,
-                    )
+            with patch("sys.stderr", FakeStderr()):
+                filepath = hf_hub_download(
+                    DUMMY_MODEL_ID,
+                    filename=constants.CONFIG_NAME,
+                    cache_dir=tmpdir,
+                )
             self.assertTrue(os.path.exists(filepath))
 
     def test_download_from_a_renamed_repo_with_hf_hub_download(self):

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -241,6 +241,36 @@ class CachedDownloadTests(unittest.TestCase):
             finally:
                 os.umask(previous_umask)
 
+    # tqdm's failed construction leaves an object without `disable` set; its destructor raises AttributeError on
+    # garbage collection. Python silently ignores exceptions in destructors, so this is only visible in pytest.
+    @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
+    def test_hf_hub_download_survives_bad_fileno(self):
+        """Download must not crash when stderr.fileno() returns -1."""
+
+        class FakeStderr:
+            def write(self, s):
+                pass
+
+            def flush(self):
+                pass
+
+            def isatty(self):
+                return True
+
+            def fileno(self):
+                return -1
+
+        with SoftTemporaryDirectory() as tmpdir:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", UserWarning)
+                with patch("sys.stderr", FakeStderr()):
+                    filepath = hf_hub_download(
+                        DUMMY_MODEL_ID,
+                        filename=constants.CONFIG_NAME,
+                        cache_dir=tmpdir,
+                    )
+            self.assertTrue(os.path.exists(filepath))
+
     def test_download_from_a_renamed_repo_with_hf_hub_download(self):
         """Checks `hf_hub_download` works also on a renamed repo.
 

--- a/tests/test_utils_tqdm.py
+++ b/tests/test_utils_tqdm.py
@@ -3,7 +3,6 @@ import logging
 import sys
 import time
 import unittest
-import warnings
 from pathlib import Path
 from unittest.mock import patch
 
@@ -298,42 +297,3 @@ class TestCreateProgressBarCustomClass:
         )
         with bar as pbar:
             pbar.update(10)
-
-    # Failed tqdm construction leaves an object without `disable` set; its
-    # destructor raises AttributeError on GC. Python silently ignores it, but
-    # pytest surfaces it as an unraisable warning — same pattern as
-    # test_hf_hub_download_survives_bad_fileno.
-    @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
-    def test_custom_tqdm_class_crash_fallback_is_disabled(self):
-        """Fallback bar must be disabled when custom tqdm_class crashes."""
-
-        class ExplodingTqdm(vanilla_tqdm):
-            def __init__(self, *args, **kwargs):
-                raise ValueError("simulated multiprocessing lock failure")
-
-        bar = _get_progress_bar_context(
-            desc="test",
-            log_level=logging.INFO,
-            total=10,
-            tqdm_class=ExplodingTqdm,
-            name="huggingface_hub.test",
-        )
-        with bar as pbar:
-            assert pbar.disable is True
-            pbar.update(5)
-            pbar.update(5)
-
-    @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
-    def test_hf_tqdm_class_crash_fallback_is_disabled(self):
-        """Fallback must use disable=True, not disable=None (TTY auto-detect)."""
-        from huggingface_hub.utils.tqdm import _create_progress_bar
-        from huggingface_hub.utils.tqdm import tqdm as hf_tqdm
-
-        class ExplodingHfTqdm(hf_tqdm):
-            def __init__(self, *args, **kwargs):
-                raise ValueError("simulated multiprocessing lock failure")
-
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", UserWarning)
-            pbar = _create_progress_bar(cls=ExplodingHfTqdm, log_level=logging.INFO, total=10, desc="test")
-        assert pbar.disable is True

--- a/tests/test_utils_tqdm.py
+++ b/tests/test_utils_tqdm.py
@@ -3,6 +3,7 @@ import logging
 import sys
 import time
 import unittest
+import warnings
 from pathlib import Path
 from unittest.mock import patch
 
@@ -297,3 +298,42 @@ class TestCreateProgressBarCustomClass:
         )
         with bar as pbar:
             pbar.update(10)
+
+    # Failed tqdm construction leaves an object without `disable` set; its
+    # destructor raises AttributeError on GC. Python silently ignores it, but
+    # pytest surfaces it as an unraisable warning — same pattern as
+    # test_hf_hub_download_survives_bad_fileno.
+    @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
+    def test_custom_tqdm_class_crash_fallback_is_disabled(self):
+        """Fallback bar must be disabled when custom tqdm_class crashes."""
+
+        class ExplodingTqdm(vanilla_tqdm):
+            def __init__(self, *args, **kwargs):
+                raise ValueError("simulated multiprocessing lock failure")
+
+        bar = _get_progress_bar_context(
+            desc="test",
+            log_level=logging.INFO,
+            total=10,
+            tqdm_class=ExplodingTqdm,
+            name="huggingface_hub.test",
+        )
+        with bar as pbar:
+            assert pbar.disable is True
+            pbar.update(5)
+            pbar.update(5)
+
+    @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
+    def test_hf_tqdm_class_crash_fallback_is_disabled(self):
+        """Fallback must use disable=True, not disable=None (TTY auto-detect)."""
+        from huggingface_hub.utils.tqdm import _create_progress_bar
+        from huggingface_hub.utils.tqdm import tqdm as hf_tqdm
+
+        class ExplodingHfTqdm(hf_tqdm):
+            def __init__(self, *args, **kwargs):
+                raise ValueError("simulated multiprocessing lock failure")
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            pbar = _create_progress_bar(cls=ExplodingHfTqdm, log_level=logging.INFO, total=10, desc="test")
+        assert pbar.disable is True


### PR DESCRIPTION
## Problem

`hf_hub_download` crashes with `ValueError: bad value(s) in fds_to_keep` when `sys.stderr.fileno()` returns `-1`. The crash happens during tqdm's progress bar setup, before the download itself runs.

In practice this hits Textual TUI apps (Textual's `app.py` returns `-1` from `fileno()`) and any custom stderr wrapper that does the same. CPython's `multiprocessing/resource_tracker` silently swallows exceptions from `fileno()`, so streams like `io.StringIO`, Jupyter's `OutStream`, and pytest's `CaptureIO` — which all *raise* on `fileno()` — are not affected. Two more preconditions are needed for the crash: the multiprocessing start method must be `spawn` or `forkserver`, and the resource tracker must not have been started already.

## Root cause

The first time tqdm's default lock is touched, it lazily constructs `TqdmDefaultWriteLock`, which calls `cls.create_mp_lock()`. That spawns the multiprocessing resource tracker via `fork_exec`, which rejects `stderr.fileno() == -1`.

## Why this fix

Setting a thread-only `RLock` on the HF tqdm subclass at module import short-circuits the lazy init: `tqdm.get_lock()` finds `_lock` already set and skips the `create_mp_lock` path entirely. The patch is one line plus a comment.

The trade-off is no inter-process tqdm bar coordination on the HF subclass — multiple separate Python processes printing tqdm bars to the same TTY may visually interleave. Downloads themselves are unaffected, and `huggingface_hub` parallelizes via threads inside one process (not subprocesses), so this is not a scenario the library targets.

## Crash demo

![Crash demo](https://vhs.charm.sh/vhs-3YHnHEbAA6QyKmDgjXzP9b.gif)

Fixes #4066

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global progress-bar locking behavior by overriding `tqdm`'s default multiprocessing lock at import time, which could affect multi-process progress bar coordination. Download logic is unchanged, and risk is largely limited to progress display behavior.
> 
> **Overview**
> Prevents `hf_hub_download` from crashing when `sys.stderr.fileno()` returns `-1` (e.g. Textual TUIs) by setting a thread-only `RLock` via `tqdm.set_lock(...)`, avoiding tqdm’s lazy multiprocessing lock/resource-tracker initialization.
> 
> Adds a regression test that patches `sys.stderr` with a bad `fileno()` implementation and verifies the download completes successfully.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16d5a58a9d023441101fbefb616d850c143037ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->