### PR TITLE
[CLI] Auto right-align numeric columns in human table output

### DIFF
--- a/src/huggingface_hub/cli/_output.py
+++ b/src/huggingface_hub/cli/_output.py
@@ -121,7 +121,9 @@ class Output:
 
                 is_truncated = _truncate_columns(screaming_headers, formatted_rows, no_truncate=self.no_truncate)
 
-                screaming_alignments = {_to_header(k): v for k, v in (alignments or {}).items()}
+                inferred = _infer_alignments(headers, rows)
+                inferred.update(alignments or {})
+                screaming_alignments = {_to_header(k): v for k, v in inferred.items()}
                 print(
                     tabulate(
                         cast("list[list[str | int]]", formatted_rows),
@@ -247,6 +249,15 @@ def _to_header(name: str) -> str:
     """Convert a camelCase or PascalCase string to SCREAMING_SNAKE_CASE."""
     s = re.sub(r"([a-z])([A-Z])", r"\1_\2", name)
     return s.upper()
+
+
+def _infer_alignments(headers: list[str], rows: list[list[Any]]) -> dict[str, str]:
+    """Return ``{"col": "right"}`` for columns where every non-None value is numeric."""
+    result: dict[str, str] = {}
+    for c, h in enumerate(headers):
+        if all(row[c] is None or isinstance(row[c], (int, float)) for row in rows):
+            result[h] = "right"
+    return result
 
 
 def _format_table_value_human(value: Any) -> str:

--- a/src/huggingface_hub/cli/_output.py
+++ b/src/huggingface_hub/cli/_output.py
@@ -121,8 +121,7 @@ class Output:
 
                 is_truncated = _truncate_columns(screaming_headers, formatted_rows, no_truncate=self.no_truncate)
 
-                inferred = _infer_alignments(headers, rows)
-                inferred.update(alignments or {})
+                inferred = {**_infer_alignments(headers, rows), **(alignments or {})}
                 screaming_alignments = {_to_header(k): v for k, v in inferred.items()}
                 print(
                     tabulate(

--- a/src/huggingface_hub/cli/_output.py
+++ b/src/huggingface_hub/cli/_output.py
@@ -255,7 +255,7 @@ def _infer_alignments(headers: list[str], rows: list[list[Any]]) -> dict[str, st
     """Return ``{"col": "right"}`` for columns where every non-None value is numeric."""
     result: dict[str, str] = {}
     for c, h in enumerate(headers):
-        if all(row[c] is None or isinstance(row[c], (int, float)) for row in rows):
+        if all(row[c] is None or (isinstance(row[c], (int, float)) and not isinstance(row[c], bool)) for row in rows):
             result[h] = "right"
     return result
 

--- a/src/huggingface_hub/cli/buckets.py
+++ b/src/huggingface_hub/cli/buckets.py
@@ -229,7 +229,7 @@ def _list_buckets(
         }
         for bucket in api.list_buckets(namespace=namespace, search=search)
     ]
-    out.table(items, alignments={"size": "right", "total_files": "right"})
+    out.table(items, alignments={"size": "right"})
 
 
 def _list_files(

--- a/src/huggingface_hub/cli/datasets.py
+++ b/src/huggingface_hub/cli/datasets.py
@@ -182,7 +182,6 @@ def datasets_leaderboard(
         results,
         headers=["rank", "model_id", "value", "source"],
         id_key="model_id",
-        alignments={"rank": "right", "value": "right"},
     )
     out.hint("Use 'hf datasets ls --filter benchmark:official' to list available leaderboards.")
     if leaderboard:

--- a/src/huggingface_hub/cli/discussions.py
+++ b/src/huggingface_hub/cli/discussions.py
@@ -147,7 +147,6 @@ def discussion_list(
         items,
         headers=["num", "title", "is_pull_request", "status", "author", "created_at"],
         id_key="num",
-        alignments={"num": "right"},
     )
 
 

--- a/src/huggingface_hub/cli/extensions.py
+++ b/src/huggingface_hub/cli/extensions.py
@@ -207,7 +207,7 @@ def extension_search() -> None:
             }
         )
 
-    out.table(rows, id_key="repo", alignments={"stars": "right"})
+    out.table(rows, id_key="repo")
 
 
 @extensions_cli.command("remove | rm", examples=["hf extensions remove claude"])

--- a/src/huggingface_hub/cli/papers.py
+++ b/src/huggingface_hub/cli/papers.py
@@ -133,7 +133,6 @@ def papers_ls(
     out.table(
         results,
         headers=["id", "title", "upvotes", "comments", "published_at", "submitted_by_name"],
-        alignments={"upvotes": "right", "comments": "right"},
     )
 
 
@@ -153,7 +152,7 @@ def papers_search(
     """Search papers on the Hub."""
     api = get_hf_api(token=token)
     results = [_dataclass_to_dict(paper_info) for paper_info in api.list_papers(query=query, limit=limit)]
-    out.table(results, headers=["id", "title", "summary", "upvotes", "published_at"], alignments={"upvotes": "right"})
+    out.table(results, headers=["id", "title", "summary", "upvotes", "published_at"])
 
 
 @papers_cli.command(

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -131,8 +131,8 @@ def test_table(check):
         human="""
         ID                                  DOWNLOADS LIKES PIPELINE_TAG
         ----------------------------------- --------- ----- ----------------------------
-        openai/gpt-oss-120b                 4133088   4631  text-generation
-        CohereLabs/cohere-transcribe-03-... 58683     670   automatic-speech-recognition
+        openai/gpt-oss-120b                   4133088  4631 text-generation
+        CohereLabs/cohere-transcribe-03-...     58683   670 automatic-speech-recognition
         """,
         agent="""
         id\tdownloads\tlikes\tpipeline_tag
@@ -179,7 +179,7 @@ def test_table_adaptive_shrinks_widest_column(monkeypatch, capsys):
         == """
 ID                                 LIKES
 ---------------------------------- -----
-some-org/some-very-long-model-n... 9
+some-org/some-very-long-model-n...     9
 """.strip()
     )
 


### PR DESCRIPTION
I feel it's cleaner to right-align numbers by default.

This PR automatically right-aligns all numeric-only columns (all values are `int`, `float`, or `None`) in human table output. Explicit `alignments` passed to `out.table()` still take precedence.

Removed now-redundant explicit `alignments` from `papers.py`, `discussions.py`, `extensions.py`, `datasets.py`, and partially from `buckets.py` (`total_files` is auto-inferred, `size` kept explicit since it can be a formatted string).

### before

```
✗ hf models ls     
ID                   CREATED_AT DOWNLOADS LIBRARY_NAME          LIKES PIPELINE_TAG       PRIVATE TAGS                  TRENDING_SCORE
-------------------- ---------- --------- --------------------- ----- ------------------ ------- --------------------- --------------
openbmb/MiniCPM5-1B  2026-05-21 15629     transformers          457   text-generation            transformers, safe... 405           
bytedance-researc... 2026-05-15 2506      Lance                 947   any-to-any                 Lance, safetensors... 395           
meituan-longcat/L... 2026-05-21 0         diffusers             355                              diffusers, onnx, s... 345           
HauhauCS/Qwen3.6-... 2026-04-17 1956558                         971   image-text-to-text         gguf, uncensored, ... 244           
```

### after

```
✗ hf models ls 
ID                   CREATED_AT DOWNLOADS LIBRARY_NAME          LIKES PIPELINE_TAG       PRIVATE TAGS                  TRENDING_SCORE
-------------------- ---------- --------- --------------------- ----- ------------------ ------- --------------------- --------------
openbmb/MiniCPM5-1B  2026-05-21     15629 transformers            457 text-generation            transformers, safe...            405
bytedance-researc... 2026-05-15      2506 Lance                   947 any-to-any                 Lance, safetensors...            395
meituan-longcat/L... 2026-05-21         0 diffusers               355                            diffusers, onnx, s...            345
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only change to CLI table formatting; explicit alignments still win, with a special case for formatted size strings in bucket listings.
> 
> **Overview**
> Human-mode CLI tables now **auto right-align** columns whose non-`None` cells are all numeric (`int`/`float`, excluding `bool`), via new `_infer_alignments` in `_output.py`. Explicit `alignments` passed to `out.table()` still override inference.
> 
> Several commands drop redundant manual alignment (`papers`, `discussions`, `extensions`, `datasets` leaderboard, etc.). **`buckets list`** keeps `size: right` only when values may be human-readable strings; `total_files` is inferred. Tests in `test_cli_output.py` expect the updated column spacing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38e8a8ea18ef0208dfe9a2e21457e696e0f3d35e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->