### PR TITLE
[Tests] Migrate everything from unittest to pytest

### DIFF
--- a/tests/test_buckets_hf_file_system.py
+++ b/tests/test_buckets_hf_file_system.py
@@ -1,5 +1,3 @@
-import unittest
-
 import pytest
 
 from huggingface_hub.hf_file_system import HfFileSystem
@@ -12,21 +10,23 @@ from .testing_utils import repo_name
 pytestmark = pytest.mark.xet
 
 
-class HfFileSystemBucketROTests(_HfFileSystemBucketChecks, _HfFileSystemBaseROTests):
+class TestHfFileSystemBucketRO(_HfFileSystemBucketChecks, _HfFileSystemBaseROTests):
     __test__ = True
 
-    @classmethod
-    def setUpClass(cls):
-        super(_HfFileSystemBaseROTests, cls).setUpClass()
+    @pytest.fixture(scope="class", autouse=True)
+    def _shared_bucket(self, request):
+        api = type(self).api
 
         # Create dummy bucket
-        repo_url = cls.api.create_bucket(repo_name())
-        cls.bucket_id = repo_url.bucket_id
-        cls.hf_path = f"buckets/{cls.bucket_id}"
+        repo_url = api.create_bucket(repo_name())
+        bucket_id = repo_url.bucket_id
+        hf_path = f"buckets/{bucket_id}"
+        request.cls.bucket_id = bucket_id
+        request.cls.hf_path = hf_path
 
         # Upload files
-        cls.api.batch_bucket_files(
-            cls.bucket_id,
+        api.batch_bucket_files(
+            bucket_id,
             add=[
                 ("dummy text data".encode("utf-8"), "data/text_data.txt"),
                 (b"dummy binary data", "data/binary_data.bin"),
@@ -34,24 +34,23 @@ class HfFileSystemBucketROTests(_HfFileSystemBucketChecks, _HfFileSystemBaseROTe
             ],
         )
 
-        cls.readme_file_path = "README.md"
-        cls.readme_file = cls.hf_path + "/" + cls.readme_file_path
-        cls.text_file_path = "data/text_data.txt"
-        cls.text_file = cls.hf_path + "/" + cls.text_file_path
+        request.cls.readme_file_path = "README.md"
+        request.cls.readme_file = hf_path + "/" + "README.md"
+        request.cls.text_file_path = "data/text_data.txt"
+        request.cls.text_file = hf_path + "/" + "data/text_data.txt"
+        yield
+        api.delete_bucket(bucket_id)
 
-    @classmethod
-    def tearDownClass(cls):
-        super(_HfFileSystemBaseROTests, cls).tearDownClass()
-        cls.api.delete_bucket(cls.bucket_id)
-
-    def setUp(self):
+    @pytest.fixture(autouse=True)
+    def _new_hffs(self):
         self.hffs = HfFileSystem(endpoint=ENDPOINT_STAGING, token=TOKEN, skip_instance_cache=True)
 
 
-class HfFileSystemBucketRWTests(_HfFileSystemBucketChecks, _HfFileSystemBaseRWTests):
+class TestHfFileSystemBucketRW(_HfFileSystemBucketChecks, _HfFileSystemBaseRWTests):
     __test__ = True
 
-    def setUp(self):
+    @pytest.fixture(autouse=True)
+    def _bucket(self):
         self.hffs = HfFileSystem(endpoint=ENDPOINT_STAGING, token=TOKEN, skip_instance_cache=True)
 
         # Create dummy bucket
@@ -73,10 +72,9 @@ class HfFileSystemBucketRWTests(_HfFileSystemBucketChecks, _HfFileSystemBaseRWTe
         self.readme_file = self.hf_path + "/" + self.readme_file_path
         self.text_file_path = "data/text_data.txt"
         self.text_file = self.hf_path + "/" + self.text_file_path
-
-    def tearDown(self):
+        yield
         self.api.delete_bucket(self.bucket_id)
 
-    @unittest.skip("Not implemented yet")
+    @pytest.mark.skip("Not implemented yet")
     def test_copy_file(self):
         pass

--- a/tests/test_cache_layout.py
+++ b/tests/test_cache_layout.py
@@ -1,14 +1,14 @@
 import os
 import time
-import unittest
 from io import BytesIO
+
+import pytest
 
 from huggingface_hub import HfApi, hf_hub_download, snapshot_download
 from huggingface_hub.errors import EntryNotFoundError
 from huggingface_hub.utils import SoftTemporaryDirectory, logging
 
-from .testing_constants import ENDPOINT_STAGING, TOKEN
-from .testing_utils import repo_name, skip_on_windows, with_production_testing
+from .testing_utils import repo_name
 
 
 logger = logging.get_logger(__name__)
@@ -22,15 +22,15 @@ def get_file_contents(path):
     return content
 
 
-@with_production_testing
-class CacheFileLayoutHfHubDownload(unittest.TestCase):
-    @skip_on_windows(reason="Symlinks are deactivated in Windows tests.")
+@pytest.mark.production
+class TestCacheFileLayoutHfHubDownload:
+    @pytest.mark.skipif(os.name == "nt", reason="Symlinks are deactivated in Windows tests.")
     def test_file_downloaded_in_cache(self):
         for revision, expected_reference in (
             (None, "main"),
             ("file-2", "file-2"),
         ):
-            with self.subTest(revision), SoftTemporaryDirectory() as cache:
+            with SoftTemporaryDirectory() as cache:
                 hf_hub_download(
                     MODEL_IDENTIFIER,
                     "file_0.txt",
@@ -45,24 +45,24 @@ class CacheFileLayoutHfHubDownload(unittest.TestCase):
                 snapshots = os.listdir(os.path.join(expected_path, "snapshots"))
 
                 # Only reference should be the expected one.
-                self.assertListEqual(refs, [expected_reference])
+                assert refs == [expected_reference]
 
                 with open(os.path.join(expected_path, "refs", expected_reference)) as f:
                     snapshot_name = f.readline().strip()
 
                 # The `main` reference should point to the only snapshot we have downloaded
-                self.assertListEqual(snapshots, [snapshot_name])
+                assert snapshots == [snapshot_name]
 
                 snapshot_path = os.path.join(expected_path, "snapshots", snapshot_name)
                 snapshot_content = os.listdir(snapshot_path)
 
                 # Only a single file in the snapshot
-                self.assertEqual(len(snapshot_content), 1)
+                assert len(snapshot_content) == 1
 
                 snapshot_content_path = os.path.join(snapshot_path, snapshot_content[0])
 
                 # The snapshot content should link to a blob
-                self.assertTrue(os.path.islink(snapshot_content_path))
+                assert os.path.islink(snapshot_content_path)
 
                 resolved_blob_relative = os.readlink(snapshot_content_path)
                 resolved_blob_absolute = os.path.normpath(os.path.join(snapshot_path, resolved_blob_relative))
@@ -71,15 +71,15 @@ class CacheFileLayoutHfHubDownload(unittest.TestCase):
                     blob_contents = f.readline().strip()
 
                 # The contents of the file should be 'File 0'.
-                self.assertEqual(blob_contents, "File 0")
+                assert blob_contents == "File 0"
 
     def test_no_exist_file_is_cached(self):
         revisions = [None, "file-2"]
         expected_references = ["main", "file-2"]
         for revision, expected_reference in zip(revisions, expected_references):
-            with self.subTest(revision), SoftTemporaryDirectory() as cache:
+            with SoftTemporaryDirectory() as cache:
                 filename = "this_does_not_exist.txt"
-                with self.assertRaises(EntryNotFoundError):
+                with pytest.raises(EntryNotFoundError):
                     # The file does not exist, so we get an exception.
                     hf_hub_download(MODEL_IDENTIFIER, filename, cache_dir=cache, revision=revision)
 
@@ -90,28 +90,28 @@ class CacheFileLayoutHfHubDownload(unittest.TestCase):
                 no_exist_snapshots = os.listdir(os.path.join(expected_path, ".no_exist"))
 
                 # Only reference should be `main`.
-                self.assertListEqual(refs, [expected_reference])
+                assert refs == [expected_reference]
 
                 with open(os.path.join(expected_path, "refs", expected_reference)) as f:
                     snapshot_name = f.readline().strip()
 
                 # The `main` reference should point to the only snapshot we have downloaded
-                self.assertListEqual(no_exist_snapshots, [snapshot_name])
+                assert no_exist_snapshots == [snapshot_name]
 
                 no_exist_path = os.path.join(expected_path, ".no_exist", snapshot_name)
                 no_exist_content = os.listdir(no_exist_path)
 
                 # Only a single file in the no_exist snapshot
-                self.assertEqual(len(no_exist_content), 1)
+                assert len(no_exist_content) == 1
 
                 # The no_exist content should be our file
-                self.assertEqual(no_exist_content[0], filename)
+                assert no_exist_content[0] == filename
 
                 with open(os.path.join(no_exist_path, filename)) as f:
                     content = f.read().strip()
 
                 # The contents of the file should be empty.
-                self.assertEqual(content, "")
+                assert content == ""
 
     def test_file_download_happens_once(self):
         # Tests that a file is only downloaded once if it's not updated.
@@ -124,9 +124,9 @@ class CacheFileLayoutHfHubDownload(unittest.TestCase):
             path = hf_hub_download(MODEL_IDENTIFIER, "file_0.txt", cache_dir=cache)
             creation_time_1 = os.path.getmtime(path)
 
-            self.assertEqual(creation_time_0, creation_time_1)
+            assert creation_time_0 == creation_time_1
 
-    @skip_on_windows(reason="Symlinks are deactivated in Windows tests.")
+    @pytest.mark.skipif(os.name == "nt", reason="Symlinks are deactivated in Windows tests.")
     def test_file_download_happens_once_intra_revision(self):
         # Tests that a file is only downloaded once if it's not updated, even across different revisions.
 
@@ -139,9 +139,9 @@ class CacheFileLayoutHfHubDownload(unittest.TestCase):
             path = hf_hub_download(MODEL_IDENTIFIER, "file_0.txt", cache_dir=cache, revision="file-2")
             creation_time_1 = os.path.getmtime(path)
 
-            self.assertEqual(creation_time_0, creation_time_1)
+            assert creation_time_0 == creation_time_1
 
-    @skip_on_windows(reason="Symlinks are deactivated in Windows tests.")
+    @pytest.mark.skipif(os.name == "nt", reason="Symlinks are deactivated in Windows tests.")
     def test_multiple_refs_for_same_file(self):
         with SoftTemporaryDirectory() as cache:
             hf_hub_download(MODEL_IDENTIFIER, "file_0.txt", cache_dir=cache)
@@ -157,25 +157,25 @@ class CacheFileLayoutHfHubDownload(unittest.TestCase):
             snapshots.sort()
 
             # Directory should contain two revisions
-            self.assertListEqual(refs, ["file-2", "main"])
+            assert refs == ["file-2", "main"]
 
             refs_contents = [get_file_contents(os.path.join(expected_path, "refs", f)) for f in refs]
             refs_contents.sort()
 
             # snapshots directory should contain two snapshots
-            self.assertListEqual(refs_contents, snapshots)
+            assert refs_contents == snapshots
 
             snapshot_links = [
                 os.readlink(os.path.join(expected_path, "snapshots", filename, "file_0.txt")) for filename in snapshots
             ]
 
             # All snapshot links should point to the same file.
-            self.assertEqual(*snapshot_links)
+            assert snapshot_links[0] == snapshot_links[1]
 
 
-@with_production_testing
-class CacheFileLayoutSnapshotDownload(unittest.TestCase):
-    @skip_on_windows(reason="Symlinks are deactivated in Windows tests.")
+@pytest.mark.production
+class TestCacheFileLayoutSnapshotDownload:
+    @pytest.mark.skipif(os.name == "nt", reason="Symlinks are deactivated in Windows tests.")
     def test_file_downloaded_in_cache(self):
         with SoftTemporaryDirectory() as cache:
             snapshot_download(MODEL_IDENTIFIER, cache_dir=cache)
@@ -189,12 +189,12 @@ class CacheFileLayoutSnapshotDownload(unittest.TestCase):
             snapshots.sort()
 
             # Directory should contain two revisions
-            self.assertListEqual(refs, ["main"])
+            assert refs == ["main"]
 
             ref_content = get_file_contents(os.path.join(expected_path, "refs", refs[0]))
 
             # snapshots directory should contain two snapshots
-            self.assertListEqual([ref_content], snapshots)
+            assert [ref_content] == snapshots
 
             snapshot_path = os.path.join(expected_path, "snapshots", snapshots[0])
 
@@ -204,9 +204,9 @@ class CacheFileLayoutSnapshotDownload(unittest.TestCase):
 
             resolved_snapshot_links = [os.path.normpath(os.path.join(snapshot_path, link)) for link in snapshot_links]
 
-            self.assertTrue(all([os.path.isfile(link) for link in resolved_snapshot_links]))
+            assert all([os.path.isfile(link) for link in resolved_snapshot_links])
 
-    @skip_on_windows(reason="Symlinks are deactivated in Windows tests.")
+    @pytest.mark.skipif(os.name == "nt", reason="Symlinks are deactivated in Windows tests.")
     def test_file_downloaded_in_cache_several_revisions(self):
         with SoftTemporaryDirectory() as cache:
             snapshot_download(MODEL_IDENTIFIER, cache_dir=cache, revision="file-3")
@@ -222,13 +222,13 @@ class CacheFileLayoutSnapshotDownload(unittest.TestCase):
             snapshots.sort()
 
             # Directory should contain two revisions
-            self.assertListEqual(refs, ["file-2", "file-3"])
+            assert refs == ["file-2", "file-3"]
 
             refs_content = [get_file_contents(os.path.join(expected_path, "refs", ref)) for ref in refs]
             refs_content.sort()
 
             # snapshots directory should contain two snapshots
-            self.assertListEqual(refs_content, snapshots)
+            assert refs_content == snapshots
 
             snapshots_paths = [os.path.join(expected_path, "snapshots", s) for s in snapshots]
 
@@ -267,20 +267,18 @@ class CacheFileLayoutSnapshotDownload(unittest.TestCase):
             #         └── [  52]  .gitattributes -> ../../blobs/ac481c8eb05e4d2496fbe076a38a7b4835dd733d
 
             # Across the two revisions, there should be 8 total links
-            self.assertEqual(len(all_links), 8)
+            assert len(all_links) == 8
 
             # Across the two revisions, there should only be 5 unique files.
-            self.assertEqual(len(all_unique_links), 5)
+            assert len(all_unique_links) == 5
 
 
-class ReferenceUpdates(unittest.TestCase):
-    _api = HfApi(endpoint=ENDPOINT_STAGING, token=TOKEN)
-
-    def test_update_reference(self):
-        repo_id = self._api.create_repo(repo_name(), exist_ok=True).repo_id
+class TestReferenceUpdates:
+    def test_update_reference(self, api: HfApi):
+        repo_id = api.create_repo(repo_name(), exist_ok=True).repo_id
 
         try:
-            self._api.upload_file(path_or_fileobj=BytesIO(b"Some string"), path_in_repo="file.txt", repo_id=repo_id)
+            api.upload_file(path_or_fileobj=BytesIO(b"Some string"), path_in_repo="file.txt", repo_id=repo_id)
 
             with SoftTemporaryDirectory() as cache:
                 hf_hub_download(repo_id, "file.txt", cache_dir=cache)
@@ -291,12 +289,12 @@ class ReferenceUpdates(unittest.TestCase):
                 refs = os.listdir(os.path.join(expected_path, "refs"))
 
                 # Directory should contain two revisions
-                self.assertListEqual(refs, ["main"])
+                assert refs == ["main"]
 
                 initial_ref_content = get_file_contents(os.path.join(expected_path, "refs", refs[0]))
 
                 # Upload a new file on the same branch
-                self._api.upload_file(
+                api.upload_file(
                     path_or_fileobj=BytesIO(b"Some new string"),
                     path_in_repo="file.txt",
                     repo_id=repo_id,
@@ -308,16 +306,12 @@ class ReferenceUpdates(unittest.TestCase):
 
                 # The `main` reference should point to two different, but existing snapshots which contain
                 # a 'file.txt'
-                self.assertNotEqual(initial_ref_content, final_ref_content)
-                self.assertTrue(os.path.isdir(os.path.join(expected_path, "snapshots", initial_ref_content)))
-                self.assertTrue(
-                    os.path.isfile(os.path.join(expected_path, "snapshots", initial_ref_content, "file.txt"))
-                )
-                self.assertTrue(os.path.isdir(os.path.join(expected_path, "snapshots", final_ref_content)))
-                self.assertTrue(
-                    os.path.isfile(os.path.join(expected_path, "snapshots", final_ref_content, "file.txt"))
-                )
+                assert initial_ref_content != final_ref_content
+                assert os.path.isdir(os.path.join(expected_path, "snapshots", initial_ref_content))
+                assert os.path.isfile(os.path.join(expected_path, "snapshots", initial_ref_content, "file.txt"))
+                assert os.path.isdir(os.path.join(expected_path, "snapshots", final_ref_content))
+                assert os.path.isfile(os.path.join(expected_path, "snapshots", final_ref_content, "file.txt"))
         except Exception:
             raise
         finally:
-            self._api.delete_repo(repo_id)
+            api.delete_repo(repo_id)

--- a/tests/test_cache_no_symlinks.py
+++ b/tests/test_cache_no_symlinks.py
@@ -12,10 +12,7 @@ from .testing_utils import DUMMY_MODEL_ID
 
 
 @pytest.mark.production
-@pytest.mark.usefixtures("fx_cache_dir")
 class TestCacheLayoutIfSymlinksNotSupported:
-    cache_dir: Path
-
     def test_are_symlinks_supported_default(self, mocker: MockerFixture) -> None:
         mocker.patch(
             "huggingface_hub.file_download._are_symlinks_supported_in_dir",
@@ -50,14 +47,14 @@ class TestCacheLayoutIfSymlinksNotSupported:
             # Try with another directory: symlinks are supported, no warnings
             assert are_symlinks_supported()  # True
 
-    def test_download_no_symlink_new_file(self, mocker: MockerFixture) -> None:
+    def test_download_no_symlink_new_file(self, mocker: MockerFixture, tmp_path: Path) -> None:
         mock_are_symlinks_supported = mocker.patch("huggingface_hub.file_download.are_symlinks_supported")
         mock_are_symlinks_supported.return_value = False
         filepath = Path(
             hf_hub_download(
                 DUMMY_MODEL_ID,
                 filename=CONFIG_NAME,
-                cache_dir=self.cache_dir,
+                cache_dir=tmp_path,
                 local_files_only=False,
             )
         )
@@ -68,14 +65,14 @@ class TestCacheLayoutIfSymlinksNotSupported:
         # Blobs directory is empty
         assert len(list((Path(filepath).parents[2] / "blobs").glob("*"))) == 0
 
-    def test_download_no_symlink_existing_file(self, mocker: MockerFixture) -> None:
+    def test_download_no_symlink_existing_file(self, mocker: MockerFixture, tmp_path: Path) -> None:
         mock_are_symlinks_supported = mocker.patch("huggingface_hub.file_download.are_symlinks_supported")
         mock_are_symlinks_supported.return_value = True
         filepath = Path(
             hf_hub_download(
                 DUMMY_MODEL_ID,
                 filename=CONFIG_NAME,
-                cache_dir=self.cache_dir,
+                cache_dir=tmp_path,
                 local_files_only=False,
             )
         )
@@ -92,7 +89,7 @@ class TestCacheLayoutIfSymlinksNotSupported:
             hf_hub_download(
                 DUMMY_MODEL_ID,
                 filename=CONFIG_NAME,
-                cache_dir=self.cache_dir,
+                cache_dir=tmp_path,
                 local_files_only=False,
             )
         )
@@ -104,7 +101,7 @@ class TestCacheLayoutIfSymlinksNotSupported:
         # => duplicate file on disk
         assert blob_path.is_file()
 
-    def test_scan_and_delete_cache_no_symlinks(self, mocker: MockerFixture) -> None:
+    def test_scan_and_delete_cache_no_symlinks(self, mocker: MockerFixture, tmp_path: Path) -> None:
         """Test scan_cache_dir works as well when cache-system doesn't use symlinks."""
         mock_are_symlinks_supported = mocker.patch("huggingface_hub.file_download.are_symlinks_supported")
         OLDER_REVISION = "44c70f043cfe8162efc274ff531575e224a0e6f0"
@@ -116,21 +113,21 @@ class TestCacheLayoutIfSymlinksNotSupported:
         hf_hub_download(
             DUMMY_MODEL_ID,
             filename=CONFIG_NAME,
-            cache_dir=self.cache_dir,
+            cache_dir=tmp_path,
         )
 
         # Download README.md from main
         hf_hub_download(
             DUMMY_MODEL_ID,
             filename="README.md",
-            cache_dir=self.cache_dir,
+            cache_dir=tmp_path,
         )
 
         # Download config.json from older revision
         hf_hub_download(
             DUMMY_MODEL_ID,
             filename=CONFIG_NAME,
-            cache_dir=self.cache_dir,
+            cache_dir=tmp_path,
             revision=OLDER_REVISION,
         )
 
@@ -141,12 +138,12 @@ class TestCacheLayoutIfSymlinksNotSupported:
         hf_hub_download(
             DUMMY_MODEL_ID,
             filename="merges.txt",
-            cache_dir=self.cache_dir,
+            cache_dir=tmp_path,
             revision=OLDER_REVISION,
         )
 
         # Scan cache directory
-        report = scan_cache_dir(self.cache_dir)
+        report = scan_cache_dir(tmp_path)
 
         # 1 repo found, no warnings
         assert len(report.repos) == 1

--- a/tests/test_cache_no_symlinks.py
+++ b/tests/test_cache_no_symlinks.py
@@ -1,44 +1,43 @@
-import unittest
 import warnings
 from pathlib import Path
-from unittest.mock import Mock, patch
 
 import pytest
+from pytest_mock import MockerFixture
 
 from huggingface_hub import hf_hub_download, scan_cache_dir
 from huggingface_hub.constants import CONFIG_NAME, HF_HUB_CACHE
 from huggingface_hub.file_download import are_symlinks_supported
 
-from .testing_utils import DUMMY_MODEL_ID, with_production_testing
+from .testing_utils import DUMMY_MODEL_ID
 
 
-@with_production_testing
+@pytest.mark.production
 @pytest.mark.usefixtures("fx_cache_dir")
-class TestCacheLayoutIfSymlinksNotSupported(unittest.TestCase):
+class TestCacheLayoutIfSymlinksNotSupported:
     cache_dir: Path
 
-    @patch(
-        "huggingface_hub.file_download._are_symlinks_supported_in_dir",
-        {HF_HUB_CACHE: True},
-    )
-    def test_are_symlinks_supported_default(self) -> None:
-        self.assertTrue(are_symlinks_supported())
+    def test_are_symlinks_supported_default(self, mocker: MockerFixture) -> None:
+        mocker.patch(
+            "huggingface_hub.file_download._are_symlinks_supported_in_dir",
+            {HF_HUB_CACHE: True},
+        )
+        assert are_symlinks_supported()
 
-    @patch("huggingface_hub.file_download.constants.HF_HUB_DISABLE_SYMLINKS", True)
-    @patch("huggingface_hub.file_download._are_symlinks_supported_in_dir", {HF_HUB_CACHE: True})
-    def test_are_symlinks_supported_disabled_by_env(self) -> None:
+    def test_are_symlinks_supported_disabled_by_env(self, mocker: MockerFixture) -> None:
         """Setting HF_HUB_DISABLE_SYMLINKS=1 forces are_symlinks_supported() to return False."""
-        self.assertFalse(are_symlinks_supported())
+        mocker.patch("huggingface_hub.file_download.constants.HF_HUB_DISABLE_SYMLINKS", True)
+        mocker.patch("huggingface_hub.file_download._are_symlinks_supported_in_dir", {HF_HUB_CACHE: True})
+        assert not are_symlinks_supported()
 
-    @patch("huggingface_hub.file_download.os.symlink")
-    @patch("huggingface_hub.file_download._are_symlinks_supported_in_dir", {})
-    def test_are_symlinks_supported_windows_specific_dir(self, mock_symlink: Mock) -> None:
+    def test_are_symlinks_supported_windows_specific_dir(self, mocker: MockerFixture) -> None:
+        mock_symlink = mocker.patch("huggingface_hub.file_download.os.symlink")
+        mocker.patch("huggingface_hub.file_download._are_symlinks_supported_in_dir", {})
         mock_symlink.side_effect = [OSError(), None]  # First dir not supported then yes
         this_dir = Path(__file__).parent
 
         # First time in `this_dir`: warning is raised
-        with self.assertWarns(UserWarning):
-            self.assertFalse(are_symlinks_supported(this_dir))
+        with pytest.warns(UserWarning):
+            assert not are_symlinks_supported(this_dir)
 
         with warnings.catch_warnings():
             # Assert no warnings raised
@@ -46,13 +45,13 @@ class TestCacheLayoutIfSymlinksNotSupported(unittest.TestCase):
             warnings.simplefilter("error")
 
             # Second time in `this_dir` but with absolute path: value is still cached
-            self.assertFalse(are_symlinks_supported(this_dir.absolute()))
+            assert not are_symlinks_supported(this_dir.absolute())
 
             # Try with another directory: symlinks are supported, no warnings
-            self.assertTrue(are_symlinks_supported())  # True
+            assert are_symlinks_supported()  # True
 
-    @patch("huggingface_hub.file_download.are_symlinks_supported")
-    def test_download_no_symlink_new_file(self, mock_are_symlinks_supported: Mock) -> None:
+    def test_download_no_symlink_new_file(self, mocker: MockerFixture) -> None:
+        mock_are_symlinks_supported = mocker.patch("huggingface_hub.file_download.are_symlinks_supported")
         mock_are_symlinks_supported.return_value = False
         filepath = Path(
             hf_hub_download(
@@ -63,14 +62,14 @@ class TestCacheLayoutIfSymlinksNotSupported(unittest.TestCase):
             )
         )
         # Not a symlink !
-        self.assertFalse(filepath.is_symlink())
-        self.assertTrue(filepath.is_file())
+        assert not filepath.is_symlink()
+        assert filepath.is_file()
 
         # Blobs directory is empty
-        self.assertEqual(len(list((Path(filepath).parents[2] / "blobs").glob("*"))), 0)
+        assert len(list((Path(filepath).parents[2] / "blobs").glob("*"))) == 0
 
-    @patch("huggingface_hub.file_download.are_symlinks_supported")
-    def test_download_no_symlink_existing_file(self, mock_are_symlinks_supported: Mock) -> None:
+    def test_download_no_symlink_existing_file(self, mocker: MockerFixture) -> None:
+        mock_are_symlinks_supported = mocker.patch("huggingface_hub.file_download.are_symlinks_supported")
         mock_are_symlinks_supported.return_value = True
         filepath = Path(
             hf_hub_download(
@@ -80,9 +79,9 @@ class TestCacheLayoutIfSymlinksNotSupported(unittest.TestCase):
                 local_files_only=False,
             )
         )
-        self.assertTrue(filepath.is_symlink())
+        assert filepath.is_symlink()
         blob_path = filepath.resolve()
-        self.assertTrue(blob_path.is_file())
+        assert blob_path.is_file()
 
         # Delete file in snapshot
         filepath.unlink()
@@ -98,16 +97,16 @@ class TestCacheLayoutIfSymlinksNotSupported(unittest.TestCase):
             )
         )
         # File exist but is not a symlink
-        self.assertFalse(new_filepath.is_symlink())
-        self.assertTrue(new_filepath.is_file())
+        assert not new_filepath.is_symlink()
+        assert new_filepath.is_file()
 
         # Blob file still exists as well (has not been deleted)
         # => duplicate file on disk
-        self.assertTrue(blob_path.is_file())
+        assert blob_path.is_file()
 
-    @patch("huggingface_hub.file_download.are_symlinks_supported")
-    def test_scan_and_delete_cache_no_symlinks(self, mock_are_symlinks_supported: Mock) -> None:
+    def test_scan_and_delete_cache_no_symlinks(self, mocker: MockerFixture) -> None:
         """Test scan_cache_dir works as well when cache-system doesn't use symlinks."""
+        mock_are_symlinks_supported = mocker.patch("huggingface_hub.file_download.are_symlinks_supported")
         OLDER_REVISION = "44c70f043cfe8162efc274ff531575e224a0e6f0"
 
         # Symlinks not supported
@@ -150,54 +149,51 @@ class TestCacheLayoutIfSymlinksNotSupported(unittest.TestCase):
         report = scan_cache_dir(self.cache_dir)
 
         # 1 repo found, no warnings
-        self.assertEqual(len(report.repos), 1)
-        self.assertEqual(len(report.warnings), 0)
+        assert len(report.repos) == 1
+        assert len(report.warnings) == 0
         repo = list(report.repos)[0]
 
         # 2 revisions found
-        self.assertEqual(len(repo.revisions), 2)
-        self.assertEqual(repo.nb_files, 4)
-        self.assertEqual(len(repo.refs), 1)  # only `main`
+        assert len(repo.revisions) == 2
+        assert repo.nb_files == 4
+        assert len(repo.refs) == 1  # only `main`
         main_revision = repo.refs["main"]
         main_ref = main_revision.commit_hash
         older_revision = [rev for rev in repo.revisions if rev is not main_revision][0]
 
         # 2 files in `main` revisions, both are not symlinks
-        self.assertEqual(main_revision.nb_files, 2)
+        assert main_revision.nb_files == 2
         for file in main_revision.files:
             # No symlinks means the files are in the snapshot dir itself
-            self.assertTrue(main_revision.snapshot_path in file.blob_path.parents)
+            assert main_revision.snapshot_path in file.blob_path.parents
 
         # 2 files in older revision, only 1 as symlink
         for file in older_revision.files:
             if file.file_name == CONFIG_NAME:
                 # In snapshot dir
-                self.assertTrue(older_revision.snapshot_path in file.blob_path.parents)
+                assert older_revision.snapshot_path in file.blob_path.parents
             else:
                 # In blob dir
-                self.assertFalse(older_revision.snapshot_path in file.blob_path.parents)
-                self.assertTrue("blobs" in str(file.blob_path))
+                assert older_revision.snapshot_path not in file.blob_path.parents
+                assert "blobs" in str(file.blob_path)
 
         # Since files are not shared (README.md is duplicated in cache), the total size
         # of the repo is the sum of each revision size. If symlinks were used, the total
         # size of the repo would be lower.
-        self.assertEqual(repo.size_on_disk, main_revision.size_on_disk + older_revision.size_on_disk)
+        assert repo.size_on_disk == main_revision.size_on_disk + older_revision.size_on_disk
 
         # Test delete repo strategy
         strategy_delete_repo = report.delete_revisions(main_ref, OLDER_REVISION)
-        self.assertEqual(strategy_delete_repo.expected_freed_size, repo.size_on_disk)
-        self.assertEqual(len(strategy_delete_repo.blobs), 0)
-        self.assertEqual(len(strategy_delete_repo.snapshots), 0)
-        self.assertEqual(len(strategy_delete_repo.refs), 0)
-        self.assertEqual(len(strategy_delete_repo.repos), 1)
+        assert strategy_delete_repo.expected_freed_size == repo.size_on_disk
+        assert len(strategy_delete_repo.blobs) == 0
+        assert len(strategy_delete_repo.snapshots) == 0
+        assert len(strategy_delete_repo.refs) == 0
+        assert len(strategy_delete_repo.repos) == 1
 
         # Test delete older revision strategy
         strategy_delete_revision = report.delete_revisions(OLDER_REVISION)
-        self.assertEqual(
-            strategy_delete_revision.blobs,
-            {file.blob_path for file in older_revision.files},
-        )
-        self.assertEqual(strategy_delete_revision.snapshots, {older_revision.snapshot_path})
-        self.assertEqual(len(strategy_delete_revision.refs), 0)
-        self.assertEqual(len(strategy_delete_revision.repos), 0)
+        assert strategy_delete_revision.blobs == {file.blob_path for file in older_revision.files}
+        assert strategy_delete_revision.snapshots == {older_revision.snapshot_path}
+        assert len(strategy_delete_revision.refs) == 0
+        assert len(strategy_delete_revision.repos) == 0
         strategy_delete_revision.execute()  # Execute without error

--- a/tests/test_commit_api.py
+++ b/tests/test_commit_api.py
@@ -1,4 +1,4 @@
-import unittest
+import pytest
 
 from huggingface_hub._commit_api import (
     CommitOperationAdd,
@@ -7,32 +7,32 @@ from huggingface_hub._commit_api import (
 )
 
 
-class TestCommitOperationDelete(unittest.TestCase):
+class TestCommitOperationDelete:
     def test_implicit_file(self):
-        self.assertFalse(CommitOperationDelete(path_in_repo="path/to/file").is_folder)
-        self.assertFalse(CommitOperationDelete(path_in_repo="path/to/file.md").is_folder)
+        assert not CommitOperationDelete(path_in_repo="path/to/file").is_folder
+        assert not CommitOperationDelete(path_in_repo="path/to/file.md").is_folder
 
     def test_implicit_folder(self):
-        self.assertTrue(CommitOperationDelete(path_in_repo="path/to/folder/").is_folder)
-        self.assertTrue(CommitOperationDelete(path_in_repo="path/to/folder.md/").is_folder)
+        assert CommitOperationDelete(path_in_repo="path/to/folder/").is_folder
+        assert CommitOperationDelete(path_in_repo="path/to/folder.md/").is_folder
 
     def test_explicit_file(self):
         # Weird case: if user explicitly set as file (`is_folder`=False) but path has a
         # trailing "/" => user input has priority
-        self.assertFalse(CommitOperationDelete(path_in_repo="path/to/folder/", is_folder=False).is_folder)
-        self.assertFalse(CommitOperationDelete(path_in_repo="path/to/folder.md/", is_folder=False).is_folder)
+        assert not CommitOperationDelete(path_in_repo="path/to/folder/", is_folder=False).is_folder
+        assert not CommitOperationDelete(path_in_repo="path/to/folder.md/", is_folder=False).is_folder
 
     def test_explicit_folder(self):
         # No need for the trailing "/" is `is_folder` explicitly passed
-        self.assertTrue(CommitOperationDelete(path_in_repo="path/to/folder", is_folder=True).is_folder)
-        self.assertTrue(CommitOperationDelete(path_in_repo="path/to/folder.md", is_folder=True).is_folder)
+        assert CommitOperationDelete(path_in_repo="path/to/folder", is_folder=True).is_folder
+        assert CommitOperationDelete(path_in_repo="path/to/folder.md", is_folder=True).is_folder
 
     def test_is_folder_wrong_value(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             CommitOperationDelete(path_in_repo="path/to/folder", is_folder="any value")
 
 
-class TestCommitOperationPathInRepo(unittest.TestCase):
+class TestCommitOperationPathInRepo:
     valid_values = {  # key is input, value is expected validated output
         "file.txt": "file.txt",
         ".file.txt": ".file.txt",
@@ -43,20 +43,18 @@ class TestCommitOperationPathInRepo(unittest.TestCase):
 
     def test_path_in_repo_valid(self) -> None:
         for input, expected in self.valid_values.items():
-            with self.subTest(f"Testing with valid input: '{input}'"):
-                self.assertEqual(CommitOperationAdd(path_in_repo=input, path_or_fileobj=b"").path_in_repo, expected)
-                self.assertEqual(CommitOperationDelete(path_in_repo=input).path_in_repo, expected)
+            assert CommitOperationAdd(path_in_repo=input, path_or_fileobj=b"").path_in_repo == expected
+            assert CommitOperationDelete(path_in_repo=input).path_in_repo == expected
 
     def test_path_in_repo_invalid(self) -> None:
         for input in self.invalid_values:
-            with self.subTest(f"Testing with invalid input: '{input}'"):
-                with self.assertRaises(ValueError):
-                    CommitOperationAdd(path_in_repo=input, path_or_fileobj=b"")
-                with self.assertRaises(ValueError):
-                    CommitOperationDelete(path_in_repo=input)
+            with pytest.raises(ValueError):
+                CommitOperationAdd(path_in_repo=input, path_or_fileobj=b"")
+            with pytest.raises(ValueError):
+                CommitOperationDelete(path_in_repo=input)
 
 
-class TestCommitOperationForbiddenPathInRepo(unittest.TestCase):
+class TestCommitOperationForbiddenPathInRepo:
     """Commit operations must throw an error on files in the .git/ or .cache/huggingface/ folders.
 
     Server would error anyway so it's best to prevent early.
@@ -88,22 +86,18 @@ class TestCommitOperationForbiddenPathInRepo(unittest.TestCase):
 
     def test_cannot_update_file_in_git_folder(self):
         for path in self.INVALID_PATHS_IN_REPO:
-            with self.subTest(msg=f"Add: '{path}'"):
-                with self.assertRaises(ValueError):
-                    CommitOperationAdd(path_in_repo=path, path_or_fileobj=b"content")
-            with self.subTest(msg=f"Delete: '{path}'"):
-                with self.assertRaises(ValueError):
-                    CommitOperationDelete(path_in_repo=path)
+            with pytest.raises(ValueError):
+                CommitOperationAdd(path_in_repo=path, path_or_fileobj=b"content")
+            with pytest.raises(ValueError):
+                CommitOperationDelete(path_in_repo=path)
 
     def test_valid_path_in_repo_containing_git(self):
         for path in self.VALID_PATHS_IN_REPO:
-            with self.subTest(msg=f"Add: '{path}'"):
-                CommitOperationAdd(path_in_repo=path, path_or_fileobj=b"content")
-            with self.subTest(msg=f"Delete: '{path}'"):
-                CommitOperationDelete(path_in_repo=path)
+            CommitOperationAdd(path_in_repo=path, path_or_fileobj=b"content")
+            CommitOperationDelete(path_in_repo=path)
 
 
-class TestWarnOnOverwritingOperations(unittest.TestCase):
+class TestWarnOnOverwritingOperations:
     add_file_ab = CommitOperationAdd(path_in_repo="a/b.txt", path_or_fileobj=b"data")
     add_file_abc = CommitOperationAdd(path_in_repo="a/b/c.md", path_or_fileobj=b"data")
     add_file_abd = CommitOperationAdd(path_in_repo="a/b/d.md", path_or_fileobj=b"data")
@@ -123,18 +117,18 @@ class TestWarnOnOverwritingOperations(unittest.TestCase):
         )
 
     def test_add_then_update_file(self) -> None:
-        with self.assertWarns(UserWarning):
+        with pytest.warns(UserWarning):
             _warn_on_overwriting_operations([self.add_file_abc, self.update_file_abc])
 
     def test_add_then_delete_file(self) -> None:
-        with self.assertWarns(UserWarning):
+        with pytest.warns(UserWarning):
             _warn_on_overwriting_operations([self.add_file_abc, self.delete_file_abc])
 
     def test_add_then_delete_folder(self) -> None:
-        with self.assertWarns(UserWarning):
+        with pytest.warns(UserWarning):
             _warn_on_overwriting_operations([self.add_file_abc, self.delete_folder_a])
 
-        with self.assertWarns(UserWarning):
+        with pytest.warns(UserWarning):
             _warn_on_overwriting_operations([self.add_file_ab, self.delete_folder_a])
 
     def test_delete_file_then_add(self) -> None:

--- a/tests/test_commit_scheduler.py
+++ b/tests/test_commit_scheduler.py
@@ -12,10 +12,7 @@ from huggingface_hub._commit_scheduler import CommitScheduler, PartialFileIO
 from .testing_utils import repo_name
 
 
-@pytest.mark.usefixtures("fx_cache_dir")
 class TestCommitScheduler:
-    cache_dir: Path
-
     @pytest.fixture(autouse=True)
     def _setup(self, api: HfApi):
         self.api = api
@@ -31,10 +28,10 @@ class TestCommitScheduler:
         except Exception:
             pass
 
-    def test_mocked_push_to_hub(self, mocker) -> None:
+    def test_mocked_push_to_hub(self, mocker, tmp_path: Path) -> None:
         push_to_hub_mock: MagicMock = mocker.patch("huggingface_hub._commit_scheduler.CommitScheduler.push_to_hub")
         self.scheduler = CommitScheduler(
-            folder_path=self.cache_dir,
+            folder_path=tmp_path,
             repo_id=self.repo_name,
             every=1 / 60 / 10,  # every 0.1s
             hf_api=self.api,
@@ -47,16 +44,16 @@ class TestCommitScheduler:
         # Can get the last upload result
         assert self.scheduler.last_future.result() == push_to_hub_mock.return_value
 
-    def test_invalid_folder_path_is_a_file(self) -> None:
+    def test_invalid_folder_path_is_a_file(self, tmp_path: Path) -> None:
         """Test cannot scheduler upload of a single file."""
-        file_path = self.cache_dir / "file.txt"
+        file_path = tmp_path / "file.txt"
         file_path.write_text("something")
 
         with pytest.raises(ValueError):
             CommitScheduler(folder_path=file_path, repo_id=self.repo_name, hf_api=self.api)
 
-    def test_missing_folder_is_created(self) -> None:
-        folder_path = self.cache_dir / "folder" / "subfolder"
+    def test_missing_folder_is_created(self, tmp_path: Path) -> None:
+        folder_path = tmp_path / "folder" / "subfolder"
         self.scheduler = CommitScheduler(folder_path=folder_path, repo_id=self.repo_name, hf_api=self.api)
         assert folder_path.is_dir()
 
@@ -64,10 +61,10 @@ class TestCommitScheduler:
         sys.platform == "win32" and sys.version_info >= (3, 14),
         reason="Flaky on Windows Python 3.14 due to file lock on lfs.bin",
     )
-    def test_sync_local_folder(self) -> None:
+    def test_sync_local_folder(self, tmp_path: Path) -> None:
         """Test sync local folder to remote repo."""
-        watched_folder = self.cache_dir / "watched_folder"
-        hub_cache = self.cache_dir / "hub"  # to download hub files
+        watched_folder = tmp_path / "watched_folder"
+        hub_cache = tmp_path / "hub"  # to download hub files
 
         file_path = watched_folder / "file.txt"
         lfs_path = watched_folder / "lfs.bin"
@@ -137,9 +134,9 @@ class TestCommitScheduler:
         assert lfs_push2.read_text() == "binary content"
         assert lfs_push3.read_text() == "binary content updated"
 
-    def test_sync_and_squash_history(self) -> None:
+    def test_sync_and_squash_history(self, tmp_path: Path) -> None:
         """Test squash history when pushing to the Hub."""
-        watched_folder = self.cache_dir / "watched_folder"
+        watched_folder = tmp_path / "watched_folder"
         watched_folder.mkdir(exist_ok=True, parents=True)
         file_path = watched_folder / "file.txt"
         with file_path.open("a") as f:
@@ -163,8 +160,8 @@ class TestCommitScheduler:
         assert len(commits) == 1
         assert commits[0].title == "Super-squash branch 'main' using huggingface_hub"
 
-    def test_context_manager(self) -> None:
-        watched_folder = self.cache_dir / "watched_folder"
+    def test_context_manager(self, tmp_path: Path) -> None:
+        watched_folder = tmp_path / "watched_folder"
         watched_folder.mkdir(exist_ok=True, parents=True)
         file_path = watched_folder / "file.txt"
 
@@ -181,17 +178,13 @@ class TestCommitScheduler:
         assert scheduler._CommitScheduler__stopped  # means the scheduler has been stopped when exiting the context
 
 
-@pytest.mark.usefixtures("fx_cache_dir")
 class TestPartialFileIO:
     """Test PartialFileIO object."""
 
-    cache_dir: Path
-
     @pytest.fixture(autouse=True)
-    def _setup(self, request) -> None:
+    def _setup(self, tmp_path) -> None:
         """Set up a test file."""
-        request.getfixturevalue("fx_cache_dir")
-        self.file_path = self.cache_dir / "file.txt"
+        self.file_path = tmp_path / "file.txt"
         self.file_path.write_text("123456789")  # file size: 9 bytes
 
     def test_read_partial_file_twice(self) -> None:

--- a/tests/test_commit_scheduler.py
+++ b/tests/test_commit_scheduler.py
@@ -1,28 +1,26 @@
 import sys
 import time
-import unittest
 from io import SEEK_END
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
 from huggingface_hub import CommitOperationAdd, HfApi, hf_hub_download
 from huggingface_hub._commit_scheduler import CommitScheduler, PartialFileIO
 
-from .testing_constants import ENDPOINT_STAGING, TOKEN
 from .testing_utils import repo_name
 
 
 @pytest.mark.usefixtures("fx_cache_dir")
-class TestCommitScheduler(unittest.TestCase):
+class TestCommitScheduler:
     cache_dir: Path
 
-    def setUp(self) -> None:
-        self.api = HfApi(token=TOKEN, endpoint=ENDPOINT_STAGING)
+    @pytest.fixture(autouse=True)
+    def _setup(self, api: HfApi):
+        self.api = api
         self.repo_name = repo_name()
-
-    def tearDown(self) -> None:
+        yield
         try:  # try stopping scheduler (if exists)
             self.scheduler.stop()
         except AttributeError:
@@ -33,8 +31,8 @@ class TestCommitScheduler(unittest.TestCase):
         except Exception:
             pass
 
-    @patch("huggingface_hub._commit_scheduler.CommitScheduler.push_to_hub")
-    def test_mocked_push_to_hub(self, push_to_hub_mock: MagicMock) -> None:
+    def test_mocked_push_to_hub(self, mocker) -> None:
+        push_to_hub_mock: MagicMock = mocker.patch("huggingface_hub._commit_scheduler.CommitScheduler.push_to_hub")
         self.scheduler = CommitScheduler(
             folder_path=self.cache_dir,
             repo_id=self.repo_name,
@@ -44,23 +42,23 @@ class TestCommitScheduler(unittest.TestCase):
         time.sleep(0.5)
 
         # Triggered at least twice (at 0.0s and then 0.1s, 0.2s,...)
-        self.assertGreater(len(push_to_hub_mock.call_args_list), 2)
+        assert len(push_to_hub_mock.call_args_list) > 2
 
         # Can get the last upload result
-        self.assertEqual(self.scheduler.last_future.result(), push_to_hub_mock.return_value)
+        assert self.scheduler.last_future.result() == push_to_hub_mock.return_value
 
     def test_invalid_folder_path_is_a_file(self) -> None:
         """Test cannot scheduler upload of a single file."""
         file_path = self.cache_dir / "file.txt"
         file_path.write_text("something")
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             CommitScheduler(folder_path=file_path, repo_id=self.repo_name, hf_api=self.api)
 
     def test_missing_folder_is_created(self) -> None:
         folder_path = self.cache_dir / "folder" / "subfolder"
         self.scheduler = CommitScheduler(folder_path=folder_path, repo_id=self.repo_name, hf_api=self.api)
-        self.assertTrue(folder_path.is_dir())
+        assert folder_path.is_dir()
 
     @pytest.mark.skipif(
         sys.platform == "win32" and sys.version_info >= (3, 14),
@@ -113,7 +111,7 @@ class TestCommitScheduler(unittest.TestCase):
         # 4 commits expected (initial commit + 3 push to hub)
         repo_id = self.scheduler.repo_id
         commits = self.api.list_repo_commits(repo_id)
-        self.assertEqual(len(commits), 4)
+        assert len(commits) == 4
         push_1 = commits[2].commit_id  # sorted by last first
         push_2 = commits[1].commit_id
         push_3 = commits[0].commit_id
@@ -126,18 +124,18 @@ class TestCommitScheduler(unittest.TestCase):
         file_push2 = _download(filename="file.txt", revision=push_2)
         file_push3 = _download(filename="file.txt", revision=push_3)
 
-        self.assertEqual(file_push1.read_text(), "first line\n")
-        self.assertEqual(file_push2.read_text(), "first line\nsecond line\n")
-        self.assertEqual(file_push3.read_text(), "first line\nsecond line\n")
+        assert file_push1.read_text() == "first line\n"
+        assert file_push2.read_text() == "first line\nsecond line\n"
+        assert file_push3.read_text() == "first line\nsecond line\n"
 
         # Check lfs.bin consistency
         lfs_push1 = _download(filename="lfs.bin", revision=push_1)
         lfs_push2 = _download(filename="lfs.bin", revision=push_2)
         lfs_push3 = _download(filename="lfs.bin", revision=push_3)
 
-        self.assertEqual(lfs_push1.read_text(), "binary content")
-        self.assertEqual(lfs_push2.read_text(), "binary content")
-        self.assertEqual(lfs_push3.read_text(), "binary content updated")
+        assert lfs_push1.read_text() == "binary content"
+        assert lfs_push2.read_text() == "binary content"
+        assert lfs_push3.read_text() == "binary content updated"
 
     def test_sync_and_squash_history(self) -> None:
         """Test squash history when pushing to the Hub."""
@@ -162,8 +160,8 @@ class TestCommitScheduler(unittest.TestCase):
 
         # Branch history has been squashed
         commits = self.api.list_repo_commits(repo_id=self.scheduler.repo_id)
-        self.assertEqual(len(commits), 1)
-        self.assertEqual(commits[0].title, "Super-squash branch 'main' using huggingface_hub")
+        assert len(commits) == 1
+        assert commits[0].title == "Super-squash branch 'main' using huggingface_hub"
 
     def test_context_manager(self) -> None:
         watched_folder = self.cache_dir / "watched_folder"
@@ -184,39 +182,41 @@ class TestCommitScheduler(unittest.TestCase):
 
 
 @pytest.mark.usefixtures("fx_cache_dir")
-class TestPartialFileIO(unittest.TestCase):
+class TestPartialFileIO:
     """Test PartialFileIO object."""
 
     cache_dir: Path
 
-    def setUp(self) -> None:
+    @pytest.fixture(autouse=True)
+    def _setup(self, request) -> None:
         """Set up a test file."""
+        request.getfixturevalue("fx_cache_dir")
         self.file_path = self.cache_dir / "file.txt"
         self.file_path.write_text("123456789")  # file size: 9 bytes
 
     def test_read_partial_file_twice(self) -> None:
         file = PartialFileIO(self.file_path, size_limit=5)
-        self.assertEqual(file.read(), b"12345")
-        self.assertEqual(file.read(), b"")  # End of file
+        assert file.read() == b"12345"
+        assert file.read() == b""  # End of file
 
     def test_read_partial_file_by_chunks(self) -> None:
         file = PartialFileIO(self.file_path, size_limit=5)
-        self.assertEqual(file.read(2), b"12")
-        self.assertEqual(file.read(2), b"34")
-        self.assertEqual(file.read(2), b"5")
-        self.assertEqual(file.read(2), b"")
+        assert file.read(2) == b"12"
+        assert file.read(2) == b"34"
+        assert file.read(2) == b"5"
+        assert file.read(2) == b""
 
     def test_read_partial_file_too_much(self) -> None:
         file = PartialFileIO(self.file_path, size_limit=5)
-        self.assertEqual(file.read(20), b"12345")
+        assert file.read(20) == b"12345"
 
     def test_partial_file_len(self) -> None:
         """Useful for httpx internally."""
         file = PartialFileIO(self.file_path, size_limit=5)
-        self.assertEqual(len(file), 5)
+        assert len(file) == 5
 
         file = PartialFileIO(self.file_path, size_limit=50)
-        self.assertEqual(len(file), 9)
+        assert len(file) == 9
 
     def test_partial_file_fileno(self) -> None:
         """We explicitly do not implement fileno() to avoid misuse.
@@ -224,37 +224,37 @@ class TestPartialFileIO(unittest.TestCase):
         httpx tries to use it to check file size which we don't want for PartialFileIO.
         """
         file = PartialFileIO(self.file_path, size_limit=5)
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             file.fileno()
 
     def test_partial_file_seek_and_tell(self) -> None:
         file = PartialFileIO(self.file_path, size_limit=5)
 
-        self.assertEqual(file.tell(), 0)
+        assert file.tell() == 0
 
         file.read(2)
-        self.assertEqual(file.tell(), 2)
+        assert file.tell() == 2
 
         file.seek(0)
-        self.assertEqual(file.tell(), 0)
+        assert file.tell() == 0
 
         file.seek(2)
-        self.assertEqual(file.tell(), 2)
+        assert file.tell() == 2
 
         file.seek(50)
-        self.assertEqual(file.tell(), 5)
+        assert file.tell() == 5
 
         file.seek(-3, SEEK_END)
-        self.assertEqual(file.tell(), 2)  # 5-3
+        assert file.tell() == 2  # 5-3
 
     def test_methods_not_implemented(self) -> None:
         """Test `PartialFileIO` only implements a subset of the `io` interface. This is on-purpose to avoid misuse."""
         file = PartialFileIO(self.file_path, size_limit=5)
 
-        with self.assertRaises(NotImplementedError):
+        with pytest.raises(NotImplementedError):
             file.readline()
 
-        with self.assertRaises(NotImplementedError):
+        with pytest.raises(NotImplementedError):
             file.write(b"123")
 
     def test_append_to_file_then_read(self) -> None:
@@ -264,7 +264,7 @@ class TestPartialFileIO(unittest.TestCase):
             f.write(b"abcdef")
 
         # Output is truncated even if new content appended to the wrapped file
-        self.assertEqual(file.read(), b"123456789")
+        assert file.read() == b"123456789"
 
     def test_high_size_limit(self) -> None:
         file = PartialFileIO(self.file_path, size_limit=20)
@@ -272,29 +272,29 @@ class TestPartialFileIO(unittest.TestCase):
             f.write(b"abcdef")
 
         # File size limit is truncated to the actual file size at instance creation (not on the fly)
-        self.assertEqual(len(file), 9)
-        self.assertEqual(file._size_limit, 9)
+        assert len(file) == 9
+        assert file._size_limit == 9
 
     def test_with_commit_operation_add(self) -> None:
         # Truncated file
         op_truncated = CommitOperationAdd(
             path_or_fileobj=PartialFileIO(self.file_path, size_limit=5), path_in_repo="file.txt"
         )
-        self.assertEqual(op_truncated.upload_info.size, 5)
-        self.assertEqual(op_truncated.upload_info.sample, b"12345")
+        assert op_truncated.upload_info.size == 5
+        assert op_truncated.upload_info.sample == b"12345"
 
         with op_truncated.as_file() as f:
-            self.assertEqual(f.read(), b"12345")
+            assert f.read() == b"12345"
 
         # Full file
         op_full = CommitOperationAdd(
             path_or_fileobj=PartialFileIO(self.file_path, size_limit=9), path_in_repo="file.txt"
         )
-        self.assertEqual(op_full.upload_info.size, 9)
-        self.assertEqual(op_full.upload_info.sample, b"123456789")
+        assert op_full.upload_info.size == 9
+        assert op_full.upload_info.sample == b"123456789"
 
         with op_full.as_file() as f:
-            self.assertEqual(f.read(), b"123456789")
+            assert f.read() == b"123456789"
 
         # Truncated file has a different hash than the full file
-        self.assertNotEqual(op_truncated.upload_info.sha256, op_full.upload_info.sha256)
+        assert op_truncated.upload_info.sha256 != op_full.upload_info.sha256

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -624,14 +624,16 @@ class TestCachedDownload:
             )
 
 
-@pytest.mark.usefixtures("fx_cache_dir")
 class TestHfHubDownloadToLocalDir:
     # `cache_dir` is a temporary directory
     # `local_dir` is a subdirectory in which files will be downloaded
     # `hub_cache_dir` is a subdirectory in which files will be cached ("HF cache")
-    cache_dir: Path
     file_name: str = "file.txt"
     lfs_name: str = "lfs.bin"
+
+    @pytest.fixture(autouse=True)
+    def _setup_cache_dir(self, tmp_path: Path):
+        self.cache_dir = tmp_path
 
     @property
     def local_dir(self) -> Path:
@@ -945,7 +947,6 @@ class TestFileDownloadDryRun:
             assert dry_run_info.will_download
 
 
-@pytest.mark.usefixtures("fx_cache_dir")
 class TestStagingCachedDownloadOnAwfulFilenames:
     """Implement regression tests for #1161.
 
@@ -954,7 +955,6 @@ class TestStagingCachedDownloadOnAwfulFilenames:
     See https://github.com/huggingface/huggingface_hub/issues/1161
     """
 
-    cache_dir: Path
     subfolder = "subfolder/to?"
     filename = "awful?filename%you:should,never.give"
     filepath = f"subfolder/to?/{filename}"
@@ -982,24 +982,23 @@ class TestStagingCachedDownloadOnAwfulFilenames:
         assert hf_hub_url(self.repo_url.repo_id, self.filename, subfolder=self.subfolder) == self.expected_resolve_url
 
     @pytest.mark.skipif(os.name == "nt", reason="Windows paths cannot contain a '?'.")
-    def test_hf_hub_download_on_awful_filepath(self):
-        local_path = hf_hub_download(self.repo_url.repo_id, self.filepath, cache_dir=self.cache_dir)
+    def test_hf_hub_download_on_awful_filepath(self, tmp_path: Path):
+        local_path = hf_hub_download(self.repo_url.repo_id, self.filepath, cache_dir=tmp_path)
         # Local path is not url-encoded
         assert local_path.endswith(self.filepath)
 
     @pytest.mark.skipif(os.name == "nt", reason="Windows paths cannot contain a '?'.")
-    def test_hf_hub_download_on_awful_subfolder_and_filename(self):
+    def test_hf_hub_download_on_awful_subfolder_and_filename(self, tmp_path: Path):
         local_path = hf_hub_download(
             self.repo_url.repo_id,
             self.filename,
             subfolder=self.subfolder,
-            cache_dir=self.cache_dir,
+            cache_dir=tmp_path,
         )
         # Local path is not url-encoded
         assert local_path.endswith(self.filepath)
 
 
-@pytest.mark.usefixtures("fx_cache_dir")
 class TestHfHubDownloadRelativePaths:
     """Regression test for HackerOne report 1928845.
 
@@ -1008,8 +1007,6 @@ class TestHfHubDownloadRelativePaths:
     In the end, multiple protections have been added to prevent this (..\\ in filename forbidden on Windows, always check
     the filepath is in local_dir/snapshot_dir).
     """
-
-    cache_dir: Path
 
     @pytest.fixture(scope="class", autouse=True)
     def setup(self, request):
@@ -1023,13 +1020,13 @@ class TestHfHubDownloadRelativePaths:
         api.delete_repo(repo_id=request.cls.repo_id)
 
     @pytest.mark.skipif(os.name == "nt", reason="Windows paths cannot contain '\\..\\'.")
-    def test_download_folder_file_in_cache_dir(self) -> None:
-        hf_hub_download(self.repo_id, "folder/..\\..\\..\\file", cache_dir=self.cache_dir)
+    def test_download_folder_file_in_cache_dir(self, tmp_path: Path) -> None:
+        hf_hub_download(self.repo_id, "folder/..\\..\\..\\file", cache_dir=tmp_path)
 
     @pytest.mark.skipif(os.name == "nt", reason="Windows paths cannot contain '\\..\\'.")
-    def test_download_folder_file_to_local_dir(self) -> None:
+    def test_download_folder_file_to_local_dir(self, tmp_path: Path) -> None:
         with SoftTemporaryDirectory() as local_dir:
-            hf_hub_download(self.repo_id, "folder/..\\..\\..\\file", cache_dir=self.cache_dir, local_dir=local_dir)
+            hf_hub_download(self.repo_id, "folder/..\\..\\..\\file", cache_dir=tmp_path, local_dir=local_dir)
 
     def test_get_pointer_path_and_valid_relative_filename(self) -> None:
         # Cannot happen because of other protections, but just in case.

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -15,7 +15,6 @@ import io
 import os
 import shutil
 import stat
-import unittest
 import warnings
 from contextlib import contextmanager
 from pathlib import Path
@@ -45,7 +44,7 @@ from huggingface_hub.utils import SoftTemporaryDirectory, WeakFileLock, get_sess
 from huggingface_hub.utils._headers import build_hf_headers
 from huggingface_hub.utils._http import _http_backoff_base
 
-from .testing_constants import ENDPOINT_STAGING, OTHER_TOKEN, TOKEN
+from .testing_constants import OTHER_TOKEN, TOKEN
 from .testing_utils import (
     DUMMY_EXTRA_LARGE_FILE_MODEL_ID,
     DUMMY_EXTRA_LARGE_FILE_NAME,
@@ -54,9 +53,6 @@ from .testing_utils import (
     DUMMY_RENAMED_OLD_MODEL_ID,
     SAMPLE_DATASET_IDENTIFIER,
     repo_name,
-    skip_on_windows,
-    use_tmp_repo,
-    with_production_testing,
 )
 
 
@@ -72,14 +68,15 @@ DATASET_REVISION_ID_ONE_SPECIFIC_COMMIT = "e25d55a1c4933f987c46cc75d8ffadd67f257
 DATASET_SAMPLE_PY_FILE = "custom_squad.py"
 
 
-class TestDiskUsageWarning(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
+class TestDiskUsageWarning:
+    @pytest.fixture(scope="class", autouse=True)
+    def setup(self, request):
         # Test with 100MB expected file size
-        cls.expected_size = 100 * 1024 * 1024
+        request.cls.expected_size = 100 * 1024 * 1024
+        yield
 
-    @patch("huggingface_hub.file_download.shutil.disk_usage")
-    def test_disk_usage_warning(self, disk_usage_mock: Mock) -> None:
+    def test_disk_usage_warning(self, mocker) -> None:
+        disk_usage_mock = mocker.patch("huggingface_hub.file_download.shutil.disk_usage")
         # Test with only 1MB free disk space / not enough disk space, with UserWarning expected
         disk_usage_mock.return_value.free = 1024 * 1024
         with warnings.catch_warnings(record=True) as w:
@@ -113,11 +110,8 @@ class TestDiskUsageWarning(unittest.TestCase):
             assert len(w) == 0
 
 
-class StagingDownloadTests(unittest.TestCase):
-    _api = HfApi(endpoint=ENDPOINT_STAGING, token=TOKEN)
-
-    @use_tmp_repo()
-    def test_download_from_a_gated_repo_with_hf_hub_download(self, repo_url: RepoUrl) -> None:
+class TestStagingDownload:
+    def test_download_from_a_gated_repo_with_hf_hub_download(self, api: HfApi, repo_factory: "RepoFactory") -> None:
         """Checks `hf_hub_download` outputs error on gated repo.
 
         Regression test for #1121.
@@ -125,48 +119,49 @@ class StagingDownloadTests(unittest.TestCase):
 
         Cannot test on staging as dynamically setting a gated repo doesn't work there.
         """
+        repo_url = repo_factory()
         # Set repo as gated
         response = get_session().put(
-            f"{self._api.endpoint}/api/models/{repo_url.repo_id}/settings",
+            f"{api.endpoint}/api/models/{repo_url.repo_id}/settings",
             json={"gated": "auto"},
-            headers=self._api._build_hf_headers(),
+            headers=api._build_hf_headers(),
         )
         hf_raise_for_status(response)
 
         # Cannot download file as repo is gated
         with SoftTemporaryDirectory() as tmpdir:
-            with self.assertRaisesRegex(
-                GatedRepoError, "Access to model .* is restricted and you are not in the authorized list"
+            with pytest.raises(
+                GatedRepoError, match="Access to model .* is restricted and you are not in the authorized list"
             ):
                 hf_hub_download(
                     repo_id=repo_url.repo_id, filename=".gitattributes", token=OTHER_TOKEN, cache_dir=tmpdir
                 )
 
-    @use_tmp_repo()
-    def test_download_regular_file_from_private_renamed_repo(self, repo_url: RepoUrl) -> None:
+    def test_download_regular_file_from_private_renamed_repo(self, api: HfApi, repo_factory: "RepoFactory") -> None:
         """Regression test for #1999.
 
         See https://github.com/huggingface/huggingface_hub/pull/1999.
         """
+        repo_url = repo_factory()
         repo_id_before = repo_url.repo_id
         repo_id_after = repo_url.repo_id + "_renamed"
 
         # Make private + rename + upload regular file
-        self._api.update_repo_settings(repo_id_before, private=True)
-        self._api.upload_file(repo_id=repo_id_before, path_in_repo="file.txt", path_or_fileobj=b"content")
-        self._api.move_repo(repo_id_before, repo_id_after)
+        api.update_repo_settings(repo_id_before, private=True)
+        api.upload_file(repo_id=repo_id_before, path_in_repo="file.txt", path_or_fileobj=b"content")
+        api.move_repo(repo_id_before, repo_id_after)
 
         # Download from private renamed repo
-        path = self._api.hf_hub_download(repo_id_before, filename="file.txt")
+        path = api.hf_hub_download(repo_id_before, filename="file.txt")
         with open(path) as f:
-            self.assertEqual(f.read(), "content")
+            assert f.read() == "content"
 
         # Move back (so that auto-cleanup works)
-        self._api.move_repo(repo_id_after, repo_id_before)
+        api.move_repo(repo_id_after, repo_id_before)
 
 
-@with_production_testing
-class CachedDownloadTests(unittest.TestCase):
+@pytest.mark.production
+class TestCachedDownload:
     def test_file_not_found_locally_and_network_disabled(self):
         # Valid file but missing locally and network is disabled.
         with SoftTemporaryDirectory() as tmpdir:
@@ -190,8 +185,7 @@ class CachedDownloadTests(unittest.TestCase):
                     local_files_only=True,
                 )
 
-    def test_private_repo_and_file_cached_locally(self):
-        api = HfApi(endpoint=ENDPOINT_STAGING)
+    def test_private_repo_and_file_cached_locally(self, api: HfApi):
         repo_id = api.create_repo(repo_id=repo_name(), private=True, token=TOKEN).repo_id
         api.upload_file(path_or_fileobj=b"content", path_in_repo="config.json", repo_id=repo_id, token=TOKEN)
 
@@ -223,7 +217,7 @@ class CachedDownloadTests(unittest.TestCase):
             # Set permission back for cleanup
             _recursive_chmod(tmpdir, 0o777)
 
-    @skip_on_windows(reason="umask is UNIX-specific")
+    @pytest.mark.skipif(os.name == "nt", reason="umask is UNIX-specific")
     def test_hf_hub_download_custom_cache_permission(self):
         """Checks `hf_hub_download` respect the cache dir permission.
 
@@ -237,7 +231,7 @@ class CachedDownloadTests(unittest.TestCase):
             try:
                 filepath = hf_hub_download(DUMMY_RENAMED_OLD_MODEL_ID, "config.json", cache_dir=tmpdir)
                 # Permissions are honored (640: u=rw,g=r,o=)
-                self.assertEqual(stat.S_IMODE(os.stat(filepath).st_mode), 0o640)
+                assert stat.S_IMODE(os.stat(filepath).st_mode) == 0o640
             finally:
                 os.umask(previous_umask)
 
@@ -264,7 +258,7 @@ class CachedDownloadTests(unittest.TestCase):
                     filename=constants.CONFIG_NAME,
                     cache_dir=tmpdir,
                 )
-            self.assertTrue(os.path.exists(filepath))
+            assert os.path.exists(filepath)
 
     def test_download_from_a_renamed_repo_with_hf_hub_download(self):
         """Checks `hf_hub_download` works also on a renamed repo.
@@ -274,7 +268,7 @@ class CachedDownloadTests(unittest.TestCase):
         """
         with SoftTemporaryDirectory() as tmpdir:
             filepath = hf_hub_download(DUMMY_RENAMED_OLD_MODEL_ID, "config.json", cache_dir=tmpdir)
-            self.assertTrue(os.path.exists(filepath))
+            assert os.path.exists(filepath)
 
     def test_hf_hub_download_with_empty_subfolder(self):
         """
@@ -293,9 +287,9 @@ class CachedDownloadTests(unittest.TestCase):
 
         # Check file exists and is not in a subfolder in cache
         # e.g: "(...)/snapshots/<commit-id>/config.json"
-        self.assertTrue(filepath.is_file())
-        self.assertEqual(filepath.name, constants.CONFIG_NAME)
-        self.assertEqual(Path(filepath).parent.parent.name, "snapshots")
+        assert filepath.is_file()
+        assert filepath.name == constants.CONFIG_NAME
+        assert Path(filepath).parent.parent.name == "snapshots"
 
     def test_hf_hub_download_offline_no_refs(self):
         """Regression test for #1305.
@@ -307,7 +301,7 @@ class CachedDownloadTests(unittest.TestCase):
         See https://github.com/huggingface/huggingface_hub/issues/1305.
         """
         with SoftTemporaryDirectory() as cache_dir:
-            with self.assertRaises(LocalEntryNotFoundError):
+            with pytest.raises(LocalEntryNotFoundError):
                 hf_hub_download(
                     DUMMY_MODEL_ID,
                     filename=constants.CONFIG_NAME,
@@ -371,26 +365,24 @@ class CachedDownloadTests(unittest.TestCase):
             filename=constants.CONFIG_NAME,
             subfolder="",  # Subfolder should be processed as `None`
         )
-        self.assertTrue(
-            url.endswith(
-                # "./resolve/main/config.json" and not "./resolve/main//config.json"
-                f"{DUMMY_MODEL_ID}/resolve/main/config.json",
-            )
+        assert url.endswith(
+            # "./resolve/main/config.json" and not "./resolve/main//config.json"
+            f"{DUMMY_MODEL_ID}/resolve/main/config.json",
         )
 
-    @patch("huggingface_hub.constants.ENDPOINT", "https://huggingface.co")
-    @patch(
-        "huggingface_hub.constants.HUGGINGFACE_CO_URL_TEMPLATE",
-        "https://huggingface.co/{repo_id}/resolve/{revision}/{filename}",
-    )
-    def test_hf_hub_url_with_endpoint(self):
-        self.assertEqual(
+    def test_hf_hub_url_with_endpoint(self, mocker):
+        mocker.patch("huggingface_hub.constants.ENDPOINT", "https://huggingface.co")
+        mocker.patch(
+            "huggingface_hub.constants.HUGGINGFACE_CO_URL_TEMPLATE",
+            "https://huggingface.co/{repo_id}/resolve/{revision}/{filename}",
+        )
+        assert (
             hf_hub_url(
                 DUMMY_MODEL_ID,
                 filename=constants.CONFIG_NAME,
                 endpoint="https://hf-ci.co",
-            ),
-            "https://hf-ci.co/julien-c/dummy-unknown/resolve/main/config.json",
+            )
+            == "https://hf-ci.co/julien-c/dummy-unknown/resolve/main/config.json"
         )
 
     def test_try_to_load_from_cache_exist(self):
@@ -398,52 +390,53 @@ class CachedDownloadTests(unittest.TestCase):
         filepath = hf_hub_download(DUMMY_MODEL_ID, filename=constants.CONFIG_NAME)
 
         new_file_path = try_to_load_from_cache(DUMMY_MODEL_ID, filename=constants.CONFIG_NAME)
-        self.assertEqual(filepath, new_file_path)
+        assert filepath == new_file_path
 
         new_file_path = try_to_load_from_cache(DUMMY_MODEL_ID, filename=constants.CONFIG_NAME, revision="main")
-        self.assertEqual(filepath, new_file_path)
+        assert filepath == new_file_path
 
         # If file is not cached, returns None
-        self.assertIsNone(try_to_load_from_cache(DUMMY_MODEL_ID, filename="conf.json"))
+        assert try_to_load_from_cache(DUMMY_MODEL_ID, filename="conf.json") is None
         # Same for uncached revisions
-        self.assertIsNone(
+        assert (
             try_to_load_from_cache(
                 DUMMY_MODEL_ID,
                 filename=constants.CONFIG_NAME,
                 revision="aaa",
             )
+            is None
         )
         # Same for uncached models
-        self.assertIsNone(try_to_load_from_cache("bert-base", filename=constants.CONFIG_NAME))
+        assert try_to_load_from_cache("bert-base", filename=constants.CONFIG_NAME) is None
 
     def test_try_to_load_from_cache_specific_pr_revision_exists(self):
         # Make sure the file is cached
         file_path = hf_hub_download(DUMMY_MODEL_ID, filename=constants.CONFIG_NAME, revision="refs/pr/1")
 
         new_file_path = try_to_load_from_cache(DUMMY_MODEL_ID, filename=constants.CONFIG_NAME, revision="refs/pr/1")
-        self.assertEqual(file_path, new_file_path)
+        assert file_path == new_file_path
 
         # If file is not cached, returns None
-        self.assertIsNone(try_to_load_from_cache(DUMMY_MODEL_ID, filename="conf.json", revision="refs/pr/1"))
+        assert try_to_load_from_cache(DUMMY_MODEL_ID, filename="conf.json", revision="refs/pr/1") is None
 
         # If revision does not exist, returns None
-        self.assertIsNone(
-            try_to_load_from_cache(DUMMY_MODEL_ID, filename=constants.CONFIG_NAME, revision="does-not-exist")
+        assert (
+            try_to_load_from_cache(DUMMY_MODEL_ID, filename=constants.CONFIG_NAME, revision="does-not-exist") is None
         )
 
     def test_try_to_load_from_cache_no_exist(self):
         # Make sure the file is cached
-        with self.assertRaises(EntryNotFoundError):
+        with pytest.raises(EntryNotFoundError):
             _ = hf_hub_download(DUMMY_MODEL_ID, filename="dummy")
 
         new_file_path = try_to_load_from_cache(DUMMY_MODEL_ID, filename="dummy")
-        self.assertEqual(new_file_path, _CACHED_NO_EXIST)
+        assert new_file_path == _CACHED_NO_EXIST
 
         new_file_path = try_to_load_from_cache(DUMMY_MODEL_ID, filename="dummy", revision="main")
-        self.assertEqual(new_file_path, _CACHED_NO_EXIST)
+        assert new_file_path == _CACHED_NO_EXIST
 
         # If file non-existence is not cached, returns None
-        self.assertIsNone(try_to_load_from_cache(DUMMY_MODEL_ID, filename="dummy2"))
+        assert try_to_load_from_cache(DUMMY_MODEL_ID, filename="dummy2") is None
 
     def test_try_to_load_from_cache_specific_commit_id_exist(self):
         """Regression test for #1306.
@@ -466,7 +459,7 @@ class CachedDownloadTests(unittest.TestCase):
                 revision=commit_id,
                 cache_dir=cache_dir,
             )
-            self.assertEqual(filepath, attempt)
+            assert filepath == attempt
 
     def test_try_to_load_from_cache_specific_commit_id_no_exist(self):
         """Regression test for #1306.
@@ -475,7 +468,7 @@ class CachedDownloadTests(unittest.TestCase):
         with SoftTemporaryDirectory() as cache_dir:
             # Cache file from specific commit id (no "refs/"" folder)
             commit_id = HfApi().model_info(DUMMY_MODEL_ID).sha
-            with self.assertRaises(EntryNotFoundError):
+            with pytest.raises(EntryNotFoundError):
                 hf_hub_download(
                     DUMMY_MODEL_ID,
                     filename="missing_file",
@@ -490,7 +483,7 @@ class CachedDownloadTests(unittest.TestCase):
                 revision=commit_id,
                 cache_dir=cache_dir,
             )
-            self.assertEqual(attempt, _CACHED_NO_EXIST)
+            assert attempt == _CACHED_NO_EXIST
 
     def test_get_hf_file_metadata_basic(self) -> None:
         """Test getting metadata from a file on the Hub."""
@@ -502,9 +495,9 @@ class CachedDownloadTests(unittest.TestCase):
         metadata = get_hf_file_metadata(url)
 
         # Metadata
-        self.assertEqual(metadata.commit_hash, DUMMY_MODEL_ID_REVISION_ONE_SPECIFIC_COMMIT)
-        self.assertIsNotNone(metadata.etag)  # example: "85c2fc2dcdd86563aaa85ef4911..."
-        self.assertEqual(metadata.size, 851)
+        assert metadata.commit_hash == DUMMY_MODEL_ID_REVISION_ONE_SPECIFIC_COMMIT
+        assert metadata.etag is not None  # example: "85c2fc2dcdd86563aaa85ef4911..."
+        assert metadata.size == 851
 
     def test_get_hf_file_metadata_from_a_lfs_file(self) -> None:
         """Test getting metadata from an LFS file.
@@ -515,7 +508,7 @@ class CachedDownloadTests(unittest.TestCase):
         metadata = get_hf_file_metadata(url)
 
         assert "xethub.hf.co" in metadata.location or "cdn.hf.co" in metadata.location  # Redirection
-        self.assertEqual(metadata.size, 497933648)  # Size of LFS file, not pointer
+        assert metadata.size == 497933648  # Size of LFS file, not pointer
 
     def test_file_consistency_check_fails_regular_file(self):
         """Regression test for #1396 (regular file).
@@ -536,7 +529,7 @@ class CachedDownloadTests(unittest.TestCase):
                 )
 
             with patch("huggingface_hub.file_download.get_hf_file_metadata", _mocked_hf_file_metadata):
-                with self.assertRaises(EnvironmentError):
+                with pytest.raises(EnvironmentError):
                     hf_hub_download(DUMMY_MODEL_ID, filename=constants.CONFIG_NAME, cache_dir=cache_dir)
 
     def test_file_consistency_check_fails_LFS_file(self):
@@ -558,7 +551,7 @@ class CachedDownloadTests(unittest.TestCase):
                 )
 
             with patch("huggingface_hub.file_download.get_hf_file_metadata", _mocked_hf_file_metadata):
-                with self.assertRaises(EnvironmentError):
+                with pytest.raises(EnvironmentError):
                     hf_hub_download(DUMMY_MODEL_ID, filename="pytorch_model.bin", cache_dir=cache_dir)
 
     def test_hf_hub_download_when_tmp_file_is_complete(self):
@@ -624,15 +617,14 @@ class CachedDownloadTests(unittest.TestCase):
                     # Happens on Windows if drives differ.
                     return False
 
-            self.assertGreater(len(acquired_lock_paths), 0, "no lock acquisition was recorded")
-            self.assertTrue(
-                any(_is_lock_under_cache_locks(path) for path in acquired_lock_paths),
-                "expected at least one lock acquisition in cache `.locks`",
+            assert len(acquired_lock_paths) > 0, "no lock acquisition was recorded"
+            assert any(_is_lock_under_cache_locks(path) for path in acquired_lock_paths), (
+                "expected at least one lock acquisition in cache `.locks`"
             )
 
 
 @pytest.mark.usefixtures("fx_cache_dir")
-class HfHubDownloadToLocalDir(unittest.TestCase):
+class TestHfHubDownloadToLocalDir:
     # `cache_dir` is a temporary directory
     # `local_dir` is a subdirectory in which files will be downloaded
     # `hub_cache_dir` is a subdirectory in which files will be cached ("HF cache")
@@ -660,23 +652,26 @@ class HfHubDownloadToLocalDir(unittest.TestCase):
     def lfs_path(self) -> Path:
         return self.local_dir / self.lfs_name
 
-    @classmethod
-    def setUpClass(cls):
-        cls.api = HfApi(endpoint=ENDPOINT_STAGING, token=TOKEN)
-        cls.repo_id = cls.api.create_repo(repo_id=repo_name()).repo_id
-        commit_1 = cls.api.upload_file(path_or_fileobj=b"content", path_in_repo=cls.file_name, repo_id=cls.repo_id)
-        commit_2 = cls.api.upload_file(path_or_fileobj=b"content", path_in_repo=cls.lfs_name, repo_id=cls.repo_id)
+    @pytest.fixture(scope="class", autouse=True)
+    def setup(self, request):
+        api = HfApi(endpoint=constants.ENDPOINT, token=TOKEN)
+        request.cls.api = api
+        request.cls.repo_id = api.create_repo(repo_id=repo_name()).repo_id
+        commit_1 = api.upload_file(
+            path_or_fileobj=b"content", path_in_repo=request.cls.file_name, repo_id=request.cls.repo_id
+        )
+        commit_2 = api.upload_file(
+            path_or_fileobj=b"content", path_in_repo=request.cls.lfs_name, repo_id=request.cls.repo_id
+        )
 
-        info = cls.api.get_paths_info(repo_id=cls.repo_id, paths=[cls.file_name, cls.lfs_name])
+        info = api.get_paths_info(repo_id=request.cls.repo_id, paths=[request.cls.file_name, request.cls.lfs_name])
         info = {item.path: item for item in info}
-        cls.commit_hash_1 = commit_1.oid
-        cls.commit_hash_2 = commit_2.oid
-        cls.file_etag = info[cls.file_name].blob_id
-        cls.lfs_etag = info[cls.lfs_name].lfs.sha256
-
-    @classmethod
-    def tearDownClass(cls) -> None:
-        cls.api.delete_repo(repo_id=cls.repo_id)
+        request.cls.commit_hash_1 = commit_1.oid
+        request.cls.commit_hash_2 = commit_2.oid
+        request.cls.file_etag = info[request.cls.file_name].blob_id
+        request.cls.lfs_etag = info[request.cls.lfs_name].lfs.sha256
+        yield
+        api.delete_repo(repo_id=request.cls.repo_id)
 
     @contextmanager
     def with_patch_head(self):
@@ -750,7 +745,7 @@ class HfHubDownloadToLocalDir(unittest.TestCase):
 
     def test_local_files_only_and_file_missing(self):
         # must raise
-        with self.assertRaises(LocalEntryNotFoundError):
+        with pytest.raises(LocalEntryNotFoundError):
             self.api.hf_hub_download(
                 self.repo_id, filename=self.file_name, local_dir=self.local_dir, local_files_only=True
             )
@@ -831,14 +826,14 @@ class HfHubDownloadToLocalDir(unittest.TestCase):
         self.api.hf_hub_download(self.repo_id, filename=self.file_name, local_dir=self.local_dir)
         assert self.file_path.read_text() == "content"
 
-    @patch("huggingface_hub.file_download.build_hf_headers")
-    def test_passing_token_false_is_respected(self, mock: Mock):
+    def test_passing_token_false_is_respected(self, mocker):
         """Regression test for #2385.
 
         A bug introduced in 0.23.0 was causing the `token` parameter to be ignored when set to `False`.
 
         See https://github.com/huggingface/huggingface_hub/issues/2385.
         """
+        mock = mocker.patch("huggingface_hub.file_download.build_hf_headers")
         # Download to local dir
         mock.reset_mock(return_value={})
         self.api.hf_hub_download(self.repo_id, filename=self.file_name, local_dir=self.local_dir, token=False)
@@ -854,8 +849,8 @@ class HfHubDownloadToLocalDir(unittest.TestCase):
             assert call.kwargs["token"] is False
 
 
-@with_production_testing
-class TestFileDownloadDryRun(unittest.TestCase):
+@pytest.mark.production
+class TestFileDownloadDryRun:
     def test_dry_run_cache_dir(self):
         with SoftTemporaryDirectory() as tmpdir:
             # Dry-run a first time => file is not cached
@@ -950,7 +945,7 @@ class TestFileDownloadDryRun(unittest.TestCase):
 
 
 @pytest.mark.usefixtures("fx_cache_dir")
-class StagingCachedDownloadOnAwfulFilenamesTest(unittest.TestCase):
+class TestStagingCachedDownloadOnAwfulFilenames:
     """Implement regression tests for #1161.
 
     Issue was on filename not url encoded by `hf_hub_download` and `hf_hub_url`.
@@ -963,39 +958,37 @@ class StagingCachedDownloadOnAwfulFilenamesTest(unittest.TestCase):
     filename = "awful?filename%you:should,never.give"
     filepath = f"subfolder/to?/{filename}"
 
-    @classmethod
-    def setUpClass(cls):
-        cls.api = HfApi(endpoint=ENDPOINT_STAGING, token=TOKEN)
-        cls.repo_url = cls.api.create_repo(repo_id=repo_name("awful_filename"))
-        cls.expected_resolve_url = (
-            f"{cls.repo_url}/resolve/main/subfolder/to%3F/awful%3Ffilename%25you%3Ashould%2Cnever.give"
+    @pytest.fixture(scope="class", autouse=True)
+    def setup(self, request):
+        api = HfApi(endpoint=constants.ENDPOINT, token=TOKEN)
+        request.cls.api = api
+        request.cls.repo_url = api.create_repo(repo_id=repo_name("awful_filename"))
+        request.cls.expected_resolve_url = (
+            f"{request.cls.repo_url}/resolve/main/subfolder/to%3F/awful%3Ffilename%25you%3Ashould%2Cnever.give"
         )
-        cls.api.upload_file(
+        api.upload_file(
             path_or_fileobj=b"content",
-            path_in_repo=cls.filepath,
-            repo_id=cls.repo_url.repo_id,
+            path_in_repo=request.cls.filepath,
+            repo_id=request.cls.repo_url.repo_id,
         )
-
-    @classmethod
-    def tearDownClass(cls) -> None:
-        cls.api.delete_repo(repo_id=cls.repo_url.repo_id)
+        yield
+        api.delete_repo(repo_id=request.cls.repo_url.repo_id)
 
     def test_hf_hub_url_on_awful_filepath(self):
-        self.assertEqual(hf_hub_url(self.repo_url.repo_id, self.filepath), self.expected_resolve_url)
+        assert hf_hub_url(self.repo_url.repo_id, self.filepath) == self.expected_resolve_url
 
     def test_hf_hub_url_on_awful_subfolder_and_filename(self):
-        self.assertEqual(
-            hf_hub_url(self.repo_url.repo_id, self.filename, subfolder=self.subfolder),
-            self.expected_resolve_url,
+        assert (
+            hf_hub_url(self.repo_url.repo_id, self.filename, subfolder=self.subfolder) == self.expected_resolve_url
         )
 
-    @skip_on_windows(reason="Windows paths cannot contain a '?'.")
+    @pytest.mark.skipif(os.name == "nt", reason="Windows paths cannot contain a '?'.")
     def test_hf_hub_download_on_awful_filepath(self):
         local_path = hf_hub_download(self.repo_url.repo_id, self.filepath, cache_dir=self.cache_dir)
         # Local path is not url-encoded
-        self.assertTrue(local_path.endswith(self.filepath))
+        assert local_path.endswith(self.filepath)
 
-    @skip_on_windows(reason="Windows paths cannot contain a '?'.")
+    @pytest.mark.skipif(os.name == "nt", reason="Windows paths cannot contain a '?'.")
     def test_hf_hub_download_on_awful_subfolder_and_filename(self):
         local_path = hf_hub_download(
             self.repo_url.repo_id,
@@ -1004,11 +997,11 @@ class StagingCachedDownloadOnAwfulFilenamesTest(unittest.TestCase):
             cache_dir=self.cache_dir,
         )
         # Local path is not url-encoded
-        self.assertTrue(local_path.endswith(self.filepath))
+        assert local_path.endswith(self.filepath)
 
 
 @pytest.mark.usefixtures("fx_cache_dir")
-class TestHfHubDownloadRelativePaths(unittest.TestCase):
+class TestHfHubDownloadRelativePaths:
     """Regression test for HackerOne report 1928845.
 
     Issue was that any file outside of the local dir could be overwritten (Windows only).
@@ -1019,36 +1012,34 @@ class TestHfHubDownloadRelativePaths(unittest.TestCase):
 
     cache_dir: Path
 
-    @classmethod
-    def setUpClass(cls):
-        cls.api = HfApi(endpoint=ENDPOINT_STAGING, token=TOKEN)
-        cls.repo_id = cls.api.create_repo(repo_id=repo_name()).repo_id
-        cls.api.upload_file(path_or_fileobj=b"content", path_in_repo="folder/..\\..\\..\\file", repo_id=cls.repo_id)
+    @pytest.fixture(scope="class", autouse=True)
+    def setup(self, request):
+        api = HfApi(endpoint=constants.ENDPOINT, token=TOKEN)
+        request.cls.api = api
+        request.cls.repo_id = api.create_repo(repo_id=repo_name()).repo_id
+        api.upload_file(path_or_fileobj=b"content", path_in_repo="folder/..\\..\\..\\file", repo_id=request.cls.repo_id)
+        yield
+        api.delete_repo(repo_id=request.cls.repo_id)
 
-    @classmethod
-    def tearDownClass(cls) -> None:
-        cls.api.delete_repo(repo_id=cls.repo_id)
-
-    @skip_on_windows(reason="Windows paths cannot contain '\\..\\'.")
+    @pytest.mark.skipif(os.name == "nt", reason="Windows paths cannot contain '\\..\\'.")
     def test_download_folder_file_in_cache_dir(self) -> None:
         hf_hub_download(self.repo_id, "folder/..\\..\\..\\file", cache_dir=self.cache_dir)
 
-    @skip_on_windows(reason="Windows paths cannot contain '\\..\\'.")
+    @pytest.mark.skipif(os.name == "nt", reason="Windows paths cannot contain '\\..\\'.")
     def test_download_folder_file_to_local_dir(self) -> None:
         with SoftTemporaryDirectory() as local_dir:
             hf_hub_download(self.repo_id, "folder/..\\..\\..\\file", cache_dir=self.cache_dir, local_dir=local_dir)
 
     def test_get_pointer_path_and_valid_relative_filename(self) -> None:
         # Cannot happen because of other protections, but just in case.
-        self.assertEqual(
-            _get_pointer_path("path/to/storage", "abcdef", "path/to/file.txt"),
-            os.path.join("path/to/storage", "snapshots", "abcdef", "path/to/file.txt"),
+        assert _get_pointer_path("path/to/storage", "abcdef", "path/to/file.txt") == os.path.join(
+            "path/to/storage", "snapshots", "abcdef", "path/to/file.txt"
         )
 
     def test_get_pointer_path_but_invalid_relative_filename(self) -> None:
         # Cannot happen because of other protections, but just in case.
         relative_filename = "folder\\..\\..\\..\\file.txt" if os.name == "nt" else "folder/../../../file.txt"
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             _get_pointer_path("path/to/storage", "abcdef", relative_filename)
 
 
@@ -1370,10 +1361,10 @@ class TestHttpGet:
         assert tracker.n == 100
 
 
-class CreateSymlinkTest(unittest.TestCase):
-    @unittest.skipIf(os.name == "nt", "No symlinks on Windows")
-    @patch("huggingface_hub.file_download.are_symlinks_supported")
-    def test_create_symlink_concurrent_access(self, mock_are_symlinks_supported: Mock) -> None:
+class TestCreateSymlink:
+    @pytest.mark.skipif(os.name == "nt", reason="No symlinks on Windows")
+    def test_create_symlink_concurrent_access(self, mocker) -> None:
+        mock_are_symlinks_supported = mocker.patch("huggingface_hub.file_download.are_symlinks_supported")
         with SoftTemporaryDirectory() as tmpdir:
             src = os.path.join(tmpdir, "source")
             other = os.path.join(tmpdir, "other")
@@ -1382,7 +1373,7 @@ class CreateSymlinkTest(unittest.TestCase):
             # Normal case: symlink does not exist
             mock_are_symlinks_supported.return_value = True
             _create_symlink(src, dst)
-            self.assertEqual(os.path.realpath(dst), os.path.realpath(src))
+            assert os.path.realpath(dst) == os.path.realpath(src)
 
             # Symlink already exists when it tries to create it (most probably from a
             # concurrent access) but do not raise exception
@@ -1400,7 +1391,7 @@ class CreateSymlinkTest(unittest.TestCase):
                 return True
 
             mock_are_symlinks_supported.side_effect = _are_symlinks_supported
-            with self.assertRaises(FileExistsError):
+            with pytest.raises(FileExistsError):
                 _create_symlink(src, dst)
 
     def test_create_symlink_relative_src(self) -> None:
@@ -1416,13 +1407,13 @@ class CreateSymlinkTest(unittest.TestCase):
         dst = Path(test_dir) / "destination"
 
         _create_symlink(str(src), str(dst))
-        self.assertTrue(dst.resolve().is_file())
+        assert dst.resolve().is_file()
         if os.name != "nt":
-            self.assertEqual(dst.resolve(), src.resolve())
+            assert dst.resolve() == src.resolve()
         shutil.rmtree(test_dir)
 
 
-class TestNormalizeEtag(unittest.TestCase):
+class TestNormalizeEtag:
     """Unit tests implemented after a server-side change broke the ETag normalization once (see #1428).
 
     TL;DR: _normalize_etag was expecting only strong references, but the server started to return weak references after
@@ -1433,27 +1424,29 @@ class TestNormalizeEtag(unittest.TestCase):
     """
 
     def test_strong_reference(self):
-        self.assertEqual(
-            _normalize_etag('"a16a55fda99d2f2e7b69cce5cf93ff4ad3049930"'), "a16a55fda99d2f2e7b69cce5cf93ff4ad3049930"
+        assert (
+            _normalize_etag('"a16a55fda99d2f2e7b69cce5cf93ff4ad3049930"') == "a16a55fda99d2f2e7b69cce5cf93ff4ad3049930"
         )
 
     def test_weak_reference(self):
-        self.assertEqual(
-            _normalize_etag('W/"a16a55fda99d2f2e7b69cce5cf93ff4ad3049930"'), "a16a55fda99d2f2e7b69cce5cf93ff4ad3049930"
+        assert (
+            _normalize_etag('W/"a16a55fda99d2f2e7b69cce5cf93ff4ad3049930"')
+            == "a16a55fda99d2f2e7b69cce5cf93ff4ad3049930"
         )
 
-    @with_production_testing
+    @pytest.mark.production
     def test_resolve_endpoint_on_regular_file(self):
         url = "https://huggingface.co/gpt2/resolve/e7da7f221d5bf496a48136c0cd264e630fe9fcc8/README.md"
         response = httpx.head(url, headers=build_hf_headers(user_agent="is_ci/true"))
-        self.assertEqual(self._get_etag_and_normalize(response), "a16a55fda99d2f2e7b69cce5cf93ff4ad3049930")
+        assert self._get_etag_and_normalize(response) == "a16a55fda99d2f2e7b69cce5cf93ff4ad3049930"
 
-    @with_production_testing
+    @pytest.mark.production
     def test_resolve_endpoint_on_lfs_file(self):
         url = "https://huggingface.co/gpt2/resolve/e7da7f221d5bf496a48136c0cd264e630fe9fcc8/pytorch_model.bin"
         response = httpx.head(url, headers=build_hf_headers(user_agent="is_ci/true"))
-        self.assertEqual(
-            self._get_etag_and_normalize(response), "7c5d3f4b8b76583b422fcb9189ad6c89d5d97a094541ce8932dce3ecabde1421"
+        assert (
+            self._get_etag_and_normalize(response)
+            == "7c5d3f4b8b76583b422fcb9189ad6c89d5d97a094541ce8932dce3ecabde1421"
         )
 
     @staticmethod
@@ -1463,15 +1456,12 @@ class TestNormalizeEtag(unittest.TestCase):
         )
 
 
-@with_production_testing
-class TestExtraLargeFileDownloadPaths(unittest.TestCase):
-    @patch("huggingface_hub.file_download.constants.HF_HUB_DISABLE_XET", True)
-    def test_large_file_http_path_error(self):
+@pytest.mark.production
+class TestExtraLargeFileDownloadPaths:
+    def test_large_file_http_path_error(self, mocker):
+        mocker.patch("huggingface_hub.file_download.constants.HF_HUB_DISABLE_XET", True)
         with SoftTemporaryDirectory() as cache_dir:
-            with self.assertRaises(
-                ValueError,
-                msg="The file is too large to be downloaded using the regular download method. Install `hf_xet` with `pip install hf_xet` for xet-powered downloads.",
-            ):
+            with pytest.raises(ValueError):
                 hf_hub_download(
                     DUMMY_EXTRA_LARGE_FILE_MODEL_ID,
                     filename=DUMMY_EXTRA_LARGE_FILE_NAME,

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -24,7 +24,7 @@ from unittest.mock import Mock, patch
 import httpx
 import pytest
 
-from huggingface_hub import HfApi, RepoUrl, constants
+from huggingface_hub import HfApi, constants
 from huggingface_hub._local_folder import write_download_metadata
 from huggingface_hub.errors import EntryNotFoundError, GatedRepoError, LocalEntryNotFoundError
 from huggingface_hub.file_download import (
@@ -44,6 +44,7 @@ from huggingface_hub.utils import SoftTemporaryDirectory, WeakFileLock, get_sess
 from huggingface_hub.utils._headers import build_hf_headers
 from huggingface_hub.utils._http import _http_backoff_base
 
+from .conftest import RepoFactory
 from .testing_constants import OTHER_TOKEN, TOKEN
 from .testing_utils import (
     DUMMY_EXTRA_LARGE_FILE_MODEL_ID,
@@ -111,7 +112,7 @@ class TestDiskUsageWarning:
 
 
 class TestStagingDownload:
-    def test_download_from_a_gated_repo_with_hf_hub_download(self, api: HfApi, repo_factory: "RepoFactory") -> None:
+    def test_download_from_a_gated_repo_with_hf_hub_download(self, api: HfApi, repo_factory: RepoFactory) -> None:
         """Checks `hf_hub_download` outputs error on gated repo.
 
         Regression test for #1121.
@@ -137,7 +138,7 @@ class TestStagingDownload:
                     repo_id=repo_url.repo_id, filename=".gitattributes", token=OTHER_TOKEN, cache_dir=tmpdir
                 )
 
-    def test_download_regular_file_from_private_renamed_repo(self, api: HfApi, repo_factory: "RepoFactory") -> None:
+    def test_download_regular_file_from_private_renamed_repo(self, api: HfApi, repo_factory: RepoFactory) -> None:
         """Regression test for #1999.
 
         See https://github.com/huggingface/huggingface_hub/pull/1999.
@@ -978,9 +979,7 @@ class TestStagingCachedDownloadOnAwfulFilenames:
         assert hf_hub_url(self.repo_url.repo_id, self.filepath) == self.expected_resolve_url
 
     def test_hf_hub_url_on_awful_subfolder_and_filename(self):
-        assert (
-            hf_hub_url(self.repo_url.repo_id, self.filename, subfolder=self.subfolder) == self.expected_resolve_url
-        )
+        assert hf_hub_url(self.repo_url.repo_id, self.filename, subfolder=self.subfolder) == self.expected_resolve_url
 
     @pytest.mark.skipif(os.name == "nt", reason="Windows paths cannot contain a '?'.")
     def test_hf_hub_download_on_awful_filepath(self):
@@ -1017,7 +1016,9 @@ class TestHfHubDownloadRelativePaths:
         api = HfApi(endpoint=constants.ENDPOINT, token=TOKEN)
         request.cls.api = api
         request.cls.repo_id = api.create_repo(repo_id=repo_name()).repo_id
-        api.upload_file(path_or_fileobj=b"content", path_in_repo="folder/..\\..\\..\\file", repo_id=request.cls.repo_id)
+        api.upload_file(
+            path_or_fileobj=b"content", path_in_repo="folder/..\\..\\..\\file", repo_id=request.cls.repo_id
+        )
         yield
         api.delete_repo(repo_id=request.cls.repo_id)
 

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2644,23 +2644,21 @@ class TestHfApiPrivate:
 
 
 @pytest.mark.xet
-@pytest.mark.usefixtures("fx_cache_dir")
 class TestUploadFolderMocked:
     api = HfApi()
-    cache_dir: Path
 
     @pytest.fixture(autouse=True)
-    def _setup(self, fx_cache_dir, mocker) -> None:
-        (self.cache_dir / "file.txt").write_text("content")
-        (self.cache_dir / "lfs.bin").write_text("content")
+    def _setup(self, tmp_path, mocker) -> None:
+        (tmp_path / "file.txt").write_text("content")
+        (tmp_path / "lfs.bin").write_text("content")
 
-        (self.cache_dir / "sub").mkdir()
-        (self.cache_dir / "sub" / "file.txt").write_text("content")
-        (self.cache_dir / "sub" / "lfs_in_sub.bin").write_text("content")
+        (tmp_path / "sub").mkdir()
+        (tmp_path / "sub" / "file.txt").write_text("content")
+        (tmp_path / "sub" / "lfs_in_sub.bin").write_text("content")
 
-        (self.cache_dir / "subdir").mkdir()
-        (self.cache_dir / "subdir" / "file.txt").write_text("content")
-        (self.cache_dir / "subdir" / "lfs_in_subdir.bin").write_text("content")
+        (tmp_path / "subdir").mkdir()
+        (tmp_path / "subdir" / "file.txt").write_text("content")
+        (tmp_path / "subdir" / "lfs_in_subdir.bin").write_text("content")
 
         self.all_local_files = {
             "lfs.bin",
@@ -2692,23 +2690,23 @@ class TestUploadFolderMocked:
         mocker.patch("huggingface_hub.hf_api.is_xet_available", return_value=True)
         mocker.patch("huggingface_hub.hf_api.pipelined_upload", self.pipeline_mock)
 
-    def _upload_folder_alias(self, **kwargs) -> list[Union[CommitOperationAdd, CommitOperationDelete]]:
+    def _upload_folder_alias(self, tmp_path, **kwargs) -> list[Union[CommitOperationAdd, CommitOperationDelete]]:
         """Alias to call `upload_folder` + retrieve the CommitOperation list passed to the pipeline."""
         if "folder_path" not in kwargs:
-            kwargs["folder_path"] = self.cache_dir
+            kwargs["folder_path"] = tmp_path
         self.api.upload_folder(repo_id="repo_id", **kwargs)
         call_kwargs = self.pipeline_mock.call_args_list[0][1]
         # `upload_folder` passes additions and deletions separately to the pipeline. Recombine them
         # (deletions first, as `create_commit` used to receive them) for the assertions below.
         return call_kwargs["delete_operations"] + call_kwargs["add_operations"]
 
-    def test_allow_everything(self):
-        operations = self._upload_folder_alias()
+    def test_allow_everything(self, tmp_path):
+        operations = self._upload_folder_alias(tmp_path)
         assert all(isinstance(op, CommitOperationAdd) for op in operations)
         assert {op.path_in_repo for op in operations} == self.all_local_files
 
-    def test_allow_everything_in_subdir_no_trailing_slash(self):
-        operations = self._upload_folder_alias(folder_path=self.cache_dir / "subdir", path_in_repo="subdir")
+    def test_allow_everything_in_subdir_no_trailing_slash(self, tmp_path):
+        operations = self._upload_folder_alias(tmp_path, folder_path=tmp_path / "subdir", path_in_repo="subdir")
         assert all(isinstance(op, CommitOperationAdd) for op in operations)
         assert {op.path_in_repo for op in operations} == {
             # correct `path_in_repo`
@@ -2716,37 +2714,37 @@ class TestUploadFolderMocked:
             "subdir/lfs_in_subdir.bin",
         }
 
-    def test_allow_everything_in_subdir_with_trailing_slash(self):
-        operations = self._upload_folder_alias(folder_path=self.cache_dir / "subdir", path_in_repo="subdir/")
+    def test_allow_everything_in_subdir_with_trailing_slash(self, tmp_path):
+        operations = self._upload_folder_alias(tmp_path, folder_path=tmp_path / "subdir", path_in_repo="subdir/")
         assert all(isinstance(op, CommitOperationAdd) for op in operations)
         assert {op.path_in_repo for op in operations} == {"subdir/file.txt", "subdir/lfs_in_subdir.bin"}
 
-    def test_allow_txt_ignore_subdir(self):
-        operations = self._upload_folder_alias(allow_patterns="*.txt", ignore_patterns="subdir/*")
+    def test_allow_txt_ignore_subdir(self, tmp_path):
+        operations = self._upload_folder_alias(tmp_path, allow_patterns="*.txt", ignore_patterns="subdir/*")
         assert all(isinstance(op, CommitOperationAdd) for op in operations)
         assert {op.path_in_repo for op in operations} == {"sub/file.txt", "file.txt"}  # only .txt files, not in subdir
 
-    def test_allow_txt_not_root_ignore_subdir(self):
-        operations = self._upload_folder_alias(allow_patterns="**/*.txt", ignore_patterns="subdir/*")
+    def test_allow_txt_not_root_ignore_subdir(self, tmp_path):
+        operations = self._upload_folder_alias(tmp_path, allow_patterns="**/*.txt", ignore_patterns="subdir/*")
         assert all(isinstance(op, CommitOperationAdd) for op in operations)
         assert {op.path_in_repo for op in operations} == {
             # only .txt files, not in subdir, not at root
             "sub/file.txt"
         }
 
-    def test_path_in_repo_dot(self):
+    def test_path_in_repo_dot(self, tmp_path):
         """Regression test for #1382 when using `path_in_repo="."`.
 
         Using `path_in_repo="."` or `path_in_repo=None` should be equivalent.
         See https://github.com/huggingface/huggingface_hub/pull/1382.
         """
-        operation_with_dot = self._upload_folder_alias(path_in_repo=".", allow_patterns=["file.txt"])[0]
-        operation_with_none = self._upload_folder_alias(path_in_repo=None, allow_patterns=["file.txt"])[0]
+        operation_with_dot = self._upload_folder_alias(tmp_path, path_in_repo=".", allow_patterns=["file.txt"])[0]
+        operation_with_none = self._upload_folder_alias(tmp_path, path_in_repo=None, allow_patterns=["file.txt"])[0]
         assert operation_with_dot.path_in_repo == "file.txt"
         assert operation_with_none.path_in_repo == "file.txt"
 
-    def test_delete_txt(self):
-        operations = self._upload_folder_alias(delete_patterns="*.txt")
+    def test_delete_txt(self, tmp_path):
+        operations = self._upload_folder_alias(tmp_path, delete_patterns="*.txt")
         added_files = {op.path_in_repo for op in operations if isinstance(op, CommitOperationAdd)}
         deleted_files = {op.path_in_repo for op in operations if isinstance(op, CommitOperationDelete)}
 
@@ -2757,9 +2755,9 @@ class TestUploadFolderMocked:
         assert "file.txt" in added_files
         assert "sub/file.txt" in added_files
 
-    def test_delete_txt_in_sub(self):
+    def test_delete_txt_in_sub(self, tmp_path):
         operations = self._upload_folder_alias(
-            path_in_repo="sub/", folder_path=self.cache_dir / "sub", delete_patterns="*.txt"
+            tmp_path, path_in_repo="sub/", folder_path=tmp_path / "sub", delete_patterns="*.txt"
         )
         added_files = {op.path_in_repo for op in operations if isinstance(op, CommitOperationAdd)}
         deleted_files = {op.path_in_repo for op in operations if isinstance(op, CommitOperationDelete)}
@@ -2767,9 +2765,13 @@ class TestUploadFolderMocked:
         assert added_files == {"sub/file.txt", "sub/lfs_in_sub.bin"}  # added only in sub/
         assert deleted_files == {"sub/file1.txt"}  # delete only in sub/
 
-    def test_delete_txt_in_sub_ignore_sub_file_txt(self):
+    def test_delete_txt_in_sub_ignore_sub_file_txt(self, tmp_path):
         operations = self._upload_folder_alias(
-            path_in_repo="sub", folder_path=self.cache_dir / "sub", ignore_patterns="file.txt", delete_patterns="*.txt"
+            tmp_path,
+            path_in_repo="sub",
+            folder_path=tmp_path / "sub",
+            ignore_patterns="file.txt",
+            delete_patterns="*.txt",
         )
         added_files = {op.path_in_repo for op in operations if isinstance(op, CommitOperationAdd)}
         deleted_files = {op.path_in_repo for op in operations if isinstance(op, CommitOperationDelete)}
@@ -2778,9 +2780,9 @@ class TestUploadFolderMocked:
         assert added_files == {"sub/lfs_in_sub.bin"}  # no "sub/file.txt"
         assert deleted_files == {"sub/file1.txt", "sub/file.txt"}
 
-    def test_delete_if_path_in_repo(self):
+    def test_delete_if_path_in_repo(self, tmp_path):
         # Regression test for https://github.com/huggingface/huggingface_hub/pull/2129
-        operations = self._upload_folder_alias(path_in_repo=".", folder_path=self.cache_dir, delete_patterns="*")
+        operations = self._upload_folder_alias(tmp_path, path_in_repo=".", folder_path=tmp_path, delete_patterns="*")
         deleted_files = {op.path_in_repo for op in operations if isinstance(op, CommitOperationDelete)}
         assert deleted_files == {"file1.txt", "sub/file1.txt"}  # all the 'old' files
 
@@ -2789,43 +2791,40 @@ class TestUploadFolderMocked:
     # See https://huggingface.slack.com/archives/C02EMARJ65P/p1772636713600769 for more details (private link)
     reason="Skipping git clone test on CI."
 )
-@pytest.mark.usefixtures("fx_cache_dir")
 class TestHfLargefiles:
-    cache_dir: Path
-
     @pytest.fixture(autouse=True)
     def _cleanup(self, api: HfApi):
         yield
         api.delete_repo(repo_id=self.repo_id)
 
-    def setup_local_clone(self) -> None:
+    def setup_local_clone(self, tmp_path) -> None:
         scheme = urlparse(self.repo_url).scheme
         repo_url_auth = self.repo_url.replace(f"{scheme}://", f"{scheme}://user:{TOKEN}@")
 
         subprocess.run(
-            ["git", "clone", repo_url_auth, str(self.cache_dir)],
+            ["git", "clone", repo_url_auth, str(tmp_path)],
             check=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
-        subprocess.run(["git", "lfs", "track", "*.pdf"], check=True, cwd=self.cache_dir)
-        subprocess.run(["git", "lfs", "track", "*.epub"], check=True, cwd=self.cache_dir)
+        subprocess.run(["git", "lfs", "track", "*.pdf"], check=True, cwd=tmp_path)
+        subprocess.run(["git", "lfs", "track", "*.epub"], check=True, cwd=tmp_path)
 
     @pytest.mark.git_lfs
-    def test_git_push_end_to_end(self, api: HfApi):
+    def test_git_push_end_to_end(self, api: HfApi, tmp_path):
         self.repo_url = api.create_repo(repo_id=repo_name())
         self.repo_id = self.repo_url.repo_id
-        self.setup_local_clone()
+        self.setup_local_clone(tmp_path)
 
         subprocess.run(
-            ["wget", LARGE_FILE_18MB], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=self.cache_dir
+            ["wget", LARGE_FILE_18MB], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=tmp_path
         )
-        subprocess.run(["git", "add", "*"], check=True, cwd=self.cache_dir)
-        subprocess.run(["git", "commit", "-m", "commit message"], check=True, cwd=self.cache_dir)
-        subprocess.run(["hf", "lfs-enable-largefiles", self.cache_dir], check=True)
+        subprocess.run(["git", "add", "*"], check=True, cwd=tmp_path)
+        subprocess.run(["git", "commit", "-m", "commit message"], check=True, cwd=tmp_path)
+        subprocess.run(["hf", "lfs-enable-largefiles", tmp_path], check=True)
 
         start_time = time.time()
-        subprocess.run(["git", "push"], check=True, cwd=self.cache_dir)
+        subprocess.run(["git", "push"], check=True, cwd=tmp_path)
         print("took", time.time() - start_time)
 
         # To be 100% sure, let's download the resolved file
@@ -3319,15 +3318,12 @@ iface.launch()
         assert runtime_after_restart.stage != SpaceStage.PAUSED
 
 
-@pytest.mark.usefixtures("fx_cache_dir")
 class TestCommitInBackground:
-    cache_dir: Path
-
-    def test_commit_to_repo_in_background(self, api: HfApi, repo_factory: RepoFactory) -> None:
+    def test_commit_to_repo_in_background(self, api: HfApi, repo_factory: RepoFactory, tmp_path) -> None:
         repo_url = repo_factory()
         repo_id = repo_url.repo_id
-        (self.cache_dir / "file.txt").write_text("content")
-        (self.cache_dir / "lfs.bin").write_text("content")
+        (tmp_path / "file.txt").write_text("content")
+        (tmp_path / "lfs.bin").write_text("content")
 
         t0 = time.time()
         upload_future_1 = api.upload_file(
@@ -3337,7 +3333,7 @@ class TestCommitInBackground:
             path_or_fileobj=b"2", path_in_repo="2.txt", repo_id=repo_id, commit_message="Upload 2", run_as_future=True
         )
         upload_future_3 = api.upload_folder(
-            repo_id=repo_id, folder_path=self.cache_dir, commit_message="Upload folder", run_as_future=True
+            repo_id=repo_id, folder_path=tmp_path, commit_message="Upload folder", run_as_future=True
         )
         t1 = time.time()
 

--- a/tests/test_hf_file_system.py
+++ b/tests/test_hf_file_system.py
@@ -6,7 +6,6 @@ import multiprocessing.pool
 import os
 import pickle
 import tempfile
-import unittest
 from pathlib import Path
 from typing import Iterable, Optional, Type
 from unittest.mock import Mock, patch
@@ -25,10 +24,10 @@ from huggingface_hub.hf_file_system import (
 )
 
 from .testing_constants import ENDPOINT_STAGING, TOKEN
-from .testing_utils import OfflineSimulationMode, offline, repo_name, with_production_testing
+from .testing_utils import OfflineSimulationMode, offline, repo_name
 
 
-class _HfFileSystemBaseTests(unittest.TestCase):
+class _HfFileSystemBaseTests:
     __test__ = False
     api = HfApi(endpoint=ENDPOINT_STAGING, token=TOKEN)
     http_url_path_prefix: str
@@ -39,108 +38,96 @@ class _HfFileSystemBaseTests(unittest.TestCase):
     text_file_path: str
     text_file: str
 
-    @classmethod
-    def setUpClass(cls):
+    @pytest.fixture(scope="class", autouse=True)
+    def _register_hf_file_system(self):
         """Register `HfFileSystem` as a `fsspec` filesystem if not already registered."""
         if HfFileSystem.protocol not in fsspec.available_protocols():
             fsspec.register_implementation(HfFileSystem.protocol, HfFileSystem)
 
-    def assertInfoIsNotExpanded(self, info):
+    def _check_info_not_expanded(self, info):
         raise NotImplementedError
 
-    def assertInfoIsExpanded(self, info):
+    def _check_info_expanded(self, info):
         raise NotImplementedError
 
-    def assertInfoFields(self, info):
+    def _check_info_fields(self, info):
         raise NotImplementedError
 
 
 class _HfFileSystemBaseROTests(_HfFileSystemBaseTests):
     def test_info(self):
         root_dir = self.hffs.info(self.hf_path)
-        self.assertEqual(root_dir["type"], "directory")
-        self.assertEqual(root_dir["size"], 0)
-        self.assertEqual(root_dir["name"], self.hf_path)
-        self.assertInfoIsNotExpanded(root_dir)
-        self.assertInfoFields(root_dir)
+        assert root_dir["type"] == "directory"
+        assert root_dir["size"] == 0
+        assert root_dir["name"] == self.hf_path
+        self._check_info_not_expanded(root_dir)
+        self._check_info_fields(root_dir)
 
         data_dir = self.hffs.info(self.hf_path + "/data")
-        self.assertEqual(data_dir["type"], "directory")
-        self.assertEqual(data_dir["size"], 0)
-        self.assertTrue(data_dir["name"].endswith("/data"))
-        self.assertInfoIsNotExpanded(data_dir)
-        self.assertInfoFields(data_dir)
+        assert data_dir["type"] == "directory"
+        assert data_dir["size"] == 0
+        assert data_dir["name"].endswith("/data")
+        self._check_info_not_expanded(data_dir)
+        self._check_info_fields(data_dir)
 
         text_data_file = self.hffs.info(self.text_file)
-        self.assertEqual(text_data_file["type"], "file")
-        self.assertTrue(text_data_file["name"].endswith("/data/text_data.txt"))
-        self.assertInfoIsNotExpanded(text_data_file)
-        self.assertInfoFields(text_data_file)
+        assert text_data_file["type"] == "file"
+        assert text_data_file["name"].endswith("/data/text_data.txt")
+        self._check_info_not_expanded(text_data_file)
+        self._check_info_fields(text_data_file)
 
         # cached info
-        self.assertEqual(self.hffs.info(self.text_file), text_data_file)
+        assert self.hffs.info(self.text_file) == text_data_file
 
     def test_glob(self):
-        self.assertEqual(
-            self.hffs.glob(self.readme_file),
-            [self.readme_file],
-        )
-        self.assertEqual(
-            sorted(self.hffs.glob(self.hf_path + "/*")),
-            sorted([self.readme_file, self.hf_path + "/data"]),
-        )
-        self.assertEqual(
-            sorted(self.hffs.glob(self.hf_path + "/doesnt-exist/*")),
-            [],
-        )
-        self.assertEqual(
-            sorted(self.hffs.glob(self.hf_path + "/doesnt/exist/at/all/*")),
-            [],
-        )
+        assert self.hffs.glob(self.readme_file) == [self.readme_file]
+        assert sorted(self.hffs.glob(self.hf_path + "/*")) == sorted([self.readme_file, self.hf_path + "/data"])
+        assert sorted(self.hffs.glob(self.hf_path + "/doesnt-exist/*")) == []
+        assert sorted(self.hffs.glob(self.hf_path + "/doesnt/exist/at/all/*")) == []
 
     def test_url(self):
-        self.assertEqual(
-            self.hffs.url(self.text_file),
-            f"{ENDPOINT_STAGING}/{self.hf_path}/resolve/{self.http_url_path_prefix}data/text_data.txt",
+        assert (
+            self.hffs.url(self.text_file)
+            == f"{ENDPOINT_STAGING}/{self.hf_path}/resolve/{self.http_url_path_prefix}data/text_data.txt"
         )
-        self.assertEqual(
-            self.hffs.url(self.hf_path + "/data"),
-            f"{ENDPOINT_STAGING}/{self.hf_path}/tree/{self.http_url_path_prefix}data",
+        assert (
+            self.hffs.url(self.hf_path + "/data")
+            == f"{ENDPOINT_STAGING}/{self.hf_path}/tree/{self.http_url_path_prefix}data"
         )
 
     def test_file_type(self):
-        self.assertTrue(self.hffs.isdir(self.hf_path + "/data") and not self.hffs.isdir(self.readme_file))
-        self.assertTrue(self.hffs.isfile(self.text_file) and not self.hffs.isfile(self.hf_path + "/data"))
+        assert self.hffs.isdir(self.hf_path + "/data") and not self.hffs.isdir(self.readme_file)
+        assert self.hffs.isfile(self.text_file) and not self.hffs.isfile(self.hf_path + "/data")
 
     def test_read_file(self):
         with self.hffs.open(self.text_file, "r") as f:
-            self.assertIsInstance(f, io.TextIOWrapper)
-            self.assertIsInstance(f.buffer, HfFileSystemFile)
-            self.assertEqual(f.read(), "dummy text data")
-            self.assertEqual(f.read(), "")
+            assert isinstance(f, io.TextIOWrapper)
+            assert isinstance(f.buffer, HfFileSystemFile)
+            assert f.read() == "dummy text data"
+            assert f.read() == ""
 
     def test_stream_file(self):
         with self.hffs.open(self.hf_path + "/data/binary_data.bin", block_size=0) as f:
-            self.assertIsInstance(f, HfFileSystemStreamFile)
-            self.assertEqual(f.read(), b"dummy binary data")
-            self.assertEqual(f.read(), b"")
+            assert isinstance(f, HfFileSystemStreamFile)
+            assert f.read() == b"dummy binary data"
+            assert f.read() == b""
 
     def test_stream_file_retry(self):
         with self.hffs.open(self.hf_path + "/data/binary_data.bin", block_size=0) as f:
-            self.assertIsInstance(f, HfFileSystemStreamFile)
-            self.assertEqual(f.read(6), b"dummy ")
+            assert isinstance(f, HfFileSystemStreamFile)
+            assert f.read(6) == b"dummy "
             # Simulate that streaming fails mid-way
             f.response = None
-            self.assertEqual(f.read(6), b"binary")
-            self.assertIsNotNone(f.response)  # a new connection has been created
+            assert f.read(6) == b"binary"
+            assert f.response is not None  # a new connection has been created
 
     def test_stream_file_reuse_response(self):
         with self.hffs.open(self.hf_path + "/data/binary_data.bin", block_size=0) as f:
-            self.assertIsInstance(f, HfFileSystemStreamFile)
-            self.assertEqual(f.read(6), b"dummy ")
+            assert isinstance(f, HfFileSystemStreamFile)
+            assert f.read(6) == b"dummy "
             first_response = f.response
-            self.assertEqual(f.read(6), b"binary")
-            self.assertEqual(f.response, first_response)
+            assert f.read(6) == b"binary"
+            assert f.response == first_response
 
     def _make_stream_file_with_fake_response(self, chunks: Iterable[bytes]):
         """Helper: create iterator from specified chunks to simulate a stream response."""
@@ -160,60 +147,60 @@ class _HfFileSystemBaseROTests(_HfFileSystemBaseTests):
     def test_stream_buffer_overflow_leftover_is_buffered(self):
         # When chunk-1 is larger than read(length), the leftover should be buffered
         f = self._make_stream_file_with_fake_response([b"dummy binary", b" data"])
-        self.assertEqual(f.read(6), b"dummy ")
-        self.assertEqual(f.loc, 6)
-        self.assertEqual(bytes(f._stream_buffer), b"binary")
-        self.assertEqual(f.read(), b"binary data")
-        self.assertEqual(f.loc, 17)
-        self.assertEqual(bytes(f._stream_buffer), b"")
+        assert f.read(6) == b"dummy "
+        assert f.loc == 6
+        assert bytes(f._stream_buffer) == b"binary"
+        assert f.read() == b"binary data"
+        assert f.loc == 17
+        assert bytes(f._stream_buffer) == b""
 
     def test_stream_read_spans_buffer_and_chunks(self):
         # When there is already a buffer, read() spans the buffer and the chunks
         f = self._make_stream_file_with_fake_response([b"dummy", b"binary"])
         f._stream_buffer.extend(b"12")
-        self.assertEqual(f.read(7), b"12dummy")
-        self.assertEqual(f.read(), b"binary")
+        assert f.read(7) == b"12dummy"
+        assert f.read() == b"binary"
 
     def test_stream_read_all_clears_buffer(self):
         # When read(-1) is called, it returns the buffer + all chunks and clears the buffer
         f = self._make_stream_file_with_fake_response([b"dummy", b"binary"])
         f._stream_buffer.extend(b"12")
-        self.assertEqual(f.read(-1), b"12dummybinary")
-        self.assertEqual(bytes(f._stream_buffer), b"")
+        assert f.read(-1) == b"12dummybinary"
+        assert bytes(f._stream_buffer) == b""
 
     def test_stream_read_negative_length_reads_all(self):
         # When length < 0, it reads all
         f = self._make_stream_file_with_fake_response([b"dummy"])
-        self.assertEqual(f.read(-2), b"dummy")
+        assert f.read(-2) == b"dummy"
 
     def test_stream_read_partially_consumes_buffer(self):
         # When read() is called with a length shorter than the buffer,
         # it returns the shorter length and the buffer is partially consumed
         f = self._make_stream_file_with_fake_response([])
         f._stream_buffer.extend(b"dummy binary")
-        self.assertEqual(f.read(6), b"dummy ")
-        self.assertEqual(bytes(f._stream_buffer), b"binary")
+        assert f.read(6) == b"dummy "
+        assert bytes(f._stream_buffer) == b"binary"
 
     def test_stream_read_past_eof_returns_shorter_then_empty(self):
         # When read() is called with a length longer than the file, it returns the shorter length and the buffer is empty
         f = self._make_stream_file_with_fake_response([b"dummy", b"binary"])
-        self.assertEqual(f.read(100), b"dummybinary")
-        self.assertEqual(f.read(1), b"")
+        assert f.read(100) == b"dummybinary"
+        assert f.read(1) == b""
 
     def test_modified_time(self):
-        self.assertIsInstance(self.hffs.modified(self.text_file), datetime.datetime)
-        self.assertIsInstance(self.hffs.modified(self.hf_path + "/data"), datetime.datetime)
+        assert isinstance(self.hffs.modified(self.text_file), datetime.datetime)
+        assert isinstance(self.hffs.modified(self.hf_path + "/data"), datetime.datetime)
         # should fail on a non-existing file
-        with self.assertRaises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError):
             self.hffs.modified(self.hf_path + "/data/not_existing_file.txt")
 
     def test_open_if_not_found(self):
         # Regression test: opening a missing file should raise a FileNotFoundError. This was not the case before when
         # opening a file in read mode.
-        with self.assertRaises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError):
             self.hffs.open("hf://missing/repo/not_existing_file.txt", mode="r")
 
-        with self.assertRaises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError):
             self.hffs.open("hf://missing/repo/not_existing_file.txt", mode="w")
 
     def test_initialize_from_fsspec(self):
@@ -224,128 +211,121 @@ class _HfFileSystemBaseROTests(_HfFileSystemBaseTests):
                 "token": TOKEN,
             },
         )
-        self.assertIsInstance(fs, HfFileSystem)
-        self.assertEqual(fs._api.endpoint, ENDPOINT_STAGING)
-        self.assertEqual(fs.token, TOKEN)
-        self.assertEqual(paths, [self.text_file])
+        assert isinstance(fs, HfFileSystem)
+        assert fs._api.endpoint == ENDPOINT_STAGING
+        assert fs.token == TOKEN
+        assert paths == [self.text_file]
 
         fs, _, paths = fsspec.get_fs_token_paths("hf://" + self.text_file)
-        self.assertIsInstance(fs, HfFileSystem)
-        self.assertEqual(paths, [self.text_file])
+        assert isinstance(fs, HfFileSystem)
+        assert paths == [self.text_file]
 
     def test_list_root_directory(self):
         files = sorted(self.hffs.ls(self.hf_path), key=lambda info: info["name"])
-        self.assertEqual(len(files), 2)
+        assert len(files) == 2
 
-        self.assertEqual(files[1]["type"], "directory")
-        self.assertEqual(files[1]["size"], 0)
-        self.assertTrue(files[1]["name"].endswith("/data"))
-        self.assertInfoIsNotExpanded(files[1])
-        self.assertInfoFields(files[1])
+        assert files[1]["type"] == "directory"
+        assert files[1]["size"] == 0
+        assert files[1]["name"].endswith("/data")
+        self._check_info_not_expanded(files[1])
+        self._check_info_fields(files[1])
 
-        self.assertEqual(files[0]["type"], "file")
-        self.assertTrue(files[0]["name"].endswith(self.readme_file_path))
-        self.assertInfoIsNotExpanded(files[0])
-        self.assertInfoFields(files[0])
+        assert files[0]["type"] == "file"
+        assert files[0]["name"].endswith(self.readme_file_path)
+        self._check_info_not_expanded(files[0])
+        self._check_info_fields(files[0])
 
     def test_list_data_directory(self):
         files = sorted(self.hffs.ls(self.hf_path + "/data"), key=lambda info: info["name"])
-        self.assertEqual(len(files), 2)
+        assert len(files) == 2
 
-        self.assertEqual(files[0]["type"], "file")
-        self.assertTrue(files[0]["name"].endswith("/data/binary_data.bin"))
-        self.assertInfoIsNotExpanded(files[0])
-        self.assertInfoFields(files[0])
+        assert files[0]["type"] == "file"
+        assert files[0]["name"].endswith("/data/binary_data.bin")
+        self._check_info_not_expanded(files[0])
+        self._check_info_fields(files[0])
 
-        self.assertEqual(files[1]["type"], "file")
-        self.assertTrue(files[1]["name"].endswith("/data/text_data.txt"))
-        self.assertInfoIsNotExpanded(files[1])
-        self.assertInfoFields(files[1])
+        assert files[1]["type"] == "file"
+        assert files[1]["name"].endswith("/data/text_data.txt")
+        self._check_info_not_expanded(files[1])
+        self._check_info_fields(files[1])
 
     def test_list_data_file(self):
         files = self.hffs.ls(self.text_file)
-        self.assertEqual(len(files), 1)
+        assert len(files) == 1
 
-        self.assertEqual(files[0]["type"], "file")
-        self.assertTrue(files[0]["name"].endswith("/data/text_data.txt"))
-        self.assertInfoIsNotExpanded(files[0])
-        self.assertInfoFields(files[0])
+        assert files[0]["type"] == "file"
+        assert files[0]["name"].endswith("/data/text_data.txt")
+        self._check_info_not_expanded(files[0])
+        self._check_info_fields(files[0])
 
     def test_list_root_directory_no_detail_then_with_detail(self):
         files = sorted(self.hffs.ls(self.hf_path, detail=False))
-        self.assertEqual(len(files), 2)
-        self.assertTrue(files[1].endswith("/data") and files[0].endswith(self.readme_file_path))
-        self.assertInfoIsNotExpanded(self.hffs.dircache[self.hf_path][0])
+        assert len(files) == 2
+        assert files[1].endswith("/data") and files[0].endswith(self.readme_file_path)
+        self._check_info_not_expanded(self.hffs.dircache[self.hf_path][0])
 
         files = sorted(self.hffs.ls(self.hf_path, detail=True), key=lambda info: info["name"])
-        self.assertEqual(len(files), 2)
-        self.assertTrue(files[1]["name"].endswith("/data") and files[0]["name"].endswith(self.readme_file_path))
-        self.assertInfoIsNotExpanded(self.hffs.dircache[self.hf_path][0])
+        assert len(files) == 2
+        assert files[1]["name"].endswith("/data") and files[0]["name"].endswith(self.readme_file_path)
+        self._check_info_not_expanded(self.hffs.dircache[self.hf_path][0])
 
         files = sorted(self.hffs.ls(self.hf_path, detail=True, expand_info=True), key=lambda info: info["name"])
-        self.assertEqual(len(files), 2)
-        self.assertTrue(files[1]["name"].endswith("/data") and files[0]["name"].endswith(self.readme_file_path))
-        self.assertInfoIsExpanded(self.hffs.dircache[self.hf_path][0])
+        assert len(files) == 2
+        assert files[1]["name"].endswith("/data") and files[0]["name"].endswith(self.readme_file_path)
+        self._check_info_expanded(self.hffs.dircache[self.hf_path][0])
 
     def test_find_root_directory(self):
         files = self.hffs.find(self.hf_path, detail=False)
-        self.assertEqual(
-            files,
+        assert files == (
             sorted(self.hffs.ls(self.hf_path, detail=False))[:1]
-            + sorted(self.hffs.ls(self.hf_path + "/data", detail=False)),
+            + sorted(self.hffs.ls(self.hf_path + "/data", detail=False))
         )
 
         files = self.hffs.find(self.hf_path, detail=True)
-        self.assertEqual(
-            files,
-            {
-                f["name"]: f
-                for f in sorted(self.hffs.ls(self.hf_path, detail=True), key=lambda info: info["name"])[:1]
-                + sorted(self.hffs.ls(self.hf_path + "/data", detail=True), key=lambda info: info["name"])
-            },
-        )
+        assert files == {
+            f["name"]: f
+            for f in sorted(self.hffs.ls(self.hf_path, detail=True), key=lambda info: info["name"])[:1]
+            + sorted(self.hffs.ls(self.hf_path + "/data", detail=True), key=lambda info: info["name"])
+        }
 
         files_with_dirs = self.hffs.find(self.hf_path, withdirs=True, detail=False)
-        self.assertEqual(
-            files_with_dirs,
-            sorted(
-                [self.hf_path]
-                + self.hffs.ls(self.hf_path, detail=False)
-                + self.hffs.ls(self.hf_path + "/data", detail=False)
-            ),
+        assert files_with_dirs == sorted(
+            [self.hf_path]
+            + self.hffs.ls(self.hf_path, detail=False)
+            + self.hffs.ls(self.hf_path + "/data", detail=False)
         )
 
     def test_find_data_file(self):
         files = self.hffs.find(self.text_file, detail=False)
-        self.assertEqual(files, [self.text_file])
+        assert files == [self.text_file]
 
     def test_find_maxdepth(self):
         text_file_depth = self.text_file_path.count("/") + 1
         files = self.hffs.find(self.hf_path, detail=False, maxdepth=text_file_depth - 1)
-        self.assertNotIn(self.text_file, files)
+        assert self.text_file not in files
         files = self.hffs.find(self.hf_path, detail=False, maxdepth=text_file_depth)
-        self.assertIn(self.text_file, files)
+        assert self.text_file in files
         # we do it again once the cache is updated
         files = self.hffs.find(self.hf_path, detail=False, maxdepth=text_file_depth - 1)
-        self.assertNotIn(self.text_file, files)
+        assert self.text_file not in files
 
     def test_read_bytes(self):
         data = self.hffs.read_bytes(self.text_file)
-        self.assertEqual(data, b"dummy text data")
+        assert data == b"dummy text data"
 
     def test_read_text(self):
         data = self.hffs.read_text(self.text_file)
-        self.assertEqual(data, "dummy text data")
+        assert data == "dummy text data"
 
     def test_open_and_read(self):
         with self.hffs.open(self.text_file, "r") as f:
-            self.assertEqual(f.read(), "dummy text data")
+            assert f.read() == "dummy text data"
 
     def test_partial_read(self):
         # If partial read => should not download whole file
         with patch.object(self.hffs, "get_file") as mock:
             with self.hffs.open(self.text_file, "r") as f:
-                self.assertEqual(f.read(5), "dummy")
+                assert f.read(5) == "dummy"
             mock.assert_not_called()
 
     def test_get_file_with_temporary_file(self):
@@ -411,19 +391,19 @@ class _HfFileSystemBaseROTests(_HfFileSystemBaseTests):
 class _HfFileSystemBaseRWTests(_HfFileSystemBaseTests):
     def test_remove_file(self):
         self.hffs.rm_file(self.text_file)
-        self.assertEqual(self.hffs.glob(self.hf_path + "/data/*"), [self.hf_path + "/data/binary_data.bin"])
+        assert self.hffs.glob(self.hf_path + "/data/*") == [self.hf_path + "/data/binary_data.bin"]
 
     def test_remove_directory(self):
         self.hffs.rm(self.hf_path + "/data", recursive=True)
-        self.assertNotIn(self.hf_path + "/data", self.hffs.ls(self.hf_path))
+        assert self.hf_path + "/data" not in self.hffs.ls(self.hf_path)
 
     def test_write_file(self):
         data = "new text data"
         with self.hffs.open(self.hf_path + "/data/new_text_data.txt", "w") as f:
             f.write(data)
-        self.assertIn(self.hf_path + "/data/new_text_data.txt", self.hffs.glob(self.hf_path + "/data/*"))
+        assert self.hf_path + "/data/new_text_data.txt" in self.hffs.glob(self.hf_path + "/data/*")
         with self.hffs.open(self.hf_path + "/data/new_text_data.txt", "r") as f:
-            self.assertEqual(f.read(), data)
+            assert f.read() == data
 
     def test_write_file_multiple_chunks(self):
         data = "a" * (4 << 20)  # 4MB
@@ -431,181 +411,172 @@ class _HfFileSystemBaseRWTests(_HfFileSystemBaseTests):
             for _ in range(8):  # 32MB in total
                 f.write(data)
 
-        self.assertIn(self.hf_path + "/data/new_text_data_big.txt", self.hffs.glob(self.hf_path + "/data/*"))
+        assert self.hf_path + "/data/new_text_data_big.txt" in self.hffs.glob(self.hf_path + "/data/*")
         with self.hffs.open(self.hf_path + "/data/new_text_data_big.txt", "r") as f:
             for _ in range(8):
-                self.assertEqual(f.read(len(data)), data)
+                assert f.read(len(data)) == data
 
-    @unittest.skip("Not implemented yet")
+    @pytest.mark.skip("Not implemented yet")
     def test_append_file(self):
         with self.hffs.open(self.text_file, "a") as f:
             f.write(" appended text")
 
         with self.hffs.open(self.text_file, "r") as f:
-            self.assertEqual(f.read(), "dummy text data appended text")
+            assert f.read() == "dummy text data appended text"
 
     def test_copy_file(self):
         # Non-LFS file
-        self.assertInfoFields(self.hffs.info(self.text_file))
+        self._check_info_fields(self.hffs.info(self.text_file))
         self.hffs.cp_file(self.text_file, self.hf_path + "/data/text_data_copy.txt")
         with self.hffs.open(self.hf_path + "/data/text_data_copy.txt", "r") as f:
-            self.assertEqual(f.read(), "dummy text data")
-        self.assertInfoFields(self.hffs.info(self.hf_path + "/data/text_data_copy.txt"))
+            assert f.read() == "dummy text data"
+        self._check_info_fields(self.hffs.info(self.hf_path + "/data/text_data_copy.txt"))
         # LFS file
-        self.assertIsNotNone(self.hffs.info(self.hf_path + "/data/binary_data.bin"))
+        assert self.hffs.info(self.hf_path + "/data/binary_data.bin") is not None
         self.hffs.cp_file(self.hf_path + "/data/binary_data.bin", self.hf_path + "/data/binary_data_copy.bin")
         with self.hffs.open(self.hf_path + "/data/binary_data_copy.bin", "rb") as f:
-            self.assertEqual(f.read(), b"dummy binary data")
-        self.assertInfoFields(self.hffs.info(self.hf_path + "/data/binary_data_copy.bin"))
+            assert f.read() == b"dummy binary data"
+        self._check_info_fields(self.hffs.info(self.hf_path + "/data/binary_data_copy.bin"))
 
 
-class _HfFileSystemRepositoryChecks(unittest.TestCase):
+class _HfFileSystemRepositoryChecks:
     __test__ = False
     http_url_path_prefix = "main/"
 
-    def assertInfoIsNotExpanded(self, info):
-        self.assertIsNone(info["last_commit"])
+    def _check_info_not_expanded(self, info):
+        assert info["last_commit"] is None
 
-    def assertInfoIsExpanded(self, info):
-        self.assertIsNotNone(info["last_commit"])
+    def _check_info_expanded(self, info):
+        assert info["last_commit"] is not None
 
-    def assertInfoFields(self, info):
+    def _check_info_fields(self, info):
         if info["type"] == "file":
-            self.assertIsNotNone(info["blob_id"])
-            self.assertGreater(info["size"], 0)  # not empty
-            self.assertIn("security", info)  # the staging endpoint does not run security checks
+            assert info["blob_id"] is not None
+            assert info["size"] > 0  # not empty
+            assert "security" in info  # the staging endpoint does not run security checks
             if info["name"].endswith(".bin"):
-                self.assertIsNotNone(info["lfs"])
-                self.assertIn("sha256", info["lfs"])
-                self.assertIn("size", info["lfs"])
-                self.assertIn("pointer_size", info["lfs"])
+                assert info["lfs"] is not None
+                assert "sha256" in info["lfs"]
+                assert "size" in info["lfs"]
+                assert "pointer_size" in info["lfs"]
 
 
-class _HfFileSystemBucketChecks(unittest.TestCase):
+class _HfFileSystemBucketChecks:
     __test__ = False
     http_url_path_prefix = ""
 
-    def assertInfoIsNotExpanded(self, info):
+    def _check_info_not_expanded(self, info):
         pass
 
-    def assertInfoIsExpanded(self, info):
+    def _check_info_expanded(self, info):
         pass
 
-    def assertInfoFields(self, info):
+    def _check_info_fields(self, info):
         is_bucket_root = info["name"].count("/") == 2
         if not is_bucket_root:
-            self.assertIsNotNone(info["uploaded_at"])
+            assert info["uploaded_at"] is not None
         if info["type"] == "file":
-            self.assertIsNotNone(info["mtime"])
-            self.assertGreater(info["size"], 0)  # not empty
+            assert info["mtime"] is not None
+            assert info["size"] > 0  # not empty
 
 
-class HfFileSystemRepositoryROTests(_HfFileSystemRepositoryChecks, _HfFileSystemBaseROTests):
+class TestHfFileSystemRepositoryRO(_HfFileSystemRepositoryChecks, _HfFileSystemBaseROTests):
     __test__ = True
 
-    @classmethod
-    def setUpClass(cls):
-        super(_HfFileSystemBaseROTests, cls).setUpClass()
+    @pytest.fixture(scope="class", autouse=True)
+    def _shared_repo(self, request):
+        api = self.api
 
         # Create dummy repo
-        repo_url = cls.api.create_repo(repo_name(), repo_type="dataset")
-        cls.repo_id = repo_url.repo_id
-        cls.hf_path = f"datasets/{cls.repo_id}"
+        repo_url = api.create_repo(repo_name(), repo_type="dataset")
+        repo_id = repo_url.repo_id
+        hf_path = f"datasets/{repo_id}"
+        request.cls.repo_id = repo_id
+        request.cls.hf_path = hf_path
 
         # Upload files
-        cls.api.upload_file(
+        api.upload_file(
             path_or_fileobj=b"dummy binary data on pr",
             path_in_repo="data/binary_data_for_pr.bin",
-            repo_id=cls.repo_id,
+            repo_id=repo_id,
             repo_type="dataset",
             create_pr=True,
         )
-        cls.api.upload_file(
+        api.upload_file(
             path_or_fileobj="dummy text data".encode("utf-8"),
             path_in_repo="data/text_data.txt",
-            repo_id=cls.repo_id,
+            repo_id=repo_id,
             repo_type="dataset",
         )
-        cls.api.upload_file(
+        api.upload_file(
             path_or_fileobj=b"dummy binary data",
             path_in_repo="data/binary_data.bin",
-            repo_id=cls.repo_id,
+            repo_id=repo_id,
             repo_type="dataset",
         )
-        cls.api.upload_file(
+        api.upload_file(
             path_or_fileobj="# Dataset card".encode("utf-8"),
             path_in_repo="README.md",
-            repo_id=cls.repo_id,
+            repo_id=repo_id,
             repo_type="dataset",
         )
-        cls.api.delete_file(
+        api.delete_file(
             path_in_repo=".gitattributes",
-            repo_id=cls.repo_id,
+            repo_id=repo_id,
             repo_type="dataset",
         )
 
-        cls.readme_file_path = "README.md"
-        cls.readme_file = cls.hf_path + "/" + cls.readme_file_path
-        cls.text_file_path = "data/text_data.txt"
-        cls.text_file = cls.hf_path + "/" + cls.text_file_path
+        request.cls.readme_file_path = "README.md"
+        request.cls.readme_file = hf_path + "/" + "README.md"
+        request.cls.text_file_path = "data/text_data.txt"
+        request.cls.text_file = hf_path + "/" + "data/text_data.txt"
+        yield
+        api.delete_repo(repo_id, repo_type="dataset")
 
-    @classmethod
-    def tearDownClass(cls):
-        super(_HfFileSystemBaseROTests, cls).tearDownClass()
-        cls.api.delete_repo(cls.repo_id, repo_type="dataset")
-
-    def setUp(self):
+    @pytest.fixture(autouse=True)
+    def _new_hffs(self):
         self.hffs = HfFileSystem(endpoint=ENDPOINT_STAGING, token=TOKEN, skip_instance_cache=True)
 
     def test_glob_with_revision(self):
-        self.assertEqual(
-            sorted(self.hffs.glob(self.hf_path + "/*", revision="main")),
-            sorted([self.readme_file, self.hf_path + "/data"]),
+        assert sorted(self.hffs.glob(self.hf_path + "/*", revision="main")) == sorted(
+            [self.readme_file, self.hf_path + "/data"]
         )
-        self.assertEqual(
-            sorted(self.hffs.glob(self.hf_path + "@main" + "/*")),
-            sorted([self.hf_path + "@main/" + self.readme_file_path, self.hf_path + "@main" + "/data"]),
+        assert sorted(self.hffs.glob(self.hf_path + "@main" + "/*")) == sorted(
+            [self.hf_path + "@main/" + self.readme_file_path, self.hf_path + "@main" + "/data"]
         )
-        self.assertEqual(
-            self.hffs.glob(self.hf_path + "@refs%2Fpr%2F1" + "/data/*"),
-            [self.hf_path + "@refs%2Fpr%2F1" + "/data/binary_data_for_pr.bin"],
-        )
-        self.assertEqual(
-            self.hffs.glob(self.hf_path + "@refs/pr/1" + "/data/*"),
-            [self.hf_path + "@refs/pr/1" + "/data/binary_data_for_pr.bin"],
-        )
-        self.assertEqual(
-            self.hffs.glob(self.hf_path + "/data/*", revision="refs/pr/1"),
-            [self.hf_path + "@refs/pr/1" + "/data/binary_data_for_pr.bin"],
-        )
+        assert self.hffs.glob(self.hf_path + "@refs%2Fpr%2F1" + "/data/*") == [
+            self.hf_path + "@refs%2Fpr%2F1" + "/data/binary_data_for_pr.bin"
+        ]
+        assert self.hffs.glob(self.hf_path + "@refs/pr/1" + "/data/*") == [
+            self.hf_path + "@refs/pr/1" + "/data/binary_data_for_pr.bin"
+        ]
+        assert self.hffs.glob(self.hf_path + "/data/*", revision="refs/pr/1") == [
+            self.hf_path + "@refs/pr/1" + "/data/binary_data_for_pr.bin"
+        ]
 
-        self.assertInfoIsNotExpanded(
+        self._check_info_not_expanded(
             self.hffs.dircache[self.hf_path + "@main"][0]
         )  # no detail -> no last_commit in cache
 
         files = self.hffs.glob(self.hf_path + "@main" + "/*", detail=True, expand_info=False)
-        self.assertIsInstance(files, dict)
-        self.assertEqual(len(files), 2)
+        assert isinstance(files, dict)
+        assert len(files) == 2
         keys = sorted(files)
-        self.assertTrue(
-            files[keys[0]]["name"].endswith(self.readme_file_path) and files[keys[1]]["name"].endswith("/data")
-        )
-        self.assertInfoIsNotExpanded(
+        assert files[keys[0]]["name"].endswith(self.readme_file_path) and files[keys[1]]["name"].endswith("/data")
+        self._check_info_not_expanded(
             self.hffs.dircache[self.hf_path + "@main"][0]
         )  # detail but no expand info -> no last_commit in cache
 
         files = self.hffs.glob(self.hf_path + "@main" + "/*", detail=True)
-        self.assertIsInstance(files, dict)
-        self.assertEqual(len(files), 2)
+        assert isinstance(files, dict)
+        assert len(files) == 2
         keys = sorted(files)
-        self.assertTrue(
-            files[keys[0]]["name"].endswith(self.readme_file_path) and files[keys[1]]["name"].endswith("/data")
-        )
-        self.assertInfoIsNotExpanded(files[keys[0]])
+        assert files[keys[0]]["name"].endswith(self.readme_file_path) and files[keys[1]]["name"].endswith("/data")
+        self._check_info_not_expanded(files[keys[0]])
 
     def test_read_file_with_revision(self):
         with self.hffs.open(self.hf_path + "/data/binary_data_for_pr.bin", "rb", revision="refs/pr/1") as f:
-            self.assertEqual(f.read(), b"dummy binary data on pr")
+            assert f.read() == b"dummy binary data on pr"
 
     def test_list_data_directory_with_revision(self):
         files = self.hffs.ls(self.hf_path + "@refs%2Fpr%2F1" + "/data")
@@ -618,20 +589,20 @@ class HfFileSystemRepositoryROTests(_HfFileSystemRepositoryChecks, _HfFileSystem
                 self.hf_path + "@refs%2Fpr%2F1" + "/data", revision="refs/pr/1"
             ),
         }.items():
-            with self.subTest(test_name):
-                self.assertEqual(len(files), 1)  # only one file in PR
-                self.assertEqual(files[0]["type"], "file")
-                self.assertTrue(files[0]["name"].endswith("/data/binary_data_for_pr.bin"))  # PR file
-                if "quoted_rev_in_path" in test_name:
-                    self.assertIn("@refs%2Fpr%2F1", files[0]["name"])
-                elif "rev_in_path" in test_name:
-                    self.assertIn("@refs/pr/1", files[0]["name"])
+            assert len(files) == 1  # only one file in PR
+            assert files[0]["type"] == "file"
+            assert files[0]["name"].endswith("/data/binary_data_for_pr.bin")  # PR file
+            if "quoted_rev_in_path" in test_name:
+                assert "@refs%2Fpr%2F1" in files[0]["name"]
+            elif "rev_in_path" in test_name:
+                assert "@refs/pr/1" in files[0]["name"]
 
 
-class HfFileSystemRepositoryRWTests(_HfFileSystemRepositoryChecks, _HfFileSystemBaseRWTests):
+class TestHfFileSystemRepositoryRW(_HfFileSystemRepositoryChecks, _HfFileSystemBaseRWTests):
     __test__ = True
 
-    def setUp(self):
+    @pytest.fixture(autouse=True)
+    def _repo(self):
         self.hffs = HfFileSystem(endpoint=ENDPOINT_STAGING, token=TOKEN, skip_instance_cache=True)
 
         # Create dummy repo
@@ -675,19 +646,18 @@ class HfFileSystemRepositoryRWTests(_HfFileSystemRepositoryChecks, _HfFileSystem
         self.readme_file = self.hf_path + "/" + self.readme_file_path
         self.text_file_path = "data/text_data.txt"
         self.text_file = self.hf_path + "/" + self.text_file_path
-
-    def tearDown(self):
+        yield
         self.api.delete_repo(self.repo_id, repo_type="dataset")
 
     def test_remove_file_with_revision(self):
         self.hffs.rm_file(self.hf_path + "@refs/pr/1" + "/data/binary_data_for_pr.bin")
-        self.assertEqual(self.hffs.glob(self.hf_path + "@refs/pr/1" + "/data/*"), [])
+        assert self.hffs.glob(self.hf_path + "@refs/pr/1" + "/data/*") == []
 
     def test_remove_directory_with_revision(self):
         self.hffs.rm(self.hf_path + "/data", recursive=True)
-        self.assertNotIn(self.hf_path + "/data", self.hffs.ls(self.hf_path))
+        assert self.hf_path + "/data" not in self.hffs.ls(self.hf_path)
         self.hffs.rm(self.hf_path + "@refs/pr/1" + "/data", recursive=True)
-        self.assertNotIn(self.hf_path + "@refs/pr/1" + "/data", self.hffs.ls(self.hf_path))
+        assert self.hf_path + "@refs/pr/1" + "/data" not in self.hffs.ls(self.hf_path)
 
     def test_find_root_directory_with_incomplete_cache(self):
         self.api.upload_file(
@@ -714,7 +684,7 @@ class HfFileSystemRepositoryRWTests(_HfFileSystemRepositoryChecks, _HfFileSystem
         # some files not expanded
         self.hffs.dircache[self.hf_path + "/data"][1]["last_commit"] = None
         out = self.hffs.find(self.hf_path, detail=True)
-        self.assertEqual(out, files)
+        assert out == files
 
 
 @pytest.mark.parametrize("path_in_repo", ["", "file.txt", "path/to/file", "path/to/@not-a-revision.txt"])
@@ -920,7 +890,7 @@ def test_cache():
         assert fs_token != fs._fs_token  # use a different instance for thread safety
 
 
-@with_production_testing
+@pytest.mark.production
 def test_hf_file_system_file_can_handle_gzipped_file():
     """Test that HfFileSystemStreamFile.read() can handle gzipped files."""
     fs = HfFileSystem(endpoint=constants.ENDPOINT)

--- a/tests/test_hub_mixin.py
+++ b/tests/test_hub_mixin.py
@@ -7,7 +7,6 @@ from typing import Optional, Union, get_type_hints
 from unittest.mock import Mock, patch
 
 import jedi
-import pytest
 from pytest_mock import MockerFixture
 
 from huggingface_hub import HfApi, hf_hub_download
@@ -195,78 +194,75 @@ class DummyWithDataclassInputs(ModelHubMixin):
         return
 
 
-@pytest.mark.usefixtures("fx_cache_dir")
 class TestHubMixin:
-    cache_dir: Path
-
-    def assert_valid_config_json(self) -> None:
+    def assert_valid_config_json(self, cache_dir: Path) -> None:
         # config.json saved correctly
-        with open(self.cache_dir / "config.json") as f:
+        with open(cache_dir / "config.json") as f:
             assert json.load(f) == CONFIG_AS_DICT
 
-    def assert_no_config_json(self) -> None:
+    def assert_no_config_json(self, cache_dir: Path) -> None:
         # config.json not saved
-        files = os.listdir(self.cache_dir)
+        files = os.listdir(cache_dir)
         assert "config.json" not in files
 
-    def test_save_pretrained_no_config(self):
+    def test_save_pretrained_no_config(self, tmp_path):
         model = DummyModelNoConfig()
-        model.save_pretrained(self.cache_dir)
-        self.assert_no_config_json()
+        model.save_pretrained(tmp_path)
+        self.assert_no_config_json(tmp_path)
 
-    def test_save_pretrained_as_dataclass_basic(self):
+    def test_save_pretrained_as_dataclass_basic(self, tmp_path):
         model = DummyModelConfigAsDataclass(CONFIG_AS_DATACLASS)
-        model.save_pretrained(self.cache_dir)
-        self.assert_valid_config_json()
+        model.save_pretrained(tmp_path)
+        self.assert_valid_config_json(tmp_path)
 
-    def test_save_pretrained_as_dict_basic(self):
+    def test_save_pretrained_as_dict_basic(self, tmp_path):
         model = DummyModelConfigAsDict(CONFIG_AS_DICT)
-        model.save_pretrained(self.cache_dir)
-        self.assert_valid_config_json()
+        model.save_pretrained(tmp_path)
+        self.assert_valid_config_json(tmp_path)
 
-    def test_save_pretrained_optional_dataclass(self):
+    def test_save_pretrained_optional_dataclass(self, tmp_path):
         model = DummyModelConfigAsOptionalDataclass()
-        model.save_pretrained(self.cache_dir)
-        self.assert_no_config_json()
+        model.save_pretrained(tmp_path)
+        self.assert_no_config_json(tmp_path)
 
         model = DummyModelConfigAsOptionalDataclass(CONFIG_AS_DATACLASS)
-        model.save_pretrained(self.cache_dir)
-        self.assert_valid_config_json()
+        model.save_pretrained(tmp_path)
+        self.assert_valid_config_json(tmp_path)
 
-    def test_save_pretrained_optional_dict(self):
+    def test_save_pretrained_optional_dict(self, tmp_path):
         model = DummyModelConfigAsOptionalDict()
-        model.save_pretrained(self.cache_dir)
-        self.assert_no_config_json()
+        model.save_pretrained(tmp_path)
+        self.assert_no_config_json(tmp_path)
 
         model = DummyModelConfigAsOptionalDict(CONFIG_AS_DICT)
-        model.save_pretrained(self.cache_dir)
-        self.assert_valid_config_json()
+        model.save_pretrained(tmp_path)
+        self.assert_valid_config_json(tmp_path)
 
-    def test_save_pretrained_with_dataclass_config(self):
+    def test_save_pretrained_with_dataclass_config(self, tmp_path):
         model = DummyModelConfigAsOptionalDataclass()
-        model.save_pretrained(self.cache_dir, config=CONFIG_AS_DATACLASS)
-        self.assert_valid_config_json()
+        model.save_pretrained(tmp_path, config=CONFIG_AS_DATACLASS)
+        self.assert_valid_config_json(tmp_path)
 
-    def test_save_pretrained_with_dict_config(self):
+    def test_save_pretrained_with_dict_config(self, tmp_path):
         model = DummyModelConfigAsOptionalDict()
-        model.save_pretrained(self.cache_dir, config=CONFIG_AS_DICT)
-        self.assert_valid_config_json()
+        model.save_pretrained(tmp_path, config=CONFIG_AS_DICT)
+        self.assert_valid_config_json(tmp_path)
 
-    def test_init_accepts_kwargs_no_config(self):
+    def test_init_accepts_kwargs_no_config(self, tmp_path):
         """
         Test that if `__init__` accepts **kwargs and config file doesn't exist then no 'config' kwargs is passed.
 
         Regression test. See https://github.com/huggingface/huggingface_hub/pull/2058.
         """
         model = DummyModelWithKwargs()
-        model.save_pretrained(self.cache_dir)
+        model.save_pretrained(tmp_path)
         with patch.object(
             DummyModelWithKwargs, "_from_pretrained", return_value=DummyModelWithKwargs()
         ) as from_pretrained_mock:
-            model = DummyModelWithKwargs.from_pretrained(self.cache_dir)
+            model = DummyModelWithKwargs.from_pretrained(tmp_path)
             assert "config" not in from_pretrained_mock.call_args_list[0].kwargs
 
-    def test_init_accepts_kwargs_with_config(self):
+    def test_init_accepts_kwargs_with_config(self, tmp_path):
         """
         Test that if `config_inject_mode="as_kwargs"` and config file exists then the 'config' kwarg is passed.
 
@@ -275,30 +271,30 @@ class TestHubMixin:
         And https://github.com/huggingface/huggingface_hub/pull/2099.
         """
         model = DummyModelFromPretrainedExpectsConfig()
-        model.save_pretrained(self.cache_dir, config=CONFIG_AS_DICT)
+        model.save_pretrained(tmp_path, config=CONFIG_AS_DICT)
         with patch.object(
             DummyModelFromPretrainedExpectsConfig,
             "_from_pretrained",
             return_value=DummyModelFromPretrainedExpectsConfig(),
         ) as from_pretrained_mock:
-            DummyModelFromPretrainedExpectsConfig.from_pretrained(self.cache_dir)
+            DummyModelFromPretrainedExpectsConfig.from_pretrained(tmp_path)
         assert "config" in from_pretrained_mock.call_args_list[0].kwargs
 
-    def test_init_accepts_kwargs_save_and_load(self):
+    def test_init_accepts_kwargs_save_and_load(self, tmp_path):
         model = DummyModelWithKwargs(something="else")
-        model.save_pretrained(self.cache_dir)
+        model.save_pretrained(tmp_path)
         assert model._hub_mixin_config == {"something": "else"}
 
         with patch.object(DummyModelWithKwargs, "__init__", return_value=None) as init_call_mock:
-            DummyModelWithKwargs.from_pretrained(self.cache_dir)
+            DummyModelWithKwargs.from_pretrained(tmp_path)
 
         # 'something' is passed to __init__ both as kwarg and in config.
         init_kwargs = init_call_mock.call_args_list[0].kwargs
         assert init_kwargs["something"] == "else"
 
-    def test_save_pretrained_with_push_to_hub(self):
+    def test_save_pretrained_with_push_to_hub(self, tmp_path):
         repo_id = repo_name("save")
-        save_directory = self.cache_dir / repo_id
+        save_directory = tmp_path / repo_id
 
         mocked_model = DummyModelConfigAsDataclass(CONFIG_AS_DATACLASS)
         mocked_model.push_to_hub = Mock()
@@ -344,19 +340,19 @@ class TestHubMixin:
             model = DummyModelConfigAsDataclass.from_pretrained(relative_save_directory)
             assert model._hub_mixin_config == CONFIG_AS_DATACLASS
 
-    def test_from_pretrained_from_absolute_path(self):
-        save_directory = self.cache_dir / "subfolder"
+    def test_from_pretrained_from_absolute_path(self, tmp_path):
+        save_directory = tmp_path / "subfolder"
         DummyModelConfigAsDataclass(config=CONFIG_AS_DATACLASS).save_pretrained(save_directory)
         model = DummyModelConfigAsDataclass.from_pretrained(save_directory)
         assert model._hub_mixin_config == CONFIG_AS_DATACLASS
 
-    def test_from_pretrained_from_absolute_string_path(self):
-        save_directory = str(self.cache_dir / "subfolder")
+    def test_from_pretrained_from_absolute_string_path(self, tmp_path):
+        save_directory = str(tmp_path / "subfolder")
         DummyModelConfigAsDataclass(config=CONFIG_AS_DATACLASS).save_pretrained(save_directory)
         model = DummyModelConfigAsDataclass.from_pretrained(save_directory)
         assert model._hub_mixin_config == CONFIG_AS_DATACLASS
 
-    def test_push_to_hub(self, api: HfApi):
+    def test_push_to_hub(self, api: HfApi, tmp_path):
         repo_id = f"{USER}/{repo_name('push_to_hub')}"
         DummyModelConfigAsDataclass(CONFIG_AS_DATACLASS).push_to_hub(repo_id=repo_id, token=TOKEN)
 
@@ -364,16 +360,14 @@ class TestHubMixin:
         api.model_info(repo_id)
 
         # Test config has been pushed to hub
-        tmp_config_path = hf_hub_download(
-            repo_id=repo_id, filename="config.json", token=TOKEN, cache_dir=self.cache_dir
-        )
+        tmp_config_path = hf_hub_download(repo_id=repo_id, filename="config.json", token=TOKEN, cache_dir=tmp_path)
         with open(tmp_config_path) as f:
             assert json.load(f) == CONFIG_AS_DICT
 
         # from_pretrained with correct serialization
         from_pretrained_kwargs = {
             "pretrained_model_name_or_path": repo_id,
-            "cache_dir": self.cache_dir,
+            "cache_dir": tmp_path,
             "api_endpoint": ENDPOINT_STAGING,
             "token": TOKEN,
         }
@@ -386,34 +380,34 @@ class TestHubMixin:
         # Delete repo
         api.delete_repo(repo_id=repo_id)
 
-    def test_save_pretrained_do_not_overwrite_new_config(self):
+    def test_save_pretrained_do_not_overwrite_new_config(self, tmp_path):
         """Regression test for https://github.com/huggingface/huggingface_hub/issues/2102.
 
         If `_from_pretrained` does save a config file, we should not overwrite it.
         """
         model = DummyModelSavingConfig()
-        model.save_pretrained(self.cache_dir)
+        model.save_pretrained(tmp_path)
         # config.json is not overwritten
-        with open(self.cache_dir / "config.json") as f:
+        with open(tmp_path / "config.json") as f:
             assert json.load(f) == {"custom_config": "custom_config"}
 
-    def test_save_pretrained_does_overwrite_legacy_config(self):
+    def test_save_pretrained_does_overwrite_legacy_config(self, tmp_path):
         """Regression test for https://github.com/huggingface/huggingface_hub/issues/2142.
 
         If a previously existing config file exists, it should be overwritten.
         """
         # Something existing in the cache dir
-        (self.cache_dir / "config.json").write_text(json.dumps({"something_legacy": 123}))
+        (tmp_path / "config.json").write_text(json.dumps({"something_legacy": 123}))
 
         # Save model
         model = DummyModelWithKwargs(a=1, b=2)
-        model.save_pretrained(self.cache_dir)
+        model.save_pretrained(tmp_path)
 
         # config.json IS overwritten
-        with open(self.cache_dir / "config.json") as f:
+        with open(tmp_path / "config.json") as f:
             assert json.load(f) == {"a": 1, "b": 2}
 
-    def test_from_pretrained_when_cls_is_a_dataclass(self):
+    def test_from_pretrained_when_cls_is_a_dataclass(self, tmp_path):
         """Regression test for #2157.
 
         When the ModelHubMixin class happens to be a dataclass, `__init__` method will accept `**kwargs` when
@@ -422,13 +416,13 @@ class TestHubMixin:
 
         See https://github.com/huggingface/huggingface_hub/issues/2157.
         """
-        (self.cache_dir / "config.json").write_text('{"foo": 42, "bar": "baz", "other": "value"}')
-        model = DummyModelThatIsAlsoADataclass.from_pretrained(self.cache_dir)
+        (tmp_path / "config.json").write_text('{"foo": 42, "bar": "baz", "other": "value"}')
+        model = DummyModelThatIsAlsoADataclass.from_pretrained(tmp_path)
         assert model.foo == 42
         assert model.bar == "baz"
         assert not hasattr(model, "other")
 
-    def test_from_cls_with_custom_type(self):
+    def test_from_cls_with_custom_type(self, tmp_path):
         model = DummyModelWithCustomTypes(
             1,
             bar="bar",
@@ -437,9 +431,9 @@ class TestHubMixin:
             optional_custom_1=CustomType("optional"),
             optional_custom_2=None,
         )
-        model.save_pretrained(self.cache_dir)
+        model.save_pretrained(tmp_path)
 
-        config = json.loads((self.cache_dir / "config.json").read_text())
+        config = json.loads((tmp_path / "config.json").read_text())
         assert config == {
             "foo": 1,
             "bar": "bar",
@@ -450,7 +444,7 @@ class TestHubMixin:
             "custom_default": {"value": "default"},
         }
 
-        model_reloaded = DummyModelWithCustomTypes.from_pretrained(self.cache_dir)
+        model_reloaded = DummyModelWithCustomTypes.from_pretrained(tmp_path)
         assert model_reloaded.foo == 1
         assert model_reloaded.bar == "bar"
         assert model_reloaded.baz == 1.0
@@ -508,20 +502,20 @@ a.dum""".strip()
         model = ModelWithHints()
         assert get_type_hints(model.method_with_hints) == {"x": int, "return": str}
 
-    def test_with_dataclass_inputs(self):
+    def test_with_dataclass_inputs(self, tmp_path):
         model = DummyWithDataclassInputs(
             arg1=DummyDataclass(foo=1, bar="1"),
             arg2=DummyDataclass(foo=2, bar="2"),
         )
-        model.save_pretrained(self.cache_dir)
+        model.save_pretrained(tmp_path)
 
-        config = json.loads((self.cache_dir / "config.json").read_text())
+        config = json.loads((tmp_path / "config.json").read_text())
         assert config == {
             "arg1": {"foo": 1, "bar": "1"},
             "arg2": {"foo": 2, "bar": "2"},
         }
 
-        model_reloaded = DummyWithDataclassInputs.from_pretrained(self.cache_dir)
+        model_reloaded = DummyWithDataclassInputs.from_pretrained(tmp_path)
         assert model_reloaded.arg1.foo == 1
         assert model_reloaded.arg1.bar == "1"
         assert model_reloaded.arg2.foo == 2

--- a/tests/test_hub_mixin.py
+++ b/tests/test_hub_mixin.py
@@ -1,7 +1,6 @@
 import inspect
 import json
 import os
-import unittest
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional, Union, get_type_hints
@@ -9,6 +8,7 @@ from unittest.mock import Mock, patch
 
 import jedi
 import pytest
+from pytest_mock import MockerFixture
 
 from huggingface_hub import HfApi, hf_hub_download
 from huggingface_hub.hub_mixin import ModelHubMixin
@@ -196,15 +196,8 @@ class DummyWithDataclassInputs(ModelHubMixin):
 
 
 @pytest.mark.usefixtures("fx_cache_dir")
-class HubMixinTest(unittest.TestCase):
+class TestHubMixin:
     cache_dir: Path
-
-    @classmethod
-    def setUpClass(cls):
-        """
-        Share this valid token in all tests below.
-        """
-        cls._api = HfApi(endpoint=ENDPOINT_STAGING, token=TOKEN)
 
     def assert_valid_config_json(self) -> None:
         # config.json saved correctly
@@ -323,16 +316,16 @@ class HubMixinTest(unittest.TestCase):
         mocked_model.save_pretrained(save_directory, push_to_hub=True)
         mocked_model.push_to_hub.assert_called_with(repo_id=repo_id, config=CONFIG_AS_DICT, model_card_kwargs={})
 
-    @patch.object(DummyModelNoConfig, "_from_pretrained")
-    def test_from_pretrained_model_id_only(self, from_pretrained_mock: Mock) -> None:
+    def test_from_pretrained_model_id_only(self, mocker: MockerFixture) -> None:
+        from_pretrained_mock = mocker.patch.object(DummyModelNoConfig, "_from_pretrained")
         model = DummyModelNoConfig.from_pretrained("namespace/repo_name")
         from_pretrained_mock.assert_called_once()
         assert model is from_pretrained_mock.return_value
 
-    @patch.object(DummyModelNoConfig, "_from_pretrained")
-    def test_from_pretrained_model_id_and_revision(self, from_pretrained_mock: Mock) -> None:
+    def test_from_pretrained_model_id_and_revision(self, mocker: MockerFixture) -> None:
         """Regression test for #1313.
         See https://github.com/huggingface/huggingface_hub/issues/1313."""
+        from_pretrained_mock = mocker.patch.object(DummyModelNoConfig, "_from_pretrained")
         model = DummyModelNoConfig.from_pretrained("namespace/repo_name", revision="123456789")
         from_pretrained_mock.assert_called_once_with(
             model_id="namespace/repo_name",

--- a/tests/test_hub_mixin.py
+++ b/tests/test_hub_mixin.py
@@ -356,12 +356,12 @@ class TestHubMixin:
         model = DummyModelConfigAsDataclass.from_pretrained(save_directory)
         assert model._hub_mixin_config == CONFIG_AS_DATACLASS
 
-    def test_push_to_hub(self):
+    def test_push_to_hub(self, api: HfApi):
         repo_id = f"{USER}/{repo_name('push_to_hub')}"
         DummyModelConfigAsDataclass(CONFIG_AS_DATACLASS).push_to_hub(repo_id=repo_id, token=TOKEN)
 
         # Test model id exists
-        self._api.model_info(repo_id)
+        api.model_info(repo_id)
 
         # Test config has been pushed to hub
         tmp_config_path = hf_hub_download(
@@ -384,7 +384,7 @@ class TestHubMixin:
             assert cls.from_pretrained(**from_pretrained_kwargs)._hub_mixin_config == CONFIG_AS_DICT
 
         # Delete repo
-        self._api.delete_repo(repo_id=repo_id)
+        api.delete_repo(repo_id=repo_id)
 
     def test_save_pretrained_do_not_overwrite_new_config(self):
         """Regression test for https://github.com/huggingface/huggingface_hub/issues/2102.

--- a/tests/test_hub_mixin_pytorch.py
+++ b/tests/test_hub_mixin_pytorch.py
@@ -182,11 +182,11 @@ class TestPytorchHubMixin:
         from_pretrained_mock.assert_called_once()
         assert model is from_pretrained_mock.return_value
 
-    def pretend_file_download(self, cache_dir: Path, **kwargs):
+    def pretend_file_download(self, tmp_dir: Path, **kwargs):
         if kwargs.get("filename") == "config.json":
             raise RemoteEntryNotFoundError("no config", response=Mock())
-        DummyModel().save_pretrained(cache_dir)
-        return cache_dir / "model.safetensors"
+        DummyModel().save_pretrained(tmp_dir)
+        return tmp_dir / "model.safetensors"
 
     def test_from_pretrained_model_from_hub_prefer_safetensor(self, mocker: MockerFixture, tmp_path) -> None:
         hf_hub_download_mock = mocker.patch("huggingface_hub.hub_mixin.hf_hub_download")

--- a/tests/test_hub_mixin_pytorch.py
+++ b/tests/test_hub_mixin_pytorch.py
@@ -203,7 +203,7 @@ class TestPytorchHubMixin:
         )
         assert model is not None
 
-    def pretend_file_download_fallback(self, cache_dir: Path, **kwargs):
+    def pretend_file_download_fallback(self, tmp_dir: Path, **kwargs):
         filename = kwargs.get("filename")
         if filename == "model.safetensors" or filename == "config.json":
             raise RemoteEntryNotFoundError("not found", response=Mock())
@@ -212,8 +212,8 @@ class TestPytorchHubMixin:
             def _save_pretrained(self, save_directory: Path) -> None:
                 torch.save(DummyModel().state_dict(), save_directory / constants.PYTORCH_WEIGHTS_NAME)
 
-        TestMixin().save_pretrained(cache_dir)
-        return cache_dir / constants.PYTORCH_WEIGHTS_NAME
+        TestMixin().save_pretrained(tmp_dir)
+        return tmp_dir / constants.PYTORCH_WEIGHTS_NAME
 
     def test_from_pretrained_model_from_hub_fallback_pickle(self, mocker: MockerFixture, tmp_path) -> None:
         hf_hub_download_mock = mocker.patch("huggingface_hub.hub_mixin.hf_hub_download")

--- a/tests/test_hub_mixin_pytorch.py
+++ b/tests/test_hub_mixin_pytorch.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from typing import Any, Optional, TypeVar
 from unittest.mock import Mock
 
-import pytest
 from pytest_mock import MockerFixture
 
 from huggingface_hub import HfApi, ModelCard, constants, hf_hub_download
@@ -135,23 +134,20 @@ else:
 
 
 @requires("torch")
-@pytest.mark.usefixtures("fx_cache_dir")
 class TestPytorchHubMixin:
-    cache_dir: Path
-
-    def test_save_pretrained_basic(self):
-        DummyModel().save_pretrained(self.cache_dir)
-        files = os.listdir(self.cache_dir)
+    def test_save_pretrained_basic(self, tmp_path):
+        DummyModel().save_pretrained(tmp_path)
+        files = os.listdir(tmp_path)
         assert set(files) == {"README.md", "model.safetensors"}
 
-    def test_save_pretrained_with_config(self):
-        DummyModel().save_pretrained(self.cache_dir, config=CONFIG)
-        files = os.listdir(self.cache_dir)
+    def test_save_pretrained_with_config(self, tmp_path):
+        DummyModel().save_pretrained(tmp_path, config=CONFIG)
+        files = os.listdir(tmp_path)
         assert set(files) == {"README.md", "config.json", "model.safetensors"}
 
-    def test_save_as_safetensors(self):
-        DummyModel().save_pretrained(self.cache_dir, config=TOKEN)
-        modelFile = self.cache_dir / "model.safetensors"
+    def test_save_as_safetensors(self, tmp_path):
+        DummyModel().save_pretrained(tmp_path, config=TOKEN)
+        modelFile = tmp_path / "model.safetensors"
         # check for safetensors header to ensure we are saving the model in safetensors format
         # while an implementation detail, assert as this has safety implications
         # https://github.com/huggingface/safetensors?tab=readme-ov-file#format
@@ -159,9 +155,9 @@ class TestPytorchHubMixin:
             header_size = struct.unpack("<Q", f.read(8))[0]
             assert header_size == 128
 
-    def test_save_pretrained_with_push_to_hub(self):
+    def test_save_pretrained_with_push_to_hub(self, tmp_path):
         repo_id = repo_name("save")
-        save_directory = self.cache_dir / repo_id
+        save_directory = tmp_path / repo_id
 
         config = {"hello": "world"}
         mocked_model = DummyModel()
@@ -186,15 +182,15 @@ class TestPytorchHubMixin:
         from_pretrained_mock.assert_called_once()
         assert model is from_pretrained_mock.return_value
 
-    def pretend_file_download(self, **kwargs):
+    def pretend_file_download(self, cache_dir: Path, **kwargs):
         if kwargs.get("filename") == "config.json":
             raise RemoteEntryNotFoundError("no config", response=Mock())
-        DummyModel().save_pretrained(self.cache_dir)
-        return self.cache_dir / "model.safetensors"
+        DummyModel().save_pretrained(cache_dir)
+        return cache_dir / "model.safetensors"
 
-    def test_from_pretrained_model_from_hub_prefer_safetensor(self, mocker: MockerFixture) -> None:
+    def test_from_pretrained_model_from_hub_prefer_safetensor(self, mocker: MockerFixture, tmp_path) -> None:
         hf_hub_download_mock = mocker.patch("huggingface_hub.hub_mixin.hf_hub_download")
-        hf_hub_download_mock.side_effect = self.pretend_file_download
+        hf_hub_download_mock.side_effect = lambda **kwargs: self.pretend_file_download(tmp_path, **kwargs)
         model = DummyModel.from_pretrained("namespace/repo_name")
         hf_hub_download_mock.assert_any_call(
             repo_id="namespace/repo_name",
@@ -207,7 +203,7 @@ class TestPytorchHubMixin:
         )
         assert model is not None
 
-    def pretend_file_download_fallback(self, **kwargs):
+    def pretend_file_download_fallback(self, cache_dir: Path, **kwargs):
         filename = kwargs.get("filename")
         if filename == "model.safetensors" or filename == "config.json":
             raise RemoteEntryNotFoundError("not found", response=Mock())
@@ -216,12 +212,12 @@ class TestPytorchHubMixin:
             def _save_pretrained(self, save_directory: Path) -> None:
                 torch.save(DummyModel().state_dict(), save_directory / constants.PYTORCH_WEIGHTS_NAME)
 
-        TestMixin().save_pretrained(self.cache_dir)
-        return self.cache_dir / constants.PYTORCH_WEIGHTS_NAME
+        TestMixin().save_pretrained(cache_dir)
+        return cache_dir / constants.PYTORCH_WEIGHTS_NAME
 
-    def test_from_pretrained_model_from_hub_fallback_pickle(self, mocker: MockerFixture) -> None:
+    def test_from_pretrained_model_from_hub_fallback_pickle(self, mocker: MockerFixture, tmp_path) -> None:
         hf_hub_download_mock = mocker.patch("huggingface_hub.hub_mixin.hf_hub_download")
-        hf_hub_download_mock.side_effect = self.pretend_file_download_fallback
+        hf_hub_download_mock.side_effect = lambda **kwargs: self.pretend_file_download_fallback(tmp_path, **kwargs)
         model = DummyModel.from_pretrained("namespace/repo_name")
         hf_hub_download_mock.assert_any_call(
             repo_id="namespace/repo_name",
@@ -265,14 +261,14 @@ class TestPytorchHubMixin:
             model = DummyModel.from_pretrained(relative_save_directory)
             assert model._hub_mixin_config == CONFIG
 
-    def test_from_pretrained_to_absolute_path(self):
-        save_directory = self.cache_dir / "subfolder"
+    def test_from_pretrained_to_absolute_path(self, tmp_path):
+        save_directory = tmp_path / "subfolder"
         DummyModel().save_pretrained(save_directory, config=CONFIG)
         model = DummyModel.from_pretrained(save_directory)
         assert model._hub_mixin_config == CONFIG
 
-    def test_from_pretrained_to_absolute_string_path(self):
-        save_directory = str(self.cache_dir / "subfolder")
+    def test_from_pretrained_to_absolute_string_path(self, tmp_path):
+        save_directory = str(tmp_path / "subfolder")
         DummyModel().save_pretrained(save_directory, config=CONFIG)
         model = DummyModel.from_pretrained(save_directory)
         assert model._hub_mixin_config == CONFIG
@@ -289,7 +285,7 @@ class TestPytorchHubMixin:
             "`PyTorchModelHubMixin.from_pretrained` return type annotation is not a TypeVar bound by `ModelHubMixin`."
         )
 
-    def test_push_to_hub(self, api: HfApi):
+    def test_push_to_hub(self, api: HfApi, tmp_path):
         repo_id = f"{USER}/{repo_name('push_to_hub')}"
         DummyModel().push_to_hub(repo_id=repo_id, token=TOKEN, config=CONFIG)
 
@@ -297,16 +293,14 @@ class TestPytorchHubMixin:
         assert api.model_info(repo_id).id == repo_id
 
         # Test config has been pushed to hub
-        tmp_config_path = hf_hub_download(
-            repo_id=repo_id, filename="config.json", token=TOKEN, cache_dir=self.cache_dir
-        )
+        tmp_config_path = hf_hub_download(repo_id=repo_id, filename="config.json", token=TOKEN, cache_dir=tmp_path)
         with open(tmp_config_path) as f:
             assert json.load(f) == CONFIG
 
         # Delete repo
         api.delete_repo(repo_id=repo_id)
 
-    def test_generate_model_card(self):
+    def test_generate_model_card(self, tmp_path):
         model = DummyModelWithModelCard()
         card = model.generate_model_card()
         assert card.data.language == ["en", "zh"]
@@ -317,41 +311,41 @@ class TestPytorchHubMixin:
         # Model card template has been used
         assert "This is a dummy model card" in str(card)
 
-        model.save_pretrained(self.cache_dir)
-        card_reloaded = ModelCard.load(self.cache_dir / "README.md")
+        model.save_pretrained(tmp_path)
+        card_reloaded = ModelCard.load(tmp_path / "README.md")
 
         assert str(card) == str(card_reloaded)
         assert card.data == card_reloaded.data
 
-    def test_load_no_config(self):
-        config_file = self.cache_dir / "config.json"
+    def test_load_no_config(self, tmp_path):
+        config_file = tmp_path / "config.json"
 
         # Test creating model => auto-generated config
         model = DummyModelNoConfig(num_classes=50)
         assert model._hub_mixin_config == {"num_classes": 50, "state": "layernorm"}
 
         # Test saving model => auto-generated config is saved
-        model.save_pretrained(self.cache_dir)
+        model.save_pretrained(tmp_path)
         assert config_file.exists()
         assert json.loads(config_file.read_text()) == {"num_classes": 50, "state": "layernorm"}
 
         # Reload model => config is reloaded
-        reloaded = DummyModelNoConfig.from_pretrained(self.cache_dir)
+        reloaded = DummyModelNoConfig.from_pretrained(tmp_path)
         assert reloaded.num_classes == 50
         assert reloaded.state == "layernorm"
         assert reloaded._hub_mixin_config == {"num_classes": 50, "state": "layernorm"}
 
         # Reload model with custom config => custom config is used
-        reloaded_with_default = DummyModelNoConfig.from_pretrained(self.cache_dir, state="other")
+        reloaded_with_default = DummyModelNoConfig.from_pretrained(tmp_path, state="other")
         assert reloaded_with_default.num_classes == 50
         assert reloaded_with_default.state == "other"
         assert reloaded_with_default._hub_mixin_config == {"num_classes": 50, "state": "other"}
 
         config_file.unlink()  # Remove config file
-        reloaded_with_default.save_pretrained(self.cache_dir)
+        reloaded_with_default.save_pretrained(tmp_path)
         assert json.loads(config_file.read_text()) == {"num_classes": 50, "state": "other"}
 
-    def test_save_with_non_jsonable_config(self):
+    def test_save_with_non_jsonable_config(self, tmp_path):
         # Save with a non-jsonable value
         my_object = object()
         model = DummyModelNoConfig(not_jsonable=my_object)
@@ -359,22 +353,22 @@ class TestPytorchHubMixin:
         assert "not_jsonable" not in model._hub_mixin_config
 
         # Reload with default value
-        model.save_pretrained(self.cache_dir)
-        reloaded_model = DummyModelNoConfig.from_pretrained(self.cache_dir)
+        model.save_pretrained(tmp_path)
+        reloaded_model = DummyModelNoConfig.from_pretrained(tmp_path)
         assert reloaded_model.not_jsonable is DUMMY_OBJECT
         assert "not_jsonable" not in model._hub_mixin_config
 
         # If jsonable value passed by user, it's saved in the config
-        (self.cache_dir / "config.json").unlink()
+        (tmp_path / "config.json").unlink()
         new_model = DummyModelNoConfig(not_jsonable=123)
-        new_model.save_pretrained(self.cache_dir)
+        new_model.save_pretrained(tmp_path)
         assert new_model._hub_mixin_config["not_jsonable"] == 123
 
-        reloaded_new_model = DummyModelNoConfig.from_pretrained(self.cache_dir)
+        reloaded_new_model = DummyModelNoConfig.from_pretrained(tmp_path)
         assert reloaded_new_model.not_jsonable == 123
         assert reloaded_new_model._hub_mixin_config["not_jsonable"] == 123
 
-    def test_save_model_with_shared_tensors(self):
+    def test_save_model_with_shared_tensors(self, tmp_path):
         """
         Regression test for #2086. Shared tensors should be saved correctly.
 
@@ -392,8 +386,8 @@ class TestPytorchHubMixin:
 
         # Save and reload model
         model = ModelWithSharedTensors()
-        model.save_pretrained(self.cache_dir)
-        reloaded = ModelWithSharedTensors.from_pretrained(self.cache_dir)
+        model.save_pretrained(tmp_path)
+        reloaded = ModelWithSharedTensors.from_pretrained(tmp_path)
 
         # Linear layers should share weights and biases in memory
         state_dict = reloaded.state_dict()
@@ -404,16 +398,16 @@ class TestPytorchHubMixin:
         assert a_weight_ptr == b_weight_ptr
         assert a_bias_ptr == b_bias_ptr
 
-    def test_save_pretrained_when_config_and_kwargs_are_passed(self):
+    def test_save_pretrained_when_config_and_kwargs_are_passed(self, tmp_path):
         # Test creating model with config and kwargs => all values are saved together in config.json
         model = DummyModelWithConfigAndKwargs(num_classes=50, state="layernorm", config={"a": 1}, b=2, c=3)
-        model.save_pretrained(self.cache_dir)
+        model.save_pretrained(tmp_path)
         assert model._hub_mixin_config == {"num_classes": 50, "state": "layernorm", "a": 1, "b": 2, "c": 3}
 
-        reloaded = DummyModelWithConfigAndKwargs.from_pretrained(self.cache_dir)
+        reloaded = DummyModelWithConfigAndKwargs.from_pretrained(tmp_path)
         assert reloaded._hub_mixin_config == model._hub_mixin_config
 
-    def test_model_card_with_custom_kwargs(self):
+    def test_model_card_with_custom_kwargs(self, tmp_path):
         model_card_kwargs = {"custom_data": "This is a model custom data: 42."}
 
         # Test creating model with custom kwargs => custom data is saved in model card
@@ -424,22 +418,22 @@ class TestPytorchHubMixin:
         assert "Paper: https://arxiv.org/abs/2304.12244" in str(card)
         assert "Docs: https://hf.co/docs/my-repo" in str(card)
         # Test saving card => model card is saved and restored with custom data
-        model.save_pretrained(self.cache_dir, model_card_kwargs=model_card_kwargs)
-        card_reloaded = ModelCard.load(self.cache_dir / "README.md")
+        model.save_pretrained(tmp_path, model_card_kwargs=model_card_kwargs)
+        card_reloaded = ModelCard.load(tmp_path / "README.md")
         assert str(card) == str(card_reloaded)
 
-    def test_config_with_custom_coders(self):
+    def test_config_with_custom_coders(self, tmp_path):
         """
         Regression test for #2334. When `config` is encoded with custom coders, it should be decoded correctly.
 
         See https://github.com/huggingface/huggingface_hub/issues/2334.
         """
         model = DummyModelWithEncodedConfig(Namespace(a=1, b=2))
-        model.save_pretrained(self.cache_dir)
+        model.save_pretrained(tmp_path)
         assert model._hub_mixin_config["a"] == 1
         assert model._hub_mixin_config["b"] == 2
 
-        reloaded = DummyModelWithEncodedConfig.from_pretrained(self.cache_dir)
+        reloaded = DummyModelWithEncodedConfig.from_pretrained(tmp_path)
         assert isinstance(reloaded.config, Namespace)
         assert reloaded.config.a == 1
         assert reloaded.config.b == 2

--- a/tests/test_hub_mixin_pytorch.py
+++ b/tests/test_hub_mixin_pytorch.py
@@ -1,13 +1,13 @@
 import json
 import os
 import struct
-import unittest
 from argparse import Namespace
 from pathlib import Path
 from typing import Any, Optional, TypeVar
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
+from pytest_mock import MockerFixture
 
 from huggingface_hub import HfApi, ModelCard, constants, hf_hub_download
 from huggingface_hub.errors import RemoteEntryNotFoundError
@@ -15,7 +15,7 @@ from huggingface_hub.hub_mixin import ModelHubMixin, PyTorchModelHubMixin
 from huggingface_hub.serialization._torch import storage_ptr
 from huggingface_hub.utils import SoftTemporaryDirectory, is_torch_available
 
-from .testing_constants import ENDPOINT_STAGING, TOKEN, USER
+from .testing_constants import TOKEN, USER
 from .testing_utils import repo_name, requires
 
 
@@ -136,15 +136,8 @@ else:
 
 @requires("torch")
 @pytest.mark.usefixtures("fx_cache_dir")
-class PytorchHubMixinTest(unittest.TestCase):
+class TestPytorchHubMixin:
     cache_dir: Path
-
-    @classmethod
-    def setUpClass(cls):
-        """
-        Share this valid token in all tests below.
-        """
-        cls._api = HfApi(endpoint=ENDPOINT_STAGING, token=TOKEN)
 
     def test_save_pretrained_basic(self):
         DummyModel().save_pretrained(self.cache_dir)
@@ -164,7 +157,7 @@ class PytorchHubMixinTest(unittest.TestCase):
         # https://github.com/huggingface/safetensors?tab=readme-ov-file#format
         with open(modelFile, "rb") as f:
             header_size = struct.unpack("<Q", f.read(8))[0]
-            self.assertEqual(header_size, 128)
+            assert header_size == 128
 
     def test_save_pretrained_with_push_to_hub(self):
         repo_id = repo_name("save")
@@ -187,11 +180,11 @@ class PytorchHubMixinTest(unittest.TestCase):
         mocked_model.save_pretrained(save_directory, push_to_hub=True, config=config)
         mocked_model.push_to_hub.assert_called_with(repo_id=repo_id, config=config, model_card_kwargs={})
 
-    @patch.object(DummyModel, "_from_pretrained")
-    def test_from_pretrained_model_id_only(self, from_pretrained_mock: Mock) -> None:
+    def test_from_pretrained_model_id_only(self, mocker: MockerFixture) -> None:
+        from_pretrained_mock = mocker.patch.object(DummyModel, "_from_pretrained")
         model = DummyModel.from_pretrained("namespace/repo_name")
         from_pretrained_mock.assert_called_once()
-        self.assertIs(model, from_pretrained_mock.return_value)
+        assert model is from_pretrained_mock.return_value
 
     def pretend_file_download(self, **kwargs):
         if kwargs.get("filename") == "config.json":
@@ -199,8 +192,8 @@ class PytorchHubMixinTest(unittest.TestCase):
         DummyModel().save_pretrained(self.cache_dir)
         return self.cache_dir / "model.safetensors"
 
-    @patch("huggingface_hub.hub_mixin.hf_hub_download")
-    def test_from_pretrained_model_from_hub_prefer_safetensor(self, hf_hub_download_mock: Mock) -> None:
+    def test_from_pretrained_model_from_hub_prefer_safetensor(self, mocker: MockerFixture) -> None:
+        hf_hub_download_mock = mocker.patch("huggingface_hub.hub_mixin.hf_hub_download")
         hf_hub_download_mock.side_effect = self.pretend_file_download
         model = DummyModel.from_pretrained("namespace/repo_name")
         hf_hub_download_mock.assert_any_call(
@@ -212,7 +205,7 @@ class PytorchHubMixinTest(unittest.TestCase):
             token=None,
             local_files_only=False,
         )
-        self.assertIsNotNone(model)
+        assert model is not None
 
     def pretend_file_download_fallback(self, **kwargs):
         filename = kwargs.get("filename")
@@ -226,8 +219,8 @@ class PytorchHubMixinTest(unittest.TestCase):
         TestMixin().save_pretrained(self.cache_dir)
         return self.cache_dir / constants.PYTORCH_WEIGHTS_NAME
 
-    @patch("huggingface_hub.hub_mixin.hf_hub_download")
-    def test_from_pretrained_model_from_hub_fallback_pickle(self, hf_hub_download_mock: Mock) -> None:
+    def test_from_pretrained_model_from_hub_fallback_pickle(self, mocker: MockerFixture) -> None:
+        hf_hub_download_mock = mocker.patch("huggingface_hub.hub_mixin.hf_hub_download")
         hf_hub_download_mock.side_effect = self.pretend_file_download_fallback
         model = DummyModel.from_pretrained("namespace/repo_name")
         hf_hub_download_mock.assert_any_call(
@@ -248,12 +241,12 @@ class PytorchHubMixinTest(unittest.TestCase):
             token=None,
             local_files_only=False,
         )
-        self.assertIsNotNone(model)
+        assert model is not None
 
-    @patch.object(DummyModel, "_from_pretrained")
-    def test_from_pretrained_model_id_and_revision(self, from_pretrained_mock: Mock) -> None:
+    def test_from_pretrained_model_id_and_revision(self, mocker: MockerFixture) -> None:
         """Regression test for #1313.
         See https://github.com/huggingface/huggingface_hub/issues/1313."""
+        from_pretrained_mock = mocker.patch.object(DummyModel, "_from_pretrained")
         model = DummyModel.from_pretrained("namespace/repo_name", revision="123456789")
         from_pretrained_mock.assert_called_once_with(
             model_id="namespace/repo_name",
@@ -263,60 +256,55 @@ class PytorchHubMixinTest(unittest.TestCase):
             local_files_only=False,
             token=None,
         )
-        self.assertIs(model, from_pretrained_mock.return_value)
+        assert model is from_pretrained_mock.return_value
 
     def test_from_pretrained_to_relative_path(self):
         with SoftTemporaryDirectory(dir=Path(".")) as tmp_relative_dir:
             relative_save_directory = Path(tmp_relative_dir) / "model"
             DummyModel().save_pretrained(relative_save_directory, config=CONFIG)
             model = DummyModel.from_pretrained(relative_save_directory)
-            self.assertDictEqual(model._hub_mixin_config, CONFIG)
+            assert model._hub_mixin_config == CONFIG
 
     def test_from_pretrained_to_absolute_path(self):
         save_directory = self.cache_dir / "subfolder"
         DummyModel().save_pretrained(save_directory, config=CONFIG)
         model = DummyModel.from_pretrained(save_directory)
-        self.assertDictEqual(model._hub_mixin_config, CONFIG)
+        assert model._hub_mixin_config == CONFIG
 
     def test_from_pretrained_to_absolute_string_path(self):
         save_directory = str(self.cache_dir / "subfolder")
         DummyModel().save_pretrained(save_directory, config=CONFIG)
         model = DummyModel.from_pretrained(save_directory)
-        self.assertDictEqual(model._hub_mixin_config, CONFIG)
+        assert model._hub_mixin_config == CONFIG
 
     def test_return_type_hint_from_pretrained(self):
-        self.assertIn(
-            "return",
-            DummyModel.from_pretrained.__annotations__,
-            "`PyTorchModelHubMixin.from_pretrained` does not set a return type annotation.",
+        assert "return" in DummyModel.from_pretrained.__annotations__, (
+            "`PyTorchModelHubMixin.from_pretrained` does not set a return type annotation."
         )
-        self.assertIsInstance(
+        assert isinstance(
             DummyModel.from_pretrained.__annotations__["return"],
             TypeVar,
-            "`PyTorchModelHubMixin.from_pretrained` return type annotation is not a TypeVar.",
-        )
-        self.assertEqual(
-            DummyModel.from_pretrained.__annotations__["return"].__bound__.__forward_arg__,
-            "ModelHubMixin",
-            "`PyTorchModelHubMixin.from_pretrained` return type annotation is not a TypeVar bound by `ModelHubMixin`.",
+        ), "`PyTorchModelHubMixin.from_pretrained` return type annotation is not a TypeVar."
+        assert DummyModel.from_pretrained.__annotations__["return"].__bound__.__forward_arg__ == "ModelHubMixin", (
+            "`PyTorchModelHubMixin.from_pretrained` return type annotation is not a TypeVar bound by `ModelHubMixin`."
         )
 
-    def test_push_to_hub(self):
+    def test_push_to_hub(self, api: HfApi):
         repo_id = f"{USER}/{repo_name('push_to_hub')}"
         DummyModel().push_to_hub(repo_id=repo_id, token=TOKEN, config=CONFIG)
 
         # Test model id exists
-        assert self._api.model_info(repo_id).id == repo_id
+        assert api.model_info(repo_id).id == repo_id
 
         # Test config has been pushed to hub
         tmp_config_path = hf_hub_download(
             repo_id=repo_id, filename="config.json", token=TOKEN, cache_dir=self.cache_dir
         )
         with open(tmp_config_path) as f:
-            self.assertDictEqual(json.load(f), CONFIG)
+            assert json.load(f) == CONFIG
 
         # Delete repo
-        self._api.delete_repo(repo_id=repo_id)
+        api.delete_repo(repo_id=repo_id)
 
     def test_generate_model_card(self):
         model = DummyModelWithModelCard()

--- a/tests/test_inference_text_generation.py
+++ b/tests/test_inference_text_generation.py
@@ -3,8 +3,7 @@
 #
 # See './src/huggingface_hub/inference/_text_generation.py' for details.
 import json
-import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -19,31 +18,29 @@ from huggingface_hub.inference._common import (
 )
 from huggingface_hub.inference._common import ValidationError as TextGenerationValidationError
 
-from .testing_utils import with_production_testing
-
 
 pytestmark = pytest.mark.inference
 
 
-class TestTextGenerationErrors(unittest.TestCase):
+class TestTextGenerationErrors:
     def test_generation_error(self):
         error = _mocked_error({"error_type": "generation", "error": "test"})
-        with self.assertRaises(GenerationError):
+        with pytest.raises(GenerationError):
             raise_text_generation_error(error)
 
     def test_incomplete_generation_error(self):
         error = _mocked_error({"error_type": "incomplete_generation", "error": "test"})
-        with self.assertRaises(IncompleteGenerationError):
+        with pytest.raises(IncompleteGenerationError):
             raise_text_generation_error(error)
 
     def test_overloaded_error(self):
         error = _mocked_error({"error_type": "overloaded", "error": "test"})
-        with self.assertRaises(OverloadedError):
+        with pytest.raises(OverloadedError):
             raise_text_generation_error(error)
 
     def test_validation_error(self):
         error = _mocked_error({"error_type": "validation", "error": "test"})
-        with self.assertRaises(TextGenerationValidationError):
+        with pytest.raises(TextGenerationValidationError):
             raise_text_generation_error(error)
 
 
@@ -54,14 +51,15 @@ def _mocked_error(payload: dict) -> MagicMock:
 
 
 @pytest.mark.skip("Temporary skipping TestTextGenerationClientVCR tests")
-@with_production_testing
-@patch.dict("huggingface_hub.inference._common._UNSUPPORTED_TEXT_GENERATION_KWARGS", {})
-class TestTextGenerationClientVCR(unittest.TestCase):
+@pytest.mark.production
+class TestTextGenerationClientVCR:
     """Use VCR test to avoid making requests to the prod infra."""
 
-    def setUp(self) -> None:
+    @pytest.fixture(autouse=True)
+    def setup(self, mocker):
+        mocker.patch.dict("huggingface_hub.inference._common._UNSUPPORTED_TEXT_GENERATION_KWARGS", {})
         self.client = InferenceClient(model="google/flan-t5-xxl")
-        return super().setUp()
+        yield
 
     def test_generate_no_details(self):
         response = self.client.text_generation("test", details=False, max_new_tokens=1)
@@ -93,7 +91,7 @@ class TestTextGenerationClientVCR(unittest.TestCase):
         assert response.details.best_of_sequences[0].seed is not None
 
     def test_generate_validation_error(self):
-        with self.assertRaises(TextGenerationValidationError):
+        with pytest.raises(TextGenerationValidationError):
             self.client.text_generation("test", max_new_tokens=10_000)
 
     def test_generate_stream_no_details(self):
@@ -124,25 +122,25 @@ class TestTextGenerationClientVCR(unittest.TestCase):
 
     def test_generate_non_tgi_endpoint(self):
         text = self.client.text_generation("0 1 2", model="gpt2", max_new_tokens=10)
-        self.assertEqual(text, " 3 4 5 6 7 8 9 10 11 12")
-        self.assertIn("gpt2", _UNSUPPORTED_TEXT_GENERATION_KWARGS)
+        assert text == " 3 4 5 6 7 8 9 10 11 12"
+        assert "gpt2" in _UNSUPPORTED_TEXT_GENERATION_KWARGS
 
         # Watermark is ignored (+ warning)
-        with self.assertWarns(UserWarning):
+        with pytest.warns(UserWarning):
             self.client.text_generation("4 5 6", model="gpt2", max_new_tokens=10, watermark=True)
 
         # Return as detail even if details=True (+ warning)
-        with self.assertWarns(UserWarning):
+        with pytest.warns(UserWarning):
             text = self.client.text_generation("0 1 2", model="gpt2", max_new_tokens=10, details=True)
-            self.assertIsInstance(text, str)
+            assert isinstance(text, str)
 
         # Return as stream raises error
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             self.client.text_generation("0 1 2", model="gpt2", max_new_tokens=10, stream=True)
 
     def test_generate_non_tgi_endpoint_regression_test(self):
         # Regression test for https://github.com/huggingface/huggingface_hub/issues/2135
-        with self.assertWarnsRegex(UserWarning, "Ignoring following parameters: return_full_text"):
+        with pytest.warns(UserWarning, match="Ignoring following parameters: return_full_text"):
             text = self.client.text_generation(
                 prompt="How are you today?", max_new_tokens=20, model="google/flan-t5-large", return_full_text=True
             )

--- a/tests/test_init_lazy_loading.py
+++ b/tests/test_init_lazy_loading.py
@@ -1,10 +1,9 @@
-import unittest
-
 import jedi
+import pytest
 
 
-class TestHuggingfaceHubInit(unittest.TestCase):
-    @unittest.skip(
+class TestHuggingfaceHubInit:
+    @pytest.mark.skip(
         reason="`jedi.Completion.get_signatures()` output differs between Python 3.12 and earlier versions, affecting test consistency"
     )
     def test_autocomplete_on_root_imports(self) -> None:
@@ -20,21 +19,21 @@ class TestHuggingfaceHubInit(unittest.TestCase):
         for completion in completions:
             if completion.name == "create_commit":
                 # Assert `create_commit` is suggestion from `huggingface_hub` lib
-                self.assertEqual(completion.module_name, "huggingface_hub")
+                assert completion.module_name == "huggingface_hub"
 
                 # Assert autocomplete knows where `create_commit` lives
                 # It would not be the case with a dynamic import.
                 goto_list = completion.goto()
-                self.assertEqual(len(goto_list), 1)
+                assert len(goto_list) == 1
 
                 # Assert docstring is find. This means autocomplete can also provide
                 # the help section.
                 signature_list = goto_list[0].get_signatures()
-                self.assertEqual(len(signature_list), 2)  # create_commit has 2 signatures (normal and `run_as_future`)
-                self.assertTrue(signature_list[0].docstring().startswith("create_commit(repo_id: str,"))
+                assert len(signature_list) == 2  # create_commit has 2 signatures (normal and `run_as_future`)
+                assert signature_list[0].docstring().startswith("create_commit(repo_id: str,")
                 break
         else:
-            self.fail(
+            pytest.fail(
                 "Jedi autocomplete did not suggest `create_commit` to complete the"
                 f" line `{source}`. It is most probable that static imports are not"
                 " correct in `./src/huggingface_hub/__init__.py`. Please run `make"

--- a/tests/test_lfs.py
+++ b/tests/test_lfs.py
@@ -1,16 +1,18 @@
 import os
-import unittest
 from hashlib import sha256
 from io import BytesIO
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
+
+import pytest
 
 from huggingface_hub.lfs import UploadInfo, post_lfs_batch_info
 from huggingface_hub.utils import SoftTemporaryDirectory
 from huggingface_hub.utils._lfs import SliceFileObj
 
 
-class TestUploadInfo(unittest.TestCase):
-    def setUp(self) -> None:
+class TestUploadInfo:
+    @pytest.fixture(autouse=True)
+    def setup(self) -> None:
         self.content = b"RandOm ConTEnT" * 1024
         self.size = len(self.content)
         self.sha = sha256(self.content).digest()
@@ -23,30 +25,31 @@ class TestUploadInfo(unittest.TestCase):
                 file.write(self.content)
             upload_info = UploadInfo.from_path(filepath)
 
-            self.assertEqual(upload_info.sample, self.sample)
-            self.assertEqual(upload_info.size, self.size)
+            assert upload_info.sample == self.sample
+            assert upload_info.size == self.size
             # sha256 is lazy: computed on first access, requires the source file to still exist
-            self.assertFalse(upload_info.is_hashed)
-            self.assertEqual(upload_info.sha256, self.sha)
-            self.assertTrue(upload_info.is_hashed)
+            assert not upload_info.is_hashed
+            assert upload_info.sha256 == self.sha
+            assert upload_info.is_hashed
 
     def test_upload_info_from_bytes(self):
         upload_info = UploadInfo.from_bytes(self.content)
 
-        self.assertEqual(upload_info.sample, self.sample)
-        self.assertEqual(upload_info.size, self.size)
-        self.assertEqual(upload_info.sha256, self.sha)
+        assert upload_info.sample == self.sample
+        assert upload_info.size == self.size
+        assert upload_info.sha256 == self.sha
 
     def test_upload_info_from_bytes_io(self):
         upload_info = UploadInfo.from_fileobj(BytesIO(self.content))
 
-        self.assertEqual(upload_info.sample, self.sample)
-        self.assertEqual(upload_info.size, self.size)
-        self.assertEqual(upload_info.sha256, self.sha)
+        assert upload_info.sample == self.sample
+        assert upload_info.size == self.size
+        assert upload_info.sha256 == self.sha
 
 
-class TestSliceFileObj(unittest.TestCase):
-    def setUp(self) -> None:
+class TestSliceFileObj:
+    @pytest.fixture(autouse=True)
+    def setup(self) -> None:
         self.content = b"RANDOM self.content uauabciabeubahveb" * 1024
 
     def test_slice_fileobj_BytesIO(self):
@@ -55,63 +58,63 @@ class TestSliceFileObj(unittest.TestCase):
 
         # Test read
         with SliceFileObj(fileobj, seek_from=24, read_limit=18) as fileobj_slice:
-            self.assertEqual(fileobj_slice.tell(), 0)
-            self.assertEqual(fileobj_slice.read(), self.content[24:42])
-            self.assertEqual(fileobj_slice.tell(), 18)
-            self.assertEqual(fileobj_slice.read(), b"")
-            self.assertEqual(fileobj_slice.tell(), 18)
+            assert fileobj_slice.tell() == 0
+            assert fileobj_slice.read() == self.content[24:42]
+            assert fileobj_slice.tell() == 18
+            assert fileobj_slice.read() == b""
+            assert fileobj_slice.tell() == 18
 
-        self.assertEqual(fileobj.tell(), prev_pos)
+        assert fileobj.tell() == prev_pos
 
         with SliceFileObj(fileobj, seek_from=0, read_limit=990) as fileobj_slice:
-            self.assertEqual(fileobj_slice.tell(), 0)
-            self.assertEqual(fileobj_slice.read(200), self.content[0:200])
-            self.assertEqual(fileobj_slice.read(500), self.content[200:700])
-            self.assertEqual(fileobj_slice.read(200), self.content[700:900])
-            self.assertEqual(fileobj_slice.read(200), self.content[900:990])
-            self.assertEqual(fileobj_slice.read(200), b"")
+            assert fileobj_slice.tell() == 0
+            assert fileobj_slice.read(200) == self.content[0:200]
+            assert fileobj_slice.read(500) == self.content[200:700]
+            assert fileobj_slice.read(200) == self.content[700:900]
+            assert fileobj_slice.read(200) == self.content[900:990]
+            assert fileobj_slice.read(200) == b""
 
         # Test seek with whence = os.SEEK_SET
         with SliceFileObj(fileobj, seek_from=100, read_limit=100) as fileobj_slice:
-            self.assertEqual(fileobj_slice.tell(), 0)
+            assert fileobj_slice.tell() == 0
             fileobj_slice.seek(2, os.SEEK_SET)
-            self.assertEqual(fileobj_slice.tell(), 2)
-            self.assertEqual(fileobj_slice.fileobj.tell(), 102)
+            assert fileobj_slice.tell() == 2
+            assert fileobj_slice.fileobj.tell() == 102
             fileobj_slice.seek(-4, os.SEEK_SET)
-            self.assertEqual(fileobj_slice.tell(), 0)
-            self.assertEqual(fileobj_slice.fileobj.tell(), 100)
+            assert fileobj_slice.tell() == 0
+            assert fileobj_slice.fileobj.tell() == 100
             fileobj_slice.seek(100 + 4, os.SEEK_SET)
-            self.assertEqual(fileobj_slice.tell(), 100)
-            self.assertEqual(fileobj_slice.fileobj.tell(), 200)
+            assert fileobj_slice.tell() == 100
+            assert fileobj_slice.fileobj.tell() == 200
 
         # Test seek with whence = os.SEEK_CUR
         with SliceFileObj(fileobj, seek_from=100, read_limit=100) as fileobj_slice:
-            self.assertEqual(fileobj_slice.tell(), 0)
+            assert fileobj_slice.tell() == 0
             fileobj_slice.seek(-5, os.SEEK_CUR)
-            self.assertEqual(fileobj_slice.tell(), 0)
-            self.assertEqual(fileobj_slice.fileobj.tell(), 100)
+            assert fileobj_slice.tell() == 0
+            assert fileobj_slice.fileobj.tell() == 100
             fileobj_slice.seek(50, os.SEEK_CUR)
-            self.assertEqual(fileobj_slice.tell(), 50)
-            self.assertEqual(fileobj_slice.fileobj.tell(), 150)
+            assert fileobj_slice.tell() == 50
+            assert fileobj_slice.fileobj.tell() == 150
             fileobj_slice.seek(100, os.SEEK_CUR)
-            self.assertEqual(fileobj_slice.tell(), 100)
-            self.assertEqual(fileobj_slice.fileobj.tell(), 200)
+            assert fileobj_slice.tell() == 100
+            assert fileobj_slice.fileobj.tell() == 200
             fileobj_slice.seek(-300, os.SEEK_CUR)
-            self.assertEqual(fileobj_slice.tell(), 0)
-            self.assertEqual(fileobj_slice.fileobj.tell(), 100)
+            assert fileobj_slice.tell() == 0
+            assert fileobj_slice.fileobj.tell() == 100
 
         # Test seek with whence = os.SEEK_END
         with SliceFileObj(fileobj, seek_from=100, read_limit=100) as fileobj_slice:
-            self.assertEqual(fileobj_slice.tell(), 0)
+            assert fileobj_slice.tell() == 0
             fileobj_slice.seek(-5, os.SEEK_END)
-            self.assertEqual(fileobj_slice.tell(), 95)
-            self.assertEqual(fileobj_slice.fileobj.tell(), 195)
+            assert fileobj_slice.tell() == 95
+            assert fileobj_slice.fileobj.tell() == 195
             fileobj_slice.seek(50, os.SEEK_END)
-            self.assertEqual(fileobj_slice.tell(), 100)
-            self.assertEqual(fileobj_slice.fileobj.tell(), 200)
+            assert fileobj_slice.tell() == 100
+            assert fileobj_slice.fileobj.tell() == 200
             fileobj_slice.seek(-200, os.SEEK_END)
-            self.assertEqual(fileobj_slice.tell(), 0)
-            self.assertEqual(fileobj_slice.fileobj.tell(), 100)
+            assert fileobj_slice.tell() == 0
+            assert fileobj_slice.fileobj.tell() == 100
 
     def test_slice_fileobj_file(self):
         self.content = b"RANDOM self.content uauabciabeubahveb" * 1024
@@ -124,69 +127,69 @@ class TestSliceFileObj(unittest.TestCase):
                 prev_pos = fileobj.tell()
                 # Test read
                 with SliceFileObj(fileobj, seek_from=24, read_limit=18) as fileobj_slice:
-                    self.assertEqual(fileobj_slice.tell(), 0)
-                    self.assertEqual(fileobj_slice.read(), self.content[24:42])
-                    self.assertEqual(fileobj_slice.tell(), 18)
-                    self.assertEqual(fileobj_slice.read(), b"")
-                    self.assertEqual(fileobj_slice.tell(), 18)
+                    assert fileobj_slice.tell() == 0
+                    assert fileobj_slice.read() == self.content[24:42]
+                    assert fileobj_slice.tell() == 18
+                    assert fileobj_slice.read() == b""
+                    assert fileobj_slice.tell() == 18
 
-                self.assertEqual(fileobj.tell(), prev_pos)
+                assert fileobj.tell() == prev_pos
 
                 with SliceFileObj(fileobj, seek_from=0, read_limit=990) as fileobj_slice:
-                    self.assertEqual(fileobj_slice.tell(), 0)
-                    self.assertEqual(fileobj_slice.read(200), self.content[0:200])
-                    self.assertEqual(fileobj_slice.read(500), self.content[200:700])
-                    self.assertEqual(fileobj_slice.read(200), self.content[700:900])
-                    self.assertEqual(fileobj_slice.read(200), self.content[900:990])
-                    self.assertEqual(fileobj_slice.read(200), b"")
+                    assert fileobj_slice.tell() == 0
+                    assert fileobj_slice.read(200) == self.content[0:200]
+                    assert fileobj_slice.read(500) == self.content[200:700]
+                    assert fileobj_slice.read(200) == self.content[700:900]
+                    assert fileobj_slice.read(200) == self.content[900:990]
+                    assert fileobj_slice.read(200) == b""
 
                 # Test seek with whence = os.SEEK_SET
                 with SliceFileObj(fileobj, seek_from=100, read_limit=100) as fileobj_slice:
-                    self.assertEqual(fileobj_slice.tell(), 0)
+                    assert fileobj_slice.tell() == 0
                     fileobj_slice.seek(2, os.SEEK_SET)
-                    self.assertEqual(fileobj_slice.tell(), 2)
-                    self.assertEqual(fileobj_slice.fileobj.tell(), 102)
+                    assert fileobj_slice.tell() == 2
+                    assert fileobj_slice.fileobj.tell() == 102
                     fileobj_slice.seek(-4, os.SEEK_SET)
-                    self.assertEqual(fileobj_slice.tell(), 0)
-                    self.assertEqual(fileobj_slice.fileobj.tell(), 100)
+                    assert fileobj_slice.tell() == 0
+                    assert fileobj_slice.fileobj.tell() == 100
                     fileobj_slice.seek(100 + 4, os.SEEK_SET)
-                    self.assertEqual(fileobj_slice.tell(), 100)
-                    self.assertEqual(fileobj_slice.fileobj.tell(), 200)
+                    assert fileobj_slice.tell() == 100
+                    assert fileobj_slice.fileobj.tell() == 200
 
                 # Test seek with whence = os.SEEK_CUR
                 with SliceFileObj(fileobj, seek_from=100, read_limit=100) as fileobj_slice:
-                    self.assertEqual(fileobj_slice.tell(), 0)
+                    assert fileobj_slice.tell() == 0
                     fileobj_slice.seek(-5, os.SEEK_CUR)
-                    self.assertEqual(fileobj_slice.tell(), 0)
-                    self.assertEqual(fileobj_slice.fileobj.tell(), 100)
+                    assert fileobj_slice.tell() == 0
+                    assert fileobj_slice.fileobj.tell() == 100
                     fileobj_slice.seek(50, os.SEEK_CUR)
-                    self.assertEqual(fileobj_slice.tell(), 50)
-                    self.assertEqual(fileobj_slice.fileobj.tell(), 150)
+                    assert fileobj_slice.tell() == 50
+                    assert fileobj_slice.fileobj.tell() == 150
                     fileobj_slice.seek(100, os.SEEK_CUR)
-                    self.assertEqual(fileobj_slice.tell(), 100)
-                    self.assertEqual(fileobj_slice.fileobj.tell(), 200)
+                    assert fileobj_slice.tell() == 100
+                    assert fileobj_slice.fileobj.tell() == 200
                     fileobj_slice.seek(-300, os.SEEK_CUR)
-                    self.assertEqual(fileobj_slice.tell(), 0)
-                    self.assertEqual(fileobj_slice.fileobj.tell(), 100)
+                    assert fileobj_slice.tell() == 0
+                    assert fileobj_slice.fileobj.tell() == 100
 
                 # Test seek with whence = os.SEEK_END
                 with SliceFileObj(fileobj, seek_from=100, read_limit=100) as fileobj_slice:
-                    self.assertEqual(fileobj_slice.tell(), 0)
+                    assert fileobj_slice.tell() == 0
                     fileobj_slice.seek(-5, os.SEEK_END)
-                    self.assertEqual(fileobj_slice.tell(), 95)
-                    self.assertEqual(fileobj_slice.fileobj.tell(), 195)
+                    assert fileobj_slice.tell() == 95
+                    assert fileobj_slice.fileobj.tell() == 195
                     fileobj_slice.seek(50, os.SEEK_END)
-                    self.assertEqual(fileobj_slice.tell(), 100)
-                    self.assertEqual(fileobj_slice.fileobj.tell(), 200)
+                    assert fileobj_slice.tell() == 100
+                    assert fileobj_slice.fileobj.tell() == 200
                     fileobj_slice.seek(-200, os.SEEK_END)
-                    self.assertEqual(fileobj_slice.tell(), 0)
-                    self.assertEqual(fileobj_slice.fileobj.tell(), 100)
+                    assert fileobj_slice.tell() == 0
+                    assert fileobj_slice.fileobj.tell() == 100
 
 
-@patch("huggingface_hub.lfs.hf_raise_for_status")
-@patch("huggingface_hub.lfs.http_backoff")
-def test_post_lfs_batch_info_uses_http_backoff(mock_http_backoff, mock_raise_for_status):
+def test_post_lfs_batch_info_uses_http_backoff(mocker):
     """post_lfs_batch_info uses http_backoff for retry on transient failures."""
+    mock_http_backoff = mocker.patch("huggingface_hub.lfs.http_backoff")
+    mocker.patch("huggingface_hub.lfs.hf_raise_for_status")
     mock_http_backoff.return_value = MagicMock(json=lambda: {"objects": []})
 
     post_lfs_batch_info(

--- a/tests/test_login_utils.py
+++ b/tests/test_login_utils.py
@@ -1,15 +1,17 @@
 import subprocess
-import unittest
 from typing import Optional
+
+import pytest
 
 from huggingface_hub._login import _set_store_as_git_credential_helper_globally
 from huggingface_hub.utils import run_subprocess
 
 
-class TestSetGlobalStore(unittest.TestCase):
+class TestSetGlobalStore:
     previous_config: Optional[str]
 
-    def setUp(self) -> None:
+    @pytest.fixture(autouse=True)
+    def setup(self):
         """Get current global config value."""
         try:
             self.previous_config = run_subprocess("git config --global credential.helper").stdout
@@ -18,8 +20,9 @@ class TestSetGlobalStore(unittest.TestCase):
 
         run_subprocess("git config --global credential.helper store")
 
-    def tearDown(self) -> None:
-        """Reset global config value."""
+        yield
+
+        # Reset global config value.
         if self.previous_config is None:
             run_subprocess("git config --global --unset credential.helper")
         else:
@@ -32,4 +35,4 @@ class TestSetGlobalStore(unittest.TestCase):
         """
         _set_store_as_git_credential_helper_globally()
         new_config = run_subprocess("git config --global credential.helper").stdout
-        self.assertEqual(new_config, "store\n")
+        assert new_config == "store\n"

--- a/tests/test_repocard.py
+++ b/tests/test_repocard.py
@@ -14,7 +14,6 @@
 import copy
 import os
 import re
-import unittest
 from pathlib import Path
 
 import pytest
@@ -45,7 +44,7 @@ from huggingface_hub.repocard_data import CardData
 from huggingface_hub.utils import SoftTemporaryDirectory, is_jinja_available
 
 from .testing_constants import ENDPOINT_STAGING, TOKEN, USER
-from .testing_utils import repo_name, with_production_testing
+from .testing_utils import repo_name
 
 
 SAMPLE_CARDS_DIR = Path(__file__).parent / "fixtures/cards"
@@ -182,67 +181,58 @@ Custom template passed as a string.
 """
 
 
-def require_jinja(test_case):
-    """
-    Decorator marking a test that requires Jinja2.
-
-    These tests are skipped when Jinja2 is not installed.
-    """
-    if not is_jinja_available():
-        return unittest.skip("test requires Jinja2.")(test_case)
-    else:
-        return test_case
+require_jinja = pytest.mark.skipif(not is_jinja_available(), reason="test requires Jinja2.")
 
 
-@pytest.mark.usefixtures("fx_cache_dir")
-class RepocardMetadataTest(unittest.TestCase):
+class TestRepocardMetadata:
     cache_dir: Path
 
-    def setUp(self) -> None:
+    @pytest.fixture(autouse=True)
+    def _setup(self, fx_cache_dir) -> None:
         self.filepath = self.cache_dir / constants.REPOCARD_NAME
 
     def test_metadata_load(self):
         self.filepath.write_text(DUMMY_MODELCARD)
         data = metadata_load(self.filepath)
-        self.assertDictEqual(data, {"license": "mit", "datasets": ["foo", "bar"]})
+        assert data == {"license": "mit", "datasets": ["foo", "bar"]}
 
     def test_metadata_save(self):
         self.filepath.write_text(DUMMY_MODELCARD)
         metadata_save(self.filepath, {"meaning_of_life": 42})
         content = self.filepath.read_text()
-        self.assertEqual(content, DUMMY_MODELCARD_TARGET)
+        assert content == DUMMY_MODELCARD_TARGET
 
     def test_metadata_save_with_emoji_character(self):
         self.filepath.write_text(DUMMY_MODELCARD)
         metadata_save(self.filepath, {"emoji": "🎁"})
         content = self.filepath.read_text(encoding="utf-8")
-        self.assertEqual(content, DUMMY_MODELCARD_TARGET_WITH_EMOJI)
+        assert content == DUMMY_MODELCARD_TARGET_WITH_EMOJI
 
     def test_metadata_save_from_file_no_yaml(self):
         self.filepath.write_text("Hello\n")
         metadata_save(self.filepath, {"meaning_of_life": 42})
         content = self.filepath.read_text()
-        self.assertEqual(content, DUMMY_MODELCARD_TARGET_NO_YAML)
+        assert content == DUMMY_MODELCARD_TARGET_NO_YAML
 
     def test_metadata_save_new_file(self):
         metadata_save(self.filepath, {"meaning_of_life": 42})
         content = self.filepath.read_text()
-        self.assertEqual(content, DUMMY_NEW_MODELCARD_TARGET)
+        assert content == DUMMY_NEW_MODELCARD_TARGET
 
     def test_no_metadata_returns_none(self):
         self.filepath.write_text(DUMMY_MODELCARD_TARGET_NO_TAGS)
         data = metadata_load(self.filepath)
-        self.assertEqual(data, None)
+        assert data is None
 
     def test_empty_metadata_returns_none_with_metadata_load(self):
         self.filepath.write_text(DUMMY_MODELCARD_EMPTY_METADATA)
         data = metadata_load(self.filepath)
-        self.assertEqual(data, None)
+        assert data is None
 
     def test_empty_metadata_returns_none_with_repocard_load(self):
         self.filepath.write_text(DUMMY_MODELCARD_EMPTY_METADATA)
-        self.assertIsNone(metadata_load(self.filepath))
-        self.assertEqual(RepoCard.load(self.filepath).data.to_dict(), {})
+        assert metadata_load(self.filepath) is None
+        assert RepoCard.load(self.filepath).data.to_dict() == {}
 
     def test_metadata_eval_result(self):
         data = metadata_eval_result(
@@ -261,10 +251,10 @@ class RepocardMetadataTest(unittest.TestCase):
         )
         metadata_save(self.filepath, data)
         content = self.filepath.read_text().splitlines()
-        self.assertEqual(content, DUMMY_MODELCARD_EVAL_RESULT.splitlines())
+        assert content == DUMMY_MODELCARD_EVAL_RESULT.splitlines()
 
 
-@with_production_testing
+@pytest.mark.production
 def test_load_from_hub_if_repo_id_or_path_is_a_dir(monkeypatch, tmp_path):
     """If `repo_id_or_path` happens to be both a `repo_id` and a local directory, the card must be loaded from the Hub.
 
@@ -286,10 +276,11 @@ def test_load_from_hub_if_repo_id_or_path_is_a_dir(monkeypatch, tmp_path):
     assert Path(repo_id).is_dir()
 
 
-class RepocardMetadataUpdateTest(unittest.TestCase):
-    def setUp(self) -> None:
+class TestRepocardMetadataUpdate:
+    @pytest.fixture(autouse=True)
+    def _setup(self, api: HfApi):
         self.token = TOKEN
-        self.api = HfApi(token=TOKEN)
+        self.api = api
 
         self.repo_id = self.api.create_repo(repo_name()).repo_id
         self.api.upload_file(
@@ -298,8 +289,7 @@ class RepocardMetadataUpdateTest(unittest.TestCase):
             path_in_repo=constants.REPOCARD_NAME,
         )
         self.existing_metadata = yaml.safe_load(DUMMY_MODELCARD_EVAL_RESULT.strip().strip("-"))
-
-    def tearDown(self) -> None:
+        yield
         self.api.delete_repo(repo_id=self.repo_id)
 
     def _get_remote_card(self) -> str:
@@ -313,7 +303,7 @@ class RepocardMetadataUpdateTest(unittest.TestCase):
         updated_metadata = metadata_load(self._get_remote_card())
         expected_metadata = copy.deepcopy(self.existing_metadata)
         expected_metadata.update(new_datasets_data)
-        self.assertDictEqual(updated_metadata, expected_metadata)
+        assert updated_metadata == expected_metadata
 
     def test_update_existing_result_with_overwrite(self):
         new_metadata = copy.deepcopy(self.existing_metadata)
@@ -321,7 +311,7 @@ class RepocardMetadataUpdateTest(unittest.TestCase):
         metadata_update(self.repo_id, new_metadata, token=self.token, overwrite=True)
 
         updated_metadata = metadata_load(self._get_remote_card())
-        self.assertDictEqual(updated_metadata, new_metadata)
+        assert updated_metadata == new_metadata
 
     def test_update_verify_token(self):
         """Tests whether updating the verification token updates in-place.
@@ -333,7 +323,7 @@ class RepocardMetadataUpdateTest(unittest.TestCase):
         metadata_update(self.repo_id, new_metadata, token=self.token, overwrite=True)
 
         updated_metadata = metadata_load(self._get_remote_card())
-        self.assertDictEqual(updated_metadata, new_metadata)
+        assert updated_metadata == new_metadata
 
     def test_metadata_update_upstream(self):
         new_metadata = copy.deepcopy(self.existing_metadata)
@@ -343,8 +333,8 @@ class RepocardMetadataUpdateTest(unittest.TestCase):
         path = self._get_remote_card()
         metadata_update(self.repo_id, new_metadata, token=self.token, overwrite=True)
 
-        self.assertNotEqual(metadata_load(path), new_metadata)
-        self.assertEqual(metadata_load(path), self.existing_metadata)
+        assert metadata_load(path) != new_metadata
+        assert metadata_load(path) == self.existing_metadata
 
     def test_update_existing_result_without_overwrite(self):
         new_metadata = copy.deepcopy(self.existing_metadata)
@@ -397,7 +387,7 @@ class RepocardMetadataUpdateTest(unittest.TestCase):
         )
 
         updated_metadata = metadata_load(self._get_remote_card())
-        self.assertDictEqual(updated_metadata, expected_metadata)
+        assert updated_metadata == expected_metadata
 
     def test_update_new_result_new_dataset(self):
         new_result = metadata_eval_result(
@@ -421,7 +411,7 @@ class RepocardMetadataUpdateTest(unittest.TestCase):
         expected_metadata["model-index"][0]["results"].append(new_result["model-index"][0]["results"][0])
 
         updated_metadata = metadata_load(self._get_remote_card())
-        self.assertDictEqual(updated_metadata, expected_metadata)
+        assert updated_metadata == expected_metadata
 
     def test_update_metadata_on_empty_text_content(self) -> None:
         """Test `update_metadata` on a model card that has metadata but no text content
@@ -439,7 +429,7 @@ class RepocardMetadataUpdateTest(unittest.TestCase):
         # Check update went fine
         updated_metadata = metadata_load(self._get_remote_card())
         expected_metadata = {"license": "cc-by-sa-4.0", "tag": "test"}
-        self.assertDictEqual(updated_metadata, expected_metadata)
+        assert updated_metadata == expected_metadata
 
     def test_update_with_existing_name(self):
         new_metadata = copy.deepcopy(self.existing_metadata)
@@ -448,7 +438,7 @@ class RepocardMetadataUpdateTest(unittest.TestCase):
         metadata_update(self.repo_id, new_metadata, token=self.token, overwrite=True)
 
         card_data = ModelCard.load(self.repo_id)
-        self.assertEqual(card_data.data.model_name, self.existing_metadata["model-index"][0]["name"])
+        assert card_data.data.model_name == self.existing_metadata["model-index"][0]["name"]
 
     def test_update_without_existing_name(self):
         # delete existing metadata
@@ -460,7 +450,7 @@ class RepocardMetadataUpdateTest(unittest.TestCase):
         metadata_update(self.repo_id, new_metadata, token=self.token, overwrite=True)
 
         card_data = ModelCard.load(self.repo_id)
-        self.assertEqual(card_data.data.model_name, self.repo_id)
+        assert card_data.data.model_name == self.repo_id
 
     def test_update_with_both_verified_and_unverified_metric(self):
         """Regression test for #1185.
@@ -477,21 +467,22 @@ class RepocardMetadataUpdateTest(unittest.TestCase):
         metadata_update(self.repo_id, metadata=metadata, overwrite=True, token=self.token)
 
         new_card = ModelCard.load(self.repo_id)
-        self.assertEqual(len(new_card.data.eval_results), 2)
+        assert len(new_card.data.eval_results) == 2
         first_result = new_card.data.eval_results[0]
         second_result = new_card.data.eval_results[1]
 
         # One is verified, the other not
-        self.assertFalse(first_result.verified)
-        self.assertTrue(second_result.verified)
+        assert not first_result.verified
+        assert second_result.verified
 
         # Result values are different
-        self.assertEqual(first_result.metric_value, 0.2662102282047272)
-        self.assertEqual(second_result.metric_value, 0.6666666666666666)
+        assert first_result.metric_value == 0.2662102282047272
+        assert second_result.metric_value == 0.6666666666666666
 
 
-class TestMetadataUpdateOnMissingCard(unittest.TestCase):
-    def setUp(self) -> None:
+class TestMetadataUpdateOnMissingCard:
+    @pytest.fixture(autouse=True)
+    def _setup(self) -> None:
         """
         Share this valid token in all tests below.
         """
@@ -505,8 +496,8 @@ class TestMetadataUpdateOnMissingCard(unittest.TestCase):
         model_card = ModelCard.load(self._repo_id, token=self._token)
 
         # Created a card with default template + metadata
-        self.assertIn("# Model Card for Model ID", str(model_card))
-        self.assertEqual(model_card.data.to_dict(), {"tag": "this_is_a_test"})
+        assert "# Model Card for Model ID" in str(model_card)
+        assert model_card.data.to_dict() == {"tag": "this_is_a_test"}
 
         self._api.delete_repo(self._repo_id)
 
@@ -521,15 +512,15 @@ class TestMetadataUpdateOnMissingCard(unittest.TestCase):
         dataset_card = DatasetCard.load(self._repo_id, token=self._token)
 
         # Created a card with default template + metadata
-        self.assertIn("# Dataset Card for Dataset Name", str(dataset_card))
-        self.assertEqual(dataset_card.data.to_dict(), {"tag": "this is a dataset test"})
+        assert "# Dataset Card for Dataset Name" in str(dataset_card)
+        assert dataset_card.data.to_dict() == {"tag": "this is a dataset test"}
 
         self._api.delete_repo(self._repo_id, repo_type="dataset")
 
     def test_metadata_update_missing_readme_on_space(self) -> None:
         self._api.create_repo(self._repo_id, repo_type="space", space_sdk="static")
         self._api.delete_file("README.md", self._repo_id, repo_type="space")
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             # Cannot create a default readme on a space repo (should be automatically
             # created on the Hub).
             metadata_update(
@@ -541,29 +532,19 @@ class TestMetadataUpdateOnMissingCard(unittest.TestCase):
         self._api.delete_repo(self._repo_id, repo_type="space")
 
 
-class TestCaseWithHfApi(unittest.TestCase):
-    _api = HfApi(endpoint=ENDPOINT_STAGING, token=TOKEN)
-
-
-class RepoCardTest(TestCaseWithHfApi):
+class TestRepoCard:
     def test_load_repocard_from_file(self):
         sample_path = SAMPLE_CARDS_DIR / "sample_simple.md"
         card = RepoCard.load(sample_path)
-        self.assertEqual(
-            card.data.to_dict(),
-            {
-                "language": ["en"],
-                "license": "mit",
-                "library_name": "pytorch-lightning",
-                "tags": ["pytorch", "image-classification"],
-                "datasets": ["beans"],
-                "metrics": ["acc"],
-            },
-        )
-        self.assertTrue(
-            card.text.strip().startswith("# my-cool-model"),
-            "Card text not loaded properly",
-        )
+        assert card.data.to_dict() == {
+            "language": ["en"],
+            "license": "mit",
+            "library_name": "pytorch-lightning",
+            "tags": ["pytorch", "image-classification"],
+            "datasets": ["beans"],
+            "metrics": ["acc"],
+        }
+        assert card.text.strip().startswith("# my-cool-model"), "Card text not loaded properly"
 
     def test_change_repocard_data(self):
         sample_path = SAMPLE_CARDS_DIR / "sample_simple.md"
@@ -575,7 +556,7 @@ class RepoCardTest(TestCaseWithHfApi):
             card.save(updated_card_path)
 
             updated_card = RepoCard.load(updated_card_path)
-            self.assertEqual(updated_card.data.language, ["fr"], "Card data not updated properly")
+            assert updated_card.data.language == ["fr"], "Card data not updated properly"
 
     @require_jinja
     def test_repo_card_from_default_template(self):
@@ -590,11 +571,8 @@ class RepoCardTest(TestCaseWithHfApi):
             ),
             model_id=None,
         )
-        self.assertIsInstance(card, RepoCard)
-        self.assertTrue(
-            card.text.strip().startswith("# Model Card for Model ID"),
-            "Default model name not set correctly",
-        )
+        assert isinstance(card, RepoCard)
+        assert card.text.strip().startswith("# Model Card for Model ID"), "Default model name not set correctly"
 
     @require_jinja
     def test_repo_card_from_default_template_with_model_id(self):
@@ -609,9 +587,8 @@ class RepoCardTest(TestCaseWithHfApi):
             ),
             model_id="my-cool-model",
         )
-        self.assertTrue(
-            card.text.strip().startswith("# Model Card for my-cool-model"),
-            "model_id not properly set in card template",
+        assert card.text.strip().startswith("# Model Card for my-cool-model"), (
+            "model_id not properly set in card template"
         )
 
     @require_jinja
@@ -630,10 +607,7 @@ class RepoCardTest(TestCaseWithHfApi):
             template_path=template_path,
             some_data="asdf",
         )
-        self.assertTrue(
-            card.text.endswith("asdf"),
-            "Custom template didn't set jinja variable correctly",
-        )
+        assert card.text.endswith("asdf"), "Custom template didn't set jinja variable correctly"
 
     @require_jinja
     def test_repo_card_from_custom_template_string(self):
@@ -649,18 +623,17 @@ class RepoCardTest(TestCaseWithHfApi):
         with pytest.raises(ValueError, match="repo card metadata block should be a dict"):
             RepoCard(sample_path.read_text())
 
-    def test_repo_card_without_metadata(self):
+    def test_repo_card_without_metadata(self, caplog):
         sample_path = SAMPLE_CARDS_DIR / "sample_no_metadata.md"
 
-        with self.assertLogs("huggingface_hub", level="WARNING") as warning_logs:
+        with caplog.at_level("WARNING", logger="huggingface_hub"):
             card = RepoCard(sample_path.read_text())
-        self.assertTrue(
-            any(
-                "Repo card metadata block was not found. Setting CardData to empty." in log
-                for log in warning_logs.output
-            )
+        records = [record for record in caplog.records if record.name.startswith("huggingface_hub")]
+        assert any(
+            "Repo card metadata block was not found. Setting CardData to empty." in record.message
+            for record in records
         )
-        self.assertEqual(card.data, CardData())
+        assert card.data == CardData()
 
     def test_validate_repocard(self):
         sample_path = SAMPLE_CARDS_DIR / "sample_simple.md"
@@ -671,9 +644,9 @@ class RepoCardTest(TestCaseWithHfApi):
         with pytest.raises(ValueError, match='- Error: "license" must be one of'):
             card.validate()
 
-    def test_push_to_hub(self):
+    def test_push_to_hub(self, api: HfApi):
         repo_id = f"{USER}/{repo_name('push-card')}"
-        self._api.create_repo(repo_id)
+        api.create_repo(repo_id)
 
         card_data = CardData(
             language="en",
@@ -689,7 +662,7 @@ class RepoCardTest(TestCaseWithHfApi):
 
         # Check this file doesn't exist (sanity check)
         readme_url = hf_hub_url(repo_id, "README.md")
-        with self.assertRaises(EntryNotFoundError):
+        with pytest.raises(EntryNotFoundError):
             get_hf_file_metadata(readme_url)
 
         # Push the card up to README.md in the repo
@@ -698,11 +671,11 @@ class RepoCardTest(TestCaseWithHfApi):
         # No error should occur now, as README.md should exist
         get_hf_file_metadata(readme_url)
 
-        self._api.delete_repo(repo_id=repo_id)
+        api.delete_repo(repo_id=repo_id)
 
-    def test_push_and_create_pr(self):
+    def test_push_and_create_pr(self, api: HfApi):
         repo_id = f"{USER}/{repo_name('pr-card')}"
-        self._api.create_repo(repo_id)
+        api.create_repo(repo_id)
         card_data = CardData(
             language="en",
             license="mit",
@@ -715,19 +688,19 @@ class RepoCardTest(TestCaseWithHfApi):
         content = f"---\n{card_data.to_yaml()}\n---\n\n# MyModel\n\nHello, world!"
         card = RepoCard(content)
 
-        discussions = list(self._api.get_repo_discussions(repo_id))
-        self.assertEqual(len(discussions), 0)
+        discussions = list(api.get_repo_discussions(repo_id))
+        assert len(discussions) == 0
 
         card.push_to_hub(repo_id, token=TOKEN, create_pr=True)
-        discussions = list(self._api.get_repo_discussions(repo_id))
-        self.assertEqual(len(discussions), 1)
+        discussions = list(api.get_repo_discussions(repo_id))
+        assert len(discussions) == 1
 
-        self._api.delete_repo(repo_id=repo_id)
+        api.delete_repo(repo_id=repo_id)
 
     def test_preserve_windows_linebreaks(self):
         card_path = SAMPLE_CARDS_DIR / "sample_windows_line_breaks.md"
         card = RepoCard.load(card_path)
-        self.assertIn("\r\n", str(card))
+        assert "\r\n" in str(card)
 
     def test_preserve_linebreaks_when_saving(self):
         card_path = SAMPLE_CARDS_DIR / "sample_simple.md"
@@ -736,50 +709,50 @@ class RepoCardTest(TestCaseWithHfApi):
             tmpfile = os.path.join(tmpdir, "readme.md")
             card.save(tmpfile)
             card2 = RepoCard.load(tmpfile)
-        self.assertEqual(str(card), str(card2))
+        assert str(card) == str(card2)
 
     def test_updating_text_updates_content(self):
         sample_path = SAMPLE_CARDS_DIR / "sample_simple.md"
         card = RepoCard.load(sample_path)
         card.text = "Hello, world!"
         line_break = "\r\n" if os.name == "nt" else "\n"
-        self.assertEqual(
-            card.content,
+        assert card.content == (
             # line_break depends on platform. Correctly set when using RepoCard.save(...) to avoid diffs
-            f"---\n{card.data.to_yaml()}\n---\nHello, world!".replace("\n", line_break),
+            f"---\n{card.data.to_yaml()}\n---\nHello, world!".replace("\n", line_break)
         )
 
 
-class TestRegexYamlBlock(unittest.TestCase):
+class TestRegexYamlBlock:
     def test_match_with_leading_whitespace(self):
-        self.assertIsNotNone(REGEX_YAML_BLOCK.search("   \n---\nmetadata: 1\n---"))
+        assert REGEX_YAML_BLOCK.search("   \n---\nmetadata: 1\n---") is not None
 
     def test_match_without_leading_whitespace(self):
-        self.assertIsNotNone(REGEX_YAML_BLOCK.search("---\nmetadata: 1\n---"))
+        assert REGEX_YAML_BLOCK.search("---\nmetadata: 1\n---") is not None
 
     def test_does_not_match_with_leading_text(self):
-        self.assertIsNone(REGEX_YAML_BLOCK.search("something\n---\nmetadata: 1\n---"))
+        assert REGEX_YAML_BLOCK.search("something\n---\nmetadata: 1\n---") is None
 
 
-class ModelCardTest(TestCaseWithHfApi):
+class TestModelCard:
     def test_model_card_with_invalid_model_index(self):
         """Test raise an error when loading a card that has invalid model-index."""
         sample_path = SAMPLE_CARDS_DIR / "sample_invalid_model_index.md"
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             ModelCard.load(sample_path)
 
-    def test_model_card_with_invalid_model_index_and_ignore_error(self):
+    def test_model_card_with_invalid_model_index_and_ignore_error(self, caplog):
         """Test trigger a warning when loading a card that has invalid model-index and `ignore_metadata_errors=True`
 
         Some information is lost.
         """
         sample_path = SAMPLE_CARDS_DIR / "sample_invalid_model_index.md"
-        with self.assertLogs("huggingface_hub", level="WARNING") as warning_logs:
+        with caplog.at_level("WARNING", logger="huggingface_hub"):
             card = ModelCard.load(sample_path, ignore_metadata_errors=True)
-        self.assertTrue(
-            any("Invalid model-index. Not loading eval results into CardData." in log for log in warning_logs.output)
+        records = [record for record in caplog.records if record.name.startswith("huggingface_hub")]
+        assert any(
+            "Invalid model-index. Not loading eval results into CardData." in record.message for record in records
         )
-        self.assertIsNone(card.data.eval_results)
+        assert card.data.eval_results is None
 
     def test_model_card_with_model_index(self):
         """Test that loading a model card with multiple evaluations is consistent with `metadata_load`.
@@ -789,27 +762,21 @@ class ModelCardTest(TestCaseWithHfApi):
         sample_path = SAMPLE_CARDS_DIR / "sample_simple_model_index.md"
         card = ModelCard.load(sample_path)
         metadata = metadata_load(sample_path)
-        self.assertDictEqual(card.data.to_dict(), metadata)
+        assert card.data.to_dict() == metadata
 
     def test_load_model_card_from_file(self):
         sample_path = SAMPLE_CARDS_DIR / "sample_simple.md"
         card = ModelCard.load(sample_path)
-        self.assertIsInstance(card, ModelCard)
-        self.assertEqual(
-            card.data.to_dict(),
-            {
-                "language": ["en"],
-                "license": "mit",
-                "library_name": "pytorch-lightning",
-                "tags": ["pytorch", "image-classification"],
-                "datasets": ["beans"],
-                "metrics": ["acc"],
-            },
-        )
-        self.assertTrue(
-            card.text.strip().startswith("# my-cool-model"),
-            "Card text not loaded properly",
-        )
+        assert isinstance(card, ModelCard)
+        assert card.data.to_dict() == {
+            "language": ["en"],
+            "license": "mit",
+            "library_name": "pytorch-lightning",
+            "tags": ["pytorch", "image-classification"],
+            "datasets": ["beans"],
+            "metrics": ["acc"],
+        }
+        assert card.text.strip().startswith("# my-cool-model"), "Card text not loaded properly"
 
     @require_jinja
     def test_model_card_from_custom_template(self):
@@ -826,11 +793,8 @@ class ModelCardTest(TestCaseWithHfApi):
             template_path=template_path,
             some_data="asdf",
         )
-        self.assertIsInstance(card, ModelCard)
-        self.assertTrue(
-            card.text.endswith("asdf"),
-            "Custom template didn't set jinja variable correctly",
-        )
+        assert isinstance(card, ModelCard)
+        assert card.text.endswith("asdf"), "Custom template didn't set jinja variable correctly"
 
     @require_jinja
     def test_model_card_from_template_eval_results(self):
@@ -857,38 +821,35 @@ class ModelCardTest(TestCaseWithHfApi):
             template_path=template_path,
             some_data="asdf",
         )
-        self.assertIsInstance(card, ModelCard)
-        self.assertTrue(card.text.endswith("asdf"))
-        self.assertTrue(card.data.to_dict().get("eval_results") is None)
-        self.assertEqual(str(card)[: len(DUMMY_MODELCARD_EVAL_RESULT)], DUMMY_MODELCARD_EVAL_RESULT)
+        assert isinstance(card, ModelCard)
+        assert card.text.endswith("asdf")
+        assert card.data.to_dict().get("eval_results") is None
+        assert str(card)[: len(DUMMY_MODELCARD_EVAL_RESULT)] == DUMMY_MODELCARD_EVAL_RESULT
 
     def test_preserve_order_load_save(self):
         model_card = ModelCard(DUMMY_MODELCARD)
         model_card.data.license = "test"
-        self.assertEqual(model_card.content, "---\nlicense: test\ndatasets:\n- foo\n- bar\n---\n\nHello\n")
+        assert model_card.content == "---\nlicense: test\ndatasets:\n- foo\n- bar\n---\n\nHello\n"
 
 
-class DatasetCardTest(TestCaseWithHfApi):
+class TestDatasetCard:
     def test_load_datasetcard_from_file(self):
         sample_path = SAMPLE_CARDS_DIR / "sample_datasetcard_simple.md"
         card = DatasetCard.load(sample_path)
-        self.assertEqual(
-            card.data.to_dict(),
-            {
-                "annotations_creators": ["crowdsourced", "expert-generated"],
-                "language_creators": ["found"],
-                "language": ["en"],
-                "license": ["bsd-3-clause"],
-                "multilinguality": ["monolingual"],
-                "size_categories": ["n<1K"],
-                "task_categories": ["image-segmentation"],
-                "task_ids": ["semantic-segmentation"],
-                "pretty_name": "Sample Segmentation",
-            },
-        )
-        self.assertIsInstance(card, DatasetCard)
-        self.assertIsInstance(card.data, DatasetCardData)
-        self.assertTrue(card.text.strip().startswith("# Dataset Card for"))
+        assert card.data.to_dict() == {
+            "annotations_creators": ["crowdsourced", "expert-generated"],
+            "language_creators": ["found"],
+            "language": ["en"],
+            "license": ["bsd-3-clause"],
+            "multilinguality": ["monolingual"],
+            "size_categories": ["n<1K"],
+            "task_categories": ["image-segmentation"],
+            "task_ids": ["semantic-segmentation"],
+            "pretty_name": "Sample Segmentation",
+        }
+        assert isinstance(card, DatasetCard)
+        assert isinstance(card.data, DatasetCardData)
+        assert card.text.strip().startswith("# Dataset Card for")
 
     @require_jinja
     def test_dataset_card_from_default_template(self):
@@ -899,7 +860,7 @@ class DatasetCardTest(TestCaseWithHfApi):
 
         # Here we check default title when pretty_name not provided.
         card = DatasetCard.from_template(card_data)
-        self.assertTrue(card.text.strip().startswith("# Dataset Card for Dataset Name"))
+        assert card.text.strip().startswith("# Dataset Card for Dataset Name")
 
         card_data = DatasetCardData(
             language="en",
@@ -909,9 +870,9 @@ class DatasetCardTest(TestCaseWithHfApi):
 
         # Here we pass the card data as kwargs as well so template picks up pretty_name.
         card = DatasetCard.from_template(card_data, **card_data.to_dict())
-        self.assertTrue(card.text.strip().startswith("# Dataset Card for My Cool Dataset"))
+        assert card.text.strip().startswith("# Dataset Card for My Cool Dataset")
 
-        self.assertIsInstance(card, DatasetCard)
+        assert isinstance(card, DatasetCard)
 
     @require_jinja
     def test_dataset_card_from_default_template_with_template_variables(self):
@@ -931,11 +892,11 @@ class DatasetCardTest(TestCaseWithHfApi):
                 "in the dataset card template are working."
             ),
         )
-        self.assertTrue(card.text.strip().startswith("# Dataset Card for My Cool Dataset"))
-        self.assertIsInstance(card, DatasetCard)
+        assert card.text.strip().startswith("# Dataset Card for My Cool Dataset")
+        assert isinstance(card, DatasetCard)
 
         matches = re.findall(r"Repository:\*\* https://github\.com/huggingface/huggingface_hub", str(card))
-        self.assertEqual(matches[0], "Repository:** https://github.com/huggingface/huggingface_hub")
+        assert matches[0] == "Repository:** https://github.com/huggingface/huggingface_hub"
 
     @require_jinja
     def test_dataset_card_from_custom_template(self):
@@ -949,20 +910,20 @@ class DatasetCardTest(TestCaseWithHfApi):
             pretty_name="My Cool Dataset",
             some_data="asdf",
         )
-        self.assertIsInstance(card, DatasetCard)
+        assert isinstance(card, DatasetCard)
 
         # Title this time is just # {{ pretty_name }}
-        self.assertTrue(card.text.strip().startswith("# My Cool Dataset"))
+        assert card.text.strip().startswith("# My Cool Dataset")
 
         # some_data is at the bottom of the template, so should end with whatever we passed to it
-        self.assertTrue(card.text.strip().endswith("asdf"))
+        assert card.text.strip().endswith("asdf")
 
 
-@with_production_testing
-class SpaceCardTest(TestCaseWithHfApi):
+@pytest.mark.production
+class TestSpaceCard:
     def test_load_spacecard_from_hub(self) -> None:
         card = SpaceCard.load("multimodalart/dreambooth-training")
-        self.assertIsInstance(card, SpaceCard)
-        self.assertIsInstance(card.data, SpaceCardData)
-        self.assertEqual(card.data.title, "Dreambooth Training")
-        self.assertIsNone(card.data.app_port)
+        assert isinstance(card, SpaceCard)
+        assert isinstance(card.data, SpaceCardData)
+        assert card.data.title == "Dreambooth Training"
+        assert card.data.app_port is None

--- a/tests/test_repocard.py
+++ b/tests/test_repocard.py
@@ -185,11 +185,9 @@ require_jinja = pytest.mark.skipif(not is_jinja_available(), reason="test requir
 
 
 class TestRepocardMetadata:
-    cache_dir: Path
-
     @pytest.fixture(autouse=True)
-    def _setup(self, fx_cache_dir) -> None:
-        self.filepath = self.cache_dir / constants.REPOCARD_NAME
+    def _setup(self, tmp_path) -> None:
+        self.filepath = tmp_path / constants.REPOCARD_NAME
 
     def test_metadata_load(self):
         self.filepath.write_text(DUMMY_MODELCARD)

--- a/tests/test_repocard_data.py
+++ b/tests/test_repocard_data.py
@@ -1,5 +1,3 @@
-import unittest
-
 import pytest
 import yaml
 
@@ -43,40 +41,40 @@ model-index:
 """
 
 
-class BaseCardDataTest(unittest.TestCase):
+class TestBaseCardData:
     def test_metadata_behave_as_dict(self):
         metadata = CardData(foo="bar")
 
         # .get and __getitem__
-        self.assertEqual(metadata.get("foo"), "bar")
-        self.assertEqual(metadata.get("FOO"), None)  # case-sensitive
-        self.assertEqual(metadata["foo"], "bar")
-        with self.assertRaises(KeyError):  # case-sensitive
+        assert metadata.get("foo") == "bar"
+        assert metadata.get("FOO") is None  # case-sensitive
+        assert metadata["foo"] == "bar"
+        with pytest.raises(KeyError):  # case-sensitive
             _ = metadata["FOO"]
 
         # __setitem__
         metadata["foo"] = "BAR"
-        self.assertEqual(metadata.get("foo"), "BAR")
-        self.assertEqual(metadata["foo"], "BAR")
+        assert metadata.get("foo") == "BAR"
+        assert metadata["foo"] == "BAR"
 
         # __contains__
-        self.assertTrue("foo" in metadata)
-        self.assertFalse("FOO" in metadata)
+        assert "foo" in metadata
+        assert "FOO" not in metadata
 
         # default value
         # Should return default when key is not in metadata
-        self.assertEqual(metadata.get("FOO", "default"), "default")
+        assert metadata.get("FOO", "default") == "default"
         # Should return default when key is in metadata but value is None
         metadata.FOO = None
-        self.assertEqual(metadata.get("FOO", "default"), "default")
+        assert metadata.get("FOO", "default") == "default"
         # export
-        self.assertEqual(str(metadata), "foo: BAR")
+        assert str(metadata) == "foo: BAR"
 
         # .pop
-        self.assertEqual(metadata.pop("foo"), "BAR")
+        assert metadata.pop("foo") == "BAR"
 
 
-class ModelCardDataTest(unittest.TestCase):
+class TestModelCardData:
     def test_eval_results_to_model_index(self):
         expected_results = yaml.safe_load(DUMMY_METADATA_WITH_MODEL_INDEX)
 
@@ -94,7 +92,7 @@ class ModelCardDataTest(unittest.TestCase):
 
         model_index = eval_results_to_model_index("my-cool-model", eval_results)
 
-        self.assertEqual(model_index, expected_results["model-index"])
+        assert model_index == expected_results["model-index"]
 
     def test_model_index_to_eval_results(self):
         model_index = [
@@ -146,24 +144,24 @@ class ModelCardDataTest(unittest.TestCase):
         ]
         model_name, eval_results = model_index_to_eval_results(model_index)
 
-        self.assertEqual(len(eval_results), 3)
-        self.assertEqual(model_name, "my-cool-model")
+        assert len(eval_results) == 3
+        assert model_name == "my-cool-model"
 
-        self.assertEqual(eval_results[0].dataset_type, "cats_vs_dogs")
-        self.assertIsNone(eval_results[0].source_name)
-        self.assertIsNone(eval_results[0].source_url)
+        assert eval_results[0].dataset_type == "cats_vs_dogs"
+        assert eval_results[0].source_name is None
+        assert eval_results[0].source_url is None
 
-        self.assertEqual(eval_results[1].metric_type, "f1")
-        self.assertEqual(eval_results[1].metric_value, 0.9)
-        self.assertIsNone(eval_results[1].source_name)
-        self.assertIsNone(eval_results[1].source_url)
+        assert eval_results[1].metric_type == "f1"
+        assert eval_results[1].metric_value == 0.9
+        assert eval_results[1].source_name is None
+        assert eval_results[1].source_url is None
 
-        self.assertEqual(eval_results[2].task_type, "image-classification")
-        self.assertEqual(eval_results[2].dataset_type, "beans")
-        self.assertEqual(eval_results[2].verified, True)
-        self.assertEqual(eval_results[2].verify_token, 1234)
-        self.assertEqual(eval_results[2].source_name, "Open LLM Leaderboard")
-        self.assertEqual(eval_results[2].source_url, OPEN_LLM_LEADERBOARD_URL)
+        assert eval_results[2].task_type == "image-classification"
+        assert eval_results[2].dataset_type == "beans"
+        assert eval_results[2].verified is True
+        assert eval_results[2].verify_token == 1234
+        assert eval_results[2].source_name == "Open LLM Leaderboard"
+        assert eval_results[2].source_url == OPEN_LLM_LEADERBOARD_URL
 
     def test_card_data_requires_model_name_for_eval_results(self):
         with pytest.raises(ValueError, match="`eval_results` requires `model_name` to be set."):
@@ -194,8 +192,8 @@ class ModelCardDataTest(unittest.TestCase):
 
         model_index = eval_results_to_model_index(data.model_name, data.eval_results)
 
-        self.assertEqual(model_index[0]["name"], "my-cool-model")
-        self.assertEqual(model_index[0]["results"][0]["task"]["type"], "image-classification")
+        assert model_index[0]["name"] == "my-cool-model"
+        assert model_index[0]["results"][0]["task"]["type"] == "image-classification"
 
     def test_arbitrary_incoming_card_data(self):
         data = ModelCardData(
@@ -212,10 +210,10 @@ class ModelCardDataTest(unittest.TestCase):
             some_arbitrary_kwarg="some_value",
         )
 
-        self.assertEqual(data.some_arbitrary_kwarg, "some_value")
+        assert data.some_arbitrary_kwarg == "some_value"
 
         data_dict = data.to_dict()
-        self.assertEqual(data_dict["some_arbitrary_kwarg"], "some_value")
+        assert data_dict["some_arbitrary_kwarg"] == "some_value"
 
     def test_eval_result_with_incomplete_source(self):
         # Source url without name: ok
@@ -229,7 +227,7 @@ class ModelCardDataTest(unittest.TestCase):
         )
 
         # Source name without url: not ok
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             EvalResult(
                 task_type="image-classification",
                 dataset_type="beans",
@@ -300,7 +298,7 @@ class ModelCardDataTest(unittest.TestCase):
         assert data.eval_results is not None and data.eval_results == eval_results
 
 
-class DatasetCardDataTest(unittest.TestCase):
+class TestDatasetCardData:
     def test_train_eval_index_keys_updated(self):
         train_eval_index = [
             {
@@ -325,15 +323,15 @@ class DatasetCardDataTest(unittest.TestCase):
             train_eval_index=train_eval_index,
         )
         # The init should have popped this out of kwargs and into train_eval_index attr
-        self.assertEqual(card_data.train_eval_index, train_eval_index)
+        assert card_data.train_eval_index == train_eval_index
         # Underlying train_eval_index gets converted to train-eval-index in DatasetCardData._to_dict.
         # So train_eval_index should be None in the dict
-        self.assertTrue(card_data.to_dict().get("train_eval_index") is None)
+        assert card_data.to_dict().get("train_eval_index") is None
         # And train-eval-index should be in the dict
-        self.assertEqual(card_data.to_dict()["train-eval-index"], train_eval_index)
+        assert card_data.to_dict()["train-eval-index"] == train_eval_index
 
 
-class SpaceCardDataTest(unittest.TestCase):
+class TestSpaceCardData:
     def test_space_card_data(self) -> None:
         card_data = SpaceCardData(
             title="Dreambooth Training",
@@ -341,13 +339,10 @@ class SpaceCardDataTest(unittest.TestCase):
             sdk="gradio",
             duplicated_from="multimodalart/dreambooth-training",
         )
-        self.assertEqual(
-            card_data.to_dict(),
-            {
-                "title": "Dreambooth Training",
-                "sdk": "gradio",
-                "license": "mit",
-                "duplicated_from": "multimodalart/dreambooth-training",
-            },
-        )
-        self.assertIsNone(card_data.tags)  # SpaceCardData has some default attributes
+        assert card_data.to_dict() == {
+            "title": "Dreambooth Training",
+            "sdk": "gradio",
+            "license": "mit",
+            "duplicated_from": "multimodalart/dreambooth-training",
+        }
+        assert card_data.tags is None  # SpaceCardData has some default attributes

--- a/tests/test_snapshot_download.py
+++ b/tests/test_snapshot_download.py
@@ -1,7 +1,8 @@
 import os
-import unittest
 from pathlib import Path
 from unittest.mock import patch
+
+import pytest
 
 from huggingface_hub import CommitOperationAdd, HfApi, snapshot_download
 from huggingface_hub.errors import LocalEntryNotFoundError, RepositoryNotFoundError
@@ -11,18 +12,18 @@ from .testing_constants import TOKEN
 from .testing_utils import OfflineSimulationMode, offline, repo_name
 
 
-class SnapshotDownloadTests(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
+class TestSnapshotDownload:
+    @pytest.fixture(scope="class", autouse=True)
+    def _shared_repo(self, request, api: HfApi):
         """
         Share this valid token in all tests below.
         """
-        cls.api = HfApi(token=TOKEN)
-        cls.repo_id = cls.api.create_repo(repo_name("snapshot-download")).repo_id
+        repo_id = api.create_repo(repo_name("snapshot-download")).repo_id
+        request.cls.repo_id = repo_id
 
         # First commit on `main`
-        cls.first_commit_hash = cls.api.create_commit(
-            repo_id=cls.repo_id,
+        request.cls.first_commit_hash = api.create_commit(
+            repo_id=repo_id,
             operations=[
                 CommitOperationAdd(path_in_repo="dummy_file.txt", path_or_fileobj=b"v1"),
                 CommitOperationAdd(path_in_repo="subpath/file.txt", path_or_fileobj=b"content in subpath"),
@@ -31,8 +32,8 @@ class SnapshotDownloadTests(unittest.TestCase):
         ).oid
 
         # Second commit on `main`
-        cls.second_commit_hash = cls.api.create_commit(
-            repo_id=cls.repo_id,
+        request.cls.second_commit_hash = api.create_commit(
+            repo_id=repo_id,
             operations=[
                 CommitOperationAdd(path_in_repo="dummy_file.txt", path_or_fileobj=b"v2"),
                 CommitOperationAdd(path_in_repo="dummy_file_2.txt", path_or_fileobj=b"v3"),
@@ -41,9 +42,9 @@ class SnapshotDownloadTests(unittest.TestCase):
         ).oid
 
         # Third commit on `other`
-        cls.api.create_branch(repo_id=cls.repo_id, branch="other")
-        cls.third_commit_hash = cls.api.create_commit(
-            repo_id=cls.repo_id,
+        api.create_branch(repo_id=repo_id, branch="other")
+        request.cls.third_commit_hash = api.create_commit(
+            repo_id=repo_id,
             operations=[
                 CommitOperationAdd(path_in_repo="dummy_file_2.txt", path_or_fileobj=b"v4"),
             ],
@@ -51,9 +52,8 @@ class SnapshotDownloadTests(unittest.TestCase):
             revision="other",
         ).oid
 
-    @classmethod
-    def tearDownClass(cls) -> None:
-        cls.api.delete_repo(repo_id=cls.repo_id)
+        yield
+        api.delete_repo(repo_id=repo_id)
 
     def test_download_model(self):
         # Test `main` branch
@@ -62,17 +62,17 @@ class SnapshotDownloadTests(unittest.TestCase):
 
             # folder contains the two files contributed and the .gitattributes
             folder_contents = os.listdir(storage_folder)
-            self.assertEqual(len(folder_contents), 4)
-            self.assertTrue("dummy_file.txt" in folder_contents)
-            self.assertTrue("dummy_file_2.txt" in folder_contents)
-            self.assertTrue(".gitattributes" in folder_contents)
+            assert len(folder_contents) == 4
+            assert "dummy_file.txt" in folder_contents
+            assert "dummy_file_2.txt" in folder_contents
+            assert ".gitattributes" in folder_contents
 
             with open(os.path.join(storage_folder, "dummy_file.txt"), "r") as f:
                 contents = f.read()
-                self.assertEqual(contents, "v2")
+                assert contents == "v2"
 
             # folder name contains the revision's commit sha.
-            self.assertTrue(self.second_commit_hash in storage_folder)
+            assert self.second_commit_hash in storage_folder
 
         # Test with specific revision
         with SoftTemporaryDirectory() as tmpdir:
@@ -84,37 +84,37 @@ class SnapshotDownloadTests(unittest.TestCase):
 
             # folder contains the two files contributed and the .gitattributes
             folder_contents = os.listdir(storage_folder)
-            self.assertEqual(len(folder_contents), 3)
-            self.assertTrue("dummy_file.txt" in folder_contents)
-            self.assertTrue(".gitattributes" in folder_contents)
+            assert len(folder_contents) == 3
+            assert "dummy_file.txt" in folder_contents
+            assert ".gitattributes" in folder_contents
 
             with open(os.path.join(storage_folder, "dummy_file.txt"), "r") as f:
                 contents = f.read()
-                self.assertEqual(contents, "v1")
+                assert contents == "v1"
 
             # folder name contains the revision's commit sha.
-            self.assertTrue(self.first_commit_hash in storage_folder)
+            assert self.first_commit_hash in storage_folder
 
-    def test_download_private_model(self):
-        self.api.update_repo_settings(repo_id=self.repo_id, private=True)
+    def test_download_private_model(self, api: HfApi):
+        api.update_repo_settings(repo_id=self.repo_id, private=True)
 
         # Test download fails without token
         with SoftTemporaryDirectory() as tmpdir:
-            with self.assertRaises(RepositoryNotFoundError):
+            with pytest.raises(RepositoryNotFoundError):
                 _ = snapshot_download(self.repo_id, revision="main", cache_dir=tmpdir)
 
         # Test we can download with token from cache
         with patch("huggingface_hub.utils._headers.get_token", return_value=TOKEN):
             with SoftTemporaryDirectory() as tmpdir:
                 storage_folder = snapshot_download(self.repo_id, revision="main", cache_dir=tmpdir)
-                self.assertTrue(self.second_commit_hash in storage_folder)
+                assert self.second_commit_hash in storage_folder
 
         # Test we can download with explicit token
         with SoftTemporaryDirectory() as tmpdir:
             storage_folder = snapshot_download(self.repo_id, revision="main", cache_dir=tmpdir, token=TOKEN)
-            self.assertTrue(self.second_commit_hash in storage_folder)
+            assert self.second_commit_hash in storage_folder
 
-        self.api.update_repo_settings(repo_id=self.repo_id, private=False)
+        api.update_repo_settings(repo_id=self.repo_id, private=False)
 
     def test_download_model_local_only(self):
         # Test no branch specified
@@ -123,7 +123,7 @@ class SnapshotDownloadTests(unittest.TestCase):
             snapshot_download(self.repo_id, cache_dir=tmpdir)
             # now load from cache
             storage_folder = snapshot_download(self.repo_id, cache_dir=tmpdir, local_files_only=True)
-            self.assertTrue(self.second_commit_hash in storage_folder)  # has expected revision
+            assert self.second_commit_hash in storage_folder  # has expected revision
 
         # Test with specific revision branch
         with SoftTemporaryDirectory() as tmpdir:
@@ -131,7 +131,7 @@ class SnapshotDownloadTests(unittest.TestCase):
             snapshot_download(self.repo_id, revision="other", cache_dir=tmpdir)
             # now load from cache
             storage_folder = snapshot_download(self.repo_id, revision="other", cache_dir=tmpdir, local_files_only=True)
-            self.assertTrue(self.third_commit_hash in storage_folder)  # has expected revision
+            assert self.third_commit_hash in storage_folder  # has expected revision
 
         # Test with specific revision hash
         with SoftTemporaryDirectory() as tmpdir:
@@ -141,7 +141,7 @@ class SnapshotDownloadTests(unittest.TestCase):
             storage_folder = snapshot_download(
                 self.repo_id, revision=self.first_commit_hash, cache_dir=tmpdir, local_files_only=True
             )
-            self.assertTrue(self.first_commit_hash in storage_folder)  # has expected revision
+            assert self.first_commit_hash in storage_folder  # has expected revision
 
         # Test with local_dir
         with SoftTemporaryDirectory() as tmpdir:
@@ -149,7 +149,7 @@ class SnapshotDownloadTests(unittest.TestCase):
             snapshot_download(self.repo_id, local_dir=tmpdir)
             # now load from local_dir
             storage_folder = snapshot_download(self.repo_id, local_dir=tmpdir, local_files_only=True)
-            self.assertEqual(str(tmpdir), storage_folder)
+            assert str(tmpdir) == storage_folder
 
     def test_download_model_to_local_dir_with_offline_mode(self):
         """Test that an already downloaded folder is returned when there is a connection error"""
@@ -160,7 +160,7 @@ class SnapshotDownloadTests(unittest.TestCase):
             for offline_mode in OfflineSimulationMode:
                 with offline(mode=offline_mode):
                     storage_folder = snapshot_download(self.repo_id, local_dir=tmpdir)
-                    self.assertEqual(str(tmpdir), storage_folder)
+                    assert str(tmpdir) == storage_folder
 
     def test_offline_mode_with_cache_and_empty_local_dir(self):
         """Test that when cache exists but an empty local_dir is specified in offline mode, we raise an error."""
@@ -169,32 +169,32 @@ class SnapshotDownloadTests(unittest.TestCase):
 
             for offline_mode in OfflineSimulationMode:
                 with offline(mode=offline_mode):
-                    with self.assertRaises(LocalEntryNotFoundError):
+                    with pytest.raises(LocalEntryNotFoundError):
                         with SoftTemporaryDirectory() as tmpdir:
                             snapshot_download(self.repo_id, cache_dir=tmpdir_cache, local_dir=tmpdir)
 
     def test_download_model_offline_mode_not_in_local_dir(self):
         """Test when connection error but local_dir is empty."""
         with SoftTemporaryDirectory() as tmpdir:
-            with self.assertRaises(LocalEntryNotFoundError):
+            with pytest.raises(LocalEntryNotFoundError):
                 snapshot_download(self.repo_id, local_dir=tmpdir, local_files_only=True)
 
         for offline_mode in OfflineSimulationMode:
             with offline(mode=offline_mode):
                 with SoftTemporaryDirectory() as tmpdir:
-                    with self.assertRaises(LocalEntryNotFoundError):
+                    with pytest.raises(LocalEntryNotFoundError):
                         snapshot_download(self.repo_id, local_dir=tmpdir)
 
     def test_download_model_offline_mode_not_cached(self):
         """Test when connection error but cache is empty."""
         with SoftTemporaryDirectory() as tmpdir:
-            with self.assertRaises(LocalEntryNotFoundError):
+            with pytest.raises(LocalEntryNotFoundError):
                 snapshot_download(self.repo_id, cache_dir=tmpdir, local_files_only=True)
 
         for offline_mode in OfflineSimulationMode:
             with offline(mode=offline_mode):
                 with SoftTemporaryDirectory() as tmpdir:
-                    with self.assertRaises(LocalEntryNotFoundError):
+                    with pytest.raises(LocalEntryNotFoundError):
                         snapshot_download(self.repo_id, cache_dir=tmpdir)
 
     def test_download_model_local_only_multiple(self):
@@ -207,7 +207,7 @@ class SnapshotDownloadTests(unittest.TestCase):
             # now make sure that loading "main" branch gives correct branch
             # folder name contains the 2nd commit sha and not the 3rd
             storage_folder = snapshot_download(self.repo_id, cache_dir=tmpdir, local_files_only=True)
-            self.assertTrue(self.second_commit_hash in storage_folder)
+            assert self.second_commit_hash in storage_folder
 
     def check_download_model_with_pattern(self, pattern, allow=True):
         # Test `main` branch
@@ -225,10 +225,10 @@ class SnapshotDownloadTests(unittest.TestCase):
 
             # folder contains the three text files but not the .gitattributes
             folder_contents = os.listdir(storage_folder)
-            self.assertEqual(len(folder_contents), 3)
-            self.assertTrue("dummy_file.txt" in folder_contents)
-            self.assertTrue("dummy_file_2.txt" in folder_contents)
-            self.assertTrue(".gitattributes" not in folder_contents)
+            assert len(folder_contents) == 3
+            assert "dummy_file.txt" in folder_contents
+            assert "dummy_file_2.txt" in folder_contents
+            assert ".gitattributes" not in folder_contents
 
     def test_download_model_with_allow_pattern(self):
         self.check_download_model_with_pattern("*.txt")

--- a/tests/test_upload_large_folder.py
+++ b/tests/test_upload_large_folder.py
@@ -153,9 +153,9 @@ class TestValidateUploadLimits:
         assert any("21.0GB" in call or "21GB" in call for call in warning_calls)
         assert any("20GB (recommended limit)" in call for call in warning_calls)
 
-    @patch("huggingface_hub._upload_large_folder.logger")
-    def test_very_large_file_warning(self, mock_logger):
+    def test_very_large_file_warning(self, mocker):
         """Test warning for files exceeding recommended maximum (200GB)."""
+        mock_logger = mocker.patch("huggingface_hub._upload_large_folder.logger")
         # Create a file that's 201 GB
         size_bytes = 201 * 1_000_000_000
         paths = [self.MockPath("huge_file.bin", size_bytes=size_bytes)]
@@ -167,9 +167,9 @@ class TestValidateUploadLimits:
         assert any("201.0GB" in call or "201GB" in call for call in warning_calls)
         assert any("200GB recommended maximum" in call for call in warning_calls)
 
-    @patch("huggingface_hub._upload_large_folder.logger")
-    def test_nested_directory_structure(self, mock_logger):
+    def test_nested_directory_structure(self, mocker):
         """Test correct handling of deeply nested directory structures."""
+        mock_logger = mocker.patch("huggingface_hub._upload_large_folder.logger")
         paths = [
             self.MockPath("a/b/c/d/e/file1.txt"),
             self.MockPath("a/b/c/d/e/file2.txt"),

--- a/tests/test_upload_large_folder.py
+++ b/tests/test_upload_large_folder.py
@@ -1,7 +1,6 @@
 # tests/test_upload_large_folder.py
-import unittest
 from hashlib import sha256
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -70,7 +69,7 @@ def test_build_hacky_operation_preserves_lfs_preupload_state(tmp_path):
     assert operation.path_or_fileobj == b""
 
 
-class TestValidateUploadLimits(unittest.TestCase):
+class TestValidateUploadLimits:
     """Test the _validate_upload_limits function directly."""
 
     class MockPath:
@@ -81,9 +80,9 @@ class TestValidateUploadLimits(unittest.TestCase):
             self.file_path = MagicMock()
             self.file_path.stat.return_value.st_size = size_bytes
 
-    @patch("huggingface_hub._upload_large_folder.logger")
-    def test_no_warnings_under_limits(self, mock_logger):
+    def test_no_warnings_under_limits(self, mocker):
         """Test that no warnings are issued when under all limits."""
+        mock_logger = mocker.patch("huggingface_hub._upload_large_folder.logger")
         paths = [
             self.MockPath("file1.txt"),
             self.MockPath("data/file2.txt"),
@@ -94,9 +93,9 @@ class TestValidateUploadLimits(unittest.TestCase):
         # Should only have info messages, no warnings
         mock_logger.warning.assert_not_called()
 
-    @patch("huggingface_hub._upload_large_folder.logger")
-    def test_warns_too_many_total_files(self, mock_logger):
+    def test_warns_too_many_total_files(self, mocker):
         """Test warning when total files exceed MAX_FILES_PER_REPO."""
+        mock_logger = mocker.patch("huggingface_hub._upload_large_folder.logger")
         # Create a list with more files than the limit
         paths = [self.MockPath(f"file{i}.txt") for i in range(MAX_FILES_PER_REPO + 10)]
         _validate_upload_limits(paths)
@@ -106,9 +105,9 @@ class TestValidateUploadLimits(unittest.TestCase):
         assert any(f"{MAX_FILES_PER_REPO + 10:,} files" in call for call in warning_calls)
         assert any("exceeds the recommended limit" in call for call in warning_calls)
 
-    @patch("huggingface_hub._upload_large_folder.logger")
-    def test_warns_too_many_subdirectories(self, mock_logger):
+    def test_warns_too_many_subdirectories(self, mocker):
         """Test warning when a folder has too many subdirectories."""
+        mock_logger = mocker.patch("huggingface_hub._upload_large_folder.logger")
         # Create files in many subdirectories under "data"
         paths = []
         for i in range(MAX_FILES_PER_FOLDER + 10):
@@ -121,9 +120,9 @@ class TestValidateUploadLimits(unittest.TestCase):
         assert any("data" in call and "subdirectories" in call for call in warning_calls)
         assert any(f"{MAX_FILES_PER_FOLDER + 10:,} subdirectories" in call for call in warning_calls)
 
-    @patch("huggingface_hub._upload_large_folder.logger")
-    def test_counts_files_and_subdirs_separately(self, mock_logger):
+    def test_counts_files_and_subdirs_separately(self, mocker):
         """Test that files and subdirectories are counted separately and correctly."""
+        mock_logger = mocker.patch("huggingface_hub._upload_large_folder.logger")
         # Create a structure with both files and subdirs in "data"
         paths = []
         # Add 5000 files directly in data/
@@ -140,9 +139,9 @@ class TestValidateUploadLimits(unittest.TestCase):
         assert any("data" in call and "10,100 entries" in call for call in warning_calls)
         assert any("5,000 files" in call and "5,100 subdirectories" in call for call in warning_calls)
 
-    @patch("huggingface_hub._upload_large_folder.logger")
-    def test_file_size_decimal_gb(self, mock_logger):
+    def test_file_size_decimal_gb(self, mocker):
         """Test that file sizes are calculated using decimal GB (10^9 bytes)."""
+        mock_logger = mocker.patch("huggingface_hub._upload_large_folder.logger")
         # Create a file that's 21 GB in decimal (21 * 10^9 bytes)
         size_bytes = 21 * 1_000_000_000
         paths = [self.MockPath("large_file.bin", size_bytes=size_bytes)]

--- a/tests/test_utils_assets.py
+++ b/tests/test_utils_assets.py
@@ -6,68 +6,65 @@ import pytest
 from huggingface_hub import cached_assets_path
 
 
-@pytest.mark.usefixtures("fx_cache_dir")
 class TestCacheAssets:
-    cache_dir: Path
-
-    def test_cached_assets_path_with_namespace_and_subfolder(self) -> None:
-        expected_path = self.cache_dir / "datasets" / "SQuAD" / "download"
+    def test_cached_assets_path_with_namespace_and_subfolder(self, tmp_path: Path) -> None:
+        expected_path = tmp_path / "datasets" / "SQuAD" / "download"
         assert not expected_path.is_dir()
 
         path = cached_assets_path(
             library_name="datasets",
             namespace="SQuAD",
             subfolder="download",
-            assets_dir=self.cache_dir,
+            assets_dir=tmp_path,
         )
 
         assert path == expected_path  # Path is generated
         assert path.is_dir()  # And dir is created
 
-    def test_cached_assets_path_without_subfolder(self) -> None:
-        path = cached_assets_path(library_name="datasets", namespace="SQuAD", assets_dir=self.cache_dir)
-        assert path == self.cache_dir / "datasets" / "SQuAD" / "default"
+    def test_cached_assets_path_without_subfolder(self, tmp_path: Path) -> None:
+        path = cached_assets_path(library_name="datasets", namespace="SQuAD", assets_dir=tmp_path)
+        assert path == tmp_path / "datasets" / "SQuAD" / "default"
         assert path.is_dir()
 
-    def test_cached_assets_path_without_namespace(self) -> None:
-        path = cached_assets_path(library_name="datasets", subfolder="download", assets_dir=self.cache_dir)
-        assert path == self.cache_dir / "datasets" / "default" / "download"
+    def test_cached_assets_path_without_namespace(self, tmp_path: Path) -> None:
+        path = cached_assets_path(library_name="datasets", subfolder="download", assets_dir=tmp_path)
+        assert path == tmp_path / "datasets" / "default" / "download"
         assert path.is_dir()
 
-    def test_cached_assets_path_without_namespace_and_subfolder(self) -> None:
-        path = cached_assets_path(library_name="datasets", assets_dir=self.cache_dir)
-        assert path == self.cache_dir / "datasets" / "default" / "default"
+    def test_cached_assets_path_without_namespace_and_subfolder(self, tmp_path: Path) -> None:
+        path = cached_assets_path(library_name="datasets", assets_dir=tmp_path)
+        assert path == tmp_path / "datasets" / "default" / "default"
         assert path.is_dir()
 
-    def test_cached_assets_path_forbidden_symbols(self) -> None:
+    def test_cached_assets_path_forbidden_symbols(self, tmp_path: Path) -> None:
         path = cached_assets_path(
             library_name="ReAlLy dumb",
             namespace="user/repo_name",
             subfolder="this is/not\\clever",
-            assets_dir=self.cache_dir,
+            assets_dir=tmp_path,
         )
-        assert path == self.cache_dir / "ReAlLy--dumb" / "user--repo_name" / "this--is--not--clever"
+        assert path == tmp_path / "ReAlLy--dumb" / "user--repo_name" / "this--is--not--clever"
         assert path.is_dir()
 
-    def test_cached_assets_path_default_assets_dir(self) -> None:
+    def test_cached_assets_path_default_assets_dir(self, tmp_path: Path) -> None:
         with patch(
             "huggingface_hub.utils._cache_assets.HF_ASSETS_CACHE",
-            self.cache_dir,
+            tmp_path,
         ):  # Uses environment variable from HF_ASSETS_CACHE
-            assert cached_assets_path(library_name="datasets") == self.cache_dir / "datasets" / "default" / "default"
+            assert cached_assets_path(library_name="datasets") == tmp_path / "datasets" / "default" / "default"
 
-    def test_cached_assets_path_is_a_file(self) -> None:
-        expected_path = self.cache_dir / "datasets" / "default" / "default"
+    def test_cached_assets_path_is_a_file(self, tmp_path: Path) -> None:
+        expected_path = tmp_path / "datasets" / "default" / "default"
         expected_path.parent.mkdir(parents=True)
         expected_path.touch()  # this should be the generated folder but is a file !
 
         with pytest.raises(ValueError):
-            cached_assets_path(library_name="datasets", assets_dir=self.cache_dir)
+            cached_assets_path(library_name="datasets", assets_dir=tmp_path)
 
-    def test_cached_assets_path_parent_is_a_file(self) -> None:
-        expected_path = self.cache_dir / "datasets" / "default" / "default"
+    def test_cached_assets_path_parent_is_a_file(self, tmp_path: Path) -> None:
+        expected_path = tmp_path / "datasets" / "default" / "default"
         expected_path.parent.parent.mkdir(parents=True)
         expected_path.parent.touch()  # cannot create folder as a parent is a file !
 
         with pytest.raises(ValueError):
-            cached_assets_path(library_name="datasets", assets_dir=self.cache_dir)
+            cached_assets_path(library_name="datasets", assets_dir=tmp_path)

--- a/tests/test_utils_assets.py
+++ b/tests/test_utils_assets.py
@@ -1,4 +1,3 @@
-import unittest
 from pathlib import Path
 from unittest.mock import patch
 
@@ -8,12 +7,12 @@ from huggingface_hub import cached_assets_path
 
 
 @pytest.mark.usefixtures("fx_cache_dir")
-class CacheAssetsTest(unittest.TestCase):
+class TestCacheAssets:
     cache_dir: Path
 
     def test_cached_assets_path_with_namespace_and_subfolder(self) -> None:
         expected_path = self.cache_dir / "datasets" / "SQuAD" / "download"
-        self.assertFalse(expected_path.is_dir())
+        assert not expected_path.is_dir()
 
         path = cached_assets_path(
             library_name="datasets",
@@ -22,23 +21,23 @@ class CacheAssetsTest(unittest.TestCase):
             assets_dir=self.cache_dir,
         )
 
-        self.assertEqual(path, expected_path)  # Path is generated
-        self.assertTrue(path.is_dir())  # And dir is created
+        assert path == expected_path  # Path is generated
+        assert path.is_dir()  # And dir is created
 
     def test_cached_assets_path_without_subfolder(self) -> None:
         path = cached_assets_path(library_name="datasets", namespace="SQuAD", assets_dir=self.cache_dir)
-        self.assertEqual(path, self.cache_dir / "datasets" / "SQuAD" / "default")
-        self.assertTrue(path.is_dir())
+        assert path == self.cache_dir / "datasets" / "SQuAD" / "default"
+        assert path.is_dir()
 
     def test_cached_assets_path_without_namespace(self) -> None:
         path = cached_assets_path(library_name="datasets", subfolder="download", assets_dir=self.cache_dir)
-        self.assertEqual(path, self.cache_dir / "datasets" / "default" / "download")
-        self.assertTrue(path.is_dir())
+        assert path == self.cache_dir / "datasets" / "default" / "download"
+        assert path.is_dir()
 
     def test_cached_assets_path_without_namespace_and_subfolder(self) -> None:
         path = cached_assets_path(library_name="datasets", assets_dir=self.cache_dir)
-        self.assertEqual(path, self.cache_dir / "datasets" / "default" / "default")
-        self.assertTrue(path.is_dir())
+        assert path == self.cache_dir / "datasets" / "default" / "default"
+        assert path.is_dir()
 
     def test_cached_assets_path_forbidden_symbols(self) -> None:
         path = cached_assets_path(
@@ -47,28 +46,22 @@ class CacheAssetsTest(unittest.TestCase):
             subfolder="this is/not\\clever",
             assets_dir=self.cache_dir,
         )
-        self.assertEqual(
-            path,
-            self.cache_dir / "ReAlLy--dumb" / "user--repo_name" / "this--is--not--clever",
-        )
-        self.assertTrue(path.is_dir())
+        assert path == self.cache_dir / "ReAlLy--dumb" / "user--repo_name" / "this--is--not--clever"
+        assert path.is_dir()
 
     def test_cached_assets_path_default_assets_dir(self) -> None:
         with patch(
             "huggingface_hub.utils._cache_assets.HF_ASSETS_CACHE",
             self.cache_dir,
         ):  # Uses environment variable from HF_ASSETS_CACHE
-            self.assertEqual(
-                cached_assets_path(library_name="datasets"),
-                self.cache_dir / "datasets" / "default" / "default",
-            )
+            assert cached_assets_path(library_name="datasets") == self.cache_dir / "datasets" / "default" / "default"
 
     def test_cached_assets_path_is_a_file(self) -> None:
         expected_path = self.cache_dir / "datasets" / "default" / "default"
         expected_path.parent.mkdir(parents=True)
         expected_path.touch()  # this should be the generated folder but is a file !
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             cached_assets_path(library_name="datasets", assets_dir=self.cache_dir)
 
     def test_cached_assets_path_parent_is_a_file(self) -> None:
@@ -76,5 +69,5 @@ class CacheAssetsTest(unittest.TestCase):
         expected_path.parent.parent.mkdir(parents=True)
         expected_path.parent.touch()  # cannot create folder as a parent is a file !
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             cached_assets_path(library_name="datasets", assets_dir=self.cache_dir)

--- a/tests/test_utils_cache.py
+++ b/tests/test_utils_cache.py
@@ -29,54 +29,48 @@ REPO_B_MAIN_HASH = "f1cdcd4641b3ea2dfa8d4333dba1ea3b532735e1"
 REF_1_NAME = "refs/pr/1"
 
 
-@pytest.mark.usefixtures("fx_cache_dir")
 class TestMissingCacheUtils:
-    cache_dir: Path
-
-    def test_cache_dir_is_missing(self) -> None:
+    def test_cache_dir_is_missing(self, tmp_path) -> None:
         """Directory to scan does not exist raises CacheNotFound."""
         with pytest.raises(CacheNotFound):
-            scan_cache_dir(self.cache_dir / "does_not_exist")
+            scan_cache_dir(tmp_path / "does_not_exist")
 
-    def test_cache_dir_is_a_file(self) -> None:
+    def test_cache_dir_is_a_file(self, tmp_path) -> None:
         """Directory to scan is a file raises ValueError."""
-        file_path = self.cache_dir / "file.txt"
+        file_path = tmp_path / "file.txt"
         file_path.touch()
         with pytest.raises(ValueError):
             scan_cache_dir(file_path)
 
 
-@pytest.mark.usefixtures("fx_cache_dir")
 @pytest.mark.production
 class TestValidCacheUtils:
-    cache_dir: Path
-
     @pytest.fixture(autouse=True)
-    def setup(self, fx_cache_dir) -> None:
+    def setup(self, tmp_path) -> None:
         """Set up a clean cache for tests that will remain valid in all tests."""
         # Download latest main
-        snapshot_download(repo_id=MODEL_ID, repo_type="model", cache_dir=self.cache_dir)
+        snapshot_download(repo_id=MODEL_ID, repo_type="model", cache_dir=tmp_path)
 
         # Download latest commit which is same as `main`
-        snapshot_download(repo_id=MODEL_ID, revision=REPO_A_MAIN_HASH, repo_type="model", cache_dir=self.cache_dir)
+        snapshot_download(repo_id=MODEL_ID, revision=REPO_A_MAIN_HASH, repo_type="model", cache_dir=tmp_path)
 
         # Download the first commit
-        snapshot_download(repo_id=MODEL_ID, revision=REPO_A_OTHER_HASH, repo_type="model", cache_dir=self.cache_dir)
+        snapshot_download(repo_id=MODEL_ID, revision=REPO_A_OTHER_HASH, repo_type="model", cache_dir=tmp_path)
 
         # Download from a PR
-        snapshot_download(repo_id=MODEL_ID, revision="refs/pr/1", repo_type="model", cache_dir=self.cache_dir)
+        snapshot_download(repo_id=MODEL_ID, revision="refs/pr/1", repo_type="model", cache_dir=tmp_path)
 
         # Download a Dataset repo from "main"
-        snapshot_download(repo_id=DATASET_ID, revision="main", repo_type="dataset", cache_dir=self.cache_dir)
+        snapshot_download(repo_id=DATASET_ID, revision="main", repo_type="dataset", cache_dir=tmp_path)
 
     @pytest.mark.skipif(os.name == "nt", reason="Windows cache is tested separately")
-    def test_scan_cache_on_valid_cache_unix(self) -> None:
+    def test_scan_cache_on_valid_cache_unix(self, tmp_path) -> None:
         """Scan the cache dir without warnings (on unix-based platform).
 
         This test is duplicated and adapted for Windows in `test_scan_cache_on_valid_cache_windows`.
         Note: Please make sure to update both if any change is made.
         """
-        report = scan_cache_dir(self.cache_dir)
+        report = scan_cache_dir(tmp_path)
 
         # Check general information about downloaded snapshots
         assert report.size_on_disk == 3766
@@ -86,7 +80,7 @@ class TestValidCacheUtils:
         repo_a = [repo for repo in report.repos if repo.repo_id == MODEL_ID][0]
 
         # Check repo A general information
-        repo_a_path = self.cache_dir / MODEL_PATH
+        repo_a_path = tmp_path / MODEL_PATH
         assert repo_a.repo_id == MODEL_ID
         assert repo_a.repo_type == "model"
         assert repo_a.repo_path == repo_a_path
@@ -145,7 +139,7 @@ class TestValidCacheUtils:
         assert pr_1_readme_file.blob_path == main_readme_blob_path  # same
 
     @pytest.mark.skipif(os.name != "nt", reason="Windows cache is tested separately")
-    def test_scan_cache_on_valid_cache_windows(self) -> None:
+    def test_scan_cache_on_valid_cache_windows(self, tmp_path) -> None:
         """Scan the cache dir without warnings (on Windows).
 
         Windows tests do not use symlinks which leads to duplication in the cache.
@@ -153,7 +147,7 @@ class TestValidCacheUtils:
         tweaks specific to windows.
         Note: Please make sure to update both if any change is made.
         """
-        report = scan_cache_dir(self.cache_dir)
+        report = scan_cache_dir(tmp_path)
 
         # Check general information about downloaded snapshots
         assert report.size_on_disk == 6728
@@ -163,7 +157,7 @@ class TestValidCacheUtils:
         repo_a = [repo for repo in report.repos if repo.repo_id == MODEL_ID][0]
 
         # Check repo A general information
-        repo_a_path = self.cache_dir / MODEL_PATH
+        repo_a_path = tmp_path / MODEL_PATH
         assert repo_a.repo_id == MODEL_ID
         assert repo_a.repo_type == "model"
         assert repo_a.repo_path == repo_a_path
@@ -225,12 +219,9 @@ class TestValidCacheUtils:
         assert pr_1_readme_file.blob_path != main_readme_file.blob_path  # Windows-specific: different as well
 
 
-@pytest.mark.usefixtures("fx_cache_dir")
 class TestIgnoredCacheFiles:
-    cache_dir: Path
-
-    def test_ignore_os_metadata_files_in_cache_structure(self) -> None:
-        repo_path = self.cache_dir / "models--foo--bar"
+    def test_ignore_os_metadata_files_in_cache_structure(self, tmp_path) -> None:
+        repo_path = tmp_path / "models--foo--bar"
         refs_path = repo_path / "refs"
         snapshots_path = repo_path / "snapshots"
         revision_path = snapshots_path / "123"
@@ -240,41 +231,39 @@ class TestIgnoredCacheFiles:
 
         ignored_files = [".DS_Store", "Thumbs.db", "desktop.ini"]
         for filename in ignored_files:
-            (self.cache_dir / filename).touch()
+            (tmp_path / filename).touch()
             (refs_path / filename).touch()
             (snapshots_path / filename).touch()
 
-        report = scan_cache_dir(self.cache_dir)
+        report = scan_cache_dir(tmp_path)
 
         assert len(report.warnings) == 0
         assert len(report.repos) == 1
 
 
-@pytest.mark.usefixtures("fx_cache_dir")
 @pytest.mark.production
 class TestCorruptedCacheUtils:
-    cache_dir: Path
     repo_path: Path
     refs_path: Path
     snapshots_path: Path
 
     @pytest.fixture(autouse=True)
-    def setup(self, fx_cache_dir) -> None:
+    def setup(self, tmp_path) -> None:
         """Set up a clean cache for tests that will get corrupted/modified in tests."""
         # Download latest main
-        snapshot_download(repo_id=MODEL_ID, repo_type="model", cache_dir=self.cache_dir)
+        snapshot_download(repo_id=MODEL_ID, repo_type="model", cache_dir=tmp_path)
 
-        self.repo_path = self.cache_dir / MODEL_PATH
+        self.repo_path = tmp_path / MODEL_PATH
         self.refs_path = self.repo_path / "refs"
         self.snapshots_path = self.repo_path / "snapshots"
 
-    def test_repo_path_not_valid_dir(self) -> None:
+    def test_repo_path_not_valid_dir(self, tmp_path) -> None:
         """Test if found a not valid path in cache dir."""
         # Case 1: a file
-        repo_path = self.cache_dir / "a_file_that_should_not_be_there.txt"
+        repo_path = tmp_path / "a_file_that_should_not_be_there.txt"
         repo_path.touch()
 
-        report = scan_cache_dir(self.cache_dir)
+        report = scan_cache_dir(tmp_path)
         assert len(report.repos) == 1  # Scan still worked !
 
         assert len(report.warnings) == 1
@@ -282,10 +271,10 @@ class TestCorruptedCacheUtils:
 
         # Case 2: a folder with wrong naming
         os.remove(repo_path)
-        repo_path = self.cache_dir / "a_folder_that_should_not_be_there"
+        repo_path = tmp_path / "a_folder_that_should_not_be_there"
         repo_path.mkdir()
 
-        report = scan_cache_dir(self.cache_dir)
+        report = scan_cache_dir(tmp_path)
         assert len(report.repos) == 1  # Scan still worked !
 
         assert len(report.warnings) == 1
@@ -293,10 +282,10 @@ class TestCorruptedCacheUtils:
 
         # Case 3: good naming but not a dataset/model/space
         rmtree_with_retry(repo_path)
-        repo_path = self.cache_dir / "not-models--t5-small"
+        repo_path = tmp_path / "not-models--t5-small"
         repo_path.mkdir()
 
-        report = scan_cache_dir(self.cache_dir)
+        report = scan_cache_dir(tmp_path)
         assert len(report.repos) == 1  # Scan still worked !
 
         assert len(report.warnings) == 1
@@ -305,28 +294,28 @@ class TestCorruptedCacheUtils:
             == f"Repo type must be `dataset`, `model` or `space`, found `not-model` ({repo_path})."
         )
 
-    def test_snapshots_path_not_found(self) -> None:
+    def test_snapshots_path_not_found(self, tmp_path) -> None:
         """Test if snapshots directory is missing in cached repo."""
         rmtree_with_retry(self.snapshots_path)
 
-        report = scan_cache_dir(self.cache_dir)
+        report = scan_cache_dir(tmp_path)
         assert len(report.repos) == 0  # Failed
 
         assert len(report.warnings) == 1
         assert str(report.warnings[0]) == f"Snapshots dir doesn't exist in cached repo: {self.snapshots_path}"
 
-    def test_file_in_snapshots_dir(self) -> None:
+    def test_file_in_snapshots_dir(self, tmp_path) -> None:
         """Test if snapshots directory contains a file."""
         wrong_file_path = self.snapshots_path / "should_not_be_there"
         wrong_file_path.touch()
 
-        report = scan_cache_dir(self.cache_dir)
+        report = scan_cache_dir(tmp_path)
         assert len(report.repos) == 0  # Failed
 
         assert len(report.warnings) == 1
         assert str(report.warnings[0]) == f"Snapshots folder corrupted. Found a file: {wrong_file_path}"
 
-    def test_snapshot_with_no_blob_files(self) -> None:
+    def test_snapshot_with_no_blob_files(self, tmp_path) -> None:
         """Test if a snapshot directory (e.g. a cached revision) is empty."""
         for revision_path in self.snapshots_path.glob("*"):
             # Delete content of the revision
@@ -334,7 +323,7 @@ class TestCorruptedCacheUtils:
             revision_path.mkdir()
 
         # Scan
-        report = scan_cache_dir(self.cache_dir)
+        report = scan_cache_dir(tmp_path)
 
         # Get single repo
         assert len(report.warnings) == 0  # Did not fail
@@ -350,14 +339,14 @@ class TestCorruptedCacheUtils:
         assert revision_report.nb_files == 0
         assert revision_report.last_modified == revision_path.stat().st_mtime
 
-    def test_repo_with_no_snapshots(self) -> None:
+    def test_repo_with_no_snapshots(self, tmp_path) -> None:
         """Test if the snapshot directory exists but is empty."""
         rmtree_with_retry(self.refs_path)
         rmtree_with_retry(self.snapshots_path)
         self.snapshots_path.mkdir()
 
         # Scan
-        report = scan_cache_dir(self.cache_dir)
+        report = scan_cache_dir(tmp_path)
 
         # Get single repo
         assert len(report.warnings) == 0  # Did not fail
@@ -370,13 +359,13 @@ class TestCorruptedCacheUtils:
         assert repo_report.last_modified == self.repo_path.stat().st_mtime
         assert repo_report.last_accessed == self.repo_path.stat().st_atime
 
-    def test_ref_to_missing_revision(self) -> None:
+    def test_ref_to_missing_revision(self, tmp_path) -> None:
         """Test if a `refs` points to a missing revision."""
         new_ref = self.repo_path / "refs" / "not_main"
         with new_ref.open("w") as f:
             f.write("revision_hash_that_does_not_exist")
 
-        report = scan_cache_dir(self.cache_dir)
+        report = scan_cache_dir(tmp_path)
         assert len(report.repos) == 0  # Failed
 
         assert len(report.warnings) == 1
@@ -387,12 +376,12 @@ class TestCorruptedCacheUtils:
         )
 
     @pytest.mark.skipif(os.name == "nt", reason="Last modified/last accessed work a bit differently on Windows.")
-    def test_scan_cache_last_modified_and_last_accessed(self) -> None:
+    def test_scan_cache_last_modified_and_last_accessed(self, tmp_path) -> None:
         """Scan the last_modified and last_accessed properties when scanning."""
         TIME_GAP = 0.1
 
         # Make a first scan
-        report_1 = scan_cache_dir(self.cache_dir)
+        report_1 = scan_cache_dir(tmp_path)
 
         # Values from first report
         repo_1 = list(report_1.repos)[0]
@@ -416,7 +405,7 @@ class TestCorruptedCacheUtils:
 
         # Sleep and re-scan
         time.sleep(TIME_GAP)
-        report_2 = scan_cache_dir(self.cache_dir)
+        report_2 = scan_cache_dir(tmp_path)
 
         # Values from second report
         repo_2 = list(report_2.repos)[0]
@@ -592,15 +581,12 @@ class TestDeleteRevisionsDryRun:
         assert records[0].message == "Revision(s) not found - cannot delete them: abcdef123456789"
 
 
-@pytest.mark.usefixtures("fx_cache_dir")
 class TestDeleteStrategyExecute:
-    cache_dir: Path
-
-    def test_execute(self) -> None:
+    def test_execute(self, tmp_path) -> None:
         # Repo folders
-        repo_A_path = self.cache_dir / "repo_A"
+        repo_A_path = tmp_path / "repo_A"
         repo_A_path.mkdir()
-        repo_B_path = self.cache_dir / "repo_B"
+        repo_B_path = tmp_path / "repo_B"
         repo_B_path.mkdir()
 
         # Refs files in repo_B
@@ -655,20 +641,17 @@ class TestDeleteStrategyExecute:
         assert not snapshot_2.exists()
 
 
-@pytest.mark.usefixtures("fx_cache_dir")
 class TestTryDeletePath:
-    cache_dir: Path
-
-    def test_delete_path_on_file_success(self) -> None:
+    def test_delete_path_on_file_success(self, tmp_path) -> None:
         """Successfully delete a local file."""
-        file_path = self.cache_dir / "file.txt"
+        file_path = tmp_path / "file.txt"
         file_path.touch()
         _try_delete_path(file_path, path_type="TYPE")
         assert not file_path.exists()
 
-    def test_delete_path_on_folder_success(self) -> None:
+    def test_delete_path_on_folder_success(self, tmp_path) -> None:
         """Successfully delete a local folder."""
-        dir_path = self.cache_dir / "something"
+        dir_path = tmp_path / "something"
         subdir_path = dir_path / "bar"
         subdir_path.mkdir(parents=True)  # subfolder
 
@@ -685,9 +668,9 @@ class TestTryDeletePath:
         assert not file_path_1.exists()
         assert not file_path_2.exists()
 
-    def test_delete_path_on_missing_file(self, caplog) -> None:
+    def test_delete_path_on_missing_file(self, caplog, tmp_path) -> None:
         """Try to delete a missing file."""
-        file_path = self.cache_dir / "file.txt"
+        file_path = tmp_path / "file.txt"
 
         with caplog.at_level(logging.WARNING, logger="huggingface_hub"):
             _try_delete_path(file_path, path_type="TYPE")
@@ -697,9 +680,9 @@ class TestTryDeletePath:
         assert len(output) > 0
         assert any(f"Couldn't delete TYPE: file not found ({file_path})" in log for log in output)
 
-    def test_delete_path_on_missing_folder(self, caplog) -> None:
+    def test_delete_path_on_missing_folder(self, caplog, tmp_path) -> None:
         """Try to delete a missing folder."""
-        dir_path = self.cache_dir / "folder"
+        dir_path = tmp_path / "folder"
 
         with caplog.at_level(logging.WARNING, logger="huggingface_hub"):
             _try_delete_path(dir_path, path_type="TYPE")
@@ -710,9 +693,9 @@ class TestTryDeletePath:
         assert any(f"Couldn't delete TYPE: file not found ({dir_path})" in log for log in output)
 
     @pytest.mark.skipif(os.name == "nt", reason="Permissions are handled differently on Windows.")
-    def test_delete_path_on_local_folder_with_wrong_permission(self, caplog) -> None:
+    def test_delete_path_on_local_folder_with_wrong_permission(self, caplog, tmp_path) -> None:
         """Try to delete a local folder that is protected."""
-        dir_path = self.cache_dir / "something"
+        dir_path = tmp_path / "something"
         dir_path.mkdir()
         file_path_1 = dir_path / "file.txt"  # file at root
         file_path_1.touch()

--- a/tests/test_utils_cache.py
+++ b/tests/test_utils_cache.py
@@ -52,7 +52,7 @@ class TestValidCacheUtils:
     cache_dir: Path
 
     @pytest.fixture(autouse=True)
-    def setup(self) -> None:
+    def setup(self, fx_cache_dir) -> None:
         """Set up a clean cache for tests that will remain valid in all tests."""
         # Download latest main
         snapshot_download(repo_id=MODEL_ID, repo_type="model", cache_dir=self.cache_dir)
@@ -259,7 +259,7 @@ class TestCorruptedCacheUtils:
     snapshots_path: Path
 
     @pytest.fixture(autouse=True)
-    def setup(self) -> None:
+    def setup(self, fx_cache_dir) -> None:
         """Set up a clean cache for tests that will get corrupted/modified in tests."""
         # Download latest main
         snapshot_download(repo_id=MODEL_ID, repo_type="model", cache_dir=self.cache_dir)

--- a/tests/test_utils_cache.py
+++ b/tests/test_utils_cache.py
@@ -1,6 +1,6 @@
+import logging
 import os
 import time
-import unittest
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -10,7 +10,7 @@ from huggingface_hub._snapshot_download import snapshot_download
 from huggingface_hub.utils import DeleteCacheStrategy, HFCacheInfo, _format_size, scan_cache_dir
 from huggingface_hub.utils._cache_manager import CacheNotFound, _try_delete_path
 
-from .testing_utils import rmtree_with_retry, skip_on_windows, with_production_testing
+from .testing_utils import rmtree_with_retry
 
 
 # On production server to avoid recreating them all the time
@@ -30,26 +30,29 @@ REF_1_NAME = "refs/pr/1"
 
 
 @pytest.mark.usefixtures("fx_cache_dir")
-class TestMissingCacheUtils(unittest.TestCase):
+class TestMissingCacheUtils:
     cache_dir: Path
 
     def test_cache_dir_is_missing(self) -> None:
         """Directory to scan does not exist raises CacheNotFound."""
-        self.assertRaises(CacheNotFound, scan_cache_dir, self.cache_dir / "does_not_exist")
+        with pytest.raises(CacheNotFound):
+            scan_cache_dir(self.cache_dir / "does_not_exist")
 
     def test_cache_dir_is_a_file(self) -> None:
         """Directory to scan is a file raises ValueError."""
         file_path = self.cache_dir / "file.txt"
         file_path.touch()
-        self.assertRaises(ValueError, scan_cache_dir, file_path)
+        with pytest.raises(ValueError):
+            scan_cache_dir(file_path)
 
 
 @pytest.mark.usefixtures("fx_cache_dir")
-class TestValidCacheUtils(unittest.TestCase):
+@pytest.mark.production
+class TestValidCacheUtils:
     cache_dir: Path
 
-    @with_production_testing
-    def setUp(self) -> None:
+    @pytest.fixture(autouse=True)
+    def setup(self) -> None:
         """Set up a clean cache for tests that will remain valid in all tests."""
         # Download latest main
         snapshot_download(repo_id=MODEL_ID, repo_type="model", cache_dir=self.cache_dir)
@@ -66,7 +69,7 @@ class TestValidCacheUtils(unittest.TestCase):
         # Download a Dataset repo from "main"
         snapshot_download(repo_id=DATASET_ID, revision="main", repo_type="dataset", cache_dir=self.cache_dir)
 
-    @unittest.skipIf(os.name == "nt", "Windows cache is tested separately")
+    @pytest.mark.skipif(os.name == "nt", reason="Windows cache is tested separately")
     def test_scan_cache_on_valid_cache_unix(self) -> None:
         """Scan the cache dir without warnings (on unix-based platform).
 
@@ -76,62 +79,60 @@ class TestValidCacheUtils(unittest.TestCase):
         report = scan_cache_dir(self.cache_dir)
 
         # Check general information about downloaded snapshots
-        self.assertEqual(report.size_on_disk, 3766)
-        self.assertEqual(len(report.repos), 2)  # Model and dataset
-        self.assertEqual(len(report.warnings), 0)  # Repos are valid
+        assert report.size_on_disk == 3766
+        assert len(report.repos) == 2  # Model and dataset
+        assert len(report.warnings) == 0  # Repos are valid
 
         repo_a = [repo for repo in report.repos if repo.repo_id == MODEL_ID][0]
 
         # Check repo A general information
         repo_a_path = self.cache_dir / MODEL_PATH
-        self.assertEqual(repo_a.repo_id, MODEL_ID)
-        self.assertEqual(repo_a.repo_type, "model")
-        self.assertEqual(repo_a.repo_path, repo_a_path)
+        assert repo_a.repo_id == MODEL_ID
+        assert repo_a.repo_type == "model"
+        assert repo_a.repo_path == repo_a_path
 
         # 4 downloads but 3 revisions because "main" and REPO_A_MAIN_HASH are the same
-        self.assertEqual(len(repo_a.revisions), 3)
-        self.assertEqual(
-            {rev.commit_hash for rev in repo_a.revisions},
-            {REPO_A_MAIN_HASH, REPO_A_PR_1_HASH, REPO_A_OTHER_HASH},
-        )
+        assert len(repo_a.revisions) == 3
+        assert {rev.commit_hash for rev in repo_a.revisions} == {
+            REPO_A_MAIN_HASH,
+            REPO_A_PR_1_HASH,
+            REPO_A_OTHER_HASH,
+        }
 
         # Repo size on disk is less than sum of revisions !
-        self.assertEqual(repo_a.size_on_disk, 1501)
-        self.assertEqual(sum(rev.size_on_disk for rev in repo_a.revisions), 4463)
+        assert repo_a.size_on_disk == 1501
+        assert sum(rev.size_on_disk for rev in repo_a.revisions) == 4463
 
         # Repo nb files is less than sum of revisions !
-        self.assertEqual(repo_a.nb_files, 3)
-        self.assertEqual(sum(rev.nb_files for rev in repo_a.revisions), 6)
+        assert repo_a.nb_files == 3
+        assert sum(rev.nb_files for rev in repo_a.revisions) == 6
 
         # 2 REFS in the repo: "main" and "refs/pr/1"
         # We could have added a tag as well
-        self.assertEqual(set(repo_a.refs.keys()), {"main", REF_1_NAME})
-        self.assertEqual(repo_a.refs["main"].commit_hash, REPO_A_MAIN_HASH)
-        self.assertEqual(repo_a.refs[REF_1_NAME].commit_hash, REPO_A_PR_1_HASH)
+        assert set(repo_a.refs.keys()) == {"main", REF_1_NAME}
+        assert repo_a.refs["main"].commit_hash == REPO_A_MAIN_HASH
+        assert repo_a.refs[REF_1_NAME].commit_hash == REPO_A_PR_1_HASH
 
         # Check "main" revision information
         main_revision = repo_a.refs["main"]
         main_revision_path = repo_a_path / "snapshots" / REPO_A_MAIN_HASH
 
-        self.assertEqual(main_revision.commit_hash, REPO_A_MAIN_HASH)
-        self.assertEqual(main_revision.snapshot_path, main_revision_path)
-        self.assertEqual(main_revision.refs, {"main"})
+        assert main_revision.commit_hash == REPO_A_MAIN_HASH
+        assert main_revision.snapshot_path == main_revision_path
+        assert main_revision.refs == {"main"}
 
         # Same nb of files and size on disk that the sum
-        self.assertEqual(main_revision.nb_files, len(main_revision.files))
-        self.assertEqual(
-            main_revision.size_on_disk,
-            sum(file.size_on_disk for file in main_revision.files),
-        )
+        assert main_revision.nb_files == len(main_revision.files)
+        assert main_revision.size_on_disk == sum(file.size_on_disk for file in main_revision.files)
 
         # Check readme file from "main" revision
         main_readme_file = [file for file in main_revision.files if file.file_name == "README.md"][0]
         main_readme_file_path = main_revision_path / "README.md"
         main_readme_blob_path = repo_a_path / "blobs" / REPO_A_MAIN_README_BLOB_HASH
 
-        self.assertEqual(main_readme_file.file_name, "README.md")
-        self.assertEqual(main_readme_file.file_path, main_readme_file_path)
-        self.assertEqual(main_readme_file.blob_path, main_readme_blob_path)
+        assert main_readme_file.file_name == "README.md"
+        assert main_readme_file.file_path == main_readme_file_path
+        assert main_readme_file.blob_path == main_readme_blob_path
 
         # Check readme file from "refs/pr/1" revision
         pr_1_revision = repo_a.refs[REF_1_NAME]
@@ -140,10 +141,10 @@ class TestValidCacheUtils(unittest.TestCase):
         pr_1_readme_file_path = pr_1_revision_path / "README.md"
 
         # file_path in "refs/pr/1" revision is different from "main" but same blob path
-        self.assertEqual(pr_1_readme_file.file_path, pr_1_readme_file_path)  # different
-        self.assertEqual(pr_1_readme_file.blob_path, main_readme_blob_path)  # same
+        assert pr_1_readme_file.file_path == pr_1_readme_file_path  # different
+        assert pr_1_readme_file.blob_path == main_readme_blob_path  # same
 
-    @unittest.skipIf(os.name != "nt", "Windows cache is tested separately")
+    @pytest.mark.skipif(os.name != "nt", reason="Windows cache is tested separately")
     def test_scan_cache_on_valid_cache_windows(self) -> None:
         """Scan the cache dir without warnings (on Windows).
 
@@ -155,64 +156,62 @@ class TestValidCacheUtils(unittest.TestCase):
         report = scan_cache_dir(self.cache_dir)
 
         # Check general information about downloaded snapshots
-        self.assertEqual(report.size_on_disk, 6728)
-        self.assertEqual(len(report.repos), 2)  # Model and dataset
-        self.assertEqual(len(report.warnings), 0)  # Repos are valid
+        assert report.size_on_disk == 6728
+        assert len(report.repos) == 2  # Model and dataset
+        assert len(report.warnings) == 0  # Repos are valid
 
         repo_a = [repo for repo in report.repos if repo.repo_id == MODEL_ID][0]
 
         # Check repo A general information
         repo_a_path = self.cache_dir / MODEL_PATH
-        self.assertEqual(repo_a.repo_id, MODEL_ID)
-        self.assertEqual(repo_a.repo_type, "model")
-        self.assertEqual(repo_a.repo_path, repo_a_path)
+        assert repo_a.repo_id == MODEL_ID
+        assert repo_a.repo_type == "model"
+        assert repo_a.repo_path == repo_a_path
 
         # 4 downloads but 3 revisions because "main" and REPO_A_MAIN_HASH are the same
-        self.assertEqual(len(repo_a.revisions), 3)
-        self.assertEqual(
-            {rev.commit_hash for rev in repo_a.revisions},
-            {REPO_A_MAIN_HASH, REPO_A_PR_1_HASH, REPO_A_OTHER_HASH},
-        )
+        assert len(repo_a.revisions) == 3
+        assert {rev.commit_hash for rev in repo_a.revisions} == {
+            REPO_A_MAIN_HASH,
+            REPO_A_PR_1_HASH,
+            REPO_A_OTHER_HASH,
+        }
 
         # Repo size on disk is equal to the sum of revisions (no symlinks)
-        self.assertEqual(repo_a.size_on_disk, 4463)  # Windows-specific
-        self.assertEqual(sum(rev.size_on_disk for rev in repo_a.revisions), 4463)
+        assert repo_a.size_on_disk == 4463  # Windows-specific
+        assert sum(rev.size_on_disk for rev in repo_a.revisions) == 4463
 
         # Repo nb files is equal to the sum of revisions !
-        self.assertEqual(repo_a.nb_files, 6)  # Windows-specific
-        self.assertEqual(sum(rev.nb_files for rev in repo_a.revisions), 6)
+        assert repo_a.nb_files == 6  # Windows-specific
+        assert sum(rev.nb_files for rev in repo_a.revisions) == 6
 
         # 2 REFS in the repo: "main" and "refs/pr/1"
         # We could have added a tag as well
         REF_1_NAME = "refs\\pr\\1"  # Windows-specific
-        self.assertEqual(set(repo_a.refs.keys()), {"main", REF_1_NAME})
-        self.assertEqual(repo_a.refs["main"].commit_hash, REPO_A_MAIN_HASH)
-        self.assertEqual(repo_a.refs[REF_1_NAME].commit_hash, REPO_A_PR_1_HASH)
+        assert set(repo_a.refs.keys()) == {"main", REF_1_NAME}
+        assert repo_a.refs["main"].commit_hash == REPO_A_MAIN_HASH
+        assert repo_a.refs[REF_1_NAME].commit_hash == REPO_A_PR_1_HASH
 
         # Check "main" revision information
         main_revision = repo_a.refs["main"]
         main_revision_path = repo_a_path / "snapshots" / REPO_A_MAIN_HASH
 
-        self.assertEqual(main_revision.commit_hash, REPO_A_MAIN_HASH)
-        self.assertEqual(main_revision.snapshot_path, main_revision_path)
-        self.assertEqual(main_revision.refs, {"main"})
+        assert main_revision.commit_hash == REPO_A_MAIN_HASH
+        assert main_revision.snapshot_path == main_revision_path
+        assert main_revision.refs == {"main"}
 
         # Same nb of files and size on disk that the sum
-        self.assertEqual(main_revision.nb_files, len(main_revision.files))
-        self.assertEqual(
-            main_revision.size_on_disk,
-            sum(file.size_on_disk for file in main_revision.files),
-        )
+        assert main_revision.nb_files == len(main_revision.files)
+        assert main_revision.size_on_disk == sum(file.size_on_disk for file in main_revision.files)
 
         # Check readme file from "main" revision
         main_readme_file = [file for file in main_revision.files if file.file_name == "README.md"][0]
         main_readme_file_path = main_revision_path / "README.md"
         main_readme_blob_path = repo_a_path / "blobs" / REPO_A_MAIN_README_BLOB_HASH
 
-        self.assertEqual(main_readme_file.file_name, "README.md")
-        self.assertEqual(main_readme_file.file_path, main_readme_file_path)
-        self.assertEqual(main_readme_file.blob_path, main_readme_file_path)  # Windows-specific: no blob file
-        self.assertFalse(main_readme_blob_path.exists())  # Windows-specific
+        assert main_readme_file.file_name == "README.md"
+        assert main_readme_file.file_path == main_readme_file_path
+        assert main_readme_file.blob_path == main_readme_file_path  # Windows-specific: no blob file
+        assert not main_readme_blob_path.exists()  # Windows-specific
 
         # Check readme file from "refs/pr/1" revision
         pr_1_revision = repo_a.refs[REF_1_NAME]
@@ -222,14 +221,12 @@ class TestValidCacheUtils(unittest.TestCase):
 
         # file_path in "refs/pr/1" revision is different from "main"
         # Windows-specific: even blob path is different
-        self.assertEqual(pr_1_readme_file.file_path, pr_1_readme_file_path)
-        self.assertNotEqual(  # Windows-specific: different as well
-            pr_1_readme_file.blob_path, main_readme_file.blob_path
-        )
+        assert pr_1_readme_file.file_path == pr_1_readme_file_path
+        assert pr_1_readme_file.blob_path != main_readme_file.blob_path  # Windows-specific: different as well
 
 
 @pytest.mark.usefixtures("fx_cache_dir")
-class TestIgnoredCacheFiles(unittest.TestCase):
+class TestIgnoredCacheFiles:
     cache_dir: Path
 
     def test_ignore_os_metadata_files_in_cache_structure(self) -> None:
@@ -249,19 +246,20 @@ class TestIgnoredCacheFiles(unittest.TestCase):
 
         report = scan_cache_dir(self.cache_dir)
 
-        self.assertEqual(len(report.warnings), 0)
-        self.assertEqual(len(report.repos), 1)
+        assert len(report.warnings) == 0
+        assert len(report.repos) == 1
 
 
 @pytest.mark.usefixtures("fx_cache_dir")
-class TestCorruptedCacheUtils(unittest.TestCase):
+@pytest.mark.production
+class TestCorruptedCacheUtils:
     cache_dir: Path
     repo_path: Path
     refs_path: Path
     snapshots_path: Path
 
-    @with_production_testing
-    def setUp(self) -> None:
+    @pytest.fixture(autouse=True)
+    def setup(self) -> None:
         """Set up a clean cache for tests that will get corrupted/modified in tests."""
         # Download latest main
         snapshot_download(repo_id=MODEL_ID, repo_type="model", cache_dir=self.cache_dir)
@@ -277,10 +275,10 @@ class TestCorruptedCacheUtils(unittest.TestCase):
         repo_path.touch()
 
         report = scan_cache_dir(self.cache_dir)
-        self.assertEqual(len(report.repos), 1)  # Scan still worked !
+        assert len(report.repos) == 1  # Scan still worked !
 
-        self.assertEqual(len(report.warnings), 1)
-        self.assertEqual(str(report.warnings[0]), f"Repo path is not a directory: {repo_path}")
+        assert len(report.warnings) == 1
+        assert str(report.warnings[0]) == f"Repo path is not a directory: {repo_path}"
 
         # Case 2: a folder with wrong naming
         os.remove(repo_path)
@@ -288,13 +286,10 @@ class TestCorruptedCacheUtils(unittest.TestCase):
         repo_path.mkdir()
 
         report = scan_cache_dir(self.cache_dir)
-        self.assertEqual(len(report.repos), 1)  # Scan still worked !
+        assert len(report.repos) == 1  # Scan still worked !
 
-        self.assertEqual(len(report.warnings), 1)
-        self.assertEqual(
-            str(report.warnings[0]),
-            f"Repo path is not a valid HuggingFace cache directory: {repo_path}",
-        )
+        assert len(report.warnings) == 1
+        assert str(report.warnings[0]) == f"Repo path is not a valid HuggingFace cache directory: {repo_path}"
 
         # Case 3: good naming but not a dataset/model/space
         rmtree_with_retry(repo_path)
@@ -302,12 +297,12 @@ class TestCorruptedCacheUtils(unittest.TestCase):
         repo_path.mkdir()
 
         report = scan_cache_dir(self.cache_dir)
-        self.assertEqual(len(report.repos), 1)  # Scan still worked !
+        assert len(report.repos) == 1  # Scan still worked !
 
-        self.assertEqual(len(report.warnings), 1)
-        self.assertEqual(
-            str(report.warnings[0]),
-            f"Repo type must be `dataset`, `model` or `space`, found `not-model` ({repo_path}).",
+        assert len(report.warnings) == 1
+        assert (
+            str(report.warnings[0])
+            == f"Repo type must be `dataset`, `model` or `space`, found `not-model` ({repo_path})."
         )
 
     def test_snapshots_path_not_found(self) -> None:
@@ -315,13 +310,10 @@ class TestCorruptedCacheUtils(unittest.TestCase):
         rmtree_with_retry(self.snapshots_path)
 
         report = scan_cache_dir(self.cache_dir)
-        self.assertEqual(len(report.repos), 0)  # Failed
+        assert len(report.repos) == 0  # Failed
 
-        self.assertEqual(len(report.warnings), 1)
-        self.assertEqual(
-            str(report.warnings[0]),
-            f"Snapshots dir doesn't exist in cached repo: {self.snapshots_path}",
-        )
+        assert len(report.warnings) == 1
+        assert str(report.warnings[0]) == f"Snapshots dir doesn't exist in cached repo: {self.snapshots_path}"
 
     def test_file_in_snapshots_dir(self) -> None:
         """Test if snapshots directory contains a file."""
@@ -329,13 +321,10 @@ class TestCorruptedCacheUtils(unittest.TestCase):
         wrong_file_path.touch()
 
         report = scan_cache_dir(self.cache_dir)
-        self.assertEqual(len(report.repos), 0)  # Failed
+        assert len(report.repos) == 0  # Failed
 
-        self.assertEqual(len(report.warnings), 1)
-        self.assertEqual(
-            str(report.warnings[0]),
-            f"Snapshots folder corrupted. Found a file: {wrong_file_path}",
-        )
+        assert len(report.warnings) == 1
+        assert str(report.warnings[0]) == f"Snapshots folder corrupted. Found a file: {wrong_file_path}"
 
     def test_snapshot_with_no_blob_files(self) -> None:
         """Test if a snapshot directory (e.g. a cached revision) is empty."""
@@ -348,18 +337,18 @@ class TestCorruptedCacheUtils(unittest.TestCase):
         report = scan_cache_dir(self.cache_dir)
 
         # Get single repo
-        self.assertEqual(len(report.warnings), 0)  # Did not fail
-        self.assertEqual(len(report.repos), 1)
+        assert len(report.warnings) == 0  # Did not fail
+        assert len(report.repos) == 1
         repo_report = list(report.repos)[0]
 
         # Repo report is empty
-        self.assertEqual(repo_report.size_on_disk, 0)
-        self.assertEqual(len(repo_report.revisions), 1)
+        assert repo_report.size_on_disk == 0
+        assert len(repo_report.revisions) == 1
         revision_report = list(repo_report.revisions)[0]
 
         # No files in revision so last_modified is the one from the revision folder
-        self.assertEqual(revision_report.nb_files, 0)
-        self.assertEqual(revision_report.last_modified, revision_path.stat().st_mtime)
+        assert revision_report.nb_files == 0
+        assert revision_report.last_modified == revision_path.stat().st_mtime
 
     def test_repo_with_no_snapshots(self) -> None:
         """Test if the snapshot directory exists but is empty."""
@@ -371,15 +360,15 @@ class TestCorruptedCacheUtils(unittest.TestCase):
         report = scan_cache_dir(self.cache_dir)
 
         # Get single repo
-        self.assertEqual(len(report.warnings), 0)  # Did not fail
-        self.assertEqual(len(report.repos), 1)
+        assert len(report.warnings) == 0  # Did not fail
+        assert len(report.repos) == 1
         repo_report = list(report.repos)[0]
 
         # No revisions in repos so last_modified is the one from the repo folder
-        self.assertEqual(repo_report.size_on_disk, 0)
-        self.assertEqual(len(repo_report.revisions), 0)
-        self.assertEqual(repo_report.last_modified, self.repo_path.stat().st_mtime)
-        self.assertEqual(repo_report.last_accessed, self.repo_path.stat().st_atime)
+        assert repo_report.size_on_disk == 0
+        assert len(repo_report.revisions) == 0
+        assert repo_report.last_modified == self.repo_path.stat().st_mtime
+        assert repo_report.last_accessed == self.repo_path.stat().st_atime
 
     def test_ref_to_missing_revision(self) -> None:
         """Test if a `refs` points to a missing revision."""
@@ -388,16 +377,16 @@ class TestCorruptedCacheUtils(unittest.TestCase):
             f.write("revision_hash_that_does_not_exist")
 
         report = scan_cache_dir(self.cache_dir)
-        self.assertEqual(len(report.repos), 0)  # Failed
+        assert len(report.repos) == 0  # Failed
 
-        self.assertEqual(len(report.warnings), 1)
-        self.assertEqual(
-            str(report.warnings[0]),
-            "Reference(s) refer to missing commit hashes: {'revision_hash_that_does_not_exist': {'not_main'}} "
-            + f"({self.repo_path}).",
+        assert len(report.warnings) == 1
+        assert (
+            str(report.warnings[0])
+            == "Reference(s) refer to missing commit hashes: {'revision_hash_that_does_not_exist': {'not_main'}} "
+            + f"({self.repo_path})."
         )
 
-    @skip_on_windows("Last modified/last accessed work a bit differently on Windows.")
+    @pytest.mark.skipif(os.name == "nt", reason="Last modified/last accessed work a bit differently on Windows.")
     def test_scan_cache_last_modified_and_last_accessed(self) -> None:
         """Scan the last_modified and last_accessed properties when scanning."""
         TIME_GAP = 0.1
@@ -412,9 +401,9 @@ class TestCorruptedCacheUtils(unittest.TestCase):
         another_file_1 = [file for file in revision_1.files if file.file_name == ".gitattributes"][0]
 
         # Comparison of last_accessed/last_modified between file and repo
-        self.assertLessEqual(readme_file_1.blob_last_accessed, repo_1.last_accessed)
-        self.assertLessEqual(readme_file_1.blob_last_modified, repo_1.last_modified)
-        self.assertEqual(revision_1.last_modified, repo_1.last_modified)
+        assert readme_file_1.blob_last_accessed <= repo_1.last_accessed
+        assert readme_file_1.blob_last_modified <= repo_1.last_modified
+        assert revision_1.last_modified == repo_1.last_modified
 
         # Sleep and write new readme
         time.sleep(TIME_GAP)
@@ -436,36 +425,34 @@ class TestCorruptedCacheUtils(unittest.TestCase):
         another_file_2 = [file for file in revision_1.files if file.file_name == ".gitattributes"][0]
 
         # Report 1 is not updated when cache changes
-        self.assertLess(repo_1.last_accessed, repo_2.last_accessed)
-        self.assertLess(repo_1.last_modified, repo_2.last_modified)
+        assert repo_1.last_accessed < repo_2.last_accessed
+        assert repo_1.last_modified < repo_2.last_modified
 
         # "Another_file.md" did not change
-        self.assertEqual(another_file_1, another_file_2)
+        assert another_file_1 == another_file_2
 
         # Readme.md has been modified and then accessed more recently
-        self.assertGreaterEqual(
-            readme_file_2.blob_last_modified - readme_file_1.blob_last_modified,
-            TIME_GAP * 0.9,  # 0.9 factor because not exactly precise
-        )
-        self.assertGreaterEqual(
-            readme_file_2.blob_last_accessed - readme_file_1.blob_last_accessed,
-            2 * TIME_GAP * 0.9,  # 0.9 factor because not exactly precise
-        )
-        self.assertGreaterEqual(
-            readme_file_2.blob_last_accessed - readme_file_2.blob_last_modified,
-            TIME_GAP * 0.9,  # 0.9 factor because not exactly precise
-        )
+        assert (
+            readme_file_2.blob_last_modified - readme_file_1.blob_last_modified >= TIME_GAP * 0.9
+        )  # 0.9 factor because not exactly precise
+        assert (
+            readme_file_2.blob_last_accessed - readme_file_1.blob_last_accessed >= 2 * TIME_GAP * 0.9
+        )  # 0.9 factor because not exactly precise
+        assert (
+            readme_file_2.blob_last_accessed - readme_file_2.blob_last_modified >= TIME_GAP * 0.9
+        )  # 0.9 factor because not exactly precise
 
         # Comparison of last_accessed/last_modified between file and repo
-        self.assertEqual(readme_file_2.blob_last_accessed, repo_2.last_accessed)
-        self.assertEqual(readme_file_2.blob_last_modified, repo_2.last_modified)
-        self.assertEqual(revision_2.last_modified, repo_2.last_modified)
+        assert readme_file_2.blob_last_accessed == repo_2.last_accessed
+        assert readme_file_2.blob_last_modified == repo_2.last_modified
+        assert revision_2.last_modified == repo_2.last_modified
 
 
-class TestDeleteRevisionsDryRun(unittest.TestCase):
+class TestDeleteRevisionsDryRun:
     cache_info: Mock  # Mocked HFCacheInfo
 
-    def setUp(self) -> None:
+    @pytest.fixture(autouse=True)
+    def setup(self) -> None:
         """Set up fake cache scan report."""
         repo_A_path = Path("repo_A")
         blobs_path = repo_A_path / "blobs"
@@ -542,7 +529,7 @@ class TestDeleteRevisionsDryRun(unittest.TestCase):
             repos=set(),  # No repo deleted as other revisions exist
             snapshots={Path("repo_A/snapshots_path/repo_A_rev_detached")},
         )
-        self.assertEqual(strategy, expected)
+        assert strategy == expected
 
     def test_delete_pr_1_revision(self) -> None:
         strategy = HFCacheInfo.delete_revisions(self.cache_info, "repo_A_rev_pr_1")
@@ -556,7 +543,7 @@ class TestDeleteRevisionsDryRun(unittest.TestCase):
             repos=set(),  # No repo deleted as other revisions exist
             snapshots={Path("repo_A/snapshots_path/repo_A_rev_pr_1")},
         )
-        self.assertEqual(strategy, expected)
+        assert strategy == expected
 
     def test_delete_pr_1_and_detached(self) -> None:
         strategy = HFCacheInfo.delete_revisions(self.cache_info, "repo_A_rev_detached", "repo_A_rev_pr_1")
@@ -575,7 +562,7 @@ class TestDeleteRevisionsDryRun(unittest.TestCase):
                 Path("repo_A/snapshots_path/repo_A_rev_pr_1"),
             },
         )
-        self.assertEqual(strategy, expected)
+        assert strategy == expected
 
     def test_delete_all_revisions(self) -> None:
         strategy = HFCacheInfo.delete_revisions(
@@ -588,27 +575,25 @@ class TestDeleteRevisionsDryRun(unittest.TestCase):
             repos={Path("repo_A")},  # No remaining revisions: full repo is deleted
             snapshots=set(),
         )
-        self.assertEqual(strategy, expected)
+        assert strategy == expected
 
-    def test_delete_unknown_revision(self) -> None:
-        with self.assertLogs() as captured:
+    def test_delete_unknown_revision(self, caplog) -> None:
+        with caplog.at_level(logging.WARNING, logger="huggingface_hub"):
             strategy = HFCacheInfo.delete_revisions(self.cache_info, "repo_A_rev_detached", "abcdef123456789")
 
         # Expected is same strategy as without "abcdef123456789"
         expected = HFCacheInfo.delete_revisions(self.cache_info, "repo_A_rev_detached")
-        self.assertEqual(strategy, expected)
+        assert strategy == expected
 
         # Expect a warning message
-        self.assertEqual(len(captured.records), 1)
-        self.assertEqual(captured.records[0].levelname, "WARNING")
-        self.assertEqual(
-            captured.records[0].message,
-            "Revision(s) not found - cannot delete them: abcdef123456789",
-        )
+        records = [r for r in caplog.records if r.name.startswith("huggingface_hub")]
+        assert len(records) == 1
+        assert records[0].levelname == "WARNING"
+        assert records[0].message == "Revision(s) not found - cannot delete them: abcdef123456789"
 
 
 @pytest.mark.usefixtures("fx_cache_dir")
-class TestDeleteStrategyExecute(unittest.TestCase):
+class TestDeleteStrategyExecute:
     cache_dir: Path
 
     def test_execute(self) -> None:
@@ -653,25 +638,25 @@ class TestDeleteStrategyExecute(unittest.TestCase):
         ).execute()
 
         # Repo A deleted
-        self.assertFalse(repo_A_path.exists())
-        self.assertTrue(repo_B_path.exists())
+        assert not repo_A_path.exists()
+        assert repo_B_path.exists()
 
         # Only `blob` 1 remains
-        self.assertTrue(blob_1.exists())
-        self.assertFalse(blob_2.exists())
-        self.assertFalse(blob_3.exists())
+        assert blob_1.exists()
+        assert not blob_2.exists()
+        assert not blob_3.exists()
 
         # Only ref `main` remains
-        self.assertTrue(refs_main_path.exists())
-        self.assertFalse(refs_pr_1_path.exists())
+        assert refs_main_path.exists()
+        assert not refs_pr_1_path.exists()
 
         # Only `snapshot_1` remains
-        self.assertTrue(snapshot_1.exists())
-        self.assertFalse(snapshot_2.exists())
+        assert snapshot_1.exists()
+        assert not snapshot_2.exists()
 
 
 @pytest.mark.usefixtures("fx_cache_dir")
-class TestTryDeletePath(unittest.TestCase):
+class TestTryDeletePath:
     cache_dir: Path
 
     def test_delete_path_on_file_success(self) -> None:
@@ -679,7 +664,7 @@ class TestTryDeletePath(unittest.TestCase):
         file_path = self.cache_dir / "file.txt"
         file_path.touch()
         _try_delete_path(file_path, path_type="TYPE")
-        self.assertFalse(file_path.exists())
+        assert not file_path.exists()
 
     def test_delete_path_on_folder_success(self) -> None:
         """Successfully delete a local folder."""
@@ -695,35 +680,37 @@ class TestTryDeletePath(unittest.TestCase):
 
         _try_delete_path(dir_path, path_type="TYPE")
 
-        self.assertFalse(dir_path.exists())
-        self.assertFalse(subdir_path.exists())
-        self.assertFalse(file_path_1.exists())
-        self.assertFalse(file_path_2.exists())
+        assert not dir_path.exists()
+        assert not subdir_path.exists()
+        assert not file_path_1.exists()
+        assert not file_path_2.exists()
 
-    def test_delete_path_on_missing_file(self) -> None:
+    def test_delete_path_on_missing_file(self, caplog) -> None:
         """Try to delete a missing file."""
         file_path = self.cache_dir / "file.txt"
 
-        with self.assertLogs() as captured:
+        with caplog.at_level(logging.WARNING, logger="huggingface_hub"):
             _try_delete_path(file_path, path_type="TYPE")
 
         # Assert warning message with traceback for debug purposes
-        assert len(captured.output) > 0
-        assert any(f"Couldn't delete TYPE: file not found ({file_path})" in log for log in captured.output)
+        output = [r.getMessage() for r in caplog.records if r.name.startswith("huggingface_hub")]
+        assert len(output) > 0
+        assert any(f"Couldn't delete TYPE: file not found ({file_path})" in log for log in output)
 
-    def test_delete_path_on_missing_folder(self) -> None:
+    def test_delete_path_on_missing_folder(self, caplog) -> None:
         """Try to delete a missing folder."""
         dir_path = self.cache_dir / "folder"
 
-        with self.assertLogs() as captured:
+        with caplog.at_level(logging.WARNING, logger="huggingface_hub"):
             _try_delete_path(dir_path, path_type="TYPE")
 
         # Assert warning message with traceback for debug purposes
-        assert len(captured.output) > 0
-        assert any(f"Couldn't delete TYPE: file not found ({dir_path})" in log for log in captured.output)
+        output = [r.getMessage() for r in caplog.records if r.name.startswith("huggingface_hub")]
+        assert len(output) > 0
+        assert any(f"Couldn't delete TYPE: file not found ({dir_path})" in log for log in output)
 
-    @skip_on_windows(reason="Permissions are handled differently on Windows.")
-    def test_delete_path_on_local_folder_with_wrong_permission(self) -> None:
+    @pytest.mark.skipif(os.name == "nt", reason="Permissions are handled differently on Windows.")
+    def test_delete_path_on_local_folder_with_wrong_permission(self, caplog) -> None:
         """Try to delete a local folder that is protected."""
         dir_path = self.cache_dir / "something"
         dir_path.mkdir()
@@ -731,26 +718,26 @@ class TestTryDeletePath(unittest.TestCase):
         file_path_1.touch()
         dir_path.chmod(444)  # Read-only folder
 
-        with self.assertLogs() as captured:
+        with caplog.at_level(logging.WARNING, logger="huggingface_hub"):
             _try_delete_path(dir_path, path_type="TYPE")
 
         # Folder still exists (couldn't be deleted)
-        self.assertTrue(dir_path.is_dir())
+        assert dir_path.is_dir()
 
         # Assert warning message with traceback for debug purposes
-        self.assertEqual(len(captured.output), 1)
-        self.assertTrue(
-            captured.output[0].startswith(
-                "WARNING:huggingface_hub.utils._cache_manager:Couldn't delete TYPE:"
-                f" permission denied ({dir_path})\nTraceback (most recent call last):"
-            )
+        records = [r for r in caplog.records if r.name.startswith("huggingface_hub")]
+        assert len(records) == 1
+        formatter = logging.Formatter("%(levelname)s:%(name)s:%(message)s")
+        assert formatter.format(records[0]).startswith(
+            "WARNING:huggingface_hub.utils._cache_manager:Couldn't delete TYPE:"
+            f" permission denied ({dir_path})\nTraceback (most recent call last):"
         )
 
         # For proper cleanup
         dir_path.chmod(509)
 
 
-class TestStringFormatters(unittest.TestCase):
+class TestStringFormatters:
     SIZES = {
         16.0: "16.0",
         1000.0: "1.0K",
@@ -774,8 +761,4 @@ class TestStringFormatters(unittest.TestCase):
     def test_format_size(self) -> None:
         """Test `_format_size` formatter."""
         for size, expected in self.SIZES.items():
-            self.assertEqual(
-                _format_size(size),
-                expected,
-                msg=f"Wrong formatting for {size} == '{expected}'",
-            )
+            assert _format_size(size) == expected, f"Wrong formatting for {size} == '{expected}'"

--- a/tests/test_utils_chunks.py
+++ b/tests/test_utils_chunks.py
@@ -1,9 +1,9 @@
-import unittest
+import pytest
 
 from huggingface_hub.utils._chunk_utils import chunk_iterable
 
 
-class TestUtilsCommon(unittest.TestCase):
+class TestUtilsCommon:
     def test_chunk_iterable_non_truncated(self):
         # Can iterable over any iterable (iterator, list, tuple,...)
         for iterable in (range(12), list(range(12)), tuple(range(12))):
@@ -12,7 +12,7 @@ class TestUtilsCommon(unittest.TestCase):
                 chunk_iterable(iterable, chunk_size=4),
                 [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]],
             ):
-                self.assertListEqual(list(chunk), expected_chunk)
+                assert list(chunk) == expected_chunk
 
     def test_chunk_iterable_last_chunk_truncated(self):
         # Can iterable over any iterable (iterator, list, tuple,...)
@@ -22,11 +22,11 @@ class TestUtilsCommon(unittest.TestCase):
                 chunk_iterable(iterable, chunk_size=5),
                 [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9], [10, 11]],
             ):
-                self.assertListEqual(list(chunk), expected_chunk)
+                assert list(chunk) == expected_chunk
 
     def test_chunk_iterable_validation(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             next(chunk_iterable(range(128), 0))
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             next(chunk_iterable(range(128), -1))

--- a/tests/test_utils_datetime.py
+++ b/tests/test_utils_datetime.py
@@ -1,4 +1,3 @@
-import unittest
 from datetime import datetime, timezone
 
 import pytest
@@ -6,25 +5,20 @@ import pytest
 from huggingface_hub.utils import parse_datetime
 
 
-class TestDatetimeUtils(unittest.TestCase):
+class TestDatetimeUtils:
     def test_parse_datetime(self):
         """Test `parse_datetime` works correctly on datetimes returned by server."""
-        self.assertEqual(
-            parse_datetime("2022-08-19T07:19:38.123Z"),
-            datetime(2022, 8, 19, 7, 19, 38, 123000, tzinfo=timezone.utc),
+        assert parse_datetime("2022-08-19T07:19:38.123Z") == datetime(
+            2022, 8, 19, 7, 19, 38, 123000, tzinfo=timezone.utc
         )
 
         # Test nanoseconds precision (should be truncated to microseconds)
-        self.assertEqual(
-            parse_datetime("2022-08-19T07:19:38.123456789Z"),
-            datetime(2022, 8, 19, 7, 19, 38, 123456, tzinfo=timezone.utc),
+        assert parse_datetime("2022-08-19T07:19:38.123456789Z") == datetime(
+            2022, 8, 19, 7, 19, 38, 123456, tzinfo=timezone.utc
         )
 
         # Test without milliseconds (should add .000)
-        self.assertEqual(
-            parse_datetime("2024-11-16T00:27:02Z"),
-            datetime(2024, 11, 16, 0, 27, 2, 0, tzinfo=timezone.utc),
-        )
+        assert parse_datetime("2024-11-16T00:27:02Z") == datetime(2024, 11, 16, 0, 27, 2, 0, tzinfo=timezone.utc)
 
         with pytest.raises(ValueError, match=r".*Cannot parse '2022-08-19T07:19:38' as a datetime.*"):
             parse_datetime("2022-08-19T07:19:38")

--- a/tests/test_utils_deprecation.py
+++ b/tests/test_utils_deprecation.py
@@ -1,4 +1,3 @@
-import unittest
 import warnings
 
 import pytest
@@ -10,7 +9,7 @@ from huggingface_hub.utils._deprecation import (
 )
 
 
-class TestDeprecationUtils(unittest.TestCase):
+class TestDeprecationUtils:
     def test_deprecate_positional_args(self):
         """Test warnings are triggered when using deprecated positional args."""
 
@@ -83,11 +82,10 @@ class TestDeprecationUtils(unittest.TestCase):
         # Default message
         with pytest.warns(FutureWarning) as record:
             dummy_deprecated_default_message(a="A")
-        self.assertEqual(len(record), 1)
-        self.assertEqual(
-            record[0].message.args[0],
+        assert len(record) == 1
+        assert record[0].message.args[0] == (
             "Deprecated argument(s) used in 'dummy_deprecated_default_message': a."
-            " Will not be supported from version 'xxx'.",
+            " Will not be supported from version 'xxx'."
         )
 
     def test_deprecate_arguments_with_custom_warning_message(self) -> None:
@@ -104,12 +102,11 @@ class TestDeprecationUtils(unittest.TestCase):
         # Custom message
         with pytest.warns(FutureWarning) as record:
             dummy_deprecated_custom_message(a="A")
-        self.assertEqual(len(record), 1)
-        self.assertEqual(
-            record[0].message.args[0],
+        assert len(record) == 1
+        assert record[0].message.args[0] == (
             "Deprecated argument(s) used in 'dummy_deprecated_custom_message': a."
             " Will not be supported from version 'xxx'.\n\nThis is a custom"
-            " message.",
+            " message."
         )
 
     def test_deprecated_method(self) -> None:
@@ -122,9 +119,8 @@ class TestDeprecationUtils(unittest.TestCase):
         # Custom message
         with pytest.warns(FutureWarning) as record:
             dummy_deprecated()
-        self.assertEqual(len(record), 1)
-        self.assertEqual(
-            record[0].message.args[0],
+        assert len(record) == 1
+        assert record[0].message.args[0] == (
             "'dummy_deprecated' (from 'tests.test_utils_deprecation') is deprecated"
-            " and will be removed from version 'xxx'. This is a custom message.",
+            " and will be removed from version 'xxx'. This is a custom message."
         )

--- a/tests/test_utils_errors.py
+++ b/tests/test_utils_errors.py
@@ -1,4 +1,3 @@
-import unittest
 from unittest.mock import Mock
 
 import pytest
@@ -15,15 +14,15 @@ from huggingface_hub.errors import (
 from huggingface_hub.utils._http import REPO_API_REGEX, X_AMZN_TRACE_ID, X_REQUEST_ID, _format, hf_raise_for_status
 
 
-class TestErrorUtils(unittest.TestCase):
+class TestErrorUtils:
     def test_hf_raise_for_status_repo_not_found(self) -> None:
         response = Response(status_code=404, headers={"X-Error-Code": "RepoNotFound", X_REQUEST_ID: "123"})
         response.request = Request(method="GET", url="https://huggingface.co/fake")
-        with self.assertRaisesRegex(RepositoryNotFoundError, "Repository Not Found") as context:
+        with pytest.raises(RepositoryNotFoundError, match="Repository Not Found") as context:
             hf_raise_for_status(response)
 
-        assert context.exception.response.status_code == 404
-        assert "Request ID: 123" in str(context.exception)
+        assert context.value.response.status_code == 404
+        assert "Request ID: 123" in str(context.value)
 
     def test_hf_raise_for_status_disabled_repo(self) -> None:
         response = Response(
@@ -31,20 +30,20 @@ class TestErrorUtils(unittest.TestCase):
         )
         response.request = Request(method="GET", url="https://huggingface.co/fake")
 
-        with self.assertRaises(DisabledRepoError) as context:
+        with pytest.raises(DisabledRepoError) as context:
             hf_raise_for_status(response)
 
-        assert context.exception.response.status_code == 403
-        assert "Request ID: 123" in str(context.exception)
+        assert context.value.response.status_code == 403
+        assert "Request ID: 123" in str(context.value)
 
     def test_hf_raise_for_status_401_repo_url_not_invalid_token(self) -> None:
         response = Response(status_code=401, headers={X_REQUEST_ID: "123"})
         response.request = Request(method="GET", url="https://huggingface.co/api/models/username/reponame")
-        with self.assertRaisesRegex(RepositoryNotFoundError, "Repository Not Found") as context:
+        with pytest.raises(RepositoryNotFoundError, match="Repository Not Found") as context:
             hf_raise_for_status(response)
 
-        assert context.exception.response.status_code == 401
-        assert "Request ID: 123" in str(context.exception)
+        assert context.value.response.status_code == 401
+        assert "Request ID: 123" in str(context.value)
 
     def test_hf_raise_for_status_401_repo_url_invalid_token(self) -> None:
         response = Response(
@@ -52,11 +51,11 @@ class TestErrorUtils(unittest.TestCase):
             headers={X_REQUEST_ID: "123", "X-Error-Message": "Invalid credentials in Authorization header"},
         )
         response.request = Request(method="GET", url="https://huggingface.co/api/models/username/reponame")
-        with self.assertRaisesRegex(HfHubHTTPError, "Invalid credentials in Authorization header") as context:
+        with pytest.raises(HfHubHTTPError, match="Invalid credentials in Authorization header") as context:
             hf_raise_for_status(response)
 
-        assert context.exception.response.status_code == 401
-        assert "Request ID: 123" in str(context.exception)
+        assert context.value.response.status_code == 401
+        assert "Request ID: 123" in str(context.value)
 
     def test_hf_raise_for_status_403_wrong_token_scope(self) -> None:
         response = Response(
@@ -64,70 +63,71 @@ class TestErrorUtils(unittest.TestCase):
         )
         response.request = Request(method="GET", url="https://huggingface.co/api/repos/create")
         expected_message_part = "403 Forbidden: specific error message"
-        with self.assertRaisesRegex(HfHubHTTPError, expected_message_part) as context:
+        with pytest.raises(HfHubHTTPError, match=expected_message_part) as context:
             hf_raise_for_status(response)
 
-        assert context.exception.response.status_code == 403
-        assert "Request ID: 123" in str(context.exception)
+        assert context.value.response.status_code == 403
+        assert "Request ID: 123" in str(context.value)
 
     def test_hf_raise_for_status_401_not_repo_url(self) -> None:
         response = Response(status_code=401, headers={X_REQUEST_ID: "123"})
         response.request = Request(method="GET", url="https://huggingface.co/api/collections")
-        with self.assertRaises(HfHubHTTPError) as context:
+        with pytest.raises(HfHubHTTPError) as context:
             hf_raise_for_status(response)
 
-        assert context.exception.response.status_code == 401
-        assert "Request ID: 123" in str(context.exception)
+        assert context.value.response.status_code == 401
+        assert "Request ID: 123" in str(context.value)
 
     def test_hf_raise_for_status_revision_not_found(self) -> None:
         response = Response(status_code=404, headers={"X-Error-Code": "RevisionNotFound", X_REQUEST_ID: "123"})
         response.request = Request(method="GET", url="https://huggingface.co/fake")
-        with self.assertRaisesRegex(RevisionNotFoundError, "Revision Not Found") as context:
+        with pytest.raises(RevisionNotFoundError, match="Revision Not Found") as context:
             hf_raise_for_status(response)
 
-        assert context.exception.response.status_code == 404
-        assert "Request ID: 123" in str(context.exception)
+        assert context.value.response.status_code == 404
+        assert "Request ID: 123" in str(context.value)
 
     def test_hf_raise_for_status_entry_not_found(self) -> None:
         response = Response(status_code=404, headers={"X-Error-Code": "EntryNotFound", X_REQUEST_ID: "123"})
         response.request = Request(method="GET", url="https://huggingface.co/fake")
-        with self.assertRaisesRegex(EntryNotFoundError, "Entry Not Found") as context:
+        with pytest.raises(EntryNotFoundError, match="Entry Not Found") as context:
             hf_raise_for_status(response)
 
-        assert context.exception.response.status_code == 404
-        assert "Request ID: 123" in str(context.exception)
+        assert context.value.response.status_code == 404
+        assert "Request ID: 123" in str(context.value)
 
     def test_hf_raise_for_status_bad_request_no_endpoint_name(self) -> None:
         """Test HTTPError converted to BadRequestError if error 400."""
         response = Response(status_code=400)
         response.request = Request(method="GET", url="https://huggingface.co/fake")
-        with self.assertRaisesRegex(BadRequestError, "Bad request:") as context:
+        with pytest.raises(BadRequestError, match="Bad request:") as context:
             hf_raise_for_status(response)
-        assert context.exception.response.status_code == 400
+        assert context.value.response.status_code == 400
 
     def test_hf_raise_for_status_bad_request_with_endpoint_name(self) -> None:
         """Test endpoint name is added to BadRequestError message."""
         response = Response(status_code=400)
         response.request = Request(method="GET", url="https://huggingface.co/fake")
-        with self.assertRaisesRegex(BadRequestError, "Bad request for preupload endpoint:") as context:
+        with pytest.raises(BadRequestError, match="Bad request for preupload endpoint:") as context:
             hf_raise_for_status(response, endpoint_name="preupload")
-        assert context.exception.response.status_code == 400
+        assert context.value.response.status_code == 400
 
     def test_hf_raise_for_status_fallback(self) -> None:
         """Test HTTPError is converted to HfHubHTTPError."""
         response = Response(status_code=404, headers={X_REQUEST_ID: "test-id"})
         response.request = Request(method="GET", url="https://huggingface.co/fake")
-        with self.assertRaisesRegex(HfHubHTTPError, "Request ID: test-id") as context:
+        with pytest.raises(HfHubHTTPError, match="Request ID: test-id") as context:
             hf_raise_for_status(response)
 
-        assert context.exception.response.status_code == 404
-        assert context.exception.response.url == "https://huggingface.co/fake"
+        assert context.value.response.status_code == 404
+        assert context.value.response.url == "https://huggingface.co/fake"
 
 
-class TestHfHubHTTPError(unittest.TestCase):
+class TestHfHubHTTPError:
     response: Response
 
-    def setUp(self) -> None:
+    @pytest.fixture(autouse=True)
+    def _setup(self) -> None:
         """Setup with a default response."""
         self.response = Response(status_code=404, request=Request(method="GET", url="https://huggingface.co/fake"))
 

--- a/tests/test_utils_experimental.py
+++ b/tests/test_utils_experimental.py
@@ -1,4 +1,3 @@
-import unittest
 import warnings
 from unittest.mock import patch
 
@@ -10,17 +9,17 @@ def dummy_function():
     return "success"
 
 
-class TestExperimentalFlag(unittest.TestCase):
+class TestExperimentalFlag:
     def test_experimental_warning(self):
         with patch("huggingface_hub.constants.HF_HUB_DISABLE_EXPERIMENTAL_WARNING", False):
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter("always")
-                self.assertEqual(dummy_function(), "success")
-            self.assertEqual(len(w), 1)
+                assert dummy_function() == "success"
+            assert len(w) == 1
 
     def test_experimental_no_warning(self):
         with patch("huggingface_hub.constants.HF_HUB_DISABLE_EXPERIMENTAL_WARNING", True):
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter("always")
-                self.assertEqual(dummy_function(), "success")
-            self.assertEqual(len(w), 0)
+                assert dummy_function() == "success"
+            assert len(w) == 0

--- a/tests/test_utils_fixes.py
+++ b/tests/test_utils_fixes.py
@@ -1,5 +1,4 @@
 import logging
-import unittest
 from pathlib import Path
 
 import filelock
@@ -8,26 +7,26 @@ import pytest
 from huggingface_hub.utils import SoftTemporaryDirectory, WeakFileLock, yaml_dump
 
 
-class TestYamlDump(unittest.TestCase):
+class TestYamlDump:
     def test_yaml_dump_emoji(self) -> None:
-        self.assertEqual(yaml_dump({"emoji": "👀"}), "emoji: 👀\n")
+        assert yaml_dump({"emoji": "👀"}) == "emoji: 👀\n"
 
     def test_yaml_dump_japanese_characters(self) -> None:
-        self.assertEqual(yaml_dump({"some unicode": "日本か"}), "some unicode: 日本か\n")
+        assert yaml_dump({"some unicode": "日本か"}) == "some unicode: 日本か\n"
 
     def test_yaml_dump_explicit_no_unicode(self) -> None:
-        self.assertEqual(yaml_dump({"emoji": "👀"}, allow_unicode=False), 'emoji: "\\U0001F440"\n')
+        assert yaml_dump({"emoji": "👀"}, allow_unicode=False) == 'emoji: "\\U0001F440"\n'
 
 
-class TestTemporaryDirectory(unittest.TestCase):
+class TestTemporaryDirectory:
     def test_temporary_directory(self) -> None:
         with SoftTemporaryDirectory(prefix="prefix", suffix="suffix") as path:
-            self.assertIsInstance(path, Path)
-            self.assertTrue(path.name.startswith("prefix"))
-            self.assertTrue(path.name.endswith("suffix"))
-            self.assertTrue(path.is_dir())
+            assert isinstance(path, Path)
+            assert path.name.startswith("prefix")
+            assert path.name.endswith("suffix")
+            assert path.is_dir()
         # Tmpdir is deleted
-        self.assertFalse(path.is_dir())
+        assert not path.is_dir()
 
 
 class TestWeakFileLock:

--- a/tests/test_utils_git_credentials.py
+++ b/tests/test_utils_git_credentials.py
@@ -1,5 +1,4 @@
 import time
-import unittest
 from pathlib import Path
 
 import pytest
@@ -24,10 +23,11 @@ STORE_AND_CACHE_HELPERS_CONFIG = """
 
 
 @pytest.mark.usefixtures("fx_cache_dir")
-class TestGitCredentials(unittest.TestCase):
+class TestGitCredentials:
     cache_dir: Path
 
-    def setUp(self):
+    @pytest.fixture(autouse=True)
+    def setup(self, fx_cache_dir):
         """Initialize and configure a local repo.
 
         Avoid to configure git helpers globally on a contributor's machine.
@@ -35,13 +35,14 @@ class TestGitCredentials(unittest.TestCase):
         run_subprocess("git init", folder=self.cache_dir)
         with (self.cache_dir / ".git" / "config").open("w") as f:
             f.write(STORE_AND_CACHE_HELPERS_CONFIG)
+        yield
 
     def test_list_credential_helpers(self) -> None:
         helpers = list_credential_helpers(folder=self.cache_dir)
-        self.assertIn("cache", helpers)
-        self.assertIn("store", helpers)
-        self.assertIn("git-credential-manager", helpers)
-        self.assertIn("/usr/libexec/git-core/git-credential-libsecret", helpers)
+        assert "cache" in helpers
+        assert "store" in helpers
+        assert "git-credential-manager" in helpers
+        assert "/usr/libexec/git-core/git-credential-libsecret" in helpers
 
     def test_set_and_unset_git_credential(self) -> None:
         username = "hf_test_user_" + str(round(time.time()))  # make username unique
@@ -54,7 +55,7 @@ class TestGitCredentials(unittest.TestCase):
             stdin.write(f"url={ENDPOINT}\nusername={username}\n\n")
             stdin.flush()
             output = stdout.read()
-        self.assertIn("password=hf_test_token", output)
+        assert "password=hf_test_token" in output
 
         # Unset credentials
         unset_git_credential(username=username, folder=self.cache_dir)
@@ -66,7 +67,7 @@ class TestGitCredentials(unittest.TestCase):
             stdin.write(f"url={ENDPOINT}\nusername={username}\n\n")
             stdin.flush()
             output = stdout.read()
-        self.assertEqual("", output)
+        assert output == ""
 
     def test_git_credential_parsing_regex(self) -> None:
         output = """

--- a/tests/test_utils_git_credentials.py
+++ b/tests/test_utils_git_credentials.py
@@ -22,48 +22,45 @@ STORE_AND_CACHE_HELPERS_CONFIG = """
 """
 
 
-@pytest.mark.usefixtures("fx_cache_dir")
 class TestGitCredentials:
-    cache_dir: Path
-
     @pytest.fixture(autouse=True)
-    def setup(self, fx_cache_dir):
+    def setup(self, tmp_path):
         """Initialize and configure a local repo.
 
         Avoid to configure git helpers globally on a contributor's machine.
         """
-        run_subprocess("git init", folder=self.cache_dir)
-        with (self.cache_dir / ".git" / "config").open("w") as f:
+        run_subprocess("git init", folder=tmp_path)
+        with (tmp_path / ".git" / "config").open("w") as f:
             f.write(STORE_AND_CACHE_HELPERS_CONFIG)
         yield
 
-    def test_list_credential_helpers(self) -> None:
-        helpers = list_credential_helpers(folder=self.cache_dir)
+    def test_list_credential_helpers(self, tmp_path: Path) -> None:
+        helpers = list_credential_helpers(folder=tmp_path)
         assert "cache" in helpers
         assert "store" in helpers
         assert "git-credential-manager" in helpers
         assert "/usr/libexec/git-core/git-credential-libsecret" in helpers
 
-    def test_set_and_unset_git_credential(self) -> None:
+    def test_set_and_unset_git_credential(self, tmp_path: Path) -> None:
         username = "hf_test_user_" + str(round(time.time()))  # make username unique
 
         # Set credentials
-        set_git_credential(token="hf_test_token", username=username, folder=self.cache_dir)
+        set_git_credential(token="hf_test_token", username=username, folder=tmp_path)
 
         # Check credentials are stored
-        with run_interactive_subprocess("git credential fill", folder=self.cache_dir) as (stdin, stdout):
+        with run_interactive_subprocess("git credential fill", folder=tmp_path) as (stdin, stdout):
             stdin.write(f"url={ENDPOINT}\nusername={username}\n\n")
             stdin.flush()
             output = stdout.read()
         assert "password=hf_test_token" in output
 
         # Unset credentials
-        unset_git_credential(username=username, folder=self.cache_dir)
+        unset_git_credential(username=username, folder=tmp_path)
 
         # Check credentials are NOT stored
         # Cannot check with `git credential fill` as it would hang forever: only
         # checking `store` helper instead.
-        with run_interactive_subprocess("git credential-store get", folder=self.cache_dir) as (stdin, stdout):
+        with run_interactive_subprocess("git credential-store get", folder=tmp_path) as (stdin, stdout):
             stdin.write(f"url={ENDPOINT}\nusername={username}\n\n")
             stdin.flush()
             output = stdout.read()

--- a/tests/test_utils_headers.py
+++ b/tests/test_utils_headers.py
@@ -1,10 +1,7 @@
-import unittest
-from unittest.mock import Mock, patch
+import pytest
 
 from huggingface_hub.utils import get_hf_hub_version, get_python_version
 from huggingface_hub.utils._headers import _deduplicate_user_agent, _http_user_agent, build_hf_headers
-
-from .testing_utils import handle_injection_in_test
 
 
 # Only for tests that are not related to user agent
@@ -19,111 +16,94 @@ FAKE_TOKEN_HEADER = {
 NO_AUTH_HEADER = {"user-agent": DEFAULT_USER_AGENT}
 
 
-class TestAuthHeadersUtil(unittest.TestCase):
+class TestAuthHeadersUtil:
     def test_token_str(self) -> None:
-        self.assertEqual(build_hf_headers(token=FAKE_TOKEN), FAKE_TOKEN_HEADER)
+        assert build_hf_headers(token=FAKE_TOKEN) == FAKE_TOKEN_HEADER
 
-    @patch("huggingface_hub.utils._headers.get_token", return_value=None)
-    def test_token_true_no_cached_token(self, mock_get_token: Mock) -> None:
-        with self.assertRaises(EnvironmentError):
+    def test_token_true_no_cached_token(self, mocker) -> None:
+        mocker.patch("huggingface_hub.utils._headers.get_token", return_value=None)
+        with pytest.raises(EnvironmentError):
             build_hf_headers(token=True)
 
-    @patch("huggingface_hub.utils._headers.get_token", return_value=FAKE_TOKEN)
-    def test_token_true_has_cached_token(self, mock_get_token: Mock) -> None:
-        self.assertEqual(build_hf_headers(token=True), FAKE_TOKEN_HEADER)
+    def test_token_true_has_cached_token(self, mocker) -> None:
+        mocker.patch("huggingface_hub.utils._headers.get_token", return_value=FAKE_TOKEN)
+        assert build_hf_headers(token=True) == FAKE_TOKEN_HEADER
 
-    @patch("huggingface_hub.utils._headers.get_token", return_value=FAKE_TOKEN)
-    def test_token_false(self, mock_get_token: Mock) -> None:
-        self.assertEqual(build_hf_headers(token=False), NO_AUTH_HEADER)
+    def test_token_false(self, mocker) -> None:
+        mocker.patch("huggingface_hub.utils._headers.get_token", return_value=FAKE_TOKEN)
+        assert build_hf_headers(token=False) == NO_AUTH_HEADER
 
-    @patch("huggingface_hub.utils._headers.get_token", return_value=None)
-    def test_token_none_no_cached_token(self, mock_get_token: Mock) -> None:
-        self.assertEqual(build_hf_headers(), NO_AUTH_HEADER)
+    def test_token_none_no_cached_token(self, mocker) -> None:
+        mocker.patch("huggingface_hub.utils._headers.get_token", return_value=None)
+        assert build_hf_headers() == NO_AUTH_HEADER
 
-    @patch("huggingface_hub.utils._headers.get_token", return_value=FAKE_TOKEN)
-    def test_token_none_has_cached_token(self, mock_get_token: Mock) -> None:
-        self.assertEqual(build_hf_headers(), FAKE_TOKEN_HEADER)
+    def test_token_none_has_cached_token(self, mocker) -> None:
+        mocker.patch("huggingface_hub.utils._headers.get_token", return_value=FAKE_TOKEN)
+        assert build_hf_headers() == FAKE_TOKEN_HEADER
 
-    @patch("huggingface_hub.utils._headers.get_token", return_value=FAKE_TOKEN)
-    def test_implicit_use_disabled(self, mock_get_token: Mock) -> None:
-        with patch(  # not as decorator to avoid friction with @handle_injection
-            "huggingface_hub.constants.HF_HUB_DISABLE_IMPLICIT_TOKEN", True
-        ):
-            self.assertEqual(build_hf_headers(), NO_AUTH_HEADER)  # token is not sent
+    def test_implicit_use_disabled(self, mocker) -> None:
+        mocker.patch("huggingface_hub.utils._headers.get_token", return_value=FAKE_TOKEN)
+        mocker.patch("huggingface_hub.constants.HF_HUB_DISABLE_IMPLICIT_TOKEN", True)
+        assert build_hf_headers() == NO_AUTH_HEADER  # token is not sent
 
-    @patch("huggingface_hub.utils._headers.get_token", return_value=FAKE_TOKEN)
-    def test_implicit_use_disabled_but_explicit_use(self, mock_get_token: Mock) -> None:
-        with patch(  # not as decorator to avoid friction with @handle_injection
-            "huggingface_hub.constants.HF_HUB_DISABLE_IMPLICIT_TOKEN", True
-        ):
-            # This is not an implicit use so we still send it
-            self.assertEqual(build_hf_headers(token=True), FAKE_TOKEN_HEADER)
+    def test_implicit_use_disabled_but_explicit_use(self, mocker) -> None:
+        mocker.patch("huggingface_hub.utils._headers.get_token", return_value=FAKE_TOKEN)
+        mocker.patch("huggingface_hub.constants.HF_HUB_DISABLE_IMPLICIT_TOKEN", True)
+        # This is not an implicit use so we still send it
+        assert build_hf_headers(token=True) == FAKE_TOKEN_HEADER
 
 
-class TestUserAgentHeadersUtil(unittest.TestCase):
+class TestUserAgentHeadersUtil:
     def _get_user_agent(self, **kwargs) -> str:
         return build_hf_headers(**kwargs)["user-agent"]
 
-    @patch("huggingface_hub.utils._headers.get_torch_version")
-    @patch("huggingface_hub.utils._headers.is_torch_available")
-    @handle_injection_in_test
-    def test_default_user_agent(
-        self,
-        mock_get_torch_version: Mock,
-        mock_is_torch_available: Mock,
-    ) -> None:
-        mock_get_torch_version.return_value = "torch_version"
-        mock_is_torch_available.return_value = True
-        self.assertEqual(
-            self._get_user_agent(),
-            f"unknown/None; hf_hub/{get_hf_hub_version()}; python/{get_python_version()}; torch/torch_version",
+    def test_default_user_agent(self, mocker) -> None:
+        mocker.patch("huggingface_hub.utils._headers.get_torch_version", return_value="torch_version")
+        mocker.patch("huggingface_hub.utils._headers.is_torch_available", return_value=True)
+        assert (
+            self._get_user_agent()
+            == f"unknown/None; hf_hub/{get_hf_hub_version()}; python/{get_python_version()}; torch/torch_version"
         )
 
-    @patch("huggingface_hub.utils._headers.is_torch_available")
-    @handle_injection_in_test
-    def test_user_agent_with_library_name_multiple_missing(self, mock_is_torch_available: Mock) -> None:
-        mock_is_torch_available.return_value = False
-        self.assertNotIn("torch", self._get_user_agent())
+    def test_user_agent_with_library_name_multiple_missing(self, mocker) -> None:
+        mocker.patch("huggingface_hub.utils._headers.is_torch_available", return_value=False)
+        assert "torch" not in self._get_user_agent()
 
     def test_user_agent_with_library_name_and_version(self) -> None:
-        self.assertTrue(
-            self._get_user_agent(
-                library_name="foo",
-                library_version="bar",
-            ).startswith("foo/bar;")
-        )
+        assert self._get_user_agent(
+            library_name="foo",
+            library_version="bar",
+        ).startswith("foo/bar;")
 
     def test_user_agent_with_library_name_no_version(self) -> None:
-        self.assertTrue(self._get_user_agent(library_name="foo").startswith("foo/None;"))
+        assert self._get_user_agent(library_name="foo").startswith("foo/None;")
 
     def test_user_agent_with_custom_agent_string(self) -> None:
-        self.assertTrue(self._get_user_agent(user_agent="this is a custom agent").endswith("this is a custom agent"))
+        assert self._get_user_agent(user_agent="this is a custom agent").endswith("this is a custom agent")
 
     def test_user_agent_with_custom_agent_dict(self) -> None:
-        self.assertTrue(self._get_user_agent(user_agent={"a": "b", "c": "d"}).endswith("a/b; c/d"))
+        assert self._get_user_agent(user_agent={"a": "b", "c": "d"}).endswith("a/b; c/d")
 
     def test_user_agent_deduplicate(self) -> None:
-        self.assertEqual(
+        assert (
             _deduplicate_user_agent(
                 "python/3.7; python/3.8; hf_hub/0.12; transformers/None; hf_hub/0.12; python/3.7; diffusers/0.12.1"
-            ),
+            )
             # 1. "python" is kept twice with different values
             # 2. "python/3.7" second occurrence is removed
             # 3. "hf_hub" second occurrence is removed
             # 4. order is preserved
-            "python/3.7; python/3.8; hf_hub/0.12; transformers/None; diffusers/0.12.1",
+            == "python/3.7; python/3.8; hf_hub/0.12; transformers/None; diffusers/0.12.1"
         )
 
-    @patch("huggingface_hub.utils._telemetry.constants.HF_HUB_USER_AGENT_ORIGIN", "custom-origin")
-    def test_user_agent_with_origin(self) -> None:
-        self.assertTrue(self._get_user_agent().endswith("origin/custom-origin"))
+    def test_user_agent_with_origin(self, mocker) -> None:
+        mocker.patch("huggingface_hub.utils._telemetry.constants.HF_HUB_USER_AGENT_ORIGIN", "custom-origin")
+        assert self._get_user_agent().endswith("origin/custom-origin")
 
-    @patch("huggingface_hub.utils._telemetry.constants.HF_HUB_USER_AGENT_ORIGIN", "custom-origin")
-    def test_user_agent_with_origin_and_user_agent(self) -> None:
-        self.assertTrue(
-            self._get_user_agent(user_agent={"a": "b", "c": "d"}).endswith("a/b; c/d; origin/custom-origin")
-        )
+    def test_user_agent_with_origin_and_user_agent(self, mocker) -> None:
+        mocker.patch("huggingface_hub.utils._telemetry.constants.HF_HUB_USER_AGENT_ORIGIN", "custom-origin")
+        assert self._get_user_agent(user_agent={"a": "b", "c": "d"}).endswith("a/b; c/d; origin/custom-origin")
 
-    @patch("huggingface_hub.utils._telemetry.constants.HF_HUB_USER_AGENT_ORIGIN", "custom-origin")
-    def test_user_agent_with_origin_and_user_agent_str(self) -> None:
-        self.assertTrue(self._get_user_agent(user_agent="a/b;c/d").endswith("a/b; c/d; origin/custom-origin"))
+    def test_user_agent_with_origin_and_user_agent_str(self, mocker) -> None:
+        mocker.patch("huggingface_hub.utils._telemetry.constants.HF_HUB_USER_AGENT_ORIGIN", "custom-origin")
+        assert self._get_user_agent(user_agent="a/b;c/d").endswith("a/b; c/d; origin/custom-origin")

--- a/tests/test_utils_http.py
+++ b/tests/test_utils_http.py
@@ -1,6 +1,5 @@
 import threading
 import time
-import unittest
 import weakref
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Generator, Optional
@@ -40,15 +39,15 @@ from huggingface_hub.utils._http import (
 URL = "https://www.google.com"
 
 
-class TestHttpBackoff(unittest.TestCase):
-    def setUp(self) -> None:
+class TestHttpBackoff:
+    @pytest.fixture(autouse=True)
+    def setup(self) -> Generator[None, None, None]:
         get_session_mock = Mock()
         self.mock_request = get_session_mock().request
 
         self.patcher = patch("huggingface_hub.utils._http.get_session", get_session_mock)
         self.patcher.start()
-
-    def tearDown(self) -> None:
+        yield
         self.patcher.stop()
 
     def test_backoff_no_errors(self) -> None:
@@ -56,7 +55,7 @@ class TestHttpBackoff(unittest.TestCase):
         data_mock = Mock()
         response = http_backoff("GET", URL, data=data_mock)
         self.mock_request.assert_called_once_with(method="GET", url=URL, data=data_mock)
-        self.assertIs(response, self.mock_request())
+        assert response is self.mock_request()
 
     def test_backoff_3_calls(self) -> None:
         """Test `http_backoff` with 2 fails."""
@@ -65,7 +64,7 @@ class TestHttpBackoff(unittest.TestCase):
         response = http_backoff(  # retry on ValueError, instant retry
             "GET", URL, retry_on_exceptions=ValueError, base_wait_time=0.0
         )
-        self.assertEqual(self.mock_request.call_count, 3)
+        assert self.mock_request.call_count == 3
         self.mock_request.assert_has_calls(
             calls=[
                 call(method="GET", url=URL),
@@ -73,16 +72,16 @@ class TestHttpBackoff(unittest.TestCase):
                 call(method="GET", url=URL),
             ]
         )
-        self.assertIs(response, response_mock)
+        assert response is response_mock
 
     def test_backoff_on_exception_until_max(self) -> None:
         """Test `http_backoff` until max limit is reached with exceptions."""
         self.mock_request.side_effect = ConnectTimeout("Connection timeout")
 
-        with self.assertRaises(ConnectTimeout):
+        with pytest.raises(ConnectTimeout):
             http_backoff("GET", URL, base_wait_time=0.0, max_retries=3)
 
-        self.assertEqual(self.mock_request.call_count, 4)
+        assert self.mock_request.call_count == 4
 
     def test_backoff_on_status_code_until_max(self) -> None:
         """Test `http_backoff` until max limit is reached with status codes."""
@@ -93,7 +92,7 @@ class TestHttpBackoff(unittest.TestCase):
         mock_504.raise_for_status.side_effect = HTTPError("HTTP Error")
         self.mock_request.side_effect = (mock_503, mock_504, mock_503, mock_504)
 
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             http_backoff(
                 "GET",
                 URL,
@@ -102,7 +101,7 @@ class TestHttpBackoff(unittest.TestCase):
                 retry_on_status_codes=(503, 504),
             )
 
-        self.assertEqual(self.mock_request.call_count, 4)
+        assert self.mock_request.call_count == 4
 
     def test_backoff_on_exceptions_and_status_codes(self) -> None:
         """Test `http_backoff` until max limit with status codes and exceptions."""
@@ -110,10 +109,10 @@ class TestHttpBackoff(unittest.TestCase):
         mock_503.status_code = 503
         self.mock_request.side_effect = (mock_503, ConnectTimeout("Connection timeout"))
 
-        with self.assertRaises(ConnectTimeout):
+        with pytest.raises(ConnectTimeout):
             http_backoff("GET", URL, base_wait_time=0.0, max_retries=1)
 
-        self.assertEqual(self.mock_request.call_count, 2)
+        assert self.mock_request.call_count == 2
 
     def test_backoff_on_valid_status_code(self) -> None:
         """Test `http_backoff` until max limit with a valid status code.
@@ -128,8 +127,8 @@ class TestHttpBackoff(unittest.TestCase):
 
         response = http_backoff("GET", URL, base_wait_time=0.0, max_retries=3, retry_on_status_codes=200)
 
-        self.assertEqual(self.mock_request.call_count, 4)
-        self.assertIs(response, mock_200)
+        assert self.mock_request.call_count == 4
+        assert response is mock_200
 
     def test_backoff_sleep_time(self) -> None:
         """Test `http_backoff` sleep time goes exponential until max limit.
@@ -152,14 +151,14 @@ class TestHttpBackoff(unittest.TestCase):
 
         self.mock_request.side_effect = _side_effect_timer()
 
-        with self.assertRaises(ConnectTimeout):
+        with pytest.raises(ConnectTimeout):
             http_backoff("GET", URL, base_wait_time=0.1, max_wait_time=0.5, max_retries=5)
 
-        self.assertEqual(self.mock_request.call_count, 6)
+        assert self.mock_request.call_count == 6
 
         # Assert sleep times are exponential until plateau
         expected_sleep_times = [0.1, 0.2, 0.4, 0.5, 0.5]
-        self.assertListEqual(sleep_times, expected_sleep_times)
+        assert sleep_times == expected_sleep_times
 
     def test_backoff_on_429_uses_ratelimit_header(self) -> None:
         """Test that 429 wait time uses full reset time from ratelimit header."""
@@ -189,13 +188,12 @@ class TestHttpBackoff(unittest.TestCase):
         assert response.status_code == 200
 
 
-class TestConfigureSession(unittest.TestCase):
-    def setUp(self) -> None:
+class TestConfigureSession:
+    @pytest.fixture(autouse=True)
+    def setup(self) -> Generator[None, None, None]:
         # Reconfigure + clear session cache between each test
         set_client_factory(default_client_factory)
-
-    @classmethod
-    def tearDownClass(cls) -> None:
+        yield
         # Clear all sessions after tests
         set_client_factory(default_client_factory)
 
@@ -208,21 +206,21 @@ class TestConfigureSession(unittest.TestCase):
     def test_default_configuration(self) -> None:
         client = get_session()
         # Check httpx.Client default configuration
-        self.assertTrue(client.follow_redirects)
-        self.assertIsNotNone(client.timeout)
+        assert client.follow_redirects
+        assert client.timeout is not None
 
     def test_set_configuration(self) -> None:
         set_client_factory(self._factory)
 
         # Check headers have been set correctly
         client = get_session()
-        self.assertNotEqual(client.headers, {"x-test-header": "4"})
-        self.assertEqual(client.headers["x-test-header"], "4")
+        assert client.headers != {"x-test-header": "4"}
+        assert client.headers["x-test-header"] == "4"
 
     def test_get_session_twice(self):
         client_1 = get_session()
         client_2 = get_session()
-        self.assertIs(client_1, client_2)  # exact same instance
+        assert client_1 is client_2  # exact same instance
 
     def test_get_session_twice_but_reconfigure_in_between(self):
         """Reconfiguring the session clears the cache."""
@@ -230,9 +228,9 @@ class TestConfigureSession(unittest.TestCase):
         set_client_factory(self._factory)
 
         client_2 = get_session()
-        self.assertIsNot(client_1, client_2)
-        self.assertIsNone(client_1.headers.get("x-test-header"))
-        self.assertEqual(client_2.headers["x-test-header"], "4")
+        assert client_1 is not client_2
+        assert client_1.headers.get("x-test-header") is None
+        assert client_2.headers["x-test-header"] == "4"
 
     def test_get_session_multiple_threads(self):
         N = 3
@@ -255,24 +253,21 @@ class TestConfigureSession(unittest.TestCase):
 
         # Check all clients are the same instance (httpx is thread-safe)
         for i in range(N):
-            self.assertIs(main_client, clients[i])
+            assert main_client is clients[i]
             for j in range(N):
-                self.assertIs(clients[i], clients[j])
+                assert clients[i] is clients[j]
 
 
-class OfflineModeSessionTest(unittest.TestCase):
-    def tearDown(self) -> None:
-        return super().tearDown()
-
-    @patch("huggingface_hub.constants.HF_HUB_OFFLINE", True)
+class TestOfflineModeSession:
     def test_offline_mode(self):
-        set_client_factory(default_client_factory)
-        client = get_session()
-        with self.assertRaises(OfflineModeIsEnabled):
-            client.get("https://huggingface.co")
+        with patch("huggingface_hub.constants.HF_HUB_OFFLINE", True):
+            set_client_factory(default_client_factory)
+            client = get_session()
+            with pytest.raises(OfflineModeIsEnabled):
+                client.get("https://huggingface.co")
 
 
-class TestUniqueRequestId(unittest.TestCase):
+class TestUniqueRequestId:
     api_endpoint = ENDPOINT + "/api/tasks"  # any endpoint is fine
 
     def test_request_id_is_used_by_server(self):
@@ -280,8 +275,8 @@ class TestUniqueRequestId(unittest.TestCase):
 
         request_id = response.request.headers.get("X-Amzn-Trace-Id")
         response_id = response.headers.get("x-request-id")
-        self.assertIn(request_id, response_id)
-        self.assertTrue(_is_uuid(request_id))
+        assert request_id in response_id
+        assert _is_uuid(request_id)
 
     def test_request_id_is_unique(self):
         response_1 = get_session().get(self.api_endpoint)
@@ -289,19 +284,19 @@ class TestUniqueRequestId(unittest.TestCase):
 
         request_id_1 = response_1.request.headers["X-Amzn-Trace-Id"]
         request_id_2 = response_2.request.headers["X-Amzn-Trace-Id"]
-        self.assertNotEqual(request_id_1, request_id_2)
+        assert request_id_1 != request_id_2
 
-        self.assertTrue(_is_uuid(request_id_1))
-        self.assertTrue(_is_uuid(request_id_2))
+        assert _is_uuid(request_id_1)
+        assert _is_uuid(request_id_2)
 
     def test_request_id_not_overwritten(self):
         response = get_session().get(self.api_endpoint, headers={"x-request-id": "custom-id"})
 
         request_id = response.request.headers["x-request-id"]
-        self.assertEqual(request_id, "custom-id")
+        assert request_id == "custom-id"
 
         response_id = response.headers["x-request-id"]
-        self.assertEqual(response_id, "custom-id")
+        assert response_id == "custom-id"
 
 
 def _is_uuid(string: str) -> bool:

--- a/tests/test_utils_pagination.py
+++ b/tests/test_utils_pagination.py
@@ -1,19 +1,16 @@
-import unittest
-from unittest.mock import Mock, call, patch
+from unittest.mock import Mock, call
+
+import pytest
 
 from huggingface_hub.utils._pagination import paginate
 
-from .testing_utils import handle_injection_in_test
 
+class TestPagination:
+    def test_mocked_paginate(self, mocker) -> None:
+        mock_get_session: Mock = mocker.patch("huggingface_hub.utils._pagination.get_session")
+        mock_http_backoff: Mock = mocker.patch("huggingface_hub.utils._pagination.http_backoff")
+        mock_hf_raise_for_status: Mock = mocker.patch("huggingface_hub.utils._pagination.hf_raise_for_status")
 
-class TestPagination(unittest.TestCase):
-    @patch("huggingface_hub.utils._pagination.get_session")
-    @patch("huggingface_hub.utils._pagination.http_backoff")
-    @patch("huggingface_hub.utils._pagination.hf_raise_for_status")
-    @handle_injection_in_test
-    def test_mocked_paginate(
-        self, mock_get_session: Mock, mock_http_backoff: Mock, mock_hf_raise_for_status: Mock
-    ) -> None:
         mock_get = mock_get_session().get
         mock_params = Mock()
         mock_headers = Mock()
@@ -70,4 +67,4 @@ class TestPagination(unittest.TestCase):
             if num == 5:
                 break
         else:
-            self.fail("Did not get more than 5 repos")
+            pytest.fail("Did not get more than 5 repos")

--- a/tests/test_utils_paths.py
+++ b/tests/test_utils_paths.py
@@ -1,7 +1,8 @@
-import unittest
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Optional, Union
+
+import pytest
 
 from huggingface_hub.utils import DEFAULT_IGNORE_PATTERNS, filter_repo_objects
 
@@ -16,7 +17,7 @@ DUMMY_PATHS = [Path(path) for path in DUMMY_FILES]
 DUMMY_OBJECTS = [DummyObject(path=path) for path in DUMMY_FILES]
 
 
-class TestPathsUtils(unittest.TestCase):
+class TestPathsUtils:
     def test_get_all_pdfs(self) -> None:
         """Get all PDFs even hidden ones."""
         self._check(
@@ -72,7 +73,7 @@ class TestPathsUtils(unittest.TestCase):
 
     def test_filter_objects_key_not_provided(self) -> None:
         """Test ValueError is raised if filtering non-string objects."""
-        with self.assertRaisesRegex(ValueError, "Please provide `key` argument"):
+        with pytest.raises(ValueError, match="Please provide `key` argument"):
             list(
                 filter_repo_objects(
                     items=DUMMY_OBJECTS,
@@ -140,7 +141,7 @@ class TestPathsUtils(unittest.TestCase):
         key: Optional[Callable[[Any], str]] = None,
     ) -> None:
         """Run `filter_repo_objects` and check output against expected result."""
-        self.assertListEqual(
+        assert (
             list(
                 filter_repo_objects(
                     items=items,
@@ -148,12 +149,12 @@ class TestPathsUtils(unittest.TestCase):
                     ignore_patterns=ignore_patterns,
                     key=key,
                 )
-            ),
-            expected_items,
+            )
+            == expected_items
         )
 
 
-class TestDefaultIgnorePatterns(unittest.TestCase):
+class TestDefaultIgnorePatterns:
     PATHS_TO_IGNORE = [
         ".git",
         ".git/file.txt",
@@ -183,4 +184,4 @@ class TestDefaultIgnorePatterns(unittest.TestCase):
         filtered_paths = filter_repo_objects(
             items=self.PATHS_TO_IGNORE + self.VALID_PATHS, ignore_patterns=DEFAULT_IGNORE_PATTERNS
         )
-        self.assertListEqual(list(filtered_paths), self.VALID_PATHS)
+        assert list(filtered_paths) == self.VALID_PATHS

--- a/tests/test_utils_runtime.py
+++ b/tests/test_utils_runtime.py
@@ -1,13 +1,11 @@
-import unittest
-
 from huggingface_hub.utils._runtime import is_google_colab, is_notebook
 
 
-class TestRuntimeUtils(unittest.TestCase):
+class TestRuntimeUtils:
     def test_is_notebook(self) -> None:
         """Test `is_notebook`."""
-        self.assertFalse(is_notebook())
+        assert not is_notebook()
 
     def test_is_google_colab(self) -> None:
         """Test `is_google_colab`."""
-        self.assertFalse(is_google_colab())
+        assert not is_google_colab()

--- a/tests/test_utils_telemetry.py
+++ b/tests/test_utils_telemetry.py
@@ -1,96 +1,97 @@
-import unittest
+import logging
 from queue import Queue
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
+
+import pytest
 
 from huggingface_hub.utils._telemetry import send_telemetry
 
 from .testing_constants import ENDPOINT_STAGING
 
 
-@patch("huggingface_hub.utils._telemetry._TELEMETRY_QUEUE", new_callable=Queue)
-@patch("huggingface_hub.utils._telemetry._TELEMETRY_THREAD", None)
-class TestSendTelemetry(unittest.TestCase):
-    def setUp(self) -> None:
+class TestSendTelemetry:
+    @pytest.fixture(autouse=True)
+    def setup(self, mocker):
+        self.queue: Queue = Queue()
+        mocker.patch("huggingface_hub.utils._telemetry._TELEMETRY_QUEUE", self.queue)
+        mocker.patch("huggingface_hub.utils._telemetry._TELEMETRY_THREAD", None)
+
         get_session_mock = Mock()
         self.mock_head = get_session_mock().head
+        mocker.patch("huggingface_hub.utils._telemetry.get_session", get_session_mock)
+        yield
 
-        self.patcher = patch("huggingface_hub.utils._telemetry.get_session", get_session_mock)
-        self.patcher.start()
-
-    def tearDown(self) -> None:
-        self.patcher.stop()
-
-    def test_topic_normal(self, queue: Queue) -> None:
+    def test_topic_normal(self) -> None:
         send_telemetry(topic="examples")
-        queue.join()  # Wait for the telemetry tasks to be completed
+        self.queue.join()  # Wait for the telemetry tasks to be completed
         self.mock_head.assert_called_once()
-        self.assertEqual(self.mock_head.call_args[0][0], f"{ENDPOINT_STAGING}/api/telemetry/examples")
+        assert self.mock_head.call_args[0][0] == f"{ENDPOINT_STAGING}/api/telemetry/examples"
 
-    def test_topic_multiple(self, queue: Queue) -> None:
+    def test_topic_multiple(self) -> None:
         send_telemetry(topic="example1")
         send_telemetry(topic="example2")
         send_telemetry(topic="example3")
-        queue.join()  # Wait for the telemetry tasks to be completed
+        self.queue.join()  # Wait for the telemetry tasks to be completed
 
-        self.assertEqual(self.mock_head.call_count, 3)  # 3 calls and order is preserved
-        self.assertEqual(self.mock_head.call_args_list[0][0][0], f"{ENDPOINT_STAGING}/api/telemetry/example1")
-        self.assertEqual(self.mock_head.call_args_list[1][0][0], f"{ENDPOINT_STAGING}/api/telemetry/example2")
-        self.assertEqual(self.mock_head.call_args_list[2][0][0], f"{ENDPOINT_STAGING}/api/telemetry/example3")
+        assert self.mock_head.call_count == 3  # 3 calls and order is preserved
+        assert self.mock_head.call_args_list[0][0][0] == f"{ENDPOINT_STAGING}/api/telemetry/example1"
+        assert self.mock_head.call_args_list[1][0][0] == f"{ENDPOINT_STAGING}/api/telemetry/example2"
+        assert self.mock_head.call_args_list[2][0][0] == f"{ENDPOINT_STAGING}/api/telemetry/example3"
 
-    def test_topic_with_subtopic(self, queue: Queue) -> None:
+    def test_topic_with_subtopic(self) -> None:
         send_telemetry(topic="gradio/image/this_one")
-        queue.join()  # Wait for the telemetry tasks to be completed
+        self.queue.join()  # Wait for the telemetry tasks to be completed
         self.mock_head.assert_called_once()
-        self.assertEqual(self.mock_head.call_args[0][0], f"{ENDPOINT_STAGING}/api/telemetry/gradio/image/this_one")
+        assert self.mock_head.call_args[0][0] == f"{ENDPOINT_STAGING}/api/telemetry/gradio/image/this_one"
 
-    def test_topic_quoted(self, queue: Queue) -> None:
+    def test_topic_quoted(self) -> None:
         send_telemetry(topic="foo bar")
-        queue.join()  # Wait for the telemetry tasks to be completed
+        self.queue.join()  # Wait for the telemetry tasks to be completed
         self.mock_head.assert_called_once()
-        self.assertEqual(self.mock_head.call_args[0][0], f"{ENDPOINT_STAGING}/api/telemetry/foo%20bar")
+        assert self.mock_head.call_args[0][0] == f"{ENDPOINT_STAGING}/api/telemetry/foo%20bar"
 
-    @patch("huggingface_hub.utils._telemetry.constants.HF_HUB_OFFLINE", True)
-    def test_hub_offline(self, queue: Queue) -> None:
+    def test_hub_offline(self, mocker) -> None:
+        mocker.patch("huggingface_hub.utils._telemetry.constants.HF_HUB_OFFLINE", True)
         send_telemetry(topic="topic")
-        self.assertTrue(queue.empty())  # no tasks
+        assert self.queue.empty()  # no tasks
         self.mock_head.assert_not_called()
 
-    @patch("huggingface_hub.utils._telemetry.constants.HF_HUB_DISABLE_TELEMETRY", True)
-    def test_telemetry_disabled(self, queue: Queue) -> None:
+    def test_telemetry_disabled(self, mocker) -> None:
+        mocker.patch("huggingface_hub.utils._telemetry.constants.HF_HUB_DISABLE_TELEMETRY", True)
         send_telemetry(topic="topic")
-        self.assertTrue(queue.empty())  # no tasks
+        assert self.queue.empty()  # no tasks
         self.mock_head.assert_not_called()
 
-    @patch("huggingface_hub.utils._telemetry.build_hf_headers")
-    def test_telemetry_use_build_hf_headers(self, mock_headers: Mock, queue: Queue) -> None:
+    def test_telemetry_use_build_hf_headers(self, mocker) -> None:
+        mock_headers = mocker.patch("huggingface_hub.utils._telemetry.build_hf_headers")
         send_telemetry(topic="topic")
-        queue.join()  # Wait for the telemetry tasks to be completed
+        self.queue.join()  # Wait for the telemetry tasks to be completed
         self.mock_head.assert_called_once()
         mock_headers.assert_called_once()
-        self.assertEqual(self.mock_head.call_args[1]["headers"], mock_headers.return_value)
+        assert self.mock_head.call_args[1]["headers"] == mock_headers.return_value
 
 
-@patch("huggingface_hub.utils._telemetry._TELEMETRY_QUEUE", new_callable=Queue)
-@patch("huggingface_hub.utils._telemetry._TELEMETRY_THREAD", None)
-class TestSendTelemetryConnectionError(unittest.TestCase):
-    def setUp(self) -> None:
+class TestSendTelemetryConnectionError:
+    @pytest.fixture(autouse=True)
+    def setup(self, mocker):
+        self.queue: Queue = Queue()
+        mocker.patch("huggingface_hub.utils._telemetry._TELEMETRY_QUEUE", self.queue)
+        mocker.patch("huggingface_hub.utils._telemetry._TELEMETRY_THREAD", None)
+
         get_session_mock = Mock()
         get_session_mock().head.side_effect = Exception("whatever")
+        mocker.patch("huggingface_hub.utils._telemetry.get_session", get_session_mock)
+        yield
 
-        self.patcher = patch("huggingface_hub.utils._telemetry.get_session", get_session_mock)
-        self.patcher.start()
-
-    def tearDown(self) -> None:
-        self.patcher.stop()
-
-    def test_telemetry_exception_silenced(self, queue: Queue) -> None:
-        with self.assertLogs(logger="huggingface_hub.utils._telemetry", level="DEBUG") as captured:
+    def test_telemetry_exception_silenced(self, caplog) -> None:
+        with caplog.at_level(logging.DEBUG, logger="huggingface_hub.utils._telemetry"):
             send_telemetry(topic="topic")
-            queue.join()
+            self.queue.join()
+
+        records = [r for r in caplog.records if r.name.startswith("huggingface_hub")]
 
         # Assert debug message with traceback for debug purposes
-        self.assertEqual(len(captured.output), 1)
-        self.assertEqual(
-            captured.output[0],
-            "DEBUG:huggingface_hub.utils._telemetry:Error while sending telemetry: whatever",
-        )
+        assert len(records) == 1
+        assert records[0].levelname == "DEBUG"
+        assert records[0].name == "huggingface_hub.utils._telemetry"
+        assert records[0].getMessage() == "Error while sending telemetry: whatever"

--- a/tests/test_utils_terminal.py
+++ b/tests/test_utils_terminal.py
@@ -1,69 +1,45 @@
 import os
-import unittest
 from unittest import mock
+
+import pytest
 
 from huggingface_hub.utils._terminal import ANSI, tabulate
 
 
-class TestCLIUtils(unittest.TestCase):
+class TestCLIUtils:
     @mock.patch.dict(os.environ, {}, clear=True)
     def test_ansi_utils(self) -> None:
         """Test `ANSI` works as expected."""
-        self.assertEqual(
-            ANSI.bold("this is bold"),
-            "\x1b[1mthis is bold\x1b[0m",
-        )
+        assert ANSI.bold("this is bold") == "\x1b[1mthis is bold\x1b[0m"
 
-        self.assertEqual(
-            ANSI.gray("this is gray"),
-            "\x1b[90mthis is gray\x1b[0m",
-        )
+        assert ANSI.gray("this is gray") == "\x1b[90mthis is gray\x1b[0m"
 
-        self.assertEqual(
-            ANSI.red("this is red"),
-            "\x1b[1m\x1b[31mthis is red\x1b[0m",
-        )
+        assert ANSI.red("this is red") == "\x1b[1m\x1b[31mthis is red\x1b[0m"
 
-        self.assertEqual(
-            ANSI.gray(ANSI.bold("this is bold and grey")),
-            "\x1b[90m\x1b[1mthis is bold and grey\x1b[0m\x1b[0m",
-        )
+        assert ANSI.gray(ANSI.bold("this is bold and grey")) == "\x1b[90m\x1b[1mthis is bold and grey\x1b[0m\x1b[0m"
 
     @mock.patch.dict(os.environ, {"NO_COLOR": "1"}, clear=True)
     def test_ansi_no_color(self) -> None:
         """Test `ANSI` respects `NO_COLOR` env var."""
 
-        self.assertEqual(
-            ANSI.bold("this is bold"),
-            "this is bold",
-        )
+        assert ANSI.bold("this is bold") == "this is bold"
 
-        self.assertEqual(
-            ANSI.gray("this is gray"),
-            "this is gray",
-        )
+        assert ANSI.gray("this is gray") == "this is gray"
 
-        self.assertEqual(
-            ANSI.red("this is red"),
-            "this is red",
-        )
+        assert ANSI.red("this is red") == "this is red"
 
-        self.assertEqual(
-            ANSI.gray(ANSI.bold("this is bold and grey")),
-            "this is bold and grey",
-        )
+        assert ANSI.gray(ANSI.bold("this is bold and grey")) == "this is bold and grey"
 
     def test_tabulate_utility(self) -> None:
         """Test `tabulate` works as expected."""
         rows = [[1, 2, 3], ["a very long value", "foo", "bar"], ["", 123, 456]]
         headers = ["Header 1", "something else", "a third column"]
-        self.assertEqual(
-            tabulate(rows=rows, headers=headers),
+        assert tabulate(rows=rows, headers=headers) == (
             "Header 1          something else a third column\n"
             "----------------- -------------- --------------\n"
             "1                 2              3             \n"
             "a very long value foo            bar           \n"
-            "                  123            456           ",
+            "                  123            456           "
         )
 
     def test_tabulate_utility_with_too_short_row(self) -> None:
@@ -71,9 +47,5 @@ class TestCLIUtils(unittest.TestCase):
         Test `tabulate` throw IndexError when a row has less values than the header
         list.
         """
-        self.assertRaises(
-            IndexError,
-            tabulate,
-            rows=[[1]],
-            headers=["Header 1", "Header 2"],
-        )
+        with pytest.raises(IndexError):
+            tabulate(rows=[[1]], headers=["Header 1", "Header 2"])

--- a/tests/test_utils_validators.py
+++ b/tests/test_utils_validators.py
@@ -1,6 +1,7 @@
-import unittest
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
+
+import pytest
 
 from huggingface_hub.utils import (
     HFValidationError,
@@ -9,17 +10,18 @@ from huggingface_hub.utils import (
 )
 
 
-@patch("huggingface_hub.utils._validators.validate_repo_id")
-class TestHfHubValidator(unittest.TestCase):
+class TestHfHubValidator:
     """Test `validate_hf_hub_args` decorator calls all default validators."""
 
-    def test_validate_repo_id_as_arg(self, validate_repo_id_mock: Mock) -> None:
+    def test_validate_repo_id_as_arg(self, mocker) -> None:
         """Test `validate_repo_id` is called when `repo_id` is passed as arg."""
+        validate_repo_id_mock: Mock = mocker.patch("huggingface_hub.utils._validators.validate_repo_id")
         self.dummy_function(123)
         validate_repo_id_mock.assert_called_once_with(123)
 
-    def test_validate_repo_id_as_kwarg(self, validate_repo_id_mock: Mock) -> None:
+    def test_validate_repo_id_as_kwarg(self, mocker) -> None:
         """Test `validate_repo_id` is called when `repo_id` is passed as kwarg."""
+        validate_repo_id_mock: Mock = mocker.patch("huggingface_hub.utils._validators.validate_repo_id")
         self.dummy_function(repo_id=123)
         validate_repo_id_mock.assert_called_once_with(123)
 
@@ -29,7 +31,7 @@ class TestHfHubValidator(unittest.TestCase):
         pass
 
 
-class TestRepoIdValidator(unittest.TestCase):
+class TestRepoIdValidator:
     VALID_VALUES = (
         "123",
         "foo",
@@ -56,5 +58,5 @@ class TestRepoIdValidator(unittest.TestCase):
     def test_not_valid_repo_ids(self) -> None:
         """Test `repo_id` validation on not valid values."""
         for repo_id in self.NOT_VALID_VALUES:
-            with self.assertRaises(HFValidationError, msg=f"'{repo_id}' must not be valid"):
+            with pytest.raises(HFValidationError):
                 validate_repo_id(repo_id)

--- a/tests/test_webhooks_server.py
+++ b/tests/test_webhooks_server.py
@@ -1,6 +1,6 @@
-import unittest
 from unittest.mock import patch
 
+import pytest
 from fastapi import Request
 
 from huggingface_hub.utils import capture_output, is_gradio_available
@@ -111,7 +111,7 @@ WEBHOOK_PAYLOAD_WITH_UPDATED_REFS = {
 
 
 @requires("gradio")
-class TestWebhookPayload(unittest.TestCase):
+class TestWebhookPayload:
     def test_deserialize_payload_example_with_comment(self) -> None:
         """Confirm that the test stub can actually be deserialized."""
         payload = WebhookPayload.model_validate(WEBHOOK_PAYLOAD_CREATE_DISCUSSION)
@@ -135,7 +135,7 @@ class TestWebhookPayload(unittest.TestCase):
 
 
 @requires("gradio")
-class TestWebhooksServerDontRun(unittest.TestCase):
+class TestWebhooksServerDontRun:
     def test_add_webhook_implicit_path(self):
         # Test adding a webhook
         app = WebhooksServer()
@@ -144,7 +144,7 @@ class TestWebhooksServerDontRun(unittest.TestCase):
         async def handler():
             pass
 
-        self.assertIn("/webhooks/handler", app.registered_webhooks)
+        assert "/webhooks/handler" in app.registered_webhooks
 
     def test_add_webhook_explicit_path(self):
         # Test adding a webhook
@@ -154,7 +154,7 @@ class TestWebhooksServerDontRun(unittest.TestCase):
         async def handler():
             pass
 
-        self.assertIn("/webhooks/test_webhook", app.registered_webhooks)  # still registered under /webhooks
+        assert "/webhooks/test_webhook" in app.registered_webhooks  # still registered under /webhooks
 
     def test_add_webhook_twice_should_fail(self):
         # Test adding a webhook
@@ -165,7 +165,7 @@ class TestWebhooksServerDontRun(unittest.TestCase):
             pass
 
         # Registering twice the same webhook should raise an error
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
 
             @app.add_webhook("my_webhook")
             async def test_webhook_2():
@@ -173,11 +173,12 @@ class TestWebhooksServerDontRun(unittest.TestCase):
 
 
 @requires("gradio")
-class TestWebhooksServerRun(unittest.TestCase):
+class TestWebhooksServerRun:
     HEADERS_VALID_SECRET = {"x-webhook-secret": "my_webhook_secret"}
     HEADERS_WRONG_SECRET = {"x-webhook-secret": "wrong_webhook_secret"}
 
-    def setUp(self) -> None:
+    @pytest.fixture(autouse=True)
+    def setup(self):
         with gr.Blocks() as ui:
             gr.Markdown("Hello World!")
         app = WebhooksServer(ui=ui, webhook_secret="my_webhook_secret")
@@ -214,7 +215,8 @@ class TestWebhooksServerRun(unittest.TestCase):
         self.app = app
         self.client = self.mocked_run_app()
 
-    def tearDown(self) -> None:
+        yield
+
         self.ui.server.close()
 
     def mocked_run_app(self) -> "TestClient":
@@ -241,32 +243,29 @@ class TestWebhooksServerRun(unittest.TestCase):
         response = self.client.post(
             "/webhooks/test_webhook", headers=self.HEADERS_VALID_SECRET, json=WEBHOOK_PAYLOAD_CREATE_DISCUSSION
         )
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), {"scope": "discussion"})
+        assert response.status_code == 200
+        assert response.json() == {"scope": "discussion"}
 
     def test_with_webhook_secret_should_succeed(self):
         """Test success if valid secret is sent."""
         for path in ["async_with_request", "sync_with_request", "async_no_request", "sync_no_request"]:
-            with self.subTest(path):
-                response = self.client.post(f"/webhooks/{path}", headers=self.HEADERS_VALID_SECRET)
-                self.assertEqual(response.status_code, 200)
-                self.assertEqual(response.json(), {"success": True})
+            response = self.client.post(f"/webhooks/{path}", headers=self.HEADERS_VALID_SECRET)
+            assert response.status_code == 200
+            assert response.json() == {"success": True}
 
     def test_no_webhook_secret_should_be_unauthorized(self):
         """Test failure if valid secret is sent."""
         for path in ["async_with_request", "sync_with_request", "async_no_request", "sync_no_request"]:
-            with self.subTest(path):
-                response = self.client.post(f"/webhooks/{path}")
-                self.assertEqual(response.status_code, 401)
+            response = self.client.post(f"/webhooks/{path}")
+            assert response.status_code == 401
 
     def test_wrong_webhook_secret_should_be_forbidden(self):
         """Test failure if valid secret is sent."""
         for path in ["async_with_request", "sync_with_request", "async_no_request", "sync_no_request"]:
-            with self.subTest(path):
-                response = self.client.post(f"/webhooks/{path}", headers=self.HEADERS_WRONG_SECRET)
-                self.assertEqual(response.status_code, 403)
+            response = self.client.post(f"/webhooks/{path}", headers=self.HEADERS_WRONG_SECRET)
+            assert response.status_code == 403
 
     def test_route_with_explicit_path(self):
         """Test that the route with an explicit path is correctly registered."""
         response = self.client.post("/webhooks/explicit_path", headers=self.HEADERS_VALID_SECRET)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -1,19 +1,13 @@
 """Contains tests that are specific to windows machines."""
 
 import os
-import unittest
+
+import pytest
 
 from huggingface_hub.file_download import are_symlinks_supported
 
 
-def require_windows(test_case):
-    if os.name != "nt":
-        return unittest.skip("test of git lfs workflow")(test_case)
-    else:
-        return test_case
-
-
-@require_windows
-class WindowsTests(unittest.TestCase):
+@pytest.mark.skipif(os.name != "nt", reason="test of git lfs workflow")
+class TestWindows:
     def test_are_symlink_supported(self) -> None:
-        self.assertFalse(are_symlinks_supported())
+        assert not are_symlinks_supported()


### PR DESCRIPTION
Follow-up of https://github.com/huggingface/huggingface_hub/pull/4407 but for remaining tests.

After that one there will be a last PR to remove all unused `testing_utils` + remove `@requires` decorator (still used by torch and gradio tests). Not done in this PR to keep things a little bit self contained.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor with no changes to library behavior; main risk is accidental fixture ordering or cleanup differences affecting CI flakiness.
> 
> **Overview**
> Finishes the **unittest → pytest** migration for the remaining integration and unit test modules (cache layout, file download, HF file system, commit API/scheduler, hub mixin, inference text generation, etc.). Production library code is unchanged.
> 
> Test classes no longer subclass **`unittest.TestCase`**; assertions use plain **`assert`**, and **`pytest.raises` / `pytest.warns`** replace **`assertRaises`** / **`assertWarns`**. Lifecycle hooks become **pytest fixtures**: class-scoped setup/teardown (repos, buckets, shared downloads) use **`@pytest.fixture(scope="class", autouse=True)`** with **`yield`** cleanup, and per-test setup uses **`autouse`** fixtures or injected **`api`**, **`tmp_path`**, and **`repo_factory`**.
> 
> Custom test helpers are swapped for pytest-native equivalents: **`@with_production_testing`** → **`@pytest.mark.production`** (handled in **`conftest`**), **`@skip_on_windows`** → **`@pytest.mark.skipif(os.name == "nt", ...)`**, **`@use_tmp_repo`** → **`repo_factory`**, **`fx_cache_dir` / `self.cache_dir`** → **`tmp_path`**, and **`unittest.mock.patch`** → **`pytest_mock`’s `mocker`**. Several suites rename classes to **`Test*`** and drop **`subTest`** wrappers without changing what they assert.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb75718b605ff0f063593d7034903417733b37f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->