### PR TITLE
[CLI] Remove progress bars on skills update

### DIFF
--- a/src/huggingface_hub/cli/_skills.py
+++ b/src/huggingface_hub/cli/_skills.py
@@ -10,6 +10,7 @@ from typing import Any, Literal
 from huggingface_hub._buckets import BucketFile
 from huggingface_hub.errors import CLIError
 
+from ..utils import disable_progress_bars
 from ._cli_utils import get_hf_api
 
 
@@ -41,14 +42,15 @@ class SkillUpdateInfo:
 def add_skill(skill_name: str, destination_root: Path, force: bool = False) -> Path:
     """Resolve a marketplace skill by name and install it."""
     api = get_hf_api()
-    marketplace_skills = _load_marketplace_skills(api)
-    skill = _select_marketplace_skill(marketplace_skills, skill_name)
-    if skill is None:
-        raise CLIError(
-            f"Skill '{skill_name}' not found in {DEFAULT_SKILLS_BUCKET_ID}. "
-            "Try `hf skills add` to install `hf-cli` or use a known skill name."
-        )
-    return _install_marketplace_skill(api, skill, destination_root, force=force)
+    with disable_progress_bars():
+        marketplace_skills = _load_marketplace_skills(api)
+        skill = _select_marketplace_skill(marketplace_skills, skill_name)
+        if skill is None:
+            raise CLIError(
+                f"Skill '{skill_name}' not found in {DEFAULT_SKILLS_BUCKET_ID}. "
+                "Try `hf skills add` to install `hf-cli` or use a known skill name."
+            )
+        return _install_marketplace_skill(api, skill, destination_root, force=force)
 
 
 def update_skills(roots: list[Path], selector: str | None = None) -> list[SkillUpdateInfo]:
@@ -61,8 +63,9 @@ def update_skills(roots: list[Path], selector: str | None = None) -> list[SkillU
             raise CLIError(f"No installed skill matches '{selector}'. Install it with `hf skills add {selector}`.")
 
     api = get_hf_api()
-    marketplace_skills = {skill.name.lower(): skill for skill in _load_marketplace_skills(api)}
-    return [_apply_single_update(api, skill_dir, marketplace_skills) for skill_dir in skill_dirs]
+    with disable_progress_bars():
+        marketplace_skills = {skill.name.lower(): skill for skill in _load_marketplace_skills(api)}
+        return [_apply_single_update(api, skill_dir, marketplace_skills) for skill_dir in skill_dirs]
 
 
 def _load_marketplace_skills(api) -> list[MarketplaceSkill]:

--- a/src/huggingface_hub/cli/buckets.py
+++ b/src/huggingface_hub/cli/buckets.py
@@ -30,9 +30,7 @@ from huggingface_hub._buckets import (
 )
 from huggingface_hub.utils import (
     SoftTemporaryDirectory,
-    are_progress_bars_disabled,
     disable_progress_bars,
-    enable_progress_bars,
 )
 
 from ._cli_utils import (
@@ -772,19 +770,13 @@ def cp(
         if dst_is_stdout:
             # Download to stdout: always suppress progress bars to avoid polluting output
             # Only re-enable if they weren't already disabled by the caller
-            pbar_was_disabled = are_progress_bars_disabled()
-            if not pbar_was_disabled:
-                disable_progress_bars()
-            try:
+            with disable_progress_bars():
                 with SoftTemporaryDirectory() as tmp_dir:
                     tmp_path = os.path.join(tmp_dir, filename)
                     api.download_bucket_files(bucket_id, [(prefix, tmp_path)])
                     with open(tmp_path, "rb") as f:
                         while chunk := f.read(32_000_000):  # 32MB chunks
                             sys.stdout.buffer.write(chunk)
-            finally:
-                if not pbar_was_disabled:
-                    enable_progress_bars()
         else:
             # Download to file
             if dst is None:

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -49,7 +49,7 @@ from huggingface_hub.errors import CLIError, RemoteEntryNotFoundError, Repositor
 from huggingface_hub.file_download import hf_hub_download
 from huggingface_hub.hf_api import ExpandSpaceProperty_T, HfApi, SpaceSort_T
 from huggingface_hub.repocard import SpaceCard
-from huggingface_hub.utils import are_progress_bars_disabled, disable_progress_bars, enable_progress_bars
+from huggingface_hub.utils import disable_progress_bars
 
 from ._cli_utils import (
     AuthorOpt,
@@ -622,20 +622,14 @@ def spaces_hot_reload(
                 ) from e
         temp_dir = tempfile.TemporaryDirectory()
         local_path = os.path.join(temp_dir.name, filename)
-        if not (pbar_disabled := are_progress_bars_disabled()):
-            disable_progress_bars()
-        try:
-            hf_hub_download(
-                repo_type="space",
-                repo_id=space_id,
-                filename=filename,
-                local_dir=temp_dir.name,
-            )
-        except RemoteEntryNotFoundError:
-            typer.secho(f"{filename} not found in remote repository. Assuming new file", fg=typer.colors.BRIGHT_BLACK)
-        finally:
-            if not pbar_disabled:
-                enable_progress_bars()
+        with disable_progress_bars():
+            try:
+                hf_hub_download(repo_type="space", repo_id=space_id, filename=filename, local_dir=temp_dir.name)
+            except RemoteEntryNotFoundError:
+                typer.secho(
+                    f"{filename} not found in remote repository. Assuming new file", fg=typer.colors.BRIGHT_BLACK
+                )
+
         editor_res = _editor_open(local_path)
         if editor_res == "no-tty":
             persistent_temp_dir = tempfile.mkdtemp()

--- a/src/huggingface_hub/utils/tqdm.py
+++ b/src/huggingface_hub/utils/tqdm.py
@@ -102,17 +102,21 @@ from ..constants import HF_HUB_DISABLE_PROGRESS_BARS
 # If `HF_HUB_DISABLE_PROGRESS_BARS` is not defined (None), it implies that users can manage
 # progress bar visibility through code. By default, progress bars are turned on.
 
-
 progress_bar_states: dict[str, bool] = {}
 
 
-def disable_progress_bars(name: str | None = None) -> None:
+class disable_progress_bars:
     """
     Disable progress bars either globally or for a specified group.
 
     This function updates the state of progress bars based on a group name.
     If no group name is provided, all progress bars are disabled. The operation
     respects the `HF_HUB_DISABLE_PROGRESS_BARS` environment variable's setting.
+
+    Works as both a regular call and a context manager:
+        disable_progress_bars()           # disables until enable_progress_bars()
+        with disable_progress_bars():     # disables for the block, re-enables on exit
+            ...
 
     Args:
         name (`str`, *optional*):
@@ -122,20 +126,34 @@ def disable_progress_bars(name: str | None = None) -> None:
     Raises:
         Warning: If the environment variable precludes changes.
     """
-    if HF_HUB_DISABLE_PROGRESS_BARS is False:
-        warnings.warn(
-            "Cannot disable progress bars: environment variable `HF_HUB_DISABLE_PROGRESS_BARS=0` is set and has priority."
-        )
-        return
 
-    if name is None:
-        progress_bar_states.clear()
-        progress_bar_states["_global"] = False
-    else:
-        keys_to_remove = [key for key in progress_bar_states if key.startswith(f"{name}.")]
-        for key in keys_to_remove:
-            del progress_bar_states[key]
-        progress_bar_states[name] = False
+    def __init__(self, name: str | None = None) -> None:
+
+        self.name = name
+
+        if HF_HUB_DISABLE_PROGRESS_BARS is False:
+            warnings.warn(
+                "Cannot disable progress bars: environment variable `HF_HUB_DISABLE_PROGRESS_BARS=0` is set and has priority."
+            )
+            self._should_reenable = False
+            return
+
+        self._should_reenable = not are_progress_bars_disabled(name)
+        if name is None:
+            progress_bar_states.clear()
+            progress_bar_states["_global"] = False
+        else:
+            keys_to_remove = [key for key in progress_bar_states if key.startswith(f"{name}.")]
+            for key in keys_to_remove:
+                del progress_bar_states[key]
+            progress_bar_states[name] = False
+
+    def __enter__(self) -> "disable_progress_bars":
+        return self
+
+    def __exit__(self, *exc) -> None:
+        if self._should_reenable:
+            enable_progress_bars(self.name)
 
 
 def enable_progress_bars(name: str | None = None) -> None:

--- a/tests/test_utils_tqdm.py
+++ b/tests/test_utils_tqdm.py
@@ -2,12 +2,10 @@ import io
 import logging
 import sys
 import time
-import unittest
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-from pytest import CaptureFixture
 from tqdm.auto import tqdm as vanilla_tqdm
 
 from huggingface_hub.utils import (
@@ -21,113 +19,96 @@ from huggingface_hub.utils import (
 from huggingface_hub.utils.tqdm import _get_progress_bar_context
 
 
-class CapsysBaseTest(unittest.TestCase):
-    @pytest.fixture(autouse=True)
-    def capsys(self, capsys: CaptureFixture) -> None:
-        """Workaround to make capsys work in unittest framework.
-
-        Capsys is a convenient pytest fixture to capture stdout.
-        See https://waylonwalker.com/pytest-capsys/.
-
-        Taken from https://github.com/pytest-dev/pytest/issues/2504#issuecomment-309475790.
-        """
-        self.capsys = capsys
+_ENV_VAR = "huggingface_hub.utils._tqdm.HF_HUB_DISABLE_PROGRESS_BARS"
 
 
-class TestTqdmUtils(CapsysBaseTest):
-    def setUp(self) -> None:
-        """Get verbosity to set it back after the tests."""
-        self._previous_are_progress_bars_disabled = are_progress_bars_disabled()
-        return super().setUp()
+@pytest.fixture(autouse=True)
+def _reset_progress_bars():
+    enable_progress_bars()
+    yield
+    enable_progress_bars()
 
-    def tearDown(self) -> None:
-        """Set back progress bars verbosity as before testing."""
-        if self._previous_are_progress_bars_disabled:
-            disable_progress_bars()
-        else:
-            enable_progress_bars()
 
-    @patch("huggingface_hub.utils._tqdm.HF_HUB_DISABLE_PROGRESS_BARS", None)
-    def test_tqdm_helpers(self) -> None:
-        """Test helpers to enable/disable progress bars."""
+@pytest.fixture(autouse=True)
+def _no_env_override():
+    with patch(_ENV_VAR, None):
+        yield
+
+
+@pytest.fixture()
+def _env_force_disabled():
+    with patch(_ENV_VAR, True):
+        yield
+
+
+@pytest.fixture()
+def _env_force_enabled():
+    with patch(_ENV_VAR, False):
+        yield
+
+
+class TestTqdmUtils:
+    def test_tqdm_helpers(self):
         disable_progress_bars()
         assert are_progress_bars_disabled()
 
         enable_progress_bars()
         assert not are_progress_bars_disabled()
 
-    @patch("huggingface_hub.utils._tqdm.HF_HUB_DISABLE_PROGRESS_BARS", True)
-    def test_cannot_enable_tqdm_when_env_variable_is_set(self) -> None:
-        """
-        Test helpers cannot enable/disable progress bars when
-        `HF_HUB_DISABLE_PROGRESS_BARS` is set.
-        """
+    def test_cannot_enable_when_env_disables(self, _env_force_disabled):
         disable_progress_bars()
         assert are_progress_bars_disabled()
 
-        with self.assertWarns(UserWarning):
+        with pytest.warns(UserWarning):
             enable_progress_bars()
-        assert are_progress_bars_disabled()  # Still disabled
+        assert are_progress_bars_disabled()
 
-    @patch("huggingface_hub.utils._tqdm.HF_HUB_DISABLE_PROGRESS_BARS", False)
-    def test_cannot_disable_tqdm_when_env_variable_is_set(self) -> None:
-        """
-        Test helpers cannot enable/disable progress bars when
-        `HF_HUB_DISABLE_PROGRESS_BARS` is set.
-        """
+    def test_cannot_disable_when_env_enables(self, _env_force_enabled):
         enable_progress_bars()
         assert not are_progress_bars_disabled()
 
-        with self.assertWarns(UserWarning):
-            disable_progress_bars()
-        assert not are_progress_bars_disabled()  # Still enabled
+        with pytest.warns(UserWarning):
+            with disable_progress_bars():
+                pass
+        assert not are_progress_bars_disabled()
 
-    @patch("huggingface_hub.utils._tqdm.HF_HUB_DISABLE_PROGRESS_BARS", None)
-    def test_tqdm_disabled(self) -> None:
-        """Test TQDM not outputting anything when globally disabled."""
+    def test_tqdm_disabled(self, capsys):
         disable_progress_bars()
         for _ in tqdm(range(10)):
             pass
 
-        captured = self.capsys.readouterr()
-        self.assertEqual(captured.out, "")
-        self.assertEqual(captured.err, "")
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert captured.err == ""
 
-    @patch("huggingface_hub.utils._tqdm.HF_HUB_DISABLE_PROGRESS_BARS", None)
-    def test_tqdm_disabled_cannot_be_forced(self) -> None:
-        """Test TQDM cannot be forced when globally disabled."""
+    def test_tqdm_disabled_cannot_be_forced(self, capsys):
         disable_progress_bars()
         for _ in tqdm(range(10), disable=False):
             pass
 
-        captured = self.capsys.readouterr()
-        self.assertEqual(captured.out, "")
-        self.assertEqual(captured.err, "")
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert captured.err == ""
 
-    @patch("huggingface_hub.utils._tqdm.HF_HUB_DISABLE_PROGRESS_BARS", None)
-    def test_tqdm_can_be_disabled_when_globally_enabled(self) -> None:
-        """Test TQDM can still be locally disabled even when globally enabled."""
+    def test_tqdm_can_be_disabled_when_globally_enabled(self, capsys):
         enable_progress_bars()
         for _ in tqdm(range(10), disable=True):
             pass
 
-        captured = self.capsys.readouterr()
-        self.assertEqual(captured.out, "")
-        self.assertEqual(captured.err, "")
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert captured.err == ""
 
-    @patch("huggingface_hub.utils._tqdm.HF_HUB_DISABLE_PROGRESS_BARS", None)
-    def test_tqdm_enabled(self) -> None:
-        """Test TQDM work normally when globally enabled."""
+    def test_tqdm_enabled(self, capsys):
         enable_progress_bars()
         for _ in tqdm(range(10)):
             pass
 
-        captured = self.capsys.readouterr()
-        self.assertEqual(captured.out, "")
-        self.assertIn("10/10", captured.err)  # tqdm log
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert "10/10" in captured.err
 
-    @patch("huggingface_hub.utils._tqdm.HF_HUB_DISABLE_PROGRESS_BARS", None)
-    def test_tqdm_stream_file(self) -> None:
+    def test_tqdm_stream_file(self, capsys):
         enable_progress_bars()
         with SoftTemporaryDirectory() as tmpdir:
             filepath = Path(tmpdir) / "config.json"
@@ -139,67 +120,45 @@ class TestTqdmUtils(CapsysBaseTest):
                     data = f.read(100)
                     if not data:
                         break
-                    time.sleep(0.001)  # Simulate a delay between each chunk
+                    time.sleep(0.001)
 
-            captured = self.capsys.readouterr()
-            self.assertEqual(captured.out, "")
-            self.assertIn("config.json: 100%", captured.err)  # log file name
-            self.assertIn("|█████████", captured.err)  # tqdm bar
-            self.assertIn("1.00k/1.00k", captured.err)  # size in B
+            captured = capsys.readouterr()
+            assert captured.out == ""
+            assert "config.json: 100%" in captured.err
+            assert "|█████████" in captured.err
+            assert "1.00k/1.00k" in captured.err
 
 
-class TestTqdmGroup(CapsysBaseTest):
-    def setUp(self):
-        """Set up the initial condition for each test."""
-        super().setUp()
-        enable_progress_bars()  # Ensure all are enabled before each test
-
-    def tearDown(self):
-        """Clean up after each test."""
-        super().tearDown()
-        enable_progress_bars()
-
-    @patch("huggingface_hub.utils._tqdm.HF_HUB_DISABLE_PROGRESS_BARS", None)
+class TestTqdmGroup:
     def test_disable_specific_group(self):
-        """Test disabling a specific group only affects that group and its subgroups."""
         disable_progress_bars("peft.foo")
         assert not are_progress_bars_disabled("peft")
         assert not are_progress_bars_disabled("peft.something")
         assert are_progress_bars_disabled("peft.foo")
         assert are_progress_bars_disabled("peft.foo.bar")
 
-    @patch("huggingface_hub.utils._tqdm.HF_HUB_DISABLE_PROGRESS_BARS", None)
     def test_enable_specific_subgroup(self):
-        """Test that enabling a subgroup does not affect the disabled state of its parent."""
         disable_progress_bars("peft.foo")
         enable_progress_bars("peft.foo.bar")
         assert are_progress_bars_disabled("peft.foo")
         assert not are_progress_bars_disabled("peft.foo.bar")
 
-    @patch("huggingface_hub.utils._tqdm.HF_HUB_DISABLE_PROGRESS_BARS", True)
-    def test_disable_override_by_environment_variable(self):
-        """Ensure progress bars are disabled regardless of local settings when environment variable is set."""
-        with self.assertWarns(UserWarning):
+    def test_disable_override_by_environment_variable(self, _env_force_disabled):
+        with pytest.warns(UserWarning):
             enable_progress_bars()
         assert are_progress_bars_disabled("peft")
         assert are_progress_bars_disabled("peft.foo")
 
-    @patch("huggingface_hub.utils._tqdm.HF_HUB_DISABLE_PROGRESS_BARS", False)
-    def test_enable_override_by_environment_variable(self):
-        """Ensure progress bars are enabled regardless of local settings when environment variable is set."""
-        with self.assertWarns(UserWarning):
+    def test_enable_override_by_environment_variable(self, _env_force_enabled):
+        with pytest.warns(UserWarning):
             disable_progress_bars("peft.foo")
         assert not are_progress_bars_disabled("peft.foo")
 
-    @patch("huggingface_hub.utils._tqdm.HF_HUB_DISABLE_PROGRESS_BARS", None)
     def test_partial_group_name_not_affected(self):
-        """Ensure groups with similar names but not exactly matching are not affected."""
         disable_progress_bars("peft.foo")
         assert not are_progress_bars_disabled("peft.footprint")
 
-    @patch("huggingface_hub.utils._tqdm.HF_HUB_DISABLE_PROGRESS_BARS", None)
     def test_nested_subgroup_behavior(self):
-        """Test enabling and disabling nested subgroups."""
         disable_progress_bars("peft")
         enable_progress_bars("peft.foo")
         disable_progress_bars("peft.foo.bar")
@@ -207,18 +166,14 @@ class TestTqdmGroup(CapsysBaseTest):
         assert not are_progress_bars_disabled("peft.foo")
         assert are_progress_bars_disabled("peft.foo.bar")
 
-    @patch("huggingface_hub.utils._tqdm.HF_HUB_DISABLE_PROGRESS_BARS", None)
     def test_empty_group_is_root(self):
-        """Test the behavior with invalid or empty group names."""
         disable_progress_bars("")
         assert not are_progress_bars_disabled("peft")
 
         enable_progress_bars("123.invalid.name")
         assert not are_progress_bars_disabled("123.invalid.name")
 
-    @patch("huggingface_hub.utils._tqdm.HF_HUB_DISABLE_PROGRESS_BARS", None)
     def test_multiple_level_toggling(self):
-        """Test multiple levels of enabling and disabling."""
         disable_progress_bars("peft")
         enable_progress_bars("peft.foo")
         disable_progress_bars("peft.foo.bar.something")
@@ -226,23 +181,22 @@ class TestTqdmGroup(CapsysBaseTest):
         assert not are_progress_bars_disabled("peft.foo")
         assert are_progress_bars_disabled("peft.foo.bar.something")
 
-    def test_progress_bar_respects_group(self) -> None:
+    def test_progress_bar_respects_group(self, capsys):
         disable_progress_bars("foo.bar")
         for _ in tqdm(range(10), name="foo.bar.something"):
             pass
-        captured = self.capsys.readouterr()
+        captured = capsys.readouterr()
         assert captured.out == ""
         assert captured.err == ""
 
         enable_progress_bars("foo.bar.something")
         for _ in tqdm(range(10), name="foo.bar.something"):
             pass
-        captured = self.capsys.readouterr()
+        captured = capsys.readouterr()
         assert captured.out == ""
         assert "10/10" in captured.err
 
-    @patch("huggingface_hub.utils._tqdm.HF_HUB_DISABLE_PROGRESS_BARS", None)
-    def test_progress_bar_context_respects_group(self) -> None:
+    def test_progress_bar_context_respects_group(self):
         disable_progress_bars("foo.bar")
         with _get_progress_bar_context(
             desc="test",
@@ -253,47 +207,88 @@ class TestTqdmGroup(CapsysBaseTest):
             assert pbar.disable
 
 
-class TestCreateProgressBarCustomClass:
-    """Regression tests for https://github.com/huggingface/huggingface_hub/issues/4050."""
+class TestDisableProgressBarsContextManager:
+    def test_restores_state(self):
+        assert not are_progress_bars_disabled()
+        with disable_progress_bars():
+            assert are_progress_bars_disabled()
+        assert not are_progress_bars_disabled()
 
-    def test_custom_tqdm_class_not_disabled_in_non_tty(self):
-        """Custom tqdm_class should not be silently disabled in non-TTY."""
+    def test_with_group(self):
+        with disable_progress_bars("peft.foo"):
+            assert are_progress_bars_disabled("peft.foo")
+            assert are_progress_bars_disabled("peft.foo.bar")
+            assert not are_progress_bars_disabled("peft")
+        assert not are_progress_bars_disabled("peft.foo")
+
+    def test_noop_when_already_disabled(self):
+        disable_progress_bars()
+        assert are_progress_bars_disabled()
+        with disable_progress_bars():
+            assert are_progress_bars_disabled()
+        assert are_progress_bars_disabled()
+
+    def test_noop_when_group_already_disabled(self):
+        disable_progress_bars("peft.foo")
+        with disable_progress_bars("peft.foo"):
+            assert are_progress_bars_disabled("peft.foo")
+        assert are_progress_bars_disabled("peft.foo")
+
+    def test_nested(self):
+        assert not are_progress_bars_disabled()
+        with disable_progress_bars():
+            assert are_progress_bars_disabled()
+            with disable_progress_bars():
+                assert are_progress_bars_disabled()
+            assert are_progress_bars_disabled()
+        assert not are_progress_bars_disabled()
+
+    def test_suppresses_output(self, capsys):
+        with disable_progress_bars():
+            for _ in tqdm(range(10)):
+                pass
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert captured.err == ""
+
+        for _ in tqdm(range(10)):
+            pass
+        captured = capsys.readouterr()
+        assert "10/10" in captured.err
+
+
+class TestCreateProgressBarCustomClass:
+    def test_custom_class_not_disabled_in_non_tty(self):
         fake_stderr = io.StringIO()
         with patch.object(sys, "stderr", fake_stderr):
-            bar = _get_progress_bar_context(
+            with _get_progress_bar_context(
                 desc="test",
                 log_level=logging.INFO,
                 total=100,
                 tqdm_class=vanilla_tqdm,
                 name="huggingface_hub.test",
-            )
-            with bar as pbar:
+            ) as pbar:
                 assert not pbar.disable
                 pbar.update(50)
                 pbar.update(50)
                 assert pbar.n == 100
 
-    @patch("huggingface_hub.utils._tqdm.HF_HUB_DISABLE_PROGRESS_BARS", True)
-    def test_custom_tqdm_class_ignores_hf_disable_signal(self):
-        """Custom tqdm_class is not affected by HF_HUB_DISABLE_PROGRESS_BARS."""
-        bar = _get_progress_bar_context(
+    def test_custom_class_ignores_hf_disable_signal(self, _env_force_disabled):
+        with _get_progress_bar_context(
             desc="test",
             log_level=logging.INFO,
             total=10,
             tqdm_class=vanilla_tqdm,
             name="huggingface_hub.test",
-        )
-        with bar as pbar:
+        ) as pbar:
             assert not pbar.disable
 
-    def test_custom_tqdm_class_no_name_kwarg(self):
-        """Custom tqdm_class should not receive HF-specific 'name' kwarg."""
-        bar = _get_progress_bar_context(
+    def test_custom_class_no_name_kwarg(self):
+        with _get_progress_bar_context(
             desc="test",
             log_level=logging.INFO,
             total=10,
             tqdm_class=vanilla_tqdm,
             name="huggingface_hub.test",
-        )
-        with bar as pbar:
+        ) as pbar:
             pbar.update(10)


### PR DESCRIPTION
When doing a `hf skills update` or `hf skills add`, some files are downloaded from HF Bucket https://huggingface.co/buckets/huggingface/skills (see https://github.com/huggingface/huggingface_hub/pull/4175) which produces unrelated logs/progress bars in the CLI "downloading files from bucket". Let's remove this as it's misleading to the user in a "skills update" context.

To simplify some logic, I've also made `disable_progress_bars` usable as a context manager. I've also updated the tests to use pytest syntax (much simpler to read) and made sure everything was still working exactly the same. 

I'll merge this PR once CI is clean to avoid having conflicts with my follow-up PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared progress-bar state management and changes `disable_progress_bars` into a context-manager class, which could subtly affect global enable/disable behavior across CLI commands if misused.
> 
> **Overview**
> Suppresses misleading download progress output during `hf skills add`/`hf skills update` by wrapping marketplace/bucket fetches in `with disable_progress_bars()`.
> 
> Refactors progress-bar control so `disable_progress_bars` can be used as a context manager that restores the previous state on exit, and simplifies CLI call sites (`buckets cp` stdout download, `spaces hot-reload` file fetch) to use the new pattern.
> 
> Rewrites `test_utils_tqdm.py` to pure `pytest` style and adds coverage for the new context-manager semantics (restoration, nesting, no-op when already disabled).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8c1a9963cf9052155ea43f6475847361c7fa9b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->