### PR TITLE
Fix umask probe writing tmp file outside download dir

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1907,8 +1907,12 @@ def _chmod_and_move(src: Path, dst: Path) -> None:
     - Fix issue: https://github.com/huggingface/huggingface_hub/issues/1141
     - Fix issue: https://github.com/huggingface/huggingface_hub/issues/1215
     """
-    # Get umask by creating a temporary file in the cached repo folder.
-    tmp_file = dst.parent.parent / f"tmp_{uuid.uuid4()}"
+    # Get umask by creating a temporary file in the folder containing the incomplete file.
+    # We know this folder is writable since the incomplete file has just been written there.
+    # Probing next to `dst` is not always possible: when downloading to a local dir, `dst` is the
+    # final file location and its parents might not be writable (e.g. read-only root filesystem).
+    # See https://github.com/huggingface/huggingface_hub/issues/4304.
+    tmp_file = src.parent / f"tmp_{uuid.uuid4()}"
     try:
         tmp_file.touch()
         cache_dir_mode = Path(tmp_file).stat().st_mode


### PR DESCRIPTION
Fixes https://github.com/huggingface/huggingface_hub/issues/4304 cc @quachc for reported it

When moving a finished download into place, `_chmod_and_move` probes the effective umask by touching a temporary `tmp_<uuid>` file at `dst.parent.parent`. That made sense for the cache layout (`.../blobs/<etag>` → two levels up is the repo folder), but since the local-dir download revamp (#2223) the same helper also receives `dst = {local_dir}/<filename>`. For a top-level file in `--local-dir /data`, two levels up is `/`, so we were touching `/tmp_<uuid>` at the filesystem root which fails with `[Errno 30] Read-only file system` on containers with a read-only root FS (and silently creates/deletes files at `/` on writable ones).

The fix probes next to the `.incomplete` file (`src.parent`) instead, which is guaranteed writable since we just wrote the download there: `blobs/` in cache mode, `{local_dir}/.cache/huggingface/download/` in local-dir mode. Same umask result, no more stray writes outside the download tree.

Quick check that the warning is gone with an unwritable destination parent:

```py
from pathlib import Path
from huggingface_hub.file_download import _chmod_and_move
import tempfile, os
with tempfile.TemporaryDirectory() as d:
    src = Path(d) / 'sub' / 'file.incomplete'
    src.parent.mkdir()
    src.write_text('hello')
    _chmod_and_move(src, Path(d) / 'file.txt')
    print('moved without warning')
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-path change in download finalization with no API or security impact; reduces filesystem side effects.
> 
> **Overview**
> Fixes **`_chmod_and_move`** so the umask probe no longer creates a temporary file two levels above the final destination.
> 
> When finishing a download, the library infers permissions by touching a zero-byte `tmp_<uuid>` file and reading its mode. That probe used **`dst.parent.parent`**, which matches the Hub cache layout (`blobs/` → repo folder) but breaks for **`local_dir`** downloads where **`dst`** is the real file path (e.g. `/data/model.bin` → probe at **`/`**). On read-only root filesystems that triggers warnings and failed chmod; on writable systems it can litter the root with probe files.
> 
> The probe now runs in **`src.parent`** (next to the `.incomplete` file), which is always writable because the download just wrote there—cache **`blobs/`** or local-dir **`.cache/huggingface/download/`**. Permission behavior is unchanged; only the probe location moves.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26b3ac7564e1fe0c204cbe5bab78fe52064f33f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->