### PR TITLE
[CLI] Coerce enum member defaults to their value when building click params

### DIFF
--- a/src/huggingface_hub/cli/_framework.py
+++ b/src/huggingface_hub/cli/_framework.py
@@ -257,6 +257,8 @@ def _build_click_param(
     """Build a Click ``Parameter`` (and its post-parse value convertor) for one function param."""
     required = signature_default is inspect.Parameter.empty
     default_value = None if required else signature_default
+    if isinstance(default_value, enum.Enum):
+        default_value = default_value.value
     if info is None:
         # A bare annotation with no marker: required positional -> Argument, else Option.
         info = Argument() if required else Option()

--- a/tests/test_cli_framework.py
+++ b/tests/test_cli_framework.py
@@ -164,6 +164,20 @@ class TestInvocation:
         assert result.exit_code == 0, result.output
         assert captured == {"repo_id": "r", "color": Color.blue, "force": True, "volumes": ["a", "b"]}
 
+    def test_enum_member_default_reaches_handler(self):
+        class Mode(str, enum.Enum):
+            ON = "on"
+            AUTO = "auto"
+
+        captured = {}
+
+        def f(mode: Annotated[Mode, Option("--mode")] = Mode.AUTO):
+            captured["mode"] = mode
+
+        result = CliRunner().invoke(build_command(f, name="run"), [])
+        assert result.exit_code == 0, result.output
+        assert captured["mode"] is Mode.AUTO
+
     def test_value_callback_is_applied(self):
         seen = {}
 


### PR DESCRIPTION
Click validates a parameter default against the `Choice` values (plain strings) at invocation time, so a command declaring an enum member as its default — `mode: Annotated[Mode, Option("--mode")] = Mode.AUTO` — fails with `Invalid value ... is not one of ...` whenever the option isn't passed explicitly.

This bites any downstream CLI built with `typer_factory`: it's the second half of the `transformers` breakage under 1.22.0 (huggingface/transformers#47064, where `transformers serve` had to work around it), and follows up the discussion there.

The fix stores the member's value as the click default; the existing enum convertor already restores the member before the handler runs, so handlers keep receiving enum members either way.

One subtlety the regression test pins down: enums whose member names equal their values (like the `Color` test fixture) mask the bug, because click 8.x normalizes enum defaults by member *name* — so the test uses an enum with distinct names and values (`AUTO = "auto"`).

cc @Wauplin @hanouticelina

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change in CLI parameter building with a regression test; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes CLI commands that use a **str enum member as an option default** (e.g. `= Mode.AUTO`) failing at runtime when the flag is omitted, because Click’s `Choice` type only accepts the string values, not the enum instance.
> 
> In `_build_click_param`, enum defaults are now passed to Click as **`default_value.value`** while the existing enum convertor still maps parsed strings back to members, so handlers continue to receive enum members unchanged.
> 
> Adds **`test_enum_member_default_reaches_handler`** with an enum whose member names differ from values (`AUTO = "auto"`), since name-equals-value enums can hide the bug under Click 8.x.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4626efa8d50ec9975c24ca30c81787d4257b791. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->