### PR TITLE
Fix catch-all empty string in CI pytest --only-rerun

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -90,7 +90,7 @@ jobs:
         working-directory: ./src # For code coverage to work
         run: |
           source ../.venv/bin/activate
-          PYTEST="python -m pytest --cov=./huggingface_hub --cov-report=xml:../coverage.xml --vcr-record=none --reruns 8 --reruns-delay 2 --only-rerun '(OSError|Timeout|HTTPError.*502|HTTPError.*504||not less than or equal to 0.01)'"
+          PYTEST="python -m pytest --cov=./huggingface_hub --cov-report=xml:../coverage.xml --vcr-record=none --reruns 8 --reruns-delay 2 --only-rerun '(OSError|Timeout|HTTPError.*502|HTTPError.*504|not less than or equal to 0.01)'"
 
           case "${{ matrix.test_name }}" in
 


### PR DESCRIPTION
Fix catch-all empty string in CI pytest --only-rerun.

This PR fixes a typo in the `--only-rerun` regular expression pattern in the `PYTEST` command ( `python-tests.yml` workflow file) by removing an extra pipe character.

- Remove accidental `||` (double pipe) in the `--only-rerun` regex pattern in the `PYTEST` command, which introduced an empty alternation that matched every test failure, causing all failing tests to be retried rather than only the intended transient errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that narrows the `--only-rerun` regex so retries only trigger for intended transient errors instead of matching everything.
> 
> **Overview**
> Fixes a typo in `.github/workflows/python-tests.yml` by removing an empty alternation from the `pytest --only-rerun` regex.
> 
> This prevents the CI rerun plugin from retrying *all* failures and limits reruns to the specified transient error patterns (e.g., timeouts/502/504).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b163ea4bece9443053cd37441789c1b94514abea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->