### PR TITLE
[Docs] Document missing parameters in lfs, hf_file_system, and repocard_data

### DIFF
--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -718,6 +718,8 @@ class HfFileSystem(fsspec.AbstractFileSystem, metaclass=_Cached):  # ty: ignore[
         Args:
             path (`str`):
                 Path pattern to match.
+            maxdepth (`int`, *optional*):
+                Maximum depth to descend into directories. By default, no limit.
 
         Returns:
             `list[str]`: List of paths matching the pattern.

--- a/src/huggingface_hub/lfs.py
+++ b/src/huggingface_hub/lfs.py
@@ -113,6 +113,9 @@ def post_lfs_batch_info(
         upload_infos (`Iterable` of `UploadInfo`):
             `UploadInfo` for the files that are being uploaded, typically obtained
             from `CommitOperationAdd.upload_info`
+        token (`str` or `None`):
+            An authentication token (see https://huggingface.co/settings/token).
+            Pass `None` to fall back to the local cached token (or no token if unauthenticated).
         repo_type (`str`):
             Type of the repo to upload to: `"model"`, `"dataset"` or `"space"`.
         repo_id (`str`):
@@ -120,6 +123,8 @@ def post_lfs_batch_info(
             by a `/`.
         revision (`str`, *optional*):
             The git revision to upload to.
+        endpoint (`str`, *optional*):
+            The Hub endpoint to send the request to. Defaults to the value of `HF_ENDPOINT`.
         headers (`dict`, *optional*):
             Additional headers to include in the request
         transfers (`list`, *optional*):
@@ -210,8 +215,14 @@ def lfs_upload(
         lfs_batch_action (`dict`):
             Upload instructions from the LFS batch endpoint for this object. See [`~utils.lfs.post_lfs_batch_info`] for
             more details.
+        token (`str`, *optional*):
+            An authentication token (see https://huggingface.co/settings/token). Used to call the
+            optional LFS verify step at the end of the upload. If `None`, falls back to the local
+            cached token.
         headers (`dict`, *optional*):
             Headers to include in the request, including authentication and user agent headers.
+        endpoint (`str`, *optional*):
+            The Hub endpoint to send the request to. Defaults to the value of `HF_ENDPOINT`.
 
     Raises:
         [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)

--- a/src/huggingface_hub/repocard_data.py
+++ b/src/huggingface_hub/repocard_data.py
@@ -201,6 +201,11 @@ class CardData:
         Args:
             line_break (str, *optional*):
                 The line break to use when dumping to yaml.
+            original_order (`list[str]`, *optional*):
+                If provided, reorder the metadata fields to match this list before dumping.
+                Any keys not in `original_order` are appended after the listed keys, preserving
+                their existing relative order. Useful for round-tripping a YAML block without
+                shuffling its keys.
 
         Returns:
             `str`: CardData represented as a YAML block.


### PR DESCRIPTION
## Summary

Four parameters in public functions were missing from their docstring `Args:` sections.

- **`post_lfs_batch_info()`** in `lfs.py` — `token` (a required parameter) and `endpoint` were both missing. `token` is the auth token and is required for the call to work; users had to read the source to discover it.
- **`lfs_upload()`** in `lfs.py` — `token` and `endpoint` missing.
- **`HfFileSystem.glob()`** in `hf_file_system.py` — `maxdepth` missing. The sibling method `HfFileSystem.find()` already documents the same fsspec parameter; I reused that wording for consistency.
- **`CardData.to_yaml()`** in `repocard_data.py` — `original_order` missing. This is the parameter that lets callers preserve the original key order when round-tripping a YAML block.

No code logic was changed — pure docstring additions.

## Files changed

- `src/huggingface_hub/lfs.py`
- `src/huggingface_hub/hf_file_system.py`
- `src/huggingface_hub/repocard_data.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only docstring text was added; no executable code paths changed.
> 
> **Overview**
> **Docstring-only PR** — fills in missing `Args:` entries for public APIs in three modules; **no runtime or behavior changes**.
> 
> In **`lfs.py`**, **`post_lfs_batch_info`** now documents **`token`** (auth; `None` uses cached token) and **`endpoint`** (Hub base URL). **`lfs_upload`** documents the same **`token`** and **`endpoint`** parameters.
> 
> In **`hf_file_system.py`**, **`HfFileSystem.glob`** documents **`maxdepth`**, aligned with the existing **`find`** docstring and fsspec semantics.
> 
> In **`repocard_data.py`**, **`CardData.to_yaml`** documents **`original_order`** for preserving YAML key order when round-tripping README metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bad0e357ba866dafad47c0b37b270e01a103302c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->