### PR TITLE
[Release] Fix bucket URL in social posts Slack notification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -735,7 +735,7 @@ jobs:
         run: |
           VERSION="${{ needs.prepare.outputs.version }}"
           BASE_VERSION=$(echo "$VERSION" | sed -E 's/\.rc.*//')
-          BUCKET_URL="https://huggingface.co/buckets/huggingface/releases/huggingface_hub/${BASE_VERSION}/socials"
+          BUCKET_URL="https://huggingface.co/buckets/huggingface/releases/tree/huggingface_hub/${BASE_VERSION}/socials"
           if [[ "${{ steps.fetch.outputs.found }}" != "true" ]]; then
             TEXT="⚠️ *Social media drafts* — skipped (no release found)"
           elif [[ "${{ job.status }}" == "success" ]]; then


### PR DESCRIPTION
## Summary

- The Slack notification posted after generating social-media drafts linked to an invalid bucket URL (missing the \`tree/\` segment).
- Corrected to the form \`https://huggingface.co/buckets/huggingface/releases/tree/huggingface_hub/<version>/socials\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line change to a GitHub Actions Slack message URL with no impact on build/release behavior beyond the link target.
> 
> **Overview**
> Fixes the `social-posts` Slack notification to link to the correct Hugging Face bucket browser URL by adding the missing `tree/` segment in `BUCKET_URL`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cccb5e321645ea4bffc18721ab2c1601b5c1c4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->