### PR TITLE
[CI] Fix two flaky Windows tests (root causes, not skips)

### DIFF
--- a/src/huggingface_hub/serialization/_torch.py
+++ b/src/huggingface_hub/serialization/_torch.py
@@ -21,7 +21,7 @@ import re
 from collections import defaultdict, namedtuple
 from collections.abc import Iterable
 from functools import lru_cache
-from pathlib import Path, PurePosixPath, PureWindowsPath
+from pathlib import Path, PureWindowsPath
 from typing import TYPE_CHECKING, Any, NamedTuple, Union
 
 from packaging import version
@@ -516,15 +516,14 @@ def _load_sharded_checkpoint(
     expected_extension = Path(filename_pattern.format(suffix="")).suffix  # e.g. ".safetensors"
     shard_files = list(set(index["weight_map"].values()))
     for shard_file in shard_files:
-        # Reject path traversal (e.g. "../malicious.bin", absolute paths).
-        # Check both POSIX and Windows semantics so e.g. "/tmp/x" is rejected on
-        # Windows too. Note: `os.path.isabs` is host-OS-specific, and since Python 3.13
-        # ntpath.isabs no longer treats a single leading "/" as absolute.
-        if (
-            PurePosixPath(shard_file).is_absolute()
-            or PureWindowsPath(shard_file).is_absolute()
-            or ".." in Path(shard_file).parts
-        ):
+        # Reject anything that could escape save_directory on any host OS:
+        # POSIX absolute ("/tmp/x"), Windows drive ("C:x", "C:\\x"), UNC
+        # ("\\\\server\\share\\x"), rooted-without-drive ("\\x", "/x"), or
+        # ".." traversal — including "..\\x" which os.path.isabs never caught on POSIX.
+        # `PureWindowsPath` parses both "/" and "\\" as separators and exposes drive/root,
+        # so a single check works on every platform.
+        win_path = PureWindowsPath(shard_file)
+        if win_path.drive or win_path.root or ".." in win_path.parts:
             raise ValueError(
                 f"Invalid shard filename '{shard_file}' in index file '{index_file}'. "
                 "Shard filenames must be relative paths without '..' components."

--- a/src/huggingface_hub/serialization/_torch.py
+++ b/src/huggingface_hub/serialization/_torch.py
@@ -21,7 +21,7 @@ import re
 from collections import defaultdict, namedtuple
 from collections.abc import Iterable
 from functools import lru_cache
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import TYPE_CHECKING, Any, NamedTuple, Union
 
 from packaging import version
@@ -516,8 +516,15 @@ def _load_sharded_checkpoint(
     expected_extension = Path(filename_pattern.format(suffix="")).suffix  # e.g. ".safetensors"
     shard_files = list(set(index["weight_map"].values()))
     for shard_file in shard_files:
-        # Reject path traversal (e.g. "../malicious.bin", absolute paths)
-        if os.path.isabs(shard_file) or ".." in Path(shard_file).parts:
+        # Reject path traversal (e.g. "../malicious.bin", absolute paths).
+        # Check both POSIX and Windows semantics so e.g. "/tmp/x" is rejected on
+        # Windows too. Note: `os.path.isabs` is host-OS-specific, and since Python 3.13
+        # ntpath.isabs no longer treats a single leading "/" as absolute.
+        if (
+            PurePosixPath(shard_file).is_absolute()
+            or PureWindowsPath(shard_file).is_absolute()
+            or ".." in Path(shard_file).parts
+        ):
             raise ValueError(
                 f"Invalid shard filename '{shard_file}' in index file '{index_file}'. "
                 "Shard filenames must be relative paths without '..' components."

--- a/src/huggingface_hub/serialization/_torch.py
+++ b/src/huggingface_hub/serialization/_torch.py
@@ -516,12 +516,17 @@ def _load_sharded_checkpoint(
     expected_extension = Path(filename_pattern.format(suffix="")).suffix  # e.g. ".safetensors"
     shard_files = list(set(index["weight_map"].values()))
     for shard_file in shard_files:
-        # Reject anything that could escape save_directory on any host OS:
+        # Reject anything that could escape `save_directory` on any host OS:
         # POSIX absolute ("/tmp/x"), Windows drive ("C:x", "C:\\x"), UNC
         # ("\\\\server\\share\\x"), rooted-without-drive ("\\x", "/x"), or
-        # ".." traversal — including "..\\x" which os.path.isabs never caught on POSIX.
-        # `PureWindowsPath` parses both "/" and "\\" as separators and exposes drive/root,
-        # so a single check works on every platform.
+        # ".." traversal — including "..\\x" which `os.path.isabs` never caught on POSIX.
+        #
+        # We parse with `PureWindowsPath` *regardless of host OS*: it treats both "/" and
+        # "\\" as separators and exposes `drive` / `root`, so a single check rejects a
+        # malicious index file on Linux too (e.g. if it's later opened on Windows). The
+        # only over-strict case is a POSIX filename like "a:foo" which would be parsed as
+        # drive "a:" — such names are never produced for safetensors shards and would
+        # break on Windows anyway, so rejecting them is fine.
         win_path = PureWindowsPath(shard_file)
         if win_path.drive or win_path.root or ".." in win_path.parts:
             raise ValueError(

--- a/tests/test_hf_file_system.py
+++ b/tests/test_hf_file_system.py
@@ -385,11 +385,17 @@ class _HfFileSystemBaseROTests(_HfFileSystemBaseTests):
 
     def test_pickle(self):
         # Test that pickling re-populates the HfFileSystem cache and keeps the instance cache attributes.
-        # Use the staging endpoint (where `text_file` actually exists) so the initial `isfile` call
-        # resolves deterministically. Going against production would either hit a 404 (triggering the
-        # namespace-fallback in `resolve_path` and populating 2 cache entries) or some other error
-        # depending on the runner's network path, which made this test flaky on Windows CI.
-        fs = HfFileSystem(endpoint=ENDPOINT_STAGING, token=TOKEN)
+        #
+        # Two things must hold for this test to be deterministic:
+        # 1. The pre-pickle fs must hit an endpoint where `text_file` actually exists, so the initial
+        #    `isfile` call resolves cleanly and populates exactly one cache entry. Going against
+        #    production would 404 and trigger the namespace fallback in `resolve_path`, adding 2 entries.
+        # 2. The pre-pickle fs must NOT be shared via fsspec's instance cache with any sibling test
+        #    (e.g. the bucket-based `test_pickle` inherited by `HfFileSystemBucketROTests`), otherwise
+        #    leftover `_bucket_exists_cache` / `dircache` entries from that test leak into this one
+        #    via the main-thread state-inheritance path in `_Cached.__call__`.
+        # `skip_instance_cache=True` guarantees a fresh instance regardless of what earlier tests ran.
+        fs = HfFileSystem(endpoint=ENDPOINT_STAGING, token=TOKEN, skip_instance_cache=True)
         fs.isfile(self.text_file)
         pickled = pickle.dumps(fs)
         HfFileSystem.clear_instance_cache()

--- a/tests/test_hf_file_system.py
+++ b/tests/test_hf_file_system.py
@@ -384,8 +384,12 @@ class _HfFileSystemBaseROTests(_HfFileSystemBaseTests):
             assert (Path(temp_dir) / "data").exists()
 
     def test_pickle(self):
-        # Test that pickling re-populates the HfFileSystem cache and keeps the instance cache attributes
-        fs = HfFileSystem()
+        # Test that pickling re-populates the HfFileSystem cache and keeps the instance cache attributes.
+        # Use the staging endpoint (where `text_file` actually exists) so the initial `isfile` call
+        # resolves deterministically. Going against production would either hit a 404 (triggering the
+        # namespace-fallback in `resolve_path` and populating 2 cache entries) or some other error
+        # depending on the runner's network path, which made this test flaky on Windows CI.
+        fs = HfFileSystem(endpoint=ENDPOINT_STAGING, token=TOKEN)
         fs.isfile(self.text_file)
         pickled = pickle.dumps(fs)
         HfFileSystem.clear_instance_cache()

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -870,8 +870,11 @@ class TestShardedCheckpointValidation:
         "malicious_path",
         [
             "/tmp/malicious.safetensors",  # POSIX absolute
+            "\\malicious.safetensors",  # Windows rooted, no drive (resolves to C:\malicious on Windows)
+            "C:malicious.safetensors",  # Windows drive-only (relative to CWD of drive C)
             "C:\\malicious.safetensors",  # Windows drive-absolute
             "\\\\server\\share\\malicious.safetensors",  # Windows UNC
+            "..\\malicious.safetensors",  # Windows-style traversal (backslash as separator)
         ],
     )
     def test_safetensors_index_rejects_absolute_path(self, tmp_path, malicious_path):

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -866,12 +866,20 @@ class TestShardedCheckpointValidation:
         with pytest.raises(ValueError, match="Invalid shard filename.*without '..' components"):
             load_torch_model(Mock(), tmp_path)
 
-    def test_safetensors_index_rejects_absolute_path(self, tmp_path):
-        """A shard filename with an absolute path must be rejected."""
+    @pytest.mark.parametrize(
+        "malicious_path",
+        [
+            "/tmp/malicious.safetensors",  # POSIX absolute
+            "C:\\malicious.safetensors",  # Windows drive-absolute
+            "\\\\server\\share\\malicious.safetensors",  # Windows UNC
+        ],
+    )
+    def test_safetensors_index_rejects_absolute_path(self, tmp_path, malicious_path):
+        """A shard filename with an absolute path must be rejected on every host OS."""
         index = {
             "metadata": {"total_size": 100},
             "weight_map": {
-                "layer_1": "/tmp/malicious.safetensors",
+                "layer_1": malicious_path,
             },
         }
         (tmp_path / "model.safetensors.index.json").write_text(json.dumps(index))


### PR DESCRIPTION
### Context: let's hope CI is finally green :crossed_fingers: 


---


Two Windows-only flaky tests, both with real root causes:

### 1. `test_safetensors_index_rejects_absolute_path` (Py 3.14 Windows)

This is a real security regression, not just a test bug. The validator in `_load_sharded_checkpoint` uses `os.path.isabs(shard_file)` to reject absolute paths in a safetensors index file. Since **Python 3.13**, `ntpath.isabs()` no longer treats `/tmp/foo` (single leading slash, no drive) as absolute — so on Windows Py 3.13+, an index file with `"/tmp/malicious.safetensors"` sails past validation and `os.path.join` resolves it to `C:\tmp\malicious.safetensors`.

Fix: check both `PurePosixPath.is_absolute()` and `PureWindowsPath.is_absolute()`, so a malicious POSIX-absolute path in an index file is rejected on Windows too (and vice-versa). Parametrized the test to cover POSIX-absolute, Windows drive-absolute, and UNC paths.

### 2. `test_hf_file_system.test_pickle` (Windows, all Py versions)

The test did `HfFileSystem()` (defaults to **production**) but `self.text_file` is a repo created on **staging**. The `isfile()` call always 404'd on production. In `resolve_path`, when a lookup fails with `RepositoryNotFoundError`, the code retries with a truncated repo_id (namespace-fallback) — writing a second cache entry. Whether the retry fires depends on the exact error returned by production, which differs between GHA Ubuntu and Windows runners. Windows consistently gets a clean 404 → fallback fires → 2 entries → `assert len(...) == 1` fails. Linux gets a different error → 1 entry → passes.

Fix: point the pickled fs at `ENDPOINT_STAGING` so the initial `isfile()` resolves deterministically against the endpoint where the repo actually exists.

## Verification

```
$ pytest tests/test_serialization.py::TestShardedCheckpointValidation
...
tests/test_serialization.py::TestShardedCheckpointValidation::test_safetensors_index_rejects_bin_shard PASSED
tests/test_serialization.py::TestShardedCheckpointValidation::test_safetensors_index_rejects_path_traversal PASSED
tests/test_serialization.py::TestShardedCheckpointValidation::test_safetensors_index_rejects_absolute_path[/tmp/malicious.safetensors] PASSED
tests/test_serialization.py::TestShardedCheckpointValidation::test_safetensors_index_rejects_absolute_path[C:\\malicious.safetensors] PASSED
tests/test_serialization.py::TestShardedCheckpointValidation::test_safetensors_index_rejects_absolute_path[\\\\server\\share\\malicious.safetensors] PASSED
5 passed
```

Windows CI behavior will be validated by this PR's own checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shard filename validation in model loading (a security-sensitive area) and adjusts filesystem caching tests; logic change is small but could affect loading behavior for unusual paths across OSes.
> 
> **Overview**
> **Hardens sharded safetensors checkpoint loading** by validating shard filenames using both `PurePosixPath.is_absolute()` and `PureWindowsPath.is_absolute()` (in addition to rejecting `..`), closing a Windows/Python 3.13+ edge case where POSIX-style absolute paths could bypass `os.path.isabs` checks.
> 
> **Deflakes Windows CI tests** by (1) parametrizing the absolute-path rejection test to cover POSIX, Windows drive, and UNC paths on any host OS, and (2) making `HfFileSystem` pickling/caching test use the staging endpoint so cache population is deterministic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c7756ba33d4f24de02f303ae807dd06f2d496b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->