### PR TITLE
Hot-fix: Fix circular import on `from huggingface_hub import login` (#4384)

### DIFF
--- a/src/huggingface_hub/_login.py
+++ b/src/huggingface_hub/_login.py
@@ -23,7 +23,6 @@ from getpass import getpass
 from pathlib import Path
 
 from . import constants
-from ._oauth_device import OAuthTokenResponse, poll_device_token, request_device_code
 from .errors import DeviceCodeError
 from .utils import (
     ANSI,
@@ -49,6 +48,7 @@ from .utils._auth import (
     _write_secret,
     get_stored_tokens,
 )
+from .utils._oauth_device import OAuthTokenResponse, poll_device_token, request_device_code
 
 
 logger = logging.get_logger(__name__)

--- a/src/huggingface_hub/cli/auth.py
+++ b/src/huggingface_hub/cli/auth.py
@@ -41,9 +41,9 @@ from huggingface_hub.constants import ENDPOINT
 from huggingface_hub.hf_api import whoami
 
 from .._login import _save_oauth_token, auth_list, auth_switch, login, logout
-from .._oauth_device import poll_device_token, request_device_code
 from ..errors import CLIError
 from ..utils import get_stored_tokens, get_token, logging, select_choice
+from ..utils._oauth_device import poll_device_token, request_device_code
 from ._cli_utils import TokenOpt, typer_factory
 from ._output import OutputFormat, out
 

--- a/src/huggingface_hub/utils/_auth.py
+++ b/src/huggingface_hub/utils/_auth.py
@@ -24,9 +24,9 @@ from threading import Lock
 from typing import TypedDict
 
 from .. import constants
-from .._oauth_device import refresh_access_token
 from ..errors import DeviceCodeError, OAuthErrorCode, OIDCError
 from ._fixes import WeakFileLock
+from ._oauth_device import refresh_access_token
 from ._runtime import is_colab_enterprise, is_google_colab
 
 

--- a/src/huggingface_hub/utils/_oauth_device.py
+++ b/src/huggingface_hub/utils/_oauth_device.py
@@ -28,9 +28,9 @@ from typing import TypedDict, cast
 
 import httpx
 
-from . import constants
-from .errors import DeviceCodeError, OAuthErrorCode
-from .utils._http import get_session, hf_raise_for_status
+from .. import constants
+from ..errors import DeviceCodeError, OAuthErrorCode
+from ._http import get_session, hf_raise_for_status
 
 
 _DEVICE_CODE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -17,7 +17,6 @@ from huggingface_hub._login import (
     auth_switch,
     logout,
 )
-from huggingface_hub._oauth_device import poll_device_token, refresh_access_token, request_device_code
 from huggingface_hub.errors import DeviceCodeError
 from huggingface_hub.utils._auth import (
     _get_token_by_name,
@@ -27,6 +26,7 @@ from huggingface_hub.utils._auth import (
     get_stored_tokens,
     get_token,
 )
+from huggingface_hub.utils._oauth_device import poll_device_token, refresh_access_token, request_device_code
 
 from .testing_constants import ENDPOINT_STAGING, OTHER_TOKEN, TOKEN
 
@@ -238,7 +238,7 @@ class TestRequestDeviceCode:
                 "verification_uri": "https://huggingface.co/oauth/device",
             }
         )
-        with patch("huggingface_hub._oauth_device.get_session") as mock_session:
+        with patch("huggingface_hub.utils._oauth_device.get_session") as mock_session:
             mock_session.return_value.post.return_value = response
             result = request_device_code()
         assert result["user_code"] == "ABCD-EFGH"
@@ -251,7 +251,7 @@ class TestRequestDeviceCode:
         response = httpx.Response(
             400, text="bad request", request=httpx.Request("POST", "https://hub.test/oauth/device")
         )
-        with patch("huggingface_hub._oauth_device.get_session") as mock_session:
+        with patch("huggingface_hub.utils._oauth_device.get_session") as mock_session:
             mock_session.return_value.post.return_value = response
             with pytest.raises(DeviceCodeError, match="Failed to request device code"):
                 request_device_code()
@@ -274,8 +274,8 @@ class TestPollDeviceToken:
         """The full token response is returned after an authorization_pending response."""
         on_pending = MagicMock()
         with (
-            patch("huggingface_hub._oauth_device.get_session") as mock_session,
-            patch("huggingface_hub._oauth_device.time.sleep"),
+            patch("huggingface_hub.utils._oauth_device.get_session") as mock_session,
+            patch("huggingface_hub.utils._oauth_device.time.sleep"),
         ):
             mock_session.return_value.post.side_effect = [
                 _mock_response({"error": "authorization_pending"}),
@@ -287,8 +287,8 @@ class TestPollDeviceToken:
 
     def test_slow_down_increases_interval(self):
         with (
-            patch("huggingface_hub._oauth_device.get_session") as mock_session,
-            patch("huggingface_hub._oauth_device.time.sleep") as mock_sleep,
+            patch("huggingface_hub.utils._oauth_device.get_session") as mock_session,
+            patch("huggingface_hub.utils._oauth_device.time.sleep") as mock_sleep,
         ):
             mock_session.return_value.post.side_effect = [
                 _mock_response({"error": "slow_down"}),
@@ -304,8 +304,8 @@ class TestPollDeviceToken:
         non_json.status_code = 429
         non_json.json.side_effect = ValueError("not json")
         with (
-            patch("huggingface_hub._oauth_device.get_session") as mock_session,
-            patch("huggingface_hub._oauth_device.time.sleep"),
+            patch("huggingface_hub.utils._oauth_device.get_session") as mock_session,
+            patch("huggingface_hub.utils._oauth_device.time.sleep"),
         ):
             mock_session.return_value.post.side_effect = [
                 httpx.ConnectError("network blip"),
@@ -323,8 +323,8 @@ class TestPollDeviceToken:
     )
     def test_oauth_errors(self, error, match):
         with (
-            patch("huggingface_hub._oauth_device.get_session") as mock_session,
-            patch("huggingface_hub._oauth_device.time.sleep"),
+            patch("huggingface_hub.utils._oauth_device.get_session") as mock_session,
+            patch("huggingface_hub.utils._oauth_device.time.sleep"),
         ):
             mock_session.return_value.post.return_value = _mock_response({"error": error})
             with pytest.raises(DeviceCodeError, match=match) as exc_info:
@@ -335,13 +335,13 @@ class TestPollDeviceToken:
 class TestRefreshAccessToken:
     def test_success(self):
         payload = {"access_token": "hf_oauth_new", "refresh_token": "rt_new", "expires_in": 2592000}
-        with patch("huggingface_hub._oauth_device.get_session") as mock_session:
+        with patch("huggingface_hub.utils._oauth_device.get_session") as mock_session:
             mock_session.return_value.post.return_value = _mock_response(payload)
             assert refresh_access_token("rt_old") == payload
 
     def test_invalid_grant(self):
         response = _mock_response({"error": "invalid_grant", "error_description": "revoked"}, status_code=400)
-        with patch("huggingface_hub._oauth_device.get_session") as mock_session:
+        with patch("huggingface_hub.utils._oauth_device.get_session") as mock_session:
             mock_session.return_value.post.return_value = response
             with pytest.raises(DeviceCodeError, match="Failed to refresh") as exc_info:
                 refresh_access_token("rt_old")


### PR DESCRIPTION
Fixes #4384.

## Summary

- `from huggingface_hub import login` raised `ImportError: cannot import name 'refresh_access_token' from partially initialized module 'huggingface_hub._oauth_device' (most likely due to a circular import)` on a fresh interpreter (regression in 1.20.0, introduced by the browser-based OAuth login in #4354).
- Root cause is a layering inversion: `_oauth_device` lived at the top level but imported from `utils._http`, while `utils._auth` imported `refresh_access_token` back from `_oauth_device`. So `import login` → `_oauth_device` → `utils._http` → (runs `utils/__init__`) → `utils._auth` → `_oauth_device` (still half-initialized) → boom.
- Fix: **move `_oauth_device.py` into the `utils` layer** (`utils/_oauth_device.py`). It only depends on `constants`, `errors`, and `utils._http` — all same-or-lower layer — so it belongs there, and now every dependency points downward. No lazy imports.
  - `utils._auth` → `from ._oauth_device import refresh_access_token` (sideways, no cycle)
  - `_login.py` / `cli/auth.py` → `from .utils._oauth_device import ...` (downward)

## Reproduction (before)

```
$ python -c 'from huggingface_hub import login'
ImportError: cannot import name 'refresh_access_token' from partially initialized module
'huggingface_hub._oauth_device' (most likely due to a circular import)
```

## After

```
$ python -c 'from huggingface_hub import login; print("ok")'
ok
```

## Why no existing test caught this

It's an import-ordering bug, and in-process unit tests are structurally blind to that class of bug.

The cycle only opens when `_login`/`_oauth_device` is the *first* thing to pull in `huggingface_hub.utils` (cold). If `utils` is imported first through any normal path — which `tests/conftest.py` does at collection time (`from huggingface_hub.utils import ...`) — its `__init__` runs to completion and pulls `_oauth_device` in as a harmless leaf, so the half-initialized window never exists.

Because `sys.modules` is per-process and shared across the whole pytest session, that warm-up happens before any test module is imported. The buggy `tests/test_auth.py` passes all 39 tests against the buggy source — the same code that crashes on `from huggingface_hub import login`. Reproducing it requires a fresh interpreter (e.g. `python -c "from huggingface_hub import login"`), which an in-process test can't recreate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)