### PR TITLE
[Utils] Treat backslashes as path separators in filter_repo_objects

### DIFF
--- a/src/huggingface_hub/utils/_paths.py
+++ b/src/huggingface_hub/utils/_paths.py
@@ -49,11 +49,14 @@ def filter_repo_objects(
     In the later case, `key` must be provided and specifies a function of one argument
     that is used to extract a path from each element in iterable.
 
-    Patterns are Standard Wildcards (globbing patterns), NOT regular expressions.
-    The pattern matching is based on Python's `fnmatch.fnmatchcase`, so it is
-    case-sensitive on every platform. Note that it matches `*` across path
-    boundaries, unlike traditional Unix shell globbing. For example,
-    `"data/*.json"` will match both `data/file.json` and `data/subdir/file.json`.
+    Patterns are Standard Wildcards (globbing patterns), NOT regular expressions. The pattern matching is based on
+    Python's `fnmatch.fnmatchcase`, so it is case-sensitive on every platform. Backslashes are treated as path separators
+    and normalized to forward slashes in both patterns and paths before matching, so patterns built with `os.path.join`
+    on Windows work as expected.
+
+    Note that it matches `*` across path boundaries, unlike traditional Unix shell globbing. For example, `"data/*.json"`
+    will match both `data/file.json` and `data/subdir/file.json`.
+
     See https://docs.python.org/3/library/fnmatch.html for more details.
 
     Args:
@@ -110,9 +113,9 @@ def filter_repo_objects(
         ignore_patterns = [ignore_patterns]
 
     if allow_patterns is not None:
-        allow_patterns = [_add_wildcard_to_directories(p) for p in allow_patterns]
+        allow_patterns = [_add_wildcard_to_directories(_normalize_separators(p)) for p in allow_patterns]
     if ignore_patterns is not None:
-        ignore_patterns = [_add_wildcard_to_directories(p) for p in ignore_patterns]
+        ignore_patterns = [_add_wildcard_to_directories(_normalize_separators(p)) for p in ignore_patterns]
 
     if key is None:
 
@@ -126,7 +129,7 @@ def filter_repo_objects(
         key = _identity  # Items must be `str` or `Path`, otherwise raise ValueError
 
     for item in items:
-        path = key(item)
+        path = _normalize_separators(key(item))
 
         # Skip if there's an allowlist and path doesn't match any
         if allow_patterns is not None and not any(fnmatchcase(path, r) for r in allow_patterns):
@@ -137,6 +140,12 @@ def filter_repo_objects(
             continue
 
         yield item
+
+
+def _normalize_separators(value: str) -> str:
+    # Repo paths always use `/` and `\` is not an fnmatch escape character, so treating backslashes as path separators
+    # (e.g. patterns built with `os.path.join` on Windows) is safe.
+    return value.replace("\\", "/")
 
 
 def _add_wildcard_to_directories(pattern: str) -> str:

--- a/src/huggingface_hub/utils/_paths.py
+++ b/src/huggingface_hub/utils/_paths.py
@@ -142,10 +142,11 @@ def filter_repo_objects(
         yield item
 
 
-def _normalize_separators(value: str) -> str:
+def _normalize_separators(value: str | Path) -> str:
     # Repo paths always use `/` and `\` is not an fnmatch escape character, so treating backslashes as path separators
     # (e.g. patterns built with `os.path.join` on Windows) is safe.
-    return value.replace("\\", "/")
+    # `value` can be a `Path` if a custom `key` returns one; coerce to `str` first.
+    return str(value).replace("\\", "/")
 
 
 def _add_wildcard_to_directories(pattern: str) -> str:

--- a/tests/test_utils_paths.py
+++ b/tests/test_utils_paths.py
@@ -156,6 +156,15 @@ class TestPathsUtils:
             ignore_patterns=["unet\\*.json"],
         )
 
+    def test_key_returning_path_object(self) -> None:
+        """A custom `key` returning a `Path` (not `str`) must work."""
+        self._check(
+            items=[DummyObject(path=Path("unet/config.json")), DummyObject(path=Path("unet/model.bin"))],
+            expected_items=[DummyObject(path=Path("unet/config.json"))],
+            allow_patterns=["unet/*.json"],
+            key=lambda x: x.path,
+        )
+
     def _check(
         self,
         items: list[Any],

--- a/tests/test_utils_paths.py
+++ b/tests/test_utils_paths.py
@@ -132,6 +132,29 @@ class TestPathsUtils:
             ignore_patterns=["*.LOG"],
         )
 
+    def test_backslashes_are_treated_as_path_separators(self) -> None:
+        """Windows-style patterns (e.g. built with `os.path.join`) match `/`-separated repo paths.
+        Regression test for https://github.com/huggingface/huggingface_hub/pull/4435 fallout.
+        """
+        # Backslash-separated pattern matches forward-slash paths.
+        self._check(
+            items=["unet/config.json", "vae/config.json", "unet/model.bin"],
+            expected_items=["unet/config.json"],
+            allow_patterns=["unet\\config.json"],
+        )
+        # Backslash-separated paths (e.g. local Windows paths) match forward-slash patterns.
+        self._check(
+            items=["unet\\config.json", "unet\\model.bin"],
+            expected_items=["unet\\config.json"],
+            allow_patterns=["unet/*.json"],
+        )
+        # Also applies to the ignore list.
+        self._check(
+            items=["unet/config.json", "unet/model.bin"],
+            expected_items=["unet/model.bin"],
+            ignore_patterns=["unet\\*.json"],
+        )
+
     def _check(
         self,
         items: list[Any],

--- a/tests/test_utils_paths.py
+++ b/tests/test_utils_paths.py
@@ -134,7 +134,8 @@ class TestPathsUtils:
 
     def test_backslashes_are_treated_as_path_separators(self) -> None:
         """Windows-style patterns (e.g. built with `os.path.join`) match `/`-separated repo paths.
-        Regression test for https://github.com/huggingface/huggingface_hub/pull/4435 fallout.
+
+        Regression test for https://github.com/huggingface/huggingface_hub/pull/4506.
         """
         # Backslash-separated pattern matches forward-slash paths.
         self._check(


### PR DESCRIPTION
[Related slack thread](https://huggingface.slack.com/archives/C02V5EA0A95/p1783517547121799?thread_ts=1783507099.363359&cid=C02V5EA0A95) (internal)

## Summary

Follow-up to #4435 (which made pattern matching case-sensitive on all platforms). On Windows, the old `fnmatch.fnmatch` also normalized `/` ↔ `\` via `os.path.normcase`, which is not the case anymore with `fnmatch.fnmatchcase`. Meaning backslash patterns built with `os.path.join` (e.g. by diffusers) stopped matching in v1.22 => `snapshot_download` silently skipped files.

Fix: normalize `\` → `/` in both patterns and paths before matching with `fnmatchcase`. Case sensitivity is kept; behavior is now identical on all platforms. Safe because repo paths always use `/` and `\` is not an fnmatch escape character.

```python
# v1.21 (Windows only) and this PR (all platforms): match
# v1.22: no match => file silently skipped
list(filter_repo_objects(["unet/config.json"], allow_patterns=["unet\\config.json"]))
# ["unet/config.json"]
```

Related to https://github.com/huggingface/peft/pull/3399 cc @BenjaminBossan .

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared filtering used by snapshot download and uploads; wrong normalization could change which files are included or excluded, though the change is narrow and well-tested.
> 
> **Overview**
> Fixes a **v1.22 regression** where `filter_repo_objects` stopped matching Windows-style patterns (e.g. from `os.path.join`) against hub repo paths that use `/`, which could cause **`snapshot_download` to silently skip files**.
> 
> The matcher now runs **`_normalize_separators`** (`\` → `/`) on allow/ignore patterns and on each item path before `fnmatchcase`, while keeping **case-sensitive** behavior from #4435. Docstrings describe the cross-platform separator behavior, and tests cover backslash patterns, ignore lists, and custom `key` callbacks that return `Path`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0d81c9c91714394ec942ccc4f73b623c41c3568. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->