### PR TITLE
[CLI] Add benchmark dataset filter examples

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -848,6 +848,9 @@ Use `hf datasets` to list datasets on the Hub and get detailed information about
 # Search for datasets
 >>> hf datasets ls --search "code"
 
+# List official benchmark datasets
+>>> hf datasets ls --filter benchmark:official
+
 # Sort by downloads
 >>> hf datasets ls --sort downloads --limit 10
 ```

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -1076,6 +1076,7 @@ Examples
   $ hf datasets ls
   $ hf datasets ls --sort downloads --limit 10
   $ hf datasets ls --search "code"
+  $ hf datasets ls --filter benchmark:official
 
 Learn more
   Use `hf <command> --help` for more information about a command.

--- a/src/huggingface_hub/cli/datasets.py
+++ b/src/huggingface_hub/cli/datasets.py
@@ -73,6 +73,7 @@ datasets_cli = typer_factory(help="Interact with datasets on the Hub.")
         "hf datasets ls",
         "hf datasets ls --sort downloads --limit 10",
         'hf datasets ls --search "code"',
+        "hf datasets ls --filter benchmark:official",
     ],
 )
 def datasets_ls(


### PR DESCRIPTION
_Comment from_ @hanouticelina : i think it's worth having an example to list official benchmarks, mostly for discoverability. a better solution for discoverability would be to expose `list_datasets(benchmark=...)` directly in the CLI. that said, `list_datasets` has several other filters that are not surfaced either (`gated`, `language`, `task_categories`, etc) so adding only `--benchmark` would mean adding the others as well for consistency. 

## Summary

- Add `hf datasets ls --filter benchmark:official` to the `hf datasets ls` CLI examples.
- Document the same example in the CLI guide.
- Regenerate the CLI reference so command help examples stay in sync.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that just adds an additional CLI usage example; no functional behavior or API surface is modified.
> 
> **Overview**
> Adds a new discoverability example for listing official benchmark datasets by documenting `hf datasets ls --filter benchmark:official` in the CLI guide and in the generated CLI reference.
> 
> Updates the `hf datasets ls` command’s Typer `examples` list so the help output and regenerated docs stay in sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 629dce541d6a9762df5d6332ad7508504f0a5d8a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->