### PR TITLE
Clarify torch serialization doc examples

### DIFF
--- a/src/huggingface_hub/serialization/_torch.py
+++ b/src/huggingface_hub/serialization/_torch.py
@@ -107,14 +107,13 @@ def save_torch_model(
     Example:
 
     ```py
-    >>> from huggingface_hub import save_torch_model
+    >>> from huggingface_hub import load_torch_model, save_torch_model
     >>> model = ... # A PyTorch model
 
     # Save state dict to "path/to/folder". The model will be split into shards of 5GB each and saved as safetensors.
     >>> save_torch_model(model, "path/to/folder")
 
     # Load model back
-    >>> from huggingface_hub import load_torch_model  # TODO
     >>> load_torch_model(model, "path/to/folder")
     >>>
     ```
@@ -205,7 +204,7 @@ def save_torch_state_dict(
     >>> model = ... # A PyTorch model
 
     # Save state dict to "path/to/folder". The model will be split into shards of 5GB each and saved as safetensors.
-    >>> state_dict = model_to_save.state_dict()
+    >>> state_dict = model.state_dict()
     >>> save_torch_state_dict(state_dict, "path/to/folder")
     ```
     """


### PR DESCRIPTION
## Summary
- remove the lingering # TODO from the save_torch_model() example
- import load_torch_model alongside save_torch_model in the example
- fix the save_torch_state_dict() example to use model.state_dict() instead of the undefined model_to_save`n
## Why
These examples are part of the public serialization helpers, so keeping them copy-pasteable helps avoid confusion for users reading the API docs.

## Testing
- compiled the updated source file locally

Issue linkage: not tied to an existing tracked issue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to docstring examples; no serialization logic or behavior is modified.
> 
> **Overview**
> Updates **docstring examples only** in `save_torch_model` and `save_torch_state_dict` so they are copy-pasteable for API readers.
> 
> For **`save_torch_model`**, the example now imports `load_torch_model` and `save_torch_model` together at the top and drops the separate `# TODO` import line before the reload step.
> 
> For **`save_torch_state_dict`**, the example uses `model.state_dict()` instead of the undefined `model_to_save`, matching the `model = ...` placeholder in the same block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90eded3ed8618656e6ebee4e55244ef9ffb19e10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->