### PR TITLE
[Docs] Fix HTTP client name in download docs

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -908,7 +908,7 @@ def hf_hub_download(
             the local cache.
         etag_timeout (`float`, *optional*, defaults to `10`):
             When fetching ETag, how many seconds to wait for the server to send
-            data before giving up which is passed to `requests.request`.
+            data before giving up, which is passed to `httpx.request`.
         token (`str`, `bool`, *optional*):
             A token to be used for the download.
                 - If `True`, the token is read from the HuggingFace config


### PR DESCRIPTION
## Summary

- update the `hf_hub_download` `etag_timeout` docstring to reference `httpx.request`
- keep it consistent with the current HTTP implementation and `snapshot_download` docs

```console
$ python -c "import inspect; from huggingface_hub import hf_hub_download; print('httpx.request' in inspect.getdoc(hf_hub_download))"
True

$ pytest tests/test_file_download.py -k 'offline_no_refs or empty_subfolder' -q
3 passed, 64 deselected
```

`make style` and `make quality` both pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API behavior impact.
> 
> **Overview**
> Updates the **`hf_hub_download`** docstring for **`etag_timeout`** so it names **`httpx.request`** instead of the outdated **`requests.request`**, matching the library’s current HTTP stack and related docs (e.g. **`snapshot_download`**).
> 
> Also adds a small punctuation fix (“giving up**,** which is passed”).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb9461dc1304bb90679cdfd12d06681196849cd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->