### PR TITLE
docs: give manage-spaces walkthrough steps real headings

### DIFF
--- a/docs/source/en/guides/manage-spaces.md
+++ b/docs/source/en/guides/manage-spaces.md
@@ -12,7 +12,7 @@ In this guide, we will see how to manage your Space runtime
 
 Here is an end-to-end example to create and set up a Space on the Hub.
 
-**1. Create a Space on the Hub.**
+### Create a Space on the Hub
 
 ```py
 >>> from huggingface_hub import HfApi
@@ -23,7 +23,7 @@ Here is an end-to-end example to create and set up a Space on the Hub.
 >>> api.create_repo(repo_id=repo_id, repo_type="space", space_sdk="gradio")
 ```
 
-**1. (bis) Duplicate a Space.**
+### Duplicate a Space
 
 This can prove useful if you want to build up from an existing Space instead of starting from scratch.
 It is also useful is you want control over the configuration/settings of a public Space. See [`duplicate_repo`] for more details.
@@ -32,7 +32,7 @@ It is also useful is you want control over the configuration/settings of a publi
 >>> api.duplicate_repo("multimodalart/dreambooth-training", repo_type="space")
 ```
 
-**2. Upload your code using your preferred solution.**
+### Upload your code using your preferred solution
 
 Here is an example to upload the local folder `src/` from your machine to your Space:
 
@@ -43,7 +43,7 @@ Here is an example to upload the local folder `src/` from your machine to your S
 At this step, your app should already be running on the Hub for free !
 However, you might want to configure it further with secrets and upgraded hardware.
 
-**3. Configure secrets and variables**
+### Configure secrets and variables
 
 Your Space might require some secret keys, token or variables to work.
 See [docs](https://huggingface.co/docs/hub/spaces-overview#managing-secrets) for more details.
@@ -90,7 +90,7 @@ Secrets and variables can be set when creating or duplicating a space:
 ... )
 ```
 
-**4. Configure the hardware**
+### Configure the hardware
 
 By default, your Space will run on a CPU environment for free. You can upgrade the hardware
 to run it on GPUs. A payment card or a community grant is required to access upgrade your
@@ -144,7 +144,7 @@ Upgraded hardware will be automatically assigned to your Space once it's built.
 ... )
 ```
 
-**5. Pause and restart your Space**
+### Pause and restart your Space
 
 By default if your Space is running on an upgraded hardware, it will never be stopped. However to avoid getting billed,
 you might want to pause it when you are not using it. This is possible using [`pause_space`]. A paused Space will be
@@ -199,7 +199,7 @@ Upgraded hardware will be automatically assigned to your Space once it's built.
 ... )
 ```
 
-**6. Mount volumes in your Space**
+### Mount volumes in your Space
 
 You can mount Hub resources (models, datasets, or storage buckets) as volumes in your Space's container. This gives your Space direct filesystem access to these resources without having to download them in your code. Volumes can be set directly when creating or duplicating a Space:
 


### PR DESCRIPTION
## Summary

Steps 1–6 under "A simple example" were `**bold pseudo-headings**`, which doc-builder doesn't turn into anchors. Promote them to `###` so each step gets a real slug (`#configure-secrets-and-variables`, `#mount-volumes-in-your-space`, etc.) and a sidebar entry.

**Why**: deep-linkable anchors are how this guide gets cross-referenced from other docs — and increasingly, how both humans and LLM agents discover the right section without scrolling a long page. [huggingface/hub-docs#2377](https://github.com/huggingface/hub-docs/pull/2377) and `hub-docs/docs/hub/storage-buckets-access.md` already reference `#mount-volumes-in-your-space`; today those links silently resolve to page-top. This fixes them and makes every other step linkable for free.

Leading `N.` numbers and trailing periods dropped — step order is preserved by document position. `**Bonus: ...**` subsections intentionally left as bold since they're variants of their parent step, not peers. Translations (de/ko) left untouched.

## Test plan

- [x] Doc-builder preview: each step renders as an H3 with a sidebar entry
- [x] `#mount-volumes-in-your-space` and the other step anchors jump to the right section
- [ ] The hub-docs#2377 preview now resolves its link correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; main impact is updated section slugs/anchors which may affect deep links if any relied on the old (non-heading) formatting.
> 
> **Overview**
> Updates `docs/source/en/guides/manage-spaces.md` by promoting steps 1–6 in the “A simple example” walkthrough from **bold pseudo-headings** to real `###` headings (and dropping the leading numbering/trailing periods).
> 
> This makes each step generate a proper doc-builder slug/anchor (and likely sidebar entry) for reliable deep linking (e.g., `#mount-volumes-in-your-space`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a724d300f31763af9d0cb8dbc45e8679e2c6a0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->