### PR TITLE
[CLI] Add `hf skills list` command

### DIFF
--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -3419,8 +3419,8 @@ $ hf skills list [OPTIONS]
 * `--help`: Show this message and exit.
 
 Examples
-  $ hf skills ls
-  $ hf skills ls --format json
+  $ hf skills list
+  $ hf skills list --format json
 
 Learn more
   Use `hf <command> --help` for more information about a command.

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -3362,6 +3362,7 @@ $ hf skills [OPTIONS] COMMAND [ARGS]...
 **Commands**:
 
 * `add`: Download a Hugging Face skill and install...
+* `list`: List available skills from the Hugging... [alias: ls]
 * `preview`: Print the generated `hf-cli` SKILL.md to...
 * `update`: Update installed Hugging Face marketplace...
 
@@ -3396,6 +3397,30 @@ Examples
   $ hf skills add --global
   $ hf skills add --claude
   $ hf skills add huggingface-gradio --claude --global
+
+Learn more
+  Use `hf <command> --help` for more information about a command.
+  Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
+
+
+### `hf skills list`
+
+List available skills from the Hugging Face marketplace. [alias: ls]
+
+**Usage**:
+
+```console
+$ hf skills list [OPTIONS]
+```
+
+**Options**:
+
+* `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
+* `--help`: Show this message and exit.
+
+Examples
+  $ hf skills ls
+  $ hf skills ls --format json
 
 Learn more
   Use `hf <command> --help` for more information about a command.

--- a/src/huggingface_hub/cli/_skills.py
+++ b/src/huggingface_hub/cli/_skills.py
@@ -29,6 +29,7 @@ SkillUpdateStatus = Literal["up_to_date", "unmanaged", "source_unreachable"]
 class MarketplaceSkill:
     name: str
     repo_path: str
+    description: str | None = None
 
 
 @dataclass(frozen=True)
@@ -82,7 +83,14 @@ def _load_marketplace_skills(api) -> list[MarketplaceSkill]:
         source = plugin.get("source")
         if not isinstance(name, str) or not isinstance(source, str):
             continue
-        skills.append(MarketplaceSkill(name=name, repo_path=_normalize_repo_path(source)))
+        description = plugin.get("description")
+        skills.append(
+            MarketplaceSkill(
+                name=name,
+                repo_path=_normalize_repo_path(source),
+                description=description if isinstance(description, str) else None,
+            )
+        )
     return skills
 
 

--- a/src/huggingface_hub/cli/skills.py
+++ b/src/huggingface_hub/cli/skills.py
@@ -372,11 +372,11 @@ def skills_preview() -> None:
 @skills_cli.command(
     "list | ls",
     examples=[
-        "hf skills ls",
-        "hf skills ls --format json",
+        "hf skills list",
+        "hf skills list --format json",
     ],
 )
-def skills_ls(
+def skills_list(
     token: TokenOpt = None,
 ) -> None:
     """List available skills from the Hugging Face marketplace."""

--- a/src/huggingface_hub/cli/skills.py
+++ b/src/huggingface_hub/cli/skills.py
@@ -42,8 +42,10 @@ from typer.main import get_command
 
 from huggingface_hub.errors import CLIError
 
+from ..utils import disable_progress_bars
 from . import _skills
-from ._cli_utils import _has_local_formatting_option, typer_factory
+from ._cli_utils import TokenOpt, _has_local_formatting_option, get_hf_api, typer_factory
+from ._output import out
 
 
 DEFAULT_SKILL_ID = "hf-cli"
@@ -365,6 +367,49 @@ def _resolve_update_roots(
 def skills_preview() -> None:
     """Print the generated `hf-cli` SKILL.md to stdout."""
     print(build_skill_md())
+
+
+@skills_cli.command(
+    "list | ls",
+    examples=[
+        "hf skills ls",
+        "hf skills ls --format json",
+    ],
+)
+def skills_ls(
+    token: TokenOpt = None,
+) -> None:
+    """List available skills from the Hugging Face marketplace."""
+    install_locations: list[tuple[str, Path]] = [
+        ("project", CENTRAL_LOCAL),
+        ("global", CENTRAL_GLOBAL),
+        ("project (claude)", CLAUDE_LOCAL),
+        ("global (claude)", CLAUDE_GLOBAL),
+    ]
+    installed: dict[str, set[str]] = {}
+    for label, root in install_locations:
+        for skill_dir in _skills._iter_unique_skill_dirs([root]):
+            installed.setdefault(skill_dir.name.lower(), set()).add(label)
+
+    api = get_hf_api(token=token)
+    with disable_progress_bars():
+        skills = _skills._load_marketplace_skills(api)
+    results = [
+        {
+            "name": skill.name,
+            "description": skill.description or "",
+            **{
+                label: "yes" if label in installed.get(skill.name.lower(), set()) else ""
+                for label, _ in install_locations
+            },
+        }
+        for skill in skills
+    ]
+    out.table(
+        results,
+        id_key="name",
+        alignments={"project": "right", "global": "right", "project (claude)": "right", "global (claude)": "right"},
+    )
 
 
 @skills_cli.command(

--- a/src/huggingface_hub/cli/skills.py
+++ b/src/huggingface_hub/cli/skills.py
@@ -382,8 +382,8 @@ def skills_list(
     """List available skills from the Hugging Face marketplace."""
     install_locations: list[tuple[str, Path]] = [
         ("project", CENTRAL_LOCAL),
-        ("global", CENTRAL_GLOBAL),
         ("project (claude)", CLAUDE_LOCAL),
+        ("global", CENTRAL_GLOBAL),
         ("global (claude)", CLAUDE_GLOBAL),
     ]
     installed: dict[str, set[str]] = {}


### PR DESCRIPTION
## Summary

- Add `hf skills list` (alias `hf skills ls`) to list available skills from the Hugging Face marketplace.
- Shows name, description, and install status across all four locations (project, global, project claude, global claude).
- Add `description` field to `MarketplaceSkill` dataclass (parsed from `marketplace.json`).

```
$ hf skills ls
  name                        description                                            project   global   project (claude)   global (claude)
  huggingface-llm-trainer     Train or fine-tune language models using TRL on...                yes      yes
  huggingface-gradio          Build Gradio apps on Hugging Face Spaces...
  hf-cli                      Hugging Face Hub CLI...                                 yes       yes      yes                yes
  ...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new read-only CLI command and extends marketplace parsing with an optional `description` field, without changing install/update behavior.
> 
> **Overview**
> Adds a new `hf skills list` (alias `ls`) command that fetches marketplace skills and prints a table including **name/description** plus whether each skill is installed in the four supported locations (project/global and Claude project/global).
> 
> Extends marketplace parsing by adding an optional `description` field to `MarketplaceSkill`, and updates the generated CLI reference docs to include the new command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f293ce63a6c2dfad63658dd4788020e6462cc73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->