### PR TITLE
Fix `_format_size` emitting "1000.0K" instead of rolling over to the next unit

### DIFF
--- a/src/huggingface_hub/utils/_cache_manager.py
+++ b/src/huggingface_hub/utils/_cache_manager.py
@@ -861,7 +861,10 @@ def _format_size(num: int) -> str:
     """
     num_f = float(num)
     for unit in ["", "K", "M", "G", "T", "P", "E", "Z"]:
-        if abs(num_f) < 1000.0:
+        # Compare the rounded value so a number that would render as "1000.0"
+        # (e.g. 999_999 bytes -> 999.999 -> rounded "1000.0K") rolls over to the
+        # next unit ("1.0M") instead.
+        if round(abs(num_f), 1) < 1000.0:
             return f"{num_f:3.1f}{unit}"
         num_f /= 1000.0
     return f"{num_f:.1f}Y"

--- a/tests/test_utils_cache.py
+++ b/tests/test_utils_cache.py
@@ -725,6 +725,11 @@ class TestStringFormatters:
         16.0: "16.0",
         1000.0: "1.0K",
         1024 * 1024 * 1024: "1.1G",  # not 1.0GiB
+        # A value that rounds up to 1000 of a unit must roll over to the next
+        # unit, not render as "1000.0K".
+        999_949: "999.9K",
+        999_950: "1.0M",
+        999_999: "1.0M",
     }
 
     SINCE = {


### PR DESCRIPTION
`_format_size` (used by `scan_cache_dir()` / `hf cache scan` for `size_on_disk_str` etc.) compares the raw value against `1000.0` before formatting with `%.1f`:

```python
for unit in ["", "K", "M", ...]:
    if abs(num_f) < 1000.0:
        return f"{num_f:3.1f}{unit}"
    num_f /= 1000.0
```

For a size in `[999.95·unit, 1000·unit)` the pre-division value is `< 1000` so the loop stops, but `%.1f` then rounds it up to `"1000.0"`. So `999_999` bytes prints `"1000.0K"` while the adjacent `1_000_000` correctly prints `"1.0M"` — inconsistent, and it breaks the humanizer's contract that the shown number stays in `[0, 1000)`.

```python
>>> _format_size(999_999)
'1000.0K'   # expected '1.0M'
>>> _format_size(1_000_000)
'1.0M'
```

Comparing the **rounded** value lets such numbers fall through to the next unit. No value that already fit changes (verified: `16.0→"16.0"`, `1000.0→"1.0K"`, `1024³→"1.1G"` unchanged).

Extends `TestStringFormatters.SIZES` with boundary cases (`999_949→"999.9K"`, `999_950→"1.0M"`, `999_999→"1.0M"`); `tests/test_utils_cache.py` passes (23).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only formatting change in cache utilities with targeted unit tests; no cache deletion or download behavior affected.
> 
> **Overview**
> Fixes human-readable cache sizes (e.g. `scan_cache_dir()` / `hf cache scan` `size_on_disk_str`) showing **"1000.0K"** for byte counts just under a million instead of **"1.0M"**.
> 
> `_format_size` now checks `round(abs(num_f), 1) < 1000.0` before picking a unit, so values that would format as `"1000.0"` with one decimal place advance to the next suffix. Existing outputs like `"16.0"`, `"1.0K"`, and `"1.1G"` stay the same.
> 
> `TestStringFormatters.SIZES` adds boundary cases (`999_949` → `"999.9K"`, `999_950` / `999_999` → `"1.0M"`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e35ca5d75954736358a0fc294d05e1f5f519fcdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->