### PR TITLE
[CLI] Add `hf repos ls` command

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -1305,7 +1305,7 @@ REPOSITORY                TYPE     UPDATED      VISIBILITY   STORAGE  % OF TOTAL
 username/bucket-raw       bucket   2026-04-29   public        1.7 TB       72.3%
 username/my-model         model    2026-05-06   public        4.8 GB       18.1%
 username/my-dataset       dataset  2024-09-14   private     598.4 MB        5.2%
-ℹ Showing 30 of 42 repos. Use `--limit 0` to list all.
+Hint: Showing 30 of 42 repos. Use `--limit 0` to list all.
 ```
 
 Filter by repository type, search by name, or adjust the limit:

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -1291,7 +1291,48 @@ To view the diff of a pull request directly in your terminal, use `hf discussion
 
 ## hf repos
 
-`hf repos` lets you create, delete, move repositories, update their settings, and delete files on the Hugging Face Hub. It also includes subcommands to manage branches and tags.
+`hf repos` lets you list, create, delete, move repositories, update their settings, and delete files on the Hugging Face Hub. It also includes subcommands to manage branches and tags.
+
+### List repos
+
+Use `hf repos ls` to list all your repositories (models, datasets, spaces, and buckets) with storage information, sorted by storage usage. By default, only the first 25 repos are shown:
+
+```bash
+# List all your repos (first 25)
+>>> hf repos ls
+REPOSITORY                TYPE     UPDATED      VISIBILITY   STORAGE  % OF TOTAL
+------------------------  -------  ----------   ----------  --------  ----------
+username/bucket-raw       bucket   2026-04-29   public        1.7 TB       72.3%
+username/my-model         model    2026-05-06   public        4.8 GB       18.1%
+username/my-dataset       dataset  2024-09-14   private     598.4 MB        5.2%
+ℹ Showing 25 of 42 repos. Use `--limit 0` to list all.
+```
+
+Filter by repository type, search by name, or adjust the limit:
+
+```bash
+# List only models
+>>> hf repos ls --type model
+
+# Search by name
+>>> hf repos ls --search "bert"
+
+# List repos from an organization
+>>> hf repos ls --namespace my-org
+
+# Combine filters
+>>> hf repos ls --namespace my-org --type dataset --search "train"
+
+# List all repos (no limit)
+>>> hf repos ls --limit 0
+```
+
+Use `--format json` for scripting or `-q` for IDs only. When piping, use `--limit 0` to export all repos:
+
+```bash
+>>> hf repos ls --limit 0 --format json | jq '.[].id'
+>>> hf repos ls -q
+```
 
 ### Create a repo
 

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -1295,17 +1295,17 @@ To view the diff of a pull request directly in your terminal, use `hf discussion
 
 ### List repos
 
-Use `hf repos ls` to list all your repositories (models, datasets, spaces, and buckets) with storage information, sorted by storage usage. By default, only the first 25 repos are shown:
+Use `hf repos ls` to list all your repositories (models, datasets, spaces, and buckets) with storage information, sorted by storage usage. By default, only the first 30 repos are shown:
 
 ```bash
-# List all your repos (first 25)
+# List all your repos (first 30)
 >>> hf repos ls
 REPOSITORY                TYPE     UPDATED      VISIBILITY   STORAGE  % OF TOTAL
 ------------------------  -------  ----------   ----------  --------  ----------
 username/bucket-raw       bucket   2026-04-29   public        1.7 TB       72.3%
 username/my-model         model    2026-05-06   public        4.8 GB       18.1%
 username/my-dataset       dataset  2024-09-14   private     598.4 MB        5.2%
-ℹ Showing 25 of 42 repos. Use `--limit 0` to list all.
+ℹ Showing 30 of 42 repos. Use `--limit 0` to list all.
 ```
 
 Filter by repository type, search by name, or adjust the limit:

--- a/docs/source/en/guides/repository.md
+++ b/docs/source/en/guides/repository.md
@@ -26,6 +26,33 @@ repositories on the Hub, especially:
 If you want to create and manage a repository on the Hub, your machine must be logged in. If you are not, please refer to
 [this section](../quick-start#authentication). In the rest of this guide, we will assume that your machine is logged in.
 
+## List your repositories
+
+You can list all repositories (models, datasets, spaces, and buckets) for your account or an organization using [`list_user_repos`]. Results include storage information and are sorted by storage usage.
+
+```py
+>>> from huggingface_hub import list_user_repos
+
+# List repos for the authenticated user
+>>> repos = list(list_user_repos())
+>>> for repo in repos[:3]:
+...     print(f"{repo.id} ({repo.type}) - {repo.storage} bytes")
+username/my-model (model) - 4828692480 bytes
+username/my-dataset (dataset) - 598427559 bytes
+username/my-space (space) - 120620146 bytes
+
+# List repos from an organization
+>>> repos = list(list_user_repos(namespace="my-org"))
+```
+
+Or via CLI (shows 25 repos by default, use `--limit 0` to list all):
+
+```bash
+>>> hf repos ls
+>>> hf repos ls --namespace my-org --type model
+>>> hf repos ls --limit 0 --format json | jq '.[].id'
+```
+
 ## Repo creation and deletion
 
 The first step is to know how to create and delete repositories. You can only manage repositories that you own (under

--- a/docs/source/en/guides/repository.md
+++ b/docs/source/en/guides/repository.md
@@ -45,7 +45,7 @@ username/my-space (space) - 120620146 bytes
 >>> repos = list(list_user_repos(namespace="my-org"))
 ```
 
-Or via CLI (shows 25 repos by default, use `--limit 0` to list all):
+Or via CLI (shows 30 repos by default, use `--limit 0` to list all):
 
 ```bash
 >>> hf repos ls

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -3001,6 +3001,7 @@ $ hf repos [OPTIONS] COMMAND [ARGS]...
 * `delete`: Delete a repo from the Hub.
 * `delete-files`: Delete files from a repo on the Hub.
 * `duplicate`: Duplicate a repo on the Hub (model,...
+* `list`: List all repos (models, datasets, spaces,... [alias: ls]
 * `move`: Move a repository from a namespace to...
 * `settings`: Update the settings of a repository.
 * `tag`: Manage tags for a repo on the Hub.
@@ -3234,6 +3235,35 @@ Examples
   $ hf repos duplicate openai/gdpval --type dataset
   $ hf repos duplicate multimodalart/dreambooth-training my-dreambooth --type space --flavor l4x4 --secrets HF_TOKEN --private
   $ hf repos duplicate org/my-space my-space --type space -v hf://org/my-model:/models -v hf://buckets/org/b:/data
+
+Learn more
+  Use `hf <command> --help` for more information about a command.
+  Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
+
+
+### `hf repos list`
+
+List all repos (models, datasets, spaces, buckets) with storage info. [alias: ls]
+
+**Usage**:
+
+```console
+$ hf repos list [OPTIONS]
+```
+
+**Options**:
+
+* `--namespace TEXT`: Organization name. If not provided, lists repos for the authenticated user.
+* `--type, --repo-type [model|dataset|space|bucket]`: Filter by repository type (model, dataset, space, or bucket).
+* `--search TEXT`: Search query.
+* `--limit INTEGER`: Limit the number of results.  [default: 25]
+* `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
+* `--help`: Show this message and exit.
+
+Examples
+  $ hf repos ls
+  $ hf repos ls --type model
+  $ hf repos ls --namespace my-org --search bert
 
 Learn more
   Use `hf <command> --help` for more information about a command.

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -3256,7 +3256,7 @@ $ hf repos list [OPTIONS]
 * `--namespace TEXT`: Organization name. If not provided, lists repos for the authenticated user.
 * `--type, --repo-type [model|dataset|space|bucket]`: Filter by repository type (model, dataset, space, or bucket).
 * `--search TEXT`: Search query.
-* `--limit INTEGER`: Limit the number of results.  [default: 25]
+* `--limit INTEGER`: Limit the number of results.  [default: 30]
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `--help`: Show this message and exit.
 

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -191,6 +191,7 @@ _SUBMOD_ATTRS = {
         "Organization",
         "RepoFile",
         "RepoFolder",
+        "RepoStorageInfo",
         "RepoUrl",
         "SpaceInfo",
         "SpaceSearchResult",
@@ -302,6 +303,7 @@ _SUBMOD_ATTRS = {
         "list_spaces_hardware",
         "list_user_followers",
         "list_user_following",
+        "list_user_repos",
         "list_webhooks",
         "merge_pull_request",
         "model_info",
@@ -803,6 +805,7 @@ __all__ = [
     "RepoCard",
     "RepoFile",
     "RepoFolder",
+    "RepoStorageInfo",
     "RepoUrl",
     "SentenceSimilarityInput",
     "SentenceSimilarityInputData",
@@ -1036,6 +1039,7 @@ __all__ = [
     "list_spaces_hardware",
     "list_user_followers",
     "list_user_following",
+    "list_user_repos",
     "list_webhooks",
     "load_state_dict_from_file",
     "load_torch_model",
@@ -1347,6 +1351,7 @@ if TYPE_CHECKING:  # pragma: no cover
         Organization,  # noqa: F401
         RepoFile,  # noqa: F401
         RepoFolder,  # noqa: F401
+        RepoStorageInfo,  # noqa: F401
         RepoUrl,  # noqa: F401
         SpaceInfo,  # noqa: F401
         SpaceSearchResult,  # noqa: F401
@@ -1458,6 +1463,7 @@ if TYPE_CHECKING:  # pragma: no cover
         list_spaces_hardware,  # noqa: F401
         list_user_followers,  # noqa: F401
         list_user_following,  # noqa: F401
+        list_user_repos,  # noqa: F401
         list_webhooks,  # noqa: F401
         merge_pull_request,  # noqa: F401
         model_info,  # noqa: F401

--- a/src/huggingface_hub/cli/repos.py
+++ b/src/huggingface_hub/cli/repos.py
@@ -168,7 +168,7 @@ def repo_list(
         repos = repos[:limit]
     items = [
         {
-            "repository": r.id,
+            "id": r.id,
             "type": r.type,
             "updated": r.updated_at.strftime("%Y-%m-%d"),
             "visibility": r.visibility,
@@ -177,7 +177,7 @@ def repo_list(
         }
         for r in repos
     ]
-    out.table(items, id_key="repository", alignments={"storage": "right", "%_of_total": "right"})
+    out.table(items, id_key="id", alignments={"storage": "right", "%_of_total": "right"})
     if limit > 0 and total > limit:
         out.hint(f"Showing {limit} of {total} repos. Use `--limit 0` to list all.")
 

--- a/src/huggingface_hub/cli/repos.py
+++ b/src/huggingface_hub/cli/repos.py
@@ -35,6 +35,7 @@ from huggingface_hub.errors import CLIError, HfHubHTTPError, RepositoryNotFoundE
 from huggingface_hub.hf_api import REPO_REGIONS
 
 from ._cli_utils import (
+    REPO_LIST_DEFAULT_LIMIT,
     EnvFileOpt,
     EnvOpt,
     LimitOpt,
@@ -151,7 +152,7 @@ def repo_list(
         ),
     ] = None,
     search: SearchOpt = None,
-    limit: LimitOpt = 25,
+    limit: LimitOpt = REPO_LIST_DEFAULT_LIMIT,
     token: TokenOpt = None,
 ) -> None:
     """List all repos (models, datasets, spaces, buckets) with storage info."""

--- a/src/huggingface_hub/cli/repos.py
+++ b/src/huggingface_hub/cli/repos.py
@@ -37,11 +37,13 @@ from huggingface_hub.hf_api import REPO_REGIONS
 from ._cli_utils import (
     EnvFileOpt,
     EnvOpt,
+    LimitOpt,
     PrivateOpt,
     RepoIdArg,
     RepoType,
     RepoTypeOpt,
     RevisionOpt,
+    SearchOpt,
     SecretsFileOpt,
     SecretsOpt,
     TokenOpt,
@@ -52,6 +54,7 @@ from ._cli_utils import (
     parse_volumes,
     typer_factory,
 )
+from ._file_listing import format_size
 from ._output import out
 
 
@@ -64,10 +67,11 @@ def _repos_callback(ctx: typer.Context) -> None:
         out.warning("`hf repo` is deprecated in favor of `hf repos`.")
 
 
-tag_cli = typer_factory(help="Manage tags for a repo on the Hub.")
-branch_cli = typer_factory(help="Manage branches for a repo on the Hub.")
-repos_cli.add_typer(tag_cli, name="tag")
-repos_cli.add_typer(branch_cli, name="branch")
+class RepoTypeAll(str, enum.Enum):
+    model = "model"
+    dataset = "dataset"
+    space = "space"
+    bucket = "bucket"
 
 
 class GatedChoices(str, enum.Enum):
@@ -115,6 +119,66 @@ SpaceSleepTimeOpt = Annotated[
         help="Seconds of inactivity before the Space is put to sleep. Use -1 to disable. Only for Spaces.",
     ),
 ]
+
+
+tag_cli = typer_factory(help="Manage tags for a repo on the Hub.")
+branch_cli = typer_factory(help="Manage branches for a repo on the Hub.")
+repos_cli.add_typer(tag_cli, name="tag")
+repos_cli.add_typer(branch_cli, name="branch")
+
+
+@repos_cli.command(
+    "list | ls",
+    examples=[
+        "hf repos ls",
+        "hf repos ls --type model",
+        "hf repos ls --namespace my-org --search bert",
+    ],
+)
+def repo_list(
+    namespace: Annotated[
+        str | None,
+        typer.Option(
+            help="Organization name. If not provided, lists repos for the authenticated user.",
+        ),
+    ] = None,
+    repo_type: Annotated[
+        RepoTypeAll | None,
+        typer.Option(
+            "--type",
+            "--repo-type",
+            help="Filter by repository type (model, dataset, space, or bucket).",
+        ),
+    ] = None,
+    search: SearchOpt = None,
+    limit: LimitOpt = 25,
+    token: TokenOpt = None,
+) -> None:
+    """List all repos (models, datasets, spaces, buckets) with storage info."""
+    api = get_hf_api(token=token)
+    repos = list(api.list_user_repos(namespace=namespace, token=token))
+    if repo_type is not None:
+        repos = [r for r in repos if r.type == repo_type.value]
+    if search is not None:
+        search_lower = search.lower()
+        repos = [r for r in repos if search_lower in r.id.lower()]
+    total = len(repos)
+    if limit > 0:
+        repos = repos[:limit]
+    items = [
+        {
+            "repository": r.id,
+            "type": r.type,
+            "updated": r.updated_at.strftime("%Y-%m-%d"),
+            "visibility": r.visibility,
+            "storage": format_size(r.storage, human_readable=True),
+            "%_of_total": f"{r.storage_percent:.1f}%",
+        }
+        for r in repos
+    ]
+    out.table(items, id_key="repository", alignments={"storage": "right", "%_of_total": "right"})
+    if limit > 0 and total > limit:
+        out.hint(f"Showing {limit} of {total} repos. Use `--limit 0` to list all.")
 
 
 @repos_cli.command(

--- a/src/huggingface_hub/cli/repos.py
+++ b/src/huggingface_hub/cli/repos.py
@@ -157,7 +157,7 @@ def repo_list(
 ) -> None:
     """List all repos (models, datasets, spaces, buckets) with storage info."""
     api = get_hf_api(token=token)
-    repos = list(api.list_user_repos(namespace=namespace, token=token))
+    repos = list(api.list_user_repos(namespace=namespace))
     if repo_type is not None:
         repos = [r for r in repos if r.type == repo_type.value]
     if search is not None:

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -1642,7 +1642,7 @@ class RepoStorageInfo:
         self.updated_at = parse_datetime(kwargs["updatedAt"])
         self.visibility = kwargs["visibility"]
         self.storage = kwargs["storage"]
-        self.storage_percent = kwargs.get("storagePercent", 0)
+        self.storage_percent = kwargs.get("storagePercent") or 0
 
 
 @dataclass

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -1608,6 +1608,44 @@ class UserLikes:
 
 
 @dataclass
+class RepoStorageInfo:
+    """
+    Contains storage information about a repository on the Hub.
+
+    Returned by [`list_user_repos`].
+
+    Attributes:
+        id (`str`):
+            ID of the repo (e.g. `username/repo-name`).
+        type (`str`):
+            Type of the repo (`model`, `dataset`, `space`, or `bucket`).
+        updated_at (`datetime`):
+            Last update time of the repo.
+        visibility (`str`):
+            Visibility of the repo (`public` or `private`).
+        storage (`int`):
+            Storage used by the repo in bytes.
+        storage_percent (`float`):
+            Percentage of the namespace's total storage used by this repo.
+    """
+
+    id: str
+    type: str
+    updated_at: datetime
+    visibility: str
+    storage: int
+    storage_percent: float
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.id = kwargs["id"]
+        self.type = kwargs["type"]
+        self.updated_at = parse_datetime(kwargs["updatedAt"])
+        self.visibility = kwargs["visibility"]
+        self.storage = kwargs["storage"]
+        self.storage_percent = kwargs.get("storagePercent", 0)
+
+
+@dataclass
 class Organization:
     """
     Contains information about an organization on the Hub.
@@ -3084,6 +3122,46 @@ class HfApi:
             datasets=[like["repo"]["name"] for like in likes if like["repo"]["type"] == "dataset"],
             spaces=[like["repo"]["name"] for like in likes if like["repo"]["type"] == "space"],
         )
+
+    def list_user_repos(
+        self,
+        namespace: str | None = None,
+        *,
+        token: bool | str | None = None,
+    ) -> Iterable[RepoStorageInfo]:
+        """List all repositories (models, datasets, spaces, buckets) for a user or organization with storage info.
+
+        Uses the `/api/settings/repositories` endpoint for the authenticated user or
+        `/api/organizations/{namespace}/settings/repositories` for an organization.
+
+        Args:
+            namespace (`str`, *optional*):
+                Organization name. If not provided, lists repos for the authenticated user.
+            token (`bool` or `str`, *optional*):
+                A valid user access token. Defaults to the locally saved token.
+
+        Returns:
+            `Iterable[RepoStorageInfo]`: An iterable of [`RepoStorageInfo`] objects.
+
+        Example:
+        ```python
+        >>> from huggingface_hub import list_user_repos
+
+        >>> repos = list(list_user_repos())
+        >>> repos[0]
+        RepoStorageInfo(id='username/my-model', type='model', ...)
+
+        >>> # List repos from an organization
+        >>> repos = list(list_user_repos(namespace="my-org"))
+        ```
+        """
+        if namespace is not None:
+            path = f"{self.endpoint}/api/organizations/{namespace}/settings/repositories"
+        else:
+            path = f"{self.endpoint}/api/settings/repositories"
+        headers = self._build_hf_headers(token=token)
+        for item in paginate(path, params={}, headers=headers):
+            yield RepoStorageInfo(**item)
 
     @validate_hf_hub_args
     def list_repo_likers(
@@ -14071,6 +14149,7 @@ run_as_future = api.run_as_future
 # Activity API
 list_liked_repos = api.list_liked_repos
 list_repo_likers = api.list_repo_likers
+list_user_repos = api.list_user_repos
 unlike = api.unlike
 
 # Community API

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1649,7 +1649,7 @@ class TestRepoListCommand:
 
         output = json.loads(result.stdout)
         assert len(output) == 1
-        assert output[0]["repository"] == model_id
+        assert output[0]["id"] == model_id
         assert output[0]["type"] == "model"
 
         api.delete_repo(model_id)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,6 +11,7 @@ import pytest
 import typer
 from typer.testing import CliRunner
 
+from huggingface_hub import HfApi
 from huggingface_hub._dataset_viewer import DatasetParquetEntry
 from huggingface_hub._jobs_api import JobInfo, _create_job_spec
 from huggingface_hub._space_api import Volume
@@ -33,7 +34,7 @@ from huggingface_hub.utils import (
 from huggingface_hub.utils._verification import FolderVerification
 
 from .testing_constants import TOKEN
-from .testing_utils import DUMMY_MODEL_ID, requires, with_production_testing
+from .testing_utils import DUMMY_MODEL_ID, repo_name, requires, with_production_testing
 
 
 @pytest.fixture
@@ -1628,6 +1629,32 @@ class TestRepoSettingsCommand:
         assert kwargs["repo_type"] == "dataset"
         assert kwargs["visibility"] == "private"
         assert kwargs["gated"] == "manual"
+
+
+class TestRepoListCommand:
+    def test_repo_list(self, runner: CliRunner) -> None:
+        """Integration test: create repos, check `hf repos ls` with search + type filter."""
+        api = HfApi(token=TOKEN)
+        suffix = repo_name("repos-ls")
+        model_id = api.create_repo(suffix, repo_type="model").repo_id
+        dataset_id = api.create_repo(suffix, repo_type="dataset").repo_id
+        space_id = api.create_repo(suffix, repo_type="space", space_sdk="static").repo_id
+
+        api.upload_file(repo_id=model_id, path_in_repo="data.bin", path_or_fileobj=b"x" * 1024)
+
+        with patch("huggingface_hub.cli.repos.get_hf_api", return_value=api):
+            result = runner.invoke(
+                app, ["repos", "ls", "--type", "model", "--search", suffix, "--limit", "0", "--format", "json"]
+            )
+
+        output = json.loads(result.stdout)
+        assert len(output) == 1
+        assert output[0]["repository"] == model_id
+        assert output[0]["type"] == "model"
+
+        api.delete_repo(model_id)
+        api.delete_repo(dataset_id, repo_type="dataset")
+        api.delete_repo(space_id, repo_type="space")
 
 
 class TestRepoDeleteCommand:


### PR DESCRIPTION
## Summary

Add `hf repos ls` / `hf repos list` CLI command to list all repos (models, datasets, spaces, buckets) for the authenticated user or an organization, with storage info. Uses the `/api/settings/repositories` endpoint (shipped in https://github.com/huggingface-internal/moon-landing/pull/17996).

- Adds `list_user_repos()` to `HfApi` (returns `Iterable[RepoStorageInfo]`, forward-compatible with pagination)
- Supports `--type`, `--search`, `--namespace`, `--limit` (defaults to 30, same as `hf models ls`) and `--format` flags
- Docs updated (cli.md guide, repository.md guide, auto-generated CLI reference)

```
$ hf repos ls
REPOSITORY                                        TYPE     UPDATED     VISIBILITY    STORAGE  % OF TOTAL
------------------------------------------------  -------  ----------  ----------  ---------  ----------
Wauplin/bucket-raw                                bucket   2026-04-29  public         1.7 TB       85.8%
Wauplin/noaa-ghcn-pds                             bucket   2026-05-18  private      265.9 GB       13.8%
Wauplin/test-upload-v2                            model    2026-05-06  public         4.8 GB        0.2%
Wauplin/alphageometry                             model    2024-01-18  public         1.2 GB        0.1%
Wauplin/my-cool-mamba                             model    2024-07-16  public       516.6 MB        0.0%
Wauplin/example-space-to-dataset-image-zip        dataset  2023-06-13  public       214.0 MB        0.0%
Wauplin/test-cloudfront-unauth                    model    2026-03-09  public       125.2 MB        0.0%
Wauplin/gradio-oauth                              space    2024-07-31  private      120.6 MB        0.0%
Wauplin/gpt-oss-rag-dev                           dataset  2025-08-15  private       83.1 MB        0.0%
Wauplin/example-space-to-dataset-parquet          dataset  2023-06-29  public        65.4 MB        0.0%
...
ℹ Showing 30 of 69 repos. Use `--limit 0` to list all.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only listing against new settings endpoints; no auth, upload, or repo mutation logic changed beyond exports and CLI wiring.
> 
> **Overview**
> Adds **`hf repos ls`** / **`hf repos list`** and a matching Python API so you can see all Hub repos you own (models, datasets, spaces, buckets) with **storage size and % of namespace total**, sorted by storage.
> 
> **API:** New `RepoStorageInfo` dataclass and `HfApi.list_user_repos()` / top-level `list_user_repos()` call the settings repositories endpoints (user or `--namespace` org), with paginated responses.
> 
> **CLI:** `repo_list` fetches the full list, applies client-side `--type`, `--search`, and `--limit` (default 30, `--limit 0` for all), then prints a table with human-readable storage; standard `--format json` / `-q` work via existing output helpers.
> 
> **Docs & tests:** CLI guide, repository guide, and package CLI reference document the command; an integration test exercises `repos ls` with type/search filters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed7f4cbfaacb819e2af084d67373c50242448012. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->