### PR TITLE
[CLI] [Jobs] Rename job listing to 'hf jobs ls' (and keep 'hf jobs ps' alias)

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -152,7 +152,7 @@ nvidia/nvidia-nemotron-v3-69388dda16167bb1607171ea
 ```
 
 > [!TIP]
-> A handful of commands keep their own local formatting options. For example, `hf jobs ps` and `hf jobs scheduled ps` accept Go templates via `--format` (e.g. `--format '{{.id}} {{.status}}'`); `hf buckets sync` has its own `-q` / `--quiet` to control sync verbosity. In those cases the global flags are silently rewritten so user-facing behaviour stays unchanged.
+> A handful of commands keep their own local formatting options. For example, `hf jobs ls` and `hf jobs scheduled ls` accept Go templates via `--format` (e.g. `--format '{{.id}} {{.status}}'`); `hf buckets sync` has its own `-q` / `--quiet` to control sync verbosity. In those cases the global flags are silently rewritten so user-facing behaviour stays unchanged.
 
 ## hf auth login
 
@@ -1824,9 +1824,9 @@ This command runs the job and shows the logs. You can pass `--detach` to run the
 
 ```bash
 # List your running jobs
->>> hf jobs ps
+>>> hf jobs ls
 # List all jobs
->>> hf jobs ps -a
+>>> hf jobs ls -a
 
 # Inspect the status of a job
 >>> hf jobs inspect <job_id>
@@ -1846,7 +1846,7 @@ This command runs the job and shows the logs. You can pass `--detach` to run the
 >>> hf jobs wait <job_id> [<job_id>...]
 
 # Wait for all currently running jobs
->>> hf jobs ps -q | xargs hf jobs wait
+>>> hf jobs ls -q | xargs hf jobs wait
 ```
 
 Non-detached `hf jobs run` and `hf jobs wait` exit with a non-zero code if a Job fails, so you can chain commands with `&&`:
@@ -2006,20 +2006,20 @@ Add labels to a Job using `-l` or `--label`. Labels are a key=value pairs that a
 
 The my-label key doesn't specify a value so its value defaults to an empty string ("").
 
-Use `--status` and `--label` in `hf jobs ps` to filter Jobs. `--status` takes one or more statuses and `--label` takes `key=value` pairs. A Job must match every filter to be listed:
+Use `--status` and `--label` in `hf jobs ls` to filter Jobs. `--status` takes one or more statuses and `--label` takes `key=value` pairs. A Job must match every filter to be listed:
 
 ```bash
 # Show completed Jobs
->>> hf jobs ps -a --status completed
+>>> hf jobs ls -a --status completed
 
 # Show running or scheduling Jobs
->>> hf jobs ps --status running,scheduling
+>>> hf jobs ls --status running,scheduling
 
 # Show Jobs with the `model=Qwen3-06B` label
->>> hf jobs ps -a --label model=Qwen3-06B
+>>> hf jobs ls -a --label model=Qwen3-06B
 
 # Combine filters: running Jobs labelled both `env=prod` and `team=ml`
->>> hf jobs ps --status running --label env=prod --label team=ml
+>>> hf jobs ls --status running --label env=prod --label team=ml
 ```
 
 <Tip warning={true}>
@@ -2106,7 +2106,7 @@ Manage scheduled jobs using
 
 ```bash
 # List your active scheduled jobs
->>> hf jobs scheduled ps
+>>> hf jobs scheduled ls
 
 # Inspect the status of a job
 >>> hf jobs scheduled inspect <scheduled_job_id>

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -152,7 +152,6 @@ nvidia/nvidia-nemotron-v3-69388dda16167bb1607171ea
 ```
 
 > [!TIP]
-> A handful of commands keep their own local formatting options. For example, `hf jobs ls` and `hf jobs scheduled ls` accept Go templates via `--format` (e.g. `--format '{{.id}} {{.status}}'`); `hf buckets sync` has its own `-q` / `--quiet` to control sync verbosity. In those cases the global flags are silently rewritten so user-facing behaviour stays unchanged.
 
 ## hf auth login
 

--- a/docs/source/en/guides/jobs.md
+++ b/docs/source/en/guides/jobs.md
@@ -174,7 +174,7 @@ The same is available in the CLI with `hf jobs wait`, which exits with code 0 on
 hf jobs wait <job_id> && hf jobs run --detach python:3.12 python eval.py
 
 # Wait for all currently running jobs
-hf jobs ps -q | xargs hf jobs wait
+hf jobs ls -q | xargs hf jobs wait
 ```
 
 Note that a non-detached `hf jobs run` (or `hf jobs uv run`) also exits with a non-zero code if the Job fails, so `hf jobs run ... && next-step` chains correctly without an explicit wait.

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -2127,8 +2127,8 @@ $ hf jobs [OPTIONS] COMMAND [ARGS]...
 * `hardware`: List available hardware options for Jobs
 * `inspect`: Display detailed information on one or...
 * `labels`: Update labels on a Job.
+* `list`: List Jobs. [alias: ls, ps]
 * `logs`: Fetch the logs of a Job.
-* `ps`: List Jobs.
 * `run`: Run a Job.
 * `scheduled`: Create and manage scheduled Jobs on the Hub.
 * `ssh`: SSH into a running Job.
@@ -2245,6 +2245,41 @@ Learn more
   Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
 
 
+### `hf jobs list | ls | ps`
+
+List Jobs.
+
+Use `--status` to filter by status (see [`JobStage`] for possible values) and `--label` to filter by `key=value`
+labels. A Job must match every filter to be listed.
+
+**Usage**:
+
+```console
+$ hf jobs list | ls | ps [OPTIONS]
+```
+
+**Options**:
+
+* `-a, --all`: Show all Jobs (default shows running and scheduling). Cannot be combined with --status.
+* `--status [COMPLETED|CANCELED|ERROR|DELETED|SCHEDULING|RUNNING]`: Only show Jobs with the given status. Comma-separated or repeated, e.g. `--status running,scheduling`.
+* `-l, --label TEXT`: Only show Jobs with the given `key=value` label. Repeat to require several labels, e.g. `--label env=prod --label team=ml`.
+* `--namespace TEXT`: The namespace where the job will be running. Defaults to the current user's namespace.
+* `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
+* `-f, --filter TEXT`: (Deprecated) Use `--status` and `--label` instead.
+* `--help`: Show this message and exit.
+
+Examples
+  $ hf jobs ls
+  $ hf jobs ls -a
+  $ hf jobs ls --status running,scheduling
+  $ hf jobs ls --label env=prod --label team=ml
+  $ hf jobs ls --all --label hf-sandbox=1
+
+Learn more
+  Use `hf <command> --help` for more information about a command.
+  Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
+
+
 ### `hf jobs logs`
 
 Fetch the logs of a Job.
@@ -2279,41 +2314,6 @@ Examples
   $ hf jobs logs -f <job_id>
   $ hf jobs logs --tail 20 <job_id>
   $ hf jobs logs -f --tail 100 <job_id>
-
-Learn more
-  Use `hf <command> --help` for more information about a command.
-  Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
-
-
-### `hf jobs ps`
-
-List Jobs.
-
-Use `--status` to filter by status (see [`JobStage`] for possible values) and `--label` to filter by `key=value`
-labels. A Job must match every filter to be listed.
-
-**Usage**:
-
-```console
-$ hf jobs ps [OPTIONS]
-```
-
-**Options**:
-
-* `-a, --all`: Show all Jobs (default shows running and scheduling). Cannot be combined with --status.
-* `--status [COMPLETED|CANCELED|ERROR|DELETED|SCHEDULING|RUNNING]`: Only show Jobs with the given status. Comma-separated or repeated, e.g. `--status running,scheduling`.
-* `-l, --label TEXT`: Only show Jobs with the given `key=value` label. Repeat to require several labels, e.g. `--label env=prod --label team=ml`.
-* `--namespace TEXT`: The namespace where the job will be running. Defaults to the current user's namespace.
-* `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
-* `-f, --filter TEXT`: (Deprecated) Use `--status` and `--label` instead.
-* `--help`: Show this message and exit.
-
-Examples
-  $ hf jobs ps
-  $ hf jobs ps -a
-  $ hf jobs ps --status running,scheduling
-  $ hf jobs ps --label env=prod --label team=ml
-  $ hf jobs ps --all --label hf-sandbox=1
 
 Learn more
   Use `hf <command> --help` for more information about a command.
@@ -2383,7 +2383,7 @@ $ hf jobs scheduled [OPTIONS] COMMAND [ARGS]...
 * `delete`: Delete a scheduled Job.
 * `inspect`: Display detailed information on one or...
 * `labels`: Update labels on a scheduled Job.
-* `ps`: List scheduled Jobs
+* `list`: List scheduled Jobs [alias: ls, ps]
 * `resume`: Resume (unpause) a scheduled Job.
 * `run`: Schedule a Job.
 * `suspend`: Suspend (pause) a scheduled Job.
@@ -2476,14 +2476,14 @@ Learn more
   Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
 
 
-#### `hf jobs scheduled ps`
+#### `hf jobs scheduled list | ls | ps`
 
 List scheduled Jobs
 
 **Usage**:
 
 ```console
-$ hf jobs scheduled ps [OPTIONS]
+$ hf jobs scheduled list | ls | ps [OPTIONS]
 ```
 
 **Options**:
@@ -2495,7 +2495,7 @@ $ hf jobs scheduled ps [OPTIONS]
 * `--help`: Show this message and exit.
 
 Examples
-  $ hf jobs scheduled ps
+  $ hf jobs scheduled ls
 
 Learn more
   Use `hf <command> --help` for more information about a command.
@@ -2820,7 +2820,7 @@ $ hf jobs wait [OPTIONS] JOB_IDS...
 Examples
   $ hf jobs wait <job_id>
   $ hf jobs wait <job_id_1> <job_id_2>
-  $ hf jobs ps -q | xargs hf jobs wait
+  $ hf jobs ls -q | xargs hf jobs wait
 
 Learn more
   Use `hf <command> --help` for more information about a command.

--- a/src/huggingface_hub/cli/_cli_utils.py
+++ b/src/huggingface_hub/cli/_cli_utils.py
@@ -379,7 +379,7 @@ def _has_local_formatting_option(cmd: click.Command) -> bool:
     """Return True if the command defines its own --format, --json or --quiet / -q.
 
     Used to skip the global formatting flag pre-processor and the duplicated "Formatting options" help section for
-    legacy commands like 'hf jobs ps' that have their own format/quiet options.
+    legacy commands like 'hf jobs ls' that have their own format/quiet options.
     """
     for param in cmd.params:
         if not isinstance(param, click.Option):
@@ -398,7 +398,7 @@ def _consume_format_flags_for_leaf(cmd: click.Command, args: list[str]) -> None:
     * **Pass-through commands** (ignore_unknown_options=True, e.g. 'hf extensions exec'):
       args are forwarded verbatim to an external binary; we don't touch them.
 
-    * **Legacy commands with a local --format option** (e.g. 'hf jobs ps' whose '--format' accepts Go templates):
+    * **Legacy commands with a local --format option** (e.g. 'hf jobs ls' whose '--format' accepts Go templates):
       the global flags are rewritten in-place to the legacy form ('--json' → '--format json', '--quiet'/'-q' → '--format quiet'
       when the cmd has no own '--quiet') so click can parse them locally. This preserves backwards compatibility with the previous shorthand behavior.
 
@@ -500,7 +500,7 @@ def _consume_no_truncate_flags(args: list[str]) -> bool:
 def _rewrite_legacy_shorthands(args: list[str], *, rewrite_json: bool, rewrite_quiet: bool) -> None:
     """Rewrite --json / -q / --quiet to --format ... for legacy commands.
 
-    Used for commands like 'hf jobs ps' that still own their '--format' option.
+    Used for commands like 'hf jobs ls' that still own their '--format' option.
     The rewrite lets users keep using the global shorthand while click parses
     '--format <value>' locally.
     """

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -18,7 +18,7 @@ Usage:
     hf jobs run <image> <command>
 
     # List running or completed jobs
-    hf jobs ps [-a] [-f key=value]
+    hf jobs ls [-a] [-f key=value]
 
     # Print logs from a job (non-blocking)
     hf jobs logs <job-id>
@@ -48,7 +48,7 @@ Usage:
     hf jobs scheduled run <schedule> <image> <command>
 
     # List scheduled jobs
-    hf jobs scheduled ps [-a] [-f key=value]
+    hf jobs scheduled ls [-a] [-f key=value]
 
     # Inspect a scheduled job
     hf jobs scheduled inspect <scheduled_job_id>
@@ -531,13 +531,13 @@ def jobs_stats(
 
 
 @jobs_cli.command(
-    "ps",
+    "list | ls | ps",
     examples=[
-        "hf jobs ps",
-        "hf jobs ps -a",
-        "hf jobs ps --status running,scheduling",
-        "hf jobs ps --label env=prod --label team=ml",
-        "hf jobs ps --all --label hf-sandbox=1",
+        "hf jobs ls",
+        "hf jobs ls -a",
+        "hf jobs ls --status running,scheduling",
+        "hf jobs ls --label env=prod --label team=ml",
+        "hf jobs ls --all --label hf-sandbox=1",
     ],
 )
 def jobs_ps(
@@ -712,7 +712,7 @@ def jobs_cancel(
     examples=[
         "hf jobs wait <job_id>",
         "hf jobs wait <job_id_1> <job_id_2>",
-        "hf jobs ps -q | xargs hf jobs wait",
+        "hf jobs ls -q | xargs hf jobs wait",
     ],
 )
 def jobs_wait(
@@ -964,7 +964,7 @@ def scheduled_run(
     out.hint(f"Use `hf jobs scheduled inspect {scheduled_job.id}` to view its details.")
 
 
-@scheduled_app.command("ps", examples=["hf jobs scheduled ps"])
+@scheduled_app.command("list | ls | ps", examples=["hf jobs scheduled ls"])
 def scheduled_ps(
     all: Annotated[
         bool,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3234,7 +3234,7 @@ class TestJobsCommand:
         assert "streaming line" in result.output
 
     def _make_mock_jobs(self):
-        """Create mock JobInfo objects for testing ps output."""
+        """Create mock JobInfo objects for testing ls output."""
         from huggingface_hub._jobs_api import JobInfo
 
         return [
@@ -3345,8 +3345,8 @@ class TestJobsCommand:
         assert job.durations.running_secs is None
         assert job.durations.total_secs == 9861
 
-    def test_ps_table_shows_runtime_column(self, runner: CliRunner) -> None:
-        """Test that `hf jobs ps -a` table includes a RUNTIME column with formatted values and `--` placeholders."""
+    def test_ls_table_shows_runtime_column(self, runner: CliRunner) -> None:
+        """Test that `hf jobs ls -a` table includes a RUNTIME column with formatted values and `--` placeholders."""
         from huggingface_hub._jobs_api import JobInfo
 
         jobs = [
@@ -3384,33 +3384,33 @@ class TestJobsCommand:
         with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
             api = api_cls.return_value
             api.list_jobs.return_value = jobs
-            result = runner.invoke(app, ["jobs", "ps", "-a"])
+            result = runner.invoke(app, ["jobs", "ls", "-a"])
         assert result.exit_code == 0
         assert "RUNTIME" in result.output
         assert "3m 7s" in result.output  # 187s running_secs formatted
         assert "--" in result.output  # SCHEDULING job has no running_secs yet
 
-    def test_ps_forwards_status_and_label_filters_server_side(self, runner: CliRunner) -> None:
+    def test_ls_forwards_status_and_label_filters_server_side(self, runner: CliRunner) -> None:
         with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
             api = api_cls.return_value
             api.list_jobs.return_value = self._make_mock_jobs()
             result = runner.invoke(
-                app, ["jobs", "ps", "--status", "completed,scheduling", "--label", "model=Qwen3-06B"]
+                app, ["jobs", "ls", "--status", "completed,scheduling", "--label", "model=Qwen3-06B"]
             )
         assert result.exit_code == 0
         kwargs = api.list_jobs.call_args.kwargs
         assert kwargs["status"] == ["completed", "scheduling"]
         assert kwargs["labels"] == {"model": "Qwen3-06B"}
 
-    def test_ps_format_json(self, runner: CliRunner) -> None:
-        """Test that `hf jobs ps -a --format json` outputs valid JSON with all fields."""
+    def test_ls_format_json(self, runner: CliRunner) -> None:
+        """Test that `hf jobs ls -a --format json` outputs valid JSON with all fields."""
         import json
 
         jobs = self._make_mock_jobs()
         with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
             api = api_cls.return_value
             api.list_jobs.return_value = jobs
-            result = runner.invoke(app, ["jobs", "ps", "-a", "--format", "json"])
+            result = runner.invoke(app, ["jobs", "ls", "-a", "--format", "json"])
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert len(data) == 2
@@ -3422,25 +3422,25 @@ class TestJobsCommand:
         assert "owner" in data[0]
 
     def test_ps_json_hidden_alias(self, runner: CliRunner) -> None:
-        """Test that `hf jobs ps -a --json` works as alias for `--format json`."""
+        """Test that `hf jobs ls -a --json` works as alias for `--format json`."""
         import json
 
         jobs = self._make_mock_jobs()
         with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
             api = api_cls.return_value
             api.list_jobs.return_value = jobs
-            result = runner.invoke(app, ["jobs", "ps", "-a", "--json"])
+            result = runner.invoke(app, ["jobs", "ls", "-a", "--json"])
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert len(data) == 2
 
-    def test_ps_quiet(self, runner: CliRunner) -> None:
-        """Test that `hf jobs ps -a -q` outputs only IDs, one per line."""
+    def test_ls_quiet(self, runner: CliRunner) -> None:
+        """Test that `hf jobs ls -a -q` outputs only IDs, one per line."""
         jobs = self._make_mock_jobs()
         with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
             api = api_cls.return_value
             api.list_jobs.return_value = jobs
-            result = runner.invoke(app, ["jobs", "ps", "-a", "-q"])
+            result = runner.invoke(app, ["jobs", "ls", "-a", "-q"])
         assert result.exit_code == 0
         lines = result.output.strip().split("\n")
         assert lines == ["abc123def456", "xyz789ghi012"]
@@ -3451,31 +3451,31 @@ class TestJobsCommand:
         with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
             api = api_cls.return_value
             api.list_jobs.return_value = jobs
-            result = runner.invoke(app, ["jobs", "ps", "-a"])
+            result = runner.invoke(app, ["jobs", "ls", "-a"])
         assert result.exit_code == 0
         assert "abc123def456" in result.output
         assert "xyz789ghi012" in result.output
 
-    def test_ps_empty_json(self, runner: CliRunner) -> None:
-        """Test that `hf jobs ps --format json` outputs `[]` when no jobs match."""
+    def test_ls_empty_json(self, runner: CliRunner) -> None:
+        """Test that `hf jobs ls --format json` outputs `[]` when no jobs match."""
         import json
 
         with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
             api = api_cls.return_value
             api.list_jobs.return_value = []
-            result = runner.invoke(app, ["jobs", "ps", "--format", "json"])
+            result = runner.invoke(app, ["jobs", "ls", "--format", "json"])
         assert result.exit_code == 0
         # Parse stdout only: the empty-state hint goes to stderr (like agent mode), so it
         # never pollutes the JSON on stdout. Mirrors the other `json.loads(result.stdout)` tests.
         data = json.loads(result.stdout)
         assert data == []
 
-    def test_ps_empty_quiet(self, runner: CliRunner) -> None:
-        """Test that `hf jobs ps -q` outputs nothing when no jobs match."""
+    def test_ls_empty_quiet(self, runner: CliRunner) -> None:
+        """Test that `hf jobs ls -q` outputs nothing when no jobs match."""
         with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
             api = api_cls.return_value
             api.list_jobs.return_value = []
-            result = runner.invoke(app, ["jobs", "ps", "-q"])
+            result = runner.invoke(app, ["jobs", "ls", "-q"])
         assert result.exit_code == 0
         assert result.output.strip() == ""
 


### PR DESCRIPTION
Let's make `hf jobs ps` consistent with all other listing commands from the CLI (`hf repos ls`, `hf models ls`, `hf collections ls`, etc.).

Initial idea was to be close to `ps` and `docker ps` but given https://github.com/huggingface/huggingface_hub/pull/4395 (and likely future PRs) we are likely going to diverge from docker command anyway. 


We keep the alias so that `hf jobs ls`, `hf jobs list` and `hf jobs ps` and still all equivalent. We simply stop documenting `hf jobs ps`.

cc @davanstrien @lhoestq for viz'


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Backward-compatible CLI alias only plus documentation and test renames; no API or job execution behavior changes.
> 
> **Overview**
> Aligns Jobs listing with other Hub CLI list commands (`hf models ls`, `hf repos ls`, etc.) by making **`hf jobs ls`** (and **`hf jobs list`**) the documented entry points, while **`hf jobs ps`** remains a backward-compatible alias.
> 
> The Typer subcommands for **`hf jobs`** and **`hf jobs scheduled`** are registered as **`list | ls | ps`**; examples, CLI reference, jobs guides, and tests now call **`ls`** instead of **`ps`**. Internal Python handlers are unchanged (`jobs_ps`, `scheduled_ps`). Comments in **`_cli_utils.py`** were updated to refer to **`hf jobs ls`** for legacy `--format` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b913fd4c5098b3d8726c4acecb234c89d7f83a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->