### PR TITLE
[CLI] inline enum choices in the generated CLI skill

### DIFF
--- a/src/huggingface_hub/cli/skills.py
+++ b/src/huggingface_hub/cli/skills.py
@@ -137,8 +137,7 @@ skills_cli = typer_factory(help="Manage skills for AI assistants.")
 def _type_hint(param) -> str:
     """Value hint for an option: enum choices inline as ``[a|b|c]``, otherwise the TYPE name.
 
-    e.g. `--sort [downloads|likes|trending_score]` instead of `--sort CHOICE`, so agents pick a
-    valid value first try instead of guessing.
+    e.g. `--sort [downloads|likes|trending_score]` instead of `--sort CHOICE`.
     """
     choices = getattr(param.type, "choices", None)
     if choices:

--- a/src/huggingface_hub/cli/skills.py
+++ b/src/huggingface_hub/cli/skills.py
@@ -125,13 +125,25 @@ _COMMON_FLAG_HELP_OVERRIDES: dict[str, str] = {
 # accept them. They aren't real click params on the command (they're consumed
 # globally — see ``_consume_format_flags_for_leaf`` in ``_cli_utils.py``) so we
 # add them synthetically here.
-_GLOBAL_FORMAT_INLINE_FLAGS = ["--format CHOICE"]
+_GLOBAL_FORMAT_INLINE_FLAGS = ["--format [auto|human|agent|json|quiet]"]
 _GLOBAL_COMMON_FLAGS: dict[str, tuple[str, str]] = {
     "--format": ("--format", "Output format."),
     "--quiet": ("-q / --quiet", "Quiet output (one ID per line)."),
 }
 
 skills_cli = typer_factory(help="Manage skills for AI assistants.")
+
+
+def _type_hint(param) -> str:
+    """Value hint for an option: enum choices inline as ``[a|b|c]``, otherwise the TYPE name.
+
+    e.g. `--sort [downloads|likes|trending_score]` instead of `--sort CHOICE`, so agents pick a
+    valid value first try instead of guessing.
+    """
+    choices = getattr(param.type, "choices", None)
+    if choices:
+        return "[" + "|".join(str(c) for c in choices) + "]"
+    return getattr(param.type, "name", "").upper() or "VALUE"
 
 
 def _format_params(cmd: Command) -> str:
@@ -144,7 +156,7 @@ def _format_params(cmd: Command) -> str:
             continue
         long_name = next((o for o in getattr(p, "opts", []) if o.startswith("--")), None)
         if long_name is not None:
-            type_name = getattr(p.type, "name", "").upper() or "VALUE"
+            type_name = _type_hint(p)
             parts.append(f"{long_name} {type_name}")
         elif p.name:
             parts.append(p.human_readable_name)
@@ -205,7 +217,7 @@ def _get_flag_names(cmd: Command, *, exclude: set[str] | None = None) -> list[st
         if getattr(p, "is_flag", False):
             flags.append(long_name)
         else:
-            type_name = getattr(p.type, "name", "").upper() or "VALUE"
+            type_name = _type_hint(p)
             flags.append(f"{long_name} {type_name}")
     if _accepts_global_format_flags(cmd):
         flags.extend(flag for flag in _GLOBAL_FORMAT_INLINE_FLAGS if not (exclude and flag.split()[0] in exclude))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3997,7 +3997,8 @@ class TestSkillGeneration:
         assert "--local-dir TEXT" in download_line
         # Common flags appear inline, except --token (kept in common-options glossary)
         assert "--token" not in download_line
-        assert "--format CHOICE" in download_line
+        # Enum options render their choices inline rather than a generic CHOICE/VALUE hint
+        assert "--format [auto|human|agent|json|quiet]" in download_line
 
     def test_format_params_distinguishes_options_from_arguments(self) -> None:
         """Required options must render with --prefix, positional args as UPPER_CASE."""


### PR DESCRIPTION
The generated `hf` CLI skill rendered `enum` options as a bare `CHOICE`, hiding the valid values, so agents guess (`--sort trending`), hit Invalid value, and waste a call recovering. This inlines the choices instead:

```md
# before
 `hf models list` — ... `--sort CHOICE ... --format CHOICE`
# after
`hf models list` — ... `--sort [created_at|downloads|last_modified|likes|trending_score] ...
--format [auto|human|agent|json|quiet]`
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to generated skill markdown; no runtime CLI behavior.
> 
> **Overview**
> The generated **`hf-cli` SKILL.md** now shows **valid enum values inline** for CLI options instead of the generic `CHOICE` placeholder.
> 
> A new **`_type_hint`** helper reads Click parameter `choices` and formats them as `[a|b|c]`; **`_format_params`** and **`_get_flag_names`** use it for required and optional flags. The synthetic global **`--format`** inline flag is updated to **`[auto|human|agent|json|quiet]`** so agents see the real output-format options in command signatures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8d6c0102e5786cdf716db2210a60a5deac83b7e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->