### PR TITLE
[Tests] Mitigate transient CI failures

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -112,7 +112,7 @@ jobs:
         working-directory: ./src # For code coverage to work
         run: |
           source ../.venv/bin/activate
-          PYTEST="python -m pytest --cov=./huggingface_hub --cov-report=xml:../coverage.xml --vcr-record=none --reruns 8 --reruns-delay 2 --only-rerun '(OSError|Timeout|HTTPError.*502|HTTPError.*504|not less than or equal to 0.01)'"
+          PYTEST="python -m pytest --cov=./huggingface_hub --cov-report=xml:../coverage.xml --vcr-record=none --reruns 8 --reruns-delay 2 --only-rerun '(OSError|Timeout|HTTPError.*409|HTTPError.*502|HTTPError.*504|not less than or equal to 0.01)'"
 
           case "${{ matrix.test_name }}" in
 
@@ -213,7 +213,7 @@ jobs:
             "--vcr-record=none",
             "--reruns", "8",
             "--reruns-delay", "2",
-            "--only-rerun", "(OSError|Timeout|HTTPError.*502|HTTPError.*504|not less than or equal to 0.01)",
+            "--only-rerun", "(OSError|Timeout|HTTPError.*409|HTTPError.*502|HTTPError.*504|not less than or equal to 0.01)",
             "../tests"
           )
 

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -112,7 +112,7 @@ jobs:
         working-directory: ./src # For code coverage to work
         run: |
           source ../.venv/bin/activate
-          PYTEST="python -m pytest --cov=./huggingface_hub --cov-report=xml:../coverage.xml --vcr-record=none --reruns 8 --reruns-delay 2 --only-rerun '(OSError|Timeout|HTTPError.*409|HTTPError.*502|HTTPError.*504|not less than or equal to 0.01)'"
+          PYTEST="python -m pytest --cov=./huggingface_hub --cov-report=xml:../coverage.xml --vcr-record=none --reruns 8 --reruns-delay 2 --only-rerun '(OSError|FileNotFoundError|Timeout|HTTPError.*409|HTTPError.*502|HTTPError.*504|not less than or equal to 0.01)'"
 
           case "${{ matrix.test_name }}" in
 
@@ -213,7 +213,7 @@ jobs:
             "--vcr-record=none",
             "--reruns", "8",
             "--reruns-delay", "2",
-            "--only-rerun", "(OSError|Timeout|HTTPError.*409|HTTPError.*502|HTTPError.*504|not less than or equal to 0.01)",
+            "--only-rerun", "(OSError|FileNotFoundError|Timeout|HTTPError.*409|HTTPError.*502|HTTPError.*504|not less than or equal to 0.01)",
             "../tests"
           )
 

--- a/tests/test_buckets_cli.py
+++ b/tests/test_buckets_cli.py
@@ -1252,12 +1252,10 @@ def test_sync_ignore_sizes_skip_reason_shows_dest_newer(api: HfApi, bucket_write
     result = cli(f"hf buckets sync {data_dir} hf://buckets/{bucket_write} --quiet")
     assert result.exit_code == 0
 
-    # Wait a bit to ensure remote mtime is set
-    time.sleep(1.5)
-
-    # Set local file mtime to be significantly older than remote (more than 1s window)
+    # Set local file mtime far in the past. The remote mtime is influenced by the server clock,
+    # so the margin must be much larger than any realistic client/server clock skew.
     local_file = data_dir / "file.txt"
-    old_mtime = time.time() - 10  # 10 seconds in the past
+    old_mtime = time.time() - 3600  # 1 hour in the past
     os.utime(local_file, (old_mtime, old_mtime))
 
     # Sync with --ignore-sizes --dry-run (upload direction)
@@ -1289,17 +1287,15 @@ def test_sync_ignore_sizes_download_skip_reason_shows_dest_newer(api: HfApi, buc
     result = cli(f"hf buckets sync {data_dir} hf://buckets/{bucket_write} --quiet")
     assert result.exit_code == 0
 
-    # Wait for remote to be stable
-    time.sleep(1.5)
-
     # Create download directory with a file that has a newer mtime
     download_dir = tmp_path / "download"
     download_dir.mkdir()
     local_file = download_dir / "file.txt"
     local_file.write_text("content")
 
-    # Set local file mtime to be significantly newer than remote (more than 1s window)
-    new_mtime = time.time() + 10  # 10 seconds in the future
+    # Set local file mtime far in the future. The remote mtime is influenced by the server clock,
+    # so the margin must be much larger than any realistic client/server clock skew.
+    new_mtime = time.time() + 3600  # 1 hour in the future
     os.utime(local_file, (new_mtime, new_mtime))
 
     # Sync with --ignore-sizes --dry-run (download direction)


### PR DESCRIPTION
## Hopefully will mitigate most CI failures without making the CI last forever because of reruns. I suggest we merge and reassess in a few days if needed.

## Summary

Mitigates flaky tests responsible for unrelated CI failures, e.g. in [run 27333818084](https://github.com/huggingface/huggingface_hub/actions/runs/27333818084) on #4338 (2 distinct tests failing across 3 jobs) and [run 27347195739](https://github.com/huggingface/huggingface_hub/actions/runs/27347195739) on this very PR.

- **`test_buckets_cli.py::test_sync_ignore_sizes_skip_reason_shows_dest_newer`** (+ its download-direction sibling): widened the mtime margin from 10s to 1h and dropped the `time.sleep(1.5)` calls. The test compares a locally-set mtime against the mtime returned by the server, which is influenced by the server clock. In the failing run, both ubuntu and windows failed this test **within 3 seconds of each other** (`08:23:49` / `08:23:52`) with the two failure modes you'd expect from a ~8-12s hub-ci clock skew (`'same mtime'` instead of `'remote newer'` on ubuntu, `'upload'` instead of `'skip'` on windows) — consistent with the server clamping a client-provided mtime it sees as "in the future" to its own now. Rather than guessing the exact server mechanism, the fix makes the margin (1h) far larger than any realistic clock skew.
- **`test_hf_api.py::CollectionAPITest::test_collection_items`**: intermittent `409 Conflict` on `POST /api/collections/<slug>/items` when adding a brand-new (UUID-named) item right after a previous add — a server-side write conflict on staging, not a real "already exists". Mitigated by adding `HTTPError.*409` to the existing `pytest-rerunfailures` `--only-rerun` pattern (both Linux and Windows jobs), the repo's established mechanism for transient Hub errors. Reruns only trigger on *failures* matching the pattern, so tests that assert a 409 via `assertRaises` are unaffected, and a deterministic 409 regression still fails after 8 reruns.
- **`test_buckets.py::test_copy_files_bucket_to_same_bucket_file`** (failed on this PR's own CI, windows 3.10): the copy batch returned 200 but the `paths-info` call issued right after by `download_bucket_files` didn't see `copied.txt` yet (read-after-write lag on hub-ci) → warn-and-skip → `FileNotFoundError` locally. The rerun filter already lists `OSError` and `FileNotFoundError` *is* an `OSError` — but `--only-rerun` matches the failure **text**, not the exception hierarchy, so it never matched. Added `FileNotFoundError` explicitly to the pattern; this covers any bucket test with the same read-after-write race.

Decisions taken:

- Chose the rerun-filter approach over retry logic inside `test_collection_items`: 409s can hit any collection/repo write on staging, so a global filter covers more than one special-cased call site.
- Same reasoning for the copy test: a poll-until-visible loop after `copy_files` would fix one test, but many bucket tests read right after writing — the rerun filter covers the whole class.
- Did not extend the rerun pattern to 500/503 — only mitigating what was actually observed.
- Possible product follow-ups (out of scope here): (1) if hub-ci really clamps future mtimes server-side, `hf buckets sync` could mis-classify files for users whose clock is slightly ahead of the Hub — worth confirming how `mtime` is handled in the buckets batch endpoint; (2) `batch_bucket_files` only checks the batch HTTP status and doesn't parse per-operation results from the ndjson response body — if the endpoint can report per-op failures inside a 200, those are currently silent.

Manual testing (both modified sync tests pass against hub-ci):

```
$ pytest tests/test_buckets_cli.py -k "skip_reason_shows_dest_newer" -q
====================== 2 passed, 87 deselected in 25.77s =======================
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)