### PR TITLE
docs: put `hf jobs uv run` flags before the script for consistency

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -2048,10 +2048,10 @@ Run UV scripts (Python scripts with inline dependencies) on HF infrastructure. U
 >>> hf jobs uv run my_script.py
 
 # Run with persistent repo
->>> hf jobs uv run my_script.py --repo my-uv-scripts
+>>> hf jobs uv run --repo my-uv-scripts my_script.py
 
 # Run with GPU
->>> hf jobs uv run ml_training.py --flavor gpu-t4-small
+>>> hf jobs uv run --flavor gpu-t4-small ml_training.py
 
 # Pass arguments to script
 >>> hf jobs uv run process.py input.csv output.parquet


### PR DESCRIPTION
The persistent-repo and GPU examples in the UV Scripts section listed the job flag after the script:

```
hf jobs uv run my_script.py --repo my-uv-scripts
hf jobs uv run ml_training.py --flavor gpu-t4-small
```

Every other `uv run` example in the docs (including the multi-line examples) lists job flags *before* the script, with only the script's own arguments trailing after it — e.g. the example right below these:

```
hf jobs uv run process.py input.csv output.parquet
```

Reorder the two outliers to match, so the section consistently shows "job flags → script → script arguments".

Docs-only; no behaviour change. `utils/generate_cli_reference.py` reports no drift (the auto-generated CLI reference is unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to example command ordering; no runtime or API changes.
> 
> **Overview**
> Aligns two **UV Scripts** examples in `cli.md` with the rest of the section: job options (`--repo`, `--flavor`) now appear **before** the script path, with only script arguments after the script (e.g. `hf jobs uv run --repo my-uv-scripts my_script.py` and `hf jobs uv run --flavor gpu-t4-small ml_training.py`).
> 
> Docs-only; no CLI behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2c8996ced288cfa64df8a11debb03cc283ab761. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->