### PR TITLE
[Security] Use bot token for style-bot GraphQL timestamp check

### DIFF
--- a/.github/workflows/style-bot-action.yml
+++ b/.github/workflows/style-bot-action.yml
@@ -115,6 +115,7 @@ jobs:
           HEAD_REPO_FULL_NAME: ${{ steps.pr_info.outputs.headRepoFullName }}
           COMMENT_DATE: ${{ github.event.comment.created_at }}
         with:
+          github-token: ${{ secrets.bot_token }}
           script: |
             const headSha = process.env.HEAD_SHA;
             const [headOwner, headRepo] = process.env.HEAD_REPO_FULL_NAME.split('/');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- uses `secrets.bot_token` for the `actions/github-script` step that queries `pushedDate` on `pr.head.repo`
- keeps the existing TOCTOU hardening (`headSha` checkout + SHA verification + server-side `pushedDate` check)
- fixes fork/private-repo compatibility where default `GITHUB_TOKEN` may not read the head repository

### Manual verification
```bash
make style && make quality
# -> passes
```

This is a follow-up to the style-bot TOCTOU hardening branch and specifically addresses the remaining token mismatch noted in review feedback.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b921e881-3bd1-4098-983a-2c9e808054e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b921e881-3bd1-4098-983a-2c9e808054e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

