### PR TITLE
Fix copy files docs

### DIFF
--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -229,8 +229,8 @@ $ hf buckets cp [OPTIONS] SRC [DST]
 
 **Arguments**:
 
-* `SRC`: Source: local file, model or dataset handle (hf://...), or - for stdin  [required]
-* `[DST]`: Destination: local path, model or dataset handle (hf://...), or - for stdout
+* `SRC`: Source: local file, any hf:// handle (model, dataset, bucket), or - for stdin  [required]
+* `[DST]`: Destination: local path, bucket handle (hf://...), or - for stdout
 
 **Options**:
 

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -230,7 +230,7 @@ $ hf buckets cp [OPTIONS] SRC [DST]
 **Arguments**:
 
 * `SRC`: Source: local file, any hf:// handle (model, dataset, bucket), or - for stdin  [required]
-* `[DST]`: Destination: local path, bucket handle (hf://...), or - for stdout
+* `[DST]`: Destination: local path, bucket hf://... handle, or - for stdout
 
 **Options**:
 

--- a/src/huggingface_hub/cli/buckets.py
+++ b/src/huggingface_hub/cli/buckets.py
@@ -941,7 +941,7 @@ def cp(
         str, typer.Argument(help="Source: local file, any hf:// handle (model, dataset, bucket), or - for stdin")
     ],
     dst: Annotated[
-        str | None, typer.Argument(help="Destination: local path, bucket handle (hf://...), or - for stdout")
+        str | None, typer.Argument(help="Destination: local path, bucket hf://... handle, or - for stdout")
     ] = None,
     quiet: QuietOpt = False,
     token: TokenOpt = None,

--- a/src/huggingface_hub/cli/buckets.py
+++ b/src/huggingface_hub/cli/buckets.py
@@ -937,9 +937,11 @@ def sync(
     ],
 )
 def cp(
-    src: Annotated[str, typer.Argument(help="Source: local file, model or dataset handle (hf://...), or - for stdin")],
+    src: Annotated[
+        str, typer.Argument(help="Source: local file, any hf:// handle (model, dataset, bucket), or - for stdin")
+    ],
     dst: Annotated[
-        str | None, typer.Argument(help="Destination: local path, model or dataset handle (hf://...), or - for stdout")
+        str | None, typer.Argument(help="Destination: local path, bucket handle (hf://...), or - for stdout")
     ] = None,
     quiet: QuietOpt = False,
     token: TokenOpt = None,


### PR DESCRIPTION
fixes https://github.com/huggingface/huggingface_hub/pull/4095#discussion_r3074619597 cc @julien-c 

<img width="1658" height="158" alt="image" src="https://github.com/user-attachments/assets/54c4c328-c6a4-4a82-84c6-f94d3b5fbece" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates CLI argument help text and generated docs, with no functional changes to copy behavior.
> 
> **Overview**
> Clarifies `hf buckets cp` argument descriptions in both the generated CLI reference (`docs/.../cli.md`) and the Typer command definition (`buckets.py`).
> 
> `SRC` is now documented as accepting *any* `hf://` handle (model/dataset/bucket) while `DST` is documented as a bucket `hf://...` handle (or local path/stdout), aligning docs/help with actual supported usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd5c3b4199d3c9502ce376464e5e3705c58a614b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->