### PR TITLE
[CLI] Add hints and example to `hf datasets leaderboard`

### DIFF
--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -1051,6 +1051,7 @@ $ hf datasets leaderboard [OPTIONS] DATASET_ID
 Examples
   $ hf datasets leaderboard SWE-bench/SWE-bench_Verified
   $ hf datasets leaderboard SWE-bench/SWE-bench_Verified --limit 5 --format json
+  $ hf datasets ls --filter benchmark:official  # list available leaderboards
 
 Learn more
   Use `hf <command> --help` for more information about a command.

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -1030,7 +1030,7 @@ Learn more
 
 ### `hf datasets leaderboard`
 
-List model scores from a dataset leaderboard. This command helps find the best models for a task or compare models by benchmark scores.
+List model scores from a dataset leaderboard. This command helps find the best models for a task or compare models by benchmark scores. Use 'hf datasets ls --filter benchmark:official' to list available leaderboards.
 
 **Usage**:
 

--- a/src/huggingface_hub/cli/datasets.py
+++ b/src/huggingface_hub/cli/datasets.py
@@ -174,7 +174,7 @@ def datasets_leaderboard(
     limit: LimitOpt = 20,
     token: TokenOpt = None,
 ) -> None:
-    """List model scores from a dataset leaderboard. This command helps find the best models for a task or compare models by benchmark scores."""
+    """List model scores from a dataset leaderboard. This command helps find the best models for a task or compare models by benchmark scores. Use 'hf datasets ls --filter benchmark:official' to list available leaderboards."""
     api = get_hf_api(token=token)
     leaderboard = api.get_dataset_leaderboard(repo_id=dataset_id)
     results = [api_object_to_dict(entry) for entry in leaderboard[:limit]]

--- a/src/huggingface_hub/cli/datasets.py
+++ b/src/huggingface_hub/cli/datasets.py
@@ -166,6 +166,7 @@ def datasets_ls(
     examples=[
         "hf datasets leaderboard SWE-bench/SWE-bench_Verified",
         "hf datasets leaderboard SWE-bench/SWE-bench_Verified --limit 5 --format json",
+        "hf datasets ls --filter benchmark:official  # list available leaderboards",
     ],
 )
 def datasets_leaderboard(
@@ -183,6 +184,9 @@ def datasets_leaderboard(
         id_key="model_id",
         alignments={"rank": "right", "value": "right"},
     )
+    out.hint("Use 'hf datasets ls --filter benchmark:official' to list available leaderboards.")
+    if leaderboard:
+        out.hint(f"Use 'hf models info {leaderboard[0].model_id}' to get details about a model.")
 
 
 @datasets_cli.command(


### PR DESCRIPTION
### Context: https://huggingface.slack.com/archives/C0A1MNQ8LF3/p1777552593518999

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improve discoverability of leaderboard-related CLI commands:

- **New example in `--help`**: Added `hf datasets ls --filter benchmark:official` as a third example in the `hf datasets leaderboard` help text, so users know how to discover available leaderboards.
- **Hint: list available leaderboards**: After the leaderboard table output, prints a hint suggesting `hf datasets ls --filter benchmark:official`.
- **Hint: get model info**: After the leaderboard table output, prints a hint suggesting `hf models info <model_id>` using the top-ranked model from the results as a concrete example.

### Example output

```
$ hf datasets leaderboard SWE-bench/SWE-bench_Verified --limit 3
RANK MODEL_ID                      VALUE SOURCE    
---- ----------------------------- ----- ----------
   1 deepseek-ai/DeepSeek-V4-Pro    80.6 Model Card
   2 moonshotai/Kimi-K2.6           80.2 Model Card
   3 deepseek-ai/DeepSeek-V4-Flash    79 Model Card
Hint: Use 'hf datasets ls --filter benchmark:official' to list available leaderboards.
Hint: Use 'hf models info deepseek-ai/DeepSeek-V4-Pro' to get details about a model.
```

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://huggingface.slack.com/archives/C0A1MNQ8LF3/p1777552593518999?thread_ts=1777552593.518999&cid=C0A1MNQ8LF3)

<div><a href="https://cursor.com/agents/bc-3d2d186f-306e-553a-942e-469e3c5f9ef8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d2d186f-306e-553a-942e-469e3c5f9ef8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

