### PR TITLE
[URIs] Percent-encode the revision in HfUri.to_url

### DIFF
--- a/src/huggingface_hub/utils/_hf_uris.py
+++ b/src/huggingface_hub/utils/_hf_uris.py
@@ -190,10 +190,12 @@ class HfUri:
         # Models live at the root ('hf.co/<id>'); other repos are namespaced by their plural prefix.
         url = f"{base}/{self.id}" if self.type == "model" else f"{base}/{_TYPE_TO_PREFIX[self.type]}/{self.id}"
         revision = self.revision
-        # Encode '/' in branch/tag names so the revision stays a single URL segment. Special refs
+        # Percent-encode the branch/tag name so it stays a single, URL-safe segment: a '/' would
+        # otherwise open a new path segment and '#'/'?' would be read as a fragment/query when the
+        # URL is opened or parsed back. This mirrors the decoding done when parsing. Special refs
         # ('refs/pr/N', 'refs/convert/<name>') are used verbatim by the Hub web routes.
-        if revision is not None and "/" in revision and _SPECIAL_REFS_REVISION_REGEX.fullmatch(revision) is None:
-            revision = revision.replace("/", "%2F")
+        if revision is not None and _SPECIAL_REFS_REVISION_REGEX.fullmatch(revision) is None:
+            revision = quote(revision, safe="")
         if path:
             url += f"/blob/{revision or constants.DEFAULT_REVISION}/{path}"
         elif revision is not None:

--- a/tests/test_utils_hf_uris.py
+++ b/tests/test_utils_hf_uris.py
@@ -474,6 +474,16 @@ TO_URL_CASES: list[tuple[HfUri, str]] = [
         HfUri(type="model", id="my-org/my-model", revision="feature/foo", path_in_repo="config.json"),
         "/my-org/my-model/blob/feature%2Ffoo/config.json",
     ),
+    # Branch name with '#' is percent-encoded so it is not read as a URL fragment (blob route)
+    (
+        HfUri(type="model", id="my-org/my-model", revision="fix#1", path_in_repo="config.json"),
+        "/my-org/my-model/blob/fix%231/config.json",
+    ),
+    # '#' in the revision is also encoded on the folder (tree) route
+    (
+        HfUri(type="dataset", id="my-org/my-dataset", revision="fix#1"),
+        "/datasets/my-org/my-dataset/tree/fix%231",
+    ),
     # Path with special characters is percent-encoded ('/' kept as the separator)
     (
         HfUri(type="model", id="my-org/my-model", revision="main", path_in_repo="dir/my file#1.txt"),


### PR DESCRIPTION
## Summary

`HfUri.to_url()` percent-encodes the path but only swapped `/` in the revision, so a branch/tag name with a `#` in it (which git allows, e.g. `fix#1`) is left as a literal `#` in the URL. Both a browser and `parse_hf_uri` then treat everything after it as a fragment, so the link points at the wrong place and the URI doesn't round-trip:

```py
>>> from huggingface_hub import parse_hf_uri, HfUri
>>> u = HfUri(type="model", id="my-org/my-model", revision="fix#1", path_in_repo="config.json")
>>> u.to_url()
'https://huggingface.co/my-org/my-model/blob/fix#1/config.json'
>>> parse_hf_uri(u.to_url())            # revision + path silently lost
HfUri(type='model', id='my-org/my-model', revision='fix', path_in_repo='')
```

The path side already handles this (`to_url` encodes `#` in filenames, and there's a test for it); the revision just wasn't getting the same treatment. I swapped the manual `/` → `%2F` replacement for `quote(revision, safe="")`, so the whole revision segment is encoded — the inverse of the `unquote()` the parser does. Special refs (`refs/pr/N`, `refs/convert/<name>`) are still emitted verbatim, since the Hub web routes expect their literal `/`.

After:

```py
>>> u.to_url()
'https://huggingface.co/my-org/my-model/blob/fix%231/config.json'
>>> parse_hf_uri(u.to_url())
HfUri(type='model', id='my-org/my-model', revision='fix#1', path_in_repo='config.json')
```

Added two `to_url` cases (blob + tree routes) covering a `#` in the revision. `make quality` and `pytest tests/test_utils_hf_uris.py` pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to URL rendering in the HF URI helper with added tests; no auth, data, or API behavior changes.
> 
> **Overview**
> **`HfUri.to_url()`** now percent-encodes the full revision segment with `quote(revision, safe="")` instead of only turning `/` into `%2F`. Branch or tag names that include `#` or `?` (valid in git, e.g. `fix#1`) no longer break browser links or **`parse_hf_uri`** round-trips, which previously treated `#` as a URL fragment and dropped the path.
> 
> Special refs (`refs/pr/N`, `refs/convert/...`) are still written literally for Hub routes. Tests cover `#` in the revision on both **blob** and **tree** URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ed452a9ada1f89f8c19220a5165deba973c8b3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->