### PR TITLE
[CLI] Add `out.status()`

### DIFF
--- a/src/huggingface_hub/cli/_output.py
+++ b/src/huggingface_hub/cli/_output.py
@@ -25,7 +25,7 @@ from typing import Any
 import typer
 
 from huggingface_hub.errors import ConfirmationError
-from huggingface_hub.utils import ANSI, disable_progress_bars, is_agent, tabulate
+from huggingface_hub.utils import ANSI, StatusLine, disable_progress_bars, is_agent, tabulate
 
 
 # TODO: remove OutputFormat in _cli_utils.py once all commands are migrated to OutputFormatWithAuto.
@@ -166,6 +166,13 @@ class Output:
         if self.mode != OutputFormatWithAuto.human:
             raise ConfirmationError(f"{message} Use --yes to skip confirmation.")
         typer.confirm(message, default=default, abort=True)
+
+    def status(self, message: str | None = None) -> StatusLine:
+        """Return a status line that emits only in human mode (no-op otherwise)."""
+        status = StatusLine(enabled=self.mode == OutputFormatWithAuto.human)
+        if message is not None:
+            status.update(message)
+        return status
 
     def warning(self, message: str) -> None:
         """Print a non-fatal warning to stderr (all modes)."""

--- a/src/huggingface_hub/cli/buckets.py
+++ b/src/huggingface_hub/cli/buckets.py
@@ -30,7 +30,6 @@ from huggingface_hub._buckets import (
 )
 from huggingface_hub.utils import (
     SoftTemporaryDirectory,
-    StatusLine,
     are_progress_bars_disabled,
     disable_progress_bars,
     enable_progress_bars,
@@ -450,8 +449,7 @@ def remove(
     api = get_hf_api(token=token)
 
     if recursive:
-        status = StatusLine(enabled=out.mode == OutputFormatWithAuto.human)
-        status.update("Listing files from remote")
+        status = out.status("Listing files from remote")
 
         all_files: list[BucketFile] = []
         for item in api.list_bucket_tree(

--- a/src/huggingface_hub/cli/extensions.py
+++ b/src/huggingface_hub/cli/extensions.py
@@ -28,7 +28,7 @@ from typing import Annotated, Literal
 import typer
 
 from huggingface_hub.errors import CLIError, CLIExtensionInstallError, ConfirmationError
-from huggingface_hub.utils import StatusLine, get_session, logging
+from huggingface_hub.utils import get_session, logging
 
 from ._cli_utils import typer_factory
 from ._output import out
@@ -386,7 +386,7 @@ def _install_python_extension(
     venv_dir = extension_dir / "venv"
     installed = False
 
-    status = StatusLine()
+    status = out.status()
     try:
         status.update(f"Creating virtual environment in {venv_dir}")
         if extension_dir.exists():

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -49,7 +49,7 @@ from huggingface_hub.errors import CLIError, RemoteEntryNotFoundError, Repositor
 from huggingface_hub.file_download import hf_hub_download
 from huggingface_hub.hf_api import ExpandSpaceProperty_T, HfApi, SpaceSort_T
 from huggingface_hub.repocard import SpaceCard
-from huggingface_hub.utils import StatusLine, are_progress_bars_disabled, disable_progress_bars, enable_progress_bars
+from huggingface_hub.utils import are_progress_bars_disabled, disable_progress_bars, enable_progress_bars
 
 from ._cli_utils import (
     AuthorOpt,
@@ -314,7 +314,7 @@ def dev_mode(
         SpaceStage.APP_STARTING: "app starting...",
         SpaceStage.RUNNING_APP_STARTING: "app starting...",
     }
-    status = StatusLine()
+    status = out.status()
     while True:
         info = api.space_info(space_id)
         if info.runtime is None:

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 import pytest
 
 from huggingface_hub.cli._cli_utils import OutputFormatWithAuto
@@ -316,6 +318,32 @@ def test_confirm_non_human_raises(mode):
     o.set_mode(mode)
     with pytest.raises(ConfirmationError, match="Use --yes to skip confirmation"):
         o.confirm("Delete everything?")
+
+
+# =============================================================================
+# out.status()
+# =============================================================================
+
+
+def test_status(check, monkeypatch):
+    class FakeStatusLine:
+        def __init__(self, *, enabled=True):
+            self.enabled = enabled
+
+        def update(self, msg):
+            if self.enabled:
+                print(msg, file=sys.stderr)
+
+    monkeypatch.setattr("huggingface_hub.cli._output.StatusLine", FakeStatusLine)
+
+    check(
+        lambda out: out.status("Working"),
+        stderr=True,
+        human="Working",
+        agent="",
+        json="",
+        quiet="",
+    )
 
 
 # =============================================================================

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -325,7 +325,7 @@ def test_confirm_non_human_raises(mode):
 # =============================================================================
 
 
-def test_status(check, monkeypatch):
+def test_status_only_enabled_for_humans(check, monkeypatch):
     class FakeStatusLine:
         def __init__(self, *, enabled=True):
             self.enabled = enabled


### PR DESCRIPTION
Follow-up to Wauplin’s review comment in https://github.com/huggingface/huggingface_hub/pull/4111#discussion_r3087129946.

This PR adds `out.status()` as the CLI wrapper around `StatusLine`, so command code can request a status line without deciding when it should render. It also migrates the existing CLI status-line call sites in buckets, extensions, and spaces to use the new helper.

**Breaking Change**

`hf extensions install` and `hf spaces dev-mode` no longer print status updates when run with `--format json`, `--quiet`, or `--format agent`.

Before, `StatusLine()` defaulted to `enabled=True`, so updates went to stderr whenever stderr was a TTY, regardless of output mode. After this PR, status updates go to stderr only in `human` mode, and still only when stderr is a TTY.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CLI stderr output behavior by suppressing status updates in `agent`/`json`/`quiet` modes, which may affect tooling that relied on those messages.
> 
> **Overview**
> Adds `Output.status()` as a CLI-level wrapper around `StatusLine`, automatically enabling status rendering only in `human` mode and remaining a no-op for `agent`/`json`/`quiet` output.
> 
> Updates existing status-line usage in `hf buckets rm --recursive`, `hf extensions install` (python extension path), and `hf spaces dev-mode` to use `out.status()` instead of constructing `StatusLine` directly, and adds a targeted unit test to lock in the new mode-dependent behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9912a86938566ce51ad01e1a818f241acc0dbb37. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->