### PR TITLE
[CLI] Add hf cache move command to move cache folder (#1757)

### DIFF
--- a/src/huggingface_hub/cli/cache.py
+++ b/src/huggingface_hub/cli/cache.py
@@ -14,17 +14,20 @@
 """Contains the 'hf cache' command group with cache management subcommands."""
 
 import re
+import shutil
 import time
 from collections import defaultdict
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from enum import Enum
+from pathlib import Path
 from typing import Annotated, Any
 
 import typer
 
 from huggingface_hub.errors import CLIError
 
+from ..constants import HF_HOME
 from ..utils import ANSI, CachedRepoInfo, CachedRevisionInfo, CacheNotFound, HFCacheInfo, _format_size, scan_cache_dir
 from ..utils._parsing import parse_duration, parse_size
 from ._cli_utils import FormatWithAutoOpt, RepoIdArg, RepoTypeOpt, RevisionOpt, TokenOpt, get_hf_api, typer_factory
@@ -754,3 +757,90 @@ def verify(
         checked=result.checked_count,
         path=str(verified_location),
     )
+
+
+@cache_cli.command(
+    examples=[
+        "hf cache move --source /path/to/old/cache --destination /path/to/new/cache",
+    ],
+)
+def move(
+    source: Annotated[
+        str,
+        typer.Option(
+            "--source",
+            help="Source cache directory to move from.",
+        ),
+    ],
+    destination: Annotated[
+        str,
+        typer.Option(
+            "--destination",
+            help="Destination cache directory to move to.",
+        ),
+    ],
+    yes: Annotated[
+        bool,
+        typer.Option(
+            "-y",
+            "--yes",
+            help="Skip confirmation prompt.",
+        ),
+    ] = False,
+    format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
+) -> None:
+    """Move cache directory from one path to another.
+
+    This command copies the cache blobs to a new location. The snapshots/ and refs/ folders are NOT copied
+    as symlinks will be resolved at runtime when the user calls hf_hub_download.
+
+    After moving the cache, make sure to update your $HF_HOME environment variable.
+
+    Examples:
+      - Move cache: `hf cache move --source /path/to/old/cache --destination /path/to/new/cache`
+    """
+
+    source_path = Path(source).resolve()
+    dest_path = Path(destination).resolve()
+
+    if not source_path.exists():
+        raise CLIError(f"Source cache directory does not exist: {source_path}")
+
+    if not source_path.is_dir():
+        raise CLIError(f"Source path is not a directory: {source_path}")
+
+    if dest_path.exists():
+        raise CLIError(f"Destination already exists: {dest_path}. Please choose a non-existent path.")
+
+    blobs_src = source_path / "blobs"
+    if not blobs_src.exists():
+        raise CLIError(
+            f"Source directory does not appear to be a valid Hugging Face cache (missing 'blobs' folder): {source_path}"
+        )
+
+    size_src = sum(f.stat().st_size for f in source_path.rglob("*") if f.is_file())
+    size_src_str = _format_size(size_src)
+
+    out.text(f"About to copy cache from:\n  - {source_path}\nTo:\n  - {dest_path}\nSize: {size_src_str}.")
+    out.warning(
+        "Note: Only the 'blobs' folder will be copied. The 'snapshots/' and 'refs/' folders "
+        "will be recreated automatically when you download files."
+    )
+
+    out.confirm("Proceed with copy?", yes=yes)
+
+    dest_path.mkdir(parents=True)
+    shutil.copytree(blobs_src, dest_path / "blobs", copy_function=shutil.copy2)
+
+    out.result(
+        f"Cache copied from {source_path} to {dest_path}.",
+        source=str(source_path),
+        destination=str(dest_path),
+    )
+
+    if dest_path.parent == Path(HF_HOME):
+        out.hint(f"Set HF_HOME='{dest_path}' in your environment to use the new cache location.")
+    elif dest_path.parent.parent == Path(HF_HOME):
+        out.hint(f"Set HF_HUB_CACHE='{dest_path}' in your environment to use the new cache location.")
+    else:
+        out.hint("Set either HF_HOME or HF_HUB_CACHE in your environment to point to the new location.")

--- a/src/huggingface_hub/cli/cache.py
+++ b/src/huggingface_hub/cli/cache.py
@@ -838,9 +838,10 @@ def move(
         destination=str(dest_path),
     )
 
-    if dest_path.parent == Path(HF_HOME):
+    hf_home = Path(HF_HOME).resolve()
+    if dest_path.parent == hf_home:
         out.hint(f"Set HF_HUB_CACHE='{dest_path}' in your environment to use the new cache location.")
-    elif dest_path.parent.parent == Path(HF_HOME):
-        out.hint(f"Set HF_HUB_CACHE='{dest_path}' in your environment to use the new cache location.")
+    elif dest_path.parent.parent == hf_home:
+        out.hint(f"Set HF_HOME='{dest_path.parent}' in your environment to use the new cache location.")
     else:
         out.hint("Set either HF_HOME or HF_HUB_CACHE in your environment to point to the new location.")

--- a/src/huggingface_hub/cli/cache.py
+++ b/src/huggingface_hub/cli/cache.py
@@ -818,7 +818,7 @@ def move(
             f"Source directory does not appear to be a valid Hugging Face cache (missing 'blobs' folder): {source_path}"
         )
 
-    size_src = sum(f.stat().st_size for f in source_path.rglob("*") if f.is_file())
+    size_src = sum(f.stat().st_size for f in blobs_src.rglob("*") if f.is_file())
     size_src_str = _format_size(size_src)
 
     out.text(f"About to copy cache from:\n  - {source_path}\nTo:\n  - {dest_path}\nSize: {size_src_str}.")
@@ -839,7 +839,7 @@ def move(
     )
 
     if dest_path.parent == Path(HF_HOME):
-        out.hint(f"Set HF_HOME='{dest_path}' in your environment to use the new cache location.")
+        out.hint(f"Set HF_HUB_CACHE='{dest_path}' in your environment to use the new cache location.")
     elif dest_path.parent.parent == Path(HF_HOME):
         out.hint(f"Set HF_HUB_CACHE='{dest_path}' in your environment to use the new cache location.")
     else:

--- a/src/huggingface_hub/cli/cache.py
+++ b/src/huggingface_hub/cli/cache.py
@@ -791,8 +791,9 @@ def move(
 ) -> None:
     """Move cache directory from one path to another.
 
-    This command copies the cache blobs to a new location. The snapshots/ and refs/ folders are NOT copied
-    as symlinks will be resolved at runtime when the user calls hf_hub_download.
+    This command copies the cache blobs to a new location and then deletes the source.
+    The snapshots/ and refs/ folders are NOT copied as symlinks will be resolved
+    at runtime when the user calls hf_hub_download.
 
     After moving the cache, make sure to update your $HF_HOME environment variable.
 
@@ -821,19 +822,23 @@ def move(
     size_src = sum(f.stat().st_size for f in blobs_src.rglob("*") if f.is_file())
     size_src_str = _format_size(size_src)
 
-    out.text(f"About to copy cache from:\n  - {source_path}\nTo:\n  - {dest_path}\nSize: {size_src_str}.")
+    out.text(f"About to move cache from:\n  - {source_path}\nTo:\n  - {dest_path}\nSize: {size_src_str}.")
     out.warning(
         "Note: Only the 'blobs' folder will be copied. The 'snapshots/' and 'refs/' folders "
-        "will be recreated automatically when you download files."
+        "will be recreated automatically when you download files.\n"
+        "The source blobs will be DELETED after a successful copy."
     )
 
-    out.confirm("Proceed with copy?", yes=yes)
+    out.confirm("Proceed with move?", yes=yes)
 
     dest_path.mkdir(parents=True)
     shutil.copytree(blobs_src, dest_path / "blobs", copy_function=shutil.copy2)
 
+    out.text("Deleting source blobs...")
+    shutil.rmtree(blobs_src)
+
     out.result(
-        f"Cache copied from {source_path} to {dest_path}.",
+        f"Cache moved from {source_path} to {dest_path}.",
         source=str(source_path),
         destination=str(dest_path),
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -369,6 +369,45 @@ class TestCacheCommand:
         assert "missing locally" in result.output
         assert "Verification failed" in result.output
 
+    def test_move_cache(self, runner: CliRunner) -> None:
+        with SoftTemporaryDirectory() as tmp_dir:
+            source = Path(tmp_dir) / "source"
+            dest = Path(tmp_dir) / "dest"
+            blobs = source / "blobs"
+            blobs.mkdir(parents=True)
+            (blobs / "file.bin").write_text("test")
+
+            result = runner.invoke(
+                app, ["cache", "move", "--source", str(source), "--destination", str(dest), "--yes"]
+            )
+
+            assert result.exit_code == 0
+            assert "copied" in result.output.lower()
+            assert (dest / "blobs" / "file.bin").exists()
+
+    def test_move_cache_nonexistent_source(self, runner: CliRunner) -> None:
+        with SoftTemporaryDirectory() as tmp_dir:
+            source = Path(tmp_dir) / "nonexistent"
+            dest = Path(tmp_dir) / "dest"
+
+            result = runner.invoke(app, ["cache", "move", "--source", str(source), "--destination", str(dest)])
+
+            assert result.exit_code != 0
+            assert result.exception is not None
+            assert "does not exist" in str(result.exception).lower()
+
+    def test_move_cache_invalid_source(self, runner: CliRunner) -> None:
+        with SoftTemporaryDirectory() as tmp_dir:
+            source = Path(tmp_dir) / "invalid"
+            dest = Path(tmp_dir) / "dest"
+            source.mkdir()
+
+            result = runner.invoke(app, ["cache", "move", "--source", str(source), "--destination", str(dest)])
+
+            assert result.exit_code != 0
+            assert result.exception is not None
+            assert "does not appear to be a valid" in str(result.exception).lower()
+
 
 class TestUploadCommand:
     def test_upload_basic(self, runner: CliRunner) -> None:


### PR DESCRIPTION
## Summary
- Add new CLI command `hf cache move` to move the cache folder from one path to another
- Only the `blobs/` folder is copied (snapshots/refs are recreated automatically when downloading files)
- Includes warning about updating $HF_HOME environment variable
- Context-aware hints about which env var to set based on destination path

## Examples
```
hf cache move --source /path/to/old/cache --destination /path/to/new/cache -y
```

## Tests
- Add 3 tests for the new command: basic move, error handling for non-existent source, error handling for invalid cache directory

Fixes #1757 and #2117 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Performs filesystem copy/delete operations on user caches; mistakes or interruptions could lead to data loss or partial moves despite guardrails and confirmation prompts.
> 
> **Overview**
> Adds a new `hf cache move` CLI subcommand to *relocate the local Hugging Face cache* by copying only the `blobs/` directory to a new destination and deleting the original blobs afterward.
> 
> The command validates source/destination paths, prints the total size and a destructive-action warning, prompts for confirmation (or `--yes`), and emits context-aware hints for setting `HF_HOME` vs `HF_HUB_CACHE` based on where the destination lives. Tests cover the happy path plus error cases for missing and invalid sources.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70bec3288c280e1cc6d87b00c4d4d262d422978c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->