### PR TITLE
[Tests] last time we need to refacto tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 from contextlib import ExitStack
 from typing import Generator, Protocol
 
@@ -18,7 +17,7 @@ from .testing_constants import (
     ENDPOINT_STAGING,
     TOKEN,
 )
-from .testing_utils import parse_flag_from_env, repo_name, set_write_permission_and_retry
+from .testing_utils import repo_name
 
 
 @pytest.fixture(autouse=True, scope="function")
@@ -89,28 +88,6 @@ def _clean_cli_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 logger = logging.get_logger(__name__)
-
-
-@pytest.fixture
-def fx_cache_dir(request: SubRequest) -> Generator[None, None, None]:
-    """Add a `cache_dir` attribute pointing to a temporary directory in tests.
-
-    Example:
-    ```py
-    @pytest.mark.usefixtures("fx_cache_dir")
-    class TestWithCache(unittest.TestCase):
-        cache_dir: Path
-
-        def test_cache_dir(self) -> None:
-            self.assertTrue(self.cache_dir.is_dir())
-    ```
-    """
-    with SoftTemporaryDirectory() as cache_dir:
-        request.cls.cache_dir = cache_dir
-        yield
-        # TemporaryDirectory is not super robust on Windows when a git repository is
-        # cloned in it. See https://www.scivision.dev/python-tempfile-permission-error-windows/.
-        shutil.rmtree(cache_dir, onerror=set_write_permission_and_retry)
 
 
 @pytest.fixture(autouse=True)
@@ -194,7 +171,7 @@ def expect_deprecation_marker(request: SubRequest) -> Generator[None, None, None
 @pytest.fixture(autouse=True)
 def git_lfs_marker(request: SubRequest) -> None:
     """Skip tests marked `@pytest.mark.git_lfs` unless `RUN_GIT_LFS_TESTS` is truthy (git-lfs needed)."""
-    if request.node.get_closest_marker("git_lfs") is not None and not parse_flag_from_env("RUN_GIT_LFS_TESTS"):
+    if request.node.get_closest_marker("git_lfs") is not None and os.environ.get("RUN_GIT_LFS_TESTS") != "1":
         pytest.skip("git-lfs test (set RUN_GIT_LFS_TESTS=1 to run)")
 
 

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -11,14 +11,6 @@ from unittest.mock import Mock, patch
 
 import httpx
 
-from huggingface_hub.utils import logging
-
-
-logger = logging.get_logger(__name__)
-
-YES = ("y", "yes", "t", "true", "on", "1")
-NO = ("n", "no", "f", "false", "off", "0")
-
 
 def repo_name(id: Optional[str] = None, prefix: str = "repo") -> str:
     """
@@ -36,23 +28,6 @@ def repo_name(id: Optional[str] = None, prefix: str = "repo") -> str:
         id = uuid.uuid4().hex[:6]
     ts = int(time.time() * 10e3)
     return f"{prefix}-{id}-{ts}"
-
-
-def parse_flag_from_env(key: str, default: bool = False) -> bool:
-    try:
-        value = os.environ[key]
-    except KeyError:
-        # KEY isn't set, default to `default`.
-        return default
-
-    # KEY is set, convert it to True or False.
-    if value.lower() in YES:
-        return True
-    elif value.lower() in NO:
-        return False
-    else:
-        # More values are supported, but let's keep the message simple.
-        raise ValueError(f"If set, '{key}' must be one of {YES + NO}. Got '{value}'.")
 
 
 class RequestWouldHangIndefinitelyError(Exception):


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only refactor; the only behavior change is stricter env parsing for git-lfs skips (must be `1`, not other truthy values).
> 
> **Overview**
> Cleans up the test harness by removing dead helpers and tightening how optional git-lfs tests are gated.
> 
> The **`fx_cache_dir`** pytest fixture (and its **`shutil`** / **`set_write_permission_and_retry`** teardown wiring in **`conftest.py`**) is removed—cache paths are already covered by the autouse **`patch_constants`** fixture. **`parse_flag_from_env`** and its **`YES`/`NO`** parsing are deleted from **`testing_utils.py`**; the **`git_lfs`** marker now skips unless **`RUN_GIT_LFS_TESTS`** is exactly **`"1"`**, instead of accepting other truthy env strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6effb8a3f7a204e55afd60d7da885956f0d8b3f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->