### PR TITLE
[Upload] Deprecate upload_large_folder (API + CLI)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ Python client library for the Hugging Face Hub. Source code is in `src/huggingfa
 - `_snapshot_download.py` — `snapshot_download` (download an entire repo).
 - `_commit_api.py` — Low-level commit operations (`CommitOperationAdd`, `CommitOperationDelete`, `CommitOperationCopy`), LFS upload handling.
 - `_commit_scheduler.py` — Background scheduled commits.
-- `_upload_large_folder.py` — Chunked upload for very large folders.
+- `_upload_large_folder.py` — Chunked upload for very large folders (deprecated; `upload_folder` now handles large/resumable uploads).
 - `hf_file_system.py` — `HfFileSystem` (fsspec-based POSIX-like filesystem for Hub repos).
 - `hub_mixin.py` — `ModelHubMixin` base class for ML framework integration (save/load to Hub).
 - `repocard.py` / `repocard_data.py` — `RepoCard`, `ModelCard`, `DatasetCard` and their metadata.

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -67,7 +67,7 @@ Main commands:
   spaces               Interact with spaces on the Hub.
   sync                 Sync files between local directory and a bucket.
   upload               Upload a file or a folder to the Hub.
-  upload-large-folder  Upload a large folder to the Hub.
+  upload-large-folder  [Deprecated] Use 'hf upload' instead.
 
 Help commands:
   env      Print information about the environment.
@@ -594,27 +594,16 @@ https://huggingface.co/Wauplin/my-cool-model/tree/main
 
 ## hf upload-large-folder
 
-Use `hf upload-large-folder` to upload very large folders (hundreds of GBs or even TBs) to the Hub. This command is optimized for resumable uploads and handles failures gracefully.
+> [!WARNING]
+> `hf upload-large-folder` is **deprecated** and will be removed in a future release. Use [`hf upload`](#hf-upload) instead: it is now resilient to interruptions and powered by Xet, so it handles very large folders out of the box and resumes automatically if you re-run the same command.
 
 ```bash
-# Upload a large folder to a model repository
->>> hf upload-large-folder Wauplin/my-cool-model ./large_model_dir
+# Upload a large folder to a model repository (resumes automatically if interrupted)
+>>> hf upload Wauplin/my-cool-model ./large_model_dir
 
-# Upload to a specific revision
->>> hf upload-large-folder Wauplin/my-cool-model ./large_model_dir --revision v1.0
-
-# Upload a dataset
->>> hf upload-large-folder Wauplin/my-cool-dataset ./large_data_dir --repo-type dataset
+# Upload a large folder to a dataset
+>>> hf upload Wauplin/my-cool-dataset ./large_data_dir --repo-type dataset
 ```
-
-The command automatically:
-
-- Splits large files into chunks for reliable uploads
-- Resumes interrupted uploads from where they left off
-- Handles network failures gracefully
-
-> [!TIP]
-> Use `hf upload-large-folder` when you have very large files or folders that may take a long time to upload. For smaller uploads, prefer `hf upload`.
 
 ## hf buckets
 

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -1463,11 +1463,8 @@ Files correctly deleted from repo. Commit: https://huggingface.co/Wauplin/my-coo
 
 Use wildcard patterns to delete sets of files. Patterns are Standard Wildcards (globbing patterns) as documented [here](https://tldp.org/LDP/GNU-Linux-Tools-Summary/html/x11655.htm). The pattern matching is based on [`fnmatch`](https://docs.python.org/3/library/fnmatch.html).
 
-<Tip warning={true}>
-
-Note that `fnmatch` matches `*` across path boundaries, unlike traditional Unix shell globbing. For example, `"data/*.json"` will match both `data/file.json` **and** `data/subdir/file.json`. To match only files in the immediate directory, you need to list them explicitly or use more specific patterns.
-
-</Tip>
+> [!WARNING]
+> Note that `fnmatch` matches `*` across path boundaries, unlike traditional Unix shell globbing. For example, `"data/*.json"` will match both `data/file.json` **and** `data/subdir/file.json`. To match only files in the immediate directory, you need to list them explicitly or use more specific patterns.
 
 ```bash
 >>> hf repos delete-files Wauplin/my-cool-model "*.txt" "folder/*.bin"
@@ -2020,11 +2017,9 @@ By default `hf jobs ps` displays at most 100 Jobs to avoid bloating the terminal
 >>> hf jobs ps -a --limit 0
 ```
 
-<Tip warning={true}>
+> [!WARNING]
+> `-f`/`--filter` is deprecated in favor of `--status` and `--label`. Matching is exact: glob patterns (`data-*`) and negation (`key!=value`) are not supported, and filtering by `id`, `image` or `command` is not available.
 
-`-f`/`--filter` is deprecated in favor of `--status` and `--label`. Matching is exact: glob patterns (`data-*`) and negation (`key!=value`) are not supported, and filtering by `id`, `image` or `command` is not available.
-
-</Tip>
 
 ### SSH into a Job
 

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -598,10 +598,10 @@ https://huggingface.co/Wauplin/my-cool-model/tree/main
 > `hf upload-large-folder` is **deprecated** and will be removed in a future release. Use [`hf upload`](#hf-upload) instead: it is now resilient to interruptions and powered by Xet, so it handles very large folders out of the box and resumes automatically if you re-run the same command.
 
 ```bash
-# Upload a large folder to a model repository (resumes automatically if interrupted)
+# Upload a large folder to a model repository
 >>> hf upload Wauplin/my-cool-model ./large_model_dir
 
-# Upload a large folder to a dataset
+# Upload a dataset
 >>> hf upload Wauplin/my-cool-dataset ./large_data_dir --repo-type dataset
 ```
 

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -595,7 +595,7 @@ https://huggingface.co/Wauplin/my-cool-model/tree/main
 ## hf upload-large-folder
 
 > [!WARNING]
-> `hf upload-large-folder` is **deprecated** and will be removed in a future release. Use [`hf upload`](#hf-upload) instead: it is now resilient to interruptions and powered by Xet, so it handles very large folders out of the box and resumes automatically if you re-run the same command.
+> `hf upload-large-folder` is deprecated and will be removed in a future release. Use [`hf upload`](#hf-upload) instead. It now handles very large folders out of the box and resumes automatically on re-run.
 
 ```bash
 # Upload a large folder to a model repository

--- a/docs/source/en/guides/upload.md
+++ b/docs/source/en/guides/upload.md
@@ -130,7 +130,7 @@ For more details about the CLI upload command, please refer to the [CLI guide](.
 
 ## Upload a large folder
 
-[`upload_folder`] and the `hf upload` command are the go-to solutions to upload files to the Hub, including for very large folders. Since they are powered by Xet, files are streamed to the Hub in several commits and the process resumes automatically if it gets interrupted: simply re-run the same call and already-uploaded files are skipped. There is nothing special to do for large folders — just point [`upload_folder`] at your directory:
+[`upload_folder`] and the `hf upload` command are the go-to solutions to upload files to the Hub, including for very large folders. Files are streamed to the Hub in several commits and the process resumes automatically if it gets interrupted. Simply re-run the same call and already-uploaded files are skipped.
 
 ```py
 >>> api.upload_folder(

--- a/docs/source/en/guides/upload.md
+++ b/docs/source/en/guides/upload.md
@@ -130,52 +130,24 @@ For more details about the CLI upload command, please refer to the [CLI guide](.
 
 ## Upload a large folder
 
-In most cases, the [`upload_folder`] method and `hf upload` command should be the go-to solutions to upload files to the Hub. They ensure a single commit will be made, handle a lot of use cases, and fail explicitly when something wrong happens. However, when dealing with a large amount of data, you will usually prefer a resilient process even if it leads to more commits or requires more CPU usage. The [`upload_large_folder`] method has been implemented in that spirit:
-- it is resumable: the upload process is split into many small tasks (hashing files, pre-uploading them, and committing them). Each time a task is completed, the result is cached locally in a `./cache/huggingface` folder inside the folder you are trying to upload. By doing so, restarting the process after an interruption will resume all completed tasks.
-- it is multi-threaded: hashing large files and pre-uploading them benefits a lot from multithreading if your machine allows it.
-- it is resilient to errors: a high-level retry-mechanism has been added to retry each independent task indefinitely until it passes (no matter if it's a OSError, ConnectionError, PermissionError, etc.). This mechanism is double-edged. If transient errors happen, the process will continue and retry. If permanent errors happen (e.g. permission denied), it will retry indefinitely without solving the root cause.
-
-If you want more technical details about how `upload_large_folder` is implemented under the hood, please have a look to the [`upload_large_folder`] package reference.
-
-Here is how to use [`upload_large_folder`] in a script. The method signature is very similar to [`upload_folder`]:
+[`upload_folder`] and the `hf upload` command are the go-to solutions to upload files to the Hub, including for very large folders. Since they are powered by Xet, files are streamed to the Hub in several commits and the process resumes automatically if it gets interrupted: simply re-run the same call and already-uploaded files are skipped. There is nothing special to do for large folders — just point [`upload_folder`] at your directory:
 
 ```py
->>> api.upload_large_folder(
+>>> api.upload_folder(
 ...     repo_id="HuggingFaceM4/Docmatix",
 ...     repo_type="dataset",
 ...     folder_path="/path/to/local/docmatix",
 ... )
 ```
 
-You will see the following output in your terminal:
-```
-Repo created: https://huggingface.co/datasets/HuggingFaceM4/Docmatix
-Found 5 candidate files to upload
-Recovering from metadata files: 100%|█████████████████████████████████████| 5/5 [00:00<00:00, 542.66it/s]
-
----------- 2024-07-22 17:23:17 (0:00:00) ----------
-Files:   hashed 5/5 (5.0G/5.0G) | pre-uploaded: 0/5 (0.0/5.0G) | committed: 0/5 (0.0/5.0G) | ignored: 0
-Workers: hashing: 0 | get upload mode: 0 | pre-uploading: 5 | committing: 0 | waiting: 11
----------------------------------------------------
-```
-
-First, the repo is created if it didn't exist before. Then, the local folder is scanned for files to upload. For each file, we try to recover metadata information (from a previously interrupted upload). From there, it is able to launch workers and print an update status every 1 minute. Here, we can see that 5 files have already been hashed but not pre-uploaded. 5 workers are pre-uploading files while the 11 others are waiting for a task.
-
-A command line is also provided. You can define the number of workers and the level of verbosity in the terminal:
+or from the terminal:
 
 ```sh
-hf upload-large-folder HuggingFaceM4/Docmatix --repo-type=dataset /path/to/local/docmatix --num-workers=16
+hf upload HuggingFaceM4/Docmatix --repo-type=dataset /path/to/local/docmatix
 ```
 
-> [!TIP]
-> For large uploads, you have to set `repo_type="model"` or `--repo-type=model` explicitly. Usually, this information is implicit in all other `HfApi` methods. This is to avoid having data uploaded to a repository with a wrong type. If that's the case, you'll have to re-upload everything.
-
 > [!WARNING]
-> While being much more robust to upload large folders, `upload_large_folder` is more limited than [`upload_folder`] feature-wise. In practice:
-> - you cannot set a custom `path_in_repo`. If you want to upload to a subfolder, you need to set the proper structure locally.
-> - you cannot set a custom `commit_message` and `commit_description` since multiple commits are created.
-> - you cannot delete from the repo while uploading. Please make a separate commit first.
-> - you cannot create a PR directly. Please create a PR first (from the UI or using [`create_pull_request`]) and then commit to it by passing `revision`.
+> The legacy [`upload_large_folder`] method and `hf upload-large-folder` command are **deprecated** and will be removed in a future release. Use [`upload_folder`] / `hf upload` instead.
 
 ### Tips and tricks for large uploads
 
@@ -184,7 +156,7 @@ There are some limitations to be aware of when dealing with a large amount of da
 Check out our [Repository limitations and recommendations](https://huggingface.co/docs/hub/repositories-recommendations) guide for best practices on how to structure your repositories on the Hub. Let's move on with some practical tips to make your upload process as smooth as possible.
 
 - **Start small**: We recommend starting with a small amount of data to test your upload script. It's easier to iterate on a script when failing takes only a little time.
-- **Expect failures**: Streaming large amounts of data is challenging. You don't know what can happen, but it's always best to consider that something will fail at least once -no matter if it's due to your machine, your connection, or our servers. For example, if you plan to upload a large number of files, it's best to keep track locally of which files you already uploaded before uploading the next batch. You are ensured that an LFS file that is already committed will never be re-uploaded twice but checking it client-side can still save some time. This is what [`upload_large_folder`] does for you.
+- **Expect failures**: Streaming large amounts of data is challenging. You don't know what can happen, but it's always best to consider that something will fail at least once -no matter if it's due to your machine, your connection, or our servers. For example, if you plan to upload a large number of files, it's best to keep track locally of which files you already uploaded before uploading the next batch. You are ensured that an LFS file that is already committed will never be re-uploaded twice but checking it client-side can still save some time. This is what [`upload_folder`] does for you.
 - **Use `hf_xet`**: this leverages the new storage backend for the Hub, is written in Rust, and is now available for everyone to use. In fact, `hf_xet` is already enabled by default when using `huggingface_hub`! For maximum performance, set [`HF_XET_HIGH_PERFORMANCE=1`](../package_reference/environment_variables.md#hf_xet_high_performance) as an environment variable. Be aware that when high performance mode is enabled, the tool will try to use all available bandwidth and CPU cores.
 
 ## Advanced features

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -45,7 +45,7 @@ $ hf [OPTIONS] [COMMAND] [ARGS]...
 * `sync`: Sync files between local directory and a...
 * `update`: Update the `hf` CLI to the latest version.
 * `upload`: Upload a file or a folder to the Hub.
-* `upload-large-folder`: Upload a large folder to the Hub.
+* `upload-large-folder`: [Deprecated] Upload a large folder to the...
 * `version`: Print information about the hf version.
 * `webhooks`: Manage webhooks on the Hub.
 
@@ -4650,7 +4650,7 @@ Learn more
 
 ## `hf upload-large-folder`
 
-Upload a large folder to the Hub. Recommended for resumable uploads.
+[Deprecated] Upload a large folder to the Hub. Use `hf upload` instead.
 
 **Usage**:
 

--- a/src/huggingface_hub/cli/upload_large_folder.py
+++ b/src/huggingface_hub/cli/upload_large_folder.py
@@ -102,6 +102,7 @@ def upload_large_folder(
         equivalent.append(f"--exclude '{pattern}'")
 
     out.warning(
+        "\n"
         "================================================================================\n"
         "`hf upload-large-folder` is DEPRECATED and will be removed in a future release.\n"
         "\n"

--- a/src/huggingface_hub/cli/upload_large_folder.py
+++ b/src/huggingface_hub/cli/upload_large_folder.py
@@ -91,9 +91,9 @@ def upload_large_folder(
         raise typer.BadParameter("Large upload is only supported for folders.", param_hint="local_path")
 
     # Build the equivalent `hf upload` command to recommend to the user.
-    equivalent = ["hf upload", repo_id, local_path, f"--repo-type {repo_type.value}"]
+    equivalent = [f"hf upload {repo_id} '{local_path}' --repo-type {repo_type.value}"]
     if revision is not None:
-        equivalent.append(f"--revision {revision}")
+        equivalent.append(f"--revision '{revision}'")
     if private:
         equivalent.append("--private")
     for pattern in include or []:
@@ -105,9 +105,7 @@ def upload_large_folder(
         "================================================================================\n"
         "`hf upload-large-folder` is DEPRECATED and will be removed in a future release.\n"
         "\n"
-        "`hf upload` is now resilient to interruptions and powered by Xet: it streams\n"
-        "files in multiple commits and resumes automatically if you re-run the same command.\n"
-        "Use it instead:\n"
+        "Use `hf upload` instead:\n"
         "\n"
         f"    {' '.join(equivalent)}\n"
         "================================================================================"

--- a/src/huggingface_hub/cli/upload_large_folder.py
+++ b/src/huggingface_hub/cli/upload_large_folder.py
@@ -14,6 +14,7 @@
 """Contains command to upload a large folder with the CLI."""
 
 import os
+import warnings
 from typing import Annotated
 
 import typer
@@ -85,45 +86,48 @@ def upload_large_folder(
         ),
     ] = False,
 ) -> None:
-    """Upload a large folder to the Hub. Recommended for resumable uploads."""
+    """[Deprecated] Upload a large folder to the Hub. Use `hf upload` instead."""
     if not os.path.isdir(local_path):
         raise typer.BadParameter("Large upload is only supported for folders.", param_hint="local_path")
 
+    # Build the equivalent `hf upload` command to recommend to the user.
+    equivalent = ["hf upload", repo_id, local_path, f"--repo-type {repo_type.value}"]
+    if revision is not None:
+        equivalent.append(f"--revision {revision}")
+    if private:
+        equivalent.append("--private")
+    for pattern in include or []:
+        equivalent.append(f"--include '{pattern}'")
+    for pattern in exclude or []:
+        equivalent.append(f"--exclude '{pattern}'")
+
     out.warning(
-        "You are about to upload a large folder to the Hub using `hf upload-large-folder`. "
-        "This is a new feature so feedback is very welcome!\n"
+        "================================================================================\n"
+        "`hf upload-large-folder` is DEPRECATED and will be removed in a future release.\n"
         "\n"
-        "A few things to keep in mind:\n"
-        "  - Repository limits still apply: https://huggingface.co/docs/hub/repositories-recommendations\n"
-        "  - Do not start several processes in parallel.\n"
-        "  - You can interrupt and resume the process at any time. "
-        "The script will pick up where it left off except for partially uploaded files that would have to be entirely reuploaded.\n"
-        "  - Do not upload the same folder to several repositories. If you need to do so, you must delete the `./.cache/huggingface/` folder first.\n"
+        "`hf upload` is now resilient to interruptions and powered by Xet: it streams\n"
+        "files in multiple commits and resumes automatically if you re-run the same command.\n"
+        "Use it instead:\n"
         "\n"
-        f"Some temporary metadata will be stored under `{local_path}/.cache/huggingface`.\n"
-        "  - You must not modify those files manually.\n"
-        "  - You must not delete the `./.cache/huggingface/` folder while a process is running.\n"
-        "  - You can delete the `./.cache/huggingface/` folder to reinitialize the upload state when process is not running. Files will have to be hashed and preuploaded again, except for already committed files.\n"
-        "\n"
-        "If the process output is too verbose, you can disable the progress bars with `--no-bars`. "
-        "You can also entirely disable the status report with `--no-report`.\n"
-        "\n"
-        "For more details, run `hf upload-large-folder --help` or check the documentation at "
-        "https://huggingface.co/docs/huggingface_hub/guides/upload#upload-a-large-folder."
+        f"    {' '.join(equivalent)}\n"
+        "================================================================================"
     )
 
     if no_bars:
         disable_progress_bars()
 
     api = get_hf_api(token=token)
-    api.upload_large_folder(
-        repo_id=repo_id,
-        folder_path=local_path,
-        repo_type=repo_type.value,
-        revision=revision,
-        private=private,
-        allow_patterns=include,
-        ignore_patterns=exclude,
-        num_workers=num_workers,
-        print_report=not no_report,
-    )
+    with warnings.catch_warnings():
+        # Avoid printing the API-level deprecation warning on top of the CLI one above.
+        warnings.simplefilter("ignore", FutureWarning)
+        api.upload_large_folder(
+            repo_id=repo_id,
+            folder_path=local_path,
+            repo_type=repo_type.value,
+            revision=revision,
+            private=private,
+            allow_patterns=include,
+            ignore_patterns=exclude,
+            num_workers=num_workers,
+            print_report=not no_report,
+        )

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -6113,6 +6113,15 @@ class HfApi:
     ) -> None:
         """Upload a large folder to the Hub in the most resilient way possible.
 
+        <Tip warning={true}>
+
+        `upload_large_folder` is deprecated and will be removed in a future release. [`upload_folder`] is now resilient
+        to interruptions (it streams files in multiple commits and resumes automatically when re-run) and powered by Xet,
+        so it is the recommended way to upload large folders. Simply replace your call with
+        `api.upload_folder(repo_id=..., repo_type=..., folder_path=...)`.
+
+        </Tip>
+
         Several workers are started to upload files in an optimized way. Before being committed to a repo, files must be
         hashed and be pre-uploaded if they are LFS files. Workers will perform these tasks for each file in the folder.
         At each step, some metadata information about the upload process is saved in the folder under `.cache/.huggingface/`
@@ -6199,6 +6208,20 @@ class HfApi:
             - Only one worker can commit at a time.
             - If no tasks are available, the worker waits for 10 seconds before checking again.
         """
+        warnings.warn(
+            "\n"
+            "================================================================================\n"
+            "`upload_large_folder` is DEPRECATED and will be removed in a future release.\n"
+            "\n"
+            "`upload_folder` is now resilient to interruptions and powered by Xet: it streams\n"
+            "files in multiple commits and resumes automatically if you re-run the same call.\n"
+            "Use it instead:\n"
+            "\n"
+            f'    api.upload_folder(repo_id="{repo_id}", repo_type="{repo_type}", folder_path="{folder_path}")\n'
+            "================================================================================\n",
+            FutureWarning,
+            stacklevel=2,
+        )
         return upload_large_folder_internal(
             self,
             repo_id=repo_id,

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -6210,7 +6210,7 @@ class HfApi:
             "\n"
             "Use `upload_folder` instead:\n"
             "\n"
-            f'    api.upload_folder(repo_id="{repo_id}", repo_type="{repo_type}", folder_path="{repr(folder_path)}")\n'
+            f'    api.upload_folder(repo_id="{repo_id}", repo_type="{repo_type}", folder_path="{folder_path}")\n'
             "================================================================================\n",
             FutureWarning,
             stacklevel=2,

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -6210,7 +6210,7 @@ class HfApi:
             "\n"
             "Use `upload_folder` instead:\n"
             "\n"
-            f'    api.upload_folder(repo_id="{repo_id}", repo_type="{repo_type}", folder_path="{folder_path}")\n'
+            f'    api.upload_folder(repo_id="{repo_id}", repo_type="{repo_type}", folder_path="{repr(folder_path)}")\n'
             "================================================================================\n",
             FutureWarning,
             stacklevel=2,

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -6213,9 +6213,7 @@ class HfApi:
             "================================================================================\n"
             "`upload_large_folder` is DEPRECATED and will be removed in a future release.\n"
             "\n"
-            "`upload_folder` is now resilient to interruptions and powered by Xet: it streams\n"
-            "files in multiple commits and resumes automatically if you re-run the same call.\n"
-            "Use it instead:\n"
+            "Use `upload_folder` instead:\n"
             "\n"
             f'    api.upload_folder(repo_id="{repo_id}", repo_type="{repo_type}", folder_path="{folder_path}")\n'
             "================================================================================\n",

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -6113,14 +6113,9 @@ class HfApi:
     ) -> None:
         """Upload a large folder to the Hub in the most resilient way possible.
 
-        <Tip warning={true}>
-
-        `upload_large_folder` is deprecated and will be removed in a future release. [`upload_folder`] is now resilient
-        to interruptions (it streams files in multiple commits and resumes automatically when re-run) and powered by Xet,
-        so it is the recommended way to upload large folders. Simply replace your call with
-        `api.upload_folder(repo_id=..., repo_type=..., folder_path=...)`.
-
-        </Tip>
+        > [!WARNING]
+        > `upload_large_folder` is deprecated and will be removed in a future release. [`upload_folder`] is now multi-commits
+        > by default and resilient to interruptions so it is the recommended way to upload large folders.
 
         Several workers are started to upload files in an optimized way. Before being committed to a repo, files must be
         hashed and be pre-uploaded if they are LFS files. Workers will perform these tasks for each file in the folder.

--- a/src/huggingface_hub/utils/_http.py
+++ b/src/huggingface_hub/utils/_http.py
@@ -332,12 +332,9 @@ def set_async_client_factory(async_client_factory: ASYNC_CLIENT_FACTORY_T) -> No
     This can be useful if you are running your scripts in a specific environment requiring custom configuration (e.g. custom proxy or certifications).
     Use [`get_async_client`] to get a correctly configured `httpx.AsyncClient`.
 
-    <Tip warning={true}>
-
-    Contrary to the `httpx.Client` that is shared between all calls made by `huggingface_hub`, the `httpx.AsyncClient` is not shared.
-    It is recommended to use an async context manager to ensure the client is properly closed when the context is exited.
-
-    </Tip>
+    > [!WARNING]
+    > Contrary to the `httpx.Client` that is shared between all calls made by `huggingface_hub`, the `httpx.AsyncClient` is not shared.
+    > It is recommended to use an async context manager to ensure the client is properly closed when the context is exited.
     """
     global _GLOBAL_ASYNC_CLIENT_FACTORY
     _GLOBAL_ASYNC_CLIENT_FACTORY = async_client_factory
@@ -364,12 +361,9 @@ def get_async_session() -> httpx.AsyncClient:
 
     Use [`set_async_client_factory`] to customize the `httpx.AsyncClient`.
 
-    <Tip warning={true}>
-
-    Contrary to the `httpx.Client` that is shared between all calls made by `huggingface_hub`, the `httpx.AsyncClient` is not shared.
-    It is recommended to use an async context manager to ensure the client is properly closed when the context is exited.
-
-    </Tip>
+    > [!WARNING]
+    > Contrary to the `httpx.Client` that is shared between all calls made by `huggingface_hub`, the `httpx.AsyncClient` is not shared.
+    > It is recommended to use an async context manager to ensure the client is properly closed when the context is exited.
     """
     return _GLOBAL_ASYNC_CLIENT_FACTORY()
 
@@ -644,17 +638,14 @@ def http_stream_backoff(
     ...     response.raise_for_status()
     ```
 
-    <Tip warning={true}>
-
-    When using `httpx` it is possible to stream data by passing an iterator to the
-    `data` argument. On http backoff this is a problem as the iterator is not reset
-    after a failed call. This issue is mitigated for file objects or any IO streams
-    by saving the initial position of the cursor (with `data.tell()`) and resetting the
-    cursor between each call (with `data.seek()`). For arbitrary iterators, http backoff
-    will fail. If this is a hard constraint for you, please let us know by opening an
-    issue on [Github](https://github.com/huggingface/huggingface_hub).
-
-    </Tip>
+    > [!WARNING]
+    > When using `httpx` it is possible to stream data by passing an iterator to the
+    > `data` argument. On http backoff this is a problem as the iterator is not reset
+    > after a failed call. This issue is mitigated for file objects or any IO streams
+    > by saving the initial position of the cursor (with `data.tell()`) and resetting the
+    > cursor between each call (with `data.seek()`). For arbitrary iterators, http backoff
+    > will fail. If this is a hard constraint for you, please let us know by opening an
+    > issue on [Github](https://github.com/huggingface/huggingface_hub).
     """
     yield from _http_backoff_base(
         method=method,

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -4644,9 +4644,10 @@ class TestLargeUpload(HfApiCommonTest):
                     (subfolder / f"file_regular_{i}_{j}.txt").write_bytes(f"content_regular_{i}_{j}".encode())
 
             # Upload the folder
-            self._api.upload_large_folder(
-                repo_id=repo_url.repo_id, repo_type=repo_url.repo_type, folder_path=folder, num_workers=4
-            )
+            with pytest.warns(FutureWarning, match="`upload_large_folder` is DEPRECATED"):
+                self._api.upload_large_folder(
+                    repo_id=repo_url.repo_id, repo_type=repo_url.repo_type, folder_path=folder, num_workers=4
+                )
 
         # Check all files have been uploaded
         uploaded_files = self._api.list_repo_files(repo_url.repo_id, repo_type=repo_url.repo_type)

--- a/tests/test_upload_large_folder.py
+++ b/tests/test_upload_large_folder.py
@@ -17,14 +17,6 @@ from huggingface_hub._upload_large_folder import (
 )
 
 
-def test_upload_large_folder_is_deprecated(tmp_path):
-    """`upload_large_folder` should warn and redirect users to `upload_folder`."""
-    with patch("huggingface_hub.hf_api.upload_large_folder_internal") as mock_internal:
-        with pytest.warns(FutureWarning, match="DEPRECATED"):
-            HfApi().upload_large_folder(repo_id="user/repo", folder_path=tmp_path, repo_type="model")
-    mock_internal.assert_called_once()
-
-
 @pytest.fixture
 def status():
     return LargeUploadStatus(items=[])

--- a/tests/test_upload_large_folder.py
+++ b/tests/test_upload_large_folder.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from huggingface_hub import HfApi
 from huggingface_hub._local_folder import LocalUploadFileMetadata, LocalUploadFilePaths
 from huggingface_hub._upload_large_folder import (
     COMMIT_SIZE_SCALE,
@@ -14,6 +15,14 @@ from huggingface_hub._upload_large_folder import (
     _build_hacky_operation,
     _validate_upload_limits,
 )
+
+
+def test_upload_large_folder_is_deprecated(tmp_path):
+    """`upload_large_folder` should warn and redirect users to `upload_folder`."""
+    with patch("huggingface_hub.hf_api.upload_large_folder_internal") as mock_internal:
+        with pytest.warns(FutureWarning, match="DEPRECATED"):
+            HfApi().upload_large_folder(repo_id="user/repo", folder_path=tmp_path, repo_type="model")
+    mock_internal.assert_called_once()
 
 
 @pytest.fixture

--- a/tests/test_upload_large_folder.py
+++ b/tests/test_upload_large_folder.py
@@ -5,7 +5,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from huggingface_hub import HfApi
 from huggingface_hub._local_folder import LocalUploadFileMetadata, LocalUploadFilePaths
 from huggingface_hub._upload_large_folder import (
     COMMIT_SIZE_SCALE,

--- a/tests/test_xet_upload.py
+++ b/tests/test_xet_upload.py
@@ -403,7 +403,8 @@ class TestXetLargeUpload:
                 (subfolder / f"file_regular_{i}_{j}.txt").write_bytes(f"content_regular_{i}_{j}".encode())
 
         with assert_upload_mode("xet"):
-            api.upload_large_folder(repo_id=repo_id, repo_type="model", folder_path=folder, num_workers=4)
+            with pytest.warns(FutureWarning, match="`upload_large_folder` is DEPRECATED"):
+                api.upload_large_folder(repo_id=repo_id, repo_type="model", folder_path=folder, num_workers=4)
 
         # Check all files have been uploaded
         uploaded_files = api.list_repo_files(repo_id=repo_id)
@@ -456,7 +457,8 @@ class TestXetLargeUpload:
             return real_upload_xet_files(**kwargs)
 
         with patch("huggingface_hub._commit_api._upload_xet_files", side_effect=spy_upload_xet_files):
-            api.upload_large_folder(repo_id=repo_id, repo_type="model", folder_path=folder, num_workers=4)
+            with pytest.warns(FutureWarning, match="`upload_large_folder` is DEPRECATED"):
+                api.upload_large_folder(repo_id=repo_id, repo_type="model", folder_path=folder, num_workers=4)
 
         # Verify _upload_xet_files was called (confirms xet upload path was used)
         assert len(num_files_per_call) > 0, "Expected _upload_xet_files to be called"


### PR DESCRIPTION
Follow-up after #4331.

This PR deprecates `upload_large_folder` (both API and CLI) in favor or `hf upload` and `upload_folder`.

- **API** (`HfApi.upload_large_folder`): prints a loud multi-line `FutureWarning` redirecting to `upload_folder`, with the equivalent call spelled out. Docstring gets a deprecation tip.
- **CLI** (`hf upload-large-folder`): prints a loud deprecation banner to stderr and recommends the **exact equivalent `hf upload` command** built from the user's args.
- **Docs**: removed the dedicated "Upload a large folder" walkthrough and the `hf upload-large-folder` guide section, replacing them with short redirects to `upload_folder` / `hf upload`. Kept the package-reference autodoc (the method still exists) and added deprecation notes there.


## Examples

API:
```
<string>:5: FutureWarning:
================================================================================
`upload_large_folder` is DEPRECATED and will be removed in a future release.

Use `upload_folder` instead:

    api.upload_folder(repo_id="Wauplin/my-model", repo_type="dataset", folder_path="/path/to/folder")
================================================================================
```

CLI:
```
$ hf upload-large-folder Wauplin/my-model ./dir --repo-type dataset --revision v1.0 --private --include '*.bin'

Warning: ================================================================================
`hf upload-large-folder` is DEPRECATED and will be removed in a future release.

Use `hf upload` instead:

    hf upload Wauplin/my-model ./dir --repo-type dataset --revision v1.0 --private --include '*.bin'
================================================================================
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Soft deprecation only: upload behavior is unchanged and users get explicit migration paths. Risk is mainly noise from new warnings until callers switch to `upload_folder` / `hf upload`.
> 
> **Overview**
> **Deprecates** `upload_large_folder` and `hf upload-large-folder` in favor of **`upload_folder`** / **`hf upload`**, which now cover large, resumable uploads. The legacy entry points still work but emit loud migration guidance.
> 
> On the **API**, `HfApi.upload_large_folder` raises a multi-line **`FutureWarning`** with an example `upload_folder` call and a deprecation note in the docstring. The **CLI** replaces the old “beta” preamble with a stderr banner that builds the **exact equivalent `hf upload …` command** from the user’s flags; it still calls the API but **suppresses** the duplicate `FutureWarning` so users only see the CLI message.
> 
> **Docs** (`upload.md`, CLI guides, `AGENTS.md`, package reference) steer readers to `upload_folder` / `hf upload` and mark the large-folder command as deprecated. **Tests** wrap existing `upload_large_folder` calls with `pytest.warns(FutureWarning)`. Unrelated doc-builder tweaks convert a few `<Tip warning>` blocks in `_http.py` to GitHub-style `> [!WARNING]` notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b522d6eb57076099c8576daf56a280487564e3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->