### PR TITLE
Fix typos in comments and debug log message

### DIFF
--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -50,7 +50,7 @@ SAFETENSORS_SINGLE_FILE = "model.safetensors"
 SAFETENSORS_INDEX_FILE = "model.safetensors.index.json"
 SAFETENSORS_MAX_HEADER_LENGTH = 25_000_000
 
-# Timeout of aquiring file lock and logging the attempt
+# Timeout of acquiring file lock and logging the attempt
 FILELOCK_LOG_EVERY_SECONDS = 10
 
 # Git-related constants

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -439,7 +439,7 @@ def http_get(
             except (httpx.ConnectError, httpx.TimeoutException) as e:
                 # If ConnectionError (SSLError) or ReadTimeout happen while streaming data from the server, it is most likely
                 # a transient error (network outage?). We log a warning message and try to resume the download a few times
-                # before giving up. Tre retry mechanism is basic but should be enough in most cases.
+                # before giving up. The retry mechanism is basic but should be enough in most cases.
                 if _nb_retries <= 0:
                     logger.warning("Error while downloading from %s: %s\nMax retries exceeded.", url, str(e))
                     raise

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -4900,7 +4900,7 @@ class HfApi:
                     )
 
         logger.debug(
-            f"About to commit to the hub: {len(additions)} addition(s), {len(copies)} copie(s) and"
+            f"About to commit to the hub: {len(additions)} addition(s), {len(copies)} copy(ies) and"
             f" {nb_deletions} deletion(s)."
         )
 
@@ -8268,7 +8268,7 @@ class HfApi:
             ```
         """
         # - Spaces /logs/{run|build} is SSE with `data: {"data": "...", "timestamp": "..."}` events.
-        # - Keep-alives are sent as empty `data:` messages (skipped by the `data: {` filter).
+        # - Keep-alive messages are sent as empty `data:` events (skipped by the `data: {` filter).
         # - In no-follow mode we use a short read timeout to drain the buffer and return.
         timeout = 120 if follow else 5
         for event in self._fetch_space_logs_sse(


### PR DESCRIPTION
Small typo cleanup — comments and a debug log message only. **No functional changes.**

## What

| File | Before | After |
|---|---|---|
| `src/huggingface_hub/constants.py` | `# Timeout of aquiring file lock…` | `# Timeout of acquiring file lock…` |
| `src/huggingface_hub/file_download.py` | `# …give up. Tre retry mechanism…` | `# …give up. The retry mechanism…` |
| `src/huggingface_hub/hf_api.py` (`create_commit` debug log) | `{len(copies)} copie(s)` | `{len(copies)} copy(ies)` |
| `src/huggingface_hub/hf_api.py` (SSE comment) | `# Keep-alives are sent as empty data: messages` | `# Keep-alive messages are sent as empty data: events` |

## Why

All four were caught by `codespell` against `src/`. The `copie(s)` one is a user-visible `logger.debug` line; the other three are inline comments. Each fix is one or two tokens — easy to review and revert if needed.

## Out of scope (intentionally not touched)

- `cachable` in `hf_file_system.py` — that's the fsspec `AbstractFileSystem.cachable` class attribute, not a typo.
- `uncommited` in `_hot_reload/types.py` — it's a `TypedDict` field name that matches a documented API contract.
- Typos in `tests/` — those are inside test fixture string literals (e.g. `"spaeces/user/id"  # with typo in repo type`) and changing them would break the test intent.
- Translated docs (`docs/source/de/…` etc.) — left for native speakers.

## Test

No behavioural change, no new tests needed. `make quality` and `make style` are no-ops on a comment/string change like this.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-only edits to comments and debug logging; no runtime, API, or security impact.
> 
> **Overview**
> This PR is **comment and log-string typo cleanup only** — no behavior changes.
> 
> It fixes **codespell** issues in `constants.py` (file-lock comment: *acquiring*), `file_download.py` (download retry comment: *The*), and `hf_api.py` (commit debug log: *copy(ies)* instead of *copie(s)*, plus a clearer SSE keep-alive comment for Space logs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e96d524343bb15c90d96c7f59394d61f49a2cbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->