### PR TITLE
[Internal] Make RELEASE_NOTES_MODEL configurable via repo variable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@
 #
 # Required repository variables:
 # - SLACK_CHANNEL_ID                     : Slack channel ID for release notifications
+# - RELEASE_NOTES_MODEL                  : HF model ID used to generate release notes and Slack announcement (e.g. `zai-org/GLM-5.1`)
 #
 # An additional secret for OpenCode authentication is needed for automated release notes generation
 # (see the release-notes job below).
@@ -425,7 +426,7 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.RELEASE_NOTES_HF_TOKEN }}
           GITHUB_TOKEN_RELEASE_NOTES: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_NOTES_MODEL: "zai-org/GLM-5.1"
+          RELEASE_NOTES_MODEL: ${{ vars.RELEASE_NOTES_MODEL }}
         run: |
           python -m utils.release_notes.generate_release_notes \
             --since "${{ needs.prepare.outputs.since_tag }}" \
@@ -567,7 +568,7 @@ jobs:
       - name: Generate Slack message
         env:
           HF_TOKEN: ${{ secrets.RELEASE_NOTES_HF_TOKEN }}
-          RELEASE_NOTES_MODEL: "zai-org/GLM-5.1"
+          RELEASE_NOTES_MODEL: ${{ vars.RELEASE_NOTES_MODEL }}
         run: |
           VERSION="${{ needs.prepare.outputs.version }}"
           BASE_VERSION=$(echo "$VERSION" | sed -E 's/\.rc.*//')


### PR DESCRIPTION
Follow-up https://github.com/huggingface/huggingface_hub/pull/4119

- Replace the hardcoded `RELEASE_NOTES_MODEL: \"zai-org/GLM-5.1\"` in the release workflow with `\${{ vars.RELEASE_NOTES_MODEL }}` so the model used for release notes generation and the Slack announcement can be changed from the GitHub repo settings without editing the workflow file.
- Document the new required repository variable in the workflow header.

Needs a `RELEASE_NOTES_MODEL` repository variable to be set (e.g. `zai-org/GLM-5.1`) before the next release run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release GitHub Actions workflow behavior by sourcing `RELEASE_NOTES_MODEL` from repository variables, so misconfiguration could break automated release-notes/Slack message generation during releases.
> 
> **Overview**
> Makes the release workflow’s AI model selection configurable by replacing the hardcoded `RELEASE_NOTES_MODEL` with `${{ vars.RELEASE_NOTES_MODEL }}` for both OpenCode release-notes generation and Slack announcement generation.
> 
> Documents `RELEASE_NOTES_MODEL` as a required repository variable in the workflow header comments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 677218e74e518cf908ed836ee5f1bbad23e2d391. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->