### PR TITLE
[Tests] Fix TestConfigDictNotRequired never being collected

### DIFF
--- a/tests/test_utils_strict_dataclass.py
+++ b/tests/test_utils_strict_dataclass.py
@@ -873,8 +873,10 @@ def test_typed_dict_to_dataclass_is_cached():
 
 @pytest.mark.skipif(sys.version_info < (3, 11), reason="Requires Python 3.11+")
 class TestConfigDictNotRequired:
-    def __init__(self):
-        # cannot be defined at class level because of Python<3.11
+    @pytest.fixture(autouse=True)
+    def _config_dict(self):
+        # Built in an autouse fixture rather than at class level: pytest cannot collect a test
+        # class with an __init__, and Required/NotRequired are only available on Python 3.11+.
         self.ConfigDictNotRequired = TypedDict(
             "ConfigDictNotRequired",
             {"required_value": Required[int], "not_required_value": NotRequired[int]},


### PR DESCRIPTION
> **Note:** This resubmits #4423 (same commit). I closed it temporarily while confirming my employer's open-source contribution policy — that's now cleared.

## Summary

- `TestConfigDictNotRequired` defined an `__init__`, so pytest silently refused to collect the whole class — its 4 tests never ran, and every run emitted a `PytestCollectionWarning`.
- Moved the lazy `TypedDict` construction into an autouse fixture, matching the pattern already used elsewhere in the suite (e.g. `TestUploadImpl._quiet_mode`). Kept the `skipif(< 3.11)` guard since `Required`/`NotRequired` are only available on Python 3.11+.

```console
# before — class is skipped at collection
$ pytest tests/test_utils_strict_dataclass.py -W error::pytest.PytestCollectionWarning
... PytestCollectionWarning: cannot collect test class 'TestConfigDictNotRequired' because it has a __init__ constructor
1 error during collection

# after — the 4 tests now actually run
$ pytest "tests/test_utils_strict_dataclass.py::TestConfigDictNotRequired" -W error::pytest.PytestCollectionWarning
4 passed
```

Closes #4421.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only harness change with no production code paths affected.
> 
> **Overview**
> **Fixes pytest collection** for `TestConfigDictNotRequired` in `tests/test_utils_strict_dataclass.py` so its four `Required`/`NotRequired` TypedDict tests actually run on Python 3.11+.
> 
> The class previously built `ConfigDictNotRequired` in `__init__`, which pytest treats as a non-test class and skips (with `PytestCollectionWarning`). That setup is replaced with an **autouse fixture** that assigns `self.ConfigDictNotRequired` before each test, keeping the lazy TypedDict definition without a class `__init__`. The existing `@pytest.mark.skipif(< 3.11)` guard is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b089cdae9508090abae218db76aba50bd10f81f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->