### PR TITLE
[Docs] Document missing parameters in hf_hub_url and preupload_lfs_files

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -225,6 +225,8 @@ def hf_hub_url(
         revision (`str`, *optional*):
             An optional Git revision id which can be a branch name, a tag, or a
             commit hash.
+        endpoint (`str`, *optional*):
+            The Hub endpoint to send the request to. Defaults to the value of `HF_ENDPOINT`.
 
     Example:
 

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -5177,7 +5177,7 @@ class HfApi:
             repo_id (`str`):
                 The repository in which you will commit the files, for example: `"username/custom_transformers"`.
 
-            operations (`Iterable` of [`CommitOperationAdd`]):
+            additions (`Iterable` of [`CommitOperationAdd`]):
                 The list of files to upload. Warning: the objects in this list will be mutated to include information
                 relative to the upload. Do not reuse the same objects for multiple commits.
 
@@ -5199,6 +5199,11 @@ class HfApi:
             num_threads (`int`, *optional*):
                 Number of concurrent threads for uploading files. Defaults to 5.
                 Setting it to 2 means at most 2 files will be uploaded concurrently.
+
+            free_memory (`bool`, *optional*, defaults to `True`):
+                If `True`, the `path_or_fileobj` attribute of each `CommitOperationAdd` is replaced by an empty
+                `bytes` object after upload to save memory. Set to `False` if you need to reuse the operation
+                objects outside of a subsequent [`create_commit`] call.
 
             gitignore_content (`str`, *optional*):
                 The content of the `.gitignore` file to know which files should be ignored. The order of priority


### PR DESCRIPTION
## Summary

Three more `Args` entries on public-API functions that were either missing or wrong, in the same shape as #4298 / #4289.

- **`hf_hub_url()`** — Args block was missing `endpoint`. Completes the triple started in #4298 (which documented it on `hf_hub_download` and `snapshot_download`).
- **`HfApi.preupload_lfs_files()`** — Args block listed `operations` but the actual signature parameter is `additions`. Renamed the entry to match. Also added the missing `free_memory` entry below `num_threads`.

No behaviour change.

## Files changed

- `src/huggingface_hub/file_download.py` — `hf_hub_url` Args: add `endpoint`
- `src/huggingface_hub/hf_api.py` — `preupload_lfs_files` Args: rename `operations` → `additions`, add `free_memory`

## Verification

- `make style` — clean
- `make quality` — clean (ruff check, generated-file checks, `ty check src` all pass)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstring-only changes with no code paths or behavior modified.
> 
> **Overview**
> Doc-only updates to public API docstrings so they match the real signatures.
> 
> **`hf_hub_url`** — the Args section now documents optional **`endpoint`** (Hub base URL; defaults to `HF_ENDPOINT`), aligning with `hf_hub_download` / `snapshot_download` docs from earlier PRs.
> 
> **`HfApi.preupload_lfs_files`** — Args now use **`additions`** instead of the incorrect **`operations`** name, and document **`free_memory`** (default `True`: clears `path_or_fileobj` on each `CommitOperationAdd` after upload unless you need to reuse the objects).
> 
> No runtime or API behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 204aa503b389afe6d5a28c86d281d77d2cdff844. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->