### PR TITLE
Fix Windows crash when downloading into a deep local_dir

### DIFF
--- a/src/huggingface_hub/_local_folder.py
+++ b/src/huggingface_hub/_local_folder.py
@@ -431,15 +431,25 @@ def _huggingface_dir(local_dir: Path) -> Path:
     """Return the path to the `.cache/huggingface` directory in a local directory."""
     # Wrap in lru_cache to avoid overwriting the .gitignore file if called multiple times
     path = local_dir / ".cache" / "huggingface"
-    path.mkdir(exist_ok=True, parents=True)
+    # Some Windows versions do not allow for paths longer than 255 characters, so creating the
+    # `.cache/huggingface` directory (and the bookkeeping files below) fails for a deep `local_dir`.
+    # Use the extended-length "\\?\" prefix for the filesystem operations, matching what
+    # `get_local_download_paths`/`get_local_upload_paths` already do for the download/upload paths.
+    # The un-prefixed `path` is still returned so callers keep re-deriving/prefixing as before.
+    target = path
+    if os.name == "nt":
+        abs_path = os.path.abspath(path)
+        if len(abs_path) > 255 and not abs_path.startswith("\\\\?\\"):
+            target = Path("\\\\?\\" + abs_path)
+    target.mkdir(exist_ok=True, parents=True)
 
     # Create a CACHEDIR.TAG so backup tools can skip this directory.
-    _create_cachedir_tag(path)
+    _create_cachedir_tag(target)
 
     # Create a .gitignore file in the .cache/huggingface directory if it doesn't exist
     # Should be thread-safe enough like this.
-    gitignore = path / ".gitignore"
-    gitignore_lock = path / ".gitignore.lock"
+    gitignore = target / ".gitignore"
+    gitignore_lock = target / ".gitignore.lock"
     if not gitignore.exists():
         try:
             with WeakFileLock(gitignore_lock, timeout=0.1):

--- a/src/huggingface_hub/_local_folder.py
+++ b/src/huggingface_hub/_local_folder.py
@@ -431,15 +431,16 @@ def _huggingface_dir(local_dir: Path) -> Path:
     """Return the path to the `.cache/huggingface` directory in a local directory."""
     # Wrap in lru_cache to avoid overwriting the .gitignore file if called multiple times
     path = local_dir / ".cache" / "huggingface"
-    # Some Windows versions do not allow for paths longer than 255 characters, so creating the
-    # `.cache/huggingface` directory (and the bookkeeping files below) fails for a deep `local_dir`.
+    # Without long path support enabled, Windows caps directory paths at 247 characters
+    # (MAX_PATH minus room for an 8.3 file name), so creating the `.cache/huggingface` directory
+    # (and the bookkeeping files below) fails for a deep `local_dir`.
     # Use the extended-length "\\?\" prefix for the filesystem operations, matching what
     # `get_local_download_paths`/`get_local_upload_paths` already do for the download/upload paths.
     # The un-prefixed `path` is still returned so callers keep re-deriving/prefixing as before.
     target = path
     if os.name == "nt":
         abs_path = os.path.abspath(path)
-        if len(abs_path) > 255 and not abs_path.startswith("\\\\?\\"):
+        if len(abs_path) > 247 and not abs_path.startswith("\\\\?\\"):
             target = Path("\\\\?\\" + abs_path)
     target.mkdir(exist_ok=True, parents=True)
 

--- a/tests/test_local_folder.py
+++ b/tests/test_local_folder.py
@@ -144,21 +144,24 @@ def test_local_download_paths_long_paths(tmp_path: Path):
 
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows-specific test.")
-def test_local_download_paths_long_local_dir(tmp_path: Path):
+@pytest.mark.parametrize("cache_dir_len", [252, 300])
+def test_local_download_paths_long_local_dir(tmp_path: Path, cache_dir_len: int):
     r"""A deep ``local_dir`` must not crash when its ``.cache/huggingface`` folder exceeds the
-    Windows ~255 char path limit.
+    Windows directory path limit (247 chars, i.e. MAX_PATH minus room for an 8.3 file name).
 
     Unlike ``test_local_download_paths_long_paths`` (long *filename*, short dir), here the
     ``local_dir`` itself is long, so the limit is first hit while ``_huggingface_dir`` creates
     ``<local_dir>/.cache/huggingface``. Without the extended-length ``\\?\`` prefix that ``mkdir``
     raised ``FileNotFoundError`` (WinError 206) before the download/upload paths were built.
+    Both boundary cases are covered: 248-259 (only directory creation exceeds the limit) and
+    260+ (file creation would fail too).
     """
-    # Create a `local_dir` long enough that `<local_dir>/.cache/huggingface` exceeds 255 chars.
+    # Create a `local_dir` so that `<local_dir>/.cache/huggingface` is `cache_dir_len` chars long.
     # Use the extended-length prefix here since a plain mkdir of such a path would itself fail.
-    padding = "d" * max(1, 250 - len(str(tmp_path)))
+    padding = "d" * max(1, cache_dir_len - len(str(tmp_path / ".cache" / "huggingface")) - 1)
     local_dir = tmp_path / padding
     os.makedirs("\\\\?\\" + os.path.abspath(local_dir), exist_ok=True)
-    assert len(str(local_dir / ".cache" / "huggingface")) > 255
+    assert len(str(local_dir / ".cache" / "huggingface")) >= max(cache_dir_len, 248)
 
     # Must not raise, and the (extended-length) parent directories must have been created.
     paths = get_local_download_paths(local_dir, "config.json")

--- a/tests/test_local_folder.py
+++ b/tests/test_local_folder.py
@@ -143,6 +143,30 @@ def test_local_download_paths_long_paths(tmp_path: Path):
     assert str(paths.metadata_path).startswith("\\\\?\\")
 
 
+@pytest.mark.skipif(os.name != "nt", reason="Windows-specific test.")
+def test_local_download_paths_long_local_dir(tmp_path: Path):
+    r"""A deep ``local_dir`` must not crash when its ``.cache/huggingface`` folder exceeds the
+    Windows ~255 char path limit.
+
+    Unlike ``test_local_download_paths_long_paths`` (long *filename*, short dir), here the
+    ``local_dir`` itself is long, so the limit is first hit while ``_huggingface_dir`` creates
+    ``<local_dir>/.cache/huggingface``. Without the extended-length ``\\?\`` prefix that ``mkdir``
+    raised ``FileNotFoundError`` (WinError 206) before the download/upload paths were built.
+    """
+    # Create a `local_dir` long enough that `<local_dir>/.cache/huggingface` exceeds 255 chars.
+    # Use the extended-length prefix here since a plain mkdir of such a path would itself fail.
+    padding = "d" * max(1, 250 - len(str(tmp_path)))
+    local_dir = tmp_path / padding
+    os.makedirs("\\\\?\\" + os.path.abspath(local_dir), exist_ok=True)
+    assert len(str(local_dir / ".cache" / "huggingface")) > 255
+
+    # Must not raise, and the (extended-length) parent directories must have been created.
+    paths = get_local_download_paths(local_dir, "config.json")
+    assert str(paths.metadata_path).startswith("\\\\?\\")
+    assert paths.metadata_path.parent.is_dir()
+    assert paths.file_path.parent.is_dir()
+
+
 def test_write_download_metadata(tmp_path: Path):
     """Test download metadata content is valid."""
     # Write metadata


### PR DESCRIPTION
On Windows the default is LongPathsEnabled=0, downloading into a deep local directory crash while creating the. cache/huggingface directory. That guard prefixes paths above 255 chars, but directory creation already fails at ≥248
(MAX_PATH minus 12 for legacy 8.3 names), so the 248-255 window slips through and throws.

The repro is local_dir whose absolute path lands in that 248-255 window + an ordinary file name -> the crash. The fix
is to lower the guard threshold to >247 so \\?\ extended-length prefix applies across the whole failing range.

Testing is a parametrized regression test at [252, 300] chars, guarded to windows, then executing in your windows-latest CI matrix. AI assisted me with this PR, I've reviewed the change and understand every line.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Windows filesystem path handling in local-dir cache setup; behavior elsewhere is unchanged and covered by a targeted regression test.
> 
> **Overview**
> Fixes **WinError 206** when downloading into a very deep `local_dir` on Windows without long-path support enabled.
> 
> **`_huggingface_dir`** now applies the `\\?\` extended-length prefix for `mkdir`, `CACHEDIR.TAG`, and `.gitignore` when the absolute `.cache/huggingface` path exceeds **247** characters (directory limit before the existing **255**-char guard on download/upload paths). It still returns the normal unprefixed path so downstream path logic is unchanged.
> 
> Adds a **Windows-only** parametrized test (`252` and `300` char cache paths) that exercises `get_local_download_paths` with a long `local_dir`, not just a long filename.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02efc9720a8fcf67b4414bc6f1161291ffe581cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->