### PR TITLE
[Build] Include huggingface_hub.templates via find_namespace_packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import find_packages, setup
+from setuptools import find_namespace_packages, setup
 
 
 def get_version() -> str:
@@ -111,7 +111,7 @@ setup(
     license="Apache-2.0",
     url="https://github.com/huggingface/huggingface_hub",
     package_dir={"": "src"},
-    packages=find_packages("src"),
+    packages=find_namespace_packages("src"),
     extras_require=extras,
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
### Tested manually and it works. From `main` getting a warning while no warning when from this branch. Tested in two clean folders to be sure local cache did not conflict. I can confirm both wheels (from main and from this branch) are identical so nothing's broken. Safe to merge I think :)

----

Fixes #4422.

`src/huggingface_hub/templates/` ships data files (`modelcard_template.md`, `datasetcard_template.md`) but has no `__init__.py`, so `find_packages("src")` skipped it — producing a setuptools warning that `huggingface_hub.templates` is "absent from the `packages` configuration".

Switched to `find_namespace_packages("src")`, which discovers data-only directories. No `__init__.py` added since `templates/` contains no Python.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build/packaging-only change with no runtime logic changes; slightly broader package discovery under `src` but aligned with existing namespace layout.
> 
> **Overview**
> **Packaging fix** so `huggingface_hub/templates/*.md` (model/dataset card defaults used by `ModelCard.from_template` / `DatasetCard.from_template`) are part of the declared package and included in wheels.
> 
> `setup.py` now uses **`find_namespace_packages("src")`** instead of **`find_packages("src")`**, because `templates/` has no `__init__.py` and was skipped before—triggering setuptools’ “absent from packages configuration” warning and risking missing template files on install.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3adbe610ec9827d00b7bbf5de91fcc6a3f17d4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->