### PR TITLE
Remove unused inputs from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,14 +50,6 @@ on:
           - minor-prerelease
           - minor-release
           - patch-release
-      version_override:
-        description: "Override version (e.g., 1.6.0.rc1, 1.5.1). Leave empty for auto-detect."
-        required: false
-        type: string
-      dry_run:
-        description: "Dry run — validate version detection without publishing"
-        type: boolean
-        default: false
 
 permissions: {}
 
@@ -91,58 +83,52 @@ jobs:
       - name: Detect version
         id: version
         env:
-          VERSION_OVERRIDE: ${{ inputs.version_override }}
           RELEASE_TYPE: ${{ inputs.release_type }}
         run: |
           set -euo pipefail
 
-          if [[ -n "$VERSION_OVERRIDE" ]]; then
-            # Strip 'v' prefix if present
-            VERSION=$(echo "$VERSION_OVERRIDE" | sed 's/^v//')
-          else
-            case "$RELEASE_TYPE" in
-              minor-prerelease)
-                # Read dev version from __init__.py: "1.6.0.dev0" → "1.6.0"
-                DEV_VERSION=$(grep -oP '__version__ = "\K[^"]+' src/huggingface_hub/__init__.py)
-                BASE_VERSION=$(echo "$DEV_VERSION" | sed 's/\.dev0//')
+          case "$RELEASE_TYPE" in
+            minor-prerelease)
+              # Read dev version from __init__.py: "1.6.0.dev0" → "1.6.0"
+              DEV_VERSION=$(grep -oP '__version__ = "\K[^"]+' src/huggingface_hub/__init__.py)
+              BASE_VERSION=$(echo "$DEV_VERSION" | sed 's/\.dev0//')
 
-                # Find existing RC tags for this base version to determine next RC number
-                LATEST_RC=$(git tag --sort=-v:refname | grep "^v${BASE_VERSION}\.rc" | head -1 || echo "")
-                if [[ -n "$LATEST_RC" ]]; then
-                  RC_NUM=$(echo "$LATEST_RC" | grep -oP '\.rc\K[0-9]+')
-                  RC_NUM=$((RC_NUM + 1))
-                else
-                  RC_NUM=0
-                fi
+              # Find existing RC tags for this base version to determine next RC number
+              LATEST_RC=$(git tag --sort=-v:refname | grep "^v${BASE_VERSION}\.rc" | head -1 || echo "")
+              if [[ -n "$LATEST_RC" ]]; then
+                RC_NUM=$(echo "$LATEST_RC" | grep -oP '\.rc\K[0-9]+')
+                RC_NUM=$((RC_NUM + 1))
+              else
+                RC_NUM=0
+              fi
 
-                VERSION="${BASE_VERSION}.rc${RC_NUM}"
-                ;;
-              minor-release)
-                # Read dev version from __init__.py to scope the RC lookup to this minor version
-                DEV_VERSION=$(grep -oP '__version__ = "\K[^"]+' src/huggingface_hub/__init__.py)
-                BASE_VERSION=$(echo "$DEV_VERSION" | sed 's/\.dev0//')
-                LATEST_RC=$(git tag --sort=-v:refname | grep -E "^v${BASE_VERSION}\.rc[0-9]+$" | head -1 || echo "")
-                if [[ -z "$LATEST_RC" ]]; then
-                  echo "::error::No RC tag found for v${BASE_VERSION}. Run a prerelease first."
-                  exit 1
-                fi
-                # v1.6.0.rc0 → 1.6.0
-                VERSION=$(echo "$LATEST_RC" | sed -E 's/^v//;s/\.rc.*//')
-                ;;
-              patch-release)
-                # Find the latest stable (non-RC) release tag
-                LATEST_RELEASE=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || echo "")
-                if [[ -z "$LATEST_RELEASE" ]]; then
-                  echo "::error::No release tag found."
-                  exit 1
-                fi
-                CURRENT=$(echo "$LATEST_RELEASE" | sed 's/^v//')
-                IFS='.' read -r MAJOR MINOR_NUM PATCH_NUM <<< "$CURRENT"
-                PATCH_NUM=$((PATCH_NUM + 1))
-                VERSION="${MAJOR}.${MINOR_NUM}.${PATCH_NUM}"
-                ;;
-            esac
-          fi
+              VERSION="${BASE_VERSION}.rc${RC_NUM}"
+              ;;
+            minor-release)
+              # Read dev version from __init__.py to scope the RC lookup to this minor version
+              DEV_VERSION=$(grep -oP '__version__ = "\K[^"]+' src/huggingface_hub/__init__.py)
+              BASE_VERSION=$(echo "$DEV_VERSION" | sed 's/\.dev0//')
+              LATEST_RC=$(git tag --sort=-v:refname | grep -E "^v${BASE_VERSION}\.rc[0-9]+$" | head -1 || echo "")
+              if [[ -z "$LATEST_RC" ]]; then
+                echo "::error::No RC tag found for v${BASE_VERSION}. Run a prerelease first."
+                exit 1
+              fi
+              # v1.6.0.rc0 → 1.6.0
+              VERSION=$(echo "$LATEST_RC" | sed -E 's/^v//;s/\.rc.*//')
+              ;;
+            patch-release)
+              # Find the latest stable (non-RC) release tag
+              LATEST_RELEASE=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || echo "")
+              if [[ -z "$LATEST_RELEASE" ]]; then
+                echo "::error::No release tag found."
+                exit 1
+              fi
+              CURRENT=$(echo "$LATEST_RELEASE" | sed 's/^v//')
+              IFS='.' read -r MAJOR MINOR_NUM PATCH_NUM <<< "$CURRENT"
+              PATCH_NUM=$((PATCH_NUM + 1))
+              VERSION="${MAJOR}.${MINOR_NUM}.${PATCH_NUM}"
+              ;;
+          esac
 
           # Derive tag, branch, and prerelease flag
           TAG="v${VERSION}"
@@ -168,7 +154,7 @@ jobs:
 
           # Validate: tag must not already exist
           if git rev-parse "$TAG" >/dev/null 2>&1; then
-            echo "::error::Tag $TAG already exists! Use version_override to specify a different version."
+            echo "::error::Tag $TAG already exists!"
             exit 1
           fi
 
@@ -190,10 +176,8 @@ jobs:
           echo "| Branch | \`$BRANCH\` |" >> $GITHUB_STEP_SUMMARY
           echo "| Since tag | \`$SINCE_TAG\` |" >> $GITHUB_STEP_SUMMARY
           echo "| Prerelease | \`$IS_PRERELEASE\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| Dry run | \`${{ inputs.dry_run }}\` |" >> $GITHUB_STEP_SUMMARY
 
       - name: Notify Slack — release started
-        if: ${{ !inputs.dry_run }}
         id: slack
         continue-on-error: true
         env:
@@ -262,7 +246,6 @@ jobs:
           grep "__version__" src/huggingface_hub/__init__.py
 
       - name: Commit, tag, and push
-        if: ${{ !inputs.dry_run }}
         run: |
           TAG="${{ steps.version.outputs.tag }}"
           BRANCH="${{ steps.version.outputs.branch }}"
@@ -286,7 +269,6 @@ jobs:
     permissions:
       contents: read
     needs: prepare
-    if: ${{ !inputs.dry_run }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -332,7 +314,6 @@ jobs:
     permissions:
       contents: read
     needs: prepare
-    if: ${{ !inputs.dry_run }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -386,7 +367,6 @@ jobs:
     permissions:
       contents: write   # create and edit GitHub releases
     needs: prepare
-    if: ${{ !inputs.dry_run }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -545,7 +525,7 @@ jobs:
     needs: [prepare, release-notes]
     # Use !cancelled() so this job runs even if release-notes failed (we fetch the draft directly from GitHub).
     # This also allows re-running this job after manually editing the draft release notes.
-    if: ${{ !cancelled() && needs.prepare.result == 'success' && needs.prepare.outputs.is_prerelease == 'true' && !inputs.dry_run }}
+    if: ${{ !cancelled() && needs.prepare.result == 'success' && needs.prepare.outputs.is_prerelease == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -665,7 +645,7 @@ jobs:
     permissions:
       contents: read
     needs: [prepare, publish-pypi]
-    if: ${{ needs.prepare.outputs.is_prerelease == 'true' && !inputs.dry_run }}
+    if: ${{ needs.prepare.outputs.is_prerelease == 'true' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -781,7 +761,7 @@ jobs:
     permissions:
       contents: read   # write operations use app token
     needs: [prepare, publish-pypi]
-    if: ${{ inputs.release_type == 'minor-release' && !inputs.dry_run }}
+    if: ${{ inputs.release_type == 'minor-release' }}
     runs-on: ubuntu-latest
     steps:
       - name: Create GitHub App token
@@ -812,7 +792,7 @@ jobs:
           NEXT_MINOR=$((MINOR + 1))
           DEV_VERSION="${MAJOR}.${NEXT_MINOR}.0.dev0"
 
-          # Guard: skip if main already has an equal or higher version (e.g. version_override for older minor)
+          # Guard: skip if main already has an equal or higher version
           CURRENT_VERSION=$(grep -oP '__version__ = "\K[^"]+' src/huggingface_hub/__init__.py)
           CURRENT_MINOR=$(echo "$CURRENT_VERSION" | cut -d. -f2)
           if [[ "$CURRENT_MINOR" -ge "$NEXT_MINOR" ]]; then
@@ -865,7 +845,7 @@ jobs:
     permissions:
       contents: read   # write operations use app token
     needs: prepare
-    if: ${{ needs.prepare.outputs.is_prerelease != 'true' && !inputs.dry_run }}
+    if: ${{ needs.prepare.outputs.is_prerelease != 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout huggingface_hub
@@ -960,7 +940,7 @@ jobs:
     permissions:
       contents: read   # write operations use app token
     needs: [prepare, publish-pypi]
-    if: ${{ inputs.release_type != 'minor-prerelease' && !inputs.dry_run }}
+    if: ${{ inputs.release_type != 'minor-prerelease' }}
     runs-on: ubuntu-latest
     steps:
       - name: Create GitHub App token
@@ -1042,7 +1022,7 @@ jobs:
   # ============================================================
   slack-complete:
     needs: [prepare, publish-pypi, publish-hf-cli, release-notes, slack-message, test-downstream, post-release, sync-hf-cli-skill, notify-prs]
-    if: ${{ always() && !inputs.dry_run && needs.prepare.outputs.message_ts }}
+    if: ${{ always() && needs.prepare.outputs.message_ts }}
     runs-on: ubuntu-latest
     steps:
       - name: Update Slack message with final status


### PR DESCRIPTION
`version_override` and `dry_run` inputs in the release workflow are noisy and never used. Removing them simplifies the workflow dispatch UI and the workflow logic itself.

(+ they are not tested so we don't even know what "--dry-run" will really run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Before:

<img width="664" height="828" alt="image" src="https://github.com/user-attachments/assets/ee0bc44b-b517-4b77-aa4b-e3893fb90056" />


After:

<img width="650" height="538" alt="image" src="https://github.com/user-attachments/assets/5e4e94cd-bd4e-40ee-a18e-705b7a4aa317" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the release automation control flow by removing the ability to skip publishing steps, so a manual dispatch will now always attempt real pushes/publishes.
> 
> **Overview**
> Simplifies the `release.yml` workflow dispatch UI by removing the `version_override` and `dry_run` inputs.
> 
> Release version detection is now always automatic based on `release_type`, and all jobs/steps previously guarded by `!inputs.dry_run` (publishing, tagging/pushing, release notes, downstream tests, post-release bump, Slack updates) will always run when their normal conditions match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4270b1042e4adea668c94468d5d9b959de0ed2f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->