### PR TITLE
Update install.ps1

### DIFF
--- a/utils/installers/install.ps1
+++ b/utils/installers/install.ps1
@@ -376,7 +376,7 @@ function Test-Installation {
     if (Test-Path $hfExecutable) {
         try {
             # Test the CLI
-            $output = & $hfExecutable version 2>&1
+            $output = & $hfExecutable version --format quiet 2>&1
             if ($?) {
                 Write-Log "CLI location: $hfExecutable"
                 Write-Log "Installation directory: $HF_CLI_DIR"


### PR DESCRIPTION
Defaults to human format at least under some circumstances and causes an error due to the check mark in "✓ hf version"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line change to install verification only; no auth, runtime, or packaging logic affected.
> 
> **Overview**
> Fixes **false install verification failures** on Windows when the post-install smoke test runs `hf version`.
> 
> `Test-Installation` in `install.ps1` now invokes **`hf version --format quiet`** instead of plain `hf version`. The default/human `version` output can include decorative text (e.g. a check mark in `✓ hf version`), which led PowerShell to treat the run as unsuccessful even when the CLI worked.
> 
> Quiet format matches the CLI’s machine-oriented output mode and keeps the existing `$?` check reliable without changing any other installer steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d683150525a8c6d7947b591b21764d0a3ea287e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->