### PR TITLE
[Inference Providers] deepinfra: add automatic-speech-recognition support

### DIFF
--- a/src/huggingface_hub/inference/_providers/__init__.py
+++ b/src/huggingface_hub/inference/_providers/__init__.py
@@ -11,7 +11,11 @@ from .black_forest_labs import BlackForestLabsTextToImageTask
 from .cerebras import CerebrasConversationalTask
 from .clarifai import ClarifaiConversationalTask
 from .cohere import CohereConversationalTask
-from .deepinfra import DeepInfraConversationalTask, DeepInfraTextGenerationTask
+from .deepinfra import (
+    DeepInfraAutomaticSpeechRecognitionTask,
+    DeepInfraConversationalTask,
+    DeepInfraTextGenerationTask,
+)
 from .fal_ai import (
     FalAIAutomaticSpeechRecognitionTask,
     FalAIImageSegmentationTask,
@@ -118,6 +122,7 @@ PROVIDERS: dict[PROVIDER_T, dict[str, TaskProviderHelper]] = {
         "conversational": CohereConversationalTask(),
     },
     "deepinfra": {
+        "automatic-speech-recognition": DeepInfraAutomaticSpeechRecognitionTask(),
         "conversational": DeepInfraConversationalTask(),
         "text-generation": DeepInfraTextGenerationTask(),
     },

--- a/src/huggingface_hub/inference/_providers/deepinfra.py
+++ b/src/huggingface_hub/inference/_providers/deepinfra.py
@@ -89,10 +89,12 @@ class DeepInfraAutomaticSpeechRecognitionTask(TaskProviderHelper):
         # DeepInfra exposes an OpenAI-compatible transcription endpoint, which expects
         # the audio and parameters as a multipart/form-data body (not JSON).
         audio = _open_as_mime_bytes(inputs)
+        # `model` is applied last so caller-supplied parameters/extra_payload cannot
+        # override the mapped provider model (matches the other DeepInfra helpers).
         fields: dict[str, Any] = {
-            "model": provider_mapping_info.provider_id,
             **filter_none(parameters),
             **filter_none(extra_payload or {}),
+            "model": provider_mapping_info.provider_id,
         }
         body, content_type = _encode_multipart(audio, fields)
         return MimeBytes(body, mime_type=content_type)

--- a/src/huggingface_hub/inference/_providers/deepinfra.py
+++ b/src/huggingface_hub/inference/_providers/deepinfra.py
@@ -1,3 +1,4 @@
+import json
 import mimetypes
 import uuid
 from typing import Any
@@ -12,14 +13,20 @@ _PROVIDER = "deepinfra"
 _BASE_URL = "https://api.deepinfra.com"
 
 
-def _encode_multipart(audio: MimeBytes, fields: dict[str, Any]) -> tuple[bytes, str]:
-    """Encode an audio file plus text fields as a ``multipart/form-data`` body.
+def _form_field_value(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, bool):  # bool before int: bool is an int subclass
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return str(value)
+    return json.dumps(value)
 
-    Returns the raw body bytes and the matching ``Content-Type`` header value
-    (including the generated boundary).
-    """
+
+def _encode_multipart(audio: MimeBytes, fields: dict[str, Any]) -> tuple[bytes, str]:
     boundary = uuid.uuid4().hex
-    filename = "audio" + (mimetypes.guess_extension(audio.mime_type or "") or "")
+    # Fall back to .wav when the MIME type is unknown: transcription servers sniff the format from the filename.
+    filename = "audio" + (mimetypes.guess_extension(audio.mime_type or "") or ".wav")
     lines: list[bytes] = [
         f"--{boundary}".encode(),
         f'Content-Disposition: form-data; name="file"; filename="{filename}"'.encode(),
@@ -32,7 +39,7 @@ def _encode_multipart(audio: MimeBytes, fields: dict[str, Any]) -> tuple[bytes, 
             f"--{boundary}".encode(),
             f'Content-Disposition: form-data; name="{key}"'.encode(),
             b"",
-            str(value).encode(),
+            _form_field_value(value).encode(),
         ]
     lines += [f"--{boundary}--".encode(), b""]
     return b"\r\n".join(lines), f"multipart/form-data; boundary={boundary}"
@@ -86,11 +93,9 @@ class DeepInfraAutomaticSpeechRecognitionTask(TaskProviderHelper):
         provider_mapping_info: InferenceProviderMapping,
         extra_payload: dict | None,
     ) -> MimeBytes | None:
-        # DeepInfra exposes an OpenAI-compatible transcription endpoint, which expects
-        # the audio and parameters as a multipart/form-data body (not JSON).
+        # OpenAI-compatible transcription endpoint expects a multipart/form-data body, not JSON.
         audio = _open_as_mime_bytes(inputs)
-        # `model` is applied last so caller-supplied parameters/extra_payload cannot
-        # override the mapped provider model (matches the other DeepInfra helpers).
+        # `model` is applied last so parameters cannot override the mapped provider model.
         fields: dict[str, Any] = {
             **filter_none(parameters),
             **filter_none(extra_payload or {}),
@@ -100,7 +105,16 @@ class DeepInfraAutomaticSpeechRecognitionTask(TaskProviderHelper):
         return MimeBytes(body, mime_type=content_type)
 
     def get_response(self, response: bytes | dict, request_params: RequestParameters | None = None) -> Any:
-        text = _as_dict(response)["text"]
+        output = _as_dict(response)
+        text = output["text"]
         if not isinstance(text, str):
             raise ValueError(f"Unexpected output format from DeepInfra API. Expected string, got {type(text)}.")
-        return {"text": text}
+        result: dict[str, Any] = {"text": text}
+        segments = output.get("segments")
+        if isinstance(segments, list):
+            result["chunks"] = [
+                {"text": segment.get("text"), "timestamp": [segment.get("start"), segment.get("end")]}
+                for segment in segments
+                if isinstance(segment, dict)
+            ]
+        return result

--- a/src/huggingface_hub/inference/_providers/deepinfra.py
+++ b/src/huggingface_hub/inference/_providers/deepinfra.py
@@ -1,13 +1,41 @@
+import mimetypes
+import uuid
 from typing import Any
 
 from huggingface_hub.hf_api import InferenceProviderMapping
-from huggingface_hub.inference._common import RequestParameters, _as_dict
+from huggingface_hub.inference._common import MimeBytes, RequestParameters, _as_dict, _open_as_mime_bytes
 
-from ._common import BaseConversationalTask, BaseTextGenerationTask, filter_none
+from ._common import BaseConversationalTask, BaseTextGenerationTask, TaskProviderHelper, filter_none
 
 
 _PROVIDER = "deepinfra"
 _BASE_URL = "https://api.deepinfra.com"
+
+
+def _encode_multipart(audio: MimeBytes, fields: dict[str, Any]) -> tuple[bytes, str]:
+    """Encode an audio file plus text fields as a ``multipart/form-data`` body.
+
+    Returns the raw body bytes and the matching ``Content-Type`` header value
+    (including the generated boundary).
+    """
+    boundary = uuid.uuid4().hex
+    filename = "audio" + (mimetypes.guess_extension(audio.mime_type or "") or "")
+    lines: list[bytes] = [
+        f"--{boundary}".encode(),
+        f'Content-Disposition: form-data; name="file"; filename="{filename}"'.encode(),
+        f"Content-Type: {audio.mime_type or 'application/octet-stream'}".encode(),
+        b"",
+        bytes(audio),
+    ]
+    for key, value in fields.items():
+        lines += [
+            f"--{boundary}".encode(),
+            f'Content-Disposition: form-data; name="{key}"'.encode(),
+            b"",
+            str(value).encode(),
+        ]
+    lines += [f"--{boundary}--".encode(), b""]
+    return b"\r\n".join(lines), f"multipart/form-data; boundary={boundary}"
 
 
 class DeepInfraTextGenerationTask(BaseTextGenerationTask):
@@ -42,3 +70,35 @@ class DeepInfraConversationalTask(BaseConversationalTask):
 
     def _prepare_route(self, mapped_model: str, api_key: str) -> str:
         return "/v1/openai/chat/completions"
+
+
+class DeepInfraAutomaticSpeechRecognitionTask(TaskProviderHelper):
+    def __init__(self):
+        super().__init__(provider=_PROVIDER, base_url=_BASE_URL, task="automatic-speech-recognition")
+
+    def _prepare_route(self, mapped_model: str, api_key: str) -> str:
+        return "/v1/openai/audio/transcriptions"
+
+    def _prepare_payload_as_bytes(
+        self,
+        inputs: Any,
+        parameters: dict,
+        provider_mapping_info: InferenceProviderMapping,
+        extra_payload: dict | None,
+    ) -> MimeBytes | None:
+        # DeepInfra exposes an OpenAI-compatible transcription endpoint, which expects
+        # the audio and parameters as a multipart/form-data body (not JSON).
+        audio = _open_as_mime_bytes(inputs)
+        fields: dict[str, Any] = {
+            "model": provider_mapping_info.provider_id,
+            **filter_none(parameters),
+            **filter_none(extra_payload or {}),
+        }
+        body, content_type = _encode_multipart(audio, fields)
+        return MimeBytes(body, mime_type=content_type)
+
+    def get_response(self, response: bytes | dict, request_params: RequestParameters | None = None) -> Any:
+        text = _as_dict(response)["text"]
+        if not isinstance(text, str):
+            raise ValueError(f"Unexpected output format from DeepInfra API. Expected string, got {type(text)}.")
+        return {"text": text}

--- a/tests/test_inference_providers.py
+++ b/tests/test_inference_providers.py
@@ -19,6 +19,7 @@ from huggingface_hub.inference._providers._common import (
 from huggingface_hub.inference._providers.black_forest_labs import BlackForestLabsTextToImageTask
 from huggingface_hub.inference._providers.clarifai import ClarifaiConversationalTask
 from huggingface_hub.inference._providers.cohere import CohereConversationalTask
+from huggingface_hub.inference._providers.deepinfra import DeepInfraAutomaticSpeechRecognitionTask
 from huggingface_hub.inference._providers.fal_ai import (
     _POLLING_INTERVAL,
     FalAIAutomaticSpeechRecognitionTask,
@@ -383,6 +384,38 @@ class TestClarifaiProvider:
             "messages": [{"role": "user", "content": "Hello!"}],
             "model": "meta-llama/llama-3.1-8B-Instruct",
         }
+
+
+class TestDeepInfraProvider:
+    def test_automatic_speech_recognition_url(self):
+        helper = DeepInfraAutomaticSpeechRecognitionTask()
+        url = helper._prepare_url("hf_token", "nvidia/some-asr-model")
+        assert url == "https://router.huggingface.co/deepinfra/v1/openai/audio/transcriptions"
+
+    def test_automatic_speech_recognition_payload(self):
+        helper = DeepInfraAutomaticSpeechRecognitionTask()
+        mapping = InferenceProviderMapping(
+            provider="deepinfra",
+            hf_model_id="nvidia/some-asr-model",
+            providerId="nvidia/Some-Provider-ASR-Model",
+            task="automatic-speech-recognition",
+            status="live",
+        )
+        data = helper._prepare_payload_as_bytes(b"dummy_audio_data", {}, mapping, None)
+
+        # multipart/form-data body carrying the audio file and the provider model id
+        assert data.mime_type.startswith("multipart/form-data; boundary=")
+        assert b'name="file"' in data
+        assert b"dummy_audio_data" in data
+        assert b'name="model"' in data
+        assert b"nvidia/Some-Provider-ASR-Model" in data
+
+    def test_automatic_speech_recognition_response(self):
+        helper = DeepInfraAutomaticSpeechRecognitionTask()
+        assert helper.get_response({"text": "Hello world"}) == {"text": "Hello world"}
+
+        with pytest.raises(ValueError):
+            helper.get_response({"text": 123})
 
 
 class TestFalAIProvider:

--- a/tests/test_inference_providers.py
+++ b/tests/test_inference_providers.py
@@ -403,16 +403,51 @@ class TestDeepInfraProvider:
         )
         data = helper._prepare_payload_as_bytes(b"dummy_audio_data", {}, mapping, None)
 
-        # multipart/form-data body carrying the audio file and the provider model id
         assert data.mime_type.startswith("multipart/form-data; boundary=")
         assert b'name="file"' in data
         assert b"dummy_audio_data" in data
         assert b'name="model"' in data
         assert b"nvidia/Some-Provider-ASR-Model" in data
+        assert b'filename="audio.wav"' in data
+
+    def test_automatic_speech_recognition_model_not_overridable(self):
+        helper = DeepInfraAutomaticSpeechRecognitionTask()
+        mapping = InferenceProviderMapping(
+            provider="deepinfra",
+            hf_model_id="nvidia/some-asr-model",
+            providerId="nvidia/Some-Provider-ASR-Model",
+            task="automatic-speech-recognition",
+            status="live",
+        )
+        data = helper._prepare_payload_as_bytes(b"audio", {"model": "attacker/model"}, mapping, None)
+        assert b"nvidia/Some-Provider-ASR-Model" in data
+        assert b"attacker/model" not in data
+
+    def test_automatic_speech_recognition_non_string_fields(self):
+        helper = DeepInfraAutomaticSpeechRecognitionTask()
+        mapping = InferenceProviderMapping(
+            provider="deepinfra",
+            hf_model_id="nvidia/some-asr-model",
+            providerId="nvidia/Some-Provider-ASR-Model",
+            task="automatic-speech-recognition",
+            status="live",
+        )
+        data = helper._prepare_payload_as_bytes(
+            b"audio",
+            {"temperature": 0, "timestamp_granularities": ["word"]},
+            mapping,
+            {"stream": True},
+        )
+        assert b'name="stream"\r\n\r\ntrue' in data
+        assert b'["word"]' in data
+        assert b"['word']" not in data
 
     def test_automatic_speech_recognition_response(self):
         helper = DeepInfraAutomaticSpeechRecognitionTask()
         assert helper.get_response({"text": "Hello world"}) == {"text": "Hello world"}
+        assert helper.get_response(
+            {"text": "Hello world", "segments": [{"text": "Hello world", "start": 0.0, "end": 1.5}]}
+        ) == {"text": "Hello world", "chunks": [{"text": "Hello world", "timestamp": [0.0, 1.5]}]}
 
         with pytest.raises(ValueError):
             helper.get_response({"text": 123})


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive provider task with tests; no changes to auth or existing DeepInfra chat/text paths.
> 
> **Overview**
> Adds **automatic-speech-recognition** for the **deepinfra** inference provider so Hub-routed ASR calls can hit DeepInfra’s OpenAI-compatible transcription API.
> 
> A new `DeepInfraAutomaticSpeechRecognitionTask` posts to `/v1/openai/audio/transcriptions` with a **multipart/form-data** body (audio `file` plus form fields for parameters). Helpers encode non-string parameters (booleans, JSON arrays) correctly, and **`model` is always taken from the provider mapping** so callers cannot override it via parameters. Responses are normalized to `{"text": ...}` and optional `chunks` from API `segments`.
> 
> The provider registry wires the task under `deepinfra` → `automatic-speech-recognition`, with unit tests covering routing URL, payload shape, model pinning, and response parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bde5cea18fb8d2ab649f51f2edcddf7d24e851f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->