### PR TITLE
[Docs] Fix compromised DO_NOT_TRACK URL

### DIFF
--- a/docs/source/en/package_reference/environment_variables.md
+++ b/docs/source/en/package_reference/environment_variables.md
@@ -227,7 +227,7 @@ Some environment variables are not specific to `huggingface_hub` but are still t
 
 ### DO_NOT_TRACK
 
-Boolean value. Equivalent to `HF_HUB_DISABLE_TELEMETRY`. When set to true, telemetry is globally disabled in the Hugging Face Python ecosystem (`transformers`, `diffusers`, `gradio`, etc.). See https://consoledonottrack.com/ for more details.
+Boolean value. Equivalent to `HF_HUB_DISABLE_TELEMETRY`. When set to true, telemetry is globally disabled in the Hugging Face Python ecosystem (`transformers`, `diffusers`, `gradio`, etc.). See https://donottrack.sh/ for more details.
 
 ### NO_COLOR
 

--- a/docs/source/ko/package_reference/environment_variables.md
+++ b/docs/source/ko/package_reference/environment_variables.md
@@ -129,7 +129,7 @@ Hugging Face 생태계의 모든 환경 변수를 표준화하기 위해 일부 
 
 ### DO_NOT_TRACK[[donottrack]]
 
-불리언 값입니다. `hf_hub_disable_telemetry`에 해당합니다. True로 설정하면 Hugging Face Python 생태계(`transformers`, `diffusers`, `gradio` 등)에서 원격 측정이 전역적으로 비활성화됩니다. 자세한 내용은 https://consoledonottrack.com/ 을 참조하세요.
+불리언 값입니다. `hf_hub_disable_telemetry`에 해당합니다. True로 설정하면 Hugging Face Python 생태계(`transformers`, `diffusers`, `gradio` 등)에서 원격 측정이 전역적으로 비활성화됩니다. 자세한 내용은 https://donottrack.sh/ 을 참조하세요.
 
 ### NO_COLOR[[nocolor]]
 

--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -240,7 +240,7 @@ HF_DEBUG = _is_true(os.environ.get("HF_DEBUG"))
 HF_HUB_DISABLE_TELEMETRY = (
     _is_true(os.environ.get("HF_HUB_DISABLE_TELEMETRY"))  # HF-specific env variable
     or _is_true(os.environ.get("DISABLE_TELEMETRY"))
-    or _is_true(os.environ.get("DO_NOT_TRACK"))  # https://consoledonottrack.com/
+    or _is_true(os.environ.get("DO_NOT_TRACK"))  # https://donottrack.sh/
 )
 
 HF_TOKEN_PATH = os.path.expandvars(


### PR DESCRIPTION
## Summary
- Replace `https://consoledonottrack.com/` (hijacked domain) with `https://donottrack.sh/` in env var docs (en, ko) and `constants.py`.
- Fixes #4544

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and comment-only URL swap with no logic or runtime behavior changes.
> 
> **Overview**
> Updates every reference to the **DO_NOT_TRACK** standard from the hijacked `consoledonottrack.com` URL to **`https://donottrack.sh/`** in the English and Korean environment-variable docs and in the inline comment next to `DO_NOT_TRACK` handling in `constants.py`.
> 
> **Telemetry behavior is unchanged**—`DO_NOT_TRACK` still opts out the same way via `HF_HUB_DISABLE_TELEMETRY`; only the documented and commented link is corrected (fixes #4544).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14137d2a5abab929d650a9c3cf71b2425981f077. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->