### PR TITLE
Add sort option to hf jobs ls

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -2045,6 +2045,16 @@ By default `hf jobs ps` displays at most 100 Jobs to avoid bloating the terminal
 >>> hf jobs ps -a --limit 0
 ```
 
+Use `--sort` to order Jobs by `created`, `status`, `runtime`, or `id`. Created time and runtime sort newest or longest first by default; pass `--reverse` to flip the order:
+
+```bash
+# Show the longest-running completed Jobs
+>>> hf jobs ps -a --status completed --sort runtime --limit 10
+
+# Show Jobs by ID in descending order
+>>> hf jobs ps -a --sort id --reverse
+```
+
 > [!WARNING]
 > `-f`/`--filter` is deprecated in favor of `--status` and `--label`. Matching is exact: glob patterns (`data-*`) and negation (`key!=value`) are not supported, and filtering by `id`, `image` or `command` is not available.
 

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -19,6 +19,7 @@ import multiprocessing.pool
 import shutil
 import time
 from collections.abc import Callable, Iterable
+from enum import Enum
 from fnmatch import fnmatch
 from pathlib import Path
 from queue import Empty, Queue
@@ -128,6 +129,39 @@ def _parse_and_sync_job_volumes(
 
 
 STATS_UPDATE_MIN_INTERVAL = 0.1  # we set a limit here since there is one update per second per job
+
+_JOB_SORT_OPTIONS = ("created", "status", "runtime", "id")
+JobSort = Enum("JobSort", {key: key for key in _JOB_SORT_OPTIONS}, type=str)  # type: ignore[misc]
+
+
+def _sort_jobs(jobs: list[JobInfo], sort: JobSort, reverse: bool) -> list[JobInfo]:
+    sort_key = sort.value
+    reverse_order = (sort_key in {"created", "runtime"}) != reverse
+
+    def sort_value(job: JobInfo) -> Any:
+        if sort_key == "created":
+            return job.created_at
+        if sort_key == "status":
+            return job.status.stage
+        if sort_key == "runtime":
+            return job.durations.running_secs if job.durations is not None else None
+        if sort_key == "id":
+            return job.id
+        raise ValueError(f"Unsupported Jobs sort key: {sort_key}")
+
+    jobs_with_values: list[tuple[Any, JobInfo]] = []
+    jobs_without_values: list[JobInfo] = []
+    for job in jobs:
+        value = sort_value(job)
+        if value is None:
+            jobs_without_values.append(job)
+        else:
+            jobs_with_values.append((value, job))
+
+    return [
+        job for _, job in sorted(jobs_with_values, key=lambda item: item[0], reverse=reverse_order)
+    ] + jobs_without_values
+
 
 # Common job-related options
 ImageArg = Annotated[
@@ -546,6 +580,7 @@ def jobs_stats(
         "hf jobs ls -a",
         "hf jobs ls --status running,scheduling",
         "hf jobs ls --label env=prod --label team=ml",
+        "hf jobs ls -a --sort runtime --limit 10",
         "hf jobs ls --all --label hf-sandbox=1",
     ],
 )
@@ -574,6 +609,17 @@ def jobs_ps(
             help="Only show Jobs with the given `key=value` label. Repeat to require several labels, e.g. `--label env=prod --label team=ml`.",
         ),
     ] = None,
+    sort: Annotated[
+        JobSort | None,
+        Option(
+            "--sort",
+            help="Sort Jobs by created, status, runtime, or id. Created and runtime sort newest/longest first.",
+        ),
+    ] = None,
+    reverse: Annotated[
+        bool,
+        Option("-r", "--reverse", help="Reverse the Jobs sort order."),
+    ] = False,
     limit: Annotated[
         int,
         Option(
@@ -631,15 +677,22 @@ def jobs_ps(
 
     jobs_iter = api.list_jobs(namespace=namespace, status=server_statuses, labels=labels or None)
 
-    # Apply the display limit. Fetch one extra Job to detect (and warn about) truncation.
     truncated = False
-    if limit > 0:
-        jobs = list(itertools.islice(jobs_iter, limit + 1))
-        if len(jobs) > limit:
+    if sort is not None:
+        jobs = _sort_jobs(list(jobs_iter), sort=sort, reverse=reverse)
+        if limit > 0 and len(jobs) > limit:
             truncated = True
             jobs = jobs[:limit]
     else:
-        jobs = list(jobs_iter)
+        if reverse:
+            raise CLIError("`--reverse` can only be used together with `--sort`.")
+        if limit > 0:
+            jobs = list(itertools.islice(jobs_iter, limit + 1))
+            if len(jobs) > limit:
+                truncated = True
+                jobs = jobs[:limit]
+        else:
+            jobs = list(jobs_iter)
 
     # Build display items. Augment the raw api dict with curated, table-friendly columns.
     job_items: list[dict[str, Any]] = []

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3494,6 +3494,75 @@ class TestJobsCommand:
         assert "abc123def456" in result.output
         assert "xyz789ghi012" in result.output
 
+    def test_ls_sorts_before_limiting(self, runner: CliRunner) -> None:
+        from huggingface_hub._jobs_api import JobInfo
+
+        jobs = [
+            JobInfo(
+                id="z-job",
+                createdAt="2026-01-13T10:30:00.000Z",
+                dockerImage="python:3.12",
+                command=["echo", "z"],
+                arguments=[],
+                environment={},
+                secrets={},
+                flavor="cpu-basic",
+                labels={},
+                status={"stage": "COMPLETED"},
+                owner={"id": "u", "name": "test", "type": "user"},
+            ),
+            JobInfo(
+                id="a-job",
+                createdAt="2026-01-15T10:30:00.000Z",
+                dockerImage="python:3.12",
+                command=["echo", "a"],
+                arguments=[],
+                environment={},
+                secrets={},
+                flavor="cpu-basic",
+                labels={},
+                status={"stage": "COMPLETED"},
+                owner={"id": "u", "name": "test", "type": "user"},
+            ),
+            JobInfo(
+                id="m-job",
+                createdAt="2026-01-14T10:30:00.000Z",
+                dockerImage="python:3.12",
+                command=["echo", "m"],
+                arguments=[],
+                environment={},
+                secrets={},
+                flavor="cpu-basic",
+                labels={},
+                status={"stage": "COMPLETED"},
+                owner={"id": "u", "name": "test", "type": "user"},
+            ),
+        ]
+        with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            api.list_jobs.return_value = jobs
+            result = runner.invoke(app, ["jobs", "ls", "-a", "-q", "--sort", "id", "--limit", "1"])
+        assert result.exit_code == 0
+        assert result.stdout.strip() == "a-job"
+
+    def test_ls_sort_reverse(self, runner: CliRunner) -> None:
+        jobs = self._make_mock_jobs()
+        with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            api.list_jobs.return_value = jobs
+            result = runner.invoke(app, ["jobs", "ls", "-a", "-q", "--sort", "id", "--reverse", "--limit", "1"])
+        assert result.exit_code == 0
+        assert result.stdout.strip() == "xyz789ghi012"
+
+    def test_ls_reverse_requires_sort(self, runner: CliRunner) -> None:
+        with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            api.list_jobs.return_value = []
+            result = runner.invoke(app, ["jobs", "ls", "-a", "--reverse"])
+        assert result.exit_code == 1
+        assert isinstance(result.exception, CLIError)
+        assert "`--reverse` can only be used together with `--sort`." in str(result.exception)
+
     def test_ls_empty_json(self, runner: CliRunner) -> None:
         """Test that `hf jobs ls --format json` outputs `[]` when no jobs match."""
         import json


### PR DESCRIPTION
Summary
- add `--sort` to `hf jobs ls/ps` for created time, status, runtime, and id
- add `--reverse` to flip the selected sort order
- keep the existing fast limit path when no sort is requested
- document the new sorting options in the CLI guide

Tests
- `python -m ruff format --check src\huggingface_hub\cli\jobs.py tests\test_cli.py`
- `python -m ruff check src\huggingface_hub\cli\jobs.py tests\test_cli.py`
- `python -m pytest tests\test_cli.py::TestJobsCommand -q`

Closes #4374

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI listing behavior with a preserved fast path when sort is omitted; covered by new unit tests.
> 
> **Overview**
> **`hf jobs ls` / `ps`** can now order results with **`--sort`** (`created`, `status`, `runtime`, or `id`) and flip direction with **`--reverse`**. For `created` and `runtime`, the default order is newest / longest first unless reversed.
> 
> When **`--sort`** is set, the command loads the matching jobs, sorts client-side, then applies **`--limit`** so the top N rows are the right slice (e.g. longest-running completed jobs). Without sort, behavior is unchanged: streaming **`--limit`** without pulling the full list. **`--reverse`** alone errors with a clear **`CLIError`**.
> 
> The CLI guide documents the new flags; tests cover sort-before-limit, reverse, and the reverse-without-sort guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a98e2bde8af42e8cbfb8e06255654f0ef2b2a7ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->