### PR TITLE
[CLI] Point users at hf jobs wait in job hints

### DIFF
--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -411,7 +411,6 @@ def jobs_logs(
     if follow:
         job_ref = f"{namespace}/{job_id}" if namespace else job_id
         out.hint(f"Stream ended. Run `hf jobs inspect {job_ref}` to check the final status (e.g. COMPLETED or ERROR).")
-        out.hint(f"Run `hf jobs wait {job_ref}` to block until it reaches a terminal state.")
 
 
 def _matches_filters(job_properties: dict[str, str], filters: list[tuple[str, str, str]]) -> bool:

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -358,6 +358,7 @@ def jobs_run(
     if detach:
         job_ref = f"{job.owner.name}/{job.id}"
         out.hint(f"Use `hf jobs logs -f {job_ref}` to stream logs, or `hf jobs inspect {job_ref}` to check status.")
+        out.hint(f"Use `hf jobs wait {job_ref}` to block until it finishes.")
         return
     _stream_logs_and_check_status(api, job)
 
@@ -410,6 +411,7 @@ def jobs_logs(
     if follow:
         job_ref = f"{namespace}/{job_id}" if namespace else job_id
         out.hint(f"Stream ended. Run `hf jobs inspect {job_ref}` to check the final status (e.g. COMPLETED or ERROR).")
+        out.hint(f"Run `hf jobs wait {job_ref}` to block until it reaches a terminal state.")
 
 
 def _matches_filters(job_properties: dict[str, str], filters: list[tuple[str, str, str]]) -> bool:
@@ -898,6 +900,7 @@ def jobs_uv_run(
     if detach:
         job_ref = f"{job.owner.name}/{job.id}"
         out.hint(f"Use `hf jobs logs -f {job_ref}` to stream logs, or `hf jobs inspect {job_ref}` to check status.")
+        out.hint(f"Use `hf jobs wait {job_ref}` to block until it finishes.")
         return
     _stream_logs_and_check_status(api, job)
 


### PR DESCRIPTION
## What
After launching a detached Job (`hf jobs run -d` / `hf jobs uv run -d`) the CLI
hints at `hf jobs logs -f` and `hf jobs inspect`, but not `hf jobs wait`. The
`hf jobs logs -f` stream-end hint likewise points only at `inspect`. This adds a
`hf jobs wait` hint at all three points.

## Why
`hf jobs wait` is the robust way to block until a Job reaches a terminal state and
to chain steps with `&&`. It's easy to miss: `hf spaces` already nudges users toward
`hf spaces wait` after starting a Space (`cli/spaces.py`), but the parallel `hf jobs`
path doesn't. Agents and scripts currently hand-roll polling with `inspect` instead.

## Notes
- Three additive `out.hint()` lines; no logic changed.
- Hints go to stderr, suppressed under `--quiet`, kept under `--json`/`--agent`
  (existing `Output.hint` behavior) — machine-readable stdout is unaffected.
- Style matches existing single-purpose hints (`cli/auth.py`, `cli/spaces.py`).
- No `cli.md` regen needed (hint strings aren't part of the generated reference).
- Verified the hint prints on stderr for `run -d`, `uv run -d`, and `logs -f`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Two additive `out.hint()` lines with no logic or API changes; hints go to stderr and follow existing CLI hint behavior.
> 
> **Overview**
> After starting a Job in **detach** mode (`hf jobs run -d` and `hf jobs uv run -d`), the CLI now prints an extra stderr hint to run **`hf jobs wait <namespace/job_id>`** so users can block until the job reaches a terminal state (alongside the existing `logs -f` and `inspect` hints).
> 
> No command behavior, APIs, or stdout/JSON output change—only user-facing guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e9e500b8392395252cb91d6c96e604f6bd2445e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->