### PR TITLE
[CLI] Add `hf discussions edit`

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -1321,6 +1321,15 @@ Add a comment to an existing discussion or PR by specifying its number. The comm
 >>> echo "LGTM" | hf discussions comment username/my-model 5 --body-file -
 ```
 
+### Edit a comment
+
+Edit an existing comment in place by passing the discussion number and the comment ID. Comment IDs are available in the `events` array of `hf discussions info ... --format json`:
+
+```bash
+>>> hf discussions edit username/my-model 5 abc123 --body "Updated comment."
+>>> hf discussions edit username/my-model 5 abc123 --body-file fixed.md
+```
+
 ### Close, reopen, and merge
 
 You can close a discussion or PR with `hf discussions close`. By default, you will be prompted for confirmation. Pass `--yes` to skip the prompt, and `--comment` to leave a closing message:

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -1323,7 +1323,7 @@ Add a comment to an existing discussion or PR by specifying its number. The comm
 
 ### Edit a comment
 
-Edit an existing comment in place by passing the discussion number and the comment ID. Comment IDs are available in the `events` array of `hf discussions info ... --format json`:
+Edit an existing comment in place by passing the discussion number and the comment ID. Comment IDs can be retrieved with `hf discussions info`:
 
 ```bash
 >>> hf discussions edit username/my-model 5 abc123 --body "Updated comment."

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -1235,6 +1235,7 @@ $ hf discussions [OPTIONS] COMMAND [ARGS]...
 * `comment`: Comment on a discussion or pull request.
 * `create`: Create a new discussion or pull request on...
 * `diff`: Show the diff of a pull request.
+* `edit`: Edit an existing comment on a discussion...
 * `info`: Get info about a discussion or pull request.
 * `list`: List discussions and pull requests on a repo. [alias: ls]
 * `merge`: Merge a pull request.
@@ -1363,6 +1364,39 @@ $ hf discussions diff [OPTIONS] REPO_ID NUM
 
 Examples
   $ hf discussions diff username/my-model 5
+
+Learn more
+  Use `hf <command> --help` for more information about a command.
+  Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
+
+
+### `hf discussions edit`
+
+Edit an existing comment on a discussion or pull request.
+
+**Usage**:
+
+```console
+$ hf discussions edit [OPTIONS] REPO_ID NUM COMMENT_ID
+```
+
+**Arguments**:
+
+* `REPO_ID`: The ID of the repo (e.g. `username/repo-name` or `spaces/username/repo-name`).  [required]
+* `NUM`: The discussion or pull request number.  [required]
+* `COMMENT_ID`: The ID of the comment to edit (see 'hf discussions info ... --format json').  [required]
+
+**Options**:
+
+* `--body TEXT`: The new comment text (supports Markdown).
+* `--body-file PATH`: Read the new comment from a file. Use '-' for stdin.
+* `--type, --repo-type [model|dataset|space]`: The type of repository (model, dataset, or space).  [default: model]
+* `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
+* `--help`: Show this message and exit.
+
+Examples
+  $ hf discussions edit username/my-model 5 abc123 --body "Updated comment."
+  $ hf discussions edit username/my-model 5 abc123 --body-file fixed.md
 
 Learn more
   Use `hf <command> --help` for more information about a command.

--- a/src/huggingface_hub/cli/discussions.py
+++ b/src/huggingface_hub/cli/discussions.py
@@ -273,6 +273,54 @@ def discussion_comment(
 
 
 @discussions_cli.command(
+    "edit",
+    examples=[
+        'hf discussions edit username/my-model 5 abc123 --body "Updated comment."',
+        "hf discussions edit username/my-model 5 abc123 --body-file fixed.md",
+    ],
+)
+def discussion_edit(
+    repo_id: RepoIdArg,
+    num: DiscussionNumArg,
+    comment_id: Annotated[
+        str,
+        typer.Argument(
+            help="The ID of the comment to edit (see 'hf discussions info ... --format json').",
+        ),
+    ],
+    body: Annotated[
+        str | None,
+        typer.Option(
+            "--body",
+            help="The new comment text (supports Markdown).",
+        ),
+    ] = None,
+    body_file: Annotated[
+        Path | None,
+        typer.Option(
+            "--body-file",
+            help="Read the new comment from a file. Use '-' for stdin.",
+        ),
+    ] = None,
+    repo_type: RepoTypeOpt = RepoType.model,
+    token: TokenOpt = None,
+) -> None:
+    """Edit an existing comment on a discussion or pull request."""
+    new_content = _read_body(body, body_file)
+    if new_content is None:
+        raise typer.BadParameter("Either --body or --body-file is required.")
+    api = get_hf_api(token=token)
+    api.edit_discussion_comment(
+        repo_id=repo_id,
+        discussion_num=num,
+        comment_id=comment_id,
+        new_content=new_content,
+        repo_type=repo_type.value,
+    )
+    out.result(f"Edited comment {comment_id} on #{num} in {repo_id}", num=num, repo=repo_id, comment_id=comment_id)
+
+
+@discussions_cli.command(
     "close",
     examples=[
         "hf discussions close username/my-model 5",


### PR DESCRIPTION
## Summary

Closes #4411.

- Adds `hf discussions edit <repo_id> <num> <comment_id>` to edit an existing comment in place, mirroring `hf discussions comment` (`--body` / `--body-file` / stdin). Backed by `HfApi.edit_discussion_comment`.
- Updates the CLI guide and auto-generated CLI reference.

```
$ hf discussions edit username/my-model 5 abc123 --body "Updated comment."
$ hf discussions edit username/my-model 5 abc123 --body-file fixed.md
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Thin CLI wrapper over an existing Hub API with documentation-only changes elsewhere; no new auth or data-model logic in this diff.
> 
> **Overview**
> Adds **`hf discussions edit`** so users can update an existing discussion or PR comment from the terminal, using the same body input patterns as **`hf discussions comment`** (`--body`, `--body-file`, and stdin via `--body-file -`).
> 
> The command takes **`repo_id`**, discussion **`num`**, and **`comment_id`** (from `hf discussions info`), then calls **`HfApi.edit_discussion_comment`**. The CLI guide and package reference document the new subcommand and its options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ef9570d5ddab89bac5cbfaca91108a9b25b9f89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->