### PR TITLE
Revise security policy with detailed reporting guidelines

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,41 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---|---|
+| Latest release | Yes |
+| Older releases | No |
+
+Only the latest release receives security fixes. Update to the current version before reporting.
+
+<br>
+
+## Reporting a Vulnerability
+
+Use GitHub's built-in private vulnerability reporting: **[Report a vulnerability](https://github.com/huggingface/huggingface_hub/security/advisories/new)**
+
+This keeps the report private until a fix is released. Do not open a public issue for security vulnerabilities.
+
+<br>
+
+## What to Include
+
+- A description of the vulnerability and its impact
+- The affected version
+- Steps to reproduce or a proof of concept
+- Any suggested fix if you have one
+
+<br>
+
+## Response Timeline
+
+We aim to acknowledge reports within 72 hours and to release a fix within 90 days of confirmation. Complex issues may take longer. We will keep you informed of progress.
+
+<br>
+
+## Scope
+
+In scope: the `huggingface_hub` Python package and its public API surface.
+
+Out of scope: the huggingface.co website and hosted services. Report those through the HuggingFace platform directly.


### PR DESCRIPTION
Updated the security policy to clarify supported versions, reporting procedures, and response timelines.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API behavior impact.
> 
> **Overview**
> Adds a new **SECURITY.md** that documents how to report vulnerabilities for `huggingface_hub`.
> 
> It states that only the **latest release** gets security fixes, directs reporters to **GitHub private vulnerability reporting** (not public issues), lists what to include in a report, sets a **72h acknowledgment / ~90 day fix** target, and defines **scope** (in-scope: the Python package and public API; out-of-scope: huggingface.co and hosted services).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63dff3a1b2b2d99bdfbc42438d61e11398556d58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->