### PR TITLE
[CLI] Expose linked repos in PaperInfo

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -1831,6 +1831,16 @@ class PaperInfo:
             URL of the GitHub repository for the paper.
         github_stars (`int`, *optional*):
             Number of stars of the GitHub repository for the paper.
+        linked_models (`list[dict]`, *optional*):
+            Models linked to the paper. Only returned by [`paper_info`].
+        num_total_models (`int`, *optional*):
+            Total number of models linked to the paper. Only returned by [`paper_info`].
+        linked_datasets (`list[dict]`, *optional*):
+            Datasets linked to the paper. Only returned by [`paper_info`].
+        num_total_datasets (`int`, *optional*):
+            Total number of datasets linked to the paper. Only returned by [`paper_info`].
+        linked_spaces (`list[dict]`, *optional*):
+            Spaces linked to the paper. Only returned by [`paper_info`].
     """
 
     id: str
@@ -1850,6 +1860,11 @@ class PaperInfo:
     project_page: str | None
     github_repo: str | None
     github_stars: int | None
+    linked_models: list[dict] | None
+    num_total_models: int | None
+    linked_datasets: list[dict] | None
+    num_total_datasets: int | None
+    linked_spaces: list[dict] | None
 
     def __init__(self, **kwargs) -> None:
         paper = kwargs.pop("paper", {})
@@ -1875,6 +1890,11 @@ class PaperInfo:
         self.project_page = kwargs.pop("projectPage", None)
         self.github_repo = kwargs.pop("githubRepo", None)
         self.github_stars = kwargs.pop("githubStars", None)
+        self.linked_models = kwargs.pop("linkedModels", None)
+        self.num_total_models = kwargs.pop("numTotalModels", None)
+        self.linked_datasets = kwargs.pop("linkedDatasets", None)
+        self.num_total_datasets = kwargs.pop("numTotalDatasets", None)
+        self.linked_spaces = kwargs.pop("linkedSpaces", None)
 
         # forward compatibility
         self.__dict__.update(**kwargs)

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -1831,15 +1831,15 @@ class PaperInfo:
             URL of the GitHub repository for the paper.
         github_stars (`int`, *optional*):
             Number of stars of the GitHub repository for the paper.
-        linked_models (`list[dict]`, *optional*):
+        linked_models (`list[ModelInfo]`, *optional*):
             Models linked to the paper. Only returned by [`paper_info`].
         num_total_models (`int`, *optional*):
             Total number of models linked to the paper. Only returned by [`paper_info`].
-        linked_datasets (`list[dict]`, *optional*):
+        linked_datasets (`list[DatasetInfo]`, *optional*):
             Datasets linked to the paper. Only returned by [`paper_info`].
         num_total_datasets (`int`, *optional*):
             Total number of datasets linked to the paper. Only returned by [`paper_info`].
-        linked_spaces (`list[dict]`, *optional*):
+        linked_spaces (`list[SpaceInfo]`, *optional*):
             Spaces linked to the paper. Only returned by [`paper_info`].
     """
 
@@ -1860,11 +1860,11 @@ class PaperInfo:
     project_page: str | None
     github_repo: str | None
     github_stars: int | None
-    linked_models: list[dict] | None
+    linked_models: list[ModelInfo] | None
     num_total_models: int | None
-    linked_datasets: list[dict] | None
+    linked_datasets: list[DatasetInfo] | None
     num_total_datasets: int | None
-    linked_spaces: list[dict] | None
+    linked_spaces: list[SpaceInfo] | None
 
     def __init__(self, **kwargs) -> None:
         paper = kwargs.pop("paper", {})
@@ -1890,11 +1890,14 @@ class PaperInfo:
         self.project_page = kwargs.pop("projectPage", None)
         self.github_repo = kwargs.pop("githubRepo", None)
         self.github_stars = kwargs.pop("githubStars", None)
-        self.linked_models = kwargs.pop("linkedModels", None)
+        linked_models = kwargs.pop("linkedModels", None)
+        self.linked_models = [ModelInfo(**m) for m in linked_models] if linked_models is not None else None
         self.num_total_models = kwargs.pop("numTotalModels", None)
-        self.linked_datasets = kwargs.pop("linkedDatasets", None)
+        linked_datasets = kwargs.pop("linkedDatasets", None)
+        self.linked_datasets = [DatasetInfo(**d) for d in linked_datasets] if linked_datasets is not None else None
         self.num_total_datasets = kwargs.pop("numTotalDatasets", None)
-        self.linked_spaces = kwargs.pop("linkedSpaces", None)
+        linked_spaces = kwargs.pop("linkedSpaces", None)
+        self.linked_spaces = [SpaceInfo(**s) for s in linked_spaces] if linked_spaces is not None else None
 
         # forward compatibility
         self.__dict__.update(**kwargs)

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -4474,6 +4474,17 @@ class PaperApiTest(unittest.TestCase):
         paper = self.api.paper_info("2407.21783")
         assert paper.title == "The Llama 3 Herd of Models"
 
+    def test_get_paper_by_id_returns_linked_repos(self) -> None:
+        paper = self.api.paper_info("2601.15621")
+        assert paper.linked_models is not None and len(paper.linked_models) > 0
+        assert all(isinstance(m, ModelInfo) for m in paper.linked_models)
+        assert paper.num_total_models is not None and paper.num_total_models > 0
+        assert paper.linked_datasets is not None
+        assert all(isinstance(d, DatasetInfo) for d in paper.linked_datasets)
+        assert paper.num_total_datasets is not None
+        assert paper.linked_spaces is not None and len(paper.linked_spaces) > 0
+        assert all(isinstance(s, SpaceInfo) for s in paper.linked_spaces)
+
     def test_get_paper_by_id_not_found(self) -> None:
         with self.assertRaises(HfHubHTTPError) as context:
             self.api.paper_info("1234.56789")
@@ -4532,35 +4543,6 @@ class PaperApiTest(unittest.TestCase):
     def test_daily_papers_limit(self) -> None:
         papers = list(self.api.list_daily_papers(date="2025-10-29", limit=10))
         assert len(papers) == 10
-
-
-class PaperInfoParseTest(unittest.TestCase):
-    def test_paper_info_parses_linked_repos(self) -> None:
-        from huggingface_hub.hf_api import PaperInfo
-
-        paper = PaperInfo(
-            id="2502.08025",
-            linkedModels=[{"id": "user/test-model"}],
-            numTotalModels=1,
-            linkedDatasets=[{"id": "user/test-dataset"}],
-            numTotalDatasets=1,
-            linkedSpaces=[{"id": "user/test-space"}],
-        )
-        assert paper.linked_models == [{"id": "user/test-model"}]
-        assert paper.num_total_models == 1
-        assert paper.linked_datasets == [{"id": "user/test-dataset"}]
-        assert paper.num_total_datasets == 1
-        assert paper.linked_spaces == [{"id": "user/test-space"}]
-
-    def test_paper_info_linked_repos_default_to_none(self) -> None:
-        from huggingface_hub.hf_api import PaperInfo
-
-        paper = PaperInfo(id="2502.08025")
-        assert paper.linked_models is None
-        assert paper.num_total_models is None
-        assert paper.linked_datasets is None
-        assert paper.num_total_datasets is None
-        assert paper.linked_spaces is None
 
 
 class WebhookApiTest(HfApiCommonTest):

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -4534,6 +4534,35 @@ class PaperApiTest(unittest.TestCase):
         assert len(papers) == 10
 
 
+class PaperInfoParseTest(unittest.TestCase):
+    def test_paper_info_parses_linked_repos(self) -> None:
+        from huggingface_hub.hf_api import PaperInfo
+
+        paper = PaperInfo(
+            id="2502.08025",
+            linkedModels=[{"id": "user/test-model"}],
+            numTotalModels=1,
+            linkedDatasets=[{"id": "user/test-dataset"}],
+            numTotalDatasets=1,
+            linkedSpaces=[{"id": "user/test-space"}],
+        )
+        assert paper.linked_models == [{"id": "user/test-model"}]
+        assert paper.num_total_models == 1
+        assert paper.linked_datasets == [{"id": "user/test-dataset"}]
+        assert paper.num_total_datasets == 1
+        assert paper.linked_spaces == [{"id": "user/test-space"}]
+
+    def test_paper_info_linked_repos_default_to_none(self) -> None:
+        from huggingface_hub.hf_api import PaperInfo
+
+        paper = PaperInfo(id="2502.08025")
+        assert paper.linked_models is None
+        assert paper.num_total_models is None
+        assert paper.linked_datasets is None
+        assert paper.num_total_datasets is None
+        assert paper.linked_spaces is None
+
+
 class WebhookApiTest(HfApiCommonTest):
     def setUp(self) -> None:
         super().setUp()


### PR DESCRIPTION
## Summary

related to https://github.com/huggingface/huggingface_hub/pull/3952

`GET /api/papers/{id}` now returns linked repos by default. This PR surfaces them on `PaperInfo`:

- `linked_models: list[dict] | None`
- `num_total_models: int | None`
- `linked_datasets: list[dict] | None`
- `num_total_datasets: int | None`
- `linked_spaces: list[dict] | None`

### Example

```bash
curl -s https://huggingface.co/api/papers/2601.15621
```

returns (truncated):

```json
{
  "id": "2601.15621",
  "linkedModels": [
    { "id": "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice", "downloads": 1556731, "likes": 1491, ... },
    { "id": "Qwen/Qwen3-TTS-12Hz-1.7B-Base", "downloads": 1954426, "likes": 393, ... }
  ],
  "numTotalModels": 261,
  "linkedDatasets": [
    { "id": "Izzyzlin/CFSDD", "downloads": 667, ... }
  ],
  "numTotalDatasets": 1,
  "linkedSpaces": [
    { "id": "HuggingFaceM4/faster-qwen3-tts-demo", "emoji": "🎙", "running": true, "featured": true }
  ]
}
```

After this PR:

```python
>>> from huggingface_hub import HfApi
>>> paper = HfApi().paper_info("2601.15621")
>>> paper.num_total_models
261
>>> paper.linked_models[0].id
'Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice'
>>> paper.linked_spaces[0].id
'HuggingFaceM4/faster-qwen3-tts-demo'
```

```bash
$ hf papers info 2601.15621 | jq ".linked_models[].id"
"Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice"
"Qwen/Qwen3-TTS-12Hz-1.7B-Base"
"Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign"
"Qwen/Qwen3-TTS-12Hz-0.6B-Base"
```

## Test plan

- [x] Added `PaperInfoParseTest` in `tests/test_hf_api.py` covering the new fields (both populated and default-None cases).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new optional fields to `PaperInfo` and parsing logic for additional API response keys, plus a focused regression test.
> 
> **Overview**
> `PaperInfo` now surfaces linked Hub repos returned by `GET /api/papers/{id}` by adding optional `linked_models`/`linked_datasets`/`linked_spaces` lists (parsed into `ModelInfo`/`DatasetInfo`/`SpaceInfo`) and accompanying `num_total_models`/`num_total_datasets` counters.
> 
> Adds a production test ensuring `paper_info` populates these new fields when present in the API response.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93d40881071512ff68e72c409aa125ce0113d027. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->