### PR TITLE
[CLI] Allow hf cache rm repo:path for file/variant deletions

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -1442,7 +1442,7 @@ Deleted 2 repo(s) and 2 revision(s); freed 5.31G.
 
 ### hf cache rm
 
-`hf cache rm` removes cached repositories or individual revisions. Pass one or more repo IDs (`model/bert-base-uncased`) or revision hashes:
+`hf cache rm` removes cached repositories, individual revisions, or specific files inside a cached repo. Pass one or more repo IDs (`model/bert-base-uncased`), revision hashes, or `repo_id:path_in_repo` targets:
 
 ```bash
 >>> hf cache rm model/LiquidAI/LFM2-VL-1.6B
@@ -1452,6 +1452,15 @@ Proceed with deletion? [y/N]: y
 Delete repo: ~/.cache/huggingface/hub/models--LiquidAI--LFM2-VL-1.6B
 Cache deletion done. Saved 3.2G.
 Deleted 1 repo(s) and 2 revision(s); freed 3.2G.
+```
+
+```bash
+>>> hf cache rm unsloth/gemma-4-26B-A4B-it-GGUF:UD-IQ4_NL --dry-run
+About to delete 1 file(s) totalling 2.1G.
+  - model/unsloth/gemma-4-26B-A4B-it-GGUF:
+      ffffffffffffffffffffffffffffffffffffffff [main]
+        UD-IQ4_NL 2.1G
+Dry run: no files were deleted.
 ```
 
 Mix repositories and specific revisions in the same call. Use `--dry-run` to preview the impact, or `--yes` to skip the confirmation prompt—handy in automated scripts:

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -552,7 +552,7 @@ $ hf cache [OPTIONS] COMMAND [ARGS]...
 
 * `list`: List cached repositories or revisions. [alias: ls]
 * `prune`: Remove detached revisions from the cache.
-* `rm`: Remove cached repositories or revisions.
+* `rm`: Remove cached repositories, revisions, or...
 * `verify`: Verify checksums for a single repo...
 
 ### `hf cache list`
@@ -613,7 +613,7 @@ Learn more
 
 ### `hf cache rm`
 
-Remove cached repositories or revisions.
+Remove cached repositories, revisions, or files.
 
 **Usage**:
 
@@ -623,7 +623,7 @@ $ hf cache rm [OPTIONS] TARGETS...
 
 **Arguments**:
 
-* `TARGETS...`: One or more repo IDs (e.g. model/bert-base-uncased) or revision hashes to delete.  [required]
+* `TARGETS...`: One or more repo IDs (e.g. model/bert-base-uncased), revision hashes, or repo:path targets to delete.  [required]
 
 **Options**:
 
@@ -635,6 +635,7 @@ $ hf cache rm [OPTIONS] TARGETS...
 Examples
   $ hf cache rm model/gpt2
   $ hf cache rm <revision_hash>
+  $ hf cache rm unsloth/gemma-4-26B-A4B-it-GGUF:UD-IQ4_NL
   $ hf cache rm model/gpt2 --dry-run
   $ hf cache rm model/gpt2 --yes
 

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -83,6 +83,7 @@ _SUBMOD_ATTRS = {
         "JobOwner",
         "JobStage",
         "JobStatus",
+        "Volume",
     ],
     "_login": [
         "auth_list",
@@ -105,11 +106,9 @@ _SUBMOD_ATTRS = {
     "_space_api": [
         "SpaceHardware",
         "SpaceRuntime",
-        "SpaceSecret",
         "SpaceStage",
         "SpaceStorage",
         "SpaceVariable",
-        "Volume",
     ],
     "_tensorboard_logger": [
         "HFSummaryWriter",
@@ -183,14 +182,12 @@ _SUBMOD_ATTRS = {
         "GitRefInfo",
         "GitRefs",
         "HfApi",
-        "KernelInfo",
         "ModelInfo",
         "Organization",
         "RepoFile",
         "RepoFolder",
         "RepoUrl",
         "SpaceInfo",
-        "SpaceSearchResult",
         "User",
         "UserLikes",
         "WebhookInfo",
@@ -206,7 +203,6 @@ _SUBMOD_ATTRS = {
         "cancel_job",
         "change_discussion_status",
         "comment_discussion",
-        "copy_files",
         "create_branch",
         "create_bucket",
         "create_collection",
@@ -233,7 +229,6 @@ _SUBMOD_ATTRS = {
         "delete_space_secret",
         "delete_space_storage",
         "delete_space_variable",
-        "delete_space_volumes",
         "delete_tag",
         "delete_webhook",
         "disable_space_dev_mode",
@@ -246,7 +241,6 @@ _SUBMOD_ATTRS = {
         "enable_webhook",
         "fetch_job_logs",
         "fetch_job_metrics",
-        "fetch_space_logs",
         "file_exists",
         "get_bucket_file_metadata",
         "get_bucket_paths_info",
@@ -263,14 +257,12 @@ _SUBMOD_ATTRS = {
         "get_repo_discussions",
         "get_safetensors_metadata",
         "get_space_runtime",
-        "get_space_secrets",
         "get_space_variables",
         "get_user_overview",
         "get_webhook",
         "grant_access",
         "inspect_job",
         "inspect_scheduled_job",
-        "kernel_info",
         "list_accepted_access_requests",
         "list_bucket_tree",
         "list_buckets",
@@ -296,7 +288,6 @@ _SUBMOD_ATTRS = {
         "list_repo_refs",
         "list_repo_tree",
         "list_spaces",
-        "list_spaces_hardware",
         "list_user_followers",
         "list_user_following",
         "list_webhooks",
@@ -327,9 +318,7 @@ _SUBMOD_ATTRS = {
         "run_job",
         "run_uv_job",
         "scale_to_zero_inference_endpoint",
-        "search_spaces",
         "set_space_sleep_time",
-        "set_space_volumes",
         "space_info",
         "super_squash_history",
         "suspend_scheduled_job",
@@ -585,7 +574,6 @@ _SUBMOD_ATTRS = {
         "CorruptedCacheException",
         "DeleteCacheStrategy",
         "HFCacheInfo",
-        "HfUri",
         "cached_assets_path",
         "close_session",
         "dump_environment_info",
@@ -594,7 +582,6 @@ _SUBMOD_ATTRS = {
         "get_token",
         "hf_raise_for_status",
         "logging",
-        "parse_hf_uri",
         "scan_cache_dir",
         "set_async_client_factory",
         "set_client_factory",
@@ -725,7 +712,6 @@ __all__ = [
     "HfFileSystemFile",
     "HfFileSystemResolvedPath",
     "HfFileSystemStreamFile",
-    "HfUri",
     "ImageClassificationInput",
     "ImageClassificationOutputElement",
     "ImageClassificationOutputTransform",
@@ -768,7 +754,6 @@ __all__ = [
     "JobOwner",
     "JobStage",
     "JobStatus",
-    "KernelInfo",
     "MCPClient",
     "ModelCard",
     "ModelCardData",
@@ -803,8 +788,6 @@ __all__ = [
     "SpaceHardware",
     "SpaceInfo",
     "SpaceRuntime",
-    "SpaceSearchResult",
-    "SpaceSecret",
     "SpaceStage",
     "SpaceStorage",
     "SpaceVariable",
@@ -918,7 +901,6 @@ __all__ = [
     "check_cli_update",
     "close_session",
     "comment_discussion",
-    "copy_files",
     "create_branch",
     "create_bucket",
     "create_collection",
@@ -945,7 +927,6 @@ __all__ = [
     "delete_space_secret",
     "delete_space_storage",
     "delete_space_variable",
-    "delete_space_volumes",
     "delete_tag",
     "delete_webhook",
     "disable_space_dev_mode",
@@ -962,7 +943,6 @@ __all__ = [
     "export_folder_as_dduf",
     "fetch_job_logs",
     "fetch_job_metrics",
-    "fetch_space_logs",
     "file_exists",
     "from_pretrained_fastai",
     "get_async_session",
@@ -983,7 +963,6 @@ __all__ = [
     "get_safetensors_metadata",
     "get_session",
     "get_space_runtime",
-    "get_space_secrets",
     "get_space_variables",
     "get_token",
     "get_torch_storage_id",
@@ -999,7 +978,6 @@ __all__ = [
     "inspect_scheduled_job",
     "interpreter_login",
     "is_offline_mode",
-    "kernel_info",
     "list_accepted_access_requests",
     "list_bucket_tree",
     "list_buckets",
@@ -1025,7 +1003,6 @@ __all__ = [
     "list_repo_refs",
     "list_repo_tree",
     "list_spaces",
-    "list_spaces_hardware",
     "list_user_followers",
     "list_user_following",
     "list_webhooks",
@@ -1045,7 +1022,6 @@ __all__ = [
     "notebook_login",
     "paper_info",
     "parse_eval_result_entries",
-    "parse_hf_uri",
     "parse_huggingface_oauth",
     "parse_local_safetensors_file_metadata",
     "parse_safetensors_file_metadata",
@@ -1074,11 +1050,9 @@ __all__ = [
     "save_torch_state_dict",
     "scale_to_zero_inference_endpoint",
     "scan_cache_dir",
-    "search_spaces",
     "set_async_client_factory",
     "set_client_factory",
     "set_space_sleep_time",
-    "set_space_volumes",
     "snapshot_download",
     "space_info",
     "split_state_dict_into_shards_factory",
@@ -1233,6 +1207,7 @@ if TYPE_CHECKING:  # pragma: no cover
         JobOwner,  # noqa: F401
         JobStage,  # noqa: F401
         JobStatus,  # noqa: F401
+        Volume,  # noqa: F401
     )
     from ._login import (
         auth_list,  # noqa: F401
@@ -1253,11 +1228,9 @@ if TYPE_CHECKING:  # pragma: no cover
     from ._space_api import (
         SpaceHardware,  # noqa: F401
         SpaceRuntime,  # noqa: F401
-        SpaceSecret,  # noqa: F401
         SpaceStage,  # noqa: F401
         SpaceStorage,  # noqa: F401
         SpaceVariable,  # noqa: F401
-        Volume,  # noqa: F401
     )
     from ._tensorboard_logger import HFSummaryWriter  # noqa: F401
     from ._webhooks_payload import (
@@ -1329,14 +1302,12 @@ if TYPE_CHECKING:  # pragma: no cover
         GitRefInfo,  # noqa: F401
         GitRefs,  # noqa: F401
         HfApi,  # noqa: F401
-        KernelInfo,  # noqa: F401
         ModelInfo,  # noqa: F401
         Organization,  # noqa: F401
         RepoFile,  # noqa: F401
         RepoFolder,  # noqa: F401
         RepoUrl,  # noqa: F401
         SpaceInfo,  # noqa: F401
-        SpaceSearchResult,  # noqa: F401
         User,  # noqa: F401
         UserLikes,  # noqa: F401
         WebhookInfo,  # noqa: F401
@@ -1352,7 +1323,6 @@ if TYPE_CHECKING:  # pragma: no cover
         cancel_job,  # noqa: F401
         change_discussion_status,  # noqa: F401
         comment_discussion,  # noqa: F401
-        copy_files,  # noqa: F401
         create_branch,  # noqa: F401
         create_bucket,  # noqa: F401
         create_collection,  # noqa: F401
@@ -1379,7 +1349,6 @@ if TYPE_CHECKING:  # pragma: no cover
         delete_space_secret,  # noqa: F401
         delete_space_storage,  # noqa: F401
         delete_space_variable,  # noqa: F401
-        delete_space_volumes,  # noqa: F401
         delete_tag,  # noqa: F401
         delete_webhook,  # noqa: F401
         disable_space_dev_mode,  # noqa: F401
@@ -1392,7 +1361,6 @@ if TYPE_CHECKING:  # pragma: no cover
         enable_webhook,  # noqa: F401
         fetch_job_logs,  # noqa: F401
         fetch_job_metrics,  # noqa: F401
-        fetch_space_logs,  # noqa: F401
         file_exists,  # noqa: F401
         get_bucket_file_metadata,  # noqa: F401
         get_bucket_paths_info,  # noqa: F401
@@ -1409,14 +1377,12 @@ if TYPE_CHECKING:  # pragma: no cover
         get_repo_discussions,  # noqa: F401
         get_safetensors_metadata,  # noqa: F401
         get_space_runtime,  # noqa: F401
-        get_space_secrets,  # noqa: F401
         get_space_variables,  # noqa: F401
         get_user_overview,  # noqa: F401
         get_webhook,  # noqa: F401
         grant_access,  # noqa: F401
         inspect_job,  # noqa: F401
         inspect_scheduled_job,  # noqa: F401
-        kernel_info,  # noqa: F401
         list_accepted_access_requests,  # noqa: F401
         list_bucket_tree,  # noqa: F401
         list_buckets,  # noqa: F401
@@ -1442,7 +1408,6 @@ if TYPE_CHECKING:  # pragma: no cover
         list_repo_refs,  # noqa: F401
         list_repo_tree,  # noqa: F401
         list_spaces,  # noqa: F401
-        list_spaces_hardware,  # noqa: F401
         list_user_followers,  # noqa: F401
         list_user_following,  # noqa: F401
         list_webhooks,  # noqa: F401
@@ -1473,9 +1438,7 @@ if TYPE_CHECKING:  # pragma: no cover
         run_job,  # noqa: F401
         run_uv_job,  # noqa: F401
         scale_to_zero_inference_endpoint,  # noqa: F401
-        search_spaces,  # noqa: F401
         set_space_sleep_time,  # noqa: F401
-        set_space_volumes,  # noqa: F401
         space_info,  # noqa: F401
         super_squash_history,  # noqa: F401
         suspend_scheduled_job,  # noqa: F401
@@ -1725,7 +1688,6 @@ if TYPE_CHECKING:  # pragma: no cover
         CorruptedCacheException,  # noqa: F401
         DeleteCacheStrategy,  # noqa: F401
         HFCacheInfo,  # noqa: F401
-        HfUri,  # noqa: F401
         cached_assets_path,  # noqa: F401
         close_session,  # noqa: F401
         dump_environment_info,  # noqa: F401
@@ -1734,7 +1696,6 @@ if TYPE_CHECKING:  # pragma: no cover
         get_token,  # noqa: F401
         hf_raise_for_status,  # noqa: F401
         logging,  # noqa: F401
-        parse_hf_uri,  # noqa: F401
         scan_cache_dir,  # noqa: F401
         set_async_client_factory,  # noqa: F401
         set_client_factory,  # noqa: F401

--- a/src/huggingface_hub/cli/cache.py
+++ b/src/huggingface_hub/cli/cache.py
@@ -515,8 +515,9 @@ def _build_delete_strategy(
             continue
 
         total_revision_count += len(selected_revisions)
-        partial_revision_count += len(selected_files_by_revision)
-        file_count += sum(len(files) for files in selected_files_by_revision.values())
+        # Only count partial revisions that are not already selected as full revisions
+        partial_revision_count += sum(1 for rev in selected_files_by_revision.keys() if rev not in selected_revisions)
+        file_count += sum(len(files) for rev, files in selected_files_by_revision.items() if rev not in selected_revisions)
 
         total_blob_refs: dict[Path, int] = defaultdict(int)
         selected_blob_refs: dict[Path, int] = defaultdict(int)
@@ -533,6 +534,9 @@ def _build_delete_strategy(
                 selected_blob_refs[file.blob_path] += 1
 
         for revision, files in selected_files_by_revision.items():
+            if revision in selected_revisions:
+                # Files in this revision are already counted when deleting the whole revision
+                continue
             for file in files:
                 files_to_delete.add(file.file_path)
                 selected_blob_refs[file.blob_path] += 1
@@ -838,6 +842,7 @@ def prune(
     resolution = _DeletionResolution(
         revisions=frozenset(revisions),
         selected=selected,
+        selected_files={},
         missing=(),
     )
     strategy = hf_cache_info.delete_revisions(*sorted(resolution.revisions))

--- a/src/huggingface_hub/cli/cache.py
+++ b/src/huggingface_hub/cli/cache.py
@@ -19,13 +19,24 @@ from collections import defaultdict
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from enum import Enum
+from pathlib import Path
 from typing import Annotated, Any
 
 import typer
 
 from huggingface_hub.errors import CLIError
 
-from ..utils import ANSI, CachedRepoInfo, CachedRevisionInfo, CacheNotFound, HFCacheInfo, _format_size, scan_cache_dir
+from ..utils import (
+    ANSI,
+    CachedFileInfo,
+    CachedRepoInfo,
+    CachedRevisionInfo,
+    CacheNotFound,
+    DeleteCacheStrategy,
+    HFCacheInfo,
+    _format_size,
+    scan_cache_dir,
+)
 from ..utils._parsing import parse_duration, parse_size
 from ._cli_utils import RepoIdArg, RepoTypeOpt, RevisionOpt, TokenOpt, get_hf_api, typer_factory
 from ._output import out
@@ -41,6 +52,7 @@ cache_cli = typer_factory(help="Manage local cache directory.")
 class _DeletionResolution:
     revisions: frozenset[str]
     selected: dict[CachedRepoInfo, frozenset[CachedRevisionInfo]]
+    selected_files: dict[CachedRepoInfo, dict[CachedRevisionInfo, frozenset[CachedFileInfo]]]
     missing: tuple[str, ...]
 
 
@@ -75,6 +87,7 @@ class CacheDeletionCounts:
     repo_count: int
     partial_revision_count: int
     total_revision_count: int
+    file_count: int = 0
 
 
 CacheEntry = tuple[CachedRepoInfo, CachedRevisionInfo | None]
@@ -83,6 +96,8 @@ RepoRefsMap = dict[CachedRepoInfo, frozenset[str]]
 
 def summarize_deletions(
     selected_by_repo: Mapping[CachedRepoInfo, frozenset[CachedRevisionInfo]],
+    *,
+    selected_files: Mapping[CachedRepoInfo, Mapping[CachedRevisionInfo, frozenset[CachedFileInfo]]] | None = None,
 ) -> CacheDeletionCounts:
     """Summarize deletions across repositories."""
     repo_count = 0
@@ -96,22 +111,57 @@ def summarize_deletions(
             revisions_in_full_repos += len(revisions)
 
     partial_revision_count = total_revisions - revisions_in_full_repos
-    return CacheDeletionCounts(repo_count, partial_revision_count, total_revisions)
+    file_count = 0
+    if selected_files is not None:
+        file_count = sum(len(files) for revisions in selected_files.values() for files in revisions.values())
+
+    return CacheDeletionCounts(repo_count, partial_revision_count, total_revisions, file_count=file_count)
 
 
-def print_cache_selected_revisions(selected_by_repo: Mapping[CachedRepoInfo, frozenset[CachedRevisionInfo]]) -> None:
+def print_cache_selected_revisions(
+    selected_by_repo: Mapping[CachedRepoInfo, frozenset[CachedRevisionInfo]],
+    selected_files: Mapping[CachedRepoInfo, Mapping[CachedRevisionInfo, frozenset[CachedFileInfo]]] | None = None,
+) -> None:
     """Pretty-print selected cache revisions during confirmation prompts."""
-    for repo in sorted(selected_by_repo.keys(), key=lambda repo: (repo.repo_type, repo.repo_id.lower())):
+    selected_files = selected_files or {}
+    repos = sorted(
+        set(selected_by_repo) | set(selected_files), key=lambda repo: (repo.repo_type, repo.repo_id.lower())
+    )
+    for repo in repos:
         repo_key = f"{repo.repo_type}/{repo.repo_id}"
-        revisions = sorted(selected_by_repo[repo], key=lambda rev: rev.commit_hash)
-        if len(revisions) == len(repo.revisions):
+        revisions = sorted(selected_by_repo.get(repo, frozenset()), key=lambda rev: rev.commit_hash)
+        revision_files = selected_files.get(repo, {})
+
+        if len(revisions) == len(repo.revisions) and not revision_files:
             out.text(f"  - {repo_key} (entire repo)")
             continue
 
         out.text(f"  - {repo_key}:")
         for revision in revisions:
             refs = " ".join(sorted(revision.refs)) or "(detached)"
-            out.text(f"      {revision.commit_hash} [{refs}] {revision.size_on_disk_str}")
+            if revision not in revision_files:
+                out.text(f"      {revision.commit_hash} [{refs}] {revision.size_on_disk_str}")
+                continue
+
+            out.text(f"      {revision.commit_hash} [{refs}]")
+            for file in sorted(
+                revision_files[revision],
+                key=lambda file: file.file_path.relative_to(revision.snapshot_path).as_posix(),
+            ):
+                relative_path = file.file_path.relative_to(revision.snapshot_path).as_posix()
+                out.text(f"        {relative_path} {file.size_on_disk_str}")
+
+        for revision in sorted(
+            (rev for rev in revision_files.keys() if rev not in revisions), key=lambda rev: rev.commit_hash
+        ):
+            refs = " ".join(sorted(revision.refs)) or "(detached)"
+            out.text(f"      {revision.commit_hash} [{refs}]")
+            for file in sorted(
+                revision_files[revision],
+                key=lambda file: file.file_path.relative_to(revision.snapshot_path).as_posix(),
+            ):
+                relative_path = file.file_path.relative_to(revision.snapshot_path).as_posix()
+                out.text(f"        {relative_path} {file.size_on_disk_str}")
 
 
 def build_cache_index(
@@ -129,6 +179,66 @@ def build_cache_index(
         for revision in repo.revisions:
             revision_lookup[revision.commit_hash.lower()] = (repo, revision)
     return repo_lookup, revision_lookup
+
+
+def _normalize_cache_id(repo_target: str) -> str:
+    target = repo_target.strip().strip("/")
+    target = re.sub(r"^https?://huggingface\.co/", "", target).strip("/")
+    target = target.removeprefix("hf://").strip("/")
+
+    parts = target.split("/")
+    if len(parts) == 1:
+        repo_type = "model"
+        namespace = None
+        repo_id = parts[0]
+    elif parts[0] in {"model", "models", "dataset", "datasets", "space", "spaces", "kernel", "kernels"}:
+        repo_type = {
+            "model": "model",
+            "models": "model",
+            "dataset": "dataset",
+            "datasets": "dataset",
+            "space": "space",
+            "spaces": "space",
+            "kernel": "kernel",
+            "kernels": "kernel",
+        }[parts[0]]
+        remaining = parts[1:]
+        if len(remaining) == 1:
+            namespace = None
+            repo_id = remaining[0]
+        else:
+            namespace = remaining[0]
+            repo_id = remaining[1]
+    else:
+        repo_type = "model"
+        namespace = parts[0]
+        repo_id = parts[1]
+
+    if namespace is None:
+        return f"{repo_type}/{repo_id}"
+    return f"{repo_type}/{namespace}/{repo_id}"
+
+
+def _resolve_file_targets(
+    repo: CachedRepoInfo,
+    path_target: str,
+) -> dict[CachedRevisionInfo, frozenset[CachedFileInfo]]:
+    selected_files: dict[CachedRevisionInfo, set[CachedFileInfo]] = defaultdict(set)
+    normalized_path_target = path_target.strip("/")
+
+    for revision in repo.revisions:
+        for file in revision.files:
+            relative_path = file.file_path.relative_to(revision.snapshot_path).as_posix()
+            if "/" in normalized_path_target:
+                matches = relative_path == normalized_path_target
+            else:
+                matches = file.file_name == normalized_path_target or relative_path.endswith(
+                    f"/{normalized_path_target}"
+                )
+            if matches:
+                selected_files[revision].add(file)
+
+    return {revision: frozenset(files) for revision, files in selected_files.items()}
 
 
 def collect_cache_entries(
@@ -301,6 +411,9 @@ def _resolve_deletion_targets(hf_cache_info: HFCacheInfo, targets: list[str]) ->
     repo_lookup, revision_lookup = build_cache_index(hf_cache_info)
 
     selected: dict[CachedRepoInfo, set[CachedRevisionInfo]] = defaultdict(set)
+    selected_files: dict[CachedRepoInfo, dict[CachedRevisionInfo, set[CachedFileInfo]]] = defaultdict(
+        lambda: defaultdict(set)
+    )
     revisions: set[str] = set()
     missing: list[str] = []
 
@@ -320,7 +433,23 @@ def _resolve_deletion_targets(hf_cache_info: HFCacheInfo, targets: list[str]) ->
             revisions.add(revision.commit_hash)
             continue
 
-        matched_repo = repo_lookup.get(lowered)
+        if ":" in target:
+            repo_target, path_target = target.split(":", 1)
+            matched_repo = repo_lookup.get(_normalize_cache_id(repo_target).lower())
+            if matched_repo is None:
+                missing.append(raw_target)
+                continue
+
+            matching_files = _resolve_file_targets(matched_repo, path_target)
+            if not matching_files:
+                missing.append(raw_target)
+                continue
+
+            for revision, files in matching_files.items():
+                selected_files[matched_repo][revision].update(files)
+            continue
+
+        matched_repo = repo_lookup.get(_normalize_cache_id(target).lower())
         if matched_repo is None:
             missing.append(raw_target)
             continue
@@ -329,12 +458,108 @@ def _resolve_deletion_targets(hf_cache_info: HFCacheInfo, targets: list[str]) ->
             selected[matched_repo].add(revision)
             revisions.add(revision.commit_hash)
 
+    # Promote file deletions that fully remove a revision into revision deletions.
+    for repo, revision_to_files in list(selected_files.items()):
+        for revision, files in list(revision_to_files.items()):
+            if len(files) == len(revision.files):
+                selected[repo].add(revision)
+                revisions.add(revision.commit_hash)
+                del revision_to_files[revision]
+
+        if len(revision_to_files) == 0:
+            del selected_files[repo]
+
+    # Promote repos whose selected revisions cover all revisions.
+    for repo, revisions_to_delete in list(selected.items()):
+        revisions.update(revision.commit_hash for revision in revisions_to_delete)
+        if len(revisions_to_delete) == len(repo.revisions):
+            selected_files.pop(repo, None)
+
     frozen_selected = {repo: frozenset(revs) for repo, revs in selected.items()}
+    frozen_selected_files = {
+        repo: {revision: frozenset(files) for revision, files in revision_to_files.items()}
+        for repo, revision_to_files in selected_files.items()
+    }
     return _DeletionResolution(
         revisions=frozenset(revisions),
         selected=frozen_selected,
+        selected_files=frozen_selected_files,
         missing=tuple(missing),
     )
+
+
+def _build_delete_strategy(
+    hf_cache_info: HFCacheInfo, resolution: _DeletionResolution
+) -> tuple[DeleteCacheStrategy, CacheDeletionCounts]:
+    blobs_to_delete: set[Path] = set()
+    blob_sizes: dict[Path, int] = {}
+    files_to_delete: set[Path] = set()
+    refs_to_delete: set[Path] = set()
+    repos_to_delete: set[Path] = set()
+    snapshots_to_delete: set[Path] = set()
+
+    repo_count = 0
+    total_revision_count = 0
+    partial_revision_count = 0
+    file_count = 0
+
+    for repo in hf_cache_info.repos:
+        selected_revisions = resolution.selected.get(repo, frozenset())
+        selected_files_by_revision = resolution.selected_files.get(repo, {})
+
+        is_repo_fully_selected = len(selected_revisions) == len(repo.revisions) and not selected_files_by_revision
+        if is_repo_fully_selected:
+            repo_count += 1
+            total_revision_count += len(repo.revisions)
+            repos_to_delete.add(repo.repo_path)
+            continue
+
+        total_revision_count += len(selected_revisions)
+        partial_revision_count += len(selected_files_by_revision)
+        file_count += sum(len(files) for files in selected_files_by_revision.values())
+
+        total_blob_refs: dict[Path, int] = defaultdict(int)
+        selected_blob_refs: dict[Path, int] = defaultdict(int)
+
+        for revision in repo.revisions:
+            for file in revision.files:
+                total_blob_refs[file.blob_path] += 1
+                blob_sizes.setdefault(file.blob_path, file.size_on_disk)
+
+        for revision in selected_revisions:
+            snapshots_to_delete.add(revision.snapshot_path)
+            refs_to_delete.update(repo.repo_path / "refs" / ref for ref in revision.refs)
+            for file in revision.files:
+                selected_blob_refs[file.blob_path] += 1
+
+        for revision, files in selected_files_by_revision.items():
+            for file in files:
+                files_to_delete.add(file.file_path)
+                selected_blob_refs[file.blob_path] += 1
+
+        for blob_path, selected_count in selected_blob_refs.items():
+            if selected_count == total_blob_refs[blob_path]:
+                blobs_to_delete.add(blob_path)
+
+    expected_freed_size = sum(blob_sizes[blob_path] for blob_path in blobs_to_delete) + sum(
+        repo.size_on_disk for repo in hf_cache_info.repos if repo.repo_path in repos_to_delete
+    )
+
+    strategy = DeleteCacheStrategy(
+        blobs=frozenset(blobs_to_delete),
+        files=frozenset(files_to_delete),
+        refs=frozenset(refs_to_delete),
+        repos=frozenset(repos_to_delete),
+        snapshots=frozenset(snapshots_to_delete),
+        expected_freed_size=expected_freed_size,
+    )
+    counts = CacheDeletionCounts(
+        repo_count=repo_count,
+        partial_revision_count=partial_revision_count,
+        total_revision_count=total_revision_count,
+        file_count=file_count,
+    )
+    return strategy, counts
 
 
 #### Cache CLI commands
@@ -480,6 +705,7 @@ def ls(
     examples=[
         "hf cache rm model/gpt2",
         "hf cache rm <revision_hash>",
+        "hf cache rm unsloth/gemma-4-26B-A4B-it-GGUF:UD-IQ4_NL",
         "hf cache rm model/gpt2 --dry-run",
         "hf cache rm model/gpt2 --yes",
     ],
@@ -488,7 +714,7 @@ def rm(
     targets: Annotated[
         list[str],
         typer.Argument(
-            help="One or more repo IDs (e.g. model/bert-base-uncased) or revision hashes to delete.",
+            help="One or more repo IDs (e.g. model/bert-base-uncased), revision hashes, or repo:path targets to delete.",
         ),
     ],
     cache_dir: Annotated[
@@ -512,7 +738,7 @@ def rm(
         ),
     ] = False,
 ) -> None:
-    """Remove cached repositories or revisions."""
+    """Remove cached repositories, revisions, or files."""
     try:
         hf_cache_info = scan_cache_dir(cache_dir)
     except CacheNotFound as exc:
@@ -524,24 +750,25 @@ def rm(
         details = "\n".join(f"  - {entry}" for entry in resolution.missing)
         out.warning(f"Could not find in cache:\n{details}")
 
-    if len(resolution.revisions) == 0:
+    if len(resolution.revisions) == 0 and not resolution.selected_files:
         out.text("Nothing to delete.")
         raise typer.Exit(code=0)
 
-    strategy = hf_cache_info.delete_revisions(*sorted(resolution.revisions))
-    counts = summarize_deletions(resolution.selected)
+    strategy, counts = _build_delete_strategy(hf_cache_info, resolution)
 
     summary_parts: list[str] = []
     if counts.repo_count:
         summary_parts.append(f"{counts.repo_count} repo(s)")
-    if counts.partial_revision_count:
-        summary_parts.append(f"{counts.partial_revision_count} revision(s)")
-    if not summary_parts:
+    if counts.total_revision_count:
         summary_parts.append(f"{counts.total_revision_count} revision(s)")
+    if counts.file_count:
+        summary_parts.append(f"{counts.file_count} file(s)")
+    if not summary_parts:
+        summary_parts.append("Nothing")
 
     summary_text = " and ".join(summary_parts)
     out.text(f"About to delete {summary_text} totalling {strategy.expected_freed_size_str}.")
-    print_cache_selected_revisions(resolution.selected)
+    print_cache_selected_revisions(resolution.selected, resolution.selected_files)
 
     if dry_run:
         out.result(
@@ -549,6 +776,7 @@ def rm(
             dry_run=True,
             repos=counts.repo_count,
             revisions=counts.total_revision_count,
+            files=counts.file_count,
             size=strategy.expected_freed_size_str,
         )
         return
@@ -556,12 +784,11 @@ def rm(
     out.confirm("Proceed with deletion?", yes=yes)
 
     strategy.execute()
-    counts = summarize_deletions(resolution.selected)
     out.result(
-        f"Deleted {counts.repo_count} repo(s) and {counts.total_revision_count} revision(s);"
-        f" freed {strategy.expected_freed_size_str}.",
+        f"Deleted {summary_text}; freed {strategy.expected_freed_size_str}.",
         repos_deleted=counts.repo_count,
         revisions_deleted=counts.total_revision_count,
+        files_deleted=counts.file_count,
         freed=strategy.expected_freed_size_str,
     )
 

--- a/src/huggingface_hub/serialization/_torch.py
+++ b/src/huggingface_hub/serialization/_torch.py
@@ -268,7 +268,9 @@ def save_torch_state_dict(
     safe_file_kwargs = {"metadata": per_file_metadata} if safe_serialization else {}
     for filename, tensors in state_dict_split.filename_to_tensors.items():
         shard = {tensor: state_dict[tensor] for tensor in tensors}
-        save_file_fn(shard, os.path.join(save_directory, filename), **safe_file_kwargs)  # ty: ignore[invalid-argument-type]
+        save_file_fn(
+            shard, os.path.join(save_directory, filename), **safe_file_kwargs
+        )  # ty: ignore[invalid-argument-type]
         logger.debug(f"Shard saved to {filename}")
 
     # Save the index (if any)

--- a/src/huggingface_hub/utils/_cache_manager.py
+++ b/src/huggingface_hub/utils/_cache_manager.py
@@ -268,6 +268,8 @@ class DeleteCacheStrategy:
             Expected freed size once strategy is executed.
         blobs (`frozenset[Path]`):
             Set of blob file paths to be deleted.
+        files (`frozenset[Path]`):
+            Set of cached file symlinks to be deleted.
         refs (`frozenset[Path]`):
             Set of reference file paths to be deleted.
         repos (`frozenset[Path]`):
@@ -281,6 +283,7 @@ class DeleteCacheStrategy:
     refs: frozenset[Path]
     repos: frozenset[Path]
     snapshots: frozenset[Path]
+    files: frozenset[Path] = frozenset()
 
     @property
     def expected_freed_size_str(self) -> str:
@@ -307,9 +310,9 @@ class DeleteCacheStrategy:
         # up in a state where a `ref`` refers to a missing snapshot or a snapshot
         # symlink refers to a deleted blob.
 
-        # Delete entire repos
-        for path in self.repos:
-            _try_delete_path(path, path_type="repo")
+        # Delete individual files first so snapshot / repo deletions don't hide them.
+        for path in self.files:
+            _try_delete_path(path, path_type="file")
 
         # Delete snapshot directories
         for path in self.snapshots:
@@ -322,6 +325,10 @@ class DeleteCacheStrategy:
         # Delete blob files
         for path in self.blobs:
             _try_delete_path(path, path_type="blob")
+
+        # Delete entire repos last once their contents are gone.
+        for path in self.repos:
+            _try_delete_path(path, path_type="repo")
 
         logger.info(f"Cache deletion done. Saved {self.expected_freed_size_str}.")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,7 +16,7 @@ from huggingface_hub._jobs_api import _create_job_spec
 from huggingface_hub._space_api import Volume
 from huggingface_hub.cli._cli_utils import RepoType, parse_volumes
 from huggingface_hub.cli._output import OutputFormatWithAuto, out
-from huggingface_hub.cli.cache import CacheDeletionCounts
+from huggingface_hub.cli.cache import CacheDeletionCounts, _DeletionResolution
 from huggingface_hub.cli.download import download
 from huggingface_hub.cli.hf import app
 from huggingface_hub.cli.jobs import _parse_namespace_from_job_id
@@ -41,12 +41,18 @@ def runner() -> CliRunner:
     return CliRunner()
 
 
-def _make_revision(commit_hash: str, *, refs: Optional[set[str]] = None) -> CachedRevisionInfo:
+def _make_revision(
+    commit_hash: str,
+    *,
+    refs: Optional[set[str]] = None,
+    files: Optional[set[CachedFileInfo]] = None,
+    size_on_disk: int = 0,
+) -> CachedRevisionInfo:
     return CachedRevisionInfo(
         commit_hash=commit_hash,
         snapshot_path=Path(f"/tmp/{commit_hash}"),
-        size_on_disk=0,
-        files=frozenset(),
+        size_on_disk=size_on_disk,
+        files=frozenset(files or set()),
         refs=frozenset(refs or set()),
         last_modified=0.0,
     )
@@ -62,6 +68,17 @@ def _make_repo(repo_id: str, *, revisions: list[CachedRevisionInfo]) -> CachedRe
         revisions=frozenset(revisions),
         last_accessed=0.0,
         last_modified=0.0,
+    )
+
+
+def _make_file(commit_hash: str, path_in_repo: str, *, size_on_disk: int = 1) -> CachedFileInfo:
+    return CachedFileInfo(
+        file_name=Path(path_in_repo).name,
+        file_path=Path(f"/tmp/{commit_hash}/{path_in_repo}"),
+        blob_path=Path(f"/tmp/blobs/{commit_hash}-{path_in_repo.replace('/', '_')}"),
+        size_on_disk=size_on_disk,
+        blob_last_accessed=0.0,
+        blob_last_modified=0.0,
     )
 
 
@@ -162,61 +179,73 @@ class TestCacheCommand:
         revision = _make_revision("c" * 40)
         repo = _make_repo("user/model", revisions=[revision])
 
-        repo_lookup = {"model/user/model": repo}
-        revision_lookup = {revision.commit_hash.lower(): (repo, revision)}
-
         strategy = Mock()
         strategy.expected_freed_size_str = "0B"
 
-        hf_cache_info = Mock()
-        hf_cache_info.delete_revisions.return_value = strategy
-
         counts = CacheDeletionCounts(repo_count=0, partial_revision_count=1, total_revision_count=1)
+        resolution = _DeletionResolution(
+            revisions=frozenset({revision.commit_hash}),
+            selected={repo: frozenset({revision})},
+            selected_files={},
+            missing=(),
+        )
 
         with (
-            patch("huggingface_hub.cli.cache.scan_cache_dir", return_value=hf_cache_info),
-            patch("huggingface_hub.cli.cache.build_cache_index", return_value=(repo_lookup, revision_lookup)),
-            patch(
-                "huggingface_hub.cli.cache.summarize_deletions",
-                return_value=counts,
-            ),
+            patch("huggingface_hub.cli.cache.scan_cache_dir", return_value=Mock()),
+            patch("huggingface_hub.cli.cache._resolve_deletion_targets", return_value=resolution),
+            patch("huggingface_hub.cli.cache._build_delete_strategy", return_value=(strategy, counts)),
             patch("huggingface_hub.cli.cache.print_cache_selected_revisions") as print_mock,
         ):
             result = runner.invoke(app, ["cache", "rm", revision.commit_hash, "--yes"])
 
         assert result.exit_code == 0
-        hf_cache_info.delete_revisions.assert_called_once_with(revision.commit_hash)
         strategy.execute.assert_called_once_with()
         print_mock.assert_called_once()
 
     def test_rm_dry_run_skips_execute(self, runner: CliRunner) -> None:
         revision = _make_revision("d" * 40)
         repo = _make_repo("user/model", revisions=[revision])
-        repo_lookup = {"model/user/model": repo}
-        revision_lookup = {revision.commit_hash.lower(): (repo, revision)}
 
         strategy = Mock()
         strategy.expected_freed_size_str = "0B"
 
-        hf_cache_info = Mock()
-        hf_cache_info.delete_revisions.return_value = strategy
-
         counts = CacheDeletionCounts(repo_count=0, partial_revision_count=1, total_revision_count=1)
+        resolution = _DeletionResolution(
+            revisions=frozenset({revision.commit_hash}),
+            selected={repo: frozenset({revision})},
+            selected_files={},
+            missing=(),
+        )
 
         with (
-            patch("huggingface_hub.cli.cache.scan_cache_dir", return_value=hf_cache_info),
-            patch("huggingface_hub.cli.cache.build_cache_index", return_value=(repo_lookup, revision_lookup)),
-            patch(
-                "huggingface_hub.cli.cache.summarize_deletions",
-                return_value=counts,
-            ),
+            patch("huggingface_hub.cli.cache.scan_cache_dir", return_value=Mock()),
+            patch("huggingface_hub.cli.cache._resolve_deletion_targets", return_value=resolution),
+            patch("huggingface_hub.cli.cache._build_delete_strategy", return_value=(strategy, counts)),
             patch("huggingface_hub.cli.cache.print_cache_selected_revisions"),
         ):
             result = runner.invoke(app, ["cache", "rm", revision.commit_hash, "--dry-run"])
 
         assert result.exit_code == 0
-        hf_cache_info.delete_revisions.assert_called_once_with(revision.commit_hash)
         strategy.execute.assert_not_called()
+
+    def test_rm_specific_file_target(self, runner: CliRunner) -> None:
+        commit_hash = "f" * 40
+        file_variant = _make_file(commit_hash, "UD-IQ4_NL", size_on_disk=1)
+        other_variant = _make_file(commit_hash, "UD-IQ2_M", size_on_disk=2)
+        revision = _make_revision(commit_hash, refs={"main"}, files={file_variant, other_variant}, size_on_disk=3)
+        repo = _make_repo("unsloth/gemma-4-26B-A4B-it-GGUF", revisions=[revision])
+        hf_cache_info = HFCacheInfo(size_on_disk=3, repos=frozenset({repo}), warnings=[])
+
+        with patch("huggingface_hub.cli.cache.scan_cache_dir", return_value=hf_cache_info):
+            result = runner.invoke(
+                app,
+                ["cache", "rm", "unsloth/gemma-4-26B-A4B-it-GGUF:UD-IQ4_NL", "--dry-run"],
+            )
+
+        assert result.exit_code == 0
+        assert "1 file(s)" in result.stdout
+        assert "UD-IQ4_NL" in result.stdout
+        assert "Dry run: no files were deleted." in result.stdout
 
     def test_prune_dry_run(self, runner: CliRunner) -> None:
         referenced = _make_revision("e" * 40, refs={"main"})

--- a/tests/test_utils_cache.py
+++ b/tests/test_utils_cache.py
@@ -644,6 +644,27 @@ class TestDeleteStrategyExecute(unittest.TestCase):
         self.assertTrue(snapshot_1.exists())
         self.assertFalse(snapshot_2.exists())
 
+    def test_execute_with_file_deletions(self) -> None:
+        file_path = self.cache_dir / "repo_C" / "snapshots" / "snapshot_1" / "UD-IQ4_NL"
+        file_path.parent.mkdir(parents=True)
+        file_path.touch()
+
+        blob_path = self.cache_dir / "repo_C" / "blobs" / "blob_1"
+        blob_path.parent.mkdir(parents=True)
+        blob_path.touch()
+
+        DeleteCacheStrategy(
+            expected_freed_size=123,
+            blobs={blob_path},
+            refs=set(),
+            repos=set(),
+            snapshots=set(),
+            files={file_path},
+        ).execute()
+
+        self.assertFalse(file_path.exists())
+        self.assertFalse(blob_path.exists())
+
 
 @pytest.mark.usefixtures("fx_cache_dir")
 class TestTryDeletePath(unittest.TestCase):


### PR DESCRIPTION
Fixes: closes #4124 

## Summary: Add repo:path syntax to hf cache rm so users can delete specific cached files (e.g., quant variants) without removing entire revisions.
- Key changes: src/huggingface_hub/cli/cache.py (parsing, _resolve_file_targets, _build_delete_strategy), src/huggingface_hub/utils/_cache_manager.py (DeleteCacheStrategy files support), tests and docs updated.
- Tests: new unit tests added; targeted tests pass locally after style/quality checks.
- Notes: Uses ":" as separator; parsing is heuristic — may need follow-ups for HF-URI/Windows-colon edge cases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new cache-deletion capabilities and rewires deletion strategy computation, which could accidentally delete too much/too little cache content if target resolution or blob reference counting is wrong.
> 
> **Overview**
> `hf cache rm` now accepts `repo:path_in_repo` targets to delete specific cached files (e.g., quant variants) in addition to whole repos or revisions, with updated confirmation output and `--dry-run` reporting file counts.
> 
> This introduces new target parsing/normalization and a custom `_build_delete_strategy` that can delete individual snapshot symlinks, then safely garbage-collect blobs only when no remaining revisions reference them; `DeleteCacheStrategy` gains a `files` field and executes file deletions before snapshots/refs/blobs/repos.
> 
> Docs and CLI reference are updated with the new syntax and example, and tests add coverage for file-target deletion plus strategy execution ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c8f04a0801b735949ca8a64b7b81c5dffd00789. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->