### PR TITLE
[Jobs] Add update_job_labels and update_scheduled_job_labels

### DIFF
--- a/docs/source/en/guides/jobs.md
+++ b/docs/source/en/guides/jobs.md
@@ -385,7 +385,7 @@ These variables are useful when you need to create unique identifiers for output
 
 ## Labels
 
-Labels are a key=value pairs that applies metadata to a Job:
+Labels are key=value pairs that attach metadata to a Job:
 
 ```python
 # Pass extra metadata with Labels
@@ -395,6 +395,35 @@ Labels are a key=value pairs that applies metadata to a Job:
 ...     command=["python", "-c", "import os; print(os.environ['MY_SECRET'])"],
 ...     labels={"my-label": "my-value", "foo": "bar"},
 ... )
+```
+
+### Update labels
+
+Use [`update_job_labels`] to replace labels on an existing job. This replaces all existing user-provided labels:
+
+```python
+>>> from huggingface_hub import update_job_labels
+>>> update_job_labels(job_id, labels={"env": "prod", "team": "ml"})
+```
+
+This also works for scheduled jobs with [`update_scheduled_job_labels`]:
+
+```python
+>>> from huggingface_hub import update_scheduled_job_labels
+>>> update_scheduled_job_labels(scheduled_job_id, labels={"env": "staging"})
+```
+
+From the CLI:
+
+```bash
+>>> hf jobs labels <job_id> --label env=prod --label team=ml
+>>> hf jobs scheduled labels <scheduled_job_id> --label env=staging
+```
+
+To remove all labels, pass `--clear`:
+
+```bash
+>>> hf jobs labels <job_id> --clear
 ```
 
 ## UV Scripts (Experimental)

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -2067,6 +2067,7 @@ $ hf jobs [OPTIONS] COMMAND [ARGS]...
 * `cancel`: Cancel a Job
 * `hardware`: List available hardware options for Jobs
 * `inspect`: Display detailed information on one or...
+* `labels`: Update labels on a Job.
 * `logs`: Fetch the logs of a Job.
 * `ps`: List Jobs.
 * `run`: Run a Job.
@@ -2146,6 +2147,37 @@ $ hf jobs inspect [OPTIONS] JOB_IDS...
 
 Examples
   $ hf jobs inspect <job_id>
+
+Learn more
+  Use `hf <command> --help` for more information about a command.
+  Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
+
+
+### `hf jobs labels`
+
+Update labels on a Job. Replaces all existing labels.
+
+**Usage**:
+
+```console
+$ hf jobs labels [OPTIONS] JOB_ID
+```
+
+**Arguments**:
+
+* `JOB_ID`: Job ID (or 'namespace/job_id')  [required]
+
+**Options**:
+
+* `-l, --label TEXT`: Set labels. E.g. --label KEY=VALUE or --label LABEL
+* `--clear`: Remove all labels from the job.
+* `--namespace TEXT`: The namespace where the job will be running. Defaults to the current user's namespace.
+* `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
+* `--help`: Show this message and exit.
+
+Examples
+  $ hf jobs labels <job_id> --label env=prod --label team=ml
+  $ hf jobs labels <job_id> --clear
 
 Learn more
   Use `hf <command> --help` for more information about a command.
@@ -2277,6 +2309,7 @@ $ hf jobs scheduled [OPTIONS] COMMAND [ARGS]...
 
 * `delete`: Delete a scheduled Job.
 * `inspect`: Display detailed information on one or...
+* `labels`: Update labels on a scheduled Job.
 * `ps`: List scheduled Jobs
 * `resume`: Resume (unpause) a scheduled Job.
 * `run`: Schedule a Job.
@@ -2333,6 +2366,37 @@ $ hf jobs scheduled inspect [OPTIONS] SCHEDULED_JOB_IDS...
 
 Examples
   $ hf jobs scheduled inspect <id>
+
+Learn more
+  Use `hf <command> --help` for more information about a command.
+  Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
+
+
+#### `hf jobs scheduled labels`
+
+Update labels on a scheduled Job. Replaces all existing labels.
+
+**Usage**:
+
+```console
+$ hf jobs scheduled labels [OPTIONS] SCHEDULED_JOB_ID
+```
+
+**Arguments**:
+
+* `SCHEDULED_JOB_ID`: Scheduled Job ID (or 'namespace/scheduled_job_id')  [required]
+
+**Options**:
+
+* `-l, --label TEXT`: Set labels. E.g. --label KEY=VALUE or --label LABEL
+* `--clear`: Remove all labels from the scheduled job.
+* `--namespace TEXT`: The namespace where the job will be running. Defaults to the current user's namespace.
+* `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
+* `--help`: Show this message and exit.
+
+Examples
+  $ hf jobs scheduled labels <id> --label env=prod --label team=ml
+  $ hf jobs scheduled labels <id> --clear
 
 Learn more
   Use `hf <command> --help` for more information about a command.

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -340,7 +340,9 @@ _SUBMOD_ATTRS = {
         "update_collection_item",
         "update_collection_metadata",
         "update_inference_endpoint",
+        "update_job_labels",
         "update_repo_settings",
+        "update_scheduled_job_labels",
         "update_webhook",
         "upload_file",
         "upload_folder",
@@ -1096,7 +1098,9 @@ __all__ = [
     "update_collection_item",
     "update_collection_metadata",
     "update_inference_endpoint",
+    "update_job_labels",
     "update_repo_settings",
+    "update_scheduled_job_labels",
     "update_webhook",
     "upload_file",
     "upload_folder",
@@ -1490,7 +1494,9 @@ if TYPE_CHECKING:  # pragma: no cover
         update_collection_item,  # noqa: F401
         update_collection_metadata,  # noqa: F401
         update_inference_endpoint,  # noqa: F401
+        update_job_labels,  # noqa: F401
         update_repo_settings,  # noqa: F401
+        update_scheduled_job_labels,  # noqa: F401
         update_webhook,  # noqa: F401
         upload_file,  # noqa: F401
         upload_folder,  # noqa: F401

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -741,6 +741,34 @@ def jobs_cancel(
             raise CLIError(f"Failed to cancel job: {e}") from e
 
 
+@jobs_cli.command(
+    "labels",
+    examples=[
+        "hf jobs labels <job_id> --label env=prod --label team=ml",
+        "hf jobs labels <job_id> --clear",
+    ],
+)
+def jobs_labels(
+    job_id: JobIdArg,
+    label: LabelsOpt = None,
+    clear: Annotated[bool, typer.Option("--clear", help="Remove all labels from the job.")] = False,
+    namespace: NamespaceOpt = None,
+    token: TokenOpt = None,
+) -> None:
+    """Update labels on a Job. Replaces all existing labels."""
+    if not label and not clear:
+        raise CLIError("Please set at least one label with --label. To remove all labels, pass --clear.")
+    if label and clear:
+        raise CLIError(
+            "Cannot set labels and clear them at the same time. Please use either --label or --clear, not both."
+        )
+    job_id, namespace = _parse_namespace_from_job_id(job_id, namespace)
+    labels = _parse_labels_map(label) or {}
+    api = get_hf_api(token=token)
+    job = api.update_job_labels(job_id=job_id, labels=labels, namespace=namespace)
+    print(json.dumps(asdict(job), indent=4, default=str))
+
+
 uv_app = typer_factory(help="Run UV scripts (Python with inline dependencies) on HF infrastructure.")
 jobs_cli.add_typer(uv_app, name="uv")
 
@@ -1015,6 +1043,36 @@ def scheduled_resume(
     scheduled_job_id, namespace = _parse_namespace_from_job_id(scheduled_job_id, namespace)
     api = get_hf_api(token=token)
     api.resume_scheduled_job(scheduled_job_id=scheduled_job_id, namespace=namespace)
+
+
+@scheduled_app.command(
+    "labels",
+    examples=[
+        "hf jobs scheduled labels <id> --label env=prod --label team=ml",
+        "hf jobs scheduled labels <id> --clear",
+    ],
+)
+def scheduled_labels(
+    scheduled_job_id: ScheduledJobIdArg,
+    label: LabelsOpt = None,
+    clear: Annotated[bool, typer.Option("--clear", help="Remove all labels from the scheduled job.")] = False,
+    namespace: NamespaceOpt = None,
+    token: TokenOpt = None,
+) -> None:
+    """Update labels on a scheduled Job. Replaces all existing labels."""
+    if not label and not clear:
+        raise CLIError("Please set at least one label with --label. To remove all labels, pass --clear.")
+    if label and clear:
+        raise CLIError(
+            "Cannot set labels and clear them at the same time. Please use either --label or --clear, not both."
+        )
+    scheduled_job_id, namespace = _parse_namespace_from_job_id(scheduled_job_id, namespace)
+    labels = _parse_labels_map(label) or {}
+    api = get_hf_api(token=token)
+    scheduled_job = api.update_scheduled_job_labels(
+        scheduled_job_id=scheduled_job_id, labels=labels, namespace=namespace
+    )
+    print(json.dumps(asdict(scheduled_job), indent=4, default=str))
 
 
 scheduled_uv_app = typer_factory(help="Schedule UV scripts on HF infrastructure.")

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -11855,7 +11855,7 @@ class HfApi:
             json={"labels": labels},
         )
         hf_raise_for_status(response)
-        return JobInfo(**response.json())
+        return JobInfo(**response.json(), endpoint=self.endpoint)
 
     @experimental
     def run_uv_job(

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -11814,6 +11814,49 @@ class HfApi:
             headers=self._build_hf_headers(token=token),
         ).raise_for_status()
 
+    def update_job_labels(
+        self,
+        *,
+        job_id: str,
+        labels: dict[str, str],
+        namespace: str | None = None,
+        token: bool | str | None = None,
+    ) -> JobInfo:
+        """
+        Update labels of an existing Job.
+
+        Replaces all existing user-provided labels with the new labels.
+
+        Args:
+            job_id (`str`):
+                ID of the Job.
+
+            labels (`dict[str, str]`):
+                New labels to set on the job. Replaces all existing labels.
+                Both keys and values must be max 100 characters and contain only
+                alphanumeric characters, dots, dashes, and underscores.
+
+            namespace (`str`, *optional*):
+                The namespace where the Job is running. Defaults to the current user's namespace.
+
+            token `(Union[bool, str, None]`, *optional*):
+                A valid user access token. If not provided, the locally saved token will be used, which is the
+                recommended authentication method. Set to `False` to disable authentication.
+                Refer to: https://huggingface.co/docs/huggingface_hub/quick-start#authentication.
+
+        Returns:
+            [`JobInfo`]: The updated Job info.
+        """
+        if namespace is None:
+            namespace = self.whoami(token=token)["name"]
+        response = get_session().put(
+            f"{self.endpoint}/api/jobs/{namespace}/{job_id}/labels",
+            headers=self._build_hf_headers(token=token),
+            json={"labels": labels},
+        )
+        hf_raise_for_status(response)
+        return JobInfo(**response.json())
+
     @experimental
     def run_uv_job(
         self,
@@ -12235,6 +12278,49 @@ class HfApi:
             f"{self.endpoint}/api/scheduled-jobs/{namespace}/{scheduled_job_id}/resume",
             headers=self._build_hf_headers(token=token),
         ).raise_for_status()
+
+    def update_scheduled_job_labels(
+        self,
+        *,
+        scheduled_job_id: str,
+        labels: dict[str, str],
+        namespace: str | None = None,
+        token: bool | str | None = None,
+    ) -> ScheduledJobInfo:
+        """
+        Update labels of an existing scheduled Job.
+
+        Replaces all existing user-provided labels with the new labels.
+
+        Args:
+            scheduled_job_id (`str`):
+                ID of the scheduled Job.
+
+            labels (`dict[str, str]`):
+                New labels to set on the scheduled job. Replaces all existing labels.
+                Both keys and values must be max 100 characters and contain only
+                alphanumeric characters, dots, dashes, and underscores.
+
+            namespace (`str`, *optional*):
+                The namespace where the scheduled Job is. Defaults to the current user's namespace.
+
+            token `(Union[bool, str, None]`, *optional*):
+                A valid user access token. If not provided, the locally saved token will be used, which is the
+                recommended authentication method. Set to `False` to disable authentication.
+                Refer to: https://huggingface.co/docs/huggingface_hub/quick-start#authentication.
+
+        Returns:
+            [`ScheduledJobInfo`]: The updated scheduled Job info.
+        """
+        if namespace is None:
+            namespace = self.whoami(token=token)["name"]
+        response = get_session().put(
+            f"{self.endpoint}/api/scheduled-jobs/{namespace}/{scheduled_job_id}/labels",
+            headers=self._build_hf_headers(token=token),
+            json={"labels": labels},
+        )
+        hf_raise_for_status(response)
+        return ScheduledJobInfo(**response.json())
 
     @experimental
     def create_scheduled_uv_job(
@@ -14079,6 +14165,7 @@ list_jobs = api.list_jobs
 list_jobs_hardware = api.list_jobs_hardware
 inspect_job = api.inspect_job
 cancel_job = api.cancel_job
+update_job_labels = api.update_job_labels
 run_uv_job = api.run_uv_job
 create_scheduled_job = api.create_scheduled_job
 list_scheduled_jobs = api.list_scheduled_jobs
@@ -14086,6 +14173,7 @@ inspect_scheduled_job = api.inspect_scheduled_job
 delete_scheduled_job = api.delete_scheduled_job
 suspend_scheduled_job = api.suspend_scheduled_job
 resume_scheduled_job = api.resume_scheduled_job
+update_scheduled_job_labels = api.update_scheduled_job_labels
 create_scheduled_uv_job = api.create_scheduled_uv_job
 
 # Buckets API

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,7 +12,7 @@ import typer
 from typer.testing import CliRunner
 
 from huggingface_hub._dataset_viewer import DatasetParquetEntry
-from huggingface_hub._jobs_api import _create_job_spec
+from huggingface_hub._jobs_api import JobInfo, _create_job_spec
 from huggingface_hub._space_api import Volume
 from huggingface_hub.cli._cli_utils import RepoType, parse_volumes
 from huggingface_hub.cli._output import OutputFormatWithAuto, out
@@ -3359,6 +3359,38 @@ class TestBucketTransport:
         # Volume is scoped to the shared subfolder via Volume.path
         assert len(extra_volumes) == 1
         assert extra_volumes[0].path == upload_prefixes.pop()
+
+    def test_update_job_labels(self, runner: CliRunner) -> None:
+        with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            api.update_job_labels.return_value = JobInfo(
+                id="my-job-id",
+                status={"stage": "RUNNING"},
+                owner={"id": "1", "name": "user", "type": "user"},
+                labels={"env": "prod", "team": "ml"},
+            )
+            result = runner.invoke(app, ["jobs", "labels", "my-job-id", "--label", "env=prod", "--label", "team=ml"])
+        assert result.exit_code == 0
+        api.update_job_labels.assert_called_once_with(
+            job_id="my-job-id", labels={"env": "prod", "team": "ml"}, namespace=None
+        )
+
+    def test_update_job_labels_clear(self, runner: CliRunner) -> None:
+        with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            api.update_job_labels.return_value = JobInfo(
+                id="my-job-id",
+                status={"stage": "RUNNING"},
+                owner={"id": "1", "name": "user", "type": "user"},
+                labels={},
+            )
+            result = runner.invoke(app, ["jobs", "labels", "my-job-id", "--clear"])
+        assert result.exit_code == 0
+        api.update_job_labels.assert_called_once_with(job_id="my-job-id", labels={}, namespace=None)
+
+    def test_update_job_labels_no_args_error(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["jobs", "labels", "my-job-id"])
+        assert result.exit_code == 1  # at least one label or clear
 
 
 class TestParseNamespaceFromJobId:


### PR DESCRIPTION
## Summary

Client-side support for label update endpoints added in https://github.com/huggingface-internal/moon-landing/pull/17932.

- Add `HfApi.update_job_labels()` and `HfApi.update_scheduled_job_labels()` (`PUT /api/jobs/:ns/:id/labels` and `PUT /api/scheduled-jobs/:ns/:id/labels`)
- Add CLI commands `hf jobs labels` and `hf jobs scheduled labels` with `--clear` flag to prevent accidental label deletion
- Docs + tests

```
>>> hf jobs labels <job_id> --label env=prod --label team=ml
>>> hf jobs labels <job_id> --clear
>>> hf jobs scheduled labels <id> --label env=staging
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new Jobs/Scheduled Jobs label update endpoints and CLI wiring without changing existing job execution logic; main risk is accidental label replacement/clearing, mitigated by explicit `--clear` and argument validation.
> 
> **Overview**
> Adds client support to **replace (or clear) user labels** on existing Jobs and Scheduled Jobs via new `HfApi.update_job_labels` and `HfApi.update_scheduled_job_labels` (PUT to `/labels` endpoints), and exports them at the package top-level.
> 
> Extends the CLI with `hf jobs labels` and `hf jobs scheduled labels`, including validation to require `--label` or `--clear` (but not both), and updates docs/CLI reference plus tests covering the new command behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2ef6ef04b3fba395202d040509a0792162dd0ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->