### PR TITLE
[CLI] Print help when leaf command with required args is called without args

### DIFF
--- a/src/huggingface_hub/cli/_cli_utils.py
+++ b/src/huggingface_hub/cli/_cli_utils.py
@@ -433,10 +433,24 @@ def HFCliCommand(topic: TOPIC_T, examples: list[str] | None = None) -> type[Type
     def format_epilog(self: click.Command, ctx: click.Context, formatter: click.HelpFormatter) -> None:
         _format_epilog_no_indent(self.epilog, ctx, formatter)
 
+    def parse_args(self: click.Command, ctx: click.Context, args: list[str]) -> list[str]:
+        # Show help when a command with required arguments is invoked without any args
+        # (mirrors group behavior: `hf jobs` prints help, so `hf download` should too).
+        if not args and not ctx.resilient_parsing:
+            if any(isinstance(p, click.Argument) and p.required for p in self.params):
+                click.echo(ctx.get_help(), color=ctx.color)
+                ctx.exit()
+        return TyperCommand.parse_args(self, ctx, args)
+
     return type(
         f"TyperCommand{topic.capitalize()}",
         (TyperCommand,),
-        {"topic": topic, "examples": examples or [], "format_epilog": format_epilog},
+        {
+            "topic": topic,
+            "examples": examples or [],
+            "format_epilog": format_epilog,
+            "parse_args": parse_args,
+        },
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -892,6 +892,13 @@ class TestDownloadCommand:
         assert kwargs["allow_patterns"] == ["art/**"]
         assert kwargs["ignore_patterns"] is None
 
+    def test_download_without_args_prints_help(self, runner: CliRunner) -> None:
+        """`hf download` without args should print help (like groups do), not error out."""
+        result = runner.invoke(app, ["download"])
+        assert result.exit_code == 0
+        assert "Usage:" in result.stdout and "download [OPTIONS] REPO_ID" in result.stdout
+        assert "Download files from the Hub." in result.stdout
+
 
 class TestDownloadImpl:
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary

- Commands like `hf download` (leaf commands with required positional arguments) used to error out with `Error: Missing argument 'REPO_ID'` when called without args. Command groups like `hf jobs` print their help instead. This PR makes leaf commands behave the same way: if a command has at least one required argument and is invoked with no args, print help and exit 0.
- Implemented by overriding `parse_args` in the `HFCliCommand` class factory. Commands with no required arguments (e.g. `hf version`, `hf env`) keep running normally. `--help` / `-h` still work.

Context: https://huggingface.slack.com/archives/C0ACCEFPU9W/p1776414191737639

### Before

```
$ hf download
Usage: hf download [OPTIONS] REPO_ID [FILENAMES]...
Try 'hf download -h' for help.

Error: Missing argument 'REPO_ID'.
```

### After

```
$ hf download
Usage: hf download [OPTIONS] REPO_ID [FILENAMES]...

  Download files from the Hub.

Arguments:
  REPO_ID         The ID of the repo (e.g. `username/repo-name` or
                  `spaces/username/repo-name`).  [required]
  [FILENAMES]...  Files to download (e.g. `config.json`,
                  `data/metadata.jsonl`).
...
```

Verified manually that `hf version`, `hf env`, `hf download --help`, and groups like `hf jobs` are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small CLI UX change confined to argument parsing for leaf commands, with a targeted test to guard behavior. Main risk is unintended help/exit behavior for commands that rely on empty-args invocation, but it’s gated on having required positional args.
> 
> **Overview**
> Leaf CLI commands with required positional arguments now **print their help and exit 0** when invoked with no args (e.g. `hf download`), matching how command groups behave.
> 
> Implemented by overriding `TyperCommand.parse_args` via `HFCliCommand` in `_cli_utils.py`, and adds a regression test asserting `hf download` without args shows usage/help instead of a missing-argument error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81ac8ffd7c9356d719853af73c53a55d7bd5940e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->