### PR TITLE
[Buckets] Fix local file scanning: follow symlinks, warn on errors, resolve paths

### DIFF
--- a/src/huggingface_hub/_buckets.py
+++ b/src/huggingface_hub/_buckets.py
@@ -411,6 +411,8 @@ def _stat_local(path: str) -> tuple[int, float] | None:
 def _list_local_files(local_path: str) -> Iterator[tuple[str, int, float]]:
     """List all files in a local directory.
 
+    Follows symlinks so that symlinked subdirectories are traversed.
+
     Yields:
         tuple: (relative_path, size, mtime_ms) for each file
     """
@@ -418,7 +420,10 @@ def _list_local_files(local_path: str) -> Iterator[tuple[str, int, float]]:
     if not os.path.isdir(local_path):
         raise ValueError(f"Local path must be a directory: {local_path}")
 
-    for root, _, files in os.walk(local_path):
+    def _on_walk_error(error: OSError) -> None:
+        logger.warning(f"Cannot list directory (skipping): {error}")
+
+    for root, _, files in os.walk(local_path, followlinks=True, onerror=_on_walk_error):
         for filename in files:
             full_path = os.path.join(root, filename)
             stat_info = _stat_local(full_path)
@@ -565,6 +570,13 @@ def _compute_sync_plan(
     if not is_upload and not is_download:
         raise ValueError("One of source or dest must be a bucket path (hf://buckets/...) and the other must be local.")
 
+    # Resolve local paths to absolute so the plan output is unambiguous
+    # and plan files work correctly regardless of CWD.
+    if is_upload:
+        source = os.path.abspath(source)
+    else:
+        dest = os.path.abspath(dest)
+
     plan = SyncPlan(
         source=source,
         dest=dest,
@@ -574,7 +586,7 @@ def _compute_sync_plan(
     remote_total: int | None = None
     if is_upload:
         # Local -> Remote
-        local_path = os.path.abspath(source)
+        local_path = source
         bucket_id, prefix = _parse_bucket_path(dest)
 
         if not os.path.isdir(local_path):
@@ -674,7 +686,7 @@ def _compute_sync_plan(
     else:
         # Remote -> Local (download)
         bucket_id, prefix = _parse_bucket_path(source)
-        local_path = os.path.abspath(dest)
+        local_path = dest
 
         # Get remote and local file lists
         remote_files = {}

--- a/tests/test_buckets_cli.py
+++ b/tests/test_buckets_cli.py
@@ -20,7 +20,7 @@ import pytest
 from typer.testing import CliRunner, Result
 
 from huggingface_hub import HfApi
-from huggingface_hub._buckets import BUCKET_PREFIX, _split_bucket_id_and_prefix
+from huggingface_hub._buckets import BUCKET_PREFIX, _list_local_files, _split_bucket_id_and_prefix
 from huggingface_hub.cli.hf import app
 from huggingface_hub.errors import BucketNotFoundError, EntryNotFoundError, HfHubHTTPError
 
@@ -1028,6 +1028,52 @@ def _make_local_dir(tmp_path: Path, files: dict[str, str]) -> Path:
     return data_dir
 
 
+# -- _list_local_files unit tests (no Hub access needed) --
+
+
+class TestListLocalFiles:
+    def test_follows_symlinked_directories(self, tmp_path: Path):
+        """Symlinked directories should be traversed."""
+        # Create a real directory with files
+        real_dir = tmp_path / "real"
+        real_dir.mkdir()
+        (real_dir / "file1.txt").write_text("a")
+        (real_dir / "nested").mkdir()
+        (real_dir / "nested" / "file2.txt").write_text("b")
+
+        # Create a separate directory that symlinks to the real one
+        root = tmp_path / "root"
+        root.mkdir()
+        (root / "direct.txt").write_text("c")
+        (root / "linked").symlink_to(real_dir)
+
+        files = {path for path, _, _ in _list_local_files(str(root))}
+        assert files == {"direct.txt", "linked/file1.txt", "linked/nested/file2.txt"}
+
+    def test_warns_on_inaccessible_directory(self, tmp_path: Path, caplog):
+        """Inaccessible directories should log a warning, not crash."""
+        import logging
+        import os
+
+        root = tmp_path / "root"
+        root.mkdir()
+        (root / "ok.txt").write_text("ok")
+        no_access = root / "noaccess"
+        no_access.mkdir()
+        (no_access / "hidden.txt").write_text("hidden")
+        os.chmod(str(no_access), 0o000)
+
+        try:
+            with caplog.at_level(logging.WARNING, logger="huggingface_hub._buckets"):
+                files = {path for path, _, _ in _list_local_files(str(root))}
+
+            assert "ok.txt" in files
+            assert "noaccess/hidden.txt" not in files
+            assert any("Cannot list directory" in msg for msg in caplog.messages)
+        finally:
+            os.chmod(str(no_access), 0o755)
+
+
 # -- Upload tests --
 
 
@@ -1282,6 +1328,10 @@ def test_sync_plan_saves_file(bucket_write: str, tmp_path: Path):
     header = json.loads(lines[0])
     assert header["type"] == "header"
     assert header["summary"]["uploads"] == 1
+    # Source path in the plan should be resolved to an absolute path
+    import os
+
+    assert os.path.isabs(header["source"])
 
     op = json.loads(lines[1])
     assert op["type"] == "operation"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Investigating a user report where `hf buckets sync` appeared to cap local file scanning at exactly 2500 files. After analysis, the most likely cause was **user error** (different source directories between runs -- their output shows `./step10000` as source in the first run but `.` in the second), but the investigation uncovered three real improvements:

- **Follow symlinks in `os.walk`**: Added `followlinks=True` so symlinked subdirectories are traversed. Previously, entire directory trees behind symlinks were silently skipped, which is common in ML workloads (e.g. symlinked checkpoint dirs on shared storage).
- **Warn on inaccessible directories**: Added `onerror` callback to `os.walk` that logs a warning when a directory can't be listed (e.g. permission denied), instead of silently skipping it.
- **Resolve local paths to absolute in `SyncPlan`**: The "Sync plan:" output now shows the absolute path for local directories, making it immediately obvious what directory is being synced. This also makes `--plan` files work correctly regardless of CWD when later applied with `--apply`.

### Analysis of the reported issue

The user reported scanning exactly 2500 files locally, but on re-run with `--verbose` seeing 4356 files. Key evidence:
- First run output: `Sync plan: ./step10000 -> hf://buckets/allenai/test/step1000`
- Second run output: `Sync plan: . -> hf://buckets/allenai/test/step1000`

The source paths differ (`./step10000` vs `.`), strongly suggesting the user pointed to different directories between runs. The `--verbose` flag does NOT affect scanning at all in the code. There is no hardcoded 2500 limit anywhere in the client.

That said, if the user had symlinked subdirectories or permission issues, those would now be handled properly with these changes.

### Example output (before vs after)

Before:
```
Sync plan: . -> hf://buckets/user/my-bucket
```

After:
```
Sync plan: /home/user/data/step10000 -> hf://buckets/user/my-bucket
```

### Tests

Added `TestListLocalFiles` class with two unit tests (no Hub access needed):
- `test_follows_symlinked_directories`: verifies files behind symlinked dirs are found
- `test_warns_on_inaccessible_directory`: verifies warning is logged and scan continues

Also added an assertion to the existing `test_sync_plan_saves_file` verifying the plan's source path is absolute.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://huggingface.slack.com/archives/D0A9313SS3G/p1778167923095649?thread_ts=1778167923.095649&cid=D0A9313SS3G)

<div><a href="https://cursor.com/agents/bc-70190835-d341-5b9f-a3f1-ae484fdfd36b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-70190835-d341-5b9f-a3f1-ae484fdfd36b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

