### PR TITLE
[CI] Catch circular imports in the check-imports job

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Check imports
         run: |
           source .venv/bin/activate
-          python -c "from huggingface_hub import *"
+          python utils/check_imports.py
 
   build-ubuntu:
     runs-on:

--- a/utils/check_imports.py
+++ b/utils/check_imports.py
@@ -1,0 +1,67 @@
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Verify the public API imports cleanly, including from a cold interpreter.
+
+Run by the `check-imports` CI job (which installs base dependencies only) to ensure:
+
+1. every public name is importable — catches a newly added top-level import of an optional dependency;
+2. each lazily-loaded submodule imports on its own in a *fresh* interpreter.
+
+(2) matters because `from huggingface_hub import *` warms up `sys.modules`, which can mask circular
+imports that only surface on a cold-start import order (see
+https://github.com/huggingface/huggingface_hub/issues/4384). Importing one representative name per
+submodule in a separate process recreates that cold start — driven from `_SUBMOD_ATTRS`, so no module
+list has to be maintained by hand.
+"""
+
+import subprocess
+import sys
+
+import huggingface_hub
+
+
+def _import(statement: str) -> tuple[bool, str]:
+    """Run `statement` in a fresh interpreter; return (succeeded, last stderr line)."""
+    result = subprocess.run([sys.executable, "-c", statement], capture_output=True, text=True)
+    if result.returncode == 0:
+        return True, ""
+    stderr = result.stderr.strip()
+    return False, stderr.splitlines()[-1] if stderr else f"exited with code {result.returncode}"
+
+
+def main() -> int:
+    # `import *` resolves every public name in one (warm) process. It cannot catch import-ordering /
+    # circular-import bugs though, because it warms up `sys.modules` first: so additionally import
+    # each lazily-loaded submodule on its own, in a fresh interpreter, where the cold path is exposed.
+    statements = ["from huggingface_hub import *"]
+    statements += [f"import huggingface_hub.{submodule}" for submodule in huggingface_hub._SUBMOD_ATTRS]
+
+    failures = []
+    for statement in statements:
+        ok, error = _import(statement)
+        print(f"  {'ok  ' if ok else 'FAIL'}  {statement}")
+        if not ok:
+            failures.append((statement, error))
+
+    if failures:
+        print("\nImport failures (circular import or missing dependency):", file=sys.stderr)
+        for statement, error in failures:
+            print(f"  - {statement}\n      {error}", file=sys.stderr)
+        return 1
+    print(f"\nAll {len(statements)} imports succeed from a cold interpreter.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Follow-up to #4385 (which fixed the circular import reported in #4384). The `check-imports` CI job should have caught that regression before release — but it didn't. This hardens it.

**Why it slipped through:** the job only ran `python -c "from huggingface_hub import *"`. With lazy loading, `import *` walks `__all__` and warms up `sys.modules` — something before `login` pulls in `huggingface_hub.utils` via a non-circular path, so by the time `_login`/`_oauth_device` load, `utils` is already cached and the cold-start cycle never opens. The bug is only reachable from a *fresh* interpreter where a submodule is the first thing to pull in `utils`.

**The fix:** add `utils/check_imports.py`, run by the job. It does two complementary things:
- `from huggingface_hub import *` — every public name resolves under base deps only (the original missing-dependency check, unchanged).
- `import huggingface_hub.<submodule>` for each lazily-loaded submodule, **each in its own fresh interpreter** — recreates the cold-start order, which is the only thing that exposes circular imports.

The submodule list is introspected from `_SUBMOD_ATTRS` (the lazy loader's own map, 30 entries), so it stays in sync with the public API automatically — no hand-maintained list.

## Verification

Ran both checks against the exact pre-fix buggy tree (`b4aa18ab`, before #4385):

| Check | Exit | Outcome |
|---|---|---|
| `from huggingface_hub import *` (old) | `0` | green — misses the bug (how #4384 shipped) |
| `python utils/check_imports.py` (new) | `1` | catches it |

The new check fails precisely on:

```
ok    from huggingface_hub import *
FAIL  import huggingface_hub._login
    ImportError: cannot import name 'refresh_access_token' from partially initialized
    module 'huggingface_hub._oauth_device' (most likely due to a circular import)
```

On current `main` (post-fix) all 31 imports pass and the job is green.

## Note

I kept `from huggingface_hub import *` even though the per-submodule imports cover the modules — it uniquely validates that all ~496 public *names* resolve under base-deps-only, which is the original purpose of the job (#4250).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change (workflow + new utility script); no runtime library behavior or security-sensitive paths are modified.
> 
> **Overview**
> **Hardens the `check-imports` CI job** so circular imports that only show up on a cold interpreter are caught before release.
> 
> The workflow no longer runs a one-liner `from huggingface_hub import *`. It runs **`utils/check_imports.py`**, which keeps that star-import (still validates ~496 public names under base deps only) and **adds per-submodule checks**: each key in `huggingface_hub._SUBMOD_ATTRS` is imported via `import huggingface_hub.<submodule>` in its **own fresh Python process**, so lazy-loading order bugs are not masked by a warmed `sys.modules`.
> 
> The submodule list is derived from `_SUBMOD_ATTRS`, so it stays aligned with the lazy loader without a hand-maintained module list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 181ff8afd38c6d62d2a905c158b4489f59944715. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->