### PR TITLE
[CLI] Use out singleton in jobs labels commands

### DIFF
--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -747,7 +747,7 @@ def jobs_labels(
     labels = _parse_labels_map(label) or {}
     api = get_hf_api(token=token)
     job = api.update_job_labels(job_id=job_id, labels=labels, namespace=namespace)
-    out.dict(job)
+    out.result("Labels updated", id=job.id)
 
 
 uv_app = typer_factory(help="Run UV scripts (Python with inline dependencies) on HF infrastructure.")

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -747,7 +747,7 @@ def jobs_labels(
     labels = _parse_labels_map(label) or {}
     api = get_hf_api(token=token)
     job = api.update_job_labels(job_id=job_id, labels=labels, namespace=namespace)
-    out.result("Labels updated", id=job.id)
+    out.dict(job)
 
 
 uv_app = typer_factory(help="Run UV scripts (Python with inline dependencies) on HF infrastructure.")

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -1034,7 +1034,7 @@ def scheduled_labels(
     scheduled_job = api.update_scheduled_job_labels(
         scheduled_job_id=scheduled_job_id, labels=labels, namespace=namespace
     )
-    out.result("Labels updated", id=scheduled_job.id)
+    out.dict(job)
 
 
 scheduled_uv_app = typer_factory(help="Schedule UV scripts on HF infrastructure.")

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -1034,7 +1034,7 @@ def scheduled_labels(
     scheduled_job = api.update_scheduled_job_labels(
         scheduled_job_id=scheduled_job_id, labels=labels, namespace=namespace
     )
-    out.dict(job)
+    out.result("Labels updated", id=job.id)
 
 
 scheduled_uv_app = typer_factory(help="Schedule UV scripts on HF infrastructure.")

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -1035,7 +1035,6 @@ def scheduled_labels(
         scheduled_job_id=scheduled_job_id, labels=labels, namespace=namespace
     )
     out.result("Labels updated", id=scheduled_job.id)
-    out.hint(f"Use `hf jobs scheduled inspect {scheduled_job.id}` to view the updated scheduled job.")
 
 
 scheduled_uv_app = typer_factory(help="Schedule UV scripts on HF infrastructure.")

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -748,7 +748,6 @@ def jobs_labels(
     api = get_hf_api(token=token)
     job = api.update_job_labels(job_id=job_id, labels=labels, namespace=namespace)
     out.result("Labels updated", id=job.id)
-    out.hint(f"Use `hf jobs inspect {job.id}` to view the updated job.")
 
 
 uv_app = typer_factory(help="Run UV scripts (Python with inline dependencies) on HF infrastructure.")


### PR DESCRIPTION
## Summary

- Migrate `hf jobs labels` and `hf jobs scheduled labels` to use the `out` singleton instead of `print(json.dumps(...))`, following the same pattern as other mutation commands (`cancel`, `delete`, `suspend`, etc.).
- Fix merge artifacts: restore `update_job_labels` / `update_scheduled_job_labels` exports in `__init__.py` and regenerate CLI reference docs.

Addresses https://github.com/huggingface/huggingface_hub/pull/4252#pullrequestreview-4362206518.

Example output after the change:
```
$ hf jobs labels <job_id> --label env=prod --label team=ml
✓ Labels updated
  id: <job_id>

$ hf jobs scheduled labels <id> --label env=prod
✓ Labels updated
  id: <id>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Scheduled labels likely fails at runtime due to undefined `job`; the regular jobs labels path is a straightforward output change only.
> 
> **Overview**
> **`hf jobs labels`** and **`hf jobs scheduled labels`** no longer dump the full API object as indented JSON; they now use the shared **`out.result`** helper with a short “Labels updated” message and the resource id, matching other mutation commands like **`cancel`** and **`scheduled delete`**.
> 
> In **`scheduled_labels`**, the new success line uses **`id=job.id`**, but that handler only defines **`scheduled_job`**—this looks like a copy-paste bug and would break the scheduled labels command at runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bf842424cfc3437c43ec29345cd663124368846. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->