### PR TITLE
[Download] Don't inflate aggregated progress total on `http_get` retries (#4208)

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -434,6 +434,11 @@ def http_get(
                     raise
                 logger.warning("Error while downloading from %s: %s\nTrying to resume download...", url, str(e))
                 time.sleep(1)
+                # Pass the live progress wrapper into the retry so
+                # `_get_progress_bar_context` short-circuits to `nullcontext(progress)`
+                # instead of constructing a fresh `_AggregatedTqdm`. Otherwise the
+                # snapshot-level shared bar's `total` and `n` get re-incremented on
+                # every retry — see issue #4208.
                 return http_get(
                     url=url,
                     temp_file=temp_file,
@@ -442,7 +447,7 @@ def http_get(
                     expected_size=expected_size,
                     tqdm_class=tqdm_class,
                     _nb_retries=_nb_retries - 1,
-                    _tqdm_bar=_tqdm_bar,
+                    _tqdm_bar=progress,
                 )
 
     if expected_size is not None and expected_size != temp_file.tell():

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -1117,6 +1117,81 @@ class TestHttpGet:
         # Note: The range headers are now handled internally by http_get's retry mechanism
         # The test verifies that the download completed successfully after retries
 
+    def test_http_get_retry_does_not_inflate_aggregated_progress_total(self, caplog):
+        """Regression for https://github.com/huggingface/huggingface_hub/issues/4208.
+
+        When `http_get` retries after a mid-stream `TimeoutException`, the
+        recursive call must reuse the live progress wrapper (`_tqdm_bar=progress`),
+        not pass the original `_tqdm_bar=None` through. Otherwise the snapshot-level
+        aggregated bar's `total` and `n` get re-incremented on every retry — what
+        the user reports as `1.42G/2.85G` for a single 971 MB file.
+        """
+
+        def _iter_content_fail_then_resume() -> Iterable[bytes]:
+            yield b"x" * 30
+            raise httpx.TimeoutException("Fake TimeoutException")
+
+        def _iter_content_resume_finish() -> Iterable[bytes]:
+            yield b"x" * 70
+
+        # Track every time the snapshot-level shared `total` and `n` are mutated
+        # via a fake `_AggregatedTqdm` matching the real one in `_snapshot_download.py`.
+        FILE_SIZE = 100
+        shared = {"total": 0, "n": 0, "init_calls": 0}
+
+        class _AggregatedTqdm:
+            def __init__(self, *args, **kwargs):
+                shared["init_calls"] += 1
+                total = kwargs.pop("total", None)
+                if total is not None:
+                    shared["total"] += total
+                initial = kwargs.pop("initial", 0)
+                if initial:
+                    shared["n"] += initial
+
+            def update(self, n):
+                shared["n"] += n
+
+            def close(self):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+            def refresh(self):
+                pass
+
+        with patch("huggingface_hub.file_download.http_stream_backoff") as mock_stream_backoff:
+            mock_response = Mock()
+            mock_response.headers = {"Content-Length": str(FILE_SIZE)}
+            mock_response.iter_bytes.side_effect = [
+                _iter_content_fail_then_resume(),
+                _iter_content_resume_finish(),
+            ]
+            mock_stream_backoff.return_value.__enter__.return_value = mock_response
+            mock_stream_backoff.return_value.__exit__.return_value = None
+
+            temp_file = io.BytesIO()
+            http_get(
+                "fake_url",
+                temp_file=temp_file,
+                expected_size=FILE_SIZE,
+                tqdm_class=_AggregatedTqdm,
+            )
+
+        assert temp_file.tell() == FILE_SIZE
+        # Pre-fix: shared["total"] == 2 * FILE_SIZE because _AggregatedTqdm.__init__
+        # ran twice (once per http_get attempt). Post-fix: __init__ only runs on the
+        # first attempt; the retry passes the live `progress` wrapper through.
+        assert shared["init_calls"] == 1, (
+            f"`_AggregatedTqdm.__init__` should be called once, not once per retry (got {shared['init_calls']})"
+        )
+        assert shared["total"] == FILE_SIZE
+        assert shared["n"] == FILE_SIZE
+
     @pytest.mark.parametrize(
         "initial_range,expected_ranges",
         [


### PR DESCRIPTION
Fixes #4208.

## Summary

When `http_get` hits a transient `httpx.ConnectError` / `httpx.TimeoutException` mid-stream, it retries by recursively calling itself:

```python
return http_get(
    ...,
    _tqdm_bar=_tqdm_bar,   # <-- was: original parameter, `None` when called via snapshot_download
)
```

Because `_tqdm_bar=None` is forwarded to the recursion, `_get_progress_bar_context` constructs a *fresh* `_AggregatedTqdm` on every retry. Its `__init__` mutates the snapshot-level shared bar (`bytes_progress.total += file_size`, and `update(initial)` for the resume offset), so a single 971 MB file that times out twice ends up displaying as `1.42G/2.85G` — 3× the true total.

## Fix

Pass the live `progress` wrapper into the retry instead. `_get_progress_bar_context` already short-circuits to `nullcontext(_tqdm_bar)` when `_tqdm_bar` is set, so no new `_AggregatedTqdm` is constructed on retries and no double-counting happens. The first call from `_download_to_tmp_and_move` is unchanged (still seeds the shared bar exactly once per file), so multi-file aggregation is preserved.

## Reproduce BEFORE/AFTER yourself

The reporter's full repro is in #4208. Adapted to a unit test in `tests/test_file_download.py::TestHttpGet::test_http_get_retry_does_not_inflate_aggregated_progress_total`:

- `origin/main`: `_AggregatedTqdm.__init__` runs **twice** (once per attempt), `shared["total"]` ends at `2 * FILE_SIZE`.
- this branch: runs **once**, `shared["total"] == FILE_SIZE` ✓.

```
pytest tests/test_file_download.py::TestHttpGet
# 6 passed
```

## Notes

- One-line behavioral change in the recursion (`_tqdm_bar=_tqdm_bar` → `_tqdm_bar=progress`); rest is the new test + a comment.
- No public API change.

---

🤖 Disclosure: Authored with assistance from Claude (Anthropic). Reproducer adapted from the issue's full snippet.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small change to retry-time progress bar plumbing plus a regression test; download data path and error handling remain the same.
> 
> **Overview**
> Fixes a retry regression in `http_get` where mid-stream `ConnectError`/`TimeoutException` retries could recreate an aggregated tqdm bar and **inflate snapshot download progress totals**. The retry now passes the live `progress` wrapper (`_tqdm_bar=progress`) into the recursive call so the progress context short-circuits and avoids double-counting.
> 
> Adds a focused regression test ensuring the aggregated progress bar is initialized only once and its `total`/`n` match the actual file size after a retry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a351c8823f68d248e0d65de8a3022f3d59c2074. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->