### PR TITLE
[Download] Add `HF_HUB_DOWNLOAD_CHUNK_SIZE` env var (#4129)

### DIFF
--- a/docs/source/en/package_reference/environment_variables.md
+++ b/docs/source/en/package_reference/environment_variables.md
@@ -84,6 +84,10 @@ Integer value to define the number of seconds to wait for server response when f
 
 Integer value to define the number of seconds to wait for server response when downloading a file. If the request times out, a TimeoutError is raised. Setting a higher value is beneficial on machine with a slow connection. A smaller value makes the process fail quicker in case of complete network outage. Default to 10s.
 
+### HF_HUB_DOWNLOAD_CHUNK_SIZE
+
+Integer value (in bytes) to control the chunk size used by the HTTP download path (`hf_hub_download`, `snapshot_download` with `HF_HUB_DISABLE_XET=1`). The progress callback fires once per chunk, so a smaller value makes progress bars animate more smoothly on slow connections; a larger value reduces per-byte Python overhead. Defaults to `10485760` (10 MiB).
+
 ## Xet 
 
 ### Other Xet environment variables

--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -35,7 +35,12 @@ EVAL_RESULTS_FOLDER = ".eval_results"
 DEFAULT_ETAG_TIMEOUT = 10
 DEFAULT_DOWNLOAD_TIMEOUT = 10
 DEFAULT_REQUEST_TIMEOUT = 10
-DOWNLOAD_CHUNK_SIZE = 10 * 1024 * 1024
+DEFAULT_DOWNLOAD_CHUNK_SIZE = 10 * 1024 * 1024
+# Allow users to tune the HTTP-download chunk size at the system level.
+# A smaller chunk size makes the per-chunk progress callback fire more often
+# (smoother progress bars on slow connections), at the cost of slightly more
+# Python overhead per byte. See issue #4129 for context.
+DOWNLOAD_CHUNK_SIZE = _as_int(os.environ.get("HF_HUB_DOWNLOAD_CHUNK_SIZE")) or DEFAULT_DOWNLOAD_CHUNK_SIZE
 MAX_HTTP_DOWNLOAD_SIZE = 50 * 1000 * 1000 * 1000  # 50 GB
 
 # Constants for serialization


### PR DESCRIPTION
Closes #4129.

## Summary

`http_get` streams response bytes in chunks of `DOWNLOAD_CHUNK_SIZE` (10 MiB by default). The user-supplied progress callback (`tqdm_class=...`) fires once per chunk, so on slow connections (~1.5 MB/s home internet) the bar updates only every ~7 s, and small files often only get a single jump at the very end. The download itself is fine — only the displayed progress is coarse.

The reporter's existing workaround is to monkey-patch the constant before any HF call. This PR exposes the same lever via an env var so users don't have to reach into private state.

```python
# Before: monkey-patch the internal constant
from huggingface_hub import constants as _c
_c.DOWNLOAD_CHUNK_SIZE = 200 * 1024

# After: standard env var, picked up at import time
HF_HUB_DOWNLOAD_CHUNK_SIZE=204800 python download.py
```

## Reproduce BEFORE/AFTER

```bash
# BEFORE: env var has no effect
HF_HUB_DOWNLOAD_CHUNK_SIZE=204800 python -c \"from huggingface_hub import constants; print(constants.DOWNLOAD_CHUNK_SIZE)\"
# 10485760  (default, unchanged)

# AFTER: env var is honored
HF_HUB_DOWNLOAD_CHUNK_SIZE=204800 python -c \"from huggingface_hub import constants; print(constants.DOWNLOAD_CHUNK_SIZE)\"
# 204800
```

## Notes

- Default is unchanged at 10 MiB.
- Added to the env-var reference doc next to `HF_HUB_DOWNLOAD_TIMEOUT`.
- This is a pure addition: existing code reads `constants.DOWNLOAD_CHUNK_SIZE` and that resolution path still works.

---

🤖 Disclosure: Authored with assistance from Claude (Anthropic), tested locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, additive configurability; behavior is unchanged unless users set `HF_HUB_DOWNLOAD_CHUNK_SIZE`, though an invalid non-integer value would now raise at import time for those users.
> 
> **Overview**
> Adds a new `HF_HUB_DOWNLOAD_CHUNK_SIZE` environment variable to control the chunk size used by the HTTP streaming download path, defaulting to the existing 10 MiB.
> 
> Updates `constants.DOWNLOAD_CHUNK_SIZE` to be derived from this env var at import time (with a new `DEFAULT_DOWNLOAD_CHUNK_SIZE` constant) and documents the new knob in the environment-variable reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af3783541d511d17ca0fd87e605bd6ddfa789e4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->