### PR TITLE
[Quality] Fix uvx ty check src errors

### DIFF
--- a/src/huggingface_hub/_tensorboard_logger.py
+++ b/src/huggingface_hub/_tensorboard_logger.py
@@ -38,7 +38,7 @@ except ImportError:
         class _DummySummaryWriter:
             pass
 
-        _RuntimeSummaryWriter = _DummySummaryWriter  # type: ignore[assignment]
+        _RuntimeSummaryWriter = _DummySummaryWriter  # type: ignore[assignment]  # ty: ignore[conflicting-declarations]
         is_summary_writer_available = False
 
 

--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -137,7 +137,7 @@ class _Cached(_cached_base):
             return obj
 
 
-class HfFileSystem(fsspec.AbstractFileSystem, metaclass=_Cached):
+class HfFileSystem(fsspec.AbstractFileSystem, metaclass=_Cached):  # ty: ignore[conflicting-metaclass]
     """
     Access a remote Hugging Face Hub repository as if were a local file system.
 


### PR DESCRIPTION
## Summary

Latest `ty` release (0.0.33) flags two pre-existing diagnostics that older versions missed, breaking the `uvx ty check src` step in the `python-quality` CI workflow. Both reflect intentional dynamic patterns that `ty` cannot model statically, so we suppress them with targeted ignore comments.

- `_tensorboard_logger.py:41`: assigning `_DummySummaryWriter` to `_RuntimeSummaryWriter` conflicts with the declared type from the earlier `tensorboardX` / `torch.utils.tensorboard` import branches. The `# type: ignore[assignment]` (mypy) was already there; added a matching `# ty: ignore[conflicting-declarations]`.
- `hf_file_system.py:140`: `HfFileSystem` uses a local `_Cached` metaclass that subclasses `type(fsspec.AbstractFileSystem)` at runtime. The subclass relationship holds at runtime but `ty` can't prove it statically — added `# ty: ignore[conflicting-metaclass]`.

Before:

```
$ uvx ty check src
src/huggingface_hub/_tensorboard_logger.py:41:9: error[conflicting-declarations] Conflicting declared types for `_RuntimeSummaryWriter`: `Unknown` and `<class 'SummaryWriter'>`
src/huggingface_hub/hf_file_system.py:140:1: error[conflicting-metaclass] The metaclass of a derived class (`HfFileSystem`) must be a subclass of the metaclasses of all its bases, but `_Cached` (metaclass of `HfFileSystem`) and `_Cached` (metaclass of base class `AbstractFileSystem`) have no subclass relationship
Found 2 diagnostics
```

After:

```
$ uvx ty check src
All checks passed!

$ make quality
ruff check src tests utils setup.py  # linter
All checks passed!
...
ty check src
All checks passed!

$ mypy src/huggingface_hub/__init__.py --follow-imports=silent --show-traceback
Success: no issues found in 1 source file
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds targeted `# ty: ignore[...]` comments to silence new static type-checker diagnostics, with no runtime logic changes.
> 
> **Overview**
> Unblocks the `uvx ty check src` CI step by adding targeted `ty` suppression comments for two intentional dynamic patterns.
> 
> Specifically, it annotates the `_DummySummaryWriter` fallback assignment in `_tensorboard_logger.py` with `# ty: ignore[conflicting-declarations]`, and marks `HfFileSystem`’s use of the custom `_Cached` metaclass in `hf_file_system.py` with `# ty: ignore[conflicting-metaclass]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6310f1924d8cba7a47e1a6c568782686a43cad34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->