### PR TITLE
[CLI] Shortcut `hf update` when already on latest version

### DIFF
--- a/src/huggingface_hub/cli/_cli_utils.py
+++ b/src/huggingface_hub/cli/_cli_utils.py
@@ -1128,12 +1128,8 @@ def _check_cli_update(library: Literal["huggingface_hub", "transformers"]) -> No
     Path(constants.CHECK_FOR_UPDATE_DONE_PATH).touch()
 
     # Check latest version from PyPI
-    response = get_session().get(f"https://pypi.org/pypi/{library}/json", timeout=2)
-    hf_raise_for_status(response)
-    data = response.json()
-    latest_version = data["info"]["version"]
-
-    if current_version == latest_version:
+    latest_version = _fetch_latest_pypi_version(library)
+    if latest_version is None or current_version == latest_version:
         return
 
     if library == "huggingface_hub":
@@ -1149,6 +1145,17 @@ def _check_cli_update(library: Literal["huggingface_hub", "transformers"]) -> No
             case _:
                 message += f"\nTo update, run: {' '.join(update_command)}"
     out.hint(message)
+
+
+def _fetch_latest_pypi_version(library: str) -> str | None:
+    """Fetch the latest version of a library from PyPI. Returns None if the request fails."""
+    try:
+        response = get_session().get(f"https://pypi.org/pypi/{library}/json", timeout=2)
+        hf_raise_for_status(response)
+        return response.json()["info"]["version"]
+    except Exception:
+        logger.debug("Error while fetching latest version from PyPI.", exc_info=True)
+        return None
 
 
 def run_update() -> int:

--- a/src/huggingface_hub/cli/system.py
+++ b/src/huggingface_hub/cli/system.py
@@ -18,7 +18,7 @@ import typer
 from huggingface_hub import __version__
 
 from ..utils import dump_environment_info
-from ._cli_utils import run_update
+from ._cli_utils import _fetch_latest_pypi_version, run_update
 from ._output import out
 
 
@@ -34,6 +34,13 @@ def version() -> None:
 
 def update() -> None:
     """Update the `hf` CLI to the latest version."""
+    out.text(f"Current version: {__version__}")
+    out.text("Checking for updates to latest version...")
+    latest_version = _fetch_latest_pypi_version("huggingface_hub")
+    if latest_version is not None and __version__ == latest_version:
+        out.text(f"hf is up to date ({__version__})")
+        return
+
     returncode = run_update()
     if returncode != 0:
         raise typer.Exit(code=returncode)


### PR DESCRIPTION
## Summary

- `hf update` now prints the current version, checks PyPI for the latest, and short-circuits with `hf is up to date (X.Y.Z)` when they match — skipping the install command (which can be slow or prompt for sudo on brew).
- If the PyPI fetch fails for any reason, the command falls through to running the update as before — no regression on the unhappy path.
- Factored the PyPI version lookup into a small `_fetch_latest_pypi_version()` helper, reused by the existing daily update-check too.

## Example

Up-to-date case:

```
$ hf update
Current version: 1.13.0
Checking for updates to latest version...
hf is up to date (1.13.0)
```

Out-of-date case (unchanged): falls through to the install command as before.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a simple PyPI version check and early-exit path in the `hf update` command; failures fall back to the existing update behavior.
> 
> **Overview**
> **Improves `hf update` UX by short-circuiting when already up to date.** The command now prints the current version, checks PyPI for the latest `huggingface_hub` release, and returns early with an “up to date” message instead of running the installer.
> 
> Extracts the PyPI lookup into a shared `_fetch_latest_pypi_version()` helper (used by both `hf update` and the existing daily update hint), and makes network/version-check failures non-fatal by returning `None` and proceeding as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b41c9d2e8cf3eff6afe6c0a77bea48c5a8772bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->