### PR TITLE
[docs] Drop duplicated Key Features list from hf jobs CLI section

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -1666,7 +1666,7 @@ Run compute jobs on Hugging Face infrastructure with a familiar Docker-like inte
 ```
 
 > [!TIP]
-> **Hugging Face Jobs** are available only to [Pro users](https://huggingface.co/pro) and [Team or Enterprise organizations](https://huggingface.co/enterprise). Upgrade your plan to get started!
+> **Hugging Face Jobs** are available to any user or organization with [pre-paid credits](https://huggingface.co/settings/billing).
 
 ### Quick Start
 

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -1645,6 +1645,8 @@ Run compute jobs on Hugging Face infrastructure with a familiar Docker-like inte
 
 `hf jobs` is a command-line tool that lets you run anything on Hugging Face's infrastructure (including GPUs and TPUs!) with simple commands. Think `docker run`, but for running code on A100s.
 
+**For a general overview of Jobs and pricing, see the [Hub Jobs documentation](https://huggingface.co/docs/hub/jobs).** For Python API usage alongside the CLI, see the [Run and manage Jobs guide](./jobs).
+
 ```bash
 # Directly run Python code
 >>> hf jobs run python:3.12 python -c 'print("Hello from the cloud!")'
@@ -1662,15 +1664,6 @@ Run compute jobs on Hugging Face infrastructure with a familiar Docker-like inte
 # Run a Python script with `uv` (experimental)
 >>> hf jobs uv run my_script.py
 ```
-
-### ✨ Key Features
-
-- 🐳 **Docker-like CLI**: Familiar commands (`run`, `ps`, `logs`, `inspect`) to run and manage jobs
-- 🔥 **Any Hardware**: From CPUs to A100 GPUs and TPU pods - switch with a simple flag
-- 📦 **Run Anything**: Use Docker images, HF Spaces, or your custom containers
-- 🔐 **Simple Auth**: Just use your HF token
-- 📊 **Live Monitoring**: Stream logs in real-time, just like running locally
-- 💰 **Pay-as-you-go**: Only pay for the seconds you use
 
 > [!TIP]
 > **Hugging Face Jobs** are available only to [Pro users](https://huggingface.co/pro) and [Team or Enterprise organizations](https://huggingface.co/enterprise). Upgrade your plan to get started!


### PR DESCRIPTION
The `hf jobs` section opened with a Key Features bullet list copied from the original standalone-`jobs` README. The same framing already lives in the [Hub Jobs documentation](https://huggingface.co/docs/hub/jobs) (rendered as a feature-card grid) and `guides/jobs.md` cross-links to it the same way.

Drops the inline bullets, adds the cross-link. Brings the section in line with sibling CLI sections (`hf download`, `hf upload`, `hf buckets`).

Also updates the gating Tip callout to reference pre-paid credits rather than Pro/Team plans, mirroring the wording in [hub-docs#2429](https://github.com/huggingface/hub-docs/pull/2429).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; it removes duplicated marketing bullets and updates eligibility wording, with no code or API behavior impact.
> 
> **Overview**
> Updates the `hf jobs` CLI guide to **link out to the Hub Jobs docs for the feature/pricing overview** and removes the duplicated “Key Features” bullet list.
> 
> Also revises the tip callout to state Jobs availability is based on having **pre-paid credits** (instead of Pro/Team plan gating).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d58e3907903e0e826a97ed9dacf1034adc85b8ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->