### PR TITLE
[CLI] Fix datasets list table rendering

### DIFF
--- a/src/huggingface_hub/cli/_output.py
+++ b/src/huggingface_hub/cli/_output.py
@@ -211,6 +211,10 @@ def _strip_ansi(text: str) -> str:
     return _ANSI_RE.sub("", text)
 
 
+def _single_line(text: str) -> str:
+    return " ".join(text.split())
+
+
 def _to_header(name: str) -> str:
     """Convert a camelCase or PascalCase string to SCREAMING_SNAKE_CASE."""
     s = re.sub(r"([a-z])([A-Z])", r"\1_\2", name)
@@ -227,13 +231,15 @@ def _format_table_value_human(value: Any) -> str:
         return value.strftime("%Y-%m-%d")
     if isinstance(value, str) and re.match(r"^\d{4}-\d{2}-\d{2}T", value):
         return value[:10]
+    if isinstance(value, str):
+        return _single_line(value)
     if isinstance(value, list):
         return ", ".join(_format_table_value_human(v) for v in value)
     elif isinstance(value, dict):
         if "name" in value:  # Likely to be a user or org => print name
-            return str(value["name"])
-        return json.dumps(value)
-    return str(value)
+            return _single_line(str(value["name"]))
+        return _single_line(json.dumps(value))
+    return _single_line(str(value))
 
 
 def _format_table_cell_human(value: Any, max_len: int = _MAX_CELL_LENGTH) -> str:
@@ -248,7 +254,7 @@ def _format_table_cell_agent(value: Any) -> str:
     """Format a cell value for agent TSV output (ISO timestamps, tabs escaped)."""
     if isinstance(value, datetime.datetime):
         return value.isoformat()
-    return str(value).replace("\t", " ")
+    return _single_line(str(value))
 
 
 out = Output()

--- a/src/huggingface_hub/cli/datasets.py
+++ b/src/huggingface_hub/cli/datasets.py
@@ -102,7 +102,10 @@ def datasets_ls(
             expand=expand,  # type: ignore
         )
     ]
-    out.table(results)
+    out.table(
+        results,
+        headers=["id", "created_at", "description", "downloads", "gated", "likes", "private", "trending_score"],
+    )
 
 
 @datasets_cli.command(

--- a/src/huggingface_hub/cli/datasets.py
+++ b/src/huggingface_hub/cli/datasets.py
@@ -102,10 +102,7 @@ def datasets_ls(
             expand=expand,  # type: ignore
         )
     ]
-    out.table(
-        results,
-        headers=["id", "created_at", "description", "downloads", "gated", "likes", "private", "trending_score"],
-    )
+    out.table(results)
 
 
 @datasets_cli.command(


### PR DESCRIPTION
This PR fixes the `hf datasets ls` table rendering when dataset descriptions contain newlines.

Root cause: the table formatter converted cell values to strings and then padded/truncated them without normalizing embedded newlines and indentation. Dataset descriptions often include Markdown with leading newlines, tabs, and spacing, so a single `DESCRIPTION` cell could spill onto multiple terminal lines and shift the remaining columns. 
The fix keeps the compact `hf datasets ls` columns, including `DESCRIPTION`, and normalizes table cells to one line for human/agent table output before truncation. JSON output still returns the original values.

Before:

```console
> hf datasets ls --filter benchmark:official
ID                            CREATED_AT DESCRIPTION                         DOWNLOADS GATED LIKES PRIVATE TRENDING_SCORE
----------------------------- ---------- ----------------------------------- --------- ----- ----- ------- --------------
hf-audio/open-asr-leaderboard 2024-06-21 


                ESB Test Sets: Parquet &... 19665           23            13            
SWE-bench/SWE-bench_Verified  2025-04-29 Dataset Summary
SWE-bench Verifi... 101465          44            13            
openai/gsm8k                  2022-04-12 


                Dataset Card for GSM8K
        ... 824734          1276          12            
llamaindex/ParseBench         2026-04-09 


                ParseBench



Quick lin... 17145           73            12            
cais/hle                      2025-01-23 


[!NOTE]
IMPORTANT: Please hel... 49653     auto  787           8             
Idavidrein/gpqa               2023-11-27 


                Dataset Card for GPQA

... 101058    auto  422           6                     
```

After:

```console
> hf datasets ls --filter benchmark:official
ID                            CREATED_AT DESCRIPTION                         DOWNLOADS GATED LIKES PRIVATE TRENDING_SCORE
----------------------------- ---------- ----------------------------------- --------- ----- ----- ------- --------------
hf-audio/open-asr-leaderboard 2024-06-21 ESB Test Sets: Parquet & Sorted ... 19665           23            13            
SWE-bench/SWE-bench_Verified  2025-04-29 Dataset Summary SWE-bench Verifi... 101465          44            13            
openai/gsm8k                  2022-04-12 Dataset Card for GSM8K Dataset S... 824734          1276          12            
llamaindex/ParseBench         2026-04-09 ParseBench Quick links: [🌐 Websi... 17145           73            12            
cais/hle                      2025-01-23 [!NOTE] IMPORTANT: Please help u... 49653     auto  787           8             
Idavidrein/gpqa               2023-11-27 Dataset Card for GPQA GPQA is a ... 101058    auto  422           6             
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared CLI table formatting for both human and agent outputs, which could subtly change whitespace in existing command outputs and affect scripts that rely on exact formatting.
> 
> **Overview**
> Fixes CLI table rendering when cell values contain newlines/tabs/extra indentation by normalizing all table cell values to a single line before truncation/printing (via new `_single_line()` used across human and agent table formatters).
> 
> Updates `hf datasets ls` to pass an explicit, ordered header list so the table consistently shows the intended compact columns (including `description`) instead of relying on auto-detected keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a394de270d5a8721bba091e55fa619b06e32a1c1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->