### PR TITLE
[Fix] fix TestConfigDictNotRequired skipped tests

### DIFF
--- a/tests/test_utils_strict_dataclass.py
+++ b/tests/test_utils_strict_dataclass.py
@@ -871,38 +871,40 @@ def test_typed_dict_to_dataclass_is_cached():
     assert strict_cls is strict_cls_bis  # "is" because dataclass is built only once
 
 
+@pytest.fixture
+def typed_dict_not_required():
+    return TypedDict(
+        "ConfigDictNotRequired",
+        {"required_value": Required[int], "not_required_value": NotRequired[int]},
+        total=False,
+    )
+
+
 @pytest.mark.skipif(sys.version_info < (3, 11), reason="Requires Python 3.11+")
-class TestConfigDictNotRequired:
-    def __init__(self):
-        # cannot be defined at class level because of Python<3.11
-        self.ConfigDictNotRequired = TypedDict(
-            "ConfigDictNotRequired",
-            {"required_value": Required[int], "not_required_value": NotRequired[int]},
-            total=False,
-        )
+@pytest.mark.parametrize(
+    "data",
+    [
+        {"required_value": 1, "not_required_value": 2},
+        {"required_value": 1},  # not required value is not validated
+    ],
+)
+def test_typed_dict_not_required_valid_data(typed_dict_not_required, data: dict):
+    validate_typed_dict(typed_dict_not_required, data)
 
-    @pytest.mark.parametrize(
-        "data",
-        [
-            {"required_value": 1, "not_required_value": 2},
-            {"required_value": 1},  # not required value is not validated
-        ],
-    )
-    def test_typed_dict_not_required_valid_data(self, data: dict):
-        validate_typed_dict(self.ConfigDictNotRequired, data)
 
-    @pytest.mark.parametrize(
-        "data",
-        [
-            # Missing required value
-            {"not_required_value": 2},
-            # If exists, the value is validated
-            {"required_value": 1, "not_required_value": "2"},
-        ],
-    )
-    def test_typed_dict_not_required_invalid_data(self, data: dict):
-        with pytest.raises(StrictDataclassFieldValidationError):
-            validate_typed_dict(self.ConfigDictNotRequired, data)
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="Requires Python 3.11+")
+@pytest.mark.parametrize(
+    "data",
+    [
+        # Missing required value
+        {"not_required_value": 2},
+        # If exists, the value is validated
+        {"required_value": 1, "not_required_value": "2"},
+    ],
+)
+def test_typed_dict_not_required_invalid_data(typed_dict_not_required, data: dict):
+    with pytest.raises(StrictDataclassFieldValidationError):
+        validate_typed_dict(typed_dict_not_required, data)
 
 
 def test_typed_dict_total_true():

--- a/tests/test_utils_strict_dataclass.py
+++ b/tests/test_utils_strict_dataclass.py
@@ -873,6 +873,8 @@ def test_typed_dict_to_dataclass_is_cached():
 
 @pytest.fixture
 def typed_dict_not_required():
+    if sys.version_info < (3, 11):
+        pytest.skip("Requires Python 3.11+")
     return TypedDict(
         "ConfigDictNotRequired",
         {"required_value": Required[int], "not_required_value": NotRequired[int]},
@@ -880,7 +882,6 @@ def typed_dict_not_required():
     )
 
 
-@pytest.mark.skipif(sys.version_info < (3, 11), reason="Requires Python 3.11+")
 @pytest.mark.parametrize(
     "data",
     [
@@ -892,7 +893,6 @@ def test_typed_dict_not_required_valid_data(typed_dict_not_required, data: dict)
     validate_typed_dict(typed_dict_not_required, data)
 
 
-@pytest.mark.skipif(sys.version_info < (3, 11), reason="Requires Python 3.11+")
 @pytest.mark.parametrize(
     "data",
     [


### PR DESCRIPTION
superseds https://github.com/huggingface/huggingface_hub/pull/4449 (slightly more pythonic / pytest way to fix the skipped test)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only restructuring with no production code changes; behavior on 3.11+ should match the previous tests.
> 
> **Overview**
> Refactors **`Required` / `NotRequired` TypedDict** coverage so it runs on Python 3.11+ instead of living behind a class-level `skipif`.
> 
> The old `TestConfigDictNotRequired` class (with per-instance TypedDict setup) is replaced by a **`typed_dict_not_required` fixture** that calls `pytest.skip` below 3.11 and returns the same TypedDict. The valid/invalid cases are now **module-level parametrized tests** that inject the fixture—same assertions, more idiomatic pytest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d0658dd2de86c657b01d5170bb3051622ea98f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->