### PR TITLE
Support scheme-less custom endpoints with ports

### DIFF
--- a/src/huggingface_hub/utils/_hf_uris.py
+++ b/src/huggingface_hub/utils/_hf_uris.py
@@ -344,8 +344,16 @@ def _looks_like_hf_url(uri: str, endpoint: str | None = None) -> bool:
     lowered = uri.lower()
     if lowered.startswith(("http://", "https://")):
         return True
-    # Scheme-less host (e.g. 'huggingface.co/org/model').
-    return any(lowered == host or lowered.startswith(host + "/") for host in _recognized_hosts(endpoint))
+    # Scheme-less host (e.g. 'huggingface.co/org/model'). Parse it instead of
+    # comparing string prefixes so custom endpoints with a port are supported.
+    try:
+        parsed = urlsplit(f"//{uri}")
+    except ValueError:
+        # Malformed netlocs (for example, an unterminated IPv6 address) are
+        # not Hugging Face URLs and should follow the regular HfUriError path.
+        return False
+    host = parsed.hostname.lower() if parsed.hostname else None
+    return host in _recognized_hosts(endpoint)
 
 
 def _decode_url_path_segment(segment: str) -> str:

--- a/tests/test_utils_hf_uris.py
+++ b/tests/test_utils_hf_uris.py
@@ -17,7 +17,7 @@ import pytest
 
 from huggingface_hub import constants
 from huggingface_hub.errors import HfUriError
-from huggingface_hub.utils import HfMount, HfUri, parse_hf_mount, parse_hf_uri
+from huggingface_hub.utils import HfMount, HfUri, is_hf_uri, parse_hf_mount, parse_hf_uri
 
 
 # ---------------------------------------------------------------------------
@@ -622,6 +622,14 @@ def test_parse_hf_uri_failure(uri: str, error_substring: str) -> None:
     assert exc_info.value.uri == uri
 
 
+@pytest.mark.parametrize("uri", ["[::1/path", "[::1"])
+def test_malformed_scheme_less_url_is_rejected(uri: str) -> None:
+    with pytest.raises(HfUriError, match="Must start with 'hf://'"):
+        parse_hf_uri(uri)
+
+    assert not is_hf_uri(uri)
+
+
 @pytest.mark.parametrize(("kwargs", "error_substring"), URI_DIRECT_INIT_INVALID_CASES)
 def test_hf_uri_direct_init_invalid(kwargs: dict, error_substring: str) -> None:
     with pytest.raises(HfUriError, match=error_substring):
@@ -650,6 +658,11 @@ def test_parse_hf_uri_custom_endpoint() -> None:
     # ... including self-hosted endpoints that carry a path prefix (stripped before parsing).
     assert parse_hf_uri(
         "http://localhost:8080/hf/my-org/my-model",
+        endpoint="http://localhost:8080/hf",
+    ) == HfUri(type="model", id="my-org/my-model", revision=None, path_in_repo="")
+
+    assert parse_hf_uri(
+        "localhost:8080/hf/my-org/my-model",
         endpoint="http://localhost:8080/hf",
     ) == HfUri(type="model", id="my-org/my-model", revision=None, path_in_repo="")
 


### PR DESCRIPTION
# Support scheme-less custom endpoints with ports in HF URI parsing

## Summary

`parse_hf_uri` accepts scheme-less Hugging Face web URLs, including custom endpoints passed through `endpoint`. However, a custom endpoint with a port, such as `http://localhost:8080/hf`, is rejected when the input omits the scheme:

```python
parse_hf_uri(
    "localhost:8080/hf/my-org/my-model",
    endpoint="http://localhost:8080/hf",
)
```

This change makes scheme-less host detection parse the hostname with `urlsplit()` instead of relying on string-prefix comparisons. The port is therefore handled separately from the hostname, while the existing recognized-host allowlist remains in place.

## Changes

- Parse scheme-less URL candidates with a temporary `//` prefix.
- Compare the parsed hostname against `_recognized_hosts(endpoint)`.
- Treat malformed scheme-less netlocs as ordinary invalid HF URIs instead of leaking `ValueError`.
- Add a regression test for a scheme-less `localhost:8080` endpoint.
- Add regression coverage for malformed IPv6-like scheme-less inputs.

## Validation

```text
python -m pytest tests/test_utils_hf_uris.py -q
142 passed
```

```text
git diff --check
```

The existing behavior for URLs with a scheme and for the public Hugging Face hosts is covered by the existing test cases.
