### PR TITLE
Fix reference cycle in `hf_raise_for_status` causing delayed object destruction

### DIFF
--- a/src/huggingface_hub/utils/_http.py
+++ b/src/huggingface_hub/utils/_http.py
@@ -774,26 +774,17 @@ def hf_raise_for_status(response: httpx.Response, endpoint_name: str | None = No
 
         if error_code == "RevisionNotFound":
             message = f"{response.status_code} Client Error." + "\n\n" + f"Revision Not Found for url: {response.url}."
-            revision_err = _format(RevisionNotFoundError, message, response)
-            revision_err.repo_type = repo_type
-            revision_err.repo_id = repo_id
-            raise revision_err from e
+            raise _format(RevisionNotFoundError, message, response, repo_type=repo_type, repo_id=repo_id) from e
 
         elif error_code == "EntryNotFound":
             message = f"{response.status_code} Client Error." + "\n\n" + f"Entry Not Found for url: {response.url}."
-            entry_err = _format(RemoteEntryNotFoundError, message, response)
-            entry_err.repo_type = repo_type
-            entry_err.repo_id = repo_id
-            raise entry_err from e
+            raise _format(RemoteEntryNotFoundError, message, response, repo_type=repo_type, repo_id=repo_id) from e
 
         elif error_code == "GatedRepo":
             message = (
                 f"{response.status_code} Client Error." + "\n\n" + f"Cannot access gated repo for url {response.url}."
             )
-            gated_err = _format(GatedRepoError, message, response)
-            gated_err.repo_type = repo_type
-            gated_err.repo_id = repo_id
-            raise gated_err from e
+            raise _format(GatedRepoError, message, response, repo_type=repo_type, repo_id=repo_id) from e
 
         elif error_message == "Access to this resource is disabled.":
             message = (
@@ -817,9 +808,9 @@ def hf_raise_for_status(response: httpx.Response, endpoint_name: str | None = No
                 + "\nPlease make sure you specified the correct bucket id (namespace/name)."
                 + "\nIf the bucket is private, make sure you are authenticated and your token has the required permissions."
             )
-            bucket_err = _format(BucketNotFoundError, message, response)
-            bucket_err.bucket_id = _parse_bucket_id_from_url(request_url)
-            raise bucket_err from e
+            raise _format(
+                BucketNotFoundError, message, response, bucket_id=_parse_bucket_id_from_url(request_url)
+            ) from e
 
         elif error_code == "RepoNotFound" or (
             response.status_code == 401
@@ -841,10 +832,7 @@ def hf_raise_for_status(response: httpx.Response, endpoint_name: str | None = No
                 " make sure you are authenticated and your token has the required permissions."
                 + "\nFor more details, see https://huggingface.co/docs/huggingface_hub/authentication"
             )
-            repo_err = _format(RepositoryNotFoundError, message, response)
-            repo_err.repo_type = repo_type
-            repo_err.repo_id = repo_id
-            raise repo_err from e
+            raise _format(RepositoryNotFoundError, message, response, repo_type=repo_type, repo_id=repo_id) from e
 
         elif response.status_code == 400:
             message = (
@@ -919,7 +907,9 @@ def _warn_on_warning_headers(response: httpx.Response) -> None:
 _HfHubHTTPErrorT = TypeVar("_HfHubHTTPErrorT", bound=HfHubHTTPError)
 
 
-def _format(error_type: type[_HfHubHTTPErrorT], custom_message: str, response: httpx.Response) -> _HfHubHTTPErrorT:
+def _format(
+    error_type: type[_HfHubHTTPErrorT], custom_message: str, response: httpx.Response, **attrs: Any
+) -> _HfHubHTTPErrorT:
     server_errors = []
 
     # Retrieve server error from header
@@ -1009,7 +999,10 @@ def _format(error_type: type[_HfHubHTTPErrorT], custom_message: str, response: h
             final_error_message += request_id_message
 
     # Return
-    return error_type(final_error_message.strip(), response=response, server_message=server_message or None)
+    err = error_type(final_error_message.strip(), response=response, server_message=server_message or None)
+    for k, v in attrs.items():
+        setattr(err, k, v)
+    return err
 
 
 def _curlify(request: httpx.Request) -> str:

--- a/tests/test_utils_http.py
+++ b/tests/test_utils_http.py
@@ -12,7 +12,14 @@ import pytest
 from httpx import ConnectTimeout, HTTPError
 
 from huggingface_hub.constants import ENDPOINT
-from huggingface_hub.errors import BucketNotFoundError, HfHubHTTPError, OfflineModeIsEnabled, RepositoryNotFoundError
+from huggingface_hub.errors import (
+    BucketNotFoundError,
+    HfHubHTTPError,
+    OfflineModeIsEnabled,
+    RemoteEntryNotFoundError,
+    RepositoryNotFoundError,
+    RevisionNotFoundError,
+)
 from huggingface_hub.utils._http import (
     _WARNED_TOPICS,
     RateLimitInfo,
@@ -702,3 +709,54 @@ class TestParseBucketIdFromUrl:
 
     def test_http_url(self):
         assert _parse_bucket_id_from_url("http://localhost:8080/api/buckets/ns/name") == "ns/name"
+
+
+class TestNoReferenceCycleInRaise:
+    """Regression test: hf_raise_for_status must not create reference cycles.
+
+    See https://github.com/huggingface/huggingface_hub/pull/4084 for details.
+    When exceptions were stored in local variables before `raise ... from e`,
+    CPython reference cycles prevented deterministic cleanup, causing real
+    issues downstream (e.g. vLLM GPU memory not released).
+    """
+
+    def _make_response(self, error_code: str, status_code: int = 404) -> httpx.Response:
+        url = "https://huggingface.co/api/models/user/repo/revision/main/file.txt"
+        request = Mock(spec=httpx.Request)
+        request.url = httpx.URL(url)
+        response = Mock(spec=httpx.Response)
+        response.status_code = status_code
+        response.url = url
+        response.headers = httpx.Headers({"X-Error-Code": error_code})
+        response.json.return_value = {}
+        response.request = request
+        response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            str(status_code), request=request, response=response
+        )
+        return response
+
+    @pytest.mark.parametrize(
+        "error_code, exception_type",
+        [
+            ("RevisionNotFound", RevisionNotFoundError),
+            ("EntryNotFound", RemoteEntryNotFoundError),
+            ("RepoNotFound", RepositoryNotFoundError),
+        ],
+    )
+    def test_no_refcycle(self, error_code, exception_type):
+        import weakref
+
+        response = self._make_response(error_code)
+        ref = None
+        try:
+            hf_raise_for_status(response)
+        except exception_type as exc:
+            # Clear the traceback to isolate our fix from the inherent
+            # except-block cycle (exc.__traceback__ -> this frame -> exc).
+            # We only care that hf_raise_for_status itself does not create a
+            # cycle via intermediate local variables.
+            exc.__traceback__ = None
+            ref = weakref.ref(exc)
+        # After exiting the except block, the exception should be freed by
+        # refcount alone (no gc.collect() needed) if there is no cycle.
+        assert ref() is None, f"Reference cycle detected for {exception_type.__name__}"

--- a/tests/test_utils_http.py
+++ b/tests/test_utils_http.py
@@ -1,6 +1,7 @@
 import threading
 import time
 import unittest
+import weakref
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Generator, Optional
 from unittest.mock import Mock, call, patch
@@ -16,9 +17,7 @@ from huggingface_hub.errors import (
     BucketNotFoundError,
     HfHubHTTPError,
     OfflineModeIsEnabled,
-    RemoteEntryNotFoundError,
     RepositoryNotFoundError,
-    RevisionNotFoundError,
 )
 from huggingface_hub.utils._http import (
     _WARNED_TOPICS,
@@ -720,37 +719,22 @@ class TestNoReferenceCycleInRaise:
     issues downstream (e.g. vLLM GPU memory not released).
     """
 
-    def _make_response(self, error_code: str, status_code: int = 404) -> httpx.Response:
-        url = "https://huggingface.co/api/models/user/repo/revision/main/file.txt"
+    def test_no_refcycle(self):
+        url = "https://huggingface.co/api/models/user/repo"
         request = Mock(spec=httpx.Request)
         request.url = httpx.URL(url)
         response = Mock(spec=httpx.Response)
-        response.status_code = status_code
+        response.status_code = 404
         response.url = url
-        response.headers = httpx.Headers({"X-Error-Code": error_code})
+        response.headers = httpx.Headers({"X-Error-Code": "RepoNotFound"})
         response.json.return_value = {}
         response.request = request
-        response.raise_for_status.side_effect = httpx.HTTPStatusError(
-            str(status_code), request=request, response=response
-        )
-        return response
+        response.raise_for_status.side_effect = httpx.HTTPStatusError("404", request=request, response=response)
 
-    @pytest.mark.parametrize(
-        "error_code, exception_type",
-        [
-            ("RevisionNotFound", RevisionNotFoundError),
-            ("EntryNotFound", RemoteEntryNotFoundError),
-            ("RepoNotFound", RepositoryNotFoundError),
-        ],
-    )
-    def test_no_refcycle(self, error_code, exception_type):
-        import weakref
-
-        response = self._make_response(error_code)
         ref = None
         try:
             hf_raise_for_status(response)
-        except exception_type as exc:
+        except RepositoryNotFoundError as exc:
             # Clear the traceback to isolate our fix from the inherent
             # except-block cycle (exc.__traceback__ -> this frame -> exc).
             # We only care that hf_raise_for_status itself does not create a
@@ -759,4 +743,4 @@ class TestNoReferenceCycleInRaise:
             ref = weakref.ref(exc)
         # After exiting the except block, the exception should be freed by
         # refcount alone (no gc.collect() needed) if there is no cycle.
-        assert ref() is None, f"Reference cycle detected for {exception_type.__name__}"
+        assert ref() is None, "Reference cycle detected: exception prevented from being freed by refcount"

--- a/tests/test_utils_http.py
+++ b/tests/test_utils_http.py
@@ -13,12 +13,7 @@ import pytest
 from httpx import ConnectTimeout, HTTPError
 
 from huggingface_hub.constants import ENDPOINT
-from huggingface_hub.errors import (
-    BucketNotFoundError,
-    HfHubHTTPError,
-    OfflineModeIsEnabled,
-    RepositoryNotFoundError,
-)
+from huggingface_hub.errors import BucketNotFoundError, HfHubHTTPError, OfflineModeIsEnabled, RepositoryNotFoundError
 from huggingface_hub.utils._http import (
     _WARNED_TOPICS,
     RateLimitInfo,
@@ -743,4 +738,4 @@ class TestNoReferenceCycleInRaise:
             ref = weakref.ref(exc)
         # After exiting the except block, the exception should be freed by
         # refcount alone (no gc.collect() needed) if there is no cycle.
-        assert ref() is None, "Reference cycle detected: exception prevented from being freed by refcount"
+        assert ref() is None


### PR DESCRIPTION

### Why? PR equivalent to https://github.com/huggingface/huggingface_hub/pull/4084 but slightly cleaner. Should solved vLLM garbage collection problem (https://github.com/vllm-project/vllm/issues/38384). It seems that in https://github.com/huggingface/huggingface_hub/pull/3889 we've introduced a reference cycle issue in `hf_raise_for_status`, making it impossible to free-up memory correctly.

### I have tested the regression test introduced in this PR and it does fail on `main`

**Kudos to @yg7445 for investigating + suggesting the solution. This was not an easy bug to spot!**

---

## Summary

Fixes a CPython reference cycle in `hf_raise_for_status()` that prevents deterministic exception cleanup.

When exceptions are stored in local variables before `raise ... from e`, a reference cycle forms: `err.__cause__` → `e` → `e.__traceback__` → frame → `f_locals['err']` → back to start. This delays garbage collection and causes real issues downstream (e.g., vLLM GPU memory not released until cyclic GC runs). See vllm-project/vllm#38384.

Alternative approach to #4084: instead of introducing two new helper functions, this extends the existing `_format()` with `**attrs` so attributes (like `repo_type`, `repo_id`, `bucket_id`) are set inside `_format` and the exception is never stored in the caller's frame.

## Changes

- Extended `_format()` to accept `**attrs` keyword arguments, set as attributes on the error
- Converted all 5 call sites in `hf_raise_for_status` from local-variable pattern to inline `raise _format(...) from e`
- Added regression test using `weakref` to verify no reference cycle exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 8ba3871177887a96e5e1d19c013f24b082d006d0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->