### PR TITLE
Make HF_HUB_ENABLE_HF_TRANSFER deprecation warning visible to users

### DIFF
--- a/docs/source/en/guides/upload.md
+++ b/docs/source/en/guides/upload.md
@@ -96,6 +96,9 @@ check if a local folder or file has the same name as the `repo_id`. If that's th
 Otherwise, an exception is raised asking the user to explicitly set `local_path`. In any case, if `path_in_repo` is not
 set, files are uploaded at the root of the repo.
 
+> [!TIP]
+> For maximum upload throughput on large files, set the [`HF_XET_HIGH_PERFORMANCE=1`](../package_reference/environment_variables.md#hf_xet_high_performance) environment variable. This enables `hf_xet`'s high-performance mode, which saturates available bandwidth and CPU cores. Note: the legacy `HF_HUB_ENABLE_HF_TRANSFER=1` flag is no longer used since `hf_transfer` was removed in favor of `hf_xet` — set `HF_XET_HIGH_PERFORMANCE=1` instead.
+
 For more details about the CLI upload command, please refer to the [CLI guide](./cli#hf-upload).
 
 ## Upload a large folder

--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -268,11 +268,10 @@ HF_XET_HIGH_PERFORMANCE: bool = _is_true(os.environ.get("HF_XET_HIGH_PERFORMANCE
 HF_JOBS_ARTIFACTS_BUCKET_NAME: str = "jobs-artifacts"
 HF_JOBS_ARTIFACTS_MOUNT_PATH: str = "/data"
 
-# hf_transfer is not used anymore. Warn the user whenever the legacy env var is set.
+# hf_transfer is not used anymore. Let's warn user is case they set the env variable.
 # Note: we use FutureWarning (shown by default) instead of DeprecationWarning (silenced
-# by default for end users) because most affected users only set the legacy flag and
-# would never see a DeprecationWarning under standard `python` execution.
-if _is_true(os.environ.get("HF_HUB_ENABLE_HF_TRANSFER")):
+# by default for end users) so users running standard `python` actually see the message.
+if _is_true(os.environ.get("HF_HUB_ENABLE_HF_TRANSFER")) and not HF_XET_HIGH_PERFORMANCE:
     import warnings
 
     warnings.warn(

--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -268,15 +268,18 @@ HF_XET_HIGH_PERFORMANCE: bool = _is_true(os.environ.get("HF_XET_HIGH_PERFORMANCE
 HF_JOBS_ARTIFACTS_BUCKET_NAME: str = "jobs-artifacts"
 HF_JOBS_ARTIFACTS_MOUNT_PATH: str = "/data"
 
-# hf_transfer is not used anymore. Let's warn user is case they set the env variable
-if _is_true(os.environ.get("HF_HUB_ENABLE_HF_TRANSFER")) and not HF_XET_HIGH_PERFORMANCE:
+# hf_transfer is not used anymore. Warn the user whenever the legacy env var is set.
+# Note: we use FutureWarning (shown by default) instead of DeprecationWarning (silenced
+# by default for end users) because most affected users only set the legacy flag and
+# would never see a DeprecationWarning under standard `python` execution.
+if _is_true(os.environ.get("HF_HUB_ENABLE_HF_TRANSFER")):
     import warnings
 
     warnings.warn(
         "The `HF_HUB_ENABLE_HF_TRANSFER` environment variable is deprecated as 'hf_transfer' is not used anymore. "
         "Please use `HF_XET_HIGH_PERFORMANCE` instead to enable high performance transfer with Xet. "
         "Visit https://huggingface.co/docs/huggingface_hub/package_reference/environment_variables#hfxethighperformance for more details.",
-        DeprecationWarning,
+        FutureWarning,
     )
 
 # Used to override the etag timeout on a system level


### PR DESCRIPTION
## What this changes

Closes #4219.

Two small changes so users with the legacy `HF_HUB_ENABLE_HF_TRANSFER=1` env variable actually learn about its deprecation and the replacement flag.

### `src/huggingface_hub/constants.py`

Changed `DeprecationWarning` → `FutureWarning`. Python silences `DeprecationWarning` by default in user-facing code, so end users running `hf upload …` from the CLI never saw the deprecation message even though the warning was being raised. `FutureWarning` is shown by default and matches the intent (alert the user that their current configuration is no longer effective). This also matches the existing convention in this package — the other `warnings.warn(...)` calls under `src/huggingface_hub/` use `FutureWarning`.

> **Note:** the initial revision of this PR also removed the `and not HF_XET_HIGH_PERFORMANCE` guard. Cursor Bugbot correctly flagged that I had the boolean logic inverted — the existing guard already fires in the common user case (legacy flag set, new flag not set), and correctly suppresses the warning for users who have already migrated to `HF_XET_HIGH_PERFORMANCE=1` but still have the legacy variable lingering in their environment. The guard has been restored in commit 936145db; only the `FutureWarning` change remains.

### `docs/source/en/guides/upload.md`

Added a TIP callout in the **Upload from the CLI** section pointing users to `HF_XET_HIGH_PERFORMANCE=1` for max throughput, and explicitly noting that the legacy `HF_HUB_ENABLE_HF_TRANSFER=1` flag is no longer effective. Currently this guidance is buried in the "Tips and tricks for large uploads" sub-section, which most users following the basic CLI quickstart never reach.

## Why

Discovered while uploading a 7.7 GB safetensors file from a residential WiFi connection — set `HF_HUB_ENABLE_HF_TRANSFER=1` per multiple older tutorials, saw no speedup, never saw any warning. After a lot of digging realized the warning was being raised but silently filtered by Python's default `DeprecationWarning` behavior. The forum has a long thread (https://discuss.huggingface.co/t/upload-speeds-extremely-slow-stalling-since-april-1st/174910) of users hitting the same confusion and being directed to `HF_HUB_DISABLE_XET=1` workarounds rather than the documented `HF_XET_HIGH_PERFORMANCE=1` path.

## Test plan

- [x] `python -c "import ast; ast.parse(open('src/huggingface_hub/constants.py').read())"` parses cleanly.
- [x] Existing 5 `[!TIP]` callouts in `docs/source/en/guides/upload.md` use the same syntax as the new one.
- [x] Setting `HF_HUB_ENABLE_HF_TRANSFER=1` (without `HF_XET_HIGH_PERFORMANCE`) and importing `huggingface_hub` now emits a visible `FutureWarning` (manually verified).
- [x] Setting both `HF_HUB_ENABLE_HF_TRANSFER=1` and `HF_XET_HIGH_PERFORMANCE=1` correctly suppresses the warning for already-migrated users.
- [ ] Will run `make style` / `make quality` and `pytest tests` before merge if maintainers want — happy to push fixups.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates user-facing documentation and changes a warning class from `DeprecationWarning` to `FutureWarning` without affecting upload logic or API behavior.
> 
> **Overview**
> Clarifies CLI upload guidance by adding a **TIP** recommending `HF_XET_HIGH_PERFORMANCE=1` for maximum throughput and explicitly noting `HF_HUB_ENABLE_HF_TRANSFER` is no longer effective.
> 
> Updates the legacy `HF_HUB_ENABLE_HF_TRANSFER` deprecation notice in `constants.py` to emit a user-visible `FutureWarning` (instead of a typically-silenced `DeprecationWarning`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 936145dbdc7069ec09336da4a02099678a9414d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->