### PR TITLE
[Download] Retry on RemoteProtocolError in http_get

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -437,8 +437,8 @@ def http_get(
                         new_resume_size += len(chunk)
                         # Some data has been downloaded from the server so we reset the number of retries.
                         _nb_retries = 5
-            except (httpx.ConnectError, httpx.TimeoutException, httpx.RemoteProtocolError) as e:
-                # If ConnectionError (SSLError) or ReadTimeout, or RemoteProtocolError (peer closed the connection before
+            except (httpx.ConnectError, httpx.TimeoutException, httpx.ProtocolError) as e:
+                # If ConnectionError (SSLError) or ReadTimeout, or ProtocolError (peer closed the connection before
                 # sending the complete body) happen while streaming data from the server, it is most likely a transient
                 # error (network outage?). We log a warning message and try to resume the download a few times
                 # before giving up. The retry mechanism is basic but should be enough in most cases.

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -437,11 +437,12 @@ def http_get(
                         new_resume_size += len(chunk)
                         # Some data has been downloaded from the server so we reset the number of retries.
                         _nb_retries = 5
-            except (httpx.ConnectError, httpx.TimeoutException, httpx.ProtocolError) as e:
-                # If ConnectionError (SSLError) or ReadTimeout, or ProtocolError (peer closed the connection before
+            except (httpx.ConnectError, httpx.TimeoutException, httpx.RemoteProtocolError) as e:
+                # If ConnectionError (SSLError), ReadTimeout, or RemoteProtocolError (peer closed the connection before
                 # sending the complete body) happen while streaming data from the server, it is most likely a transient
-                # error (network outage?). We log a warning message and try to resume the download a few times
-                # before giving up. The retry mechanism is basic but should be enough in most cases.
+                # error (network outage? flaky CDN?). We log a warning message and try to resume the download a few times
+                # before giving up. Since `_nb_retries` is reset to 5 whenever a chunk is received, a download that keeps
+                # making progress will keep resuming. The retry mechanism is basic but should be enough in most cases.
                 if _nb_retries <= 0:
                     logger.warning("Error while downloading from %s: %s\nMax retries exceeded.", url, str(e))
                     raise

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -437,10 +437,12 @@ def http_get(
                         new_resume_size += len(chunk)
                         # Some data has been downloaded from the server so we reset the number of retries.
                         _nb_retries = 5
-            except (httpx.ConnectError, httpx.TimeoutException) as e:
-                # If ConnectionError (SSLError) or ReadTimeout happen while streaming data from the server, it is most likely
-                # a transient error (network outage?). We log a warning message and try to resume the download a few times
-                # before giving up. The retry mechanism is basic but should be enough in most cases.
+            except (httpx.ConnectError, httpx.TimeoutException, httpx.RemoteProtocolError) as e:
+                # If ConnectionError (SSLError), ReadTimeout, or RemoteProtocolError (peer closed the connection before
+                # sending the complete body) happen while streaming data from the server, it is most likely a transient
+                # error (network outage? flaky CDN?). We log a warning message and try to resume the download a few times
+                # before giving up. Since `_nb_retries` is reset to 5 whenever a chunk is received, a download that keeps
+                # making progress will keep resuming. The retry mechanism is basic but should be enough in most cases.
                 if _nb_retries <= 0:
                     logger.warning("Error while downloading from %s: %s\nMax retries exceeded.", url, str(e))
                     raise

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -440,9 +440,8 @@ def http_get(
             except (httpx.ConnectError, httpx.TimeoutException, httpx.RemoteProtocolError) as e:
                 # If ConnectionError (SSLError), ReadTimeout, or RemoteProtocolError (peer closed the connection before
                 # sending the complete body) happen while streaming data from the server, it is most likely a transient
-                # error (network outage? flaky CDN?). We log a warning message and try to resume the download a few times
-                # before giving up. Since `_nb_retries` is reset to 5 whenever a chunk is received, a download that keeps
-                # making progress will keep resuming. The retry mechanism is basic but should be enough in most cases.
+                # error (network outage?). We log a warning message and try to resume the download a few times  before
+                # giving up. The retry mechanism is basic but should be enough in most cases.
                 if _nb_retries <= 0:
                     logger.warning("Error while downloading from %s: %s\nMax retries exceeded.", url, str(e))
                     raise

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -438,11 +438,10 @@ def http_get(
                         # Some data has been downloaded from the server so we reset the number of retries.
                         _nb_retries = 5
             except (httpx.ConnectError, httpx.TimeoutException, httpx.RemoteProtocolError) as e:
-                # If ConnectionError (SSLError), ReadTimeout, or RemoteProtocolError (peer closed the connection before
+                # If ConnectionError (SSLError) or ReadTimeout, or RemoteProtocolError (peer closed the connection before
                 # sending the complete body) happen while streaming data from the server, it is most likely a transient
-                # error (network outage? flaky CDN?). We log a warning message and try to resume the download a few times
-                # before giving up. Since `_nb_retries` is reset to 5 whenever a chunk is received, a download that keeps
-                # making progress will keep resuming. The retry mechanism is basic but should be enough in most cases.
+                # error (network outage?). We log a warning message and try to resume the download a few times
+                # before giving up. The retry mechanism is basic but should be enough in most cases.
                 if _nb_retries <= 0:
                     logger.warning("Error while downloading from %s: %s\nMax retries exceeded.", url, str(e))
                     raise

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -1105,6 +1105,33 @@ class TestHttpGet:
         # Note: The range headers are now handled internally by http_get's retry mechanism
         # The test verifies that the download completed successfully after retries
 
+    def test_http_get_retries_on_remote_protocol_error(self, caplog):
+        """A RemoteProtocolError (peer closed the connection before sending the full body) must be retried/resumed.
+
+        Regression test for https://github.com/huggingface/huggingface_hub/issues/4349.
+        """
+
+        def _fail_after(data: bytes):
+            yield data
+            raise httpx.RemoteProtocolError(
+                "peer closed connection without sending complete message body (received 30 bytes, expected 100)"
+            )
+
+        temp_file = self._http_get_with_mocked_responses(
+            [
+                self._mock_response(headers={"Content-Length": "100"}, iter_bytes=_fail_after(b"A" * 30)),
+                self._mock_response(
+                    status_code=206,
+                    headers={"Content-Length": "70", "Content-Range": "bytes 30-99/100"},
+                    iter_bytes=iter([b"B" * 70]),
+                ),
+            ],
+            expected_size=100,
+        )
+
+        assert temp_file.getvalue() == b"A" * 30 + b"B" * 70
+        assert len([r for r in caplog.records if r.levelname == "WARNING"]) == 1
+
     @pytest.mark.parametrize(
         "initial_range,expected_ranges",
         [

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -1105,33 +1105,6 @@ class TestHttpGet:
         # Note: The range headers are now handled internally by http_get's retry mechanism
         # The test verifies that the download completed successfully after retries
 
-    def test_http_get_retries_on_remote_protocol_error(self, caplog):
-        """A RemoteProtocolError (peer closed the connection before sending the full body) must be retried/resumed.
-
-        Regression test for https://github.com/huggingface/huggingface_hub/issues/4349.
-        """
-
-        def _fail_after(data: bytes):
-            yield data
-            raise httpx.RemoteProtocolError(
-                "peer closed connection without sending complete message body (received 30 bytes, expected 100)"
-            )
-
-        temp_file = self._http_get_with_mocked_responses(
-            [
-                self._mock_response(headers={"Content-Length": "100"}, iter_bytes=_fail_after(b"A" * 30)),
-                self._mock_response(
-                    status_code=206,
-                    headers={"Content-Length": "70", "Content-Range": "bytes 30-99/100"},
-                    iter_bytes=iter([b"B" * 70]),
-                ),
-            ],
-            expected_size=100,
-        )
-
-        assert temp_file.getvalue() == b"A" * 30 + b"B" * 70
-        assert len([r for r in caplog.records if r.levelname == "WARNING"]) == 1
-
     @pytest.mark.parametrize(
         "initial_range,expected_ranges",
         [


### PR DESCRIPTION
## Summary

- The non-xet HTTP download path (`http_get` in `file_download.py`) auto-resumes on `httpx.ConnectError` and `httpx.TimeoutException`, but **not** on `httpx.RemoteProtocolError`.
- A flaky CDN/network that drops the connection before sending the full body raises `RemoteProtocolError: peer closed connection without sending complete message body (received X bytes, expected Y)`. This bypassed the retry block entirely, so the whole download failed with no resume attempt.
- Fix: add `httpx.RemoteProtocolError` to the caught exceptions. It reuses the existing resume-via-`Range` machinery — no new structure on this legacy path.

Reported in #4349 (40 GB download failing ~2/3 of the time with `HF_HUB_DISABLE_XET=1`).

Worst case (a genuinely malformed-response server) is a slightly slower bounded failure (5 retries × 1s), not a hang or corruption.

Note: this resumes **within** a single `http_get` call. Cross-process resume is out of scope — the unique `.incomplete` temp file is still deleted on failure by design.

> [!NOTE]
> The longer-term recommendation for users on flaky/large transfers remains `hf_xet`, which handles this far more robustly. This just makes the legacy path fail less often.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to transient download error handling on the legacy HTTP path; reuses existing bounded resume logic and adds a unit test.
> 
> **Overview**
> **`http_get`** now treats **`httpx.RemoteProtocolError`** (peer closes the connection before the full body is sent) like **`ConnectError`** and **`TimeoutException`**: log a warning, sleep, and **resume** via the existing **`Range`** / **`resume_size`** retry path instead of failing immediately.
> 
> Adds **`test_http_get_retries_on_remote_protocol_error`** to assert a mid-stream protocol error is resumed and the final bytes match (regression for #4349).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de86a09f76cecb58eb31846ecba9d8385f9b9800. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->