### PR TITLE
[Jobs] Add hf jobs wait command + HfApi.wait_for_job

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -1773,6 +1773,11 @@ This command runs the job and shows the logs. You can pass `--detach` to run the
 
 # Cancel a job
 >>> hf jobs cancel <job_id>
+
+# Wait for a job to finish (exits non-zero if it did not complete successfully)
+>>> hf jobs wait <job_id>
+# Chain jobs together: only run the second job if the first one succeeds
+>>> JOB_ID=$(hf jobs run -d python:3.12 python train.py) && hf jobs wait "$JOB_ID" && hf jobs uv run eval.py
 ```
 
 #### 3. Run on GPU

--- a/docs/source/en/guides/jobs.md
+++ b/docs/source/en/guides/jobs.md
@@ -149,16 +149,29 @@ Hello from the cloud!
 >>> cancel_job(job_id=job_id)
 ```
 
-Check the status of multiple jobs to know when they're all finished using a loop and [`inspect_job`]:
+## Wait for a Job
+
+Use [`wait_for_job`] to block until a Job reaches a terminal state (`COMPLETED`, `ERROR`, `CANCELED` or `DELETED`). It returns the final [`JobInfo`], so you can inspect `status.stage` to tell success from failure:
 
 ```python
-# Run multiple jobs in parallel and wait for their completions
->>> import time
->>> from huggingface_hub import inspect_job, run_job
+>>> from huggingface_hub import run_job, wait_for_job
+>>> job = run_job(image="python:3.12", command=["python", "-c", "print('Hello!')"])
+>>> job = wait_for_job(job_id=job.id, timeout=600)
+>>> job.status.stage
+'COMPLETED'
+```
+
+[`JobInfo.wait`] is a convenience shortcut for the same thing:
+
+```python
+>>> job = run_job(image="python:3.12", command=["python", "-c", "print('Hello!')"]).wait()
+```
+
+To run multiple jobs in parallel and wait for them all to finish:
+
+```python
 >>> jobs = [run_job(image=image, command=command) for command in commands]
->>> for job in jobs:
-...     while inspect_job(job_id=job.id).status.stage not in ("COMPLETED", "ERROR"):
-...         time.sleep(10)
+>>> jobs = [wait_for_job(job_id=job.id) for job in jobs]
 ```
 
 ## Select the hardware

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -2074,6 +2074,7 @@ $ hf jobs [OPTIONS] COMMAND [ARGS]...
 * `scheduled`: Create and manage scheduled Jobs on the Hub.
 * `stats`: Fetch the resource usage statistics and...
 * `uv`: Run UV scripts (Python with inline...
+* `wait`: Wait for one or more Jobs to reach a...
 
 ### `hf jobs cancel`
 
@@ -2669,6 +2670,42 @@ Examples
   $ hf jobs uv run ml_training.py --flavor a10g-small
   $ hf jobs uv run --with transformers train.py
   $ hf jobs uv run -v hf://org/my-model:/data -v hf://buckets/org/b:/mnt script.py
+
+Learn more
+  Use `hf <command> --help` for more information about a command.
+  Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
+
+
+### `hf jobs wait`
+
+Wait for one or more Jobs to reach a terminal state.
+
+Blocks until each Job finishes and prints its final status. Exits with a non-zero status code if
+any Job did not complete successfully, so it can gate shell pipelines
+(e.g. `hf jobs wait "$JOB_ID" && hf jobs uv run eval.py`).
+
+**Usage**:
+
+```console
+$ hf jobs wait [OPTIONS] JOB_IDS...
+```
+
+**Arguments**:
+
+* `JOB_IDS...`: Job IDs to wait for (or 'namespace/job_id')  [required]
+
+**Options**:
+
+* `--timeout FLOAT`: Maximum time to wait, in seconds. Waits indefinitely if not set.
+* `--poll-interval INTEGER`: Time between two polls of the Job status, in seconds.  [default: 5]
+* `--namespace TEXT`: The namespace where the job will be running. Defaults to the current user's namespace.
+* `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
+* `--help`: Show this message and exit.
+
+Examples
+  $ hf jobs wait <job_id>
+  $ hf jobs wait <job_id> --timeout 600
+  $ hf jobs wait <job_id1> <job_id2>
 
 Learn more
   Use `hf <command> --help` for more information about a command.

--- a/docs/source/en/package_reference/jobs.md
+++ b/docs/source/en/package_reference/jobs.md
@@ -12,6 +12,7 @@ Check the [`HfApi`] documentation page for the reference of methods to manage yo
 - Inspect Job: [`inspect_job`]
 - List Jobs: [`list_jobs`]
 - Cancel Job: [`cancel_job`]
+- Wait for a Job: [`wait_for_job`]
 - Run a UV Job: [`run_uv_job`]
 
 ## Data structures

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -351,6 +351,7 @@ _SUBMOD_ATTRS = {
         "upload_folder",
         "upload_large_folder",
         "verify_repo_checksums",
+        "wait_for_job",
         "whoami",
     ],
     "hf_file_system": [
@@ -1112,6 +1113,7 @@ __all__ = [
     "upload_folder",
     "upload_large_folder",
     "verify_repo_checksums",
+    "wait_for_job",
     "webhook_endpoint",
     "whoami",
 ]
@@ -1511,6 +1513,7 @@ if TYPE_CHECKING:  # pragma: no cover
         upload_folder,  # noqa: F401
         upload_large_folder,  # noqa: F401
         verify_repo_checksums,  # noqa: F401
+        wait_for_job,  # noqa: F401
         whoami,  # noqa: F401
     )
     from .hf_file_system import (

--- a/src/huggingface_hub/_jobs_api.py
+++ b/src/huggingface_hub/_jobs_api.py
@@ -260,6 +260,49 @@ class JobInfo:
         self.endpoint = kwargs.get("endpoint", constants.ENDPOINT)
         self.url = f"{self.endpoint}/jobs/{self.owner.name}/{self.id}"
 
+    def wait(
+        self,
+        *,
+        timeout: float | None = None,
+        refresh_every: int = 5,
+        token: bool | str | None = None,
+    ) -> "JobInfo":
+        """
+        Wait for the Job to reach a terminal state and return the updated [`JobInfo`].
+
+        Convenience wrapper around [`HfApi.wait_for_job`]. Since [`JobInfo`] does not store the token
+        used to create it, the locally saved token is used unless `token` is provided.
+
+        Args:
+            timeout (`float`, *optional*):
+                The maximum time to wait, in seconds. If `None` (default), waits indefinitely.
+            refresh_every (`int`, *optional*):
+                The time to wait between two polls of the Job status, in seconds. Defaults to 5s.
+            token `(Union[bool, str, None]`, *optional*):
+                A valid user access token. Defaults to the locally saved token.
+
+        Returns:
+            [`JobInfo`]: the Job information once it reached a terminal state.
+
+        Example:
+
+            ```python
+            >>> from huggingface_hub import run_job
+            >>> job = run_job(image="python:3.12", command=["python", "-c", "print('Hello!')"]).wait()
+            >>> job.status.stage
+            'COMPLETED'
+            ```
+        """
+        from .hf_api import HfApi
+
+        return HfApi(endpoint=self.endpoint).wait_for_job(
+            job_id=self.id,
+            namespace=self.owner.name,
+            timeout=timeout,
+            refresh_every=refresh_every,
+            token=token,
+        )
+
 
 @dataclass
 class JobSpec:

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -35,6 +35,9 @@ Usage:
     # Cancel a running job
     hf jobs cancel <job-id>
 
+    # Wait for a job to finish (exits non-zero if it did not complete successfully)
+    hf jobs wait <job-id>
+
     # List available hardware options
     hf jobs hardware
 
@@ -72,8 +75,8 @@ from typing import Annotated, Any, TypeVar
 
 import typer
 
-from huggingface_hub import JobHardware
-from huggingface_hub.errors import CLIError, HfHubHTTPError
+from huggingface_hub import JobHardware, JobStage
+from huggingface_hub.errors import CLIError, HfHubHTTPError, JobTimeoutError
 from huggingface_hub.utils import logging
 from huggingface_hub.utils._cache_manager import _format_size
 from huggingface_hub.utils._parsing import format_duration
@@ -675,6 +678,74 @@ def jobs_cancel(
         else:
             raise CLIError(f"Failed to cancel job: {e}") from e
     out.result("Job cancelled", id=job_id)
+
+
+@jobs_cli.command(
+    "wait",
+    examples=[
+        "hf jobs wait <job_id>",
+        "hf jobs wait <job_id> --timeout 600",
+        "hf jobs wait <job_id1> <job_id2>",
+    ],
+)
+def jobs_wait(
+    job_ids: Annotated[
+        list[str],
+        typer.Argument(
+            help="Job IDs to wait for (or 'namespace/job_id')",
+        ),
+    ],
+    timeout: Annotated[
+        float | None,
+        typer.Option(
+            help="Maximum time to wait, in seconds. Waits indefinitely if not set.",
+        ),
+    ] = None,
+    poll_interval: Annotated[
+        int,
+        typer.Option(
+            "--poll-interval",
+            help="Time between two polls of the Job status, in seconds.",
+        ),
+    ] = 5,
+    namespace: NamespaceOpt = None,
+    token: TokenOpt = None,
+) -> None:
+    """Wait for one or more Jobs to reach a terminal state.
+
+    Blocks until each Job finishes and prints its final status. Exits with a non-zero status code if
+    any Job did not complete successfully, so it can gate shell pipelines
+    (e.g. `hf jobs wait "$JOB_ID" && hf jobs uv run eval.py`).
+    """
+    api = get_hf_api(token=token)
+    finished = []
+    for job_id in job_ids:
+        parsed_id, parsed_namespace = _parse_namespace_from_job_id(job_id, namespace)
+        try:
+            finished.append(
+                api.wait_for_job(
+                    job_id=parsed_id,
+                    namespace=parsed_namespace,
+                    timeout=timeout,
+                    refresh_every=poll_interval,
+                )
+            )
+        except JobTimeoutError as e:
+            raise CLIError(str(e)) from e
+        except HfHubHTTPError as e:
+            status = e.response.status_code if e.response is not None else None
+            if status == 404:
+                raise CLIError("Job not found. Please check the job ID.") from e
+            elif status == 403:
+                raise CLIError("Access denied. You may not have permission to view this job.") from e
+            else:
+                raise CLIError(f"Failed to wait for job: {e}") from e
+
+    out.table([_dataclass_to_dict(job) for job in finished])
+    failed = [job for job in finished if (job.status.stage if job.status else None) != JobStage.COMPLETED]
+    if failed:
+        out.hint(f"Run 'hf jobs logs {failed[0].id}' to inspect the failure.")
+        raise CLIError("Job(s) did not complete successfully: " + ", ".join(job.id for job in failed))
 
 
 @jobs_cli.command(

--- a/src/huggingface_hub/errors.py
+++ b/src/huggingface_hub/errors.py
@@ -116,6 +116,13 @@ class InferenceEndpointTimeoutError(InferenceEndpointError, TimeoutError):
     """Exception for timeouts while waiting for Inference Endpoint."""
 
 
+# JOB ERRORS
+
+
+class JobTimeoutError(TimeoutError):
+    """Raised when a Job does not reach a terminal state within the given timeout."""
+
+
 # SAFETENSORS ERRORS
 
 

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -73,7 +73,7 @@ from ._commit_api import (
 from ._dataset_viewer import DatasetParquetEntry
 from ._eval_results import EvalResultEntry, parse_eval_result_entries
 from ._inference_endpoints import InferenceEndpoint, InferenceEndpointScalingMetric, InferenceEndpointType
-from ._jobs_api import JobHardware, JobHardwareInfo, JobInfo, JobSpec, ScheduledJobInfo, _create_job_spec
+from ._jobs_api import JobHardware, JobHardwareInfo, JobInfo, JobSpec, JobStage, ScheduledJobInfo, _create_job_spec
 from ._space_api import (
     SpaceHardware,
     SpaceRuntime,
@@ -98,6 +98,7 @@ from .errors import (
     FileDuplicationError,
     GatedRepoError,
     HfHubHTTPError,
+    JobTimeoutError,
     LocalTokenNotFoundError,
     RemoteEntryNotFoundError,
     RepositoryNotFoundError,
@@ -11994,6 +11995,79 @@ class HfApi:
         response.raise_for_status()
         return JobInfo(**response.json(), endpoint=self.endpoint)
 
+    def wait_for_job(
+        self,
+        *,
+        job_id: str,
+        namespace: str | None = None,
+        timeout: float | None = None,
+        refresh_every: int = 5,
+        token: bool | str | None = None,
+    ) -> JobInfo:
+        """
+        Wait for a compute Job to reach a terminal state.
+
+        Polls [`HfApi.inspect_job`] every `refresh_every` seconds until the Job reaches a terminal
+        stage (`COMPLETED`, `ERROR`, `CANCELED` or `DELETED`) and returns the corresponding
+        [`JobInfo`]. The Job's final outcome is not raised as an error: inspect the returned
+        `status.stage` to tell success (`COMPLETED`) from failure.
+
+        Args:
+            job_id (`str`):
+                ID of the Job.
+
+            namespace (`str`, *optional*):
+                The namespace where the Job is running. Defaults to the current user's namespace.
+
+            timeout (`float`, *optional*):
+                The maximum time to wait, in seconds. If `None` (default), waits indefinitely.
+
+            refresh_every (`int`, *optional*):
+                The time to wait between two polls of the Job status, in seconds. Defaults to 5s.
+
+            token `(Union[bool, str, None]`, *optional*):
+                A valid user access token. If not provided, the locally saved token will be used, which is the
+                recommended authentication method. Set to `False` to disable authentication.
+                Refer to: https://huggingface.co/docs/huggingface_hub/quick-start#authentication.
+
+        Returns:
+            [`JobInfo`]: the Job information once it reached a terminal state.
+
+        Raises:
+            [`~errors.JobTimeoutError`]:
+                If the Job did not reach a terminal state within `timeout` seconds.
+
+        Example:
+
+            ```python
+            >>> from huggingface_hub import run_job, wait_for_job
+            >>> job = run_job(image="python:3.12", command=["python", "-c", "print('Hello from HF compute!')"])
+            >>> job = wait_for_job(job_id=job.id)
+            >>> job.status.stage
+            'COMPLETED'
+            ```
+        """
+        if timeout is not None and timeout < 0:
+            raise ValueError("`timeout` cannot be negative.")
+        if refresh_every <= 0:
+            raise ValueError("`refresh_every` must be positive.")
+        if namespace is None:
+            # Resolve the namespace once to avoid an extra `whoami` call on every poll.
+            namespace = self.whoami(token=token)["name"]
+
+        terminal_stages = {JobStage.COMPLETED, JobStage.CANCELED, JobStage.ERROR, JobStage.DELETED}
+        start = time.time()
+        while True:
+            job = self.inspect_job(job_id=job_id, namespace=namespace, token=token)
+            stage = job.status.stage if job.status else None
+            if stage in terminal_stages:
+                return job
+            if timeout is not None and time.time() - start > timeout:
+                raise JobTimeoutError(
+                    f"Job {job_id} did not reach a terminal state within {timeout}s (last stage: {stage})."
+                )
+            time.sleep(refresh_every)
+
     def cancel_job(
         self,
         *,
@@ -14455,6 +14529,7 @@ fetch_job_metrics = api.fetch_job_metrics
 list_jobs = api.list_jobs
 list_jobs_hardware = api.list_jobs_hardware
 inspect_job = api.inspect_job
+wait_for_job = api.wait_for_job
 cancel_job = api.cancel_job
 update_job_labels = api.update_job_labels
 run_uv_job = api.run_uv_job

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2935,6 +2935,37 @@ class TestJobsCommand:
         api.fetch_job_logs.assert_called_once_with(job_id="my-job-id", namespace=None, follow=True, tail=100)
         assert "streaming line" in result.output
 
+    def test_wait_success(self, runner: CliRunner) -> None:
+        """`hf jobs wait <id>` forwards options and exits 0 when the job completes."""
+        job = JobInfo(id="my-job-id", status={"stage": "COMPLETED"}, owner={"id": "i", "name": "me", "type": "user"})
+        with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            api.wait_for_job.return_value = job
+            result = runner.invoke(app, ["jobs", "wait", "my-job-id", "--timeout", "600", "--poll-interval", "2"])
+        assert result.exit_code == 0
+        api.wait_for_job.assert_called_once_with(job_id="my-job-id", namespace=None, timeout=600.0, refresh_every=2)
+        assert "my-job-id" in result.output
+
+    def test_wait_failure_exits_non_zero(self, runner: CliRunner) -> None:
+        """A job ending in a non-COMPLETED terminal stage makes `hf jobs wait` exit non-zero."""
+        job = JobInfo(id="my-job-id", status={"stage": "ERROR"}, owner={"id": "i", "name": "me", "type": "user"})
+        with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            api.wait_for_job.return_value = job
+            result = runner.invoke(app, ["jobs", "wait", "my-job-id"])
+        assert result.exit_code != 0
+        api.wait_for_job.assert_called_once_with(job_id="my-job-id", namespace=None, timeout=None, refresh_every=5)
+
+    def test_wait_timeout_exits_non_zero(self, runner: CliRunner) -> None:
+        """A `JobTimeoutError` from the API surfaces as a non-zero exit code."""
+        from huggingface_hub.errors import JobTimeoutError
+
+        with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            api.wait_for_job.side_effect = JobTimeoutError("Job my-job-id did not reach a terminal state within 1.0s.")
+            result = runner.invoke(app, ["jobs", "wait", "my-job-id", "--timeout", "1"])
+        assert result.exit_code != 0
+
     def _make_mock_jobs(self):
         """Create mock JobInfo objects for testing ps output."""
         from huggingface_hub._jobs_api import JobInfo

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,0 +1,63 @@
+from unittest.mock import patch
+
+import pytest
+
+from huggingface_hub import HfApi
+from huggingface_hub._jobs_api import JobInfo
+from huggingface_hub.errors import JobTimeoutError
+
+
+def _job(stage: str) -> JobInfo:
+    return JobInfo(id="job-id", status={"stage": stage}, owner={"id": "i", "name": "me", "type": "user"})
+
+
+class TestWaitForJob:
+    def test_returns_when_completed(self) -> None:
+        api = HfApi()
+        with (
+            patch.object(api, "whoami", return_value={"name": "me"}) as whoami,
+            patch.object(
+                api, "inspect_job", side_effect=[_job("RUNNING"), _job("RUNNING"), _job("COMPLETED")]
+            ) as inspect,
+            patch("huggingface_hub.hf_api.time.sleep"),
+        ):
+            job = api.wait_for_job(job_id="job-id")
+        assert job.status.stage == "COMPLETED"
+        assert inspect.call_count == 3
+        # Namespace is resolved once up front, not on every poll.
+        whoami.assert_called_once()
+        inspect.assert_called_with(job_id="job-id", namespace="me", token=None)
+
+    def test_returns_terminal_failure_without_raising(self) -> None:
+        api = HfApi()
+        with (
+            patch.object(api, "inspect_job", return_value=_job("ERROR")),
+            patch("huggingface_hub.hf_api.time.sleep"),
+        ):
+            job = api.wait_for_job(job_id="job-id", namespace="me")
+        # A failed Job is a normal terminal outcome: it is returned, not raised.
+        assert job.status.stage == "ERROR"
+
+    def test_raises_on_timeout(self) -> None:
+        api = HfApi()
+        with (
+            patch.object(api, "inspect_job", return_value=_job("RUNNING")),
+            patch("huggingface_hub.hf_api.time.sleep"),
+            patch("huggingface_hub.hf_api.time.time", side_effect=[0.0, 100.0]),
+        ):
+            with pytest.raises(JobTimeoutError):
+                api.wait_for_job(job_id="job-id", namespace="me", timeout=10)
+
+    def test_invalid_arguments(self) -> None:
+        api = HfApi()
+        with pytest.raises(ValueError):
+            api.wait_for_job(job_id="job-id", namespace="me", timeout=-1)
+        with pytest.raises(ValueError):
+            api.wait_for_job(job_id="job-id", namespace="me", refresh_every=0)
+
+    def test_jobinfo_wait_delegates_to_api(self) -> None:
+        job = _job("RUNNING")
+        with patch("huggingface_hub.hf_api.HfApi.wait_for_job", return_value=_job("COMPLETED")) as wait_for_job:
+            result = job.wait(timeout=30)
+        assert result.status.stage == "COMPLETED"
+        wait_for_job.assert_called_once_with(job_id="job-id", namespace="me", timeout=30, refresh_every=5, token=None)


### PR DESCRIPTION
## Summary

Adds a first-class **wait** primitive for Jobs so you can block until a Job finishes with a clean exit code. Closes #4311.

Today you can launch a Job but there's no built-in way to wait for it to complete — you have to hand-roll an `inspect_job` polling loop. This adds:

- **`HfApi.wait_for_job(...)`** — polls `inspect_job` until the Job reaches a terminal stage (`COMPLETED`, `ERROR`, `CANCELED`, `DELETED`) and returns the final `JobInfo`. The namespace is resolved once up front to avoid a `whoami` call on every poll.
- **`JobInfo.wait()`** — convenience shortcut so `run_job(...).wait()` works.
- **`hf jobs wait <id>...`** — blocks on one or more Jobs and prints their final status. Exits non-zero unless every Job completed, so it gates shell pipelines. Supports `--timeout` and `--poll-interval`, and inherits the global `--format` / `--no-truncate` flags.
- **`JobTimeoutError`** — raised when the timeout elapses before a terminal state.

It mirrors the existing `InferenceEndpoint.wait()` pattern and needs **no server changes** (reuses `inspect_job` + the `JobStage` terminal states).

### Design notes

- `wait_for_job` returns the `JobInfo` for *any* terminal stage and only raises on **timeout** — a Job ending in `ERROR` is a normal outcome you'll want the details for. The CLI maps the final stage to the exit code (0 = all `COMPLETED`, 1 otherwise).
- Param is named `refresh_every` to match `InferenceEndpoint.wait()` for in-library consistency (the issue suggested `poll_interval`; the CLI flag is `--poll-interval`).
- `JobInfo` doesn't store the token used to create it, so `JobInfo.wait()` falls back to the locally-saved token unless you pass `token=`.

## Examples

```
$ hf jobs wait --help
Usage: hf jobs wait [OPTIONS] JOB_IDS...

  Wait for one or more Jobs to reach a terminal state.

  Blocks until each Job finishes and prints its final status. Exits with a
  non-zero status code if any Job did not complete successfully, so it can
  gate shell pipelines (e.g. `hf jobs wait "$JOB_ID" && hf jobs uv run
  eval.py`).

Arguments:
  JOB_IDS...  Job IDs to wait for (or 'namespace/job_id')  [required]

Options:
  --timeout FLOAT          Maximum time to wait, in seconds. Waits indefinitely if not set.
  --poll-interval INTEGER  Time between two polls of the Job status, in seconds.  [default: 5]
  --namespace TEXT         The namespace where the job will be running. Defaults to the current user's namespace.
  --token TEXT             A User Access Token generated from https://huggingface.co/settings/tokens.
```

Python:

```python
>>> from huggingface_hub import run_job, wait_for_job
>>> job = run_job(image="python:3.12", command=["python", "-c", "print('Hello!')"])
>>> wait_for_job(job_id=job.id, timeout=600).status.stage
'COMPLETED'
>>> # or the convenience shortcut
>>> run_job(image="python:3.12", command=["python", "-c", "print('Hello!')"]).wait()
```

Chaining in the shell — only run eval if training succeeds:

```bash
JOB_ID=$(hf jobs run -d python:3.12 python train.py) && hf jobs wait "$JOB_ID" && hf jobs uv run eval.py
```

CLI exit-code behaviour (API stubbed locally — I don't have compute handy):

```
$ hf jobs wait 687fb701029421ae5549d998        # job completes
ID        DOCKER_IMAGE COMMAND   FLAVOR    STATUS    OWNER   ...
687fb7... python:3.12  python... cpu-basic {"stag... lhoestq ...
(exit code: 0)

$ hf jobs wait 687fb701029421ae5549d998        # job errored
... STATUS {"stage":"ERROR"} ...
Hint: Run 'hf jobs logs 687fb701029421ae5549d998' to inspect the failure.
(exit code: 1)
```

## Tests

- `tests/test_jobs.py` — `wait_for_job` unit tests (completion, terminal-failure-returns-without-raising, timeout, arg validation, `JobInfo.wait` delegation); polling/sleep mocked.
- `tests/test_cli.py::TestJobsCommand` — `hf jobs wait` success (exit 0), failure (exit 1), timeout (exit 1).

`make style` + `make quality` (ruff, static imports, `__all__`, CLI reference, `ty`) all clean; `mypy src` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive client-only polling on existing `inspect_job`; behavior is covered by unit and CLI tests with no auth or data-model changes.
> 
> **Overview**
> Adds a **wait** flow for Hub Jobs so scripts and shells can block until a job finishes without hand-rolled `inspect_job` loops.
> 
> **Python API:** `HfApi.wait_for_job` polls `inspect_job` until a terminal stage (`COMPLETED`, `ERROR`, `CANCELED`, `DELETED`), resolves namespace once up front, and raises **`JobTimeoutError`** only on timeout (failed jobs still return `JobInfo`). **`JobInfo.wait()`** delegates to the same logic; **`wait_for_job`** is exported from the package.
> 
> **CLI:** New **`hf jobs wait`** accepts one or more job IDs, optional `--timeout` and `--poll-interval`, prints final status, and exits non-zero unless every job is **`COMPLETED`** (timeouts and HTTP errors map to CLI errors).
> 
> Docs and package reference are updated; **`tests/test_jobs.py`** and CLI tests cover polling, timeout, and exit codes. No server changes—reuses existing job status APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 116e784bc820544975a9e26c0681787edac2175c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->