### PR TITLE
Docs: Jobs are no longer Pro-only — update availability note in jobs guide

### DIFF
--- a/docs/source/en/guides/jobs.md
+++ b/docs/source/en/guides/jobs.md
@@ -19,7 +19,7 @@ If you want to run and manage a job on the Hub, your machine must be logged in. 
 [this section](../quick-start#authentication). In the rest of this guide, we will assume that your machine is logged in.
 
 > [!TIP]
-> **Hugging Face Jobs** are available only to [Pro users](https://huggingface.co/pro) and [Team or Enterprise organizations](https://huggingface.co/enterprise). Upgrade your plan to get started!
+> **Hugging Face Jobs** are available to any user or organization with a positive [credit balance](https://huggingface.co/settings/billing). See [Jobs pricing and billing](https://huggingface.co/docs/hub/jobs-pricing) for details.
 
 ## Jobs Command Line Interface
 


### PR DESCRIPTION
The jobs guide still says Jobs are "available only to Pro users and Team or Enterprise organizations". Jobs moved to pay-as-you-go: per the [Hub Jobs pricing docs](https://huggingface.co/docs/hub/jobs-pricing), they're available to any user or organization with a positive credit balance — no specific plan required.

This updates the callout to match, linking the pricing page as the source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to a single callout; no product or code behavior affected.
> 
> **Overview**
> Aligns the **Hugging Face Jobs** availability callout in the jobs guide with pay-as-you-go billing: Jobs are no longer described as **Pro / Team / Enterprise only**.
> 
> The TIP now states that any user or organization with a positive **credit balance** can use Jobs, with links to billing settings and the Hub **Jobs pricing and billing** docs as the source of truth.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08134e4a07534711bdbe40a5e003fefe13aadc89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->