### PR TITLE
Do not suggest reporting if colab vault error

### DIFF
--- a/src/huggingface_hub/utils/_auth.py
+++ b/src/huggingface_hub/utils/_auth.py
@@ -135,12 +135,7 @@ def _get_token_from_google_colab() -> str | None:
             _GOOGLE_COLAB_SECRET = None
         except ColabError as e:
             # Something happen but we don't know what => recommend to open a GitHub issue
-            warnings.warn(
-                f"\nError while fetching `HF_TOKEN` secret value from your vault: '{str(e)}'."
-                "\nYou are not authenticated with the Hugging Face Hub in this notebook."
-                "\nIf the error persists, please let us know by opening an issue on GitHub "
-                "(https://github.com/huggingface/huggingface_hub/issues/new)."
-            )
+            warnings.warn(f"\nError while fetching `HF_TOKEN` secret value from your vault: '{str(e)}'.")
             _GOOGLE_COLAB_SECRET = None
 
         _IS_GOOGLE_COLAB_CHECKED = True


### PR DESCRIPTION
cc @hanouticelina 

Frankly doesn't bring much value to suggest users to report their error. I think just warning that an error happening is already fine. Mid-term I'd even be tempted to remove this feature now that we have proper OAuth-based login

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing warning text only; Colab token lookup behavior and fallbacks are unchanged.
> 
> **Overview**
> When Google Colab’s secrets vault raises a generic `ColabError` while reading `HF_TOKEN`, the **`warnings.warn` text is trimmed** so users only see the vault fetch error message.
> 
> Removed the extra lines that stated the notebook is not authenticated with the Hub and that users should **open a GitHub issue** if the problem persists. Handling is unchanged: the warning still fires and `_GOOGLE_COLAB_SECRET` is still cleared.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 157e416e7341507fd7f349a84c6502b107136aec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->