### PR TITLE
[Fix] TestConfigDictNotRequired is silently skipped (has __init__) (#4421)

### DIFF
--- a/tests/test_utils_strict_dataclass.py
+++ b/tests/test_utils_strict_dataclass.py
@@ -873,7 +873,8 @@ def test_typed_dict_to_dataclass_is_cached():
 
 @pytest.mark.skipif(sys.version_info < (3, 11), reason="Requires Python 3.11+")
 class TestConfigDictNotRequired:
-    def __init__(self):
+    @pytest.fixture(autouse=True)
+    def _setup(self):
         # cannot be defined at class level because of Python<3.11
         self.ConfigDictNotRequired = TypedDict(
             "ConfigDictNotRequired",


### PR DESCRIPTION
## Motivation

`TestConfigDictNotRequired`'s two tests never run — pytest emits `PytestCollectionWarning` and silently skips the whole class, so the `NotRequired`/`Required` TypedDict behavior is effectively untested (#4421).

## Root cause

In `tests/test_utils_strict_dataclass.py`, the class defines an `__init__`:

```python
class TestConfigDictNotRequired:
    def __init__(self):
        self.ConfigDictNotRequired = TypedDict(...)
```

pytest cannot collect test classes that define `__init__`, so it skips `test_typed_dict_not_required_valid_data` and `test_typed_dict_not_required_invalid_data` entirely — they only *look* like they run.

## Modifications

`tests/test_utils_strict_dataclass.py`: replace the `__init__` with an `@pytest.fixture(autouse=True)` setup method (`_setup`). The class becomes collectible, the per-instance `self.ConfigDictNotRequired` is still built before each test, and the test methods are unchanged. (`pytest`, `sys`, `TypedDict`, `Required`, `NotRequired` are already imported.)

## Duplicate-check

- Track A — `gh api 'repos/huggingface/huggingface_hub/pulls?state=open&per_page=100' --paginate` grepped for `4421` / `TestConfigDictNotRequired` / `strict_dataclass` → no references.
- Track B — issue #4421 has 0 comments and no in-progress claim.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no library or runtime behavior modifications.
> 
> **Overview**
> **Fixes silent skip of `TestConfigDictNotRequired`** — pytest would not collect the class because it defined `__init__`, so the `NotRequired`/`Required` TypedDict tests never ran.
> 
> Replaces that `__init__` with an **`@pytest.fixture(autouse=True)` `_setup`** method that still builds `self.ConfigDictNotRequired` per test (needed because the TypedDict cannot live at class level on Python &lt; 3.11). Test bodies are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e9c1b2b6f6f8dec0106e800d352732226f9f60b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->