### PR TITLE
[CLI] Wait for Job to be running in `hf jobs ssh`

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -2001,7 +2001,7 @@ Pass `--ssh` to `hf jobs run` (or `hf jobs uv run`) to make the Job's container 
 # Start a job with SSH enabled
 >>> hf jobs run --ssh --detach python:3.12 sleep infinity
 
-# Open an SSH session into it
+# Open an SSH session into it (waits for the Job to be running if still scheduling)
 >>> hf jobs ssh <job_id>
 
 # Print the SSH command instead of running it
@@ -2010,6 +2010,8 @@ Pass `--ssh` to `hf jobs run` (or `hf jobs uv run`) to make the Job's container 
 # Use a specific identity file
 >>> hf jobs ssh <job_id> -i ~/.ssh/id_ed25519
 ```
+
+If the Job is still scheduling, `hf jobs ssh` waits until it reaches the `RUNNING` stage before connecting. If the Job finishes (e.g. errors out or completes) before reaching `RUNNING`, the command exits with an error.
 
 Only users with write access to the Job's namespace are allowed in (the Job creator, or members of the owner organization), authenticated by an SSH public key registered at https://huggingface.co/settings/keys.
 

--- a/docs/source/en/guides/jobs.md
+++ b/docs/source/en/guides/jobs.md
@@ -305,7 +305,7 @@ Pass `ssh=True` to [`run_job`] (or [`run_uv_job`]) to make the Job's container r
 'ssh://68498e23210b3a4f4e6e2a23@ssh.hf.jobs'
 ```
 
-Connect from a terminal with `hf jobs ssh <job_id>` (or directly with `ssh <job_id>@ssh.hf.jobs`):
+Connect from a terminal with `hf jobs ssh <job_id>` (or directly with `ssh <job_id>@ssh.hf.jobs`). If the Job is still scheduling, the command waits until it reaches the `RUNNING` stage:
 
 ```bash
 >>> hf jobs ssh 68498e23210b3a4f4e6e2a23

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -2646,6 +2646,8 @@ Learn more
 
 SSH into a running Job.
 
+If the Job is still scheduling, waits until it reaches the RUNNING stage.
+
 Requires the Job to be started with SSH enabled (`hf jobs run --ssh ...`) and your SSH
 public key to be registered at https://huggingface.co/settings/keys.
 

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -68,7 +68,7 @@ import time
 from collections.abc import Callable, Iterable
 from fnmatch import fnmatch
 from queue import Empty, Queue
-from typing import Annotated, Any, TypeVar
+from typing import TYPE_CHECKING, Annotated, Any, TypeVar
 from urllib.parse import urlsplit
 
 import typer
@@ -96,6 +96,11 @@ from ._cli_utils import (
     typer_factory,
 )
 from ._output import _dataclass_to_dict, out
+
+
+if TYPE_CHECKING:
+    from huggingface_hub import JobInfo
+    from huggingface_hub.hf_api import HfApi
 
 
 logger = logging.get_logger(__name__)
@@ -709,6 +714,32 @@ def jobs_labels(
     out.result("Labels updated", id=job.id)
 
 
+_TERMINAL_JOB_STAGES = {"COMPLETED", "CANCELED", "ERROR", "DELETED"}
+
+
+def _wait_for_job_running(api: "HfApi", job_id: str, namespace: str | None) -> "JobInfo":
+    """Poll inspect_job until the Job reaches RUNNING (or a terminal stage)."""
+    job = api.inspect_job(job_id=job_id, namespace=namespace)
+    if job.status.stage == "RUNNING":
+        return job
+
+    if str(job.status.stage) in _TERMINAL_JOB_STAGES:
+        raise CLIError(f"Cannot SSH into job '{job.id}': job already finished (stage: '{job.status.stage}').")
+
+    status = out.status(f"Waiting for job to be running (stage: '{job.status.stage}')...")
+    while job.status.stage != "RUNNING":
+        if str(job.status.stage) in _TERMINAL_JOB_STAGES:
+            status.done(f"Job finished (stage: '{job.status.stage}').")
+            raise CLIError(
+                f"Cannot SSH into job '{job.id}': job finished while waiting (stage: '{job.status.stage}')."
+            )
+        time.sleep(2)
+        job = api.inspect_job(job_id=job_id, namespace=namespace)
+        status.update(f"Waiting for job to be running (stage: '{job.status.stage}')...")
+    status.done("Job is running!")
+    return job
+
+
 @jobs_cli.command(
     "ssh",
     examples=[
@@ -726,16 +757,16 @@ def jobs_ssh(
 ) -> None:
     """SSH into a running Job.
 
+    If the Job is still scheduling, waits until it reaches the RUNNING stage.
+
     Requires the Job to be started with SSH enabled (`hf jobs run --ssh ...`) and your SSH
     public key to be registered at https://huggingface.co/settings/keys.
     """
     job_id, namespace = _parse_namespace_from_job_id(job_id, namespace)
     api = get_hf_api(token=token)
-    job = api.inspect_job(job_id=job_id, namespace=namespace)
+    job = _wait_for_job_running(api, job_id, namespace)
     if job.status.ssh_url is None:
         raise CLIError("SSH is not enabled on this job. Start a job with SSH support using `hf jobs run --ssh ...`.")
-    if job.status.stage != "RUNNING":
-        raise CLIError(f"Cannot SSH into job '{job.id}': job is not running (stage: '{job.status.stage}').")
     ssh_url = urlsplit(job.status.ssh_url)
     exec_ssh(
         f"{ssh_url.username}@{ssh_url.hostname}",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3400,6 +3400,62 @@ class TestJobsCommand:
         assert volume_2.read_only is None
 
 
+class TestJobsSshCommand:
+    """Tests for `hf jobs ssh` — waiting for job to be running."""
+
+    @staticmethod
+    def _make_job(stage: str, ssh_url: str | None = "ssh://abc123@ssh.hf.jobs") -> Mock:
+        status = Mock(stage=stage, ssh_url=ssh_url)
+        return Mock(id="abc123", status=status)
+
+    def test_ssh_running_immediately(self, runner: CliRunner) -> None:
+        job = self._make_job("RUNNING")
+        with (
+            patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls,
+            patch("huggingface_hub.cli.jobs.exec_ssh"),
+        ):
+            api = api_cls.return_value
+            api.inspect_job.return_value = job
+            result = runner.invoke(app, ["jobs", "ssh", "abc123", "--dry-run"])
+        assert result.exit_code == 0
+        api.inspect_job.assert_called_once()
+
+    def test_ssh_waits_for_scheduling(self, runner: CliRunner) -> None:
+        scheduling_job = self._make_job("SCHEDULING")
+        running_job = self._make_job("RUNNING")
+        with (
+            patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls,
+            patch("huggingface_hub.cli.jobs.exec_ssh"),
+            patch("huggingface_hub.cli.jobs.time") as mock_time,
+        ):
+            api = api_cls.return_value
+            api.inspect_job.side_effect = [scheduling_job, scheduling_job, running_job]
+            result = runner.invoke(app, ["jobs", "ssh", "abc123", "--dry-run"])
+        assert result.exit_code == 0
+        assert api.inspect_job.call_count == 3
+        assert mock_time.sleep.call_count == 2
+
+    def test_ssh_fails_on_terminal_stage(self, runner: CliRunner) -> None:
+        job = self._make_job("ERROR")
+        with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            api.inspect_job.return_value = job
+            result = runner.invoke(app, ["jobs", "ssh", "abc123"])
+        assert result.exit_code == 1
+        assert isinstance(result.exception, CLIError)
+        assert "already finished" in str(result.exception)
+
+    def test_ssh_fails_when_not_enabled(self, runner: CliRunner) -> None:
+        job = self._make_job("RUNNING", ssh_url=None)
+        with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            api.inspect_job.return_value = job
+            result = runner.invoke(app, ["jobs", "ssh", "abc123"])
+        assert result.exit_code == 1
+        assert isinstance(result.exception, CLIError)
+        assert "SSH is not enabled" in str(result.exception)
+
+
 class TestBucketTransport:
     """Tests for the bucket-based script transport used when `hf jobs uv run` is given local files."""
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #4352 (SSH support) and #4345 (wait_for_job API).

Instead of failing fast when the Job is not yet running, `hf jobs ssh` now polls `inspect_job` until the Job reaches the `RUNNING` stage before connecting. This improves the workflow where you start a job and immediately SSH into it — no more manual waiting for the scheduling phase to finish.

- **Waiting behavior**: if the Job is still `SCHEDULING` (or `UPDATING`), `hf jobs ssh` shows a status line and polls every 2 seconds until the Job reaches `RUNNING`.
- **Terminal stage handling**: if the Job hits a terminal stage (`COMPLETED`, `CANCELED`, `ERROR`, `DELETED`) while waiting, the command exits with a descriptive error.
- **Already running**: if the Job is already `RUNNING`, behaves exactly like before (no delay).

The pattern follows `_wait_for_dev_mode` in `spaces.py`.

## Changes

- `src/huggingface_hub/cli/jobs.py`: new `_wait_for_job_running` helper + updated `jobs_ssh` to use it
- `docs/source/en/guides/cli.md`: updated SSH section to mention wait behavior
- `docs/source/en/guides/jobs.md`: updated SSH section to mention wait behavior
- `docs/source/en/package_reference/cli.md`: auto-generated update from `make style`
- `tests/test_cli.py`: 4 new tests (`TestJobsSshCommand`)

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://huggingface.slack.com/archives/D0A9313SS3G/p1781705564411569?thread_ts=1781705564.411569&cid=D0A9313SS3G)

<div><a href="https://cursor.com/agents/bc-8663d9f8-14a3-5afa-9aca-4b4895ffcd0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8663d9f8-14a3-5afa-9aca-4b4895ffcd0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

