### PR TITLE
Add UomiRouter as inference provider

### DIFF
--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -135,7 +135,7 @@ class InferenceClient:
             Note: for better compatibility with OpenAI's client, `model` has been aliased as `base_url`. Those 2
             arguments are mutually exclusive. If a URL is passed as `model` or `base_url` for chat completion, the `(/v1)/chat/completions` suffix path will be appended to the URL.
         provider (`str`, *optional*):
-            Name of the provider to use for inference. Can be `"black-forest-labs"`, `"cerebras"`, `"clarifai"`, `"cohere"`, `"deepinfra"`, `"fal-ai"`, `"featherless-ai"`, `"fireworks-ai"`, `"groq"`, `"hf-inference"`, `"hyperbolic"`, `"nebius"`, `"novita"`, `"nscale"`, `"nvidia"`, `"openai"`, `"ovhcloud"`, `"publicai"`, `"replicate"`, `"sambanova"`, `"scaleway"`, `"together"`, `"wavespeed"` or `"zai-org"`.
+            Name of the provider to use for inference. Can be `"black-forest-labs"`, `"cerebras"`, `"clarifai"`, `"cohere"`, `"deepinfra"`, `"fal-ai"`, `"featherless-ai"`, `"fireworks-ai"`, `"groq"`, `"hf-inference"`, `"hyperbolic"`, `"nebius"`, `"novita"`, `"nscale"`, `"nvidia"`, `"openai"`, `"ovhcloud"`, `"publicai"`, `"replicate"`, `"sambanova"`, `"scaleway"`, `"together"`, `"uomirouter"`, `"wavespeed"` or `"zai-org"`.
             Defaults to "auto": automatic routing, which defaults to "fastest" provider; you can
             switch to "cheapest" or "preferred" provider order at https://hf.co/settings/inference-providers.
             If model is a URL or `base_url` is passed, then `provider` is not used.

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -125,7 +125,7 @@ class AsyncInferenceClient:
             Note: for better compatibility with OpenAI's client, `model` has been aliased as `base_url`. Those 2
             arguments are mutually exclusive. If a URL is passed as `model` or `base_url` for chat completion, the `(/v1)/chat/completions` suffix path will be appended to the URL.
         provider (`str`, *optional*):
-            Name of the provider to use for inference. Can be `"black-forest-labs"`, `"cerebras"`, `"clarifai"`, `"cohere"`, `"deepinfra"`, `"fal-ai"`, `"featherless-ai"`, `"fireworks-ai"`, `"groq"`, `"hf-inference"`, `"hyperbolic"`, `"nebius"`, `"novita"`, `"nscale"`, `"nvidia"`, `"openai"`, `"ovhcloud"`, `"publicai"`, `"replicate"`, `"sambanova"`, `"scaleway"`, `"together"`, `"wavespeed"` or `"zai-org"`.
+            Name of the provider to use for inference. Can be `"black-forest-labs"`, `"cerebras"`, `"clarifai"`, `"cohere"`, `"deepinfra"`, `"fal-ai"`, `"featherless-ai"`, `"fireworks-ai"`, `"groq"`, `"hf-inference"`, `"hyperbolic"`, `"nebius"`, `"novita"`, `"nscale"`, `"nvidia"`, `"openai"`, `"ovhcloud"`, `"publicai"`, `"replicate"`, `"sambanova"`, `"scaleway"`, `"together"`, `"uomirouter"`, `"wavespeed"` or `"zai-org"`.
             Defaults to "auto": automatic routing, which defaults to "fastest" provider; you can
             switch to "cheapest" or "preferred" provider order at https://hf.co/settings/inference-providers.
             If model is a URL or `base_url` is passed, then `provider` is not used.

--- a/src/huggingface_hub/inference/_providers/__init__.py
+++ b/src/huggingface_hub/inference/_providers/__init__.py
@@ -61,6 +61,7 @@ from .together import (
     TogetherTextToSpeechTask,
     TogetherTextToVideoTask,
 )
+from .uomirouter import UomiRouterConversationalTask
 from .wavespeed import (
     WavespeedAIImageToImageTask,
     WavespeedAIImageToVideoTask,
@@ -96,6 +97,7 @@ PROVIDER_T = Literal[
     "sambanova",
     "scaleway",
     "together",
+    "uomirouter",
     "wavespeed",
     "zai-org",
 ]
@@ -224,6 +226,9 @@ PROVIDERS: dict[PROVIDER_T, dict[str, TaskProviderHelper]] = {
         "text-to-image": TogetherTextToImageTask(),
         "text-to-speech": TogetherTextToSpeechTask(),
         "text-to-video": TogetherTextToVideoTask(),
+    },
+    "uomirouter": {
+        "conversational": UomiRouterConversationalTask(),
     },
     "wavespeed": {
         "text-to-image": WavespeedAITextToImageTask(),

--- a/src/huggingface_hub/inference/_providers/uomirouter.py
+++ b/src/huggingface_hub/inference/_providers/uomirouter.py
@@ -1,0 +1,33 @@
+"""UomiRouter inference provider.
+
+UomiRouter (https://uomi.ai) is a distributed inference network: each request is
+dispatched across a pool of operator-run GPU nodes and the response carries an
+``Inference-Id`` header for on-chain verifiable attestation. The gateway exposes
+an OpenAI-compatible surface at ``/v1/chat/completions`` (streaming, tool calling
+and structured output included), so the helper here is intentionally minimal —
+``BaseConversationalTask`` already covers the request/response shape.
+
+See the registered mapping of HF model ID => UomiRouter model ID here:
+
+    https://huggingface.co/api/partners/uomirouter/models
+
+- If you work at UomiRouter and want to update this mapping, please use the
+  model-mapping API we provide on huggingface.co.
+- If you're a community member and want to add a new supported HF model to
+  UomiRouter, please open an issue on huggingface/huggingface_hub and tag the
+  UomiRouter team.
+"""
+
+from ._common import BaseConversationalTask
+
+
+class UomiRouterConversationalTask(BaseConversationalTask):
+    """Conversational (chat completion) task helper for UomiRouter.
+
+    The UomiRouter gateway is OpenAI-compatible, so no payload or response
+    overrides are needed — the base class default of POSTing the OpenAI-format
+    payload to ``/v1/chat/completions`` is exactly what the gateway expects.
+    """
+
+    def __init__(self):
+        super().__init__(provider="uomirouter", base_url="https://gateway.uomi.ai")

--- a/src/huggingface_hub/inference/_providers/uomirouter.py
+++ b/src/huggingface_hub/inference/_providers/uomirouter.py
@@ -2,7 +2,7 @@
 
 UomiRouter (https://uomi.ai) is a distributed inference network: each request is
 dispatched across a pool of operator-run GPU nodes and the response carries an
-``Inference-Id`` header for on-chain verifiable attestation. The gateway exposes
+``Inference-Id`` header for verifiable response attestation (off-chain today; on-chain anchoring on UOMI L1 is the next milestone). The gateway exposes
 an OpenAI-compatible surface at ``/v1/chat/completions`` (streaming, tool calling
 and structured output included), so the helper here is intentionally minimal —
 ``BaseConversationalTask`` already covers the request/response shape.

--- a/tests/test_inference_providers.py
+++ b/tests/test_inference_providers.py
@@ -66,6 +66,7 @@ from huggingface_hub.inference._providers.together import (
     TogetherTextToSpeechTask,
     TogetherTextToVideoTask,
 )
+from huggingface_hub.inference._providers.uomirouter import UomiRouterConversationalTask
 from huggingface_hub.inference._providers.wavespeed import (
     WavespeedAIImageToImageTask,
     WavespeedAIImageToVideoTask,
@@ -1438,6 +1439,30 @@ class TestOpenAIProvider:
     def test_prepare_url(self):
         helper = OpenAIConversationalTask()
         assert helper._prepare_url("sk-XXXXXX", "gpt-4o-mini") == "https://api.openai.com/v1/chat/completions"
+
+
+class TestUomiRouterProvider:
+    def test_provider_and_base_url(self):
+        helper = UomiRouterConversationalTask()
+        assert helper.provider == "uomirouter"
+        assert helper.task == "conversational"
+        assert helper.base_url == "https://gateway.uomi.ai"
+
+    def test_prepare_url(self):
+        helper = UomiRouterConversationalTask()
+        # Non-HF API keys (e.g. sk-uomi-...) hit the gateway directly.
+        assert (
+            helper._prepare_url("sk-uomi-xxxxxx", "Qwen/Qwen3.6-35B-A3B")
+            == "https://gateway.uomi.ai/v1/chat/completions"
+        )
+
+    def test_prepare_route(self):
+        helper = UomiRouterConversationalTask()
+        assert helper._prepare_route("Qwen/Qwen3.6-35B-A3B", "sk-uomi-xxxxxx") == "/v1/chat/completions"
+
+    def test_registered_in_providers_mapping(self):
+        assert "uomirouter" in PROVIDERS
+        assert isinstance(PROVIDERS["uomirouter"]["conversational"], UomiRouterConversationalTask)
 
 
 class TestNvidiaProvider:


### PR DESCRIPTION
## What

Register **UomiRouter** as a new inference provider, mirroring the JS PR.

UomiRouter is an OpenAI-compatible distributed inference network with verifiable on-chain signed responses (UOMI L1 Proof of Computation). Endpoint `https://gateway.uomi.ai`. Open-weight catalog at \$0.10/Mtok input + output.

## Changes

- `src/huggingface_hub/inference/_providers/uomirouter.py` — `UomiRouterConversationalTask` subclassing the conversational base (no overrides; gateway is byte-compatible with the OpenAI shape)
- `_providers/__init__.py` — register `uomirouter` in `PROVIDER_T` literal + `PROVIDERS` mapping (alphabetical between `together` and `wavespeed`)
- `_client.py` + `_generated/_async_client.py` — extend provider list in `InferenceClient`/`AsyncInferenceClient` docstrings per the new-provider guide
- `tests/test_inference_providers.py` — `TestUomiRouterProvider` with 4 cases (attrs, `_prepare_url`, `_prepare_route`, registry)

## Companion PRs

- huggingface.js: https://github.com/huggingface/huggingface.js/pull/2193
- hub-docs: <pending>

## Reviewers

cc @Wauplin @SBrandeis @hanouticelina per the [new-provider checklist](https://huggingface.co/docs/inference-providers/register-as-a-provider).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Provider registration and docs only; no changes to auth, billing, or existing provider behavior beyond a new optional routing target.
> 
> **Overview**
> Registers **UomiRouter** (`uomirouter`) as a Hugging Face inference provider so `InferenceClient` / `AsyncInferenceClient` can route **conversational** (chat completion) calls to `https://gateway.uomi.ai` via the standard OpenAI-compatible `/v1/chat/completions` path.
> 
> Adds `UomiRouterConversationalTask` (thin `BaseConversationalTask` subclass with no custom payload/URL logic), wires it into `PROVIDER_T` and `PROVIDERS`, and documents `uomirouter` in sync and async client docstrings. **Tests** cover provider metadata, URL/route preparation, and registry lookup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcefdef65e874220cf679ecb8defe20193bbe7e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->