### PR TITLE
best optimization: remove `filtered_repo_files = list(filtered_repo_files)`, which converted the `Iterator` to a `list`.

### DIFF
--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -1,5 +1,6 @@
 import os
 from collections.abc import Iterable
+from operator import attrgetter, is_not_none
 from pathlib import Path
 from typing import Literal, overload
 
@@ -17,7 +18,7 @@ from .errors import (
     RevisionNotFoundError,
 )
 from .file_download import REGEX_COMMIT_HASH, DryRunFileInfo, hf_hub_download, repo_folder_name
-from .hf_api import DatasetInfo, HfApi, KernelInfo, ModelInfo, RepoFile, SpaceInfo
+from .hf_api import DatasetInfo, HfApi, KernelInfo, ModelInfo, RepoFile, RepoFolder, RepoSibling, SpaceInfo
 from .utils import OfflineModeIsEnabled, filter_repo_objects, logging, validate_hf_hub_args
 from .utils.tqdm import _create_progress_bar
 from .utils.tqdm import tqdm as hf_tqdm
@@ -340,18 +341,15 @@ def snapshot_download(
     # Corner case: on very large repos, the siblings list in `repo_info` might not contain all files.
     # In that case, we need to use the `list_repo_tree` method to prevent caching issues.
     # Note: kernel repos don't expose siblings in their info response, so we always fall back to `list_repo_tree`.
-    siblings = getattr(repo_info, "siblings", None)
-    repo_files: Iterable[str] = [f.rfilename for f in siblings] if siblings is not None else []
-    unreliable_nb_files = siblings is None or len(siblings) == 0 or len(siblings) > LARGE_REPO_THRESHOLD
+    siblings: list[RepoSibling] | Iterable[RepoFile | RepoFolder] = getattr(repo_info, "siblings", [])
+    unreliable_nb_files: bool = not (0 < len(list(siblings)) <= LARGE_REPO_THRESHOLD)
     if unreliable_nb_files:
         logger.info(
             "Number of files in the repo is unreliable. Using `list_repo_tree` to ensure all files are listed."
         )
-        repo_files = (
-            f.rfilename
-            for f in api.list_repo_tree(repo_id=repo_id, recursive=True, revision=revision, repo_type=repo_type)
-            if isinstance(f, RepoFile)
-        )
+        siblings = api.list_repo_tree(repo_id=repo_id, recursive=True, revision=revision, repo_type=repo_type)
+
+    repo_files: Iterable[str] = filter(is_not_none, map(attrgetter("rfilename"), siblings))
 
     filtered_repo_files: Iterable[str] = filter_repo_objects(
         items=repo_files,
@@ -359,11 +357,10 @@ def snapshot_download(
         ignore_patterns=ignore_patterns,
     )
 
-    if not unreliable_nb_files:
-        filtered_repo_files = list(filtered_repo_files)
-        tqdm_desc = f"Fetching {len(filtered_repo_files)} files"
+    if unreliable_nb_files:
+        tqdm_desc: str = "Fetching ... files"
     else:
-        tqdm_desc = "Fetching ... files"
+        tqdm_desc = f"Fetching {len(tuple(filtered_repo_files))} files"
     if dry_run:
         tqdm_desc = "[dry-run] " + tqdm_desc
 

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -834,7 +834,7 @@ class RepoFile:
         self.security = security
 
         # backwards compatibility
-        self.rfilename = self.path
+        self.rfilename: str = self.path
         self.lastCommit = self.last_commit
 
 


### PR DESCRIPTION
1. siblings = list[RepoSibling] or `[]`, not `None`.
2. Simplify `unreliable_nb_files` conditional check.
3. Create `repo_files` once instead of possibly twice.
4. `if unreliable_nb_files:` mirrors the first `if unreliable_nb_files:`
5. `f"Fetching {len(tuple(filtered_repo_files))} files"` does not alter the `Iterator`; `tuple` is faster than `list`.

I _feel_ like there are more possible optimizations, but I don't want to make bigger, riskier changes. (Like, I _feel_ that with the right parameters passed to `filter_repo_objects`, y'all could remove `filter(is_not_none...`: perhaps by using the `key` parameter.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core download file enumeration; the unified `list_repo_tree` path no longer filters to `RepoFile` only, which could affect large/kernel repos if folder nodes lack `rfilename`.
> 
> **Overview**
> Refactors how `snapshot_download` builds the file list from `repo_info.siblings` vs `list_repo_tree`, using a single `siblings` source and `map(attrgetter("rfilename"), …)` instead of separate branches that rebuilt `repo_files`.
> 
> **Reliability check** is simplified to “sibling count in `(0, LARGE_REPO_THRESHOLD]`”; missing siblings default to `[]` instead of `None`. **Progress text** for the reliable case now uses `len(tuple(filtered_repo_files))` only when the sibling count is trusted, avoiding the previous `list(filtered_repo_files)` that fully materialized paths before download; the large-repo path keeps `"Fetching ... files"`.
> 
> Adds typing on `RepoFile.rfilename` and imports `RepoFolder` / `RepoSibling` for the unified typing. Note: the old `list_repo_tree` path only yielded `RepoFile` entries; the new pipeline maps `rfilename` over all tree items, which differs if folder nodes appear in that iterable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 793eca2af45862328f51c077d72aebe182f16e2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->