### PR TITLE
[CLI] Accept web URLs in bucket CLI commands

### DIFF
--- a/src/huggingface_hub/_buckets.py
+++ b/src/huggingface_hub/_buckets.py
@@ -40,6 +40,7 @@ from .utils import (
     parse_datetime,
     parse_hf_uri,
 )
+from .utils._hf_uris import _looks_like_hf_url
 
 
 if TYPE_CHECKING:
@@ -247,9 +248,13 @@ class BucketFolder:
 def _parse_bucket_uri(path: str) -> HfUri:
     """Parse a bucket path into a HfUri.
 
-    Accepts both `hf://buckets/namespace/name(/path/in/repo)` and plain `namespace/name(/path/in/repo)`.
+    Accepts:
+    - `hf://buckets/namespace/name(/path/in/repo)` URIs,
+    - Hugging Face web URLs such as `https://huggingface.co/buckets/namespace/name(/tree/path)`,
+    - plain `namespace/name(/path/in/repo)` paths.
     """
-    if path.startswith(constants.HF_PROTOCOL):
+    if path.startswith(constants.HF_PROTOCOL) or _looks_like_hf_url(path):
+        # Don't use 'if is_hf_uri(...)' here as we prefer 'parse_hf_uri(...)' to raise the exact error message.
         parsed = parse_hf_uri(path)
         if not parsed.is_bucket:
             raise ValueError(f"Invalid bucket path: {path}. Must be a bucket URI (hf://buckets/...).")

--- a/tests/test_buckets_cli.py
+++ b/tests/test_buckets_cli.py
@@ -649,6 +649,19 @@ def test_list_files_with_hf_prefix_and_subprefix(tree_bucket: str):
     )
 
 
+def test_list_files_with_web_url(tree_bucket: str):
+    """A Hugging Face web URL (https://huggingface.co/buckets/...) lists files like the hf:// prefix."""
+    _check_list_output(
+        f"hf buckets list https://huggingface.co/buckets/{tree_bucket} -R",
+        [
+            f"        2048  {MTIME_FIX}  big.bin",
+            f"           5  {MTIME_FIX}  file.txt",
+            f"           4  {MTIME_FIX}  sub/deep/file.txt",
+            f"          14  {MTIME_FIX}  sub/nested.txt",
+        ],
+    )
+
+
 def test_list_files_empty_bucket(api: HfApi):
     """Empty bucket prints '(empty)'."""
     bucket_url = api.create_bucket(bucket_name())


### PR DESCRIPTION
Related to #4296.
Forgot to update `_parse_bucket_uri` to also accept URLs copy-pasted from the browser in addition to `hf://` URIs and plain `namespace/name` paths.

**Example:**

```
hf buckets ls https://huggingface.co/buckets/commoncrawl/commoncrawl
```

(previously: `Error: Invalid bucket path ... Expected format: namespace/bucket_name`)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized parser change reusing existing `parse_hf_uri` URL handling; behavior for non-URL paths is unchanged.
> 
> **Overview**
> **Bucket path parsing** now treats copy-pasted **`https://huggingface.co/buckets/...`** links like existing `hf://buckets/...` URIs by routing them through `parse_hf_uri` when `_looks_like_hf_url` matches, instead of failing as plain `namespace/name` paths.
> 
> Docstrings for `_parse_bucket_uri` document the new accepted form. A CLI test asserts **`hf buckets list`** with a web URL produces the same recursive listing as the `hf://` form.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d2ea8b23f747d22e4e1dec98516cd694949a39b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->