### PR TITLE
[Internal] Use Comment bot in model card gh action

### DIFF
--- a/.github/workflows/model_card_consistency_reminder.yml
+++ b/.github/workflows/model_card_consistency_reminder.yml
@@ -11,11 +11,18 @@ jobs:
   comment:
     runs-on: ubuntu-latest
     steps:
+      - name: Create GitHub App token
+        id: app_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          app-id: ${{ secrets.COMMENT_BOT_APP_ID }}
+          private-key: ${{ secrets.COMMENT_BOT_SECRET_PEM }}
+
       - name: maintain-comment
         uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0  # v3.0.4
         with:
           header: model-card-consistency
-          GITHUB_TOKEN: ${{ secrets.comment_bot_token }}
+          GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
           message: |
             It looks like you've updated code related to model or dataset cards in this PR.
 

--- a/.github/workflows/model_card_consistency_reminder.yml
+++ b/.github/workflows/model_card_consistency_reminder.yml
@@ -17,7 +17,8 @@ jobs:
         with:
           app-id: ${{ secrets.COMMENT_BOT_APP_ID }}
           private-key: ${{ secrets.COMMENT_BOT_SECRET_PEM }}
-
+      owner: ${{ github.repository_owner }}
+      repositories: ${{ github.event.repository.name }}
       - name: maintain-comment
         uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0  # v3.0.4
         with:

--- a/.github/workflows/model_card_consistency_reminder.yml
+++ b/.github/workflows/model_card_consistency_reminder.yml
@@ -17,8 +17,8 @@ jobs:
         with:
           app-id: ${{ secrets.COMMENT_BOT_APP_ID }}
           private-key: ${{ secrets.COMMENT_BOT_SECRET_PEM }}
-      owner: ${{ github.repository_owner }}
-      repositories: ${{ github.event.repository.name }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
       - name: maintain-comment
         uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0  # v3.0.4
         with:


### PR DESCRIPTION
Should solve https://github.com/huggingface/tracking-issues/issues/781. To be merged instead of https://github.com/huggingface/huggingface_hub/pull/4276.

Once merged we can remove `comment_bot_token` from this repo settings.

cc @paulinebm 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only GitHub Actions credential wiring changes; no runtime library or user-facing behavior is modified.
> 
> **Overview**
> The **model and dataset card consistency reminder** workflow now authenticates PR comments with a **GitHub App** instead of a long-lived `comment_bot_token` secret.
> 
> A new **Create GitHub App token** step uses `actions/create-github-app-token` with `COMMENT_BOT_APP_ID` and `COMMENT_BOT_SECRET_PEM`, scoped to the repo owner and current repository. The sticky comment step’s `GITHUB_TOKEN` is wired to that minted token. The reminder message and path triggers are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dc22ef6706077094fc3604289452676158cb4ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->