### PR TITLE
Make filter_repo_objects pattern matching case-sensitive on all platforms

### DIFF
--- a/src/huggingface_hub/utils/_paths.py
+++ b/src/huggingface_hub/utils/_paths.py
@@ -14,7 +14,7 @@
 """Contains utilities to handle paths in Huggingface Hub."""
 
 from collections.abc import Callable, Generator, Iterable
-from fnmatch import fnmatch
+from fnmatch import fnmatchcase
 from pathlib import Path
 from typing import TypeVar
 
@@ -50,8 +50,9 @@ def filter_repo_objects(
     that is used to extract a path from each element in iterable.
 
     Patterns are Standard Wildcards (globbing patterns), NOT regular expressions.
-    The pattern matching is based on Python's `fnmatch`. Note that `fnmatch` matches
-    `*` across path boundaries, unlike traditional Unix shell globbing. For example,
+    The pattern matching is based on Python's `fnmatch.fnmatchcase`, so it is
+    case-sensitive on every platform. Note that it matches `*` across path
+    boundaries, unlike traditional Unix shell globbing. For example,
     `"data/*.json"` will match both `data/file.json` and `data/subdir/file.json`.
     See https://docs.python.org/3/library/fnmatch.html for more details.
 
@@ -79,7 +80,7 @@ def filter_repo_objects(
     ```python
     >>> # Filter only PDFs that are not hidden.
     >>> list(filter_repo_objects(
-    ...     ["aaa.PDF", "bbb.jpg", ".ccc.pdf", ".ddd.png"],
+    ...     ["aaa.pdf", "bbb.jpg", ".ccc.pdf", ".ddd.png"],
     ...     allow_patterns=["*.pdf"],
     ...     ignore_patterns=[".*"],
     ... ))
@@ -128,11 +129,11 @@ def filter_repo_objects(
         path = key(item)
 
         # Skip if there's an allowlist and path doesn't match any
-        if allow_patterns is not None and not any(fnmatch(path, r) for r in allow_patterns):
+        if allow_patterns is not None and not any(fnmatchcase(path, r) for r in allow_patterns):
             continue
 
         # Skip if there's a denylist and path matches any
-        if ignore_patterns is not None and any(fnmatch(path, r) for r in ignore_patterns):
+        if ignore_patterns is not None and any(fnmatchcase(path, r) for r in ignore_patterns):
             continue
 
         yield item

--- a/tests/test_utils_paths.py
+++ b/tests/test_utils_paths.py
@@ -110,7 +110,6 @@ class TestPathsUtils(unittest.TestCase):
 
     def test_filter_is_case_sensitive(self) -> None:
         """Pattern matching is case-sensitive.
-        
         Regression test for https://github.com/huggingface/huggingface_hub/issues/4434.
         """
         # Uppercase pattern matches only the uppercase path, not the lowercase one.

--- a/tests/test_utils_paths.py
+++ b/tests/test_utils_paths.py
@@ -108,6 +108,32 @@ class TestPathsUtils(unittest.TestCase):
             ignore_patterns=[""],
         )
 
+    def test_filter_is_case_sensitive(self) -> None:
+        """Pattern matching must be case-sensitive on every platform (see #4434).
+
+        `fnmatch.fnmatch` applies `os.path.normcase`, which made matching case-insensitive
+        on Windows but case-sensitive on Linux/macOS. Repo paths are case-sensitive, so the
+        result must not depend on the client OS.
+        """
+        # Uppercase pattern matches only the uppercase path, not the lowercase one.
+        self._check(
+            items=["README.md", "notes.MD"],
+            expected_items=["notes.MD"],
+            allow_patterns=["*.MD"],
+        )
+        # Lowercase pattern matches only the lowercase path, not the uppercase one.
+        self._check(
+            items=["README.md", "notes.MD"],
+            expected_items=["README.md"],
+            allow_patterns=["*.md"],
+        )
+        # Case-sensitivity also applies to the ignore list.
+        self._check(
+            items=["keep.txt", "drop.LOG", "keep.log"],
+            expected_items=["keep.txt", "keep.log"],
+            ignore_patterns=["*.LOG"],
+        )
+
     def _check(
         self,
         items: list[Any],

--- a/tests/test_utils_paths.py
+++ b/tests/test_utils_paths.py
@@ -109,11 +109,9 @@ class TestPathsUtils(unittest.TestCase):
         )
 
     def test_filter_is_case_sensitive(self) -> None:
-        """Pattern matching must be case-sensitive on every platform (see #4434).
-
-        `fnmatch.fnmatch` applies `os.path.normcase`, which made matching case-insensitive
-        on Windows but case-sensitive on Linux/macOS. Repo paths are case-sensitive, so the
-        result must not depend on the client OS.
+        """Pattern matching is case-sensitive.
+        
+        Regression test for https://github.com/huggingface/huggingface_hub/issues/4434.
         """
         # Uppercase pattern matches only the uppercase path, not the lowercase one.
         self._check(


### PR DESCRIPTION
Closes #4434.

`filter_repo_objects` matched `allow_patterns` / `ignore_patterns` with `fnmatch.fnmatch`, which applies `os.path.normcase` — so matching was case-insensitive on Windows but case-sensitive on Linux/macOS. Since these patterns are matched against case-sensitive Hub paths, the same call could return different files depending on the client OS (e.g. `snapshot_download(..., allow_patterns=["*.PDF"])`).

This switches to `fnmatch.fnmatchcase`, which performs the same wildcard matching without OS-dependent case normalization, making behavior consistent on all platforms. Adds a regression test and fixes an inconsistent docstring example.

Note: this is a behavior change on Windows (matching becomes case-sensitive). I believe consistent, case-sensitive matching is the correct behavior for Hub paths, but happy to gate it behind an option instead if you'd prefer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cross-platform filtering behavior for downloads and repo uploads on Windows; Linux/macOS users with case-mismatched patterns may see fewer matches than before on those OSes only if they relied on accidental case-insensitivity.
> 
> **Overview**
> **`filter_repo_objects`** now matches `allow_patterns` and `ignore_patterns` with **`fnmatch.fnmatchcase`** instead of **`fnmatch`**, so wildcard filtering is **case-sensitive on every platform** (aligned with case-sensitive Hub paths). On Windows this is a **behavior change**: patterns like `*.PDF` no longer match `file.pdf`.
> 
> Docs and the path-filtering example are updated to describe case-sensitive matching. A regression test covers allow/ignore case sensitivity (issue #4434).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46ba4780bdfa1e849e00c96609e2528d716b3d70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->