### PR TITLE
[Serialization] Exclude skipped string tensors from single-shard index

### DIFF
--- a/src/huggingface_hub/serialization/_base.py
+++ b/src/huggingface_hub/serialization/_base.py
@@ -152,10 +152,14 @@ def split_state_dict_into_shards_factory(
     # If we only have one shard, we return it => no need to build the index
     if nb_shards == 1:
         filename = filename_pattern.format(suffix="")
+        # Use the keys from the shard itself rather than `state_dict` directly, so that tensors
+        # skipped above (e.g. string tensors from bnb serialization) are excluded from the index,
+        # consistently with the multi-shard path below.
+        keys = list(shard_list[0].keys())
         return StateDictSplit(
             metadata={"total_size": total_size},
-            filename_to_tensors={filename: list(state_dict.keys())},
-            tensor_to_filename={key: filename for key in state_dict.keys()},
+            filename_to_tensors={filename: keys},
+            tensor_to_filename={key: filename for key in keys},
         )
 
     # Now that each tensor is assigned to a shard, let's assign a filename to each shard

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -243,6 +243,28 @@ def test_tensor_same_storage():
     assert state_dict_split.metadata == {"total_size": 3}  # count them once
 
 
+def test_single_shard_skips_string_tensors():
+    # String values can appear in a state dict when bnb serialization is used (see
+    # https://github.com/huggingface/transformers/pull/24416). They are skipped when building
+    # shards, so they must also be absent from the single-shard index, consistently with the
+    # multi-shard path.
+    state_dict_split = split_state_dict_into_shards_factory(
+        {
+            "layer_1": [6],
+            "bnb_string": "quantization_metadata",  # skipped, must not appear in the index
+            "layer_2": [10],
+        },
+        get_storage_id=_dummy_get_storage_id,
+        get_storage_size=_dummy_get_storage_size,
+        max_shard_size=100,  # large shard size => only one shard
+        filename_pattern="file{suffix}.dummy",
+    )
+    assert not state_dict_split.is_sharded
+    assert state_dict_split.filename_to_tensors == {"file.dummy": ["layer_1", "layer_2"]}
+    assert state_dict_split.tensor_to_filename == {"layer_1": "file.dummy", "layer_2": "file.dummy"}
+    assert state_dict_split.metadata == {"total_size": 16}
+
+
 @requires("torch")
 def test_get_torch_storage_size():
     import torch  # type: ignore[import]


### PR DESCRIPTION
## Summary

- `split_state_dict_into_shards_factory` skips string tensors while building shards (these show up with bnb serialization, see huggingface/transformers#24416). In the multi-shard path they're correctly absent from the returned index.
- The single-shard path (`nb_shards == 1`) built the index from `state_dict.keys()` directly, so it re-included those skipped string tensors in both `filename_to_tensors` and `tensor_to_filename` — even though `total_size` excluded them.
- Result: the single- vs multi-shard index was inconsistent. With a single shard, the weight map claimed a string tensor lived in the safetensors file although it was never written.
- Fix: build the single-shard index from the shard's own keys (`shard_list[0].keys()`), which mirrors the multi-shard path and naturally drops skipped tensors. Minimal change, no behavior change for normal state dicts.

### Reproduction (before the fix)

```python
from huggingface_hub.serialization._base import split_state_dict_into_shards_factory

state_dict = {"real_layer": [10], "bnb_string_param": "quantized_string"}
split = split_state_dict_into_shards_factory(
    state_dict, get_storage_size=sum, max_shard_size=1000, filename_pattern="model{suffix}.safetensors"
)
print(split.filename_to_tensors)  # {'model.safetensors': ['real_layer', 'bnb_string_param']}  <- string leaked in
print(split.tensor_to_filename)   # {'real_layer': ..., 'bnb_string_param': ...}                <- string leaked in
print(split.metadata)             # {'total_size': 10}                                           <- but size excludes it
```

For the same input split into 2+ shards, `bnb_string_param` is (correctly) never listed.

### After the fix

```python
print(split.filename_to_tensors)  # {'model.safetensors': ['real_layer']}
print(split.tensor_to_filename)   # {'real_layer': 'model.safetensors'}
print(split.metadata)             # {'total_size': 10}
```

Now the single-shard index matches the multi-shard behavior.

### Tests

Added `test_single_shard_skips_string_tensors` in `tests/test_serialization.py`. It fails on `main` (the string tensor leaks into `filename_to_tensors`/`tensor_to_filename`) and passes with this change. Existing serialization tests still pass:

```
$ pytest tests/test_serialization.py -q
18 passed, 29 skipped
```

(`ruff check` and `ruff format --check` are clean on the changed files.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized index-building fix with a regression test; normal tensor-only state dicts are unchanged.
> 
> **Overview**
> Fixes an inconsistency in **`split_state_dict_into_shards_factory`** when sharding produces a **single** file: the returned `filename_to_tensors` / `tensor_to_filename` index was built from the full `state_dict`, so **string entries** (skipped during shard building, e.g. bitsandbytes metadata) could appear in the weight map even though they are not written and `total_size` already ignored them. Multi-shard indexing did not have this leak.
> 
> The single-shard path now indexes **`shard_list[0].keys()`**, aligned with the multi-shard loop. Adds **`test_single_shard_skips_string_tensors`** to lock in the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a830f251f063c56d36f64c881cc50938909098b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->