### PR TITLE
fix(cache): list repos with broken symlinks instead of silently dropping them

### DIFF
--- a/src/huggingface_hub/utils/_cache_manager.py
+++ b/src/huggingface_hub/utils/_cache_manager.py
@@ -789,7 +789,17 @@ def _scan_cached_repo(repo_path: Path) -> CachedRepoInfo:
 
             blob_path = Path(file_path).resolve()
             if not blob_path.exists():
-                raise CorruptedCacheException(f"Blob missing (broken symlink): {blob_path}")
+                # Broken symlink (e.g. blob removed manually or a partial download where
+                # the snapshot link was created before the blob finished writing). Skip the
+                # file instead of dropping the whole repo from the listing: silently
+                # omitting an entire cached repo just because one file is missing is
+                # surprising and hides potentially large amounts of cached data.
+                logger.warning(
+                    "Ignored broken symlink in cache (blob missing): %s. The file is kept"
+                    " on disk but not counted in the cache report.",
+                    blob_path,
+                )
+                continue
 
             if blob_path not in blob_stats:
                 blob_stats[blob_path] = blob_path.stat()

--- a/tests/test_utils_cache.py
+++ b/tests/test_utils_cache.py
@@ -43,6 +43,89 @@ class TestMissingCacheUtils:
             scan_cache_dir(file_path)
 
 
+class TestScanBrokenSymlink:
+    """Local (offline) tests for how `scan_cache_dir` handles broken symlinks.
+
+    A partial download or a manually pruned cache can leave snapshot entries that are
+    symlinks pointing to blobs that no longer exist. Previously this dropped the entire
+    repo from the listing (the exception was swallowed into `warnings`); the repo should
+    instead be listed with only the resolvable files counted.
+    """
+
+    @staticmethod
+    def _make_repo(repo_path: Path, commit_hash: str, files: dict[str, str], broken: list[str]) -> None:
+        """Create a fake cached repo under `repo_path`.
+
+        `files` maps snapshot filename -> blob content (valid symlinks).
+        `broken` lists snapshot filenames whose blob is intentionally not created.
+        """
+        snapshots = repo_path / "snapshots" / commit_hash
+        refs = repo_path / "refs"
+        blobs = repo_path / "blobs"
+        snapshots.mkdir(parents=True)
+        refs.mkdir(parents=True)
+        blobs.mkdir()
+        (refs / "main").write_text(commit_hash)
+        for filename, content in files.items():
+            blob_name = f"blob_{filename}"
+            (blobs / blob_name).write_text(content)
+            (snapshots / filename).symlink_to(blobs / blob_name)
+        for filename in broken:
+            (snapshots / filename).symlink_to(blobs / f"missing_{filename}")
+
+    def test_repo_with_broken_symlink_is_still_listed(self, tmp_path, caplog) -> None:
+        """A broken symlink must not hide the whole repo from the listing."""
+        cache_dir = tmp_path / "hub"
+        self._make_repo(
+            cache_dir / "models--org--partial",
+            commit_hash="abc123",
+            files={"config.json": "{}"},
+            broken=["weights.gguf"],
+        )
+
+        with caplog.at_level("WARNING", logger="huggingface_hub.utils._cache_manager"):
+            report = scan_cache_dir(cache_dir)
+
+        # Repo is listed (not swallowed into warnings)
+        assert len(report.repos) == 1
+        assert len(report.warnings) == 0
+
+        repo = list(report.repos)[0]
+        assert repo.repo_id == "org/partial"
+        assert repo.repo_type == "model"
+
+        # Only the resolvable file is counted; the broken one is skipped
+        revision = list(repo.revisions)[0]
+        assert revision.commit_hash == "abc123"
+        assert revision.nb_files == 1
+        assert revision.size_on_disk == len("{}")
+        # The `main` ref is preserved
+        assert revision.refs == frozenset({"main"})
+
+        # A warning was logged about the ignored broken symlink
+        assert any("broken symlink" in record.message for record in caplog.records)
+
+    def test_repo_with_only_broken_symlinks_is_listed_as_empty(self, tmp_path) -> None:
+        """If every file in the revision is a broken symlink, the repo is still listed."""
+        cache_dir = tmp_path / "hub"
+        self._make_repo(
+            cache_dir / "models--org--allbroken",
+            commit_hash="def456",
+            files={},
+            broken=["a.bin", "b.bin"],
+        )
+
+        report = scan_cache_dir(cache_dir)
+
+        assert len(report.repos) == 1
+        assert len(report.warnings) == 0
+        repo = list(report.repos)[0]
+        assert repo.size_on_disk == 0
+        revision = list(repo.revisions)[0]
+        assert revision.nb_files == 0
+        assert revision.refs == frozenset({"main"})
+
+
 @pytest.mark.production
 class TestValidCacheUtils:
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
When a cached repo has a broken symlink in a snapshot (a blob that was removed manually, or a partial download where the snapshot link outlived the blob), `_scan_cached_repo` raises `CorruptedCacheException("Blob missing (broken symlink)")`. `scan_cache_dir` swallows that into `warnings`, so the entire repo vanishes from `hf cache list` — even though its refs and the rest of its files are perfectly fine. `hf cache verify` resolves the same repo without trouble, which is how the mismatch in #4419 was spotted. The total disk usage reported by `hf cache list` is then wrong too (#4420), since the whole repo is omitted from the sum.

The fix skips the individual broken file and logs a warning, instead of failing the whole repo. The repo then shows up in the listing with only the resolvable files counted toward size, and its refs (e.g. `main`) are preserved. This is consistent with how empty revisions are already handled (`test_snapshot_with_no_blob_files`), and it doesn't change any public dataclass shape, so callers of `scan_cache_dir` don't need to adapt.

Added two offline unit tests (no network needed): one for a repo with a single broken symlink alongside a valid file, and one where every file in the revision is broken (repo still listed, size 0, refs intact). `make style`, `make quality` (including `ty check src`) and the local cache tests all pass.

Fixes #4419
Fixes #4420

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to cache scanning error handling with no API or security impact; behavior is more permissive but aligns with empty-revision handling and is covered by new unit tests.
> 
> **Overview**
> **`scan_cache_dir` no longer treats a missing blob behind a snapshot symlink as a corrupted repo.** In `_scan_cached_repo`, a broken symlink now logs a warning and is skipped instead of raising `CorruptedCacheException`, so `hf cache list` and total size include the repo with only resolvable files counted and refs preserved.
> 
> Offline tests cover mixed valid/broken symlinks and revisions where every snapshot entry is broken (repo still listed, zero size).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be7d1f5c906d509382940e536896c33117811630. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->