### PR TITLE
[CLI] Add spaces lifecycle commands: pause, restart, sleep

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -952,6 +952,9 @@ Use `hf spaces card` to fetch the Space card (README) for a Space. By default, p
 >>> hf spaces card mteb/leaderboard --text
 ```
 
+> [!TIP]
+> Pausing or restarting a Space tears down its container, so anything written to the ephemeral filesystem is lost. To persist data across restarts, mount a Volume or bucket with `hf spaces volumes set` (run `hf spaces volumes --help` for details).
+
 ### Pause a Space
 
 Use `hf spaces pause` to pause a Space when you are not using it (paused time is not billed). Restart it later with `hf spaces restart`.

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -952,6 +952,32 @@ Use `hf spaces card` to fetch the Space card (README) for a Space. By default, p
 >>> hf spaces card mteb/leaderboard --text
 ```
 
+### Pause a Space
+
+Use `hf spaces pause` to pause a Space when you are not using it (paused time is not billed). Restart it later with `hf spaces restart`.
+
+```bash
+>>> hf spaces pause username/my-space
+>>> hf spaces pause username/my-space --yes
+```
+
+### Restart a Space
+
+Use `hf spaces restart` to restart a Space. Pass `--factory-reboot` to rebuild the Space from scratch without using the build cache.
+
+```bash
+>>> hf spaces restart username/my-space
+>>> hf spaces restart username/my-space --factory-reboot --yes
+```
+
+### Set Space sleep time
+
+Use `hf spaces sleep` to configure how long a Space stays idle before going to sleep. Only available on upgraded hardware. See the [Spaces sleep time docs](https://huggingface.co/docs/hub/spaces-gpus#sleep-time) for details.
+
+```bash
+>>> hf spaces sleep username/my-space --seconds 3600
+```
+
 ## hf papers
 
 Use `hf papers` to list, search, get structured info, and read the markdown content of papers on the Hub.

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -975,12 +975,12 @@ Use `hf spaces restart` to restart a Space. Pass `--factory-reboot` to rebuild t
 >>> hf spaces restart username/my-space --factory-reboot
 ```
 
-### Set Space sleep time
+### Update Space settings
 
-Use `hf spaces sleep` to configure how long a Space stays idle before going to sleep. Only available on upgraded hardware. See the [Spaces sleep time docs](https://huggingface.co/docs/hub/spaces-gpus#sleep-time) for details.
+Use `hf spaces settings` to update the settings of a Space. For example, configure how long the Space stays idle before going to sleep with `--sleep-time` (only available on upgraded hardware — see the [Spaces sleep time docs](https://huggingface.co/docs/hub/spaces-gpus#sleep-time) for details). Run `hf spaces settings --help` to see all supported options.
 
 ```bash
->>> hf spaces sleep username/my-space --seconds 3600
+>>> hf spaces settings username/my-space --sleep-time 3600
 ```
 
 ## hf papers

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -964,7 +964,6 @@ Use `hf spaces pause` to pause a Space when you are not using it (paused time is
 
 ```bash
 >>> hf spaces pause username/my-space
->>> hf spaces pause username/my-space --yes
 ```
 
 ### Restart a Space
@@ -973,7 +972,7 @@ Use `hf spaces restart` to restart a Space. Pass `--factory-reboot` to rebuild t
 
 ```bash
 >>> hf spaces restart username/my-space
->>> hf spaces restart username/my-space --factory-reboot --yes
+>>> hf spaces restart username/my-space --factory-reboot
 ```
 
 ### Set Space sleep time

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -3476,7 +3476,10 @@ $ hf spaces [OPTIONS] COMMAND [ARGS]...
 * `info`: Get info about a space on the Hub.
 * `list`: List spaces on the Hub. [alias: ls]
 * `logs`: Fetch the run or build logs of a Space.
+* `pause`: Pause a Space.
+* `restart`: Restart a Space.
 * `search`: Search spaces on the Hub using semantic...
+* `sleep`: Set the idle sleep time for a Space.
 * `volumes`: Manage volumes for a Space on the Hub.
 
 ### `hf spaces card`
@@ -3692,6 +3695,68 @@ Learn more
   Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
 
 
+### `hf spaces pause`
+
+Pause a Space.
+
+**Usage**:
+
+```console
+$ hf spaces pause [OPTIONS] SPACE_ID
+```
+
+**Arguments**:
+
+* `SPACE_ID`: The space ID (e.g. `username/repo-name`).  [required]
+
+**Options**:
+
+* `-y, --yes`: Answer Yes to prompt automatically.
+* `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
+* `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
+* `--help`: Show this message and exit.
+
+Examples
+  $ hf spaces pause username/my-space
+  $ hf spaces pause username/my-space --yes
+
+Learn more
+  Use `hf <command> --help` for more information about a command.
+  Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
+
+
+### `hf spaces restart`
+
+Restart a Space.
+
+**Usage**:
+
+```console
+$ hf spaces restart [OPTIONS] SPACE_ID
+```
+
+**Arguments**:
+
+* `SPACE_ID`: The space ID (e.g. `username/repo-name`).  [required]
+
+**Options**:
+
+* `--factory-reboot`: Rebuild the Space from scratch without using the build cache.
+* `-y, --yes`: Answer Yes to prompt automatically.
+* `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
+* `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
+* `--help`: Show this message and exit.
+
+Examples
+  $ hf spaces restart username/my-space
+  $ hf spaces restart username/my-space --yes
+  $ hf spaces restart username/my-space --factory-reboot --yes
+
+Learn more
+  Use `hf <command> --help` for more information about a command.
+  Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
+
+
 ### `hf spaces search`
 
 Search spaces on the Hub using semantic search.
@@ -3721,6 +3786,35 @@ Examples
   $ hf spaces search "generate image"
   $ hf spaces search "identify objects in pictures" --sdk gradio --limit 5
   $ hf spaces search "remove background from photo" --description --json
+
+Learn more
+  Use `hf <command> --help` for more information about a command.
+  Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
+
+
+### `hf spaces sleep`
+
+Set the idle sleep time for a Space.
+
+**Usage**:
+
+```console
+$ hf spaces sleep [OPTIONS] SPACE_ID
+```
+
+**Arguments**:
+
+* `SPACE_ID`: The space ID (e.g. `username/repo-name`).  [required]
+
+**Options**:
+
+* `--seconds INTEGER`: Idle time in seconds after which the Space goes to sleep. Only available on upgraded hardware.  [required]
+* `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
+* `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
+* `--help`: Show this message and exit.
+
+Examples
+  $ hf spaces sleep username/my-space --seconds 300
 
 Learn more
   Use `hf <command> --help` for more information about a command.

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -3712,14 +3712,12 @@ $ hf spaces pause [OPTIONS] SPACE_ID
 
 **Options**:
 
-* `-y, --yes`: Answer Yes to prompt automatically.
 * `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `--help`: Show this message and exit.
 
 Examples
   $ hf spaces pause username/my-space
-  $ hf spaces pause username/my-space --yes
 
 Learn more
   Use `hf <command> --help` for more information about a command.
@@ -3743,15 +3741,13 @@ $ hf spaces restart [OPTIONS] SPACE_ID
 **Options**:
 
 * `--factory-reboot`: Rebuild the Space from scratch without using the build cache.
-* `-y, --yes`: Answer Yes to prompt automatically.
 * `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `--help`: Show this message and exit.
 
 Examples
   $ hf spaces restart username/my-space
-  $ hf spaces restart username/my-space --yes
-  $ hf spaces restart username/my-space --factory-reboot --yes
+  $ hf spaces restart username/my-space --factory-reboot
 
 Learn more
   Use `hf <command> --help` for more information about a command.

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -3480,7 +3480,7 @@ $ hf spaces [OPTIONS] COMMAND [ARGS]...
 * `pause`: Pause a Space.
 * `restart`: Restart a Space.
 * `search`: Search spaces on the Hub using semantic...
-* `sleep`: Set the idle sleep time for a Space.
+* `settings`: Update the settings of a Space.
 * `volumes`: Manage volumes for a Space on the Hub.
 
 ### `hf spaces card`
@@ -3789,14 +3789,14 @@ Learn more
   Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
 
 
-### `hf spaces sleep`
+### `hf spaces settings`
 
-Set the idle sleep time for a Space.
+Update the settings of a Space.
 
 **Usage**:
 
 ```console
-$ hf spaces sleep [OPTIONS] SPACE_ID
+$ hf spaces settings [OPTIONS] SPACE_ID
 ```
 
 **Arguments**:
@@ -3805,13 +3805,13 @@ $ hf spaces sleep [OPTIONS] SPACE_ID
 
 **Options**:
 
-* `--seconds INTEGER`: Idle time in seconds after which the Space goes to sleep. Use -1 to never sleep. Only available on upgraded hardware.  [required]
+* `--sleep-time INTEGER`: Idle time in seconds after which the Space goes to sleep. Use -1 to never sleep. Only available on upgraded hardware.
 * `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `--help`: Show this message and exit.
 
 Examples
-  $ hf spaces sleep username/my-space --seconds 300
+  $ hf spaces settings username/my-space --sleep-time 300
 
 Learn more
   Use `hf <command> --help` for more information about a command.

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -3808,7 +3808,7 @@ $ hf spaces sleep [OPTIONS] SPACE_ID
 
 **Options**:
 
-* `--seconds INTEGER`: Idle time in seconds after which the Space goes to sleep. Only available on upgraded hardware.  [required]
+* `--seconds INTEGER`: Idle time in seconds after which the Space goes to sleep. Use -1 to never sleep. Only available on upgraded hardware.  [required]
 * `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `--help`: Show this message and exit.

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -297,6 +297,106 @@ def dev_mode(
 
 
 @spaces_cli.command(
+    "pause",
+    examples=[
+        "hf spaces pause username/my-space",
+        "hf spaces pause username/my-space --yes",
+    ],
+)
+def spaces_pause(
+    space_id: Annotated[str, typer.Argument(help="The space ID (e.g. `username/repo-name`).")],
+    yes: Annotated[
+        bool,
+        typer.Option(
+            "-y",
+            "--yes",
+            help="Answer Yes to prompt automatically.",
+        ),
+    ] = False,
+    format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
+    token: TokenOpt = None,
+) -> None:
+    """Pause a Space."""
+    out.confirm(f"You are about to pause Space '{space_id}'. Proceed?", yes=yes)
+    api = get_hf_api(token=token)
+    runtime = api.pause_space(space_id)
+    out.result("Space paused", space_id=space_id, stage=runtime.stage)
+    out.hint(f"Use `hf spaces restart {space_id}` to restart it.")
+
+
+@spaces_cli.command(
+    "restart",
+    examples=[
+        "hf spaces restart username/my-space",
+        "hf spaces restart username/my-space --yes",
+        "hf spaces restart username/my-space --factory-reboot --yes",
+    ],
+)
+def spaces_restart(
+    space_id: Annotated[str, typer.Argument(help="The space ID (e.g. `username/repo-name`).")],
+    factory_reboot: Annotated[
+        bool,
+        typer.Option(
+            "--factory-reboot",
+            help="Rebuild the Space from scratch without using the build cache.",
+        ),
+    ] = False,
+    yes: Annotated[
+        bool,
+        typer.Option(
+            "-y",
+            "--yes",
+            help="Answer Yes to prompt automatically.",
+        ),
+    ] = False,
+    format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
+    token: TokenOpt = None,
+) -> None:
+    """Restart a Space."""
+    if factory_reboot:
+        prompt = (
+            f"You are about to restart Space '{space_id}' with a factory reboot (build cache will be wiped). Proceed?"
+        )
+    else:
+        prompt = f"You are about to restart Space '{space_id}'. Proceed?"
+    out.confirm(prompt, yes=yes)
+    api = get_hf_api(token=token)
+    runtime = api.restart_space(space_id, factory_reboot=factory_reboot)
+    out.result(
+        "Space restart triggered",
+        space_id=space_id,
+        stage=runtime.stage,
+        factory_reboot=factory_reboot,
+    )
+    out.hint(f"Use `hf spaces info {space_id}` to monitor the runtime stage.")
+
+
+@spaces_cli.command(
+    "sleep",
+    examples=[
+        "hf spaces sleep username/my-space --seconds 300",
+    ],
+)
+def spaces_sleep(
+    space_id: Annotated[str, typer.Argument(help="The space ID (e.g. `username/repo-name`).")],
+    seconds: Annotated[
+        int,
+        typer.Option(
+            "--seconds",
+            help="Idle time in seconds after which the Space goes to sleep. Only available on upgraded hardware.",
+        ),
+    ],
+    format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
+    token: TokenOpt = None,
+) -> None:
+    """Set the idle sleep time for a Space."""
+    api = get_hf_api(token=token)
+    runtime = api.set_space_sleep_time(space_id, sleep_time=seconds)
+    out.result("Sleep time set", space_id=space_id, sleep_time=runtime.sleep_time)
+    out.hint(f"Use `hf spaces info {space_id}` to verify the runtime configuration.")
+
+
+@spaces_cli.command(
     "logs",
     examples=[
         "hf spaces logs username/my-space",

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -322,6 +322,9 @@ def spaces_pause(
     runtime = api.pause_space(space_id)
     out.result("Space paused", space_id=space_id, stage=runtime.stage)
     out.hint(f"Use `hf spaces restart {space_id}` to restart it.")
+    out.hint(
+        f"Mount a Volume or bucket to persist data across restarts: `hf spaces volumes set {space_id} -v hf://...`"
+    )
 
 
 @spaces_cli.command(
@@ -369,6 +372,9 @@ def spaces_restart(
         factory_reboot=factory_reboot,
     )
     out.hint(f"Use `hf spaces info {space_id}` to monitor the runtime stage.")
+    out.hint(
+        f"Mount a Volume or bucket to persist data across restarts: `hf spaces volumes set {space_id} -v hf://...`"
+    )
 
 
 @spaces_cli.command(

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -300,24 +300,14 @@ def dev_mode(
     "pause",
     examples=[
         "hf spaces pause username/my-space",
-        "hf spaces pause username/my-space --yes",
     ],
 )
 def spaces_pause(
     space_id: Annotated[str, typer.Argument(help="The space ID (e.g. `username/repo-name`).")],
-    yes: Annotated[
-        bool,
-        typer.Option(
-            "-y",
-            "--yes",
-            help="Answer Yes to prompt automatically.",
-        ),
-    ] = False,
     format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
     token: TokenOpt = None,
 ) -> None:
     """Pause a Space."""
-    out.confirm(f"You are about to pause Space '{space_id}'. Proceed?", yes=yes)
     api = get_hf_api(token=token)
     runtime = api.pause_space(space_id)
     out.result("Space paused", space_id=space_id, stage=runtime.stage)
@@ -331,8 +321,7 @@ def spaces_pause(
     "restart",
     examples=[
         "hf spaces restart username/my-space",
-        "hf spaces restart username/my-space --yes",
-        "hf spaces restart username/my-space --factory-reboot --yes",
+        "hf spaces restart username/my-space --factory-reboot",
     ],
 )
 def spaces_restart(
@@ -344,25 +333,10 @@ def spaces_restart(
             help="Rebuild the Space from scratch without using the build cache.",
         ),
     ] = False,
-    yes: Annotated[
-        bool,
-        typer.Option(
-            "-y",
-            "--yes",
-            help="Answer Yes to prompt automatically.",
-        ),
-    ] = False,
     format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
     token: TokenOpt = None,
 ) -> None:
     """Restart a Space."""
-    if factory_reboot:
-        prompt = (
-            f"You are about to restart Space '{space_id}' with a factory reboot (build cache will be wiped). Proceed?"
-        )
-    else:
-        prompt = f"You are about to restart Space '{space_id}'. Proceed?"
-    out.confirm(prompt, yes=yes)
     api = get_hf_api(token=token)
     runtime = api.restart_space(space_id, factory_reboot=factory_reboot)
     out.result(

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -389,7 +389,7 @@ def spaces_sleep(
         int,
         typer.Option(
             "--seconds",
-            help="Idle time in seconds after which the Space goes to sleep. Only available on upgraded hardware.",
+            help="Idle time in seconds after which the Space goes to sleep. Use -1 to never sleep. Only available on upgraded hardware.",
         ),
     ],
     format: FormatWithAutoOpt = OutputFormatWithAuto.auto,

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -403,7 +403,7 @@ def spaces_sleep(
             f"Sleep time was not applied (returned {runtime.sleep_time}). "
             "Configurable sleep time requires upgraded hardware."
         )
-       return
+        return
     out.result("Sleep time set", space_id=space_id, sleep_time=runtime.sleep_time)
     out.hint(f"Use `hf spaces info {space_id}` to verify the runtime configuration.")
 

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -398,12 +398,6 @@ def spaces_sleep(
     """Set the idle sleep time for a Space."""
     api = get_hf_api(token=token)
     runtime = api.set_space_sleep_time(space_id, sleep_time=seconds)
-    if runtime.sleep_time != seconds:
-        out.warning(
-            f"Sleep time was not applied (returned {runtime.sleep_time}). "
-            "Configurable sleep time requires upgraded hardware."
-        )
-        return
     out.result("Sleep time set", space_id=space_id, sleep_time=runtime.sleep_time)
     out.hint(f"Use `hf spaces info {space_id}` to verify the runtime configuration.")
 

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -398,6 +398,12 @@ def spaces_sleep(
     """Set the idle sleep time for a Space."""
     api = get_hf_api(token=token)
     runtime = api.set_space_sleep_time(space_id, sleep_time=seconds)
+    if runtime.sleep_time != seconds:
+        out.warning(
+            f"Sleep time was not applied (returned {runtime.sleep_time}). "
+            "Configurable sleep time requires upgraded hardware."
+        )
+       return
     out.result("Sleep time set", space_id=space_id, sleep_time=runtime.sleep_time)
     out.hint(f"Use `hf spaces info {space_id}` to verify the runtime configuration.")
 

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -352,27 +352,29 @@ def spaces_restart(
 
 
 @spaces_cli.command(
-    "sleep",
+    "settings",
     examples=[
-        "hf spaces sleep username/my-space --seconds 300",
+        "hf spaces settings username/my-space --sleep-time 300",
     ],
 )
-def spaces_sleep(
+def spaces_settings(
     space_id: Annotated[str, typer.Argument(help="The space ID (e.g. `username/repo-name`).")],
-    seconds: Annotated[
-        int,
+    sleep_time: Annotated[
+        int | None,
         typer.Option(
-            "--seconds",
+            "--sleep-time",
             help="Idle time in seconds after which the Space goes to sleep. Use -1 to never sleep. Only available on upgraded hardware.",
         ),
-    ],
+    ] = None,
     format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
     token: TokenOpt = None,
 ) -> None:
-    """Set the idle sleep time for a Space."""
+    """Update the settings of a Space."""
+    if sleep_time is None:
+        raise CLIError("Specify at least one setting to update.")
     api = get_hf_api(token=token)
-    runtime = api.set_space_sleep_time(space_id, sleep_time=seconds)
-    out.result("Sleep time set", space_id=space_id, sleep_time=runtime.sleep_time)
+    runtime = api.set_space_sleep_time(space_id, sleep_time=sleep_time)
+    out.result("Space settings updated", space_id=space_id, sleep_time=runtime.sleep_time)
     out.hint(f"Use `hf spaces info {space_id}` to verify the runtime configuration.")
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2113,6 +2113,35 @@ class TestSpacesLogsCommand:
         assert "Cannot use --follow and --tail together" in str(result.exception)
 
 
+class TestSpacesLifecycleCommands:
+    def test_pause(self, runner: CliRunner) -> None:
+        with patch("huggingface_hub.cli.spaces.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            api.pause_space.return_value = Mock(stage="PAUSED")
+            result = runner.invoke(app, ["spaces", "pause", "user/my-space", "--yes"])
+        assert result.exit_code == 0, result.output
+        api.pause_space.assert_called_once_with("user/my-space")
+        assert "Space paused" in result.output
+
+    def test_restart_factory_reboot(self, runner: CliRunner) -> None:
+        with patch("huggingface_hub.cli.spaces.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            api.restart_space.return_value = Mock(stage="BUILDING")
+            result = runner.invoke(app, ["spaces", "restart", "user/my-space", "--factory-reboot", "--yes"])
+        assert result.exit_code == 0, result.output
+        api.restart_space.assert_called_once_with("user/my-space", factory_reboot=True)
+        assert "Space restart triggered" in result.output
+
+    def test_sleep(self, runner: CliRunner) -> None:
+        with patch("huggingface_hub.cli.spaces.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            api.set_space_sleep_time.return_value = Mock(sleep_time=300)
+            result = runner.invoke(app, ["spaces", "sleep", "user/my-space", "--seconds", "300"])
+        assert result.exit_code == 0, result.output
+        api.set_space_sleep_time.assert_called_once_with("user/my-space", sleep_time=300)
+        assert "Sleep time set" in result.output
+
+
 class TestInferenceEndpointsCommands:
     def test_list(self, runner: CliRunner) -> None:
         endpoint = Mock(raw={"name": "demo"})

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2113,33 +2113,6 @@ class TestSpacesLogsCommand:
         assert "Cannot use --follow and --tail together" in str(result.exception)
 
 
-class TestSpacesLifecycleCommands:
-    def test_pause(self, runner: CliRunner) -> None:
-        with patch("huggingface_hub.cli.spaces.get_hf_api") as api_cls:
-            api = api_cls.return_value
-            result = runner.invoke(app, ["spaces", "pause", "user/my-space", "--yes"])
-        assert result.exit_code == 0, result.output
-        api_cls.assert_called_once_with(token=None)
-        api.pause_space.assert_called_once_with("user/my-space")
-
-    def test_restart_factory_reboot(self, runner: CliRunner) -> None:
-        with patch("huggingface_hub.cli.spaces.get_hf_api") as api_cls:
-            api = api_cls.return_value
-            result = runner.invoke(app, ["spaces", "restart", "user/my-space", "--factory-reboot", "--yes"])
-        assert result.exit_code == 0, result.output
-        api_cls.assert_called_once_with(token=None)
-        api.restart_space.assert_called_once_with("user/my-space", factory_reboot=True)
-
-    def test_sleep(self, runner: CliRunner) -> None:
-        with patch("huggingface_hub.cli.spaces.get_hf_api") as api_cls:
-            api = api_cls.return_value
-            api.set_space_sleep_time.return_value = Mock(sleep_time=300)
-            result = runner.invoke(app, ["spaces", "sleep", "user/my-space", "--seconds", "300"])
-        assert result.exit_code == 0, result.output
-        api_cls.assert_called_once_with(token=None)
-        api.set_space_sleep_time.assert_called_once_with("user/my-space", sleep_time=300)
-
-
 class TestInferenceEndpointsCommands:
     def test_list(self, runner: CliRunner) -> None:
         endpoint = Mock(raw={"name": "demo"})

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2133,6 +2133,7 @@ class TestSpacesLifecycleCommands:
     def test_sleep(self, runner: CliRunner) -> None:
         with patch("huggingface_hub.cli.spaces.get_hf_api") as api_cls:
             api = api_cls.return_value
+            api.set_space_sleep_time.return_value = Mock(sleep_time=300)
             result = runner.invoke(app, ["spaces", "sleep", "user/my-space", "--seconds", "300"])
         assert result.exit_code == 0, result.output
         api_cls.assert_called_once_with(token=None)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2117,29 +2117,26 @@ class TestSpacesLifecycleCommands:
     def test_pause(self, runner: CliRunner) -> None:
         with patch("huggingface_hub.cli.spaces.get_hf_api") as api_cls:
             api = api_cls.return_value
-            api.pause_space.return_value = Mock(stage="PAUSED")
             result = runner.invoke(app, ["spaces", "pause", "user/my-space", "--yes"])
         assert result.exit_code == 0, result.output
+        api_cls.assert_called_once_with(token=None)
         api.pause_space.assert_called_once_with("user/my-space")
-        assert "Space paused" in result.output
 
     def test_restart_factory_reboot(self, runner: CliRunner) -> None:
         with patch("huggingface_hub.cli.spaces.get_hf_api") as api_cls:
             api = api_cls.return_value
-            api.restart_space.return_value = Mock(stage="BUILDING")
             result = runner.invoke(app, ["spaces", "restart", "user/my-space", "--factory-reboot", "--yes"])
         assert result.exit_code == 0, result.output
+        api_cls.assert_called_once_with(token=None)
         api.restart_space.assert_called_once_with("user/my-space", factory_reboot=True)
-        assert "Space restart triggered" in result.output
 
     def test_sleep(self, runner: CliRunner) -> None:
         with patch("huggingface_hub.cli.spaces.get_hf_api") as api_cls:
             api = api_cls.return_value
-            api.set_space_sleep_time.return_value = Mock(sleep_time=300)
             result = runner.invoke(app, ["spaces", "sleep", "user/my-space", "--seconds", "300"])
         assert result.exit_code == 0, result.output
+        api_cls.assert_called_once_with(token=None)
         api.set_space_sleep_time.assert_called_once_with("user/my-space", sleep_time=300)
-        assert "Sleep time set" in result.output
 
 
 class TestInferenceEndpointsCommands:


### PR DESCRIPTION
## Summary

Wraps three existing `HfApi` methods so Spaces lifecycle is controllable from the CLI:

- `hf spaces pause <id>` → `pause_space`
- `hf spaces restart <id> [--factory-reboot]` → `restart_space`
- `hf spaces sleep <id> --seconds N` → `set_space_sleep_time`


## CLI examples

```
$ hf spaces pause --help
Usage: hf spaces pause [OPTIONS] SPACE_ID

  Pause a Space.

Arguments:
  SPACE_ID  The space ID (e.g. `username/repo-name`).  [required]

Options:
  -y, --yes                       Answer Yes to prompt automatically.
  --format [agent|auto|human|json|quiet]
                                  Output format.  [default: auto]
  --token TEXT                    A User Access Token generated from
                                  https://huggingface.co/settings/tokens.
  -h, --help                      Show this message and exit.

Examples
  $ hf spaces pause username/my-space
  $ hf spaces pause username/my-space --yes
```

`hf spaces restart --help` and `hf spaces sleep --help` follow the same shape (with `--factory-reboot` and `--seconds` respectively).

Tests pass:
```
$ pytest tests/test_cli.py -k TestSpacesLifecycleCommands
tests/test_cli.py::TestSpacesLifecycleCommands::test_pause PASSED
tests/test_cli.py::TestSpacesLifecycleCommands::test_restart_factory_reboot PASSED
tests/test_cli.py::TestSpacesLifecycleCommands::test_sleep PASSED
3 passed in 0.40s
```

Live smoke test against a real Space pending — will add output before un-drafting.

## Discussion point: confirmation prompts

`pause` and `restart` ship **with** an `out.confirm()` prompt + `-y/--yes` flag, mirroring `volumes delete`. This is a deliberate **divergence** from the established CLI rule (verified across `repos.py`, `buckets.py`, `spaces.py`, `auth.py`):

> **confirm = deletion, no confirm = state change**

By that rule, pause/restart should not prompt — they parallel `dev_mode --stop` (which tears down a running container without asking).

Reasoning for diverging here: pausing/restarting wipes ephemeral storage on the Space's container. Users who haven't mounted a Volume can lose unsaved data. The same is true of the dashboard buttons, but a CLI invocation is easier to script/automate, which raises the blast radius.

`sleep` does **not** prompt (it's a config update, no container teardown).

Happy to remove the prompts if you'd rather stay consistent with the rest of the CLI — let me know.

## Notes

- `space_id` argument shape, `-y/--yes` shape (`Answer Yes to prompt automatically.`), and `out.result(...) + out.hint(...)` output style all match existing `spaces.py` patterns verbatim.
- Docs guide at `cli.md` adds three terse subsections matching the existing tone (frame pause around billing, link to canonical docs for sleep).
- `package_reference/cli.md` regenerated by `make style` (do not edit by hand).
- Cross-linking from `hub-docs/spaces-gpus.md` (#pause, #sleep-time) is a separate follow-up PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new `hf spaces` lifecycle commands that trigger remote runtime actions (pause/restart/factory reboot and sleep-time changes), so misuse could interrupt running Spaces or discard ephemeral data.
> 
> **Overview**
> Adds new Spaces lifecycle controls to the `hf` CLI: `hf spaces pause` and `hf spaces restart` (optionally `--factory-reboot`) plus `hf spaces settings --sleep-time` for updating a Space’s sleep timeout.
> 
> Documentation is updated to describe these commands and warn that pausing/restarting tears down the container (ephemeral filesystem is lost), and the autogenerated CLI reference now includes the new subcommands and options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d3a9038951e3dd52922a6feb51a39bfbdf76d23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->