### PR TITLE
[Fix] Match Unix `cp -r` nesting semantics in `copy_files`

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -12635,16 +12635,10 @@ class HfApi:
                 destination_is_directory = False
             else:
                 # Check if destination is an existing "directory" (prefix with children)
-                destination_exists_as_directory = (
-                    next(
-                        iter(
-                            self.list_bucket_tree(
-                                destination_bucket_id, prefix=destination_path, recursive=False, token=token
-                            )
-                        ),
-                        None,
+                destination_exists_as_directory = any(
+                    self.list_bucket_tree(
+                        destination_bucket_id, prefix=destination_path, recursive=False, token=token
                     )
-                    is not None
                 )
                 # Treat as directory if it exists as one, or if the user signaled with trailing slash
                 destination_is_directory = destination_exists_as_directory or destination.endswith("/")

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -12621,15 +12621,21 @@ class HfApi:
 
         destination_bucket_id = destination_handle.bucket_id
         destination_path = destination_handle.path
-        if destination_path == "" or destination.endswith("/"):
+        destination_is_directory = False
+        destination_exists_as_directory = False
+
+        if destination_path == "":
+            # Bucket root always exists as a directory
             destination_is_directory = True
+            destination_exists_as_directory = True
         else:
-            # Check if destination path is an existing file or a directory in the bucket
+            # Check if destination matches an existing file
             dest_path_info = list(self.get_bucket_paths_info(destination_bucket_id, [destination_path], token=token))
             if dest_path_info:
                 destination_is_directory = False
             else:
-                destination_is_directory = (
+                # Check if destination is an existing "directory" (prefix with children)
+                destination_exists_as_directory = (
                     next(
                         iter(
                             self.list_bucket_tree(
@@ -12640,6 +12646,8 @@ class HfApi:
                     )
                     is not None
                 )
+                # Treat as directory if it exists as one, or if the user signaled with trailing slash
+                destination_is_directory = destination_exists_as_directory or destination.endswith("/")
 
         all_adds: list[tuple[str, str]] = []
         all_copies: list[_BucketCopyFile] = []
@@ -12665,6 +12673,14 @@ class HfApi:
 
             if rel_path == "":
                 raise ValueError("Cannot copy an empty relative path.")
+
+            # Match Unix `cp -r` behavior: when the destination already exists as a
+            # directory, nest the source folder inside it (e.g. cp -r src dst → dst/src/...).
+            # When the destination does not exist, use rename semantics (cp -r src new → new/...).
+            if destination_exists_as_directory and src_root_path is not None:
+                src_dir_basename = src_root_path.rsplit("/", 1)[-1]
+                rel_path = f"{src_dir_basename}/{rel_path}"
+
             if destination_path == "":
                 return rel_path
             return f"{destination_path.rstrip('/')}/{rel_path}"
@@ -12712,7 +12728,6 @@ class HfApi:
                 )
             else:
                 # Source path is a folder (or prefix) — list and copy all matching files
-                destination_is_directory = True
                 for item in self.list_bucket_tree(
                     source_handle.bucket_id, prefix=source_path or None, recursive=True, token=token
                 ):
@@ -12744,7 +12759,6 @@ class HfApi:
                 _add_repo_file(source_repo_path_info[0], target_path)
             else:
                 # Source path is a folder — list and copy all files recursively
-                destination_is_directory = True
                 for repo_item in self.list_repo_tree(
                     repo_id=source_handle.repo_id,
                     path_in_repo=source_path,

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -12636,9 +12636,7 @@ class HfApi:
             else:
                 # Check if destination is an existing "directory" (prefix with children)
                 destination_exists_as_directory = any(
-                    self.list_bucket_tree(
-                        destination_bucket_id, prefix=destination_path, recursive=False, token=token
-                    )
+                    self.list_bucket_tree(destination_bucket_id, prefix=destination_path, recursive=False, token=token)
                 )
                 # Treat as directory if it exists as one, or if the user signaled with trailing slash
                 destination_is_directory = destination_exists_as_directory or destination.endswith("/")

--- a/tests/test_buckets.py
+++ b/tests/test_buckets.py
@@ -388,7 +388,7 @@ def test_copy_files_folder_to_nonexistent_dest(api: HfApi, bucket_write: str, bu
 
 @requires("hf_xet")
 def test_copy_files_folder_to_existing_folder_dest(api: HfApi, bucket_write: str, bucket_write_2: str):
-    """source=folder, dest is an existing folder => files merged under dest path."""
+    """source=folder, dest is an existing folder => source folder nested under dest (like `cp -r`)."""
     api.batch_bucket_files(bucket_write, add=[(b"a", "folder/a.txt"), (b"b", "folder/sub/b.txt")])
     api.batch_bucket_files(bucket_write_2, add=[(b"existing", "target-folder/existing.txt")])
 
@@ -397,10 +397,11 @@ def test_copy_files_folder_to_existing_folder_dest(api: HfApi, bucket_write: str
         f"hf://buckets/{bucket_write_2}/target-folder",
     )
 
+    # Like `cp -r folder target-folder` when target-folder exists: nests as target-folder/folder/...
     destination_files = {entry.path for entry in api.list_bucket_tree(bucket_write_2)}
     assert "target-folder/existing.txt" in destination_files
-    assert "target-folder/a.txt" in destination_files
-    assert "target-folder/sub/b.txt" in destination_files
+    assert "target-folder/folder/a.txt" in destination_files
+    assert "target-folder/folder/sub/b.txt" in destination_files
 
 
 @requires("hf_xet")
@@ -447,6 +448,57 @@ def test_copy_files_file_to_folder_dest(api: HfApi, bucket_write: str, bucket_wr
     output_path = tmp_path / "source.txt"
     api.download_bucket_files(bucket_write_2, [("folder/source.txt", str(output_path))])
     assert output_path.read_bytes() == b"content"
+
+
+@requires("hf_xet")
+def test_copy_files_folder_to_existing_folder_with_trailing_slash(api: HfApi, bucket_write: str, bucket_write_2: str):
+    """source=folder, dest is existing folder with trailing '/' => source folder nested (like `cp -r`)."""
+    api.batch_bucket_files(bucket_write, add=[(b"a", "logs/a.txt"), (b"b", "logs/sub/b.txt")])
+    api.batch_bucket_files(bucket_write_2, add=[(b"existing", "backup/existing.txt")])
+
+    api.copy_files(
+        f"hf://buckets/{bucket_write}/logs",
+        f"hf://buckets/{bucket_write_2}/backup/",
+    )
+
+    # Like `cp -r logs backup/` when backup/ exists: nests as backup/logs/...
+    destination_files = {entry.path for entry in api.list_bucket_tree(bucket_write_2)}
+    assert "backup/existing.txt" in destination_files
+    assert "backup/logs/a.txt" in destination_files
+    assert "backup/logs/sub/b.txt" in destination_files
+
+
+@requires("hf_xet")
+def test_copy_files_folder_to_nonexistent_dest_with_trailing_slash(api: HfApi, bucket_write: str, bucket_write_2: str):
+    """source=folder, dest doesn't exist but has trailing '/' => rename semantics (no nesting)."""
+    api.batch_bucket_files(bucket_write, add=[(b"a", "logs/a.txt"), (b"b", "logs/sub/b.txt")])
+
+    api.copy_files(
+        f"hf://buckets/{bucket_write}/logs",
+        f"hf://buckets/{bucket_write_2}/new-backup/",
+    )
+
+    # Like `cp -r logs new-backup/` when new-backup/ doesn't exist:
+    # in Unix this errors, but in object storage we create it with rename semantics.
+    destination_files = {entry.path for entry in api.list_bucket_tree(bucket_write_2)}
+    assert "new-backup/a.txt" in destination_files
+    assert "new-backup/sub/b.txt" in destination_files
+
+
+@requires("hf_xet")
+def test_copy_files_folder_to_bucket_root(api: HfApi, bucket_write: str, bucket_write_2: str):
+    """source=folder, dest is bucket root => source folder nested at root (like `cp -r models /`)."""
+    api.batch_bucket_files(bucket_write, add=[(b"a", "models/a.txt"), (b"b", "models/sub/b.txt")])
+
+    api.copy_files(
+        f"hf://buckets/{bucket_write}/models",
+        f"hf://buckets/{bucket_write_2}/",
+    )
+
+    # Bucket root always "exists" as a directory, so nesting applies
+    destination_files = {entry.path for entry in api.list_bucket_tree(bucket_write_2)}
+    assert "models/a.txt" in destination_files
+    assert "models/sub/b.txt" in destination_files
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Why? Let's make `hf buckets cp` as consistent as possible with unix `cp`. It's already almost the case (see table), this PR solves the few remaining issues + adds tests.

---

## Summary

When copying a folder to a destination that already exists as a directory, Unix `cp -r` **nests** the source folder inside it. Our `copy_files` implementation was instead always copying the **contents** directly (merge/rename semantics), which is closer to `rsync src/ dst/` than `cp -r`.

This PR introduces a `destination_exists_as_directory` flag (separate from `destination_is_directory`) so the folder-copy path can distinguish "destination confirmed to exist via API" from "user hinted directory with trailing `/`". Nesting only applies when the destination actually exists as a prefix.

## `cp` vs `hf buckets cp` — full comparison

| Scenario | Unix `cp` result | `hf buckets cp` result | Notes |
|---|---|---|---|
| **File → explicit name** | `dst.txt` | `dst.txt` | |
| `cp f.txt new.txt` | `new.txt` | `new.txt` | |
| **File → existing file** | Overwrites | Overwrites | |
| `cp f.txt existing.txt` | `existing.txt` (overwritten) | `existing.txt` (overwritten) | |
| **File → nonexistent path** | Creates file | Creates file | |
| `cp f.txt newname` | `newname` | `newname` | |
| **File → existing dir (no `/`)** | Copies into dir | Copies into dir | Detected via API lookup |
| `cp f.txt dir` | `dir/f.txt` | `dir/f.txt` | |
| **File → path with trailing `/`** | Copies into dir | Copies into dir | |
| `cp f.txt dir/` | `dir/f.txt` | `dir/f.txt` | |
| **File → bucket root** | Copies into root | Copies into root | |
| `cp f.txt /` | `/f.txt` | `f.txt` (at root) | |
| **Folder → nonexistent dest** | Rename semantics | Rename semantics | |
| `cp -r src newdst` | `newdst/contents...` | `newdst/contents...` | |
| **Folder → existing dir (no `/`)** | **Nests source** | **Nests source** | **Fixed in this PR** (was: merge) |
| `cp -r src dst` | `dst/src/contents...` | `dst/src/contents...` | |
| **Folder → existing dir (trailing `/`)** | **Nests source** | **Nests source** | **Fixed in this PR** (was: merge) |
| `cp -r src dst/` | `dst/src/contents...` | `dst/src/contents...` | |
| **Folder → nonexistent with `/`** | ERROR | Rename semantics | Can't error in object storage — no real dirs |
| `cp -r src newdst/` | error: no such dir | `newdst/contents...` | Reasonable divergence for object storage |
| **Folder → bucket root** | **Nests source** | **Nests source** | **Fixed in this PR** (was: merge) |
| `cp -r src /` | `/src/contents...` | `src/contents...` (at root) | |
| **Trailing `/` on source** | No effect | No effect | Both strip/ignore it for dirs |
| `cp -r src/ dst` | same as `cp -r src dst` | same | |
| **Recursive flag** | Required (`-r`) | Automatic | Not applicable to object storage |

## Test plan

- [x] Updated `test_copy_files_folder_to_existing_folder_dest` — now expects nested paths
- [x] Added `test_copy_files_folder_to_existing_folder_with_trailing_slash` — existing dir + trailing `/`
- [x] Added `test_copy_files_folder_to_nonexistent_dest_with_trailing_slash` — rename semantics preserved
- [x] Added `test_copy_files_folder_to_bucket_root` — nesting at bucket root
- [x] Existing single-file tests unaffected (file→file, file→dir, file→nonexistent all unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes destination path resolution for folder copies, which can alter where files land for existing bucket prefixes (including root) and may break callers relying on the previous merge behavior.
> 
> **Overview**
> `HfApi.copy_files` now distinguishes between *destination hinted as a directory* (trailing `/`) and *destination confirmed to exist as a directory prefix* via API checks. When copying a folder into an existing destination directory (including bucket root), it now **nests the source folder** under the destination to match Unix `cp -r` semantics instead of merging contents directly.
> 
> Tests were updated/added to cover nesting for existing destinations (with and without trailing `/`), preserved rename semantics for non-existent destinations, and the bucket-root folder copy case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4f041322a3cf3fdf92688f9f765ec11eac862a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->