### PR TITLE
[Internal] Update style bot permissions

### DIFF
--- a/.github/workflows/style-bot.yml
+++ b/.github/workflows/style-bot.yml
@@ -5,7 +5,7 @@ on:
     types: [created]
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 jobs:

--- a/.github/workflows/style-bot.yml
+++ b/.github/workflows/style-bot.yml
@@ -5,7 +5,7 @@ on:
     types: [created]
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
 
 jobs:
@@ -15,4 +15,5 @@ jobs:
       python_quality_dependencies: "[quality]"
       style_command_type: "style_only"
     secrets:
-      bot_token: ${{ secrets.HF_STYLE_BOT_ACTION }}
+      app_id: ${{ secrets.HF_BOT_STYLE_APP_ID }}
+      app_private_key: ${{ secrets.HF_BOT_STYLE_SECRET_PEM }}


### PR DESCRIPTION
Summary

 - Fix the Style Bot workflow, which has been failing for a while at workflow validation time.
 - Pass the required GitHub App secrets (`app_id` and `app_private_key`) to the reusable `style-bot-action.yml` workflow. see #4183.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only secret wiring for the style bot; no application or runtime behavior changes.
> 
> **Overview**
> Fixes the **Style Bot** workflow so it passes validation again by wiring the secrets the reusable `style-bot-action.yml` job actually expects.
> 
> The caller **drops** the legacy `bot_token` (`HF_STYLE_BOT_ACTION`) and **passes** `app_id` and `app_private_key` from `HF_BOT_STYLE_APP_ID` and `HF_BOT_STYLE_SECRET_PEM`, matching the GitHub App token flow used inside the reusable workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9a2057214162f3dab4b533ec6610cf8d7501c9a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->