### PR TITLE
[CLI] Drop legacy printing helpers from `_cli_utils.py`

### DIFF
--- a/src/huggingface_hub/cli/_cli_utils.py
+++ b/src/huggingface_hub/cli/_cli_utils.py
@@ -41,7 +41,7 @@ from huggingface_hub.utils import (
 from huggingface_hub.utils._dotenv import load_dotenv
 
 from ._help_formatter import StyledContext
-from ._output import OutputFormatWithAuto, out
+from ._output import OutputFormat, out
 
 
 logger = logging.get_logger()
@@ -432,7 +432,7 @@ def _consume_format_flags_for_leaf(cmd: click.Command, args: list[str]) -> None:
         return
 
     # Strip --format/--json/-q/--quiet from 'args' and apply to 'out'
-    chosen_mode: OutputFormatWithAuto = OutputFormatWithAuto.auto
+    chosen_mode: OutputFormat = OutputFormat.auto
     chosen_flag: str | None = None
 
     def _check_conflict(new_flag: str) -> None:
@@ -463,13 +463,13 @@ def _consume_format_flags_for_leaf(cmd: click.Command, args: list[str]) -> None:
             continue
         if arg == "--json":
             _check_conflict("--json")
-            chosen_mode = OutputFormatWithAuto.json
+            chosen_mode = OutputFormat.json
             chosen_flag = "--json"
             del args[i : i + 1]
             continue
         if arg in ("-q", "--quiet"):
             _check_conflict(arg)
-            chosen_mode = OutputFormatWithAuto.quiet
+            chosen_mode = OutputFormat.quiet
             chosen_flag = arg
             del args[i : i + 1]
             continue
@@ -521,11 +521,11 @@ def _rewrite_legacy_shorthands(args: list[str], *, rewrite_json: bool, rewrite_q
             args[idx : idx + 1] = ["--format", "quiet"]
 
 
-def _parse_format_value(value: str) -> "OutputFormatWithAuto":
+def _parse_format_value(value: str) -> "OutputFormat":
     try:
-        return OutputFormatWithAuto(value)
+        return OutputFormat(value)
     except ValueError:
-        valid = ", ".join(m.value for m in OutputFormatWithAuto)
+        valid = ", ".join(m.value for m in OutputFormat)
         raise click.UsageError(f"Invalid value for '--format': '{value}'. Valid values: {valid}.") from None
 
 

--- a/src/huggingface_hub/cli/_cli_utils.py
+++ b/src/huggingface_hub/cli/_cli_utils.py
@@ -13,11 +13,8 @@
 # limitations under the License.
 """Contains CLI utilities (styling, helpers)."""
 
-import dataclasses
-import datetime
 import difflib
 import importlib.metadata
-import json
 import os
 import re
 import subprocess
@@ -26,7 +23,7 @@ import time
 from collections.abc import Callable, Sequence
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Any, Literal, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Annotated, Any, Literal, TypeVar, cast
 
 import click
 import typer
@@ -40,7 +37,6 @@ from huggingface_hub.utils import (
     installation_method,
     logging,
     parse_hf_mount,
-    tabulate,
 )
 from huggingface_hub.utils._dotenv import load_dotenv
 
@@ -49,9 +45,6 @@ from ._output import OutputFormatWithAuto, out
 
 
 logger = logging.get_logger()
-
-# Arbitrary maximum length of a cell in a table output
-_MAX_CELL_LENGTH = 35
 
 # Arbitrary default limit for models/datasets/spaces list commands.
 REPO_LIST_DEFAULT_LIMIT = 30
@@ -906,158 +899,6 @@ def parse_volumes(volumes: list[str] | None) -> "list[Volume] | None":
             )
         )
     return result
-
-
-class OutputFormat(str, Enum):
-    """Output format for CLI list commands."""
-
-    table = "table"
-    json = "json"
-
-
-FormatOpt = Annotated[
-    OutputFormat,
-    typer.Option(
-        help="Output format (table or json).",
-    ),
-]
-
-
-def _set_output_mode(value: OutputFormatWithAuto) -> OutputFormatWithAuto:
-    """Callback for the legacy FormatWithAutoOpt option type.
-
-    Most commands now rely on the global --format / --json / -q flags consumed by _consume_format_flags_for_leaf instead
-    of declaring FormatWithAutoOpt themselves.  This callback is kept for the rare cases where a command still wires
-    FormatWithAutoOpt explicitly.
-    """
-    out.set_mode(value)
-    return value
-
-
-FormatWithAutoOpt = Annotated[
-    OutputFormatWithAuto,
-    typer.Option(help="Output format.", callback=_set_output_mode),
-]
-
-QuietOpt = Annotated[
-    bool,
-    typer.Option("-q", "--quiet", help="Print only IDs (one per line)."),
-]
-
-
-def _to_header(name: str) -> str:
-    """Convert a camelCase or PascalCase string to SCREAMING_SNAKE_CASE to be used as table header."""
-    s = re.sub(r"([a-z])([A-Z])", r"\1_\2", name)
-    return s.upper()
-
-
-def _format_value(value: Any) -> str:
-    """Convert a value to string for terminal display."""
-    if not value:
-        return ""
-    if isinstance(value, bool):
-        return "✔" if value else ""
-    if isinstance(value, datetime.datetime):
-        return value.strftime("%Y-%m-%d")
-    if isinstance(value, str) and re.match(r"^\d{4}-\d{2}-\d{2}T", value):
-        return value[:10]
-    if isinstance(value, list):
-        return ", ".join(_format_value(v) for v in value)
-    elif isinstance(value, dict):
-        if "name" in value:  # Likely to be a user or org => print name
-            return str(value["name"])
-        # TODO: extend if needed
-        return json.dumps(value)
-    return str(value)
-
-
-def _format_cell(value: Any, max_len: int = _MAX_CELL_LENGTH) -> str:
-    """Format a value + truncate it for table display."""
-    cell = _format_value(value)
-    if len(cell) > max_len:
-        cell = cell[: max_len - 3] + "..."
-    return cell
-
-
-def print_as_table(
-    items: Sequence[dict[str, Any]],
-    headers: list[str],
-    row_fn: Callable[[dict[str, Any]], list[str]],
-    alignments: dict[str, str] | None = None,
-) -> None:
-    """Print items as a formatted table.
-
-    Args:
-        items: Sequence of dictionaries representing the items to display.
-        headers: List of column headers.
-        row_fn: Function that takes an item dict and returns a list of string values for each column.
-        alignments: Optional mapping of header name to "left" or "right". Defaults to "left".
-    """
-    if not items:
-        print("No results found.")
-        return
-    rows = cast(list[list[Union[str, int]]], [row_fn(item) for item in items])
-    screaming_headers = [_to_header(h) for h in headers]
-    # Remap alignments keys to screaming case to match tabulate headers
-    screaming_alignments = {_to_header(k): v for k, v in (alignments or {}).items()}
-    print(tabulate(rows, headers=screaming_headers, alignments=screaming_alignments))
-
-
-def print_list_output(
-    items: Sequence[dict[str, Any]],
-    format: OutputFormat,
-    quiet: bool,
-    id_key: str = "id",
-    headers: list[str] | None = None,
-    row_fn: Callable[[dict[str, Any]], list[str]] | None = None,
-    alignments: dict[str, str] | None = None,
-) -> None:
-    """Print list command output in the specified format.
-
-    Args:
-        items: Sequence of dictionaries representing the items to display.
-        format: Output format.
-        quiet: If True, print only IDs (one per line).
-        id_key: Key to use for extracting IDs in quiet mode.
-        headers: Optional list of column names for headers. If not provided, auto-detected from keys.
-        row_fn: Optional function to extract row values. If not provided, uses _format_cell on each column.
-        alignments: Optional mapping of header name to "left" or "right". Defaults to "left".
-    """
-    if quiet:
-        for item in items:
-            print(item[id_key])
-        return
-
-    if format == OutputFormat.json:
-        print(json.dumps(list(items), indent=2, default=str))
-        return
-
-    if headers is None:
-        all_columns = list(items[0].keys()) if items else [id_key]
-        headers = [col for col in all_columns if any(_format_cell(item.get(col)) for item in items)]
-
-    if row_fn is None:
-
-        def row_fn(item: dict[str, Any]) -> list[str]:
-            return [_format_cell(item.get(col)) for col in headers]  # type: ignore[union-attr]
-
-    print_as_table(items, headers=headers, row_fn=row_fn, alignments=alignments)
-
-
-def _serialize_value(v: object) -> object:
-    """Recursively serialize a value to be JSON-compatible."""
-    if isinstance(v, datetime.datetime):
-        return v.isoformat()
-    elif isinstance(v, dict):
-        return {key: _serialize_value(val) for key, val in v.items() if val is not None}
-    elif isinstance(v, list):
-        return [_serialize_value(item) for item in v]
-    return v
-
-
-def api_object_to_dict(info: Any) -> dict[str, Any]:
-    """Convert repo info dataclasses to json-serializable dicts."""
-    return {k: _serialize_value(v) for k, v in dataclasses.asdict(info).items() if v is not None}
 
 
 def make_expand_properties_parser(valid_properties: Sequence[ExpandPropertyT]):

--- a/src/huggingface_hub/cli/_file_listing.py
+++ b/src/huggingface_hub/cli/_file_listing.py
@@ -23,7 +23,7 @@ from huggingface_hub._buckets import BucketFile, BucketFolder
 from huggingface_hub.hf_api import RepoFile, RepoFolder
 
 from ._cli_utils import get_hf_api
-from ._output import OutputFormatWithAuto, _dataclass_to_dict, out
+from ._output import OutputFormat, _dataclass_to_dict, out
 
 
 BucketItem = BucketFile | BucketFolder
@@ -173,7 +173,7 @@ def list_repo_files_cmd(
     token: str | None,
 ) -> None:
     """List files in a repo on the Hub. Used by models/datasets/spaces ls commands."""
-    if as_tree and out.mode == OutputFormatWithAuto.json:
+    if as_tree and out.mode == OutputFormat.json:
         raise typer.BadParameter("Cannot use --tree with --format json.")
 
     api = get_hf_api(token=token)
@@ -200,12 +200,12 @@ def print_file_listing(
     has_directories = any(isinstance(item, BucketFolder | RepoFolder) for item in items)
 
     if as_tree:
-        quiet = out.mode == OutputFormatWithAuto.quiet
+        quiet = out.mode == OutputFormat.quiet
         for line in build_tree(items, human_readable=human_readable, quiet=quiet):
             print(line)
-    elif out.mode == OutputFormatWithAuto.json:
+    elif out.mode == OutputFormat.json:
         print(json.dumps([_dataclass_to_dict(item) for item in items], indent=2))
-    elif out.mode == OutputFormatWithAuto.quiet:
+    elif out.mode == OutputFormat.quiet:
         for item in items:
             if isinstance(item, BucketFolder | RepoFolder):
                 print(f"{item.path}/")

--- a/src/huggingface_hub/cli/_file_listing.py
+++ b/src/huggingface_hub/cli/_file_listing.py
@@ -22,8 +22,8 @@ import typer
 from huggingface_hub._buckets import BucketFile, BucketFolder
 from huggingface_hub.hf_api import RepoFile, RepoFolder
 
-from ._cli_utils import api_object_to_dict, get_hf_api
-from ._output import OutputFormatWithAuto, out
+from ._cli_utils import get_hf_api
+from ._output import OutputFormatWithAuto, _dataclass_to_dict, out
 
 
 BucketItem = BucketFile | BucketFolder
@@ -204,7 +204,7 @@ def print_file_listing(
         for line in build_tree(items, human_readable=human_readable, quiet=quiet):
             print(line)
     elif out.mode == OutputFormatWithAuto.json:
-        print(json.dumps([api_object_to_dict(item) for item in items], indent=2))
+        print(json.dumps([_dataclass_to_dict(item) for item in items], indent=2))
     elif out.mode == OutputFormatWithAuto.quiet:
         for item in items:
             if isinstance(item, BucketFolder | RepoFolder):

--- a/src/huggingface_hub/cli/_output.py
+++ b/src/huggingface_hub/cli/_output.py
@@ -29,8 +29,7 @@ from huggingface_hub.errors import ConfirmationError
 from huggingface_hub.utils import ANSI, StatusLine, disable_progress_bars, is_agent, tabulate
 
 
-# TODO: remove OutputFormat in _cli_utils.py once all commands are migrated to OutputFormatWithAuto.
-class OutputFormatWithAuto(str, Enum):
+class OutputFormat(str, Enum):
     """Output format for CLI commands with auto detection of agent/human mode."""
 
     agent = "agent"
@@ -47,19 +46,19 @@ class Output:
     and can be overridden per-command via `set_mode()`.
     """
 
-    mode: OutputFormatWithAuto
+    mode: OutputFormat
     no_truncate: bool
 
     def __init__(self) -> None:
         self.no_truncate = False
         self.set_mode()
 
-    def set_mode(self, mode: OutputFormatWithAuto = OutputFormatWithAuto.auto) -> None:
+    def set_mode(self, mode: OutputFormat = OutputFormat.auto) -> None:
         """Override the output mode (called once at startup and again per '--format' flag)."""
-        if mode == OutputFormatWithAuto.auto:
-            mode = OutputFormatWithAuto.agent if is_agent() else OutputFormatWithAuto.human
+        if mode == OutputFormat.auto:
+            mode = OutputFormat.agent if is_agent() else OutputFormat.human
         self.mode = mode
-        if mode != OutputFormatWithAuto.human:
+        if mode != OutputFormat.human:
             disable_progress_bars()
 
     def set_no_truncate(self, no_truncate: bool) -> None:
@@ -67,7 +66,7 @@ class Output:
         self.no_truncate = no_truncate
 
     def is_quiet(self) -> bool:
-        return self.mode == OutputFormatWithAuto.quiet
+        return self.mode == OutputFormat.quiet
 
     def text(self, msg: str | None = None, *, human: str | None = None, agent: str | None = None) -> None:
         """Print a free-form text message to stdout."""
@@ -78,10 +77,10 @@ class Output:
             agent = _strip_ansi(msg)
 
         match self.mode:
-            case OutputFormatWithAuto.human:
+            case OutputFormat.human:
                 if human is not None:
                     print(human)
-            case OutputFormatWithAuto.agent:
+            case OutputFormat.agent:
                 if agent is not None:
                     print(agent)
             # json/quiet: no-op
@@ -104,9 +103,9 @@ class Output:
         """
         if not items:
             match self.mode:
-                case OutputFormatWithAuto.agent | OutputFormatWithAuto.human:
+                case OutputFormat.agent | OutputFormat.human:
                     print("No results found.")
-                case OutputFormatWithAuto.json:
+                case OutputFormat.json:
                     print("[]")
             return
 
@@ -116,7 +115,7 @@ class Output:
         rows = [[item.get(h) for h in headers] for item in items]
 
         match self.mode:
-            case OutputFormatWithAuto.human:  # padded table, adaptive truncation, SCREAMING_SNAKE headers
+            case OutputFormat.human:  # padded table, adaptive truncation, SCREAMING_SNAKE headers
                 screaming_headers = [_to_header(h) for h in headers]
                 formatted_rows: list[list[str]] = [[_format_table_value_human(v) for v in row] for row in rows]
 
@@ -132,13 +131,13 @@ class Output:
                 )
                 if is_truncated:
                     self.hint("Use `--no-truncate` or `--format json` to display full values.")
-            case OutputFormatWithAuto.agent:  # TSV, no truncation, full timestamps
+            case OutputFormat.agent:  # TSV, no truncation, full timestamps
                 print("\t".join(headers))
                 for row in rows:
                     print("\t".join(_format_table_cell_agent(v) for v in row))
-            case OutputFormatWithAuto.json:  # compact JSON array
+            case OutputFormat.json:  # compact JSON array
                 print(json.dumps(list(items), default=str))
-            case OutputFormatWithAuto.quiet:  # id_key column (or first column), one per line
+            case OutputFormat.quiet:  # id_key column (or first column), one per line
                 quiet_key = id_key or headers[0]
                 for item in items:
                     print(item.get(quiet_key, ""))
@@ -150,27 +149,27 @@ class Output:
         """
         if dataclasses.is_dataclass(data) and not isinstance(data, type):
             data = _dataclass_to_dict(data)
-        if self.mode == OutputFormatWithAuto.quiet and id_key is not None:
+        if self.mode == OutputFormat.quiet and id_key is not None:
             print(data.get(id_key, ""))
             return
-        indent = 2 if self.mode == OutputFormatWithAuto.human else None
+        indent = 2 if self.mode == OutputFormat.human else None
         print(json.dumps(data, indent=indent, default=str))
 
     def result(self, message: str, **data: Any) -> None:
         """Print a success summary to stdout."""
         match self.mode:
-            case OutputFormatWithAuto.human:  # ✓ message + key: value lines
+            case OutputFormat.human:  # ✓ message + key: value lines
                 parts = [ANSI.green(f"✓ {message}")]
                 for k, v in data.items():
                     if v is not None:
                         parts.append(f"  {k}: {v}")
                 print("\n".join(parts))
-            case OutputFormatWithAuto.agent:  # key=val pairs, space-separated
+            case OutputFormat.agent:  # key=val pairs, space-separated
                 parts = [f"{k}={v}" for k, v in data.items() if v is not None]
                 print(" ".join(parts) if parts else message)
-            case OutputFormatWithAuto.json:  # json.dumps(data), message ignored
+            case OutputFormat.json:  # json.dumps(data), message ignored
                 print(json.dumps(data, default=str) if data else "")
-            case OutputFormatWithAuto.quiet:  # first value only
+            case OutputFormat.quiet:  # first value only
                 values = list(data.values())
                 if values:
                     print(values[0])
@@ -181,34 +180,34 @@ class Output:
         """
         if yes:
             return
-        if self.mode != OutputFormatWithAuto.human:
+        if self.mode != OutputFormat.human:
             raise ConfirmationError(f"{message} Use {confirm_param} to skip confirmation.")
         typer.confirm(message, default=default, abort=True)
 
     def status(self, message: str | None = None) -> StatusLine:
         """Return a status line that emits only in human mode (no-op otherwise)."""
-        status = StatusLine(enabled=self.mode == OutputFormatWithAuto.human)
+        status = StatusLine(enabled=self.mode == OutputFormat.human)
         if message is not None:
             status.update(message)
         return status
 
     def warning(self, message: str) -> None:
         """Print a non-fatal warning to stderr (all modes)."""
-        if self.mode == OutputFormatWithAuto.human:
+        if self.mode == OutputFormat.human:
             print(ANSI.yellow(f"Warning: {message}"), file=sys.stderr)
         else:
             print(f"Warning: {message}", file=sys.stderr)
 
     def error(self, message: str) -> None:
         """Print an error to stderr (all modes)."""
-        if self.mode == OutputFormatWithAuto.human:
+        if self.mode == OutputFormat.human:
             print(ANSI.red(f"Error: {message}"), file=sys.stderr)
         else:
             print(f"Error: {message}", file=sys.stderr)
 
     def hint(self, message: str) -> None:
         """Print a helpful hint to stderr (human: gray, agent/json: plain text)."""
-        if self.mode == OutputFormatWithAuto.human:
+        if self.mode == OutputFormat.human:
             print(ANSI.gray(f"Hint: {message}"), file=sys.stderr)
         else:
             print(f"Hint: {message}", file=sys.stderr)

--- a/src/huggingface_hub/cli/buckets.py
+++ b/src/huggingface_hub/cli/buckets.py
@@ -37,7 +37,7 @@ from ._cli_utils import (
     typer_factory,
 )
 from ._file_listing import format_size, print_file_listing
-from ._output import OutputFormatWithAuto, out
+from ._output import OutputFormat, out
 
 
 logger = logging.get_logger(__name__)
@@ -240,7 +240,7 @@ def _list_files(
     token: str | None,
 ) -> None:
     """List files in a bucket."""
-    if as_tree and out.mode == OutputFormatWithAuto.json:
+    if as_tree and out.mode == OutputFormat.json:
         raise typer.BadParameter("Cannot use --tree with --format json.")
 
     api = get_hf_api(token=token)

--- a/src/huggingface_hub/cli/collections.py
+++ b/src/huggingface_hub/cli/collections.py
@@ -40,8 +40,8 @@ import typer
 
 from huggingface_hub.hf_api import CollectionItemType_T, CollectionSort_T
 
-from ._cli_utils import LimitOpt, TokenOpt, api_object_to_dict, get_hf_api, typer_factory
-from ._output import out
+from ._cli_utils import LimitOpt, TokenOpt, get_hf_api, typer_factory
+from ._output import _dataclass_to_dict, out
 
 
 # Build enums dynamically from Literal types to avoid duplication
@@ -85,7 +85,7 @@ def collections_ls(
     api = get_hf_api(token=token)
     sort_key = sort.value if sort else None
     results = [
-        api_object_to_dict(collection)
+        _dataclass_to_dict(collection)
         for collection in api.list_collections(
             owner=owner,
             item=item,

--- a/src/huggingface_hub/cli/datasets.py
+++ b/src/huggingface_hub/cli/datasets.py
@@ -42,13 +42,12 @@ from ._cli_utils import (
     RevisionOpt,
     SearchOpt,
     TokenOpt,
-    api_object_to_dict,
     get_hf_api,
     make_expand_properties_parser,
     typer_factory,
 )
 from ._file_listing import list_repo_files_cmd
-from ._output import out
+from ._output import _dataclass_to_dict, out
 
 
 _EXPAND_PROPERTIES = sorted(get_args(ExpandDatasetProperty_T))
@@ -149,7 +148,7 @@ def datasets_ls(
     api = get_hf_api(token=token)
     sort_key = sort.value if sort else None
     results = [
-        api_object_to_dict(dataset_info)
+        _dataclass_to_dict(dataset_info)
         for dataset_info in api.list_datasets(
             filter=filter,
             author=author,
@@ -178,7 +177,7 @@ def datasets_leaderboard(
     """List model scores from a dataset leaderboard. This command helps find the best models for a task or compare models by benchmark scores. Use 'hf datasets ls --filter benchmark:official' to list available leaderboards."""
     api = get_hf_api(token=token)
     leaderboard = api.get_dataset_leaderboard(repo_id=dataset_id)
-    results = [api_object_to_dict(entry) for entry in leaderboard[:limit]]
+    results = [_dataclass_to_dict(entry) for entry in leaderboard[:limit]]
     out.table(
         results,
         headers=["rank", "model_id", "value", "source"],

--- a/src/huggingface_hub/cli/discussions.py
+++ b/src/huggingface_hub/cli/discussions.py
@@ -29,11 +29,10 @@ from ._cli_utils import (
     RepoType,
     RepoTypeOpt,
     TokenOpt,
-    api_object_to_dict,
     get_hf_api,
     typer_factory,
 )
-from ._output import out
+from ._output import _dataclass_to_dict, out
 
 
 class DiscussionStatus(str, enum.Enum):
@@ -143,7 +142,7 @@ def discussion_list(
         if len(discussions) >= limit:
             break
 
-    items = [api_object_to_dict(d) for d in discussions]
+    items = [_dataclass_to_dict(d) for d in discussions]
     out.table(
         items,
         headers=["num", "title", "is_pull_request", "status", "author", "created_at"],

--- a/src/huggingface_hub/cli/models.py
+++ b/src/huggingface_hub/cli/models.py
@@ -41,13 +41,12 @@ from ._cli_utils import (
     RevisionOpt,
     SearchOpt,
     TokenOpt,
-    api_object_to_dict,
     get_hf_api,
     make_expand_properties_parser,
     typer_factory,
 )
 from ._file_listing import list_repo_files_cmd
-from ._output import out
+from ._output import _dataclass_to_dict, out
 
 
 _EXPAND_PROPERTIES = sorted(get_args(ExpandModelProperty_T))
@@ -152,7 +151,7 @@ def models_ls(
     api = get_hf_api(token=token)
     sort_key = sort.value if sort else None
     results = [
-        api_object_to_dict(model_info)
+        _dataclass_to_dict(model_info)
         for model_info in api.list_models(
             filter=filter,
             author=author,

--- a/src/huggingface_hub/cli/papers.py
+++ b/src/huggingface_hub/cli/papers.py
@@ -54,11 +54,10 @@ from huggingface_hub.hf_api import DailyPapersSort_T
 from ._cli_utils import (
     LimitOpt,
     TokenOpt,
-    api_object_to_dict,
     get_hf_api,
     typer_factory,
 )
-from ._output import out
+from ._output import _dataclass_to_dict, out
 
 
 _SORT_OPTIONS = get_args(DailyPapersSort_T)
@@ -127,7 +126,7 @@ def papers_ls(
         sort=sort_key,
         limit=limit,
     ):
-        item = api_object_to_dict(paper_info)
+        item = _dataclass_to_dict(paper_info)
         submitted_by = item.get("submitted_by") or {}
         item["submitted_by_name"] = submitted_by.get("fullname") or submitted_by.get("username") or ""
         results.append(item)
@@ -153,7 +152,7 @@ def papers_search(
 ) -> None:
     """Search papers on the Hub."""
     api = get_hf_api(token=token)
-    results = [api_object_to_dict(paper_info) for paper_info in api.list_papers(query=query, limit=limit)]
+    results = [_dataclass_to_dict(paper_info) for paper_info in api.list_papers(query=query, limit=limit)]
     out.table(results, headers=["id", "title", "summary", "upvotes", "published_at"], alignments={"upvotes": "right"})
 
 

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -65,7 +65,6 @@ from ._cli_utils import (
     SecretsOpt,
     TokenOpt,
     VolumesOpt,
-    api_object_to_dict,
     get_hf_api,
     make_expand_properties_parser,
     parse_env_map,
@@ -73,7 +72,7 @@ from ._cli_utils import (
     typer_factory,
 )
 from ._file_listing import list_repo_files_cmd
-from ._output import out
+from ._output import _dataclass_to_dict, out
 
 
 HOT_RELOADING_MIN_GRADIO = "6.1.0"
@@ -179,7 +178,7 @@ def spaces_ls(
     api = get_hf_api(token=token)
     sort_key = sort.value if sort else None
     results = [
-        api_object_to_dict(space_info)
+        _dataclass_to_dict(space_info)
         for space_info in api.list_spaces(
             filter=filter,
             author=author,
@@ -878,7 +877,7 @@ def volumes_ls(
     if info.runtime is None:
         raise CLIError(f"Runtime not available for Space '{space_id}'.")
     volumes = info.runtime.volumes or []
-    items = [api_object_to_dict(v) for v in volumes]
+    items = [_dataclass_to_dict(v) for v in volumes]
     out.table(items)
     out.hint(
         f"Use `hf spaces volumes set {space_id} -v hf://<repo_type>/<repo_id>:/<mount_path>` to set volumes for a Space."
@@ -947,7 +946,7 @@ def secrets_ls(
     """List secrets for a Space. Secret values are write-only and not returned."""
     api = get_hf_api(token=token)
     secrets = api.get_space_secrets(space_id)
-    items = [api_object_to_dict(s) for s in secrets.values()]
+    items = [_dataclass_to_dict(s) for s in secrets.values()]
     out.table(items)
     out.hint(f"Use `hf spaces secrets add {space_id} -s KEY=VALUE` to add secrets to a Space.")
 
@@ -1019,7 +1018,7 @@ def variables_ls(
     """List environment variables for a Space."""
     api = get_hf_api(token=token)
     variables = api.get_space_variables(space_id)
-    items = [api_object_to_dict(v) for v in variables.values()]
+    items = [_dataclass_to_dict(v) for v in variables.values()]
     out.table(items)
     out.hint(f"Use `hf spaces variables add {space_id} -e KEY=VALUE` to add variables to a Space.")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,7 +15,7 @@ from huggingface_hub._dataset_viewer import DatasetParquetEntry
 from huggingface_hub._jobs_api import JobInfo, _create_job_spec
 from huggingface_hub._space_api import Volume
 from huggingface_hub.cli._cli_utils import RepoType, parse_volumes
-from huggingface_hub.cli._output import OutputFormatWithAuto, out
+from huggingface_hub.cli._output import OutputFormat, out
 from huggingface_hub.cli.cache import CacheDeletionCounts
 from huggingface_hub.cli.download import download
 from huggingface_hub.cli.hf import app
@@ -699,7 +699,7 @@ class TestResolveUploadPaths:
 class TestUploadImpl:
     @pytest.fixture(autouse=True)
     def _quiet_mode(self):
-        out.set_mode(OutputFormatWithAuto.quiet)
+        out.set_mode(OutputFormat.quiet)
 
     def test_upload_folder_mock(self, *_: object) -> None:
         api = Mock()
@@ -953,7 +953,7 @@ class TestDownloadCommand:
 class TestDownloadImpl:
     @pytest.fixture(autouse=True)
     def _quiet_mode(self):
-        out.set_mode(OutputFormatWithAuto.quiet)
+        out.set_mode(OutputFormat.quiet)
 
     @patch("huggingface_hub.cli.download.snapshot_download")
     @patch("huggingface_hub.cli.download.hf_hub_download")

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -19,8 +19,7 @@ import sys
 
 import pytest
 
-from huggingface_hub.cli._cli_utils import OutputFormatWithAuto
-from huggingface_hub.cli._output import Output, _to_header
+from huggingface_hub.cli._output import Output, OutputFormatWithAuto, _to_header
 from huggingface_hub.errors import ConfirmationError
 
 

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -19,14 +19,14 @@ import sys
 
 import pytest
 
-from huggingface_hub.cli._output import Output, OutputFormatWithAuto, _to_header
+from huggingface_hub.cli._output import Output, OutputFormat, _to_header
 from huggingface_hub.errors import ConfirmationError
 
 
-HUMAN = OutputFormatWithAuto.human
-AGENT = OutputFormatWithAuto.agent
-JSON = OutputFormatWithAuto.json
-QUIET = OutputFormatWithAuto.quiet
+HUMAN = OutputFormat.human
+AGENT = OutputFormat.agent
+JSON = OutputFormat.json
+QUIET = OutputFormat.quiet
 
 
 def _normalize(text: str) -> list[str]:
@@ -77,7 +77,7 @@ def test_auto_resolves_to_agent(monkeypatch):
 def test_auto_resets_after_explicit():
     o = Output()
     o.set_mode(QUIET)
-    o.set_mode(OutputFormatWithAuto.auto)
+    o.set_mode(OutputFormat.auto)
     assert o.mode == HUMAN
 
 


### PR DESCRIPTION
**let's review and merge https://github.com/huggingface/huggingface_hub/pull/4286 before merging this one**

Part of #3979 — the final cleanup after every command has been migrated to the `out` singleton.

Most of the legacy printing helpers in `_cli_utils.py` had **zero remaining callers** (verified by grep across `src/` and `tests/`). The one exception was `api_object_to_dict`, still used to convert dataclasses → dicts before `out.table` or JSON serialization in 11 callsites — but `_output.py` already exposes the same conversion as `_dataclass_to_dict`. So this PR does a 1:1 swap and deletes the dead code.

## Changes

- **Switch callers** from `api_object_to_dict` to `_dataclass_to_dict` (imported from `._output`) in `discussions.py`, `models.py`, `datasets.py` (×2), `papers.py` (×2), `spaces.py` (×4), `collections.py`, `_file_listing.py`.
- **Delete from `_cli_utils.py`**:
  - Printing helpers: `print_as_table`, `print_list_output`, `_format_cell`, `_format_value`, `_to_header`, `_MAX_CELL_LENGTH`, `_serialize_value`, `api_object_to_dict`.
  - Legacy format types: `OutputFormat` (the old `table | json` enum), `_set_output_mode`, `FormatOpt`, `FormatWithAutoOpt`, `QuietOpt`.
  - Now-orphaned top-level imports: `json`, `dataclasses`, `datetime`, `tabulate`, `Union`.
- **Tests**: update `tests/test_cli_output.py` to import `OutputFormatWithAuto` from `._output` directly instead of via the `_cli_utils` re-export.

Net diff: **+23 / -188** across 9 files. No behavior change.

## Verification

```
$ pytest tests/test_cli_output.py tests/test_cli.py
======================= 278 passed, 7 warnings in 12.00s =======================
```

Smoke test on a list command that goes through the new path:

```
$ hf models ls --limit 2 --format human
Hint: Use `--no-truncate` or `--format json` to display full values.
ID   CREATED_AT DOWNLOADS LIBRARY_NAME LIKES PIPELINE_TAG PRIVATE TAGS TRENDING_SCORE
---- ---------- --------- ------------ ----- ------------ ------- ---- --------------
b... 2026-05-15 1908      Lance        901   any-to-any           L... 440
m... 2026-05-21 0         diffusers    333                        d... 323

$ hf models ls --limit 2 --format json
[
    {
        "id": "bytedance-research/Lance",
        "created_at": "2026-05-15T08:05:57+00:00",
        ...
    },
    ...
]
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor with tests passing; only risk is if any external code imported removed symbols from `_cli_utils`.
> 
> **Overview**
> This PR finishes CLI output consolidation after migration to the `out` singleton: it **removes dead legacy printing code** from `_cli_utils.py` and **routes all dataclass→dict conversion** through `_output._dataclass_to_dict`.
> 
> **`_cli_utils.py`:** Deletes unused helpers (`print_as_table`, `print_list_output`, `api_object_to_dict`, legacy `OutputFormat` / `FormatOpt` / `QuietOpt`, etc.) and drops imports that only served that code (`tabulate`, extra `json`/`dataclasses`/`datetime` usage there).
> 
> **Call sites:** `discussions`, `models`, `datasets`, `papers`, `spaces`, `collections`, and `_file_listing` now import `_dataclass_to_dict` from `._output` instead of `api_object_to_dict` from `._cli_utils`—same role for `out.table()` and JSON paths.
> 
> **Tests:** `OutputFormatWithAuto` is imported from `._output` in `test_cli_output.py` instead of via `_cli_utils`.
> 
> No intended behavior change; large net deletion (~165 lines).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51107e7807d0c6779680f4030304278c253ed5a0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->