### PR TITLE
[Hub] Allow SPDX -or-later licenses in README validation

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -34,6 +34,7 @@ from urllib.parse import quote, unquote
 
 import httpcore
 import httpx
+import yaml
 from tqdm.auto import tqdm as base_tqdm
 from tqdm.contrib.concurrent import thread_map
 
@@ -237,6 +238,7 @@ REPO_REGIONS = Literal["us", "eu"]
 USERNAME_PLACEHOLDER = "hf_user"
 _REGEX_DISCUSSION_URL = re.compile(r".*/discussions/(\d+)$")
 _REGEX_HTTP_PROTOCOL = re.compile(r"https?://")
+_REGEX_REPOCARD_YAML_BLOCK = re.compile(r"^(\s*---[\r\n]+)([\S\s]*?)([\r\n]+---(\r\n|\n|$))")
 
 _CREATE_COMMIT_NO_REPO_ERROR_MESSAGE = (
     "\nNote: Creating a commit assumes that the repo already exists on the"
@@ -262,6 +264,53 @@ SPECIAL_REFS_REVISION_REGEX = re.compile(
 )
 
 logger = logging.get_logger(__name__)
+
+
+def _extract_license_values_from_readme(content: str) -> list[str]:
+    match = _REGEX_REPOCARD_YAML_BLOCK.search(content)
+    if match is None:
+        return []
+
+    try:
+        data = yaml.safe_load(match.group(2))
+    except yaml.YAMLError:
+        return []
+
+    if not isinstance(data, dict):
+        return []
+
+    license_value = data.get("license")
+    if isinstance(license_value, str):
+        return [license_value]
+    if isinstance(license_value, list):
+        return [value for value in license_value if isinstance(value, str)]
+    return []
+
+
+def _is_spdx_or_later_license(value: str) -> bool:
+    return value.strip().lower().endswith("-or-later")
+
+
+def _is_license_validation_error(error: dict[str, Any]) -> bool:
+    message = str(error.get("message", "")).lower()
+    if "must be one of" in message and "license" in message:
+        return True
+
+    location = error.get("loc") or error.get("path")
+    if isinstance(location, list):
+        return any(str(item).lower() == "license" for item in location)
+    return False
+
+
+def _should_ignore_spdx_or_later_license_error(content: str, errors: list[dict[str, Any]]) -> bool:
+    if not errors or not all(_is_license_validation_error(error) for error in errors):
+        return False
+
+    license_values = _extract_license_values_from_readme(content)
+    if not license_values:
+        return False
+
+    return all(_is_spdx_or_later_license(value) for value in license_values)
 
 
 def _resolve_repo_visibility(
@@ -10993,6 +11042,13 @@ class HfApi:
             hf_raise_for_status(response)
         except BadRequestError as e:
             errors = response_content.get("errors", [])
+            if _should_ignore_spdx_or_later_license_error(content, errors):
+                warnings.warn(
+                    "Hub validation rejected SPDX license identifiers ending with '-or-later'. "
+                    "Proceeding without blocking validation. If the Hub later rejects the metadata, "
+                    "use `license_name` and `license_link` instead."
+                )
+                return
             message = "\n".join([f"- {error.get('message')}" for error in errors])
             raise ValueError(f"Invalid metadata in README.md.\n{message}") from e
 

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -238,6 +238,10 @@ REPO_REGIONS = Literal["us", "eu"]
 USERNAME_PLACEHOLDER = "hf_user"
 _REGEX_DISCUSSION_URL = re.compile(r".*/discussions/(\d+)$")
 _REGEX_HTTP_PROTOCOL = re.compile(r"https?://")
+# NOTE: This is a copy of REGEX_YAML_BLOCK from repocard.py, which must stay
+# in sync with the Hub server's YAML block parser.
+# See https://github.com/huggingface/moon-landing/blob/main/server/lib/ViewMarkdown.ts#L18
+# If you update this regex, update REGEX_YAML_BLOCK in repocard.py too (or vice versa).
 _REGEX_REPOCARD_YAML_BLOCK = re.compile(r"^(\s*---[\r\n]+)([\S\s]*?)([\r\n]+---(\r\n|\n|$))")
 
 _CREATE_COMMIT_NO_REPO_ERROR_MESSAGE = (

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -29,6 +29,7 @@ from typing import Optional, Union, get_args
 from unittest.mock import Mock, patch
 from urllib.parse import urlparse
 
+import httpx
 import pytest
 
 from huggingface_hub import HfApi, SpaceHardware, SpaceStage, SpaceStorage, constants
@@ -1065,6 +1066,18 @@ class CommitApiTest(HfApiCommonTest):
 
         # Commit still happened correctly
         assert isinstance(commit, CommitInfo)
+
+    def test_validate_yaml_accepts_spdx_or_later_license(self) -> None:
+        content = "---\nlicense: gpl-2.0-or-later\n---\n\n# Model Card\n"
+        response = httpx.Response(
+            status_code=400,
+            json={"errors": [{"message": '"license" must be one of [mit]'}], "warnings": []},
+            request=httpx.Request("POST", "https://huggingface.co/api/validate-yaml"),
+        )
+        with patch("huggingface_hub.hf_api.get_session") as mock_get_session:
+            mock_get_session.return_value.post.return_value = response
+            with self.assertWarnsRegex(UserWarning, "SPDX license identifiers ending with '-or-later'"):
+                self._api._validate_yaml(content)
 
     def test_create_file_with_relative_path(self):
         """Creating a file with a relative path_in_repo is forbidden.


### PR DESCRIPTION
fixes #4218

## Summary
- Allow SPDX `*-or-later` license identifiers in README metadata validation while warning.
- Add unit coverage for the `-or-later` validation path.

## Examples
```
$ PATH="/tmp/pyshim:$PATH" PYTHONPATH=src make quality
ruff check src tests utils setup.py  # linter
All checks passed!
ruff format --check src tests utils setup.py # formatter
268 files already formatted
ty check src
All checks passed!
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes client-side README metadata validation to ignore a specific Hub 400 error pattern, which could let some invalid license metadata through if the detection is too broad, but scope is limited to `license` fields ending in `-or-later`.
> 
> **Overview**
> README metadata validation in `HfApi._validate_yaml` now **special-cases Hub 400 validation errors for `license`**: if the README’s YAML front-matter contains only SPDX identifiers ending in `-or-later`, the client warns and continues instead of raising `ValueError`.
> 
> This adds YAML parsing helpers (and a shared YAML-block regex) to extract `license` values from the README, plus a unit test that asserts the warning + non-failing behavior when the server responds with a license "must be one of" error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 029bdef1f14d1a332ff291a36cc7fc9bb2de27b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->