### PR TITLE
[CI] Fix Transformers RC testing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -871,10 +871,6 @@ jobs:
 
           git checkout -b "$BRANCH_NAME"
 
-          allow_prereleases_in_workflows() {
-            find .github/workflows/ -type f -exec perl -0pi -e 's/uv pip install (?!--prerelease=allow )/uv pip install --prerelease=allow /g' {} +
-          }
-
           # Update setup.py if exists
           if [ -f "setup.py" ]; then
             sed -i -E "s/\"huggingface-hub(>=|==)[^\"]*\"/\"huggingface-hub==${VERSION}\"/" setup.py
@@ -914,7 +910,7 @@ jobs:
           # --prerelease=allow would also pull in unrelated prereleases (e.g. tokenizers) that break
           # the latest transformers and cause spurious CI failures.
           if [ "${{ matrix.target-repo }}" != "sentence-transformers" ]; then
-            allow_prereleases_in_workflows
+            find .github/workflows/ -type f -exec perl -0pi -e 's/uv pip install (?!--prerelease=allow )/uv pip install --prerelease=allow /g' {} +
             git add .github/workflows/
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -871,6 +871,10 @@ jobs:
 
           git checkout -b "$BRANCH_NAME"
 
+          allow_prereleases_in_workflows() {
+            find .github/workflows/ -type f -exec perl -0pi -e 's/uv pip install (?!--prerelease=allow )/uv pip install --prerelease=allow /g' {} +
+          }
+
           # Update setup.py if exists
           if [ -f "setup.py" ]; then
             sed -i -E "s/\"huggingface-hub(>=|==)[^\"]*\"/\"huggingface-hub==${VERSION}\"/" setup.py
@@ -881,6 +885,16 @@ jobs:
           if [ "${{ matrix.target-repo }}" = "transformers" ]; then
             sed -i -E "s/\"huggingface-hub(>=|==)[^\"]*\"/\"huggingface-hub==${VERSION}\"/" src/transformers/dependency_versions_table.py
             git add src/transformers/dependency_versions_table.py
+
+            # The current Transformers PR CI delegates to reusable workflows from
+            # huggingface/transformers-test-ci. Copy those workflows into this test
+            # branch so the prerelease patch applies to the actual quality install.
+            curl -fsSL https://raw.githubusercontent.com/huggingface/transformers-test-ci/main/.github/workflows/pr-ci_dynamic_caller_example.yml \
+              -o .github/workflows/pr-ci_dynamic_caller_example.yml
+            curl -fsSL https://raw.githubusercontent.com/huggingface/transformers-test-ci/main/.github/workflows/pr-ci_reusable_test_job.yml \
+              -o .github/workflows/pr-ci_reusable_test_job.yml
+            sed -i -E "s|uses: huggingface/transformers-test-ci/\.github/workflows/pr-ci_dynamic_caller_example\.yml@[^[:space:]]+.*|uses: ./.github/workflows/pr-ci_dynamic_caller_example.yml # patched for hfh prerelease|" .github/workflows/pr-ci-caller.yml
+            git add .github/workflows/pr-ci-caller.yml .github/workflows/pr-ci_dynamic_caller_example.yml .github/workflows/pr-ci_reusable_test_job.yml
           fi
 
           # diffusers-specific
@@ -900,7 +914,7 @@ jobs:
           # --prerelease=allow would also pull in unrelated prereleases (e.g. tokenizers) that break
           # the latest transformers and cause spurious CI failures.
           if [ "${{ matrix.target-repo }}" != "sentence-transformers" ]; then
-            find .github/workflows/ -type f -exec sed -i 's/uv pip install /uv pip install --prerelease=allow /g' {} +
+            allow_prereleases_in_workflows
             git add .github/workflows/
           fi
 


### PR DESCRIPTION
## Summary
- Fix Transformers RC testing after its PR CI moved the quality checks to reusable workflows in `huggingface/transformers-test-ci`.
- Copy those reusable workflow files into the generated Transformers test branch and patch their `uv pip install` commands with `--prerelease=allow`.
- Keep the existing downstream behavior for other repos, including the sentence-transformers prerelease exception.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only release automation for downstream RC test branches; no library runtime, auth, or data-path impact.
> 
> **Overview**
> Fixes **downstream Transformers RC validation** in `release.yml` now that PR CI runs quality checks via reusable workflows in `huggingface/transformers-test-ci` instead of only local workflow files.
> 
> For **transformers** test branches, the job **vendors** `pr-ci_dynamic_caller_example.yml` and `pr-ci_reusable_test_job.yml` from `transformers-test-ci/main`, **rewires** `pr-ci-caller.yml` to call the local copies, and stages those files so the existing workflow-wide `uv pip install --prerelease=allow` patch applies where installs actually run.
> 
> The global prerelease patch switches from a blunt `sed` on every `uv pip install` to **perl** that inserts `--prerelease=allow` only when it is **not already** present, avoiding duplicate flags. **sentence-transformers** still skips the prerelease workflow patch unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 840323471870613ad3921e7ba8c8ac15c72078ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->