### PR TITLE
[Spaces] Add `wait_for_space` API and `hf spaces wait` CLI

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -1115,6 +1115,20 @@ Use `hf spaces restart` to restart a Space. Pass `--factory-reboot` to rebuild t
 >>> hf spaces restart username/my-space --factory-reboot
 ```
 
+### Wait for a Space
+
+Use `hf spaces wait` to block until a Space finishes building/starting and reaches a settled stage. Exits with code 0 if the Space is `RUNNING`, or non-zero otherwise (e.g. `BUILD_ERROR`). Handy for scripting after a restart or hardware change.
+
+```bash
+>>> hf spaces wait username/my-space
+
+# With a timeout
+>>> hf spaces wait username/my-space --timeout 5m
+
+# Chain with restart
+>>> hf spaces restart username/my-space && hf spaces wait username/my-space
+```
+
 ### List available hardware
 
 Use `hf spaces hardware` to list all available hardware options for Spaces, including pricing.

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -2799,7 +2799,7 @@ $ hf jobs wait [OPTIONS] JOB_IDS...
 
 **Arguments**:
 
-* `JOB_IDS...`: Job IDs to wait for.  [required]
+* `JOB_IDS...`: Job IDs to wait for (or 'namespace/job_id').  [required]
 
 **Options**:
 
@@ -3789,6 +3789,7 @@ $ hf spaces [OPTIONS] COMMAND [ARGS]...
 * `ssh`: SSH into a Space's Dev Mode container.
 * `variables`: Manage environment variables for a Space...
 * `volumes`: Manage volumes for a Space on the Hub.
+* `wait`: Wait for a Space to finish building/starting.
 
 ### `hf spaces card`
 
@@ -4509,6 +4510,39 @@ $ hf spaces volumes set [OPTIONS] SPACE_ID
 Examples
   $ hf spaces volumes set username/my-space -v hf://models/username/my-model:/models
   $ hf spaces volumes set username/my-space -v hf://buckets/username/my-bucket:/data -v hf://datasets/username/my-dataset:/datasets:ro
+
+Learn more
+  Use `hf <command> --help` for more information about a command.
+  Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
+
+
+### `hf spaces wait`
+
+Wait for a Space to finish building/starting.
+
+Blocks until the Space leaves an intermediate stage (BUILDING, APP_STARTING, etc.)
+and reaches a settled stage. Exits with code 0 if the Space is RUNNING,
+or a non-zero exit code otherwise (e.g. BUILD_ERROR, RUNTIME_ERROR).
+
+**Usage**:
+
+```console
+$ hf spaces wait [OPTIONS] SPACE_ID
+```
+
+**Arguments**:
+
+* `SPACE_ID`: The space ID (e.g. `username/repo-name`).  [required]
+
+**Options**:
+
+* `--timeout TEXT`: Max time to wait: int/float with s (seconds, default), m (minutes), h (hours) or d (days).
+* `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
+* `--help`: Show this message and exit.
+
+Examples
+  $ hf spaces wait username/my-space
+  $ hf spaces wait username/my-space --timeout 5m
 
 Learn more
   Use `hf <command> --help` for more information about a command.

--- a/docs/source/en/package_reference/space_runtime.md
+++ b/docs/source/en/package_reference/space_runtime.md
@@ -12,6 +12,7 @@ Check the [`HfApi`] documentation page for the reference of methods to manage yo
 - Manage secrets: [`add_space_secret`] and [`delete_space_secret`]
 - Manage hardware: [`request_space_hardware`]
 - Manage state: [`pause_space`], [`restart_space`], [`set_space_sleep_time`]
+- Wait until Space is ready: [`wait_for_space`]
 
 ## Data structures
 

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -352,6 +352,7 @@ _SUBMOD_ATTRS = {
         "upload_large_folder",
         "verify_repo_checksums",
         "wait_for_job",
+        "wait_for_space",
         "whoami",
     ],
     "hf_file_system": [
@@ -1114,6 +1115,7 @@ __all__ = [
     "upload_large_folder",
     "verify_repo_checksums",
     "wait_for_job",
+    "wait_for_space",
     "webhook_endpoint",
     "whoami",
 ]
@@ -1514,6 +1516,7 @@ if TYPE_CHECKING:  # pragma: no cover
         upload_large_folder,  # noqa: F401
         verify_repo_checksums,  # noqa: F401
         wait_for_job,  # noqa: F401
+        wait_for_space,  # noqa: F401
         whoami,  # noqa: F401
     )
     from .hf_file_system import (

--- a/src/huggingface_hub/_space_api.py
+++ b/src/huggingface_hub/_space_api.py
@@ -46,6 +46,25 @@ class SpaceStage(str, Enum):
     RUNNING_APP_STARTING = "RUNNING_APP_STARTING"
 
 
+INTERMEDIATE_SPACE_STAGES = (
+    SpaceStage.BUILDING,
+    SpaceStage.RUNNING_BUILDING,
+    SpaceStage.APP_STARTING,
+    SpaceStage.RUNNING_APP_STARTING,
+)
+
+TERMINAL_SPACE_STAGES = (
+    SpaceStage.RUNNING,
+    SpaceStage.BUILD_ERROR,
+    SpaceStage.RUNTIME_ERROR,
+    SpaceStage.CONFIG_ERROR,
+    SpaceStage.NO_APP_FILE,
+    SpaceStage.STOPPED,
+    SpaceStage.PAUSED,
+    SpaceStage.DELETING,
+)
+
+
 class SpaceHardware(str, Enum):
     """
     Enumeration of hardwares available to run your Space on the Hub.

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -324,9 +324,9 @@ def spaces_wait(
         status.done("Timed out.")
         raise CLIError(f"Timed out after {timeout} waiting for Space '{space_id}' to be ready.") from None
     status.done(f"Space reached stage '{runtime.stage}'.")
-    out.result("Space ready", space_id=space_id, stage=str(runtime.stage))
     if runtime.stage != SpaceStage.RUNNING:
         raise CLIError(f"Space '{space_id}' is not running (stage='{runtime.stage}').")
+    out.result("Space ready", space_id=space_id, stage=str(runtime.stage))
     out.hint(f"Use `hf spaces logs {space_id}` to view run logs.")
 
 

--- a/src/huggingface_hub/cli/spaces.py
+++ b/src/huggingface_hub/cli/spaces.py
@@ -48,9 +48,10 @@ from huggingface_hub._space_api import SpaceHardware, SpaceStage
 from huggingface_hub.cli._cli_utils import SoftChoice
 from huggingface_hub.errors import CLIError, RemoteEntryNotFoundError, RepositoryNotFoundError, RevisionNotFoundError
 from huggingface_hub.file_download import hf_hub_download
-from huggingface_hub.hf_api import ExpandSpaceProperty_T, HfApi, SpaceInfo, SpaceSort_T
+from huggingface_hub.hf_api import ExpandSpaceProperty_T, HfApi, SpaceSort_T
 from huggingface_hub.repocard import SpaceCard
 from huggingface_hub.utils import disable_progress_bars
+from huggingface_hub.utils._parsing import parse_duration
 
 from ._cli_utils import (
     REPO_LIST_DEFAULT_LIMIT,
@@ -291,30 +292,42 @@ def spaces_search(
         out.hint("Use --description to show AI-generated descriptions.")
 
 
-_DEV_MODE_INTERMEDIATE_STATUSES = {
-    SpaceStage.BUILDING: "building...",
-    SpaceStage.RUNNING_BUILDING: "building...",
-    SpaceStage.APP_STARTING: "app starting...",
-    SpaceStage.RUNNING_APP_STARTING: "app starting...",
-}
+@spaces_cli.command(
+    "wait",
+    examples=[
+        "hf spaces wait username/my-space",
+        "hf spaces wait username/my-space --timeout 5m",
+    ],
+)
+def spaces_wait(
+    space_id: Annotated[str, typer.Argument(help="The space ID (e.g. `username/repo-name`).")],
+    timeout: Annotated[
+        str | None,
+        typer.Option(
+            help="Max time to wait: int/float with s (seconds, default), m (minutes), h (hours) or d (days).",
+        ),
+    ] = None,
+    token: TokenOpt = None,
+) -> None:
+    """Wait for a Space to finish building/starting.
 
-
-def _wait_for_dev_mode(api: HfApi, space_id: str) -> SpaceInfo | None:
-
-    status = out.status()
-    while True:
-        info = api.space_info(space_id)
-        if info.runtime is None:
-            return None
-        if info.runtime.stage not in _DEV_MODE_INTERMEDIATE_STATUSES:
-            break
-        status.update(_DEV_MODE_INTERMEDIATE_STATUSES[info.runtime.stage])
-        time.sleep(1)
-    if info.runtime.stage != SpaceStage.RUNNING:
-        status.done(f"Dev mode is not ready (stage='{info.runtime.stage}')")
-        return None
-    status.done("Dev mode ready!")
-    return info
+    Blocks until the Space leaves an intermediate stage (BUILDING, APP_STARTING, etc.)
+    and reaches a settled stage. Exits with code 0 if the Space is RUNNING,
+    or a non-zero exit code otherwise (e.g. BUILD_ERROR, RUNTIME_ERROR).
+    """
+    timeout_secs = parse_duration(timeout) if timeout is not None else None
+    api = get_hf_api(token=token)
+    status = out.status("Waiting for Space to be ready...")
+    try:
+        runtime = api.wait_for_space(space_id, timeout=timeout_secs)
+    except TimeoutError:
+        status.done("Timed out.")
+        raise CLIError(f"Timed out after {timeout} waiting for Space '{space_id}' to be ready.") from None
+    status.done(f"Space reached stage '{runtime.stage}'.")
+    out.result("Space ready", space_id=space_id, stage=str(runtime.stage))
+    if runtime.stage != SpaceStage.RUNNING:
+        raise CLIError(f"Space '{space_id}' is not running (stage='{runtime.stage}').")
+    out.hint(f"Use `hf spaces logs {space_id}` to view run logs.")
 
 
 @spaces_cli.command(
@@ -343,9 +356,11 @@ def dev_mode(
         print(f"Dev mode disabled for '{space_id}'")
         return
     api.enable_space_dev_mode(space_id)
-    info = _wait_for_dev_mode(api, space_id)
-    if info is None:
+    runtime = api.wait_for_space(space_id)
+    if runtime.stage != SpaceStage.RUNNING:
+        out.warning(f"Dev mode is not ready (stage='{runtime.stage}')")
         return
+    info = api.space_info(space_id)
     folder = getattr(info.card_data, "dev-mode-folder", "" if info.sdk == "docker" else "/home/user/app")
     folder_query_param = f"folder={folder}" if folder else ""
     print("Connect to dev environment:")
@@ -399,10 +414,10 @@ def spaces_ssh(
             f"Dev Mode is disabled on '{space_id}'. Enable it now?", yes=auto, default=True, confirm_param="--auto"
         )
         api.enable_space_dev_mode(space_id)
-        new_info = _wait_for_dev_mode(api, space_id)
-        if new_info is None:
-            raise CLIError(f"Runtime not available for Space '{space_id}'.")
-        info = new_info
+        runtime = api.wait_for_space(space_id)
+        if runtime.stage != SpaceStage.RUNNING:
+            raise CLIError(f"Space '{space_id}' is not running (stage='{runtime.stage}').")
+        info = api.space_info(space_id)
     exec_ssh(f"{info.subdomain}@ssh.hf.space", identity_file=identity_file, dry_run=dry_run)
 
 
@@ -453,7 +468,7 @@ def spaces_restart(
         stage=runtime.stage,
         factory_reboot=factory_reboot,
     )
-    out.hint(f"Use `hf spaces info {space_id}` to monitor the runtime stage.")
+    out.hint(f"Use `hf spaces wait {space_id}` to wait until the Space is ready.")
     out.hint(
         f"Mount a Volume or bucket to persist data across restarts: `hf spaces volumes set {space_id} -v hf://...`"
     )

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -81,6 +81,7 @@ from ._jobs_api import (
     _create_job_spec,
 )
 from ._space_api import (
+    INTERMEDIATE_SPACE_STAGES,
     SpaceHardware,
     SpaceRuntime,
     SpaceSearchResult,
@@ -8524,6 +8525,66 @@ class HfApi:
         ):
             yield event["data"]
 
+    @validate_hf_hub_args
+    def wait_for_space(
+        self,
+        repo_id: str,
+        *,
+        timeout: float | None = None,
+        poll_interval: float = 5.0,
+        token: bool | str | None = None,
+    ) -> SpaceRuntime:
+        """Wait until a Space reaches a terminal stage (not building/starting).
+
+        Polls [`get_space_runtime`] every `poll_interval` seconds until the Space's stage
+        is no longer intermediate (`BUILDING`, `RUNNING_BUILDING`, `APP_STARTING`,
+        `RUNNING_APP_STARTING`). Returns the final [`SpaceRuntime`] in all cases — check
+        `runtime.stage` to act on the outcome (e.g. `RUNNING` vs `BUILD_ERROR`).
+
+        Args:
+            repo_id (`str`):
+                ID of the Space to wait for. Example: `"username/my-space"`.
+            timeout (`float`, *optional*):
+                Maximum time to wait in seconds. If `None`, waits indefinitely.
+            poll_interval (`float`, *optional*):
+                Seconds between status checks. Defaults to 5s.
+            token (`bool` or `str`, *optional*):
+                A valid user access token. Defaults to the locally saved token, which is the
+                recommended authentication method. Set to `False` to disable authentication.
+                See https://huggingface.co/docs/huggingface_hub/quick-start#authentication.
+
+        Returns:
+            [`SpaceRuntime`]: The final runtime information once the Space reaches a terminal stage.
+
+        Raises:
+            `TimeoutError`:
+                If the Space has not reached a terminal stage after `timeout` seconds.
+
+        Example:
+
+            ```python
+            >>> from huggingface_hub import restart_space, wait_for_space
+            >>> restart_space("username/my-space")
+            >>> runtime = wait_for_space("username/my-space")
+            >>> runtime.stage
+            'RUNNING'
+            ```
+        """
+        if timeout is not None and timeout < 0:
+            raise ValueError("`timeout` cannot be negative.")
+        if poll_interval <= 0:
+            raise ValueError("`poll_interval` must be positive.")
+
+        deadline = None if timeout is None else time.monotonic() + timeout
+        while True:
+            runtime = self.get_space_runtime(repo_id, token=token)
+            if runtime.stage not in INTERMEDIATE_SPACE_STAGES:
+                return runtime
+            remaining = None if deadline is None else deadline - time.monotonic()
+            if remaining is not None and remaining <= 0:
+                raise TimeoutError(f"Space '{repo_id}' is still in stage '{runtime.stage}' after {timeout} seconds.")
+            time.sleep(poll_interval if remaining is None else min(poll_interval, remaining))
+
     @_deprecate_arguments(
         version="2.0",
         deprecated_args={"space_storage"},
@@ -14561,6 +14622,7 @@ delete_space_volumes = api.delete_space_volumes
 enable_space_dev_mode = api.enable_space_dev_mode
 disable_space_dev_mode = api.disable_space_dev_mode
 fetch_space_logs = api.fetch_space_logs
+wait_for_space = api.wait_for_space
 
 # Inference Endpoint API
 list_inference_endpoints = api.list_inference_endpoints

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -8531,7 +8531,7 @@ class HfApi:
         repo_id: str,
         *,
         timeout: float | None = None,
-        poll_interval: float = 5.0,
+        poll_interval: float = 1.0,
         token: bool | str | None = None,
     ) -> SpaceRuntime:
         """Wait until a Space reaches a terminal stage (not building/starting).
@@ -8547,7 +8547,7 @@ class HfApi:
             timeout (`float`, *optional*):
                 Maximum time to wait in seconds. If `None`, waits indefinitely.
             poll_interval (`float`, *optional*):
-                Seconds between status checks. Defaults to 5s.
+                Seconds between status checks. Defaults to 1s.
             token (`bool` or `str`, *optional*):
                 A valid user access token. Defaults to the locally saved token, which is the
                 recommended authentication method. Set to `False` to disable authentication.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2445,41 +2445,6 @@ class TestSpacesHardwareCommand:
         assert cpu_basic["cost/hour"] == "free"
 
 
-class TestSpacesWaitCommand:
-    def _runtime(self, stage: str) -> Mock:
-        runtime = Mock()
-        runtime.stage = stage
-        return runtime
-
-    def test_wait_running(self, runner: CliRunner) -> None:
-        with patch("huggingface_hub.cli.spaces.get_hf_api") as api_cls:
-            api = api_cls.return_value
-            api.wait_for_space.return_value = self._runtime("RUNNING")
-            result = runner.invoke(app, ["spaces", "wait", "user/my-space"])
-        assert result.exit_code == 0
-        api.wait_for_space.assert_called_once_with("user/my-space", timeout=None)
-
-    def test_wait_build_error(self, runner: CliRunner) -> None:
-        with patch("huggingface_hub.cli.spaces.get_hf_api") as api_cls:
-            api = api_cls.return_value
-            api.wait_for_space.return_value = self._runtime("BUILD_ERROR")
-            result = runner.invoke(app, ["spaces", "wait", "user/my-space"])
-        assert result.exit_code == 1
-        assert isinstance(result.exception, CLIError)
-        assert "BUILD_ERROR" in str(result.exception)
-        assert "Space ready" not in result.stdout
-
-    def test_wait_timeout(self, runner: CliRunner) -> None:
-        with patch("huggingface_hub.cli.spaces.get_hf_api") as api_cls:
-            api = api_cls.return_value
-            api.wait_for_space.side_effect = TimeoutError
-            result = runner.invoke(app, ["spaces", "wait", "user/my-space", "--timeout", "30s"])
-        assert result.exit_code == 1
-        assert isinstance(result.exception, CLIError)
-        assert "Timed out after 30s" in str(result.exception)
-        api.wait_for_space.assert_called_once_with("user/my-space", timeout=30)
-
-
 class TestInferenceEndpointsCommands:
     def test_list(self, runner: CliRunner) -> None:
         endpoint = Mock(raw={"name": "demo"})

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2467,6 +2467,7 @@ class TestSpacesWaitCommand:
         assert result.exit_code == 1
         assert isinstance(result.exception, CLIError)
         assert "BUILD_ERROR" in str(result.exception)
+        assert "Space ready" not in result.stdout
 
     def test_wait_timeout(self, runner: CliRunner) -> None:
         with patch("huggingface_hub.cli.spaces.get_hf_api") as api_cls:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2445,6 +2445,40 @@ class TestSpacesHardwareCommand:
         assert cpu_basic["cost/hour"] == "free"
 
 
+class TestSpacesWaitCommand:
+    def _runtime(self, stage: str) -> Mock:
+        runtime = Mock()
+        runtime.stage = stage
+        return runtime
+
+    def test_wait_running(self, runner: CliRunner) -> None:
+        with patch("huggingface_hub.cli.spaces.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            api.wait_for_space.return_value = self._runtime("RUNNING")
+            result = runner.invoke(app, ["spaces", "wait", "user/my-space"])
+        assert result.exit_code == 0
+        api.wait_for_space.assert_called_once_with("user/my-space", timeout=None)
+
+    def test_wait_build_error(self, runner: CliRunner) -> None:
+        with patch("huggingface_hub.cli.spaces.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            api.wait_for_space.return_value = self._runtime("BUILD_ERROR")
+            result = runner.invoke(app, ["spaces", "wait", "user/my-space"])
+        assert result.exit_code == 1
+        assert isinstance(result.exception, CLIError)
+        assert "BUILD_ERROR" in str(result.exception)
+
+    def test_wait_timeout(self, runner: CliRunner) -> None:
+        with patch("huggingface_hub.cli.spaces.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            api.wait_for_space.side_effect = TimeoutError
+            result = runner.invoke(app, ["spaces", "wait", "user/my-space", "--timeout", "30s"])
+        assert result.exit_code == 1
+        assert isinstance(result.exception, CLIError)
+        assert "Timed out after 30s" in str(result.exception)
+        api.wait_for_space.assert_called_once_with("user/my-space", timeout=30)
+
+
 class TestInferenceEndpointsCommands:
     def test_list(self, runner: CliRunner) -> None:
         endpoint = Mock(raw={"name": "demo"})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `wait_for_space` primitive for Spaces, mirroring what [#4345](https://github.com/huggingface/huggingface_hub/pull/4345) introduced for Jobs.

- **`HfApi.wait_for_space(repo_id, *, timeout=None, poll_interval=5.0, token=None)`** — polls `get_space_runtime()` until the Space leaves an intermediate stage (`BUILDING`, `RUNNING_BUILDING`, `APP_STARTING`, `RUNNING_APP_STARTING`). Returns the final `SpaceRuntime` in all cases (check `runtime.stage` to act on the outcome); only raises `TimeoutError` on timeout.

- **`hf spaces wait <space_id>`** — blocks until the Space settles, exits 0 if `RUNNING`, non-zero otherwise. Supports `--timeout 5m`-style durations.

- **Refactored `hf spaces ssh` and `hf spaces dev-mode`** to use `wait_for_space` instead of the old `_wait_for_dev_mode` CLI-only helper. The old helper (which polled `space_info()` with hardcoded 1s intervals and inline stage maps) is removed in favor of the reusable API method.

- New `INTERMEDIATE_SPACE_STAGES` and `TERMINAL_SPACE_STAGES` constants in `_space_api.py`.

### Design decisions

- **`get_space_runtime()` over `space_info()`** for polling: lighter endpoint, only the stage is needed during the wait loop. When `ssh`/`dev-mode` need the full `SpaceInfo` (for `subdomain`, `card_data`, etc.), they call `space_info()` once after the wait completes.

- **Return, don't raise, on error stages** (mirrors the Jobs pattern): a `BUILD_ERROR` Space is a normal inspectable outcome — the caller/CLI decides what to do with it.

- **No `target_stage` parameter**: the wait always waits for any non-intermediate stage. This keeps it simple and covers the 99% use case. Can be relaxed later if needed.

### Examples

Wait after restart:
```console
$ hf spaces restart username/my-space && hf spaces wait username/my-space
```

With timeout:
```console
$ hf spaces wait username/my-space --timeout 5m
```

Python API:
```python
>>> from huggingface_hub import restart_space, wait_for_space
>>> restart_space("username/my-space")
>>> runtime = wait_for_space("username/my-space")
>>> runtime.stage
'RUNNING'
```
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://huggingface.slack.com/archives/D0A9313SS3G/p1781773294599729?thread_ts=1781773294.599729&cid=D0A9313SS3G)

<div><a href="https://cursor.com/agents/bc-3947676b-1802-50ef-9c51-6b12432a7244"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3947676b-1802-50ef-9c51-6b12432a7244"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

