### PR TITLE
[Download] Fix xet download rate: show summed, not per-file speed

### DIFF
--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -25,6 +25,7 @@ from .utils._xet_progress_reporting import (
     XET_BYTES_BAR_FORMAT,
     XET_TRANSFER_BAR_FORMAT,
     _finish_transfer_bar,
+    _set_aggregate_rate_postfix,
     _update_transfer_bar,
 )
 from .utils.tqdm import _create_progress_bar
@@ -480,10 +481,11 @@ def snapshot_download(
             _update_transfer_bar(transfer_progress, int(n or 0))
 
         def set_postfix_str(self, postfix: str, refresh: bool = False) -> None:
-            reconstruct_progress.set_postfix_str(postfix, refresh=refresh)
+            # Discard the caller's per-file rate; report the summed rate across all files instead.
+            _set_aggregate_rate_postfix(reconstruct_progress)
 
         def set_transfer_postfix_str(self, postfix: str, refresh: bool = False) -> None:
-            transfer_progress.set_postfix_str(postfix, refresh=refresh)
+            _set_aggregate_rate_postfix(transfer_progress)
 
     # Pass the commit_hash as revision to hf_hub_download to skip network call if:
     # - file is cached

--- a/src/huggingface_hub/utils/_xet_progress_reporting.py
+++ b/src/huggingface_hub/utils/_xet_progress_reporting.py
@@ -47,6 +47,16 @@ def _finish_transfer_bar(bar) -> None:
         bar.refresh()
 
 
+def _set_aggregate_rate_postfix(bar) -> None:
+    """Show a shared bar's own throughput as its rate.
+
+    When many files feed one bar (snapshot download), each file only knows its own per-item rate — a
+    fraction of the total. Deriving the rate from the shared bar's aggregated byte count reports the
+    true combined speed instead of whichever single file reported last.
+    """
+    bar.set_postfix_str(_format_speed_postfix(bar.format_dict.get("rate")), refresh=False)
+
+
 class XetDownloadProgressReporter:
     """Dual progress bars for Xet downloads: network transfer and file reconstruction.
 

--- a/tests/test_xet_progress_reporting.py
+++ b/tests/test_xet_progress_reporting.py
@@ -1,5 +1,7 @@
 from huggingface_hub.utils._xet_progress_reporting import (
     _finish_transfer_bar,
+    _format_speed_postfix,
+    _set_aggregate_rate_postfix,
     _set_monotonic_total,
     _update_transfer_bar,
 )
@@ -15,6 +17,21 @@ class _RecordingBar:
 
     def refresh(self) -> None:
         pass
+
+
+class _RateBar:
+    """Stub bar exposing a tqdm-like ``format_dict['rate']`` and recording its postfix."""
+
+    def __init__(self, rate):
+        self._rate = rate
+        self.postfix = None
+
+    @property
+    def format_dict(self):
+        return {"rate": self._rate}
+
+    def set_postfix_str(self, postfix: str, refresh: bool = False) -> None:
+        self.postfix = postfix
 
 
 class TestXetProgressBarHelpers:
@@ -42,3 +59,16 @@ class TestXetProgressBarHelpers:
         bar.n = 2_000_000
         _finish_transfer_bar(bar)
         assert bar.total == 2_000_000
+
+    def test_aggregate_rate_postfix_reports_bar_own_summed_rate(self):
+        # Regression: shared snapshot bar must show its own aggregated throughput, not a per-file rate.
+        # https://github.com/huggingface/huggingface_hub/issues/4519
+        bar = _RateBar(rate=234_000_000)  # bytes/s summed across all files
+        _set_aggregate_rate_postfix(bar)
+        assert "MB/s" in bar.postfix
+        assert bar.postfix == _format_speed_postfix(234_000_000)
+
+    def test_aggregate_rate_postfix_handles_unknown_rate(self):
+        bar = _RateBar(rate=None)
+        _set_aggregate_rate_postfix(bar)
+        assert "???" in bar.postfix


### PR DESCRIPTION
## Summary

- Fixes #4519 — `hf download` reporting a bit rate far lower than the actual download speed.
- Multi-file xet downloads (`hf download <repo>` / `snapshot_download`) share two progress bars ("Downloading bytes" and "Reconstructing (incomplete total...)") across all files. The byte *counts* are aggregated correctly, but each file's progress callback also wrote **its own per-group completion rate** to the shared bar's postfix. Since ~15 files download concurrently, the displayed rate was clobbered to a single file's speed instead of the sum — so the bar raced ahead (~1 GB/s) while the rate read 5–200 MB/s.
- Fix: derive the shared bars' rate from **their own aggregated byte count** (tqdm's smoothed throughput) via a small `_set_aggregate_rate_postfix` helper, and have `_AggregatedTqdm` discard the incoming per-file rate. Single-file `hf_hub_download` is unchanged — its bar already reflects exactly one file, so its per-file rate stays correct.

## Why this approach

The two shared bars already receive summed byte updates, so tqdm is in the best position to compute the aggregate rate — no need to sum per-group rates across a changing set of in-flight files (which would require tracking and zeroing each file's last rate as it completes). The per-file EWMA rate hf_xet reports is still the right thing for the single-file path, which is untouched. The helper follows the module's existing pattern of small, unit-tested bar helpers (`_update_transfer_bar`, `_finish_transfer_bar`, `_set_monotonic_total`).

## Manual verification

Drove the real `XetDownloadProgressReporter` in aggregated mode with two files that each *report* a per-file rate of 15 MB/s, pushing 100 MB each per tick:

```
reconstruct_progress.n = 1,000,000,000  (expected sum = 1,000,000,000)
transfer_progress.n    = 1,000,000,000
per-file reported rate : 15.0MB/s      <- what was shown before (a single file)
displayed recon rate   : 4.27GB/s      <- after fix: bar's own summed throughput
displayed xfer rate    : 4.27GB/s
```

Also:

```
ruff format --check  ->  3 files already formatted
ruff check           ->  All checks passed!
ty check <changed>   ->  All checks passed!
pytest tests/test_xet_progress_reporting.py tests/test_file_download.py -k "...progress/rate/tqdm..." -> 8 passed
```

Added two unit tests for the new helper (summed-rate and unknown-rate cases) in `tests/test_xet_progress_reporting.py`.

## Not a breaking change

Public API is unchanged; only the internal snapshot progress plumbing and a private helper are touched. Single-file download output is identical to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wr4cVEYeGC1kGZ9mVidzxP

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal progress-display plumbing only; no API or download logic changes, and single-file paths are untouched.
> 
> **Overview**
> Fixes misleading **download speed** on multi-file Xet snapshot downloads (`snapshot_download` / `hf download <repo>`). Shared “Downloading bytes” and “Reconstructing” bars already aggregate byte counts across concurrent files, but each file’s callback was still writing **its own per-file rate** into the shared postfix—so the displayed speed looked far lower than actual combined throughput (fixes #4519).
> 
> Adds `_set_aggregate_rate_postfix` to set the postfix from the **shared bar’s tqdm `rate`** (aggregated bytes), and wires `_AggregatedTqdm` in `snapshot_download` to use it for both reconstruction and transfer postfixes instead of forwarding per-file strings. **Single-file** `hf_hub_download` behavior is unchanged.
> 
> Unit tests cover summed-rate formatting and unknown-rate (`???`) handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e133b4b8b3268b805a2f1b0727385661299728b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->