### PR TITLE
fix: skip space_sdk override when uploading to existing static Spaces

### DIFF
--- a/src/huggingface_hub/cli/upload.py
+++ b/src/huggingface_hub/cli/upload.py
@@ -201,15 +201,32 @@ def upload(
         # Otherwise, create repo and proceed with the upload
         if not os.path.isfile(resolved_local_path) and not os.path.isdir(resolved_local_path):
             raise FileNotFoundError(f"No such file or directory: '{resolved_local_path}'.")
-        created = api.create_repo(
-            repo_id=repo_id,
-            repo_type=repo_type_str,
-            exist_ok=True,
-            private=private,
-            space_sdk="gradio" if repo_type_str == "space" else None,
-            # ^ We don't want it to fail when uploading to a Space => let's set Gradio by default.
-            # ^ I'd rather not add CLI args to set it explicitly as we already have `hf repos create` for that.
-        ).repo_id
+
+        # Check if repo already exists to avoid sending space_sdk="gradio" to the server
+        # when uploading to an existing static Space (which would trigger a 402 payment
+        # check for Gradio Spaces on free cpu-basic hardware).
+        # See https://github.com/huggingface/huggingface_hub/issues/4535
+        existing_repo = None
+        if repo_type_str == "space":
+            try:
+                existing_repo = api.repo_info(repo_id=repo_id, repo_type=repo_type_str)
+            except Exception:
+                pass  # Repo doesn't exist yet, will be created below
+
+        if existing_repo is not None:
+            # Repo already exists — skip create_repo entirely to avoid overwriting
+            # Space SDK or triggering payment checks on the server side.
+            created = repo_id
+        else:
+            created = api.create_repo(
+                repo_id=repo_id,
+                repo_type=repo_type_str,
+                exist_ok=True,
+                private=private,
+                space_sdk="gradio" if repo_type_str == "space" else None,
+                # ^ We don't want it to fail when uploading to a Space => let's set Gradio by default.
+                # ^ I'd rather not add CLI args to set it explicitly as we already have `hf repos create` for that.
+            ).repo_id
 
         # Check if branch already exists and if not, create it
         if revision is not None and not create_pr:

--- a/src/huggingface_hub/cli/upload.py
+++ b/src/huggingface_hub/cli/upload.py
@@ -206,14 +206,11 @@ def upload(
         # when uploading to an existing static Space (which would trigger a 402 payment
         # check for Gradio Spaces on free cpu-basic hardware).
         # See https://github.com/huggingface/huggingface_hub/issues/4535
-        existing_repo = None
-        if repo_type_str == "space":
-            try:
-                existing_repo = api.repo_info(repo_id=repo_id, repo_type=repo_type_str)
-            except Exception:
-                pass  # Repo doesn't exist yet, will be created below
+        repo_already_exists = (
+            repo_type_str == "space" and api.repo_exists(repo_id=repo_id, repo_type=repo_type_str)
+        )
 
-        if existing_repo is not None:
+        if repo_already_exists:
             # Repo already exists — skip create_repo entirely to avoid overwriting
             # Space SDK or triggering payment checks on the server side.
             created = repo_id

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -704,13 +704,13 @@ class TestUploadCommand:
             ):
                 api = api_cls.return_value
                 # Simulate that the Space already exists
-                api.repo_info.return_value = Mock(repo_id="user/my-space")
+                api.repo_exists.return_value = True
                 api.upload_folder.return_value = "uploaded"
                 result = runner.invoke(app, ["upload", "user/my-space", "my-folder", "--repo-type", "space"])
         assert result.exit_code == 0, result.output
         # create_repo must NOT be called when the Space already exists
         api.create_repo.assert_not_called()
-        api.repo_info.assert_called_once_with(repo_id="user/my-space", repo_type="space")
+        api.repo_exists.assert_called_once_with(repo_id="user/my-space", repo_type="space")
         api.upload_folder.assert_called_once()
 
     def test_upload_to_new_space_creates_repo_with_gradio_sdk(self, runner: CliRunner) -> None:
@@ -727,7 +727,7 @@ class TestUploadCommand:
             ):
                 api = api_cls.return_value
                 # Simulate that the Space does NOT exist
-                api.repo_info.side_effect = Exception("Repo not found")
+                api.repo_exists.return_value = False
                 api.create_repo.return_value = Mock(repo_id="user/new-space")
                 api.upload_folder.return_value = "uploaded"
                 result = runner.invoke(app, ["upload", "user/new-space", "my-folder", "--repo-type", "space"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -690,6 +690,57 @@ class TestUploadCommand:
         with pytest.raises(CLIError, match="Cannot combine a path"):
             upload(repo_id="hf://datasets/foo/bar/data/train.csv", local_path="./train.csv", path_in_repo="other.csv")
 
+    def test_upload_to_existing_space_skips_create_repo(self, runner: CliRunner) -> None:
+        """Uploading to an existing Space must NOT call create_repo to avoid 402 on static Spaces."""
+        with SoftTemporaryDirectory() as tmp_dir:
+            folder = Path(tmp_dir) / "my-folder"
+            folder.mkdir()
+            with (
+                patch(
+                    "huggingface_hub.cli.upload._resolve_upload_paths",
+                    return_value=(folder.as_posix(), ".", None),
+                ),
+                patch("huggingface_hub.cli.upload.get_hf_api") as api_cls,
+            ):
+                api = api_cls.return_value
+                # Simulate that the Space already exists
+                api.repo_info.return_value = Mock(repo_id="user/my-space")
+                api.upload_folder.return_value = "uploaded"
+                result = runner.invoke(app, ["upload", "user/my-space", "my-folder", "--repo-type", "space"])
+        assert result.exit_code == 0, result.output
+        # create_repo must NOT be called when the Space already exists
+        api.create_repo.assert_not_called()
+        api.repo_info.assert_called_once_with(repo_id="user/my-space", repo_type="space")
+        api.upload_folder.assert_called_once()
+
+    def test_upload_to_new_space_creates_repo_with_gradio_sdk(self, runner: CliRunner) -> None:
+        """When Space does not exist, create_repo is called with space_sdk='gradio'."""
+        with SoftTemporaryDirectory() as tmp_dir:
+            folder = Path(tmp_dir) / "my-folder"
+            folder.mkdir()
+            with (
+                patch(
+                    "huggingface_hub.cli.upload._resolve_upload_paths",
+                    return_value=(folder.as_posix(), ".", None),
+                ),
+                patch("huggingface_hub.cli.upload.get_hf_api") as api_cls,
+            ):
+                api = api_cls.return_value
+                # Simulate that the Space does NOT exist
+                api.repo_info.side_effect = Exception("Repo not found")
+                api.create_repo.return_value = Mock(repo_id="user/new-space")
+                api.upload_folder.return_value = "uploaded"
+                result = runner.invoke(app, ["upload", "user/new-space", "my-folder", "--repo-type", "space"])
+        assert result.exit_code == 0, result.output
+        api.create_repo.assert_called_once_with(
+            repo_id="user/new-space",
+            repo_type="space",
+            exist_ok=True,
+            private=None,
+            space_sdk="gradio",
+        )
+        api.upload_folder.assert_called_once()
+
 
 class TestResolveUploadPaths:
     def test_upload_with_wildcard(self) -> None:


### PR DESCRIPTION
## Problem

`huggingface upload` fails with a **402 Payment Required** when uploading to an existing **static Space** on free `cpu-basic` hardware.

**Root cause:** In `run_upload()`, `create_repo()` is always called with `space_sdk="gradio"` when `repo_type` is `"space"`. Even though `exist_ok=True` is set, the server-side request still includes `sdk=gradio` in the payload, which triggers a paywall check for Gradio Spaces — even when the target Space already exists as a static (`sdk: static`) Space.

## Fix

Before calling `create_repo()`, check if the Space already exists via `api.repo_info()`. If it does, skip the `create_repo()` call entirely:

- **Existing Space** → skip `create_repo()`, go straight to upload
- **New Space** → call `create_repo()` with `space_sdk="gradio"` as before

This avoids the 402 error while preserving the existing behavior for new Space creation.

## Changes

- **`src/huggingface_hub/cli/upload.py`** — `run_upload()` now calls `repo_info()` to check for an existing Space before calling `create_repo()`.
- **`tests/test_cli.py`** — Two new tests:
  - `test_upload_to_existing_space_skips_create_repo` — verifies `create_repo` is not called when the Space already exists
  - `test_upload_to_new_space_creates_repo_with_gradio_sdk` — verifies `create_repo` is called with `space_sdk="gradio"` when the Space does not exist

Closes #4535

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow CLI upload change for Spaces only; models/datasets behavior unchanged, with regression tests for the new branch.
> 
> **Overview**
> Fixes **402 Payment Required** when `hf upload` targets an **existing static Space** on free hardware. The upload path always called `create_repo()` with `space_sdk="gradio"`, which still sent Gradio SDK metadata to the Hub and triggered a paid-Space check even when the repo already existed.
> 
> For **`--repo-type space`**, `run_upload()` now calls **`api.repo_exists()`** first. If the Space is already there, it **skips `create_repo()`** and uploads with the given `repo_id`. **New Spaces** still go through **`create_repo(..., space_sdk="gradio")`** as before.
> 
> Tests cover both branches: existing Space must not call `create_repo`, new Space must still create with `space_sdk="gradio"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 854d161bc4befa178c292557c27bbeca977d348c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->