### PR TITLE
[CLI] Fix parent aliases leaking into subcommand headers in CLI reference

### DIFF
--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -1919,7 +1919,7 @@ $ hf extensions [OPTIONS] COMMAND [ARGS]...
 * `remove`: Remove an installed extension. [alias: rm]
 * `search`: Search extensions available on GitHub...
 
-### `hf extensions | ext exec`
+### `hf extensions exec`
 
 Execute an installed extension.
 
@@ -1946,7 +1946,7 @@ Learn more
   Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
 
 
-### `hf extensions | ext install`
+### `hf extensions install`
 
 Install an extension from a public GitHub repository.
 
@@ -1978,7 +1978,7 @@ Learn more
   Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
 
 
-### `hf extensions | ext list`
+### `hf extensions list`
 
 List installed extension commands. [alias: ls]
 
@@ -2000,7 +2000,7 @@ Learn more
   Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
 
 
-### `hf extensions | ext remove`
+### `hf extensions remove`
 
 Remove an installed extension. [alias: rm]
 
@@ -2026,7 +2026,7 @@ Learn more
   Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
 
 
-### `hf extensions | ext search`
+### `hf extensions search`
 
 Search extensions available on GitHub (tagged with 'hf-extension' topic).
 
@@ -2945,7 +2945,7 @@ $ hf repos [OPTIONS] COMMAND [ARGS]...
 * `settings`: Update the settings of a repository.
 * `tag`: Manage tags for a repo on the Hub.
 
-### `hf repos | repo branch`
+### `hf repos branch`
 
 Manage branches for a repo on the Hub.
 
@@ -2964,7 +2964,7 @@ $ hf repos branch [OPTIONS] COMMAND [ARGS]...
 * `create`: Create a new branch for a repo on the Hub.
 * `delete`: Delete a branch from a repo on the Hub.
 
-#### `hf repos | repo branch create`
+#### `hf repos branch create`
 
 Create a new branch for a repo on the Hub.
 
@@ -2996,7 +2996,7 @@ Learn more
   Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
 
 
-#### `hf repos | repo branch delete`
+#### `hf repos branch delete`
 
 Delete a branch from a repo on the Hub.
 
@@ -3025,7 +3025,7 @@ Learn more
   Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
 
 
-### `hf repos | repo create`
+### `hf repos create`
 
 Create a new repo on the Hub.
 
@@ -3072,7 +3072,7 @@ Learn more
   Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
 
 
-### `hf repos | repo delete`
+### `hf repos delete`
 
 Delete a repo from the Hub. This is an irreversible operation.
 
@@ -3102,7 +3102,7 @@ Learn more
   Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
 
 
-### `hf repos | repo delete-files`
+### `hf repos delete-files`
 
 Delete files from a repo on the Hub.
 
@@ -3137,7 +3137,7 @@ Learn more
   Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
 
 
-### `hf repos | repo duplicate`
+### `hf repos duplicate`
 
 Duplicate a repo on the Hub (model, dataset, or Space).
 
@@ -3180,7 +3180,7 @@ Learn more
   Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
 
 
-### `hf repos | repo move`
+### `hf repos move`
 
 Move a repository from a namespace to another namespace.
 
@@ -3209,7 +3209,7 @@ Learn more
   Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
 
 
-### `hf repos | repo settings`
+### `hf repos settings`
 
 Update the settings of a repository.
 
@@ -3243,7 +3243,7 @@ Learn more
   Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
 
 
-### `hf repos | repo tag`
+### `hf repos tag`
 
 Manage tags for a repo on the Hub.
 
@@ -3263,7 +3263,7 @@ $ hf repos tag [OPTIONS] COMMAND [ARGS]...
 * `delete`: Delete a tag for a repo.
 * `list`: List tags for a repo. [alias: ls]
 
-#### `hf repos | repo tag create`
+#### `hf repos tag create`
 
 Create a tag for a repo.
 
@@ -3295,7 +3295,7 @@ Learn more
   Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
 
 
-#### `hf repos | repo tag delete`
+#### `hf repos tag delete`
 
 Delete a tag for a repo.
 
@@ -3325,7 +3325,7 @@ Learn more
   Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
 
 
-#### `hf repos | repo tag list`
+#### `hf repos tag list`
 
 List tags for a repo. [alias: ls]
 

--- a/tests/test_generate_cli_reference.py
+++ b/tests/test_generate_cli_reference.py
@@ -16,7 +16,7 @@ $ hf repos | repo tag list | ls [OPTIONS] REPO_ID
 
     normalized = _normalize_command_aliases(content)
 
-    assert "#### `hf repos | repo tag list`" in normalized
+    assert "#### `hf repos tag list`" in normalized
     assert "List tags for a repo. [alias: ls]" in normalized
     assert "$ hf repos tag list [OPTIONS] REPO_ID" in normalized
     assert "$ hf repos | repo tag list [OPTIONS] REPO_ID" not in normalized

--- a/utils/generate_cli_reference.py
+++ b/utils/generate_cli_reference.py
@@ -83,29 +83,46 @@ def _normalize_command_aliases(content: str) -> str:
         flags=re.MULTILINE,
     )
 
-    # Transform section headers: `## `hf cmd | alias`` or `### `hf parent cmd | alias``
-    # and add alias info to the description on the next non-empty line.
-    # Match the *last* aliased segment so parent aliases (e.g. `repos | repo`) are preserved.
+    # Transform section headers: `## `hf repos | repo branch create`` → `## `hf repos branch create``
+    # Strip aliases from *all* segments in the command path, and append alias info for the
+    # *leaf* command only (the last segment that has aliases) to the description line.
     def _transform_section(match: re.Match) -> str:
-        hashes = match.group(1)  # "##" or "###"
-        prefix = match.group(2)  # "hf" or "hf parent"
-        full_name = match.group(3)  # "cmd | alias"
-        whitespace = match.group(4)  # newlines between header and description
-        description = match.group(5)  # first line of description
+        hashes = match.group(1)  # "##", "###", ...
+        command_path = match.group(2)  # "hf repos | repo branch create"
+        whitespace = match.group(3)  # newlines between header and description
+        description = match.group(4)  # first line of description
 
-        parts = [p.strip() for p in full_name.split("|")]
-        primary = parts[0]
-        aliases = parts[1:]
+        # Split path into segments, strip aliases from each.
+        # Only annotate the description when the *leaf* (last) segment has aliases.
+        segments = re.split(r"\s+", command_path)
+        primary_segments: list[str] = []
+        last_aliases: list[str] = []
+        i = 0
+        while i < len(segments):
+            seg = segments[i]
+            if i + 1 < len(segments) and segments[i + 1] == "|":
+                aliases = []
+                j = i + 1
+                while j < len(segments) and segments[j] == "|":
+                    aliases.append(segments[j + 1])
+                    j += 2
+                primary_segments.append(seg)
+                last_aliases = aliases
+                i = j
+            else:
+                primary_segments.append(seg)
+                last_aliases = []  # reset — a plain segment followed, so leaf has no alias
+                i += 1
 
-        new_header = f"{hashes} `{prefix} {primary}`"
-        if aliases:
-            new_description = f"{description} {_format_aliases(aliases)}"
+        new_header = f"{hashes} `{' '.join(primary_segments)}`"
+        if last_aliases:
+            new_description = f"{description} {_format_aliases(last_aliases)}"
         else:
             new_description = description
         return f"{new_header}{whitespace}{new_description}"
 
     content = re.sub(
-        r"^(#{2,}) `(hf(?: [\w-]+(?: \| [\w-]+)?)*) ([\w-]+(?: \| [\w-]+)+)`(\n+)([^\n#*]+)",
+        r"^(#{2,}) `(hf(?: [\w-]+(?: \| [\w-]+)?)+(?: [\w-]+)*)`(\n+)([^\n#*]+)",
         _transform_section,
         content,
         flags=re.MULTILINE,


### PR DESCRIPTION
Fixes titles [in current docs](https://huggingface.co/docs/huggingface_hub/v1.16.0/en/package_reference/cli):

<img width="468" height="378" alt="image" src="https://github.com/user-attachments/assets/3015ea39-41ea-4136-8374-ccb4a44d445b" />



- Parent group aliases (e.g. `repos | repo`, `extensions | ext`) were leaking into subcommand section headers in the generated CLI reference. For instance `#### hf repos | repo branch create` instead of `#### hf repos branch create`.
- Fixed `_transform_section` in `generate_cli_reference.py` to strip aliases from all path segments, and only annotate the description when the leaf command itself has aliases (e.g. `list | ls`).

Before: `### hf repos | repo branch create`, `### hf extensions | ext install`
After: `### hf repos branch create`, `### hf extensions install`



🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-generation change: adjusts regex parsing for CLI reference headers and updates the generated `cli.md` plus a unit test, with no runtime CLI behavior impact.
> 
> **Overview**
> Fixes CLI reference generation so *parent* group aliases (e.g. `repos | repo`, `extensions | ext`) no longer leak into subcommand section headers.
> 
> Updates `_normalize_command_aliases` in `utils/generate_cli_reference.py` to strip aliases from every command-path segment and only append alias info for the leaf command, then regenerates `docs/source/en/package_reference/cli.md` accordingly and updates the related test expectation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f5f46ac16f9d7535915061c9f326e872bd8366e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->