### PR TITLE
[Internal] Cap typer below 0.26.0 (CLI incompatibility)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ install_requires = [
     "packaging>=20.9",
     "pyyaml>=5.1",
     "tqdm>=4.42.1",
-    "typer>=0.20.0",
+    "typer>=0.20.0,<0.26.0",
     "typing-extensions>=4.1.0",  # to be able to import TypeAlias, dataclass_transform
 ]
 


### PR DESCRIPTION
from @hanouticelina : follow-up to #4270, typer broke other things as well 🙃 

## Summary

Cap `typer` to `<0.26.0` in `install_requires`. Typer 0.26.0 (released 2026-05-26) [vendored Click internally](https://github.com/fastapi/typer/pull/1774), which breaks the `hf` CLI in several ways:

- Every `--help` invocation (e.g. `hf jobs ps --help`, `hf spaces ls --help`) prints help correctly but then dumps `click.exceptions.Exit: 0` to stderr — typer now raises its vendored `typer._click.exceptions.Exit`, which our `HFCliTyperGroup` handling no longer catches.
- The global formatting flags (`--json`, `-q`, `--format`, `--no-truncate`) are no longer intercepted by `_consume_format_flags_for_leaf` — `hf jobs ps --json` prints "No jobs found" instead of `[]`, `hf jobs ps -q` prints the full human table, etc.
- Bucket CLI tests, models ls / webhooks / papers tests fail on CI because of the above.

Local verification:

| typer | `hf jobs ps --help` | `hf jobs ps --json` | `pytest tests/test_cli.py` |
|---|---|---|---|
| 0.26.0 | dumps `Exit(0)` traceback | "No jobs found" (wrong mode) | many failures |
| 0.25.1 | clean exit | `[]` | 250 passed |

This is a **temporary** cap. The real fix is to make `HFCliTyperGroup` (and the rest of the framework in `_cli_utils.py` / `_help_formatter.py`) compatible with typer 0.26.0's vendored-Click internals — happy to open a follow-up issue for that. For now this unblocks CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 89afd0a42def13bc455e3a8deabe9acb5597c3df. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->