### PR TITLE
Expose base_model filter param on get_dataset_leaderboard

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -3390,7 +3390,7 @@ class HfApi:
         self,
         repo_id: str,
         *,
-        base_model: bool = True,
+        base_model_only: bool | None = None,
         token: bool | str | None = None,
         timeout: float | None = None,
     ) -> list[DatasetLeaderboardEntry]:
@@ -3405,12 +3405,11 @@ class HfApi:
             repo_id (`str`):
                 A namespace (user or an organization) and a repo name separated
                 by a `/`. For example: `"allenai/olmOCR-bench"`.
-            base_model (`bool`, *optional*):
-                By default (`True`), the leaderboard only includes models that have no declared
-                `base_model` relation (i.e. canonical/root repos), matching the Hub's default
-                leaderboard view. Fine-tuned or derivative repos that declare a parent model are
-                excluded. Pass `False` to disable this filter and include every submitted result,
-                regardless of whether the model declares a base model relation.
+            base_model_only (`bool` or `None`, *optional*):
+                By default, the leaderboard only includes models that have no declared `base_model` relation
+                (i.e. canonical/root repos), matching the Hub's default leaderboard view. Fine-tuned or derivative
+                repos that declare a parent model are excluded. Pass `base_model_only=False` to disable this filter and
+                include every submitted result, regardless of whether the model declares a base model relation.
             token (`bool` or `str`, *optional*):
                 A valid user access token. Defaults to the locally saved
                 token, which is the recommended method for authentication (see
@@ -3442,13 +3441,15 @@ class HfApi:
             >>> leaderboard[0].rank
             1
 
-            >>> # Include fine-tuned / derivative models too
-            >>> full_leaderboard = api.get_dataset_leaderboard("allenai/olmOCR-bench", base_model=False)
+            # Include fine-tuned / derivative models too
+            >>> full_leaderboard = api.get_dataset_leaderboard("allenai/olmOCR-bench", base_model_only=False)
             ```
         """
         headers = self._build_hf_headers(token=token)
         path = f"{self.endpoint}/api/datasets/{repo_id}/leaderboard"
-        params = {"base_model": "true" if base_model else "false"}
+        params = {}
+        if base_model_only is not None:
+            params["base_model_only"] = base_model_only
         r = get_session().get(path, headers=headers, params=params, timeout=timeout)
         hf_raise_for_status(r)
         data = r.json()

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -3449,7 +3449,7 @@ class HfApi:
         path = f"{self.endpoint}/api/datasets/{repo_id}/leaderboard"
         params = {}
         if base_model_only is not None:
-            params["base_model_only"] = base_model_only
+            params["base_model"] = base_model_only
         r = get_session().get(path, headers=headers, params=params, timeout=timeout)
         hf_raise_for_status(r)
         data = r.json()

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -3390,6 +3390,7 @@ class HfApi:
         self,
         repo_id: str,
         *,
+        base_model: bool = True,
         token: bool | str | None = None,
         timeout: float | None = None,
     ) -> list[DatasetLeaderboardEntry]:
@@ -3404,6 +3405,12 @@ class HfApi:
             repo_id (`str`):
                 A namespace (user or an organization) and a repo name separated
                 by a `/`. For example: `"allenai/olmOCR-bench"`.
+            base_model (`bool`, *optional*):
+                By default (`True`), the leaderboard only includes models that have no declared
+                `base_model` relation (i.e. canonical/root repos), matching the Hub's default
+                leaderboard view. Fine-tuned or derivative repos that declare a parent model are
+                excluded. Pass `False` to disable this filter and include every submitted result,
+                regardless of whether the model declares a base model relation.
             token (`bool` or `str`, *optional*):
                 A valid user access token. Defaults to the locally saved
                 token, which is the recommended method for authentication (see
@@ -3434,11 +3441,15 @@ class HfApi:
             'datalab-to/chandra-ocr-2'
             >>> leaderboard[0].rank
             1
+
+            >>> # Include fine-tuned / derivative models too
+            >>> full_leaderboard = api.get_dataset_leaderboard("allenai/olmOCR-bench", base_model=False)
             ```
         """
         headers = self._build_hf_headers(token=token)
         path = f"{self.endpoint}/api/datasets/{repo_id}/leaderboard"
-        r = get_session().get(path, headers=headers, timeout=timeout)
+        params = {"base_model": "true" if base_model else "false"}
+        r = get_session().get(path, headers=headers, params=params, timeout=timeout)
         hf_raise_for_status(r)
         data = r.json()
         return [DatasetLeaderboardEntry(**entry) for entry in data]

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2258,12 +2258,10 @@ class TestHfApiPublicProduction:
 
     @pytest.mark.production
     def test_get_dataset_leaderboard_base_model_filter(self):
-        # By default, the leaderboard only includes models with no declared base_model relation.
-        # Passing base_model=False must return at least as many entries, since it lifts that filter.
         api = HfApi()
         default_leaderboard = api.get_dataset_leaderboard("LiquidAI/ifstruct-v1.0")
-        explicit_true_leaderboard = api.get_dataset_leaderboard("LiquidAI/ifstruct-v1.0", base_model=True)
-        full_leaderboard = api.get_dataset_leaderboard("LiquidAI/ifstruct-v1.0", base_model=False)
+        explicit_true_leaderboard = api.get_dataset_leaderboard("LiquidAI/ifstruct-v1.0", base_model_only=True)
+        full_leaderboard = api.get_dataset_leaderboard("LiquidAI/ifstruct-v1.0", base_model_only=False)
         assert len(default_leaderboard) == len(explicit_true_leaderboard)
         assert len(full_leaderboard) >= len(default_leaderboard)
         default_model_ids = {entry.model_id for entry in default_leaderboard}

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2257,6 +2257,20 @@ class TestHfApiPublicProduction:
         assert entry.notes is None or isinstance(entry.notes, str)
 
     @pytest.mark.production
+    def test_get_dataset_leaderboard_base_model_filter(self):
+        # By default, the leaderboard only includes models with no declared base_model relation.
+        # Passing base_model=False must return at least as many entries, since it lifts that filter.
+        api = HfApi()
+        default_leaderboard = api.get_dataset_leaderboard("LiquidAI/ifstruct-v1.0")
+        explicit_true_leaderboard = api.get_dataset_leaderboard("LiquidAI/ifstruct-v1.0", base_model=True)
+        full_leaderboard = api.get_dataset_leaderboard("LiquidAI/ifstruct-v1.0", base_model=False)
+        assert len(default_leaderboard) == len(explicit_true_leaderboard)
+        assert len(full_leaderboard) >= len(default_leaderboard)
+        default_model_ids = {entry.model_id for entry in default_leaderboard}
+        full_model_ids = {entry.model_id for entry in full_leaderboard}
+        assert default_model_ids.issubset(full_model_ids)
+
+    @pytest.mark.production
     def test_get_dataset_leaderboard_not_found(self):
         with pytest.raises(RepositoryNotFoundError):
             HfApi().get_dataset_leaderboard("this-repo-does-not-exist/404")

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2263,7 +2263,7 @@ class TestHfApiPublicProduction:
         explicit_true_leaderboard = api.get_dataset_leaderboard("LiquidAI/ifstruct-v1.0", base_model_only=True)
         full_leaderboard = api.get_dataset_leaderboard("LiquidAI/ifstruct-v1.0", base_model_only=False)
         assert len(default_leaderboard) == len(explicit_true_leaderboard)
-        assert len(full_leaderboard) >= len(default_leaderboard)
+        assert len(full_leaderboard) > len(default_leaderboard)
         default_model_ids = {entry.model_id for entry in default_leaderboard}
         full_model_ids = {entry.model_id for entry in full_leaderboard}
         assert default_model_ids.issubset(full_model_ids)


### PR DESCRIPTION
## Summary
- The Hub's `/api/datasets/{repo_id}/leaderboard` endpoint takes a `base_model` query param that defaults to `true` server-side. When `true`, results are restricted to models with **no declared `base_model` relation** (i.e. canonical/root repos) — fine-tuned or derivative repos that declare a parent model are excluded (see `server/lib/SearchBuilder.ts` `baseModelFilters()` / `server/app/apiListingRoutes.ts` `getApiDatasetLeaderboard` in the Hub backend).
- `get_dataset_leaderboard()` never sent this param at all, so it silently inherited the restrictive default with no way to opt out. This produces meaningfully incomplete leaderboards — e.g. `LiquidAI/ifstruct-v1.0` returns only 4 entries by default vs. 15 when the filter is disabled (missing `google/gemma-4-31B-it`, the actual #1-ranked entry, among others).
- Added a `base_model: bool = True` kwarg (default preserves current behavior, so this is non-breaking) that forwards to the query string, letting callers pass `base_model=False` to get every submitted result regardless of base-model lineage.

## Test plan
- [x] Added `test_get_dataset_leaderboard_base_model_filter`, a production test against `LiquidAI/ifstruct-v1.0` asserting: default == explicit `base_model=True`, `base_model=False` returns a superset, and the default result set is a subset of the full one.
- [x] Verified manually: `get_dataset_leaderboard("LiquidAI/ifstruct-v1.0")` → 4 entries; `get_dataset_leaderboard("LiquidAI/ifstruct-v1.0", base_model=False)` → 15 entries, matching what the Hub website shows with the "base model" filter toggled off.
- [x] Existing `test_get_dataset_leaderboard` / `test_get_dataset_leaderboard_not_found` still pass.
- [x] `ruff check` / `ruff format --diff` clean on changed files.

Related to #4473 (separate `source` KeyError fix on the same method) but kept independent since this is an additive parameter rather than a bug fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive optional API parameter on a read-only endpoint; default behavior unchanged when the kwarg is omitted.
> 
> **Overview**
> Adds optional **`base_model_only`** to **`get_dataset_leaderboard`**, forwarding the Hub leaderboard API’s **`base_model`** query parameter so callers can match the website’s “base model” filter.
> 
> When **`base_model_only` is omitted**, no query param is sent and the server keeps its default (canonical/root models only, excluding fine-tuned repos with a declared base model). **`base_model_only=False`** requests the full leaderboard including derivatives; **`True`** explicitly enables the same filter as the default.
> 
> Docs and an example for **`base_model_only=False`** are updated. A production test on **`LiquidAI/ifstruct-v1.0`** checks default vs explicit **`True`** match and **`False`** returns a strict superset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e065894e7fbf913f255462407f7982731032e71a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->