### PR TITLE
Make doc builds faster

### DIFF
--- a/.github/workflows/build_documentation.yaml
+++ b/.github/workflows/build_documentation.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
    build:
-    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@bcff59fca682130d2e7271ca8589911b7ac0b8bf  # main
+    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@e60a538eea9817ab312196d0d233604b01697265  # main (light installs, no custom container)
     with:
       commit_sha: ${{ github.sha }}
       package: huggingface_hub

--- a/.github/workflows/build_pr_documentation.yaml
+++ b/.github/workflows/build_pr_documentation.yaml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@bcff59fca682130d2e7271ca8589911b7ac0b8bf  # main
+    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@e60a538eea9817ab312196d0d233604b01697265  # main (light installs, no custom container)
     with:
       commit_sha: ${{ github.event.pull_request.head.sha }}
       pr_number: ${{ github.event.number }}


### PR DESCRIPTION
Companion to the doc-builder tracker: huggingface/doc-builder#802

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow pin with no application or runtime code changes; risk is limited to doc build behavior if the new doc-builder revision regresses.
> 
> **Overview**
> Updates the **main** and **PR** documentation GitHub Actions workflows to call newer reusable workflows from `huggingface/doc-builder` (commit `e60a538…` instead of `bcff59f…`).
> 
> The pinned workflows use **lighter installs** and **no custom container**, intended to speed up doc builds. Workflow inputs (`package`, `languages`, secrets, concurrency) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63e0d56a11d891251f42219a1453ae5e57d7d9fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->