### PR TITLE
fix `snapshot_download` overload

### DIFF
--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -74,7 +74,7 @@ def snapshot_download(
     tqdm_class: type[base_tqdm] | None = None,
     headers: dict[str, str] | None = None,
     endpoint: str | None = None,
-    dry_run: Literal[True] = True,
+    dry_run: Literal[True],
 ) -> list[DryRunFileInfo]: ...
 
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-line overload signature fix with no runtime logic changes.
> 
> **Overview**
> Fixes the **`dry_run=True`** overload of `snapshot_download` in `_snapshot_download.py` by dropping the default **`= True`** on `dry_run: Literal[True]`, so overload resolution matches the pattern used elsewhere (e.g. `HfApi.snapshot_download`).
> 
> This is a **typing-only** change; runtime behavior of `snapshot_download` is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc74d86d2a12666d4464c81401a7138fc28a24b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->