### PR TITLE
Reject path-traversal filenames on Linux/macOS in local downloads/uploads

### DIFF
--- a/src/huggingface_hub/_local_folder.py
+++ b/src/huggingface_hub/_local_folder.py
@@ -196,6 +196,29 @@ class LocalUploadFileMetadata:
             self.timestamp = new_timestamp
 
 
+def _sanitize_filename(filename: str) -> str:
+    """Convert a Hub-style ``/``-separated filename into an OS path and reject traversal.
+
+    On Windows, ``..\\`` segments are caught and rejected. On Linux/macOS,
+    ``os.path.join`` does **not** neutralise ``..`` components, so a malicious
+    repo filename like ``../../etc/passwd`` would resolve outside the
+    local directory. We must reject these explicitly.
+    """
+    sanitized = os.path.join(*filename.split("/"))
+    if os.name == "nt":
+        if sanitized.startswith("..\\") or "\\..\\" in sanitized:
+            raise ValueError(
+                f"Invalid filename: cannot handle filename '{sanitized}' on Windows. Please ask the repository"
+                " owner to rename this file."
+            )
+    else:
+        if sanitized.startswith("../") or "/../" in sanitized or sanitized == "..":
+            raise ValueError(
+                f"Invalid filename: path '{filename}' attempts to traverse outside the local directory."
+            )
+    return sanitized
+
+
 def get_local_download_paths(local_dir: Path, filename: str) -> LocalDownloadFilePaths:
     """Compute paths to the files related to a download process.
 
@@ -211,14 +234,8 @@ def get_local_download_paths(local_dir: Path, filename: str) -> LocalDownloadFil
         [`LocalDownloadFilePaths`]: the paths to the files (file_path, lock_path, metadata_path, incomplete_path).
     """
     # filename is the path in the Hub repository (separated by '/')
-    # make sure to have a cross-platform transcription
-    sanitized_filename = os.path.join(*filename.split("/"))
-    if os.name == "nt":
-        if sanitized_filename.startswith("..\\") or "\\..\\" in sanitized_filename:
-            raise ValueError(
-                f"Invalid filename: cannot handle filename '{sanitized_filename}' on Windows. Please ask the repository"
-                " owner to rename this file."
-            )
+    # make sure to have a cross-platform transcription and reject traversal
+    sanitized_filename = _sanitize_filename(filename)
     file_path = local_dir / sanitized_filename
     metadata_path = _huggingface_dir(local_dir) / "download" / f"{sanitized_filename}.metadata"
     lock_path = metadata_path.with_suffix(".lock")
@@ -251,14 +268,8 @@ def get_local_upload_paths(local_dir: Path, filename: str) -> LocalUploadFilePat
         [`LocalUploadFilePaths`]: the paths to the files (file_path, lock_path, metadata_path).
     """
     # filename is the path in the Hub repository (separated by '/')
-    # make sure to have a cross-platform transcription
-    sanitized_filename = os.path.join(*filename.split("/"))
-    if os.name == "nt":
-        if sanitized_filename.startswith("..\\") or "\\..\\" in sanitized_filename:
-            raise ValueError(
-                f"Invalid filename: cannot handle filename '{sanitized_filename}' on Windows. Please ask the repository"
-                " owner to rename this file."
-            )
+    # make sure to have a cross-platform transcription and reject traversal
+    sanitized_filename = _sanitize_filename(filename)
     file_path = local_dir / sanitized_filename
     metadata_path = _huggingface_dir(local_dir) / "upload" / f"{sanitized_filename}.metadata"
     lock_path = metadata_path.with_suffix(".lock")


### PR DESCRIPTION
`get_local_download_paths` and `get_local_upload_paths` only checked for `'..'` traversal on Windows. On Linux/macOS, `os.path.join` does not neutralize `'.'` components, so a malicious repo filename like `../../etc/passwd` would resolve outside `local_dir`.

This patch extracts the sanitization into `_sanitize_filename()` and adds the traversal check on non-Windows platforms, raising `ValueError` for `..` segments. Both the download and upload paths now share the same validation.

Fixes #4086

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes path sanitization behavior for local download/upload flows and can now raise `ValueError` for previously-accepted repo filenames (including edge-case paths containing `..`).
> 
> **Overview**
> Prevents path-traversal via malicious repo filenames when computing local download/upload paths.
> 
> This extracts filename normalization into a shared `_sanitize_filename()` helper and extends validation beyond Windows to also **reject `..` traversal** on Linux/macOS, causing `get_local_download_paths` and `get_local_upload_paths` to raise `ValueError` for unsafe paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 398dd9549a75401ffca15ef46817221822451030. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->