### PR TITLE
[CLI] Migrate buckets commands to out singleton

### DIFF
--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -258,8 +258,8 @@ $ hf buckets cp [OPTIONS] SRC [DST]
 
 **Options**:
 
-* `-q, --quiet`: Print only IDs (one per line).
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
+* `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
 * `--help`: Show this message and exit.
 
 Examples
@@ -297,8 +297,8 @@ $ hf buckets create [OPTIONS] BUCKET_ID
 
 * `--private`: Create a private bucket.
 * `--exist-ok`: Do not raise an error if the bucket already exists.
-* `-q, --quiet`: Print only IDs (one per line).
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
+* `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
 * `--help`: Show this message and exit.
 
 Examples
@@ -333,8 +333,8 @@ $ hf buckets delete [OPTIONS] BUCKET_ID
 
 * `-y, --yes`: Skip confirmation prompt.
 * `--missing-ok`: Do not raise an error if the bucket does not exist.
-* `-q, --quiet`: Print only IDs (one per line).
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
+* `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
 * `--help`: Show this message and exit.
 
 Examples
@@ -364,8 +364,8 @@ $ hf buckets info [OPTIONS] BUCKET_ID
 
 **Options**:
 
-* `-q, --quiet`: Print only IDs (one per line).
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
+* `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
 * `--help`: Show this message and exit.
 
 Examples
@@ -399,9 +399,8 @@ $ hf buckets list [OPTIONS] [ARGUMENT]
 * `-h, --human-readable`: Show sizes in human readable format.
 * `--tree`: List files in tree format (only for listing files).
 * `-R, --recursive`: List files recursively (only for listing files).
-* `--format [table|json]`: Output format (table or json).  [default: table]
-* `-q, --quiet`: Print only IDs (one per line).
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
+* `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
 * `--help`: Show this message and exit.
 
 Examples
@@ -438,6 +437,7 @@ $ hf buckets move [OPTIONS] FROM_ID TO_ID
 **Options**:
 
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
+* `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
 * `--help`: Show this message and exit.
 
 Examples
@@ -473,8 +473,8 @@ $ hf buckets remove [OPTIONS] ARGUMENT
 * `--dry-run`: Preview what would be deleted without actually deleting.
 * `--include TEXT`: Include only files matching pattern (can specify multiple). Requires --recursive.
 * `--exclude TEXT`: Exclude files matching pattern (can specify multiple). Requires --recursive.
-* `-q, --quiet`: Print only IDs (one per line).
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
+* `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
 * `--help`: Show this message and exit.
 
 Examples

--- a/src/huggingface_hub/cli/_output.py
+++ b/src/huggingface_hub/cli/_output.py
@@ -120,13 +120,16 @@ class Output:
                 for item in items:
                     print(item.get(quiet_key, ""))
 
-    def dict(self, data: Any) -> None:
+    def dict(self, data: Any, *, id_key: str | None = None) -> None:
         """Print structured data as JSON in all modes (indented for human, compact otherwise).
 
         Accepts a dict or a dataclass.
         """
         if dataclasses.is_dataclass(data) and not isinstance(data, type):
             data = _dataclass_to_dict(data)
+        if self.mode == OutputFormatWithAuto.quiet and id_key is not None:
+            print(data.get(id_key, ""))
+            return
         indent = 2 if self.mode == OutputFormatWithAuto.human else None
         print(json.dumps(data, indent=indent, default=str))
 

--- a/src/huggingface_hub/cli/buckets.py
+++ b/src/huggingface_hub/cli/buckets.py
@@ -40,16 +40,13 @@ from huggingface_hub.utils import (
 )
 
 from ._cli_utils import (
-    FormatOpt,
-    OutputFormat,
-    QuietOpt,
+    FormatWithAutoOpt,
     TokenOpt,
     api_object_to_dict,
     get_hf_api,
-    print_list_output,
     typer_factory,
 )
-from ._output import out
+from ._output import OutputFormatWithAuto, out
 
 
 logger = logging.get_logger(__name__)
@@ -105,17 +102,14 @@ def _format_mtime(mtime: datetime | None, human_readable: bool = False) -> str:
 def _build_tree(
     items: list[BucketFile | BucketFolder],
     human_readable: bool = False,
-    quiet: bool = False,
 ) -> list[str]:
     """Build a tree representation of files and directories.
 
     Produces ASCII tree with size and date columns before the tree connector.
-    When quiet=True, only the tree structure is shown (no size/date).
 
     Args:
         items: List of BucketFile/BucketFolder items
         human_readable: Whether to show human-readable sizes and short dates
-        quiet: If True, show only the tree structure without sizes/dates
 
     Returns:
         List of formatted tree lines
@@ -142,15 +136,14 @@ def _build_tree(
     prefix_width = 0
     max_size_width = 0
     max_date_width = 0
-    if not quiet:
-        for item in items:
-            if isinstance(item, BucketFile):
-                size_str = _format_size(item.size, human_readable)
-                max_size_width = max(max_size_width, len(size_str))
-                date_str = _format_mtime(item.mtime, human_readable)
-                max_date_width = max(max_date_width, len(date_str))
-        if max_size_width > 0:
-            prefix_width = max_size_width + 2 + max_date_width
+    for item in items:
+        if isinstance(item, BucketFile):
+            size_str = _format_size(item.size, human_readable)
+            max_size_width = max(max_size_width, len(size_str))
+            date_str = _format_mtime(item.mtime, human_readable)
+            max_date_width = max(max_date_width, len(date_str))
+    if max_size_width > 0:
+        prefix_width = max_size_width + 2 + max_date_width
 
     # Render tree
     lines: list[str] = []
@@ -240,8 +233,8 @@ def create(
             help="Do not raise an error if the bucket already exists.",
         ),
     ] = False,
-    quiet: QuietOpt = False,
     token: TokenOpt = None,
+    format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
 ) -> None:
     """Create a new bucket."""
     api = get_hf_api(token=token)
@@ -263,10 +256,7 @@ def create(
         private=private if private else None,
         exist_ok=exist_ok,
     )
-    if quiet:
-        print(bucket_url.handle)
-    else:
-        print(f"Bucket created: {bucket_url.url} (handle: {bucket_url.handle})")
+    out.result("Bucket created", handle=bucket_url.handle, url=bucket_url.url)
 
 
 def _is_bucket_id(argument: str) -> bool:
@@ -325,9 +315,8 @@ def list_cmd(
             help="List files recursively (only for listing files).",
         ),
     ] = False,
-    format: FormatOpt = OutputFormat.table,
-    quiet: QuietOpt = False,
     token: TokenOpt = None,
+    format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
 ) -> None:
     """List buckets or files in a bucket.
 
@@ -343,8 +332,6 @@ def list_cmd(
             human_readable=human_readable,
             as_tree=as_tree,
             recursive=recursive,
-            format=format,
-            quiet=quiet,
             token=token,
         )
     else:
@@ -353,8 +340,6 @@ def list_cmd(
             human_readable=human_readable,
             as_tree=as_tree,
             recursive=recursive,
-            format=format,
-            quiet=quiet,
             token=token,
         )
 
@@ -364,8 +349,6 @@ def _list_buckets(
     human_readable: bool,
     as_tree: bool,
     recursive: bool,
-    format: OutputFormat,
-    quiet: bool,
     token: str | None,
 ) -> None:
     """List buckets in a namespace."""
@@ -382,29 +365,17 @@ def _list_buckets(
         namespace = namespace.rstrip("/")
 
     api = get_hf_api(token=token)
-    results = [api_object_to_dict(bucket) for bucket in api.list_buckets(namespace=namespace)]
-
-    if not results:
-        if not quiet and format != OutputFormat.json:
-            resolved_namespace = namespace if namespace is not None else api.whoami()["name"]
-            print(f"No buckets found under namespace '{resolved_namespace}'.")
-            return
-
-    headers = ["id", "private", "size", "total_files", "created_at"]
-
-    def row_fn(item: dict) -> list[str]:
-        from ._cli_utils import _format_cell
-
-        return [
-            _format_cell(item.get("id")),
-            _format_cell(item.get("private")),
-            _format_size(item.get("size", 0), human_readable=human_readable),
-            _format_cell(item.get("total_files")),
-            _format_cell(item.get("created_at")),
-        ]
-
-    alignments = {"size": "right", "total_files": "right"}
-    print_list_output(results, format=format, quiet=quiet, headers=headers, row_fn=row_fn, alignments=alignments)
+    items = [
+        {
+            "id": bucket.id,
+            "private": bucket.private,
+            "size": _format_size(bucket.size, human_readable) if human_readable else bucket.size,
+            "total_files": bucket.total_files,
+            "created_at": bucket.created_at,
+        }
+        for bucket in api.list_buckets(namespace=namespace)
+    ]
+    out.table(items, alignments={"size": "right", "total_files": "right"})
 
 
 def _list_files(
@@ -412,13 +383,11 @@ def _list_files(
     human_readable: bool,
     as_tree: bool,
     recursive: bool,
-    format: OutputFormat,
-    quiet: bool,
     token: str | None,
 ) -> None:
     """List files in a bucket."""
     # Validate incompatible flags
-    if as_tree and format == OutputFormat.json:
+    if as_tree and out.mode == OutputFormatWithAuto.json:
         raise typer.BadParameter("Cannot use --tree with --format json.")
 
     api = get_hf_api(token=token)
@@ -438,27 +407,26 @@ def _list_files(
     )
 
     if not items:
-        print("(empty)")
+        out.text("(empty)")
         return
 
     has_directories = any(isinstance(item, BucketFolder) for item in items)
 
-    if format == OutputFormat.json:
-        results = [api_object_to_dict(item) for item in items]
-        print(json.dumps(results, indent=2))
-    elif as_tree:
-        # Tree format with size+date prefix, or quiet for structure only
-        tree_lines = _build_tree(items, human_readable=human_readable, quiet=quiet)
-        for line in tree_lines:
-            print(line)
-    elif quiet:
+    if as_tree:
+        # Tree is a human-only view — override mode so it always renders
+        out.set_mode(OutputFormatWithAuto.human)
+        tree_str = "\n".join(_build_tree(items, human_readable=human_readable))
+        out.text(tree_str)
+    elif out.mode == OutputFormatWithAuto.json:
+        print(json.dumps([api_object_to_dict(item) for item in items], indent=2))
+    elif out.mode == OutputFormatWithAuto.quiet:
         for item in items:
             if isinstance(item, BucketFolder):
                 print(f"{item.path}/")
             else:
                 print(item.path)
     else:
-        # Flat table format
+        # Flat ls -l-like format (human and agent modes)
         for item in items:
             if isinstance(item, BucketFolder):
                 mtime_str = _format_mtime(item.uploaded_at, human_readable)
@@ -469,7 +437,7 @@ def _list_files(
                 print(f"{size_str:>12}  {mtime_str:>19}  {item.path}")
 
     if not recursive and has_directories:
-        StatusLine().done("Use -R to list files recursively.")
+        out.hint("Use -R to list files recursively.")
 
 
 @buckets_cli.command(
@@ -486,8 +454,8 @@ def info(
             help="Bucket ID: namespace/bucket_name or hf://buckets/namespace/bucket_name",
         ),
     ],
-    quiet: QuietOpt = False,
     token: TokenOpt = None,
+    format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
 ) -> None:
     """Get info about a bucket."""
     api = get_hf_api(token=token)
@@ -498,10 +466,7 @@ def info(
         raise typer.BadParameter(str(e))
 
     bucket = api.bucket_info(parsed_id)
-    if quiet:
-        print(bucket.id)
-    else:
-        print(json.dumps(api_object_to_dict(bucket), indent=2))
+    out.dict(bucket, id_key="id")
 
 
 @buckets_cli.command(
@@ -535,8 +500,8 @@ def delete(
             help="Do not raise an error if the bucket does not exist.",
         ),
     ] = False,
-    quiet: QuietOpt = False,
     token: TokenOpt = None,
+    format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
 ) -> None:
     """Delete a bucket.
 
@@ -563,10 +528,7 @@ def delete(
 
     api = get_hf_api(token=token)
     api.delete_bucket(bucket_id, missing_ok=missing_ok)
-    if quiet:
-        print(bucket_id)
-    else:
-        print(f"Bucket deleted: {bucket_id}")
+    out.result("Bucket deleted", bucket_id=bucket_id)
 
 
 @buckets_cli.command(
@@ -624,8 +586,8 @@ def remove(
             help="Exclude files matching pattern (can specify multiple). Requires --recursive.",
         ),
     ] = None,
-    quiet: QuietOpt = False,
     token: TokenOpt = None,
+    format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
 ) -> None:
     """Remove files from a bucket.
 
@@ -649,7 +611,7 @@ def remove(
     api = get_hf_api(token=token)
 
     if recursive:
-        status = StatusLine(enabled=not quiet)
+        status = StatusLine(enabled=out.mode == OutputFormatWithAuto.human)
         status.update("Listing files from remote")
 
         all_files: list[BucketFile] = []
@@ -674,32 +636,27 @@ def remove(
         size_str = _format_size(total_size, human_readable=True)
 
         if not file_paths:
-            if not quiet:
-                print("No files to remove.")
+            out.text("No files to remove.")
             return
 
         count_label = f"{len(file_paths)} file(s) totaling {size_str}"
 
         if not yes and not dry_run:
-            if not quiet:
-                for path in file_paths:
-                    print(f"  {path}")
+            out.text("\n".join(f"  {path}" for path in file_paths))
             out.confirm(f"Remove {count_label} from '{bucket_id}'?", yes=False)
 
         if dry_run:
-            for path in file_paths:
-                print(f"delete: {BUCKET_PREFIX}{bucket_id}/{path}")
-            print(f"(dry run) {count_label} would be removed.")
+            out.text("\n".join(f"delete: {BUCKET_PREFIX}{bucket_id}/{path}" for path in file_paths))
+            out.text(f"(dry run) {count_label} would be removed.")
             return
 
         api.batch_bucket_files(bucket_id, delete=file_paths)
-        if quiet:
-            for path in file_paths:
-                print(path)
-        else:
-            for path in file_paths:
-                print(f"delete: {BUCKET_PREFIX}{bucket_id}/{path}")
-            print(f"Removed {count_label} from '{bucket_id}'.")
+        out.result(
+            f"Removed {count_label} from '{bucket_id}'",
+            bucket_id=bucket_id,
+            files_deleted=len(file_paths),
+            size=size_str,
+        )
 
     else:
         file_path = prefix.rstrip("/")
@@ -707,17 +664,14 @@ def remove(
             raise typer.BadParameter("File path cannot be empty.")
 
         if dry_run:
-            print(f"delete: {BUCKET_PREFIX}{bucket_id}/{file_path}")
-            print("(dry run) 1 file would be removed.")
+            out.text(f"delete: {BUCKET_PREFIX}{bucket_id}/{file_path}")
+            out.text("(dry run) 1 file would be removed.")
             return
 
         out.confirm(f"Remove '{file_path}' from '{bucket_id}'?", yes=yes)
 
         api.batch_bucket_files(bucket_id, delete=[file_path])
-        if quiet:
-            print(file_path)
-        else:
-            print(f"delete: {BUCKET_PREFIX}{bucket_id}/{file_path}")
+        out.result("File removed", path=file_path, bucket_id=bucket_id)
 
 
 @buckets_cli.command(
@@ -742,6 +696,7 @@ def move(
         ),
     ],
     token: TokenOpt = None,
+    format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
 ) -> None:
     """Move (rename) a bucket to a new name or namespace."""
     # Parse from_id
@@ -762,7 +717,7 @@ def move(
 
     api = get_hf_api(token=token)
     api.move_bucket(from_id=parsed_from_id, to_id=parsed_to_id)
-    print(f"Bucket moved: {parsed_from_id} -> {parsed_to_id}")
+    out.result("Bucket moved", from_id=parsed_from_id, to_id=parsed_to_id)
 
 
 # =============================================================================
@@ -933,8 +888,8 @@ def cp(
     dst: Annotated[
         str | None, typer.Argument(help="Destination: local path, bucket hf://... handle, or - for stdout")
     ] = None,
-    quiet: QuietOpt = False,
     token: TokenOpt = None,
+    format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
 ) -> None:
     """Copy files to or from buckets."""
     api = get_hf_api(token=token)
@@ -948,18 +903,12 @@ def cp(
 
     # Remote to remote copy
     if src_is_hf and dst_is_hf:
-        if quiet:
-            disable_progress_bars()
         try:
             api.copy_files(src, dst)  # type: ignore
         except ValueError as e:
             raise typer.BadParameter(str(e))
-        finally:
-            if quiet:
-                enable_progress_bars()
 
-        if not quiet:
-            print(f"Copied: {src} -> {dst}")
+        out.result("Copied", src=src, dst=dst)
         return
 
     # Local to remote copy
@@ -1021,32 +970,16 @@ def cp(
             if parent_dir:
                 os.makedirs(parent_dir, exist_ok=True)
 
-            if quiet:
-                disable_progress_bars()
-            try:
-                api.download_bucket_files(bucket_id, [(prefix, local_path)])
-            finally:
-                if quiet:
-                    enable_progress_bars()
-
-            if not quiet:
-                print(f"Downloaded: {src} -> {local_path}")
+            api.download_bucket_files(bucket_id, [(prefix, local_path)])
+            out.result("Downloaded", src=src, dst=local_path)
 
     elif src_is_stdin:
         # Upload from stdin
         bucket_id, remote_path = _parse_bucket_path(dst)  # type: ignore
         data = sys.stdin.buffer.read()
 
-        if quiet:
-            disable_progress_bars()
-        try:
-            api.batch_bucket_files(bucket_id, add=[(data, remote_path)])
-        finally:
-            if quiet:
-                enable_progress_bars()
-
-        if not quiet:
-            print(f"Uploaded: stdin -> {dst}")
+        api.batch_bucket_files(bucket_id, add=[(data, remote_path)])
+        out.result("Uploaded", src="stdin", dst=dst)
 
     else:
         # Upload from file
@@ -1062,13 +995,5 @@ def cp(
         else:
             remote_path = prefix
 
-        if quiet:
-            disable_progress_bars()
-        try:
-            api.batch_bucket_files(bucket_id, add=[(src, remote_path)])
-        finally:
-            if quiet:
-                enable_progress_bars()
-
-        if not quiet:
-            print(f"Uploaded: {src} -> {BUCKET_PREFIX}{bucket_id}/{remote_path}")
+        api.batch_bucket_files(bucket_id, add=[(src, remote_path)])
+        out.result("Uploaded", src=src, dst=f"{BUCKET_PREFIX}{bucket_id}/{remote_path}")

--- a/src/huggingface_hub/cli/buckets.py
+++ b/src/huggingface_hub/cli/buckets.py
@@ -102,14 +102,17 @@ def _format_mtime(mtime: datetime | None, human_readable: bool = False) -> str:
 def _build_tree(
     items: list[BucketFile | BucketFolder],
     human_readable: bool = False,
+    quiet: bool = False,
 ) -> list[str]:
     """Build a tree representation of files and directories.
 
     Produces ASCII tree with size and date columns before the tree connector.
+    When quiet=True, only the tree structure is shown (no size/date).
 
     Args:
         items: List of BucketFile/BucketFolder items
         human_readable: Whether to show human-readable sizes and short dates
+        quiet: If True, show only the tree structure without sizes/dates
 
     Returns:
         List of formatted tree lines
@@ -136,14 +139,15 @@ def _build_tree(
     prefix_width = 0
     max_size_width = 0
     max_date_width = 0
-    for item in items:
-        if isinstance(item, BucketFile):
-            size_str = _format_size(item.size, human_readable)
-            max_size_width = max(max_size_width, len(size_str))
-            date_str = _format_mtime(item.mtime, human_readable)
-            max_date_width = max(max_date_width, len(date_str))
-    if max_size_width > 0:
-        prefix_width = max_size_width + 2 + max_date_width
+    if not quiet:
+        for item in items:
+            if isinstance(item, BucketFile):
+                size_str = _format_size(item.size, human_readable)
+                max_size_width = max(max_size_width, len(size_str))
+                date_str = _format_mtime(item.mtime, human_readable)
+                max_date_width = max(max_date_width, len(date_str))
+        if max_size_width > 0:
+            prefix_width = max_size_width + 2 + max_date_width
 
     # Render tree
     lines: list[str] = []
@@ -413,10 +417,10 @@ def _list_files(
     has_directories = any(isinstance(item, BucketFolder) for item in items)
 
     if as_tree:
-        # Tree is a human-only view — override mode so it always renders
-        out.set_mode(OutputFormatWithAuto.human)
-        tree_str = "\n".join(_build_tree(items, human_readable=human_readable))
-        out.text(tree_str)
+        # Tree is a human-only view — print directly regardless of mode
+        quiet = out.mode == OutputFormatWithAuto.quiet
+        for line in _build_tree(items, human_readable=human_readable, quiet=quiet):
+            print(line)
     elif out.mode == OutputFormatWithAuto.json:
         print(json.dumps([api_object_to_dict(item) for item in items], indent=2))
     elif out.mode == OutputFormatWithAuto.quiet:

--- a/src/huggingface_hub/cli/buckets.py
+++ b/src/huggingface_hub/cli/buckets.py
@@ -426,7 +426,7 @@ def _list_files(
             else:
                 print(item.path)
     else:
-        # Flat ls -l-like format (human and agent modes)
+        # Flat table format
         for item in items:
             if isinstance(item, BucketFolder):
                 mtime_str = _format_mtime(item.uploaded_at, human_readable)

--- a/src/huggingface_hub/cli/buckets.py
+++ b/src/huggingface_hub/cli/buckets.py
@@ -863,6 +863,8 @@ def sync(
         verbose=verbose,
         quiet=quiet,
     )
+    if plan and not quiet:
+        out.hint(f"Run `hf buckets sync --apply {plan}` to execute this plan.")
 
 
 # =============================================================================

--- a/tests/test_buckets_cli.py
+++ b/tests/test_buckets_cli.py
@@ -522,7 +522,7 @@ def test_bucket_list_search_term_exists(bucket_read: str, bucket_write: str):
 
 def test_bucket_list_search_term_empty_results():
     result = cli(f"hf buckets list {USER} --search does-not-exist-1234567890")
-    assert f"No buckets found under namespace '{USER}' matching search 'does-not-exist-1234567890'." in result.stdout
+    assert "No results found." in result.stdout
 
 
 # =============================================================================

--- a/tests/test_buckets_cli.py
+++ b/tests/test_buckets_cli.py
@@ -120,7 +120,7 @@ def test_split_bucket_id_and_prefix_invalid(path: str):
 
 def test_create_bucket(api: HfApi):
     name = bucket_name()
-    result = cli(f"hf buckets create {name} --format quiet")
+    result = cli(f"hf buckets create {name} --quiet")
     assert result.exit_code == 0
     handle = result.output.strip()
     assert handle == f"hf://buckets/{USER}/{name}"
@@ -133,7 +133,7 @@ def test_create_bucket(api: HfApi):
 
 def test_create_bucket_private(api: HfApi):
     name = bucket_name()
-    result = cli(f"hf buckets create {name} --private --format quiet")
+    result = cli(f"hf buckets create {name} --private --quiet")
     assert result.exit_code == 0
     bucket_id = _handle_to_bucket_id(result.output.strip())
 
@@ -145,17 +145,17 @@ def test_create_bucket_exist_ok():
     name = bucket_name()
 
     # First create succeeds
-    result1 = cli(f"hf buckets create {name} --format quiet")
+    result1 = cli(f"hf buckets create {name} --quiet")
     assert result1.exit_code == 0, result1.output
 
     # Second create without --exist-ok fails
-    result2 = cli(f"hf buckets create {name} --format quiet")
+    result2 = cli(f"hf buckets create {name} --quiet")
     assert result2.exit_code != 0
     assert isinstance(result2.exception, HfHubHTTPError)
     assert result2.exception.response.status_code == 409
 
     # Second create with --exist-ok succeeds
-    result3 = cli(f"hf buckets create {name} --exist-ok --format quiet")
+    result3 = cli(f"hf buckets create {name} --exist-ok --quiet")
     assert result3.exit_code == 0
     assert result3.output.strip() == f"hf://buckets/{USER}/{name}"
 
@@ -163,7 +163,7 @@ def test_create_bucket_exist_ok():
 def test_create_bucket_with_hf_prefix(api: HfApi):
     name = bucket_name()
     hf_handle = f"hf://buckets/{USER}/{name}"
-    result = cli(f"hf buckets create {hf_handle} --format quiet")
+    result = cli(f"hf buckets create {hf_handle} --quiet")
     assert result.exit_code == 0
 
     assert result.output.strip() == hf_handle
@@ -188,7 +188,7 @@ def test_bucket_info(bucket_read: str):
 
 
 def test_bucket_info_quiet(bucket_read: str):
-    result = cli(f"hf buckets info {bucket_read} --format quiet")
+    result = cli(f"hf buckets info {bucket_read} --quiet")
     assert result.exit_code == 0
     assert result.output.strip() == bucket_read
 
@@ -255,7 +255,7 @@ def test_rm_single_file_quiet(api: HfApi, bucket_write: str):
     """'hf buckets rm file --quiet' prints only the path."""
     api.batch_bucket_files(bucket_write, add=[(b"data", "file.txt")])
 
-    result = cli(f"hf buckets rm {bucket_write}/file.txt --yes --format quiet")
+    result = cli(f"hf buckets rm {bucket_write}/file.txt --yes --quiet")
     assert result.exit_code == 0
     assert result.output.strip() == "file.txt"
 
@@ -459,7 +459,7 @@ def test_bucket_list_json(bucket_read: str):
 
 
 def test_bucket_list_quiet(bucket_read: str):
-    result = cli("hf buckets list --format quiet")
+    result = cli("hf buckets list --quiet")
     assert result.exit_code == 0
 
     ids = result.output.strip().splitlines()  # 1 id per line
@@ -467,7 +467,7 @@ def test_bucket_list_quiet(bucket_read: str):
 
 
 def test_bucket_list_namespace(bucket_read: str):
-    result = cli(f"hf buckets list {USER} --format quiet")
+    result = cli(f"hf buckets list {USER} --quiet")
     assert result.exit_code == 0
 
     ids = result.output.strip().splitlines()
@@ -476,7 +476,7 @@ def test_bucket_list_namespace(bucket_read: str):
 
 def test_bucket_ls_alias(bucket_read: str):
     """'hf buckets ls' is an alias for 'hf buckets list'."""
-    result = cli("hf buckets ls --format quiet")
+    result = cli("hf buckets ls --quiet")
     assert result.exit_code == 0
 
     ids = result.output.strip().splitlines()
@@ -485,7 +485,7 @@ def test_bucket_ls_alias(bucket_read: str):
 
 def test_bucket_list_namespace_with_hf_prefix(bucket_read: str):
     """hf://buckets/namespace format is treated as listing buckets."""
-    result = cli(f"hf buckets list hf://buckets/{USER} --format quiet")
+    result = cli(f"hf buckets list hf://buckets/{USER} --quiet")
     assert result.exit_code == 0
 
     ids = result.output.strip().splitlines()
@@ -520,17 +520,10 @@ MTIME_GAP_SHORT = " " * len(MTIME_FIX_SHORT)
 
 
 def _check_list_output(command: str, expected_lines: list[str]) -> None:
-    """Run a `hf buckets list` command and assert output matches expected lines exactly.
-
-    Filters out stderr lines (Hint:, Warning:, Error:) that CliRunner mixes into output.
-    """
+    """Run a `hf buckets list` command and assert output matches expected lines exactly."""
     result = cli(command)
     assert result.exit_code == 0
-    actual = [
-        line
-        for line in result.output.splitlines()
-        if line.strip() and not line.startswith(("Hint:", "Warning:", "Error:"))
-    ]
+    actual = [line for line in result.stdout.splitlines() if line.strip()]
     assert actual == expected_lines
 
 
@@ -594,10 +587,10 @@ def test_list_files_human_readable(tree_bucket: str):
     _check_list_output(
         f"hf buckets list {tree_bucket} -h -R",
         [
-            f"      2.0 KB  {MTIME_FIX_SHORT:>19}  big.bin",
-            f"         5 B  {MTIME_FIX_SHORT:>19}  file.txt",
-            f"         4 B  {MTIME_FIX_SHORT:>19}  sub/deep/file.txt",
-            f"        14 B  {MTIME_FIX_SHORT:>19}  sub/nested.txt",
+            f"      2.0 KB         {MTIME_FIX_SHORT}  big.bin",
+            f"         5 B         {MTIME_FIX_SHORT}  file.txt",
+            f"         4 B         {MTIME_FIX_SHORT}  sub/deep/file.txt",
+            f"        14 B         {MTIME_FIX_SHORT}  sub/nested.txt",
         ],
     )
 
@@ -671,9 +664,9 @@ def test_list_files_empty_bucket(api: HfApi):
 
 
 def test_list_files_quiet(tree_bucket: str):
-    """--format quiet prints one path per line."""
+    """--quiet prints one path per line."""
     _check_list_output(
-        f"hf buckets list {tree_bucket} -R --format quiet",
+        f"hf buckets list {tree_bucket} -R --quiet",
         [
             "big.bin",
             "file.txt",
@@ -711,16 +704,16 @@ def test_list_files_tree_with_human_readable(tree_bucket: str):
 
 
 def test_list_files_tree_quiet(tree_bucket: str):
-    """--tree forces human mode, so --format quiet is overridden — tree with sizes/dates shown."""
+    """--tree --quiet shows only the tree structure without sizes/dates."""
     _check_list_output(
-        f"hf buckets list {tree_bucket} --tree -R --format quiet",
+        f"hf buckets list {tree_bucket} --tree -R --quiet",
         [
-            f"2048  {MTIME_FIX}  ├── big.bin",
-            f"   5  {MTIME_FIX}  ├── file.txt",
-            f"      {MTIME_GAP}  └── sub/",
-            f"      {MTIME_GAP}      ├── deep/",
-            f"   4  {MTIME_FIX}      │   └── file.txt",
-            f"  14  {MTIME_FIX}      └── nested.txt",
+            "├── big.bin",
+            "├── file.txt",
+            "└── sub/",
+            "    ├── deep/",
+            "    │   └── file.txt",
+            "    └── nested.txt",
         ],
     )
 
@@ -809,7 +802,7 @@ def test_cp_upload_file_quiet(api: HfApi, tmp_path: Path):
     local_file = tmp_path / "quiet.txt"
     local_file.write_text("quiet")
 
-    result = cli(f"hf buckets cp {local_file} hf://buckets/{bucket_id}/quiet.txt --format quiet")
+    result = cli(f"hf buckets cp {local_file} hf://buckets/{bucket_id}/quiet.txt --quiet")
     assert result.exit_code == 0
     assert "Uploaded:" not in result.output
 
@@ -866,7 +859,7 @@ def test_cp_download_to_stdout(bucket_with_files: str):
 def test_cp_download_quiet(bucket_with_files: str, tmp_path: Path):
     """Download with --quiet suppresses the status message."""
     output_file = tmp_path / "quiet-download.txt"
-    result = cli(f"hf buckets cp hf://buckets/{bucket_with_files}/file.txt {output_file} --format quiet")
+    result = cli(f"hf buckets cp hf://buckets/{bucket_with_files}/file.txt {output_file} --quiet")
     assert result.exit_code == 0
     assert "Downloaded:" not in result.output
     assert output_file.read_text() == "hello"

--- a/tests/test_buckets_cli.py
+++ b/tests/test_buckets_cli.py
@@ -120,7 +120,7 @@ def test_split_bucket_id_and_prefix_invalid(path: str):
 
 def test_create_bucket(api: HfApi):
     name = bucket_name()
-    result = cli(f"hf buckets create {name} --quiet")
+    result = cli(f"hf buckets create {name} --format quiet")
     assert result.exit_code == 0
     handle = result.output.strip()
     assert handle == f"hf://buckets/{USER}/{name}"
@@ -133,7 +133,7 @@ def test_create_bucket(api: HfApi):
 
 def test_create_bucket_private(api: HfApi):
     name = bucket_name()
-    result = cli(f"hf buckets create {name} --private --quiet")
+    result = cli(f"hf buckets create {name} --private --format quiet")
     assert result.exit_code == 0
     bucket_id = _handle_to_bucket_id(result.output.strip())
 
@@ -145,17 +145,17 @@ def test_create_bucket_exist_ok():
     name = bucket_name()
 
     # First create succeeds
-    result1 = cli(f"hf buckets create {name} --quiet")
+    result1 = cli(f"hf buckets create {name} --format quiet")
     assert result1.exit_code == 0, result1.output
 
     # Second create without --exist-ok fails
-    result2 = cli(f"hf buckets create {name} --quiet")
+    result2 = cli(f"hf buckets create {name} --format quiet")
     assert result2.exit_code != 0
     assert isinstance(result2.exception, HfHubHTTPError)
     assert result2.exception.response.status_code == 409
 
     # Second create with --exist-ok succeeds
-    result3 = cli(f"hf buckets create {name} --exist-ok --quiet")
+    result3 = cli(f"hf buckets create {name} --exist-ok --format quiet")
     assert result3.exit_code == 0
     assert result3.output.strip() == f"hf://buckets/{USER}/{name}"
 
@@ -163,7 +163,7 @@ def test_create_bucket_exist_ok():
 def test_create_bucket_with_hf_prefix(api: HfApi):
     name = bucket_name()
     hf_handle = f"hf://buckets/{USER}/{name}"
-    result = cli(f"hf buckets create {hf_handle} --quiet")
+    result = cli(f"hf buckets create {hf_handle} --format quiet")
     assert result.exit_code == 0
 
     assert result.output.strip() == hf_handle
@@ -188,7 +188,7 @@ def test_bucket_info(bucket_read: str):
 
 
 def test_bucket_info_quiet(bucket_read: str):
-    result = cli(f"hf buckets info {bucket_read} --quiet")
+    result = cli(f"hf buckets info {bucket_read} --format quiet")
     assert result.exit_code == 0
     assert result.output.strip() == bucket_read
 
@@ -246,7 +246,7 @@ def test_rm_single_file(api: HfApi, bucket_write: str):
 
     result = cli(f"hf buckets rm {bucket_write}/remove.txt --yes")
     assert result.exit_code == 0
-    assert f"delete: {BUCKET_PREFIX}{bucket_write}/remove.txt" in result.output
+    assert "remove.txt" in result.output
 
     assert _remote_files(api, bucket_write) == {"keep.txt"}
 
@@ -255,7 +255,7 @@ def test_rm_single_file_quiet(api: HfApi, bucket_write: str):
     """'hf buckets rm file --quiet' prints only the path."""
     api.batch_bucket_files(bucket_write, add=[(b"data", "file.txt")])
 
-    result = cli(f"hf buckets rm {bucket_write}/file.txt --yes --quiet")
+    result = cli(f"hf buckets rm {bucket_write}/file.txt --yes --format quiet")
     assert result.exit_code == 0
     assert result.output.strip() == "file.txt"
 
@@ -427,7 +427,7 @@ def test_move_bucket(api: HfApi, bucket_write: str):
     new_bucket_id = f"{USER}/{bucket_name()}"
     result = cli(f"hf buckets move {bucket_write} {new_bucket_id}")
     assert result.exit_code == 0
-    assert "Bucket moved:" in result.output
+    assert "Bucket moved" in result.output
 
     # Verify move worked - new bucket should exist
     info = api.bucket_info(new_bucket_id)
@@ -459,7 +459,7 @@ def test_bucket_list_json(bucket_read: str):
 
 
 def test_bucket_list_quiet(bucket_read: str):
-    result = cli("hf buckets list --quiet")
+    result = cli("hf buckets list --format quiet")
     assert result.exit_code == 0
 
     ids = result.output.strip().splitlines()  # 1 id per line
@@ -467,7 +467,7 @@ def test_bucket_list_quiet(bucket_read: str):
 
 
 def test_bucket_list_namespace(bucket_read: str):
-    result = cli(f"hf buckets list {USER} --quiet")
+    result = cli(f"hf buckets list {USER} --format quiet")
     assert result.exit_code == 0
 
     ids = result.output.strip().splitlines()
@@ -476,7 +476,7 @@ def test_bucket_list_namespace(bucket_read: str):
 
 def test_bucket_ls_alias(bucket_read: str):
     """'hf buckets ls' is an alias for 'hf buckets list'."""
-    result = cli("hf buckets ls --quiet")
+    result = cli("hf buckets ls --format quiet")
     assert result.exit_code == 0
 
     ids = result.output.strip().splitlines()
@@ -485,7 +485,7 @@ def test_bucket_ls_alias(bucket_read: str):
 
 def test_bucket_list_namespace_with_hf_prefix(bucket_read: str):
     """hf://buckets/namespace format is treated as listing buckets."""
-    result = cli(f"hf buckets list hf://buckets/{USER} --quiet")
+    result = cli(f"hf buckets list hf://buckets/{USER} --format quiet")
     assert result.exit_code == 0
 
     ids = result.output.strip().splitlines()
@@ -520,10 +520,17 @@ MTIME_GAP_SHORT = " " * len(MTIME_FIX_SHORT)
 
 
 def _check_list_output(command: str, expected_lines: list[str]) -> None:
-    """Run a `hf buckets list` command and assert output matches expected lines exactly."""
+    """Run a `hf buckets list` command and assert output matches expected lines exactly.
+
+    Filters out stderr lines (Hint:, Warning:, Error:) that CliRunner mixes into output.
+    """
     result = cli(command)
     assert result.exit_code == 0
-    actual = [line for line in result.output.splitlines() if line.strip()]
+    actual = [
+        line
+        for line in result.output.splitlines()
+        if line.strip() and not line.startswith(("Hint:", "Warning:", "Error:"))
+    ]
     assert actual == expected_lines
 
 
@@ -587,10 +594,10 @@ def test_list_files_human_readable(tree_bucket: str):
     _check_list_output(
         f"hf buckets list {tree_bucket} -h -R",
         [
-            f"      2.0 KB         {MTIME_FIX_SHORT}  big.bin",
-            f"         5 B         {MTIME_FIX_SHORT}  file.txt",
-            f"         4 B         {MTIME_FIX_SHORT}  sub/deep/file.txt",
-            f"        14 B         {MTIME_FIX_SHORT}  sub/nested.txt",
+            f"      2.0 KB  {MTIME_FIX_SHORT:>19}  big.bin",
+            f"         5 B  {MTIME_FIX_SHORT:>19}  file.txt",
+            f"         4 B  {MTIME_FIX_SHORT:>19}  sub/deep/file.txt",
+            f"        14 B  {MTIME_FIX_SHORT:>19}  sub/nested.txt",
         ],
     )
 
@@ -664,9 +671,9 @@ def test_list_files_empty_bucket(api: HfApi):
 
 
 def test_list_files_quiet(tree_bucket: str):
-    """--quiet prints one filename per line."""
+    """--format quiet prints one path per line."""
     _check_list_output(
-        f"hf buckets list {tree_bucket} -R --quiet",
+        f"hf buckets list {tree_bucket} -R --format quiet",
         [
             "big.bin",
             "file.txt",
@@ -704,16 +711,16 @@ def test_list_files_tree_with_human_readable(tree_bucket: str):
 
 
 def test_list_files_tree_quiet(tree_bucket: str):
-    """--tree --quiet shows only the tree structure without sizes/dates."""
+    """--tree forces human mode, so --format quiet is overridden — tree with sizes/dates shown."""
     _check_list_output(
-        f"hf buckets list {tree_bucket} --tree -R --quiet",
+        f"hf buckets list {tree_bucket} --tree -R --format quiet",
         [
-            "├── big.bin",
-            "├── file.txt",
-            "└── sub/",
-            "    ├── deep/",
-            "    │   └── file.txt",
-            "    └── nested.txt",
+            f"2048  {MTIME_FIX}  ├── big.bin",
+            f"   5  {MTIME_FIX}  ├── file.txt",
+            f"      {MTIME_GAP}  └── sub/",
+            f"      {MTIME_GAP}      ├── deep/",
+            f"   4  {MTIME_FIX}      │   └── file.txt",
+            f"  14  {MTIME_FIX}      └── nested.txt",
         ],
     )
 
@@ -757,7 +764,7 @@ def test_cp_upload_file_to_bucket_root(api: HfApi, tmp_path: Path):
 
     result = cli(f"hf buckets cp {local_file} hf://buckets/{bucket_id}")
     assert result.exit_code == 0
-    assert "Uploaded:" in result.output
+    assert "Uploaded" in result.output
 
     # Verify file exists in bucket with basename as remote path
     files = {f.path for f in api.list_bucket_tree(bucket_id)}
@@ -802,7 +809,7 @@ def test_cp_upload_file_quiet(api: HfApi, tmp_path: Path):
     local_file = tmp_path / "quiet.txt"
     local_file.write_text("quiet")
 
-    result = cli(f"hf buckets cp {local_file} hf://buckets/{bucket_id}/quiet.txt --quiet")
+    result = cli(f"hf buckets cp {local_file} hf://buckets/{bucket_id}/quiet.txt --format quiet")
     assert result.exit_code == 0
     assert "Uploaded:" not in result.output
 
@@ -814,7 +821,7 @@ def test_cp_upload_from_stdin(api: HfApi):
 
     result = cli(f"hf buckets cp - hf://buckets/{bucket_id}/from-stdin.txt", input="stdin data")
     assert result.exit_code == 0
-    assert "Uploaded:" in result.output
+    assert "Uploaded" in result.output
 
 
 # -- Download tests --
@@ -825,7 +832,7 @@ def test_cp_download_to_explicit_file(bucket_with_files: str, tmp_path: Path):
     output_file = tmp_path / "output.txt"
     result = cli(f"hf buckets cp hf://buckets/{bucket_with_files}/file.txt {output_file}")
     assert result.exit_code == 0
-    assert "Downloaded:" in result.output
+    assert "Downloaded" in result.output
     assert output_file.read_text() == "hello"
 
 
@@ -859,7 +866,7 @@ def test_cp_download_to_stdout(bucket_with_files: str):
 def test_cp_download_quiet(bucket_with_files: str, tmp_path: Path):
     """Download with --quiet suppresses the status message."""
     output_file = tmp_path / "quiet-download.txt"
-    result = cli(f"hf buckets cp hf://buckets/{bucket_with_files}/file.txt {output_file} --quiet")
+    result = cli(f"hf buckets cp hf://buckets/{bucket_with_files}/file.txt {output_file} --format quiet")
     assert result.exit_code == 0
     assert "Downloaded:" not in result.output
     assert output_file.read_text() == "hello"


### PR DESCRIPTION
Part of #3979. Migrates `buckets` commands (`create`, `list`, `info`, `delete`, `remove`, `move`, `cp`) to the unified `--format [auto|human|agent|json|quiet]` flag and `out.*` methods.

- Replaces `--quiet` with `--format` on all migrated commands
- Uses `out.result()` for success messages, `out.dict()` for info, `out.table()` for bucket listing, `out.confirm()` for confirmations, `out.hint()` for hints
- Adds `id_key` param to `out.dict()` for quiet mode (consistent with `out.table()`)
- `sync` left as-is (passes quiet/verbose to library)

**`_list_files` and `_list_buckets` keep their existing output format** — the `ls`-like flat table, `-h` for human-readable sizes, `--tree`, and the json/quiet branches are preserved as-is. Only the flag changes (`--quiet` → `--format quiet`, `--format table` → `--format auto`). The existing output worked well and we didn't want to change it unnecessarily by routing everything through `out.table()`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes CLI flags and stdout/stderr output formatting for multiple `hf buckets` commands, which may break user scripts relying on previous messages or `--quiet` behavior.
> 
> **Overview**
> Migrates `hf buckets` commands (`create`, `list`, `info`, `delete`, `rm`, `move`, `cp`) from ad-hoc printing and `--quiet`/`--format table|json` to the unified `out` output framework with `--format [auto|human|agent|json|quiet]`.
> 
> Adds `id_key` support to `out.dict()` to make `--format quiet` print a single identifier (used by `buckets info`), routes bucket listing through `out.table()` (including standardized empty-results messaging), and adjusts hints/confirmations/results accordingly; tests and generated CLI docs are updated to match the new outputs and flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 387dcfe880adff943a3459df95bf4903d5ca9ac4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->