### PR TITLE
[Release] Move social drafts to minor-release and archive release notes to bucket

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -646,8 +646,8 @@ jobs:
   # Runs on minor-release (not prerelease) so that release notes can be
   # manually reviewed/edited between the RC and the final release. Fetches
   # the (possibly edited) notes from the GitHub draft release, generates
-  # social media drafts and a Slack announcement, and uploads everything
-  # (social posts, slack.txt, release_notes.txt) to the HF bucket.
+  # social media drafts, and uploads everything (social posts,
+  # release_notes.txt) to the HF bucket.
   # ============================================================
   social-posts:
     permissions:
@@ -716,18 +716,6 @@ jobs:
             --version "v${VERSION}" \
             --input .release-notes/notes.md
 
-      - name: Generate Slack announcement
-        if: ${{ steps.fetch.outputs.found == 'true' }}
-        env:
-          HF_TOKEN: ${{ secrets.RELEASE_NOTES_HF_TOKEN }}
-          RELEASE_NOTES_MODEL: ${{ vars.RELEASE_NOTES_MODEL }}
-        run: |
-          VERSION="${{ needs.prepare.outputs.version }}"
-          python -m utils.release_notes.generate_slack_message \
-            --version "v${VERSION}" \
-            --rc-version "${VERSION}" \
-            --input .release-notes/notes.md
-
       - name: Upload to bucket
         if: ${{ steps.fetch.outputs.found == 'true' }}
         env:
@@ -740,7 +728,6 @@ jobs:
           mkdir -p "${STAGING}/socials"
           cp .release-notes/socials/* "${STAGING}/socials/" 2>/dev/null || true
           cp .release-notes/notes.md "${STAGING}/release_notes.txt"
-          cp ".release-notes/SLACK_MESSAGE_v${VERSION}.md" "${STAGING}/slack.txt"
 
           hf buckets sync "${STAGING}/" \
             "hf://buckets/huggingface/releases/huggingface_hub/${VERSION}/"
@@ -759,10 +746,6 @@ jobs:
               echo "" >> $GITHUB_STEP_SUMMARY
             fi
           done
-          echo "## Slack Announcement" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          cat ".release-notes/SLACK_MESSAGE_v${{ needs.prepare.outputs.version }}.md" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
 
       - name: Notify Slack
         if: ${{ always() && needs.prepare.outputs.message_ts }}
@@ -774,11 +757,11 @@ jobs:
           VERSION="${{ needs.prepare.outputs.version }}"
           BUCKET_URL="https://huggingface.co/buckets/huggingface/releases/tree/huggingface_hub/${VERSION}"
           if [[ "${{ steps.fetch.outputs.found }}" != "true" ]]; then
-            TEXT="⚠️ *Social & Slack drafts* — skipped (no release found)"
+            TEXT="⚠️ *Social media drafts* — skipped (no release found)"
           elif [[ "${{ job.status }}" == "success" ]]; then
-            TEXT="✅ *Social & Slack drafts* — <${BUCKET_URL}|uploaded to bucket>"
+            TEXT="✅ *Social media drafts* — <${BUCKET_URL}|uploaded to bucket>"
           else
-            TEXT="❌ *Social & Slack drafts* — generation failed"
+            TEXT="❌ *Social media drafts* — generation failed"
           fi
           curl -s -X POST https://slack.com/api/chat.postMessage \
             -H "Authorization: Bearer $SLACK_BOT_TOKEN" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -712,8 +712,9 @@ jobs:
           RELEASE_NOTES_MODEL: ${{ vars.RELEASE_NOTES_MODEL }}
         run: |
           VERSION="${{ needs.prepare.outputs.version }}"
+          BASE_VERSION=$(echo "$VERSION" | sed -E 's/\.rc.*//')
           python -m utils.release_notes.generate_social_posts \
-            --version "v${VERSION}" \
+            --version "v${BASE_VERSION}" \
             --input .release-notes/notes.md
 
       - name: Upload to bucket
@@ -755,7 +756,8 @@ jobs:
           SLACK_CHANNEL_ID: ${{ vars.SLACK_CHANNEL_ID }}
         run: |
           VERSION="${{ needs.prepare.outputs.version }}"
-          BUCKET_URL="https://huggingface.co/buckets/huggingface/releases/tree/huggingface_hub/${VERSION}"
+          BASE_VERSION=$(echo "$VERSION" | sed -E 's/\.rc.*//')
+          BUCKET_URL="https://huggingface.co/buckets/huggingface/releases/tree/huggingface_hub/${BASE_VERSION}"
           if [[ "${{ steps.fetch.outputs.found }}" != "true" ]]; then
             TEXT="⚠️ *Social media drafts* — skipped (no release found)"
           elif [[ "${{ job.status }}" == "success" ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -641,7 +641,13 @@ jobs:
           fi
 
   # ============================================================
-  # 4c. SOCIAL POSTS — generate draft social media posts for prereleases
+  # 4c. SOCIAL POSTS & BUCKET ARCHIVE — generate drafts on minor-release
+  #
+  # Runs on minor-release (not prerelease) so that release notes can be
+  # manually reviewed/edited between the RC and the final release. Fetches
+  # the (possibly edited) notes from the GitHub draft release, generates
+  # social media drafts and a Slack announcement, and uploads everything
+  # (social posts, slack.txt, release_notes.txt) to the HF bucket.
   # ============================================================
   social-posts:
     permissions:
@@ -649,7 +655,7 @@ jobs:
     needs: [prepare, release-notes]
     # Use !cancelled() so this job runs even if release-notes failed (we fetch the draft directly from GitHub).
     # This also allows re-running this job after manually editing the draft release notes.
-    if: ${{ !cancelled() && needs.prepare.result == 'success' && needs.prepare.outputs.is_prerelease == 'true' }}
+    if: ${{ !cancelled() && needs.prepare.result == 'success' && inputs.release_type == 'minor-release' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -674,14 +680,22 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          TAG="${{ needs.prepare.outputs.tag }}"
           VERSION="${{ needs.prepare.outputs.version }}"
           MINOR=$(echo "$VERSION" | sed -E 's/^([0-9]+\.[0-9]+).*/\1/')
 
-          RELEASE_TAG=$(gh release list --json tagName,isDraft,isPrerelease --limit 100 \
-            | jq -r ".[] | select(.isDraft or .isPrerelease) | select(.tagName | startswith(\"v${MINOR}.\")) | .tagName" | head -1)
+          # After the release-notes job, the draft release has been promoted to the final tag.
+          # Try the exact tag first, then fall back to searching by minor version.
+          RELEASE_TAG=""
+          if gh release view "$TAG" --json tagName -q '.tagName' >/dev/null 2>&1; then
+            RELEASE_TAG="$TAG"
+          else
+            RELEASE_TAG=$(gh release list --json tagName,isDraft --limit 100 \
+              | jq -r ".[] | select(.tagName | startswith(\"v${MINOR}.\")) | .tagName" | head -1)
+          fi
 
           if [[ -z "$RELEASE_TAG" ]]; then
-            echo "::warning::No release found for v${MINOR}. Skipping social media draft generation (likely because release-notes failed)."
+            echo "::warning::No release found for v${MINOR}. Skipping drafts generation (likely because release-notes failed)."
             echo "found=false" >> $GITHUB_OUTPUT
             exit 0
           fi
@@ -698,20 +712,38 @@ jobs:
           RELEASE_NOTES_MODEL: ${{ vars.RELEASE_NOTES_MODEL }}
         run: |
           VERSION="${{ needs.prepare.outputs.version }}"
-          BASE_VERSION=$(echo "$VERSION" | sed -E 's/\.rc.*//')
           python -m utils.release_notes.generate_social_posts \
-            --version "v${BASE_VERSION}" \
+            --version "v${VERSION}" \
             --input .release-notes/notes.md
 
-      - name: Upload drafts to bucket
+      - name: Generate Slack announcement
+        if: ${{ steps.fetch.outputs.found == 'true' }}
+        env:
+          HF_TOKEN: ${{ secrets.RELEASE_NOTES_HF_TOKEN }}
+          RELEASE_NOTES_MODEL: ${{ vars.RELEASE_NOTES_MODEL }}
+        run: |
+          VERSION="${{ needs.prepare.outputs.version }}"
+          python -m utils.release_notes.generate_slack_message \
+            --version "v${VERSION}" \
+            --rc-version "${VERSION}" \
+            --input .release-notes/notes.md
+
+      - name: Upload to bucket
         if: ${{ steps.fetch.outputs.found == 'true' }}
         env:
           HF_TOKEN: ${{ secrets.RELEASE_BUCKET_HF_TOKEN }}
         run: |
           VERSION="${{ needs.prepare.outputs.version }}"
-          BASE_VERSION=$(echo "$VERSION" | sed -E 's/\.rc.*//')
-          hf buckets sync .release-notes/socials/ \
-            "hf://buckets/huggingface/releases/huggingface_hub/${BASE_VERSION}/socials/"
+
+          # Stage all artifacts into a single directory for one sync
+          STAGING=".release-notes/bucket"
+          mkdir -p "${STAGING}/socials"
+          cp .release-notes/socials/* "${STAGING}/socials/" 2>/dev/null || true
+          cp .release-notes/notes.md "${STAGING}/release_notes.txt"
+          cp ".release-notes/SLACK_MESSAGE_v${VERSION}.md" "${STAGING}/slack.txt"
+
+          hf buckets sync "${STAGING}/" \
+            "hf://buckets/huggingface/releases/huggingface_hub/${VERSION}/"
 
       - name: Print drafts to summary
         if: ${{ steps.fetch.outputs.found == 'true' }}
@@ -727,6 +759,10 @@ jobs:
               echo "" >> $GITHUB_STEP_SUMMARY
             fi
           done
+          echo "## Slack Announcement" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cat ".release-notes/SLACK_MESSAGE_v${{ needs.prepare.outputs.version }}.md" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
 
       - name: Notify Slack
         if: ${{ always() && needs.prepare.outputs.message_ts }}
@@ -736,14 +772,13 @@ jobs:
           SLACK_CHANNEL_ID: ${{ vars.SLACK_CHANNEL_ID }}
         run: |
           VERSION="${{ needs.prepare.outputs.version }}"
-          BASE_VERSION=$(echo "$VERSION" | sed -E 's/\.rc.*//')
-          BUCKET_URL="https://huggingface.co/buckets/huggingface/releases/tree/huggingface_hub/${BASE_VERSION}/socials"
+          BUCKET_URL="https://huggingface.co/buckets/huggingface/releases/tree/huggingface_hub/${VERSION}"
           if [[ "${{ steps.fetch.outputs.found }}" != "true" ]]; then
-            TEXT="⚠️ *Social media drafts* — skipped (no release found)"
+            TEXT="⚠️ *Social & Slack drafts* — skipped (no release found)"
           elif [[ "${{ job.status }}" == "success" ]]; then
-            TEXT="✅ *Social media drafts* — <${BUCKET_URL}|uploaded to bucket>"
+            TEXT="✅ *Social & Slack drafts* — <${BUCKET_URL}|uploaded to bucket>"
           else
-            TEXT="❌ *Social media drafts* — generation failed"
+            TEXT="❌ *Social & Slack drafts* — generation failed"
           fi
           curl -s -X POST https://slack.com/api/chat.postMessage \
             -H "Authorization: Bearer $SLACK_BOT_TOKEN" \


### PR DESCRIPTION
## Summary

- **Social media posts now generated on `minor-release` instead of `minor-prerelease`**, giving time to manually review/edit the GitHub release notes between the RC and the final release.
- **Release notes are archived to the HF bucket** at `hf://buckets/huggingface/releases/huggingface_hub/<version>/release_notes.txt` alongside the social posts.



🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release workflow gating and artifact publishing paths; misconfiguration could cause missing social drafts or bucket uploads during a production release.
> 
> **Overview**
> Moves the `social-posts` job to run on `minor-release` (instead of prerelease) so social drafts are generated from the *final, manually edited* GitHub release notes.
> 
> Updates release-note fetching to prefer the exact final tag (post-promotion) with a minor-version fallback, and changes bucket publishing to sync a single staged directory containing both social drafts and an archived `release_notes.txt` under `hf://.../huggingface_hub/${VERSION}/` (with Slack linking to the new base bucket path).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0f9ea3179090ddf82b43a555dc91f90117ff830. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->