### PR TITLE
[CLI] Migrate `download`, `upload`, `upload-large-folder` to `out` singleton

### DIFF
--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -1431,8 +1431,8 @@ $ hf download [OPTIONS] REPO_ID [FILENAMES]...
 * `--force-download / --no-force-download`: If True, the files will be downloaded even if they are already cached.  [default: no-force-download]
 * `--dry-run / --no-dry-run`: If True, perform a dry run without actually downloading the file.  [default: no-dry-run]
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
-* `--quiet / --no-quiet`: If True, progress bars are disabled and only the path to the download files is printed.  [default: no-quiet]
 * `--max-workers INTEGER`: Maximum number of workers to use for downloading files. Default is 8.  [default: 8]
+* `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
 * `--help`: Show this message and exit.
 
 Examples
@@ -3572,7 +3572,7 @@ $ hf upload [OPTIONS] REPO_ID [LOCAL_PATH] [PATH_IN_REPO]
 * `--create-pr / --no-create-pr`: Whether to upload content as a new Pull Request.  [default: no-create-pr]
 * `--every FLOAT`: If set, a background job is scheduled to create commits every `every` minutes.
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
-* `--quiet / --no-quiet`: Disable progress bars and warnings; print only the returned path.  [default: no-quiet]
+* `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
 * `--help`: Show this message and exit.
 
 Examples
@@ -3613,6 +3613,7 @@ $ hf upload-large-folder [OPTIONS] REPO_ID LOCAL_PATH
 * `--num-workers INTEGER`: Number of workers to use to hash, upload and commit files.
 * `--no-report / --no-no-report`: Whether to disable regular status report.  [default: no-no-report]
 * `--no-bars / --no-no-bars`: Whether to disable progress bars.  [default: no-no-bars]
+* `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
 * `--help`: Show this message and exit.
 
 Examples

--- a/src/huggingface_hub/cli/_cli_utils.py
+++ b/src/huggingface_hub/cli/_cli_utils.py
@@ -791,7 +791,7 @@ FormatOpt = Annotated[
 
 def _set_output_mode(value: OutputFormatWithAuto) -> OutputFormatWithAuto:
     out.set_mode(value)
-    if out.mode == OutputFormatWithAuto.quiet:
+    if out.mode != OutputFormatWithAuto.human:
         disable_progress_bars()
     return value
 

--- a/src/huggingface_hub/cli/_cli_utils.py
+++ b/src/huggingface_hub/cli/_cli_utils.py
@@ -34,7 +34,15 @@ from typer.core import TyperCommand, TyperGroup
 
 from huggingface_hub import Volume, __version__, constants
 from huggingface_hub.errors import CLIError
-from huggingface_hub.utils import ANSI, get_session, hf_raise_for_status, installation_method, logging, tabulate
+from huggingface_hub.utils import (
+    ANSI,
+    disable_progress_bars,
+    get_session,
+    hf_raise_for_status,
+    installation_method,
+    logging,
+    tabulate,
+)
 from huggingface_hub.utils._dotenv import load_dotenv
 
 from ._output import OutputFormatWithAuto, out
@@ -783,6 +791,8 @@ FormatOpt = Annotated[
 
 def _set_output_mode(value: OutputFormatWithAuto) -> OutputFormatWithAuto:
     out.set_mode(value)
+    if out.mode == OutputFormatWithAuto.quiet:
+        disable_progress_bars()
     return value
 
 

--- a/src/huggingface_hub/cli/download.py
+++ b/src/huggingface_hub/cli/download.py
@@ -43,13 +43,13 @@ from typing import Annotated
 
 import typer
 
-from huggingface_hub import logging
 from huggingface_hub._snapshot_download import snapshot_download
 from huggingface_hub.errors import CLIError
 from huggingface_hub.file_download import DryRunFileInfo, hf_hub_download
-from huggingface_hub.utils import _format_size, disable_progress_bars, enable_progress_bars, tabulate
+from huggingface_hub.utils import _format_size
 
-from ._cli_utils import RepoIdArg, RepoTypeOpt, RevisionOpt, TokenOpt
+from ._cli_utils import FormatWithAutoOpt, RepoIdArg, RepoTypeOpt, RevisionOpt, TokenOpt
+from ._output import OutputFormatWithAuto, out
 
 
 DOWNLOAD_EXAMPLES = [
@@ -59,9 +59,6 @@ DOWNLOAD_EXAMPLES = [
     "hf download meta-llama/Llama-3.2-1B-Instruct --local-dir ./models/llama",
     "hf download HuggingFaceM4/FineVision art/ --repo-type dataset",
 ]
-
-
-logger = logging.get_logger(__name__)
 
 
 def download(
@@ -111,18 +108,13 @@ def download(
         ),
     ] = False,
     token: TokenOpt = None,
-    quiet: Annotated[
-        bool,
-        typer.Option(
-            help="If True, progress bars are disabled and only the path to the download files is printed.",
-        ),
-    ] = False,
     max_workers: Annotated[
         int,
         typer.Option(
             help="Maximum number of workers to use for downloading files. Default is 8.",
         ),
     ] = 8,
+    format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
 ) -> None:
     """Download files from the Hub."""
 
@@ -198,27 +190,25 @@ def download(
 
     def _print_result(result: str | DryRunFileInfo | list[DryRunFileInfo]) -> None:
         if isinstance(result, str):
-            print(result)
+            out.result("Downloaded", path=result)
             return
 
         # Print dry run info
         if isinstance(result, DryRunFileInfo):
             result = [result]
-        print(
-            f"[dry-run] Will download {len([r for r in result if r.will_download])} files (out of {len(result)}) totalling {_format_size(sum(r.file_size for r in result if r.will_download))}."
+        will_download = [r for r in result if r.will_download]
+        out.text(
+            f"[dry-run] Will download {len(will_download)} files"
+            f" (out of {len(result)})"
+            f" totalling {_format_size(sum(r.file_size for r in will_download))}."
         )
-        columns = ["File", "Bytes to download"]
-        items: list[list[str | int]] = []
-        for info in sorted(result, key=lambda x: x.filename):
-            items.append([info.filename, _format_size(info.file_size) if info.will_download else "-"])
-        print(tabulate(items, headers=columns))
+        items = [
+            {
+                "file": info.filename,
+                "size": _format_size(info.file_size) if info.will_download else "-",
+            }
+            for info in sorted(result, key=lambda x: x.filename)
+        ]
+        out.table(items)
 
-    if quiet:
-        disable_progress_bars()
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            _print_result(run_download())
-        enable_progress_bars()
-    else:
-        _print_result(run_download())
-        logging.set_verbosity_warning()
+    _print_result(run_download())

--- a/src/huggingface_hub/cli/upload.py
+++ b/src/huggingface_hub/cli/upload.py
@@ -55,9 +55,9 @@ import typer
 from huggingface_hub import logging
 from huggingface_hub._commit_scheduler import CommitScheduler
 from huggingface_hub.errors import RevisionNotFoundError
-from huggingface_hub.utils import disable_progress_bars, enable_progress_bars
 
 from ._cli_utils import (
+    FormatWithAutoOpt,
     PrivateOpt,
     RepoIdArg,
     RepoType,
@@ -66,6 +66,7 @@ from ._cli_utils import (
     TokenOpt,
     get_hf_api,
 )
+from ._output import OutputFormatWithAuto, out
 
 
 logger = logging.get_logger(__name__)
@@ -140,12 +141,7 @@ def upload(
         ),
     ] = None,
     token: TokenOpt = None,
-    quiet: Annotated[
-        bool,
-        typer.Option(
-            help="Disable progress bars and warnings; print only the returned path.",
-        ),
-    ] = False,
+    format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
 ) -> None:
     """Upload a file or a folder to the Hub. Recommended for single-commit uploads."""
 
@@ -204,7 +200,7 @@ def upload(
                 every=every,
                 hf_api=api,
             )
-            print(f"Scheduling commits every {every} minutes to {scheduler.repo_id}.")
+            out.text(f"Scheduling commits every {every} minutes to {scheduler.repo_id}.")
             try:
                 while True:
                     time.sleep(100)
@@ -262,15 +258,8 @@ def upload(
             delete_patterns=delete,
         )
 
-    if quiet:
-        disable_progress_bars()
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            print(run_upload())
-        enable_progress_bars()
-    else:
-        print(run_upload())
-        logging.set_verbosity_warning()
+    result = run_upload()
+    out.result("Uploaded", url=result)
 
 
 def _resolve_upload_paths(

--- a/src/huggingface_hub/cli/upload_large_folder.py
+++ b/src/huggingface_hub/cli/upload_large_folder.py
@@ -19,9 +19,10 @@ from typing import Annotated
 import typer
 
 from huggingface_hub import logging
-from huggingface_hub.utils import ANSI, disable_progress_bars
+from huggingface_hub.utils import disable_progress_bars
 
 from ._cli_utils import (
+    FormatWithAutoOpt,
     PrivateOpt,
     RepoIdArg,
     RepoType,
@@ -30,6 +31,7 @@ from ._cli_utils import (
     TokenOpt,
     get_hf_api,
 )
+from ._output import OutputFormatWithAuto, out
 
 
 logger = logging.get_logger(__name__)
@@ -83,34 +85,33 @@ def upload_large_folder(
             help="Whether to disable progress bars.",
         ),
     ] = False,
+    format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
 ) -> None:
     """Upload a large folder to the Hub. Recommended for resumable uploads."""
     if not os.path.isdir(local_path):
         raise typer.BadParameter("Large upload is only supported for folders.", param_hint="local_path")
 
-    print(
-        ANSI.yellow(
-            "You are about to upload a large folder to the Hub using `hf upload-large-folder`. "
-            "This is a new feature so feedback is very welcome!\n"
-            "\n"
-            "A few things to keep in mind:\n"
-            "  - Repository limits still apply: https://huggingface.co/docs/hub/repositories-recommendations\n"
-            "  - Do not start several processes in parallel.\n"
-            "  - You can interrupt and resume the process at any time. "
-            "The script will pick up where it left off except for partially uploaded files that would have to be entirely reuploaded.\n"
-            "  - Do not upload the same folder to several repositories. If you need to do so, you must delete the `./.cache/huggingface/` folder first.\n"
-            "\n"
-            f"Some temporary metadata will be stored under `{local_path}/.cache/huggingface`.\n"
-            "  - You must not modify those files manually.\n"
-            "  - You must not delete the `./.cache/huggingface/` folder while a process is running.\n"
-            "  - You can delete the `./.cache/huggingface/` folder to reinitialize the upload state when process is not running. Files will have to be hashed and preuploaded again, except for already committed files.\n"
-            "\n"
-            "If the process output is too verbose, you can disable the progress bars with `--no-bars`. "
-            "You can also entirely disable the status report with `--no-report`.\n"
-            "\n"
-            "For more details, run `hf upload-large-folder --help` or check the documentation at "
-            "https://huggingface.co/docs/huggingface_hub/guides/upload#upload-a-large-folder."
-        )
+    out.text(
+        "You are about to upload a large folder to the Hub using `hf upload-large-folder`. "
+        "This is a new feature so feedback is very welcome!\n"
+        "\n"
+        "A few things to keep in mind:\n"
+        "  - Repository limits still apply: https://huggingface.co/docs/hub/repositories-recommendations\n"
+        "  - Do not start several processes in parallel.\n"
+        "  - You can interrupt and resume the process at any time. "
+        "The script will pick up where it left off except for partially uploaded files that would have to be entirely reuploaded.\n"
+        "  - Do not upload the same folder to several repositories. If you need to do so, you must delete the `./.cache/huggingface/` folder first.\n"
+        "\n"
+        f"Some temporary metadata will be stored under `{local_path}/.cache/huggingface`.\n"
+        "  - You must not modify those files manually.\n"
+        "  - You must not delete the `./.cache/huggingface/` folder while a process is running.\n"
+        "  - You can delete the `./.cache/huggingface/` folder to reinitialize the upload state when process is not running. Files will have to be hashed and preuploaded again, except for already committed files.\n"
+        "\n"
+        "If the process output is too verbose, you can disable the progress bars with `--no-bars`. "
+        "You can also entirely disable the status report with `--no-report`.\n"
+        "\n"
+        "For more details, run `hf upload-large-folder --help` or check the documentation at "
+        "https://huggingface.co/docs/huggingface_hub/guides/upload#upload-a-large-folder."
     )
 
     if no_bars:

--- a/src/huggingface_hub/cli/upload_large_folder.py
+++ b/src/huggingface_hub/cli/upload_large_folder.py
@@ -91,7 +91,7 @@ def upload_large_folder(
     if not os.path.isdir(local_path):
         raise typer.BadParameter("Large upload is only supported for folders.", param_hint="local_path")
 
-    out.text(
+    out.warning(
         "You are about to upload a large folder to the Hub using `hf upload-large-folder`. "
         "This is a new feature so feedback is very welcome!\n"
         "\n"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,6 +15,7 @@ from huggingface_hub._dataset_viewer import DatasetParquetEntry
 from huggingface_hub._jobs_api import _create_job_spec
 from huggingface_hub._space_api import Volume
 from huggingface_hub.cli._cli_utils import RepoType, parse_volumes
+from huggingface_hub.cli._output import OutputFormatWithAuto, out
 from huggingface_hub.cli.cache import CacheDeletionCounts
 from huggingface_hub.cli.download import download
 from huggingface_hub.cli.hf import app
@@ -463,7 +464,8 @@ class TestUploadCommand:
                         "5",
                         "--token",
                         "my-token",
-                        "--quiet",
+                        "--format",
+                        "quiet",
                     ],
                 )
         assert result.exit_code == 0
@@ -641,6 +643,10 @@ class TestResolveUploadPaths:
 
 
 class TestUploadImpl:
+    @pytest.fixture(autouse=True)
+    def _quiet_mode(self):
+        out.set_mode(OutputFormatWithAuto.quiet)
+
     def test_upload_folder_mock(self, *_: object) -> None:
         api = Mock()
         api.create_repo.return_value = Mock(repo_id="my-model")
@@ -659,7 +665,6 @@ class TestUploadImpl:
                     include=["*.json"],
                     delete=["*.json"],
                     private=True,
-                    quiet=True,
                 )
         api.create_repo.assert_called_once_with(
             repo_id="my-model",
@@ -700,7 +705,6 @@ class TestUploadImpl:
                     local_path=str(file_path),
                     path_in_repo="logs/file.txt",
                     create_pr=True,
-                    quiet=True,
                 )
         api.create_repo.assert_called_once_with(
             repo_id="my-dataset",
@@ -735,7 +739,6 @@ class TestUploadImpl:
                     repo_id="my-model",
                     local_path=str(file_path),
                     path_in_repo="logs/file.txt",
-                    quiet=True,
                 )
         api.repo_info.assert_not_called()
 
@@ -755,7 +758,6 @@ class TestUploadImpl:
                     revision="my-branch",
                     local_path=str(file_path),
                     path_in_repo="logs/file.txt",
-                    quiet=True,
                 )
         api.repo_info.assert_called_once_with(repo_id="my-model", repo_type="model", revision="my-branch")
         api.create_branch.assert_called_once_with(
@@ -778,7 +780,6 @@ class TestUploadImpl:
                     local_path=str(file_path),
                     path_in_repo="logs/file.txt",
                     create_pr=True,
-                    quiet=True,
                 )
         api.repo_info.assert_not_called()
         api.create_branch.assert_not_called()
@@ -791,7 +792,6 @@ class TestUploadImpl:
                     repo_id="my-model",
                     local_path="/path/to/missing_file",
                     path_in_repo="logs/file.txt",
-                    quiet=True,
                 )
         api.create_repo.assert_not_called()
 
@@ -847,7 +847,8 @@ class TestDownloadCommand:
                     "/tmp",
                     "--token",
                     "my-token",
-                    "--quiet",
+                    "--format",
+                    "quiet",
                     "--local-dir",
                     ".",
                     "--max-workers",
@@ -892,6 +893,10 @@ class TestDownloadCommand:
 
 
 class TestDownloadImpl:
+    @pytest.fixture(autouse=True)
+    def _quiet_mode(self):
+        out.set_mode(OutputFormatWithAuto.quiet)
+
     @patch("huggingface_hub.cli.download.snapshot_download")
     @patch("huggingface_hub.cli.download.hf_hub_download")
     def test_download_file_from_revision(self, mock_download: Mock, mock_snapshot: Mock) -> None:
@@ -902,7 +907,6 @@ class TestDownloadImpl:
                 filenames=["config.json"],
                 repo_type=RepoType.model,
                 revision="main",
-                quiet=True,
             )
         print_mock.assert_called_once_with("file-path")
         mock_download.assert_called_once_with(
@@ -930,7 +934,6 @@ class TestDownloadImpl:
                 repo_type=RepoType.model,
                 force_download=True,
                 max_workers=4,
-                quiet=True,
             )
         print_mock.assert_called_once_with("folder-path")
         mock_download.assert_not_called()
@@ -959,7 +962,6 @@ class TestDownloadImpl:
                 include=["*.json"],
                 exclude=["data/*"],
                 force_download=True,
-                quiet=True,
             )
         mock_snapshot.assert_called_once_with(
             repo_id="author/model",
@@ -982,8 +984,6 @@ class TestDownloadImpl:
         mock_snapshot.return_value = "folder-path"
         with (
             patch("builtins.print") as print_mock,
-            patch("huggingface_hub.cli.download.logging.set_verbosity_info"),
-            patch("huggingface_hub.cli.download.logging.set_verbosity_warning"),
             warnings.catch_warnings(record=True) as caught,
         ):
             download(
@@ -1022,7 +1022,6 @@ class TestDownloadImpl:
                 repo_id="author/dataset",
                 filenames=["art/"],
                 repo_type=RepoType.dataset,
-                quiet=True,
             )
         print_mock.assert_called_once_with("folder-path")
         mock_download.assert_not_called()
@@ -1051,7 +1050,6 @@ class TestDownloadImpl:
                 repo_id="author/model",
                 filenames=["art/", "config.json"],
                 repo_type=RepoType.model,
-                quiet=True,
             )
         print_mock.assert_called_once_with("folder-path")
         mock_download.assert_not_called()
@@ -1080,7 +1078,6 @@ class TestDownloadImpl:
                 repo_id="author/model",
                 filenames=["art/", "data/images/"],
                 repo_type=RepoType.model,
-                quiet=True,
             )
         print_mock.assert_called_once_with("folder-path")
         mock_download.assert_not_called()
@@ -1107,7 +1104,6 @@ class TestDownloadImpl:
                 filenames=["art/"],
                 repo_type=RepoType.model,
                 include=["*.json"],
-                quiet=True,
             )
 
     def test_download_subfolder_with_exclude_raises_error(self) -> None:
@@ -1118,7 +1114,6 @@ class TestDownloadImpl:
                 filenames=["art/"],
                 repo_type=RepoType.model,
                 exclude=["*.bin"],
-                quiet=True,
             )
 
 
@@ -3486,7 +3481,7 @@ class TestSkillGeneration:
         assert "--local-dir TEXT" in download_line
         # Common flags appear inline, except --token (kept in common-options glossary)
         assert "--token" not in download_line
-        assert "--quiet" in download_line
+        assert "--format CHOICE" in download_line
 
     def test_format_params_distinguishes_options_from_arguments(self) -> None:
         """Required options must render with --prefix, positional args as UPPER_CASE."""


### PR DESCRIPTION
Part of #3979.
This PR migrates `download`, `upload`, `upload-large-folder` CLI commands to the `out` singleton.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CLI public interface and stdout/stderr output for `hf download`, `hf upload`, and `hf upload-large-folder` by replacing `--quiet`/`print()` with `--format`/`out`, which may break existing scripts relying on old flags or exact output text.
> 
> **Overview**
> Migrates `hf download`, `hf upload`, and `hf upload-large-folder` to the shared `out` output singleton, replacing ad-hoc `print()`/tabulate output with `out.result`, `out.text`, and `out.table` (including structured dry-run output for `download`).
> 
> Replaces the commands’ `--quiet` flag with `--format [agent|auto|human|json|quiet]` and wires `quiet` mode to automatically disable progress bars via the `FormatWithAutoOpt` callback.
> 
> Updates generated CLI docs and adjusts CLI tests/skill markdown expectations to use `--format quiet` and the new output paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9369722dbf7e68aec2996c91b3ac11bdc28e07b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->