### PR TITLE
[CLI] Store tokens in XDG_CONFIG_HOME instead of cache directory

### DIFF
--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -208,17 +208,14 @@ HF_HUB_DISABLE_TELEMETRY = (
 # Token config (XDG_CONFIG_HOME for security-sensitive data like tokens)
 # https://specifications.freedesktop.org/basedir/latest/
 default_token_home = os.path.join(os.path.expanduser("~"), ".config")
-HF_TOKEN_HOME = os.path.expandvars(
-    os.path.expanduser(
-        os.getenv(
-            "HF_TOKEN_HOME",
-            os.path.join(
-                os.getenv("HF_HOME") or os.getenv("XDG_CONFIG_HOME", default_token_home),
-                "huggingface",
-            ),
-        )
+if "HF_TOKEN_HOME" in os.environ:
+    HF_TOKEN_HOME = os.path.expandvars(os.path.expanduser(os.environ["HF_TOKEN_HOME"]))
+elif "HF_HOME" in os.environ:
+    HF_TOKEN_HOME = os.path.expandvars(os.path.expanduser(os.environ["HF_HOME"]))
+else:
+    HF_TOKEN_HOME = os.path.expandvars(
+        os.path.expanduser(os.path.join(os.getenv("XDG_CONFIG_HOME", default_token_home), "huggingface"))
     )
-)
 
 # Support HF_TOKEN_PATH for backward compatibility
 HF_TOKEN_PATH = os.path.expandvars(

--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -221,15 +221,17 @@ HF_TOKEN_HOME = os.path.expandvars(
 HF_TOKEN_PATH = os.path.expandvars(
     os.path.expanduser(os.getenv("HF_TOKEN_PATH", os.path.join(HF_TOKEN_HOME, "token")))
 )
-HF_STORED_TOKENS_PATH = os.path.join(HF_TOKEN_HOME, "stored_tokens")
+HF_STORED_TOKENS_PATH = os.path.join(os.path.dirname(HF_TOKEN_PATH), "stored_tokens")
 
 if _staging_mode:
     # In staging mode, we use a different cache to ensure we don't mix up production and staging data or tokens
     # In practice in `huggingface_hub` tests, we monkeypatch these values with temporary directories. The following
     # lines are only used in third-party libraries tests (e.g. `transformers`, `diffusers`, etc.).
-    _staging_home = os.path.join(os.path.expanduser("~"), ".config", "huggingface_staging")
-    HUGGINGFACE_HUB_CACHE = os.path.join(_staging_home, "hub")
-    HF_TOKEN_PATH = os.path.join(_staging_home, "token")
+    # Cache goes in ~/.cache (XDG_CACHE_HOME), tokens go in ~/.config (XDG_CONFIG_HOME)
+    _staging_cache_home = os.path.join(os.path.expanduser("~"), ".cache", "huggingface_staging")
+    _staging_config_home = os.path.join(os.path.expanduser("~"), ".config", "huggingface_staging")
+    HUGGINGFACE_HUB_CACHE = os.path.join(_staging_cache_home, "hub")
+    HF_TOKEN_PATH = os.path.join(_staging_config_home, "token")
 
 # Here, `True` will disable progress bars globally without possibility of enabling it
 # programmatically. `False` will enable them without possibility of disabling them.

--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -205,21 +205,29 @@ HF_HUB_DISABLE_TELEMETRY = (
     or _is_true(os.environ.get("DO_NOT_TRACK"))  # https://consoledonottrack.com/
 )
 
-HF_TOKEN_PATH = os.path.expandvars(
+# Token config (XDG_CONFIG_HOME for security-sensitive data like tokens)
+# https://specifications.freedesktop.org/basedir/latest/
+default_token_home = os.path.join(os.path.expanduser("~"), ".config")
+HF_TOKEN_HOME = os.path.expandvars(
     os.path.expanduser(
         os.getenv(
-            "HF_TOKEN_PATH",
-            os.path.join(HF_HOME, "token"),
+            "HF_TOKEN_PATH_CONFIG",
+            os.path.join(os.getenv("XDG_CONFIG_HOME", default_token_home), "huggingface"),
         )
     )
 )
-HF_STORED_TOKENS_PATH = os.path.join(os.path.dirname(HF_TOKEN_PATH), "stored_tokens")
+
+# Support HF_TOKEN_PATH for backward compatibility
+HF_TOKEN_PATH = os.path.expandvars(
+    os.path.expanduser(os.getenv("HF_TOKEN_PATH", os.path.join(HF_TOKEN_HOME, "token")))
+)
+HF_STORED_TOKENS_PATH = os.path.join(HF_TOKEN_HOME, "stored_tokens")
 
 if _staging_mode:
     # In staging mode, we use a different cache to ensure we don't mix up production and staging data or tokens
     # In practice in `huggingface_hub` tests, we monkeypatch these values with temporary directories. The following
     # lines are only used in third-party libraries tests (e.g. `transformers`, `diffusers`, etc.).
-    _staging_home = os.path.join(os.path.expanduser("~"), ".cache", "huggingface_staging")
+    _staging_home = os.path.join(os.path.expanduser("~"), ".config", "huggingface_staging")
     HUGGINGFACE_HUB_CACHE = os.path.join(_staging_home, "hub")
     HF_TOKEN_PATH = os.path.join(_staging_home, "token")
 

--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -211,8 +211,11 @@ default_token_home = os.path.join(os.path.expanduser("~"), ".config")
 HF_TOKEN_HOME = os.path.expandvars(
     os.path.expanduser(
         os.getenv(
-            "HF_TOKEN_PATH_CONFIG",
-            os.path.join(os.getenv("XDG_CONFIG_HOME", default_token_home), "huggingface"),
+            "HF_TOKEN_HOME",
+            os.path.join(
+                os.getenv("HF_HOME") or os.getenv("XDG_CONFIG_HOME", default_token_home),
+                "huggingface",
+            ),
         )
     )
 )

--- a/src/huggingface_hub/utils/_auth.py
+++ b/src/huggingface_hub/utils/_auth.py
@@ -127,7 +127,7 @@ def _get_token_from_file() -> str | None:
 def get_stored_tokens() -> dict[str, str]:
     """
     Returns the parsed INI file containing the access tokens.
-    The file is located at `HF_STORED_TOKENS_PATH`, defaulting to `~/.cache/huggingface/stored_tokens`.
+    The file is located at `HF_STORED_TOKENS_PATH`, defaulting to `~/.config/huggingface/stored_tokens`.
     If the file does not exist, an empty dictionary is returned.
 
     Returns: `dict[str, str]`

--- a/utils/release_notes/generate_release_notes.py
+++ b/utils/release_notes/generate_release_notes.py
@@ -72,9 +72,7 @@ def check_opencode_model(model: str) -> None:
     if not opencode_cmd:
         raise RuntimeError("'opencode' command not found in PATH")
 
-    result = subprocess.run(
-        [opencode_cmd, "models"], check=True, capture_output=True, text=True
-    )
+    result = subprocess.run([opencode_cmd, "models"], check=True, capture_output=True, text=True)
     available = [line.strip() for line in result.stdout.splitlines() if line.strip()]
     if model not in available:
         raise RuntimeError(


### PR DESCRIPTION
## Summary

Following the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir/latest/), tokens (as security-sensitive credentials) are now stored in `$XDG_CONFIG_HOME` (default: `~/.config/huggingface`) instead of `$XDG_CACHE_HOME` (default: `~/.cache/huggingface`).

This fixes issue #4144 where clearing `~/.cache/huggingface` would lose the token, even though tokens are not cached/regeneratable data.

Fixes #4144 

### Changes
- Add `HF_TOKEN_HOME` using `XDG_CONFIG_HOME` (default: `~/.config/huggingface`)
- `HF_TOKEN_PATH` now defaults to `HF_TOKEN_HOME/token`
- Maintain backward compatibility with `HF_TOKEN_PATH` env var
- Update docstrings to reflect new default path

### Example
```bash
# Before (tokens in cache dir - could be cleared!)
~/.cache/huggingface/token

# After (tokens in config dir - persist across cache clears)
~/.config/huggingface/token
```

If `XDG_CONFIG_HOME` is set, tokens will be stored at `$XDG_CONFIG_HOME/huggingface/token`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default on-disk locations for auth tokens, which can break existing setups/scripts or cause users to appear logged out if they relied on the previous cache path. Backward compatibility via `HF_TOKEN_PATH` mitigates this, but path/permission edge cases may surface across environments.
> 
> **Overview**
> Updates token persistence to follow the XDG Base Directory spec by defaulting credentials to `$XDG_CONFIG_HOME` (typically `~/.config/huggingface`) instead of the cache directory.
> 
> Introduces `HF_TOKEN_HOME` with precedence rules (`HF_TOKEN_HOME` > `HF_HOME` > XDG config default), keeps `HF_TOKEN_PATH` as an override for backward compatibility, and separates staging-mode cache vs token locations. Documentation in `get_stored_tokens` is updated to reflect the new default path, and a minor formatting tweak is made in the release notes generator’s `subprocess.run` call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a462f89ef8a24d36fa0e2a69d39384d40212fee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->