### PR TITLE
[Tests] Add `inference` pytest marker to filter inference tests

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -117,7 +117,7 @@ jobs:
           case "${{ matrix.test_name }}" in
 
             "Inference only")
-              # Run inference tests concurrently (marked with `pytest.mark.inference`).
+              # Run inference tests concurrently
               PYTEST="$PYTEST ../tests -m 'inference' -n 4"
               echo $PYTEST
               eval $PYTEST
@@ -224,7 +224,6 @@ jobs:
               python $PYTEST_ARGS -m "not no_xet and not inference"
             }
             "no hf_xet" {
-              # Includes inference tests (no dedicated "Inference only" job on Windows).
               python $PYTEST_ARGS -m "not xet"
             }
           }

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -117,14 +117,14 @@ jobs:
           case "${{ matrix.test_name }}" in
 
             "Inference only")
-              # Run inference tests concurrently
-              PYTEST="$PYTEST ../tests -k 'test_inference' -n 4"
+              # Run inference tests concurrently (marked with `pytest.mark.inference`).
+              PYTEST="$PYTEST ../tests -m 'inference' -n 4"
               echo $PYTEST
               eval $PYTEST
             ;;
 
             "no hf_xet")
-              PYTEST="$PYTEST ../tests -m 'not xet' -k 'not test_inference' -n 4"
+              PYTEST="$PYTEST ../tests -m 'not xet and not inference' -n 4"
               echo $PYTEST
               eval $PYTEST
             ;;
@@ -145,7 +145,7 @@ jobs:
             "with hf_xet")
               # `xet` tests + unmarked tests, all with hf_xet installed.
               # Inference tests are excluded: they have their own job and don't depend on Xet.
-              PYTEST="$PYTEST ../tests -m 'not no_xet' -k 'not test_inference' -n 4"
+              PYTEST="$PYTEST ../tests -m 'not no_xet and not inference' -n 4"
               echo $PYTEST
               eval $PYTEST
             ;;
@@ -221,9 +221,10 @@ jobs:
             "with hf_xet" {
               # `xet` tests + unmarked tests, all with hf_xet installed.
               # Inference tests already run in "no hf_xet" and don't depend on Xet.
-              python $PYTEST_ARGS -m "not no_xet" -k "not test_inference"
+              python $PYTEST_ARGS -m "not no_xet and not inference"
             }
             "no hf_xet" {
+              # Includes inference tests (no dedicated "Inference only" job on Windows).
               python $PYTEST_ARGS -m "not xet"
             }
           }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -246,3 +246,18 @@ $ pytest tests -m no_xet                 # only legacy tests (skipped if hf_xet 
 $ pytest tests -m "not xet"              # what CI runs without hf_xet installed
 $ pytest tests -m "not no_xet"           # what CI runs with hf_xet installed
 ```
+
+#### Inference tests
+
+Inference tests (client, providers, types, endpoints) are declared with the `inference`
+marker and run in their own CI job, separate from the Xet jobs above:
+
+- `@pytest.mark.inference` — the test belongs to the Inference suite. Mark a whole module
+  with `pytestmark = pytest.mark.inference` (this is how the `test_inference_*.py` files
+  are tagged).
+- unmarked — everything else.
+
+```bash
+$ pytest tests -m inference              # only inference tests (the dedicated CI job)
+$ pytest tests -m "not inference"        # everything except inference tests
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ addopts = "-Werror::FutureWarning --log-cli-level=INFO -sv --durations=0 --stric
 markers = [
     "xet: test requires the `hf_xet` package; Xet is force-enabled (skipped if `hf_xet` is not installed)",
     "no_xet: test must run without `hf_xet`; skipped if `hf_xet` is installed",
-    "inference: inference test (client, providers, types, endpoints); runs in the dedicated 'Inference only' CI job",
+    "inference: inference test (client, providers, types); runs in the dedicated 'Inference only' CI job",
 ]
 # The defined variables will be added to the environment before any tests are
 # run, part of pytest-env plugin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ addopts = "-Werror::FutureWarning --log-cli-level=INFO -sv --durations=0 --stric
 markers = [
     "xet: test requires the `hf_xet` package; Xet is force-enabled (skipped if `hf_xet` is not installed)",
     "no_xet: test must run without `hf_xet`; skipped if `hf_xet` is installed",
+    "inference: inference test (client, providers, types, endpoints); runs in the dedicated 'Inference only' CI job",
 ]
 # The defined variables will be added to the environment before any tests are
 # run, part of pytest-env plugin

--- a/tests/test_inference_async_client.py
+++ b/tests/test_inference_async_client.py
@@ -49,7 +49,6 @@ from .test_inference_client import CHAT_COMPLETE_NON_TGI_MODEL, CHAT_COMPLETION_
 from .testing_utils import with_production_testing
 
 
-# Whole module runs in the dedicated "Inference only" CI job (see pyproject.toml markers).
 pytestmark = pytest.mark.inference
 
 

--- a/tests/test_inference_async_client.py
+++ b/tests/test_inference_async_client.py
@@ -49,6 +49,10 @@ from .test_inference_client import CHAT_COMPLETE_NON_TGI_MODEL, CHAT_COMPLETION_
 from .testing_utils import with_production_testing
 
 
+# Whole module runs in the dedicated "Inference only" CI job (see pyproject.toml markers).
+pytestmark = pytest.mark.inference
+
+
 @pytest.fixture(autouse=True)
 def patch_non_tgi_server(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(huggingface_hub.inference._common, "_UNSUPPORTED_TEXT_GENERATION_KWARGS", {})

--- a/tests/test_inference_client.py
+++ b/tests/test_inference_client.py
@@ -58,6 +58,10 @@ from huggingface_hub.inference._providers.hf_inference import _build_chat_comple
 from .testing_utils import with_production_testing
 
 
+# Whole module runs in the dedicated "Inference only" CI job (see pyproject.toml markers).
+pytestmark = pytest.mark.inference
+
+
 # Avoid calling APIs in VCRed tests
 _RECOMMENDED_MODELS_FOR_VCR = {
     "black-forest-labs": {

--- a/tests/test_inference_client.py
+++ b/tests/test_inference_client.py
@@ -58,7 +58,6 @@ from huggingface_hub.inference._providers.hf_inference import _build_chat_comple
 from .testing_utils import with_production_testing
 
 
-# Whole module runs in the dedicated "Inference only" CI job (see pyproject.toml markers).
 pytestmark = pytest.mark.inference
 
 

--- a/tests/test_inference_endpoints.py
+++ b/tests/test_inference_endpoints.py
@@ -14,10 +14,6 @@ from huggingface_hub import (
 )
 
 
-# Whole module runs in the dedicated "Inference only" CI job (see pyproject.toml markers).
-pytestmark = pytest.mark.inference
-
-
 MOCK_INITIALIZING = {
     "name": "my-endpoint-name",
     "type": "protected",

--- a/tests/test_inference_endpoints.py
+++ b/tests/test_inference_endpoints.py
@@ -14,6 +14,10 @@ from huggingface_hub import (
 )
 
 
+# Whole module runs in the dedicated "Inference only" CI job (see pyproject.toml markers).
+pytestmark = pytest.mark.inference
+
+
 MOCK_INITIALIZING = {
     "name": "my-endpoint-name",
     "type": "protected",

--- a/tests/test_inference_providers.py
+++ b/tests/test_inference_providers.py
@@ -78,6 +78,10 @@ from huggingface_hub.inference._providers.zai_org import ZaiConversationalTask, 
 from .testing_utils import assert_in_logs
 
 
+# Whole module runs in the dedicated "Inference only" CI job (see pyproject.toml markers).
+pytestmark = pytest.mark.inference
+
+
 class TestBasicTaskProviderHelper:
     def test_api_key_from_provider(self):
         helper = TaskProviderHelper(provider="provider-name", base_url="https://api.provider.com", task="task-name")

--- a/tests/test_inference_providers.py
+++ b/tests/test_inference_providers.py
@@ -78,7 +78,6 @@ from huggingface_hub.inference._providers.zai_org import ZaiConversationalTask, 
 from .testing_utils import assert_in_logs
 
 
-# Whole module runs in the dedicated "Inference only" CI job (see pyproject.toml markers).
 pytestmark = pytest.mark.inference
 
 

--- a/tests/test_inference_text_generation.py
+++ b/tests/test_inference_text_generation.py
@@ -22,7 +22,6 @@ from huggingface_hub.inference._common import ValidationError as TextGenerationV
 from .testing_utils import with_production_testing
 
 
-# Whole module runs in the dedicated "Inference only" CI job (see pyproject.toml markers).
 pytestmark = pytest.mark.inference
 
 

--- a/tests/test_inference_text_generation.py
+++ b/tests/test_inference_text_generation.py
@@ -22,6 +22,10 @@ from huggingface_hub.inference._common import ValidationError as TextGenerationV
 from .testing_utils import with_production_testing
 
 
+# Whole module runs in the dedicated "Inference only" CI job (see pyproject.toml markers).
+pytestmark = pytest.mark.inference
+
+
 class TestTextGenerationErrors(unittest.TestCase):
     def test_generation_error(self):
         error = _mocked_error({"error_type": "generation", "error": "test"})

--- a/tests/test_inference_types.py
+++ b/tests/test_inference_types.py
@@ -9,6 +9,10 @@ from huggingface_hub.inference._generated.types import AutomaticSpeechRecognitio
 from huggingface_hub.inference._generated.types.base import BaseInferenceType, dataclass_with_extra
 
 
+# Whole module runs in the dedicated "Inference only" CI job (see pyproject.toml markers).
+pytestmark = pytest.mark.inference
+
+
 @dataclass_with_extra
 class DummyType(BaseInferenceType):
     foo: int

--- a/tests/test_inference_types.py
+++ b/tests/test_inference_types.py
@@ -9,7 +9,6 @@ from huggingface_hub.inference._generated.types import AutomaticSpeechRecognitio
 from huggingface_hub.inference._generated.types.base import BaseInferenceType, dataclass_with_extra
 
 
-# Whole module runs in the dedicated "Inference only" CI job (see pyproject.toml markers).
 pytestmark = pytest.mark.inference
 
 


### PR DESCRIPTION
## Summary

Same treatment as #4336 (xet/no_xet markers), applied to inference tests.

- Adds a `pytest.mark.inference` marker (registered in `pyproject.toml`, enforced by `--strict-markers`).
- Tags the inference test modules with `pytestmark = pytest.mark.inference`.
- CI now selects them via markers instead of test-name matching:
  - "Inference only" job: `-m inference` (was `-k 'test_inference'`)
  - "no hf_xet" job: `-m 'not xet and not inference'` (was `-m 'not xet' -k 'not test_inference'`)
  - "with hf_xet" job: `-m 'not no_xet and not inference'` (was `-m 'not no_xet' -k 'not test_inference'`)
  - Windows "with hf_xet": `-m 'not no_xet and not inference'` (was `-k 'not test_inference'`)
- Documents the marker in `CONTRIBUTING.md`.

### Intentional scope changes vs the old `-k 'test_inference'`

The old name-based selection matched a few tests that aren't really inference tests. These are now **unmarked** and run in the regular jobs instead of "Inference only":

- `test_inference_endpoints.py` — mocked `InferenceEndpoint` logic, not an inference (client/providers) test, so it's deliberately left **unmarked**.
- `test_hf_api.py::...::test_inference_provider_mapping_model_info` / `..._list_models` — Hub API tests, only matched by name coincidence.
- `test_cli.py::...::test_inference_endpoints_alias` — mocked CLI unit test, only matched by name coincidence.

The `inference` marker therefore tags the 5 real inference modules (client, async client, providers, text generation, types):

```
$ pytest tests -m inference --collect-only        # 376 tests, the 5 inference modules
$ pytest tests -m "not inference" --collect-only  # everything else, incl. endpoints + the strays above
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test orchestration and documentation only; no library or production behavior changes.
> 
> **Overview**
> Introduces a registered **`inference`** pytest marker (alongside the existing Xet markers) so the Inference suite is selected explicitly instead of by filename.
> 
> Five inference modules (`test_inference_client`, async client, providers, text generation, types) are tagged with `pytestmark = pytest.mark.inference`. CI switches from `-k 'test_inference'` / `-k 'not test_inference'` to **`-m inference`** for the dedicated job and **`not inference`** on the Xet matrix jobs (Ubuntu and Windows `with hf_xet`). `CONTRIBUTING.md` documents how to run inference-only vs non-inference locally.
> 
> Compared to the old name filter, **`test_inference_endpoints.py`** and a few Hub API / CLI tests that only matched `test_inference` in the name stay **unmarked** and run in the regular jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90c3a4c9e9ef7594fa49c3e157bba0cfac61b288. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->