### PR TITLE
[Xet] Remove dead connection info helpers

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -37,10 +37,6 @@ import httpx
 from tqdm.auto import tqdm as base_tqdm
 from tqdm.contrib.concurrent import thread_map
 
-from huggingface_hub.utils._xet import (
-    reset_xet_connection_info_cache_for_repo,
-)
-
 from . import constants
 from ._buckets import (
     BucketFile,
@@ -4690,7 +4686,6 @@ class HfApi:
 
         headers = self._build_hf_headers(token=token)
         r = get_session().request("DELETE", path, headers=headers, json=json)
-        reset_xet_connection_info_cache_for_repo(repo_type, repo_id)
         try:
             hf_raise_for_status(r)
         except RepositoryNotFoundError:
@@ -13486,7 +13481,6 @@ class HfApi:
             headers=self._build_hf_headers(token=token),
         )
 
-        reset_xet_connection_info_cache_for_repo("bucket", bucket_id)
         try:
             hf_raise_for_status(response)
         except HfHubHTTPError as e:

--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -118,12 +118,9 @@ from ._terminal import ANSI, StatusLine, select_choice, tabulate
 from ._typing import is_jsonable, is_simple_optional_type, unwrap_simple_optional_type
 from ._validators import validate_hf_hub_args, validate_repo_id
 from ._xet import (
-    XetConnectionInfo,
     XetFileData,
     XetTokenType,
-    fetch_xet_connection_info_from_repo_info,
     parse_xet_file_data_from_response,
-    refresh_xet_connection_info,
 )
 from .tqdm import (
     are_progress_bars_disabled,

--- a/src/huggingface_hub/utils/_xet.py
+++ b/src/huggingface_hub/utils/_xet.py
@@ -1,18 +1,12 @@
 import os
 import threading
-import time
 from dataclasses import dataclass
 from enum import Enum
 
 import httpx
 
 from .. import constants
-from . import hf_raise_for_status, http_backoff, validate_hf_hub_args
-
-
-XET_CONNECTION_INFO_SAFETY_PERIOD = 60  # seconds
-XET_CONNECTION_INFO_CACHE_SIZE = 1_000
-XET_CONNECTION_INFO_CACHE: dict[str, "XetConnectionInfo"] = {}
+from . import validate_hf_hub_args
 
 
 class XetTokenType(str, Enum):
@@ -24,13 +18,6 @@ class XetTokenType(str, Enum):
 class XetFileData:
     file_hash: str
     refresh_route: str
-
-
-@dataclass(frozen=True)
-class XetConnectionInfo:
-    access_token: str
-    expiration_unix_epoch: int
-    endpoint: str
 
 
 def parse_xet_file_data_from_response(response: httpx.Response, endpoint: str | None = None) -> XetFileData | None:
@@ -68,59 +55,6 @@ def parse_xet_file_data_from_response(response: httpx.Response, endpoint: str | 
     )
 
 
-def parse_xet_connection_info_from_headers(headers: dict[str, str]) -> XetConnectionInfo | None:
-    """
-    Parse XET connection info from the HTTP headers or return None if not found.
-    Args:
-        headers (`dict`):
-           HTTP headers to extract the XET metadata from.
-    Returns:
-        `XetConnectionInfo` or `None`:
-            The information needed to connect to the XET storage service.
-            Returns `None` if the headers do not contain the XET connection info.
-    """
-    try:
-        endpoint = headers[constants.HUGGINGFACE_HEADER_X_XET_ENDPOINT]
-        access_token = headers[constants.HUGGINGFACE_HEADER_X_XET_ACCESS_TOKEN]
-        expiration_unix_epoch = int(headers[constants.HUGGINGFACE_HEADER_X_XET_EXPIRATION])
-    except (KeyError, ValueError, TypeError):
-        return None
-
-    return XetConnectionInfo(
-        endpoint=endpoint,
-        access_token=access_token,
-        expiration_unix_epoch=expiration_unix_epoch,
-    )
-
-
-@validate_hf_hub_args
-def refresh_xet_connection_info(
-    *,
-    file_data: XetFileData,
-    headers: dict[str, str],
-) -> XetConnectionInfo:
-    """
-    Utilizes the information in the parsed metadata to request the Hub xet connection information.
-    This includes the access token, expiration, and XET service URL.
-    Args:
-        file_data: (`XetFileData`):
-            The file data needed to refresh the xet connection information.
-        headers (`dict[str, str]`):
-            Headers to use for the request, including authorization headers and user agent.
-    Returns:
-        `XetConnectionInfo`:
-            The connection information needed to make the request to the xet storage service.
-    Raises:
-        [`~utils.HfHubHTTPError`]
-            If the Hub API returned an error.
-        [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
-            If the Hub API response is improperly formatted.
-    """
-    if file_data.refresh_route is None:
-        raise ValueError("The provided xet metadata does not contain a refresh endpoint.")
-    return _fetch_xet_connection_info_with_url(file_data.refresh_route, headers)
-
-
 @validate_hf_hub_args
 def xet_connection_info_refresh_url(
     *,
@@ -156,138 +90,6 @@ def xet_connection_info_refresh_url(
         # => pass "/None" in URL and server will return a token for PR refs.
         url += f"/{revision}"
     return url
-
-
-@validate_hf_hub_args
-def fetch_xet_connection_info_from_repo_info(
-    *,
-    token_type: XetTokenType,
-    repo_id: str,
-    repo_type: str,
-    revision: str | None = None,
-    headers: dict[str, str],
-    endpoint: str | None = None,
-    params: dict[str, str] | None = None,
-) -> XetConnectionInfo:
-    """
-    Uses the repo info to request a xet access token from Hub.
-    Args:
-        token_type (`XetTokenType`):
-            Type of the token to request: `"read"` or `"write"`.
-        repo_id (`str`):
-            A namespace (user or an organization) and a repo name separated by a `/`.
-        repo_type (`str`):
-            Type of the repo to upload to: `"model"`, `"dataset"` or `"space"`.
-        revision (`str`, `optional`):
-            The revision of the repo to get the token for.
-        headers (`dict[str, str]`):
-            Headers to use for the request, including authorization headers and user agent.
-        endpoint (`str`, `optional`):
-            The endpoint to use for the request. Defaults to the Hub endpoint.
-        params (`dict[str, str]`, `optional`):
-            Additional parameters to pass with the request.
-    Returns:
-        `XetConnectionInfo`:
-            The connection information needed to make the request to the xet storage service.
-    Raises:
-        [`~utils.HfHubHTTPError`]
-            If the Hub API returned an error.
-        [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
-            If the Hub API response is improperly formatted.
-    """
-    url = xet_connection_info_refresh_url(
-        token_type=token_type,
-        repo_id=repo_id,
-        repo_type=repo_type,
-        revision=revision,
-        endpoint=endpoint,
-    )
-    return _fetch_xet_connection_info_with_url(url, headers, params, cache_key_prefix=f"{repo_type}-{repo_id}")
-
-
-@validate_hf_hub_args
-def _fetch_xet_connection_info_with_url(
-    url: str,
-    headers: dict[str, str],
-    params: dict[str, str] | None = None,
-    cache_key_prefix: str | None = None,
-) -> XetConnectionInfo:
-    """
-    Requests the xet connection info from the supplied URL. This includes the
-    access token, expiration time, and endpoint to use for the xet storage service.
-
-    Result is cached to avoid redundant requests.
-
-    Args:
-        url: (`str`):
-            The access token endpoint URL.
-        headers (`dict[str, str]`):
-            Headers to use for the request, including authorization headers and user agent.
-        params (`dict[str, str]`, `optional`):
-            Additional parameters to pass with the request.
-    Returns:
-        `XetConnectionInfo`:
-            The connection information needed to make the request to the xet storage service.
-    Raises:
-        [`~utils.HfHubHTTPError`]
-            If the Hub API returned an error.
-        [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
-            If the Hub API response is improperly formatted.
-    """
-    # Check cache first
-    cache_key = _cache_key(url, headers, params, prefix=cache_key_prefix)
-    cached_info = XET_CONNECTION_INFO_CACHE.get(cache_key)
-    if cached_info is not None:
-        if not _is_expired(cached_info):
-            return cached_info
-
-    # Fetch from server
-    resp = http_backoff("GET", url, headers=headers, params=params)
-    hf_raise_for_status(resp)
-
-    metadata = parse_xet_connection_info_from_headers(resp.headers)  # type: ignore
-    if metadata is None:
-        raise ValueError("Xet headers have not been correctly set by the server.")
-
-    # Delete expired cache entries
-    for k, v in list(XET_CONNECTION_INFO_CACHE.items()):
-        if _is_expired(v):
-            XET_CONNECTION_INFO_CACHE.pop(k, None)
-
-    # Enforce cache size limit
-    if len(XET_CONNECTION_INFO_CACHE) >= XET_CONNECTION_INFO_CACHE_SIZE:
-        XET_CONNECTION_INFO_CACHE.pop(next(iter(XET_CONNECTION_INFO_CACHE)))
-
-    # Update cache
-    XET_CONNECTION_INFO_CACHE[cache_key] = metadata
-
-    return metadata
-
-
-def reset_xet_connection_info_cache_for_repo(repo_type: str | None, repo_id: str) -> None:
-    """Reset the XET connection info cache for the given repo type and repo id.
-
-    Used when a repo is deleted.
-    """
-    if repo_type is None:
-        repo_type = constants.REPO_TYPE_MODEL
-    prefix = f"{repo_type}-{repo_id}|"
-    for k in list(XET_CONNECTION_INFO_CACHE.keys()):
-        if k.startswith(prefix):
-            XET_CONNECTION_INFO_CACHE.pop(k, None)
-
-
-def _cache_key(url: str, headers: dict[str, str], params: dict[str, str] | None, prefix: str | None = None) -> str:
-    """Return a unique cache key for the given request parameters."""
-    lower_headers = {k.lower(): v for k, v in headers.items()}  # casing is not guaranteed here
-    auth_header = lower_headers.get("authorization", "")
-    params_str = "&".join(f"{k}={v}" for k, v in sorted((params or {}).items(), key=lambda x: x[0]))
-    return f"{prefix}|{url}|{auth_header}|{params_str}"
-
-
-def _is_expired(connection_info: XetConnectionInfo) -> bool:
-    """Check if the given XET connection info is expired."""
-    return connection_info.expiration_unix_epoch <= int(time.time()) + XET_CONNECTION_INFO_SAFETY_PERIOD
 
 
 class XetSessionHolder:

--- a/tests/test_xet_download.py
+++ b/tests/test_xet_download.py
@@ -14,10 +14,7 @@ from huggingface_hub.file_download import (
     try_to_load_from_cache,
     xet_get,
 )
-from huggingface_hub.utils import (
-    XetFileData,
-    refresh_xet_connection_info,
-)
+from huggingface_hub.utils import XetFileData
 
 from .testing_constants import (
     DUMMY_XET_FILE,
@@ -88,12 +85,7 @@ class TestXetFileDownload:
         metadata = get_hf_file_metadata(url)
         assert metadata.xet_file_data is not None
         assert metadata.xet_file_data.file_hash is not None
-
-        connection_info = refresh_xet_connection_info(file_data=metadata.xet_file_data, headers={})
-        assert connection_info is not None
-        assert connection_info.endpoint is not None
-        assert connection_info.access_token is not None
-        assert isinstance(connection_info.expiration_unix_epoch, int)
+        assert metadata.xet_file_data.refresh_route is not None
 
     def test_basic_download(self, tmp_path):
         # Make sure that xet_get is called
@@ -304,42 +296,3 @@ class TestXetSnapshotDownload:
 
             # Verify xet_get was not called (files were cached)
             mock_xet_get.assert_not_called()
-
-    def test_download_backward_compatibility(self, tmp_path):
-        """Test that xet download works with the old pointer file protocol.
-
-        Until the next major version of hf-xet is released, we need to support the old
-        pointer file based download to support old huggingface_hub versions.
-        """
-
-        file_path = os.path.join(tmp_path, DUMMY_XET_FILE)
-
-        file_metadata = get_hf_file_metadata(
-            hf_hub_url(
-                repo_id=DUMMY_XET_MODEL_ID,
-                filename=DUMMY_XET_FILE,
-            )
-        )
-
-        xet_file_data = file_metadata.xet_file_data
-
-        # Mock the response to not include xet metadata
-        from hf_xet import PyPointerFile, download_files
-
-        connection_info = refresh_xet_connection_info(file_data=xet_file_data, headers={})
-
-        def token_refresher() -> tuple[str, int]:
-            connection_info = refresh_xet_connection_info(file_data=xet_file_data, headers={})
-            return connection_info.access_token, connection_info.expiration_unix_epoch
-
-        pointer_files = [PyPointerFile(path=file_path, hash=xet_file_data.file_hash, filesize=file_metadata.size)]
-
-        download_files(
-            pointer_files,
-            endpoint=connection_info.endpoint,
-            token_info=(connection_info.access_token, connection_info.expiration_unix_epoch),
-            token_refresher=token_refresher,
-            progress_updater=None,
-        )
-
-        assert os.path.exists(file_path)

--- a/tests/test_xet_upload.py
+++ b/tests/test_xet_upload.py
@@ -27,7 +27,7 @@ from huggingface_hub.file_download import (
     hf_hub_download,
     hf_hub_url,
 )
-from huggingface_hub.utils import build_hf_headers, refresh_xet_connection_info
+from huggingface_hub.utils import build_hf_headers
 
 from .testing_constants import ENDPOINT_STAGING, TOKEN
 from .testing_utils import repo_name
@@ -154,8 +154,7 @@ class TestXetUpload:
         )
         metadata = get_hf_file_metadata(url)
         assert metadata.xet_file_data is not None
-        xet_connection = refresh_xet_connection_info(file_data=metadata.xet_file_data, headers={})
-        assert xet_connection is not None
+        assert metadata.xet_file_data.refresh_route is not None
 
     def test_upload_file_with_bytesio(self, api, tmp_path, repo_url):
         repo_id = repo_url.repo_id

--- a/tests/test_xet_utils.py
+++ b/tests/test_xet_utils.py
@@ -6,21 +6,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
 
-from huggingface_hub import HfApi, constants
 from huggingface_hub.utils._xet import (
-    XetFileData,
     XetSessionHolder,
     XetTokenType,
-    _fetch_xet_connection_info_with_url,
-    fetch_xet_connection_info_from_repo_info,
-    parse_xet_connection_info_from_headers,
     parse_xet_file_data_from_response,
-    refresh_xet_connection_info,
     xet_connection_info_refresh_url,
 )
-
-from .testing_constants import ENDPOINT_STAGING, TOKEN
-from .testing_utils import repo_name
 
 
 pytestmark = pytest.mark.xet
@@ -92,203 +83,18 @@ def test_parse_header_file_info_with_endpoint(refresh_route: str, expected_refre
     assert file_data.file_hash == "sha256:abcdef"
 
 
-def test_parse_valid_headers_connection_info() -> None:
-    headers = {
-        "X-Xet-Cas-Url": "https://xet.example.com",
-        "X-Xet-Access-Token": "xet_token_abc",
-        "X-Xet-Token-Expiration": "1234567890",
-    }
-
-    connection_info = parse_xet_connection_info_from_headers(headers)
-
-    assert connection_info is not None
-    assert connection_info.endpoint == "https://xet.example.com"
-    assert connection_info.access_token == "xet_token_abc"
-    assert connection_info.expiration_unix_epoch == 1234567890
-
-
 def test_parse_valid_headers_full() -> None:
     mock_response = MagicMock()
     mock_response.headers = {
-        "X-Xet-Cas-Url": "https://xet.example.com",
-        "X-Xet-Access-Token": "xet_token_abc",
-        "X-Xet-Token-Expiration": "1234567890",
         "X-Xet-Refresh-Route": "/api/refresh",
         "X-Xet-Hash": "sha256:abcdef",
     }
     mock_response.links = {}
 
     file_metadata = parse_xet_file_data_from_response(mock_response)
-    connection_info = parse_xet_connection_info_from_headers(mock_response.headers)
-
     assert file_metadata is not None
     assert file_metadata.refresh_route == "/api/refresh"
     assert file_metadata.file_hash == "sha256:abcdef"
-
-    assert connection_info is not None
-    assert connection_info.endpoint == "https://xet.example.com"
-    assert connection_info.access_token == "xet_token_abc"
-    assert connection_info.expiration_unix_epoch == 1234567890
-
-
-@pytest.mark.parametrize(
-    "missing_key",
-    [
-        "X-Xet-Cas-Url",
-        "X-Xet-Access-Token",
-        "X-Xet-Token-Expiration",
-    ],
-)
-def test_parse_missing_required_header(missing_key: str) -> None:
-    headers = {
-        "X-Xet-Cas-Url": "https://xet.example.com",
-        "X-Xet-Access-Token": "xet_token_abc",
-        "X-Xet-Token-Expiration": "1234567890",
-    }
-
-    # Remove the key to test
-    headers.pop(missing_key)
-
-    connection_info = parse_xet_connection_info_from_headers(headers)
-    assert connection_info is None
-
-
-def test_parse_invalid_expiration() -> None:
-    """Test parsing headers with invalid expiration format returns None."""
-    headers = {
-        "X-Xet-Cas-Url": "https://xet.example.com",
-        "X-Xet-Access-Token": "xet_token_abc",
-        "X-Xet-Token-Expiration": "not-a-number",
-    }
-
-    connection_info = parse_xet_connection_info_from_headers(headers)
-    assert connection_info is None
-
-
-def test_refresh_metadata_success(mocker) -> None:
-    # Mock headers for the refreshed response
-    mock_response = MagicMock()
-    mock_response.headers = {
-        "X-Xet-Cas-Url": "https://example.xethub.hf.co",
-        "X-Xet-Access-Token": "new_token",
-        "X-Xet-Token-Expiration": "1234599999",
-        "X-Xet-Refresh-Route": f"{constants.ENDPOINT}/api/models/username/repo_name/xet-read-token/token",
-    }
-
-    http_backoff_mock = mocker.patch("huggingface_hub.utils._xet.http_backoff", return_value=mock_response)
-
-    headers = {"user-agent": "user-agent-example"}
-    refreshed_connection = refresh_xet_connection_info(
-        file_data=XetFileData(
-            refresh_route=f"{constants.ENDPOINT}/api/models/username/repo_name/xet-read-token/token",
-            file_hash="sha256:abcdef",
-        ),
-        headers=headers,
-    )
-
-    # Verify the request
-    expected_url = f"{constants.ENDPOINT}/api/models/username/repo_name/xet-read-token/token"
-    http_backoff_mock.assert_called_once_with(
-        "GET",
-        expected_url,
-        headers=headers,
-        params=None,
-    )
-
-    assert refreshed_connection.endpoint == "https://example.xethub.hf.co"
-    assert refreshed_connection.access_token == "new_token"
-    assert refreshed_connection.expiration_unix_epoch == 1234599999
-
-
-def test_refresh_metadata_custom_endpoint(mocker) -> None:
-    custom_endpoint = "https://custom.xethub.hf.co"
-
-    # Mock headers for the refreshed response
-    mock_response = MagicMock()
-    mock_response.headers = {
-        "X-Xet-Cas-Url": "https://custom.xethub.hf.co",
-        "X-Xet-Access-Token": "new_token",
-        "X-Xet-Token-Expiration": "1234599999",
-    }
-
-    http_backoff_mock = mocker.patch("huggingface_hub.utils._xet.http_backoff", return_value=mock_response)
-
-    headers = {"user-agent": "user-agent-example"}
-    refresh_xet_connection_info(
-        file_data=XetFileData(
-            refresh_route=f"{custom_endpoint}/api/models/username/repo_name/xet-read-token/token",
-            file_hash="sha256:abcdef",
-        ),
-        headers=headers,
-    )
-
-    # Verify the request used the custom endpoint
-    expected_url = f"{custom_endpoint}/api/models/username/repo_name/xet-read-token/token"
-    http_backoff_mock.assert_called_once_with(
-        "GET",
-        expected_url,
-        headers=headers,
-        params=None,
-    )
-
-
-def test_refresh_metadata_missing_refresh_route() -> None:
-    # Create metadata without refresh_route
-    headers = {"user-agent": "user-agent-example"}
-
-    # Verify it raises ValueError
-    with pytest.raises(ValueError, match="The provided xet metadata does not contain a refresh endpoint."):
-        refresh_xet_connection_info(
-            file_data=XetFileData(
-                refresh_route=None,
-                file_hash="sha256:abcdef",
-            ),
-            headers=headers,
-        )
-
-
-def test_fetch_xet_metadata_with_url(mocker) -> None:
-    mock_response = MagicMock()
-    mock_response.headers = {
-        "X-Xet-Cas-Url": "https://example.xethub.hf.co",
-        "X-Xet-Access-Token": "xet_token123",
-        "X-Xet-Token-Expiration": "1234567890",
-    }
-
-    # Mock the session.get method
-    http_backoff_mock = mocker.patch("huggingface_hub.utils._xet.http_backoff", return_value=mock_response)
-
-    # Call the function
-    url = "https://example.xethub.hf.co/api/models/username/repo_name/xet-read-token/token"
-    headers = {"user-agent": "user-agent-example"}
-    metadata = _fetch_xet_connection_info_with_url(url=url, headers=headers)
-
-    # Verify the request
-    http_backoff_mock.assert_called_once_with(
-        "GET",
-        url,
-        headers=headers,
-        params=None,
-    )
-
-    # Verify returned metadata
-    assert metadata.endpoint == "https://example.xethub.hf.co"
-    assert metadata.access_token == "xet_token123"
-    assert metadata.expiration_unix_epoch == 1234567890
-
-
-def test_fetch_xet_metadata_with_url_invalid_response(mocker) -> None:
-    mock_response = MagicMock()
-    mock_response.headers = {"Content-Type": "application/json"}  # No XET headers
-
-    # Mock the session.get method
-    mocker.patch("huggingface_hub.utils._xet.http_backoff", return_value=mock_response)
-
-    url = "https://example.xethub.hf.co/api/models/username/repo_name/xet-read-token/token"
-    headers = {"user-agent": "user-agent-example"}
-
-    with pytest.raises(ValueError, match="Xet headers have not been correctly set by the server."):
-        _fetch_xet_connection_info_with_url(url=url, headers=headers)
 
 
 def test_env_var_hf_hub_disable_xet() -> None:
@@ -299,57 +105,6 @@ def test_env_var_hf_hub_disable_xet() -> None:
     monkeypatch.setattr("huggingface_hub.constants.HF_HUB_DISABLE_XET", True)
 
     assert not is_xet_available()
-
-
-def test_xet_token_reset_after_repo_deletion() -> None:
-    """Test Xet token is reset after repo deletion.
-
-    Regression test for https://github.com/huggingface/huggingface_hub/issues/3829
-    """
-    # Create a repo
-    api = HfApi(endpoint=ENDPOINT_STAGING, token=TOKEN)
-    repo_id = api.create_repo(repo_id=repo_name()).repo_id
-
-    # Get XET token
-    xet_info_read = fetch_xet_connection_info_from_repo_info(
-        token_type=XetTokenType.READ,
-        repo_id=repo_id,
-        repo_type="model",
-        revision="main",
-        headers=api._build_hf_headers(),
-    )
-
-    xet_info_write = fetch_xet_connection_info_from_repo_info(
-        token_type=XetTokenType.WRITE,
-        repo_id=repo_id,
-        repo_type="model",
-        revision="main",
-        headers=api._build_hf_headers(),
-    )
-
-    # Recreate the repo
-    api.delete_repo(repo_id=repo_id)
-    api.create_repo(repo_id)
-
-    # Get XET token for the new repo (same repo ID, same revision)
-    xet_info_read_new = fetch_xet_connection_info_from_repo_info(
-        token_type=XetTokenType.READ,
-        repo_id=repo_id,
-        repo_type="model",
-        revision="main",
-        headers=api._build_hf_headers(),
-    )
-    xet_info_write_new = fetch_xet_connection_info_from_repo_info(
-        token_type=XetTokenType.WRITE,
-        repo_id=repo_id,
-        repo_type="model",
-        revision="main",
-        headers=api._build_hf_headers(),
-    )
-
-    # XET token must have changed (reset after repo deletion)
-    assert xet_info_read.access_token != xet_info_read_new.access_token
-    assert xet_info_write.access_token != xet_info_write_new.access_token
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
I realized that since the `XetSession` integration (#4116 cc @seanses) some legacy helpers are just dead code now.  This PR cleans them.

- Remove unused Python-side Xet connection info fetching/cache helpers.
- Drop stale tests and assertions that only covered that old path.

@seanses would you mind having a look at it to make sure I'm not breaking anything? (doesn't seem to be the case + it's internal stuff only but wanna make sure)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large deletion in Xet auth plumbing; behavior should be unchanged if all transfers already use hf_xet token refresh, but any external code importing the removed helpers will break.
> 
> **Overview**
> Removes the legacy Python path for fetching and caching Xet CAS connection tokens (`XetConnectionInfo`, header parsing, `http_backoff` fetches, and the in-memory cache). **Upload/download now rely on `hf_xet`**, which refreshes tokens via `token_refresh_url` / per-file `refresh_route` from `XetFileData`.
> 
> **Public surface:** `huggingface_hub.utils` no longer exports `XetConnectionInfo`, `refresh_xet_connection_info`, or `fetch_xet_connection_info_from_repo_info`. **`xet_connection_info_refresh_url`** and file-metadata parsing stay.
> 
> **API cleanup:** `delete_repo` and `delete_bucket` no longer call `reset_xet_connection_info_cache_for_repo` because that cache is gone.
> 
> Tests drop coverage of the removed helpers (including the old pointer-file backward-compat download path and the post-delete token cache regression) and assert **`refresh_route`** on metadata instead of resolving full connection info.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17850927eb95b63517d57994b23276e8a03a60dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->