### PR TITLE
Fix local from_pretrained when CONFIG_NAME contains subdirectories

### DIFF
--- a/src/huggingface_hub/hub_mixin.py
+++ b/src/huggingface_hub/hub_mixin.py
@@ -499,10 +499,15 @@ class ModelHubMixin:
         model_id = str(pretrained_model_name_or_path)
         config_file: str | None = None
         if os.path.isdir(model_id):
-            if constants.CONFIG_NAME in os.listdir(model_id):
-                config_file = os.path.join(model_id, constants.CONFIG_NAME)
+            # Use a real path check: CONFIG_NAME may contain subdirectories (e.g. `codecs/image/config.json`).
+            # `os.listdir(model_id)` only returns the top level, so nested paths were never found locally.
+            local_config_path = os.path.join(model_id, constants.CONFIG_NAME)
+            if os.path.isfile(local_config_path):
+                config_file = local_config_path
             else:
-                logger.warning(f"{constants.CONFIG_NAME} not found in {Path(model_id).resolve()}")
+                logger.warning(
+                    f"{constants.CONFIG_NAME} not found under local directory {Path(model_id).resolve()}"
+                )
         else:
             try:
                 config_file = hf_hub_download(

--- a/tests/test_hub_mixin.py
+++ b/tests/test_hub_mixin.py
@@ -133,6 +133,30 @@ class DummyModelThatIsAlsoADataclass(ModelHubMixin):
         return cls(**model_kwargs)
 
 
+class DummyModelNestedConfigFile(ModelHubMixin):
+    """Model whose config.json lives in a subdirectory when loading from a local folder."""
+
+    def __init__(self, answer: int):
+        self.answer = answer
+
+    def _save_pretrained(self, save_directory: Path) -> None:
+        return
+
+    @classmethod
+    def _from_pretrained(
+        cls,
+        *,
+        model_id: str,
+        revision: Optional[str],
+        cache_dir: Optional[Union[str, Path]],
+        force_download: bool,
+        local_files_only: bool,
+        token: Optional[Union[str, bool]],
+        **model_kwargs,
+    ):
+        return cls(**model_kwargs)
+
+
 class CustomType:
     def __init__(self, value: str):
         self.value = value
@@ -434,6 +458,28 @@ class HubMixinTest(unittest.TestCase):
         assert model.foo == 42
         assert model.bar == "baz"
         assert not hasattr(model, "other")
+
+    def test_from_pretrained_nested_config_path_in_local_dir(self) -> None:
+        """`CONFIG_NAME` may include subdirectories; local loading must still find the file.
+
+        Regression: previously only `CONFIG_NAME in os.listdir(root)` was used, which fails for paths like
+        `nested/sub/config.json`. Remote `hf_hub_download` already supported nested filenames.
+        """
+        with SoftTemporaryDirectory() as tmp:
+            root = Path(tmp)
+            cfg_file = root / "nested" / "sub" / "config.json"
+            cfg_file.parent.mkdir(parents=True)
+            cfg_file.write_text(json.dumps({"answer": 42}))
+
+            from huggingface_hub.hub_mixin import constants as hub_mixin_constants
+
+            previous = hub_mixin_constants.CONFIG_NAME
+            try:
+                hub_mixin_constants.CONFIG_NAME = "nested/sub/config.json"
+                model = DummyModelNestedConfigFile.from_pretrained(str(root))
+                self.assertEqual(model.answer, 42)
+            finally:
+                hub_mixin_constants.CONFIG_NAME = previous
 
     def test_from_cls_with_custom_type(self):
         model = DummyModelWithCustomTypes(


### PR DESCRIPTION
ModelHubMixin.from_pretrained used CONFIG_NAME in os.listdir(model_id) for local directories. listdir only returns top-level names, so nested paths such as codecs/XXXX/config.json are never detected; remote hf_hub_download already supported such filenames.  This is a correction to make local behave like remote.

here's a tag to help get to the heart of the issue:   local from_pretrained + CONFIG_NAME containing /

Use os.path.isfile(os.path.join(model_id, CONFIG_NAME)) instead.

Adds regression test with temporary nested config path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk bugfix limited to local config discovery in `ModelHubMixin.from_pretrained`, plus a regression test. Main risk is unintended behavior change for local directory loads if a file exists at the joined path.
> 
> **Overview**
> Fixes `ModelHubMixin.from_pretrained` local loading to correctly detect configs when `constants.CONFIG_NAME` includes subdirectories by switching from a top-level `os.listdir` check to `os.path.isfile(os.path.join(dir, CONFIG_NAME))`, and updates the warning message accordingly.
> 
> Adds a regression test (with a small dummy model) that temporarily sets `CONFIG_NAME` to a nested path and verifies `from_pretrained` can load `config.json` from that nested location in a local folder.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6835fbcf136fc2fbd4b1bf0a9afa6b965f312223. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->