### PR TITLE
[CLI] Migrate `repos` and `repo-files` to `out` singleton + add confirmation to `hf repos delete`

### DIFF
--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -2986,6 +2986,7 @@ $ hf repos delete [OPTIONS] REPO_ID
 * `--type, --repo-type [model|dataset|space]`: The type of repository (model, dataset, or space).  [default: model]
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `--missing-ok / --no-missing-ok`: If set to True, do not raise an error if repo does not exist.  [default: no-missing-ok]
+* `-y, --yes`: Answer Yes to prompt automatically.
 * `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
 * `--help`: Show this message and exit.
 

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -2879,6 +2879,7 @@ $ hf repos branch create [OPTIONS] REPO_ID BRANCH
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `--type, --repo-type [model|dataset|space]`: The type of repository (model, dataset, or space).  [default: model]
 * `--exist-ok / --no-exist-ok`: If set to True, do not raise an error if branch already exists.  [default: no-exist-ok]
+* `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
 * `--help`: Show this message and exit.
 
 Examples
@@ -2909,6 +2910,7 @@ $ hf repos branch delete [OPTIONS] REPO_ID BRANCH
 
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `--type, --repo-type [model|dataset|space]`: The type of repository (model, dataset, or space).  [default: model]
+* `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
 * `--help`: Show this message and exit.
 
 Examples
@@ -2951,6 +2953,7 @@ $ hf repos create [OPTIONS] REPO_ID
 * `-e, --env TEXT`: Set environment variables. E.g. --env ENV=value
 * `--env-file TEXT`: Read in a file of environment variables.
 * `-v, --volume TEXT`: Mount a volume. Format: hf://[TYPE/]SOURCE:/MOUNT_PATH[:ro]. TYPE is one of: models, datasets, spaces, buckets. TYPE defaults to models if omitted. models, datasets and spaces are always mounted read-only. buckets are read+write by default.E.g. -v hf://gpt2:/data or -v hf://datasets/org/ds:/data or -v hf://buckets/org/b:/mnt:ro
+* `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
 * `--help`: Show this message and exit.
 
 Examples
@@ -2983,6 +2986,7 @@ $ hf repos delete [OPTIONS] REPO_ID
 * `--type, --repo-type [model|dataset|space]`: The type of repository (model, dataset, or space).  [default: model]
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `--missing-ok / --no-missing-ok`: If set to True, do not raise an error if repo does not exist.  [default: no-missing-ok]
+* `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
 * `--help`: Show this message and exit.
 
 Examples
@@ -3016,6 +3020,7 @@ $ hf repos delete-files [OPTIONS] REPO_ID PATTERNS...
 * `--commit-description TEXT`: The description of the generated commit.
 * `--create-pr / --no-create-pr`: Whether to create a new Pull Request for these changes.  [default: no-create-pr]
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
+* `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
 * `--help`: Show this message and exit.
 
 Examples
@@ -3059,6 +3064,7 @@ $ hf repos duplicate [OPTIONS] FROM_ID [TO_ID]
 * `-e, --env TEXT`: Set environment variables. E.g. --env ENV=value
 * `--env-file TEXT`: Read in a file of environment variables.
 * `-v, --volume TEXT`: Mount a volume. Format: hf://[TYPE/]SOURCE:/MOUNT_PATH[:ro]. TYPE is one of: models, datasets, spaces, buckets. TYPE defaults to models if omitted. models, datasets and spaces are always mounted read-only. buckets are read+write by default.E.g. -v hf://gpt2:/data or -v hf://datasets/org/ds:/data or -v hf://buckets/org/b:/mnt:ro
+* `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
 * `--help`: Show this message and exit.
 
 Examples
@@ -3090,6 +3096,7 @@ $ hf repos move [OPTIONS] FROM_ID TO_ID
 
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `--type, --repo-type [model|dataset|space]`: The type of repository (model, dataset, or space).  [default: model]
+* `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
 * `--help`: Show this message and exit.
 
 Examples
@@ -3122,6 +3129,7 @@ $ hf repos settings [OPTIONS] REPO_ID
 * `--protected`: Whether to make the Space protected (Spaces only). Ignored if the repo already exists.
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `--type, --repo-type [model|dataset|space]`: The type of repository (model, dataset, or space).  [default: model]
+* `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
 * `--help`: Show this message and exit.
 
 Examples
@@ -3175,6 +3183,7 @@ $ hf repos tag create [OPTIONS] REPO_ID TAG
 * `--revision TEXT`: Git revision id which can be a branch name, a tag, or a commit hash.
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `--type, --repo-type [model|dataset|space]`: The type of repository (model, dataset, or space).  [default: model]
+* `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
 * `--help`: Show this message and exit.
 
 Examples
@@ -3206,6 +3215,7 @@ $ hf repos tag delete [OPTIONS] REPO_ID TAG
 * `-y, --yes`: Answer Yes to prompt automatically
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `--type, --repo-type [model|dataset|space]`: The type of repository (model, dataset, or space).  [default: model]
+* `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
 * `--help`: Show this message and exit.
 
 Examples
@@ -3234,6 +3244,7 @@ $ hf repos tag list [OPTIONS] REPO_ID
 
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `--type, --repo-type [model|dataset|space]`: The type of repository (model, dataset, or space).  [default: model]
+* `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
 * `--help`: Show this message and exit.
 
 Examples

--- a/src/huggingface_hub/cli/repo_files.py
+++ b/src/huggingface_hub/cli/repo_files.py
@@ -16,18 +16,21 @@
 Kept for backward compatibility. Users are nudged to use `hf repos delete-files` instead.
 """
 
-import sys
 from typing import Annotated
 
 import typer
 
-from huggingface_hub import logging
-from huggingface_hub.utils import ANSI
-
-from ._cli_utils import RepoIdArg, RepoType, RepoTypeOpt, RevisionOpt, TokenOpt, get_hf_api, typer_factory
-
-
-logger = logging.get_logger(__name__)
+from ._cli_utils import (
+    FormatWithAutoOpt,
+    RepoIdArg,
+    RepoType,
+    RepoTypeOpt,
+    RevisionOpt,
+    TokenOpt,
+    get_hf_api,
+    typer_factory,
+)
+from ._output import OutputFormatWithAuto, out
 
 
 repo_files_cli = typer_factory(
@@ -67,11 +70,9 @@ def repo_files_delete(
         ),
     ] = False,
     token: TokenOpt = None,
+    format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
 ) -> None:
-    print(
-        ANSI.yellow("FutureWarning: `hf repo-files delete` is deprecated. Use `hf repos delete-files` instead."),
-        file=sys.stderr,
-    )
+    out.warning("`hf repo-files delete` is deprecated. Use `hf repos delete-files` instead.")
     api = get_hf_api(token=token)
     url = api.delete_files(
         delete_patterns=patterns,
@@ -82,5 +83,4 @@ def repo_files_delete(
         commit_description=commit_description,
         create_pr=create_pr,
     )
-    print(f"Files correctly deleted from repo. Commit: {url}.")
-    logging.set_verbosity_warning()
+    out.result("Files deleted", repo_id=repo_id, commit_url=url)

--- a/src/huggingface_hub/cli/repos.py
+++ b/src/huggingface_hub/cli/repos.py
@@ -246,9 +246,18 @@ def repo_delete(
             help="If set to True, do not raise an error if repo does not exist.",
         ),
     ] = False,
+    yes: Annotated[
+        bool,
+        typer.Option(
+            "-y",
+            "--yes",
+            help="Answer Yes to prompt automatically.",
+        ),
+    ] = False,
     format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
 ) -> None:
     """Delete a repo from the Hub. This is an irreversible operation."""
+    out.confirm(f"You are about to permanently delete {repo_type.value} '{repo_id}'. Proceed?", yes=yes)
     api = get_hf_api(token=token)
     api.delete_repo(
         repo_id=repo_id,

--- a/src/huggingface_hub/cli/repos.py
+++ b/src/huggingface_hub/cli/repos.py
@@ -232,7 +232,7 @@ def repo_duplicate(
         space_variables=env_map_to_key_value_list(parse_env_map(env, env_file)),
         space_volumes=parse_volumes(volume),
     )
-    out.result("Repo duplicated", from_id=from_id, repo_id=repo_url.repo_id, url=str(repo_url))
+    out.result("Repo duplicated", from_id=from_id, to_id=repo_url.repo_id, url=str(repo_url))
 
 
 @repos_cli.command("delete", examples=["hf repos delete my-model"])
@@ -491,7 +491,7 @@ def tag_list(
         refs = api.list_repo_refs(repo_id=repo_id, repo_type=repo_type_str)
     except RepositoryNotFoundError as e:
         raise CLIError(f"{repo_type_str.capitalize()} '{repo_id}' not found.") from e
-    items = [{"name": t.name, "target_commit": t.target_commit} for t in refs.tags]
+    items = [{"name": t.name, "target_commit": t.target_commit, "ref": t.ref} for t in refs.tags]
     out.table(items)
 
 

--- a/src/huggingface_hub/cli/repos.py
+++ b/src/huggingface_hub/cli/repos.py
@@ -25,18 +25,17 @@ Usage:
 """
 
 import enum
-import sys
 from typing import Annotated
 
 import typer
 
 from huggingface_hub import SpaceHardware, SpaceStorage
 from huggingface_hub.errors import CLIError, HfHubHTTPError, RepositoryNotFoundError, RevisionNotFoundError
-from huggingface_hub.utils import ANSI
 
 from ._cli_utils import (
     EnvFileOpt,
     EnvOpt,
+    FormatWithAutoOpt,
     PrivateOpt,
     RepoIdArg,
     RepoType,
@@ -52,7 +51,7 @@ from ._cli_utils import (
     parse_volumes,
     typer_factory,
 )
-from ._output import out
+from ._output import OutputFormatWithAuto, out
 
 
 repos_cli = typer_factory(help="Manage repos on the Hub.")
@@ -61,10 +60,7 @@ repos_cli = typer_factory(help="Manage repos on the Hub.")
 @repos_cli.callback(invoke_without_command=True)
 def _repos_callback(ctx: typer.Context) -> None:
     if ctx.info_name == "repo":
-        print(
-            ANSI.yellow("FutureWarning: `hf repo` is deprecated in favor of `hf repos`."),
-            file=sys.stderr,
-        )
+        out.warning("`hf repo` is deprecated in favor of `hf repos`.")
 
 
 tag_cli = typer_factory(help="Manage tags for a repo on the Hub.")
@@ -161,6 +157,7 @@ def repo_create(
     env: EnvOpt = None,
     env_file: EnvFileOpt = None,
     volume: VolumesOpt = None,
+    format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
 ) -> None:
     """Create a new repo on the Hub."""
     api = get_hf_api(token=token)
@@ -179,8 +176,7 @@ def repo_create(
         space_variables=env_map_to_key_value_list(parse_env_map(env, env_file)),
         space_volumes=parse_volumes(volume),
     )
-    print(f"Successfully created {ANSI.bold(repo_url.repo_id)} on the Hub.")
-    print(f"Your repo is now available at {ANSI.bold(repo_url)}")
+    out.result("Repo created", repo_id=repo_url.repo_id, url=str(repo_url))
 
 
 @repos_cli.command(
@@ -218,6 +214,7 @@ def repo_duplicate(
     env: EnvOpt = None,
     env_file: EnvFileOpt = None,
     volume: VolumesOpt = None,
+    format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
 ) -> None:
     """Duplicate a repo on the Hub (model, dataset, or Space)."""
     api = get_hf_api(token=token)
@@ -235,8 +232,7 @@ def repo_duplicate(
         space_variables=env_map_to_key_value_list(parse_env_map(env, env_file)),
         space_volumes=parse_volumes(volume),
     )
-    print(f"Successfully duplicated {ANSI.bold(from_id)} to {ANSI.bold(repo_url.repo_id)} on the Hub.")
-    print(f"Your repo is now available at {ANSI.bold(repo_url)}")
+    out.result("Repo duplicated", from_id=from_id, repo_id=repo_url.repo_id, url=str(repo_url))
 
 
 @repos_cli.command("delete", examples=["hf repos delete my-model"])
@@ -250,6 +246,7 @@ def repo_delete(
             help="If set to True, do not raise an error if repo does not exist.",
         ),
     ] = False,
+    format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
 ) -> None:
     """Delete a repo from the Hub. This is an irreversible operation."""
     api = get_hf_api(token=token)
@@ -258,7 +255,7 @@ def repo_delete(
         repo_type=repo_type.value,
         missing_ok=missing_ok,
     )
-    print(f"Successfully deleted {ANSI.bold(repo_id)} on the Hub.")
+    out.result("Repo deleted", repo_id=repo_id)
 
 
 @repos_cli.command("move", examples=["hf repos move old-namespace/my-model new-namespace/my-model"])
@@ -267,6 +264,7 @@ def repo_move(
     to_id: RepoIdArg,
     token: TokenOpt = None,
     repo_type: RepoTypeOpt = RepoType.model,
+    format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
 ) -> None:
     """Move a repository from a namespace to another namespace."""
     api = get_hf_api(token=token)
@@ -275,7 +273,7 @@ def repo_move(
         to_id=to_id,
         repo_type=repo_type.value,
     )
-    print(f"Successfully moved {ANSI.bold(from_id)} to {ANSI.bold(to_id)} on the Hub.")
+    out.result("Repo moved", from_id=from_id, to_id=to_id)
 
 
 @repos_cli.command(
@@ -299,6 +297,7 @@ def repo_settings(
     protected: ProtectedOpt = None,
     token: TokenOpt = None,
     repo_type: RepoTypeOpt = RepoType.model,
+    format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
 ) -> None:
     """Update the settings of a repository."""
     api = get_hf_api(token=token)
@@ -308,7 +307,7 @@ def repo_settings(
         visibility="private" if private else "public" if public else "protected" if protected else None,  # type: ignore [arg-type]
         repo_type=repo_type.value,
     )
-    print(f"Successfully updated the settings of {ANSI.bold(repo_id)} on the Hub.")
+    out.result("Repo settings updated", repo_id=repo_id)
 
 
 @repos_cli.command(
@@ -348,6 +347,7 @@ def repo_delete_files(
         ),
     ] = False,
     token: TokenOpt = None,
+    format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
 ) -> None:
     """Delete files from a repo on the Hub."""
     api = get_hf_api(token=token)
@@ -360,7 +360,7 @@ def repo_delete_files(
         commit_description=commit_description,
         create_pr=create_pr,
     )
-    print(f"Files correctly deleted from repo. Commit: {url}.")
+    out.result("Files deleted", repo_id=repo_id, commit_url=url)
 
 
 @branch_cli.command(
@@ -387,6 +387,7 @@ def branch_create(
             help="If set to True, do not raise an error if branch already exists.",
         ),
     ] = False,
+    format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
 ) -> None:
     """Create a new branch for a repo on the Hub."""
     api = get_hf_api(token=token)
@@ -397,7 +398,7 @@ def branch_create(
         repo_type=repo_type.value,
         exist_ok=exist_ok,
     )
-    print(f"Successfully created {ANSI.bold(branch)} branch on {repo_type.value} {ANSI.bold(repo_id)}")
+    out.result("Branch created", branch=branch, repo_type=repo_type.value, repo_id=repo_id)
 
 
 @branch_cli.command("delete", examples=["hf repos branch delete my-model dev"])
@@ -411,6 +412,7 @@ def branch_delete(
     ],
     token: TokenOpt = None,
     repo_type: RepoTypeOpt = RepoType.model,
+    format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
 ) -> None:
     """Delete a branch from a repo on the Hub."""
     api = get_hf_api(token=token)
@@ -419,7 +421,7 @@ def branch_delete(
         branch=branch,
         repo_type=repo_type.value,
     )
-    print(f"Successfully deleted {ANSI.bold(branch)} branch on {repo_type.value} {ANSI.bold(repo_id)}")
+    out.result("Branch deleted", branch=branch, repo_type=repo_type.value, repo_id=repo_id)
 
 
 @tag_cli.command(
@@ -448,11 +450,11 @@ def tag_create(
     revision: RevisionOpt = None,
     token: TokenOpt = None,
     repo_type: RepoTypeOpt = RepoType.model,
+    format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
 ) -> None:
     """Create a tag for a repo."""
     repo_type_str = repo_type.value
     api = get_hf_api(token=token)
-    print(f"You are about to create tag {ANSI.bold(tag)} on {repo_type_str} {ANSI.bold(repo_id)}")
     try:
         api.create_tag(repo_id=repo_id, tag=tag, tag_message=message, revision=revision, repo_type=repo_type_str)
     except RepositoryNotFoundError as e:
@@ -463,7 +465,7 @@ def tag_create(
         if e.response.status_code == 409:
             raise CLIError(f"Tag '{tag}' already exists on '{repo_id}'.") from e
         raise
-    print(f"Tag {ANSI.bold(tag)} created on {ANSI.bold(repo_id)}")
+    out.result("Tag created", tag=tag, repo_type=repo_type_str, repo_id=repo_id)
 
 
 @tag_cli.command("list | ls", examples=["hf repos tag list my-model"])
@@ -471,6 +473,7 @@ def tag_list(
     repo_id: RepoIdArg,
     token: TokenOpt = None,
     repo_type: RepoTypeOpt = RepoType.model,
+    format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
 ) -> None:
     """List tags for a repo."""
     repo_type_str = repo_type.value
@@ -479,12 +482,8 @@ def tag_list(
         refs = api.list_repo_refs(repo_id=repo_id, repo_type=repo_type_str)
     except RepositoryNotFoundError as e:
         raise CLIError(f"{repo_type_str.capitalize()} '{repo_id}' not found.") from e
-    if len(refs.tags) == 0:
-        print("No tags found")
-        raise typer.Exit(code=0)
-    print(f"Tags for {repo_type_str} {ANSI.bold(repo_id)}:")
-    for t in refs.tags:
-        print(t.name)
+    items = [{"name": t.name, "target_commit": t.target_commit} for t in refs.tags]
+    out.table(items)
 
 
 @tag_cli.command("delete", examples=["hf repos tag delete my-model v1.0"])
@@ -506,10 +505,11 @@ def tag_delete(
     ] = False,
     token: TokenOpt = None,
     repo_type: RepoTypeOpt = RepoType.model,
+    format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
 ) -> None:
     """Delete a tag for a repo."""
     repo_type_str = repo_type.value
-    print(f"You are about to delete tag {ANSI.bold(tag)} on {repo_type_str} {ANSI.bold(repo_id)}")
+    out.text(f"You are about to delete tag {tag} on {repo_type_str} {repo_id}")
     out.confirm("Proceed?", yes=yes)
     api = get_hf_api(token=token)
     try:
@@ -518,4 +518,4 @@ def tag_delete(
         raise CLIError(f"{repo_type_str.capitalize()} '{repo_id}' not found.") from e
     except RevisionNotFoundError as e:
         raise CLIError(f"Tag '{tag}' not found on '{repo_id}'.") from e
-    print(f"Tag {ANSI.bold(tag)} deleted on {ANSI.bold(repo_id)}")
+    out.result("Tag deleted", tag=tag, repo_type=repo_type_str, repo_id=repo_id)


### PR DESCRIPTION
 Part of #3979.

This PR migrates all `repos` and `repo-files` CLI commands to the `out` singleton, and adds a confirmation prompt to `hf repos delete`.