### PR TITLE
[CLI] Agent-friendly hints + examples for hf jobs

### DIFF
--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -2237,6 +2237,9 @@ By default, prints currently available logs and exits (non-blocking).
 Use --follow/-f to stream logs in real-time until the job completes.
 Use --tail/-n to limit the number of lines returned (server-side when supported).
 
+Note: following exits when the log stream ends, regardless of whether the Job
+succeeded or failed. Run `hf jobs inspect <job_id>` to check the final status.
+
 **Usage**:
 
 ```console
@@ -2325,6 +2328,7 @@ $ hf jobs run [OPTIONS] IMAGE COMMAND...
 
 Examples
   $ hf jobs run python:3.12 python -c 'print("Hello!")'
+  $ hf jobs run -d python:3.12 python script.py
   $ hf jobs run -e FOO=foo python:3.12 python script.py
   $ hf jobs run --secrets HF_TOKEN python:3.12 python script.py
   $ hf jobs run -v hf://org/my-model:/data -v hf://buckets/org/b:/mnt python:3.12 python script.py
@@ -2711,6 +2715,7 @@ $ hf jobs uv run [OPTIONS] SCRIPT [SCRIPT_ARGS]...
 
 Examples
   $ hf jobs uv run my_script.py
+  $ hf jobs uv run -d my_script.py
   $ hf jobs uv run ml_training.py --flavor a10g-small
   $ hf jobs uv run --with transformers train.py
   $ hf jobs uv run -v hf://org/my-model:/data -v hf://buckets/org/b:/mnt script.py

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -2331,7 +2331,7 @@ $ hf jobs run [OPTIONS] IMAGE COMMAND...
 
 Examples
   $ hf jobs run python:3.12 python -c 'print("Hello!")'
-  $ hf jobs run -d python:3.12 python script.py
+  $ hf jobs run --detach python:3.12 python script.py
   $ hf jobs run -e FOO=foo python:3.12 python script.py
   $ hf jobs run --secrets HF_TOKEN python:3.12 python script.py
   $ hf jobs run -v hf://org/my-model:/data -v hf://buckets/org/b:/mnt python:3.12 python script.py
@@ -2718,7 +2718,7 @@ $ hf jobs uv run [OPTIONS] SCRIPT [SCRIPT_ARGS]...
 
 Examples
   $ hf jobs uv run my_script.py
-  $ hf jobs uv run -d my_script.py
+  $ hf jobs uv run --detach my_script.py
   $ hf jobs uv run ml_training.py --flavor a10g-small
   $ hf jobs uv run --with transformers train.py
   $ hf jobs uv run -v hf://org/my-model:/data -v hf://buckets/org/b:/mnt script.py

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -311,7 +311,8 @@ def jobs_run(
     )
     out.result("Job started", id=job.id, url=job.url)
     if detach:
-        out.hint(f"Use `hf jobs logs -f {job.id}` to stream logs, or `hf jobs inspect {job.id}` to check status.")
+        job_ref = f"{job.owner.name}/{job.id}"
+        out.hint(f"Use `hf jobs logs -f {job_ref}` to stream logs, or `hf jobs inspect {job_ref}` to check status.")
         return
     for log in api.fetch_job_logs(job_id=job.id, namespace=job.owner.name, follow=True):
         out.text(log)
@@ -364,8 +365,9 @@ def jobs_logs(
         for log in logs:
             out.text(log)
         if follow:
+            job_ref = f"{namespace}/{job_id}" if namespace else job_id
             out.hint(
-                f"Stream ended. Run `hf jobs inspect {job_id}` to check the final status (e.g. COMPLETED or ERROR)."
+                f"Stream ended. Run `hf jobs inspect {job_ref}` to check the final status (e.g. COMPLETED or ERROR)."
             )
     except HfHubHTTPError as e:
         status = e.response.status_code if e.response is not None else None
@@ -771,7 +773,8 @@ def jobs_uv_run(
     )
     out.result("Job started", id=job.id, url=job.url)
     if detach:
-        out.hint(f"Use `hf jobs logs -f {job.id}` to stream logs, or `hf jobs inspect {job.id}` to check status.")
+        job_ref = f"{job.owner.name}/{job.id}"
+        out.hint(f"Use `hf jobs logs -f {job_ref}` to stream logs, or `hf jobs inspect {job_ref}` to check status.")
         return
     for log in api.fetch_job_logs(job_id=job.id, namespace=job.owner.name, follow=True):
         out.text(log)

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -91,7 +91,7 @@ from ._cli_utils import (
     parse_volumes,
     typer_factory,
 )
-from ._output import _dataclass_to_dict, out
+from ._output import OutputFormat, _dataclass_to_dict, out
 
 
 logger = logging.get_logger(__name__)
@@ -603,7 +603,8 @@ def jobs_ps(
         if filters:
             filters_msg = ", ".join(f"{k}{o}{v}" for k, o, v in filters)
             out.text(f"No jobs matched filters: {filters_msg}")
-        elif not all and not labels_filters:
+        elif not all and not labels_filters and out.mode not in (OutputFormat.json, OutputFormat.quiet):
+            # Hint is human/agent guidance; keep json/quiet output clean for machine consumers.
             out.hint("No running jobs. Use `-a`/`--all` to include finished (and failed) jobs.")
 
 

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -272,6 +272,7 @@ jobs_cli = typer_factory(help="Run and manage Jobs on the Hub.")
     context_settings={"ignore_unknown_options": True},
     examples=[
         "hf jobs run python:3.12 python -c 'print(\"Hello!\")'",
+        "hf jobs run -d python:3.12 python script.py",
         "hf jobs run -e FOO=foo python:3.12 python script.py",
         "hf jobs run --secrets HF_TOKEN python:3.12 python script.py",
         "hf jobs run -v hf://org/my-model:/data -v hf://buckets/org/b:/mnt python:3.12 python script.py",
@@ -310,7 +311,7 @@ def jobs_run(
     )
     out.result("Job started", id=job.id, url=job.url)
     if detach:
-        out.hint(f"Use `hf jobs logs {job.id}` to fetch the logs.")
+        out.hint(f"Use `hf jobs logs -f {job.id}` to stream logs, or `hf jobs inspect {job.id}` to check status.")
         return
     for log in api.fetch_job_logs(job_id=job.id, namespace=job.owner.name, follow=True):
         out.text(log)
@@ -351,6 +352,9 @@ def jobs_logs(
     By default, prints currently available logs and exits (non-blocking).
     Use --follow/-f to stream logs in real-time until the job completes.
     Use --tail/-n to limit the number of lines returned (server-side when supported).
+
+    Note: following exits when the log stream ends, regardless of whether the Job
+    succeeded or failed. Run `hf jobs inspect <job_id>` to check the final status.
     """
     job_id, namespace = _parse_namespace_from_job_id(job_id, namespace)
 
@@ -359,6 +363,10 @@ def jobs_logs(
         logs = api.fetch_job_logs(job_id=job_id, namespace=namespace, follow=follow, tail=tail)
         for log in logs:
             out.text(log)
+        if follow:
+            out.hint(
+                f"Stream ended. Run `hf jobs inspect {job_id}` to check the final status (e.g. COMPLETED or ERROR)."
+            )
     except HfHubHTTPError as e:
         status = e.response.status_code if e.response is not None else None
         if status == 404:
@@ -591,9 +599,12 @@ def jobs_ps(
         headers=["job_id", "image/space", "command", "created", "status", "runtime"],
         id_key="job_id",
     )
-    if not items and filters:
-        filters_msg = ", ".join(f"{k}{o}{v}" for k, o, v in filters)
-        out.text(f"No jobs matched filters: {filters_msg}")
+    if not items:
+        if filters:
+            filters_msg = ", ".join(f"{k}{o}{v}" for k, o, v in filters)
+            out.text(f"No jobs matched filters: {filters_msg}")
+        elif not all:
+            out.hint("No running jobs. Use `-a`/`--all` to include finished (and failed) jobs.")
 
 
 @jobs_cli.command("hardware", examples=["hf jobs hardware"])
@@ -714,6 +725,7 @@ jobs_cli.add_typer(uv_app, name="uv")
     context_settings={"ignore_unknown_options": True},
     examples=[
         "hf jobs uv run my_script.py",
+        "hf jobs uv run -d my_script.py",
         "hf jobs uv run ml_training.py --flavor a10g-small",
         "hf jobs uv run --with transformers train.py",
         "hf jobs uv run -v hf://org/my-model:/data -v hf://buckets/org/b:/mnt script.py",
@@ -758,7 +770,7 @@ def jobs_uv_run(
     )
     out.result("Job started", id=job.id, url=job.url)
     if detach:
-        out.hint(f"Use `hf jobs logs {job.id}` to fetch the logs.")
+        out.hint(f"Use `hf jobs logs -f {job.id}` to stream logs, or `hf jobs inspect {job.id}` to check status.")
         return
     for log in api.fetch_job_logs(job_id=job.id, namespace=job.owner.name, follow=True):
         out.text(log)

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -728,7 +728,7 @@ jobs_cli.add_typer(uv_app, name="uv")
     context_settings={"ignore_unknown_options": True},
     examples=[
         "hf jobs uv run my_script.py",
-        "hf jobs uv run -d my_script.py",
+        "hf jobs uv run --detach my_script.py",
         "hf jobs uv run ml_training.py --flavor a10g-small",
         "hf jobs uv run --with transformers train.py",
         "hf jobs uv run -v hf://org/my-model:/data -v hf://buckets/org/b:/mnt script.py",

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -603,7 +603,7 @@ def jobs_ps(
         if filters:
             filters_msg = ", ".join(f"{k}{o}{v}" for k, o, v in filters)
             out.text(f"No jobs matched filters: {filters_msg}")
-        elif not all:
+        elif not all and not labels_filters:
             out.hint("No running jobs. Use `-a`/`--all` to include finished (and failed) jobs.")
 
 

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -272,7 +272,7 @@ jobs_cli = typer_factory(help="Run and manage Jobs on the Hub.")
     context_settings={"ignore_unknown_options": True},
     examples=[
         "hf jobs run python:3.12 python -c 'print(\"Hello!\")'",
-        "hf jobs run -d python:3.12 python script.py",
+        "hf jobs run --detach python:3.12 python script.py",
         "hf jobs run -e FOO=foo python:3.12 python script.py",
         "hf jobs run --secrets HF_TOKEN python:3.12 python script.py",
         "hf jobs run -v hf://org/my-model:/data -v hf://buckets/org/b:/mnt python:3.12 python script.py",

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -91,7 +91,7 @@ from ._cli_utils import (
     parse_volumes,
     typer_factory,
 )
-from ._output import OutputFormat, _dataclass_to_dict, out
+from ._output import _dataclass_to_dict, out
 
 
 logger = logging.get_logger(__name__)
@@ -605,8 +605,7 @@ def jobs_ps(
         if filters:
             filters_msg = ", ".join(f"{k}{o}{v}" for k, o, v in filters)
             out.text(f"No jobs matched filters: {filters_msg}")
-        elif not all and not labels_filters and out.mode not in (OutputFormat.json, OutputFormat.quiet):
-            # Hint is human/agent guidance; keep json/quiet output clean for machine consumers.
+        elif not all and not labels_filters:
             out.hint("No running jobs. Use `-a`/`--all` to include finished (and failed) jobs.")
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3270,7 +3270,9 @@ class TestJobsCommand:
             api.list_jobs.return_value = []
             result = runner.invoke(app, ["jobs", "ps", "--format", "json"])
         assert result.exit_code == 0
-        data = json.loads(result.output)
+        # Parse stdout only: the empty-state hint goes to stderr (like agent mode), so it
+        # never pollutes the JSON on stdout. Mirrors the other `json.loads(result.stdout)` tests.
+        data = json.loads(result.stdout)
         assert data == []
 
     def test_ps_empty_quiet(self, runner: CliRunner) -> None:


### PR DESCRIPTION
## What

Small agent-ergonomics polish for `hf jobs` — help text + three `out.hint()`s, no new commands or flags (one file):

- **`logs`**: document that `-f/--follow` exits when the stream ends *regardless of whether the job succeeded or failed* (it never inspects the final stage), and add a hint after a followed stream pointing at `hf jobs inspect <id>` to check the outcome (COMPLETED/ERROR).
- **`ps`**: when nothing is running (no `-a`, no filters) add a hint — `No running jobs. Use -a/--all to include finished (and failed) jobs.` Previously this printed only "No results found." with no next step.
- **`run` / `uv run`**: the detach hint now points at `hf jobs logs -f <id>` *or* `hf jobs inspect <id>`, and each gains a `--detach` example so the detach→poll workflow is discoverable (examples feed the auto-generated `hf-cli` skill).

Hints go to stderr per the `out` convention, so they never pollute agent-parsed stdout. No `--format` examples on purpose — agent output is already auto-selected via `is_agent()`.

## Motivation

Hit these myself in a session today driving Jobs from an agent: a followed `logs -f` returned exit 0 on a job that had actually errored, and a bare `ps` with nothing running left me with no next step. Small nudges to smooth that out.

## Update — rebased on #4310 (centralized hint suppression)

Now that #4310 has merged (hint suppression centralized in the `out` singleton — `out.hint()` is a no-op only in `quiet`; `human`/`agent`/`json` still emit to stderr), this branch is brought up to date with `main` and the empty-`ps` hint is aligned to the new pattern:

- Dropped the now-redundant per-command guard `out.mode not in (OutputFormat.json, OutputFormat.quiet)` on the empty-`ps` hint. The singleton handles `quiet` centrally, and `json` now gets the hint **on stderr** — consistent with treating `json` like `agent` (the shape agreed by @hanouticelina / @Wauplin in #4310). The `not all and not labels_filters` data check stays (only hint on a bare `ps` with nothing running).
- Removed the now-unused `OutputFormat` import from `jobs.py`.
- `test_ps_empty_json` now parses `result.stdout` (the hint lands on stderr and never pollutes the JSON), matching the other `json.loads(result.stdout)` tests in the suite. `test_ps_empty_quiet` keeps asserting on the combined output, so it doubles as the regression test proving `quiet` suppression.

## A note on process

This is tiny and purely help/examples, so I thought a focused PR was clearer than an issue here — but happy to close it and open an issue instead if you'd prefer under the updated CONTRIBUTING workflow.
