### PR TITLE
[Tests] Fix kernel tests for moved file on production

### DIFF
--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -26,7 +26,7 @@ from .testing_utils import repo_name
 
 
 KERNEL_TEST_REPO_ID = "kernels-community/relu"
-KERNEL_TEST_REPO_FILE = "build/torch-ext/torch_binding.cpp"
+KERNEL_TEST_REPO_FILE = "benchmarks/benchmark.py"
 
 
 def kernel_name() -> str:
@@ -139,9 +139,9 @@ def test_download_file_from_revision(api: HfApi, tmp_path) -> None:
 def test_snapshot_download_allow_patterns(api: HfApi, tmp_path) -> None:
     """Test partial downloading from kernel repo works."""
     path = api.snapshot_download(
-        KERNEL_TEST_REPO_ID, repo_type="kernel", cache_dir=tmp_path, allow_patterns="build/torch-ext/*"
+        KERNEL_TEST_REPO_ID, repo_type="kernel", cache_dir=tmp_path, allow_patterns="benchmarks/*"
     )
     assert os.path.isdir(path)
     assert "kernels--kernels-community--relu" in path  # kernel path
     assert "snapshots" in path
-    assert os.path.isfile(os.path.join(path, "build", "torch-ext", "torch_binding.cpp"))
+    assert os.path.isfile(os.path.join(path, "benchmarks", "benchmark.py"))


### PR DESCRIPTION
**TL;DR:**

currently getting this in tests, let's fix it
```
=========================== short test summary info ============================
FAILED ../tests/test_kernels.py::test_list_repo_files - AssertionError: assert 'build/torch-ext/torch_binding.cpp' in ['.gitattributes', 'README.md', 'benchmarks/benchmark.py', 'build/torch210-cpu-aarch64-darwin/__init__.py', 'build/torch210-cpu-aarch64-darwin/_ops.py', 'build/torch210-cpu-aarch64-darwin/_relu_cpu_d597fb7.abi3.so', ...]
FAILED ../tests/test_kernels.py::test_list_repo_tree - assert False
 +  where False = any(<generator object test_list_repo_tree.<locals>.<genexpr> at 0x7faf04386b20>)
FAILED ../tests/test_kernels.py::test_download_existing_file - huggingface_hub.errors.RemoteEntryNotFoundError: 404 Client Error. (Request ID: Root=1-6a350b27-1650acdb480ac08d1f20a45f;739bf9f9-88ec-4d76-aa31-459b71de275d)

Entry Not Found for url: https://huggingface.co/kernels/kernels-community/relu/resolve/main/build/torch-ext/torch_binding.cpp.
FAILED ../tests/test_kernels.py::test_redownload_file_offline_mode - huggingface_hub.errors.RemoteEntryNotFoundError: 404 Client Error. (Request ID: Root=1-6a350b27-46d8b4d35fa8141d33ea32bb;6a8794c7-9afd-4ad6-88c7-9898c94679ea)

Entry Not Found for url: https://huggingface.co/kernels/kernels-community/relu/resolve/main/build/torch-ext/torch_binding.cpp.
FAILED ../tests/test_kernels.py::test_download_file_from_revision - huggingface_hub.errors.RemoteEntryNotFoundError: 404 Client Error. (Request ID: Root=1-6a350b28-0b9e6f597d3c0bd604788edf;07e621d6-c710-4cf6-b311-76b6013fc31c)

Entry Not Found for url: https://huggingface.co/kernels/kernels-community/relu/resolve/main/build/torch-ext/torch_binding.cpp.
FAILED ../tests/test_kernels.py::test_snapshot_download_allow_patterns - AssertionError: assert False
 +  where False = <function isdir at 0x7faf263825f0>('/tmp/pytest-of-runner/pytest-0/popen-gw3/test_snapshot_download_allow_p0/kernels--kernels-community--relu/snapshots/0fcbe0f180f60c95f53c38a1cdc4a898b18e324c')
 +    where <function isdir at 0x7faf263825f0> = <module 'posixpath' from '/home/runner/_work/_tool/Python/3.10.20/x64/lib/python3.10/posixpath.py'>.isdir
 +      where <module 'posixpath' from '/home/runner/_work/_tool/Python/3.10.20/x64/lib/python3.10/posixpath.py'> = os.path
= 6 failed, 1797 passed, 74 skipped, 116 warnings, 57 subtests passed in 709.57s (0:11:49) =
```


## Summary

The `kernels-community/relu` repo was restructured on production and `build/torch-ext/torch_binding.cpp` is no longer served via the **kernel** repo type:

- The `/api/kernels/.../tree` endpoint now filters out the `build/torch-ext/` source files (only compiled artifacts under `build/torch<ver>-...` are listed) — so `list_repo_files`/`list_repo_tree` no longer return it.
- `/kernels/.../resolve/.../build/torch-ext/torch_binding.cpp` returns `404`.

This broke 6 tests in `tests/test_kernels.py` that referenced this fixture file (list, tree, download, offline re-download, revision download, snapshot allow-patterns).

## Fix

Switch the fixture file to `benchmarks/benchmark.py` — a stable subfolder file that:
- is present on both `main` and `v1`,
- is listed by the kernel tree endpoint (`/api/kernels/.../tree`),
- downloads fine via `/kernels/.../resolve/...` on both revisions.

The `allow_patterns` in `test_snapshot_download_allow_patterns` is updated from `build/torch-ext/*` to `benchmarks/*`.

## Verification

```
$ pytest tests/test_kernels.py -v
======================= 10 passed in 3.91s =======================
```

All 6 previously-failing tests now pass against production.

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only constant and assertion updates with no library or runtime behavior changes.
> 
> **Overview**
> Updates kernel integration tests to use **`benchmarks/benchmark.py`** instead of **`build/torch-ext/torch_binding.cpp`** on the production `kernels-community/relu` fixture, after that C++ path stopped appearing in kernel tree/list APIs and began returning 404 on resolve.
> 
> **`test_snapshot_download_allow_patterns`** now uses `allow_patterns="benchmarks/*"` and asserts the downloaded snapshot contains `benchmarks/benchmark.py`. All other tests keep using the shared `KERNEL_TEST_REPO_FILE` constant, so list/tree/download/offline/revision coverage is unchanged—only the fixture path aligns with what production still serves for the kernel repo type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57b99e36d5c683f3d493c8170a8de6e7fda92c0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->