### PR TITLE
[Download] Fall back to any cached snapshot when refs file is missing in offline mode

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1143,6 +1143,40 @@ def _hf_hub_download_to_cache_dir(
                     if not force_download:
                         return pointer_path
 
+            # refs file missing (cache built without it, or revision was always a commit hash).
+            # Scan all snapshots for any version that has the file and fall back to the most
+            # recently downloaded one so offline / local_files_only callers are not broken.
+            if commit_hash is None:
+                snapshots_dir = os.path.join(storage_folder, "snapshots")
+                if os.path.isdir(snapshots_dir):
+                    candidates = [
+                        sha
+                        for sha in os.listdir(snapshots_dir)
+                        if os.path.exists(_get_pointer_path(storage_folder, sha, relative_filename))
+                    ]
+                    if candidates:
+                        best_sha = max(
+                            candidates,
+                            key=lambda sha: os.path.getmtime(os.path.join(snapshots_dir, sha)),
+                        )
+                        pointer_path = _get_pointer_path(storage_folder, best_sha, relative_filename)
+                        logger.warning(
+                            f"Couldn't resolve refs/{revision} from cache but found the file in snapshot"
+                            f" {best_sha[:8]}. Returning that version. To silence this warning, run"
+                            " hf_hub_download once with network access so the refs file is written."
+                        )
+                        if dry_run:
+                            return DryRunFileInfo(
+                                commit_hash=best_sha,
+                                file_size=os.path.getsize(pointer_path),
+                                filename=filename,
+                                is_cached=True,
+                                local_path=pointer_path,
+                                will_download=force_download,
+                            )
+                        if not force_download:
+                            return pointer_path
+
             if isinstance(head_call_error, _DEFAULT_RETRY_ON_EXCEPTIONS) or (
                 isinstance(head_call_error, HfHubHTTPError)
                 and head_call_error.response.status_code in _DEFAULT_RETRY_ON_STATUS_CODES

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -311,6 +311,44 @@ class TestCachedDownload:
                     cache_dir=cache_dir,
                 )
 
+    def test_hf_hub_download_offline_no_refs_file_cached(self):
+        """Regression test for #4487.
+
+        When the cache contains a snapshot for a file but the refs/{revision} pointer is
+        absent (e.g. cache built against a specific commit hash, or copied without the refs
+        directory), hf_hub_download should still return the cached file in offline /
+        local_files_only mode instead of raising LocalEntryNotFoundError.
+
+        See https://github.com/huggingface/huggingface_hub/issues/4487.
+        """
+        from huggingface_hub.file_download import repo_folder_name
+
+        fake_commit_hash = "a" * 40
+        repo_id = "dummy-org/dummy-model"
+
+        with SoftTemporaryDirectory() as cache_dir:
+            # Build the cache structure manually — snapshot exists, refs/main does NOT.
+            storage_folder = os.path.join(cache_dir, repo_folder_name(repo_id=repo_id, repo_type="model"))
+            blob_path = os.path.join(storage_folder, "blobs", "fake_etag")
+            pointer_path = _get_pointer_path(storage_folder, fake_commit_hash, "config.json")
+
+            os.makedirs(os.path.dirname(blob_path), exist_ok=True)
+            os.makedirs(os.path.dirname(pointer_path), exist_ok=True)
+            Path(blob_path).write_text('{"model_type": "bert"}')
+            _create_symlink(blob_path, pointer_path, new_blob=True)
+
+            # No refs/main — simulates a cache built with revision=commit_hash or a partial copy.
+            assert not os.path.exists(os.path.join(storage_folder, "refs", "main"))
+
+            result = hf_hub_download(
+                repo_id,
+                filename="config.json",
+                local_files_only=True,
+                cache_dir=cache_dir,
+            )
+            assert result == pointer_path
+            assert os.path.isfile(result)
+
     def test_hf_hub_download_with_user_agent(self):
         """
         Check that user agent is correctly sent to the HEAD call when downloading a file.


### PR DESCRIPTION
## Summary

Fixes #4487.

When `local_files_only=True` or the network is unavailable, `hf_hub_download` tries to resolve the cached file path by reading `refs/{revision}` to get a commit hash, then looking up `snapshots/{hash}/{filename}`. If `refs/{revision}` is absent — which happens when the cache was populated with an explicit commit hash as the revision, or when a cache directory was copied/moved without the `refs/` subtree — `commit_hash` stays `None` and the whole cache lookup is silently skipped, raising `LocalEntryNotFoundError` even though the file exists inside a snapshot directory.

- Added a fallback in `_hf_hub_download_to_cache_dir`: when `commit_hash` is still `None` after the refs lookup, scan `snapshots/` for any subdirectory that contains the requested filename and return the most recently downloaded one.
- A `logger.warning` is emitted so users know the refs file is missing and how to fix it (one online download writes the file).
- Added a regression test (`test_hf_hub_download_offline_no_refs_file_cached`) that builds a minimal fake cache with the snapshot file but no `refs/main`, then asserts `hf_hub_download(..., local_files_only=True)` returns the cached path.

## Before / after

```python
import os, tempfile
from pathlib import Path
from huggingface_hub.file_download import (
    hf_hub_download, repo_folder_name, _get_pointer_path, _create_symlink
)

with tempfile.TemporaryDirectory() as cache_dir:
    sha = "a" * 40
    storage = os.path.join(cache_dir, repo_folder_name(repo_id="org/model", repo_type="model"))
    blob = os.path.join(storage, "blobs", "etag0")
    ptr  = _get_pointer_path(storage, sha, "config.json")
    os.makedirs(os.path.dirname(blob), exist_ok=True)
    os.makedirs(os.path.dirname(ptr),  exist_ok=True)
    Path(blob).write_text('{}')
    _create_symlink(blob, ptr, new_blob=True)
    # refs/main intentionally absent

    # Before: raises LocalEntryNotFoundError
    # After:  returns ptr with a warning
    result = hf_hub_download("org/model", "config.json", local_files_only=True, cache_dir=cache_dir)
    print(result)  # .../snapshots/aaaa.../config.json
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which cached revision is returned when refs are absent; users may get a non-`main` snapshot (with a warning) instead of `LocalEntryNotFoundError`.
> 
> **Overview**
> Fixes offline/`local_files_only` failures when a file exists under `snapshots/` but `refs/{revision}` is missing (e.g. cache populated with a commit hash or a partial cache copy).
> 
> **`_hf_hub_download_to_cache_dir`** now, after a failed metadata/HEAD path and no resolvable `commit_hash`, scans `snapshots/` for any commit folder that contains the requested file and returns the pointer from the **most recently modified** candidate. A **warning** explains that the refs entry is missing and suggests one online download to populate it. The same path is used for **`dry_run=True`**.
> 
> Adds regression test **`test_hf_hub_download_offline_no_refs_file_cached`** (#4487): snapshot + blob without `refs/main` must succeed with `local_files_only=True`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b730615e639dea142aab0a2e99dfed2ada779b9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->