### PR TITLE
fix(cli): hint users about full-output formats when table values are truncated

### DIFF
--- a/src/huggingface_hub/cli/_output.py
+++ b/src/huggingface_hub/cli/_output.py
@@ -114,6 +114,8 @@ class Output:
                 screaming_headers = [_to_header(h) for h in headers]
                 screaming_alignments = {_to_header(k): v for k, v in (alignments or {}).items()}
                 print(tabulate(formatted_rows, headers=screaming_headers, alignments=screaming_alignments))
+                if any(len(_format_table_value_human(v)) > _MAX_CELL_LENGTH for row in rows for v in row):
+                    self.hint("Some values were truncated. Use '--format json' or '--format agent' to see full values.")
             case OutputFormatWithAuto.agent:  # TSV, no truncation, full timestamps
                 print("\t".join(headers))
                 for row in rows:

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -145,6 +145,27 @@ def test_table(check):
     )
 
 
+def test_table_truncation_hint(capsys):
+    """Hint is printed to stderr in human mode when any cell value is truncated."""
+    items = [{"id": "x" * 40, "likes": 1}]  # id is 40 chars, exceeds _MAX_CELL_LENGTH (35)
+    o = Output()
+    o.set_mode(HUMAN)
+    o.table(items)
+    captured = capsys.readouterr()
+    assert "--format json" in captured.err
+    assert "--format agent" in captured.err
+
+
+def test_table_no_truncation_hint_when_fits(capsys):
+    """No hint is printed to stderr when all cell values fit within the limit."""
+    items = [{"id": "short-id", "likes": 1}]
+    o = Output()
+    o.set_mode(HUMAN)
+    o.table(items)
+    captured = capsys.readouterr()
+    assert captured.err == ""
+
+
 def test_table_empty(check):
     check(
         lambda out: out.table([]),


### PR DESCRIPTION
## Summary

When `hf models ls` is run in the default human-readable mode, long cell values (IDs, tags, etc.) are silently truncated to 35 characters with a trailing `...`. Users have no indication that values were cut short and no way to recover the full content without knowing that `--format json` or `--format agent` exist. This adds a stderr hint after the table whenever any cell was truncated, pointing users to the exact flags that produce untruncated output.

The hint fires only in human mode (the only mode that truncates), and only when at least one value actually exceeds the 35-char limit, so users who never see truncation are unaffected. The hint goes to stderr, keeping stdout pipeable. Agent/json/quiet modes already show full content and receive no hint.

The underlying truncation limit is intentional for readability in terminals, so this fix does not change that limit — it just surfaces the escape hatch.

## Issue

Refs #4207

## Local verification

```
$ cd /tmp/huggingface_hub
$ ruff check src/huggingface_hub/cli/_output.py tests/test_cli_output.py
All checks passed!
$ pre-commit run --files src/huggingface_hub/cli/_output.py tests/test_cli_output.py
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
check for case conflicts.................................................Passed
check for merge conflicts................................................Passed
ruff.....................................................................Passed
$ python -m pytest tests/test_cli_output.py -v 2>&1 | tail -5
============================== 32 passed in 0.23s ==============================
=== LOCAL_TEST_PASSED ===
```

## Risk

The hint is printed to stderr in human mode only and only when truncation occurs; all other modes and all non-truncating tables are unaffected. No existing stdout output is changed, so pipelines and scripts that parse `hf models ls` output are unbroken. The stderr message is new content, which could theoretically interfere with scripts that capture stderr, but this is an uncommon pattern for a human-facing command.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: behavior change is limited to an extra stderr hint in human mode only when truncation occurs, leaving stdout and other formats unchanged.
> 
> **Overview**
> In `Output.table()` human mode, prints a **stderr hint** after the rendered table when any cell exceeds the truncation limit, directing users to `--format json` or `--format agent` for full values.
> 
> Adds tests ensuring the hint appears only when truncation happens and remains absent when all values fit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c56c276638aa574ec2a4c25e73c404114cf9d98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->