### PR TITLE
[Jobs] Add --expose <port> option to expose job ports through the jobs proxy

### DIFF
--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -2322,7 +2322,7 @@ $ hf jobs run [OPTIONS] IMAGE COMMAND...
 * `--flavor [cpu-basic|cpu-upgrade|cpu-performance|cpu-xl|t4-small|t4-medium|l4x1|l4x4|l40sx1|l40sx4|l40sx8|a10g-small|a10g-large|a10g-largex2|a10g-largex4|a100-large|a100x4|a100x8|h200|h200x2|h200x4|h200x8|rtx-pro-6000|rtx-pro-6000x2|rtx-pro-6000x4|rtx-pro-6000x8]`: Flavor for the hardware. Run 'hf jobs hardware' to list available flavors. Defaults to `cpu-basic`.
 * `--timeout TEXT`: Max duration: int/float with s (seconds, default), m (minutes), h (hours) or d (days).
 * `-d, --detach`: Run the Job in the background and print the Job ID.
-* `--expose`: Expose every port the Job's container listens on through the jobs proxy. Each port is reachable on the public jobs domain; access requires an HF token with read access to the job's namespace.
+* `--expose / --no-expose`: Expose every port the Job's container listens on through the jobs proxy. Each port is reachable on the public jobs domain; access requires an HF token with read access to the job's namespace.
 * `--namespace TEXT`: The namespace where the job will be running. Defaults to the current user's namespace.
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `--help`: Show this message and exit.
@@ -2532,7 +2532,7 @@ $ hf jobs scheduled run [OPTIONS] SCHEDULE IMAGE COMMAND...
 * `--secrets-file TEXT`: Read in a file of secret environment variables.
 * `--flavor [cpu-basic|cpu-upgrade|cpu-performance|cpu-xl|t4-small|t4-medium|l4x1|l4x4|l40sx1|l40sx4|l40sx8|a10g-small|a10g-large|a10g-largex2|a10g-largex4|a100-large|a100x4|a100x8|h200|h200x2|h200x4|h200x8|rtx-pro-6000|rtx-pro-6000x2|rtx-pro-6000x4|rtx-pro-6000x8]`: Flavor for the hardware. Run 'hf jobs hardware' to list available flavors. Defaults to `cpu-basic`.
 * `--timeout TEXT`: Max duration: int/float with s (seconds, default), m (minutes), h (hours) or d (days).
-* `--expose`: Expose every port the Job's container listens on through the jobs proxy. Each port is reachable on the public jobs domain; access requires an HF token with read access to the job's namespace.
+* `--expose / --no-expose`: Expose every port the Job's container listens on through the jobs proxy. Each port is reachable on the public jobs domain; access requires an HF token with read access to the job's namespace.
 * `--namespace TEXT`: The namespace where the job will be running. Defaults to the current user's namespace.
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `--help`: Show this message and exit.
@@ -2620,7 +2620,7 @@ $ hf jobs scheduled uv run [OPTIONS] SCHEDULE SCRIPT [SCRIPT_ARGS]...
 * `--env-file TEXT`: Read in a file of environment variables.
 * `--secrets-file TEXT`: Read in a file of secret environment variables.
 * `--timeout TEXT`: Max duration: int/float with s (seconds, default), m (minutes), h (hours) or d (days).
-* `--expose`: Expose every port the Job's container listens on through the jobs proxy. Each port is reachable on the public jobs domain; access requires an HF token with read access to the job's namespace.
+* `--expose / --no-expose`: Expose every port the Job's container listens on through the jobs proxy. Each port is reachable on the public jobs domain; access requires an HF token with read access to the job's namespace.
 * `--namespace TEXT`: The namespace where the job will be running. Defaults to the current user's namespace.
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `--with TEXT`: Run with the given packages installed
@@ -2709,7 +2709,7 @@ $ hf jobs uv run [OPTIONS] SCRIPT [SCRIPT_ARGS]...
 * `--secrets-file TEXT`: Read in a file of secret environment variables.
 * `--timeout TEXT`: Max duration: int/float with s (seconds, default), m (minutes), h (hours) or d (days).
 * `-d, --detach`: Run the Job in the background and print the Job ID.
-* `--expose`: Expose every port the Job's container listens on through the jobs proxy. Each port is reachable on the public jobs domain; access requires an HF token with read access to the job's namespace.
+* `--expose / --no-expose`: Expose every port the Job's container listens on through the jobs proxy. Each port is reachable on the public jobs domain; access requires an HF token with read access to the job's namespace.
 * `--namespace TEXT`: The namespace where the job will be running. Defaults to the current user's namespace.
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `--with TEXT`: Run with the given packages installed

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -2322,6 +2322,7 @@ $ hf jobs run [OPTIONS] IMAGE COMMAND...
 * `--flavor [cpu-basic|cpu-upgrade|cpu-performance|cpu-xl|t4-small|t4-medium|l4x1|l4x4|l40sx1|l40sx4|l40sx8|a10g-small|a10g-large|a10g-largex2|a10g-largex4|a100-large|a100x4|a100x8|h200|h200x2|h200x4|h200x8|rtx-pro-6000|rtx-pro-6000x2|rtx-pro-6000x4|rtx-pro-6000x8]`: Flavor for the hardware. Run 'hf jobs hardware' to list available flavors. Defaults to `cpu-basic`.
 * `--timeout TEXT`: Max duration: int/float with s (seconds, default), m (minutes), h (hours) or d (days).
 * `-d, --detach`: Run the Job in the background and print the Job ID.
+* `--expose`: Expose every port the Job's container listens on through the jobs proxy. Each port is reachable on the public jobs domain; access requires an HF token with read access to the job's namespace.
 * `--namespace TEXT`: The namespace where the job will be running. Defaults to the current user's namespace.
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `--help`: Show this message and exit.
@@ -2531,6 +2532,7 @@ $ hf jobs scheduled run [OPTIONS] SCHEDULE IMAGE COMMAND...
 * `--secrets-file TEXT`: Read in a file of secret environment variables.
 * `--flavor [cpu-basic|cpu-upgrade|cpu-performance|cpu-xl|t4-small|t4-medium|l4x1|l4x4|l40sx1|l40sx4|l40sx8|a10g-small|a10g-large|a10g-largex2|a10g-largex4|a100-large|a100x4|a100x8|h200|h200x2|h200x4|h200x8|rtx-pro-6000|rtx-pro-6000x2|rtx-pro-6000x4|rtx-pro-6000x8]`: Flavor for the hardware. Run 'hf jobs hardware' to list available flavors. Defaults to `cpu-basic`.
 * `--timeout TEXT`: Max duration: int/float with s (seconds, default), m (minutes), h (hours) or d (days).
+* `--expose`: Expose every port the Job's container listens on through the jobs proxy. Each port is reachable on the public jobs domain; access requires an HF token with read access to the job's namespace.
 * `--namespace TEXT`: The namespace where the job will be running. Defaults to the current user's namespace.
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `--help`: Show this message and exit.
@@ -2618,6 +2620,7 @@ $ hf jobs scheduled uv run [OPTIONS] SCHEDULE SCRIPT [SCRIPT_ARGS]...
 * `--env-file TEXT`: Read in a file of environment variables.
 * `--secrets-file TEXT`: Read in a file of secret environment variables.
 * `--timeout TEXT`: Max duration: int/float with s (seconds, default), m (minutes), h (hours) or d (days).
+* `--expose`: Expose every port the Job's container listens on through the jobs proxy. Each port is reachable on the public jobs domain; access requires an HF token with read access to the job's namespace.
 * `--namespace TEXT`: The namespace where the job will be running. Defaults to the current user's namespace.
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `--with TEXT`: Run with the given packages installed
@@ -2706,6 +2709,7 @@ $ hf jobs uv run [OPTIONS] SCRIPT [SCRIPT_ARGS]...
 * `--secrets-file TEXT`: Read in a file of secret environment variables.
 * `--timeout TEXT`: Max duration: int/float with s (seconds, default), m (minutes), h (hours) or d (days).
 * `-d, --detach`: Run the Job in the background and print the Job ID.
+* `--expose`: Expose every port the Job's container listens on through the jobs proxy. Each port is reachable on the public jobs domain; access requires an HF token with read access to the job's namespace.
 * `--namespace TEXT`: The namespace where the job will be running. Defaults to the current user's namespace.
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `--with TEXT`: Run with the given packages installed

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -2322,7 +2322,7 @@ $ hf jobs run [OPTIONS] IMAGE COMMAND...
 * `--flavor [cpu-basic|cpu-upgrade|cpu-performance|cpu-xl|t4-small|t4-medium|l4x1|l4x4|l40sx1|l40sx4|l40sx8|a10g-small|a10g-large|a10g-largex2|a10g-largex4|a100-large|a100x4|a100x8|h200|h200x2|h200x4|h200x8|rtx-pro-6000|rtx-pro-6000x2|rtx-pro-6000x4|rtx-pro-6000x8]`: Flavor for the hardware. Run 'hf jobs hardware' to list available flavors. Defaults to `cpu-basic`.
 * `--timeout TEXT`: Max duration: int/float with s (seconds, default), m (minutes), h (hours) or d (days).
 * `-d, --detach`: Run the Job in the background and print the Job ID.
-* `--expose / --no-expose`: Expose every port the Job's container listens on through the jobs proxy. Each port is reachable on the public jobs domain; access requires an HF token with read access to the job's namespace.
+* `--expose INTEGER`: Expose a container port through the jobs proxy. Repeat the flag for multiple ports (e.g. `--expose 8000 --expose 8001`). Each exposed port is reachable on the public jobs domain; access requires an HF token with read access to the job's namespace.
 * `--namespace TEXT`: The namespace where the job will be running. Defaults to the current user's namespace.
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `--help`: Show this message and exit.
@@ -2532,7 +2532,7 @@ $ hf jobs scheduled run [OPTIONS] SCHEDULE IMAGE COMMAND...
 * `--secrets-file TEXT`: Read in a file of secret environment variables.
 * `--flavor [cpu-basic|cpu-upgrade|cpu-performance|cpu-xl|t4-small|t4-medium|l4x1|l4x4|l40sx1|l40sx4|l40sx8|a10g-small|a10g-large|a10g-largex2|a10g-largex4|a100-large|a100x4|a100x8|h200|h200x2|h200x4|h200x8|rtx-pro-6000|rtx-pro-6000x2|rtx-pro-6000x4|rtx-pro-6000x8]`: Flavor for the hardware. Run 'hf jobs hardware' to list available flavors. Defaults to `cpu-basic`.
 * `--timeout TEXT`: Max duration: int/float with s (seconds, default), m (minutes), h (hours) or d (days).
-* `--expose / --no-expose`: Expose every port the Job's container listens on through the jobs proxy. Each port is reachable on the public jobs domain; access requires an HF token with read access to the job's namespace.
+* `--expose INTEGER`: Expose a container port through the jobs proxy. Repeat the flag for multiple ports (e.g. `--expose 8000 --expose 8001`). Each exposed port is reachable on the public jobs domain; access requires an HF token with read access to the job's namespace.
 * `--namespace TEXT`: The namespace where the job will be running. Defaults to the current user's namespace.
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `--help`: Show this message and exit.
@@ -2620,7 +2620,7 @@ $ hf jobs scheduled uv run [OPTIONS] SCHEDULE SCRIPT [SCRIPT_ARGS]...
 * `--env-file TEXT`: Read in a file of environment variables.
 * `--secrets-file TEXT`: Read in a file of secret environment variables.
 * `--timeout TEXT`: Max duration: int/float with s (seconds, default), m (minutes), h (hours) or d (days).
-* `--expose / --no-expose`: Expose every port the Job's container listens on through the jobs proxy. Each port is reachable on the public jobs domain; access requires an HF token with read access to the job's namespace.
+* `--expose INTEGER`: Expose a container port through the jobs proxy. Repeat the flag for multiple ports (e.g. `--expose 8000 --expose 8001`). Each exposed port is reachable on the public jobs domain; access requires an HF token with read access to the job's namespace.
 * `--namespace TEXT`: The namespace where the job will be running. Defaults to the current user's namespace.
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `--with TEXT`: Run with the given packages installed
@@ -2709,7 +2709,7 @@ $ hf jobs uv run [OPTIONS] SCRIPT [SCRIPT_ARGS]...
 * `--secrets-file TEXT`: Read in a file of secret environment variables.
 * `--timeout TEXT`: Max duration: int/float with s (seconds, default), m (minutes), h (hours) or d (days).
 * `-d, --detach`: Run the Job in the background and print the Job ID.
-* `--expose / --no-expose`: Expose every port the Job's container listens on through the jobs proxy. Each port is reachable on the public jobs domain; access requires an HF token with read access to the job's namespace.
+* `--expose INTEGER`: Expose a container port through the jobs proxy. Repeat the flag for multiple ports (e.g. `--expose 8000 --expose 8001`). Each exposed port is reachable on the public jobs domain; access requires an HF token with read access to the job's namespace.
 * `--namespace TEXT`: The namespace where the job will be running. Defaults to the current user's namespace.
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `--with TEXT`: Run with the given packages installed

--- a/src/huggingface_hub/_jobs_api.py
+++ b/src/huggingface_hub/_jobs_api.py
@@ -484,6 +484,7 @@ def _create_job_spec(
     timeout: int | float | str | None,
     labels: dict[str, str] | None = None,
     volumes: list[Volume] | None = None,
+    expose: bool = False,
 ) -> dict[str, Any]:
     # prepare job spec to send to HF Jobs API
     job_spec: dict[str, Any] = {
@@ -508,6 +509,9 @@ def _create_job_spec(
     # volumes are optional
     if volumes:
         job_spec["volumes"] = [vol.to_dict() for vol in volumes]
+    # expose ports through the jobs proxy
+    if expose:
+        job_spec["expose"] = {"enabled": True}
     # input is either from docker hub or from HF spaces
     for prefix in (
         "https://huggingface.co/spaces/",

--- a/src/huggingface_hub/_jobs_api.py
+++ b/src/huggingface_hub/_jobs_api.py
@@ -484,7 +484,7 @@ def _create_job_spec(
     timeout: int | float | str | None,
     labels: dict[str, str] | None = None,
     volumes: list[Volume] | None = None,
-    expose: bool | None = None,
+    expose: list[int] | None = None,
 ) -> dict[str, Any]:
     # prepare job spec to send to HF Jobs API
     job_spec: dict[str, Any] = {
@@ -510,8 +510,8 @@ def _create_job_spec(
     if volumes:
         job_spec["volumes"] = [vol.to_dict() for vol in volumes]
     # expose ports through the jobs proxy
-    if expose is not None:
-        job_spec["expose"] = {"enabled": expose}
+    if expose:
+        job_spec["expose"] = {"ports": expose}
     # input is either from docker hub or from HF spaces
     for prefix in (
         "https://huggingface.co/spaces/",

--- a/src/huggingface_hub/_jobs_api.py
+++ b/src/huggingface_hub/_jobs_api.py
@@ -484,7 +484,7 @@ def _create_job_spec(
     timeout: int | float | str | None,
     labels: dict[str, str] | None = None,
     volumes: list[Volume] | None = None,
-    expose: bool = False,
+    expose: bool | None = None,
 ) -> dict[str, Any]:
     # prepare job spec to send to HF Jobs API
     job_spec: dict[str, Any] = {
@@ -510,8 +510,8 @@ def _create_job_spec(
     if volumes:
         job_spec["volumes"] = [vol.to_dict() for vol in volumes]
     # expose ports through the jobs proxy
-    if expose:
-        job_spec["expose"] = {"enabled": True}
+    if expose is not None:
+        job_spec["expose"] = {"enabled": expose}
     # input is either from docker hub or from HF spaces
     for prefix in (
         "https://huggingface.co/spaces/",

--- a/src/huggingface_hub/_jobs_api.py
+++ b/src/huggingface_hub/_jobs_api.py
@@ -89,6 +89,7 @@ class JobStage(str, Enum):
 class JobStatus:
     stage: JobStage
     message: str | None
+    expose_urls: list[str] | None
 
 
 @dataclass
@@ -226,7 +227,6 @@ class JobInfo:
     durations: JobDurations | None
     owner: JobOwner
     initiator: JobInitiator | None
-    expose_urls: list[str] | None
 
     # Inferred fields
     endpoint: str
@@ -253,8 +253,9 @@ class JobInfo:
         volumes = kwargs.get("volumes")
         self.volumes = [Volume(**v) for v in volumes] if volumes else None
         status = kwargs.get("status", {})
-        self.status = JobStatus(stage=status["stage"], message=status.get("message"))
-        self.expose_urls = status.get("exposeUrls")
+        self.status = JobStatus(
+            stage=status["stage"], message=status.get("message"), expose_urls=status.get("exposeUrls")
+        )
         durations = kwargs.get("durations")
         self.durations = JobDurations(**durations) if durations else None
         initiator = kwargs.get("initiator")

--- a/src/huggingface_hub/_jobs_api.py
+++ b/src/huggingface_hub/_jobs_api.py
@@ -185,6 +185,10 @@ class JobInfo:
             Owner of the Job, e.g. `JobOwner(id="5e9ecfc04957053f60648a3e", name="lhoestq", type="user")`
         initiator (`JobInitiator` or `None`):
             What triggered the Job, e.g. `JobInitiator(type="scheduled-job", id="...")` for a cron-triggered run.
+        expose_urls (`list[str]` or `None`):
+            Public URLs through which the Job's exposed ports are reachable (one per port exposed via `expose=`),
+            e.g. `["https://687fb701029421ae5549d998--8000.hf.jobs"]`. `None` when no port is exposed.
+            Accessing a URL requires an HF token with read access to the Job's namespace.
 
     Example:
 
@@ -222,6 +226,7 @@ class JobInfo:
     durations: JobDurations | None
     owner: JobOwner
     initiator: JobInitiator | None
+    expose_urls: list[str] | None
 
     # Inferred fields
     endpoint: str
@@ -249,6 +254,7 @@ class JobInfo:
         self.volumes = [Volume(**v) for v in volumes] if volumes else None
         status = kwargs.get("status", {})
         self.status = JobStatus(stage=status["stage"], message=status.get("message"))
+        self.expose_urls = status.get("exposeUrls")
         durations = kwargs.get("durations")
         self.durations = JobDurations(**durations) if durations else None
         initiator = kwargs.get("initiator")

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -183,9 +183,9 @@ NamespaceOpt = Annotated[
 ]
 
 ExposeOpt = Annotated[
-    bool,
+    bool | None,
     typer.Option(
-        "--expose",
+        "--expose/--no-expose",
         help="Expose every port the Job's container listens on through the jobs proxy. Each port is reachable on the public jobs domain; access requires an HF token with read access to the job's namespace.",
     ),
 ]
@@ -297,7 +297,7 @@ def jobs_run(
     flavor: FlavorOpt = None,
     timeout: TimeoutOpt = None,
     detach: DetachOpt = False,
-    expose: ExposeOpt = False,
+    expose: ExposeOpt = None,
     namespace: NamespaceOpt = None,
     token: TokenOpt = None,
 ) -> None:
@@ -742,7 +742,7 @@ def jobs_uv_run(
     secrets_file: SecretsFileOpt = None,
     timeout: TimeoutOpt = None,
     detach: DetachOpt = False,
-    expose: ExposeOpt = False,
+    expose: ExposeOpt = None,
     namespace: NamespaceOpt = None,
     token: TokenOpt = None,
     with_: WithOpt = None,
@@ -799,7 +799,7 @@ def scheduled_run(
     secrets_file: SecretsFileOpt = None,
     flavor: FlavorOpt = None,
     timeout: TimeoutOpt = None,
-    expose: ExposeOpt = False,
+    expose: ExposeOpt = None,
     namespace: NamespaceOpt = None,
     token: TokenOpt = None,
 ) -> None:
@@ -1028,7 +1028,7 @@ def scheduled_uv_run(
     env_file: EnvFileOpt = None,
     secrets_file: SecretsFileOpt = None,
     timeout: TimeoutOpt = None,
-    expose: ExposeOpt = False,
+    expose: ExposeOpt = None,
     namespace: NamespaceOpt = None,
     token: TokenOpt = None,
     with_: WithOpt = None,

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -182,6 +182,14 @@ NamespaceOpt = Annotated[
     ),
 ]
 
+ExposeOpt = Annotated[
+    bool,
+    typer.Option(
+        "--expose",
+        help="Expose every port the Job's container listens on through the jobs proxy. Each port is reachable on the public jobs domain; access requires an HF token with read access to the job's namespace.",
+    ),
+]
+
 WithOpt = Annotated[
     list[str] | None,
     typer.Option(
@@ -289,6 +297,7 @@ def jobs_run(
     flavor: FlavorOpt = None,
     timeout: TimeoutOpt = None,
     detach: DetachOpt = False,
+    expose: ExposeOpt = False,
     namespace: NamespaceOpt = None,
     token: TokenOpt = None,
 ) -> None:
@@ -306,6 +315,7 @@ def jobs_run(
         volumes=parse_volumes(volume),
         flavor=flavor,
         timeout=timeout,
+        expose=expose,
         namespace=namespace,
     )
     out.result("Job started", id=job.id, url=job.url)
@@ -732,6 +742,7 @@ def jobs_uv_run(
     secrets_file: SecretsFileOpt = None,
     timeout: TimeoutOpt = None,
     detach: DetachOpt = False,
+    expose: ExposeOpt = False,
     namespace: NamespaceOpt = None,
     token: TokenOpt = None,
     with_: WithOpt = None,
@@ -754,6 +765,7 @@ def jobs_uv_run(
         volumes=parse_volumes(volume),
         flavor=flavor,
         timeout=timeout,
+        expose=expose,
         namespace=namespace,
     )
     out.result("Job started", id=job.id, url=job.url)
@@ -787,6 +799,7 @@ def scheduled_run(
     secrets_file: SecretsFileOpt = None,
     flavor: FlavorOpt = None,
     timeout: TimeoutOpt = None,
+    expose: ExposeOpt = False,
     namespace: NamespaceOpt = None,
     token: TokenOpt = None,
 ) -> None:
@@ -807,6 +820,7 @@ def scheduled_run(
         volumes=parse_volumes(volume),
         flavor=flavor,
         timeout=timeout,
+        expose=expose,
         namespace=namespace,
     )
     out.result("Scheduled Job created", id=scheduled_job.id)
@@ -1014,6 +1028,7 @@ def scheduled_uv_run(
     env_file: EnvFileOpt = None,
     secrets_file: SecretsFileOpt = None,
     timeout: TimeoutOpt = None,
+    expose: ExposeOpt = False,
     namespace: NamespaceOpt = None,
     token: TokenOpt = None,
     with_: WithOpt = None,
@@ -1039,6 +1054,7 @@ def scheduled_uv_run(
         volumes=parse_volumes(volume),
         flavor=flavor,
         timeout=timeout,
+        expose=expose,
         namespace=namespace,
     )
     out.result("Scheduled Job created", id=job.id)

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -319,8 +319,8 @@ def jobs_run(
         namespace=namespace,
     )
     out.result("Job started", id=job.id, url=job.url)
-    if job.expose_urls:
-        urls = "\n".join(f"  {url}" for url in job.expose_urls)
+    if isinstance(job.status.expose_urls, list):
+        urls = "\n".join(f"  {url}" for url in job.status.expose_urls)
         out.hint(f"Exposed ports are reachable at (requires an HF token with read access to the job):\n{urls}")
     if detach:
         out.hint(f"Use `hf jobs logs {job.id}` to fetch the logs.")
@@ -772,8 +772,8 @@ def jobs_uv_run(
         namespace=namespace,
     )
     out.result("Job started", id=job.id, url=job.url)
-    if job.expose_urls:
-        urls = "\n".join(f"  {url}" for url in job.expose_urls)
+    if isinstance(job.status.expose_urls, list):
+        urls = "\n".join(f"  {url}" for url in job.status.expose_urls)
         out.hint(f"Exposed ports are reachable at (requires an HF token with read access to the job):\n{urls}")
     if detach:
         out.hint(f"Use `hf jobs logs {job.id}` to fetch the logs.")

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -319,6 +319,9 @@ def jobs_run(
         namespace=namespace,
     )
     out.result("Job started", id=job.id, url=job.url)
+    if job.expose_urls:
+        urls = "\n".join(f"  {url}" for url in job.expose_urls)
+        out.hint(f"Exposed ports are reachable at (requires an HF token with read access to the job):\n{urls}")
     if detach:
         out.hint(f"Use `hf jobs logs {job.id}` to fetch the logs.")
         return
@@ -769,6 +772,9 @@ def jobs_uv_run(
         namespace=namespace,
     )
     out.result("Job started", id=job.id, url=job.url)
+    if job.expose_urls:
+        urls = "\n".join(f"  {url}" for url in job.expose_urls)
+        out.hint(f"Exposed ports are reachable at (requires an HF token with read access to the job):\n{urls}")
     if detach:
         out.hint(f"Use `hf jobs logs {job.id}` to fetch the logs.")
         return

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -183,10 +183,10 @@ NamespaceOpt = Annotated[
 ]
 
 ExposeOpt = Annotated[
-    bool | None,
+    list[int] | None,
     typer.Option(
-        "--expose/--no-expose",
-        help="Expose every port the Job's container listens on through the jobs proxy. Each port is reachable on the public jobs domain; access requires an HF token with read access to the job's namespace.",
+        "--expose",
+        help="Expose a container port through the jobs proxy. Repeat the flag for multiple ports (e.g. `--expose 8000 --expose 8001`). Each exposed port is reachable on the public jobs domain; access requires an HF token with read access to the job's namespace.",
     ),
 ]
 

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -11606,7 +11606,7 @@ class HfApi:
         timeout: int | float | str | None = None,
         labels: dict[str, str] | None = None,
         volumes: list[Volume] | None = None,
-        expose: bool = False,
+        expose: bool | None = None,
         namespace: str | None = None,
         token: bool | str | None = None,
     ) -> JobInfo:
@@ -12093,7 +12093,7 @@ class HfApi:
         timeout: int | float | str | None = None,
         labels: dict[str, str] | None = None,
         volumes: list[Volume] | None = None,
-        expose: bool = False,
+        expose: bool | None = None,
         namespace: str | None = None,
         token: bool | str | None = None,
     ) -> JobInfo:
@@ -12237,7 +12237,7 @@ class HfApi:
         timeout: int | float | str | None = None,
         labels: dict[str, str] | None = None,
         volumes: list[Volume] | None = None,
-        expose: bool = False,
+        expose: bool | None = None,
         namespace: str | None = None,
         token: bool | str | None = None,
     ) -> ScheduledJobInfo:
@@ -12575,7 +12575,7 @@ class HfApi:
         timeout: int | float | str | None = None,
         labels: dict[str, str] | None = None,
         volumes: list[Volume] | None = None,
-        expose: bool = False,
+        expose: bool | None = None,
         namespace: str | None = None,
         token: bool | str | None = None,
     ) -> ScheduledJobInfo:

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -11606,6 +11606,7 @@ class HfApi:
         timeout: int | float | str | None = None,
         labels: dict[str, str] | None = None,
         volumes: list[Volume] | None = None,
+        expose: bool = False,
         namespace: str | None = None,
         token: bool | str | None = None,
     ) -> JobInfo:
@@ -11642,6 +11643,11 @@ class HfApi:
                 Hugging Face Buckets or Repos to mount as volumes in the job container.
                 Each volume is a [`Volume`] with `type` (`"bucket"`, `"model"`, `"dataset"`, or `"space"`),
                 `source` (e.g. `"username/my-bucket"`), and `mount_path` (e.g. `"/data"`).
+
+            expose (`bool`, *optional*, defaults to `False`):
+                If True, expose every port the job's container listens on through the jobs proxy.
+                Each exposed port is then reachable on the public jobs domain. Access always
+                requires an HF token with read access to the job's namespace.
 
             namespace (`str`, *optional*):
                 The namespace where the Job will be created. Defaults to the current user's namespace.
@@ -11691,6 +11697,7 @@ class HfApi:
             timeout=timeout,
             labels=labels,
             volumes=volumes,
+            expose=expose,
         )
         response = get_session().post(
             f"{self.endpoint}/api/jobs/{namespace}",
@@ -12086,6 +12093,7 @@ class HfApi:
         timeout: int | float | str | None = None,
         labels: dict[str, str] | None = None,
         volumes: list[Volume] | None = None,
+        expose: bool = False,
         namespace: str | None = None,
         token: bool | str | None = None,
     ) -> JobInfo:
@@ -12129,6 +12137,11 @@ class HfApi:
                 Hugging Face Buckets or Repos to mount as volumes in the job container.
                 Each volume is a [`Volume`] with `type` (`"bucket"`, `"model"`, `"dataset"`, or `"space"`),
                 `source` (e.g. `"username/my-bucket"`), and `mount_path` (e.g. `"/data"`).
+
+            expose (`bool`, *optional*, defaults to `False`):
+                If True, expose every port the job's container listens on through the jobs proxy.
+                Each exposed port is then reachable on the public jobs domain. Access always
+                requires an HF token with read access to the job's namespace.
 
             namespace (`str`, *optional*):
                 The namespace where the Job will be created. Defaults to the current user's namespace.
@@ -12205,6 +12218,7 @@ class HfApi:
             timeout=timeout,
             labels=labels,
             volumes=volumes,
+            expose=expose,
             namespace=namespace,
             token=token,
         )
@@ -12223,6 +12237,7 @@ class HfApi:
         timeout: int | float | str | None = None,
         labels: dict[str, str] | None = None,
         volumes: list[Volume] | None = None,
+        expose: bool = False,
         namespace: str | None = None,
         token: bool | str | None = None,
     ) -> ScheduledJobInfo:
@@ -12270,6 +12285,11 @@ class HfApi:
                 Each volume is a [`Volume`] with `type` (`"bucket"`, `"model"`, `"dataset"`, or `"space"`),
                 `source` (e.g. `"username/my-bucket"`), and `mount_path` (e.g. `"/data"`).
 
+            expose (`bool`, *optional*, defaults to `False`):
+                If True, expose every port the job's container listens on through the jobs proxy.
+                Each exposed port is then reachable on the public jobs domain. Access always
+                requires an HF token with read access to the job's namespace.
+
             namespace (`str`, *optional*):
                 The namespace where the Job will be created. Defaults to the current user's namespace.
 
@@ -12316,6 +12336,7 @@ class HfApi:
             timeout=timeout,
             labels=labels,
             volumes=volumes,
+            expose=expose,
         )
         input_json: dict[str, Any] = {
             "jobSpec": job_spec,
@@ -12554,6 +12575,7 @@ class HfApi:
         timeout: int | float | str | None = None,
         labels: dict[str, str] | None = None,
         volumes: list[Volume] | None = None,
+        expose: bool = False,
         namespace: str | None = None,
         token: bool | str | None = None,
     ) -> ScheduledJobInfo:
@@ -12607,6 +12629,11 @@ class HfApi:
                 Hugging Face Buckets or Repos to mount as volumes in the job container.
                 Each volume is a [`Volume`] with `type` (`"bucket"`, `"model"`, `"dataset"`, or `"space"`),
                 `source` (e.g. `"username/my-bucket"`), and `mount_path` (e.g. `"/data"`).
+
+            expose (`bool`, *optional*, defaults to `False`):
+                If True, expose every port the job's container listens on through the jobs proxy.
+                Each exposed port is then reachable on the public jobs domain. Access always
+                requires an HF token with read access to the job's namespace.
 
             namespace (`str`, *optional*):
                 The namespace where the Job will be created. Defaults to the current user's namespace.
@@ -12673,6 +12700,7 @@ class HfApi:
             timeout=timeout,
             labels=labels,
             volumes=volumes,
+            expose=expose,
             namespace=namespace,
             token=token,
         )

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -11606,7 +11606,7 @@ class HfApi:
         timeout: int | float | str | None = None,
         labels: dict[str, str] | None = None,
         volumes: list[Volume] | None = None,
-        expose: bool | None = None,
+        expose: list[int] | None = None,
         namespace: str | None = None,
         token: bool | str | None = None,
     ) -> JobInfo:
@@ -11644,9 +11644,9 @@ class HfApi:
                 Each volume is a [`Volume`] with `type` (`"bucket"`, `"model"`, `"dataset"`, or `"space"`),
                 `source` (e.g. `"username/my-bucket"`), and `mount_path` (e.g. `"/data"`).
 
-            expose (`bool`, *optional*, defaults to `False`):
-                If True, expose every port the job's container listens on through the jobs proxy.
-                Each exposed port is then reachable on the public jobs domain. Access always
+            expose (`list[int]`, *optional*):
+                Container ports to expose through the jobs proxy. Each listed port is reachable
+                on the public jobs domain (e.g. `https://<job_id>--8000.hf.jobs`). Access always
                 requires an HF token with read access to the job's namespace.
 
             namespace (`str`, *optional*):
@@ -12093,7 +12093,7 @@ class HfApi:
         timeout: int | float | str | None = None,
         labels: dict[str, str] | None = None,
         volumes: list[Volume] | None = None,
-        expose: bool | None = None,
+        expose: list[int] | None = None,
         namespace: str | None = None,
         token: bool | str | None = None,
     ) -> JobInfo:
@@ -12138,9 +12138,9 @@ class HfApi:
                 Each volume is a [`Volume`] with `type` (`"bucket"`, `"model"`, `"dataset"`, or `"space"`),
                 `source` (e.g. `"username/my-bucket"`), and `mount_path` (e.g. `"/data"`).
 
-            expose (`bool`, *optional*, defaults to `False`):
-                If True, expose every port the job's container listens on through the jobs proxy.
-                Each exposed port is then reachable on the public jobs domain. Access always
+            expose (`list[int]`, *optional*):
+                Container ports to expose through the jobs proxy. Each listed port is reachable
+                on the public jobs domain (e.g. `https://<job_id>--8000.hf.jobs`). Access always
                 requires an HF token with read access to the job's namespace.
 
             namespace (`str`, *optional*):
@@ -12237,7 +12237,7 @@ class HfApi:
         timeout: int | float | str | None = None,
         labels: dict[str, str] | None = None,
         volumes: list[Volume] | None = None,
-        expose: bool | None = None,
+        expose: list[int] | None = None,
         namespace: str | None = None,
         token: bool | str | None = None,
     ) -> ScheduledJobInfo:
@@ -12285,9 +12285,9 @@ class HfApi:
                 Each volume is a [`Volume`] with `type` (`"bucket"`, `"model"`, `"dataset"`, or `"space"`),
                 `source` (e.g. `"username/my-bucket"`), and `mount_path` (e.g. `"/data"`).
 
-            expose (`bool`, *optional*, defaults to `False`):
-                If True, expose every port the job's container listens on through the jobs proxy.
-                Each exposed port is then reachable on the public jobs domain. Access always
+            expose (`list[int]`, *optional*):
+                Container ports to expose through the jobs proxy. Each listed port is reachable
+                on the public jobs domain (e.g. `https://<job_id>--8000.hf.jobs`). Access always
                 requires an HF token with read access to the job's namespace.
 
             namespace (`str`, *optional*):
@@ -12575,7 +12575,7 @@ class HfApi:
         timeout: int | float | str | None = None,
         labels: dict[str, str] | None = None,
         volumes: list[Volume] | None = None,
-        expose: bool | None = None,
+        expose: list[int] | None = None,
         namespace: str | None = None,
         token: bool | str | None = None,
     ) -> ScheduledJobInfo:
@@ -12630,9 +12630,9 @@ class HfApi:
                 Each volume is a [`Volume`] with `type` (`"bucket"`, `"model"`, `"dataset"`, or `"space"`),
                 `source` (e.g. `"username/my-bucket"`), and `mount_path` (e.g. `"/data"`).
 
-            expose (`bool`, *optional*, defaults to `False`):
-                If True, expose every port the job's container listens on through the jobs proxy.
-                Each exposed port is then reachable on the public jobs domain. Access always
+            expose (`list[int]`, *optional*):
+                Container ports to expose through the jobs proxy. Each listed port is reachable
+                on the public jobs domain (e.g. `https://<job_id>--8000.hf.jobs`). Access always
                 requires an HF token with read access to the job's namespace.
 
             namespace (`str`, *optional*):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2805,6 +2805,7 @@ class TestJobsCommand:
             volumes=None,
             flavor=None,
             timeout=None,
+            expose=False,
             namespace=None,
         )
         api.fetch_job_logs.assert_not_called()
@@ -2830,6 +2831,7 @@ class TestJobsCommand:
             volumes=None,
             flavor=None,
             timeout=None,
+            expose=False,
             namespace=None,
         )
         api.fetch_job_logs.assert_not_called()
@@ -2859,6 +2861,7 @@ class TestJobsCommand:
             volumes=None,
             flavor=None,
             timeout=None,
+            expose=False,
             namespace=None,
         )
 
@@ -2884,6 +2887,7 @@ class TestJobsCommand:
             volumes=None,
             flavor=None,
             timeout=None,
+            expose=False,
             namespace=None,
         )
         api.fetch_job_logs.assert_not_called()
@@ -2912,6 +2916,7 @@ class TestJobsCommand:
             volumes=None,
             flavor=None,
             timeout=None,
+            expose=False,
             namespace=None,
         )
         api.fetch_job_logs.assert_not_called()
@@ -2938,6 +2943,7 @@ class TestJobsCommand:
             volumes=None,
             flavor=None,
             timeout=None,
+            expose=False,
             namespace=None,
         )
 
@@ -2965,6 +2971,7 @@ class TestJobsCommand:
             volumes=None,
             flavor=None,
             timeout=None,
+            expose=False,
             namespace=None,
         )
         api.fetch_job_logs.assert_not_called()
@@ -3670,6 +3677,18 @@ class TestVolume:
         )
         assert spec["volumes"][0]["revision"] == "main"
         assert spec["volumes"][0]["path"] == "subdir"
+
+    def test_serialize_expose_disabled_by_default(self) -> None:
+        spec = _create_job_spec(
+            image="python:3.12", command=["echo"], env=None, secrets=None, flavor=None, timeout=None
+        )
+        assert "expose" not in spec
+
+    def test_serialize_expose_enabled(self) -> None:
+        spec = _create_job_spec(
+            image="python:3.12", command=["echo"], env=None, secrets=None, flavor=None, timeout=None, expose=True
+        )
+        assert spec["expose"] == {"enabled": True}
 
 
 class TestWebhooksCommand:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3678,17 +3678,15 @@ class TestVolume:
         assert spec["volumes"][0]["revision"] == "main"
         assert spec["volumes"][0]["path"] == "subdir"
 
-    def test_serialize_expose_disabled_by_default(self) -> None:
+    @pytest.mark.parametrize(
+        "expose, expected",
+        [(None, None), (True, {"enabled": True}), (False, {"enabled": False})],
+    )
+    def test_serialize_expose(self, expose: bool | None, expected: dict | None) -> None:
         spec = _create_job_spec(
-            image="python:3.12", command=["echo"], env=None, secrets=None, flavor=None, timeout=None
+            image="python:3.12", command=["echo"], env=None, secrets=None, flavor=None, timeout=None, expose=expose
         )
-        assert "expose" not in spec
-
-    def test_serialize_expose_enabled(self) -> None:
-        spec = _create_job_spec(
-            image="python:3.12", command=["echo"], env=None, secrets=None, flavor=None, timeout=None, expose=True
-        )
-        assert spec["expose"] == {"enabled": True}
+        assert spec.get("expose") == expected
 
 
 class TestWebhooksCommand:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2805,7 +2805,7 @@ class TestJobsCommand:
             volumes=None,
             flavor=None,
             timeout=None,
-            expose=False,
+            expose=None,
             namespace=None,
         )
         api.fetch_job_logs.assert_not_called()
@@ -2831,7 +2831,7 @@ class TestJobsCommand:
             volumes=None,
             flavor=None,
             timeout=None,
-            expose=False,
+            expose=None,
             namespace=None,
         )
         api.fetch_job_logs.assert_not_called()
@@ -2861,7 +2861,7 @@ class TestJobsCommand:
             volumes=None,
             flavor=None,
             timeout=None,
-            expose=False,
+            expose=None,
             namespace=None,
         )
 
@@ -2887,7 +2887,7 @@ class TestJobsCommand:
             volumes=None,
             flavor=None,
             timeout=None,
-            expose=False,
+            expose=None,
             namespace=None,
         )
         api.fetch_job_logs.assert_not_called()
@@ -2916,7 +2916,7 @@ class TestJobsCommand:
             volumes=None,
             flavor=None,
             timeout=None,
-            expose=False,
+            expose=None,
             namespace=None,
         )
         api.fetch_job_logs.assert_not_called()
@@ -2943,7 +2943,7 @@ class TestJobsCommand:
             volumes=None,
             flavor=None,
             timeout=None,
-            expose=False,
+            expose=None,
             namespace=None,
         )
 
@@ -2971,7 +2971,7 @@ class TestJobsCommand:
             volumes=None,
             flavor=None,
             timeout=None,
-            expose=False,
+            expose=None,
             namespace=None,
         )
         api.fetch_job_logs.assert_not_called()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3680,9 +3680,14 @@ class TestVolume:
 
     @pytest.mark.parametrize(
         "expose, expected",
-        [(None, None), (True, {"enabled": True}), (False, {"enabled": False})],
+        [
+            (None, None),
+            ([], None),
+            ([8000], {"ports": [8000]}),
+            ([8000, 8001], {"ports": [8000, 8001]}),
+        ],
     )
-    def test_serialize_expose(self, expose: bool | None, expected: dict | None) -> None:
+    def test_serialize_expose(self, expose: list[int] | None, expected: dict | None) -> None:
         spec = _create_job_spec(
             image="python:3.12", command=["echo"], env=None, secrets=None, flavor=None, timeout=None, expose=expose
         )


### PR DESCRIPTION
## Summary

Add a repeatable `--expose <port>` flag on the four job-runner CLI commands and a matching `expose: list[int] | None` parameter on the Python API:

- `HfApi.run_job(..., expose=None)` / `hf jobs run --expose 8000 --expose 8001 ...`
- `HfApi.run_uv_job(..., expose=None)` / `hf jobs uv run --expose 8000 ...`
- `HfApi.create_scheduled_job(..., expose=None)` / `hf jobs scheduled run --expose 8000 ...`
- `HfApi.create_scheduled_uv_job(..., expose=None)` / `hf jobs scheduled uv run --expose 8000 ...`

When set, the request payload includes `expose: { ports: [...] }`, which tells the Jobs backend to register each port on the public jobs proxy. The job is then reachable at `https://<job_id>--<port>.hf.jobs`. Access still requires an HF token with read access to the job's namespace.

## Example

```bash
hf jobs run --expose 8000 python:3.12 python -m http.server 8000
hf jobs run --expose 8000 --expose 8001 python:3.12 my-multiport-app
```

```python
from huggingface_hub import run_job
run_job(image="python:3.12", command=["python", "-m", "http.server", "8000"], expose=[8000])
```

## Notes

- The default is `None` (omit `expose` from the payload). Pass a non-empty list to declare ports; an empty list is also accepted and serializes to `{"ports": []}` (same as no expose).
- The CLI help / docstrings deliberately don't hard-code the public domain (the helm chart owns it).
- The parametrized `test_serialize_expose` covers `None`, empty list, single port, and multi-port.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Exposes container ports on a public jobs domain (token-gated); changes job API payloads and `JobStatus` shape, but behavior is opt-in and scoped to Jobs.
> 
> **Overview**
> Adds **port exposure** for Hugging Face Jobs so workloads can be reached through the jobs proxy instead of only via logs/SSH-style workflows.
> 
> The Python API gains an optional `expose: list[int]` on `run_job`, `run_uv_job`, `create_scheduled_job`, and `create_scheduled_uv_job`. `_create_job_spec` sends `expose: { "ports": [...] }` when the list is non-empty; `None` and `[]` leave the field out of the payload. Job responses now surface **`expose_urls`** on `JobStatus` (from API `exposeUrls`), documented on `JobInfo`.
> 
> The CLI adds a repeatable **`--expose INTEGER`** on `hf jobs run`, `hf jobs uv run`, `hf jobs scheduled run`, and `hf jobs scheduled uv run`. After starting a job, `run` / `uv run` print a hint with the public URLs and note that access needs an HF token with read access to the job namespace. CLI reference docs are updated for all four commands.
> 
> Tests expect `expose=None` on existing job CLI mocks and add `test_serialize_expose` for job spec serialization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7eee9d038c7b592794bd2603c8b7c19ae08cbbf9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->