### PR TITLE
[Jobs] Add optional names to Jobs CLI and API

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -1795,7 +1795,7 @@ Run compute jobs on Hugging Face infrastructure with a familiar Docker-like inte
 
 ```bash
 # Directly run Python code
->>> hf jobs run python:3.12 python -c 'print("Hello from the cloud!")'
+>>> hf jobs run --name hello-world python:3.12 python -c 'print("Hello from the cloud!")'
 
 # Use GPUs without any setup
 >>> hf jobs run --flavor a10g-small pytorch/pytorch:2.6.0-cuda12.4-cudnn9-devel \
@@ -1808,7 +1808,7 @@ Run compute jobs on Hugging Face infrastructure with a familiar Docker-like inte
 >>> hf jobs run hf.co/spaces/lhoestq/duckdb duckdb -c 'select "hello world"'
 
 # Run a Python script with `uv` (experimental)
->>> hf jobs uv run my_script.py
+>>> hf jobs uv run --name my-script my_script.py
 ```
 
 > [!TIP]
@@ -2028,6 +2028,13 @@ Add labels to a Job using `-l` or `--label`. Labels are a key=value pairs that a
 
 The my-label key doesn't specify a value so its value defaults to an empty string ("").
 
+Use `--name` to add the `name` label when creating a Job. Names make Jobs easier to find and identify in the UI; they are optional and do not have to be unique. You can also name an existing Job:
+
+```bash
+>>> hf jobs run --name training-v2 python:3.12 python train.py
+>>> hf jobs labels <job_id> --name training-v2
+```
+
 Use `--status` and `--label` in `hf jobs ls` to filter Jobs. `--status` takes one or more statuses and `--label` takes `key=value` pairs. A Job must match every filter to be listed:
 
 ```bash
@@ -2117,7 +2124,7 @@ The schedule should be one of `@annually`, `@yearly`, `@monthly`, `@weekly`, `@d
 
 ```bash
 # Schedule a job that runs every hour
->>> hf jobs scheduled run @hourly python:3.12 python -c 'print("This runs every hour!")'
+>>> hf jobs scheduled run @hourly --name hourly-task python:3.12 python -c 'print("This runs every hour!")'
 
 # Use the CRON syntax
 >>> hf jobs scheduled run "*/5 * * * *" python:3.12 python -c 'print("This runs every 5 minutes!")'
@@ -2127,7 +2134,7 @@ The schedule should be one of `@annually`, `@yearly`, `@monthly`, `@weekly`, `@d
 ... python -c "import torch; print(f"This code ran with the following GPU: {torch.cuda.get_device_name()}")"
 
 # Schedule a UV script
->>> hf jobs scheduled uv run @hourly my_script.py
+>>> hf jobs scheduled uv run @hourly --name hourly-script my_script.py
 ```
 
 Use the same parameters as `hf jobs run` to pass environment variables, secrets, timeout, etc.

--- a/docs/source/en/guides/jobs.md
+++ b/docs/source/en/guides/jobs.md
@@ -28,15 +28,15 @@ Use the [`hf jobs` CLI](./cli#hf-jobs) to run Jobs from the command line, and pa
 `hf jobs run` runs Jobs with a Docker image and a command with a familiar Docker-like interface. Think `docker run`, but for running code on any hardware:
 
 ```bash
->>> hf jobs run python:3.12 python -c "print('Hello world')"
->>> hf jobs run --flavor a10g-small pytorch/pytorch:2.6.0-cuda12.4-cudnn9-devel python -c "import torch; print(torch.cuda.get_device_name())"
+>>> hf jobs run --name hello-world python:3.12 python -c "print('Hello world')"
+>>> hf jobs run --name gpu-check --flavor a10g-small pytorch/pytorch:2.6.0-cuda12.4-cudnn9-devel python -c "import torch; print(torch.cuda.get_device_name())"
 ```
 
 Use `hf jobs uv run` to run local or remote UV scripts:
 
 ```bash
->>> hf jobs uv run my_script.py
->>> hf jobs uv run --flavor a10g-small "https://raw.githubusercontent.com/huggingface/trl/main/trl/scripts/sft.py" 
+>>> hf jobs uv run --name my-script my_script.py
+>>> hf jobs uv run --name sft-training --flavor a10g-small "https://raw.githubusercontent.com/huggingface/trl/main/trl/scripts/sft.py"
 ```
 
 UV scripts are Python scripts that include their dependencies directly in the file using a special comment syntax defined in the [UV documentation](https://docs.astral.sh/uv/guides/scripts/).
@@ -506,6 +506,20 @@ These variables are useful when you need to create unique identifiers for output
 ## Labels
 
 Labels are key=value pairs that attach metadata to a Job:
+
+Use `name` to make Jobs easier to find and identify in the UI. Names are optional and do not have to be unique:
+
+```python
+>>> from huggingface_hub import run_job
+>>> run_job(name="daily-report", image="python:3.12", command=["python", "report.py"])
+```
+
+From the CLI, pass `--name` when creating a Job, or name an existing Job through the labels command:
+
+```bash
+>>> hf jobs run --name daily-report python:3.12 python report.py
+>>> hf jobs labels <job_id> --name daily-report
+```
 
 ```python
 # Pass extra metadata with Labels

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -2294,6 +2294,7 @@ $ hf jobs labels [OPTIONS] JOB_ID
 
 **Options**:
 
+* `--name TEXT`: Name the Job. Stored as the `name` label. Names do not have to be unique.
 * `-l, --label TEXT`: Set labels. E.g. --label KEY=VALUE or --label LABEL
 * `--clear`: Remove all labels from the job.
 * `--namespace TEXT`: The namespace where the job will be running. Defaults to the current user's namespace.
@@ -2301,6 +2302,7 @@ $ hf jobs labels [OPTIONS] JOB_ID
 * `--help`: Show this message and exit.
 
 Examples
+  $ hf jobs labels <job_id> --name training-v2
   $ hf jobs labels <job_id> --label env=prod --label team=ml
   $ hf jobs labels <job_id> --clear
 
@@ -2404,6 +2406,7 @@ $ hf jobs run [OPTIONS] IMAGE COMMAND...
 
 * `-e, --env TEXT`: Set environment variables. E.g. --env ENV=value
 * `-s, --secrets TEXT`: Set secret environment variables. E.g. --secrets SECRET=value or `--secrets HF_TOKEN` to pass your Hugging Face token.
+* `--name TEXT`: Name the Job. Stored as the `name` label. Names do not have to be unique.
 * `-l, --label TEXT`: Set labels. E.g. --label KEY=VALUE or --label LABEL
 * `-v, --volume TEXT`: Mount one or more volumes. Format: hf://[TYPE/]SOURCE:/MOUNT_PATH[:ro|:rw] or LOCAL_DIR:/MOUNT_PATH[:ro|:rw]. TYPE is one of: models, datasets, spaces, buckets. TYPE defaults to models if omitted. models, datasets and spaces are always mounted read-only. buckets are read+write by default. A local directory source is first synced to a bucket and mounted read-only by default. E.g. -v hf://datasets/org/ds:/data or -v hf://buckets/org/b:/mnt:ro or -v ./inputs:/inputs
 * `--env-file TEXT`: Read in a file of environment variables.
@@ -2418,7 +2421,7 @@ $ hf jobs run [OPTIONS] IMAGE COMMAND...
 * `--help`: Show this message and exit.
 
 Examples
-  $ hf jobs run python:3.12 python -c 'print("Hello!")'
+  $ hf jobs run --name hello-world python:3.12 python -c 'print("Hello!")'
   $ hf jobs run --detach python:3.12 python script.py
   $ hf jobs run -e FOO=foo python:3.12 python script.py
   $ hf jobs run --secrets HF_TOKEN python:3.12 python script.py
@@ -2527,6 +2530,7 @@ $ hf jobs scheduled labels [OPTIONS] SCHEDULED_JOB_ID
 
 **Options**:
 
+* `--name TEXT`: Name the Job. Stored as the `name` label. Names do not have to be unique.
 * `-l, --label TEXT`: Set labels. E.g. --label KEY=VALUE or --label LABEL
 * `--clear`: Remove all labels from the scheduled job.
 * `--namespace TEXT`: The namespace where the job will be running. Defaults to the current user's namespace.
@@ -2534,6 +2538,7 @@ $ hf jobs scheduled labels [OPTIONS] SCHEDULED_JOB_ID
 * `--help`: Show this message and exit.
 
 Examples
+  $ hf jobs scheduled labels <id> --name daily-script
   $ hf jobs scheduled labels <id> --label env=prod --label team=ml
   $ hf jobs scheduled labels <id> --clear
 
@@ -2618,6 +2623,7 @@ $ hf jobs scheduled run [OPTIONS] SCHEDULE IMAGE COMMAND...
 * `--concurrency / --no-concurrency`: Allow multiple instances of this Job to run concurrently
 * `-e, --env TEXT`: Set environment variables. E.g. --env ENV=value
 * `-s, --secrets TEXT`: Set secret environment variables. E.g. --secrets SECRET=value or `--secrets HF_TOKEN` to pass your Hugging Face token.
+* `--name TEXT`: Name the Job. Stored as the `name` label. Names do not have to be unique.
 * `-l, --label TEXT`: Set labels. E.g. --label KEY=VALUE or --label LABEL
 * `-v, --volume TEXT`: Mount one or more volumes. Format: hf://[TYPE/]SOURCE:/MOUNT_PATH[:ro|:rw] or LOCAL_DIR:/MOUNT_PATH[:ro|:rw]. TYPE is one of: models, datasets, spaces, buckets. TYPE defaults to models if omitted. models, datasets and spaces are always mounted read-only. buckets are read+write by default. A local directory source is first synced to a bucket and mounted read-only by default. E.g. -v hf://datasets/org/ds:/data or -v hf://buckets/org/b:/mnt:ro or -v ./inputs:/inputs
 * `--env-file TEXT`: Read in a file of environment variables.
@@ -2630,7 +2636,7 @@ $ hf jobs scheduled run [OPTIONS] SCHEDULE IMAGE COMMAND...
 * `--help`: Show this message and exit.
 
 Examples
-  $ hf jobs scheduled run "0 0 * * *" python:3.12 python script.py
+  $ hf jobs scheduled run "0 0 * * *" --name daily-script python:3.12 python script.py
 
 Learn more
   Use `hf <command> --help` for more information about a command.
@@ -2735,6 +2741,7 @@ $ hf jobs scheduled uv run [OPTIONS] SCHEDULE SCRIPT [SCRIPT_ARGS]...
 * `--flavor [cpu-basic|cpu-upgrade|cpu-performance|cpu-xl|t4-small|t4-medium|l4x1|l4x4|l40sx1|l40sx4|l40sx8|a10g-small|a10g-large|a10g-largex2|a10g-largex4|a100-large|a100x4|a100x8|h200|h200x2|h200x4|h200x8|rtx-pro-6000|rtx-pro-6000x2|rtx-pro-6000x4|rtx-pro-6000x8]`: Flavor for the hardware. Run 'hf jobs hardware' to list available flavors. Defaults to `cpu-basic`.
 * `-e, --env TEXT`: Set environment variables. E.g. --env ENV=value
 * `-s, --secrets TEXT`: Set secret environment variables. E.g. --secrets SECRET=value or `--secrets HF_TOKEN` to pass your Hugging Face token.
+* `--name TEXT`: Name the Job. Stored as the `name` label. Names do not have to be unique.
 * `-l, --label TEXT`: Set labels. E.g. --label KEY=VALUE or --label LABEL
 * `-v, --volume TEXT`: Mount one or more volumes. Format: hf://[TYPE/]SOURCE:/MOUNT_PATH[:ro|:rw] or LOCAL_DIR:/MOUNT_PATH[:ro|:rw]. TYPE is one of: models, datasets, spaces, buckets. TYPE defaults to models if omitted. models, datasets and spaces are always mounted read-only. buckets are read+write by default. A local directory source is first synced to a bucket and mounted read-only by default. E.g. -v hf://datasets/org/ds:/data or -v hf://buckets/org/b:/mnt:ro or -v ./inputs:/inputs
 * `--env-file TEXT`: Read in a file of environment variables.
@@ -2748,7 +2755,7 @@ $ hf jobs scheduled uv run [OPTIONS] SCHEDULE SCRIPT [SCRIPT_ARGS]...
 * `--help`: Show this message and exit.
 
 Examples
-  $ hf jobs scheduled uv run "0 0 * * *" script.py
+  $ hf jobs scheduled uv run "0 0 * * *" --name daily-script script.py
   $ hf jobs scheduled uv run "0 0 * * *" script.py --with pandas
 
 Learn more
@@ -2859,6 +2866,7 @@ $ hf jobs uv run [OPTIONS] SCRIPT [SCRIPT_ARGS]...
 * `--flavor [cpu-basic|cpu-upgrade|cpu-performance|cpu-xl|t4-small|t4-medium|l4x1|l4x4|l40sx1|l40sx4|l40sx8|a10g-small|a10g-large|a10g-largex2|a10g-largex4|a100-large|a100x4|a100x8|h200|h200x2|h200x4|h200x8|rtx-pro-6000|rtx-pro-6000x2|rtx-pro-6000x4|rtx-pro-6000x8]`: Flavor for the hardware. Run 'hf jobs hardware' to list available flavors. Defaults to `cpu-basic`.
 * `-e, --env TEXT`: Set environment variables. E.g. --env ENV=value
 * `-s, --secrets TEXT`: Set secret environment variables. E.g. --secrets SECRET=value or `--secrets HF_TOKEN` to pass your Hugging Face token.
+* `--name TEXT`: Name the Job. Stored as the `name` label. Names do not have to be unique.
 * `-l, --label TEXT`: Set labels. E.g. --label KEY=VALUE or --label LABEL
 * `-v, --volume TEXT`: Mount one or more volumes. Format: hf://[TYPE/]SOURCE:/MOUNT_PATH[:ro|:rw] or LOCAL_DIR:/MOUNT_PATH[:ro|:rw]. TYPE is one of: models, datasets, spaces, buckets. TYPE defaults to models if omitted. models, datasets and spaces are always mounted read-only. buckets are read+write by default. A local directory source is first synced to a bucket and mounted read-only by default. E.g. -v hf://datasets/org/ds:/data or -v hf://buckets/org/b:/mnt:ro or -v ./inputs:/inputs
 * `--env-file TEXT`: Read in a file of environment variables.
@@ -2874,7 +2882,7 @@ $ hf jobs uv run [OPTIONS] SCRIPT [SCRIPT_ARGS]...
 * `--help`: Show this message and exit.
 
 Examples
-  $ hf jobs uv run my_script.py
+  $ hf jobs uv run --name my-script my_script.py
   $ hf jobs uv run --detach my_script.py
   $ hf jobs uv run ml_training.py --flavor a10g-small
   $ hf jobs uv run --with transformers train.py

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -2280,7 +2280,7 @@ Learn more
 
 ### `hf jobs labels`
 
-Update labels on a Job. Replaces all existing labels.
+Update labels on a Job. Passing --label replaces all existing labels; passing --name alone keeps them.
 
 **Usage**:
 
@@ -2516,7 +2516,7 @@ Learn more
 
 #### `hf jobs scheduled labels`
 
-Update labels on a scheduled Job. Replaces all existing labels.
+Update labels on a scheduled Job. Passing --label replaces all existing labels; passing --name alone keeps them.
 
 **Usage**:
 

--- a/src/huggingface_hub/_jobs_api.py
+++ b/src/huggingface_hub/_jobs_api.py
@@ -518,11 +518,17 @@ def _create_job_spec(
     secrets: dict[str, Any] | None,
     flavor: JobHardware | str | None,
     timeout: int | float | str | None,
+    name: str | None = None,
     labels: dict[str, str] | None = None,
     volumes: list[Volume] | None = None,
     expose: list[int] | None = None,
     ssh: bool = False,
 ) -> dict[str, Any]:
+    if name is not None:
+        if labels is not None and "name" in labels:
+            raise ValueError("`name` and the `name` key in `labels` cannot both be provided.")
+        labels = {**(labels or {}), "name": name}
+
     # prepare job spec to send to HF Jobs API
     job_spec: dict[str, Any] = {
         "command": command,

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -825,7 +825,7 @@ def jobs_labels(
     namespace: NamespaceOpt = None,
     token: TokenOpt = None,
 ) -> None:
-    """Update labels on a Job. Replaces all existing labels."""
+    """Update labels on a Job. Passing --label replaces all existing labels; passing --name alone keeps them."""
     if not label and name is None and not clear:
         raise CLIError(
             "Please set a name with --name or at least one label with --label. To remove all labels, pass --clear."
@@ -835,8 +835,13 @@ def jobs_labels(
             "Cannot set a name or labels and clear them at the same time. Please use --name/--label or --clear, not both."
         )
     job_id, namespace = _parse_namespace_from_job_id(job_id, namespace)
-    labels = _parse_labels_map(label, name=name) or {}
     api = get_hf_api(token=token)
+    if name is not None and not label:
+        # Naming a Job should not wipe its existing labels: fetch them and merge the name in.
+        current_labels = api.inspect_job(job_id=job_id, namespace=namespace).labels or {}
+        labels = {**current_labels, "name": name}
+    else:
+        labels = _parse_labels_map(label, name=name) or {}
     job = api.update_job_labels(job_id=job_id, labels=labels, namespace=namespace)
     out.result("Labels updated", id=job.id)
 
@@ -1010,8 +1015,10 @@ def scheduled_run(
     )
     out.result("Scheduled Job created", id=scheduled_job.id)
     if name is None:
-        out.hint(f"Name this scheduled Job with `hf jobs scheduled labels {scheduled_job.id} --name NAME`.")
-    out.hint(f"Use `hf jobs scheduled inspect {scheduled_job.id}` to view its details.")
+        out.hint(
+            f"Name this scheduled Job with `hf jobs scheduled labels {scheduled_job.owner.name}/{scheduled_job.id} --name NAME`."
+        )
+    out.hint(f"Use `hf jobs scheduled inspect {scheduled_job.owner.name}/{scheduled_job.id}` to view its details.")
 
 
 @scheduled_app.command("list | ls | ps", examples=["hf jobs scheduled ls"])
@@ -1192,7 +1199,7 @@ def scheduled_labels(
     namespace: NamespaceOpt = None,
     token: TokenOpt = None,
 ) -> None:
-    """Update labels on a scheduled Job. Replaces all existing labels."""
+    """Update labels on a scheduled Job. Passing --label replaces all existing labels; passing --name alone keeps them."""
     if not label and name is None and not clear:
         raise CLIError(
             "Please set a name with --name or at least one label with --label. To remove all labels, pass --clear."
@@ -1202,8 +1209,15 @@ def scheduled_labels(
             "Cannot set a name or labels and clear them at the same time. Please use --name/--label or --clear, not both."
         )
     scheduled_job_id, namespace = _parse_namespace_from_job_id(scheduled_job_id, namespace)
-    labels = _parse_labels_map(label, name=name) or {}
     api = get_hf_api(token=token)
+    if name is not None and not label:
+        # Naming a scheduled Job should not wipe its existing labels: fetch them and merge the name in.
+        current_labels = (
+            api.inspect_scheduled_job(scheduled_job_id=scheduled_job_id, namespace=namespace).job_spec.labels or {}
+        )
+        labels = {**current_labels, "name": name}
+    else:
+        labels = _parse_labels_map(label, name=name) or {}
     scheduled_job = api.update_scheduled_job_labels(
         scheduled_job_id=scheduled_job_id, labels=labels, namespace=namespace
     )
@@ -1269,8 +1283,8 @@ def scheduled_uv_run(
     )
     out.result("Scheduled Job created", id=job.id)
     if name is None:
-        out.hint(f"Name this scheduled Job with `hf jobs scheduled labels {job.id} --name NAME`.")
-    out.hint(f"Use `hf jobs scheduled inspect {job.id}` to view its details.")
+        out.hint(f"Name this scheduled Job with `hf jobs scheduled labels {job.owner.name}/{job.id} --name NAME`.")
+    out.hint(f"Use `hf jobs scheduled inspect {job.owner.name}/{job.id}` to view its details.")
 
 
 ### UTILS

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -161,6 +161,14 @@ LabelsOpt = Annotated[
     ),
 ]
 
+NameOpt = Annotated[
+    str | None,
+    Option(
+        "--name",
+        help="Name the Job. Stored as the `name` label. Names do not have to be unique.",
+    ),
+]
+
 TimeoutOpt = Annotated[
     str | None,
     Option(
@@ -315,7 +323,7 @@ def _stream_logs_and_check_status(api: HfApi, job: JobInfo) -> None:
     "run",
     context_settings={"ignore_unknown_options": True},
     examples=[
-        "hf jobs run python:3.12 python -c 'print(\"Hello!\")'",
+        "hf jobs run --name hello-world python:3.12 python -c 'print(\"Hello!\")'",
         "hf jobs run --detach python:3.12 python script.py",
         "hf jobs run -e FOO=foo python:3.12 python script.py",
         "hf jobs run --secrets HF_TOKEN python:3.12 python script.py",
@@ -327,6 +335,7 @@ def jobs_run(
     command: CommandArg,
     env: EnvOpt = None,
     secrets: SecretsOpt = None,
+    name: NameOpt = None,
     label: LabelsOpt = None,
     volume: JobVolumesOpt = None,
     env_file: EnvFileOpt = None,
@@ -349,7 +358,7 @@ def jobs_run(
         command=command,
         env=env_map,
         secrets=secrets_map,
-        labels=_parse_labels_map(label),
+        labels=_parse_labels_map(label, name=name),
         volumes=_parse_and_sync_job_volumes(volume, api=api, namespace=namespace),
         flavor=flavor,
         timeout=timeout,
@@ -358,6 +367,8 @@ def jobs_run(
         namespace=namespace,
     )
     out.result("Job started", id=job.id, url=job.url)
+    if name is None:
+        out.hint(f"Name this Job with `hf jobs labels {job.owner.name}/{job.id} --name NAME`.")
     if isinstance(job.status.expose_urls, list):
         urls = "\n".join(f"  {url}" for url in job.status.expose_urls)
         out.hint(f"Exposed ports are reachable at (requires an HF token with read access to the job):\n{urls}")
@@ -801,26 +812,30 @@ def jobs_wait(
 @jobs_cli.command(
     "labels",
     examples=[
+        "hf jobs labels <job_id> --name training-v2",
         "hf jobs labels <job_id> --label env=prod --label team=ml",
         "hf jobs labels <job_id> --clear",
     ],
 )
 def jobs_labels(
     job_id: JobIdArg,
+    name: NameOpt = None,
     label: LabelsOpt = None,
     clear: Annotated[bool, Option("--clear", help="Remove all labels from the job.")] = False,
     namespace: NamespaceOpt = None,
     token: TokenOpt = None,
 ) -> None:
     """Update labels on a Job. Replaces all existing labels."""
-    if not label and not clear:
-        raise CLIError("Please set at least one label with --label. To remove all labels, pass --clear.")
-    if label and clear:
+    if not label and name is None and not clear:
         raise CLIError(
-            "Cannot set labels and clear them at the same time. Please use either --label or --clear, not both."
+            "Please set a name with --name or at least one label with --label. To remove all labels, pass --clear."
+        )
+    if (label or name is not None) and clear:
+        raise CLIError(
+            "Cannot set a name or labels and clear them at the same time. Please use --name/--label or --clear, not both."
         )
     job_id, namespace = _parse_namespace_from_job_id(job_id, namespace)
-    labels = _parse_labels_map(label) or {}
+    labels = _parse_labels_map(label, name=name) or {}
     api = get_hf_api(token=token)
     job = api.update_job_labels(job_id=job_id, labels=labels, namespace=namespace)
     out.result("Labels updated", id=job.id)
@@ -880,7 +895,7 @@ jobs_cli.add_group(uv_app, name="uv")
     "run",
     context_settings={"ignore_unknown_options": True},
     examples=[
-        "hf jobs uv run my_script.py",
+        "hf jobs uv run --name my-script my_script.py",
         "hf jobs uv run --detach my_script.py",
         "hf jobs uv run ml_training.py --flavor a10g-small",
         "hf jobs uv run --with transformers train.py",
@@ -894,6 +909,7 @@ def jobs_uv_run(
     flavor: FlavorOpt = None,
     env: EnvOpt = None,
     secrets: SecretsOpt = None,
+    name: NameOpt = None,
     label: LabelsOpt = None,
     volume: JobVolumesOpt = None,
     env_file: EnvFileOpt = None,
@@ -920,7 +936,7 @@ def jobs_uv_run(
         image=image,
         env=env_map,
         secrets=secrets_map,
-        labels=_parse_labels_map(label),
+        labels=_parse_labels_map(label, name=name),
         volumes=_parse_and_sync_job_volumes(volume, api=api, namespace=namespace),
         flavor=flavor,
         timeout=timeout,
@@ -929,6 +945,8 @@ def jobs_uv_run(
         namespace=namespace,
     )
     out.result("Job started", id=job.id, url=job.url)
+    if name is None:
+        out.hint(f"Name this Job with `hf jobs labels {job.owner.name}/{job.id} --name NAME`.")
     if isinstance(job.status.expose_urls, list):
         urls = "\n".join(f"  {url}" for url in job.status.expose_urls)
         out.hint(f"Exposed ports are reachable at (requires an HF token with read access to the job):\n{urls}")
@@ -949,7 +967,7 @@ jobs_cli.add_group(scheduled_app, name="scheduled")
 @scheduled_app.command(
     "run",
     context_settings={"ignore_unknown_options": True},
-    examples=['hf jobs scheduled run "0 0 * * *" python:3.12 python script.py'],
+    examples=['hf jobs scheduled run "0 0 * * *" --name daily-script python:3.12 python script.py'],
 )
 def scheduled_run(
     schedule: ScheduleArg,
@@ -959,6 +977,7 @@ def scheduled_run(
     concurrency: ConcurrencyOpt = None,
     env: EnvOpt = None,
     secrets: SecretsOpt = None,
+    name: NameOpt = None,
     label: LabelsOpt = None,
     volume: JobVolumesOpt = None,
     env_file: EnvFileOpt = None,
@@ -982,7 +1001,7 @@ def scheduled_run(
         concurrency=concurrency,
         env=env_map,
         secrets=secrets_map,
-        labels=_parse_labels_map(label),
+        labels=_parse_labels_map(label, name=name),
         volumes=_parse_and_sync_job_volumes(volume, api=api, namespace=namespace),
         flavor=flavor,
         timeout=timeout,
@@ -990,6 +1009,8 @@ def scheduled_run(
         namespace=namespace,
     )
     out.result("Scheduled Job created", id=scheduled_job.id)
+    if name is None:
+        out.hint(f"Name this scheduled Job with `hf jobs scheduled labels {scheduled_job.id} --name NAME`.")
     out.hint(f"Use `hf jobs scheduled inspect {scheduled_job.id}` to view its details.")
 
 
@@ -1158,26 +1179,30 @@ def scheduled_trigger(
 @scheduled_app.command(
     "labels",
     examples=[
+        "hf jobs scheduled labels <id> --name daily-script",
         "hf jobs scheduled labels <id> --label env=prod --label team=ml",
         "hf jobs scheduled labels <id> --clear",
     ],
 )
 def scheduled_labels(
     scheduled_job_id: ScheduledJobIdArg,
+    name: NameOpt = None,
     label: LabelsOpt = None,
     clear: Annotated[bool, Option("--clear", help="Remove all labels from the scheduled job.")] = False,
     namespace: NamespaceOpt = None,
     token: TokenOpt = None,
 ) -> None:
     """Update labels on a scheduled Job. Replaces all existing labels."""
-    if not label and not clear:
-        raise CLIError("Please set at least one label with --label. To remove all labels, pass --clear.")
-    if label and clear:
+    if not label and name is None and not clear:
         raise CLIError(
-            "Cannot set labels and clear them at the same time. Please use either --label or --clear, not both."
+            "Please set a name with --name or at least one label with --label. To remove all labels, pass --clear."
+        )
+    if (label or name is not None) and clear:
+        raise CLIError(
+            "Cannot set a name or labels and clear them at the same time. Please use --name/--label or --clear, not both."
         )
     scheduled_job_id, namespace = _parse_namespace_from_job_id(scheduled_job_id, namespace)
-    labels = _parse_labels_map(label) or {}
+    labels = _parse_labels_map(label, name=name) or {}
     api = get_hf_api(token=token)
     scheduled_job = api.update_scheduled_job_labels(
         scheduled_job_id=scheduled_job_id, labels=labels, namespace=namespace
@@ -1193,7 +1218,7 @@ scheduled_app.add_group(scheduled_uv_app, name="uv")
     "run",
     context_settings={"ignore_unknown_options": True},
     examples=[
-        'hf jobs scheduled uv run "0 0 * * *" script.py',
+        'hf jobs scheduled uv run "0 0 * * *" --name daily-script script.py',
         'hf jobs scheduled uv run "0 0 * * *" script.py --with pandas',
     ],
 )
@@ -1207,6 +1232,7 @@ def scheduled_uv_run(
     flavor: FlavorOpt = None,
     env: EnvOpt = None,
     secrets: SecretsOpt = None,
+    name: NameOpt = None,
     label: LabelsOpt = None,
     volume: JobVolumesOpt = None,
     env_file: EnvFileOpt = None,
@@ -1234,7 +1260,7 @@ def scheduled_uv_run(
         image=image,
         env=env_map,
         secrets=secrets_map,
-        labels=_parse_labels_map(label),
+        labels=_parse_labels_map(label, name=name),
         volumes=_parse_and_sync_job_volumes(volume, api=api, namespace=namespace),
         flavor=flavor,
         timeout=timeout,
@@ -1242,27 +1268,33 @@ def scheduled_uv_run(
         namespace=namespace,
     )
     out.result("Scheduled Job created", id=job.id)
+    if name is None:
+        out.hint(f"Name this scheduled Job with `hf jobs scheduled labels {job.id} --name NAME`.")
     out.hint(f"Use `hf jobs scheduled inspect {job.id}` to view its details.")
 
 
 ### UTILS
 
 
-def _parse_labels_map(labels: list[str] | None) -> dict[str, str] | None:
+def _parse_labels_map(labels: list[str] | None, *, name: str | None = None) -> dict[str, str] | None:
     """Parse label key-value pairs from CLI arguments.
 
     Args:
         labels: List of label strings in KEY=VALUE format. If KEY only, then VALUE is set to empty string.
 
     Returns:
-        Dictionary mapping label keys to values, or None if no labels provided.
+        Dictionary mapping label keys to values, or None if no labels or name provided.
     """
-    if not labels:
+    if not labels and name is None:
         return None
     labels_map: dict[str, str] = {}
-    for label_var in labels:
+    for label_var in labels or []:
         key, value = label_var.split("=", 1) if "=" in label_var else (label_var, "")
         labels_map[key] = value
+    if name is not None:
+        if "name" in labels_map:
+            raise CLIError("--name and --label name=... cannot both be provided.")
+        labels_map["name"] = name
     return labels_map
 
 

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -11808,6 +11808,7 @@ class HfApi:
         secrets: dict[str, Any] | None = None,
         flavor: JobHardware | str | None = None,
         timeout: int | float | str | None = None,
+        name: str | None = None,
         labels: dict[str, str] | None = None,
         volumes: list[Volume] | None = None,
         expose: list[int] | None = None,
@@ -11840,6 +11841,10 @@ class HfApi:
             timeout (`Union[int, float, str]`, *optional*):
                 Max duration for the Job: int with s (seconds, default), m (minutes), h (hours) or d (days).
                 Example: `300` or `"5m"` for 5 minutes.
+
+            name (`str`, *optional*):
+                A name for the Job. Stored as the `name` label. Cannot be passed together with a `name` key in
+                `labels`. Names do not have to be unique.
 
             labels (`dict[str, str]`, *optional*):
                 Labels to attach to the job (key-value pairs).
@@ -11906,6 +11911,7 @@ class HfApi:
             secrets=secrets,
             flavor=flavor,
             timeout=timeout,
+            name=name,
             labels=labels,
             volumes=volumes,
             expose=expose,
@@ -12434,6 +12440,7 @@ class HfApi:
         secrets: dict[str, Any] | None = None,
         flavor: JobHardware | str | None = None,
         timeout: int | float | str | None = None,
+        name: str | None = None,
         labels: dict[str, str] | None = None,
         volumes: list[Volume] | None = None,
         expose: list[int] | None = None,
@@ -12473,6 +12480,10 @@ class HfApi:
             timeout (`Union[int, float, str]`, *optional*):
                 Max duration for the Job: int with s (seconds, default), m (minutes), h (hours) or d (days).
                 Example: `300` or `"5m"` for 5 minutes.
+
+            name (`str`, *optional*):
+                A name for the Job. Stored as the `name` label. Cannot be passed together with a `name` key in
+                `labels`. Names do not have to be unique.
 
             labels (`dict[str, str]`, *optional*):
                 Labels to attach to the job (key-value pairs).
@@ -12566,6 +12577,7 @@ class HfApi:
             secrets=secrets,
             flavor=flavor,
             timeout=timeout,
+            name=name,
             labels=labels,
             volumes=volumes,
             expose=expose,
@@ -12586,6 +12598,7 @@ class HfApi:
         secrets: dict[str, Any] | None = None,
         flavor: JobHardware | str | None = None,
         timeout: int | float | str | None = None,
+        name: str | None = None,
         labels: dict[str, str] | None = None,
         volumes: list[Volume] | None = None,
         expose: list[int] | None = None,
@@ -12627,6 +12640,10 @@ class HfApi:
             timeout (`Union[int, float, str]`, *optional*):
                 Max duration for the Job: int with s (seconds, default), m (minutes), h (hours) or d (days).
                 Example: `300` or `"5m"` for 5 minutes.
+
+            name (`str`, *optional*):
+                A name for the scheduled Job. Stored as the `name` label. Cannot be passed together with a `name`
+                key in `labels`. Names do not have to be unique.
 
             labels (`dict[str, str]`, *optional*):
                 Labels to attach to the job (key-value pairs).
@@ -12685,6 +12702,7 @@ class HfApi:
             secrets=secrets,
             flavor=flavor,
             timeout=timeout,
+            name=name,
             labels=labels,
             volumes=volumes,
             expose=expose,
@@ -12968,6 +12986,7 @@ class HfApi:
         secrets: dict[str, Any] | None = None,
         flavor: JobHardware | str | None = None,
         timeout: int | float | str | None = None,
+        name: str | None = None,
         labels: dict[str, str] | None = None,
         volumes: list[Volume] | None = None,
         expose: list[int] | None = None,
@@ -13016,6 +13035,10 @@ class HfApi:
             timeout (`Union[int, float, str]`, *optional*):
                 Max duration for the Job: int with s (seconds, default), m (minutes), h (hours) or d (days).
                 Example: `300` or `"5m"` for 5 minutes.
+
+            name (`str`, *optional*):
+                A name for the scheduled Job. Stored as the `name` label. Cannot be passed together with a `name`
+                key in `labels`. Names do not have to be unique.
 
             labels (`dict[str, str]`, *optional*):
                 Labels to attach to the job (key-value pairs).
@@ -13093,6 +13116,7 @@ class HfApi:
             secrets=secrets,
             flavor=flavor,
             timeout=timeout,
+            name=name,
             labels=labels,
             volumes=volumes,
             expose=expose,


### PR DESCRIPTION
## Summary

- add optional `name=` support to `run_job`, `run_uv_job`, `create_scheduled_job`, and `create_scheduled_uv_job`
- add `--name` to Docker/UV creation commands and to existing/scheduled label updates
- store names as the `name` label, with an explicit error when `name` and a `name` label are both provided
- suggest naming unnamed Jobs after creation and document the workflow in the Jobs guides

Names stay optional and do not need to be unique. The dedicated option is intentionally just a friendlier interface over the existing labels field, so filtering and UI behavior remain consistent.

Manual CLI checks:

```console
$ hf jobs run --help | rg -- '--name|--label'
  --name TEXT                     Name the Job. Stored as the `name` label.
  -l, --label TEXT                Set labels. E.g. --label KEY=VALUE or

$ hf jobs labels --help | rg -- '--name|--label'
  --name TEXT       Name the Job. Stored as the `name` label. Names do not
  -l, --label TEXT  Set labels. E.g. --label KEY=VALUE or --label LABEL
```

Validation:

```console
$ pytest tests/test_cli.py -k 'TestJobsCommand or test_update_job_labels'
30 passed, 267 deselected in 4.36s

$ make quality
All checks passed!
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive optional metadata on Jobs APIs and CLI; label-merge behavior for `--name`-only updates is a small behavior change but limited to the labels subcommand.
> 
> **Overview**
> Adds an optional **name** for Hub Jobs via `--name` on the CLI and `name=` on the Python API (`run_job`, `run_uv_job`, `create_scheduled_job`, `create_scheduled_uv_job`). Names are stored as the existing `name` label; passing both `name` and a `name` key in `labels` is rejected.
> 
> **`hf jobs labels`** (and scheduled equivalent) now accepts `--name` alone: it merges into current labels instead of replacing them, while `--label` still replaces all labels as before. Creation commands (`run`, `uv run`, scheduled variants) wire `--name` through `_parse_labels_map`, and unnamed jobs get a hint to name them after start.
> 
> Documentation and CLI reference examples are updated to show the naming workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81725bdaf0a94a6d506ffa4aca628d1c01f59070. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->