### PR TITLE
[Fix] Make concurrent downloads safe even when file locking is broken

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -713,7 +713,11 @@ def _cache_commit_hash_for_specific_revision(storage_folder: str, revision: str,
             # Update ref only if has been updated. Could cause useless error in case
             # repo is already cached and user doesn't have write access to cache folder.
             # See https://github.com/huggingface/huggingface_hub/issues/1216.
-            ref_path.write_text(commit_hash)
+            # Write atomically (tmp file + rename) so that concurrent readers never see
+            # a partially written ref.
+            tmp_path = ref_path.with_name(f"{ref_path.name}.{uuid.uuid4().hex[:8]}.tmp")
+            tmp_path.write_text(commit_hash)
+            os.replace(tmp_path, ref_path)
 
 
 @validate_hf_hub_args
@@ -1196,7 +1200,10 @@ def _hf_hub_download_to_cache_dir(
     _cache_commit_hash_for_specific_revision(storage_folder, revision, commit_hash)
 
     # Prevent parallel downloads of the same file with a lock.
-    # etag could be duplicated across repos,
+    # etag could be duplicated across repos.
+    # Note: the lock is best-effort to avoid downloading the same file twice. Cache correctness
+    # does not depend on it: each download writes to a process-unique temporary file that is
+    # atomically renamed into place (see `_download_to_tmp_and_move`).
     lock_path = os.path.join(locks_dir, repo_folder_name(repo_id=repo_id, repo_type=repo_type), f"{etag}.lock")
 
     # Some Windows versions do not allow for paths longer than 255 characters.
@@ -1824,10 +1831,8 @@ def _download_to_tmp_and_move(
 
     Internal logic:
     - return early if file is already downloaded
-    - resume download if possible (from incomplete file)
-    - do not resume download if `force_download=True`
     - check disk space before downloading
-    - download content to a temporary file
+    - download content to a process-unique temporary file
     - set correct permissions on temporary file
     - move the temporary file to the destination path
 
@@ -1837,54 +1842,55 @@ def _download_to_tmp_and_move(
         # Do nothing if already exists (except if force_download=True)
         return
 
-    if incomplete_path.exists() and force_download:
-        # By default, we will try to resume the download if possible.
-        # However, if the user has set `force_download=True`, then we should
-        # not resume the download => delete the incomplete file.
-        logger.debug(f"Removing incomplete file '{incomplete_path}' (force_download=True)")
-        incomplete_path.unlink(missing_ok=True)
+    # Download to a process-unique temporary file before moving it in place. A shared
+    # `<etag>.incomplete` file corrupts the cache whenever the surrounding lock is not honored:
+    # on some filesystems (Lustre, GPFS, some NFS mounts) `flock(2)` silently succeeds for every
+    # caller and concurrent processes end up appending to the same file. With a unique file per
+    # process, a broken lock costs only duplicated bandwidth: each process downloads the full
+    # file and atomically renames it to the final destination.
+    # See https://github.com/huggingface/huggingface_hub/pull/4228.
+    tmp_path = incomplete_path.with_name(f"{incomplete_path.stem}.{uuid.uuid4().hex[:8]}.incomplete")
+    try:
+        with tmp_path.open("wb") as f:
+            logger.debug(f"Downloading '{filename}' to '{tmp_path}'")
 
-    with incomplete_path.open("ab") as f:
-        resume_size = f.tell()
-        message = f"Downloading '{filename}' to '{incomplete_path}'"
-        if resume_size > 0 and expected_size is not None:
-            message += f" (resume from {resume_size}/{expected_size})"
-        logger.debug(message)
+            if expected_size is not None:  # might be None if HTTP header not set correctly
+                # Check disk space in both tmp and destination path
+                _check_disk_space(expected_size, tmp_path.parent)
+                _check_disk_space(expected_size, destination_path.parent)
 
-        if expected_size is not None:  # might be None if HTTP header not set correctly
-            # Check disk space in both tmp and destination path
-            _check_disk_space(expected_size, incomplete_path.parent)
-            _check_disk_space(expected_size, destination_path.parent)
+            if xet_file_data is not None and is_xet_available():
+                logger.debug("Xet Storage is enabled for this repo. Downloading file from Xet Storage..")
+                xet_get(
+                    incomplete_path=tmp_path,
+                    xet_file_data=xet_file_data,
+                    headers=headers,
+                    expected_size=expected_size,
+                    displayed_filename=filename,
+                    tqdm_class=tqdm_class,
+                )
+            else:
+                if xet_file_data is not None and not constants.HF_HUB_DISABLE_XET:
+                    logger.warning(
+                        "Xet Storage is enabled for this repo, but the 'hf_xet' package is not installed. "
+                        "Falling back to regular HTTP download. "
+                        "For better performance, install the package with: `pip install huggingface_hub[hf_xet]` or `pip install hf_xet`"
+                    )
 
-        if xet_file_data is not None and is_xet_available():
-            logger.debug("Xet Storage is enabled for this repo. Downloading file from Xet Storage..")
-            xet_get(
-                incomplete_path=incomplete_path,
-                xet_file_data=xet_file_data,
-                headers=headers,
-                expected_size=expected_size,
-                displayed_filename=filename,
-                tqdm_class=tqdm_class,
-            )
-        else:
-            if xet_file_data is not None and not constants.HF_HUB_DISABLE_XET:
-                logger.warning(
-                    "Xet Storage is enabled for this repo, but the 'hf_xet' package is not installed. "
-                    "Falling back to regular HTTP download. "
-                    "For better performance, install the package with: `pip install huggingface_hub[hf_xet]` or `pip install hf_xet`"
+                http_get(
+                    url_to_download,
+                    f,
+                    headers=headers,
+                    expected_size=expected_size,
+                    tqdm_class=tqdm_class,
                 )
 
-            http_get(
-                url_to_download,
-                f,
-                resume_size=resume_size,
-                headers=headers,
-                expected_size=expected_size,
-                tqdm_class=tqdm_class,
-            )
-
-    logger.debug(f"Download complete. Moving file to {destination_path}")
-    _chmod_and_move(incomplete_path, destination_path)
+        logger.debug(f"Download complete. Moving file to {destination_path}")
+        _chmod_and_move(tmp_path, destination_path)
+    finally:
+        # No-op on success (file has been moved). On failure, do not keep a partial file around:
+        # it could not be reused anyway since the temporary name is unique to this download.
+        tmp_path.unlink(missing_ok=True)
 
 
 def _int_or_none(value: str | None) -> int | None:

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -566,16 +566,14 @@ class CachedDownloadTests(unittest.TestCase):
 
         See https://github.com/huggingface/huggingface_hub/issues/2511.
 
-        When downloading a file, we first download to a temporary file and then move it to the final location.
-        If the temporary file is already partially downloaded, we resume from where we left off.
-        However, if the temporary file is already fully downloaded, we should try to make a GET call with an empty range.
-        This was causing a "416 Range Not Satisfiable" error.
+        A leftover `<blob>.incomplete` file (e.g. from an interrupted download with a previous version
+        of `huggingface_hub`) must not break the download.
         """
         with SoftTemporaryDirectory() as tmpdir:
             # Download the file once
             filepath = Path(hf_hub_download(DUMMY_MODEL_ID, filename="pytorch_model.bin", cache_dir=tmpdir))
 
-            # Fake tmp file
+            # Fake leftover tmp file
             incomplete_filepath = Path(str(filepath.resolve()) + ".incomplete")
             incomplete_filepath.write_bytes(filepath.read_bytes())  # fake a partial download
             filepath.resolve().unlink()
@@ -585,6 +583,12 @@ class CachedDownloadTests(unittest.TestCase):
 
             # Download must not fail
             hf_hub_download(DUMMY_MODEL_ID, filename="pytorch_model.bin", cache_dir=tmpdir)
+
+    def test_no_incomplete_file_left_after_download(self):
+        """Temporary `*.incomplete` files are cleaned up after a successful download."""
+        with SoftTemporaryDirectory() as tmpdir:
+            hf_hub_download(DUMMY_MODEL_ID, filename="pytorch_model.bin", cache_dir=tmpdir)
+            assert not list(Path(tmpdir).rglob("*.incomplete"))
 
     def test_keep_lock_file(self):
         """Downloading should acquire locks under `.locks`."""
@@ -827,21 +831,14 @@ class HfHubDownloadToLocalDir(unittest.TestCase):
         self.api.hf_hub_download(self.repo_id, filename=self.file_name, local_dir=self.local_dir)
         assert self.file_path.read_text() == "content"
 
-    def test_resume_from_incomplete(self):
-        # An incomplete file already exists => use it
-        incomplete_path = self.local_dir / ".cache" / "huggingface" / "download" / (self.file_name + ".incomplete")
-        incomplete_path.parent.mkdir(parents=True, exist_ok=True)
-        incomplete_path.write_text("XXXX")  # Here we put fake data to test the resume
-        self.api.hf_hub_download(self.repo_id, filename=self.file_name, local_dir=self.local_dir)
-        self.file_path.read_text() == "XXXXent"
-
-    def test_do_not_resume_on_force_download(self):
-        # An incomplete file already exists but force_download=True
+    def test_do_not_resume_from_incomplete(self):
+        # A leftover incomplete file (e.g. from an interrupted download) is ignored: each download
+        # writes to its own process-unique temporary file.
         incomplete_path = self.local_dir / ".cache" / "huggingface" / "download" / (self.file_name + ".incomplete")
         incomplete_path.parent.mkdir(parents=True, exist_ok=True)
         incomplete_path.write_text("XXXX")
-        self.api.hf_hub_download(self.repo_id, filename=self.file_name, local_dir=self.local_dir, force_download=True)
-        self.file_path.read_text() == "content"
+        self.api.hf_hub_download(self.repo_id, filename=self.file_name, local_dir=self.local_dir)
+        assert self.file_path.read_text() == "content"
 
     @patch("huggingface_hub.file_download.build_hf_headers")
     def test_passing_token_false_is_respected(self, mock: Mock):

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -573,7 +573,7 @@ class CachedDownloadTests(unittest.TestCase):
             # Download the file once
             filepath = Path(hf_hub_download(DUMMY_MODEL_ID, filename="pytorch_model.bin", cache_dir=tmpdir))
 
-            # Fake leftover tmp file
+            # Fake tmp file
             incomplete_filepath = Path(str(filepath.resolve()) + ".incomplete")
             incomplete_filepath.write_bytes(filepath.read_bytes())  # fake a partial download
             filepath.resolve().unlink()
@@ -828,15 +828,6 @@ class HfHubDownloadToLocalDir(unittest.TestCase):
     def test_file_exists_and_overwrites(self):
         # 1 HEAD call + 1 download
         self.file_path.write_text("another content")
-        self.api.hf_hub_download(self.repo_id, filename=self.file_name, local_dir=self.local_dir)
-        assert self.file_path.read_text() == "content"
-
-    def test_do_not_resume_from_incomplete(self):
-        # A leftover incomplete file (e.g. from an interrupted download) is ignored: each download
-        # writes to its own process-unique temporary file.
-        incomplete_path = self.local_dir / ".cache" / "huggingface" / "download" / (self.file_name + ".incomplete")
-        incomplete_path.parent.mkdir(parents=True, exist_ok=True)
-        incomplete_path.write_text("XXXX")
         self.api.hf_hub_download(self.repo_id, filename=self.file_name, local_dir=self.local_dir)
         assert self.file_path.read_text() == "content"
 


### PR DESCRIPTION
**TL;DR:**
- `filelock` is not bullet-proof on some filesystems (see issue)
- let's continue to use it as "best-effort" to avoid duplicate downloads in parallel (as before)
- BUT let's not make the file consistency depends on `filelock` i.e. we always download to a new tmp file instead of resuming from incomplete file

**:warning: Breaking change:** resuming a failed download is no longer possible. However file resumability was already a niche use case only applicable when `hf_xet` is disabled.

---

Alternative to #4228 (thanks @vadiklyutiy for the report and investigation!) addressing the cache corruption reported there, also related to https://github.com/tox-dev/filelock/issues/389 and https://github.com/huggingface/transformers/issues/30859.

On Lustre/GPFS and some NFS mounts, `flock(2)` silently succeeds for every caller, so `WeakFileLock` is a no-op and concurrent `hf_hub_download` calls end up appending to the same shared `<etag>.incomplete` file. Worst case is silent cache poisoning: the first process to finish passes its consistency check and renames the file into the blob store, while a slower process still holds an open fd on the renamed inode and keeps appending to the now-live blob.

The bug can be reproduced on any machine (no Lustre needed) with the script below: it patches `fcntl.flock` to a silent no-op — exactly what those filesystems do — and races two `hf_hub_download` processes with worst-case timing. On `main`, it reliably poisons the cache: a corrupted blob (134,981,632 bytes instead of 125,162,496, wrong sha256) behind a valid pointer, which is the same symptom as the `vllm serve` crash described in #4228. With this PR, the same script ends with both processes succeeding and a bit-identical blob.

<details>
<summary><code>repro_4228.py</code></summary>

```python
"""Repro for PR #4228: silent cache corruption when flock() is a no-op (Lustre/GPFS/NFS).

Simulates the broken-filesystem behavior locally by patching `fcntl.flock` to a silent
no-op (exactly what Lustre/GPFS do: return success for every caller without blocking).

Scenario reproduced (the "silent poisoning" variant seen with multi-process vllm serve):
  - Process A starts downloading a 125MB file to `<etag>.incomplete` (opened in append mode).
  - Mid-download, process B enters the same code path. The no-op lock lets it in. B opens the
    same `.incomplete` file in append mode, sees resume_size=current size, and requests the
    missing tail via a Range request. B is a bit slower than A (here: simulated with a delay
    before its first write — in real life: network jitter, slower node, GIL pause, ...).
  - A finishes first. Its consistency check passes (B hasn't written yet), so A renames
    `.incomplete` -> blob and creates the pointer symlink. The cache looks healthy.
  - B still holds an open fd on the *renamed* inode (rename doesn't invalidate open fds) and
    appends its tail bytes to the now-live blob. The blob silently becomes larger than
    expected with duplicated bytes, while a valid pointer exists -> every subsequent reader
    gets a corrupted file. B itself fails its consistency check, but the damage is done.

Run: HF_HUB_DISABLE_XET=1 .venv/bin/python repro_4228.py
"""

import hashlib
import os
import subprocess
import sys
import tempfile
import time
from pathlib import Path

REPO_ID = "openai-community/gpt2"
FILENAME = "64-8bits.tflite"
EXPECTED_SIZE = 125162496
EXPECTED_SHA256 = "c966da3b74697803352ca7c6f2f220e7090a557b619de9da0c6b34d89f7825c1"

WORKER_A = """
import sys
import fcntl
fcntl.flock = lambda *a, **k: None  # Lustre/GPFS behavior: silent success for every caller
from huggingface_hub import hf_hub_download
path = hf_hub_download(repo_id=sys.argv[1], filename=sys.argv[2])
print("worker A done:", path)
"""

# Worker B: same no-op flock, but (1) pre-warms imports + TLS connection, then waits for a
# signal file so it can enter the download loop while A is mid-flight, and (2) delays its
# first chunk write by a few seconds to emulate a slower sibling process.
WORKER_B = """
import os
import sys
import time
import fcntl
fcntl.flock = lambda *a, **k: None  # Lustre/GPFS behavior: silent success for every caller

import huggingface_hub.file_download as fd
from huggingface_hub import hf_hub_download, get_hf_file_metadata, hf_hub_url

repo_id, filename, signal_file = sys.argv[1], sys.argv[2], sys.argv[3]

# Pre-warm DNS/TLS + imports so the post-signal latency is minimal.
get_hf_file_metadata(hf_hub_url(repo_id=repo_id, filename=filename))

_orig_http_get = fd.http_get

class SlowFirstWrite:
    def __init__(self, f):
        self._f = f
        self._first = True
    def write(self, data):
        if self._first:
            time.sleep(6)  # let A finish, pass its consistency check, and rename the blob
            self._first = False
        return self._f.write(data)
    def __getattr__(self, name):
        return getattr(self._f, name)

def slow_http_get(url, temp_file, **kwargs):
    return _orig_http_get(url, SlowFirstWrite(temp_file), **kwargs)

fd.http_get = slow_http_get

while not os.path.exists(signal_file):
    time.sleep(0.01)

path = hf_hub_download(repo_id=repo_id, filename=filename)
print("worker B done:", path)
"""


def main() -> None:
    tmp = tempfile.mkdtemp(prefix="hf_repro_4228_")
    env = {**os.environ, "HF_HOME": tmp, "HF_HUB_DISABLE_XET": "1"}
    signal_file = os.path.join(tmp, "go_b")
    print(f"HF_HOME={tmp}")

    repo_dir = Path(tmp) / "hub" / "models--openai-community--gpt2"

    b = subprocess.Popen(
        [sys.executable, "-c", WORKER_B, REPO_ID, FILENAME, signal_file],
        env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
    )
    time.sleep(3)  # let B pre-warm
    a = subprocess.Popen(
        [sys.executable, "-c", WORKER_A, REPO_ID, FILENAME],
        env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
    )

    # Signal B once A's download is ~half way.
    deadline = time.time() + 300
    while time.time() < deadline:
        candidates = list(repo_dir.glob("blobs/*.incomplete")) if repo_dir.exists() else []
        if candidates and candidates[0].stat().st_size > 0.85 * EXPECTED_SIZE:
            print(f"incomplete at {candidates[0].stat().st_size / EXPECTED_SIZE:.0%} -> signaling worker B")
            Path(signal_file).touch()
            break
        if a.poll() is not None:
            print("worker A finished too early; rerun")
            print(a.stdout.read())
            b.kill()
            return
        time.sleep(0.02)

    out_a, _ = a.communicate()
    print(f"--- worker A (exit {a.returncode}) ---\n{out_a}")

    blob = repo_dir / "blobs" / EXPECTED_SHA256
    if blob.exists():
        print(f"blob right after A finished: size={blob.stat().st_size} (expected {EXPECTED_SIZE}) -> looks healthy")

    out_b, _ = b.communicate()
    print(f"--- worker B (exit {b.returncode}) ---\n{out_b}")

    pointer = next((repo_dir / "snapshots").rglob(FILENAME), None) if (repo_dir / "snapshots").exists() else None
    print(f"pointer: {pointer}")
    if blob.exists():
        actual_size = blob.stat().st_size
        actual_sha = hashlib.sha256(blob.read_bytes()).hexdigest()
        print(f"final blob size: {actual_size} (expected {EXPECTED_SIZE})")
        print(f"final blob sha256: {actual_sha}\n     expected sha256: {EXPECTED_SHA256}")
        if pointer is not None and (actual_size != EXPECTED_SIZE or actual_sha != EXPECTED_SHA256):
            print("\n*** SILENT CACHE POISONING: corrupted blob behind a valid pointer ***")
        elif actual_size == EXPECTED_SIZE and actual_sha == EXPECTED_SHA256:
            print("\nblob is intact (race not triggered this run, try again)")
    else:
        print(f"blob missing: {blob}")


if __name__ == "__main__":
    main()
```

</details>

Instead of detecting broken filesystems, this PR removes the lock from the correctness equation: each download now writes to a process-unique temporary file (`<etag>.<random>.incomplete`) and atomically renames it into place, and `refs/<revision>` is written atomically (tmp file + rename) so readers can never observe a truncated ref — that ref write happens outside any lock today and was racy even on local filesystems. With this change a broken lock costs only duplicated bandwidth, on any filesystem, including configurations that detection can't catch (FUSE wrappers, Lustre `localflock`, NFS `local_lock=flock`). The lock is kept as a best-effort way to avoid downloading the same file twice.

> [!WARNING]
> **Breaking change:** interrupted downloads are no longer resumed by a later call — each download writes to its own unique temporary file (in-process retry/resume in `http_get` is unaffected). Sharing a partial file across processes is exactly what made the corruption possible. Xet-backed downloads (the default for new repos) recover most of the resume value through chunk dedup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core download/cache write paths and drops cross-process resume from shared incomplete files, which can increase bandwidth on failure but fixes silent blob corruption on shared/cluster filesystems.
> 
> **Overview**
> Makes Hub cache downloads safe when **`flock`-based locks are ineffective** (e.g. Lustre/GPFS/some NFS), where concurrent processes could corrupt a shared `<etag>.incomplete` blob.
> 
> **`_download_to_tmp_and_move`** no longer appends to or resumes a shared incomplete file. Each download writes to a **process-unique** `*.{uuid}.incomplete` path, then **`_chmod_and_move`** into the final blob; a **`finally`** block removes any leftover temp file. Cross-process **resume from `.incomplete` is removed** (in-process `http_get` retries are unchanged). **`_cache_commit_hash_for_specific_revision`** now writes refs via **tmp + `os.replace`** so readers never see a half-written ref.
> 
> **`WeakFileLock`** stays as **best-effort** deduplication only; comments document that correctness does not depend on it. Tests drop resume/`force_download` incomplete tests, add cleanup of `*.incomplete`, and adjust the legacy-complete-incomplete regression scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75cbbca7f2dcb04f280924b01af7e0d3b375b0d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->