### PR TITLE
Fix misleading max_retries docstring in http_backoff

### DIFF
--- a/src/huggingface_hub/utils/_http.py
+++ b/src/huggingface_hub/utils/_http.py
@@ -527,7 +527,7 @@ def http_backoff(
         url (`str`):
             The URL of the resource to fetch.
         max_retries (`int`, *optional*, defaults to `5`):
-            Maximum number of retries, defaults to 5 (no retries).
+            Maximum number of retries, defaults to 5. Set to `0` to disable retries.
         base_wait_time (`float`, *optional*, defaults to `1`):
             Duration (in seconds) to wait before retrying the first time.
             Wait time between retries then grows exponentially, capped by
@@ -608,7 +608,7 @@ def http_stream_backoff(
         url (`str`):
             The URL of the resource to fetch.
         max_retries (`int`, *optional*, defaults to `5`):
-            Maximum number of retries, defaults to 5 (no retries).
+            Maximum number of retries, defaults to 5. Set to `0` to disable retries.
         base_wait_time (`float`, *optional*, defaults to `1`):
             Duration (in seconds) to wait before retrying the first time.
             Wait time between retries then grows exponentially, capped by


### PR DESCRIPTION
Small docs fix. The `max_retries` docstring in `http_backoff` and `http_stream_backoff` says it "defaults to 5 (no retries)", which doesn't add up - 5 means 5 retries, not none. Looks like a leftover from when the default used
to be 0. I updated both to say the default is 5, and to mention you can pass `0` if you actually want to turn retries off.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime behavior impact.
> 
> **Overview**
> Corrects the **`max_retries`** argument documentation on **`http_backoff`** and **`http_stream_backoff`** in `_http.py`.
> 
> The old text claimed the default is **5** while also saying **“(no retries)”**, which contradicts the implementation (default **5** retries, **`0`** disables retries). Both docstrings now state that the default is **5** and that **`max_retries=0`** turns retries off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1a325cab1a5d7440cc4284a67da1fea70d68c05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->