### PR TITLE
[CLI] Support hf -v to print version

### DIFF
--- a/src/huggingface_hub/cli/hf.py
+++ b/src/huggingface_hub/cli/hf.py
@@ -67,7 +67,7 @@ def _version_callback(value: bool) -> None:
 @app.callback(invoke_without_command=True)
 def app_callback(
     version: Annotated[
-        bool | None, typer.Option("--version", callback=_version_callback, is_eager=True, hidden=True)
+        bool | None, typer.Option("-v", "--version", callback=_version_callback, is_eager=True, hidden=True)
     ] = None,
 ) -> None:
     pass


### PR DESCRIPTION
```
$ hf -v
1.14.0.dev0
```

cc @Pierrci who asked for it

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new short flag alias for the existing hidden `--version` option without changing version-printing behavior or other CLI commands.
> 
> **Overview**
> Adds `-v` as a shorthand for the existing hidden `--version` option on the `hf` CLI, so `hf -v` prints the package version and exits early via the same callback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23e6defd6b65630368078c5e2c466a55c5239ebc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->