### PR TITLE
Add timeout parameter to safetensors metadata methods

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -6591,6 +6591,7 @@ class HfApi:
         repo_type: str | None = None,
         revision: str | None = None,
         token: bool | str | None = None,
+        timeout: float | None = constants.HF_HUB_DOWNLOAD_TIMEOUT,
     ) -> SafetensorsRepoMetadata:
         """
         Parse metadata for a safetensors repo on the Hub.
@@ -6617,6 +6618,10 @@ class HfApi:
                 token, which is the recommended method for authentication (see
                 https://huggingface.co/docs/huggingface_hub/quick-start#authentication).
                 To disable authentication, pass `False`.
+            timeout (`float`, *optional*, defaults to 10):
+                How many seconds to wait for the server to send data before giving up, passed to each request that
+                fetches a safetensors file header. Set to `None` to disable the timeout (not recommended, as a stalled
+                connection can hang the call indefinitely).
 
         Returns:
             [`SafetensorsRepoMetadata`]: information related to safetensors repo.
@@ -6668,6 +6673,7 @@ class HfApi:
                 repo_type=repo_type,
                 revision=revision,
                 token=token,
+                timeout=timeout,
             )
             return SafetensorsRepoMetadata(
                 metadata=None,
@@ -6702,7 +6708,12 @@ class HfApi:
 
             def _parse(filename: str) -> None:
                 files_metadata[filename] = self.parse_safetensors_file_metadata(
-                    repo_id=repo_id, filename=filename, repo_type=repo_type, revision=revision, token=token
+                    repo_id=repo_id,
+                    filename=filename,
+                    repo_type=repo_type,
+                    revision=revision,
+                    token=token,
+                    timeout=timeout,
                 )
 
             thread_map(
@@ -6732,6 +6743,7 @@ class HfApi:
         repo_type: str | None = None,
         revision: str | None = None,
         token: bool | str | None = None,
+        timeout: float | None = constants.HF_HUB_DOWNLOAD_TIMEOUT,
     ) -> SafetensorsFileMetadata:
         """
         Parse metadata from a safetensors file on the Hub.
@@ -6756,6 +6768,9 @@ class HfApi:
                 token, which is the recommended method for authentication (see
                 https://huggingface.co/docs/huggingface_hub/quick-start#authentication).
                 To disable authentication, pass `False`.
+            timeout (`float`, *optional*, defaults to 10):
+                How many seconds to wait for the server to send data before giving up. Set to `None` to disable the
+                timeout (not recommended, as a stalled connection can hang the call indefinitely).
 
         Returns:
             [`SafetensorsFileMetadata`]: information related to a safetensors file.
@@ -6779,7 +6794,7 @@ class HfApi:
         # We assume fetching 100kb is faster than making 2 GET requests. Therefore we always fetch the first 100kb to
         # avoid the 2nd GET in most cases.
         # See https://github.com/huggingface/huggingface_hub/pull/1855#discussion_r1404286419.
-        response = get_session().get(url, headers={**_headers, "range": "bytes=0-100000"})
+        response = get_session().get(url, headers={**_headers, "range": "bytes=0-100000"}, timeout=timeout)
         hf_raise_for_status(response)
 
         # 2. Parse and validate metadata size using shared helper
@@ -6789,7 +6804,9 @@ class HfApi:
         if metadata_size <= 100000:
             metadata_as_bytes = response.content[8 : 8 + metadata_size]
         else:  # 3.b. Request full metadata
-            response = get_session().get(url, headers={**_headers, "range": f"bytes=8-{metadata_size + 7}"})
+            response = get_session().get(
+                url, headers={**_headers, "range": f"bytes=8-{metadata_size + 7}"}, timeout=timeout
+            )
             hf_raise_for_status(response)
             metadata_as_bytes = response.content
 

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2634,6 +2634,27 @@ class HfApiPublicProductionTest(unittest.TestCase):
                 "HuggingFaceH4/zephyr-7b-beta", "pytorch_model-00001-of-00008.bin"
             )
 
+    def test_parse_safetensors_metadata_default_timeout(self) -> None:
+        # Regression test: the Range request must carry a timeout so a stalled connection cannot hang forever.
+        with patch("huggingface_hub.hf_api.get_session") as mock_get_session:
+            mock_get_session.return_value.get.side_effect = RuntimeError("stop after first request")
+            with self.assertRaises(RuntimeError):
+                self._api.parse_safetensors_file_metadata(
+                    "HuggingFaceH4/zephyr-7b-beta", "model-00003-of-00008.safetensors"
+                )
+        _, kwargs = mock_get_session.return_value.get.call_args
+        assert kwargs["timeout"] == constants.HF_HUB_DOWNLOAD_TIMEOUT
+
+    def test_parse_safetensors_metadata_custom_timeout(self) -> None:
+        with patch("huggingface_hub.hf_api.get_session") as mock_get_session:
+            mock_get_session.return_value.get.side_effect = RuntimeError("stop after first request")
+            with self.assertRaises(RuntimeError):
+                self._api.parse_safetensors_file_metadata(
+                    "HuggingFaceH4/zephyr-7b-beta", "model-00003-of-00008.safetensors", timeout=42
+                )
+        _, kwargs = mock_get_session.return_value.get.call_args
+        assert kwargs["timeout"] == 42
+
     def test_inference_provider_mapping_model_info(self):
         model = self._api.model_info("deepseek-ai/DeepSeek-R1-0528", expand="inferenceProviderMapping")
         mapping = model.inference_provider_mapping

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2634,27 +2634,6 @@ class HfApiPublicProductionTest(unittest.TestCase):
                 "HuggingFaceH4/zephyr-7b-beta", "pytorch_model-00001-of-00008.bin"
             )
 
-    def test_parse_safetensors_metadata_default_timeout(self) -> None:
-        # Regression test: the Range request must carry a timeout so a stalled connection cannot hang forever.
-        with patch("huggingface_hub.hf_api.get_session") as mock_get_session:
-            mock_get_session.return_value.get.side_effect = RuntimeError("stop after first request")
-            with self.assertRaises(RuntimeError):
-                self._api.parse_safetensors_file_metadata(
-                    "HuggingFaceH4/zephyr-7b-beta", "model-00003-of-00008.safetensors"
-                )
-        _, kwargs = mock_get_session.return_value.get.call_args
-        assert kwargs["timeout"] == constants.HF_HUB_DOWNLOAD_TIMEOUT
-
-    def test_parse_safetensors_metadata_custom_timeout(self) -> None:
-        with patch("huggingface_hub.hf_api.get_session") as mock_get_session:
-            mock_get_session.return_value.get.side_effect = RuntimeError("stop after first request")
-            with self.assertRaises(RuntimeError):
-                self._api.parse_safetensors_file_metadata(
-                    "HuggingFaceH4/zephyr-7b-beta", "model-00003-of-00008.safetensors", timeout=42
-                )
-        _, kwargs = mock_get_session.return_value.get.call_args
-        assert kwargs["timeout"] == 42
-
     def test_inference_provider_mapping_model_info(self):
         model = self._api.model_info("deepseek-ai/DeepSeek-R1-0528", expand="inferenceProviderMapping")
         mapping = model.inference_provider_mapping


### PR DESCRIPTION
## What

  Add a `timeout` parameter to `HfApi.get_safetensors_metadata` and
  `parse_safetensors_file_metadata`, passed through to the underlying Range `GET` requests.
  Default is `constants.HF_HUB_DOWNLOAD_TIMEOUT`.

  Closes #4377 

  ## Why

  `get_safetensors_metadata` fans one Range `GET` per shard out via `thread_map` with no
  overall deadline, and each request reads a response body. With the client default being
  unbounded (`requests` → `None` in 0.x; httpx `timeout=None` on `main`), a single stalled
  connection blocks a worker forever and hangs the whole call, with no way to bound it.
  The `*_info` methods and `get_hf_file_metadata` already expose `timeout` for the same
  reason; this follows that precedent.

  ## Notes

  - **Default `HF_HUB_DOWNLOAD_TIMEOUT`, not `HF_HUB_ETAG_TIMEOUT`**: these aren't HEAD
    requests like `get_hf_file_metadata` — they fetch content via Range `GET` and read the
    body, i.e. "download" semantics. Reusing the constant keeps it overridable via the env
    var. (Both default to 10s, so default behavior is unchanged.)
  - Backwards compatible: keyword-only with a default; `timeout=None` restores the previous
    unbounded behavior.
  - **Scope**: `timeout` intentionally covers only the header Range `GET`s that are fanned
    out via `thread_map`. The preliminary `file_exists` / `hf_hub_download` (index) requests
    in `get_safetensors_metadata` are not bounded by it, as they aren't part of the fan-out
    hot path this change targets.

  ## AI assistance

  AI was used to help investigate and draft this change. I have reviewed every line and can
  explain and defend it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Backward-compatible optional parameter with an unchanged default; only affects HTTP wait behavior for safetensors header fetches.
> 
> **Overview**
> Adds a keyword-only **`timeout`** argument (default **`constants.HF_HUB_DOWNLOAD_TIMEOUT`**) to **`HfApi.get_safetensors_metadata`** and **`parse_safetensors_file_metadata`**, matching how other Hub download-style calls expose deadlines.
> 
> The value is threaded into both Range **`GET`** calls in **`parse_safetensors_file_metadata`** (initial 100kb fetch and optional full-metadata fetch) and forwarded for single-file and per-shard parsing in sharded repos. **`timeout=None`** keeps prior unbounded client behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf6ed26e5af4446de19c6a545075f9d96db41776. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
