### PR TITLE
WIP: Stream Xet files through HfFileSystem read paths

### DIFF
--- a/benchmarks/benchmark_hffs_xet_streaming.py
+++ b/benchmarks/benchmark_hffs_xet_streaming.py
@@ -1,0 +1,53 @@
+"""Benchmark HfFileSystem streaming reads: xet vs HTTP.
+
+Run twice — once with HF_HUB_DISABLE_XET=1 (HTTP baseline) and once without (xet) —
+and compare. Pass a real xet-backed hf:// file path (parquet or any large file).
+
+Usage:
+    HF_HUB_DISABLE_XET=1 python benchmarks/benchmark_hffs_xet_streaming.py <hf://...>
+    python benchmarks/benchmark_hffs_xet_streaming.py <hf://...>
+"""
+
+import sys
+import time
+
+from huggingface_hub import HfFileSystem
+from huggingface_hub.utils._runtime import is_xet_available
+
+
+def _time(fn):
+    start = time.perf_counter()
+    fn()
+    return time.perf_counter() - start
+
+
+def main(path: str) -> None:
+    fs = HfFileSystem()
+    size = fs.info(path)["size"]
+    mode = "xet" if is_xet_available() else "http"
+    print(f"mode={mode} size={size} path={path}")
+
+    def footer_read():
+        with fs.open(path, "rb") as f:
+            f.seek(max(0, size - 64 * 1024))
+            f.read(64 * 1024)
+
+    def full_scan():
+        with fs.open(path, "rb", block_size=0) as f:
+            while f.read(8 * 1024 * 1024):
+                pass
+
+    def random_access():
+        with fs.open(path, "rb") as f:
+            step = max(1, size // 16)
+            for off in range(0, size, step):
+                f.seek(off)
+                f.read(min(256 * 1024, size - off))
+
+    print(f"footer_read     : {_time(footer_read):.3f}s")
+    print(f"full_scan       : {_time(full_scan):.3f}s")
+    print(f"random_access   : {_time(random_access):.3f}s")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1])

--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -29,10 +29,13 @@ from .errors import (
 )
 from .file_download import get_hf_file_metadata, hf_hub_url, http_get
 from .hf_api import SPECIAL_REFS_REVISION_REGEX, BucketFile, BucketFolder, HfApi, LastCommitInfo, RepoFile, RepoFolder
-from .utils import HFValidationError, XetFileData, hf_raise_for_status, http_backoff, http_stream_backoff, parse_hf_uri
+from .utils import HFValidationError, XetFileData, hf_raise_for_status, http_backoff, http_stream_backoff, logging, parse_hf_uri
 from .utils._runtime import is_xet_available
 from .utils._xet import get_xet_download_stream_group, xet_download_stream
 from .utils.insecure_hashlib import md5
+
+
+logger = logging.get_logger(__name__)
 
 
 @dataclass
@@ -1456,11 +1459,17 @@ def _try_get_xet_metadata(
     """Return ``(xet_file_data, size)`` for ``url`` when Xet is usable, else ``(None, None)``.
 
     Performs a single HEAD via :func:`get_hf_file_metadata`. ``xet_file_data`` is ``None``
-    when the file is not Xet-backed, in which case the caller falls back to HTTP.
+    when the file is not Xet-backed, when Xet is unavailable, or when the metadata lookup
+    fails — in all cases the caller falls back to the HTTP read path (which has its own
+    retries), so Xet detection never breaks a read.
     """
     if not is_xet_available():
         return None, None
-    metadata = get_hf_file_metadata(url, headers=headers, endpoint=endpoint)
+    try:
+        metadata = get_hf_file_metadata(url, headers=headers, endpoint=endpoint)
+    except Exception as e:
+        logger.warning(f"Could not fetch Xet metadata for {url}, falling back to HTTP: {e}")
+        return None, None
     return metadata.xet_file_data, metadata.size
 
 

--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -1330,6 +1330,7 @@ class HfFileSystemStreamFile(fsspec.spec.AbstractBufferedFile):
         # (Re)open when never opened, or when an HTTP stream's response was dropped
         # (used to force a reconnect, e.g. after a mid-stream failure). In xet mode there
         # is no response object, so the iterator alone drives the stream.
+        # Xet streams can only be force-reopened via the retry loop below.
         if not self._stream_opened or (not self._xet_mode and self.response is None):
             self._open_connection()
 
@@ -1341,6 +1342,12 @@ class HfFileSystemStreamFile(fsspec.spec.AbstractBufferedFile):
                 out = self._read_from_stream(self._stream_iterator, length)
                 self.loc += len(out)
                 return out
+            except KeyboardInterrupt:
+                if self._xet_mode:
+                    from .utils._xet import abort_xet_session
+
+                    abort_xet_session()
+                raise
             except Exception:
                 if self.response is not None:
                     self.response.close()
@@ -1415,9 +1422,15 @@ class HfFileSystemStreamFile(fsspec.spec.AbstractBufferedFile):
                 refresh_route=xet_file_data.refresh_route, headers=headers, endpoint=self.fs.endpoint
             )
             start = self.loc if self.loc > 0 else None
-            self._stream_iterator = xet_download_stream(
-                group, xet_file_data.file_hash, self.size, start=start, end=None
-            )
+            try:
+                self._stream_iterator = xet_download_stream(
+                    group, xet_file_data.file_hash, self.size, start=start, end=None
+                )
+            except KeyboardInterrupt:
+                from .utils._xet import abort_xet_session
+
+                abort_xet_session()
+                raise
             return
 
         url = self.url()

--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -29,7 +29,15 @@ from .errors import (
 )
 from .file_download import get_hf_file_metadata, hf_hub_url, http_get
 from .hf_api import SPECIAL_REFS_REVISION_REGEX, BucketFile, BucketFolder, HfApi, LastCommitInfo, RepoFile, RepoFolder
-from .utils import HFValidationError, XetFileData, hf_raise_for_status, http_backoff, http_stream_backoff, logging, parse_hf_uri
+from .utils import (
+    HFValidationError,
+    XetFileData,
+    hf_raise_for_status,
+    http_backoff,
+    http_stream_backoff,
+    logging,
+    parse_hf_uri,
+)
 from .utils._runtime import is_xet_available
 from .utils._xet import get_xet_download_stream_group, xet_download_stream
 from .utils.insecure_hashlib import md5

--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -39,7 +39,7 @@ from .utils import (
     parse_hf_uri,
 )
 from .utils._runtime import is_xet_available
-from .utils._xet import get_xet_download_stream_group, xet_download_stream
+from .utils._xet import open_xet_download_stream_group, xet_download_file, xet_download_stream
 from .utils.insecure_hashlib import md5
 
 
@@ -1118,13 +1118,6 @@ class HfFileSystem(fsspec.AbstractFileSystem, metaclass=_Cached):  # ty: ignore[
         if isinstance(lpath, (str, Path)):  # otherwise, let's assume it's a file-like object
             os.makedirs(os.path.dirname(lpath), exist_ok=True)
 
-        # Open file if not already open
-        close_file = False
-        if outfile is None:
-            outfile = open(lpath, "wb")
-            close_file = True
-        initial_pos = outfile.tell()
-
         # Custom implementation of `get_file` to use `http_get`.
         resolve_remote_path = self.resolve_path(rpath, revision=revision)
         expected_size = self.info(rpath, revision=revision)["size"]
@@ -1132,11 +1125,40 @@ class HfFileSystem(fsspec.AbstractFileSystem, metaclass=_Cached):  # ty: ignore[
         headers = self._api._build_hf_headers()
         download_url = self.url(resolve_remote_path.unresolve())
         xet_file_data, _ = _try_get_xet_metadata(download_url, headers, self.endpoint)
+
+        # Fast path: a Xet-backed file written to a real local path. Hand the path to hf_xet
+        # so it writes the file directly from Rust (parallel) and populates the local chunk
+        # cache, instead of streaming chunks through Python. Only applies when we have a path
+        # (not a file-like object).
+        if xet_file_data is not None and outfile is None and isinstance(lpath, (str, Path)):
+            _prev = 0
+
+            def _on_progress(group_report, _):
+                nonlocal _prev
+                current = group_report.total_bytes_completed
+                callback.relative_update(max(0, current - _prev))
+                _prev = current
+
+            xet_download_file(
+                file_data=xet_file_data,
+                headers=headers,
+                size=expected_size,
+                path=str(Path(lpath).absolute()),
+                progress_callback=_on_progress if isinstance(callback, TqdmCallback) else None,
+            )
+            return
+
+        # Open file if not already open
+        close_file = False
+        if outfile is None:
+            outfile = open(lpath, "wb")
+            close_file = True
+        initial_pos = outfile.tell()
         try:
             if xet_file_data is not None:
-                group = get_xet_download_stream_group(
-                    refresh_route=xet_file_data.refresh_route, headers=headers, endpoint=self.endpoint
-                )
+                # Xet-backed file written to a file-like object (no path for hf_xet to write
+                # to) => reconstruct as a byte stream and write the chunks ourselves.
+                group = open_xet_download_stream_group(file_data=xet_file_data, headers=headers)
                 try:
                     for chunk in xet_download_stream(group, xet_file_data.file_hash, expected_size):
                         outfile.write(chunk)
@@ -1225,9 +1247,7 @@ class HfFileSystemFile(fsspec.spec.AbstractBufferedFile):
         headers = self.fs._api._build_hf_headers()
         xet_file_data, size = _try_get_xet_metadata(self.url(), headers, self.fs.endpoint)
         if xet_file_data is not None:
-            self._xet_group = get_xet_download_stream_group(
-                refresh_route=xet_file_data.refresh_route, headers=headers, endpoint=self.fs.endpoint
-            )
+            self._xet_group = open_xet_download_stream_group(file_data=xet_file_data, headers=headers)
             self._xet_file_hash = xet_file_data.file_hash
             if self.size is None and size is not None:
                 self.size = size
@@ -1443,9 +1463,7 @@ class HfFileSystemStreamFile(fsspec.spec.AbstractBufferedFile):
             self._xet_mode = True
             if self.size is None and size is not None:
                 self.size = size
-            group = get_xet_download_stream_group(
-                refresh_route=xet_file_data.refresh_route, headers=headers, endpoint=self.fs.endpoint
-            )
+            group = open_xet_download_stream_group(file_data=xet_file_data, headers=headers)
             start = self.loc if self.loc > 0 else None
             try:
                 self._stream_iterator = xet_download_stream(

--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -1121,16 +1121,33 @@ class HfFileSystem(fsspec.AbstractFileSystem, metaclass=_Cached):  # ty: ignore[
         resolve_remote_path = self.resolve_path(rpath, revision=revision)
         expected_size = self.info(rpath, revision=revision)["size"]
         callback.set_size(expected_size)
+        headers = self._api._build_hf_headers()
+        download_url = self.url(resolve_remote_path.unresolve())
+        xet_file_data, _ = _try_get_xet_metadata(download_url, headers, self.endpoint)
         try:
-            http_get(
-                url=self.url(resolve_remote_path.unresolve()),
-                temp_file=outfile,  # type: ignore
-                displayed_filename=rpath,
-                expected_size=expected_size,
-                resume_size=0,
-                headers=self._api._build_hf_headers(),
-                _tqdm_bar=callback.tqdm if isinstance(callback, TqdmCallback) else None,
-            )
+            if xet_file_data is not None:
+                group = get_xet_download_stream_group(
+                    refresh_route=xet_file_data.refresh_route, headers=headers, endpoint=self.endpoint
+                )
+                try:
+                    for chunk in xet_download_stream(group, xet_file_data.file_hash, expected_size):
+                        outfile.write(chunk)
+                        callback.relative_update(len(chunk))
+                except KeyboardInterrupt:
+                    from .utils._xet import abort_xet_session
+
+                    abort_xet_session()
+                    raise
+            else:
+                http_get(
+                    url=download_url,
+                    temp_file=outfile,  # type: ignore
+                    displayed_filename=rpath,
+                    expected_size=expected_size,
+                    resume_size=0,
+                    headers=headers,
+                    _tqdm_bar=callback.tqdm if isinstance(callback, TqdmCallback) else None,
+                )
             outfile.seek(initial_pos)
         finally:
             # Close file only if we opened it ourselves

--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -1309,6 +1309,8 @@ class HfFileSystemStreamFile(fsspec.spec.AbstractBufferedFile):
         # streaming state
         self._stream_iterator: Iterator[bytes] | None = None
         self._stream_buffer = bytearray()
+        self._stream_opened = False
+        self._xet_mode = False
 
     def seek(self, loc: int, whence: int = 0):
         if loc == 0 and whence == 1:
@@ -1325,13 +1327,16 @@ class HfFileSystemStreamFile(fsspec.spec.AbstractBufferedFile):
 
         If reading the stream fails, we retry with a new connection.
         """
-        if self.response is None:
+        # (Re)open when never opened, or when an HTTP stream's response was dropped
+        # (used to force a reconnect, e.g. after a mid-stream failure). In xet mode there
+        # is no response object, so the iterator alone drives the stream.
+        if not self._stream_opened or (not self._xet_mode and self.response is None):
             self._open_connection()
 
         retried_once = False
         while True:
             try:
-                if self.response is None or self._stream_iterator is None:
+                if self._stream_iterator is None:
                     return b""  # Already read the entire file
                 out = self._read_from_stream(self._stream_iterator, length)
                 self.loc += len(out)
@@ -1341,7 +1346,7 @@ class HfFileSystemStreamFile(fsspec.spec.AbstractBufferedFile):
                     self.response.close()
                 if retried_once:  # Already retried once, give up
                     raise
-                # First failure, retry with range header
+                # First failure, retry with a fresh connection / stream from self.loc
                 self._open_connection()
                 retried_once = True
 
@@ -1393,13 +1398,29 @@ class HfFileSystemStreamFile(fsspec.spec.AbstractBufferedFile):
         return reopen, (self.fs, self.path, self.mode, self.blocksize, self.cache.name)
 
     def _open_connection(self):
-        """Open a connection to the remote file."""
+        """Open a connection to the remote file (xet stream when Xet-backed, else HTTP)."""
         # reset streaming state
         self._stream_buffer.clear()
         self._stream_iterator = None
+        self._stream_opened = True
+        self._xet_mode = False
+
+        headers = self.fs._api._build_hf_headers()
+        xet_file_data, size = _try_get_xet_metadata(self.url(), headers, self.fs.endpoint)
+        if xet_file_data is not None:
+            self._xet_mode = True
+            if self.size is None and size is not None:
+                self.size = size
+            group = get_xet_download_stream_group(
+                refresh_route=xet_file_data.refresh_route, headers=headers, endpoint=self.fs.endpoint
+            )
+            start = self.loc if self.loc > 0 else None
+            self._stream_iterator = xet_download_stream(
+                group, xet_file_data.file_hash, self.size, start=start, end=None
+            )
+            return
 
         url = self.url()
-        headers = self.fs._api._build_hf_headers()
         if self.loc > 0:
             headers["Range"] = f"bytes={self.loc}-"
         self.response = self._exit_stack.enter_context(

--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -27,9 +27,11 @@ from .errors import (
     RepositoryNotFoundError,
     RevisionNotFoundError,
 )
-from .file_download import hf_hub_url, http_get
+from .file_download import get_hf_file_metadata, hf_hub_url, http_get
 from .hf_api import SPECIAL_REFS_REVISION_REGEX, BucketFile, BucketFolder, HfApi, LastCommitInfo, RepoFile, RepoFolder
-from .utils import HFValidationError, hf_raise_for_status, http_backoff, http_stream_backoff, parse_hf_uri
+from .utils import HFValidationError, XetFileData, hf_raise_for_status, http_backoff, http_stream_backoff, parse_hf_uri
+from .utils._runtime import is_xet_available
+from .utils._xet import get_xet_download_stream_group, xet_download_stream
 from .utils.insecure_hashlib import md5
 
 
@@ -1418,6 +1420,20 @@ def make_instance(cls, args, kwargs, instance_state):
     for attr, state_value in instance_state.items():
         setattr(fs, attr, state_value)
     return fs
+
+
+def _try_get_xet_metadata(
+    url: str, headers: dict[str, str], endpoint: str | None
+) -> tuple["XetFileData | None", int | None]:
+    """Return ``(xet_file_data, size)`` for ``url`` when Xet is usable, else ``(None, None)``.
+
+    Performs a single HEAD via :func:`get_hf_file_metadata`. ``xet_file_data`` is ``None``
+    when the file is not Xet-backed, in which case the caller falls back to HTTP.
+    """
+    if not is_xet_available():
+        return None, None
+    metadata = get_hf_file_metadata(url, headers=headers, endpoint=endpoint)
+    return metadata.xet_file_data, metadata.size
 
 
 hffs = HfFileSystem()

--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -1180,6 +1180,9 @@ class HfFileSystemFile(fsspec.spec.AbstractBufferedFile):
             raise
         super().__init__(fs, self.resolved_path.unresolve(), **kwargs)
         self.fs: HfFileSystem
+        self._xet_checked = False
+        self._xet_group = None
+        self._xet_file_hash: str | None = None
 
     def __del__(self):
         if not hasattr(self, "resolved_path"):
@@ -1187,7 +1190,32 @@ class HfFileSystemFile(fsspec.spec.AbstractBufferedFile):
             return
         return super().__del__()
 
+    def _ensure_xet(self) -> None:
+        if self._xet_checked:
+            return
+        self._xet_checked = True
+        headers = self.fs._api._build_hf_headers()
+        xet_file_data, size = _try_get_xet_metadata(self.url(), headers, self.fs.endpoint)
+        if xet_file_data is not None:
+            self._xet_group = get_xet_download_stream_group(
+                refresh_route=xet_file_data.refresh_route, headers=headers, endpoint=self.fs.endpoint
+            )
+            self._xet_file_hash = xet_file_data.file_hash
+            if self.size is None and size is not None:
+                self.size = size
+
     def _fetch_range(self, start: int, end: int) -> bytes:
+        self._ensure_xet()
+        if self._xet_group is not None:
+            try:
+                return b"".join(
+                    xet_download_stream(self._xet_group, self._xet_file_hash, self.size, start=start, end=end)
+                )
+            except KeyboardInterrupt:
+                from .utils._xet import abort_xet_session
+
+                abort_xet_session()
+                raise
         headers = {
             "range": f"bytes={start}-{end - 1}",
             **self.fs._api._build_hf_headers(),

--- a/src/huggingface_hub/utils/_xet.py
+++ b/src/huggingface_hub/utils/_xet.py
@@ -1,7 +1,6 @@
 import os
 import threading
 import time
-from collections import OrderedDict
 from collections.abc import Iterator
 from dataclasses import dataclass
 from enum import Enum
@@ -373,64 +372,43 @@ def abort_xet_session():
     _GLOBAL_XET_HOLDER.sigint_abort()
 
 
-# Bounded LRU cache of download stream groups. Each group holds a CAS connection pool;
-# evicted groups are released via the Rust `Drop` impl when garbage-collected (no explicit
-# close), same as the connection-info cache above. The bound keeps this from growing
-# unboundedly while amortizing the CAS handshake across files of a repo.
-XET_DOWNLOAD_STREAM_GROUP_CACHE_SIZE = 128
-_XET_DOWNLOAD_STREAM_GROUP_CACHE: "OrderedDict[str, object]" = OrderedDict()
-_XET_DOWNLOAD_STREAM_GROUP_LOCK = threading.Lock()
+def _xet_group_seed_kwargs(file_data: "XetFileData", headers: dict[str, str]) -> dict[str, Any]:
+    """Build the kwargs that seed a fresh download/file group with a cached read token.
 
+    The short-lived CAS read token (with its endpoint and expiry) is looked up via
+    :func:`refresh_xet_connection_info`, which caches it by refresh route + auth until expiry.
+    Seeding via ``token``/``token_expiry_unix_secs`` skips the group's initial token-refresh
+    round-trip, while ``token_refresh_url`` stays set so the group refreshes the token itself
+    once the seeded one expires.
 
-def _xet_download_stream_group_cache_key(refresh_route: str, headers: dict[str, str], endpoint: str) -> str:
-    lower_headers = {k.lower(): v for k, v in headers.items()}
-    auth_header = lower_headers.get("authorization", "")
-    return f"{endpoint}|{refresh_route}|{auth_header}"
-
-
-def get_xet_download_stream_group(
-    *, refresh_route: str, headers: dict[str, str], endpoint: str | None = None
-) -> "Any":
-    """Return a shared :class:`hf_xet.XetDownloadStreamGroup` for a repo's Xet endpoint.
-
-    Groups are cached (bounded LRU) by ``(endpoint, refresh_route, authorization)`` so the
-    CAS handshake and token fetch are amortized across all files/reads of a dataset.
+    Note: only this token info is cached (it is plain, fork-safe data). The group itself is
+    NOT cached — see :func:`open_xet_download_stream_group`.
     """
-    endpoint = endpoint if endpoint is not None else constants.ENDPOINT
-    key = _xet_download_stream_group_cache_key(refresh_route, headers, endpoint)
+    connection_info = refresh_xet_connection_info(file_data=file_data, headers=headers)
+    return {
+        "endpoint": connection_info.endpoint,
+        "token": connection_info.access_token,
+        "token_expiry_unix_secs": connection_info.expiration_unix_epoch,
+        "token_refresh_url": file_data.refresh_route,
+        "token_refresh_headers": headers,
+        "custom_headers": xet_headers_without_auth(headers),
+    }
 
-    # Fast path: return a cached group without doing any network work under the lock.
-    with _XET_DOWNLOAD_STREAM_GROUP_LOCK:
-        group = _XET_DOWNLOAD_STREAM_GROUP_CACHE.get(key)
-        if group is not None:
-            _XET_DOWNLOAD_STREAM_GROUP_CACHE.move_to_end(key)
-            return group
 
-    # Slow path: establish the connection outside the lock (network handshake).
+def open_xet_download_stream_group(*, file_data: "XetFileData", headers: dict[str, str]) -> "Any":
+    """Create a new :class:`hf_xet.XetDownloadStreamGroup`, seeded with a cached read token.
+
+    A fresh group is created on every call and is **never cached**. A group is bound to the
+    current :class:`hf_xet.XetSession`'s runtime, which is torn down on ``KeyboardInterrupt``
+    (:func:`abort_xet_session`) and is invalid in a forked child; a cached group would then
+    reference a dead runtime. Only the short-lived read token is cached (see
+    :func:`refresh_xet_connection_info`), so creating a group does not re-fetch the token.
+
+    Reuse the returned group for multiple ``download_stream`` calls on the same file (e.g.
+    across ``_fetch_range`` blocks); do not store it past the file's lifetime.
+    """
     session = get_xet_session()
-    group = session.new_download_stream_group(
-        token_refresh_url=refresh_route,
-        token_refresh_headers=headers,
-        custom_headers=xet_headers_without_auth(headers),
-    )
-
-    # Insert under the lock, honoring a concurrent insert of the same key.
-    with _XET_DOWNLOAD_STREAM_GROUP_LOCK:
-        existing = _XET_DOWNLOAD_STREAM_GROUP_CACHE.get(key)
-        if existing is not None:
-            group = existing
-        else:
-            _XET_DOWNLOAD_STREAM_GROUP_CACHE[key] = group
-            while len(_XET_DOWNLOAD_STREAM_GROUP_CACHE) > XET_DOWNLOAD_STREAM_GROUP_CACHE_SIZE:
-                _XET_DOWNLOAD_STREAM_GROUP_CACHE.popitem(last=False)
-        _XET_DOWNLOAD_STREAM_GROUP_CACHE.move_to_end(key)
-        return group
-
-
-def reset_xet_download_stream_group_cache() -> None:
-    """Clear the cached download stream groups. Used by tests."""
-    with _XET_DOWNLOAD_STREAM_GROUP_LOCK:
-        _XET_DOWNLOAD_STREAM_GROUP_CACHE.clear()
+    return session.new_download_stream_group(**_xet_group_seed_kwargs(file_data, headers))
 
 
 def xet_download_stream(
@@ -444,3 +422,34 @@ def xet_download_stream(
 
     file_info = XetFileInfo(file_hash, size)
     return group.download_stream(file_info, start=start, end=end)
+
+
+def xet_download_file(
+    *,
+    file_data: "XetFileData",
+    headers: dict[str, str],
+    size: int | None,
+    path: str,
+    progress_callback: "Any | None" = None,
+) -> None:
+    """Download a Xet file directly to ``path`` on disk via a fresh file-download group.
+
+    Unlike :func:`xet_download_stream` (which reconstructs through Python on every read),
+    this lets ``hf_xet`` write the file from Rust (parallel) and populates the local chunk
+    cache, so it is the right tool when a real local path is available. The group is created
+    fresh and seeded with a cached read token (never cached itself, like
+    :func:`open_xet_download_stream_group`). ``progress_callback``, if given, receives
+    ``(GroupProgressReport, dict)`` updates roughly every 100ms.
+    """
+    from hf_xet import XetFileInfo  # type: ignore[no-redef]
+
+    session = get_xet_session()
+    group_kwargs = _xet_group_seed_kwargs(file_data, headers)
+    if progress_callback is not None:
+        group_kwargs["progress_callback"] = progress_callback
+    try:
+        with session.new_file_download_group(**group_kwargs) as group:
+            group.start_download_file(XetFileInfo(file_data.file_hash, size), path)
+    except KeyboardInterrupt:
+        abort_xet_session()
+        raise

--- a/src/huggingface_hub/utils/_xet.py
+++ b/src/huggingface_hub/utils/_xet.py
@@ -1,6 +1,7 @@
 import os
 import threading
 import time
+from collections import OrderedDict
 from dataclasses import dataclass
 from enum import Enum
 
@@ -368,3 +369,57 @@ def abort_xet_session():
     call to :func:`get_xet_session` starts fresh (notebook-friendly).
     """
     _GLOBAL_XET_HOLDER.sigint_abort()
+
+
+XET_DOWNLOAD_STREAM_GROUP_CACHE_SIZE = 128
+_XET_DOWNLOAD_STREAM_GROUP_CACHE: "OrderedDict[str, object]" = OrderedDict()
+_XET_DOWNLOAD_STREAM_GROUP_LOCK = threading.Lock()
+
+
+def _xet_download_stream_group_cache_key(refresh_route: str, headers: dict[str, str], endpoint: str) -> str:
+    lower_headers = {k.lower(): v for k, v in headers.items()}
+    auth_header = lower_headers.get("authorization", "")
+    return f"{endpoint}|{refresh_route}|{auth_header}"
+
+
+def get_xet_download_stream_group(*, refresh_route: str, headers: dict[str, str], endpoint: str | None = None):
+    """Return a shared :class:`hf_xet.XetDownloadStreamGroup` for a repo's Xet endpoint.
+
+    Groups are cached (bounded LRU) by ``(endpoint, refresh_route, authorization)`` so the
+    CAS handshake and token fetch are amortized across all files/reads of a dataset.
+    """
+    endpoint = endpoint if endpoint is not None else constants.ENDPOINT
+    key = _xet_download_stream_group_cache_key(refresh_route, headers, endpoint)
+    with _XET_DOWNLOAD_STREAM_GROUP_LOCK:
+        group = _XET_DOWNLOAD_STREAM_GROUP_CACHE.get(key)
+        if group is not None:
+            _XET_DOWNLOAD_STREAM_GROUP_CACHE.move_to_end(key)
+            return group
+        session = get_xet_session()
+        group = session.new_download_stream_group(
+            token_refresh_url=refresh_route,
+            token_refresh_headers=headers,
+            custom_headers=xet_headers_without_auth(headers),
+        )
+        _XET_DOWNLOAD_STREAM_GROUP_CACHE[key] = group
+        _XET_DOWNLOAD_STREAM_GROUP_CACHE.move_to_end(key)
+        while len(_XET_DOWNLOAD_STREAM_GROUP_CACHE) > XET_DOWNLOAD_STREAM_GROUP_CACHE_SIZE:
+            _XET_DOWNLOAD_STREAM_GROUP_CACHE.popitem(last=False)
+        return group
+
+
+def reset_xet_download_stream_group_cache() -> None:
+    """Clear the cached download stream groups. Used by tests."""
+    with _XET_DOWNLOAD_STREAM_GROUP_LOCK:
+        _XET_DOWNLOAD_STREAM_GROUP_CACHE.clear()
+
+
+def xet_download_stream(group, file_hash: str, size: int | None, start: int | None = None, end: int | None = None):
+    """Return an ordered ``bytes`` iterator for ``[start, end)`` of a Xet file.
+
+    ``end`` is exclusive, matching both fsspec ``_fetch_range`` and hf_xet ``download_stream``.
+    """
+    from hf_xet import XetFileInfo  # type: ignore[no-redef]
+
+    file_info = XetFileInfo(file_hash, size)
+    return group.download_stream(file_info, start=start, end=end)

--- a/src/huggingface_hub/utils/_xet.py
+++ b/src/huggingface_hub/utils/_xet.py
@@ -388,7 +388,9 @@ def _xet_download_stream_group_cache_key(refresh_route: str, headers: dict[str, 
     return f"{endpoint}|{refresh_route}|{auth_header}"
 
 
-def get_xet_download_stream_group(*, refresh_route: str, headers: dict[str, str], endpoint: str | None = None) -> "Any":
+def get_xet_download_stream_group(
+    *, refresh_route: str, headers: dict[str, str], endpoint: str | None = None
+) -> "Any":
     """Return a shared :class:`hf_xet.XetDownloadStreamGroup` for a repo's Xet endpoint.
 
     Groups are cached (bounded LRU) by ``(endpoint, refresh_route, authorization)`` so the
@@ -431,7 +433,9 @@ def reset_xet_download_stream_group_cache() -> None:
         _XET_DOWNLOAD_STREAM_GROUP_CACHE.clear()
 
 
-def xet_download_stream(group: "Any", file_hash: str, size: int | None, start: int | None = None, end: int | None = None) -> Iterator[bytes]:
+def xet_download_stream(
+    group: "Any", file_hash: str, size: int | None, start: int | None = None, end: int | None = None
+) -> Iterator[bytes]:
     """Return an ordered ``bytes`` iterator for ``[start, end)`` of a Xet file.
 
     ``end`` is exclusive, matching both fsspec ``_fetch_range`` and hf_xet ``download_stream``.

--- a/src/huggingface_hub/utils/_xet.py
+++ b/src/huggingface_hub/utils/_xet.py
@@ -2,8 +2,10 @@ import os
 import threading
 import time
 from collections import OrderedDict
+from collections.abc import Iterator
 from dataclasses import dataclass
 from enum import Enum
+from typing import Any
 
 import httpx
 
@@ -382,7 +384,7 @@ def _xet_download_stream_group_cache_key(refresh_route: str, headers: dict[str, 
     return f"{endpoint}|{refresh_route}|{auth_header}"
 
 
-def get_xet_download_stream_group(*, refresh_route: str, headers: dict[str, str], endpoint: str | None = None):
+def get_xet_download_stream_group(*, refresh_route: str, headers: dict[str, str], endpoint: str | None = None) -> "Any":
     """Return a shared :class:`hf_xet.XetDownloadStreamGroup` for a repo's Xet endpoint.
 
     Groups are cached (bounded LRU) by ``(endpoint, refresh_route, authorization)`` so the
@@ -390,21 +392,32 @@ def get_xet_download_stream_group(*, refresh_route: str, headers: dict[str, str]
     """
     endpoint = endpoint if endpoint is not None else constants.ENDPOINT
     key = _xet_download_stream_group_cache_key(refresh_route, headers, endpoint)
+
+    # Fast path: return a cached group without doing any network work under the lock.
     with _XET_DOWNLOAD_STREAM_GROUP_LOCK:
         group = _XET_DOWNLOAD_STREAM_GROUP_CACHE.get(key)
         if group is not None:
             _XET_DOWNLOAD_STREAM_GROUP_CACHE.move_to_end(key)
             return group
-        session = get_xet_session()
-        group = session.new_download_stream_group(
-            token_refresh_url=refresh_route,
-            token_refresh_headers=headers,
-            custom_headers=xet_headers_without_auth(headers),
-        )
-        _XET_DOWNLOAD_STREAM_GROUP_CACHE[key] = group
+
+    # Slow path: establish the connection outside the lock (network handshake).
+    session = get_xet_session()
+    group = session.new_download_stream_group(
+        token_refresh_url=refresh_route,
+        token_refresh_headers=headers,
+        custom_headers=xet_headers_without_auth(headers),
+    )
+
+    # Insert under the lock, honoring a concurrent insert of the same key.
+    with _XET_DOWNLOAD_STREAM_GROUP_LOCK:
+        existing = _XET_DOWNLOAD_STREAM_GROUP_CACHE.get(key)
+        if existing is not None:
+            group = existing
+        else:
+            _XET_DOWNLOAD_STREAM_GROUP_CACHE[key] = group
+            while len(_XET_DOWNLOAD_STREAM_GROUP_CACHE) > XET_DOWNLOAD_STREAM_GROUP_CACHE_SIZE:
+                _XET_DOWNLOAD_STREAM_GROUP_CACHE.popitem(last=False)
         _XET_DOWNLOAD_STREAM_GROUP_CACHE.move_to_end(key)
-        while len(_XET_DOWNLOAD_STREAM_GROUP_CACHE) > XET_DOWNLOAD_STREAM_GROUP_CACHE_SIZE:
-            _XET_DOWNLOAD_STREAM_GROUP_CACHE.popitem(last=False)
         return group
 
 
@@ -414,7 +427,7 @@ def reset_xet_download_stream_group_cache() -> None:
         _XET_DOWNLOAD_STREAM_GROUP_CACHE.clear()
 
 
-def xet_download_stream(group, file_hash: str, size: int | None, start: int | None = None, end: int | None = None):
+def xet_download_stream(group: "Any", file_hash: str, size: int | None, start: int | None = None, end: int | None = None) -> Iterator[bytes]:
     """Return an ordered ``bytes`` iterator for ``[start, end)`` of a Xet file.
 
     ``end`` is exclusive, matching both fsspec ``_fetch_range`` and hf_xet ``download_stream``.

--- a/src/huggingface_hub/utils/_xet.py
+++ b/src/huggingface_hub/utils/_xet.py
@@ -373,6 +373,10 @@ def abort_xet_session():
     _GLOBAL_XET_HOLDER.sigint_abort()
 
 
+# Bounded LRU cache of download stream groups. Each group holds a CAS connection pool;
+# evicted groups are released via the Rust `Drop` impl when garbage-collected (no explicit
+# close), same as the connection-info cache above. The bound keeps this from growing
+# unboundedly while amortizing the CAS handshake across files of a repo.
 XET_DOWNLOAD_STREAM_GROUP_CACHE_SIZE = 128
 _XET_DOWNLOAD_STREAM_GROUP_CACHE: "OrderedDict[str, object]" = OrderedDict()
 _XET_DOWNLOAD_STREAM_GROUP_LOCK = threading.Lock()

--- a/tests/test_hf_file_system.py
+++ b/tests/test_hf_file_system.py
@@ -7,6 +7,7 @@ import os
 import pickle
 import tempfile
 import unittest
+from contextlib import ExitStack
 from pathlib import Path
 from typing import Iterable, Optional, Type
 from unittest.mock import MagicMock, Mock, patch
@@ -132,10 +133,13 @@ class _HfFileSystemBaseROTests(_HfFileSystemBaseTests):
         with self.hffs.open(self.hf_path + "/data/binary_data.bin", block_size=0) as f:
             self.assertIsInstance(f, HfFileSystemStreamFile)
             self.assertEqual(f.read(6), b"dummy ")
-            # Simulate that streaming fails mid-way
+            # Simulate that streaming fails mid-way (HTTP mode only: drop the response)
             f.response = None
             self.assertEqual(f.read(6), b"binary")
-            self.assertIsNotNone(f.response)  # a new connection has been created
+            # In HTTP mode a new connection is opened (response becomes non-None).
+            # In Xet mode there is no response object; the stream iterator drives reads.
+            if not f._xet_mode:
+                self.assertIsNotNone(f.response)  # a new connection has been created
 
     def test_stream_file_reuse_response(self):
         with self.hffs.open(self.hf_path + "/data/binary_data.bin", block_size=0) as f:
@@ -158,6 +162,8 @@ class _HfFileSystemBaseROTests(_HfFileSystemBaseTests):
         f = HfFileSystemStreamFile(self.hffs, self.hf_path + "/data/binary_data.bin")  # dummy
         f.response = _FakeResponse(chunks)
         f._stream_iterator = f.response.iter_bytes()
+        f._stream_opened = True
+        f._xet_mode = False
         return f
 
     def test_stream_buffer_overflow_leftover_is_buffered(self):
@@ -1011,3 +1017,74 @@ class TestHfFileSystemFileXetRouting:
             f._fetch_range(0, 1)
             f._fetch_range(1, 2)
         mock_meta.assert_called_once()  # detection HEAD happens at most once per file
+
+
+class TestHfFileSystemStreamFileXetRouting:
+    def _make_stream_file(self):
+        fs = HfFileSystem(endpoint="https://hub")
+        f = HfFileSystemStreamFile.__new__(HfFileSystemStreamFile)
+        f.fs = fs
+        f.path = "datasets/x/data.parquet"
+        f.loc = 0
+        f.size = None
+        f.response = None
+        f._stream_opened = False
+        f._xet_mode = False
+        f._stream_iterator = None
+        f._stream_buffer = bytearray()
+        f._exit_stack = ExitStack()
+        f.url = lambda: "https://hub/resolve/data.parquet"
+        return f, fs
+
+    def test_open_connection_uses_xet_when_backed(self):
+        f, fs = self._make_stream_file()
+        fake_group = object()
+        with patch.object(hffs_mod, "_try_get_xet_metadata",
+                          return_value=(XetFileData(file_hash="h", refresh_route="r"), 8)), \
+             patch.object(hffs_mod, "get_xet_download_stream_group", return_value=fake_group), \
+             patch.object(hffs_mod, "xet_download_stream", return_value=iter([b"abcd", b"efgh"])) as mock_stream, \
+             patch.object(fs._api, "_build_hf_headers", return_value={"authorization": "a"}):
+            data = f.read()
+        assert data == b"abcdefgh"
+        assert f.response is None
+        assert f._xet_mode is True
+        assert mock_stream.call_args[0] == (fake_group, "h", 8)
+        assert mock_stream.call_args[1] == {"start": None, "end": None}
+
+    def test_open_connection_falls_back_to_http(self):
+        f, fs = self._make_stream_file()
+        with patch.object(hffs_mod, "_try_get_xet_metadata", return_value=(None, None)), \
+             patch.object(hffs_mod, "http_stream_backoff") as mock_http, \
+             patch.object(hffs_mod, "hf_raise_for_status"), \
+             patch.object(fs._api, "_build_hf_headers", return_value={}):
+            response = MagicMock()
+            response.iter_bytes.return_value = iter([b"xy"])
+            mock_http.return_value.__enter__.return_value = response
+            data = f.read()
+        assert data == b"xy"
+        assert f._xet_mode is False
+        mock_http.assert_called_once()
+
+    def test_http_response_none_forces_reopen(self):
+        # Offline mirror of test_stream_file_retry: in HTTP mode, dropping `response`
+        # mid-stream must trigger a fresh connection on the next read.
+        f, fs = self._make_stream_file()
+        opened = []
+
+        def fake_http(*args, **kwargs):
+            resp = MagicMock()
+            resp.iter_bytes.return_value = iter([b"part"])
+            opened.append(resp)
+            cm = MagicMock()
+            cm.__enter__.return_value = resp
+            return cm
+
+        with patch.object(hffs_mod, "_try_get_xet_metadata", return_value=(None, None)), \
+             patch.object(hffs_mod, "http_stream_backoff", side_effect=fake_http), \
+             patch.object(hffs_mod, "hf_raise_for_status"), \
+             patch.object(fs._api, "_build_hf_headers", return_value={}):
+            assert f.read(4) == b"part"
+            f.response = None  # simulate mid-stream failure
+            assert f.read(4) == b"part"
+        assert len(opened) == 2  # a new connection was opened
+        assert f.response is not None

--- a/tests/test_hf_file_system.py
+++ b/tests/test_hf_file_system.py
@@ -1105,6 +1105,33 @@ class TestHfFileSystemStreamFileXetRouting:
                 f.read()
         mock_abort.assert_called_once()
 
+    def test_xet_stream_resumes_byte_exact_after_midstream_error(self):
+        # A non-KeyboardInterrupt failure mid-stream must be retried by reopening the
+        # xet stream from self.loc (only advanced on bytes actually returned), producing
+        # byte-exact output with no loss or duplication.
+        f, fs = self._make_stream_file()
+        starts = []
+
+        def fake_stream(group, file_hash, size, start=None, end=None):
+            starts.append(start)
+            if len(starts) == 1:
+                def gen():
+                    yield b"abcd"
+                    raise RuntimeError("mid-stream failure")
+                return gen()
+            return iter([b"efgh"])
+
+        with patch.object(hffs_mod, "_try_get_xet_metadata",
+                          return_value=(XetFileData(file_hash="h", refresh_route="r"), 8)), \
+             patch.object(hffs_mod, "get_xet_download_stream_group", return_value=object()), \
+             patch.object(hffs_mod, "xet_download_stream", side_effect=fake_stream), \
+             patch.object(fs._api, "_build_hf_headers", return_value={}):
+            first = f.read(4)
+            second = f.read(4)
+        assert first == b"abcd"
+        assert second == b"efgh"
+        assert starts == [None, 4]  # resumed from self.loc after the 4 returned bytes
+
 
 class TestGetFileXetRouting:
     def test_get_file_uses_xet_when_backed(self, tmp_path):

--- a/tests/test_hf_file_system.py
+++ b/tests/test_hf_file_system.py
@@ -954,6 +954,11 @@ class TestXetMetadataResolution:
         assert kwargs["headers"] == {"authorization": "a"}
         assert kwargs["endpoint"] == "http://endpoint"
 
+    def test_returns_none_when_metadata_lookup_fails(self):
+        with patch.object(hffs_mod, "is_xet_available", return_value=True), \
+             patch.object(hffs_mod, "get_hf_file_metadata", side_effect=RuntimeError("boom")):
+            assert hffs_mod._try_get_xet_metadata("http://u", {"authorization": "a"}, None) == (None, None)
+
 
 class TestHfFileSystemFileXetRouting:
     def _make_file(self):

--- a/tests/test_hf_file_system.py
+++ b/tests/test_hf_file_system.py
@@ -996,7 +996,7 @@ class TestHfFileSystemFileXetRouting:
             patch.object(
                 hffs_mod, "_try_get_xet_metadata", return_value=(XetFileData(file_hash="h", refresh_route="r"), 100)
             ),
-            patch.object(hffs_mod, "get_xet_download_stream_group", return_value=fake_group),
+            patch.object(hffs_mod, "open_xet_download_stream_group", return_value=fake_group),
             patch.object(hffs_mod, "xet_download_stream", return_value=iter([b"AB", b"CD"])) as mock_stream,
             patch.object(fs._api, "_build_hf_headers", return_value={"authorization": "a"}),
         ):
@@ -1027,7 +1027,7 @@ class TestHfFileSystemFileXetRouting:
             patch.object(
                 hffs_mod, "_try_get_xet_metadata", return_value=(XetFileData(file_hash="h", refresh_route="r"), 100)
             ) as mock_meta,
-            patch.object(hffs_mod, "get_xet_download_stream_group", return_value=fake_group),
+            patch.object(hffs_mod, "open_xet_download_stream_group", return_value=fake_group),
             patch.object(hffs_mod, "xet_download_stream", return_value=iter([b"x"])),
             patch.object(fs._api, "_build_hf_headers", return_value={"authorization": "a"}),
         ):
@@ -1060,7 +1060,7 @@ class TestHfFileSystemStreamFileXetRouting:
             patch.object(
                 hffs_mod, "_try_get_xet_metadata", return_value=(XetFileData(file_hash="h", refresh_route="r"), 8)
             ),
-            patch.object(hffs_mod, "get_xet_download_stream_group", return_value=fake_group),
+            patch.object(hffs_mod, "open_xet_download_stream_group", return_value=fake_group),
             patch.object(hffs_mod, "xet_download_stream", return_value=iter([b"abcd", b"efgh"])) as mock_stream,
             patch.object(fs._api, "_build_hf_headers", return_value={"authorization": "a"}),
         ):
@@ -1123,7 +1123,7 @@ class TestHfFileSystemStreamFileXetRouting:
             patch.object(
                 hffs_mod, "_try_get_xet_metadata", return_value=(XetFileData(file_hash="h", refresh_route="r"), 8)
             ),
-            patch.object(hffs_mod, "get_xet_download_stream_group", return_value=object()),
+            patch.object(hffs_mod, "open_xet_download_stream_group", return_value=object()),
             patch.object(hffs_mod, "xet_download_stream", side_effect=boom),
             patch.object(fs._api, "_build_hf_headers", return_value={}),
             patch("huggingface_hub.utils._xet.abort_xet_session") as mock_abort,
@@ -1154,7 +1154,7 @@ class TestHfFileSystemStreamFileXetRouting:
             patch.object(
                 hffs_mod, "_try_get_xet_metadata", return_value=(XetFileData(file_hash="h", refresh_route="r"), 8)
             ),
-            patch.object(hffs_mod, "get_xet_download_stream_group", return_value=object()),
+            patch.object(hffs_mod, "open_xet_download_stream_group", return_value=object()),
             patch.object(hffs_mod, "xet_download_stream", side_effect=fake_stream),
             patch.object(fs._api, "_build_hf_headers", return_value={}),
         ):
@@ -1166,9 +1166,39 @@ class TestHfFileSystemStreamFileXetRouting:
 
 
 class TestGetFileXetRouting:
-    def test_get_file_uses_xet_when_backed(self, tmp_path):
+    def test_get_file_to_path_uses_xet_download_file(self, tmp_path):
+        # A real local path => hand the path to hf_xet (file-based download, writes to disk).
         fs = HfFileSystem(endpoint="https://hub")
         out_path = tmp_path / "out.bin"
+
+        def fake_download_file(*, file_data, headers, size, path, progress_callback=None):
+            Path(path).write_bytes(b"abcdef")
+
+        with (
+            patch.object(fs, "resolve_path") as mock_resolve,
+            patch.object(fs, "info", return_value={"size": 6}),
+            patch.object(fs, "isdir", return_value=False),
+            patch.object(fs, "url", return_value="https://hub/resolve/data.bin"),
+            patch.object(fs._api, "_build_hf_headers", return_value={"authorization": "a"}),
+            patch.object(
+                hffs_mod, "_try_get_xet_metadata", return_value=(XetFileData(file_hash="h", refresh_route="r"), 6)
+            ),
+            patch.object(hffs_mod, "xet_download_file", side_effect=fake_download_file) as mock_dl,
+            patch.object(hffs_mod, "xet_download_stream") as mock_stream,
+        ):
+            mock_resolve.return_value.unresolve.return_value = "hf://datasets/x/data.bin"
+            fs.get_file("datasets/x/data.bin", str(out_path))
+        assert out_path.read_bytes() == b"abcdef"
+        mock_stream.assert_not_called()  # path target must not stream chunks through Python
+        _, kwargs = mock_dl.call_args
+        assert kwargs["file_data"] == XetFileData(file_hash="h", refresh_route="r")
+        assert kwargs["size"] == 6
+        assert kwargs["path"] == str(out_path.absolute())
+
+    def test_get_file_to_filelike_uses_streaming(self):
+        # A file-like target has no path for hf_xet to write to => stream chunks.
+        fs = HfFileSystem(endpoint="https://hub")
+        buf = io.BytesIO()
         fake_group = object()
         with (
             patch.object(fs, "resolve_path") as mock_resolve,
@@ -1179,13 +1209,16 @@ class TestGetFileXetRouting:
             patch.object(
                 hffs_mod, "_try_get_xet_metadata", return_value=(XetFileData(file_hash="h", refresh_route="r"), 6)
             ),
-            patch.object(hffs_mod, "get_xet_download_stream_group", return_value=fake_group),
+            patch.object(hffs_mod, "open_xet_download_stream_group", return_value=fake_group),
+            patch.object(hffs_mod, "xet_download_file") as mock_dl,
             patch.object(hffs_mod, "xet_download_stream", return_value=iter([b"abc", b"def"])) as mock_stream,
         ):
             mock_resolve.return_value.unresolve.return_value = "hf://datasets/x/data.bin"
-            fs.get_file("datasets/x/data.bin", str(out_path))
-        assert out_path.read_bytes() == b"abcdef"
+            fs.get_file("datasets/x/data.bin", buf)
+        assert buf.getvalue() == b"abcdef"
+        mock_stream.assert_called_once()
         assert mock_stream.call_args[0] == (fake_group, "h", 6)
+        mock_dl.assert_not_called()  # file-like target must not use the file-based download
 
     def test_get_file_falls_back_to_http_when_not_xet(self, tmp_path):
         fs = HfFileSystem(endpoint="https://hub")
@@ -1208,9 +1241,9 @@ class TestGetFileXetRouting:
         assert out_path.read_bytes() == b"http-data"
         mock_http.assert_called_once()
 
-    def test_get_file_aborts_xet_session_on_keyboard_interrupt(self, tmp_path):
+    def test_get_file_to_filelike_aborts_xet_session_on_keyboard_interrupt(self):
         fs = HfFileSystem(endpoint="https://hub")
-        out_path = tmp_path / "out.bin"
+        buf = io.BytesIO()
 
         def boom(*args, **kwargs):
             raise KeyboardInterrupt
@@ -1224,11 +1257,11 @@ class TestGetFileXetRouting:
             patch.object(
                 hffs_mod, "_try_get_xet_metadata", return_value=(XetFileData(file_hash="h", refresh_route="r"), 6)
             ),
-            patch.object(hffs_mod, "get_xet_download_stream_group", return_value=object()),
+            patch.object(hffs_mod, "open_xet_download_stream_group", return_value=object()),
             patch.object(hffs_mod, "xet_download_stream", side_effect=boom),
             patch("huggingface_hub.utils._xet.abort_xet_session") as mock_abort,
         ):
             mock_resolve.return_value.unresolve.return_value = "hf://datasets/x/data.bin"
             with pytest.raises(KeyboardInterrupt):
-                fs.get_file("datasets/x/data.bin", str(out_path))
+                fs.get_file("datasets/x/data.bin", buf)
         mock_abort.assert_called_once()

--- a/tests/test_hf_file_system.py
+++ b/tests/test_hf_file_system.py
@@ -1104,3 +1104,62 @@ class TestHfFileSystemStreamFileXetRouting:
             with pytest.raises(KeyboardInterrupt):
                 f.read()
         mock_abort.assert_called_once()
+
+
+class TestGetFileXetRouting:
+    def test_get_file_uses_xet_when_backed(self, tmp_path):
+        fs = HfFileSystem(endpoint="https://hub")
+        out_path = tmp_path / "out.bin"
+        fake_group = object()
+        with patch.object(fs, "resolve_path") as mock_resolve, \
+             patch.object(fs, "info", return_value={"size": 6}), \
+             patch.object(fs, "isdir", return_value=False), \
+             patch.object(fs, "url", return_value="https://hub/resolve/data.bin"), \
+             patch.object(fs._api, "_build_hf_headers", return_value={"authorization": "a"}), \
+             patch.object(hffs_mod, "_try_get_xet_metadata",
+                          return_value=(XetFileData(file_hash="h", refresh_route="r"), 6)), \
+             patch.object(hffs_mod, "get_xet_download_stream_group", return_value=fake_group), \
+             patch.object(hffs_mod, "xet_download_stream", return_value=iter([b"abc", b"def"])) as mock_stream:
+            mock_resolve.return_value.unresolve.return_value = "hf://datasets/x/data.bin"
+            fs.get_file("datasets/x/data.bin", str(out_path))
+        assert out_path.read_bytes() == b"abcdef"
+        assert mock_stream.call_args[0] == (fake_group, "h", 6)
+
+    def test_get_file_falls_back_to_http_when_not_xet(self, tmp_path):
+        fs = HfFileSystem(endpoint="https://hub")
+        out_path = tmp_path / "out.bin"
+        def fake_http_get(*, url, temp_file, **kwargs):
+            temp_file.write(b"http-data")
+        with patch.object(fs, "resolve_path") as mock_resolve, \
+             patch.object(fs, "info", return_value={"size": 9}), \
+             patch.object(fs, "isdir", return_value=False), \
+             patch.object(fs, "url", return_value="https://hub/resolve/data.bin"), \
+             patch.object(fs._api, "_build_hf_headers", return_value={"authorization": "a"}), \
+             patch.object(hffs_mod, "_try_get_xet_metadata", return_value=(None, None)), \
+             patch.object(hffs_mod, "http_get", side_effect=fake_http_get) as mock_http:
+            mock_resolve.return_value.unresolve.return_value = "hf://datasets/x/data.bin"
+            fs.get_file("datasets/x/data.bin", str(out_path))
+        assert out_path.read_bytes() == b"http-data"
+        mock_http.assert_called_once()
+
+    def test_get_file_aborts_xet_session_on_keyboard_interrupt(self, tmp_path):
+        fs = HfFileSystem(endpoint="https://hub")
+        out_path = tmp_path / "out.bin"
+
+        def boom(*args, **kwargs):
+            raise KeyboardInterrupt
+
+        with patch.object(fs, "resolve_path") as mock_resolve, \
+             patch.object(fs, "info", return_value={"size": 6}), \
+             patch.object(fs, "isdir", return_value=False), \
+             patch.object(fs, "url", return_value="https://hub/resolve/data.bin"), \
+             patch.object(fs._api, "_build_hf_headers", return_value={"authorization": "a"}), \
+             patch.object(hffs_mod, "_try_get_xet_metadata",
+                          return_value=(XetFileData(file_hash="h", refresh_route="r"), 6)), \
+             patch.object(hffs_mod, "get_xet_download_stream_group", return_value=object()), \
+             patch.object(hffs_mod, "xet_download_stream", side_effect=boom), \
+             patch("huggingface_hub.utils._xet.abort_xet_session") as mock_abort:
+            mock_resolve.return_value.unresolve.return_value = "hf://datasets/x/data.bin"
+            with pytest.raises(KeyboardInterrupt):
+                fs.get_file("datasets/x/data.bin", str(out_path))
+        mock_abort.assert_called_once()

--- a/tests/test_hf_file_system.py
+++ b/tests/test_hf_file_system.py
@@ -19,7 +19,6 @@ import huggingface_hub.hf_file_system as hffs_mod
 from huggingface_hub import HfApi, constants, hf_file_system
 from huggingface_hub.errors import BucketNotFoundError, RepositoryNotFoundError, RevisionNotFoundError
 from huggingface_hub.file_download import HfFileMetadata
-from huggingface_hub.utils import XetFileData
 from huggingface_hub.hf_file_system import (
     HfFileSystem,
     HfFileSystemFile,
@@ -27,6 +26,7 @@ from huggingface_hub.hf_file_system import (
     HfFileSystemResolvedRepositoryPath,
     HfFileSystemStreamFile,
 )
+from huggingface_hub.utils import XetFileData
 
 from .testing_constants import ENDPOINT_STAGING, TOKEN
 from .testing_utils import OfflineSimulationMode, offline, repo_name, with_production_testing
@@ -941,18 +941,25 @@ def test_hf_file_system_file_can_handle_gzipped_file():
 
 class TestXetMetadataResolution:
     def test_returns_none_when_xet_unavailable(self):
-        with patch.object(hffs_mod, "is_xet_available", return_value=False), \
-             patch.object(hffs_mod, "get_hf_file_metadata") as mock_meta:
+        with (
+            patch.object(hffs_mod, "is_xet_available", return_value=False),
+            patch.object(hffs_mod, "get_hf_file_metadata") as mock_meta,
+        ):
             assert hffs_mod._try_get_xet_metadata("http://u", {}, None) == (None, None)
         mock_meta.assert_not_called()
 
     def test_returns_xet_file_data_and_size_when_available(self):
         meta = HfFileMetadata(
-            commit_hash="c", etag="e", location="loc", size=1234,
+            commit_hash="c",
+            etag="e",
+            location="loc",
+            size=1234,
             xet_file_data=XetFileData(file_hash="h", refresh_route="r"),
         )
-        with patch.object(hffs_mod, "is_xet_available", return_value=True), \
-             patch.object(hffs_mod, "get_hf_file_metadata", return_value=meta) as mock_meta:
+        with (
+            patch.object(hffs_mod, "is_xet_available", return_value=True),
+            patch.object(hffs_mod, "get_hf_file_metadata", return_value=meta) as mock_meta,
+        ):
             xfd, size = hffs_mod._try_get_xet_metadata("http://u", {"authorization": "a"}, "http://endpoint")
         assert xfd == XetFileData(file_hash="h", refresh_route="r")
         assert size == 1234
@@ -961,8 +968,10 @@ class TestXetMetadataResolution:
         assert kwargs["endpoint"] == "http://endpoint"
 
     def test_returns_none_when_metadata_lookup_fails(self):
-        with patch.object(hffs_mod, "is_xet_available", return_value=True), \
-             patch.object(hffs_mod, "get_hf_file_metadata", side_effect=RuntimeError("boom")):
+        with (
+            patch.object(hffs_mod, "is_xet_available", return_value=True),
+            patch.object(hffs_mod, "get_hf_file_metadata", side_effect=RuntimeError("boom")),
+        ):
             assert hffs_mod._try_get_xet_metadata("http://u", {"authorization": "a"}, None) == (None, None)
 
 
@@ -983,11 +992,14 @@ class TestHfFileSystemFileXetRouting:
     def test_fetch_range_uses_xet_when_backed(self):
         f, fs = self._make_file()
         fake_group = object()
-        with patch.object(hffs_mod, "_try_get_xet_metadata",
-                          return_value=(XetFileData(file_hash="h", refresh_route="r"), 100)), \
-             patch.object(hffs_mod, "get_xet_download_stream_group", return_value=fake_group), \
-             patch.object(hffs_mod, "xet_download_stream", return_value=iter([b"AB", b"CD"])) as mock_stream, \
-             patch.object(fs._api, "_build_hf_headers", return_value={"authorization": "a"}):
+        with (
+            patch.object(
+                hffs_mod, "_try_get_xet_metadata", return_value=(XetFileData(file_hash="h", refresh_route="r"), 100)
+            ),
+            patch.object(hffs_mod, "get_xet_download_stream_group", return_value=fake_group),
+            patch.object(hffs_mod, "xet_download_stream", return_value=iter([b"AB", b"CD"])) as mock_stream,
+            patch.object(fs._api, "_build_hf_headers", return_value={"authorization": "a"}),
+        ):
             out = f._fetch_range(10, 14)
         assert out == b"ABCD"
         _, kwargs = mock_stream.call_args
@@ -998,10 +1010,12 @@ class TestHfFileSystemFileXetRouting:
         f, fs = self._make_file()
         response = MagicMock()
         response.content = b"http-bytes"
-        with patch.object(hffs_mod, "_try_get_xet_metadata", return_value=(None, None)), \
-             patch.object(hffs_mod, "http_backoff", return_value=response) as mock_http, \
-             patch.object(hffs_mod, "hf_raise_for_status"), \
-             patch.object(fs._api, "_build_hf_headers", return_value={"authorization": "a"}):
+        with (
+            patch.object(hffs_mod, "_try_get_xet_metadata", return_value=(None, None)),
+            patch.object(hffs_mod, "http_backoff", return_value=response) as mock_http,
+            patch.object(hffs_mod, "hf_raise_for_status"),
+            patch.object(fs._api, "_build_hf_headers", return_value={"authorization": "a"}),
+        ):
             out = f._fetch_range(0, 10)
         assert out == b"http-bytes"
         mock_http.assert_called_once()
@@ -1009,11 +1023,14 @@ class TestHfFileSystemFileXetRouting:
     def test_fetch_range_detects_xet_only_once(self):
         f, fs = self._make_file()
         fake_group = object()
-        with patch.object(hffs_mod, "_try_get_xet_metadata",
-                          return_value=(XetFileData(file_hash="h", refresh_route="r"), 100)) as mock_meta, \
-             patch.object(hffs_mod, "get_xet_download_stream_group", return_value=fake_group), \
-             patch.object(hffs_mod, "xet_download_stream", return_value=iter([b"x"])), \
-             patch.object(fs._api, "_build_hf_headers", return_value={"authorization": "a"}):
+        with (
+            patch.object(
+                hffs_mod, "_try_get_xet_metadata", return_value=(XetFileData(file_hash="h", refresh_route="r"), 100)
+            ) as mock_meta,
+            patch.object(hffs_mod, "get_xet_download_stream_group", return_value=fake_group),
+            patch.object(hffs_mod, "xet_download_stream", return_value=iter([b"x"])),
+            patch.object(fs._api, "_build_hf_headers", return_value={"authorization": "a"}),
+        ):
             f._fetch_range(0, 1)
             f._fetch_range(1, 2)
         mock_meta.assert_called_once()  # detection HEAD happens at most once per file
@@ -1039,11 +1056,14 @@ class TestHfFileSystemStreamFileXetRouting:
     def test_open_connection_uses_xet_when_backed(self):
         f, fs = self._make_stream_file()
         fake_group = object()
-        with patch.object(hffs_mod, "_try_get_xet_metadata",
-                          return_value=(XetFileData(file_hash="h", refresh_route="r"), 8)), \
-             patch.object(hffs_mod, "get_xet_download_stream_group", return_value=fake_group), \
-             patch.object(hffs_mod, "xet_download_stream", return_value=iter([b"abcd", b"efgh"])) as mock_stream, \
-             patch.object(fs._api, "_build_hf_headers", return_value={"authorization": "a"}):
+        with (
+            patch.object(
+                hffs_mod, "_try_get_xet_metadata", return_value=(XetFileData(file_hash="h", refresh_route="r"), 8)
+            ),
+            patch.object(hffs_mod, "get_xet_download_stream_group", return_value=fake_group),
+            patch.object(hffs_mod, "xet_download_stream", return_value=iter([b"abcd", b"efgh"])) as mock_stream,
+            patch.object(fs._api, "_build_hf_headers", return_value={"authorization": "a"}),
+        ):
             data = f.read()
         assert data == b"abcdefgh"
         assert f.response is None
@@ -1053,10 +1073,12 @@ class TestHfFileSystemStreamFileXetRouting:
 
     def test_open_connection_falls_back_to_http(self):
         f, fs = self._make_stream_file()
-        with patch.object(hffs_mod, "_try_get_xet_metadata", return_value=(None, None)), \
-             patch.object(hffs_mod, "http_stream_backoff") as mock_http, \
-             patch.object(hffs_mod, "hf_raise_for_status"), \
-             patch.object(fs._api, "_build_hf_headers", return_value={}):
+        with (
+            patch.object(hffs_mod, "_try_get_xet_metadata", return_value=(None, None)),
+            patch.object(hffs_mod, "http_stream_backoff") as mock_http,
+            patch.object(hffs_mod, "hf_raise_for_status"),
+            patch.object(fs._api, "_build_hf_headers", return_value={}),
+        ):
             response = MagicMock()
             response.iter_bytes.return_value = iter([b"xy"])
             mock_http.return_value.__enter__.return_value = response
@@ -1079,10 +1101,12 @@ class TestHfFileSystemStreamFileXetRouting:
             cm.__enter__.return_value = resp
             return cm
 
-        with patch.object(hffs_mod, "_try_get_xet_metadata", return_value=(None, None)), \
-             patch.object(hffs_mod, "http_stream_backoff", side_effect=fake_http), \
-             patch.object(hffs_mod, "hf_raise_for_status"), \
-             patch.object(fs._api, "_build_hf_headers", return_value={}):
+        with (
+            patch.object(hffs_mod, "_try_get_xet_metadata", return_value=(None, None)),
+            patch.object(hffs_mod, "http_stream_backoff", side_effect=fake_http),
+            patch.object(hffs_mod, "hf_raise_for_status"),
+            patch.object(fs._api, "_build_hf_headers", return_value={}),
+        ):
             assert f.read(4) == b"part"
             f.response = None  # simulate mid-stream failure
             assert f.read(4) == b"part"
@@ -1095,12 +1119,15 @@ class TestHfFileSystemStreamFileXetRouting:
         def boom(*args, **kwargs):
             raise KeyboardInterrupt
 
-        with patch.object(hffs_mod, "_try_get_xet_metadata",
-                          return_value=(XetFileData(file_hash="h", refresh_route="r"), 8)), \
-             patch.object(hffs_mod, "get_xet_download_stream_group", return_value=object()), \
-             patch.object(hffs_mod, "xet_download_stream", side_effect=boom), \
-             patch.object(fs._api, "_build_hf_headers", return_value={}), \
-             patch("huggingface_hub.utils._xet.abort_xet_session") as mock_abort:
+        with (
+            patch.object(
+                hffs_mod, "_try_get_xet_metadata", return_value=(XetFileData(file_hash="h", refresh_route="r"), 8)
+            ),
+            patch.object(hffs_mod, "get_xet_download_stream_group", return_value=object()),
+            patch.object(hffs_mod, "xet_download_stream", side_effect=boom),
+            patch.object(fs._api, "_build_hf_headers", return_value={}),
+            patch("huggingface_hub.utils._xet.abort_xet_session") as mock_abort,
+        ):
             with pytest.raises(KeyboardInterrupt):
                 f.read()
         mock_abort.assert_called_once()
@@ -1115,17 +1142,22 @@ class TestHfFileSystemStreamFileXetRouting:
         def fake_stream(group, file_hash, size, start=None, end=None):
             starts.append(start)
             if len(starts) == 1:
+
                 def gen():
                     yield b"abcd"
                     raise RuntimeError("mid-stream failure")
+
                 return gen()
             return iter([b"efgh"])
 
-        with patch.object(hffs_mod, "_try_get_xet_metadata",
-                          return_value=(XetFileData(file_hash="h", refresh_route="r"), 8)), \
-             patch.object(hffs_mod, "get_xet_download_stream_group", return_value=object()), \
-             patch.object(hffs_mod, "xet_download_stream", side_effect=fake_stream), \
-             patch.object(fs._api, "_build_hf_headers", return_value={}):
+        with (
+            patch.object(
+                hffs_mod, "_try_get_xet_metadata", return_value=(XetFileData(file_hash="h", refresh_route="r"), 8)
+            ),
+            patch.object(hffs_mod, "get_xet_download_stream_group", return_value=object()),
+            patch.object(hffs_mod, "xet_download_stream", side_effect=fake_stream),
+            patch.object(fs._api, "_build_hf_headers", return_value={}),
+        ):
             first = f.read(4)
             second = f.read(4)
         assert first == b"abcd"
@@ -1138,15 +1170,18 @@ class TestGetFileXetRouting:
         fs = HfFileSystem(endpoint="https://hub")
         out_path = tmp_path / "out.bin"
         fake_group = object()
-        with patch.object(fs, "resolve_path") as mock_resolve, \
-             patch.object(fs, "info", return_value={"size": 6}), \
-             patch.object(fs, "isdir", return_value=False), \
-             patch.object(fs, "url", return_value="https://hub/resolve/data.bin"), \
-             patch.object(fs._api, "_build_hf_headers", return_value={"authorization": "a"}), \
-             patch.object(hffs_mod, "_try_get_xet_metadata",
-                          return_value=(XetFileData(file_hash="h", refresh_route="r"), 6)), \
-             patch.object(hffs_mod, "get_xet_download_stream_group", return_value=fake_group), \
-             patch.object(hffs_mod, "xet_download_stream", return_value=iter([b"abc", b"def"])) as mock_stream:
+        with (
+            patch.object(fs, "resolve_path") as mock_resolve,
+            patch.object(fs, "info", return_value={"size": 6}),
+            patch.object(fs, "isdir", return_value=False),
+            patch.object(fs, "url", return_value="https://hub/resolve/data.bin"),
+            patch.object(fs._api, "_build_hf_headers", return_value={"authorization": "a"}),
+            patch.object(
+                hffs_mod, "_try_get_xet_metadata", return_value=(XetFileData(file_hash="h", refresh_route="r"), 6)
+            ),
+            patch.object(hffs_mod, "get_xet_download_stream_group", return_value=fake_group),
+            patch.object(hffs_mod, "xet_download_stream", return_value=iter([b"abc", b"def"])) as mock_stream,
+        ):
             mock_resolve.return_value.unresolve.return_value = "hf://datasets/x/data.bin"
             fs.get_file("datasets/x/data.bin", str(out_path))
         assert out_path.read_bytes() == b"abcdef"
@@ -1155,15 +1190,19 @@ class TestGetFileXetRouting:
     def test_get_file_falls_back_to_http_when_not_xet(self, tmp_path):
         fs = HfFileSystem(endpoint="https://hub")
         out_path = tmp_path / "out.bin"
+
         def fake_http_get(*, url, temp_file, **kwargs):
             temp_file.write(b"http-data")
-        with patch.object(fs, "resolve_path") as mock_resolve, \
-             patch.object(fs, "info", return_value={"size": 9}), \
-             patch.object(fs, "isdir", return_value=False), \
-             patch.object(fs, "url", return_value="https://hub/resolve/data.bin"), \
-             patch.object(fs._api, "_build_hf_headers", return_value={"authorization": "a"}), \
-             patch.object(hffs_mod, "_try_get_xet_metadata", return_value=(None, None)), \
-             patch.object(hffs_mod, "http_get", side_effect=fake_http_get) as mock_http:
+
+        with (
+            patch.object(fs, "resolve_path") as mock_resolve,
+            patch.object(fs, "info", return_value={"size": 9}),
+            patch.object(fs, "isdir", return_value=False),
+            patch.object(fs, "url", return_value="https://hub/resolve/data.bin"),
+            patch.object(fs._api, "_build_hf_headers", return_value={"authorization": "a"}),
+            patch.object(hffs_mod, "_try_get_xet_metadata", return_value=(None, None)),
+            patch.object(hffs_mod, "http_get", side_effect=fake_http_get) as mock_http,
+        ):
             mock_resolve.return_value.unresolve.return_value = "hf://datasets/x/data.bin"
             fs.get_file("datasets/x/data.bin", str(out_path))
         assert out_path.read_bytes() == b"http-data"
@@ -1176,16 +1215,19 @@ class TestGetFileXetRouting:
         def boom(*args, **kwargs):
             raise KeyboardInterrupt
 
-        with patch.object(fs, "resolve_path") as mock_resolve, \
-             patch.object(fs, "info", return_value={"size": 6}), \
-             patch.object(fs, "isdir", return_value=False), \
-             patch.object(fs, "url", return_value="https://hub/resolve/data.bin"), \
-             patch.object(fs._api, "_build_hf_headers", return_value={"authorization": "a"}), \
-             patch.object(hffs_mod, "_try_get_xet_metadata",
-                          return_value=(XetFileData(file_hash="h", refresh_route="r"), 6)), \
-             patch.object(hffs_mod, "get_xet_download_stream_group", return_value=object()), \
-             patch.object(hffs_mod, "xet_download_stream", side_effect=boom), \
-             patch("huggingface_hub.utils._xet.abort_xet_session") as mock_abort:
+        with (
+            patch.object(fs, "resolve_path") as mock_resolve,
+            patch.object(fs, "info", return_value={"size": 6}),
+            patch.object(fs, "isdir", return_value=False),
+            patch.object(fs, "url", return_value="https://hub/resolve/data.bin"),
+            patch.object(fs._api, "_build_hf_headers", return_value={"authorization": "a"}),
+            patch.object(
+                hffs_mod, "_try_get_xet_metadata", return_value=(XetFileData(file_hash="h", refresh_route="r"), 6)
+            ),
+            patch.object(hffs_mod, "get_xet_download_stream_group", return_value=object()),
+            patch.object(hffs_mod, "xet_download_stream", side_effect=boom),
+            patch("huggingface_hub.utils._xet.abort_xet_session") as mock_abort,
+        ):
             mock_resolve.return_value.unresolve.return_value = "hf://datasets/x/data.bin"
             with pytest.raises(KeyboardInterrupt):
                 fs.get_file("datasets/x/data.bin", str(out_path))

--- a/tests/test_hf_file_system.py
+++ b/tests/test_hf_file_system.py
@@ -9,7 +9,7 @@ import tempfile
 import unittest
 from pathlib import Path
 from typing import Iterable, Optional, Type
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import fsspec
 import pytest
@@ -953,3 +953,56 @@ class TestXetMetadataResolution:
         _, kwargs = mock_meta.call_args
         assert kwargs["headers"] == {"authorization": "a"}
         assert kwargs["endpoint"] == "http://endpoint"
+
+
+class TestHfFileSystemFileXetRouting:
+    def _make_file(self):
+        fs = HfFileSystem(endpoint="https://hub")
+        f = HfFileSystemFile.__new__(HfFileSystemFile)
+        # bypass network in __init__; set the attributes _fetch_range relies on
+        f.fs = fs
+        f.path = "datasets/x/data.parquet"
+        f.size = 100
+        f._xet_checked = False
+        f._xet_group = None
+        f._xet_file_hash = None
+        f.url = lambda: "https://hub/resolve/data.parquet"
+        return f, fs
+
+    def test_fetch_range_uses_xet_when_backed(self):
+        f, fs = self._make_file()
+        fake_group = object()
+        with patch.object(hffs_mod, "_try_get_xet_metadata",
+                          return_value=(XetFileData(file_hash="h", refresh_route="r"), 100)), \
+             patch.object(hffs_mod, "get_xet_download_stream_group", return_value=fake_group), \
+             patch.object(hffs_mod, "xet_download_stream", return_value=iter([b"AB", b"CD"])) as mock_stream, \
+             patch.object(fs._api, "_build_hf_headers", return_value={"authorization": "a"}):
+            out = f._fetch_range(10, 14)
+        assert out == b"ABCD"
+        _, kwargs = mock_stream.call_args
+        assert kwargs == {"start": 10, "end": 14}
+        assert mock_stream.call_args[0] == (fake_group, "h", 100)
+
+    def test_fetch_range_falls_back_to_http_when_not_xet(self):
+        f, fs = self._make_file()
+        response = MagicMock()
+        response.content = b"http-bytes"
+        with patch.object(hffs_mod, "_try_get_xet_metadata", return_value=(None, None)), \
+             patch.object(hffs_mod, "http_backoff", return_value=response) as mock_http, \
+             patch.object(hffs_mod, "hf_raise_for_status"), \
+             patch.object(fs._api, "_build_hf_headers", return_value={"authorization": "a"}):
+            out = f._fetch_range(0, 10)
+        assert out == b"http-bytes"
+        mock_http.assert_called_once()
+
+    def test_fetch_range_detects_xet_only_once(self):
+        f, fs = self._make_file()
+        fake_group = object()
+        with patch.object(hffs_mod, "_try_get_xet_metadata",
+                          return_value=(XetFileData(file_hash="h", refresh_route="r"), 100)) as mock_meta, \
+             patch.object(hffs_mod, "get_xet_download_stream_group", return_value=fake_group), \
+             patch.object(hffs_mod, "xet_download_stream", return_value=iter([b"x"])), \
+             patch.object(fs._api, "_build_hf_headers", return_value={"authorization": "a"}):
+            f._fetch_range(0, 1)
+            f._fetch_range(1, 2)
+        mock_meta.assert_called_once()  # detection HEAD happens at most once per file

--- a/tests/test_hf_file_system.py
+++ b/tests/test_hf_file_system.py
@@ -14,8 +14,11 @@ from unittest.mock import Mock, patch
 import fsspec
 import pytest
 
+import huggingface_hub.hf_file_system as hffs_mod
 from huggingface_hub import HfApi, constants, hf_file_system
 from huggingface_hub.errors import BucketNotFoundError, RepositoryNotFoundError, RevisionNotFoundError
+from huggingface_hub.file_download import HfFileMetadata
+from huggingface_hub.utils import XetFileData
 from huggingface_hub.hf_file_system import (
     HfFileSystem,
     HfFileSystemFile,
@@ -928,3 +931,25 @@ def test_hf_file_system_file_can_handle_gzipped_file():
     with fs.open("datasets/allenai/math_qa/math_qa.py", "r", encoding="utf-8") as f:
         out = f.read()
     assert "class MathQa" in out
+
+
+class TestXetMetadataResolution:
+    def test_returns_none_when_xet_unavailable(self):
+        with patch.object(hffs_mod, "is_xet_available", return_value=False), \
+             patch.object(hffs_mod, "get_hf_file_metadata") as mock_meta:
+            assert hffs_mod._try_get_xet_metadata("http://u", {}, None) == (None, None)
+        mock_meta.assert_not_called()
+
+    def test_returns_xet_file_data_and_size_when_available(self):
+        meta = HfFileMetadata(
+            commit_hash="c", etag="e", location="loc", size=1234,
+            xet_file_data=XetFileData(file_hash="h", refresh_route="r"),
+        )
+        with patch.object(hffs_mod, "is_xet_available", return_value=True), \
+             patch.object(hffs_mod, "get_hf_file_metadata", return_value=meta) as mock_meta:
+            xfd, size = hffs_mod._try_get_xet_metadata("http://u", {"authorization": "a"}, "http://endpoint")
+        assert xfd == XetFileData(file_hash="h", refresh_route="r")
+        assert size == 1234
+        _, kwargs = mock_meta.call_args
+        assert kwargs["headers"] == {"authorization": "a"}
+        assert kwargs["endpoint"] == "http://endpoint"

--- a/tests/test_hf_file_system.py
+++ b/tests/test_hf_file_system.py
@@ -1088,3 +1088,19 @@ class TestHfFileSystemStreamFileXetRouting:
             assert f.read(4) == b"part"
         assert len(opened) == 2  # a new connection was opened
         assert f.response is not None
+
+    def test_keyboard_interrupt_aborts_xet_session(self):
+        f, fs = self._make_stream_file()
+
+        def boom(*args, **kwargs):
+            raise KeyboardInterrupt
+
+        with patch.object(hffs_mod, "_try_get_xet_metadata",
+                          return_value=(XetFileData(file_hash="h", refresh_route="r"), 8)), \
+             patch.object(hffs_mod, "get_xet_download_stream_group", return_value=object()), \
+             patch.object(hffs_mod, "xet_download_stream", side_effect=boom), \
+             patch.object(fs._api, "_build_hf_headers", return_value={}), \
+             patch("huggingface_hub.utils._xet.abort_xet_session") as mock_abort:
+            with pytest.raises(KeyboardInterrupt):
+                f.read()
+        mock_abort.assert_called_once()

--- a/tests/test_xet_download.py
+++ b/tests/test_xet_download.py
@@ -19,7 +19,6 @@ from huggingface_hub.utils import (
     XetFileData,
     refresh_xet_connection_info,
 )
-from huggingface_hub.utils._xet import reset_xet_download_stream_group_cache
 
 from .testing_utils import (
     DUMMY_XET_FILE,
@@ -350,12 +349,6 @@ class TestXetSnapshotDownload:
 
 @with_production_testing
 class TestHfFileSystemXetStreaming:
-    @pytest.fixture(autouse=True)
-    def _clear_group_cache(self):
-        reset_xet_download_stream_group_cache()
-        yield
-        reset_xet_download_stream_group_cache()
-
     def _reference_bytes(self) -> bytes:
         local = hf_hub_download(DUMMY_XET_MODEL_ID, DUMMY_XET_FILE)
         return Path(local).read_bytes()

--- a/tests/test_xet_download.py
+++ b/tests/test_xet_download.py
@@ -5,7 +5,8 @@ from unittest.mock import DEFAULT, MagicMock, Mock, patch
 
 import pytest
 
-from huggingface_hub import snapshot_download
+import huggingface_hub.hf_file_system as hffs_mod
+from huggingface_hub import HfFileSystem, snapshot_download
 from huggingface_hub.file_download import (
     HfFileMetadata,
     get_hf_file_metadata,
@@ -18,6 +19,7 @@ from huggingface_hub.utils import (
     XetFileData,
     refresh_xet_connection_info,
 )
+from huggingface_hub.utils._xet import reset_xet_download_stream_group_cache
 
 from .testing_utils import (
     DUMMY_XET_FILE,
@@ -344,3 +346,59 @@ class TestXetSnapshotDownload:
         )
 
         assert os.path.exists(file_path)
+
+
+@with_production_testing
+class TestHfFileSystemXetStreaming:
+    @pytest.fixture(autouse=True)
+    def _clear_group_cache(self):
+        reset_xet_download_stream_group_cache()
+        yield
+        reset_xet_download_stream_group_cache()
+
+    def _reference_bytes(self) -> bytes:
+        local = hf_hub_download(DUMMY_XET_MODEL_ID, DUMMY_XET_FILE)
+        return Path(local).read_bytes()
+
+    def _path(self) -> str:
+        return f"{DUMMY_XET_MODEL_ID}/{DUMMY_XET_FILE}"
+
+    def test_random_access_range_is_byte_exact(self):
+        expected = self._reference_bytes()
+        assert len(expected) > 128, "test file too small to exercise a mid-file range"
+        mid = len(expected) // 2
+        fs = HfFileSystem()
+        with fs.open(self._path(), "rb") as f:  # buffered (random-access) file
+            f.seek(mid)
+            chunk = f.read(64)
+        assert chunk == expected[mid : mid + 64]
+
+    def test_sequential_full_read_is_byte_exact(self):
+        expected = self._reference_bytes()
+        fs = HfFileSystem()
+        with fs.open(self._path(), "rb", block_size=0) as f:  # streaming file
+            data = f.read()
+        assert data == expected
+
+    def test_get_file_is_byte_exact(self, tmp_path):
+        expected = self._reference_bytes()
+        out = tmp_path / "copy.bin"
+        HfFileSystem().get_file(self._path(), str(out))
+        assert out.read_bytes() == expected
+
+    def test_stream_read_uses_xet_path(self):
+        fs = HfFileSystem()
+        with patch.object(hffs_mod, "xet_download_stream", wraps=hffs_mod.xet_download_stream) as spy:
+            with fs.open(self._path(), "rb", block_size=0) as f:
+                f.read()
+        spy.assert_called()  # confirms the read went through the xet path, not HTTP
+
+    def test_random_access_uses_xet_path(self):
+        expected_len_probe = HfFileSystem().info(self._path())["size"]
+        assert expected_len_probe is not None
+        fs = HfFileSystem()
+        with patch.object(hffs_mod, "xet_download_stream", wraps=hffs_mod.xet_download_stream) as spy:
+            with fs.open(self._path(), "rb") as f:
+                f.seek(0)
+                f.read(32)
+        spy.assert_called()

--- a/tests/test_xet_utils.py
+++ b/tests/test_xet_utils.py
@@ -437,6 +437,57 @@ def test_xet_session_holder_fork_safety_multiprocessing():
         assert wpid is not None
 
 
+from unittest.mock import MagicMock, patch
+
+import huggingface_hub.utils._xet as _xet_mod
+from huggingface_hub.utils._xet import (
+    get_xet_download_stream_group,
+    reset_xet_download_stream_group_cache,
+    xet_download_stream,
+)
+
+
+class TestXetDownloadStreamHelpers:
+    def setup_method(self):
+        reset_xet_download_stream_group_cache()
+
+    def test_group_is_built_from_session_with_expected_args(self):
+        fake_session = MagicMock()
+        with patch.object(_xet_mod, "get_xet_session", return_value=fake_session):
+            group = get_xet_download_stream_group(
+                refresh_route="https://hub/api/models/x/xet-read-token/main",
+                headers={"authorization": "Bearer hf_abc", "user-agent": "ua"},
+                endpoint="https://hub",
+            )
+        assert group is fake_session.new_download_stream_group.return_value
+        _, kwargs = fake_session.new_download_stream_group.call_args
+        assert kwargs["token_refresh_url"] == "https://hub/api/models/x/xet-read-token/main"
+        assert kwargs["token_refresh_headers"] == {"authorization": "Bearer hf_abc", "user-agent": "ua"}
+        assert "authorization" not in {k.lower() for k in kwargs["custom_headers"]}
+
+    def test_group_is_cached_by_route_and_auth(self):
+        fake_session = MagicMock()
+        # side_effect returns a fresh MagicMock per call so distinct groups are distinguishable
+        fake_session.new_download_stream_group.side_effect = [MagicMock(), MagicMock()]
+        with patch.object(_xet_mod, "get_xet_session", return_value=fake_session):
+            g1 = get_xet_download_stream_group(refresh_route="r", headers={"authorization": "a"}, endpoint="e")
+            g2 = get_xet_download_stream_group(refresh_route="r", headers={"authorization": "a"}, endpoint="e")
+            g3 = get_xet_download_stream_group(refresh_route="r", headers={"authorization": "b"}, endpoint="e")
+        assert g1 is g2
+        assert g1 is not g3
+        assert fake_session.new_download_stream_group.call_count == 2
+
+    def test_xet_download_stream_passes_range_to_group(self):
+        group = MagicMock()
+        group.download_stream.return_value = iter([b"ab", b"cd"])
+        with patch("hf_xet.XetFileInfo", create=True) as file_info_cls:
+            out = b"".join(xet_download_stream(group, "hash123", 4, start=1, end=3))
+        assert out == b"abcd"
+        file_info_cls.assert_called_once_with("hash123", 4)
+        _, kwargs = group.download_stream.call_args
+        assert kwargs == {"start": 1, "end": 3}
+
+
 @pytest.mark.parametrize(
     "kwargs, expected_suffix",
     [

--- a/tests/test_xet_utils.py
+++ b/tests/test_xet_utils.py
@@ -9,17 +9,18 @@ from _pytest.monkeypatch import MonkeyPatch
 import huggingface_hub.utils._xet as _xet_mod
 from huggingface_hub import HfApi, constants
 from huggingface_hub.utils._xet import (
+    XetConnectionInfo,
     XetFileData,
     XetSessionHolder,
     XetTokenType,
     _fetch_xet_connection_info_with_url,
     fetch_xet_connection_info_from_repo_info,
-    get_xet_download_stream_group,
+    open_xet_download_stream_group,
     parse_xet_connection_info_from_headers,
     parse_xet_file_data_from_response,
     refresh_xet_connection_info,
-    reset_xet_download_stream_group_cache,
     xet_connection_info_refresh_url,
+    xet_download_file,
     xet_download_stream,
 )
 
@@ -442,34 +443,32 @@ def test_xet_session_holder_fork_safety_multiprocessing():
 
 
 class TestXetDownloadStreamHelpers:
-    def setup_method(self):
-        reset_xet_download_stream_group_cache()
-
-    def test_group_is_built_from_session_with_expected_args(self):
+    def test_open_group_seeds_cached_token_and_is_not_cached(self):
+        # The group is created fresh every call (never cached — it is bound to the session
+        # runtime), but the short-lived read token is reused from the connection-info cache.
         fake_session = MagicMock()
-        with patch.object(_xet_mod, "get_xet_session", return_value=fake_session):
-            group = get_xet_download_stream_group(
-                refresh_route="https://hub/api/models/x/xet-read-token/main",
-                headers={"authorization": "Bearer hf_abc", "user-agent": "ua"},
-                endpoint="https://hub",
-            )
-        assert group is fake_session.new_download_stream_group.return_value
-        _, kwargs = fake_session.new_download_stream_group.call_args
-        assert kwargs["token_refresh_url"] == "https://hub/api/models/x/xet-read-token/main"
-        assert kwargs["token_refresh_headers"] == {"authorization": "Bearer hf_abc", "user-agent": "ua"}
-        assert "authorization" not in {k.lower() for k in kwargs["custom_headers"]}
-
-    def test_group_is_cached_by_route_and_auth(self):
-        fake_session = MagicMock()
-        # side_effect returns a fresh MagicMock per call so distinct groups are distinguishable
         fake_session.new_download_stream_group.side_effect = [MagicMock(), MagicMock()]
-        with patch.object(_xet_mod, "get_xet_session", return_value=fake_session):
-            g1 = get_xet_download_stream_group(refresh_route="r", headers={"authorization": "a"}, endpoint="e")
-            g2 = get_xet_download_stream_group(refresh_route="r", headers={"authorization": "a"}, endpoint="e")
-            g3 = get_xet_download_stream_group(refresh_route="r", headers={"authorization": "b"}, endpoint="e")
-        assert g1 is g2
-        assert g1 is not g3
+        conn = XetConnectionInfo(access_token="tok", expiration_unix_epoch=999, endpoint="https://cas")
+        file_data = XetFileData(file_hash="h", refresh_route="https://hub/api/models/x/xet-read-token/main")
+        headers = {"authorization": "Bearer hf_abc", "user-agent": "ua"}
+        with (
+            patch.object(_xet_mod, "get_xet_session", return_value=fake_session),
+            patch.object(_xet_mod, "refresh_xet_connection_info", return_value=conn) as mock_refresh,
+        ):
+            g1 = open_xet_download_stream_group(file_data=file_data, headers=headers)
+            g2 = open_xet_download_stream_group(file_data=file_data, headers=headers)
+        # No group caching: two calls => two distinct groups.
+        assert g1 is not g2
         assert fake_session.new_download_stream_group.call_count == 2
+        # Token reused from the (cached) connection info and seeded into the group.
+        assert mock_refresh.call_count == 2  # the cache lives in refresh_xet_connection_info, mocked here
+        _, kwargs = fake_session.new_download_stream_group.call_args
+        assert kwargs["endpoint"] == "https://cas"
+        assert kwargs["token"] == "tok"
+        assert kwargs["token_expiry_unix_secs"] == 999
+        assert kwargs["token_refresh_url"] == "https://hub/api/models/x/xet-read-token/main"
+        assert kwargs["token_refresh_headers"] == headers
+        assert "authorization" not in {k.lower() for k in kwargs["custom_headers"]}
 
     def test_xet_download_stream_passes_range_to_group(self):
         group = MagicMock()
@@ -481,26 +480,44 @@ class TestXetDownloadStreamHelpers:
         _, kwargs = group.download_stream.call_args
         assert kwargs == {"start": 1, "end": 3}
 
-    def test_reset_clears_cache(self):
+    def test_xet_download_file_seeds_token_and_starts_download(self):
         fake_session = MagicMock()
-        with patch.object(_xet_mod, "get_xet_session", return_value=fake_session):
-            get_xet_download_stream_group(refresh_route="r", headers={"authorization": "a"}, endpoint="e")
-        assert len(_xet_mod._XET_DOWNLOAD_STREAM_GROUP_CACHE) == 1
-        reset_xet_download_stream_group_cache()
-        assert len(_xet_mod._XET_DOWNLOAD_STREAM_GROUP_CACHE) == 0
+        group = fake_session.new_file_download_group.return_value.__enter__.return_value
+        conn = XetConnectionInfo(access_token="tok", expiration_unix_epoch=999, endpoint="https://cas")
+        with (
+            patch.object(_xet_mod, "get_xet_session", return_value=fake_session),
+            patch.object(_xet_mod, "refresh_xet_connection_info", return_value=conn),
+            patch("hf_xet.XetFileInfo", create=True) as file_info_cls,
+        ):
+            xet_download_file(
+                file_data=XetFileData(file_hash="h", refresh_route="r"),
+                headers={"authorization": "a"},
+                size=42,
+                path="/tmp/out.bin",
+            )
+        _, kwargs = fake_session.new_file_download_group.call_args
+        assert kwargs["token"] == "tok"
+        assert kwargs["endpoint"] == "https://cas"
+        assert kwargs["token_refresh_url"] == "r"
+        assert "progress_callback" not in kwargs  # omitted when not provided
+        file_info_cls.assert_called_once_with("h", 42)
+        group.start_download_file.assert_called_once_with(file_info_cls.return_value, "/tmp/out.bin")
 
-    def test_lru_eviction_drops_oldest(self):
-        size = _xet_mod.XET_DOWNLOAD_STREAM_GROUP_CACHE_SIZE
+    def test_xet_download_file_aborts_session_on_keyboard_interrupt(self):
         fake_session = MagicMock()
-        fake_session.new_download_stream_group.side_effect = [MagicMock() for _ in range(size + 1)]
-        with patch.object(_xet_mod, "get_xet_session", return_value=fake_session):
-            for i in range(size + 1):
-                get_xet_download_stream_group(refresh_route=f"r{i}", headers={"authorization": "a"}, endpoint="e")
-        assert len(_xet_mod._XET_DOWNLOAD_STREAM_GROUP_CACHE) == size
-        # r0 was the oldest and must have been evicted; r1..rN remain
-        keys = list(_xet_mod._XET_DOWNLOAD_STREAM_GROUP_CACHE.keys())
-        assert not any(k.endswith("|r0|a") for k in keys)
-        assert any(k.endswith("|r1|a") for k in keys)
+        fake_session.new_file_download_group.side_effect = KeyboardInterrupt
+        conn = XetConnectionInfo(access_token="t", expiration_unix_epoch=1, endpoint="e")
+        with (
+            patch.object(_xet_mod, "get_xet_session", return_value=fake_session),
+            patch.object(_xet_mod, "refresh_xet_connection_info", return_value=conn),
+            patch.object(_xet_mod, "abort_xet_session") as mock_abort,
+            patch("hf_xet.XetFileInfo", create=True),
+        ):
+            with pytest.raises(KeyboardInterrupt):
+                xet_download_file(
+                    file_data=XetFileData(file_hash="h", refresh_route="r"), headers={}, size=1, path="/tmp/x"
+                )
+        mock_abort.assert_called_once()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_xet_utils.py
+++ b/tests/test_xet_utils.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
 
+import huggingface_hub.utils._xet as _xet_mod
 from huggingface_hub import HfApi, constants
 from huggingface_hub.utils._xet import (
     XetFileData,
@@ -13,10 +14,13 @@ from huggingface_hub.utils._xet import (
     XetTokenType,
     _fetch_xet_connection_info_with_url,
     fetch_xet_connection_info_from_repo_info,
+    get_xet_download_stream_group,
     parse_xet_connection_info_from_headers,
     parse_xet_file_data_from_response,
     refresh_xet_connection_info,
+    reset_xet_download_stream_group_cache,
     xet_connection_info_refresh_url,
+    xet_download_stream,
 )
 
 from .testing_constants import ENDPOINT_STAGING, TOKEN
@@ -437,16 +441,6 @@ def test_xet_session_holder_fork_safety_multiprocessing():
         assert wpid is not None
 
 
-from unittest.mock import MagicMock, patch
-
-import huggingface_hub.utils._xet as _xet_mod
-from huggingface_hub.utils._xet import (
-    get_xet_download_stream_group,
-    reset_xet_download_stream_group_cache,
-    xet_download_stream,
-)
-
-
 class TestXetDownloadStreamHelpers:
     def setup_method(self):
         reset_xet_download_stream_group_cache()
@@ -486,6 +480,27 @@ class TestXetDownloadStreamHelpers:
         file_info_cls.assert_called_once_with("hash123", 4)
         _, kwargs = group.download_stream.call_args
         assert kwargs == {"start": 1, "end": 3}
+
+    def test_reset_clears_cache(self):
+        fake_session = MagicMock()
+        with patch.object(_xet_mod, "get_xet_session", return_value=fake_session):
+            get_xet_download_stream_group(refresh_route="r", headers={"authorization": "a"}, endpoint="e")
+        assert len(_xet_mod._XET_DOWNLOAD_STREAM_GROUP_CACHE) == 1
+        reset_xet_download_stream_group_cache()
+        assert len(_xet_mod._XET_DOWNLOAD_STREAM_GROUP_CACHE) == 0
+
+    def test_lru_eviction_drops_oldest(self):
+        size = _xet_mod.XET_DOWNLOAD_STREAM_GROUP_CACHE_SIZE
+        fake_session = MagicMock()
+        fake_session.new_download_stream_group.side_effect = [MagicMock() for _ in range(size + 1)]
+        with patch.object(_xet_mod, "get_xet_session", return_value=fake_session):
+            for i in range(size + 1):
+                get_xet_download_stream_group(refresh_route=f"r{i}", headers={"authorization": "a"}, endpoint="e")
+        assert len(_xet_mod._XET_DOWNLOAD_STREAM_GROUP_CACHE) == size
+        # r0 was the oldest and must have been evicted; r1..rN remain
+        keys = list(_xet_mod._XET_DOWNLOAD_STREAM_GROUP_CACHE.keys())
+        assert not any(k.endswith("|r0|a") for k in keys)
+        assert any(k.endswith("|r1|a") for k in keys)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

`HfFileSystem` now downloads Xet-backed files through `hf_xet`'s ranged download-stream interface across **all read paths** — `HfFileSystemFile._fetch_range` (random access), `HfFileSystemStreamFile` (sequential), and `get_file` — falling back to the existing HTTP path for non-Xet files or when `hf_xet` is unavailable. This gives `datasets` (and other fsspec consumers) a fast streaming path for Xet files, which previously always went over plain HTTP and bypassed Xet entirely.

Key points:
- **Per-file detection** (repos can mix Xet/non-Xet blobs) via a single best-effort metadata HEAD (`get_hf_file_metadata`); any failure degrades gracefully to the HTTP path so detection never breaks a read.
- **Shared stream group**: a bounded, thread-safe LRU cache shares one `XetDownloadStreamGroup` per `(endpoint, refresh-route, auth)`, amortizing the CAS handshake + token fetch across all files of a repo.
- **Ranged reconstruction**: byte ranges map 1:1 to `download_stream(start, end)` (exclusive end, matching the old `bytes=start-(end-1)`), so random-access reads (e.g. parquet footers / row groups) fetch only the covering chunks.
- **Interrupt handling**: `KeyboardInterrupt` aborts the Xet session consistently across all three paths.
- No `hf_xet` / xet-core changes required — the ranged streaming API already exists in `hf_xet` 1.5.x.

## Performance (no regression)

Benchmarked on a 238 MB Xet-backed parquet (`open-thoughts/OpenThoughts-114k`), Xet vs `HF_HUB_DISABLE_XET=1`:
- `full_scan` (sequential throughput): Xet ≈ HTTP (~117s mean both) — at parity.
- `random_access`: within HTTP's own run-to-run variance.
- `footer_read`: marginally slower on Xet (one-time CAS handshake), small in absolute terms.

Note: the streaming path does not populate the local chunk cache (that cache is used by `hf_hub_download`, not streaming), so warm reads aren't faster than cold — but parity with HTTP holds. A reusable benchmark script is included under `benchmarks/`.

## Test Plan

- [x] Unit tests (offline, mocked): stream-group cache + LRU eviction, per-file detection (once-only, best-effort fallback), all three read paths, HTTP fallback, KeyboardInterrupt→abort, and byte-exact resume after a mid-stream error.
- [x] Integration tests against a real Xet repo: byte-exact random-access / sequential / `get_file`, plus spies confirming the Xet path is taken.
- [x] `ruff check` and `ruff format --check` clean.

## Follow-up (not in this PR)

A companion `datasets` change (bump `huggingface_hub>=1.20`, add a streaming-uses-xet integration test) is prepared but held until this ships in a release, since the version floor can't resolve from PyPI before then.