### PR TITLE
[Utils] Add `get_cached_repo_tree` utility

### DIFF
--- a/docs/source/en/package_reference/file_download.md
+++ b/docs/source/en/package_reference/file_download.md
@@ -18,6 +18,10 @@ rendered properly in your Markdown viewer.
 
 [[autodoc]] huggingface_hub.snapshot_download
 
+## Read the cached repo tree
+
+[[autodoc]] huggingface_hub.get_cached_repo_tree
+
 ## Get metadata about a file
 
 ### get_hf_file_metadata

--- a/docs/source/en/package_reference/utilities.md
+++ b/docs/source/en/package_reference/utilities.md
@@ -233,6 +233,10 @@ user as possible.
 
 [[autodoc]] huggingface_hub.errors.IncompleteSnapshotError
 
+#### CachedRepoTreeNotFoundError
+
+[[autodoc]] huggingface_hub.errors.CachedRepoTreeNotFoundError
+
 #### OfflineModeIsEnabled
 
 [[autodoc]] huggingface_hub.errors.OfflineModeIsEnabled

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -109,6 +109,7 @@ _SUBMOD_ATTRS = {
         "SandboxProcess",
     ],
     "_snapshot_download": [
+        "get_cached_repo_tree",
         "snapshot_download",
     ],
     "_space_api": [
@@ -998,6 +999,7 @@ __all__ = [
     "get_async_session",
     "get_bucket_file_metadata",
     "get_bucket_paths_info",
+    "get_cached_repo_tree",
     "get_collection",
     "get_dataset_leaderboard",
     "get_dataset_tags",
@@ -1296,7 +1298,10 @@ if TYPE_CHECKING:  # pragma: no cover
         SandboxPool,  # noqa: F401
         SandboxProcess,  # noqa: F401
     )
-    from ._snapshot_download import snapshot_download  # noqa: F401
+    from ._snapshot_download import (
+        get_cached_repo_tree,  # noqa: F401
+        snapshot_download,  # noqa: F401
+    )
     from ._space_api import (
         SpaceHardware,  # noqa: F401
         SpaceRuntime,  # noqa: F401

--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -578,6 +578,7 @@ def get_cached_repo_tree(
     repo_type: str | None = None,
     revision: str | None = None,
     cache_dir: str | Path | None = None,
+    local_dir: str | Path | None = None,
 ) -> list[RepoFile]:
     """Return the cached tree listing of a repo at a given revision, without any network call.
 
@@ -598,6 +599,10 @@ def get_cached_repo_tree(
             default branch. Branch/tag names are resolved to a commit hash using the local cache (`refs/`).
         cache_dir (`str`, `Path`, *optional*):
             Path to the folder where cached files are stored. Defaults to the value of `HF_HUB_CACHE`.
+        local_dir (`str` or `Path`, *optional*):
+            If provided, read the tree listing cached by a `local_dir` download (from
+            `local_dir/.cache/huggingface/`) instead of the main cache. Branch/tag revisions are still resolved
+            to a commit hash using the main cache (`cache_dir`).
 
     Returns:
         `list[RepoFile]`: The list of [`RepoFile`] objects cached for this revision.
@@ -617,6 +622,8 @@ def get_cached_repo_tree(
     if cache_dir is None:
         cache_dir = constants.HF_HUB_CACHE
     cache_dir = str(Path(cache_dir).expanduser().resolve())
+    if local_dir is not None:
+        local_dir = str(Path(local_dir).expanduser().resolve())
     if revision is None:
         revision = constants.DEFAULT_REVISION
     if repo_type is None:
@@ -627,6 +634,10 @@ def get_cached_repo_tree(
         )
 
     storage_folder = os.path.join(cache_dir, repo_folder_name(repo_id=repo_id, repo_type=repo_type))
+
+    # For `local_dir` downloads the tree listing lives under `local_dir/.cache/huggingface/`; otherwise it lives
+    # in the per-repo `storage_folder`. Refs are always recorded in the main cache, so we resolve them there.
+    tree_cache_folder = tree_cache_folder_for_local_dir(local_dir) if local_dir is not None else storage_folder
 
     # The tree cache is keyed by commit hash. Resolve the revision to a commit hash: either it already is one,
     # or it's a branch/tag name recorded in `refs/` by a previous download.
@@ -643,11 +654,11 @@ def get_cached_repo_tree(
         with open(ref_path) as f:
             commit_hash = f.read()
 
-    tree_entries = read_tree_cache(storage_folder, commit_hash)
+    tree_entries = read_tree_cache(tree_cache_folder, commit_hash)
     if tree_entries is None:
         raise CachedRepoTreeNotFoundError(
             f"No cached tree listing found for '{repo_id}' (revision '{revision}', commit '{commit_hash}', "
-            f"repo_type '{repo_type}') in '{storage_folder}'. Download the repo (e.g. with `snapshot_download`) "
+            f"repo_type '{repo_type}') in '{tree_cache_folder}'. Download the repo (e.g. with `snapshot_download`) "
             "to populate the cache first."
         )
 

--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -9,6 +9,7 @@ from tqdm.contrib.concurrent import thread_map
 from . import constants
 from ._tree_cache import TreeCacheEntry, read_tree_cache, tree_cache_folder_for_local_dir, write_tree_cache
 from .errors import (
+    CachedRepoTreeNotFoundError,
     DryRunError,
     GatedRepoError,
     HfHubHTTPError,
@@ -568,6 +569,98 @@ def _raise_if_incomplete_snapshot(
         f"{len(missing)} file(s) are missing ({sample}). {reason} Re-run the download with network access "
         "to complete the snapshot."
     ) from api_call_error
+
+
+@validate_hf_hub_args
+def get_cached_repo_tree(
+    repo_id: str,
+    *,
+    repo_type: str | None = None,
+    revision: str | None = None,
+    cache_dir: str | Path | None = None,
+) -> list[RepoFile]:
+    """Return the cached tree listing of a repo at a given revision, without any network call.
+
+    The tree listing is the set of files (with their download metadata) of a repo at a commit. It is populated
+    on disk as a side effect of [`snapshot_download`] (see the `trees/<commit_hash>.json` cache files) and is
+    used to skip network calls on subsequent downloads. This function exposes that cache directly.
+
+    Unlike [`HfApi.list_repo_tree`], it never hits the Hub: it always returns the **full** list of files as
+    [`RepoFile`] objects (never [`RepoFolder`]), and does not support recursion/expand/path filtering options —
+    everything cached is returned. This is a power-user helper; if you need a fresh, filterable listing, use
+    [`HfApi.list_repo_tree`] instead.
+
+    Args:
+        repo_id (`str`):
+            A user or an organization name and a repo name separated by a `/`.
+        repo_type (`str`, *optional*):
+            Set to `"dataset"`, `"space"` or `"kernel"` if listing from a dataset, space or kernel repo,
+            `None` or `"model"` if listing from a model. Default is `None`.
+        revision (`str`, *optional*):
+            An optional Git revision id, which can be a branch name, a tag, or a commit hash. Defaults to the
+            default branch. Branch/tag names are resolved to a commit hash using the local cache (`refs/`).
+        cache_dir (`str`, `Path`, *optional*):
+            Path to the folder where cached files are stored. Defaults to the value of `HF_HUB_CACHE`.
+
+    Returns:
+        `list[RepoFile]`: The list of files cached for this revision.
+
+    Raises:
+        [`~errors.CachedRepoTreeNotFoundError`]
+            If no tree listing is cached for the requested revision (e.g. the repo was never downloaded at
+            this revision).
+
+    Example:
+        ```py
+        >>> from huggingface_hub import get_cached_repo_tree
+        >>> files = get_cached_repo_tree("gpt2")
+        >>> [f.path for f in files]
+        ['.gitattributes', 'config.json', 'model.safetensors', ...]
+        ```
+    """
+    if cache_dir is None:
+        cache_dir = constants.HF_HUB_CACHE
+    cache_dir = str(Path(cache_dir).expanduser().resolve())
+    if revision is None:
+        revision = constants.DEFAULT_REVISION
+    if repo_type is None:
+        repo_type = "model"
+
+    storage_folder = os.path.join(cache_dir, repo_folder_name(repo_id=repo_id, repo_type=repo_type))
+
+    # The tree cache is keyed by commit hash. Resolve the revision to a commit hash: either it already is one,
+    # or it's a branch/tag name recorded in `refs/` by a previous download.
+    if REGEX_COMMIT_HASH.match(revision):
+        commit_hash = revision
+    else:
+        ref_path = os.path.join(storage_folder, "refs", revision)
+        if not os.path.isfile(ref_path):
+            raise CachedRepoTreeNotFoundError(
+                f"No cached tree listing found for '{repo_id}' (revision '{revision}', repo_type '{repo_type}'): "
+                f"the revision is not a commit hash and no matching ref is cached in '{storage_folder}'. "
+                "Download the repo (e.g. with `snapshot_download`) to populate the cache first."
+            )
+        with open(ref_path) as f:
+            commit_hash = f.read()
+
+    tree_entries = read_tree_cache(storage_folder, commit_hash)
+    if tree_entries is None:
+        raise CachedRepoTreeNotFoundError(
+            f"No cached tree listing found for '{repo_id}' (revision '{revision}', commit '{commit_hash}', "
+            f"repo_type '{repo_type}') in '{storage_folder}'. Download the repo (e.g. with `snapshot_download`) "
+            "to populate the cache first."
+        )
+
+    return [_tree_cache_entry_to_repo_file(path, entry) for path, entry in tree_entries.items()]
+
+
+def _tree_cache_entry_to_repo_file(path: str, entry: TreeCacheEntry) -> RepoFile:
+    """Rebuild a [`RepoFile`] from a cached tree entry (only the fields stored in the cache are populated)."""
+    kwargs: dict = {"path": path, "size": entry.size, "oid": entry.blob_id, "xetHash": entry.xet_hash}
+    if entry.lfs_sha256 is not None:
+        # `pointerSize` is not stored in the tree cache, hence set to `None`.
+        kwargs["lfs"] = {"size": entry.lfs_size, "oid": entry.lfs_sha256, "pointerSize": None}
+    return RepoFile(**kwargs)
 
 
 def _local_file_exists(base_dir: str, path: str) -> bool:

--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -585,10 +585,7 @@ def get_cached_repo_tree(
     on disk as a side effect of [`snapshot_download`] (see the `trees/<commit_hash>.json` cache files) and is
     used to skip network calls on subsequent downloads. This function exposes that cache directly.
 
-    Unlike [`HfApi.list_repo_tree`], it never hits the Hub: it always returns the **full** list of files as
-    [`RepoFile`] objects (never [`RepoFolder`]), and does not support recursion/expand/path filtering options —
-    everything cached is returned. This is a power-user helper; if you need a fresh, filterable listing, use
-    [`HfApi.list_repo_tree`] instead.
+    If you need the current tree listing of a repo on the Hub, use [`list_repo_tree`] instead.
 
     Args:
         repo_id (`str`):
@@ -603,17 +600,16 @@ def get_cached_repo_tree(
             Path to the folder where cached files are stored. Defaults to the value of `HF_HUB_CACHE`.
 
     Returns:
-        `list[RepoFile]`: The list of files cached for this revision.
+        `list[RepoFile]`: The list of [`RepoFile`] objects cached for this revision.
 
     Raises:
         [`~errors.CachedRepoTreeNotFoundError`]
-            If no tree listing is cached for the requested revision (e.g. the repo was never downloaded at
-            this revision).
+            If no tree listing is cached for the requested revision (e.g. the repo was never downloaded at this revision).
 
     Example:
         ```py
         >>> from huggingface_hub import get_cached_repo_tree
-        >>> files = get_cached_repo_tree("gpt2")
+        >>> files = get_cached_repo_tree("openai-community/gpt2")
         >>> [f.path for f in files]
         ['.gitattributes', 'config.json', 'model.safetensors', ...]
         ```
@@ -624,7 +620,11 @@ def get_cached_repo_tree(
     if revision is None:
         revision = constants.DEFAULT_REVISION
     if repo_type is None:
-        repo_type = "model"
+        repo_type = constants.REPO_TYPE_MODEL
+    if repo_type not in constants.REPO_TYPES_WITH_KERNEL:
+        raise ValueError(
+            f"Invalid repo type: {repo_type}. Accepted repo types are: {str(constants.REPO_TYPES_WITH_KERNEL)}"
+        )
 
     storage_folder = os.path.join(cache_dir, repo_folder_name(repo_id=repo_id, repo_type=repo_type))
 
@@ -651,16 +651,10 @@ def get_cached_repo_tree(
             "to populate the cache first."
         )
 
-    return [_tree_cache_entry_to_repo_file(path, entry) for path, entry in tree_entries.items()]
-
-
-def _tree_cache_entry_to_repo_file(path: str, entry: TreeCacheEntry) -> RepoFile:
-    """Rebuild a [`RepoFile`] from a cached tree entry (only the fields stored in the cache are populated)."""
-    kwargs: dict = {"path": path, "size": entry.size, "oid": entry.blob_id, "xetHash": entry.xet_hash}
-    if entry.lfs_sha256 is not None:
-        # `pointerSize` is not stored in the tree cache, hence set to `None`.
-        kwargs["lfs"] = {"size": entry.lfs_size, "oid": entry.lfs_sha256, "pointerSize": None}
-    return RepoFile(**kwargs)
+    return [
+        RepoFile(path=path, size=entry.size, oid=entry.blob_id, xetHash=entry.xet_hash)
+        for path, entry in tree_entries.items()
+    ]
 
 
 def _local_file_exists(base_dir: str, path: str) -> bool:

--- a/src/huggingface_hub/errors.py
+++ b/src/huggingface_hub/errors.py
@@ -26,8 +26,7 @@ class CorruptedCacheException(Exception):
 class CachedRepoTreeNotFoundError(Exception):
     """Raised by [`get_cached_repo_tree`] when no tree listing is cached for the requested revision.
 
-    The tree listing is populated as a side effect of [`snapshot_download`] (or [`hf_hub_download`]); if the
-    repository has never been downloaded at this revision, there is nothing to return from the cache.
+    The tree listing is populated as a side effect of [`snapshot_download`].
     """
 
 

--- a/src/huggingface_hub/errors.py
+++ b/src/huggingface_hub/errors.py
@@ -23,6 +23,14 @@ class CorruptedCacheException(Exception):
     """Exception for any unexpected structure in the Huggingface cache-system."""
 
 
+class CachedRepoTreeNotFoundError(Exception):
+    """Raised by [`get_cached_repo_tree`] when no tree listing is cached for the requested revision.
+
+    The tree listing is populated as a side effect of [`snapshot_download`] (or [`hf_hub_download`]); if the
+    repository has never been downloaded at this revision, there is nothing to return from the cache.
+    """
+
+
 # HEADERS ERRORS
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1562,6 +1562,7 @@ class TestRepoCreateCommand:
             space_secrets=None,
             space_variables=None,
             space_volumes=None,
+            space_template=None,
         )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1539,6 +1539,7 @@ class TestRepoCreateCommand:
             space_secrets=[{"key": "HF_TOKEN", "value": "secret_val"}],
             space_variables=[{"key": "THEME", "value": "dark"}, {"key": "DEBUG", "value": "1"}],
             space_volumes=[Volume(type="model", source="org/gpt2", mount_path="/model", read_only=None, path=None)],
+            space_template=None,
         )
 
     def test_repo_create_without_space_options(self, runner: CliRunner) -> None:

--- a/tests/test_tree_cache.py
+++ b/tests/test_tree_cache.py
@@ -17,6 +17,7 @@ from unittest.mock import patch
 
 import pytest
 
+from huggingface_hub import RepoFile, get_cached_repo_tree
 from huggingface_hub._tree_cache import (
     _IN_MEMORY_TREE_CACHE,
     TREE_CACHE_FORMAT_VERSION,
@@ -25,6 +26,7 @@ from huggingface_hub._tree_cache import (
     tree_cache_folder_for_local_dir,
     write_tree_cache,
 )
+from huggingface_hub.errors import CachedRepoTreeNotFoundError
 from huggingface_hub.file_download import (
     _get_metadata_or_catch_error,
     _xet_file_metadata_from_tree_cache,
@@ -233,6 +235,50 @@ class TestTreeCacheSkipsHeadCall:
                     local_files_only=False,
                     tree_cache_folder=tree_cache_folder,
                 )
+
+
+class TestGetCachedRepoTree:
+    def test_returns_cached_files_as_repo_files(self, tmp_path: Path):
+        storage_folder = tmp_path / repo_folder_name(repo_id="user/repo", repo_type="model")
+        write_tree_cache(str(storage_folder), COMMIT_HASH, _entries())
+
+        files = get_cached_repo_tree("user/repo", revision=COMMIT_HASH, cache_dir=str(tmp_path))
+
+        assert all(isinstance(f, RepoFile) for f in files)
+        by_path = {f.path: f for f in files}
+        assert set(by_path) == {"config.json", "model.safetensors"}
+
+        config = by_path["config.json"]
+        assert config.size == 5
+        assert config.blob_id == "blob-config"
+        assert config.lfs is None
+
+        model = by_path["model.safetensors"]
+        assert model.size == 42
+        assert model.blob_id == "blob-model"
+        assert model.xet_hash == "xet-model"
+        assert model.lfs is not None
+        assert model.lfs.sha256 == "sha256-model"
+        assert model.lfs.size == 1024
+
+    def test_resolves_branch_via_refs(self, tmp_path: Path):
+        storage_folder = tmp_path / repo_folder_name(repo_id="user/repo", repo_type="model")
+        write_tree_cache(str(storage_folder), COMMIT_HASH, _entries())
+        ref_path = storage_folder / "refs" / "main"
+        ref_path.parent.mkdir(parents=True)
+        ref_path.write_text(COMMIT_HASH)
+
+        files = get_cached_repo_tree("user/repo", revision="main", cache_dir=str(tmp_path))
+        assert {f.path for f in files} == {"config.json", "model.safetensors"}
+
+    def test_raises_when_commit_not_cached(self, tmp_path: Path):
+        with pytest.raises(CachedRepoTreeNotFoundError):
+            get_cached_repo_tree("user/repo", revision=COMMIT_HASH, cache_dir=str(tmp_path))
+
+    def test_raises_when_branch_not_cached(self, tmp_path: Path):
+        # No `refs/main` on disk => cannot resolve the branch to a commit hash.
+        with pytest.raises(CachedRepoTreeNotFoundError):
+            get_cached_repo_tree("user/repo", revision="main", cache_dir=str(tmp_path))
 
 
 class TestTreeCacheForLocalDir:

--- a/tests/test_tree_cache.py
+++ b/tests/test_tree_cache.py
@@ -257,9 +257,7 @@ class TestGetCachedRepoTree:
         assert model.size == 42
         assert model.blob_id == "blob-model"
         assert model.xet_hash == "xet-model"
-        assert model.lfs is not None
-        assert model.lfs.sha256 == "sha256-model"
-        assert model.lfs.size == 1024
+        assert model.lfs is None
 
     def test_resolves_branch_via_refs(self, tmp_path: Path):
         storage_folder = tmp_path / repo_folder_name(repo_id="user/repo", repo_type="model")


### PR DESCRIPTION
Follow-up PR after https://github.com/huggingface/huggingface_hub/pull/4394.

This PR adds a utility to retrieve the cached repo tree from snapshot_download. First mentioned in https://github.com/huggingface/diffusers/pull/14118#discussion_r3542459656. Should help `diffusers` integration to define the structure of repo (with its variants, etc.) even in offline mode. cc @sayakpaul 

## Summary

Adds a power-user helper `get_cached_repo_tree(repo_id, repo_type=..., revision=..., cache_dir=...)` that returns the repo's cached `/tree` listing (populated as a side effect of `snapshot_download`) as a `list[RepoFile]`, without any network call.

- Kept separate from `HfApi.list_repo_tree`: it always returns the **full** list, `RepoFile` only (no `RepoFolder`), and has no `recursive`/`expand`/`path`/... options — everything cached is returned.
- Raises a new `errors.CachedRepoTreeNotFoundError` when nothing is cached for the requested revision.

## Example

```py
>>> from huggingface_hub import snapshot_download, get_cached_repo_tree
>>> snapshot_download("gpt2")
>>> files = get_cached_repo_tree("openai-community/gpt2")
>>> [f.path for f in files][:3]
['.gitattributes', '64-8bits.tflite', '64-fp16.tflite']

>>> get_cached_repo_tree("gpt2", revision="does-not-exist")
huggingface_hub.errors.CachedRepoTreeNotFoundError: No cached tree listing found for 'openai-community/gpt2' ...
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive public API over existing on-disk tree cache; read-only local filesystem access with clear errors when cache is missing.
> 
> **Overview**
> Adds **`get_cached_repo_tree`**, a read-only helper that returns the full cached repo file tree as `list[RepoFile]` from the `trees/<commit_hash>.json` data written by **`snapshot_download`**, with no Hub request. Revisions can be commit hashes or branch/tag names resolved via cached `refs/`; **`local_dir`** reads trees from `local_dir/.cache/huggingface/` while still resolving refs from the main cache.
> 
> Introduces **`CachedRepoTreeNotFoundError`** when no ref or tree cache exists, documents both in the package reference, exports **`get_cached_repo_tree`** from the public API, and adds unit tests in **`test_tree_cache.py`**. CLI repo-create tests expect **`space_template=None`** on **`create_repo`** (unrelated assertion fix).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65571288b3de591d40c9b633f889247c2a11ef80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->