### PR TITLE
[CI] Rename transformers-test-ci to transformers-ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -883,13 +883,13 @@ jobs:
             git add src/transformers/dependency_versions_table.py
 
             # The current Transformers PR CI delegates to reusable workflows from
-            # huggingface/transformers-test-ci. Copy those workflows into this test
+            # huggingface/transformers-ci. Copy those workflows into this test
             # branch so the prerelease patch applies to the actual quality install.
-            curl -fsSL https://raw.githubusercontent.com/huggingface/transformers-test-ci/main/.github/workflows/pr-ci_dynamic_caller_example.yml \
+            curl -fsSL https://raw.githubusercontent.com/huggingface/transformers-ci/main/.github/workflows/pr-ci_dynamic_caller_example.yml \
               -o .github/workflows/pr-ci_dynamic_caller_example.yml
-            curl -fsSL https://raw.githubusercontent.com/huggingface/transformers-test-ci/main/.github/workflows/pr-ci_reusable_test_job.yml \
+            curl -fsSL https://raw.githubusercontent.com/huggingface/transformers-ci/main/.github/workflows/pr-ci_reusable_test_job.yml \
               -o .github/workflows/pr-ci_reusable_test_job.yml
-            sed -i -E "s|uses: huggingface/transformers-test-ci/\.github/workflows/pr-ci_dynamic_caller_example\.yml@[^[:space:]]+.*|uses: ./.github/workflows/pr-ci_dynamic_caller_example.yml # patched for hfh prerelease|" .github/workflows/pr-ci-caller.yml
+            sed -i -E "s|uses: huggingface/transformers-ci/\.github/workflows/pr-ci_dynamic_caller_example\.yml@[^[:space:]]+.*|uses: ./.github/workflows/pr-ci_dynamic_caller_example.yml # patched for hfh prerelease|" .github/workflows/pr-ci-caller.yml
             git add .github/workflows/pr-ci-caller.yml .github/workflows/pr-ci_dynamic_caller_example.yml .github/workflows/pr-ci_reusable_test_job.yml
           fi
 


### PR DESCRIPTION
## Summary

Follow-up to #4481: the repo was renamed from `huggingface/transformers-test-ci` to `huggingface/transformers-ci`.

- Update the 2 `curl` URLs that fetch reusable workflow files from that repo
- Update the `sed` pattern that rewires `pr-ci-caller.yml` to point to the local copies

## Test plan
- [ ] Verify the next Transformers RC release run successfully fetches workflows from `huggingface/transformers-ci`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-only CI URL/path updates with no runtime library or auth changes; risk is limited to the next Transformers RC run failing if the renamed repo paths differ.
> 
> **Overview**
> Updates the **release** workflow’s Transformers downstream RC test step to use the renamed repo **`huggingface/transformers-ci`** (was `transformers-test-ci`).
> 
> When a prerelease pushes a test branch to Transformers, the job still vendors reusable PR CI workflows and rewires `pr-ci-caller.yml` to local copies; only the **raw GitHub URLs** for the two workflow files and the **`sed` pattern** on the external `uses:` reference are updated to the new org/repo name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3dea7cb478e09debd5cfb3a1ec65b93dd44d15b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->