### PR TITLE
[Cache] Strip trailing whitespace when reading `refs/<revision>` (#4133)

### DIFF
--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -285,9 +285,10 @@ def snapshot_download(
         else:
             ref_path = os.path.join(storage_folder, "refs", revision)
             if os.path.exists(ref_path):
-                # retrieve commit_hash from refs file
+                # retrieve commit_hash from refs file (strip whitespace: trailing newlines
+                # appear when the cache directory is copied between environments — see #4133).
                 with open(ref_path) as f:
-                    commit_hash = f.read()
+                    commit_hash = f.read().strip()
 
         # Try to locate snapshot folder for this commit hash
         if commit_hash is not None and local_dir is None:

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -694,7 +694,9 @@ def _cache_commit_hash_for_specific_revision(storage_folder: str, revision: str,
     if revision != commit_hash:
         ref_path = Path(storage_folder) / "refs" / revision
         ref_path.parent.mkdir(parents=True, exist_ok=True)
-        if not ref_path.exists() or commit_hash != ref_path.read_text():
+        # `.strip()` to tolerate trailing newlines from caches copied between
+        # environments (#4133).
+        if not ref_path.exists() or commit_hash != ref_path.read_text().strip():
             # Update ref only if has been updated. Could cause useless error in case
             # repo is already cached and user doesn't have write access to cache folder.
             # See https://github.com/huggingface/huggingface_hub/issues/1216.
@@ -1102,8 +1104,10 @@ def _hf_hub_download_to_cache_dir(
             else:
                 ref_path = os.path.join(storage_folder, "refs", revision)
                 if os.path.isfile(ref_path):
+                    # See #4133: strip trailing newline that can appear when the cache
+                    # directory was copied between environments.
                     with open(ref_path) as f:
-                        commit_hash = f.read()
+                        commit_hash = f.read().strip()
 
             # Return pointer file if exists
             if commit_hash is not None:
@@ -1515,8 +1519,10 @@ def try_to_load_from_cache(
     if os.path.isdir(refs_dir):
         revision_file = os.path.join(refs_dir, revision)
         if os.path.isfile(revision_file):
+            # Strip whitespace: trailing newlines can appear when the cache is copied
+            # between environments — see #4133.
             with open(revision_file) as f:
-                revision = f.read()
+                revision = f.read().strip()
 
     # Check if file is cached as "no_exist"
     if os.path.isfile(os.path.join(no_exist_dir, revision, filename)):

--- a/src/huggingface_hub/utils/_cache_manager.py
+++ b/src/huggingface_hub/utils/_cache_manager.py
@@ -719,8 +719,10 @@ def _scan_cached_repo(repo_path: Path) -> CachedRepoInfo:
                 continue
 
             ref_name = str(ref_path.relative_to(refs_path))
+            # See #4133: strip trailing newline that can appear when the cache
+            # directory was copied between environments.
             with ref_path.open() as f:
-                commit_hash = f.read()
+                commit_hash = f.read().strip()
 
             refs_by_hash[commit_hash].add(ref_name)
 

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -445,6 +445,33 @@ class CachedDownloadTests(unittest.TestCase):
         # If file non-existence is not cached, returns None
         self.assertIsNone(try_to_load_from_cache(DUMMY_MODEL_ID, filename="dummy2"))
 
+    def test_try_to_load_from_cache_strips_trailing_newline_in_refs(self):
+        """Regression test for https://github.com/huggingface/huggingface_hub/issues/4133.
+
+        When the HF cache is copied between environments, `refs/<revision>` files can
+        end up with a trailing newline. The commit hash must still be resolved.
+        """
+        with SoftTemporaryDirectory() as cache_dir:
+            cache_dir = Path(cache_dir)
+            repo_id = "user/repo"
+            repo_dir = cache_dir / "models--user--repo"
+            (repo_dir / "refs").mkdir(parents=True)
+            commit_id = "f90f040c7cb709ee7c55bddb3af1941289361ad6"
+            snap = repo_dir / "snapshots" / commit_id
+            snap.mkdir(parents=True)
+            target = snap / "config.json"
+            target.write_text("{}")
+            # Trailing newline simulates the corrupted refs file from the issue.
+            (repo_dir / "refs" / "main").write_text(commit_id + "\n")
+
+            resolved = try_to_load_from_cache(
+                repo_id,
+                filename="config.json",
+                cache_dir=str(cache_dir),
+                revision="main",
+            )
+            self.assertEqual(Path(resolved).resolve(), target.resolve())
+
     def test_try_to_load_from_cache_specific_commit_id_exist(self):
         """Regression test for #1306.
 


### PR DESCRIPTION
Fixes #4133.

## Summary

When the HF cache is copied between environments, `refs/<revision>` files can end up with a trailing newline (e.g. `echo "<sha>" > refs/main`). The four `f.read()` call sites that resolve a ref to a commit hash didn't strip whitespace:

```python
with open(ref_path) as f:
    commit_hash = f.read()   # ← trailing "\n" stays in the hash
```

So the resulting snapshot path becomes `snapshots/<sha>\n/`, which doesn't exist, and `snapshot_download(local_files_only=True)` / `try_to_load_from_cache` fail offline even though the snapshot is present. This is especially painful in air-gapped environments where the cache is transferred manually.

## Fix

`.strip()` in all four sites:

- `_snapshot_download._snapshot_download` (offline ref resolution)
- `file_download.try_to_load_from_cache`
- `file_download.cache_commit_hash_for_specific_revision` (the `commit_hash != ref_path.read_text()` comparison was likewise affected and would re-write the ref unnecessarily)
- `utils/_cache_manager._scan_cached_repo`

This mirrors the existing behavior in `utils/_verification.py`, which already strips.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# --- BEFORE: origin/main, returns None ---
git fetch origin main && git checkout origin/main
python - <<'PY'
import os, tempfile
from pathlib import Path
from huggingface_hub import try_to_load_from_cache
cache = Path(tempfile.mkdtemp())
repo = cache / "models--user--repo"
(repo / "refs").mkdir(parents=True); (repo / "snapshots/f90f040c7cb709ee7c55bddb3af1941289361ad6").mkdir(parents=True)
(repo / "snapshots/f90f040c7cb709ee7c55bddb3af1941289361ad6/config.json").write_text("{}")
(repo / "refs/main").write_text("f90f040c7cb709ee7c55bddb3af1941289361ad6\n")  # trailing newline
print(try_to_load_from_cache("user/repo", filename="config.json", cache_dir=str(cache), revision="main"))
# Expected: None
PY

# --- AFTER: this branch ---
git fetch origin pull/<PR>/head:fix && git checkout fix
# (same script as above; resolves to the config.json path)
```

## What I ran locally

```
pytest tests/test_file_download.py::CachedDownloadTests::test_try_to_load_from_cache_strips_trailing_newline_in_refs
# 1 passed
```

The new test fails on `origin/main` (returns `None`) and passes on this branch. The full `tests/test_file_download.py` cache-related suite is otherwise unchanged.

---

🤖 Disclosure: Authored with assistance from Claude (Anthropic). Reproducer and regression test both verified end-to-end.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to cache ref parsing/comparison plus a regression test; behavior only differs for malformed `refs/<revision>` files with trailing whitespace.
> 
> **Overview**
> Fixes offline cache lookup failures when cached `refs/<revision>` files include trailing whitespace (e.g., newline after copying caches between environments).
> 
> All ref-to-commit resolution paths now `strip()` the read ref value (in `snapshot_download`, `hf_hub_download`/`try_to_load_from_cache`, and cache scanning), and the ref cache update check also strips to avoid unnecessary rewrites. Adds a regression test ensuring `try_to_load_from_cache` resolves a snapshot even when `refs/main` ends with `\n`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23b2b84106f30fb148b61a0d11da4fec92c1837f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->