### PR TITLE
[CLI] Add global `--no-truncate` flag for human tables

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -135,8 +135,9 @@ Most `hf` commands accept the same set of global formatting flags. They are docu
 | `--format <value>` | — | Pick the output format explicitly. Accepted values: `auto` (default), `human`, `agent`, `json`, `quiet`. |
 | `--json` | `--format json` | Print structured JSON. Useful for piping into `jq` or other scripts. |
 | `-q`, `--quiet` | `--format quiet` | Print only IDs (one per line). Useful for piping IDs into other commands. |
+| `--no-truncate` | — | Show full scalar values in human tables instead of shortening long values with `...`. List- and dict-valued columns (e.g. `tags`) stay shortened; use `--format json` to see them in full. |
 
-`auto` (the default) picks `human` for an interactive terminal and `agent` when the CLI is invoked by an AI agent. `human` adds colors and pretty tables; `agent` produces tab-separated values without truncation; `json` emits a compact JSON object or array. Mixing two of these flags (e.g. `--json` together with `--format table`) raises a usage error.
+`auto` (the default) picks `human` for an interactive terminal and `agent` when the CLI is invoked by an AI agent. `human` adds colors and pretty tables; `agent` produces tab-separated values without truncation; `json` emits a compact JSON object or array. Use `--no-truncate` with human tables when you need full scalar values (for example long cache IDs); for full list or dict columns, use `--format json`. Mixing two output-mode flags (e.g. `--json` together with `--format table`) raises a usage error.
 
 ```bash
 # JSON output for scripting

--- a/src/huggingface_hub/cli/_cli_utils.py
+++ b/src/huggingface_hub/cli/_cli_utils.py
@@ -116,7 +116,7 @@ class HFCliTyperGroup(TyperGroup):
     - separates commands by topic (main, help, etc.).
     - formats epilog without extra indentation.
     - supports aliases via pipe-separated names (e.g. ``name="list | ls"``).
-    - consumes the global formatting flags (``--format``, ``--json``, ``-q`` / ``--quiet``)
+    - consumes the global formatting flags (``--format``, ``--json``, ``-q`` / ``--quiet``, ``--no-truncate``)
       anywhere in the args of a leaf command and applies them to ``out``, so leaf
       commands don't need to declare these options themselves.
     - rewrites ``spaces/user/repo`` to ``user/repo --type space`` for commands that accept ``--type``.
@@ -188,7 +188,7 @@ class HFCliTyperGroup(TyperGroup):
             raise
 
         # If we just resolved a leaf command, eagerly consume any global formatting
-        # flags (--format / --json / -q / --quiet) from its args before click parses
+        # flags (--format / --json / -q / --quiet / --no-truncate) from its args before click parses
         # them.  Group resolution is recursive — leaves (and only leaves) need this.
         if resolved_cmd is not None and not isinstance(resolved_cmd, click.Group):
             _consume_format_flags_for_leaf(resolved_cmd, sub_args)
@@ -371,6 +371,7 @@ _FORMATTING_OPTIONS_HELP_RECORDS: list[tuple[str, str]] = [
     ),
     ("--json", "JSON output. Equivalent to '--format json'."),
     ("-q, --quiet", "Quiet output (one ID per line). Equivalent to '--format quiet'."),
+    ("--no-truncate", "Do not truncate scalar values in human tables (list/dict columns stay shortened)."),
 ]
 
 
@@ -408,10 +409,15 @@ def _consume_format_flags_for_leaf(cmd: click.Command, args: list[str]) -> None:
 
     * **Modern commands** (no local format/quiet/json options): the flags '--format <value>' / '--json' / '--quiet' / '-q' are stripped from 'args' and applied to the singleton 'out'.
 
+    '--no-truncate' is stripped for all non-pass-through commands; when present, human table cells are not truncated.
+
     Raises click.UsageError if multiple conflicting flags are supplied (e.g. '--json' together with '--format table').
     """
     if cmd.context_settings.get("ignore_unknown_options"):
         return
+
+    no_truncate = _consume_no_truncate_flags(args)
+    out.set_no_truncate(no_truncate)
 
     has_local_format = False
     has_local_quiet = False
@@ -476,6 +482,24 @@ def _consume_format_flags_for_leaf(cmd: click.Command, args: list[str]) -> None:
         i += 1
 
     out.set_mode(chosen_mode)
+
+
+def _consume_no_truncate_flags(args: list[str]) -> bool:
+    """Strip all global --no-truncate flags from args and return whether any was provided."""
+    no_truncate = False
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg == "--":
+            break  # everything after '--' is a positional literal
+        if arg == "--no-truncate":
+            no_truncate = True
+            del args[i : i + 1]
+            continue
+        if arg.startswith("--no-truncate="):
+            raise click.UsageError("Option '--no-truncate' does not take a value.")
+        i += 1
+    return no_truncate
 
 
 def _rewrite_legacy_shorthands(args: list[str], *, rewrite_json: bool, rewrite_quiet: bool) -> None:

--- a/src/huggingface_hub/cli/_output.py
+++ b/src/huggingface_hub/cli/_output.py
@@ -47,8 +47,10 @@ class Output:
     """
 
     mode: OutputFormatWithAuto
+    no_truncate: bool
 
     def __init__(self) -> None:
+        self.no_truncate = False
         self.set_mode()
 
     def set_mode(self, mode: OutputFormatWithAuto = OutputFormatWithAuto.auto) -> None:
@@ -58,6 +60,10 @@ class Output:
         self.mode = mode
         if mode != OutputFormatWithAuto.human:
             disable_progress_bars()
+
+    def set_no_truncate(self, no_truncate: bool) -> None:
+        """Toggle off cell truncation for human table output."""
+        self.no_truncate = no_truncate
 
     def is_quiet(self) -> bool:
         return self.mode == OutputFormatWithAuto.quiet
@@ -110,10 +116,31 @@ class Output:
 
         match self.mode:
             case OutputFormatWithAuto.human:  # padded table, truncated cells, SCREAMING_SNAKE headers
-                formatted_rows: list[list[str | int]] = [[_format_table_cell_human(v) for v in row] for row in rows]
+                formatted_rows: list[list[str | int]] = []
+                scalar_truncated = False
+                container_truncated = False
+                for row in rows:
+                    formatted_row: list[str | int] = []
+                    for value in row:
+                        cell = _format_table_value_human(value)
+                        # Containers (lists/dicts) can be arbitrarily long (e.g. `tags`); always shorten
+                        # them in human mode and point users at `--format json` for full content.
+                        is_container = isinstance(value, (dict, list, set, tuple))
+                        if len(cell) > _MAX_CELL_LENGTH and (not self.no_truncate or is_container):
+                            if is_container:
+                                container_truncated = True
+                            else:
+                                scalar_truncated = True
+                            cell = cell[: _MAX_CELL_LENGTH - 3] + "..."
+                        formatted_row.append(cell)
+                    formatted_rows.append(formatted_row)
                 screaming_headers = [_to_header(h) for h in headers]
                 screaming_alignments = {_to_header(k): v for k, v in (alignments or {}).items()}
                 print(tabulate(formatted_rows, headers=screaming_headers, alignments=screaming_alignments))
+                if scalar_truncated:
+                    self.hint("Use `--no-truncate` to display full values.")
+                elif container_truncated:
+                    self.hint("Use `--format json` to display full lists/dicts.")
             case OutputFormatWithAuto.agent:  # TSV, no truncation, full timestamps
                 print("\t".join(headers))
                 for row in rows:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,7 @@ def _clean_cli_env(monkeypatch: pytest.MonkeyPatch) -> None:
     from huggingface_hub.cli._output import out
 
     out.set_mode()
+    out.set_no_truncate(False)
 
 
 logger = logging.get_logger(__name__)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3578,6 +3578,7 @@ class TestGlobalFormattingFlags:
         assert "--format" in result.output
         assert "--json" in result.output
         assert "--quiet" in result.output
+        assert "--no-truncate" in result.output
 
     def test_help_skips_section_for_legacy_command_with_local_format(self, runner: CliRunner) -> None:
         """Legacy commands (e.g. 'hf jobs ps') keep their local --format/--quiet

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -161,6 +161,19 @@ def test_table_empty(check):
     )
 
 
+def test_table_no_truncate(capsys):
+    long_id = "org/very-long-model-name-that-exceeds-thirty-five-characters"
+    o = Output()
+    o.set_mode(HUMAN)
+    o.set_no_truncate(True)
+    o.table([{"id": long_id}], headers=["id"])
+
+    captured = capsys.readouterr()
+    assert long_id in captured.out
+    assert "..." not in captured.out
+    assert captured.err == ""
+
+
 # =============================================================================
 # out.dict()
 # =============================================================================

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -161,6 +161,17 @@ def test_table_empty(check):
     )
 
 
+def test_table_truncates_by_default(capsys):
+    long_id = "org/very-long-model-name-that-exceeds-thirty-five-characters"
+    o = Output()
+    o.set_mode(HUMAN)
+    o.table([{"id": long_id}], headers=["id"])
+
+    captured = capsys.readouterr()
+    assert long_id not in captured.out
+    assert "..." in captured.out
+
+
 def test_table_no_truncate(capsys):
     long_id = "org/very-long-model-name-that-exceeds-thirty-five-characters"
     o = Output()
@@ -171,7 +182,6 @@ def test_table_no_truncate(capsys):
     captured = capsys.readouterr()
     assert long_id in captured.out
     assert "..." not in captured.out
-    assert captured.err == ""
 
 
 # =============================================================================


### PR DESCRIPTION
> Disclaimer: Implemented with Pi and GPT-5.5 and reviewed by me. a follow-up PR will improve the rendering of wide tables further, fitting columns to the terminal width, do something smarter for this.

This PR adds `--no-truncate` as a global CLI formatting flag. It applies to all `hf` commands that render human-mode tables and disables the `...` truncation on scalar cells. List- and dict-valued columns (e.g. tags) are intentionally still shortened in human mode since they can be arbitrarily long. for those, the hint points users to `--format json`. To keep the new behavior discoverable, human tables now also print a one-line hint at the bottom when any cell was truncated, telling the user which flag to use depending on whether scalars or containers were shortened.


**Examples**

```console
> hf models ls
ID                                  CREATED_AT DOWNLOADS LIBRARY_NAME          LIKES PIPELINE_TAG         PRIVATE TAGS                                TRENDING_SCORE
----------------------------------- ---------- --------- --------------------- ----- -------------------- ------- ----------------------------------- --------------
froggeric/Qwen-Fixed-Chat-Templates 2026-04-23 0         mlx                   201                                mlx, jinja, chat-template, qwen,... 96
HiDream-ai/HiDream-O1-Image-Dev     2026-05-08 3819      transformers          94    image-text-to-image          transformers, safetensors, qwen3... 94
Qwen/Qwen3.6-35B-A3B                2026-04-15 4938568   transformers          1765  image-text-to-text           transformers, safetensors, qwen3... 93
circlestone-labs/Anima              2026-01-29 465511    diffusion-single-file 1301                               diffusion-single-file, comfyui, ... 89
jackxinning/Leanly_AI               2026-04-16 10822                           111   question-answering           gguf, medical, question-answerin... 89
Qwen/Qwen3.6-27B                    2026-04-21 3099139   transformers          1283  image-text-to-text           transformers, safetensors, qwen3... 88
deepseek-ai/DeepSeek-V4-Flash       2026-04-22 1624247   transformers          1084  text-generation              transformers, safetensors, deeps... 87
Jiunsong/supergemma4-26b-uncenso... 2026-04-11 279744                          590   text-generation              gguf, gemma4, uncensored, fast, ... 86
google/gemma-4-31B-it-assistant     2026-04-23 125005    transformers          237   any-to-any                   transformers, safetensors, gemma... 80
openai/privacy-filter               2026-04-17 229377    transformers          1441  token-classification         transformers, onnx, safetensors,... 75
k2-fsa/OmniVoice                    2026-03-30 2189655   omnivoice             881   text-to-speech               omnivoice, safetensors, zero-sho... 74
RuneXX/LTX-2.3-Workflows            2026-03-05 0                               554   image-to-video               ltx, ltx-2, comfyui, comfy, gguf... 73
google/gemma-4-31B-it               2026-03-11 9827416   transformers          2642  image-text-to-text           transformers, safetensors, gemma... 72
antirez/deepseek-v4-gguf            2026-04-26 230548    gguf                  110   text-generation              gguf, quantized, deepseek, deeps... 71
ResembleAI/Dramabox                 2026-04-17 429       ltx-audio-tts         67    text-to-speech               ltx-audio-tts, dramabox-tts, tts... 67
unsloth/Qwen3.6-35B-A3B-GGUF        2026-04-16 3075105   transformers          1033  image-text-to-text           transformers, gguf, unsloth, qwe... 63
TencentARC/Pixal3D                  2026-04-30 0                               65    image-to-3d                  image-to-3d, arxiv:2605.10922, l... 62
sensenova/SenseNova-U1-8B-MoT       2026-04-22 11417     transformers          256   any-to-any                   transformers, safetensors, neo_c... 60
havenoammo/Qwen3.6-27B-MTP-UD-GGUF  2026-05-06 62035     transformers          93    image-text-to-text           transformers, gguf, unsloth, qwe... 58
joyfox/LTX2.3-ICEdit-Insight        2026-04-23 5041      diffusers             72    video-to-video               diffusers, video-editing, video-... 56
Hint: Use `--no-truncate` to display full values.


> hf models ls --no-truncate
ID                                          CREATED_AT DOWNLOADS LIBRARY_NAME          LIKES PIPELINE_TAG         PRIVATE TAGS                                TRENDING_SCORE
------------------------------------------- ---------- --------- --------------------- ----- -------------------- ------- ----------------------------------- --------------
froggeric/Qwen-Fixed-Chat-Templates         2026-04-23 0         mlx                   201                                mlx, jinja, chat-template, qwen,... 96
HiDream-ai/HiDream-O1-Image-Dev             2026-05-08 3819      transformers          94    image-text-to-image          transformers, safetensors, qwen3... 94
Qwen/Qwen3.6-35B-A3B                        2026-04-15 4938568   transformers          1765  image-text-to-text           transformers, safetensors, qwen3... 93
circlestone-labs/Anima                      2026-01-29 465511    diffusion-single-file 1301                               diffusion-single-file, comfyui, ... 89
jackxinning/Leanly_AI                       2026-04-16 10822                           111   question-answering           gguf, medical, question-answerin... 89
Qwen/Qwen3.6-27B                            2026-04-21 3099139   transformers          1283  image-text-to-text           transformers, safetensors, qwen3... 88
deepseek-ai/DeepSeek-V4-Flash               2026-04-22 1624247   transformers          1084  text-generation              transformers, safetensors, deeps... 87
Jiunsong/supergemma4-26b-uncensored-gguf-v2 2026-04-11 279744                          590   text-generation              gguf, gemma4, uncensored, fast, ... 86
google/gemma-4-31B-it-assistant             2026-04-23 125005    transformers          237   any-to-any                   transformers, safetensors, gemma... 80
openai/privacy-filter                       2026-04-17 229377    transformers          1441  token-classification         transformers, onnx, safetensors,... 75
k2-fsa/OmniVoice                            2026-03-30 2189655   omnivoice             881   text-to-speech               omnivoice, safetensors, zero-sho... 74
RuneXX/LTX-2.3-Workflows                    2026-03-05 0                               554   image-to-video               ltx, ltx-2, comfyui, comfy, gguf... 73
google/gemma-4-31B-it                       2026-03-11 9827416   transformers          2642  image-text-to-text           transformers, safetensors, gemma... 72
antirez/deepseek-v4-gguf                    2026-04-26 230548    gguf                  110   text-generation              gguf, quantized, deepseek, deeps... 71
ResembleAI/Dramabox                         2026-04-17 429       ltx-audio-tts         67    text-to-speech               ltx-audio-tts, dramabox-tts, tts... 67
unsloth/Qwen3.6-35B-A3B-GGUF                2026-04-16 3075105   transformers          1033  image-text-to-text           transformers, gguf, unsloth, qwe... 63
TencentARC/Pixal3D                          2026-04-30 0                               65    image-to-3d                  image-to-3d, arxiv:2605.10922, l... 62
sensenova/SenseNova-U1-8B-MoT               2026-04-22 11417     transformers          256   any-to-any                   transformers, safetensors, neo_c... 60
havenoammo/Qwen3.6-27B-MTP-UD-GGUF          2026-05-06 62035     transformers          93    image-text-to-text           transformers, gguf, unsloth, qwe... 58
joyfox/LTX2.3-ICEdit-Insight                2026-04-23 5041      diffusers             72    video-to-video               diffusers, video-editing, video-... 56
Hint: Use `--format json` to display full lists/dicts.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches global CLI argument consumption and table rendering logic, which could subtly affect output/arg parsing across many commands (especially in scripts expecting truncated human output). Changes are otherwise additive and covered by new tests.
> 
> **Overview**
> Adds a new global CLI flag `--no-truncate` that is consumed alongside existing formatting flags and toggles a new `Output.no_truncate` setting.
> 
> Updates human-mode table rendering to optionally skip truncation for *scalar* cell values, while still shortening list/dict-like columns, and prints a one-line stderr hint when truncation occurs (pointing to `--no-truncate` or `--format json`). Documentation and tests are extended to cover the new help entry, default reset behavior, and `--no-truncate` table output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cfb83b5e2389eafe5bb4acb4f5bab857cfe54fe. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->