### PR TITLE
Add cache doctor CLI for cache diagnostics and safe repairs

### DIFF
--- a/docs/source/en/guides/manage-cache.md
+++ b/docs/source/en/guides/manage-cache.md
@@ -494,6 +494,45 @@ HFCacheInfo(
 )
 ```
 
+### Diagnose your cache
+
+Use `hf cache doctor` to check whether the local cache layout is healthy. The command
+builds on [`scan_cache_dir`] and reports corrupted cache entries such as invalid repo
+folders, missing `snapshots` directories, broken `refs`, unexpected files in snapshot
+folders, and broken snapshot links.
+
+```bash
+>>> hf cache doctor
+```
+
+When issues are detected, the command prints the category, affected path, explanation,
+and suggested action. It exits with code `1` so it can be used in scripts or CI jobs.
+Use JSON output when you need to inspect the diagnostics programmatically:
+
+```bash
+>>> hf cache doctor --format json
+```
+
+Some cache issues have a safe automatic repair target, for example an unexpected file
+inside the cache root or an incomplete cached repo with no `snapshots` directory. Preview
+those actions first with `--dry-run`:
+
+```bash
+>>> hf cache doctor --repair --dry-run
+```
+
+If the proposed actions look correct, run the repair with confirmation:
+
+```bash
+>>> hf cache doctor --repair
+```
+
+For non-interactive usage, pass `--yes`:
+
+```bash
+>>> hf cache doctor --repair --yes
+```
+
 ### Verify your cache
 
 `huggingface_hub` can verify that your cached files match the checksums on the Hub. Use `hf cache verify` CLI to validate file consistency for a specific revision of a specific repository:

--- a/src/huggingface_hub/cli/cache.py
+++ b/src/huggingface_hub/cli/cache.py
@@ -19,6 +19,7 @@ from collections import defaultdict
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from enum import Enum
+from pathlib import Path
 from typing import Annotated, Any
 
 import typer
@@ -35,9 +36,10 @@ from ..utils import (
     parse_hf_uri,
     scan_cache_dir,
 )
+from ..utils._cache_manager import _try_delete_path
 from ..utils._parsing import parse_duration, parse_size
 from ._cli_utils import RepoIdArg, RepoTypeOpt, RevisionOpt, TokenOpt, get_hf_api, typer_factory
-from ._output import out
+from ._output import OutputFormat, out
 
 
 cache_cli = typer_factory(help="Manage local cache directory.")
@@ -88,6 +90,54 @@ class CacheDeletionCounts:
 
 CacheEntry = tuple[CachedRepoInfo, CachedRevisionInfo | None]
 RepoRefsMap = dict[CachedRepoInfo, frozenset[str]]
+
+
+def build_cache_diagnostics(hf_cache_info: HFCacheInfo) -> list[dict[str, Any]]:
+    """Convert cache scan warnings into stable CLI rows."""
+    diagnostics: list[dict[str, Any]] = []
+    for warning in hf_cache_info.warnings:
+        repair_path = warning.repair_path
+        diagnostics.append(
+            {
+                "category": warning.category or "corrupted-cache",
+                "path": str(warning.path or ""),
+                "message": str(warning),
+                "suggestion": warning.suggestion or "Inspect this cache entry and remove it if it is corrupted.",
+                "repair": warning.repair_action,
+                "repair_path": str(repair_path) if repair_path is not None else None,
+                "repair_type": warning.repair_type,
+                "repairable": repair_path is not None,
+            }
+        )
+    return diagnostics
+
+
+def _repairable_cache_diagnostics(diagnostics: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return diagnostics with a safe repair target."""
+    return [item for item in diagnostics if item["repairable"] and item["repair_path"]]
+
+
+def _delete_cache_diagnostics(diagnostics: list[dict[str, Any]]) -> None:
+    """Delete safe repair targets from cache diagnostics."""
+    for item in diagnostics:
+        _try_delete_path(Path(item["repair_path"]), path_type=item["repair_type"] or "cache entry")
+
+
+def _cache_doctor_payload(
+    hf_cache_info: HFCacheInfo,
+    diagnostics: list[dict[str, Any]],
+    *,
+    repair: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a structured payload for `hf cache doctor --format json`."""
+    return {
+        "healthy": len(diagnostics) == 0,
+        "repo_count": len(hf_cache_info.repos),
+        "size": hf_cache_info.size_on_disk_str,
+        "warning_count": len(diagnostics),
+        "issues": diagnostics,
+        "repair": repair,
+    }
 
 
 def summarize_deletions(
@@ -360,6 +410,141 @@ def _resolve_deletion_targets(hf_cache_info: HFCacheInfo, targets: list[str]) ->
 
 
 #### Cache CLI commands
+
+
+@cache_cli.command(
+    examples=[
+        "hf cache doctor",
+        "hf cache doctor --format json",
+        "hf cache doctor --repair --dry-run",
+        "hf cache doctor --repair --yes",
+    ],
+)
+def doctor(
+    cache_dir: Annotated[
+        str | None,
+        typer.Option(
+            help="Cache directory to scan (defaults to Hugging Face cache).",
+        ),
+    ] = None,
+    repair: Annotated[
+        bool,
+        typer.Option(
+            help="Delete scanner-approved repair targets after confirmation.",
+        ),
+    ] = False,
+    dry_run: Annotated[
+        bool,
+        typer.Option(
+            help="Preview repair actions without deleting anything.",
+        ),
+    ] = False,
+    yes: Annotated[
+        bool,
+        typer.Option(
+            "-y",
+            "--yes",
+            help="Skip confirmation prompt when using --repair.",
+        ),
+    ] = False,
+) -> None:
+    """Diagnose corrupted local cache entries and optionally repair safe cases."""
+    try:
+        hf_cache_info = scan_cache_dir(cache_dir)
+    except CacheNotFound as exc:
+        raise CLIError(f"Cache directory not found: {exc.cache_dir}") from exc
+
+    diagnostics = build_cache_diagnostics(hf_cache_info)
+    repair_info: dict[str, Any] | None = None
+
+    if repair:
+        repairable = _repairable_cache_diagnostics(diagnostics)
+        repair_info = {
+            "dry_run": dry_run,
+            "repairable_count": len(repairable),
+            "targets": [
+                {
+                    "category": item["category"],
+                    "path": item["repair_path"],
+                    "action": item["repair"],
+                }
+                for item in repairable
+            ],
+        }
+
+        if out.mode == OutputFormat.json:
+            if not dry_run and not yes:
+                raise CLIError("Use --yes with --repair when running `hf cache doctor --format json`.")
+            if repairable and not dry_run:
+                _delete_cache_diagnostics(repairable)
+                hf_cache_info = scan_cache_dir(cache_dir)
+                diagnostics = build_cache_diagnostics(hf_cache_info)
+                repair_info["remaining_warning_count"] = len(diagnostics)
+            out.dict(_cache_doctor_payload(hf_cache_info, diagnostics, repair=repair_info))
+            if diagnostics:
+                raise typer.Exit(code=1)
+            return
+
+        if not diagnostics:
+            out.result("Cache healthy", repos=len(hf_cache_info.repos), size=hf_cache_info.size_on_disk_str)
+            return
+
+        out.table(
+            diagnostics,
+            headers=["category", "path", "message", "suggestion", "repairable"],
+            id_key="path",
+        )
+
+        if not repairable:
+            out.warning("No safe automatic repair is available for the detected cache issue(s).")
+            raise typer.Exit(code=1)
+
+        out.text(f"\nAbout to repair {len(repairable)} cache issue(s).")
+        out.table(
+            repairable,
+            headers=["category", "repair_path", "repair"],
+            id_key="repair_path",
+        )
+
+        if dry_run:
+            out.result(
+                "Dry run: no files were deleted.",
+                issues=len(diagnostics),
+                repairable=len(repairable),
+            )
+            raise typer.Exit(code=1)
+
+        out.confirm("Proceed with cache repair?", yes=yes)
+
+        _delete_cache_diagnostics(repairable)
+        repaired_cache_info = scan_cache_dir(cache_dir)
+        remaining_diagnostics = build_cache_diagnostics(repaired_cache_info)
+        if remaining_diagnostics:
+            out.table(
+                remaining_diagnostics,
+                headers=["category", "path", "message", "suggestion", "repairable"],
+                id_key="path",
+            )
+            out.warning(f"{len(remaining_diagnostics)} cache issue(s) remain after repair.")
+            raise typer.Exit(code=1)
+
+        out.result("Cache repaired", repaired=len(repairable), warnings=0)
+        return
+
+    if out.mode == OutputFormat.json:
+        out.dict(_cache_doctor_payload(hf_cache_info, diagnostics))
+    elif diagnostics:
+        out.table(
+            diagnostics,
+            headers=["category", "path", "message", "suggestion", "repairable"],
+            id_key="path",
+        )
+        out.hint("Run `hf cache doctor --repair --dry-run` to preview safe automatic repairs.")
+    else:
+        out.result("Cache healthy", repos=len(hf_cache_info.repos), size=hf_cache_info.size_on_disk_str, warnings=0)
+
+    if diagnostics:
+        raise typer.Exit(code=1)
 
 
 @cache_cli.command(

--- a/src/huggingface_hub/errors.py
+++ b/src/huggingface_hub/errors.py
@@ -21,6 +21,32 @@ class CacheNotFound(Exception):
 class CorruptedCacheException(Exception):
     """Exception for any unexpected structure in the Huggingface cache-system."""
 
+    category: str | None
+    path: Path | None
+    suggestion: str | None
+    repair_path: Path | None
+    repair_action: str | None
+    repair_type: str | None
+
+    def __init__(
+        self,
+        msg: str,
+        *args: object,
+        category: str | None = None,
+        path: str | Path | None = None,
+        suggestion: str | None = None,
+        repair_path: str | Path | None = None,
+        repair_action: str | None = None,
+        repair_type: str | None = None,
+    ) -> None:
+        super().__init__(msg, *args)
+        self.category = category
+        self.path = Path(path) if path is not None else None
+        self.suggestion = suggestion
+        self.repair_path = Path(repair_path) if repair_path is not None else None
+        self.repair_action = repair_action
+        self.repair_type = repair_type
+
 
 # HEADERS ERRORS
 

--- a/src/huggingface_hub/errors.py
+++ b/src/huggingface_hub/errors.py
@@ -30,7 +30,7 @@ class CorruptedCacheException(Exception):
 
     def __init__(
         self,
-        msg: str,
+        msg: str = "",
         *args: object,
         category: str | None = None,
         path: str | Path | None = None,

--- a/src/huggingface_hub/utils/_cache_manager.py
+++ b/src/huggingface_hub/utils/_cache_manager.py
@@ -677,10 +677,23 @@ def _scan_cached_repo(repo_path: Path) -> CachedRepoInfo:
     Any unexpected behavior will raise a [`~CorruptedCacheException`].
     """
     if not repo_path.is_dir():
-        raise CorruptedCacheException(f"Repo path is not a directory: {repo_path}")
+        raise CorruptedCacheException(
+            f"Repo path is not a directory: {repo_path}",
+            category="invalid-cache-entry",
+            path=repo_path,
+            suggestion="Remove this unexpected file from the cache directory.",
+            repair_path=repo_path,
+            repair_action="delete unexpected file",
+            repair_type="file",
+        )
 
     if "--" not in repo_path.name:
-        raise CorruptedCacheException(f"Repo path is not a valid HuggingFace cache directory: {repo_path}")
+        raise CorruptedCacheException(
+            f"Repo path is not a valid HuggingFace cache directory: {repo_path}",
+            category="invalid-cache-entry",
+            path=repo_path,
+            suggestion="Inspect this directory. If it is not used by another tool, move it out of the Hub cache.",
+        )
 
     repo_type, repo_id = repo_path.name.split("--", maxsplit=1)
     repo_type = repo_type[:-1]  # "models" -> "model"
@@ -688,7 +701,10 @@ def _scan_cached_repo(repo_path: Path) -> CachedRepoInfo:
 
     if repo_type not in {"dataset", "model", "space"}:
         raise CorruptedCacheException(
-            f"Repo type must be `dataset`, `model` or `space`, found `{repo_type}` ({repo_path})."
+            f"Repo type must be `dataset`, `model` or `space`, found `{repo_type}` ({repo_path}).",
+            category="invalid-repo-type",
+            path=repo_path,
+            suggestion="Remove or move this invalid repo cache directory.",
         )
 
     blob_stats: dict[Path, os.stat_result] = {}  # Key is blob_path, value is blob stats
@@ -697,7 +713,15 @@ def _scan_cached_repo(repo_path: Path) -> CachedRepoInfo:
     refs_path = repo_path / "refs"
 
     if not snapshots_path.exists() or not snapshots_path.is_dir():
-        raise CorruptedCacheException(f"Snapshots dir doesn't exist in cached repo: {snapshots_path}")
+        raise CorruptedCacheException(
+            f"Snapshots dir doesn't exist in cached repo: {snapshots_path}",
+            category="missing-snapshots",
+            path=snapshots_path,
+            suggestion="Delete the incomplete cached repo. It will be downloaded again when needed.",
+            repair_path=repo_path,
+            repair_action="delete incomplete cached repo",
+            repair_type="repo",
+        )
 
     # Scan over `refs` directory
 
@@ -711,7 +735,15 @@ def _scan_cached_repo(repo_path: Path) -> CachedRepoInfo:
         #         └── pr
         #             └── 1
         if refs_path.is_file():
-            raise CorruptedCacheException(f"Refs directory cannot be a file: {refs_path}")
+            raise CorruptedCacheException(
+                f"Refs directory cannot be a file: {refs_path}",
+                category="invalid-refs",
+                path=refs_path,
+                suggestion="Delete this file so the refs directory can be recreated on the next download.",
+                repair_path=refs_path,
+                repair_action="delete invalid refs file",
+                repair_type="file",
+            )
 
         for ref_path in refs_path.glob("**/*"):
             # glob("**/*") iterates over all files and directories -> skip directories
@@ -731,7 +763,15 @@ def _scan_cached_repo(repo_path: Path) -> CachedRepoInfo:
         if revision_path.name in FILES_TO_IGNORE:
             continue
         if revision_path.is_file():
-            raise CorruptedCacheException(f"Snapshots folder corrupted. Found a file: {revision_path}")
+            raise CorruptedCacheException(
+                f"Snapshots folder corrupted. Found a file: {revision_path}",
+                category="invalid-snapshot-entry",
+                path=revision_path,
+                suggestion="Delete this unexpected file from the snapshots directory.",
+                repair_path=revision_path,
+                repair_action="delete unexpected snapshot file",
+                repair_type="file",
+            )
 
         cached_files = set()
         for file_path in revision_path.glob("**/*"):
@@ -741,7 +781,12 @@ def _scan_cached_repo(repo_path: Path) -> CachedRepoInfo:
 
             blob_path = Path(file_path).resolve()
             if not blob_path.exists():
-                raise CorruptedCacheException(f"Blob missing (broken symlink): {blob_path}")
+                raise CorruptedCacheException(
+                    f"Blob missing (broken symlink): {blob_path}",
+                    category="missing-blob",
+                    path=file_path,
+                    suggestion="Delete the affected cached repo or force-download the revision again.",
+                )
 
             if blob_path not in blob_stats:
                 blob_stats[blob_path] = blob_path.stat()
@@ -780,7 +825,10 @@ def _scan_cached_repo(repo_path: Path) -> CachedRepoInfo:
     # Check that all refs referred to an existing revision
     if len(refs_by_hash) > 0:
         raise CorruptedCacheException(
-            f"Reference(s) refer to missing commit hashes: {dict(refs_by_hash)} ({repo_path})."
+            f"Reference(s) refer to missing commit hashes: {dict(refs_by_hash)} ({repo_path}).",
+            category="dangling-ref",
+            path=refs_path,
+            suggestion="Delete the dangling ref files or force-download the referenced revisions again.",
         )
 
     # Last modified is either the last modified blob file or the repo folder itself if

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,7 +22,7 @@ from huggingface_hub.cli.download import download
 from huggingface_hub.cli.hf import app
 from huggingface_hub.cli.jobs import _parse_namespace_from_job_id
 from huggingface_hub.cli.upload import _resolve_upload_paths, upload
-from huggingface_hub.errors import CLIError, HfUriError, RevisionNotFoundError
+from huggingface_hub.errors import CLIError, CorruptedCacheException, HfUriError, RevisionNotFoundError
 from huggingface_hub.hf_api import ModelInfo
 from huggingface_hub.utils import (
     CachedFileInfo,
@@ -158,6 +158,104 @@ class TestCacheCommand:
 
         # Check limit of 2 entries
         assert "model1" not in stdout
+
+    def test_doctor_healthy_cache(self, runner: CliRunner) -> None:
+        repo = _make_repo("user/model", revisions=[_make_revision("a" * 40)])
+        hf_cache_info = HFCacheInfo(size_on_disk=0, repos=frozenset({repo}), warnings=[])
+
+        with patch("huggingface_hub.cli.cache.scan_cache_dir", return_value=hf_cache_info):
+            result = runner.invoke(app, ["cache", "doctor"])
+
+        assert result.exit_code == 0
+        assert "Cache healthy" in result.stdout
+        assert "repos: 1" in result.stdout
+
+    def test_doctor_reports_cache_warnings(self, runner: CliRunner) -> None:
+        warning = CorruptedCacheException(
+            "Snapshots dir doesn't exist in cached repo: /tmp/models--user--model/snapshots",
+            category="missing-snapshots",
+            path=Path("/tmp/models--user--model/snapshots"),
+            suggestion="Delete the incomplete cached repo.",
+            repair_path=Path("/tmp/models--user--model"),
+            repair_action="delete incomplete cached repo",
+            repair_type="repo",
+        )
+        hf_cache_info = HFCacheInfo(size_on_disk=0, repos=frozenset(), warnings=[warning])
+
+        with patch("huggingface_hub.cli.cache.scan_cache_dir", return_value=hf_cache_info):
+            result = runner.invoke(app, ["cache", "doctor"])
+
+        assert result.exit_code == 1
+        assert "missing-snapshots" in result.stdout
+        assert "Delete the incomplete cached repo." in result.stdout
+
+    def test_doctor_json_output(self, runner: CliRunner) -> None:
+        warning = CorruptedCacheException(
+            "Repo path is not a directory: /tmp/bad-file",
+            category="invalid-cache-entry",
+            path=Path("/tmp/bad-file"),
+            suggestion="Remove this unexpected file from the cache directory.",
+            repair_path=Path("/tmp/bad-file"),
+            repair_action="delete unexpected file",
+            repair_type="file",
+        )
+        hf_cache_info = HFCacheInfo(size_on_disk=0, repos=frozenset(), warnings=[warning])
+
+        with patch("huggingface_hub.cli.cache.scan_cache_dir", return_value=hf_cache_info):
+            result = runner.invoke(app, ["cache", "doctor", "--format", "json"])
+
+        assert result.exit_code == 1
+        payload = json.loads(result.stdout)
+        assert payload["healthy"] is False
+        assert payload["warning_count"] == 1
+        assert payload["issues"][0]["category"] == "invalid-cache-entry"
+        assert payload["issues"][0]["repairable"] is True
+
+    def test_doctor_repair_dry_run(self, runner: CliRunner) -> None:
+        warning = CorruptedCacheException(
+            "Repo path is not a directory: /tmp/bad-file",
+            category="invalid-cache-entry",
+            path=Path("/tmp/bad-file"),
+            suggestion="Remove this unexpected file from the cache directory.",
+            repair_path=Path("/tmp/bad-file"),
+            repair_action="delete unexpected file",
+            repair_type="file",
+        )
+        hf_cache_info = HFCacheInfo(size_on_disk=0, repos=frozenset(), warnings=[warning])
+
+        with (
+            patch("huggingface_hub.cli.cache.scan_cache_dir", return_value=hf_cache_info),
+            patch("huggingface_hub.cli.cache._try_delete_path") as delete_mock,
+        ):
+            result = runner.invoke(app, ["cache", "doctor", "--repair", "--dry-run"])
+
+        assert result.exit_code == 1
+        assert "Dry run: no files were deleted." in result.stdout
+        delete_mock.assert_not_called()
+
+    def test_doctor_repair_executes_safe_targets(self, runner: CliRunner) -> None:
+        repair_path = Path("/tmp/bad-file")
+        warning = CorruptedCacheException(
+            f"Repo path is not a directory: {repair_path}",
+            category="invalid-cache-entry",
+            path=repair_path,
+            suggestion="Remove this unexpected file from the cache directory.",
+            repair_path=repair_path,
+            repair_action="delete unexpected file",
+            repair_type="file",
+        )
+        unhealthy_cache_info = HFCacheInfo(size_on_disk=0, repos=frozenset(), warnings=[warning])
+        healthy_cache_info = HFCacheInfo(size_on_disk=0, repos=frozenset(), warnings=[])
+
+        with (
+            patch("huggingface_hub.cli.cache.scan_cache_dir", side_effect=[unhealthy_cache_info, healthy_cache_info]),
+            patch("huggingface_hub.cli.cache._try_delete_path") as delete_mock,
+        ):
+            result = runner.invoke(app, ["cache", "doctor", "--repair", "--yes"])
+
+        assert result.exit_code == 0
+        assert "Cache repaired" in result.stdout
+        delete_mock.assert_called_once_with(repair_path, path_type="file")
 
     def test_rm_revision_executes_strategy(self, runner: CliRunner) -> None:
         revision = _make_revision("c" * 40)

--- a/tests/test_utils_cache.py
+++ b/tests/test_utils_cache.py
@@ -45,6 +45,27 @@ class TestMissingCacheUtils(unittest.TestCase):
 
 
 @pytest.mark.usefixtures("fx_cache_dir")
+class TestCacheWarningMetadata(unittest.TestCase):
+    cache_dir: Path
+
+    def test_invalid_cache_file_warning_has_repair_metadata(self) -> None:
+        """Cache warnings include structured metadata for CLI diagnostics."""
+        unexpected_file = self.cache_dir / "unexpected-file"
+        unexpected_file.touch()
+
+        report = scan_cache_dir(self.cache_dir)
+
+        self.assertEqual(len(report.warnings), 1)
+        warning = report.warnings[0]
+        self.assertEqual(str(warning), f"Repo path is not a directory: {unexpected_file}")
+        self.assertEqual(warning.category, "invalid-cache-entry")
+        self.assertEqual(warning.path, unexpected_file)
+        self.assertEqual(warning.repair_path, unexpected_file)
+        self.assertEqual(warning.repair_action, "delete unexpected file")
+        self.assertEqual(warning.repair_type, "file")
+
+
+@pytest.mark.usefixtures("fx_cache_dir")
 class TestValidCacheUtils(unittest.TestCase):
     cache_dir: Path
 

--- a/tests/test_utils_cache.py
+++ b/tests/test_utils_cache.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock
 import pytest
 
 from huggingface_hub._snapshot_download import snapshot_download
+from huggingface_hub.errors import CorruptedCacheException
 from huggingface_hub.utils import DeleteCacheStrategy, HFCacheInfo, _format_size, scan_cache_dir
 from huggingface_hub.utils._cache_manager import CacheNotFound, _try_delete_path
 
@@ -42,6 +43,15 @@ class TestMissingCacheUtils(unittest.TestCase):
         file_path = self.cache_dir / "file.txt"
         file_path.touch()
         self.assertRaises(ValueError, scan_cache_dir, file_path)
+
+
+class TestCorruptedCacheException(unittest.TestCase):
+    def test_backward_compatible_empty_message(self) -> None:
+        warning = CorruptedCacheException()
+
+        self.assertEqual(str(warning), "")
+        self.assertIsNone(warning.category)
+        self.assertIsNone(warning.path)
 
 
 @pytest.mark.usefixtures("fx_cache_dir")


### PR DESCRIPTION
## What does this PR do?

Adds `hf cache doctor`, a CLI command to diagnose corrupted local Hugging Face cache entries and optionally repair safe cases.

The command reports cache scan warnings with structured categories, affected paths, suggestions, and repairability. It supports human/table output, JSON output, dry-run repair previews, and confirmed repairs.

## Changes

- Add structured metadata to `CorruptedCacheException`
- Add `hf cache doctor`
- Support `--format json`, `--repair --dry-run`, and `--repair --yes`
- Document cache diagnostics in the cache guide
- Add CLI and cache warning metadata tests

## Tests

- `python -m pytest tests\test_cli.py::TestCacheCommand tests\test_utils_cache.py::TestCacheWarningMetadata -q`
- `python -m ruff check src\huggingface_hub\errors.py src\huggingface_hub\utils\_cache_manager.py src\huggingface_hub\cli\cache.py tests\test_cli.py tests\test_utils_cache.py`
- `python -m py_compile src\huggingface_hub\errors.py src\huggingface_hub\utils\_cache_manager.py src\huggingface_hub\cli\cache.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> `--repair` deletes local cache paths on disk; behavior is limited to scanner-marked targets but mistaken use could remove incomplete repos or stray files users still wanted to keep.
> 
> **Overview**
> Adds **`hf cache doctor`** to scan the Hub cache via `scan_cache_dir`, surface corruption warnings in tables or JSON, exit with code **1** when issues exist (CI-friendly), and optionally **repair** scanner-approved targets through `_try_delete_path` with `--repair --dry-run`, interactive confirm, or `--repair --yes`.
> 
> **`CorruptedCacheException`** now carries structured fields (`category`, `path`, `suggestion`, `repair_path`, `repair_action`, `repair_type`). Cache scanning in **`_scan_cached_repo`** populates them so some problems (unexpected cache-root files, missing `snapshots`, invalid `refs`/snapshot files) are marked repairable; others (invalid repo layout, broken symlinks, dangling refs) only get guidance.
> 
> The cache management guide documents the new workflow; tests cover the doctor CLI paths and warning metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 906b86ea98b6049fd20abe5d8c104ac4fc74adc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->