### PR TITLE
[Release] Mark minor releases as "latest" on GitHub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -386,7 +386,6 @@ jobs:
           gh release create "${{ needs.prepare.outputs.tag }}" \
             --title "v${{ needs.prepare.outputs.version }}" \
             --draft \
-            --latest=false \
             --generate-notes
 
       # --- Prerelease: generate notes only if no draft exists for this minor ---

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,8 @@
 # to point to the final tag, and opens a PR to bump main to the next dev version (e.g., 1.7.0.dev0).
 #
 # For a patch release, cherry-pick fixes to the release branch first, then trigger a "patch-release" run. This increments
-# the patch version (e.g., 1.6.1), publishes to PyPI, and creates a GitHub release.
+# the patch version (e.g., 1.6.1), publishes to PyPI, and creates a GitHub release. Patch releases are NOT marked as
+# "latest release" on GitHub — only minor releases get that label, so that the latest minor version stays highlighted.
 #
 # The workflow uses GITHUB_TOKEN for most git operations (branch creation, tag push) and a GitHub App token
 # (huggingface-hub-bot) for PR creation in the post-release job. Since events triggered by GITHUB_TOKEN do not
@@ -385,6 +386,7 @@ jobs:
           gh release create "${{ needs.prepare.outputs.tag }}" \
             --title "v${{ needs.prepare.outputs.version }}" \
             --draft \
+            --latest=false \
             --generate-notes
 
       # --- Prerelease: generate notes only if no draft exists for this minor ---
@@ -478,12 +480,14 @@ jobs:
             echo "Updating existing draft release from $EXISTING_TAG to $TAG"
             gh release edit "$EXISTING_TAG" \
               --tag "$TAG" \
-              --prerelease=false
+              --prerelease=false \
+              --latest
           else
             echo "::warning::No draft release found for v${MINOR}. Creating new release with auto-generated notes."
             gh release create "$TAG" \
               --title "v${VERSION}" \
               --draft \
+              --latest \
               --generate-notes
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -486,7 +486,6 @@ jobs:
             gh release create "$TAG" \
               --title "v${VERSION}" \
               --draft \
-              --latest \
               --generate-notes
           fi
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When publishing a GitHub release, **minor releases** should be labelled as "latest release" — patch releases should not take over that label, so that the latest minor version stays highlighted on the repo's releases page.

Changes in `.github/workflows/release.yml`:

- **Minor release — promote draft** (`gh release edit`): added `--latest` so that promoting the prerelease draft to a final release explicitly marks it as "latest".
- Updated the top-of-file comment to document this behavior.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://huggingface.slack.com/archives/C03V11RNS7P/p1777455637766889?thread_ts=1777455637.766889&cid=C03V11RNS7P)

<div><a href="https://cursor.com/agents/bc-4f2d04b0-229e-5cc6-93be-073c69364b8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4f2d04b0-229e-5cc6-93be-073c69364b8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

