### PR TITLE
[CI] Add `click` as an explicit dependency (typer 0.26.0 fix)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ def get_version() -> str:
 HF_XET_VERSION = "hf-xet>=1.4.3,<2.0.0"
 
 install_requires = [
+    "click>=8.4.0",
     "filelock>=3.10.0",
     "fsspec>=2023.5.0",
     f"{HF_XET_VERSION}; platform_machine=='x86_64' or platform_machine=='amd64' or platform_machine=='AMD64' or platform_machine=='arm64' or platform_machine=='aarch64'",


### PR DESCRIPTION
## Summary

- Typer 0.26.0 (released 2026-05-26) removed `click` from its required dependencies and now ships a vendored copy of Click internally — see [typer#1774](https://github.com/fastapi/typer/pull/1774).
- We import the public `click` package directly in `cli/_cli_utils.py`, `cli/_help_formatter.py`, and `cli/skills.py`, so we need to declare it explicitly now that typer no longer brings it along.
- This unblocks the `check-imports` CI job, which started failing on every PR today because `from huggingface_hub import *` triggers `cli/_cli_utils.py` (via the lazy loader) and that module's `import click` blew up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only change that restores a previously transitive dependency; no runtime logic changes.
> 
> **Overview**
> Adds **`click>=8.4.0`** to `install_requires` in `setup.py` so the public `click` package is installed directly.
> 
> Typer **0.26.0** no longer pulls in `click` as a dependency, but the hub CLI still imports `click` in modules such as `_cli_utils.py`, `_help_formatter.py`, and `skills.py`. Without this pin, installs and CI checks that load those modules (for example `check-imports` via `from huggingface_hub import *`) can fail when `click` is missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 680e2f1f042ed2a667a8d899fb41bec41ea94147. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->