### PR TITLE
[CI] Fix two flaky Windows tests

### DIFF
--- a/src/huggingface_hub/serialization/_torch.py
+++ b/src/huggingface_hub/serialization/_torch.py
@@ -21,7 +21,7 @@ import re
 from collections import defaultdict, namedtuple
 from collections.abc import Iterable
 from functools import lru_cache
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import TYPE_CHECKING, Any, NamedTuple, Union
 
 from packaging import version
@@ -516,8 +516,19 @@ def _load_sharded_checkpoint(
     expected_extension = Path(filename_pattern.format(suffix="")).suffix  # e.g. ".safetensors"
     shard_files = list(set(index["weight_map"].values()))
     for shard_file in shard_files:
-        # Reject path traversal (e.g. "../malicious.bin", absolute paths)
-        if os.path.isabs(shard_file) or ".." in Path(shard_file).parts:
+        # Reject anything that could escape `save_directory` on any host OS:
+        # POSIX absolute ("/tmp/x"), Windows drive ("C:x", "C:\\x"), UNC
+        # ("\\\\server\\share\\x"), rooted-without-drive ("\\x", "/x"), or
+        # ".." traversal — including "..\\x" which `os.path.isabs` never caught on POSIX.
+        #
+        # We parse with `PureWindowsPath` *regardless of host OS*: it treats both "/" and
+        # "\\" as separators and exposes `drive` / `root`, so a single check rejects a
+        # malicious index file on Linux too (e.g. if it's later opened on Windows). The
+        # only over-strict case is a POSIX filename like "a:foo" which would be parsed as
+        # drive "a:" — such names are never produced for safetensors shards and would
+        # break on Windows anyway, so rejecting them is fine.
+        win_path = PureWindowsPath(shard_file)
+        if win_path.drive or win_path.root or ".." in win_path.parts:
             raise ValueError(
                 f"Invalid shard filename '{shard_file}' in index file '{index_file}'. "
                 "Shard filenames must be relative paths without '..' components."

--- a/tests/test_hf_file_system.py
+++ b/tests/test_hf_file_system.py
@@ -384,8 +384,18 @@ class _HfFileSystemBaseROTests(_HfFileSystemBaseTests):
             assert (Path(temp_dir) / "data").exists()
 
     def test_pickle(self):
-        # Test that pickling re-populates the HfFileSystem cache and keeps the instance cache attributes
-        fs = HfFileSystem()
+        # Test that pickling re-populates the HfFileSystem cache and keeps the instance cache attributes.
+        #
+        # Two things must hold for this test to be deterministic:
+        # 1. The pre-pickle fs must hit an endpoint where `text_file` actually exists, so the initial
+        #    `isfile` call resolves cleanly and populates exactly one cache entry. Going against
+        #    production would 404 and trigger the namespace fallback in `resolve_path`, adding 2 entries.
+        # 2. The pre-pickle fs must NOT be shared via fsspec's instance cache with any sibling test
+        #    (e.g. the bucket-based `test_pickle` inherited by `HfFileSystemBucketROTests`), otherwise
+        #    leftover `_bucket_exists_cache` / `dircache` entries from that test leak into this one
+        #    via the main-thread state-inheritance path in `_Cached.__call__`.
+        # `skip_instance_cache=True` guarantees a fresh instance regardless of what earlier tests ran.
+        fs = HfFileSystem(endpoint=ENDPOINT_STAGING, token=TOKEN, skip_instance_cache=True)
         fs.isfile(self.text_file)
         pickled = pickle.dumps(fs)
         HfFileSystem.clear_instance_cache()

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -866,12 +866,23 @@ class TestShardedCheckpointValidation:
         with pytest.raises(ValueError, match="Invalid shard filename.*without '..' components"):
             load_torch_model(Mock(), tmp_path)
 
-    def test_safetensors_index_rejects_absolute_path(self, tmp_path):
-        """A shard filename with an absolute path must be rejected."""
+    @pytest.mark.parametrize(
+        "malicious_path",
+        [
+            "/tmp/malicious.safetensors",  # POSIX absolute
+            "\\malicious.safetensors",  # Windows rooted, no drive (resolves to C:\malicious on Windows)
+            "C:malicious.safetensors",  # Windows drive-only (relative to CWD of drive C)
+            "C:\\malicious.safetensors",  # Windows drive-absolute
+            "\\\\server\\share\\malicious.safetensors",  # Windows UNC
+            "..\\malicious.safetensors",  # Windows-style traversal (backslash as separator)
+        ],
+    )
+    def test_safetensors_index_rejects_absolute_path(self, tmp_path, malicious_path):
+        """A shard filename with an absolute path must be rejected on every host OS."""
         index = {
             "metadata": {"total_size": 100},
             "weight_map": {
-                "layer_1": "/tmp/malicious.safetensors",
+                "layer_1": malicious_path,
             },
         }
         (tmp_path / "model.safetensors.index.json").write_text(json.dumps(index))


### PR DESCRIPTION
## Summary

Two Windows-only flaky tests, both reproducing on `main` (independent from PR #4159):
- https://github.com/huggingface/huggingface_hub/actions/runs/25049111886/job/73371951943?pr=4159
- https://github.com/huggingface/huggingface_hub/actions/runs/25049111886/job/73371951946?pr=4159

Both have real root causes (no skip / retry).

### 1. `test_safetensors_index_rejects_absolute_path` (Windows Py 3.14)

The validator in `_load_sharded_checkpoint` used `os.path.isabs(shard_file)` to reject absolute paths in a safetensors index. **Since Python 3.13**, `ntpath.isabs()` no longer treats `/tmp/foo` (single leading slash, no drive) as absolute — so on Windows Py 3.13+, `"/tmp/malicious.safetensors"` sailed past validation and `os.path.join` resolved it to `C:\tmp\malicious.safetensors`. This is a **real security regression**, not just a test bug.

Fix: parse with `PureWindowsPath` regardless of host OS and check `drive or root or '..' in parts` — one expression catches POSIX-absolute, Windows-rooted (with or without drive), UNC, and `..\` traversal. Test is parametrized with 6 representative malicious paths.

### 2. `test_hf_file_system::test_pickle` (Windows, all Py versions)

The pre-pickle fs was constructed via `HfFileSystem()` (defaults to **production**), but `self.text_file` only exists on **staging**. The 404 on production triggered `resolve_path`'s namespace fallback — writing 2 cache entries instead of 1 — making `assert len(...) == 1` flip depending on the runner's exact error. Pointing the fs at `ENDPOINT_STAGING` (with `skip_instance_cache=True` to avoid fsspec instance-cache bleed from sibling tests) makes the assertion deterministic.

## Verification

```
$ pytest tests/test_serialization.py::TestShardedCheckpointValidation -v
...
test_safetensors_index_rejects_absolute_path[/tmp/malicious.safetensors]              PASSED
test_safetensors_index_rejects_absolute_path[\\malicious.safetensors]                 PASSED
test_safetensors_index_rejects_absolute_path[C:malicious.safetensors]                 PASSED
test_safetensors_index_rejects_absolute_path[C:\\malicious.safetensors]               PASSED
test_safetensors_index_rejects_absolute_path[\\\\server\\share\\malicious.safetensors] PASSED
test_safetensors_index_rejects_absolute_path[..\\malicious.safetensors]               PASSED
8 passed
```

Windows CI behavior validated by this PR's own checks.

Note: supersedes draft PR #4141 which had stale main; same fixes, fresh branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sharded checkpoint loading validation to reject more path forms across OSes; while the change is small, it affects a security-sensitive file path check and could block previously-accepted edge-case filenames.
> 
> **Overview**
> **Hardens sharded safetensors checkpoint loading** by strengthening shard filename validation in `_load_sharded_checkpoint` to reject Windows drive/UNC/rooted paths and backslash-based `..` traversal using `PureWindowsPath`, closing a Windows/Python 3.13+ gap in absolute-path detection.
> 
> **Deflakes Windows CI tests** by making `HfFileSystem` pickling tests deterministic (use staging endpoint, explicit token, and `skip_instance_cache=True`) and expanding serialization tests to parameterize multiple malicious absolute/traversal path variants across platforms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d1535411b1cc1c35aaa97bbbfc065360ab2a56e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->