### PR TITLE
Fix ~ user home not expanded in local_dir and cache_dir on file download

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -955,14 +955,15 @@ def hf_hub_download(
         # Respect environment variable above user value
         etag_timeout = constants.HF_HUB_ETAG_TIMEOUT
 
-    if cache_dir is None:
-        cache_dir = constants.HF_HUB_CACHE
     if revision is None:
         revision = constants.DEFAULT_REVISION
-    if isinstance(cache_dir, Path):
-        cache_dir = str(cache_dir)
-    if isinstance(local_dir, Path):
-        local_dir = str(local_dir)
+
+    if cache_dir is None:
+        cache_dir = constants.HF_HUB_CACHE
+    cache_dir = str(Path(cache_dir).expanduser().resolve())
+
+    if local_dir is not None:
+        local_dir = str(Path(local_dir).expanduser().resolve())
 
     if subfolder == "":
         subfolder = None


### PR DESCRIPTION
Fix https://github.com/huggingface/huggingface_hub/issues/4292 cc @monkmonk99

When passing `local_dir` or `cache_dir` with a `~`, the user home was not expanded, leading to errors down the line when downloading files. This PR fixes it by resolving `cache_dir = str(Path(cache_dir).expanduser().resolve())` before any path manipulation.

I did not add a test as I wasn't sure how to properly do that (home user depends on the machine). I think it's fine like this.

### Before / after

```sh
(main) ✗ hf download tiiuae/falcon-7b-instruct config.json --cache-dir "~/.local/huggingface/hub/"
Traceback (most recent call last):
(...)
  File "/home/wauplin/projects/huggingface_hub/src/huggingface_hub/file_download.py", line 677, in _create_symlink
    os.symlink(src_rel_or_abs, abs_dst)
FileNotFoundError: [Errno 2] No such file or directory: '../../blobs/84d8843072cbc300692c6bccff5b9c08c430498e' -> '/home/wauplin/.local/huggingface/hub/models--tiiuae--falcon-7b-instruct/snapshots/8782b5c5d8c9290412416618f36a133653e85285/config.json'

(main) ✗ git switch fix-4292-cache-dir-not-resolved                                               
Switched to branch 'fix-4292-cache-dir-not-resolved'
Your branch is up to date with 'origin/fix-4292-cache-dir-not-resolved'.

(fix-4292-cache-dir-not-resolved) ✗ hf download tiiuae/falcon-7b-instruct config.json --cache-dir "~/.local/huggingface/hub/"
config.json: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████| 1.05k/1.05k [00:00<00:00, 3.16MB/s]
✓ Downloaded
  path: /home/wauplin/.local/huggingface/hub/models--tiiuae--falcon-7b-instruct/snapshots/8782b5c5d8c9290412416618f36a133653e85285/config.json
```