### PR TITLE
[CI] make test_model_info_with_security for robust

### DIFF
--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2011,8 +2011,9 @@ class HfApiPublicProductionTest(unittest.TestCase):
             revision=DUMMY_MODEL_ID_REVISION_ONE_SPECIFIC_COMMIT,
             securityStatus=True,
         )
-        self.assertIsNotNone(model.security_repo_status)
-        self.assertEqual(model.security_repo_status, {"scansDone": True, "filesWithIssues": []})
+        assert model.security_repo_status is not None
+        assert isinstance(model.security_repo_status["scansDone"], bool)
+        assert "filesWithIssues" in model.security_repo_status
 
     def test_model_info_with_file_metadata(self):
         model = self._api.model_info(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only change that loosens assertions on the server-returned `security_repo_status` payload to avoid brittleness when the API response shape evolves.
> 
> **Overview**
> Updates `test_model_info_with_security` to stop asserting an exact `security_repo_status` dict and instead validate only key invariants (object present, `scansDone` is a boolean, and `filesWithIssues` exists), making CI less sensitive to server-side response changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49e3bfa0917a0803f58d906cb7bf0801e4106342. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->