### PR TITLE
[Jobs] Paginate list_jobs and add --limit to `hf jobs ps`

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -2022,6 +2022,16 @@ Use `--status` and `--label` in `hf jobs ps` to filter Jobs. `--status` takes on
 >>> hf jobs ps --status running --label env=prod --label team=ml
 ```
 
+By default `hf jobs ps` displays at most 100 Jobs to avoid bloating the terminal. Use `--limit` to change this, or `--limit 0` to show all of them:
+
+```bash
+# Show up to 500 Jobs
+>>> hf jobs ps -a --limit 500
+
+# Show all Jobs (no limit)
+>>> hf jobs ps -a --limit 0
+```
+
 <Tip warning={true}>
 
 `-f`/`--filter` is deprecated in favor of `--status` and `--label`. Matching is exact: glob patterns (`data-*`) and negation (`key!=value`) are not supported, and filtering by `id`, `image` or `command` is not available.

--- a/docs/source/en/guides/jobs.md
+++ b/docs/source/en/guides/jobs.md
@@ -109,11 +109,14 @@ Jobs run in the background. The next section guides you through [`inspect_job`] 
 ## Check Job status
 
 ```python
-# List your jobs
+# List your jobs (results are paginated and returned as an iterator)
 >>> from huggingface_hub import list_jobs
 >>> jobs = list_jobs()
->>> jobs[0]
+>>> next(iter(jobs))
 JobInfo(id='687f911eaea852de79c4a50a', created_at=datetime.datetime(2025, 7, 22, 13, 24, 46, 909000, tzinfo=datetime.timezone.utc), docker_image='python:3.12', space_id=None, command=['python', '-c', "print('Hello from the cloud!')"], arguments=[], environment={}, secrets={}, flavor='cpu-basic', status=JobStatus(stage='COMPLETED', message=None), owner=JobOwner(id='5e9ecfc04957053f60648a3e', name='lhoestq'), endpoint='https://huggingface.co', url='https://huggingface.co/jobs/lhoestq/687f911eaea852de79c4a50a')
+
+# Materialize the iterator into a list
+>>> all_jobs = list(list_jobs())
 
 # List your running jobs
 >>> running_jobs = list_jobs(status="RUNNING")

--- a/docs/source/en/guides/jobs.md
+++ b/docs/source/en/guides/jobs.md
@@ -116,7 +116,7 @@ Jobs run in the background. The next section guides you through [`inspect_job`] 
 JobInfo(id='687f911eaea852de79c4a50a', created_at=datetime.datetime(2025, 7, 22, 13, 24, 46, 909000, tzinfo=datetime.timezone.utc), docker_image='python:3.12', space_id=None, command=['python', '-c', "print('Hello from the cloud!')"], arguments=[], environment={}, secrets={}, flavor='cpu-basic', status=JobStatus(stage='COMPLETED', message=None), owner=JobOwner(id='5e9ecfc04957053f60648a3e', name='lhoestq'), endpoint='https://huggingface.co', url='https://huggingface.co/jobs/lhoestq/687f911eaea852de79c4a50a')
 
 # Materialize the iterator into a list
->>> all_jobs = list(list_jobs())
+>>> all_jobs = [job for job in list_jobs()]
 
 # List your running jobs
 >>> running_jobs = list_jobs(status="RUNNING")

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -2303,7 +2303,7 @@ $ hf jobs ps [OPTIONS]
 * `-a, --all`: Show all Jobs (default shows running and scheduling). Cannot be combined with --status.
 * `--status [COMPLETED|CANCELED|ERROR|DELETED|SCHEDULING|RUNNING]`: Only show Jobs with the given status. Comma-separated or repeated, e.g. `--status running,scheduling`.
 * `-l, --label TEXT`: Only show Jobs with the given `key=value` label. Repeat to require several labels, e.g. `--label env=prod --label team=ml`.
-* `--limit INTEGER`: Maximum number of Jobs to display. Set to 0 to show all (no limit). Defaults to 100.  [default: 100]
+* `--limit INTEGER`: Maximum number of Jobs to display. Set to 0 to show all (no limit).  [default: 100]
 * `--namespace TEXT`: The namespace where the job will be running. Defaults to the current user's namespace.
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `-f, --filter TEXT`: (Deprecated) Use `--status` and `--label` instead.

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -2303,6 +2303,7 @@ $ hf jobs ps [OPTIONS]
 * `-a, --all`: Show all Jobs (default shows running and scheduling). Cannot be combined with --status.
 * `--status [COMPLETED|CANCELED|ERROR|DELETED|SCHEDULING|RUNNING]`: Only show Jobs with the given status. Comma-separated or repeated, e.g. `--status running,scheduling`.
 * `-l, --label TEXT`: Only show Jobs with the given `key=value` label. Repeat to require several labels, e.g. `--label env=prod --label team=ml`.
+* `--limit INTEGER`: Maximum number of Jobs to display. Set to 0 to show all (no limit). Defaults to 100.  [default: 100]
 * `--namespace TEXT`: The namespace where the job will be running. Defaults to the current user's namespace.
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `-f, --filter TEXT`: (Deprecated) Use `--status` and `--label` instead.

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -570,7 +570,7 @@ def jobs_ps(
         int,
         typer.Option(
             "--limit",
-            help="Maximum number of Jobs to display. Set to 0 to show all (no limit). Defaults to 100.",
+            help="Maximum number of Jobs to display. Set to 0 to show all (no limit).",
         ),
     ] = 100,
     namespace: NamespaceOpt = None,

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -64,6 +64,7 @@ Usage:
 
 """
 
+import itertools
 import multiprocessing
 import multiprocessing.pool
 import shutil
@@ -565,6 +566,13 @@ def jobs_ps(
             help="Only show Jobs with the given `key=value` label. Repeat to require several labels, e.g. `--label env=prod --label team=ml`.",
         ),
     ] = None,
+    limit: Annotated[
+        int,
+        typer.Option(
+            "--limit",
+            help="Maximum number of Jobs to display. Set to 0 to show all (no limit). Defaults to 100.",
+        ),
+    ] = 100,
     namespace: NamespaceOpt = None,
     token: TokenOpt = None,
     filter: Annotated[
@@ -613,7 +621,17 @@ def jobs_ps(
         key, value = item.split("=")
         labels[key] = value
 
-    jobs = api.list_jobs(namespace=namespace, status=server_statuses, labels=labels or None)
+    jobs_iter = api.list_jobs(namespace=namespace, status=server_statuses, labels=labels or None)
+
+    # Apply the display limit. Fetch one extra Job to detect (and warn about) truncation.
+    truncated = False
+    if limit > 0:
+        jobs = list(itertools.islice(jobs_iter, limit + 1))
+        if len(jobs) > limit:
+            truncated = True
+            jobs = jobs[:limit]
+    else:
+        jobs = list(jobs_iter)
 
     # Build display items. Augment the raw api dict with curated, table-friendly columns.
     job_items: list[dict[str, Any]] = []
@@ -634,6 +652,8 @@ def jobs_ps(
         headers=["job_id", "image/space", "command", "created", "status", "runtime"],
         id_key="job_id",
     )
+    if truncated:
+        out.hint(f"Output truncated to {limit} Jobs. Use `--limit 0` to show all (or `--limit N`).")
     if not job_items:
         if raw_statuses or labels:
             filters_msg = ", ".join(

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -12023,9 +12023,12 @@ class HfApi:
         timeout: int | None = None,
         namespace: str | None = None,
         token: bool | str | None = None,
-    ) -> list[JobInfo]:
+    ) -> Iterable[JobInfo]:
         """
         List compute Jobs on Hugging Face infrastructure.
+
+        Results are paginated and returned as an iterator: the Hub is queried page by page as you iterate over the
+        result. To get a list, wrap the result in `list(...)`.
 
         Args:
             status (`JobStage`, `str` or `list`, *optional*):
@@ -12045,6 +12048,9 @@ class HfApi:
                 A valid user access token. If not provided, the locally saved token will be used, which is the
                 recommended authentication method. Set to `False` to disable authentication.
                 Refer to: https://huggingface.co/docs/huggingface_hub/quick-start#authentication.
+
+        Returns:
+            `Iterable[JobInfo]`: an iterable of [`JobInfo`] objects.
         """
         if namespace is None:
             namespace = whoami(token=token)["name"]
@@ -12054,14 +12060,24 @@ class HfApi:
             params.extend(("stage", (s.value if isinstance(s, JobStage) else str(s)).upper()) for s in statuses)
         if labels is not None:
             params.extend(("label", f"{key}={value}") for key, value in labels.items())
+
+        headers = self._build_hf_headers(token=token)
         response = get_session().get(
             f"{self.endpoint}/api/jobs/{namespace}",
-            headers=self._build_hf_headers(token=token),
+            headers=headers,
             params=params or None,
             timeout=timeout,
         )
         hf_raise_for_status(response)
-        return [JobInfo(**job_info, endpoint=self.endpoint) for job_info in response.json()]
+        yield from (JobInfo(**job_info, endpoint=self.endpoint) for job_info in response.json())
+
+        # Follow pagination. The "next" link (if any) already contains the query params for the next page.
+        next_page = response.links.get("next", {}).get("url")
+        while next_page is not None:
+            response = http_backoff("GET", next_page, headers=headers, timeout=timeout)
+            hf_raise_for_status(response)
+            yield from (JobInfo(**job_info, endpoint=self.endpoint) for job_info in response.json())
+            next_page = response.links.get("next", {}).get("url")
 
     def list_jobs_hardware(self, token: bool | str | None = None) -> list[JobHardwareInfo]:
         """

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -12027,9 +12027,6 @@ class HfApi:
         """
         List compute Jobs on Hugging Face infrastructure.
 
-        Results are paginated and returned as an iterator: the Hub is queried page by page as you iterate over the
-        result. To get a list, wrap the result in `list(...)`.
-
         Args:
             status (`JobStage`, `str` or `list`, *optional*):
                 Only return Jobs with the given status(es), e.g. `"RUNNING"` or `[JobStage.RUNNING, JobStage.SCHEDULING]`.

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -12058,23 +12058,10 @@ class HfApi:
         if labels is not None:
             params.extend(("label", f"{key}={value}") for key, value in labels.items())
 
+        path = f"{self.endpoint}/api/jobs/{namespace}"
         headers = self._build_hf_headers(token=token)
-        response = get_session().get(
-            f"{self.endpoint}/api/jobs/{namespace}",
-            headers=headers,
-            params=params or None,
-            timeout=timeout,
-        )
-        hf_raise_for_status(response)
-        yield from (JobInfo(**job_info, endpoint=self.endpoint) for job_info in response.json())
-
-        # Follow pagination. The "next" link (if any) already contains the query params for the next page.
-        next_page = response.links.get("next", {}).get("url")
-        while next_page is not None:
-            response = http_backoff("GET", next_page, headers=headers, timeout=timeout)
-            hf_raise_for_status(response)
-            yield from (JobInfo(**job_info, endpoint=self.endpoint) for job_info in response.json())
-            next_page = response.links.get("next", {}).get("url")
+        for job_info in paginate(path, params=params, headers=headers, timeout=timeout):
+            yield JobInfo(**job_info, endpoint=self.endpoint)
 
     def list_jobs_hardware(self, token: bool | str | None = None) -> list[JobHardwareInfo]:
         """

--- a/src/huggingface_hub/utils/_pagination.py
+++ b/src/huggingface_hub/utils/_pagination.py
@@ -14,6 +14,7 @@
 """Contains utilities to handle pagination on Huggingface Hub."""
 
 from collections.abc import Iterable
+from typing import Any
 
 import httpx
 
@@ -23,7 +24,7 @@ from . import get_session, hf_raise_for_status, http_backoff, logging
 logger = logging.get_logger(__name__)
 
 
-def paginate(path: str, params: dict, headers: dict) -> Iterable:
+def paginate(path: str, params: dict | list[tuple[str, Any]], headers: dict, timeout: float | None = None) -> Iterable:
     """Fetch a list of models/datasets/spaces and paginate through results.
 
     This is using the same "Link" header format as GitHub.
@@ -32,7 +33,7 @@ def paginate(path: str, params: dict, headers: dict) -> Iterable:
     - https://docs.github.com/en/rest/guides/traversing-with-pagination#link-header
     """
     session = get_session()
-    r = session.get(path, params=params, headers=headers)
+    r = session.get(path, params=params, headers=headers, timeout=timeout)
     hf_raise_for_status(r)
     yield from r.json()
 
@@ -41,7 +42,7 @@ def paginate(path: str, params: dict, headers: dict) -> Iterable:
     next_page = _get_next_page(r)
     while next_page is not None:
         logger.debug(f"Pagination detected. Requesting next page: {next_page}")
-        r = http_backoff("GET", next_page, headers=headers)
+        r = http_backoff("GET", next_page, headers=headers, timeout=timeout)
         hf_raise_for_status(r)
         yield from r.json()
         next_page = _get_next_page(r)

--- a/tests/test_utils_pagination.py
+++ b/tests/test_utils_pagination.py
@@ -57,10 +57,10 @@ class TestPagination(unittest.TestCase):
         assert mock_hf_raise_for_status.call_count == 3
 
         # Params not passed to next pages
-        assert mock_get.call_args_list == [call("url", params=mock_params, headers=mock_headers)]
+        assert mock_get.call_args_list == [call("url", params=mock_params, headers=mock_headers, timeout=None)]
         assert mock_http_backoff.call_args_list == [
-            call("GET", "url_p2", headers=mock_headers),
-            call("GET", "url_p3", headers=mock_headers),
+            call("GET", "url_p2", headers=mock_headers, timeout=None),
+            call("GET", "url_p3", headers=mock_headers, timeout=None),
         ]
 
     def test_paginate_hf_api(self) -> None:


### PR DESCRIPTION
Follow-up to #4395 and the server-side support added in huggingface-internal/moon-landing#18664 (internal PR).

## Summary

- **`HfApi.list_jobs(...)` now paginates** like `list_models`, `list_datasets`, etc.
- **`hf jobs ps --limit N`** caps how many Jobs are displayed (default `100`) to avoid bloating the terminal, and prints a hint when the output is truncated. `--limit 0` disables the limit (fetches everything).

```python
>>> from huggingface_hub import list_jobs
>>> jobs = list_jobs()          # lazy iterator, fetched page by page
>>> next(iter(jobs))            # first Job, only one page fetched
JobInfo(id='687f911e...', ...)
>>> all_jobs = [job for job in list_jobs()]  # materialize everything
```

```bash
# Default: at most 100 Jobs, hint shown if there are more
>>> hf jobs ps -a --limit 3
job_id                    image/space  command    created              status    runtime
6a39435d953ed90bfb9483ef  python:3.12  sleep 90   2026-06-22 14:14:53  CANCELED  --
...
Hint: Output truncated to 3 Jobs. Use `--limit 0` to show all (or `--limit N`).

# Show everything (followed pagination across pages)
>>> hf jobs ps -a --limit 0 -q | wc -l
826
```

## ⚠️ Breaking change

`HfApi.list_jobs()` (and the top-level `list_jobs()` helper) now returns a **lazy iterator** (`Iterable[JobInfo]`) instead of a `list[JobInfo]`. Code that indexes or re-iterates the result needs to wrap it in `list(...)`:

```python
# Before
jobs = list_jobs()
first = jobs[0]

# After
jobs = list(list_jobs())
first = jobs[0]
# or, without materializing everything:
first = next(iter(list_jobs()))
```

This mirrors the other listing methods in `HfApi` (`list_models`, `list_datasets`, …), which are all lazy iterators.

Note that now, `hf jobs ls -a` returns at most 100 entries by default. This is not a breaking change but a fix. Before this PR, the client was not following pagination meaning that `hf jobs ls -a` was already stopped at 100 without have way to list beyond that.

## Docs

- Updated the Jobs guide and CLI guide to reflect the iterator return type and the new `--limit` option.
- CLI reference regenerated via `make style`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change to `list_jobs()` return type may break downstream code that indexed the result; behavior is otherwise aligned with other Hub list APIs and limited to jobs listing/pagination.
> 
> **Overview**
> **`HfApi.list_jobs()`** now walks Hub pages via the shared **`paginate`** helper and yields a **lazy `Iterable[JobInfo]`** instead of loading a single response into a **`list`**. Callers that indexed or assumed a list must use **`list(list_jobs())`** or **`next(iter(...))`**.
> 
> **`paginate`** accepts list-style query params and an optional **`timeout`**, passed through on the first request and follow-up pages.
> 
> **`hf jobs ps`** adds **`--limit`** (default **100**). It slices the iterator (one extra item to detect truncation) and prints a hint when output is capped; **`--limit 0`** disables the cap.
> 
> Docs for the Jobs guide, CLI guide, and CLI reference describe the iterator behavior and **`--limit`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38ac1f86703addb4cd288e7bcfc8143e7d3e07f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->