### PR TITLE
[Cache] Warn on inconsistency in cache

### DIFF
--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -577,6 +577,7 @@ $ hf cache list [OPTIONS]
 * `-f, --filter TEXT`: Filter entries (e.g. 'size>1GB', 'type=model', 'accessed>7d'). Can be used multiple times.
 * `--sort [accessed|accessed:asc|accessed:desc|modified|modified:asc|modified:desc|name|name:asc|name:desc|size|size:asc|size:desc]`: Sort entries by key. Supported keys: 'accessed', 'modified', 'name', 'size'. Append ':asc' or ':desc' to explicitly set the order (e.g., 'modified:asc'). Defaults: 'accessed', 'modified', 'size' default to 'desc' (newest/biggest first); 'name' defaults to 'asc' (alphabetical).
 * `--limit INTEGER`: Limit the number of results returned. Returns only the top N entries after sorting.
+* `--show-warnings / --no-show-warnings`: Show warnings about cache inconsistencies.  [default: no-show-warnings]
 * `--help`: Show this message and exit.
 
 Examples

--- a/src/huggingface_hub/cli/cache.py
+++ b/src/huggingface_hub/cli/cache.py
@@ -517,7 +517,7 @@ def ls(
     if len(hf_cache_info.warnings):
         if show_warnings:
             for warning in hf_cache_info.warnings:
-                out.warning(f"{warning}. Repo ignored.")
+                out.warning(str(warning).rstrip(".") + ". Repo ignored.")
         else:
             out.warning(
                 f"Found {len(hf_cache_info.warnings)} cache inconsistencies. Re-run with `--show-warnings` to display them."

--- a/src/huggingface_hub/cli/cache.py
+++ b/src/huggingface_hub/cli/cache.py
@@ -418,6 +418,12 @@ def ls(
             help="Limit the number of results returned. Returns only the top N entries after sorting.",
         ),
     ] = None,
+    show_warnings: Annotated[
+        bool,
+        Option(
+            help="Show warnings about cache inconsistencies.",
+        ),
+    ] = False,
 ) -> None:
     """List cached repositories or revisions."""
     try:
@@ -507,6 +513,15 @@ def ls(
                 f" and {_format_size(total_size)} on disk."
             )
         )
+
+    if len(hf_cache_info.warnings):
+        if show_warnings:
+            for warning in hf_cache_info.warnings:
+                out.warning(f"{warning}. Repo ignored.")
+        else:
+            out.warning(
+                f"Found {len(hf_cache_info.warnings)} cache inconsistencies. Re-run with `--show-warnings` to display them."
+            )
 
     incomplete_files = hf_cache_info.incomplete_files
     if incomplete_files:


### PR DESCRIPTION
Should mitigate https://github.com/huggingface/huggingface_hub/issues/4419 and https://github.com/huggingface/huggingface_hub/issues/4420

When scanning the cache, if an inconsistency is found (doesn't follow expected format, broken symlink, etc.) we drop the corrupted repo. The errors are collected in a list of warnings but are not displayed in the CLI. This PR adds a warning "Found X cache inconsistencies. Re-run with `--show-warnings` to display them." to the cache list output in case at least 1 inconsistency has been found. And adds the `--show-warnings` flag to display all of them. I didn't want to display all warnings by default to avoid bloating the output.

```
$ hf cache list
No results found.
Warning: Found 1 cache inconsistencies. Re-run with `--show-warnings` to display them.

$ hf cache list --show-warnings
No results found.
Warning: Blob missing (broken symlink): /home/wauplin/.cache/huggingface/hub/models--openai-community--gpt2/blobs/192e8257ae9e8f796f764630f4a488a6a16d1461762d62b49ef7405df951a283. Repo ignored.
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only output change for existing scan warnings; no changes to cache deletion or scan logic beyond visibility.
> 
> **Overview**
> **`hf cache list`** now reports when `scan_cache_dir` finds cache inconsistencies (e.g. broken symlinks, malformed entries) that cause repos to be skipped.
> 
> By default it prints a single warning with the count and tells users to re-run with **`--show-warnings`**. With that flag, each collected warning is printed in full, suffixed with “Repo ignored.” The new option is documented in the CLI reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00b88c1874780ac9bb6350622db48469f4b2ce77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->