### PR TITLE
[Internal] Update AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,36 +65,48 @@ Python client library for the Hugging Face Hub. Source code is in `src/huggingfa
 - `tqdm.py` — Custom progress bar wrappers.
 - Other: `_datetime.py`, `_dotenv.py`, `_git_credential.py`, `_subprocess.py`, `_telemetry.py`, `sha.py`, `_xet.py`, ...
 
-### Serialization (`src/huggingface_hub/serialization/`)
-
-- `_torch.py` — `save_torch_model()`, `load_torch_model()`, state-dict splitting, safetensors support.
-- `_dduf.py` — DDUF format support.
-
 ### CLI (`src/huggingface_hub/cli/`)
 
-Entry point: `hf.py` (Typer app). Subcommands split into modules: `auth.py`, `repo.py`, `repo_files.py`, etc.
+Entry point: `hf.py` (Typer app). Subcommands split into modules: `auth.py`, `repos.py`, `spaces.py`, `models.py`, `datasets.py`, `buckets.py`, `jobs.py`, `collections.py`, `webhooks.py`, etc.
 
-### Tests (`tests/`)
+#### Adding CLI commands
 
-- One `test_<module>.py` per source module (e.g. `test_hf_api.py`, `test_file_download.py`, `test_inference_client.py`).
-- `conftest.py` — Fixtures (temp cache dirs, env patching).
-- `testing_utils.py` / `testing_constants.py` — Shared test helpers and staging-repo constants.
-- `cassettes/` — Recorded HTTP responses for offline tests (`@pytest.mark.vcr`). **Do not add new cassettes.**
-- `fixtures/` — Static test data.
+**Structure & naming conventions:**
 
-### Dev scripts (`utils/`)
+- Commands are organized as **Typer groups** registered in `hf.py` (e.g. `app.add_typer(spaces_cli, name="spaces")`).
+- Each module creates its app with `typer_factory(help="...")` and defines commands with `@app.command("name")`.
+- Use **pipe-separated aliases**: `@app.command("list | ls")` registers both `list` and `ls`.
+- Use standard **verb names**: `ls`/`list`, `info`, `create`, `set`, `delete`, `update`.
+- For **sub-resources** with multiple operations, create a nested subgroup: `volumes_cli = typer_factory(...)` then `spaces_cli.add_typer(volumes_cli, name="volumes")` → gives `hf spaces volumes ls/set/delete`. See `repos.py` for examples (`tag_cli`, `branch_cli`).
 
-- `check_static_imports.py` — Ensures `__init__.py` static imports match the lazy loader.
-- `check_all_variable.py` — Validates `__all__` exports.
-- `generate_async_inference_client.py` — Generates `AsyncInferenceClient` from sync client.
-- `generate_inference_types.py` — Generates inference type definitions.
-- `generate_cli_reference.py` — Generates CLI docs.
+**Reusable option types** (from `_cli_utils.py` — import and use these, don't reinvent):
 
-## Style
+- `TokenOpt`, `RepoIdArg`, `RepoTypeOpt`, `RevisionOpt` — standard auth/repo options.
+- `SearchOpt`, `AuthorOpt`, `FilterOpt`, `LimitOpt` — list/search options.
+- `FormatWithAutoOpt` / `FormatOpt` — output format (`auto|json|human|quiet|agent`).
+- `VolumesOpt` + `parse_volumes()` — `-v`/`--volume` flag with `hf://[TYPE/]SOURCE:/MOUNT_PATH[:ro]` syntax.
+- `get_hf_api(token=token)` — creates an `HfApi` instance with token.
+- `api_object_to_dict(obj)` — converts dataclass API objects to dicts for output.
 
-- Max line length: 119 chars.
-- Linter/formatter: `ruff`.
-- Imports sorted by `ruff` (isort-compatible).
+**Output** (from `_output.py` — use the `out` singleton):
+
+- `out.table(items)` — list results (auto-formats as padded table / TSV / JSON depending on `--format`).
+- `out.dict(data)` — single-item detail view.
+- `out.result("Message", key=value, ...)` — success summary with green checkmark.
+- `out.confirm("Prompt?", yes=yes)` — confirmation for destructive operations. Pair with a `-y`/`--yes` flag.
+- `out.hint("...")` — actionable follow-up suggestion. Try to add hints when adding new commands or refactoring a command. Hints should preferably reuse the input args to be specific to the current use case. Example: `out.hint(f"Use 'hf buckets ls {bucket_id}' to list files from the bucket.")` after a bucket creation.
+- `out.text()`, `out.warning()`, `out.error()` — free-form output.
+
+**Destructive operations** should use `out.confirm()` with a `yes: Annotated[bool, typer.Option("-y", "--yes", help="Answer Yes to prompt automatically.")]` parameter.
+
+**Errors**: raise `CLIError("message")` for user-facing errors. Never wrap API calls with try/except for `RepositoryNotFoundError`, `RevisionNotFoundError`, etc. (already done globally)
+
+**Generated docs**: `make style` auto-regenerates `docs/source/en/package_reference/cli.md` via `utils/generate_cli_reference.py`. Don't edit that file by hand.
+
+**Guides**: update the CLI guide `docs/sources/en/guides/cli.md` when adding / updating CLI commands. If the command is specific to a topic which has its own guide in `docs/sources/en/guides`, add a mention in the guide as well, using the same tone as the existing guide.
+
+**CLI tests**: add tests in `tests/test_cli.py`. Try to group tests into classes when relevant. Do not add a test for each specific use case / parameter set. Usually testing the 1-2 main use cases is enough.
+
 
 ### Type checking: local vs CI
 
@@ -105,8 +117,8 @@ Locally, `make quality` runs `ty check src` using whatever version of `ty` is in
 
 If CI fails on type checks that pass locally, the likely cause is a newer `ty` version or a `mypy`-only diagnostic. Fix the reported errors rather than downgrading the checker.
 
-## Testing notes
+## Commits & PRs
 
-- Tests use `pytest` with `pytest-env` setting `HUGGINGFACE_CO_STAGING=1` (tests hit staging Hub by default).
-- Most integration tests require `HF_TOKEN` to be set. Unit tests don't.
-- do not register or commit new HTTP cassettes.
+- **Commit message prefix**: use `[Area]` prefix matching the scope, e.g. `[CLI] Add ...`, `[CLI] Fix ...`, `[Inference] ...`.
+- **PR title**: short (under 70 chars), same `[Area]` prefix convention.
+- **PR description**: keep it casual. Include a `## Summary` with a few bullet points and real CLI/code **examples** from manual testing (copy-paste terminal output). No need for a formal "Test plan" section.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,8 @@ Entry point: `hf.py` (Typer app). Subcommands split into modules: `auth.py`, `re
 
 **Output** (from `_output.py` — use the `out` singleton):
 
+Convention: stderr for prompts/warnings, stdout for data. Warnings go to stderr even in quiet/json modes.
+
 - `out.table(items)` — list results (auto-formats as padded table / TSV / JSON depending on `--format`).
 - `out.dict(data)` — single-item detail view.
 - `out.result("Message", key=value, ...)` — success summary with green checkmark.
@@ -122,3 +124,21 @@ If CI fails on type checks that pass locally, the likely cause is a newer `ty` v
 - **Commit message prefix**: use `[Area]` prefix matching the scope, e.g. `[CLI] Add ...`, `[CLI] Fix ...`, `[Inference] ...`.
 - **PR title**: short (under 70 chars), same `[Area]` prefix convention.
 - **PR description**: keep it casual. Include a `## Summary` with a few bullet points and real CLI/code **examples** from manual testing (copy-paste terminal output). No need for a formal "Test plan" section. Call out breaking changes explicitly if any. It is important to document any decision taken in the PR or instructions provided in the prompt while working on the PR, ideally with the rationale behind it.
+
+## Code conventions
+
+### Simplicity is the #1 priority
+
+- No premature abstractions. No unnecessary generalization.
+- Don't implement features until they're actually needed.
+- Don't accept parameters without a use case.
+- No redundant `try`/`except` - don't catch errors already handled up the call stack.
+- Prefer strictness now, relax later.
+
+### Follow Python 3.10+ idioms
+
+- `match`/`case` over `if`/`elif` chains when dispatching on a value.
+- `str | None` not `Optional[str]`.
+- f-strings over `.format()` or `%`.
+- Walrus operator (`:=`) when it improves readability.
+- Comprehensions over `map`/`filter` with lambdas.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,4 +121,4 @@ If CI fails on type checks that pass locally, the likely cause is a newer `ty` v
 
 - **Commit message prefix**: use `[Area]` prefix matching the scope, e.g. `[CLI] Add ...`, `[CLI] Fix ...`, `[Inference] ...`.
 - **PR title**: short (under 70 chars), same `[Area]` prefix convention.
-- **PR description**: keep it casual. Include a `## Summary` with a few bullet points and real CLI/code **examples** from manual testing (copy-paste terminal output). No need for a formal "Test plan" section.
+- **PR description**: keep it casual. Include a `## Summary` with a few bullet points and real CLI/code **examples** from manual testing (copy-paste terminal output). No need for a formal "Test plan" section. It is important to document any decision taken in the PR or instructions provided in the prompt while working on the PR, ideally with the rational behind it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,4 +121,4 @@ If CI fails on type checks that pass locally, the likely cause is a newer `ty` v
 
 - **Commit message prefix**: use `[Area]` prefix matching the scope, e.g. `[CLI] Add ...`, `[CLI] Fix ...`, `[Inference] ...`.
 - **PR title**: short (under 70 chars), same `[Area]` prefix convention.
-- **PR description**: keep it casual. Include a `## Summary` with a few bullet points and real CLI/code **examples** from manual testing (copy-paste terminal output). No need for a formal "Test plan" section. It is important to document any decision taken in the PR or instructions provided in the prompt while working on the PR, ideally with the rational behind it.
+- **PR description**: keep it casual. Include a `## Summary` with a few bullet points and real CLI/code **examples** from manual testing (copy-paste terminal output). No need for a formal "Test plan" section. Call out breaking changes explicitly if any. It is important to document any decision taken in the PR or instructions provided in the prompt while working on the PR, ideally with the rationale behind it.


### PR DESCRIPTION
This PR updates `AGENTS.md` with instructions that I usually give to my local Claude. I think they can be relevant to everyone else.

In particular:
- adding specifics about how to deal with the CLI since it's one of the main focus at the moment. Especially:
  - mention `out.xxx` in detail and nudge the agent to add some nice `out.hints` to new commands
  - do not try/catch errors in most cases
  - update CLI guide + CLI package reference + any relate guide
  - CLI tests should not cover everything, just the main use cases
- some instructions around PRs and commit messages (casual, explicit [Topic] in title, etc.)

I also removed parts that felt useless for an AGENTS.md or not relevant for what we work on at the moment.

Any suggestion welcome!

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes that do not affect runtime behavior. Risk is limited to potentially incorrect guidance for future contributors.
> 
> **Overview**
> Updates `AGENTS.md` to emphasize **CLI-focused development conventions**, including how to structure Typer command groups, reuse standard option types, and use the `out` output helpers (including confirmations and hints).
> 
> Adds contribution guidance around **destructive operations**, user-facing error handling via `CLIError`, generated CLI docs regeneration, minimal CLI test expectations, and new conventions for **commit/PR titles and descriptions**, plus general Python 3.10+ style recommendations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c863a4d103393ed3e93e0ab46f6ed48bf979488c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->