### PR TITLE
fix: bound safetensors metadata Range requests with a timeout

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -6889,8 +6889,15 @@ class HfApi:
             [`SafetensorsParsingError`]:
                 If a safetensors file header couldn't be parsed correctly.
         """
+        # Normalize the timeout before handing it to httpx. `None` resolves to the
+        # configured default (`HF_HUB_DOWNLOAD_TIMEOUT`), while `0` is the documented
+        # way to disable the bound entirely. Note that for httpx `0` means a
+        # zero-second timeout (i.e. immediate failure), so we translate it to `None`,
+        # which is the only value that actually disables timeouts.
         if timeout is None:
             timeout = constants.HF_HUB_DOWNLOAD_TIMEOUT
+        elif timeout == 0:
+            timeout = None
         url = hf_hub_url(
             repo_id=repo_id, filename=filename, repo_type=repo_type, revision=revision, endpoint=self.endpoint
         )

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -6694,6 +6694,7 @@ class HfApi:
         repo_type: str | None = None,
         revision: str | None = None,
         token: bool | str | None = None,
+        timeout: float | None = None,
     ) -> SafetensorsRepoMetadata:
         """
         Parse metadata for a safetensors repo on the Hub.
@@ -6720,6 +6721,12 @@ class HfApi:
                 token, which is the recommended method for authentication (see
                 https://huggingface.co/docs/huggingface_hub/quick-start#authentication).
                 To disable authentication, pass `False`.
+            timeout (`float` or `None`, *optional*):
+                Timeout for each Range request, in seconds. If `None` (default), falls back to
+                [`~constants.HF_HUB_DOWNLOAD_TIMEOUT`] (defaults to 10s). Pass `0` to disable. Without a
+                bound, a stalled or half-open connection to a shard can block the worker indefinitely
+                and hang the whole call (and any caller). See
+                https://github.com/huggingface/huggingface_hub/issues/4377.
 
         Returns:
             [`SafetensorsRepoMetadata`]: information related to safetensors repo.
@@ -6771,6 +6778,7 @@ class HfApi:
                 repo_type=repo_type,
                 revision=revision,
                 token=token,
+                timeout=timeout,
             )
             return SafetensorsRepoMetadata(
                 metadata=None,
@@ -6805,7 +6813,12 @@ class HfApi:
 
             def _parse(filename: str) -> None:
                 files_metadata[filename] = self.parse_safetensors_file_metadata(
-                    repo_id=repo_id, filename=filename, repo_type=repo_type, revision=revision, token=token
+                    repo_id=repo_id,
+                    filename=filename,
+                    repo_type=repo_type,
+                    revision=revision,
+                    token=token,
+                    timeout=timeout,
                 )
 
             thread_map(
@@ -6835,6 +6848,7 @@ class HfApi:
         repo_type: str | None = None,
         revision: str | None = None,
         token: bool | str | None = None,
+        timeout: float | None = None,
     ) -> SafetensorsFileMetadata:
         """
         Parse metadata from a safetensors file on the Hub.
@@ -6859,6 +6873,11 @@ class HfApi:
                 token, which is the recommended method for authentication (see
                 https://huggingface.co/docs/huggingface_hub/quick-start#authentication).
                 To disable authentication, pass `False`.
+            timeout (`float` or `None`, *optional*):
+                Timeout for each Range request, in seconds. If `None` (default), falls back to
+                [`~constants.HF_HUB_DOWNLOAD_TIMEOUT`] (defaults to 10s). Pass `0` to disable. Without a
+                bound, a stalled or half-open connection can block the read indefinitely and hang the
+                caller. See https://github.com/huggingface/huggingface_hub/issues/4377.
 
         Returns:
             [`SafetensorsFileMetadata`]: information related to a safetensors file.
@@ -6870,6 +6889,8 @@ class HfApi:
             [`SafetensorsParsingError`]:
                 If a safetensors file header couldn't be parsed correctly.
         """
+        if timeout is None:
+            timeout = constants.HF_HUB_DOWNLOAD_TIMEOUT
         url = hf_hub_url(
             repo_id=repo_id, filename=filename, repo_type=repo_type, revision=revision, endpoint=self.endpoint
         )
@@ -6882,7 +6903,7 @@ class HfApi:
         # We assume fetching 100kb is faster than making 2 GET requests. Therefore we always fetch the first 100kb to
         # avoid the 2nd GET in most cases.
         # See https://github.com/huggingface/huggingface_hub/pull/1855#discussion_r1404286419.
-        response = get_session().get(url, headers={**_headers, "range": "bytes=0-100000"})
+        response = get_session().get(url, headers={**_headers, "range": "bytes=0-100000"}, timeout=timeout)
         hf_raise_for_status(response)
 
         # 2. Parse and validate metadata size using shared helper
@@ -6892,7 +6913,9 @@ class HfApi:
         if metadata_size <= 100000:
             metadata_as_bytes = response.content[8 : 8 + metadata_size]
         else:  # 3.b. Request full metadata
-            response = get_session().get(url, headers={**_headers, "range": f"bytes=8-{metadata_size + 7}"})
+            response = get_session().get(
+                url, headers={**_headers, "range": f"bytes=8-{metadata_size + 7}"}, timeout=timeout
+            )
             hf_raise_for_status(response)
             metadata_as_bytes = response.content
 

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -4927,3 +4927,17 @@ class TestSafetensorsMetadataTimeout:
 
         _, kwargs = parse.call_args
         assert kwargs["timeout"] == 7.5
+
+    def test_parse_safetensors_file_metadata_zero_disables_timeout(self, api: HfApi) -> None:
+        """Per the docstring, `timeout=0` disables the bound (rather than meaning a
+        zero-second/immediate-failure timeout, which is how httpx interprets `0`)."""
+        header_json = b'{"__metadata__":{"format":"pt"}}'
+        content = len(header_json).to_bytes(8, "little") + header_json
+
+        with patch("huggingface_hub.hf_api.get_session") as get_session:
+            get_session().get.return_value = self._mock_response(content)
+            api.parse_safetensors_file_metadata("org/repo", "model.safetensors", timeout=0)
+
+        assert get_session().get.call_count == 1
+        _, kwargs = get_session().get.call_args
+        assert kwargs["timeout"] is None

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -4860,3 +4860,70 @@ def _to_snake_case(name: str) -> str:
     import re
 
     return re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", name).replace("-", "_").lower()
+
+
+class TestSafetensorsMetadataTimeout:
+    """Regression tests for the timeout on safetensors metadata Range requests.
+
+    Before the fix, `parse_safetensors_file_metadata` and `get_safetensors_metadata`
+    issued Range GETs with no `timeout`, so a stalled/half-open CDN connection
+    could block the worker thread indefinitely and hang the whole call.
+    See https://github.com/huggingface/huggingface_hub/issues/4377.
+    """
+
+    @pytest.fixture
+    def api(self) -> HfApi:
+        return HfApi(endpoint="https://hf.co", token="token")
+
+    @staticmethod
+    def _mock_response(content: bytes):
+        response = Mock()
+        response.content = content
+        return response
+
+    def test_parse_safetensors_file_metadata_passes_default_timeout(self, api: HfApi) -> None:
+        """When timeout is None, the HF_HUB_DOWNLOAD_TIMEOUT default is applied."""
+        # Minimal valid safetensors header: 8-byte little-endian length + JSON body
+        # with only a __metadata__ block (no tensor keys).
+        header_json = b'{"__metadata__":{"format":"pt"}}'
+        content = len(header_json).to_bytes(8, "little") + header_json
+
+        with patch("huggingface_hub.hf_api.get_session") as get_session:
+            get_session().get.return_value = self._mock_response(content)
+            api.parse_safetensors_file_metadata("org/repo", "model.safetensors")
+
+        assert get_session().get.call_count == 1
+        _, kwargs = get_session().get.call_args
+        assert kwargs["timeout"] == constants.HF_HUB_DOWNLOAD_TIMEOUT
+
+    def test_parse_safetensors_file_metadata_explicit_timeout_is_forwarded(self, api: HfApi) -> None:
+        """A caller-supplied timeout overrides the default on both Range requests."""
+        # Header length > 100000 forces the second (full-metadata) Range request.
+        # Put the bulk in the __metadata__ block so there are no tensor keys to
+        # validate.
+        pad = "x" * 120000
+        header_json = ('{"__metadata__":{"format":"' + pad + '"}}').encode()
+        full_content = len(header_json).to_bytes(8, "little") + header_json
+        # The first GET returns the first 100kb (prefix + header preview); the
+        # second GET returns the bare metadata bytes (no prefix).
+        first_response = self._mock_response(full_content)
+        second_response = self._mock_response(header_json)
+
+        with patch("huggingface_hub.hf_api.get_session") as get_session:
+            get_session().get.side_effect = [first_response, second_response]
+            api.parse_safetensors_file_metadata("org/repo", "model.safetensors", timeout=42.0)
+
+        timeouts = [call.kwargs["timeout"] for call in get_session().get.call_args_list]
+        assert timeouts == [42.0, 42.0]
+
+    def test_get_safetensors_metadata_forwards_timeout_to_file_parse(self, api: HfApi) -> None:
+        """`get_safetensors_metadata` threads its timeout into the per-file parse call."""
+        with (
+            patch.object(HfApi, "file_exists", side_effect=lambda **kw: kw["filename"] == "model.safetensors"),
+            patch.object(HfApi, "parse_safetensors_file_metadata") as parse,
+        ):
+            parse.return_value = SafetensorsFileMetadata(metadata={"format": "pt"}, tensors={})
+            api.get_safetensors_metadata("org/repo", timeout=7.5)
+
+        _, kwargs = parse.call_args
+        assert kwargs["timeout"] == 7.5


### PR DESCRIPTION
Fixes #4377.

HfApi.get_safetensors_metadata and HfApi.parse_safetensors_file_metadata fetched each shard header via a Range GET with no timeout, and fanned the requests out via thread_map with no overall deadline. A stalled or half-open connection to the CDN (one that accepts the request then never delivers the body and never closes) would block the worker thread indefinitely, hanging the whole call and any caller for the life of the process.

Both methods now accept a timeout parameter (default None, which falls back to constants.HF_HUB_DOWNLOAD_TIMEOUT, consistent with the *_info methods, get_hf_file_metadata, and file_download). The value is forwarded to every Range GET in parse_safetensors_file_metadata, and get_safetensors_metadata threads it through to the per-file parse call.

Added TestSafetensorsMetadataTimeout with three offline, mocked tests covering the default-timeout fallback, an explicit override on both Range requests (the small-header and the full-metadata paths), and the forwarding through get_safetensors_metadata. All three pass; ruff check + format clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted networking change with backward-compatible defaults; behavior matches existing download timeout patterns elsewhere in the library.
> 
> **Overview**
> Adds a **`timeout`** parameter to **`get_safetensors_metadata`** and **`parse_safetensors_file_metadata`**, forwarding it to every Range GET when reading safetensors headers (fixes indefinite hangs on stalled CDN connections, #4377).
> 
> **`None`** uses **`HF_HUB_DOWNLOAD_TIMEOUT`** (same as other Hub downloads); **`0`** disables the bound by mapping to httpx **`None`** (not a zero-second timeout). Sharded repos pass the same timeout through each per-shard parse.
> 
> **`TestSafetensorsMetadataTimeout`** adds mocked regression tests for default timeout, explicit override on one- and two-request paths, forwarding from **`get_safetensors_metadata`**, and **`timeout=0`** behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9abf5dc7cd60d6eec5f5ffe0b6d4526273b807c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->