### PR TITLE
docs: clarify upload_folder has no Xet server-side fallback

### DIFF
--- a/docs/source/en/guides/upload.md
+++ b/docs/source/en/guides/upload.md
@@ -93,7 +93,9 @@ Found 5,000 files to upload
   Committing  ██████████████████░░  4,580 / 5,000  6 commits
 ```
 
-If `hf_xet` is not installed, [`upload_folder`] falls back to the legacy behavior: hash everything first, upload over HTTP, then create a single commit. We always recommend to keep `hf_xet` installed for better robustness
+If `hf_xet` is not installed, [`upload_folder`] falls back to the legacy behavior: hash everything first, upload over HTTP, then create a single commit. We always recommend to keep `hf_xet` installed for better robustness.
+
+If `hf_xet` **is** installed but the target Hub does not support Xet server-side (for example `/api/{type}/{repo}/xet-write-token/{revision}` returns 404, or the repo reports `xetEnabled: false`), there is **no automatic transport fallback**. Set [`HF_HUB_DISABLE_XET=1`](../package_reference/environment_variables.md#hfhubdisablexet) to force the legacy upload path. Self-hosted or non-Xet Hub deployments should use that env var (or uninstall `hf_xet`) rather than expecting a silent client-side fallback.
 
 ## Upload from the CLI
 

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -5751,7 +5751,7 @@ class HfApi:
         read pass), and large folders are automatically committed in several batches to stay below server limits
         (follow-up commits get a ` (part N)` suffix on the commit message). If the upload is interrupted, re-running
         the same call resumes it: already-committed files are skipped and already-uploaded data is deduplicated. When
-        `hf_xet` is not installed, falls back to a single commit created with [`create_commit`].
+        `hf_xet` is not installed, falls back to a single commit created with [`create_commit`]. If `hf_xet` is installed but the Hub does not support Xet server-side, set `HF_HUB_DISABLE_XET=1` to force the legacy path (there is no automatic transport fallback).
 
         Args:
             repo_id (`str`):


### PR DESCRIPTION
## Summary

Clarify `upload_folder` Xet behavior when the **client** has `hf_xet` but the **target Hub** does not support Xet server-side (#4507).

Previously the upload guide only described the client-side case (`hf_xet` not installed → legacy path). When `hf_xet` is installed and the Hub returns 404 on the Xet write-token endpoint (or `xetEnabled: false`), there is **no automatic transport fallback** — users should set `HF_HUB_DISABLE_XET=1` (or uninstall `hf_xet`).

Also notes the same in the `upload_folder` docstring.

## Testing

Docs/docstring only; no runtime change.

Fixes #4507

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and docstring updates only; no code path or upload logic changes.
> 
> **Overview**
> Documents a gap that was only partially covered before: when **`hf_xet` is installed** but the **Hub does not support Xet server-side** (404 on the xet write-token route or `xetEnabled: false`), **`upload_folder` does not automatically fall back** to the legacy hash-then-HTTP path.
> 
> The upload guide now states that self-hosted or non-Xet deployments should set **`HF_HUB_DISABLE_XET=1`** (or uninstall `hf_xet`) instead of expecting silent client-side fallback. A missing period on the existing “`hf_xet` not installed” sentence is fixed.
> 
> The same guidance is added to the **`upload_folder`** docstring in `hf_api.py`. **No runtime behavior changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11e5ed71850105fe659a5a53747d40f8c41d3635. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->