### PR TITLE
docs: normalize CLI guide warning comment

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -1,4 +1,4 @@
-<!--⚠️ Note that this file is in Markdown but contains specific syntax for our doc-builder (similar to MDX) that may not be
+<!-- Note: this file is in Markdown but contains specific syntax for our doc-builder (similar to MDX) that may not be
 rendered properly in your Markdown viewer.
 -->
 


### PR DESCRIPTION
## Summary
- replace the corrupted warning glyph in the CLI guide's leading HTML comment with plain ASCII text
- keep the note's meaning intact so the file still warns readers about doc-builder-specific syntax

## Why
The current warning comment can render inconsistently depending on terminal or editor encoding support. Using plain ASCII keeps the note readable everywhere without changing the guide content.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only, single-line comment edit with no runtime or API impact.
> 
> **Overview**
> Updates the **leading HTML comment** at the top of `docs/source/en/guides/cli.md` so the doc-builder disclaimer uses plain ASCII instead of a warning glyph prefix.
> 
> The line changes from `<!--⚠️ Note that this file...` to `<!-- Note: this file...`; the rest of the comment and all guide body content are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b21a058df184315afb56d1601750e8ebbc5817f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->