### PR TITLE
[Benchmark] snapshot_download HTTP call-count

### DIFF
--- a/bench-download-calls/00-methodology.md
+++ b/bench-download-calls/00-methodology.md
@@ -1,0 +1,49 @@
+# Methodology — snapshot_download HTTP call benchmark
+
+**Dates**: 2026-06-12 (small repo) · 2026-06-13 (large repo) · **Base**: `huggingface_hub` 1.20.0.dev0 (main @ `ca9284561`) · **hf-xet**: 1.4.3 · **Python**: 3.10
+
+## Two test repositories
+
+Every variant is benchmarked on **two repos of identical shape but 10× different size**. The second one deliberately crosses `LARGE_REPO_THRESHOLD = 1000`, which changes the client's behavior (see reports).
+
+### Small — [`Wauplin/snapshot-download-bench`](https://huggingface.co/Wauplin/snapshot-download-bench) — 201 files (~105 MB)
+
+- 100 regular text files (`file_000.txt` …), each a unique UUID (~37 B), stored in git.
+- 100 binary files (`bin_000.bin` …), each 1 MiB of unique random bytes, stored as LFS/Xet (all have a `xetHash`).
+- +1 `.gitattributes`.
+- Tag **`v1`** = commit `668054422…` (all 200 files in one commit).
+- PR **`refs/pr/1`** = commit `89f58185d…` updating 50 text + 50 binary files in place (100 differ from v1, 100 identical).
+- Validation per run: **201 files, 104,862,819 bytes**.
+
+### Large — [`Wauplin/snapshot-download-bench-2k`](https://huggingface.co/Wauplin/snapshot-download-bench-2k) — 2001 files (~1.05 GB)
+
+- 1000 regular text files + 1000 binary (1 MiB) xet files + `.gitattributes`.
+- Tag **`v1`** = commit `389cf1edd…`; PR **`refs/pr/1`** = commit `b1254dd11…` updating 500 text + 500 binary in place.
+- Validation per run: **2001 files, 1,048,614,519 bytes**.
+
+## Measurement
+
+All Python HTTP traffic is routed through a local mitmproxy that logs every request (method, host, path, status, redirect). Per the agreed scope, **only Python-side calls are measured**: hf_xet's data-plane traffic (CAS reconstructions, CDN xorb ranges) bypasses the proxy via `NO_PROXY=.xethub.hf.co,.cdn.hf.co` and is not counted.
+
+One exception is shown in the tables: `GET /api/models/…/xet-read-token/{rev}` is issued by hf_xet but **lands on huggingface.co**. It is reported on its own line (and excluded from "excl. token" totals) so both views are available.
+
+## Protocol (identical for every variant, both repos)
+
+Fresh empty cache directory per variant, then 4 sequential runs against it:
+
+1. **run1** — `snapshot_download(repo, revision="v1")` (cold cache)
+2. **run2** — same call again (warm)
+3. **run3** — `snapshot_download(repo, revision="refs/pr/1")` (half the files new, half reusable from v1)
+4. **run4** — same call again (warm)
+
+Content was additionally spot-checked by sha256 (xet files) and git-sha1 (pack-fetched files) in smoke tests.
+
+Variants are run from git worktrees via `PYTHONPATH` override:
+
+- **A** = `main` (baseline)
+- **B** = PR [#4348](https://github.com/huggingface/huggingface_hub/pull/4348) (`reuse-tree-data-in-snapshot`); on the small repo also run with its `LARGE_REPO_THRESHOLD` gate lowered ("B-forced") since the gate otherwise keeps it inert below 1000 files
+- **C** = branch [`bench-c-tree-cache`](https://github.com/huggingface/huggingface_hub/tree/bench-c-tree-cache)
+- **D** = branch [`bench-d-min-calls`](https://github.com/huggingface/huggingface_hub/tree/bench-d-min-calls)
+- **E** = branch [`bench-e-no-git`](https://github.com/huggingface/huggingface_hub/tree/bench-e-no-git) (added after review: same goal as D but without git endpoints)
+
+Harness & raw captures: `~/projects/hub-download-bench/` — `scripts/` (parametrized via `BENCH_REPO`/`BENCH_N`/`BENCH_N_UPDATED`; `run_all_2k.sh` driver), `captures/<variant>[-2k]/run*.jsonl`.

--- a/bench-download-calls/combined-report.md
+++ b/bench-download-calls/combined-report.md
@@ -1,0 +1,79 @@
+# snapshot_download HTTP call count — combined results
+
+Scope: Python-side calls to huggingface.co only (hf_xet CAS/CDN data-plane excluded by agreement). Two repos of identical shape, 10× apart in size, each with tag `v1` and a PR updating half the files in place (see `00-methodology.md`):
+
+- **Small** — 201 files (100 git-text + 100 xet-LFS + .gitattributes), PR updates 50+50.
+- **Large** — 2001 files (1000 + 1000 + .gitattributes), PR updates 500+500. Crosses `LARGE_REPO_THRESHOLD = 1000`.
+
+## Headline numbers (every run downloads/validates all files)
+
+**Total calls to huggingface.co** (incl. the hf_xet-issued `xet-read-token`):
+
+### Small repo (201 files)
+
+| Run | A `main` | B #4348 as-is | B forced* | C tree-cache | E no-git** | D git-pack |
+|---|---|---|---|---|---|---|
+| 1. v1 cold | 504 | 504 | 304 | 304 | 104 | **4** |
+| 2. v1 warm | 1 | 1 | 2 | **1** | **1** | **1** |
+| 3. PR cold (50+50 changed) | 403 | 403 | 152 | 152 | 53 | **4** |
+| 4. PR warm | 1 | 1 | 2 | **1** | **1** | **1** |
+
+### Large repo (2001 files)
+
+| Run | A `main` | B #4348 | C tree-cache | E no-git | D git-pack |
+|---|---|---|---|---|---|
+| 1. v1 cold | 5007 | 3006 | 3006 | 1006 | **6** |
+| 2. v1 warm | 4 | 4 | **1** | **1** | **1** |
+| 3. PR cold (500+500 changed) | 4006 | 1504 | 1504 | 505 | **6** |
+| 4. PR warm | 4 | 4 | **1** | **1** | **1** |
+
+**Excluding `xet-read-token`** (per agreed scope), cold runs:
+
+| | A | B (active) | C | E | D |
+|---|---|---|---|---|---|
+| small v1 cold | 404 | 204 | 204 | 103 | **3** |
+| small PR cold | 353 | 102 | 102 | 52 | **3** |
+| large v1 cold | 4007 | 2006 | 2006 | 1005 | **5** |
+| large PR cold | 3506 | 1004 | 1004 | 504 | **5** |
+
+\* On the small repo B's tree path is inert (201 ≤ 1000 siblings) so it equals main; "forced" = gate lowered to show its potential. On the large repo it activates automatically (no forcing).
+\** E added after review feedback: same goal as D but restricted to regular HTTP endpoints (no git protocol).
+
+## Where the calls go (cold v1)
+
+| Call | A | B / C | E | D |
+|---|---|---|---|---|
+| `GET /api/models/{repo}/revision/{rev}` (ref→sha) | 1 / 1 | 1 / 1 | 1 / 1 | 1 / 1 |
+| `GET /api/models/{repo}/tree/{sha}` (paginated `ceil(N/1000)`) | 0 / 3 | 1 / 3 | 1 / 3 | 1 / 3 |
+| `HEAD /resolve` → 307 + follow-up (regular) | 202 / 2002 | 0 | 0 | 0 |
+| `HEAD /resolve` → 302 (xet) | 100 / 1000 | 0 | 0 | 0 |
+| `GET` content, regular (307→resolve-cache, or direct) | 101 / 1001 † | 202 / 2002 | **101 / 1001** | 0 |
+| `POST /{repo}.git/git-upload-pack` (all regular blobs, 1 pack) | – | – | – | 1 / 1 |
+| `GET /api/…/xet-read-token` (hf_xet) | 100 / 1000 | 100 / 1000 | **1 / 1** | **1 / 1** |
+
+Cells show `small / large`. On the small repo, main uses `siblings` (no tree call); above 1000 files it lists the tree like everyone else.
+† On main the content GET goes straight to the resolve-cache URL learned from the preceding HEAD redirect (1 GET); without that HEAD (B/C) each GET pays its own 307 (2 GETs). Net effect identical.
+
+## Key findings
+
+1. **Main's cost is ~2.5 hub calls per file, linear in repo size, even when nothing changed.** Confirmed across 10× (504→5007 cold). In the PR-update runs the *unchanged* half still costs ~2 calls each: per-file HEAD metadata is fetched before the cache can declare a hit.
+2. **The per-file HEAD is fully redundant with `/tree`.** etag (`lfs.sha256` | `blob_id`), size, and `xetHash` from the tree listing are byte-identical to what `/resolve` HEAD returns (verified against live responses and resulting `blobs/` layout). PR #4348 got this right.
+3. **PR #4348 only helps above 1000 files, and re-lists the tree on every call.** Below the threshold it is inert (identical to main); above it, cold drops 5007→3006 (−40%) — but warm runs still pay the (now paginated, 3-page) listing: **4 calls** where they should be 1.
+4. **A commit's tree is immutable → cache it on disk (Test C).** `trees/<commit>.json` makes warm runs **1 call at any size** (vs B's 2 small / 4 large), removes the threshold heuristic (same path everywhere), and gives `allow_patterns` filtering + future snapshot-completeness checks for free. C equals B on cold; its entire edge is the disk cache.
+5. **Tree pagination is the only O(N) term left for C/D/E** — `ceil(N_files/1000)` calls (3 at 2001 files) — but they pay it **once per commit** (cached); A and B pay it on **every** call.
+6. **`xet-read-token` is fetched once per FILE, not per session** (hf_xet creates one download group per file). 100/1000 hub calls per cold run in A/B/C. Declared ignorable for counting, but it's the single biggest remaining hub-call source after C — trivially fixed by batching all files into one download group (D/E do this: 1 call).
+7. **Without git endpoints, the floor is `revision + ceil(N/1000) tree + files-to-download + 1 token`** (Test E: small 104, large 1006). The public-repo `/resolve` 307 target (`/api/resolve-cache/{type}s/{repo}/{commit}/{file}?…&etag=…`) is deterministic from tree data, so the redirect hop is skipped — every download a single clean 200. Caveat: resolve-cache is an internal route; shipping needs the server to bless it (or return the direct URL in `/tree`/`paths-info`), with `/resolve` as fallback.
+8. **O(1) cold downloads are possible with today's server (Test D: small 4, large 6):** git smart-HTTP v2 accepts arbitrary blob `want`s → all regular files in one POST (sha1-verified pack, ~200-line parser, graceful fallback); one xet download group → one token; `/tree` without `expand` returns everything at 1000/page (`expand=true` silently drops the page to 50 — avoid). The only growth with size is tree pages.
+9. **Server-side observations** for the rate-limit discussion:
+   - the public-repo `307 → /api/resolve-cache` redirect doubles every regular-file HEAD/GET — a client calling `/resolve` n times generates 2n requests;
+   - `POST /api/{type}s/{repo}/paths-info/{rev}` (2000 paths/call, returns oid/size/lfs/xetHash) is the natural batch-metadata endpoint for partial downloads — unused by the library today;
+   - no batch endpoint exists for *content* of small files; D works around it via git-upload-pack (heavier per request for gitaly, but replaces hundreds/thousands of requests). A sanctioned batch-content endpoint would remove that trade-off.
+
+## Recommendations
+
+1. **Short term**: land C's approach — always-on tree listing at the pinned commit + `trees/` disk cache + per-file HEAD skip. Moderate, self-contained diff; biggest win per unit of risk. PR #4348 is a step toward it — un-gate it (the 2k run shows it only acts above 1000 files), list at `repo_info.sha`, add the disk cache, fix the warm-run re-listing.
+2. **Short term (hub load)**: batch xet downloads into one group per `snapshot_download` (or fix token caching across groups in hf_xet) — eliminates ~1 hub call per LFS file (1000 → 1 on the large repo).
+3. **Short/medium term (no git)**: bless direct resolve-cache downloads (Test E) — same server load as today's redirected traffic, halves regular-file requests. Cleanest form: have `/tree`/`paths-info` return the direct download URL so clients don't hardcode the route.
+4. **Medium term**: decide whether git-upload-pack blob fetch is a sanctioned client path; if not, consider a batch content endpoint. Either turns cold snapshots into O(1) hub calls.
+5. **Before merging C/D/E**: make `snapshot_download` degrade gracefully when a download fails after metadata prefetch (3 offline-simulation tests currently fail on a split-brain scenario: API reachable, downloads not), and fix per-file progress reporting for prefetched files.
+6. **Rate-limit design**: identical user work costs 4–5007 hub calls depending on client version/path. Raw request counts are a poor billing unit for downloads; weight by route class (metadata vs resolve vs git), and expect `/resolve` volumes to fall sharply as tree-based clients roll out. Note the scale trap: above 1000 files even today's *no-op* warm re-pull costs 4 calls (uncached paginated listing).

--- a/bench-download-calls/executive-summary.md
+++ b/bench-download-calls/executive-summary.md
@@ -1,0 +1,27 @@
+# Executive summary — what does `snapshot_download` really cost the Hub?
+
+**Setup.** Two controlled repos — a 201-file (100 git + 100 xet/LFS) and a 2001-file (1000 + 1000) — with every HTTP call from the Python client to huggingface.co measured via an intercepting proxy, across 4 scenarios each: cold download, warm re-run, download of a PR updating half the files, warm re-run. Five client variants compared. hf_xet's data-plane (CAS/CDN) is excluded — it doesn't touch hub rate limits.
+
+**Today (v1.20 main): a cold snapshot costs ~2.5 calls to huggingface.co per file** — 504 calls for 201 files, 5007 for 2001. The cost scales with file count, not changed bytes: each file pays a HEAD metadata round-trip (doubled by the public-repo resolve-cache redirect) even when it's already cached, so re-downloading a PR where half the files are unchanged barely helps (403 / 4006).
+
+**Almost all of this is avoidable without any server change**, because one `/tree` API call already returns every file's etag, size and xet hash, and a commit's tree is immutable so it can be cached on disk forever. The same five variants on both repos (cold / warm / PR-cold / PR-warm):
+
+| Variant | 201-file repo | 2001-file repo |
+|---|---|---|
+| A. main (baseline) | 504 / 1 / 403 / 1 | 5007 / 4 / 4006 / 4 |
+| B. community PR #4348 | 504 / 1 / 403 / 1 *(inert ≤1000 files)* | 3006 / 4 / 1504 / 4 |
+| C. tree listing + on-disk cache, no per-file HEAD | 304 / 1 / 152 / 1 | 3006 / **1** / 1504 / **1** |
+| E. C + redirect-free downloads + 1 xet token (plain HTTP) | 104 / 1 / 53 / 1 | 1006 / 1 / 505 / 1 |
+| D. C + batched content fetches (git protocol) | **4 / 1 / 4 / 1** | **6 / 1 / 6 / 1** |
+
+**C is the recommended short-term change** (moderate diff, caches stay compatible): always list the tree once per commit, cache it under the existing layout (`trees/`), skip every per-file HEAD. PR #4348 validates the same idea but **only activates above 1000 files** and re-fetches the listing on every call — including warm ones. The 2001-file column makes both gaps visible: B and C are identical on cold, but C's cache keeps warm pulls at 1 call where B (and main) cost 4.
+
+**A scale trap worth flagging on its own**: above 1000 files, today's client lists the repo tree on *every* call without caching it, so even a **no-op warm re-pull costs 4 calls** (a paginated 3-page listing). C removes this; it is invisible below 1000 files.
+
+**E is the floor using only regular HTTP endpoints (−79% to −80% cold)**: every public-repo download today pays a systematic 307 redirect to an internal resolve-cache URL the client can build itself from tree data — so each file costs one clean 200. It also fixes a hidden hub load: **hf_xet requests a read token per file** (100/1000 calls per cold run in A–C); batching all files into one xet download group reduces that to 1. Needs the server to bless the resolve-cache route (or return direct URLs in the tree listing).
+
+**D shows the absolute floor with today's server: a full snapshot in 4–6 calls (−99%+) regardless of size** — ref resolution, tree listing, one git-protocol POST fetching all small files as a verified pack, one xet token. The git-protocol fetch trades many cheap requests for one heavier one — a deliberate call (sanction it, or add a batch-content endpoint to get D's numbers with E's cleanliness).
+
+**Rate-limit implication.** Identical user work costs anywhere from 4 to 5007 requests depending on client version and path. Raw request counts are therefore a poor billing unit for downloads; weight by route class (metadata vs resolve vs git), and expect headline `/resolve` volumes to drop dramatically as tree-based clients roll out.
+
+Branches `bench-c-tree-cache`, `bench-d-min-calls` and `bench-e-no-git` pushed (no PRs). Full details in `combined-report.md`, the per-test reports (each now covering both repos), and `00-methodology.md`.

--- a/bench-download-calls/test-A-main.md
+++ b/bench-download-calls/test-A-main.md
@@ -1,0 +1,47 @@
+# Test A — baseline (`main`)
+
+Totals (cold-v1 / warm / PR-cold / warm): **small repo 504 / 1 / 403 / 1** · **large repo 5007 / 4 / 4006 / 4**.
+
+## Small repo (201 files)
+
+### run1 — v1 cold: 504 calls
+
+| # | Method | Status | Endpoint |
+|---|--------|--------|----------|
+| 1 | GET | 200 | `/api/models/{repo}/revision/v1` (repo_info) |
+| 101 | HEAD | 307 | `/{repo}/resolve/{sha}/{file}` (regular files + .gitattributes) |
+| 101 | HEAD | 200 | `/api/resolve-cache/models/{repo}/{sha}/{file}` (redirect follow-up) |
+| 101 | GET | 200 | `/api/resolve-cache/models/{repo}/{sha}/{file}` (content) |
+| 100 | HEAD | 302 | `/{repo}/resolve/{sha}/{file}` (xet files; 302 carries metadata, not followed) |
+| 100 | GET | 200 | `/api/models/{repo}/xet-read-token/{sha}` *(hf_xet, ignorable per scope)* |
+
+- **run2 — v1 warm: 1 call** — `GET /revision/v1` only. The commit-hash shortcut in `hf_hub_download` (pointer exists → return) makes warm same-commit runs optimal.
+- **run3 — PR cold: 403 calls** — same shape as run1, but only the 50 changed text files are GET-downloaded and only the 50 changed xet files trigger a token call. **The 201 HEAD chains happen regardless of whether the file changed** — unchanged files still cost 2 HEADs (regular) or 1 HEAD (xet) each just to discover they're already cached.
+- **run4 — PR warm: 1 call.**
+
+Here `repo_info.siblings` (≤1000 files) supplies the file list — **no `/tree` call**.
+
+## Large repo (2001 files) — crosses the 1000-file threshold
+
+### run1 — v1 cold: 5007 calls
+
+| # | Method | Status | Endpoint |
+|---|--------|--------|----------|
+| 1 | GET | 200 | `/api/models/{repo}/revision/v1` |
+| 3 | GET | 200 | `/api/models/{repo}/tree/{rev}` (paginated, 1000/page → 3 pages) |
+| 1001 | HEAD | 307 | `/{repo}/resolve/{sha}/{file}` (regular) |
+| 1001 | HEAD | 200 | `/api/resolve-cache/models/{repo}/{sha}/{file}` |
+| 1001 | GET | 200 | `/api/resolve-cache/models/{repo}/{sha}/{file}` (content) |
+| 1000 | HEAD | 302 | `/{repo}/resolve/{sha}/{file}` (xet) |
+| 1000 | GET | 200 | `/api/models/{repo}/xet-read-token/{sha}` *(hf_xet)* |
+
+- **run2 — v1 warm: 4 calls** — `1 revision + 3 tree`. **Not 1!** See below.
+- **run3 — PR cold: 4006 calls** — 1 revision + 3 tree + 2002 regular HEAD chains + 1000 xet HEAD + 500 changed-text GET + 500 changed-xet token.
+- **run4 — PR warm: 4 calls.**
+
+## Observations
+
+- **Cost is linear in file count, not in changed bytes**: per regular file 2 HEAD + 1 GET, per xet file 1 HEAD (+1 token when downloaded) — ~2.5 calls/file cold, at both scales (504→5007 is a clean 10×).
+- **The `/api/resolve-cache` 307 redirect doubles regular-file HEAD/GET traffic** on public repos: `HEAD /resolve` never answers directly, it redirects and the target is hit again.
+- **Scale-dependent regression: above 1000 files, warm runs jump from 1 to 4 calls.** When `siblings` is judged unreliable (`>LARGE_REPO_THRESHOLD`), main lists the tree via `list_repo_tree` for the file list — paginated at 1000/page (3 pages for 2001 files) — and **never caches it**, so a no-op warm re-pull still costs `1 revision + 3 tree`. Below the threshold the file list comes from `repo_info.siblings` (already fetched) so warm = 1.
+- hf_xet requests **one read token per file** (1000 × `xet-read-token` on the large cold run). Out of scope for counting, but it lands on huggingface.co.

--- a/bench-download-calls/test-B-pr4348.md
+++ b/bench-download-calls/test-B-pr4348.md
@@ -1,0 +1,45 @@
+# Test B — PR #4348 (`reuse-tree-data-in-snapshot`)
+
+The PR builds per-file metadata (`etag`, `size`, `xetHash`) from `list_repo_tree` and passes it to a new internal `_hf_hub_download`, skipping the per-file HEAD. **But the tree path is gated behind `unreliable_nb_files`** (siblings missing/empty or > `LARGE_REPO_THRESHOLD` = 1000). So the PR does nothing below 1000 files and activates above it — the two repos show exactly that.
+
+Totals (cold-v1 / warm / PR-cold / warm): **small 504 / 1 / 403 / 1 (inert)** · **large 3006 / 4 / 1504 / 4 (active)**.
+
+## Small repo (201 files) — gate never triggers
+
+### B as-is: 504 / 1 / 403 / 1 — identical to main
+
+201 siblings ≤ 1000, so the optimization stays dormant. It only helps kernel repos (no siblings) and >1000-file repos — by design, but worth stating: on the typical repo the PR changes **nothing**.
+
+### B-forced (gate lowered to 100): 304 / 2 / 152 / 2
+
+To show the intended effect at small scale, the threshold was lowered:
+
+| Run | Calls | Breakdown |
+|-----|-------|-----------|
+| run1 v1 cold | 304 | 1 revision + 1 tree + 101 GET resolve (307) + 101 GET resolve-cache (200) + 100 xet-token* |
+| run2 v1 warm | **2** | 1 revision + **1 tree (re-listed every warm run)** |
+| run3 PR cold | 152 | 1 revision + 1 tree + 50 GET (307) + 50 GET (200) + 50 xet-token* |
+| run4 PR warm | **2** | 1 revision + 1 tree |
+
+## Large repo (2001 files) — gate triggers, optimization active
+
+| Run | Calls | Breakdown |
+|-----|-------|-----------|
+| run1 v1 cold | **3006** | 1 revision + 3 tree + 1001 GET resolve (307) + 1001 GET resolve-cache (200) + 1000 xet-token* |
+| run2 v1 warm | **4** | 1 revision + **3 tree (paginated, re-listed every warm run)** |
+| run3 PR cold | **1504** | 1 revision + 3 tree + 500 GET (307) + 500 GET (200) + 500 xet-token* |
+| run4 PR warm | **4** | 1 revision + 3 tree |
+
+\* hf_xet-issued, ignorable per scope.
+
+Cold drops **5007 → 3006 (−40%)** vs main: the PR removes exactly the ~3000 per-file HEAD round-trips (regular 307+200 follow-up, xet 302). It is **identical to Test C on every cold run** — both use the same tree-metadata path; the only difference shows up warm (below).
+
+## Observations
+
+- When active, the metadata construction is correct (etag = `lfs.sha256` or `blob_id`, xet data from `xetHash` + reconstructed refresh route — verified against actual `/resolve` etags and cache blob names) and removes all per-file HEADs.
+- **Warm-run regression at both scales**: nothing is persisted, so every warm call re-lists the tree (small +1, large +3 paginated pages → 1 vs 2/4 calls). Test C fixes this with the on-disk `trees/` cache.
+- Regular-file downloads still cost 2 GETs each (resolve 307 → resolve-cache); Test E removes that hop.
+- Tree is listed at the resolved `repo_info.sha` (good — consistent listing) and without `expand` (good — 1000 items/page; `expand=true` drops the page size to 50).
+- Caveat shared with C/D/E: with pre-fetched metadata, a download failure surfaces as a raw connection error instead of the HEAD-fallback path (`LocalEntryNotFoundError`) — only in split-brain situations (API reachable, downloads failing). The offline-simulation tests catch this now that the tree path activates.
+
+**Verdict**: right direction, two gaps — (1) gated to >1000-file repos, (2) tree re-fetched on every call including warm ones. C generalizes it (any size) and caches the listing.

--- a/bench-download-calls/test-C-tree-cache.md
+++ b/bench-download-calls/test-C-tree-cache.md
@@ -1,0 +1,61 @@
+# Test C — tree listing cached on disk (`bench-c-tree-cache`)
+
+Branch: [`bench-c-tree-cache`](https://github.com/huggingface/huggingface_hub/tree/bench-c-tree-cache) (no PR opened).
+
+## Results
+
+Totals (cold-v1 / warm / PR-cold / warm): **small 304 / 1 / 152 / 1** · **large 3006 / 1 / 1504 / 1**.
+
+### Small repo (201 files)
+
+| Run | Calls | Breakdown |
+|-----|-------|-----------|
+| run1 v1 cold | 304 | 1 revision + 1 tree + 101 GET resolve (307) + 101 GET resolve-cache (200) + 100 xet-token* |
+| run2 v1 warm | **1** | 1 revision (tree read from disk cache) |
+| run3 PR cold | 152 | 1 revision + 1 tree + 50 GET (307) + 50 GET (200) + 50 xet-token* |
+| run4 PR warm | **1** | 1 revision |
+
+### Large repo (2001 files)
+
+| Run | Calls | Breakdown |
+|-----|-------|-----------|
+| run1 v1 cold | 3006 | 1 revision + 3 tree (paginated) + 1001 GET resolve (307) + 1001 GET resolve-cache (200) + 1000 xet-token* |
+| run2 v1 warm | **1** | 1 revision (tree read from disk cache) |
+| run3 PR cold | 1504 | 1 revision + 3 tree + 500 GET (307) + 500 GET (200) + 500 xet-token* |
+| run4 PR warm | **1** | 1 revision |
+
+\* hf_xet-issued, ignorable per scope. vs main: cold −40% (both scales), PR-update −62%/−62%; excl. tokens: small 404→204, large 4007→2006.
+
+**C vs B**: identical on every cold run (same tree-metadata path) — C's value is the **on-disk cache**, so warm/incremental pulls are **1 call** where B re-lists the tree (2 calls small, **4 large**). The gap grows with repo size because the listing is paginated (`ceil(N/1000)` calls), and C also drops the `LARGE_REPO_THRESHOLD` heuristic so the same code path runs at any size.
+
+## Design decisions
+
+1. **`list_repo_tree` on every snapshot_download** (as requested), replacing the `siblings`-based listing entirely — no more `LARGE_REPO_THRESHOLD` heuristic. Listed at the resolved `repo_info.sha`, `recursive=true`, **without `expand`** (1000 items/page vs 50 with expand; lfs oid/size and xetHash are included anyway — verified).
+2. **New cache folder `trees/`**, sibling of `refs/ blobs/ snapshots/`: one `trees/<commit_hash>.json` per commit. A commit's tree is immutable → cache forever, no invalidation problem. Format is a human-readable JSON index, files sorted, keyed by path for direct lookup:
+   ```json
+   {
+     "format_version": 1,
+     "repo_id": "Wauplin/snapshot-download-bench",
+     "repo_type": "model",
+     "commit_hash": "66805442…",
+     "files": {
+       "bin_000.bin": {"size": 1048576, "blob_id": "0875fae8…", "lfs_sha256": "6e0065d2…", "lfs_size": 1048576, "xet_hash": "c1404b89…"},
+       "file_000.txt": {"size": 37, "blob_id": "536fa2db…"}
+     }
+   }
+   ```
+3. **Per-file HEAD calls eliminated**: an `HfFileMetadata` is built from each tree entry and threaded through `hf_hub_download → _get_metadata_or_catch_error` (new optional `file_metadata` parameter; public behavior unchanged when not provided). Key equivalences, verified against live `/resolve` responses and resulting cache layout:
+   - `etag` = `lfs.sha256` for LFS files, git `blob_id` otherwise (identical to `/resolve`'s `X-Linked-ETag`/`ETag` → identical `blobs/` filenames, so caches stay interoperable with main).
+   - `size` = `lfs.size` or blob size.
+   - `XetFileData` = (`xetHash` from tree, refresh route rebuilt as `/api/{type}s/{repo}/xet-read-token/{commit}`).
+4. `repo_info` is kept as the one ref→commit resolution call. It cannot be replaced by `/tree`: the tree response does not expose the resolved commit hash (no `X-Repo-Commit` header — checked).
+
+## Side benefits
+
+- `allow_patterns`/`ignore_patterns` downloads no longer hit the network for the file list when the tree is cached (verified: filtered download on a cached commit = 0 listing calls).
+- The cached index gives a future `snapshot_download` enough information to *verify* a snapshot folder is complete instead of blindly returning it (today's behavior after partial failures). Not implemented — out of scope.
+
+## Caveats
+
+- 3 of 13 `test_snapshot_download.py` tests fail (10 pass): all three simulate offline by patching only the file-download HTTP session, while `repo_info`/`tree` (HfApi client) stay reachable. With pre-fetched metadata the per-file HEAD fallback no longer converts that split-brain into `LocalEntryNotFoundError`. Real offline (everything down) keeps today's behavior — `repo_info` fails first. A mergeable version should catch download errors in `snapshot_download` and degrade gracefully (and the tests should mock at the client level).
+- PR #4348 has the same blind spot once its tree path activates.

--- a/bench-download-calls/test-D-min-calls.md
+++ b/bench-download-calls/test-D-min-calls.md
@@ -1,0 +1,56 @@
+# Test D — minimal hub calls (`bench-d-min-calls`)
+
+Branch: [`bench-d-min-calls`](https://github.com/huggingface/huggingface_hub/tree/bench-d-min-calls) (no PR opened). Builds on top of Test C.
+
+## Results
+
+Totals (cold-v1 / warm / PR-cold / warm): **small 4 / 1 / 4 / 1** · **large 6 / 1 / 6 / 1**.
+
+### Small repo (201 files)
+
+| Run | Calls | Breakdown |
+|-----|-------|-----------|
+| run1 v1 cold | **4** | 1 revision + 1 tree + 1 git-upload-pack + 1 xet-token |
+| run2 v1 warm | **1** | 1 revision |
+| run3 PR cold | **4** | 1 revision + 1 tree + 1 git-upload-pack + 1 xet-token |
+| run4 PR warm | **1** | 1 revision |
+
+### Large repo (2001 files)
+
+| Run | Calls | Breakdown |
+|-----|-------|-----------|
+| run1 v1 cold | **6** | 1 revision + 3 tree (paginated) + 1 git-upload-pack + 1 xet-token |
+| run2 v1 warm | **1** | 1 revision |
+| run3 PR cold | **6** | 1 revision + 3 tree + 1 git-upload-pack + 1 xet-token |
+| run4 PR warm | **1** | 1 revision |
+
+Cold-run hub calls are **O(1) in file count**, the only growth being tree pagination (`ceil(N/1000)` pages): small 504 → 4 (−99.2%), large 5007 → 6 (−99.9%). One `git-upload-pack` fetches all regular blobs and one xet group fetches all xet blobs regardless of count. Wall-clock cold also dropped (small 18s→6s, large 230s→46s), despite time not being a goal.
+
+## What it does on top of C
+
+### 1. All regular (non-LFS) files in ONE request — git smart HTTP
+
+The Hub's git server supports protocol v2 with arbitrary **blob oids in `want` lines** (discovered empirically; capability line: `fetch=shallow wait-for-done filter`). `snapshot_download` collects the blob oids of all missing regular files (already known from the tree listing) and POSTs a single `fetch` to `/{repo}.git/git-upload-pack`. The returned packfile is parsed in pure Python (~200 lines: pkt-line/side-band demux, varint headers, zlib objects, OFS/REF delta support), each blob is **verified against its git sha1**, and written directly to `blobs/` — the per-file loop then only creates symlinks, zero HTTP.
+
+- Small repo: 101 files in one ~80 KB response, replacing 202 GETs. Large repo: all 1000 regular blobs in a single request (one POST regardless of count).
+- In run3, only the changed text blobs are requested (50 small / 500 large) — the tree cache + blob presence check make the request minimal.
+- Threshold: used when ≥ 4 blobs are missing (below that, per-file GETs are CDN-cacheable and simpler). Falls back to the normal per-file path on *any* error (older deployments, parse failure, missing blob).
+- Bearer-token auth on the git endpoint worked fine (sent; repo is public — private-repo auth not exercised).
+
+### 2. All xet files in ONE download group — single token fetch
+
+`hf_hub_download` creates one hf_xet download group per file, and **hf_xet fetches a fresh read token per group** → 100 × `GET /api/…/xet-read-token` on huggingface.co in the baseline (these are "ignorable" per scope but still hit the hub). D registers all missing xet blobs in a single `XetSession.new_file_download_group()` → exactly **1 token call**, parallelism handled inside hf_xet. Blobs are downloaded to `blobs/<sha256>` directly (sha256 spot-verified) and symlinked by the normal loop.
+
+## Decisions & trade-offs
+
+- **`repo_info` kept**: the only single-call way to resolve a ref to a commit hash (`/tree` doesn't return it, `ls-refs` would cost 2 git calls). Warm floor stays 1 call — unavoidable as long as refs are mutable and must be revalidated.
+- **`paths-info` not used**: `POST /api/{type}s/{repo}/paths-info/{rev}` (max 2000 paths, returns oid/size/lfs/xetHash) would be ideal for *partial* downloads with `allow_patterns`, but for full snapshots `/tree` is equivalent at 1 call ≤1000 files.
+- **Request count vs request weight**: one `git-upload-pack` is heavier server-side (gitaly pack generation) than one resolve GET — but vastly lighter than 202 of them. If git-protocol use from the library is unwanted, the same shape could be a dedicated batch-content endpoint (e.g. POST paths → multipart/zip), which doesn't exist today.
+- Prefetches are skipped for `dry_run` and `local_dir` modes (the latter falls back to C behavior: metadata available, no HEAD, per-file GETs).
+- `snapshot_download`'s signature is unchanged; per-file progress bars for prefetched files are bypassed (bytes shown once at symlink time) — cosmetic regression to fix in a real PR.
+
+## Caveats
+
+- Same 3 offline-simulation test failures as C (split-brain mock; see test C report). 10/13 pass.
+- Pack fetch of a very large text corpus buffers the response in memory; a streaming pack parser (or size cap + fallback) is needed before productionizing.
+- Failed group downloads leave `*.incomplete`/`*.pack.tmp` files behind (cleaned on next successful run); acceptable for an experiment.

--- a/bench-download-calls/test-E-no-git.md
+++ b/bench-download-calls/test-E-no-git.md
@@ -1,0 +1,56 @@
+# Test E — minimal hub calls, no git endpoints (`bench-e-no-git`)
+
+Branch: [`bench-e-no-git`](https://github.com/huggingface/huggingface_hub/tree/bench-e-no-git) (no PR opened). Builds on Test C; answers "how low can we go using only regular HTTP endpoints?" after Test D was (rightly) called out for leaning on the git smart-HTTP protocol.
+
+## Results
+
+Totals (cold-v1 / warm / PR-cold / warm): **small 104 / 1 / 53 / 1** · **large 1006 / 1 / 505 / 1**.
+
+### Small repo (201 files)
+
+| Run | Calls | Breakdown |
+|-----|-------|-----------|
+| run1 v1 cold | **104** | 1 revision + 1 tree + 101 GET resolve-cache (one per regular file) + 1 xet-token |
+| run2 v1 warm | **1** | 1 revision |
+| run3 PR cold | **53** | 1 revision + 1 tree + 50 GET resolve-cache + 1 xet-token |
+| run4 PR warm | **1** | 1 revision |
+
+### Large repo (2001 files)
+
+| Run | Calls | Breakdown |
+|-----|-------|-----------|
+| run1 v1 cold | **1006** | 1 revision + 3 tree (paginated) + 1001 GET resolve-cache + 1 xet-token |
+| run2 v1 warm | **1** | 1 revision |
+| run3 PR cold | **505** | 1 revision + 3 tree + 500 GET resolve-cache + 1 xet-token |
+| run4 PR warm | **1** | 1 revision |
+
+Every call is a clean 200 — zero redirects, zero HEADs. vs main: cold −79% (small) / −80% (large), PR update −87% / −87%. Excl. tokens, v1 cold: small 404→103, large 4007→1005; PR cold: small 353→52, large 3506→504. Cold cost is `revision + ceil(N/1000) tree pages + files_to_download + 1 token`.
+
+## What it does on top of C
+
+### 1. Regular files: skip the systematic 307 redirect (2 GETs → 1 GET)
+
+On public repos, `GET /resolve/...` *always* answers 307 → `/api/resolve-cache/{type}s/{repo}/{commit}/{file}?{resolve-path}=&etag="{etag}"`. That target is fully deterministic — commit hash, path and etag are all in the tree listing — so E builds it client-side and downloads directly. Verified: same content, same `ETag`/`X-Repo-Commit` response headers as the redirected flow; the exact query string the server's 307 would produce is included (it looks like a CDN cache key, so behaving identically to redirected clients matters).
+
+Guards: private repos keep the `/resolve` URL (they serve content directly, no redirect), and LFS/xet files are untouched (signed CDN redirects can't be built client-side).
+
+### 2. Xet files: one download group → one token (same as D)
+
+All missing xet blobs are registered in a single `XetSession` download group instead of one group per file: 1 × `xet-read-token` instead of 100.
+
+## Decisions & trade-offs
+
+- **`/api/resolve-cache` is an internal, undocumented endpoint.** Today it's where 100% of public-repo download traffic already lands (every resolve call is redirected there), so the load profile is identical — we only remove the redirect hop. But the URL shape is not a public contract; shipping this requires either (a) moon-landing blessing the route as stable, or (b) the server including the direct URL in the `/tree` / `paths-info` response so clients don't hardcode it. Until then it's redirect-shaped coupling, with the plain `/resolve` URL as the natural fallback if the route ever changes (a 404 would surface loudly — a production version should catch and retry via `/resolve`).
+- **Per-file content GETs are the irreducible floor for REST**: without a batch-content endpoint (or git packs, see Test D), N regular files cost N GETs. E's cold cost is `3 + regular_files_to_download` (+1 tree page per 1000 files); the gap to D's O(1) is exactly the batch-content capability.
+- Same caveats as C/D: 3/13 offline-simulation tests fail (split-brain mock artifact — see Test C report; 10 pass), and prefetched xet files bypass the per-file progress bar.
+
+## E vs D
+
+| | E (no git) | D (git pack) |
+|---|---|---|
+| v1 cold — small / large | 104 / 1006 | 4 / 6 |
+| PR cold — small / large | 53 / 505 | 4 / 6 |
+| Scaling | O(files downloaded) | O(1) |
+| Endpoints used | revision, tree, resolve-cache, xet-token | revision, tree, **git-upload-pack**, xet-token |
+| Server cost profile | same as today's redirected traffic | shifts small-file load to gitaly |
+| Coupling risk | resolve-cache URL shape (internal) | git protocol (stable, but unconventional for the lib) |


### PR DESCRIPTION
## Reports-only PR (no library changes) — a benchmark + write-up to ground our discussions on download counts and rate limits. Check markdown reports under [`bench-download-calls/`](https://github.com/huggingface/huggingface_hub/tree/tmp-download-call-benchmark/bench-download-calls).

## What this measures

How many **Python-side HTTP calls to huggingface.co** `snapshot_download` makes (method + endpoint + status + redirects). hf_xet data-plane traffic (CAS/CDN) is out of scope — it doesn't hit hub rate limits — except `xet-read-token`, which is hf_xet-issued but lands on huggingface.co, so it's reported on its own line.

Two repos of identical shape, 10× apart, each with a `v1` tag and a PR updating half the files in place. The large one deliberately crosses `LARGE_REPO_THRESHOLD = 1000`:
- **Small** — 201 files (100 git-text + 100 xet/LFS + .gitattributes)
- **Large** — 2001 files (1000 + 1000 + .gitattributes)

Each variant runs 4 times against a fresh cache: v1 cold → v1 warm → PR cold → PR warm. Full setup in [`00-methodology.md`](https://github.com/huggingface/huggingface_hub/blob/tmp-download-call-benchmark/bench-download-calls/00-methodology.md).

## Tests, reports & branches

| Test | What | Report | Branch |
|------|------|--------|--------|
| **A** | `main` baseline | [test-A-main.md](https://github.com/huggingface/huggingface_hub/blob/tmp-download-call-benchmark/bench-download-calls/test-A-main.md) | `main` |
| **B** | community PR (reuse tree data) | [test-B-pr4348.md](https://github.com/huggingface/huggingface_hub/blob/tmp-download-call-benchmark/bench-download-calls/test-B-pr4348.md) | [#4348](https://github.com/huggingface/huggingface_hub/pull/4348) |
| **C** | tree listing cached on disk (`trees/`), no per-file HEAD | [test-C-tree-cache.md](https://github.com/huggingface/huggingface_hub/blob/tmp-download-call-benchmark/bench-download-calls/test-C-tree-cache.md) | [`bench-c-tree-cache`](https://github.com/huggingface/huggingface_hub/tree/bench-c-tree-cache) |
| **D** | minimal calls (git-upload-pack + 1 xet group) | [test-D-min-calls.md](https://github.com/huggingface/huggingface_hub/blob/tmp-download-call-benchmark/bench-download-calls/test-D-min-calls.md) | [`bench-d-min-calls`](https://github.com/huggingface/huggingface_hub/tree/bench-d-min-calls) |
| **E** | minimal calls **without git endpoints** | [test-E-no-git.md](https://github.com/huggingface/huggingface_hub/blob/tmp-download-call-benchmark/bench-download-calls/test-E-no-git.md) | [`bench-e-no-git`](https://github.com/huggingface/huggingface_hub/tree/bench-e-no-git) |

Cross-cutting: **[combined-report.md](https://github.com/huggingface/huggingface_hub/blob/tmp-download-call-benchmark/bench-download-calls/combined-report.md)** (full tables + findings + recommendations) · **[executive-summary.md](https://github.com/huggingface/huggingface_hub/blob/tmp-download-call-benchmark/bench-download-calls/executive-summary.md)** (high-level, shareable).

> C/D/E are experimental branches to quantify ceilings — not merge candidates as-is (each has the same 3 offline-simulation test failures from a split-brain mock; details in the C report).

## Results — calls to huggingface.co (cold-v1 / warm / PR-cold / warm)

| Variant | 201-file repo | 2001-file repo |
|---|---|---|
| A. main | 504 / 1 / 403 / 1 | 5007 / 4 / 4006 / 4 |
| B. #4348 | 504 / 1 / 403 / 1 *(inert ≤1000 files)* | 3006 / 4 / 1504 / 4 |
| C. tree-cache | 304 / 1 / 152 / 1 | 3006 / **1** / 1504 / **1** |
| E. no-git | 104 / 1 / 53 / 1 | 1006 / 1 / 505 / 1 |
| D. git-pack | **4 / 1 / 4 / 1** | **6 / 1 / 6 / 1** |

## Takeaways (details in the reports)

- **`main` costs ~2.5 calls/file, even for unchanged files** — per-file HEAD metadata is fetched before the cache can declare a hit.
- **The per-file HEAD is redundant with `/tree`** (etag/size/xetHash are byte-identical). Caching the immutable tree on disk (**C**) removes it and keeps warm pulls at 1 call.
- **Scale trap**: above 1000 files, `main` lists the tree on *every* call without caching it → even a no-op warm re-pull costs 4 calls. This is also where **PR #4348 first activates**.
- **`xet-read-token` is fetched once per file** (1000 calls on the large cold run); one xet download group → 1.
- **Floors**: without git, **E** = `revision + tree pages + 1 GET/file + 1 token`; with git-upload-pack, **D** = O(1) (4–6 calls at any size).
- **For rate limits**: identical work spans 4–5007 calls depending on client version/path — raw request counts are a poor billing unit; consider weighting by route class.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only additions; no runtime or API behavior changes in this PR.
> 
> **Overview**
> Adds a **reports-only** documentation set under `bench-download-calls/` — no library changes. It documents how many Python-side HTTP calls to huggingface.co `snapshot_download` makes, measured via mitmproxy on two fixed test repos (201 and 2001 files) across cold/warm and PR-update scenarios.
> 
> New files include **`00-methodology.md`** (repos, proxy scope, variant A–E), **`combined-report.md`** and **`executive-summary.md`** (tables and recommendations), plus per-variant write-ups **`test-A-main.md`** through **`test-E-no-git.md`**. Variants compare `main`, PR #4348, and experimental branches for tree caching, git pack fetch, and redirect-free HTTP.
> 
> The write-ups argue baseline cost is ~2.5 hub calls per file, that per-file HEAD is redundant with `/tree`, and they recommend short-term tree listing + on-disk `trees/` cache; they also note rate-limit implications (4–5007 calls for the same work).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 138385bd4e8347d567ca3a735261435c0b9f0147. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->