### PR TITLE
[CLI] Add hf spaces duplicate command

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -1078,6 +1078,18 @@ Use `hf spaces settings` to update the settings of a Space.
 - `--sleep-time`: idle time in seconds before the Space sleeps. Use `-1` to never sleep. Only available on upgraded hardware (see the [Spaces sleep time docs](https://huggingface.co/docs/hub/spaces-gpus#sleep-time)).
 - `--hardware`: hardware flavor (e.g. `cpu-basic`, `t4-medium`, `l4x4`). Run `hf spaces hardware` to see all options.
 
+### Duplicate a Space
+
+Use `hf spaces duplicate` to copy a Space into your namespace. By default the new Space inherits the source visibility, hardware, secrets, and variables; pass flags to override at duplicate time.
+
+```bash
+>>> hf spaces duplicate username/my-space
+>>> hf spaces duplicate username/my-space my-copy --private
+>>> hf spaces duplicate username/my-space my-copy --hardware l4x4 --secrets HF_TOKEN -v hf://buckets/org/b:/data
+```
+
+Run `hf spaces duplicate --help` for the full flag list, including `--public`/`--protected`, `--storage`, `--sleep-time`, `--secrets-file`, `--env-file`, and `--exist-ok`.
+
 ### Manage Space secrets
 
 Use `hf spaces secrets ls` to list secrets on a Space, `hf spaces secrets add` to add or update one or more secrets, and `hf spaces secrets delete` to remove one. Pass `--secrets-file PATH` to load secrets from a `.env`-style file. Existing keys are overwritten.

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -1038,6 +1038,18 @@ Use `hf spaces card` to fetch the Space card (README) for a Space. By default, p
 >>> hf spaces card mteb/leaderboard --text
 ```
 
+### Duplicate a Space
+
+Use `hf spaces duplicate` to copy a Space into your namespace. By default the new Space inherits the source visibility, hardware, secrets, and variables; pass flags to override at duplicate time.
+
+```bash
+>>> hf spaces duplicate username/my-space
+>>> hf spaces duplicate username/my-space my-copy --private
+>>> hf spaces duplicate username/my-space my-copy --hardware l4x4 --secrets HF_TOKEN -v hf://buckets/org/b:/data
+```
+
+Run `hf spaces duplicate --help` for the full flag list, including `--public`/`--protected`, `--storage`, `--sleep-time`, `--secrets-file`, `--env-file`, and `--exist-ok`.
+
 > [!TIP]
 > Pausing or restarting a Space tears down its container, so anything written to the ephemeral filesystem is lost. To persist data across restarts, mount a Volume or bucket with `hf spaces volumes set` (run `hf spaces volumes --help` for details).
 
@@ -1077,18 +1089,6 @@ Use `hf spaces settings` to update the settings of a Space.
 
 - `--sleep-time`: idle time in seconds before the Space sleeps. Use `-1` to never sleep. Only available on upgraded hardware (see the [Spaces sleep time docs](https://huggingface.co/docs/hub/spaces-gpus#sleep-time)).
 - `--hardware`: hardware flavor (e.g. `cpu-basic`, `t4-medium`, `l4x4`). Run `hf spaces hardware` to see all options.
-
-### Duplicate a Space
-
-Use `hf spaces duplicate` to copy a Space into your namespace. By default the new Space inherits the source visibility, hardware, secrets, and variables; pass flags to override at duplicate time.
-
-```bash
->>> hf spaces duplicate username/my-space
->>> hf spaces duplicate username/my-space my-copy --private
->>> hf spaces duplicate username/my-space my-copy --hardware l4x4 --secrets HF_TOKEN -v hf://buckets/org/b:/data
-```
-
-Run `hf spaces duplicate --help` for the full flag list, including `--public`/`--protected`, `--storage`, `--sleep-time`, `--secrets-file`, `--env-file`, and `--exist-ok`.
 
 ### Manage Space secrets
 

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -3559,8 +3559,8 @@ $ hf spaces duplicate [OPTIONS] FROM_ID [TO_ID]
 
 **Arguments**:
 
-* `FROM_ID`: Source Space ID to duplicate (e.g. `username/my-space`).  [required]
-* `[TO_ID]`: Destination Space ID (e.g. `myorg/my-copy`). Defaults to your namespace with the same Space name.
+* `FROM_ID`: The source space ID (e.g. `username/my-space`).  [required]
+* `[TO_ID]`: Destination space ID (e.g. `myorg/my-copy`). Defaults to your namespace with the same space name.
 
 **Options**:
 
@@ -3568,7 +3568,7 @@ $ hf spaces duplicate [OPTIONS] FROM_ID [TO_ID]
 * `--public`: Whether to make the repo public. Ignored if the repo already exists.
 * `--protected`: Whether to make the Space protected (Spaces only). Ignored if the repo already exists.
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
-* `--exist-ok / --no-exist-ok`: Do not raise an error if Space already exists.  [default: no-exist-ok]
+* `--exist-ok / --no-exist-ok`: Do not raise an error if repo already exists.  [default: no-exist-ok]
 * `--hardware [cpu-basic|cpu-upgrade|cpu-performance|cpu-xl|sprx8|zero-a10g|t4-small|t4-medium|l4x1|l4x4|l40sx1|l40sx4|l40sx8|a10g-small|a10g-large|a10g-largex2|a10g-largex4|a100-large|a100x4|a100x8|h200|h200x2|h200x4|h200x8|inf2x6]`: Space hardware flavor (e.g. 'cpu-basic', 't4-medium', 'l4x4'). Run 'hf spaces hardware' to list available options.
 * `--storage [small|medium|large]`: (Deprecated, use volumes instead) Space persistent storage tier ('small', 'medium', or 'large').
 * `--sleep-time INTEGER`: Idle time in seconds after which the Space goes to sleep. Use -1 to never sleep. Only available on upgraded hardware.

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -3467,6 +3467,7 @@ $ hf spaces [OPTIONS] COMMAND [ARGS]...
 
 * `card`: Get the Space card (README) for a Space on...
 * `dev-mode`: Enable or disable dev mode on a Space.
+* `duplicate`: Duplicate a Space on the Hub.
 * `hardware`: List available hardware options for Spaces.
 * `hot-reload`: Hot-reload any Python file of a Space...
 * `info`: Get info about a space on the Hub.
@@ -3540,6 +3541,48 @@ $ hf spaces dev-mode [OPTIONS] SPACE_ID
 
 Examples
   $ hf spaces dev-mode my-user-name/deepsite
+
+Learn more
+  Use `hf <command> --help` for more information about a command.
+  Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
+
+
+### `hf spaces duplicate`
+
+Duplicate a Space on the Hub.
+
+**Usage**:
+
+```console
+$ hf spaces duplicate [OPTIONS] FROM_ID [TO_ID]
+```
+
+**Arguments**:
+
+* `FROM_ID`: Source Space ID to duplicate (e.g. `username/my-space`).  [required]
+* `[TO_ID]`: Destination Space ID (e.g. `myorg/my-copy`). Defaults to your namespace with the same Space name.
+
+**Options**:
+
+* `--private / --no-private`: Whether to create a private repo if repo doesn't exist on the Hub. Ignored if the repo already exists.
+* `--public`: Whether to make the repo public. Ignored if the repo already exists.
+* `--protected`: Whether to make the Space protected (Spaces only). Ignored if the repo already exists.
+* `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
+* `--exist-ok / --no-exist-ok`: Do not raise an error if Space already exists.  [default: no-exist-ok]
+* `--hardware [cpu-basic|cpu-upgrade|cpu-performance|cpu-xl|sprx8|zero-a10g|t4-small|t4-medium|l4x1|l4x4|l40sx1|l40sx4|l40sx8|a10g-small|a10g-large|a10g-largex2|a10g-largex4|a100-large|a100x4|a100x8|h200|h200x2|h200x4|h200x8|inf2x6]`: Space hardware flavor (e.g. 'cpu-basic', 't4-medium', 'l4x4'). Run 'hf spaces hardware' to list available options.
+* `--storage [small|medium|large]`: (Deprecated, use volumes instead) Space persistent storage tier ('small', 'medium', or 'large').
+* `--sleep-time INTEGER`: Idle time in seconds after which the Space goes to sleep. Use -1 to never sleep. Only available on upgraded hardware.
+* `-s, --secrets TEXT`: Set secret environment variables. E.g. --secrets SECRET=value or `--secrets HF_TOKEN` to pass your Hugging Face token.
+* `--secrets-file TEXT`: Read in a file of secret environment variables.
+* `-e, --env TEXT`: Set environment variables. E.g. --env ENV=value
+* `--env-file TEXT`: Read in a file of environment variables.
+* `-v, --volume TEXT`: Mount one or more volumes. Format: hf://[TYPE/]SOURCE:/MOUNT_PATH[:ro]. TYPE is one of: models, datasets, spaces, buckets. TYPE defaults to models if omitted. models, datasets and spaces are always mounted read-only. buckets are read+write by default. E.g. -v hf://org/m:/data or -v hf://datasets/org/ds:/data or -v hf://buckets/org/b:/mnt:ro
+* `--help`: Show this message and exit.
+
+Examples
+  $ hf spaces duplicate username/my-space
+  $ hf spaces duplicate username/my-space my-copy --private
+  $ hf spaces duplicate username/my-space my-copy --hardware l4x4 --secrets HF_TOKEN -v hf://buckets/org/b:/data
 
 Learn more
   Use `hf <command> --help` for more information about a command.

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -44,7 +44,7 @@ from typing_extensions import assert_never
 
 from huggingface_hub._hot_reload.client import multi_replica_reload_events
 from huggingface_hub._hot_reload.types import ApiGetReloadEventSourceData, ReloadRegion
-from huggingface_hub._space_api import SpaceHardware, SpaceStage
+from huggingface_hub._space_api import SpaceHardware, SpaceStage, SpaceStorage
 from huggingface_hub.errors import CLIError, RemoteEntryNotFoundError, RepositoryNotFoundError, RevisionNotFoundError
 from huggingface_hub.file_download import hf_hub_download
 from huggingface_hub.hf_api import ExpandSpaceProperty_T, HfApi, SpaceSort_T
@@ -58,6 +58,7 @@ from ._cli_utils import (
     EnvOpt,
     FilterOpt,
     LimitOpt,
+    PrivateOpt,
     RevisionOpt,
     SearchOpt,
     SecretsFileOpt,
@@ -65,6 +66,7 @@ from ._cli_utils import (
     TokenOpt,
     VolumesOpt,
     api_object_to_dict,
+    env_map_to_key_value_list,
     get_hf_api,
     make_expand_properties_parser,
     parse_env_map,
@@ -88,6 +90,22 @@ ExpandOpt = Annotated[
     typer.Option(
         help=f"Comma-separated properties to return. When used, only the listed properties (and id) are returned. Example: '--expand=likes,tags'. Valid: {', '.join(_EXPAND_PROPERTIES)}.",
         callback=make_expand_properties_parser(_EXPAND_PROPERTIES),
+    ),
+]
+
+PublicOpt = Annotated[
+    bool | None,
+    typer.Option(
+        "--public",
+        help="Whether to make the repo public. Ignored if the repo already exists.",
+    ),
+]
+
+ProtectedOpt = Annotated[
+    bool | None,
+    typer.Option(
+        "--protected",
+        help="Whether to make the Space protected (Spaces only). Ignored if the repo already exists.",
     ),
 ]
 
@@ -482,6 +500,83 @@ def spaces_settings(
         sleep_time=runtime.sleep_time,
     )
     out.hint(f"Use `hf spaces info {space_id}` to verify the runtime configuration.")
+
+
+@spaces_cli.command(
+    "duplicate",
+    examples=[
+        "hf spaces duplicate username/my-space",
+        "hf spaces duplicate username/my-space my-copy --private",
+        "hf spaces duplicate username/my-space my-copy --hardware l4x4 --secrets HF_TOKEN -v hf://buckets/org/b:/data",
+    ],
+)
+def spaces_duplicate(
+    from_id: Annotated[str, typer.Argument(help="Source Space ID to duplicate (e.g. `username/my-space`).")],
+    to_id: Annotated[
+        str | None,
+        typer.Argument(
+            help="Destination Space ID (e.g. `myorg/my-copy`). Defaults to your namespace with the same Space name.",
+        ),
+    ] = None,
+    private: PrivateOpt = None,
+    public: PublicOpt = None,
+    protected: ProtectedOpt = None,
+    token: TokenOpt = None,
+    exist_ok: Annotated[
+        bool,
+        typer.Option(
+            help="Do not raise an error if Space already exists.",
+        ),
+    ] = False,
+    hardware: Annotated[
+        SpaceHardware | None,
+        typer.Option(
+            "--hardware",
+            help="Space hardware flavor (e.g. 'cpu-basic', 't4-medium', 'l4x4'). Run 'hf spaces hardware' to list available options.",
+        ),
+    ] = None,
+    storage: Annotated[
+        SpaceStorage | None,
+        typer.Option(
+            "--storage",
+            help="(Deprecated, use volumes instead) Space persistent storage tier ('small', 'medium', or 'large').",
+        ),
+    ] = None,
+    sleep_time: Annotated[
+        int | None,
+        typer.Option(
+            "--sleep-time",
+            help="Idle time in seconds after which the Space goes to sleep. Use -1 to never sleep. Only available on upgraded hardware.",
+        ),
+    ] = None,
+    secrets: SecretsOpt = None,
+    secrets_file: SecretsFileOpt = None,
+    env: EnvOpt = None,
+    env_file: EnvFileOpt = None,
+    volume: VolumesOpt = None,
+) -> None:
+    """Duplicate a Space on the Hub."""
+    api = get_hf_api(token=token)
+    repo_url = api.duplicate_repo(
+        from_id=from_id,
+        to_id=to_id,
+        repo_type="space",
+        visibility="private" if private else "public" if public else "protected" if protected else None,  # type: ignore [arg-type]
+        token=token,
+        exist_ok=exist_ok,
+        space_hardware=hardware,
+        space_storage=storage,
+        space_sleep_time=sleep_time,
+        space_secrets=env_map_to_key_value_list(parse_env_map(secrets, secrets_file)),
+        space_variables=env_map_to_key_value_list(parse_env_map(env, env_file)),
+        space_volumes=parse_volumes(volume),
+    )
+    out.result("Space duplicated", from_id=from_id, to_id=repo_url.repo_id, url=str(repo_url))
+    out.hint(f"Use `hf spaces info {repo_url.repo_id}` to monitor the runtime stage.")
+    out.hint(
+        f"Source secrets and variables are not copied. "
+        f"Run `hf spaces secrets ls {from_id}` and `hf spaces variables ls {from_id}` to see what to set on the new Space."
+    )
 
 
 @spaces_cli.command(

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -511,11 +511,11 @@ def spaces_settings(
     ],
 )
 def spaces_duplicate(
-    from_id: Annotated[str, typer.Argument(help="Source Space ID to duplicate (e.g. `username/my-space`).")],
+    from_id: Annotated[str, typer.Argument(help="The source space ID (e.g. `username/my-space`).")],
     to_id: Annotated[
         str | None,
         typer.Argument(
-            help="Destination Space ID (e.g. `myorg/my-copy`). Defaults to your namespace with the same Space name.",
+            help="Destination space ID (e.g. `myorg/my-copy`). Defaults to your namespace with the same space name.",
         ),
     ] = None,
     private: PrivateOpt = None,
@@ -525,7 +525,7 @@ def spaces_duplicate(
     exist_ok: Annotated[
         bool,
         typer.Option(
-            help="Do not raise an error if Space already exists.",
+            help="Do not raise an error if repo already exists.",
         ),
     ] = False,
     hardware: Annotated[


### PR DESCRIPTION
Adds `hf spaces duplicate <from_id> [<to_id>]` so duplicate sits alongside the other `hf spaces` lifecycle/management commands (`pause`, `restart`, `settings`, `secrets`, `variables`, `volumes`, `card`, `logs`, `hardware`).

```bash
hf spaces duplicate username/my-space
hf spaces duplicate username/my-space my-copy --private
hf spaces duplicate username/my-space my-copy --hardware l4x4 --secrets HF_TOKEN -v hf://buckets/org/b:/data
```

## Design notes

- **Wraps `duplicate_repo`, not `duplicate_space`** — the latter is `@_deprecate_method(version="2.0", ...)` at `hf_api.py:8468`. `duplicate_repo` already plumbs through all the Space-specific args.
- **Why a new command when `hf repos duplicate --type space` exists?** Same rationale as `hf spaces card` (#4118): per-type ergonomic wrapper keeps the spaces namespace internally consistent.
- **Flag names** — `--hardware`, `--sleep-time` match `hf spaces settings` (#4163), not `--flavor` from `hf repos duplicate`. Internal-namespace consistency over cross-namespace mirror.
- **Flag set is a full mirror of `hf repos duplicate` minus `--type`.**
- **`PublicOpt` / `ProtectedOpt` are copy-pasted verbatim** from `cli/repos.py:77–91`. Could be lifted to `_cli_utils.py` for one source of truth — happy to do that as a small follow-up.
- **No tests** per #4155 review feedback. **No confirmation prompt** — duplicate is creation, not destruction.

## Hint chain

After a successful duplicate:

```
Hint: Use `hf spaces info <to_id>` to monitor the runtime stage.
Hint: Source secrets and variables are not copied. Run `hf spaces secrets ls <from_id>`
      and `hf spaces variables ls <from_id>` to see what to set on the new Space.
```

`secrets ls` / `variables ls` already emit hints with the `add` syntax, so an agent chains through without this command pre-fetching anything.

## Smoke test

```text
$ hf spaces duplicate multimodalart/dreambooth-training davanstrien/duplicate-smoke-test --private
# 400: "Hardware must be specified when duplicating a Space"  ← server validation surfaces cleanly

$ hf spaces duplicate multimodalart/dreambooth-training davanstrien/duplicate-smoke-test --private --hardware cpu-basic
# Space duplicated  + hint chain renders correctly

# Carry-over check:
$ hf spaces variables add davanstrien/duplicate-smoke-test -e CARRY_TEST_VAR=hello
$ hf spaces secrets   add davanstrien/duplicate-smoke-test -s CARRY_TEST_SECRET=shh
$ hf spaces duplicate davanstrien/duplicate-smoke-test davanstrien/duplicate-carry-test-2 --private --hardware cpu-basic
$ hf spaces variables ls davanstrien/duplicate-carry-test-2   # → no results
$ hf spaces secrets   ls davanstrien/duplicate-carry-test-2   # → no results
# Confirmed: secrets and variables do not carry over from source.
```

## Found while testing (separate follow-up)

`duplicate_repo` (`hf_api.py:8466`) crashes with `KeyError: 'url'` when `exist_ok=True` hits a 409 — the swallow path falls through to `r.json()["url"]` on what's actually an error body. Independent of this PR; will open a separate fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new CLI surface that creates/duplicates Spaces and forwards many runtime/visibility/env options to the Hub API, so mistakes could create misconfigured or incorrectly visible Spaces. Changes are localized to CLI wiring and docs, with no core auth or data-path refactors.
> 
> **Overview**
> Adds a new `hf spaces duplicate FROM_ID [TO_ID]` command that wraps `HfApi.duplicate_repo(..., repo_type="space")`, supporting visibility flags plus Space runtime overrides like `--hardware`, `--sleep-time`, deprecated `--storage`, and optional secrets/vars/volume mounts.
> 
> Updates the CLI guide and generated CLI reference to document the new command and its flags, and prints post-run hints (including that source secrets/variables are not copied).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20ba28038defe35a77361fe8a3c308be21b35dac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->