### PR TITLE
[Jobs] Add `hf jobs scheduled trigger ...` to trigger scheduled jobs on demand

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -2138,6 +2138,9 @@ Manage scheduled jobs using
 # Resume a scheduled job
 >>> hf jobs scheduled resume <scheduled_job_id>
 
+# Trigger a scheduled job to run right now (does not change the schedule)
+>>> hf jobs scheduled trigger <scheduled_job_id>
+
 # Delete a scheduled job
 >>> hf jobs scheduled delete <scheduled_job_id>
 ```

--- a/docs/source/en/guides/jobs.md
+++ b/docs/source/en/guides/jobs.md
@@ -631,7 +631,7 @@ Use [`create_scheduled_job`] or [`create_scheduled_uv_job`] with a schedule of `
 
 Use the same parameters as [`run_job`] and [`run_uv_job`] to pass environment variables, secrets, timeout, etc.
 
-Manage scheduled jobs using [`list_scheduled_jobs`], [`inspect_scheduled_job`], [`suspend_scheduled_job`], [`resume_scheduled_job`], [`run_scheduled_job`], and [`delete_scheduled_job`]:
+Manage scheduled jobs using [`list_scheduled_jobs`], [`inspect_scheduled_job`], [`suspend_scheduled_job`], [`resume_scheduled_job`], [`trigger_scheduled_job`], and [`delete_scheduled_job`]:
 
 ```python
 # List your active scheduled jobs
@@ -651,8 +651,8 @@ Manage scheduled jobs using [`list_scheduled_jobs`], [`inspect_scheduled_job`], 
 >>> resume_scheduled_job(scheduled_job_id)
 
 # Trigger a scheduled job to run right now (does not change the schedule)
->>> from huggingface_hub import run_scheduled_job
->>> job = run_scheduled_job(scheduled_job_id)
+>>> from huggingface_hub import trigger_scheduled_job
+>>> job = trigger_scheduled_job(scheduled_job_id)
 >>> job.url
 
 # Delete a scheduled job

--- a/docs/source/en/guides/jobs.md
+++ b/docs/source/en/guides/jobs.md
@@ -631,7 +631,7 @@ Use [`create_scheduled_job`] or [`create_scheduled_uv_job`] with a schedule of `
 
 Use the same parameters as [`run_job`] and [`run_uv_job`] to pass environment variables, secrets, timeout, etc.
 
-Manage scheduled jobs using [`list_scheduled_jobs`], [`inspect_scheduled_job`], [`suspend_scheduled_job`], [`resume_scheduled_job`], and [`delete_scheduled_job`]:
+Manage scheduled jobs using [`list_scheduled_jobs`], [`inspect_scheduled_job`], [`suspend_scheduled_job`], [`resume_scheduled_job`], [`run_scheduled_job`], and [`delete_scheduled_job`]:
 
 ```python
 # List your active scheduled jobs
@@ -649,6 +649,11 @@ Manage scheduled jobs using [`list_scheduled_jobs`], [`inspect_scheduled_job`], 
 # Resume a scheduled job
 >>> from huggingface_hub import resume_scheduled_job
 >>> resume_scheduled_job(scheduled_job_id)
+
+# Trigger a scheduled job to run right now (does not change the schedule)
+>>> from huggingface_hub import run_scheduled_job
+>>> job = run_scheduled_job(scheduled_job_id)
+>>> job.url
 
 # Delete a scheduled job
 >>> from huggingface_hub import delete_scheduled_job

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -2423,6 +2423,7 @@ $ hf jobs scheduled [OPTIONS] COMMAND [ARGS]...
 * `resume`: Resume (unpause) a scheduled Job.
 * `run`: Schedule a Job.
 * `suspend`: Suspend (pause) a scheduled Job.
+* `trigger`: Trigger a scheduled Job to run immediately...
 * `uv`: Schedule UV scripts on HF infrastructure.
 
 #### `hf jobs scheduled delete`
@@ -2629,6 +2630,34 @@ $ hf jobs scheduled suspend [OPTIONS] SCHEDULED_JOB_ID
 
 Examples
   $ hf jobs scheduled suspend <id>
+
+Learn more
+  Use `hf <command> --help` for more information about a command.
+  Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
+
+
+#### `hf jobs scheduled trigger`
+
+Trigger a scheduled Job to run immediately (does not change the schedule).
+
+**Usage**:
+
+```console
+$ hf jobs scheduled trigger [OPTIONS] SCHEDULED_JOB_ID
+```
+
+**Arguments**:
+
+* `SCHEDULED_JOB_ID`: Scheduled Job ID (or 'namespace/scheduled_job_id')  [required]
+
+**Options**:
+
+* `--namespace TEXT`: The namespace where the job will be running. Defaults to the current user's namespace.
+* `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
+* `--help`: Show this message and exit.
+
+Examples
+  $ hf jobs scheduled trigger <id>
 
 Learn more
   Use `hf <command> --help` for more information about a command.

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -335,7 +335,6 @@ _SUBMOD_ATTRS = {
         "revision_exists",
         "run_as_future",
         "run_job",
-        "run_scheduled_job",
         "run_uv_job",
         "scale_to_zero_inference_endpoint",
         "search_spaces",
@@ -346,6 +345,7 @@ _SUBMOD_ATTRS = {
         "suspend_scheduled_job",
         "sync_bucket",
         "sync_job_volume",
+        "trigger_scheduled_job",
         "unlike",
         "update_collection_item",
         "update_collection_metadata",
@@ -1095,7 +1095,6 @@ __all__ = [
     "revision_exists",
     "run_as_future",
     "run_job",
-    "run_scheduled_job",
     "run_uv_job",
     "save_torch_model",
     "save_torch_state_dict",
@@ -1114,6 +1113,7 @@ __all__ = [
     "suspend_scheduled_job",
     "sync_bucket",
     "sync_job_volume",
+    "trigger_scheduled_job",
     "try_to_load_from_cache",
     "typer_factory",
     "unlike",
@@ -1513,7 +1513,6 @@ if TYPE_CHECKING:  # pragma: no cover
         revision_exists,  # noqa: F401
         run_as_future,  # noqa: F401
         run_job,  # noqa: F401
-        run_scheduled_job,  # noqa: F401
         run_uv_job,  # noqa: F401
         scale_to_zero_inference_endpoint,  # noqa: F401
         search_spaces,  # noqa: F401
@@ -1524,6 +1523,7 @@ if TYPE_CHECKING:  # pragma: no cover
         suspend_scheduled_job,  # noqa: F401
         sync_bucket,  # noqa: F401
         sync_job_volume,  # noqa: F401
+        trigger_scheduled_job,  # noqa: F401
         unlike,  # noqa: F401
         update_collection_item,  # noqa: F401
         update_collection_metadata,  # noqa: F401

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -335,6 +335,7 @@ _SUBMOD_ATTRS = {
         "revision_exists",
         "run_as_future",
         "run_job",
+        "run_scheduled_job",
         "run_uv_job",
         "scale_to_zero_inference_endpoint",
         "search_spaces",
@@ -1094,6 +1095,7 @@ __all__ = [
     "revision_exists",
     "run_as_future",
     "run_job",
+    "run_scheduled_job",
     "run_uv_job",
     "save_torch_model",
     "save_torch_state_dict",
@@ -1511,6 +1513,7 @@ if TYPE_CHECKING:  # pragma: no cover
         revision_exists,  # noqa: F401
         run_as_future,  # noqa: F401
         run_job,  # noqa: F401
+        run_scheduled_job,  # noqa: F401
         run_uv_job,  # noqa: F401
         scale_to_zero_inference_endpoint,  # noqa: F401
         search_spaces,  # noqa: F401

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -59,6 +59,9 @@ Usage:
     # Resume a scheduled job
     hf jobs scheduled resume <scheduled_job_id>
 
+    # Trigger a scheduled job to run now
+    hf jobs scheduled trigger <scheduled_job_id>
+
     # Delete a scheduled job
     hf jobs scheduled delete <scheduled_job_id>
 
@@ -1187,6 +1190,20 @@ def scheduled_resume(
     api = get_hf_api(token=token)
     api.resume_scheduled_job(scheduled_job_id=scheduled_job_id, namespace=namespace)
     out.result("Scheduled Job resumed", id=scheduled_job_id)
+
+
+@scheduled_app.command("trigger", examples=["hf jobs scheduled trigger <id>"])
+def scheduled_trigger(
+    scheduled_job_id: ScheduledJobIdArg,
+    namespace: NamespaceOpt = None,
+    token: TokenOpt = None,
+) -> None:
+    """Trigger a scheduled Job to run immediately (does not change the schedule)."""
+    scheduled_job_id, namespace = _parse_namespace_from_job_id(scheduled_job_id, namespace)
+    api = get_hf_api(token=token)
+    job = api.run_scheduled_job(scheduled_job_id=scheduled_job_id, namespace=namespace)
+    out.result("Scheduled Job triggered", id=job.id, url=job.url)
+    out.hint(f"Use `hf jobs logs -f {job.owner.name}/{job.id}` to stream logs.")
 
 
 @scheduled_app.command(

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -11,61 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Contains commands to interact with jobs on the Hugging Face Hub.
-
-Usage:
-    # run a job
-    hf jobs run <image> <command>
-
-    # List running or completed jobs
-    hf jobs ls [-a] [-f key=value]
-
-    # Print logs from a job (non-blocking)
-    hf jobs logs <job-id>
-
-    # Stream logs from a job (blocking, like `docker logs -f`)
-    hf jobs logs -f <job-id>
-
-    # Stream resources usage stats and metrics from a job
-    hf jobs stats <job-id>
-
-    # Inspect detailed information about a job
-    hf jobs inspect <job-id>
-
-    # Cancel a running job
-    hf jobs cancel <job-id>
-
-    # Wait until one or more jobs finish
-    hf jobs wait <job-id> [<job-id>...]
-
-    # List available hardware options
-    hf jobs hardware
-
-    # Run a UV script
-    hf jobs uv run <script>
-
-    # Schedule a job
-    hf jobs scheduled run <schedule> <image> <command>
-
-    # List scheduled jobs
-    hf jobs scheduled ls [-a] [-f key=value]
-
-    # Inspect a scheduled job
-    hf jobs scheduled inspect <scheduled_job_id>
-
-    # Suspend a scheduled job
-    hf jobs scheduled suspend <scheduled_job_id>
-
-    # Resume a scheduled job
-    hf jobs scheduled resume <scheduled_job_id>
-
-    # Trigger a scheduled job to run now
-    hf jobs scheduled trigger <scheduled_job_id>
-
-    # Delete a scheduled job
-    hf jobs scheduled delete <scheduled_job_id>
-
-"""
+"""Contains commands to interact with jobs on the Hugging Face Hub."""
 
 import itertools
 import multiprocessing
@@ -1125,6 +1071,10 @@ def scheduled_ps(
     if not items and filters:
         filters_msg = ", ".join(f"{k}{o}{v}" for k, o, v in filters)
         out.text(f"No scheduled jobs matched filters: {filters_msg}")
+    if items:
+        first_item_id = items[0]["id"]
+        out.hint(f"Use `hf jobs scheduled inspect {first_item_id}` to view details about a scheduled job.")
+        out.hint(f"Use `hf jobs scheduled trigger {first_item_id}` to trigger a scheduled job immediately.")
 
 
 @scheduled_app.command("inspect", examples=["hf jobs scheduled inspect <id>"])

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -1201,7 +1201,7 @@ def scheduled_trigger(
     """Trigger a scheduled Job to run immediately (does not change the schedule)."""
     scheduled_job_id, namespace = _parse_namespace_from_job_id(scheduled_job_id, namespace)
     api = get_hf_api(token=token)
-    job = api.run_scheduled_job(scheduled_job_id=scheduled_job_id, namespace=namespace)
+    job = api.trigger_scheduled_job(scheduled_job_id=scheduled_job_id, namespace=namespace)
     out.result("Scheduled Job triggered", id=job.id, url=job.url)
     out.hint(f"Use `hf jobs logs -f {job.owner.name}/{job.id}` to stream logs.")
 

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -12792,6 +12792,48 @@ class HfApi:
         )
         hf_raise_for_status(response)
 
+    def run_scheduled_job(
+        self,
+        *,
+        scheduled_job_id: str,
+        namespace: str | None = None,
+        token: bool | str | None = None,
+    ) -> JobInfo:
+        """
+        Trigger a scheduled Job to run immediately.
+
+        This triggers one immediate run of the scheduled job's spec. It does **not** modify the schedule
+        and does **not** affect the next scheduled run. If an instance is already running and the scheduled
+        job does not allow concurrent runs, the request is rejected (HTTP 409).
+
+        Args:
+            scheduled_job_id (`str`):
+                ID of the scheduled Job.
+
+            namespace (`str`, *optional*):
+                The namespace where the scheduled Job is. Defaults to the current user's namespace.
+
+            token `(Union[bool, str, None]`, *optional*):
+                A valid user access token. If not provided, the locally saved token will be used, which is the
+                recommended authentication method. Set to `False` to disable authentication.
+                Refer to: https://huggingface.co/docs/huggingface_hub/quick-start#authentication.
+
+        Returns:
+            [`JobInfo`]: Info about the triggered run.
+
+        Raises:
+            [`~utils.HfHubHTTPError`]:
+                HTTP 409 if another instance is already running and `concurrency` is disabled on the scheduled job.
+        """
+        if namespace is None:
+            namespace = self.whoami(token=token)["name"]
+        response = get_session().post(
+            f"{self.endpoint}/api/scheduled-jobs/{namespace}/{scheduled_job_id}/run",
+            headers=self._build_hf_headers(token=token),
+        )
+        hf_raise_for_status(response)
+        return JobInfo(**response.json(), endpoint=self.endpoint)
+
     def update_scheduled_job_labels(
         self,
         *,
@@ -14832,6 +14874,7 @@ inspect_scheduled_job = api.inspect_scheduled_job
 delete_scheduled_job = api.delete_scheduled_job
 suspend_scheduled_job = api.suspend_scheduled_job
 resume_scheduled_job = api.resume_scheduled_job
+run_scheduled_job = api.run_scheduled_job
 update_scheduled_job_labels = api.update_scheduled_job_labels
 create_scheduled_uv_job = api.create_scheduled_uv_job
 sync_job_volume = api.sync_job_volume

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -12792,7 +12792,7 @@ class HfApi:
         )
         hf_raise_for_status(response)
 
-    def run_scheduled_job(
+    def trigger_scheduled_job(
         self,
         *,
         scheduled_job_id: str,
@@ -14874,7 +14874,7 @@ inspect_scheduled_job = api.inspect_scheduled_job
 delete_scheduled_job = api.delete_scheduled_job
 suspend_scheduled_job = api.suspend_scheduled_job
 resume_scheduled_job = api.resume_scheduled_job
-run_scheduled_job = api.run_scheduled_job
+trigger_scheduled_job = api.trigger_scheduled_job
 update_scheduled_job_labels = api.update_scheduled_job_labels
 create_scheduled_uv_job = api.create_scheduled_uv_job
 sync_job_volume = api.sync_job_volume

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3055,6 +3055,16 @@ class TestJobsCommand:
             namespace=None,
         )
 
+    def test_trigger_scheduled_job(self, runner: CliRunner) -> None:
+        job = Mock(id="run-123", url="https://huggingface.co/jobs/me/run-123")
+        job.owner = Mock(name="me")
+        with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            api.run_scheduled_job.return_value = job
+            result = runner.invoke(app, ["jobs", "scheduled", "trigger", "sched-456"])
+        assert result.exit_code == 0
+        api.run_scheduled_job.assert_called_once_with(scheduled_job_id="sched-456", namespace=None)
+
     def test_uv_command(self, runner: CliRunner) -> None:
         job = Mock(id="my-job-id", url="https://huggingface.co/api/jobs/687f911eaea852de79c4a50a")
         with (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3060,10 +3060,10 @@ class TestJobsCommand:
         job.owner = Mock(name="me")
         with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
             api = api_cls.return_value
-            api.run_scheduled_job.return_value = job
+            api.trigger_scheduled_job.return_value = job
             result = runner.invoke(app, ["jobs", "scheduled", "trigger", "sched-456"])
         assert result.exit_code == 0
-        api.run_scheduled_job.assert_called_once_with(scheduled_job_id="sched-456", namespace=None)
+        api.trigger_scheduled_job.assert_called_once_with(scheduled_job_id="sched-456", namespace=None)
 
     def test_uv_command(self, runner: CliRunner) -> None:
         job = Mock(id="my-job-id", url="https://huggingface.co/api/jobs/687f911eaea852de79c4a50a")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3055,16 +3055,6 @@ class TestJobsCommand:
             namespace=None,
         )
 
-    def test_trigger_scheduled_job(self, runner: CliRunner) -> None:
-        job = Mock(id="run-123", url="https://huggingface.co/jobs/me/run-123")
-        job.owner = Mock(name="me")
-        with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
-            api = api_cls.return_value
-            api.trigger_scheduled_job.return_value = job
-            result = runner.invoke(app, ["jobs", "scheduled", "trigger", "sched-456"])
-        assert result.exit_code == 0
-        api.trigger_scheduled_job.assert_called_once_with(scheduled_job_id="sched-456", namespace=None)
-
     def test_uv_command(self, runner: CliRunner) -> None:
         job = Mock(id="my-job-id", url="https://huggingface.co/api/jobs/687f911eaea852de79c4a50a")
         with (


### PR DESCRIPTION
### This PR adds support for `hf jobs scheduled trigger <...>`. Already shipped in UI, missing in CLI

Tested and working great:

```sh
$ hf jobs scheduled ls
ID                       SCHEDULE  IMAGE/SPACE                             COMMAND                              LAST_RUN            NEXT_RUN            SUSPEND
------------------------ --------- --------------------------------------- ------------------------------------ ------------------- ------------------- -------
6a43e79b7a748a878b5991cf 0 0 * * * ghcr.io/astral-sh/uv:python3.12-book... uv run /data/sync_hf_docs_archive.py 2026-07-01 11:44:41 2026-07-02 00:00:00        
Hint: Use `--no-truncate` or `--format json` to display full values.
Hint: Use `hf jobs scheduled inspect 6a43e79b7a748a878b5991cf` to view details about a scheduled job.
Hint: Use `hf jobs scheduled trigger 6a43e79b7a748a878b5991cf` to trigger a scheduled job immediately.


$ hf jobs scheduled trigger 6a43e79b7a748a878b5991cf
✓ Scheduled Job triggered
  id: 6a4502d1fb6818a83db2f3ca
  url: https://huggingface.co/jobs/Wauplin/6a4502d1fb6818a83db2f3ca
Hint: Use `hf jobs logs -f Wauplin/6a4502d1fb6818a83db2f3ca` to stream logs.


$ hf jobs logs -f Wauplin/6a4502d1fb6818a83db2f3ca
Downloading hf-xet (4.3MiB)
Downloading pygments (1.2MiB)
Downloading pydantic-core (2.0MiB)
Downloading openai (1.3MiB)
 Downloaded pydantic-core
 Downloaded hf-xet
 Downloaded pygments
 Downloaded openai
Installed 30 packages in 45ms
...
```


---

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Cursor summary

Adds the missing "run now" action for scheduled jobs. The server-side endpoint (`POST /api/scheduled-jobs/{namespace}/{scheduled_job_id}/run`) is already live — this is purely a client-side addition.

### Changes

- **`HfApi.trigger_scheduled_job()`** — new method that POSTs to the `/run` endpoint and returns a `JobInfo` for the freshly triggered run. Follows the exact same pattern as `suspend_scheduled_job` / `resume_scheduled_job` but parses the response into `JobInfo` (like `run_job` does).
- **`hf jobs scheduled trigger <id>`** — new CLI subcommand. Named `trigger` to avoid collision with the existing `hf jobs scheduled run` (which *creates* a scheduled job). Prints the triggered job's id and URL, plus a hint to stream logs.
- **Docs** — updated `guides/jobs.md` (Python example), `guides/cli.md` (CLI example), and auto-generated `package_reference/cli.md`.
- **Exports** — `trigger_scheduled_job` added to `_SUBMOD_ATTRS`, `__all__`, static imports, and module-level alias in `hf_api.py`.
- **Test** — basic CLI test in `tests/test_cli.py` for the `trigger` subcommand.

### Usage

**Python:**
```python
from huggingface_hub import trigger_scheduled_job

job = trigger_scheduled_job(scheduled_job_id="my-scheduled-job-id")
print(job.url)
```

**CLI:**
```bash
hf jobs scheduled trigger my-scheduled-job-id
# ✔ Scheduled Job triggered (id=run-abc123, url=https://huggingface.co/jobs/me/run-abc123)
# 💡 Use `hf jobs logs -f me/run-abc123` to stream logs.
```

### Design decisions

- **Method name `trigger_scheduled_job`** — consistent with the CLI verb `trigger` and less ambiguous than `run_scheduled_job` (which could be confused with "create and run a scheduled job").
- **CLI verb `trigger`** — avoids collision with `hf jobs scheduled run` (which creates a scheduled job).
- Returns `JobInfo` (not `ScheduledJobInfo`) since the endpoint creates a regular job run, matching the server response shape.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://huggingface.slack.com/archives/D0A9313SS3G/p1782906617663209?thread_ts=1782906617.663209&cid=D0A9313SS3G)

<div><a href="https://cursor.com/agents/bc-cfc7a48d-2bc8-55cd-ad10-e16d982dd934"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cfc7a48d-2bc8-55cd-ad10-e16d982dd934"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

