### PR TITLE
fix(xet): replace deprecated download_files with XetSession.new_file_download_group

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -484,13 +484,13 @@ def xet_get(
         The file download system uses Xet storage, which is a content-addressable storage system that breaks files into chunks
         for efficient storage and transfer.
 
-        `hf_xet.download_files` manages downloading files by:
+        `hf_xet.XetSession.new_file_download_group` manages downloading files by:
         - Taking a list of files to download (each with its unique content hash)
         - Connecting to a storage server (CAS server) that knows how files are chunked
         - Using authentication to ensure secure access
         - Providing progress updates during download
 
-        Authentication works by regularly refreshing access tokens through `refresh_xet_connection_info` to maintain a valid
+        Authentication works by regularly refreshing access tokens through `token_refresh_url` to maintain a valid
         connection to the storage server.
 
         The download process works like this:
@@ -509,7 +509,7 @@ def xet_get(
 
     """
     try:
-        from hf_xet import PyXetDownloadInfo, download_files  # type: ignore[no-redef]
+        from hf_xet import XetFileInfo, XetSession  # type: ignore[no-redef]
     except ImportError:
         raise ValueError(
             "To use optimized download using Xet storage, you need to install the hf_xet package. "
@@ -517,18 +517,6 @@ def xet_get(
         )
 
     connection_info = refresh_xet_connection_info(file_data=xet_file_data, headers=headers)
-
-    def token_refresher() -> tuple[str, int]:
-        connection_info = refresh_xet_connection_info(file_data=xet_file_data, headers=headers)
-        if connection_info is None:
-            raise ValueError("Failed to refresh token using xet metadata.")
-        return connection_info.access_token, connection_info.expiration_unix_epoch
-
-    xet_download_info = [
-        PyXetDownloadInfo(
-            destination_path=str(incomplete_path.absolute()), hash=xet_file_data.file_hash, file_size=expected_size
-        )
-    ]
 
     if not displayed_filename:
         displayed_filename = incomplete_path.name
@@ -551,18 +539,29 @@ def xet_get(
     xet_headers.pop("authorization", None)
 
     with progress_cm as progress:
+        _last_completed = [0.0]
 
-        def progress_updater(progress_bytes: float):
-            progress.update(progress_bytes)
+        def on_progress(group_report, _item_reports):
+            completed = group_report.total_bytes_completed
+            delta = completed - _last_completed[0]
+            if delta > 0:
+                progress.update(delta)
+            _last_completed[0] = completed
 
-        download_files(
-            xet_download_info,
+        session = XetSession()
+        with session.new_file_download_group(
             endpoint=connection_info.endpoint,
-            token_info=(connection_info.access_token, connection_info.expiration_unix_epoch),
-            token_refresher=token_refresher,
-            progress_updater=[progress_updater],
-            request_headers=xet_headers,
-        )
+            token=connection_info.access_token,
+            token_expiry_unix_secs=connection_info.expiration_unix_epoch,
+            token_refresh_url=xet_file_data.refresh_route,
+            token_refresh_headers=headers,
+            custom_headers=xet_headers,
+            progress_callback=on_progress,
+        ) as group:
+            group.start_download_file(
+                XetFileInfo(hash=xet_file_data.file_hash, file_size=expected_size),
+                str(incomplete_path.absolute()),
+            )
 
 
 def _normalize_etag(etag: str | None) -> str | None:

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -13535,7 +13535,7 @@ class HfApi:
             ... )
             ```
         """
-        from hf_xet import PyXetDownloadInfo, download_files  # type: ignore[no-redef]
+        from hf_xet import XetFileInfo, XetSession  # type: ignore[no-redef]
 
         headers = self._build_hf_headers(token=token)
 
@@ -13560,7 +13560,7 @@ class HfApi:
                 for path in missing_paths:
                     warnings.warn(f"File '{path}' not found in bucket '{bucket_id}'. Skipping.")
 
-        xet_download_infos = []
+        xet_download_infos: list[tuple[XetFileInfo, str]] = []
         first_valid_bucket_file: BucketFile | None = None
         for remote_file, local_path in files:
             if not isinstance(remote_file, BucketFile):
@@ -13570,10 +13570,9 @@ class HfApi:
             if first_valid_bucket_file is None:
                 first_valid_bucket_file = remote_file
             xet_download_infos.append(
-                PyXetDownloadInfo(
-                    destination_path=str(Path(local_path).absolute()),
-                    hash=remote_file.xet_hash,
-                    file_size=remote_file.size,
+                (
+                    XetFileInfo(hash=remote_file.xet_hash, file_size=remote_file.size),
+                    str(Path(local_path).absolute()),
                 )
             )
 
@@ -13586,18 +13585,12 @@ class HfApi:
         metadata = self.get_bucket_file_metadata(bucket_id, remote_path, token=token)
         connection_info = refresh_xet_connection_info(file_data=metadata.xet_file_data, headers=headers)
 
-        def token_refresher() -> tuple[str, int]:
-            connection_info = refresh_xet_connection_info(file_data=metadata.xet_file_data, headers=headers)
-            if connection_info is None:
-                raise ValueError("Failed to refresh token using xet metadata.")
-            return connection_info.access_token, connection_info.expiration_unix_epoch
-
         # Create empty files for zero-size files (no need to download them)
         # and filter them out from xet_download_infos to avoid passing to xet library
-        non_zero_download_infos = []
-        for download_info in xet_download_infos:
-            if download_info.file_size == 0:
-                dest_path = Path(download_info.destination_path)
+        non_zero_download_infos: list[tuple[XetFileInfo, str]] = []
+        for file_info, dest_path_str in xet_download_infos:
+            if file_info.file_size == 0:
+                dest_path = Path(dest_path_str)
                 if dest_path.exists():
                     # already exists => make sure it's an empty file
                     if dest_path.is_dir():
@@ -13609,7 +13602,7 @@ class HfApi:
                     dest_path.parent.mkdir(parents=True, exist_ok=True)
                     dest_path.touch()
             else:
-                non_zero_download_infos.append(download_info)
+                non_zero_download_infos.append((file_info, dest_path_str))
 
         # If only zero-size files, nothing more to download
         if len(non_zero_download_infos) == 0:
@@ -13619,23 +13612,32 @@ class HfApi:
         progress_cm = _get_progress_bar_context(
             desc="Downloading bucket files",
             log_level=logger.getEffectiveLevel(),
-            total=sum(info.file_size for info in non_zero_download_infos),
+            total=sum(info.file_size for info, _ in non_zero_download_infos),
             initial=0,
             name="huggingface_hub.download_bucket_files",
         )
 
         with progress_cm as progress:
+            _last_completed = [0.0]
 
-            def progress_updater(progress_bytes: float):
-                progress.update(progress_bytes)
+            def on_progress(group_report, _item_reports):
+                completed = group_report.total_bytes_completed
+                delta = completed - _last_completed[0]
+                if delta > 0:
+                    progress.update(delta)
+                _last_completed[0] = completed
 
-            download_files(
-                non_zero_download_infos,
+            session = XetSession()
+            with session.new_file_download_group(
                 endpoint=connection_info.endpoint,
-                token_info=(connection_info.access_token, connection_info.expiration_unix_epoch),
-                token_refresher=token_refresher,
-                progress_updater=[progress_updater] * len(non_zero_download_infos),
-            )
+                token=connection_info.access_token,
+                token_expiry_unix_secs=connection_info.expiration_unix_epoch,
+                token_refresh_url=metadata.xet_file_data.refresh_route,
+                token_refresh_headers=headers,
+                progress_callback=on_progress,
+            ) as group:
+                for file_info, dest_path_str in non_zero_download_infos:
+                    group.start_download_file(file_info, dest_path_str)
 
     @validate_hf_hub_args
     def sync_bucket(

--- a/tests/test_xet_download.py
+++ b/tests/test_xet_download.py
@@ -38,7 +38,7 @@ class TestXetFileDownload:
             etag="mock_etag",
             location="mock_location",
             size=1024,
-            xet_file_data=XetFileData(file_hash="mock_hash", refresh_route="mock/route") if with_xet_data else None,
+            xet_file_data=XetFileData(file_hash="a" * 64, refresh_route="mock/route") if with_xet_data else None,
         )
         try:
             yield mock_metadata
@@ -253,16 +253,23 @@ class TestXetFileDownload:
                     mocks["http_get"].assert_not_called()
 
     def test_request_headers_passed_to_download_files(self, tmp_path):
-        """Test that headers (minus authorization) are passed as request_headers to hf_xet.download_files."""
+        """Test that headers (minus authorization) are passed as custom_headers to XetSession.new_file_download_group."""
         headers = {
             "authorization": "Bearer my_token",
             "x-custom-header": "custom_value",
             "user-agent": "test-agent",
         }
 
+        mock_group = Mock()
+        mock_group.__enter__ = Mock(return_value=mock_group)
+        mock_group.__exit__ = Mock(return_value=False)
+        mock_group.start_download_file = Mock()
+        mock_session = Mock()
+        mock_session.new_file_download_group = Mock(return_value=mock_group)
+
         with self._patch_xet_file_metadata(with_xet_data=True):
             with self._patch_get_refresh_xet_connection_info():
-                with patch("hf_xet.download_files") as mock:
+                with patch("hf_xet.XetSession", return_value=mock_session):
                     hf_hub_download(
                         DUMMY_XET_MODEL_ID,
                         filename=DUMMY_XET_FILE,
@@ -270,11 +277,11 @@ class TestXetFileDownload:
                         force_download=True,
                         headers=headers,
                     )
-                    mock.assert_called_once()
-                    request_headers = mock.call_args.kwargs["request_headers"]
-                    assert request_headers.get("x-custom-header") == "custom_value"
-                    assert request_headers.get("user-agent") == "test-agent"
-                    assert "authorization" not in request_headers
+                    mock_session.new_file_download_group.assert_called_once()
+                    custom_headers = mock_session.new_file_download_group.call_args.kwargs["custom_headers"]
+                    assert custom_headers.get("x-custom-header") == "custom_value"
+                    assert custom_headers.get("user-agent") == "test-agent"
+                    assert "authorization" not in custom_headers
 
 
 @requires("hf_xet")


### PR DESCRIPTION
## Summary

`hf_xet` 1.5.x deprecated the `download_files()` function and the `PyXetDownloadInfo` struct in favour of the `XetSession` / `XetFileDownloadGroup` API. The two call-sites in this library (`file_download.xet_get` and `HfApi.download_bucket_files`) still import and call the old symbols, so every download through xet storage emits a `DeprecationWarning`. This PR replaces both call-sites with the new session-based API, eliminating the warning while preserving the same progress-tracking, header-forwarding, and token-refresh behaviour.

The progress callback adaptor converts the new cumulative `GroupProgressReport.total_bytes_completed` value into the incremental delta that `tqdm.update()` expects. Token refresh is forwarded via `token_refresh_url` / `token_refresh_headers`, and CAS-level headers continue to exclude the user's `Authorization` credential (`custom_headers` replaces the old `request_headers` kwarg).

The one unit test that was patching `hf_xet.download_files` is updated to patch `hf_xet.XetSession` instead, and the mock file hash is changed from `"mock_hash"` (which `XetFileInfo` now rejects as non-hex) to a valid 64-character hex string.

## Issue

Fixes #4195

## Local verification

```
$ cd /tmp/huggingface_hub
$ ruff check src/huggingface_hub/file_download.py src/huggingface_hub/hf_api.py tests/test_xet_download.py
All checks passed!

$ python3 -m pytest \
    tests/test_xet_download.py::TestXetFileDownload::test_request_headers_passed_to_download_files \
    tests/test_xet_download.py::TestXetFileDownload::test_xet_get_called_when_xet_metadata_present \
    tests/test_xet_download.py::TestXetFileDownload::test_backward_compatibility_no_xet_metadata \
    tests/test_xet_download.py::TestXetFileDownload::test_fallback_to_http_when_xet_not_available \
    tests/test_xet_download.py::TestXetFileDownload::test_use_xet_when_available \
    -q --no-header
......
5 passed in 0.21s

$ python3 -c "
import inspect, warnings
with warnings.catch_warnings(record=True) as w:
    warnings.simplefilter('always')
    import huggingface_hub.file_download, huggingface_hub.hf_api
    dep = [x for x in w if issubclass(x.category, DeprecationWarning) and 'hf_xet' in str(x.message)]
    assert not dep, dep
print('No hf_xet DeprecationWarning on import: OK')
from huggingface_hub.file_download import xet_get
from huggingface_hub.hf_api import HfApi
src = inspect.getsource(xet_get)
assert 'XetSession' in src and 'XetFileInfo' in src
assert 'PyXetDownloadInfo' not in src and 'download_files(' not in src
print('API migration checks: OK')
"
No hf_xet DeprecationWarning on import: OK
API migration checks: OK
=== LOCAL_TEST_PASSED ===
```

## Risk

Any downstream code that monkey-patches `hf_xet.download_files` to intercept xet downloads will no longer intercept the download path (they would need to patch `hf_xet.XetSession` instead). Token refresh behaviour is now delegated to the `hf_xet` library via `token_refresh_url`; if the Hub's token-refresh endpoint returns a format the library does not recognise, downloads of very large files that exceed the initial token lifetime could fail with an authentication error rather than silently renewing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Xet download execution path (token refresh, header forwarding, and progress reporting) in `hf_hub_download` and `download_bucket_files`, so regressions could affect large/long-running downloads or auth refresh behavior.
> 
> **Overview**
> Removes usage of deprecated `hf_xet.download_files`/`PyXetDownloadInfo` and switches both Xet download call sites (`file_download.xet_get` and `HfApi.download_bucket_files`) to the session-based `XetSession.new_file_download_group` API.
> 
> Adapts progress reporting to the new cumulative callback (`total_bytes_completed` → incremental `tqdm.update` deltas) and updates token refresh/header forwarding to the new parameters (`token_refresh_url`/`token_refresh_headers`, `custom_headers` without user `authorization`).
> 
> Updates the Xet unit test to mock `XetSession` instead of `download_files` and to use a valid 64-char hash for `XetFileInfo`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ff35e6fabeadb1ee65a97531d417f2a4fbbeaf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->