### PR TITLE
[Auth] Take google colab token from env first

### DIFF
--- a/src/huggingface_hub/utils/_auth.py
+++ b/src/huggingface_hub/utils/_auth.py
@@ -64,7 +64,7 @@ def get_token() -> str | None:
     Returns:
         `str` or `None`: The token, `None` if it doesn't exist.
     """
-    return _get_token_from_google_colab() or _get_token_from_environment() or _get_token_from_file()
+    return _get_token_from_environment() or _get_token_from_file() or _get_token_from_google_colab()
 
 
 def _get_token_from_google_colab() -> str | None:


### PR DESCRIPTION
_Originally from @xenova on [slack](https://huggingface.slack.com/archives/C02V5EA0A95/p1780673953456969) (internal):_

> Raising as potential unexpected behaviour. The team were making model changes via colab, and even though they logged in, it seemed to have picked the colab secret instead.

This PR fixes this. If a user runs `login` in a Colab (saves the token in a local file) or sets an env variable, it should take precedence over the Colab's vault.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authentication precedence in Google Colab, which can alter which HF account is used for hub requests when multiple token sources exist.
> 
> **Overview**
> **Reorders HF token resolution in Colab** so explicit user credentials win over the notebook secrets vault.
> 
> `get_token()` now checks **`HF_TOKEN` / `HUGGING_FACE_HUB_TOKEN`**, then the **on-disk token file** (e.g. after `login()`), and only then **Google Colab’s `HF_TOKEN` secret**. Previously Colab’s vault was consulted first, which could override a token the user had just saved via `login()` or set in the environment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3e2a9b0bd82c378deea855d081bb98591860925. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->