### PR TITLE
Update Apache License version date to July 2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
                                  Apache License
-                           Version 2.0, January 2004
+                           Version 2.0, July 16 2026
                         http://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only header change with no runtime, security, or dependency impact.
> 
> **Overview**
> Updates the **Apache License 2.0** banner in `LICENSE` so the version line reads **July 16 2026** instead of **January 2004**.
> 
> No other license terms or sections are modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da00c547a9b17c2b368fe08a8a1105f3307fb432. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->