### PR TITLE
[CLI] Check Homebrew registry for updates when installed via brew

### DIFF
--- a/src/huggingface_hub/cli/_cli_utils.py
+++ b/src/huggingface_hub/cli/_cli_utils.py
@@ -1130,8 +1130,11 @@ def _check_cli_update(library: Literal["huggingface_hub", "transformers"]) -> No
     Path(constants.CHECK_FOR_UPDATE_DONE_PATH).parent.mkdir(parents=True, exist_ok=True)
     Path(constants.CHECK_FOR_UPDATE_DONE_PATH).touch()
 
-    # Check latest version from PyPI
-    latest_version = _fetch_latest_pypi_version(library)
+    # Check latest version from the appropriate registry
+    if library == "huggingface_hub" and installation_method() == "brew":
+        latest_version = _fetch_latest_brew_version()
+    else:
+        latest_version = _fetch_latest_pypi_version(library)
     if latest_version is None or current_version == latest_version:
         return
 
@@ -1158,6 +1161,17 @@ def _fetch_latest_pypi_version(library: str) -> str | None:
         return response.json()["info"]["version"]
     except Exception:
         logger.debug("Error while fetching latest version from PyPI.", exc_info=True)
+        return None
+
+
+def _fetch_latest_brew_version() -> str | None:
+    """Fetch the latest version of the `hf` formula from the Homebrew registry. Returns None if the request fails."""
+    try:
+        response = get_session().get("https://formulae.brew.sh/api/formula/hf.json", timeout=2)
+        hf_raise_for_status(response)
+        return response.json()["versions"]["stable"]
+    except Exception:
+        logger.debug("Error while fetching latest version from Homebrew.", exc_info=True)
         return None
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When `huggingface_hub` is installed via Homebrew, the CLI update checker now queries the Homebrew registry (`https://formulae.brew.sh/api/formula/hf.json`) instead of PyPI. This fixes the issue where `hf update` suggests an update that isn't yet available in the brew registry, leading to a confusing experience:

1. User gets "A new version of huggingface_hub (X.Y.Z) is available!" hint
2. User runs `hf update` (which runs `brew upgrade hf`)
3. Brew doesn't have the new version yet → nothing happens
4. User is confused

**What changed:**
- Added `_fetch_latest_brew_version()` that hits `https://formulae.brew.sh/api/formula/hf.json` and reads `.versions.stable`
- Modified `_check_cli_update` to use the brew registry when `installation_method() == "brew"` (only for `huggingface_hub`)
- Non-brew installs continue to check PyPI as before

The existing `installation_method()` utility already reliably detects brew installs. The new brew version fetch follows the same pattern as the PyPI fetch (2s timeout, graceful fallback to `None` on failure).
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://huggingface.slack.com/archives/C02V5EA0A95/p1778076748644619?thread_ts=1778076748.644619&cid=C02V5EA0A95)

<div><a href="https://cursor.com/agents/bc-65726699-fd58-5a5b-a0e0-bfb207e78d33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-65726699-fd58-5a5b-a0e0-bfb207e78d33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

