### PR TITLE
[Cache] List partially-downloaded repos instead of dropping them

### DIFF
--- a/src/huggingface_hub/utils/_cache_manager.py
+++ b/src/huggingface_hub/utils/_cache_manager.py
@@ -789,7 +789,15 @@ def _scan_cached_repo(repo_path: Path) -> CachedRepoInfo:
 
             blob_path = Path(file_path).resolve()
             if not blob_path.exists():
-                raise CorruptedCacheException(f"Blob missing (broken symlink): {blob_path}")
+                # The snapshot references a blob that is not present on disk. This is expected
+                # for a *partial* download: `hf download` (or `snapshot_download` with
+                # `allow_patterns`) resolves the full file list for a revision but only
+                # materializes the requested files, leaving the un-downloaded ones as broken
+                # symlinks. Treat such a file as simply "not cached yet" and skip it, rather
+                # than raising a CorruptedCacheException that would drop the *entire* repo from
+                # `scan_cache_dir` (and thus from `hf cache list` and the reported total size).
+                # The present files of the repo are still reported. See issues #4419 and #4420.
+                continue
 
             if blob_path not in blob_stats:
                 blob_stats[blob_path] = blob_path.stat()

--- a/tests/test_utils_cache.py
+++ b/tests/test_utils_cache.py
@@ -339,6 +339,52 @@ class TestCorruptedCacheUtils:
         assert revision_report.nb_files == 0
         assert revision_report.last_modified == revision_path.stat().st_mtime
 
+    def test_snapshot_with_partially_downloaded_files(self, tmp_path) -> None:
+        """A partial download (some snapshot symlinks point to not-yet-downloaded blobs).
+
+        Regression test for #4419 / #4420. `hf download` (or `snapshot_download` with
+        `allow_patterns`) resolves the full file list for a revision but only materializes
+        the requested files, leaving the un-downloaded ones as broken symlinks. Such a repo
+        must still be listed by `scan_cache_dir` (with its present files), instead of being
+        silently dropped as a `CorruptedCacheException`.
+        """
+        # Gather the files of the (single) cached revision.
+        revision_path = next(self.snapshots_path.glob("*"))
+        snapshot_files = sorted(p for p in revision_path.glob("**/*") if not p.is_dir())
+        assert len(snapshot_files) >= 2, "fixture repo is expected to have at least 2 files"
+
+        # Simulate a partial download: point the first file's symlink at a blob that was
+        # never downloaded (broken symlink), while keeping the remaining files intact.
+        missing_file = snapshot_files[0]
+        present_files = snapshot_files[1:]
+        missing_blob = missing_file.resolve()
+        missing_file.unlink()
+        os.remove(missing_blob)  # the blob was never materialized
+        missing_file.symlink_to(missing_blob)  # dangling symlink, as left by a partial download
+        assert not missing_file.exists()  # sanity: broken symlink
+
+        # Scan
+        report = scan_cache_dir(tmp_path)
+
+        # The repo is still reported (not dropped) and produced no warning.
+        assert len(report.warnings) == 0
+        assert len(report.repos) == 1
+        repo_report = list(report.repos)[0]
+
+        # Only the present files are reported; the missing one is skipped.
+        assert len(repo_report.revisions) == 1
+        revision_report = list(repo_report.revisions)[0]
+        reported_names = {file.file_name for file in revision_report.files}
+        assert missing_file.name not in reported_names
+        assert reported_names == {p.name for p in present_files}
+
+        # The reported size accounts for the present blobs only, and is non-zero so the repo
+        # contributes to the `hf cache list` total (the core of #4420).
+        expected_size = sum(p.resolve().stat().st_size for p in present_files)
+        assert repo_report.size_on_disk == expected_size
+        assert repo_report.size_on_disk > 0
+        assert repo_report.nb_files == len(present_files)
+
     def test_repo_with_no_snapshots(self, tmp_path) -> None:
         """Test if the snapshot directory exists but is empty."""
         rmtree_with_retry(self.refs_path)


### PR DESCRIPTION
## What this fixes

Fixes #4419
Fixes #4420

`scan_cache_dir` (which powers `hf cache list` and its reported total size) **silently drops an entire cached repo** when that repo contains a partially-downloaded revision.

### Root cause

In `_scan_cached_repo` (`src/huggingface_hub/utils/_cache_manager.py`), each snapshot file's symlink is resolved to its blob, and a missing blob raised:

```python
blob_path = Path(file_path).resolve()
if not blob_path.exists():
    raise CorruptedCacheException(f"Blob missing (broken symlink): {blob_path}")
```

`scan_cache_dir` catches `CorruptedCacheException` **per repo** and turns it into a warning — so a single missing blob removes the whole repo from `.repos`, and its size from `.size_on_disk`.

But a **partial download legitimately produces missing blobs.** `hf download` (and `snapshot_download` with `allow_patterns`) resolve the full file list for a revision but only materialize the requested files, leaving the un-downloaded ones as broken symlinks in the snapshot folder. The reporter's case: a GGUF repo where only some quantizations were downloaded (downloading the rest would waste disk). The consequences:

- **#4419:** the repo vanishes from `hf cache list`, even though `hf cache verify` resolves and verifies its present files fine.
- **#4420:** because the repo is dropped, its on-disk size is excluded from the reported cache total (understating real usage).

### The fix

Treat a missing blob as a **not-yet-downloaded file** and skip it, instead of raising and dropping the whole repo:

```python
blob_path = Path(file_path).resolve()
if not blob_path.exists():
    # partial download: skip the un-downloaded file, keep the repo + its present files
    continue
```

The repo is now listed with its present files and their real size. This mirrors:
- the existing graceful handling of empty revisions (`test_snapshot_with_no_blob_files` asserts `warnings == 0`, `repos == 1`), and
- the semantics of `hf cache verify`, which already tolerates missing-but-remote files.

## Reproduction (before → after)

Building a cache with one present file (`model-Q4.gguf`) and one un-downloaded quantization (`model-Q8.gguf`, dangling symlink):

| | `.repos` | `.warnings` | reported size |
|---|---|---|---|
| **before** | `[]` (repo dropped) | 1× `Blob missing (broken symlink)` | 0 |
| **after** | `[kashif3314/nemotron]` | 0 | present blob size ✅ |

## Tests

Added `test_snapshot_with_partially_downloaded_files` to `TestCorruptedCacheUtils`. It breaks one snapshot symlink (simulating a partial download) and asserts the repo is still listed with only its present files and correct non-zero size.

- **With the fix:** passes.
- **Without the fix (reverting only the source change):** fails — `repos=frozenset()`, repo shunted to `warnings=[CorruptedCacheException('Blob missing (broken symlink)')]`. So the test genuinely guards the regression.

Full local run (`make quality` + cache suite):

```
ruff check .............. All checks passed!
ruff format --check ..... 2 files already formatted
make quality ............ all codegen/import checks ✅
ty check src ............ All checks passed!
pytest tests/test_utils_cache.py -k "Corrupted or ValidCache or Ignored or StringFormatters"
    10 passed, 1 skipped
```

(One unrelated test, `test_repo_with_no_snapshots`, fails on my macOS box due to an `st_atime` timing comparison — it fails **identically on a clean `main` checkout**, so it is pre-existing/environmental and untouched by this change.)

## Note for reviewers

This changes user-visible `hf cache list` behavior in the "correct direction" both linked issues ask for (list the repo rather than hide it). If you'd instead prefer to **surface** the not-yet-downloaded files explicitly (e.g. a distinct count/field on `CachedRevisionInfo`) rather than silently skipping them, I'm happy to extend this — but that's a larger API addition, so I kept this PR to the minimal robustness fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to cache scanning error handling; improves listing behavior without touching downloads, auth, or deletion logic.
> 
> **Overview**
> **`scan_cache_dir`** (and **`hf cache list`**) no longer treats a revision with dangling snapshot symlinks as a corrupted repo. When a snapshot file resolves to a **missing blob**—as with partial **`hf download`** / **`allow_patterns`** downloads—the scanner **skips** that entry instead of raising **`CorruptedCacheException`**, so the repo stays in results with only on-disk files and a correct non-zero total size (fixes #4419 / #4420).
> 
> A regression test simulates one broken symlink and asserts the repo is listed, warnings stay empty, and reported size matches present blobs only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb8d0ed52e05094cca0e104f817e702976eff167. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->