### PR TITLE
Keep doc-builder pin comment dependabot-compatible

### DIFF
--- a/.github/workflows/build_documentation.yaml
+++ b/.github/workflows/build_documentation.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
    build:
-    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@e60a538eea9817ab312196d0d233604b01697265  # main (light installs, no custom container)
+    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@e60a538eea9817ab312196d0d233604b01697265  # main
     with:
       commit_sha: ${{ github.sha }}
       package: huggingface_hub

--- a/.github/workflows/build_pr_documentation.yaml
+++ b/.github/workflows/build_pr_documentation.yaml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@e60a538eea9817ab312196d0d233604b01697265  # main (light installs, no custom container)
+    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@e60a538eea9817ab312196d0d233604b01697265  # main
     with:
       commit_sha: ${{ github.event.pull_request.head.sha }}
       pr_number: ${{ github.event.number }}


### PR DESCRIPTION
Follow-up to the doc-build workflow update: dependabot parses the comment after a SHA pin, so it must stay a plain ref name. See https://github.com/huggingface/peft/pull/3393#discussion_r3528292192

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only CI workflow edits with no change to pins, triggers, or build behavior.
> 
> **Overview**
> Updates the inline comments on the reusable `huggingface/doc-builder` workflow SHA pins in **build documentation** and **build PR documentation** workflows.
> 
> The comment after each pin is shortened from `# main (light installs, no custom container)` to **`# main`** so Dependabot can parse the ref name correctly. The pinned commit (`e60a538…`) and all workflow inputs are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6aba0267e24f8ab8f88cf36a05c0f153d2671ae2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->