### PR TITLE
[CLI] migrate `hf skills` to bucket

### DIFF
--- a/src/huggingface_hub/cli/_skills.py
+++ b/src/huggingface_hub/cli/_skills.py
@@ -53,15 +53,16 @@ def add_skill(skill_name: str, destination_root: Path, force: bool = False) -> P
 
 def update_skills(roots: list[Path], selector: str | None = None) -> list[SkillUpdateInfo]:
     """Re-sync managed marketplace skill installs from the bucket."""
+    skill_dirs = _iter_unique_skill_dirs(roots)
+    if selector is not None:
+        selector_lower = selector.strip().lower()
+        skill_dirs = [d for d in skill_dirs if d.name.lower() == selector_lower]
+        if not skill_dirs:
+            raise CLIError(f"No installed skill matches '{selector}'. Install it with `hf skills add {selector}`.")
+
     api = get_hf_api()
     marketplace_skills = {skill.name.lower(): skill for skill in _load_marketplace_skills(api)}
-    updates = [
-        _apply_single_update(api, skill_dir, marketplace_skills) for skill_dir in _iter_unique_skill_dirs(roots)
-    ]
-    filtered = _filter_updates(updates, selector)
-    if selector is not None and not filtered:
-        raise CLIError(f"No installed skills match '{selector}'.")
-    return filtered
+    return [_apply_single_update(api, skill_dir, marketplace_skills) for skill_dir in skill_dirs]
 
 
 def _load_marketplace_skills(api) -> list[MarketplaceSkill]:
@@ -242,10 +243,3 @@ def _apply_single_update(api, skill_dir: Path, marketplace_skills: dict[str, Mar
         return replace(base, status="source_unreachable", detail=str(exc))
 
     return replace(base, status="up_to_date")
-
-
-def _filter_updates(updates: list[SkillUpdateInfo], selector: str | None) -> list[SkillUpdateInfo]:
-    if selector is None:
-        return updates
-    selector_lower = selector.strip().lower()
-    return [update for update in updates if update.name.lower() == selector_lower]

--- a/src/huggingface_hub/cli/_skills.py
+++ b/src/huggingface_hub/cli/_skills.py
@@ -176,10 +176,14 @@ def _download_skill_files(api, skill: MarketplaceSkill, files: list[BucketFile],
     prefix = skill.repo_path.rstrip("/")
     prefix_with_slash = f"{prefix}/"
 
-    # Strip the `skills/<name>/` prefix so files land directly under `install_dir`,
-    # preserving any nested directory structure.
+    # `list_bucket_tree(prefix=...)` matches as a raw string prefix, so e.g. asking for
+    # "skills/gradio" can also return "skills/gradio-tools/...". Filter on the trailing
+    # slash to keep only files actually inside the directory, then strip it so files land
+    # directly under `install_dir` preserving any nested structure.
     download_specs: list[tuple[str | BucketFile, str | Path]] = []
     for bucket_file in files:
+        if not bucket_file.path.startswith(prefix_with_slash):
+            continue
         relative = bucket_file.path[len(prefix_with_slash) :]
         local_file = install_dir.joinpath(*PurePosixPath(relative).parts)
         local_file.parent.mkdir(parents=True, exist_ok=True)

--- a/src/huggingface_hub/cli/_skills.py
+++ b/src/huggingface_hub/cli/_skills.py
@@ -1,35 +1,27 @@
 """Internal helpers for Hugging Face marketplace skill installation and upgrades."""
 
-import base64
-import io
 import json
 import shutil
-import tarfile
 import tempfile
 from dataclasses import dataclass, replace
 from pathlib import Path, PurePosixPath
 from typing import Any, Literal
 
+from huggingface_hub._buckets import BucketFile
 from huggingface_hub.errors import CLIError
-from huggingface_hub.utils import get_session
+
+from ._cli_utils import get_hf_api
 
 
-DEFAULT_SKILLS_REPO_ID = "huggingface/skills"
-DEFAULT_SKILLS_REPO_OWNER, DEFAULT_SKILLS_REPO_NAME = DEFAULT_SKILLS_REPO_ID.split("/")
-DEFAULT_SKILLS_REF = "main"
-MARKETPLACE_PATH = ".claude-plugin/marketplace.json"
-GITHUB_API_TIMEOUT = 10
-SKILL_MANIFEST_FILENAME = ".hf-skill-manifest.json"
-SKILL_MANIFEST_SCHEMA_VERSION = 1
+DEFAULT_SKILLS_BUCKET_ID = "huggingface/skills"
+MARKETPLACE_PATH = "marketplace.json"
+# Empty marker file dropped into managed skill installs so `hf skills update` knows
+# to touch them and leave user-placed skill dirs alone. Filename is historical (used
+# to be a JSON manifest with a revision); we keep it for backward compat with installs
+# made by previous versions.
+MANAGED_MARKER_FILENAME = ".hf-skill-manifest.json"
 
-SkillUpdateStatus = Literal[
-    "up_to_date",
-    "update_available",
-    "updated",
-    "unmanaged",
-    "invalid_metadata",
-    "source_unreachable",
-]
+SkillUpdateStatus = Literal["up_to_date", "unmanaged", "source_unreachable"]
 
 
 @dataclass(frozen=True)
@@ -39,24 +31,41 @@ class MarketplaceSkill:
 
 
 @dataclass(frozen=True)
-class InstalledSkillManifest:
-    schema_version: int
-    installed_revision: str
-
-
-@dataclass(frozen=True)
 class SkillUpdateInfo:
     name: str
     skill_dir: Path
     status: SkillUpdateStatus
     detail: str | None = None
-    current_revision: str | None = None
-    available_revision: str | None = None
 
 
-def load_marketplace_skills() -> list[MarketplaceSkill]:
-    """Load skills from the default Hugging Face marketplace."""
-    payload = _load_marketplace_payload()
+def add_skill(skill_name: str, destination_root: Path, force: bool = False) -> Path:
+    """Resolve a marketplace skill by name and install it."""
+    api = get_hf_api()
+    marketplace_skills = _load_marketplace_skills(api)
+    skill = _select_marketplace_skill(marketplace_skills, skill_name)
+    if skill is None:
+        raise CLIError(
+            f"Skill '{skill_name}' not found in {DEFAULT_SKILLS_BUCKET_ID}. "
+            "Try `hf skills add` to install `hf-cli` or use a known skill name."
+        )
+    return _install_marketplace_skill(api, skill, destination_root, force=force)
+
+
+def update_skills(roots: list[Path], selector: str | None = None) -> list[SkillUpdateInfo]:
+    """Re-sync managed marketplace skill installs from the bucket."""
+    api = get_hf_api()
+    marketplace_skills = {skill.name.lower(): skill for skill in _load_marketplace_skills(api)}
+    updates = [
+        _apply_single_update(api, skill_dir, marketplace_skills) for skill_dir in _iter_unique_skill_dirs(roots)
+    ]
+    filtered = _filter_updates(updates, selector)
+    if selector is not None and not filtered:
+        raise CLIError(f"No installed skills match '{selector}'.")
+    return filtered
+
+
+def _load_marketplace_skills(api) -> list[MarketplaceSkill]:
+    payload = _load_marketplace_payload(api)
     plugins = payload.get("plugins")
     if not isinstance(plugins, list):
         raise CLIError("Invalid marketplace payload: expected a top-level 'plugins' list.")
@@ -73,36 +82,27 @@ def load_marketplace_skills() -> list[MarketplaceSkill]:
     return skills
 
 
-def get_marketplace_skill(selector: str) -> MarketplaceSkill:
-    """Resolve a marketplace skill by name."""
-    selected = _select_marketplace_skill(load_marketplace_skills(), selector)
-    if selected is None:
-        raise CLIError(
-            f"Skill '{selector}' not found in {DEFAULT_SKILLS_REPO_ID}. "
-            "Try `hf skills add` to install `hf-cli` or use a known skill name."
-        )
-    return selected
-
-
-def install_marketplace_skill(skill: MarketplaceSkill, destination_root: Path, force: bool = False) -> Path:
+def _install_marketplace_skill(api, skill: MarketplaceSkill, destination_root: Path, force: bool = False) -> Path:
     """Install a marketplace skill into a local skills directory."""
     destination_root = destination_root.expanduser().resolve()
     destination_root.mkdir(parents=True, exist_ok=True)
     install_dir = destination_root / skill.name
+    already_exists = install_dir.exists()
 
-    if install_dir.exists() and not force:
+    if already_exists and not force:
         raise FileExistsError(f"Skill already exists: {install_dir}")
 
-    if install_dir.exists():
+    if already_exists:
+        # Stage the new content in a sibling tempdir and atomically rename, so the
+        # existing install stays intact if the download fails halfway through.
         with tempfile.TemporaryDirectory(dir=destination_root, prefix=f".{install_dir.name}.install-") as tmp_dir_str:
-            tmp_dir = Path(tmp_dir_str)
-            staged_dir = tmp_dir / install_dir.name
-            _populate_install_dir(skill=skill, install_dir=staged_dir)
+            staged_dir = Path(tmp_dir_str) / install_dir.name
+            _populate_install_dir(api, skill=skill, install_dir=staged_dir)
             _atomic_replace_directory(existing_dir=install_dir, staged_dir=staged_dir)
         return install_dir
 
     try:
-        _populate_install_dir(skill=skill, install_dir=install_dir)
+        _populate_install_dir(api, skill=skill, install_dir=install_dir)
     except Exception:
         if install_dir.exists():
             shutil.rmtree(install_dir)
@@ -110,81 +110,15 @@ def install_marketplace_skill(skill: MarketplaceSkill, destination_root: Path, f
     return install_dir
 
 
-def check_for_updates(
-    roots: list[Path],
-    selector: str | None = None,
-) -> list[SkillUpdateInfo]:
-    """Check managed skill installs for newer upstream revisions."""
-    marketplace_skills = {skill.name.lower(): skill for skill in load_marketplace_skills()}
-    updates = [_evaluate_update(skill_dir, marketplace_skills) for skill_dir in _iter_unique_skill_dirs(roots)]
-    filtered = _filter_updates(updates, selector)
-    if selector is not None and not filtered:
-        raise CLIError(f"No installed skills match '{selector}'.")
-    return filtered
-
-
-def apply_updates(
-    roots: list[Path],
-    selector: str | None = None,
-) -> list[SkillUpdateInfo]:
-    """Upgrade managed skills in place when the upstream revision changes."""
-    updates = check_for_updates(roots, selector)
-    results: list[SkillUpdateInfo] = []
-    for update in updates:
-        results.append(_apply_single_update(update))
-    return results
-
-
-def read_installed_skill_manifest(skill_dir: Path) -> tuple[InstalledSkillManifest | None, str | None]:
-    """Read local skill metadata written by `hf skills add`."""
-    manifest_path = skill_dir / SKILL_MANIFEST_FILENAME
-    if not manifest_path.exists():
-        return None, None
-    try:
-        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
-    except Exception as exc:  # noqa: BLE001
-        return None, f"invalid json: {exc}"
-    if not isinstance(payload, dict):
-        return None, "metadata root must be an object"
-    try:
-        return _parse_installed_skill_manifest(payload), None
-    except ValueError as exc:
-        return None, str(exc)
-
-
-def write_installed_skill_manifest(skill_dir: Path, manifest: InstalledSkillManifest) -> None:
-    payload = {
-        "schema_version": manifest.schema_version,
-        "installed_revision": manifest.installed_revision,
-    }
-    (skill_dir / SKILL_MANIFEST_FILENAME).write_text(
-        json.dumps(payload, indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
-    )
-
-
-def _load_marketplace_payload() -> dict[str, Any]:
-    response = _fetch_from_skills_repo(
-        f"contents/{MARKETPLACE_PATH}",
-        params={"ref": DEFAULT_SKILLS_REF},
-    )
-    try:
-        payload = response.json()
-    except Exception as exc:  # noqa: BLE001
-        raise CLIError(f"Failed to decode GitHub API response for 'contents/{MARKETPLACE_PATH}': {exc}") from exc
-    if not isinstance(payload, dict):
-        raise CLIError("Invalid marketplace response: expected a JSON object.")
-
-    content = payload.get("content")
-    encoding = payload.get("encoding")
-    if not isinstance(content, str) or encoding != "base64":
-        raise CLIError("Invalid marketplace payload: expected base64-encoded content.")
-
-    try:
-        decoded = base64.b64decode(content).decode("utf-8")
-        parsed = json.loads(decoded)
-    except Exception as exc:  # noqa: BLE001
-        raise CLIError(f"Failed to decode marketplace payload: {exc}") from exc
+def _load_marketplace_payload(api) -> dict[str, Any]:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        local_path = Path(tmp_dir) / "marketplace.json"
+        api.download_bucket_files(
+            DEFAULT_SKILLS_BUCKET_ID,
+            [(MARKETPLACE_PATH, local_path)],
+            raise_on_missing_files=True,
+        )
+        parsed = json.loads(local_path.read_text(encoding="utf-8"))
 
     if not isinstance(parsed, dict):
         raise CLIError("Invalid marketplace payload: expected a JSON object.")
@@ -209,22 +143,12 @@ def _normalize_repo_path(path: str) -> str:
     return normalized
 
 
-def _populate_install_dir(skill: MarketplaceSkill, install_dir: Path) -> None:
-    installed_revision = _resolve_available_revision(skill)
+def _populate_install_dir(api, skill: MarketplaceSkill, install_dir: Path) -> None:
     install_dir.mkdir(parents=True, exist_ok=True)
-    _extract_remote_github_path(
-        revision=installed_revision,
-        source_path=skill.repo_path,
-        install_dir=install_dir,
-    )
+    bucket_files = _list_skill_files(api, skill)
+    _download_skill_files(api, skill, bucket_files, install_dir)
     _validate_installed_skill_dir(install_dir)
-    write_installed_skill_manifest(
-        install_dir,
-        InstalledSkillManifest(
-            schema_version=SKILL_MANIFEST_SCHEMA_VERSION,
-            installed_revision=installed_revision,
-        ),
-    )
+    (install_dir / MANAGED_MARKER_FILENAME).touch()
 
 
 def _validate_installed_skill_dir(skill_dir: Path) -> None:
@@ -233,54 +157,37 @@ def _validate_installed_skill_dir(skill_dir: Path) -> None:
         raise RuntimeError(f"Installed skill is missing SKILL.md: {skill_file}")
 
 
-def _extract_remote_github_path(revision: str, source_path: str, install_dir: Path) -> None:
-    tar_bytes = _fetch_from_skills_repo(f"tarball/{revision}").content
-    _extract_tar_subpath(tar_bytes, source_path=source_path, install_dir=install_dir)
+def _list_skill_files(api, skill: MarketplaceSkill) -> list[BucketFile]:
+    """List all files under `skill.repo_path` in the marketplace bucket."""
+    prefix = skill.repo_path.rstrip("/")
+    files: list[BucketFile] = [
+        item
+        for item in api.list_bucket_tree(DEFAULT_SKILLS_BUCKET_ID, prefix=prefix, recursive=True)
+        if isinstance(item, BucketFile)
+    ]
+    if not files:
+        raise FileNotFoundError(f"Path '{prefix}' not found in bucket '{DEFAULT_SKILLS_BUCKET_ID}'.")
+    return files
 
 
-def _extract_tar_subpath(tar_bytes: bytes, source_path: str, install_dir: Path) -> None:
-    """Extract a skill subdirectory from a tar archive.
+def _download_skill_files(api, skill: MarketplaceSkill, files: list[BucketFile], install_dir: Path) -> None:
+    """Download bucket files into `install_dir`."""
+    prefix = skill.repo_path.rstrip("/")
+    prefix_with_slash = f"{prefix}/"
 
-    GitHub tarballs include a leading `<repo>-<revision>/` directory. The helper also
-    accepts archives that start directly at `skills/<name>/...` to keep tests simple.
-    """
-    source_parts = PurePosixPath(source_path).parts
-    with tarfile.open(fileobj=io.BytesIO(tar_bytes), mode="r:*") as archive:
-        members = archive.getmembers()
-        matched = False
-        for member in members:
-            relative_parts = _member_relative_parts(member_name=member.name, source_parts=source_parts)
-            if relative_parts is None:
-                continue
-            if not relative_parts:
-                matched = True
-                continue
-            matched = True
-            relative_path = Path(*relative_parts)
-            if ".." in relative_path.parts:
-                raise RuntimeError(f"Invalid path found in archive for {source_path}.")
-            destination_path = install_dir / relative_path
-            if member.isdir():
-                destination_path.mkdir(parents=True, exist_ok=True)
-                continue
-            if not member.isfile():
-                continue
-            destination_path.parent.mkdir(parents=True, exist_ok=True)
-            extracted = archive.extractfile(member)
-            if extracted is None:
-                raise RuntimeError(f"Failed to extract {member.name}.")
-            destination_path.write_bytes(extracted.read())
-    if not matched:
-        raise FileNotFoundError(f"Path '{source_path}' not found in source archive.")
+    # Strip the `skills/<name>/` prefix so files land directly under `install_dir`,
+    # preserving any nested directory structure.
+    download_specs: list[tuple[str | BucketFile, str | Path]] = []
+    for bucket_file in files:
+        relative = bucket_file.path[len(prefix_with_slash) :]
+        local_file = install_dir.joinpath(*PurePosixPath(relative).parts)
+        local_file.parent.mkdir(parents=True, exist_ok=True)
+        download_specs.append((bucket_file, local_file))
 
+    if not download_specs:
+        raise FileNotFoundError(f"No files found under '{prefix}' in bucket '{DEFAULT_SKILLS_BUCKET_ID}'.")
 
-def _member_relative_parts(member_name: str, source_parts: tuple[str, ...]) -> tuple[str, ...] | None:
-    path_parts = PurePosixPath(member_name).parts
-    if tuple(path_parts[: len(source_parts)]) == source_parts:
-        return path_parts[len(source_parts) :]
-    if len(path_parts) > len(source_parts) and tuple(path_parts[1 : 1 + len(source_parts)]) == source_parts:
-        return path_parts[1 + len(source_parts) :]
-    return None
+    api.download_bucket_files(DEFAULT_SKILLS_BUCKET_ID, download_specs)
 
 
 def _atomic_replace_directory(existing_dir: Path, staged_dir: Path) -> None:
@@ -315,49 +222,26 @@ def _iter_unique_skill_dirs(roots: list[Path]) -> list[Path]:
     return discovered
 
 
-def _evaluate_update(skill_dir: Path, marketplace_skills: dict[str, MarketplaceSkill]) -> SkillUpdateInfo:
+def _apply_single_update(api, skill_dir: Path, marketplace_skills: dict[str, MarketplaceSkill]) -> SkillUpdateInfo:
     base = SkillUpdateInfo(name=skill_dir.name, skill_dir=skill_dir, status="unmanaged")
 
-    manifest, error = read_installed_skill_manifest(skill_dir)
-    if manifest is None:
-        return replace(base, status="invalid_metadata" if error else "unmanaged", detail=error)
+    if not (skill_dir / MANAGED_MARKER_FILENAME).exists():
+        return base
 
     skill = marketplace_skills.get(skill_dir.name.lower())
     if skill is None:
         return replace(
             base,
             status="source_unreachable",
-            detail=f"Skill '{skill_dir.name}' is no longer available in {DEFAULT_SKILLS_REPO_ID}.",
-            current_revision=manifest.installed_revision,
+            detail=f"Skill '{skill_dir.name}' is no longer available in {DEFAULT_SKILLS_BUCKET_ID}.",
         )
 
-    current_revision = manifest.installed_revision
     try:
-        available_revision = _resolve_available_revision(skill)
+        _install_marketplace_skill(api, skill, skill_dir.parent, force=True)
     except Exception as exc:
-        return replace(base, status="source_unreachable", detail=str(exc), current_revision=current_revision)
+        return replace(base, status="source_unreachable", detail=str(exc))
 
-    status: SkillUpdateStatus = "up_to_date" if available_revision == current_revision else "update_available"
-    return replace(
-        base,
-        status=status,
-        detail="update available" if status == "update_available" else None,
-        current_revision=current_revision,
-        available_revision=available_revision,
-    )
-
-
-def _apply_single_update(update: SkillUpdateInfo) -> SkillUpdateInfo:
-    if update.status != "update_available":
-        return update
-
-    try:
-        skill = get_marketplace_skill(update.skill_dir.name)
-        install_marketplace_skill(skill, update.skill_dir.parent, force=True)
-    except Exception as exc:
-        return replace(update, status="source_unreachable", detail=str(exc))
-
-    return replace(update, status="updated", detail="updated")
+    return replace(base, status="up_to_date")
 
 
 def _filter_updates(updates: list[SkillUpdateInfo], selector: str | None) -> list[SkillUpdateInfo]:
@@ -365,55 +249,3 @@ def _filter_updates(updates: list[SkillUpdateInfo], selector: str | None) -> lis
         return updates
     selector_lower = selector.strip().lower()
     return [update for update in updates if update.name.lower() == selector_lower]
-
-
-def _resolve_available_revision(skill: MarketplaceSkill) -> str:
-    response = _fetch_from_skills_repo(
-        "commits",
-        params={"sha": DEFAULT_SKILLS_REF, "path": skill.repo_path, "per_page": 1},
-    )
-    try:
-        payload = response.json()
-    except Exception as exc:  # noqa: BLE001
-        raise CLIError(f"Failed to decode GitHub API response for 'commits': {exc}") from exc
-    if not isinstance(payload, list) or not payload:
-        raise CLIError(f"Unable to resolve the current revision for skill '{skill.name}'.")
-
-    latest = payload[0]
-    if not isinstance(latest, dict):
-        raise CLIError(f"Invalid commit response while resolving skill '{skill.name}'.")
-
-    revision = latest.get("sha")
-    if not isinstance(revision, str) or not revision:
-        raise CLIError(f"Invalid commit response while resolving skill '{skill.name}'.")
-    return revision
-
-
-def _parse_installed_skill_manifest(payload: dict[str, Any]) -> InstalledSkillManifest:
-    if payload.get("schema_version") != SKILL_MANIFEST_SCHEMA_VERSION:
-        raise ValueError(f"unsupported schema_version: {payload.get('schema_version')}")
-
-    installed_revision = payload.get("installed_revision")
-    if not isinstance(installed_revision, str) or not installed_revision:
-        raise ValueError("missing installed_revision")
-
-    return InstalledSkillManifest(
-        schema_version=SKILL_MANIFEST_SCHEMA_VERSION,
-        installed_revision=installed_revision,
-    )
-
-
-def _fetch_from_skills_repo(endpoint: str, params: dict[str, Any] | None = None) -> Any:
-    url = f"https://api.github.com/repos/{DEFAULT_SKILLS_REPO_OWNER}/{DEFAULT_SKILLS_REPO_NAME}/{endpoint.lstrip('/')}"
-    try:
-        response = get_session().get(
-            url,
-            params=params,
-            headers={"Accept": "application/vnd.github+json"},
-            follow_redirects=True,
-            timeout=GITHUB_API_TIMEOUT,
-        )
-        response.raise_for_status()
-    except Exception as exc:  # noqa: BLE001
-        raise CLIError(f"Failed to fetch '{endpoint}' from {DEFAULT_SKILLS_REPO_ID}: {exc}") from exc
-    return response

--- a/src/huggingface_hub/cli/skills.py
+++ b/src/huggingface_hub/cli/skills.py
@@ -326,9 +326,8 @@ def _remove_existing(path: Path, force: bool) -> None:
 
 def _install_to(skills_dir: Path, skill_name: str, force: bool) -> Path:
     """Install a marketplace skill into a skills directory. Returns the installed path."""
-    skill = _skills.get_marketplace_skill(skill_name)
     try:
-        return _skills.install_marketplace_skill(skill, skills_dir, force=force)
+        return _skills.add_skill(skill_name, skills_dir, force=force)
     except FileExistsError as exc:
         raise CLIError(f"{exc}\nRe-run with --force to overwrite.") from exc
 
@@ -462,7 +461,7 @@ def skills_upgrade(
     """Upgrade installed Hugging Face marketplace skills."""
     roots = _resolve_update_roots(claude=claude, global_=global_, dest=dest)
 
-    results = _skills.apply_updates(roots, selector=name)
+    results = _skills.update_skills(roots, selector=name)
     if not results:
         print("No installed skills found.")
         return

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,7 +33,7 @@ from huggingface_hub.utils import (
 from huggingface_hub.utils._verification import FolderVerification
 
 from .testing_constants import TOKEN
-from .testing_utils import DUMMY_MODEL_ID, with_production_testing
+from .testing_utils import DUMMY_MODEL_ID, requires, with_production_testing
 
 
 @pytest.fixture
@@ -3826,6 +3826,7 @@ class TestSkillGeneration:
         assert any("jobs uv run" in p for p in leaf_paths)
 
 
+@requires("hf_xet")
 class TestSkillsMarketplaceCLI:
     @with_production_testing
     def test_add_installs_marketplace_skill_to_dest(self, runner: CliRunner, tmp_path: Path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3827,6 +3827,7 @@ class TestSkillGeneration:
 
 
 class TestSkillsMarketplaceCLI:
+    @with_production_testing
     def test_add_installs_marketplace_skill_to_dest(self, runner: CliRunner, tmp_path: Path) -> None:
         dest = tmp_path / "managed-skills"
 
@@ -3838,7 +3839,8 @@ class TestSkillsMarketplaceCLI:
         assert skill_dir.joinpath("SKILL.md").is_file()
         assert skill_dir.joinpath(".hf-skill-manifest.json").is_file()
 
-    def test_upgrade_checks_remote_revision_for_installed_skill(self, runner: CliRunner, tmp_path: Path) -> None:
+    @with_production_testing
+    def test_upgrade_resyncs_installed_skill(self, runner: CliRunner, tmp_path: Path) -> None:
         dest = tmp_path / "managed-skills"
         add_result = runner.invoke(app, ["skills", "add", "huggingface-gradio", "--dest", str(dest)])
         assert add_result.exit_code == 0, add_result.output
@@ -3846,14 +3848,4 @@ class TestSkillsMarketplaceCLI:
         result = runner.invoke(app, ["skills", "upgrade", "--dest", str(dest)])
 
         assert result.exit_code == 0, result.output
-        skill_dir = dest / "huggingface-gradio"
-        assert skill_dir.joinpath("SKILL.md").is_file()
-        assert skill_dir.joinpath(".hf-skill-manifest.json").is_file()
-        # Live marketplace content can change between the add and upgrade calls.
-        assert any(
-            status in result.stdout
-            for status in (
-                "huggingface-gradio: up_to_date",
-                "huggingface-gradio: updated",
-            )
-        ), result.stdout
+        assert "huggingface-gradio: up_to_date" in result.stdout


### PR DESCRIPTION
This PR updates `hf skills add` / `hf skills update` to fetch the skills from the [huggingface/skills](https://huggingface.co/buckets/huggingface/skills) bucket instead of the GitHub API. the bucket is populated by a workflow on `huggingface/skills` that syncs skills + `marketplace.json` on every merge to `main` (companion PR: https://github.com/huggingface/skills/pull/134).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Switches the `hf skills` install/update backend from GitHub tarball/commit polling to Hugging Face bucket listing/downloading, changing update semantics and managed-skill detection. Risk is mainly around regressions in install/update behavior (file filtering, partial downloads, and compatibility with older installs).
> 
> **Overview**
> `hf skills add`/`hf skills update` now fetch marketplace metadata and skill contents from the `huggingface/skills` *bucket* (via `list_bucket_tree` + `download_bucket_files`) instead of the GitHub API/tarballs.
> 
> Update behavior is simplified to a re-sync: managed installs are detected via a marker file (`.hf-skill-manifest.json`, now an empty touch file kept for backward compatibility) and are reinstalled atomically; revision-based `update_available/updated` statuses and manifest parsing/writing are removed. Production CLI tests are updated accordingly and gated behind `hf_xet`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73f215a42358ddadc4976143deb97478855e8062. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->