### PR TITLE
Include models with zero co2_eq_emissions in threshold filter

### DIFF
--- a/src/huggingface_hub/utils/endpoint_helpers.py
+++ b/src/huggingface_hub/utils/endpoint_helpers.py
@@ -54,7 +54,7 @@ def _is_emission_within_threshold(model_info: "ModelInfo", minimum_threshold: fl
     emission = card_data.get("co2_eq_emissions", None)
     if isinstance(emission, dict):
         emission = emission["emissions"]
-    if not emission:
+    if emission is None:
         return False
 
     # Filter out if value is missing or out of range

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2395,6 +2395,17 @@ class TestHfApiPublicProduction:
         model = ModelInfo(**kwargs)
         assert _is_emission_within_threshold(model, -1, 100)
 
+    def test_is_emission_within_threshold_includes_zero(self):
+        # a model reporting 0 emissions is within range and must not be dropped
+        # by the falsy guard (0 is legitimate emission data, not missing data)
+        kwargs = {field.name: None for field in fields(ModelInfo) if field.init}
+
+        model = ModelInfo(**{**kwargs, "card_data": ModelCardData(co2_eq_emissions=0)})
+        assert _is_emission_within_threshold(model, -1, 100)
+
+        model = ModelInfo(**{**kwargs, "card_data": ModelCardData(co2_eq_emissions={"emissions": 0})})
+        assert _is_emission_within_threshold(model, -1, 100)
+
     def test_filter_emissions_with_max(self, api: HfApi):
         assert all(
             model.card_data["co2_eq_emissions"] <= 100


### PR DESCRIPTION
## Problem

`_is_emission_within_threshold` in `utils/endpoint_helpers.py` guards missing emission data with `if not emission:`. Because `0` is falsy, a model that legitimately reports `co2_eq_emissions = 0` (or `{"emissions": 0}`) is treated as having *no* emission data and silently dropped.

This contradicts the function's own docstring ("Whether the model's emission is within the given threshold"): with the default lower bound (`minimum_threshold` becomes `-1` when `None`), a 0-emission model *is* within range, since `-1 <= 0 <= maximum_threshold`. So a genuinely zero-emission model gets excluded from `list_models(emissions_thresholds=...)` results even though it should match.

## Fix

Guard on `emission is None` instead of `not emission`. Missing data (`None`) is still skipped, but a real value of `0` now flows through to the range check where it belongs. The change is a single line.

## Test

Adds a regression test (`test_is_emission_within_threshold_includes_zero`) covering both the plain-number (`co2_eq_emissions=0`) and dict (`{"emissions": 0}`) forms. It fails on the old code and passes with the fix; the existing `test_is_emission_within_threshold` continues to pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line guard change in emission filtering plus regression tests; no auth, API contract, or broad behavior change beyond including legitimate zero-emission models in filtered results.
> 
> **Overview**
> **Fixes client-side CO2 filtering** so models that report **`co2_eq_emissions = 0`** (scalar or `{"emissions": 0}`) are no longer dropped when using `list_models(emissions_thresholds=...)`.
> 
> `_is_emission_within_threshold` now treats only **`None`** as missing data (`if emission is None:`) instead of rejecting any falsy value, so **0** reaches the numeric range check as intended.
> 
> Adds **`test_is_emission_within_threshold_includes_zero`** for both card-data shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c3d1fd5b3f1acc9e6bcea5e2c6411540aa9a4b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->