### PR TITLE
[Cache] Strip whitespace when reading commit hash from refs file

### DIFF
--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -287,7 +287,7 @@ def snapshot_download(
             if os.path.exists(ref_path):
                 # retrieve commit_hash from refs file
                 with open(ref_path) as f:
-                    commit_hash = f.read()
+                    commit_hash = f.read().strip()
 
         # Try to locate snapshot folder for this commit hash
         if commit_hash is not None and local_dir is None:

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -694,7 +694,7 @@ def _cache_commit_hash_for_specific_revision(storage_folder: str, revision: str,
     if revision != commit_hash:
         ref_path = Path(storage_folder) / "refs" / revision
         ref_path.parent.mkdir(parents=True, exist_ok=True)
-        if not ref_path.exists() or commit_hash != ref_path.read_text():
+        if not ref_path.exists() or commit_hash != ref_path.read_text().strip():
             # Update ref only if has been updated. Could cause useless error in case
             # repo is already cached and user doesn't have write access to cache folder.
             # See https://github.com/huggingface/huggingface_hub/issues/1216.
@@ -1103,7 +1103,7 @@ def _hf_hub_download_to_cache_dir(
                 ref_path = os.path.join(storage_folder, "refs", revision)
                 if os.path.isfile(ref_path):
                     with open(ref_path) as f:
-                        commit_hash = f.read()
+                        commit_hash = f.read().strip()
 
             # Return pointer file if exists
             if commit_hash is not None:
@@ -1516,7 +1516,7 @@ def try_to_load_from_cache(
         revision_file = os.path.join(refs_dir, revision)
         if os.path.isfile(revision_file):
             with open(revision_file) as f:
-                revision = f.read()
+                revision = f.read().strip()
 
     # Check if file is cached as "no_exist"
     if os.path.isfile(os.path.join(no_exist_dir, revision, filename)):

--- a/src/huggingface_hub/utils/_cache_manager.py
+++ b/src/huggingface_hub/utils/_cache_manager.py
@@ -720,7 +720,7 @@ def _scan_cached_repo(repo_path: Path) -> CachedRepoInfo:
 
             ref_name = str(ref_path.relative_to(refs_path))
             with ref_path.open() as f:
-                commit_hash = f.read()
+                commit_hash = f.read().strip()
 
             refs_by_hash[commit_hash].add(ref_name)
 

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -492,6 +492,31 @@ class CachedDownloadTests(unittest.TestCase):
             )
             self.assertEqual(attempt, _CACHED_NO_EXIST)
 
+    def test_try_to_load_from_cache_strips_refs_whitespace(self):
+        """Regression test for #4133.
+
+        Refs files copied between environments may pick up trailing newlines.
+        The commit hash read from `refs/<revision>` must be stripped so the
+        snapshot path resolves correctly.
+        """
+        with SoftTemporaryDirectory() as cache_dir:
+            commit_hash = "f90f040c7cb709ee7c55bddb3af1941289361ad6"
+            repo_dir = Path(cache_dir) / "models--user--repo"
+            (repo_dir / "refs").mkdir(parents=True)
+            (repo_dir / "refs" / "main").write_text(f"{commit_hash}\n")
+            snapshot_dir = repo_dir / "snapshots" / commit_hash
+            snapshot_dir.mkdir(parents=True)
+            file_path = snapshot_dir / "config.json"
+            file_path.write_text("{}")
+
+            attempt = try_to_load_from_cache(
+                "user/repo",
+                filename="config.json",
+                revision="main",
+                cache_dir=cache_dir,
+            )
+            self.assertEqual(attempt, str(file_path))
+
     def test_get_hf_file_metadata_basic(self) -> None:
         """Test getting metadata from a file on the Hub."""
         url = hf_hub_url(


### PR DESCRIPTION
## Summary

Fixes #4133. When a HuggingFace cache is transferred between
environments (e.g. copied to an air-gapped machine), the
`refs/<revision>` files can end up with a trailing newline. The
unstripped hash gets concatenated into the snapshot path and the
snapshot can no longer be resolved, even though it exists on disk.

@Wauplin mentioned in the issue thread that stripping the value would
be fine — this PR does exactly that, in every place where the ref file
is consumed.

- `_cache_commit_hash_for_specific_revision` — strip before the
  equality check so a stray newline doesn't trigger an unnecessary
  rewrite.
- `hf_hub_download` (offline path) — strip the hash used to build the
  pointer path.
- `try_to_load_from_cache` — strip the revision read from the refs
  file.
- `snapshot_download` — strip the hash used to locate the snapshot
  folder.
- `scan_cache_dir` — strip the hash used to group revisions by ref.

## Reproduction

Same as the issue:

```bash
echo "f90f040c7cb709ee7c55bddb3af1941289361ad6" > refs/main
echo "" >> refs/main
```

```python
from huggingface_hub import snapshot_download

snapshot_download(
    repo_id="docling-project/docling-layout-heron",
    local_files_only=True,
)
```

Before the fix the call raises `LocalEntryNotFoundError` because the
resolved snapshot path contains a literal `\n`. After the fix it
returns the cached snapshot folder.

## Tests

Added a network-free regression test
(`test_try_to_load_from_cache_strips_refs_whitespace`) that builds a
minimal cache layout with a trailing-newline `refs/main` and asserts
that `try_to_load_from_cache` resolves the file correctly. The test
fails on `main` and passes with the fix applied.

```
$ pytest tests/test_file_download.py -k test_try_to_load_from_cache_strips_refs_whitespace
====================== 1 passed, 64 deselected in 0.18s =======================
```

`ruff format --check` and `ruff check` are clean on the touched files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to cache metadata parsing (`.strip()` on ref file reads) plus a regression test; low chance of behavioral regressions beyond fixing previously broken offline lookups.
> 
> **Overview**
> Fixes offline cache resolution when `refs/<revision>` files contain trailing whitespace/newlines by stripping the read commit hash across cache consumers (`snapshot_download`, `hf_hub_download` offline fallback, `try_to_load_from_cache`, and `scan_cache_dir`).
> 
> Also prevents unnecessary ref rewrites by stripping before comparing in `_cache_commit_hash_for_specific_revision`, and adds a regression test ensuring `try_to_load_from_cache` resolves a snapshot correctly when `refs/main` ends with a newline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97bd6ed8592b85a2f027a16363a7e713816627b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->