### PR TITLE
fix(release.yml): restore env: block on 'Detect version' step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,10 +86,11 @@ jobs:
 
       - name: Detect version
         id: version
+        env:
+          RELEASE_TYPE: ${{ inputs.release_type }}
         run: |
           set -euo pipefail
 
-          RELEASE_TYPE="${{ inputs.release_type }}"
           case "$RELEASE_TYPE" in
             minor-prerelease)
               # Read dev version from __init__.py: "1.6.0.dev0" → "1.6.0"


### PR DESCRIPTION
## Summary
- Restores the step-level `env:` block on the `Detect version` step in `.github/workflows/release.yml` that was removed by #4264.
