### PR TITLE
Update copy files CLI docs

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -671,9 +671,9 @@ To filter by prefix, append the prefix to the bucket path:
 >>> hf buckets list username/my-bucket/sub -R
 ```
 
-### Copy single files
+### Copy files
 
-Use `hf buckets cp` to copy individual files to and from a bucket, or to copy any file hosted on the Hub to a Bucket.
+Use `hf buckets cp` to copy local files to and from a bucket, or to copy any files hosted on the Hub to a Bucket.
 
 To upload a file:
 
@@ -715,7 +715,7 @@ To copy from a repo or a bucket on the Hub:
 
 Notes:
 
-- Bucket-to-repo copy is not supported.
+- Bucket-to-repo copy is not yet supported.
 
 ### Sync directories
 

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -229,8 +229,8 @@ $ hf buckets cp [OPTIONS] SRC [DST]
 
 **Arguments**:
 
-* `SRC`: Source: local file, HF handle (hf://...), or - for stdin  [required]
-* `[DST]`: Destination: local path, HF handle (hf://...), or - for stdout
+* `SRC`: Source: local file, model or dataset handle (hf://...), or - for stdin  [required]
+* `[DST]`: Destination: local path, model or dataset handle (hf://...), or - for stdout
 
 **Options**:
 

--- a/src/huggingface_hub/cli/buckets.py
+++ b/src/huggingface_hub/cli/buckets.py
@@ -937,9 +937,9 @@ def sync(
     ],
 )
 def cp(
-    src: Annotated[str, typer.Argument(help="Source: local file, HF handle (hf://...), or - for stdin")],
+    src: Annotated[str, typer.Argument(help="Source: local file, model or dataset handle (hf://...), or - for stdin")],
     dst: Annotated[
-        str | None, typer.Argument(help="Destination: local path, HF handle (hf://...), or - for stdout")
+        str | None, typer.Argument(help="Destination: local path, model or dataset handle (hf://...), or - for stdout")
     ] = None,
     quiet: QuietOpt = False,
     token: TokenOpt = None,


### PR DESCRIPTION
Small doc update.

`hf buckets cp` is not only for files, works also on remote folders.

context (private DMs) https://huggingface.slack.com/archives/C07KX53FZTK/p1776090965972179


<img width="1594" height="488" alt="image" src="https://github.com/user-attachments/assets/ac5182f4-b415-4ead-8900-81cad1540fbf" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/CLI help-text only changes; no functional behavior or security-sensitive logic is modified.
> 
> **Overview**
> Updates `hf buckets cp` documentation and help text to better reflect supported sources/destinations (local files plus model/dataset `hf://...` handles, including folder-style paths for repo/bucket copies).
> 
> Also tweaks wording in the CLI guide to remove the “single files” framing and clarifies that bucket-to-repo copy is *not yet* supported.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed82a1601433a912338d9bf277b365e0441bb14d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->