### PR TITLE
[Internal] Fix slack-message draft release permissions + update model

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -425,7 +425,7 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.RELEASE_NOTES_HF_TOKEN }}
           GITHUB_TOKEN_RELEASE_NOTES: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_NOTES_MODEL: "huggingface/MiniMaxAI/MiniMax-M2.5"
+          RELEASE_NOTES_MODEL: "zai-org/GLM-5.1"
         run: |
           python -m utils.release_notes.generate_release_notes \
             --since "${{ needs.prepare.outputs.since_tag }}" \
@@ -521,7 +521,7 @@ jobs:
   # ============================================================
   slack-message:
     permissions:
-      contents: read
+      contents: write  # need write to list draft releases
     needs: [prepare, release-notes]
     # Use !cancelled() so this job runs even if release-notes failed (we fetch the draft directly from GitHub).
     # This also allows re-running this job after manually editing the draft release notes.
@@ -567,7 +567,7 @@ jobs:
       - name: Generate Slack message
         env:
           HF_TOKEN: ${{ secrets.RELEASE_NOTES_HF_TOKEN }}
-          RELEASE_NOTES_MODEL: "huggingface/MiniMaxAI/MiniMax-M2.5"
+          RELEASE_NOTES_MODEL: "zai-org/GLM-5.1"
         run: |
           VERSION="${{ needs.prepare.outputs.version }}"
           BASE_VERSION=$(echo "$VERSION" | sed -E 's/\.rc.*//')


### PR DESCRIPTION
The slack-message job failed because it had `contents: read` permissions and couldn't list draft GH releases created by the `release-notes` job. Upgrade to `contents: write` so `gh release list` can see drafts.

i was looking for separate releases permission scope but`contents: write` is the minimum to access draft release notes, cf: https://github.com/cli/cli/issues/3037


Also update `RELEASE_NOTES_MODEL` to `zai-org/GLM-5.1`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Workflow now grants the `slack-message` job broader `contents: write` permissions, increasing the blast radius of a compromised job/token; functional changes are otherwise limited to switching the AI model used for generated text.
> 
> **Overview**
> Fixes the prerelease `slack-message` job by elevating its GitHub Actions permissions to `contents: write`, allowing `gh release list` to see draft releases created earlier in the workflow.
> 
> Updates the OpenCode `RELEASE_NOTES_MODEL` used for both GitHub release-note generation and Slack announcement generation from `huggingface/MiniMaxAI/MiniMax-M2.5` to `zai-org/GLM-5.1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 821637d4fe48f4a11e4752e19f22757f7ff2785f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->