### PR TITLE
[CLI] Add `hf spaces ssh`

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -1104,6 +1104,26 @@ Use `hf spaces variables` to manage non-secret environment variables on a Space.
 >>> hf spaces variables delete username/my-space MAX_TOKENS --yes
 ```
 
+### SSH into a Space (Dev Mode)
+
+Use `hf spaces ssh` to open an SSH session into a Space's Dev Mode container. If Dev Mode is not enabled, the CLI will prompt you to enable it (or use `--auto` to skip the prompt).
+
+Your SSH public key must be registered [in your settings](https://huggingface.co/settings/keys). See the [Dev Mode documentation](https://huggingface.co/docs/hub/spaces-dev-mode) for more details.
+
+```bash
+# SSH into a Space
+>>> hf spaces ssh username/my-space
+
+# Print the SSH command without running it
+>>> hf spaces ssh username/my-space --dry-run
+
+# Auto-enable Dev Mode if disabled
+>>> hf spaces ssh username/my-space --auto
+
+# Use a specific SSH key
+>>> hf spaces ssh username/my-space -i ~/.ssh/id_ed25519
+```
+
 ## hf papers
 
 Use `hf papers` to list, search, get structured info, and read the markdown content of papers on the Hub.

--- a/docs/source/en/guides/manage-spaces.md
+++ b/docs/source/en/guides/manage-spaces.md
@@ -204,6 +204,34 @@ it will go to sleep. Any visitor landing on your Space will start it back up. Yo
 Note: if you are using a 'cpu-basic' hardware, you cannot configure a custom sleep time. Your Space will automatically
 be paused after 48h of inactivity.
 
+**Bonus: set a sleep time while requesting hardware**
+
+Upgraded hardware will be automatically assigned to your Space once it's built.
+
+```py
+>>> api.request_space_hardware(repo_id=repo_id, hardware=SpaceHardware.T4_MEDIUM, sleep_time=3600)
+```
+
+**Bonus: set a sleep time when creating or duplicating the Space!**
+
+```py
+>>> api.create_repo(
+...     repo_id=repo_id,
+...     repo_type="space",
+...     space_sdk="gradio"
+...     space_hardware="t4-medium",
+...     space_sleep_time="3600",
+... )
+```
+```py
+>>> api.duplicate_repo(
+...     from_id=repo_id,
+...     repo_type="space",
+...     space_hardware="t4-medium",
+...     space_sleep_time="3600",
+... )
+```
+
 ### Debug a failing Space by reading its logs
 
 When a Space fails to build or crashes at runtime, the logs you normally view in the browser are also available programmatically via [`fetch_space_logs`]. This is particularly useful from scripts or agentic workflows where opening a browser is not an option.
@@ -231,32 +259,30 @@ hf spaces logs username/my-space -f          # stream in real time
 hf spaces logs username/my-space -n 50       # last 50 lines only
 ```
 
-**Bonus: set a sleep time while requesting hardware**
+### SSH into a Space (Dev Mode)
 
-Upgraded hardware will be automatically assigned to your Space once it's built.
+[Dev Mode](https://huggingface.co/docs/hub/spaces-dev-mode) lets you SSH into a running Space container for live debugging and development. Use `hf spaces ssh` to open a session directly from the terminal. If Dev Mode is not yet enabled on the Space, the CLI will prompt you to enable it (or pass `--auto` to skip the prompt).
 
-```py
->>> api.request_space_hardware(repo_id=repo_id, hardware=SpaceHardware.T4_MEDIUM, sleep_time=3600)
+Your SSH public key must be registered at [in your settings](https://huggingface.co/settings/keys).
+
+```bash
+# SSH into a Space (enables Dev Mode if needed)
+hf spaces ssh username/my-space
+
+# Auto-enable Dev Mode without prompting
+hf spaces ssh username/my-space --auto
+
+# Print the SSH command without running it
+hf spaces ssh username/my-space --dry-run
+
+# Use a specific SSH key
+hf spaces ssh username/my-space -i ~/.ssh/id_ed25519
 ```
 
-**Bonus: set a sleep time when creating or duplicating the Space!**
+You can also enable Dev Mode without SSH using `hf spaces dev-mode`, which prints connection instructions for SSH, VS Code, Cursor, and Windsurf:
 
-```py
->>> api.create_repo(
-...     repo_id=repo_id,
-...     repo_type="space",
-...     space_sdk="gradio"
-...     space_hardware="t4-medium",
-...     space_sleep_time="3600",
-... )
-```
-```py
->>> api.duplicate_repo(
-...     from_id=repo_id,
-...     repo_type="space",
-...     space_hardware="t4-medium",
-...     space_sleep_time="3600",
-... )
+```bash
+hf spaces dev-mode username/my-space
 ```
 
 ### Mount volumes in your Space

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -3509,6 +3509,7 @@ $ hf spaces [OPTIONS] COMMAND [ARGS]...
 * `search`: Search spaces on the Hub using semantic...
 * `secrets`: Manage secrets for a Space on the Hub.
 * `settings`: Update the settings of a Space.
+* `ssh`: SSH into a Space's Dev Mode container.
 * `variables`: Manage environment variables for a Space...
 * `volumes`: Manage volumes for a Space on the Hub.
 
@@ -3981,6 +3982,43 @@ $ hf spaces settings [OPTIONS] SPACE_ID
 Examples
   $ hf spaces settings username/my-space --sleep-time 300
   $ hf spaces settings username/my-space --hardware t4-medium
+
+Learn more
+  Use `hf <command> --help` for more information about a command.
+  Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
+
+
+### `hf spaces ssh`
+
+SSH into a Space's Dev Mode container.
+
+Requires Dev Mode to be running on the Space and your SSH public key to be registered at https://huggingface.co/settings/keys.
+
+See: https://huggingface.co/docs/hub/spaces-dev-mode
+
+**Usage**:
+
+```console
+$ hf spaces ssh [OPTIONS] SPACE_ID
+```
+
+**Arguments**:
+
+* `SPACE_ID`: The space ID (e.g. `username/repo-name`).  [required]
+
+**Options**:
+
+* `-i, --identity-file PATH`: Path to the SSH identity file (forwarded to `ssh -i`).
+* `--dry-run`: Print the SSH command instead of running it.
+* `--auto`: Enable Dev Mode without prompting if not already enabled.
+* `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
+* `--help`: Show this message and exit.
+
+Examples
+  $ hf spaces ssh username/my-space
+  $ hf spaces ssh username/my-space --dry-run
+  $ hf spaces ssh username/my-space -i ~/.ssh/id_ed25519
+  $ hf spaces ssh username/my-space --auto
 
 Learn more
   Use `hf <command> --help` for more information about a command.

--- a/src/huggingface_hub/_space_api.py
+++ b/src/huggingface_hub/_space_api.py
@@ -214,6 +214,7 @@ class SpaceRuntime:
     requested_hardware: SpaceHardware | None
     sleep_time: int | None
     storage: SpaceStorage | None
+    dev_mode: bool
     hot_reloading: SpaceHotReloading | None
     volumes: list[Volume] | None
     raw: dict
@@ -224,6 +225,7 @@ class SpaceRuntime:
         self.requested_hardware = data.get("hardware", {}).get("requested")
         self.sleep_time = data.get("gcTimeout")
         self.storage = data.get("storage")
+        self.dev_mode = data.get("devMode", False)
         self.hot_reloading = SpaceHotReloading(raw_hr) if (raw_hr := data.get("hotReloading")) is not None else None
         raw_volumes = data.get("volumes")
         self.volumes = [Volume(**v) for v in raw_volumes] if raw_volumes is not None else None

--- a/src/huggingface_hub/cli/_output.py
+++ b/src/huggingface_hub/cli/_output.py
@@ -184,14 +184,14 @@ class Output:
                 if values:
                     print(values[0])
 
-    def confirm(self, message: str, *, default: bool = False, yes: bool = False) -> None:
+    def confirm(self, message: str, *, default: bool = False, yes: bool = False, confirm_param: str = "--yes") -> None:
         """
         Ask for confirmation. Raises `ConfirmationError` in non-human modes.
         """
         if yes:
             return
         if self.mode != OutputFormatWithAuto.human:
-            raise ConfirmationError(f"{message} Use --yes to skip confirmation.")
+            raise ConfirmationError(f"{message} Use {confirm_param} to skip confirmation.")
         typer.confirm(message, default=default, abort=True)
 
     def status(self, message: str | None = None) -> StatusLine:

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -398,7 +398,7 @@ def spaces_ssh(
     api = get_hf_api(token=token)
     info = api.space_info(space_id)
     if info.runtime is None or not info.runtime.dev_mode:
-        out.confirm(f"Dev Mode is not enabled on '{space_id}'. Enable it now?", yes=auto)
+        out.confirm(f"Dev Mode is not enabled on '{space_id}'. Enable it now?", yes=auto, confirm_param="--auto")
         api.enable_space_dev_mode(space_id)
         new_info = _wait_for_dev_mode(api, space_id)
         if new_info is None:

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -403,6 +403,7 @@ def spaces_ssh(
         new_info = _wait_for_dev_mode(api, space_id)
         if new_info is None:
             raise CLIError(f"Runtime not available for Space '{space_id}'.")
+        info = new_info
     cmd = ["ssh"]
     if identity_file is not None:
         cmd += ["-i", str(identity_file)]

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -400,8 +400,8 @@ def spaces_ssh(
     if info.runtime is None or not info.runtime.dev_mode:
         out.confirm(f"Dev Mode is not enabled on '{space_id}'. Enable it now?", yes=auto)
         api.enable_space_dev_mode(space_id)
-        info = _wait_for_dev_mode(api, space_id)
-        if info is None:
+        new_info = _wait_for_dev_mode(api, space_id)
+        if new_info is None:
             raise CLIError(f"Runtime not available for Space '{space_id}'.")
     cmd = ["ssh"]
     if identity_file is not None:

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -398,7 +398,9 @@ def spaces_ssh(
     api = get_hf_api(token=token)
     info = api.space_info(space_id)
     if info.runtime is None or not info.runtime.dev_mode:
-        out.confirm(f"Dev Mode is not enabled on '{space_id}'. Enable it now?", yes=auto, confirm_param="--auto")
+        out.confirm(
+            f"Dev Mode is disabled on '{space_id}'. Enable it now?", yes=auto, default=True, confirm_param="--auto"
+        )
         api.enable_space_dev_mode(space_id)
         new_info = _wait_for_dev_mode(api, space_id)
         if new_info is None:
@@ -411,6 +413,7 @@ def spaces_ssh(
     if dry_run:
         out.text(shlex.join(cmd))
         return
+    out.text(f"Running `{shlex.join(cmd)}`")
     result = subprocess.run(cmd)
     raise typer.Exit(code=result.returncode)
 

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -358,6 +358,63 @@ def dev_mode(
 
 
 @spaces_cli.command(
+    "ssh",
+    examples=[
+        "hf spaces ssh username/my-space",
+        "hf spaces ssh username/my-space --print",
+        "hf spaces ssh username/my-space -i ~/.ssh/id_ed25519",
+    ],
+)
+def spaces_ssh(
+    space_id: Annotated[str, typer.Argument(help="The space ID (e.g. `username/repo-name`).")],
+    identity_file: Annotated[
+        Path | None,
+        typer.Option(
+            "-i",
+            "--identity-file",
+            help="Path to the SSH identity file (forwarded to `ssh -i`).",
+        ),
+    ] = None,
+    print_only: Annotated[
+        bool,
+        typer.Option(
+            "--print",
+            help="Print the SSH command instead of running it.",
+        ),
+    ] = False,
+    token: TokenOpt = None,
+) -> None:
+    """SSH into a Space's Dev Mode container.
+
+    Requires Dev Mode to be running on the Space and your SSH public key to be registered
+    at https://huggingface.co/settings/keys. See:
+    https://huggingface.co/docs/hub/spaces-dev-mode
+    """
+    api = get_hf_api(token=token)
+    try:
+        info = api.space_info(space_id)
+    except RepositoryNotFoundError as e:
+        raise CLIError(f"Space '{space_id}' not found.") from e
+    if not info.subdomain:
+        raise CLIError(
+            f"No SSH endpoint available for '{space_id}'. "
+            f"Enable Dev Mode first with `hf spaces dev-mode {space_id}`."
+        )
+    cmd = ["ssh"]
+    if identity_file is not None:
+        cmd += ["-i", str(identity_file)]
+    cmd.append(f"{info.subdomain}@ssh.hf.space")
+    if print_only:
+        out.text(shlex.join(cmd))
+        return
+    try:
+        result = subprocess.run(cmd)
+    except FileNotFoundError as e:
+        raise CLIError("`ssh` command not found. Install an OpenSSH client.") from e
+    raise typer.Exit(code=result.returncode)
+
+
+@spaces_cli.command(
     "pause",
     examples=[
         "hf spaces pause username/my-space",

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -47,7 +47,7 @@ from huggingface_hub._hot_reload.types import ApiGetReloadEventSourceData, Reloa
 from huggingface_hub._space_api import SpaceHardware, SpaceStage
 from huggingface_hub.errors import CLIError, RemoteEntryNotFoundError, RepositoryNotFoundError, RevisionNotFoundError
 from huggingface_hub.file_download import hf_hub_download
-from huggingface_hub.hf_api import ExpandSpaceProperty_T, HfApi, SpaceSort_T
+from huggingface_hub.hf_api import ExpandSpaceProperty_T, HfApi, SpaceInfo, SpaceSort_T
 from huggingface_hub.repocard import SpaceCard
 from huggingface_hub.utils import disable_progress_bars
 
@@ -288,6 +288,32 @@ def spaces_search(
         out.hint("Use --description to show AI-generated descriptions.")
 
 
+_DEV_MODE_INTERMEDIATE_STATUSES = {
+    SpaceStage.BUILDING: "building...",
+    SpaceStage.RUNNING_BUILDING: "building...",
+    SpaceStage.APP_STARTING: "app starting...",
+    SpaceStage.RUNNING_APP_STARTING: "app starting...",
+}
+
+
+def _wait_for_dev_mode(api: HfApi, space_id: str) -> SpaceInfo | None:
+
+    status = out.status()
+    while True:
+        info = api.space_info(space_id)
+        if info.runtime is None:
+            return None
+        if info.runtime.stage not in _DEV_MODE_INTERMEDIATE_STATUSES:
+            break
+        status.update(_DEV_MODE_INTERMEDIATE_STATUSES[info.runtime.stage])
+        time.sleep(1)
+    if info.runtime.stage != SpaceStage.RUNNING:
+        status.done(f"Dev mode is not ready (stage='{info.runtime.stage}')")
+        return None
+    status.done("Dev mode ready!")
+    return info
+
+
 @spaces_cli.command(
     "dev-mode",
     examples=[
@@ -314,30 +340,11 @@ def dev_mode(
         print(f"Dev mode disabled for '{space_id}'")
         return
     api.enable_space_dev_mode(space_id)
-    info = api.space_info(space_id)
+    info = _wait_for_dev_mode(api, space_id)
+    if info is None:
+        return
     folder = getattr(info.card_data, "dev-mode-folder", "" if info.sdk == "docker" else "/home/user/app")
     folder_query_param = f"folder={folder}" if folder else ""
-    print(f"Dev mode is currently building, track the progress here: https://huggingface.co/spaces/{info.id}")
-    intermediate_statuses_and_messages = {
-        SpaceStage.BUILDING: "building...",
-        SpaceStage.RUNNING_BUILDING: "building...",
-        SpaceStage.APP_STARTING: "app starting...",
-        SpaceStage.RUNNING_APP_STARTING: "app starting...",
-    }
-    status = out.status()
-    while True:
-        info = api.space_info(space_id)
-        if info.runtime is None:
-            print("Runtime of the space unavailable")
-            return
-        if info.runtime.stage not in intermediate_statuses_and_messages:
-            break
-        status.update(intermediate_statuses_and_messages[info.runtime.stage])
-        time.sleep(1)
-    if info.runtime.stage != SpaceStage.RUNNING:
-        status.done(f"Dev mode is not ready (stage='{info.runtime.stage}')")
-        return
-    status.done("Dev mode ready!")
     print("Connect to dev environment:")
     print("")
     print("Web:")
@@ -349,7 +356,7 @@ def dev_mode(
     print("")
     print("Local:")
     print("1. Add your SSH key to https://huggingface.co/settings/keys")
-    print(f"2. SSH with `ssh -i <your_key> {ssh_host}`")
+    print(f"2. SSH with `hf spaces ssh {space_id}` (or `ssh -i <your_key> {ssh_host}`)")
     print("   Or open")
     print(f"  * VSCode: vscode://vscode-remote/ssh-remote+{ssh_host}{folder}")
     print(f"  * Cursor: cursor://vscode-remote/ssh-remote+{ssh_host}{folder}")
@@ -361,56 +368,49 @@ def dev_mode(
     "ssh",
     examples=[
         "hf spaces ssh username/my-space",
-        "hf spaces ssh username/my-space --print",
+        "hf spaces ssh username/my-space --dry-run",
         "hf spaces ssh username/my-space -i ~/.ssh/id_ed25519",
+        "hf spaces ssh username/my-space --auto",
     ],
 )
 def spaces_ssh(
     space_id: Annotated[str, typer.Argument(help="The space ID (e.g. `username/repo-name`).")],
     identity_file: Annotated[
         Path | None,
-        typer.Option(
-            "-i",
-            "--identity-file",
-            help="Path to the SSH identity file (forwarded to `ssh -i`).",
-        ),
+        typer.Option("-i", "--identity-file", help="Path to the SSH identity file (forwarded to `ssh -i`)."),
     ] = None,
-    print_only: Annotated[
+    dry_run: Annotated[
         bool,
-        typer.Option(
-            "--print",
-            help="Print the SSH command instead of running it.",
-        ),
+        typer.Option("--dry-run", help="Print the SSH command instead of running it."),
+    ] = False,
+    auto: Annotated[
+        bool,
+        typer.Option("--auto", help="Enable Dev Mode without prompting if not already enabled."),
     ] = False,
     token: TokenOpt = None,
 ) -> None:
     """SSH into a Space's Dev Mode container.
 
-    Requires Dev Mode to be running on the Space and your SSH public key to be registered
-    at https://huggingface.co/settings/keys. See:
-    https://huggingface.co/docs/hub/spaces-dev-mode
+    Requires Dev Mode to be running on the Space and your SSH public key to be registered at https://huggingface.co/settings/keys.
+
+    See: https://huggingface.co/docs/hub/spaces-dev-mode
     """
     api = get_hf_api(token=token)
-    try:
-        info = api.space_info(space_id)
-    except RepositoryNotFoundError as e:
-        raise CLIError(f"Space '{space_id}' not found.") from e
-    if not info.subdomain:
-        raise CLIError(
-            f"No SSH endpoint available for '{space_id}'. "
-            f"Enable Dev Mode first with `hf spaces dev-mode {space_id}`."
-        )
+    info = api.space_info(space_id)
+    if info.runtime is None or not info.runtime.dev_mode:
+        out.confirm(f"Dev Mode is not enabled on '{space_id}'. Enable it now?", yes=auto)
+        api.enable_space_dev_mode(space_id)
+        info = _wait_for_dev_mode(api, space_id)
+        if info is None:
+            raise CLIError(f"Runtime not available for Space '{space_id}'.")
     cmd = ["ssh"]
     if identity_file is not None:
         cmd += ["-i", str(identity_file)]
     cmd.append(f"{info.subdomain}@ssh.hf.space")
-    if print_only:
+    if dry_run:
         out.text(shlex.join(cmd))
         return
-    try:
-        result = subprocess.run(cmd)
-    except FileNotFoundError as e:
-        raise CLIError("`ssh` command not found. Install an OpenSSH client.") from e
+    result = subprocess.run(cmd)
     raise typer.Exit(code=result.returncode)
 
 


### PR DESCRIPTION
## Summary

Add `hf spaces ssh <space_id>` to SSH into a Space's Dev Mode container.

**Features:**
- Detects whether Dev Mode is enabled via `SpaceRuntime.dev_mode` (new field, from API `devMode`).
- If Dev Mode is off, prompts the user to enable it interactively (default to True), then waits until it's ready before connecting.
- `--auto` flag skips the prompt and enables Dev Mode automatically.
- `--dry-run` flag prints the `ssh` command instead of running it.
- `-i` / `--identity-file` to forward a specific SSH key.

**Other changes:**
- Updated `hf spaces dev-mode` output to mention `hf spaces ssh`.
- Added `dev_mode: bool` attribute to `SpaceRuntime`.

**Example:**

```bash
✗ hf spaces ssh huggingface/tmp-dev-mode-test                     
Dev Mode is disabled on 'huggingface/tmp-dev-mode-test'. Enable it now? [Y/n]: 
app starting...
Dev mode ready!
Running `ssh huggingface-tmp-dev-mode-test@ssh.hf.space`
root@r-huggingface-tmp-dev-mode-test-2msg752d-86560-vhqp4:/app# ls
```

**Usage:**

```
# Basic usage
$ hf spaces ssh username/my-space

# Print the command without running it
$ hf spaces ssh username/my-space --dry-run
ssh username-my-space@ssh.hf.space

# Auto-enable dev mode + SSH
$ hf spaces ssh username/my-space --auto

# With a specific SSH key
$ hf spaces ssh username/my-space -i ~/.ssh/id_ed25519
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: primarily adds a new CLI entrypoint plus small refactoring and a new `SpaceRuntime.dev_mode` field; behavior changes are limited to Dev Mode workflows and interactive confirmations.
> 
> **Overview**
> Adds `hf spaces ssh` to open an SSH session into a Space’s Dev Mode container, supporting `--auto` (enable Dev Mode without prompting), `--dry-run` (print the `ssh` command), and `-i/--identity-file` (forward an SSH key).
> 
> Extends `SpaceRuntime` with a `dev_mode` flag sourced from the API (`devMode`), refactors `hf spaces dev-mode` to reuse a shared “wait until Dev Mode is ready” helper, and updates CLI/docs reference pages to document the new SSH workflow. Also generalizes `out.confirm()` so commands can customize the “skip confirmation” flag text (used to point users to `--auto` for this command).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db5beece6011aa680c5b594a5e8607afc39973f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->