### PR TITLE
[Download] Update file-count progress on completion

### DIFF
--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -1,10 +1,10 @@
 import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Literal, overload
 
 import httpx
 from tqdm.auto import tqdm as base_tqdm
-from tqdm.contrib.concurrent import thread_map
 
 from . import constants
 from ._tree_cache import TreeCacheEntry, read_tree_cache, tree_cache_folder_for_local_dir, write_tree_cache
@@ -510,13 +510,11 @@ def snapshot_download(
             )
         )
 
-    thread_map(
-        _inner_hf_hub_download,
-        filtered_repo_files,
-        desc=tqdm_desc,
-        max_workers=max_workers,
-        tqdm_class=tqdm_class,
-    )
+    # Consume futures as they complete so one slow file cannot stall the file-count progress bar.
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = [executor.submit(_inner_hf_hub_download, repo_file) for repo_file in filtered_repo_files]
+        for future in tqdm_class(as_completed(futures), desc=tqdm_desc, total=len(futures)):
+            future.result()
 
     _finish_transfer_bar(transfer_progress)
     transfer_progress.set_description("Download complete")

--- a/tests/test_snapshot_download.py
+++ b/tests/test_snapshot_download.py
@@ -1,16 +1,75 @@
 import os
+import threading
 from pathlib import Path
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
 
 import pytest
+from tqdm.auto import tqdm as base_tqdm
 
 from huggingface_hub import CommitOperationAdd, HfApi, snapshot_download
 from huggingface_hub.errors import IncompleteSnapshotError, LocalEntryNotFoundError, RepositoryNotFoundError
 from huggingface_hub.file_download import repo_folder_name
+from huggingface_hub.hf_api import RepoFile
 from huggingface_hub.utils import SoftTemporaryDirectory, _http
 
 from .testing_constants import TOKEN
 from .testing_utils import OfflineSimulationMode, offline, repo_name
+
+
+def test_file_progress_updates_as_each_download_completes(tmp_path, mocker):
+    slow_release = threading.Event()
+    fast_done = threading.Event()
+    file_progress_updated = threading.Event()
+
+    class RecordingTqdm(base_tqdm):
+        def __init__(self, *args, **kwargs):
+            kwargs["disable"] = True
+            self._tracks_files = kwargs.get("desc") == "Fetching 2 files"
+            super().__init__(*args, **kwargs)
+
+        def __iter__(self):
+            for item in self.iterable:
+                yield item
+                if self._tracks_files:
+                    file_progress_updated.set()
+
+    api = Mock()
+    api.repo_info.return_value = SimpleNamespace(sha="a" * 40)
+    api.list_repo_tree.return_value = [
+        RepoFile(path="slow.bin", size=1, oid="slow"),
+        RepoFile(path="fast.bin", size=1, oid="fast"),
+    ]
+    mocker.patch("huggingface_hub._snapshot_download.HfApi", return_value=api)
+
+    def fake_download(repo_id, *, filename, **kwargs):
+        if filename == "slow.bin":
+            slow_release.wait(timeout=5)
+        else:
+            fast_done.set()
+        return f"/fake/{filename}"
+
+    mocker.patch("huggingface_hub._snapshot_download.hf_hub_download", side_effect=fake_download)
+
+    errors = []
+
+    def run_download():
+        try:
+            snapshot_download("owner/repo", cache_dir=tmp_path, max_workers=2, tqdm_class=RecordingTqdm)
+        except BaseException as error:
+            errors.append(error)
+
+    worker = threading.Thread(target=run_download)
+    worker.start()
+    try:
+        assert fast_done.wait(timeout=2)
+        assert file_progress_updated.wait(timeout=2)
+    finally:
+        slow_release.set()
+        worker.join(timeout=5)
+
+    assert not worker.is_alive()
+    assert not errors
 
 
 class TestSnapshotDownload:


### PR DESCRIPTION
## Summary

- `thread_map` consumed results in input order, so one slow early file kept `Fetching N files` at zero after later files had completed.
- Consume futures with `as_completed()` and cover the slow-first, fast-second case with a deterministic regression test.

The reproduction now advances from 0/2 to 1/2 while the first file remains blocked. Fixes #4518.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to concurrent download iteration and progress reporting in snapshot_download; behavior for errors and max_workers is unchanged aside from progress timing.
> 
> **Overview**
> Fixes **`Fetching N files`** staying at **0/N** when an early file is slow but later files finish first.
> 
> **`snapshot_download`** no longer uses **`thread_map`** (which advanced progress in submission order). It runs parallel downloads with **`ThreadPoolExecutor`** and iterates **`as_completed(futures)`** inside the tqdm wrapper so the file counter increments when each download actually finishes.
> 
> Adds a regression test that blocks the first file while the second completes and asserts the file-progress tqdm advances before the slow download is released.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b63663af56d03c1560ac994a27a48204dc4db733. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->