### PR TITLE
[CLI] Add hf spaces secrets and variables subgroups

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -1068,6 +1068,30 @@ Use `hf spaces settings` to update the settings of a Space.
 - `--sleep-time`: idle time in seconds before the Space sleeps. Use `-1` to never sleep. Only available on upgraded hardware (see the [Spaces sleep time docs](https://huggingface.co/docs/hub/spaces-gpus#sleep-time)).
 - `--hardware`: hardware flavor (e.g. `cpu-basic`, `t4-medium`, `l4x4`). Run `hf spaces hardware` to see all options.
 
+### Manage Space secrets
+
+Use `hf spaces secrets set` to add or update one or more secrets on a Space, and `hf spaces secrets delete` to remove one. Pass `--secrets-file PATH` to load secrets from a `.env`-style file. Existing keys are overwritten.
+
+```bash
+>>> hf spaces secrets set username/my-space -s OPENAI_API_KEY=sk-...
+>>> hf spaces secrets set username/my-space --secrets-file .env.secrets
+>>> hf spaces secrets delete username/my-space OPENAI_API_KEY --yes
+```
+
+> [!NOTE]
+> There is no `hf spaces secrets ls` command. The Hub exposes secrets as write-only — once set, their values cannot be read back via the API. To audit which keys exist on a Space, view it in the browser.
+
+### Manage Space environment variables
+
+Use `hf spaces variables` to manage non-secret environment variables on a Space. Unlike secrets, variables are readable, so `ls` shows both keys and values. Pass `--env-file PATH` on `set` to load from a `.env`-style file.
+
+```bash
+>>> hf spaces variables ls username/my-space
+>>> hf spaces variables set username/my-space -e MODEL_ID=gpt2 -e MAX_TOKENS=512
+>>> hf spaces variables set username/my-space --env-file .env
+>>> hf spaces variables delete username/my-space MAX_TOKENS
+```
+
 ## hf papers
 
 Use `hf papers` to list, search, get structured info, and read the markdown content of papers on the Hub.

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -1079,7 +1079,7 @@ Use `hf spaces secrets add` to add or update one or more secrets on a Space, and
 ```
 
 > [!NOTE]
-> There is no `hf spaces secrets ls` command. The Hub exposes secrets as write-only — once set, their values cannot be read back via the API. To audit which keys exist on a Space, view it in the browser.
+> There is no `hf spaces secrets ls` command. The Hub exposes secrets as write-only — once set, their values cannot be read back via the API.
 
 ### Manage Space environment variables
 

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -1070,11 +1070,11 @@ Use `hf spaces settings` to update the settings of a Space.
 
 ### Manage Space secrets
 
-Use `hf spaces secrets set` to add or update one or more secrets on a Space, and `hf spaces secrets delete` to remove one. Pass `--secrets-file PATH` to load secrets from a `.env`-style file. Existing keys are overwritten.
+Use `hf spaces secrets add` to add or update one or more secrets on a Space, and `hf spaces secrets delete` to remove one. Pass `--secrets-file PATH` to load secrets from a `.env`-style file. Existing keys are overwritten.
 
 ```bash
->>> hf spaces secrets set username/my-space -s OPENAI_API_KEY=sk-...
->>> hf spaces secrets set username/my-space --secrets-file .env.secrets
+>>> hf spaces secrets add username/my-space -s OPENAI_API_KEY=sk-...
+>>> hf spaces secrets add username/my-space --secrets-file .env.secrets
 >>> hf spaces secrets delete username/my-space OPENAI_API_KEY --yes
 ```
 
@@ -1083,13 +1083,13 @@ Use `hf spaces secrets set` to add or update one or more secrets on a Space, and
 
 ### Manage Space environment variables
 
-Use `hf spaces variables` to manage non-secret environment variables on a Space. Unlike secrets, variables are readable, so `ls` shows both keys and values. Pass `--env-file PATH` on `set` to load from a `.env`-style file.
+Use `hf spaces variables` to manage non-secret environment variables on a Space. Unlike secrets, variables are readable, so `ls` shows both keys and values. Pass `--env-file PATH` on `add` to load from a `.env`-style file.
 
 ```bash
 >>> hf spaces variables ls username/my-space
->>> hf spaces variables set username/my-space -e MODEL_ID=gpt2 -e MAX_TOKENS=512
->>> hf spaces variables set username/my-space --env-file .env
->>> hf spaces variables delete username/my-space MAX_TOKENS
+>>> hf spaces variables add username/my-space -e MODEL_ID=gpt2 -e MAX_TOKENS=512
+>>> hf spaces variables add username/my-space --env-file .env
+>>> hf spaces variables delete username/my-space MAX_TOKENS --yes
 ```
 
 ## hf papers

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -3856,7 +3856,7 @@ $ hf spaces secrets add [OPTIONS] SPACE_ID
 * `--help`: Show this message and exit.
 
 Examples
-  $ hf spaces secrets add username/my-space -s HF_TOKEN=hf_xxx
+  $ hf spaces secrets add username/my-space -s HF_TOKEN
   $ hf spaces secrets add username/my-space -s OPENAI_API_KEY=sk-... -s ANTHROPIC_API_KEY=sk-...
   $ hf spaces secrets add username/my-space --secrets-file .env.secrets
 

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -3473,7 +3473,9 @@ $ hf spaces [OPTIONS] COMMAND [ARGS]...
 * `pause`: Pause a Space.
 * `restart`: Restart a Space.
 * `search`: Search spaces on the Hub using semantic...
+* `secrets`: Manage secrets for a Space on the Hub.
 * `settings`: Update the settings of a Space.
+* `variables`: Manage environment variables for a Space...
 * `volumes`: Manage volumes for a Space on the Hub.
 
 ### `hf spaces card`
@@ -3813,6 +3815,88 @@ Learn more
   Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
 
 
+### `hf spaces secrets`
+
+Manage secrets for a Space on the Hub.
+
+**Usage**:
+
+```console
+$ hf spaces secrets [OPTIONS] COMMAND [ARGS]...
+```
+
+**Options**:
+
+* `--help`: Show this message and exit.
+
+**Commands**:
+
+* `delete`: Remove a secret from a Space.
+* `set`: Set secrets for a Space.
+
+#### `hf spaces secrets delete`
+
+Remove a secret from a Space.
+
+**Usage**:
+
+```console
+$ hf spaces secrets delete [OPTIONS] SPACE_ID KEY
+```
+
+**Arguments**:
+
+* `SPACE_ID`: The space ID (e.g. `username/repo-name`).  [required]
+* `KEY`: Name of the secret to remove.  [required]
+
+**Options**:
+
+* `-y, --yes`: Answer Yes to prompt automatically.
+* `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
+* `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
+* `--help`: Show this message and exit.
+
+Examples
+  $ hf spaces secrets delete username/my-space HF_TOKEN
+  $ hf spaces secrets delete username/my-space HF_TOKEN --yes
+
+Learn more
+  Use `hf <command> --help` for more information about a command.
+  Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
+
+
+#### `hf spaces secrets set`
+
+Set secrets for a Space.
+
+**Usage**:
+
+```console
+$ hf spaces secrets set [OPTIONS] SPACE_ID
+```
+
+**Arguments**:
+
+* `SPACE_ID`: The space ID (e.g. `username/repo-name`).  [required]
+
+**Options**:
+
+* `-s, --secrets TEXT`: Set secret environment variables. E.g. --secrets SECRET=value or `--secrets HF_TOKEN` to pass your Hugging Face token.
+* `--secrets-file TEXT`: Read in a file of secret environment variables.
+* `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
+* `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
+* `--help`: Show this message and exit.
+
+Examples
+  $ hf spaces secrets set username/my-space -s HF_TOKEN=hf_xxx
+  $ hf spaces secrets set username/my-space -s OPENAI_API_KEY=sk-... -s ANTHROPIC_API_KEY=sk-...
+  $ hf spaces secrets set username/my-space --secrets-file .env.secrets
+
+Learn more
+  Use `hf <command> --help` for more information about a command.
+  Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
+
+
 ### `hf spaces settings`
 
 Update the settings of a Space.
@@ -3837,6 +3921,115 @@ $ hf spaces settings [OPTIONS] SPACE_ID
 Examples
   $ hf spaces settings username/my-space --sleep-time 300
   $ hf spaces settings username/my-space --hardware t4-medium
+
+Learn more
+  Use `hf <command> --help` for more information about a command.
+  Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
+
+
+### `hf spaces variables`
+
+Manage environment variables for a Space on the Hub.
+
+**Usage**:
+
+```console
+$ hf spaces variables [OPTIONS] COMMAND [ARGS]...
+```
+
+**Options**:
+
+* `--help`: Show this message and exit.
+
+**Commands**:
+
+* `delete`: Remove an environment variable from a Space.
+* `list`: List environment variables for a Space. [alias: ls]
+* `set`: Set environment variables for a Space.
+
+#### `hf spaces variables delete`
+
+Remove an environment variable from a Space.
+
+**Usage**:
+
+```console
+$ hf spaces variables delete [OPTIONS] SPACE_ID KEY
+```
+
+**Arguments**:
+
+* `SPACE_ID`: The space ID (e.g. `username/repo-name`).  [required]
+* `KEY`: Name of the variable to remove.  [required]
+
+**Options**:
+
+* `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
+* `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
+* `--help`: Show this message and exit.
+
+Examples
+  $ hf spaces variables delete username/my-space DEBUG
+
+Learn more
+  Use `hf <command> --help` for more information about a command.
+  Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
+
+
+#### `hf spaces variables list`
+
+List environment variables for a Space. [alias: ls]
+
+**Usage**:
+
+```console
+$ hf spaces variables list [OPTIONS] SPACE_ID
+```
+
+**Arguments**:
+
+* `SPACE_ID`: The space ID (e.g. `username/repo-name`).  [required]
+
+**Options**:
+
+* `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
+* `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
+* `--help`: Show this message and exit.
+
+Examples
+  $ hf spaces variables ls username/my-space
+
+Learn more
+  Use `hf <command> --help` for more information about a command.
+  Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
+
+
+#### `hf spaces variables set`
+
+Set environment variables for a Space.
+
+**Usage**:
+
+```console
+$ hf spaces variables set [OPTIONS] SPACE_ID
+```
+
+**Arguments**:
+
+* `SPACE_ID`: The space ID (e.g. `username/repo-name`).  [required]
+
+**Options**:
+
+* `-e, --env TEXT`: Set environment variables. E.g. --env ENV=value
+* `--env-file TEXT`: Read in a file of environment variables.
+* `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
+* `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
+* `--help`: Show this message and exit.
+
+Examples
+  $ hf spaces variables set username/my-space -e DEBUG=1
+  $ hf spaces variables set username/my-space -e MODEL_ID=gpt2 -e MAX_TOKENS=512
+  $ hf spaces variables set username/my-space --env-file .env
 
 Learn more
   Use `hf <command> --help` for more information about a command.

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -3831,8 +3831,39 @@ $ hf spaces secrets [OPTIONS] COMMAND [ARGS]...
 
 **Commands**:
 
+* `add`: Add or update secrets for a Space.
 * `delete`: Remove a secret from a Space.
-* `set`: Set secrets for a Space.
+
+#### `hf spaces secrets add`
+
+Add or update secrets for a Space.
+
+**Usage**:
+
+```console
+$ hf spaces secrets add [OPTIONS] SPACE_ID
+```
+
+**Arguments**:
+
+* `SPACE_ID`: The space ID (e.g. `username/repo-name`).  [required]
+
+**Options**:
+
+* `-s, --secrets TEXT`: Set secret environment variables. E.g. --secrets SECRET=value or `--secrets HF_TOKEN` to pass your Hugging Face token.
+* `--secrets-file TEXT`: Read in a file of secret environment variables.
+* `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
+* `--help`: Show this message and exit.
+
+Examples
+  $ hf spaces secrets add username/my-space -s HF_TOKEN=hf_xxx
+  $ hf spaces secrets add username/my-space -s OPENAI_API_KEY=sk-... -s ANTHROPIC_API_KEY=sk-...
+  $ hf spaces secrets add username/my-space --secrets-file .env.secrets
+
+Learn more
+  Use `hf <command> --help` for more information about a command.
+  Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
+
 
 #### `hf spaces secrets delete`
 
@@ -3852,45 +3883,12 @@ $ hf spaces secrets delete [OPTIONS] SPACE_ID KEY
 **Options**:
 
 * `-y, --yes`: Answer Yes to prompt automatically.
-* `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `--help`: Show this message and exit.
 
 Examples
   $ hf spaces secrets delete username/my-space HF_TOKEN
   $ hf spaces secrets delete username/my-space HF_TOKEN --yes
-
-Learn more
-  Use `hf <command> --help` for more information about a command.
-  Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
-
-
-#### `hf spaces secrets set`
-
-Set secrets for a Space.
-
-**Usage**:
-
-```console
-$ hf spaces secrets set [OPTIONS] SPACE_ID
-```
-
-**Arguments**:
-
-* `SPACE_ID`: The space ID (e.g. `username/repo-name`).  [required]
-
-**Options**:
-
-* `-s, --secrets TEXT`: Set secret environment variables. E.g. --secrets SECRET=value or `--secrets HF_TOKEN` to pass your Hugging Face token.
-* `--secrets-file TEXT`: Read in a file of secret environment variables.
-* `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
-* `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
-* `--help`: Show this message and exit.
-
-Examples
-  $ hf spaces secrets set username/my-space -s HF_TOKEN=hf_xxx
-  $ hf spaces secrets set username/my-space -s OPENAI_API_KEY=sk-... -s ANTHROPIC_API_KEY=sk-...
-  $ hf spaces secrets set username/my-space --secrets-file .env.secrets
 
 Learn more
   Use `hf <command> --help` for more information about a command.
@@ -3943,9 +3941,40 @@ $ hf spaces variables [OPTIONS] COMMAND [ARGS]...
 
 **Commands**:
 
+* `add`: Add or update environment variables for a...
 * `delete`: Remove an environment variable from a Space.
 * `list`: List environment variables for a Space. [alias: ls]
-* `set`: Set environment variables for a Space.
+
+#### `hf spaces variables add`
+
+Add or update environment variables for a Space.
+
+**Usage**:
+
+```console
+$ hf spaces variables add [OPTIONS] SPACE_ID
+```
+
+**Arguments**:
+
+* `SPACE_ID`: The space ID (e.g. `username/repo-name`).  [required]
+
+**Options**:
+
+* `-e, --env TEXT`: Set environment variables. E.g. --env ENV=value
+* `--env-file TEXT`: Read in a file of environment variables.
+* `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
+* `--help`: Show this message and exit.
+
+Examples
+  $ hf spaces variables add username/my-space -e DEBUG=1
+  $ hf spaces variables add username/my-space -e MODEL_ID=gpt2 -e MAX_TOKENS=512
+  $ hf spaces variables add username/my-space --env-file .env
+
+Learn more
+  Use `hf <command> --help` for more information about a command.
+  Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
+
 
 #### `hf spaces variables delete`
 
@@ -3964,12 +3993,13 @@ $ hf spaces variables delete [OPTIONS] SPACE_ID KEY
 
 **Options**:
 
-* `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
+* `-y, --yes`: Answer Yes to prompt automatically.
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `--help`: Show this message and exit.
 
 Examples
   $ hf spaces variables delete username/my-space DEBUG
+  $ hf spaces variables delete username/my-space DEBUG --yes
 
 Learn more
   Use `hf <command> --help` for more information about a command.
@@ -3992,44 +4022,11 @@ $ hf spaces variables list [OPTIONS] SPACE_ID
 
 **Options**:
 
-* `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `--help`: Show this message and exit.
 
 Examples
   $ hf spaces variables ls username/my-space
-
-Learn more
-  Use `hf <command> --help` for more information about a command.
-  Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
-
-
-#### `hf spaces variables set`
-
-Set environment variables for a Space.
-
-**Usage**:
-
-```console
-$ hf spaces variables set [OPTIONS] SPACE_ID
-```
-
-**Arguments**:
-
-* `SPACE_ID`: The space ID (e.g. `username/repo-name`).  [required]
-
-**Options**:
-
-* `-e, --env TEXT`: Set environment variables. E.g. --env ENV=value
-* `--env-file TEXT`: Read in a file of environment variables.
-* `--format [agent|auto|human|json|quiet]`: Output format.  [default: auto]
-* `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
-* `--help`: Show this message and exit.
-
-Examples
-  $ hf spaces variables set username/my-space -e DEBUG=1
-  $ hf spaces variables set username/my-space -e MODEL_ID=gpt2 -e MAX_TOKENS=512
-  $ hf spaces variables set username/my-space --env-file .env
 
 Learn more
   Use `hf <command> --help` for more information about a command.

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -881,7 +881,7 @@ def volumes_delete(
 @secrets_cli.command(
     "add",
     examples=[
-        "hf spaces secrets add username/my-space -s HF_TOKEN=hf_xxx",
+        "hf spaces secrets add username/my-space -s HF_TOKEN",
         "hf spaces secrets add username/my-space -s OPENAI_API_KEY=sk-... -s ANTHROPIC_API_KEY=sk-...",
         "hf spaces secrets add username/my-space --secrets-file .env.secrets",
     ],

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -53,15 +53,20 @@ from huggingface_hub.utils import StatusLine, are_progress_bars_disabled, disabl
 
 from ._cli_utils import (
     AuthorOpt,
+    EnvFileOpt,
+    EnvOpt,
     FilterOpt,
     LimitOpt,
     RevisionOpt,
     SearchOpt,
+    SecretsFileOpt,
+    SecretsOpt,
     TokenOpt,
     VolumesOpt,
     api_object_to_dict,
     get_hf_api,
     make_expand_properties_parser,
+    parse_env_map,
     parse_volumes,
     typer_factory,
 )
@@ -87,7 +92,11 @@ ExpandOpt = Annotated[
 
 spaces_cli = typer_factory(help="Interact with spaces on the Hub.")
 volumes_cli = typer_factory(help="Manage volumes for a Space on the Hub.")
+secrets_cli = typer_factory(help="Manage secrets for a Space on the Hub.")
+variables_cli = typer_factory(help="Manage environment variables for a Space on the Hub.")
 spaces_cli.add_typer(volumes_cli, name="volumes")
+spaces_cli.add_typer(secrets_cli, name="secrets")
+spaces_cli.add_typer(variables_cli, name="variables")
 
 
 @spaces_cli.command(
@@ -867,3 +876,121 @@ def volumes_delete(
     out.hint(
         f"Use `hf spaces volumes set {space_id} -v hf://<repo_type>/<repo_id>:/<mount_path>` to set volumes for a Space."
     )
+
+
+@secrets_cli.command(
+    "set",
+    examples=[
+        "hf spaces secrets set username/my-space -s HF_TOKEN=hf_xxx",
+        "hf spaces secrets set username/my-space -s OPENAI_API_KEY=sk-... -s ANTHROPIC_API_KEY=sk-...",
+        "hf spaces secrets set username/my-space --secrets-file .env.secrets",
+    ],
+)
+def secrets_set(
+    space_id: Annotated[str, typer.Argument(help="The space ID (e.g. `username/repo-name`).")],
+    secrets: SecretsOpt = None,
+    secrets_file: SecretsFileOpt = None,
+    format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
+    token: TokenOpt = None,
+) -> None:
+    """Set secrets for a Space."""
+    secrets_map = parse_env_map(secrets, secrets_file)
+    if not secrets_map:
+        raise CLIError("At least one secret must be specified with -s/--secrets or --secrets-file.")
+    api = get_hf_api(token=token)
+    for key, value in secrets_map.items():
+        api.add_space_secret(space_id, key=key, value=value or "")
+    out.result("Secrets set", space_id=space_id, keys=list(secrets_map))
+    out.hint(f"Use `hf spaces secrets delete {space_id} <key>` to remove a secret from a Space.")
+
+
+@secrets_cli.command(
+    "delete",
+    examples=[
+        "hf spaces secrets delete username/my-space HF_TOKEN",
+        "hf spaces secrets delete username/my-space HF_TOKEN --yes",
+    ],
+)
+def secrets_delete(
+    space_id: Annotated[str, typer.Argument(help="The space ID (e.g. `username/repo-name`).")],
+    key: Annotated[str, typer.Argument(help="Name of the secret to remove.")],
+    yes: Annotated[
+        bool,
+        typer.Option(
+            "-y",
+            "--yes",
+            help="Answer Yes to prompt automatically.",
+        ),
+    ] = False,
+    format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
+    token: TokenOpt = None,
+) -> None:
+    """Remove a secret from a Space."""
+    out.confirm(
+        f"You are about to remove secret '{key}' from Space '{space_id}'. The value cannot be recovered. Proceed?",
+        yes=yes,
+    )
+    api = get_hf_api(token=token)
+    api.delete_space_secret(space_id, key=key)
+    out.result("Secret deleted", space_id=space_id, key=key)
+    out.hint(f"Use `hf spaces secrets set {space_id} -s {key}=<value>` to re-add a secret to a Space.")
+
+
+@variables_cli.command(
+    "list | ls",
+    examples=["hf spaces variables ls username/my-space"],
+)
+def variables_ls(
+    space_id: Annotated[str, typer.Argument(help="The space ID (e.g. `username/repo-name`).")],
+    format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
+    token: TokenOpt = None,
+) -> None:
+    """List environment variables for a Space."""
+    api = get_hf_api(token=token)
+    variables = api.get_space_variables(space_id)
+    items = [api_object_to_dict(v) for v in variables.values()]
+    out.table(items)
+    out.hint(f"Use `hf spaces variables set {space_id} -e KEY=VALUE` to set variables for a Space.")
+
+
+@variables_cli.command(
+    "set",
+    examples=[
+        "hf spaces variables set username/my-space -e DEBUG=1",
+        "hf spaces variables set username/my-space -e MODEL_ID=gpt2 -e MAX_TOKENS=512",
+        "hf spaces variables set username/my-space --env-file .env",
+    ],
+)
+def variables_set(
+    space_id: Annotated[str, typer.Argument(help="The space ID (e.g. `username/repo-name`).")],
+    env: EnvOpt = None,
+    env_file: EnvFileOpt = None,
+    format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
+    token: TokenOpt = None,
+) -> None:
+    """Set environment variables for a Space."""
+    env_map = parse_env_map(env, env_file)
+    if not env_map:
+        raise CLIError("At least one variable must be specified with -e/--env or --env-file.")
+    api = get_hf_api(token=token)
+    for key, value in env_map.items():
+        api.add_space_variable(space_id, key=key, value=value or "")
+    out.result("Variables set", space_id=space_id, keys=list(env_map))
+    out.hint(f"Use `hf spaces variables ls {space_id}` to list variables for a Space.")
+
+
+@variables_cli.command(
+    "delete",
+    examples=["hf spaces variables delete username/my-space DEBUG"],
+)
+def variables_delete(
+    space_id: Annotated[str, typer.Argument(help="The space ID (e.g. `username/repo-name`).")],
+    key: Annotated[str, typer.Argument(help="Name of the variable to remove.")],
+    format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
+    token: TokenOpt = None,
+) -> None:
+    """Remove an environment variable from a Space."""
+    api = get_hf_api(token=token)
+    api.delete_space_variable(space_id, key=key)
+    out.result("Variable deleted", space_id=space_id, key=key)
+    out.hint(f"Use `hf spaces variables ls {space_id}` to list remaining variables for a Space.")

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -879,28 +879,27 @@ def volumes_delete(
 
 
 @secrets_cli.command(
-    "set",
+    "add",
     examples=[
-        "hf spaces secrets set username/my-space -s HF_TOKEN=hf_xxx",
-        "hf spaces secrets set username/my-space -s OPENAI_API_KEY=sk-... -s ANTHROPIC_API_KEY=sk-...",
-        "hf spaces secrets set username/my-space --secrets-file .env.secrets",
+        "hf spaces secrets add username/my-space -s HF_TOKEN=hf_xxx",
+        "hf spaces secrets add username/my-space -s OPENAI_API_KEY=sk-... -s ANTHROPIC_API_KEY=sk-...",
+        "hf spaces secrets add username/my-space --secrets-file .env.secrets",
     ],
 )
-def secrets_set(
+def secrets_add(
     space_id: Annotated[str, typer.Argument(help="The space ID (e.g. `username/repo-name`).")],
     secrets: SecretsOpt = None,
     secrets_file: SecretsFileOpt = None,
-    format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
     token: TokenOpt = None,
 ) -> None:
-    """Set secrets for a Space."""
+    """Add or update secrets for a Space."""
     secrets_map = parse_env_map(secrets, secrets_file)
     if not secrets_map:
         raise CLIError("At least one secret must be specified with -s/--secrets or --secrets-file.")
     api = get_hf_api(token=token)
     for key, value in secrets_map.items():
         api.add_space_secret(space_id, key=key, value=value or "")
-    out.result("Secrets set", space_id=space_id, keys=list(secrets_map))
+    out.result("Secrets added", space_id=space_id, keys=list(secrets_map))
     out.hint(f"Use `hf spaces secrets delete {space_id} <key>` to remove a secret from a Space.")
 
 
@@ -922,7 +921,6 @@ def secrets_delete(
             help="Answer Yes to prompt automatically.",
         ),
     ] = False,
-    format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
     token: TokenOpt = None,
 ) -> None:
     """Remove a secret from a Space."""
@@ -933,7 +931,7 @@ def secrets_delete(
     api = get_hf_api(token=token)
     api.delete_space_secret(space_id, key=key)
     out.result("Secret deleted", space_id=space_id, key=key)
-    out.hint(f"Use `hf spaces secrets set {space_id} -s {key}=<value>` to re-add a secret to a Space.")
+    out.hint(f"Use `hf spaces secrets add {space_id} -s {key}=<value>` to re-add a secret to a Space.")
 
 
 @variables_cli.command(
@@ -942,7 +940,6 @@ def secrets_delete(
 )
 def variables_ls(
     space_id: Annotated[str, typer.Argument(help="The space ID (e.g. `username/repo-name`).")],
-    format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
     token: TokenOpt = None,
 ) -> None:
     """List environment variables for a Space."""
@@ -950,46 +947,59 @@ def variables_ls(
     variables = api.get_space_variables(space_id)
     items = [api_object_to_dict(v) for v in variables.values()]
     out.table(items)
-    out.hint(f"Use `hf spaces variables set {space_id} -e KEY=VALUE` to set variables for a Space.")
+    out.hint(f"Use `hf spaces variables add {space_id} -e KEY=VALUE` to add variables to a Space.")
 
 
 @variables_cli.command(
-    "set",
+    "add",
     examples=[
-        "hf spaces variables set username/my-space -e DEBUG=1",
-        "hf spaces variables set username/my-space -e MODEL_ID=gpt2 -e MAX_TOKENS=512",
-        "hf spaces variables set username/my-space --env-file .env",
+        "hf spaces variables add username/my-space -e DEBUG=1",
+        "hf spaces variables add username/my-space -e MODEL_ID=gpt2 -e MAX_TOKENS=512",
+        "hf spaces variables add username/my-space --env-file .env",
     ],
 )
-def variables_set(
+def variables_add(
     space_id: Annotated[str, typer.Argument(help="The space ID (e.g. `username/repo-name`).")],
     env: EnvOpt = None,
     env_file: EnvFileOpt = None,
-    format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
     token: TokenOpt = None,
 ) -> None:
-    """Set environment variables for a Space."""
+    """Add or update environment variables for a Space."""
     env_map = parse_env_map(env, env_file)
     if not env_map:
         raise CLIError("At least one variable must be specified with -e/--env or --env-file.")
     api = get_hf_api(token=token)
     for key, value in env_map.items():
         api.add_space_variable(space_id, key=key, value=value or "")
-    out.result("Variables set", space_id=space_id, keys=list(env_map))
+    out.result("Variables added", space_id=space_id, keys=list(env_map))
     out.hint(f"Use `hf spaces variables ls {space_id}` to list variables for a Space.")
 
 
 @variables_cli.command(
     "delete",
-    examples=["hf spaces variables delete username/my-space DEBUG"],
+    examples=[
+        "hf spaces variables delete username/my-space DEBUG",
+        "hf spaces variables delete username/my-space DEBUG --yes",
+    ],
 )
 def variables_delete(
     space_id: Annotated[str, typer.Argument(help="The space ID (e.g. `username/repo-name`).")],
     key: Annotated[str, typer.Argument(help="Name of the variable to remove.")],
-    format: FormatWithAutoOpt = OutputFormatWithAuto.auto,
+    yes: Annotated[
+        bool,
+        typer.Option(
+            "-y",
+            "--yes",
+            help="Answer Yes to prompt automatically.",
+        ),
+    ] = False,
     token: TokenOpt = None,
 ) -> None:
     """Remove an environment variable from a Space."""
+    out.confirm(
+        f"You are about to remove variable '{key}' from Space '{space_id}'. Proceed?",
+        yes=yes,
+    )
     api = get_hf_api(token=token)
     api.delete_space_variable(space_id, key=key)
     out.result("Variable deleted", space_id=space_id, key=key)


### PR DESCRIPTION
## Summary

Adds two nested subgroups under `hf spaces`, mirroring `volumes` per the #4155 thread:

- `hf spaces secrets {add,delete}` → `add_space_secret` / `delete_space_secret`
- `hf spaces variables {add,delete,ls}` → `add_space_variable` / `delete_space_variable` / `get_space_variables`

Both `add` commands accept multiple `-s`/`-e` flags and `--secrets-file`/`--env-file` (dotenv), reusing the existing `parse_env_map` helper — no new parsing code.

## Examples (smoke-tested on a live Space)

```
$ hf spaces variables add me/space -e MODEL_ID=gpt2 -e MAX_TOKENS=512
✓ Variables added
  keys: ['MODEL_ID', 'MAX_TOKENS']

$ hf spaces variables ls me/space
KEY        VALUE  UPDATED_AT
---------- ------ ----------
MODEL_ID   gpt2   2026-04-30
MAX_TOKENS 512    2026-04-30

$ hf spaces variables delete me/space MAX_TOKENS
You are about to remove variable 'MAX_TOKENS' from Space 'me/space'. Proceed? [y/N]: y
✓ Variable deleted

$ hf spaces secrets delete me/space OPENAI_API_KEY
You are about to remove secret 'OPENAI_API_KEY' from Space 'me/space'. The value cannot be recovered. Proceed? [y/N]: y
✓ Secret deleted
```

## Design notes

- **`add` (not `set`)** — mirrors the underlying `add_space_secret` / `add_space_variable` API verbs and signals upsert semantics explicitly (vs `volumes set`, which is replace-all).
- **Confirm + `--yes` on both `delete` commands.** Per [@Wauplin's review](https://github.com/huggingface/huggingface_hub/pull/4170#issuecomment-4351208819) — consistency over micro-optimization.
- **Confirm message phrasing is deliberately asymmetric.** `secrets delete` warns "...The value cannot be recovered." because the Hub never exposes secret values. `variables delete` uses the shorter volumes-style "...Proceed?" because variable values are visible via `ls` *before* deletion, so a "cannot be recovered" warning would be misleading.
- **No `secrets ls`** — Hub exposes secrets as write-only (no GET endpoint). Will land in a follow-up here once @Wauplin's moon-landing PR exposes secret keys.
- **Verb is `delete`** to match every other destructive command in the CLI.
- **No new tests** — matches #4109 (volumes) and #4155 (lifecycle) precedent for thin `HfApi` wrappers. Parsing is covered by existing `parse_env_map` tests via `jobs run` / `repos create`.
- Both `delete_space_secret` and `delete_space_variable` are **idempotent** server-side — deleting a non-existent key returns success, not 4xx.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new CLI surface area that mutates Space configuration and handles secret values, so mistakes could overwrite or delete environment settings. Implementation is thin wrappers over existing API calls with confirmation prompts on destructive actions.
> 
> **Overview**
> Adds two new `hf spaces` subgroups: `secrets` (supports `add`/`delete`) and `variables` (supports `ls`/`add`/`delete`) to manage a Space’s secret and non-secret environment variables via `HfApi`.
> 
> Both `add` commands accept repeated flags and dotenv-style files (`--secrets-file` / `--env-file`) via existing `parse_env_map`, and both `delete` commands add confirmation prompts with `--yes`. Documentation and the generated CLI reference are updated to describe the new commands and the write-only nature of secrets (no `secrets ls`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a883e84ff968e3bbefa1c4723094604f69ce1f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->