### PR TITLE
Add Telnyx as an inference provider

### DIFF
--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -135,7 +135,7 @@ class InferenceClient:
             Note: for better compatibility with OpenAI's client, `model` has been aliased as `base_url`. Those 2
             arguments are mutually exclusive. If a URL is passed as `model` or `base_url` for chat completion, the `(/v1)/chat/completions` suffix path will be appended to the URL.
         provider (`str`, *optional*):
-            Name of the provider to use for inference. Can be `"black-forest-labs"`, `"cerebras"`, `"clarifai"`, `"cohere"`, `"deepinfra"`, `"fal-ai"`, `"featherless-ai"`, `"fireworks-ai"`, `"groq"`, `"hf-inference"`, `"hyperbolic"`, `"nebius"`, `"novita"`, `"nscale"`, `"nvidia"`, `"openai"`, `"ovhcloud"`, `"publicai"`, `"replicate"`, `"sambanova"`, `"scaleway"`, `"together"`, `"wavespeed"` or `"zai-org"`.
+            Name of the provider to use for inference. Can be `"black-forest-labs"`, `"cerebras"`, `"clarifai"`, `"cohere"`, `"deepinfra"`, `"fal-ai"`, `"featherless-ai"`, `"fireworks-ai"`, `"groq"`, `"hf-inference"`, `"hyperbolic"`, `"nebius"`, `"novita"`, `"nscale"`, `"nvidia"`, `"openai"`, `"ovhcloud"`, `"publicai"`, `"replicate"`, `"sambanova"`, `"scaleway"`, `"telnyx"`, `"together"`, `"wavespeed"` or `"zai-org"`.
             Defaults to "auto": automatic routing, which defaults to "fastest" provider; you can
             switch to "cheapest" or "preferred" provider order at https://hf.co/settings/inference-providers.
             If model is a URL or `base_url` is passed, then `provider` is not used.

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -125,7 +125,7 @@ class AsyncInferenceClient:
             Note: for better compatibility with OpenAI's client, `model` has been aliased as `base_url`. Those 2
             arguments are mutually exclusive. If a URL is passed as `model` or `base_url` for chat completion, the `(/v1)/chat/completions` suffix path will be appended to the URL.
         provider (`str`, *optional*):
-            Name of the provider to use for inference. Can be `"black-forest-labs"`, `"cerebras"`, `"clarifai"`, `"cohere"`, `"deepinfra"`, `"fal-ai"`, `"featherless-ai"`, `"fireworks-ai"`, `"groq"`, `"hf-inference"`, `"hyperbolic"`, `"nebius"`, `"novita"`, `"nscale"`, `"nvidia"`, `"openai"`, `"ovhcloud"`, `"publicai"`, `"replicate"`, `"sambanova"`, `"scaleway"`, `"together"`, `"wavespeed"` or `"zai-org"`.
+            Name of the provider to use for inference. Can be `"black-forest-labs"`, `"cerebras"`, `"clarifai"`, `"cohere"`, `"deepinfra"`, `"fal-ai"`, `"featherless-ai"`, `"fireworks-ai"`, `"groq"`, `"hf-inference"`, `"hyperbolic"`, `"nebius"`, `"novita"`, `"nscale"`, `"nvidia"`, `"openai"`, `"ovhcloud"`, `"publicai"`, `"replicate"`, `"sambanova"`, `"scaleway"`, `"telnyx"`, `"together"`, `"wavespeed"` or `"zai-org"`.
             Defaults to "auto": automatic routing, which defaults to "fastest" provider; you can
             switch to "cheapest" or "preferred" provider order at https://hf.co/settings/inference-providers.
             If model is a URL or `base_url` is passed, then `provider` is not used.

--- a/src/huggingface_hub/inference/_providers/__init__.py
+++ b/src/huggingface_hub/inference/_providers/__init__.py
@@ -51,6 +51,7 @@ from .replicate import (
 )
 from .sambanova import SambanovaConversationalTask, SambanovaFeatureExtractionTask
 from .scaleway import ScalewayConversationalTask, ScalewayFeatureExtractionTask
+from .telnyx import TelnyxConversationalTask
 from .together import (
     TogetherConversationalTask,
     TogetherFeatureExtractionTask,
@@ -95,6 +96,7 @@ PROVIDER_T = Literal[
     "replicate",
     "sambanova",
     "scaleway",
+    "telnyx",
     "together",
     "wavespeed",
     "zai-org",
@@ -214,6 +216,9 @@ PROVIDERS: dict[PROVIDER_T, dict[str, TaskProviderHelper]] = {
     "scaleway": {
         "conversational": ScalewayConversationalTask(),
         "feature-extraction": ScalewayFeatureExtractionTask(),
+    },
+    "telnyx": {
+        "conversational": TelnyxConversationalTask(),
     },
     "together": {
         "conversational": TogetherConversationalTask(),

--- a/src/huggingface_hub/inference/_providers/telnyx.py
+++ b/src/huggingface_hub/inference/_providers/telnyx.py
@@ -1,0 +1,9 @@
+from ._common import BaseConversationalTask
+
+
+class TelnyxConversationalTask(BaseConversationalTask):
+    def __init__(self):
+        super().__init__(provider="telnyx", base_url="https://api.telnyx.com/v2/ai/openai")
+
+    def _prepare_route(self, mapped_model: str, api_key: str) -> str:
+        return "/chat/completions"

--- a/tests/test_inference_providers.py
+++ b/tests/test_inference_providers.py
@@ -57,6 +57,7 @@ from huggingface_hub.inference._providers.replicate import (
 )
 from huggingface_hub.inference._providers.sambanova import SambanovaConversationalTask, SambanovaFeatureExtractionTask
 from huggingface_hub.inference._providers.scaleway import ScalewayConversationalTask, ScalewayFeatureExtractionTask
+from huggingface_hub.inference._providers.telnyx import TelnyxConversationalTask
 from huggingface_hub.inference._providers.together import (
     TogetherConversationalTask,
     TogetherFeatureExtractionTask,
@@ -1735,6 +1736,17 @@ class TestSambanovaProvider:
             helper._prepare_url("hf_token", "username/repo_name")
             == "https://router.huggingface.co/sambanova/v1/embeddings"
         )
+
+
+class TestTelnyxProvider:
+    def test_conversational_properties(self):
+        helper = TelnyxConversationalTask()
+        assert helper.base_url == "https://api.telnyx.com/v2/ai/openai"
+        assert helper.provider == "telnyx"
+
+    def test_prepare_route(self):
+        helper = TelnyxConversationalTask()
+        assert helper._prepare_route("some/model", "hf_token") == "/chat/completions"
 
 
 class TestTogetherProvider:


### PR DESCRIPTION
## Summary

- Adds Telnyx as a new OpenAI-compatible Inference Provider in the Python client.
- Uses base URL `https://api.telnyx.com/v2/ai/openai` and supports the conversational task for now.
- Overrides the chat completions route to `/chat/completions` because Telnyx does not use the default `/v1/chat/completions` path.
- This is step 5, Python client integration, of the Inference Provider registration guide.
- The JS integration PR is being opened in parallel.

Manual checks:

```console
$ make style
...
✅ All good! (AsyncInferenceClient)
✅ All good! (CLI reference)

$ make quality
...
ty check src
All checks passed!

$ python -m pytest tests/test_inference_providers.py -q
186 passed in 1.79s
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive provider registration and docs with isolated routing override; no changes to auth or existing provider behavior.
> 
> **Overview**
> Adds **Telnyx** as a Hugging Face Inference Provider so `InferenceClient` can route conversational (`chat_completion`) calls with `provider="telnyx"`.
> 
> A new `TelnyxConversationalTask` targets Telnyx’s OpenAI-compatible API at `https://api.telnyx.com/v2/ai/openai` and overrides the chat path to **`/chat/completions`** (not the default `/v1/chat/completions`). The provider is registered in the inference providers registry (conversational only), and sync/async client docs list `"telnyx"` among supported providers. Unit tests cover base URL, provider id, and route preparation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21c9c3aebd6e06a8bf9480faedea10d79bbd82e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->