### PR TITLE
[CLI] Add `out.confirm()` and migrate all confirmation prompts

### DIFF
--- a/src/huggingface_hub/cli/_output.py
+++ b/src/huggingface_hub/cli/_output.py
@@ -22,6 +22,9 @@ from collections.abc import Sequence
 from enum import Enum
 from typing import Any
 
+import typer
+
+from huggingface_hub.errors import CLIError
 from huggingface_hub.utils import ANSI, is_agent, tabulate
 
 
@@ -145,6 +148,16 @@ class Output:
                 values = list(data.values())
                 if values:
                     print(values[0])
+
+    def confirm(self, message: str, *, yes: bool = False) -> None:
+        """
+        Ask for confirmation. Raises CLIError in non-human modes.
+        """
+        if yes:
+            return
+        if self.mode != OutputFormatWithAuto.human:
+            raise CLIError(f"{message} Use --yes to skip confirmation.")
+        typer.confirm(message, default=False, abort=True)
 
     def warning(self, message: str) -> None:
         """Print a non-fatal warning to stderr (all modes)."""

--- a/src/huggingface_hub/cli/_output.py
+++ b/src/huggingface_hub/cli/_output.py
@@ -24,7 +24,7 @@ from typing import Any
 
 import typer
 
-from huggingface_hub.errors import CLIError
+from huggingface_hub.errors import ConfirmationError
 from huggingface_hub.utils import ANSI, is_agent, tabulate
 
 
@@ -149,15 +149,15 @@ class Output:
                 if values:
                     print(values[0])
 
-    def confirm(self, message: str, *, yes: bool = False) -> None:
+    def confirm(self, message: str, *, default: bool = False, yes: bool = False) -> None:
         """
-        Ask for confirmation. Raises CLIError in non-human modes.
+        Ask for confirmation. Raises `ConfirmationError` in non-human modes.
         """
         if yes:
             return
         if self.mode != OutputFormatWithAuto.human:
-            raise CLIError(f"{message} Use --yes to skip confirmation.")
-        typer.confirm(message, default=False, abort=True)
+            raise ConfirmationError(f"{message} Use --yes to skip confirmation.")
+        typer.confirm(message, default=default, abort=True)
 
     def warning(self, message: str) -> None:
         """Print a non-fatal warning to stderr (all modes)."""

--- a/src/huggingface_hub/cli/buckets.py
+++ b/src/huggingface_hub/cli/buckets.py
@@ -49,6 +49,7 @@ from ._cli_utils import (
     print_list_output,
     typer_factory,
 )
+from ._output import out
 
 
 logger = logging.get_logger(__name__)
@@ -558,11 +559,7 @@ def delete(
             f" Must be in format namespace/bucket_name or {BUCKET_PREFIX}namespace/bucket_name."
         )
 
-    if not yes:
-        confirm = typer.confirm(f"Are you sure you want to delete bucket '{bucket_id}'?")
-        if not confirm:
-            print("Aborted.")
-            raise typer.Abort()
+    out.confirm(f"Are you sure you want to delete bucket '{bucket_id}'?", yes=yes)
 
     api = get_hf_api(token=token)
     api.delete_bucket(bucket_id, missing_ok=missing_ok)
@@ -687,10 +684,7 @@ def remove(
             if not quiet:
                 for path in file_paths:
                     print(f"  {path}")
-            confirm = typer.confirm(f"Remove {count_label} from '{bucket_id}'?")
-            if not confirm:
-                print("Aborted.")
-                raise typer.Abort()
+            out.confirm(f"Remove {count_label} from '{bucket_id}'?", yes=False)
 
         if dry_run:
             for path in file_paths:
@@ -717,11 +711,7 @@ def remove(
             print("(dry run) 1 file would be removed.")
             return
 
-        if not yes:
-            confirm = typer.confirm(f"Remove '{file_path}' from '{bucket_id}'?")
-            if not confirm:
-                print("Aborted.")
-                raise typer.Abort()
+        out.confirm(f"Remove '{file_path}' from '{bucket_id}'?", yes=yes)
 
         api.batch_bucket_files(bucket_id, delete=[file_path])
         if quiet:

--- a/src/huggingface_hub/cli/cache.py
+++ b/src/huggingface_hub/cli/cache.py
@@ -555,9 +555,7 @@ def rm(
         )
         return
 
-    if not yes and not typer.confirm("Proceed with deletion?", default=False):
-        out.text("Deletion cancelled.")
-        return
+    out.confirm("Proceed with deletion?", yes=yes)
 
     strategy.execute()
     counts = summarize_deletions(resolution.selected)
@@ -635,9 +633,7 @@ def prune(
         )
         return
 
-    if not yes and not typer.confirm("Proceed?"):
-        out.text("Pruning cancelled.")
-        return
+    out.confirm("Proceed?", yes=yes)
 
     strategy.execute()
     out.result(

--- a/src/huggingface_hub/cli/discussions.py
+++ b/src/huggingface_hub/cli/discussions.py
@@ -309,11 +309,7 @@ def discussion_close(
     token: TokenOpt = None,
 ) -> None:
     """Close a discussion or pull request."""
-    if not yes:
-        confirm = typer.confirm(f"Close #{num} on '{repo_id}'?")
-        if not confirm:
-            out.text("Aborted.")
-            raise typer.Exit()
+    out.confirm(f"Close #{num} on '{repo_id}'?", yes=yes)
     api = get_hf_api(token=token)
     api.change_discussion_status(
         repo_id=repo_id,
@@ -355,11 +351,7 @@ def discussion_reopen(
     token: TokenOpt = None,
 ) -> None:
     """Reopen a closed discussion or pull request."""
-    if not yes:
-        confirm = typer.confirm(f"Reopen #{num} on '{repo_id}'?")
-        if not confirm:
-            out.text("Aborted.")
-            raise typer.Exit()
+    out.confirm(f"Reopen #{num} on '{repo_id}'?", yes=yes)
     api = get_hf_api(token=token)
     api.change_discussion_status(
         repo_id=repo_id,
@@ -431,11 +423,7 @@ def discussion_merge(
     token: TokenOpt = None,
 ) -> None:
     """Merge a pull request."""
-    if not yes:
-        confirm = typer.confirm(f"Merge #{num} on '{repo_id}'?")
-        if not confirm:
-            out.text("Aborted.")
-            raise typer.Exit()
+    out.confirm(f"Merge #{num} on '{repo_id}'?", yes=yes)
     api = get_hf_api(token=token)
     api.merge_pull_request(
         repo_id=repo_id,

--- a/src/huggingface_hub/cli/extensions.py
+++ b/src/huggingface_hub/cli/extensions.py
@@ -27,7 +27,7 @@ from typing import Annotated, Literal
 
 import typer
 
-from huggingface_hub.errors import CLIError, CLIExtensionInstallError
+from huggingface_hub.errors import CLIError, CLIExtensionInstallError, ConfirmationError
 from huggingface_hub.utils import StatusLine, get_session, logging
 
 from ._cli_utils import FormatWithAutoOpt, typer_factory
@@ -303,7 +303,7 @@ def _auto_install_official_extension(short_name: str) -> Path | None:
         return None
     try:
         out.confirm(f"'{short_name}' is an official Hugging Face extension ({owner}/{repo_name}). Install it?")
-    except Exception:
+    except ConfirmationError:
         return None
     try:
         manifest = _install_extension_from_github(

--- a/src/huggingface_hub/cli/extensions.py
+++ b/src/huggingface_hub/cli/extensions.py
@@ -301,7 +301,9 @@ def _auto_install_official_extension(short_name: str) -> Path | None:
         branch = response.json()["default_branch"]
     except Exception:
         return None
-    if not typer.confirm(f"'{short_name}' is an official Hugging Face extension ({owner}/{repo_name}). Install it?"):
+    try:
+        out.confirm(f"'{short_name}' is an official Hugging Face extension ({owner}/{repo_name}). Install it?")
+    except Exception:
         return None
     try:
         manifest = _install_extension_from_github(

--- a/src/huggingface_hub/cli/inference_endpoints.py
+++ b/src/huggingface_hub/cli/inference_endpoints.py
@@ -371,11 +371,7 @@ def delete(
     token: TokenOpt = None,
 ) -> None:
     """Delete an Inference Endpoint permanently."""
-    if not yes:
-        confirmation = typer.prompt(f"Delete endpoint '{name}'? Type the name to confirm.")
-        if confirmation != name:
-            out.text("Aborted.")
-            raise typer.Exit(code=2)
+    out.confirm(f"Delete endpoint '{name}'?", yes=yes)
 
     api = get_hf_api(token=token)
     try:

--- a/src/huggingface_hub/cli/repos.py
+++ b/src/huggingface_hub/cli/repos.py
@@ -52,6 +52,7 @@ from ._cli_utils import (
     parse_volumes,
     typer_factory,
 )
+from ._output import out
 
 
 repos_cli = typer_factory(help="Manage repos on the Hub.")
@@ -509,11 +510,7 @@ def tag_delete(
     """Delete a tag for a repo."""
     repo_type_str = repo_type.value
     print(f"You are about to delete tag {ANSI.bold(tag)} on {repo_type_str} {ANSI.bold(repo_id)}")
-    if not yes:
-        choice = input("Proceed? [Y/n] ").lower()
-        if choice not in ("", "y", "yes"):
-            print("Abort")
-            raise typer.Exit()
+    out.confirm("Proceed?", yes=yes)
     api = get_hf_api(token=token)
     try:
         api.delete_tag(repo_id=repo_id, tag=tag, repo_type=repo_type_str)

--- a/src/huggingface_hub/cli/webhooks.py
+++ b/src/huggingface_hub/cli/webhooks.py
@@ -294,11 +294,7 @@ def webhooks_delete(
     token: TokenOpt = None,
 ) -> None:
     """Delete a webhook permanently."""
-    if not yes:
-        confirm = typer.confirm(f"Are you sure you want to delete webhook '{webhook_id}'?")
-        if not confirm:
-            out.text("Aborted.")
-            raise typer.Abort()
+    out.confirm(f"Are you sure you want to delete webhook '{webhook_id}'?", yes=yes)
     api = get_hf_api(token=token)
     api.delete_webhook(webhook_id)
     out.result("Webhook deleted", id=webhook_id)

--- a/src/huggingface_hub/errors.py
+++ b/src/huggingface_hub/errors.py
@@ -469,5 +469,9 @@ class CLIError(Exception):
     """CLI error with clean message (no traceback by default)."""
 
 
+class ConfirmationError(CLIError):
+    """Raised when a confirmation prompt is declined (non-interactive mode)."""
+
+
 class CLIExtensionInstallError(CLIError):
     """Error during CLI extension installation."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ from _pytest.fixtures import SubRequest
 import huggingface_hub
 from huggingface_hub import constants
 from huggingface_hub.utils import SoftTemporaryDirectory, logging
+from huggingface_hub.utils._detect_agent import _STANDARD_AGENT_VARS, _TOOL_AGENTS
 
 from .testing_utils import set_write_permission_and_retry
 
@@ -23,6 +24,20 @@ def patch_constants(mocker):
         mocker.patch.object(constants, "HF_TOKEN_PATH", os.path.join(cache_dir, "token"))
         mocker.patch.object(constants, "HF_STORED_TOKENS_PATH", os.path.join(cache_dir, "stored_tokens"))
         yield
+
+
+@pytest.fixture(autouse=True)
+def _clean_cli_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Deterministic baseline: no agent env vars, no ANSI colors, reset output mode."""
+    all_vars = list(_STANDARD_AGENT_VARS)
+    for env_vars, _ in _TOOL_AGENTS:
+        all_vars.extend(env_vars)
+    for var in all_vars:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("NO_COLOR", "1")
+    from huggingface_hub.cli._output import out
+
+    out.set_mode()
 
 
 logger = logging.get_logger(__name__)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3285,7 +3285,6 @@ class TestWebhooksCommand:
         with patch("huggingface_hub.cli.webhooks.get_hf_api") as api_cls:
             result = runner.invoke(app, ["webhooks", "delete", "wh-abc123"], input="n\n")
         assert result.exit_code != 0
-        assert "Aborted" in result.output
         api_cls.return_value.delete_webhook.assert_not_called()
 
 

--- a/tests/test_cli_discussions.py
+++ b/tests/test_cli_discussions.py
@@ -252,9 +252,10 @@ def test_close_with_comment(api: HfApi, repo_for_write: str):
 
 def test_close_requires_confirmation(api: HfApi, repo_for_write: str):
     discussion = api.create_discussion(repo_id=repo_for_write, title="Close confirm test")
-    result = cli(f"hf discussions close {repo_for_write} {discussion.num}", input="n\n")
-    assert result.exit_code == 0
-    assert "Aborted" in result.output
+
+    result = cli(f"hf discussions close {repo_for_write} {discussion.num} --format agent")
+    assert result.exit_code != 0
+    assert "Use --yes" in str(result.exception)
 
     details = api.get_discussion_details(repo_id=repo_for_write, discussion_num=discussion.num)
     assert details.status == "open"
@@ -315,9 +316,10 @@ def test_merge_requires_confirmation(api: HfApi, repo_for_write: str):
         commit_message="Merge confirm test PR",
     )
     pr_num = int(commit.pr_url.split("/")[-1])
-    result = cli(f"hf discussions merge {repo_for_write} {pr_num}", input="n\n")
-    assert result.exit_code == 0
-    assert "Aborted" in result.output
+
+    result = cli(f"hf discussions merge {repo_for_write} {pr_num} --format agent")
+    assert result.exit_code != 0
+    assert "Use --yes" in str(result.exception)
 
 
 # =============================================================================

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -17,7 +17,7 @@ import pytest
 
 from huggingface_hub.cli._cli_utils import OutputFormatWithAuto
 from huggingface_hub.cli._output import Output, _format_table_cell_human, _to_header
-from huggingface_hub.errors import CLIError
+from huggingface_hub.errors import ConfirmationError
 
 
 HUMAN = OutputFormatWithAuto.human
@@ -314,7 +314,7 @@ def test_confirm_yes_skips(mode):
 def test_confirm_non_human_raises(mode):
     o = Output()
     o.set_mode(mode)
-    with pytest.raises(CLIError, match="Use --yes to skip confirmation"):
+    with pytest.raises(ConfirmationError, match="Use --yes to skip confirmation"):
         o.confirm("Delete everything?")
 
 

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -17,7 +17,7 @@ import pytest
 
 from huggingface_hub.cli._cli_utils import OutputFormatWithAuto
 from huggingface_hub.cli._output import Output, _format_table_cell_human, _to_header
-from huggingface_hub.utils._detect_agent import _STANDARD_AGENT_VARS, _TOOL_AGENTS
+from huggingface_hub.errors import CLIError
 
 
 HUMAN = OutputFormatWithAuto.human
@@ -33,17 +33,6 @@ def _normalize(text: str) -> list[str]:
     lines = text.split("\n")
     baseline = len(lines[-1]) - len(lines[-1].lstrip()) if lines else 0
     return [line[baseline:].rstrip() for line in lines if line.strip()]
-
-
-@pytest.fixture(autouse=True)
-def _clean_env(monkeypatch):
-    """Deterministic baseline: no agent env vars, no ANSI colors."""
-    all_vars = list(_STANDARD_AGENT_VARS)
-    for env_vars, _ in _TOOL_AGENTS:
-        all_vars.extend(env_vars)
-    for var in all_vars:
-        monkeypatch.delenv(var, raising=False)
-    monkeypatch.setenv("NO_COLOR", "1")
 
 
 @pytest.fixture
@@ -307,6 +296,26 @@ def test_hint(check):
         Hint: Set HF_DEBUG=1 for full traceback.
         """,
     )
+
+
+# =============================================================================
+# out.confirm()
+# =============================================================================
+
+
+@pytest.mark.parametrize("mode", [HUMAN, AGENT, JSON, QUIET])
+def test_confirm_yes_skips(mode):
+    o = Output()
+    o.set_mode(mode)
+    o.confirm("Delete everything?", yes=True)  # should not raise
+
+
+@pytest.mark.parametrize("mode", [AGENT, JSON, QUIET])
+def test_confirm_non_human_raises(mode):
+    o = Output()
+    o.set_mode(mode)
+    with pytest.raises(CLIError, match="Use --yes to skip confirmation"):
+        o.confirm("Delete everything?")
 
 
 # =============================================================================


### PR DESCRIPTION
Part of #3979

this PR adds `out.confirm(message, yes=False)` to the `out` singleton and migrates all `typer.confirm` / `typer.prompt` / `input()` confirmation patterns across the CLI.

**Behavior:**
- `yes=True` -> no-op (proceed silently)
- Human mode -> prompts via `typer.confirm`
- Agent/JSON/quiet -> raises `CLIError("... Use --yes to skip confirmation.")`

No breaking changes introduced.


### Commands migrated

| Command | Old pattern |
|---|---|
| `hf cache rm` | `typer.confirm` |
| `hf cache prune` | `typer.confirm` |
| `hf webhooks delete` | `typer.confirm` |
| `hf endpoints delete` | `typer.prompt` (name typing) |
| `hf discussions close/reopen/merge` | `typer.confirm` |
| `hf buckets delete` | `typer.confirm` |
| `hf buckets rm` (2 paths) | `typer.confirm` |
| `hf repos tag-delete` | `input("Proceed?")` |
| `hf extensions` (auto-install) | `typer.confirm` |
