### PR TITLE
[CLI] Add get_space_secrets + hf spaces secrets ls

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -1070,16 +1070,17 @@ Use `hf spaces settings` to update the settings of a Space.
 
 ### Manage Space secrets
 
-Use `hf spaces secrets add` to add or update one or more secrets on a Space, and `hf spaces secrets delete` to remove one. Pass `--secrets-file PATH` to load secrets from a `.env`-style file. Existing keys are overwritten.
+Use `hf spaces secrets ls` to list secrets on a Space, `hf spaces secrets add` to add or update one or more secrets, and `hf spaces secrets delete` to remove one. Pass `--secrets-file PATH` to load secrets from a `.env`-style file. Existing keys are overwritten.
 
 ```bash
+>>> hf spaces secrets ls username/my-space
 >>> hf spaces secrets add username/my-space -s OPENAI_API_KEY=sk-...
 >>> hf spaces secrets add username/my-space --secrets-file .env.secrets
 >>> hf spaces secrets delete username/my-space OPENAI_API_KEY --yes
 ```
 
 > [!NOTE]
-> There is no `hf spaces secrets ls` command. The Hub exposes secrets as write-only — once set, their values cannot be read back via the API.
+> Secret values are write-only — `hf spaces secrets ls` shows keys, descriptions, and update timestamps, but never the secret values themselves.
 
 ### Manage Space environment variables
 

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -1080,7 +1080,7 @@ Use `hf spaces secrets ls` to list secrets on a Space, `hf spaces secrets add` t
 ```
 
 > [!NOTE]
-> Secret values are write-only — `hf spaces secrets ls` shows keys, descriptions, and update timestamps, but never the secret values themselves.
+> Secret values are write-only so `hf spaces secrets ls` shows keys, descriptions, and update timestamps, but never the secret values themselves.
 
 ### Manage Space environment variables
 

--- a/docs/source/en/guides/manage-spaces.md
+++ b/docs/source/en/guides/manage-spaces.md
@@ -78,6 +78,15 @@ For example, an HF token to upload an image dataset to the Hub once generated fr
 >>> api.add_space_variable(repo_id=repo_id, key="MODEL_REPO_ID", value="user/repo")
 ```
 
+You can list existing secrets and variables. Secret values are write-only, so only keys, descriptions, and update timestamps are returned:
+
+```py
+>>> api.get_space_secrets(repo_id=repo_id)
+{'HF_TOKEN': SpaceSecret(key='HF_TOKEN', description=None, updated_at=datetime.datetime(...))}
+>>> api.get_space_variables(repo_id=repo_id)
+{'MODEL_REPO_ID': SpaceVariable(key='MODEL_REPO_ID', value='user/repo', description=None, updated_at=...)}
+```
+
 Secrets and variables can be deleted as well:
 ```py
 >>> api.delete_space_secret(repo_id=repo_id, key="HF_TOKEN")

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -3834,6 +3834,7 @@ $ hf spaces secrets [OPTIONS] COMMAND [ARGS]...
 
 * `add`: Add or update secrets for a Space.
 * `delete`: Remove a secret from a Space.
+* `list`: List secrets for a Space. [alias: ls]
 
 #### `hf spaces secrets add`
 
@@ -3890,6 +3891,33 @@ $ hf spaces secrets delete [OPTIONS] SPACE_ID KEY
 Examples
   $ hf spaces secrets delete username/my-space HF_TOKEN
   $ hf spaces secrets delete username/my-space HF_TOKEN --yes
+
+Learn more
+  Use `hf <command> --help` for more information about a command.
+  Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
+
+
+#### `hf spaces secrets list`
+
+List secrets for a Space. Secret values are write-only and not returned. [alias: ls]
+
+**Usage**:
+
+```console
+$ hf spaces secrets list [OPTIONS] SPACE_ID
+```
+
+**Arguments**:
+
+* `SPACE_ID`: The space ID (e.g. `username/repo-name`).  [required]
+
+**Options**:
+
+* `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
+* `--help`: Show this message and exit.
+
+Examples
+  $ hf spaces secrets ls username/my-space
 
 Learn more
   Use `hf <command> --help` for more information about a command.

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -105,6 +105,7 @@ _SUBMOD_ATTRS = {
     "_space_api": [
         "SpaceHardware",
         "SpaceRuntime",
+        "SpaceSecret",
         "SpaceStage",
         "SpaceStorage",
         "SpaceVariable",
@@ -262,6 +263,7 @@ _SUBMOD_ATTRS = {
         "get_repo_discussions",
         "get_safetensors_metadata",
         "get_space_runtime",
+        "get_space_secrets",
         "get_space_variables",
         "get_user_overview",
         "get_webhook",
@@ -802,6 +804,7 @@ __all__ = [
     "SpaceInfo",
     "SpaceRuntime",
     "SpaceSearchResult",
+    "SpaceSecret",
     "SpaceStage",
     "SpaceStorage",
     "SpaceVariable",
@@ -980,6 +983,7 @@ __all__ = [
     "get_safetensors_metadata",
     "get_session",
     "get_space_runtime",
+    "get_space_secrets",
     "get_space_variables",
     "get_token",
     "get_torch_storage_id",
@@ -1249,6 +1253,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from ._space_api import (
         SpaceHardware,  # noqa: F401
         SpaceRuntime,  # noqa: F401
+        SpaceSecret,  # noqa: F401
         SpaceStage,  # noqa: F401
         SpaceStorage,  # noqa: F401
         SpaceVariable,  # noqa: F401
@@ -1404,6 +1409,7 @@ if TYPE_CHECKING:  # pragma: no cover
         get_repo_discussions,  # noqa: F401
         get_safetensors_metadata,  # noqa: F401
         get_space_runtime,  # noqa: F401
+        get_space_secrets,  # noqa: F401
         get_space_variables,  # noqa: F401
         get_user_overview,  # noqa: F401
         get_webhook,  # noqa: F401

--- a/src/huggingface_hub/_space_api.py
+++ b/src/huggingface_hub/_space_api.py
@@ -230,6 +230,34 @@ class SpaceRuntime:
 
 
 @dataclass
+class SpaceSecret:
+    """
+    Contains information about a secret of a Space.
+
+    Secret values are write-only and cannot be read back. Only the key, description,
+    and last update time are returned by the API.
+
+    Args:
+        key (`str`):
+            Secret key. Example: `"GITHUB_API_KEY"`
+        description (`str` or None):
+            Description of the secret. Example: `"Github API key to access the Github API"`.
+        updated_at (`datetime` or None):
+            datetime of the last update of the secret (if the secret has been updated at least once).
+    """
+
+    key: str
+    description: str | None
+    updated_at: datetime | None
+
+    def __init__(self, key: str, values: dict) -> None:
+        self.key = key
+        self.description = values.get("description")
+        updated_at = values.get("updatedAt")
+        self.updated_at = parse_datetime(updated_at) if updated_at is not None else None
+
+
+@dataclass
 class SpaceVariable:
     """
     Contains information about the current variables of a Space.

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -874,6 +874,22 @@ def volumes_delete(
 
 
 @secrets_cli.command(
+    "list | ls",
+    examples=["hf spaces secrets ls username/my-space"],
+)
+def secrets_ls(
+    space_id: Annotated[str, typer.Argument(help="The space ID (e.g. `username/repo-name`).")],
+    token: TokenOpt = None,
+) -> None:
+    """List secrets for a Space. Secret values are write-only and not returned."""
+    api = get_hf_api(token=token)
+    secrets = api.get_space_secrets(space_id)
+    items = [api_object_to_dict(s) for s in secrets.values()]
+    out.table(items)
+    out.hint(f"Use `hf spaces secrets add {space_id} -s KEY=VALUE` to add secrets to a Space.")
+
+
+@secrets_cli.command(
     "add",
     examples=[
         "hf spaces secrets add username/my-space -s HF_TOKEN",

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -13967,6 +13967,7 @@ rename_discussion = api.rename_discussion
 merge_pull_request = api.merge_pull_request
 
 # Space API
+get_space_secrets = api.get_space_secrets
 add_space_secret = api.add_space_secret
 delete_space_secret = api.delete_space_secret
 get_space_variables = api.get_space_variables

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -72,7 +72,15 @@ from ._dataset_viewer import DatasetParquetEntry
 from ._eval_results import EvalResultEntry, parse_eval_result_entries
 from ._inference_endpoints import InferenceEndpoint, InferenceEndpointScalingMetric, InferenceEndpointType
 from ._jobs_api import JobHardware, JobInfo, JobSpec, ScheduledJobInfo, _create_job_spec
-from ._space_api import SpaceHardware, SpaceRuntime, SpaceSearchResult, SpaceStorage, SpaceVariable, Volume
+from ._space_api import (
+    SpaceHardware,
+    SpaceRuntime,
+    SpaceSearchResult,
+    SpaceSecret,
+    SpaceStorage,
+    SpaceVariable,
+    Volume,
+)
 from ._upload_large_folder import upload_large_folder_internal
 from .community import (
     Discussion,
@@ -7668,6 +7676,43 @@ class HfApi:
             json={"key": key},
         )
         hf_raise_for_status(r)
+
+    @validate_hf_hub_args
+    def get_space_secrets(self, repo_id: str, *, token: bool | str | None = None) -> dict[str, SpaceSecret]:
+        """Gets all secrets from a Space.
+
+        Secret values are write-only and cannot be read back. Only the key, description, and last update time
+        are returned.
+
+        Secrets allow to set secret keys or tokens to a Space without hardcoding them.
+        For more details, see https://huggingface.co/docs/hub/spaces-overview#managing-secrets.
+
+        Args:
+            repo_id (`str`):
+                ID of the repo to query. Example: `"bigcode/in-the-stack"`.
+            token (`bool` or `str`, *optional*):
+                A valid user access token (string). Defaults to the locally saved
+                token, which is the recommended method for authentication (see
+                https://huggingface.co/docs/huggingface_hub/quick-start#authentication).
+                To disable authentication, pass `False`.
+
+        Returns:
+            `dict[str, SpaceSecret]`: Dictionary of [`SpaceSecret`] objects keyed by secret name.
+
+        Example:
+        ```python
+        >>> from huggingface_hub import HfApi
+        >>> api = HfApi()
+        >>> api.get_space_secrets("username/my-space")
+        {'HF_TOKEN': SpaceSecret(key='HF_TOKEN', description='...', updated_at=datetime.datetime(...))}
+        ```
+        """
+        r = get_session().get(
+            f"{self.endpoint}/api/spaces/{repo_id}/secrets",
+            headers=self._build_hf_headers(token=token),
+        )
+        hf_raise_for_status(r)
+        return {k: SpaceSecret(k, v) for k, v in r.json().items()}
 
     @validate_hf_hub_args
     def get_space_variables(self, repo_id: str, *, token: bool | str | None = None) -> dict[str, SpaceVariable]:


### PR DESCRIPTION
Follow-up on https://github.com/huggingface-internal/moon-landing/pull/18019 (internal) and https://github.com/huggingface/huggingface_hub/pull/4170.

- Add `SpaceSecret` dataclass + `HfApi.get_space_secrets()` method calling `GET /api/spaces/{repo_id}/secrets`
- Add `hf spaces secrets ls` CLI command
- update docs

```bash
$ hf spaces secrets ls smolagents/ml-intern          
KEY                     UPDATED_AT
----------------------- ----------
GITHUB_TOKEN            2026-01-27
HF_ADMIN_TOKEN          2026-01-28
ANTHROPIC_API_KEY       2026-04-23
INFERENCE_TOKEN         2026-02-13
HF_NAMESPACE            2026-02-13
HF_SESSION_UPLOAD_TOKEN 2026-03-05
HF_BILL_TO              2026-04-22
CLAUDE_FREE_DAILY       2026-04-23
CLAUDE_PRO_DAILY        2026-04-23
AWS_ACCESS_KEY_ID       2026-04-23
AWS_SECRET_ACCESS_KEY   2026-04-23
AWS_REGION              2026-04-23
MONGODB_DB              2026-04-28
MONGODB_URI             2026-04-28
OPENAI_API_KEY          2026-04-29

$ hf spaces variables ls smolagents/ml-intern
KEY             VALUE       UPDATED_AT
--------------- ----------- ----------
HF_EMPLOYEE_ORG huggingface 2026-05-01
```

```python
>>> from huggingface_hub import HfApi
>>> api = HfApi()
>>> api.get_space_secrets("username/my-space")
{'HF_TOKEN': SpaceSecret(key='HF_TOKEN', description=None, updated_at=datetime.datetime(...))}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk additive change that introduces a new `GET /api/spaces/{repo_id}/secrets` wrapper and a CLI listing command; main risk is compatibility with the backend response shape and exposing secret metadata in outputs (values remain write-only).
> 
> **Overview**
> Adds support to **list Space secrets without revealing values**.
> 
> Introduces `SpaceSecret` plus `HfApi.get_space_secrets()` (and top-level `get_space_secrets`) to call `GET /api/spaces/{repo_id}/secrets` and parse secret metadata (key/description/updated timestamp). Exposes this in the CLI via `hf spaces secrets list` / `ls`, updates the CLI reference, and refreshes guides to document that listing shows metadata only (no secret values).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffcbe662cb1ecef37089914d60c976febd9aa3a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->