### PR TITLE
fix docstring

### DIFF
--- a/src/huggingface_hub/utils/_paths.py
+++ b/src/huggingface_hub/utils/_paths.py
@@ -98,7 +98,7 @@ def filter_repo_objects(
     ... ],
     ... allow_patterns=["*.pdf"],
     ... ignore_patterns=[".*"],
-    ... key=lambda x: x.repo_in_path
+    ... key=lambda x: x.path_in_repo
     ... ))
     [CommitOperationAdd(path_or_fileobj="/tmp/aaa.pdf", path_in_repo="aaa.pdf")]
     ```


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change; no runtime behavior affected.
> 
> **Overview**
> Corrects the **`filter_repo_objects`** docstring example so the `key` callback uses **`x.path_in_repo`** instead of the non-existent **`x.repo_in_path`**, matching **`CommitOperationAdd`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0fe12bc256b36d40677358da25cd24f217dd6be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->