### PR TITLE
[CLI] Add file listing to models/datasets/spaces ls

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -809,7 +809,7 @@ Use `hf models` to list models on the Hub and get detailed information about a s
 >>> hf models ls --sort downloads --limit 10
 ```
 
-When called with a model ID, `hf models ls` lists files in that model repo — similar to `hf buckets ls`:
+When called with a model ID, `hf models ls` lists files in that model repo:
 
 ```bash
 # List files in a model repo
@@ -973,16 +973,16 @@ When called with a Space ID, `hf spaces ls` lists files in that Space repo:
 
 ```bash
 # List files in a Space repo
->>> hf spaces ls enzostvs/deepsite
+>>> hf spaces ls victor/deepsite
 
 # List files recursively with tree view
->>> hf spaces ls enzostvs/deepsite --tree -R -h
+>>> hf spaces ls victor/deepsite --tree -R -h
 ```
 
 ### Get Space info
 
 ```bash
->>> hf spaces info enzostvs/deepsite
+>>> hf spaces info victor/deepsite
 ```
 
 ### Get Space card

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -809,6 +809,22 @@ Use `hf models` to list models on the Hub and get detailed information about a s
 >>> hf models ls --sort downloads --limit 10
 ```
 
+When called with a model ID, `hf models ls` lists files in that model repo — similar to `hf buckets ls`:
+
+```bash
+# List files in a model repo
+>>> hf models ls meta-llama/Llama-3.2-1B-Instruct
+
+# List files recursively
+>>> hf models ls meta-llama/Llama-3.2-1B-Instruct -R
+
+# Tree view with human-readable sizes
+>>> hf models ls meta-llama/Llama-3.2-1B-Instruct --tree -h
+
+# List files at a specific revision
+>>> hf models ls meta-llama/Llama-3.2-1B-Instruct --revision main
+```
+
 ### Get model info
 
 ```bash
@@ -853,6 +869,19 @@ Use `hf datasets` to list datasets on the Hub and get detailed information about
 
 # Sort by downloads
 >>> hf datasets ls --sort downloads --limit 10
+```
+
+When called with a dataset ID, `hf datasets ls` lists files in that dataset repo:
+
+```bash
+# List files in a dataset repo
+>>> hf datasets ls HuggingFaceFW/fineweb
+
+# List files recursively with human-readable sizes
+>>> hf datasets ls HuggingFaceFW/fineweb -R -h
+
+# Tree view
+>>> hf datasets ls HuggingFaceFW/fineweb --tree
 ```
 
 ### List a dataset leaderboard
@@ -938,6 +967,16 @@ Use `hf spaces` to list Spaces on the Hub and get detailed information about a s
 
 # Sort by likes
 >>> hf spaces ls --sort likes --limit 10
+```
+
+When called with a Space ID, `hf spaces ls` lists files in that Space repo:
+
+```bash
+# List files in a Space repo
+>>> hf spaces ls enzostvs/deepsite
+
+# List files recursively with tree view
+>>> hf spaces ls enzostvs/deepsite --tree -R -h
 ```
 
 ### Get Space info

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -983,7 +983,7 @@ $ hf datasets [OPTIONS] COMMAND [ARGS]...
 * `card`: Get the dataset card (README) for a...
 * `info`: Get info about a dataset on the Hub.
 * `leaderboard`: List model scores from a dataset leaderboard.
-* `list`: List datasets on the Hub. [alias: ls]
+* `list`: List datasets on the Hub, or files in a... [alias: ls]
 * `parquet`: List parquet file URLs available for a...
 * `sql`: Execute a raw SQL query with DuckDB...
 
@@ -1083,13 +1083,20 @@ Learn more
 
 ### `hf datasets list`
 
-List datasets on the Hub. [alias: ls]
+List datasets on the Hub, or files in a dataset repo. [alias: ls]
+
+When called with no argument, lists datasets on the Hub.
+When called with a dataset ID, lists files in that dataset repo.
 
 **Usage**:
 
 ```console
-$ hf datasets list [OPTIONS]
+$ hf datasets list [OPTIONS] [REPO_ID]
 ```
+
+**Arguments**:
+
+* `[REPO_ID]`: Dataset ID (e.g. `username/repo-name`) to list files from. If omitted, lists datasets.
 
 **Options**:
 
@@ -1099,6 +1106,10 @@ $ hf datasets list [OPTIONS]
 * `--sort [created_at|downloads|last_modified|likes|trending_score]`: Sort results.
 * `--limit INTEGER`: Limit the number of results.  [default: 10]
 * `--expand TEXT`: Comma-separated properties to return. When used, only the listed properties (and id) are returned. Example: '--expand=downloads,likes,tags'. Valid: author, cardData, citation, createdAt, description, disabled, downloads, downloadsAllTime, gated, lastModified, likes, mainSize, paperswithcode_id, private, resourceGroup, sha, siblings, tags, trendingScore, usedStorage.
+* `-h, --human-readable`: Show sizes in human readable format (only for listing files).
+* `--tree`: List files in tree format (only for listing files).
+* `-R, --recursive`: List files recursively (only for listing files).
+* `--revision TEXT`: Git revision id which can be a branch name, a tag, or a commit hash.
 * `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `--help`: Show this message and exit.
@@ -1108,6 +1119,9 @@ Examples
   $ hf datasets ls --sort downloads --limit 10
   $ hf datasets ls --search "code"
   $ hf datasets ls --filter benchmark:official
+  $ hf datasets ls HuggingFaceFW/fineweb
+  $ hf datasets ls HuggingFaceFW/fineweb -R
+  $ hf datasets ls HuggingFaceFW/fineweb --tree -h
 
 Learn more
   Use `hf <command> --help` for more information about a command.
@@ -2700,7 +2714,7 @@ $ hf models [OPTIONS] COMMAND [ARGS]...
 
 * `card`: Get the model card (README) for a model on...
 * `info`: Get info about a model on the Hub.
-* `list`: List models on the Hub. [alias: ls]
+* `list`: List models on the Hub, or files in a... [alias: ls]
 
 ### `hf models card`
 
@@ -2768,13 +2782,20 @@ Learn more
 
 ### `hf models list`
 
-List models on the Hub. [alias: ls]
+List models on the Hub, or files in a model repo. [alias: ls]
+
+When called with no argument, lists models on the Hub.
+When called with a model ID, lists files in that model repo.
 
 **Usage**:
 
 ```console
-$ hf models list [OPTIONS]
+$ hf models list [OPTIONS] [REPO_ID]
 ```
+
+**Arguments**:
+
+* `[REPO_ID]`: Model ID (e.g. `username/repo-name`) to list files from. If omitted, lists models.
 
 **Options**:
 
@@ -2785,6 +2806,10 @@ $ hf models list [OPTIONS]
 * `--sort [created_at|downloads|last_modified|likes|trending_score]`: Sort results.
 * `--limit INTEGER`: Limit the number of results.  [default: 10]
 * `--expand TEXT`: Comma-separated properties to return. When used, only the listed properties (and id) are returned. Example: '--expand=downloads,likes,tags'. Valid: author, baseModels, cardData, childrenModelCount, config, createdAt, disabled, downloads, downloadsAllTime, evalResults, gated, gguf, inference, inferenceProviderMapping, lastModified, library_name, likes, mask_token, model-index, pipeline_tag, private, resourceGroup, safetensors, sha, siblings, spaces, tags, transformersInfo, trendingScore, usedStorage, widgetData.
+* `-h, --human-readable`: Show sizes in human readable format (only for listing files).
+* `--tree`: List files in tree format (only for listing files).
+* `-R, --recursive`: List files recursively (only for listing files).
+* `--revision TEXT`: Git revision id which can be a branch name, a tag, or a commit hash.
 * `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `--help`: Show this message and exit.
@@ -2793,6 +2818,9 @@ Examples
   $ hf models ls --sort downloads --limit 10
   $ hf models ls --search "llama" --author meta-llama
   $ hf models ls --num-parameters min:6B,max:128B --sort likes
+  $ hf models ls meta-llama/Llama-3.2-1B-Instruct
+  $ hf models ls meta-llama/Llama-3.2-1B-Instruct -R
+  $ hf models ls meta-llama/Llama-3.2-1B-Instruct --tree -h
 
 Learn more
   Use `hf <command> --help` for more information about a command.
@@ -3506,7 +3534,7 @@ $ hf spaces [OPTIONS] COMMAND [ARGS]...
 * `dev-mode`: Enable or disable dev mode on a Space.
 * `hot-reload`: Hot-reload any Python file of a Space...
 * `info`: Get info about a space on the Hub.
-* `list`: List spaces on the Hub. [alias: ls]
+* `list`: List spaces on the Hub, or files in a... [alias: ls]
 * `logs`: Fetch the run or build logs of a Space.
 * `pause`: Pause a Space.
 * `restart`: Restart a Space.
@@ -3660,13 +3688,20 @@ Learn more
 
 ### `hf spaces list`
 
-List spaces on the Hub. [alias: ls]
+List spaces on the Hub, or files in a space repo. [alias: ls]
+
+When called with no argument, lists spaces on the Hub.
+When called with a space ID, lists files in that space repo.
 
 **Usage**:
 
 ```console
-$ hf spaces list [OPTIONS]
+$ hf spaces list [OPTIONS] [REPO_ID]
 ```
+
+**Arguments**:
+
+* `[REPO_ID]`: Space ID (e.g. `username/repo-name`) to list files from. If omitted, lists spaces.
 
 **Options**:
 
@@ -3676,6 +3711,10 @@ $ hf spaces list [OPTIONS]
 * `--sort [created_at|last_modified|likes|trending_score]`: Sort results.
 * `--limit INTEGER`: Limit the number of results.  [default: 10]
 * `--expand TEXT`: Comma-separated properties to return. When used, only the listed properties (and id) are returned. Example: '--expand=likes,tags'. Valid: author, cardData, createdAt, datasets, disabled, lastModified, likes, models, private, resourceGroup, runtime, sdk, sha, siblings, subdomain, tags, trendingScore, usedStorage.
+* `-h, --human-readable`: Show sizes in human readable format (only for listing files).
+* `--tree`: List files in tree format (only for listing files).
+* `-R, --recursive`: List files recursively (only for listing files).
+* `--revision TEXT`: Git revision id which can be a branch name, a tag, or a commit hash.
 * `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `--help`: Show this message and exit.
@@ -3683,6 +3722,9 @@ $ hf spaces list [OPTIONS]
 Examples
   $ hf spaces ls --limit 10
   $ hf spaces ls --search "chatbot" --author huggingface
+  $ hf spaces ls enzostvs/deepsite
+  $ hf spaces ls enzostvs/deepsite -R
+  $ hf spaces ls enzostvs/deepsite --tree -h
 
 Learn more
   Use `hf <command> --help` for more information about a command.

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -3722,9 +3722,9 @@ $ hf spaces list [OPTIONS] [REPO_ID]
 Examples
   $ hf spaces ls --limit 10
   $ hf spaces ls --search "chatbot" --author huggingface
-  $ hf spaces ls enzostvs/deepsite
-  $ hf spaces ls enzostvs/deepsite -R
-  $ hf spaces ls enzostvs/deepsite --tree -h
+  $ hf spaces ls victor/deepsite
+  $ hf spaces ls victor/deepsite -R
+  $ hf spaces ls victor/deepsite --tree -h
 
 Learn more
   Use `hf <command> --help` for more information about a command.

--- a/src/huggingface_hub/cli/_file_listing.py
+++ b/src/huggingface_hub/cli/_file_listing.py
@@ -1,0 +1,222 @@
+# Copyright 2025-present, the HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Shared helpers for listing files in buckets and repos (tree view, flat view, formatting)."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from typing import Any, Sequence
+
+from ._cli_utils import api_object_to_dict, get_hf_api
+from ._output import OutputFormatWithAuto, out
+
+
+def is_folder(item: Any) -> bool:
+    """Check if an item is a folder (not a file). Files have a `size` attribute."""
+    return not hasattr(item, "size") or not isinstance(getattr(item, "size"), int)
+
+
+def get_item_date(item: Any) -> datetime | None:
+    """Extract date from an item, supporting both repo items (last_commit.date) and bucket items (mtime/uploaded_at)."""
+    if hasattr(item, "mtime") and getattr(item, "mtime") is not None:
+        return getattr(item, "mtime")
+    if hasattr(item, "uploaded_at") and getattr(item, "uploaded_at") is not None:
+        return getattr(item, "uploaded_at")
+    if hasattr(item, "last_commit") and getattr(item, "last_commit") is not None:
+        return getattr(item, "last_commit").date
+    return None
+
+
+def format_size(size: int | float, human_readable: bool = False) -> str:
+    """Format a size in bytes."""
+    if not human_readable:
+        return str(size)
+
+    for unit in ["B", "KB", "MB", "GB", "TB"]:
+        if size < 1000:
+            if unit == "B":
+                return f"{size} {unit}"
+            return f"{size:.1f} {unit}"
+        size /= 1000
+    return f"{size:.1f} PB"
+
+
+def format_date(dt: datetime | None, human_readable: bool = False) -> str:
+    """Format a datetime to a readable date string."""
+    if dt is None:
+        return ""
+    if human_readable:
+        return dt.strftime("%b %d %H:%M")
+    return dt.strftime("%Y-%m-%d %H:%M:%S")
+
+
+def build_tree(
+    items: Sequence[Any],
+    human_readable: bool = False,
+    quiet: bool = False,
+) -> list[str]:
+    """Build a tree representation of files and directories.
+
+    Produces ASCII tree with size and date columns before the tree connector.
+    When quiet=True, only the tree structure is shown (no size/date).
+    """
+    tree: dict = {}
+
+    for item in items:
+        parts = item.path.split("/")
+        current = tree
+        for part in parts[:-1]:
+            if part not in current:
+                current[part] = {"__children__": {}}
+            current = current[part]["__children__"]
+
+        final_part = parts[-1]
+        if is_folder(item):
+            if final_part not in current:
+                current[final_part] = {"__children__": {}}
+        else:
+            current[final_part] = {"__item__": item}
+
+    prefix_width = 0
+    max_size_width = 0
+    max_date_width = 0
+    if not quiet:
+        for item in items:
+            if not is_folder(item):
+                size_str = format_size(item.size, human_readable)  # type: ignore[union-attr]
+                max_size_width = max(max_size_width, len(size_str))
+                date_str = format_date(get_item_date(item), human_readable)
+                max_date_width = max(max_date_width, len(date_str))
+        if max_size_width > 0:
+            prefix_width = max_size_width + 2 + max_date_width
+
+    lines: list[str] = []
+    _render_tree(
+        tree,
+        lines,
+        "",
+        prefix_width=prefix_width,
+        max_size_width=max_size_width,
+        human_readable=human_readable,
+    )
+    return lines
+
+
+def _render_tree(
+    node: dict,
+    lines: list[str],
+    indent: str,
+    prefix_width: int = 0,
+    max_size_width: int = 0,
+    human_readable: bool = False,
+) -> None:
+    """Recursively render a tree structure with size+date prefix."""
+    sorted_items = sorted(node.items())
+    for i, (name, value) in enumerate(sorted_items):
+        is_last = i == len(sorted_items) - 1
+        connector = "└── " if is_last else "├── "
+
+        is_dir = "__children__" in value
+        children = value.get("__children__", {})
+
+        if prefix_width > 0:
+            if is_dir:
+                prefix = " " * prefix_width
+            else:
+                item = value.get("__item__")
+                if item is not None:
+                    size_str = format_size(item.size, human_readable)
+                    date_str = format_date(get_item_date(item), human_readable)
+                    prefix = f"{size_str:>{max_size_width}}  {date_str}"
+                else:
+                    prefix = " " * prefix_width
+            lines.append(f"{prefix}  {indent}{connector}{name}{'/' if is_dir else ''}")
+        else:
+            lines.append(f"{indent}{connector}{name}{'/' if is_dir else ''}")
+
+        if children:
+            child_indent = indent + ("    " if is_last else "│   ")
+            _render_tree(
+                children,
+                lines,
+                child_indent,
+                prefix_width=prefix_width,
+                max_size_width=max_size_width,
+                human_readable=human_readable,
+            )
+
+
+def list_repo_files_cmd(
+    repo_id: str,
+    repo_type: str,
+    human_readable: bool,
+    as_tree: bool,
+    recursive: bool,
+    revision: str | None,
+    token: str | None,
+) -> None:
+    """List files in a repo on the Hub. Used by models/datasets/spaces ls commands."""
+    import typer
+
+    if as_tree and out.mode == OutputFormatWithAuto.json:
+        raise typer.BadParameter("Cannot use --tree with --format json.")
+
+    api = get_hf_api(token=token)
+    items = list(api.list_repo_tree(repo_id, recursive=recursive, revision=revision, repo_type=repo_type))
+    print_file_listing(items, human_readable=human_readable, as_tree=as_tree, recursive=recursive)
+
+
+def print_file_listing(
+    items: Sequence[Any],
+    *,
+    human_readable: bool = False,
+    as_tree: bool = False,
+    recursive: bool = False,
+) -> None:
+    """Print a file listing in the appropriate format based on the current output mode.
+
+    Supports tree, json, quiet, and flat human-readable views. Works with both
+    BucketFile/BucketFolder and RepoFile/RepoFolder items.
+    """
+    if not items:
+        out.text("(empty)")
+        return
+
+    has_directories = any(is_folder(item) for item in items)
+
+    if as_tree:
+        quiet = out.mode == OutputFormatWithAuto.quiet
+        for line in build_tree(items, human_readable=human_readable, quiet=quiet):
+            print(line)
+    elif out.mode == OutputFormatWithAuto.json:
+        print(json.dumps([api_object_to_dict(item) for item in items], indent=2))
+    elif out.mode == OutputFormatWithAuto.quiet:
+        for item in items:
+            if is_folder(item):
+                print(f"{item.path}/")
+            else:
+                print(item.path)
+    else:
+        for item in items:
+            if is_folder(item):
+                date_str = format_date(get_item_date(item), human_readable)
+                print(f"{'':>12}  {date_str:>19}  {item.path}/")
+            else:
+                size_str = format_size(item.size, human_readable)  # type: ignore[union-attr]
+                date_str = format_date(get_item_date(item), human_readable)
+                print(f"{size_str:>12}  {date_str:>19}  {item.path}")
+
+    if not recursive and has_directories:
+        out.hint("Use -R to list files recursively.")

--- a/src/huggingface_hub/cli/_file_listing.py
+++ b/src/huggingface_hub/cli/_file_listing.py
@@ -31,11 +31,6 @@ RepoItem = RepoFile | RepoFolder
 ListingItem = BucketItem | RepoItem
 
 
-def is_folder(item: ListingItem) -> bool:
-    """Check if an item is a folder (not a file)."""
-    return isinstance(item, (BucketFolder, RepoFolder))
-
-
 def get_item_date(item: ListingItem) -> datetime | None:
     """Extract date from an item, supporting both repo items (last_commit.date) and bucket items (mtime/uploaded_at)."""
     match item:
@@ -93,7 +88,7 @@ def build_tree(
             current = current[part]["__children__"]
 
         final_part = parts[-1]
-        if is_folder(item):
+        if isinstance(item, BucketFolder | RepoFolder):
             if final_part not in current:
                 current[final_part] = {"__children__": {}}
         else:
@@ -104,7 +99,7 @@ def build_tree(
     max_date_width = 0
     if not quiet:
         for item in items:
-            if not is_folder(item):
+            if isinstance(item, BucketFile | RepoFile):
                 size_str = format_size(item.size, human_readable)
                 max_size_width = max(max_size_width, len(size_str))
                 date_str = format_date(get_item_date(item), human_readable)
@@ -202,7 +197,7 @@ def print_file_listing(
         out.text("(empty)")
         return
 
-    has_directories = any(is_folder(item) for item in items)
+    has_directories = any(isinstance(item, BucketFolder | RepoFolder) for item in items)
 
     if as_tree:
         quiet = out.mode == OutputFormatWithAuto.quiet
@@ -212,13 +207,13 @@ def print_file_listing(
         print(json.dumps([api_object_to_dict(item) for item in items], indent=2))
     elif out.mode == OutputFormatWithAuto.quiet:
         for item in items:
-            if is_folder(item):
+            if isinstance(item, BucketFolder | RepoFolder):
                 print(f"{item.path}/")
             else:
                 print(item.path)
     else:
         for item in items:
-            if is_folder(item):
+            if isinstance(item, BucketFolder | RepoFolder):
                 date_str = format_date(get_item_date(item), human_readable)
                 print(f"{'':>12}  {date_str:>19}  {item.path}/")
             else:

--- a/src/huggingface_hub/cli/_file_listing.py
+++ b/src/huggingface_hub/cli/_file_listing.py
@@ -182,7 +182,7 @@ def list_repo_files_cmd(
         raise typer.BadParameter("Cannot use --tree with --format json.")
 
     api = get_hf_api(token=token)
-    items = list(api.list_repo_tree(repo_id, recursive=recursive, revision=revision, repo_type=repo_type))
+    items = list(api.list_repo_tree(repo_id, recursive=recursive, revision=revision, repo_type=repo_type, expand=True))
     print_file_listing(items, human_readable=human_readable, as_tree=as_tree, recursive=recursive)
 
 

--- a/src/huggingface_hub/cli/_file_listing.py
+++ b/src/huggingface_hub/cli/_file_listing.py
@@ -1,4 +1,4 @@
-# Copyright 2025-present, the HuggingFace Inc. team.
+# Copyright 2026-present, the HuggingFace Inc. team.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,11 +13,11 @@
 # limitations under the License.
 """Shared helpers for listing files in buckets and repos (tree view, flat view, formatting)."""
 
-from __future__ import annotations
-
 import json
 from datetime import datetime
 from typing import Any, Sequence
+
+import typer
 
 from ._cli_utils import api_object_to_dict, get_hf_api
 from ._output import OutputFormatWithAuto, out
@@ -168,10 +168,8 @@ def list_repo_files_cmd(
     token: str | None,
 ) -> None:
     """List files in a repo on the Hub. Used by models/datasets/spaces ls commands."""
-    import typer
-
     if as_tree and out.mode == OutputFormatWithAuto.json:
-        raise typer.BadParameter("Cannot use --tree with --format json.")
+        raise typer.BadParameter("Cannot use --tree with json format.")
 
     api = get_hf_api(token=token)
     items = list(api.list_repo_tree(repo_id, recursive=recursive, revision=revision, repo_type=repo_type))

--- a/src/huggingface_hub/cli/_file_listing.py
+++ b/src/huggingface_hub/cli/_file_listing.py
@@ -15,28 +15,38 @@
 
 import json
 from datetime import datetime
-from typing import Any, Sequence
+from typing import Sequence
 
 import typer
+
+from huggingface_hub._buckets import BucketFile, BucketFolder
+from huggingface_hub.hf_api import RepoFile, RepoFolder
 
 from ._cli_utils import api_object_to_dict, get_hf_api
 from ._output import OutputFormatWithAuto, out
 
 
-def is_folder(item: Any) -> bool:
-    """Check if an item is a folder (not a file). Files have a `size` attribute."""
-    return not hasattr(item, "size") or not isinstance(getattr(item, "size"), int)
+BucketItem = BucketFile | BucketFolder
+RepoItem = RepoFile | RepoFolder
+ListingItem = BucketItem | RepoItem
 
 
-def get_item_date(item: Any) -> datetime | None:
+def is_folder(item: ListingItem) -> bool:
+    """Check if an item is a folder (not a file)."""
+    return isinstance(item, (BucketFolder, RepoFolder))
+
+
+def get_item_date(item: ListingItem) -> datetime | None:
     """Extract date from an item, supporting both repo items (last_commit.date) and bucket items (mtime/uploaded_at)."""
-    if hasattr(item, "mtime") and getattr(item, "mtime") is not None:
-        return getattr(item, "mtime")
-    if hasattr(item, "uploaded_at") and getattr(item, "uploaded_at") is not None:
-        return getattr(item, "uploaded_at")
-    if hasattr(item, "last_commit") and getattr(item, "last_commit") is not None:
-        return getattr(item, "last_commit").date
-    return None
+    match item:
+        case BucketFile(mtime=mtime) if mtime is not None:
+            return mtime
+        case BucketFile(uploaded_at=uploaded_at) | BucketFolder(uploaded_at=uploaded_at) if uploaded_at is not None:
+            return uploaded_at
+        case RepoFile(last_commit=last_commit) | RepoFolder(last_commit=last_commit) if last_commit is not None:
+            return last_commit.date
+        case _:
+            return None
 
 
 def format_size(size: int | float, human_readable: bool = False) -> str:
@@ -63,7 +73,7 @@ def format_date(dt: datetime | None, human_readable: bool = False) -> str:
 
 
 def build_tree(
-    items: Sequence[Any],
+    items: Sequence[BucketItem] | Sequence[RepoItem],
     human_readable: bool = False,
     quiet: bool = False,
 ) -> list[str]:
@@ -95,7 +105,7 @@ def build_tree(
     if not quiet:
         for item in items:
             if not is_folder(item):
-                size_str = format_size(item.size, human_readable)  # type: ignore[union-attr]
+                size_str = format_size(item.size, human_readable)
                 max_size_width = max(max_size_width, len(size_str))
                 date_str = format_date(get_item_date(item), human_readable)
                 max_date_width = max(max_date_width, len(date_str))
@@ -169,7 +179,7 @@ def list_repo_files_cmd(
 ) -> None:
     """List files in a repo on the Hub. Used by models/datasets/spaces ls commands."""
     if as_tree and out.mode == OutputFormatWithAuto.json:
-        raise typer.BadParameter("Cannot use --tree with json format.")
+        raise typer.BadParameter("Cannot use --tree with --format json.")
 
     api = get_hf_api(token=token)
     items = list(api.list_repo_tree(repo_id, recursive=recursive, revision=revision, repo_type=repo_type))
@@ -177,7 +187,7 @@ def list_repo_files_cmd(
 
 
 def print_file_listing(
-    items: Sequence[Any],
+    items: Sequence[BucketItem] | Sequence[RepoItem],
     *,
     human_readable: bool = False,
     as_tree: bool = False,
@@ -212,7 +222,7 @@ def print_file_listing(
                 date_str = format_date(get_item_date(item), human_readable)
                 print(f"{'':>12}  {date_str:>19}  {item.path}/")
             else:
-                size_str = format_size(item.size, human_readable)  # type: ignore[union-attr]
+                size_str = format_size(item.size, human_readable)
                 date_str = format_date(get_item_date(item), human_readable)
                 print(f"{size_str:>12}  {date_str:>19}  {item.path}")
 

--- a/src/huggingface_hub/cli/buckets.py
+++ b/src/huggingface_hub/cli/buckets.py
@@ -235,8 +235,6 @@ def _list_buckets(
         raise typer.BadParameter("Cannot use --tree when listing buckets.")
     if recursive:
         raise typer.BadParameter("Cannot use --recursive when listing buckets.")
-    if human_readable:
-        raise typer.BadParameter("Cannot use --human-readable when listing buckets.")
 
     # Handle hf://buckets/namespace format
     if namespace is not None and namespace.startswith(BUCKET_PREFIX):

--- a/src/huggingface_hub/cli/buckets.py
+++ b/src/huggingface_hub/cli/buckets.py
@@ -74,11 +74,6 @@ def _parse_bucket_argument(argument: str) -> tuple[str, str]:
         )
 
 
-def _format_size(size: int | float, human_readable: bool = False) -> str:
-    """Format a size in bytes. Thin wrapper kept for `_list_buckets`."""
-    return format_size(size, human_readable)
-
-
 @buckets_cli.command(
     name="create",
     examples=[
@@ -252,7 +247,7 @@ def _list_buckets(
         {
             "id": bucket.id,
             "private": bucket.private,
-            "size": _format_size(bucket.size, human_readable) if human_readable else bucket.size,
+            "size": format_size(bucket.size, human_readable) if human_readable else bucket.size,
             "total_files": bucket.total_files,
             "created_at": bucket.created_at,
         }
@@ -483,7 +478,7 @@ def remove(
 
         file_paths = [f.path for f in matched_files]
         total_size = sum(f.size for f in matched_files)
-        size_str = _format_size(total_size, human_readable=True)
+        size_str = format_size(total_size, human_readable=True)
 
         if not file_paths:
             out.text("No files to remove.")

--- a/src/huggingface_hub/cli/buckets.py
+++ b/src/huggingface_hub/cli/buckets.py
@@ -235,6 +235,8 @@ def _list_buckets(
         raise typer.BadParameter("Cannot use --tree when listing buckets.")
     if recursive:
         raise typer.BadParameter("Cannot use --recursive when listing buckets.")
+    if human_readable:
+        raise typer.BadParameter("Cannot use --human-readable when listing buckets.")
 
     # Handle hf://buckets/namespace format
     if namespace is not None and namespace.startswith(BUCKET_PREFIX):

--- a/src/huggingface_hub/cli/buckets.py
+++ b/src/huggingface_hub/cli/buckets.py
@@ -13,10 +13,8 @@
 # limitations under the License.
 """Contains commands to interact with buckets via the CLI."""
 
-import json
 import os
 import sys
-from datetime import datetime
 from typing import Annotated
 
 import typer
@@ -25,7 +23,6 @@ from huggingface_hub import logging
 from huggingface_hub._buckets import (
     BUCKET_PREFIX,
     BucketFile,
-    BucketFolder,
     FilterMatcher,
     _is_bucket_path,
     _parse_bucket_path,
@@ -43,10 +40,10 @@ from ._cli_utils import (
     FormatWithAutoOpt,
     SearchOpt,
     TokenOpt,
-    api_object_to_dict,
     get_hf_api,
     typer_factory,
 )
+from ._file_listing import format_size, print_file_listing
 from ._output import OutputFormatWithAuto, out
 
 
@@ -78,133 +75,8 @@ def _parse_bucket_argument(argument: str) -> tuple[str, str]:
 
 
 def _format_size(size: int | float, human_readable: bool = False) -> str:
-    """Format a size in bytes."""
-    if not human_readable:
-        return str(size)
-
-    for unit in ["B", "KB", "MB", "GB", "TB"]:
-        if size < 1000:
-            if unit == "B":
-                return f"{size} {unit}"
-            return f"{size:.1f} {unit}"
-        size /= 1000
-    return f"{size:.1f} PB"
-
-
-def _format_mtime(mtime: datetime | None, human_readable: bool = False) -> str:
-    """Format mtime datetime to a readable date string."""
-    if mtime is None:
-        return ""
-    if human_readable:
-        return mtime.strftime("%b %d %H:%M")
-    return mtime.strftime("%Y-%m-%d %H:%M:%S")
-
-
-def _build_tree(
-    items: list[BucketFile | BucketFolder],
-    human_readable: bool = False,
-    quiet: bool = False,
-) -> list[str]:
-    """Build a tree representation of files and directories.
-
-    Produces ASCII tree with size and date columns before the tree connector.
-    When quiet=True, only the tree structure is shown (no size/date).
-
-    Args:
-        items: List of BucketFile/BucketFolder items
-        human_readable: Whether to show human-readable sizes and short dates
-        quiet: If True, show only the tree structure without sizes/dates
-
-    Returns:
-        List of formatted tree lines
-    """
-    # Build a nested structure
-    tree: dict = {}
-
-    for item in items:
-        parts = item.path.split("/")
-        current = tree
-        for part in parts[:-1]:
-            if part not in current:
-                current[part] = {"__children__": {}}
-            current = current[part]["__children__"]
-
-        final_part = parts[-1]
-        if isinstance(item, BucketFolder):
-            if final_part not in current:
-                current[final_part] = {"__children__": {}}
-        else:
-            current[final_part] = {"__item__": item}
-
-    # Compute prefix width for alignment (size + date columns)
-    prefix_width = 0
-    max_size_width = 0
-    max_date_width = 0
-    if not quiet:
-        for item in items:
-            if isinstance(item, BucketFile):
-                size_str = _format_size(item.size, human_readable)
-                max_size_width = max(max_size_width, len(size_str))
-                date_str = _format_mtime(item.mtime, human_readable)
-                max_date_width = max(max_date_width, len(date_str))
-        if max_size_width > 0:
-            prefix_width = max_size_width + 2 + max_date_width
-
-    # Render tree
-    lines: list[str] = []
-    _render_tree(
-        tree,
-        lines,
-        "",
-        prefix_width=prefix_width,
-        max_size_width=max_size_width,
-        human_readable=human_readable,
-    )
-    return lines
-
-
-def _render_tree(
-    node: dict,
-    lines: list[str],
-    indent: str,
-    prefix_width: int = 0,
-    max_size_width: int = 0,
-    human_readable: bool = False,
-) -> None:
-    """Recursively render a tree structure with size+date prefix."""
-    items = sorted(node.items())
-    for i, (name, value) in enumerate(items):
-        is_last = i == len(items) - 1
-        connector = "└── " if is_last else "├── "
-
-        is_dir = "__children__" in value
-        children = value.get("__children__", {})
-
-        if prefix_width > 0:
-            if is_dir:
-                prefix = " " * prefix_width
-            else:
-                item = value.get("__item__")
-                if item is not None:
-                    size_str = _format_size(item.size, human_readable)
-                    date_str = _format_mtime(item.mtime, human_readable)
-                    prefix = f"{size_str:>{max_size_width}}  {date_str}"
-                else:
-                    prefix = " " * prefix_width
-            lines.append(f"{prefix}  {indent}{connector}{name}{'/' if is_dir else ''}")
-        else:
-            lines.append(f"{indent}{connector}{name}{'/' if is_dir else ''}")
-
-        if children:
-            child_indent = indent + ("    " if is_last else "│   ")
-            _render_tree(
-                children,
-                lines,
-                child_indent,
-                prefix_width=prefix_width,
-                max_size_width=max_size_width,
-                human_readable=human_readable,
-            )
+    """Format a size in bytes. Thin wrapper kept for `_list_buckets`."""
+    return format_size(size, human_readable)
 
 
 @buckets_cli.command(
@@ -397,7 +269,6 @@ def _list_files(
     token: str | None,
 ) -> None:
     """List files in a bucket."""
-    # Validate incompatible flags
     if as_tree and out.mode == OutputFormatWithAuto.json:
         raise typer.BadParameter("Cannot use --tree with --format json.")
 
@@ -408,7 +279,6 @@ def _list_files(
     except ValueError as e:
         raise typer.BadParameter(str(e))
 
-    # Fetch items from the bucket
     items = list(
         api.list_bucket_tree(
             bucket_id,
@@ -417,38 +287,7 @@ def _list_files(
         )
     )
 
-    if not items:
-        out.text("(empty)")
-        return
-
-    has_directories = any(isinstance(item, BucketFolder) for item in items)
-
-    if as_tree:
-        # Tree is a human-only view — print directly regardless of mode
-        quiet = out.mode == OutputFormatWithAuto.quiet
-        for line in _build_tree(items, human_readable=human_readable, quiet=quiet):
-            print(line)
-    elif out.mode == OutputFormatWithAuto.json:
-        print(json.dumps([api_object_to_dict(item) for item in items], indent=2))
-    elif out.mode == OutputFormatWithAuto.quiet:
-        for item in items:
-            if isinstance(item, BucketFolder):
-                print(f"{item.path}/")
-            else:
-                print(item.path)
-    else:
-        # Flat table format
-        for item in items:
-            if isinstance(item, BucketFolder):
-                mtime_str = _format_mtime(item.uploaded_at, human_readable)
-                print(f"{'':>12}  {mtime_str:>19}  {item.path}/")
-            else:
-                size_str = _format_size(item.size, human_readable)
-                mtime_str = _format_mtime(item.mtime, human_readable)
-                print(f"{size_str:>12}  {mtime_str:>19}  {item.path}")
-
-    if not recursive and has_directories:
-        out.hint("Use -R to list files recursively.")
+    print_file_listing(items, human_readable=human_readable, as_tree=as_tree, recursive=recursive)
 
 
 @buckets_cli.command(

--- a/src/huggingface_hub/cli/datasets.py
+++ b/src/huggingface_hub/cli/datasets.py
@@ -116,7 +116,7 @@ def datasets_ls(
     When called with a dataset ID, lists files in that dataset repo.
     """
     if repo_id is not None:
-        list_repo_files_cmd(
+        return list_repo_files_cmd(
             repo_id=repo_id,
             repo_type="dataset",
             human_readable=human_readable,
@@ -125,29 +125,30 @@ def datasets_ls(
             revision=revision,
             token=token,
         )
-    else:
-        if as_tree:
-            raise typer.BadParameter("Cannot use --tree when listing datasets.")
-        if recursive:
-            raise typer.BadParameter("Cannot use --recursive when listing datasets.")
-        if human_readable:
-            raise typer.BadParameter("Cannot use --human-readable when listing datasets.")
-        if revision is not None:
-            raise typer.BadParameter("Cannot use --revision when listing datasets.")
-        api = get_hf_api(token=token)
-        sort_key = sort.value if sort else None
-        results = [
-            api_object_to_dict(dataset_info)
-            for dataset_info in api.list_datasets(
-                filter=filter,
-                author=author,
-                search=search,
-                sort=sort_key,
-                limit=limit,
-                expand=expand,  # type: ignore
-            )
-        ]
-        out.table(results)
+
+    if as_tree:
+        raise typer.BadParameter("Cannot use --tree when listing datasets.")
+    if recursive:
+        raise typer.BadParameter("Cannot use --recursive when listing datasets.")
+    if human_readable:
+        raise typer.BadParameter("Cannot use --human-readable when listing datasets.")
+    if revision is not None:
+        raise typer.BadParameter("Cannot use --revision when listing datasets.")
+
+    api = get_hf_api(token=token)
+    sort_key = sort.value if sort else None
+    results = [
+        api_object_to_dict(dataset_info)
+        for dataset_info in api.list_datasets(
+            filter=filter,
+            author=author,
+            search=search,
+            sort=sort_key,
+            limit=limit,
+            expand=expand,  # type: ignore
+        )
+    ]
+    out.table(results)
 
 
 @datasets_cli.command(

--- a/src/huggingface_hub/cli/datasets.py
+++ b/src/huggingface_hub/cli/datasets.py
@@ -116,6 +116,18 @@ def datasets_ls(
     When called with a dataset ID, lists files in that dataset repo.
     """
     if repo_id is not None:
+        if search is not None:
+            raise typer.BadParameter("Cannot use --search when listing files.")
+        if author is not None:
+            raise typer.BadParameter("Cannot use --author when listing files.")
+        if filter is not None:
+            raise typer.BadParameter("Cannot use --filter when listing files.")
+        if sort is not None:
+            raise typer.BadParameter("Cannot use --sort when listing files.")
+        if limit != 10:
+            raise typer.BadParameter("Cannot use --limit when listing files.")
+        if expand is not None:
+            raise typer.BadParameter("Cannot use --expand when listing files.")
         return list_repo_files_cmd(
             repo_id=repo_id,
             repo_type="dataset",

--- a/src/huggingface_hub/cli/datasets.py
+++ b/src/huggingface_hub/cli/datasets.py
@@ -47,6 +47,7 @@ from ._cli_utils import (
     make_expand_properties_parser,
     typer_factory,
 )
+from ._file_listing import list_repo_files_cmd
 from ._output import OutputFormatWithAuto, out
 
 
@@ -74,9 +75,16 @@ datasets_cli = typer_factory(help="Interact with datasets on the Hub.")
         "hf datasets ls --sort downloads --limit 10",
         'hf datasets ls --search "code"',
         "hf datasets ls --filter benchmark:official",
+        "hf datasets ls HuggingFaceFW/fineweb",
+        "hf datasets ls HuggingFaceFW/fineweb -R",
+        "hf datasets ls HuggingFaceFW/fineweb --tree -h",
     ],
 )
 def datasets_ls(
+    repo_id: Annotated[
+        str | None,
+        typer.Argument(help="Dataset ID (e.g. `username/repo-name`) to list files from. If omitted, lists datasets."),
+    ] = None,
     search: SearchOpt = None,
     author: AuthorOpt = None,
     filter: FilterOpt = None,
@@ -86,24 +94,60 @@ def datasets_ls(
     ] = None,
     limit: LimitOpt = 10,
     expand: ExpandOpt = None,
+    human_readable: Annotated[
+        bool,
+        typer.Option("--human-readable", "-h", help="Show sizes in human readable format (only for listing files)."),
+    ] = False,
+    as_tree: Annotated[
+        bool,
+        typer.Option("--tree", help="List files in tree format (only for listing files)."),
+    ] = False,
+    recursive: Annotated[
+        bool,
+        typer.Option("--recursive", "-R", help="List files recursively (only for listing files)."),
+    ] = False,
+    revision: RevisionOpt = None,
     format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
     token: TokenOpt = None,
 ) -> None:
-    """List datasets on the Hub."""
-    api = get_hf_api(token=token)
-    sort_key = sort.value if sort else None
-    results = [
-        api_object_to_dict(dataset_info)
-        for dataset_info in api.list_datasets(
-            filter=filter,
-            author=author,
-            search=search,
-            sort=sort_key,
-            limit=limit,
-            expand=expand,  # type: ignore
+    """List datasets on the Hub, or files in a dataset repo.
+
+    When called with no argument, lists datasets on the Hub.
+    When called with a dataset ID, lists files in that dataset repo.
+    """
+    if repo_id is not None:
+        list_repo_files_cmd(
+            repo_id=repo_id,
+            repo_type="dataset",
+            human_readable=human_readable,
+            as_tree=as_tree,
+            recursive=recursive,
+            revision=revision,
+            token=token,
         )
-    ]
-    out.table(results)
+    else:
+        if as_tree:
+            raise typer.BadParameter("Cannot use --tree when listing datasets.")
+        if recursive:
+            raise typer.BadParameter("Cannot use --recursive when listing datasets.")
+        if human_readable:
+            raise typer.BadParameter("Cannot use --human-readable when listing datasets.")
+        if revision is not None:
+            raise typer.BadParameter("Cannot use --revision when listing datasets.")
+        api = get_hf_api(token=token)
+        sort_key = sort.value if sort else None
+        results = [
+            api_object_to_dict(dataset_info)
+            for dataset_info in api.list_datasets(
+                filter=filter,
+                author=author,
+                search=search,
+                sort=sort_key,
+                limit=limit,
+                expand=expand,  # type: ignore
+            )
+        ]
+        out.table(results)
 
 
 @datasets_cli.command(

--- a/src/huggingface_hub/cli/models.py
+++ b/src/huggingface_hub/cli/models.py
@@ -118,7 +118,7 @@ def models_ls(
     When called with a model ID, lists files in that model repo.
     """
     if repo_id is not None:
-        list_repo_files_cmd(
+        return list_repo_files_cmd(
             repo_id=repo_id,
             repo_type="model",
             human_readable=human_readable,
@@ -127,30 +127,30 @@ def models_ls(
             revision=revision,
             token=token,
         )
-    else:
-        if as_tree:
-            raise typer.BadParameter("Cannot use --tree when listing models.")
-        if recursive:
-            raise typer.BadParameter("Cannot use --recursive when listing models.")
-        if human_readable:
-            raise typer.BadParameter("Cannot use --human-readable when listing models.")
-        if revision is not None:
-            raise typer.BadParameter("Cannot use --revision when listing models.")
-        api = get_hf_api(token=token)
-        sort_key = sort.value if sort else None
-        results = [
-            api_object_to_dict(model_info)
-            for model_info in api.list_models(
-                filter=filter,
-                author=author,
-                search=search,
-                num_parameters=num_parameters,
-                sort=sort_key,
-                limit=limit,
-                expand=expand,  # type: ignore
-            )
-        ]
-        out.table(results)
+
+    if as_tree:
+        raise typer.BadParameter("Cannot use --tree when listing models.")
+    if recursive:
+        raise typer.BadParameter("Cannot use --recursive when listing models.")
+    if human_readable:
+        raise typer.BadParameter("Cannot use --human-readable when listing models.")
+    if revision is not None:
+        raise typer.BadParameter("Cannot use --revision when listing models.")
+    api = get_hf_api(token=token)
+    sort_key = sort.value if sort else None
+    results = [
+        api_object_to_dict(model_info)
+        for model_info in api.list_models(
+            filter=filter,
+            author=author,
+            search=search,
+            num_parameters=num_parameters,
+            sort=sort_key,
+            limit=limit,
+            expand=expand,  # type: ignore
+        )
+    ]
+    out.table(results)
 
 
 @models_cli.command(

--- a/src/huggingface_hub/cli/models.py
+++ b/src/huggingface_hub/cli/models.py
@@ -118,6 +118,20 @@ def models_ls(
     When called with a model ID, lists files in that model repo.
     """
     if repo_id is not None:
+        if search is not None:
+            raise typer.BadParameter("Cannot use --search when listing files.")
+        if author is not None:
+            raise typer.BadParameter("Cannot use --author when listing files.")
+        if filter is not None:
+            raise typer.BadParameter("Cannot use --filter when listing files.")
+        if num_parameters is not None:
+            raise typer.BadParameter("Cannot use --num-parameters when listing files.")
+        if sort is not None:
+            raise typer.BadParameter("Cannot use --sort when listing files.")
+        if limit != 10:
+            raise typer.BadParameter("Cannot use --limit when listing files.")
+        if expand is not None:
+            raise typer.BadParameter("Cannot use --expand when listing files.")
         return list_repo_files_cmd(
             repo_id=repo_id,
             repo_type="model",

--- a/src/huggingface_hub/cli/models.py
+++ b/src/huggingface_hub/cli/models.py
@@ -46,6 +46,7 @@ from ._cli_utils import (
     make_expand_properties_parser,
     typer_factory,
 )
+from ._file_listing import list_repo_files_cmd
 from ._output import OutputFormatWithAuto, out
 
 
@@ -72,9 +73,16 @@ models_cli = typer_factory(help="Interact with models on the Hub.")
         "hf models ls --sort downloads --limit 10",
         'hf models ls --search "llama" --author meta-llama',
         "hf models ls --num-parameters min:6B,max:128B --sort likes",
+        "hf models ls meta-llama/Llama-3.2-1B-Instruct",
+        "hf models ls meta-llama/Llama-3.2-1B-Instruct -R",
+        "hf models ls meta-llama/Llama-3.2-1B-Instruct --tree -h",
     ],
 )
 def models_ls(
+    repo_id: Annotated[
+        str | None,
+        typer.Argument(help="Model ID (e.g. `username/repo-name`) to list files from. If omitted, lists models."),
+    ] = None,
     search: SearchOpt = None,
     author: AuthorOpt = None,
     filter: FilterOpt = None,
@@ -88,25 +96,61 @@ def models_ls(
     ] = None,
     limit: LimitOpt = 10,
     expand: ExpandOpt = None,
+    human_readable: Annotated[
+        bool,
+        typer.Option("--human-readable", "-h", help="Show sizes in human readable format (only for listing files)."),
+    ] = False,
+    as_tree: Annotated[
+        bool,
+        typer.Option("--tree", help="List files in tree format (only for listing files)."),
+    ] = False,
+    recursive: Annotated[
+        bool,
+        typer.Option("--recursive", "-R", help="List files recursively (only for listing files)."),
+    ] = False,
+    revision: RevisionOpt = None,
     format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
     token: TokenOpt = None,
 ) -> None:
-    """List models on the Hub."""
-    api = get_hf_api(token=token)
-    sort_key = sort.value if sort else None
-    results = [
-        api_object_to_dict(model_info)
-        for model_info in api.list_models(
-            filter=filter,
-            author=author,
-            search=search,
-            num_parameters=num_parameters,
-            sort=sort_key,
-            limit=limit,
-            expand=expand,  # type: ignore
+    """List models on the Hub, or files in a model repo.
+
+    When called with no argument, lists models on the Hub.
+    When called with a model ID, lists files in that model repo.
+    """
+    if repo_id is not None:
+        list_repo_files_cmd(
+            repo_id=repo_id,
+            repo_type="model",
+            human_readable=human_readable,
+            as_tree=as_tree,
+            recursive=recursive,
+            revision=revision,
+            token=token,
         )
-    ]
-    out.table(results)
+    else:
+        if as_tree:
+            raise typer.BadParameter("Cannot use --tree when listing models.")
+        if recursive:
+            raise typer.BadParameter("Cannot use --recursive when listing models.")
+        if human_readable:
+            raise typer.BadParameter("Cannot use --human-readable when listing models.")
+        if revision is not None:
+            raise typer.BadParameter("Cannot use --revision when listing models.")
+        api = get_hf_api(token=token)
+        sort_key = sort.value if sort else None
+        results = [
+            api_object_to_dict(model_info)
+            for model_info in api.list_models(
+                filter=filter,
+                author=author,
+                search=search,
+                num_parameters=num_parameters,
+                sort=sort_key,
+                limit=limit,
+                expand=expand,  # type: ignore
+            )
+        ]
+        out.table(results)
 
 
 @models_cli.command(

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -96,9 +96,9 @@ spaces_cli.add_typer(volumes_cli, name="volumes")
     examples=[
         "hf spaces ls --limit 10",
         'hf spaces ls --search "chatbot" --author huggingface',
-        "hf spaces ls enzostvs/deepsite",
-        "hf spaces ls enzostvs/deepsite -R",
-        "hf spaces ls enzostvs/deepsite --tree -h",
+        "hf spaces ls victor/deepsite",
+        "hf spaces ls victor/deepsite -R",
+        "hf spaces ls victor/deepsite --tree -h",
     ],
 )
 def spaces_ls(

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -137,7 +137,7 @@ def spaces_ls(
     When called with a space ID, lists files in that space repo.
     """
     if repo_id is not None:
-        list_repo_files_cmd(
+        return list_repo_files_cmd(
             repo_id=repo_id,
             repo_type="space",
             human_readable=human_readable,
@@ -146,29 +146,29 @@ def spaces_ls(
             revision=revision,
             token=token,
         )
-    else:
-        if as_tree:
-            raise typer.BadParameter("Cannot use --tree when listing spaces.")
-        if recursive:
-            raise typer.BadParameter("Cannot use --recursive when listing spaces.")
-        if human_readable:
-            raise typer.BadParameter("Cannot use --human-readable when listing spaces.")
-        if revision is not None:
-            raise typer.BadParameter("Cannot use --revision when listing spaces.")
-        api = get_hf_api(token=token)
-        sort_key = sort.value if sort else None
-        results = [
-            api_object_to_dict(space_info)
-            for space_info in api.list_spaces(
-                filter=filter,
-                author=author,
-                search=search,
-                sort=sort_key,
-                limit=limit,
-                expand=expand,  # type: ignore[arg-type]
-            )
-        ]
-        out.table(results)
+
+    if as_tree:
+        raise typer.BadParameter("Cannot use --tree when listing spaces.")
+    if recursive:
+        raise typer.BadParameter("Cannot use --recursive when listing spaces.")
+    if human_readable:
+        raise typer.BadParameter("Cannot use --human-readable when listing spaces.")
+    if revision is not None:
+        raise typer.BadParameter("Cannot use --revision when listing spaces.")
+    api = get_hf_api(token=token)
+    sort_key = sort.value if sort else None
+    results = [
+        api_object_to_dict(space_info)
+        for space_info in api.list_spaces(
+            filter=filter,
+            author=author,
+            search=search,
+            sort=sort_key,
+            limit=limit,
+            expand=expand,  # type: ignore[arg-type]
+        )
+    ]
+    out.table(results)
 
 
 @spaces_cli.command(

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -66,6 +66,7 @@ from ._cli_utils import (
     parse_volumes,
     typer_factory,
 )
+from ._file_listing import list_repo_files_cmd
 from ._output import OutputFormatWithAuto, out
 
 
@@ -95,9 +96,16 @@ spaces_cli.add_typer(volumes_cli, name="volumes")
     examples=[
         "hf spaces ls --limit 10",
         'hf spaces ls --search "chatbot" --author huggingface',
+        "hf spaces ls enzostvs/deepsite",
+        "hf spaces ls enzostvs/deepsite -R",
+        "hf spaces ls enzostvs/deepsite --tree -h",
     ],
 )
 def spaces_ls(
+    repo_id: Annotated[
+        str | None,
+        typer.Argument(help="Space ID (e.g. `username/repo-name`) to list files from. If omitted, lists spaces."),
+    ] = None,
     search: SearchOpt = None,
     author: AuthorOpt = None,
     filter: FilterOpt = None,
@@ -107,24 +115,60 @@ def spaces_ls(
     ] = None,
     limit: LimitOpt = 10,
     expand: ExpandOpt = None,
+    human_readable: Annotated[
+        bool,
+        typer.Option("--human-readable", "-h", help="Show sizes in human readable format (only for listing files)."),
+    ] = False,
+    as_tree: Annotated[
+        bool,
+        typer.Option("--tree", help="List files in tree format (only for listing files)."),
+    ] = False,
+    recursive: Annotated[
+        bool,
+        typer.Option("--recursive", "-R", help="List files recursively (only for listing files)."),
+    ] = False,
+    revision: RevisionOpt = None,
     format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
     token: TokenOpt = None,
 ) -> None:
-    """List spaces on the Hub."""
-    api = get_hf_api(token=token)
-    sort_key = sort.value if sort else None
-    results = [
-        api_object_to_dict(space_info)
-        for space_info in api.list_spaces(
-            filter=filter,
-            author=author,
-            search=search,
-            sort=sort_key,
-            limit=limit,
-            expand=expand,  # type: ignore[arg-type]
+    """List spaces on the Hub, or files in a space repo.
+
+    When called with no argument, lists spaces on the Hub.
+    When called with a space ID, lists files in that space repo.
+    """
+    if repo_id is not None:
+        list_repo_files_cmd(
+            repo_id=repo_id,
+            repo_type="space",
+            human_readable=human_readable,
+            as_tree=as_tree,
+            recursive=recursive,
+            revision=revision,
+            token=token,
         )
-    ]
-    out.table(results)
+    else:
+        if as_tree:
+            raise typer.BadParameter("Cannot use --tree when listing spaces.")
+        if recursive:
+            raise typer.BadParameter("Cannot use --recursive when listing spaces.")
+        if human_readable:
+            raise typer.BadParameter("Cannot use --human-readable when listing spaces.")
+        if revision is not None:
+            raise typer.BadParameter("Cannot use --revision when listing spaces.")
+        api = get_hf_api(token=token)
+        sort_key = sort.value if sort else None
+        results = [
+            api_object_to_dict(space_info)
+            for space_info in api.list_spaces(
+                filter=filter,
+                author=author,
+                search=search,
+                sort=sort_key,
+                limit=limit,
+                expand=expand,  # type: ignore[arg-type]
+            )
+        ]
+        out.table(results)
 
 
 @spaces_cli.command(

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -137,6 +137,18 @@ def spaces_ls(
     When called with a space ID, lists files in that space repo.
     """
     if repo_id is not None:
+        if search is not None:
+            raise typer.BadParameter("Cannot use --search when listing files.")
+        if author is not None:
+            raise typer.BadParameter("Cannot use --author when listing files.")
+        if filter is not None:
+            raise typer.BadParameter("Cannot use --filter when listing files.")
+        if sort is not None:
+            raise typer.BadParameter("Cannot use --sort when listing files.")
+        if limit != 10:
+            raise typer.BadParameter("Cannot use --limit when listing files.")
+        if expand is not None:
+            raise typer.BadParameter("Cannot use --expand when listing files.")
         return list_repo_files_cmd(
             repo_id=repo_id,
             repo_type="space",

--- a/tests/test_buckets_cli.py
+++ b/tests/test_buckets_cli.py
@@ -564,14 +564,14 @@ def _populated_bucket(api: HfApi) -> str:
 
 @pytest.fixture
 def tree_bucket(monkeypatch: pytest.MonkeyPatch, _populated_bucket: str) -> str:
-    """Use populated bucket + make _format_mtime return a fixed date for exact output matching."""
+    """Use populated bucket + make format_date return a fixed date for exact output matching."""
 
-    def _fixed(mtime, human_readable=False):
-        if mtime is None:
+    def _fixed(dt, human_readable=False):
+        if dt is None:
             return ""
         return MTIME_FIX_SHORT if human_readable else MTIME_FIX
 
-    monkeypatch.setattr("huggingface_hub.cli.buckets._format_mtime", _fixed)
+    monkeypatch.setattr("huggingface_hub.cli._file_listing.format_date", _fixed)
 
     return _populated_bucket
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,7 +22,7 @@ from huggingface_hub.cli.hf import app
 from huggingface_hub.cli.jobs import _parse_namespace_from_job_id
 from huggingface_hub.cli.upload import _resolve_upload_paths, upload
 from huggingface_hub.errors import CLIError, RevisionNotFoundError
-from huggingface_hub.hf_api import ModelInfo, RepoFile, RepoFolder
+from huggingface_hub.hf_api import ModelInfo
 from huggingface_hub.utils import (
     CachedFileInfo,
     CachedRepoInfo,
@@ -1785,39 +1785,38 @@ class TestModelsLsCommand:
         assert result.exit_code == 2
         assert "Invalid value" in result.output
 
-    def test_models_ls_files(self, runner: CliRunner) -> None:
-        """When a repo_id is passed, `hf models ls <repo_id>` lists files in that repo."""
-        file1 = RepoFile(path="config.json", size=1234, oid="abc123")
-        file2 = RepoFile(path="model.safetensors", size=5000000, oid="def456")
-        folder = RepoFolder(path="subfolder", oid="ghi789")
-
-        with patch("huggingface_hub.cli._file_listing.get_hf_api") as api_cls:
-            api = api_cls.return_value
-            api.list_repo_tree.return_value = iter([file1, file2, folder])
-            result = runner.invoke(app, ["models", "ls", "user/my-model", "--format", "json"])
-
+    @with_production_testing
+    def test_models_ls_files_json(self, runner: CliRunner) -> None:
+        """List files from a real model repo on the Hub (JSON output)."""
+        result = runner.invoke(app, ["models", "ls", "t5-small", "--format", "json"])
         assert result.exit_code == 0
         output = json.loads(result.stdout)
-        assert len(output) == 3
-        assert output[0]["path"] == "config.json"
-        api.list_repo_tree.assert_called_once_with("user/my-model", recursive=False, revision=None, repo_type="model")
+        paths = {item["path"] for item in output}
+        assert "config.json" in paths
+        assert "tokenizer.json" in paths
 
-    def test_models_ls_files_recursive(self, runner: CliRunner) -> None:
-        with patch("huggingface_hub.cli._file_listing.get_hf_api") as api_cls:
-            api = api_cls.return_value
-            api.list_repo_tree.return_value = iter([])
-            result = runner.invoke(app, ["models", "ls", "user/my-model", "-R"])
-
+    @with_production_testing
+    def test_models_ls_files_quiet(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["models", "ls", "t5-small", "--format", "quiet"])
         assert result.exit_code == 0
-        api.list_repo_tree.assert_called_once_with("user/my-model", recursive=True, revision=None, repo_type="model")
+        lines = result.stdout.strip().splitlines()
+        assert "config.json" in lines
+        assert "onnx/" in lines
 
-    def test_models_ls_files_tree_incompatible_with_json(self, runner: CliRunner) -> None:
-        with patch("huggingface_hub.cli._file_listing.get_hf_api") as api_cls:
-            api = api_cls.return_value
-            api.list_repo_tree.return_value = iter([])
-            result = runner.invoke(app, ["models", "ls", "user/my-model", "--tree", "--format", "json"])
+    @with_production_testing
+    def test_models_ls_files_tree(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["models", "ls", "t5-small", "--tree"])
+        assert result.exit_code == 0
+        assert "├──" in result.stdout or "└──" in result.stdout
+        assert "config.json" in result.stdout
 
-        assert result.exit_code != 0
+    @with_production_testing
+    def test_models_ls_files_recursive(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["models", "ls", "t5-small", "-R", "--format", "quiet"])
+        assert result.exit_code == 0
+        lines = result.stdout.strip().splitlines()
+        assert "config.json" in lines
+        assert any(line.startswith("onnx/") for line in lines)
 
     def test_models_ls_tree_without_repo_id_fails(self, runner: CliRunner) -> None:
         result = runner.invoke(app, ["models", "ls", "--tree"])
@@ -1835,19 +1834,14 @@ class TestDatasetsLsCommand:
         _, kwargs = api.list_datasets.call_args
         assert kwargs["sort"] == "downloads"
 
+    @with_production_testing
     def test_datasets_ls_files(self, runner: CliRunner) -> None:
-        file1 = RepoFile(path="data.parquet", size=99999, oid="abc")
-        with patch("huggingface_hub.cli._file_listing.get_hf_api") as api_cls:
-            api = api_cls.return_value
-            api.list_repo_tree.return_value = iter([file1])
-            result = runner.invoke(app, ["datasets", "ls", "user/my-dataset", "--format", "json"])
-
+        """List files from a real dataset repo on the Hub."""
+        result = runner.invoke(app, ["datasets", "ls", "rajpurkar/squad", "--format", "json"])
         assert result.exit_code == 0
         output = json.loads(result.stdout)
-        assert output[0]["path"] == "data.parquet"
-        api.list_repo_tree.assert_called_once_with(
-            "user/my-dataset", recursive=False, revision=None, repo_type="dataset"
-        )
+        paths = {item["path"] for item in output}
+        assert "README.md" in paths
 
 
 class TestModelsCardCommand:
@@ -2133,17 +2127,15 @@ class TestSpacesLsCommand:
         assert result.exit_code == 2
         assert "Invalid value" in result.output
 
+    @with_production_testing
     def test_spaces_ls_files(self, runner: CliRunner) -> None:
-        file1 = RepoFile(path="app.py", size=512, oid="abc")
-        with patch("huggingface_hub.cli._file_listing.get_hf_api") as api_cls:
-            api = api_cls.return_value
-            api.list_repo_tree.return_value = iter([file1])
-            result = runner.invoke(app, ["spaces", "ls", "user/my-space", "--format", "json"])
-
+        """List files from a real space repo on the Hub."""
+        result = runner.invoke(app, ["spaces", "ls", "gradio/theme_builder", "--format", "json"])
         assert result.exit_code == 0
         output = json.loads(result.stdout)
-        assert output[0]["path"] == "app.py"
-        api.list_repo_tree.assert_called_once_with("user/my-space", recursive=False, revision=None, repo_type="space")
+        paths = {item["path"] for item in output}
+        assert "README.md" in paths
+        assert "run.py" in paths
 
 
 class TestSpacesLogsCommand:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,7 +22,7 @@ from huggingface_hub.cli.hf import app
 from huggingface_hub.cli.jobs import _parse_namespace_from_job_id
 from huggingface_hub.cli.upload import _resolve_upload_paths, upload
 from huggingface_hub.errors import CLIError, RevisionNotFoundError
-from huggingface_hub.hf_api import ModelInfo
+from huggingface_hub.hf_api import ModelInfo, RepoFile, RepoFolder
 from huggingface_hub.utils import (
     CachedFileInfo,
     CachedRepoInfo,
@@ -1785,6 +1785,44 @@ class TestModelsLsCommand:
         assert result.exit_code == 2
         assert "Invalid value" in result.output
 
+    def test_models_ls_files(self, runner: CliRunner) -> None:
+        """When a repo_id is passed, `hf models ls <repo_id>` lists files in that repo."""
+        file1 = RepoFile(path="config.json", size=1234, oid="abc123")
+        file2 = RepoFile(path="model.safetensors", size=5000000, oid="def456")
+        folder = RepoFolder(path="subfolder", oid="ghi789")
+
+        with patch("huggingface_hub.cli._file_listing.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            api.list_repo_tree.return_value = iter([file1, file2, folder])
+            result = runner.invoke(app, ["models", "ls", "user/my-model", "--format", "json"])
+
+        assert result.exit_code == 0
+        output = json.loads(result.stdout)
+        assert len(output) == 3
+        assert output[0]["path"] == "config.json"
+        api.list_repo_tree.assert_called_once_with("user/my-model", recursive=False, revision=None, repo_type="model")
+
+    def test_models_ls_files_recursive(self, runner: CliRunner) -> None:
+        with patch("huggingface_hub.cli._file_listing.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            api.list_repo_tree.return_value = iter([])
+            result = runner.invoke(app, ["models", "ls", "user/my-model", "-R"])
+
+        assert result.exit_code == 0
+        api.list_repo_tree.assert_called_once_with("user/my-model", recursive=True, revision=None, repo_type="model")
+
+    def test_models_ls_files_tree_incompatible_with_json(self, runner: CliRunner) -> None:
+        with patch("huggingface_hub.cli._file_listing.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            api.list_repo_tree.return_value = iter([])
+            result = runner.invoke(app, ["models", "ls", "user/my-model", "--tree", "--format", "json"])
+
+        assert result.exit_code != 0
+
+    def test_models_ls_tree_without_repo_id_fails(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["models", "ls", "--tree"])
+        assert result.exit_code != 0
+
 
 class TestDatasetsLsCommand:
     def test_datasets_ls_with_sort(self, runner: CliRunner) -> None:
@@ -1796,6 +1834,20 @@ class TestDatasetsLsCommand:
         assert result.exit_code == 0
         _, kwargs = api.list_datasets.call_args
         assert kwargs["sort"] == "downloads"
+
+    def test_datasets_ls_files(self, runner: CliRunner) -> None:
+        file1 = RepoFile(path="data.parquet", size=99999, oid="abc")
+        with patch("huggingface_hub.cli._file_listing.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            api.list_repo_tree.return_value = iter([file1])
+            result = runner.invoke(app, ["datasets", "ls", "user/my-dataset", "--format", "json"])
+
+        assert result.exit_code == 0
+        output = json.loads(result.stdout)
+        assert output[0]["path"] == "data.parquet"
+        api.list_repo_tree.assert_called_once_with(
+            "user/my-dataset", recursive=False, revision=None, repo_type="dataset"
+        )
 
 
 class TestModelsCardCommand:
@@ -2080,6 +2132,18 @@ class TestSpacesLsCommand:
         result = runner.invoke(app, ["spaces", "ls", "--sort", "downloads"])
         assert result.exit_code == 2
         assert "Invalid value" in result.output
+
+    def test_spaces_ls_files(self, runner: CliRunner) -> None:
+        file1 = RepoFile(path="app.py", size=512, oid="abc")
+        with patch("huggingface_hub.cli._file_listing.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            api.list_repo_tree.return_value = iter([file1])
+            result = runner.invoke(app, ["spaces", "ls", "user/my-space", "--format", "json"])
+
+        assert result.exit_code == 0
+        output = json.loads(result.stdout)
+        assert output[0]["path"] == "app.py"
+        api.list_repo_tree.assert_called_once_with("user/my-space", recursive=False, revision=None, repo_type="space")
 
 
 class TestSpacesLogsCommand:


### PR DESCRIPTION
### Context: we can list tree from buckets but not from repos. This PR adds support for this.

**For reviewers:** most of the code is a move from the existing code in `buckets.py` to a "repo/bucket-agnostic version". For tests, I've added a few ones for model repos for the main use cases but only 1 for datasets/spaces (same logic anyway). 


Note for a follow-up PR: when too many files (>1000?) IMO we should truncate the output and put a warning "Output has been truncated. Pass --full to get full list". This would be a change for both buckets and repos so I think it's out of scope for this PR. 

----

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

`hf models ls`, `hf datasets ls`, and `hf spaces ls` can now list files from an individual repo when called with a repo ID matching the existing behavior of `hf buckets ls <bucket_id>`. When a positional `repo_id` argument is given, the `ls` command switches from "list repos" to "list files in that repo" mode.

Supports the same options as bucket file listing: `--tree`, `-R` (recursive), `-h` (human-readable sizes), plus `--revision`.


**Examples:**

```
$ hf models ls meta-llama/Llama-3.2-1B-Instruct --format json | jq ".[].path"
Hint: Use -R to list files recursively.
"original"
".gitattributes"
"LICENSE.txt"
"README.md"
"USE_POLICY.md"
"config.json"
"generation_config.json"
"model.safetensors"
"special_tokens_map.json"
"tokenizer.json"
"tokenizer_config.json"
```

```
$ hf datasets ls nvidia/Nemotron-Personas-Korea -R 
              2026-04-20 21:09:08  data/
              2026-04-23 07:42:48  images/
        2504  2026-04-20 21:07:51  .gitattributes
       35929  2026-04-23 07:42:48  README.md
   220263908  2026-04-20 21:09:08  data/train-00000-of-00009.parquet
   220182609  2026-04-20 21:09:08  data/train-00001-of-00009.parquet
   220265631  2026-04-20 21:09:08  data/train-00002-of-00009.parquet
   220283830  2026-04-20 21:09:08  data/train-00003-of-00009.parquet
   220304978  2026-04-20 21:09:08  data/train-00004-of-00009.parquet
   220183836  2026-04-20 21:09:08  data/train-00005-of-00009.parquet
   220384182  2026-04-20 21:09:08  data/train-00006-of-00009.parquet
   220272087  2026-04-20 21:09:08  data/train-00007-of-00009.parquet
   220254045  2026-04-20 21:09:08  data/train-00008-of-00009.parquet
        6148  2026-04-20 23:13:09  images/.DS_Store
       49060  2026-04-20 23:13:09  images/nemotron_personas_korea_age_group_distribution.png
      183123  2026-04-20 23:13:09  images/nemotron_personas_korea_approach.png
      458678  2026-04-20 23:13:09  images/nemotron_personas_korea_education_distribution.png
      108946  2026-04-20 23:13:09  images/nemotron_personas_korea_education_map.png
      152334  2026-04-20 23:13:09  images/nemotron_personas_korea_field_stats.png
      307342  2026-04-20 23:13:09  images/nemotron_personas_korea_household_type_distribution.png
       97610  2026-04-20 23:13:09  images/nemotron_personas_korea_marital_status_distribution.png
      225771  2026-04-20 23:13:09  images/nemotron_personas_korea_occupation.png
      185838  2026-04-20 23:13:09  images/nemotron_personas_korea_schema_en.png
      197596  2026-04-23 07:42:48  images/nemotron_personas_korea_schema_ko.png
```

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://huggingface.slack.com/archives/D0A9313SS3G/p1777446381809169?thread_ts=1777446381.809169&cid=D0A9313SS3G)

<div><a href="https://cursor.com/agents/bc-08f5bc53-8922-5d5c-8da9-913d3e77f6e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08f5bc53-8922-5d5c-8da9-913d3e77f6e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

