### PR TITLE
Skip repo creation when using short-lived JWT tokens with CLI

### DIFF
--- a/src/huggingface_hub/_upload_large_folder.py
+++ b/src/huggingface_hub/_upload_large_folder.py
@@ -29,7 +29,7 @@ from urllib.parse import quote
 from ._commit_api import CommitOperationAdd, UploadInfo, _fetch_upload_modes
 from ._local_folder import LocalUploadFileMetadata, LocalUploadFilePaths, get_local_upload_paths, read_upload_metadata
 from .constants import DEFAULT_REVISION, REPO_TYPES
-from .utils import DEFAULT_IGNORE_PATTERNS, _format_size, filter_repo_objects, tqdm
+from .utils import DEFAULT_IGNORE_PATTERNS, _format_size, filter_repo_objects, get_token, tqdm
 from .utils._runtime import is_xet_available
 from .utils.sha import sha_fileobj
 
@@ -193,9 +193,16 @@ def upload_large_folder_internal(
         num_workers = max(nb_cores // 2, 1)  # Use at most half of cpu cores
 
     # 2. Create repo if missing
-    repo_url = api.create_repo(repo_id=repo_id, repo_type=repo_type, private=private, exist_ok=True)
-    logger.info(f"Repo created: {repo_url}")
-    repo_id = repo_url.repo_id
+    # Skip `create_repo` when authenticated with a short-lived JWT (`hf_jwt_...`):
+    # those tokens are scoped to a specific repo and don't have permission to create
+    # repos, so calling `create_repo` would fail. The repo is assumed to already exist.
+    effective_token = api.token if isinstance(api.token, str) else get_token()
+    if isinstance(effective_token, str) and effective_token.startswith("hf_jwt_"):
+        logger.info("Skipping `create_repo` (JWT token detected): assuming repo already exists.")
+    else:
+        repo_url = api.create_repo(repo_id=repo_id, repo_type=repo_type, private=private, exist_ok=True)
+        logger.info(f"Repo created: {repo_url}")
+        repo_id = repo_url.repo_id
 
     # Warn on too many commits
     try:

--- a/src/huggingface_hub/cli/upload.py
+++ b/src/huggingface_hub/cli/upload.py
@@ -55,6 +55,7 @@ import typer
 from huggingface_hub import logging
 from huggingface_hub._commit_scheduler import CommitScheduler
 from huggingface_hub.errors import RevisionNotFoundError
+from huggingface_hub.utils import get_token
 
 from ._cli_utils import (
     PrivateOpt,
@@ -209,15 +210,23 @@ def upload(
         # Otherwise, create repo and proceed with the upload
         if not os.path.isfile(resolved_local_path) and not os.path.isdir(resolved_local_path):
             raise FileNotFoundError(f"No such file or directory: '{resolved_local_path}'.")
-        created = api.create_repo(
-            repo_id=repo_id,
-            repo_type=repo_type_str,
-            exist_ok=True,
-            private=private,
-            space_sdk="gradio" if repo_type_str == "space" else None,
-            # ^ We don't want it to fail when uploading to a Space => let's set Gradio by default.
-            # ^ I'd rather not add CLI args to set it explicitly as we already have `hf repos create` for that.
-        ).repo_id
+
+        # Skip `create_repo` when authenticated with a short-lived JWT (`hf_jwt_...`):
+        # those tokens are scoped to a specific repo and don't have permission to create
+        # repos, so calling `create_repo` would fail. The repo is assumed to already exist.
+        effective_token = token if isinstance(token, str) else api.token if isinstance(api.token, str) else get_token()
+        if isinstance(effective_token, str) and effective_token.startswith("hf_jwt_"):
+            created = repo_id
+        else:
+            created = api.create_repo(
+                repo_id=repo_id,
+                repo_type=repo_type_str,
+                exist_ok=True,
+                private=private,
+                space_sdk="gradio" if repo_type_str == "space" else None,
+                # ^ We don't want it to fail when uploading to a Space => let's set Gradio by default.
+                # ^ I'd rather not add CLI args to set it explicitly as we already have `hf repos create` for that.
+            ).repo_id
 
         # Check if branch already exists and if not, create it
         if revision is not None and not create_pr:


### PR DESCRIPTION
See https://github.com/huggingface/hub-docs/pull/2506 / https://moon-ci-docs.huggingface.co/docs/hub/pr_2506/en/trusted-publishers (not published to main doc yet)

```yaml
      - name: Upload checkpoint
        # `hf upload` calls create_repo() first, which a Trusted Publisher token
        # isn't allowed to do. Call upload_folder() directly to skip that step.
        run: |
          python - <<'PY'
          import os
          from huggingface_hub import upload_folder

          upload_folder(
              repo_id="acme/awesome-model",
              folder_path="./checkpoint",
              commit_message=f"Publish from {os.environ['GITHUB_SHA'][:7]}",
          )
          PY
```

We have to call the API directly instead of being able to use the CLI (which sees a 401 from the JWT and gives up)


This PR skips the create repo in case of jwt - the JWT doesn't work on create_repo endpoint because it's not a scoped route (and doesn't support jwt auth anyway)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, conditional branch around repo creation for a specific token prefix; normal PAT flows unchanged.
> 
> **Overview**
> **`hf upload` and large-folder uploads** no longer call `create_repo` when the effective auth token is a short-lived JWT (`hf_jwt_...`). The code resolves the token from the CLI/API/`get_token()` and, for JWTs, assumes the target repo already exists and continues with upload only.
> 
> This unblocks **Trusted Publisher** / CI flows where JWTs are repo-scoped and cannot create repos (which previously caused 401s and forced workarounds like calling `upload_folder()` directly instead of the CLI).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit baf96e2e522fb6243a3d2ea804931ef3cc86d664. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->