### PR TITLE
[CLI] Rename `hf skills upgrade` -> `hf skills update`

### DIFF
--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -3362,7 +3362,7 @@ $ hf skills [OPTIONS] COMMAND [ARGS]...
 
 * `add`: Download a Hugging Face skill and install...
 * `preview`: Print the generated `hf-cli` SKILL.md to...
-* `upgrade`: Upgrade installed Hugging Face marketplace...
+* `update`: Update installed Hugging Face marketplace...
 
 ### `hf skills add`
 
@@ -3415,32 +3415,32 @@ $ hf skills preview [OPTIONS]
 
 * `--help`: Show this message and exit.
 
-### `hf skills upgrade`
+### `hf skills update`
 
-Upgrade installed Hugging Face marketplace skills.
+Update installed Hugging Face marketplace skills.
 
 **Usage**:
 
 ```console
-$ hf skills upgrade [OPTIONS] [NAME]
+$ hf skills update [OPTIONS] [NAME]
 ```
 
 **Arguments**:
 
-* `[NAME]`: Optional installed skill name to upgrade.
+* `[NAME]`: Optional installed skill name to update.
 
 **Options**:
 
-* `--claude`: Upgrade skills installed for Claude.
+* `--claude`: Update skills installed for Claude.
 * `-g, --global`: Use global skills directories instead of the current project.
-* `--dest PATH`: Upgrade skills in a custom skills directory.
+* `--dest PATH`: Update skills in a custom skills directory.
 * `--help`: Show this message and exit.
 
 Examples
-  $ hf skills upgrade
-  $ hf skills upgrade hf-cli
-  $ hf skills upgrade huggingface-gradio --dest=~/my-skills
-  $ hf skills upgrade --claude
+  $ hf skills update
+  $ hf skills update hf-cli
+  $ hf skills update huggingface-gradio --dest=~/my-skills
+  $ hf skills update --claude
 
 Learn more
   Use `hf <command> --help` for more information about a command.

--- a/src/huggingface_hub/cli/skills.py
+++ b/src/huggingface_hub/cli/skills.py
@@ -430,20 +430,20 @@ def skills_add(
 
 
 @skills_cli.command(
-    "upgrade",
+    "update",
     examples=[
-        "hf skills upgrade",
-        "hf skills upgrade hf-cli",
-        "hf skills upgrade huggingface-gradio --dest=~/my-skills",
-        "hf skills upgrade --claude",
+        "hf skills update",
+        "hf skills update hf-cli",
+        "hf skills update huggingface-gradio --dest=~/my-skills",
+        "hf skills update --claude",
     ],
 )
-def skills_upgrade(
+def skills_update(
     name: Annotated[
         str | None,
-        typer.Argument(help="Optional installed skill name to upgrade.", show_default=False),
+        typer.Argument(help="Optional installed skill name to update.", show_default=False),
     ] = None,
-    claude: Annotated[bool, typer.Option("--claude", help="Upgrade skills installed for Claude.")] = False,
+    claude: Annotated[bool, typer.Option("--claude", help="Update skills installed for Claude.")] = False,
     global_: Annotated[
         bool,
         typer.Option(
@@ -455,11 +455,11 @@ def skills_upgrade(
     dest: Annotated[
         Path | None,
         typer.Option(
-            help="Upgrade skills in a custom skills directory.",
+            help="Update skills in a custom skills directory.",
         ),
     ] = None,
 ) -> None:
-    """Upgrade installed Hugging Face marketplace skills."""
+    """Update installed Hugging Face marketplace skills."""
     roots = _resolve_update_roots(claude=claude, global_=global_, dest=dest)
 
     results = _skills.apply_updates(roots, selector=name)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3838,18 +3838,18 @@ class TestSkillsMarketplaceCLI:
         assert skill_dir.joinpath("SKILL.md").is_file()
         assert skill_dir.joinpath(".hf-skill-manifest.json").is_file()
 
-    def test_upgrade_checks_remote_revision_for_installed_skill(self, runner: CliRunner, tmp_path: Path) -> None:
+    def test_update_checks_remote_revision_for_installed_skill(self, runner: CliRunner, tmp_path: Path) -> None:
         dest = tmp_path / "managed-skills"
         add_result = runner.invoke(app, ["skills", "add", "huggingface-gradio", "--dest", str(dest)])
         assert add_result.exit_code == 0, add_result.output
 
-        result = runner.invoke(app, ["skills", "upgrade", "--dest", str(dest)])
+        result = runner.invoke(app, ["skills", "update", "--dest", str(dest)])
 
         assert result.exit_code == 0, result.output
         skill_dir = dest / "huggingface-gradio"
         assert skill_dir.joinpath("SKILL.md").is_file()
         assert skill_dir.joinpath(".hf-skill-manifest.json").is_file()
-        # Live marketplace content can change between the add and upgrade calls.
+        # Live marketplace content can change between the add and update calls.
         assert any(
             status in result.stdout
             for status in (


### PR DESCRIPTION
 Rename `hf skills upgrade` to `hf skills update` per @julien-c's https://github.com/huggingface/huggingface_hub/pull/4131#discussion_r3168373125.

**Breaking change**

`hf skills upgrade` no longer exists — use `hf skills update`. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 661ef7c4d7d22e17ada797e0a51adae66747465a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->