### PR TITLE
[CLI] Add `hf spaces hardware` command

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -984,6 +984,14 @@ Use `hf spaces restart` to restart a Space. Pass `--factory-reboot` to rebuild t
 >>> hf spaces restart username/my-space --factory-reboot
 ```
 
+### List available hardware
+
+Use `hf spaces hardware` to list all available hardware options for Spaces, including pricing.
+
+```bash
+>>> hf spaces hardware
+```
+
 ### Update Space settings
 
 Use `hf spaces settings` to update the settings of a Space.
@@ -994,7 +1002,7 @@ Use `hf spaces settings` to update the settings of a Space.
 ```
 
 - `--sleep-time`: idle time in seconds before the Space sleeps. Use `-1` to never sleep. Only available on upgraded hardware (see the [Spaces sleep time docs](https://huggingface.co/docs/hub/spaces-gpus#sleep-time)).
-- `--hardware`: hardware flavor (e.g. `cpu-basic`, `t4-medium`, `l4x4`).
+- `--hardware`: hardware flavor (e.g. `cpu-basic`, `t4-medium`, `l4x4`). Run `hf spaces hardware` to see all options.
 
 ## hf papers
 

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -3504,6 +3504,7 @@ $ hf spaces [OPTIONS] COMMAND [ARGS]...
 
 * `card`: Get the Space card (README) for a Space on...
 * `dev-mode`: Enable or disable dev mode on a Space.
+* `hardware`: List available hardware options for Spaces.
 * `hot-reload`: Hot-reload any Python file of a Space...
 * `info`: Get info about a space on the Hub.
 * `list`: List spaces on the Hub. [alias: ls]
@@ -3575,6 +3576,30 @@ $ hf spaces dev-mode [OPTIONS] SPACE_ID
 
 Examples
   $ hf spaces dev-mode my-user-name/deepsite
+
+Learn more
+  Use `hf <command> --help` for more information about a command.
+  Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
+
+
+### `hf spaces hardware`
+
+List available hardware options for Spaces.
+
+**Usage**:
+
+```console
+$ hf spaces hardware [OPTIONS]
+```
+
+**Options**:
+
+* `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
+* `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
+* `--help`: Show this message and exit.
+
+Examples
+  $ hf spaces hardware
 
 Learn more
   Use `hf <command> --help` for more information about a command.
@@ -3837,7 +3862,7 @@ $ hf spaces settings [OPTIONS] SPACE_ID
 **Options**:
 
 * `--sleep-time INTEGER`: Idle time in seconds after which the Space goes to sleep. Use -1 to never sleep. Only available on upgraded hardware.
-* `--hardware [cpu-basic|cpu-upgrade|cpu-performance|cpu-xl|sprx8|zero-a10g|t4-small|t4-medium|l4x1|l4x4|l40sx1|l40sx4|l40sx8|a10g-small|a10g-large|a10g-largex2|a10g-largex4|a100-large|a100x4|a100x8|h200|h200x2|h200x4|h200x8|inf2x6]`: Space hardware flavor (e.g. 'cpu-basic', 't4-medium', 'l4x4').
+* `--hardware [cpu-basic|cpu-upgrade|cpu-performance|cpu-xl|sprx8|zero-a10g|t4-small|t4-medium|l4x1|l4x4|l40sx1|l40sx4|l40sx8|a10g-small|a10g-large|a10g-largex2|a10g-largex4|a100-large|a100x4|a100x8|h200|h200x2|h200x4|h200x8|inf2x6]`: Space hardware flavor (e.g. 'cpu-basic', 't4-medium', 'l4x4'). Run 'hf spaces hardware' to list available options.
 * `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `--help`: Show this message and exit.

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -294,6 +294,7 @@ _SUBMOD_ATTRS = {
         "list_repo_refs",
         "list_repo_tree",
         "list_spaces",
+        "list_spaces_hardware",
         "list_user_followers",
         "list_user_following",
         "list_webhooks",
@@ -1017,6 +1018,7 @@ __all__ = [
     "list_repo_refs",
     "list_repo_tree",
     "list_spaces",
+    "list_spaces_hardware",
     "list_user_followers",
     "list_user_following",
     "list_webhooks",
@@ -1430,6 +1432,7 @@ if TYPE_CHECKING:  # pragma: no cover
         list_repo_refs,  # noqa: F401
         list_repo_tree,  # noqa: F401
         list_spaces,  # noqa: F401
+        list_spaces_hardware,  # noqa: F401
         list_user_followers,  # noqa: F401
         list_user_following,  # noqa: F401
         list_webhooks,  # noqa: F401

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -662,12 +662,12 @@ def jobs_hardware() -> None:
     rows: list[list[str | int]] = []
 
     for hw in hardware_list:
-        accelerator_info = "N/A"
+        accelerator_info = ""
         if hw.accelerator:
             accelerator_info = f"{hw.accelerator.quantity}x {hw.accelerator.model} ({hw.accelerator.vram})"
-        cost_min = f"${hw.unit_cost_usd:.4f}" if hw.unit_cost_usd is not None else "N/A"
-        cost_hour = f"${hw.unit_cost_usd * 60:.2f}" if hw.unit_cost_usd is not None else "N/A"
-        rows.append([hw.name, hw.pretty_name or "N/A", hw.cpu, hw.ram, accelerator_info, cost_min, cost_hour])
+        cost_min = f"${hw.unit_cost_usd:.4f}" if hw.unit_cost_usd else "free"
+        cost_hour = f"${hw.unit_cost_usd * 60:.2f}" if hw.unit_cost_usd else "free"
+        rows.append([hw.name, hw.pretty_name or "", hw.cpu, hw.ram, accelerator_info, cost_min, cost_hour])
 
     if not rows:
         print("No hardware options found")

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -374,12 +374,12 @@ def spaces_hardware(
         items.append(
             {
                 "name": hw.name,
-                "pretty_name": hw.pretty_name,
+                "pretty name": hw.pretty_name,
                 "cpu": hw.cpu,
                 "ram": hw.ram,
                 "accelerator": accelerator,
-                "cost_min": cost_min,
-                "cost_hour": cost_hour,
+                "cost/min": cost_min,
+                "cost/hour": cost_hour,
             }
         )
     out.table(items)

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -369,7 +369,8 @@ def spaces_hardware(
         accelerator = (
             f"{hw.accelerator.quantity}x {hw.accelerator.model} ({hw.accelerator.vram})" if hw.accelerator else None
         )
-        cost_per_hour = f"${hw.unit_cost_usd * 60:.2f}/h" if hw.unit_cost_usd else "free"
+        cost_min = f"${hw.unit_cost_usd:.4f}" if hw.unit_cost_usd else "free"
+        cost_hour = f"${hw.unit_cost_usd * 60:.2f}" if hw.unit_cost_usd else "free"
         items.append(
             {
                 "name": hw.name,
@@ -377,7 +378,8 @@ def spaces_hardware(
                 "cpu": hw.cpu,
                 "ram": hw.ram,
                 "accelerator": accelerator,
-                "cost": cost_per_hour,
+                "cost_min": cost_min,
+                "cost_hour": cost_hour,
             }
         )
     out.table(items)

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -381,7 +381,7 @@ def spaces_hardware(
             }
         )
     out.table(items)
-    out.hint("Use `hf spaces settings <space_id> --hardware <name>` to set hardware on a Space.")
+    out.hint("Use `hf spaces settings <space_id> --hardware <name>` to request hardware for a Space.")
 
 
 @spaces_cli.command(

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -352,6 +352,39 @@ def spaces_restart(
 
 
 @spaces_cli.command(
+    "hardware",
+    examples=[
+        "hf spaces hardware",
+    ],
+)
+def spaces_hardware(
+    format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
+    token: TokenOpt = None,
+) -> None:
+    """List available hardware options for Spaces."""
+    api = get_hf_api(token=token)
+    hardware_list = api.list_spaces_hardware()
+    items = []
+    for hw in hardware_list:
+        accelerator = (
+            f"{hw.accelerator.quantity}x {hw.accelerator.model} ({hw.accelerator.vram})" if hw.accelerator else None
+        )
+        cost_per_hour = f"${hw.unit_cost_usd * 60:.2f}/h" if hw.unit_cost_usd else "free"
+        items.append(
+            {
+                "name": hw.name,
+                "pretty_name": hw.pretty_name,
+                "cpu": hw.cpu,
+                "ram": hw.ram,
+                "accelerator": accelerator,
+                "cost": cost_per_hour,
+            }
+        )
+    out.table(items)
+    out.hint("Use `hf spaces settings <space_id> --hardware <name>` to set hardware on a Space.")
+
+
+@spaces_cli.command(
     "settings",
     examples=[
         "hf spaces settings username/my-space --sleep-time 300",
@@ -371,7 +404,7 @@ def spaces_settings(
         SpaceHardware | None,
         typer.Option(
             "--hardware",
-            help="Space hardware flavor (e.g. 'cpu-basic', 't4-medium', 'l4x4').",
+            help="Space hardware flavor (e.g. 'cpu-basic', 't4-medium', 'l4x4'). Run 'hf spaces hardware' to list available options.",
         ),
     ] = None,
     format: FormatWithAutoOpt = OutputFormatWithAuto.auto,

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -7783,6 +7783,33 @@ class HfApi:
         hf_raise_for_status(r)
         return SpaceRuntime(r.json())
 
+    def list_spaces_hardware(self, token: bool | str | None = None) -> list[JobHardware]:
+        """List available hardware options for Spaces.
+
+        The response format is the same as for Jobs hardware ([`list_jobs_hardware`]),
+        but the catalog differs: `cpu-basic` is free and `zero-a10g` (ZeroGPU) is available.
+
+        Returns:
+            `list[JobHardware]`: A list of available hardware configurations.
+
+        Example:
+
+        ```python
+        >>> from huggingface_hub import HfApi
+        >>> api = HfApi()
+        >>> hardware_list = api.list_spaces_hardware()
+        >>> hardware_list[0]
+        JobHardware(name='cpu-basic', pretty_name='CPU Basic', cpu='2 vCPU', ram='16 GB', ...)
+        >>> hardware_list[0].name
+        'cpu-basic'
+        ```
+        """
+        response = get_session().get(
+            f"{self.endpoint}/api/spaces/hardware", headers=self._build_hf_headers(token=token)
+        )
+        hf_raise_for_status(response)
+        return [JobHardware(**hardware) for hardware in response.json()]
+
     @validate_hf_hub_args
     def request_space_hardware(
         self,

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -7786,18 +7786,14 @@ class HfApi:
     def list_spaces_hardware(self, token: bool | str | None = None) -> list[JobHardware]:
         """List available hardware options for Spaces.
 
-        The response format is the same as for Jobs hardware ([`list_jobs_hardware`]),
-        but the catalog differs: `cpu-basic` is free and `zero-a10g` (ZeroGPU) is available.
-
         Returns:
             `list[JobHardware]`: A list of available hardware configurations.
 
         Example:
 
         ```python
-        >>> from huggingface_hub import HfApi
-        >>> api = HfApi()
-        >>> hardware_list = api.list_spaces_hardware()
+        >>> from huggingface_hub import list_spaces_hardware
+        >>> hardware_list = list_spaces_hardware()
         >>> hardware_list[0]
         JobHardware(name='cpu-basic', pretty_name='CPU Basic', cpu='2 vCPU', ram='16 GB', ...)
         >>> hardware_list[0].name

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -13932,6 +13932,7 @@ get_space_variables = api.get_space_variables
 add_space_variable = api.add_space_variable
 delete_space_variable = api.delete_space_variable
 get_space_runtime = api.get_space_runtime
+list_spaces_hardware = api.list_spaces_hardware
 request_space_hardware = api.request_space_hardware
 set_space_sleep_time = api.set_space_sleep_time
 pause_space = api.pause_space

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2119,12 +2119,12 @@ class TestSpacesHardwareCommand:
         result = runner.invoke(app, ["spaces", "hardware", "--format", "json"])
         cpu_basic = next(hw for hw in json.loads(result.stdout) if hw["name"] == "cpu-basic")
         assert cpu_basic["name"] == "cpu-basic"
-        assert cpu_basic["pretty_name"] == "CPU Basic"
+        assert cpu_basic["pretty name"] == "CPU Basic"
         assert cpu_basic["cpu"] == "2 vCPU"
         assert cpu_basic["ram"] == "16 GB"
         assert cpu_basic["accelerator"] is None
-        assert cpu_basic["cost_min"] == "free"
-        assert cpu_basic["cost_hour"] == "free"
+        assert cpu_basic["cost/min"] == "free"
+        assert cpu_basic["cost/hour"] == "free"
 
 
 class TestInferenceEndpointsCommands:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2113,6 +2113,57 @@ class TestSpacesLogsCommand:
         assert "Cannot use --follow and --tail together" in str(result.exception)
 
 
+class TestSpacesHardwareCommand:
+    def test_list_hardware(self, runner: CliRunner) -> None:
+        """`hf spaces hardware` lists available hardware with pricing."""
+        from huggingface_hub._jobs_api import JobHardware
+
+        hardware = [
+            JobHardware(
+                **{
+                    "name": "cpu-basic",
+                    "prettyName": "CPU Basic",
+                    "cpu": "2 vCPU",
+                    "ram": "16 GB",
+                    "accelerator": None,
+                    "unitCostMicroUSD": 0,
+                    "unitCostUSD": 0,
+                    "unitLabel": "minute",
+                }
+            ),
+            JobHardware(
+                **{
+                    "name": "t4-small",
+                    "prettyName": "Nvidia T4 - small",
+                    "cpu": "4 vCPU",
+                    "ram": "15 GB",
+                    "accelerator": {
+                        "type": "gpu",
+                        "model": "T4",
+                        "quantity": "1",
+                        "vram": "16 GB",
+                        "manufacturer": "Nvidia",
+                    },
+                    "unitCostMicroUSD": 6667,
+                    "unitCostUSD": 0.006667,
+                    "unitLabel": "minute",
+                }
+            ),
+        ]
+        with patch("huggingface_hub.cli.spaces.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            api.list_spaces_hardware.return_value = hardware
+            result = runner.invoke(app, ["spaces", "hardware", "--format", "json"])
+        assert result.exit_code == 0
+        output = json.loads(result.stdout)
+        assert len(output) == 2
+        assert output[0]["name"] == "cpu-basic"
+        assert output[0]["cost"] == "free"
+        assert output[1]["name"] == "t4-small"
+        assert output[1]["accelerator"] == "1x T4 (16 GB)"
+        assert "$0.40/h" in output[1]["cost"]
+
+
 class TestInferenceEndpointsCommands:
     def test_list(self, runner: CliRunner) -> None:
         endpoint = Mock(raw={"name": "demo"})

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2113,55 +2113,19 @@ class TestSpacesLogsCommand:
         assert "Cannot use --follow and --tail together" in str(result.exception)
 
 
+@with_production_testing
 class TestSpacesHardwareCommand:
     def test_list_hardware(self, runner: CliRunner) -> None:
-        """`hf spaces hardware` lists available hardware with pricing."""
-        from huggingface_hub._jobs_api import JobHardware
-
-        hardware = [
-            JobHardware(
-                **{
-                    "name": "cpu-basic",
-                    "prettyName": "CPU Basic",
-                    "cpu": "2 vCPU",
-                    "ram": "16 GB",
-                    "accelerator": None,
-                    "unitCostMicroUSD": 0,
-                    "unitCostUSD": 0,
-                    "unitLabel": "minute",
-                }
-            ),
-            JobHardware(
-                **{
-                    "name": "t4-small",
-                    "prettyName": "Nvidia T4 - small",
-                    "cpu": "4 vCPU",
-                    "ram": "15 GB",
-                    "accelerator": {
-                        "type": "gpu",
-                        "model": "T4",
-                        "quantity": "1",
-                        "vram": "16 GB",
-                        "manufacturer": "Nvidia",
-                    },
-                    "unitCostMicroUSD": 6667,
-                    "unitCostUSD": 0.006667,
-                    "unitLabel": "minute",
-                }
-            ),
-        ]
-        with patch("huggingface_hub.cli.spaces.get_hf_api") as api_cls:
-            api = api_cls.return_value
-            api.list_spaces_hardware.return_value = hardware
-            result = runner.invoke(app, ["spaces", "hardware", "--format", "json"])
+        result = runner.invoke(app, ["spaces", "hardware", "--format", "json"])
         assert result.exit_code == 0
         output = json.loads(result.stdout)
-        assert len(output) == 2
-        assert output[0]["name"] == "cpu-basic"
-        assert output[0]["cost"] == "free"
-        assert output[1]["name"] == "t4-small"
-        assert output[1]["accelerator"] == "1x T4 (16 GB)"
-        assert "$0.40/h" in output[1]["cost"]
+        cpu_basic = next(hw for hw in output if hw["name"] == "cpu-basic")
+        assert cpu_basic["name"] == "cpu-basic"
+        assert cpu_basic["pretty_name"] == "CPU Basic"
+        assert cpu_basic["cpu"] == "2 vCPU"
+        assert cpu_basic["ram"] == "16 GB"
+        assert cpu_basic["accelerator"] is None
+        assert cpu_basic["cost"] == "free"
 
 
 class TestInferenceEndpointsCommands:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2117,9 +2117,7 @@ class TestSpacesLogsCommand:
 class TestSpacesHardwareCommand:
     def test_list_hardware(self, runner: CliRunner) -> None:
         result = runner.invoke(app, ["spaces", "hardware", "--format", "json"])
-        assert result.exit_code == 0
-        output = json.loads(result.stdout)
-        cpu_basic = next(hw for hw in output if hw["name"] == "cpu-basic")
+        cpu_basic = next(hw for hw in json.loads(result.stdout) if hw["name"] == "cpu-basic")
         assert cpu_basic["name"] == "cpu-basic"
         assert cpu_basic["pretty_name"] == "CPU Basic"
         assert cpu_basic["cpu"] == "2 vCPU"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2123,7 +2123,8 @@ class TestSpacesHardwareCommand:
         assert cpu_basic["cpu"] == "2 vCPU"
         assert cpu_basic["ram"] == "16 GB"
         assert cpu_basic["accelerator"] is None
-        assert cpu_basic["cost"] == "free"
+        assert cpu_basic["cost_min"] == "free"
+        assert cpu_basic["cost_hour"] == "free"
 
 
 class TestInferenceEndpointsCommands:


### PR DESCRIPTION
Follow-up https://github.com/huggingface/huggingface_hub/pull/4163#pullrequestreview-4196878112.

Adds `hf spaces hardware` to list available Space hardware options (from `GET /api/spaces/hardware`).

`list_spaces_hardware` returns a `JobHardware` even though it's not Job's specific. Not very important, we can always change if the data format changes between Jobs and Spaces in the future.

Includes a hint at the end: _"Use `hf spaces settings <space_id> --hardware <name>` to set hardware on a Space."_



```bash
$ hf spaces hardware
NAME         PRETTY_NAME            CPU               RAM     ACCELERATOR      COST/MIN COST/HOUR
------------ ---------------------- ----------------- ------- ---------------- -------- ---------
cpu-basic    CPU Basic              2 vCPU            16 GB                    free     free     
zero-a10g    ZeroGPU                Dynamic resources -                        free     free     
cpu-upgrade  CPU Upgrade            8 vCPU            32 GB                    $0.0005  $0.03    
t4-small     Nvidia T4 - small      4 vCPU            15 GB   1x T4 (16 GB)    $0.0067  $0.40    
t4-medium    Nvidia T4 - medium     8 vCPU            30 GB   1x T4 (16 GB)    $0.0100  $0.60    
a10g-small   Nvidia A10G - small    4 vCPU            15 GB   1x A10G (24 GB)  $0.0167  $1.00    
a10g-large   Nvidia A10G - large    12 vCPU           46 GB   1x A10G (24 GB)  $0.0250  $1.50    
a10g-largex2 2x Nvidia A10G - large 24 vCPU           92 GB   2x A10G (48 GB)  $0.0500  $3.00    
a10g-largex4 4x Nvidia A10G - large 48 vCPU           184 GB  4x A10G (96 GB)  $0.0833  $5.00    
a100-large   Nvidia A100 - large    12 vCPU           142 GB  1x A100 (80 GB)  $0.0417  $2.50    
a100x4       4x Nvidia A100         48 vCPU           568 GB  4x A100 (320 GB) $0.1667  $10.00   
a100x8       8x Nvidia A100         96 vCPU           1136 GB 8x A100 (640 GB) $0.3333  $20.00   
l4x1         1x Nvidia L4           8 vCPU            30 GB   1x L4 (24 GB)    $0.0133  $0.80    
l4x4         4x Nvidia L4           48 vCPU           186 GB  1x L4 (96 GB)    $0.0633  $3.80    
l40sx1       1x Nvidia L40S         8 vCPU            62 GB   1x L4 (48 GB)    $0.0300  $1.80    
l40sx4       4x Nvidia L40S         48 vCPU           382 GB  4x L4 (192 GB)   $0.1383  $8.30    
l40sx8       8x Nvidia L40S         192 vCPU          1534 GB 8x L4 (384 GB)   $0.3917  $23.50   
Hint: Use `hf spaces settings <space_id> --hardware <name>` to request hardware for a Space.
```

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://huggingface.slack.com/archives/D0A9313SS3G/p1777465490087939?thread_ts=1777465490.087939&cid=D0A9313SS3G)

<div><a href="https://cursor.com/agents/bc-c657dd2a-e7d7-52a5-98c0-cc27144e9495"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c657dd2a-e7d7-52a5-98c0-cc27144e9495"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily adds a new read-only CLI/API endpoint call and documentation updates, with minimal impact on existing behavior aside from small formatting changes in `hf jobs hardware` output.
> 
> **Overview**
> Adds a new `hf spaces hardware` CLI subcommand that fetches `GET /api/spaces/hardware` and renders available Space hardware (CPU/RAM/accelerator) with *per-minute* and *per-hour* pricing.
> 
> Exposes this capability in the Python API via `HfApi.list_spaces_hardware` (and top-level `list_spaces_hardware`) and updates `spaces settings --hardware` help/docs to point users to the new listing command; also adjusts `hf jobs hardware` output to display missing/zero pricing as `free` instead of `N/A`, and adds a production-gated CLI test for the new command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 468940a3e0f4fcd5828124d706e976e6fb39d6a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->