### PR TITLE
[fix] Transient locaion error due to CDN

### DIFF
--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -514,7 +514,7 @@ class CachedDownloadTests(unittest.TestCase):
         url = hf_hub_url("gpt2", filename="tf_model.h5")
         metadata = get_hf_file_metadata(url)
 
-        self.assertIn("xethub.hf.co", metadata.location)  # Redirection
+        assert "xethub.hf.co" in metadata.location or "cdn.hf.co" in metadata.location  # Redirection
         self.assertEqual(metadata.size, 497933648)  # Size of LFS file, not pointer
 
     def test_file_consistency_check_fails_regular_file(self):


### PR DESCRIPTION
should fix this transient error

```
FAILED ..\tests\test_file_download.py::CachedDownloadTests::test_get_hf_file_metadata_from_a_lfs_file - AssertionError: 'xethub.hf.co' not found in 'https://us.aws.cdn.hf.co/xet-bridge-us/621ffdc036468d709f17434d/4195b41d9f36814bcbecf956b7e90bcbf41105ce9dd695a97246266b9328af55?X-Xet-Cas-Uid=public&response-content-disposition=inline%3B+filename*%3DUTF-8%27%27tf_model.h5%3B+filename%3D%22tf_model.h5%22%3B&Expires=1781168727&Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaHR0cHM6Ly91cy5hd3MuY2RuLmhmLmNvL3hldC1icmlkZ2UtdXMvNjIxZmZkYzAzNjQ2OGQ3MDlmMTc0MzRkLzQxOTViNDFkOWYzNjgxNGJjYmVjZjk1NmI3ZTkwYmNiZjQxMTA1Y2U5ZGQ2OTVhOTcyNDYyNjZiOTMyOGFmNTVcXD9YLVhldC1DYXMtVWlkPXB1YmxpYyZyZXNwb25zZS1jb250ZW50LWRpc3Bvc2l0aW9uPWlubGluZSUzQitmaWxlbmFtZSUyQSUzRFVURi04JTI3JTI3dGZfbW9kZWwuaDUlM0IrZmlsZW5hbWUlM0QlMjJ0Zl9tb2RlbC5oNSUyMiUzQiIsIkNvbmRpdGlvbiI6eyJEYXRlTGVzc1RoYW4iOnsiRXBvY2hUaW1lIjoxNzgxMTY4NzI3fX19XX0_&Signature=MEUCIHpPGgUtNdIVczEOFwPbLxlinhbLx0bRJVS75rSUjJ9pAiEAhfRXpPAWbxzNq4uYwbDgWIB67yCgAv1J060ysofIl3A_&Key-Pair-Id=01KAYHXK2CBJSW0YZTMNXK9W1M'
```

CDN is used only X% of the time, hence the transient error and the need for a double check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code or security impact.
> 
> **Overview**
> Fixes flaky CI in **`test_get_hf_file_metadata_from_a_lfs_file`** by loosening the redirect URL check when fetching LFS metadata for `gpt2`/`tf_model.h5`.
> 
> The test no longer requires **`metadata.location`** to always include `xethub.hf.co`; it now passes if the final URL contains **`xethub.hf.co` or `cdn.hf.co`**, matching intermittent Hub routing to the CDN. The LFS size assertion is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79a5f432a03f9ff128300274e3571e22b9873d32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->