### PR TITLE
Update unit test warnings check to ignore unrelated deprecation warnings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def get_version() -> str:
 
 
 # hf-xet version used in both install_requires and extras["hf_xet"]
-HF_XET_VERSION = "hf-xet>=1.4.3,<2.0.0"
+HF_XET_VERSION = "hf-xet>=1.5.0.dev3,<2.0.0"
 
 install_requires = [
     "filelock>=3.10.0",

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def get_version() -> str:
 
 
 # hf-xet version used in both install_requires and extras["hf_xet"]
-HF_XET_VERSION = "hf-xet>=1.5.0.dev3,<2.0.0"
+HF_XET_VERSION = "hf-xet>=1.4.3,<2.0.0"
 
 install_requires = [
     "filelock>=3.10.0",

--- a/tests/test_buckets.py
+++ b/tests/test_buckets.py
@@ -282,10 +282,10 @@ def test_download_bucket_files_skips_missing_first_file(api: HfApi, bucket_read:
         warnings.simplefilter("always")
         api.download_bucket_files(bucket_read, files)
 
-        # Verify warning was issued for missing file
-        assert len(w) == 1
-        assert "non_existent_file.txt" in str(w[0].message)
-        assert "not found" in str(w[0].message).lower()
+        # Verify warning was issued for missing file (ignore unrelated deprecation warnings)
+        not_found_warnings = [x for x in w if "non_existent_file.txt" in str(x.message)]
+        assert len(not_found_warnings) == 1
+        assert "not found" in str(not_found_warnings[0].message).lower()
 
     # Valid file should be downloaded
     assert (tmp_path / "file.txt").exists()


### PR DESCRIPTION
The unit test `test_buckets.py/test_download_bucket_files_skips_missing_first_file` asserts number of warning messages emit from downloading a "non existent" bucket file is 1. Since `hf-xet` 1.5.0, it emits deprecation warning message from legacy APIs (`upload_files`, `download_files`, ...) so this unit test fails in the hf-xet pre-release testing workflow, e.g. in https://github.com/huggingface/huggingface_hub/actions/runs/25361805293/job/74362888965:
```
FAILED ../tests/test_buckets.py::test_download_bucket_files_skips_missing_first_file - assert 2 == 1
 +  where 2 = len([<WarningMessage {message : UserWarning("File 'non_existent_file.txt' not found in bucket '__DUMMY_HUB_USER__/bucket-664eb1-17779633453324'. Skipping."), category : 'UserWarning', filename : '/home/runner/work/huggingface_hub/huggingface_hub/src/huggingface_hub/hf_api.py', lineno : 13479, line : None}>, <WarningMessage {message : DeprecationWarning('hf_xet.download_files() is deprecated. Use XetSession().new_file_download_group().start_download_file() instead.'), category : 'DeprecationWarning', filename : '/home/runner/work/huggingface_hub/huggingface_hub/src/huggingface_hub/utils/_validators.py', lineno : 88, line : None}>])
```

This PR updates this unit test to filter out unrelated deprecation warnings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to a unit test assertion and only affect how warnings are filtered/validated during test execution.
> 
> **Overview**
> Makes `test_download_bucket_files_skips_missing_first_file` resilient to extra warnings by filtering the captured warnings to only those mentioning the missing file, instead of asserting an exact warning count.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 021604649fbe2f22ab356ed924c2696477a8ed97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->