### PR TITLE
[Jobs] Add stage/label filtering to list_jobs API and CLI

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -2006,23 +2006,27 @@ Add labels to a Job using `-l` or `--label`. Labels are a key=value pairs that a
 
 The my-label key doesn't specify a value so its value defaults to an empty string ("").
 
-Use `-f` or `--filter` in `hf jobs ps` to filter Jobs that match certain labels:
+Use `-f` or `--filter` in `hf jobs ps` to filter Jobs server-side. Two keys are supported, `status=<stage>` and `label=<key>=<value>`, and both are repeatable. A Job must match every filter to be listed:
 
 ```bash
-# Show fine-tuning Jobs
->>> hf jobs ps -a --filter label=fine-tuning
-
-# Show Jobs that don't have the "prod" label and have a label that starts with "data-"
->>> hf jobs ps -a --filter label!=prod --filter "label=data-*"
-
-# Show Jobs based on key=value labels
->>> hf jobs ps -a --filter label=model=Qwen3-06B --filter label=dataset!=Capybara
-
-# Filter by status
+# Show completed Jobs
 >>> hf jobs ps -a --filter status=completed
+
+# Show Jobs with the `model=Qwen3-06B` label
+>>> hf jobs ps -a --filter label=model=Qwen3-06B
+
+# Combine filters: running Jobs labelled both `env=prod` and `team=ml`
+>>> hf jobs ps --filter status=running --filter label=env=prod --filter label=team=ml
 ```
 
-You can filter by any of `id`, `image`, `command`, `status` and `label`, and values support glob patterns (e.g. `data-*`) and negation (`key!=value`). Exact status and `key=value` label filters are pushed to the server so they apply to all your Jobs, not just the most recent ones; glob and negation filters are applied client-side.
+<Tip warning={true}>
+
+Filtering is performed server-side and matching is exact: glob patterns (`label=data-*`) and negation (`label!=prod`, `status!=...`) are no longer supported, and filtering by `id`, `image` or `command` was removed. Only `status` and `label` filters are accepted.
+
+</Tip>
+
+> [!TIP]
+> Server-side filtering requires a recent enough Hub. Against an older Hub that doesn't support it, the filters are ignored and `hf jobs ps` falls back to listing your most recent Jobs.
 
 ### SSH into a Job
 

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -2006,27 +2006,27 @@ Add labels to a Job using `-l` or `--label`. Labels are a key=value pairs that a
 
 The my-label key doesn't specify a value so its value defaults to an empty string ("").
 
-Use `-f` or `--filter` in `hf jobs ps` to filter Jobs server-side. Two keys are supported, `status=<stage>` and `label=<key>=<value>`, and both are repeatable. A Job must match every filter to be listed:
+Use `--status` and `--label` in `hf jobs ps` to filter Jobs server-side. `--status` takes one or more statuses (comma-separated or repeated) and `--label` takes a `key=value` pair (repeat it to require several). A Job must match every filter to be listed:
 
 ```bash
 # Show completed Jobs
->>> hf jobs ps -a --filter status=completed
+>>> hf jobs ps -a --status completed
+
+# Show running or scheduling Jobs
+>>> hf jobs ps --status running,scheduling
 
 # Show Jobs with the `model=Qwen3-06B` label
->>> hf jobs ps -a --filter label=model=Qwen3-06B
+>>> hf jobs ps -a --label model=Qwen3-06B
 
 # Combine filters: running Jobs labelled both `env=prod` and `team=ml`
->>> hf jobs ps --filter status=running --filter label=env=prod --filter label=team=ml
+>>> hf jobs ps --status running --label env=prod --label team=ml
 ```
 
 <Tip warning={true}>
 
-Filtering is performed server-side and matching is exact: glob patterns (`label=data-*`) and negation (`label!=prod`, `status!=...`) are no longer supported, and filtering by `id`, `image` or `command` was removed. Only `status` and `label` filters are accepted.
+`-f`/`--filter` is deprecated in favor of `--status` and `--label`. Matching is exact: glob patterns (`data-*`) and negation (`key!=value`) are not supported, and filtering by `id`, `image` or `command` is not available.
 
 </Tip>
-
-> [!TIP]
-> Server-side filtering requires a recent enough Hub. Against an older Hub that doesn't support it, the filters are ignored and `hf jobs ps` falls back to listing your most recent Jobs.
 
 ### SSH into a Job
 

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -2017,7 +2017,12 @@ Use `-f` or `--filter` in `hf jobs ps` to filter Jobs that match certain labels:
 
 # Show Jobs based on key=value labels
 >>> hf jobs ps -a --filter label=model=Qwen3-06B --filter label=dataset!=Capybara
+
+# Filter by status
+>>> hf jobs ps -a --filter status=completed
 ```
+
+You can filter by any of `id`, `image`, `command`, `status` and `label`, and values support glob patterns (e.g. `data-*`) and negation (`key!=value`). Exact status and `key=value` label filters are pushed to the server so they apply to all your Jobs, not just the most recent ones; glob and negation filters are applied client-side.
 
 ### SSH into a Job
 

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -2006,7 +2006,7 @@ Add labels to a Job using `-l` or `--label`. Labels are a key=value pairs that a
 
 The my-label key doesn't specify a value so its value defaults to an empty string ("").
 
-Use `--status` and `--label` in `hf jobs ps` to filter Jobs server-side. `--status` takes one or more statuses (comma-separated or repeated) and `--label` takes a `key=value` pair (repeat it to require several). A Job must match every filter to be listed:
+Use `--status` and `--label` in `hf jobs ps` to filter Jobs. `--status` takes one or more statuses and `--label` takes `key=value` pairs. A Job must match every filter to be listed:
 
 ```bash
 # Show completed Jobs

--- a/docs/source/en/guides/jobs.md
+++ b/docs/source/en/guides/jobs.md
@@ -115,7 +115,7 @@ Jobs run in the background. The next section guides you through [`inspect_job`] 
 >>> jobs[0]
 JobInfo(id='687f911eaea852de79c4a50a', created_at=datetime.datetime(2025, 7, 22, 13, 24, 46, 909000, tzinfo=datetime.timezone.utc), docker_image='python:3.12', space_id=None, command=['python', '-c', "print('Hello from the cloud!')"], arguments=[], environment={}, secrets={}, flavor='cpu-basic', status=JobStatus(stage='COMPLETED', message=None), owner=JobOwner(id='5e9ecfc04957053f60648a3e', name='lhoestq'), endpoint='https://huggingface.co', url='https://huggingface.co/jobs/lhoestq/687f911eaea852de79c4a50a')
 
-# List your running jobs (filtering happens server-side)
+# List your running jobs
 >>> running_jobs = list_jobs(status="RUNNING")
 
 # Filter by one or more statuses and/or labels

--- a/docs/source/en/guides/jobs.md
+++ b/docs/source/en/guides/jobs.md
@@ -116,10 +116,10 @@ Jobs run in the background. The next section guides you through [`inspect_job`] 
 JobInfo(id='687f911eaea852de79c4a50a', created_at=datetime.datetime(2025, 7, 22, 13, 24, 46, 909000, tzinfo=datetime.timezone.utc), docker_image='python:3.12', space_id=None, command=['python', '-c', "print('Hello from the cloud!')"], arguments=[], environment={}, secrets={}, flavor='cpu-basic', status=JobStatus(stage='COMPLETED', message=None), owner=JobOwner(id='5e9ecfc04957053f60648a3e', name='lhoestq'), endpoint='https://huggingface.co', url='https://huggingface.co/jobs/lhoestq/687f911eaea852de79c4a50a')
 
 # List your running jobs (filtering happens server-side)
->>> running_jobs = list_jobs(stage="RUNNING")
+>>> running_jobs = list_jobs(status="RUNNING")
 
-# Filter by one or more stages and/or labels
->>> list_jobs(stage=["RUNNING", "SCHEDULING"], labels={"env": "prod"})
+# Filter by one or more statuses and/or labels
+>>> list_jobs(status=["RUNNING", "SCHEDULING"], labels={"env": "prod"})
 
 # Inspect the status of a job
 >>> from huggingface_hub import inspect_job

--- a/docs/source/en/guides/jobs.md
+++ b/docs/source/en/guides/jobs.md
@@ -115,8 +115,11 @@ Jobs run in the background. The next section guides you through [`inspect_job`] 
 >>> jobs[0]
 JobInfo(id='687f911eaea852de79c4a50a', created_at=datetime.datetime(2025, 7, 22, 13, 24, 46, 909000, tzinfo=datetime.timezone.utc), docker_image='python:3.12', space_id=None, command=['python', '-c', "print('Hello from the cloud!')"], arguments=[], environment={}, secrets={}, flavor='cpu-basic', status=JobStatus(stage='COMPLETED', message=None), owner=JobOwner(id='5e9ecfc04957053f60648a3e', name='lhoestq'), endpoint='https://huggingface.co', url='https://huggingface.co/jobs/lhoestq/687f911eaea852de79c4a50a')
 
-# List your running jobs
->>> running_jobs = [job for job in list_jobs() if job.status.stage == "RUNNING"]
+# List your running jobs (filtering happens server-side)
+>>> running_jobs = list_jobs(stage="RUNNING")
+
+# Filter by one or more stages and/or labels
+>>> list_jobs(stage=["RUNNING", "SCHEDULING"], labels={"env": "prod"})
 
 # Inspect the status of a job
 >>> from huggingface_hub import inspect_job

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -2301,7 +2301,7 @@ $ hf jobs ps [OPTIONS]
 **Options**:
 
 * `-a, --all`: Show all Jobs (default shows running and scheduling)
-* `--status TEXT`: Only show Jobs with the given status. Comma-separated or repeated, e.g. `--status running,scheduling`.
+* `--status [COMPLETED|CANCELED|ERROR|DELETED|SCHEDULING|RUNNING]`: Only show Jobs with the given status. Comma-separated or repeated, e.g. `--status running,scheduling`.
 * `-l, --label TEXT`: Only show Jobs with the given `key=value` label. Repeat to require several labels, e.g. `--label env=prod --label team=ml`.
 * `--namespace TEXT`: The namespace where the job will be running. Defaults to the current user's namespace.
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -2289,6 +2289,9 @@ Learn more
 
 List Jobs.
 
+Use `--status` to filter by status (see [`JobStage`] for possible values) and `--label` to filter by `key=value`
+labels. A Job must match every filter to be listed.
+
 **Usage**:
 
 ```console
@@ -2297,15 +2300,19 @@ $ hf jobs ps [OPTIONS]
 
 **Options**:
 
-* `-a, --all`: Show all Jobs (default shows just running)
+* `-a, --all`: Show all Jobs (default shows running and scheduling)
+* `--status TEXT`: Only show Jobs with the given status. Comma-separated or repeated, e.g. `--status running,scheduling`.
+* `-l, --label TEXT`: Only show Jobs with the given `key=value` label. Repeat to require several labels, e.g. `--label env=prod --label team=ml`.
 * `--namespace TEXT`: The namespace where the job will be running. Defaults to the current user's namespace.
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
-* `-f, --filter TEXT`: Filter output based on conditions provided (format: key=value)
+* `-f, --filter TEXT`: (Deprecated) Use `--status` and `--label` instead.
 * `--help`: Show this message and exit.
 
 Examples
   $ hf jobs ps
   $ hf jobs ps -a
+  $ hf jobs ps --status running,scheduling
+  $ hf jobs ps --label env=prod --label team=ml
 
 Learn more
   Use `hf <command> --help` for more information about a command.

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -2300,7 +2300,7 @@ $ hf jobs ps [OPTIONS]
 
 **Options**:
 
-* `-a, --all`: Show all Jobs (default shows running and scheduling)
+* `-a, --all`: Show all Jobs (default shows running and scheduling). Cannot be combined with --status.
 * `--status [COMPLETED|CANCELED|ERROR|DELETED|SCHEDULING|RUNNING]`: Only show Jobs with the given status. Comma-separated or repeated, e.g. `--status running,scheduling`.
 * `-l, --label TEXT`: Only show Jobs with the given `key=value` label. Repeat to require several labels, e.g. `--label env=prod --label team=ml`.
 * `--namespace TEXT`: The namespace where the job will be running. Defaults to the current user's namespace.
@@ -2313,6 +2313,7 @@ Examples
   $ hf jobs ps -a
   $ hf jobs ps --status running,scheduling
   $ hf jobs ps --label env=prod --label team=ml
+  $ hf jobs ps --all --label hf-sandbox=1
 
 Learn more
   Use `hf <command> --help` for more information about a command.

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -530,7 +530,15 @@ def jobs_stats(
                 last_update_time = now
 
 
-@jobs_cli.command("ps", examples=["hf jobs ps", "hf jobs ps -a"])
+@jobs_cli.command(
+    "ps",
+    examples=[
+        "hf jobs ps",
+        "hf jobs ps -a",
+        "hf jobs ps --status running,scheduling",
+        "hf jobs ps --label env=prod --label team=ml",
+    ],
+)
 def jobs_ps(
     all: Annotated[
         bool,
@@ -540,6 +548,21 @@ def jobs_ps(
             help="Show all Jobs (default shows just running)",
         ),
     ] = False,
+    status: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--status",
+            help="Only show Jobs with the given status. Comma-separated or repeated, e.g. `--status running,scheduling`.",
+        ),
+    ] = None,
+    label: Annotated[
+        list[str] | None,
+        typer.Option(
+            "-l",
+            "--label",
+            help="Only show Jobs with the given `key=value` label. Repeat to require several labels, e.g. `--label env=prod --label team=ml`.",
+        ),
+    ] = None,
     namespace: NamespaceOpt = None,
     token: TokenOpt = None,
     filter: Annotated[
@@ -547,35 +570,52 @@ def jobs_ps(
         typer.Option(
             "-f",
             "--filter",
-            help="Filter Jobs server-side by status or label. Repeatable. E.g. `-f status=running -f label=env=prod`.",
+            help="(Deprecated) Use `--status` and `--label` instead.",
         ),
     ] = None,
 ) -> None:
     """List Jobs.
 
-    Filtering happens server-side and supports two keys: `status=<stage>` (e.g. `status=running`) and
-    `label=<key>=<value>` (e.g. `label=env=prod`). Repeat `-f`/`--filter` to combine them; a Job must
-    match every filter to be listed. Matching is exact (no glob patterns or negation).
+    Filtering happens server-side. Use `--status` to filter by status (see [`JobStage`] for possible values)
+    and `--label` to filter by `key=value` labels. A Job must match every filter to be listed.
     """
     api = get_hf_api(token=token)
 
-    # Filtering is delegated to the server: collect the requested stages and labels and forward them as-is.
-    stages: list[str] = []
+    # Filtering is delegated to the server: collect the requested statuses and labels and forward them as-is.
+    statuses: list[str] = []
     labels: dict[str, str] = {}
-    for f in filter or []:
-        if f.startswith("status="):
-            stages.append(f[len("status=") :].upper())
-        elif f.startswith("label="):
-            key, _, value = f[len("label=") :].partition("=")
-            labels[key] = value
-        else:
-            out.warning(
-                f"Ignoring unsupported filter '{f}'. Only 'status=<stage>' and 'label=<key>=<value>' are supported."
-            )
+    for value in status or []:
+        statuses.extend(part.strip() for part in value.split(",") if part.strip())
+    for item in label or []:
+        key, _, value = item.partition("=")
+        labels[key] = value
 
-    # Default to the active Jobs unless `--all` or an explicit status filter is provided.
-    server_stages = stages if (all or stages) else ["RUNNING", "UPDATING"]
-    jobs = api.list_jobs(namespace=namespace, stage=server_stages or None, labels=labels or None)
+    # `--filter key=value` is the legacy syntax: still honored but nudged towards the dedicated options.
+    if filter:
+        out.warning("`-f`/`--filter` is deprecated and will be removed in a future release. Use `--status`/`--label`.")
+        for f in filter:
+            if f.startswith("status="):
+                statuses.extend(part.strip() for part in f[len("status=") :].split(",") if part.strip())
+            elif f.startswith("label="):
+                key, _, value = f[len("label=") :].partition("=")
+                labels[key] = value
+            else:
+                out.warning(
+                    f"Ignoring unsupported filter '{f}'. Only 'status=<status>' and 'label=<key>=<value>' are supported."
+                )
+
+    # Normalize and validate statuses against the known stages so we surface a friendly error instead of a 400.
+    normalized_statuses: list[str] = []
+    for s in statuses:
+        try:
+            normalized_statuses.append(JobStage(s.upper()).value)
+        except ValueError:
+            valid = ", ".join(stage.value for stage in JobStage)
+            raise CLIError(f"Invalid status '{s}'. Valid values are: {valid}.") from None
+
+    # Default to the running Jobs unless `--all` or an explicit status filter is provided.
+    server_statuses = normalized_statuses if (all or normalized_statuses) else [JobStage.RUNNING.value]
+    jobs = api.list_jobs(namespace=namespace, status=server_statuses or None, labels=labels or None)
 
     # Build display items. Augment the raw api dict with curated, table-friendly columns.
     items: list[dict[str, Any]] = []
@@ -597,8 +637,10 @@ def jobs_ps(
         id_key="job_id",
     )
     if not items:
-        if stages or labels:
-            filters_msg = ", ".join([*(f"status={s}" for s in stages), *(f"label={k}={v}" for k, v in labels.items())])
+        if normalized_statuses or labels:
+            filters_msg = ", ".join(
+                [*(f"status={s}" for s in normalized_statuses), *(f"label={k}={v}" for k, v in labels.items())]
+            )
             out.text(f"No jobs matched filters: {filters_msg}")
         elif not all:
             out.hint("No running jobs. Use `-a`/`--all` to include finished (and failed) jobs.")

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -583,33 +583,36 @@ def jobs_ps(
     """
     api = get_hf_api(token=token)
 
-    statuses: list[str] = []
-    labels: dict[str, str] = {}
-    for value in status or []:
-        statuses.extend(part.strip() for part in value.split(",") if part.strip())
-    for item in label or []:
-        if "=" not in item:
-            raise CLIError(f"Invalid label filter '{item}': must be in the form 'key=value'")
-        key, value = item.split("=")
-        labels[key] = value
-
     if filter:
         out.warning(
             f"Ignoring filter '{filter}'."
             " `-f`/`--filter` is deprecated and will be removed in a future release. Use `--status`/`--label`."
         )
 
-    if all and statuses:
+    if all and status:
         raise CLIError("`-a`/`--all` cannot be combined with `--status`.")
 
-    # Default to the active Jobs unless `--all` or an explicit `--status` is provided.
+    # Status filtering (default to active Jobs, unless `--all` or `--status` is provided).
+    raw_statuses: list[str] = []
+    for value in status or []:
+        raw_statuses.extend(part.strip() for part in value.split(",") if part.strip())
+
     server_statuses: list[str] | None
-    if statuses:
-        server_statuses = statuses
+    if raw_statuses:
+        server_statuses = raw_statuses
     elif all:
         server_statuses = None
     else:
         server_statuses = [JobStage.RUNNING.value, JobStage.SCHEDULING.value]
+
+    # Labels filtering
+    labels: dict[str, str] = {}
+    for item in label or []:
+        if "=" not in item:
+            raise CLIError(f"Invalid label filter '{item}': must be in the form 'key=value'")
+        key, value = item.split("=")
+        labels[key] = value
+
     jobs = api.list_jobs(namespace=namespace, status=server_statuses, labels=labels or None)
 
     # Build display items. Augment the raw api dict with curated, table-friendly columns.

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -592,18 +592,15 @@ def jobs_ps(
         key, value = item.split("=")
         labels[key] = value
 
-    # `-f`/`--filter` is the legacy syntax: now ignored, with a nudge towards the dedicated `--status`/`--label`.
     if filter:
         out.warning(
             f"Ignoring filter '{filter}'."
             " `-f`/`--filter` is deprecated and will be removed in a future release. Use `--status`/`--label`."
         )
 
-    # `--all` lists every Job, so combining it with a filter is contradictory.
     if all and (statuses or labels):
         raise CLIError("`-a`/`--all` cannot be combined with `--status` or `--label`.")
 
-    # Statuses are forwarded as-is (`SoftChoice` accepts any value) and validated server-side; `list_jobs` uppercases.
     # Default to the active Jobs unless `--all` or an explicit `--status` is provided.
     server_statuses: list[str] | None
     if statuses:

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -587,7 +587,9 @@ def jobs_ps(
     for value in status or []:
         statuses.extend(part.strip() for part in value.split(",") if part.strip())
     for item in label or []:
-        key, _, value = item.partition("=")
+        if "=" not in item:
+            raise CLIError(f"Invalid label filter '{item}': must be in the form 'key=value'")
+        key, value = item.split("=")
         labels[key] = value
 
     # `-f`/`--filter` is the legacy syntax: now ignored, with a nudge towards the dedicated `--status`/`--label`.

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -552,6 +552,7 @@ def jobs_ps(
         list[str] | None,
         typer.Option(
             "--status",
+            click_type=SoftChoice(JobStage),
             help="Only show Jobs with the given status. Comma-separated or repeated, e.g. `--status running,scheduling`.",
         ),
     ] = None,
@@ -576,12 +577,11 @@ def jobs_ps(
 ) -> None:
     """List Jobs.
 
-    Filtering happens server-side. Use `--status` to filter by status (see [`JobStage`] for possible values)
-    and `--label` to filter by `key=value` labels. A Job must match every filter to be listed.
+    Use `--status` to filter by status (see [`JobStage`] for possible values) and `--label` to filter by `key=value`
+    labels. A Job must match every filter to be listed.
     """
     api = get_hf_api(token=token)
 
-    # Filtering is delegated to the server: collect the requested statuses and labels and forward them as-is.
     statuses: list[str] = []
     labels: dict[str, str] = {}
     for value in status or []:
@@ -590,34 +590,27 @@ def jobs_ps(
         key, _, value = item.partition("=")
         labels[key] = value
 
-    # `--filter key=value` is the legacy syntax: still honored but nudged towards the dedicated options.
+    # `-f`/`--filter` is the legacy syntax: now ignored, with a nudge towards the dedicated `--status`/`--label`.
     if filter:
-        out.warning("`-f`/`--filter` is deprecated and will be removed in a future release. Use `--status`/`--label`.")
-        for f in filter:
-            if f.startswith("status="):
-                statuses.extend(part.strip() for part in f[len("status=") :].split(",") if part.strip())
-            elif f.startswith("label="):
-                key, _, value = f[len("label=") :].partition("=")
-                labels[key] = value
-            else:
-                out.warning(
-                    f"Ignoring unsupported filter '{f}'. Only 'status=<status>' and 'label=<key>=<value>' are supported."
-                )
+        out.warning(
+            f"Ignoring filter '{filter}'."
+            " `-f`/`--filter` is deprecated and will be removed in a future release. Use `--status`/`--label`."
+        )
 
-    # Normalize and validate statuses against the known stages so we surface a friendly error instead of a 400.
-    normalized_statuses: list[str] = []
-    for s in statuses:
-        try:
-            normalized_statuses.append(JobStage(s.upper()).value)
-        except ValueError:
-            valid = ", ".join(stage.value for stage in JobStage)
-            raise CLIError(f"Invalid status '{s}'. Valid values are: {valid}.") from None
+    # `--all` lists every Job, so combining it with a filter is contradictory.
+    if all and (statuses or labels):
+        raise CLIError("`-a`/`--all` cannot be combined with `--status` or `--label`.")
 
-    # Default to the active Jobs unless `--all` or an explicit status filter is provided.
-    server_statuses = (
-        normalized_statuses if (all or normalized_statuses) else [JobStage.RUNNING.value, JobStage.SCHEDULING.value]
-    )
-    jobs = api.list_jobs(namespace=namespace, status=server_statuses or None, labels=labels or None)
+    # Statuses are forwarded as-is (`SoftChoice` accepts any value) and validated server-side; `list_jobs` uppercases.
+    # Default to the active Jobs unless `--all` or an explicit `--status` is provided.
+    server_statuses: list[str] | None
+    if statuses:
+        server_statuses = statuses
+    elif all:
+        server_statuses = None
+    else:
+        server_statuses = [JobStage.RUNNING.value, JobStage.SCHEDULING.value]
+    jobs = api.list_jobs(namespace=namespace, status=server_statuses, labels=labels or None)
 
     # Build display items. Augment the raw api dict with curated, table-friendly columns.
     items: list[dict[str, Any]] = []
@@ -639,9 +632,9 @@ def jobs_ps(
         id_key="job_id",
     )
     if not items:
-        if normalized_statuses or labels:
+        if statuses or labels:
             filters_msg = ", ".join(
-                [*(f"status={s}" for s in normalized_statuses), *(f"label={k}={v}" for k, v in labels.items())]
+                [*(f"status={s}" for s in statuses), *(f"label={k}={v}" for k, v in labels.items())]
             )
             out.text(f"No jobs matched filters: {filters_msg}")
         elif not all:

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -635,9 +635,9 @@ def jobs_ps(
         id_key="job_id",
     )
     if not items:
-        if statuses or labels:
+        if raw_statuses or labels:
             filters_msg = ", ".join(
-                [*(f"status={s}" for s in statuses), *(f"label={k}={v}" for k, v in labels.items())]
+                [*(f"status={s}" for s in raw_statuses), *(f"label={k}={v}" for k, v in labels.items())]
             )
             out.text(f"No jobs matched filters: {filters_msg}")
         elif not all:

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -545,7 +545,7 @@ def jobs_ps(
         typer.Option(
             "-a",
             "--all",
-            help="Show all Jobs (default shows just running)",
+            help="Show all Jobs (default shows running and scheduling)",
         ),
     ] = False,
     status: Annotated[
@@ -613,8 +613,10 @@ def jobs_ps(
             valid = ", ".join(stage.value for stage in JobStage)
             raise CLIError(f"Invalid status '{s}'. Valid values are: {valid}.") from None
 
-    # Default to the running Jobs unless `--all` or an explicit status filter is provided.
-    server_statuses = normalized_statuses if (all or normalized_statuses) else [JobStage.RUNNING.value]
+    # Default to the active Jobs unless `--all` or an explicit status filter is provided.
+    server_statuses = (
+        normalized_statuses if (all or normalized_statuses) else [JobStage.RUNNING.value, JobStage.SCHEDULING.value]
+    )
     jobs = api.list_jobs(namespace=namespace, status=server_statuses or None, labels=labels or None)
 
     # Build display items. Augment the raw api dict with curated, table-friendly columns.

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -616,25 +616,25 @@ def jobs_ps(
     jobs = api.list_jobs(namespace=namespace, status=server_statuses, labels=labels or None)
 
     # Build display items. Augment the raw api dict with curated, table-friendly columns.
-    items: list[dict[str, Any]] = []
+    job_items: list[dict[str, Any]] = []
     for job in jobs:
-        item = _dataclass_to_dict(job)
-        durations = item.get("durations") or {}
-        cmd = item.get("command") or []
-        item["job_id"] = item.get("id", "")
-        item["image/space"] = item.get("docker_image") or "N/A"
-        item["command"] = " ".join(cmd) if cmd else "N/A"
-        item["created"] = item["created_at"][:19].replace("T", " ") if item.get("created_at") else "N/A"
-        item["status"] = (item.get("status") or {}).get("stage", "UNKNOWN")
-        item["runtime"] = format_duration(durations.get("running_secs"))
-        items.append(item)
+        job_item = _dataclass_to_dict(job)
+        durations = job_item.get("durations") or {}
+        cmd = job_item.get("command") or []
+        job_item["job_id"] = job_item.get("id", "")
+        job_item["image/space"] = job_item.get("docker_image") or "N/A"
+        job_item["command"] = " ".join(cmd) if cmd else "N/A"
+        job_item["created"] = job_item["created_at"][:19].replace("T", " ") if job_item.get("created_at") else "N/A"
+        job_item["status"] = (job_item.get("status") or {}).get("stage", "UNKNOWN")
+        job_item["runtime"] = format_duration(durations.get("running_secs"))
+        job_items.append(job_item)
 
     out.table(
-        items,
+        job_items,
         headers=["job_id", "image/space", "command", "created", "status", "runtime"],
         id_key="job_id",
     )
-    if not items:
+    if not job_items:
         if raw_statuses or labels:
             filters_msg = ", ".join(
                 [*(f"status={s}" for s in raw_statuses), *(f"label={k}={v}" for k, v in labels.items())]

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -412,6 +412,11 @@ def jobs_logs(
         out.hint(f"Stream ended. Run `hf jobs inspect {job_ref}` to check the final status (e.g. COMPLETED or ERROR).")
 
 
+def _is_exact_pattern(pattern: str) -> bool:
+    """Whether a filter value is a plain string (no `fnmatch` glob characters)."""
+    return not any(char in pattern for char in "*?[")
+
+
 def _matches_filters(job_properties: dict[str, str], filters: list[tuple[str, str, str]]) -> bool:
     """Check if scheduled job matches all specified filters."""
     for key, op_str, pattern in filters:
@@ -553,7 +558,6 @@ def jobs_ps(
 ) -> None:
     """List Jobs."""
     api = get_hf_api(token=token)
-    jobs = api.list_jobs(namespace=namespace)
 
     filters: list[tuple[str, str, str]] = []
     labels_filters: list[tuple[str, str, str]] = []
@@ -589,6 +593,18 @@ def jobs_ps(
             filters.append((key.lower(), op, value.lower()))
         else:
             out.warning(f"Ignoring invalid filter format '{f}'. Use key=value format.")
+
+    # Push exact status/label filters to the server to narrow results before the client-side filtering
+    # below. Glob patterns and negations (`!=`) are not supported server-side, so they stay client-only.
+    # The client-side pass remains authoritative, so this is a no-op against an endpoint that ignores the
+    # params (e.g. before the server-side feature is deployed).
+    server_stages = [
+        value.upper() for key, op, value in filters if key == "status" and op == "=" and _is_exact_pattern(value)
+    ]
+    server_labels = {
+        key: value for key, op, value in labels_filters if op == "=" and value != "*" and _is_exact_pattern(value)
+    }
+    jobs = api.list_jobs(namespace=namespace, stage=server_stages or None, labels=server_labels or None)
 
     # Filter jobs (operating on JobInfo objects to preserve existing filter behavior)
     filtered_jobs = []

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -537,6 +537,7 @@ def jobs_stats(
         "hf jobs ps -a",
         "hf jobs ps --status running,scheduling",
         "hf jobs ps --label env=prod --label team=ml",
+        "hf jobs ps --all --label hf-sandbox=1",
     ],
 )
 def jobs_ps(
@@ -545,7 +546,7 @@ def jobs_ps(
         typer.Option(
             "-a",
             "--all",
-            help="Show all Jobs (default shows running and scheduling)",
+            help="Show all Jobs (default shows running and scheduling). Cannot be combined with --status.",
         ),
     ] = False,
     status: Annotated[
@@ -598,8 +599,8 @@ def jobs_ps(
             " `-f`/`--filter` is deprecated and will be removed in a future release. Use `--status`/`--label`."
         )
 
-    if all and (statuses or labels):
-        raise CLIError("`-a`/`--all` cannot be combined with `--status` or `--label`.")
+    if all and statuses:
+        raise CLIError("`-a`/`--all` cannot be combined with `--status`.")
 
     # Default to the active Jobs unless `--all` or an explicit `--status` is provided.
     server_statuses: list[str] | None

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -412,11 +412,6 @@ def jobs_logs(
         out.hint(f"Stream ended. Run `hf jobs inspect {job_ref}` to check the final status (e.g. COMPLETED or ERROR).")
 
 
-def _is_exact_pattern(pattern: str) -> bool:
-    """Whether a filter value is a plain string (no `fnmatch` glob characters)."""
-    return not any(char in pattern for char in "*?[")
-
-
 def _matches_filters(job_properties: dict[str, str], filters: list[tuple[str, str, str]]) -> bool:
     """Check if scheduled job matches all specified filters."""
     for key, op_str, pattern in filters:
@@ -552,79 +547,39 @@ def jobs_ps(
         typer.Option(
             "-f",
             "--filter",
-            help="Filter output based on conditions provided (format: key=value)",
+            help="Filter Jobs server-side by status or label. Repeatable. E.g. `-f status=running -f label=env=prod`.",
         ),
     ] = None,
 ) -> None:
-    """List Jobs."""
+    """List Jobs.
+
+    Filtering happens server-side and supports two keys: `status=<stage>` (e.g. `status=running`) and
+    `label=<key>=<value>` (e.g. `label=env=prod`). Repeat `-f`/`--filter` to combine them; a Job must
+    match every filter to be listed. Matching is exact (no glob patterns or negation).
+    """
     api = get_hf_api(token=token)
 
-    filters: list[tuple[str, str, str]] = []
-    labels_filters: list[tuple[str, str, str]] = []
+    # Filtering is delegated to the server: collect the requested stages and labels and forward them as-is.
+    stages: list[str] = []
+    labels: dict[str, str] = {}
     for f in filter or []:
-        if f.startswith("label!=") or f.startswith("label="):
-            if f.startswith("label!="):
-                label_part = f[len("label!=") :]
-                if "=" in label_part:
-                    out.warning(f"Ignoring invalid label filter format 'label!={label_part}'. Use label!=key format.")
-                    continue
-                label_key, op, label_value = label_part, "!=", "*"
-            else:
-                label_part = f[len("label=") :]
-                if "=" in label_part:
-                    label_key, label_value = label_part.split("=", 1)
-                else:
-                    label_key, label_value = label_part, "*"
-                # Negate predicate in case of key!=value
-                if label_key.endswith("!"):
-                    op = "!="
-                    label_key = label_key[:-1]
-                else:
-                    op = "="
-            labels_filters.append((label_key.lower(), op, label_value.lower()))
-        elif "=" in f:
-            key, value = f.split("=", 1)
-            # Negate predicate in case of key!=value
-            if key.endswith("!"):
-                op = "!="
-                key = key[:-1]
-            else:
-                op = "="
-            filters.append((key.lower(), op, value.lower()))
+        if f.startswith("status="):
+            stages.append(f[len("status=") :].upper())
+        elif f.startswith("label="):
+            key, _, value = f[len("label=") :].partition("=")
+            labels[key] = value
         else:
-            out.warning(f"Ignoring invalid filter format '{f}'. Use key=value format.")
+            out.warning(
+                f"Ignoring unsupported filter '{f}'. Only 'status=<stage>' and 'label=<key>=<value>' are supported."
+            )
 
-    # Push exact status/label filters to the server to narrow results before the client-side filtering
-    # below. Glob patterns and negations (`!=`) are not supported server-side, so they stay client-only.
-    # The client-side pass remains authoritative, so this is a no-op against an endpoint that ignores the
-    # params (e.g. before the server-side feature is deployed).
-    server_stages = [
-        value.upper() for key, op, value in filters if key == "status" and op == "=" and _is_exact_pattern(value)
-    ]
-    server_labels = {
-        key: value for key, op, value in labels_filters if op == "=" and value != "*" and _is_exact_pattern(value)
-    }
-    jobs = api.list_jobs(namespace=namespace, stage=server_stages or None, labels=server_labels or None)
-
-    # Filter jobs (operating on JobInfo objects to preserve existing filter behavior)
-    filtered_jobs = []
-    for job in jobs:
-        status = job.status.stage if job.status else "UNKNOWN"
-        if not all and status not in ("RUNNING", "UPDATING"):
-            continue
-        image_or_space = job.docker_image or "N/A"
-        cmd = job.command or []
-        command_str = " ".join(cmd) if cmd else "N/A"
-        props = {"id": job.id, "image": image_or_space, "status": status.lower(), "command": command_str}
-        if not _matches_filters(props, filters):
-            continue
-        if not _matches_filters(job.labels or {}, labels_filters):
-            continue
-        filtered_jobs.append(job)
+    # Default to the active Jobs unless `--all` or an explicit status filter is provided.
+    server_stages = stages if (all or stages) else ["RUNNING", "UPDATING"]
+    jobs = api.list_jobs(namespace=namespace, stage=server_stages or None, labels=labels or None)
 
     # Build display items. Augment the raw api dict with curated, table-friendly columns.
     items: list[dict[str, Any]] = []
-    for job in filtered_jobs:
+    for job in jobs:
         item = _dataclass_to_dict(job)
         durations = item.get("durations") or {}
         cmd = item.get("command") or []
@@ -642,10 +597,10 @@ def jobs_ps(
         id_key="job_id",
     )
     if not items:
-        if filters:
-            filters_msg = ", ".join(f"{k}{o}{v}" for k, o, v in filters)
+        if stages or labels:
+            filters_msg = ", ".join([*(f"status={s}" for s in stages), *(f"label={k}={v}" for k, v in labels.items())])
             out.text(f"No jobs matched filters: {filters_msg}")
-        elif not all and not labels_filters:
+        elif not all:
             out.hint("No running jobs. Use `-a`/`--all` to include finished (and failed) jobs.")
 
 

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -12018,6 +12018,8 @@ class HfApi:
     def list_jobs(
         self,
         *,
+        stage: list[JobStage | str] | JobStage | str | None = None,
+        labels: dict[str, str] | None = None,
         timeout: int | None = None,
         namespace: str | None = None,
         token: bool | str | None = None,
@@ -12026,6 +12028,14 @@ class HfApi:
         List compute Jobs on Hugging Face infrastructure.
 
         Args:
+            stage (`JobStage`, `str` or `list`, *optional*):
+                Only return Jobs in the given stage(s), e.g. `"RUNNING"` or `[JobStage.RUNNING, JobStage.SCHEDULING]`.
+                See [`JobStage`] for possible values. Filtering happens server-side.
+
+            labels (`dict[str, str]`, *optional*):
+                Only return Jobs that have all the given `key=value` labels, e.g. `{"env": "prod", "team": "ml"}`.
+                Filtering happens server-side.
+
             timeout (`float`, *optional*):
                 Whether to set a timeout for the request to the Hub.
 
@@ -12039,9 +12049,16 @@ class HfApi:
         """
         if namespace is None:
             namespace = whoami(token=token)["name"]
+        params: list[tuple[str, str | int | float | None]] = []
+        if stage is not None:
+            stages = [stage] if isinstance(stage, (str, JobStage)) else stage
+            params.extend(("stage", s.value if isinstance(s, JobStage) else str(s)) for s in stages)
+        if labels is not None:
+            params.extend(("label", f"{key}={value}") for key, value in labels.items())
         response = get_session().get(
             f"{self.endpoint}/api/jobs/{namespace}",
             headers=self._build_hf_headers(token=token),
+            params=params or None,
             timeout=timeout,
         )
         hf_raise_for_status(response)

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -12048,7 +12048,7 @@ class HfApi:
         """
         if namespace is None:
             namespace = whoami(token=token)["name"]
-        params: list[tuple[str, str | int | float | None]] = []
+        params: list[tuple[str, Any]] = []
         if status is not None:
             statuses = [status] if isinstance(status, (str, JobStage)) else status
             params.extend(("stage", (s.value if isinstance(s, JobStage) else str(s)).upper()) for s in statuses)

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -12030,11 +12030,10 @@ class HfApi:
         Args:
             status (`JobStage`, `str` or `list`, *optional*):
                 Only return Jobs with the given status(es), e.g. `"RUNNING"` or `[JobStage.RUNNING, JobStage.SCHEDULING]`.
-                See [`JobStage`] for possible values. Filtering happens server-side.
+                See [`JobStage`] for possible values.
 
             labels (`dict[str, str]`, *optional*):
                 Only return Jobs that have all the given `key=value` labels, e.g. `{"env": "prod", "team": "ml"}`.
-                Filtering happens server-side.
 
             timeout (`float`, *optional*):
                 Whether to set a timeout for the request to the Hub.

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -12018,7 +12018,7 @@ class HfApi:
     def list_jobs(
         self,
         *,
-        stage: list[JobStage | str] | JobStage | str | None = None,
+        status: list[JobStage | str] | JobStage | str | None = None,
         labels: dict[str, str] | None = None,
         timeout: int | None = None,
         namespace: str | None = None,
@@ -12028,8 +12028,8 @@ class HfApi:
         List compute Jobs on Hugging Face infrastructure.
 
         Args:
-            stage (`JobStage`, `str` or `list`, *optional*):
-                Only return Jobs in the given stage(s), e.g. `"RUNNING"` or `[JobStage.RUNNING, JobStage.SCHEDULING]`.
+            status (`JobStage`, `str` or `list`, *optional*):
+                Only return Jobs with the given status(es), e.g. `"RUNNING"` or `[JobStage.RUNNING, JobStage.SCHEDULING]`.
                 See [`JobStage`] for possible values. Filtering happens server-side.
 
             labels (`dict[str, str]`, *optional*):
@@ -12050,9 +12050,9 @@ class HfApi:
         if namespace is None:
             namespace = whoami(token=token)["name"]
         params: list[tuple[str, str | int | float | None]] = []
-        if stage is not None:
-            stages = [stage] if isinstance(stage, (str, JobStage)) else stage
-            params.extend(("stage", s.value if isinstance(s, JobStage) else str(s)) for s in stages)
+        if status is not None:
+            statuses = [status] if isinstance(status, (str, JobStage)) else status
+            params.extend(("stage", (s.value if isinstance(s, JobStage) else str(s)).upper()) for s in statuses)
         if labels is not None:
             params.extend(("label", f"{key}={value}") for key, value in labels.items())
         response = get_session().get(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3391,11 +3391,6 @@ class TestJobsCommand:
         assert "--" in result.output  # SCHEDULING job has no running_secs yet
 
     def test_ps_forwards_status_and_label_filters_server_side(self, runner: CliRunner) -> None:
-        """`--status` (comma-separated) and `--label` are forwarded to `list_jobs` for server-side filtering.
-
-        Statuses are forwarded as-is (`list_jobs` normalizes casing) and label key/value casing is preserved
-        (no lowercasing) so it matches what the server stored.
-        """
         with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
             api = api_cls.return_value
             api.list_jobs.return_value = self._make_mock_jobs()
@@ -3406,58 +3401,6 @@ class TestJobsCommand:
         kwargs = api.list_jobs.call_args.kwargs
         assert kwargs["status"] == ["completed", "scheduling"]
         assert kwargs["labels"] == {"model": "Qwen3-06B"}
-
-    def test_ps_defaults_to_active_statuses_server_side(self, runner: CliRunner) -> None:
-        """Without `-a` or an explicit `--status`, the active (RUNNING + SCHEDULING) Jobs are requested."""
-        with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
-            api = api_cls.return_value
-            api.list_jobs.return_value = self._make_mock_jobs()
-            result = runner.invoke(app, ["jobs", "ps"])
-        assert result.exit_code == 0
-        kwargs = api.list_jobs.call_args.kwargs
-        assert kwargs["status"] == ["RUNNING", "SCHEDULING"]
-        assert kwargs["labels"] is None
-
-    def test_ps_all_lists_every_status(self, runner: CliRunner) -> None:
-        """`-a`/`--all` drops the default status filter so all Jobs are listed."""
-        with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
-            api = api_cls.return_value
-            api.list_jobs.return_value = self._make_mock_jobs()
-            result = runner.invoke(app, ["jobs", "ps", "-a"])
-        assert result.exit_code == 0
-        assert api.list_jobs.call_args.kwargs["status"] is None
-
-    def test_ps_all_with_filter_errors(self, runner: CliRunner) -> None:
-        """`-a`/`--all` lists every Job, so combining it with `--status`/`--label` is rejected."""
-        with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
-            api = api_cls.return_value
-            result = runner.invoke(app, ["jobs", "ps", "-a", "--status", "completed"])
-        assert result.exit_code != 0
-        assert isinstance(result.exception, CLIError)
-        assert "cannot be combined" in str(result.exception)
-        api.list_jobs.assert_not_called()
-
-    def test_ps_unknown_status_forwarded_to_server(self, runner: CliRunner) -> None:
-        """`--status` uses `SoftChoice`: unknown values are forwarded as-is and left for the server to reject."""
-        with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
-            api = api_cls.return_value
-            api.list_jobs.return_value = self._make_mock_jobs()
-            result = runner.invoke(app, ["jobs", "ps", "--status", "bogus"])
-        assert result.exit_code == 0
-        assert api.list_jobs.call_args.kwargs["status"] == ["bogus"]
-
-    def test_ps_filter_is_deprecated_and_ignored(self, runner: CliRunner) -> None:
-        """The legacy `-f`/`--filter` syntax warns and is ignored: use `--status`/`--label` instead."""
-        with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
-            api = api_cls.return_value
-            api.list_jobs.return_value = self._make_mock_jobs()
-            result = runner.invoke(app, ["jobs", "ps", "-f", "status=completed", "-f", "label=env=test"])
-        assert result.exit_code == 0
-        assert "deprecated" in result.output
-        kwargs = api.list_jobs.call_args.kwargs
-        # `--filter` is ignored, so only the default active-status filter is applied.
-        assert kwargs["status"] == ["RUNNING", "SCHEDULING"]
-        assert kwargs["labels"] is None
 
     def test_ps_format_json(self, runner: CliRunner) -> None:
         """Test that `hf jobs ps -a --format json` outputs valid JSON with all fields."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3390,6 +3390,28 @@ class TestJobsCommand:
         assert "3m 7s" in result.output  # 187s running_secs formatted
         assert "--" in result.output  # SCHEDULING job has no running_secs yet
 
+    def test_ps_pushes_exact_status_and_label_filters_server_side(self, runner: CliRunner) -> None:
+        """Exact `status=` and `label=key=value` filters are forwarded to `list_jobs` for server-side filtering."""
+        with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            api.list_jobs.return_value = self._make_mock_jobs()
+            result = runner.invoke(app, ["jobs", "ps", "-a", "-f", "status=completed", "-f", "label=env=test"])
+        assert result.exit_code == 0
+        kwargs = api.list_jobs.call_args.kwargs
+        assert kwargs["stage"] == ["COMPLETED"]
+        assert kwargs["labels"] == {"env": "test"}
+
+    def test_ps_does_not_push_glob_or_negated_filters(self, runner: CliRunner) -> None:
+        """Glob patterns and negations can't be expressed server-side, so they stay client-side only."""
+        with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            api.list_jobs.return_value = self._make_mock_jobs()
+            result = runner.invoke(app, ["jobs", "ps", "-a", "-f", "status=run*", "-f", "label!=prod"])
+        assert result.exit_code == 0
+        kwargs = api.list_jobs.call_args.kwargs
+        assert kwargs["stage"] is None
+        assert kwargs["labels"] is None
+
     def test_ps_format_json(self, runner: CliRunner) -> None:
         """Test that `hf jobs ps -a --format json` outputs valid JSON with all fields."""
         import json

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3391,50 +3391,63 @@ class TestJobsCommand:
         assert "--" in result.output  # SCHEDULING job has no running_secs yet
 
     def test_ps_forwards_status_and_label_filters_server_side(self, runner: CliRunner) -> None:
-        """`status=` and `label=key=value` filters are forwarded to `list_jobs` for server-side filtering.
+        """`--status` (comma-separated) and `--label` are forwarded to `list_jobs` for server-side filtering.
 
         Label key/value casing is preserved (no lowercasing) so it matches what the server stored.
         """
         with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
             api = api_cls.return_value
             api.list_jobs.return_value = self._make_mock_jobs()
-            result = runner.invoke(app, ["jobs", "ps", "-f", "status=completed", "-f", "label=model=Qwen3-06B"])
+            result = runner.invoke(
+                app, ["jobs", "ps", "--status", "completed,scheduling", "--label", "model=Qwen3-06B"]
+            )
         assert result.exit_code == 0
         kwargs = api.list_jobs.call_args.kwargs
-        assert kwargs["stage"] == ["COMPLETED"]
+        assert kwargs["status"] == ["COMPLETED", "SCHEDULING"]
         assert kwargs["labels"] == {"model": "Qwen3-06B"}
 
-    def test_ps_defaults_to_running_stages_server_side(self, runner: CliRunner) -> None:
-        """Without `-a` or an explicit status filter, the active stages are requested server-side."""
+    def test_ps_defaults_to_running_status_server_side(self, runner: CliRunner) -> None:
+        """Without `-a` or an explicit `--status`, only RUNNING Jobs are requested server-side."""
         with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
             api = api_cls.return_value
             api.list_jobs.return_value = self._make_mock_jobs()
             result = runner.invoke(app, ["jobs", "ps"])
         assert result.exit_code == 0
         kwargs = api.list_jobs.call_args.kwargs
-        assert kwargs["stage"] == ["RUNNING", "UPDATING"]
+        assert kwargs["status"] == ["RUNNING"]
         assert kwargs["labels"] is None
 
-    def test_ps_all_lists_every_stage(self, runner: CliRunner) -> None:
-        """`-a`/`--all` drops the default stage filter so all Jobs are listed."""
+    def test_ps_all_lists_every_status(self, runner: CliRunner) -> None:
+        """`-a`/`--all` drops the default status filter so all Jobs are listed."""
         with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
             api = api_cls.return_value
             api.list_jobs.return_value = self._make_mock_jobs()
             result = runner.invoke(app, ["jobs", "ps", "-a"])
         assert result.exit_code == 0
-        assert api.list_jobs.call_args.kwargs["stage"] is None
+        assert api.list_jobs.call_args.kwargs["status"] is None
 
-    def test_ps_unsupported_filter_warns(self, runner: CliRunner) -> None:
-        """Filtering by anything other than status/label (or using negation/globs) warns and is ignored."""
+    def test_ps_invalid_status_errors(self, runner: CliRunner) -> None:
+        """An unknown status is rejected client-side with a friendly error before hitting the server."""
         with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
             api = api_cls.return_value
             api.list_jobs.return_value = self._make_mock_jobs()
-            result = runner.invoke(app, ["jobs", "ps", "-a", "-f", "image=python", "-f", "label!=prod"])
+            result = runner.invoke(app, ["jobs", "ps", "--status", "bogus"])
+        assert result.exit_code != 0
+        assert isinstance(result.exception, CLIError)
+        assert "Invalid status 'bogus'" in str(result.exception)
+        api.list_jobs.assert_not_called()
+
+    def test_ps_filter_is_deprecated_but_still_works(self, runner: CliRunner) -> None:
+        """The legacy `-f`/`--filter` syntax warns but is still translated into server-side filters."""
+        with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            api.list_jobs.return_value = self._make_mock_jobs()
+            result = runner.invoke(app, ["jobs", "ps", "-f", "status=completed", "-f", "label=env=test"])
         assert result.exit_code == 0
-        assert "Ignoring unsupported filter" in result.output
+        assert "deprecated" in result.output
         kwargs = api.list_jobs.call_args.kwargs
-        assert kwargs["stage"] is None
-        assert kwargs["labels"] is None
+        assert kwargs["status"] == ["COMPLETED"]
+        assert kwargs["labels"] == {"env": "test"}
 
     def test_ps_format_json(self, runner: CliRunner) -> None:
         """Test that `hf jobs ps -a --format json` outputs valid JSON with all fields."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3406,15 +3406,15 @@ class TestJobsCommand:
         assert kwargs["status"] == ["COMPLETED", "SCHEDULING"]
         assert kwargs["labels"] == {"model": "Qwen3-06B"}
 
-    def test_ps_defaults_to_running_status_server_side(self, runner: CliRunner) -> None:
-        """Without `-a` or an explicit `--status`, only RUNNING Jobs are requested server-side."""
+    def test_ps_defaults_to_active_statuses_server_side(self, runner: CliRunner) -> None:
+        """Without `-a` or an explicit `--status`, the active (RUNNING + SCHEDULING) Jobs are requested."""
         with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
             api = api_cls.return_value
             api.list_jobs.return_value = self._make_mock_jobs()
             result = runner.invoke(app, ["jobs", "ps"])
         assert result.exit_code == 0
         kwargs = api.list_jobs.call_args.kwargs
-        assert kwargs["status"] == ["RUNNING"]
+        assert kwargs["status"] == ["RUNNING", "SCHEDULING"]
         assert kwargs["labels"] is None
 
     def test_ps_all_lists_every_status(self, runner: CliRunner) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3393,7 +3393,8 @@ class TestJobsCommand:
     def test_ps_forwards_status_and_label_filters_server_side(self, runner: CliRunner) -> None:
         """`--status` (comma-separated) and `--label` are forwarded to `list_jobs` for server-side filtering.
 
-        Label key/value casing is preserved (no lowercasing) so it matches what the server stored.
+        Statuses are forwarded as-is (`list_jobs` normalizes casing) and label key/value casing is preserved
+        (no lowercasing) so it matches what the server stored.
         """
         with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
             api = api_cls.return_value
@@ -3403,7 +3404,7 @@ class TestJobsCommand:
             )
         assert result.exit_code == 0
         kwargs = api.list_jobs.call_args.kwargs
-        assert kwargs["status"] == ["COMPLETED", "SCHEDULING"]
+        assert kwargs["status"] == ["completed", "scheduling"]
         assert kwargs["labels"] == {"model": "Qwen3-06B"}
 
     def test_ps_defaults_to_active_statuses_server_side(self, runner: CliRunner) -> None:
@@ -3426,19 +3427,27 @@ class TestJobsCommand:
         assert result.exit_code == 0
         assert api.list_jobs.call_args.kwargs["status"] is None
 
-    def test_ps_invalid_status_errors(self, runner: CliRunner) -> None:
-        """An unknown status is rejected client-side with a friendly error before hitting the server."""
+    def test_ps_all_with_filter_errors(self, runner: CliRunner) -> None:
+        """`-a`/`--all` lists every Job, so combining it with `--status`/`--label` is rejected."""
+        with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            result = runner.invoke(app, ["jobs", "ps", "-a", "--status", "completed"])
+        assert result.exit_code != 0
+        assert isinstance(result.exception, CLIError)
+        assert "cannot be combined" in str(result.exception)
+        api.list_jobs.assert_not_called()
+
+    def test_ps_unknown_status_forwarded_to_server(self, runner: CliRunner) -> None:
+        """`--status` uses `SoftChoice`: unknown values are forwarded as-is and left for the server to reject."""
         with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
             api = api_cls.return_value
             api.list_jobs.return_value = self._make_mock_jobs()
             result = runner.invoke(app, ["jobs", "ps", "--status", "bogus"])
-        assert result.exit_code != 0
-        assert isinstance(result.exception, CLIError)
-        assert "Invalid status 'bogus'" in str(result.exception)
-        api.list_jobs.assert_not_called()
+        assert result.exit_code == 0
+        assert api.list_jobs.call_args.kwargs["status"] == ["bogus"]
 
-    def test_ps_filter_is_deprecated_but_still_works(self, runner: CliRunner) -> None:
-        """The legacy `-f`/`--filter` syntax warns but is still translated into server-side filters."""
+    def test_ps_filter_is_deprecated_and_ignored(self, runner: CliRunner) -> None:
+        """The legacy `-f`/`--filter` syntax warns and is ignored: use `--status`/`--label` instead."""
         with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
             api = api_cls.return_value
             api.list_jobs.return_value = self._make_mock_jobs()
@@ -3446,8 +3455,9 @@ class TestJobsCommand:
         assert result.exit_code == 0
         assert "deprecated" in result.output
         kwargs = api.list_jobs.call_args.kwargs
-        assert kwargs["status"] == ["COMPLETED"]
-        assert kwargs["labels"] == {"env": "test"}
+        # `--filter` is ignored, so only the default active-status filter is applied.
+        assert kwargs["status"] == ["RUNNING", "SCHEDULING"]
+        assert kwargs["labels"] is None
 
     def test_ps_format_json(self, runner: CliRunner) -> None:
         """Test that `hf jobs ps -a --format json` outputs valid JSON with all fields."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3390,24 +3390,48 @@ class TestJobsCommand:
         assert "3m 7s" in result.output  # 187s running_secs formatted
         assert "--" in result.output  # SCHEDULING job has no running_secs yet
 
-    def test_ps_pushes_exact_status_and_label_filters_server_side(self, runner: CliRunner) -> None:
-        """Exact `status=` and `label=key=value` filters are forwarded to `list_jobs` for server-side filtering."""
+    def test_ps_forwards_status_and_label_filters_server_side(self, runner: CliRunner) -> None:
+        """`status=` and `label=key=value` filters are forwarded to `list_jobs` for server-side filtering.
+
+        Label key/value casing is preserved (no lowercasing) so it matches what the server stored.
+        """
         with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
             api = api_cls.return_value
             api.list_jobs.return_value = self._make_mock_jobs()
-            result = runner.invoke(app, ["jobs", "ps", "-a", "-f", "status=completed", "-f", "label=env=test"])
+            result = runner.invoke(app, ["jobs", "ps", "-f", "status=completed", "-f", "label=model=Qwen3-06B"])
         assert result.exit_code == 0
         kwargs = api.list_jobs.call_args.kwargs
         assert kwargs["stage"] == ["COMPLETED"]
-        assert kwargs["labels"] == {"env": "test"}
+        assert kwargs["labels"] == {"model": "Qwen3-06B"}
 
-    def test_ps_does_not_push_glob_or_negated_filters(self, runner: CliRunner) -> None:
-        """Glob patterns and negations can't be expressed server-side, so they stay client-side only."""
+    def test_ps_defaults_to_running_stages_server_side(self, runner: CliRunner) -> None:
+        """Without `-a` or an explicit status filter, the active stages are requested server-side."""
         with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
             api = api_cls.return_value
             api.list_jobs.return_value = self._make_mock_jobs()
-            result = runner.invoke(app, ["jobs", "ps", "-a", "-f", "status=run*", "-f", "label!=prod"])
+            result = runner.invoke(app, ["jobs", "ps"])
         assert result.exit_code == 0
+        kwargs = api.list_jobs.call_args.kwargs
+        assert kwargs["stage"] == ["RUNNING", "UPDATING"]
+        assert kwargs["labels"] is None
+
+    def test_ps_all_lists_every_stage(self, runner: CliRunner) -> None:
+        """`-a`/`--all` drops the default stage filter so all Jobs are listed."""
+        with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            api.list_jobs.return_value = self._make_mock_jobs()
+            result = runner.invoke(app, ["jobs", "ps", "-a"])
+        assert result.exit_code == 0
+        assert api.list_jobs.call_args.kwargs["stage"] is None
+
+    def test_ps_unsupported_filter_warns(self, runner: CliRunner) -> None:
+        """Filtering by anything other than status/label (or using negation/globs) warns and is ignored."""
+        with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            api.list_jobs.return_value = self._make_mock_jobs()
+            result = runner.invoke(app, ["jobs", "ps", "-a", "-f", "image=python", "-f", "label!=prod"])
+        assert result.exit_code == 0
+        assert "Ignoring unsupported filter" in result.output
         kwargs = api.list_jobs.call_args.kwargs
         assert kwargs["stage"] is None
         assert kwargs["labels"] is None

--- a/tests/test_jobs_api.py
+++ b/tests/test_jobs_api.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -74,3 +74,45 @@ class TestWaitForJob:
         ):
             job = self.api.wait_for_job(job_id="job-id", namespace="user", stages=[JobStage.RUNNING])
         assert job.status.stage == "ERROR"
+
+
+class TestListJobs:
+    api = HfApi(token="hf_test")
+
+    def _patch_session(self):
+        response = Mock()
+        response.json.return_value = []
+        session = patch("huggingface_hub.hf_api.get_session")
+        return session, response
+
+    def test_forwards_stage_and_labels_as_query_params(self) -> None:
+        session, response = self._patch_session()
+        with session as mock_session:
+            mock_session.return_value.get.return_value = response
+            self.api.list_jobs(
+                namespace="user",
+                stage=[JobStage.RUNNING, "SCHEDULING"],
+                labels={"env": "prod", "team": "ml"},
+            )
+        params = mock_session.return_value.get.call_args.kwargs["params"]
+        # `stage` is serialized to its raw string value (not `JobStage.RUNNING`), labels as `key=value`.
+        assert params == [
+            ("stage", "RUNNING"),
+            ("stage", "SCHEDULING"),
+            ("label", "env=prod"),
+            ("label", "team=ml"),
+        ]
+
+    def test_single_stage_string_is_wrapped(self) -> None:
+        session, response = self._patch_session()
+        with session as mock_session:
+            mock_session.return_value.get.return_value = response
+            self.api.list_jobs(namespace="user", stage="RUNNING")
+        assert mock_session.return_value.get.call_args.kwargs["params"] == [("stage", "RUNNING")]
+
+    def test_no_filters_sends_no_params(self) -> None:
+        session, response = self._patch_session()
+        with session as mock_session:
+            mock_session.return_value.get.return_value = response
+            self.api.list_jobs(namespace="user")
+        assert mock_session.return_value.get.call_args.kwargs["params"] is None

--- a/tests/test_jobs_api.py
+++ b/tests/test_jobs_api.py
@@ -85,17 +85,17 @@ class TestListJobs:
         session = patch("huggingface_hub.hf_api.get_session")
         return session, response
 
-    def test_forwards_stage_and_labels_as_query_params(self) -> None:
+    def test_forwards_status_and_labels_as_query_params(self) -> None:
         session, response = self._patch_session()
         with session as mock_session:
             mock_session.return_value.get.return_value = response
             self.api.list_jobs(
                 namespace="user",
-                stage=[JobStage.RUNNING, "SCHEDULING"],
+                status=[JobStage.RUNNING, "scheduling"],
                 labels={"env": "prod", "team": "ml"},
             )
         params = mock_session.return_value.get.call_args.kwargs["params"]
-        # `stage` is serialized to its raw string value (not `JobStage.RUNNING`), labels as `key=value`.
+        # `status` is forwarded as the `stage` query param, upper-cased; labels as `key=value`.
         assert params == [
             ("stage", "RUNNING"),
             ("stage", "SCHEDULING"),
@@ -103,11 +103,11 @@ class TestListJobs:
             ("label", "team=ml"),
         ]
 
-    def test_single_stage_string_is_wrapped(self) -> None:
+    def test_single_status_string_is_wrapped(self) -> None:
         session, response = self._patch_session()
         with session as mock_session:
             mock_session.return_value.get.return_value = response
-            self.api.list_jobs(namespace="user", stage="RUNNING")
+            self.api.list_jobs(namespace="user", status="RUNNING")
         assert mock_session.return_value.get.call_args.kwargs["params"] == [("stage", "RUNNING")]
 
     def test_no_filters_sends_no_params(self) -> None:

--- a/tests/test_jobs_api.py
+++ b/tests/test_jobs_api.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -74,45 +74,3 @@ class TestWaitForJob:
         ):
             job = self.api.wait_for_job(job_id="job-id", namespace="user", stages=[JobStage.RUNNING])
         assert job.status.stage == "ERROR"
-
-
-class TestListJobs:
-    api = HfApi(token="hf_test")
-
-    def _patch_session(self):
-        response = Mock()
-        response.json.return_value = []
-        session = patch("huggingface_hub.hf_api.get_session")
-        return session, response
-
-    def test_forwards_status_and_labels_as_query_params(self) -> None:
-        session, response = self._patch_session()
-        with session as mock_session:
-            mock_session.return_value.get.return_value = response
-            self.api.list_jobs(
-                namespace="user",
-                status=[JobStage.RUNNING, "scheduling"],
-                labels={"env": "prod", "team": "ml"},
-            )
-        params = mock_session.return_value.get.call_args.kwargs["params"]
-        # `status` is forwarded as the `stage` query param, upper-cased; labels as `key=value`.
-        assert params == [
-            ("stage", "RUNNING"),
-            ("stage", "SCHEDULING"),
-            ("label", "env=prod"),
-            ("label", "team=ml"),
-        ]
-
-    def test_single_status_string_is_wrapped(self) -> None:
-        session, response = self._patch_session()
-        with session as mock_session:
-            mock_session.return_value.get.return_value = response
-            self.api.list_jobs(namespace="user", status="RUNNING")
-        assert mock_session.return_value.get.call_args.kwargs["params"] == [("stage", "RUNNING")]
-
-    def test_no_filters_sends_no_params(self) -> None:
-        session, response = self._patch_session()
-        with session as mock_session:
-            mock_session.return_value.get.return_value = response
-            self.api.list_jobs(namespace="user")
-        assert mock_session.return_value.get.call_args.kwargs["params"] is None


### PR DESCRIPTION
(related to server-side update https://github.com/huggingface-internal/moon-landing/pull/18664 -internal link-)

## Summary

Adds server-side filtering to the Jobs listing endpoint (now deployed on the Hub) and exposes it through both the Python API and the CLI.

- **`HfApi.list_jobs(status=..., labels=...)`**:
  - `status`: a `JobStage`/`str` or list of them e.g. `list_jobs(status=["RUNNING", "SCHEDULING"])`
  - `labels`: a `dict[str, str]` → forwarded as `?label=env=prod&label=team=ml` (logical OR)
- **`hf jobs ps`** gets dedicated filter options:
  - `--status` e.g. `--status running,scheduling`
  - `--label` e.g. `--label env=prod --label team=ml`
  - `-f`/`--filter` is **deprecated** and **ignored**

Filtering is fully server-side; the default view (no `-a`) requests `RUNNING` and `SCHEDULING` jobs.

```python
>>> from huggingface_hub import list_jobs
>>> list_jobs(status=["RUNNING", "SCHEDULING", labels={"env": "prod"})
```

```bash
# Running jobs labelled both env=prod and team=ml
>>> hf jobs ps --status running,scheduling --label env=prod --label team=ml
```

## ⚠️ Breaking changes (`hf jobs ps`)

The CLI now delegates filtering to the server, so the old rich client-side matching is gone:

- `-f`/`--filter` is deprecated in favor of `--status` / `--label`.
- **Removed filter keys**: `id=`, `image=`, `command=`. Only status and label filtering exist.
- **No glob patterns** (`label=data-*`) and **no negation** (`label!=prod`, `status!=...`) — matching is exact.
- **Label matching is now exact and case-sensitive** (was case-insensitive `fnmatch`).

`HfApi.list_jobs` itself stays backward-compatible.


🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The Python API change is backward-compatible, but `hf jobs ps` behavior changes for anyone relying on `-f`/`--filter` (globs, negation, or non-label fields), and the default active-job stages shift from RUNNING/UPDATING to RUNNING/SCHEDULING.
> 
> **Overview**
> Adds **server-side** filtering when listing Jobs: `HfApi.list_jobs()` and the top-level `list_jobs()` helper accept optional `status` and `labels`, sent to the Hub as `stage` and `label=key=value` query parameters.
> 
> **`hf jobs ps`** is reworked to use that API instead of client-side `-f`/`--filter` matching. New flags are `--status` (comma-separated or repeated) and `--label` (repeatable `key=value`; all must match). The default listing (without `-a`) now requests **RUNNING** and **SCHEDULING** on the server; `-a` cannot be combined with `--status`. **`-f`/`--filter` is deprecated**, emits a warning, and is **ignored**.
> 
> Docs (CLI guide, jobs guide, CLI reference) describe the new options and call out CLI breaking behavior: no globs, negation, or filtering by id/image/command; label matching is exact.
> 
> A CLI test asserts `list_jobs` is called with the parsed `status` and `labels` kwargs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d59efe206d984cf6bb3901c8f14f252a974c8e23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->