### PR TITLE
[Upload] Show "uploading metadata" indicator during xet finalization

### DIFF
--- a/src/huggingface_hub/utils/_xet_progress_reporting.py
+++ b/src/huggingface_hub/utils/_xet_progress_reporting.py
@@ -1,8 +1,13 @@
+import time
 from collections import OrderedDict
 from typing import Any
 
 from . import is_google_colab, is_notebook
 from .tqdm import tqdm
+
+
+# Braille spinner frames cycled while the upload is finalizing (uploading metadata).
+_SPINNER_FRAMES = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
 
 
 class XetProgressReporter:
@@ -49,6 +54,12 @@ class XetProgressReporter:
         self.item_state: OrderedDict[str, Any] = OrderedDict()
         self.current_bars: list = [None] * self.n_lines
 
+        # Finalization indicator: shown once all data is uploaded and hf_xet is uploading
+        # shards/metadata (the "stuck at 100%" window). Created lazily on first detection.
+        self._finalize_bar: tqdm | None = None
+        self._finalize_start: float | None = None
+        self._spinner_idx: int = 0
+
     def format_desc(self, name: str, indent: bool) -> str:
         """
         if name is longer than width characters, prints ... at the start and then the last width-3 characters of the name, otherwise
@@ -74,6 +85,12 @@ class XetProgressReporter:
         self.known_items.clear()
         self.completed_items.clear()
         self.item_state.clear()
+
+        if self._finalize_bar is not None:
+            self._finalize_bar.close()
+            self._finalize_bar = None
+        self._finalize_start = None
+        self._spinner_idx = 0
 
     def update_progress(self, group_report, item_reports: dict):
         # Update all the per-item values.
@@ -169,7 +186,49 @@ class XetProgressReporter:
         self.upload_bar.set_postfix_str(postfix(group_report.total_transfer_bytes_completion_rate), refresh=False)
         self.upload_bar.update(transfer_inc)
 
+        self._update_finalizing(group_report)
+
+    def _finalize_position(self) -> int:
+        # Sit below the summary bars (and below the per-file bar slots in console mode).
+        return 2 + self.n_lines if self.per_file_progress else 2
+
+    def _update_finalizing(self, group_report) -> None:
+        """Show/animate the 'uploading metadata' line during hf_xet's post-transfer finalization.
+
+        All data is uploaded once processing is complete and every unique (post-dedup) byte has
+        been transferred. The progress callback keeps firing during finalization with static byte
+        counts, so we animate a spinner to make clear the upload is finalizing, not stuck.
+        """
+        finalizing = (
+            group_report.total_bytes > 0
+            and group_report.total_bytes_completed >= group_report.total_bytes
+            and group_report.total_transfer_bytes_completed >= group_report.total_transfer_bytes
+        )
+        if not finalizing:
+            return
+
+        if self._finalize_bar is None:
+            self._finalize_start = time.monotonic()
+            self._finalize_bar = tqdm(
+                total=0, position=self._finalize_position(), bar_format="{desc}", leave=self.tqdm_settings["leave"]
+            )
+        else:
+            self._spinner_idx += 1
+
+        start = self._finalize_start if self._finalize_start is not None else time.monotonic()
+        spinner = _SPINNER_FRAMES[self._spinner_idx % len(_SPINNER_FRAMES)]
+        elapsed = int(time.monotonic() - start)
+        prefix = self.format_desc("Finalizing", False)
+        self._finalize_bar.set_description_str(f"{prefix}  {spinner} uploading metadata… ({elapsed}s)", refresh=True)
+
     def close(self):
+        if self._finalize_bar is not None:
+            if self._finalize_start is not None:
+                elapsed = int(time.monotonic() - self._finalize_start)
+                prefix = self.format_desc("Finalizing", False)
+                self._finalize_bar.set_description_str(f"{prefix}  ✓ metadata uploaded ({elapsed}s)", refresh=True)
+            self._finalize_bar.close()
+
         self.data_processing_bar.close()
         self.upload_bar.close()
 

--- a/tests/test_xet_progress_reporting.py
+++ b/tests/test_xet_progress_reporting.py
@@ -1,0 +1,84 @@
+# Copyright 2025 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for `XetProgressReporter` (no network / no xet binding required)."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from huggingface_hub.utils import disable_progress_bars, enable_progress_bars
+from huggingface_hub.utils._xet_progress_reporting import XetProgressReporter
+
+
+@pytest.fixture(autouse=True)
+def _silence_progress_bars():
+    # Keep test output clean and TTY-independent; the reporter objects still behave normally.
+    disable_progress_bars()
+    yield
+    enable_progress_bars()
+
+
+def _group(total_bytes, bytes_completed, transfer_total, transfer_completed):
+    return SimpleNamespace(
+        total_bytes=total_bytes,
+        total_bytes_completed=bytes_completed,
+        total_bytes_completion_rate=1.0,
+        total_transfer_bytes=transfer_total,
+        total_transfer_bytes_completed=transfer_completed,
+        total_transfer_bytes_completion_rate=1.0,
+    )
+
+
+def _item(name, bytes_completed, total_bytes):
+    return SimpleNamespace(item_name=name, bytes_completed=bytes_completed, total_bytes=total_bytes)
+
+
+class TestFinalizingIndicator:
+    def test_no_finalize_line_while_transfer_in_progress(self):
+        reporter = XetProgressReporter()
+        try:
+            # Processing/transfer still in flight: no finalization indicator yet.
+            reporter.update_progress(_group(1000, 400, 800, 300), {"a.bin": _item("a.bin", 400, 1000)})
+            assert getattr(reporter, "_finalize_bar", None) is None
+        finally:
+            reporter.close()
+
+    def test_finalize_line_appears_once_transfer_completes(self):
+        reporter = XetProgressReporter()
+        try:
+            # All data processed and all unique bytes transferred -> finalizing (metadata upload).
+            reporter.update_progress(_group(1000, 1000, 800, 800), {"a.bin": _item("a.bin", 1000, 1000)})
+            assert getattr(reporter, "_finalize_bar", None) is not None
+        finally:
+            reporter.close()
+
+    def test_finalize_line_appears_when_fully_deduplicated(self):
+        # Nothing new to transfer (everything deduplicated) still finalizes shards/metadata.
+        reporter = XetProgressReporter()
+        try:
+            reporter.update_progress(_group(1000, 1000, 0, 0), {"a.bin": _item("a.bin", 1000, 1000)})
+            assert getattr(reporter, "_finalize_bar", None) is not None
+        finally:
+            reporter.close()
+
+    def test_reset_for_next_commit_clears_finalize_state(self):
+        reporter = XetProgressReporter()
+        try:
+            reporter.update_progress(_group(1000, 1000, 800, 800), {"a.bin": _item("a.bin", 1000, 1000)})
+            assert getattr(reporter, "_finalize_bar", None) is not None
+            reporter.reset_for_next_commit()
+            assert getattr(reporter, "_finalize_bar", None) is None
+            assert getattr(reporter, "_finalize_start", None) is None
+        finally:
+            reporter.close()


### PR DESCRIPTION
## Summary

Users frequently report that uploads look "stuck": the progress bar hits 100% but the command doesn't return for a while. It's not actually stuck — after all data bytes are transferred, hf_xet enters a `Finalizing` phase where it joins any remaining xorb uploads and then uploads the shards/metadata that describe the content. Shard/metadata upload reports no byte-level progress, so the bars sit at 100% with no explanation. For large files or large batches this window can last a while.

This adds a dedicated, animated line to `XetProgressReporter` that appears once all data is uploaded, so users can see the upload is finalizing rather than frozen:

- Detects the finalization window purely from the existing progress report — all `total_bytes` processed **and** all `total_transfer_bytes` transferred. No hf_xet/Rust change needed; works with already-released `hf-xet`.
- The hf_xet progress poller keeps firing the callback (~10×/s) throughout `Finalizing` with static byte counts, so we animate a braille spinner + elapsed timer to make clear work is ongoing.
- Lazily creates a single `{desc}`-only line below the existing bars and closes it (with a ✓) when the commit completes. Resets cleanly across multi-commit reuse.
- Covers the fully-deduplicated case (`total_transfer_bytes == 0`), which is itself a common "instant 100%, then stuck" scenario.

Scope is just `XetProgressReporter` (used by `create_commit` and the deprecated large-folder path). The `upload_folder` pipeline (`_LiveDisplay`) already shows a "Committing" stage, so it's out of scope.

## Example

While uploading (unchanged):

```
Processing Files (1 / 1)        |█████████| 4.10GB / 4.10GB
New Data Upload                 |█████████| 3.80GB / 3.80GB
```

Once all data is transferred, the new line appears and animates during shard/metadata upload:

```
Processing Files (1 / 1)        |█████████| 4.10GB / 4.10GB
New Data Upload                 |█████████| 3.80GB / 3.80GB
Finalizing                      ⠹ uploading metadata… (12s)
```

On completion:

```
Finalizing                      ✓ metadata uploaded (14s)
```

## Decisions

- **Python-only, heuristic.** We infer "finalizing" from the byte counters rather than reading hf_xet's actual `Finalizing` task state, because that state isn't passed to the progress callback. Inferring keeps this a pure-Python change that ships immediately and works with the currently-released hf-xet. A future hf_xet change could expose the real state (or real per-shard byte progress) for an exact progress bar — left as a follow-up.
- **No public API change, no breaking changes.**
- Spinner glyphs are a small hardcoded braille string — nothing in our deps provides a spinner, and it's not worth adding one for this.

## Testing

New unit tests in `tests/test_xet_progress_reporting.py` (no network / no xet binding): the indicator stays hidden mid-transfer, appears once processing + transfer complete, appears in the fully-deduplicated case, and is cleared by `reset_for_next_commit`. `make style`/ruff clean; type-checked with `uvx ty check` (the checker CI uses).
