### PR TITLE
[CLI] Expose `out` singleton publicly + add `out.log` method

### DIFF
--- a/src/huggingface_hub/cli/__init__.py
+++ b/src/huggingface_hub/cli/__init__.py
@@ -11,3 +11,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from huggingface_hub.cli._output import out  # noqa: F401

--- a/src/huggingface_hub/cli/_output.py
+++ b/src/huggingface_hub/cli/_output.py
@@ -212,6 +212,20 @@ class Output:
         else:
             _print_flush(f"Error: {message}", file=sys.stderr)
 
+    def log(self, message: str) -> None:
+        """Print a text message to stderr (human: gray, json/agent: plain text).
+
+        Suppressed in quiet mode. Kept in json mode (like agent) since agents
+        commonly run with ``--format json`` and the message goes to stderr so
+        it never pollutes the parsed stdout.
+        """
+        if self.mode == OutputFormat.quiet:
+            return
+        if self.mode == OutputFormat.human:
+            _print_flush(ANSI.gray(message), file=sys.stderr)
+        else:
+            _print_flush(message, file=sys.stderr)
+
     def hint(self, message: str) -> None:
         """Print a helpful hint to stderr (human: gray, json/agent: plain text).
 
@@ -219,12 +233,7 @@ class Output:
         commonly run with ``--format json`` and the next-command hints are useful
         there; hints go to stderr so they never pollute the parsed stdout.
         """
-        if self.mode == OutputFormat.quiet:
-            return
-        if self.mode == OutputFormat.human:
-            _print_flush(ANSI.gray(f"Hint: {message}"), file=sys.stderr)
-        else:
-            _print_flush(f"Hint: {message}", file=sys.stderr)
+        self.log(f"Hint: {message}")
 
 
 # HELPERS

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -340,6 +340,23 @@ def test_hint(check):
     )
 
 
+def test_log(check):
+    check(
+        lambda out: out.log("Set HF_DEBUG=1 for full traceback."),
+        stderr=True,
+        human="""
+        Set HF_DEBUG=1 for full traceback.
+        """,
+        agent="""
+        Set HF_DEBUG=1 for full traceback.
+        """,
+        json="""
+        Set HF_DEBUG=1 for full traceback.
+        """,
+        quiet="",
+    )
+
+
 # =============================================================================
 # out.confirm()
 # =============================================================================


### PR DESCRIPTION
It often happens to me that I want to print a lower-level information to the output but doesn't want it to be in `stdout` (so `.text`, `.result`, `.table`, etc. doesn't fit) and it's not a `hint` either so prepending `"Hint: "` to the message would feel weird. Let's add a `.log(...)` method that does exactly the same as a `.hint(...)` but without being a `"Hint:"`.

I also took the opportunity to expose `out` publicly so external libraries can do

```py
from huggingface_hub.cli import out
```

instead of 

```py
from huggingface_hub.cli._output import out
```

(like in https://github.com/huggingface/diffusers/pull/13966)



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive CLI output API change; `hint` behavior is preserved through delegation.
> 
> **Overview**
> Adds **`out.log(message)`** on the CLI `Output` helper so commands can print secondary text to **stderr** (gray in human mode, plain in agent/json) without a **`Hint:`** prefix and without touching stdout—same quiet-mode suppression as hints.
> 
> **`out.hint`** is refactored to **`self.log(f"Hint: {message}")`**, so existing hint behavior stays the same. **`out`** is re-exported from **`huggingface_hub.cli`**, and **`test_log`** covers the new method across output modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad0e95d32143143741efb58122e6776a430f4eea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->