### PR TITLE
[Inference] Expose a close() handle on streaming responses

### DIFF
--- a/docs/source/en/package_reference/inference_client.md
+++ b/docs/source/en/package_reference/inference_client.md
@@ -27,3 +27,19 @@ An async version of the client is also provided, based on `asyncio` and `httpx`.
 ## InferenceTimeoutError
 
 [[autodoc]] InferenceTimeoutError
+
+## InferenceStream
+
+Object returned by [`InferenceClient.chat_completion`] and [`InferenceClient.text_generation`] when `stream=True`.
+In addition to being iterable, it exposes a `close()` method to cancel the stream early and release the underlying
+HTTP connection.
+
+[[autodoc]] InferenceStream
+
+## AsyncInferenceStream
+
+Async equivalent of [`InferenceStream`], returned by [`AsyncInferenceClient.chat_completion`] and
+[`AsyncInferenceClient.text_generation`] when `stream=True`. `close()` can safely be called from another task
+while the stream is being iterated.
+
+[[autodoc]] AsyncInferenceStream

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -381,6 +381,10 @@ _SUBMOD_ATTRS = {
         "InferenceClient",
         "InferenceTimeoutError",
     ],
+    "inference._common": [
+        "AsyncInferenceStream",
+        "InferenceStream",
+    ],
     "inference._generated._async_client": [
         "AsyncInferenceClient",
     ],
@@ -637,6 +641,7 @@ __all__ = [
     "ASYNC_CLIENT_FACTORY_T",
     "Agent",
     "AsyncInferenceClient",
+    "AsyncInferenceStream",
     "AudioClassificationInput",
     "AudioClassificationOutputElement",
     "AudioClassificationOutputTransform",
@@ -783,6 +788,7 @@ __all__ = [
     "InferenceEndpointStatus",
     "InferenceEndpointTimeoutError",
     "InferenceEndpointType",
+    "InferenceStream",
     "InferenceTimeoutError",
     "JobAccelerator",
     "JobDurations",
@@ -1568,6 +1574,10 @@ if TYPE_CHECKING:  # pragma: no cover
     from .inference._client import (
         InferenceClient,  # noqa: F401
         InferenceTimeoutError,  # noqa: F401
+    )
+    from .inference._common import (
+        AsyncInferenceStream,  # noqa: F401
+        InferenceStream,  # noqa: F401
     )
     from .inference._generated._async_client import AsyncInferenceClient  # noqa: F401
     from .inference._generated.types import (

--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -36,15 +36,17 @@ import logging
 import os
 import re
 import warnings
-from collections.abc import Iterable
 from contextlib import ExitStack
 from typing import TYPE_CHECKING, Any, Literal, Optional, Union, overload
+
+import httpx
 
 from huggingface_hub import constants
 from huggingface_hub.errors import BadRequestError, HfHubHTTPError, InferenceTimeoutError
 from huggingface_hub.inference._common import (
     TASKS_EXPECTING_IMAGES,
     ContentT,
+    InferenceStream,
     RequestParameters,
     _b64_encode,
     _b64_to_image,
@@ -257,12 +259,14 @@ class InferenceClient:
     @overload
     def _inner_post(  # type: ignore[misc]
         self, request_parameters: RequestParameters, *, stream: Literal[True] = ...
-    ) -> Iterable[str]: ...
+    ) -> httpx.Response: ...
 
     @overload
-    def _inner_post(self, request_parameters: RequestParameters, *, stream: bool = False) -> bytes | Iterable[str]: ...
+    def _inner_post(
+        self, request_parameters: RequestParameters, *, stream: bool = False
+    ) -> bytes | httpx.Response: ...
 
-    def _inner_post(self, request_parameters: RequestParameters, *, stream: bool = False) -> bytes | Iterable[str]:
+    def _inner_post(self, request_parameters: RequestParameters, *, stream: bool = False) -> bytes | httpx.Response:
         """Make a request to the inference server."""
         # TODO: this should be handled in provider helpers directly
         if request_parameters.task in TASKS_EXPECTING_IMAGES and "Accept" not in request_parameters.headers:
@@ -282,7 +286,7 @@ class InferenceClient:
             )
             hf_raise_for_status(response)
             if stream:
-                return response.iter_lines()
+                return response
             else:
                 return response.read()
         except TimeoutError as error:
@@ -504,7 +508,7 @@ class InferenceClient:
         top_logprobs: int | None = None,
         top_p: float | None = None,
         extra_body: dict | None = None,
-    ) -> Iterable[ChatCompletionStreamOutput]: ...
+    ) -> InferenceStream[ChatCompletionStreamOutput]: ...
 
     @overload
     def chat_completion(
@@ -530,7 +534,7 @@ class InferenceClient:
         top_logprobs: int | None = None,
         top_p: float | None = None,
         extra_body: dict | None = None,
-    ) -> ChatCompletionOutput | Iterable[ChatCompletionStreamOutput]: ...
+    ) -> ChatCompletionOutput | InferenceStream[ChatCompletionStreamOutput]: ...
 
     def chat_completion(
         self,
@@ -556,7 +560,7 @@ class InferenceClient:
         top_logprobs: int | None = None,
         top_p: float | None = None,
         extra_body: dict | None = None,
-    ) -> ChatCompletionOutput | Iterable[ChatCompletionStreamOutput]:
+    ) -> ChatCompletionOutput | InferenceStream[ChatCompletionStreamOutput]:
         """
         A method for completing conversations using a specified language model.
 
@@ -629,6 +633,8 @@ class InferenceClient:
             Generated text returned from the server:
             - if `stream=False`, the generated text is returned as a [`ChatCompletionOutput`] (default).
             - if `stream=True`, the generated text is returned token by token as a sequence of [`ChatCompletionStreamOutput`].
+              The returned object also exposes a `close()` method to cancel the stream early and release the
+              underlying HTTP connection.
 
         Raises:
             [`InferenceTimeoutError`]:
@@ -1975,7 +1981,7 @@ class InferenceClient:
         truncate: int | None = None,
         typical_p: float | None = None,
         watermark: bool | None = None,
-    ) -> Iterable[TextGenerationStreamOutput]: ...
+    ) -> InferenceStream[TextGenerationStreamOutput]: ...
 
     @overload
     def text_generation(
@@ -2035,7 +2041,7 @@ class InferenceClient:
         truncate: int | None = None,
         typical_p: float | None = None,
         watermark: bool | None = None,
-    ) -> Iterable[str]: ...
+    ) -> InferenceStream[str]: ...
 
     @overload
     def text_generation(
@@ -2095,7 +2101,7 @@ class InferenceClient:
         truncate: int | None = None,
         typical_p: float | None = None,
         watermark: bool | None = None,
-    ) -> str | TextGenerationOutput | Iterable[str] | Iterable[TextGenerationStreamOutput]: ...
+    ) -> str | TextGenerationOutput | InferenceStream[str] | InferenceStream[TextGenerationStreamOutput]: ...
 
     def text_generation(
         self,
@@ -2124,7 +2130,7 @@ class InferenceClient:
         truncate: int | None = None,
         typical_p: float | None = None,
         watermark: bool | None = None,
-    ) -> str | TextGenerationOutput | Iterable[str] | Iterable[TextGenerationStreamOutput]:
+    ) -> str | TextGenerationOutput | InferenceStream[str] | InferenceStream[TextGenerationStreamOutput]:
         """
         Given a prompt, generate the following text.
 
@@ -2198,6 +2204,9 @@ class InferenceClient:
             - if `stream=True` and `details=False`, the generated text is returned token by token as a `Iterable[str]`
             - if `stream=False` and `details=True`, the generated text is returned with more details as a [`~huggingface_hub.TextGenerationOutput`]
             - if `details=True` and `stream=True`, the generated text is returned token by token as a iterable of [`~huggingface_hub.TextGenerationStreamOutput`]
+
+            When `stream=True`, the returned object also exposes a `close()` method to cancel the stream early and
+            release the underlying HTTP connection.
 
         Raises:
             `ValidationError`:

--- a/src/huggingface_hub/inference/_common.py
+++ b/src/huggingface_hub/inference/_common.py
@@ -18,10 +18,10 @@ import io
 import json
 import logging
 import mimetypes
-from collections.abc import AsyncIterable, Iterable
+from collections.abc import AsyncIterable, AsyncIterator, Iterable, Iterator
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, BinaryIO, Literal, NoReturn, Union, overload
+from typing import TYPE_CHECKING, Any, BinaryIO, Literal, NoReturn, TypeVar, Union, overload
 
 import httpx
 
@@ -255,33 +255,84 @@ def _as_dict(response: bytes | dict) -> dict:
 
 ## STREAMING UTILS
 
+_T = TypeVar("_T")
+
+
+class InferenceStream(Iterable[_T]):
+    """Iterable over outputs streamed by the inference server, with a handle on the underlying HTTP response.
+
+    Returned by [`InferenceClient.chat_completion`] and [`InferenceClient.text_generation`] when `stream=True`.
+    Iterate over it as over any iterable. Call [`~InferenceStream.close`] to cancel the stream before it is
+    exhausted and release the underlying HTTP connection.
+    """
+
+    def __init__(self, iterable: Iterable[_T], response: httpx.Response) -> None:
+        self._iterable = iterable
+        self._response = response
+
+    def __iter__(self) -> Iterator[_T]:
+        return iter(self._iterable)
+
+    def close(self) -> None:
+        """Cancel the stream and release the underlying HTTP connection."""
+        self._response.close()
+
+
+class AsyncInferenceStream(AsyncIterable[_T]):
+    """Async iterable over outputs streamed by the inference server, with a handle on the underlying HTTP response.
+
+    Returned by [`AsyncInferenceClient.chat_completion`] and [`AsyncInferenceClient.text_generation`] when
+    `stream=True`. Iterate over it with `async for`. Call [`~AsyncInferenceStream.close`] to cancel the stream
+    before it is exhausted and release the underlying HTTP connection. Contrary to closing the async iterator
+    itself, `close()` can safely be called from another task while the stream is being iterated.
+    """
+
+    def __init__(self, iterable: AsyncIterable[_T], response: httpx.Response) -> None:
+        self._iterable = iterable
+        self._response = response
+
+    def __aiter__(self) -> AsyncIterator[_T]:
+        return self._iterable.__aiter__()
+
+    async def close(self) -> None:
+        """Cancel the stream and release the underlying HTTP connection."""
+        await self._response.aclose()
+
 
 def _stream_text_generation_response(
-    output_lines: Iterable[str], details: bool
-) -> Iterable[str] | Iterable[TextGenerationStreamOutput]:
+    response: httpx.Response, details: bool
+) -> InferenceStream[str] | InferenceStream[TextGenerationStreamOutput]:
     """Used in `InferenceClient.text_generation`."""
-    # Parse ServerSentEvents
-    for line in output_lines:
-        try:
-            output = _format_text_generation_stream_output(line, details)
-        except StopIteration:
-            break
-        if output is not None:
-            yield output
+
+    def _iter() -> Iterator[Any]:
+        # Parse ServerSentEvents
+        for line in response.iter_lines():
+            try:
+                output = _format_text_generation_stream_output(line, details)
+            except StopIteration:
+                break
+            if output is not None:
+                yield output
+
+    return InferenceStream(_iter(), response)
 
 
-async def _async_stream_text_generation_response(
-    output_lines: AsyncIterable[str], details: bool
-) -> AsyncIterable[str] | AsyncIterable[TextGenerationStreamOutput]:
+def _async_stream_text_generation_response(
+    response: httpx.Response, details: bool
+) -> AsyncInferenceStream[str] | AsyncInferenceStream[TextGenerationStreamOutput]:
     """Used in `AsyncInferenceClient.text_generation`."""
-    # Parse ServerSentEvents
-    async for line in output_lines:
-        try:
-            output = _format_text_generation_stream_output(line, details)
-        except StopIteration:
-            break
-        if output is not None:
-            yield output
+
+    async def _aiter() -> AsyncIterator[Any]:
+        # Parse ServerSentEvents
+        async for line in response.aiter_lines():
+            try:
+                output = _format_text_generation_stream_output(line.strip(), details)
+            except StopIteration:
+                break
+            if output is not None:
+                yield output
+
+    return AsyncInferenceStream(_aiter(), response)
 
 
 def _format_text_generation_stream_output(line: str, details: bool) -> str | TextGenerationStreamOutput | None:
@@ -305,29 +356,37 @@ def _format_text_generation_stream_output(line: str, details: bool) -> str | Tex
 
 
 def _stream_chat_completion_response(
-    lines: Iterable[str],
-) -> Iterable[ChatCompletionStreamOutput]:
+    response: httpx.Response,
+) -> InferenceStream[ChatCompletionStreamOutput]:
     """Used in `InferenceClient.chat_completion` if model is served with TGI."""
-    for line in lines:
-        try:
-            output = _format_chat_completion_stream_output(line)
-        except StopIteration:
-            break
-        if output is not None:
-            yield output
+
+    def _iter() -> Iterator[ChatCompletionStreamOutput]:
+        for line in response.iter_lines():
+            try:
+                output = _format_chat_completion_stream_output(line)
+            except StopIteration:
+                break
+            if output is not None:
+                yield output
+
+    return InferenceStream(_iter(), response)
 
 
-async def _async_stream_chat_completion_response(
-    lines: AsyncIterable[str],
-) -> AsyncIterable[ChatCompletionStreamOutput]:
+def _async_stream_chat_completion_response(
+    response: httpx.Response,
+) -> AsyncInferenceStream[ChatCompletionStreamOutput]:
     """Used in `AsyncInferenceClient.chat_completion`."""
-    async for line in lines:
-        try:
-            output = _format_chat_completion_stream_output(line)
-        except StopIteration:
-            break
-        if output is not None:
-            yield output
+
+    async def _aiter() -> AsyncIterator[ChatCompletionStreamOutput]:
+        async for line in response.aiter_lines():
+            try:
+                output = _format_chat_completion_stream_output(line.strip())
+            except StopIteration:
+                break
+            if output is not None:
+                yield output
+
+    return AsyncInferenceStream(_aiter(), response)
 
 
 def _format_chat_completion_stream_output(
@@ -348,11 +407,6 @@ def _format_chat_completion_stream_output(
 
     # Or parse token payload
     return ChatCompletionStreamOutput.parse_obj_as_instance(json_payload)
-
-
-async def _async_yield_from(client: httpx.AsyncClient, response: httpx.Response) -> AsyncIterable[str]:
-    async for line in response.aiter_lines():
-        yield line.strip()
 
 
 # "TGI servers" are servers running with the `text-generation-inference` backend.

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -24,7 +24,7 @@ import os
 import re
 import warnings
 from contextlib import AsyncExitStack
-from typing import TYPE_CHECKING, Any, AsyncIterable, Literal, Optional, Union, overload
+from typing import TYPE_CHECKING, Any, Literal, Optional, Union, overload
 
 import httpx
 
@@ -32,6 +32,7 @@ from huggingface_hub import constants
 from huggingface_hub.errors import BadRequestError, HfHubHTTPError, InferenceTimeoutError
 from huggingface_hub.inference._common import (
     TASKS_EXPECTING_IMAGES,
+    AsyncInferenceStream,
     ContentT,
     RequestParameters,
     _async_stream_chat_completion_response,
@@ -96,8 +97,6 @@ from huggingface_hub.utils import (
     validate_hf_hub_args,
 )
 from huggingface_hub.utils._auth import get_token
-
-from .._common import _async_yield_from
 
 
 if TYPE_CHECKING:
@@ -262,16 +261,16 @@ class AsyncInferenceClient:
     @overload
     async def _inner_post(  # type: ignore[misc]
         self, request_parameters: RequestParameters, *, stream: Literal[True] = ...
-    ) -> AsyncIterable[str]: ...
+    ) -> httpx.Response: ...
 
     @overload
     async def _inner_post(
         self, request_parameters: RequestParameters, *, stream: bool = False
-    ) -> bytes | AsyncIterable[str]: ...
+    ) -> bytes | httpx.Response: ...
 
     async def _inner_post(
         self, request_parameters: RequestParameters, *, stream: bool = False
-    ) -> bytes | AsyncIterable[str]:
+    ) -> bytes | httpx.Response:
         """Make a request to the inference server."""
 
         # TODO: this should be handled in provider helpers directly
@@ -293,7 +292,7 @@ class AsyncInferenceClient:
                     )
                 )
                 hf_raise_for_status(response)
-                return _async_yield_from(client, response)
+                return response
             else:
                 response = await client.post(
                     request_parameters.url,
@@ -527,7 +526,7 @@ class AsyncInferenceClient:
         top_logprobs: int | None = None,
         top_p: float | None = None,
         extra_body: dict | None = None,
-    ) -> AsyncIterable[ChatCompletionStreamOutput]: ...
+    ) -> AsyncInferenceStream[ChatCompletionStreamOutput]: ...
 
     @overload
     async def chat_completion(
@@ -553,7 +552,7 @@ class AsyncInferenceClient:
         top_logprobs: int | None = None,
         top_p: float | None = None,
         extra_body: dict | None = None,
-    ) -> ChatCompletionOutput | AsyncIterable[ChatCompletionStreamOutput]: ...
+    ) -> ChatCompletionOutput | AsyncInferenceStream[ChatCompletionStreamOutput]: ...
 
     async def chat_completion(
         self,
@@ -579,7 +578,7 @@ class AsyncInferenceClient:
         top_logprobs: int | None = None,
         top_p: float | None = None,
         extra_body: dict | None = None,
-    ) -> ChatCompletionOutput | AsyncIterable[ChatCompletionStreamOutput]:
+    ) -> ChatCompletionOutput | AsyncInferenceStream[ChatCompletionStreamOutput]:
         """
         A method for completing conversations using a specified language model.
 
@@ -652,6 +651,8 @@ class AsyncInferenceClient:
             Generated text returned from the server:
             - if `stream=False`, the generated text is returned as a [`ChatCompletionOutput`] (default).
             - if `stream=True`, the generated text is returned token by token as a sequence of [`ChatCompletionStreamOutput`].
+              The returned object also exposes a `close()` method to cancel the stream early and release the
+              underlying HTTP connection.
 
         Raises:
             [`InferenceTimeoutError`]:
@@ -2020,7 +2021,7 @@ class AsyncInferenceClient:
         truncate: int | None = None,
         typical_p: float | None = None,
         watermark: bool | None = None,
-    ) -> AsyncIterable[TextGenerationStreamOutput]: ...
+    ) -> AsyncInferenceStream[TextGenerationStreamOutput]: ...
 
     @overload
     async def text_generation(
@@ -2080,7 +2081,7 @@ class AsyncInferenceClient:
         truncate: int | None = None,
         typical_p: float | None = None,
         watermark: bool | None = None,
-    ) -> AsyncIterable[str]: ...
+    ) -> AsyncInferenceStream[str]: ...
 
     @overload
     async def text_generation(
@@ -2140,7 +2141,7 @@ class AsyncInferenceClient:
         truncate: int | None = None,
         typical_p: float | None = None,
         watermark: bool | None = None,
-    ) -> str | TextGenerationOutput | AsyncIterable[str] | AsyncIterable[TextGenerationStreamOutput]: ...
+    ) -> str | TextGenerationOutput | AsyncInferenceStream[str] | AsyncInferenceStream[TextGenerationStreamOutput]: ...
 
     async def text_generation(
         self,
@@ -2169,7 +2170,7 @@ class AsyncInferenceClient:
         truncate: int | None = None,
         typical_p: float | None = None,
         watermark: bool | None = None,
-    ) -> str | TextGenerationOutput | AsyncIterable[str] | AsyncIterable[TextGenerationStreamOutput]:
+    ) -> str | TextGenerationOutput | AsyncInferenceStream[str] | AsyncInferenceStream[TextGenerationStreamOutput]:
         """
         Given a prompt, generate the following text.
 
@@ -2243,6 +2244,9 @@ class AsyncInferenceClient:
             - if `stream=True` and `details=False`, the generated text is returned token by token as a `AsyncIterable[str]`
             - if `stream=False` and `details=True`, the generated text is returned with more details as a [`~huggingface_hub.TextGenerationOutput`]
             - if `details=True` and `stream=True`, the generated text is returned token by token as a iterable of [`~huggingface_hub.TextGenerationStreamOutput`]
+
+            When `stream=True`, the returned object also exposes a `close()` method to cancel the stream early and
+            release the underlying HTTP connection.
 
         Raises:
             `ValidationError`:

--- a/tests/test_inference_async_client.py
+++ b/tests/test_inference_async_client.py
@@ -27,6 +27,7 @@ import asyncio
 import inspect
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
+import httpx
 import numpy as np
 import pytest
 
@@ -42,8 +43,12 @@ from huggingface_hub import (
     InferenceTimeoutError,
     TextGenerationOutputPrefillToken,
 )
+from huggingface_hub.inference._common import (
+    AsyncInferenceStream,
+    _async_stream_chat_completion_response,
+    _get_unsupported_text_generation_kwargs,
+)
 from huggingface_hub.inference._common import ValidationError as TextGenerationValidationError
-from huggingface_hub.inference._common import _get_unsupported_text_generation_kwargs
 
 from .test_inference_client import CHAT_COMPLETE_NON_TGI_MODEL, CHAT_COMPLETION_MESSAGES, CHAT_COMPLETION_MODEL
 
@@ -437,3 +442,75 @@ async def test_use_async_with_inference_client():
         async with AsyncInferenceClient():
             pass
     mock_close.assert_called_once()
+
+
+CHAT_COMPLETION_STREAM_CHUNK = (
+    'data: {"object":"chat.completion.chunk","id":"","created":1721737661,"model":"",'
+    '"system_fingerprint":"2.1.2-dev0-sha-5fca30e","choices":[{"index":0,"delta":'
+    '{"role":"assistant","content":"Both"},"logprobs":null,"finish_reason":null}]}'
+)
+
+
+@pytest.mark.asyncio
+async def test_async_stream_close_releases_underlying_response() -> None:
+    """The object returned by async streaming calls exposes `close()` to cancel the stream early.
+
+    Regression test for https://github.com/huggingface/huggingface_hub/issues/4224.
+    """
+
+    async def aiter_lines():
+        yield CHAT_COMPLETION_STREAM_CHUNK
+        yield "data: [DONE]"
+
+    response = MagicMock(spec=httpx.Response)
+    response.aiter_lines = aiter_lines
+    response.aclose = AsyncMock()
+
+    stream = _async_stream_chat_completion_response(response)
+    assert isinstance(stream, AsyncInferenceStream)
+
+    async for chunk in stream:
+        assert chunk.choices[0].delta.content == "Both"
+        break
+
+    await stream.close()
+    response.aclose.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_async_stream_close_from_another_task() -> None:
+    """`close()` can be called from another task while the stream is being iterated.
+
+    Regression test for https://github.com/huggingface/huggingface_hub/issues/4224: closing the async
+    generator itself while it is being iterated raises `RuntimeError: aclose(): asynchronous generator
+    is already running`. Closing the underlying HTTP response must not.
+    """
+    blocked = asyncio.Event()
+
+    async def aiter_lines():
+        yield CHAT_COMPLETION_STREAM_CHUNK
+        blocked.set()
+        await asyncio.Event().wait()  # hang forever, as a stalled server would
+
+    response = MagicMock(spec=httpx.Response)
+    response.aiter_lines = aiter_lines
+    response.aclose = AsyncMock()
+
+    stream = _async_stream_chat_completion_response(response)
+    chunks = []
+
+    async def consume():
+        async for chunk in stream:
+            chunks.append(chunk)
+
+    consumer = asyncio.create_task(consume())
+    await blocked.wait()
+
+    # The stream is being iterated in `consumer`: closing it from here must not raise.
+    await stream.close()
+    response.aclose.assert_awaited_once()
+
+    consumer.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await consumer
+    assert len(chunks) == 1

--- a/tests/test_inference_client.py
+++ b/tests/test_inference_client.py
@@ -20,6 +20,7 @@ import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import httpx
 import numpy as np
 import pytest
 from PIL import Image
@@ -46,6 +47,7 @@ from huggingface_hub import (
 )
 from huggingface_hub.errors import HfHubHTTPError, ValidationError
 from huggingface_hub.inference._common import (
+    InferenceStream,
     MimeBytes,
     _as_url,
     _open_as_mime_bytes,
@@ -1016,7 +1018,9 @@ def test_stream_text_generation_response(stop_signal: bytes):
         # Won't parse after
         'data: {"index":2,"token":{"id":311,"text":" to","logprob":-0.026245117,"special":false},"generated_text":" trying to","details":null}',
     ]
-    output = list(_stream_text_generation_response(data, details=False))
+    response = MagicMock(spec=httpx.Response)
+    response.iter_lines.return_value = iter(data)
+    output = list(_stream_text_generation_response(response, details=False))
     assert len(output) == 2
     assert output == [" trying", " to"]
 
@@ -1039,7 +1043,9 @@ def test_stream_chat_completion_response(stop_signal: bytes):
         # Won't parse after
         'data: {"index":2,"token":{"id":311,"text":" to","logprob":-0.026245117,"special":false},"generated_text":" trying to","details":null}',
     ]
-    output = list(_stream_chat_completion_response(data))
+    response = MagicMock(spec=httpx.Response)
+    response.iter_lines.return_value = iter(data)
+    output = list(_stream_chat_completion_response(response))
     assert len(output) == 2
     assert output[0].choices[0].delta.content == "Both"
     assert output[1].choices[0].delta.content == " Rust"
@@ -1054,9 +1060,55 @@ def test_chat_completion_error_in_stream():
         'data: {"object":"chat.completion.chunk","id":"","created":1721737661,"model":"","system_fingerprint":"2.1.2-dev0-sha-5fca30e","choices":[{"index":0,"delta":{"role":"assistant","content":"Both"},"logprobs":null,"finish_reason":null}]}',
         'data: {"error":"Input validation error: `inputs` tokens + `max_new_tokens` must be <= 4096. Given: 6 `inputs` tokens and 4091 `max_new_tokens`","error_type":"validation"}',
     ]
+    response = MagicMock(spec=httpx.Response)
+    response.iter_lines.return_value = iter(data)
     with pytest.raises(ValidationError):
-        for token in _stream_chat_completion_response(data):
+        for token in _stream_chat_completion_response(response):
             pass
+
+
+def test_stream_close_releases_underlying_response():
+    """The object returned by streaming calls exposes `close()` to cancel the stream early.
+
+    Regression test for https://github.com/huggingface/huggingface_hub/issues/4224.
+    """
+    data = [
+        'data: {"object":"chat.completion.chunk","id":"","created":1721737661,"model":"","system_fingerprint":"2.1.2-dev0-sha-5fca30e","choices":[{"index":0,"delta":{"role":"assistant","content":"Both"},"logprobs":null,"finish_reason":null}]}',
+        'data: {"object":"chat.completion.chunk","id":"","created":1721737661,"model":"","system_fingerprint":"2.1.2-dev0-sha-5fca30e","choices":[{"index":0,"delta":{"role":"assistant","content":" Rust"},"logprobs":null,"finish_reason":null}]}',
+    ]
+    response = MagicMock(spec=httpx.Response)
+    response.iter_lines.return_value = iter(data)
+
+    stream = _stream_chat_completion_response(response)
+    assert isinstance(stream, InferenceStream)
+    assert next(iter(stream)).choices[0].delta.content == "Both"
+
+    stream.close()
+    response.close.assert_called_once()
+
+
+def test_chat_completion_stream_returns_closable_stream():
+    """`chat_completion(..., stream=True)` returns an `InferenceStream` wired to the HTTP response."""
+    data = [
+        'data: {"object":"chat.completion.chunk","id":"","created":1721737661,"model":"","system_fingerprint":"2.1.2-dev0-sha-5fca30e","choices":[{"index":0,"delta":{"role":"assistant","content":"Both"},"logprobs":null,"finish_reason":null}]}',
+    ]
+    response = MagicMock(spec=httpx.Response)
+    response.iter_lines.return_value = iter(data)
+
+    helper = MagicMock()
+    helper.prepare_request.return_value = MagicMock()
+    client = InferenceClient(model="meta-llama/Meta-Llama-3-8B-Instruct")
+
+    with (
+        patch("huggingface_hub.inference._client.get_provider_helper", return_value=helper),
+        patch.object(InferenceClient, "_inner_post", return_value=response),
+    ):
+        stream = client.chat_completion(CHAT_COMPLETION_MESSAGES, stream=True)
+
+    assert isinstance(stream, InferenceStream)
+    assert [chunk.choices[0].delta.content for chunk in stream] == ["Both"]
+    stream.close()
+    response.close.assert_called_once()
 
 
 INFERENCE_API_URL = "https://api-inference.huggingface.co/models"

--- a/utils/generate_async_inference_client.py
+++ b/utils/generate_async_inference_client.py
@@ -137,7 +137,6 @@ def _add_imports(code: str) -> str:
         r"(\nimport .*?\n)",
         repl=(
             r"\1"
-            + "from .._common import _async_yield_from\n"
             + "from huggingface_hub.utils import get_async_session\n"
             + "from typing import AsyncIterable\n"
             + "from contextlib import AsyncExitStack\n"
@@ -177,7 +176,7 @@ ASYNC_INNER_POST_CODE = """
                     )
                 )
                 hf_raise_for_status(response)
-                return _async_yield_from(client, response)
+                return response
             else:
                 response = await client.post(
                     request_parameters.url,
@@ -365,6 +364,7 @@ def _use_async_streaming_util(code: str) -> str:
         "_async_stream_text_generation_response",
     )
     code = code.replace("_stream_chat_completion_response", "_async_stream_chat_completion_response")
+    code = code.replace("InferenceStream", "AsyncInferenceStream")
     return code
 
 


### PR DESCRIPTION
Fixes #4224.

## Summary
- `chat_completion(..., stream=True)` and `text_generation(..., stream=True)` now return `InferenceStream` / `AsyncInferenceStream`: thin iterable wrappers over the same parsed SSE outputs that also keep a handle on the underlying `httpx.Response` and expose `close()` to cancel the stream early.
- This makes it possible to cancel an async stream from another task. Previously the only handle was the async generator itself, and calling `aclose()` on it while it is being iterated raises `RuntimeError: aclose(): asynchronous generator is already running` (the pydantic-ai problem in #4224). `close()` sidesteps the generator entirely and closes the HTTP response directly — same approach as `Stream.close()` in the OpenAI and Anthropic SDKs.
- Mechanics: `_inner_post(stream=True)` returns the `httpx.Response` instead of `response.iter_lines()`, and the `_stream_*` helpers in `inference/_common.py` wrap the parsing generator + response into the new objects. `_async_yield_from` is no longer needed and was removed. The async client was regenerated; both classes are exported at top level and documented.
- Iteration behavior is unchanged (`for chunk in ...` / `async for chunk in ...` work exactly as before); the wrappers still satisfy `Iterable` / `AsyncIterable`.

Manually tested against a local SSE server:
```
[sync] got: InferenceStream
[sync] chunk 0: tok
[sync] chunk 1: tok
[sync] chunk 2: tok
[sync] stream closed early, no error
[server] client disconnected (connection released)
[async] got: AsyncInferenceStream
[async] closed from another task while iterating (after 7 chunks), no RuntimeError
[async] consumer ended with: ReadError
```
Note: after `close()`, a consumer still blocked on the stream gets an `httpx.ReadError` — consistent with how the OpenAI/Anthropic SDKs behave when the transport is closed underneath a running stream.

Decision taken: return-type annotations for the streaming overloads were updated from `Iterable[...]`/`AsyncIterable[...]` to the new concrete types so `close()` is visible to type checkers; since the wrappers subclass `Iterable`/`AsyncIterable`, this is not a breaking change for existing annotations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted inference streaming API change with backward-compatible iteration; main surface change is narrower return types and optional `close()` for connection lifecycle.
> 
> **Overview**
> Adds **`InferenceStream`** and **`AsyncInferenceStream`**: iterable wrappers around the same SSE-parsed chunks as before, but they keep the underlying **`httpx.Response`** and expose **`close()`** / **`await close()`** to stop a stream without exhausting it and to release the connection.
> 
> **`_inner_post(..., stream=True)`** now returns the raw **`httpx.Response`** instead of line iterators; **`_stream_*`** helpers build the new wrapper types. **`_async_yield_from`** is removed. Sync/async clients, overload return types, top-level exports, docs, and the async-client generator are updated accordingly.
> 
> Iteration behavior is unchanged (`for` / `async for`). After **`close()`**, a consumer still blocked on the stream may see a transport read error, similar to other SDKs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a60c04d50fc30fa108e8884e00b1fb26d912d7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->