### PR TITLE
[Hot-fix] [Inference] Remove Together ASR task to drop urllib3 dependency

### DIFF
--- a/src/huggingface_hub/inference/_providers/__init__.py
+++ b/src/huggingface_hub/inference/_providers/__init__.py
@@ -52,7 +52,6 @@ from .replicate import (
 from .sambanova import SambanovaConversationalTask, SambanovaFeatureExtractionTask
 from .scaleway import ScalewayConversationalTask, ScalewayFeatureExtractionTask
 from .together import (
-    TogetherAutomaticSpeechRecognitionTask,
     TogetherConversationalTask,
     TogetherFeatureExtractionTask,
     TogetherImageToImageTask,
@@ -217,7 +216,6 @@ PROVIDERS: dict[PROVIDER_T, dict[str, TaskProviderHelper]] = {
         "feature-extraction": ScalewayFeatureExtractionTask(),
     },
     "together": {
-        "automatic-speech-recognition": TogetherAutomaticSpeechRecognitionTask(),
         "conversational": TogetherConversationalTask(),
         "feature-extraction": TogetherFeatureExtractionTask(),
         "image-to-image": TogetherImageToImageTask(),

--- a/src/huggingface_hub/inference/_providers/together.py
+++ b/src/huggingface_hub/inference/_providers/together.py
@@ -1,18 +1,13 @@
 import base64
-import json
 import time
 from abc import ABC
 from typing import Any
 
-from urllib3.filepost import encode_multipart_formdata
-
 from huggingface_hub.hf_api import InferenceProviderMapping
 from huggingface_hub.inference._common import (
-    MimeBytes,
     RequestParameters,
     _as_dict,
     _as_url,
-    _open_as_mime_bytes,
 )
 from huggingface_hub.inference._providers._common import (
     BaseConversationalTask,
@@ -39,17 +34,6 @@ _VIDEO_MAX_POLL_ATTEMPTS = 150  # ~5 minutes at _VIDEO_POLLING_INTERVAL
 _VIDEO_PENDING_STATUSES = {"queued", "in_progress"}
 
 
-def _coerce_multipart(value: Any) -> str | bytes | tuple:
-    """Coerce a value to a type accepted by multipart/form-data fields."""
-    if isinstance(value, (str, bytes, tuple)):
-        return value
-    if isinstance(value, bool):
-        return "true" if value else "false"
-    if isinstance(value, (dict, list)):
-        return json.dumps(value)
-    return str(value)
-
-
 class TogetherTask(TaskProviderHelper, ABC):
     """Base class for Together API tasks."""
 
@@ -62,8 +46,6 @@ class TogetherTask(TaskProviderHelper, ABC):
                 return "/v1/images/generations"
             case "text-to-speech":
                 return "/v1/audio/speech"
-            case "automatic-speech-recognition":
-                return "/v1/audio/transcriptions"
             case "feature-extraction":
                 return "/v1/embeddings"
             case "text-to-video" | "image-to-video":
@@ -209,52 +191,6 @@ class TogetherTextToSpeechTask(TogetherTask):
         if isinstance(response, bytes):
             return response
         raise ValueError(f"Expected raw audio bytes for text-to-speech, got {type(response).__name__}.")
-
-
-class TogetherAutomaticSpeechRecognitionTask(TogetherTask):
-    def __init__(self):
-        super().__init__("automatic-speech-recognition")
-
-    def _prepare_payload_as_bytes(
-        self,
-        inputs: Any,
-        parameters: dict,
-        provider_mapping_info: InferenceProviderMapping,
-        extra_payload: dict | None,
-    ) -> MimeBytes | None:
-        fields: dict[str, Any] = {"model": provider_mapping_info.provider_id}
-
-        if isinstance(inputs, str) and inputs.startswith(("http://", "https://")):
-            # The API also accepts a public HTTPS URL string in the `file` form field.
-            fields["file"] = inputs
-        else:
-            audio = _open_as_mime_bytes(inputs)
-            mime_type = audio.mime_type or "audio/wav"
-            extension = mime_type.rsplit("/", 1)[-1]
-            fields["file"] = (f"audio.{extension}", bytes(audio), mime_type)
-
-        for key, value in filter_none(parameters or {}).items():
-            fields[key] = _coerce_multipart(value)
-        for key, value in filter_none(extra_payload or {}).items():
-            fields[key] = _coerce_multipart(value)
-
-        body, content_type = encode_multipart_formdata(fields)
-        return MimeBytes(body, mime_type=content_type)
-
-    def get_response(self, response: bytes | dict, request_params: RequestParameters | None = None) -> Any:
-        response_dict = _as_dict(response)
-        text = response_dict.get("text")
-        if not isinstance(text, str):
-            raise ValueError(f"Unexpected ASR response from Together: missing 'text' field. Got: {response!r}")
-        out: dict[str, Any] = {"text": text}
-        segments = response_dict.get("segments")
-        if isinstance(segments, list):
-            out["chunks"] = [
-                {"text": seg.get("text"), "timestamp": [seg.get("start"), seg.get("end")]}
-                for seg in segments
-                if isinstance(seg, dict)
-            ]
-        return out
 
 
 def _normalize_video_parameters(parameters: dict) -> dict:

--- a/tests/test_inference_providers.py
+++ b/tests/test_inference_providers.py
@@ -58,7 +58,6 @@ from huggingface_hub.inference._providers.replicate import (
 from huggingface_hub.inference._providers.sambanova import SambanovaConversationalTask, SambanovaFeatureExtractionTask
 from huggingface_hub.inference._providers.scaleway import ScalewayConversationalTask, ScalewayFeatureExtractionTask
 from huggingface_hub.inference._providers.together import (
-    TogetherAutomaticSpeechRecognitionTask,
     TogetherConversationalTask,
     TogetherFeatureExtractionTask,
     TogetherImageToImageTask,
@@ -1929,98 +1928,6 @@ class TestTogetherProvider:
         helper = TogetherTextToSpeechTask()
         response = helper.get_response(b"audio_bytes")
         assert response == b"audio_bytes"
-
-    def test_prepare_route_automatic_speech_recognition(self):
-        helper = TogetherAutomaticSpeechRecognitionTask()
-        assert helper._prepare_route("openai/whisper-large-v3", "hf_token") == "/v1/audio/transcriptions"
-
-    def test_prepare_payload_as_bytes_automatic_speech_recognition_url(self):
-        helper = TogetherAutomaticSpeechRecognitionTask()
-        body = helper._prepare_payload_as_bytes(
-            "https://example.com/audio.wav",
-            {"language": "en"},
-            InferenceProviderMapping(
-                provider="together",
-                hf_model_id="openai/whisper-large-v3",
-                providerId="openai/whisper-large-v3",
-                task="automatic-speech-recognition",
-                status="live",
-            ),
-            extra_payload=None,
-        )
-        assert body.mime_type.startswith("multipart/form-data")
-        assert b'name="file"\r\n\r\nhttps://example.com/audio.wav' in body
-        assert b'name="model"\r\n\r\nopenai/whisper-large-v3' in body
-        assert b'name="language"\r\n\r\nen' in body
-
-    def test_prepare_payload_as_bytes_automatic_speech_recognition_bytes(self):
-        helper = TogetherAutomaticSpeechRecognitionTask()
-        body = helper._prepare_payload_as_bytes(
-            b"raw audio bytes",
-            {},
-            InferenceProviderMapping(
-                provider="together",
-                hf_model_id="openai/whisper-large-v3",
-                providerId="openai/whisper-large-v3",
-                task="automatic-speech-recognition",
-                status="live",
-            ),
-            extra_payload=None,
-        )
-        assert body.mime_type.startswith("multipart/form-data")
-        assert b'filename="audio.wav"' in body
-        assert b"raw audio bytes" in body
-
-    def test_prepare_payload_as_bytes_automatic_speech_recognition_filters_none_in_extra(self):
-        # `None` values in parameters and extra_payload must be dropped so they don't
-        # serialize as the literal string "None" in multipart form fields.
-        helper = TogetherAutomaticSpeechRecognitionTask()
-        body = helper._prepare_payload_as_bytes(
-            b"raw audio bytes",
-            {"language": None, "temperature": 0.0},
-            InferenceProviderMapping(
-                provider="together",
-                hf_model_id="openai/whisper-large-v3",
-                providerId="openai/whisper-large-v3",
-                task="automatic-speech-recognition",
-                status="live",
-            ),
-            extra_payload={"prompt": None, "response_format": "json"},
-        )
-        assert b"None" not in bytes(body)
-        assert b'name="response_format"' in bytes(body)
-        assert b'name="temperature"' in bytes(body)
-        assert b'name="language"' not in bytes(body)
-        assert b'name="prompt"' not in bytes(body)
-
-    def test_automatic_speech_recognition_get_response(self):
-        helper = TogetherAutomaticSpeechRecognitionTask()
-        response = helper.get_response({"text": "Hello, world!"})
-        assert response == {"text": "Hello, world!"}
-
-    def test_automatic_speech_recognition_get_response_with_segments(self):
-        helper = TogetherAutomaticSpeechRecognitionTask()
-        response = helper.get_response(
-            {
-                "text": "Hello, world!",
-                "segments": [
-                    {"id": 0, "start": 0.0, "end": 1.5, "text": "Hello,"},
-                    {"id": 1, "start": 1.5, "end": 2.7, "text": " world!"},
-                ],
-            }
-        )
-        assert response == {
-            "text": "Hello, world!",
-            "chunks": [
-                {"text": "Hello,", "timestamp": [0.0, 1.5]},
-                {"text": " world!", "timestamp": [1.5, 2.7]},
-            ],
-        }
-
-    def test_automatic_speech_recognition_get_response_missing_text(self):
-        helper = TogetherAutomaticSpeechRecognitionTask()
-        with pytest.raises(ValueError, match="missing 'text' field"):
-            helper.get_response({"segments": []})
 
     def test_prepare_route_text_to_video(self):
         helper = TogetherTextToVideoTask()


### PR DESCRIPTION
Removes `TogetherAutomaticSpeechRecognitionTask` entirely along with all supporting code (`_coerce_multipart`, the ASR route in `_prepare_route`).

ASR task was added in https://github.com/huggingface/huggingface_hub/issues/4164 and released in 1.6.0. The urllib3 import is breaking since it's not a dependency as reported internally [on slack](https://huggingface.slack.com/archives/C02V5EA0A95/p1779387750448949?thread_ts=1779360717.916529&cid=C02V5EA0A95). We will make a patch release for this one now and will add ASR back later with a urllib3-free solution.

This is a hotfix — Together ASR support can be re-added later without the `urllib3` dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes Together automatic-speech-recognition support and its tests, which is a user-visible/breaking capability change for that provider. Otherwise changes are straightforward deletions with low likelihood of introducing new runtime bugs.
> 
> **Overview**
> **Removes Together automatic speech recognition support** from the inference provider layer.
> 
> Deletes `TogetherAutomaticSpeechRecognitionTask` (including multipart payload building and the `/v1/audio/transcriptions` route), removes the task from the Together provider registry, and drops the related imports/tests—eliminating the need for the extra `urllib3` dependency that was only used for multipart encoding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de6d6f39e96e0a50c93690c8dc9ecf017d206c62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->