### PR TITLE
Retry requests on httpx.RemoteProtocolError

### DIFF
--- a/src/huggingface_hub/utils/_http.py
+++ b/src/huggingface_hub/utils/_http.py
@@ -401,8 +401,6 @@ if hasattr(os, "register_at_fork"):
     os.register_at_fork(after_in_child=close_session)
 
 
-# `RemoteProtocolError` is included to retry stale keep-alive connections dropped by the server
-# (it is a `ProtocolError`, not a `NetworkError`, so it is not covered by the latter).
 _DEFAULT_RETRY_ON_EXCEPTIONS: tuple[type[Exception], ...] = (
     httpx.TimeoutException,
     httpx.NetworkError,

--- a/src/huggingface_hub/utils/_http.py
+++ b/src/huggingface_hub/utils/_http.py
@@ -401,7 +401,13 @@ if hasattr(os, "register_at_fork"):
     os.register_at_fork(after_in_child=close_session)
 
 
-_DEFAULT_RETRY_ON_EXCEPTIONS: tuple[type[Exception], ...] = (httpx.TimeoutException, httpx.NetworkError)
+# `RemoteProtocolError` is included to retry stale keep-alive connections dropped by the server
+# (it is a `ProtocolError`, not a `NetworkError`, so it is not covered by the latter).
+_DEFAULT_RETRY_ON_EXCEPTIONS: tuple[type[Exception], ...] = (
+    httpx.TimeoutException,
+    httpx.NetworkError,
+    httpx.RemoteProtocolError,
+)
 _DEFAULT_RETRY_ON_STATUS_CODES: tuple[int, ...] = (408, 429, 500, 502, 503, 504)
 
 
@@ -538,7 +544,7 @@ def http_backoff(
             Maximum duration (in seconds) to wait before retrying.
         retry_on_exceptions (`type[Exception]` or `tuple[type[Exception]]`, *optional*):
             Define which exceptions must be caught to retry the request. Can be a single type or a tuple of types.
-            By default, retry on `httpx.TimeoutException` and `httpx.NetworkError`.
+            By default, retry on `httpx.TimeoutException`, `httpx.NetworkError` and `httpx.RemoteProtocolError`.
         retry_on_status_codes (`int` or `tuple[int]`, *optional*, defaults to `(429, 500, 502, 503, 504)`):
             Define on which status codes the request must be retried. By default, retries
             on rate limit (429) and server errors (5xx).
@@ -619,7 +625,7 @@ def http_stream_backoff(
             Maximum duration (in seconds) to wait before retrying.
         retry_on_exceptions (`type[Exception]` or `tuple[type[Exception]]`, *optional*):
             Define which exceptions must be caught to retry the request. Can be a single type or a tuple of types.
-            By default, retry on `httpx.TimeoutException` and `httpx.NetworkError`.
+            By default, retry on `httpx.TimeoutException`, `httpx.NetworkError` and `httpx.RemoteProtocolError`.
         retry_on_status_codes (`int` or `tuple[int]`, *optional*, defaults to `(429, 500, 502, 503, 504)`):
             Define on which status codes the request must be retried. By default, retries
             on rate limit (429) and server errors (5xx).


### PR DESCRIPTION
## Summary

Fixes the retry gap reported in #4397. When a keep-alive connection is dropped by the server (or an intermediate proxy / load balancer), `httpx` raises `RemoteProtocolError` (e.g. "Server disconnected without sending a response."). This is a `ProtocolError` (→ `TransportError` → `RequestError`), **not** a `NetworkError`, so it was not part of the default retry set `(httpx.TimeoutException, httpx.NetworkError)` and was never retried.

- Add `httpx.RemoteProtocolError` to `_DEFAULT_RETRY_ON_EXCEPTIONS`, so **both** `http_backoff` and `http_stream_backoff` retry on it.

```python
>>> import httpx
>>> issubclass(httpx.RemoteProtocolError, httpx.NetworkError)
False
>>> from huggingface_hub.utils._http import _DEFAULT_RETRY_ON_EXCEPTIONS
>>> _DEFAULT_RETRY_ON_EXCEPTIONS
(<class 'httpx.TimeoutException'>, <class 'httpx.NetworkError'>, <class 'httpx.RemoteProtocolError'>)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
