### PR TITLE
Update staging ci user

### DIFF
--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -175,8 +175,8 @@ class HfApiEndpointsTest(HfApiCommonTest):
         assert info["name"] == USER
         assert info["fullname"] == FULL_NAME
         assert isinstance(info["orgs"], list)
-        valid_org = [org for org in info["orgs"] if org["name"] == "valid_org"][0]
-        assert valid_org["fullname"] == "Dummy Org"
+        valid_org = [org for org in info["orgs"] if org["name"] == "valid_org_hub"][0]
+        assert valid_org["fullname"] == "Dummy Hub Org"
 
     @patch("huggingface_hub.hf_api.get_token", return_value=TOKEN)
     def test_whoami_with_implicit_token_from_login(self, mock_get_token: Mock) -> None:

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2701,57 +2701,48 @@ class HfApiPublicProductionTest(unittest.TestCase):
 
 
 class HfApiPrivateTest(HfApiCommonTest):
-    def setUp(self) -> None:
-        super().setUp()
-        self.REPO_NAME = repo_name("private")
-        self._api.create_repo(repo_id=self.REPO_NAME, private=True)
-        self._api.create_repo(repo_id=self.REPO_NAME, private=True, repo_type="dataset")
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        cls.repo_id = f"{USER}/{repo_name('private')}"
+        cls._api.create_repo(repo_id=cls.repo_id, private=True)
+        cls._api.create_repo(repo_id=cls.repo_id, private=True, repo_type="dataset")
 
-    def tearDown(self) -> None:
-        self._api.delete_repo(repo_id=self.REPO_NAME)
-        self._api.delete_repo(repo_id=self.REPO_NAME, repo_type="dataset")
+    @classmethod
+    def tearDownClass(cls) -> None:
+        super().tearDownClass()
+        cls._api.delete_repo(repo_id=cls.repo_id)
+        cls._api.delete_repo(repo_id=cls.repo_id, repo_type="dataset")
 
     @patch("huggingface_hub.utils._headers.get_token", return_value=None)
     def test_model_info(self, mock_get_token: Mock) -> None:
-        with patch.object(self._api, "token", None):  # no default token
-            # Test we cannot access model info without a token
-            with self.assertRaisesRegex(
-                HfHubHTTPError,
-                re.compile(
-                    r"401 Client Error(.+)\(Request ID: .+\)(.*)Repository Not Found",
-                    flags=re.DOTALL,
-                ),
-            ):
-                _ = self._api.model_info(repo_id=f"{USER}/{self.REPO_NAME}")
+        # Auth => retrieve private model
+        self._api.model_info(repo_id=self.repo_id)
 
-            model_info = self._api.model_info(repo_id=f"{USER}/{self.REPO_NAME}", token=self._token)
-            self.assertIsInstance(model_info, ModelInfo)
+        # No auth => cannot access private model
+        with patch.object(self._api, "token", None):
+            with pytest.raises(HfHubHTTPError, match=r".*Repository Not Found.*"):
+                _ = self._api.model_info(repo_id=self.repo_id)
 
     @patch("huggingface_hub.utils._headers.get_token", return_value=None)
     def test_dataset_info(self, mock_get_token: Mock) -> None:
-        with patch.object(self._api, "token", None):  # no default token
-            # Test we cannot access model info without a token
-            with self.assertRaisesRegex(
-                HfHubHTTPError,
-                re.compile(
-                    r"401 Client Error(.+)\(Request ID: .+\)(.*)Repository Not Found",
-                    flags=re.DOTALL,
-                ),
-            ):
-                _ = self._api.dataset_info(repo_id=f"{USER}/{self.REPO_NAME}")
+        # Auth => retrieve private dataset
+        self._api.dataset_info(repo_id=self.repo_id)
 
-            dataset_info = self._api.dataset_info(repo_id=f"{USER}/{self.REPO_NAME}", token=self._token)
-            self.assertIsInstance(dataset_info, DatasetInfo)
+        # No auth => cannot access private dataset
+        with patch.object(self._api, "token", None):
+            with pytest.raises(HfHubHTTPError, match=r".*Repository Not Found.*"):
+                _ = self._api.dataset_info(repo_id=self.repo_id)
 
     def test_list_private_datasets(self):
-        orig = len(list(self._api.list_datasets(token=False)))
-        new = len(list(self._api.list_datasets(token=self._token)))
-        self.assertGreater(new, orig)
+        kwargs = {"sort": "created_at", "limit": 100}
+        assert all(dataset.id != self.repo_id for dataset in self._api.list_datasets(token=False, **kwargs))
+        assert any(dataset.id == self.repo_id for dataset in self._api.list_datasets(token=self._token, **kwargs))
 
     def test_list_private_models(self):
-        orig = len(list(self._api.list_models(token=False)))
-        new = len(list(self._api.list_models(token=self._token)))
-        self.assertGreater(new, orig)
+        kwargs = {"sort": "created_at", "limit": 100}
+        assert all(model.id != self.repo_id for model in self._api.list_models(token=False, **kwargs))
+        assert any(model.id == self.repo_id for model in self._api.list_models(token=self._token, **kwargs))
 
 
 @pytest.mark.usefixtures("fx_cache_dir")

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2753,12 +2753,6 @@ class HfApiPrivateTest(HfApiCommonTest):
         new = len(list(self._api.list_models(token=self._token)))
         self.assertGreater(new, orig)
 
-    @with_production_testing
-    def test_list_private_spaces(self):
-        orig = len(list(self._api.list_spaces(token=False)))
-        new = len(list(self._api.list_spaces(token=self._token)))
-        self.assertGreaterEqual(new, orig)
-
 
 @pytest.mark.usefixtures("fx_cache_dir")
 class UploadFolderMockedTest(unittest.TestCase):

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2735,12 +2735,12 @@ class HfApiPrivateTest(HfApiCommonTest):
                 _ = self._api.dataset_info(repo_id=self.repo_id)
 
     def test_list_private_datasets(self):
-        kwargs = {"sort": "created_at", "limit": 100}
+        kwargs = {"sort": "created_at", "limit": 100, "author": USER}
         assert all(dataset.id != self.repo_id for dataset in self._api.list_datasets(token=False, **kwargs))
         assert any(dataset.id == self.repo_id for dataset in self._api.list_datasets(token=self._token, **kwargs))
 
     def test_list_private_models(self):
-        kwargs = {"sort": "created_at", "limit": 100}
+        kwargs = {"sort": "created_at", "limit": 100, "author": USER}
         assert all(model.id != self.repo_id for model in self._api.list_models(token=False, **kwargs))
         assert any(model.id == self.repo_id for model in self._api.list_models(token=self._token, **kwargs))
 

--- a/tests/testing_constants.py
+++ b/tests/testing_constants.py
@@ -1,9 +1,9 @@
-USER = "__DUMMY_TRANSFORMERS_USER__"
+USER = "__DUMMY_HUB_USER__"
 FULL_NAME = "Dummy User"
 PASS = "__DUMMY_TRANSFORMERS_PASS__"
 
 # Not critical, only usable on the sandboxed CI instance.
-TOKEN = "hf_94wBhPGp6KrrTH3KDchhKpRxZwd6dmHWLL"
+TOKEN = "hf_HubCITokenXXXXXXXXXXXXXXXXXXXXX"
 
 # Used to create repos that we don't own (example: for gated repo)
 # Token is not critical. Also public in https://github.com/huggingface/datasets-server


### PR DESCRIPTION
Related to server-side update https://github.com/huggingface-internal/moon-landing/pull/17685 (private link).

This updates the dummy CI account we are using to test things. Goal is that we have our own user so tests from other CIs (transformers, diffusers, etc.) are not interfering with ours.

Note: requires the moon PR to be merged first.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only updates that change CI credentials/fixtures and tighten private-repo assertions; no production code paths are modified.
> 
> **Overview**
> Updates the staging CI test identity by switching `USER`/`TOKEN` constants to a dedicated Hub CI dummy account and adjusting the `whoami` org expectation.
> 
> Refactors `HfApiPrivateTest` to create/delete its private model+dataset once per class and makes the assertions more deterministic by explicitly checking that the private repo is *absent* from unauthenticated `list_models`/`list_datasets` results but *present* when authenticated, and by simplifying the expected unauthenticated error match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c8ef344577dbab51121eddb8b20976f0dd343e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->