### PR TITLE
[CI] Fix expand property type tests

### DIFF
--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -4481,22 +4481,18 @@ class TestWebhookApi:
             api.get_webhook(webhook_to_delete.id)
 
 
+@pytest.mark.production
 class TestExpandPropertyType:
-    def test_expand_model_property_type_is_up_to_date(self, api: HfApi, repo_factory: RepoFactory):
-        repo_url = repo_factory("model")
-        self._check_expand_property_is_up_to_date(api, repo_url)
+    def test_expand_model_property_type_is_up_to_date(self, api_prod: HfApi, repo_factory: RepoFactory):
+        self._check_expand_property_is_up_to_date(api_prod, "model", "zai-org/GLM-5.2")
 
-    def test_expand_dataset_property_type_is_up_to_date(self, api: HfApi, repo_factory: RepoFactory):
-        repo_url = repo_factory("dataset")
-        self._check_expand_property_is_up_to_date(api, repo_url)
+    def test_expand_dataset_property_type_is_up_to_date(self, api_prod: HfApi, repo_factory: RepoFactory):
+        self._check_expand_property_is_up_to_date(api_prod, "dataset", "openai/gsm8k")
 
-    def test_expand_space_property_type_is_up_to_date(self, api: HfApi, repo_factory: RepoFactory):
-        repo_url = repo_factory("space")
-        self._check_expand_property_is_up_to_date(api, repo_url)
+    def test_expand_space_property_type_is_up_to_date(self, api_prod: HfApi, repo_factory: RepoFactory):
+        self._check_expand_property_is_up_to_date(api_prod, "space", "black-forest-labs/FLUX.1-dev")
 
-    def _check_expand_property_is_up_to_date(self, api: HfApi, repo_url: RepoUrl):
-        repo_id = repo_url.repo_id
-        repo_type = repo_url.repo_type
+    def _check_expand_property_is_up_to_date(self, api: HfApi, repo_type: str, repo_id: str):
         property_type = (
             ExpandModelProperty_T
             if repo_type == "model"


### PR DESCRIPTION
In `TestExpandPropertyType` we were previously using the staging endpoint, which needed to create empty repos before doing the expand check. This is now failing because Space creation is forbidden for free users. Simplest solution is just to rely on existing repos on prod that we know won't move anytime soon. 

Side effect, it runs slightly faster since we are not create/deleting repos anymore.

CI currently fails with

```
FAILED ../tests/test_hf_api.py::TestExpandPropertyType::test_expand_space_property_type_is_up_to_date - huggingface_hub.errors.HfHubHTTPError: Client error '402 Payment Required' for url 'https://hub-ci.huggingface.co/api/repos/create' (Request ID: Root=1-6a4e6672-302e9c4549d667a040ea1e78;2dd8aa86-e831-4655-8992-b93165d2639b)
For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/402

Static Spaces are free for everyone, but hosting Gradio and Docker Spaces on free cpu-basic requires a PRO subscription. Subscribe at https://hub-ci.huggingface.co/pro
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; no library or runtime behavior is modified.
> 
> **Overview**
> Fixes CI failures in **`TestExpandPropertyType`** where staging tried to create temporary Spaces and hit **402 Payment Required** (Gradio/Docker Spaces need PRO on hub-ci).
> 
> The class is now marked **`@pytest.mark.production`** and uses the **`api_prod`** client against stable public repos (`zai-org/GLM-5.2`, `openai/gsm8k`, `black-forest-labs/FLUX.1-dev`) instead of **`repo_factory`** create/delete on staging. The shared helper takes **`repo_type`** and **`repo_id`** directly rather than a **`RepoUrl`** from a freshly created repo, so the expand-parameter sync check still works without write access or Space creation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6903d898ff2c59b965217f9b41cb0a0c3ab9a7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->