### PR TITLE
Only sync skill if SKILL.md has changed

### DIFF
--- a/.github/workflows/sync-hf-cli-skill.yml
+++ b/.github/workflows/sync-hf-cli-skill.yml
@@ -62,15 +62,23 @@ jobs:
       - name: Copy generated files
         run: cp /tmp/hf-cli-skill/SKILL.md skills-repo/skills/hf-cli/
 
-      - name: Regenerate skills repo artifacts
-        working-directory: skills-repo
-        run: ./scripts/publish.sh
-
-      - name: Check for changes
+      - name: Check for HF CLI skill changes
         id: check_changes
         working-directory: skills-repo
         run: |
-          git diff --quiet && echo "changed=false" >> $GITHUB_OUTPUT || echo "changed=true" >> $GITHUB_OUTPUT
+          if git diff --quiet -- skills/hf-cli/SKILL.md; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No hf-cli skill changes; skipping PR"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Bump plugin version and regenerate skills repo artifacts
+        if: steps.check_changes.outputs.changed == 'true'
+        working-directory: skills-repo
+        run: |
+          uv run scripts/plugin_versions.py bump patch
+          ./scripts/publish.sh
 
       - name: Create Pull Request
         if: steps.check_changes.outputs.changed == 'true'

--- a/.github/workflows/sync-hf-cli-skill.yml
+++ b/.github/workflows/sync-hf-cli-skill.yml
@@ -65,6 +65,7 @@ jobs:
       - name: Check for HF CLI skill changes
         id: check_changes
         working-directory: skills-repo
+        # git diff returns zero if there is no diff
         run: |
           if git diff --quiet -- skills/hf-cli/SKILL.md; then
             echo "changed=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Skip publishing if the Skill hasn't changed -- this is to avoid unnecessary version bumps in the skills repo :) 

Related PR in Skills repo https://github.com/huggingface/skills/pull/140 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts GitHub Actions workflow logic to gate version bumps/PR creation on a targeted diff check, without touching runtime code paths.
> 
> **Overview**
> Updates the `sync-hf-cli-skill` workflow to **skip publishing/version bumps and PR creation when the generated `skills/hf-cli/SKILL.md` is unchanged**.
> 
> When changes are detected, the workflow now **bumps the skills plugin patch version** via `scripts/plugin_versions.py` before running `./scripts/publish.sh`, keeping artifact regeneration tied to actual skill updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 234d227fe8adfddeae915a1ffd1250b7bb545836. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->