### PR TITLE
Fix KeyError in get_dataset_leaderboard when entry has no source

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -2060,9 +2060,9 @@ class DatasetLeaderboardEntry:
             Name of the result file containing the evaluation data.
         verified (`bool`):
             Whether the result has been verified.
-        source (`dict[str, Any]`):
+        source (`dict[str, Any]`, *optional*):
             Information about the source of the evaluation result. Contains keys like
-            `"url"`, `"name"`, and `"isExternal"`.
+            `"url"`, `"name"`, and `"isExternal"`. Not all entries have a source.
         author (`User` or `Organization`):
             The model author, parsed based on the `"type"` field in the API response.
         pull_request (`int`, *optional*):
@@ -2076,7 +2076,7 @@ class DatasetLeaderboardEntry:
     value: float
     filename: str
     verified: bool
-    source: dict[str, Any]
+    source: dict[str, Any] | None
     author: User | Organization
     pull_request: int | None = None
     notes: str | None = None
@@ -2087,7 +2087,7 @@ class DatasetLeaderboardEntry:
         self.value = kwargs.pop("value")
         self.filename = kwargs.pop("filename")
         self.verified = kwargs.pop("verified")
-        self.source = kwargs.pop("source")
+        self.source = kwargs.pop("source", None)
         author_data = dict(kwargs.pop("author"))
         author_type = author_data.get("type")
         if author_type == "org":

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2261,6 +2261,20 @@ class TestHfApiPublicProduction:
         with pytest.raises(RepositoryNotFoundError):
             HfApi().get_dataset_leaderboard("this-repo-does-not-exist/404")
 
+    def test_dataset_leaderboard_entry_missing_source(self):
+        # Some leaderboard entries returned by the server omit the "source" key entirely
+        # (e.g. https://huggingface.co/api/datasets/Idavidrein/gpqa/leaderboard). This should
+        # not raise a KeyError.
+        entry = DatasetLeaderboardEntry(
+            rank=1,
+            modelId="some-org/some-model",
+            value=42.0,
+            filename="results.yaml",
+            verified=False,
+            author={"type": "org", "name": "some-org"},
+        )
+        assert entry.source is None
+
     def test_space_info(self, api: HfApi) -> None:
         space = api.space_info(repo_id="HuggingFaceH4/zephyr-chat")
         assert space.id == "HuggingFaceH4/zephyr-chat"


### PR DESCRIPTION
## Summary
- `HfApi.get_dataset_leaderboard` crashes with `KeyError: 'source'` when a leaderboard entry from the server omits the `source` field. This happens in practice — e.g. `hf datasets leaderboard Idavidrein/gpqa` currently fails because 6 of its 98 entries (all `JetBrains/Mellum2-*` submissions) have no `source` key.
- `DatasetLeaderboardEntry.__init__` did `kwargs.pop("source")` with no default, so any entry missing the key raises instead of just leaving it unset.
- Made `source` optional (`dict[str, Any] | None`) and default to `None` when absent, consistent with how other optional fields (`pull_request`, `notes`) are already handled.

## Test plan
- [x] Added `test_dataset_leaderboard_entry_missing_source`, a fast offline unit test that reproduces the exact `KeyError: 'source'` crash on the old code and passes with the fix.
- [x] Verified against the real API: `HfApi().get_dataset_leaderboard("Idavidrein/gpqa")` now returns all 98 entries instead of raising.
- [x] Existing `test_get_dataset_leaderboard` / `test_get_dataset_leaderboard_not_found` production tests still pass.
- [x] `ruff check` / `ruff format --diff` clean on changed files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small API-model fix with a unit test; no auth or data-path changes.
> 
> **Overview**
> Fixes **`get_dataset_leaderboard`** failing with **`KeyError: 'source'`** when the Hub returns leaderboard rows without a `source` field (e.g. some entries on `Idavidrein/gpqa`).
> 
> **`DatasetLeaderboardEntry`** now treats **`source`** as optional: type **`dict[str, Any] | None`**, docs note it may be absent, and **`__init__`** uses **`kwargs.pop("source", None)`** like **`pull_request`** and **`notes`**. An offline test constructs an entry without **`source`** and asserts **`entry.source is None`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb004aa21a25876b4837e6586cef414a0388939a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->