### PR TITLE
[CLI] Add `--hardware` flag to `hf spaces settings`

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -991,8 +991,8 @@ Use `hf spaces restart` to restart a Space. Pass `--factory-reboot` to rebuild t
 >>> hf spaces settings username/my-space --hardware t4-medium
 ```
 
-- `--sleep-time SECONDS`: idle time before the Space sleeps. Use `-1` to never sleep. Only available on upgraded hardware (see the [Spaces sleep time docs](https://huggingface.co/docs/hub/spaces-gpus#sleep-time)).
-- `--hardware FLAVOR`: hardware flavor (e.g. `cpu-basic`, `t4-medium`, `l4x4`).
+- `--sleep-time`: idle time in seconds before the Space sleeps. Use `-1` to never sleep. Only available on upgraded hardware (see the [Spaces sleep time docs](https://huggingface.co/docs/hub/spaces-gpus#sleep-time)).
+- `--hardware`: hardware flavor (e.g. `cpu-basic`, `t4-medium`, `l4x4`).
 
 ## hf papers
 

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -986,6 +986,8 @@ Use `hf spaces restart` to restart a Space. Pass `--factory-reboot` to rebuild t
 
 ### Update Space settings
 
+Use `hf spaces settings` to update the settings of a Space.
+
 ```bash
 >>> hf spaces settings username/my-space --sleep-time 3600
 >>> hf spaces settings username/my-space --hardware t4-medium

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -986,11 +986,13 @@ Use `hf spaces restart` to restart a Space. Pass `--factory-reboot` to rebuild t
 
 ### Update Space settings
 
-Use `hf spaces settings` to update the settings of a Space. For example, configure how long the Space stays idle before going to sleep with `--sleep-time` (only available on upgraded hardware — see the [Spaces sleep time docs](https://huggingface.co/docs/hub/spaces-gpus#sleep-time) for details). Run `hf spaces settings --help` to see all supported options.
-
 ```bash
 >>> hf spaces settings username/my-space --sleep-time 3600
+>>> hf spaces settings username/my-space --hardware t4-medium
 ```
+
+- `--sleep-time SECONDS`: idle time before the Space sleeps. Use `-1` to never sleep. Only available on upgraded hardware (see the [Spaces sleep time docs](https://huggingface.co/docs/hub/spaces-gpus#sleep-time)).
+- `--hardware FLAVOR`: hardware flavor (e.g. `cpu-basic`, `t4-medium`, `l4x4`).
 
 ## hf papers
 

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -3837,7 +3837,7 @@ $ hf spaces settings [OPTIONS] SPACE_ID
 **Options**:
 
 * `--sleep-time INTEGER`: Idle time in seconds after which the Space goes to sleep. Use -1 to never sleep. Only available on upgraded hardware.
-* `--hardware [cpu-basic|cpu-upgrade|cpu-performance|cpu-xl|sprx8|zero-a10g|t4-small|t4-medium|l4x1|l4x4|l40sx1|l40sx4|l40sx8|a10g-small|a10g-large|a10g-largex2|a10g-largex4|a100-large|a100x4|a100x8|h200|h200x2|h200x4|h200x8|inf2x6]`: Hardware flavor to run the Space on (e.g. 'cpu-basic', 't4-medium', 'l4x4').
+* `--hardware [cpu-basic|cpu-upgrade|cpu-performance|cpu-xl|sprx8|zero-a10g|t4-small|t4-medium|l4x1|l4x4|l40sx1|l40sx4|l40sx8|a10g-small|a10g-large|a10g-largex2|a10g-largex4|a100-large|a100x4|a100x8|h200|h200x2|h200x4|h200x8|inf2x6]`: Space hardware flavor (e.g. 'cpu-basic', 't4-medium', 'l4x4').
 * `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `--help`: Show this message and exit.

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -3837,12 +3837,14 @@ $ hf spaces settings [OPTIONS] SPACE_ID
 **Options**:
 
 * `--sleep-time INTEGER`: Idle time in seconds after which the Space goes to sleep. Use -1 to never sleep. Only available on upgraded hardware.
+* `--hardware [cpu-basic|cpu-upgrade|cpu-performance|cpu-xl|sprx8|zero-a10g|t4-small|t4-medium|l4x1|l4x4|l40sx1|l40sx4|l40sx8|a10g-small|a10g-large|a10g-largex2|a10g-largex4|a100-large|a100x4|a100x8|h200|h200x2|h200x4|h200x8|inf2x6]`: Hardware flavor to run the Space on (e.g. 'cpu-basic', 't4-medium', 'l4x4').
 * `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `--help`: Show this message and exit.
 
 Examples
   $ hf spaces settings username/my-space --sleep-time 300
+  $ hf spaces settings username/my-space --hardware t4-medium
 
 Learn more
   Use `hf <command> --help` for more information about a command.

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -378,13 +378,13 @@ def spaces_settings(
     token: TokenOpt = None,
 ) -> None:
     """Update the settings of a Space."""
-    if sleep_time is None and hardware is None:
-        raise CLIError("Specify at least one setting to update.")
     api = get_hf_api(token=token)
     if hardware is not None:
         runtime = api.request_space_hardware(space_id, hardware=hardware, sleep_time=sleep_time)
-    else:
+    elif sleep_time is not None:
         runtime = api.set_space_sleep_time(space_id, sleep_time=sleep_time)
+    else:
+        raise CLIError("Specify at least one setting to update.")
     out.result(
         "Space settings updated",
         space_id=space_id,

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -44,7 +44,7 @@ from typing_extensions import assert_never
 
 from huggingface_hub._hot_reload.client import multi_replica_reload_events
 from huggingface_hub._hot_reload.types import ApiGetReloadEventSourceData, ReloadRegion
-from huggingface_hub._space_api import SpaceStage
+from huggingface_hub._space_api import SpaceHardware, SpaceStage
 from huggingface_hub.errors import CLIError, RemoteEntryNotFoundError, RepositoryNotFoundError, RevisionNotFoundError
 from huggingface_hub.file_download import hf_hub_download
 from huggingface_hub.hf_api import ExpandSpaceProperty_T, HfApi, SpaceSort_T
@@ -355,6 +355,7 @@ def spaces_restart(
     "settings",
     examples=[
         "hf spaces settings username/my-space --sleep-time 300",
+        "hf spaces settings username/my-space --hardware t4-medium",
     ],
 )
 def spaces_settings(
@@ -366,15 +367,30 @@ def spaces_settings(
             help="Idle time in seconds after which the Space goes to sleep. Use -1 to never sleep. Only available on upgraded hardware.",
         ),
     ] = None,
+    hardware: Annotated[
+        SpaceHardware | None,
+        typer.Option(
+            "--hardware",
+            help="Hardware flavor to run the Space on (e.g. 'cpu-basic', 't4-medium', 'l4x4').",
+        ),
+    ] = None,
     format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
     token: TokenOpt = None,
 ) -> None:
     """Update the settings of a Space."""
-    if sleep_time is None:
+    if sleep_time is None and hardware is None:
         raise CLIError("Specify at least one setting to update.")
     api = get_hf_api(token=token)
-    runtime = api.set_space_sleep_time(space_id, sleep_time=sleep_time)
-    out.result("Space settings updated", space_id=space_id, sleep_time=runtime.sleep_time)
+    if hardware is not None:
+        runtime = api.request_space_hardware(space_id, hardware=hardware, sleep_time=sleep_time)
+    else:
+        runtime = api.set_space_sleep_time(space_id, sleep_time=sleep_time)
+    result_kwargs: dict[str, object] = {"space_id": space_id}
+    if hardware is not None:
+        result_kwargs["hardware"] = runtime.requested_hardware
+    if sleep_time is not None:
+        result_kwargs["sleep_time"] = runtime.sleep_time
+    out.result("Space settings updated", **result_kwargs)
     out.hint(f"Use `hf spaces info {space_id}` to verify the runtime configuration.")
 
 

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -371,7 +371,7 @@ def spaces_settings(
         SpaceHardware | None,
         typer.Option(
             "--hardware",
-            help="Hardware flavor to run the Space on (e.g. 'cpu-basic', 't4-medium', 'l4x4').",
+            help="Space hardware flavor (e.g. 'cpu-basic', 't4-medium', 'l4x4').",
         ),
     ] = None,
     format: FormatWithAutoOpt = OutputFormatWithAuto.auto,

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -385,12 +385,12 @@ def spaces_settings(
         runtime = api.request_space_hardware(space_id, hardware=hardware, sleep_time=sleep_time)
     else:
         runtime = api.set_space_sleep_time(space_id, sleep_time=sleep_time)
-    result_kwargs: dict[str, object] = {"space_id": space_id}
-    if hardware is not None:
-        result_kwargs["hardware"] = runtime.requested_hardware
-    if sleep_time is not None:
-        result_kwargs["sleep_time"] = runtime.sleep_time
-    out.result("Space settings updated", **result_kwargs)
+    out.result(
+        "Space settings updated",
+        space_id=space_id,
+        hardware=runtime.requested_hardware,
+        sleep_time=runtime.sleep_time,
+    )
     out.hint(f"Use `hf spaces info {space_id}` to verify the runtime configuration.")
 
 


### PR DESCRIPTION
Extends the settings command from #4155 to also accept `--hardware <FLAVOR>`. Maps to `HfApi.request_space_hardware`. When both `--hardware` and `--sleep-time` are passed, sends a single `request_space_hardware` call (the API accepts both in one payload).

```bash
$ hf spaces settings username/my-space --hardware t4-medium
$ hf spaces settings username/my-space --hardware t4-medium --sleep-time 1800
$ hf spaces settings dummy/space
Error: Specify at least one setting to update.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes a CLI code path that triggers remote Space reconfiguration (hardware changes) and alters the settings update flow/output. While scoped, mistakes could lead to unexpected hardware requests or user confusion.
> 
> **Overview**
> Adds a `--hardware` option to `hf spaces settings` so users can request a Space hardware flavor change from the CLI, and (when provided) combines it with `--sleep-time` in a single `HfApi.request_space_hardware` call.
> 
> Updates command output and generated/docs guidance to include the new flag, its allowed values, and examples; the command now errors only when neither `--sleep-time` nor `--hardware` is provided.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1a505f752ba58dbb7edde6a414d39e98fda8e38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->