### PR TITLE
[Spaces] Add fetch_space_logs + hf spaces logs command

### DIFF
--- a/docs/source/en/guides/manage-spaces.md
+++ b/docs/source/en/guides/manage-spaces.md
@@ -173,9 +173,7 @@ be paused after 48h of inactivity.
 
 **5b. Debug a failing Space by reading its logs**
 
-When a Space fails to build or crashes at runtime, the logs you normally view in the browser are also available
-programmatically via [`fetch_space_logs`]. This is particularly useful from scripts or agentic workflows where
-opening a browser is not an option.
+When a Space fails to build or crashes at runtime, the logs you normally view in the browser are also available programmatically via [`fetch_space_logs`]. This is particularly useful from scripts or agentic workflows where opening a browser is not an option.
 
 ```py
 # Drain the currently available run logs and return immediately (like `docker logs`)

--- a/docs/source/en/guides/manage-spaces.md
+++ b/docs/source/en/guides/manage-spaces.md
@@ -195,7 +195,7 @@ it will go to sleep. Any visitor landing on your Space will start it back up. Yo
 Note: if you are using a 'cpu-basic' hardware, you cannot configure a custom sleep time. Your Space will automatically
 be paused after 48h of inactivity.
 
-**5b. Debug a failing Space by reading its logs**
+### Debug a failing Space by reading its logs
 
 When a Space fails to build or crashes at runtime, the logs you normally view in the browser are also available programmatically via [`fetch_space_logs`]. This is particularly useful from scripts or agentic workflows where opening a browser is not an option.
 

--- a/docs/source/en/guides/manage-spaces.md
+++ b/docs/source/en/guides/manage-spaces.md
@@ -171,6 +171,35 @@ it will go to sleep. Any visitor landing on your Space will start it back up. Yo
 Note: if you are using a 'cpu-basic' hardware, you cannot configure a custom sleep time. Your Space will automatically
 be paused after 48h of inactivity.
 
+**5b. Debug a failing Space by reading its logs**
+
+When a Space fails to build or crashes at runtime, the logs you normally view in the browser are also available
+programmatically via [`fetch_space_logs`]. This is particularly useful from scripts or agentic workflows where
+opening a browser is not an option.
+
+```py
+# Drain the currently available run logs and return immediately (like `docker logs`)
+>>> for line in api.fetch_space_logs(repo_id=repo_id):
+...     print(line, end="")
+
+# Read the container build logs instead (useful when the Space is stuck in BUILD_ERROR)
+>>> for line in api.fetch_space_logs(repo_id=repo_id, build=True):
+...     print(line, end="")
+
+# Stream run logs in real time until the server closes the stream (Ctrl-C to stop)
+>>> for line in api.fetch_space_logs(repo_id=repo_id, follow=True):
+...     print(line, end="")
+```
+
+The same functionality is available from the CLI:
+
+```bash
+hf spaces logs username/my-space             # drain run logs
+hf spaces logs username/my-space --build     # read build logs
+hf spaces logs username/my-space -f          # stream in real time
+hf spaces logs username/my-space -n 50       # last 50 lines only
+```
+
 **Bonus: set a sleep time while requesting hardware**
 
 Upgraded hardware will be automatically assigned to your Space once it's built.

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -3403,6 +3403,7 @@ $ hf spaces [OPTIONS] COMMAND [ARGS]...
 * `hot-reload`: Hot-reload any Python file of a Space...
 * `info`: Get info about a space on the Hub.
 * `list`: List spaces on the Hub. [alias: ls]
+* `logs`: Fetch the run or build logs of a Space.
 * `search`: Search spaces on the Hub using semantic...
 
 ### `hf spaces dev-mode`
@@ -3541,6 +3542,44 @@ $ hf spaces list [OPTIONS]
 Examples
   $ hf spaces ls --limit 10
   $ hf spaces ls --search "chatbot" --author huggingface
+
+Learn more
+  Use `hf <command> --help` for more information about a command.
+  Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
+
+
+### `hf spaces logs`
+
+Fetch the run or build logs of a Space.
+
+By default, prints currently available run logs and exits (non-blocking, like
+`docker logs`). Use --follow/-f to stream until the server closes the stream.
+Use --build to see the container build logs instead (useful when a Space is
+stuck in BUILD_ERROR).
+
+**Usage**:
+
+```console
+$ hf spaces logs [OPTIONS] SPACE_ID
+```
+
+**Arguments**:
+
+* `SPACE_ID`: The space ID (e.g. `username/repo-name`).  [required]
+
+**Options**:
+
+* `--build`: Fetch the container build logs instead of the run logs. Useful when a Space is stuck in BUILD_ERROR.
+* `-f, --follow`: Follow log output (stream until the server closes the stream). Without this flag, only currently available logs are printed.
+* `-n, --tail INTEGER`: Number of lines to show from the end of the logs.
+* `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
+* `--help`: Show this message and exit.
+
+Examples
+  $ hf spaces logs username/my-space
+  $ hf spaces logs username/my-space --build
+  $ hf spaces logs -f username/my-space
+  $ hf spaces logs -n 50 username/my-space
 
 Learn more
   Use `hf <command> --help` for more information about a command.

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -3351,6 +3351,7 @@ $ hf spaces [OPTIONS] COMMAND [ARGS]...
 * `hot-reload`: Hot-reload any Python file of a Space...
 * `info`: Get info about a space on the Hub.
 * `list`: List spaces on the Hub. [alias: ls]
+* `logs`: Fetch the run or build logs of a Space.
 
 ### `hf spaces dev-mode`
 
@@ -3488,6 +3489,44 @@ $ hf spaces list [OPTIONS]
 Examples
   $ hf spaces ls --limit 10
   $ hf spaces ls --search "chatbot" --author huggingface
+
+Learn more
+  Use `hf <command> --help` for more information about a command.
+  Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
+
+
+### `hf spaces logs`
+
+Fetch the run or build logs of a Space.
+
+By default, prints currently available run logs and exits (non-blocking, like
+`docker logs`). Use --follow/-f to stream until the server closes the stream.
+Use --build to see the container build logs instead (useful when a Space is
+stuck in BUILD_ERROR).
+
+**Usage**:
+
+```console
+$ hf spaces logs [OPTIONS] SPACE_ID
+```
+
+**Arguments**:
+
+* `SPACE_ID`: The space ID (e.g. `username/repo-name`).  [required]
+
+**Options**:
+
+* `--build`: Fetch the container build logs instead of the run logs. Useful when a Space is stuck in BUILD_ERROR.
+* `-f, --follow`: Follow log output (stream until the server closes the stream). Without this flag, only currently available logs are printed.
+* `-n, --tail INTEGER`: Number of lines to show from the end of the logs.
+* `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
+* `--help`: Show this message and exit.
+
+Examples
+  $ hf spaces logs username/my-space
+  $ hf spaces logs username/my-space --build
+  $ hf spaces logs -f username/my-space
+  $ hf spaces logs -n 50 username/my-space
 
 Learn more
   Use `hf <command> --help` for more information about a command.

--- a/docs/source/en/package_reference/space_runtime.md
+++ b/docs/source/en/package_reference/space_runtime.md
@@ -8,6 +8,7 @@ Check the [`HfApi`] documentation page for the reference of methods to manage yo
 
 - Duplicate a Space: [`duplicate_space`]
 - Fetch current runtime: [`get_space_runtime`]
+- Fetch build or run logs: [`fetch_space_logs`]
 - Manage secrets: [`add_space_secret`] and [`delete_space_secret`]
 - Manage hardware: [`request_space_hardware`]
 - Manage state: [`pause_space`], [`restart_space`], [`set_space_sleep_time`]

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -243,6 +243,7 @@ _SUBMOD_ATTRS = {
         "enable_webhook",
         "fetch_job_logs",
         "fetch_job_metrics",
+        "fetch_space_logs",
         "file_exists",
         "get_bucket_file_metadata",
         "get_bucket_paths_info",
@@ -948,6 +949,7 @@ __all__ = [
     "export_folder_as_dduf",
     "fetch_job_logs",
     "fetch_job_metrics",
+    "fetch_space_logs",
     "file_exists",
     "from_pretrained_fastai",
     "get_async_session",
@@ -1369,6 +1371,7 @@ if TYPE_CHECKING:  # pragma: no cover
         enable_webhook,  # noqa: F401
         fetch_job_logs,  # noqa: F401
         fetch_job_metrics,  # noqa: F401
+        fetch_space_logs,  # noqa: F401
         file_exists,  # noqa: F401
         get_bucket_file_metadata,  # noqa: F401
         get_bucket_paths_info,  # noqa: F401

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -43,7 +43,7 @@ from typing_extensions import assert_never
 from huggingface_hub._hot_reload.client import multi_replica_reload_events
 from huggingface_hub._hot_reload.types import ApiGetReloadEventSourceData, ReloadRegion
 from huggingface_hub._space_api import SpaceStage
-from huggingface_hub.errors import CLIError, HfHubHTTPError, RepositoryNotFoundError, RevisionNotFoundError
+from huggingface_hub.errors import CLIError, RepositoryNotFoundError, RevisionNotFoundError
 from huggingface_hub.file_download import hf_hub_download
 from huggingface_hub.hf_api import ExpandSpaceProperty_T, HfApi, SpaceSort_T
 from huggingface_hub.utils import StatusLine, are_progress_bars_disabled, disable_progress_bars, enable_progress_bars
@@ -268,16 +268,9 @@ def spaces_logs(
         if tail is not None:
             logs = deque(logs, maxlen=tail)
         for line in logs:
-            print(line, end="" if line.endswith("\n") else "\n")
+            out.text(line.strip())
     except RepositoryNotFoundError as e:
         raise CLIError(f"Space '{space_id}' not found.") from e
-    except HfHubHTTPError as e:
-        status = e.response.status_code if e.response is not None else None
-        if status == 404:
-            raise CLIError(f"Space '{space_id}' not found.") from e
-        if status == 403:
-            raise CLIError(f"Access denied to '{space_id}'. You need write access to read Space logs.") from e
-        raise CLIError(f"Failed to fetch Space logs: {e}") from e
 
 
 @spaces_cli.command(

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -263,14 +263,11 @@ def spaces_logs(
         )
 
     api = get_hf_api(token=token)
-    try:
-        logs = api.fetch_space_logs(space_id, build=build, follow=follow)
-        if tail is not None:
-            logs = deque(logs, maxlen=tail)
-        for line in logs:
-            out.text(line.strip())
-    except RepositoryNotFoundError as e:
-        raise CLIError(f"Space '{space_id}' not found.") from e
+    logs = api.fetch_space_logs(space_id, build=build, follow=follow)
+    if tail is not None:
+        logs = deque(logs, maxlen=tail)
+    for line in logs:
+        out.text(line.strip())
 
 
 @spaces_cli.command(

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -313,8 +313,14 @@ def spaces_logs(
     logs = api.fetch_space_logs(space_id, build=build, follow=follow)
     if tail is not None:
         logs = deque(logs, maxlen=tail)
+    found_logs = False
     for line in logs:
-        out.text(line.strip())
+        clean_line = line.strip()
+        out.text(clean_line)
+        if clean_line:
+            found_logs = True
+    if not found_logs and not build:
+        out.hint(f"No run logs found for space {space_id}. Try passing --build to fetch build logs instead.")
 
 
 @spaces_cli.command(

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -33,6 +33,7 @@ import subprocess
 import sys
 import tempfile
 import time
+from collections import deque
 from typing import Annotated, Literal, get_args
 
 import typer
@@ -42,7 +43,7 @@ from typing_extensions import assert_never
 from huggingface_hub._hot_reload.client import multi_replica_reload_events
 from huggingface_hub._hot_reload.types import ApiGetReloadEventSourceData, ReloadRegion
 from huggingface_hub._space_api import SpaceStage
-from huggingface_hub.errors import CLIError, RepositoryNotFoundError, RevisionNotFoundError
+from huggingface_hub.errors import CLIError, HfHubHTTPError, RepositoryNotFoundError, RevisionNotFoundError
 from huggingface_hub.file_download import hf_hub_download
 from huggingface_hub.hf_api import ExpandSpaceProperty_T, HfApi, SpaceSort_T
 from huggingface_hub.utils import StatusLine, are_progress_bars_disabled, disable_progress_bars, enable_progress_bars
@@ -211,6 +212,72 @@ def dev_mode(
     print(f"  * Cursor: cursor://vscode-remote/ssh-remote+{ssh_host}{folder}")
     print("")
     print("PS: Dev mode stops after 48h of inactivity, don't forget to save your changes regularly.")
+
+
+@spaces_cli.command(
+    "logs",
+    examples=[
+        "hf spaces logs username/my-space",
+        "hf spaces logs username/my-space --build",
+        "hf spaces logs -f username/my-space",
+        "hf spaces logs -n 50 username/my-space",
+    ],
+)
+def spaces_logs(
+    space_id: Annotated[str, typer.Argument(help="The space ID (e.g. `username/repo-name`).")],
+    build: Annotated[
+        bool,
+        typer.Option(
+            "--build",
+            help="Fetch the container build logs instead of the run logs. Useful when a Space is stuck in BUILD_ERROR.",
+        ),
+    ] = False,
+    follow: Annotated[
+        bool,
+        typer.Option(
+            "-f",
+            "--follow",
+            help="Follow log output (stream until the server closes the stream). Without this flag, only currently available logs are printed.",
+        ),
+    ] = False,
+    tail: Annotated[
+        int | None,
+        typer.Option(
+            "-n",
+            "--tail",
+            help="Number of lines to show from the end of the logs.",
+        ),
+    ] = None,
+    token: TokenOpt = None,
+) -> None:
+    """Fetch the run or build logs of a Space.
+
+    By default, prints currently available run logs and exits (non-blocking, like
+    `docker logs`). Use --follow/-f to stream until the server closes the stream.
+    Use --build to see the container build logs instead (useful when a Space is
+    stuck in BUILD_ERROR).
+    """
+    if follow and tail is not None:
+        raise CLIError(
+            "Cannot use --follow and --tail together. Use --follow to stream logs or --tail to show recent logs."
+        )
+
+    api = get_hf_api(token=token)
+    try:
+        logs = api.fetch_space_logs(space_id, build=build, follow=follow)
+        if tail is not None:
+            logs = deque(logs, maxlen=tail)
+        for line in logs:
+            print(line, end="" if line.endswith("\n") else "\n")
+    except RepositoryNotFoundError as e:
+        raise CLIError(f"Space '{space_id}' not found.") from e
+    except HfHubHTTPError as e:
+        status = e.response.status_code if e.response is not None else None
+        if status == 404:
+            raise CLIError(f"Space '{space_id}' not found.") from e
+        if status == 403:
+            raise CLIError(f"Access denied to '{space_id}'. You need write access to read Space logs.") from e
+        raise CLIError(f"Failed to fetch Space logs: {e}") from e
 
 
 @spaces_cli.command(

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -11438,7 +11438,6 @@ class HfApi:
             timeout=10 * seconds_between_events,
             skip_previous_events_on_retry=False,
             tolerated_status_codes=(500,),
-            tolerated_exception_types=(httpx.ReadTimeout,),
             namespace=namespace,
             token=token,
         )

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -7889,6 +7889,130 @@ class HfApi:
         hf_raise_for_status(r)
         return SpaceRuntime(r.json())
 
+    def _fetch_space_logs_sse(
+        self,
+        *,
+        repo_id: str,
+        build: bool,
+        timeout: int,
+        follow: bool,
+        token: bool | str | None = None,
+    ) -> Iterable[dict[str, Any]]:
+        log_type = "build" if build else "run"
+        nb_tries = 0
+        max_retries = 5 if follow else 0
+        min_wait_time = 1
+        max_wait_time = 10
+        sleep_time = 0
+        start_event_idx = 0
+        error_to_retry: Exception | None = None
+        while True:
+            if error_to_retry is not None:
+                logger.warning(f"'{error_to_retry}' thrown while requesting spaces /logs/{log_type} for {repo_id=}")
+                logger.warning(f"Retrying in {sleep_time}s [Retry {nb_tries}/{max_retries}].")
+                error_to_retry = None
+                time.sleep(sleep_time)
+            try:
+                with get_session().stream(
+                    "GET",
+                    f"{self.endpoint}/api/spaces/{repo_id}/logs/{log_type}",
+                    headers=self._build_hf_headers(token=token),
+                    timeout=timeout,
+                ) as response:
+                    if response.status_code == 200:
+                        event_idx = -1
+                        for line in response.iter_lines():
+                            if line and line.startswith("data: {"):
+                                event_idx += 1
+                                if event_idx >= start_event_idx:
+                                    start_event_idx += 1
+                                    yield json.loads(line[len("data: ") :])
+                        break
+                    hf_raise_for_status(response)
+            except httpx.HTTPStatusError:
+                raise
+            except httpx.DecodingError:
+                break
+            except KeyboardInterrupt:
+                break
+            except (httpx.HTTPError, httpcore.TimeoutException) as err:
+                is_no_new_line_timeout = isinstance(err, (httpx.ReadTimeout, httpcore.ReadTimeout))
+                if is_no_new_line_timeout and not follow:
+                    break  # no-follow: timeout means the buffer is drained
+                if nb_tries >= max_retries:
+                    if is_no_new_line_timeout:
+                        break  # follow mode, silent stream, retries exhausted: give up
+                    raise  # real error, retries exhausted: surface it
+                nb_tries += 1
+                sleep_time = min(max_wait_time, max(min_wait_time, sleep_time * 2))
+                error_to_retry = err
+
+    @validate_hf_hub_args
+    def fetch_space_logs(
+        self,
+        repo_id: str,
+        *,
+        build: bool = False,
+        follow: bool = False,
+        token: bool | str | None = None,
+    ) -> Iterable[str]:
+        """Fetch the run or build logs of a Space on the Hub.
+
+        Useful for debugging a Space that is failing to build or crashing at runtime,
+        especially from a script or agentic workflow where reading logs in a browser
+        is not an option.
+
+        Args:
+            repo_id (`str`):
+                ID of the Space. Example: `"bigcode/in-the-stack"`.
+            build (`bool`, *optional*, defaults to `False`):
+                If `True`, fetch the container build logs (useful when a Space is stuck
+                in `BUILD_ERROR`). If `False` (default), fetch the run logs, i.e. the
+                stdout/stderr of the running application.
+            follow (`bool`, *optional*, defaults to `False`):
+                If `True`, stream logs in real-time (blocking) until the server closes
+                the stream or `KeyboardInterrupt` is raised. If `False` (default), fetch
+                only the currently buffered logs and return immediately (non-blocking,
+                like `docker logs`).
+            token (`bool` or `str`, *optional*):
+                A valid user access token. Defaults to the locally saved token, which is
+                the recommended authentication method. Set to `False` to disable
+                authentication. See
+                https://huggingface.co/docs/huggingface_hub/quick-start#authentication.
+
+        Returns:
+            `Iterable[str]`: A generator yielding log lines as they become available.
+
+        Example:
+
+            ```python
+            >>> from huggingface_hub import fetch_space_logs
+            >>> # Non-blocking: print currently available run logs and exit.
+            >>> for line in fetch_space_logs("username/my-space"):
+            ...     print(line, end="")
+
+            >>> # Debug a build failure:
+            >>> for line in fetch_space_logs("username/my-space", build=True):
+            ...     print(line, end="")
+
+            >>> # Stream run logs until the server closes the stream.
+            >>> for line in fetch_space_logs("username/my-space", follow=True):
+            ...     print(line, end="")
+            ```
+        """
+        # - Spaces /logs/{run|build} is SSE with `data: {"data": "...", "timestamp": "..."}` events.
+        # - Keep-alives are sent as empty `data:` messages (skipped by the `data: {` filter).
+        # - In no-follow mode we use a short read timeout to drain the buffer and return.
+        timeout = 120 if follow else 5
+        for event in self._fetch_space_logs_sse(
+            repo_id=repo_id,
+            build=build,
+            timeout=timeout,
+            follow=follow,
+            token=token,
+        ):
+            yield event["data"]
+
     @_deprecate_arguments(
         version="2.0",
         deprecated_args={"space_storage"},
@@ -13558,6 +13682,7 @@ set_space_volumes = api.set_space_volumes
 delete_space_volumes = api.delete_space_volumes
 enable_space_dev_mode = api.enable_space_dev_mode
 disable_space_dev_mode = api.disable_space_dev_mode
+fetch_space_logs = api.fetch_space_logs
 
 # Inference Endpoint API
 list_inference_endpoints = api.list_inference_endpoints

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -7889,6 +7889,95 @@ class HfApi:
         hf_raise_for_status(r)
         return SpaceRuntime(r.json())
 
+    def _stream_sse_events(
+        self,
+        *,
+        url: str,
+        log_label: str,
+        timeout: int,
+        follow: bool,
+        token: bool | str | None = None,
+        skip_previous_events_on_retry: bool = True,
+        tolerated_status_codes: tuple[int, ...] = (),
+        tolerated_exception_types: tuple[type[Exception], ...] = (),
+        on_iteration_end: Callable[[], bool] | None = None,
+    ) -> Iterable[dict[str, Any]]:
+        # Shared SSE streaming loop with retry/backoff and event-index dedup.
+        # Used by Spaces logs and Jobs logs/metrics. Two retry styles:
+        #   - on_iteration_end is None: retries are the only backstop (Spaces).
+        #   - on_iteration_end is set: it polls authoritative state after every
+        #     failed iteration; ReadTimeouts/tolerated errors fall through to it
+        #     instead of consuming retries (Jobs).
+        nb_tries = 0
+        max_retries = 5 if follow else 0
+        min_wait_time = 1
+        max_wait_time = 10
+        sleep_time = 0
+        start_event_idx = 0
+        error_to_retry: Exception | None = None
+        while True:
+            if error_to_retry is not None:
+                logger.warning(f"'{error_to_retry}' thrown while requesting {log_label}")
+                logger.warning(f"Retrying in {sleep_time}s [Retry {nb_tries}/{max_retries}].")
+                error_to_retry = None
+                time.sleep(sleep_time)
+            try:
+                with get_session().stream(
+                    "GET",
+                    url,
+                    headers=self._build_hf_headers(token=token),
+                    timeout=timeout,
+                ) as response:
+                    if response.status_code == 200:
+                        event_idx = -1
+                        for line in response.iter_lines():
+                            if line and line.startswith("data: {"):
+                                event_idx += 1
+                                if event_idx >= start_event_idx:
+                                    if skip_previous_events_on_retry:
+                                        start_event_idx += 1
+                                    yield json.loads(line[len("data: ") :])
+                        break
+                    elif response.status_code not in tolerated_status_codes:
+                        hf_raise_for_status(response)
+            except HfHubHTTPError:
+                # Permanent HTTP error (404/403/...). Never retry — fail fast.
+                raise
+            except httpx.DecodingError:
+                # Response ended prematurely.
+                break
+            except KeyboardInterrupt:
+                break
+            except (httpx.HTTPError, httpcore.TimeoutException) as err:
+                is_no_new_line_timeout = isinstance(err, (httpx.ReadTimeout, httpcore.ReadTimeout))
+                if is_no_new_line_timeout and not follow:
+                    break  # no-follow: timeout means the buffer is drained
+                if on_iteration_end is not None:
+                    # Authoritative-state mode: ReadTimeouts and tolerated errors
+                    # fall through to the post-iteration check without consuming
+                    # retries. Note: ReadTimeout is handled here regardless of
+                    # `tolerated_exception_types` — entries in that tuple only
+                    # fire for non-timeout errors.
+                    if is_no_new_line_timeout or type(err) in tolerated_exception_types:
+                        pass
+                    elif nb_tries >= max_retries:
+                        raise
+                    else:
+                        nb_tries += 1
+                        sleep_time = min(max_wait_time, max(min_wait_time, sleep_time * 2))
+                        error_to_retry = err
+                else:
+                    # Retry-only mode: every error in follow mode burns a retry.
+                    if nb_tries >= max_retries:
+                        if is_no_new_line_timeout:
+                            break  # follow mode, silent stream, retries exhausted: give up
+                        raise
+                    nb_tries += 1
+                    sleep_time = min(max_wait_time, max(min_wait_time, sleep_time * 2))
+                    error_to_retry = err
+            if on_iteration_end is not None and on_iteration_end():
+                break
+
     def _fetch_space_logs_sse(
         self,
         *,
@@ -7899,53 +7988,13 @@ class HfApi:
         token: bool | str | None = None,
     ) -> Iterable[dict[str, Any]]:
         log_type = "build" if build else "run"
-        nb_tries = 0
-        max_retries = 5 if follow else 0
-        min_wait_time = 1
-        max_wait_time = 10
-        sleep_time = 0
-        start_event_idx = 0
-        error_to_retry: Exception | None = None
-        while True:
-            if error_to_retry is not None:
-                logger.warning(f"'{error_to_retry}' thrown while requesting spaces /logs/{log_type} for {repo_id=}")
-                logger.warning(f"Retrying in {sleep_time}s [Retry {nb_tries}/{max_retries}].")
-                error_to_retry = None
-                time.sleep(sleep_time)
-            try:
-                with get_session().stream(
-                    "GET",
-                    f"{self.endpoint}/api/spaces/{repo_id}/logs/{log_type}",
-                    headers=self._build_hf_headers(token=token),
-                    timeout=timeout,
-                ) as response:
-                    if response.status_code == 200:
-                        event_idx = -1
-                        for line in response.iter_lines():
-                            if line and line.startswith("data: {"):
-                                event_idx += 1
-                                if event_idx >= start_event_idx:
-                                    start_event_idx += 1
-                                    yield json.loads(line[len("data: ") :])
-                        break
-                    hf_raise_for_status(response)
-            except HfHubHTTPError:
-                raise
-            except httpx.DecodingError:
-                break
-            except KeyboardInterrupt:
-                break
-            except (httpx.HTTPError, httpcore.TimeoutException) as err:
-                is_no_new_line_timeout = isinstance(err, (httpx.ReadTimeout, httpcore.ReadTimeout))
-                if is_no_new_line_timeout and not follow:
-                    break  # no-follow: timeout means the buffer is drained
-                if nb_tries >= max_retries:
-                    if is_no_new_line_timeout:
-                        break  # follow mode, silent stream, retries exhausted: give up
-                    raise  # real error, retries exhausted: surface it
-                nb_tries += 1
-                sleep_time = min(max_wait_time, max(min_wait_time, sleep_time * 2))
-                error_to_retry = err
+        yield from self._stream_sse_events(
+            url=f"{self.endpoint}/api/spaces/{repo_id}/logs/{log_type}",
+            log_label=f"spaces /logs/{log_type} for repo_id={repo_id!r}",
+            timeout=timeout,
+            follow=follow,
+            token=token,
+        )
 
     @validate_hf_hub_args
     def fetch_space_logs(
@@ -11227,76 +11276,37 @@ class HfApi:
         route: str,
         timeout: int,
         skip_previous_events_on_retry: bool,
-        double_check_job_has_finished_on_status_code_or_error: tuple[int | type[Exception], ...],
+        tolerated_status_codes: tuple[int, ...] = (),
+        tolerated_exception_types: tuple[type[Exception], ...] = (),
         follow: bool = True,
         namespace: str | None = None,
         token: bool | str | None = None,
     ) -> Iterable[dict[str, Any]]:
         if namespace is None:
             namespace = self.whoami(token=token)["name"]
-        # We don't use http_backoff since we need to check ourselves if the job is still running
-        nb_tries = 0
-        max_retries = 5 if follow else 0
-        min_wait_time = 1
-        max_wait_time = 10
-        sleep_time = 0
-        start_event_idx = 0
-        error_to_retry = None
-        while True:
-            if error_to_retry is not None:
-                logger.warning(f"'{error_to_retry}' thrown while requesting jobs /{route} for {job_id=}")
-                logger.warning(f"Retrying in {sleep_time}s [Retry {nb_tries}/{max_retries}].")
-                error_to_retry = None
-                time.sleep(sleep_time)
-            try:
-                with get_session().stream(
-                    "GET",
-                    f"{self.endpoint}/api/jobs/{namespace}/{job_id}/{route}",
-                    headers=self._build_hf_headers(token=token),
-                    timeout=timeout,
-                ) as response:
-                    if response.status_code == 200:
-                        event_idx = -1
-                        for line in response.iter_lines():
-                            if line and line.startswith("data: {"):
-                                event_idx += 1
-                                if event_idx >= start_event_idx:
-                                    if skip_previous_events_on_retry:
-                                        start_event_idx += 1
-                                    yield json.loads(line[len("data: ") :])
-                        break
-                    elif response.status_code not in double_check_job_has_finished_on_status_code_or_error:
-                        hf_raise_for_status(response)
-            except httpx.HTTPStatusError:
-                raise
-            except httpx.DecodingError:
-                # Response ended prematurely
-                break
-            except KeyboardInterrupt:
-                break
-            except (httpx.HTTPError, httpcore.TimeoutException) as err:
-                is_no_new_line_timeout = isinstance(err, (httpx.ReadTimeout, httpcore.ReadTimeout))
-                if is_no_new_line_timeout:
-                    if not follow:
-                        break  # no-follow mode: got all buffered events
-                    # follow mode: job is likely finished
-                    pass
-                elif type(err) in double_check_job_has_finished_on_status_code_or_error:
-                    pass
-                elif nb_tries >= max_retries:
-                    raise
-                else:
-                    nb_tries += 1
-                    sleep_time = min(max_wait_time, max(min_wait_time, sleep_time * 2))
-                    error_to_retry = err
+
+        def has_job_finished() -> bool:
+            # We don't use http_backoff: this is the authoritative check that
+            # decides whether to keep streaming.
             job_status_response = get_session().get(
                 f"{self.endpoint}/api/jobs/{namespace}/{job_id}",
                 headers=self._build_hf_headers(token=token),
             )
             hf_raise_for_status(job_status_response)
             job_status = job_status_response.json()
-            if "status" in job_status and job_status["status"]["stage"] not in ("RUNNING", "UPDATING"):
-                break
+            return "status" in job_status and job_status["status"]["stage"] not in ("RUNNING", "UPDATING")
+
+        yield from self._stream_sse_events(
+            url=f"{self.endpoint}/api/jobs/{namespace}/{job_id}/{route}",
+            log_label=f"jobs /{route} for {job_id=}",
+            timeout=timeout,
+            follow=follow,
+            token=token,
+            skip_previous_events_on_retry=skip_previous_events_on_retry,
+            tolerated_status_codes=tolerated_status_codes,
+            tolerated_exception_types=tolerated_exception_types,
+            on_iteration_end=has_job_finished,
+        )
 
     def fetch_job_logs(
         self,
@@ -11357,7 +11367,6 @@ class HfApi:
             route="logs",
             timeout=timeout,
             skip_previous_events_on_retry=True,
-            double_check_job_has_finished_on_status_code_or_error=tuple(),
             follow=follow,
             namespace=namespace,
             token=token,
@@ -11428,7 +11437,8 @@ class HfApi:
             route="metrics",
             timeout=10 * seconds_between_events,
             skip_previous_events_on_retry=False,
-            double_check_job_has_finished_on_status_code_or_error=(500, httpx.ReadTimeout),
+            tolerated_status_codes=(500,),
+            tolerated_exception_types=(httpx.ReadTimeout,),
             namespace=namespace,
             token=token,
         )

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -7929,7 +7929,7 @@ class HfApi:
                                     yield json.loads(line[len("data: ") :])
                         break
                     hf_raise_for_status(response)
-            except httpx.HTTPStatusError:
+            except HfHubHTTPError:
                 raise
             except httpx.DecodingError:
                 break

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2095,18 +2095,18 @@ class TestSpacesLogsCommand:
 
     def test_logs_404(self, runner: CliRunner) -> None:
         """A 404 from the API surfaces as a clean 'Space not found' CLI error."""
-        from huggingface_hub.errors import HfHubHTTPError
+        from huggingface_hub.errors import RepositoryNotFoundError
 
         response = Mock(status_code=404)
         with patch("huggingface_hub.cli.spaces.get_hf_api") as api_cls:
             api = api_cls.return_value
-            api.fetch_space_logs.side_effect = HfHubHTTPError("404 Client Error", response=response)
+            api.fetch_space_logs.side_effect = RepositoryNotFoundError("404 Client Error", response=response)
             result = runner.invoke(app, ["spaces", "logs", "user/missing-space"])
         assert result.exit_code != 0
         assert "Space 'user/missing-space' not found" in str(result.exception)
 
     def test_logs_403(self, runner: CliRunner) -> None:
-        """A 403 surfaces as a clean access-denied CLI error."""
+        """A 403 surfaces via the global HfHubHTTPError handler — the local catch was dropped."""
         from huggingface_hub.errors import HfHubHTTPError
 
         response = Mock(status_code=403)
@@ -2115,7 +2115,8 @@ class TestSpacesLogsCommand:
             api.fetch_space_logs.side_effect = HfHubHTTPError("403 Forbidden", response=response)
             result = runner.invoke(app, ["spaces", "logs", "user/private-space"])
         assert result.exit_code != 0
-        assert "Access denied" in str(result.exception)
+        assert isinstance(result.exception, HfHubHTTPError)
+        assert "403" in str(result.exception)
 
 
 class TestInferenceEndpointsCommands:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2081,6 +2081,26 @@ class TestSpacesLogsCommand:
         assert result.exit_code != 0
         assert "Cannot use --follow and --tail together" in str(result.exception)
 
+    def test_logs_empty_run_logs_shows_build_hint(self, runner: CliRunner) -> None:
+        """Empty run logs trigger a hint suggesting --build."""
+        with patch("huggingface_hub.cli.spaces.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            api.fetch_space_logs.return_value = iter([])
+            result = runner.invoke(app, ["spaces", "logs", "user/my-space"])
+        assert result.exit_code == 0
+        assert "No run logs found for space user/my-space" in result.output
+        assert "--build" in result.output
+
+    def test_logs_empty_build_logs_no_hint(self, runner: CliRunner) -> None:
+        """Empty build logs do NOT trigger the run-logs hint."""
+        with patch("huggingface_hub.cli.spaces.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            api.fetch_space_logs.return_value = iter([])
+            result = runner.invoke(app, ["spaces", "logs", "user/my-space", "--build"])
+        assert result.exit_code == 0
+        assert "No run logs found" not in result.output
+
+
 class TestInferenceEndpointsCommands:
     def test_list(self, runner: CliRunner) -> None:
         endpoint = Mock(raw={"name": "demo"})

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2039,36 +2039,16 @@ class TestSpacesLsCommand:
 
 
 class TestSpacesLogsCommand:
-    def test_logs_default_no_follow(self, runner: CliRunner) -> None:
+    def test_build_logs_follow(self, runner: CliRunner) -> None:
         """`hf spaces logs <id>` defaults to run logs, follow=False."""
         with patch("huggingface_hub.cli.spaces.get_hf_api") as api_cls:
             api = api_cls.return_value
             api.fetch_space_logs.return_value = iter(["line 1\n", "line 2\n"])
-            result = runner.invoke(app, ["spaces", "logs", "user/my-space"])
+            result = runner.invoke(app, ["spaces", "logs", "user/my-space", "-f", "--build"])
         assert result.exit_code == 0
-        api.fetch_space_logs.assert_called_once_with("user/my-space", build=False, follow=False)
+        api.fetch_space_logs.assert_called_once_with("user/my-space", build=True, follow=True)
         assert "line 1" in result.output
         assert "line 2" in result.output
-
-    def test_logs_follow_flag(self, runner: CliRunner) -> None:
-        """`hf spaces logs -f <id>` passes follow=True."""
-        with patch("huggingface_hub.cli.spaces.get_hf_api") as api_cls:
-            api = api_cls.return_value
-            api.fetch_space_logs.return_value = iter(["streaming line\n"])
-            result = runner.invoke(app, ["spaces", "logs", "-f", "user/my-space"])
-        assert result.exit_code == 0
-        api.fetch_space_logs.assert_called_once_with("user/my-space", build=False, follow=True)
-        assert "streaming line" in result.output
-
-    def test_logs_build_flag(self, runner: CliRunner) -> None:
-        """`hf spaces logs --build <id>` fetches build logs."""
-        with patch("huggingface_hub.cli.spaces.get_hf_api") as api_cls:
-            api = api_cls.return_value
-            api.fetch_space_logs.return_value = iter(["build step\n"])
-            result = runner.invoke(app, ["spaces", "logs", "--build", "user/my-space"])
-        assert result.exit_code == 0
-        api.fetch_space_logs.assert_called_once_with("user/my-space", build=True, follow=False)
-        assert "build step" in result.output
 
     def test_logs_tail(self, runner: CliRunner) -> None:
         """`hf spaces logs --tail 2 <id>` shows only the last 2 lines."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2043,6 +2043,81 @@ class TestSpacesLsCommand:
         assert "Invalid value" in result.output
 
 
+class TestSpacesLogsCommand:
+    def test_logs_default_no_follow(self, runner: CliRunner) -> None:
+        """`hf spaces logs <id>` defaults to run logs, follow=False."""
+        with patch("huggingface_hub.cli.spaces.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            api.fetch_space_logs.return_value = iter(["line 1\n", "line 2\n"])
+            result = runner.invoke(app, ["spaces", "logs", "user/my-space"])
+        assert result.exit_code == 0
+        api.fetch_space_logs.assert_called_once_with("user/my-space", build=False, follow=False)
+        assert "line 1" in result.output
+        assert "line 2" in result.output
+
+    def test_logs_follow_flag(self, runner: CliRunner) -> None:
+        """`hf spaces logs -f <id>` passes follow=True."""
+        with patch("huggingface_hub.cli.spaces.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            api.fetch_space_logs.return_value = iter(["streaming line\n"])
+            result = runner.invoke(app, ["spaces", "logs", "-f", "user/my-space"])
+        assert result.exit_code == 0
+        api.fetch_space_logs.assert_called_once_with("user/my-space", build=False, follow=True)
+        assert "streaming line" in result.output
+
+    def test_logs_build_flag(self, runner: CliRunner) -> None:
+        """`hf spaces logs --build <id>` fetches build logs."""
+        with patch("huggingface_hub.cli.spaces.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            api.fetch_space_logs.return_value = iter(["build step\n"])
+            result = runner.invoke(app, ["spaces", "logs", "--build", "user/my-space"])
+        assert result.exit_code == 0
+        api.fetch_space_logs.assert_called_once_with("user/my-space", build=True, follow=False)
+        assert "build step" in result.output
+
+    def test_logs_tail(self, runner: CliRunner) -> None:
+        """`hf spaces logs --tail 2 <id>` shows only the last 2 lines."""
+        with patch("huggingface_hub.cli.spaces.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            api.fetch_space_logs.return_value = iter(["line 1\n", "line 2\n", "line 3\n", "line 4\n"])
+            result = runner.invoke(app, ["spaces", "logs", "--tail", "2", "user/my-space"])
+        assert result.exit_code == 0
+        assert "line 1" not in result.output
+        assert "line 2" not in result.output
+        assert "line 3" in result.output
+        assert "line 4" in result.output
+
+    def test_logs_follow_and_tail_error(self, runner: CliRunner) -> None:
+        """`hf spaces logs -f --tail 5 <id>` raises an error."""
+        result = runner.invoke(app, ["spaces", "logs", "-f", "--tail", "5", "user/my-space"])
+        assert result.exit_code != 0
+        assert "Cannot use --follow and --tail together" in str(result.exception)
+
+    def test_logs_404(self, runner: CliRunner) -> None:
+        """A 404 from the API surfaces as a clean 'Space not found' CLI error."""
+        from huggingface_hub.errors import HfHubHTTPError
+
+        response = Mock(status_code=404)
+        with patch("huggingface_hub.cli.spaces.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            api.fetch_space_logs.side_effect = HfHubHTTPError("404 Client Error", response=response)
+            result = runner.invoke(app, ["spaces", "logs", "user/missing-space"])
+        assert result.exit_code != 0
+        assert "Space 'user/missing-space' not found" in str(result.exception)
+
+    def test_logs_403(self, runner: CliRunner) -> None:
+        """A 403 surfaces as a clean access-denied CLI error."""
+        from huggingface_hub.errors import HfHubHTTPError
+
+        response = Mock(status_code=403)
+        with patch("huggingface_hub.cli.spaces.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            api.fetch_space_logs.side_effect = HfHubHTTPError("403 Forbidden", response=response)
+            result = runner.invoke(app, ["spaces", "logs", "user/private-space"])
+        assert result.exit_code != 0
+        assert "Access denied" in str(result.exception)
+
+
 class TestInferenceEndpointsCommands:
     def test_list(self, runner: CliRunner) -> None:
         endpoint = Mock(raw={"name": "demo"})

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2088,32 +2088,6 @@ class TestSpacesLogsCommand:
         assert result.exit_code != 0
         assert "Cannot use --follow and --tail together" in str(result.exception)
 
-    def test_logs_404(self, runner: CliRunner) -> None:
-        """A 404 from the API surfaces as a clean 'Space not found' CLI error."""
-        from huggingface_hub.errors import RepositoryNotFoundError
-
-        response = Mock(status_code=404)
-        with patch("huggingface_hub.cli.spaces.get_hf_api") as api_cls:
-            api = api_cls.return_value
-            api.fetch_space_logs.side_effect = RepositoryNotFoundError("404 Client Error", response=response)
-            result = runner.invoke(app, ["spaces", "logs", "user/missing-space"])
-        assert result.exit_code != 0
-        assert "Space 'user/missing-space' not found" in str(result.exception)
-
-    def test_logs_403(self, runner: CliRunner) -> None:
-        """A 403 surfaces via the global HfHubHTTPError handler — the local catch was dropped."""
-        from huggingface_hub.errors import HfHubHTTPError
-
-        response = Mock(status_code=403)
-        with patch("huggingface_hub.cli.spaces.get_hf_api") as api_cls:
-            api = api_cls.return_value
-            api.fetch_space_logs.side_effect = HfHubHTTPError("403 Forbidden", response=response)
-            result = runner.invoke(app, ["spaces", "logs", "user/private-space"])
-        assert result.exit_code != 0
-        assert isinstance(result.exception, HfHubHTTPError)
-        assert "403" in str(result.exception)
-
-
 class TestInferenceEndpointsCommands:
     def test_list(self, runner: CliRunner) -> None:
         endpoint = Mock(raw={"name": "demo"})

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2081,25 +2081,6 @@ class TestSpacesLogsCommand:
         assert result.exit_code != 0
         assert "Cannot use --follow and --tail together" in str(result.exception)
 
-    def test_logs_empty_run_logs_shows_build_hint(self, runner: CliRunner) -> None:
-        """Empty run logs trigger a hint suggesting --build."""
-        with patch("huggingface_hub.cli.spaces.get_hf_api") as api_cls:
-            api = api_cls.return_value
-            api.fetch_space_logs.return_value = iter([])
-            result = runner.invoke(app, ["spaces", "logs", "user/my-space"])
-        assert result.exit_code == 0
-        assert "No run logs found for space user/my-space" in result.output
-        assert "--build" in result.output
-
-    def test_logs_empty_build_logs_no_hint(self, runner: CliRunner) -> None:
-        """Empty build logs do NOT trigger the run-logs hint."""
-        with patch("huggingface_hub.cli.spaces.get_hf_api") as api_cls:
-            api = api_cls.return_value
-            api.fetch_space_logs.return_value = iter([])
-            result = runner.invoke(app, ["spaces", "logs", "user/my-space", "--build"])
-        assert result.exit_code == 0
-        assert "No run logs found" not in result.output
-
 
 class TestInferenceEndpointsCommands:
     def test_list(self, runner: CliRunner) -> None:


### PR DESCRIPTION
## Summary

WIP and happy to discuss if it makes sense! 

Using agents with Spaces, I found it helpful to give access to logs, and currently, this isn't exposed in the CLI. An alternative design would be to just return the URL for logs from methods that create /modify Spaces, but this might be better for actual scripting, etc. 

- Adds `HfApi.fetch_space_logs(repo_id, *, build=False, follow=False)` — programmatic access to Space build/run logs via the SSE endpoint `/api/spaces/{repo_id}/logs/{run|build}`
- Adds `hf spaces logs <repo_id> [--build] [-f/--follow] [-n/--tail N]` CLI command
- 7 mock-based CLI tests, docs in manage-spaces guide + package reference

> **Note:** This is a first pass — the API shape and implementation approach are open to discussion. Happy to iterate on naming, flag style, or the streaming/retry strategy based on feedback.

## Motivation

Agents and scripts that manage Spaces (restart, set volumes, push code) currently have no way to read *why* a Space failed without knowing the raw endpoint URL and crafting a curl request. `get_space_runtime()` surfaces the stage (`BUILD_ERROR`, `RUNTIME_ERROR`) but not the actual error — that lives behind `/api/spaces/{repo_id}/logs/{build|run}`.

By wrapping this as a first-class method, agents can autonomously check logs when something goes wrong — no human nudge needed to provide a URL or paste output. The pattern already exists for Jobs (`fetch_job_logs` + `hf jobs logs`); this closes the equivalent gap for Spaces.

## API shape

```python
# Run logs (default) — like `docker logs`
for line in api.fetch_space_logs("username/my-space"):
    print(line, end="")

# Build logs — for BUILD_ERROR debugging
for line in api.fetch_space_logs("username/my-space", build=True):
    print(line, end="")

# Stream in real time
for line in api.fetch_space_logs("username/my-space", follow=True):
    print(line, end="")
```

```bash
hf spaces logs username/my-space              # run logs
hf spaces logs username/my-space --build      # build logs
hf spaces logs username/my-space -f           # stream
hf spaces logs username/my-space -n 50        # last 50 lines
```

### Design decisions (all open for discussion)

**`build=True` boolean flag vs `log_type="build"` enum.** We tested this by prompting an independent agent with no knowledge of the implementation to write the CLI/Python calls they'd intuitively expect. They converged on `--build` as a boolean toggle (like `kubectl logs --previous`) rather than `--type build` as an enum. Rationale: shorter, no string literal to remember, honours the asymmetry ("logs" = run logs by default, build is the special case). 

**No `SpaceStage` polling in the helper.** The helper trusts that and does not poll `get_space_runtime()` as a backstop. Upstream misbehavior (observed on one RUNTIME_ERROR space where the server held the socket open with zero bytes) is bounded by read timeout + retry cap. This avoids coupling to the `SpaceStage` enum, which is currently incomplete (server returns `SLEEPING` but the Python enum doesn't have it).

**Single method, not separate `fetch_space_logs` + `fetch_space_build_logs`.**  Since both log endpoints share `Iterable[str]` and only differ by a URL segment, a single method with a boolean toggle felt like the right granularity but open to splitting if preferred.

## Test plan

- [x] 7 mock-based CLI tests (default, --follow, --build, --tail, --follow+--tail error, 404, 403)
- [x] `make style` + `make quality` clean (2 pre-existing `ty` errors in `cli/_output.py`, not introduced here)
- [x] Full `test_cli.py` — 228/228 passing
- [x] Live-tested against real Spaces in RUNTIME_ERROR, RUNNING, and SLEEPING stages


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new SSE-based log streaming API and CLI surface, and refactors Jobs SSE streaming to reuse the same retry/dedup loop, which could affect log/metrics streaming behavior under timeouts/retries.
> 
> **Overview**
> Adds programmatic Space log access via `HfApi.fetch_space_logs(repo_id, build=..., follow=...)`, streaming from the Hub’s SSE endpoints for both *run* and *build* logs.
> 
> Introduces `hf spaces logs` with `--build`, `--follow/-f`, and `--tail/-n` (including validation of incompatible flags), plus a small shared SSE streaming helper in `hf_api.py` that also replaces the bespoke Jobs SSE loop. Documentation and CLI reference are updated, and new CLI tests cover the new command behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7625a59411b8fe970b0b77b722d309253eacf5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->