### PR TITLE
[Buckets] Add search param to list_buckets

### DIFF
--- a/docs/source/en/guides/buckets.md
+++ b/docs/source/en/guides/buckets.md
@@ -128,6 +128,16 @@ username/logs                321.8 MB        2000 2026-02-13
 
 # List buckets in a specific namespace
 >>> hf buckets ls huggingface
+
+# Filter buckets by name
+>>> hf buckets list --search "checkpoint"
+```
+
+You can also filter buckets by name using `search`:
+
+```py
+>>> for bucket in list_buckets(search="checkpoint"):
+...     print(bucket.id)
 ```
 
 You can use the `--quiet` and `--format json` options to get different output format. This is particularly interesting if you want to pipe the output to another tool like `grep` or `jq`.

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -574,6 +574,9 @@ username/logs                321.8 MB        2000 2026-02-13
 
 # List buckets in a specific namespace
 >>> hf buckets ls my-org
+
+# Filter buckets by name
+>>> hf buckets list --search "checkpoint"
 ```
 
 To get detailed information about a specific bucket (returned as JSON), use `hf buckets info`:

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -399,6 +399,7 @@ $ hf buckets list [OPTIONS] [ARGUMENT]
 * `-h, --human-readable`: Show sizes in human readable format.
 * `--tree`: List files in tree format (only for listing files).
 * `-R, --recursive`: List files recursively (only for listing files).
+* `--search TEXT`: Search query.
 * `--format [table|json]`: Output format (table or json).  [default: table]
 * `-q, --quiet`: Print only IDs (one per line).
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
@@ -407,6 +408,7 @@ $ hf buckets list [OPTIONS] [ARGUMENT]
 Examples
   $ hf buckets list
   $ hf buckets list huggingface
+  $ hf buckets list --search "my-prefix"
   $ hf buckets list user/my-bucket
   $ hf buckets list user/my-bucket -R
   $ hf buckets list user/my-bucket -h

--- a/src/huggingface_hub/cli/buckets.py
+++ b/src/huggingface_hub/cli/buckets.py
@@ -394,7 +394,10 @@ def _list_buckets(
     if not results:
         if not quiet and format != OutputFormat.json:
             resolved_namespace = namespace if namespace is not None else api.whoami()["name"]
-            print(f"No buckets found under namespace '{resolved_namespace}'.")
+            if search is None:
+                print(f"No buckets found under namespace '{resolved_namespace}'.")
+            else:
+                print(f"No buckets found under namespace '{resolved_namespace}' matching search '{search}'.")
             return
 
     headers = ["id", "private", "size", "total_files", "created_at"]

--- a/src/huggingface_hub/cli/buckets.py
+++ b/src/huggingface_hub/cli/buckets.py
@@ -43,6 +43,7 @@ from ._cli_utils import (
     FormatOpt,
     OutputFormat,
     QuietOpt,
+    SearchOpt,
     TokenOpt,
     api_object_to_dict,
     get_hf_api,
@@ -283,6 +284,7 @@ def _is_bucket_id(argument: str) -> bool:
     examples=[
         "hf buckets list",
         "hf buckets list huggingface",
+        'hf buckets list --search "my-prefix"',
         "hf buckets list user/my-bucket",
         "hf buckets list user/my-bucket -R",
         "hf buckets list user/my-bucket -h",
@@ -325,6 +327,7 @@ def list_cmd(
             help="List files recursively (only for listing files).",
         ),
     ] = False,
+    search: SearchOpt = None,
     format: FormatOpt = OutputFormat.table,
     quiet: QuietOpt = False,
     token: TokenOpt = None,
@@ -338,6 +341,8 @@ def list_cmd(
     is_file_mode = argument is not None and _is_bucket_id(argument)
 
     if is_file_mode:
+        if search is not None:
+            raise typer.BadParameter("Cannot use --search when listing files.")
         _list_files(
             argument=argument,  # type: ignore
             human_readable=human_readable,
@@ -350,6 +355,7 @@ def list_cmd(
     else:
         _list_buckets(
             namespace=argument,
+            search=search,
             human_readable=human_readable,
             as_tree=as_tree,
             recursive=recursive,
@@ -361,6 +367,7 @@ def list_cmd(
 
 def _list_buckets(
     namespace: str | None,
+    search: str | None,
     human_readable: bool,
     as_tree: bool,
     recursive: bool,
@@ -382,7 +389,7 @@ def _list_buckets(
         namespace = namespace.rstrip("/")
 
     api = get_hf_api(token=token)
-    results = [api_object_to_dict(bucket) for bucket in api.list_buckets(namespace=namespace)]
+    results = [api_object_to_dict(bucket) for bucket in api.list_buckets(namespace=namespace, search=search)]
 
     if not results:
         if not quiet and format != OutputFormat.json:

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -12523,6 +12523,7 @@ class HfApi:
         self,
         namespace: str | None = None,
         *,
+        search: str | None = None,
         token: bool | str | None = None,
     ) -> Iterable[BucketInfo]:
         """List buckets on the Hub under a certain namespace.
@@ -12530,6 +12531,8 @@ class HfApi:
         Args:
             namespace (`str`, *optional*):
                 List buckets under this namespace (user or organization). Defaults to listing user's buckets.
+            search (`str`, *optional*):
+                A search string to filter bucket names.
             token (`bool` or `str`, *optional*):
                 A valid user access token (string). Defaults to the locally saved
                 token, which is the recommended method for authentication (see
@@ -12547,12 +12550,18 @@ class HfApi:
 
             >>> for bucket in list_buckets(namespace="huggingface"): # lists buckets in the "huggingface" organization
             ...     print(bucket)
+
+            >>> for bucket in list_buckets(search="my-prefix"): # filter buckets by name
+            ...     print(bucket)
             ```
         """
         if namespace is None:
             namespace = "me"
+        params: dict[str, Any] = {}
+        if search is not None:
+            params["search"] = search
         for item in paginate(
-            f"{self.endpoint}/api/buckets/{namespace}", params={}, headers=self._build_hf_headers(token=token)
+            f"{self.endpoint}/api/buckets/{namespace}", params=params, headers=self._build_hf_headers(token=token)
         ):
             yield BucketInfo(**item)
 

--- a/tests/test_buckets_cli.py
+++ b/tests/test_buckets_cli.py
@@ -506,6 +506,13 @@ def test_bucket_list_error_recursive_with_namespace():
     assert "Cannot use --recursive when listing buckets" in result.output
 
 
+def test_bucket_list_error_search_with_files(tree_bucket: str):
+    """Cannot use --search when listing files."""
+    result = cli(f"hf buckets list {tree_bucket} --search foo")
+    assert result.exit_code != 0
+    assert "Cannot use --search when listing files" in result.output
+
+
 # =============================================================================
 # List files
 # =============================================================================

--- a/tests/test_buckets_cli.py
+++ b/tests/test_buckets_cli.py
@@ -506,28 +506,23 @@ def test_bucket_list_error_recursive_with_namespace():
     assert "Cannot use --recursive when listing buckets" in result.output
 
 
-def test_bucket_list_error_search_with_files(tree_bucket: str):
+def test_bucket_list_search_error_with_files(tree_bucket: str):
     """Cannot use --search when listing files."""
     result = cli(f"hf buckets list {tree_bucket} --search foo")
     assert result.exit_code != 0
     assert "Cannot use --search when listing files" in result.output
 
 
-def test_bucket_list_empty_search_mentions_filter(monkeypatch: pytest.MonkeyPatch):
-    class DummyApi:
-        def list_buckets(self, namespace: str | None, search: str | None):
-            assert namespace == USER
-            assert search == "does-not-exist-1234567890"
-            return []
+def test_bucket_list_search_term_exists(bucket_read: str, bucket_write: str):
+    search_term = bucket_read.split("/")[1].split("-")[1]  # e.g. 9447e4
+    result = cli(f"hf buckets list {USER} --search {search_term} --quiet")
+    assert bucket_read in result.stdout
+    assert bucket_write not in result.stdout
 
-        def whoami(self):
-            return {"name": USER}
 
-    monkeypatch.setattr("huggingface_hub.cli.buckets.get_hf_api", lambda token=None: DummyApi())
-
+def test_bucket_list_search_term_empty_results():
     result = cli(f"hf buckets list {USER} --search does-not-exist-1234567890")
-    assert result.exit_code == 0
-    assert f"No buckets found under namespace '{USER}' matching search 'does-not-exist-1234567890'." in result.output
+    assert f"No buckets found under namespace '{USER}' matching search 'does-not-exist-1234567890'." in result.stdout
 
 
 # =============================================================================

--- a/tests/test_buckets_cli.py
+++ b/tests/test_buckets_cli.py
@@ -513,6 +513,23 @@ def test_bucket_list_error_search_with_files(tree_bucket: str):
     assert "Cannot use --search when listing files" in result.output
 
 
+def test_bucket_list_empty_search_mentions_filter(monkeypatch: pytest.MonkeyPatch):
+    class DummyApi:
+        def list_buckets(self, namespace: str | None, search: str | None):
+            assert namespace == USER
+            assert search == "does-not-exist-1234567890"
+            return []
+
+        def whoami(self):
+            return {"name": USER}
+
+    monkeypatch.setattr("huggingface_hub.cli.buckets.get_hf_api", lambda token=None: DummyApi())
+
+    result = cli(f"hf buckets list {USER} --search does-not-exist-1234567890")
+    assert result.exit_code == 0
+    assert f"No buckets found under namespace '{USER}' matching search 'does-not-exist-1234567890'." in result.output
+
+
 # =============================================================================
 # List files
 # =============================================================================


### PR DESCRIPTION
Add support for buckets list search params.

_100% vibecoded, but should be fine_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive change that only affects bucket-listing queries and CLI flag parsing; main risk is behavior differences in list results when `--search`/`search` is used.
> 
> **Overview**
> Adds a `search` filter for bucket listing in both Python and CLI.
> 
> `HfApi.list_buckets(..., search=...)` now forwards a `search` query param to the Hub, and `hf buckets list --search ...` exposes it with validation to reject use when listing files plus an updated empty-results message. Documentation and CLI reference are updated and new CLI tests cover the flag and error cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a647a9be54c380b26318ae07572360ec2f06f180. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->