### PR TITLE
[Internal] Silence `ty` `invalid-type-form` on `WebhooksServer` annotations

### DIFF
--- a/src/huggingface_hub/_webhooks_server.py
+++ b/src/huggingface_hub/_webhooks_server.py
@@ -35,7 +35,7 @@ else:
     FastAPI = Request = JSONResponse = None  # type: ignore
 
 
-_global_app: Optional["WebhooksServer"] = None
+_global_app: Optional["WebhooksServer"] = None  # ty: ignore[invalid-type-form]
 _is_local = os.environ.get("SPACE_ID") is None
 
 
@@ -88,7 +88,7 @@ class WebhooksServer:
         ```
     """
 
-    def __new__(cls, *args, **kwargs) -> "WebhooksServer":
+    def __new__(cls, *args, **kwargs) -> "WebhooksServer":  # ty: ignore[invalid-type-form]
         if not is_gradio_available():
             raise ImportError(
                 "You must have `gradio` installed to use `WebhooksServer`. Please run `pip install --upgrade gradio`"
@@ -301,7 +301,7 @@ def webhook_endpoint(path: str | None = None) -> Callable:
     return _inner
 
 
-def _get_global_app() -> WebhooksServer:
+def _get_global_app() -> WebhooksServer:  # ty: ignore[invalid-type-form]
     global _global_app
     if _global_app is None:
         _global_app = WebhooksServer()


### PR DESCRIPTION
## Summary

- CI's `uvx ty check src` (which runs the latest `ty` release) started flagging 3 `invalid-type-form` errors in `_webhooks_server.py`:
  - `_global_app: Optional[\"WebhooksServer\"] = None`
  - `def __new__(cls, *args, **kwargs) -> \"WebhooksServer\":`
  - `def _get_global_app() -> WebhooksServer:`
- Root cause: `@experimental` wraps `WebhooksServer`, so ty sees the class as `(...) -> Unknown` and rejects it in type expressions. The annotations are correct — this is a ty limitation around decorated classes.
- Fix: add `# ty: ignore[invalid-type-form]` to the three offending lines. Cheapest, most targeted workaround; doesn't change runtime behavior or the public API.

### Before

```
src/huggingface_hub/_webhooks_server.py:38:24: error[invalid-type-form] Variable of type `(...) -> Unknown` is not allowed in a type expression
src/huggingface_hub/_webhooks_server.py:91:43: error[invalid-type-form] Variable of type `(...) -> Unknown` is not allowed in a return type annotation
src/huggingface_hub/_webhooks_server.py:304:26: error[invalid-type-form] Variable of type `(...) -> Unknown` is not allowed in a return type annotation
Found 3 diagnostics
```

### After

```
$ ty check src/huggingface_hub/_webhooks_server.py
All checks passed!
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: purely type-checker directive changes to suppress `ty` false positives; no runtime logic or API behavior changes.
> 
> **Overview**
> Silences `ty` `invalid-type-form` errors in `_webhooks_server.py` by adding targeted `# ty: ignore[invalid-type-form]` comments to the `WebhooksServer`-related type annotations (`_global_app`, `WebhooksServer.__new__` return type, and `_get_global_app` return type).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f03348123a81911ddd69f9e3f6729f927339c33e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->