### PR TITLE
[Cache] Detect Lustre/GPFS/NFS in `WeakFileLock` and fall back to `SoftFileLock`

### DIFF
--- a/docs/source/en/package_reference/environment_variables.md
+++ b/docs/source/en/package_reference/environment_variables.md
@@ -84,7 +84,7 @@ Integer value to define the number of seconds to wait for server response when f
 
 Integer value to define the number of seconds to wait for server response when downloading a file. If the request times out, a TimeoutError is raised. Setting a higher value is beneficial on machine with a slow connection. A smaller value makes the process fail quicker in case of complete network outage. Default to 10s.
 
-## Xet 
+## Xet
 
 ### Other Xet environment variables
 * [`HF_HUB_DISABLE_XET`](../package_reference/environment_variables#hfhubdisablexet)
@@ -100,13 +100,13 @@ Defaults to `0` (0 bytes, means chunk cache is disabled).
 
 ### HF_XET_SHARD_CACHE_SIZE_LIMIT
 
-To set the size of the Xet shard cache locally. Increasing this will improve upload efficiency as chunks referenced in cached shard files are not re-uploaded. Note that the default soft limit is likely sufficient for most workloads. 
+To set the size of the Xet shard cache locally. Increasing this will improve upload efficiency as chunks referenced in cached shard files are not re-uploaded. Note that the default soft limit is likely sufficient for most workloads.
 
 Defaults to `4000000000` (4GB).
 
 ### HF_XET_NUM_CONCURRENT_RANGE_GETS
 
-To set the number of concurrent terms (range of bytes from within a xorb, often called a chunk) downloaded from S3 per file. Increasing this will help with the speed of downloading a file if there is network bandwidth available. 
+To set the number of concurrent terms (range of bytes from within a xorb, often called a chunk) downloaded from S3 per file. Increasing this will help with the speed of downloading a file if there is network bandwidth available.
 
 Defaults to `16`.
 
@@ -154,6 +154,20 @@ If set, `huggingface_hub` will never create symlinks in the cache. Instead, file
 
 An example use case is when a shared network drive (e.g. NAS) is used as `HF_HUB_CACHE` across machines running different operating
 systems. Symlinks created on Linux are not always traversable on Windows, leading to errors. Setting `HF_HUB_DISABLE_SYMLINKS=1` avoids this problem at the cost of disk-space deduplication.
+
+### HF_HUB_USE_SOFT_FILELOCK
+
+If set, `huggingface_hub` will use a lock-file-based [`SoftFileLock`](https://py-filelock.readthedocs.io/en/latest/api.html#filelock.SoftFileLock) for all cache writes, regardless of which filesystem the cache lives on.
+
+By default `huggingface_hub` uses native `flock(2)` for fast, kernel-enforced mutual exclusion, falling back to `SoftFileLock` only when it can detect the filesystem is one where `flock(2)` is unreliable (Lustre, GPFS, NFS, SMB, CIFS — see [`tox-dev/filelock#389`](https://github.com/tox-dev/filelock/issues/389) and [`huggingface/transformers#30859`](https://github.com/huggingface/transformers/issues/30859)). On those filesystems `flock(2)` silently grants the lock to every caller without blocking, which corrupts the cache when multiple processes download or update the same repo concurrently — readers can transiently see a truncated or interleaved `config.json`.
+
+Set `HF_HUB_USE_SOFT_FILELOCK=1` to force the safe path even when autodetection misses (e.g. exotic FUSE mounts that wrap one of the unsafe backends).
+
+### HF_HUB_FORCE_FLOCK
+
+If set, `huggingface_hub` will use native `flock(2)` for all cache writes, even when filesystem autodetection would have picked `SoftFileLock`.
+
+This is the opt-back-in escape hatch for sites that have deliberately mounted a parallel filesystem with cluster-wide `flock` support (e.g. Lustre with the `flock` mount option) and want the small performance benefit of native locking. Only use it when you are certain `flock(2)` actually serializes across all nodes that share the cache — otherwise the cache will silently corrupt under concurrent writers.
 
 ### HF_HUB_DISABLE_SYMLINKS_WARNING
 

--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -253,6 +253,16 @@ HF_HUB_DISABLE_PROGRESS_BARS: bool | None = (
 # Disable symlinks in the cache (files are copied instead of symlinked)
 HF_HUB_DISABLE_SYMLINKS: bool = _is_true(os.environ.get("HF_HUB_DISABLE_SYMLINKS"))
 
+# Force `WeakFileLock` to use `SoftFileLock` (lock-file based) regardless of filesystem detection.
+# Useful on shared caches mounted on parallel filesystems (Lustre, GPFS, NFS, ...) where `flock()`
+# silently succeeds for every caller and the native lock is a no-op.
+HF_HUB_USE_SOFT_FILELOCK: bool = _is_true(os.environ.get("HF_HUB_USE_SOFT_FILELOCK"))
+
+# Opt back into native `flock()` regardless of filesystem detection. Use when you know your shared
+# filesystem is mounted with cluster-wide `flock` support (e.g. Lustre with the `flock` mount
+# option) and want the small perf benefit over `SoftFileLock`.
+HF_HUB_FORCE_FLOCK: bool = _is_true(os.environ.get("HF_HUB_FORCE_FLOCK"))
+
 # Disable warning on machines that do not support symlinks (e.g. Windows non-developer)
 HF_HUB_DISABLE_SYMLINKS_WARNING: bool = _is_true(os.environ.get("HF_HUB_DISABLE_SYMLINKS_WARNING"))
 

--- a/src/huggingface_hub/utils/_fixes.py
+++ b/src/huggingface_hub/utils/_fixes.py
@@ -1,4 +1,7 @@
 import contextlib
+import ctypes
+import ctypes.util
+import functools
 import os
 import shutil
 import stat
@@ -16,6 +19,29 @@ from . import logging
 
 
 logger = logging.get_logger(__name__)
+
+
+# Linux statfs(2) f_type magic numbers (see <linux/magic.h>). Filesystems where `flock(2)` is known
+# to silently succeed for every caller without serializing — making `WeakFileLock` a no-op and
+# corrupting concurrent cache writes. See `HF-MODEL-READ-FIX.md` and:
+# - https://github.com/tox-dev/filelock/issues/389  (FileLock not work on gpfs)
+# - https://github.com/huggingface/transformers/issues/30859
+_LUSTRE_SUPER_MAGIC = 0x0BD00BD0
+_GPFS_SUPER_MAGIC = 0x47504653
+_NFS_SUPER_MAGIC = 0x6969
+_SMB_SUPER_MAGIC = 0x517B
+_CIFS_SUPER_MAGIC = 0xFF534D42
+# FUSE is intentionally NOT in the broken set — its backend can be anything (Lustre, S3, sshfs, ...)
+# so we let the runtime probe decide.
+_KNOWN_BROKEN_FOR_FLOCK = frozenset(
+    {
+        _LUSTRE_SUPER_MAGIC,
+        _GPFS_SUPER_MAGIC,
+        _NFS_SUPER_MAGIC,
+        _SMB_SUPER_MAGIC,
+        _CIFS_SUPER_MAGIC,
+    }
+)
 
 # Wrap `yaml.dump` to set `allow_unicode=True` by default.
 #
@@ -73,6 +99,132 @@ def _set_write_permission_and_retry(func, path, excinfo):
     func(path)
 
 
+def _fs_magic(path: str) -> int:
+    """Return the `statfs(2)` `f_type` magic for the filesystem at `path`, or `0` on any error.
+
+    Posix-only. Used as the primary, cross-node-correct signal for filesystems where `flock(2)`
+    is silently broken (returns success for every caller). Returning `0` on non-posix or on any
+    error means callers fall through to the runtime probe / default code path.
+    """
+    if os.name != "posix":
+        return 0
+
+    class _Statfs(ctypes.Structure):
+        # Layout differs by libc/arch; we only need `f_type`, which is the first field on Linux.
+        # Reserve 128 bytes total — comfortably larger than any known `struct statfs`.
+        _fields_ = [("f_type", ctypes.c_long), ("_pad", ctypes.c_ubyte * 120)]
+
+    try:
+        libc_name = ctypes.util.find_library("c") or "libc.so.6"
+        libc = ctypes.CDLL(libc_name, use_errno=True)
+        s = _Statfs()
+        if libc.statfs(os.fsencode(path), ctypes.byref(s)) != 0:
+            return 0
+        return int(s.f_type) & 0xFFFFFFFF
+    except (OSError, AttributeError):
+        return 0
+
+
+def _flock_probe_child(probe_path: str, q) -> None:
+    """Child-process worker for `_flock_actually_serializes`.
+
+    Defined at module top-level so the `spawn` start method can pickle it (lambdas/closures
+    can't be pickled, which would break on platforms that default to spawn).
+    """
+    import fcntl as _fcntl
+
+    try:
+        with open(probe_path, "r") as child_fd:
+            try:
+                _fcntl.flock(child_fd, _fcntl.LOCK_EX | _fcntl.LOCK_NB)
+                # Got the lock while the parent still holds it — `flock` is a no-op here.
+                q.put("broken")
+            except BlockingIOError:
+                q.put("ok")
+    except Exception:
+        q.put("error")
+
+
+@functools.lru_cache(maxsize=None)
+def _flock_actually_serializes(cache_dir: str) -> bool:
+    """Best-effort probe: does `fcntl.flock` actually serialize on `cache_dir`?
+
+    Spawns a child process that re-opens a probe file in `cache_dir` and tries `LOCK_EX | LOCK_NB`
+    while the parent still holds the lock. On a healthy local filesystem the child should be
+    blocked (`BlockingIOError`); on a broken parallel filesystem it gets the lock too.
+
+    This is a within-node sanity check, not a cross-node test, and is only meaningful as a
+    secondary signal on top of `_fs_magic`-based detection. Fail-closed: any timeout, exception,
+    or ambiguous result returns `False` (treat as broken → caller will pick `SoftFileLock`).
+    """
+    import fcntl
+    import multiprocessing
+
+    probe = os.path.join(cache_dir, ".hf-flock-probe")
+    try:
+        os.makedirs(cache_dir, exist_ok=True)
+        parent_fd = open(probe, "w")
+    except OSError:
+        return False  # Can't even create the probe file; fail closed.
+
+    try:
+        try:
+            fcntl.flock(parent_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except (OSError, BlockingIOError):
+            # Something else holds the lock on this exact path; can't make a determination.
+            return False
+
+        # Use an explicit `spawn` context so we don't inherit the parent's lock-holding fd via
+        # `fork`. The child re-opens the path; on a sane FS its fresh open file description must
+        # block on the parent's lock. Spawn is slower (~100-200ms) but pickle-safe and portable.
+        ctx = multiprocessing.get_context("spawn")
+        q = ctx.Queue()
+        p = ctx.Process(target=_flock_probe_child, args=(probe, q))
+        p.start()
+        p.join(timeout=2.0)
+        if p.is_alive():
+            p.terminate()
+            p.join(timeout=1.0)
+            return False  # Timeout → fail closed.
+        try:
+            result = q.get_nowait()
+        except Exception:
+            result = "error"
+        return result == "ok"
+    finally:
+        try:
+            fcntl.flock(parent_fd, fcntl.LOCK_UN)
+        except OSError:
+            pass
+        parent_fd.close()
+        try:
+            os.unlink(probe)
+        except OSError:
+            pass
+
+
+@functools.lru_cache(maxsize=None)
+def _should_use_soft_lock(cache_dir: str) -> bool:
+    """Decide whether `WeakFileLock` should pick `SoftFileLock` over native `FileLock`.
+
+    Order of precedence:
+      1. `HF_HUB_USE_SOFT_FILELOCK=1` → always soft.
+      2. `HF_HUB_FORCE_FLOCK=1` → always native (override for sites with cluster-wide flock).
+      3. Non-posix → native (Windows uses `WindowsFileLock` internally; not affected).
+      4. `_fs_magic(cache_dir)` is in `_KNOWN_BROKEN_FOR_FLOCK` → soft.
+      5. Otherwise: run the runtime probe and fall back to soft if it fails.
+    """
+    if constants.HF_HUB_USE_SOFT_FILELOCK:
+        return True
+    if constants.HF_HUB_FORCE_FLOCK:
+        return False
+    if os.name != "posix":
+        return False
+    if _fs_magic(cache_dir) in _KNOWN_BROKEN_FOR_FLOCK:
+        return True
+    return not _flock_actually_serializes(cache_dir)
+
+
 @contextlib.contextmanager
 def WeakFileLock(lock_file: str | Path, *, timeout: float | None = None) -> Generator[BaseFileLock, None, None]:
     """A filelock with some custom logic.
@@ -80,6 +232,10 @@ def WeakFileLock(lock_file: str | Path, *, timeout: float | None = None) -> Gene
     This filelock is weaker than the default filelock in that:
     1. It won't raise an exception if release fails.
     2. It will default to a SoftFileLock if the filesystem does not support flock.
+       Detection happens up-front via `_should_use_soft_lock` (statfs-based for known broken
+       families like Lustre/GPFS/NFS, plus a fail-closed runtime probe for unknown filesystems).
+       The legacy `NotImplementedError` fallback inside the acquisition loop is kept as a
+       belt-and-suspenders safety net.
     3. Lock files are created with mode 0o664 (group-writable) instead of the default 0o644.
        This allows multiple users sharing a cache directory to wait for locks.
 
@@ -87,7 +243,12 @@ def WeakFileLock(lock_file: str | Path, *, timeout: float | None = None) -> Gene
     If a timeout is provided, a `filelock.Timeout` exception is raised if the lock is not acquired within the timeout.
     """
     log_interval = constants.FILELOCK_LOG_EVERY_SECONDS
-    lock = FileLock(lock_file, timeout=log_interval, mode=0o664)
+    cache_dir = os.path.dirname(os.path.abspath(str(lock_file)))
+    lock: BaseFileLock
+    if _should_use_soft_lock(cache_dir):
+        lock = SoftFileLock(lock_file, timeout=log_interval)
+    else:
+        lock = FileLock(lock_file, timeout=log_interval, mode=0o664)
     start_time = time.time()
 
     while True:

--- a/tests/test_utils_fixes.py
+++ b/tests/test_utils_fixes.py
@@ -4,8 +4,18 @@ from pathlib import Path
 
 import filelock
 import pytest
+from filelock import FileLock, SoftFileLock
 
 from huggingface_hub.utils import SoftTemporaryDirectory, WeakFileLock, yaml_dump
+from huggingface_hub.utils._fixes import (
+    _CIFS_SUPER_MAGIC,
+    _GPFS_SUPER_MAGIC,
+    _LUSTRE_SUPER_MAGIC,
+    _NFS_SUPER_MAGIC,
+    _SMB_SUPER_MAGIC,
+    _flock_actually_serializes,
+    _should_use_soft_lock,
+)
 
 
 class TestYamlDump(unittest.TestCase):
@@ -46,3 +56,59 @@ class TestWeakFileLock:
 
         assert len(caplog.records) >= 3
         assert caplog.records[0].message.startswith(f"Still waiting to acquire lock on {lock_file}")
+
+
+@pytest.fixture(autouse=True)
+def _clear_soft_lock_caches() -> None:
+    """`_should_use_soft_lock` and `_flock_actually_serializes` are `lru_cache`'d per cache_dir.
+
+    Tests parametrize over magics / env vars for the same `tmp_path`, so we must clear both caches
+    before and after each test, otherwise the second test in a class would see a stale decision.
+    """
+    _should_use_soft_lock.cache_clear()
+    _flock_actually_serializes.cache_clear()
+    yield
+    _should_use_soft_lock.cache_clear()
+    _flock_actually_serializes.cache_clear()
+
+
+class TestSoftLockDetection:
+    @pytest.mark.parametrize(
+        "magic",
+        [_LUSTRE_SUPER_MAGIC, _GPFS_SUPER_MAGIC, _NFS_SUPER_MAGIC, _SMB_SUPER_MAGIC, _CIFS_SUPER_MAGIC],
+    )
+    def test_known_broken_magic_uses_soft_lock(
+        self, magic: int, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("huggingface_hub.utils._fixes._fs_magic", lambda _path: magic)
+        with WeakFileLock(tmp_path / ".lock") as lock:
+            assert isinstance(lock, SoftFileLock)
+
+    def test_local_filesystem_uses_native_flock(self, tmp_path: Path) -> None:
+        # `tmp_path` lives under `/tmp` (ext4/tmpfs in CI and on dev boxes), which is not in the
+        # known-broken set. This also exercises the real `_flock_actually_serializes` probe.
+        with WeakFileLock(tmp_path / ".lock") as lock:
+            assert isinstance(lock, FileLock)
+            assert not isinstance(lock, SoftFileLock)
+
+    def test_env_force_soft_overrides_detection(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("huggingface_hub.constants.HF_HUB_USE_SOFT_FILELOCK", True)
+        # Even with a "looks healthy" magic, the env var must win.
+        monkeypatch.setattr("huggingface_hub.utils._fixes._fs_magic", lambda _path: 0xEF53)  # ext4
+        with WeakFileLock(tmp_path / ".lock") as lock:
+            assert isinstance(lock, SoftFileLock)
+
+    def test_env_force_flock_overrides_detection(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("huggingface_hub.constants.HF_HUB_FORCE_FLOCK", True)
+        # Even when the FS reports a known-broken magic, the env var must win.
+        monkeypatch.setattr("huggingface_hub.utils._fixes._fs_magic", lambda _path: _LUSTRE_SUPER_MAGIC)
+        with WeakFileLock(tmp_path / ".lock") as lock:
+            assert isinstance(lock, FileLock)
+            assert not isinstance(lock, SoftFileLock)
+
+    def test_probe_failure_falls_back_to_soft(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Unknown magic (0) → falls through to the runtime probe; force probe to fail-closed.
+        monkeypatch.setattr("huggingface_hub.utils._fixes._fs_magic", lambda _path: 0)
+        monkeypatch.setattr("huggingface_hub.utils._fixes._flock_actually_serializes", lambda _path: False)
+        with WeakFileLock(tmp_path / ".lock") as lock:
+            assert isinstance(lock, SoftFileLock)


### PR DESCRIPTION
## Problem

On Lustre, GPFS, and many NFS mounts, `fcntl.flock(2)` returns success for every caller without blocking — so `WeakFileLock` is a silent no-op on shared HF caches. Concurrent `hf_hub_download` cycles can interleave `O_APPEND` writes to `<etag>.incomplete`, producing a syntactically-valid but semantically-wrong blob (or a transiently-empty `refs/<revision>`).

The downstream symptom seen on multi-process `vllm serve` jobs sharing `HF_HOME` on Lustre is a sporadic `transformers.AutoConfig.from_pretrained` crash on one of N siblings: `Unrecognized model … Should have a "model_type" key in its config.json`. The same `config.json` was read successfully ~50 ms earlier in the same process, and 7 of 8 sibling processes parse it fine — a classic race.

The current code only falls back to `SoftFileLock` when `filelock` raises `NotImplementedError`, which Lustre/GPFS never do.

Related: [`tox-dev/filelock#389`](https://github.com/tox-dev/filelock/issues/389), [`huggingface/transformers#30859`](https://github.com/huggingface/transformers/issues/30859).

## Solution

`WeakFileLock` now decides between native `FileLock` and `SoftFileLock` up-front, via two layers in `src/huggingface_hub/utils/_fixes.py`:

1. **Primary: `statfs(2)` family detection** — Lustre, GPFS, NFS, SMB, CIFS magic numbers route to `SoftFileLock`. Cross-node-correct, no IPC needed.
2. **Secondary: fail-closed runtime probe** for unknown filesystems — spawns a child process (`multiprocessing.get_context("spawn")` for pickle-safety) that re-opens a probe file and tries `LOCK_EX|LOCK_NB` while the parent still holds the lock. Any timeout, exception, or non-`"ok"` result → `SoftFileLock`.

Both helpers are `@functools.lru_cache`'d per cache directory.

Two opt-out env vars cover edge cases:

- `HF_HUB_USE_SOFT_FILELOCK=1` — force soft regardless of detection (for exotic FUSE mounts that wrap an unsafe backend).
- `HF_HUB_FORCE_FLOCK=1` — force native for sites that mount Lustre with cluster-wide `flock` support and want the small perf benefit.

The legacy `NotImplementedError` → `SoftFileLock` fallback inside the acquisition loop is preserved as belt-and-suspenders.

## Tests

New `TestSoftLockDetection` (10 cases):

- 5 parametrized known-broken magics (Lustre / GPFS / NFS / SMB / CIFS) → asserts `SoftFileLock`.
- Local FS via `tmp_path` (under `/tmp`, ext4) → asserts native `FileLock`; exercises the real probe end-to-end.
- `HF_HUB_USE_SOFT_FILELOCK=True` overrides a healthy magic → `SoftFileLock`.
- `HF_HUB_FORCE_FLOCK=True` overrides a Lustre magic → `FileLock`.
- Probe failure with unknown magic (`0`) → `SoftFileLock` (verifies fail-closed).

Results:

- `pytest tests/test_utils_fixes.py -v` → **14 passed** (10 new + 4 pre-existing).
- `pytest tests/test_local_folder.py` → **13 passed, 2 skipped**.
- `pytest tests/test_file_download.py` → bit-identical to `origin/main` baseline (failures are sandbox `HF_HUB_OFFLINE` network restrictions, not regressions; confirmed via `git stash` + rerun).
- `make style` and `make quality` → clean, including `ty check src`.
- `mypy src` (CI parity) → `Success: no issues found in 176 source files`.

Real-world detection on the dev box, which happens to use NFS for `$HOME`:

- `_fs_magic("/home/scratch.vgimpelson_ent/huggingface_hub")` → `0x6969` (NFS) → `_should_use_soft_lock` returns `True`.
- `_fs_magic("/tmp")` → `0xef53` (ext4) → `_should_use_soft_lock` returns `False`.

Exactly the cases the fix is designed to discriminate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Hub cache locking behavior on POSIX and shared/network filesystems; wrong detection could hurt performance (unnecessary soft locks) or, if forced native flock is misused, reintroduce rare concurrent-write corruption.
> 
> **Overview**
> Fixes **silent cache corruption** when multiple processes share `HF_HUB_CACHE` on parallel filesystems where `flock(2)` appears to succeed but does not serialize writers.
> 
> `WeakFileLock` now **chooses `SoftFileLock` vs native `FileLock` before acquisition**, instead of only falling back on `NotImplementedError`. Detection uses **`statfs(2)` magic numbers** for Lustre, GPFS, NFS, SMB, and CIFS, plus a **fail-closed child-process probe** for unknown POSIX filesystems. Decisions are cached per cache directory.
> 
> New knobs: **`HF_HUB_USE_SOFT_FILELOCK`** (always soft) and **`HF_HUB_FORCE_FLOCK`** (always native when cluster-wide flock is known good). Constants and docs were added; **`TestSoftLockDetection`** covers magics, local FS, env overrides, and probe failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 748df016e2b4ba70453660c503cf2b1a953ff686. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->