### PR TITLE
[Tests] Speed up upload-limit validation tests

### DIFF
--- a/tests/test_upload_large_folder.py
+++ b/tests/test_upload_large_folder.py
@@ -1,7 +1,8 @@
 # tests/test_upload_large_folder.py
 import unittest
 from hashlib import sha256
-from unittest.mock import MagicMock, patch
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 
@@ -74,12 +75,22 @@ class TestValidateUploadLimits(unittest.TestCase):
     """Test the _validate_upload_limits function directly."""
 
     class MockPath:
-        """Mock object to simulate LocalUploadFilePaths."""
+        """Mock object to simulate LocalUploadFilePaths.
+
+        Uses a lightweight stub instead of MagicMock for `file_path`: some tests create
+        100k+ instances and MagicMock construction/configuration would take ~70s.
+        """
+
+        class _FileStub:
+            def __init__(self, size_bytes):
+                self._stat = SimpleNamespace(st_size=size_bytes)
+
+            def stat(self):
+                return self._stat
 
         def __init__(self, path_in_repo, size_bytes=1000):
             self.path_in_repo = path_in_repo
-            self.file_path = MagicMock()
-            self.file_path.stat.return_value.st_size = size_bytes
+            self.file_path = self._FileStub(size_bytes)
 
     @patch("huggingface_hub._upload_large_folder.logger")
     def test_no_warnings_under_limits(self, mock_logger):


### PR DESCRIPTION
## Summary

- `MockPath` in `TestValidateUploadLimits` wrapped a `MagicMock()` per instance, but some tests build 100k+ of them. MagicMock construction/configuration alone took ~70s.
- Replaced it with a tiny stub exposing just `stat().st_size` (the only attribute used).
- `test_warns_too_many_total_files`: **98s → ~0.8s**; whole class **~115s → ~1.1s**. All tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code touched; behavior under test stays the same.
> 
> **Overview**
> **Speeds up `TestValidateUploadLimits`** by replacing per-instance `MagicMock` on `MockPath.file_path` with a small `_FileStub` that only implements `stat().st_size`, which is what `_validate_upload_limits` uses.
> 
> Tests that materialize **100k+** mock paths no longer pay MagicMock setup cost (reported **~115s → ~1s** for the class). Imports drop `MagicMock` in favor of `SimpleNamespace`; assertions and patched logger behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f369c7b41c752479d8a789543d061b4bd9a1b323. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->