### PR TITLE
[HTTP] Retry on HTTP 408 Request Timeout by default

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -375,7 +375,7 @@ def http_get(
         headers=headers,
         timeout=constants.HF_HUB_DOWNLOAD_TIMEOUT,
         retry_on_exceptions=(),
-        retry_on_status_codes=(429,),
+        retry_on_status_codes=(408, 429),
     ) as response:
         hf_raise_for_status(response)
 

--- a/src/huggingface_hub/utils/_http.py
+++ b/src/huggingface_hub/utils/_http.py
@@ -391,7 +391,7 @@ if hasattr(os, "register_at_fork"):
 
 
 _DEFAULT_RETRY_ON_EXCEPTIONS: tuple[type[Exception], ...] = (httpx.TimeoutException, httpx.NetworkError)
-_DEFAULT_RETRY_ON_STATUS_CODES: tuple[int, ...] = (429, 500, 502, 503, 504)
+_DEFAULT_RETRY_ON_STATUS_CODES: tuple[int, ...] = (408, 429, 500, 502, 503, 504)
 
 
 def _http_backoff_base(


### PR DESCRIPTION
### Context: https://huggingface.slack.com/archives/C087TU2FE3G/p1781284549155409

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Added HTTP 408 (Request Timeout) to `_DEFAULT_RETRY_ON_STATUS_CODES` in `src/huggingface_hub/utils/_http.py`, so all callers of `http_backoff` / `http_stream_backoff` automatically retry on server-side request timeouts.
- Also added 408 to the explicit `retry_on_status_codes` override in `http_get` (`file_download.py`), which previously only retried on 429.

### What this covers

HTTP 408 is a server-side "Request Timeout" — the server timed out waiting for the request to complete. This is a transient condition and safe to retry. By adding it to the default retryable status codes, the following paths now retry on 408:

- **`HfFileSystem._fetch_range`** — range-based reads via `http_backoff`
- **`HfFileSystem._open_connection`** — streaming reads via `http_stream_backoff`
- **`http_get`** (file downloads) — via explicit `retry_on_status_codes=(408, 429)`
- **LFS uploads** (`lfs.py`)
- **Paginated API responses** (`_pagination.py`)
- **Metadata HEAD requests** (`get_hf_file_metadata` with `retry_on_errors=True`)
- **`hf_hub_download` metadata retry** — references `_DEFAULT_RETRY_ON_STATUS_CODES` directly
- All other callers of `http_backoff` / `http_stream_backoff` that use defaults

### Rationale

Unlike client-side timeouts (already retried via `httpx.TimeoutException`), HTTP 408 is a status code returned by the server or an intermediate proxy indicating the request timed out server-side. These are inherently transient and retrying is the correct behavior, consistent with how 429 and 5xx errors are already handled.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://huggingface.slack.com/archives/D0A9313SS3G/p1781513824690519?thread_ts=1781513824.690519&cid=D0A9313SS3G)

<div><a href="https://cursor.com/agents/bc-b3b048df-c5ec-5ae3-adc8-e95f4e3666e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3b048df-c5ec-5ae3-adc8-e95f4e3666e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

