### PR TITLE
[Docs] Mention storage region limitation for server-side copy

### DIFF
--- a/docs/source/en/guides/buckets.md
+++ b/docs/source/en/guides/buckets.md
@@ -550,6 +550,7 @@ When copying folders, a trailing `/` on the source uses rsync-style semantics â€
 Notes:
 
 - Bucket-to-repo copy is not yet supported.
+- Server-side copies only work within the same [storage region](https://huggingface.co/docs/hub/storage-regions).
 - Files tracked with Xet (in buckets or repos) are copied server-side by hash â€” no data is downloaded or re-uploaded.
 - Small text files not tracked with Xet on repo sources are downloaded and re-uploaded to the destination bucket.
 - [`copy_files`] can also be used for repo-to-repo copies. See the [repository guide](./repository#copy-files) for more details.

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -779,6 +779,7 @@ Notes:
 - `hf cp` copies a single file when a local path is involved. To copy whole directories to/from local, use `hf upload`/`hf download` (repos) or `hf buckets sync` (buckets).
 - Bucket-to-repo copy is not yet supported.
 - Local-to-local copy is not supported (use your shell's `cp`).
+- Copies between two Hub locations only work within the same [storage region](https://huggingface.co/docs/hub/storage-regions).
 
 ### Sync directories
 

--- a/docs/source/en/guides/repository.md
+++ b/docs/source/en/guides/repository.md
@@ -211,6 +211,9 @@ Or via CLI, with the unified `hf cp` command (also available as `hf repos cp`):
 > [!TIP]
 > `copy_files` (and `hf cp`) can also copy files from a repository to a [Bucket](./buckets). Copying *from* a bucket *to* a repository is not supported. See the [Buckets](./buckets) guide for more details.
 
+> [!WARNING]
+> Server-side copies only work within the same [storage region](https://huggingface.co/docs/hub/storage-regions).
+
 ## Branches and tags
 
 Git repositories often make use of branches to store different versions of a same repository.

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -249,7 +249,8 @@ Copy files between local paths, repositories, and buckets.
 Handles uploads (local/stdin -> repo/bucket), downloads (repo/bucket -> local/stdout) and
 remote-to-remote copies (repo/bucket -> repo/bucket). Bucket-to-repo and local-to-local
 copies are not supported. For directories, use `hf upload`/`hf download` (repos) or
-`hf buckets sync` (buckets).
+`hf buckets sync` (buckets). Remote-to-remote copies only work within the same storage
+region (https://huggingface.co/docs/hub/storage-regions).
 
 **Usage**:
 
@@ -957,7 +958,8 @@ Copy files between local paths, repositories, and buckets.
 Handles uploads (local/stdin -> repo/bucket), downloads (repo/bucket -> local/stdout) and
 remote-to-remote copies (repo/bucket -> repo/bucket). Bucket-to-repo and local-to-local
 copies are not supported. For directories, use `hf upload`/`hf download` (repos) or
-`hf buckets sync` (buckets).
+`hf buckets sync` (buckets). Remote-to-remote copies only work within the same storage
+region (https://huggingface.co/docs/hub/storage-regions).
 
 **Usage**:
 
@@ -3139,7 +3141,8 @@ Copy files between local paths, repositories, and buckets.
 Handles uploads (local/stdin -> repo/bucket), downloads (repo/bucket -> local/stdout) and
 remote-to-remote copies (repo/bucket -> repo/bucket). Bucket-to-repo and local-to-local
 copies are not supported. For directories, use `hf upload`/`hf download` (repos) or
-`hf buckets sync` (buckets).
+`hf buckets sync` (buckets). Remote-to-remote copies only work within the same storage
+region (https://huggingface.co/docs/hub/storage-regions).
 
 **Usage**:
 

--- a/src/huggingface_hub/_commit_api.py
+++ b/src/huggingface_hub/_commit_api.py
@@ -98,7 +98,8 @@ class CommitOperationCopy:
 
     Cross-repository copies are supported by setting `src_repo_id` and `src_repo_type`. For cross-repo LFS copies,
     the LFS objects are duplicated to the destination repository before the commit is created. This is handled
-    automatically by [`create_commit`].
+    automatically by [`create_commit`]. Note that cross-repository copies only work within the same
+    [storage region](https://huggingface.co/docs/hub/storage-regions); copying across regions is not supported.
 
     Note: you can combine a [`CommitOperationCopy`] and a [`CommitOperationDelete`] to rename an LFS file on the Hub.
 

--- a/src/huggingface_hub/cli/_cp.py
+++ b/src/huggingface_hub/cli/_cp.py
@@ -79,7 +79,8 @@ def make_cp(context: CpContext | None = None):
         Handles uploads (local/stdin -> repo/bucket), downloads (repo/bucket -> local/stdout) and
         remote-to-remote copies (repo/bucket -> repo/bucket). Bucket-to-repo and local-to-local
         copies are not supported. For directories, use `hf upload`/`hf download` (repos) or
-        `hf buckets sync` (buckets).
+        `hf buckets sync` (buckets). Remote-to-remote copies only work within the same storage
+        region (https://huggingface.co/docs/hub/storage-regions).
         """
         _enforce_context(context, src, dst)
         _run_cp(src, dst, token)

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -13219,6 +13219,9 @@ class HfApi:
         Repo-to-repo copies use [`CommitOperationCopy`] under the hood and create a commit on the destination
         repository. Bucket-to-repo copies are not supported.
 
+        > [!WARNING]
+        > Server-side copies only work within the same [storage region](https://huggingface.co/docs/hub/storage-regions).
+
         Args:
             source (`str`):
                 Source location as an `hf://` URI. Can be a bucket path (e.g. `"hf://buckets/my-bucket/path/to/file"`)


### PR DESCRIPTION
Mentioned by @Pierrci [in slack](https://huggingface.slack.com/archives/C02V5EA0A95/p1780334395442979?thread_ts=1779980897.080899&cid=C02V5EA0A95) (private)

Server-side copy (`copy_files` / `hf cp`, added in #4295, #4203, #3874) only works within a single [storage region](https://huggingface.co/docs/hub/storage-regions). This adds short disclaimers (each linking to the storage-regions docs) wherever copy is documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit a60e99364367b2ae33d3925182bd51550adf0c95. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->