### PR TITLE
[Sandbox] Optimize parallel file transfer constants for better throughput

### DIFF
--- a/src/huggingface_hub/_sandbox.py
+++ b/src/huggingface_hub/_sandbox.py
@@ -174,9 +174,9 @@ class SandboxFiles:
     # Above this size, transfers are split into ranged requests over parallel
     # connections: a single TCP stream through the jobs proxy is limited by the
     # bandwidth-delay product (~2 MiB/s at ~100ms RTT); parallel streams scale it.
-    PARALLEL_THRESHOLD = 8 * 1024 * 1024
-    PARALLEL_CHUNK_SIZE = 4 * 1024 * 1024
-    PARALLEL_MAX_WORKERS = 8
+    PARALLEL_THRESHOLD = 2 * 1024 * 1024
+    PARALLEL_CHUNK_SIZE = 1 * 1024 * 1024
+    PARALLEL_MAX_WORKERS = 16
 
     def __init__(self, sandbox: "Sandbox") -> None:
         self._sandbox = sandbox


### PR DESCRIPTION
Optimizes the parallel transfer constants in SandboxFiles to increase aggregate throughput when reading/writing files through the sandbox proxy.

**Changes:**
- Lowered  from 8MiB to 2MiB.
- Reduced  from 4MiB to 1MiB.
- Increased  from 8 to 16.

**Rationale:**
A single TCP stream through the jobs proxy is limited by the bandwidth-delay product. By increasing the number of parallel streams (smaller chunks), we can bypass this single-stream ceiling.

**Benchmark (Local):**
- Write (10MB): 5.68 MB/s $\rightarrow$ 11.70 MB/s
- Read (10MB): 13.46 MB/s $\rightarrow$ 14.65 MB/s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance tuning of internal transfer thresholds only; no API, auth, or transfer protocol changes.
> 
> **Overview**
> **`SandboxFiles`** parallel transfer tuning only: large reads/writes through the jobs proxy use ranged HTTP requests over more, smaller chunks.
> 
> **`PARALLEL_THRESHOLD`** drops from 8 MiB to 2 MiB so parallel mode starts on smaller files. **`PARALLEL_CHUNK_SIZE`** goes from 4 MiB to 1 MiB, and **`PARALLEL_MAX_WORKERS`** from 8 to 16, increasing concurrent TCP streams to work around single-stream bandwidth-delay limits on the proxy path. Dedicated sandbox **`httpx`** connection limits already scale with **`PARALLEL_MAX_WORKERS + 2`**, so they rise with the new worker cap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6fd9bb0546591d437a72d4d831b9f5e1a1aabc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->