### PR TITLE
[Release] Make release-notes job fail loudly on bad model/empty output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -439,35 +439,26 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="${{ needs.prepare.outputs.tag }}"
-          VERSION="${{ needs.prepare.outputs.version }}"
 
-          # Find generated notes file (if any)
+          # Find generated notes file produced by the OpenCode step above.
           NOTES_FILE=""
           for f in .release-notes/RELEASE_NOTES_*.md; do
-            if [[ -f "$f" ]]; then
+            if [[ -f "$f" && -s "$f" ]]; then
               NOTES_FILE="$f"
               break
             fi
           done
 
-          ARGS=(
-            "$TAG"
-            --draft
-            --prerelease
-          )
-
-          if [[ -n "$NOTES_FILE" ]]; then
-            echo "Using generated release notes from $NOTES_FILE"
-            # Extract title from first line (strip "# " prefix) and use rest as body
-            TITLE=$(head -1 "$NOTES_FILE" | sed 's/^# //')
-            tail -n +2 "$NOTES_FILE" > "${NOTES_FILE}.body"
-            ARGS+=(--title "$TITLE" --notes-file "${NOTES_FILE}.body")
-          else
-            echo "No generated notes found, using GitHub auto-generated notes"
-            ARGS+=(--title "v${VERSION}" --generate-notes)
+          if [[ -z "$NOTES_FILE" ]]; then
+            echo "::error::No generated release notes file found in .release-notes/. Refusing to create a release with GitHub auto-generated notes (they can exceed the 125k-char body limit). Fix the release-notes step and re-run."
+            exit 1
           fi
 
-          gh release create "${ARGS[@]}"
+          echo "Using generated release notes from $NOTES_FILE"
+          # Extract title from first line (strip "# " prefix) and use rest as body
+          TITLE=$(head -1 "$NOTES_FILE" | sed 's/^# //')
+          tail -n +2 "$NOTES_FILE" > "${NOTES_FILE}.body"
+          gh release create "$TAG" --draft --prerelease --title "$TITLE" --notes-file "${NOTES_FILE}.body"
 
       # --- Minor release: update existing draft to point to the final tag ---
       - name: Promote draft release to final version
@@ -548,6 +539,7 @@ jobs:
         run: echo "${{ vars.OPENCODE_SHA256 }}  $(which opencode)" | sha256sum -c -
 
       - name: Fetch release notes from GitHub
+        id: fetch
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -559,14 +551,17 @@ jobs:
             | jq -r ".[] | select(.isDraft or .isPrerelease) | select(.tagName | startswith(\"v${MINOR}.\")) | .tagName" | head -1)
 
           if [[ -z "$RELEASE_TAG" ]]; then
-            echo "::error::No release found for v${MINOR}. Ensure a prerelease or draft release exists."
-            exit 1
+            echo "::warning::No release found for v${MINOR}. Skipping Slack message generation (likely because release-notes failed)."
+            echo "found=false" >> $GITHUB_OUTPUT
+            exit 0
           fi
 
           echo "Found release: $RELEASE_TAG"
           gh release view "$RELEASE_TAG" --json body -q '.body' > notes.md
+          echo "found=true" >> $GITHUB_OUTPUT
 
       - name: Generate Slack message
+        if: ${{ steps.fetch.outputs.found == 'true' }}
         env:
           HF_TOKEN: ${{ secrets.RELEASE_NOTES_HF_TOKEN }}
           RELEASE_NOTES_MODEL: ${{ vars.RELEASE_NOTES_MODEL }}
@@ -583,6 +578,7 @@ jobs:
             --input notes.md
 
       - name: Print Slack message to summary
+        if: ${{ steps.fetch.outputs.found == 'true' }}
         run: |
           VERSION="${{ needs.prepare.outputs.version }}"
           BASE_VERSION=$(echo "$VERSION" | sed -E 's/\.rc.*//')
@@ -602,7 +598,9 @@ jobs:
           BASE_VERSION=$(echo "$VERSION" | sed -E 's/\.rc.*//')
           SLACK_MSG_FILE=".release-notes/SLACK_MESSAGE_v${BASE_VERSION}.md"
 
-          if [[ "${{ job.status }}" == "success" ]]; then
+          if [[ "${{ steps.fetch.outputs.found }}" != "true" ]]; then
+            TEXT="⚠️ *Slack announcement* — skipped (no release found)"
+          elif [[ "${{ job.status }}" == "success" ]]; then
             TEXT="✅ *Slack announcement* — message generated"
           else
             TEXT="❌ *Slack announcement* — generation failed"
@@ -670,6 +668,7 @@ jobs:
         run: echo "${{ vars.OPENCODE_SHA256 }}  $(which opencode)" | sha256sum -c -
 
       - name: Fetch release notes from GitHub
+        id: fetch
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -680,15 +679,18 @@ jobs:
             | jq -r ".[] | select(.isDraft or .isPrerelease) | select(.tagName | startswith(\"v${MINOR}.\")) | .tagName" | head -1)
 
           if [[ -z "$RELEASE_TAG" ]]; then
-            echo "::error::No release found for v${MINOR}."
-            exit 1
+            echo "::warning::No release found for v${MINOR}. Skipping social media draft generation (likely because release-notes failed)."
+            echo "found=false" >> $GITHUB_OUTPUT
+            exit 0
           fi
 
           echo "Found release: $RELEASE_TAG"
           mkdir -p .release-notes
           gh release view "$RELEASE_TAG" --json body -q '.body' > .release-notes/notes.md
+          echo "found=true" >> $GITHUB_OUTPUT
 
       - name: Generate social media drafts
+        if: ${{ steps.fetch.outputs.found == 'true' }}
         env:
           HF_TOKEN: ${{ secrets.RELEASE_NOTES_HF_TOKEN }}
           RELEASE_NOTES_MODEL: ${{ vars.RELEASE_NOTES_MODEL }}
@@ -700,6 +702,7 @@ jobs:
             --input .release-notes/notes.md
 
       - name: Upload drafts to bucket
+        if: ${{ steps.fetch.outputs.found == 'true' }}
         env:
           HF_TOKEN: ${{ secrets.RELEASE_BUCKET_HF_TOKEN }}
         run: |
@@ -709,6 +712,7 @@ jobs:
             "hf://buckets/huggingface/releases/huggingface_hub/${BASE_VERSION}/socials/"
 
       - name: Print drafts to summary
+        if: ${{ steps.fetch.outputs.found == 'true' }}
         run: |
           echo "## Social Media Drafts" >> $GITHUB_STEP_SUMMARY
           for f in .release-notes/socials/*.txt; do
@@ -732,7 +736,9 @@ jobs:
           VERSION="${{ needs.prepare.outputs.version }}"
           BASE_VERSION=$(echo "$VERSION" | sed -E 's/\.rc.*//')
           BUCKET_URL="https://huggingface.co/buckets/huggingface/releases/huggingface_hub/${BASE_VERSION}/socials"
-          if [[ "${{ job.status }}" == "success" ]]; then
+          if [[ "${{ steps.fetch.outputs.found }}" != "true" ]]; then
+            TEXT="⚠️ *Social media drafts* — skipped (no release found)"
+          elif [[ "${{ job.status }}" == "success" ]]; then
             TEXT="✅ *Social media drafts* — <${BUCKET_URL}|uploaded to bucket>"
           else
             TEXT="❌ *Social media drafts* — generation failed"

--- a/utils/release_notes/generate_release_notes.py
+++ b/utils/release_notes/generate_release_notes.py
@@ -61,6 +61,29 @@ def bump_version(tag: str, bump_type: str = "patch") -> str:
     return f"{prefix}{major}.{minor}.{patch}"
 
 
+def check_opencode_model(model: str) -> None:
+    """Verify that ``model`` is listed by ``opencode models``.
+
+    OpenCode exits 0 and prints an error line when an unknown model is passed
+    via ``--model``, so calls silently no-op unless we validate up front.
+    Raises ``RuntimeError`` if opencode is missing or the model is unknown.
+    """
+    opencode_cmd = shutil.which("opencode")
+    if not opencode_cmd:
+        raise RuntimeError("'opencode' command not found in PATH")
+
+    result = subprocess.run(
+        [opencode_cmd, "models"], check=True, capture_output=True, text=True
+    )
+    available = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    if model not in available:
+        raise RuntimeError(
+            f"RELEASE_NOTES_MODEL={model!r} not found in `opencode models` output. "
+            f"Expected the full `provider/model` form (e.g. `huggingface/zai-org/GLM-4.6`). "
+            f"{len(available)} model(s) available — first 10: {', '.join(available[:10])}"
+        )
+
+
 def run_opencode_skill(
     skill_name: str,
     version: str,
@@ -144,6 +167,17 @@ def main(since_tag: str, bump_type: str = "patch", max_iterations: int = 3) -> i
     """
     t_total_start = time.monotonic()
 
+    # 0. Validate the configured model before doing any expensive work.
+    #    OpenCode exits 0 on unknown models, so a typo here would otherwise
+    #    silently produce empty release notes.
+    model = os.environ.get("RELEASE_NOTES_MODEL")
+    if model:
+        try:
+            check_opencode_model(model)
+        except RuntimeError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            return 1
+
     # 1. Clean up and setup directories
     if OUTPUT_DIR.exists():
         print("Cleaning up previous release notes...")
@@ -179,6 +213,17 @@ def main(since_tag: str, bump_type: str = "patch", max_iterations: int = 3) -> i
         print("Failed to generate initial release notes", file=sys.stderr)
         return 1
     agent_calls += 1
+
+    # OpenCode can exit 0 without writing the expected file (e.g. auth/quota
+    # issues). Fail fast instead of falling through to a 0-byte output.
+    initial_output = OUTPUT_DIR / f"RELEASE_NOTES_{version}.md"
+    if not initial_output.exists() or initial_output.stat().st_size == 0:
+        print(
+            f"Error: OpenCode did not produce {initial_output} (or file is empty). "
+            f"Check OpenCode logs above for the real error.",
+            file=sys.stderr,
+        )
+        return 1
 
     # 5. Validation loop
     validation_iterations = 0
@@ -240,6 +285,13 @@ def main(since_tag: str, bump_type: str = "patch", max_iterations: int = 3) -> i
     print(f"  Output file:           {output_file}")
     print(f"  Output size:           {output_size:,} bytes")
     print("=" * 60)
+
+    if output_size == 0:
+        print(
+            f"Error: {output_file} is empty after validation loop.",
+            file=sys.stderr,
+        )
+        return 1
 
     print(f"\nRelease notes saved to {output_file}")
     return 0


### PR DESCRIPTION
## Summary

Follow-up to the [v1.12.0.rc0 release run](https://github.com/huggingface/huggingface_hub/actions/runs/24890106247) which created no GitHub release and cascaded into `slack-message` / `social-posts` failures.

Root cause: `RELEASE_NOTES_MODEL` was set to `zai-org/GLM-5.1` (missing the `huggingface/` provider prefix). OpenCode prints an error but exits 0, so `generate_release_notes.py` finished "successfully" with a 0-byte file, the workflow fell back to `gh release create --generate-notes`, and GitHub's auto-notes exceeded the 125k char body limit (HTTP 422). The repo variable has since been updated to `huggingface/zai-org/GLM-5.1`.

Changes to prevent this class of silent failure:

- **Validate the model up front**: new `check_opencode_model()` runs `opencode models` and errors with a clear message (listing available models) if `RELEASE_NOTES_MODEL` isn't present. Called before any expensive work in `main()`.
- **Fail fast on empty output**: after the initial OpenCode call and again at the end of `main()`, error out if `RELEASE_NOTES_<version>.md` is missing or 0 bytes.
- **Drop the GitHub auto-notes fallback** in the `Create draft GitHub release (prerelease)` step. If the generated notes file is missing, fail with an explicit error rather than creating a release with a 125k+ char body.
- **Downgrade downstream jobs to warnings**: `slack-message` and `social-posts` now emit `::warning::` and skip (rather than `::error::` + `exit 1`) when no release is found, so a broken `release-notes` step doesn't manufacture two extra red jobs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the release automation workflow and adds new failure conditions that can block creating prerelease GitHub releases if note generation misbehaves.
> 
> **Overview**
> Hardens prerelease release-note generation to **fail loudly instead of silently producing empty outputs**.
> 
> `utils/release_notes/generate_release_notes.py` now validates `RELEASE_NOTES_MODEL` against `opencode models` before doing any work, and errors out if OpenCode doesn’t produce the expected `RELEASE_NOTES_<version>.md` file or if the final output is empty.
> 
> The release workflow (`release.yml`) stops falling back to `gh release create --generate-notes` for minor prereleases, requiring a non-empty generated notes file, and updates the `slack-message`/`social-posts` jobs to **skip gracefully** (via a `fetch` step output) when no draft/prerelease release is found.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15de7ffc7f7c81723525206b7f2c3cff431e0be4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->