### PR TITLE
Retry reads on 408 (request time-out)

### DIFF
--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -1191,7 +1191,17 @@ class HfFileSystemFile(fsspec.spec.AbstractBufferedFile):
             **self.fs._api._build_hf_headers(),
         }
         url = self.url()
-        r = http_backoff("GET", url, headers=headers, timeout=constants.HF_HUB_DOWNLOAD_TIMEOUT)
+        r = http_backoff(
+            "GET",
+            url,
+            headers=headers,
+            timeout=constants.HF_HUB_DOWNLOAD_TIMEOUT,
+            # 408 is added to the default retried statuses: under concurrent range reads the Hub's
+            # load balancer (in front of the CDN) can intermittently return "408 Request Time-out"
+            # before the request reaches the backend. It is transient and safe to repeat per
+            # RFC 7231 §6.5.7, and recovers on the next (fresh-connection) attempt.
+            retry_on_status_codes=(408, 429, 500, 502, 503, 504),
+        )
         hf_raise_for_status(r)
         return r.content
 

--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -1196,10 +1196,10 @@ class HfFileSystemFile(fsspec.spec.AbstractBufferedFile):
             url,
             headers=headers,
             timeout=constants.HF_HUB_DOWNLOAD_TIMEOUT,
-            # 408 is added to the default retried statuses: under concurrent range reads the Hub's
-            # load balancer (in front of the CDN) can intermittently return "408 Request Time-out"
-            # before the request reaches the backend. It is transient and safe to repeat per
-            # RFC 7231 §6.5.7, and recovers on the next (fresh-connection) attempt.
+            # (429, 500, 502, 503, 504) are the http_backoff defaults, restated here because
+            # passing retry_on_status_codes replaces the default set. 408 is the addition: under
+            # concurrent range reads the Hub's load balancer can return a transient "408 Request
+            # Time-out" that is safe to repeat (RFC 7231 §6.5.7) and recovers on retry.
             retry_on_status_codes=(408, 429, 500, 502, 503, 504),
         )
         hf_raise_for_status(r)

--- a/tests/test_hf_file_system.py
+++ b/tests/test_hf_file_system.py
@@ -932,13 +932,12 @@ def test_hf_file_system_file_can_handle_gzipped_file():
 
 def test_fetch_range_retries_on_request_timeout():
     """`_fetch_range` should opt into retrying 408 Request Time-out.
-
-    Under concurrent range reads the Hub's load balancer (in front of the CDN) can
+    
+    With concurrent range reads the Hub's load balancer (in front of the CDN) can
     intermittently return a transient 408 before the request reaches the backend. It is
     safe to repeat (RFC 7231 §6.5.7) and recovers on a fresh connection, so range reads
     must pass 408 to `http_backoff`'s retried statuses (it is not in the default set).
     """
-    # Build a file object without hitting the network (skip __init__ / resolve_path).
     file = HfFileSystemFile.__new__(HfFileSystemFile)
     file.fs = Mock()
     file.fs._api._build_hf_headers.return_value = {}

--- a/tests/test_hf_file_system.py
+++ b/tests/test_hf_file_system.py
@@ -928,3 +928,29 @@ def test_hf_file_system_file_can_handle_gzipped_file():
     with fs.open("datasets/allenai/math_qa/math_qa.py", "r", encoding="utf-8") as f:
         out = f.read()
     assert "class MathQa" in out
+
+
+def test_fetch_range_retries_on_request_timeout():
+    """`_fetch_range` should opt into retrying 408 Request Time-out.
+
+    Under concurrent range reads the Hub's load balancer (in front of the CDN) can
+    intermittently return a transient 408 before the request reaches the backend. It is
+    safe to repeat (RFC 7231 §6.5.7) and recovers on a fresh connection, so range reads
+    must pass 408 to `http_backoff`'s retried statuses (it is not in the default set).
+    """
+    # Build a file object without hitting the network (skip __init__ / resolve_path).
+    file = HfFileSystemFile.__new__(HfFileSystemFile)
+    file.fs = Mock()
+    file.fs._api._build_hf_headers.return_value = {}
+    file.url = Mock(return_value="https://huggingface.co/datasets/foo/resolve/main/data.parquet")
+
+    response = Mock(content=b"data")
+    with (
+        patch.object(hf_file_system, "http_backoff", return_value=response) as mock_http_backoff,
+        patch.object(hf_file_system, "hf_raise_for_status"),
+    ):
+        out = file._fetch_range(0, 4)
+
+    assert out == b"data"
+    mock_http_backoff.assert_called_once()
+    assert 408 in mock_http_backoff.call_args.kwargs["retry_on_status_codes"]


### PR DESCRIPTION
## What does this PR do?

When you stream a dataset from the Hub, the library reads files in small pieces ("range reads"). Sometimes one of those reads comes back with a **`408 Request Time-out`** error, and right now that error makes the whole read fail.

The official HTTP spec says it's safe to simply try again. So this PR tells the range-read code to **retry on 408**, the same way it already retries on other temporary errors (429, 500, 502, 503, 504).

## Why is this needed?

While streaming a large dataset with `datasets` (`streaming=True`), I kept hitting random 408 errors. 

- **It only happens under load.** With ~24 readers running at once, about 3 of them hit a 408 within 20 minutes. A single reader almost never does.
- **It fixes itself on retry.** Every single 408 I saw succeeded the moment it was retried.

## How was it tested?

- **Added a unit test** that checks `_fetch_range` is set up to retry on 408.
- **Reproduced the original problem** by streaming `allenai/MolmoAct2-BimanualYAM-Dataset` with many readers at once., with the fix, the 408 recover.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to buffered range-read retries; only extends backoff to a status code considered safe to repeat, with a focused unit test.
> 
> **Overview**
> **Hub file streaming** no longer fails on transient **408 Request Time-out** during byte-range fetches. `HfFileSystemFile._fetch_range` now passes an explicit `retry_on_status_codes` tuple to `http_backoff` that keeps the usual retriable server/rate-limit codes and **adds 408**, which can appear under concurrent range reads at the load balancer.
> 
> A unit test asserts `_fetch_range` includes **408** in `retry_on_status_codes` when calling `http_backoff`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c09b293de36fdfdeefaa19c8ef468cdcf02eeff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->