### PR TITLE
Fix HFValidationError for existing local paths in validate_repo_id

### DIFF
--- a/src/huggingface_hub/utils/_validators.py
+++ b/src/huggingface_hub/utils/_validators.py
@@ -14,6 +14,7 @@
 """Contains utilities to validate argument values in `huggingface_hub`."""
 
 import inspect
+import os
 import re
 import warnings
 from functools import wraps
@@ -127,7 +128,11 @@ def validate_repo_id(repo_id: str | None) -> None:
     if not isinstance(repo_id, str):
         # Typically, a Path is not a repo_id
         raise HFValidationError(f"Repo id must be a string, not {type(repo_id)}: '{repo_id}'.")
-
+    
+    if os.path.isdir(repo_id) or os.path.isfile(repo_id):
+        # It's an existing local path, not a Hub repo_id — skip Hub-specific validation
+        return
+    
     if repo_id.count("/") > 1:
         raise HFValidationError(
             "Repo id must be in the form 'repo_name' or 'namespace/repo_name':"

--- a/tests/test_utils_validators.py
+++ b/tests/test_utils_validators.py
@@ -60,3 +60,7 @@ class TestRepoIdValidator:
         for repo_id in self.NOT_VALID_VALUES:
             with pytest.raises(HFValidationError):
                 validate_repo_id(repo_id)
+
+    def test_valid_repo_id_when_local_path_exists(self, tmp_path) -> None:
+        """An existing local path should not be validated as a Hub repo id."""
+        validate_repo_id(str(tmp_path))


### PR DESCRIPTION
Fixes #2004

`validate_repo_id` was rejecting valid, existing local filesystem paths
(e.g. `/Users/john/models/all-MiniLM-L6-v2`) because they contain more
than one `/`, raising a misleading HFValidationError. This adds a check:
if `repo_id` is an existing local directory or file, skip Hub-specific
repo_id validation entirely.

Added a test using pytest's `tmp_path` fixture to confirm existing local
paths pass validation without raising.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to input validation with no auth or network impact; only strings that resolve to real local paths bypass Hub rules.
> 
> **Overview**
> **`validate_repo_id`** no longer treats strings that point at an **existing local file or directory** as Hub repo IDs, so deep paths (e.g. `/Users/.../model`) stop failing the “more than one `/`” rule with a misleading `HFValidationError`.
> 
> The check runs after the type guard and **returns early** before slash-count, regex, and other Hub rules. Hub validation is unchanged for strings that are not present on the local filesystem.
> 
> A test confirms **`tmp_path`** passes validation without raising.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d02b2b8e07b1a9540f4c0453e3d3e33c8b50a3b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->