### PR TITLE
[CLI] Add --pipeline-tag, --gated, --apps filters to hf models ls

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -882,17 +882,17 @@ Use `hf models` to list models on the Hub and get detailed information about a s
 # Filter by author
 >>> hf models ls --author Qwen
 
-# Filter by pipeline tag (canonical task)
+# Filter by pipeline tag
 >>> hf models ls --pipeline-tag summarization
 
 # Filter by parameter count
 >>> hf models ls --num-parameters min:6B,max:128B
 
-# Only gated models
->>> hf models ls --gated --author meta-llama
+# Only non-gated models
+>>> hf models ls --no-gated --author meta-llama
 
 # Only models runnable by a given app
->>> hf models ls --apps ollama
+>>> hf models ls --apps llama.cpp
 
 # Sort by downloads
 >>> hf models ls --sort downloads --limit 10

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -882,8 +882,17 @@ Use `hf models` to list models on the Hub and get detailed information about a s
 # Filter by author
 >>> hf models ls --author Qwen
 
+# Filter by pipeline tag (canonical task)
+>>> hf models ls --pipeline-tag summarization
+
 # Filter by parameter count
 >>> hf models ls --num-parameters min:6B,max:128B
+
+# Only gated models
+>>> hf models ls --gated --author meta-llama
+
+# Only models runnable by a given app
+>>> hf models ls --apps ollama
 
 # Sort by downloads
 >>> hf models ls --sort downloads --limit 10

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -889,7 +889,7 @@ Use `hf models` to list models on the Hub and get detailed information about a s
 >>> hf models ls --num-parameters min:6B,max:128B
 
 # Only non-gated models
->>> hf models ls --no-gated --author meta-llama
+>>> hf models ls --no-gated --author google
 
 # Only models runnable by a given app
 >>> hf models ls --apps llama.cpp

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -3082,11 +3082,10 @@ $ hf models list [OPTIONS] [REPO_ID]
 Examples
   $ hf models ls --sort downloads --limit 10
   $ hf models ls --search "llama" --author meta-llama
-  $ hf models ls --pipeline-tag summarization --sort downloads
   $ hf models ls --pipeline-tag text-generation --warm
   $ hf models ls --num-parameters min:6B,max:128B --sort likes
-  $ hf models ls --gated --author meta-llama
-  $ hf models ls --apps ollama --apps vllm
+  $ hf models ls --no-gated --author meta-llama
+  $ hf models ls --apps llama.cpp --apps vllm
   $ hf models ls --inference-provider fireworks-ai --sort downloads
   $ hf models ls --warm --search llama
   $ hf models ls meta-llama/Llama-3.2-1B-Instruct

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -3084,7 +3084,7 @@ Examples
   $ hf models ls --search "llama" --author meta-llama
   $ hf models ls --pipeline-tag text-generation --warm
   $ hf models ls --num-parameters min:6B,max:128B --sort likes
-  $ hf models ls --no-gated --author meta-llama
+  $ hf models ls --no-gated --author google
   $ hf models ls --apps llama.cpp --apps vllm
   $ hf models ls --inference-provider fireworks-ai --sort downloads
   $ hf models ls --warm --search llama

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -3063,6 +3063,9 @@ $ hf models list [OPTIONS] [REPO_ID]
 * `--search TEXT`: Search query.
 * `--author TEXT`: Filter by author or organization.
 * `--filter TEXT`: Filter by tags (e.g. 'text-classification'). Can be used multiple times.
+* `--pipeline-tag TEXT`: Filter by pipeline tag (canonical task), e.g. 'summarization'.
+* `--gated / --no-gated`: Filter by gated status. '--gated' for gated only, '--no-gated' for non-gated only.
+* `--apps TEXT`: Filter by app(s) that can run the model, e.g. 'ollama' or 'vllm'.
 * `--num-parameters TEXT`: Filter by parameter count, e.g. 'min:6B,max:128B'.
 * `--inference-provider [cerebras|cohere|deepinfra|fal-ai|featherless-ai|fireworks-ai|groq|hf-inference|novita|nscale|openai|ovhcloud|publicai|replicate|scaleway|together|wavespeed|zai-org]`: Filter by inference provider(s) serving the model, e.g. 'fireworks-ai'.
 * `--warm`: Only list models currently served by at least one inference provider.
@@ -3079,7 +3082,11 @@ $ hf models list [OPTIONS] [REPO_ID]
 Examples
   $ hf models ls --sort downloads --limit 10
   $ hf models ls --search "llama" --author meta-llama
+  $ hf models ls --pipeline-tag summarization --sort downloads
+  $ hf models ls --pipeline-tag text-generation --warm
   $ hf models ls --num-parameters min:6B,max:128B --sort likes
+  $ hf models ls --gated --author meta-llama
+  $ hf models ls --apps ollama --apps vllm
   $ hf models ls --inference-provider fireworks-ai --sort downloads
   $ hf models ls --warm --search llama
   $ hf models ls meta-llama/Llama-3.2-1B-Instruct

--- a/src/huggingface_hub/cli/models.py
+++ b/src/huggingface_hub/cli/models.py
@@ -68,7 +68,7 @@ models_cli = typer_factory(help="Interact with models on the Hub.")
         'hf models ls --search "llama" --author meta-llama',
         "hf models ls --pipeline-tag text-generation --warm",
         "hf models ls --num-parameters min:6B,max:128B --sort likes",
-        "hf models ls --no-gated --author meta-llama",
+        "hf models ls --no-gated --author google",
         "hf models ls --apps llama.cpp --apps vllm",
         "hf models ls --inference-provider fireworks-ai --sort downloads",
         "hf models ls --warm --search llama",

--- a/src/huggingface_hub/cli/models.py
+++ b/src/huggingface_hub/cli/models.py
@@ -66,11 +66,10 @@ models_cli = typer_factory(help="Interact with models on the Hub.")
     examples=[
         "hf models ls --sort downloads --limit 10",
         'hf models ls --search "llama" --author meta-llama',
-        "hf models ls --pipeline-tag summarization --sort downloads",
         "hf models ls --pipeline-tag text-generation --warm",
         "hf models ls --num-parameters min:6B,max:128B --sort likes",
-        "hf models ls --gated --author meta-llama",
-        "hf models ls --apps ollama --apps vllm",
+        "hf models ls --no-gated --author meta-llama",
+        "hf models ls --apps llama.cpp --apps vllm",
         "hf models ls --inference-provider fireworks-ai --sort downloads",
         "hf models ls --warm --search llama",
         "hf models ls meta-llama/Llama-3.2-1B-Instruct",

--- a/src/huggingface_hub/cli/models.py
+++ b/src/huggingface_hub/cli/models.py
@@ -66,7 +66,11 @@ models_cli = typer_factory(help="Interact with models on the Hub.")
     examples=[
         "hf models ls --sort downloads --limit 10",
         'hf models ls --search "llama" --author meta-llama',
+        "hf models ls --pipeline-tag summarization --sort downloads",
+        "hf models ls --pipeline-tag text-generation --warm",
         "hf models ls --num-parameters min:6B,max:128B --sort likes",
+        "hf models ls --gated --author meta-llama",
+        "hf models ls --apps ollama --apps vllm",
         "hf models ls --inference-provider fireworks-ai --sort downloads",
         "hf models ls --warm --search llama",
         "hf models ls meta-llama/Llama-3.2-1B-Instruct",
@@ -82,6 +86,21 @@ def models_ls(
     search: SearchOpt = None,
     author: AuthorOpt = None,
     filter: FilterOpt = None,
+    pipeline_tag: Annotated[
+        str | None,
+        Option("--pipeline-tag", help="Filter by pipeline tag (canonical task), e.g. 'summarization'."),
+    ] = None,
+    gated: Annotated[
+        bool | None,
+        Option(
+            "--gated/--no-gated",
+            help="Filter by gated status. '--gated' for gated only, '--no-gated' for non-gated only.",
+        ),
+    ] = None,
+    apps: Annotated[
+        list[str] | None,
+        Option("--apps", help="Filter by app(s) that can run the model, e.g. 'ollama' or 'vllm'."),
+    ] = None,
     num_parameters: Annotated[
         str | None,
         Option(help="Filter by parameter count, e.g. 'min:6B,max:128B'."),
@@ -131,6 +150,12 @@ def models_ls(
             raise click.BadParameter("Cannot use --author when listing files.")
         if filter is not None:
             raise click.BadParameter("Cannot use --filter when listing files.")
+        if pipeline_tag is not None:
+            raise click.BadParameter("Cannot use --pipeline-tag when listing files.")
+        if gated is not None:
+            raise click.BadParameter("Cannot use --gated/--no-gated when listing files.")
+        if apps is not None:
+            raise click.BadParameter("Cannot use --apps when listing files.")
         if num_parameters is not None:
             raise click.BadParameter("Cannot use --num-parameters when listing files.")
         if inference_provider is not None:
@@ -171,6 +196,9 @@ def models_ls(
             filter=filter,
             author=author,
             search=search,
+            pipeline_tag=pipeline_tag,
+            gated=gated,
+            apps=apps,
             num_parameters=num_parameters,
             inference="warm" if warm else None,
             inference_provider=inference_provider,


### PR DESCRIPTION
Closes #4511

Add `--pipeline-tag`, `--gated/--no-gated`, and `--apps` filters to `hf models ls`, mapping to the existing `HfApi.list_models` params.
```
$ hf models ls --pipeline-tag summarization --limit 3
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Thin CLI wiring to existing API parameters plus validation and documentation; no new Hub protocol or auth behavior.
> 
> **Overview**
> Extends **`hf models ls`** (Hub model listing mode) with three filters that were already supported on **`HfApi.list_models`** but missing from the CLI: **`--pipeline-tag`**, **`--gated` / `--no-gated`**, and repeatable **`--apps`**.
> 
> Those options are forwarded into **`api.list_models(...)`** alongside existing filters. When **`hf models ls`** is used with a **`REPO_ID`** to list files in a repo, the new flags are rejected with **`BadParameter`**, consistent with other Hub-only list options.
> 
> User-facing docs in **`docs/source/en/guides/cli.md`** and **`docs/source/en/package_reference/cli.md`** are updated with examples and option reference entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e28198e3c12382976b69684dbcfa898c227d19b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->