### PR TITLE
Centralize hf:// URI parsing

### DIFF
--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -78,6 +78,8 @@
       title: MCP Client
     - local: package_reference/hf_file_system
       title: HfFileSystem
+    - local: package_reference/hf_uris
+      title: HF URIs
     - local: package_reference/utilities
       title: Utilities
     - local: package_reference/community

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -2236,7 +2236,7 @@ $ hf jobs run [OPTIONS] IMAGE COMMAND...
 * `-e, --env TEXT`: Set environment variables. E.g. --env ENV=value
 * `-s, --secrets TEXT`: Set secret environment variables. E.g. --secrets SECRET=value or `--secrets HF_TOKEN` to pass your Hugging Face token.
 * `-l, --label TEXT`: Set labels. E.g. --label KEY=VALUE or --label LABEL
-* `-v, --volume TEXT`: Mount one or more volumes. Format: hf://[TYPE/]SOURCE:/MOUNT_PATH[:ro]. TYPE is one of: models, datasets, spaces, buckets. TYPE defaults to models if omitted. models, datasets and spaces are always mounted read-only. buckets are read+write by default. E.g. -v hf://gpt2:/data or -v hf://datasets/org/ds:/data or -v hf://buckets/org/b:/mnt:ro
+* `-v, --volume TEXT`: Mount one or more volumes. Format: hf://[TYPE/]SOURCE:/MOUNT_PATH[:ro]. TYPE is one of: models, datasets, spaces, buckets. TYPE defaults to models if omitted. models, datasets and spaces are always mounted read-only. buckets are read+write by default. E.g. -v hf://org/m:/data or -v hf://datasets/org/ds:/data or -v hf://buckets/org/b:/mnt:ro
 * `--env-file TEXT`: Read in a file of environment variables.
 * `--secrets-file TEXT`: Read in a file of secret environment variables.
 * `--flavor [cpu-basic|cpu-upgrade|cpu-performance|cpu-xl|sprx8|zero-a10g|t4-small|t4-medium|l4x1|l4x4|l40sx1|l40sx4|l40sx8|a10g-small|a10g-large|a10g-largex2|a10g-largex4|a100-large|a100x4|a100x8|h200|h200x2|h200x4|h200x8|inf2x6]`: Flavor for the hardware, as in HF Spaces. Run 'hf jobs hardware' to list available flavors. Defaults to `cpu-basic`.
@@ -2416,7 +2416,7 @@ $ hf jobs scheduled run [OPTIONS] SCHEDULE IMAGE COMMAND...
 * `-e, --env TEXT`: Set environment variables. E.g. --env ENV=value
 * `-s, --secrets TEXT`: Set secret environment variables. E.g. --secrets SECRET=value or `--secrets HF_TOKEN` to pass your Hugging Face token.
 * `-l, --label TEXT`: Set labels. E.g. --label KEY=VALUE or --label LABEL
-* `-v, --volume TEXT`: Mount one or more volumes. Format: hf://[TYPE/]SOURCE:/MOUNT_PATH[:ro]. TYPE is one of: models, datasets, spaces, buckets. TYPE defaults to models if omitted. models, datasets and spaces are always mounted read-only. buckets are read+write by default. E.g. -v hf://gpt2:/data or -v hf://datasets/org/ds:/data or -v hf://buckets/org/b:/mnt:ro
+* `-v, --volume TEXT`: Mount one or more volumes. Format: hf://[TYPE/]SOURCE:/MOUNT_PATH[:ro]. TYPE is one of: models, datasets, spaces, buckets. TYPE defaults to models if omitted. models, datasets and spaces are always mounted read-only. buckets are read+write by default. E.g. -v hf://org/m:/data or -v hf://datasets/org/ds:/data or -v hf://buckets/org/b:/mnt:ro
 * `--env-file TEXT`: Read in a file of environment variables.
 * `--secrets-file TEXT`: Read in a file of secret environment variables.
 * `--flavor [cpu-basic|cpu-upgrade|cpu-performance|cpu-xl|sprx8|zero-a10g|t4-small|t4-medium|l4x1|l4x4|l40sx1|l40sx4|l40sx8|a10g-small|a10g-large|a10g-largex2|a10g-largex4|a100-large|a100x4|a100x8|h200|h200x2|h200x4|h200x8|inf2x6]`: Flavor for the hardware, as in HF Spaces. Run 'hf jobs hardware' to list available flavors. Defaults to `cpu-basic`.
@@ -2504,7 +2504,7 @@ $ hf jobs scheduled uv run [OPTIONS] SCHEDULE SCRIPT [SCRIPT_ARGS]...
 * `-e, --env TEXT`: Set environment variables. E.g. --env ENV=value
 * `-s, --secrets TEXT`: Set secret environment variables. E.g. --secrets SECRET=value or `--secrets HF_TOKEN` to pass your Hugging Face token.
 * `-l, --label TEXT`: Set labels. E.g. --label KEY=VALUE or --label LABEL
-* `-v, --volume TEXT`: Mount one or more volumes. Format: hf://[TYPE/]SOURCE:/MOUNT_PATH[:ro]. TYPE is one of: models, datasets, spaces, buckets. TYPE defaults to models if omitted. models, datasets and spaces are always mounted read-only. buckets are read+write by default. E.g. -v hf://gpt2:/data or -v hf://datasets/org/ds:/data or -v hf://buckets/org/b:/mnt:ro
+* `-v, --volume TEXT`: Mount one or more volumes. Format: hf://[TYPE/]SOURCE:/MOUNT_PATH[:ro]. TYPE is one of: models, datasets, spaces, buckets. TYPE defaults to models if omitted. models, datasets and spaces are always mounted read-only. buckets are read+write by default. E.g. -v hf://org/m:/data or -v hf://datasets/org/ds:/data or -v hf://buckets/org/b:/mnt:ro
 * `--env-file TEXT`: Read in a file of environment variables.
 * `--secrets-file TEXT`: Read in a file of secret environment variables.
 * `--timeout TEXT`: Max duration: int/float with s (seconds, default), m (minutes), h (hours) or d (days).
@@ -2591,7 +2591,7 @@ $ hf jobs uv run [OPTIONS] SCRIPT [SCRIPT_ARGS]...
 * `-e, --env TEXT`: Set environment variables. E.g. --env ENV=value
 * `-s, --secrets TEXT`: Set secret environment variables. E.g. --secrets SECRET=value or `--secrets HF_TOKEN` to pass your Hugging Face token.
 * `-l, --label TEXT`: Set labels. E.g. --label KEY=VALUE or --label LABEL
-* `-v, --volume TEXT`: Mount one or more volumes. Format: hf://[TYPE/]SOURCE:/MOUNT_PATH[:ro]. TYPE is one of: models, datasets, spaces, buckets. TYPE defaults to models if omitted. models, datasets and spaces are always mounted read-only. buckets are read+write by default. E.g. -v hf://gpt2:/data or -v hf://datasets/org/ds:/data or -v hf://buckets/org/b:/mnt:ro
+* `-v, --volume TEXT`: Mount one or more volumes. Format: hf://[TYPE/]SOURCE:/MOUNT_PATH[:ro]. TYPE is one of: models, datasets, spaces, buckets. TYPE defaults to models if omitted. models, datasets and spaces are always mounted read-only. buckets are read+write by default. E.g. -v hf://org/m:/data or -v hf://datasets/org/ds:/data or -v hf://buckets/org/b:/mnt:ro
 * `--env-file TEXT`: Read in a file of environment variables.
 * `--secrets-file TEXT`: Read in a file of secret environment variables.
 * `--timeout TEXT`: Max duration: int/float with s (seconds, default), m (minutes), h (hours) or d (days).
@@ -3048,7 +3048,7 @@ $ hf repos create [OPTIONS] REPO_ID
 * `--secrets-file TEXT`: Read in a file of secret environment variables.
 * `-e, --env TEXT`: Set environment variables. E.g. --env ENV=value
 * `--env-file TEXT`: Read in a file of environment variables.
-* `-v, --volume TEXT`: Mount one or more volumes. Format: hf://[TYPE/]SOURCE:/MOUNT_PATH[:ro]. TYPE is one of: models, datasets, spaces, buckets. TYPE defaults to models if omitted. models, datasets and spaces are always mounted read-only. buckets are read+write by default. E.g. -v hf://gpt2:/data or -v hf://datasets/org/ds:/data or -v hf://buckets/org/b:/mnt:ro
+* `-v, --volume TEXT`: Mount one or more volumes. Format: hf://[TYPE/]SOURCE:/MOUNT_PATH[:ro]. TYPE is one of: models, datasets, spaces, buckets. TYPE defaults to models if omitted. models, datasets and spaces are always mounted read-only. buckets are read+write by default. E.g. -v hf://org/m:/data or -v hf://datasets/org/ds:/data or -v hf://buckets/org/b:/mnt:ro
 * `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
 * `--help`: Show this message and exit.
 
@@ -3160,7 +3160,7 @@ $ hf repos duplicate [OPTIONS] FROM_ID [TO_ID]
 * `--secrets-file TEXT`: Read in a file of secret environment variables.
 * `-e, --env TEXT`: Set environment variables. E.g. --env ENV=value
 * `--env-file TEXT`: Read in a file of environment variables.
-* `-v, --volume TEXT`: Mount one or more volumes. Format: hf://[TYPE/]SOURCE:/MOUNT_PATH[:ro]. TYPE is one of: models, datasets, spaces, buckets. TYPE defaults to models if omitted. models, datasets and spaces are always mounted read-only. buckets are read+write by default. E.g. -v hf://gpt2:/data or -v hf://datasets/org/ds:/data or -v hf://buckets/org/b:/mnt:ro
+* `-v, --volume TEXT`: Mount one or more volumes. Format: hf://[TYPE/]SOURCE:/MOUNT_PATH[:ro]. TYPE is one of: models, datasets, spaces, buckets. TYPE defaults to models if omitted. models, datasets and spaces are always mounted read-only. buckets are read+write by default. E.g. -v hf://org/m:/data or -v hf://datasets/org/ds:/data or -v hf://buckets/org/b:/mnt:ro
 * `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
 * `--help`: Show this message and exit.
 
@@ -3912,7 +3912,7 @@ $ hf spaces volumes set [OPTIONS] SPACE_ID
 
 **Options**:
 
-* `-v, --volume TEXT`: Mount one or more volumes. Format: hf://[TYPE/]SOURCE:/MOUNT_PATH[:ro]. TYPE is one of: models, datasets, spaces, buckets. TYPE defaults to models if omitted. models, datasets and spaces are always mounted read-only. buckets are read+write by default. E.g. -v hf://gpt2:/data or -v hf://datasets/org/ds:/data or -v hf://buckets/org/b:/mnt:ro
+* `-v, --volume TEXT`: Mount one or more volumes. Format: hf://[TYPE/]SOURCE:/MOUNT_PATH[:ro]. TYPE is one of: models, datasets, spaces, buckets. TYPE defaults to models if omitted. models, datasets and spaces are always mounted read-only. buckets are read+write by default. E.g. -v hf://org/m:/data or -v hf://datasets/org/ds:/data or -v hf://buckets/org/b:/mnt:ro
 * `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `--help`: Show this message and exit.

--- a/docs/source/en/package_reference/hf_uris.md
+++ b/docs/source/en/package_reference/hf_uris.md
@@ -4,8 +4,7 @@ rendered properly in your Markdown viewer.
 
 # HF URIs
 
-A *HF URI* is a URI-like string that identifies a location on the Hugging Face
-Hub. Throughout the library and the CLI, `hf://...` strings are used to point at:
+A *HF URI* is a URI-like string that identifies a location on the Hugging Face Hub. Throughout the library and the CLI, `hf://...` strings are used to point at:
 
 - a model, dataset, space or kernel repository (optionally pinned at a revision);
 - a file or sub-folder inside such a repository;
@@ -13,9 +12,7 @@ Hub. Throughout the library and the CLI, `hf://...` strings are used to point at
 - a [Spaces](../guides/manage-spaces) or [Jobs](../guides/jobs) volume to mount,
   with an optional `:ro` / `:rw` flag.
 
-This page documents the canonical syntax of HF URIs. The same parser is used
-everywhere in the library, so a URI that is valid in one context (e.g.
-[`HfFileSystem`]) is parsed identically in another (e.g. `hf jobs run -v`).
+This page documents the canonical syntax of HF URIs. The same parser is used everywhere in the library, so a URI that is valid in one context (e.g. [`HfFileSystem`]) is parsed identically in another (e.g. `hf jobs run -v`).
 
 ## Canonical syntax
 
@@ -84,8 +81,7 @@ The parser is strict on purpose. The following are **rejected**:
 
 ## Parsing in Python
 
-[`parse_hf_uri`] is the centralized parser. It is a pure string parser (no
-network calls) and returns a frozen [`HfUri`] dataclass.
+[`parse_hf_uri`] is the centralized parser. It is a pure string parser (no network calls) and returns a frozen [`HfUri`] dataclass.
 
 ```python
 >>> from huggingface_hub import parse_hf_uri
@@ -96,8 +92,7 @@ HfUri(type='dataset', id='squad', revision='refs/pr/3', path_in_repo='train.json
 HfUri(type='bucket', id='my-org/my-bucket', revision=None, path_in_repo='sub/dir', mount_path='/mnt', read_only=True)
 ```
 
-[`HfUri`] is round-trippable via [`HfUri.to_uri`], which always emits the
-canonical form (with an explicit type prefix):
+[`HfUri`] is round-trippable via [`HfUri.to_uri`], which always emits the canonical form (with an explicit type prefix):
 
 ```python
 >>> uri = parse_hf_uri("hf://gpt2@v1/config.json")
@@ -105,9 +100,7 @@ canonical form (with an explicit type prefix):
 'hf://models/gpt2@v1/config.json'
 ```
 
-Use the `type` and `id` fields directly. The boolean properties [`is_repo`]
-and [`is_bucket`] disambiguate between repository URIs and bucket URIs when
-needed.
+Use the `type` and `id` fields directly. The boolean properties [`is_repo`] and [`is_bucket`] disambiguate between repository URIs and bucket URIs when needed.
 
 ## Reference
 

--- a/docs/source/en/package_reference/hf_uris.md
+++ b/docs/source/en/package_reference/hf_uris.md
@@ -8,16 +8,16 @@ A *HF URI* is a URI-like string that identifies a location on the Hugging Face H
 
 - a model, dataset, space or kernel repository (optionally pinned at a revision);
 - a file or sub-folder inside such a repository;
-- a [bucket](../guides/buckets) or a sub-folder inside a bucket;
-- a [Spaces](../guides/manage-spaces) or [Jobs](../guides/jobs) volume to mount,
-  with an optional `:ro` / `:rw` flag.
+- a [bucket](../guides/buckets) or a sub-folder inside a bucket.
 
-This page documents the canonical syntax of HF URIs. The same parser is used everywhere in the library, so a URI that is valid in one context (e.g. [`HfFileSystem`]) is parsed identically in another (e.g. `hf jobs run -v`).
+A *HF mount* wraps a HF URI with a local mount path and an optional `:ro` / `:rw` flag, used by [Spaces](../guides/manage-spaces) and [Jobs](../guides/jobs) volumes.
 
-## Canonical syntax
+This page documents the canonical syntax of HF URIs and HF mounts. The same parser is used everywhere in the library, so a URI that is valid in one context (e.g. [`HfFileSystem`]) is parsed identically in another.
+
+## HF URI syntax
 
 ```text
-hf://[<TYPE>/]<ID>[@<REVISION>][/<PATH>][:<MOUNT_PATH>[:ro|:rw]]
+hf://[<TYPE>/]<ID>[@<REVISION>][/<PATH>]
 ```
 
 | Component       | Required | Allowed values                                                      |
@@ -27,8 +27,19 @@ hf://[<TYPE>/]<ID>[@<REVISION>][/<PATH>][:<MOUNT_PATH>[:ro|:rw]]
 | `<ID>`          | yes      | `<namespace>/<name>`                                                |
 | `@<REVISION>`   | no       | Branch, tag, commit SHA, or special ref (`refs/pr/N`, `refs/convert/...`). Repos only. |
 | `/<PATH>`       | no       | Path inside the repo or bucket.                                     |
-| `:<MOUNT_PATH>` | no       | Absolute mount path (volume use case).                              |
-| `:ro` / `:rw`   | no       | Read-only / read-write flag (mount URIs only).                      |
+
+## HF mount syntax
+
+```text
+hf://[<TYPE>/]<ID>[@<REVISION>][/<PATH>]:<MOUNT_PATH>[:ro|:rw]
+```
+
+A mount is a HF URI followed by `:<MOUNT_PATH>` and an optional `:ro` / `:rw` flag.
+
+| Component       | Required | Allowed values                                                      |
+| --------------- | -------- | ------------------------------------------------------------------- |
+| `<MOUNT_PATH>`  | yes      | Absolute mount path (must start with `/`).                          |
+| `:ro` / `:rw`   | no       | Read-only / read-write flag.                                        |
 
 ## What is a HF URI
 
@@ -54,8 +65,11 @@ hf://datasets/my-org/my-dataset@refs/convert/parquet/data.parquet
 # Buckets (always 'namespace/name', no revision)
 hf://buckets/my-org/my-bucket
 hf://buckets/my-org/my-bucket/sub/folder
+```
 
-# Volume URIs (append `:<MOUNT_PATH>[:ro|:rw]`)
+The following are **valid HF mounts** (volume specifications):
+
+```text
 hf://my-org/my-model:/data
 hf://datasets/my-org/my-dataset:/mnt:ro
 hf://datasets/my-org/my-dataset/train:/mnt:rw    # mount a sub-folder
@@ -76,20 +90,18 @@ The parser is strict on purpose. The following are **rejected**:
 | `hf://buckets/org/b@v1`                           | Buckets do not support a revision marker.                               |
 | `hf://org/m@`, `hf://datasets/foo/bar@/x`         | Empty revision after `@`.                                               |
 | `hf://a/b/c@v1`                                   | A repo id must be `namespace/name`, extra segments are paths.           |
-| `hf://org/m:ro`, `hf://org/m:rw`                  | `:ro`/`:rw` requires a mount path (`hf://org/m:/data:ro`).              |
 | `hf://org/m:/`                                    | Mount path must be a non-empty absolute path.                           |
 
 ## Parsing in Python
 
-[`parse_hf_uri`] is the centralized parser. It is a pure string parser (no network calls) and returns a frozen [`HfUri`] dataclass.
+### Parsing URIs
+
+[`parse_hf_uri`] is the centralized URI parser. It is a pure string parser (no network calls) and returns a frozen [`HfUri`] dataclass.
 
 ```python
 >>> from huggingface_hub import parse_hf_uri
 >>> parse_hf_uri("hf://datasets/my-org/my-dataset@refs/pr/3/train.json")
-HfUri(type='dataset', id='my-org/my-dataset', revision='refs/pr/3', path_in_repo='train.json', mount_path=None, read_only=None)
-
->>> parse_hf_uri("hf://buckets/my-org/my-bucket/sub/dir:/mnt:ro")
-HfUri(type='bucket', id='my-org/my-bucket', revision=None, path_in_repo='sub/dir', mount_path='/mnt', read_only=True)
+HfUri(type='dataset', id='my-org/my-dataset', revision='refs/pr/3', path_in_repo='train.json')
 ```
 
 [`HfUri`] is round-trippable via [`HfUri.to_uri`], which always emits the canonical form (with an explicit type prefix):
@@ -102,8 +114,30 @@ HfUri(type='bucket', id='my-org/my-bucket', revision=None, path_in_repo='sub/dir
 
 Use the `type` and `id` fields directly. The boolean properties [`is_repo`] and [`is_bucket`] disambiguate between repository URIs and bucket URIs when needed.
 
+### Parsing mounts
+
+[`parse_hf_mount`] parses a mount specification (a HF URI with a local mount path and optional `:ro`/`:rw` flag) and returns a frozen [`HfMount`] dataclass. It uses [`parse_hf_uri`] under the hood.
+
+```python
+>>> from huggingface_hub import parse_hf_mount
+>>> parse_hf_mount("hf://buckets/my-org/my-bucket/sub/dir:/mnt:ro")
+HfMount(source=HfUri(type='bucket', id='my-org/my-bucket', revision=None, path_in_repo='sub/dir'), mount_path='/mnt', read_only=True)
+```
+
+[`HfMount`] is round-trippable via [`HfMount.to_uri`]:
+
+```python
+>>> mount = parse_hf_mount("hf://my-org/my-model:/data:ro")
+>>> mount.to_uri()
+'hf://models/my-org/my-model:/data:ro'
+```
+
 ## Reference
 
 [[autodoc]] huggingface_hub.utils.HfUri
 
 [[autodoc]] huggingface_hub.utils.parse_hf_uri
+
+[[autodoc]] huggingface_hub.utils.HfMount
+
+[[autodoc]] huggingface_hub.utils.parse_hf_mount

--- a/docs/source/en/package_reference/hf_uris.md
+++ b/docs/source/en/package_reference/hf_uris.md
@@ -38,14 +38,14 @@ hf://[<TYPE>/]<ID>[@<REVISION>][/<PATH>][:<MOUNT_PATH>[:ro|:rw]]
 The following are **all valid HF URIs**:
 
 ```text
-# Models — type prefix is optional
+# Models (type prefix is optional)
 hf://gpt2                                       # canonical model
 hf://my-org/my-model                            # namespaced model
 hf://models/my-org/my-model                     # explicit type prefix
 hf://models/my-org/my-model/config.json         # file inside a model repo
 hf://models/my-org/my-model@v1.0/config.json    # pinned to a revision
 
-# Datasets, Spaces, Kernels — type prefix is required
+# Datasets, Spaces, Kernels (type prefix is required)
 hf://datasets/squad                             # canonical dataset
 hf://datasets/my-org/my-dataset@dev/train.csv
 hf://spaces/my-user/my-space
@@ -55,11 +55,11 @@ hf://kernels/my-org/my-kernel
 hf://datasets/my-org/my-dataset@refs/pr/10/data.csv
 hf://datasets/my-org/my-dataset@refs/convert/parquet/data.parquet
 
-# Buckets — always 'namespace/name', no revision
+# Buckets (always 'namespace/name', no revision)
 hf://buckets/my-org/my-bucket
 hf://buckets/my-org/my-bucket/sub/folder
 
-# Volume URIs — append `:<MOUNT_PATH>[:ro|:rw]`
+# Volume URIs (append `:<MOUNT_PATH>[:ro|:rw]`)
 hf://gpt2:/data
 hf://datasets/my-org/my-dataset:/mnt:ro
 hf://datasets/my-org/my-dataset/train:/mnt:rw    # mount a sub-folder
@@ -73,19 +73,19 @@ The parser is strict on purpose. The following are **rejected**:
 | Invalid URI                               | Reason                                                                  |
 | ----------------------------------------- | ----------------------------------------------------------------------- |
 | `gpt2`, `huggingface.co/gpt2`             | Missing `hf://` protocol prefix.                                        |
-| `hf://dataset/foo/bar`, `hf://model/gpt2` | Singular type forms are forbidden — use the plural (`datasets/`, ...). |
-| `hf://datasets`, `hf://buckets/`          | A type prefix alone is not a valid URI — an `<ID>` is required.        |
+| `hf://dataset/foo/bar`, `hf://model/gpt2` | Singular type forms are forbidden, use the plural (`datasets/`, ...).  |
+| `hf://datasets`, `hf://buckets/`          | A type prefix alone is not a valid URI, an `<ID>` is required.         |
 | `hf://buckets/single-segment`             | Buckets must always be `namespace/name`.                                |
 | `hf://buckets/org/b@v1`                   | Buckets do not support a revision marker.                               |
 | `hf://gpt2@`, `hf://datasets/foo/bar@/x`  | Empty revision after `@`.                                               |
-| `hf://a/b/c@v1`                           | A repo id can be at most `namespace/name` — extra segments are paths.   |
+| `hf://a/b/c@v1`                           | A repo id can be at most `namespace/name`, extra segments are paths.    |
 | `hf://gpt2:ro`, `hf://gpt2:rw`            | `:ro`/`:rw` requires a mount path (`hf://gpt2:/data:ro`).               |
 | `hf://gpt2:/`                             | Mount path must be a non-empty absolute path.                           |
 
 ## Parsing in Python
 
-[`parse_hf_uri`] is the centralized parser. It is a pure string parser — no
-network calls — and returns a frozen [`HfUri`] dataclass.
+[`parse_hf_uri`] is the centralized parser. It is a pure string parser (no
+network calls) and returns a frozen [`HfUri`] dataclass.
 
 ```python
 >>> from huggingface_hub import parse_hf_uri

--- a/docs/source/en/package_reference/hf_uris.md
+++ b/docs/source/en/package_reference/hf_uris.md
@@ -107,12 +107,9 @@ canonical form (with an explicit type prefix):
 True
 ```
 
-For repository URIs the convenience properties [`repo_type`][huggingface_hub.utils.HfUri.repo_type]
-and [`repo_id`][huggingface_hub.utils.HfUri.repo_id] are available; for bucket
-URIs use [`bucket_id`][huggingface_hub.utils.HfUri.bucket_id]. The boolean
-properties [`is_repo`][huggingface_hub.utils.HfUri.is_repo] and
-[`is_bucket`][huggingface_hub.utils.HfUri.is_bucket] disambiguate between the
-two kinds.
+For repository URIs the convenience properties [`repo_type`] and [`repo_id`]
+are available; for bucket URIs use [`bucket_id`]. The boolean properties
+[`is_repo`] and [`is_bucket`] disambiguate between the two kinds.
 
 ## Reference
 

--- a/docs/source/en/package_reference/hf_uris.md
+++ b/docs/source/en/package_reference/hf_uris.md
@@ -107,9 +107,9 @@ canonical form (with an explicit type prefix):
 True
 ```
 
-For repository URIs the convenience properties [`repo_type`] and [`repo_id`]
-are available; for bucket URIs use [`bucket_id`]. The boolean properties
-[`is_repo`] and [`is_bucket`] disambiguate between the two kinds.
+Use the `type` and `id` fields directly. The boolean properties [`is_repo`]
+and [`is_bucket`] disambiguate between repository URIs and bucket URIs when
+needed.
 
 ## Reference
 

--- a/docs/source/en/package_reference/hf_uris.md
+++ b/docs/source/en/package_reference/hf_uris.md
@@ -96,15 +96,13 @@ HfUri(type='dataset', id='squad', revision='refs/pr/3', path_in_repo='train.json
 HfUri(type='bucket', id='my-org/my-bucket', revision=None, path_in_repo='sub/dir', mount_path='/mnt', read_only=True)
 ```
 
-[`HfUri`] is round-trippable via [`HfUri.to_string`], which always emits the
+[`HfUri`] is round-trippable via [`HfUri.to_uri`], which always emits the
 canonical form (with an explicit type prefix):
 
 ```python
 >>> uri = parse_hf_uri("hf://gpt2@v1/config.json")
->>> uri.to_string()
+>>> uri.to_uri()
 'hf://models/gpt2@v1/config.json'
->>> str(uri) == uri.to_string()
-True
 ```
 
 Use the `type` and `id` fields directly. The boolean properties [`is_repo`]

--- a/docs/source/en/package_reference/hf_uris.md
+++ b/docs/source/en/package_reference/hf_uris.md
@@ -1,0 +1,121 @@
+<!--⚠️ Note that this file is in Markdown but contains specific syntax for our doc-builder (similar to MDX) that may not be
+rendered properly in your Markdown viewer.
+-->
+
+# HF URIs
+
+A *HF URI* is a URI-like string that identifies a location on the Hugging Face
+Hub. Throughout the library and the CLI, `hf://...` strings are used to point at:
+
+- a model, dataset, space or kernel repository (optionally pinned at a revision);
+- a file or sub-folder inside such a repository;
+- a [bucket](../guides/buckets) or a sub-folder inside a bucket;
+- a [Spaces](../guides/manage-spaces) or [Jobs](../guides/jobs) volume to mount,
+  with an optional `:ro` / `:rw` flag.
+
+This page documents the canonical syntax of HF URIs. The same parser is used
+everywhere in the library, so a URI that is valid in one context (e.g.
+[`HfFileSystem`]) is parsed identically in another (e.g. `hf jobs run -v`).
+
+## Canonical syntax
+
+```text
+hf://[<TYPE>/]<ID>[@<REVISION>][/<PATH>][:<MOUNT_PATH>[:ro|:rw]]
+```
+
+| Component       | Required | Allowed values                                                      |
+| --------------- | -------- | ------------------------------------------------------------------- |
+| `hf://`         | yes      | Literal protocol prefix.                                            |
+| `<TYPE>/`       | no       | `models/`, `datasets/`, `spaces/`, `kernels/`, `buckets/` (plural). |
+| `<ID>`          | yes      | `<repo_id>` for repos, `<namespace>/<name>` for buckets.            |
+| `@<REVISION>`   | no       | Branch, tag, commit SHA, or special ref (`refs/pr/N`, `refs/convert/...`). Repos only. |
+| `/<PATH>`       | no       | Path inside the repo or bucket.                                     |
+| `:<MOUNT_PATH>` | no       | Absolute mount path (volume use case).                              |
+| `:ro` / `:rw`   | no       | Read-only / read-write flag (mount URIs only).                      |
+
+## What is a HF URI
+
+The following are **all valid HF URIs**:
+
+```text
+# Models — type prefix is optional
+hf://gpt2                                       # canonical model
+hf://my-org/my-model                            # namespaced model
+hf://models/my-org/my-model                     # explicit type prefix
+hf://models/my-org/my-model/config.json         # file inside a model repo
+hf://models/my-org/my-model@v1.0/config.json    # pinned to a revision
+
+# Datasets, Spaces, Kernels — type prefix is required
+hf://datasets/squad                             # canonical dataset
+hf://datasets/my-org/my-dataset@dev/train.csv
+hf://spaces/my-user/my-space
+hf://kernels/my-org/my-kernel
+
+# Special revisions (preserved as-is)
+hf://datasets/my-org/my-dataset@refs/pr/10/data.csv
+hf://datasets/my-org/my-dataset@refs/convert/parquet/data.parquet
+
+# Buckets — always 'namespace/name', no revision
+hf://buckets/my-org/my-bucket
+hf://buckets/my-org/my-bucket/sub/folder
+
+# Volume URIs — append `:<MOUNT_PATH>[:ro|:rw]`
+hf://gpt2:/data
+hf://datasets/my-org/my-dataset:/mnt:ro
+hf://datasets/my-org/my-dataset/train:/mnt:rw    # mount a sub-folder
+hf://buckets/my-org/my-bucket:/storage:rw
+```
+
+## What is **not** a HF URI
+
+The parser is strict on purpose. The following are **rejected**:
+
+| Invalid URI                               | Reason                                                                  |
+| ----------------------------------------- | ----------------------------------------------------------------------- |
+| `gpt2`, `huggingface.co/gpt2`             | Missing `hf://` protocol prefix.                                        |
+| `hf://dataset/foo/bar`, `hf://model/gpt2` | Singular type forms are forbidden — use the plural (`datasets/`, ...). |
+| `hf://datasets`, `hf://buckets/`          | A type prefix alone is not a valid URI — an `<ID>` is required.        |
+| `hf://buckets/single-segment`             | Buckets must always be `namespace/name`.                                |
+| `hf://buckets/org/b@v1`                   | Buckets do not support a revision marker.                               |
+| `hf://gpt2@`, `hf://datasets/foo/bar@/x`  | Empty revision after `@`.                                               |
+| `hf://a/b/c@v1`                           | A repo id can be at most `namespace/name` — extra segments are paths.   |
+| `hf://gpt2:ro`, `hf://gpt2:rw`            | `:ro`/`:rw` requires a mount path (`hf://gpt2:/data:ro`).               |
+| `hf://gpt2:/`                             | Mount path must be a non-empty absolute path.                           |
+
+## Parsing in Python
+
+[`parse_hf_uri`] is the centralized parser. It is a pure string parser — no
+network calls — and returns a frozen [`HfUri`] dataclass.
+
+```python
+>>> from huggingface_hub import parse_hf_uri
+>>> parse_hf_uri("hf://datasets/squad@refs/pr/3/train.json")
+HfUri(type='dataset', id='squad', revision='refs/pr/3', path_in_repo='train.json', mount_path=None, read_only=None)
+
+>>> parse_hf_uri("hf://buckets/my-org/my-bucket/sub/dir:/mnt:ro")
+HfUri(type='bucket', id='my-org/my-bucket', revision=None, path_in_repo='sub/dir', mount_path='/mnt', read_only=True)
+```
+
+[`HfUri`] is round-trippable via [`HfUri.to_string`], which always emits the
+canonical form (with an explicit type prefix):
+
+```python
+>>> uri = parse_hf_uri("hf://gpt2@v1/config.json")
+>>> uri.to_string()
+'hf://models/gpt2@v1/config.json'
+>>> str(uri) == uri.to_string()
+True
+```
+
+For repository URIs the convenience properties [`repo_type`][huggingface_hub.utils.HfUri.repo_type]
+and [`repo_id`][huggingface_hub.utils.HfUri.repo_id] are available; for bucket
+URIs use [`bucket_id`][huggingface_hub.utils.HfUri.bucket_id]. The boolean
+properties [`is_repo`][huggingface_hub.utils.HfUri.is_repo] and
+[`is_bucket`][huggingface_hub.utils.HfUri.is_bucket] disambiguate between the
+two kinds.
+
+## Reference
+
+[[autodoc]] huggingface_hub.utils.HfUri
+
+[[autodoc]] huggingface_hub.utils.parse_hf_uri

--- a/docs/source/en/package_reference/hf_uris.md
+++ b/docs/source/en/package_reference/hf_uris.md
@@ -24,7 +24,7 @@ hf://[<TYPE>/]<ID>[@<REVISION>][/<PATH>][:<MOUNT_PATH>[:ro|:rw]]
 | --------------- | -------- | ------------------------------------------------------------------- |
 | `hf://`         | yes      | Literal protocol prefix.                                            |
 | `<TYPE>/`       | no       | `models/`, `datasets/`, `spaces/`, `kernels/`, `buckets/` (plural). |
-| `<ID>`          | yes      | `<repo_id>` for repos, `<namespace>/<name>` for buckets.            |
+| `<ID>`          | yes      | `<namespace>/<name>`                                                |
 | `@<REVISION>`   | no       | Branch, tag, commit SHA, or special ref (`refs/pr/N`, `refs/convert/...`). Repos only. |
 | `/<PATH>`       | no       | Path inside the repo or bucket.                                     |
 | `:<MOUNT_PATH>` | no       | Absolute mount path (volume use case).                              |
@@ -35,15 +35,14 @@ hf://[<TYPE>/]<ID>[@<REVISION>][/<PATH>][:<MOUNT_PATH>[:ro|:rw]]
 The following are **all valid HF URIs**:
 
 ```text
-# Models (type prefix is optional)
-hf://gpt2                                       # canonical model
-hf://my-org/my-model                            # namespaced model
+# Models (type prefix is optional, but the id is always 'namespace/name')
+hf://my-org/my-model                            # implicit type prefix
 hf://models/my-org/my-model                     # explicit type prefix
 hf://models/my-org/my-model/config.json         # file inside a model repo
 hf://models/my-org/my-model@v1.0/config.json    # pinned to a revision
 
 # Datasets, Spaces, Kernels (type prefix is required)
-hf://datasets/squad                             # canonical dataset
+hf://datasets/my-org/my-dataset
 hf://datasets/my-org/my-dataset@dev/train.csv
 hf://spaces/my-user/my-space
 hf://kernels/my-org/my-kernel
@@ -57,7 +56,7 @@ hf://buckets/my-org/my-bucket
 hf://buckets/my-org/my-bucket/sub/folder
 
 # Volume URIs (append `:<MOUNT_PATH>[:ro|:rw]`)
-hf://gpt2:/data
+hf://my-org/my-model:/data
 hf://datasets/my-org/my-dataset:/mnt:ro
 hf://datasets/my-org/my-dataset/train:/mnt:rw    # mount a sub-folder
 hf://buckets/my-org/my-bucket:/storage:rw
@@ -67,17 +66,18 @@ hf://buckets/my-org/my-bucket:/storage:rw
 
 The parser is strict on purpose. The following are **rejected**:
 
-| Invalid URI                               | Reason                                                                  |
-| ----------------------------------------- | ----------------------------------------------------------------------- |
-| `gpt2`, `huggingface.co/gpt2`             | Missing `hf://` protocol prefix.                                        |
-| `hf://dataset/foo/bar`, `hf://model/gpt2` | Singular type forms are forbidden, use the plural (`datasets/`, ...).  |
-| `hf://datasets`, `hf://buckets/`          | A type prefix alone is not a valid URI, an `<ID>` is required.         |
-| `hf://buckets/single-segment`             | Buckets must always be `namespace/name`.                                |
-| `hf://buckets/org/b@v1`                   | Buckets do not support a revision marker.                               |
-| `hf://gpt2@`, `hf://datasets/foo/bar@/x`  | Empty revision after `@`.                                               |
-| `hf://a/b/c@v1`                           | A repo id can be at most `namespace/name`, extra segments are paths.    |
-| `hf://gpt2:ro`, `hf://gpt2:rw`            | `:ro`/`:rw` requires a mount path (`hf://gpt2:/data:ro`).               |
-| `hf://gpt2:/`                             | Mount path must be a non-empty absolute path.                           |
+| Invalid URI                                       | Reason                                                                  |
+| ------------------------------------------------- | ----------------------------------------------------------------------- |
+| `my-org/my-model`, `huggingface.co/org/m`         | Missing `hf://` protocol prefix.                                        |
+| `hf://dataset/org/m`, `hf://model/org/m`          | Singular type forms are forbidden, use the plural (`datasets/`, ...).   |
+| `hf://datasets`, `hf://buckets/`                  | A type prefix alone is not a valid URI, an `<ID>` is required.          |
+| `hf://gpt2`, `hf://datasets/squad`                | Canonical repos (without a namespace) are not supported.                |
+| `hf://buckets/single-segment`                     | Buckets must always be `namespace/name`.                                |
+| `hf://buckets/org/b@v1`                           | Buckets do not support a revision marker.                               |
+| `hf://org/m@`, `hf://datasets/foo/bar@/x`         | Empty revision after `@`.                                               |
+| `hf://a/b/c@v1`                                   | A repo id must be `namespace/name`, extra segments are paths.           |
+| `hf://org/m:ro`, `hf://org/m:rw`                  | `:ro`/`:rw` requires a mount path (`hf://org/m:/data:ro`).              |
+| `hf://org/m:/`                                    | Mount path must be a non-empty absolute path.                           |
 
 ## Parsing in Python
 
@@ -85,8 +85,8 @@ The parser is strict on purpose. The following are **rejected**:
 
 ```python
 >>> from huggingface_hub import parse_hf_uri
->>> parse_hf_uri("hf://datasets/squad@refs/pr/3/train.json")
-HfUri(type='dataset', id='squad', revision='refs/pr/3', path_in_repo='train.json', mount_path=None, read_only=None)
+>>> parse_hf_uri("hf://datasets/my-org/my-dataset@refs/pr/3/train.json")
+HfUri(type='dataset', id='my-org/my-dataset', revision='refs/pr/3', path_in_repo='train.json', mount_path=None, read_only=None)
 
 >>> parse_hf_uri("hf://buckets/my-org/my-bucket/sub/dir:/mnt:ro")
 HfUri(type='bucket', id='my-org/my-bucket', revision=None, path_in_repo='sub/dir', mount_path='/mnt', read_only=True)
@@ -95,9 +95,9 @@ HfUri(type='bucket', id='my-org/my-bucket', revision=None, path_in_repo='sub/dir
 [`HfUri`] is round-trippable via [`HfUri.to_uri`], which always emits the canonical form (with an explicit type prefix):
 
 ```python
->>> uri = parse_hf_uri("hf://gpt2@v1/config.json")
+>>> uri = parse_hf_uri("hf://my-org/my-model@v1/config.json")
 >>> uri.to_uri()
-'hf://models/gpt2@v1/config.json'
+'hf://models/my-org/my-model@v1/config.json'
 ```
 
 Use the `type` and `id` fields directly. The boolean properties [`is_repo`] and [`is_bucket`] disambiguate between repository URIs and bucket URIs when needed.

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -582,6 +582,7 @@ _SUBMOD_ATTRS = {
         "CorruptedCacheException",
         "DeleteCacheStrategy",
         "HFCacheInfo",
+        "HfUri",
         "cached_assets_path",
         "close_session",
         "dump_environment_info",
@@ -590,6 +591,7 @@ _SUBMOD_ATTRS = {
         "get_token",
         "hf_raise_for_status",
         "logging",
+        "parse_hf_uri",
         "scan_cache_dir",
         "set_async_client_factory",
         "set_client_factory",
@@ -720,6 +722,7 @@ __all__ = [
     "HfFileSystemFile",
     "HfFileSystemResolvedPath",
     "HfFileSystemStreamFile",
+    "HfUri",
     "ImageClassificationInput",
     "ImageClassificationOutputElement",
     "ImageClassificationOutputTransform",
@@ -1036,6 +1039,7 @@ __all__ = [
     "notebook_login",
     "paper_info",
     "parse_eval_result_entries",
+    "parse_hf_uri",
     "parse_huggingface_oauth",
     "parse_local_safetensors_file_metadata",
     "parse_safetensors_file_metadata",
@@ -1712,6 +1716,7 @@ if TYPE_CHECKING:  # pragma: no cover
         CorruptedCacheException,  # noqa: F401
         DeleteCacheStrategy,  # noqa: F401
         HFCacheInfo,  # noqa: F401
+        HfUri,  # noqa: F401
         cached_assets_path,  # noqa: F401
         close_session,  # noqa: F401
         dump_environment_info,  # noqa: F401
@@ -1720,6 +1725,7 @@ if TYPE_CHECKING:  # pragma: no cover
         get_token,  # noqa: F401
         hf_raise_for_status,  # noqa: F401
         logging,  # noqa: F401
+        parse_hf_uri,  # noqa: F401
         scan_cache_dir,  # noqa: F401
         set_async_client_factory,  # noqa: F401
         set_client_factory,  # noqa: F401

--- a/src/huggingface_hub/cli/_cli_utils.py
+++ b/src/huggingface_hub/cli/_cli_utils.py
@@ -680,7 +680,7 @@ VolumesOpt = Annotated[
         "TYPE is one of: models, datasets, spaces, buckets. "
         "TYPE defaults to models if omitted. "
         "models, datasets and spaces are always mounted read-only. buckets are read+write by default. "
-        "E.g. -v hf://gpt2:/data or -v hf://datasets/org/ds:/data or -v hf://buckets/org/b:/mnt:ro",
+        "E.g. -v hf://org/m:/data or -v hf://datasets/org/ds:/data or -v hf://buckets/org/b:/mnt:ro",
     ),
 ]
 
@@ -704,7 +704,6 @@ def parse_volumes(volumes: list[str] | None) -> "list[Volume] | None":
     Optional ':ro' or ':rw' suffix for read-only or read-write.
 
     Examples:
-        hf://gpt2:/data                          (model, implicit type)
         hf://my-org/my-model:/data                (model, implicit type)
         hf://models/my-org/my-model:/data         (model, explicit type)
         hf://datasets/my-org/my-dataset:/data:ro
@@ -733,7 +732,7 @@ def parse_volumes(volumes: list[str] | None) -> "list[Volume] | None":
         if not spec.startswith(_HF_PREFIX):
             raise CLIError(
                 f"Invalid volume format: '{raw_spec}'. Source must start with 'hf://'. "
-                f"Expected hf://[TYPE/]SOURCE:/MOUNT_PATH[:ro]. E.g. hf://gpt2:/data"
+                f"Expected hf://[TYPE/]SOURCE:/MOUNT_PATH[:ro]. E.g. hf://org/m:/data"
             )
         spec = spec[len(_HF_PREFIX) :]
 
@@ -741,7 +740,7 @@ def parse_volumes(volumes: list[str] | None) -> "list[Volume] | None":
         colon_slash_idx = spec.find(":/")
         if colon_slash_idx == -1:
             raise CLIError(
-                f"Invalid volume format: '{raw_spec}'. Expected hf://[TYPE/]SOURCE:/MOUNT_PATH[:ro]. E.g. hf://gpt2:/data"
+                f"Invalid volume format: '{raw_spec}'. Expected hf://[TYPE/]SOURCE:/MOUNT_PATH[:ro]. E.g. hf://org/m:/data"
             )
         source_part = spec[:colon_slash_idx]
         mount_path = spec[colon_slash_idx + 1 :]

--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -123,6 +123,20 @@ REPO_TYPES_MAPPING = {
     "kernels": REPO_TYPE_KERNEL,
 }
 
+# HF Hub URIs (``hf://...``). See ``huggingface_hub/utils/_hf_uris.py``
+# and ``docs/source/en/package_reference/hf_uris.md`` for the full grammar.
+HF_PROTOCOL = "hf://"
+HfUriType = Literal["model", "dataset", "space", "kernel", "bucket"]
+# Maps the plural URI prefix that may appear in a HF URI (e.g. ``datasets/``)
+# to the canonical singular type name. Buckets are first-class HF URI types.
+HF_URI_TYPE_PREFIXES: dict[str, HfUriType] = {
+    "models": "model",
+    "datasets": "dataset",
+    "spaces": "space",
+    "kernels": "kernel",
+    "buckets": "bucket",
+}
+
 
 DiscussionTypeFilter = Literal["all", "discussion", "pull_request"]
 DISCUSSION_TYPES: tuple[DiscussionTypeFilter, ...] = typing.get_args(DiscussionTypeFilter)

--- a/src/huggingface_hub/errors.py
+++ b/src/huggingface_hub/errors.py
@@ -182,6 +182,7 @@ class HfUriError(ValueError):
 
     def __init__(self, uri: str, msg: str):
         self.uri = uri
+        self.msg = msg
         full_msg = f"Invalid HF URI '{uri}'. {msg}" if uri else f"Invalid HF URI. {msg}"
         super().__init__(full_msg)
 

--- a/src/huggingface_hub/errors.py
+++ b/src/huggingface_hub/errors.py
@@ -170,6 +170,18 @@ class HFValidationError(ValueError):
     """
 
 
+class HfUriError(ValueError):
+    """Raised when an `hf://...` URI is malformed.
+
+    See [`parse_hf_uri`][huggingface_hub.utils.parse_hf_uri] and the
+    [HF URIs reference](https://huggingface.co/docs/huggingface_hub/main/en/package_reference/hf_uris)
+    for the canonical syntax.
+
+    Inherits from [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
+    for backward compatibility.
+    """
+
+
 # FILE METADATA ERRORS
 
 

--- a/src/huggingface_hub/errors.py
+++ b/src/huggingface_hub/errors.py
@@ -173,7 +173,7 @@ class HFValidationError(ValueError):
 class HfUriError(ValueError):
     """Raised when an `hf://...` URI is malformed.
 
-    See [`parse_hf_uri`][huggingface_hub.utils.parse_hf_uri] and the
+    See [`parse_hf_uri`] and the
     [HF URIs reference](https://huggingface.co/docs/huggingface_hub/main/en/package_reference/hf_uris)
     for the canonical syntax.
 

--- a/src/huggingface_hub/errors.py
+++ b/src/huggingface_hub/errors.py
@@ -180,6 +180,10 @@ class HfUriError(ValueError):
     Inherits from [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError).
     """
 
+    def __init__(self, uri: str, msg: str):
+        super().__init__(f"Invalid HF URI '{uri}'. {msg}")
+        self.uri = uri
+
 
 # FILE METADATA ERRORS
 

--- a/src/huggingface_hub/errors.py
+++ b/src/huggingface_hub/errors.py
@@ -181,8 +181,9 @@ class HfUriError(ValueError):
     """
 
     def __init__(self, uri: str, msg: str):
-        super().__init__(f"Invalid HF URI '{uri}'. {msg}")
         self.uri = uri
+        full_msg = f"Invalid HF URI '{uri}'. {msg}" if uri else f"Invalid HF URI. {msg}"
+        super().__init__(full_msg)
 
 
 # FILE METADATA ERRORS

--- a/src/huggingface_hub/errors.py
+++ b/src/huggingface_hub/errors.py
@@ -177,8 +177,7 @@ class HfUriError(ValueError):
     [HF URIs reference](https://huggingface.co/docs/huggingface_hub/main/en/package_reference/hf_uris)
     for the canonical syntax.
 
-    Inherits from [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
-    for backward compatibility.
+    Inherits from [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError).
     """
 
 

--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -23,7 +23,6 @@ from huggingface_hub.errors import (
     FileMetadataError,
     GatedRepoError,
     HfHubHTTPError,
-    HfUriError,
     HFValidationError,
     LocalEntryNotFoundError,
     LocalTokenNotFoundError,

--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -52,6 +52,7 @@ from ._experimental import experimental
 from ._fixes import SoftTemporaryDirectory, WeakFileLock, yaml_dump
 from ._git_credential import list_credential_helpers, set_git_credential, unset_git_credential
 from ._headers import build_hf_headers, get_token_to_send
+from ._hf_uris import HfUri, parse_hf_uri
 from ._http import (
     ASYNC_CLIENT_FACTORY_T,
     CLIENT_FACTORY_T,

--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -52,7 +52,7 @@ from ._experimental import experimental
 from ._fixes import SoftTemporaryDirectory, WeakFileLock, yaml_dump
 from ._git_credential import list_credential_helpers, set_git_credential, unset_git_credential
 from ._headers import build_hf_headers, get_token_to_send
-from ._hf_uris import HfUri, parse_hf_uri
+from ._hf_uris import HfMount, HfUri, parse_hf_mount, parse_hf_uri
 from ._http import (
     ASYNC_CLIENT_FACTORY_T,
     CLIENT_FACTORY_T,

--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -23,6 +23,7 @@ from huggingface_hub.errors import (
     FileMetadataError,
     GatedRepoError,
     HfHubHTTPError,
+    HfUriError,
     HFValidationError,
     LocalEntryNotFoundError,
     LocalTokenNotFoundError,

--- a/src/huggingface_hub/utils/_hf_uris.py
+++ b/src/huggingface_hub/utils/_hf_uris.py
@@ -34,7 +34,6 @@ See 'docs/source/en/package_reference/hf_uris.md' for the full grammar and examp
 """
 
 import re
-import typing
 from dataclasses import dataclass, field
 from urllib.parse import unquote
 
@@ -55,8 +54,8 @@ _TYPE_TO_PREFIX: dict[str, str] = {v: k for k, v in constants.HF_URI_TYPE_PREFIX
 # so names like 'parquet-v2' or 'duckdb.v1' round-trip correctly.
 _SPECIAL_REFS_REVISION_REGEX = re.compile(r"^refs/(?:convert/[\w.-]+|pr/\d+)")
 
-# Same as constants.HfUriType, but as a set of strings for easy lookup.
-_VALID_URI_TYPES: frozenset[str] = frozenset(typing.get_args(constants.HfUriType))
+# Same as constants.HfUriType, but as a set of strings for easy lookup.)
+_VALID_URI_TYPES: frozenset[str] = frozenset(constants.HF_URI_TYPE_PREFIXES.values())
 
 
 @dataclass(frozen=True)
@@ -315,10 +314,6 @@ def _split_mount(body: str, *, raw: str) -> tuple[str, str | None, bool | None]:
     mount_path = body[idx + 1 :]  # includes the leading '/'
     if not location:
         raise HfUriError(uri=raw, msg="Missing location before mount path.")
-    if not mount_path.startswith("/") or mount_path == "/":
-        raise HfUriError(
-            uri=raw, msg=f"Mount path must be a non-empty absolute path starting with '/', got '{mount_path}'."
-        )
     return location, mount_path, read_only
 
 

--- a/src/huggingface_hub/utils/_hf_uris.py
+++ b/src/huggingface_hub/utils/_hf_uris.py
@@ -90,13 +90,13 @@ class HfUri:
         return self.type != "bucket"
 
     def __str__(self) -> str:
-        return self.to_string()
+        return self.to_uri()
 
-    def to_string(self) -> str:
+    def to_uri(self) -> str:
         """Render the URI as a canonical 'hf://' string.
 
         The type prefix is always written explicitly (e.g. 'hf://models/gpt2',
-        not 'hf://gpt2'). Round-tripping 'parse_hf_uri(uri.to_string())'
+        not 'hf://gpt2'). Round-tripping 'parse_hf_uri(uri.to_uri())'
         always yields the same URI.
         """
         parts: list[str] = [constants.HF_PROTOCOL, _TYPE_TO_PREFIX[self.type], "/", self.id]

--- a/src/huggingface_hub/utils/_hf_uris.py
+++ b/src/huggingface_hub/utils/_hf_uris.py
@@ -172,13 +172,12 @@ def _split_mount(body: str, *, raw: str) -> tuple[str, str | None, bool | None]:
 
     Returns '(location, mount_path, read_only)' where 'mount_path' is 'None' if no mount segment is present.
     """
-    read_only: bool | None = None
     if body.endswith(":ro"):
-        read_only = True
-        body = body[:-3]
+        read_only, body = True, body.removesuffix(":ro")
     elif body.endswith(":rw"):
-        read_only = False
-        body = body[:-3]
+        read_only, body = False, body.removesuffix(":rw")
+    else:
+        read_only = None
 
     # Mount paths always start with '/', so the delimiter is ':/'.
     # We use rfind() because the mount segment is always trailing

--- a/src/huggingface_hub/utils/_hf_uris.py
+++ b/src/huggingface_hub/utils/_hf_uris.py
@@ -39,12 +39,7 @@ from ._validators import validate_repo_id
 
 # Inverse map (singular → plural URI prefix). Built once from the canonical
 # 'constants.HF_URI_TYPE_PREFIXES' and used to render URIs.
-_TYPE_TO_PREFIX: dict[constants.HfUriType, str] = {v: k for k, v in constants.HF_URI_TYPE_PREFIXES.items()}
-
-# Same map but typed as 'dict[str, str]' so it can be indexed with arbitrary
-# strings without confusing the type-checker (used only to suggest the plural
-# form when the user wrote a singular type like 'hf://dataset/...').
-_PLURAL_FROM_SINGULAR_NAME: dict[str, str] = {str(k): v for k, v in _TYPE_TO_PREFIX.items()}
+_TYPE_TO_PREFIX: dict[str, str] = {v: k for k, v in constants.HF_URI_TYPE_PREFIXES.items()}
 
 # Special revisions that contain a '/'. They take precedence when splitting
 # the part after '@' into '<revision>/<path-in-repo>'. Matches 'refs/pr/N'
@@ -154,14 +149,15 @@ def parse_hf_uri(uri: str) -> HfUri:
     """
     if not uri.startswith(constants.HF_PROTOCOL):
         raise HfUriError(
-            f"Invalid HF URI '{uri}': must start with '{constants.HF_PROTOCOL}'. "
-            f"Expected format: {constants.HF_PROTOCOL}[<TYPE>/]<ID>[@<REVISION>][/<PATH>][:<MOUNT_PATH>[:ro|:rw]]"
+            uri,
+            f"Must start with '{constants.HF_PROTOCOL}'. "
+            f"Expected format: {constants.HF_PROTOCOL}[<TYPE>/]<ID>[@<REVISION>][/<PATH>][:<MOUNT_PATH>[:ro|:rw]]",
         )
 
     raw = uri
     body = uri[len(constants.HF_PROTOCOL) :]
     if not body:
-        raise HfUriError(f"Invalid HF URI '{raw}': empty body after '{constants.HF_PROTOCOL}'.")
+        raise HfUriError(uri, f"Empty body after '{constants.HF_PROTOCOL}'.")
 
     location, mount_path, read_only = _split_mount(body, raw=raw)
     type_, location = _split_type(location, raw=raw)
@@ -190,18 +186,18 @@ def _split_mount(body: str, *, raw: str) -> tuple[str, str | None, bool | None]:
     if idx == -1:
         if read_only is not None:
             raise HfUriError(
-                f"Invalid HF URI '{raw}': ':ro'/':rw' suffix is only valid when a mount path is provided "
-                "(e.g. 'hf://...:/<MOUNT_PATH>:ro')."
+                uri=raw,
+                msg="':ro'/':rw' suffix is only valid when a mount path is provided (e.g. 'hf://...:/<MOUNT_PATH>:ro').",
             )
         return body, None, None
 
     location = body[:idx]
     mount_path = body[idx + 1 :]  # includes the leading '/'
     if not location:
-        raise HfUriError(f"Invalid HF URI '{raw}': missing location before mount path.")
+        raise HfUriError(uri=raw, msg="Missing location before mount path.")
     if not mount_path.startswith("/") or mount_path == "/":
         raise HfUriError(
-            f"Invalid HF URI '{raw}': mount path must be a non-empty absolute path starting with '/', got '{mount_path}'."
+            uri=raw, msg=f"Mount path must be a non-empty absolute path starting with '/', got '{mount_path}'."
         )
     return location, mount_path, read_only
 
@@ -216,11 +212,13 @@ def _split_type(location: str, *, raw: str) -> tuple[constants.HfUriType, str]:
         # Single segment, no prefix. Reject if it looks like a bare type name.
         if location in constants.HF_URI_TYPE_PREFIXES:
             raise HfUriError(
-                f"Invalid HF URI '{raw}': missing identifier after '{location}'. Expected '{constants.HF_PROTOCOL}{location}/<ID>'."
+                uri=raw,
+                msg=f"Missing identifier after '{location}'. Expected '{constants.HF_PROTOCOL}{location}/<ID>'.",
             )
-        if (singular_plural := _PLURAL_FROM_SINGULAR_NAME.get(location)) is not None:
+        if (singular_plural := _TYPE_TO_PREFIX.get(location)) is not None:
             raise HfUriError(
-                f"Invalid HF URI '{raw}': type prefix must be plural. Did you mean '{constants.HF_PROTOCOL}{singular_plural}/...'?"
+                uri=raw,
+                msg=f"Type prefix must be plural. Did you mean '{constants.HF_PROTOCOL}{singular_plural}/...'?",
             )
         return "model", location
 
@@ -228,9 +226,9 @@ def _split_type(location: str, *, raw: str) -> tuple[constants.HfUriType, str]:
     rest = location[slash_idx + 1 :]
     if first in constants.HF_URI_TYPE_PREFIXES:
         return constants.HF_URI_TYPE_PREFIXES[first], rest
-    if (singular_plural := _PLURAL_FROM_SINGULAR_NAME.get(first)) is not None:
+    if (singular_plural := _TYPE_TO_PREFIX.get(first)) is not None:
         raise HfUriError(
-            f"Invalid HF URI '{raw}': type prefix must be plural, got '{first}/'. Did you mean '{singular_plural}/'?"
+            uri=raw, msg=f"Type prefix must be plural, got '{first}/'. Did you mean '{singular_plural}/'?"
         )
     return "model", location
 
@@ -245,11 +243,11 @@ def _parse_bucket_body(
 ) -> HfUri:
     """Parse the body of a bucket URI: 'namespace/name[/path]'."""
     if "@" in location:
-        raise HfUriError(f"Invalid HF URI '{raw}': bucket URIs do not support a revision marker ('@').")
+        raise HfUriError(uri=raw, msg="Bucket URIs do not support a revision marker ('@').")
     location = location.strip("/")
     parts = location.split("/", 2)
     if len(parts) < 2 or not parts[0] or not parts[1]:
-        raise HfUriError(f"Invalid HF URI '{raw}': bucket id must be 'namespace/name', got '{location}'.")
+        raise HfUriError(uri=raw, msg=f"Bucket id must be 'namespace/name', got '{location}'.")
     bucket_id = f"{parts[0]}/{parts[1]}"
     path_in_bucket = parts[2].strip("/") if len(parts) >= 3 else ""
     return HfUri(
@@ -273,7 +271,7 @@ def _parse_repo_body(
     """Parse the body of a repo URI: '<repo_id>[@<revision>][/<path>]'."""
     location = location.strip("/")
     if not location:
-        raise HfUriError(f"Invalid HF URI '{raw}': missing repository id.")
+        raise HfUriError(uri=raw, msg="Missing repository id.")
 
     # The first '@' separates the repo_id from the revision (and rest of path).
     # No valid repo_id contains '@' and no valid revision contains '@'.
@@ -284,24 +282,16 @@ def _parse_repo_body(
         revision = None
         parts = location.split("/", 2)
         if len(parts) < 2:
-            raise HfUriError(
-                f"Invalid HF URI '{raw}': repository id must be 'namespace/name', got '{location}'. "
-                "Canonical repos (without a namespace) are not supported."
-            )
+            raise HfUriError(uri=raw, msg=f"Repository id must be 'namespace/name', got '{location}'. ")
         repo_id = f"{parts[0]}/{parts[1]}"
         path_in_repo = parts[2] if len(parts) > 2 else ""
     else:
         repo_id = location[:at_idx]
         rev_and_path = location[at_idx + 1 :]
         if not repo_id:
-            raise HfUriError(f"Invalid HF URI '{raw}': missing repository id before '@'.")
-        if "/" not in repo_id:
-            raise HfUriError(
-                f"Invalid HF URI '{raw}': repository id must be 'namespace/name', got '{repo_id}'. "
-                "Canonical repos (without a namespace) are not supported."
-            )
-        if repo_id.count("/") > 1:
-            raise HfUriError(f"Invalid HF URI '{raw}': repository id must be 'namespace/name', got '{repo_id}'.")
+            raise HfUriError(uri=raw, msg="Missing repository id before '@'.")
+        if repo_id.count("/") != 1:
+            raise HfUriError(uri=raw, msg=f"Repository id must be 'namespace/name', got '{repo_id}'.")
         # Special refs like 'refs/pr/10' contain '/' and must be matched eagerly,
         # otherwise we would split them at the first '/' and treat the rest as a path.
         match = _SPECIAL_REFS_REVISION_REGEX.match(rev_and_path)
@@ -318,12 +308,12 @@ def _parse_repo_body(
                 path_in_repo = rev_and_path[slash_idx + 1 :]
         revision = unquote(revision)
         if not revision:
-            raise HfUriError(f"Invalid HF URI '{raw}': empty revision after '@'.")
+            raise HfUriError(uri=raw, msg="Empty revision after '@'.")
 
     try:
         validate_repo_id(repo_id)
     except HFValidationError as e:
-        raise HfUriError(f"Invalid HF URI '{raw}': {e}") from e
+        raise HfUriError(uri=raw, msg=str(e)) from e
 
     return HfUri(
         type=type_,

--- a/src/huggingface_hub/utils/_hf_uris.py
+++ b/src/huggingface_hub/utils/_hf_uris.py
@@ -62,7 +62,7 @@ class HfUri:
         type (`str`):
             One of 'model', 'dataset', 'space', 'kernel' or 'bucket'.
         id (`str`):
-            The repository id (e.g. 'gpt2' or 'my-org/my-model') for repo URIs, or the bucket id (always 'namespace/name') for bucket URIs.
+            The repository id ('namespace/name', e.g. 'my-org/my-model') for repo URIs, or the bucket id ('namespace/name') for bucket URIs.
         revision (`str`, *optional*):
             The revision specified after '@' in the URI, URL-decoded. 'None' if no revision was specified, or for bucket URIs (which
             never carry a revision). Special refs like 'refs/pr/10' and 'refs/convert/parquet' are preserved as-is.
@@ -97,7 +97,7 @@ class HfUri:
     def to_uri(self) -> str:
         """Render the URI as a canonical 'hf://' string.
 
-        The type prefix is always written explicitly (e.g. 'hf://models/gpt2', not 'hf://gpt2').
+        The type prefix is always written explicitly (e.g. 'hf://models/my-org/my-model').
         """
         parts: list[str] = [constants.HF_PROTOCOL, _TYPE_TO_PREFIX[self.type], "/", self.id]
         if self.revision is not None:
@@ -144,10 +144,10 @@ def parse_hf_uri(uri: str) -> HfUri:
     Examples:
         ```py
         >>> from huggingface_hub.utils import parse_hf_uri
-        >>> parse_hf_uri("hf://gpt2")
-        HfUri(type='model', id='gpt2', revision=None, path_in_repo='', mount_path=None, read_only=None)
-        >>> parse_hf_uri("hf://datasets/squad@refs/pr/3/train.json")
-        HfUri(type='dataset', id='squad', revision='refs/pr/3', path_in_repo='train.json', mount_path=None, read_only=None)
+        >>> parse_hf_uri("hf://my-org/my-model")
+        HfUri(type='model', id='my-org/my-model', revision=None, path_in_repo='', mount_path=None, read_only=None)
+        >>> parse_hf_uri("hf://datasets/my-org/my-dataset@refs/pr/3/train.json")
+        HfUri(type='dataset', id='my-org/my-dataset', revision='refs/pr/3', path_in_repo='train.json', mount_path=None, read_only=None)
         >>> parse_hf_uri("hf://buckets/my-org/my-bucket/sub/dir:/mnt:ro")
         HfUri(type='bucket', id='my-org/my-bucket', revision=None, path_in_repo='sub/dir', mount_path='/mnt', read_only=True)
         ```
@@ -280,24 +280,28 @@ def _parse_repo_body(
     at_idx = location.find("@")
     revision: str | None
     if at_idx == -1:
-        # No revision. Take the first 1-2 segments as repo_id, rest as path_in_repo.
+        # No revision. Take the first 2 segments as repo_id, rest as path_in_repo.
         revision = None
         parts = location.split("/", 2)
-        if len(parts) == 1:
-            repo_id = parts[0]
-            path_in_repo = ""
-        else:
-            repo_id = f"{parts[0]}/{parts[1]}"
-            path_in_repo = parts[2] if len(parts) > 2 else ""
+        if len(parts) < 2:
+            raise HfUriError(
+                f"Invalid HF URI '{raw}': repository id must be 'namespace/name', got '{location}'. "
+                "Canonical repos (without a namespace) are not supported."
+            )
+        repo_id = f"{parts[0]}/{parts[1]}"
+        path_in_repo = parts[2] if len(parts) > 2 else ""
     else:
         repo_id = location[:at_idx]
         rev_and_path = location[at_idx + 1 :]
         if not repo_id:
             raise HfUriError(f"Invalid HF URI '{raw}': missing repository id before '@'.")
-        if repo_id.count("/") > 1:
+        if "/" not in repo_id:
             raise HfUriError(
-                f"Invalid HF URI '{raw}': repository id must be 'name' or 'namespace/name', got '{repo_id}'."
+                f"Invalid HF URI '{raw}': repository id must be 'namespace/name', got '{repo_id}'. "
+                "Canonical repos (without a namespace) are not supported."
             )
+        if repo_id.count("/") > 1:
+            raise HfUriError(f"Invalid HF URI '{raw}': repository id must be 'namespace/name', got '{repo_id}'.")
         # Special refs like 'refs/pr/10' contain '/' and must be matched eagerly,
         # otherwise we would split them at the first '/' and treat the rest as a path.
         match = _SPECIAL_REFS_REVISION_REGEX.match(rev_and_path)

--- a/src/huggingface_hub/utils/_hf_uris.py
+++ b/src/huggingface_hub/utils/_hf_uris.py
@@ -26,15 +26,14 @@ See ``docs/source/en/package_reference/hf_uris.md`` for the full grammar and
 examples.
 """
 
-from __future__ import annotations
-
 import re
 from dataclasses import dataclass
 from urllib.parse import unquote
 
 from huggingface_hub import constants
+from huggingface_hub.errors import HfUriError, HFValidationError
 
-from ._validators import HFValidationError, validate_repo_id
+from ._validators import validate_repo_id
 
 
 # Inverse map (singular → plural URI prefix). Built once from the canonical
@@ -162,9 +161,9 @@ def parse_hf_uri(uri: str) -> HfUri:
         [`HfUri`]: the parsed URI.
 
     Raises:
-        `ValueError`:
+        [`HfUriError`][huggingface_hub.errors.HfUriError]:
             If the URI is malformed (missing prefix, invalid type, missing
-            id, etc.).
+            id, etc.). Inherits from `ValueError` for backward compatibility.
 
     Examples:
         ```py
@@ -178,7 +177,7 @@ def parse_hf_uri(uri: str) -> HfUri:
         ```
     """
     if not uri.startswith(constants.HF_PROTOCOL):
-        raise ValueError(
+        raise HfUriError(
             f"Invalid HF URI '{uri}': must start with '{constants.HF_PROTOCOL}'. "
             f"Expected format: {constants.HF_PROTOCOL}[<TYPE>/]<ID>[@<REVISION>][/<PATH>][:<MOUNT_PATH>[:ro|:rw]]"
         )
@@ -186,7 +185,7 @@ def parse_hf_uri(uri: str) -> HfUri:
     raw = uri
     body = uri[len(constants.HF_PROTOCOL) :]
     if not body:
-        raise ValueError(f"Invalid HF URI '{raw}': empty body after '{constants.HF_PROTOCOL}'.")
+        raise HfUriError(f"Invalid HF URI '{raw}': empty body after '{constants.HF_PROTOCOL}'.")
 
     location, mount_path, read_only = _split_mount(body, raw=raw)
     type_, location = _split_type(location, raw=raw)
@@ -216,7 +215,7 @@ def _split_mount(body: str, *, raw: str) -> tuple[str, str | None, bool | None]:
     idx = body.rfind(":/")
     if idx == -1:
         if read_only is not None:
-            raise ValueError(
+            raise HfUriError(
                 f"Invalid HF URI '{raw}': ':ro'/':rw' suffix is only valid when a mount path "
                 "is provided (e.g. 'hf://...:/<MOUNT_PATH>:ro')."
             )
@@ -225,9 +224,9 @@ def _split_mount(body: str, *, raw: str) -> tuple[str, str | None, bool | None]:
     location = body[:idx]
     mount_path = body[idx + 1 :]  # includes the leading '/'
     if not location:
-        raise ValueError(f"Invalid HF URI '{raw}': missing location before mount path.")
+        raise HfUriError(f"Invalid HF URI '{raw}': missing location before mount path.")
     if not mount_path.startswith("/") or mount_path == "/":
-        raise ValueError(
+        raise HfUriError(
             f"Invalid HF URI '{raw}': mount path must be a non-empty absolute path "
             f"starting with '/', got '{mount_path}'."
         )
@@ -244,12 +243,12 @@ def _split_type(location: str, *, raw: str) -> tuple[constants.HfUriType, str]:
     if slash_idx == -1:
         # Single segment, no prefix. Reject if it looks like a bare type name.
         if location in constants.HF_URI_TYPE_PREFIXES:
-            raise ValueError(
+            raise HfUriError(
                 f"Invalid HF URI '{raw}': missing identifier after '{location}'. "
                 f"Expected '{constants.HF_PROTOCOL}{location}/<ID>'."
             )
         if (singular_plural := _PLURAL_FROM_SINGULAR_NAME.get(location)) is not None:
-            raise ValueError(
+            raise HfUriError(
                 f"Invalid HF URI '{raw}': type prefix must be plural. "
                 f"Did you mean '{constants.HF_PROTOCOL}{singular_plural}/...'?"
             )
@@ -260,7 +259,7 @@ def _split_type(location: str, *, raw: str) -> tuple[constants.HfUriType, str]:
     if first in constants.HF_URI_TYPE_PREFIXES:
         return constants.HF_URI_TYPE_PREFIXES[first], rest
     if (singular_plural := _PLURAL_FROM_SINGULAR_NAME.get(first)) is not None:
-        raise ValueError(
+        raise HfUriError(
             f"Invalid HF URI '{raw}': type prefix must be plural, got '{first}/'. Did you mean '{singular_plural}/'?"
         )
     return "model", location
@@ -276,11 +275,11 @@ def _parse_bucket_body(
 ) -> HfUri:
     """Parse the body of a bucket URI: ``namespace/name[/path]``."""
     if "@" in location:
-        raise ValueError(f"Invalid HF URI '{raw}': bucket URIs do not support a revision marker ('@').")
+        raise HfUriError(f"Invalid HF URI '{raw}': bucket URIs do not support a revision marker ('@').")
     location = location.strip("/")
     parts = location.split("/", 2)
     if len(parts) < 2 or not parts[0] or not parts[1]:
-        raise ValueError(f"Invalid HF URI '{raw}': bucket id must be 'namespace/name', got '{location}'.")
+        raise HfUriError(f"Invalid HF URI '{raw}': bucket id must be 'namespace/name', got '{location}'.")
     bucket_id = f"{parts[0]}/{parts[1]}"
     path_in_bucket = parts[2].strip("/") if len(parts) >= 3 else ""
     return HfUri(
@@ -304,7 +303,7 @@ def _parse_repo_body(
     """Parse the body of a repo URI: ``<repo_id>[@<revision>][/<path>]``."""
     location = location.strip("/")
     if not location:
-        raise ValueError(f"Invalid HF URI '{raw}': missing repository id.")
+        raise HfUriError(f"Invalid HF URI '{raw}': missing repository id.")
 
     # The first '@' separates the repo_id from the revision (and rest of path).
     # No valid repo_id contains '@' and no valid revision contains '@'.
@@ -324,9 +323,9 @@ def _parse_repo_body(
         repo_id = location[:at_idx]
         rev_and_path = location[at_idx + 1 :]
         if not repo_id:
-            raise ValueError(f"Invalid HF URI '{raw}': missing repository id before '@'.")
+            raise HfUriError(f"Invalid HF URI '{raw}': missing repository id before '@'.")
         if repo_id.count("/") > 1:
-            raise ValueError(
+            raise HfUriError(
                 f"Invalid HF URI '{raw}': repository id must be 'name' or 'namespace/name', got '{repo_id}'."
             )
         # Special refs like 'refs/pr/10' contain '/' and must be matched eagerly,
@@ -345,12 +344,12 @@ def _parse_repo_body(
                 path_in_repo = rev_and_path[slash_idx + 1 :]
         revision = unquote(revision)
         if not revision:
-            raise ValueError(f"Invalid HF URI '{raw}': empty revision after '@'.")
+            raise HfUriError(f"Invalid HF URI '{raw}': empty revision after '@'.")
 
     try:
         validate_repo_id(repo_id)
     except HFValidationError as e:
-        raise ValueError(f"Invalid HF URI '{raw}': {e}") from e
+        raise HfUriError(f"Invalid HF URI '{raw}': {e}") from e
 
     return HfUri(
         type=type_,

--- a/src/huggingface_hub/utils/_hf_uris.py
+++ b/src/huggingface_hub/utils/_hf_uris.py
@@ -11,19 +11,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Centralized parser for Hugging Face Hub URIs (``hf://...``).
+"""Centralized parser for Hugging Face Hub URIs ('hf://...').
 
-A *HF URI* is a URI-like string that identifies a location on the Hugging Face
+A HF URI is a URI-like string that identifies a location on the Hugging Face
 Hub: a model/dataset/space/kernel repository, a bucket, optionally a revision,
 optionally a path inside the repo or bucket, and optionally a local mount path
-with a ``:ro``/``:rw`` flag (used by Spaces and Jobs volumes).
+with a ':ro'/':rw' flag (used by Spaces and Jobs volumes).
 
-Canonical syntax::
+Canonical syntax:
 
-    hf://[<TYPE>/]<ID>[@<REVISION>][/<PATH>][:<MOUNT_PATH>[:ro|:rw]]
+```
+hf://[<TYPE>/]<ID>[@<REVISION>][/<PATH>][:<MOUNT_PATH>[:ro|:rw]]
+```
 
-See ``docs/source/en/package_reference/hf_uris.md`` for the full grammar and
-examples.
+See 'docs/source/en/package_reference/hf_uris.md' for the full grammar and examples.
 """
 
 import re
@@ -37,46 +38,46 @@ from ._validators import validate_repo_id
 
 
 # Inverse map (singular → plural URI prefix). Built once from the canonical
-# ``constants.HF_URI_TYPE_PREFIXES`` and used to render URIs.
+# 'constants.HF_URI_TYPE_PREFIXES' and used to render URIs.
 _TYPE_TO_PREFIX: dict[constants.HfUriType, str] = {v: k for k, v in constants.HF_URI_TYPE_PREFIXES.items()}
 
-# Same map but typed as ``dict[str, str]`` so it can be indexed with arbitrary
+# Same map but typed as 'dict[str, str]' so it can be indexed with arbitrary
 # strings without confusing the type-checker (used only to suggest the plural
-# form when the user wrote a singular type like ``hf://dataset/...``).
+# form when the user wrote a singular type like 'hf://dataset/...').
 _PLURAL_FROM_SINGULAR_NAME: dict[str, str] = {str(k): v for k, v in _TYPE_TO_PREFIX.items()}
 
-# Special revisions that contain a ``/``. They take precedence when splitting
-# the part after ``@`` into ``<revision>/<path-in-repo>``. Matches ``refs/pr/N``
-# (Pull Request refs) and ``refs/convert/<name>`` (e.g. parquet conversions).
+# Special revisions that contain a '/'. They take precedence when splitting
+# the part after '@' into '<revision>/<path-in-repo>'. Matches 'refs/pr/N'
+# (Pull Request refs) and 'refs/convert/<name>' (e.g. parquet conversions).
 _SPECIAL_REFS_REVISION_REGEX = re.compile(r"^refs/(?:convert/\w+|pr/\d+)")
 
 
 @dataclass(frozen=True)
 class HfUri:
-    """Parsed representation of a Hugging Face Hub URI (``hf://...``).
+    """Parsed representation of a Hugging Face Hub URI ('hf://...').
 
     Attributes:
         type (`str`):
-            One of ``"model"``, ``"dataset"``, ``"space"``, ``"kernel"`` or ``"bucket"``.
+            One of '"model"', '"dataset"', '"space"', '"kernel"' or '"bucket"'.
         id (`str`):
-            The repository id (e.g. ``"gpt2"`` or ``"my-org/my-model"``) for repo
-            URIs, or the bucket id (always ``"namespace/name"``) for bucket URIs.
+            The repository id (e.g. '"gpt2"' or '"my-org/my-model"') for repo
+            URIs, or the bucket id (always '"namespace/name"') for bucket URIs.
             Use the [`repo_id`] and [`bucket_id`] convenience properties when
             relevant.
         revision (`str`, *optional*):
-            The revision specified after ``@`` in the URI, URL-decoded.
-            ``None`` if no revision was specified, or for bucket URIs (which
-            never carry a revision). Special refs like ``"refs/pr/10"`` and
-            ``"refs/convert/parquet"`` are preserved as-is.
+            The revision specified after '@' in the URI, URL-decoded.
+            'None' if no revision was specified, or for bucket URIs (which
+            never carry a revision). Special refs like '"refs/pr/10"' and
+            '"refs/convert/parquet"' are preserved as-is.
         path_in_repo (`str`):
             The path inside the repo or bucket. Empty string if the URI
             points at the root.
         mount_path (`str`, *optional*):
-            The local mount path specified after ``:`` (always starts with ``/``).
-            ``None`` if the URI is a plain location URI.
+            The local mount path specified after ':' (always starts with '/').
+            'None' if the URI is a plain location URI.
         read_only (`bool`, *optional*):
-            ``True`` if the URI ends with ``:ro``, ``False`` if it ends with
-            ``:rw``, ``None`` if no read/write flag was provided.
+            'True' if the URI ends with ':ro', 'False' if it ends with
+            ':rw', 'None' if no read/write flag was provided.
     """
 
     type: constants.HfUriType
@@ -88,12 +89,12 @@ class HfUri:
 
     @property
     def is_bucket(self) -> bool:
-        """``True`` if this URI points at a bucket."""
+        """'True' if this URI points at a bucket."""
         return self.type == "bucket"
 
     @property
     def is_repo(self) -> bool:
-        """``True`` if this URI points at a repository (model, dataset, space or kernel)."""
+        """'True' if this URI points at a repository (model, dataset, space or kernel)."""
         return self.type != "bucket"
 
     @property
@@ -121,10 +122,10 @@ class HfUri:
         return self.to_string()
 
     def to_string(self) -> str:
-        """Render the URI as a canonical ``hf://`` string.
+        """Render the URI as a canonical 'hf://' string.
 
-        The type prefix is always written explicitly (e.g. ``hf://models/gpt2``,
-        not ``hf://gpt2``). Round-tripping ``parse_hf_uri(uri.to_string())``
+        The type prefix is always written explicitly (e.g. 'hf://models/gpt2',
+        not 'hf://gpt2'). Round-tripping 'parse_hf_uri(uri.to_string())'
         always yields the same URI.
         """
         parts: list[str] = [constants.HF_PROTOCOL, _TYPE_TO_PREFIX[self.type], "/", self.id]
@@ -142,19 +143,19 @@ class HfUri:
 
 
 def parse_hf_uri(uri: str) -> HfUri:
-    """Parse a Hugging Face Hub URI (``hf://...``).
+    """Parse a Hugging Face Hub URI ('hf://...').
 
     A HF URI is a URI-like string identifying a location on the Hugging Face
     Hub. The full grammar is::
 
         hf://[<TYPE>/]<ID>[@<REVISION>][/<PATH>][:<MOUNT_PATH>[:ro|:rw]]
 
-    See ``docs/source/en/package_reference/hf_uris.md`` for the full
+    See 'docs/source/en/package_reference/hf_uris.md' for the full
     specification.
 
     Args:
         uri (`str`):
-            The URI to parse. Must start with ``hf://``.
+            The URI to parse. Must start with 'hf://'.
 
     Returns:
         [`HfUri`]: the parsed URI.
@@ -195,10 +196,10 @@ def parse_hf_uri(uri: str) -> HfUri:
 
 
 def _split_mount(body: str, *, raw: str) -> tuple[str, str | None, bool | None]:
-    """Split the ``:<MOUNT_PATH>[:ro|:rw]`` suffix from ``body``.
+    """Split the ':<MOUNT_PATH>[:ro|:rw]' suffix from 'body'.
 
-    Returns ``(location, mount_path, read_only)`` where ``mount_path`` is
-    ``None`` if no mount segment is present.
+    Returns '(location, mount_path, read_only)' where 'mount_path' is
+    'None' if no mount segment is present.
     """
     read_only: bool | None = None
     if body.endswith(":ro"):
@@ -208,9 +209,9 @@ def _split_mount(body: str, *, raw: str) -> tuple[str, str | None, bool | None]:
         read_only = False
         body = body[:-3]
 
-    # Mount paths always start with '/', so the delimiter is ``:/``. We use
+    # Mount paths always start with '/', so the delimiter is ':/'. We use
     # rfind() because the mount segment is always trailing — paths inside
-    # repos may technically contain ``:`` characters.
+    # repos may technically contain ':' characters.
     idx = body.rfind(":/")
     if idx == -1:
         if read_only is not None:
@@ -233,10 +234,10 @@ def _split_mount(body: str, *, raw: str) -> tuple[str, str | None, bool | None]:
 
 
 def _split_type(location: str, *, raw: str) -> tuple[constants.HfUriType, str]:
-    """Detect the (optional) type prefix and return ``(type, remaining_location)``.
+    """Detect the (optional) type prefix and return '(type, remaining_location)'.
 
-    A missing type prefix defaults to ``"model"``. Singular forms (``model/``,
-    ``dataset/``, etc.) are explicitly rejected with a helpful error.
+    A missing type prefix defaults to '"model"'. Singular forms ('model/',
+    'dataset/', etc.) are explicitly rejected with a helpful error.
     """
     slash_idx = location.find("/")
     if slash_idx == -1:
@@ -272,7 +273,7 @@ def _parse_bucket_body(
     *,
     raw: str,
 ) -> HfUri:
-    """Parse the body of a bucket URI: ``namespace/name[/path]``."""
+    """Parse the body of a bucket URI: 'namespace/name[/path]'."""
     if "@" in location:
         raise HfUriError(f"Invalid HF URI '{raw}': bucket URIs do not support a revision marker ('@').")
     location = location.strip("/")
@@ -299,7 +300,7 @@ def _parse_repo_body(
     *,
     raw: str,
 ) -> HfUri:
-    """Parse the body of a repo URI: ``<repo_id>[@<revision>][/<path>]``."""
+    """Parse the body of a repo URI: '<repo_id>[@<revision>][/<path>]'."""
     location = location.strip("/")
     if not location:
         raise HfUriError(f"Invalid HF URI '{raw}': missing repository id.")

--- a/src/huggingface_hub/utils/_hf_uris.py
+++ b/src/huggingface_hub/utils/_hf_uris.py
@@ -1,0 +1,362 @@
+# Copyright 2026-present, the HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Centralized parser for Hugging Face Hub URIs (``hf://...``).
+
+A *HF URI* is a URI-like string that identifies a location on the Hugging Face
+Hub: a model/dataset/space/kernel repository, a bucket, optionally a revision,
+optionally a path inside the repo or bucket, and optionally a local mount path
+with a ``:ro``/``:rw`` flag (used by Spaces and Jobs volumes).
+
+Canonical syntax::
+
+    hf://[<TYPE>/]<ID>[@<REVISION>][/<PATH>][:<MOUNT_PATH>[:ro|:rw]]
+
+See ``docs/source/en/package_reference/hf_uris.md`` for the full grammar and
+examples.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from urllib.parse import unquote
+
+from huggingface_hub import constants
+
+from ._validators import HFValidationError, validate_repo_id
+
+
+# Inverse map (singular → plural URI prefix). Built once from the canonical
+# ``constants.HF_URI_TYPE_PREFIXES`` and used to render URIs.
+_TYPE_TO_PREFIX: dict[constants.HfUriType, str] = {v: k for k, v in constants.HF_URI_TYPE_PREFIXES.items()}
+
+# Same map but typed as ``dict[str, str]`` so it can be indexed with arbitrary
+# strings without confusing the type-checker (used only to suggest the plural
+# form when the user wrote a singular type like ``hf://dataset/...``).
+_PLURAL_FROM_SINGULAR_NAME: dict[str, str] = {str(k): v for k, v in _TYPE_TO_PREFIX.items()}
+
+# Special revisions that contain a ``/``. They take precedence when splitting
+# the part after ``@`` into ``<revision>/<path-in-repo>``. Matches ``refs/pr/N``
+# (Pull Request refs) and ``refs/convert/<name>`` (e.g. parquet conversions).
+_SPECIAL_REFS_REVISION_REGEX = re.compile(r"^refs/(?:convert/\w+|pr/\d+)")
+
+
+@dataclass(frozen=True)
+class HfUri:
+    """Parsed representation of a Hugging Face Hub URI (``hf://...``).
+
+    Attributes:
+        type (`str`):
+            One of ``"model"``, ``"dataset"``, ``"space"``, ``"kernel"`` or ``"bucket"``.
+        id (`str`):
+            The repository id (e.g. ``"gpt2"`` or ``"my-org/my-model"``) for repo
+            URIs, or the bucket id (always ``"namespace/name"``) for bucket URIs.
+            Use the [`repo_id`][huggingface_hub.utils.HfUri.repo_id] and
+            [`bucket_id`][huggingface_hub.utils.HfUri.bucket_id] convenience
+            properties when relevant.
+        revision (`str`, *optional*):
+            The revision specified after ``@`` in the URI, URL-decoded.
+            ``None`` if no revision was specified, or for bucket URIs (which
+            never carry a revision). Special refs like ``"refs/pr/10"`` and
+            ``"refs/convert/parquet"`` are preserved as-is.
+        path_in_repo (`str`):
+            The path inside the repo or bucket. Empty string if the URI
+            points at the root.
+        mount_path (`str`, *optional*):
+            The local mount path specified after ``:`` (always starts with ``/``).
+            ``None`` if the URI is a plain location URI.
+        read_only (`bool`, *optional*):
+            ``True`` if the URI ends with ``:ro``, ``False`` if it ends with
+            ``:rw``, ``None`` if no read/write flag was provided.
+    """
+
+    type: constants.HfUriType
+    id: str
+    revision: str | None = None
+    path_in_repo: str = ""
+    mount_path: str | None = None
+    read_only: bool | None = None
+
+    @property
+    def is_bucket(self) -> bool:
+        """``True`` if this URI points at a bucket."""
+        return self.type == "bucket"
+
+    @property
+    def is_repo(self) -> bool:
+        """``True`` if this URI points at a repository (model, dataset, space or kernel)."""
+        return self.type != "bucket"
+
+    @property
+    def repo_type(self) -> constants.HfUriType:
+        """Alias of [`type`][huggingface_hub.utils.HfUri.type] for repo URIs."""
+        if self.is_bucket:
+            raise AttributeError("Bucket URIs do not have a `repo_type`. Use `type` or `bucket_id`.")
+        return self.type
+
+    @property
+    def repo_id(self) -> str:
+        """Repository id. Raises if the URI is a bucket URI."""
+        if self.is_bucket:
+            raise AttributeError("Bucket URIs do not have a `repo_id`. Use `bucket_id` instead.")
+        return self.id
+
+    @property
+    def bucket_id(self) -> str:
+        """Bucket id. Raises if the URI is not a bucket URI."""
+        if not self.is_bucket:
+            raise AttributeError("Only bucket URIs have a `bucket_id`. Use `repo_id` instead.")
+        return self.id
+
+    def __str__(self) -> str:
+        return self.to_string()
+
+    def to_string(self) -> str:
+        """Render the URI as a canonical ``hf://`` string.
+
+        The type prefix is always written explicitly (e.g. ``hf://models/gpt2``,
+        not ``hf://gpt2``). Round-tripping ``parse_hf_uri(uri.to_string())``
+        always yields the same URI.
+        """
+        parts: list[str] = [constants.HF_PROTOCOL, _TYPE_TO_PREFIX[self.type], "/", self.id]
+        if self.revision is not None:
+            parts.append(f"@{self.revision}")
+        if self.path_in_repo:
+            parts.append(f"/{self.path_in_repo}")
+        if self.mount_path is not None:
+            parts.append(f":{self.mount_path}")
+            if self.read_only is True:
+                parts.append(":ro")
+            elif self.read_only is False:
+                parts.append(":rw")
+        return "".join(parts)
+
+
+def parse_hf_uri(uri: str) -> HfUri:
+    """Parse a Hugging Face Hub URI (``hf://...``).
+
+    A HF URI is a URI-like string identifying a location on the Hugging Face
+    Hub. The full grammar is::
+
+        hf://[<TYPE>/]<ID>[@<REVISION>][/<PATH>][:<MOUNT_PATH>[:ro|:rw]]
+
+    See ``docs/source/en/package_reference/hf_uris.md`` for the full
+    specification.
+
+    Args:
+        uri (`str`):
+            The URI to parse. Must start with ``hf://``.
+
+    Returns:
+        [`HfUri`]: the parsed URI.
+
+    Raises:
+        `ValueError`:
+            If the URI is malformed (missing prefix, invalid type, missing
+            id, etc.).
+
+    Examples:
+        ```py
+        >>> from huggingface_hub.utils import parse_hf_uri
+        >>> parse_hf_uri("hf://gpt2")
+        HfUri(type='model', id='gpt2', revision=None, path_in_repo='', mount_path=None, read_only=None)
+        >>> parse_hf_uri("hf://datasets/squad@refs/pr/3/train.json")
+        HfUri(type='dataset', id='squad', revision='refs/pr/3', path_in_repo='train.json', mount_path=None, read_only=None)
+        >>> parse_hf_uri("hf://buckets/my-org/my-bucket/sub/dir:/mnt:ro")
+        HfUri(type='bucket', id='my-org/my-bucket', revision=None, path_in_repo='sub/dir', mount_path='/mnt', read_only=True)
+        ```
+    """
+    if not uri.startswith(constants.HF_PROTOCOL):
+        raise ValueError(
+            f"Invalid HF URI '{uri}': must start with '{constants.HF_PROTOCOL}'. "
+            f"Expected format: {constants.HF_PROTOCOL}[<TYPE>/]<ID>[@<REVISION>][/<PATH>][:<MOUNT_PATH>[:ro|:rw]]"
+        )
+
+    raw = uri
+    body = uri[len(constants.HF_PROTOCOL) :]
+    if not body:
+        raise ValueError(f"Invalid HF URI '{raw}': empty body after '{constants.HF_PROTOCOL}'.")
+
+    location, mount_path, read_only = _split_mount(body, raw=raw)
+    type_, location = _split_type(location, raw=raw)
+
+    if type_ == "bucket":
+        return _parse_bucket_body(location, type_, mount_path, read_only, raw=raw)
+    return _parse_repo_body(location, type_, mount_path, read_only, raw=raw)
+
+
+def _split_mount(body: str, *, raw: str) -> tuple[str, str | None, bool | None]:
+    """Split the ``:<MOUNT_PATH>[:ro|:rw]`` suffix from ``body``.
+
+    Returns ``(location, mount_path, read_only)`` where ``mount_path`` is
+    ``None`` if no mount segment is present.
+    """
+    read_only: bool | None = None
+    if body.endswith(":ro"):
+        read_only = True
+        body = body[:-3]
+    elif body.endswith(":rw"):
+        read_only = False
+        body = body[:-3]
+
+    # Mount paths always start with '/', so the delimiter is ``:/``. We use
+    # rfind() because the mount segment is always trailing — paths inside
+    # repos may technically contain ``:`` characters.
+    idx = body.rfind(":/")
+    if idx == -1:
+        if read_only is not None:
+            raise ValueError(
+                f"Invalid HF URI '{raw}': ':ro'/':rw' suffix is only valid when a mount path "
+                "is provided (e.g. 'hf://...:/<MOUNT_PATH>:ro')."
+            )
+        return body, None, None
+
+    location = body[:idx]
+    mount_path = body[idx + 1 :]  # includes the leading '/'
+    if not location:
+        raise ValueError(f"Invalid HF URI '{raw}': missing location before mount path.")
+    if not mount_path.startswith("/") or mount_path == "/":
+        raise ValueError(
+            f"Invalid HF URI '{raw}': mount path must be a non-empty absolute path "
+            f"starting with '/', got '{mount_path}'."
+        )
+    return location, mount_path, read_only
+
+
+def _split_type(location: str, *, raw: str) -> tuple[constants.HfUriType, str]:
+    """Detect the (optional) type prefix and return ``(type, remaining_location)``.
+
+    A missing type prefix defaults to ``"model"``. Singular forms (``model/``,
+    ``dataset/``, etc.) are explicitly rejected with a helpful error.
+    """
+    slash_idx = location.find("/")
+    if slash_idx == -1:
+        # Single segment, no prefix. Reject if it looks like a bare type name.
+        if location in constants.HF_URI_TYPE_PREFIXES:
+            raise ValueError(
+                f"Invalid HF URI '{raw}': missing identifier after '{location}'. "
+                f"Expected '{constants.HF_PROTOCOL}{location}/<ID>'."
+            )
+        if (singular_plural := _PLURAL_FROM_SINGULAR_NAME.get(location)) is not None:
+            raise ValueError(
+                f"Invalid HF URI '{raw}': type prefix must be plural. "
+                f"Did you mean '{constants.HF_PROTOCOL}{singular_plural}/...'?"
+            )
+        return "model", location
+
+    first = location[:slash_idx]
+    rest = location[slash_idx + 1 :]
+    if first in constants.HF_URI_TYPE_PREFIXES:
+        return constants.HF_URI_TYPE_PREFIXES[first], rest
+    if (singular_plural := _PLURAL_FROM_SINGULAR_NAME.get(first)) is not None:
+        raise ValueError(
+            f"Invalid HF URI '{raw}': type prefix must be plural, got '{first}/'. Did you mean '{singular_plural}/'?"
+        )
+    return "model", location
+
+
+def _parse_bucket_body(
+    location: str,
+    type_: constants.HfUriType,
+    mount_path: str | None,
+    read_only: bool | None,
+    *,
+    raw: str,
+) -> HfUri:
+    """Parse the body of a bucket URI: ``namespace/name[/path]``."""
+    if "@" in location:
+        raise ValueError(f"Invalid HF URI '{raw}': bucket URIs do not support a revision marker ('@').")
+    location = location.strip("/")
+    parts = location.split("/", 2)
+    if len(parts) < 2 or not parts[0] or not parts[1]:
+        raise ValueError(f"Invalid HF URI '{raw}': bucket id must be 'namespace/name', got '{location}'.")
+    bucket_id = f"{parts[0]}/{parts[1]}"
+    path_in_bucket = parts[2].strip("/") if len(parts) >= 3 else ""
+    return HfUri(
+        type=type_,
+        id=bucket_id,
+        revision=None,
+        path_in_repo=path_in_bucket,
+        mount_path=mount_path,
+        read_only=read_only,
+    )
+
+
+def _parse_repo_body(
+    location: str,
+    type_: constants.HfUriType,
+    mount_path: str | None,
+    read_only: bool | None,
+    *,
+    raw: str,
+) -> HfUri:
+    """Parse the body of a repo URI: ``<repo_id>[@<revision>][/<path>]``."""
+    location = location.strip("/")
+    if not location:
+        raise ValueError(f"Invalid HF URI '{raw}': missing repository id.")
+
+    # The first '@' separates the repo_id from the revision (and rest of path).
+    # No valid repo_id contains '@' and no valid revision contains '@'.
+    at_idx = location.find("@")
+    revision: str | None
+    if at_idx == -1:
+        # No revision. Take the first 1-2 segments as repo_id, rest as path_in_repo.
+        revision = None
+        parts = location.split("/", 2)
+        if len(parts) == 1:
+            repo_id = parts[0]
+            path_in_repo = ""
+        else:
+            repo_id = f"{parts[0]}/{parts[1]}"
+            path_in_repo = parts[2] if len(parts) > 2 else ""
+    else:
+        repo_id = location[:at_idx]
+        rev_and_path = location[at_idx + 1 :]
+        if not repo_id:
+            raise ValueError(f"Invalid HF URI '{raw}': missing repository id before '@'.")
+        if repo_id.count("/") > 1:
+            raise ValueError(
+                f"Invalid HF URI '{raw}': repository id must be 'name' or 'namespace/name', got '{repo_id}'."
+            )
+        # Special refs like 'refs/pr/10' contain '/' and must be matched eagerly,
+        # otherwise we would split them at the first '/' and treat the rest as a path.
+        match = _SPECIAL_REFS_REVISION_REGEX.match(rev_and_path)
+        if match is not None:
+            revision = match.group()
+            path_in_repo = rev_and_path[len(revision) :].lstrip("/")
+        else:
+            slash_idx = rev_and_path.find("/")
+            if slash_idx == -1:
+                revision = rev_and_path
+                path_in_repo = ""
+            else:
+                revision = rev_and_path[:slash_idx]
+                path_in_repo = rev_and_path[slash_idx + 1 :]
+        revision = unquote(revision)
+        if not revision:
+            raise ValueError(f"Invalid HF URI '{raw}': empty revision after '@'.")
+
+    try:
+        validate_repo_id(repo_id)
+    except HFValidationError as e:
+        raise ValueError(f"Invalid HF URI '{raw}': {e}") from e
+
+    return HfUri(
+        type=type_,
+        id=repo_id,
+        revision=revision,
+        path_in_repo=path_in_repo,
+        mount_path=mount_path,
+        read_only=read_only,
+    )

--- a/src/huggingface_hub/utils/_hf_uris.py
+++ b/src/huggingface_hub/utils/_hf_uris.py
@@ -61,9 +61,8 @@ class HfUri:
         id (`str`):
             The repository id (e.g. ``"gpt2"`` or ``"my-org/my-model"``) for repo
             URIs, or the bucket id (always ``"namespace/name"``) for bucket URIs.
-            Use the [`repo_id`][huggingface_hub.utils.HfUri.repo_id] and
-            [`bucket_id`][huggingface_hub.utils.HfUri.bucket_id] convenience
-            properties when relevant.
+            Use the [`repo_id`] and [`bucket_id`] convenience properties when
+            relevant.
         revision (`str`, *optional*):
             The revision specified after ``@`` in the URI, URL-decoded.
             ``None`` if no revision was specified, or for bucket URIs (which
@@ -99,7 +98,7 @@ class HfUri:
 
     @property
     def repo_type(self) -> constants.HfUriType:
-        """Alias of [`type`][huggingface_hub.utils.HfUri.type] for repo URIs."""
+        """Alias of [`type`] for repo URIs."""
         if self.is_bucket:
             raise AttributeError("Bucket URIs do not have a `repo_type`. Use `type` or `bucket_id`.")
         return self.type
@@ -161,7 +160,7 @@ def parse_hf_uri(uri: str) -> HfUri:
         [`HfUri`]: the parsed URI.
 
     Raises:
-        [`HfUriError`][huggingface_hub.errors.HfUriError]:
+        [`HfUriError`]:
             If the URI is malformed (missing prefix, invalid type, missing
             id, etc.). Inherits from `ValueError` for backward compatibility.
 

--- a/src/huggingface_hub/utils/_hf_uris.py
+++ b/src/huggingface_hub/utils/_hf_uris.py
@@ -95,9 +95,7 @@ class HfUri:
     def to_uri(self) -> str:
         """Render the URI as a canonical 'hf://' string.
 
-        The type prefix is always written explicitly (e.g. 'hf://models/gpt2',
-        not 'hf://gpt2'). Round-tripping 'parse_hf_uri(uri.to_uri())'
-        always yields the same URI.
+        The type prefix is always written explicitly (e.g. 'hf://models/gpt2', not 'hf://gpt2').
         """
         parts: list[str] = [constants.HF_PROTOCOL, _TYPE_TO_PREFIX[self.type], "/", self.id]
         if self.revision is not None:
@@ -116,13 +114,11 @@ class HfUri:
 def parse_hf_uri(uri: str) -> HfUri:
     """Parse a Hugging Face Hub URI ('hf://...').
 
-    A HF URI is a URI-like string identifying a location on the Hugging Face
-    Hub. The full grammar is::
+    A HF URI is a URI-like string identifying a location on the Hugging Face Hub. The full grammar is::
 
         hf://[<TYPE>/]<ID>[@<REVISION>][/<PATH>][:<MOUNT_PATH>[:ro|:rw]]
 
-    See 'docs/source/en/package_reference/hf_uris.md' for the full
-    specification.
+    See 'docs/source/en/package_reference/hf_uris.md' for the full specification.
 
     Args:
         uri (`str`):
@@ -133,8 +129,7 @@ def parse_hf_uri(uri: str) -> HfUri:
 
     Raises:
         [`HfUriError`]:
-            If the URI is malformed (missing prefix, invalid type, missing
-            id, etc.). Inherits from `ValueError` for backward compatibility.
+            If the URI is malformed (missing prefix, invalid type, missing id, etc.).
 
     Examples:
         ```py
@@ -169,8 +164,7 @@ def parse_hf_uri(uri: str) -> HfUri:
 def _split_mount(body: str, *, raw: str) -> tuple[str, str | None, bool | None]:
     """Split the ':<MOUNT_PATH>[:ro|:rw]' suffix from 'body'.
 
-    Returns '(location, mount_path, read_only)' where 'mount_path' is
-    'None' if no mount segment is present.
+    Returns '(location, mount_path, read_only)' where 'mount_path' is 'None' if no mount segment is present.
     """
     read_only: bool | None = None
     if body.endswith(":ro"):
@@ -180,15 +174,14 @@ def _split_mount(body: str, *, raw: str) -> tuple[str, str | None, bool | None]:
         read_only = False
         body = body[:-3]
 
-    # Mount paths always start with '/', so the delimiter is ':/'. We use
-    # rfind() because the mount segment is always trailing — paths inside
-    # repos may technically contain ':' characters.
+    # Mount paths always start with '/', so the delimiter is ':/'.
+    # We use rfind() because the mount segment is always trailing
     idx = body.rfind(":/")
     if idx == -1:
         if read_only is not None:
             raise HfUriError(
-                f"Invalid HF URI '{raw}': ':ro'/':rw' suffix is only valid when a mount path "
-                "is provided (e.g. 'hf://...:/<MOUNT_PATH>:ro')."
+                f"Invalid HF URI '{raw}': ':ro'/':rw' suffix is only valid when a mount path is provided "
+                "(e.g. 'hf://...:/<MOUNT_PATH>:ro')."
             )
         return body, None, None
 
@@ -198,8 +191,7 @@ def _split_mount(body: str, *, raw: str) -> tuple[str, str | None, bool | None]:
         raise HfUriError(f"Invalid HF URI '{raw}': missing location before mount path.")
     if not mount_path.startswith("/") or mount_path == "/":
         raise HfUriError(
-            f"Invalid HF URI '{raw}': mount path must be a non-empty absolute path "
-            f"starting with '/', got '{mount_path}'."
+            f"Invalid HF URI '{raw}': mount path must be a non-empty absolute path starting with '/', got '{mount_path}'."
         )
     return location, mount_path, read_only
 
@@ -207,21 +199,18 @@ def _split_mount(body: str, *, raw: str) -> tuple[str, str | None, bool | None]:
 def _split_type(location: str, *, raw: str) -> tuple[constants.HfUriType, str]:
     """Detect the (optional) type prefix and return '(type, remaining_location)'.
 
-    A missing type prefix defaults to 'model'. Singular forms ('model/',
-    'dataset/', etc.) are explicitly rejected with a helpful error.
+    A missing type prefix defaults to 'model'. Singular forms ('model/', 'dataset/', etc.) are explicitly rejected with a helpful error.
     """
     slash_idx = location.find("/")
     if slash_idx == -1:
         # Single segment, no prefix. Reject if it looks like a bare type name.
         if location in constants.HF_URI_TYPE_PREFIXES:
             raise HfUriError(
-                f"Invalid HF URI '{raw}': missing identifier after '{location}'. "
-                f"Expected '{constants.HF_PROTOCOL}{location}/<ID>'."
+                f"Invalid HF URI '{raw}': missing identifier after '{location}'. Expected '{constants.HF_PROTOCOL}{location}/<ID>'."
             )
         if (singular_plural := _PLURAL_FROM_SINGULAR_NAME.get(location)) is not None:
             raise HfUriError(
-                f"Invalid HF URI '{raw}': type prefix must be plural. "
-                f"Did you mean '{constants.HF_PROTOCOL}{singular_plural}/...'?"
+                f"Invalid HF URI '{raw}': type prefix must be plural. Did you mean '{constants.HF_PROTOCOL}{singular_plural}/...'?"
             )
         return "model", location
 

--- a/src/huggingface_hub/utils/_hf_uris.py
+++ b/src/huggingface_hub/utils/_hf_uris.py
@@ -114,9 +114,11 @@ class HfUri:
 def parse_hf_uri(uri: str) -> HfUri:
     """Parse a Hugging Face Hub URI ('hf://...').
 
-    A HF URI is a URI-like string identifying a location on the Hugging Face Hub. The full grammar is::
+    A HF URI is a URI-like string identifying a location on the Hugging Face Hub. The full grammar is:
 
-        hf://[<TYPE>/]<ID>[@<REVISION>][/<PATH>][:<MOUNT_PATH>[:ro|:rw]]
+    ```
+    hf://[<TYPE>/]<ID>[@<REVISION>][/<PATH>][:<MOUNT_PATH>[:ro|:rw]]
+    ```
 
     See 'docs/source/en/package_reference/hf_uris.md' for the full specification.
 

--- a/src/huggingface_hub/utils/_hf_uris.py
+++ b/src/huggingface_hub/utils/_hf_uris.py
@@ -11,17 +11,23 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Centralized parser for Hugging Face Hub URIs ('hf://...').
+"""Centralized parser for Hugging Face Hub URIs ('hf://...') and mount specifications.
 
 A HF URI is a URI-like string that identifies a location on the Hugging Face
 Hub: a model/dataset/space/kernel repository, a bucket, optionally a revision,
-optionally a path inside the repo or bucket, and optionally a local mount path
-with a ':ro'/':rw' flag (used by Spaces and Jobs volumes).
+and optionally a path inside the repo or bucket.
 
 Canonical syntax:
 
 ```
-hf://[<TYPE>/]<ID>[@<REVISION>][/<PATH>][:<MOUNT_PATH>[:ro|:rw]]
+hf://[<TYPE>/]<ID>[@<REVISION>][/<PATH>]
+```
+
+A HF mount wraps a HF URI with a local mount path and an optional ':ro'/':rw'
+flag (used by Spaces and Jobs volumes):
+
+```
+hf://[<TYPE>/]<ID>[@<REVISION>][/<PATH>]:<MOUNT_PATH>[:ro|:rw]
 ```
 
 See 'docs/source/en/package_reference/hf_uris.md' for the full grammar and examples.
@@ -67,18 +73,12 @@ class HfUri:
             never carry a revision). Special refs like 'refs/pr/10' and 'refs/convert/parquet' are preserved as-is.
         path_in_repo (`str`):
             The path inside the repo or bucket. Empty string if the URI points at the root.
-        mount_path (`str`, *optional*):
-            The local mount path specified after ':' (always starts with '/'). 'None' if the URI is a plain location URI.
-        read_only (`bool`, *optional*):
-            True if the URI ends with ':ro', False if it ends with ':rw', 'None' if no read/write flag was provided.
     """
 
     type: constants.HfUriType
     id: str
     revision: str | None = None
     path_in_repo: str = ""
-    mount_path: str | None = None
-    read_only: bool | None = None
     _raw: str | None = field(repr=False, hash=False, compare=False, default=None)
 
     def __post_init__(self) -> None:
@@ -108,16 +108,6 @@ class HfUri:
             if self.path_in_repo.startswith("/") or "//" in self.path_in_repo:
                 raise HfUriError(uri=uri, msg=f"Path must not contain empty segments (got '{self.path_in_repo}').")
 
-        # Check valid mount path
-        if self.mount_path is not None:
-            if not self.mount_path.startswith("/") or self.mount_path == "/":
-                raise HfUriError(
-                    uri=uri,
-                    msg=f"Mount path must be a non-empty absolute path starting with '/', got '{self.mount_path}'.",
-                )
-        if self.read_only is not None and self.mount_path is None:
-            raise HfUriError(uri=uri, msg="read_only can only be set when mount_path is provided.")
-
     @property
     def is_bucket(self) -> bool:
         """True if this URI points at a bucket."""
@@ -127,9 +117,6 @@ class HfUri:
     def is_repo(self) -> bool:
         """True if this URI points at a repository (model, dataset, space or kernel)."""
         return self.type != "bucket"
-
-    def __str__(self) -> str:
-        return self.to_uri()
 
     def to_uri(self) -> str:
         """Render the URI as a canonical 'hf://' string.
@@ -147,12 +134,49 @@ class HfUri:
             parts.append(f"@{revision}")
         if self.path_in_repo:
             parts.append(f"/{self.path_in_repo}")
-        if self.mount_path is not None:
-            parts.append(f":{self.mount_path}")
-            if self.read_only is True:
-                parts.append(":ro")
-            elif self.read_only is False:
-                parts.append(":rw")
+        return "".join(parts)
+
+
+@dataclass(frozen=True)
+class HfMount:
+    """A HF URI paired with a local mount path and optional read-only flag.
+
+    Used by Spaces and Jobs to describe volume mounts. The full syntax is:
+
+    ```
+    hf://[<TYPE>/]<ID>[@<REVISION>][/<PATH>]:<MOUNT_PATH>[:ro|:rw]
+    ```
+
+    Attributes:
+        source ([`HfUri`]):
+            The parsed HF URI identifying the Hub resource to mount.
+        mount_path (`str`):
+            The local mount path (always starts with '/').
+        read_only (`bool`, *optional*):
+            True if the mount ends with ':ro', False if it ends with ':rw', 'None' if no flag was provided.
+    """
+
+    source: HfUri
+    mount_path: str
+    read_only: bool | None = None
+    _raw: str | None = field(repr=False, hash=False, compare=False, default=None)
+
+    def __post_init__(self) -> None:
+        raw = self._raw or ""
+        if not self.mount_path.startswith("/") or self.mount_path == "/":
+            raise HfUriError(
+                uri=raw,
+                msg=f"Mount path must be a non-empty absolute path starting with '/', got '{self.mount_path}'.",
+            )
+
+    def to_uri(self) -> str:
+        """Render the mount as a canonical 'hf://' string.
+
+        Example: 'hf://models/my-org/my-model:/data:ro'
+        """
+        parts = [self.source.to_uri(), ":", self.mount_path]
+        if self.read_only is not None:
+            parts.append(":ro" if self.read_only else ":rw")
         return "".join(parts)
 
 
@@ -162,7 +186,7 @@ def parse_hf_uri(uri: str) -> HfUri:
     A HF URI is a URI-like string identifying a location on the Hugging Face Hub. The full grammar is:
 
     ```
-    hf://[<TYPE>/]<ID>[@<REVISION>][/<PATH>][:<MOUNT_PATH>[:ro|:rw]]
+    hf://[<TYPE>/]<ID>[@<REVISION>][/<PATH>]
     ```
 
     See 'docs/source/en/package_reference/hf_uris.md' for the full specification.
@@ -182,18 +206,16 @@ def parse_hf_uri(uri: str) -> HfUri:
         ```py
         >>> from huggingface_hub.utils import parse_hf_uri
         >>> parse_hf_uri("hf://my-org/my-model")
-        HfUri(type='model', id='my-org/my-model', revision=None, path_in_repo='', mount_path=None, read_only=None)
+        HfUri(type='model', id='my-org/my-model', revision=None, path_in_repo='')
         >>> parse_hf_uri("hf://datasets/my-org/my-dataset@refs/pr/3/train.json")
-        HfUri(type='dataset', id='my-org/my-dataset', revision='refs/pr/3', path_in_repo='train.json', mount_path=None, read_only=None)
-        >>> parse_hf_uri("hf://buckets/my-org/my-bucket/sub/dir:/mnt:ro")
-        HfUri(type='bucket', id='my-org/my-bucket', revision=None, path_in_repo='sub/dir', mount_path='/mnt', read_only=True)
+        HfUri(type='dataset', id='my-org/my-dataset', revision='refs/pr/3', path_in_repo='train.json')
         ```
     """
     if not uri.startswith(constants.HF_PROTOCOL):
         raise HfUriError(
             uri,
             f"Must start with '{constants.HF_PROTOCOL}'. "
-            f"Expected format: {constants.HF_PROTOCOL}[<TYPE>/]<ID>[@<REVISION>][/<PATH>][:<MOUNT_PATH>[:ro|:rw]]",
+            f"Expected format: {constants.HF_PROTOCOL}[<TYPE>/]<ID>[@<REVISION>][/<PATH>]",
         )
 
     raw = uri
@@ -201,12 +223,69 @@ def parse_hf_uri(uri: str) -> HfUri:
     if not body:
         raise HfUriError(uri, f"Empty body after '{constants.HF_PROTOCOL}'.")
 
-    location, mount_path, read_only = _split_mount(body, raw=raw)
-    type_, location = _split_type(location, raw=raw)
+    type_, location = _split_type(body, raw=raw)
 
     if type_ == "bucket":
-        return _parse_bucket_body(location, type_, mount_path, read_only, raw=raw)
-    return _parse_repo_body(location, type_, mount_path, read_only, raw=raw)
+        return _parse_bucket_body(location, type_, raw=raw)
+    return _parse_repo_body(location, type_, raw=raw)
+
+
+def parse_hf_mount(mount_str: str) -> HfMount:
+    """Parse a HF mount specification ('hf://...:<MOUNT_PATH>[:ro|:rw]').
+
+    A mount specification is a HF URI followed by a local mount path and an optional read-only/read-write flag.
+    The full grammar is:
+
+    ```
+    hf://[<TYPE>/]<ID>[@<REVISION>][/<PATH>]:<MOUNT_PATH>[:ro|:rw]
+    ```
+
+    See 'docs/source/en/package_reference/hf_uris.md' for the full specification.
+
+    Args:
+        mount_str (`str`):
+            The mount string to parse. Must start with 'hf://' and contain a ':<MOUNT_PATH>' segment.
+
+    Returns:
+        [`HfMount`]: the parsed mount.
+
+    Raises:
+        [`HfUriError`]:
+            If the mount string is malformed (missing mount path, invalid URI, etc.).
+
+    Examples:
+        ```py
+        >>> from huggingface_hub.utils import parse_hf_mount
+        >>> parse_hf_mount("hf://my-org/my-model:/data:ro")
+        HfMount(source=HfUri(type='model', id='my-org/my-model', revision=None, path_in_repo=''), mount_path='/data', read_only=True)
+        >>> parse_hf_mount("hf://buckets/my-org/my-bucket/sub/dir:/mnt:rw")
+        HfMount(source=HfUri(type='bucket', id='my-org/my-bucket', revision=None, path_in_repo='sub/dir'), mount_path='/mnt', read_only=False)
+        ```
+    """
+    if not mount_str.startswith(constants.HF_PROTOCOL):
+        raise HfUriError(
+            uri=mount_str,
+            msg=f"Must start with '{constants.HF_PROTOCOL}'.",
+        )
+
+    raw = mount_str
+    body = mount_str[len(constants.HF_PROTOCOL) :]
+    if not body:
+        raise HfUriError(uri=raw, msg=f"Empty body after '{constants.HF_PROTOCOL}'.")
+
+    location, mount_path, read_only = _split_mount(body, raw=raw)
+
+    if mount_path is None:
+        raise HfUriError(uri=raw, msg="Missing mount path. Expected ':<MOUNT_PATH>' (e.g. 'hf://org/model:/data').")
+
+    # Re-assemble the URI part and parse it
+    uri_str = constants.HF_PROTOCOL + location
+    try:
+        source = parse_hf_uri(uri_str)
+    except HfUriError as e:
+        raise HfUriError(uri=raw, msg=e.msg) from e
+
+    return HfMount(source=source, mount_path=mount_path, read_only=read_only, _raw=raw)
 
 
 def _split_mount(body: str, *, raw: str) -> tuple[str, str | None, bool | None]:
@@ -277,8 +356,6 @@ def _split_type(location: str, *, raw: str) -> tuple[constants.HfUriType, str]:
 def _parse_bucket_body(
     location: str,
     type_: constants.HfUriType,
-    mount_path: str | None,
-    read_only: bool | None,
     *,
     raw: str,
 ) -> HfUri:
@@ -296,8 +373,6 @@ def _parse_bucket_body(
         id=bucket_id,
         revision=None,
         path_in_repo=path_in_bucket,
-        mount_path=mount_path,
-        read_only=read_only,
         _raw=raw,
     )
 
@@ -305,8 +380,6 @@ def _parse_bucket_body(
 def _parse_repo_body(
     location: str,
     type_: constants.HfUriType,
-    mount_path: str | None,
-    read_only: bool | None,
     *,
     raw: str,
 ) -> HfUri:
@@ -357,7 +430,5 @@ def _parse_repo_body(
         id=repo_id,
         revision=revision,
         path_in_repo=path_in_repo,
-        mount_path=mount_path,
-        read_only=read_only,
         _raw=raw,
     )

--- a/src/huggingface_hub/utils/_hf_uris.py
+++ b/src/huggingface_hub/utils/_hf_uris.py
@@ -28,7 +28,8 @@ See 'docs/source/en/package_reference/hf_uris.md' for the full grammar and examp
 """
 
 import re
-from dataclasses import dataclass
+import typing
+from dataclasses import dataclass, field
 from urllib.parse import unquote
 
 from huggingface_hub import constants
@@ -37,7 +38,7 @@ from huggingface_hub.errors import HfUriError, HFValidationError
 from ._validators import validate_repo_id
 
 
-# Inverse map (singular → plural URI prefix). Built once from the canonical
+# Inverse map (singular -> plural URI prefix). Built once from the canonical
 # 'constants.HF_URI_TYPE_PREFIXES' and used to render URIs.
 _TYPE_TO_PREFIX: dict[str, str] = {v: k for k, v in constants.HF_URI_TYPE_PREFIXES.items()}
 
@@ -47,6 +48,9 @@ _TYPE_TO_PREFIX: dict[str, str] = {v: k for k, v in constants.HF_URI_TYPE_PREFIX
 # The conversion name allows the typical git ref characters '[a-zA-Z0-9_.-]'
 # so names like 'parquet-v2' or 'duckdb.v1' round-trip correctly.
 _SPECIAL_REFS_REVISION_REGEX = re.compile(r"^refs/(?:convert/[\w.-]+|pr/\d+)")
+
+# Same as constants.HfUriType, but as a set of strings for easy lookup.
+_VALID_URI_TYPES: frozenset[str] = frozenset(typing.get_args(constants.HfUriType))
 
 
 @dataclass(frozen=True)
@@ -75,6 +79,44 @@ class HfUri:
     path_in_repo: str = ""
     mount_path: str | None = None
     read_only: bool | None = None
+    _raw: str | None = field(repr=False, hash=False, compare=False, default=None)
+
+    def __post_init__(self) -> None:
+        uri = self._raw or ""  # For error messages
+
+        # Check valid URI type
+        if self.type not in _VALID_URI_TYPES:
+            raise HfUriError(uri=uri, msg=f"Invalid type '{self.type}'. Must be one of {sorted(_VALID_URI_TYPES)}.")
+
+        # Check valid ID
+        if not self.id or self.id.count("/") != 1:
+            raise HfUriError(uri=uri, msg=f"Id must be 'namespace/name', got '{self.id}'.")
+        if self.type != "bucket":
+            try:
+                validate_repo_id(self.id)
+            except HFValidationError as e:
+                raise HfUriError(uri=uri, msg=str(e)) from e
+
+        # Check valid revision
+        if self.revision is not None and not self.revision:
+            raise HfUriError(uri=uri, msg="Revision must not be an empty string.")
+        if self.type == "bucket" and self.revision is not None:
+            raise HfUriError(uri=uri, msg="Bucket URIs do not support a revision.")
+
+        # Check valid path in repo
+        if self.path_in_repo:
+            if self.path_in_repo.startswith("/") or "//" in self.path_in_repo:
+                raise HfUriError(uri=uri, msg=f"Path must not contain empty segments (got '{self.path_in_repo}').")
+
+        # Check valid mount path
+        if self.mount_path is not None:
+            if not self.mount_path.startswith("/") or self.mount_path == "/":
+                raise HfUriError(
+                    uri=uri,
+                    msg=f"Mount path must be a non-empty absolute path starting with '/', got '{self.mount_path}'.",
+                )
+        if self.read_only is not None and self.mount_path is None:
+            raise HfUriError(uri=uri, msg="read_only can only be set when mount_path is provided.")
 
     @property
     def is_bucket(self) -> bool:
@@ -248,7 +290,7 @@ def _parse_bucket_body(
     if len(parts) < 2 or not parts[0] or not parts[1]:
         raise HfUriError(uri=raw, msg=f"Bucket id must be 'namespace/name', got '{location}'.")
     bucket_id = f"{parts[0]}/{parts[1]}"
-    path_in_bucket = parts[2].strip("/") if len(parts) >= 3 else ""
+    path_in_bucket = parts[2] if len(parts) >= 3 else ""
     return HfUri(
         type=type_,
         id=bucket_id,
@@ -256,6 +298,7 @@ def _parse_bucket_body(
         path_in_repo=path_in_bucket,
         mount_path=mount_path,
         read_only=read_only,
+        _raw=raw,
     )
 
 
@@ -296,7 +339,7 @@ def _parse_repo_body(
         match = _SPECIAL_REFS_REVISION_REGEX.match(rev_and_path)
         if match is not None:
             revision = match.group()
-            path_in_repo = rev_and_path[len(revision) :].lstrip("/")
+            path_in_repo = rev_and_path[len(revision) :].removeprefix("/")
         else:
             slash_idx = rev_and_path.find("/")
             if slash_idx == -1:
@@ -309,11 +352,6 @@ def _parse_repo_body(
         if not revision:
             raise HfUriError(uri=raw, msg="Empty revision after '@'.")
 
-    try:
-        validate_repo_id(repo_id)
-    except HFValidationError as e:
-        raise HfUriError(uri=raw, msg=str(e)) from e
-
     return HfUri(
         type=type_,
         id=repo_id,
@@ -321,4 +359,5 @@ def _parse_repo_body(
         path_in_repo=path_in_repo,
         mount_path=mount_path,
         read_only=read_only,
+        _raw=raw,
     )

--- a/src/huggingface_hub/utils/_hf_uris.py
+++ b/src/huggingface_hub/utils/_hf_uris.py
@@ -99,7 +99,13 @@ class HfUri:
         """
         parts: list[str] = [constants.HF_PROTOCOL, _TYPE_TO_PREFIX[self.type], "/", self.id]
         if self.revision is not None:
-            parts.append(f"@{self.revision}")
+            # Encode '/' as '%2F' for revisions that would otherwise be split as '<revision>/<path>'
+            # at parse time. Special refs ('refs/pr/N', 'refs/convert/<name>') are kept verbatim
+            # because the parser matches them eagerly.
+            revision = self.revision
+            if "/" in revision and _SPECIAL_REFS_REVISION_REGEX.fullmatch(revision) is None:
+                revision = revision.replace("/", "%2F")
+            parts.append(f"@{revision}")
         if self.path_in_repo:
             parts.append(f"/{self.path_in_repo}")
         if self.mount_path is not None:

--- a/src/huggingface_hub/utils/_hf_uris.py
+++ b/src/huggingface_hub/utils/_hf_uris.py
@@ -58,26 +58,18 @@ class HfUri:
 
     Attributes:
         type (`str`):
-            One of '"model"', '"dataset"', '"space"', '"kernel"' or '"bucket"'.
+            One of 'model', 'dataset', 'space', 'kernel' or 'bucket'.
         id (`str`):
-            The repository id (e.g. '"gpt2"' or '"my-org/my-model"') for repo
-            URIs, or the bucket id (always '"namespace/name"') for bucket URIs.
-            Use the [`repo_id`] and [`bucket_id`] convenience properties when
-            relevant.
+            The repository id (e.g. 'gpt2' or 'my-org/my-model') for repo URIs, or the bucket id (always 'namespace/name') for bucket URIs.
         revision (`str`, *optional*):
-            The revision specified after '@' in the URI, URL-decoded.
-            'None' if no revision was specified, or for bucket URIs (which
-            never carry a revision). Special refs like '"refs/pr/10"' and
-            '"refs/convert/parquet"' are preserved as-is.
+            The revision specified after '@' in the URI, URL-decoded. 'None' if no revision was specified, or for bucket URIs (which
+            never carry a revision). Special refs like 'refs/pr/10' and 'refs/convert/parquet' are preserved as-is.
         path_in_repo (`str`):
-            The path inside the repo or bucket. Empty string if the URI
-            points at the root.
+            The path inside the repo or bucket. Empty string if the URI points at the root.
         mount_path (`str`, *optional*):
-            The local mount path specified after ':' (always starts with '/').
-            'None' if the URI is a plain location URI.
+            The local mount path specified after ':' (always starts with '/'). 'None' if the URI is a plain location URI.
         read_only (`bool`, *optional*):
-            'True' if the URI ends with ':ro', 'False' if it ends with
-            ':rw', 'None' if no read/write flag was provided.
+            True if the URI ends with ':ro', False if it ends with ':rw', 'None' if no read/write flag was provided.
     """
 
     type: constants.HfUriType
@@ -89,34 +81,13 @@ class HfUri:
 
     @property
     def is_bucket(self) -> bool:
-        """'True' if this URI points at a bucket."""
+        """True if this URI points at a bucket."""
         return self.type == "bucket"
 
     @property
     def is_repo(self) -> bool:
-        """'True' if this URI points at a repository (model, dataset, space or kernel)."""
+        """True if this URI points at a repository (model, dataset, space or kernel)."""
         return self.type != "bucket"
-
-    @property
-    def repo_type(self) -> constants.HfUriType:
-        """Alias of [`type`] for repo URIs."""
-        if self.is_bucket:
-            raise AttributeError("Bucket URIs do not have a `repo_type`. Use `type` or `bucket_id`.")
-        return self.type
-
-    @property
-    def repo_id(self) -> str:
-        """Repository id. Raises if the URI is a bucket URI."""
-        if self.is_bucket:
-            raise AttributeError("Bucket URIs do not have a `repo_id`. Use `bucket_id` instead.")
-        return self.id
-
-    @property
-    def bucket_id(self) -> str:
-        """Bucket id. Raises if the URI is not a bucket URI."""
-        if not self.is_bucket:
-            raise AttributeError("Only bucket URIs have a `bucket_id`. Use `repo_id` instead.")
-        return self.id
 
     def __str__(self) -> str:
         return self.to_string()
@@ -236,7 +207,7 @@ def _split_mount(body: str, *, raw: str) -> tuple[str, str | None, bool | None]:
 def _split_type(location: str, *, raw: str) -> tuple[constants.HfUriType, str]:
     """Detect the (optional) type prefix and return '(type, remaining_location)'.
 
-    A missing type prefix defaults to '"model"'. Singular forms ('model/',
+    A missing type prefix defaults to 'model'. Singular forms ('model/',
     'dataset/', etc.) are explicitly rejected with a helpful error.
     """
     slash_idx = location.find("/")

--- a/src/huggingface_hub/utils/_hf_uris.py
+++ b/src/huggingface_hub/utils/_hf_uris.py
@@ -49,7 +49,9 @@ _PLURAL_FROM_SINGULAR_NAME: dict[str, str] = {str(k): v for k, v in _TYPE_TO_PRE
 # Special revisions that contain a '/'. They take precedence when splitting
 # the part after '@' into '<revision>/<path-in-repo>'. Matches 'refs/pr/N'
 # (Pull Request refs) and 'refs/convert/<name>' (e.g. parquet conversions).
-_SPECIAL_REFS_REVISION_REGEX = re.compile(r"^refs/(?:convert/\w+|pr/\d+)")
+# The conversion name allows the typical git ref characters '[a-zA-Z0-9_.-]'
+# so names like 'parquet-v2' or 'duckdb.v1' round-trip correctly.
+_SPECIAL_REFS_REVISION_REGEX = re.compile(r"^refs/(?:convert/[\w.-]+|pr/\d+)")
 
 
 @dataclass(frozen=True)

--- a/tests/test_utils_hf_uris.py
+++ b/tests/test_utils_hf_uris.py
@@ -16,11 +16,13 @@
 import pytest
 
 from huggingface_hub.errors import HfUriError
-from huggingface_hub.utils import HfUri, parse_hf_uri
+from huggingface_hub.utils import HfMount, HfUri, parse_hf_mount, parse_hf_uri
 
 
-# A "success" case is described as (uri, expected_HfUri, expected_roundtrip).
-SUCCESS_CASES: list[tuple[str, HfUri, str]] = [
+# ---------------------------------------------------------------------------
+# HfUri success cases: (uri, expected_HfUri, expected_roundtrip)
+# ---------------------------------------------------------------------------
+URI_SUCCESS_CASES: list[tuple[str, HfUri, str]] = [
     # --- Models ----------------------------------------------------------------
     # Namespaced model (implicit type prefix)
     (
@@ -156,84 +158,13 @@ SUCCESS_CASES: list[tuple[str, HfUri, str]] = [
         HfUri(type="model", id="my-org/my-model", revision="refs/pr/3"),
         "hf://models/my-org/my-model@refs/pr/3",
     ),
-    # --- Mount path + ro/rw ----------------------------------------------------
-    (
-        "hf://my-org/my-model:/data",
-        HfUri(type="model", id="my-org/my-model", mount_path="/data"),
-        "hf://models/my-org/my-model:/data",
-    ),
-    (
-        "hf://my-org/my-model:/data:ro",
-        HfUri(type="model", id="my-org/my-model", mount_path="/data", read_only=True),
-        "hf://models/my-org/my-model:/data:ro",
-    ),
-    (
-        "hf://my-org/my-model:/data:rw",
-        HfUri(type="model", id="my-org/my-model", mount_path="/data", read_only=False),
-        "hf://models/my-org/my-model:/data:rw",
-    ),
-    (
-        "hf://datasets/my-org/my-dataset:/mnt",
-        HfUri(type="dataset", id="my-org/my-dataset", mount_path="/mnt"),
-        "hf://datasets/my-org/my-dataset:/mnt",
-    ),
-    # Mount path with revision
-    (
-        "hf://datasets/my-org/my-dataset@v1:/mnt:ro",
-        HfUri(
-            type="dataset",
-            id="my-org/my-dataset",
-            revision="v1",
-            mount_path="/mnt",
-            read_only=True,
-        ),
-        "hf://datasets/my-org/my-dataset@v1:/mnt:ro",
-    ),
-    # Mount path with sub-path inside repo
-    (
-        "hf://datasets/my-org/my-dataset/train:/mnt",
-        HfUri(
-            type="dataset",
-            id="my-org/my-dataset",
-            path_in_repo="train",
-            mount_path="/mnt",
-        ),
-        "hf://datasets/my-org/my-dataset/train:/mnt",
-    ),
-    # Bucket with mount path and ro/rw
-    (
-        "hf://buckets/my-org/my-bucket:/mnt:rw",
-        HfUri(
-            type="bucket",
-            id="my-org/my-bucket",
-            mount_path="/mnt",
-            read_only=False,
-        ),
-        "hf://buckets/my-org/my-bucket:/mnt:rw",
-    ),
-    # Bucket with sub-path and mount
-    (
-        "hf://buckets/my-org/my-bucket/sub/dir:/mnt:ro",
-        HfUri(
-            type="bucket",
-            id="my-org/my-bucket",
-            path_in_repo="sub/dir",
-            mount_path="/mnt",
-            read_only=True,
-        ),
-        "hf://buckets/my-org/my-bucket/sub/dir:/mnt:ro",
-    ),
-    # Mount path with several path segments
-    (
-        "hf://my-org/my-model:/path/to/mount",
-        HfUri(type="model", id="my-org/my-model", mount_path="/path/to/mount"),
-        "hf://models/my-org/my-model:/path/to/mount",
-    ),
 ]
 
 
-# A "failure" case is '(uri, error_substring)'
-FAILURE_CASES: list[tuple[str, str]] = [
+# ---------------------------------------------------------------------------
+# HfUri failure cases: (uri, error_substring)
+# ---------------------------------------------------------------------------
+URI_FAILURE_CASES: list[tuple[str, str]] = [
     # Missing protocol
     ("gpt2", "Must start with 'hf://'"),
     ("https://huggingface.co/gpt2", "Must start with 'hf://'"),
@@ -257,8 +188,6 @@ FAILURE_CASES: list[tuple[str, str]] = [
     ("hf://datasets/squad", "Repository id must be 'namespace/name'"),
     ("hf://gpt2@v1", "Repository id must be 'namespace/name'"),
     ("hf://gpt2@v1/config.json", "Repository id must be 'namespace/name'"),
-    ("hf://gpt2:/data", "Repository id must be 'namespace/name'"),
-    ("hf://gpt2:/data:ro", "Repository id must be 'namespace/name'"),
     # Buckets must always have namespace/name
     ("hf://buckets/single-segment", "Bucket id must be 'namespace/name'"),
     # Buckets cannot have a revision
@@ -274,11 +203,6 @@ FAILURE_CASES: list[tuple[str, str]] = [
     # Invalid repo id chars (validated by validate_repo_id)
     ("hf://datasets/foo/.invalid", "Repo id must use alphanumeric"),
     ("hf://models/foo--bar/baz", "Cannot have -- or .."),
-    # Mount path that is not absolute
-    ("hf://my-org/my-model:/", "Mount path must be a non-empty absolute path"),
-    # Read-only flag without a mount path
-    ("hf://my-org/my-model:ro", "':ro'/':rw' suffix is only valid"),
-    ("hf://my-org/my-model:rw", "':ro'/':rw' suffix is only valid"),
     # Empty path segments (adjacent slashes)
     ("hf://models/org/m//sub", "empty segments"),
     ("hf://buckets/org/b//sub", "empty segments"),
@@ -288,7 +212,126 @@ FAILURE_CASES: list[tuple[str, str]] = [
 ]
 
 
-@pytest.mark.parametrize(("uri", "expected", "expected_roundtrip"), SUCCESS_CASES)
+# ---------------------------------------------------------------------------
+# HfUri direct init invalid cases: (kwargs, error_substring)
+# ---------------------------------------------------------------------------
+URI_DIRECT_INIT_INVALID_CASES: list[tuple[dict, str]] = [
+    ({"type": "unknown", "id": "org/repo"}, "Invalid type"),
+    ({"type": "model", "id": "gpt2"}, "namespace/name"),
+    ({"type": "model", "id": "a/b/c"}, "namespace/name"),
+    ({"type": "dataset", "id": "foo--bar/baz"}, "Cannot have -- or .."),
+    ({"type": "model", "id": "org/repo", "revision": ""}, "empty string"),
+    ({"type": "bucket", "id": "org/bucket", "revision": "main"}, "do not support a revision"),
+    ({"type": "model", "id": "org/repo", "path_in_repo": "a//b"}, "empty segments"),
+]
+
+
+# ---------------------------------------------------------------------------
+# HfMount success cases: (mount_str, expected_HfMount, expected_roundtrip)
+# ---------------------------------------------------------------------------
+MOUNT_SUCCESS_CASES: list[tuple[str, HfMount, str]] = [
+    (
+        "hf://my-org/my-model:/data",
+        HfMount(source=HfUri(type="model", id="my-org/my-model"), mount_path="/data"),
+        "hf://models/my-org/my-model:/data",
+    ),
+    (
+        "hf://my-org/my-model:/data:ro",
+        HfMount(source=HfUri(type="model", id="my-org/my-model"), mount_path="/data", read_only=True),
+        "hf://models/my-org/my-model:/data:ro",
+    ),
+    (
+        "hf://my-org/my-model:/data:rw",
+        HfMount(source=HfUri(type="model", id="my-org/my-model"), mount_path="/data", read_only=False),
+        "hf://models/my-org/my-model:/data:rw",
+    ),
+    (
+        "hf://datasets/my-org/my-dataset:/mnt",
+        HfMount(source=HfUri(type="dataset", id="my-org/my-dataset"), mount_path="/mnt"),
+        "hf://datasets/my-org/my-dataset:/mnt",
+    ),
+    # Mount path with revision
+    (
+        "hf://datasets/my-org/my-dataset@v1:/mnt:ro",
+        HfMount(
+            source=HfUri(type="dataset", id="my-org/my-dataset", revision="v1"),
+            mount_path="/mnt",
+            read_only=True,
+        ),
+        "hf://datasets/my-org/my-dataset@v1:/mnt:ro",
+    ),
+    # Mount path with sub-path inside repo
+    (
+        "hf://datasets/my-org/my-dataset/train:/mnt",
+        HfMount(
+            source=HfUri(type="dataset", id="my-org/my-dataset", path_in_repo="train"),
+            mount_path="/mnt",
+        ),
+        "hf://datasets/my-org/my-dataset/train:/mnt",
+    ),
+    # Bucket with mount path and ro/rw
+    (
+        "hf://buckets/my-org/my-bucket:/mnt:rw",
+        HfMount(
+            source=HfUri(type="bucket", id="my-org/my-bucket"),
+            mount_path="/mnt",
+            read_only=False,
+        ),
+        "hf://buckets/my-org/my-bucket:/mnt:rw",
+    ),
+    # Bucket with sub-path and mount
+    (
+        "hf://buckets/my-org/my-bucket/sub/dir:/mnt:ro",
+        HfMount(
+            source=HfUri(type="bucket", id="my-org/my-bucket", path_in_repo="sub/dir"),
+            mount_path="/mnt",
+            read_only=True,
+        ),
+        "hf://buckets/my-org/my-bucket/sub/dir:/mnt:ro",
+    ),
+    # Mount path with several path segments
+    (
+        "hf://my-org/my-model:/path/to/mount",
+        HfMount(source=HfUri(type="model", id="my-org/my-model"), mount_path="/path/to/mount"),
+        "hf://models/my-org/my-model:/path/to/mount",
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# HfMount failure cases: (mount_str, error_substring)
+# ---------------------------------------------------------------------------
+MOUNT_FAILURE_CASES: list[tuple[str, str]] = [
+    # Missing protocol
+    ("my-org/my-model:/data", "Must start with 'hf://'"),
+    # Missing mount path entirely
+    ("hf://my-org/my-model", "Missing mount path"),
+    # Mount path that is just '/'
+    ("hf://my-org/my-model:/", "Mount path must be a non-empty absolute path"),
+    # Read-only flag without a mount path
+    ("hf://my-org/my-model:ro", "':ro'/':rw' suffix is only valid"),
+    ("hf://my-org/my-model:rw", "':ro'/':rw' suffix is only valid"),
+    # Invalid URI inside the mount (canonical repo without namespace)
+    ("hf://gpt2:/data", "Repository id must be 'namespace/name'"),
+    ("hf://gpt2:/data:ro", "Repository id must be 'namespace/name'"),
+]
+
+
+# ---------------------------------------------------------------------------
+# HfMount direct init invalid cases: (kwargs, error_substring)
+# ---------------------------------------------------------------------------
+MOUNT_DIRECT_INIT_INVALID_CASES: list[tuple[dict, str]] = [
+    ({"source": HfUri(type="model", id="org/repo"), "mount_path": "relative"}, "absolute path"),
+    ({"source": HfUri(type="model", id="org/repo"), "mount_path": "/"}, "absolute path"),
+]
+
+
+# ===========================================================================
+# Tests
+# ===========================================================================
+
+
+@pytest.mark.parametrize(("uri", "expected", "expected_roundtrip"), URI_SUCCESS_CASES)
 def test_parse_hf_uri_success(uri: str, expected: HfUri, expected_roundtrip: str) -> None:
     result = parse_hf_uri(uri)
     assert result == expected
@@ -297,27 +340,36 @@ def test_parse_hf_uri_success(uri: str, expected: HfUri, expected_roundtrip: str
     assert parse_hf_uri(expected_roundtrip) == expected
 
 
-@pytest.mark.parametrize(("uri", "error_substring"), FAILURE_CASES)
+@pytest.mark.parametrize(("uri", "error_substring"), URI_FAILURE_CASES)
 def test_parse_hf_uri_failure(uri: str, error_substring: str) -> None:
     with pytest.raises(HfUriError, match=error_substring) as exc_info:
         parse_hf_uri(uri)
     assert exc_info.value.uri == uri
 
 
-DIRECT_INIT_INVALID_CASES: list[tuple[dict, str]] = [
-    ({"type": "unknown", "id": "org/repo"}, "Invalid type"),
-    ({"type": "model", "id": "gpt2"}, "namespace/name"),
-    ({"type": "model", "id": "a/b/c"}, "namespace/name"),
-    ({"type": "dataset", "id": "foo--bar/baz"}, "Cannot have -- or .."),
-    ({"type": "model", "id": "org/repo", "revision": ""}, "empty string"),
-    ({"type": "bucket", "id": "org/bucket", "revision": "main"}, "do not support a revision"),
-    ({"type": "model", "id": "org/repo", "path_in_repo": "a//b"}, "empty segments"),
-    ({"type": "model", "id": "org/repo", "mount_path": "relative"}, "absolute path"),
-    ({"type": "model", "id": "org/repo", "read_only": True}, "read_only"),
-]
-
-
-@pytest.mark.parametrize(("kwargs", "error_substring"), DIRECT_INIT_INVALID_CASES)
+@pytest.mark.parametrize(("kwargs", "error_substring"), URI_DIRECT_INIT_INVALID_CASES)
 def test_hf_uri_direct_init_invalid(kwargs: dict, error_substring: str) -> None:
     with pytest.raises(HfUriError, match=error_substring):
         HfUri(**kwargs)
+
+
+@pytest.mark.parametrize(("mount_str", "expected", "expected_roundtrip"), MOUNT_SUCCESS_CASES)
+def test_parse_hf_mount_success(mount_str: str, expected: HfMount, expected_roundtrip: str) -> None:
+    result = parse_hf_mount(mount_str)
+    assert result == expected
+    assert result.to_uri() == expected_roundtrip
+    # Re-parsing the canonical form must yield the same mount (idempotency).
+    assert parse_hf_mount(expected_roundtrip) == expected
+
+
+@pytest.mark.parametrize(("mount_str", "error_substring"), MOUNT_FAILURE_CASES)
+def test_parse_hf_mount_failure(mount_str: str, error_substring: str) -> None:
+    with pytest.raises(HfUriError, match=error_substring) as exc_info:
+        parse_hf_mount(mount_str)
+    assert exc_info.value.uri == mount_str
+
+
+@pytest.mark.parametrize(("kwargs", "error_substring"), MOUNT_DIRECT_INIT_INVALID_CASES)
+def test_hf_mount_direct_init_invalid(kwargs: dict, error_substring: str) -> None:
+    with pytest.raises(HfUriError, match=error_substring):
+        HfMount(**kwargs)

--- a/tests/test_utils_hf_uris.py
+++ b/tests/test_utils_hf_uris.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests for the centralized HF URI parser (``huggingface_hub.utils._hf_uris``)."""
+"""Tests for the centralized HF URI parser ('huggingface_hub.utils._hf_uris')."""
 
 import pytest
 
@@ -19,12 +19,7 @@ from huggingface_hub.errors import HfUriError
 from huggingface_hub.utils import HfUri, parse_hf_uri
 
 
-# A "success" case is described as ``(uri, expected_HfUri, expected_roundtrip)``.
-# - ``uri``: the input string fed to ``parse_hf_uri``.
-# - ``expected_HfUri``: the expected parsed value.
-# - ``expected_roundtrip``: the expected output of ``HfUri.to_string()``. May
-#   differ from the input when the URI is reformatted (implicit ``models/``
-#   prefix added, URL-encoded revision decoded, ...).
+# A "success" case is described as (uri, expected_HfUri, expected_roundtrip).
 SUCCESS_CASES: list[tuple[str, HfUri, str]] = [
     # --- Models ----------------------------------------------------------------
     # Canonical model id, no namespace
@@ -33,7 +28,7 @@ SUCCESS_CASES: list[tuple[str, HfUri, str]] = [
         HfUri(type="model", id="gpt2"),
         "hf://models/gpt2",
     ),
-    # Canonical model id with explicit ``models/`` prefix
+    # Canonical model id with explicit 'models/' prefix
     (
         "hf://models/gpt2",
         HfUri(type="model", id="gpt2"),
@@ -75,7 +70,7 @@ SUCCESS_CASES: list[tuple[str, HfUri, str]] = [
         "hf://models/gpt2@main/config.json",
     ),
     # --- Datasets --------------------------------------------------------------
-    # Canonical dataset (single-segment id, e.g. ``squad``, ``glue``)
+    # Canonical dataset (single-segment id, e.g. 'squad', 'glue')
     (
         "hf://datasets/squad",
         HfUri(type="dataset", id="squad"),
@@ -232,8 +227,7 @@ SUCCESS_CASES: list[tuple[str, HfUri, str]] = [
 ]
 
 
-# A "failure" case is ``(uri, error_substring)``: ``parse_hf_uri(uri)`` must
-# raise a ``ValueError`` whose message contains ``error_substring``.
+# A "failure" case is '(uri, error_substring)'
 FAILURE_CASES: list[tuple[str, str]] = [
     # Missing protocol
     ("gpt2", "must start with 'hf://'"),
@@ -279,7 +273,6 @@ FAILURE_CASES: list[tuple[str, str]] = [
 
 @pytest.mark.parametrize(("uri", "expected", "expected_roundtrip"), SUCCESS_CASES)
 def test_parse_hf_uri_success(uri: str, expected: HfUri, expected_roundtrip: str) -> None:
-    """``parse_hf_uri`` returns the expected ``HfUri`` and round-trips back to a canonical string."""
     result = parse_hf_uri(uri)
     assert result == expected
     assert result.to_string() == expected_roundtrip
@@ -289,16 +282,8 @@ def test_parse_hf_uri_success(uri: str, expected: HfUri, expected_roundtrip: str
 
 @pytest.mark.parametrize(("uri", "error_substring"), FAILURE_CASES)
 def test_parse_hf_uri_failure(uri: str, error_substring: str) -> None:
-    """``parse_hf_uri`` rejects malformed URIs with a helpful error message."""
     with pytest.raises(HfUriError, match=error_substring):
         parse_hf_uri(uri)
-
-
-def test_hf_uri_error_inherits_from_value_error() -> None:
-    """``HfUriError`` must keep ``ValueError`` as a base class for backward compatibility."""
-    assert issubclass(HfUriError, ValueError)
-    with pytest.raises(ValueError):
-        parse_hf_uri("not-a-uri")
 
 
 # --- A few targeted tests not easily expressed as parametrized cases. ---------
@@ -307,19 +292,19 @@ def test_hf_uri_error_inherits_from_value_error() -> None:
 def test_repo_id_property_on_bucket_uri_raises() -> None:
     uri = parse_hf_uri("hf://buckets/org/b")
     with pytest.raises(AttributeError, match="bucket_id"):
-        uri.repo_id  # noqa: B018
+        uri.repo_id
 
 
 def test_bucket_id_property_on_repo_uri_raises() -> None:
     uri = parse_hf_uri("hf://datasets/org/ds")
     with pytest.raises(AttributeError, match="repo_id"):
-        uri.bucket_id  # noqa: B018
+        uri.bucket_id
 
 
 def test_repo_type_property_on_bucket_uri_raises() -> None:
     uri = parse_hf_uri("hf://buckets/org/b")
     with pytest.raises(AttributeError, match="repo_type"):
-        uri.repo_type  # noqa: B018
+        uri.repo_type
 
 
 def test_is_repo_and_is_bucket_are_mutually_exclusive() -> None:
@@ -327,14 +312,3 @@ def test_is_repo_and_is_bucket_are_mutually_exclusive() -> None:
     assert repo_uri.is_repo and not repo_uri.is_bucket
     bucket_uri = parse_hf_uri("hf://buckets/org/b")
     assert bucket_uri.is_bucket and not bucket_uri.is_repo
-
-
-def test_to_string_always_includes_type_prefix_for_models() -> None:
-    """Even when the input omitted the ``models/`` prefix, the canonical form keeps it."""
-    uri = parse_hf_uri("hf://gpt2")
-    assert uri.to_string() == "hf://models/gpt2"
-
-
-def test_uri_str_is_to_string() -> None:
-    uri = parse_hf_uri("hf://datasets/my-org/my-dataset@v1/file.csv")
-    assert str(uri) == uri.to_string()

--- a/tests/test_utils_hf_uris.py
+++ b/tests/test_utils_hf_uris.py
@@ -139,6 +139,27 @@ SUCCESS_CASES: list[tuple[str, HfUri, str]] = [
         ),
         "hf://datasets/foo/bar@refs/convert/parquet/data.parquet",
     ),
+    # Convert ref name with hyphen (and dot) — must not be split at the hyphen.
+    (
+        "hf://datasets/foo/bar@refs/convert/parquet-v2/data.parquet",
+        HfUri(
+            type="dataset",
+            id="foo/bar",
+            revision="refs/convert/parquet-v2",
+            path_in_repo="data.parquet",
+        ),
+        "hf://datasets/foo/bar@refs/convert/parquet-v2/data.parquet",
+    ),
+    (
+        "hf://datasets/foo/bar@refs/convert/duckdb.v1/data.db",
+        HfUri(
+            type="dataset",
+            id="foo/bar",
+            revision="refs/convert/duckdb.v1",
+            path_in_repo="data.db",
+        ),
+        "hf://datasets/foo/bar@refs/convert/duckdb.v1/data.db",
+    ),
     # URL-encoded special revision
     (
         "hf://datasets/foo/bar@refs%2Fpr%2F10/file.csv",

--- a/tests/test_utils_hf_uris.py
+++ b/tests/test_utils_hf_uris.py
@@ -13,10 +13,9 @@
 # limitations under the License.
 """Tests for the centralized HF URI parser (``huggingface_hub.utils._hf_uris``)."""
 
-from __future__ import annotations
-
 import pytest
 
+from huggingface_hub.errors import HfUriError
 from huggingface_hub.utils import HfUri, parse_hf_uri
 
 
@@ -291,8 +290,15 @@ def test_parse_hf_uri_success(uri: str, expected: HfUri, expected_roundtrip: str
 @pytest.mark.parametrize(("uri", "error_substring"), FAILURE_CASES)
 def test_parse_hf_uri_failure(uri: str, error_substring: str) -> None:
     """``parse_hf_uri`` rejects malformed URIs with a helpful error message."""
-    with pytest.raises(ValueError, match=error_substring):
+    with pytest.raises(HfUriError, match=error_substring):
         parse_hf_uri(uri)
+
+
+def test_hf_uri_error_inherits_from_value_error() -> None:
+    """``HfUriError`` must keep ``ValueError`` as a base class for backward compatibility."""
+    assert issubclass(HfUriError, ValueError)
+    with pytest.raises(ValueError):
+        parse_hf_uri("not-a-uri")
 
 
 # --- A few targeted tests not easily expressed as parametrized cases. ---------

--- a/tests/test_utils_hf_uris.py
+++ b/tests/test_utils_hf_uris.py
@@ -22,24 +22,13 @@ from huggingface_hub.utils import HfUri, parse_hf_uri
 # A "success" case is described as (uri, expected_HfUri, expected_roundtrip).
 SUCCESS_CASES: list[tuple[str, HfUri, str]] = [
     # --- Models ----------------------------------------------------------------
-    # Canonical model id, no namespace
-    (
-        "hf://gpt2",
-        HfUri(type="model", id="gpt2"),
-        "hf://models/gpt2",
-    ),
-    # Canonical model id with explicit 'models/' prefix
-    (
-        "hf://models/gpt2",
-        HfUri(type="model", id="gpt2"),
-        "hf://models/gpt2",
-    ),
-    # Namespaced model
+    # Namespaced model (implicit type prefix)
     (
         "hf://my-org/my-model",
         HfUri(type="model", id="my-org/my-model"),
         "hf://models/my-org/my-model",
     ),
+    # Namespaced model (explicit type prefix)
     (
         "hf://models/my-org/my-model",
         HfUri(type="model", id="my-org/my-model"),
@@ -63,19 +52,7 @@ SUCCESS_CASES: list[tuple[str, HfUri, str]] = [
         HfUri(type="model", id="my-org/my-model", revision="dev", path_in_repo="sub/file.bin"),
         "hf://models/my-org/my-model@dev/sub/file.bin",
     ),
-    # Canonical model with path
-    (
-        "hf://gpt2@main/config.json",
-        HfUri(type="model", id="gpt2", revision="main", path_in_repo="config.json"),
-        "hf://models/gpt2@main/config.json",
-    ),
     # --- Datasets --------------------------------------------------------------
-    # Canonical dataset (single-segment id, e.g. 'squad', 'glue')
-    (
-        "hf://datasets/squad",
-        HfUri(type="dataset", id="squad"),
-        "hf://datasets/squad",
-    ),
     (
         "hf://datasets/my-org/my-dataset",
         HfUri(type="dataset", id="my-org/my-dataset"),
@@ -169,31 +146,31 @@ SUCCESS_CASES: list[tuple[str, HfUri, str]] = [
     # Branch name containing '/' (e.g. 'feature/foo'). Must be URL-encoded so that the
     # parser does not split it at the first '/' and treat the rest as a path-in-repo.
     (
-        "hf://gpt2@feature%2Ffoo/config.json",
-        HfUri(type="model", id="gpt2", revision="feature/foo", path_in_repo="config.json"),
-        "hf://models/gpt2@feature%2Ffoo/config.json",
+        "hf://my-org/my-model@feature%2Ffoo/config.json",
+        HfUri(type="model", id="my-org/my-model", revision="feature/foo", path_in_repo="config.json"),
+        "hf://models/my-org/my-model@feature%2Ffoo/config.json",
     ),
     # Special revision with no path after it
     (
-        "hf://gpt2@refs/pr/3",
-        HfUri(type="model", id="gpt2", revision="refs/pr/3"),
-        "hf://models/gpt2@refs/pr/3",
+        "hf://my-org/my-model@refs/pr/3",
+        HfUri(type="model", id="my-org/my-model", revision="refs/pr/3"),
+        "hf://models/my-org/my-model@refs/pr/3",
     ),
     # --- Mount path + ro/rw ----------------------------------------------------
     (
-        "hf://gpt2:/data",
-        HfUri(type="model", id="gpt2", mount_path="/data"),
-        "hf://models/gpt2:/data",
+        "hf://my-org/my-model:/data",
+        HfUri(type="model", id="my-org/my-model", mount_path="/data"),
+        "hf://models/my-org/my-model:/data",
     ),
     (
-        "hf://gpt2:/data:ro",
-        HfUri(type="model", id="gpt2", mount_path="/data", read_only=True),
-        "hf://models/gpt2:/data:ro",
+        "hf://my-org/my-model:/data:ro",
+        HfUri(type="model", id="my-org/my-model", mount_path="/data", read_only=True),
+        "hf://models/my-org/my-model:/data:ro",
     ),
     (
-        "hf://gpt2:/data:rw",
-        HfUri(type="model", id="gpt2", mount_path="/data", read_only=False),
-        "hf://models/gpt2:/data:rw",
+        "hf://my-org/my-model:/data:rw",
+        HfUri(type="model", id="my-org/my-model", mount_path="/data", read_only=False),
+        "hf://models/my-org/my-model:/data:rw",
     ),
     (
         "hf://datasets/my-org/my-dataset:/mnt",
@@ -248,9 +225,9 @@ SUCCESS_CASES: list[tuple[str, HfUri, str]] = [
     ),
     # Mount path with several path segments
     (
-        "hf://gpt2:/path/to/mount",
-        HfUri(type="model", id="gpt2", mount_path="/path/to/mount"),
-        "hf://models/gpt2:/path/to/mount",
+        "hf://my-org/my-model:/path/to/mount",
+        HfUri(type="model", id="my-org/my-model", mount_path="/path/to/mount"),
+        "hf://models/my-org/my-model:/path/to/mount",
     ),
 ]
 
@@ -271,29 +248,37 @@ FAILURE_CASES: list[tuple[str, str]] = [
     ("hf://buckets/", "bucket id must be 'namespace/name'"),
     # Singular type forms are forbidden
     ("hf://dataset/foo/bar", "must be plural"),
-    ("hf://model/gpt2", "must be plural"),
+    ("hf://model/my-org/my-model", "must be plural"),
     ("hf://space/user/my-space", "must be plural"),
     ("hf://bucket/org/b", "must be plural"),
+    # Canonical repos (no namespace) are forbidden
+    ("hf://gpt2", "Canonical repos"),
+    ("hf://models/gpt2", "Canonical repos"),
+    ("hf://datasets/squad", "Canonical repos"),
+    ("hf://gpt2@v1", "Canonical repos"),
+    ("hf://gpt2@v1/config.json", "Canonical repos"),
+    ("hf://gpt2:/data", "Canonical repos"),
+    ("hf://gpt2:/data:ro", "Canonical repos"),
     # Buckets must always have namespace/name
     ("hf://buckets/single-segment", "bucket id must be 'namespace/name'"),
     # Buckets cannot have a revision
     ("hf://buckets/org/b@v1", "do not support a revision"),
     ("hf://buckets/org/b@v1/path", "do not support a revision"),
     # Empty revision
-    ("hf://gpt2@", "empty revision"),
+    ("hf://my-org/my-model@", "empty revision"),
     ("hf://datasets/foo/bar@/file", "empty revision"),
     # Empty repo id before '@'
     ("hf://@v1/file", "missing repository id"),
     # Repo id with too many slashes
-    ("hf://a/b/c@v1", "repository id must be 'name' or 'namespace/name'"),
+    ("hf://a/b/c@v1", "repository id must be 'namespace/name'"),
     # Invalid repo id chars (validated by validate_repo_id)
     ("hf://datasets/foo/.invalid", "Repo id must use alphanumeric"),
-    ("hf://models/foo--bar", "Cannot have -- or .."),
+    ("hf://models/foo--bar/baz", "Cannot have -- or .."),
     # Mount path that is not absolute
-    ("hf://gpt2:/", "mount path must be a non-empty absolute path"),
+    ("hf://my-org/my-model:/", "mount path must be a non-empty absolute path"),
     # Read-only flag without a mount path
-    ("hf://gpt2:ro", "':ro'/':rw' suffix is only valid"),
-    ("hf://gpt2:rw", "':ro'/':rw' suffix is only valid"),
+    ("hf://my-org/my-model:ro", "':ro'/':rw' suffix is only valid"),
+    ("hf://my-org/my-model:rw", "':ro'/':rw' suffix is only valid"),
 ]
 
 

--- a/tests/test_utils_hf_uris.py
+++ b/tests/test_utils_hf_uris.py
@@ -279,6 +279,12 @@ FAILURE_CASES: list[tuple[str, str]] = [
     # Read-only flag without a mount path
     ("hf://my-org/my-model:ro", "':ro'/':rw' suffix is only valid"),
     ("hf://my-org/my-model:rw", "':ro'/':rw' suffix is only valid"),
+    # Empty path segments (adjacent slashes)
+    ("hf://models/org/m//sub", "empty segments"),
+    ("hf://buckets/org/b//sub", "empty segments"),
+    ("hf://models/org/m/sub//dir", "empty segments"),
+    ("hf://models/org/m@main//file.txt", "empty segments"),
+    ("hf://datasets/foo/bar@refs/pr/10//file.csv", "empty segments"),
 ]
 
 
@@ -296,3 +302,22 @@ def test_parse_hf_uri_failure(uri: str, error_substring: str) -> None:
     with pytest.raises(HfUriError, match=error_substring) as exc_info:
         parse_hf_uri(uri)
     assert exc_info.value.uri == uri
+
+
+DIRECT_INIT_INVALID_CASES: list[tuple[dict, str]] = [
+    ({"type": "unknown", "id": "org/repo"}, "Invalid type"),
+    ({"type": "model", "id": "gpt2"}, "namespace/name"),
+    ({"type": "model", "id": "a/b/c"}, "namespace/name"),
+    ({"type": "dataset", "id": "foo--bar/baz"}, "Cannot have -- or .."),
+    ({"type": "model", "id": "org/repo", "revision": ""}, "empty string"),
+    ({"type": "bucket", "id": "org/bucket", "revision": "main"}, "do not support a revision"),
+    ({"type": "model", "id": "org/repo", "path_in_repo": "a//b"}, "empty segments"),
+    ({"type": "model", "id": "org/repo", "mount_path": "relative"}, "absolute path"),
+    ({"type": "model", "id": "org/repo", "read_only": True}, "read_only"),
+]
+
+
+@pytest.mark.parametrize(("kwargs", "error_substring"), DIRECT_INIT_INVALID_CASES)
+def test_hf_uri_direct_init_invalid(kwargs: dict, error_substring: str) -> None:
+    with pytest.raises(HfUriError, match=error_substring):
+        HfUri(**kwargs)

--- a/tests/test_utils_hf_uris.py
+++ b/tests/test_utils_hf_uris.py
@@ -289,24 +289,6 @@ def test_parse_hf_uri_failure(uri: str, error_substring: str) -> None:
 # --- A few targeted tests not easily expressed as parametrized cases. ---------
 
 
-def test_repo_id_property_on_bucket_uri_raises() -> None:
-    uri = parse_hf_uri("hf://buckets/org/b")
-    with pytest.raises(AttributeError, match="bucket_id"):
-        uri.repo_id
-
-
-def test_bucket_id_property_on_repo_uri_raises() -> None:
-    uri = parse_hf_uri("hf://datasets/org/ds")
-    with pytest.raises(AttributeError, match="repo_id"):
-        uri.bucket_id
-
-
-def test_repo_type_property_on_bucket_uri_raises() -> None:
-    uri = parse_hf_uri("hf://buckets/org/b")
-    with pytest.raises(AttributeError, match="repo_type"):
-        uri.repo_type
-
-
 def test_is_repo_and_is_bucket_are_mutually_exclusive() -> None:
     repo_uri = parse_hf_uri("hf://datasets/org/ds")
     assert repo_uri.is_repo and not repo_uri.is_bucket

--- a/tests/test_utils_hf_uris.py
+++ b/tests/test_utils_hf_uris.py
@@ -275,7 +275,7 @@ FAILURE_CASES: list[tuple[str, str]] = [
 def test_parse_hf_uri_success(uri: str, expected: HfUri, expected_roundtrip: str) -> None:
     result = parse_hf_uri(uri)
     assert result == expected
-    assert result.to_string() == expected_roundtrip
+    assert result.to_uri() == expected_roundtrip
     # Re-parsing the canonical form must yield the same URI (idempotency).
     assert parse_hf_uri(expected_roundtrip) == expected
 
@@ -294,3 +294,15 @@ def test_is_repo_and_is_bucket_are_mutually_exclusive() -> None:
     assert repo_uri.is_repo and not repo_uri.is_bucket
     bucket_uri = parse_hf_uri("hf://buckets/org/b")
     assert bucket_uri.is_bucket and not bucket_uri.is_repo
+
+
+def test_uri_str_is_to_uri() -> None:
+    uri = parse_hf_uri("hf://datasets/my-org/my-dataset@v1/file.csv")
+    assert str(uri) == uri.to_uri()
+
+
+def test_hf_uri_error_inherits_from_value_error() -> None:
+    """HfUriError must keep ValueError as a base class for backward compatibility."""
+    assert issubclass(HfUriError, ValueError)
+    with pytest.raises(ValueError):
+        parse_hf_uri("not-a-uri")

--- a/tests/test_utils_hf_uris.py
+++ b/tests/test_utils_hf_uris.py
@@ -235,47 +235,47 @@ SUCCESS_CASES: list[tuple[str, HfUri, str]] = [
 # A "failure" case is '(uri, error_substring)'
 FAILURE_CASES: list[tuple[str, str]] = [
     # Missing protocol
-    ("gpt2", "must start with 'hf://'"),
-    ("https://huggingface.co/gpt2", "must start with 'hf://'"),
-    ("hf:/gpt2", "must start with 'hf://'"),
+    ("gpt2", "Must start with 'hf://'"),
+    ("https://huggingface.co/gpt2", "Must start with 'hf://'"),
+    ("hf:/gpt2", "Must start with 'hf://'"),
     # Empty body after protocol
-    ("hf://", "empty body"),
+    ("hf://", "Empty body"),
     # Empty repo id (just a type prefix)
-    ("hf://datasets", "missing identifier"),
-    ("hf://datasets/", "missing repository id"),
-    ("hf://models/", "missing repository id"),
-    ("hf://buckets", "missing identifier"),
-    ("hf://buckets/", "bucket id must be 'namespace/name'"),
+    ("hf://datasets", "Missing identifier"),
+    ("hf://datasets/", "Missing repository id"),
+    ("hf://models/", "Missing repository id"),
+    ("hf://buckets", "Missing identifier"),
+    ("hf://buckets/", "Bucket id must be 'namespace/name'"),
     # Singular type forms are forbidden
-    ("hf://dataset/foo/bar", "must be plural"),
-    ("hf://model/my-org/my-model", "must be plural"),
-    ("hf://space/user/my-space", "must be plural"),
-    ("hf://bucket/org/b", "must be plural"),
+    ("hf://dataset/foo/bar", "Type prefix must be plural"),
+    ("hf://model/my-org/my-model", "Type prefix must be plural"),
+    ("hf://space/user/my-space", "Type prefix must be plural"),
+    ("hf://bucket/org/b", "Type prefix must be plural"),
     # Canonical repos (no namespace) are forbidden
-    ("hf://gpt2", "Canonical repos"),
-    ("hf://models/gpt2", "Canonical repos"),
-    ("hf://datasets/squad", "Canonical repos"),
-    ("hf://gpt2@v1", "Canonical repos"),
-    ("hf://gpt2@v1/config.json", "Canonical repos"),
-    ("hf://gpt2:/data", "Canonical repos"),
-    ("hf://gpt2:/data:ro", "Canonical repos"),
+    ("hf://gpt2", "Repository id must be 'namespace/name'"),
+    ("hf://models/gpt2", "Repository id must be 'namespace/name'"),
+    ("hf://datasets/squad", "Repository id must be 'namespace/name'"),
+    ("hf://gpt2@v1", "Repository id must be 'namespace/name'"),
+    ("hf://gpt2@v1/config.json", "Repository id must be 'namespace/name'"),
+    ("hf://gpt2:/data", "Repository id must be 'namespace/name'"),
+    ("hf://gpt2:/data:ro", "Repository id must be 'namespace/name'"),
     # Buckets must always have namespace/name
-    ("hf://buckets/single-segment", "bucket id must be 'namespace/name'"),
+    ("hf://buckets/single-segment", "Bucket id must be 'namespace/name'"),
     # Buckets cannot have a revision
     ("hf://buckets/org/b@v1", "do not support a revision"),
     ("hf://buckets/org/b@v1/path", "do not support a revision"),
     # Empty revision
-    ("hf://my-org/my-model@", "empty revision"),
-    ("hf://datasets/foo/bar@/file", "empty revision"),
+    ("hf://my-org/my-model@", "Empty revision"),
+    ("hf://datasets/foo/bar@/file", "Empty revision"),
     # Empty repo id before '@'
-    ("hf://@v1/file", "missing repository id"),
+    ("hf://@v1/file", "Missing repository id"),
     # Repo id with too many slashes
-    ("hf://a/b/c@v1", "repository id must be 'namespace/name'"),
+    ("hf://a/b/c@v1", "Repository id must be 'namespace/name'"),
     # Invalid repo id chars (validated by validate_repo_id)
     ("hf://datasets/foo/.invalid", "Repo id must use alphanumeric"),
     ("hf://models/foo--bar/baz", "Cannot have -- or .."),
     # Mount path that is not absolute
-    ("hf://my-org/my-model:/", "mount path must be a non-empty absolute path"),
+    ("hf://my-org/my-model:/", "Mount path must be a non-empty absolute path"),
     # Read-only flag without a mount path
     ("hf://my-org/my-model:ro", "':ro'/':rw' suffix is only valid"),
     ("hf://my-org/my-model:rw", "':ro'/':rw' suffix is only valid"),
@@ -293,27 +293,6 @@ def test_parse_hf_uri_success(uri: str, expected: HfUri, expected_roundtrip: str
 
 @pytest.mark.parametrize(("uri", "error_substring"), FAILURE_CASES)
 def test_parse_hf_uri_failure(uri: str, error_substring: str) -> None:
-    with pytest.raises(HfUriError, match=error_substring):
+    with pytest.raises(HfUriError, match=error_substring) as exc_info:
         parse_hf_uri(uri)
-
-
-# --- A few targeted tests not easily expressed as parametrized cases. ---------
-
-
-def test_is_repo_and_is_bucket_are_mutually_exclusive() -> None:
-    repo_uri = parse_hf_uri("hf://datasets/org/ds")
-    assert repo_uri.is_repo and not repo_uri.is_bucket
-    bucket_uri = parse_hf_uri("hf://buckets/org/b")
-    assert bucket_uri.is_bucket and not bucket_uri.is_repo
-
-
-def test_uri_str_is_to_uri() -> None:
-    uri = parse_hf_uri("hf://datasets/my-org/my-dataset@v1/file.csv")
-    assert str(uri) == uri.to_uri()
-
-
-def test_hf_uri_error_inherits_from_value_error() -> None:
-    """HfUriError must keep ValueError as a base class for backward compatibility."""
-    assert issubclass(HfUriError, ValueError)
-    with pytest.raises(ValueError):
-        parse_hf_uri("not-a-uri")
+    assert exc_info.value.uri == uri

--- a/tests/test_utils_hf_uris.py
+++ b/tests/test_utils_hf_uris.py
@@ -294,8 +294,6 @@ FAILURE_CASES: list[tuple[str, str]] = [
     # Read-only flag without a mount path
     ("hf://gpt2:ro", "':ro'/':rw' suffix is only valid"),
     ("hf://gpt2:rw", "':ro'/':rw' suffix is only valid"),
-    # Wrong type
-    ("hf://", "empty body"),
 ]
 
 

--- a/tests/test_utils_hf_uris.py
+++ b/tests/test_utils_hf_uris.py
@@ -1,0 +1,334 @@
+# Copyright 2026-present, the HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the centralized HF URI parser (``huggingface_hub.utils._hf_uris``)."""
+
+from __future__ import annotations
+
+import pytest
+
+from huggingface_hub.utils import HfUri, parse_hf_uri
+
+
+# A "success" case is described as ``(uri, expected_HfUri, expected_roundtrip)``.
+# - ``uri``: the input string fed to ``parse_hf_uri``.
+# - ``expected_HfUri``: the expected parsed value.
+# - ``expected_roundtrip``: the expected output of ``HfUri.to_string()``. May
+#   differ from the input when the URI is reformatted (implicit ``models/``
+#   prefix added, URL-encoded revision decoded, ...).
+SUCCESS_CASES: list[tuple[str, HfUri, str]] = [
+    # --- Models ----------------------------------------------------------------
+    # Canonical model id, no namespace
+    (
+        "hf://gpt2",
+        HfUri(type="model", id="gpt2"),
+        "hf://models/gpt2",
+    ),
+    # Canonical model id with explicit ``models/`` prefix
+    (
+        "hf://models/gpt2",
+        HfUri(type="model", id="gpt2"),
+        "hf://models/gpt2",
+    ),
+    # Namespaced model
+    (
+        "hf://my-org/my-model",
+        HfUri(type="model", id="my-org/my-model"),
+        "hf://models/my-org/my-model",
+    ),
+    (
+        "hf://models/my-org/my-model",
+        HfUri(type="model", id="my-org/my-model"),
+        "hf://models/my-org/my-model",
+    ),
+    # Model with path inside the repo
+    (
+        "hf://models/my-org/my-model/config.json",
+        HfUri(type="model", id="my-org/my-model", path_in_repo="config.json"),
+        "hf://models/my-org/my-model/config.json",
+    ),
+    # Model with explicit revision
+    (
+        "hf://my-org/my-model@v1.0",
+        HfUri(type="model", id="my-org/my-model", revision="v1.0"),
+        "hf://models/my-org/my-model@v1.0",
+    ),
+    # Model with revision and path
+    (
+        "hf://models/my-org/my-model@dev/sub/file.bin",
+        HfUri(type="model", id="my-org/my-model", revision="dev", path_in_repo="sub/file.bin"),
+        "hf://models/my-org/my-model@dev/sub/file.bin",
+    ),
+    # Canonical model with path
+    (
+        "hf://gpt2@main/config.json",
+        HfUri(type="model", id="gpt2", revision="main", path_in_repo="config.json"),
+        "hf://models/gpt2@main/config.json",
+    ),
+    # --- Datasets --------------------------------------------------------------
+    # Canonical dataset (single-segment id, e.g. ``squad``, ``glue``)
+    (
+        "hf://datasets/squad",
+        HfUri(type="dataset", id="squad"),
+        "hf://datasets/squad",
+    ),
+    (
+        "hf://datasets/my-org/my-dataset",
+        HfUri(type="dataset", id="my-org/my-dataset"),
+        "hf://datasets/my-org/my-dataset",
+    ),
+    # Dataset with revision and path
+    (
+        "hf://datasets/my-org/my-dataset@v1/train.csv",
+        HfUri(type="dataset", id="my-org/my-dataset", revision="v1", path_in_repo="train.csv"),
+        "hf://datasets/my-org/my-dataset@v1/train.csv",
+    ),
+    # --- Spaces ----------------------------------------------------------------
+    (
+        "hf://spaces/user/my-space",
+        HfUri(type="space", id="user/my-space"),
+        "hf://spaces/user/my-space",
+    ),
+    (
+        "hf://spaces/user/my-space@main",
+        HfUri(type="space", id="user/my-space", revision="main"),
+        "hf://spaces/user/my-space@main",
+    ),
+    # --- Kernels ---------------------------------------------------------------
+    (
+        "hf://kernels/my-org/my-kernel",
+        HfUri(type="kernel", id="my-org/my-kernel"),
+        "hf://kernels/my-org/my-kernel",
+    ),
+    # --- Buckets ---------------------------------------------------------------
+    (
+        "hf://buckets/my-org/my-bucket",
+        HfUri(type="bucket", id="my-org/my-bucket"),
+        "hf://buckets/my-org/my-bucket",
+    ),
+    (
+        "hf://buckets/my-org/my-bucket/sub/path",
+        HfUri(type="bucket", id="my-org/my-bucket", path_in_repo="sub/path"),
+        "hf://buckets/my-org/my-bucket/sub/path",
+    ),
+    # Trailing slashes are tolerated and stripped.
+    (
+        "hf://buckets/my-org/my-bucket/",
+        HfUri(type="bucket", id="my-org/my-bucket"),
+        "hf://buckets/my-org/my-bucket",
+    ),
+    # --- Special revisions (refs/pr/N, refs/convert/parquet) -------------------
+    # Special PR revision: must be matched eagerly even though it contains '/'
+    (
+        "hf://datasets/foo/bar@refs/pr/10/file.csv",
+        HfUri(type="dataset", id="foo/bar", revision="refs/pr/10", path_in_repo="file.csv"),
+        "hf://datasets/foo/bar@refs/pr/10/file.csv",
+    ),
+    # Special convert revision
+    (
+        "hf://datasets/foo/bar@refs/convert/parquet/data.parquet",
+        HfUri(
+            type="dataset",
+            id="foo/bar",
+            revision="refs/convert/parquet",
+            path_in_repo="data.parquet",
+        ),
+        "hf://datasets/foo/bar@refs/convert/parquet/data.parquet",
+    ),
+    # URL-encoded special revision
+    (
+        "hf://datasets/foo/bar@refs%2Fpr%2F10/file.csv",
+        HfUri(type="dataset", id="foo/bar", revision="refs/pr/10", path_in_repo="file.csv"),
+        "hf://datasets/foo/bar@refs/pr/10/file.csv",
+    ),
+    # Special revision with no path after it
+    (
+        "hf://gpt2@refs/pr/3",
+        HfUri(type="model", id="gpt2", revision="refs/pr/3"),
+        "hf://models/gpt2@refs/pr/3",
+    ),
+    # --- Mount path + ro/rw ----------------------------------------------------
+    (
+        "hf://gpt2:/data",
+        HfUri(type="model", id="gpt2", mount_path="/data"),
+        "hf://models/gpt2:/data",
+    ),
+    (
+        "hf://gpt2:/data:ro",
+        HfUri(type="model", id="gpt2", mount_path="/data", read_only=True),
+        "hf://models/gpt2:/data:ro",
+    ),
+    (
+        "hf://gpt2:/data:rw",
+        HfUri(type="model", id="gpt2", mount_path="/data", read_only=False),
+        "hf://models/gpt2:/data:rw",
+    ),
+    (
+        "hf://datasets/my-org/my-dataset:/mnt",
+        HfUri(type="dataset", id="my-org/my-dataset", mount_path="/mnt"),
+        "hf://datasets/my-org/my-dataset:/mnt",
+    ),
+    # Mount path with revision
+    (
+        "hf://datasets/my-org/my-dataset@v1:/mnt:ro",
+        HfUri(
+            type="dataset",
+            id="my-org/my-dataset",
+            revision="v1",
+            mount_path="/mnt",
+            read_only=True,
+        ),
+        "hf://datasets/my-org/my-dataset@v1:/mnt:ro",
+    ),
+    # Mount path with sub-path inside repo
+    (
+        "hf://datasets/my-org/my-dataset/train:/mnt",
+        HfUri(
+            type="dataset",
+            id="my-org/my-dataset",
+            path_in_repo="train",
+            mount_path="/mnt",
+        ),
+        "hf://datasets/my-org/my-dataset/train:/mnt",
+    ),
+    # Bucket with mount path and ro/rw
+    (
+        "hf://buckets/my-org/my-bucket:/mnt:rw",
+        HfUri(
+            type="bucket",
+            id="my-org/my-bucket",
+            mount_path="/mnt",
+            read_only=False,
+        ),
+        "hf://buckets/my-org/my-bucket:/mnt:rw",
+    ),
+    # Bucket with sub-path and mount
+    (
+        "hf://buckets/my-org/my-bucket/sub/dir:/mnt:ro",
+        HfUri(
+            type="bucket",
+            id="my-org/my-bucket",
+            path_in_repo="sub/dir",
+            mount_path="/mnt",
+            read_only=True,
+        ),
+        "hf://buckets/my-org/my-bucket/sub/dir:/mnt:ro",
+    ),
+    # Mount path with several path segments
+    (
+        "hf://gpt2:/path/to/mount",
+        HfUri(type="model", id="gpt2", mount_path="/path/to/mount"),
+        "hf://models/gpt2:/path/to/mount",
+    ),
+]
+
+
+# A "failure" case is ``(uri, error_substring)``: ``parse_hf_uri(uri)`` must
+# raise a ``ValueError`` whose message contains ``error_substring``.
+FAILURE_CASES: list[tuple[str, str]] = [
+    # Missing protocol
+    ("gpt2", "must start with 'hf://'"),
+    ("https://huggingface.co/gpt2", "must start with 'hf://'"),
+    ("hf:/gpt2", "must start with 'hf://'"),
+    # Empty body after protocol
+    ("hf://", "empty body"),
+    # Empty repo id (just a type prefix)
+    ("hf://datasets", "missing identifier"),
+    ("hf://datasets/", "missing repository id"),
+    ("hf://models/", "missing repository id"),
+    ("hf://buckets", "missing identifier"),
+    ("hf://buckets/", "bucket id must be 'namespace/name'"),
+    # Singular type forms are forbidden
+    ("hf://dataset/foo/bar", "must be plural"),
+    ("hf://model/gpt2", "must be plural"),
+    ("hf://space/user/my-space", "must be plural"),
+    ("hf://bucket/org/b", "must be plural"),
+    # Buckets must always have namespace/name
+    ("hf://buckets/single-segment", "bucket id must be 'namespace/name'"),
+    # Buckets cannot have a revision
+    ("hf://buckets/org/b@v1", "do not support a revision"),
+    ("hf://buckets/org/b@v1/path", "do not support a revision"),
+    # Empty revision
+    ("hf://gpt2@", "empty revision"),
+    ("hf://datasets/foo/bar@/file", "empty revision"),
+    # Empty repo id before '@'
+    ("hf://@v1/file", "missing repository id"),
+    # Repo id with too many slashes
+    ("hf://a/b/c@v1", "repository id must be 'name' or 'namespace/name'"),
+    # Invalid repo id chars (validated by validate_repo_id)
+    ("hf://datasets/foo/.invalid", "Repo id must use alphanumeric"),
+    ("hf://models/foo--bar", "Cannot have -- or .."),
+    # Mount path that is not absolute
+    ("hf://gpt2:/", "mount path must be a non-empty absolute path"),
+    # Read-only flag without a mount path
+    ("hf://gpt2:ro", "':ro'/':rw' suffix is only valid"),
+    ("hf://gpt2:rw", "':ro'/':rw' suffix is only valid"),
+    # Wrong type
+    ("hf://", "empty body"),
+]
+
+
+@pytest.mark.parametrize(("uri", "expected", "expected_roundtrip"), SUCCESS_CASES)
+def test_parse_hf_uri_success(uri: str, expected: HfUri, expected_roundtrip: str) -> None:
+    """``parse_hf_uri`` returns the expected ``HfUri`` and round-trips back to a canonical string."""
+    result = parse_hf_uri(uri)
+    assert result == expected
+    assert result.to_string() == expected_roundtrip
+    # Re-parsing the canonical form must yield the same URI (idempotency).
+    assert parse_hf_uri(expected_roundtrip) == expected
+
+
+@pytest.mark.parametrize(("uri", "error_substring"), FAILURE_CASES)
+def test_parse_hf_uri_failure(uri: str, error_substring: str) -> None:
+    """``parse_hf_uri`` rejects malformed URIs with a helpful error message."""
+    with pytest.raises(ValueError, match=error_substring):
+        parse_hf_uri(uri)
+
+
+# --- A few targeted tests not easily expressed as parametrized cases. ---------
+
+
+def test_repo_id_property_on_bucket_uri_raises() -> None:
+    uri = parse_hf_uri("hf://buckets/org/b")
+    with pytest.raises(AttributeError, match="bucket_id"):
+        uri.repo_id  # noqa: B018
+
+
+def test_bucket_id_property_on_repo_uri_raises() -> None:
+    uri = parse_hf_uri("hf://datasets/org/ds")
+    with pytest.raises(AttributeError, match="repo_id"):
+        uri.bucket_id  # noqa: B018
+
+
+def test_repo_type_property_on_bucket_uri_raises() -> None:
+    uri = parse_hf_uri("hf://buckets/org/b")
+    with pytest.raises(AttributeError, match="repo_type"):
+        uri.repo_type  # noqa: B018
+
+
+def test_is_repo_and_is_bucket_are_mutually_exclusive() -> None:
+    repo_uri = parse_hf_uri("hf://datasets/org/ds")
+    assert repo_uri.is_repo and not repo_uri.is_bucket
+    bucket_uri = parse_hf_uri("hf://buckets/org/b")
+    assert bucket_uri.is_bucket and not bucket_uri.is_repo
+
+
+def test_to_string_always_includes_type_prefix_for_models() -> None:
+    """Even when the input omitted the ``models/`` prefix, the canonical form keeps it."""
+    uri = parse_hf_uri("hf://gpt2")
+    assert uri.to_string() == "hf://models/gpt2"
+
+
+def test_uri_str_is_to_string() -> None:
+    uri = parse_hf_uri("hf://datasets/my-org/my-dataset@v1/file.csv")
+    assert str(uri) == uri.to_string()

--- a/tests/test_utils_hf_uris.py
+++ b/tests/test_utils_hf_uris.py
@@ -145,6 +145,13 @@ SUCCESS_CASES: list[tuple[str, HfUri, str]] = [
         HfUri(type="dataset", id="foo/bar", revision="refs/pr/10", path_in_repo="file.csv"),
         "hf://datasets/foo/bar@refs/pr/10/file.csv",
     ),
+    # Branch name containing '/' (e.g. 'feature/foo'). Must be URL-encoded so that the
+    # parser does not split it at the first '/' and treat the rest as a path-in-repo.
+    (
+        "hf://gpt2@feature%2Ffoo/config.json",
+        HfUri(type="model", id="gpt2", revision="feature/foo", path_in_repo="config.json"),
+        "hf://models/gpt2@feature%2Ffoo/config.json",
+    ),
     # Special revision with no path after it
     (
         "hf://gpt2@refs/pr/3",


### PR DESCRIPTION
## Summary

Adds a single source of truth for parsing `hf://...` URIs, addressing #3971.

- New `HfUri` dataclass and `parse_hf_uri` helper, plus shared constants in `huggingface_hub.constants` (`HF_PROTOCOL`, `HfUriType`, `HF_URI_TYPE_PREFIXES`).
- Separate `HfMount` dataclass and `parse_hf_mount` helper for volume mount specifications (`hf://...:<MOUNT_PATH>[:ro|:rw]`). Mount logic is cleanly separated from URI parsing — `HfUri` is a pure location identifier, `HfMount` wraps a `HfUri` with a mount path and read-only flag.
- A reference page documenting the canonical syntax for both URIs and mounts, and what does (and does not) qualify as a HF URI — strict-by-design (plural-only type prefixes, no canonical repos without namespace, etc.).
- Pure string parser, no network calls. Round-trippable via `HfUri.to_uri()` and `HfMount.to_uri()`.

```py
>>> from huggingface_hub import parse_hf_uri
>>> parse_hf_uri("hf://datasets/namespace/my-dataset@refs/pr/3/train.json")
HfUri(type='dataset', id='namespace/my-dataset', revision='refs/pr/3', path_in_repo='train.json')

>>> from huggingface_hub import parse_hf_mount
>>> parse_hf_mount("hf://buckets/my-org/my-bucket/sub/dir:/mnt:ro")
HfMount(source=HfUri(type='bucket', id='my-org/my-bucket', revision=None, path_in_repo='sub/dir'), mount_path='/mnt', read_only=True)
```

## Follow-ups (not in this PR)

- Migrate existing call sites to the new parser:
  - `HfFileSystem.resolve_path` (keeps its 1- vs 2-segment network fallback on top of the parser)
  - `_parse_hf_copy_handle` in `hf_api.py` (the spot already carries a `# TODO` referencing #3971)
  - `parse_volumes` in `cli/_cli_utils.py`
  - `_split_bucket_id_and_prefix` / `_parse_bucket_path` / `_is_bucket_path` in `_buckets.py` and `_parse_bucket_argument` / `_is_hf_handle` in `cli/buckets.py`
  - `Volume.to_hf_handle` formatter in `_space_api.py` (mirror of `HfMount.to_uri`)
- Decide what to do with `repo_type_and_id_from_hf_id` (used by `RepoUrl`): it's a mixed parser accepting both `hf://` URIs and `https://huggingface.co/...` URLs. Likely split into two helpers, with the URI half delegating to `parse_hf_uri`.
- Possibly extend the parser later to accept HTTPS Hub URLs, if the `RepoUrl` migration would benefit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new public parsing APIs and stricter URI semantics (e.g., requiring `namespace/name`), which could affect downstream users who adopt the new helpers or rely on older, looser examples.
> 
> **Overview**
> Introduces a new centralized `hf://...` parser in `utils/_hf_uris.py`, including frozen `HfUri`/`HfMount` dataclasses with canonical round-tripping (`to_uri`) and strict validation/error reporting via a new `HfUriError`.
> 
> Exports `HfUri` and `parse_hf_uri` from the package (`huggingface_hub` and `huggingface_hub.utils`), adds shared URI constants/types in `constants.py`, and adds comprehensive unit tests plus a new docs reference page (`package_reference/hf_uris`) linked from the docs toctree. CLI volume help text/examples are updated to reflect namespaced model URIs (no more `hf://gpt2`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 116f6eae2ec36ec66e973b0e5ba625f53dee36fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->