### PR TITLE
[Docs] Document missing endpoint and template_str parameters

### DIFF
--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -172,6 +172,8 @@ def snapshot_download(
                 - If a string, it's used as the authentication token.
         headers (`dict`, *optional*):
             Additional headers to include in the request. Those headers take precedence over the others.
+        endpoint (`str`, *optional*):
+            The Hub endpoint to send the request to. Defaults to the value of `HF_ENDPOINT`.
         local_files_only (`bool`, *optional*, defaults to `False`):
             If `True`, do not download any files even if they are not in `cache_dir` or `local_dir`.
         allow_patterns (`list[str]` or `str`, *optional*):

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -919,6 +919,8 @@ def hf_hub_download(
             local cached file if it exists.
         headers (`dict`, *optional*):
             Additional headers to be sent with the request.
+        endpoint (`str`, *optional*):
+            The Hub endpoint to send the request to. Defaults to the value of `HF_ENDPOINT`.
         tqdm_class (`tqdm`, *optional*):
             If provided, overwrites the default behavior for the progress bar. Passed
             argument must inherit from `tqdm.auto.tqdm` or at least mimic its behavior.

--- a/src/huggingface_hub/repocard.py
+++ b/src/huggingface_hub/repocard.py
@@ -305,6 +305,9 @@ class RepoCard:
             template_path (`str`, *optional*):
                 A path to a markdown file with optional Jinja template variables that can be filled
                 in with `template_kwargs`. Defaults to the default template.
+            template_str (`str`, *optional*):
+                A raw Jinja template string with optional variables. Used when neither `template_path`
+                nor the default template is appropriate. Ignored if `template_path` is also provided.
 
         Returns:
             [`huggingface_hub.repocard.RepoCard`]: A RepoCard instance with the specified card data and content from the
@@ -355,6 +358,9 @@ class ModelCard(RepoCard):
             template_path (`str`, *optional*):
                 A path to a markdown file with optional Jinja template variables that can be filled
                 in with `template_kwargs`. Defaults to the default template.
+            template_str (`str`, *optional*):
+                A raw Jinja template string with optional variables. Used when neither `template_path`
+                nor the default template is appropriate. Ignored if `template_path` is also provided.
 
         Returns:
             [`huggingface_hub.ModelCard`]: A ModelCard instance with the specified card data and content from the
@@ -436,6 +442,9 @@ class DatasetCard(RepoCard):
             template_path (`str`, *optional*):
                 A path to a markdown file with optional Jinja template variables that can be filled
                 in with `template_kwargs`. Defaults to the default template.
+            template_str (`str`, *optional*):
+                A raw Jinja template string with optional variables. Used when neither `template_path`
+                nor the default template is appropriate. Ignored if `template_path` is also provided.
 
         Returns:
             [`huggingface_hub.DatasetCard`]: A DatasetCard instance with the specified card data and content from the


### PR DESCRIPTION
## Summary

Fills five `Args` entries that exist in the public-API signatures but aren't documented. Same shape as #4289 — pure docstring additions, no behaviour change.

- `hf_hub_download` — add `endpoint` (`file_download.py`).
- `snapshot_download` — add `endpoint` (`_snapshot_download.py`).
- `RepoCard.from_template` / `ModelCard.from_template` / `DatasetCard.from_template` — add `template_str` (`repocard.py`, three docstrings).

`endpoint` text matches the wording introduced for `lfs.py` / `repocard_data.py` in #4289 (*"The Hub endpoint to send the request to. Defaults to the value of `HF_ENDPOINT`."*). `template_str` text notes the precedence rule the implementation already enforces (`template_path` overrides `template_str` when both are supplied).

`make style` and `make quality` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstring-only updates with no code or behavior changes.
> 
> **Overview**
> Documents five public API parameters that were already in function signatures but missing from **Args** sections—no runtime changes.
> 
> **Download APIs:** `hf_hub_download` (`file_download.py`) and `snapshot_download` (`_snapshot_download.py`) now document **`endpoint`** (Hub URL; defaults to `HF_ENDPOINT`), aligned with wording from #4289.
> 
> **Repo cards:** `RepoCard.from_template`, `ModelCard.from_template`, and `DatasetCard.from_template` (`repocard.py`) now document **`template_str`** for inline Jinja templates, including that **`template_path` takes precedence** when both are set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ff8c4d692ec3c1ab9c1ab1a2772fe64d3031a73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->