### PR TITLE
[Buckets] Support rsync-style trailing slash in copy_files

### DIFF
--- a/docs/source/en/guides/buckets.md
+++ b/docs/source/en/guides/buckets.md
@@ -525,6 +525,16 @@ The same is available from the CLI:
 >>> hf buckets cp hf://username/my-model/config.json hf://buckets/username/my-bucket/models/config.json
 ```
 
+When copying folders, a trailing `/` on the source uses rsync-style semantics — only the *contents* of the folder are copied, without nesting the folder itself:
+
+```bash
+# Without trailing slash: "logs" dir is nested => destination/logs/...
+>>> hf buckets cp hf://buckets/username/source-bucket/logs hf://buckets/username/destination-bucket/
+
+# With trailing slash: only contents of "logs" are copied => destination/...
+>>> hf buckets cp hf://buckets/username/source-bucket/logs/ hf://buckets/username/destination-bucket/
+```
+
 Notes:
 
 - Bucket-to-repo copy is not yet supported.

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -753,6 +753,16 @@ To copy from a repo or a bucket on the Hub:
 >>> hf buckets cp hf://datasets/username/my-dataset/data/train/ hf://buckets/username/my-bucket/datasets/train/
 ```
 
+When copying folders, a trailing `/` on the source path controls whether the folder itself is nested or only its contents are copied (rsync-style):
+
+```bash
+# Without trailing slash: "logs" dir is nested => archive/logs/...
+>>> hf buckets cp hf://buckets/username/my-bucket/logs hf://buckets/username/archive-bucket/
+
+# With trailing slash: only contents of "logs" are copied => archive/...
+>>> hf buckets cp hf://buckets/username/my-bucket/logs/ hf://buckets/username/archive-bucket/
+```
+
 Notes:
 
 - Bucket-to-repo copy is not yet supported.

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -270,7 +270,8 @@ Examples
   $ hf buckets cp my-config.json hf://buckets/user/my-bucket/logs/
   $ hf buckets cp my-config.json hf://buckets/user/my-bucket/remote-config.json
   $ hf buckets cp - hf://buckets/user/my-bucket/config.json
-  $ hf buckets cp hf://buckets/user/my-bucket/logs/ hf://buckets/user/archive-bucket/logs/
+  $ hf buckets cp hf://buckets/user/my-bucket/logs hf://buckets/user/archive-bucket/  # nests logs/ dir
+  $ hf buckets cp hf://buckets/user/my-bucket/logs/ hf://buckets/user/archive-bucket/  # copies contents only
   $ hf buckets cp hf://datasets/user/my-dataset/processed/ hf://buckets/user/my-bucket/dataset/processed/
 
 Learn more

--- a/src/huggingface_hub/cli/buckets.py
+++ b/src/huggingface_hub/cli/buckets.py
@@ -705,7 +705,8 @@ def sync(
         "hf buckets cp my-config.json hf://buckets/user/my-bucket/logs/",
         "hf buckets cp my-config.json hf://buckets/user/my-bucket/remote-config.json",
         "hf buckets cp - hf://buckets/user/my-bucket/config.json",
-        "hf buckets cp hf://buckets/user/my-bucket/logs/ hf://buckets/user/archive-bucket/logs/",
+        "hf buckets cp hf://buckets/user/my-bucket/logs hf://buckets/user/archive-bucket/  # nests logs/ dir",
+        "hf buckets cp hf://buckets/user/my-bucket/logs/ hf://buckets/user/archive-bucket/  # copies contents only",
         "hf buckets cp hf://datasets/user/my-dataset/processed/ hf://buckets/user/my-bucket/dataset/processed/",
     ],
 )

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -12849,6 +12849,10 @@ class HfApi:
 
         Currently, only bucket destinations are supported. Copying to a repository is not supported.
 
+        When copying folders, a trailing `/` on the source path uses rsync-style semantics: copy the *contents*
+        of the folder into the destination, without nesting the source folder itself. Without a trailing `/`,
+        the source folder is nested inside the destination (like `cp -r`).
+
         When copying from a repository, `.gitattributes` files are automatically excluded since they are
         git-specific metadata and not relevant in a bucket context.
 
@@ -12876,7 +12880,10 @@ class HfApi:
             # Copy a single file between buckets
             >>> copy_files("hf://buckets/my-bucket/data.bin", "hf://buckets/other-bucket/data.bin")
 
-            # Copy a folder from a bucket to another bucket
+            # Copy a folder into another bucket (nests: backup/models/...)
+            >>> copy_files("hf://buckets/my-bucket/models", "hf://buckets/other-bucket/backup/")
+
+            # Copy folder contents (trailing /): files go directly into backup/
             >>> copy_files("hf://buckets/my-bucket/models/", "hf://buckets/other-bucket/backup/")
 
             # Copy a file from a model repo to a bucket
@@ -12886,6 +12893,10 @@ class HfApi:
             >>> copy_files("hf://datasets/username/my-dataset/", "hf://buckets/my-bucket/datasets/")
             ```
         """
+        # Rsync-style trailing slash on source: "copy contents of" instead of "copy directory into".
+        # Check before parsing strips the slash.
+        source_is_contents_only = source.endswith("/")
+
         source_handle = _parse_hf_copy_handle(source)
         destination_handle = _parse_hf_copy_handle(destination)
 
@@ -12939,10 +12950,10 @@ class HfApi:
             if rel_path == "":
                 raise ValueError("Cannot copy an empty relative path.")
 
-            # Match Unix `cp -r` behavior: when the destination already exists as a
-            # directory, nest the source folder inside it (e.g. cp -r src dst → dst/src/...).
-            # When the destination does not exist, use rename semantics (cp -r src new → new/...).
-            if destination_exists_as_directory and src_root_path is not None:
+            # Rsync-style trailing slash on source means "copy contents of" — skip nesting.
+            # Without trailing slash, match `cp -r` behavior: nest source folder inside
+            # existing destination directory. Non-existing destination always uses rename semantics.
+            if destination_exists_as_directory and src_root_path is not None and not source_is_contents_only:
                 src_dir_basename = src_root_path.rsplit("/", 1)[-1]
                 rel_path = f"{src_dir_basename}/{rel_path}"
 

--- a/tests/test_buckets.py
+++ b/tests/test_buckets.py
@@ -405,6 +405,27 @@ def test_copy_files_folder_to_existing_folder_dest(api: HfApi, bucket_write: str
 
 
 @requires("hf_xet")
+def test_copy_files_folder_contents_to_existing_folder_with_trailing_slash(
+    api: HfApi, bucket_write: str, bucket_write_2: str
+):
+    """source=folder/ (trailing slash), dest exists => copy contents, no nesting (rsync semantics)."""
+    api.batch_bucket_files(bucket_write, add=[(b"a", "folder/a.txt"), (b"b", "folder/sub/b.txt")])
+    api.batch_bucket_files(bucket_write_2, add=[(b"existing", "target-folder/existing.txt")])
+
+    api.copy_files(
+        f"hf://buckets/{bucket_write}/folder/",
+        f"hf://buckets/{bucket_write_2}/target-folder",
+    )
+
+    # Trailing slash on source = "copy contents of folder" => no nesting
+    destination_files = {entry.path for entry in api.list_bucket_tree(bucket_write_2)}
+    assert "target-folder/existing.txt" in destination_files
+    assert "target-folder/a.txt" in destination_files
+    assert "target-folder/sub/b.txt" in destination_files
+    assert "target-folder/folder/a.txt" not in destination_files
+
+
+@requires("hf_xet")
 def test_copy_files_file_to_existing_file_dest(api: HfApi, bucket_write: str, bucket_write_2: str, tmp_path):
     """source=file, dest is an existing file => must work (overwrite)."""
     api.batch_bucket_files(bucket_write, add=[(b"new-content", "source.txt")])


### PR DESCRIPTION
### Context: @Pierrci 's report in [private slack](https://huggingface.slack.com/archives/C0ACCEFPU9W/p1777969740886359). Currently it's not possible to copy the content of a folder from a bucket, to the root of another bucket.

Solution suggested by Claude:

- "copy src dst/" => copy src files under `dst/src`
- "copy src/ dst/" => copy src files under `dst/`

This follows `rsync` style, not UNIX `cp` style so it's more of a design question rather than implementation problem. What's your take on this @hanouticelina @Pierrci @julien-c ?

**Before (no way to avoid nesting):**
```bash
# Both with and without trailing slash would nest nvidia/ inside target
hf buckets cp hf://buckets/src/nvidia/ hf://buckets/dst/
# => dst/nvidia/file1.txt, dst/nvidia/file2.txt
```

**After (rsync-style trailing slash):**
```bash
# Without trailing slash: nests (cp -r behavior)
hf buckets cp hf://buckets/src/nvidia hf://buckets/dst/
# => dst/nvidia/file1.txt, dst/nvidia/file2.txt

# With trailing slash: copies contents only (rsync behavior)
hf buckets cp hf://buckets/src/nvidia/ hf://buckets/dst/
# => dst/file1.txt, dst/file2.txt
```

The implementation is a one-line condition change in `_resolve_target_path` — when `source_is_contents_only` (trailing `/` detected before parsing), the nesting step is skipped.

Updated docs in CLI guide, buckets guide, CLI reference, and `copy_files` docstring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes folder-copy path resolution in `HfApi.copy_files` based on a trailing `/`, which could alter destination layouts for existing callers that relied on the previous nesting behavior. Covered by a new regression test, but impacts data placement in buckets.
> 
> **Overview**
> **Folder copy semantics changed for buckets/repo-to-bucket copies.** `HfApi.copy_files` now treats a trailing `/` on the *source* as “copy contents only” (rsync-style), skipping the usual nesting of the source directory when the destination exists.
> 
> **Docs + CLI examples updated**, and a new test asserts the new trailing-slash behavior when copying a folder into an existing destination directory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35628678bdbb39c6431869ed0637710fa131dfdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->