### PR TITLE
[CLI] hf cache: surface & prune incomplete downloads

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -1594,19 +1594,21 @@ When working outside the default cache location, pair the command with `--cache-
 
 ### hf cache prune
 
-`hf cache prune` is a convenience shortcut that deletes every detached (unreferenced) revision in your cache. This keeps only revisions that are still reachable through a branch or tag:
+`hf cache prune` is a convenience shortcut that reclaims space taken by cache garbage: every detached (unreferenced) revision (keeping only revisions still reachable through a branch or tag) and any leftover `.incomplete` files from interrupted downloads:
 
 ```bash
 >>> hf cache prune
-About to delete 3 unreferenced revision(s) (2.4G total).
+About to delete 3 unreferenced revision(s) and 2 incomplete download(s) (2.4G total).
   - model/t5-small:
       1c610f6b [refs/pr/1] 820.1M
       d4ec9b72 [(detached)] 640.5M
   - dataset/google/fleurs:
       2b91c8dd [(detached)] 937.6M
 Proceed? [y/N]: y
-Deleted 3 unreferenced revision(s); freed 2.4G.
+Deleted 3 unreferenced revision(s) and 2 incomplete download(s); freed 2.4G.
 ```
+
+`.incomplete` files are partial downloads left behind when a download is interrupted. They are not tracked by `hf cache ls`/`rm` (which work at the revision level), so `hf cache ls` points them out with a hint and `hf cache prune` removes them automatically.
 
 As with the other cache commands, `--dry-run`, `--yes`, and `--cache-dir` are available. Refer to the [Manage your cache](./manage-cache) guide for more examples.
 

--- a/docs/source/en/guides/manage-cache.md
+++ b/docs/source/en/guides/manage-cache.md
@@ -589,20 +589,26 @@ Dry run: no files were deleted.
 When working outside the default cache location, pair the command with
 `--cache-dir PATH`.
 
-To clean up detached snapshots in bulk, run `hf cache prune`. It automatically selects
-revisions that are no longer referenced by a branch or tag:
+To clean up cache garbage in bulk, run `hf cache prune`. It automatically deletes both
+revisions that are no longer referenced by a branch or tag and any leftover `.incomplete`
+files from interrupted downloads:
 
 ```text
 ➜ hf cache prune
-About to delete 3 unreferenced revision(s) (2.4G total).
+About to delete 3 unreferenced revision(s) and 2 incomplete download(s) (2.4G total).
   - model/t5-small:
       1c610f6b [refs/pr/1] 820.1M
       d4ec9b72 [(detached)] 640.5M
   - dataset/google/fleurs:
       2b91c8dd [(detached)] 937.6M
 Proceed? [y/N]: y
-Deleted 3 unreferenced revision(s); freed 2.4G.
+Deleted 3 unreferenced revision(s) and 2 incomplete download(s); freed 2.4G.
 ```
+
+`.incomplete` files are partial blobs left behind when a download is interrupted. They are
+not tracked by the revision-based scan, so `hf cache ls` only flags them with a hint
+(`Found X incomplete download(s) ...`) while `hf cache prune` is the command that actually
+removes them. `hf cache rm` never touches them, except when it deletes an entire repo.
 
 Both commands support `--dry-run`, `--yes`, and `--cache-dir` so you can preview, automate,
 and target alternate cache directories as needed.

--- a/docs/source/en/package_reference/cache.md
+++ b/docs/source/en/package_reference/cache.md
@@ -47,6 +47,10 @@ All structures are built and returned by [`scan_cache_dir`] and are immutable.
 [[autodoc]] huggingface_hub.CachedFileInfo
     - size_on_disk_str
 
+### CachedIncompleteFileInfo
+
+[[autodoc]] huggingface_hub.CachedIncompleteFileInfo
+
 ### DeleteCacheStrategy
 
 [[autodoc]] huggingface_hub.DeleteCacheStrategy

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -555,7 +555,7 @@ $ hf cache [OPTIONS] COMMAND [ARGS]...
 **Commands**:
 
 * `list`: List cached repositories or revisions. [alias: ls]
-* `prune`: Remove detached revisions from the cache.
+* `prune`: Remove detached revisions and incomplete...
 * `rm`: Remove cached repositories or revisions.
 * `verify`: Verify checksums for a single repo...
 
@@ -591,7 +591,7 @@ Learn more
 
 ### `hf cache prune`
 
-Remove detached revisions from the cache.
+Remove detached revisions and incomplete downloads from the cache.
 
 **Usage**:
 

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -589,6 +589,7 @@ _SUBMOD_ATTRS = {
         "CLIENT_FACTORY_T",
         "CacheNotFound",
         "CachedFileInfo",
+        "CachedIncompleteFileInfo",
         "CachedRepoInfo",
         "CachedRevisionInfo",
         "CorruptedCacheException",
@@ -646,6 +647,7 @@ __all__ = [
     "CONFIG_NAME",
     "CacheNotFound",
     "CachedFileInfo",
+    "CachedIncompleteFileInfo",
     "CachedRepoInfo",
     "CachedRevisionInfo",
     "CardData",
@@ -1746,6 +1748,7 @@ if TYPE_CHECKING:  # pragma: no cover
         ASYNC_CLIENT_FACTORY_T,  # noqa: F401
         CLIENT_FACTORY_T,  # noqa: F401
         CachedFileInfo,  # noqa: F401
+        CachedIncompleteFileInfo,  # noqa: F401
         CachedRepoInfo,  # noqa: F401
         CachedRevisionInfo,  # noqa: F401
         CacheNotFound,  # noqa: F401

--- a/src/huggingface_hub/cli/cache.py
+++ b/src/huggingface_hub/cli/cache.py
@@ -653,10 +653,10 @@ def prune(
 
     strategy = hf_cache_info.delete_revisions(*sorted(revisions))
     counts = summarize_deletions(selected)
-    expected_freed = strategy.expected_freed_size + hf_cache_info.incomplete_size_on_disk
+    total_freed = strategy.expected_freed_size + hf_cache_info.incomplete_size_on_disk
 
     summary = _prune_summary(counts.total_revision_count, len(incomplete_files))
-    out.text(f"About to delete {summary} ({_format_size(expected_freed)} total).")
+    out.text(f"About to delete {summary} ({_format_size(total_freed)} total).")
     print_cache_selected_revisions(selected)
 
     if dry_run:
@@ -665,33 +665,24 @@ def prune(
             dry_run=True,
             revisions=counts.total_revision_count,
             incomplete=len(incomplete_files),
-            size=_format_size(expected_freed),
+            size=_format_size(total_freed),
         )
         return
 
     out.confirm("Proceed?", yes=yes)
 
     strategy.execute()
-
-    # Track incomplete files that are actually removed (deletions may fail)
-    incomplete_deleted = 0
-    incomplete_freed = 0
     for incomplete_file in incomplete_files:
         try:
             incomplete_file.file_path.unlink()
         except FileNotFoundError:
-            pass
+            pass  # already removed (e.g. by a full-repo deletion above)
         except OSError as exc:
             out.warning(f"Could not delete incomplete file {incomplete_file.file_path}: {exc}")
-            continue
-        incomplete_deleted += 1
-        incomplete_freed += incomplete_file.size_on_disk
-
-    total_freed = strategy.expected_freed_size + incomplete_freed
     out.result(
-        f"Deleted {_prune_summary(counts.total_revision_count, incomplete_deleted)}; freed {_format_size(total_freed)}.",
+        f"Deleted {summary}; freed {_format_size(total_freed)}.",
         revisions_deleted=counts.total_revision_count,
-        incomplete_deleted=incomplete_deleted,
+        incomplete_deleted=len(incomplete_files),
         freed=_format_size(total_freed),
     )
 

--- a/src/huggingface_hub/cli/cache.py
+++ b/src/huggingface_hub/cli/cache.py
@@ -672,15 +672,15 @@ def prune(
     out.confirm("Proceed?", yes=yes)
 
     strategy.execute()
-    # Track what is actually removed: deletions may fail (e.g. permissions), so we can't
-    # rely on the projected totals for the final report.
+
+    # Track incomplete files that are actually removed (deletions may fail)
     incomplete_deleted = 0
     incomplete_freed = 0
     for incomplete_file in incomplete_files:
         try:
             incomplete_file.file_path.unlink()
         except FileNotFoundError:
-            pass  # already gone, nothing to free
+            pass
         except OSError as exc:
             out.warning(f"Could not delete incomplete file {incomplete_file.file_path}: {exc}")
             continue

--- a/src/huggingface_hub/cli/cache.py
+++ b/src/huggingface_hub/cli/cache.py
@@ -536,8 +536,8 @@ def ls(
     incomplete_files, incomplete_size = _scan_incomplete_files(cache_dir)
     if incomplete_files:
         out.hint(
-            f"Found {len(incomplete_files)} incomplete download(s) totalling {_format_size(incomplete_size)} "
-            "(leftovers from interrupted downloads). Remove them with 'hf cache prune'."
+            f"Found {len(incomplete_files)} incomplete download(s) totalling {_format_size(incomplete_size)}. "
+            "Remove them with 'hf cache prune'."
         )
 
 

--- a/src/huggingface_hub/cli/cache.py
+++ b/src/huggingface_hub/cli/cache.py
@@ -664,7 +664,7 @@ def prune(
             "Dry run: no files were deleted.",
             dry_run=True,
             revisions=counts.total_revision_count,
-            incomplete=len(incomplete_files),
+            incomplete=len(incomplete_files), # might be overstated but it's fine
             size=_format_size(total_freed),
         )
         return

--- a/src/huggingface_hub/cli/cache.py
+++ b/src/huggingface_hub/cli/cache.py
@@ -19,14 +19,12 @@ from collections import defaultdict
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from enum import Enum
-from pathlib import Path
 from typing import Annotated, Any
 
 import typer
 
 from huggingface_hub.errors import CLIError
 
-from ..constants import HF_HUB_CACHE
 from ..utils import (
     ANSI,
     CachedRepoInfo,
@@ -150,30 +148,6 @@ def build_cache_index(
         for revision in repo.revisions:
             revision_lookup[revision.commit_hash.lower()] = (repo, revision)
     return repo_lookup, revision_lookup
-
-
-def _scan_incomplete_files(cache_dir: str | None) -> tuple[list[Path], int]:
-    """Find orphaned `*.incomplete` partial-download files in the cache.
-
-    Interrupted downloads leave `<cache>/<repo>/blobs/<etag>.incomplete` files behind.
-    These are not tracked by [`scan_cache_dir`] (which only indexes committed blobs and
-    snapshots), so they are surfaced by `hf cache ls` and cleaned up by `hf cache prune`.
-
-    Returns a `(files, total_size)` tuple where `total_size` is in bytes.
-    """
-    root = Path(cache_dir if cache_dir is not None else HF_HUB_CACHE).expanduser().resolve()
-    if not root.is_dir():
-        return [], 0
-
-    files: list[Path] = []
-    total_size = 0
-    for path in sorted(root.glob("*/blobs/*.incomplete")):
-        try:
-            total_size += path.stat().st_size
-        except OSError:
-            continue  # file vanished between glob and stat
-        files.append(path)
-    return files, total_size
 
 
 def _repo_cache_id_from_target(target: str) -> str:
@@ -533,10 +507,11 @@ def ls(
             )
         )
 
-    incomplete_files, incomplete_size = _scan_incomplete_files(cache_dir)
+    incomplete_files = hf_cache_info.incomplete_files
     if incomplete_files:
         out.hint(
-            f"Found {len(incomplete_files)} incomplete download(s) totalling {_format_size(incomplete_size)}. "
+            f"Found {len(incomplete_files)} incomplete download(s) totalling "
+            f"{_format_size(hf_cache_info.incomplete_size_on_disk)}. "
             "Remove them with 'hf cache prune'."
         )
 
@@ -670,7 +645,7 @@ def prune(
         selected[repo] = detached
         revisions.update(revision.commit_hash for revision in detached)
 
-    incomplete_files, incomplete_size = _scan_incomplete_files(cache_dir)
+    incomplete_files = hf_cache_info.incomplete_files
 
     if len(revisions) == 0 and not incomplete_files:
         out.text("No unreferenced revisions or incomplete downloads found. Nothing to prune.")
@@ -678,7 +653,7 @@ def prune(
 
     strategy = hf_cache_info.delete_revisions(*sorted(revisions))
     counts = summarize_deletions(selected)
-    total_freed = strategy.expected_freed_size + incomplete_size
+    total_freed = strategy.expected_freed_size + hf_cache_info.incomplete_size_on_disk
 
     summary = _prune_summary(counts.total_revision_count, len(incomplete_files))
     out.text(f"About to delete {summary} ({_format_size(total_freed)} total).")
@@ -697,13 +672,13 @@ def prune(
     out.confirm("Proceed?", yes=yes)
 
     strategy.execute()
-    for path in incomplete_files:
+    for incomplete_file in incomplete_files:
         try:
-            path.unlink()
+            incomplete_file.file_path.unlink()
         except FileNotFoundError:
             pass
         except OSError as exc:
-            out.warning(f"Could not delete incomplete file {path}: {exc}")
+            out.warning(f"Could not delete incomplete file {incomplete_file.file_path}: {exc}")
     out.result(
         f"Deleted {summary}; freed {_format_size(total_freed)}.",
         revisions_deleted=counts.total_revision_count,

--- a/src/huggingface_hub/cli/cache.py
+++ b/src/huggingface_hub/cli/cache.py
@@ -653,10 +653,10 @@ def prune(
 
     strategy = hf_cache_info.delete_revisions(*sorted(revisions))
     counts = summarize_deletions(selected)
-    total_freed = strategy.expected_freed_size + hf_cache_info.incomplete_size_on_disk
+    expected_freed = strategy.expected_freed_size + hf_cache_info.incomplete_size_on_disk
 
     summary = _prune_summary(counts.total_revision_count, len(incomplete_files))
-    out.text(f"About to delete {summary} ({_format_size(total_freed)} total).")
+    out.text(f"About to delete {summary} ({_format_size(expected_freed)} total).")
     print_cache_selected_revisions(selected)
 
     if dry_run:
@@ -665,24 +665,33 @@ def prune(
             dry_run=True,
             revisions=counts.total_revision_count,
             incomplete=len(incomplete_files),
-            size=_format_size(total_freed),
+            size=_format_size(expected_freed),
         )
         return
 
     out.confirm("Proceed?", yes=yes)
 
     strategy.execute()
+    # Track what is actually removed: deletions may fail (e.g. permissions), so we can't
+    # rely on the projected totals for the final report.
+    incomplete_deleted = 0
+    incomplete_freed = 0
     for incomplete_file in incomplete_files:
         try:
             incomplete_file.file_path.unlink()
         except FileNotFoundError:
-            pass
+            pass  # already gone, nothing to free
         except OSError as exc:
             out.warning(f"Could not delete incomplete file {incomplete_file.file_path}: {exc}")
+            continue
+        incomplete_deleted += 1
+        incomplete_freed += incomplete_file.size_on_disk
+
+    total_freed = strategy.expected_freed_size + incomplete_freed
     out.result(
-        f"Deleted {summary}; freed {_format_size(total_freed)}.",
+        f"Deleted {_prune_summary(counts.total_revision_count, incomplete_deleted)}; freed {_format_size(total_freed)}.",
         revisions_deleted=counts.total_revision_count,
-        incomplete_deleted=len(incomplete_files),
+        incomplete_deleted=incomplete_deleted,
         freed=_format_size(total_freed),
     )
 

--- a/src/huggingface_hub/cli/cache.py
+++ b/src/huggingface_hub/cli/cache.py
@@ -19,12 +19,14 @@ from collections import defaultdict
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from enum import Enum
+from pathlib import Path
 from typing import Annotated, Any
 
 import typer
 
 from huggingface_hub.errors import CLIError
 
+from ..constants import HF_HUB_CACHE
 from ..utils import (
     ANSI,
     CachedRepoInfo,
@@ -108,6 +110,16 @@ def summarize_deletions(
     return CacheDeletionCounts(repo_count, partial_revision_count, total_revisions)
 
 
+def _prune_summary(revision_count: int, incomplete_count: int) -> str:
+    """Build the human-readable summary of what `hf cache prune` is about to delete."""
+    parts: list[str] = []
+    if revision_count:
+        parts.append(f"{revision_count} unreferenced revision(s)")
+    if incomplete_count:
+        parts.append(f"{incomplete_count} incomplete download(s)")
+    return " and ".join(parts)
+
+
 def print_cache_selected_revisions(selected_by_repo: Mapping[CachedRepoInfo, frozenset[CachedRevisionInfo]]) -> None:
     """Pretty-print selected cache revisions during confirmation prompts."""
     for repo in sorted(selected_by_repo.keys(), key=lambda repo: (repo.repo_type, repo.repo_id.lower())):
@@ -138,6 +150,30 @@ def build_cache_index(
         for revision in repo.revisions:
             revision_lookup[revision.commit_hash.lower()] = (repo, revision)
     return repo_lookup, revision_lookup
+
+
+def _scan_incomplete_files(cache_dir: str | None) -> tuple[list[Path], int]:
+    """Find orphaned `*.incomplete` partial-download files in the cache.
+
+    Interrupted downloads leave `<cache>/<repo>/blobs/<etag>.incomplete` files behind.
+    These are not tracked by [`scan_cache_dir`] (which only indexes committed blobs and
+    snapshots), so they are surfaced by `hf cache ls` and cleaned up by `hf cache prune`.
+
+    Returns a `(files, total_size)` tuple where `total_size` is in bytes.
+    """
+    root = Path(cache_dir if cache_dir is not None else HF_HUB_CACHE).expanduser().resolve()
+    if not root.is_dir():
+        return [], 0
+
+    files: list[Path] = []
+    total_size = 0
+    for path in sorted(root.glob("*/blobs/*.incomplete")):
+        try:
+            total_size += path.stat().st_size
+        except OSError:
+            continue  # file vanished between glob and stat
+        files.append(path)
+    return files, total_size
 
 
 def _repo_cache_id_from_target(target: str) -> str:
@@ -497,6 +533,13 @@ def ls(
             )
         )
 
+    incomplete_files, incomplete_size = _scan_incomplete_files(cache_dir)
+    if incomplete_files:
+        out.hint(
+            f"Found {len(incomplete_files)} incomplete download(s) totalling {_format_size(incomplete_size)} "
+            "(leftovers from interrupted downloads). Remove them with 'hf cache prune'."
+        )
+
 
 @cache_cli.command(
     examples=[
@@ -612,7 +655,7 @@ def prune(
         ),
     ] = False,
 ) -> None:
-    """Remove detached revisions from the cache."""
+    """Remove detached revisions and incomplete downloads from the cache."""
     try:
         hf_cache_info = scan_cache_dir(cache_dir)
     except CacheNotFound as exc:
@@ -627,21 +670,18 @@ def prune(
         selected[repo] = detached
         revisions.update(revision.commit_hash for revision in detached)
 
-    if len(revisions) == 0:
-        out.text("No unreferenced revisions found. Nothing to prune.")
+    incomplete_files, incomplete_size = _scan_incomplete_files(cache_dir)
+
+    if len(revisions) == 0 and not incomplete_files:
+        out.text("No unreferenced revisions or incomplete downloads found. Nothing to prune.")
         return
 
-    resolution = _DeletionResolution(
-        revisions=frozenset(revisions),
-        selected=selected,
-        missing=(),
-    )
-    strategy = hf_cache_info.delete_revisions(*sorted(resolution.revisions))
+    strategy = hf_cache_info.delete_revisions(*sorted(revisions))
     counts = summarize_deletions(selected)
+    total_freed = strategy.expected_freed_size + incomplete_size
 
-    out.text(
-        f"About to delete {counts.total_revision_count} unreferenced revision(s) ({strategy.expected_freed_size_str} total)."
-    )
+    summary = _prune_summary(counts.total_revision_count, len(incomplete_files))
+    out.text(f"About to delete {summary} ({_format_size(total_freed)} total).")
     print_cache_selected_revisions(selected)
 
     if dry_run:
@@ -649,17 +689,26 @@ def prune(
             "Dry run: no files were deleted.",
             dry_run=True,
             revisions=counts.total_revision_count,
-            size=strategy.expected_freed_size_str,
+            incomplete=len(incomplete_files),
+            size=_format_size(total_freed),
         )
         return
 
     out.confirm("Proceed?", yes=yes)
 
     strategy.execute()
+    for path in incomplete_files:
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            out.warning(f"Could not delete incomplete file {path}: {exc}")
     out.result(
-        f"Deleted {counts.total_revision_count} unreferenced revision(s); freed {strategy.expected_freed_size_str}.",
+        f"Deleted {summary}; freed {_format_size(total_freed)}.",
         revisions_deleted=counts.total_revision_count,
-        freed=strategy.expected_freed_size_str,
+        incomplete_deleted=len(incomplete_files),
+        freed=_format_size(total_freed),
     )
 
 

--- a/src/huggingface_hub/cli/cache.py
+++ b/src/huggingface_hub/cli/cache.py
@@ -664,7 +664,7 @@ def prune(
             "Dry run: no files were deleted.",
             dry_run=True,
             revisions=counts.total_revision_count,
-            incomplete=len(incomplete_files), # might be overstated but it's fine
+            incomplete=len(incomplete_files),  # might be overstated but it's fine
             size=_format_size(total_freed),
         )
         return

--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -39,6 +39,7 @@ from ._auth import get_stored_tokens, get_token
 from ._cache_assets import cached_assets_path
 from ._cache_manager import (
     CachedFileInfo,
+    CachedIncompleteFileInfo,
     CachedRepoInfo,
     CachedRevisionInfo,
     DeleteCacheStrategy,

--- a/src/huggingface_hub/utils/_cache_manager.py
+++ b/src/huggingface_hub/utils/_cache_manager.py
@@ -723,7 +723,7 @@ def _scan_incomplete_files(cache_dir: Path) -> frozenset[CachedIncompleteFileInf
         try:
             size_on_disk = path.stat().st_size
         except OSError:
-            continue  # file vanished between glob and stat
+            continue
         files.add(CachedIncompleteFileInfo(file_path=path, size_on_disk=size_on_disk))
     return frozenset(files)
 

--- a/src/huggingface_hub/utils/_cache_manager.py
+++ b/src/huggingface_hub/utils/_cache_manager.py
@@ -344,15 +344,6 @@ class CachedIncompleteFileInfo:
     file_path: Path
     size_on_disk: int
 
-    @property
-    def size_on_disk_str(self) -> str:
-        """
-        (property) Size of the partially-downloaded file as a human-readable string.
-
-        Example: "42.2K".
-        """
-        return _format_size(self.size_on_disk)
-
 
 @dataclass(frozen=True)
 class HFCacheInfo:

--- a/src/huggingface_hub/utils/_cache_manager.py
+++ b/src/huggingface_hub/utils/_cache_manager.py
@@ -327,6 +327,34 @@ class DeleteCacheStrategy:
 
 
 @dataclass(frozen=True)
+class CachedIncompleteFileInfo:
+    """Frozen data structure holding information about a single incomplete download.
+
+    Interrupted downloads leave `<cache>/<repo>/blobs/<etag>.incomplete` files behind.
+    These are not part of any committed revision, so they are surfaced separately by
+    [`scan_cache_dir`].
+
+    Args:
+        file_path (`Path`):
+            Path of the `.incomplete` file in the `blobs` folder.
+        size_on_disk (`int`):
+            Size of the partially-downloaded file in bytes.
+    """
+
+    file_path: Path
+    size_on_disk: int
+
+    @property
+    def size_on_disk_str(self) -> str:
+        """
+        (property) Size of the partially-downloaded file as a human-readable string.
+
+        Example: "42.2K".
+        """
+        return _format_size(self.size_on_disk)
+
+
+@dataclass(frozen=True)
 class HFCacheInfo:
     """Frozen data structure holding information about the entire cache-system.
 
@@ -338,6 +366,9 @@ class HFCacheInfo:
         repos (`frozenset[CachedRepoInfo]`):
             Set of [`~CachedRepoInfo`] describing all valid cached repos found on the
             cache-system while scanning.
+        incomplete_files (`frozenset[CachedIncompleteFileInfo]`):
+            Set of [`~CachedIncompleteFileInfo`] describing orphaned `*.incomplete`
+            files left behind by interrupted downloads.
         warnings (`list[CorruptedCacheException]`):
             List of [`~CorruptedCacheException`] that occurred while scanning the cache.
             Those exceptions are captured so that the scan can continue. Corrupted repos
@@ -350,6 +381,7 @@ class HFCacheInfo:
 
     size_on_disk: int
     repos: frozenset[CachedRepoInfo]
+    incomplete_files: frozenset[CachedIncompleteFileInfo]
     warnings: list[CorruptedCacheException]
 
     @property
@@ -361,6 +393,11 @@ class HFCacheInfo:
         Example: "42.2K".
         """
         return _format_size(self.size_on_disk)
+
+    @property
+    def incomplete_size_on_disk(self) -> int:
+        """(property) Sum of all incomplete download sizes in bytes."""
+        return sum(file.size_on_disk for file in self.incomplete_files)
 
     def delete_revisions(self, *revisions: str) -> DeleteCacheStrategy:
         """Prepare the strategy to delete one or more revisions cached locally.
@@ -669,8 +706,26 @@ def scan_cache_dir(cache_dir: str | Path | None = None) -> HFCacheInfo:
     return HFCacheInfo(
         repos=frozenset(repos),
         size_on_disk=sum(repo.size_on_disk for repo in repos),
+        incomplete_files=_scan_incomplete_files(cache_dir),
         warnings=warnings,
     )
+
+
+def _scan_incomplete_files(cache_dir: Path) -> frozenset[CachedIncompleteFileInfo]:
+    """Find orphaned `*.incomplete` partial-download files in the cache.
+
+    Interrupted downloads leave `<cache>/<repo>/blobs/<etag>.incomplete` files behind.
+    These are not part of any committed revision, so they are reported separately in the
+    [`~HFCacheInfo`] returned by [`scan_cache_dir`].
+    """
+    files: set[CachedIncompleteFileInfo] = set()
+    for path in cache_dir.glob("*/blobs/*.incomplete"):
+        try:
+            size_on_disk = path.stat().st_size
+        except OSError:
+            continue  # file vanished between glob and stat
+        files.add(CachedIncompleteFileInfo(file_path=path, size_on_disk=size_on_disk))
+    return frozenset(files)
 
 
 def _scan_cached_repo(repo_path: Path) -> CachedRepoInfo:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -287,9 +287,11 @@ class TestCacheCommand:
 
         counts = CacheDeletionCounts(repo_count=0, partial_revision_count=1, total_revision_count=1)
 
+        hf_cache_info.incomplete_files = frozenset()
+        hf_cache_info.incomplete_size_on_disk = 0
+
         with (
             patch("huggingface_hub.cli.cache.scan_cache_dir", return_value=hf_cache_info),
-            patch("huggingface_hub.cli.cache._scan_incomplete_files", return_value=([], 0)),
             patch(
                 "huggingface_hub.cli.cache.summarize_deletions",
                 return_value=counts,
@@ -436,6 +438,7 @@ class TestCacheCommand:
             hf_cache_info = HFCacheInfo(
                 size_on_disk=blob_path.stat().st_size,
                 repos=frozenset({repo}),
+                incomplete_files=frozenset(),
                 warnings=[],
             )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -281,6 +281,7 @@ class TestCacheCommand:
         hf_cache_info.repos = frozenset({repo})
 
         strategy = Mock()
+        strategy.expected_freed_size = 0
         strategy.expected_freed_size_str = "0B"
         hf_cache_info.delete_revisions.return_value = strategy
 
@@ -288,6 +289,7 @@ class TestCacheCommand:
 
         with (
             patch("huggingface_hub.cli.cache.scan_cache_dir", return_value=hf_cache_info),
+            patch("huggingface_hub.cli.cache._scan_incomplete_files", return_value=([], 0)),
             patch(
                 "huggingface_hub.cli.cache.summarize_deletions",
                 return_value=counts,
@@ -300,6 +302,39 @@ class TestCacheCommand:
         hf_cache_info.delete_revisions.assert_called_once_with(detached.commit_hash)
         strategy.execute.assert_not_called()
         print_mock.assert_called_once()
+
+    def test_prune_deletes_incomplete_files(self, runner: CliRunner) -> None:
+        # Build a minimal cache dir with an orphaned `.incomplete` file and no revisions.
+        with SoftTemporaryDirectory() as tmp_dir:
+            cache_dir = Path(tmp_dir)
+            repo_dir = cache_dir / "models--user--model"
+            (repo_dir / "snapshots").mkdir(parents=True)
+            (repo_dir / "refs").mkdir()
+            blobs_dir = repo_dir / "blobs"
+            blobs_dir.mkdir()
+            incomplete = blobs_dir / ("a" * 64 + ".incomplete")
+            incomplete.write_bytes(b"partial download")
+
+            result = runner.invoke(app, ["cache", "prune", "--cache-dir", str(cache_dir), "--yes"])
+
+            assert result.exit_code == 0
+            assert "1 incomplete download(s)" in result.output
+            assert not incomplete.exists()
+
+    def test_ls_hints_incomplete_files(self, runner: CliRunner) -> None:
+        with SoftTemporaryDirectory() as tmp_dir:
+            cache_dir = Path(tmp_dir)
+            repo_dir = cache_dir / "models--user--model"
+            (repo_dir / "snapshots").mkdir(parents=True)
+            blobs_dir = repo_dir / "blobs"
+            blobs_dir.mkdir()
+            (blobs_dir / ("a" * 64 + ".incomplete")).write_bytes(b"partial download")
+
+            result = runner.invoke(app, ["cache", "ls", "--cache-dir", str(cache_dir)])
+
+            assert result.exit_code == 0
+            assert "1 incomplete download(s)" in result.output
+            assert "hf cache prune" in result.output
 
     def test_verify_success(self, runner: CliRunner) -> None:
         repo_id = "user/model"


### PR DESCRIPTION
## Summary

Closes #4412. Interrupted downloads leave orphaned `*.incomplete` blobs in the cache that `scan_cache_dir` doesn't track. Rather than a `--incomplete` flag on `prune`, this wires them into the existing commands:

- **`hf cache ls`** scans for `*.incomplete` files and prints a hint at the end:
  `Hint: Found 2 incomplete download(s) totalling 7.0M (leftovers from interrupted downloads). Remove them with 'hf cache prune'.`
- **`hf cache prune`** now deletes them automatically (no flag), alongside detached revisions.
- **`hf cache rm`** is unchanged — it never touches `.incomplete` files, except when deleting a full repo (the whole repo dir is `rmtree`'d).

## Examples

```
➜ hf cache ls --cache-dir ./cache
(...)
Hint: Found 56 incomplete download(s) totalling 1.5G. Remove them with 'hf cache prune'.
```
```
➜ hf cache prune --cache-dir ./cache
About to delete 2 unreferenced revision(s) and 56 incomplete download(s) (2.5G total).
  - model/google/gemma-4-31B-it:
      419b2efe421994fdfd3394e621983d4cc511cd4f [(detached)] 169.3K
  - model/kernels-community/flash-attn2:
      172e23272e585d3c0d97124bc690593af81a0b95 [(detached)] 1.0G
Proceed? [y/N]:
Cache deletion done. Saved 1.0G.
✓ Deleted 2 unreferenced revision(s) and 56 incomplete download(s); freed 2.5G.
  revisions_deleted: 2
  incomplete_deleted: 56
  freed: 2.5G
```
```
➜ hf cache prune --cache-dir ./cache
No unreferenced revisions or incomplete downloads found. Nothing to prune.
```

Docs (`manage-cache`, `cli` guides, CLI reference) and a minimal test for `ls`/`prune` included.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are localized to cache scanning and CLI cleanup; prune only deletes known orphan `.incomplete` paths and detached revisions, with no auth or download-path changes.
> 
> **Overview**
> **`scan_cache_dir`** now discovers orphaned `*.incomplete` blobs under `*/blobs/` and exposes them on **`HFCacheInfo`** via new **`CachedIncompleteFileInfo`** and **`incomplete_size_on_disk`**.
> 
> **`hf cache ls`** prints a hint when incomplete downloads are present and points users to **`hf cache prune`**. **`hf cache prune`** removes those files automatically (no new flag), together with detached revisions, with updated messaging and freed-size accounting. **`hf cache rm`** behavior is unchanged except when wiping a whole repo.
> 
> Docs and public exports are updated; CLI tests cover the hint and prune deletion paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd57f48aafafb28c7a068b9412cf2ff0b569c206. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->