### PR TITLE
[CLI] Allow unquoted multi-word search for ls commands

### DIFF
--- a/src/huggingface_hub/cli/datasets.py
+++ b/src/huggingface_hub/cli/datasets.py
@@ -39,7 +39,6 @@ from ._cli_utils import (
     FormatWithAutoOpt,
     LimitOpt,
     RevisionOpt,
-    SearchOpt,
     TokenOpt,
     api_object_to_dict,
     get_hf_api,
@@ -71,11 +70,14 @@ datasets_cli = typer_factory(help="Interact with datasets on the Hub.")
     examples=[
         "hf datasets ls",
         "hf datasets ls --sort downloads --limit 10",
-        'hf datasets ls --search "code"',
+        "hf datasets ls code",
     ],
 )
 def datasets_ls(
-    search: SearchOpt = None,
+    query: Annotated[
+        str | None,
+        typer.Argument(help="Search query.", show_default=False),
+    ] = None,
     author: AuthorOpt = None,
     filter: FilterOpt = None,
     sort: Annotated[
@@ -95,7 +97,7 @@ def datasets_ls(
         for dataset_info in api.list_datasets(
             filter=filter,
             author=author,
-            search=search,
+            search=query,
             sort=sort_key,
             limit=limit,
             expand=expand,  # type: ignore

--- a/src/huggingface_hub/cli/datasets.py
+++ b/src/huggingface_hub/cli/datasets.py
@@ -75,7 +75,7 @@ datasets_cli = typer_factory(help="Interact with datasets on the Hub.")
 )
 def datasets_ls(
     query: Annotated[
-        str | None,
+        list[str] | None,
         typer.Argument(help="Search query.", show_default=False),
     ] = None,
     author: AuthorOpt = None,
@@ -92,12 +92,13 @@ def datasets_ls(
     """List datasets on the Hub."""
     api = get_hf_api(token=token)
     sort_key = sort.value if sort else None
+    search_query = " ".join(query) if query else None
     results = [
         api_object_to_dict(dataset_info)
         for dataset_info in api.list_datasets(
             filter=filter,
             author=author,
-            search=query,
+            search=search_query,
             sort=sort_key,
             limit=limit,
             expand=expand,  # type: ignore

--- a/src/huggingface_hub/cli/models.py
+++ b/src/huggingface_hub/cli/models.py
@@ -38,7 +38,6 @@ from ._cli_utils import (
     FormatWithAutoOpt,
     LimitOpt,
     RevisionOpt,
-    SearchOpt,
     TokenOpt,
     api_object_to_dict,
     get_hf_api,
@@ -69,12 +68,15 @@ models_cli = typer_factory(help="Interact with models on the Hub.")
     "list | ls",
     examples=[
         "hf models ls --sort downloads --limit 10",
-        'hf models ls --search "llama" --author meta-llama',
+        "hf models ls llama --author meta-llama",
         "hf models ls --num-parameters min:6B,max:128B --sort likes",
     ],
 )
 def models_ls(
-    search: SearchOpt = None,
+    query: Annotated[
+        str | None,
+        typer.Argument(help="Search query.", show_default=False),
+    ] = None,
     author: AuthorOpt = None,
     filter: FilterOpt = None,
     num_parameters: Annotated[
@@ -98,7 +100,7 @@ def models_ls(
         for model_info in api.list_models(
             filter=filter,
             author=author,
-            search=search,
+            search=query,
             num_parameters=num_parameters,
             sort=sort_key,
             limit=limit,

--- a/src/huggingface_hub/cli/models.py
+++ b/src/huggingface_hub/cli/models.py
@@ -74,7 +74,7 @@ models_cli = typer_factory(help="Interact with models on the Hub.")
 )
 def models_ls(
     query: Annotated[
-        str | None,
+        list[str] | None,
         typer.Argument(help="Search query.", show_default=False),
     ] = None,
     author: AuthorOpt = None,
@@ -95,12 +95,13 @@ def models_ls(
     """List models on the Hub."""
     api = get_hf_api(token=token)
     sort_key = sort.value if sort else None
+    search_query = " ".join(query) if query else None
     results = [
         api_object_to_dict(model_info)
         for model_info in api.list_models(
             filter=filter,
             author=author,
-            search=query,
+            search=search_query,
             num_parameters=num_parameters,
             sort=sort_key,
             limit=limit,

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -97,7 +97,7 @@ spaces_cli.add_typer(volumes_cli, name="volumes")
 )
 def spaces_ls(
     query: Annotated[
-        str | None,
+        list[str] | None,
         typer.Argument(help="Search query.", show_default=False),
     ] = None,
     author: AuthorOpt = None,
@@ -114,12 +114,13 @@ def spaces_ls(
     """List spaces on the Hub."""
     api = get_hf_api(token=token)
     sort_key = sort.value if sort else None
+    search_query = " ".join(query) if query else None
     results = [
         api_object_to_dict(space_info)
         for space_info in api.list_spaces(
             filter=filter,
             author=author,
-            search=query,
+            search=search_query,
             sort=sort_key,
             limit=limit,
             expand=expand,  # type: ignore[arg-type]

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -56,7 +56,6 @@ from ._cli_utils import (
     FormatWithAutoOpt,
     LimitOpt,
     RevisionOpt,
-    SearchOpt,
     TokenOpt,
     VolumesOpt,
     api_object_to_dict,
@@ -93,11 +92,14 @@ spaces_cli.add_typer(volumes_cli, name="volumes")
     "list | ls",
     examples=[
         "hf spaces ls --limit 10",
-        'hf spaces ls --search "chatbot" --author huggingface',
+        "hf spaces ls chatbot --author huggingface",
     ],
 )
 def spaces_ls(
-    search: SearchOpt = None,
+    query: Annotated[
+        str | None,
+        typer.Argument(help="Search query.", show_default=False),
+    ] = None,
     author: AuthorOpt = None,
     filter: FilterOpt = None,
     sort: Annotated[
@@ -117,7 +119,7 @@ def spaces_ls(
         for space_info in api.list_spaces(
             filter=filter,
             author=author,
-            search=search,
+            search=query,
             sort=sort_key,
             limit=limit,
             expand=expand,  # type: ignore[arg-type]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1747,7 +1747,6 @@ class TestModelsLsCommand:
                     "ls",
                     "--author",
                     "google",
-                    "--search",
                     "bert",
                     "--filter",
                     "text-classification",

--- a/utils/release_notes/generate_release_notes.py
+++ b/utils/release_notes/generate_release_notes.py
@@ -72,9 +72,7 @@ def check_opencode_model(model: str) -> None:
     if not opencode_cmd:
         raise RuntimeError("'opencode' command not found in PATH")
 
-    result = subprocess.run(
-        [opencode_cmd, "models"], check=True, capture_output=True, text=True
-    )
+    result = subprocess.run([opencode_cmd, "models"], check=True, capture_output=True, text=True)
     available = [line.strip() for line in result.stdout.splitlines() if line.strip()]
     if model not in available:
         raise RuntimeError(


### PR DESCRIPTION
## Summary

- Changed `--search` option to a positional `[QUERY]` argument for `hf datasets ls`, `hf models ls`, and `hf spaces ls`
- This allows users to run unquoted multi-word searches like:
  - `hf datasets ls japanese instruction` (parses as single query)
  - `hf models llama 3` (parses as single query)
  - `hf spaces chatbot` (parses as single query)

Previously required quoting:
- `hf datasets ls --search "japanese instruction"`

## Examples from manual testing

```
$ hf datasets ls --help
Usage: root ls [OPTIONS] [QUERY]

Arguments:
  [QUERY]  Search query.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the public CLI interface by replacing `--search` with a positional query, which can break existing scripts/automation relying on the old flag.
> 
> **Overview**
> **CLI behavior change:** `hf models|datasets|spaces ls` now takes the search term(s) as a positional `QUERY` argument (accepting multiple words without quoting) and joins them into the `search` parameter passed to the Hub API, instead of using the `--search` option.
> 
> Tests were updated to reflect the new invocation style, and a small formatting-only tweak was made in `utils/release_notes/generate_release_notes.py` (single-line `subprocess.run(...)`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75c7f3b631511de1dd28209c3324a9171cfc1730. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->