### PR TITLE
[CLI] Fix ty/mypy errors with click 8.4.2

### DIFF
--- a/src/huggingface_hub/cli/_cli_utils.py
+++ b/src/huggingface_hub/cli/_cli_utils.py
@@ -173,7 +173,7 @@ class HFCliTyperGroup(TyperGroup):
                 matches = difflib.get_close_matches(cmd_name, visible_names)
                 if matches:
                     suggestions = ", ".join(f"'{m}'" for m in matches)
-                    e.message = f"{e.message.rstrip('.')}. Did you mean {suggestions}?"
+                    setattr(e, "message", f"{e.message.rstrip('.')}. Did you mean {suggestions}?")
                 items = [
                     (name, sub.get_short_help_str(limit=80))
                     for name in self.list_commands(ctx)
@@ -541,8 +541,8 @@ def _enrich_usage_error(error: click.UsageError, label: str, items: list[tuple[s
     lines.append(f"\nRun '{cmd_path} --help' for full details.")
     if isinstance(error, click.NoSuchOption) and error.possibilities:
         lines.append(f"\nDid you mean: {', '.join(sorted(error.possibilities))}?")
-        error.possibilities = []
-    error.message += "\n".join(lines)
+        setattr(error, "possibilities", [])
+    setattr(error, "message", error.message + "\n".join(lines))
 
 
 def fallback_typer_group_factory(

--- a/src/huggingface_hub/cli/_help_formatter.py
+++ b/src/huggingface_hub/cli/_help_formatter.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Pretty ANSI help formatter for the `hf` CLI."""
 
-from collections.abc import Sequence
+from collections.abc import Iterable
 
 import click
 
@@ -25,7 +25,7 @@ class StyledHelpFormatter(click.HelpFormatter):
         styled = ANSI.underline(heading + ":")
         self.write(f"{'':>{self.current_indent}}{styled}\n")
 
-    def write_dl(self, rows: Sequence[tuple[str, str]], col_max: int = 30, col_spacing: int = 2) -> None:
+    def write_dl(self, rows: Iterable[tuple[str, str]], col_max: int = 30, col_spacing: int = 2) -> None:
         rows = [(ANSI.bold(first), second) for first, second in rows]
         super().write_dl(rows, col_max=col_max, col_spacing=col_spacing)
 


### PR DESCRIPTION
## Summary
- click 8.4.2 marks `ClickException.message` and `NoSuchOption.possibilities` as `Final` → use `setattr` to keep enriching caught errors.
- click 8.4.2 widens `HelpFormatter.write_dl`'s `rows` param to `Iterable` → match it in our override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Typing-only CLI adjustments; behavior of help and usage-error messages should stay the same.
> 
> **Overview**
> Updates the `hf` CLI helpers for **Click 8.4.2** API/typing changes without changing runtime behavior.
> 
> Error enrichment for unknown commands/options now uses **`setattr`** to update `UsageError.message` and to clear `NoSuchOption.possibilities`, because those attributes are marked **`Final`** in newer Click and direct assignment fails **ty/mypy**.
> 
> `StyledHelpFormatter.write_dl` now accepts **`Iterable[tuple[str, str]]`** instead of `Sequence`, matching the widened signature on Click’s `HelpFormatter.write_dl`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d5f664aa598fca2e92018d5c092bde05144dd38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->