### PR TITLE
[CLI] Fix escaped backslash handling in .env value parsing

### DIFF
--- a/src/huggingface_hub/utils/_dotenv.py
+++ b/src/huggingface_hub/utils/_dotenv.py
@@ -2,6 +2,22 @@
 import re
 
 
+# Escape sequences expanded inside quoted values. Double-quoted values additionally
+# expand "\$" to "$"; single-quoted values keep it verbatim.
+_ESCAPES = {"n": "\n", "t": "\t", '"': '"', "\\": "\\"}
+_DOUBLE_QUOTE_ESCAPES = {**_ESCAPES, "$": "$"}
+
+
+def _unescape(value: str, escapes: dict[str, str]) -> str:
+    r"""Expand backslash escapes in a single left-to-right pass.
+
+    Processing in one pass (rather than chained `str.replace` calls) ensures an escaped
+    backslash (`\\`) is consumed as a unit and cannot merge with the following character,
+    e.g. `\\n` is a backslash followed by `n`, not a newline. Unknown escapes are kept as-is.
+    """
+    return re.sub(r"\\(.)", lambda match: escapes.get(match.group(1), match.group(0)), value)
+
+
 def load_dotenv(dotenv_str: str, environ: dict[str, str] | None = None) -> dict[str, str]:
     """
     Parse a DOTENV-format string and return a dictionary of key-value pairs.
@@ -40,10 +56,8 @@ def load_dotenv(dotenv_str: str, environ: dict[str, str] | None = None) -> dict[
                 val = raw_val.strip()
                 # Remove surrounding quotes if quoted
                 if (val.startswith('"') and val.endswith('"')) or (val.startswith("'") and val.endswith("'")):
-                    val = val[1:-1]
-                    val = val.replace(r"\n", "\n").replace(r"\t", "\t").replace(r"\"", '"').replace(r"\\", "\\")
-                    if raw_val.startswith('"'):
-                        val = val.replace(r"\$", "$")  # only in double quotes
+                    escapes = _DOUBLE_QUOTE_ESCAPES if raw_val.startswith('"') else _ESCAPES
+                    val = _unescape(val[1:-1], escapes)
             elif environ is not None:
                 # Get it from the current environment
                 val = environ.get(key)

--- a/tests/test_utils_dotenv.py
+++ b/tests/test_utils_dotenv.py
@@ -49,6 +49,23 @@ def test_complex_quotes():
     }
 
 
+def test_escaped_backslash_before_escape_char():
+    # An escaped backslash ("\\") collapses to a single backslash and the next character
+    # stays literal, even when it is "n", "t" or a quote. This used to break: the trailing
+    # character got merged into a newline/tab, so a Windows path like "C:\\new" came out as
+    # "C:" + backslash + newline + "ew".
+    data = r"""
+    WIN="C:\\new"
+    LITERAL="a\\nb"
+    TAB="x\\t"
+    """
+    assert load_dotenv(data) == {
+        "WIN": "C:\\new",
+        "LITERAL": "a\\nb",
+        "TAB": "x\\t",
+    }
+
+
 def test_no_value():
     data = "NOVALUE="
     assert load_dotenv(data) == {"NOVALUE": ""}


### PR DESCRIPTION
## Summary

While poking at the `.env` parsing used by the CLI I hit a case where an escaped backslash in a double-quoted value is unescaped incorrectly. The unescaping is a chain of `str.replace` calls that expands `\n`/`\t`/`\"` *before* collapsing `\\`, so when a `\\` pair is followed by `n`/`t`/`"` the second backslash gets eaten by the next character.

The one that caught my eye is a Windows-style path written with an escaped backslash:

```python
>>> from huggingface_hub.utils._dotenv import load_dotenv
>>> load_dotenv(r'WIN="C:\\new"')
# before: {'WIN': 'C:\\\new'}   -> backslash + newline + "ew"
# after:  {'WIN': 'C:\\new'}    -> C:\new, as written
```

Same thing for `"a\\nb"` (the `\\n` turned into a newline instead of a literal `\n`) and `"x\\t"`.

The fix does the unescaping in a single left-to-right pass with `re.sub`, so an escaped backslash is consumed as a unit and the following character stays literal. The `\$` (double-quoted only) and `\\` behaviour is otherwise unchanged — I checked it against all the existing cases.

Added a regression test in `tests/test_utils_dotenv.py`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to CLI `.env` parsing with regression tests; no auth or security surface.
> 
> **Overview**
> Fixes incorrect parsing of **double-quoted** `.env` values when a backslash is escaped before characters like `n`, `t`, or `"`. Chained `str.replace` unescaping could turn sequences such as `\\n` into a newline instead of a literal backslash plus `n` (e.g. `WIN="C:\\new"`).
> 
> Quoted values now use a single left-to-right `_unescape` pass via `re.sub`, with separate escape tables for double quotes (`\$` still expanded) vs single quotes. A regression test covers Windows-style paths and similar cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 231db9b456088a8294ab79c983dfe3f4dcb966c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->