### PR TITLE
feat: add production marker for offline/non-production testing (addresses #2820)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,9 @@ env = [
     "HUGGINGFACE_CO_STAGING=1",
     "HUGGING_FACE_HUB_TOKEN=",
 ]
+markers = [
+    "production: tests that connect to the production hub at huggingface.co",
+]
 
 [tool.ruff]
 exclude = [

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -245,7 +245,19 @@ def rmtree_with_retry(path: Union[str, Path]) -> None:
 def with_production_testing(func):
     file_download = patch("huggingface_hub.constants.HUGGINGFACE_CO_URL_TEMPLATE", ENDPOINT_PRODUCTION_URL_SCHEME)
     hf_api = patch("huggingface_hub.constants.ENDPOINT", ENDPOINT_PRODUCTION)
-    return hf_api(file_download(func))
+    patched = hf_api(file_download(func))
+    
+    import pytest
+    if isinstance(patched, type):  # If decorating a class
+        if not hasattr(patched, "pytestmark"):
+            patched.pytestmark = []
+        elif not isinstance(patched.pytestmark, list):
+            patched.pytestmark = [patched.pytestmark]
+        patched.pytestmark.append(pytest.mark.production)
+    else:  # If decorating a function/method
+        patched = pytest.mark.production(patched)
+        
+    return patched
 
 
 def expect_deprecation(function_name: str):


### PR DESCRIPTION
 (addresses #2820)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only pytest configuration and decorator behavior; no library or production runtime paths change.
> 
> **Overview**
> Adds a registered **`production`** pytest marker and wires it into **`with_production_testing`**, so tests that patch the hub to **huggingface.co** are explicitly tagged.
> 
> Decorated **classes** get `pytestmark` updated; decorated **functions** get `pytest.mark.production`. You can run the suite without live production traffic (e.g. `pytest -m "not production"`) while keeping the existing endpoint patches unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc2d75dfa50a58058505c20f93cb08152bdf4cc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->