### PR TITLE
OIDC: Include error_description in HTTP error messages

### DIFF
--- a/src/huggingface_hub/cli/_errors.py
+++ b/src/huggingface_hub/cli/_errors.py
@@ -111,7 +111,7 @@ CLI_ERROR_MAPPINGS: dict[type[Exception], Callable[..., str]] = {
     RepositoryNotFoundError: _format_repo_not_found,
     RevisionNotFoundError: _format_revision_not_found,
     LocalTokenNotFoundError: lambda _: "Not logged in. Run 'hf auth login' first.",
-    OIDCError: lambda error: f"OICD Exchange failed. {error}",
+    OIDCError: lambda error: f"OIDC Exchange failed. {error}",
     RemoteEntryNotFoundError: _format_entry_not_found,
     LocalEntryNotFoundError: _format_local_entry_not_found,
     EntryNotFoundError: lambda error: str(error),

--- a/src/huggingface_hub/utils/_http.py
+++ b/src/huggingface_hub/utils/_http.py
@@ -935,13 +935,20 @@ def _format(
                 data = {}
 
         error = data.get("error")
+        error_description = data.get("error_description")
         if error is not None:
             if isinstance(error, list):
                 # Case {'error': ['my error 1', 'my error 2']}
                 server_errors.extend(error)
+            elif error_description is not None:
+                # OAuth-style case {'error': 'invalid_grant', 'error_description': 'my description'}
+                server_errors.append(f"{error}: {error_description}")
             else:
                 # Case {'error': 'my error'}
                 server_errors.append(error)
+        elif error_description is not None:
+            # Case {'error_description': 'my description'} (no 'error' field)
+            server_errors.append(error_description)
 
         errors = data.get("errors")
         if errors is not None:

--- a/tests/test_utils_errors.py
+++ b/tests/test_utils_errors.py
@@ -169,6 +169,21 @@ class TestHfHubHTTPError(unittest.TestCase):
         assert str(error) == "this is a message\n\nThis is a message returned by the server"
         assert error.server_message == "This is a message returned by the server"
 
+    def test_hf_hub_http_error_init_with_error_description(self) -> None:
+        """Test OAuth-style `error_description` is appended alongside the `error` field."""
+        self.response = Response(status_code=400, request=Request(method="POST", url="https://huggingface.co/fake"))
+        self.response._content = b'{"error": "invalid_grant", "error_description": "something helpful"}'
+        error = _format(HfHubHTTPError, "this is a message", response=self.response)
+        assert str(error) == "this is a message\n\ninvalid_grant: something helpful"
+        assert error.server_message == "invalid_grant: something helpful"
+
+    def test_hf_hub_http_error_init_with_error_description_only(self) -> None:
+        """Test `error_description` is used even when the `error` field is absent."""
+        self.response._content = b'{"error_description": "something helpful"}'
+        error = _format(HfHubHTTPError, "this is a message", response=self.response)
+        assert str(error) == "this is a message\n\nsomething helpful"
+        assert error.server_message == "something helpful"
+
     def test_hf_hub_http_error_init_with_server_error_and_multiline_message(
         self,
     ) -> None:


### PR DESCRIPTION
The hub - following oauth protocol - sends the error message in error_description for oidc responses

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to error-message parsing and a string typo; no changes to auth or token exchange logic.
> 
> **Overview**
> Improves how **OAuth/OIDC-style HTTP error bodies** are surfaced in `HfHubHTTPError` messages when the Hub returns JSON with `error_description` (common for OIDC token exchange failures).
> 
> `_format` in `utils/_http.py` now reads `error_description` from the response JSON: when both `error` and `error_description` are present it appends `"{error}: {error_description}"`; when only `error_description` is present it uses that alone. Existing handling for plain `error`, `errors[]`, and headers is unchanged.
> 
> Also fixes a CLI typo: **"OICD" → "OIDC"** in the `OIDCError` message prefix. New unit tests cover the combined and description-only JSON cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 095ee4841876ff795defce92c80ad07a2fba0c91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->