### PR TITLE
 [CLI] migrate `hf jobs` to `out` singleton

### DIFF
--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -2205,7 +2205,6 @@ $ hf jobs ps [OPTIONS]
 * `--namespace TEXT`: The namespace where the job will be running. Defaults to the current user's namespace.
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `-f, --filter TEXT`: Filter output based on conditions provided (format: key=value)
-* `--format TEXT`: Output format: auto|human|agent|json|quiet, or a Go-template string (e.g. '{{.id}}').  [default: auto]
 * `--help`: Show this message and exit.
 
 Examples
@@ -2354,7 +2353,6 @@ $ hf jobs scheduled ps [OPTIONS]
 * `--namespace TEXT`: The namespace where the job will be running. Defaults to the current user's namespace.
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `-f, --filter TEXT`: Filter output based on conditions provided (format: key=value)
-* `--format TEXT`: Output format: auto|human|agent|json|quiet, or a Go-template string (e.g. '{{.id}}').  [default: auto]
 * `--help`: Show this message and exit.
 
 Examples

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -2205,8 +2205,7 @@ $ hf jobs ps [OPTIONS]
 * `--namespace TEXT`: The namespace where the job will be running. Defaults to the current user's namespace.
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `-f, --filter TEXT`: Filter output based on conditions provided (format: key=value)
-* `--format TEXT`: Output format: 'table' (default), 'json', or a Go template (e.g. '{{.id}}')
-* `-q, --quiet`: Print only IDs (one per line).
+* `--format TEXT`: Output format: auto|human|agent|json|quiet, or a Go-template string (e.g. '{{.id}}').  [default: auto]
 * `--help`: Show this message and exit.
 
 Examples
@@ -2355,8 +2354,7 @@ $ hf jobs scheduled ps [OPTIONS]
 * `--namespace TEXT`: The namespace where the job will be running. Defaults to the current user's namespace.
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `-f, --filter TEXT`: Filter output based on conditions provided (format: key=value)
-* `--format TEXT`: Output format: 'table' (default), 'json', or a Go template (e.g. '{{.id}}')
-* `-q, --quiet`: Print only IDs (one per line).
+* `--format TEXT`: Output format: auto|human|agent|json|quiet, or a Go-template string (e.g. '{{.id}}').  [default: auto]
 * `--help`: Show this message and exit.
 
 Examples

--- a/src/huggingface_hub/cli/_output.py
+++ b/src/huggingface_hub/cli/_output.py
@@ -53,8 +53,13 @@ class Output:
         self.no_truncate = False
         self.set_mode()
 
-    def set_mode(self, mode: OutputFormatWithAuto = OutputFormatWithAuto.auto) -> None:
-        """Override the output mode (called once at startup and again per '--format' flag)."""
+    def set_mode(self, mode: OutputFormatWithAuto | str = OutputFormatWithAuto.auto) -> None:
+        """Override the output mode (called once at startup and again per '--format' flag).
+
+        Accepts the ``OutputFormatWithAuto`` enum or its string name (e.g. ``'agent'``, ``'json'``).
+        """
+        if isinstance(mode, str):
+            mode = OutputFormatWithAuto(mode)
         if mode == OutputFormatWithAuto.auto:
             mode = OutputFormatWithAuto.agent if is_agent() else OutputFormatWithAuto.human
         self.mode = mode

--- a/src/huggingface_hub/cli/_output.py
+++ b/src/huggingface_hub/cli/_output.py
@@ -53,13 +53,8 @@ class Output:
         self.no_truncate = False
         self.set_mode()
 
-    def set_mode(self, mode: OutputFormatWithAuto | str = OutputFormatWithAuto.auto) -> None:
-        """Override the output mode (called once at startup and again per '--format' flag).
-
-        Accepts the ``OutputFormatWithAuto`` enum or its string name (e.g. ``'agent'``, ``'json'``).
-        """
-        if isinstance(mode, str):
-            mode = OutputFormatWithAuto(mode)
+    def set_mode(self, mode: OutputFormatWithAuto = OutputFormatWithAuto.auto) -> None:
+        """Override the output mode (called once at startup and again per '--format' flag)."""
         if mode == OutputFormatWithAuto.auto:
             mode = OutputFormatWithAuto.agent if is_agent() else OutputFormatWithAuto.human
         self.mode = mode

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -613,13 +613,14 @@ def jobs_ps(
         filtered_jobs.append(job)
 
     # Build display items. Augment the raw api dict with curated, table-friendly columns
-    # (image, command, created, status, runtime) — these double as Go-template fields.
+    # — these double as Go-template fields and as table headers (via SCREAMING_SNAKE).
     items: list[dict[str, Any]] = []
     for job in filtered_jobs:
         item = api_object_to_dict(job)
         durations = item.get("durations") or {}
         cmd = item.get("command") or []
-        item["image"] = item.get("docker_image") or "N/A"
+        item["job_id"] = item.get("id", "")
+        item["image/space"] = item.get("docker_image") or "N/A"
         item["command"] = " ".join(cmd) if cmd else "N/A"
         item["created"] = item["created_at"][:19].replace("T", " ") if item.get("created_at") else "N/A"
         item["status"] = (item.get("status") or {}).get("stage", "UNKNOWN")
@@ -630,7 +631,11 @@ def jobs_ps(
         _render_template(format, items)
         return
 
-    out.table(items, headers=["id", "image", "command", "created", "status", "runtime"], id_key="id")
+    out.table(
+        items,
+        headers=["job_id", "image/space", "command", "created", "status", "runtime"],
+        id_key="job_id",
+    )
     if not items and filters:
         filters_msg = ", ".join(f"{k}{o}{v}" for k, o, v in filters)
         out.hint(f"No jobs matched filters: {filters_msg}")
@@ -877,8 +882,8 @@ def scheduled_ps(
             continue
         filtered_jobs.append(scheduled_job)
 
-    # Build display items. Augment with curated columns (image, command, last, next) that also
-    # serve as Go-template fields.
+    # Build display items. Augment with curated columns that also serve as Go-template fields
+    # and as table headers (via SCREAMING_SNAKE).
     items: list[dict[str, Any]] = []
     for sj in filtered_jobs:
         item = api_object_to_dict(sj)
@@ -886,10 +891,10 @@ def scheduled_ps(
         status_dict = item.get("status") or {}
         last_job = status_dict.get("last_job")
         cmd = job_spec.get("command") or []
-        item["image"] = job_spec.get("docker_image") or "N/A"
+        item["image/space"] = job_spec.get("docker_image") or "N/A"
         item["command"] = " ".join(cmd) if cmd else "N/A"
-        item["last"] = last_job["at"][:19].replace("T", " ") if last_job and last_job.get("at") else "N/A"
-        item["next"] = (
+        item["last_run"] = last_job["at"][:19].replace("T", " ") if last_job and last_job.get("at") else "N/A"
+        item["next_run"] = (
             status_dict["next_job_run_at"][:19].replace("T", " ") if status_dict.get("next_job_run_at") else "N/A"
         )
         item["suspend"] = item.get("suspend") or False
@@ -901,7 +906,7 @@ def scheduled_ps(
 
     out.table(
         items,
-        headers=["id", "schedule", "image", "command", "last", "next", "suspend"],
+        headers=["id", "schedule", "image/space", "command", "last_run", "next_run", "suspend"],
         id_key="id",
     )
     if not items and filters:

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -1034,7 +1034,7 @@ def scheduled_labels(
     scheduled_job = api.update_scheduled_job_labels(
         scheduled_job_id=scheduled_job_id, labels=labels, namespace=namespace
     )
-    out.result("Labels updated", id=job.id)
+    out.result("Labels updated", id=scheduled_job.id)
 
 
 scheduled_uv_app = typer_factory(help="Schedule UV scripts on HF infrastructure.")

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -18,7 +18,7 @@ Usage:
     hf jobs run <image> <command>
 
     # List running or completed jobs
-    hf jobs ps [-a] [-f key=value] [--format table|json|TEMPLATE] [-q]
+    hf jobs ps [-a] [-f key=value]
 
     # Print logs from a job (non-blocking)
     hf jobs logs <job-id>
@@ -45,7 +45,7 @@ Usage:
     hf jobs scheduled run <schedule> <image> <command>
 
     # List scheduled jobs
-    hf jobs scheduled ps [-a] [-f key=value] [--format table|json] [-q]
+    hf jobs scheduled ps [-a] [-f key=value]
 
     # Inspect a scheduled job
     hf jobs scheduled inspect <scheduled_job_id>
@@ -383,49 +383,6 @@ def _matches_filters(job_properties: dict[str, str], filters: list[tuple[str, st
     return True
 
 
-def _is_template(value: str) -> bool:
-    """A --format value is a Go template iff it contains the ``{{`` placeholder syntax."""
-    return "{{" in value
-
-
-def _render_template(template: str, items: list[dict[str, Any]]) -> None:
-    """Render each item through a Go-style template (e.g. ``'{{.id}} {{.status}}'``) and print it."""
-    for item in items:
-        line = template
-        for key, value in item.items():
-            placeholder = f"{{{{.{key}}}}}"
-            if placeholder in line:
-                line = line.replace(placeholder, "" if value is None else str(value))
-        print(line)
-
-
-def _set_jobs_format(value: str) -> str:
-    """Callback for ``FormatWithTemplateOpt``: set ``out`` mode from a ``--format`` value.
-
-    Accepts standard output modes (``auto|human|agent|json|quiet``) or a Go-template string like
-    ``'{{.id}}'``. Templates render via ``print()`` and bypass ``out``, so the mode is left untouched.
-    """
-    if _is_template(value):
-        return value
-    try:
-        out.set_mode(value)
-    except ValueError as e:
-        raise typer.BadParameter(
-            f"Invalid --format value: '{value}'. Use auto|human|agent|json|quiet, or a Go template."
-        ) from e
-    return value
-
-
-FormatWithTemplateOpt = Annotated[
-    str,
-    typer.Option(
-        "--format",
-        help="Output format: auto|human|agent|json|quiet, or a Go-template string (e.g. '{{.id}}').",
-        callback=_set_jobs_format,
-    ),
-]
-
-
 def _clear_line(n: int) -> None:
     LINE_UP = "\033[1A"
     LINE_CLEAR = "\x1b[2K"
@@ -557,7 +514,6 @@ def jobs_ps(
             help="Filter output based on conditions provided (format: key=value)",
         ),
     ] = None,
-    format: FormatWithTemplateOpt = "auto",
 ) -> None:
     """List Jobs."""
     api = get_hf_api(token=token)
@@ -579,6 +535,7 @@ def jobs_ps(
                     label_key, label_value = label_part.split("=", 1)
                 else:
                     label_key, label_value = label_part, "*"
+                # Negate predicate in case of key!=value
                 if label_key.endswith("!"):
                     op = "!="
                     label_key = label_key[:-1]
@@ -587,6 +544,7 @@ def jobs_ps(
             labels_filters.append((label_key.lower(), op, label_value.lower()))
         elif "=" in f:
             key, value = f.split("=", 1)
+            # Negate predicate in case of key!=value
             if key.endswith("!"):
                 op = "!="
                 key = key[:-1]
@@ -612,8 +570,7 @@ def jobs_ps(
             continue
         filtered_jobs.append(job)
 
-    # Build display items. Augment the raw api dict with curated, table-friendly columns
-    # — these double as Go-template fields and as table headers (via SCREAMING_SNAKE).
+    # Build display items. Augment the raw api dict with curated, table-friendly columns.
     items: list[dict[str, Any]] = []
     for job in filtered_jobs:
         item = api_object_to_dict(job)
@@ -626,10 +583,6 @@ def jobs_ps(
         item["status"] = (item.get("status") or {}).get("stage", "UNKNOWN")
         item["runtime"] = format_duration(durations.get("running_secs"))
         items.append(item)
-
-    if _is_template(format):
-        _render_template(format, items)
-        return
 
     out.table(
         items,
@@ -850,7 +803,6 @@ def scheduled_ps(
             help="Filter output based on conditions provided (format: key=value)",
         ),
     ] = None,
-    format: FormatWithTemplateOpt = "auto",
 ) -> None:
     """List scheduled Jobs"""
     api = get_hf_api(token=token)
@@ -859,6 +811,7 @@ def scheduled_ps(
     for f in filter or []:
         if "=" in f:
             key, value = f.split("=", 1)
+            # Negate predicate in case of key!=value
             if key.endswith("!"):
                 op = "!="
                 key = key[:-1]
@@ -882,8 +835,7 @@ def scheduled_ps(
             continue
         filtered_jobs.append(scheduled_job)
 
-    # Build display items. Augment with curated columns that also serve as Go-template fields
-    # and as table headers (via SCREAMING_SNAKE).
+    # Build display items. Augment with curated columns.
     items: list[dict[str, Any]] = []
     for sj in filtered_jobs:
         item = api_object_to_dict(sj)
@@ -899,10 +851,6 @@ def scheduled_ps(
         )
         item["suspend"] = item.get("suspend") or False
         items.append(item)
-
-    if _is_template(format):
-        _render_template(format, items)
-        return
 
     out.table(
         items,

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -61,13 +61,11 @@ Usage:
 
 """
 
-import json
 import multiprocessing
 import multiprocessing.pool
 import shutil
 import time
 from collections.abc import Callable, Iterable
-from dataclasses import asdict
 from fnmatch import fnmatch
 from queue import Empty, Queue
 from typing import Annotated, Any, TypeVar
@@ -97,6 +95,7 @@ from ._cli_utils import (
     print_list_output,
     typer_factory,
 )
+from ._output import out
 
 
 logger = logging.get_logger(__name__)
@@ -313,15 +312,12 @@ def jobs_run(
         timeout=timeout,
         namespace=namespace,
     )
-    # Always print the job ID to the user
-    print(f"Job started with ID: {job.id}")
-    print(f"View at: {job.url}")
-
+    out.result("Job started", id=job.id, url=job.url)
     if detach:
+        out.hint(f"Use `hf jobs logs {job.id}` to fetch the logs.")
         return
-    # Now let's stream the logs
     for log in api.fetch_job_logs(job_id=job.id, namespace=job.owner.name, follow=True):
-        print(log)
+        out.text(log)
 
 
 @jobs_cli.command(
@@ -366,7 +362,7 @@ def jobs_logs(
     try:
         logs = api.fetch_job_logs(job_id=job_id, namespace=namespace, follow=follow, tail=tail)
         for log in logs:
-            print(log)
+            out.text(log)
     except HfHubHTTPError as e:
         status = e.response.status_code if e.response is not None else None
         if status == 404:
@@ -660,33 +656,27 @@ def jobs_hardware() -> None:
     """List available hardware options for Jobs"""
     api = get_hf_api()
     hardware_list = api.list_jobs_hardware()
-    table_headers = ["NAME", "PRETTY NAME", "CPU", "RAM", "STORAGE", "ACCELERATOR", "COST/MIN", "COST/HOUR"]
-    headers_aliases = ["name", "prettyName", "cpu", "ram", "ephemeralStorage", "accelerator", "costMin", "costHour"]
-    rows: list[list[str | int]] = []
-
+    items = []
     for hw in hardware_list:
-        accelerator_info = ""
-        if hw.accelerator:
-            accelerator_info = f"{hw.accelerator.quantity}x {hw.accelerator.model} ({hw.accelerator.vram})"
+        accelerator = (
+            f"{hw.accelerator.quantity}x {hw.accelerator.model} ({hw.accelerator.vram})" if hw.accelerator else None
+        )
         cost_min = f"${hw.unit_cost_usd:.4f}" if hw.unit_cost_usd else "free"
         cost_hour = f"${hw.unit_cost_usd * 60:.2f}" if hw.unit_cost_usd else "free"
-        rows.append(
-            [
-                hw.name,
-                hw.pretty_name or "",
-                hw.cpu,
-                hw.ram,
-                hw.ephemeral_storage,
-                accelerator_info,
-                cost_min,
-                cost_hour,
-            ]
+        items.append(
+            {
+                "name": hw.name,
+                "pretty name": hw.pretty_name,
+                "cpu": hw.cpu,
+                "ram": hw.ram,
+                "storage": hw.ephemeral_storage,
+                "accelerator": accelerator,
+                "cost/min": cost_min,
+                "cost/hour": cost_hour,
+            }
         )
-
-    if not rows:
-        print("No hardware options found")
-        return
-    _print_output(rows, table_headers, headers_aliases, None)
+    out.table(items)
+    out.hint("Use `hf jobs run --flavor <name> ...` to request a specific hardware flavor.")
 
 
 @jobs_cli.command("inspect", examples=["hf jobs inspect <job_id>"])
@@ -709,7 +699,6 @@ def jobs_inspect(
     api = get_hf_api(token=token)
     try:
         jobs = [api.inspect_job(job_id=job_id, namespace=namespace) for job_id in job_ids]
-        print(json.dumps([asdict(job) for job in jobs], indent=4, default=str))
     except HfHubHTTPError as e:
         status = e.response.status_code if e.response is not None else None
         if status == 404:
@@ -718,6 +707,7 @@ def jobs_inspect(
             raise CLIError("Access denied. You may not have permission to view this job.") from e
         else:
             raise CLIError(f"Failed to inspect job: {e}") from e
+    out.dict([api_object_to_dict(job) for job in jobs])
 
 
 @jobs_cli.command("cancel", examples=["hf jobs cancel <job_id>"])
@@ -739,6 +729,7 @@ def jobs_cancel(
             raise CLIError("Access denied. You may not have permission to cancel this job.") from e
         else:
             raise CLIError(f"Failed to cancel job: {e}") from e
+    out.result("Job cancelled", id=job_id)
 
 
 uv_app = typer_factory(help="Run UV scripts (Python with inline dependencies) on HF infrastructure.")
@@ -792,14 +783,12 @@ def jobs_uv_run(
         timeout=timeout,
         namespace=namespace,
     )
-    # Always print the job ID to the user
-    print(f"Job started with ID: {job.id}")
-    print(f"View at: {job.url}")
+    out.result("Job started", id=job.id, url=job.url)
     if detach:
+        out.hint(f"Use `hf jobs logs {job.id}` to fetch the logs.")
         return
-    # Now let's stream the logs
     for log in api.fetch_job_logs(job_id=job.id, namespace=job.owner.name, follow=True):
-        print(log)
+        out.text(log)
 
 
 scheduled_app = typer_factory(help="Create and manage scheduled Jobs on the Hub.")
@@ -847,7 +836,8 @@ def scheduled_run(
         timeout=timeout,
         namespace=namespace,
     )
-    print(f"Scheduled Job created with ID: {scheduled_job.id}")
+    out.result("Scheduled Job created", id=scheduled_job.id)
+    out.hint(f"Use `hf jobs scheduled inspect {scheduled_job.id}` to view its details.")
 
 
 @scheduled_app.command("ps", examples=["hf jobs scheduled ps"])
@@ -978,7 +968,7 @@ def scheduled_inspect(
         api.inspect_scheduled_job(scheduled_job_id=scheduled_job_id, namespace=namespace)
         for scheduled_job_id in scheduled_job_ids
     ]
-    print(json.dumps([asdict(scheduled_job) for scheduled_job in scheduled_jobs], indent=4, default=str))
+    out.dict([api_object_to_dict(scheduled_job) for scheduled_job in scheduled_jobs])
 
 
 @scheduled_app.command("delete", examples=["hf jobs scheduled delete <id>"])
@@ -991,6 +981,7 @@ def scheduled_delete(
     scheduled_job_id, namespace = _parse_namespace_from_job_id(scheduled_job_id, namespace)
     api = get_hf_api(token=token)
     api.delete_scheduled_job(scheduled_job_id=scheduled_job_id, namespace=namespace)
+    out.result("Scheduled Job deleted", id=scheduled_job_id)
 
 
 @scheduled_app.command("suspend", examples=["hf jobs scheduled suspend <id>"])
@@ -1003,6 +994,8 @@ def scheduled_suspend(
     scheduled_job_id, namespace = _parse_namespace_from_job_id(scheduled_job_id, namespace)
     api = get_hf_api(token=token)
     api.suspend_scheduled_job(scheduled_job_id=scheduled_job_id, namespace=namespace)
+    out.result("Scheduled Job suspended", id=scheduled_job_id)
+    out.hint(f"Use `hf jobs scheduled resume {scheduled_job_id}` to resume it.")
 
 
 @scheduled_app.command("resume", examples=["hf jobs scheduled resume <id>"])
@@ -1015,6 +1008,7 @@ def scheduled_resume(
     scheduled_job_id, namespace = _parse_namespace_from_job_id(scheduled_job_id, namespace)
     api = get_hf_api(token=token)
     api.resume_scheduled_job(scheduled_job_id=scheduled_job_id, namespace=namespace)
+    out.result("Scheduled Job resumed", id=scheduled_job_id)
 
 
 scheduled_uv_app = typer_factory(help="Schedule UV scripts on HF infrastructure.")
@@ -1071,7 +1065,8 @@ def scheduled_uv_run(
         timeout=timeout,
         namespace=namespace,
     )
-    print(f"Scheduled Job created with ID: {job.id}")
+    out.result("Scheduled Job created", id=job.id)
+    out.hint(f"Use `hf jobs scheduled inspect {job.id}` to view its details.")
 
 
 ### UTILS

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -81,18 +81,14 @@ from huggingface_hub.utils._parsing import format_duration
 from ._cli_utils import (
     EnvFileOpt,
     EnvOpt,
-    OutputFormat,
-    QuietOpt,
     SecretsFileOpt,
     SecretsOpt,
     TokenOpt,
     VolumesOpt,
-    _format_cell,
     api_object_to_dict,
     get_hf_api,
     parse_env_map,
     parse_volumes,
-    print_list_output,
     typer_factory,
 )
 from ._output import out
@@ -387,21 +383,47 @@ def _matches_filters(job_properties: dict[str, str], filters: list[tuple[str, st
     return True
 
 
-def _print_output(rows: list[list[str | int]], headers: list[str], aliases: list[str], fmt: str | None) -> None:
-    """Print output according to the chosen format."""
-    if fmt:
-        # Use custom template if provided
-        template = fmt
-        for row in rows:
-            line = template
-            for i, field in enumerate(aliases):
-                placeholder = f"{{{{.{field}}}}}"
-                if placeholder in line:
-                    line = line.replace(placeholder, str(row[i]))
-            print(line)
-    else:
-        # Default tabular format
-        print(_tabulate(rows, headers=headers))
+def _is_template(value: str) -> bool:
+    """A --format value is a Go template iff it contains the ``{{`` placeholder syntax."""
+    return "{{" in value
+
+
+def _render_template(template: str, items: list[dict[str, Any]]) -> None:
+    """Render each item through a Go-style template (e.g. ``'{{.id}} {{.status}}'``) and print it."""
+    for item in items:
+        line = template
+        for key, value in item.items():
+            placeholder = f"{{{{.{key}}}}}"
+            if placeholder in line:
+                line = line.replace(placeholder, "" if value is None else str(value))
+        print(line)
+
+
+def _set_jobs_format(value: str) -> str:
+    """Callback for ``FormatWithTemplateOpt``: set ``out`` mode from a ``--format`` value.
+
+    Accepts standard output modes (``auto|human|agent|json|quiet``) or a Go-template string like
+    ``'{{.id}}'``. Templates render via ``print()`` and bypass ``out``, so the mode is left untouched.
+    """
+    if _is_template(value):
+        return value
+    try:
+        out.set_mode(value)
+    except ValueError as e:
+        raise typer.BadParameter(
+            f"Invalid --format value: '{value}'. Use auto|human|agent|json|quiet, or a Go template."
+        ) from e
+    return value
+
+
+FormatWithTemplateOpt = Annotated[
+    str,
+    typer.Option(
+        "--format",
+        help="Output format: auto|human|agent|json|quiet, or a Go-template string (e.g. '{{.id}}').",
+        callback=_set_jobs_format,
+    ),
+]
 
 
 def _clear_line(n: int) -> None:
@@ -475,17 +497,6 @@ def jobs_stats(
         "GPU MEM %",
         "GPU MEM USAGE",
     ]
-    headers_aliases = [
-        "id",
-        "cpu_usage_pct",
-        "cpu_millicores",
-        "memory_used_bytes_pct",
-        "memory_used_bytes_and_total_bytes",
-        "rx_bps_and_tx_bps",
-        "gpu_utilization",
-        "gpu_memory_used_bytes_pct",
-        "gpu_memory_used_bytes_and_total_bytes",
-    ]
     try:
         with multiprocessing.pool.ThreadPool(len(job_ids)) as pool:
             rows_per_job_id: dict[str, list[list[str | int]]] = {}
@@ -495,7 +506,7 @@ def jobs_stats(
                 rows_per_job_id[job_id] = [row]
             last_update_time = time.time()
             total_rows = [row for job_id in rows_per_job_id for row in rows_per_job_id[job_id]]
-            _print_output(total_rows, table_headers, headers_aliases, None)
+            print(_tabulate(total_rows, headers=table_headers))
 
             kwargs_list = [
                 {
@@ -514,7 +525,7 @@ def jobs_stats(
                 if now - last_update_time >= STATS_UPDATE_MIN_INTERVAL:
                     _clear_line(2 + len(total_rows))
                     total_rows = [row for job_id in rows_per_job_id for row in rows_per_job_id[job_id]]
-                    _print_output(total_rows, table_headers, headers_aliases, None)
+                    print(_tabulate(total_rows, headers=table_headers))
                     last_update_time = now
     except HfHubHTTPError as e:
         status = e.response.status_code if e.response is not None else None
@@ -546,15 +557,10 @@ def jobs_ps(
             help="Filter output based on conditions provided (format: key=value)",
         ),
     ] = None,
-    format: Annotated[
-        str | None,
-        typer.Option(help="Output format: 'table' (default), 'json', or a Go template (e.g. '{{.id}}')"),
-    ] = None,
-    quiet: QuietOpt = False,
+    format: FormatWithTemplateOpt = "auto",
 ) -> None:
     """List Jobs."""
     api = get_hf_api(token=token)
-    # Fetch jobs data
     jobs = api.list_jobs(namespace=namespace)
 
     filters: list[tuple[str, str, str]] = []
@@ -564,9 +570,7 @@ def jobs_ps(
             if f.startswith("label!="):
                 label_part = f[len("label!=") :]
                 if "=" in label_part:
-                    print(
-                        f"Warning: Ignoring invalid label filter format 'label!={label_part}'. Use label!=key format."
-                    )
+                    out.warning(f"Ignoring invalid label filter format 'label!={label_part}'. Use label!=key format.")
                     continue
                 label_key, op, label_value = label_part, "!=", "*"
             else:
@@ -575,7 +579,6 @@ def jobs_ps(
                     label_key, label_value = label_part.split("=", 1)
                 else:
                     label_key, label_value = label_part, "*"
-                # Negate predicate in case of key!=value
                 if label_key.endswith("!"):
                     op = "!="
                     label_key = label_key[:-1]
@@ -584,7 +587,6 @@ def jobs_ps(
             labels_filters.append((label_key.lower(), op, label_value.lower()))
         elif "=" in f:
             key, value = f.split("=", 1)
-            # Negate predicate in case of key!=value
             if key.endswith("!"):
                 op = "!="
                 key = key[:-1]
@@ -592,7 +594,7 @@ def jobs_ps(
                 op = "="
             filters.append((key.lower(), op, value.lower()))
         else:
-            print(f"Warning: Ignoring invalid filter format '{f}'. Use key=value format.")
+            out.warning(f"Ignoring invalid filter format '{f}'. Use key=value format.")
 
     # Filter jobs (operating on JobInfo objects to preserve existing filter behavior)
     filtered_jobs = []
@@ -610,45 +612,28 @@ def jobs_ps(
             continue
         filtered_jobs.append(job)
 
-    if not filtered_jobs:
-        if not quiet and format != "json":
-            filters_msg = f" matching filters: {', '.join([f'{k}{o}{v}' for k, o, v in filters])}" if filters else ""
-            print(f"No jobs found{filters_msg}")
-        elif format == "json":
-            print("[]")
-        return
-
-    headers = ["JOB ID", "IMAGE/SPACE", "COMMAND", "CREATED", "STATUS", "RUNTIME"]
-    aliases = ["id", "image", "command", "created", "status", "runtime"]
-    items = [api_object_to_dict(job) for job in filtered_jobs]
-
-    def row_fn(item: dict[str, Any]) -> list[str]:
-        status = item.get("status", {})
+    # Build display items. Augment the raw api dict with curated, table-friendly columns
+    # (image, command, created, status, runtime) — these double as Go-template fields.
+    items: list[dict[str, Any]] = []
+    for job in filtered_jobs:
+        item = api_object_to_dict(job)
         durations = item.get("durations") or {}
         cmd = item.get("command") or []
-        command_str = " ".join(cmd) if cmd else "N/A"
-        return [
-            str(item.get("id", "")),
-            _format_cell(item.get("docker_image") or "N/A"),
-            _format_cell(command_str),
-            item["created_at"][:19].replace("T", " ") if item.get("created_at") else "N/A",
-            str(status.get("stage", "UNKNOWN")),
-            format_duration(durations.get("running_secs")),
-        ]
+        item["image"] = item.get("docker_image") or "N/A"
+        item["command"] = " ".join(cmd) if cmd else "N/A"
+        item["created"] = item["created_at"][:19].replace("T", " ") if item.get("created_at") else "N/A"
+        item["status"] = (item.get("status") or {}).get("stage", "UNKNOWN")
+        item["runtime"] = format_duration(durations.get("running_secs"))
+        items.append(item)
 
-    # Custom template format
-    if format and format not in ("table", "json"):
-        _print_output([row_fn(item) for item in items], headers, aliases, format)  # type: ignore
-    else:
-        output_format = OutputFormat.json if format == "json" else OutputFormat.table
-        print_list_output(
-            items=items,
-            format=output_format,
-            quiet=quiet,
-            id_key="id",
-            headers=headers,
-            row_fn=row_fn,
-        )
+    if _is_template(format):
+        _render_template(format, items)
+        return
+
+    out.table(items, headers=["id", "image", "command", "created", "status", "runtime"], id_key="id")
+    if not items and filters:
+        filters_msg = ", ".join(f"{k}{o}{v}" for k, o, v in filters)
+        out.hint(f"No jobs matched filters: {filters_msg}")
 
 
 @jobs_cli.command("hardware", examples=["hf jobs hardware"])
@@ -860,11 +845,7 @@ def scheduled_ps(
             help="Filter output based on conditions provided (format: key=value)",
         ),
     ] = None,
-    format: Annotated[
-        str | None,
-        typer.Option(help="Output format: 'table' (default), 'json', or a Go template (e.g. '{{.id}}')"),
-    ] = None,
-    quiet: QuietOpt = False,
+    format: FormatWithTemplateOpt = "auto",
 ) -> None:
     """List scheduled Jobs"""
     api = get_hf_api(token=token)
@@ -873,7 +854,6 @@ def scheduled_ps(
     for f in filter or []:
         if "=" in f:
             key, value = f.split("=", 1)
-            # Negate predicate in case of key!=value
             if key.endswith("!"):
                 op = "!="
                 key = key[:-1]
@@ -881,7 +861,7 @@ def scheduled_ps(
                 op = "="
             filters.append((key.lower(), op, value.lower()))
         else:
-            print(f"Warning: Ignoring invalid filter format '{f}'. Use key=value format.")
+            out.warning(f"Ignoring invalid filter format '{f}'. Use key=value format.")
 
     # Filter scheduled jobs (operating on ScheduledJobInfo objects to preserve existing filter behavior)
     filtered_jobs = []
@@ -897,53 +877,36 @@ def scheduled_ps(
             continue
         filtered_jobs.append(scheduled_job)
 
-    if not filtered_jobs:
-        if not quiet and format != "json":
-            filters_msg = f" matching filters: {', '.join([f'{k}{o}{v}' for k, o, v in filters])}" if filters else ""
-            print(f"No scheduled jobs found{filters_msg}")
-        elif format == "json":
-            print("[]")
+    # Build display items. Augment with curated columns (image, command, last, next) that also
+    # serve as Go-template fields.
+    items: list[dict[str, Any]] = []
+    for sj in filtered_jobs:
+        item = api_object_to_dict(sj)
+        job_spec = item.get("job_spec") or {}
+        status_dict = item.get("status") or {}
+        last_job = status_dict.get("last_job")
+        cmd = job_spec.get("command") or []
+        item["image"] = job_spec.get("docker_image") or "N/A"
+        item["command"] = " ".join(cmd) if cmd else "N/A"
+        item["last"] = last_job["at"][:19].replace("T", " ") if last_job and last_job.get("at") else "N/A"
+        item["next"] = (
+            status_dict["next_job_run_at"][:19].replace("T", " ") if status_dict.get("next_job_run_at") else "N/A"
+        )
+        item["suspend"] = item.get("suspend") or False
+        items.append(item)
+
+    if _is_template(format):
+        _render_template(format, items)
         return
 
-    headers = ["ID", "SCHEDULE", "IMAGE/SPACE", "COMMAND", "LAST RUN", "NEXT RUN", "SUSPEND"]
-    aliases = ["id", "schedule", "image", "command", "last", "next", "suspend"]
-    items = [api_object_to_dict(sj) for sj in filtered_jobs]
-
-    def row_fn(item: dict[str, Any]) -> list[str]:
-        job_spec = item.get("job_spec", {})
-        status = item.get("status", {})
-        last_job = status.get("last_job")
-        cmd = job_spec.get("command") or []
-        last_job_at = "N/A"
-        if last_job and last_job.get("at"):
-            last_job_at = last_job["at"][:19].replace("T", " ")
-        next_run = "N/A"
-        if status.get("next_job_run_at"):
-            next_run = status["next_job_run_at"][:19].replace("T", " ")
-        command_str = " ".join(cmd) if cmd else "N/A"
-        return [
-            str(item.get("id", "")),
-            str(item.get("schedule") or "N/A"),
-            _format_cell(job_spec.get("docker_image") or "N/A"),
-            _format_cell(command_str),
-            last_job_at,
-            next_run,
-            str(item.get("suspend", False)),
-        ]
-
-    # Custom template format (e.g. --format '{{.id}} {{.schedule}}')
-    if format and format not in ("table", "json"):
-        _print_output([row_fn(item) for item in items], headers, aliases, format)  # type: ignore
-    else:
-        output_format = OutputFormat.json if format == "json" else OutputFormat.table
-        print_list_output(
-            items=items,
-            format=output_format,
-            quiet=quiet,
-            id_key="id",
-            headers=headers,
-            row_fn=row_fn,
-        )
+    out.table(
+        items,
+        headers=["id", "schedule", "image", "command", "last", "next", "suspend"],
+        id_key="id",
+    )
+    if not items and filters:
+        filters_msg = ", ".join(f"{k}{o}{v}" for k, o, v in filters)
+        out.hint(f"No scheduled jobs matched filters: {filters_msg}")
 
 
 @scheduled_app.command("inspect", examples=["hf jobs scheduled inspect <id>"])

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -658,9 +658,9 @@ def jobs_hardware() -> None:
     hardware_list = api.list_jobs_hardware()
     items = []
     for hw in hardware_list:
-        accelerator = (
-            f"{hw.accelerator.quantity}x {hw.accelerator.model} ({hw.accelerator.vram})" if hw.accelerator else None
-        )
+        accelerator_info = ""
+        if hw.accelerator:
+            accelerator_info = f"{hw.accelerator.quantity}x {hw.accelerator.model} ({hw.accelerator.vram})"
         cost_min = f"${hw.unit_cost_usd:.4f}" if hw.unit_cost_usd else "free"
         cost_hour = f"${hw.unit_cost_usd * 60:.2f}" if hw.unit_cost_usd else "free"
         items.append(
@@ -670,7 +670,7 @@ def jobs_hardware() -> None:
                 "cpu": hw.cpu,
                 "ram": hw.ram,
                 "storage": hw.ephemeral_storage,
-                "accelerator": accelerator,
+                "accelerator": accelerator_info,
                 "cost/min": cost_min,
                 "cost/hour": cost_hour,
             }

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -747,7 +747,7 @@ def jobs_labels(
     labels = _parse_labels_map(label) or {}
     api = get_hf_api(token=token)
     job = api.update_job_labels(job_id=job_id, labels=labels, namespace=namespace)
-    print(json.dumps(asdict(job), indent=4, default=str))
+    out.result("Labels updated", id=job.id)
 
 
 uv_app = typer_factory(help="Run UV scripts (Python with inline dependencies) on HF infrastructure.")
@@ -1034,7 +1034,7 @@ def scheduled_labels(
     scheduled_job = api.update_scheduled_job_labels(
         scheduled_job_id=scheduled_job_id, labels=labels, namespace=namespace
     )
-    print(json.dumps(asdict(scheduled_job), indent=4, default=str))
+    out.result("Labels updated", id=job.id)
 
 
 scheduled_uv_app = typer_factory(help="Schedule UV scripts on HF infrastructure.")

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -85,13 +85,12 @@ from ._cli_utils import (
     SecretsOpt,
     TokenOpt,
     VolumesOpt,
-    api_object_to_dict,
     get_hf_api,
     parse_env_map,
     parse_volumes,
     typer_factory,
 )
-from ._output import out
+from ._output import _dataclass_to_dict, out
 
 
 logger = logging.get_logger(__name__)
@@ -441,7 +440,7 @@ def jobs_stats(
             if (job.status.stage if job.status else "UNKNOWN") in ("RUNNING", "UPDATING")
         ]
     if len(job_ids) == 0:
-        print("No running jobs found")
+        out.text("No running jobs found")
         return
     table_headers = [
         "JOB ID",
@@ -463,6 +462,8 @@ def jobs_stats(
                 rows_per_job_id[job_id] = [row]
             last_update_time = time.time()
             total_rows = [row for job_id in rows_per_job_id for row in rows_per_job_id[job_id]]
+            # In-place refresh (cursor-up + clear) requires a fixed line count and layout —
+            # `out.table`'s mode-dependent formatting would break it.
             print(_tabulate(total_rows, headers=table_headers))
 
             kwargs_list = [
@@ -573,7 +574,7 @@ def jobs_ps(
     # Build display items. Augment the raw api dict with curated, table-friendly columns.
     items: list[dict[str, Any]] = []
     for job in filtered_jobs:
-        item = api_object_to_dict(job)
+        item = _dataclass_to_dict(job)
         durations = item.get("durations") or {}
         cmd = item.get("command") or []
         item["job_id"] = item.get("id", "")
@@ -591,7 +592,7 @@ def jobs_ps(
     )
     if not items and filters:
         filters_msg = ", ".join(f"{k}{o}{v}" for k, o, v in filters)
-        out.hint(f"No jobs matched filters: {filters_msg}")
+        out.text(f"No jobs matched filters: {filters_msg}")
 
 
 @jobs_cli.command("hardware", examples=["hf jobs hardware"])
@@ -650,7 +651,7 @@ def jobs_inspect(
             raise CLIError("Access denied. You may not have permission to view this job.") from e
         else:
             raise CLIError(f"Failed to inspect job: {e}") from e
-    out.dict([api_object_to_dict(job) for job in jobs])
+    out.table([_dataclass_to_dict(job) for job in jobs])
 
 
 @jobs_cli.command("cancel", examples=["hf jobs cancel <job_id>"])
@@ -866,7 +867,7 @@ def scheduled_ps(
     # Build display items. Augment with curated columns.
     items: list[dict[str, Any]] = []
     for sj in filtered_jobs:
-        item = api_object_to_dict(sj)
+        item = _dataclass_to_dict(sj)
         job_spec = item.get("job_spec") or {}
         status_dict = item.get("status") or {}
         last_job = status_dict.get("last_job")
@@ -887,7 +888,7 @@ def scheduled_ps(
     )
     if not items and filters:
         filters_msg = ", ".join(f"{k}{o}{v}" for k, o, v in filters)
-        out.hint(f"No scheduled jobs matched filters: {filters_msg}")
+        out.text(f"No scheduled jobs matched filters: {filters_msg}")
 
 
 @scheduled_app.command("inspect", examples=["hf jobs scheduled inspect <id>"])
@@ -912,7 +913,7 @@ def scheduled_inspect(
         api.inspect_scheduled_job(scheduled_job_id=scheduled_job_id, namespace=namespace)
         for scheduled_job_id in scheduled_job_ids
     ]
-    out.dict([api_object_to_dict(scheduled_job) for scheduled_job in scheduled_jobs])
+    out.table([_dataclass_to_dict(scheduled_job) for scheduled_job in scheduled_jobs])
 
 
 @scheduled_app.command("delete", examples=["hf jobs scheduled delete <id>"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3140,29 +3140,6 @@ class TestJobsCommand:
         assert result.exit_code == 0
         assert result.output.strip() == ""
 
-    def test_ps_go_template_format(self, runner: CliRunner) -> None:
-        """Test that `hf jobs ps --format '{{.id}}'` uses legacy Go-template output."""
-        jobs = self._make_mock_jobs()
-        with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
-            api = api_cls.return_value
-            api.list_jobs.return_value = jobs
-            result = runner.invoke(app, ["jobs", "ps", "-a", "--format", "{{.id}}"])
-        assert result.exit_code == 0
-        lines = result.output.strip().split("\n")
-        assert "abc123def456" in lines
-        assert "xyz789ghi012" in lines
-
-    def test_ps_go_template_multiple_fields(self, runner: CliRunner) -> None:
-        """Test that Go-template with multiple fields works."""
-        jobs = self._make_mock_jobs()
-        with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
-            api = api_cls.return_value
-            api.list_jobs.return_value = jobs
-            result = runner.invoke(app, ["jobs", "ps", "-a", "--format", "{{.id}} {{.status}}"])
-        assert result.exit_code == 0
-        assert "abc123def456 RUNNING" in result.output
-        assert "xyz789ghi012 COMPLETED" in result.output
-
     def test_run_with_volumes(self, runner: CliRunner) -> None:
         job = Mock(id="job-id", url="https://huggingface.co/jobs/me/job-id")
         with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
@@ -3755,13 +3732,6 @@ class TestGlobalFormattingFlags:
         assert "--json" in result.output
         assert "--quiet" in result.output
         assert "--no-truncate" in result.output
-
-    def test_help_skips_section_for_legacy_command_with_local_format(self, runner: CliRunner) -> None:
-        """Legacy commands (e.g. 'hf jobs ps') keep their local --format/--quiet
-        and don't get the duplicated 'Formatting options' section."""
-        result = runner.invoke(app, ["jobs", "ps", "--help"])
-        assert result.exit_code == 0, result.output
-        assert "Formatting options:" not in result.output
 
     def test_help_skips_section_for_pass_through_command(self, runner: CliRunner) -> None:
         """Pass-through commands (e.g. `hf extensions exec`) don't show the section either."""


### PR DESCRIPTION
Last piece of #3979. 
This PR migrates `hf jobs` to the `out` framework. 

breaking changes introduced in `hf jobs ps` and `hf jobs scheduled ps` (I think it's fine, the alternative would be special casing `_output.py` justfor these two list commands) :

  1.` --format` table is removed. Use `--format auto|human|agent|quiet|json`.
  2. json output shape changed for `hf jobs ps`:
    - `command` is now a string (e.g. "python script.py"), was a list (e.g.
  ["python", "script.py"]).
    - `status` is now a string (e.g. `"RUNNING"`), was a dict (e.g. ```{"stage": "RUNNING"```).
 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> User-visible CLI breaking changes on `hf jobs ps` and `hf jobs scheduled ps` (format flags and JSON field shapes); behavior is otherwise presentation-layer only for jobs commands.
> 
> **Overview**
> Migrates the **`hf jobs`** command group to the shared **`out`** CLI output layer (`out.result`, `out.table`, `out.dict`, `out.text`, `out.warning`, `out.hint`) instead of ad-hoc `print` / `json.dumps` / `print_list_output`.
> 
> **`hf jobs ps`** and **`hf jobs scheduled ps`** now use **`--format auto|human|agent|json|quiet`** (default `auto`) with optional Go-style templates (`{{.id}}`). **`--format table`** and **`-q` / `--quiet`** are removed; quiet IDs come from **`--format quiet`**. For **`hf jobs ps`**, JSON output flattens **`command`** to a string and **`status`** to a stage string (not a list or nested object). Inspect/labels and lifecycle commands get consistent structured output; docs for the list commands are regenerated to match.
> 
> **`_output.Output.set_mode`** accepts string mode names (e.g. `'agent'`) in addition to the enum.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63b352d29c1a0b9030008d33442ec847efdb3ce8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->