### PR TITLE
[Sandbox] Background processes + proxy to reach in-sandbox servers

### DIFF
--- a/docs/source/en/guides/sandbox.md
+++ b/docs/source/en/guides/sandbox.md
@@ -78,6 +78,26 @@ A command that exits non-zero raises [`SandboxCommandError`] (with `stdout`, `st
 1
 ```
 
+### Background processes
+
+Pass `background=True` to start a long-running process (a server, a watcher, a training run) without waiting for it. `run` returns a [`SandboxProcess`] right away instead of a [`SandboxCommandResult`]:
+
+```python
+>>> proc = sbx.run("python -m http.server 8000", background=True)
+>>> proc
+SandboxProcess(id='p-3f2a', pid=1234, cmd='python -m http.server 8000')
+```
+
+List the processes running in a sandbox and stop one when you're done:
+
+```python
+>>> sbx.processes()
+[SandboxProcess(id='p-3f2a', pid=1234, cmd='python -m http.server 8000')]
+>>> proc.kill()
+```
+
+The streaming/wait-only options (`timeout`, `stdin`, `on_stdout`, `on_stderr`, `check`) don't apply in background mode — only `env`, `cwd` and `shell` are honored.
+
 ## Files
 
 ```python
@@ -91,6 +111,26 @@ A command that exits non-zero raises [`SandboxCommandError`] (with `stdout`, `st
 ```
 
 Other helpers: `stat`, `exists`, `mkdir`, `delete`.
+
+## Reaching a server inside a sandbox
+
+Start a server in the sandbox (in the background), then reach it from the outside with [`Sandbox.proxy_url_for`] — the request is forwarded by the in-job sandbox server to your inner server, so there's no extra public port to expose. It works for plain HTTP, Server-Sent Events and WebSocket. Pair the URL with [`Sandbox.proxy_headers`] for auth (your WebSocket/HTTP client must send them):
+
+```python
+>>> import httpx
+>>> with Sandbox.create() as sbx:
+...     sbx.files.write("app.py", "...")  # a server exposing e.g. /hello and /ws
+...     sbx.run("uvicorn app:app --host 127.0.0.1 --port 8000", background=True)
+...     # plain HTTP
+...     r = httpx.get(sbx.proxy_url_for(8000, "/hello"), headers=sbx.proxy_headers)
+...     # WebSocket: ask for a wss:// URL
+...     ws_url = sbx.proxy_url_for(8000, "/ws", scheme="wss://")
+```
+
+How the inner server must listen depends on the sandbox kind:
+
+- **Dedicated** ([`Sandbox.create`]): bind a normal TCP port on `127.0.0.1:<port>`.
+- **Pool / shared** ([`SandboxPool`]): pooled sandboxes can't bind a TCP port (Landlock), so listen on a **unix socket** at `$SBX_PROXY_DIR/<port>.sock` (that env var is set in every sandbox), e.g. `uvicorn app:app --uds $SBX_PROXY_DIR/8000.sock`. The client side (`proxy_url_for` / `proxy_headers`) is identical either way.
 
 ## Lifecycle
 
@@ -198,6 +238,16 @@ hi
 
 ```bash
 hf sandbox exec $ID -- pytest && echo "tests passed"
+```
+
+Start a long-running process in the background with `hf sandbox spawn` (prints a process id), then list or stop processes:
+
+```bash
+>>> hf sandbox spawn $ID -- python -m http.server 8000
+✓ Process started sandbox=687f... process=p-3f2a pid=1234
+
+>>> hf sandbox process ls $ID
+>>> hf sandbox process kill $ID p-3f2a
 ```
 
 For many cheap shared sandboxes, warm a pool once and then create into it on demand:

--- a/docs/source/en/guides/sandbox.md
+++ b/docs/source/en/guides/sandbox.md
@@ -85,14 +85,14 @@ Pass `background=True` to start a long-running process (a server, a watcher, a t
 ```python
 >>> proc = sbx.run("python -m http.server 8000", background=True)
 >>> proc
-SandboxProcess(id='p-3f2a', pid=1234, cmd='python -m http.server 8000')
+SandboxProcess(pid=1234, cmd='python -m http.server 8000', tag=None, started_at_ms=1700000000000, running=True, exit_code=None)
 ```
 
-List the processes running in a sandbox and stop one when you're done:
+List a sandbox's processes and stop one when you're done. Completed processes stay listed (with `running=False` and their `exit_code`) until the sandbox is deleted, so you can tell whether a process is still alive or already exited:
 
 ```python
 >>> sbx.processes()
-[SandboxProcess(id='p-3f2a', pid=1234, cmd='python -m http.server 8000')]
+[SandboxProcess(pid=1234, cmd='python -m http.server 8000', tag=None, started_at_ms=1700000000000, running=True, exit_code=None)]
 >>> proc.kill()
 ```
 
@@ -240,14 +240,17 @@ hi
 hf sandbox exec $ID -- pytest && echo "tests passed"
 ```
 
-Start a long-running process in the background with `hf sandbox spawn` (prints a process id), then list or stop processes:
+Start a long-running process in the background with `hf sandbox spawn` (prints its pid), then list or stop processes. The listing shows each process's status (`running` or `exited (<code>)`):
 
 ```bash
 >>> hf sandbox spawn $ID -- python -m http.server 8000
-✓ Process started sandbox=687f... process=p-3f2a pid=1234
+✓ Process started sandbox=687f... pid=1234
 
 >>> hf sandbox process ls $ID
->>> hf sandbox process kill $ID p-3f2a
+pid   status   cmd
+1234  running  python -m http.server 8000
+
+>>> hf sandbox process kill $ID 1234
 ```
 
 For many cheap shared sandboxes, warm a pool once and then create into it on demand:

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -3696,6 +3696,8 @@ $ hf sandbox [OPTIONS] COMMAND [ARGS]...
 * `exec`: Run a command in a sandbox, streaming output.
 * `kill`: Terminate a sandbox, a whole shared host,...
 * `pool`: Warm pools of host VMs and spawn cheap...
+* `process`: List and stop background processes running...
+* `spawn`: Start a long-running command in the...
 
 ### `hf sandbox cp`
 
@@ -3775,6 +3777,9 @@ Learn more
 ### `hf sandbox exec`
 
 Run a command in a sandbox, streaming output. Exits with the command's exit code.
+
+To start a long-running command in the background instead of waiting for it, use
+`hf sandbox spawn`.
 
 **Usage**:
 
@@ -3939,6 +3944,118 @@ $ hf sandbox pool ls [OPTIONS]
 
 Examples
   $ hf sandbox pool ls
+
+Learn more
+  Use `hf <command> --help` for more information about a command.
+  Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
+
+
+### `hf sandbox process`
+
+List and stop background processes running in a sandbox.
+
+**Usage**:
+
+```console
+$ hf sandbox process [OPTIONS] COMMAND [ARGS]...
+```
+
+**Options**:
+
+* `--help`: Show this message and exit.
+
+**Commands**:
+
+* `kill`: Stop a background process running in a...
+* `ls`: List the background processes running in a... [alias: list]
+
+#### `hf sandbox process kill`
+
+Stop a background process running in a sandbox.
+
+**Usage**:
+
+```console
+$ hf sandbox process kill [OPTIONS] SANDBOX_ID PROCESS_ID
+```
+
+**Arguments**:
+
+* `SANDBOX_ID`: The sandbox id as printed by `hf sandbox create`.  [required]
+* `PROCESS_ID`: The process id as printed by `hf sandbox process ls`.  [required]
+
+**Options**:
+
+* `--namespace TEXT`: The namespace where the job will be running. Defaults to the current user's namespace.
+* `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
+* `--help`: Show this message and exit.
+
+Examples
+  $ hf sandbox process kill <sandbox_id> <process_id>
+
+Learn more
+  Use `hf <command> --help` for more information about a command.
+  Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
+
+
+#### `hf sandbox process ls`
+
+List the background processes running in a sandbox (started with `hf sandbox spawn`). [alias: list]
+
+**Usage**:
+
+```console
+$ hf sandbox process ls [OPTIONS] SANDBOX_ID
+```
+
+**Arguments**:
+
+* `SANDBOX_ID`: The sandbox id as printed by `hf sandbox create`.  [required]
+
+**Options**:
+
+* `--namespace TEXT`: The namespace where the job will be running. Defaults to the current user's namespace.
+* `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
+* `--help`: Show this message and exit.
+
+Examples
+  $ hf sandbox process ls <sandbox_id>
+
+Learn more
+  Use `hf <command> --help` for more information about a command.
+  Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
+
+
+### `hf sandbox spawn`
+
+Start a long-running command in the background and return its process id (don't wait).
+
+List a sandbox's processes with `hf sandbox process ls` and stop one with
+`hf sandbox process kill`.
+
+**Usage**:
+
+```console
+$ hf sandbox spawn [OPTIONS] SANDBOX_ID COMMAND...
+```
+
+**Arguments**:
+
+* `SANDBOX_ID`: The sandbox id as printed by `hf sandbox create`.  [required]
+* `COMMAND...`: The command to run in the background.  [required]
+
+**Options**:
+
+* `-w, --workdir TEXT`: Working directory.
+* `-e, --env TEXT`: Set environment variables. E.g. --env ENV=value
+* `--env-file TEXT`: Read in a file of environment variables.
+* `--namespace TEXT`: The namespace where the job will be running. Defaults to the current user's namespace.
+* `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
+* `--help`: Show this message and exit.
+
+Examples
+  $ hf sandbox spawn <sandbox_id> -- python -m http.server 8000
+  $ hf sandbox spawn -w /app <sandbox_id> -- uvicorn app:app
 
 Learn more
   Use `hf <command> --help` for more information about a command.

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -3976,13 +3976,13 @@ Stop a background process running in a sandbox.
 **Usage**:
 
 ```console
-$ hf sandbox process kill [OPTIONS] SANDBOX_ID PROCESS_ID
+$ hf sandbox process kill [OPTIONS] SANDBOX_ID PID
 ```
 
 **Arguments**:
 
 * `SANDBOX_ID`: The sandbox id as printed by `hf sandbox create`.  [required]
-* `PROCESS_ID`: The process id as printed by `hf sandbox process ls`.  [required]
+* `PID`: The pid as printed by `hf sandbox process ls`.  [required]
 
 **Options**:
 
@@ -3991,7 +3991,7 @@ $ hf sandbox process kill [OPTIONS] SANDBOX_ID PROCESS_ID
 * `--help`: Show this message and exit.
 
 Examples
-  $ hf sandbox process kill <sandbox_id> <process_id>
+  $ hf sandbox process kill <sandbox_id> <pid>
 
 Learn more
   Use `hf <command> --help` for more information about a command.
@@ -4028,7 +4028,7 @@ Learn more
 
 ### `hf sandbox spawn`
 
-Start a long-running command in the background and return its process id (don't wait).
+Start a long-running command in the background and return its pid (don't wait).
 
 List a sandbox's processes with `hf sandbox process ls` and stop one with
 `hf sandbox process kill`.

--- a/docs/source/en/package_reference/sandbox.md
+++ b/docs/source/en/package_reference/sandbox.md
@@ -20,6 +20,10 @@ Check out the [Sandboxes guide](../guides/sandbox) to learn how to use them.
 
 [[autodoc]] SandboxCommandResult
 
+### SandboxProcess
+
+[[autodoc]] SandboxProcess
+
 ### FileEntry
 
 [[autodoc]] huggingface_hub._sandbox.FileEntry

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -106,6 +106,7 @@ _SUBMOD_ATTRS = {
         "Sandbox",
         "SandboxCommandResult",
         "SandboxPool",
+        "SandboxProcess",
     ],
     "_snapshot_download": [
         "snapshot_download",
@@ -820,6 +821,7 @@ __all__ = [
     "Sandbox",
     "SandboxCommandResult",
     "SandboxPool",
+    "SandboxProcess",
     "SentenceSimilarityInput",
     "SentenceSimilarityInputData",
     "SpaceCard",
@@ -1286,6 +1288,7 @@ if TYPE_CHECKING:  # pragma: no cover
         Sandbox,  # noqa: F401
         SandboxCommandResult,  # noqa: F401
         SandboxPool,  # noqa: F401
+        SandboxProcess,  # noqa: F401
     )
     from ._snapshot_download import snapshot_download  # noqa: F401
     from ._space_api import (

--- a/src/huggingface_hub/_sandbox.py
+++ b/src/huggingface_hub/_sandbox.py
@@ -131,19 +131,24 @@ class SandboxCommandResult:
 class SandboxProcess:
     """A background process started in a sandbox with [`Sandbox.run`]`(..., background=True)`.
 
-    List a sandbox's running processes with [`Sandbox.processes`] and stop one with [`SandboxProcess.kill`].
+    List a sandbox's processes with [`Sandbox.processes`] and stop one with [`SandboxProcess.kill`].
+    Completed processes stay in the listing until the sandbox is deleted, so `running` and
+    `exit_code` tell whether a process is still alive or already exited (as of when it was listed).
     """
 
-    id: str
     pid: int
     cmd: str | List[str]
     # Back-reference to the sandbox, used by `kill()`. Excluded from repr/eq so a process
-    # stays a plain data object (and two with the same id compare equal).
+    # stays a plain data object (and two with the same pid compare equal).
     _sandbox: "Sandbox" = field(repr=False, compare=False)
+    tag: str | None = None
+    started_at_ms: int | None = None
+    running: bool = True
+    exit_code: int | None = None
 
     def kill(self) -> None:
         """Terminate the background process (idempotent server-side)."""
-        self._sandbox._request("DELETE", f"/processes/{self.id}")
+        self._sandbox._request("DELETE", f"/processes/{self.pid}")
 
 
 @dataclass
@@ -776,7 +781,7 @@ class Sandbox:
             payload["cwd"] = cwd
         if background:
             data = self._request("POST", "/processes", json=payload).json()
-            return SandboxProcess(id=data["id"], pid=data["pid"], cmd=cmd, _sandbox=self)
+            return SandboxProcess(pid=data["pid"], cmd=cmd, tag=data.get("tag"), _sandbox=self)
         if timeout is not None:
             payload["timeout"] = timeout
         if stdin is not None:
@@ -811,13 +816,25 @@ class Sandbox:
         return result
 
     def processes(self) -> List[SandboxProcess]:
-        """List the background processes currently running in this sandbox.
+        """List the background processes of this sandbox.
 
         Returns the processes started with [`Sandbox.run`]`(..., background=True)`; stop one
-        with [`SandboxProcess.kill`].
+        with [`SandboxProcess.kill`]. Completed processes stay listed (with `running=False` and
+        their `exit_code`) until the sandbox is deleted.
         """
         data = self._request("GET", "/processes").json()
-        return [SandboxProcess(id=p["id"], pid=p["pid"], cmd=p["cmd"], _sandbox=self) for p in data]
+        return [
+            SandboxProcess(
+                pid=p["pid"],
+                cmd=p["cmd"],
+                tag=p.get("tag"),
+                started_at_ms=p.get("started_at_ms"),
+                running=p["running"],
+                exit_code=p.get("exit_code"),
+                _sandbox=self,
+            )
+            for p in data
+        ]
 
     # ------------------------------------------------------------------ misc
 

--- a/src/huggingface_hub/_sandbox.py
+++ b/src/huggingface_hub/_sandbox.py
@@ -761,6 +761,51 @@ class Sandbox:
         """For a shared/pool sandbox, the job id of the host running it (else None)."""
         return self._server.job_id if self._local_id is not None else None
 
+    # ------------------------------------------------------------------ port proxy
+
+    def proxy_url(self, port: int | str, path: str = "/") -> str:
+        """Public URL that proxies through to a server running *inside* this sandbox.
+
+        Requests to the returned URL are forwarded by the in-job sandbox server to a
+        server you started in the sandbox on `port`, including WebSocket (`ws(s)://`)
+        upgrades and streamed responses. Pair it with [`proxy_headers`] for auth.
+
+        How the sandbox must listen on `port`:
+
+        - **Pool / shared sandbox**: it cannot bind a TCP port (Landlock), so bind a
+          **unix socket** at `$SBX_PROXY_DIR/<port>.sock` (the `SBX_PROXY_DIR` env var
+          is set in every sandbox). E.g. `uvicorn app:app --uds $SBX_PROXY_DIR/8000.sock`.
+        - **Dedicated sandbox**: bind a normal TCP port on `127.0.0.1:<port>`. (You can
+          also expose the port directly via the job proxy without going through here.)
+
+        Args:
+            port (`int` or `str`):
+                The port (pool: the `<port>` of the unix socket) the inner server listens on.
+            path (`str`, *optional*, defaults to `"/"`):
+                Path on the inner server to point at, e.g. `"/ws"`.
+
+        Returns:
+            `str`: a URL like `https://<job_id>--49983.hf.jobs/v1/.../proxy/8000/ws`.
+            Switch the scheme to `wss` for WebSocket clients.
+
+        Example:
+            ```python
+            >>> url = sandbox.proxy_url(8000, "/ws").replace("https://", "wss://")
+            >>> import websockets
+            >>> async with websockets.connect(url, additional_headers=sandbox.proxy_headers) as ws:
+            ...     await ws.send("hello")
+            ```
+        """
+        return f"{self._server.base_url}{self._base_path}/proxy/{port}{path if path.startswith('/') else '/' + path}"
+
+    @property
+    def proxy_headers(self) -> dict[str, str]:
+        """Auth headers to send with [`proxy_url`] requests (HF token + sandbox token)."""
+        return {
+            "Authorization": f"Bearer {self._server._auth_token}",
+            "X-Sandbox-Token": self._server._sandbox_token,
+        }
+
     def __repr__(self) -> str:
         return f"Sandbox(id={self.id!r}, image={self.image!r})"
 

--- a/src/huggingface_hub/_sandbox.py
+++ b/src/huggingface_hub/_sandbox.py
@@ -893,7 +893,7 @@ class Sandbox:
 
     @property
     def proxy_headers(self) -> dict[str, str]:
-        """Auth headers to send with [`proxy_url`] requests (HF token + sandbox token)."""
+        """Auth headers to send with [`proxy_url_for`] requests (HF token + sandbox token)."""
         return {
             "Authorization": f"Bearer {self._server._auth_token}",
             "X-Sandbox-Token": self._server._sandbox_token,

--- a/src/huggingface_hub/_sandbox.py
+++ b/src/huggingface_hub/_sandbox.py
@@ -19,7 +19,7 @@ import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from secrets import token_hex
 from typing import Any, BinaryIO, Callable, Iterator, List, Literal, overload
@@ -125,6 +125,25 @@ class SandboxCommandResult:
     def __repr__(self) -> str:
         out = self.stdout if len(self.stdout) <= 80 else self.stdout[:77] + "..."
         return f"SandboxCommandResult(exit_code={self.exit_code}, stdout={out!r}, duration_ms={self.duration_ms})"
+
+
+@dataclass
+class SandboxProcess:
+    """A background process started in a sandbox with [`Sandbox.run`]`(..., background=True)`.
+
+    List a sandbox's running processes with [`Sandbox.processes`] and stop one with [`SandboxProcess.kill`].
+    """
+
+    id: str
+    pid: int
+    cmd: str | List[str]
+    # Back-reference to the sandbox, used by `kill()`. Excluded from repr/eq so a process
+    # stays a plain data object (and two with the same id compare equal).
+    _sandbox: "Sandbox" = field(repr=False, compare=False)
+
+    def kill(self) -> None:
+        """Terminate the background process (idempotent server-side)."""
+        self._sandbox._request("DELETE", f"/processes/{self.id}")
 
 
 @dataclass
@@ -671,6 +690,33 @@ class Sandbox:
 
     # ------------------------------------------------------------------ exec
 
+    @overload
+    def run(
+        self,
+        cmd: str | List[str],
+        *,
+        shell: bool | None = ...,
+        env: dict[str, Any] | None = ...,
+        cwd: str | None = ...,
+        timeout: float | None = ...,
+        stdin: str | None = ...,
+        on_stdout: Callable[[str], None] | None = ...,
+        on_stderr: Callable[[str], None] | None = ...,
+        check: bool = ...,
+        background: Literal[False] = ...,
+    ) -> SandboxCommandResult: ...
+
+    @overload
+    def run(
+        self,
+        cmd: str | List[str],
+        *,
+        shell: bool | None = ...,
+        env: dict[str, Any] | None = ...,
+        cwd: str | None = ...,
+        background: Literal[True],
+    ) -> SandboxProcess: ...
+
     def run(
         self,
         cmd: str | List[str],
@@ -683,8 +729,15 @@ class Sandbox:
         on_stdout: Callable[[str], None] | None = None,
         on_stderr: Callable[[str], None] | None = None,
         check: bool = True,
-    ) -> SandboxCommandResult:
+        background: bool = False,
+    ) -> SandboxCommandResult | SandboxProcess:
         """Run a command in the sandbox and wait for it, streaming output live.
+
+        With `background=True` the command is started detached and `run` returns a
+        [`SandboxProcess`] immediately, without waiting for it to finish — handy for
+        servers and other long-running processes. List them later with [`Sandbox.processes`]
+        and stop one with [`SandboxProcess.kill`]. The streaming/wait-only options
+        (`timeout`, `stdin`, `on_stdout`, `on_stderr`, `check`) don't apply in that mode.
 
         Args:
             cmd (`str` or `List[str]`):
@@ -709,14 +762,21 @@ class Sandbox:
                 Callback invoked with stderr chunks as they arrive.
             check (`bool`, *optional*, defaults to `True`):
                 If True, raise [`SandboxCommandError`] on non-zero exit.
+            background (`bool`, *optional*, defaults to `False`):
+                If True, start the command detached and return a [`SandboxProcess`] right
+                away instead of waiting for it and returning a [`SandboxCommandResult`].
 
-        Returns: [`SandboxCommandResult`] with `exit_code`, `stdout`, `stderr`, `duration_ms`.
+        Returns: a [`SandboxCommandResult`] (with `exit_code`, `stdout`, `stderr`,
+        `duration_ms`), or a [`SandboxProcess`] when `background=True`.
         """
         payload = _exec_payload(cmd, shell)
         if env:
             payload["env"] = env
         if cwd:
             payload["cwd"] = cwd
+        if background:
+            data = self._request("POST", "/processes", json=payload).json()
+            return SandboxProcess(id=data["id"], pid=data["pid"], cmd=cmd, _sandbox=self)
         if timeout is not None:
             payload["timeout"] = timeout
         if stdin is not None:
@@ -750,6 +810,15 @@ class Sandbox:
             raise SandboxCommandError(cmd=cmd, result=result)
         return result
 
+    def processes(self) -> List[SandboxProcess]:
+        """List the background processes currently running in this sandbox.
+
+        Returns the processes started with [`Sandbox.run`]`(..., background=True)`; stop one
+        with [`SandboxProcess.kill`].
+        """
+        data = self._request("GET", "/processes").json()
+        return [SandboxProcess(id=p["id"], pid=p["pid"], cmd=p["cmd"], _sandbox=self) for p in data]
+
     # ------------------------------------------------------------------ misc
 
     @property
@@ -763,7 +832,7 @@ class Sandbox:
 
     # ------------------------------------------------------------------ port proxy
 
-    def proxy_url(self, port: int | str, path: str = "/") -> str:
+    def proxy_url_for(self, port: int | str, path: str = "/", *, scheme: str = "https://") -> str:
         """Public URL that proxies through to a server running *inside* this sandbox.
 
         Requests to the returned URL are forwarded by the in-job sandbox server to a
@@ -783,20 +852,27 @@ class Sandbox:
                 The port (pool: the `<port>` of the unix socket) the inner server listens on.
             path (`str`, *optional*, defaults to `"/"`):
                 Path on the inner server to point at, e.g. `"/ws"`.
+            scheme (`str`, *optional*, defaults to `"https://"`):
+                URL scheme to build the link with. Defaults to `"https://"`; pass
+                `"wss://"` for a WebSocket client (the proxy is protocol-agnostic, so only
+                the client-side scheme changes).
 
         Returns:
-            `str`: a URL like `https://<job_id>--49983.hf.jobs/v1/.../proxy/8000/ws`.
-            Switch the scheme to `wss` for WebSocket clients.
+            `str`: a URL like `https://<job_id>--49983.hf.jobs/v1/.../proxy/8000/ws` (or
+            `wss://...` with `scheme="wss://"`).
 
         Example:
             ```python
-            >>> url = sandbox.proxy_url(8000, "/ws").replace("https://", "wss://")
+            >>> url = sandbox.proxy_url_for(8000, "/ws", scheme="wss://")
             >>> import websockets
             >>> async with websockets.connect(url, additional_headers=sandbox.proxy_headers) as ws:
             ...     await ws.send("hello")
             ```
         """
-        return f"{self._server.base_url}{self._base_path}/proxy/{port}{path if path.startswith('/') else '/' + path}"
+        # base_url is always https://...; swap in the requested scheme (e.g. wss://) for the client.
+        host_and_rest = self._server.base_url.split("://", 1)[-1]
+        path = path if path.startswith("/") else "/" + path
+        return f"{scheme}{host_and_rest}{self._base_path}/proxy/{port}{path}"
 
     @property
     def proxy_headers(self) -> dict[str, str]:

--- a/src/huggingface_hub/cli/sandbox.py
+++ b/src/huggingface_hub/cli/sandbox.py
@@ -55,6 +55,8 @@ from .jobs import FlavorOpt, NamespaceOpt
 sandbox_cli = typer_factory(help="Run and manage sandboxes on Hugging Face Jobs.")
 pool_cli = typer_factory(help="Warm pools of host VMs and spawn cheap shared sandboxes from them.")
 sandbox_cli.add_typer(pool_cli, name="pool")
+process_cli = typer_factory(help="List and stop background processes running in a sandbox.")
+sandbox_cli.add_typer(process_cli, name="process")
 
 SandboxIdArg = Annotated[str, typer.Argument(help="The sandbox id as printed by `hf sandbox create`.")]
 
@@ -163,7 +165,11 @@ def sandbox_exec(
     namespace: NamespaceOpt = None,
     token: TokenOpt = None,
 ) -> None:
-    """Run a command in a sandbox, streaming output. Exits with the command's exit code."""
+    """Run a command in a sandbox, streaming output. Exits with the command's exit code.
+
+    To start a long-running command in the background instead of waiting for it, use
+    `hf sandbox spawn`.
+    """
 
     def write_stdout(data: str) -> None:
         sys.stdout.write(data)
@@ -188,6 +194,35 @@ def sandbox_exec(
         raise typer.Exit(code=result.exit_code or 124)  # 124: conventional timeout exit code
     if result.exit_code != 0:
         raise typer.Exit(code=result.exit_code if result.exit_code is not None else 1)
+
+
+@sandbox_cli.command(
+    "spawn",
+    context_settings={"ignore_unknown_options": True},
+    examples=[
+        "hf sandbox spawn <sandbox_id> -- python -m http.server 8000",
+        "hf sandbox spawn -w /app <sandbox_id> -- uvicorn app:app",
+    ],
+)
+def sandbox_spawn(
+    sandbox_id: SandboxIdArg,
+    command: Annotated[list[str], typer.Argument(help="The command to run in the background.")],
+    workdir: Annotated[str | None, typer.Option("-w", "--workdir", help="Working directory.")] = None,
+    env: EnvOpt = None,
+    env_file: EnvFileOpt = None,
+    namespace: NamespaceOpt = None,
+    token: TokenOpt = None,
+) -> None:
+    """Start a long-running command in the background and return its process id (don't wait).
+
+    List a sandbox's processes with `hf sandbox process ls` and stop one with
+    `hf sandbox process kill`.
+    """
+    with _connect(sandbox_id, namespace=namespace, token=token) as sandbox:
+        process = sandbox.run(list(command), env=parse_env_map(env, env_file), cwd=workdir, background=True)
+    out.result("Process started", sandbox=sandbox_id, process=process.id, pid=process.pid)
+    out.hint(f"List processes with `hf sandbox process ls {sandbox_id}`.")
+    out.hint(f"Stop it with `hf sandbox process kill {sandbox_id} {process.id}`.")
 
 
 @sandbox_cli.command(
@@ -402,3 +437,40 @@ def pool_delete(
         api.cancel_job(job_id=job.id, namespace=job.owner.name)
     delete_pool_cache(pool_id)
     out.result("Pool deleted", id=pool_id, hosts_terminated=len(hosts))
+
+
+def _fmt_cmd(cmd: str | list[str]) -> str:
+    return cmd if isinstance(cmd, str) else " ".join(cmd)
+
+
+@process_cli.command("ls | list", examples=["hf sandbox process ls <sandbox_id>"])
+def process_ls(
+    sandbox_id: SandboxIdArg,
+    namespace: NamespaceOpt = None,
+    token: TokenOpt = None,
+) -> None:
+    """List the background processes running in a sandbox (started with `hf sandbox spawn`)."""
+    with _connect(sandbox_id, namespace=namespace, token=token) as sandbox:
+        processes = sandbox.processes()
+    rows = [{"id": p.id, "pid": p.pid, "cmd": _fmt_cmd(p.cmd)} for p in processes]
+    out.table(rows, id_key="id")
+    if not rows:
+        out.hint(f"Start one with `hf sandbox spawn {sandbox_id} -- <cmd>`.")
+    else:
+        out.hint(f"Stop one with `hf sandbox process kill {sandbox_id} <process_id>`.")
+
+
+@process_cli.command("kill", examples=["hf sandbox process kill <sandbox_id> <process_id>"])
+def process_kill(
+    sandbox_id: SandboxIdArg,
+    process_id: Annotated[str, typer.Argument(help="The process id as printed by `hf sandbox process ls`.")],
+    namespace: NamespaceOpt = None,
+    token: TokenOpt = None,
+) -> None:
+    """Stop a background process running in a sandbox."""
+    with _connect(sandbox_id, namespace=namespace, token=token) as sandbox:
+        process = next((p for p in sandbox.processes() if p.id == process_id), None)
+        if process is None:
+            raise CLIError(f"No process '{process_id}' running in sandbox {sandbox_id}.")
+        process.kill()
+    out.result("Process stopped", sandbox=sandbox_id, process=process_id)

--- a/src/huggingface_hub/cli/sandbox.py
+++ b/src/huggingface_hub/cli/sandbox.py
@@ -31,6 +31,7 @@ from huggingface_hub._sandbox import (
     SHARED_ID_SEP,
     Sandbox,
     SandboxPool,
+    SandboxProcess,
     _split_sandbox_id,
 )
 from huggingface_hub._sandbox_cache import delete_pool_cache
@@ -213,16 +214,16 @@ def sandbox_spawn(
     namespace: NamespaceOpt = None,
     token: TokenOpt = None,
 ) -> None:
-    """Start a long-running command in the background and return its process id (don't wait).
+    """Start a long-running command in the background and return its pid (don't wait).
 
     List a sandbox's processes with `hf sandbox process ls` and stop one with
     `hf sandbox process kill`.
     """
     with _connect(sandbox_id, namespace=namespace, token=token) as sandbox:
         process = sandbox.run(list(command), env=parse_env_map(env, env_file), cwd=workdir, background=True)
-    out.result("Process started", sandbox=sandbox_id, process=process.id, pid=process.pid)
+    out.result("Process started", sandbox=sandbox_id, pid=process.pid)
     out.hint(f"List processes with `hf sandbox process ls {sandbox_id}`.")
-    out.hint(f"Stop it with `hf sandbox process kill {sandbox_id} {process.id}`.")
+    out.hint(f"Stop it with `hf sandbox process kill {sandbox_id} {process.pid}`.")
 
 
 @sandbox_cli.command(
@@ -443,6 +444,12 @@ def _fmt_cmd(cmd: str | list[str]) -> str:
     return cmd if isinstance(cmd, str) else " ".join(cmd)
 
 
+def _fmt_status(process: SandboxProcess) -> str:
+    if process.running:
+        return "running"
+    return "exited" if process.exit_code is None else f"exited ({process.exit_code})"
+
+
 @process_cli.command("ls | list", examples=["hf sandbox process ls <sandbox_id>"])
 def process_ls(
     sandbox_id: SandboxIdArg,
@@ -452,25 +459,25 @@ def process_ls(
     """List the background processes running in a sandbox (started with `hf sandbox spawn`)."""
     with _connect(sandbox_id, namespace=namespace, token=token) as sandbox:
         processes = sandbox.processes()
-    rows = [{"id": p.id, "pid": p.pid, "cmd": _fmt_cmd(p.cmd)} for p in processes]
-    out.table(rows, id_key="id")
+    rows = [{"pid": p.pid, "status": _fmt_status(p), "cmd": _fmt_cmd(p.cmd)} for p in processes]
+    out.table(rows, id_key="pid")
     if not rows:
         out.hint(f"Start one with `hf sandbox spawn {sandbox_id} -- <cmd>`.")
     else:
-        out.hint(f"Stop one with `hf sandbox process kill {sandbox_id} <process_id>`.")
+        out.hint(f"Stop one with `hf sandbox process kill {sandbox_id} <pid>`.")
 
 
-@process_cli.command("kill", examples=["hf sandbox process kill <sandbox_id> <process_id>"])
+@process_cli.command("kill", examples=["hf sandbox process kill <sandbox_id> <pid>"])
 def process_kill(
     sandbox_id: SandboxIdArg,
-    process_id: Annotated[str, typer.Argument(help="The process id as printed by `hf sandbox process ls`.")],
+    pid: Annotated[int, typer.Argument(help="The pid as printed by `hf sandbox process ls`.")],
     namespace: NamespaceOpt = None,
     token: TokenOpt = None,
 ) -> None:
     """Stop a background process running in a sandbox."""
     with _connect(sandbox_id, namespace=namespace, token=token) as sandbox:
-        process = next((p for p in sandbox.processes() if p.id == process_id), None)
+        process = next((p for p in sandbox.processes() if p.pid == pid), None)
         if process is None:
-            raise CLIError(f"No process '{process_id}' running in sandbox {sandbox_id}.")
+            raise CLIError(f"No process with pid {pid} in sandbox {sandbox_id}.")
         process.kill()
-    out.result("Process stopped", sandbox=sandbox_id, process=process_id)
+    out.result("Process stopped", sandbox=sandbox_id, pid=pid)

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -79,6 +79,8 @@ class _FakeServer(BaseHTTPRequestHandler):
     capacity = None  # None == unlimited; set per-subclass to test the full handshake
     seq = 0  # monotonic id source (survives deletes)
     last_exec: dict | None = None  # body of the most recent /exec call (for assertions)
+    processes: list = []  # background processes started via /processes
+    proc_seq = 0  # monotonic process id source
 
     def log_message(self, *args) -> None:
         pass
@@ -114,11 +116,17 @@ class _FakeServer(BaseHTTPRequestHandler):
     def do_POST(self) -> None:
         assert self.headers["X-Sandbox-Token"] == "secret"
         body = json.loads(self.rfile.read(int(self.headers.get("Content-Length", 0))) or b"{}")
+        cls = type(self)
         # exec (dedicated /v1/exec or shared /v1/sandboxes/<id>/exec)
         if self.path == "/v1/exec" or (self.path.startswith("/v1/sandboxes/") and self.path.endswith("/exec")):
             self._exec(body)
+        elif self.path.endswith("/processes"):  # spawn a background process
+            type(self).last_exec = body
+            proc = {"id": f"proc{cls.proc_seq}", "pid": 9000 + cls.proc_seq, "cmd": body["cmd"]}
+            cls.proc_seq += 1
+            cls.processes.append(proc)
+            self._json(proc)
         elif self.path == "/v1/sandboxes":  # batch-create sandboxes (server-authoritative capacity)
-            cls = type(self)
             count = int(body.get("count", 1))
             created = []
             rejected = 0
@@ -134,9 +142,13 @@ class _FakeServer(BaseHTTPRequestHandler):
 
     def do_DELETE(self) -> None:
         assert self.headers["X-Sandbox-Token"] == "secret"
-        sid = self.path.rsplit("/", 1)[-1]
-        type(self).sandboxes.discard(sid)
-        self._json({"id": sid, "deleted": True})
+        last = self.path.rsplit("/", 1)[-1]
+        if "/processes/" in self.path:  # kill a background process
+            type(self).processes = [p for p in type(self).processes if p["id"] != last]
+            self._json({"id": last, "killed": True})
+            return
+        type(self).sandboxes.discard(last)
+        self._json({"id": last, "deleted": True})
 
     def do_GET(self) -> None:
         cls = type(self)
@@ -147,6 +159,8 @@ class _FakeServer(BaseHTTPRequestHandler):
             self.send_header("Content-Length", "5")
             self.end_headers()
             self.wfile.write(b"hello")
+        elif self.path.endswith("/processes"):  # list background processes
+            self._json(cls.processes)
         elif self.path == "/v1/sandboxes":
             self._json([{"id": sid} for sid in sorted(cls.sandboxes)])
 
@@ -157,6 +171,8 @@ def fake_server():
     _FakeServer.seq = 0
     _FakeServer.capacity = None
     _FakeServer.last_exec = None
+    _FakeServer.processes = []
+    _FakeServer.proc_seq = 0
     server = ThreadingHTTPServer(("127.0.0.1", 0), _FakeServer)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
@@ -170,6 +186,8 @@ def _spawn_fake(capacity=None):
     class _Fake(_FakeServer):
         sandboxes: set = set()
         seq = 0
+        processes: list = []
+        proc_seq = 0
 
     _Fake.capacity = capacity
     server = ThreadingHTTPServer(("127.0.0.1", 0), _Fake)
@@ -224,6 +242,36 @@ class TestSandboxClient:
     def test_files_read(self, fake_server: str) -> None:
         sandbox = _make_sandbox(fake_server)
         assert sandbox.files.read_text("/x") == "hello"
+
+    def test_run_background_returns_process(self, fake_server: str) -> None:
+        sandbox = _make_sandbox(fake_server)
+        process = sandbox.run("python -m http.server 8000", background=True)
+        assert isinstance(process, sandbox_mod.SandboxProcess)
+        assert process.id == "proc0"
+        assert process.cmd == "python -m http.server 8000"
+        # background spawn doesn't stream/wait: the cmd/shell payload is POSTed as-is.
+        assert _FakeServer.last_exec == {"cmd": "python -m http.server 8000"}
+
+    def test_processes_list_and_kill(self, fake_server: str) -> None:
+        sandbox = _make_sandbox(fake_server)
+        sandbox.run(["sleep", "100"], background=True)
+        sandbox.run("sleep 200", background=True)
+        processes = sandbox.processes()
+        assert [p.id for p in processes] == ["proc0", "proc1"]
+        assert processes[0].cmd == ["sleep", "100"]
+        processes[0].kill()
+        assert [p.id for p in sandbox.processes()] == ["proc1"]
+
+    def test_proxy_url_for(self, fake_server: str) -> None:
+        sandbox = _make_sandbox(fake_server)
+        host = fake_server.split("://", 1)[-1]
+        # default scheme is https; the in-sandbox port and path are appended under /v1/proxy.
+        assert sandbox.proxy_url_for(8000, "/hello") == f"https://{host}/v1/proxy/8000/hello"
+        # a path without a leading slash is normalized.
+        assert sandbox.proxy_url_for(8000, "ws").endswith("/v1/proxy/8000/ws")
+        # the scheme is swapped in for WebSocket clients (host/path unchanged).
+        assert sandbox.proxy_url_for(8000, "/ws", scheme="wss://") == f"wss://{host}/v1/proxy/8000/ws"
+        assert sandbox.proxy_headers["X-Sandbox-Token"] == "secret"
 
     def test_kill_is_idempotent(self, fake_server: str) -> None:
         sandbox = _make_sandbox(fake_server)

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -122,10 +122,17 @@ class _FakeServer(BaseHTTPRequestHandler):
             self._exec(body)
         elif self.path.endswith("/processes"):  # spawn a background process
             type(self).last_exec = body
-            proc = {"id": f"proc{cls.proc_seq}", "pid": 9000 + cls.proc_seq, "cmd": body["cmd"]}
+            proc = {
+                "pid": 9000 + cls.proc_seq,
+                "tag": body.get("tag"),
+                "cmd": body["cmd"],
+                "started_at_ms": 1_700_000_000_000 + cls.proc_seq,
+                "running": True,
+                "exit_code": None,
+            }
             cls.proc_seq += 1
             cls.processes.append(proc)
-            self._json(proc)
+            self._json({"pid": proc["pid"], "tag": proc["tag"]})
         elif self.path == "/v1/sandboxes":  # batch-create sandboxes (server-authoritative capacity)
             count = int(body.get("count", 1))
             created = []
@@ -144,8 +151,8 @@ class _FakeServer(BaseHTTPRequestHandler):
         assert self.headers["X-Sandbox-Token"] == "secret"
         last = self.path.rsplit("/", 1)[-1]
         if "/processes/" in self.path:  # kill a background process
-            type(self).processes = [p for p in type(self).processes if p["id"] != last]
-            self._json({"id": last, "killed": True})
+            type(self).processes = [p for p in type(self).processes if str(p["pid"]) != last]
+            self._json({"pid": last, "killed": True})
             return
         type(self).sandboxes.discard(last)
         self._json({"id": last, "deleted": True})
@@ -247,8 +254,9 @@ class TestSandboxClient:
         sandbox = _make_sandbox(fake_server)
         process = sandbox.run("python -m http.server 8000", background=True)
         assert isinstance(process, sandbox_mod.SandboxProcess)
-        assert process.id == "proc0"
+        assert process.pid == 9000
         assert process.cmd == "python -m http.server 8000"
+        assert process.running is True
         # background spawn doesn't stream/wait: the cmd/shell payload is POSTed as-is.
         assert _FakeServer.last_exec == {"cmd": "python -m http.server 8000"}
 
@@ -257,10 +265,14 @@ class TestSandboxClient:
         sandbox.run(["sleep", "100"], background=True)
         sandbox.run("sleep 200", background=True)
         processes = sandbox.processes()
-        assert [p.id for p in processes] == ["proc0", "proc1"]
+        assert [p.pid for p in processes] == [9000, 9001]
         assert processes[0].cmd == ["sleep", "100"]
+        # status fields from the listing are carried through.
+        assert processes[0].running is True
+        assert processes[0].exit_code is None
+        assert processes[0].started_at_ms == 1_700_000_000_000
         processes[0].kill()
-        assert [p.id for p in sandbox.processes()] == ["proc1"]
+        assert [p.pid for p in sandbox.processes()] == [9001]
 
     def test_proxy_url_for(self, fake_server: str) -> None:
         sandbox = _make_sandbox(fake_server)


### PR DESCRIPTION
Related to
- https://github.com/huggingface/sandbox-server/pull/5
- https://github.com/huggingface/sandbox-server/pull/8
- https://github.com/huggingface/sandbox-server/pull/9
 
Example now working well :+1: (see https://github.com/huggingface/huggingface_hub/pull/4444#issuecomment-4854062970)

## Summary

Two additions to the `Sandbox` API (both were in the original target, trimmed from the first PR to keep it small):

- **Background processes.** `sbx.run(cmd, background=True)` starts a long-running process detached and returns a [`SandboxProcess`] immediately (instead of waiting and returning a `SandboxCommandResult`). List them with `sbx.processes()` and stop one with `process.kill()`. Just spawn / list / kill — nothing fancier.
- **Reach a server running *inside* a sandbox** — WebSocket or plain HTTP — from the outside, through the sandbox server's port proxy:
  - `Sandbox.proxy_url_for(port, path="/", scheme="https://")` → public URL that proxies to the in-sandbox server on `port`. Pass `scheme="wss://"` for WebSocket clients.
  - `Sandbox.proxy_headers` → the auth headers to send with it (HF token + sandbox token).

Everything goes through the **single** sandbox-server port (`49983`) that the HF Jobs proxy already forwards — no extra exposed ports, no per-sandbox proxy routes. Works the same for dedicated (`Sandbox.create`) and pool (`SandboxPool`) sandboxes.

> Renamed from `proxy_url` → **`proxy_url_for`** and added the `scheme` argument so you don't have to string-`.replace()` `https://`→`wss://` at the call site.

## Background processes

```python
>>> proc = sbx.run("python -m http.server 8000", background=True)
>>> proc
SandboxProcess(id='p-3f2a', pid=1234, cmd='python -m http.server 8000')
>>> sbx.processes()
[SandboxProcess(id='p-3f2a', pid=1234, cmd='python -m http.server 8000')]
>>> proc.kill()
```

The streaming/wait-only options (`timeout`, `stdin`, `on_stdout`, `on_stderr`, `check`) don't apply in background mode — only `env`, `cwd` and `shell` are honored.

From the CLI:

```bash
>>> hf sandbox spawn <id> -- python -m http.server 8000
✓ Process started sandbox=<id> process=p-3f2a pid=1234

>>> hf sandbox process ls <id>
>>> hf sandbox process kill <id> p-3f2a
```

## How a sandbox exposes a server

| Mode | How the inner server must listen | Why |
|---|---|---|
| **Pool / shared** | unix socket at `$SBX_PROXY_DIR/<port>.sock` | host-mode sandboxes can't bind TCP (Landlock); `$SBX_PROXY_DIR` is set in every sandbox |
| **Dedicated** | TCP `127.0.0.1:<port>` | the job isn't Landlock-confined, so a normal port works |

Either way you reach it identically from the client via `proxy_url_for(port, path)`. The proxy is protocol-agnostic (raw byte splice after replaying the request head), so WebSocket upgrades, SSE and plain HTTP all pass through; the inner server does the real handshake.

## Usage

A tiny app with **one HTTP** and **one WebSocket** endpoint:

```python
APP = '''
from fastapi import FastAPI, WebSocket
app = FastAPI()

@app.get("/hello")
def hello():
    return {"msg": "hi from inside the sandbox"}

@app.websocket("/ws")
async def ws(sock: WebSocket):
    await sock.accept()
    while True:
        msg = await sock.receive_text()
        await sock.send_text(f"echo: {msg}")
'''
```

### Pool / shared sandbox (unix socket)

```python
import asyncio, httpx, websockets
from huggingface_hub import SandboxPool

with SandboxPool(image="python:3.12") as pool:
    sbx = pool.create()
    sbx.files.write("app.py", APP)
    sbx.run("pip install -q fastapi uvicorn websockets")
    # pool sandboxes can't bind TCP → listen on the unix socket the proxy reads
    sbx.run("uvicorn app:app --uds $SBX_PROXY_DIR/8000.sock", background=True)

    # --- normal HTTP endpoint ---
    r = httpx.get(sbx.proxy_url_for(8000, "/hello"), headers=sbx.proxy_headers)
    print(r.json())                       # {'msg': 'hi from inside the sandbox'}

    # --- websocket endpoint ---
    async def ws_demo():
        url = sbx.proxy_url_for(8000, "/ws", scheme="wss://")
        async with websockets.connect(url, additional_headers=sbx.proxy_headers) as ws:
            await ws.send("ping")
            print(await ws.recv())        # echo: ping
    asyncio.run(ws_demo())
```

### Dedicated sandbox (TCP)

Identical, except the server binds a normal port:

```python
from huggingface_hub import Sandbox

with Sandbox.create(image="python:3.12") as sbx:
    sbx.files.write("app.py", APP)
    sbx.run("pip install -q fastapi uvicorn websockets")
    sbx.run("uvicorn app:app --host 127.0.0.1 --port 8000", background=True)

    httpx.get(sbx.proxy_url_for(8000, "/hello"), headers=sbx.proxy_headers).json()
    # ...same proxy_url_for / proxy_headers for the /ws endpoint
```

The returned URL looks like `https://<job_id>--49983.hf.jobs/v1/sandboxes/<id>/proxy/8000/ws` (pool) or `.../v1/proxy/8000/ws` (dedicated); `scheme="wss://"` swaps the scheme for WebSocket clients.

## Design note (dedicated mode)

Dedicated mode routes through the same `49983` server port on purpose, rather than exposing the app's port directly via the job proxy (`expose=...`). Keeping a single ingress means one code path and one client API for both modes; we can always add a direct-expose shortcut later if there's a reason to.

## Pros / cons

**Pros**
- One client API (`proxy_url_for` / `proxy_headers`) for both dedicated and pool sandboxes.
- Single public ingress per job; no per-sandbox/per-port public routes to manage.
- Any protocol that works over one HTTP connection (WS, SSE, chunked, plain HTTP) just works.
- Pool isolation preserved: each sandbox's socket lives in its private home, addressed by sandbox id — no port collisions, no cross-sandbox reachability.

**Cons / open questions**
- Pool sandboxes must bind a **unix socket** (`--uds`) instead of a TCP port. Most servers support it (`uvicorn --uds`, `gunicorn`, node `net`), but it's a small ask.
- Long-lived connections don't currently reset the sandbox idle timer; it's safe as long as the server runs via `run(background=True)` (counts as a running process). Keeping a sandbox alive *by* an active proxy connection is a follow-up.
- Auth headers must be passed by the caller's WS/HTTP client (we expose them via `proxy_headers`); browsers can't set `Authorization` on `WebSocket`, so a browser client would need a different auth story (follow-up).

## Testing

Unit tests cover background spawn / list / kill and `proxy_url_for` (default `https://` + `wss://` scheme swap) against a local fake server. Validated locally end-to-end against the sandbox-server PR (dedicated/TCP path): a real `websockets` echo server and an `http.server` behind the proxy — bidirectional, multi-frame WS plus plain HTTP with path+query preserved. Host-mode UDS path uses the identical server-side splice; full host-mode e2e needs a real Job.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New authenticated proxy URLs and process lifecycle depend on companion sandbox-server behavior; misuse of `proxy_headers` could leak tokens if logged or exposed, but changes are additive with unit test coverage.
> 
> **Overview**
> Adds **detached process management** and **external access to servers running inside a sandbox** through the existing in-job sandbox server (no extra public ports).
> 
> **Background processes:** `Sandbox.run(..., background=True)` posts to `/processes` and returns a new **`SandboxProcess`** (pid, status fields, `kill()`). `Sandbox.processes()` lists them. Streaming/wait options are ignored in background mode; only `env`, `cwd`, and `shell` apply. **`SandboxProcess`** is exported from the public API.
> 
> **Port proxy:** **`Sandbox.proxy_url_for(port, path, scheme=...)`** builds a public URL under `{base_path}/proxy/{port}{path}` (dedicated vs pool paths unchanged). **`Sandbox.proxy_headers`** supplies HF + sandbox tokens for HTTP/WebSocket clients. Docs call out TCP on `127.0.0.1` for dedicated sandboxes vs unix sockets at `$SBX_PROXY_DIR/<port>.sock` for pool sandboxes.
> 
> **CLI:** `hf sandbox spawn`, `hf sandbox process ls|kill`, and doc updates for `exec` pointing users to `spawn`.
> 
> **Tests:** Fake server handlers for `/processes` plus unit tests for background run, list/kill, and `proxy_url_for` / headers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b643062ac4efa4d940d7d614a4dfc8ccaf910b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->