### PR TITLE
fix(cli/jobs): correct cell truncation when terminal-fit loop compresses columns below width 3

### DIFF
--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -1312,6 +1312,22 @@ def _parse_labels_map(labels: list[str] | None, *, name: str | None = None) -> d
     return labels_map
 
 
+def _truncate_to_width(value: str, col_width: int) -> str:
+    """Truncate ``value`` to ``col_width`` columns, appending ``...`` when truncated.
+
+    Handles ``col_width < 3`` (which the terminal-fit loop in :func:`_tabulate` can
+    produce): the previous ``value[: col_width - 3] + "..."`` form turned into a
+    negative slice that dropped trailing chars and then overflowed the column
+    with the ellipsis.
+    """
+    if len(value) <= col_width:
+        return value
+    if col_width <= 3:
+        # Not enough room for an ellipsis; hard-truncate to the exact width.
+        return value[:col_width]
+    return value[: col_width - 3] + "..."
+
+
 def _tabulate(rows: list[list[str | int]], headers: list[str]) -> str:
     """
     Inspired by:
@@ -1331,10 +1347,7 @@ def _tabulate(rows: list[list[str | int]], headers: list[str]) -> str:
     lines.append(row_format.format(*headers))
     lines.append(row_format.format(*["-" * w for w in col_widths]))
     for row in rows:
-        row_format_args = [
-            str(x)[: col_width - 3] + "..." if len(str(x)) > col_width else str(x)
-            for x, col_width in zip(row, col_widths)
-        ]
+        row_format_args = [_truncate_to_width(str(x), col_width) for x, col_width in zip(row, col_widths)]
         lines.append(row_format.format(*row_format_args))
     return "\n".join(lines)
 

--- a/tests/test_cli_jobs_tabulate.py
+++ b/tests/test_cli_jobs_tabulate.py
@@ -1,0 +1,58 @@
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+from unittest import mock
+
+from huggingface_hub.cli.jobs import _tabulate, _truncate_to_width
+
+
+class TestJobsTabulate:
+    def test_truncate_to_width_handles_narrow_columns(self) -> None:
+        """Regression: ``col_width < 3`` must not produce output longer than the value.
+
+        The previous ``value[: col_width - 3] + "..."`` form turned into a negative
+        slice for ``col_width`` in (0, 1, 2), dropping trailing chars and then
+        overflowing the column with the ellipsis. The result was longer than the
+        original value and longer than the column, corrupting the table layout.
+        """
+        value = "averylongvalue"
+        for col_width in range(0, 8):
+            truncated = _truncate_to_width(value, col_width)
+            assert len(truncated) <= col_width
+            assert truncated == truncated.strip("\n")  # no stray newlines
+
+    def test_truncate_to_width_keeps_short_values(self) -> None:
+        assert _truncate_to_width("abc", 5) == "abc"
+        assert _truncate_to_width("abc", 3) == "abc"
+
+    def test_truncate_to_width_appends_ellipsis_when_room(self) -> None:
+        assert _truncate_to_width("abcdef", 5) == "ab..."
+        assert _truncate_to_width("abcdef", 4) == "a..."
+
+    def test_tabulate_does_not_overflow_on_narrow_terminal(self) -> None:
+        """When the terminal-fit loop compresses columns below 3, no cell may exceed its width."""
+        rows: list[list[str | int]] = [
+            ["owner-ns/job-1234567890", "RUNNING", "2026-07-20"],
+            ["really-long-job-name-here", "DONE", "2026-07-19"],
+        ]
+        headers = ["JOB ID", "STATUS", "CREATED"]
+        with mock.patch("huggingface_hub.cli.jobs.shutil.get_terminal_size") as mocked:
+            mocked.return_value = os.terminal_size((25, 24))
+            output = _tabulate(rows, headers=headers)
+
+        # Header and data lines should all share the same width (no ragged overflow).
+        line_lengths = {len(line) for line in output.split("\n")}
+        assert len(line_lengths) == 1
+        # No cell value should appear un-truncated in a compressed column.
+        assert "owner-ns/job-1234567890" not in output


### PR DESCRIPTION
The private _tabulate helper used by `hf jobs ps` / `hf jobs ls` truncates overflowing cells with `value[: col_width - 3] + "..."`. The terminal-fit loop above it (`while len(headers) + sum(col_widths) > terminal_width: col_widths[...] //= 2`) can compress a column down to width 0, 1, or 2 when the terminal is narrow relative to the content. In that range the slice `col_width - 3` goes negative, so instead of truncating it drops trailing characters and then the appended "..." makes the cell longer than both the original value and the column. The visible effect is that `hf jobs ps` rows become ragged/overflowing in narrow terminals instead of staying aligned.

Fix: extracted the truncation into _truncate_to_width, which hard-truncates to the exact column width when there is no room for an ellipsis (col_width <= 3) and otherwise keeps the existing `value[: col_width - 3] + "..."` behavior. Added tests/test_cli_jobs_tabulate.py covering the narrow-width cases and a full narrow-terminal table render asserting no row overflows.

Ran ruff check/format on the two changed files (clean) and the new tests pass. Note: I could not run the full `make quality` locally because generate_cli_reference.py fails in my environment on a click/Typer version mismatch unrelated to this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 1e2dfc5241d4b3d33161a95fa4cd351093964571. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->