### PR TITLE
[CI] Do not fail on tmp repo deletion

### DIFF
--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -468,7 +468,10 @@ def use_tmp_repo(repo_type: str = "model") -> Callable[[T], T]:
             try:
                 return test_fn(*args, **kwargs, repo_url=repo_url)
             finally:
-                self._api.delete_repo(repo_id=repo_url.repo_id, repo_type=repo_type)
+                try:
+                    self._api.delete_repo(repo_id=repo_url.repo_id, repo_type=repo_type)
+                except Exception:
+                    pass
 
         return _inner
 


### PR DESCRIPTION
`use_tmp_repo` testing decorator can be flaky in CI when e.g. the tmp repo is renamed or deleted+recreated. Let's not fail on cleanup.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only teardown change; production behavior is unchanged.
> 
> **Overview**
> **`use_tmp_repo`** cleanup no longer fails the test when **`delete_repo`** errors after the test body runs.
> 
> The decorator’s **`finally`** block now wraps **`self._api.delete_repo(...)`** in **`try/except`** and ignores any exception, so flaky CI cases (e.g. repo already renamed or deleted/recreated) don’t turn successful tests into failures during teardown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2676653b16c6b7d791d04862e2821b8c01c31f58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->