### PR TITLE
[CLI] Add `hf spaces search` command with semantic search

### DIFF
--- a/docs/source/en/guides/manage-spaces.md
+++ b/docs/source/en/guides/manage-spaces.md
@@ -8,6 +8,31 @@ In this guide, we will see how to manage your Space runtime
 ([secrets](https://huggingface.co/docs/hub/spaces-overview#managing-secrets),
 [hardware](https://huggingface.co/docs/hub/spaces-gpus), and volumes) using `huggingface_hub`.
 
+## Search for Spaces
+
+You can search for Spaces on the Hub using semantic search with [`search_spaces`]. This uses embedding-based search for multi-word queries and full-text search for single-word queries.
+
+```py
+>>> from huggingface_hub import HfApi
+>>> api = HfApi()
+>>> results = list(api.search_spaces("generate image"))
+>>> results[0]
+SpaceSearchResult(id='mrfakename/Z-Image-Turbo', title='Z Image Turbo', sdk='gradio', likes=2867, ...)
+```
+
+You can filter results by SDK or tags:
+
+```py
+>>> results = api.search_spaces("chatbot", sdk="gradio", filter="mcp-server")
+```
+
+Or via CLI:
+
+```bash
+>>> hf spaces search "generate image"
+>>> hf spaces search "chatbot" --sdk gradio --limit 5
+```
+
 ## A simple example: configure secrets and hardware.
 
 Here is an end-to-end example to create and set up a Space on the Hub.

--- a/docs/source/en/guides/manage-spaces.md
+++ b/docs/source/en/guides/manage-spaces.md
@@ -13,9 +13,8 @@ In this guide, we will see how to manage your Space runtime
 You can search for Spaces on the Hub using semantic search with [`search_spaces`]. This uses embedding-based search for multi-word queries and full-text search for single-word queries.
 
 ```py
->>> from huggingface_hub import HfApi
->>> api = HfApi()
->>> results = list(api.search_spaces("generate image"))
+>>> from huggingface_hub import search_spaces
+>>> results = list(search_spaces("generate image"))
 >>> results[0]
 SpaceSearchResult(id='mrfakename/Z-Image-Turbo', title='Z Image Turbo', sdk='gradio', likes=2867, ...)
 ```

--- a/docs/source/en/guides/manage-spaces.md
+++ b/docs/source/en/guides/manage-spaces.md
@@ -22,7 +22,7 @@ SpaceSearchResult(id='mrfakename/Z-Image-Turbo', title='Z Image Turbo', sdk='gra
 You can filter results by SDK or tags:
 
 ```py
->>> results = api.search_spaces("chatbot", sdk="gradio", filter="mcp-server")
+>>> results = search_spaces("chatbot", sdk="gradio", filter="mcp-server")
 ```
 
 Or via CLI:

--- a/docs/source/en/guides/repository.md
+++ b/docs/source/en/guides/repository.md
@@ -121,6 +121,19 @@ RepoUrl('https://huggingface.co/spaces/nateraw/dreambooth-training',...)
 RepoUrl('https://huggingface.co/datasets/nateraw/gdpval',...)
 ```
 
+## Search for Spaces
+
+The Hub provides a semantic search API for discovering Spaces. You can search using natural language queries with [`search_spaces`]:
+
+```py
+>>> from huggingface_hub import search_spaces
+>>> results = list(search_spaces("generate image"))
+>>> results[0].id
+'mrfakename/Z-Image-Turbo'
+```
+
+For more details and filtering options, see the [Manage your Spaces](./manage-spaces#search-for-spaces) guide.
+
 ## Upload and download files
 
 Now that you have created your repository, you are interested in pushing changes to it and downloading files from it.

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -3538,8 +3538,8 @@ $ hf spaces search [OPTIONS] QUERY
 
 Examples
   $ hf spaces search "generate image"
-  $ hf spaces search "chatbot" --sdk gradio --limit 5
-  $ hf spaces search "animate image" --description --json
+  $ hf spaces search "identify objects in pictures" --sdk gradio --limit 5
+  $ hf spaces search "remove background from photo" --description --json
 
 Learn more
   Use `hf <command> --help` for more information about a command.

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -3367,6 +3367,7 @@ $ hf spaces [OPTIONS] COMMAND [ARGS]...
 * `hot-reload`: Hot-reload any Python file of a Space...
 * `info`: Get info about a space on the Hub.
 * `list`: List spaces on the Hub. [alias: ls]
+* `search`: Search spaces on the Hub using semantic...
 
 ### `hf spaces dev-mode`
 
@@ -3504,6 +3505,41 @@ $ hf spaces list [OPTIONS]
 Examples
   $ hf spaces ls --limit 10
   $ hf spaces ls --search "chatbot" --author huggingface
+
+Learn more
+  Use `hf <command> --help` for more information about a command.
+  Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
+
+
+### `hf spaces search`
+
+Search spaces on the Hub using semantic search.
+
+**Usage**:
+
+```console
+$ hf spaces search [OPTIONS] QUERY
+```
+
+**Arguments**:
+
+* `QUERY`: Search query.  [required]
+
+**Options**:
+
+* `--filter TEXT`: Filter by tags (e.g. 'text-classification'). Can be used multiple times.
+* `--sdk TEXT`: Filter by SDK (e.g. gradio, docker, static).
+* `--include-non-running / --no-include-non-running`: Include non-running spaces in results.  [default: no-include-non-running]
+* `--description / --no-description`: Show AI-generated descriptions.  [default: no-description]
+* `--limit INTEGER`: Limit the number of results.  [default: 10]
+* `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
+* `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
+* `--help`: Show this message and exit.
+
+Examples
+  $ hf spaces search "generate image"
+  $ hf spaces search "chatbot" --sdk gradio --limit 5
+  $ hf spaces search "animate image" --description --json
 
 Learn more
   Use `hf <command> --help` for more information about a command.

--- a/docs/source/en/package_reference/hf_api.md
+++ b/docs/source/en/package_reference/hf_api.md
@@ -133,6 +133,10 @@ models = hf_api.list_models()
 
 [[autodoc]] huggingface_hub.hf_api.SpaceInfo
 
+### SpaceSearchResult
+
+[[autodoc]] huggingface_hub._space_api.SpaceSearchResult
+
 ### TensorInfo
 
 [[autodoc]] huggingface_hub.utils.TensorInfo

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -189,6 +189,7 @@ _SUBMOD_ATTRS = {
         "RepoFolder",
         "RepoUrl",
         "SpaceInfo",
+        "SpaceSearchResult",
         "User",
         "UserLikes",
         "WebhookInfo",
@@ -322,6 +323,7 @@ _SUBMOD_ATTRS = {
         "run_job",
         "run_uv_job",
         "scale_to_zero_inference_endpoint",
+        "search_spaces",
         "set_space_sleep_time",
         "set_space_volumes",
         "space_info",
@@ -794,6 +796,7 @@ __all__ = [
     "SpaceHardware",
     "SpaceInfo",
     "SpaceRuntime",
+    "SpaceSearchResult",
     "SpaceStage",
     "SpaceStorage",
     "SpaceVariable",
@@ -1059,6 +1062,7 @@ __all__ = [
     "save_torch_state_dict",
     "scale_to_zero_inference_endpoint",
     "scan_cache_dir",
+    "search_spaces",
     "set_async_client_factory",
     "set_client_factory",
     "set_space_sleep_time",
@@ -1319,6 +1323,7 @@ if TYPE_CHECKING:  # pragma: no cover
         RepoFolder,  # noqa: F401
         RepoUrl,  # noqa: F401
         SpaceInfo,  # noqa: F401
+        SpaceSearchResult,  # noqa: F401
         User,  # noqa: F401
         UserLikes,  # noqa: F401
         WebhookInfo,  # noqa: F401
@@ -1452,6 +1457,7 @@ if TYPE_CHECKING:  # pragma: no cover
         run_job,  # noqa: F401
         run_uv_job,  # noqa: F401
         scale_to_zero_inference_endpoint,  # noqa: F401
+        search_spaces,  # noqa: F401
         set_space_sleep_time,  # noqa: F401
         set_space_volumes,  # noqa: F401
         space_info,  # noqa: F401

--- a/src/huggingface_hub/_space_api.py
+++ b/src/huggingface_hub/_space_api.py
@@ -249,3 +249,73 @@ class SpaceVariable:
         self.description = values.get("description")
         updated_at = values.get("updatedAt")
         self.updated_at = parse_datetime(updated_at) if updated_at is not None else None
+
+
+@dataclass
+class SpaceSearchResult:
+    """A single result from the Spaces semantic search API.
+
+    Returned by [`HfApi.search_spaces`].
+
+    Attributes:
+        id (`str`):
+            ID of the Space (e.g. `"username/repo-name"`).
+        author (`str`):
+            Author of the Space.
+        title (`str`):
+            Display title of the Space.
+        emoji (`str` or `None`):
+            Emoji icon of the Space.
+        sdk (`str` or `None`):
+            SDK used by the Space (e.g. `"gradio"`, `"docker"`, `"static"`).
+        likes (`int`):
+            Number of likes.
+        private (`bool`):
+            Whether the Space is private.
+        tags (`list[str]` or `None`):
+            List of tags.
+        runtime ([`SpaceRuntime`] or `None`):
+            Runtime information (stage, hardware, etc.).
+        ai_short_description (`str` or `None`):
+            AI-generated short description.
+        ai_category (`str` or `None`):
+            AI-generated category (e.g. `"Image Generation"`).
+        semantic_relevancy_score (`float` or `None`):
+            Semantic relevancy score (0-1) relative to the search query.
+        trending_score (`int` or `None`):
+            Trending score.
+    """
+
+    id: str
+    author: str
+    title: str
+    emoji: str | None
+    sdk: str | None
+    likes: int
+    private: bool
+    tags: list[str] | None
+    runtime: SpaceRuntime | None
+    ai_short_description: str | None
+    ai_category: str | None
+    semantic_relevancy_score: float | None
+    trending_score: int | None
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "SpaceSearchResult":
+        """Create a SpaceSearchResult from an API response dict."""
+        runtime = data.get("runtime")
+        return cls(
+            id=data["id"],
+            author=data.get("author", ""),
+            title=data.get("title", ""),
+            emoji=data.get("emoji"),
+            sdk=data.get("sdk"),
+            likes=data.get("likes", 0),
+            private=data.get("private", False),
+            tags=data.get("tags"),
+            runtime=SpaceRuntime(runtime) if runtime else None,
+            ai_short_description=data.get("ai_short_description"),
+            ai_category=data.get("ai_category"),
+            semantic_relevancy_score=data.get("semanticRelevancyScore"),
+            trending_score=data.get("trendingScore"),
+        )

--- a/src/huggingface_hub/_space_api.py
+++ b/src/huggingface_hub/_space_api.py
@@ -300,22 +300,18 @@ class SpaceSearchResult:
     semantic_relevancy_score: float | None
     trending_score: int | None
 
-    @classmethod
-    def from_dict(cls, data: dict) -> "SpaceSearchResult":
-        """Create a SpaceSearchResult from an API response dict."""
+    def __init__(self, data: dict) -> None:
         runtime = data.get("runtime")
-        return cls(
-            id=data["id"],
-            author=data.get("author", ""),
-            title=data.get("title", ""),
-            emoji=data.get("emoji"),
-            sdk=data.get("sdk"),
-            likes=data.get("likes", 0),
-            private=data.get("private", False),
-            tags=data.get("tags"),
-            runtime=SpaceRuntime(runtime) if runtime else None,
-            ai_short_description=data.get("ai_short_description"),
-            ai_category=data.get("ai_category"),
-            semantic_relevancy_score=data.get("semanticRelevancyScore"),
-            trending_score=data.get("trendingScore"),
-        )
+        self.id = data["id"]
+        self.author = data.get("author", "")
+        self.title = data.get("title", "")
+        self.emoji = data.get("emoji")
+        self.sdk = data.get("sdk")
+        self.likes = data.get("likes", 0)
+        self.private = data.get("private", False)
+        self.tags = data.get("tags")
+        self.runtime = SpaceRuntime(runtime) if runtime else None
+        self.ai_short_description = data.get("ai_short_description")
+        self.ai_category = data.get("ai_category")
+        self.semantic_relevancy_score = data.get("semanticRelevancyScore")
+        self.trending_score = data.get("trendingScore")

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -149,8 +149,8 @@ def spaces_info(
     "search",
     examples=[
         'hf spaces search "generate image"',
-        'hf spaces search "chatbot" --sdk gradio --limit 5',
-        'hf spaces search "animate image" --description --json',
+        'hf spaces search "identify objects in pictures" --sdk gradio --limit 5',
+        'hf spaces search "remove background from photo" --description --json',
     ],
 )
 def spaces_search(

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -26,6 +26,7 @@ Usage:
 
 import enum
 import functools
+import itertools
 import os
 import shlex
 import shutil
@@ -142,6 +143,52 @@ def spaces_info(
     except RevisionNotFoundError as e:
         raise CLIError(f"Revision '{revision}' not found on '{space_id}'.") from e
     out.dict(info)
+
+
+@spaces_cli.command(
+    "search",
+    examples=[
+        'hf spaces search "generate image"',
+        'hf spaces search "chatbot" --sdk gradio --limit 5',
+        'hf spaces search "animate image" --description --json',
+    ],
+)
+def spaces_search(
+    query: Annotated[str, typer.Argument(help="Search query.")],
+    filter: FilterOpt = None,
+    sdk: Annotated[str | None, typer.Option(help="Filter by SDK (e.g. gradio, docker, static).")] = None,
+    include_non_running: Annotated[bool, typer.Option(help="Include non-running spaces in results.")] = False,
+    description: Annotated[bool, typer.Option(help="Show AI-generated descriptions.")] = False,
+    limit: LimitOpt = 10,
+    format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
+    token: TokenOpt = None,
+) -> None:
+    """Search spaces on the Hub using semantic search."""
+    api = get_hf_api(token=token)
+    results = api.search_spaces(
+        query=query,
+        filter=filter,
+        sdk=sdk,
+        include_non_running=include_non_running,
+        token=token,
+    )
+    items = []
+    for r in itertools.islice(results, limit):
+        item: dict = {
+            "id": r.id,
+            "title": r.title,
+            "sdk": r.sdk,
+            "likes": r.likes,
+            "stage": r.runtime.stage if r.runtime else None,
+            "category": r.ai_category,
+            "score": round(r.semantic_relevancy_score, 2) if r.semantic_relevancy_score is not None else None,
+        }
+        if description:
+            item["description"] = r.ai_short_description
+        items.append(item)
+    out.table(items)
+    if not description:
+        out.hint("Use --description to show AI-generated descriptions.")
 
 
 @spaces_cli.command(

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -156,7 +156,7 @@ def spaces_info(
 def spaces_search(
     query: Annotated[str, typer.Argument(help="Search query.")],
     filter: FilterOpt = None,
-    sdk: Annotated[str | None, typer.Option(help="Filter by SDK (e.g. gradio, docker, static).")] = None,
+    sdk: Annotated[list[str] | None, typer.Option(help="Filter by SDK (e.g. gradio, docker, static).")] = None,
     include_non_running: Annotated[bool, typer.Option(help="Include non-running spaces in results.")] = False,
     description: Annotated[bool, typer.Option(help="Show AI-generated descriptions.")] = False,
     limit: LimitOpt = 10,

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -2962,7 +2962,7 @@ class HfApi:
         r = get_session().get(path, headers=headers, params=params)
         hf_raise_for_status(r)
         for item in r.json():
-            yield SpaceSearchResult.from_dict(item)
+            yield SpaceSearchResult(item)
 
     @validate_hf_hub_args
     def unlike(

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -13640,6 +13640,7 @@ dataset_info = api.dataset_info
 get_dataset_leaderboard = api.get_dataset_leaderboard
 
 list_spaces = api.list_spaces
+search_spaces = api.search_spaces
 space_info = api.space_info
 
 kernel_info = api.kernel_info

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -72,7 +72,7 @@ from ._dataset_viewer import DatasetParquetEntry
 from ._eval_results import EvalResultEntry, parse_eval_result_entries
 from ._inference_endpoints import InferenceEndpoint, InferenceEndpointScalingMetric, InferenceEndpointType
 from ._jobs_api import JobHardware, JobInfo, JobSpec, ScheduledJobInfo, _create_job_spec
-from ._space_api import SpaceHardware, SpaceRuntime, SpaceStorage, SpaceVariable, Volume
+from ._space_api import SpaceHardware, SpaceRuntime, SpaceSearchResult, SpaceStorage, SpaceVariable, Volume
 from ._upload_large_folder import upload_large_folder_internal
 from .community import (
     Discussion,
@@ -2904,6 +2904,65 @@ class HfApi:
             if "siblings" not in item:
                 item["siblings"] = None
             yield SpaceInfo(**item)
+
+    @validate_hf_hub_args
+    def search_spaces(
+        self,
+        query: str,
+        *,
+        filter: str | Iterable[str] | None = None,
+        sdk: str | list[str] | None = None,
+        include_non_running: bool = False,
+        token: bool | str | None = None,
+    ) -> Iterable[SpaceSearchResult]:
+        """Search Spaces on the Hub using semantic search.
+
+        This endpoint uses semantic search (embedding-based) for multi-word queries
+        and full-text search for single-word queries.
+
+        Args:
+            query (`str`):
+                The search query string.
+            filter (`str` or `Iterable[str]`, *optional*):
+                A string tag or list of tags to filter by.
+            sdk (`str` or `list[str]`, *optional*):
+                Filter by SDK (e.g. `"gradio"`, `"docker"`, `"static"`).
+            include_non_running (`bool`, *optional*):
+                Whether to include non-running Spaces in results. Defaults to `False`.
+            token (`bool` or `str`, *optional*):
+                A valid user access token (string). Defaults to the locally saved
+                token, which is the recommended method for authentication (see
+                https://huggingface.co/docs/huggingface_hub/quick-start#authentication).
+                To disable authentication, pass `False`.
+
+        Returns:
+            `Iterable[SpaceSearchResult]`: an iterable of [`SpaceSearchResult`] objects.
+
+        Example:
+            ```python
+            >>> from huggingface_hub import HfApi
+            >>> api = HfApi()
+            >>> results = list(api.search_spaces("generate image"))
+            >>> results[0].id
+            'mrfakename/Z-Image-Turbo'
+            >>> results[0].ai_category
+            'Image Generation'
+            ```
+        """
+        path = f"{self.endpoint}/api/spaces/semantic-search"
+        headers = self._build_hf_headers(token=token)
+        params: dict[str, Any] = {"q": query}
+        if filter is not None:
+            params["filter"] = filter
+        if sdk is not None:
+            params["sdk"] = sdk
+        if include_non_running:
+            params["includeNonRunning"] = True
+
+        r = get_session().get(path, headers=headers, params=params)
+        hf_raise_for_status(r)
+        for item in r.json():
+            yield SpaceSearchResult.from_dict(item)
 
     @validate_hf_hub_args
     def unlike(

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -65,6 +65,7 @@ from huggingface_hub.hf_api import (
     RepoUrl,
     SpaceInfo,
     SpaceRuntime,
+    SpaceSearchResult,
     User,
     WebhookInfo,
     WebhookWatchedItem,
@@ -2580,6 +2581,20 @@ class HfApiPublicProductionTest(unittest.TestCase):
         # `expand` cannot be used with full
         with self.assertRaises(ValueError):
             next(self._api.list_spaces(expand=["author"], full=True))
+
+    def test_search_spaces(self):
+        results = list(self._api.search_spaces("generate image"))
+        assert len(results) > 0
+        result = results[0]
+        assert isinstance(result, SpaceSearchResult)
+        assert result.id
+        assert result.author
+        assert result.title
+        assert result.likes >= 0
+        assert result.semantic_relevancy_score is not None
+        assert result.semantic_relevancy_score > 0
+        assert result.runtime is not None
+        assert isinstance(result.runtime, SpaceRuntime)
 
     def test_get_paths_info(self):
         paths_info = self._api.get_paths_info(


### PR DESCRIPTION

This PR introduces `search_spaces()` to perform semantic search of Spaces on the Hub (this endpoint: https://huggingface.co/api/spaces/semantic-search?q=generate+image)

Also adds `hf spaces search <query>` CLI command.

### `hf spaces search "generate image"`

```
ID                                  TITLE                       SDK    LIKES STAGE   CATEGORY         SCORE
----------------------------------- --------------------------- ------ ----- ------- ---------------- -----
mrfakename/Z-Image-Turbo            Z Image Turbo               gradio 2867  RUNNING Image Generation 0.9  
r3gm/wan2-2-fp8da-aoti-preview      Wan2.2 14B Preview          gradio 2016  RUNNING Video Generation 0.81 
black-forest-labs/FLUX.2-dev        FLUX.2 [dev]                gradio 825   RUNNING Image Generation 0.77 
black-forest-labs/FLUX.2-klein-9B   FLUX.2 [Klein] 9B           gradio 739   RUNNING Image Generation 0.76 
Kwai-Kolors/Kolors-Virtual-Try-On   Kolors Virtual Try-On       gradio 10028 RUNNING Image Editing    0.75 
multimodalart/nano-banana           Nano Banana PRO             gradio 663   RUNNING Image Generation 0.75 
microsoft/TRELLIS.2                 TRELLIS.2                   gradio 1394  RUNNING 3D Modeling      0.74 
black-forest-labs/FLUX.1-dev        FLUX.1 [dev]                gradio 9427  RUNNING Image Generation 0.74 
r3gm/wan2-2-fp8da-aoti-preview2     Wan2.2 14B Fast Preview     gradio 667   RUNNING Video Generation 0.74 
prithivMLmods/FireRed-Image-Edit... FireRed Image Edit 1.0 Fast gradio 803   RUNNING Image Editing    0.73 
Hint: Use --description to show AI-generated descriptions.
```

### `hf spaces search "chatbot" --sdk gradio --limit 2`

```
ID                      TITLE   SDK    LIKES STAGE   CATEGORY SCORE
----------------------- ------- ------ ----- ------- -------- -----
BarBar288/Chatbot       Chatbot gradio 4     RUNNING Other    0.5  
Pankajpandey221/Chatbot Chatbot gradio 2     RUNNING Chatbots 0.47 
Hint: Use --description to show AI-generated descriptions.
```

### `hf spaces search "remove background from photo" --description --json  --limit 1| jq `

```
[
  {
    "id": "briaai/BRIA-RMBG-1.4",
    "title": "BRIA RMBG 1.4",
    "sdk": "gradio",
    "likes": 871,
    "stage": "RUNNING",
    "category": "Image Editing",
    "score": 0.87,
    "description": "Remove background from your photos instantly"
  }
]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API/CLI and documentation changes with minimal impact on existing behavior; main risk is correctness/compatibility with the new `/api/spaces/semantic-search` response shape.
> 
> **Overview**
> Adds a new `HfApi.search_spaces` method (and top-level `search_spaces`) that calls the Hub’s `/api/spaces/semantic-search` endpoint and returns structured `SpaceSearchResult` objects.
> 
> Introduces a new `hf spaces search` CLI command that renders search results (optionally including AI-generated descriptions) and updates docs/API reference to document the new search capability, with a basic test covering the new API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f23ec9972fae7f070bcbaa9f7939a67f0a10b90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->