### PR TITLE
[Download] Fix snapshot bar inflation on http_get retry

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -393,6 +393,14 @@ def http_get(
             resume_size = 0
 
         total: int | None = _get_file_length_from_http_response(response)
+        if total is None:
+            # Hub serves compressible text files (e.g. vocab.json) with
+            # `Content-Encoding: gzip` and `Transfer-Encoding: chunked`, so the
+            # response carries no `Content-Length`. Fall back to the caller's
+            # `expected_size` (always known from the metadata HEAD on the hf_hub
+            # path) so the progress bar — and any aggregating wrapper such as
+            # snapshot_download's `_AggregatedTqdm` — still sees the file size.
+            total = expected_size
 
         if displayed_filename is None:
             displayed_filename = url

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -384,22 +384,18 @@ def http_get(
             temp_file.seek(0)
             temp_file.truncate()
             if _tqdm_bar is not None:
-                # When the progress bar is reused across retries, its counter has
-                # already been advanced by `resume_size` worth of chunks from
-                # earlier attempts. Those bytes are gone from disk now, so roll
-                # the counter back to keep the upcoming full re-download from
-                # double-counting (e.g. ending at 130/100 on a 100-byte file).
+                # When the progress bar is reused across retries, its counter has already been advanced by `resume_size`
+                # worth of chunks from earlier attempts. Those bytes are gone from disk now, so roll the counter back
+                # to keep the upcoming full re-download from double-counting (e.g. ending at 130/100 on a 100-byte file).
                 _tqdm_bar.update(-resume_size)
             resume_size = 0
 
         total: int | None = _get_file_length_from_http_response(response)
         if total is None:
-            # Hub serves compressible text files (e.g. vocab.json) with
-            # `Content-Encoding: gzip` and `Transfer-Encoding: chunked`, so the
-            # response carries no `Content-Length`. Fall back to the caller's
-            # `expected_size` (always known from the metadata HEAD on the hf_hub
-            # path) so the progress bar — and any aggregating wrapper such as
-            # snapshot_download's `_AggregatedTqdm` — still sees the file size.
+            # Hub serves compressible text files (e.g. vocab.json) with `Content-Encoding: gzip` and
+            # `Transfer-Encoding: chunked`, so the response carries no `Content-Length`. Fall back to the caller's
+            # `expected_size` (always known from the metadata HEAD on the hf_hub path) so the progress bar, and any
+            # aggregating wrapper such as snapshot_download's `_AggregatedTqdm` — still sees the file size.
             total = expected_size
 
         if displayed_filename is None:
@@ -457,10 +453,8 @@ def http_get(
                     expected_size=expected_size,
                     tqdm_class=tqdm_class,
                     _nb_retries=_nb_retries - 1,
-                    # Reuse the existing progress bar across retries so a custom
-                    # `tqdm_class` (e.g. snapshot_download's `_AggregatedTqdm`,
-                    # which mutates a shared parent bar in `__init__`) is not
-                    # re-instantiated and does not double-count `total`/`initial`.
+                    # Reuse the existing progress bar across retries so a custom `tqdm_class` (e.g. snapshot_download's `_AggregatedTqdm`,
+                    # which mutates a shared parent bar in `__init__`) is not re-instantiated and does not double-count `total`/`initial`.
                     _tqdm_bar=progress,
                 )
 

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -442,7 +442,11 @@ def http_get(
                     expected_size=expected_size,
                     tqdm_class=tqdm_class,
                     _nb_retries=_nb_retries - 1,
-                    _tqdm_bar=_tqdm_bar,
+                    # Reuse the existing progress bar across retries so a custom
+                    # `tqdm_class` (e.g. snapshot_download's `_AggregatedTqdm`,
+                    # which mutates a shared parent bar in `__init__`) is not
+                    # re-instantiated and does not double-count `total`/`initial`.
+                    _tqdm_bar=progress,
                 )
 
     if expected_size is not None and expected_size != temp_file.tell():

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -383,6 +383,13 @@ def http_get(
         if resume_size > 0 and response.status_code == 200:
             temp_file.seek(0)
             temp_file.truncate()
+            if _tqdm_bar is not None:
+                # When the progress bar is reused across retries, its counter has
+                # already been advanced by `resume_size` worth of chunks from
+                # earlier attempts. Those bytes are gone from disk now, so roll
+                # the counter back to keep the upcoming full re-download from
+                # double-counting (e.g. ending at 130/100 on a 100-byte file).
+                _tqdm_bar.update(-resume_size)
             resume_size = 0
 
         total: int | None = _get_file_length_from_http_response(response)

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -1346,6 +1346,89 @@ class TestHttpGet:
         assert parent.total == 100
         assert parent.n == 100
 
+    def test_http_get_retry_rolls_back_reused_bar_when_range_ignored(self):
+        """When a retry's server ignores Range and returns 200 with the full body,
+        the reused progress bar must be rolled back by ``resume_size`` so the
+        upcoming full re-download is not double-counted.
+
+        Without the rollback, a 100-byte file with a 30-byte first attempt
+        followed by a Range-ignored 200 retry would end at parent.n = 130.
+        """
+
+        class _Parent:
+            def __init__(self):
+                self.total = 0
+                self.n = 0
+
+            def refresh(self):
+                pass
+
+            def update(self, n):
+                self.n += n
+
+        parent = _Parent()
+
+        class _AggregatedLikeTqdm:
+            def __init__(self, *args, **kwargs):
+                total = kwargs.pop("total", None)
+                if total is not None:
+                    parent.total += total
+                    parent.refresh()
+                initial = kwargs.pop("initial", 0)
+                if initial:
+                    parent.update(initial)
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_value, traceback):
+                pass
+
+            def update(self, n=1):
+                parent.update(n)
+
+        def _iter_first() -> Iterable[bytes]:
+            yield b"A" * 30
+            raise httpx.TimeoutException("first timeout")
+
+        def _iter_second() -> Iterable[bytes]:
+            # Server ignores Range header and returns full body
+            yield b"B" * 100
+
+        r1 = Mock()
+        r1.status_code = 200
+        r1.headers = {"Content-Length": "100"}
+        r1.iter_bytes.return_value = _iter_first()
+
+        r2 = Mock()
+        r2.status_code = 200  # 200, not 206 — Range was ignored on the retry
+        r2.headers = {"Content-Length": "100"}
+        r2.iter_bytes.return_value = _iter_second()
+
+        responses = iter([r1, r2])
+
+        @contextmanager
+        def _mock_stream(*args, **kwargs):
+            yield next(responses)
+
+        with patch("huggingface_hub.file_download.http_stream_backoff", side_effect=_mock_stream):
+            temp_file = io.BytesIO()
+            http_get(
+                "fake_url",
+                temp_file=temp_file,
+                expected_size=100,
+                tqdm_class=_AggregatedLikeTqdm,
+            )
+
+        # File on disk holds only the retry's full body (first attempt was truncated).
+        assert temp_file.tell() == 100
+        assert temp_file.getvalue() == b"B" * 100
+
+        # Parent bar lands exactly on file_size, not 130 (which is what the
+        # bug would produce without the rollback).
+        assert parent.total == 100
+        assert parent.n == 100
+
 
 class CreateSymlinkTest(unittest.TestCase):
     @unittest.skipIf(os.name == "nt", "No symlinks on Windows")

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -1244,6 +1244,108 @@ class TestHttpGet:
         assert temp_file.tell() == 100
         assert temp_file.getvalue() == b"B" * 100
 
+    def test_http_get_retry_reuses_tqdm_class_instance(self):
+        """Retries must not re-instantiate the user-supplied tqdm_class.
+
+        Regression test for the snapshot_download bug where ``_AggregatedTqdm``
+        was re-constructed on every retry, inflating the shared bar's ``total``
+        by ``expected_size`` and advancing ``n`` by ``resume_size`` per retry.
+
+        This test uses a stand-in ``tqdm_class`` that aggregates into a shared
+        ``parent`` object (same shape as ``_AggregatedTqdm``) and asserts the
+        parent ends with exactly one file's worth of total/n after two
+        transient failures.
+        """
+
+        class _Parent:
+            def __init__(self):
+                self.total = 0
+                self.n = 0
+
+            def refresh(self):
+                pass
+
+            def update(self, n):
+                self.n += n
+
+        parent = _Parent()
+
+        class _AggregatedLikeTqdm:
+            instances = 0
+
+            def __init__(self, *args, **kwargs):
+                type(self).instances += 1
+                total = kwargs.pop("total", None)
+                if total is not None:
+                    parent.total += total
+                    parent.refresh()
+                initial = kwargs.pop("initial", 0)
+                if initial:
+                    parent.update(initial)
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_value, traceback):
+                pass
+
+            def update(self, n=1):
+                parent.update(n)
+
+        def _iter_content_1() -> Iterable[bytes]:
+            yield b"A" * 30
+            raise httpx.TimeoutException("Fake timeout #1")
+
+        def _iter_content_2() -> Iterable[bytes]:
+            yield b"B" * 25
+            raise httpx.TimeoutException("Fake timeout #2")
+
+        def _iter_content_3() -> Iterable[bytes]:
+            yield b"C" * 45  # remaining 100 - 30 - 25
+
+        r1 = Mock()
+        r1.status_code = 200
+        r1.headers = {"Content-Length": "100"}
+        r1.iter_bytes.return_value = _iter_content_1()
+
+        r2 = Mock()
+        r2.status_code = 206
+        r2.headers = {"Content-Length": "70", "Content-Range": "bytes 30-99/100"}
+        r2.iter_bytes.return_value = _iter_content_2()
+
+        r3 = Mock()
+        r3.status_code = 206
+        r3.headers = {"Content-Length": "45", "Content-Range": "bytes 55-99/100"}
+        r3.iter_bytes.return_value = _iter_content_3()
+
+        responses = iter([r1, r2, r3])
+
+        @contextmanager
+        def _mock_stream(*args, **kwargs):
+            yield next(responses)
+
+        with patch("huggingface_hub.file_download.http_stream_backoff", side_effect=_mock_stream):
+            temp_file = io.BytesIO()
+            http_get(
+                "fake_url",
+                temp_file=temp_file,
+                expected_size=100,
+                tqdm_class=_AggregatedLikeTqdm,
+            )
+
+        # File on disk is correct.
+        assert temp_file.tell() == 100
+        assert temp_file.getvalue() == b"A" * 30 + b"B" * 25 + b"C" * 45
+
+        # The wrapper class was constructed exactly once for the whole download,
+        # not once per retry.
+        assert _AggregatedLikeTqdm.instances == 1
+
+        # Shared parent bar reflects one file's total and full progress, not
+        # 3x the file size (one per attempt).
+        assert parent.total == 100
+        assert parent.n == 100
+
 
 class CreateSymlinkTest(unittest.TestCase):
     @unittest.skipIf(os.name == "nt", "No symlinks on Windows")

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -1246,12 +1246,7 @@ class TestHttpGet:
 
     @staticmethod
     def _make_aggregated_tqdm():
-        """Create a (tracker, tqdm_class) pair mimicking _AggregatedTqdm.
-
-        The tracker accumulates total/n/instances the same way the real
-        _AggregatedTqdm's parent bar does, so tests can assert correct
-        progress accounting without pulling in the real implementation.
-        """
+        """Mimic _AggregatedTqdm defined in snapshot_download."""
 
         class _Tracker:
             def __init__(self):
@@ -1305,8 +1300,7 @@ class TestHttpGet:
     def test_http_get_retry_reuses_tqdm_class_instance(self):
         """Retries must not re-instantiate the user-supplied tqdm_class.
 
-        Regression test: _AggregatedTqdm was re-constructed on every retry,
-        inflating the shared bar's total and advancing n per retry.
+        Regression test for https://github.com/huggingface/huggingface_hub/issues/4208.
         """
         tracker, tqdm_class = self._make_aggregated_tqdm()
 
@@ -1338,8 +1332,9 @@ class TestHttpGet:
         assert tracker.n == 100
 
     def test_http_get_retry_rolls_back_reused_bar_when_range_ignored(self):
-        """When a retry server ignores Range and returns 200, the reused bar
-        must be rolled back so the full re-download is not double-counted.
+        """Test reused bar rolls back when file is re-downloaded from scratch (when Range is ignored by the server).
+
+        Regression test for https://github.com/huggingface/huggingface_hub/issues/4208.
         """
         tracker, tqdm_class = self._make_aggregated_tqdm()
 
@@ -1361,15 +1356,20 @@ class TestHttpGet:
         assert tracker.n == 100
 
     def test_http_get_falls_back_to_expected_size_when_response_lacks_content_length(self):
-        """When the response is gzip+chunked (no Content-Length), the bar's
-        total must fall back to expected_size so _AggregatedTqdm still works.
+        """Test correct progress on small files when the response is gzip+chunked (i.e. no Content-Length).
+
+        Regression test for https://github.com/huggingface/huggingface_hub/issues/4208.
         """
         tracker, tqdm_class = self._make_aggregated_tqdm()
 
         temp_file = self._http_get_with_mocked_responses(
             [
                 self._mock_response(
-                    headers={"Content-Encoding": "gzip", "Transfer-Encoding": "chunked", "Content-Type": "application/json"},
+                    headers={
+                        "Content-Encoding": "gzip",
+                        "Transfer-Encoding": "chunked",
+                        "Content-Type": "application/json",
+                    },
                     iter_bytes=iter([b"X" * 100]),
                 ),
             ],

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -1429,6 +1429,86 @@ class TestHttpGet:
         assert parent.total == 100
         assert parent.n == 100
 
+    def test_http_get_falls_back_to_expected_size_when_response_lacks_content_length(self):
+        """When the response is gzip+chunked (Content-Length absent), the bar's
+        total must fall back to the caller's ``expected_size``.
+
+        Reproduces the Hub's behavior for compressible text files served from
+        huggingface.co (e.g. vocab.json: ``Content-Encoding: gzip`` +
+        ``Transfer-Encoding: chunked``, no Content-Length). Without the
+        fallback, snapshot_download's ``_AggregatedTqdm`` is constructed with
+        ``total=None`` and the file never contributes to the parent bar.
+        """
+
+        class _Parent:
+            def __init__(self):
+                self.total = 0
+                self.n = 0
+
+            def refresh(self):
+                pass
+
+            def update(self, n):
+                self.n += n
+
+        parent = _Parent()
+
+        class _AggregatedLikeTqdm:
+            def __init__(self, *args, **kwargs):
+                total = kwargs.pop("total", None)
+                if total is not None:
+                    parent.total += total
+                    parent.refresh()
+                initial = kwargs.pop("initial", 0)
+                if initial:
+                    parent.update(initial)
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_value, traceback):
+                pass
+
+            def update(self, n=1):
+                parent.update(n)
+
+        def _iter_chunked_gzip() -> Iterable[bytes]:
+            # Decompressed content: 100 bytes. Real httpx already returns the
+            # decompressed body via iter_bytes, so we just yield 100 bytes here.
+            yield b"X" * 100
+
+        # Real-world shape: gzip + chunked + no Content-Length.
+        response = Mock()
+        response.status_code = 200
+        response.headers = {
+            "Content-Encoding": "gzip",
+            "Transfer-Encoding": "chunked",
+            "Content-Type": "application/json",
+        }
+        response.iter_bytes.return_value = _iter_chunked_gzip()
+
+        @contextmanager
+        def _mock_stream(*args, **kwargs):
+            yield response
+
+        with patch("huggingface_hub.file_download.http_stream_backoff", side_effect=_mock_stream):
+            temp_file = io.BytesIO()
+            http_get(
+                "fake_url",
+                temp_file=temp_file,
+                expected_size=100,
+                tqdm_class=_AggregatedLikeTqdm,
+            )
+
+        # Bytes-on-disk are correct.
+        assert temp_file.tell() == 100
+        assert temp_file.getvalue() == b"X" * 100
+
+        # Without the expected_size fallback, parent.total stays at 0 and the
+        # file silently fails to contribute to the snapshot bar.
+        assert parent.total == 100
+        assert parent.n == 100
+
 
 class CreateSymlinkTest(unittest.TestCase):
     @unittest.skipIf(os.name == "nt", "No symlinks on Windows")

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -1244,270 +1244,142 @@ class TestHttpGet:
         assert temp_file.tell() == 100
         assert temp_file.getvalue() == b"B" * 100
 
+    @staticmethod
+    def _make_aggregated_tqdm():
+        """Create a (tracker, tqdm_class) pair mimicking _AggregatedTqdm.
+
+        The tracker accumulates total/n/instances the same way the real
+        _AggregatedTqdm's parent bar does, so tests can assert correct
+        progress accounting without pulling in the real implementation.
+        """
+
+        class _Tracker:
+            def __init__(self):
+                self.total = 0
+                self.n = 0
+                self.instances = 0
+
+        tracker = _Tracker()
+
+        class _TqdmClass:
+            def __init__(self, *args, **kwargs):
+                tracker.instances += 1
+                if (total := kwargs.get("total")) is not None:
+                    tracker.total += total
+                if initial := kwargs.get("initial", 0):
+                    tracker.n += initial
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                pass
+
+            def update(self, n=1):
+                tracker.n += n
+
+        return tracker, _TqdmClass
+
+    @staticmethod
+    def _mock_response(*, status_code=200, headers, iter_bytes):
+        r = Mock()
+        r.status_code = status_code
+        r.headers = headers
+        r.iter_bytes.return_value = iter_bytes
+        return r
+
+    @staticmethod
+    def _http_get_with_mocked_responses(responses, **http_get_kwargs):
+        """Run http_get against a sequence of mock responses, return the BytesIO."""
+        it = iter(responses)
+
+        @contextmanager
+        def _mock_stream(*args, **kwargs):
+            yield next(it)
+
+        with patch("huggingface_hub.file_download.http_stream_backoff", side_effect=_mock_stream):
+            temp_file = io.BytesIO()
+            http_get("fake_url", temp_file=temp_file, **http_get_kwargs)
+        return temp_file
+
     def test_http_get_retry_reuses_tqdm_class_instance(self):
         """Retries must not re-instantiate the user-supplied tqdm_class.
 
-        Regression test for the snapshot_download bug where ``_AggregatedTqdm``
-        was re-constructed on every retry, inflating the shared bar's ``total``
-        by ``expected_size`` and advancing ``n`` by ``resume_size`` per retry.
-
-        This test uses a stand-in ``tqdm_class`` that aggregates into a shared
-        ``parent`` object (same shape as ``_AggregatedTqdm``) and asserts the
-        parent ends with exactly one file's worth of total/n after two
-        transient failures.
+        Regression test: _AggregatedTqdm was re-constructed on every retry,
+        inflating the shared bar's total and advancing n per retry.
         """
+        tracker, tqdm_class = self._make_aggregated_tqdm()
 
-        class _Parent:
-            def __init__(self):
-                self.total = 0
-                self.n = 0
+        def _fail_after(data: bytes):
+            yield data
+            raise httpx.TimeoutException("timeout")
 
-            def refresh(self):
-                pass
+        temp_file = self._http_get_with_mocked_responses(
+            [
+                self._mock_response(headers={"Content-Length": "100"}, iter_bytes=_fail_after(b"A" * 30)),
+                self._mock_response(
+                    status_code=206,
+                    headers={"Content-Length": "70", "Content-Range": "bytes 30-99/100"},
+                    iter_bytes=_fail_after(b"B" * 25),
+                ),
+                self._mock_response(
+                    status_code=206,
+                    headers={"Content-Length": "45", "Content-Range": "bytes 55-99/100"},
+                    iter_bytes=iter([b"C" * 45]),
+                ),
+            ],
+            expected_size=100,
+            tqdm_class=tqdm_class,
+        )
 
-            def update(self, n):
-                self.n += n
-
-        parent = _Parent()
-
-        class _AggregatedLikeTqdm:
-            instances = 0
-
-            def __init__(self, *args, **kwargs):
-                type(self).instances += 1
-                total = kwargs.pop("total", None)
-                if total is not None:
-                    parent.total += total
-                    parent.refresh()
-                initial = kwargs.pop("initial", 0)
-                if initial:
-                    parent.update(initial)
-
-            def __enter__(self):
-                return self
-
-            def __exit__(self, exc_type, exc_value, traceback):
-                pass
-
-            def update(self, n=1):
-                parent.update(n)
-
-        def _iter_content_1() -> Iterable[bytes]:
-            yield b"A" * 30
-            raise httpx.TimeoutException("Fake timeout #1")
-
-        def _iter_content_2() -> Iterable[bytes]:
-            yield b"B" * 25
-            raise httpx.TimeoutException("Fake timeout #2")
-
-        def _iter_content_3() -> Iterable[bytes]:
-            yield b"C" * 45  # remaining 100 - 30 - 25
-
-        r1 = Mock()
-        r1.status_code = 200
-        r1.headers = {"Content-Length": "100"}
-        r1.iter_bytes.return_value = _iter_content_1()
-
-        r2 = Mock()
-        r2.status_code = 206
-        r2.headers = {"Content-Length": "70", "Content-Range": "bytes 30-99/100"}
-        r2.iter_bytes.return_value = _iter_content_2()
-
-        r3 = Mock()
-        r3.status_code = 206
-        r3.headers = {"Content-Length": "45", "Content-Range": "bytes 55-99/100"}
-        r3.iter_bytes.return_value = _iter_content_3()
-
-        responses = iter([r1, r2, r3])
-
-        @contextmanager
-        def _mock_stream(*args, **kwargs):
-            yield next(responses)
-
-        with patch("huggingface_hub.file_download.http_stream_backoff", side_effect=_mock_stream):
-            temp_file = io.BytesIO()
-            http_get(
-                "fake_url",
-                temp_file=temp_file,
-                expected_size=100,
-                tqdm_class=_AggregatedLikeTqdm,
-            )
-
-        # File on disk is correct.
-        assert temp_file.tell() == 100
         assert temp_file.getvalue() == b"A" * 30 + b"B" * 25 + b"C" * 45
-
-        # The wrapper class was constructed exactly once for the whole download,
-        # not once per retry.
-        assert _AggregatedLikeTqdm.instances == 1
-
-        # Shared parent bar reflects one file's total and full progress, not
-        # 3x the file size (one per attempt).
-        assert parent.total == 100
-        assert parent.n == 100
+        assert tracker.instances == 1
+        assert tracker.total == 100
+        assert tracker.n == 100
 
     def test_http_get_retry_rolls_back_reused_bar_when_range_ignored(self):
-        """When a retry's server ignores Range and returns 200 with the full body,
-        the reused progress bar must be rolled back by ``resume_size`` so the
-        upcoming full re-download is not double-counted.
-
-        Without the rollback, a 100-byte file with a 30-byte first attempt
-        followed by a Range-ignored 200 retry would end at parent.n = 130.
+        """When a retry server ignores Range and returns 200, the reused bar
+        must be rolled back so the full re-download is not double-counted.
         """
+        tracker, tqdm_class = self._make_aggregated_tqdm()
 
-        class _Parent:
-            def __init__(self):
-                self.total = 0
-                self.n = 0
+        def _fail_after(data: bytes):
+            yield data
+            raise httpx.TimeoutException("timeout")
 
-            def refresh(self):
-                pass
+        temp_file = self._http_get_with_mocked_responses(
+            [
+                self._mock_response(headers={"Content-Length": "100"}, iter_bytes=_fail_after(b"A" * 30)),
+                self._mock_response(headers={"Content-Length": "100"}, iter_bytes=iter([b"B" * 100])),
+            ],
+            expected_size=100,
+            tqdm_class=tqdm_class,
+        )
 
-            def update(self, n):
-                self.n += n
-
-        parent = _Parent()
-
-        class _AggregatedLikeTqdm:
-            def __init__(self, *args, **kwargs):
-                total = kwargs.pop("total", None)
-                if total is not None:
-                    parent.total += total
-                    parent.refresh()
-                initial = kwargs.pop("initial", 0)
-                if initial:
-                    parent.update(initial)
-
-            def __enter__(self):
-                return self
-
-            def __exit__(self, exc_type, exc_value, traceback):
-                pass
-
-            def update(self, n=1):
-                parent.update(n)
-
-        def _iter_first() -> Iterable[bytes]:
-            yield b"A" * 30
-            raise httpx.TimeoutException("first timeout")
-
-        def _iter_second() -> Iterable[bytes]:
-            # Server ignores Range header and returns full body
-            yield b"B" * 100
-
-        r1 = Mock()
-        r1.status_code = 200
-        r1.headers = {"Content-Length": "100"}
-        r1.iter_bytes.return_value = _iter_first()
-
-        r2 = Mock()
-        r2.status_code = 200  # 200, not 206 — Range was ignored on the retry
-        r2.headers = {"Content-Length": "100"}
-        r2.iter_bytes.return_value = _iter_second()
-
-        responses = iter([r1, r2])
-
-        @contextmanager
-        def _mock_stream(*args, **kwargs):
-            yield next(responses)
-
-        with patch("huggingface_hub.file_download.http_stream_backoff", side_effect=_mock_stream):
-            temp_file = io.BytesIO()
-            http_get(
-                "fake_url",
-                temp_file=temp_file,
-                expected_size=100,
-                tqdm_class=_AggregatedLikeTqdm,
-            )
-
-        # File on disk holds only the retry's full body (first attempt was truncated).
-        assert temp_file.tell() == 100
         assert temp_file.getvalue() == b"B" * 100
-
-        # Parent bar lands exactly on file_size, not 130 (which is what the
-        # bug would produce without the rollback).
-        assert parent.total == 100
-        assert parent.n == 100
+        assert tracker.total == 100
+        assert tracker.n == 100
 
     def test_http_get_falls_back_to_expected_size_when_response_lacks_content_length(self):
-        """When the response is gzip+chunked (Content-Length absent), the bar's
-        total must fall back to the caller's ``expected_size``.
-
-        Reproduces the Hub's behavior for compressible text files served from
-        huggingface.co (e.g. vocab.json: ``Content-Encoding: gzip`` +
-        ``Transfer-Encoding: chunked``, no Content-Length). Without the
-        fallback, snapshot_download's ``_AggregatedTqdm`` is constructed with
-        ``total=None`` and the file never contributes to the parent bar.
+        """When the response is gzip+chunked (no Content-Length), the bar's
+        total must fall back to expected_size so _AggregatedTqdm still works.
         """
+        tracker, tqdm_class = self._make_aggregated_tqdm()
 
-        class _Parent:
-            def __init__(self):
-                self.total = 0
-                self.n = 0
+        temp_file = self._http_get_with_mocked_responses(
+            [
+                self._mock_response(
+                    headers={"Content-Encoding": "gzip", "Transfer-Encoding": "chunked", "Content-Type": "application/json"},
+                    iter_bytes=iter([b"X" * 100]),
+                ),
+            ],
+            expected_size=100,
+            tqdm_class=tqdm_class,
+        )
 
-            def refresh(self):
-                pass
-
-            def update(self, n):
-                self.n += n
-
-        parent = _Parent()
-
-        class _AggregatedLikeTqdm:
-            def __init__(self, *args, **kwargs):
-                total = kwargs.pop("total", None)
-                if total is not None:
-                    parent.total += total
-                    parent.refresh()
-                initial = kwargs.pop("initial", 0)
-                if initial:
-                    parent.update(initial)
-
-            def __enter__(self):
-                return self
-
-            def __exit__(self, exc_type, exc_value, traceback):
-                pass
-
-            def update(self, n=1):
-                parent.update(n)
-
-        def _iter_chunked_gzip() -> Iterable[bytes]:
-            # Decompressed content: 100 bytes. Real httpx already returns the
-            # decompressed body via iter_bytes, so we just yield 100 bytes here.
-            yield b"X" * 100
-
-        # Real-world shape: gzip + chunked + no Content-Length.
-        response = Mock()
-        response.status_code = 200
-        response.headers = {
-            "Content-Encoding": "gzip",
-            "Transfer-Encoding": "chunked",
-            "Content-Type": "application/json",
-        }
-        response.iter_bytes.return_value = _iter_chunked_gzip()
-
-        @contextmanager
-        def _mock_stream(*args, **kwargs):
-            yield response
-
-        with patch("huggingface_hub.file_download.http_stream_backoff", side_effect=_mock_stream):
-            temp_file = io.BytesIO()
-            http_get(
-                "fake_url",
-                temp_file=temp_file,
-                expected_size=100,
-                tqdm_class=_AggregatedLikeTqdm,
-            )
-
-        # Bytes-on-disk are correct.
-        assert temp_file.tell() == 100
         assert temp_file.getvalue() == b"X" * 100
-
-        # Without the expected_size fallback, parent.total stays at 0 and the
-        # file silently fails to contribute to the snapshot bar.
-        assert parent.total == 100
-        assert parent.n == 100
+        assert tracker.total == 100
+        assert tracker.n == 100
 
 
 class CreateSymlinkTest(unittest.TestCase):


### PR DESCRIPTION
Fixes #4208.

## Summary

Three small, additive fixes inside `http_get`. All scoped to the retry / progress-accounting path; bytes-on-disk are unchanged on every code path.

1. **Reuse the live progress wrapper across retries.** `http_get` retries by recursively calling itself on transient `httpx.ConnectError` / `httpx.TimeoutException`. The recursion used to forward the original `_tqdm_bar=None`, so `_get_progress_bar_context` constructed a *fresh* `tqdm_class` instance on every retry. In `snapshot_download` that class is `_AggregatedTqdm`, whose `__init__` mutates a shared `bytes_progress` bar — so each retry added another file-size to `total` and another `resume_size` to `n`. The user-reported `971M → 1.91G → 2.85G` inflation in #4208 is exactly that. Fix: pass the live `progress` object (already bound by `with progress_cm as progress:`) into the recursion. `_get_progress_bar_context` short-circuits to `nullcontext(_tqdm_bar)` and reuses the existing wrapper.

2. **Roll the reused bar back when a retry's `Range` is ignored.** With (1) in place, the existing CloudFront-with-gzip case (server ignores `Range` and returns a fresh 200) double-counts on the reused bar: the bar's counter is at `resume_size` from earlier attempts but the file just got truncated. Fix: at the same place we `truncate()` the file, also `_tqdm_bar.update(-resume_size)` if the bar is being reused. The first call's path is unchanged (no `_tqdm_bar` to roll back; the freshly-constructed bar starts at `initial=0` after reset).

3. **Fall back to `expected_size` when the response lacks `Content-Length`.** A real-Hub probe of `https://huggingface.co` (HF_ENDPOINT unset) shows that compressible text files (e.g. `vocab.json`, `merges.txt`, `README.md`, …) are served as `Content-Encoding: gzip` + `Transfer-Encoding: chunked` with **no** `Content-Length`. Today `_get_file_length_from_http_response` returns `None` for those, and `_AggregatedTqdm.__init__` is called with `total=None`, so the file silently never contributes to `bytes_progress.total`. Fix: when the response carries no length, fall back to the caller's `expected_size`, which is always known on the `hf_hub_download` / `snapshot_download` path (it's pulled from the metadata HEAD before the GET).

## Verification

### Standalone repro from #4208

```
# main
$ python repro.py
file size            : 9710
bytes_progress.total : 29130   # 3 x file size
bytes_progress.n     : 14540
=> bar shows ~50% on a fully-downloaded file

# this PR
$ python repro.py
file size            : 9710
bytes_progress.total : 9710
bytes_progress.n     : 9710
=> bar shows 100%, single file size, no inflation
```

Multi-file (no-retry) aggregation sanity-check on the same harness with two files (4k + 6k): `total = 10_000`, `n = 10_000` — unchanged.

### Empirical impact on `hf download Qwen/Qwen3-0.6B`

Probed every file in the repo, recording what `_get_file_length_from_http_response` returns on the first GET (HF_ENDPOINT unset, official endpoint):

| Class | Files | First-GET behavior | Today | This PR |
|---|---|---|---|---|
| `huggingface.co`, gzip+chunked | `.gitattributes`, `LICENSE`, `README.md`, `merges.txt`, `tokenizer_config.json`, `vocab.json` | `Content-Encoding: gzip`, `Transfer-Encoding: chunked`, no `Content-Length` → parsed `None` | not added to `bytes_progress.total` | added via `expected_size` fallback |
| `huggingface.co`, direct | `config.json` (726 B), `generation_config.json` (239 B) | `Content-Length` present | OK | OK (no change) |
| `cas-bridge.xethub.hf.co` | `model.safetensors` (1.5 GB), `tokenizer.json` (11.4 MB) | `Content-Length` present | OK | OK (no change) |

Six of ten files (≈4.49 MB of decompressed content) are silently dropped from the snapshot bar's `total` on `main`. The bar's `n` accumulates *every* file's chunks, so the bar overflows past 100% by ≈4.5 MB at the end of every Qwen-style snapshot. With this PR it lands at exactly `1,519,209,243 / 1,519,209,243` and ETA estimates stay sane throughout the run.

### Tests

```
$ pytest tests/test_file_download.py::TestHttpGet -v
tests/test_file_download.py::TestHttpGet::test_http_get_with_ssl_and_timeout_error PASSED
tests/test_file_download.py::TestHttpGet::test_http_get_with_range_headers[bytes=-100-expected_ranges0] PASSED
tests/test_file_download.py::TestHttpGet::test_http_get_with_range_headers[bytes=15--expected_ranges1] PASSED
tests/test_file_download.py::TestHttpGet::test_http_get_with_range_headers[bytes=15-114-expected_ranges2] PASSED
tests/test_file_download.py::TestHttpGet::test_http_get_retry_resets_file_when_range_ignored PASSED
tests/test_file_download.py::TestHttpGet::test_http_get_retry_reuses_tqdm_class_instance PASSED
tests/test_file_download.py::TestHttpGet::test_http_get_retry_rolls_back_reused_bar_when_range_ignored PASSED
tests/test_file_download.py::TestHttpGet::test_http_get_falls_back_to_expected_size_when_response_lacks_content_length PASSED
============================== 8 passed in 16.18s ==============================
```

`make style` and `make quality` both clean.

Three new tests, one per fix:
- `test_http_get_retry_reuses_tqdm_class_instance` — passes a stand-in `tqdm_class` shaped like `_AggregatedTqdm` through two simulated `TimeoutException`s, asserts the class is constructed exactly once and the shared parent ends at `total == n == file_size`.
- `test_http_get_retry_rolls_back_reused_bar_when_range_ignored` — first attempt downloads 30 bytes then times out; the retry's server ignores `Range` and returns 200 with the full body; asserts `parent.n == file_size` (without the rollback it fails at `parent.n == 130`).
- `test_http_get_falls_back_to_expected_size_when_response_lacks_content_length` — mocks the gzip+chunked shape (no `Content-Length`); asserts the parent bar receives `expected_size` (without the fallback it fails at `parent.total == 0`).

## Notes

- No public API change. All three changes live inside the `http_get` body.
- Case-by-case scope: only the snapshot/aggregated bar's accounting is corrected. `xet_get` (the `hf_xet`-installed path) is not on the http-fallback path the user hit and is untouched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches `http_get` retry/progress accounting; while intended to be additive, it changes how progress bars and totals are computed and reused, which could surface edge cases in callers that pass custom `tqdm_class` or missing `expected_size`.
> 
> **Overview**
> Fixes progress bar over-counting during `http_get` retries by **reusing the same progress bar instance** across recursive retry calls instead of re-instantiating `tqdm_class` each time.
> 
> When a server ignores the `Range` header and forces a full re-download, the reused bar is now **rolled back by `resume_size`** to avoid double-counting after truncating the temp file. Additionally, if the response lacks `Content-Length` (e.g. gzip+chunked), `http_get` now **falls back to `expected_size`** so aggregated progress bars still get an accurate `total`.
> 
> Adds regression tests covering bar reuse, rollback on ignored ranges, and missing `Content-Length` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a3695ac555e877af534b6ef1310808e0b1f573e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

