### PR TITLE
[HfFileSystem] Harden streaming read reconnects on dropped connections

### DIFF
--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 import threading
+import time
 from collections import deque
 from collections.abc import Iterable, Iterator
 from contextlib import ExitStack
@@ -31,6 +32,13 @@ from .file_download import hf_hub_url, http_get
 from .hf_api import SPECIAL_REFS_REVISION_REGEX, BucketFile, BucketFolder, HfApi, LastCommitInfo, RepoFile, RepoFolder
 from .utils import HFValidationError, hf_raise_for_status, http_backoff, http_stream_backoff, parse_hf_uri
 from .utils.insecure_hashlib import md5
+
+
+# Reconnect attempts (with exponential backoff) for a single streaming `read()` call when the
+# connection drops mid-transfer. Mirrors the defaults used by `http_backoff`.
+_STREAM_READ_MAX_RETRIES = 5
+_STREAM_READ_BASE_WAIT = 1.0  # seconds
+_STREAM_READ_MAX_WAIT = 8.0  # seconds
 
 
 @dataclass
@@ -1287,15 +1295,17 @@ class HfFileSystemStreamFile(fsspec.spec.AbstractBufferedFile):
     def read(self, length: int = -1):
         """Read the remote file.
 
-        If the file is already open, we reuse the connection.
-        Otherwise, open a new connection and read from it.
+        If the file is already open, we reuse the connection. Otherwise, open a new connection.
 
-        If reading the stream fails, we retry with a new connection.
+        If reading the stream fails (e.g. a stale keep-alive connection is dropped mid-transfer),
+        we reconnect and resume from the current position via a Range header, retrying up to
+        `_STREAM_READ_MAX_RETRIES` times with exponential backoff before giving up.
         """
         if self.response is None:
             self._open_connection()
 
-        retried_once = False
+        nb_retries = 0
+        sleep_time = _STREAM_READ_BASE_WAIT
         while True:
             try:
                 if self.response is None or self._stream_iterator is None:
@@ -1304,13 +1314,12 @@ class HfFileSystemStreamFile(fsspec.spec.AbstractBufferedFile):
                 self.loc += len(out)
                 return out
             except Exception:
-                if self.response is not None:
-                    self.response.close()
-                if retried_once:  # Already retried once, give up
+                nb_retries += 1
+                if nb_retries > _STREAM_READ_MAX_RETRIES:
                     raise
-                # First failure, retry with range header
-                self._open_connection()
-                retried_once = True
+                time.sleep(sleep_time)
+                sleep_time = min(_STREAM_READ_MAX_WAIT, sleep_time * 2)
+                self._open_connection()  # reconnect with Range header (also closes the stale one)
 
     def _read_from_stream(self, iterator: Iterator[bytes], length: int = -1) -> bytes:
         """Read up to `length` bytes from stream buffer and stream.
@@ -1361,7 +1370,13 @@ class HfFileSystemStreamFile(fsspec.spec.AbstractBufferedFile):
 
     def _open_connection(self):
         """Open a connection to the remote file."""
+        # Close the previous connection (if any) so stale response context managers don't pile up
+        # in the ExitStack across reconnects.
+        self._exit_stack.close()
+        self._exit_stack = ExitStack()
+
         # reset streaming state
+        self.response = None
         self._stream_buffer.clear()
         self._stream_iterator = None
 


### PR DESCRIPTION
## Summary

Follow-up to #4398, covering the two remaining streaming issues from #4397. When an `HfFileSystem` streaming read (`block_size=0`, used by WebDataset / dataset streaming) hits a connection dropped mid-transfer, `HfFileSystemStreamFile` reconnects and resumes from the current position via a `Range` header. This hardens that reconnect path:

- **Retry budget per `read()`** — replace the single `retried_once` boolean with a counter + exponential backoff (up to 5 attempts). Previously a second drop within the *same* `read()` call raised immediately.
- **No `ExitStack` growth** — `_open_connection()` now closes the previous connection before opening a new one, so stale (already-closed) response context managers no longer pile up in the `ExitStack` until the file is closed.

## Backward compatibility

Fully backward compatible — only internals of `HfFileSystemStreamFile` change. `read()`'s signature and return contract are unchanged; it just retries more before giving up.

## Notes

- Tests are not included yet (reproducing the failure requires simulating a mid-stream connection drop). I'll add them before marking ready for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal streaming-read resilience only; public `read()` contract is unchanged, with slightly longer waits on repeated failures within one call.
> 
> **Overview**
> **Hardens `HfFileSystemStreamFile` when HTTP streaming drops mid-`read()`** (e.g. stale keep-alive), which matters for `block_size=0` / dataset streaming paths.
> 
> Instead of a single reconnect per `read()`, failures now retry up to **5 times** with **exponential backoff** (1s → 8s, aligned with `http_backoff`), each time reopening the GET with a **`Range`** header at the current byte offset.
> 
> **`_open_connection()`** now tears down the previous `ExitStack` before opening a new stream and clears `self.response`, so dead response context managers do not accumulate across reconnects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b04750a94b41ee8ca747b8c2f65c4b33bb557aa. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->