### PR TITLE
[CI] Add import check with base dependencies only

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -13,6 +13,25 @@ on:
       - "docs/**"
 
 jobs:
+  check-imports:
+    # Catch missing dependencies: install only base requirements and verify all public imports work.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+        with:
+          python-version: "3.14"
+      - name: Install base dependencies only
+        run: |
+          pip install --upgrade uv
+          uv venv
+          uv pip install .
+      - name: Check imports
+        run: |
+          source .venv/bin/activate
+          python -c "from huggingface_hub import *"
+
   build-ubuntu:
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
(related [slack thread](https://huggingface.slack.com/archives/C02V5EA0A95/p1779435131779159?thread_ts=1779360717.916529&cid=C02V5EA0A95))

## Summary

- Adds a `check-imports` job to the CI that installs `huggingface_hub` with **only base dependencies** (no extras) and runs `from huggingface_hub import *`.
- This catches cases where a new import is added in the public API surface that requires a library not listed in `install_requires`, which would result in an `ImportError` for users installing the package without dev extras.

Motivated by https://github.com/huggingface/huggingface_hub/pull/4248 where a transitive dependency (`urllib3`) was imported at the top level, causing an `ImportError` for users after release. The existing CI didn't catch it because test dependencies pull in the missing library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since it only changes CI configuration; potential impact is limited to longer or occasionally flakier CI runs due to the new environment setup step.
> 
> **Overview**
> Adds a new **`check-imports`** GitHub Actions job that creates a fresh venv, installs the project with *base dependencies only* (`uv pip install .`), and runs `from huggingface_hub import *` to catch missing `install_requires` dependencies in the public API surface before release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd7c6bcb52376cce0de178ac943dc8a96d60a791. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->