### PR TITLE
Ignore Windows metadata files in cache scan

### DIFF
--- a/src/huggingface_hub/utils/_cache_manager.py
+++ b/src/huggingface_hub/utils/_cache_manager.py
@@ -33,7 +33,7 @@ logger = logging.get_logger(__name__)
 REPO_TYPE_T = Literal["model", "dataset", "space"]
 
 # List of OS-created helper files that need to be ignored
-FILES_TO_IGNORE = [".DS_Store"]
+FILES_TO_IGNORE = [".DS_Store", "Thumbs.db", "desktop.ini"]
 
 
 @dataclass(frozen=True)
@@ -655,6 +655,8 @@ def scan_cache_dir(cache_dir: str | Path | None = None) -> HFCacheInfo:
     repos: set[CachedRepoInfo] = set()
     warnings: list[CorruptedCacheException] = []
     for repo_path in cache_dir.iterdir():
+        if repo_path.name in FILES_TO_IGNORE:
+            continue
         if repo_path.name == ".locks":  # skip './.locks/' folder
             continue
         if repo_path.name == "CACHEDIR.TAG":  # skip CACHEDIR.TAG file

--- a/tests/test_utils_cache.py
+++ b/tests/test_utils_cache.py
@@ -229,6 +229,31 @@ class TestValidCacheUtils(unittest.TestCase):
 
 
 @pytest.mark.usefixtures("fx_cache_dir")
+class TestIgnoredCacheFiles(unittest.TestCase):
+    cache_dir: Path
+
+    def test_ignore_os_metadata_files_in_cache_structure(self) -> None:
+        repo_path = self.cache_dir / "models--foo--bar"
+        refs_path = repo_path / "refs"
+        snapshots_path = repo_path / "snapshots"
+        revision_path = snapshots_path / "123"
+        revision_path.mkdir(parents=True)
+        refs_path.mkdir()
+        (refs_path / "main").write_text("123")
+
+        ignored_files = [".DS_Store", "Thumbs.db", "desktop.ini"]
+        for filename in ignored_files:
+            (self.cache_dir / filename).touch()
+            (refs_path / filename).touch()
+            (snapshots_path / filename).touch()
+
+        report = scan_cache_dir(self.cache_dir)
+
+        self.assertEqual(len(report.warnings), 0)
+        self.assertEqual(len(report.repos), 1)
+
+
+@pytest.mark.usefixtures("fx_cache_dir")
 class TestCorruptedCacheUtils(unittest.TestCase):
     cache_dir: Path
     repo_path: Path


### PR DESCRIPTION
## What this changes

This is a smaller follow-up to the cache diagnostics discussion in #4347.

The cache scanner already ignores `.DS_Store` in some structural cache directories. This PR extends that behavior to common Windows metadata files and also applies the ignore list at the cache root, where OS-created files can otherwise be reported as corrupted cache entries.

Ignored structural metadata files:

- `.DS_Store`
- `Thumbs.db`
- `desktop.ini`

## Why

These files can be created by the OS or file explorer and are not part of the Hugging Face cache layout. Reporting them as cache corruption creates noisy warnings even though no cached repo data is broken.

This keeps the fix intentionally small: it does not add a new repair command, and it does not try to handle broader cache corruption cases such as broken symlinks or interrupted downloads.

## Tests

- Added a no-network regression test covering ignored metadata files at the cache root, `refs`, and `snapshots` levels.
- `python -m pytest tests\test_utils_cache.py::TestIgnoredCacheFiles -q`
- `python -m ruff check src\huggingface_hub\utils\_cache_manager.py tests\test_utils_cache.py`
- `python -m py_compile src\huggingface_hub\utils\_cache_manager.py tests\test_utils_cache.py`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to cache scan filtering and diagnostics only; no download, auth, or cache deletion behavior.
> 
> **Overview**
> Extends cache scanning so **OS metadata files** (`.DS_Store`, `Thumbs.db`, `desktop.ini`) are skipped instead of treated as invalid cache layout.
> 
> `FILES_TO_IGNORE` gains the two Windows names and is now applied when iterating the **cache root** in `scan_cache_dir`, in addition to existing skips under `refs` and `snapshots`. That stops root-level metadata from surfacing as corrupted-cache warnings.
> 
> Adds a no-network test (`TestIgnoredCacheFiles`) that places those files at the cache root, `refs`, and `snapshots` and asserts a clean scan with one valid repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9bf63b6df4dd8535947874ec377fe74332bac79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->