### PR TITLE
Include huggingface_hub.templates in package discovery (fixes #4422)

### DIFF
--- a/src/huggingface_hub/templates/__init__.py
+++ b/src/huggingface_hub/templates/__init__.py
@@ -1,0 +1,1 @@
+"""Jinja2 templates bundled with ``huggingface_hub`` for generating model and dataset cards."""


### PR DESCRIPTION
### Summary

Building the package emits a setuptools warning (reported in #4422):

```
Package 'huggingface_hub.templates' is absent from the `packages` configuration.
Python recognizes 'huggingface_hub.templates' as an importable package,
but it is absent from setuptools' `packages` configuration.
```

**Root cause:** `src/huggingface_hub/templates/` (which holds `modelcard_template.md` and `datasetcard_template.md`) has no `__init__.py`, so `find_packages("src")` in `setup.py` skips it — yet Python treats the directory as an importable namespace package, so setuptools warns about the mismatch.

### Fix

Add an `__init__.py` to `src/huggingface_hub/templates/`, so the directory is discovered as a regular subpackage. Minimal and low-risk:

- The template `.md` files (already listed in `MANIFEST.in`) continue to ship.
- The runtime load via `TEMPLATE_MODELCARD_PATH = Path(__file__).parent / "templates" / ...` in `repocard.py` is unaffected.

### Verification

```
# find_packages now discovers it
python -c "from setuptools import find_packages; print('huggingface_hub.templates' in find_packages('src'))"  # True

# sdist build: warning gone, templates still bundled
python -m build --sdist  # no 'absent from packages' warning; templates/{__init__.py,*.md} present
```

Fixes #4422.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only change with no behavior changes to card generation or template loading.
> 
> **Overview**
> Adds **`src/huggingface_hub/templates/__init__.py`** so `find_packages("src")` in **`setup.py`** treats `huggingface_hub.templates` as a normal subpackage instead of a namespace package setuptools did not list.
> 
> This removes the **“Package 'huggingface_hub.templates' is absent from the `packages` configuration”** warning on sdist builds (fixes #4422). Template **`.md`** files still ship via **`MANIFEST.in`**, and **`repocard.py`** path-based loading of those files is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cce15dd54db4e0a66ca4096677e46e98169f82b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->