### PR TITLE
[Release] Add social media draft generation to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@
 # - PYPI_TOKEN_DIST_HF                   : publish `hf` package to PyPI
 # - HUGGINGFACE_HUB_AUTOMATIC_RC_TESTING : open PRs for automatic RC testing in downstream repositories
 # - RELEASE_NOTES_HF_TOKEN               : HF TOKEN scoped to Inference Providers used for automated release notes generation
+# - RELEASE_BUCKET_HF_TOKEN              : HF TOKEN scoped to push data to the huggingface/releases bucket
 # - APP_ID_HUGGINGFACE_HUB_BOT           : GitHub App ID for huggingface-hub-bot (PRs, issues, releases)
 # - APP_SECRET_PEM_HUGGINGFACE_HUB_BOT   : GitHub App private key for huggingface-hub-bot
 # - APP_ID_HUB_SKILLS_REPO               : GitHub App ID for creating tokens to access the skills repo
@@ -640,6 +641,107 @@ jobs:
           fi
 
   # ============================================================
+  # 4c. SOCIAL POSTS — generate draft social media posts for prereleases
+  # ============================================================
+  social-posts:
+    permissions:
+      contents: write  # need write to list draft releases
+    needs: [prepare, release-notes]
+    if: ${{ !cancelled() && needs.prepare.result == 'success' && needs.prepare.outputs.is_prerelease == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ needs.prepare.outputs.tag }}
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -e .
+
+      - name: Install hf CLI
+        run: curl -LsSf https://hf.co/cli/install.sh | bash
+
+      - name: Fetch release notes from GitHub
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ needs.prepare.outputs.version }}"
+          MINOR=$(echo "$VERSION" | sed -E 's/^([0-9]+\.[0-9]+).*/\1/')
+
+          RELEASE_TAG=$(gh release list --json tagName,isDraft,isPrerelease --limit 100 \
+            | jq -r ".[] | select(.isDraft or .isPrerelease) | select(.tagName | startswith(\"v${MINOR}.\")) | .tagName" | head -1)
+
+          if [[ -z "$RELEASE_TAG" ]]; then
+            echo "::error::No release found for v${MINOR}."
+            exit 1
+          fi
+
+          echo "Found release: $RELEASE_TAG"
+          mkdir -p .release-notes
+          gh release view "$RELEASE_TAG" --json body -q '.body' > .release-notes/notes.md
+
+      - name: Generate social media drafts
+        env:
+          HF_TOKEN: ${{ secrets.RELEASE_NOTES_HF_TOKEN }}
+          RELEASE_NOTES_MODEL: ${{ vars.RELEASE_NOTES_MODEL }}
+        run: |
+          VERSION="${{ needs.prepare.outputs.version }}"
+          BASE_VERSION=$(echo "$VERSION" | sed -E 's/\.rc.*//')
+          python -m utils.release_notes.generate_social_posts \
+            --version "v${BASE_VERSION}" \
+            --input .release-notes/notes.md
+
+      - name: Upload drafts to bucket
+        env:
+          HF_TOKEN: ${{ secrets.RELEASE_BUCKET_HF_TOKEN }}
+        run: |
+          VERSION="${{ needs.prepare.outputs.version }}"
+          BASE_VERSION=$(echo "$VERSION" | sed -E 's/\.rc.*//')
+          hf buckets sync .release-notes/socials/ \
+            "hf://buckets/huggingface/releases/huggingface_hub/${BASE_VERSION}/socials/"
+
+      - name: Print drafts to summary
+        run: |
+          echo "## Social Media Drafts" >> $GITHUB_STEP_SUMMARY
+          for f in .release-notes/socials/*.txt; do
+            if [[ -f "$f" ]]; then
+              BASENAME=$(basename "$f")
+              echo "### ${BASENAME}" >> $GITHUB_STEP_SUMMARY
+              echo '```' >> $GITHUB_STEP_SUMMARY
+              cat "$f" >> $GITHUB_STEP_SUMMARY
+              echo '```' >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+            fi
+          done
+
+      - name: Notify Slack
+        if: ${{ always() && needs.prepare.outputs.message_ts }}
+        continue-on-error: true
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ vars.SLACK_CHANNEL_ID }}
+        run: |
+          VERSION="${{ needs.prepare.outputs.version }}"
+          BASE_VERSION=$(echo "$VERSION" | sed -E 's/\.rc.*//')
+          BUCKET_URL="https://huggingface.co/buckets/huggingface/releases/huggingface_hub/${BASE_VERSION}/socials"
+          if [[ "${{ job.status }}" == "success" ]]; then
+            TEXT="✅ *Social media drafts* — <${BUCKET_URL}|uploaded to bucket>"
+          else
+            TEXT="❌ *Social media drafts* — generation failed"
+          fi
+          curl -s -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -n \
+              --arg channel "$SLACK_CHANNEL_ID" \
+              --arg text "$TEXT" \
+              --arg thread_ts "${{ needs.prepare.outputs.message_ts }}" \
+              '{channel: $channel, text: $text, thread_ts: $thread_ts, unfurl_links: false}')" > /dev/null
+
+  # ============================================================
   # 5. DOWNSTREAM TESTING — test RC in transformers, datasets, etc.
   # ============================================================
   test-downstream:
@@ -1022,7 +1124,7 @@ jobs:
   # 9. SLACK — final status update
   # ============================================================
   slack-complete:
-    needs: [prepare, publish-pypi, publish-hf-cli, release-notes, slack-message, test-downstream, post-release, sync-hf-cli-skill, notify-prs]
+    needs: [prepare, publish-pypi, publish-hf-cli, release-notes, slack-message, social-posts, test-downstream, post-release, sync-hf-cli-skill, notify-prs]
     if: ${{ always() && needs.prepare.outputs.message_ts }}
     runs-on: ubuntu-latest
     steps:
@@ -1047,6 +1149,7 @@ jobs:
             "${{ needs.publish-hf-cli.result }}" \
             "${{ needs.release-notes.result }}" \
             "${{ needs.slack-message.result }}" \
+            "${{ needs.social-posts.result }}" \
             "${{ needs.test-downstream.result }}" \
             "${{ needs.post-release.result }}" \
             "${{ needs.sync-hf-cli-skill.result }}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -647,6 +647,8 @@ jobs:
     permissions:
       contents: write  # need write to list draft releases
     needs: [prepare, release-notes]
+    # Use !cancelled() so this job runs even if release-notes failed (we fetch the draft directly from GitHub).
+    # This also allows re-running this job after manually editing the draft release notes.
     if: ${{ !cancelled() && needs.prepare.result == 'success' && needs.prepare.outputs.is_prerelease == 'true' }}
     runs-on: ubuntu-latest
     steps:
@@ -661,8 +663,11 @@ jobs:
       - name: Install dependencies
         run: pip install -e .
 
-      - name: Install hf CLI
-        run: curl -LsSf https://hf.co/cli/install.sh | bash
+      - name: Install OpenCode
+        run: curl -fsSL https://opencode.ai/install | bash -s -- --version ${{ vars.OPENCODE_VERSION }}
+
+      - name: Verify OpenCode checksum
+        run: echo "${{ vars.OPENCODE_SHA256 }}  $(which opencode)" | sha256sum -c -
 
       - name: Fetch release notes from GitHub
         env:

--- a/.opencode/skills/hf-release-notes/SOCIAL.md
+++ b/.opencode/skills/hf-release-notes/SOCIAL.md
@@ -1,13 +1,15 @@
 ---
 name: hf-release-notes:social
-description: Generate draft social media posts (LinkedIn and X) from drafted release notes. Use when asked to create social media drafts for a huggingface_hub release.
+description: Generate draft social media posts (LinkedIn and X) from release notes. Use when asked to create social media drafts for a huggingface_hub release.
 ---
 
 # Social Media Drafts
 
 ## Overview
 
-Generate draft social media posts for LinkedIn and X (Twitter) from existing release notes. Each platform gets multiple drafts with different tones and angles, ready for the team to pick, edit, and post.
+Generate draft social media posts for LinkedIn and X (Twitter) from existing release notes for a huggingface_hub release. The output is a set of `.txt` files — multiple drafts per platform with distinct tones — ready for the team to review, edit, and publish.
+
+**Important:** The prompt will specify the release notes path and output directory. Write each draft as a separate `.txt` file using the naming convention below.
 
 ## Workflow
 
@@ -16,45 +18,84 @@ Generate draft social media posts for LinkedIn and X (Twitter) from existing rel
 The prompt will specify:
 - **Version**: The release version (e.g., `v1.8.0`)
 - **Release notes path**: Path to the full release notes markdown file
-- **Output directory**: Where to write the drafts
+- **Output directory**: Where to write the draft files
 
-Read the release notes file first to understand what's in the release.
+Read the release notes file to understand what's in the release.
 
-### 2. Generate drafts
+### 2. Generate LinkedIn drafts
 
-For each platform, generate multiple posts with distinct angles:
+Generate **3 LinkedIn posts**, each 150–250 words, with a distinct angle:
 
-**LinkedIn** (150-250 words each):
-- `professional`: Technical value, what problems these features solve for ML engineers
-- `community`: Celebrate contributors, ecosystem impact, invite people to try it
-- `tutorial`: Pick top 1-2 features, show a quick code snippet or before/after
+#### `linkedin_professional_1.txt` — Technical / professional
 
-**X / Twitter** (280 chars per tweet):
-- `announcement`: Punchy, energetic, lead with the #1 feature. Main tweet + follow-up.
-- `technical`: Developer-focused, mention specific APIs/commands. Main tweet + code follow-up.
-- `thread`: 3-5 tweet thread walking through highlights. Numbered 1/, 2/, etc.
+Write as a developer relations expert. Focus on the technical value and what problems the new features solve for ML engineers and data scientists. Use short paragraphs. Mention concrete features, APIs, or CLI commands by name. Include 2–3 relevant hashtags at the end (e.g., `#MachineLearning #OpenSource #Python`).
 
-### 3. Formatting rules
+#### `linkedin_community_2.txt` — Community / ecosystem
 
-- LinkedIn posts: natural paragraphs, 2-3 hashtags at end
-- X posts: tweets separated by `---`, each under 280 characters
-- Every draft ends with a picture suggestion in brackets:
-  `[Picture: description of suggested image/screenshot]`
-- Use `[LINK]` placeholder for the release notes URL
-- No internal jargon — write for the broader ML/dev community
+Write as a community manager celebrating an open-source release. Emphasize the collaborative nature: thank contributors (mention a few by handle if names appear in the notes), highlight the ecosystem impact (transformers, diffusers, datasets, sentence-transformers all depend on huggingface_hub), and invite people to try it out or contribute. Warm, inclusive tone. Include 2–3 hashtags.
 
-### 4. Write output
+#### `linkedin_tutorial_3.txt` — Tutorial / practical
 
-Write each draft to the output directory as:
-- `linkedin_<tone>_<number>.txt`
-- `x_<tone>_<number>.txt`
+Write as a technical writer. Pick the 1–2 most impactful new features and show a quick before/after or a mini code snippet. The goal is to make readers think "I need to try this right now." Include 2–3 hashtags.
+
+### 3. Generate X (Twitter) drafts
+
+Generate **3 X posts**. Each tweet must be under 280 characters. Separate tweets within a draft with `---` on its own line.
+
+#### `x_announcement_1.txt` — Announcement / hype
+
+One punchy main tweet + one follow-up. Lead with the single most exciting feature. Use an energetic tone. 1–2 emoji max. The follow-up should contain a `[LINK]` placeholder for the release notes URL.
+
+#### `x_technical_2.txt` — Technical / developer
+
+One main tweet + one follow-up with a code snippet or command example. Focus on DX improvements, new APIs, or performance gains. Mention concrete method names or CLI commands.
+
+#### `x_thread_3.txt` — Thread / storytelling
+
+A short thread of 3–5 tweets walking through the highlights. Number them `1/`, `2/`, etc. The first tweet should hook the reader. The last tweet should link to the release notes with a `[LINK]` placeholder.
+
+### 4. Picture suggestions
+
+Every draft file must end with a picture suggestion on the last line, in brackets:
+
+```
+[Picture: description of suggested image, screenshot, or graphic]
+```
+
+Examples:
+- `[Picture: screenshot of the new CLI output with a dark terminal theme]`
+- `[Picture: side-by-side code comparison showing the old vs new API]`
+- `[Picture: infographic summarizing the top 3 features with icons]`
+- `[Picture: collage of contributor avatars or a community celebration graphic]`
+- `[Picture: short GIF of the new command in action in a terminal]`
+
+### 5. Formatting rules
+
+- LinkedIn: natural paragraphs, no markdown headers. 2–3 hashtags at end.
+- X: tweets separated by `---`, each under 280 characters.
+- Use `[LINK]` placeholder for the release notes URL (never hardcode a URL).
+- No internal jargon — write for the broader ML/developer community.
+- Mention "huggingface_hub" (the Python package name) and "Hugging Face Hub" (the platform).
+- Do NOT fabricate features — only mention what's actually in the release notes.
+
+### 6. Write output
+
+Write each draft as a separate file in the output directory:
+- `linkedin_professional_1.txt`
+- `linkedin_community_2.txt`
+- `linkedin_tutorial_3.txt`
+- `x_announcement_1.txt`
+- `x_technical_2.txt`
+- `x_thread_3.txt`
+
+Each file should contain ONLY the post text (including picture suggestion). No metadata, no headers, no extra formatting.
 
 ## Input
 
-- Version string (e.g., "v1.8.0")
+- Version string (e.g., `v1.8.0`)
 - Path to release notes markdown file
-- Output directory
+- Output directory path
 
 ## Output
 
-- 6 draft text files (3 LinkedIn + 3 X)
+- 6 draft `.txt` files in the output directory

--- a/.opencode/skills/hf-release-notes/SOCIAL.md
+++ b/.opencode/skills/hf-release-notes/SOCIAL.md
@@ -1,0 +1,60 @@
+---
+name: hf-release-notes:social
+description: Generate draft social media posts (LinkedIn and X) from drafted release notes. Use when asked to create social media drafts for a huggingface_hub release.
+---
+
+# Social Media Drafts
+
+## Overview
+
+Generate draft social media posts for LinkedIn and X (Twitter) from existing release notes. Each platform gets multiple drafts with different tones and angles, ready for the team to pick, edit, and post.
+
+## Workflow
+
+### 1. Read inputs
+
+The prompt will specify:
+- **Version**: The release version (e.g., `v1.8.0`)
+- **Release notes path**: Path to the full release notes markdown file
+- **Output directory**: Where to write the drafts
+
+Read the release notes file first to understand what's in the release.
+
+### 2. Generate drafts
+
+For each platform, generate multiple posts with distinct angles:
+
+**LinkedIn** (150-250 words each):
+- `professional`: Technical value, what problems these features solve for ML engineers
+- `community`: Celebrate contributors, ecosystem impact, invite people to try it
+- `tutorial`: Pick top 1-2 features, show a quick code snippet or before/after
+
+**X / Twitter** (280 chars per tweet):
+- `announcement`: Punchy, energetic, lead with the #1 feature. Main tweet + follow-up.
+- `technical`: Developer-focused, mention specific APIs/commands. Main tweet + code follow-up.
+- `thread`: 3-5 tweet thread walking through highlights. Numbered 1/, 2/, etc.
+
+### 3. Formatting rules
+
+- LinkedIn posts: natural paragraphs, 2-3 hashtags at end
+- X posts: tweets separated by `---`, each under 280 characters
+- Every draft ends with a picture suggestion in brackets:
+  `[Picture: description of suggested image/screenshot]`
+- Use `[LINK]` placeholder for the release notes URL
+- No internal jargon — write for the broader ML/dev community
+
+### 4. Write output
+
+Write each draft to the output directory as:
+- `linkedin_<tone>_<number>.txt`
+- `x_<tone>_<number>.txt`
+
+## Input
+
+- Version string (e.g., "v1.8.0")
+- Path to release notes markdown file
+- Output directory
+
+## Output
+
+- 6 draft text files (3 LinkedIn + 3 X)

--- a/utils/release_notes/generate_social_posts.py
+++ b/utils/release_notes/generate_social_posts.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""Generate draft social media posts from release notes.
+
+This script:
+1. Reads existing release notes (from file or GitHub draft release)
+2. Generates multiple draft posts for LinkedIn and X (Twitter)
+   with different tones/angles using an LLM via huggingface_hub
+3. Writes each draft as a .txt file under a local output directory
+4. Optionally uploads to a HF bucket via the `hf` CLI
+
+Each platform gets posts with several distinct angles:
+- LinkedIn: professional/technical, community/ecosystem, tutorial/practical
+- X: announcement/hype, technical/developer, thread/storytelling
+
+Usage:
+  python -m utils.release_notes.generate_social_posts \
+    --version v1.8.0 \
+    --input .release-notes/RELEASE_NOTES_v1.8.0.md
+
+  # With bucket upload
+  python -m utils.release_notes.generate_social_posts \
+    --version v1.8.0 \
+    --upload-bucket huggingface/releases
+"""
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from huggingface_hub import InferenceClient
+
+from .validate_notes import find_release_notes_file
+
+
+OUTPUT_DIR = Path(os.environ.get("RELEASE_NOTES_OUTPUT_DIR", ".release-notes"))
+
+# ── Post specifications ─────────────────────────────────────────────
+# Each entry: (platform, tone_slug, system_prompt_extra, user_prompt_template)
+# The user_prompt_template receives {version} and {release_notes} as format keys.
+
+LINKEDIN_SPECS: list[tuple[str, str]] = [
+    (
+        "professional",
+        (
+            "You are a developer relations expert writing a LinkedIn post about an open-source "
+            "Python library release. Write in a professional but approachable tone. Focus on "
+            "the technical value and what problems these features solve for ML engineers and "
+            "data scientists. Use short paragraphs. Include 2-3 relevant hashtags at the end "
+            "(e.g. #MachineLearning #OpenSource #Python). The post should be 150-250 words. "
+            "Suggest a picture idea in brackets at the very end, e.g. "
+            "[Picture: screenshot of the new CLI output with a terminal theme]."
+        ),
+    ),
+    (
+        "community",
+        (
+            "You are a community manager writing a LinkedIn post celebrating an open-source "
+            "release. Emphasize the collaborative nature: thank contributors, highlight the "
+            "ecosystem impact (transformers, diffusers, datasets all depend on this library), "
+            "and invite people to try it out. Keep a warm, inclusive tone. Mention that this "
+            "is the Python client for the Hugging Face Hub. 150-250 words. Include 2-3 "
+            "hashtags. Suggest a picture idea in brackets at the very end, e.g. "
+            "[Picture: collage of contributor avatars or a community graphic]."
+        ),
+    ),
+    (
+        "tutorial",
+        (
+            "You are a technical writer creating a LinkedIn post that is practical and "
+            "tutorial-oriented. Pick the 1-2 most impactful new features and show a quick "
+            "before/after or a mini code snippet (use LinkedIn code formatting). The goal is "
+            "to make readers think 'I need to try this right now.' 150-250 words. Include "
+            "2-3 hashtags. Suggest a picture idea in brackets at the very end, e.g. "
+            "[Picture: side-by-side code comparison or a short GIF of the feature in action]."
+        ),
+    ),
+]
+
+X_SPECS: list[tuple[str, str]] = [
+    (
+        "announcement",
+        (
+            "You are writing a punchy X (Twitter) post announcing a new release of "
+            "huggingface_hub, the Python client for the Hugging Face Hub. Keep it under 280 "
+            "characters for the main tweet. Use an energetic, excited tone. Lead with the "
+            "single most exciting feature. Use 1-2 emoji max. Add a short follow-up tweet "
+            "(also under 280 chars) with a link placeholder '[LINK]' to the release notes. "
+            "Separate the two tweets with '---'. Suggest a picture idea in brackets at the "
+            "very end, e.g. [Picture: hero image of the main new feature]."
+        ),
+    ),
+    (
+        "technical",
+        (
+            "You are a developer writing an X (Twitter) post targeting other developers. "
+            "Focus on DX improvements, new APIs, or performance gains. Be concise and "
+            "specific — mention concrete method names or CLI commands if relevant. Keep the "
+            "main tweet under 280 characters. Include a follow-up tweet (under 280 chars) "
+            "with a code snippet or command example. Separate tweets with '---'. Suggest a "
+            "picture idea in brackets at the very end, e.g. "
+            "[Picture: terminal screenshot showing the new command in action]."
+        ),
+    ),
+    (
+        "thread",
+        (
+            "You are writing a short X (Twitter) thread (3-5 tweets) walking through the "
+            "highlights of a new release. Each tweet must be under 280 characters. Number "
+            "them 1/, 2/, etc. The first tweet should hook the reader. The last tweet should "
+            "link to the release notes with a '[LINK]' placeholder. Separate tweets with "
+            "'---'. Suggest a picture idea in brackets at the very end, e.g. "
+            "[Picture: infographic summarizing the top 3 features]."
+        ),
+    ),
+]
+
+USER_PROMPT_TEMPLATE = (
+    "Write a {platform} post about huggingface_hub {version}.\n\nHere are the release notes:\n\n{release_notes}"
+)
+
+
+def generate_post(
+    client: InferenceClient,
+    model: str,
+    platform: str,
+    tone: str,
+    system_prompt: str,
+    version: str,
+    release_notes: str,
+) -> str:
+    """Generate a single social media draft using the inference API.
+
+    Returns the generated text.
+    """
+    user_prompt = USER_PROMPT_TEMPLATE.format(
+        platform=platform,
+        version=version,
+        release_notes=release_notes,
+    )
+    response = client.chat_completion(
+        model=model,
+        messages=[
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
+        ],
+        max_tokens=1024,
+        temperature=0.8,
+    )
+    return response.choices[0].message.content.strip()
+
+
+def upload_to_bucket(local_dir: Path, bucket_id: str, version: str) -> bool:
+    """Upload generated drafts to an HF bucket using the `hf` CLI.
+
+    Uploads files from local_dir to:
+      hf://buckets/<bucket_id>/huggingface_hub/<version>/socials/
+
+    Returns True on success.
+    """
+    hf_cmd = shutil.which("hf")
+    if not hf_cmd:
+        print("Error: 'hf' CLI not found in PATH", file=sys.stderr)
+        return False
+
+    dest = f"hf://buckets/{bucket_id}/huggingface_hub/{version}/socials/"
+    cmd = [hf_cmd, "buckets", "sync", str(local_dir), dest]
+    print(f"Uploading to bucket: {' '.join(cmd)}")
+
+    try:
+        subprocess.run(cmd, check=True)
+        return True
+    except subprocess.CalledProcessError as e:
+        print(f"Bucket upload failed with exit code {e.returncode}", file=sys.stderr)
+        return False
+
+
+def main(
+    version: str,
+    input_file: Path | None = None,
+    upload_bucket: str | None = None,
+    model: str | None = None,
+) -> int:
+    """Generate social media drafts from release notes.
+
+    Args:
+        version: Release version (e.g., "v1.8.0")
+        input_file: Path to release notes markdown (auto-detected if None)
+        upload_bucket: Optional HF bucket ID to upload results (e.g., "huggingface/releases")
+        model: HF model ID for text generation
+
+    Returns:
+        Exit code (0 for success, non-zero for failure)
+    """
+    # Resolve input
+    if input_file is None:
+        input_file = find_release_notes_file(version)
+    if input_file is None or not input_file.exists():
+        print(f"Error: Release notes file not found for {version}", file=sys.stderr)
+        print(f"Expected at: {OUTPUT_DIR}/RELEASE_NOTES_{version}.md", file=sys.stderr)
+        return 1
+
+    release_notes = input_file.read_text().strip()
+    if not release_notes:
+        print("Error: Release notes file is empty", file=sys.stderr)
+        return 1
+
+    # Resolve model
+    if model is None:
+        model = os.environ.get("RELEASE_NOTES_MODEL")
+    if not model:
+        print("Error: No model specified. Set RELEASE_NOTES_MODEL or use --model.", file=sys.stderr)
+        return 1
+
+    # Prepare output directory
+    socials_dir = OUTPUT_DIR / "socials"
+    socials_dir.mkdir(parents=True, exist_ok=True)
+
+    # Create inference client
+    client = InferenceClient()
+
+    generated = 0
+    errors = 0
+
+    # Generate LinkedIn posts
+    for idx, (tone, system_prompt) in enumerate(LINKEDIN_SPECS, start=1):
+        filename = f"linkedin_{tone}_{idx}.txt"
+        print(f"Generating {filename}...")
+        try:
+            text = generate_post(client, model, "LinkedIn", tone, system_prompt, version, release_notes)
+            (socials_dir / filename).write_text(text + "\n")
+            generated += 1
+        except Exception as e:
+            print(f"  Error generating {filename}: {e}", file=sys.stderr)
+            errors += 1
+
+    # Generate X posts
+    for idx, (tone, system_prompt) in enumerate(X_SPECS, start=1):
+        filename = f"x_{tone}_{idx}.txt"
+        print(f"Generating {filename}...")
+        try:
+            text = generate_post(client, model, "X (Twitter)", tone, system_prompt, version, release_notes)
+            (socials_dir / filename).write_text(text + "\n")
+            generated += 1
+        except Exception as e:
+            print(f"  Error generating {filename}: {e}", file=sys.stderr)
+            errors += 1
+
+    print(f"\nGenerated {generated} drafts ({errors} errors) in {socials_dir}")
+
+    # Upload to bucket if requested
+    if upload_bucket and generated > 0:
+        # Strip leading "v" for the bucket path if present
+        bucket_version = version.lstrip("v")
+        if not upload_to_bucket(socials_dir, upload_bucket, bucket_version):
+            print("Warning: Bucket upload failed", file=sys.stderr)
+            return 1
+        print(f"Uploaded to bucket {upload_bucket}/huggingface_hub/{bucket_version}/socials/")
+
+    return 0 if errors == 0 else 1
+
+
+def cli():
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="Generate draft social media posts from release notes",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Generate drafts for v1.8.0
+  python -m utils.release_notes.generate_social_posts --version v1.8.0
+
+  # With explicit input and bucket upload
+  python -m utils.release_notes.generate_social_posts \\
+    --version v1.8.0 \\
+    --input notes.md \\
+    --upload-bucket huggingface/releases
+""",
+    )
+    parser.add_argument(
+        "--version",
+        required=True,
+        help="Release version (e.g., v1.8.0)",
+    )
+    parser.add_argument(
+        "--input",
+        type=Path,
+        default=None,
+        help="Path to release notes file (auto-detected if omitted)",
+    )
+    parser.add_argument(
+        "--upload-bucket",
+        default=None,
+        help="HF bucket ID to upload results (e.g., huggingface/releases)",
+    )
+    parser.add_argument(
+        "--model",
+        default=None,
+        help="HF model ID for generation (defaults to RELEASE_NOTES_MODEL env var)",
+    )
+    args = parser.parse_args()
+
+    sys.exit(main(args.version, args.input, args.upload_bucket, args.model))
+
+
+if __name__ == "__main__":
+    cli()

--- a/utils/release_notes/generate_social_posts.py
+++ b/utils/release_notes/generate_social_posts.py
@@ -2,25 +2,21 @@
 """Generate draft social media posts from release notes.
 
 This script:
-1. Reads existing release notes (from file or GitHub draft release)
-2. Generates multiple draft posts for LinkedIn and X (Twitter)
-   with different tones/angles using an LLM via huggingface_hub
-3. Writes each draft as a .txt file under a local output directory
-4. Optionally uploads to a HF bucket via the `hf` CLI
+1. Reads existing release notes (from file or auto-detected)
+2. Invokes OpenCode with the hf-release-notes:social skill to generate
+   6 draft posts (3 LinkedIn + 3 X) with different tones/angles
+3. Validates that all expected files were produced
+4. Outputs drafts to .release-notes/socials/
 
-Each platform gets posts with several distinct angles:
-- LinkedIn: professional/technical, community/ecosystem, tutorial/practical
-- X: announcement/hype, technical/developer, thread/storytelling
+The drafts are saved to disk only. Uploading to a bucket is handled
+separately by the caller (e.g. the release workflow).
 
 Usage:
-  python -m utils.release_notes.generate_social_posts \
-    --version v1.8.0 \
-    --input .release-notes/RELEASE_NOTES_v1.8.0.md
+  python -m utils.release_notes.generate_social_posts --version v1.8.0
 
-  # With bucket upload
-  python -m utils.release_notes.generate_social_posts \
-    --version v1.8.0 \
-    --upload-bucket huggingface/releases
+  # With explicit input
+  python -m utils.release_notes.generate_social_posts \\
+    --version v1.8.0 --input notes.md
 """
 
 import argparse
@@ -30,166 +26,68 @@ import subprocess
 import sys
 from pathlib import Path
 
-from huggingface_hub import InferenceClient
-
 from .validate_notes import find_release_notes_file
 
 
 OUTPUT_DIR = Path(os.environ.get("RELEASE_NOTES_OUTPUT_DIR", ".release-notes"))
 
-# ── Post specifications ─────────────────────────────────────────────
-# Each entry: (platform, tone_slug, system_prompt_extra, user_prompt_template)
-# The user_prompt_template receives {version} and {release_notes} as format keys.
-
-LINKEDIN_SPECS: list[tuple[str, str]] = [
-    (
-        "professional",
-        (
-            "You are a developer relations expert writing a LinkedIn post about an open-source "
-            "Python library release. Write in a professional but approachable tone. Focus on "
-            "the technical value and what problems these features solve for ML engineers and "
-            "data scientists. Use short paragraphs. Include 2-3 relevant hashtags at the end "
-            "(e.g. #MachineLearning #OpenSource #Python). The post should be 150-250 words. "
-            "Suggest a picture idea in brackets at the very end, e.g. "
-            "[Picture: screenshot of the new CLI output with a terminal theme]."
-        ),
-    ),
-    (
-        "community",
-        (
-            "You are a community manager writing a LinkedIn post celebrating an open-source "
-            "release. Emphasize the collaborative nature: thank contributors, highlight the "
-            "ecosystem impact (transformers, diffusers, datasets all depend on this library), "
-            "and invite people to try it out. Keep a warm, inclusive tone. Mention that this "
-            "is the Python client for the Hugging Face Hub. 150-250 words. Include 2-3 "
-            "hashtags. Suggest a picture idea in brackets at the very end, e.g. "
-            "[Picture: collage of contributor avatars or a community graphic]."
-        ),
-    ),
-    (
-        "tutorial",
-        (
-            "You are a technical writer creating a LinkedIn post that is practical and "
-            "tutorial-oriented. Pick the 1-2 most impactful new features and show a quick "
-            "before/after or a mini code snippet (use LinkedIn code formatting). The goal is "
-            "to make readers think 'I need to try this right now.' 150-250 words. Include "
-            "2-3 hashtags. Suggest a picture idea in brackets at the very end, e.g. "
-            "[Picture: side-by-side code comparison or a short GIF of the feature in action]."
-        ),
-    ),
+EXPECTED_FILES = [
+    "linkedin_professional_1.txt",
+    "linkedin_community_2.txt",
+    "linkedin_tutorial_3.txt",
+    "x_announcement_1.txt",
+    "x_technical_2.txt",
+    "x_thread_3.txt",
 ]
 
-X_SPECS: list[tuple[str, str]] = [
-    (
-        "announcement",
-        (
-            "You are writing a punchy X (Twitter) post announcing a new release of "
-            "huggingface_hub, the Python client for the Hugging Face Hub. Keep it under 280 "
-            "characters for the main tweet. Use an energetic, excited tone. Lead with the "
-            "single most exciting feature. Use 1-2 emoji max. Add a short follow-up tweet "
-            "(also under 280 chars) with a link placeholder '[LINK]' to the release notes. "
-            "Separate the two tweets with '---'. Suggest a picture idea in brackets at the "
-            "very end, e.g. [Picture: hero image of the main new feature]."
-        ),
-    ),
-    (
-        "technical",
-        (
-            "You are a developer writing an X (Twitter) post targeting other developers. "
-            "Focus on DX improvements, new APIs, or performance gains. Be concise and "
-            "specific — mention concrete method names or CLI commands if relevant. Keep the "
-            "main tweet under 280 characters. Include a follow-up tweet (under 280 chars) "
-            "with a code snippet or command example. Separate tweets with '---'. Suggest a "
-            "picture idea in brackets at the very end, e.g. "
-            "[Picture: terminal screenshot showing the new command in action]."
-        ),
-    ),
-    (
-        "thread",
-        (
-            "You are writing a short X (Twitter) thread (3-5 tweets) walking through the "
-            "highlights of a new release. Each tweet must be under 280 characters. Number "
-            "them 1/, 2/, etc. The first tweet should hook the reader. The last tweet should "
-            "link to the release notes with a '[LINK]' placeholder. Separate tweets with "
-            "'---'. Suggest a picture idea in brackets at the very end, e.g. "
-            "[Picture: infographic summarizing the top 3 features]."
-        ),
-    ),
-]
 
-USER_PROMPT_TEMPLATE = (
-    "Write a {platform} post about huggingface_hub {version}.\n\nHere are the release notes:\n\n{release_notes}"
-)
+def run_opencode_skill(version: str, input_file: Path, output_dir: Path) -> bool:
+    """Run the hf-release-notes:social OpenCode skill.
 
+    Args:
+        version: Release version (e.g., "v1.8.0")
+        input_file: Path to the release notes markdown
+        output_dir: Directory to write draft files
 
-def generate_post(
-    client: InferenceClient,
-    model: str,
-    platform: str,
-    tone: str,
-    system_prompt: str,
-    version: str,
-    release_notes: str,
-) -> str:
-    """Generate a single social media draft using the inference API.
-
-    Returns the generated text.
+    Returns:
+        True if successful, False otherwise
     """
-    user_prompt = USER_PROMPT_TEMPLATE.format(
-        platform=platform,
-        version=version,
-        release_notes=release_notes,
+    prompt = (
+        f"Run the hf-release-notes:social skill. "
+        f"Generate social media drafts for version {version}. "
+        f"Read the release notes from {input_file}. "
+        f"Write each draft file to {output_dir}/. "
     )
-    response = client.chat_completion(
-        model=model,
-        messages=[
-            {"role": "system", "content": system_prompt},
-            {"role": "user", "content": user_prompt},
-        ],
-        max_tokens=1024,
-        temperature=0.8,
-    )
-    return response.choices[0].message.content.strip()
 
-
-def upload_to_bucket(local_dir: Path, bucket_id: str, version: str) -> bool:
-    """Upload generated drafts to an HF bucket using the `hf` CLI.
-
-    Uploads files from local_dir to:
-      hf://buckets/<bucket_id>/huggingface_hub/<version>/socials/
-
-    Returns True on success.
-    """
-    hf_cmd = shutil.which("hf")
-    if not hf_cmd:
-        print("Error: 'hf' CLI not found in PATH", file=sys.stderr)
+    opencode_cmd = shutil.which("opencode")
+    if not opencode_cmd:
+        print("Error: 'opencode' command not found in PATH", file=sys.stderr)
         return False
 
-    dest = f"hf://buckets/{bucket_id}/huggingface_hub/{version}/socials/"
-    cmd = [hf_cmd, "buckets", "sync", str(local_dir), dest]
-    print(f"Uploading to bucket: {' '.join(cmd)}")
+    cmd = [opencode_cmd]
+    model = os.environ.get("RELEASE_NOTES_MODEL")
+    if model:
+        cmd.extend(["--model", model])
+    cmd.extend(["run", prompt])
+    print(f"Running: {' '.join(cmd)}")
 
     try:
-        subprocess.run(cmd, check=True)
-        return True
+        result = subprocess.run(cmd, check=True, capture_output=False)
+        return result.returncode == 0
     except subprocess.CalledProcessError as e:
-        print(f"Bucket upload failed with exit code {e.returncode}", file=sys.stderr)
+        print(f"OpenCode command failed with exit code {e.returncode}", file=sys.stderr)
+        return False
+    except FileNotFoundError:
+        print("Error: 'opencode' command not found", file=sys.stderr)
         return False
 
 
-def main(
-    version: str,
-    input_file: Path | None = None,
-    upload_bucket: str | None = None,
-    model: str | None = None,
-) -> int:
+def main(version: str, input_file: Path | None = None) -> int:
     """Generate social media drafts from release notes.
 
     Args:
         version: Release version (e.g., "v1.8.0")
         input_file: Path to release notes markdown (auto-detected if None)
-        upload_bucket: Optional HF bucket ID to upload results (e.g., "huggingface/releases")
-        model: HF model ID for text generation
 
     Returns:
         Exit code (0 for success, non-zero for failure)
@@ -202,64 +100,41 @@ def main(
         print(f"Expected at: {OUTPUT_DIR}/RELEASE_NOTES_{version}.md", file=sys.stderr)
         return 1
 
-    release_notes = input_file.read_text().strip()
-    if not release_notes:
-        print("Error: Release notes file is empty", file=sys.stderr)
-        return 1
-
-    # Resolve model
-    if model is None:
-        model = os.environ.get("RELEASE_NOTES_MODEL")
-    if not model:
-        print("Error: No model specified. Set RELEASE_NOTES_MODEL or use --model.", file=sys.stderr)
-        return 1
-
     # Prepare output directory
     socials_dir = OUTPUT_DIR / "socials"
     socials_dir.mkdir(parents=True, exist_ok=True)
 
-    # Create inference client
-    client = InferenceClient()
+    print(f"Input:  {input_file}")
+    print(f"Output: {socials_dir}")
 
-    generated = 0
-    errors = 0
+    # Generate with OpenCode
+    if not run_opencode_skill(version, input_file, socials_dir):
+        print("Failed to generate social media drafts", file=sys.stderr)
+        return 1
 
-    # Generate LinkedIn posts
-    for idx, (tone, system_prompt) in enumerate(LINKEDIN_SPECS, start=1):
-        filename = f"linkedin_{tone}_{idx}.txt"
-        print(f"Generating {filename}...")
-        try:
-            text = generate_post(client, model, "LinkedIn", tone, system_prompt, version, release_notes)
-            (socials_dir / filename).write_text(text + "\n")
-            generated += 1
-        except Exception as e:
-            print(f"  Error generating {filename}: {e}", file=sys.stderr)
-            errors += 1
+    # Validate outputs
+    generated = []
+    missing = []
+    for filename in EXPECTED_FILES:
+        path = socials_dir / filename
+        if path.exists() and path.stat().st_size > 0:
+            generated.append(filename)
+        else:
+            missing.append(filename)
 
-    # Generate X posts
-    for idx, (tone, system_prompt) in enumerate(X_SPECS, start=1):
-        filename = f"x_{tone}_{idx}.txt"
-        print(f"Generating {filename}...")
-        try:
-            text = generate_post(client, model, "X (Twitter)", tone, system_prompt, version, release_notes)
-            (socials_dir / filename).write_text(text + "\n")
-            generated += 1
-        except Exception as e:
-            print(f"  Error generating {filename}: {e}", file=sys.stderr)
-            errors += 1
+    print(f"\nGenerated {len(generated)}/{len(EXPECTED_FILES)} drafts in {socials_dir}")
 
-    print(f"\nGenerated {generated} drafts ({errors} errors) in {socials_dir}")
+    if missing:
+        print(f"Missing: {', '.join(missing)}", file=sys.stderr)
 
-    # Upload to bucket if requested
-    if upload_bucket and generated > 0:
-        # Strip leading "v" for the bucket path if present
-        bucket_version = version.lstrip("v")
-        if not upload_to_bucket(socials_dir, upload_bucket, bucket_version):
-            print("Warning: Bucket upload failed", file=sys.stderr)
-            return 1
-        print(f"Uploaded to bucket {upload_bucket}/huggingface_hub/{bucket_version}/socials/")
+    # Print summaries
+    for filename in generated:
+        path = socials_dir / filename
+        content = path.read_text().strip()
+        preview = content[:120] + "..." if len(content) > 120 else content
+        print(f"  {filename} ({path.stat().st_size} bytes): {preview}")
 
-    return 0 if errors == 0 else 1
+    return 0 if not missing else 1
 
 
 def cli():
@@ -272,11 +147,9 @@ Examples:
   # Generate drafts for v1.8.0
   python -m utils.release_notes.generate_social_posts --version v1.8.0
 
-  # With explicit input and bucket upload
+  # With explicit input file
   python -m utils.release_notes.generate_social_posts \\
-    --version v1.8.0 \\
-    --input notes.md \\
-    --upload-bucket huggingface/releases
+    --version v1.8.0 --input notes.md
 """,
     )
     parser.add_argument(
@@ -290,19 +163,9 @@ Examples:
         default=None,
         help="Path to release notes file (auto-detected if omitted)",
     )
-    parser.add_argument(
-        "--upload-bucket",
-        default=None,
-        help="HF bucket ID to upload results (e.g., huggingface/releases)",
-    )
-    parser.add_argument(
-        "--model",
-        default=None,
-        help="HF model ID for generation (defaults to RELEASE_NOTES_MODEL env var)",
-    )
     args = parser.parse_args()
 
-    sys.exit(main(args.version, args.input, args.upload_bucket, args.model))
+    sys.exit(main(args.version, args.input))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#### Note: `RELEASE_BUCKET_HF_TOKEN` secret already added to the repo + https://huggingface.co/buckets/huggingface/releases already exists (private)

---

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds automated social media draft generation to the release workflow. During prereleases, the new `social-posts` job generates 6 draft posts (3 LinkedIn + 3 X/Twitter) with different tones/angles from the release notes, saves them to disk, and uploads them to an HF bucket for the team to review and post.

Opencode skill definition with all tone/angle rules hardcoded:
  - **LinkedIn**: professional (technical value), community (ecosystem/contributors), tutorial (code snippets) — 150-250 words each
  - **X**: announcement (punchy hype), technical (DX-focused), thread (3-5 tweets) — 280 chars per tweet
  - Each draft includes a picture suggestion at the end


### Bucket structure

```
huggingface/releases/
  huggingface_hub/
    1.8.0/
      socials/
        linkedin_professional_1.txt
        linkedin_community_2.txt
        linkedin_tutorial_3.txt
        x_announcement_1.txt
        x_technical_2.txt
        x_thread_3.txt
```

### Design decisions

- Uses OpenCode for generation, matching the existing release-notes and slack-message pattern
- Script saves files to disk only; the single `hf buckets sync` in the workflow handles upload (clean separation)
- Job runs on prereleases only with `!cancelled()` so it can be re-run independently
- New secret: `RELEASE_BUCKET_HF_TOKEN` — HF token scoped to push to the `huggingface/releases` bucket

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://huggingface.slack.com/archives/D0A9313SS3G/p1776874070866419?thread_ts=1776874070.866419&cid=D0A9313SS3G)

<div><a href="https://cursor.com/agents/bc-8732e1be-083e-5137-a5df-b9426b7f1f3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8732e1be-083e-5137-a5df-b9426b7f1f3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

