### PR TITLE
[CLI] Add `hf extensions update` command

### DIFF
--- a/docs/source/en/guides/cli-extensions.md
+++ b/docs/source/en/guides/cli-extensions.md
@@ -217,6 +217,9 @@ During development, you can install your extension directly from your GitHub rep
 # Reinstall after making changes (push to GitHub first)
 >>> hf extensions install <your-username>/hf-<name> --force
 
+# Update to the latest version (only if a newer commit is available)
+>>> hf extensions update <name>
+
 # List installed extensions
 >>> hf extensions list
 
@@ -226,6 +229,22 @@ During development, you can install your extension directly from your GitHub rep
 
 > [!TIP]
 > Use `--force` to overwrite a previously installed version when testing updates.
+
+## Update installed extensions
+
+Once an extension is installed, you can update it to the latest version published on GitHub:
+
+```bash
+# Update a single extension (accepts `<name>`, `hf-<name>` or `OWNER/hf-<name>`)
+>>> hf extensions update hf-claude
+
+# Check every installed extension and update the outdated ones
+>>> hf extensions update
+```
+
+`hf extensions update` only updates extensions that are **already installed**. If the extension is not
+installed, an error is raised with the exact command to install it (extensions are never installed
+implicitly by `update`). Extensions already on the latest commit are skipped.
 
 ## Naming rules
 

--- a/docs/source/en/guides/cli-extensions.md
+++ b/docs/source/en/guides/cli-extensions.md
@@ -242,9 +242,7 @@ Once an extension is installed, you can update it to the latest version publishe
 >>> hf extensions update
 ```
 
-`hf extensions update` only updates extensions that are **already installed**. If the extension is not
-installed, an error is raised with the exact command to install it (extensions are never installed
-implicitly by `update`). Extensions already on the latest commit are skipped.
+`hf extensions update` only updates extensions that are already installed. If the extension is not installed, an error is raised. Extensions already up to date are skipped.
 
 ## Naming rules
 

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -2012,6 +2012,7 @@ $ hf extensions [OPTIONS] COMMAND [ARGS]...
 * `list`: List installed extension commands. [alias: ls]
 * `remove`: Remove an installed extension. [alias: rm]
 * `search`: Search extensions available on GitHub...
+* `update`: Update installed extension(s) to their...
 
 ### `hf extensions exec`
 
@@ -2136,6 +2137,37 @@ $ hf extensions search [OPTIONS]
 
 Examples
   $ hf extensions search
+
+Learn more
+  Use `hf <command> --help` for more information about a command.
+  Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
+
+
+### `hf extensions update`
+
+Update installed extension(s) to their latest version.
+
+Only extensions that are already installed are updated. An extension that is not installed
+is never installed implicitly, an error is raised instead.
+
+**Usage**:
+
+```console
+$ hf extensions update [OPTIONS] [NAME]
+```
+
+**Arguments**:
+
+* `[NAME]`: Extension to update (with or without `hf-` prefix, optionally as `OWNER/hf-<name>`). If omitted, all installed extensions are checked and the outdated ones are updated.
+
+**Options**:
+
+* `--help`: Show this message and exit.
+
+Examples
+  $ hf extensions update
+  $ hf extensions update hf-claude
+  $ hf extensions update alvarobartt/hf-mem
 
 Learn more
   Use `hf <command> --help` for more information about a command.

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -2147,9 +2147,6 @@ Learn more
 
 Update installed extension(s) to their latest version.
 
-Only extensions that are already installed are updated. An extension that is not installed
-is never installed implicitly, an error is raised instead.
-
 **Usage**:
 
 ```console

--- a/src/huggingface_hub/cli/extensions.py
+++ b/src/huggingface_hub/cli/extensions.py
@@ -64,11 +64,9 @@ class ExtensionManifest:
     repo: str
     repo_id: str
     short_name: str
-    executable_name: str
     executable_path: str
     type: Literal["binary", "python"]
     installed_at: datetime
-    source: str
     description: str | None = None
     commit_sha: str | None = None
 
@@ -78,6 +76,8 @@ class ExtensionManifest:
         if not manifest_path.is_file():
             raise CLIError(f"Manifest file not found at {manifest_path}. Your extension may be corrupted.")
         data = json.loads(manifest_path.read_text())
+        # Ignore keys not in the dataclass (e.g. fields dropped since the manifest was written).
+        data = {key: value for key, value in data.items() if key in cls.__dataclass_fields__}
         data["installed_at"] = datetime.fromisoformat(data["installed_at"])
         return ExtensionManifest(**data)
 
@@ -118,10 +118,16 @@ def extension_install(
             f"Cannot install extension '{short_name}' because it conflicts with an existing `hf {short_name}` command."
         )
 
-    if _get_extension_dir(short_name).exists() and not force:
-        raise CLIError(f"Extension '{short_name}' is already installed. Use --force to overwrite.")
+    extension_dir = _get_extension_dir(short_name)
+    if extension_dir.exists():
+        if not force:
+            raise CLIError(f"Extension '{short_name}' is already installed. Use --force to overwrite.")
+        shutil.rmtree(extension_dir)
 
-    manifest = _clean_install_extension(owner=owner, repo_name=repo_name, short_name=short_name)
+    branch, description = _fetch_github_repo_info(owner=owner, repo_name=repo_name)
+    manifest = _install_extension(
+        owner=owner, repo_name=repo_name, short_name=short_name, branch=branch, description=description
+    )
     ext_type = manifest.type.capitalize()
     out.result(
         f"{ext_type} extension installed",
@@ -243,8 +249,7 @@ def extension_search() -> None:
 
     rows = []
     for repo in data.get("items", []):
-        repo_name = repo["name"]
-        short_name = repo_name[3:] if repo_name.startswith("hf-") else repo_name
+        short_name = repo["name"].removeprefix("hf-")
         rows.append(
             {
                 "name": short_name,
@@ -316,11 +321,12 @@ def dispatch_unknown_top_level_extension(args: list[str], known_commands: set[st
     if command_name in all_known:
         return None
 
-    short_name = command_name[3:] if command_name.startswith("hf-") else command_name
-    if not short_name:
+    try:
+        short_name = _validate_extension_short_name(command_name.removeprefix("hf-"), original_input=command_name)
+    except CLIError:
         return None
 
-    executable_path: Path | None = None
+    executable_path: Path | None
     try:
         executable_path = _resolve_installed_executable_path(short_name)
     except Exception:
@@ -335,15 +341,11 @@ def dispatch_unknown_top_level_extension(args: list[str], known_commands: set[st
 def _auto_install_official_extension(short_name: str) -> Path | None:
     """Try to auto-install huggingface/hf-<name>. Returns executable path or None."""
     owner, repo_name = DEFAULT_EXTENSION_OWNER, f"hf-{short_name}"
-    try:
-        extension_dir = _get_extension_dir(short_name)
-    except Exception:
-        return None
-    if extension_dir.exists():
+    if _get_extension_dir(short_name).exists():
         return None
 
     try:
-        repo_info = _fetch_github_repo_info(owner=owner, repo_name=repo_name)
+        branch, description = _fetch_github_repo_info(owner=owner, repo_name=repo_name)
     except Exception:
         return None
 
@@ -352,18 +354,11 @@ def _auto_install_official_extension(short_name: str) -> Path | None:
     except ConfirmationError:
         return None
     try:
-        branch, description = repo_info
-        manifest = _install_extension_from_github(
-            owner=owner,
-            repo_name=repo_name,
-            short_name=short_name,
-            extension_dir=extension_dir,
-            branch=branch,
-            description=description,
+        manifest = _install_extension(
+            owner=owner, repo_name=repo_name, short_name=short_name, branch=branch, description=description
         )
         return Path(manifest.executable_path).expanduser()
     except Exception:
-        shutil.rmtree(extension_dir, ignore_errors=True)
         return None
 
 
@@ -397,7 +392,7 @@ def _update_installed_extension(manifest: ExtensionManifest) -> _ExtensionUpdate
     if latest_sha == manifest.commit_sha:
         return _ExtensionUpdateStatus.UP_TO_DATE
 
-    _clean_install_extension(
+    _install_extension(
         owner=owner,
         repo_name=repo_name,
         short_name=short_name,
@@ -408,33 +403,71 @@ def _update_installed_extension(manifest: ExtensionManifest) -> _ExtensionUpdate
     return _ExtensionUpdateStatus.UPDATED
 
 
-def _clean_install_extension(
+def _install_extension(
     *,
     owner: str,
     repo_name: str,
     short_name: str,
-    branch: str | None = None,
+    branch: str,
     description: str | None = None,
     commit_sha: str | None = None,
 ) -> ExtensionManifest:
-    """Fetch, install (binary or Python), and persist an extension, overwriting any existing install.
+    """Fetch and install an extension (binary or Python package), then persist its manifest.
 
-    Used by `hf extensions install` (fresh install and `--force` reinstall) and `hf extensions update`.
+    Installs in place: an existing install is overwritten without being removed first, so a failed
+    update keeps the previous version working. A failed fresh install is cleaned up entirely.
     """
     extension_dir = _get_extension_dir(short_name)
-    if extension_dir.exists():
-        shutil.rmtree(extension_dir)
-    if branch is None:
-        branch, description = _fetch_github_repo_info(owner=owner, repo_name=repo_name)
-    return _install_extension_from_github(
-        owner=owner,
-        repo_name=repo_name,
-        short_name=short_name,
-        extension_dir=extension_dir,
-        branch=branch,
-        description=description,
-        commit_sha=commit_sha,
-    )
+    fresh_install = not extension_dir.exists()
+    installed = False
+    try:
+        try:
+            binary = _fetch_remote_binary(owner=owner, repo_name=repo_name, branch=branch, short_name=short_name)
+        except Exception:
+            binary = None
+
+        if binary is not None:
+            executable_path = _install_binary_extension(
+                extension_dir=extension_dir, short_name=short_name, binary=binary
+            )
+        else:
+            executable_path = _install_python_extension(
+                extension_dir=extension_dir, owner=owner, repo_name=repo_name, short_name=short_name, branch=branch
+            )
+
+        manifest = ExtensionManifest(
+            owner=owner,
+            repo=repo_name,
+            repo_id=f"{owner}/{repo_name}",
+            short_name=short_name,
+            executable_path=str(executable_path),
+            type="binary" if binary is not None else "python",
+            installed_at=datetime.now(timezone.utc),
+            description=_try_fetch_remote_description(
+                owner=owner, repo_name=repo_name, branch=branch, candidate_description=description
+            ),
+            commit_sha=commit_sha or _fetch_latest_commit_sha(owner=owner, repo_name=repo_name, branch=branch),
+        )
+        manifest.save(extension_dir)
+        installed = True
+        return manifest
+    except CLIError:
+        raise
+    except subprocess.TimeoutExpired as e:
+        raise CLIExtensionInstallError(
+            f"Pip install timed out after {_EXTENSIONS_PIP_INSTALL_TIMEOUT}s for '{owner}/{repo_name}'. "
+            "See pip output above for details."
+        ) from e
+    except subprocess.CalledProcessError as e:
+        raise CLIExtensionInstallError(
+            f"Failed to install pip package from '{owner}/{repo_name}' (exit code {e.returncode}). "
+            "See pip output above for details."
+        ) from e
+    except Exception as e:
+        raise CLIExtensionInstallError(f"Failed to install extension from '{owner}/{repo_name}': {e}") from e
+    finally:
+        if not installed and fresh_install:
+            shutil.rmtree(extension_dir, ignore_errors=True)
 
 
 def _fetch_latest_commit_sha(*, owner: str, repo_name: str, branch: str, warn: bool = True) -> str | None:
@@ -451,155 +484,68 @@ def _fetch_latest_commit_sha(*, owner: str, repo_name: str, branch: str, warn: b
         return None
 
 
-def _install_extension_from_github(
-    *,
-    owner: str,
-    repo_name: str,
-    short_name: str,
-    extension_dir: Path,
-    branch: str,
-    description: str | None = None,
-    commit_sha: str | None = None,
-) -> ExtensionManifest:
-    """Fetch, install (binary or Python), and save manifest for a GitHub extension."""
-    try:
-        binary = _fetch_remote_binary(owner=owner, repo_name=repo_name, branch=branch, short_name=short_name)
-    except Exception:
-        binary = None
-    if binary is not None:
-        manifest = _install_binary_extension(
-            owner=owner, repo_name=repo_name, short_name=short_name, extension_dir=extension_dir, binary=binary
-        )
-    else:
-        manifest = _install_python_extension(
-            owner=owner, repo_name=repo_name, short_name=short_name, extension_dir=extension_dir, branch=branch
-        )
-    manifest.description = _try_fetch_remote_description(
-        owner=owner, repo_name=repo_name, branch=branch, candidate_description=description
-    )
-    manifest.commit_sha = commit_sha or _fetch_latest_commit_sha(owner=owner, repo_name=repo_name, branch=branch)
-    manifest.save(extension_dir)
-    return manifest
-
-
-def _fetch_remote_binary(owner: str, repo_name: str, branch: str, short_name: str) -> bytes:
+def _fetch_remote_binary(*, owner: str, repo_name: str, branch: str, short_name: str) -> bytes:
     executable_name = _get_executable_name(short_name)
     raw_url = f"https://raw.githubusercontent.com/{owner}/{repo_name}/refs/heads/{branch}/{executable_name}"
     response = _github_get(raw_url)
     return response.content
 
 
-def _install_binary_extension(
-    *, owner: str, repo_name: str, short_name: str, extension_dir: Path, binary: bytes
-) -> ExtensionManifest:
-    # Save extension binary
-    executable_name = _get_executable_name(short_name)
-    extension_dir.mkdir(parents=True, exist_ok=False)
-    executable_path = extension_dir / executable_name
+def _install_binary_extension(*, extension_dir: Path, short_name: str, binary: bytes) -> Path:
+    extension_dir.mkdir(parents=True, exist_ok=True)
+    executable_path = extension_dir / _get_executable_name(short_name)
     executable_path.write_bytes(binary)
 
-    # Make it executable
     if os.name != "nt":
         os.chmod(executable_path, 0o755)
 
-    # Create manifest
-    return ExtensionManifest(
-        owner=owner,
-        repo=repo_name,
-        repo_id=f"{owner}/{repo_name}",
-        short_name=short_name,
-        executable_name=executable_name,
-        executable_path=str(executable_path),
-        type="binary",
-        installed_at=datetime.now(timezone.utc),
-        source=f"https://github.com/{owner}/{repo_name}",
-    )
+    return executable_path
 
 
 def _install_python_extension(
-    *, owner: str, repo_name: str, short_name: str, extension_dir: Path, branch: str
-) -> ExtensionManifest:
+    *, extension_dir: Path, owner: str, repo_name: str, short_name: str, branch: str
+) -> Path:
     source_url = f"https://github.com/{owner}/{repo_name}/archive/refs/heads/{branch}.zip"
     venv_dir = extension_dir / "venv"
-    installed = False
+    venv_python = _get_venv_bin_path(venv_dir, "python.exe" if os.name == "nt" else "python")
+    uv_path = shutil.which("uv")
 
     status = out.status()
-    try:
+    if not venv_python.is_file():
         status.update(f"Creating virtual environment in {venv_dir}")
-        if extension_dir.exists():
-            shutil.rmtree(extension_dir, ignore_errors=True)
-        extension_dir.mkdir(parents=True, exist_ok=False)
-
-        uv_path = shutil.which("uv")
-        venv_python = _get_venv_python_path(venv_dir)
+        extension_dir.mkdir(parents=True, exist_ok=True)
         if uv_path:
             subprocess.run([uv_path, "venv", str(venv_dir)], check=True)
-            status.done(f"Virtual environment created in {venv_dir}")
-
-            status.update(f"Installing package from {source_url}")
-            subprocess.run(
-                [uv_path, "pip", "install", "--python", str(venv_python), source_url],
-                check=True,
-                timeout=_EXTENSIONS_PIP_INSTALL_TIMEOUT,
-            )
         else:
             venv.EnvBuilder(with_pip=True).create(str(venv_dir))
-            status.done(f"Virtual environment created in {venv_dir}")
+        status.done(f"Virtual environment created in {venv_dir}")
 
-            status.update(f"Installing package from {source_url}")
-            subprocess.run(
-                [
-                    str(venv_python),
-                    "-m",
-                    "pip",
-                    "install",
-                    "--disable-pip-version-check",
-                    "--no-input",
-                    source_url,
-                ],
-                check=True,
-                timeout=_EXTENSIONS_PIP_INSTALL_TIMEOUT,
-            )
-        status.done(f"Package installed from {source_url}")
+    status.update(f"Installing package from {source_url}")
+    if uv_path:
+        # --reinstall: the source URL is the same for every commit, so cached data must be refreshed.
+        install_cmd = [uv_path, "pip", "install", "--reinstall", "--python", str(venv_python), source_url]
+    else:
+        install_cmd = [
+            str(venv_python),
+            "-m",
+            "pip",
+            "install",
+            "--disable-pip-version-check",
+            "--no-input",
+            "--force-reinstall",
+            source_url,
+        ]
+    subprocess.run(install_cmd, check=True, timeout=_EXTENSIONS_PIP_INSTALL_TIMEOUT)
+    status.done(f"Package installed from {source_url}")
 
-        executable_name = _get_executable_name(short_name)
-        venv_executable = _get_venv_extension_executable_path(venv_dir, short_name)
-        if not venv_executable.is_file():
-            raise CLIError(
-                f"Installed package from '{owner}/{repo_name}' does not expose the required console script "
-                f"'{executable_name}'."
-            )
-
-        manifest = ExtensionManifest(
-            owner=owner,
-            repo=repo_name,
-            repo_id=f"{owner}/{repo_name}",
-            short_name=short_name,
-            executable_name=executable_name,
-            executable_path=str(venv_executable.resolve()),
-            type="python",
-            installed_at=datetime.now(timezone.utc),
-            source=f"https://github.com/{owner}/{repo_name}",
+    executable_name = _get_executable_name(short_name)
+    venv_executable = _get_venv_bin_path(venv_dir, executable_name)
+    if not venv_executable.is_file():
+        raise CLIError(
+            f"Installed package from '{owner}/{repo_name}' does not expose the required console script "
+            f"'{executable_name}'."
         )
-        installed = True
-        return manifest
-    except CLIError:
-        raise
-    except subprocess.TimeoutExpired as e:
-        raise CLIExtensionInstallError(
-            f"Pip install timed out after {_EXTENSIONS_PIP_INSTALL_TIMEOUT}s for '{owner}/{repo_name}'. "
-            "See pip output above for details."
-        ) from e
-    except subprocess.CalledProcessError as e:
-        raise CLIExtensionInstallError(
-            f"Failed to install pip package from '{owner}/{repo_name}' (exit code {e.returncode}). "
-            "See pip output above for details."
-        ) from e
-    except Exception as e:
-        raise CLIExtensionInstallError(f"Failed to set up pip extension from '{owner}/{repo_name}': {e}") from e
-    finally:
-        if not installed:
-            shutil.rmtree(extension_dir, ignore_errors=True)
+    return venv_executable.resolve()
 
 
 def _try_fetch_remote_description(
@@ -639,19 +585,11 @@ def _try_fetch_remote_description(
     return candidate_description
 
 
-def _get_extensions_root() -> Path:
-    root_dir = EXTENSIONS_ROOT.expanduser()
-    root_dir.mkdir(parents=True, exist_ok=True)
-    return root_dir
-
-
 def _get_extension_dir(short_name: str) -> Path:
-    safe_name = _validate_extension_short_name(short_name, original_input=short_name)
-    root = _get_extensions_root().resolve()
-    target = (root / f"hf-{safe_name}").resolve()
-    if root not in target.parents:
-        raise CLIError(f"Invalid extension name '{short_name}'.")
-    return target
+    # Callers validate at the parse boundary already; re-validate here as defense-in-depth since
+    # this path is rmtree'd on removal.
+    _validate_extension_short_name(short_name, original_input=short_name)
+    return EXTENSIONS_ROOT.expanduser() / f"hf-{short_name}"
 
 
 def _github_get(url: str, *, params: dict | None = None, headers: dict | None = None):
@@ -690,14 +628,7 @@ def _resolve_installed_executable_path(short_name: str) -> Path:
     return Path(manifest.executable_path).expanduser()
 
 
-def _get_venv_python_path(venv_dir: Path) -> Path:
-    if os.name == "nt":
-        return venv_dir / "Scripts" / "python.exe"
-    return venv_dir / "bin" / "python"
-
-
-def _get_venv_extension_executable_path(venv_dir: Path, short_name: str) -> Path:
-    executable_name = _get_executable_name(short_name)
+def _get_venv_bin_path(venv_dir: Path, executable_name: str) -> Path:
     if os.name == "nt":
         return venv_dir / "Scripts" / executable_name
     return venv_dir / "bin" / executable_name
@@ -737,7 +668,7 @@ def _normalize_repo_id(repo_id: str) -> tuple[str, str, str]:
     if not repo_name.startswith("hf-"):
         raise CLIError(f"Extension repository name must start with 'hf-', got '{repo_name}'.")
 
-    short_name = repo_name[3:]
+    short_name = repo_name.removeprefix("hf-")
     if not short_name:
         raise CLIError("Invalid extension repository name 'hf-'.")
     _validate_extension_short_name(short_name, original_input=repo_id)
@@ -747,8 +678,7 @@ def _normalize_repo_id(repo_id: str) -> tuple[str, str, str]:
 
 def _normalize_extension_name(name: str) -> str:
     repo_name = name.strip().rsplit("/", 1)[-1]
-    normalized = repo_name[3:] if repo_name.startswith("hf-") else repo_name
-    return _validate_extension_short_name(normalized, original_input=name)
+    return _validate_extension_short_name(repo_name.removeprefix("hf-"), original_input=name)
 
 
 def _execute_extension_binary(executable_path: Path, args: list[str]) -> int:

--- a/src/huggingface_hub/cli/extensions.py
+++ b/src/huggingface_hub/cli/extensions.py
@@ -64,6 +64,7 @@ class ExtensionManifest:
     installed_at: datetime
     source: str
     description: str | None = None
+    commit_sha: str | None = None
 
     @classmethod
     def load(cls, path: Path) -> "ExtensionManifest":
@@ -136,6 +137,67 @@ def extension_install(
         command=f"hf {short_name}",
     )
     out.hint(f"Run it with: hf {short_name}")
+
+
+@extensions_cli.command(
+    "update",
+    examples=[
+        "hf extensions update",
+        "hf extensions update hf-claude",
+        "hf extensions update alvarobartt/hf-mem",
+    ],
+)
+def extension_update(
+    name: Annotated[
+        str | None,
+        Argument(
+            help=(
+                "Extension to update (with or without `hf-` prefix, optionally as `OWNER/hf-<name>`). "
+                "If omitted, all installed extensions are checked and the outdated ones are updated."
+            ),
+        ),
+    ] = None,
+) -> None:
+    """Update installed extension(s) to their latest version.
+
+    Only extensions that are already installed are updated. An extension that is not installed
+    is never installed implicitly, an error is raised instead.
+    """
+    if name is not None:
+        short_name = _parse_update_target(name)
+        extension_dir = _get_extension_dir(short_name)
+        if not extension_dir.is_dir():
+            install_target = name if "/" in name else f"hf-{short_name}"
+            raise CLIError(
+                f"Extension '{short_name}' is not installed. Install it first with: "
+                f"hf extensions install {install_target}"
+            )
+        manifest = ExtensionManifest.load(extension_dir)
+        if _update_extension(manifest):
+            out.result("Extension updated", name=short_name, source=manifest.repo_id)
+        else:
+            out.result(f"Extension '{short_name}' is already up to date", name=short_name)
+        return
+
+    manifests = _list_installed_extensions()
+    if not manifests:
+        out.warning("No extensions installed.")
+        out.hint("Install one with: hf extensions install <repo_id>")
+        return
+
+    updated = []
+    up_to_date = []
+    for manifest in manifests:
+        out.log(f"Checking '{manifest.short_name}' ({manifest.repo_id})...")
+        if _update_extension(manifest):
+            updated.append(manifest.short_name)
+        else:
+            up_to_date.append(manifest.short_name)
+    out.result(
+        "Extensions update complete",
+        updated=", ".join(updated) if updated else None,
+        up_to_date=", ".join(up_to_date) if up_to_date else None,
+    )
 
 
 @extensions_cli.command(
@@ -320,6 +382,46 @@ def _auto_install_official_extension(short_name: str) -> Path | None:
         return None
 
 
+def _update_extension(manifest: ExtensionManifest) -> bool:
+    """Reinstall an installed extension if a newer version is available on GitHub.
+
+    Returns True if the extension was updated, False if it was already up to date.
+    """
+    owner, repo_name, short_name = manifest.owner, manifest.repo, manifest.short_name
+    branch, description = _resolve_github_repo_info(owner=owner, repo_name=repo_name)
+
+    latest_sha = _fetch_latest_commit_sha(owner=owner, repo_name=repo_name, branch=branch)
+    if latest_sha is not None and latest_sha == manifest.commit_sha:
+        return False
+
+    extension_dir = _get_extension_dir(short_name)
+    shutil.rmtree(extension_dir, ignore_errors=True)
+    _install_extension_from_github(
+        owner=owner,
+        repo_name=repo_name,
+        short_name=short_name,
+        extension_dir=extension_dir,
+        branch=branch,
+        description=description,
+    )
+    return True
+
+
+def _fetch_latest_commit_sha(*, owner: str, repo_name: str, branch: str) -> str | None:
+    """Best-effort fetch of the latest commit SHA for a branch, used to detect available updates."""
+    try:
+        response = get_session().get(
+            f"https://api.github.com/repos/{owner}/{repo_name}/commits/{branch}",
+            headers={"Accept": "application/vnd.github.sha"},
+            follow_redirects=True,
+            timeout=_EXTENSIONS_DOWNLOAD_TIMEOUT,
+        )
+        response.raise_for_status()
+        return response.text.strip() or None
+    except Exception:
+        return None
+
+
 def _install_extension_from_github(
     *,
     owner: str,
@@ -345,6 +447,7 @@ def _install_extension_from_github(
     manifest.description = _try_fetch_remote_description(
         owner=owner, repo_name=repo_name, branch=branch, candidate_description=description
     )
+    manifest.commit_sha = _fetch_latest_commit_sha(owner=owner, repo_name=repo_name, branch=branch)
     manifest.save(extension_dir)
     return manifest
 
@@ -609,6 +712,20 @@ def _normalize_repo_id(repo_id: str) -> tuple[str, str, str]:
     _validate_extension_short_name(short_name, original_input=repo_id)
 
     return owner, repo_name, short_name
+
+
+def _parse_update_target(name: str) -> str:
+    """Return the short name from an update target given as `<name>`, `hf-<name>`, or `[OWNER/]hf-<name>`.
+
+    Updates operate on already-installed extensions (identified by their short name), so the optional
+    owner prefix is accepted but ignored, both `alvarobartt/hf-mem` and `hf-mem` resolve to `mem`.
+    """
+    candidate = name.strip()
+    if not candidate:
+        raise CLIError("Extension name cannot be empty.")
+    repo_name = candidate.rsplit("/", 1)[-1]
+    normalized = repo_name[3:] if repo_name.startswith("hf-") else repo_name
+    return _validate_extension_short_name(normalized, original_input=name)
 
 
 def _normalize_extension_name(name: str) -> str:

--- a/src/huggingface_hub/cli/extensions.py
+++ b/src/huggingface_hub/cli/extensions.py
@@ -148,6 +148,7 @@ def extension_install(
     ],
 )
 def extension_update(
+    ctx: click.Context,
     name: Annotated[
         str | None,
         Argument(
@@ -173,10 +174,14 @@ def extension_update(
                 f"hf extensions install {install_target}"
             )
         manifest = ExtensionManifest.load(extension_dir)
-        if _update_extension(manifest):
-            out.result("Extension updated", name=short_name, source=manifest.repo_id)
-        else:
-            out.result(f"Extension '{short_name}' is already up to date", name=short_name)
+        match _check_extension_update(manifest):
+            case None:
+                pass  # warning already emitted by _check_extension_update
+            case True:
+                ctx.invoke(extension_install, repo_id=manifest.repo_id, force=True)
+                out.result("Extension updated", name=short_name, source=manifest.repo_id)
+            case False:
+                out.result(f"Extension '{short_name}' is already up to date", name=short_name)
         return
 
     manifests = _list_installed_extensions()
@@ -189,10 +194,14 @@ def extension_update(
     up_to_date = []
     for manifest in manifests:
         out.log(f"Checking '{manifest.short_name}' ({manifest.repo_id})...")
-        if _update_extension(manifest):
-            updated.append(manifest.short_name)
-        else:
-            up_to_date.append(manifest.short_name)
+        match _check_extension_update(manifest):
+            case None:
+                pass  # warning already emitted by _check_extension_update
+            case True:
+                ctx.invoke(extension_install, repo_id=manifest.repo_id, force=True)
+                updated.append(manifest.short_name)
+            case False:
+                up_to_date.append(manifest.short_name)
     out.result(
         "Extensions update complete",
         updated=", ".join(updated) if updated else None,
@@ -382,29 +391,26 @@ def _auto_install_official_extension(short_name: str) -> Path | None:
         return None
 
 
-def _update_extension(manifest: ExtensionManifest) -> bool:
-    """Reinstall an installed extension if a newer version is available on GitHub.
+def _check_extension_update(manifest: ExtensionManifest) -> bool | None:
+    """Check whether an installed extension has a newer version on GitHub.
 
-    Returns True if the extension was updated, False if it was already up to date.
+    Returns:
+        - `True` if a newer commit is available (the extension should be reinstalled).
+        - `False` if the extension is already up to date.
+        - `None` if the check could not be performed (e.g. GitHub unreachable). The existing
+          install is left untouched and a warning is emitted.
     """
     owner, repo_name, short_name = manifest.owner, manifest.repo, manifest.short_name
-    branch, description = _resolve_github_repo_info(owner=owner, repo_name=repo_name)
+    branch, _description = _resolve_github_repo_info(owner=owner, repo_name=repo_name)
 
     latest_sha = _fetch_latest_commit_sha(owner=owner, repo_name=repo_name, branch=branch)
-    if latest_sha is not None and latest_sha == manifest.commit_sha:
-        return False
-
-    extension_dir = _get_extension_dir(short_name)
-    shutil.rmtree(extension_dir, ignore_errors=True)
-    _install_extension_from_github(
-        owner=owner,
-        repo_name=repo_name,
-        short_name=short_name,
-        extension_dir=extension_dir,
-        branch=branch,
-        description=description,
-    )
-    return True
+    if latest_sha is None:
+        out.warning(
+            f"Could not check updates for '{short_name}' ({owner}/{repo_name}): "
+            "GitHub is unreachable. Skipping."
+        )
+        return None
+    return latest_sha != manifest.commit_sha
 
 
 def _fetch_latest_commit_sha(*, owner: str, repo_name: str, branch: str) -> str | None:

--- a/src/huggingface_hub/cli/extensions.py
+++ b/src/huggingface_hub/cli/extensions.py
@@ -112,24 +112,10 @@ def extension_install(
             f"Cannot install extension '{short_name}' because it conflicts with an existing `hf {short_name}` command."
         )
 
-    extension_dir = _get_extension_dir(short_name)
-    extension_exists = extension_dir.exists()
-    if extension_exists and not force:
+    if _get_extension_dir(short_name).exists() and not force:
         raise CLIError(f"Extension '{short_name}' is already installed. Use --force to overwrite.")
 
-    branch, description = _resolve_github_repo_info(owner=owner, repo_name=repo_name)
-
-    if extension_exists:
-        shutil.rmtree(extension_dir)
-
-    manifest = _install_extension_from_github(
-        owner=owner,
-        repo_name=repo_name,
-        short_name=short_name,
-        extension_dir=extension_dir,
-        branch=branch,
-        description=description,
-    )
+    manifest = _clean_install_extension(owner=owner, repo_name=repo_name, short_name=short_name)
     ext_type = manifest.type.capitalize()
     out.result(
         f"{ext_type} extension installed",
@@ -148,7 +134,6 @@ def extension_install(
     ],
 )
 def extension_update(
-    ctx: click.Context,
     name: Annotated[
         str | None,
         Argument(
@@ -178,7 +163,7 @@ def extension_update(
             case None:
                 pass  # warning already emitted by _check_extension_update
             case True:
-                ctx.invoke(extension_install, repo_id=manifest.repo_id, force=True)
+                _clean_install_extension(owner=manifest.owner, repo_name=manifest.repo, short_name=manifest.short_name)
                 out.result("Extension updated", name=short_name, source=manifest.repo_id)
             case False:
                 out.result(f"Extension '{short_name}' is already up to date", name=short_name)
@@ -198,7 +183,7 @@ def extension_update(
             case None:
                 pass  # warning already emitted by _check_extension_update
             case True:
-                ctx.invoke(extension_install, repo_id=manifest.repo_id, force=True)
+                _clean_install_extension(owner=manifest.owner, repo_name=manifest.repo, short_name=manifest.short_name)
                 updated.append(manifest.short_name)
             case False:
                 up_to_date.append(manifest.short_name)
@@ -254,13 +239,10 @@ def extension_list() -> None:
 @extensions_cli.command("search", examples=["hf extensions search"])
 def extension_search() -> None:
     """Search extensions available on GitHub (tagged with 'hf-extension' topic)."""
-    response = get_session().get(
+    response = _github_get(
         "https://api.github.com/search/repositories",
         params={"q": f"topic:{_EXTENSIONS_GITHUB_TOPIC}", "sort": "stars", "order": "desc", "per_page": 100},
-        follow_redirects=True,
-        timeout=_EXTENSIONS_DOWNLOAD_TIMEOUT,
     )
-    response.raise_for_status()
     data = response.json()
 
     installed = {m.short_name for m in _list_installed_extensions()}
@@ -365,25 +347,19 @@ def _auto_install_official_extension(short_name: str) -> Path | None:
         return None
     if extension_dir.exists():
         return None
+
     try:
-        response = get_session().get(
-            f"https://api.github.com/repos/{owner}/{repo_name}",
-            follow_redirects=True,
-            timeout=_EXTENSIONS_DOWNLOAD_TIMEOUT,
-        )
-        if response.status_code == 404:
-            return None
-        response.raise_for_status()
-        branch = response.json()["default_branch"]
-    except Exception:
+        repo_info = _fetch_github_repo_info(owner=owner, repo_name=repo_name)
+    except Exception:  # 404 or unreachable -> do nothing
         return None
+
     try:
         out.confirm(f"'{short_name}' is an official Hugging Face extension ({owner}/{repo_name}). Install it?")
     except ConfirmationError:
         return None
     try:
         manifest = _install_extension_from_github(
-            owner=owner, repo_name=repo_name, short_name=short_name, extension_dir=extension_dir, branch=branch
+            owner=owner, repo_name=repo_name, short_name=short_name, extension_dir=extension_dir, branch=repo_info[0]
         )
         return Path(manifest.executable_path).expanduser()
     except Exception:
@@ -401,30 +377,49 @@ def _check_extension_update(manifest: ExtensionManifest) -> bool | None:
           install is left untouched and a warning is emitted.
     """
     owner, repo_name, short_name = manifest.owner, manifest.repo, manifest.short_name
-    branch, _description = _resolve_github_repo_info(owner=owner, repo_name=repo_name)
+
+    repo_info = _fetch_github_repo_info(owner=owner, repo_name=repo_name)
+    branch = repo_info[0] if repo_info is not None else _EXTENSIONS_DEFAULT_BRANCH
 
     latest_sha = _fetch_latest_commit_sha(owner=owner, repo_name=repo_name, branch=branch)
     if latest_sha is None:
         out.warning(
-            f"Could not check updates for '{short_name}' ({owner}/{repo_name}): "
-            "GitHub is unreachable. Skipping."
+            f"Could not check updates for '{short_name}' ({owner}/{repo_name}): GitHub is unreachable. Skipping."
         )
         return None
     return latest_sha != manifest.commit_sha
 
 
+def _clean_install_extension(*, owner: str, repo_name: str, short_name: str) -> ExtensionManifest:
+    """Fetch, install (binary or Python), and persist an extension, overwriting any existing install.
+
+    Used by `hf extensions install` (fresh install and `--force` reinstall) and `hf extensions update`.
+    """
+    extension_dir = _get_extension_dir(short_name)
+    if extension_dir.exists():
+        shutil.rmtree(extension_dir)
+    repo_info = _fetch_github_repo_info(owner=owner, repo_name=repo_name)
+    branch, description = repo_info if repo_info is not None else (_EXTENSIONS_DEFAULT_BRANCH, None)
+    return _install_extension_from_github(
+        owner=owner,
+        repo_name=repo_name,
+        short_name=short_name,
+        extension_dir=extension_dir,
+        branch=branch,
+        description=description,
+    )
+
+
 def _fetch_latest_commit_sha(*, owner: str, repo_name: str, branch: str) -> str | None:
     """Best-effort fetch of the latest commit SHA for a branch, used to detect available updates."""
     try:
-        response = get_session().get(
+        response = _github_get(
             f"https://api.github.com/repos/{owner}/{repo_name}/commits/{branch}",
             headers={"Accept": "application/vnd.github.sha"},
-            follow_redirects=True,
-            timeout=_EXTENSIONS_DOWNLOAD_TIMEOUT,
         )
-        response.raise_for_status()
         return response.text.strip() or None
-    except Exception:
+    except Exception as error:
+        out.warning(f"Could not fetch latest commit SHA for '{repo_name}' ({owner}/{repo_name}): {error}")
         return None
 
 
@@ -461,8 +456,7 @@ def _install_extension_from_github(
 def _fetch_remote_binary(owner: str, repo_name: str, branch: str, short_name: str) -> bytes:
     executable_name = _get_executable_name(short_name)
     raw_url = f"https://raw.githubusercontent.com/{owner}/{repo_name}/refs/heads/{branch}/{executable_name}"
-    response = get_session().get(raw_url, follow_redirects=True, timeout=_EXTENSIONS_DOWNLOAD_TIMEOUT)
-    response.raise_for_status()
+    response = _github_get(raw_url)
     return response.content
 
 
@@ -588,15 +582,12 @@ def _try_fetch_remote_description(
 
     Only best effort, no error handling.
     """
+    base = f"https://raw.githubusercontent.com/{owner}/{repo_name}/refs/heads/{branch}"
+
     # from manifest.json
     try:
-        response = get_session().get(
-            f"https://raw.githubusercontent.com/{owner}/{repo_name}/refs/heads/{branch}/{MANIFEST_FILENAME}",
-            follow_redirects=True,
-        )
-        response.raise_for_status()
-        data = response.json()
-        description = data.get("description")
+        response = _github_get(f"{base}/{MANIFEST_FILENAME}")
+        description = response.json().get("description")
         if isinstance(description, str):
             return description
     except Exception:
@@ -604,11 +595,7 @@ def _try_fetch_remote_description(
 
     # from pyproject.toml
     try:
-        response = get_session().get(
-            f"https://raw.githubusercontent.com/{owner}/{repo_name}/refs/heads/{branch}/pyproject.toml",
-            follow_redirects=True,
-        )
-        response.raise_for_status()
+        response = _github_get(f"{base}/pyproject.toml")
 
         # Weak parser but ok for "best effort"
         for line in response.text.splitlines():
@@ -638,18 +625,27 @@ def _get_extension_dir(short_name: str) -> Path:
     return target
 
 
-def _resolve_github_repo_info(owner: str, repo_name: str) -> tuple[str, str | None]:
-    try:
-        response = get_session().get(
-            f"https://api.github.com/repos/{owner}/{repo_name}",
-            follow_redirects=True,
-            timeout=_EXTENSIONS_DOWNLOAD_TIMEOUT,
-        )
-        response.raise_for_status()
-        data = response.json()
-        return data["default_branch"], data.get("description")
-    except Exception:
-        return _EXTENSIONS_DEFAULT_BRANCH, None
+def _github_get(url: str, *, params: dict | None = None, headers: dict | None = None):
+    """Perform a GitHub GET request.
+
+    Shared by every GitHub/Raw fetch in this module so the timeout and redirect policy are shared.
+    """
+    response = get_session().get(
+        url,
+        params=params,
+        headers=headers,
+        follow_redirects=True,
+        timeout=_EXTENSIONS_DOWNLOAD_TIMEOUT,
+    )
+    response.raise_for_status()
+    return response
+
+
+def _fetch_github_repo_info(*, owner: str, repo_name: str) -> tuple[str, str | None] | None:
+    """Fetch `default_branch` + `description` for a GitHub repo from `GET /repos/{owner}/{repo}`."""
+    response = _github_get(f"https://api.github.com/repos/{owner}/{repo_name}")
+    data = response.json()
+    return data["default_branch"], data.get("description")
 
 
 def _get_executable_name(short_name: str) -> str:

--- a/src/huggingface_hub/cli/extensions.py
+++ b/src/huggingface_hub/cli/extensions.py
@@ -119,12 +119,13 @@ def extension_install(
         )
 
     extension_dir = _get_extension_dir(short_name)
-    if extension_dir.exists():
-        if not force:
-            raise CLIError(f"Extension '{short_name}' is already installed. Use --force to overwrite.")
-        shutil.rmtree(extension_dir)
+    if extension_dir.exists() and not force:
+        raise CLIError(f"Extension '{short_name}' is already installed. Use --force to overwrite.")
 
     branch, description = _fetch_github_repo_info(owner=owner, repo_name=repo_name)
+    if extension_dir.exists():
+        # --force reinstall: only remove the previous install once the repo metadata is resolved.
+        shutil.rmtree(extension_dir)
     manifest = _install_extension(
         owner=owner, repo_name=repo_name, short_name=short_name, branch=branch, description=description
     )
@@ -179,7 +180,12 @@ def extension_update(
     up_to_date = []
     for manifest in manifests:
         out.log(f"Checking '{manifest.short_name}' ({manifest.repo_id})...")
-        update_status = _update_installed_extension(manifest)
+        try:
+            update_status = _update_installed_extension(manifest)
+        except Exception as error:
+            # Keep updating the other extensions even if one fails.
+            out.warning(f"Could not update '{manifest.short_name}' ({manifest.repo_id}): {error}. Skipping.")
+            continue
         match update_status:
             case _ExtensionUpdateStatus.UPDATED:
                 updated.append(manifest.short_name)
@@ -366,7 +372,8 @@ def _load_installed_extension_for_update(name: str) -> ExtensionManifest:
     short_name = _normalize_extension_name(name)
     extension_dir = _get_extension_dir(short_name)
     if not extension_dir.is_dir():
-        install_target = name if "/" in name else f"hf-{short_name}"
+        owner, _, _ = name.strip().rpartition("/")
+        install_target = f"{owner}/hf-{short_name}" if owner else f"hf-{short_name}"
         raise CLIError(
             f"Extension '{short_name}' is not installed. Install it first with: hf extensions install {install_target}"
         )

--- a/src/huggingface_hub/cli/extensions.py
+++ b/src/huggingface_hub/cli/extensions.py
@@ -346,7 +346,7 @@ def _auto_install_official_extension(short_name: str) -> Path | None:
 
     try:
         repo_info = _fetch_github_repo_info(owner=owner, repo_name=repo_name)
-    except Exception:  # 404 or unreachable -> do nothing
+    except Exception:
         return None
 
     try:

--- a/src/huggingface_hub/cli/extensions.py
+++ b/src/huggingface_hub/cli/extensions.py
@@ -144,11 +144,7 @@ def extension_update(
         ),
     ] = None,
 ) -> None:
-    """Update installed extension(s) to their latest version.
-
-    Only extensions that are already installed are updated. An extension that is not installed
-    is never installed implicitly, an error is raised instead.
-    """
+    """Update installed extension(s) to their latest version."""
     if name is not None:
         short_name = _parse_update_target(name)
         extension_dir = _get_extension_dir(short_name)

--- a/src/huggingface_hub/cli/extensions.py
+++ b/src/huggingface_hub/cli/extensions.py
@@ -22,6 +22,7 @@ import subprocess
 import venv
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
+from enum import Enum
 from pathlib import Path
 from typing import Annotated, Literal
 
@@ -44,12 +45,17 @@ EXTENSIONS_HELP = (
     "Install only from sources you trust."
 )
 extensions_cli = typer_factory(help=EXTENSIONS_HELP)
-_EXTENSIONS_DEFAULT_BRANCH = "main"  # Fallback when the GitHub API is unreachable.
 _EXTENSIONS_GITHUB_TOPIC = "hf-extension"
 _EXTENSIONS_DOWNLOAD_TIMEOUT = 10
 _EXTENSIONS_PIP_INSTALL_TIMEOUT = 300
 
 logger = logging.get_logger(__name__)
+
+
+class _ExtensionUpdateStatus(str, Enum):
+    UPDATED = "updated"
+    UP_TO_DATE = "up_to_date"
+    SKIPPED = "skipped"
 
 
 @dataclass
@@ -146,23 +152,15 @@ def extension_update(
 ) -> None:
     """Update installed extension(s) to their latest version."""
     if name is not None:
-        short_name = _parse_update_target(name)
-        extension_dir = _get_extension_dir(short_name)
-        if not extension_dir.is_dir():
-            install_target = name if "/" in name else f"hf-{short_name}"
-            raise CLIError(
-                f"Extension '{short_name}' is not installed. Install it first with: "
-                f"hf extensions install {install_target}"
-            )
-        manifest = ExtensionManifest.load(extension_dir)
-        match _check_extension_update(manifest):
-            case None:
-                pass  # warning already emitted by _check_extension_update
-            case True:
-                _clean_install_extension(owner=manifest.owner, repo_name=manifest.repo, short_name=manifest.short_name)
-                out.result("Extension updated", name=short_name, source=manifest.repo_id)
-            case False:
-                out.result(f"Extension '{short_name}' is already up to date", name=short_name)
+        manifest = _load_installed_extension_for_update(name)
+        update_status = _update_installed_extension(manifest)
+        match update_status:
+            case _ExtensionUpdateStatus.UPDATED:
+                out.result("Extension updated", name=manifest.short_name, source=manifest.repo_id)
+            case _ExtensionUpdateStatus.UP_TO_DATE:
+                out.result(f"Extension '{manifest.short_name}' is already up to date", name=manifest.short_name)
+            case _ExtensionUpdateStatus.SKIPPED:
+                pass  # warning already emitted by _update_installed_extension
         return
 
     manifests = _list_installed_extensions()
@@ -175,14 +173,14 @@ def extension_update(
     up_to_date = []
     for manifest in manifests:
         out.log(f"Checking '{manifest.short_name}' ({manifest.repo_id})...")
-        match _check_extension_update(manifest):
-            case None:
-                pass  # warning already emitted by _check_extension_update
-            case True:
-                _clean_install_extension(owner=manifest.owner, repo_name=manifest.repo, short_name=manifest.short_name)
+        update_status = _update_installed_extension(manifest)
+        match update_status:
+            case _ExtensionUpdateStatus.UPDATED:
                 updated.append(manifest.short_name)
-            case False:
+            case _ExtensionUpdateStatus.UP_TO_DATE:
                 up_to_date.append(manifest.short_name)
+            case _ExtensionUpdateStatus.SKIPPED:
+                pass  # warning already emitted by _update_installed_extension
     out.result(
         "Extensions update complete",
         updated=", ".join(updated) if updated else None,
@@ -354,8 +352,14 @@ def _auto_install_official_extension(short_name: str) -> Path | None:
     except ConfirmationError:
         return None
     try:
+        branch, description = repo_info
         manifest = _install_extension_from_github(
-            owner=owner, repo_name=repo_name, short_name=short_name, extension_dir=extension_dir, branch=repo_info[0]
+            owner=owner,
+            repo_name=repo_name,
+            short_name=short_name,
+            extension_dir=extension_dir,
+            branch=branch,
+            description=description,
         )
         return Path(manifest.executable_path).expanduser()
     except Exception:
@@ -363,30 +367,56 @@ def _auto_install_official_extension(short_name: str) -> Path | None:
         return None
 
 
-def _check_extension_update(manifest: ExtensionManifest) -> bool | None:
-    """Check whether an installed extension has a newer version on GitHub.
+def _load_installed_extension_for_update(name: str) -> ExtensionManifest:
+    short_name = _parse_update_target(name)
+    extension_dir = _get_extension_dir(short_name)
+    if not extension_dir.is_dir():
+        install_target = name if "/" in name else f"hf-{short_name}"
+        raise CLIError(
+            f"Extension '{short_name}' is not installed. Install it first with: hf extensions install {install_target}"
+        )
+    return ExtensionManifest.load(extension_dir)
 
-    Returns:
-        - `True` if a newer commit is available (the extension should be reinstalled).
-        - `False` if the extension is already up to date.
-        - `None` if the check could not be performed (e.g. GitHub unreachable). The existing
-          install is left untouched and a warning is emitted.
-    """
+
+def _update_installed_extension(manifest: ExtensionManifest) -> _ExtensionUpdateStatus:
     owner, repo_name, short_name = manifest.owner, manifest.repo, manifest.short_name
 
-    repo_info = _fetch_github_repo_info(owner=owner, repo_name=repo_name)
-    branch = repo_info[0] if repo_info is not None else _EXTENSIONS_DEFAULT_BRANCH
+    try:
+        branch, description = _fetch_github_repo_info(owner=owner, repo_name=repo_name)
+    except Exception as error:
+        out.warning(f"Could not check updates for '{short_name}' ({owner}/{repo_name}): {error}. Skipping.")
+        return _ExtensionUpdateStatus.SKIPPED
 
-    latest_sha = _fetch_latest_commit_sha(owner=owner, repo_name=repo_name, branch=branch)
+    latest_sha = _fetch_latest_commit_sha(owner=owner, repo_name=repo_name, branch=branch, warn=False)
     if latest_sha is None:
         out.warning(
             f"Could not check updates for '{short_name}' ({owner}/{repo_name}): GitHub is unreachable. Skipping."
         )
-        return None
-    return latest_sha != manifest.commit_sha
+        return _ExtensionUpdateStatus.SKIPPED
+
+    if latest_sha == manifest.commit_sha:
+        return _ExtensionUpdateStatus.UP_TO_DATE
+
+    _clean_install_extension(
+        owner=owner,
+        repo_name=repo_name,
+        short_name=short_name,
+        branch=branch,
+        description=description,
+        commit_sha=latest_sha,
+    )
+    return _ExtensionUpdateStatus.UPDATED
 
 
-def _clean_install_extension(*, owner: str, repo_name: str, short_name: str) -> ExtensionManifest:
+def _clean_install_extension(
+    *,
+    owner: str,
+    repo_name: str,
+    short_name: str,
+    branch: str | None = None,
+    description: str | None = None,
+    commit_sha: str | None = None,
+) -> ExtensionManifest:
     """Fetch, install (binary or Python), and persist an extension, overwriting any existing install.
 
     Used by `hf extensions install` (fresh install and `--force` reinstall) and `hf extensions update`.
@@ -394,8 +424,8 @@ def _clean_install_extension(*, owner: str, repo_name: str, short_name: str) -> 
     extension_dir = _get_extension_dir(short_name)
     if extension_dir.exists():
         shutil.rmtree(extension_dir)
-    repo_info = _fetch_github_repo_info(owner=owner, repo_name=repo_name)
-    branch, description = repo_info if repo_info is not None else (_EXTENSIONS_DEFAULT_BRANCH, None)
+    if branch is None:
+        branch, description = _fetch_github_repo_info(owner=owner, repo_name=repo_name)
     return _install_extension_from_github(
         owner=owner,
         repo_name=repo_name,
@@ -403,10 +433,11 @@ def _clean_install_extension(*, owner: str, repo_name: str, short_name: str) -> 
         extension_dir=extension_dir,
         branch=branch,
         description=description,
+        commit_sha=commit_sha,
     )
 
 
-def _fetch_latest_commit_sha(*, owner: str, repo_name: str, branch: str) -> str | None:
+def _fetch_latest_commit_sha(*, owner: str, repo_name: str, branch: str, warn: bool = True) -> str | None:
     """Best-effort fetch of the latest commit SHA for a branch, used to detect available updates."""
     try:
         response = _github_get(
@@ -415,7 +446,8 @@ def _fetch_latest_commit_sha(*, owner: str, repo_name: str, branch: str) -> str 
         )
         return response.text.strip() or None
     except Exception as error:
-        out.warning(f"Could not fetch latest commit SHA for '{repo_name}' ({owner}/{repo_name}): {error}")
+        if warn:
+            out.warning(f"Could not fetch latest commit SHA for '{repo_name}' ({owner}/{repo_name}): {error}")
         return None
 
 
@@ -427,6 +459,7 @@ def _install_extension_from_github(
     extension_dir: Path,
     branch: str,
     description: str | None = None,
+    commit_sha: str | None = None,
 ) -> ExtensionManifest:
     """Fetch, install (binary or Python), and save manifest for a GitHub extension."""
     try:
@@ -444,7 +477,7 @@ def _install_extension_from_github(
     manifest.description = _try_fetch_remote_description(
         owner=owner, repo_name=repo_name, branch=branch, candidate_description=description
     )
-    manifest.commit_sha = _fetch_latest_commit_sha(owner=owner, repo_name=repo_name, branch=branch)
+    manifest.commit_sha = commit_sha or _fetch_latest_commit_sha(owner=owner, repo_name=repo_name, branch=branch)
     manifest.save(extension_dir)
     return manifest
 
@@ -637,7 +670,7 @@ def _github_get(url: str, *, params: dict | None = None, headers: dict | None = 
     return response
 
 
-def _fetch_github_repo_info(*, owner: str, repo_name: str) -> tuple[str, str | None] | None:
+def _fetch_github_repo_info(*, owner: str, repo_name: str) -> tuple[str, str | None]:
     """Fetch `default_branch` + `description` for a GitHub repo from `GET /repos/{owner}/{repo}`."""
     response = _github_get(f"https://api.github.com/repos/{owner}/{repo_name}")
     data = response.json()

--- a/src/huggingface_hub/cli/extensions.py
+++ b/src/huggingface_hub/cli/extensions.py
@@ -368,7 +368,7 @@ def _auto_install_official_extension(short_name: str) -> Path | None:
 
 
 def _load_installed_extension_for_update(name: str) -> ExtensionManifest:
-    short_name = _parse_update_target(name)
+    short_name = _normalize_extension_name(name)
     extension_dir = _get_extension_dir(short_name)
     if not extension_dir.is_dir():
         install_target = name if "/" in name else f"hf-{short_name}"
@@ -745,25 +745,9 @@ def _normalize_repo_id(repo_id: str) -> tuple[str, str, str]:
     return owner, repo_name, short_name
 
 
-def _parse_update_target(name: str) -> str:
-    """Return the short name from an update target given as `<name>`, `hf-<name>`, or `[OWNER/]hf-<name>`.
-
-    Updates operate on already-installed extensions (identified by their short name), so the optional
-    owner prefix is accepted but ignored, both `alvarobartt/hf-mem` and `hf-mem` resolve to `mem`.
-    """
-    candidate = name.strip()
-    if not candidate:
-        raise CLIError("Extension name cannot be empty.")
-    repo_name = candidate.rsplit("/", 1)[-1]
-    normalized = repo_name[3:] if repo_name.startswith("hf-") else repo_name
-    return _validate_extension_short_name(normalized, original_input=name)
-
-
 def _normalize_extension_name(name: str) -> str:
-    candidate = name.strip()
-    if not candidate:
-        raise CLIError("Extension name cannot be empty.")
-    normalized = candidate[3:] if candidate.startswith("hf-") else candidate
+    repo_name = name.strip().rsplit("/", 1)[-1]
+    normalized = repo_name[3:] if repo_name.startswith("hf-") else repo_name
     return _validate_extension_short_name(normalized, original_input=name)
 
 


### PR DESCRIPTION
## Summary

Adds a new `hf extensions update` command to update installed CLI extensions to their latest version published on GitHub. It has two modes:

- **`hf extensions update <name>`** — updates a single, already-installed extension. If the extension is **not** installed, it raises an error with the exact install command instead of installing it implicitly. Both the short form and the owner-qualified form resolve to the same installed extension, so `hf extensions update alvarobartt/hf-mem` and `hf extensions update hf-mem` (and `hf extensions update mem`) all work.
- **`hf extensions update`** (no argument) — checks every installed extension individually and only updates the outdated ones.

## How update detection works

- The install manifest now stores the `commit_sha` of the installed branch (a new optional field, so existing installs stay compatible — they just get treated as outdated once and refreshed).
- On update, we fetch the latest commit SHA of the default branch (`GET /repos/{owner}/{repo}/commits/{branch}` with `Accept: application/vnd.github.sha`). If it matches the stored SHA, the extension is up to date; otherwise it is updated and the SHA refreshed.
- Checks are best-effort: if GitHub can't be reached, the extension is skipped with a warning and kept as-is.

## Updates are in-place (not rm + reinstall)

Updating no longer deletes the extension before reinstalling it:

- Binary extensions: the executable is overwritten in place.
- Python extensions: the existing venv is reused and the package reinstalled into it (`uv pip install --reinstall`, or `pip install --force-reinstall` without uv) — much faster than recreating the venv, since wheels come from cache. The `--reinstall` flag is required because the GitHub zip URL is identical across commits.
- A failed update no longer leaves the extension uninstalled (previously the directory was removed before reinstalling). Fetch/resolution failures — the common case — leave the old version untouched. A failure during the pip install phase itself can still leave the venv in a bad state; `hf extensions install <repo_id> --force` is the recovery path.
- `hf extensions update` (bulk) warns and continues with the remaining extensions when one fails to update.
- `hf extensions install --force` intentionally keeps the full clean-reinstall behavior, as an escape hatch for corrupted installs. Corner case: an extension switching type (python ↔ binary) between releases leaves a stale venv/binary on disk until a `--force` reinstall — harmless, documented trade-off.

## Notes / decisions

- `update` never installs a missing extension — this is intentional per the request. The error message provides the exact `hf extensions install ...` command (echoing the owner-qualified form when given, otherwise defaulting to the `huggingface` namespace `hf-<name>`).
- The whole module also got a simplification pass (net −70 lines, no CLI change): install/update/auto-install now share a single install primitive, failure cleanup and error formatting apply to binary extensions too (previously python-only), and the manifest dropped two unused fields (`source`, `executable_name`) — unknown keys in existing manifests are ignored on load.
- No tests added, as requested.

## Examples

Not installed (huggingface namespace):

```console
$ hf extensions update hf-claude
Error: Extension 'claude' is not installed. Install it first with: hf extensions install hf-claude
```

Not installed (third-party namespace):

```console
$ hf extensions update alvarobartt/hf-mem
Error: Extension 'mem' is not installed. Install it first with: hf extensions install alvarobartt/hf-mem
```

Up to date (both name forms resolve to the same installed extension):

```console
$ hf extensions update claude --format human
✓ Extension 'claude' is already up to date
  name: claude
$ hf extensions update hanouticelina/hf-claude --format human
✓ Extension 'claude' is already up to date
  name: claude
```

Outdated → updated in place (venv reused, packages swapped from cache):

```console
$ hf extensions update mem
Checking 'mem' (alvarobartt/hf-mem)...
Uninstalled 12 packages in 3ms
Installed 12 packages in 2ms
updated=mem
```

No extensions installed:

```console
$ hf extensions update
Warning: No extensions installed.
Hint: Install one with: hf extensions install <repo_id>
```

[Slack Thread](https://huggingface.slack.com/archives/D0A9313SS3G/p1783418003653489?thread_ts=1783418003.653489&cid=D0A9313SS3G)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how extensions are installed and updated on disk (including pip/venv behavior) and adds network-dependent update logic, though scope stays within the extensions CLI module.
> 
> **Overview**
> Adds **`hf extensions update`** to refresh already-installed CLI extensions from GitHub, either for one extension or for all installed ones (only outdated entries are upgraded).
> 
> Update detection stores an optional **`commit_sha`** on the install manifest and compares it to the default branch tip via the GitHub API; missing SHA on old installs triggers a one-time refresh. Uninstalled names error with an install hint; GitHub failures skip with warnings.
> 
> Install/update paths are **refactored** around shared `_install_extension`, `_github_get`, and `_fetch_github_repo_info`. Updates apply **in-place** (overwrite binaries, reuse venv with `--reinstall` / `--force-reinstall` for Python) so a failed update leaves the previous build usable; **`install --force`** still wipes and reinstalls. Manifest drops unused fields and ignores unknown keys on load.
> 
> Docs cover the new command in the CLI extensions guide and generated CLI reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9799c887e3bb74b882f2278963a70d9b2e1e16f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->