### PR TITLE
[CLI] Make `hf jobs ssh` wait for job to be running

### DIFF
--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -2658,8 +2658,9 @@ Learn more
 
 SSH into a running Job.
 
-Requires the Job to be started with SSH enabled (`hf jobs run --ssh ...`) and your SSH
-public key to be registered at https://huggingface.co/settings/keys.
+If the Job is not yet running, waits until it reaches the RUNNING state before
+connecting. Requires the Job to be started with SSH enabled (`hf jobs run --ssh ...`)
+and your SSH public key to be registered at https://huggingface.co/settings/keys.
 
 **Usage**:
 
@@ -2799,7 +2800,7 @@ $ hf jobs wait [OPTIONS] JOB_IDS...
 
 **Arguments**:
 
-* `JOB_IDS...`: Job IDs to wait for.  [required]
+* `JOB_IDS...`: Job IDs to wait for (or 'namespace/job_id').  [required]
 
 **Options**:
 

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -817,9 +817,7 @@ def jobs_ssh(
         raise CLIError(f"Cannot SSH into job '{job.id}': job has already finished (stage: '{job.status.stage}').")
     if job.status.stage != JobStage.RUNNING:
         status = out.status(f"Waiting for job '{job.id}' to be running (stage: '{job.status.stage}')...")
-        while job.status.stage not in (JobStage.RUNNING, *TERMINAL_JOB_STAGES):
-            time.sleep(5)
-            job = api.inspect_job(job_id=job.id, namespace=namespace)
+        job = api.wait_for_job(job_id=job.id, namespace=namespace, stages=[JobStage.RUNNING, ])
         if job.status.stage != JobStage.RUNNING:
             status.done("Job finished.")
             raise CLIError(

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -77,6 +77,7 @@ from urllib.parse import urlsplit
 import typer
 
 from huggingface_hub import HfApi, JobHardware, JobInfo, JobStage
+from huggingface_hub._jobs_api import TERMINAL_JOB_STAGES
 from huggingface_hub.errors import CLIError
 from huggingface_hub.utils import logging
 from huggingface_hub.utils._cache_manager import _format_size
@@ -803,16 +804,28 @@ def jobs_ssh(
 ) -> None:
     """SSH into a running Job.
 
-    Requires the Job to be started with SSH enabled (`hf jobs run --ssh ...`) and your SSH
-    public key to be registered at https://huggingface.co/settings/keys.
+    If the Job is not yet running, waits until it reaches the RUNNING state before
+    connecting. Requires the Job to be started with SSH enabled (`hf jobs run --ssh ...`)
+    and your SSH public key to be registered at https://huggingface.co/settings/keys.
     """
     job_id, namespace = _parse_namespace_from_job_id(job_id, namespace)
     api = get_hf_api(token=token)
     job = api.inspect_job(job_id=job_id, namespace=namespace)
     if job.status.ssh_url is None:
         raise CLIError("SSH is not enabled on this job. Start a job with SSH support using `hf jobs run --ssh ...`.")
-    if job.status.stage != "RUNNING":
-        raise CLIError(f"Cannot SSH into job '{job.id}': job is not running (stage: '{job.status.stage}').")
+    if job.status.stage in TERMINAL_JOB_STAGES:
+        raise CLIError(f"Cannot SSH into job '{job.id}': job has already finished (stage: '{job.status.stage}').")
+    if job.status.stage != JobStage.RUNNING:
+        status = out.status(f"Waiting for job '{job.id}' to be running (stage: '{job.status.stage}')...")
+        while job.status.stage not in (JobStage.RUNNING, *TERMINAL_JOB_STAGES):
+            time.sleep(5)
+            job = api.inspect_job(job_id=job.id, namespace=namespace)
+        if job.status.stage != JobStage.RUNNING:
+            status.done("Job finished.")
+            raise CLIError(
+                f"Cannot SSH into job '{job.id}': job finished before reaching RUNNING (stage: '{job.status.stage}')."
+            )
+        status.done("Job is running.")
     ssh_url = urlsplit(job.status.ssh_url)
     exec_ssh(
         f"{ssh_url.username}@{ssh_url.hostname}",

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -826,7 +826,7 @@ def jobs_ssh(
         status.done("Job is running.")
     ssh_url = urlsplit(job.status.ssh_url)
     exec_ssh(
-        f"{ssh_url.username}@{ssh_url.hostname}",
+        f"{ssh_url.username}@{ssh_url.hostname}",  # type: ignore
         port=ssh_url.port,
         identity_file=identity_file,
         dry_run=dry_run,

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -817,7 +817,7 @@ def jobs_ssh(
         raise CLIError(f"Cannot SSH into job '{job.id}': job has already finished (stage: '{job.status.stage}').")
     if job.status.stage != JobStage.RUNNING:
         status = out.status(f"Waiting for job '{job.id}' to be running (stage: '{job.status.stage}')...")
-        job = api.wait_for_job(job_id=job.id, namespace=namespace, stages=[JobStage.RUNNING, ])
+        job = api.wait_for_job(job_id=job.id, namespace=namespace, stages=[JobStage.RUNNING])
         if job.status.stage != JobStage.RUNNING:
             status.done("Job finished.")
             raise CLIError(

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -77,6 +77,7 @@ from ._jobs_api import (
     JobHardwareInfo,
     JobInfo,
     JobSpec,
+    JobStage,
     ScheduledJobInfo,
     _create_job_spec,
 )
@@ -12070,7 +12071,8 @@ class HfApi:
         job_id: str,
         *,
         timeout: float | None = None,
-        poll_interval: float = 5.0,
+        poll_interval: float = 1.0,
+        stages: list[JobStage] | None = None,
         namespace: str | None = None,
         token: bool | str | None = None,
     ) -> JobInfo: ...
@@ -12081,7 +12083,8 @@ class HfApi:
         job_id: list[str],
         *,
         timeout: float | None = None,
-        poll_interval: float = 5.0,
+        poll_interval: float = 1.0,
+        stages: list[JobStage] | None = None,
         namespace: str | None = None,
         token: bool | str | None = None,
     ) -> list[JobInfo]: ...
@@ -12091,17 +12094,21 @@ class HfApi:
         job_id: str | list[str],
         *,
         timeout: float | None = None,
-        poll_interval: float = 5.0,
+        poll_interval: float = 1.0,
+        stages: list[JobStage] | None = None,
         namespace: str | None = None,
         token: bool | str | None = None,
     ) -> JobInfo | list[JobInfo]:
         """
-        Wait until one or more compute Jobs on Hugging Face infrastructure reach a terminal state.
+        Wait until one or more compute Jobs on Hugging Face infrastructure reach a given stage.
 
-        Each Job status is polled (with [`inspect_job`]) every `poll_interval` seconds until its stage is
-        terminal: `"COMPLETED"`, `"CANCELED"`, `"ERROR"` or `"DELETED"`. The final [`JobInfo`] is returned
-        in all cases: a failed or canceled Job does **not** raise an exception — check `job.status.stage`
-        to act on the outcome.
+        Each Job status is polled (with [`inspect_job`]) every `poll_interval` seconds until its stage is one
+        of `stages` (terminal stages by default: `"COMPLETED"`, `"CANCELED"`, `"ERROR"` or `"DELETED"`). The
+        final [`JobInfo`] is returned in all cases: a failed or canceled Job does **not** raise an exception —
+        check `job.status.stage` to act on the outcome.
+
+        Terminal stages always stop the wait, even when not listed in `stages`. This avoids waiting forever for
+        a stage the Job will never reach (e.g. waiting for `"RUNNING"` on a Job that fails during scheduling).
 
         Args:
             job_id (`str` or `list[str]`):
@@ -12113,7 +12120,12 @@ class HfApi:
                 indefinitely.
 
             poll_interval (`float`, *optional*):
-                The time to wait between each status check, in seconds. Defaults to 5s.
+                The time to wait between each status check, in seconds. Defaults to 1s.
+
+            stages (`list[JobStage]`, *optional*):
+                The stages to wait for. Defaults to the terminal stages (`"COMPLETED"`, `"CANCELED"`,
+                `"ERROR"`, `"DELETED"`). Pass e.g. `[JobStage.RUNNING]` to wait for the Job to start running.
+                Terminal stages always stop the wait regardless of this value.
 
             namespace (`str`, *optional*):
                 The namespace where the Job(s) are running. Defaults to the current user's namespace.
@@ -12124,11 +12136,11 @@ class HfApi:
                 Refer to: https://huggingface.co/docs/huggingface_hub/quick-start#authentication.
 
         Returns:
-            [`JobInfo`] or `list[JobInfo]`: the final Job info(s), in a terminal stage.
+            [`JobInfo`] or `list[JobInfo]`: the final Job info(s).
 
         Raises:
             `TimeoutError`:
-                If at least one Job has not reached a terminal stage after `timeout` seconds.
+                If at least one Job has not reached one of the target stages after `timeout` seconds.
 
         Example:
 
@@ -12144,6 +12156,9 @@ class HfApi:
         if poll_interval <= 0:
             raise ValueError("`poll_interval` must be positive.")
 
+        # Terminal stages always stop the wait, so a Job that never reaches the target stage doesn't hang.
+        target_stages = set(stages) | set(TERMINAL_JOB_STAGES) if stages else set(TERMINAL_JOB_STAGES)
+
         if namespace is None:
             namespace = self.whoami(token=token)["name"]
         deadline = None if timeout is None else time.monotonic() + timeout
@@ -12151,7 +12166,7 @@ class HfApi:
         def _wait_single(single_job_id: str) -> JobInfo:
             while True:
                 job = self.inspect_job(job_id=single_job_id, namespace=namespace, token=token)
-                if job.status.stage in TERMINAL_JOB_STAGES:
+                if job.status.stage in target_stages:
                     return job
                 remaining = None if deadline is None else deadline - time.monotonic()
                 if remaining is not None and remaining <= 0:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3564,53 +3564,6 @@ class TestJobsWaitCommand:
         api.wait_for_job.assert_not_called()
 
 
-class TestJobsSshCommand:
-    def _job(self, stage: str, ssh_url: str | None = "ssh://my-job-id@ssh.hf.jobs") -> Mock:
-        job = Mock(id="my-job-id")
-        job.status.stage = stage
-        job.status.ssh_url = ssh_url
-        return job
-
-    def test_ssh_waits_for_running(self, runner: CliRunner) -> None:
-        from huggingface_hub import JobStage
-
-        scheduling_job = self._job("SCHEDULING")
-        running_job = self._job("RUNNING")
-        with (
-            patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls,
-            patch("huggingface_hub.cli.jobs.exec_ssh") as mock_exec_ssh,
-        ):
-            api = api_cls.return_value
-            api.inspect_job.return_value = scheduling_job
-            api.wait_for_job.return_value = running_job
-            result = runner.invoke(app, ["jobs", "ssh", "my-job-id"])
-        assert result.exit_code == 0
-        api.wait_for_job.assert_called_once_with(job_id="my-job-id", namespace=None, stages=[JobStage.RUNNING])
-        mock_exec_ssh.assert_called_once()
-
-    def test_ssh_errors_if_job_finishes_before_running(self, runner: CliRunner) -> None:
-        scheduling_job = self._job("SCHEDULING")
-        completed_job = self._job("COMPLETED")
-        with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
-            api = api_cls.return_value
-            api.inspect_job.return_value = scheduling_job
-            api.wait_for_job.return_value = completed_job
-            result = runner.invoke(app, ["jobs", "ssh", "my-job-id"])
-        assert result.exit_code == 1
-        assert isinstance(result.exception, CLIError)
-        assert "finished before reaching RUNNING" in str(result.exception)
-
-    def test_ssh_errors_if_ssh_not_enabled(self, runner: CliRunner) -> None:
-        job = self._job("RUNNING", ssh_url=None)
-        with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
-            api = api_cls.return_value
-            api.inspect_job.return_value = job
-            result = runner.invoke(app, ["jobs", "ssh", "my-job-id"])
-        assert result.exit_code == 1
-        assert isinstance(result.exception, CLIError)
-        assert "SSH is not enabled" in str(result.exception)
-
-
 class TestBucketTransport:
     """Tests for the bucket-based script transport used when `hf jobs uv run` is given local files."""
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3564,6 +3564,53 @@ class TestJobsWaitCommand:
         api.wait_for_job.assert_not_called()
 
 
+class TestJobsSshCommand:
+    def _job(self, stage: str, ssh_url: str | None = "ssh://my-job-id@ssh.hf.jobs") -> Mock:
+        job = Mock(id="my-job-id")
+        job.status.stage = stage
+        job.status.ssh_url = ssh_url
+        return job
+
+    def test_ssh_waits_for_running(self, runner: CliRunner) -> None:
+        scheduling_job = self._job("SCHEDULING")
+        running_job = self._job("RUNNING")
+        with (
+            patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls,
+            patch("huggingface_hub.cli.jobs.exec_ssh") as mock_exec_ssh,
+            patch("huggingface_hub.cli.jobs.time.sleep"),
+        ):
+            api = api_cls.return_value
+            api.inspect_job.side_effect = [scheduling_job, scheduling_job, running_job]
+            result = runner.invoke(app, ["jobs", "ssh", "my-job-id"])
+        assert result.exit_code == 0
+        assert api.inspect_job.call_count == 3
+        mock_exec_ssh.assert_called_once()
+
+    def test_ssh_errors_if_job_finishes_before_running(self, runner: CliRunner) -> None:
+        scheduling_job = self._job("SCHEDULING")
+        completed_job = self._job("COMPLETED")
+        with (
+            patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls,
+            patch("huggingface_hub.cli.jobs.time.sleep"),
+        ):
+            api = api_cls.return_value
+            api.inspect_job.side_effect = [scheduling_job, completed_job]
+            result = runner.invoke(app, ["jobs", "ssh", "my-job-id"])
+        assert result.exit_code == 1
+        assert isinstance(result.exception, CLIError)
+        assert "finished before reaching RUNNING" in str(result.exception)
+
+    def test_ssh_errors_if_ssh_not_enabled(self, runner: CliRunner) -> None:
+        job = self._job("RUNNING", ssh_url=None)
+        with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            api.inspect_job.return_value = job
+            result = runner.invoke(app, ["jobs", "ssh", "my-job-id"])
+        assert result.exit_code == 1
+        assert isinstance(result.exception, CLIError)
+        assert "SSH is not enabled" in str(result.exception)
+
+
 class TestBucketTransport:
     """Tests for the bucket-based script transport used when `hf jobs uv run` is given local files."""
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3572,29 +3572,29 @@ class TestJobsSshCommand:
         return job
 
     def test_ssh_waits_for_running(self, runner: CliRunner) -> None:
+        from huggingface_hub import JobStage
+
         scheduling_job = self._job("SCHEDULING")
         running_job = self._job("RUNNING")
         with (
             patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls,
             patch("huggingface_hub.cli.jobs.exec_ssh") as mock_exec_ssh,
-            patch("huggingface_hub.cli.jobs.time.sleep"),
         ):
             api = api_cls.return_value
-            api.inspect_job.side_effect = [scheduling_job, scheduling_job, running_job]
+            api.inspect_job.return_value = scheduling_job
+            api.wait_for_job.return_value = running_job
             result = runner.invoke(app, ["jobs", "ssh", "my-job-id"])
         assert result.exit_code == 0
-        assert api.inspect_job.call_count == 3
+        api.wait_for_job.assert_called_once_with(job_id="my-job-id", namespace=None, stages=[JobStage.RUNNING])
         mock_exec_ssh.assert_called_once()
 
     def test_ssh_errors_if_job_finishes_before_running(self, runner: CliRunner) -> None:
         scheduling_job = self._job("SCHEDULING")
         completed_job = self._job("COMPLETED")
-        with (
-            patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls,
-            patch("huggingface_hub.cli.jobs.time.sleep"),
-        ):
+        with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
             api = api_cls.return_value
-            api.inspect_job.side_effect = [scheduling_job, completed_job]
+            api.inspect_job.return_value = scheduling_job
+            api.wait_for_job.return_value = completed_job
             result = runner.invoke(app, ["jobs", "ssh", "my-job-id"])
         assert result.exit_code == 1
         assert isinstance(result.exception, CLIError)

--- a/tests/test_jobs_api.py
+++ b/tests/test_jobs_api.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 import pytest
 
-from huggingface_hub import HfApi
+from huggingface_hub import HfApi, JobStage
 from huggingface_hub._jobs_api import JobInfo
 
 
@@ -49,8 +49,6 @@ class TestWaitForJob:
                 self.api.wait_for_job(job_id="job-id", timeout=0, namespace="user")
 
     def test_stages_waits_for_running(self) -> None:
-        from huggingface_hub import JobStage
-
         with (
             patch.object(
                 self.api,
@@ -65,8 +63,6 @@ class TestWaitForJob:
         assert mock_inspect.call_count == 2
 
     def test_stages_stops_on_terminal_even_if_target_not_reached(self) -> None:
-        from huggingface_hub import JobStage
-
         # Terminal stages always stop the wait, so waiting for RUNNING doesn't hang on a Job that fails early.
         with (
             patch.object(

--- a/tests/test_jobs_api.py
+++ b/tests/test_jobs_api.py
@@ -47,3 +47,34 @@ class TestWaitForJob:
         ):
             with pytest.raises(TimeoutError):
                 self.api.wait_for_job(job_id="job-id", timeout=0, namespace="user")
+
+    def test_stages_waits_for_running(self) -> None:
+        from huggingface_hub import JobStage
+
+        with (
+            patch.object(
+                self.api,
+                "inspect_job",
+                side_effect=[_job_info("SCHEDULING"), _job_info("RUNNING"), _job_info("COMPLETED")],
+            ) as mock_inspect,
+            patch("huggingface_hub.hf_api.time.sleep"),
+        ):
+            job = self.api.wait_for_job(job_id="job-id", namespace="user", stages=[JobStage.RUNNING])
+        # Stops as soon as RUNNING is reached, without waiting for a terminal stage.
+        assert job.status.stage == "RUNNING"
+        assert mock_inspect.call_count == 2
+
+    def test_stages_stops_on_terminal_even_if_target_not_reached(self) -> None:
+        from huggingface_hub import JobStage
+
+        # Terminal stages always stop the wait, so waiting for RUNNING doesn't hang on a Job that fails early.
+        with (
+            patch.object(
+                self.api,
+                "inspect_job",
+                side_effect=[_job_info("SCHEDULING"), _job_info("ERROR")],
+            ),
+            patch("huggingface_hub.hf_api.time.sleep"),
+        ):
+            job = self.api.wait_for_job(job_id="job-id", namespace="user", stages=[JobStage.RUNNING])
+        assert job.status.stage == "ERROR"


### PR DESCRIPTION
## Summary

Makes `hf jobs ssh` wait for the job to reach RUNNING before connecting, instead of erroring immediately when the job is still in SCHEDULING. The wait logic now lives in `HfApi.wait_for_job` rather than being reimplemented in the CLI.

This was requested now that #4345 (`hf jobs wait` / `wait_for_job`) and #4352 (SSH support) are merged.

### `wait_for_job` changes

- Added a `stages: list[JobStage] | None` argument. By default it waits for the terminal stages (`COMPLETED`, `CANCELED`, `ERROR`, `DELETED`) — unchanged behavior. Callers can now wait for a custom stage, e.g. `stages=[JobStage.RUNNING]`.
- Terminal stages **always** stop the wait, even when not listed in `stages`. This avoids waiting forever for a stage the job will never reach (e.g. waiting for `RUNNING` on a job that fails during scheduling).
- Changed the default `poll_interval` from `5.0s` to `1.0s` (more responsive, especially for the SSH "wait for running" case).

### `hf jobs ssh` changes

- Dropped the hand-rolled `inspect_job` + `time.sleep` polling loop and now calls `api.wait_for_job(..., stages=[JobStage.RUNNING])`.
- Kept the `out.status(...)` spinner and the post-wait checks (already-finished / finished-before-running) — behavior from the user's point of view is unchanged.

### Example behavior

```
$ hf jobs run --ssh --detach python:3.12 sleep infinity
✓ Job started
  id: 6a33ba2aef9220ea67d98a03
  url: https://huggingface.co/jobs/Wauplin/6a33ba2aef9220ea67d98a03
Hint: Use `hf jobs ssh Wauplin/6a33ba2aef9220ea67d98a03` to open an SSH session into the job.
Hint: Use `hf jobs logs -f Wauplin/6a33ba2aef9220ea67d98a03` to stream logs, or `hf jobs inspect Wauplin/6a33ba2aef9220ea67d98a03` to check status.

$ hf jobs ssh Wauplin/6a33ba2aef9220ea67d98a03
Job is running.
Running `ssh 6a33ba2aef9220ea67d98a03@ssh.hf.jobs`
root@j-wauplin-6a33ba2aef9220ea67d98a03-do4bduvn-5f153-458k4:/# 
```


<div><a href="https://cursor.com/agents/bc-16433070-00dd-593f-b444-94e2d6cb61c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16433070-00dd-593f-b444-94e2d6cb61c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Backward-compatible API default; only behavioral change for callers is faster polling (1s). SSH wait is additive CLI behavior with existing error paths preserved.
> 
> **Overview**
> **`hf jobs ssh`** no longer fails immediately when the job is still scheduling. It polls (with a status spinner) until the job is **RUNNING**, then opens SSH. Jobs already in a terminal stage still error out; jobs that finish before reaching RUNNING get a clear error after the wait.
> 
> **`HfApi.wait_for_job`** gains an optional **`stages`** argument (e.g. `[JobStage.RUNNING]`) so callers can wait for a specific stage, not only terminal completion. **Terminal stages always end the wait** even if they are not in `stages`, so waiting for `RUNNING` cannot hang when the job errors during scheduling. Default **`poll_interval`** changes from **5s to 1s** (default “wait until finished” behavior is unchanged). CLI docs note SSH waiting and `namespace/job_id` for **`hf jobs wait`**.
> 
> Tests cover waiting for `RUNNING` and early exit on terminal stages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b7c07d95e525e031e70afaf0cb32a1bbb870941. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->