### PR TITLE
Avoid reuploading preuploaded LFS files in upload-large-folder

### DIFF
--- a/src/huggingface_hub/_upload_large_folder.py
+++ b/src/huggingface_hub/_upload_large_folder.py
@@ -724,6 +724,9 @@ def _build_hacky_operation(item: JOB_ITEM_T) -> HackyCommitOperationAdd:
     operation._upload_mode = metadata.upload_mode  # type: ignore
     operation._should_ignore = metadata.should_ignore
     operation._remote_oid = metadata.remote_oid
+    operation._is_uploaded = metadata.is_uploaded
+    if metadata.is_uploaded and metadata.upload_mode == "lfs":
+        operation.path_or_fileobj = b""
     return operation
 
 

--- a/tests/test_upload_large_folder.py
+++ b/tests/test_upload_large_folder.py
@@ -1,14 +1,17 @@
 # tests/test_upload_large_folder.py
 import unittest
+from hashlib import sha256
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from huggingface_hub._local_folder import LocalUploadFileMetadata, LocalUploadFilePaths
 from huggingface_hub._upload_large_folder import (
     COMMIT_SIZE_SCALE,
     MAX_FILES_PER_FOLDER,
     MAX_FILES_PER_REPO,
     LargeUploadStatus,
+    _build_hacky_operation,
     _validate_upload_limits,
 )
 
@@ -41,6 +44,30 @@ def test_update_chunk_transitions(status, start_idx, success, delta_items, durat
 
     assert status._chunk_idx == expected_idx
     assert status.target_chunk() == COMMIT_SIZE_SCALE[expected_idx]
+
+
+def test_build_hacky_operation_preserves_lfs_preupload_state(tmp_path):
+    file_path = tmp_path / "file.bin"
+    content = b"content"
+    file_path.write_bytes(content)
+
+    paths = LocalUploadFilePaths(
+        path_in_repo="file.bin",
+        file_path=file_path,
+        lock_path=tmp_path / "file.bin.lock",
+        metadata_path=tmp_path / "file.bin.metadata",
+    )
+    metadata = LocalUploadFileMetadata(
+        size=len(content),
+        sha256=sha256(content).hexdigest(),
+        upload_mode="lfs",
+        is_uploaded=True,
+    )
+
+    operation = _build_hacky_operation((paths, metadata))
+
+    assert operation._is_uploaded
+    assert operation.path_or_fileobj == b""
 
 
 class TestValidateUploadLimits(unittest.TestCase):


### PR DESCRIPTION
## What does this PR do?

upload_large_folder stores whether a file has already been preuploaded in LocalUploadFileMetadata.is_uploaded, but _build_hacky_operation did not restore that state on the CommitOperationAdd created for the commit step.

As a result, create_commit could call preupload_lfs_files again for files that were already uploaded by the large-folder preupload step. This makes the commit phase unnecessarily re-read/re-upload LFS files after resuming or after preupload completion.

This PR restores _is_uploaded from the local metadata and clears path_or_fileobj for already uploaded LFS files, matching the behavior of preupload_lfs_files after a successful upload.

## Tests

- uv run python -m compileall -q src/huggingface_hub/_upload_large_folder.py tests/test_upload_large_folder.py
- uv run --with pytest --with pytest-mock --with pytest-env --with-editable . pytest tests/test_upload_large_folder.py -q
- uv run --with ruff ruff format --check src/huggingface_hub/_upload_large_folder.py tests/test_upload_large_folder.py
- uv run --with ruff ruff check src/huggingface_hub/_upload_large_folder.py tests/test_upload_large_folder.py