### PR TITLE
chore: bump doc-builder SHA for main doc build workflow

### DIFF
--- a/.github/workflows/build_documentation.yaml
+++ b/.github/workflows/build_documentation.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
    build:
-    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@90b4ee2c10b81b5c1a6367c4e6fc9e2fb510a7e3  # main
+    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@2430c1ec91d04667414e2fa31ecfc36c153ea391  # main
     with:
       commit_sha: ${{ github.sha }}
       package: huggingface_hub


### PR DESCRIPTION
Bump the pinned doc-builder SHA so that main documentation builds also sync to the HF bucket (dual-write introduced in doc-builder PR #780, 2026-04-15). The current pin predates that change, so release docs never land in the bucket — only in the legacy dataset.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that just advances the pinned external workflow commit; main impact is on where/how docs are published during the workflow run.
> 
> **Overview**
> Bumps the pinned `huggingface/doc-builder` reusable workflow commit in `.github/workflows/build_documentation.yaml`, so documentation builds run against a newer `doc-builder` revision (potentially affecting publish/sync behavior) without changing this repo’s build inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c4225ead9530d4c2a8b3a3f1ace3fa3095885bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->