### PR TITLE
Fix IndexError in filter_repo_objects on an empty allow/ignore pattern

### DIFF
--- a/src/huggingface_hub/utils/_paths.py
+++ b/src/huggingface_hub/utils/_paths.py
@@ -139,6 +139,6 @@ def filter_repo_objects(
 
 
 def _add_wildcard_to_directories(pattern: str) -> str:
-    if pattern[-1] == "/":
+    if pattern.endswith("/"):
         return pattern + "*"
     return pattern

--- a/tests/test_utils_paths.py
+++ b/tests/test_utils_paths.py
@@ -95,6 +95,19 @@ class TestPathsUtils(unittest.TestCase):
             allow_patterns=["path/to/"],
         )
 
+    def test_filter_object_with_empty_pattern(self) -> None:
+        # An empty pattern must not raise: `_add_wildcard_to_directories("")` indexed `pattern[-1]`.
+        self._check(
+            items=["file.txt", "lfs.bin"],
+            expected_items=[],
+            allow_patterns=[""],
+        )
+        self._check(
+            items=["file.txt", "lfs.bin"],
+            expected_items=["file.txt", "lfs.bin"],
+            ignore_patterns=[""],
+        )
+
     def _check(
         self,
         items: list[Any],


### PR DESCRIPTION
## Describe your change

`_add_wildcard_to_directories` indexes `pattern[-1]`, which raises `IndexError: string index out of range`
on an empty-string pattern. `filter_repo_objects` passes every `allow_patterns` / `ignore_patterns` entry
through that helper, so an empty pattern crashes the public function:

```python
from huggingface_hub.utils import filter_repo_objects

list(filter_repo_objects(["a.txt"], allow_patterns=[""]))
# IndexError: string index out of range
```

The fix replaces `pattern[-1] == "/"` with `pattern.endswith("/")`, which is `False` for `""` and leaves
the existing directory-wildcard behavior unchanged. After it, an empty `allow_patterns` matches nothing and
an empty `ignore_patterns` ignores nothing — no exception.

A regression test is added in `tests/test_utils_paths.py`.

- [ ] Did you read the [contributor guideline](https://github.com/huggingface/huggingface_hub/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure to update the documentation with your changes? (n/a — behavior fix)
- [x] Did you write any new necessary tests?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tiny behavior-preserving guard in path pattern normalization with targeted tests; no auth, security, or data-path changes.
> 
> **Overview**
> Fixes a crash in **`filter_repo_objects`** when **`allow_patterns`** or **`ignore_patterns`** includes an empty string.
> 
> **`_add_wildcard_to_directories`** no longer uses **`pattern[-1]`** (which raised **`IndexError`** on **`""`**). It now uses **`pattern.endswith("/")`**, so directory patterns still get a trailing **`*`** unchanged. Empty allow patterns match nothing; empty ignore patterns ignore nothing.
> 
> Regression coverage is added in **`tests/test_utils_paths.py`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cf38ff6ade4bf4e5144008503000f59e485e7e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->