### PR TITLE
Ignore .gitattributes when copying repo files to a bucket

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -12579,6 +12579,9 @@ class HfApi:
 
         Currently, only bucket destinations are supported. Copying to a repository is not supported.
 
+        When copying from a repository, `.gitattributes` files are automatically excluded since they are
+        git-specific metadata and not relevant in a bucket context.
+
         Args:
             source (`str`):
                 Source location as an `hf://` handle. Can be a bucket path (e.g. `"hf://buckets/my-bucket/path/to/file"`)
@@ -12739,7 +12742,9 @@ class HfApi:
                 )
 
             if len(source_repo_path_info) == 1 and isinstance(source_repo_path_info[0], RepoFile):
-                # Source path matched a single file
+                # Source path matched a single file — skip .gitattributes (git-specific metadata)
+                if source_repo_path_info[0].path.rsplit("/", 1)[-1] == ".gitattributes":
+                    return
                 target_path = _resolve_target_path(source_repo_path_info[0].path, None, is_single_file=True)
                 _add_repo_file(source_repo_path_info[0], target_path)
             else:
@@ -12754,6 +12759,9 @@ class HfApi:
                     token=token,
                 ):
                     if not isinstance(repo_item, RepoFile):
+                        continue
+                    # Skip .gitattributes files (git-specific metadata, not relevant in a bucket)
+                    if repo_item.path.rsplit("/", 1)[-1] == ".gitattributes":
                         continue
                     target_path = _resolve_target_path(repo_item.path, source_path or None, is_single_file=False)
                     _add_repo_file(repo_item, target_path)


### PR DESCRIPTION

**Context:** https://huggingface.slack.com/archives/C0A4RUVRLSC/p1775725585026259 (internal private thread)
`.gitattributes` files are specific to git-based repos. Let's not copy them to buckets.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small behavioral change limited to `copy_files` when the source is a repo, with no auth/data model changes. Main risk is unexpected omission if a user intentionally wanted `.gitattributes` copied to a bucket.
> 
> **Overview**
> Updates `HfApi.copy_files` to **exclude `.gitattributes`** when the source is a repository, both for single-file copies (early return) and recursive folder copies (filter during tree walk).
> 
> Documents this repo-to-bucket filtering in the `copy_files` docstring; bucket-to-bucket copy behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee2f122a61fb3bb508090134c62ba3db0b40af47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->