### PR TITLE
[CLI] Migrate `extensions`, `lfs-enable-largefiles`, `version` to `out` singleton

### DIFF
--- a/src/huggingface_hub/cli/extensions.py
+++ b/src/huggingface_hub/cli/extensions.py
@@ -129,8 +129,12 @@ def extension_install(
         description=description,
     )
     ext_type = manifest.type.capitalize()
-    print(f"{ext_type} extension installed successfully from {owner}/{repo_name}.")
-    print(f"Run it with: hf {short_name}")
+    out.result(
+        f"{ext_type} extension installed",
+        source=f"{owner}/{repo_name}",
+        command=f"hf {short_name}",
+    )
+    out.hint(f"Run it with: hf {short_name}")
 
 
 @extensions_cli.command(
@@ -221,7 +225,7 @@ def extension_remove(
         raise CLIError(f"Extension '{short_name}' is not installed.")
 
     shutil.rmtree(extension_dir)
-    print(f"Removed extension '{short_name}'.")
+    out.result("Extension removed", name=short_name)
 
 
 ### HELPER FUNCTIONS

--- a/src/huggingface_hub/cli/lfs.py
+++ b/src/huggingface_hub/cli/lfs.py
@@ -29,6 +29,7 @@ from huggingface_hub.lfs import LFS_MULTIPART_UPLOAD_COMMAND
 
 from ..utils import get_session, hf_raise_for_status, logging
 from ..utils._lfs import SliceFileObj
+from ._output import out
 
 
 logger = logging.get_logger(__name__)
@@ -61,7 +62,7 @@ def lfs_enable_largefiles(
         check=True,
         cwd=local_path,
     )
-    print("Local repo set up for largefiles")
+    out.result("Local repo set up for largefiles", path=local_path)
 
 
 def write_msg(msg: dict):

--- a/src/huggingface_hub/cli/system.py
+++ b/src/huggingface_hub/cli/system.py
@@ -29,7 +29,7 @@ def env() -> None:
 
 def version() -> None:
     """Print information about the hf version."""
-    print(__version__)
+    out.result("hf version", version=__version__)
 
 
 def update() -> None:


### PR DESCRIPTION
Part of #3979. Migrates the last few stragglers that still used `print()` directly: `hf extensions install`, `hf extensions remove`, `hf lfs-enable-largefiles`, and `hf version`.

- `hf extensions install` → `out.result("<Type> extension installed", source=..., command=...)` + an `out.hint("Run it with: hf <name>")` for the follow-up.
- `hf extensions remove` → `out.result("Extension removed", name=...)`.
- `hf lfs-enable-largefiles` → `out.result("Local repo set up for largefiles", path=...)`.
- `hf version` (the subcommand) → `out.result("hf version", version=...)`. The global `--version` flag in `hf.py` keeps its raw `print(__version__)` because it fires as an eager Typer callback before `out` is set up.

`hf extensions ls` and `hf extensions search` were already migrated in #4057 — this PR just cleans up the leftover write paths in the same module.

## Examples

```
$ hf version
✓ hf version
  version: 1.17.0.dev0

$ hf version --format json
{"version": "1.17.0.dev0"}

$ hf version --format quiet
1.17.0.dev0

$ hf version --format agent
version=1.17.0.dev0
```

```
$ hf lfs-enable-largefiles ./my-repo
✓ Local repo set up for largefiles
  path: /Users/celina/my-repo

$ hf lfs-enable-largefiles ./my-repo --format json
{"path": "/Users/celina/my-repo"}
```

```
$ hf extensions install gradio-app/hf-gradio
✓ Python extension installed
  source: gradio-app/hf-gradio
  command: hf gradio
Hint: Run it with: hf gradio

$ hf extensions remove gradio
✓ Extension removed
  name: gradio
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Output-only changes with no behavior to auth, uploads, or extension install logic beyond formatting.
> 
> **Overview**
> Finishes the CLI output migration (#3979) by replacing the last direct **`print()`** calls in **`extensions`**, **`lfs-enable-largefiles`**, and the **`version`** subcommand with the shared **`out`** helpers.
> 
> **`hf extensions install`** now reports success via **`out.result`** (type, source, command) and uses **`out.hint`** for the run command. **`hf extensions remove`** and **`hf lfs-enable-largefiles`** use **`out.result`** with structured fields. **`hf version`** prints through **`out.result`** so **`--format`** (json, quiet, agent) works like other commands; the global **`--version`** flag is unchanged and still prints raw text before **`out`** is initialized.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8cceae81e638769432bd19b47837715333af40c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->