### PR TITLE
[paths] Fix docstring typo. Reduce complexity.

### DIFF
--- a/src/huggingface_hub/utils/_paths.py
+++ b/src/huggingface_hub/utils/_paths.py
@@ -102,16 +102,17 @@ def filter_repo_objects(
     [CommitOperationAdd(path_or_fileobj="/tmp/aaa.pdf", path_in_repo="aaa.pdf")]
     ```
     """
+    allow_patterns = allow_patterns or []
+    ignore_patterns = ignore_patterns or []
+
     if isinstance(allow_patterns, str):
         allow_patterns = [allow_patterns]
 
     if isinstance(ignore_patterns, str):
         ignore_patterns = [ignore_patterns]
 
-    if allow_patterns is not None:
-        allow_patterns = [_add_wildcard_to_directories(p) for p in allow_patterns]
-    if ignore_patterns is not None:
-        ignore_patterns = [_add_wildcard_to_directories(p) for p in ignore_patterns]
+    allow_patterns = [_add_wildcard_to_directories(p) for p in allow_patterns]
+    ignore_patterns = [_add_wildcard_to_directories(p) for p in ignore_patterns]
 
     if key is None:
 
@@ -128,11 +129,11 @@ def filter_repo_objects(
         path = key(item)
 
         # Skip if there's an allowlist and path doesn't match any
-        if allow_patterns is not None and not any(fnmatch(path, r) for r in allow_patterns):
+        if not any(fnmatch(path, r) for r in allow_patterns):
             continue
 
         # Skip if there's a denylist and path matches any
-        if ignore_patterns is not None and any(fnmatch(path, r) for r in ignore_patterns):
+        if any(fnmatch(path, r) for r in ignore_patterns):
             continue
 
         yield item

--- a/src/huggingface_hub/utils/_paths.py
+++ b/src/huggingface_hub/utils/_paths.py
@@ -102,7 +102,7 @@ def filter_repo_objects(
     [CommitOperationAdd(path_or_fileobj="/tmp/aaa.pdf", path_in_repo="aaa.pdf")]
     ```
     """
-    allow_patterns = allow_patterns or []
+    allow_patterns = allow_patterns or ['*']
     ignore_patterns = ignore_patterns or []
 
     if isinstance(allow_patterns, str):

--- a/src/huggingface_hub/utils/_paths.py
+++ b/src/huggingface_hub/utils/_paths.py
@@ -102,7 +102,6 @@ def filter_repo_objects(
     [CommitOperationAdd(path_or_fileobj="/tmp/aaa.pdf", path_in_repo="aaa.pdf")]
     ```
     """
-    allow_patterns = allow_patterns or ['*']
     ignore_patterns = ignore_patterns or []
 
     if isinstance(allow_patterns, str):
@@ -111,7 +110,8 @@ def filter_repo_objects(
     if isinstance(ignore_patterns, str):
         ignore_patterns = [ignore_patterns]
 
-    allow_patterns = [_add_wildcard_to_directories(p) for p in allow_patterns]
+    if allow_patterns is not None:
+        allow_patterns = [_add_wildcard_to_directories(p) for p in allow_patterns]
     ignore_patterns = [_add_wildcard_to_directories(p) for p in ignore_patterns]
 
     if key is None:
@@ -129,7 +129,7 @@ def filter_repo_objects(
         path = key(item)
 
         # Skip if there's an allowlist and path doesn't match any
-        if not any(fnmatch(path, r) for r in allow_patterns):
+        if allow_patterns is not None and not any(fnmatch(path, r) for r in allow_patterns):
             continue
 
         # Skip if there's a denylist and path matches any

--- a/src/huggingface_hub/utils/_paths.py
+++ b/src/huggingface_hub/utils/_paths.py
@@ -97,7 +97,7 @@ def filter_repo_objects(
     ... ],
     ... allow_patterns=["*.pdf"],
     ... ignore_patterns=[".*"],
-    ... key=lambda x: x.repo_in_path
+    ... key=lambda x: x.path_in_repo
     ... ))
     [CommitOperationAdd(path_or_fileobj="/tmp/aaa.pdf", path_in_repo="aaa.pdf")]
     ```


### PR DESCRIPTION
`allow_patterns = allow_patterns or []` at the start of the function, for example, removes a conditional check from the function's `for` loop.

Y'all could optimize the function further. The typeshed typing of fnmatch.fnmatch omits (or omitted https://github.com/python/typeshed/pull/15963) `os.PathLike[AnyStr]`. Therefore, `_identity`, for example, does not need to convert `Path` to `str`, so you could combine the two `if isinstance` checks. 

To maximize the gains, you would need to broaden the typing of the signature, which would change some internal logic. I didn't try to change the signature type because that likely affects other functions, and I don't know this codebase.

You can avoid making a new, custom TypeVar by using `AnyStr` for a signature similar to this:

```python
from os import PathLike
from typing import AnyStr

def filter_repo_objects(
    items: Iterable[T],
    *,
    allow_patterns: list[AnyStr | PathLike[AnyStr]] | AnyStr | PathLike[AnyStr] | None = None,
    ignore_patterns: list[AnyStr | PathLike[AnyStr]] | AnyStr | PathLike[AnyStr] | None = None,
    key: Callable[[T], AnyStr | PathLike[AnyStr]] | None = None,
) -> Generator[T]: ...
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small control-flow refactor in path filtering with equivalent behavior when ignore_patterns is omitted; docstring-only fix otherwise.
> 
> **Overview**
> **`filter_repo_objects`** in `_paths.py` is simplified so **`ignore_patterns`** is normalized up front with `ignore_patterns or []`, directory wildcards are always applied to that list, and the per-item loop no longer branches on whether a denylist was provided.
> 
> The docstring example for object filtering is corrected: the `key` lambda uses **`path_in_repo`** instead of the typo **`repo_in_path`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78aafcf6eba4c38ba2f15d9dc24cb4cbcf9e8a98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->