### PR TITLE
Start Spanish (es) documentation translation

### DIFF
--- a/.github/workflows/build_documentation.yaml
+++ b/.github/workflows/build_documentation.yaml
@@ -13,6 +13,6 @@ jobs:
     with:
       commit_sha: ${{ github.sha }}
       package: huggingface_hub
-      languages: cn de fr en hi ko tm
+      languages: cn de es fr en hi ko tm
     secrets:
       hf_token: ${{ secrets.HF_DOC_BUILD_PUSH }}

--- a/.github/workflows/build_pr_documentation.yaml
+++ b/.github/workflows/build_pr_documentation.yaml
@@ -14,4 +14,4 @@ jobs:
       commit_sha: ${{ github.event.pull_request.head.sha }}
       pr_number: ${{ github.event.number }}
       package: huggingface_hub
-      languages: cn de fr en hi ko tm
+      languages: cn de es fr en hi ko tm

--- a/docs/source/es/_toctree.yml
+++ b/docs/source/es/_toctree.yml
@@ -4,3 +4,5 @@
       title: Inicio
     - local: quick-start
       title: Inicio rápido
+    - local: installation
+      title: Instalación

--- a/docs/source/es/_toctree.yml
+++ b/docs/source/es/_toctree.yml
@@ -1,0 +1,6 @@
+- title: "Empezar"
+  sections:
+    - local: index
+      title: Inicio
+    - local: quick-start
+      title: Inicio rápido

--- a/docs/source/es/index.md
+++ b/docs/source/es/index.md
@@ -1,0 +1,60 @@
+<!--⚠️ Note that this file is in Markdown but contains specific syntax for our doc-builder (similar to MDX) that may not be
+rendered properly in your Markdown viewer.
+-->
+
+# 🤗 Librería cliente del Hub
+
+La librería `huggingface_hub` te permite interactuar con el [Hugging Face
+Hub](https://hf.co), una plataforma de aprendizaje automático para creadores y
+colaboradores. Descubre modelos y datasets preentrenados para tus proyectos o prueba los
+cientos de aplicaciones de aprendizaje automático alojadas en el Hub. También puedes crear
+y compartir tus propios modelos y datasets con la comunidad. La librería `huggingface_hub`
+ofrece una forma sencilla de hacer todo esto con Python.
+
+Lee la [guía de inicio rápido](quick-start) para empezar a usar la librería
+`huggingface_hub`. Aprenderás a descargar archivos del Hub, crear un repositorio y subir
+archivos al Hub. Sigue leyendo para saber más sobre cómo gestionar tus repositorios en el
+🤗 Hub, cómo participar en discusiones o incluso cómo ejecutar inferencia.
+
+<div class="mt-10">
+  <div class="w-full flex flex-col space-y-4 md:space-y-0 md:grid md:grid-cols-2 md:gap-y-4 md:gap-x-5">
+
+    <a class="!no-underline border dark:border-gray-700 p-5 rounded-lg shadow hover:shadow-lg" href="./guides/overview">
+      <div class="w-full text-center bg-gradient-to-br from-indigo-400 to-indigo-500 rounded-lg py-1.5 font-semibold mb-5 text-white text-lg leading-relaxed">Guías prácticas</div>
+      <p class="text-gray-700">Guías prácticas para ayudarte a alcanzar un objetivo concreto. Échales un vistazo para aprender a usar huggingface_hub y resolver problemas del mundo real.</p>
+    </a>
+
+    <a class="!no-underline border dark:border-gray-700 p-5 rounded-lg shadow hover:shadow-lg" href="./package_reference/overview">
+      <div class="w-full text-center bg-gradient-to-br from-purple-400 to-purple-500 rounded-lg py-1.5 font-semibold mb-5 text-white text-lg leading-relaxed">Referencia</div>
+      <p class="text-gray-700">Descripción técnica y exhaustiva de las clases y métodos de huggingface_hub.</p>
+    </a>
+
+    <a class="!no-underline border dark:border-gray-700 p-5 rounded-lg shadow hover:shadow-lg" href="./concepts/git_vs_http">
+      <div class="w-full text-center bg-gradient-to-br from-pink-400 to-pink-500 rounded-lg py-1.5 font-semibold mb-5 text-white text-lg leading-relaxed">Guías conceptuales</div>
+      <p class="text-gray-700">Explicaciones de alto nivel para entender mejor la filosofía de huggingface_hub.</p>
+    </a>
+
+  </div>
+</div>
+
+<!--
+<a class="!no-underline border dark:border-gray-700 p-5 rounded-lg shadow hover:shadow-lg" href="./tutorials/overview"
+  ><div class="w-full text-center bg-gradient-to-br from-blue-400 to-blue-500 rounded-lg py-1.5 font-semibold mb-5 text-white text-lg leading-relaxed">Tutorials</div>
+  <p class="text-gray-700">Learn the basics and become familiar with using huggingface_hub to programmatically interact with the 🤗 Hub!</p>
+</a> -->
+
+## Contribuir
+
+¡Todas las contribuciones a `huggingface_hub` son bienvenidas y se valoran por igual! 🤗
+Además de añadir o corregir issues existentes en el código, también puedes ayudar a mejorar
+la documentación asegurándote de que sea precisa y esté actualizada, ayudar a responder
+preguntas en los issues y proponer nuevas funcionalidades que creas que mejorarían la
+librería. Échale un vistazo a la [guía de
+contribución](https://github.com/huggingface/huggingface_hub/blob/main/CONTRIBUTING.md)
+para saber más sobre cómo enviar un nuevo issue o solicitud de funcionalidad, cómo enviar un
+pull request y cómo probar tus contribuciones para asegurarte de que todo funciona como se
+espera.
+
+Los colaboradores también deben respetar nuestro [código de
+conducta](https://github.com/huggingface/huggingface_hub/blob/main/CODE_OF_CONDUCT.md) para
+crear un espacio de colaboración inclusivo y acogedor para todos.

--- a/docs/source/es/installation.md
+++ b/docs/source/es/installation.md
@@ -1,0 +1,173 @@
+<!--⚠️ Note that this file is in Markdown but contains specific syntax for our doc-builder (similar to MDX) that may not be
+rendered properly in your Markdown viewer.
+-->
+
+# Instalación
+
+Antes de empezar, tendrás que preparar tu entorno instalando los paquetes adecuados.
+
+`huggingface_hub` se prueba en **Python 3.10+**.
+
+## Instalar con pip
+
+Es muy recomendable instalar `huggingface_hub` en un [entorno virtual](https://docs.python.org/3/library/venv.html).
+Si no estás familiarizado con los entornos virtuales de Python, échale un vistazo a esta [guía](https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/).
+Un entorno virtual facilita gestionar distintos proyectos y evita problemas de compatibilidad entre dependencias.
+
+Empieza creando un entorno virtual en el directorio de tu proyecto:
+
+```bash
+python -m venv .venv
+```
+
+Activa el entorno virtual. En Linux y macOS:
+
+```bash
+source .venv/bin/activate
+```
+
+Activa el entorno virtual en Windows:
+
+```bash
+.venv/Scripts/activate
+```
+
+Ahora ya puedes instalar `huggingface_hub` [desde el registro de PyPi](https://pypi.org/project/huggingface-hub/):
+
+```bash
+pip install --upgrade huggingface_hub
+```
+
+Una vez hecho, [comprueba que la instalación](#comprobar-la-instalación) funciona correctamente.
+
+### Instalar dependencias opcionales
+
+Algunas dependencias de `huggingface_hub` son [opcionales](https://setuptools.pypa.io/en/latest/userguide/dependency_management.html#optional-dependencies) porque no son necesarias para ejecutar las funcionalidades principales de `huggingface_hub`. Sin embargo, algunas funcionalidades de `huggingface_hub` pueden no estar disponibles si no se instalan las dependencias opcionales.
+
+Puedes instalar las dependencias opcionales con `pip`:
+```bash
+# Instala las dependencias para las funcionalidades específicas de torch y de MCP.
+pip install 'huggingface_hub[mcp,torch]'
+```
+
+Esta es la lista de dependencias opcionales de `huggingface_hub`:
+- `fastai`, `torch`: dependencias para ejecutar funcionalidades específicas de cada framework.
+- `dev`: dependencias para contribuir a la librería. Incluye `testing` (para ejecutar los tests), `typing` (para ejecutar el comprobador de tipos) y `quality` (para ejecutar los linters).
+
+
+
+### Instalar desde el código fuente
+
+En algunos casos resulta interesante instalar `huggingface_hub` directamente desde el código fuente.
+Esto te permite usar la versión `main` más reciente en lugar de la última versión estable.
+La versión `main` es útil para estar al día de los últimos desarrollos, por ejemplo
+si un error se ha corregido desde la última versión oficial pero todavía no se ha publicado una nueva versión.
+
+Sin embargo, esto significa que la versión `main` no siempre es estable. Nos esforzamos por mantener la
+versión `main` operativa, y la mayoría de los problemas suelen resolverse
+en unas pocas horas o en un día. Si te encuentras con un problema, abre una Issue para que podamos
+corregirlo aún antes.
+
+```bash
+pip install git+https://github.com/huggingface/huggingface_hub
+```
+
+Al instalar desde el código fuente, también puedes indicar una rama concreta. Esto es útil si
+quieres probar una nueva funcionalidad o una corrección que aún no se ha fusionado:
+
+```bash
+pip install git+https://github.com/huggingface/huggingface_hub@my-feature-branch
+```
+
+Una vez hecho, [comprueba que la instalación](#comprobar-la-instalación) funciona correctamente.
+
+### Instalación editable
+
+Instalar desde el código fuente te permite configurar una [instalación editable](https://pip.pypa.io/en/stable/topics/local-project-installs/#editable-installs).
+Es una instalación más avanzada, pensada para cuando vas a contribuir a `huggingface_hub`
+y necesitas probar cambios en el código. Necesitas clonar una copia local de `huggingface_hub`
+en tu máquina.
+
+```bash
+# Primero, clona el repositorio en local
+git clone https://github.com/huggingface/huggingface_hub.git
+
+# Después, instala con el flag -e
+cd huggingface_hub
+pip install -e .
+```
+
+Estos comandos enlazan la carpeta a la que clonaste el repositorio con las rutas de tus librerías de Python.
+Ahora Python buscará dentro de la carpeta que clonaste además de en las rutas habituales de librerías.
+Por ejemplo, si tus paquetes de Python se instalan normalmente en `./.venv/lib/python3.13/site-packages/`,
+Python también buscará en la carpeta a la que clonaste `./huggingface_hub/`.
+
+## Instalar la CLI de Hugging Face
+
+Usa nuestros instaladores de una línea para configurar la CLI `hf` sin tocar tu entorno de Python:
+
+En macOS y Linux:
+
+```bash
+curl -LsSf https://hf.co/cli/install.sh | bash
+```
+
+En Windows:
+
+```powershell
+powershell -ExecutionPolicy ByPass -c "irm https://hf.co/cli/install.ps1 | iex"
+```
+
+Para actualizar una instalación existente, ejecuta `hf update`: detecta cómo se instaló `hf` (instalador independiente, Homebrew o pip) y ejecuta el comando correspondiente.
+
+## Instalar con conda
+
+Si te resulta más familiar, puedes instalar `huggingface_hub` usando el [canal conda-forge](https://anaconda.org/conda-forge/huggingface_hub):
+
+
+```bash
+conda install -c conda-forge huggingface_hub
+```
+
+Una vez hecho, [comprueba que la instalación](#comprobar-la-instalación) funciona correctamente.
+
+## Comprobar la instalación
+
+Una vez instalado, comprueba que `huggingface_hub` funciona correctamente ejecutando el siguiente comando:
+
+```bash
+python -c "from huggingface_hub import model_info; print(model_info('gpt2'))"
+```
+
+Este comando obtendrá del Hub información sobre el modelo [gpt2](https://huggingface.co/gpt2).
+La salida debería tener este aspecto:
+
+```text
+Model Name: gpt2
+Tags: ['pytorch', 'tf', 'jax', 'tflite', 'rust', 'safetensors', 'gpt2', 'text-generation', 'en', 'doi:10.57967/hf/0039', 'transformers', 'exbert', 'license:mit', 'has_space']
+Task: text-generation
+```
+
+## Limitaciones en Windows
+
+Con nuestro objetivo de democratizar el buen ML en todas partes, construimos `huggingface_hub` para que sea una
+librería multiplataforma y, en particular, para que funcione correctamente tanto en sistemas basados en Unix como en
+Windows. Sin embargo, hay algunos casos en los que `huggingface_hub` tiene ciertas limitaciones al
+ejecutarse en Windows. Esta es una lista exhaustiva de los problemas conocidos. Háznoslo saber si te
+encuentras con algún problema no documentado abriendo [una issue en Github](https://github.com/huggingface/huggingface_hub/issues/new/choose).
+
+- El sistema de caché de `huggingface_hub` se basa en enlaces simbólicos para cachear de forma eficiente los archivos descargados
+del Hub. En Windows, debes activar el modo desarrollador o ejecutar tu script como administrador para
+habilitar los enlaces simbólicos. Si no están activados, el sistema de caché sigue funcionando, pero de forma no optimizada.
+Lee la sección [limitaciones de la caché](./guides/manage-cache#limitations) para más detalles.
+- Las rutas de archivo en el Hub pueden tener caracteres especiales (por ejemplo, `"path/to?/my/file"`). Windows es
+más restrictivo con los [caracteres especiales](https://learn.microsoft.com/en-us/windows/win32/intl/character-sets-used-in-file-names),
+lo que hace imposible descargar esos archivos en Windows. Por suerte es un caso poco frecuente.
+Ponte en contacto con el propietario del repositorio si crees que es un error, o con nosotros para encontrar
+una solución.
+
+
+## Próximos pasos
+
+Una vez `huggingface_hub` está correctamente instalado en tu máquina, quizá quieras
+[configurar las variables de entorno](package_reference/environment_variables) o [consultar alguna de nuestras guías](guides/overview) para empezar.

--- a/docs/source/es/quick-start.md
+++ b/docs/source/es/quick-start.md
@@ -1,0 +1,211 @@
+<!--⚠️ Note that this file is in Markdown but contains specific syntax for our doc-builder (similar to MDX) that may not be
+rendered properly in your Markdown viewer.
+-->
+
+# Inicio rápido
+
+El [Hugging Face Hub](https://huggingface.co/) es el lugar de referencia para compartir
+modelos de aprendizaje automático, demos, datasets y métricas. La librería `huggingface_hub`
+te ayuda a interactuar con el Hub sin salir de tu entorno de desarrollo. Puedes crear y
+gestionar repositorios fácilmente, descargar y subir archivos, y obtener metadatos útiles de
+modelos y datasets del Hub.
+
+## Instalación
+
+Para empezar, instala la librería `huggingface_hub`:
+
+```bash
+pip install --upgrade huggingface_hub
+```
+
+Para más detalles, consulta la guía de [instalación](installation).
+
+> [!TIP]
+> `huggingface_hub` también incluye una [CLI `hf`](./guides/cli) que te permite interactuar con el Hub directamente desde la terminal.
+> Si usas agentes de IA (Claude Code, Codex, Cursor, ...), instala la Skill para que tu agente pueda usar la CLI:
+> ```bash
+> # para Codex, Cursor, OpenCode, Pi y otros agentes que cargan skills desde `.agents/skills`
+> hf skills add
+> # incluye lo anterior + Claude Code
+> hf skills add --claude
+> ```
+> Consulta la guía [Hugging Face CLI for AI Agents](https://huggingface.co/docs/hub/agents-cli) para más detalles.
+
+## Descargar archivos
+
+Los repositorios del Hub están versionados con git, y los usuarios pueden descargar un solo
+archivo o el repositorio completo. Puedes usar la función [`hf_hub_download`] para descargar
+archivos. Esta función descarga y guarda en caché un archivo en tu disco local. La próxima
+vez que necesites ese archivo, se cargará desde la caché, así que no necesitas volver a
+descargarlo.
+
+Necesitarás el id del repositorio y el nombre del archivo que quieras descargar. Por ejemplo,
+para descargar el archivo de configuración del modelo
+[Pegasus](https://huggingface.co/google/pegasus-xsum):
+
+```py
+>>> from huggingface_hub import hf_hub_download
+>>> hf_hub_download(repo_id="google/pegasus-xsum", filename="config.json")
+```
+
+Para descargar una versión concreta del archivo, usa el parámetro `revision` para indicar el
+nombre de la rama, la etiqueta o el hash del commit. Si decides usar el hash del commit, debe
+ser el hash completo en lugar del hash corto de 7 caracteres:
+
+```py
+>>> from huggingface_hub import hf_hub_download
+>>> hf_hub_download(
+...     repo_id="google/pegasus-xsum",
+...     filename="config.json",
+...     revision="4d33b01d79672f27f001f6abade33f22d993b151"
+... )
+```
+
+Para más detalles y opciones, consulta la referencia de la API de [`hf_hub_download`].
+
+<a id="login"></a> <!-- backward compatible anchor -->
+
+## Autenticación
+
+En muchos casos, debes estar autenticado con una cuenta de Hugging Face para interactuar con
+el Hub: descargar repositorios privados, subir archivos, crear PRs, ...
+[Crea una cuenta](https://huggingface.co/join) si todavía no tienes una.
+
+### Comando de inicio de sesión
+
+La forma más sencilla de autenticarte es con el comando [`login`]:
+
+```bash
+hf auth login
+```
+
+Si ya has iniciado sesión, el comando volverá de inmediato. Para forzar un nuevo inicio de
+sesión, usa `hf auth login --force`. Si no has iniciado sesión, se te pedirá que lo hagas con
+tu navegador: abre la URL que se muestra, introduce el código corto, aprueba la solicitud y se
+obtendrá un token de acceso que se guardará en tu directorio `HF_HOME` (por defecto
+`~/.cache/huggingface/token`). El token caduca al cabo de un tiempo, pero se renueva
+automáticamente mientras lo sigas usando. Cualquier script o librería que interactúe con el
+Hub usará este token al enviar peticiones. Como alternativa, puedes pegar un [token de acceso
+de usuario](https://huggingface.co/docs/hub/security-tokens) generado desde tu [página de
+Ajustes](https://huggingface.co/settings/tokens).
+
+> [!TIP]
+> Los tokens de acceso de usuario pueden tener permisos de `read` (lectura) o `write` (escritura). Asegúrate de tener un token de tipo `write` si quieres crear o editar un repositorio. En caso contrario, lo mejor es generar un token de tipo `read` para reducir el riesgo si tu token se filtra por accidente.
+
+Como alternativa, puedes iniciar sesión por código usando [`login`] en un notebook o un script:
+
+```py
+>>> from huggingface_hub import login
+>>> login()
+```
+
+Solo puedes tener sesión iniciada en una cuenta a la vez. Iniciar sesión en una cuenta nueva
+te cerrará automáticamente la sesión de la anterior. Para saber cuál es tu cuenta activa,
+ejecuta el comando `hf auth whoami`.
+
+> [!WARNING]
+> Una vez has iniciado sesión, todas las peticiones al Hub (incluso los métodos que no requieren autenticación) usarán tu token de acceso por defecto. Si quieres desactivar el uso implícito de tu token, debes definir la variable de entorno `HF_HUB_DISABLE_IMPLICIT_TOKEN=1` (consulta la [referencia](../package_reference/environment_variables#hfhubdisableimplicittoken)).
+
+### Gestionar varios tokens en local
+
+Puedes guardar varios tokens en tu máquina simplemente iniciando sesión con el comando
+[`login`] con cada token. Si necesitas cambiar entre estos tokens en local, puedes usar el
+comando [`auth switch`]:
+
+```bash
+hf auth switch
+```
+
+Este comando te pedirá que selecciones un token por su nombre de una lista de tokens
+guardados. Una vez seleccionado, el token elegido pasa a ser el token _activo_ y se usará en
+todas las interacciones con el Hub.
+
+
+Puedes listar todos los tokens de acceso disponibles en tu máquina con `hf auth list`.
+
+### Variable de entorno
+
+La variable de entorno `HF_TOKEN` también puede usarse para autenticarte. Esto resulta
+especialmente útil en un Space, donde puedes definir `HF_TOKEN` como un [secret del
+Space](https://huggingface.co/docs/hub/spaces-overview#managing-secrets).
+
+> [!TIP]
+> **NUEVO:** Google Colaboratory te permite definir [claves privadas](https://twitter.com/GoogleColab/status/1719798406195867814) para tus notebooks. Define un secret `HF_TOKEN` para autenticarte automáticamente.
+
+La autenticación mediante una variable de entorno o un secret tiene prioridad sobre el token
+guardado en tu máquina.
+
+### Parámetros de los métodos
+
+Por último, también es posible autenticarte pasando tu token a cualquier método que acepte
+`token` como parámetro.
+
+```
+from huggingface_hub import whoami
+
+user = whoami(token=...)
+```
+
+En general esto se desaconseja, salvo en un entorno donde no quieras guardar tu token de forma
+permanente o si necesitas manejar varios tokens a la vez.
+
+> [!WARNING]
+> Ten cuidado al pasar tokens como parámetro. Siempre es mejor práctica cargar el token desde un almacén seguro en lugar de escribirlo directamente en tu código o notebook. Los tokens escritos en el código presentan un riesgo importante de filtración si compartes tu código por accidente.
+
+## Crear un repositorio
+
+Una vez te has registrado e iniciado sesión, crea un repositorio con la función
+[`create_repo`]:
+
+```py
+>>> from huggingface_hub import HfApi
+>>> api = HfApi()
+>>> api.create_repo(repo_id="super-cool-model")
+```
+
+Si quieres que tu repositorio sea privado:
+
+```py
+>>> from huggingface_hub import HfApi
+>>> api = HfApi()
+>>> api.create_repo(repo_id="super-cool-model", private=True)
+```
+
+Los repositorios privados no serán visibles para nadie excepto para ti.
+
+> [!TIP]
+> Para crear un repositorio o subir contenido al Hub, debes proporcionar un token de acceso de usuario que tenga el permiso `write`. Puedes elegir el permiso al crear el token en tu [página de Ajustes](https://huggingface.co/settings/tokens).
+
+## Subir archivos
+
+Usa la función [`upload_file`] para añadir un archivo a tu repositorio recién creado. Debes
+indicar:
+
+1. La ruta del archivo que vas a subir.
+2. La ruta del archivo en el repositorio.
+3. El id del repositorio donde quieres añadir el archivo.
+
+```py
+>>> from huggingface_hub import HfApi
+>>> api = HfApi()
+>>> api.upload_file(
+...     path_or_fileobj="/home/lysandre/dummy-test/README.md",
+...     path_in_repo="README.md",
+...     repo_id="lysandre/test-model",
+... )
+```
+
+Para subir más de un archivo a la vez, échale un vistazo a la guía de [Subida](./guides/upload),
+que te presentará varios métodos para subir archivos (con o sin git).
+
+## Próximos pasos
+
+La librería `huggingface_hub` ofrece una forma sencilla de interactuar con el Hub usando
+Python. Para saber más sobre cómo gestionar tus archivos y repositorios en el Hub, te
+recomendamos leer nuestras [guías prácticas](./guides/overview) para:
+
+- [Gestionar tu repositorio](./guides/repository).
+- [Descargar](./guides/download) archivos del Hub.
+- [Subir](./guides/upload) archivos al Hub.
+- [Buscar en el Hub](./guides/search) el modelo o dataset que quieras.
+- [Ejecutar inferencia](./guides/inference) en varios servicios para modelos alojados en el Hugging Face Hub.


### PR DESCRIPTION
This PR starts the Spanish (es) translation of the documentation, as part of the community translation effort (#1700).

It adds the "Get started" section:
- `docs/source/es/index.md`
- `docs/source/es/quick-start.md`
- `docs/source/es/_toctree.yml`

and registers `es` in the documentation build workflows.

I am a native Spanish speaker. I kept all code blocks, links, doc-builder syntax and admonitions unchanged, translating only the prose. More pages (installation, guides, ...) can follow in later PRs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and workflow language-list changes only; no library or runtime behavior is modified.
> 
> **Overview**
> Adds **Spanish (`es`)** as a documentation locale and wires it into CI so main and PR doc builds include `es` alongside existing languages.
> 
> Introduces the **“Empezar”** section under `docs/source/es/`: landing page (`index.md`), **Inicio rápido** (`quick-start.md`), **Instalación** (`installation.md`), and `_toctree.yml` navigation. Prose is translated; code blocks, links, doc-builder markup, and admonitions stay aligned with the English sources. Several “next steps” links still point at guides/package sections that are not translated yet in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66b72d8b55bc241aecce76e94d492f1c9bdffd99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->