### PR TITLE
[CLI] Detect `pi` agent

### DIFF
--- a/src/huggingface_hub/utils/_detect_agent.py
+++ b/src/huggingface_hub/utils/_detect_agent.py
@@ -46,6 +46,7 @@ _TOOL_AGENTS: tuple[tuple[tuple[str, ...], str], ...] = (
     (("GOOSE_TERMINAL",), "goose"),
     (("OPENCLAW_SHELL",), "openclaw"),
     (("OPENCODE_CLIENT",), "opencode"),
+    (("PI_CODING_AGENT",), "pi"),
     (("REPL_ID",), "replit"),
     (("ROO_ACTIVE",), "roo-code"),
     (("TRAE_AI_SHELL_ID",), "trae"),


### PR DESCRIPTION
This PR adds the detection of Pi sessions when `PI_CODING_AGENT` is set, matching the env var added in [badlogic/pi-mono@6101583](https://github.com/badlogic/pi-mono/commit/61015830ed64e6144d90c7f429e1b512c35b8e78)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single new environment-variable check for agent detection and only affects the reported `agent/...` user-agent suffix when `PI_CODING_AGENT` is set.
> 
> **Overview**
> Adds support for detecting *Pi* coding sessions by mapping the `PI_CODING_AGENT` environment variable to the `pi` agent name in `detect_agent()`, which in turn can be appended to the telemetry user-agent string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b5e255664dc70bcadf202baeb84bb6eb984c3db. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->