### PR TITLE
[Security] Fix TOCTOU race in style-bot-action workflow

### DIFF
--- a/.github/workflows/style-bot-action.yml
+++ b/.github/workflows/style-bot-action.yml
@@ -25,10 +25,13 @@ on:
           description: "Python version to run code formatter"
           default: "3.10"
       secrets:
-        bot_token:
+        app_id:
           required: true
-          description: "GitHub token with permissions to comment and push to PR"
-  
+          description: "GitHub App ID used to generate a short-lived token"
+        app_private_key:
+          required: true
+          description: "GitHub App private key used to generate a short-lived token"
+
 jobs:
   check-permissions:
     if: >
@@ -60,6 +63,14 @@ jobs:
     needs: check-permissions
     if: needs.check-permissions.outputs.is_authorized == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+      contents: read
+    outputs:
+      headRepoFullName: ${{ steps.pr_info.outputs.headRepoFullName }}
+      headRef: ${{ steps.pr_info.outputs.headRef }}
+      headSha: ${{ steps.pr_info.outputs.headSha }}
+      prNumber: ${{ steps.pr_info.outputs.prNumber }}
     steps:
       - name: Extract PR details
         id: pr_info
@@ -78,77 +89,96 @@ jobs:
             // Set outputs for use in subsequent steps
             core.setOutput('headRepoFullName', pr.head.repo.full_name);
             core.setOutput('headRef', pr.head.ref);
+            core.setOutput('headSha', pr.head.sha);
             core.setOutput('baseRef', pr.base.ref);
             core.setOutput('prNumber', prNumber);
-            
+
             console.log('PR Details:', {
               number: prNumber,
               headRepo: pr.head.repo.full_name,
               headRef: pr.head.ref,
+              headSha: pr.head.sha,
               baseRef: pr.base.ref
             });
         
       - name: Check out PR branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        env:
-          HEADREPOFULLNAME: ${{ steps.pr_info.outputs.headRepoFullName }}
-          HEADREF: ${{ steps.pr_info.outputs.headRef }}
         with:
-          # Instead of checking out the base repo, use the contributor's repo name
-          repository: ${{ env.HEADREPOFULLNAME }}
-          ref: ${{ env.HEADREF }}
-          # You may need fetch-depth: 0 for being able to push
+          repository: ${{ steps.pr_info.outputs.headRepoFullName }}
+          ref: ${{ steps.pr_info.outputs.headSha }}
           fetch-depth: 0
-          token: ${{ secrets.bot_token }}
+          persist-credentials: false
 
-      - name: Check commit timestamps
+      - name: Verify checked-out SHA
         env:
-          COMMENT_DATE: ${{ github.event.comment.created_at }}
-          PR_NUMBER: ${{ steps.pr_info.outputs.prNumber }}
-          BASE_REPO_URL: https://github.com/${{ github.repository }}
-          HEADREF: ${{ steps.pr_info.outputs.headRef }}
+          HEAD_SHA: ${{ steps.pr_info.outputs.headSha }}
         run: |
-            echo "--- Checking remotes ---"
-            git remote -v
-            echo "--- Checking ref on origin (${{ steps.pr_info.outputs.headRepoFullName }}) ---"
-            git ls-remote origin refs/pull/$PR_NUMBER/merge || echo "Ref not found on origin (fork)."
-            echo "--- Checking ref on base (${{ github.repository }}) ---"
-            git ls-remote $BASE_REPO_URL refs/pull/$PR_NUMBER/merge || echo "Ref not found on base repository."
-            
-            echo "--- Proceeding with fetch from base repository ---"
-            git fetch $BASE_REPO_URL refs/pull/$PR_NUMBER/merge:refs/remotes/pull/$PR_NUMBER/merge
-            git checkout refs/remotes/pull/$PR_NUMBER/merge
-            echo "PR_MERGE_SHA: $(git log -1 --format=%H)"
-            PR_MERGE_COMMIT_TIMESTAMP=$(git log -1 --date=unix --format=%cd)
-            echo "PR_MERGE_COMMIT_TIMESTAMP: $PR_MERGE_COMMIT_TIMESTAMP"
-            COMMENT_TIMESTAMP=$(date -d "${COMMENT_DATE}" +"%s")
-            echo "COMMENT_DATE: $COMMENT_DATE"
-            echo "COMMENT_TIMESTAMP: $COMMENT_TIMESTAMP"
-            if [ $COMMENT_TIMESTAMP -le $PR_MERGE_COMMIT_TIMESTAMP ]; then
-              echo "❌ Last commit on the pull request is newer than the issue comment triggering this run! Abort!";
-              exit -1;
+            if [ "$(git rev-parse HEAD)" != "$HEAD_SHA" ]; then
+              echo "❌ Checked-out SHA does not match expected HEAD SHA! Abort!";
+              exit 1;
             fi
 
-            echo "--- Checking out contributor branch ($HEADREF) ---"
-            git checkout $HEADREF
-
-      - name: Comment on PR with workflow run link
-        id: init_comment
+      - name: Verify PR head SHA is unchanged before running untrusted code
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8
+        env:
+          EXPECTED_HEAD_SHA: ${{ steps.pr_info.outputs.headSha }}
         with:
           script: |
-            const prNumber = parseInt(process.env.prNumber, 10);
-            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
-
-            const { data: botComment } = await github.rest.issues.createComment({
+            const prNumber = context.payload.issue.number;
+            const { data: pr } = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: prNumber,
-              body: `Style fix is beginning .... [View the workflow run here](${runUrl}).`
+              pull_number: prNumber
             });
-            core.setOutput('comment_id', botComment.id);
+            if (pr.head.sha !== process.env.EXPECTED_HEAD_SHA) {
+              core.setFailed(
+                `❌ PR head changed during the workflow bootstrap. Expected ${process.env.EXPECTED_HEAD_SHA}, got ${pr.head.sha}. Aborting.`
+              );
+            }
+
+      - name: Check commit was pushed before the triggering comment
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8
         env:
-          prNumber: ${{ steps.pr_info.outputs.prNumber }}
+          HEAD_SHA: ${{ steps.pr_info.outputs.headSha }}
+          HEAD_REPO_FULL_NAME: ${{ steps.pr_info.outputs.headRepoFullName }}
+          COMMENT_DATE: ${{ github.event.comment.created_at }}
+        with:
+          script: |
+            const headSha = process.env.HEAD_SHA;
+            const [headOwner, headRepo] = process.env.HEAD_REPO_FULL_NAME.split('/');
+            const commentTimestamp = new Date(process.env.COMMENT_DATE).getTime();
+
+            // pushedDate is set server-side by GitHub when the push is received —
+            // unlike committer.date which is part of the git object and forgeable via GIT_COMMITTER_DATE.
+            const query = `
+              query($owner: String!, $repo: String!, $sha: GitObjectID!) {
+                repository(owner: $owner, name: $repo) {
+                  object(oid: $sha) {
+                    ... on Commit {
+                      pushedDate
+                    }
+                  }
+                }
+              }
+            `;
+            const result = await github.graphql(query, { owner: headOwner, repo: headRepo, sha: headSha });
+
+            const pushedDate = result.repository.object?.pushedDate;
+            if (!pushedDate) {
+              // pushedDate is null for commits created via GitHub API or web UI (merge, squash, etc.)
+              // SHA pinning + re-validation already protect against mid-workflow injection, so we skip
+              // the timestamp check rather than blocking legitimate runs.
+              core.warning(`⚠️ pushedDate unavailable for commit ${headSha} (likely created via API/web UI). Skipping timestamp check.`);
+              return;
+            }
+
+            const pushTimestamp = new Date(pushedDate).getTime();
+            console.log(`Push timestamp (server-side): ${pushedDate}, Comment date: ${process.env.COMMENT_DATE}`);
+            if (pushTimestamp >= commentTimestamp) {
+              core.setFailed(`❌ Commit ${headSha} was pushed at or after the @bot /style comment. Aborting.`);
+            } else {
+              console.log('✅ Push timestamp check passed.');
+            }
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
@@ -161,7 +191,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install .$python_quality_dependencies
-          echo ${{ steps.init_comment.outputs.comment_id }}
 
       - name: Run style command
         id: run_style
@@ -188,13 +217,124 @@ jobs:
               ;;
           esac
 
+      - name: Export style fixes as patch artifact
+        env:
+          STYLE_BOT_OUTPUT_DIR: ${{ runner.temp }}/style-bot-output
+        run: |
+          mkdir -p "$STYLE_BOT_OUTPUT_DIR"
+          if [ -n "$(git status --porcelain)" ]; then
+            git add -A
+            git diff --cached --binary > "$STYLE_BOT_OUTPUT_DIR/style-fixes.patch"
+            echo "changes_present=true" > "$STYLE_BOT_OUTPUT_DIR/metadata.env"
+          else
+            echo "changes_present=false" > "$STYLE_BOT_OUTPUT_DIR/metadata.env"
+          fi
+
+      - name: Upload style fixes artifact
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08  # v4.6.0
+        with:
+          name: style-bot-output-${{ github.run_id }}
+          path: ${{ runner.temp }}/style-bot-output
+          if-no-files-found: error
+
+  push-style-fixes:
+    needs:
+      - check-permissions
+      - run-style-bot
+    if: needs.check-permissions.outputs.is_authorized == 'true' && needs.run-style-bot.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - name: Generate bot token
+        id: generate_token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v1
+        with:
+          app-id: ${{ secrets.app_id }}
+          private-key: ${{ secrets.app_private_key }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
+      - name: Re-validate PR head SHA before trusted steps
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8
+        env:
+          EXPECTED_HEAD_SHA: ${{ needs.run-style-bot.outputs.headSha }}
+        with:
+          script: |
+            const prNumber = context.payload.issue.number;
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber
+            });
+            if (pr.head.sha !== process.env.EXPECTED_HEAD_SHA) {
+              core.setFailed(
+                `❌ PR head changed after the untrusted style run. Expected ${process.env.EXPECTED_HEAD_SHA}, got ${pr.head.sha}. Aborting.`
+              );
+            }
+
+      - name: Check out reviewed PR SHA
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          repository: ${{ needs.run-style-bot.outputs.headRepoFullName }}
+          ref: ${{ needs.run-style-bot.outputs.headSha }}
+          fetch-depth: 0
+          token: ${{ steps.generate_token.outputs.token }}
+          persist-credentials: false
+
+      - name: Verify checked-out SHA
+        env:
+          HEAD_SHA: ${{ needs.run-style-bot.outputs.headSha }}
+        run: |
+          if [ "$(git rev-parse HEAD)" != "$HEAD_SHA" ]; then
+            echo "❌ Checked-out SHA does not match expected HEAD SHA! Abort!"
+            exit 1
+          fi
+
+      - name: Download style fixes artifact
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+        with:
+          name: style-bot-output-${{ github.run_id }}
+          path: ${{ runner.temp }}/style-bot-output
+
+      - name: Comment on PR with workflow run link
+        id: init_comment
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8
+        with:
+          script: |
+            const prNumber = parseInt(process.env.prNumber, 10);
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
+
+            const { data: botComment } = await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: `Style fix is beginning .... [View the workflow run here](${runUrl}).`
+            });
+            core.setOutput('comment_id', botComment.id);
+        env:
+          prNumber: ${{ needs.run-style-bot.outputs.prNumber }}
+
+      - name: Apply style fixes patch
+        id: apply_patch
+        env:
+          STYLE_BOT_OUTPUT_DIR: ${{ runner.temp }}/style-bot-output
+        run: |
+          if grep -qx 'changes_present=true' "$STYLE_BOT_OUTPUT_DIR/metadata.env"; then
+            git apply --binary "$STYLE_BOT_OUTPUT_DIR/style-fixes.patch"
+            echo "changes_present=true" >> $GITHUB_OUTPUT
+          else
+            echo "No changes to apply."
+            echo "changes_present=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Commit and push changes
         id: commit_and_push
         env:
-          HEADREPOFULLNAME: ${{ steps.pr_info.outputs.headRepoFullName }}
-          HEADREF: ${{ steps.pr_info.outputs.headRef }}
-          PRNUMBER: ${{ steps.pr_info.outputs.prNumber }}
-          GITHUB_TOKEN: ${{ secrets.bot_token }}
+          HEADREPOFULLNAME: ${{ needs.run-style-bot.outputs.headRepoFullName }}
+          HEADREF: ${{ needs.run-style-bot.outputs.headRef }}
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
         run: |
           echo "HEADREPOFULLNAME: $HEADREPOFULLNAME, HEADREF: $HEADREF"
           # Configure git with the Actions bot user
@@ -205,11 +345,11 @@ jobs:
           git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/$HEADREPOFULLNAME.git"
 
           # If there are changes after running style/quality, commit them
-          if [ -n "$(git status --porcelain)" ]; then
+          if [ "${{ steps.apply_patch.outputs.changes_present }}" = "true" ] && [ -n "$(git status --porcelain)" ]; then
             git add .
             git commit -m "Apply style fixes"
             # Push to the original contributor's forked branch
-            git push origin HEAD:$HEADREF
+            git -c lfs.locksverify=false push origin HEAD:$HEADREF
             echo "changes_pushed=true" >> $GITHUB_OUTPUT
           else
             echo "No changes to commit."
@@ -239,4 +379,4 @@ jobs:
               body: `${{ steps.prepare_final_comment.outputs.final_comment }}`
             });
         env:
-          prNumber: ${{ steps.pr_info.outputs.prNumber }}
+          prNumber: ${{ needs.run-style-bot.outputs.prNumber }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it restructures the style-bot GitHub Actions workflow, changing how code is checked out and how credentials are generated/passed for pushing fixes, which could break automation or alter permissions if misconfigured.
> 
> **Overview**
> **Hardens the `style-bot-action` reusable workflow against TOCTOU attacks when running on PRs.** It now pins execution to the PR `headSha`, verifies the SHA before running untrusted code and again before pushing, and replaces the previous timestamp-based git checks with a server-side `pushedDate` check.
> 
> **Separates untrusted formatting from trusted push steps.** The style run exports any changes as a binary patch artifact, and a new `push-style-fixes` job downloads/applies that patch and pushes using a short-lived GitHub App token (`app_id`/`app_private_key`) with tightened job permissions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42642d4a896bd43a8360b29f5f32934232f4db32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->