### PR TITLE
[CI] Run tests on internal workers

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -33,7 +33,8 @@ jobs:
           python -c "from huggingface_hub import *"
 
   build-ubuntu:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: aws-general-8-plus
     env:
       UV_HTTP_TIMEOUT: 600 # max 10min to install deps
 


### PR DESCRIPTION
Related [slack thread](https://huggingface.slack.com/archives/CTKK32GE8/p1780690221707969?thread_ts=1780678593.811179&cid=CTKK32GE8).

Using internal workers should prevent 429 rate limits we are experiencing in the CI. These rate limits are not due to the user account but to the WAF flagging some GH IPs as spam.

**TL;DR:** should be more reliable

Note: not updating the windows test since internal workers are unix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only runner label change for the Ubuntu job; no application or test logic changes.
> 
> **Overview**
> The **`build-ubuntu`** Python test matrix no longer uses GitHub-hosted `ubuntu-latest` runners. It now targets the internal runner group **`aws-general-8-plus`**, so Ubuntu CI runs on Hugging Face’s own workers instead of default GitHub IPs.
> 
> This is meant to cut down **429 / WAF-related rate limiting** that was hitting CI when traffic came from flagged GitHub IP ranges. **`check-imports`** and **`build-windows`** are unchanged (Windows stays on `windows-latest` because internal workers are Unix-only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 458bb5f9a1b78bb551c1a7a0db05c2d2b365cb01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->