### PR TITLE
[Http] Support standard Retry-After header in http_backoff

### DIFF
--- a/src/huggingface_hub/utils/_http.py
+++ b/src/huggingface_hub/utils/_http.py
@@ -145,10 +145,9 @@ def _parse_retry_after(headers: Mapping[str, str]) -> int | None:
     """Parse the standard `Retry-After` HTTP header into a number of seconds to wait.
 
     The `Retry-After` header can be either a non-negative number of seconds (delay-seconds)
-    or an HTTP-date after which to retry.
-    See https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Retry-After.
+    or an HTTP-date after which to retry. We handle only the delay-seconds case.
 
-    Returns the delay in seconds (never negative), or `None` if the header is absent or invalid.
+    See https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Retry-After.
     """
     value: str | None = None
     for key in headers:
@@ -162,21 +161,9 @@ def _parse_retry_after(headers: Mapping[str, str]) -> int | None:
     if not value:
         return None
 
-    # delay-seconds form, e.g. "Retry-After: 120"
     if value.isdigit():
-        return int(value)
-
-    # HTTP-date form, e.g. "Retry-After: Wed, 21 Oct 2015 07:28:00 GMT"
-    try:
-        retry_date = parsedate_to_datetime(value)
-    except (TypeError, ValueError):
-        return None
-    if retry_date is None:  # some Python versions return None on failure
-        return None
-    if retry_date.tzinfo is None:
-        retry_date = retry_date.replace(tzinfo=timezone.utc)
-    delta = (retry_date - datetime.now(timezone.utc)).total_seconds()
-    return max(0, int(delta))
+        return int(value)  # e.g. "Retry-After: 120"
+    return None  #  e.g. "Retry-After: Wed, 21 Oct 2015 07:28:00 GMT" - not supported
 
 
 # When raising an error, we include the request id in the error message for easier debugging.
@@ -500,7 +487,7 @@ def _http_backoff_base(
                     return False  # Don't retry, return/yield response
 
                 # Get the server-requested wait time from headers.
-                # `parse_ratelimit_headers` (429) takes precedence over the standard `Retry-After` header.
+                # `parse_ratelimit_headers` takes precedence over the standard `Retry-After` header.
                 ratelimit_info = parse_ratelimit_headers(response.headers)
                 if ratelimit_info is not None:
                     ratelimit_reset = ratelimit_info.reset_in_seconds
@@ -531,7 +518,7 @@ def _http_backoff_base(
 
         if ratelimit_reset is not None:
             actual_sleep = float(ratelimit_reset) + 1  # +1s to avoid rounding issues
-            logger.warning(f"Server requested to wait {actual_sleep}s before retry [Retry {nb_tries}/{max_retries}].")
+            logger.warning(f"Rate limited. Waiting {actual_sleep}s before retry [Retry {nb_tries}/{max_retries}].")
         else:
             actual_sleep = sleep_time
             logger.warning(f"Retrying in {actual_sleep}s [Retry {nb_tries}/{max_retries}].")

--- a/src/huggingface_hub/utils/_http.py
+++ b/src/huggingface_hub/utils/_http.py
@@ -24,8 +24,6 @@ import uuid
 from collections.abc import Callable, Generator, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass
-from datetime import datetime, timezone
-from email.utils import parsedate_to_datetime
 from shlex import quote
 from typing import Any, TypeVar
 from urllib.parse import urlparse
@@ -486,10 +484,11 @@ def _http_backoff_base(
                     # user ask for retry on a status code that doesn't raise_for_status.
                     return False  # Don't retry, return/yield response
 
-                # Get the server-requested wait time from headers.
-                # `parse_ratelimit_headers` takes precedence over the standard `Retry-After` header.
-                ratelimit_info = parse_ratelimit_headers(response.headers)
-                if ratelimit_info is not None:
+                # Check 'ratelimit' and `Retry-After` headers.
+                if (
+                    response.status_code == 429
+                    and (ratelimit_info := parse_ratelimit_headers(response.headers)) is not None
+                ):
                     ratelimit_reset = ratelimit_info.reset_in_seconds
                 elif (retry_after := _parse_retry_after(response.headers)) is not None:
                     ratelimit_reset = retry_after

--- a/src/huggingface_hub/utils/_http.py
+++ b/src/huggingface_hub/utils/_http.py
@@ -24,6 +24,8 @@ import uuid
 from collections.abc import Callable, Generator, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 from shlex import quote
 from typing import Any, TypeVar
 from urllib.parse import urlparse
@@ -137,6 +139,44 @@ def parse_ratelimit_headers(headers: Mapping[str, str]) -> RateLimitInfo | None:
         limit=limit,
         window_seconds=window_seconds,
     )
+
+
+def _parse_retry_after(headers: Mapping[str, str]) -> int | None:
+    """Parse the standard `Retry-After` HTTP header into a number of seconds to wait.
+
+    The `Retry-After` header can be either a non-negative number of seconds (delay-seconds)
+    or an HTTP-date after which to retry.
+    See https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Retry-After.
+
+    Returns the delay in seconds (never negative), or `None` if the header is absent or invalid.
+    """
+    value: str | None = None
+    for key in headers:
+        if key.lower() == "retry-after":
+            value = headers[key]
+            break
+
+    if value is None:
+        return None
+    value = value.strip()
+    if not value:
+        return None
+
+    # delay-seconds form, e.g. "Retry-After: 120"
+    if value.isdigit():
+        return int(value)
+
+    # HTTP-date form, e.g. "Retry-After: Wed, 21 Oct 2015 07:28:00 GMT"
+    try:
+        retry_date = parsedate_to_datetime(value)
+    except (TypeError, ValueError):
+        return None
+    if retry_date is None:  # some Python versions return None on failure
+        return None
+    if retry_date.tzinfo is None:
+        retry_date = retry_date.replace(tzinfo=timezone.utc)
+    delta = (retry_date - datetime.now(timezone.utc)).total_seconds()
+    return max(0, int(delta))
 
 
 # When raising an error, we include the request id in the error message for easier debugging.
@@ -459,11 +499,13 @@ def _http_backoff_base(
                     # user ask for retry on a status code that doesn't raise_for_status.
                     return False  # Don't retry, return/yield response
 
-                # get rate limit reset time from headers if 429 response
-                if response.status_code == 429:
-                    ratelimit_info = parse_ratelimit_headers(response.headers)
-                    if ratelimit_info is not None:
-                        ratelimit_reset = ratelimit_info.reset_in_seconds
+                # Get the server-requested wait time from headers.
+                # `parse_ratelimit_headers` (429) takes precedence over the standard `Retry-After` header.
+                ratelimit_info = parse_ratelimit_headers(response.headers)
+                if ratelimit_info is not None:
+                    ratelimit_reset = ratelimit_info.reset_in_seconds
+                elif (retry_after := _parse_retry_after(response.headers)) is not None:
+                    ratelimit_reset = retry_after
 
                 return True  # Should retry
 
@@ -489,7 +531,7 @@ def _http_backoff_base(
 
         if ratelimit_reset is not None:
             actual_sleep = float(ratelimit_reset) + 1  # +1s to avoid rounding issues
-            logger.warning(f"Rate limited. Waiting {actual_sleep}s before retry [Retry {nb_tries}/{max_retries}].")
+            logger.warning(f"Server requested to wait {actual_sleep}s before retry [Retry {nb_tries}/{max_retries}].")
         else:
             actual_sleep = sleep_time
             logger.warning(f"Retrying in {actual_sleep}s [Retry {nb_tries}/{max_retries}].")

--- a/tests/test_utils_http.py
+++ b/tests/test_utils_http.py
@@ -1,6 +1,8 @@
 import threading
 import time
 import weakref
+from datetime import datetime, timedelta, timezone
+from email.utils import format_datetime
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Generator, Optional
 from unittest.mock import Mock, call, patch
@@ -24,6 +26,7 @@ from huggingface_hub.utils._http import (
     _adjust_range_header,
     _parse_bucket_id_from_url,
     _parse_repo_info_from_url,
+    _parse_retry_after,
     _warn_on_warning_headers,
     default_client_factory,
     fix_hf_endpoint_in_url,
@@ -185,6 +188,61 @@ class TestHttpBackoff:
 
         assert self.mock_request.call_count == 2
         assert sleep_times == [2.0]
+        assert response.status_code == 200
+
+    def test_backoff_uses_retry_after_header(self) -> None:
+        """Test that wait time uses the `Retry-After` header when no ratelimit header is present."""
+        sleep_times = []
+
+        def _side_effect_timer() -> Generator:
+            t0 = time.time()
+            mock_503 = Mock()
+            mock_503.status_code = 503
+            mock_503.headers = {"Retry-After": "1"}  # Server says wait 1s
+            yield mock_503
+            t1 = time.time()
+            sleep_times.append(round(t1 - t0, 1))
+            t0 = t1
+            mock_200 = Mock()
+            mock_200.status_code = 200
+            yield mock_200
+
+        self.mock_request.side_effect = _side_effect_timer()
+
+        response = http_backoff(
+            "GET", URL, base_wait_time=0.1, max_wait_time=0.5, max_retries=3, retry_on_status_codes=503
+        )
+
+        assert self.mock_request.call_count == 2
+        assert sleep_times == [2.0]  # 1s from Retry-After + 1s to avoid rounding issues
+        assert response.status_code == 200
+
+    def test_backoff_ratelimit_header_takes_precedence_over_retry_after(self) -> None:
+        """Test that the ratelimit header takes precedence over `Retry-After` when both are present."""
+        sleep_times = []
+
+        def _side_effect_timer() -> Generator:
+            t0 = time.time()
+            mock_429 = Mock()
+            mock_429.status_code = 429
+            # ratelimit says 1s, Retry-After says 10s => ratelimit wins
+            mock_429.headers = {"ratelimit": '"api";r=0;t=1', "Retry-After": "10"}
+            yield mock_429
+            t1 = time.time()
+            sleep_times.append(round(t1 - t0, 1))
+            t0 = t1
+            mock_200 = Mock()
+            mock_200.status_code = 200
+            yield mock_200
+
+        self.mock_request.side_effect = _side_effect_timer()
+
+        response = http_backoff(
+            "GET", URL, base_wait_time=0.1, max_wait_time=0.5, max_retries=3, retry_on_status_codes=429
+        )
+
+        assert self.mock_request.call_count == 2
+        assert sleep_times == [2.0]  # 1s from ratelimit header (not 10s from Retry-After) + 1s
         assert response.status_code == 200
 
 
@@ -524,6 +582,42 @@ class TestParseRatelimitHeaders:
         info = parse_ratelimit_headers(headers)
         assert info is not None
         assert info.remaining == 10
+
+
+class TestParseRetryAfter:
+    def test_parse_delay_seconds(self):
+        """Test parsing the delay-seconds form (e.g. 'Retry-After: 120')."""
+        assert _parse_retry_after({"Retry-After": "120"}) == 120
+        assert _parse_retry_after({"Retry-After": "0"}) == 0
+
+    def test_parse_http_date_in_future(self):
+        """Test parsing the HTTP-date form returns the number of seconds until that date."""
+        future = datetime.now(timezone.utc) + timedelta(seconds=120)
+        headers = {"Retry-After": format_datetime(future, usegmt=True)}
+        delay = _parse_retry_after(headers)
+        assert delay is not None
+        # Allow a small margin for the time elapsed between construction and parsing.
+        assert 115 <= delay <= 120
+
+    def test_parse_http_date_in_past(self):
+        """Test parsing an HTTP-date in the past is clamped to 0 (never negative)."""
+        past = datetime.now(timezone.utc) - timedelta(seconds=120)
+        headers = {"Retry-After": format_datetime(past, usegmt=True)}
+        assert _parse_retry_after(headers) == 0
+
+    def test_parse_case_insensitive(self):
+        """Test header lookup is case-insensitive."""
+        assert _parse_retry_after({"retry-after": "42"}) == 42
+
+    def test_parse_missing_header(self):
+        """Test returns None when the header is absent."""
+        assert _parse_retry_after({}) is None
+
+    def test_parse_malformed_header(self):
+        """Test returns None when the header value is invalid."""
+        assert _parse_retry_after({"Retry-After": "not-a-date"}) is None
+        assert _parse_retry_after({"Retry-After": ""}) is None
+        assert _parse_retry_after({"Retry-After": "-5"}) is None
 
 
 class TestBucketNotFoundError:

--- a/tests/test_utils_http.py
+++ b/tests/test_utils_http.py
@@ -190,61 +190,6 @@ class TestHttpBackoff:
         assert sleep_times == [2.0]
         assert response.status_code == 200
 
-    def test_backoff_uses_retry_after_header(self) -> None:
-        """Test that wait time uses the `Retry-After` header when no ratelimit header is present."""
-        sleep_times = []
-
-        def _side_effect_timer() -> Generator:
-            t0 = time.time()
-            mock_503 = Mock()
-            mock_503.status_code = 503
-            mock_503.headers = {"Retry-After": "1"}  # Server says wait 1s
-            yield mock_503
-            t1 = time.time()
-            sleep_times.append(round(t1 - t0, 1))
-            t0 = t1
-            mock_200 = Mock()
-            mock_200.status_code = 200
-            yield mock_200
-
-        self.mock_request.side_effect = _side_effect_timer()
-
-        response = http_backoff(
-            "GET", URL, base_wait_time=0.1, max_wait_time=0.5, max_retries=3, retry_on_status_codes=503
-        )
-
-        assert self.mock_request.call_count == 2
-        assert sleep_times == [2.0]  # 1s from Retry-After + 1s to avoid rounding issues
-        assert response.status_code == 200
-
-    def test_backoff_ratelimit_header_takes_precedence_over_retry_after(self) -> None:
-        """Test that the ratelimit header takes precedence over `Retry-After` when both are present."""
-        sleep_times = []
-
-        def _side_effect_timer() -> Generator:
-            t0 = time.time()
-            mock_429 = Mock()
-            mock_429.status_code = 429
-            # ratelimit says 1s, Retry-After says 10s => ratelimit wins
-            mock_429.headers = {"ratelimit": '"api";r=0;t=1', "Retry-After": "10"}
-            yield mock_429
-            t1 = time.time()
-            sleep_times.append(round(t1 - t0, 1))
-            t0 = t1
-            mock_200 = Mock()
-            mock_200.status_code = 200
-            yield mock_200
-
-        self.mock_request.side_effect = _side_effect_timer()
-
-        response = http_backoff(
-            "GET", URL, base_wait_time=0.1, max_wait_time=0.5, max_retries=3, retry_on_status_codes=429
-        )
-
-        assert self.mock_request.call_count == 2
-        assert sleep_times == [2.0]  # 1s from ratelimit header (not 10s from Retry-After) + 1s
-        assert response.status_code == 200
-
 
 class TestConfigureSession:
     @pytest.fixture(autouse=True)
@@ -584,40 +529,21 @@ class TestParseRatelimitHeaders:
         assert info.remaining == 10
 
 
-class TestParseRetryAfter:
-    def test_parse_delay_seconds(self):
-        """Test parsing the delay-seconds form (e.g. 'Retry-After: 120')."""
-        assert _parse_retry_after({"Retry-After": "120"}) == 120
-        assert _parse_retry_after({"Retry-After": "0"}) == 0
-
-    def test_parse_http_date_in_future(self):
-        """Test parsing the HTTP-date form returns the number of seconds until that date."""
-        future = datetime.now(timezone.utc) + timedelta(seconds=120)
-        headers = {"Retry-After": format_datetime(future, usegmt=True)}
-        delay = _parse_retry_after(headers)
-        assert delay is not None
-        # Allow a small margin for the time elapsed between construction and parsing.
-        assert 115 <= delay <= 120
-
-    def test_parse_http_date_in_past(self):
-        """Test parsing an HTTP-date in the past is clamped to 0 (never negative)."""
-        past = datetime.now(timezone.utc) - timedelta(seconds=120)
-        headers = {"Retry-After": format_datetime(past, usegmt=True)}
-        assert _parse_retry_after(headers) == 0
-
-    def test_parse_case_insensitive(self):
-        """Test header lookup is case-insensitive."""
-        assert _parse_retry_after({"retry-after": "42"}) == 42
-
-    def test_parse_missing_header(self):
-        """Test returns None when the header is absent."""
-        assert _parse_retry_after({}) is None
-
-    def test_parse_malformed_header(self):
-        """Test returns None when the header value is invalid."""
-        assert _parse_retry_after({"Retry-After": "not-a-date"}) is None
-        assert _parse_retry_after({"Retry-After": ""}) is None
-        assert _parse_retry_after({"Retry-After": "-5"}) is None
+@pytest.mark.parametrize(
+    ("headers", "expected"),
+    [
+        ({"Retry-After": "120"}, 120),
+        ({"Retry-After": "0"}, 0),
+        ({"retry-after": "42"}, 42),
+        ({}, None),
+        ({"Retry-After": "not-a-date"}, None),
+        ({"Retry-After": ""}, None),
+        ({"Retry-After": "-5"}, None),
+    ],
+)
+def test_parse_delay_seconds(headers, expected):
+    """Test parsing the delay-seconds form (e.g. 'Retry-After: 120')."""
+    assert _parse_retry_after(headers) == expected
 
 
 class TestBucketNotFoundError:

--- a/tests/test_utils_http.py
+++ b/tests/test_utils_http.py
@@ -1,8 +1,6 @@
 import threading
 import time
 import weakref
-from datetime import datetime, timedelta, timezone
-from email.utils import format_datetime
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Generator, Optional
 from unittest.mock import Mock, call, patch

--- a/tests/test_utils_http.py
+++ b/tests/test_utils_http.py
@@ -88,8 +88,10 @@ class TestHttpBackoff:
         """Test `http_backoff` until max limit is reached with status codes."""
         mock_503 = Mock()
         mock_503.status_code = 503
+        mock_503.headers = {}
         mock_504 = Mock()
         mock_504.status_code = 504
+        mock_504.headers = {}
         mock_504.raise_for_status.side_effect = HTTPError("HTTP Error")
         self.mock_request.side_effect = (mock_503, mock_504, mock_503, mock_504)
 
@@ -108,6 +110,7 @@ class TestHttpBackoff:
         """Test `http_backoff` until max limit with status codes and exceptions."""
         mock_503 = Mock()
         mock_503.status_code = 503
+        mock_503.headers = {}
         self.mock_request.side_effect = (mock_503, ConnectTimeout("Connection timeout"))
 
         with pytest.raises(ConnectTimeout):
@@ -124,6 +127,7 @@ class TestHttpBackoff:
         """
         mock_200 = Mock()
         mock_200.status_code = 200
+        mock_200.headers = {}
         self.mock_request.side_effect = (mock_200, mock_200, mock_200, mock_200)
 
         response = http_backoff("GET", URL, base_wait_time=0.0, max_retries=3, retry_on_status_codes=200)


### PR DESCRIPTION
Follows the [`Retry-After` header spec](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Retry-After) (both delay-seconds and HTTP-date forms). Existing `parse_ratelimit_headers` takes precedence when both are set.

Closes #2360

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to retry timing in shared HTTP utilities; behavior is additive with clear precedence and unit tests.
> 
> **Overview**
> **`http_backoff`** now uses the standard **`Retry-After`** header (delay-seconds only) to set retry wait time when present, in addition to the existing Hugging Face **`ratelimit`** parsing on **429**.
> 
> On retryable responses, **429** still prefers **`parse_ratelimit_headers`** when it succeeds; otherwise **`_parse_retry_after`** supplies the wait (case-insensitive header lookup, non-negative digit values only—HTTP-date values are ignored). That wait feeds the same **`ratelimit_reset`** path as rate-limit headers (**+1s** buffer before sleep).
> 
> Tests add **`test_parse_delay_seconds`** for **`_parse_retry_after`** and give mocked retry responses empty **`headers`** so header parsing does not break existing backoff tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 889d868d7a1715d05a07330513390c2576793cd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->