### PR TITLE
Do not fail on repo/bucket creation if HTTP 401 and already exists

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -12882,10 +12882,12 @@ class HfApi:
             hf_raise_for_status(response)
         except HfHubHTTPError as err:
             if exist_ok and err.response.status_code == 409:
-                # Repo already exists and `exist_ok=True`
+                # Bucket already exists and `exist_ok=True`
                 pass
-            elif exist_ok and err.response.status_code == 403:
-                # No write permission on the namespace but repo might already exist
+            elif exist_ok and err.response.status_code in (401, 403):
+                # 401 -> if JWT token without create bucket scope
+                # 403 -> if no write permission on the namespace
+                # In both cases, bucket might already exist
                 try:
                     self.bucket_info(bucket_id=bucket_id, token=token)
                     return BucketUrl(f"{self.endpoint}/buckets/{bucket_id}", endpoint=self.endpoint)

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -4598,8 +4598,10 @@ class HfApi:
             if exist_ok and err.response.status_code == 409:
                 # Repo already exists and `exist_ok=True`
                 pass
-            elif exist_ok and err.response.status_code == 403:
-                # No write permission on the namespace but repo might already exist
+            elif exist_ok and err.response.status_code in (401, 403):
+                # 401 -> if JWT token without create repo scope
+                # 403 -> if no write permission on the namespace
+                # In both cases, repo might already exist
                 try:
                     self.repo_info(repo_id=repo_id, repo_type=repo_type, token=token)
                     if repo_type is None or repo_type == constants.REPO_TYPE_MODEL:


### PR DESCRIPTION
To be merged instead of https://github.com/huggingface/huggingface_hub/pull/4290

With the introduction of JWT tokens, it is possible to get a HTTP 401 on repo creation even if the user is authenticated and has correct rights to push to that repo. If the repo already exists and `exists_ok=True` has been passed, let's not raise any error and continue normally.

The auto-repo creation is common in the ecosystem (in `upload_folder` but also transformers/diffusers/etc. 's `push_to_hub`) so an ad-hoc fix like in https://github.com/huggingface/huggingface_hub/pull/4290 wouldn't be robust. The solution here fixes the problem inside `create_repo` directly.

**EDIT:** also added the fix to `create_bucket` since bucket support for "Trusted Publishers" is also on the roadmap ( https://github.com/huggingface-internal/moon-landing/pull/17449#issuecomment-4558854897). 

cc @coyotte508 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to error handling when exist_ok=True; behavior only relaxes failures when the target already exists.
> 
> **Overview**
> When **`exist_ok=True`**, **`create_repo`** and **`create_bucket`** now treat **HTTP 401** like **403**: if creation fails for auth reasons (e.g. JWT without create-repo/create-bucket scope, or no write on the namespace), they probe whether the repo/bucket already exists via **`repo_info`** / **`bucket_info`** and return normally instead of raising.
> 
> This targets flows such as **`upload_folder`** and **`push_to_hub`** that auto-create repos, where a 401 on create could wrongly fail even when the user can push to an existing repo. A comment typo in the bucket path was fixed (**“Repo” → “Bucket”**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7eeca9a30ed6ae4265440381d257f46f9908be25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->