### PR TITLE
Fix hint message to use 'hf skills update'

### DIFF
--- a/src/huggingface_hub/cli/system.py
+++ b/src/huggingface_hub/cli/system.py
@@ -45,6 +45,6 @@ def update() -> None:
     if returncode != 0:
         raise typer.Exit(code=returncode)
     out.hint(
-        "You may also want to run `hf skills upgrade` to refresh any installed skills "
+        "You may also want to run `hf skills update` to refresh any installed skills "
         "so your AI agent sees the latest command surface."
     )


### PR DESCRIPTION
with v1.14 it seems the command changed? (got an error with `hf skills upgrade`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only a CLI hint string and does not affect update behavior or data handling.
> 
> **Overview**
> Fixes the post-`hf update` hint in `cli/system.py` to recommend `hf skills update` (instead of the outdated `hf skills upgrade`) when refreshing installed skills after updating the CLI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ed386bc33bdad09331cf7a6d57abc31cea0ce99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->