### PR TITLE
[Jobs] Add SSH support to run a Job and connect to it

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -1984,6 +1984,26 @@ Use `-f` or `--filter` in `hf jobs ps` to filter Jobs that match certain labels:
 >>> hf jobs ps -a --filter label=model=Qwen3-06B --filter label=dataset!=Capybara
 ```
 
+### SSH into a Job
+
+Pass `--ssh` to `hf jobs run` (or `hf jobs uv run`) to make the Job's container reachable over SSH, then connect with `hf jobs ssh`:
+
+```bash
+# Start a job with SSH enabled
+>>> hf jobs run --ssh --detach python:3.12 sleep infinity
+
+# Open an SSH session into it
+>>> hf jobs ssh <job_id>
+
+# Print the SSH command instead of running it
+>>> hf jobs ssh <job_id> --dry-run
+
+# Use a specific identity file
+>>> hf jobs ssh <job_id> -i ~/.ssh/id_ed25519
+```
+
+Only users with write access to the Job's namespace are allowed in (the Job creator, or members of the owner organization), authenticated by an SSH public key registered at https://huggingface.co/settings/keys.
+
 ### UV Scripts (Experimental)
 
 Run UV scripts (Python scripts with inline dependencies) on HF infrastructure. UV scripts are Python scripts that include their dependencies directly in the file using a special comment syntax.

--- a/docs/source/en/guides/jobs.md
+++ b/docs/source/en/guides/jobs.md
@@ -290,6 +290,29 @@ This is especially useful for storage buckets, which provide fast, mutable stora
 
 Use `read_only=True` to enable read-only: `Volume(type="bucket", read_only=True, ...)`.
 
+## SSH into a Job
+
+Pass `ssh=True` to [`run_job`] (or [`run_uv_job`]) to make the Job's container reachable over SSH. The SSH endpoint is available in the Job status:
+
+```python
+>>> from huggingface_hub import run_job
+>>> job = run_job(
+...     image="python:3.12",
+...     command=["sleep", "infinity"],
+...     ssh=True,
+... )
+>>> job.status.ssh_url
+'ssh://68498e23210b3a4f4e6e2a23@ssh.hf.jobs'
+```
+
+Connect from a terminal with `hf jobs ssh <job_id>` (or directly with `ssh <job_id>@ssh.hf.jobs`):
+
+```bash
+>>> hf jobs ssh 68498e23210b3a4f4e6e2a23
+```
+
+Only users with write access to the Job's namespace are allowed in (the Job creator, or members of the owner organization), authenticated by an SSH public key registered at https://huggingface.co/settings/keys.
+
 ## Configure Job Timeout
 
 Jobs have a default timeout (30 minutes), after which they will automatically stop. This is important to know when running long-running tasks like model training.

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -2120,6 +2120,7 @@ $ hf jobs [OPTIONS] COMMAND [ARGS]...
 * `ps`: List Jobs.
 * `run`: Run a Job.
 * `scheduled`: Create and manage scheduled Jobs on the Hub.
+* `ssh`: SSH into a running Job.
 * `stats`: Fetch the resource usage statistics and...
 * `uv`: Run UV scripts (Python with inline...
 
@@ -2326,6 +2327,7 @@ $ hf jobs run [OPTIONS] IMAGE COMMAND...
 * `--timeout TEXT`: Max duration: int/float with s (seconds, default), m (minutes), h (hours) or d (days).
 * `-d, --detach`: Run the Job in the background and print the Job ID.
 * `--expose INTEGER`: Expose a container port through the jobs proxy. Repeat the flag for multiple ports (e.g. `--expose 8000 --expose 8001`). Each exposed port is reachable on the public jobs domain; access requires an HF token with read access to the job's namespace.
+* `--ssh`: Make the job's container reachable over SSH. Connect with `hf jobs ssh <job_id>`. Requires an SSH public key registered on https://huggingface.co/settings/keys.
 * `--namespace TEXT`: The namespace where the job will be running. Defaults to the current user's namespace.
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `--help`: Show this message and exit.
@@ -2640,6 +2642,41 @@ Learn more
   Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
 
 
+### `hf jobs ssh`
+
+SSH into a running Job.
+
+Requires the Job to be started with SSH enabled (`hf jobs run --ssh ...`) and your SSH
+public key to be registered at https://huggingface.co/settings/keys.
+
+**Usage**:
+
+```console
+$ hf jobs ssh [OPTIONS] JOB_ID
+```
+
+**Arguments**:
+
+* `JOB_ID`: Job ID (or 'namespace/job_id')  [required]
+
+**Options**:
+
+* `-i, --identity-file PATH`: Path to the SSH identity file (forwarded to `ssh -i`).
+* `--dry-run`: Print the SSH command instead of running it.
+* `--namespace TEXT`: The namespace where the job will be running. Defaults to the current user's namespace.
+* `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
+* `--help`: Show this message and exit.
+
+Examples
+  $ hf jobs ssh <job_id>
+  $ hf jobs ssh <job_id> --dry-run
+  $ hf jobs ssh <job_id> -i ~/.ssh/id_ed25519
+
+Learn more
+  Use `hf <command> --help` for more information about a command.
+  Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
+
+
 ### `hf jobs stats`
 
 Fetch the resource usage statistics and metrics of Jobs
@@ -2714,6 +2751,7 @@ $ hf jobs uv run [OPTIONS] SCRIPT [SCRIPT_ARGS]...
 * `--timeout TEXT`: Max duration: int/float with s (seconds, default), m (minutes), h (hours) or d (days).
 * `-d, --detach`: Run the Job in the background and print the Job ID.
 * `--expose INTEGER`: Expose a container port through the jobs proxy. Repeat the flag for multiple ports (e.g. `--expose 8000 --expose 8001`). Each exposed port is reachable on the public jobs domain; access requires an HF token with read access to the job's namespace.
+* `--ssh`: Make the job's container reachable over SSH. Connect with `hf jobs ssh <job_id>`. Requires an SSH public key registered on https://huggingface.co/settings/keys.
 * `--namespace TEXT`: The namespace where the job will be running. Defaults to the current user's namespace.
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `--with TEXT`: Run with the given packages installed

--- a/src/huggingface_hub/_jobs_api.py
+++ b/src/huggingface_hub/_jobs_api.py
@@ -90,6 +90,7 @@ class JobStatus:
     stage: JobStage
     message: str | None
     expose_urls: list[str] | None
+    ssh_url: str | None
 
 
 @dataclass
@@ -190,6 +191,10 @@ class JobInfo:
             Public URLs through which the Job's exposed ports are reachable (one per port exposed via `expose=`),
             e.g. `["https://687fb701029421ae5549d998--8000.hf.jobs"]`. `None` when no port is exposed.
             Accessing a URL requires an HF token with read access to the Job's namespace.
+        ssh_url (`str` or `None`):
+            SSH endpoint of the Job, e.g. `"ssh://687fb701029421ae5549d998@ssh.hf.jobs"`. Only present when the Job
+            was started with `ssh=True`. Connecting requires write access to the Job's namespace and an SSH public
+            key registered on the Hub (https://huggingface.co/settings/keys).
 
     Example:
 
@@ -254,7 +259,10 @@ class JobInfo:
         self.volumes = [Volume(**v) for v in volumes] if volumes else None
         status = kwargs.get("status", {})
         self.status = JobStatus(
-            stage=status["stage"], message=status.get("message"), expose_urls=status.get("exposeUrls")
+            stage=status["stage"],
+            message=status.get("message"),
+            expose_urls=status.get("exposeUrls"),
+            ssh_url=status.get("sshUrl"),
         )
         durations = kwargs.get("durations")
         self.durations = JobDurations(**durations) if durations else None
@@ -492,6 +500,7 @@ def _create_job_spec(
     labels: dict[str, str] | None = None,
     volumes: list[Volume] | None = None,
     expose: list[int] | None = None,
+    ssh: bool = False,
 ) -> dict[str, Any]:
     # prepare job spec to send to HF Jobs API
     job_spec: dict[str, Any] = {
@@ -519,6 +528,9 @@ def _create_job_spec(
     # expose ports through the jobs proxy
     if expose:
         job_spec["expose"] = {"ports": expose}
+    # make the job container reachable over SSH
+    if ssh:
+        job_spec["ssh"] = {"enabled": True}
     # input is either from docker hub or from HF spaces
     for prefix in (
         "https://huggingface.co/spaces/",

--- a/src/huggingface_hub/cli/_cli_utils.py
+++ b/src/huggingface_hub/cli/_cli_utils.py
@@ -17,6 +17,7 @@ import difflib
 import importlib.metadata
 import os
 import re
+import shlex
 import subprocess
 import sys
 import time
@@ -929,6 +930,41 @@ def make_expand_properties_parser(valid_properties: Sequence[ExpandPropertyT]):
         return [cast(ExpandPropertyT, prop) for prop in properties]
 
     return _parse_expand_properties
+
+
+### SSH
+
+
+SshIdentityFileOpt = Annotated[
+    Path | None,
+    typer.Option("-i", "--identity-file", help="Path to the SSH identity file (forwarded to `ssh -i`)."),
+]
+
+SshDryRunOpt = Annotated[
+    bool,
+    typer.Option("--dry-run", help="Print the SSH command instead of running it."),
+]
+
+
+def exec_ssh(
+    destination: str, *, port: int | None = None, identity_file: Path | None = None, dry_run: bool = False
+) -> None:
+    """Run an interactive `ssh` command to `destination` (`user@host`) and exit with its return code.
+
+    With `dry_run`, print the command instead of running it.
+    """
+    cmd = ["ssh"]
+    if identity_file is not None:
+        cmd += ["-i", str(identity_file)]
+    if port is not None:
+        cmd += ["-p", str(port)]
+    cmd.append(destination)
+    if dry_run:
+        out.text(shlex.join(cmd))
+        return
+    out.text(f"Running `{shlex.join(cmd)}`")
+    result = subprocess.run(cmd)
+    raise typer.Exit(code=result.returncode)
 
 
 ### PyPI VERSION CHECKER

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -63,12 +63,16 @@ Usage:
 
 import multiprocessing
 import multiprocessing.pool
+import shlex
 import shutil
+import subprocess
 import time
 from collections.abc import Callable, Iterable
 from fnmatch import fnmatch
+from pathlib import Path
 from queue import Empty, Queue
 from typing import Annotated, Any, TypeVar
+from urllib.parse import urlsplit
 
 import typer
 
@@ -190,6 +194,14 @@ ExposeOpt = Annotated[
     ),
 ]
 
+SshEnabledOpt = Annotated[
+    bool,
+    typer.Option(
+        "--ssh",
+        help="Make the job's container reachable over SSH. Connect with `hf jobs ssh <job_id>`. Requires an SSH public key registered on https://huggingface.co/settings/keys.",
+    ),
+]
+
 WithOpt = Annotated[
     list[str] | None,
     typer.Option(
@@ -299,6 +311,7 @@ def jobs_run(
     timeout: TimeoutOpt = None,
     detach: DetachOpt = False,
     expose: ExposeOpt = None,
+    ssh: SshEnabledOpt = False,
     namespace: NamespaceOpt = None,
     token: TokenOpt = None,
 ) -> None:
@@ -317,12 +330,15 @@ def jobs_run(
         flavor=flavor,
         timeout=timeout,
         expose=expose,
+        ssh=ssh,
         namespace=namespace,
     )
     out.result("Job started", id=job.id, url=job.url)
     if isinstance(job.status.expose_urls, list):
         urls = "\n".join(f"  {url}" for url in job.status.expose_urls)
         out.hint(f"Exposed ports are reachable at (requires an HF token with read access to the job):\n{urls}")
+    if isinstance(job.status.ssh_url, str):
+        out.hint(f"Use `hf jobs ssh {job.id}` to open an SSH session into the job.")
     if detach:
         job_ref = f"{job.owner.name}/{job.id}"
         out.hint(f"Use `hf jobs logs -f {job_ref}` to stream logs, or `hf jobs inspect {job_ref}` to check status.")
@@ -731,6 +747,60 @@ def jobs_labels(
     out.result("Labels updated", id=job.id)
 
 
+@jobs_cli.command(
+    "ssh",
+    examples=[
+        "hf jobs ssh <job_id>",
+        "hf jobs ssh <job_id> --dry-run",
+        "hf jobs ssh <job_id> -i ~/.ssh/id_ed25519",
+    ],
+)
+def jobs_ssh(
+    job_id: JobIdArg,
+    identity_file: Annotated[
+        Path | None,
+        typer.Option("-i", "--identity-file", help="Path to the SSH identity file (forwarded to `ssh -i`)."),
+    ] = None,
+    dry_run: Annotated[
+        bool,
+        typer.Option("--dry-run", help="Print the SSH command instead of running it."),
+    ] = False,
+    namespace: NamespaceOpt = None,
+    token: TokenOpt = None,
+) -> None:
+    """SSH into a running Job.
+
+    Requires the Job to be started with SSH enabled (`hf jobs run --ssh ...`) and your SSH
+    public key to be registered at https://huggingface.co/settings/keys.
+    """
+    job_id, namespace = _parse_namespace_from_job_id(job_id, namespace)
+    api = get_hf_api(token=token)
+    job = api.inspect_job(job_id=job_id, namespace=namespace)
+    if job.status.ssh_url is None:
+        raise CLIError("SSH is not enabled on this job. Start a job with SSH support using `hf jobs run --ssh ...`.")
+    if job.status.stage == "SCHEDULING":
+        status = out.status("Waiting for the job to start...")
+        while job.status.stage == "SCHEDULING":
+            time.sleep(1)
+            job = api.inspect_job(job_id=job_id, namespace=namespace)
+        status.done(f"Job is {job.status.stage}")
+    if job.status.stage != "RUNNING":
+        raise CLIError(f"Cannot SSH into job '{job.id}': job is not running (stage: '{job.status.stage}').")
+    ssh_url = urlsplit(job.status.ssh_url)
+    cmd = ["ssh"]
+    if identity_file is not None:
+        cmd += ["-i", str(identity_file)]
+    if ssh_url.port is not None:
+        cmd += ["-p", str(ssh_url.port)]
+    cmd.append(f"{ssh_url.username}@{ssh_url.hostname}")
+    if dry_run:
+        out.text(shlex.join(cmd))
+        return
+    out.text(f"Running `{shlex.join(cmd)}`")
+    result = subprocess.run(cmd)
+    raise typer.Exit(code=result.returncode)
+
+
 uv_app = typer_factory(help="Run UV scripts (Python with inline dependencies) on HF infrastructure.")
 jobs_cli.add_typer(uv_app, name="uv")
 
@@ -760,6 +830,7 @@ def jobs_uv_run(
     timeout: TimeoutOpt = None,
     detach: DetachOpt = False,
     expose: ExposeOpt = None,
+    ssh: SshEnabledOpt = False,
     namespace: NamespaceOpt = None,
     token: TokenOpt = None,
     with_: WithOpt = None,
@@ -783,12 +854,15 @@ def jobs_uv_run(
         flavor=flavor,
         timeout=timeout,
         expose=expose,
+        ssh=ssh,
         namespace=namespace,
     )
     out.result("Job started", id=job.id, url=job.url)
     if isinstance(job.status.expose_urls, list):
         urls = "\n".join(f"  {url}" for url in job.status.expose_urls)
         out.hint(f"Exposed ports are reachable at (requires an HF token with read access to the job):\n{urls}")
+    if isinstance(job.status.ssh_url, str):
+        out.hint(f"Use `hf jobs ssh {job.id}` to open an SSH session into the job.")
     if detach:
         job_ref = f"{job.owner.name}/{job.id}"
         out.hint(f"Use `hf jobs logs -f {job_ref}` to stream logs, or `hf jobs inspect {job_ref}` to check status.")

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -778,12 +778,6 @@ def jobs_ssh(
     job = api.inspect_job(job_id=job_id, namespace=namespace)
     if job.status.ssh_url is None:
         raise CLIError("SSH is not enabled on this job. Start a job with SSH support using `hf jobs run --ssh ...`.")
-    if job.status.stage == "SCHEDULING":
-        status = out.status("Waiting for the job to start...")
-        while job.status.stage == "SCHEDULING":
-            time.sleep(1)
-            job = api.inspect_job(job_id=job_id, namespace=namespace)
-        status.done(f"Job is {job.status.stage}")
     if job.status.stage != "RUNNING":
         raise CLIError(f"Cannot SSH into job '{job.id}': job is not running (stage: '{job.status.stage}').")
     ssh_url = urlsplit(job.status.ssh_url)

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -63,13 +63,10 @@ Usage:
 
 import multiprocessing
 import multiprocessing.pool
-import shlex
 import shutil
-import subprocess
 import time
 from collections.abc import Callable, Iterable
 from fnmatch import fnmatch
-from pathlib import Path
 from queue import Empty, Queue
 from typing import Annotated, Any, TypeVar
 from urllib.parse import urlsplit
@@ -88,8 +85,11 @@ from ._cli_utils import (
     SecretsFileOpt,
     SecretsOpt,
     SoftChoice,
+    SshDryRunOpt,
+    SshIdentityFileOpt,
     TokenOpt,
     VolumesOpt,
+    exec_ssh,
     get_hf_api,
     parse_env_map,
     parse_volumes,
@@ -757,14 +757,8 @@ def jobs_labels(
 )
 def jobs_ssh(
     job_id: JobIdArg,
-    identity_file: Annotated[
-        Path | None,
-        typer.Option("-i", "--identity-file", help="Path to the SSH identity file (forwarded to `ssh -i`)."),
-    ] = None,
-    dry_run: Annotated[
-        bool,
-        typer.Option("--dry-run", help="Print the SSH command instead of running it."),
-    ] = False,
+    identity_file: SshIdentityFileOpt = None,
+    dry_run: SshDryRunOpt = False,
     namespace: NamespaceOpt = None,
     token: TokenOpt = None,
 ) -> None:
@@ -781,18 +775,12 @@ def jobs_ssh(
     if job.status.stage != "RUNNING":
         raise CLIError(f"Cannot SSH into job '{job.id}': job is not running (stage: '{job.status.stage}').")
     ssh_url = urlsplit(job.status.ssh_url)
-    cmd = ["ssh"]
-    if identity_file is not None:
-        cmd += ["-i", str(identity_file)]
-    if ssh_url.port is not None:
-        cmd += ["-p", str(ssh_url.port)]
-    cmd.append(f"{ssh_url.username}@{ssh_url.hostname}")
-    if dry_run:
-        out.text(shlex.join(cmd))
-        return
-    out.text(f"Running `{shlex.join(cmd)}`")
-    result = subprocess.run(cmd)
-    raise typer.Exit(code=result.returncode)
+    exec_ssh(
+        f"{ssh_url.username}@{ssh_url.hostname}",
+        port=ssh_url.port,
+        identity_file=identity_file,
+        dry_run=dry_run,
+    )
 
 
 uv_app = typer_factory(help="Run UV scripts (Python with inline dependencies) on HF infrastructure.")

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -338,7 +338,7 @@ def jobs_run(
         urls = "\n".join(f"  {url}" for url in job.status.expose_urls)
         out.hint(f"Exposed ports are reachable at (requires an HF token with read access to the job):\n{urls}")
     if isinstance(job.status.ssh_url, str):
-        out.hint(f"Use `hf jobs ssh {job.id}` to open an SSH session into the job.")
+        out.hint(f"Use `hf jobs ssh {job.owner.name}/{job.id}` to open an SSH session into the job.")
     if detach:
         job_ref = f"{job.owner.name}/{job.id}"
         out.hint(f"Use `hf jobs logs -f {job_ref}` to stream logs, or `hf jobs inspect {job_ref}` to check status.")
@@ -862,7 +862,7 @@ def jobs_uv_run(
         urls = "\n".join(f"  {url}" for url in job.status.expose_urls)
         out.hint(f"Exposed ports are reachable at (requires an HF token with read access to the job):\n{urls}")
     if isinstance(job.status.ssh_url, str):
-        out.hint(f"Use `hf jobs ssh {job.id}` to open an SSH session into the job.")
+        out.hint(f"Use `hf jobs ssh {job.owner.name}/{job.id}` to open an SSH session into the job.")
     if detach:
         job_ref = f"{job.owner.name}/{job.id}"
         out.hint(f"Use `hf jobs logs -f {job_ref}` to stream logs, or `hf jobs inspect {job_ref}` to check status.")

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -63,8 +63,11 @@ from ._cli_utils import (
     SearchOpt,
     SecretsFileOpt,
     SecretsOpt,
+    SshDryRunOpt,
+    SshIdentityFileOpt,
     TokenOpt,
     VolumesOpt,
+    exec_ssh,
     get_hf_api,
     make_expand_properties_parser,
     parse_env_map,
@@ -375,14 +378,8 @@ def dev_mode(
 )
 def spaces_ssh(
     space_id: Annotated[str, typer.Argument(help="The space ID (e.g. `username/repo-name`).")],
-    identity_file: Annotated[
-        Path | None,
-        typer.Option("-i", "--identity-file", help="Path to the SSH identity file (forwarded to `ssh -i`)."),
-    ] = None,
-    dry_run: Annotated[
-        bool,
-        typer.Option("--dry-run", help="Print the SSH command instead of running it."),
-    ] = False,
+    identity_file: SshIdentityFileOpt = None,
+    dry_run: SshDryRunOpt = False,
     auto: Annotated[
         bool,
         typer.Option("--auto", help="Enable Dev Mode without prompting if not already enabled."),
@@ -406,16 +403,7 @@ def spaces_ssh(
         if new_info is None:
             raise CLIError(f"Runtime not available for Space '{space_id}'.")
         info = new_info
-    cmd = ["ssh"]
-    if identity_file is not None:
-        cmd += ["-i", str(identity_file)]
-    cmd.append(f"{info.subdomain}@ssh.hf.space")
-    if dry_run:
-        out.text(shlex.join(cmd))
-        return
-    out.text(f"Running `{shlex.join(cmd)}`")
-    result = subprocess.run(cmd)
-    raise typer.Exit(code=result.returncode)
+    exec_ssh(f"{info.subdomain}@ssh.hf.space", identity_file=identity_file, dry_run=dry_run)
 
 
 @spaces_cli.command(

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -11606,6 +11606,7 @@ class HfApi:
         labels: dict[str, str] | None = None,
         volumes: list[Volume] | None = None,
         expose: list[int] | None = None,
+        ssh: bool = False,
         namespace: str | None = None,
         token: bool | str | None = None,
     ) -> JobInfo:
@@ -11647,6 +11648,12 @@ class HfApi:
                 Container ports to expose through the jobs proxy. Each listed port is reachable
                 on the public jobs domain (e.g. `https://<job_id>--8000.hf.jobs`). Access always
                 requires an HF token with read access to the job's namespace.
+
+            ssh (`bool`, *optional*):
+                If True, the job's container is reachable over SSH at the URL given by `job.status.ssh_url`
+                (e.g. `ssh <job_id>@ssh.hf.jobs`, or `hf jobs ssh <job_id>` from the CLI). Connecting requires
+                write access to the job's namespace and an SSH public key registered on the Hub
+                (https://huggingface.co/settings/keys). Defaults to False.
 
             namespace (`str`, *optional*):
                 The namespace where the Job will be created. Defaults to the current user's namespace.
@@ -11697,6 +11704,7 @@ class HfApi:
             labels=labels,
             volumes=volumes,
             expose=expose,
+            ssh=ssh,
         )
         response = get_session().post(
             f"{self.endpoint}/api/jobs/{namespace}",
@@ -12093,6 +12101,7 @@ class HfApi:
         labels: dict[str, str] | None = None,
         volumes: list[Volume] | None = None,
         expose: list[int] | None = None,
+        ssh: bool = False,
         namespace: str | None = None,
         token: bool | str | None = None,
     ) -> JobInfo:
@@ -12141,6 +12150,12 @@ class HfApi:
                 Container ports to expose through the jobs proxy. Each listed port is reachable
                 on the public jobs domain (e.g. `https://<job_id>--8000.hf.jobs`). Access always
                 requires an HF token with read access to the job's namespace.
+
+            ssh (`bool`, *optional*):
+                If True, the job's container is reachable over SSH at the URL given by `job.status.ssh_url`
+                (e.g. `ssh <job_id>@ssh.hf.jobs`, or `hf jobs ssh <job_id>` from the CLI). Connecting requires
+                write access to the job's namespace and an SSH public key registered on the Hub
+                (https://huggingface.co/settings/keys). Defaults to False.
 
             namespace (`str`, *optional*):
                 The namespace where the Job will be created. Defaults to the current user's namespace.
@@ -12218,6 +12233,7 @@ class HfApi:
             labels=labels,
             volumes=volumes,
             expose=expose,
+            ssh=ssh,
             namespace=namespace,
             token=token,
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2806,6 +2806,7 @@ class TestJobsCommand:
             flavor=None,
             timeout=None,
             expose=None,
+            ssh=False,
             namespace=None,
         )
         api.fetch_job_logs.assert_not_called()
@@ -2832,6 +2833,7 @@ class TestJobsCommand:
             flavor=None,
             timeout=None,
             expose=None,
+            ssh=False,
             namespace=None,
         )
         api.fetch_job_logs.assert_not_called()
@@ -2888,6 +2890,7 @@ class TestJobsCommand:
             flavor=None,
             timeout=None,
             expose=None,
+            ssh=False,
             namespace=None,
         )
         api.fetch_job_logs.assert_not_called()
@@ -2917,6 +2920,7 @@ class TestJobsCommand:
             flavor=None,
             timeout=None,
             expose=None,
+            ssh=False,
             namespace=None,
         )
         api.fetch_job_logs.assert_not_called()
@@ -2944,6 +2948,7 @@ class TestJobsCommand:
             flavor=None,
             timeout=None,
             expose=None,
+            ssh=False,
             namespace=None,
         )
 
@@ -2972,6 +2977,7 @@ class TestJobsCommand:
             flavor=None,
             timeout=None,
             expose=None,
+            ssh=False,
             namespace=None,
         )
         api.fetch_job_logs.assert_not_called()


### PR DESCRIPTION
## Summary

Client-side integration of Jobs SSH (server side: https://github.com/huggingface-internal/moon-landing/pull/18500):

- `ssh: bool = False` parameter on `run_job` / `run_uv_job` → sends `ssh: {"enabled": true}` in the job spec. Not added to scheduled jobs since the server only forwards `ssh` on the direct job-start route.
- `JobStatus.ssh_url` parsed from the API's `sshUrl` (e.g. `ssh://<job_id>@ssh.hf.jobs`).
- CLI: `--ssh` flag on `hf jobs run` and `hf jobs uv run`, plus a new `hf jobs ssh <job_id>` command mirroring `hf spaces ssh` (`--dry-run`, `-i/--identity-file`).
- After starting a job with `--ssh`, a hint suggests `hf jobs ssh <job_id>`.

Similar to `hf spaces ssh`.

> [!NOTE]
> Once https://github.com/huggingface/huggingface_hub/pull/4345 get's merged (i.e. add a `wait_for_job` API), I'll open a follow-up PR to make `hf jobs ssh ...` wait for the Job to be running instead of failing fast.

## Manual test

```bash
$ hf jobs run --ssh --detach --timeout 10m python:3.12 sleep infinity
✓ Job started
  id: 6a2bd1f1871c005b5352ad31
  url: https://huggingface.co/jobs/Wauplin/6a2bd1f1871c005b5352ad31
Hint: Use `hf jobs ssh 6a2bd1f1871c005b5352ad31` to open an SSH session into the job.

$ hf jobs ssh 6a2bd1f1871c005b5352ad31 --dry-run
ssh 6a2bd1f1871c005b5352ad31@ssh.hf.jobs

$ ssh 6a2bd1f1871c005b5352ad31@ssh.hf.jobs 'echo "hello from $(hostname)"'
hello from j-wauplin-6a2bd1f1871c005b5352ad31-e69in0j5-e286a-59hjc
```

Requires your SSH public key to be registered at https://huggingface.co/settings/keys and write access to the job's namespace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Opens interactive shell access to job containers when enabled; access is gated on namespace write permissions and registered SSH keys, but misconfiguration could widen attack surface compared to log-only jobs.
> 
> **Overview**
> Adds **SSH access to HF Jobs** end-to-end: opt-in at job start, endpoint on job status, and a CLI to connect.
> 
> **API & job spec:** `run_job` and `run_uv_job` gain `ssh=False`; when true, the job spec includes `ssh: {"enabled": true}`. `JobStatus` now exposes `ssh_url` from the API’s `sshUrl`.
> 
> **CLI:** `--ssh` on `hf jobs run` and `hf jobs uv run`; new `hf jobs ssh <job_id>` builds and runs `ssh` from `job.status.ssh_url` (with `--dry-run`, `-i/--identity-file`), errors if SSH wasn’t enabled or the job isn’t `RUNNING`, and hints after detach when SSH is on.
> 
> **Docs:** CLI guide, jobs guide, and package reference updated for SSH workflows and access rules (write access + Hub SSH keys).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 592820a373a786b343255ec4b55014041487c500. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->