### PR TITLE
[Release] Skip --prerelease=allow injection for sentence-transformers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -886,9 +886,14 @@ jobs:
             git add pyproject.toml
           fi
 
-          # Enable prerelease flag in workflow files
-          find .github/workflows/ -type f -exec sed -i 's/uv pip install /uv pip install --prerelease=allow /g' {} +
-          git add .github/workflows/
+          # Enable prerelease flag in workflow files.
+          # Skipped for sentence-transformers: its pyproject.toml pin already forces our RC, and
+          # --prerelease=allow would also pull in unrelated prereleases (e.g. tokenizers) that break
+          # the latest transformers and cause spurious CI failures.
+          if [ "${{ matrix.target-repo }}" != "sentence-transformers" ]; then
+            find .github/workflows/ -type f -exec sed -i 's/uv pip install /uv pip install --prerelease=allow /g' {} +
+            git add .github/workflows/
+          fi
 
           git --no-pager diff --staged
           git commit -m "Test hfh ${VERSION}"


### PR DESCRIPTION
## Summary

During the `v1.19.0` release, the downstream RC testing job pushes a test branch to each downstream repo (transformers, datasets, diffusers, sentence-transformers) and injects `--prerelease=allow` into every `uv pip install` in their workflows.

For **sentence-transformers** this is both unnecessary and harmful:

- Its `pyproject.toml` pin is already rewritten to `huggingface-hub==<RC>` by the job (the existing `sed`), so the RC is picked up without `--prerelease=allow`.
- `--prerelease=allow` additionally pulls in *unrelated* prereleases — notably `tokenizers==0.23.0rc0`, which the latest `transformers` doesn't work with — causing spurious CI failures unrelated to `huggingface_hub`.

> Tom Aarsen, after debugging the ST CI failure:
> "For Sentence Transformers, the CI passes if we just exclude the `--prerelease=allow` addition: the huggingface_hub RC is already automatically used because it's set in the pyproject.toml. Could we perhaps not run the `--prerelease=allow` replacement in the huggingface_hub release Action?"

This PR guards the injection so it's skipped for `sentence-transformers` only; the other repos keep the existing behavior.

```diff
-          # Enable prerelease flag in workflow files
-          find .github/workflows/ -type f -exec sed -i 's/uv pip install /uv pip install --prerelease=allow /g' {} +
-          git add .github/workflows/
+          # Enable prerelease flag in workflow files.
+          # Skipped for sentence-transformers: its pyproject.toml pin already forces our RC, and
+          # --prerelease=allow would also pull in unrelated prereleases (e.g. tokenizers) that break
+          # the latest transformers and cause spurious CI failures.
+          if [ "${{ matrix.target-repo }}" != "sentence-transformers" ]; then
+            find .github/workflows/ -type f -exec sed -i 's/uv pip install /uv pip install --prerelease=allow /g' {} +
+            git add .github/workflows/
+          fi
```

cc @tomaarsen

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single conditional in release automation; no runtime library or auth changes.
> 
> **Overview**
> During **huggingface_hub** prerelease downstream RC testing, the release workflow no longer injects `uv pip install --prerelease=allow` into **sentence-transformers** workflow files.
> 
> **transformers**, **datasets**, and **diffusers** still get the `sed` that adds `--prerelease=allow` so their CI can install the hub RC. For **sentence-transformers**, the job already rewrites `pyproject.toml` to `huggingface-hub==<RC>`, which is enough to test the RC without widening prerelease resolution.
> 
> Skipping the flag avoids pulling unrelated prereleases (e.g. `tokenizers` RCs) that were breaking CI against latest **transformers**, unrelated to **huggingface_hub** changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de204c85a78be8b8d691e5f50f46d2386f903223. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->