### PR TITLE
[CLI] Suppress hints in quiet output mode

### DIFF
--- a/src/huggingface_hub/cli/_output.py
+++ b/src/huggingface_hub/cli/_output.py
@@ -207,7 +207,12 @@ class Output:
             print(f"Error: {message}", file=sys.stderr)
 
     def hint(self, message: str) -> None:
-        """Print a helpful hint to stderr (human: gray, agent/json: plain text)."""
+        """Print a helpful hint to stderr (human: gray, agent: plain text).
+
+        Suppressed in json and quiet modes so machine-readable output stays clean.
+        """
+        if self.mode in (OutputFormat.json, OutputFormat.quiet):
+            return
         if self.mode == OutputFormat.human:
             print(ANSI.gray(f"Hint: {message}"), file=sys.stderr)
         else:

--- a/src/huggingface_hub/cli/_output.py
+++ b/src/huggingface_hub/cli/_output.py
@@ -207,11 +207,13 @@ class Output:
             print(f"Error: {message}", file=sys.stderr)
 
     def hint(self, message: str) -> None:
-        """Print a helpful hint to stderr (human: gray, agent: plain text).
+        """Print a helpful hint to stderr (human: gray, json/agent: plain text).
 
-        Suppressed in json and quiet modes so machine-readable output stays clean.
+        Suppressed in quiet mode. Kept in json mode (like agent) since agents
+        commonly run with ``--format json`` and the next-command hints are useful
+        there; hints go to stderr so they never pollute the parsed stdout.
         """
-        if self.mode in (OutputFormat.json, OutputFormat.quiet):
+        if self.mode == OutputFormat.quiet:
             return
         if self.mode == OutputFormat.human:
             print(ANSI.gray(f"Hint: {message}"), file=sys.stderr)

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -329,7 +329,9 @@ def test_hint(check):
         agent="""
         Hint: Set HF_DEBUG=1 for full traceback.
         """,
-        json="",
+        json="""
+        Hint: Set HF_DEBUG=1 for full traceback.
+        """,
         quiet="",
     )
 

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -329,12 +329,8 @@ def test_hint(check):
         agent="""
         Hint: Set HF_DEBUG=1 for full traceback.
         """,
-        json="""
-        Hint: Set HF_DEBUG=1 for full traceback.
-        """,
-        quiet="""
-        Hint: Set HF_DEBUG=1 for full traceback.
-        """,
+        json="",
+        quiet="",
     )
 
 


### PR DESCRIPTION
## What

`out.hint()` is now a no-op in `quiet` mode, so `--quiet` output stays clean.
`human`, `agent`, and `json` modes all still emit hints to stderr — the
"next-command" hints are a feature for agents, and agents commonly run with
`--format json`, so `json` is treated like `agent`. Hints go to stderr, so they
never pollute parsed stdout/json.

Previously every `out.hint()` printed in all modes, so a command had to guard
hints per-call to keep quiet output clean. Moving the rule into the `out`
singleton removes that need.

## Context

Follow-up to @Wauplin's review on #4308: *"we want as minimal `OutputFormat`
checks as possible in the commands logic and delegate that part to the `out`
singleton … happy to review a PR if you want to remove hints globally from
json/quiet modes."* This is that PR.

Scope narrowed during review: @hanouticelina suggested suppressing hints in
`quiet` only and keeping them in `json` (treating `json` like `agent`, since
agents tend to run `--format json` where the hints are genuinely useful).
@Wauplin agreed.

## Implications (intentionally left out of this PR)

To keep this focused, I've not touched the per-command guards this makes
redundant — happy to follow up once we agree the shape:
- `cli/jobs.py` — the empty-`ps` hint (#4308) is gated with
  `out.mode not in (OutputFormat.json, OutputFormat.quiet)`; that mode guard can
  be dropped (the singleton handles quiet, and json then gets the hint too —
  consistent with treating json like agent).
- `cli/buckets.py` — the sync-plan hint is wrapped in
  `if plan and not out.is_quiet():`; the `not out.is_quiet()` guard becomes
  redundant (the `if plan` data check stays).

## Test

Updated `test_hint` to expect a hint in human/agent/json and no output in quiet.
Full CLI suite green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavior change in CLI stderr output for quiet mode only; no auth, data, or API impact.
> 
> **Overview**
> Centralizes hint suppression in the CLI **`out`** singleton: **`out.hint()`** now returns immediately in **`quiet`** mode so **`--quiet`** stays free of stderr hints without per-command guards.
> 
> **Human**, **agent**, and **json** modes are unchanged—hints still go to stderr (including for **`--format json`**, where next-command hints stay useful for agents and do not affect parsed stdout). The **`test_hint`** expectation for quiet mode is updated to no output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cad6d0399bbec050b49e0cc13a0ea9e54b068587. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->