### PR TITLE
[Utils] Reject negative values in parse_size and parse_duration

### DIFF
--- a/src/huggingface_hub/utils/_parsing.py
+++ b/src/huggingface_hub/utils/_parsing.py
@@ -59,9 +59,15 @@ def _parse_with_unit(value: str, units: dict[str, int]) -> int:
     if not stripped:
         raise ValueError("Value cannot be empty.")
     try:
-        return int(value)
+        number = int(value)
     except ValueError:
         pass
+    else:
+        # `int()` accepts a leading sign, so a bare negative like "-5" would slip through the
+        # plain-number path even though the unit path (RE_NUMBER_WITH_UNIT) only allows `\d+`.
+        if number < 0:
+            raise ValueError(f"Invalid value '{value}'. Value cannot be negative.")
+        return number
 
     match = RE_NUMBER_WITH_UNIT.fullmatch(stripped)
     if not match:

--- a/tests/test_utils_parsing.py
+++ b/tests/test_utils_parsing.py
@@ -29,6 +29,7 @@ def test_parse_size_valid(value, expected):
     [
         "1.5G",
         "-5M",
+        "-5",
         "10X",
         "abc",
         "",
@@ -64,6 +65,7 @@ def test_parse_duration_valid(value, expected):
         "1.5h",
         "3month",
         "-5m",
+        "-5",
         "10X",
         "abc",
         "",


### PR DESCRIPTION
`parse_size` and `parse_duration` validate a non-negative size/duration string and are expected to raise `ValueError` on malformed input. The unit path (`RE_NUMBER_WITH_UNIT = r"(\d+)([a-z]+)"`) already rejects a leading sign, and `test_parse_size_invalid` / `test_parse_duration_invalid` assert that `"-5M"` / `"-5m"` raise.

But the plain-number fast path calls `int(value)`, and `int("-5")` is a valid Python int, so a bare negative slips straight through:

```python
>>> from huggingface_hub.utils._parsing import parse_size, parse_duration
>>> parse_size("-5M")      # ValueError   (correct)
>>> parse_size("-5")       # -5           <-- returns a negative size
>>> parse_duration("-5")   # -5           <-- returns a negative duration
```

A negative size/duration is never meaningful, and there is no negative sentinel downstream — the value flows into the `hf` CLI as-is (e.g. job `--timeout`, cache `--size-threshold`), so `-5` yields a negative timeout instead of an error.

## Fix

Reject negative values in the shared `_parse_with_unit` helper, so both `parse_size` and `parse_duration` are covered. Positive plain numbers and unit strings are unchanged.

## Tests

Added `"-5"` to both invalid parametrizations. Both fail on `main` (`DID NOT RAISE ValueError`) and pass with the fix. The rest of `test_utils_parsing.py` (53 cases) and `test_parse_size_to_int` still pass; `ruff check`, `ruff format --check` and `mypy` are clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small validation tightening in shared parsing used by CLI options; no auth or data-path changes, and behavior for valid inputs is unchanged.
> 
> **Overview**
> **`parse_size` and `parse_duration`** shared **`_parse_with_unit`** logic now rejects bare negative plain numbers (e.g. `"-5"`), which previously returned a negative int via **`int()`** while unit forms like `"-5M"` were already invalid.
> 
> After a successful plain-number parse, values **&lt; 0** raise **`ValueError`** with an explicit message; positive integers and unit strings behave as before.
> 
> Tests add **`"-5"`** to the invalid parametrizations for both parsers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7af31c32a28ca59784ccfedf074e7e31f3bc8cc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->