### PR TITLE
feat: avoid per file resolve call in snapshot path

### DIFF
--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -16,9 +16,17 @@ from .errors import (
     RepositoryNotFoundError,
     RevisionNotFoundError,
 )
-from .file_download import REGEX_COMMIT_HASH, DryRunFileInfo, hf_hub_download, repo_folder_name
+from .file_download import (
+    REGEX_COMMIT_HASH,
+    DryRunFileInfo,
+    HfFileMetadata,
+    _hf_hub_download,
+    hf_hub_url,
+    repo_folder_name,
+)
 from .hf_api import DatasetInfo, HfApi, KernelInfo, ModelInfo, RepoFile, SpaceInfo
-from .utils import OfflineModeIsEnabled, filter_repo_objects, logging, validate_hf_hub_args
+from .utils import OfflineModeIsEnabled, XetFileData, filter_repo_objects, logging, validate_hf_hub_args
+from .utils._xet import XetTokenType, xet_connection_info_refresh_url
 from .utils.tqdm import _create_progress_bar
 from .utils.tqdm import tqdm as hf_tqdm
 
@@ -343,15 +351,29 @@ def snapshot_download(
     siblings = getattr(repo_info, "siblings", None)
     repo_files: Iterable[str] = [f.rfilename for f in siblings] if siblings is not None else []
     unreliable_nb_files = siblings is None or len(siblings) == 0 or len(siblings) > LARGE_REPO_THRESHOLD
+    # When the tree listing is used, file metadata (etag, size, xet hash) is collected along the way so that
+    # `hf_hub_download` can skip its per-file HEAD call. This drastically reduces the number of requests sent
+    # to the Hub for repos with many files.
+    file_metadata_by_path: dict[str, HfFileMetadata] = {}
     if unreliable_nb_files:
         logger.info(
             "Number of files in the repo is unreliable. Using `list_repo_tree` to ensure all files are listed."
         )
-        repo_files = (
-            f.rfilename
-            for f in api.list_repo_tree(repo_id=repo_id, recursive=True, revision=revision, repo_type=repo_type)
-            if isinstance(f, RepoFile)
-        )
+        # List the tree at the resolved commit hash: files are downloaded at this exact commit, so the
+        # listing and the collected metadata are guaranteed to be consistent with it.
+        tree_files: list[str] = []
+        for repo_file in api.list_repo_tree(
+            repo_id=repo_id, recursive=True, revision=repo_info.sha, repo_type=repo_type
+        ):
+            if not isinstance(repo_file, RepoFile):
+                continue
+            tree_files.append(repo_file.rfilename)
+            file_metadata = _file_metadata_from_repo_file(
+                repo_file, repo_id=repo_id, repo_type=repo_type, commit_hash=repo_info.sha, endpoint=endpoint
+            )
+            if file_metadata is not None:
+                file_metadata_by_path[repo_file.rfilename] = file_metadata
+        repo_files = tree_files
 
     filtered_repo_files: Iterable[str] = filter_repo_objects(
         items=repo_files,
@@ -433,7 +455,7 @@ def snapshot_download(
     # have the file locally.
     def _inner_hf_hub_download(repo_file: str) -> None:
         results.append(
-            hf_hub_download(  # type: ignore
+            _hf_hub_download(
                 repo_id,
                 filename=repo_file,
                 repo_type=repo_type,
@@ -450,6 +472,7 @@ def snapshot_download(
                 headers=headers,
                 tqdm_class=_AggregatedTqdm,  # type: ignore
                 dry_run=dry_run,
+                file_metadata=file_metadata_by_path.get(repo_file),
             )
         )
 
@@ -470,3 +493,40 @@ def snapshot_download(
     if local_dir is not None:
         return str(os.path.realpath(local_dir))
     return snapshot_folder
+
+
+def _file_metadata_from_repo_file(
+    repo_file: RepoFile, *, repo_id: str, repo_type: str, commit_hash: str, endpoint: str | None
+) -> HfFileMetadata | None:
+    """Build the metadata of a file from its tree listing entry, sparing a per-file HEAD call.
+
+    Returns `None` if the entry does not contain enough information, in which case `hf_hub_download` falls back to
+    fetching metadata with a HEAD call.
+    """
+    # For an LFS file, etag is its sha256 and size is the size of the actual file (not the pointer).
+    # For a regular file, etag is its git blob id. Same logic as the `/resolve` HEAD endpoint server-side.
+    etag = repo_file.lfs.sha256 if repo_file.lfs is not None else repo_file.blob_id
+    size = repo_file.lfs.size if repo_file.lfs is not None else repo_file.size
+    if etag is None or size is None:
+        return None
+    xet_file_data = None
+    if repo_file.xet_hash is not None:
+        xet_file_data = XetFileData(
+            file_hash=repo_file.xet_hash,
+            refresh_route=xet_connection_info_refresh_url(
+                token_type=XetTokenType.READ,
+                repo_id=repo_id,
+                repo_type=repo_type,
+                revision=commit_hash,
+                endpoint=endpoint,
+            ),
+        )
+    return HfFileMetadata(
+        commit_hash=commit_hash,
+        etag=etag,
+        location=hf_hub_url(
+            repo_id, repo_file.rfilename, repo_type=repo_type, revision=commit_hash, endpoint=endpoint
+        ),
+        size=size,
+        xet_file_data=xet_file_data,
+    )

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -955,6 +955,55 @@ def hf_hub_download(
             If some parameter value is invalid.
 
     """
+    return _hf_hub_download(
+        repo_id,
+        filename,
+        subfolder=subfolder,
+        repo_type=repo_type,
+        revision=revision,
+        library_name=library_name,
+        library_version=library_version,
+        cache_dir=cache_dir,
+        local_dir=local_dir,
+        user_agent=user_agent,
+        force_download=force_download,
+        etag_timeout=etag_timeout,
+        token=token,
+        local_files_only=local_files_only,
+        headers=headers,
+        endpoint=endpoint,
+        tqdm_class=tqdm_class,
+        dry_run=dry_run,
+    )
+
+
+def _hf_hub_download(
+    repo_id: str,
+    filename: str,
+    *,
+    subfolder: str | None = None,
+    repo_type: str | None = None,
+    revision: str | None = None,
+    library_name: str | None = None,
+    library_version: str | None = None,
+    cache_dir: str | Path | None = None,
+    local_dir: str | Path | None = None,
+    user_agent: dict | str | None = None,
+    force_download: bool = False,
+    etag_timeout: float = constants.DEFAULT_ETAG_TIMEOUT,
+    token: bool | str | None = None,
+    local_files_only: bool = False,
+    headers: dict[str, str] | None = None,
+    endpoint: str | None = None,
+    tqdm_class: type[base_tqdm] | None = None,
+    dry_run: bool = False,
+    file_metadata: HfFileMetadata | None = None,
+) -> str | DryRunFileInfo:
+    """Internal implementation of `hf_hub_download`.
+
+    Same as the public function, with an extra `file_metadata` argument for metadata that has already been
+    fetched by the caller (e.g. by `snapshot_download` from the tree listing), sparing the per-file HEAD call.
+    """
     if constants.HF_HUB_ETAG_TIMEOUT != constants.DEFAULT_ETAG_TIMEOUT:
         # Respect environment variable above user value
         etag_timeout = constants.HF_HUB_ETAG_TIMEOUT
@@ -1010,6 +1059,7 @@ def hf_hub_download(
             local_files_only=local_files_only,
             tqdm_class=tqdm_class,
             dry_run=dry_run,
+            file_metadata=file_metadata,
         )
     else:
         return _hf_hub_download_to_cache_dir(
@@ -1030,6 +1080,7 @@ def hf_hub_download(
             force_download=force_download,
             tqdm_class=tqdm_class,
             dry_run=dry_run,
+            file_metadata=file_metadata,
         )
 
 
@@ -1052,6 +1103,7 @@ def _hf_hub_download_to_cache_dir(
     force_download: bool,
     tqdm_class: type[base_tqdm] | None,
     dry_run: bool,
+    file_metadata: HfFileMetadata | None = None,
 ) -> str | DryRunFileInfo:
     """Download a given file to a cache folder, if not already present.
 
@@ -1099,6 +1151,7 @@ def _hf_hub_download_to_cache_dir(
         local_files_only=local_files_only,
         storage_folder=storage_folder,
         relative_filename=relative_filename,
+        file_metadata=file_metadata,
     )
 
     # etag can be None for several reasons:
@@ -1272,6 +1325,7 @@ def _hf_hub_download_to_local_dir(
     local_files_only: bool,
     tqdm_class: type[base_tqdm] | None,
     dry_run: bool,
+    file_metadata: HfFileMetadata | None = None,
 ) -> str | DryRunFileInfo:
     """Download a given file to a local folder, if not already present.
 
@@ -1316,6 +1370,7 @@ def _hf_hub_download_to_local_dir(
         headers=headers,
         token=token,
         local_files_only=local_files_only,
+        file_metadata=file_metadata,
     )
 
     if head_call_error is not None:
@@ -1645,6 +1700,7 @@ def _get_metadata_or_catch_error(
     relative_filename: str | None = None,  # only used to store `.no_exists` in cache
     storage_folder: str | None = None,  # only used to store `.no_exists` in cache
     retry_on_errors: bool = False,
+    file_metadata: HfFileMetadata | None = None,  # pre-fetched metadata, spares the HEAD call
 ) -> (
     # Either an exception is caught and returned
     tuple[None, None, None, None, None, Exception]
@@ -1673,6 +1729,18 @@ def _get_metadata_or_catch_error(
                 f"Cannot access file since 'local_files_only=True' as been set. (repo_id: {repo_id}, repo_type: {repo_type}, revision: {revision}, filename: {filename})"
             ),
         )
+
+    if file_metadata is not None:
+        # Metadata has been pre-fetched by the caller (e.g. by `snapshot_download` from the tree listing)
+        # => skip the HEAD call entirely.
+        return (
+            file_metadata.location,
+            file_metadata.etag,
+            file_metadata.commit_hash,
+            file_metadata.size,
+            file_metadata.xet_file_data,
+            None,
+        )  # type: ignore
 
     url = hf_hub_url(repo_id, filename, repo_type=repo_type, revision=revision, endpoint=endpoint)
     url_to_download: str = url


### PR DESCRIPTION
this PR explores avoiding the per file resolve call in the `snapshot_download` path and prefers using the  `list_repo_tree` to for the repo's files metadata.

this change was motivated by kernel repos that contain many small files like https://huggingface.co/kernels/kernels-community/deep-gemm/tree/v2 (which vendors cutlass in each build variant). 

when testing these changes locally via the `get_kernel` method from the kernels library this reduces the number of "resolve" calls from 1413 to 1 (since the kernels library makes an extra `hf_hub_download` call when downloading).

not sure if these changes align with the rest of the library but wanted to open as a possible solution/improvement for repos with many small files. note I was careful to avoid making changes to any public functions to avoid any api breakage

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the shared download metadata path; incorrect tree-derived etags/URLs could cause wrong cache keys or failed downloads, though incomplete entries still fall back to HEAD.
> 
> **Overview**
> **`snapshot_download`** now reuses file metadata from **`list_repo_tree`** when the repo file list is unreliable (empty/missing siblings, >1000 files, kernel repos), so each file download can skip the per-file **resolve/HEAD** round trip.
> 
> While walking the tree at the resolved **`repo_info.sha`**, it builds a path → **`HfFileMetadata`** map via **`_file_metadata_from_repo_file`** (etag/size from LFS or blob id, resolve URL, optional Xet data) and passes it into downloads through a new internal **`_hf_hub_download`** used only from snapshot. Public **`hf_hub_download`** is unchanged and still delegates without pre-fetched metadata.
> 
> **`_get_metadata_or_catch_error`** returns the caller-supplied metadata immediately when present; otherwise behavior is unchanged (HEAD + fallbacks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25b79bbd427d6e3e6368090fe58058c534675336. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->