### PR TITLE
Make TestConfigDictNotRequired collectible via a fixture (fixes #4421)

### DIFF
--- a/tests/test_utils_strict_dataclass.py
+++ b/tests/test_utils_strict_dataclass.py
@@ -873,9 +873,11 @@ def test_typed_dict_to_dataclass_is_cached():
 
 @pytest.mark.skipif(sys.version_info < (3, 11), reason="Requires Python 3.11+")
 class TestConfigDictNotRequired:
-    def __init__(self):
-        # cannot be defined at class level because of Python<3.11
-        self.ConfigDictNotRequired = TypedDict(
+    @pytest.fixture
+    def config_dict_not_required(self):
+        # cannot be defined at class level because of Python<3.11; a fixture keeps
+        # the class collectible (an __init__ makes pytest skip it with a warning).
+        return TypedDict(
             "ConfigDictNotRequired",
             {"required_value": Required[int], "not_required_value": NotRequired[int]},
             total=False,
@@ -888,8 +890,8 @@ class TestConfigDictNotRequired:
             {"required_value": 1},  # not required value is not validated
         ],
     )
-    def test_typed_dict_not_required_valid_data(self, data: dict):
-        validate_typed_dict(self.ConfigDictNotRequired, data)
+    def test_typed_dict_not_required_valid_data(self, config_dict_not_required, data: dict):
+        validate_typed_dict(config_dict_not_required, data)
 
     @pytest.mark.parametrize(
         "data",
@@ -900,9 +902,9 @@ class TestConfigDictNotRequired:
             {"required_value": 1, "not_required_value": "2"},
         ],
     )
-    def test_typed_dict_not_required_invalid_data(self, data: dict):
+    def test_typed_dict_not_required_invalid_data(self, config_dict_not_required, data: dict):
         with pytest.raises(StrictDataclassFieldValidationError):
-            validate_typed_dict(self.ConfigDictNotRequired, data)
+            validate_typed_dict(config_dict_not_required, data)
 
 
 def test_typed_dict_total_true():


### PR DESCRIPTION
### Summary

`TestConfigDictNotRequired` (in `tests/test_utils_strict_dataclass.py`) defines an `__init__` to lazily build a `Required`/`NotRequired` `TypedDict` (which requires Python 3.11+). But pytest **cannot collect test classes that define `__init__`**, so it emits a `PytestCollectionWarning` (10 per run) and **silently skips the class's tests** (reported in #4421):

```
PytestCollectionWarning: cannot collect test class 'TestConfigDictNotRequired' because it has a __init__ constructor
```

### Fix

Move the lazy `TypedDict` construction from `__init__` into a `@pytest.fixture` (`config_dict_not_required`) that the two test methods consume. The class no longer has an `__init__`, so:

- it's collected without any warning, and
- its parametrized tests **actually run** on Python 3.11+ (still skipped below 3.11 via the existing `@pytest.mark.skipif`).

The lazy construction is preserved — `Required[int]`/`NotRequired[int]` are only evaluated inside the fixture, which runs only when the (3.11+-gated) tests execute.

### Verification

```
pytest tests/test_utils_strict_dataclass.py -W error::pytest.PytestCollectionWarning -k not_required
# 4 passed — no collection warning (previously: warning + tests skipped)
```

Fixes #4421.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor with no production code changes; it restores previously skipped coverage for TypedDict `Required`/`NotRequired` validation.
> 
> **Overview**
> Fixes pytest **not collecting** `TestConfigDictNotRequired` because the class defined `__init__` to lazily build a Python 3.11+ `TypedDict` with `Required`/`NotRequired`, which triggered `PytestCollectionWarning` and skipped its parametrized tests.
> 
> The `TypedDict` setup moves from `__init__` to a **`config_dict_not_required` fixture**; both test methods take the fixture instead of `self.ConfigDictNotRequired`. Collection works without warnings, and the same tests run on 3.11+ (still gated by the existing `skipif`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91dd1fb6e67a888f6d4f18253f370c7fe4a7256e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->