### PR TITLE
[CLI] Add `hf update` + drop interactive update prompt

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -114,15 +114,15 @@ You can also install the CLI using [Homebrew](https://brew.sh/):
 
 Check out the Homebrew huggingface page [here](https://formulae.brew.sh/formula/hf) for more details.
 
-### Upgrading
+### Updating
 
 To upgrade to the latest version, run:
 
 ```bash
->>> hf upgrade
+>>> hf update
 ```
 
-This detects how `hf` was installed (Homebrew, standalone installer, or pip) and runs the matching upgrade command.
+This detects how `hf` was installed (Homebrew, standalone installer, or pip) and runs the matching update command.
 
 By default, the CLI also prints a one-line yellow warning to stderr when a newer version is available on PyPI. To silence it (e.g. in offline CI), set `HF_HUB_DISABLE_UPDATE_CHECK=1`.
 

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -124,7 +124,7 @@ To upgrade to the latest version, run:
 
 This detects how `hf` was installed (Homebrew, standalone installer, or pip) and runs the matching upgrade command.
 
-By default, the CLI also prints a one-line yellow warning to stderr when a newer version is available on PyPI. To silence it (e.g. in offline CI), set `HF_HUB_NO_UPDATE_CHECK=1`.
+By default, the CLI also prints a one-line yellow warning to stderr when a newer version is available on PyPI. To silence it (e.g. in offline CI), set `HF_HUB_DISABLE_UPDATE_CHECK=1`.
 
 ## hf auth login
 

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -114,6 +114,18 @@ You can also install the CLI using [Homebrew](https://brew.sh/):
 
 Check out the Homebrew huggingface page [here](https://formulae.brew.sh/formula/hf) for more details.
 
+### Upgrading
+
+To upgrade to the latest version, run:
+
+```bash
+>>> hf upgrade
+```
+
+This detects how `hf` was installed (Homebrew, standalone installer, or pip) and runs the matching upgrade command.
+
+By default, the CLI also prints a one-line yellow warning to stderr when a newer version is available on PyPI. To silence it (e.g. in offline CI), set `HF_HUB_NO_UPDATE_CHECK=1`.
+
 ## hf auth login
 
 In many cases, you must be logged in to a Hugging Face account to interact with the Hub (download private repos, upload files, create PRs, etc.). To do so, you need a [User Access Token](https://huggingface.co/docs/hub/security-tokens) from your [Settings page](https://huggingface.co/settings/tokens). The User Access Token is used to authenticate your identity to the Hub. Make sure to set a token with write access if you want to upload or modify content.

--- a/docs/source/en/installation.md
+++ b/docs/source/en/installation.md
@@ -118,6 +118,8 @@ On Windows:
 powershell -ExecutionPolicy ByPass -c "irm https://hf.co/cli/install.ps1 | iex"
 ```
 
+To upgrade an existing install, run `hf upgrade` — it detects how `hf` was installed (standalone installer, Homebrew, or pip) and runs the matching command.
+
 ## Install with conda
 
 If you are more familiar with it, you can install `huggingface_hub` using the [conda-forge channel](https://anaconda.org/conda-forge/huggingface_hub):

--- a/docs/source/en/installation.md
+++ b/docs/source/en/installation.md
@@ -118,7 +118,7 @@ On Windows:
 powershell -ExecutionPolicy ByPass -c "irm https://hf.co/cli/install.ps1 | iex"
 ```
 
-To upgrade an existing install, run `hf upgrade` — it detects how `hf` was installed (standalone installer, Homebrew, or pip) and runs the matching command.
+To upgrade an existing install, run `hf update` — it detects how `hf` was installed (standalone installer, Homebrew, or pip) and runs the matching command.
 
 ## Install with conda
 

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -42,7 +42,7 @@ $ hf [OPTIONS] COMMAND [ARGS]...
 * `skills`: Manage skills for AI assistants.
 * `spaces`: Interact with spaces on the Hub.
 * `sync`: Sync files between local directory and a...
-* `upgrade`: Upgrade the `hf` CLI to the latest version.
+* `update`: Update the `hf` CLI to the latest version.
 * `upload`: Upload a file or a folder to the Hub.
 * `upload-large-folder`: Upload a large folder to the Hub.
 * `version`: Print information about the hf version.
@@ -3764,14 +3764,14 @@ $ hf sync [OPTIONS] [SOURCE] [DEST]
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `--help`: Show this message and exit.
 
-## `hf upgrade`
+## `hf update`
 
-Upgrade the `hf` CLI to the latest version.
+Update the `hf` CLI to the latest version.
 
 **Usage**:
 
 ```console
-$ hf upgrade [OPTIONS]
+$ hf update [OPTIONS]
 ```
 
 **Options**:

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -42,6 +42,7 @@ $ hf [OPTIONS] COMMAND [ARGS]...
 * `skills`: Manage skills for AI assistants.
 * `spaces`: Interact with spaces on the Hub.
 * `sync`: Sync files between local directory and a...
+* `upgrade`: Upgrade the `hf` CLI to the latest version.
 * `upload`: Upload a file or a folder to the Hub.
 * `upload-large-folder`: Upload a large folder to the Hub.
 * `version`: Print information about the hf version.
@@ -3761,6 +3762,20 @@ $ hf sync [OPTIONS] [SOURCE] [DEST]
 * `-v, --verbose`: Show detailed logging with reasoning.
 * `-q, --quiet`: Minimal output.
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
+* `--help`: Show this message and exit.
+
+## `hf upgrade`
+
+Upgrade the `hf` CLI to the latest version.
+
+**Usage**:
+
+```console
+$ hf upgrade [OPTIONS]
+```
+
+**Options**:
+
 * `--help`: Show this message and exit.
 
 ## `hf upload`

--- a/docs/source/en/package_reference/environment_variables.md
+++ b/docs/source/en/package_reference/environment_variables.md
@@ -183,7 +183,7 @@ You can set `HF_HUB_DISABLE_TELEMETRY=1` as environment variable to globally dis
 
 ### HF_HUB_DISABLE_UPDATE_CHECK
 
-By default, the `hf` CLI checks PyPI for a newer release at startup (at most once every 24 hours) and prints a one-line yellow warning to stderr when one is available, suggesting `hf upgrade`. The check is already a no-op on dev and pre-release versions.
+By default, the `hf` CLI checks PyPI for a newer release at startup (at most once every 24 hours) and prints a one-line yellow warning to stderr when one is available, suggesting `hf update`. The check is already a no-op on dev and pre-release versions.
 
 Set `HF_HUB_DISABLE_UPDATE_CHECK=1` to skip the PyPI request and silence the warning entirely. Useful in offline CI environments or when you prefer a quieter shell output.
 

--- a/docs/source/en/package_reference/environment_variables.md
+++ b/docs/source/en/package_reference/environment_variables.md
@@ -181,15 +181,15 @@ Each library defines its own policy (i.e. which usage to monitor) but the core i
 
 You can set `HF_HUB_DISABLE_TELEMETRY=1` as environment variable to globally disable telemetry.
 
-### HF_HUB_DISABLE_XET
-
-Set to disable using `hf-xet`, even if it is available in your Python environment. This is since `hf-xet` will be used automatically if it is found, this allows explicitly disabling its usage. If you are disabling Xet, please consider [filing an issue and including the diagnostics](https://github.com/huggingface/xet-core?tab=readme-ov-file#issues-diagnostics--debugging) information to help us understand why Xet is not working for you.
-
-### HF_HUB_NO_UPDATE_CHECK
+### HF_HUB_DISABLE_UPDATE_CHECK
 
 By default, the `hf` CLI checks PyPI for a newer release at startup (at most once every 24 hours) and prints a one-line yellow warning to stderr when one is available, suggesting `hf upgrade`. The check is already a no-op on dev and pre-release versions.
 
-Set `HF_HUB_NO_UPDATE_CHECK=1` to skip the PyPI request and silence the warning entirely. Useful in offline CI environments or when you prefer a quieter shell output.
+Set `HF_HUB_DISABLE_UPDATE_CHECK=1` to skip the PyPI request and silence the warning entirely. Useful in offline CI environments or when you prefer a quieter shell output.
+
+### HF_HUB_DISABLE_XET
+
+Set to disable using `hf-xet`, even if it is available in your Python environment. This is since `hf-xet` will be used automatically if it is found, this allows explicitly disabling its usage. If you are disabling Xet, please consider [filing an issue and including the diagnostics](https://github.com/huggingface/xet-core?tab=readme-ov-file#issues-diagnostics--debugging) information to help us understand why Xet is not working for you.
 
 ### HF_HUB_ENABLE_HF_TRANSFER
 

--- a/docs/source/en/package_reference/environment_variables.md
+++ b/docs/source/en/package_reference/environment_variables.md
@@ -185,6 +185,12 @@ You can set `HF_HUB_DISABLE_TELEMETRY=1` as environment variable to globally dis
 
 Set to disable using `hf-xet`, even if it is available in your Python environment. This is since `hf-xet` will be used automatically if it is found, this allows explicitly disabling its usage. If you are disabling Xet, please consider [filing an issue and including the diagnostics](https://github.com/huggingface/xet-core?tab=readme-ov-file#issues-diagnostics--debugging) information to help us understand why Xet is not working for you.
 
+### HF_HUB_NO_UPDATE_CHECK
+
+By default, the `hf` CLI checks PyPI for a newer release at startup (at most once every 24 hours) and prints a one-line yellow warning to stderr when one is available, suggesting `hf upgrade`. The check is already a no-op on dev and pre-release versions.
+
+Set `HF_HUB_NO_UPDATE_CHECK=1` to skip the PyPI request and silence the warning entirely. Useful in offline CI environments or when you prefer a quieter shell output.
+
 ### HF_HUB_ENABLE_HF_TRANSFER
 
 > [!WARNING]

--- a/src/huggingface_hub/cli/_cli_utils.py
+++ b/src/huggingface_hub/cli/_cli_utils.py
@@ -1006,7 +1006,11 @@ def _check_cli_update(library: Literal["huggingface_hub", "transformers"]) -> No
 
     message = f"A new version of {library} ({latest_version}) is available! You are using version {current_version}."
     if update_command is not None:
-        message += "\nTo update, run: hf upgrade"
+        match library:
+            case "huggingface_hub":
+                message += "\nTo update, run: hf upgrade"
+            case _:
+                message += f"\nTo update, run: {update_command}"
     out.hint(message)
 
 

--- a/src/huggingface_hub/cli/_cli_utils.py
+++ b/src/huggingface_hub/cli/_cli_utils.py
@@ -1007,7 +1007,7 @@ def _check_cli_update(library: Literal["huggingface_hub", "transformers"]) -> No
     message = f"A new version of {library} ({latest_version}) is available! You are using version {current_version}."
     if update_command is not None:
         message += "\nTo update, run: hf upgrade"
-    out.warning(message)
+    out.hint(message)
 
 
 def run_upgrade() -> int:

--- a/src/huggingface_hub/cli/_cli_utils.py
+++ b/src/huggingface_hub/cli/_cli_utils.py
@@ -35,7 +35,6 @@ from typer.core import TyperCommand, TyperGroup
 from huggingface_hub import Volume, __version__, constants
 from huggingface_hub.errors import CLIError
 from huggingface_hub.utils import (
-    ANSI,
     disable_progress_bars,
     get_session,
     hf_raise_for_status,
@@ -953,10 +952,10 @@ def check_cli_update(library: Literal["huggingface_hub", "transformers"]) -> Non
     """
     Check whether a newer version of a library is available on PyPI.
 
-    If a newer version is found and stdin/stderr are attached to a TTY, prompt the user to update interactively.
-    Otherwise (non-TTY or update command cannot be determined), print a warning to stderr.
+    If a newer version is found, print a yellow warning to stderr pointing at `hf upgrade`.
 
     If current version is a pre-release (e.g. `1.0.0.rc1`), or a dev version (e.g. `1.0.0.dev1`), no check is performed.
+    If `HF_HUB_NO_UPDATE_CHECK` is set, the check is skipped entirely.
 
     This function is called at the entry point of the CLI. It only performs the check once every 24 hours, and any error
     during the check is caught and logged, to avoid breaking the CLI.
@@ -972,6 +971,9 @@ def check_cli_update(library: Literal["huggingface_hub", "transformers"]) -> Non
 
 
 def _check_cli_update(library: Literal["huggingface_hub", "transformers"]) -> None:
+    if constants.HF_HUB_NO_UPDATE_CHECK:
+        return
+
     current_version = importlib.metadata.version(library)
 
     # Skip if current version is a pre-release or dev version
@@ -1002,81 +1004,24 @@ def _check_cli_update(library: Literal["huggingface_hub", "transformers"]) -> No
     else:
         update_command = _get_transformers_update_command()
 
-    if sys.stdin.isatty() and sys.stderr.isatty() and update_command is not None:
-        _prompt_autoupdate(library, current_version, latest_version, update_command)
-    else:
-        display_cmd = " ".join(update_command) if update_command else None
-        update_hint = f"To update, run: {ANSI.bold(display_cmd)}" if display_cmd else ""
-        click.echo(
-            ANSI.yellow(
-                f"A new version of {library} ({latest_version}) is available! "
-                f"You are using version {current_version}." + (f"\n{update_hint}" if update_hint else "") + "\n"
-            ),
-            file=sys.stderr,
-        )
+    message = f"A new version of {library} ({latest_version}) is available! You are using version {current_version}."
+    if update_command is not None:
+        message += "\nTo update, run: hf upgrade"
+    out.warning(message)
 
 
-def _prompt_autoupdate(
-    library: str,
-    current_version: str,
-    latest_version: str,
-    update_command: list[str],
-) -> None:
-    """Interactively ask the user if they want to update, and run the update command if accepted.
+def run_upgrade() -> int:
+    """Run the install-method-appropriate upgrade command for the `hf` CLI.
 
-    After a successful update the CLI exits so the user can re-run their command with the new version.
-    All output goes to stderr to keep stdout clean for command output.
+    Raises CLIError if the installation method can't be determined.
+    Returns the subprocess exit code on success/failure of the upgrade itself.
     """
-    display_cmd = " ".join(update_command)
-
-    click.echo("", file=sys.stderr)
-    click.echo(
-        ANSI.yellow(f"  A new version of {library} is available: {current_version} → {latest_version}"),
-        file=sys.stderr,
-    )
-    click.echo("", file=sys.stderr)
-
-    click.echo(
-        ANSI.yellow("  Do you want to update now? [Y/n] ") + ANSI.gray(f"({display_cmd})") + " ",
-        file=sys.stderr,
-        nl=False,
-    )
-    try:
-        raw_answer = sys.stdin.readline()
-    except (EOFError, KeyboardInterrupt):
-        click.echo("", file=sys.stderr)
-        return
-
-    if raw_answer == "":
-        # EOF (e.g. Ctrl+D) — treat as cancellation, not acceptance
-        click.echo("", file=sys.stderr)
-        return
-
-    answer = raw_answer.strip().lower()  # Note: if user press 'Enter', raw_answer is `\n`
-    if answer in ("", "y", "yes"):
-        click.echo("", file=sys.stderr)
-        click.echo(ANSI.gray(f"  Running: {display_cmd}"), file=sys.stderr)
-        click.echo("", file=sys.stderr)
-        returncode = subprocess.call(update_command)
-        if returncode == 0:
-            click.echo("", file=sys.stderr)
-            click.echo(
-                ANSI.green(f"  ✓ Successfully updated {library} to {latest_version}. Please re-run your command."),
-                file=sys.stderr,
-            )
-            raise SystemExit(0)
-        else:
-            click.echo("", file=sys.stderr)
-            click.echo(
-                ANSI.red(f"  ✗ Update failed (exit code {returncode}). Please update manually."),
-                file=sys.stderr,
-            )
-    else:
-        click.echo(
-            ANSI.gray(f"  Skipped. You can update later with: {display_cmd}"),
-            file=sys.stderr,
+    cmd = _get_huggingface_hub_update_command()
+    if cmd is None:
+        raise CLIError(
+            "Cannot determine how to upgrade huggingface_hub (unknown installation method). Please upgrade manually."
         )
-    click.echo("", file=sys.stderr)
+    return subprocess.call(cmd)
 
 
 def _get_huggingface_hub_update_command() -> list[str] | None:

--- a/src/huggingface_hub/cli/_cli_utils.py
+++ b/src/huggingface_hub/cli/_cli_utils.py
@@ -952,7 +952,7 @@ def check_cli_update(library: Literal["huggingface_hub", "transformers"]) -> Non
     """
     Check whether a newer version of a library is available on PyPI.
 
-    If a newer version is found, print a yellow warning to stderr pointing at `hf upgrade`.
+    If a newer version is found, print a hint pointing at `hf upgrade`.
 
     If current version is a pre-release (e.g. `1.0.0.rc1`), or a dev version (e.g. `1.0.0.dev1`), no check is performed.
     If `HF_HUB_DISABLE_UPDATE_CHECK` is set, the check is skipped entirely.

--- a/src/huggingface_hub/cli/_cli_utils.py
+++ b/src/huggingface_hub/cli/_cli_utils.py
@@ -1010,7 +1010,7 @@ def _check_cli_update(library: Literal["huggingface_hub", "transformers"]) -> No
             case "huggingface_hub":
                 message += "\nTo update, run: hf upgrade"
             case _:
-                message += f"\nTo update, run: {update_command}"
+                message += f"\nTo update, run: {' '.join(update_command)}"
     out.hint(message)
 
 

--- a/src/huggingface_hub/cli/_cli_utils.py
+++ b/src/huggingface_hub/cli/_cli_utils.py
@@ -952,7 +952,7 @@ def check_cli_update(library: Literal["huggingface_hub", "transformers"]) -> Non
     """
     Check whether a newer version of a library is available on PyPI.
 
-    If a newer version is found, print a hint pointing at `hf upgrade`.
+    If a newer version is found, print a hint pointing at `hf update`.
 
     If current version is a pre-release (e.g. `1.0.0.rc1`), or a dev version (e.g. `1.0.0.dev1`), no check is performed.
     If `HF_HUB_DISABLE_UPDATE_CHECK` is set, the check is skipped entirely.
@@ -1008,7 +1008,7 @@ def _check_cli_update(library: Literal["huggingface_hub", "transformers"]) -> No
     if update_command is not None:
         match library:
             case "huggingface_hub":
-                message += "\nTo update, run: hf upgrade"
+                message += "\nTo update, run: hf update"
             case _:
                 message += f"\nTo update, run: {' '.join(update_command)}"
     out.hint(message)

--- a/src/huggingface_hub/cli/_cli_utils.py
+++ b/src/huggingface_hub/cli/_cli_utils.py
@@ -955,7 +955,7 @@ def check_cli_update(library: Literal["huggingface_hub", "transformers"]) -> Non
     If a newer version is found, print a yellow warning to stderr pointing at `hf upgrade`.
 
     If current version is a pre-release (e.g. `1.0.0.rc1`), or a dev version (e.g. `1.0.0.dev1`), no check is performed.
-    If `HF_HUB_NO_UPDATE_CHECK` is set, the check is skipped entirely.
+    If `HF_HUB_DISABLE_UPDATE_CHECK` is set, the check is skipped entirely.
 
     This function is called at the entry point of the CLI. It only performs the check once every 24 hours, and any error
     during the check is caught and logged, to avoid breaking the CLI.
@@ -971,7 +971,7 @@ def check_cli_update(library: Literal["huggingface_hub", "transformers"]) -> Non
 
 
 def _check_cli_update(library: Literal["huggingface_hub", "transformers"]) -> None:
-    if constants.HF_HUB_NO_UPDATE_CHECK:
+    if constants.HF_HUB_DISABLE_UPDATE_CHECK:
         return
 
     current_version = importlib.metadata.version(library)

--- a/src/huggingface_hub/cli/_cli_utils.py
+++ b/src/huggingface_hub/cli/_cli_utils.py
@@ -1014,16 +1014,16 @@ def _check_cli_update(library: Literal["huggingface_hub", "transformers"]) -> No
     out.hint(message)
 
 
-def run_upgrade() -> int:
-    """Run the install-method-appropriate upgrade command for the `hf` CLI.
+def run_update() -> int:
+    """Run the install-method-appropriate update command for the `hf` CLI.
 
     Raises CLIError if the installation method can't be determined.
-    Returns the subprocess exit code on success/failure of the upgrade itself.
+    Returns the subprocess exit code on success/failure of the update itself.
     """
     cmd = _get_huggingface_hub_update_command()
     if cmd is None:
         raise CLIError(
-            "Cannot determine how to upgrade huggingface_hub (unknown installation method). Please upgrade manually."
+            "Cannot determine how to update huggingface_hub (unknown installation method). Please update manually."
         )
     return subprocess.call(cmd)
 

--- a/src/huggingface_hub/cli/hf.py
+++ b/src/huggingface_hub/cli/hf.py
@@ -42,7 +42,7 @@ from huggingface_hub.cli.repo_files import repo_files_cli
 from huggingface_hub.cli.repos import repos_cli
 from huggingface_hub.cli.skills import skills_cli
 from huggingface_hub.cli.spaces import spaces_cli
-from huggingface_hub.cli.system import env, version
+from huggingface_hub.cli.system import env, upgrade, version
 from huggingface_hub.cli.upload import UPLOAD_EXAMPLES, upload
 from huggingface_hub.cli.upload_large_folder import UPLOAD_LARGE_FOLDER_EXAMPLES, upload_large_folder
 from huggingface_hub.cli.webhooks import webhooks_cli
@@ -80,6 +80,7 @@ app.command(examples=UPLOAD_EXAMPLES)(upload)
 app.command(examples=UPLOAD_LARGE_FOLDER_EXAMPLES)(upload_large_folder)
 
 app.command(topic="help")(env)
+app.command(topic="help")(upgrade)
 app.command(topic="help")(version)
 
 app.command(hidden=True)(lfs_enable_largefiles)

--- a/src/huggingface_hub/cli/hf.py
+++ b/src/huggingface_hub/cli/hf.py
@@ -42,7 +42,7 @@ from huggingface_hub.cli.repo_files import repo_files_cli
 from huggingface_hub.cli.repos import repos_cli
 from huggingface_hub.cli.skills import skills_cli
 from huggingface_hub.cli.spaces import spaces_cli
-from huggingface_hub.cli.system import env, upgrade, version
+from huggingface_hub.cli.system import env, update, version
 from huggingface_hub.cli.upload import UPLOAD_EXAMPLES, upload
 from huggingface_hub.cli.upload_large_folder import UPLOAD_LARGE_FOLDER_EXAMPLES, upload_large_folder
 from huggingface_hub.cli.webhooks import webhooks_cli
@@ -80,7 +80,7 @@ app.command(examples=UPLOAD_EXAMPLES)(upload)
 app.command(examples=UPLOAD_LARGE_FOLDER_EXAMPLES)(upload_large_folder)
 
 app.command(topic="help")(env)
-app.command(topic="help")(upgrade)
+app.command(topic="help")(update)
 app.command(topic="help")(version)
 
 app.command(hidden=True)(lfs_enable_largefiles)

--- a/src/huggingface_hub/cli/skills.py
+++ b/src/huggingface_hub/cli/skills.py
@@ -101,6 +101,7 @@ Some command examples:
 
 - Use `hf <command> --help` for full options, descriptions, usage, and real-world examples
 - Authenticate with `HF_TOKEN` env var (recommended) or with `--token`
+- Upgrade the CLI with `hf upgrade` (uses the correct command for the detected install method)
 """
 
 CENTRAL_LOCAL = Path(".agents/skills")

--- a/src/huggingface_hub/cli/skills.py
+++ b/src/huggingface_hub/cli/skills.py
@@ -101,7 +101,7 @@ Some command examples:
 
 - Use `hf <command> --help` for full options, descriptions, usage, and real-world examples
 - Authenticate with `HF_TOKEN` env var (recommended) or with `--token`
-- Upgrade the CLI with `hf upgrade` (uses the correct command for the detected install method)
+- Update the CLI with `hf update` (uses the correct command for the detected install method)
 """
 
 CENTRAL_LOCAL = Path(".agents/skills")

--- a/src/huggingface_hub/cli/system.py
+++ b/src/huggingface_hub/cli/system.py
@@ -16,6 +16,8 @@
 from huggingface_hub import __version__
 
 from ..utils import dump_environment_info
+from ._cli_utils import run_upgrade
+from ._output import out
 
 
 def env() -> None:
@@ -26,3 +28,13 @@ def env() -> None:
 def version() -> None:
     """Print information about the hf version."""
     print(__version__)
+
+
+def upgrade() -> None:
+    """Upgrade the `hf` CLI to the latest version."""
+    returncode = run_upgrade()
+    if returncode == 0:
+        out.hint(
+            "You may also want to run `hf skills upgrade` to refresh any installed skills "
+            "so your AI agent sees the latest command surface."
+        )

--- a/src/huggingface_hub/cli/system.py
+++ b/src/huggingface_hub/cli/system.py
@@ -18,7 +18,7 @@ import typer
 from huggingface_hub import __version__
 
 from ..utils import dump_environment_info
-from ._cli_utils import run_upgrade
+from ._cli_utils import run_update
 from ._output import out
 
 
@@ -32,9 +32,9 @@ def version() -> None:
     print(__version__)
 
 
-def upgrade() -> None:
-    """Upgrade the `hf` CLI to the latest version."""
-    returncode = run_upgrade()
+def update() -> None:
+    """Update the `hf` CLI to the latest version."""
+    returncode = run_update()
     if returncode != 0:
         raise typer.Exit(code=returncode)
     out.hint(

--- a/src/huggingface_hub/cli/system.py
+++ b/src/huggingface_hub/cli/system.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 """Contains commands to print information about the environment and version."""
 
+import typer
+
 from huggingface_hub import __version__
 
 from ..utils import dump_environment_info
@@ -33,8 +35,9 @@ def version() -> None:
 def upgrade() -> None:
     """Upgrade the `hf` CLI to the latest version."""
     returncode = run_upgrade()
-    if returncode == 0:
-        out.hint(
-            "You may also want to run `hf skills upgrade` to refresh any installed skills "
-            "so your AI agent sees the latest command surface."
-        )
+    if returncode != 0:
+        raise typer.Exit(code=returncode)
+    out.hint(
+        "You may also want to run `hf skills upgrade` to refresh any installed skills "
+        "so your AI agent sees the latest command surface."
+    )

--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -194,6 +194,9 @@ def is_offline_mode() -> bool:
 # Check is performed once per 24 hours at most.
 CHECK_FOR_UPDATE_DONE_PATH = os.path.join(HF_HOME, ".check_for_update_done")
 
+# Set to skip the CLI update check (PyPI query + "new version available" warning at startup).
+HF_HUB_NO_UPDATE_CHECK = _is_true(os.environ.get("HF_HUB_NO_UPDATE_CHECK"))
+
 # If set, log level will be set to DEBUG and all requests made to the Hub will be logged
 # as curl commands for reproducibility.
 HF_DEBUG = _is_true(os.environ.get("HF_DEBUG"))

--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -195,7 +195,7 @@ def is_offline_mode() -> bool:
 CHECK_FOR_UPDATE_DONE_PATH = os.path.join(HF_HOME, ".check_for_update_done")
 
 # Set to skip the CLI update check (PyPI query + "new version available" warning at startup).
-HF_HUB_NO_UPDATE_CHECK = _is_true(os.environ.get("HF_HUB_NO_UPDATE_CHECK"))
+HF_HUB_DISABLE_UPDATE_CHECK = _is_true(os.environ.get("HF_HUB_DISABLE_UPDATE_CHECK"))
 
 # If set, log level will be set to DEBUG and all requests made to the Hub will be logged
 # as curl commands for reproducibility.


### PR DESCRIPTION
Follow-up after discussion in https://github.com/huggingface/huggingface_hub/pull/3983#issuecomment-4267963832 (also see internal [slack thread](https://huggingface.slack.com/archives/C0ACCEFPU9W/p1776414408260499))

## Summary

- Drop the blocking interactive Y/n auto-update prompt at CLI startup. TTY detection was catching too many non-interactive contexts (CI runners, Homebrew post-install hooks, Jupyter) and hanging automation.
- Replace it with a single stderr warning that points at the new `hf update` command.
- Add `hf update` (grouped under `help` like `env`/`version`): detects how `hf` was installed (brew / standalone installer / pip) and runs the right command. Hints at `hf skills upgrade` on success so installed agent skills stay in sync with the new command surface.
- Add `HF_HUB_DISABLE_UPDATE_CHECK=1` to silence the startup PyPI check entirely (offline CI, quieter shell output). The check was already a no-op on dev / pre-release versions and 24h-cached.

## Breaking change

The interactive auto-update prompt is gone. Users who relied on pressing Enter to accept an upgrade will now get a warning and run `hf update` themselves. No flag change, no scripting breakage — the prompt only ran in TTY sessions.

## Notes / decisions

- Removed `_prompt_autoupdate` entirely rather than gating it on a new heuristic. Once the prompt is gone the leftover check is just a 24h-cached PyPI GET + one stderr line — both harmless in CI. `HF_HUB_DISABLE_UPDATE_CHECK` is the only opt-out; no auto-detection of `CI`/`NONINTERACTIVE`/Jupyter (no premature abstraction).
- Early-return inside `_check_cli_update`, not the outer `check_cli_update` wrapper — keeps the exception-swallowing guarantee.
- `hf update` has no flags (no `--yes`): the user already opted in by running it. Transformers is not updateable from `hf update` — the helper still exists but isn't exposed.
- Registered under `topic="help"` next to `env`/`version` — it's installation meta, not a Hub operation.
- The skill's "Commands" section is regenerated automatically from the Typer tree, so `hf update` shows up without touching `build_skill_md`. Added a single tip bullet to `_SKILL_TIPS`.




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Alters CLI startup behavior and introduces a new command that shells out to platform/package-manager update commands, so failures or mis-detected install methods could impact user workflows (though core Hub operations are unchanged).
> 
> **Overview**
> Adds a new `hf update` command (wired into `hf` via `system.update` + `_cli_utils.run_update`) that detects the CLI installation method (Homebrew/standalone installer/pip) and runs the appropriate upgrade command, then hints to refresh installed skills.
> 
> Changes the CLI startup PyPI version check to be **non-interactive** by removing the blocking Y/n auto-update prompt and always emitting a one-line hint (pointing at `hf update` for `huggingface_hub`), with a new `HF_HUB_DISABLE_UPDATE_CHECK` env var to skip the check entirely.
> 
> Updates docs and generated CLI reference to document `hf update` and `HF_HUB_DISABLE_UPDATE_CHECK`, and adds a short tip in `skills` docs about upgrading via `hf update`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2108297be186bdec74ff12d6d43268845a86c43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->