### PR TITLE
[CLI] Add `hf spaces volumes` commands

### DIFF
--- a/docs/source/en/guides/manage-spaces.md
+++ b/docs/source/en/guides/manage-spaces.md
@@ -259,6 +259,21 @@ To remove all volumes from your Space:
 > [!WARNING]
 > Setting volumes replaces any previously mounted volumes. To add a volume to an existing list, first read the current volumes from the runtime and include them in the new list.
 
+All volume operations are also available from the CLI:
+
+```bash
+# List current volumes
+hf spaces volumes ls username/my-space
+
+# Set (replace) volumes
+hf spaces volumes set username/my-space \
+    -v hf://models/username/my-model:/models \
+    -v hf://buckets/username/my-bucket:/data
+
+# Remove all volumes
+hf spaces volumes delete username/my-space
+```
+
 ## More advanced: temporarily upgrade your Space !
 
 Spaces allow for a lot of different use cases. Sometimes, you might want

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -3403,6 +3403,7 @@ $ hf spaces [OPTIONS] COMMAND [ARGS]...
 * `hot-reload`: Hot-reload any Python file of a Space...
 * `info`: Get info about a space on the Hub.
 * `list`: List spaces on the Hub. [alias: ls]
+* `volumes`: Manage volumes for a Space on the Hub.
 
 ### `hf spaces dev-mode`
 
@@ -3540,6 +3541,114 @@ $ hf spaces list [OPTIONS]
 Examples
   $ hf spaces ls --limit 10
   $ hf spaces ls --search "chatbot" --author huggingface
+
+Learn more
+  Use `hf <command> --help` for more information about a command.
+  Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
+
+
+### `hf spaces volumes`
+
+Manage volumes for a Space on the Hub.
+
+**Usage**:
+
+```console
+$ hf spaces volumes [OPTIONS] COMMAND [ARGS]...
+```
+
+**Options**:
+
+* `--help`: Show this message and exit.
+
+**Commands**:
+
+* `delete`: Remove all volumes from a Space.
+* `list`: List volumes mounted in a Space. [alias: ls]
+* `set`: Set (replace) volumes for a Space.
+
+#### `hf spaces volumes delete`
+
+Remove all volumes from a Space.
+
+**Usage**:
+
+```console
+$ hf spaces volumes delete [OPTIONS] SPACE_ID
+```
+
+**Arguments**:
+
+* `SPACE_ID`: The space ID (e.g. `username/repo-name`).  [required]
+
+**Options**:
+
+* `-y, --yes`: Answer Yes to prompt automatically.
+* `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
+* `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
+* `--help`: Show this message and exit.
+
+Examples
+  $ hf spaces volumes delete username/my-space
+  $ hf spaces volumes delete username/my-space --yes
+
+Learn more
+  Use `hf <command> --help` for more information about a command.
+  Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
+
+
+#### `hf spaces volumes list`
+
+List volumes mounted in a Space. [alias: ls]
+
+**Usage**:
+
+```console
+$ hf spaces volumes list [OPTIONS] SPACE_ID
+```
+
+**Arguments**:
+
+* `SPACE_ID`: The space ID (e.g. `username/repo-name`).  [required]
+
+**Options**:
+
+* `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
+* `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
+* `--help`: Show this message and exit.
+
+Examples
+  $ hf spaces volumes ls username/my-space
+
+Learn more
+  Use `hf <command> --help` for more information about a command.
+  Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
+
+
+#### `hf spaces volumes set`
+
+Set (replace) volumes for a Space.
+
+**Usage**:
+
+```console
+$ hf spaces volumes set [OPTIONS] SPACE_ID
+```
+
+**Arguments**:
+
+* `SPACE_ID`: The space ID (e.g. `username/repo-name`).  [required]
+
+**Options**:
+
+* `-v, --volume TEXT`: Mount a volume. Format: hf://[TYPE/]SOURCE:/MOUNT_PATH[:ro]. TYPE is one of: models, datasets, spaces, buckets. TYPE defaults to models if omitted. models, datasets and spaces are always mounted read-only. buckets are read+write by default.E.g. -v hf://gpt2:/data or -v hf://datasets/org/ds:/data or -v hf://buckets/org/b:/mnt:ro
+* `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
+* `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
+* `--help`: Show this message and exit.
+
+Examples
+  $ hf spaces volumes set username/my-space -v hf://models/username/my-model:/models
+  $ hf spaces volumes set username/my-space -v hf://buckets/username/my-bucket:/data -v hf://datasets/username/my-dataset:/datasets:ro
 
 Learn more
   Use `hf <command> --help` for more information about a command.

--- a/src/huggingface_hub/_space_api.py
+++ b/src/huggingface_hub/_space_api.py
@@ -161,15 +161,11 @@ class Volume:
             data["path"] = self.path
         return data
 
-    def to_hf_handle(self) -> str:
-        """Return the volume as an HF handle in the format expected by the CLI."""
-        return (
-            f"hf://{self.type}s/{self.source}"
-            f"{'@' + self.revision if self.revision else ''}"
-            f"{'/' + self.path if self.path else ''}"
-            f":{self.mount_path}"
-            f"{':ro' if self.read_only else ':rw' if self.read_only is False else ''}"
-        )
+  def to_hf_handle(self) -> str:
+      """Return the volume as an HF handle in the format expected by the CLI."""
+      path = f"/{self.path}" if self.path else ""
+      ro = {True: ":ro", False: ":rw"}.get(self.read_only, "")
+      return f"hf://{self.type}s/{self.source}{path}:{self.mount_path}{ro}"
 
 
 @dataclass

--- a/src/huggingface_hub/_space_api.py
+++ b/src/huggingface_hub/_space_api.py
@@ -161,6 +161,15 @@ class Volume:
             data["path"] = self.path
         return data
 
+    def to_str(self) -> str:
+        return (
+            f"hf://{self.type}/{self.source}"
+            f"{'@' + self.revision if self.revision else ''}"
+            f"{'/' + self.path if self.path else ''}"
+            f":{self.mount_path}"
+            f"{':ro' if self.read_only else ':rw' if self.read_only is False else ''}"
+        )
+
 
 @dataclass
 class SpaceHotReloading:

--- a/src/huggingface_hub/_space_api.py
+++ b/src/huggingface_hub/_space_api.py
@@ -161,11 +161,12 @@ class Volume:
             data["path"] = self.path
         return data
 
-  def to_hf_handle(self) -> str:
-      """Return the volume as an HF handle in the format expected by the CLI."""
-      path = f"/{self.path}" if self.path else ""
-      ro = {True: ":ro", False: ":rw"}.get(self.read_only, "")
-      return f"hf://{self.type}s/{self.source}{path}:{self.mount_path}{ro}"
+    def to_hf_handle(self) -> str:
+        """Return the volume as an HF handle in the format expected by the CLI."""
+        path = f"/{self.path}" if self.path else ""
+        revision = f"@{self.revision}" if self.revision else ""
+        ro = {True: ":ro", False: ":rw"}.get(self.read_only, "")
+        return f"hf://{self.type}s/{self.source}{revision}{path}:{self.mount_path}{ro}"
 
 
 @dataclass

--- a/src/huggingface_hub/_space_api.py
+++ b/src/huggingface_hub/_space_api.py
@@ -165,7 +165,7 @@ class Volume:
         """Return the volume as an HF handle in the format expected by the CLI."""
         path = f"/{self.path}" if self.path else ""
         revision = f"@{self.revision}" if self.revision else ""
-        ro = {True: ":ro", False: ":rw"}.get(self.read_only, "")
+        ro = {True: ":ro", False: ":rw", None: ""}.get(self.read_only, "")
         return f"hf://{self.type}s/{self.source}{revision}{path}:{self.mount_path}{ro}"
 
 

--- a/src/huggingface_hub/_space_api.py
+++ b/src/huggingface_hub/_space_api.py
@@ -161,9 +161,10 @@ class Volume:
             data["path"] = self.path
         return data
 
-    def to_str(self) -> str:
+    def to_hf_handle(self) -> str:
+        """Return the volume as an HF handle in the format expected by the CLI."""
         return (
-            f"hf://{self.type}/{self.source}"
+            f"hf://{self.type}s/{self.source}"
             f"{'@' + self.revision if self.revision else ''}"
             f"{'/' + self.path if self.path else ''}"
             f":{self.mount_path}"

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -531,7 +531,7 @@ def volumes_set(
         raise CLIError("At least one volume must be specified with -v/--volume.")
     api = get_hf_api(token=token)
     api.set_space_volumes(space_id, volumes=volumes)
-    out.result("Volumes set", space_id=space_id, volumes=[v.to_str() for v in volumes])
+    out.result("Volumes set", space_id=space_id, volumes=[v.to_hf_handle() for v in volumes])
     out.hint(f"Use `hf spaces volumes ls {space_id}` to list volumes for a Space.")
 
 

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -55,9 +55,11 @@ from ._cli_utils import (
     RevisionOpt,
     SearchOpt,
     TokenOpt,
+    VolumesOpt,
     api_object_to_dict,
     get_hf_api,
     make_expand_properties_parser,
+    parse_volumes,
     typer_factory,
 )
 from ._output import OutputFormatWithAuto, out
@@ -80,6 +82,8 @@ ExpandOpt = Annotated[
 ]
 
 spaces_cli = typer_factory(help="Interact with spaces on the Hub.")
+volumes_cli = typer_factory(help="Manage volumes for a Space on the Hub.")
+spaces_cli.add_typer(volumes_cli, name="volumes")
 
 
 @spaces_cli.command(
@@ -435,3 +439,73 @@ def _editor_open(local_path: str) -> int | Literal["no-tty", "no-editor"]:
     command = [*shlex.split(editor_command), local_path]
     res = subprocess.run(command, start_new_session=True)
     return res.returncode
+
+
+@volumes_cli.command(
+    "list | ls",
+    examples=[
+        "hf spaces volumes ls username/my-space",
+    ],
+)
+def volumes_ls(
+    space_id: Annotated[str, typer.Argument(help="The space ID (e.g. `username/repo-name`).")],
+    format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
+    token: TokenOpt = None,
+) -> None:
+    """List volumes mounted in a Space."""
+    api = get_hf_api(token=token)
+    info = api.space_info(space_id)
+    if info.runtime is None:
+        raise CLIError(f"Runtime not available for Space '{space_id}'.")
+    volumes = info.runtime.volumes or []
+    items = [api_object_to_dict(v) for v in volumes]
+    out.table(items)
+
+
+@volumes_cli.command(
+    "set",
+    examples=[
+        "hf spaces volumes set username/my-space -v hf://models/username/my-model:/models",
+        "hf spaces volumes set username/my-space -v hf://buckets/username/my-bucket:/data -v hf://datasets/username/my-dataset:/datasets:ro",
+    ],
+)
+def volumes_set(
+    space_id: Annotated[str, typer.Argument(help="The space ID (e.g. `username/repo-name`).")],
+    volume: VolumesOpt = None,
+    format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
+    token: TokenOpt = None,
+) -> None:
+    """Set (replace) volumes for a Space."""
+    volumes = parse_volumes(volume)
+    if not volumes:
+        raise CLIError("At least one volume must be specified with -v/--volume.")
+    api = get_hf_api(token=token)
+    api.set_space_volumes(space_id, volumes=volumes)
+    out.result("Volumes set", space_id=space_id, volumes=[v.to_str() for v in volumes])
+
+
+@volumes_cli.command(
+    "delete",
+    examples=[
+        "hf spaces volumes delete username/my-space",
+        "hf spaces volumes delete username/my-space --yes",
+    ],
+)
+def volumes_delete(
+    space_id: Annotated[str, typer.Argument(help="The space ID (e.g. `username/repo-name`).")],
+    yes: Annotated[
+        bool,
+        typer.Option(
+            "-y",
+            "--yes",
+            help="Answer Yes to prompt automatically.",
+        ),
+    ] = False,
+    format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
+    token: TokenOpt = None,
+) -> None:
+    """Remove all volumes from a Space."""
+    out.confirm(f"You are about to remove all volumes from Space '{space_id}'. Proceed?", yes=yes)
+    api = get_hf_api(token=token)
+    api.delete_space_volumes(space_id)
+    out.result("Volumes deleted", space_id=space_id)

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -507,6 +507,9 @@ def volumes_ls(
     volumes = info.runtime.volumes or []
     items = [api_object_to_dict(v) for v in volumes]
     out.table(items)
+    out.hint(
+        f"Use `hf spaces volumes set {space_id} -v hf://<repo_type>/<repo_id>:/<mount_path>` to set volumes for a Space."
+    )
 
 
 @volumes_cli.command(
@@ -529,6 +532,7 @@ def volumes_set(
     api = get_hf_api(token=token)
     api.set_space_volumes(space_id, volumes=volumes)
     out.result("Volumes set", space_id=space_id, volumes=[v.to_str() for v in volumes])
+    out.hint(f"Use `hf spaces volumes ls {space_id}` to list volumes for a Space.")
 
 
 @volumes_cli.command(
@@ -556,3 +560,6 @@ def volumes_delete(
     api = get_hf_api(token=token)
     api.delete_space_volumes(space_id)
     out.result("Volumes deleted", space_id=space_id)
+    out.hint(
+        f"Use `hf spaces volumes set {space_id} -v hf://<repo_type>/<repo_id>:/<mount_path>` to set volumes for a Space."
+    )


### PR DESCRIPTION
Mentioned by @davanstrien  in https://github.com/huggingface/hub-docs/pull/2381#discussion_r3085482607.

## Summary

Adds `hf spaces volumes ls/set/delete` to manage Space volumes from the CLI. Reuses the existing `-v`/`--volume` syntax from `hf repos create` and `hf jobs run`.

## Examples

```
$ hf spaces volumes ls Wauplin/test-volumes
TYPE    SOURCE                MOUNT_PATH READ_ONLY
------- --------------------- ---------- ---------
model   gpt2                  /data      ✔        
dataset badlogicgames/pi-mono /data2     ✔        
Hint: Use `hf spaces volumes set Wauplin/test-volumes -v hf://<repo_type>/<repo_id>:/<mount_path>` to set volumes for a Space.

$ hf spaces volumes set Wauplin/test-volumes -v hf://models/gpt2:/data-new
✓ Volumes set
  space_id: Wauplin/test-volumes
  volumes: ['hf://models/gpt2:/data-new']
Hint: Use `hf spaces volumes ls Wauplin/test-volumes` to list volumes for a Space.

$ hf spaces volumes ls Wauplin/test-volumes                               
TYPE  SOURCE MOUNT_PATH READ_ONLY
----- ------ ---------- ---------
model gpt2   /data-new  ✔        
Hint: Use `hf spaces volumes set Wauplin/test-volumes -v hf://<repo_type>/<repo_id>:/<mount_path>` to set volumes for a Space.

$ hf spaces volumes delete Wauplin/test-volumes
You are about to remove all volumes from Space 'Wauplin/test-volumes'. Proceed? [y/N]: 
Aborted!

$ hf spaces volumes delete Wauplin/test-volumes --yes
✓ Volumes deleted
  space_id: Wauplin/test-volumes
Hint: Use `hf spaces volumes set Wauplin/test-volumes -v hf://<repo_type>/<repo_id>:/<mount_path>` to set volumes for a Space.

$ hf spaces volumes ls Wauplin/test-volumes                               
No results found.
Hint: Use `hf spaces volumes set Wauplin/test-volumes -v hf://<repo_type>/<repo_id>:/<mount_path>` to set volumes for a Space.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Next I think we should also add commands for environment variables, secrets, sleep time and to request new hardware. If we agree on the syntax in this PR, adding the next ones should be straightforward.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new CLI paths that can modify a Space’s mounted volumes (including destructive replace/delete), so mistakes could impact running Spaces but the change is largely additive and gated behind explicit user actions.
> 
> **Overview**
> Adds a new `hf spaces volumes` CLI group with `ls`, `set`, and `delete` commands to manage Space volume mounts via `space_info`, `set_space_volumes`, and `delete_space_volumes`, including confirmation prompting for deletes.
> 
> Introduces `Volume.to_hf_handle()` to round-trip volumes back into the CLI `hf://...` syntax for output, and updates docs (`manage-spaces.md` and generated `cli.md`) to document the new commands and examples.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f2137defd6093a57cc8771b45f1bc40fc955613. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->