### PR TITLE
[URIs] Use `parse_hf_uri` in `RepoUrl` + soft-deprecate `repo_type_and_id_from_hf_id`

### DIFF
--- a/docs/source/en/package_reference/hf_uris.md
+++ b/docs/source/en/package_reference/hf_uris.md
@@ -106,6 +106,13 @@ HfUri(type='dataset', id='my-org/my-dataset', revision='main', path_in_repo='tra
 
 URLs from `huggingface.co` (and its `hf.co` short domain, the staging host, and the host of a custom `HF_ENDPOINT`) are recognized, with or without the `https://` scheme. Query strings (`?download=true`) and fragments (`#L10`) are ignored.
 
+To parse a URL from another Hub deployment (e.g. a self-hosted or proxied Hub), pass its base URL as `endpoint`. Its host is then recognized in addition to the default ones, and a path prefix (e.g. `http://localhost:8080/hf`) is stripped before parsing:
+
+```python
+>>> parse_hf_uri("https://hub.my-company.com/datasets/my-org/my-dataset", endpoint="https://hub.my-company.com")
+HfUri(type='dataset', id='my-org/my-dataset', revision=None, path_in_repo='')
+```
+
 ### Supported URL formats
 
 The table below lists the supported routes. For brevity, only the **URL path** is shown (the part after the host, e.g. `huggingface.co`); the recognized host is implied.

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -674,19 +674,15 @@ class RepoUrl(str):
         super().__init__()
         self.endpoint = endpoint or constants.ENDPOINT
 
-        # Normalize the input into a canonical 'hf://' URI and parse it with the shared
-        # 'parse_hf_uri' parser. The endpoint prefix is stripped (falling back to a generic
-        # scheme + host strip) so that web URLs from any host (custom / self-hosted endpoints,
-        # 'hf.co', staging, ...) and bare '<namespace>/<name>' ids all reach the same parser.
+        # Parse with the shared 'parse_hf_uri' parser, which handles both 'hf://' URIs and Hugging
+        # Face web URLs. If that fails, the input is either a bare '<namespace>/<name>' id or a URL
+        # on a custom endpoint that 'parse_hf_uri' doesn't recognize: strip the endpoint prefix and
+        # reparse it as an 'hf://' URI.
         raw = str(self)
-        if raw.startswith(constants.HF_PROTOCOL):
-            uri_str = raw
-        else:
-            path = raw.removeprefix(self.endpoint)
-            if "://" in path:  # endpoint prefix didn't match -> strip scheme + host generically
-                path = path.split("://", 1)[1].partition("/")[2]
-            uri_str = constants.HF_PROTOCOL + path.lstrip("/")
-        parsed = parse_hf_uri(uri_str)
+        try:
+            parsed = parse_hf_uri(raw)
+        except HfUriError:
+            parsed = parse_hf_uri(f"{constants.HF_PROTOCOL}{raw.removeprefix(self.endpoint).lstrip('/')}")
 
         # Populate fields ('parsed.id' is always '<namespace>/<name>').
         self.namespace, self.repo_name = parsed.id.split("/")
@@ -8627,21 +8623,23 @@ class HfApi:
             constants.REPO_TYPE_SPACE: "spaces",
         }[repo_type]
 
-        # Infer target namespace + name. 'from_id'/'to_id' are bare '<namespace>/<name>' ids, so
-        # we parse them as 'hf://' URIs. When 'to_id' is provided we take the name from it; otherwise
-        # we reuse the source name. If 'to_id' has no namespace (or is not provided), the namespace
-        # defaults to the caller's account.
+        # Resolve the target namespace + name. When 'to_id' is provided we take the name from it,
+        # otherwise we reuse the source name. Both may be a URL, an 'hf://' URI, or a bare id, so we
+        # try 'parse_hf_uri' first and fall back to a plain split ('<namespace>/<name>', or just
+        # '<name>' for 'to_id'). A missing namespace defaults to the caller's account.
         to_namespace: str | None = None
         if to_id is not None:
             try:
-                to_uri = parse_hf_uri(f"{constants.HF_PROTOCOL}{to_id}")
+                to_namespace, to_repo_name = parse_hf_uri(to_id).id.split("/")
             except HfUriError:
-                # 'to_id' is a bare '<name>' (no namespace): keep it as the name, guess the namespace.
-                to_repo_name = to_id
-            else:
-                to_namespace, to_repo_name = to_uri.id.split("/")
+                namespace_and_name = to_id.rsplit("/", 1)
+                to_namespace = namespace_and_name[0] if len(namespace_and_name) == 2 else None
+                to_repo_name = namespace_and_name[-1]
         else:
-            to_repo_name = parse_hf_uri(f"{constants.HF_PROTOCOL}{from_id}").id.split("/")[1]
+            try:
+                to_repo_name = parse_hf_uri(from_id).id.split("/")[1]
+            except HfUriError:
+                to_repo_name = from_id.rsplit("/", 1)[-1]
         if to_namespace is None:
             to_namespace = self.whoami(token)["name"]
 

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -293,6 +293,15 @@ def repo_type_and_id_from_hf_id(hf_id: str, hub_url: str | None = None) -> tuple
     Returns the repo type and ID from a huggingface.co URL linking to a
     repository
 
+    <Tip warning={true}>
+
+    Deprecated: prefer [`parse_hf_uri`], which parses both `hf://` URIs and Hugging Face web URLs into
+    a structured [`HfUri`]. `parse_hf_uri` is stricter (it does not accept canonical single-segment
+    repos or bare `<namespace>/<name>` ids without a scheme), so this function is kept for backward
+    compatibility but is no longer used internally by `huggingface_hub`.
+
+    </Tip>
+
     Args:
         hf_id (`str`):
             An URL or ID of a repository on the HF hub. Accepted values are:
@@ -627,9 +636,9 @@ class RepoUrl(str):
     """Subclass of `str` describing a repo URL on the Hub.
 
     `RepoUrl` is returned by `HfApi.create_repo`. It inherits from `str` for backward
-    compatibility. At initialization, the URL is parsed to populate properties:
+    compatibility. At initialization, the URL is parsed (via [`parse_hf_uri`]) to populate properties:
     - endpoint (`str`)
-    - namespace (`Optional[str]`)
+    - namespace (`str`)
     - repo_name (`str`)
     - repo_id (`str`)
     - repo_type (`Literal["model", "dataset", "space"]`)
@@ -643,8 +652,8 @@ class RepoUrl(str):
 
     Example:
     ```py
-    >>> RepoUrl('https://huggingface.co/gpt2')
-    RepoUrl('https://huggingface.co/gpt2', endpoint='https://huggingface.co', repo_type='model', repo_id='gpt2')
+    >>> RepoUrl('https://huggingface.co/gpt2')  # doctest: +SKIP
+    RepoUrl('https://huggingface.co/openai-community/gpt2', endpoint='https://huggingface.co', repo_type='model', repo_id='openai-community/gpt2')
 
     >>> RepoUrl('https://hub-ci.huggingface.co/datasets/dummy_user/dummy_dataset', endpoint='https://hub-ci.huggingface.co')
     RepoUrl('https://hub-ci.huggingface.co/datasets/dummy_user/dummy_dataset', endpoint='https://hub-ci.huggingface.co', repo_type='dataset', repo_id='dummy_user/dummy_dataset')
@@ -656,11 +665,14 @@ class RepoUrl(str):
     RepoUrl('https://huggingface.co/Wauplin/dummy_model', endpoint='https://huggingface.co', repo_type='model', repo_id='Wauplin/dummy_model')
     ```
 
+    > [!WARNING]
+    > Canonical single-segment repos (e.g. 'gpt2', without a namespace) are not supported. They are
+    > archived/read-only on the Hub and all have a namespaced alias (e.g. 'openai-community/gpt2').
+
     Raises:
-        [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
-            If URL cannot be parsed.
-        [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
-            If `repo_type` is unknown.
+        [`~errors.HfUriError`]:
+            If the URL cannot be parsed (e.g. canonical single-segment repo, or unknown `repo_type`).
+            `HfUriError` is a subclass of `ValueError`.
     """
 
     def __new__(cls, url: Any, endpoint: str | None = None):
@@ -669,15 +681,26 @@ class RepoUrl(str):
 
     def __init__(self, url: Any, endpoint: str | None = None) -> None:
         super().__init__()
-        # Parse URL
         self.endpoint = endpoint or constants.ENDPOINT
-        repo_type, namespace, repo_name = repo_type_and_id_from_hf_id(self, hub_url=self.endpoint)
 
-        # Populate fields
-        self.namespace = namespace
-        self.repo_name = repo_name
-        self.repo_id = repo_name if namespace is None else f"{namespace}/{repo_name}"
-        self.repo_type = repo_type or constants.REPO_TYPE_MODEL
+        # Normalize the input into a canonical 'hf://' URI and parse it with the shared
+        # 'parse_hf_uri' parser. The endpoint prefix is stripped (falling back to a generic
+        # scheme + host strip) so that web URLs from any host (custom / self-hosted endpoints,
+        # 'hf.co', staging, ...) and bare '<namespace>/<name>' ids all reach the same parser.
+        raw = str(self)
+        if raw.startswith(constants.HF_PROTOCOL):
+            uri_str = raw
+        else:
+            path = raw.removeprefix(self.endpoint)
+            if "://" in path:  # endpoint prefix didn't match -> strip scheme + host generically
+                path = path.split("://", 1)[1].partition("/")[2]
+            uri_str = constants.HF_PROTOCOL + path.lstrip("/")
+        parsed = parse_hf_uri(uri_str)
+
+        # Populate fields ('parsed.id' is always '<namespace>/<name>').
+        self.namespace, self.repo_name = parsed.id.split("/")
+        self.repo_id = parsed.id
+        self.repo_type = parsed.type
         self.url = str(self)  # just in case it's needed
 
     def __repr__(self) -> str:
@@ -8613,16 +8636,17 @@ class HfApi:
             constants.REPO_TYPE_SPACE: "spaces",
         }[repo_type]
 
-        # Parse to_id if provided
-        parsed_to_id = RepoUrl(to_id) if to_id is not None else None
-
-        # Infer target repo_id
-        to_namespace = (
-            parsed_to_id.namespace
-            if parsed_to_id is not None and parsed_to_id.namespace is not None
-            else self.whoami(token)["name"]
-        )
-        to_repo_name = parsed_to_id.repo_name if to_id is not None else RepoUrl(from_id).repo_name  # type: ignore
+        # Infer target namespace + name. When 'to_id' is provided, split it as
+        # '<namespace>/<name>' (a bare '<name>' has no namespace); otherwise reuse the source
+        # name. A missing namespace defaults to the caller's account.
+        if to_id is not None:
+            namespace_and_name = to_id.rsplit("/", 1)
+            to_namespace = namespace_and_name[0] if len(namespace_and_name) == 2 else None
+            to_repo_name = namespace_and_name[-1]
+        else:
+            to_namespace, to_repo_name = None, from_id.rsplit("/", 1)[-1]
+        if to_namespace is None:
+            to_namespace = self.whoami(token)["name"]
 
         payload: dict[str, Any] = {"repository": f"{to_namespace}/{to_repo_name}"}
 

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -294,14 +294,9 @@ def repo_type_and_id_from_hf_id(hf_id: str, hub_url: str | None = None) -> tuple
     Returns the repo type and ID from a huggingface.co URL linking to a
     repository
 
-    <Tip warning={true}>
-
-    Deprecated: prefer [`parse_hf_uri`], which parses both `hf://` URIs and Hugging Face web URLs into
-    a structured [`HfUri`]. `parse_hf_uri` is stricter (it does not accept canonical single-segment
-    repos or bare `<namespace>/<name>` ids without a scheme), so this function is kept for backward
-    compatibility but is no longer used internally by `huggingface_hub`.
-
-    </Tip>
+    > [!WARNING]
+    > Deprecated: prefer [`parse_hf_uri`], which parses both `hf://` URIs and Hugging Face web URLs into a structured [`HfUri`].
+    > See https://huggingface.co/docs/huggingface_hub/package_reference/hf_uris for more details.
 
     Args:
         hf_id (`str`):
@@ -637,7 +632,7 @@ class RepoUrl(str):
     """Subclass of `str` describing a repo URL on the Hub.
 
     `RepoUrl` is returned by `HfApi.create_repo`. It inherits from `str` for backward
-    compatibility. At initialization, the URL is parsed (via [`parse_hf_uri`]) to populate properties:
+    compatibility. At initialization, the URL is parsed to populate properties:
     - endpoint (`str`)
     - namespace (`str`)
     - repo_name (`str`)
@@ -653,7 +648,7 @@ class RepoUrl(str):
 
     Example:
     ```py
-    >>> RepoUrl('https://huggingface.co/gpt2')  # doctest: +SKIP
+    >>> RepoUrl('https://huggingface.co/openai-community/gpt2')
     RepoUrl('https://huggingface.co/openai-community/gpt2', endpoint='https://huggingface.co', repo_type='model', repo_id='openai-community/gpt2')
 
     >>> RepoUrl('https://hub-ci.huggingface.co/datasets/dummy_user/dummy_dataset', endpoint='https://hub-ci.huggingface.co')
@@ -666,14 +661,9 @@ class RepoUrl(str):
     RepoUrl('https://huggingface.co/Wauplin/dummy_model', endpoint='https://huggingface.co', repo_type='model', repo_id='Wauplin/dummy_model')
     ```
 
-    > [!WARNING]
-    > Canonical single-segment repos (e.g. 'gpt2', without a namespace) are not supported. They are
-    > archived/read-only on the Hub and all have a namespaced alias (e.g. 'openai-community/gpt2').
-
     Raises:
         [`~errors.HfUriError`]:
             If the URL cannot be parsed (e.g. canonical single-segment repo, or unknown `repo_type`).
-            `HfUriError` is a subclass of `ValueError`.
     """
 
     def __new__(cls, url: Any, endpoint: str | None = None):

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -674,15 +674,16 @@ class RepoUrl(str):
         super().__init__()
         self.endpoint = endpoint or constants.ENDPOINT
 
-        # Parse with the shared 'parse_hf_uri' parser, which handles both 'hf://' URIs and Hugging
-        # Face web URLs. If that fails, the input is either a bare '<namespace>/<name>' id or a URL
-        # on a custom endpoint that 'parse_hf_uri' doesn't recognize: strip the endpoint prefix and
-        # reparse it as an 'hf://' URI.
+        # Parse with the shared 'parse_hf_uri' parser, which handles 'hf://' URIs as well as Hugging
+        # Face web URLs (including ones on this custom 'endpoint'). If that fails, the input is a bare
+        # '<namespace>/<name>' id, which we reparse as an 'hf://' URI.
         raw = str(self)
         try:
-            parsed = parse_hf_uri(raw)
+            parsed = parse_hf_uri(raw, endpoint=self.endpoint)
         except HfUriError:
-            parsed = parse_hf_uri(f"{constants.HF_PROTOCOL}{raw.removeprefix(self.endpoint).lstrip('/')}")
+            if "://" in raw:
+                raise  # it was a URL: the original error is authoritative, don't retry as a bare id
+            parsed = parse_hf_uri(f"{constants.HF_PROTOCOL}{raw}")
 
         # Populate fields ('parsed.id' is always '<namespace>/<name>').
         self.namespace, self.repo_name = parsed.id.split("/")

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -98,6 +98,7 @@ from .errors import (
     FileDuplicationError,
     GatedRepoError,
     HfHubHTTPError,
+    HfUriError,
     LocalTokenNotFoundError,
     RemoteEntryNotFoundError,
     RepositoryNotFoundError,
@@ -8636,15 +8637,21 @@ class HfApi:
             constants.REPO_TYPE_SPACE: "spaces",
         }[repo_type]
 
-        # Infer target namespace + name. When 'to_id' is provided, split it as
-        # '<namespace>/<name>' (a bare '<name>' has no namespace); otherwise reuse the source
-        # name. A missing namespace defaults to the caller's account.
+        # Infer target namespace + name. 'from_id'/'to_id' are bare '<namespace>/<name>' ids, so
+        # we parse them as 'hf://' URIs. When 'to_id' is provided we take the name from it; otherwise
+        # we reuse the source name. If 'to_id' has no namespace (or is not provided), the namespace
+        # defaults to the caller's account.
+        to_namespace: str | None = None
         if to_id is not None:
-            namespace_and_name = to_id.rsplit("/", 1)
-            to_namespace = namespace_and_name[0] if len(namespace_and_name) == 2 else None
-            to_repo_name = namespace_and_name[-1]
+            try:
+                to_uri = parse_hf_uri(f"{constants.HF_PROTOCOL}{to_id}")
+            except HfUriError:
+                # 'to_id' is a bare '<name>' (no namespace): keep it as the name, guess the namespace.
+                to_repo_name = to_id
+            else:
+                to_namespace, to_repo_name = to_uri.id.split("/")
         else:
-            to_namespace, to_repo_name = None, from_id.rsplit("/", 1)[-1]
+            to_repo_name = parse_hf_uri(f"{constants.HF_PROTOCOL}{from_id}").id.split("/")[1]
         if to_namespace is None:
             to_namespace = self.whoami(token)["name"]
 

--- a/src/huggingface_hub/utils/_hf_uris.py
+++ b/src/huggingface_hub/utils/_hf_uris.py
@@ -254,7 +254,7 @@ def is_hf_uri(uri: str) -> bool:
 
 
 @functools.lru_cache
-def parse_hf_uri(uri: str) -> HfUri:
+def parse_hf_uri(uri: str, endpoint: str | None = None) -> HfUri:
     """Parse a Hugging Face Hub URI ('hf://...') or a Hugging Face web URL.
 
     A HF URI is a URI-like string identifying a location on the Hugging Face Hub. The full grammar is:
@@ -273,6 +273,10 @@ def parse_hf_uri(uri: str) -> HfUri:
     Args:
         uri (`str`):
             The URI to parse. Must start with 'hf://', or be a Hugging Face URL (e.g. 'https://huggingface.co/...').
+        endpoint (`str`, *optional*):
+            A custom Hub endpoint (e.g. a self-hosted or proxied Hub like 'https://hub.my-company.com' or
+            'http://localhost:8080/hf'). When provided, web URLs on that endpoint are recognized in addition to
+            the default Hugging Face hosts. Has no effect on 'hf://' URIs.
 
     Returns:
         [`HfUri`]: the parsed URI.
@@ -297,8 +301,8 @@ def parse_hf_uri(uri: str) -> HfUri:
         body = uri[len(constants.HF_PROTOCOL) :]
         if not body:
             raise HfUriError(uri, f"Empty body after '{constants.HF_PROTOCOL}'.")
-    elif _looks_like_hf_url(uri):
-        body = _url_to_uri_body(uri)
+    elif _looks_like_hf_url(uri, endpoint=endpoint):
+        body = _url_to_uri_body(uri, endpoint=endpoint)
     else:
         raise HfUriError(
             uri,
@@ -313,13 +317,33 @@ def parse_hf_uri(uri: str) -> HfUri:
     return _parse_repo_body(location, type_, raw=raw)
 
 
-def _looks_like_hf_url(uri: str) -> bool:
+def _endpoint_host_and_path(endpoint: str | None) -> tuple[str | None, str]:
+    """Return the lowercased host and stripped path prefix of a custom Hub 'endpoint'.
+
+    E.g. 'https://hub.my-company.com' -> ('hub.my-company.com', '') and a self-hosted
+    'http://localhost:8080/hf' -> ('localhost', 'hf'). Returns '(None, "")' when 'endpoint' is None.
+    """
+    if endpoint is None:
+        return None, ""
+    # Prefix '//' for scheme-less endpoints so 'urlsplit' populates 'netloc' instead of 'path'.
+    parsed = urlsplit(endpoint if "://" in endpoint else "//" + endpoint)
+    host = parsed.hostname.lower() if parsed.hostname else None
+    return host, parsed.path.strip("/")
+
+
+def _recognized_hosts(endpoint: str | None) -> frozenset[str]:
+    """The set of hosts whose web URLs can be parsed: the default Hugging Face hosts plus 'endpoint'."""
+    host, _ = _endpoint_host_and_path(endpoint)
+    return constants.HF_URL_HOSTS | {host} if host else constants.HF_URL_HOSTS
+
+
+def _looks_like_hf_url(uri: str, endpoint: str | None = None) -> bool:
     """Return True if 'uri' looks like a (possibly scheme-less) Hugging Face web URL."""
     lowered = uri.lower()
     if lowered.startswith(("http://", "https://")):
         return True
     # Scheme-less host (e.g. 'huggingface.co/org/model').
-    return any(lowered == host or lowered.startswith(host + "/") for host in constants.HF_URL_HOSTS)
+    return any(lowered == host or lowered.startswith(host + "/") for host in _recognized_hosts(endpoint))
 
 
 def _decode_url_path_segment(segment: str) -> str:
@@ -332,25 +356,34 @@ def _decode_url_path_segment(segment: str) -> str:
     return unquote(segment).replace("/", "%2F")
 
 
-def _url_to_uri_body(url: str) -> str:
+def _url_to_uri_body(url: str, endpoint: str | None = None) -> str:
     """Normalize a Hugging Face web URL into the body of a 'hf://' URI (everything after 'hf://').
 
     The returned string is fed back into the regular URI parsing logic, so all validation
     (repo id, revision, empty path segments, ...) is shared with the canonical 'hf://' path.
-    Only unambiguous URLs are accepted: any unrecognized route raises [`HfUriError`].
+    Only unambiguous URLs are accepted: any unrecognized route raises [`HfUriError`]. When 'endpoint'
+    is provided, URLs on that custom Hub host are recognized too (and its path prefix is stripped).
     """
     raw = url
     # Prefix '//' for scheme-less inputs so 'urlsplit' populates 'netloc' instead of 'path'.
     parsed = urlsplit(url if "://" in url else "//" + url)
     host = (parsed.hostname or "").lower()
-    if host not in constants.HF_URL_HOSTS:
+    if host not in _recognized_hosts(endpoint):
         raise HfUriError(
             uri=raw,
             msg=f"Unrecognized host '{host or url}'. Expected a Hugging Face URL (e.g. 'https://huggingface.co/...').",
         )
 
     # Query string and fragment are intentionally dropped (e.g. '?download=true').
-    segments = [segment for segment in parsed.path.split("/") if segment]
+    path = parsed.path
+    # For a self-hosted endpoint with a path prefix (e.g. 'http://localhost:8080/hf'), drop it so the
+    # remaining segments are '[<TYPE>/]<namespace>/<name>[/...]' just like on the public Hub.
+    endpoint_host, endpoint_path = _endpoint_host_and_path(endpoint)
+    if endpoint_path and host == endpoint_host:
+        prefix = "/" + endpoint_path
+        if path == prefix or path.startswith(prefix + "/"):
+            path = path[len(prefix) :]
+    segments = [segment for segment in path.split("/") if segment]
     if not segments:
         raise HfUriError(uri=raw, msg=f"Missing repository or bucket identifier in URL '{url}'.")
 

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -3942,34 +3942,36 @@ class HfApiTokenAttributeTest(unittest.TestCase):
 @patch("huggingface_hub.constants.ENDPOINT", ENDPOINT_PRODUCTION)
 class RepoUrlTest(unittest.TestCase):
     def test_repo_url_class(self):
-        url = RepoUrl("https://huggingface.co/gpt2")
+        url = RepoUrl("https://huggingface.co/user/repo_name")
 
         # RepoUrl Is a string
         self.assertIsInstance(url, str)
-        self.assertEqual(url, "https://huggingface.co/gpt2")
+        self.assertEqual(url, "https://huggingface.co/user/repo_name")
 
         # Any str-method can be applied
-        self.assertEqual(url.split("/"), "https://huggingface.co/gpt2".split("/"))
+        self.assertEqual(url.split("/"), "https://huggingface.co/user/repo_name".split("/"))
 
         # String formatting and concatenation work
-        self.assertEqual(f"New repo: {url}", "New repo: https://huggingface.co/gpt2")
-        self.assertEqual("New repo: " + url, "New repo: https://huggingface.co/gpt2")
+        self.assertEqual(f"New repo: {url}", "New repo: https://huggingface.co/user/repo_name")
+        self.assertEqual("New repo: " + url, "New repo: https://huggingface.co/user/repo_name")
 
         # __repr__ is modified for debugging purposes
         self.assertEqual(
             repr(url),
-            "RepoUrl('https://huggingface.co/gpt2',"
-            " endpoint='https://huggingface.co', repo_type='model', repo_id='gpt2')",
+            "RepoUrl('https://huggingface.co/user/repo_name',"
+            " endpoint='https://huggingface.co', repo_type='model', repo_id='user/repo_name')",
         )
 
     def test_repo_url_endpoint(self):
         # Implicit endpoint
-        url = RepoUrl("https://huggingface.co/gpt2")
+        url = RepoUrl("https://huggingface.co/user/repo_name")
         self.assertEqual(url.endpoint, ENDPOINT_PRODUCTION)
 
-        # Explicit endpoint
-        url = RepoUrl("https://example.com/gpt2", endpoint="https://example.com")
+        # Explicit (custom / self-hosted) endpoint: the endpoint prefix is stripped before parsing.
+        url = RepoUrl("https://example.com/user/repo_name", endpoint="https://example.com")
         self.assertEqual(url.endpoint, "https://example.com")
+        self.assertEqual(url.repo_id, "user/repo_name")
+        self.assertEqual(url.repo_type, "model")
 
     def test_repo_url_repo_type(self):
         # Explicit repo type
@@ -3987,37 +3989,37 @@ class RepoUrlTest(unittest.TestCase):
         self.assertEqual(url.repo_type, "model")
 
     def test_repo_url_namespace(self):
-        # Canonical model (e.g. no username)
-        url = RepoUrl("https://huggingface.co/gpt2")
-        self.assertIsNone(url.namespace)
-        self.assertEqual(url.repo_id, "gpt2")
-
-        # "Normal" model
         url = RepoUrl("https://huggingface.co/dummy_user/dummy_model")
         self.assertEqual(url.namespace, "dummy_user")
+        self.assertEqual(url.repo_name, "dummy_model")
         self.assertEqual(url.repo_id, "dummy_user/dummy_model")
 
     def test_repo_url_url_property(self):
         # RepoUrl.url returns a pure `str` value
-        url = RepoUrl("https://huggingface.co/gpt2")
-        self.assertEqual(url, "https://huggingface.co/gpt2")
-        self.assertEqual(url.url, "https://huggingface.co/gpt2")
+        url = RepoUrl("https://huggingface.co/user/repo_name")
+        self.assertEqual(url, "https://huggingface.co/user/repo_name")
+        self.assertEqual(url.url, "https://huggingface.co/user/repo_name")
         self.assertIsInstance(url, RepoUrl)
         self.assertNotIsInstance(url.url, RepoUrl)
 
-    def test_repo_url_canonical_model(self):
-        for _id in ("gpt2", "hf://gpt2", "https://huggingface.co/gpt2"):
+    def test_repo_url_accepts_bare_and_hf_ids(self):
+        # Bare '<namespace>/<name>' ids and 'hf://' URIs are normalized through `parse_hf_uri`.
+        for _id in ("user/repo_name", "hf://user/repo_name"):
             with self.subTest(_id):
                 url = RepoUrl(_id)
-                self.assertEqual(url.repo_id, "gpt2")
+                self.assertEqual(url.repo_id, "user/repo_name")
                 self.assertEqual(url.repo_type, "model")
 
-    def test_repo_url_canonical_dataset(self):
-        for _id in ("datasets/squad", "hf://datasets/squad", "https://huggingface.co/datasets/squad"):
+        url = RepoUrl("hf://datasets/user/squad")
+        self.assertEqual(url.repo_id, "user/squad")
+        self.assertEqual(url.repo_type, "dataset")
+
+    def test_repo_url_canonical_repo_not_supported(self):
+        # Canonical single-segment repos (no namespace) are intentionally rejected.
+        for _id in ("gpt2", "hf://gpt2", "https://huggingface.co/gpt2", "https://huggingface.co/datasets/squad"):
             with self.subTest(_id):
-                url = RepoUrl(_id)
-                self.assertEqual(url.repo_id, "squad")
-                self.assertEqual(url.repo_type, "dataset")
+                with self.assertRaises(ValueError):
+                    RepoUrl(_id)
 
     def test_repo_url_in_commit_info(self):
         info = CommitInfo(

--- a/tests/test_utils_hf_uris.py
+++ b/tests/test_utils_hf_uris.py
@@ -630,6 +630,24 @@ def test_parse_hf_uri_from_url_failure(url: str, error_substring: str) -> None:
     assert exc_info.value.uri == url
 
 
+def test_parse_hf_uri_custom_endpoint() -> None:
+    # URLs on a custom Hub endpoint are recognized when 'endpoint' is passed...
+    assert parse_hf_uri(
+        "https://hub.my-company.com/datasets/my-org/my-dataset/blob/main/train.csv",
+        endpoint="https://hub.my-company.com",
+    ) == HfUri(type="dataset", id="my-org/my-dataset", revision="main", path_in_repo="train.csv")
+
+    # ... including self-hosted endpoints that carry a path prefix (stripped before parsing).
+    assert parse_hf_uri(
+        "http://localhost:8080/hf/my-org/my-model",
+        endpoint="http://localhost:8080/hf",
+    ) == HfUri(type="model", id="my-org/my-model", revision=None, path_in_repo="")
+
+    # ... but the same URL is rejected without the matching 'endpoint'.
+    with pytest.raises(HfUriError, match="Unrecognized host"):
+        parse_hf_uri("https://hub.my-company.com/my-org/my-model")
+
+
 @pytest.mark.parametrize(("uri", "expected_path"), TO_URL_CASES)
 def test_hf_uri_to_url(uri: HfUri, expected_path: str) -> None:
     expected = constants.ENDPOINT + expected_path


### PR DESCRIPTION
Address https://github.com/huggingface/huggingface_hub/pull/4296#issuecomment-4601365443

Now that `parse_hf_uri` understands both `hf://` URIs and web URLs, `RepoUrl` no longer needs its own parser (`repo_type_and_id_from_hf_id`)

With this PR:

- `RepoUrl` uses `parse_hf_uri` internally
- `repo_type_and_id_from_hf_id` no longer used inside `huggingface_hub` + is softly deprecated (i.e. only documented as legacy but doesn't warn)
   - => will open PRs in transformers/diffusers/etc. later
- `duplicate_repo` stops abusing `RepoUrl(...)` just to split a bare `from_id`/`to_id` (use `parse_hf_uri` + custom str handling)
- `parse_hf_uri` gained an optional `endpoint` argument to recognize web URLs from custom / self-hosted Hubs (incl. path prefixes like `/hf`)

`parse_hf_uri` is deliberately stricter than the old helper, so this is not a literal swap.

🚨 **Breaking change:**

Support for canonical single-segment repos (`gpt2`, `datasets/squad`) in `RepoUrl` has been dropped.
In practice not a problem since it was only used for repo creation and file upload.

Note that `hf_hub_download("gpt2", ...)` never went through `RepoUrl`, so downloads of canonical repos keep working.


## Example

```py
>>> from huggingface_hub import parse_hf_uri
>>> from huggingface_hub.hf_api import RepoUrl
>>> RepoUrl("https://huggingface.co/datasets/user/ds")
RepoUrl('https://huggingface.co/datasets/user/ds', endpoint='https://huggingface.co', repo_type='dataset', repo_id='user/ds')
>>> parse_hf_uri("http://localhost:8080/hf/my-org/my-model", endpoint="http://localhost:8080/hf")  # custom endpoint
HfUri(type='model', id='my-org/my-model', revision=None, path_in_repo='')
>>> RepoUrl("gpt2")  # canonical -> rejected
huggingface_hub.errors.HfUriError: Invalid HF URI 'hf://gpt2'. Repository id must be 'namespace/name', got 'gpt2'.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
