### PR TITLE
fix(cache): strip trailing whitespace from refs/<revision> files

### DIFF
--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -287,7 +287,7 @@ def snapshot_download(
             if os.path.exists(ref_path):
                 # retrieve commit_hash from refs file
                 with open(ref_path) as f:
-                    commit_hash = f.read()
+                    commit_hash = f.read().strip()
 
         # Try to locate snapshot folder for this commit hash
         if commit_hash is not None and local_dir is None:

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1103,7 +1103,7 @@ def _hf_hub_download_to_cache_dir(
                 ref_path = os.path.join(storage_folder, "refs", revision)
                 if os.path.isfile(ref_path):
                     with open(ref_path) as f:
-                        commit_hash = f.read()
+                        commit_hash = f.read().strip()
 
             # Return pointer file if exists
             if commit_hash is not None:
@@ -1516,7 +1516,7 @@ def try_to_load_from_cache(
         revision_file = os.path.join(refs_dir, revision)
         if os.path.isfile(revision_file):
             with open(revision_file) as f:
-                revision = f.read()
+                revision = f.read().strip()
 
     # Check if file is cached as "no_exist"
     if os.path.isfile(os.path.join(no_exist_dir, revision, filename)):

--- a/src/huggingface_hub/utils/_cache_manager.py
+++ b/src/huggingface_hub/utils/_cache_manager.py
@@ -720,7 +720,7 @@ def _scan_cached_repo(repo_path: Path) -> CachedRepoInfo:
 
             ref_name = str(ref_path.relative_to(refs_path))
             with ref_path.open() as f:
-                commit_hash = f.read()
+                commit_hash = f.read().strip()
 
             refs_by_hash[commit_hash].add(ref_name)
 

--- a/tests/test_utils_cache.py
+++ b/tests/test_utils_cache.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock
 import pytest
 
 from huggingface_hub._snapshot_download import snapshot_download
+from huggingface_hub.file_download import try_to_load_from_cache
 from huggingface_hub.utils import DeleteCacheStrategy, HFCacheInfo, _format_size, scan_cache_dir
 from huggingface_hub.utils._cache_manager import CacheNotFound, _try_delete_path
 
@@ -372,6 +373,31 @@ class TestCorruptedCacheUtils(unittest.TestCase):
             + f"({self.repo_path}).",
         )
 
+    def test_ref_with_trailing_newline_still_resolves(self) -> None:
+        """Regression test for https://github.com/huggingface/huggingface_hub/issues/4133.
+
+        A refs/<revision> file that contains a trailing newline (e.g. written with
+        `echo` or copied between environments) must still be resolved to the correct
+        snapshot.  Before the fix `f.read()` returned `hash\\n`, making the key in
+        `refs_by_hash` differ from the actual snapshot directory name and triggering a
+        spurious "missing commit hash" CorruptedCacheException.
+        """
+        # Read the clean hash that the upstream download wrote.
+        main_ref = self.refs_path / "main"
+        commit_hash = main_ref.read_text().strip()
+
+        # Overwrite the file with an explicit trailing newline to simulate the bug.
+        main_ref.write_text(commit_hash + "\n")
+
+        report = scan_cache_dir(self.cache_dir)
+
+        self.assertEqual(len(report.warnings), 0, f"Unexpected warnings: {report.warnings}")
+        self.assertEqual(len(report.repos), 1)
+        repo = list(report.repos)[0]
+        self.assertEqual(len(repo.revisions), 1)
+        revision = list(repo.revisions)[0]
+        self.assertIn("main", revision.refs)
+
     @skip_on_windows("Last modified/last accessed work a bit differently on Windows.")
     def test_scan_cache_last_modified_and_last_accessed(self) -> None:
         """Scan the last_modified and last_accessed properties when scanning."""
@@ -435,6 +461,62 @@ class TestCorruptedCacheUtils(unittest.TestCase):
         self.assertEqual(readme_file_2.blob_last_accessed, repo_2.last_accessed)
         self.assertEqual(readme_file_2.blob_last_modified, repo_2.last_modified)
         self.assertEqual(revision_2.last_modified, repo_2.last_modified)
+
+
+@pytest.mark.usefixtures("fx_cache_dir")
+class TestRefTrailingNewlineHandlingUnit(unittest.TestCase):
+    """Unit-level regression tests for https://github.com/huggingface/huggingface_hub/issues/4133.
+
+    These tests construct a minimal fake cache on-disk and do not require network access.
+    They ensure that a trailing newline in refs/<revision> files does not break cache
+    lookups in try_to_load_from_cache or scan_cache_dir.
+    """
+
+    cache_dir: Path
+
+    FAKE_REPO_ID = "test-org/my-model"
+    FAKE_COMMIT_HASH = "a" * 40
+    FAKE_FILENAME = "config.json"
+
+    def _build_minimal_cache(self, ref_content: str) -> None:
+        """Populate cache_dir with a minimal single-file cache."""
+        repo_dir = self.cache_dir / "models--test-org--my-model"
+        snapshot_dir = repo_dir / "snapshots" / self.FAKE_COMMIT_HASH
+        refs_dir = repo_dir / "refs"
+
+        snapshot_dir.mkdir(parents=True)
+        (snapshot_dir / self.FAKE_FILENAME).write_text("{}")
+
+        refs_dir.mkdir(parents=True)
+        (refs_dir / "main").write_text(ref_content)
+
+    def test_try_to_load_from_cache_strips_trailing_newline(self) -> None:
+        """try_to_load_from_cache must find the cached file even when refs/main ends with \\n."""
+        self._build_minimal_cache(ref_content=self.FAKE_COMMIT_HASH + "\n")
+
+        result = try_to_load_from_cache(
+            self.FAKE_REPO_ID,
+            filename=self.FAKE_FILENAME,
+            revision="main",
+            cache_dir=self.cache_dir,
+        )
+
+        self.assertIsNotNone(result, "Expected cached file to be found despite trailing newline in refs/main")
+        self.assertTrue(str(result).endswith(self.FAKE_FILENAME))
+
+    def test_scan_cache_strips_trailing_newline(self) -> None:
+        """scan_cache_dir must correctly map a ref whose file ends with \\n to the snapshot."""
+        self._build_minimal_cache(ref_content=self.FAKE_COMMIT_HASH + "\n")
+
+        report = scan_cache_dir(self.cache_dir)
+
+        self.assertEqual(len(report.warnings), 0, f"Unexpected warnings: {report.warnings}")
+        self.assertEqual(len(report.repos), 1)
+        repo = list(report.repos)[0]
+        self.assertEqual(len(repo.revisions), 1)
+        revision = list(repo.revisions)[0]
+        self.assertEqual(revision.commit_hash, self.FAKE_COMMIT_HASH)
+        self.assertIn("main", revision.refs)
 
 
 class TestDeleteRevisionsDryRun(unittest.TestCase):


### PR DESCRIPTION
## Summary

`refs/<revision>` files in the HF Hub cache store a single commit hash (a 40-character hex SHA-1). When these files are written by tools such as `echo` or when a cache directory is transferred between environments, a trailing newline can end up in the file. Before this fix, every code path that read such a file called `f.read()` without `.strip()`, so the returned string was `"<hash>\n"` rather than `"<hash>"`. That extra byte makes the commit-hash string differ from any real snapshot directory name (which carries no newline), so all subsequent path constructions — `snapshots/<hash>\n/`, pointer-file lookups, and `refs_by_hash` dict keys in `scan_cache_dir` — silently failed even though the correct data was already present on disk. Offline and air-gapped environments are the most affected because the fallback to a network download is disabled, so the error surfaces as an uncatchable `EnvironmentError`. Four sites in the codebase had the same omission; all four are fixed here by adding `.strip()` to the `f.read()` call. The existing `.strip()` in `utils/_verification.py` (lines 59 and 65) already used the correct pattern and is left unchanged.

## Issue

Fixes #4133

## Local verification

```
$ cd /tmp/huggingface_hub

# Linter
$ ruff check src/huggingface_hub/_snapshot_download.py \
             src/huggingface_hub/file_download.py \
             src/huggingface_hub/utils/_cache_manager.py \
             tests/test_utils_cache.py
All checks passed!

# Formatter
$ ruff format --check src/huggingface_hub/_snapshot_download.py \
                      src/huggingface_hub/file_download.py \
                      src/huggingface_hub/utils/_cache_manager.py \
                      tests/test_utils_cache.py
4 files already formatted

# pre-commit (all hooks)
$ pre-commit run --files src/huggingface_hub/_snapshot_download.py \
                         src/huggingface_hub/file_download.py \
                         src/huggingface_hub/utils/_cache_manager.py \
                         tests/test_utils_cache.py
check yaml...........................................(no files to check)Skipped
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
check for case conflicts.................................................Passed
check for merge conflicts................................................Passed
ruff.....................................................................Passed
toml-sort-fix........................................(no files to check)Skipped

# New regression tests (no network required)
$ pytest tests/test_utils_cache.py::TestRefTrailingNewlineHandlingUnit -v
============================= test session starts ==============================
platform linux -- Python 3.11.15, pytest-9.0.3, pluggy-1.6.0
collecting ... collected 2 items

tests/test_utils_cache.py::TestRefTrailingNewlineHandlingUnit::test_scan_cache_strips_trailing_newline PASSED
tests/test_utils_cache.py::TestRefTrailingNewlineHandlingUnit::test_try_to_load_from_cache_strips_trailing_newline PASSED

============================== 2 passed in 0.16s ==============================
=== LOCAL_TEST_PASSED ===
```

## Risk

The change is limited to four `f.read()` → `f.read().strip()` call sites, each of which reads a file that is documented to contain exactly one commit hash and nothing else. `.strip()` removes only leading/trailing whitespace and newlines, so a clean file (no trailing newline) is unaffected. The only behavioural change is that a refs file with an accidental trailing newline now resolves correctly instead of producing a corrupted path; no other callers are affected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: behavior only changes for malformed `refs/<revision>` files (e.g., trailing newline), improving cache resolution without affecting valid refs.
> 
> **Overview**
> Fixes cache lookups when `refs/<revision>` contains trailing whitespace/newlines by applying `.strip()` when reading ref files in `snapshot_download`, `hf_hub_download` fallback paths, `try_to_load_from_cache`, and `scan_cache_dir`.
> 
> Adds regression coverage in `tests/test_utils_cache.py`, including a production-cache scenario and a unit test that builds a minimal on-disk cache to ensure refs with trailing newlines still resolve to the correct snapshot/file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efcba687ae07b642435029123e5b2216f32dc3de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->