### PR TITLE
[CI] Fix versioned docs not publishing on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
   # ============================================================
   prepare:
     permissions:
-      contents: write   # push branches and tags
+      contents: read   # branch/tag push uses the app token (see checkout below)
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
@@ -74,10 +74,22 @@ jobs:
       bump_type: ${{ steps.version.outputs.bump_type }}
       message_ts: ${{ steps.slack.outputs.message_ts }}
     steps:
+      # Push the release branch/tag with a GitHub App token rather than the default GITHUB_TOKEN.
+      # GitHub does not emit events for GITHUB_TOKEN-authored pushes (recursion guard), so a
+      # GITHUB_TOKEN push to v*-release never triggered build_documentation.yaml and versioned
+      # docs stopped publishing. An App-token push triggers downstream workflows normally.
+      - name: Create GitHub App token
+        id: app_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          app-id: ${{ secrets.APP_ID_HUGGINGFACE_HUB_BOT }}
+          private-key: ${{ secrets.APP_SECRET_PEM_HUGGINGFACE_HUB_BOT }}
+
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           ref: main
           fetch-depth: 0
+          token: ${{ steps.app_token.outputs.token }}
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
## Summary

Versioned docs (`/docs/huggingface_hub/en/index`) have been stuck at **v1.16.2** — 1.17 / 1.18 / 1.19 were never published, even though the releases went out fine.

**Root cause:** the `prepare` job in `release.yml` pushes the `v*-release` branch with the default `GITHUB_TOKEN`. GitHub deliberately does **not** emit `push` events for `GITHUB_TOKEN`-authored pushes (recursion guard), so `build_documentation.yaml` (trigger: `push` to `v*-release`) never fired for bot-cut releases → no versioned docs were ever built/uploaded.

**Fix:** mint the existing `huggingface-hub-bot` GitHub App token in `prepare` and use it for `actions/checkout` (`token:`). App-token pushes *do* trigger downstream workflows, so the doc build now runs on every release.

## Evidence

`build_documentation` runs per release branch:

| branch | doc build runs |
|---|---|
| `v1.16-release` | ✅ ran (human-pushed patches) |
| `v1.17-release` | ❌ **zero runs** |
| `v1.18-release` | ❌ **zero runs** |
| `v1.19-release` | ✅ ran (manual cherry-pick push) |

Matching state in `hf-doc-build/doc-build`:
- `_versions.yml` latest stable entry = `v1.16.2`.
- zips present: `v1.16.0`, `v1.16.2`, `v1.19.0.rc1`; absent (404): `v1.16.4`, `v1.17.0`, `v1.18.0`, `v1.19.0.rc0`.

The pattern is exact: only **human** pushes to a release branch triggered a build; every **bot** `Release: vX` push produced nothing (`v1.16.4`, tagged right after the last human-pushed build, has no docs).

## Notes / decisions

- Reuses the same App already used by `post-release` / `notify-prs` (`APP_ID_HUGGINGFACE_HUB_BOT` / `APP_SECRET_PEM_HUGGINGFACE_HUB_BOT`) — no new secret.
- Dropped `prepare`'s `contents: write` → `contents: read`, mirroring `post-release` ("write operations use app token"), since the push now goes through the app token.
- This only fixes things **going forward**: 1.17 / 1.18 stay gaps in the dropdown unless backfilled (a human/App push to those branches). The next stable release (1.19.0) will publish and advance the default version.

Draft because it should be confirmed on the next real release run; pairs with cherry-picking onto `v1.19-release` if we want 1.19.0 to benefit immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release automation credentials and git push identity; misconfigured App secrets could break release branch/tag pushes, but scope is limited to CI and reuses an existing App.
> 
> **Overview**
> Fixes **versioned docs not updating** after automated releases by changing how the `prepare` job pushes `v*-release` branches.
> 
> The job now mints the existing **huggingface-hub-bot** GitHub App token and passes it to `actions/checkout`, so the subsequent commit/tag push is attributed to the App instead of `GITHUB_TOKEN`. GitHub suppresses `push` events for `GITHUB_TOKEN` pushes, which meant `build_documentation.yaml` (triggered on `v*-release`) never ran for bot-cut releases. **`prepare` permissions** are tightened from `contents: write` to `contents: read`, matching other jobs that rely on the App for writes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5aaaea7a2abf0115b2ac3b380b3968a49df21f0b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->