### PR TITLE
[CLI] Increase default --limit from 10 to 30 for list commands

### DIFF
--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -1081,7 +1081,7 @@ $ hf datasets list [OPTIONS] [REPO_ID]
 * `--author TEXT`: Filter by author or organization.
 * `--filter TEXT`: Filter by tags (e.g. 'text-classification'). Can be used multiple times.
 * `--sort [created_at|downloads|last_modified|likes|trending_score]`: Sort results.
-* `--limit INTEGER`: Limit the number of results.  [default: 10]
+* `--limit INTEGER`: Limit the number of results.  [default: 30]
 * `--expand TEXT`: Comma-separated properties to return. When used, only the listed properties (and id) are returned. Example: '--expand=downloads,likes,tags'. Valid: author, cardData, citation, createdAt, description, disabled, downloads, downloadsAllTime, gated, lastModified, likes, mainSize, paperswithcode_id, private, resourceGroup, sha, siblings, tags, trendingScore, usedStorage.
 * `-h, --human-readable`: Show sizes in human readable format (only for listing files).
 * `--tree`: List files in tree format (only for listing files).
@@ -2753,7 +2753,7 @@ $ hf models list [OPTIONS] [REPO_ID]
 * `--filter TEXT`: Filter by tags (e.g. 'text-classification'). Can be used multiple times.
 * `--num-parameters TEXT`: Filter by parameter count, e.g. 'min:6B,max:128B'.
 * `--sort [created_at|downloads|last_modified|likes|trending_score]`: Sort results.
-* `--limit INTEGER`: Limit the number of results.  [default: 10]
+* `--limit INTEGER`: Limit the number of results.  [default: 30]
 * `--expand TEXT`: Comma-separated properties to return. When used, only the listed properties (and id) are returned. Example: '--expand=downloads,likes,tags'. Valid: author, baseModels, cardData, childrenModelCount, config, createdAt, disabled, downloads, downloadsAllTime, evalResults, gated, gguf, inference, inferenceProviderMapping, lastModified, library_name, likes, mask_token, model-index, pipeline_tag, private, resourceGroup, safetensors, sha, siblings, spaces, tags, transformersInfo, trendingScore, usedStorage, widgetData.
 * `-h, --human-readable`: Show sizes in human readable format (only for listing files).
 * `--tree`: List files in tree format (only for listing files).
@@ -3665,7 +3665,7 @@ $ hf spaces list [OPTIONS] [REPO_ID]
 * `--author TEXT`: Filter by author or organization.
 * `--filter TEXT`: Filter by tags (e.g. 'text-classification'). Can be used multiple times.
 * `--sort [created_at|last_modified|likes|trending_score]`: Sort results.
-* `--limit INTEGER`: Limit the number of results.  [default: 10]
+* `--limit INTEGER`: Limit the number of results.  [default: 30]
 * `--expand TEXT`: Comma-separated properties to return. When used, only the listed properties (and id) are returned. Example: '--expand=likes,tags'. Valid: author, cardData, createdAt, datasets, disabled, lastModified, likes, models, private, resourceGroup, runtime, sdk, sha, siblings, subdomain, tags, trendingScore, usedStorage.
 * `-h, --human-readable`: Show sizes in human readable format (only for listing files).
 * `--tree`: List files in tree format (only for listing files).

--- a/src/huggingface_hub/cli/_cli_utils.py
+++ b/src/huggingface_hub/cli/_cli_utils.py
@@ -51,6 +51,9 @@ logger = logging.get_logger()
 # Arbitrary maximum length of a cell in a table output
 _MAX_CELL_LENGTH = 35
 
+# Arbitrary default limit for models/datasets/spaces list commands.
+REPO_LIST_DEFAULT_LIMIT = 30
+
 if TYPE_CHECKING:
     from huggingface_hub.hf_api import HfApi
 

--- a/src/huggingface_hub/cli/datasets.py
+++ b/src/huggingface_hub/cli/datasets.py
@@ -35,6 +35,7 @@ from huggingface_hub.hf_api import DatasetSort_T, ExpandDatasetProperty_T
 from huggingface_hub.repocard import DatasetCard
 
 from ._cli_utils import (
+    REPO_LIST_DEFAULT_LIMIT,
     AuthorOpt,
     FilterOpt,
     LimitOpt,
@@ -91,7 +92,7 @@ def datasets_ls(
         DatasetSortEnum | None,
         typer.Option(help="Sort results."),
     ] = None,
-    limit: LimitOpt = 30,
+    limit: LimitOpt = REPO_LIST_DEFAULT_LIMIT,
     expand: ExpandOpt = None,
     human_readable: Annotated[
         bool,
@@ -122,7 +123,7 @@ def datasets_ls(
             raise typer.BadParameter("Cannot use --filter when listing files.")
         if sort is not None:
             raise typer.BadParameter("Cannot use --sort when listing files.")
-        if limit != 10:
+        if limit != REPO_LIST_DEFAULT_LIMIT:
             raise typer.BadParameter("Cannot use --limit when listing files.")
         if expand is not None:
             raise typer.BadParameter("Cannot use --expand when listing files.")

--- a/src/huggingface_hub/cli/datasets.py
+++ b/src/huggingface_hub/cli/datasets.py
@@ -91,7 +91,7 @@ def datasets_ls(
         DatasetSortEnum | None,
         typer.Option(help="Sort results."),
     ] = None,
-    limit: LimitOpt = 10,
+    limit: LimitOpt = 30,
     expand: ExpandOpt = None,
     human_readable: Annotated[
         bool,

--- a/src/huggingface_hub/cli/models.py
+++ b/src/huggingface_hub/cli/models.py
@@ -34,6 +34,7 @@ from huggingface_hub.hf_api import ExpandModelProperty_T, ModelSort_T
 from huggingface_hub.repocard import ModelCard
 
 from ._cli_utils import (
+    REPO_LIST_DEFAULT_LIMIT,
     AuthorOpt,
     FilterOpt,
     LimitOpt,
@@ -93,7 +94,7 @@ def models_ls(
         ModelSortEnum | None,
         typer.Option(help="Sort results."),
     ] = None,
-    limit: LimitOpt = 30,
+    limit: LimitOpt = REPO_LIST_DEFAULT_LIMIT,
     expand: ExpandOpt = None,
     human_readable: Annotated[
         bool,
@@ -126,7 +127,7 @@ def models_ls(
             raise typer.BadParameter("Cannot use --num-parameters when listing files.")
         if sort is not None:
             raise typer.BadParameter("Cannot use --sort when listing files.")
-        if limit != 10:
+        if limit != REPO_LIST_DEFAULT_LIMIT:
             raise typer.BadParameter("Cannot use --limit when listing files.")
         if expand is not None:
             raise typer.BadParameter("Cannot use --expand when listing files.")

--- a/src/huggingface_hub/cli/models.py
+++ b/src/huggingface_hub/cli/models.py
@@ -93,7 +93,7 @@ def models_ls(
         ModelSortEnum | None,
         typer.Option(help="Sort results."),
     ] = None,
-    limit: LimitOpt = 10,
+    limit: LimitOpt = 30,
     expand: ExpandOpt = None,
     human_readable: Annotated[
         bool,

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -52,6 +52,7 @@ from huggingface_hub.repocard import SpaceCard
 from huggingface_hub.utils import disable_progress_bars
 
 from ._cli_utils import (
+    REPO_LIST_DEFAULT_LIMIT,
     AuthorOpt,
     FilterOpt,
     LimitOpt,
@@ -112,7 +113,7 @@ def spaces_ls(
         SpaceSortEnum | None,
         typer.Option(help="Sort results."),
     ] = None,
-    limit: LimitOpt = 30,
+    limit: LimitOpt = REPO_LIST_DEFAULT_LIMIT,
     expand: ExpandOpt = None,
     human_readable: Annotated[
         bool,
@@ -143,7 +144,7 @@ def spaces_ls(
             raise typer.BadParameter("Cannot use --filter when listing files.")
         if sort is not None:
             raise typer.BadParameter("Cannot use --sort when listing files.")
-        if limit != 10:
+        if limit != REPO_LIST_DEFAULT_LIMIT:
             raise typer.BadParameter("Cannot use --limit when listing files.")
         if expand is not None:
             raise typer.BadParameter("Cannot use --expand when listing files.")

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -112,7 +112,7 @@ def spaces_ls(
         SpaceSortEnum | None,
         typer.Option(help="Sort results."),
     ] = None,
-    limit: LimitOpt = 10,
+    limit: LimitOpt = 30,
     expand: ExpandOpt = None,
     human_readable: Annotated[
         bool,


### PR DESCRIPTION
### Context: https://huggingface.slack.com/archives/C03V11RNS7P/p1777634553808299

## Summary

- Bump the default `--limit` from 10 to 30 for `hf models list`, `hf datasets list`, and `hf spaces list`.
- 10 felt too few as a default — 30 gives a better overview without being overwhelming.
- Other commands (`hf spaces search`, `hf datasets leaderboard`) are left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only the default pagination size for `hf models/datasets/spaces ls`, with no auth, data mutation, or protocol changes; main impact is slightly larger API responses by default.
> 
> **Overview**
> Increases the default `--limit` from **10 → 30** for `hf models ls`, `hf datasets ls`, and `hf spaces ls`, and updates the generated CLI docs to match.
> 
> Centralizes this default as `REPO_LIST_DEFAULT_LIMIT` in `cli/_cli_utils.py` and updates the “listing files” validation checks to compare against the new default constant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7fee43757f96c319bfbe5d06825bf9c1fe88fff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->