### PR TITLE
Polish migration and collection API wording

### DIFF
--- a/docs/source/en/concepts/migration.md
+++ b/docs/source/en/concepts/migration.md
@@ -86,7 +86,7 @@ Some methods and parameters have been removed in v1.0. The ones listed below hav
 
 ## CLI cache commands
 
-Cache management from the CLI has been redesigned to follow a Docker-inspired workflow. The deprecated `huggingface-cli` has been removed, `hf` (introduced in v0.34) replaces it with a clearer ressource-action CLI. 
+Cache management from the CLI has been redesigned to follow a Docker-inspired workflow. The deprecated `huggingface-cli` has been removed, `hf` (introduced in v0.34) replaces it with a clearer resource-action CLI.
 The legacy `hf cache scan` and `hf cache delete` commands are also removed in v1.0 and are replaced with the new trio below:
 
 - `hf cache ls` lists cache entries with concise table, JSON, or CSV output. Use `--revisions` to inspect individual revisions, add `--filter` expressions such as `size>1GB` or `accessed>30d`, and combine them with `--quiet` when you only need the identifiers.

--- a/src/huggingface_hub/cli/download.py
+++ b/src/huggingface_hub/cli/download.py
@@ -184,9 +184,9 @@ def download(
         # Warn user if patterns are ignored (only if regular filenames are provided)
         if len(regular_filenames) > 0:
             if include is not None and len(include) > 0:
-                warnings.warn("Ignoring `--include` since filenames have being explicitly set.")
+                warnings.warn("Ignoring `--include` since filenames have been explicitly set.")
             if exclude is not None and len(exclude) > 0:
-                warnings.warn("Ignoring `--exclude` since filenames have being explicitly set.")
+                warnings.warn("Ignoring `--exclude` since filenames have been explicitly set.")
 
         # Single file to download (not a subfolder): use `hf_hub_download`
         if len(regular_filenames) == 1 and len(subfolder_patterns) == 0:

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -4580,7 +4580,7 @@ class HfApi:
                 # Since https://github.com/huggingface/moon-landing/pull/7272 (private repo), it is not possible to
                 # concurrently create repos on the Hub for a same user. This is rarely an issue, except when running
                 # tests. To avoid any inconvenience, we retry to create the repo for this specific error.
-                # NOTE: This could have being fixed directly in the tests but adding it here should fixed CIs for all
+                # NOTE: This could have been fixed directly in the tests, but adding it here should fix CIs for all
                 # dependent libraries.
                 # NOTE: If a fix is implemented server-side, we should be able to remove this retry mechanism.
                 logger.debug("Create repo failed due to a concurrency issue. Retrying...")
@@ -9907,7 +9907,7 @@ class HfApi:
             collection_slug (`str`):
                 Slug of the collection to delete. Example: `"TheBloke/recent-models-64f9a55bb3115b4f513ec026"`.
             missing_ok (`bool`, *optional*):
-                If `True`, do not raise an error if collection doesn't exists.
+                If `True`, do not raise an error if the collection doesn't exist.
             token (`bool` or `str`, *optional*):
                 A valid user access token (string). Defaults to the locally saved
                 token, which is the recommended method for authentication (see
@@ -9931,7 +9931,7 @@ class HfApi:
             hf_raise_for_status(r)
         except HfHubHTTPError as err:
             if missing_ok and err.response.status_code == 404:
-                # Collection doesn't exists and `missing_ok=True`
+                # Collection doesn't exist and `missing_ok=True`
                 return
             else:
                 raise
@@ -10090,7 +10090,7 @@ class HfApi:
                 ID of the item in the collection. This is not the id of the item on the Hub (repo_id or paper id).
                 It must be retrieved from a [`CollectionItem`] object. Example: `collection.items[0].item_object_id`.
             missing_ok (`bool`, *optional*):
-                If `True`, do not raise an error if item doesn't exists.
+                If `True`, do not raise an error if the item doesn't exist.
             token (`bool` or `str`, *optional*):
                 A valid user access token (string). Defaults to the locally saved
                 token, which is the recommended method for authentication (see

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1111,7 +1111,11 @@ class TestDownloadImpl:
                 force_download=True,
             )
         print_mock.assert_called_once_with("folder-path")
-        assert any("Ignoring" in str(w.message) for w in caught)
+        warning_messages = [str(w.message) for w in caught]
+        assert warning_messages == [
+            "Ignoring `--include` since filenames have been explicitly set.",
+            "Ignoring `--exclude` since filenames have been explicitly set.",
+        ]
         mock_download.assert_not_called()
         mock_snapshot.assert_called_once_with(
             repo_id="author/model",


### PR DESCRIPTION
## Summary
- fix the `hf` migration note to describe the resource-action CLI wording correctly
- clean up a few collection API comments and parameter descriptions in `hf_api.py`

## Why
These are small wording issues, but they show up in migration guidance and public API docs where precise language helps avoid confusion.

## Validation
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String and documentation-only changes with no API or runtime logic modifications beyond corrected user-facing warning text.
> 
> **Overview**
> **Documentation and copy edits** only—no behavior changes except the exact strings emitted by `hf download` when `--include`/`--exclude` are ignored alongside explicit filenames.
> 
> The v1.0 **migration guide** now says **resource-action** (was `ressource-action`) when describing the `hf` CLI.
> 
> **`hf download`** warning messages use correct grammar: *"filenames have **been** explicitly set"* instead of *"have being"*.
> 
> **`HfApi`** docstrings and inline comments for collections are cleaned up (`doesn't exist`, create-repo retry note grammar). **`test_download_with_ignored_patterns`** now asserts the full ordered list of warning messages instead of a loose `"Ignoring"` substring check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b04589facaad2623c81a620f11b0fa82924ba04e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->