### PR TITLE
[CLI] Rename `OutputFormatWithAuto` to `OutputFormat`

### DIFF
--- a/src/huggingface_hub/cli/_cli_utils.py
+++ b/src/huggingface_hub/cli/_cli_utils.py
@@ -41,7 +41,7 @@ from huggingface_hub.utils import (
 from huggingface_hub.utils._dotenv import load_dotenv
 
 from ._help_formatter import StyledContext
-from ._output import OutputFormatWithAuto, out
+from ._output import OutputFormat, out
 
 
 logger = logging.get_logger()
@@ -432,7 +432,7 @@ def _consume_format_flags_for_leaf(cmd: click.Command, args: list[str]) -> None:
         return
 
     # Strip --format/--json/-q/--quiet from 'args' and apply to 'out'
-    chosen_mode: OutputFormatWithAuto = OutputFormatWithAuto.auto
+    chosen_mode: OutputFormat = OutputFormat.auto
     chosen_flag: str | None = None
 
     def _check_conflict(new_flag: str) -> None:
@@ -463,13 +463,13 @@ def _consume_format_flags_for_leaf(cmd: click.Command, args: list[str]) -> None:
             continue
         if arg == "--json":
             _check_conflict("--json")
-            chosen_mode = OutputFormatWithAuto.json
+            chosen_mode = OutputFormat.json
             chosen_flag = "--json"
             del args[i : i + 1]
             continue
         if arg in ("-q", "--quiet"):
             _check_conflict(arg)
-            chosen_mode = OutputFormatWithAuto.quiet
+            chosen_mode = OutputFormat.quiet
             chosen_flag = arg
             del args[i : i + 1]
             continue
@@ -521,11 +521,11 @@ def _rewrite_legacy_shorthands(args: list[str], *, rewrite_json: bool, rewrite_q
             args[idx : idx + 1] = ["--format", "quiet"]
 
 
-def _parse_format_value(value: str) -> "OutputFormatWithAuto":
+def _parse_format_value(value: str) -> "OutputFormat":
     try:
-        return OutputFormatWithAuto(value)
+        return OutputFormat(value)
     except ValueError:
-        valid = ", ".join(m.value for m in OutputFormatWithAuto)
+        valid = ", ".join(m.value for m in OutputFormat)
         raise click.UsageError(f"Invalid value for '--format': '{value}'. Valid values: {valid}.") from None
 
 

--- a/src/huggingface_hub/cli/_file_listing.py
+++ b/src/huggingface_hub/cli/_file_listing.py
@@ -23,7 +23,7 @@ from huggingface_hub._buckets import BucketFile, BucketFolder
 from huggingface_hub.hf_api import RepoFile, RepoFolder
 
 from ._cli_utils import get_hf_api
-from ._output import OutputFormatWithAuto, _dataclass_to_dict, out
+from ._output import OutputFormat, _dataclass_to_dict, out
 
 
 BucketItem = BucketFile | BucketFolder
@@ -173,7 +173,7 @@ def list_repo_files_cmd(
     token: str | None,
 ) -> None:
     """List files in a repo on the Hub. Used by models/datasets/spaces ls commands."""
-    if as_tree and out.mode == OutputFormatWithAuto.json:
+    if as_tree and out.mode == OutputFormat.json:
         raise typer.BadParameter("Cannot use --tree with --format json.")
 
     api = get_hf_api(token=token)
@@ -200,12 +200,12 @@ def print_file_listing(
     has_directories = any(isinstance(item, BucketFolder | RepoFolder) for item in items)
 
     if as_tree:
-        quiet = out.mode == OutputFormatWithAuto.quiet
+        quiet = out.mode == OutputFormat.quiet
         for line in build_tree(items, human_readable=human_readable, quiet=quiet):
             print(line)
-    elif out.mode == OutputFormatWithAuto.json:
+    elif out.mode == OutputFormat.json:
         print(json.dumps([_dataclass_to_dict(item) for item in items], indent=2))
-    elif out.mode == OutputFormatWithAuto.quiet:
+    elif out.mode == OutputFormat.quiet:
         for item in items:
             if isinstance(item, BucketFolder | RepoFolder):
                 print(f"{item.path}/")

--- a/src/huggingface_hub/cli/_output.py
+++ b/src/huggingface_hub/cli/_output.py
@@ -29,8 +29,7 @@ from huggingface_hub.errors import ConfirmationError
 from huggingface_hub.utils import ANSI, StatusLine, disable_progress_bars, is_agent, tabulate
 
 
-# TODO: remove OutputFormat in _cli_utils.py once all commands are migrated to OutputFormatWithAuto.
-class OutputFormatWithAuto(str, Enum):
+class OutputFormat(str, Enum):
     """Output format for CLI commands with auto detection of agent/human mode."""
 
     agent = "agent"
@@ -47,19 +46,19 @@ class Output:
     and can be overridden per-command via `set_mode()`.
     """
 
-    mode: OutputFormatWithAuto
+    mode: OutputFormat
     no_truncate: bool
 
     def __init__(self) -> None:
         self.no_truncate = False
         self.set_mode()
 
-    def set_mode(self, mode: OutputFormatWithAuto = OutputFormatWithAuto.auto) -> None:
+    def set_mode(self, mode: OutputFormat = OutputFormat.auto) -> None:
         """Override the output mode (called once at startup and again per '--format' flag)."""
-        if mode == OutputFormatWithAuto.auto:
-            mode = OutputFormatWithAuto.agent if is_agent() else OutputFormatWithAuto.human
+        if mode == OutputFormat.auto:
+            mode = OutputFormat.agent if is_agent() else OutputFormat.human
         self.mode = mode
-        if mode != OutputFormatWithAuto.human:
+        if mode != OutputFormat.human:
             disable_progress_bars()
 
     def set_no_truncate(self, no_truncate: bool) -> None:
@@ -67,7 +66,7 @@ class Output:
         self.no_truncate = no_truncate
 
     def is_quiet(self) -> bool:
-        return self.mode == OutputFormatWithAuto.quiet
+        return self.mode == OutputFormat.quiet
 
     def text(self, msg: str | None = None, *, human: str | None = None, agent: str | None = None) -> None:
         """Print a free-form text message to stdout."""
@@ -78,10 +77,10 @@ class Output:
             agent = _strip_ansi(msg)
 
         match self.mode:
-            case OutputFormatWithAuto.human:
+            case OutputFormat.human:
                 if human is not None:
                     print(human)
-            case OutputFormatWithAuto.agent:
+            case OutputFormat.agent:
                 if agent is not None:
                     print(agent)
             # json/quiet: no-op
@@ -104,9 +103,9 @@ class Output:
         """
         if not items:
             match self.mode:
-                case OutputFormatWithAuto.agent | OutputFormatWithAuto.human:
+                case OutputFormat.agent | OutputFormat.human:
                     print("No results found.")
-                case OutputFormatWithAuto.json:
+                case OutputFormat.json:
                     print("[]")
             return
 
@@ -116,7 +115,7 @@ class Output:
         rows = [[item.get(h) for h in headers] for item in items]
 
         match self.mode:
-            case OutputFormatWithAuto.human:  # padded table, adaptive truncation, SCREAMING_SNAKE headers
+            case OutputFormat.human:  # padded table, adaptive truncation, SCREAMING_SNAKE headers
                 screaming_headers = [_to_header(h) for h in headers]
                 formatted_rows: list[list[str]] = [[_format_table_value_human(v) for v in row] for row in rows]
 
@@ -132,13 +131,13 @@ class Output:
                 )
                 if is_truncated:
                     self.hint("Use `--no-truncate` or `--format json` to display full values.")
-            case OutputFormatWithAuto.agent:  # TSV, no truncation, full timestamps
+            case OutputFormat.agent:  # TSV, no truncation, full timestamps
                 print("\t".join(headers))
                 for row in rows:
                     print("\t".join(_format_table_cell_agent(v) for v in row))
-            case OutputFormatWithAuto.json:  # compact JSON array
+            case OutputFormat.json:  # compact JSON array
                 print(json.dumps(list(items), default=str))
-            case OutputFormatWithAuto.quiet:  # id_key column (or first column), one per line
+            case OutputFormat.quiet:  # id_key column (or first column), one per line
                 quiet_key = id_key or headers[0]
                 for item in items:
                     print(item.get(quiet_key, ""))
@@ -150,27 +149,27 @@ class Output:
         """
         if dataclasses.is_dataclass(data) and not isinstance(data, type):
             data = _dataclass_to_dict(data)
-        if self.mode == OutputFormatWithAuto.quiet and id_key is not None:
+        if self.mode == OutputFormat.quiet and id_key is not None:
             print(data.get(id_key, ""))
             return
-        indent = 2 if self.mode == OutputFormatWithAuto.human else None
+        indent = 2 if self.mode == OutputFormat.human else None
         print(json.dumps(data, indent=indent, default=str))
 
     def result(self, message: str, **data: Any) -> None:
         """Print a success summary to stdout."""
         match self.mode:
-            case OutputFormatWithAuto.human:  # ✓ message + key: value lines
+            case OutputFormat.human:  # ✓ message + key: value lines
                 parts = [ANSI.green(f"✓ {message}")]
                 for k, v in data.items():
                     if v is not None:
                         parts.append(f"  {k}: {v}")
                 print("\n".join(parts))
-            case OutputFormatWithAuto.agent:  # key=val pairs, space-separated
+            case OutputFormat.agent:  # key=val pairs, space-separated
                 parts = [f"{k}={v}" for k, v in data.items() if v is not None]
                 print(" ".join(parts) if parts else message)
-            case OutputFormatWithAuto.json:  # json.dumps(data), message ignored
+            case OutputFormat.json:  # json.dumps(data), message ignored
                 print(json.dumps(data, default=str) if data else "")
-            case OutputFormatWithAuto.quiet:  # first value only
+            case OutputFormat.quiet:  # first value only
                 values = list(data.values())
                 if values:
                     print(values[0])
@@ -181,34 +180,34 @@ class Output:
         """
         if yes:
             return
-        if self.mode != OutputFormatWithAuto.human:
+        if self.mode != OutputFormat.human:
             raise ConfirmationError(f"{message} Use {confirm_param} to skip confirmation.")
         typer.confirm(message, default=default, abort=True)
 
     def status(self, message: str | None = None) -> StatusLine:
         """Return a status line that emits only in human mode (no-op otherwise)."""
-        status = StatusLine(enabled=self.mode == OutputFormatWithAuto.human)
+        status = StatusLine(enabled=self.mode == OutputFormat.human)
         if message is not None:
             status.update(message)
         return status
 
     def warning(self, message: str) -> None:
         """Print a non-fatal warning to stderr (all modes)."""
-        if self.mode == OutputFormatWithAuto.human:
+        if self.mode == OutputFormat.human:
             print(ANSI.yellow(f"Warning: {message}"), file=sys.stderr)
         else:
             print(f"Warning: {message}", file=sys.stderr)
 
     def error(self, message: str) -> None:
         """Print an error to stderr (all modes)."""
-        if self.mode == OutputFormatWithAuto.human:
+        if self.mode == OutputFormat.human:
             print(ANSI.red(f"Error: {message}"), file=sys.stderr)
         else:
             print(f"Error: {message}", file=sys.stderr)
 
     def hint(self, message: str) -> None:
         """Print a helpful hint to stderr (human: gray, agent/json: plain text)."""
-        if self.mode == OutputFormatWithAuto.human:
+        if self.mode == OutputFormat.human:
             print(ANSI.gray(f"Hint: {message}"), file=sys.stderr)
         else:
             print(f"Hint: {message}", file=sys.stderr)

--- a/src/huggingface_hub/cli/buckets.py
+++ b/src/huggingface_hub/cli/buckets.py
@@ -37,7 +37,7 @@ from ._cli_utils import (
     typer_factory,
 )
 from ._file_listing import format_size, print_file_listing
-from ._output import OutputFormatWithAuto, out
+from ._output import OutputFormat, out
 
 
 logger = logging.get_logger(__name__)
@@ -240,7 +240,7 @@ def _list_files(
     token: str | None,
 ) -> None:
     """List files in a bucket."""
-    if as_tree and out.mode == OutputFormatWithAuto.json:
+    if as_tree and out.mode == OutputFormat.json:
         raise typer.BadParameter("Cannot use --tree with --format json.")
 
     api = get_hf_api(token=token)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,7 +15,7 @@ from huggingface_hub._dataset_viewer import DatasetParquetEntry
 from huggingface_hub._jobs_api import JobInfo, _create_job_spec
 from huggingface_hub._space_api import Volume
 from huggingface_hub.cli._cli_utils import RepoType, parse_volumes
-from huggingface_hub.cli._output import OutputFormatWithAuto, out
+from huggingface_hub.cli._output import OutputFormat, out
 from huggingface_hub.cli.cache import CacheDeletionCounts
 from huggingface_hub.cli.download import download
 from huggingface_hub.cli.hf import app
@@ -699,7 +699,7 @@ class TestResolveUploadPaths:
 class TestUploadImpl:
     @pytest.fixture(autouse=True)
     def _quiet_mode(self):
-        out.set_mode(OutputFormatWithAuto.quiet)
+        out.set_mode(OutputFormat.quiet)
 
     def test_upload_folder_mock(self, *_: object) -> None:
         api = Mock()
@@ -953,7 +953,7 @@ class TestDownloadCommand:
 class TestDownloadImpl:
     @pytest.fixture(autouse=True)
     def _quiet_mode(self):
-        out.set_mode(OutputFormatWithAuto.quiet)
+        out.set_mode(OutputFormat.quiet)
 
     @patch("huggingface_hub.cli.download.snapshot_download")
     @patch("huggingface_hub.cli.download.hf_hub_download")

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -19,14 +19,14 @@ import sys
 
 import pytest
 
-from huggingface_hub.cli._output import Output, OutputFormatWithAuto, _to_header
+from huggingface_hub.cli._output import Output, OutputFormat, _to_header
 from huggingface_hub.errors import ConfirmationError
 
 
-HUMAN = OutputFormatWithAuto.human
-AGENT = OutputFormatWithAuto.agent
-JSON = OutputFormatWithAuto.json
-QUIET = OutputFormatWithAuto.quiet
+HUMAN = OutputFormat.human
+AGENT = OutputFormat.agent
+JSON = OutputFormat.json
+QUIET = OutputFormat.quiet
 
 
 def _normalize(text: str) -> list[str]:
@@ -77,7 +77,7 @@ def test_auto_resolves_to_agent(monkeypatch):
 def test_auto_resets_after_explicit():
     o = Output()
     o.set_mode(QUIET)
-    o.set_mode(OutputFormatWithAuto.auto)
+    o.set_mode(OutputFormat.auto)
     assert o.mode == HUMAN
 
 


### PR DESCRIPTION
Stacked on top of #4285.

Now that the legacy `OutputFormat` (the old `table | json` enum) has been deleted, the name is free. `OutputFormatWithAuto` was always the "real" enum — covering `auto | human | agent | json | quiet` — so this drops the disambiguating suffix.

- Pure rename across `_output.py`, `_cli_utils.py`, `_file_listing.py`, `buckets.py`, and the two test files.
- Also removes a stale `TODO` comment in `_output.py` that referenced the (now deleted) legacy enum.

No behavior change.

```
$ pytest tests/test_cli_output.py tests/test_cli.py
======================= 278 passed, 7 warnings in 12.91s =======================
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical rename and comment cleanup only; tests confirm unchanged CLI output behavior.
> 
> **Overview**
> Renames the CLI output-mode enum from **`OutputFormatWithAuto`** to **`OutputFormat`** everywhere it is imported or referenced (`_output.py`, `_cli_utils.py`, `_file_listing.py`, `buckets.py`, and CLI tests). The enum still covers **`auto`**, **`human`**, **`agent`**, **`json`**, and **`quiet`**; only the type name changes now that the older, narrower **`OutputFormat`** was removed elsewhere.
> 
> Also drops a stale **TODO** in `_output.py` that pointed at that legacy enum. **No runtime or CLI behavior change**—format flag handling and `out.set_mode()` logic are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50e1fa9e7df4bd555d698aa8a7a328bc324064a2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->