### PR TITLE
Document the 150-character limit on collection descriptions

### DIFF
--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -766,7 +766,7 @@ $ hf collections create [OPTIONS] TITLE
 **Options**:
 
 * `--namespace TEXT`: The namespace (username or organization). Defaults to the authenticated user.
-* `--description TEXT`: A description for the collection.
+* `--description TEXT`: A description for the collection (max 150 characters).
 * `--private / --no-private`: Create a private collection.  [default: no-private]
 * `--exists-ok / --no-exists-ok`: Do not raise an error if the collection already exists.  [default: no-exists-ok]
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
@@ -905,7 +905,7 @@ $ hf collections update [OPTIONS] COLLECTION_SLUG
 **Options**:
 
 * `--title TEXT`: The new title for the collection.
-* `--description TEXT`: The new description for the collection.
+* `--description TEXT`: The new description for the collection (max 150 characters).
 * `--position INTEGER`: The new position of the collection in the owner's list.
 * `--private / --no-private`: Whether the collection should be private.
 * `--theme TEXT`: The theme color for the collection (e.g., 'green', 'blue').

--- a/src/huggingface_hub/cli/collections.py
+++ b/src/huggingface_hub/cli/collections.py
@@ -107,7 +107,7 @@ def collections_create(
     ] = None,
     description: Annotated[
         str | None,
-        Option(help="A description for the collection."),
+        Option(help="A description for the collection (max 150 characters)."),
     ] = None,
     private: Annotated[
         bool,
@@ -147,7 +147,7 @@ def collections_update(
     ] = None,
     description: Annotated[
         str | None,
-        Option(help="The new description for the collection."),
+        Option(help="The new description for the collection (max 150 characters)."),
     ] = None,
     position: Annotated[
         int | None,

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -10015,7 +10015,7 @@ class HfApi:
             namespace (`str`, *optional*):
                 Namespace of the collection to create (username or org). Will default to the owner name.
             description (`str`, *optional*):
-                Description of the collection to create.
+                Description of the collection to create. The maximum size for a description is 150 characters.
             private (`bool`, *optional*):
                 Whether the collection should be private or not. Defaults to `False` (i.e. public collection).
             exists_ok (`bool`, *optional*):
@@ -10086,7 +10086,7 @@ class HfApi:
             title (`str`):
                 Title of the collection to update.
             description (`str`, *optional*):
-                Description of the collection to update.
+                Description of the collection to update. The maximum size for a description is 150 characters.
             position (`int`, *optional*):
                 New position of the collection in the list of collections of the user.
             private (`bool`, *optional*):


### PR DESCRIPTION
The Hub rejects collection descriptions over 150 characters with a 400, but the limit isn't documented anywhere client-side — `--description` was described as just "A description for the collection", so you only find out by hitting it mid-script.

```
hf collections create "my-collection" --description "$(python3 -c 'print("x"*151)')"
# Error: Bad request:
# * Too big: expected string to have <150 characters * at description
```

This adds the limit to the `create`/`update` CLI help and to the `create_collection` / `update_collection_metadata` docstrings, matching the convention already used for item notes ("max 500 characters"). `docs/source/en/package_reference/cli.md` is regenerated via `generate_cli_reference.py --update`.

Docs only — no validation added, since the server error is already clear once you know the limit exists.

One note in case it's useful to whoever owns the API: the server message says `expected string to have <150 characters`, but the limit is inclusive — 150 characters is accepted and 151 is rejected. I documented the observed behaviour (max 150).

*Investigated and drafted with Claude Code; verified against the live Hub on `huggingface_hub` 1.24.0, and `make quality` passes locally.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only string updates with no runtime or validation changes.
> 
> **Overview**
> Documents the Hub’s **150-character cap** on collection `description` values so users see the limit before a 400 from the API.
> 
> **`hf collections create`** and **`hf collections update`** now say `(max 150 characters)` in `--description` help, aligned with how item **`--note`** already documents `(max 500 characters)`. The same limit is spelled out in **`create_collection`** and **`update_collection_metadata`** docstrings in `hf_api.py`, and the generated **`cli.md`** reference is updated accordingly.
> 
> No client-side validation is added; behavior is unchanged aside from documentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ad7347dcae69cfe32d1bc26012f9aef82434665. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->