### PR TITLE
Fix failing on read-only file system even if the non-existence of file is already cached

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1693,13 +1693,14 @@ def _get_metadata_or_catch_error(
                     commit_hash = http_error.response.headers.get(constants.HUGGINGFACE_HEADER_X_REPO_COMMIT)
                     if commit_hash is not None:
                         no_exist_file_path = Path(storage_folder) / ".no_exist" / commit_hash / relative_filename
-                        try:
-                            no_exist_file_path.parent.mkdir(parents=True, exist_ok=True)
-                            no_exist_file_path.touch()
-                        except OSError as e:
-                            logger.error(
-                                f"Could not cache non-existence of file. Will ignore error and continue. Error: {e}"
-                            )
+                        if not no_exist_file_path.exists():
+                            try:
+                                no_exist_file_path.parent.mkdir(parents=True, exist_ok=True)
+                                no_exist_file_path.touch()
+                            except OSError as e:
+                                logger.error(
+                                    f"Could not cache non-existence of file. Will ignore error and continue. Error: {e}"
+                                )
                         _cache_commit_hash_for_specific_revision(storage_folder, revision, commit_hash)
                 raise
 


### PR DESCRIPTION
For security reason, some CI workflows now using read-only (shared) file system of cache (but the cached files are already in the cache directory, from the CI workflows that have write permission).

This PR avoids such failures - add a condition 

> if not no_exist_file_path.exists():

before trying to create directory and files.


TBH, it's not a hard failure as the log says

```
Could not cache non-existence of file. Will ignore error and continue. Error: [Errno 30] Read-only file system: '/mnt/cache/hub/datasets--hf-internal-testing--librispeech_asr_dummy/.no_exist/5be91486e11a2d616f4ec5db8d3fd248585ac07a/librispeech_asr_dummy.py'
```

So it continues anyway. But the logic of this PR change is still valid IMO.

See a failing run

https://github.com/huggingface/transformers-test-ci/actions/runs/26447817457/job/78022469266

and a run that doesn't have this issue (running against this PR)

https://github.com/huggingface/transformers-test-ci/actions/runs/26500105668/job/78038233032

(the fetch hub objects step)



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small guard around optional cache bookkeeping on 404; no change to download success paths or auth.
> 
> **Overview**
> When the Hub returns **404** for a file, `huggingface_hub` records that fact under `.no_exist/<commit_hash>/<path>` so later lookups can skip the network. The PR **skips** `mkdir`/`touch` when that marker **already exists**.
> 
> That avoids noisy **read-only filesystem** errors in CI jobs that mount a shared, pre-populated cache (writable in an earlier step, read-only afterward). Behavior is unchanged when the marker is missing and the cache is writable; commit-hash ref caching still runs either way.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 702a8f5f8a4a1ace16ce2c62ec5a5f9ae9708399. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->