### PR TITLE
[CLI] Add `hf auth token` command

### DIFF
--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -67,6 +67,7 @@ $ hf auth [OPTIONS] COMMAND [ARGS]...
 * `login`: Login using a token from...
 * `logout`: Logout from a specific token.
 * `switch`: Switch between access tokens.
+* `token`: Print the current access token to stdout.
 * `whoami`: Find out which huggingface.co account you...
 
 ### `hf auth list`
@@ -162,6 +163,29 @@ $ hf auth switch [OPTIONS]
 Examples
   $ hf auth switch
   $ hf auth switch --token-name my-token
+
+Learn more
+  Use `hf <command> --help` for more information about a command.
+  Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
+
+
+### `hf auth token`
+
+Print the current access token to stdout.
+
+**Usage**:
+
+```console
+$ hf auth token [OPTIONS]
+```
+
+**Options**:
+
+* `--help`: Show this message and exit.
+
+Examples
+  $ hf auth token
+  $ hf auth token | xargs curl -H 'Authorization: Bearer {}'
 
 Learn more
   Use `hf <command> --help` for more information about a command.

--- a/src/huggingface_hub/cli/auth.py
+++ b/src/huggingface_hub/cli/auth.py
@@ -156,6 +156,7 @@ def auth_token() -> None:
         out.error("Not logged in. Run `hf auth login` first.")
         raise typer.Exit(code=1)
     print(token)
+    out.hint("Run `hf auth whoami` to see which account this token belongs to.")
 
 
 @auth_cli.command("whoami", examples=["hf auth whoami", "hf auth whoami --format json"])

--- a/src/huggingface_hub/cli/auth.py
+++ b/src/huggingface_hub/cli/auth.py
@@ -148,6 +148,16 @@ def auth_list_cmd() -> None:
     auth_list()
 
 
+@auth_cli.command("token", examples=["hf auth token", "hf auth token | xargs curl -H 'Authorization: Bearer {}'"])
+def auth_token() -> None:
+    """Print the current access token to stdout."""
+    token = get_token()
+    if token is None:
+        out.error("Not logged in. Run `hf auth login` first.")
+        raise typer.Exit(code=1)
+    print(token)
+
+
 @auth_cli.command("whoami", examples=["hf auth whoami", "hf auth whoami --format json"])
 def auth_whoami(
     format: FormatWithAutoOpt = OutputFormatWithAuto.auto,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1658,6 +1658,21 @@ class TestAuthWhoamiCommand:
         assert "Not logged in" in result.output
 
 
+class TestAuthTokenCommand:
+    def test_token_prints_to_stdout(self, runner: CliRunner) -> None:
+        with patch("huggingface_hub.cli.auth.get_token", return_value="hf_HubCITokenXXXXXXXXXXXXXXXXXXXXX"):
+            result = runner.invoke(app, ["auth", "token"])
+        assert result.exit_code == 0
+        assert result.stdout.strip() == "hf_HubCITokenXXXXXXXXXXXXXXXXXXXXX"
+
+    def test_token_not_logged_in(self, runner: CliRunner) -> None:
+        with patch("huggingface_hub.cli.auth.get_token", return_value=None):
+            result = runner.invoke(app, ["auth", "token"])
+        assert result.exit_code == 1
+        assert "Not logged in" in result.output
+        assert "hf auth login" in result.output
+
+
 class TestModelsLsCommand:
     def test_models_ls_basic(self, runner: CliRunner) -> None:
         repo = ModelInfo(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,6 +32,7 @@ from huggingface_hub.utils import (
 )
 from huggingface_hub.utils._verification import FolderVerification
 
+from .testing_constants import TOKEN
 from .testing_utils import DUMMY_MODEL_ID, with_production_testing
 
 
@@ -1660,10 +1661,10 @@ class TestAuthWhoamiCommand:
 
 class TestAuthTokenCommand:
     def test_token_prints_to_stdout(self, runner: CliRunner) -> None:
-        with patch("huggingface_hub.cli.auth.get_token", return_value="hf_HubCITokenXXXXXXXXXXXXXXXXXXXXX"):
+        with patch("huggingface_hub.cli.auth.get_token", return_value=TOKEN):
             result = runner.invoke(app, ["auth", "token"])
         assert result.exit_code == 0
-        assert result.stdout.strip() == "hf_HubCITokenXXXXXXXXXXXXXXXXXXXXX"
+        assert result.stdout.strip() == TOKEN
         assert "hf auth whoami" in result.output
 
     def test_token_not_logged_in(self, runner: CliRunner) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1664,6 +1664,7 @@ class TestAuthTokenCommand:
             result = runner.invoke(app, ["auth", "token"])
         assert result.exit_code == 0
         assert result.stdout.strip() == "hf_HubCITokenXXXXXXXXXXXXXXXXXXXXX"
+        assert "hf auth whoami" in result.output
 
     def test_token_not_logged_in(self, runner: CliRunner) -> None:
         with patch("huggingface_hub.cli.auth.get_token", return_value=None):


### PR DESCRIPTION
(related to internal private [slack thread](https://huggingface.slack.com/archives/C07KX53FZTK/p1775677573964369))


Adds `hf auth token` to print the current token to stdout. Handy for piping into other commands.

```
$ hf auth token
hf_xxx***
Hint: Run `hf auth whoami` to see which account this token belongs to.
```

You can pipe this output to make a cURL call

```
$ hf auth token | xargs -I {} curl -H "Authorization: Bearer {}" https://huggingface.co/api/settings/billing/usage
```

If not logged in, prints an error nudging to `hf auth login` and exits 1.

```
$ hf auth token
Error: Not logged in. Run `hf auth login` first.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

#### Note: the plan in a future PR is to provide a `hf api` command similar to `gh api` to make authenticated calls to any endpoint on hf.co/ (would need a maybe a `hf api schema` to fetch https://huggingface.co/spaces/huggingface/openapi + `hf api run` ?). In any case,  `hf auth token` will still be useful for instance to do `export ANTHROPIC_AUTH_TOKEN="$(hf auth token)"` in [hf-claude](https://github.com/hanouticelina/hf-claude) cc @hanouticelina 