### PR TITLE
[CLI] Support hf:// URIs in cache rm

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -1443,7 +1443,7 @@ Deleted 2 repo(s) and 2 revision(s); freed 5.31G.
 
 ### hf cache rm
 
-`hf cache rm` removes cached repositories or individual revisions. Pass one or more repo IDs (`model/bert-base-uncased`) or revision hashes:
+`hf cache rm` removes cached repositories or individual revisions. Pass one or more repo IDs (`model/bert-base-uncased`), repo-level `hf://` URIs, or revision hashes:
 
 ```bash
 >>> hf cache rm model/LiquidAI/LFM2-VL-1.6B
@@ -1453,6 +1453,15 @@ Proceed with deletion? [y/N]: y
 Delete repo: ~/.cache/huggingface/hub/models--LiquidAI--LFM2-VL-1.6B
 Cache deletion done. Saved 3.2G.
 Deleted 1 repo(s) and 2 revision(s); freed 3.2G.
+```
+
+Repo-level `hf://` URIs are also supported:
+
+```bash
+>>> hf cache rm hf://models/openai-community/gpt2 --dry-run
+About to delete 1 repo(s) totalling 1.1G.
+  - model/openai-community/gpt2 (entire repo)
+Dry run: no files were deleted.
 ```
 
 Mix repositories and specific revisions in the same call. Use `--dry-run` to preview the impact, or `--yes` to skip the confirmation prompt—handy in automated scripts:

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -623,7 +623,7 @@ $ hf cache rm [OPTIONS] TARGETS...
 
 **Arguments**:
 
-* `TARGETS...`: One or more repo IDs (e.g. model/bert-base-uncased) or revision hashes to delete.  [required]
+* `TARGETS...`: One or more repo IDs (e.g. model/bert-base-uncased), repo-level hf:// URIs, or revision hashes to delete.  [required]
 
 **Options**:
 
@@ -634,6 +634,7 @@ $ hf cache rm [OPTIONS] TARGETS...
 
 Examples
   $ hf cache rm model/gpt2
+  $ hf cache rm hf://models/openai-community/gpt2
   $ hf cache rm <revision_hash>
   $ hf cache rm model/gpt2 --dry-run
   $ hf cache rm model/gpt2 --yes

--- a/src/huggingface_hub/cli/cache.py
+++ b/src/huggingface_hub/cli/cache.py
@@ -25,7 +25,16 @@ import typer
 
 from huggingface_hub.errors import CLIError
 
-from ..utils import ANSI, CachedRepoInfo, CachedRevisionInfo, CacheNotFound, HFCacheInfo, _format_size, scan_cache_dir
+from ..utils import (
+    ANSI,
+    CachedRepoInfo,
+    CachedRevisionInfo,
+    CacheNotFound,
+    HFCacheInfo,
+    _format_size,
+    parse_hf_uri,
+    scan_cache_dir,
+)
 from ..utils._parsing import parse_duration, parse_size
 from ._cli_utils import RepoIdArg, RepoTypeOpt, RevisionOpt, TokenOpt, get_hf_api, typer_factory
 from ._output import out
@@ -129,6 +138,19 @@ def build_cache_index(
         for revision in repo.revisions:
             revision_lookup[revision.commit_hash.lower()] = (repo, revision)
     return repo_lookup, revision_lookup
+
+
+def _repo_cache_id_from_target(target: str) -> str:
+    """Return the cache id matching a repo target passed to `hf cache rm`."""
+    if not target.startswith("hf://"):
+        return target
+
+    uri = parse_hf_uri(target)
+    if not uri.is_repo:
+        raise CLIError("Only repository hf:// URIs are supported by `hf cache rm`.")
+    if uri.revision is not None or uri.path_in_repo:
+        raise CLIError("Only repo-level hf:// URIs are supported by `hf cache rm` for now.")
+    return f"{uri.type}/{uri.id}"
 
 
 def collect_cache_entries(
@@ -320,7 +342,7 @@ def _resolve_deletion_targets(hf_cache_info: HFCacheInfo, targets: list[str]) ->
             revisions.add(revision.commit_hash)
             continue
 
-        matched_repo = repo_lookup.get(lowered)
+        matched_repo = repo_lookup.get(_repo_cache_id_from_target(target).lower())
         if matched_repo is None:
             missing.append(raw_target)
             continue
@@ -479,6 +501,7 @@ def ls(
 @cache_cli.command(
     examples=[
         "hf cache rm model/gpt2",
+        "hf cache rm hf://models/openai-community/gpt2",
         "hf cache rm <revision_hash>",
         "hf cache rm model/gpt2 --dry-run",
         "hf cache rm model/gpt2 --yes",
@@ -488,7 +511,7 @@ def rm(
     targets: Annotated[
         list[str],
         typer.Argument(
-            help="One or more repo IDs (e.g. model/bert-base-uncased) or revision hashes to delete.",
+            help="One or more repo IDs (e.g. model/bert-base-uncased), repo-level hf:// URIs, or revision hashes to delete.",
         ),
     ],
     cache_dir: Annotated[

--- a/src/huggingface_hub/serialization/_torch.py
+++ b/src/huggingface_hub/serialization/_torch.py
@@ -268,9 +268,7 @@ def save_torch_state_dict(
     safe_file_kwargs = {"metadata": per_file_metadata} if safe_serialization else {}
     for filename, tensors in state_dict_split.filename_to_tensors.items():
         shard = {tensor: state_dict[tensor] for tensor in tensors}
-        save_file_fn(
-            shard, os.path.join(save_directory, filename), **safe_file_kwargs
-        )  # ty: ignore[invalid-argument-type]
+        save_file_fn(shard, os.path.join(save_directory, filename), **safe_file_kwargs)  # ty: ignore[invalid-argument-type]
         logger.debug(f"Shard saved to {filename}")
 
     # Save the index (if any)

--- a/src/huggingface_hub/serialization/_torch.py
+++ b/src/huggingface_hub/serialization/_torch.py
@@ -268,7 +268,9 @@ def save_torch_state_dict(
     safe_file_kwargs = {"metadata": per_file_metadata} if safe_serialization else {}
     for filename, tensors in state_dict_split.filename_to_tensors.items():
         shard = {tensor: state_dict[tensor] for tensor in tensors}
-        save_file_fn(shard, os.path.join(save_directory, filename), **safe_file_kwargs)  # ty: ignore[invalid-argument-type]
+        save_file_fn(
+            shard, os.path.join(save_directory, filename), **safe_file_kwargs
+        )  # ty: ignore[invalid-argument-type]
         logger.debug(f"Shard saved to {filename}")
 
     # Save the index (if any)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -189,6 +189,59 @@ class TestCacheCommand:
         strategy.execute.assert_called_once_with()
         print_mock.assert_called_once()
 
+    def test_rm_hf_uri_executes_strategy(self, runner: CliRunner) -> None:
+        revision = _make_revision("c" * 40)
+        repo = _make_repo("openai-community/gpt2", revisions=[revision])
+
+        repo_lookup = {"model/openai-community/gpt2": repo}
+        revision_lookup = {}
+
+        strategy = Mock()
+        strategy.expected_freed_size_str = "0B"
+
+        hf_cache_info = Mock()
+        hf_cache_info.delete_revisions.return_value = strategy
+
+        with (
+            patch("huggingface_hub.cli.cache.scan_cache_dir", return_value=hf_cache_info),
+            patch("huggingface_hub.cli.cache.build_cache_index", return_value=(repo_lookup, revision_lookup)),
+            patch("huggingface_hub.cli.cache.print_cache_selected_revisions"),
+        ):
+            result = runner.invoke(app, ["cache", "rm", "hf://models/openai-community/gpt2", "--yes"])
+
+        assert result.exit_code == 0
+        hf_cache_info.delete_revisions.assert_called_once_with(revision.commit_hash)
+        strategy.execute.assert_called_once_with()
+
+    @pytest.mark.parametrize(
+        "target",
+        [
+            "hf://models/openai-community/gpt2@main",
+            "hf://models/openai-community/gpt2/config.json",
+        ],
+    )
+    def test_rm_hf_uri_rejects_revisions_and_paths(self, runner: CliRunner, target: str) -> None:
+        with (
+            patch("huggingface_hub.cli.cache.scan_cache_dir"),
+            patch("huggingface_hub.cli.cache.build_cache_index", return_value=({}, {})),
+        ):
+            result = runner.invoke(app, ["cache", "rm", target])
+
+        assert result.exit_code == 1
+        assert isinstance(result.exception, CLIError)
+        assert "Only repo-level hf:// URIs are supported" in str(result.exception)
+
+    def test_rm_hf_uri_rejects_buckets(self, runner: CliRunner) -> None:
+        with (
+            patch("huggingface_hub.cli.cache.scan_cache_dir"),
+            patch("huggingface_hub.cli.cache.build_cache_index", return_value=({}, {})),
+        ):
+            result = runner.invoke(app, ["cache", "rm", "hf://buckets/openai-community/gpt2"])
+
+        assert result.exit_code == 1
+        assert isinstance(result.exception, CLIError)
+        assert "Only repository hf:// URIs are supported" in str(result.exception)
+
     def test_rm_dry_run_skips_execute(self, runner: CliRunner) -> None:
         revision = _make_revision("d" * 40)
         repo = _make_repo("user/model", revisions=[revision])


### PR DESCRIPTION
## Summary

- Add support for repo-level `hf://` URIs in `hf cache rm`
- Reuse the centralized `parse_hf_uri` helper introduced in #4189
- Keep revisions, filenames and buckets out of scope for now with clear errors
- Update CLI docs and generated CLI reference

Example:

```bash
hf cache rm hf://models/openai-community/gpt2 --dry-run
```

For now this only supports repo-level URIs like hf://models/openai-community/gpt2. Follow-up PRs can expand this to revisions and filenames...

Validation:
make style
make quality
PYTHONPATH=src python3 -m pytest tests/test_cli.py::TestCacheCommand
tests/test_cli.py::TestCacheCommand passes locally. 
Full tests/test_cli.py hits unrelated network/DNS failures in production-style tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends cache-deletion target parsing to accept `hf://` inputs; while scoped to repo-level URIs and covered by new tests, mistakes could cause unintended cache removals if URI-to-cache-id resolution is wrong.
> 
> **Overview**
> `hf cache rm` now accepts *repo-level* `hf://` URIs (e.g. `hf://models/openai-community/gpt2`) in addition to `model/...` IDs and revision hashes by resolving URIs via `parse_hf_uri`.
> 
> The command explicitly rejects non-repo URIs (e.g. buckets) and any `hf://` URI that includes a revision (`@...`) or a path, and the CLI docs/reference plus tests were updated to reflect and validate this behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08c0c4020c9f38909652e72fab5324dac97fdcbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->