### PR TITLE
Mention the hf CLI in the README quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,14 @@ upload_folder(
 
 For details in the [upload guide](https://huggingface.co/docs/huggingface_hub/en/guides/upload).
 
+### Use the CLI
+
+The `huggingface_hub` package comes with a built-in CLI called [`hf`](https://huggingface.co/docs/huggingface_hub/en/guides/cli) to interact with the Hub directly from the terminal:
+
+```bash
+hf --help
+```
+
 ## Integrating to the Hub.
 
 We're partnering with cool open source ML libraries to provide free model hosting and versioning. You can find the existing integrations [here](https://huggingface.co/docs/hub/libraries).


### PR DESCRIPTION
Small addition to the README to mention the `hf` CLI.

Could maybe mention more, but good to flag the entry point at least? Wording mirrors the CLI guide's opening sentence.

(Translated READMEs left untouched.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README change with no runtime or API impact.
> 
> **Overview**
> Adds a **Use the CLI** subsection to the README **Quick start**, right after the upload examples.
> 
> It points readers to the built-in **`hf`** CLI and the [CLI guide](https://huggingface.co/docs/huggingface_hub/en/guides/cli), with a sample `hf --help` command. Wording aligns with the CLI guide intro. Translated READMEs are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 207d2973bb5721ec7adb6351e3ae7e91f2255adb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->