### PR TITLE
Add new JobNotFound error

### DIFF
--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -74,7 +74,7 @@ from urllib.parse import urlsplit
 import typer
 
 from huggingface_hub import JobHardware
-from huggingface_hub.errors import CLIError, HfHubHTTPError
+from huggingface_hub.errors import CLIError
 from huggingface_hub.utils import logging
 from huggingface_hub.utils._cache_manager import _format_size
 from huggingface_hub.utils._parsing import format_duration
@@ -389,23 +389,12 @@ def jobs_logs(
     job_id, namespace = _parse_namespace_from_job_id(job_id, namespace)
 
     api = get_hf_api(token=token)
-    try:
-        logs = api.fetch_job_logs(job_id=job_id, namespace=namespace, follow=follow, tail=tail)
-        for log in logs:
-            out.text(log)
-        if follow:
-            job_ref = f"{namespace}/{job_id}" if namespace else job_id
-            out.hint(
-                f"Stream ended. Run `hf jobs inspect {job_ref}` to check the final status (e.g. COMPLETED or ERROR)."
-            )
-    except HfHubHTTPError as e:
-        status = e.response.status_code if e.response is not None else None
-        if status == 404:
-            raise CLIError("Job not found. Please check the job ID.") from e
-        elif status == 403:
-            raise CLIError("Access denied. You may not have permission to view this job.") from e
-        else:
-            raise CLIError(f"Failed to fetch job logs: {e}") from e
+    logs = api.fetch_job_logs(job_id=job_id, namespace=namespace, follow=follow, tail=tail)
+    for log in logs:
+        out.text(log)
+    if follow:
+        job_ref = f"{namespace}/{job_id}" if namespace else job_id
+        out.hint(f"Stream ended. Run `hf jobs inspect {job_ref}` to check the final status (e.g. COMPLETED or ERROR).")
 
 
 def _matches_filters(job_properties: dict[str, str], filters: list[tuple[str, str, str]]) -> bool:
@@ -493,46 +482,37 @@ def jobs_stats(
         "GPU MEM %",
         "GPU MEM USAGE",
     ]
-    try:
-        with multiprocessing.pool.ThreadPool(len(job_ids)) as pool:
-            rows_per_job_id: dict[str, list[list[str | int]]] = {}
-            for job_id in job_ids:
-                row: list[str | int] = [job_id]
-                row += ["-- / --" if ("/" in header or "USAGE" in header) else "--" for header in table_headers[1:]]
-                rows_per_job_id[job_id] = [row]
-            last_update_time = time.time()
-            total_rows = [row for job_id in rows_per_job_id for row in rows_per_job_id[job_id]]
-            # In-place refresh (cursor-up + clear) requires a fixed line count and layout —
-            # `out.table`'s mode-dependent formatting would break it.
-            print(_tabulate(total_rows, headers=table_headers))
+    with multiprocessing.pool.ThreadPool(len(job_ids)) as pool:
+        rows_per_job_id: dict[str, list[list[str | int]]] = {}
+        for job_id in job_ids:
+            row: list[str | int] = [job_id]
+            row += ["-- / --" if ("/" in header or "USAGE" in header) else "--" for header in table_headers[1:]]
+            rows_per_job_id[job_id] = [row]
+        last_update_time = time.time()
+        total_rows = [row for job_id in rows_per_job_id for row in rows_per_job_id[job_id]]
+        # In-place refresh (cursor-up + clear) requires a fixed line count and layout —
+        # `out.table`'s mode-dependent formatting would break it.
+        print(_tabulate(total_rows, headers=table_headers))
 
-            kwargs_list = [
-                {
-                    "job_id": job_id,
-                    "metrics_stream": api.fetch_job_metrics(job_id=job_id, namespace=namespace),
-                    "table_headers": table_headers,
-                }
-                for job_id in job_ids
-            ]
-            for done, job_id, rows in iflatmap_unordered(pool, _get_jobs_stats_rows, kwargs_list=kwargs_list):
-                if done:
-                    rows_per_job_id.pop(job_id, None)
-                else:
-                    rows_per_job_id[job_id] = rows
-                now = time.time()
-                if now - last_update_time >= STATS_UPDATE_MIN_INTERVAL:
-                    _clear_line(2 + len(total_rows))
-                    total_rows = [row for job_id in rows_per_job_id for row in rows_per_job_id[job_id]]
-                    print(_tabulate(total_rows, headers=table_headers))
-                    last_update_time = now
-    except HfHubHTTPError as e:
-        status = e.response.status_code if e.response is not None else None
-        if status == 404:
-            raise CLIError("Job not found. Please check the job ID.") from e
-        elif status == 403:
-            raise CLIError("Access denied. You may not have permission to view this job.") from e
-        else:
-            raise CLIError(f"Failed to fetch job stats: {e}") from e
+        kwargs_list = [
+            {
+                "job_id": job_id,
+                "metrics_stream": api.fetch_job_metrics(job_id=job_id, namespace=namespace),
+                "table_headers": table_headers,
+            }
+            for job_id in job_ids
+        ]
+        for done, job_id, rows in iflatmap_unordered(pool, _get_jobs_stats_rows, kwargs_list=kwargs_list):
+            if done:
+                rows_per_job_id.pop(job_id, None)
+            else:
+                rows_per_job_id[job_id] = rows
+            now = time.time()
+            if now - last_update_time >= STATS_UPDATE_MIN_INTERVAL:
+                _clear_line(2 + len(total_rows))
+                total_rows = [row for job_id in rows_per_job_id for row in rows_per_job_id[job_id]]
+                print(_tabulate(total_rows, headers=table_headers))
+                last_update_time = now
 
 
 @jobs_cli.command("ps", examples=["hf jobs ps", "hf jobs ps -a"])
@@ -684,16 +664,7 @@ def jobs_inspect(
         parsed_ids.append(job_id)
     job_ids = parsed_ids
     api = get_hf_api(token=token)
-    try:
-        jobs = [api.inspect_job(job_id=job_id, namespace=namespace) for job_id in job_ids]
-    except HfHubHTTPError as e:
-        status = e.response.status_code if e.response is not None else None
-        if status == 404:
-            raise CLIError("Job not found. Please check the job ID.") from e
-        elif status == 403:
-            raise CLIError("Access denied. You may not have permission to view this job.") from e
-        else:
-            raise CLIError(f"Failed to inspect job: {e}") from e
+    jobs = [api.inspect_job(job_id=job_id, namespace=namespace) for job_id in job_ids]
     out.table([_dataclass_to_dict(job) for job in jobs])
 
 
@@ -706,16 +677,7 @@ def jobs_cancel(
     """Cancel a Job"""
     job_id, namespace = _parse_namespace_from_job_id(job_id, namespace)
     api = get_hf_api(token=token)
-    try:
-        api.cancel_job(job_id=job_id, namespace=namespace)
-    except HfHubHTTPError as e:
-        status = e.response.status_code if e.response is not None else None
-        if status == 404:
-            raise CLIError("Job not found. Please check the job ID.") from e
-        elif status == 403:
-            raise CLIError("Access denied. You may not have permission to cancel this job.") from e
-        else:
-            raise CLIError(f"Failed to cancel job: {e}") from e
+    api.cancel_job(job_id=job_id, namespace=namespace)
     out.result("Job cancelled", id=job_id)
 
 

--- a/src/huggingface_hub/errors.py
+++ b/src/huggingface_hub/errors.py
@@ -273,6 +273,21 @@ class BucketNotFoundError(HfHubHTTPError):
     bucket_id: str | None = None
 
 
+# JOB ERRORS
+
+
+class JobNotFoundError(HfHubHTTPError):
+    """
+    Raised when trying to access a Job that does not exist.
+
+    Attributes:
+        job_id (`str`):
+            The job id that was not found.
+    """
+
+    job_id: str
+
+
 # REPOSITORY ERRORS
 
 

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -11951,7 +11951,7 @@ class HfApi:
             headers=self._build_hf_headers(token=token),
             timeout=timeout,
         )
-        response.raise_for_status()
+        hf_raise_for_status(response)
         return [JobInfo(**job_info, endpoint=self.endpoint) for job_info in response.json()]
 
     def list_jobs_hardware(self, token: bool | str | None = None) -> list[JobHardwareInfo]:
@@ -12030,7 +12030,7 @@ class HfApi:
             f"{self.endpoint}/api/jobs/{namespace}/{job_id}",
             headers=self._build_hf_headers(token=token),
         )
-        response.raise_for_status()
+        hf_raise_for_status(response)
         return JobInfo(**response.json(), endpoint=self.endpoint)
 
     def cancel_job(
@@ -12057,10 +12057,11 @@ class HfApi:
         """
         if namespace is None:
             namespace = self.whoami(token=token)["name"]
-        get_session().post(
+        response = get_session().post(
             f"{self.endpoint}/api/jobs/{namespace}/{job_id}/cancel",
             headers=self._build_hf_headers(token=token),
-        ).raise_for_status()
+        )
+        hf_raise_for_status(response)
 
     def update_job_labels(
         self,
@@ -12515,10 +12516,11 @@ class HfApi:
         """
         if namespace is None:
             namespace = self.whoami(token=token)["name"]
-        get_session().post(
+        response = get_session().post(
             f"{self.endpoint}/api/scheduled-jobs/{namespace}/{scheduled_job_id}/suspend",
             headers=self._build_hf_headers(token=token),
-        ).raise_for_status()
+        )
+        hf_raise_for_status(response)
 
     def resume_scheduled_job(
         self,
@@ -12544,10 +12546,11 @@ class HfApi:
         """
         if namespace is None:
             namespace = self.whoami(token=token)["name"]
-        get_session().post(
+        response = get_session().post(
             f"{self.endpoint}/api/scheduled-jobs/{namespace}/{scheduled_job_id}/resume",
             headers=self._build_hf_headers(token=token),
-        ).raise_for_status()
+        )
+        hf_raise_for_status(response)
 
     def update_scheduled_job_labels(
         self,

--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -24,6 +24,7 @@ from huggingface_hub.errors import (
     GatedRepoError,
     HfHubHTTPError,
     HFValidationError,
+    JobNotFoundError,
     LocalEntryNotFoundError,
     LocalTokenNotFoundError,
     NotASafetensorsRepoError,

--- a/src/huggingface_hub/utils/_http.py
+++ b/src/huggingface_hub/utils/_http.py
@@ -39,6 +39,7 @@ from ..errors import (
     DisabledRepoError,
     GatedRepoError,
     HfHubHTTPError,
+    JobNotFoundError,
     RemoteEntryNotFoundError,
     RepositoryNotFoundError,
     RevisionNotFoundError,
@@ -169,6 +170,10 @@ BUCKET_API_REGEX = re.compile(
     flags=re.VERBOSE,
 )
 
+# Regex to extract the job_id from a (scheduled) job API URL.
+# Matches /api/jobs/{namespace}/{job_id}[/...] and /api/scheduled-jobs/{namespace}/{job_id}[/...].
+_JOB_ID_FROM_URL_REGEX = re.compile(r"^https?://[^/]+/api/(?:scheduled-jobs|jobs)/[^/]+/([^/?]+)")
+
 # Regex to extract repo_type and repo_id from API URLs.
 # Captures: group(1) = repo_type plural (models/datasets/spaces), group(2) = first path segment, group(3) = optional second segment.
 _REPO_ID_FROM_URL_REGEX = re.compile(r"^https?://[^/]+/api/(models|datasets|spaces)/([^/]+)(?:/([^/]+))?")
@@ -208,6 +213,12 @@ def _parse_repo_info_from_url(url: str) -> tuple[str | None, str | None]:
 def _parse_bucket_id_from_url(url: str) -> str | None:
     """Extract bucket_id (namespace/name) from a bucket API URL."""
     match = _BUCKET_ID_FROM_URL_REGEX.search(url)
+    return match.group(1) if match else None
+
+
+def _parse_job_id_from_url(url: str) -> str | None:
+    """Extract the job_id from a (scheduled) job API URL, if present."""
+    match = _JOB_ID_FROM_URL_REGEX.search(url)
     return match.group(1) if match else None
 
 
@@ -811,6 +822,19 @@ def hf_raise_for_status(response: httpx.Response, endpoint_name: str | None = No
             raise _format(
                 BucketNotFoundError, message, response, bucket_id=_parse_bucket_id_from_url(request_url)
             ) from e
+
+        elif (
+            response.status_code == 404
+            and request_url is not None
+            and (job_id := _parse_job_id_from_url(request_url)) is not None
+        ):
+            message = (
+                f"{response.status_code} Client Error."
+                + "\n\n"
+                + f"Job Not Found for url: {response.url}."
+                + "\nPlease make sure you specified the correct job ID and namespace."
+            )
+            raise _format(JobNotFoundError, message, response, job_id=job_id) from e
 
         elif error_code == "RepoNotFound" or (
             response.status_code == 401

--- a/tests/test_utils_http.py
+++ b/tests/test_utils_http.py
@@ -16,7 +16,6 @@ from huggingface_hub.constants import ENDPOINT
 from huggingface_hub.errors import (
     BucketNotFoundError,
     HfHubHTTPError,
-    JobNotFoundError,
     OfflineModeIsEnabled,
     RepositoryNotFoundError,
 )

--- a/tests/test_utils_http.py
+++ b/tests/test_utils_http.py
@@ -13,7 +13,13 @@ import pytest
 from httpx import ConnectTimeout, HTTPError
 
 from huggingface_hub.constants import ENDPOINT
-from huggingface_hub.errors import BucketNotFoundError, HfHubHTTPError, OfflineModeIsEnabled, RepositoryNotFoundError
+from huggingface_hub.errors import (
+    BucketNotFoundError,
+    HfHubHTTPError,
+    JobNotFoundError,
+    OfflineModeIsEnabled,
+    RepositoryNotFoundError,
+)
 from huggingface_hub.utils._http import (
     _WARNED_TOPICS,
     RateLimitInfo,


### PR DESCRIPTION
Related to https://github.com/huggingface/huggingface_hub/pull/4345#issuecomment-4689936548 from @davanstrien 

Errors in the Jobs CLI were not caught correctly. First of all, `response.raise_for_status` was used in several places in the Jobs API instead of `hf_raise_for_status`, causing `HTTPError` to be raised instead of `HfHubHttpError`, making the CLI ugly when failing.

I also took the opportunity to add a `JobNotFoundError` (regex based) and to remove all the `try/except` sections from the Jobs CLI => we prefer to catch these globally rather than on a per-command basis. 

(and yes, I wrote that PR and PR description myself :sunglasses:)

**Before:**

```
✗ hf jobs inspect 000
Traceback (most recent call last):
  File "/home/wauplin/projects/huggingface_hub/.venv/bin/hf", line 10, in <module>
    sys.exit(main())
  File "/home/wauplin/projects/huggingface_hub/src/huggingface_hub/cli/hf.py", line 116, in main
    app()
  File "/home/wauplin/projects/huggingface_hub/.venv/lib/python3.10/site-packages/typer/main.py", line 1152, in __call__
    raise e
  File "/home/wauplin/projects/huggingface_hub/.venv/lib/python3.10/site-packages/typer/main.py", line 1135, in __call__
    return get_command(self)(*args, **kwargs)
  File "/home/wauplin/projects/huggingface_hub/.venv/lib/python3.10/site-packages/click/core.py", line 1524, in __call__
    return self.main(*args, **kwargs)
(...)
    return callback(**use_params)
  File "/home/wauplin/projects/huggingface_hub/src/huggingface_hub/cli/jobs.py", line 688, in jobs_inspect
    jobs = [api.inspect_job(job_id=job_id, namespace=namespace) for job_id in job_ids]
  File "/home/wauplin/projects/huggingface_hub/src/huggingface_hub/cli/jobs.py", line 688, in <listcomp>
    jobs = [api.inspect_job(job_id=job_id, namespace=namespace) for job_id in job_ids]
  File "/home/wauplin/projects/huggingface_hub/src/huggingface_hub/hf_api.py", line 12033, in inspect_job
    response.raise_for_status()
  File "/home/wauplin/projects/huggingface_hub/.venv/lib/python3.10/site-packages/httpx/_models.py", line 829, in raise_for_status
    raise HTTPStatusError(message, request=request, response=self)
httpx.HTTPStatusError: Client error '404 Not Found' for url 'https://huggingface.co/api/jobs/Wauplin/000'
For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
```

**Now:**

```
$ hf jobs inspect 000
Error: 404 Client Error. (Request ID: Root=1-6a316470-1f2898ca1875167b67349c92;83e49a17-56ba-47e8-a3f1-6c0f59d0c738)

Job Not Found for url: https://huggingface.co/api/jobs/Wauplin/000.
Please make sure you specified the correct job ID and namespace.
Set HF_DEBUG=1 as environment variable for full traceback.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized error-handling refactor; 403 and other failures now surface as generic `HfHubHTTPError` messages instead of the old per-command CLIError text.
> 
> **Overview**
> Fixes ugly `httpx` tracebacks when Jobs CLI commands fail by routing Jobs API responses through **`hf_raise_for_status`** instead of raw **`raise_for_status`**, and by dropping per-command **`HfHubHTTPError`** handlers in **`jobs.py`** (logs, stats, inspect, cancel) so errors are handled like the rest of the CLI.
> 
> Adds **`JobNotFoundError`**: on **404** for `/api/jobs/...` and `/api/scheduled-jobs/...` URLs, **`hf_raise_for_status`** parses the job id from the URL and raises a typed error with a clear message (request id, etc.). Several **`hf_api`** job endpoints (list/inspect/cancel and scheduled suspend/resume) are updated to use **`hf_raise_for_status`** on their responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adeb86dfb505b4794bd6795357b6c6ef48fa6f89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->