### PR TITLE
[i18n-HI] Add Hindi translation for guides/search

### DIFF
--- a/docs/source/hi/_toctree.yml
+++ b/docs/source/hi/_toctree.yml
@@ -11,3 +11,5 @@
   sections:
     - local: guides/overview
       title: उपयोग मार्गदर्शिकाएँ
+    - local: guides/search
+      title: खोज

--- a/docs/source/hi/guides/search.md
+++ b/docs/source/hi/guides/search.md
@@ -1,0 +1,84 @@
+<!--⚠️ Note that this file is in Markdown but contains specific syntax for our doc-builder (similar to MDX) that may not be
+rendered properly in your Markdown viewer.
+-->
+
+# Hub पर खोजें
+
+इस ट्यूटोरियल में, आप सीखेंगे कि `huggingface_hub` का उपयोग करके Hub पर Models, Datasets और Spaces कैसे खोजें।
+
+## Repositories को कैसे सूचीबद्ध करें ?
+
+`huggingface_hub` library में Hub के साथ इंटरैक्ट करने के लिए एक HTTP client [`HfApi`] शामिल है।
+अन्य चीज़ों के अलावा, यह Hub पर संग्रहीत Models, Datasets और Spaces को सूचीबद्ध कर सकता है:
+
+```py
+>>> from huggingface_hub import HfApi
+>>> api = HfApi()
+>>> models = api.list_models()
+```
+
+[`list_models`] का आउटपुट Hub पर संग्रहीत Models का एक iterator होता है।
+
+इसी तरह, आप Datasets को सूचीबद्ध करने के लिए [`list_datasets`] और Spaces को सूचीबद्ध करने के लिए [`list_spaces`] का उपयोग कर सकते हैं।
+
+## Repositories को कैसे फ़िल्टर करें ?
+
+Repositories को सूचीबद्ध करना तो बढ़िया है, लेकिन अब शायद आप अपनी खोज को फ़िल्टर करना चाहें।
+list helpers में कई attributes होते हैं, जैसे:
+- `filter`
+- `author`
+- `search`
+- `num_parameters`
+- ...
+
+चलिए एक उदाहरण देखते हैं जिसमें Hub पर मौजूद वे सभी Models प्राप्त किए जाते हैं जो image classification करते हैं, imagenet dataset पर ट्रेन किए गए हैं और PyTorch के साथ चलते हैं।
+
+```py
+models = hf_api.list_models(filter=["image-classification", "pytorch", "imagenet"])
+```
+
+आप Hub UI जैसी ही range syntax का उपयोग करके Models को parameter count के आधार पर भी फ़िल्टर कर सकते हैं:
+
+```py
+models = hf_api.list_models(num_parameters="min:6B,max:128B")
+```
+
+फ़िल्टर करते समय, आप Models को sort भी कर सकते हैं और केवल top results ही ले सकते हैं। उदाहरण के लिए,
+नीचे दिया गया उदाहरण Hub पर सबसे ज़्यादा डाउनलोड किए गए top 5 Datasets प्राप्त करता है:
+
+```py
+>>> list(list_datasets(sort="downloads", limit=5))
+[DatasetInfo(
+	id='argilla/databricks-dolly-15k-curated-en',
+	author='argilla',
+	sha='4dcd1dedbe148307a833c931b21ca456a1fc4281',
+	last_modified=datetime.datetime(2023, 10, 2, 12, 32, 53, tzinfo=datetime.timezone.utc),
+	private=False,
+	downloads=8889377,
+	(...)
+```
+
+
+
+Hub पर उपलब्ध filters को एक्सप्लोर करने के लिए, अपने browser में [models](https://huggingface.co/models) और [datasets](https://huggingface.co/datasets) पेज खोलें,
+कुछ parameters खोजें और URL में मौजूद values देखें।
+
+## CLI का उपयोग करना
+
+आप `hf` command-line interface का उपयोग करके भी Models, Datasets और Spaces को सूचीबद्ध और खोज सकते हैं:
+
+```bash
+# Models सूचीबद्ध करें
+>>> hf models ls --search "llama" --sort downloads --limit 5
+
+# Datasets सूचीबद्ध करें
+>>> hf datasets ls --author Qwen
+
+# Spaces सूचीबद्ध करें
+>>> hf spaces ls --search "3d"
+
+# किसी विशिष्ट model की जानकारी प्राप्त करें
+>>> hf models info Lightricks/LTX-2
+```
+
+अधिक जानकारी के लिए, [CLI गाइड](./cli.md#hf-models) देखें।


### PR DESCRIPTION
Adds a Hindi translation for `guides/search.md`.

- Added `docs/source/hi/guides/search.md`
- Updated `docs/source/hi/_toctree.yml`
- Preserved code blocks, links, and doc-builder syntax

Part of #1771. cc @Wauplin @stevhliu 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only i18n with no library or runtime behavior changes.
> 
> **Overview**
> Adds Hindi documentation for searching the Hub, mirroring the English `guides/search` guide as **`docs/source/hi/guides/search.md`**.
> 
> The new page covers listing models, datasets, and spaces with **`HfApi`**, filtering/sorting (including parameter ranges), and equivalent **`hf`** CLI examples, with code blocks, links, and doc-builder syntax left intact.
> 
> **`docs/source/hi/_toctree.yml`** now includes a **खोज** entry under उपयोग मार्गदर्शिकाएँ so the translated guide appears in the Hindi docs navigation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e820bd967ad5b09b83509067133f3d10e8940ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->