### PR TITLE
fix(cli): allow '=' in hf jobs ls --label values

### DIFF
--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -637,7 +637,7 @@ def jobs_ps(
     for item in label or []:
         if "=" not in item:
             raise CLIError(f"Invalid label filter '{item}': must be in the form 'key=value'")
-        key, value = item.split("=")
+        key, value = item.split("=", 1)
         labels[key] = value
 
     jobs_iter = api.list_jobs(namespace=namespace, status=server_statuses, labels=labels or None)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3443,6 +3443,23 @@ class TestJobsCommand:
         assert kwargs["status"] == ["completed", "scheduling"]
         assert kwargs["labels"] == {"model": "Qwen3-06B"}
 
+    def test_ls_label_filter_accepts_value_containing_equals_sign(self, runner: CliRunner) -> None:
+        """Regression: a label value with an embedded '=' (e.g. a base64 blob, URL, or JSON
+        fragment) must not crash the CLI. Before the fix, `item.split("=")` raised
+        `ValueError: too many values to unpack` because it yielded more than 2 parts."""
+        with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            api.list_jobs.return_value = self._make_mock_jobs()
+            result = runner.invoke(
+                app, ["jobs", "ls", "--label", "token=abc=def==ghi", "--label", "url=https://example.co/x?a=1"]
+            )
+        assert result.exit_code == 0
+        kwargs = api.list_jobs.call_args.kwargs
+        assert kwargs["labels"] == {
+            "token": "abc=def==ghi",
+            "url": "https://example.co/x?a=1",
+        }
+
     def test_ls_format_json(self, runner: CliRunner) -> None:
         """Test that `hf jobs ls -a --format json` outputs valid JSON with all fields."""
         import json


### PR DESCRIPTION
The label-filter parser in jobs_ps used item.split("=") with no maxsplit, so a label value that itself contains an '=' (common for base64 tokens, URLs with query strings, or JSON fragments like config=key=value) crashed with 'ValueError: too many values to unpack' instead of being sent to the API. Only the simple key=value case worked.

This switches to split("=", 1) so everything after the first '=' is treated as the value. That matches how the same module already parses env/secret entries (jobs.py:1306) and how the legacy --filter path works (jobs.py:1051), so the behavior is now consistent across the jobs CLI.

Added a regression test that passes --label with values containing multiple '=' signs and asserts they round-trip unchanged into the list_jobs call.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI parsing fix with a targeted test; no auth, API contract, or server behavior changes.
> 
> **Overview**
> **`hf jobs ls --label`** no longer crashes when a label value contains `=` (e.g. base64, URLs with query strings).
> 
> The filter parser in **`jobs_ps`** now uses **`split("=", 1)`** so only the first `=` separates key from value, matching **`_parse_labels_map`** and the scheduled jobs **`--filter`** path. A CLI regression test asserts multi-`=` values are passed through to **`list_jobs`** unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88394a8869d2f8cd04007a9d5775cfb301a64ca4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->