### PR TITLE
[CLI] --sdk instead of --space-sdk in CLI for consistency

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -1411,7 +1411,7 @@ Create a private dataset or a Space:
 
 ```bash
 >>> hf repos create my-cool-dataset --repo-type dataset --private
->>> hf repos create my-gradio-space --repo-type space --space-sdk gradio
+>>> hf repos create my-gradio-space --repo-type space --sdk gradio
 ```
 
 Use `--exist-ok` if the repo may already exist, and `--resource-group-id` to target an Enterprise resource group.

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -3392,7 +3392,7 @@ $ hf repos create [OPTIONS] REPO_ID
 **Options**:
 
 * `--type, --repo-type [model|dataset|space]`: The type of repository (model, dataset, or space).  [default: model]
-* `--space-sdk TEXT`: Hugging Face Spaces SDK type. Required when --type is set to 'space'.
+* `--sdk TEXT`: Hugging Face Spaces SDK type. Required when --type is set to 'space'.
 * `--private / --no-private`: Whether to create a private repo if repo doesn't exist on the Hub. Ignored if the repo already exists.
 * `--public`: Whether to make the repo public. Ignored if the repo already exists.
 * `--protected`: Whether to make the Space protected (Spaces only). Ignored if the repo already exists.
@@ -3408,13 +3408,14 @@ $ hf repos create [OPTIONS] REPO_ID
 * `-e, --env TEXT`: Set environment variables. E.g. --env ENV=value
 * `--env-file TEXT`: Read in a file of environment variables.
 * `-v, --volume TEXT`: Mount one or more volumes. Format: hf://[TYPE/]SOURCE:/MOUNT_PATH[:ro]. TYPE is one of: models, datasets, spaces, buckets. TYPE defaults to models if omitted. models, datasets and spaces are always mounted read-only. buckets are read+write by default. E.g. -v hf://org/m:/data or -v hf://datasets/org/ds:/data or -v hf://buckets/org/b:/mnt:ro
+* `--space-sdk TEXT`: Deprecated. Use --sdk instead.
 * `--help`: Show this message and exit.
 
 Examples
   $ hf repos create my-model
   $ hf repos create my-dataset --repo-type dataset --private
-  $ hf repos create my-space --type space --space-sdk gradio --flavor t4-medium --secrets HF_TOKEN -e THEME=dark --protected
-  $ hf repos create my-space --type space --space-sdk gradio -v hf://org/my-model:/models -v hf://buckets/org/b:/data
+  $ hf repos create my-space --type space --sdk gradio --flavor t4-medium --secrets HF_TOKEN -e THEME=dark --protected
+  $ hf repos create my-space --type space --sdk gradio -v hf://org/my-model:/models -v hf://buckets/org/b:/data
   $ hf repos create my-model --region us
 
 Learn more

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -3392,7 +3392,7 @@ $ hf repos create [OPTIONS] REPO_ID
 **Options**:
 
 * `--type, --repo-type [model|dataset|space]`: The type of repository (model, dataset, or space).  [default: model]
-* `--sdk TEXT`: Hugging Face Spaces SDK type. Required when --type is set to 'space'.
+* `--sdk, --space-sdk TEXT`: Hugging Face Spaces SDK type. Required when --type is set to 'space'.
 * `--private / --no-private`: Whether to create a private repo if repo doesn't exist on the Hub. Ignored if the repo already exists.
 * `--public`: Whether to make the repo public. Ignored if the repo already exists.
 * `--protected`: Whether to make the Space protected (Spaces only). Ignored if the repo already exists.
@@ -3408,7 +3408,6 @@ $ hf repos create [OPTIONS] REPO_ID
 * `-e, --env TEXT`: Set environment variables. E.g. --env ENV=value
 * `--env-file TEXT`: Read in a file of environment variables.
 * `-v, --volume TEXT`: Mount one or more volumes. Format: hf://[TYPE/]SOURCE:/MOUNT_PATH[:ro]. TYPE is one of: models, datasets, spaces, buckets. TYPE defaults to models if omitted. models, datasets and spaces are always mounted read-only. buckets are read+write by default. E.g. -v hf://org/m:/data or -v hf://datasets/org/ds:/data or -v hf://buckets/org/b:/mnt:ro
-* `--space-sdk TEXT`: Deprecated. Use --sdk instead.
 * `--help`: Show this message and exit.
 
 Examples

--- a/src/huggingface_hub/cli/repos.py
+++ b/src/huggingface_hub/cli/repos.py
@@ -201,6 +201,8 @@ def repo_create(
     sdk: Annotated[
         str | None,
         Option(
+            "--sdk",
+            "--space-sdk",
             help="Hugging Face Spaces SDK type. Required when --type is set to 'space'.",
         ),
     ] = None,
@@ -235,11 +237,9 @@ def repo_create(
     env: EnvOpt = None,
     env_file: EnvFileOpt = None,
     volume: VolumesOpt = None,
-    space_sdk: Annotated[str | None, Option(help="Deprecated. Use --sdk instead.")] = None,
 ) -> None:
     """Create a new repo on the Hub."""
     api = get_hf_api(token=token)
-    space_sdk = sdk or space_sdk
     repo_url = api.create_repo(
         repo_id=repo_id,
         repo_type=repo_type.value,
@@ -248,7 +248,7 @@ def repo_create(
         exist_ok=exist_ok,
         resource_group_id=resource_group_id,
         region=region,
-        space_sdk=space_sdk,
+        space_sdk=sdk,
         space_hardware=hardware,
         space_storage=storage,
         space_sleep_time=sleep_time,

--- a/src/huggingface_hub/cli/repos.py
+++ b/src/huggingface_hub/cli/repos.py
@@ -190,15 +190,15 @@ def repo_list(
     examples=[
         "hf repos create my-model",
         "hf repos create my-dataset --repo-type dataset --private",
-        "hf repos create my-space --type space --space-sdk gradio --flavor t4-medium --secrets HF_TOKEN -e THEME=dark --protected",
-        "hf repos create my-space --type space --space-sdk gradio -v hf://org/my-model:/models -v hf://buckets/org/b:/data",
+        "hf repos create my-space --type space --sdk gradio --flavor t4-medium --secrets HF_TOKEN -e THEME=dark --protected",
+        "hf repos create my-space --type space --sdk gradio -v hf://org/my-model:/models -v hf://buckets/org/b:/data",
         "hf repos create my-model --region us",
     ],
 )
 def repo_create(
     repo_id: RepoIdArg,
     repo_type: RepoTypeOpt = RepoType.model,
-    space_sdk: Annotated[
+    sdk: Annotated[
         str | None,
         Option(
             help="Hugging Face Spaces SDK type. Required when --type is set to 'space'.",
@@ -235,9 +235,11 @@ def repo_create(
     env: EnvOpt = None,
     env_file: EnvFileOpt = None,
     volume: VolumesOpt = None,
+    space_sdk: Annotated[str | None, Option(help="Deprecated. Use --sdk instead.")] = None,
 ) -> None:
     """Create a new repo on the Hub."""
     api = get_hf_api(token=token)
+    space_sdk = sdk or space_sdk
     repo_url = api.create_repo(
         repo_id=repo_id,
         repo_type=repo_type.value,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1504,7 +1504,7 @@ class TestRepoCreateCommand:
                     "my-space",
                     "--type",
                     "space",
-                    "--space-sdk",
+                    "--sdk",
                     "gradio",
                     "--flavor",
                     "t4-medium",


### PR DESCRIPTION
Small PR to recommend

`hf repos create --type space --sdk gradio`

instead of 

`hf repos create --type space --space-sdk gradio`

All other space-specific options doesn't repeat `--space` in their name: `--hardware`, `--storage`, `--sleep-time`, `--secrets`, etc. Space SDK was the only exception, let's change that. Kept `--space-sdk` for backward compatibility.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only flag alias with backward compatibility; no API or Hub behavior changes.
> 
> **Overview**
> **`hf repos create`** now documents and prefers **`--sdk`** (e.g. `--type space --sdk gradio`) instead of **`--space-sdk`**, aligning with other space options that don’t repeat the `space` prefix.
> 
> The Typer option exposes **`--sdk`** as the primary flag while **`--space-sdk`** remains as a backward-compatible alias; the handler parameter is renamed to `sdk` but still forwards to `api.create_repo(..., space_sdk=sdk)`. Docs, CLI reference examples, built-in help examples, and tests are updated to use **`--sdk`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8564cd90cbbc886920de821943ff26164450ac6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->