### PR TITLE
[Download] [Fix] Update file-count progress bar on completion

### DIFF
--- a/src/huggingface_hub/_commit_api.py
+++ b/src/huggingface_hub/_commit_api.py
@@ -16,8 +16,6 @@ from itertools import groupby
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any, BinaryIO, Literal, NamedTuple, Union
 
-from tqdm.contrib.concurrent import thread_map
-
 from . import constants
 from .errors import EntryNotFoundError
 from .file_download import hf_hub_url
@@ -31,6 +29,7 @@ from .utils import (
     http_backoff,
     logging,
     sha,
+    thread_map,
     tqdm_stream_file,
     validate_hf_hub_args,
 )

--- a/src/huggingface_hub/_commit_api.py
+++ b/src/huggingface_hub/_commit_api.py
@@ -26,10 +26,10 @@ from .utils import (
     chunk_iterable,
     get_session,
     hf_raise_for_status,
+    hf_thread_map,
     http_backoff,
     logging,
     sha,
-    thread_map,
     tqdm_stream_file,
     validate_hf_hub_args,
 )
@@ -535,7 +535,7 @@ def _upload_lfs_files(
         logger.debug(
             f"Uploading {len(filtered_actions)} LFS files to the Hub using up to {num_threads} threads concurrently"
         )
-        thread_map(
+        hf_thread_map(
             _wrapped_lfs_upload,
             filtered_actions,
             desc=f"Upload {len(filtered_actions)} LFS files",

--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -27,7 +27,7 @@ from .utils._xet_progress_reporting import (
     _set_aggregate_rate_postfix,
     _update_transfer_bar,
 )
-from .utils.tqdm import _create_progress_bar, thread_map
+from .utils.tqdm import _create_progress_bar, hf_thread_map
 from .utils.tqdm import tqdm as hf_tqdm
 
 
@@ -511,7 +511,7 @@ def snapshot_download(
             )
         )
 
-    thread_map(
+    hf_thread_map(
         _inner_hf_hub_download,
         filtered_repo_files,
         desc=tqdm_desc,

--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -4,7 +4,6 @@ from typing import Literal, overload
 
 import httpx
 from tqdm.auto import tqdm as base_tqdm
-from tqdm.contrib.concurrent import thread_map
 
 from . import constants
 from ._tree_cache import TreeCacheEntry, read_tree_cache, tree_cache_folder_for_local_dir, write_tree_cache
@@ -28,7 +27,7 @@ from .utils._xet_progress_reporting import (
     _set_aggregate_rate_postfix,
     _update_transfer_bar,
 )
-from .utils.tqdm import _create_progress_bar
+from .utils.tqdm import _create_progress_bar, thread_map
 from .utils.tqdm import tqdm as hf_tqdm
 
 

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -271,7 +271,7 @@ def hf_hub_url(
         raise ValueError("Invalid repo type")
 
     if repo_type in constants.REPO_TYPES_URL_PREFIXES:
-        repo_id = constants.REPO_TYPES_URL_PREFIXES[repo_type] + repo_id
+        repo_id = constants.REPO_TYPES_URL_PREFIXES[repo_type] + repo_id  # type: ignore
 
     if revision is None:
         revision = constants.DEFAULT_REVISION

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -35,7 +35,6 @@ from urllib.parse import quote
 import httpcore
 import httpx
 from tqdm.auto import tqdm as base_tqdm
-from tqdm.contrib.concurrent import thread_map
 
 from . import constants
 from ._buckets import (
@@ -137,6 +136,7 @@ from .utils import (
     parse_hf_uri,
     parse_xet_file_data_from_response,
     silent_tqdm,
+    thread_map,
     validate_hf_hub_args,
 )
 from .utils import tqdm as hf_tqdm

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -422,7 +422,7 @@ def repo_type_and_id_from_hf_id(hf_id: str, hub_url: str | None = None) -> tuple
 
     # Check if repo type is known (mapping "spaces" => "space" + empty value => `None`)
     if repo_type in constants.REPO_TYPES_MAPPING:
-        repo_type = constants.REPO_TYPES_MAPPING[repo_type]
+        repo_type = constants.REPO_TYPES_MAPPING[repo_type]  # type: ignore
     if repo_type == "":
         repo_type = None
     if repo_type not in constants.REPO_TYPES_WITH_KERNEL and repo_type != "bucket":

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -129,6 +129,7 @@ from .utils import (
     get_session,
     get_token,
     hf_raise_for_status,
+    hf_thread_map,
     http_backoff,
     logging,
     paginate,
@@ -136,7 +137,6 @@ from .utils import (
     parse_hf_uri,
     parse_xet_file_data_from_response,
     silent_tqdm,
-    thread_map,
     validate_hf_hub_args,
 )
 from .utils import tqdm as hf_tqdm
@@ -6819,7 +6819,7 @@ class HfApi:
                     timeout=timeout,
                 )
 
-            thread_map(
+            hf_thread_map(
                 _parse,
                 set(weight_map.values()),
                 desc="Parse safetensors files",
@@ -13949,7 +13949,7 @@ class HfApi:
                 )
                 all_adds.append((local_path, target_path))
 
-            thread_map(_download_and_collect, pending_downloads, desc="Downloading text files for copy")
+            hf_thread_map(_download_and_collect, pending_downloads, desc="Downloading text files for copy")
 
         # Send copies first (no upload needed), then adds (may need upload)
         if all_copies:

--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -126,9 +126,9 @@ from .tqdm import (
     are_progress_bars_disabled,
     disable_progress_bars,
     enable_progress_bars,
+    hf_thread_map,
     is_tqdm_disabled,
     silent_tqdm,
-    thread_map,
     tqdm,
     tqdm_stream_file,
 )

--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -128,6 +128,7 @@ from .tqdm import (
     enable_progress_bars,
     is_tqdm_disabled,
     silent_tqdm,
+    thread_map,
     tqdm,
     tqdm_stream_file,
 )

--- a/src/huggingface_hub/utils/tqdm.py
+++ b/src/huggingface_hub/utils/tqdm.py
@@ -387,15 +387,12 @@ def hf_thread_map(
 ) -> list[R]:
     """Drop-in replacement for `tqdm.contrib.concurrent.thread_map`.
 
-    The version shipped by `tqdm` consumes results in submission order (it iterates over
-    `Executor.map()`), so the progress bar only advances when the *next item in input order*
-    finishes. A single slow early item therefore pins the bar near zero while later items
-    complete, with everything flushed at once at the end (see
-    https://github.com/huggingface/huggingface_hub/issues/4518).
+    The version shipped by `tqdm` consumes results in submission order and the progress bar only advances when the "next
+    item in input order" finishes. A single slow early item pins the bar near zero while later items
+    complete, with everything flushed at once at the end. This helper avoids that problem by consuming items in completion
+    order.
 
-    This implementation submits all tasks to a `ThreadPoolExecutor` and consumes them with
-    `as_completed`, updating the bar as each task *actually completes*. Results are still
-    returned in input order to preserve the `list(map(fn, iterable))` contract.
+    See https://github.com/huggingface/huggingface_hub/issues/4518 for more details.
 
     Args:
         fn (`Callable`):
@@ -403,11 +400,9 @@ def hf_thread_map(
         iterable (`Iterable`):
             Items to process.
         max_workers (`int`, *optional*):
-            Maximum number of worker threads. Defaults to tqdm's own default
-            (`min(32, cpu_count() + 4)`).
+            Maximum number of worker threads. Defaults to tqdm's own default.
         tqdm_class (`type`, *optional*):
-            Progress bar class to use. Defaults to `huggingface_hub`'s `tqdm` (which respects
-            `HF_HUB_DISABLE_PROGRESS_BARS` and group-based disabling).
+            Progress bar class to use. Defaults to `huggingface_hub`'s `tqdm`.
         **tqdm_kwargs:
             Additional keyword arguments forwarded to the progress bar (e.g. `desc`).
 
@@ -424,7 +419,14 @@ def hf_thread_map(
         ThreadPoolExecutor(max_workers=max_workers) as executor,
     ):
         future_to_index = {executor.submit(fn, item): index for index, item in enumerate(items)}
-        for future in as_completed(future_to_index):
-            results[future_to_index[future]] = future.result()
-            pbar.update(1)
+        try:
+            for future in as_completed(future_to_index):
+                results[future_to_index[future]] = future.result()
+                pbar.update(1)
+        except BaseException:
+            # Cancel not-yet-started tasks so a single failure doesn't keep the whole queue running
+            # (mirrors `tqdm.contrib.concurrent.thread_map`, which relies on `Executor.map` for this).
+            for future in future_to_index:
+                future.cancel()
+            raise
     return cast("list[R]", results)

--- a/src/huggingface_hub/utils/tqdm.py
+++ b/src/huggingface_hub/utils/tqdm.py
@@ -84,10 +84,11 @@ import logging
 import os
 import threading
 import warnings
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import contextmanager, nullcontext
 from pathlib import Path
-from typing import ContextManager
+from typing import Callable, ContextManager, TypeVar, cast
 
 from tqdm.auto import tqdm as old_tqdm
 
@@ -370,3 +371,60 @@ def _get_progress_bar_context(
         initial=initial,
         desc=desc,
     )
+
+
+T = TypeVar("T")
+R = TypeVar("R")
+
+
+def thread_map(
+    fn: Callable[[T], R],
+    iterable: Iterable[T],
+    *,
+    max_workers: int | None = None,
+    tqdm_class: type[old_tqdm] | None = None,
+    **tqdm_kwargs,
+) -> list[R]:
+    """Drop-in replacement for `tqdm.contrib.concurrent.thread_map`.
+
+    The version shipped by `tqdm` consumes results in submission order (it iterates over
+    `Executor.map()`), so the progress bar only advances when the *next item in input order*
+    finishes. A single slow early item therefore pins the bar near zero while later items
+    complete, with everything flushed at once at the end (see
+    https://github.com/huggingface/huggingface_hub/issues/4518).
+
+    This implementation submits all tasks to a `ThreadPoolExecutor` and consumes them with
+    `as_completed`, updating the bar as each task *actually completes*. Results are still
+    returned in input order to preserve the `list(map(fn, iterable))` contract.
+
+    Args:
+        fn (`Callable`):
+            Function to apply to each item.
+        iterable (`Iterable`):
+            Items to process.
+        max_workers (`int`, *optional*):
+            Maximum number of worker threads. Defaults to tqdm's own default
+            (`min(32, cpu_count() + 4)`).
+        tqdm_class (`type`, *optional*):
+            Progress bar class to use. Defaults to `huggingface_hub`'s `tqdm` (which respects
+            `HF_HUB_DISABLE_PROGRESS_BARS` and group-based disabling).
+        **tqdm_kwargs:
+            Additional keyword arguments forwarded to the progress bar (e.g. `desc`).
+
+    Returns:
+        `list`: Results in the same order as `iterable`.
+    """
+    items = list(iterable)
+    if max_workers is None:
+        max_workers = min(32, (os.cpu_count() or 1) + 4)
+    tqdm_kwargs.setdefault("total", len(items))
+    results: list[R | None] = [None] * len(items)
+    with (
+        (tqdm_class or tqdm)(**tqdm_kwargs) as pbar,
+        ThreadPoolExecutor(max_workers=max_workers) as executor,
+    ):
+        future_to_index = {executor.submit(fn, item): index for index, item in enumerate(items)}
+        for future in as_completed(future_to_index):
+            results[future_to_index[future]] = future.result()
+            pbar.update(1)
+    return cast("list[R]", results)

--- a/src/huggingface_hub/utils/tqdm.py
+++ b/src/huggingface_hub/utils/tqdm.py
@@ -377,6 +377,22 @@ T = TypeVar("T")
 R = TypeVar("R")
 
 
+def _make_thread_pool_executor(*, max_workers: int | None, bar_class: type[old_tqdm]) -> ThreadPoolExecutor:
+    """Create a `ThreadPoolExecutor` that shares the tqdm lock with its worker threads.
+
+    Like `tqdm.contrib.concurrent.thread_map`, we make sure the bar class has a lock and pass it to the
+    worker threads, so that bars created inside the mapped function (e.g. the per-file download bars in
+    `snapshot_download`) don't race on concurrent `update()` calls. `get_lock()` creates the shared
+    class-level lock if needed. Classes that don't implement tqdm's locking API (e.g. `silent_tqdm`)
+    render nothing anyway, so no lock is needed.
+    """
+    if hasattr(bar_class, "get_lock") and hasattr(bar_class, "set_lock"):
+        return ThreadPoolExecutor(
+            max_workers=max_workers, initializer=bar_class.set_lock, initargs=(bar_class.get_lock(),)
+        )
+    return ThreadPoolExecutor(max_workers=max_workers)
+
+
 def hf_thread_map(
     fn: Callable[[T], R],
     iterable: Iterable[T],
@@ -413,10 +429,11 @@ def hf_thread_map(
     if max_workers is None:
         max_workers = min(32, (os.cpu_count() or 1) + 4)
     tqdm_kwargs.setdefault("total", len(items))
+    bar_class = tqdm_class or tqdm
     results: list[R | None] = [None] * len(items)
     with (
-        (tqdm_class or tqdm)(**tqdm_kwargs) as pbar,
-        ThreadPoolExecutor(max_workers=max_workers) as executor,
+        bar_class(**tqdm_kwargs) as pbar,
+        _make_thread_pool_executor(max_workers=max_workers, bar_class=bar_class) as executor,
     ):
         future_to_index = {executor.submit(fn, item): index for index, item in enumerate(items)}
         try:

--- a/src/huggingface_hub/utils/tqdm.py
+++ b/src/huggingface_hub/utils/tqdm.py
@@ -377,7 +377,7 @@ T = TypeVar("T")
 R = TypeVar("R")
 
 
-def thread_map(
+def hf_thread_map(
     fn: Callable[[T], R],
     iterable: Iterable[T],
     *,

--- a/tests/test_utils_tqdm.py
+++ b/tests/test_utils_tqdm.py
@@ -326,6 +326,32 @@ class TestHfThreadMap:
         # The failing first task cancels the queued tasks instead of running all 50.
         assert len(started) < 50
 
+    def test_shares_tqdm_lock_with_worker_threads(self):
+        # A custom bar class: hf_thread_map must share a single lock with the worker threads so bars
+        # created inside `fn` don't race on concurrent updates (mirrors tqdm.contrib's `ensure_lock`).
+        class CustomTqdm(vanilla_tqdm):
+            pass
+
+        seen_locks = []
+        lock = threading.Lock()
+
+        def fn(x):
+            with lock:
+                seen_locks.append(CustomTqdm.get_lock())
+            return x
+
+        hf_thread_map(fn, range(8), max_workers=4, tqdm_class=CustomTqdm, disable=True)
+
+        # Every worker thread observed the same, single shared lock.
+        assert seen_locks
+        assert all(observed is seen_locks[0] for observed in seen_locks)
+
+    def test_works_with_class_without_lock_api(self):
+        # Classes that don't implement tqdm's locking API (e.g. `silent_tqdm`) must not crash.
+        from huggingface_hub.utils import silent_tqdm
+
+        assert hf_thread_map(lambda x: x * 2, range(4), max_workers=2, tqdm_class=silent_tqdm) == [0, 2, 4, 6]
+
 
 class TestCreateProgressBarCustomClass:
     def test_custom_class_not_disabled_in_non_tty(self):

--- a/tests/test_utils_tqdm.py
+++ b/tests/test_utils_tqdm.py
@@ -1,6 +1,7 @@
 import io
 import logging
 import sys
+import threading
 import time
 from pathlib import Path
 from unittest.mock import patch
@@ -13,6 +14,7 @@ from huggingface_hub.utils import (
     are_progress_bars_disabled,
     disable_progress_bars,
     enable_progress_bars,
+    hf_thread_map,
     tqdm,
     tqdm_stream_file,
 )
@@ -255,6 +257,74 @@ class TestDisableProgressBarsContextManager:
             pass
         captured = capsys.readouterr()
         assert "10/10" in captured.err
+
+
+class TestHfThreadMap:
+    def test_returns_results_in_input_order(self):
+        # Earlier items finish later, so completion order differs from input order.
+        def fn(x):
+            time.sleep(0.02 * (4 - x))
+            return x * 10
+
+        assert hf_thread_map(fn, range(5), max_workers=5, disable=True) == [0, 10, 20, 30, 40]
+
+    def test_bar_advances_on_completion_not_submission_order(self):
+        # Regression test for https://github.com/huggingface/huggingface_hub/issues/4518: a slow
+        # first-submitted item must not prevent the bar from advancing when later items complete.
+        slow_release = threading.Event()
+        fast_done = threading.Event()
+        updates = []
+
+        class RecordingTqdm(vanilla_tqdm):
+            def update(self, n=1):
+                updates.append(n)
+                return super().update(n)
+
+        def fn(x):
+            if x == 0:
+                slow_release.wait(timeout=5)  # first-submitted item stays blocked
+            else:
+                fast_done.set()
+            return x
+
+        results = []
+
+        def run():
+            results.append(hf_thread_map(fn, range(2), max_workers=2, tqdm_class=RecordingTqdm, disable=True))
+
+        worker = threading.Thread(target=run)
+        worker.start()
+        try:
+            assert fast_done.wait(timeout=5)
+            # The fast item completed; the bar should advance even though the slow item is still blocked.
+            deadline = time.time() + 5
+            while not updates and time.time() < deadline:
+                time.sleep(0.01)
+            assert updates
+        finally:
+            slow_release.set()
+            worker.join(timeout=5)
+
+        assert not worker.is_alive()
+        assert results == [[0, 1]]
+
+    def test_cancels_pending_tasks_on_error(self):
+        started = []
+        lock = threading.Lock()
+
+        def fn(x):
+            with lock:
+                started.append(x)
+            if x == 0:
+                raise ValueError("boom")
+            time.sleep(0.05)
+            return x
+
+        with pytest.raises(ValueError, match="boom"):
+            hf_thread_map(fn, range(50), max_workers=1, disable=True)
+
+        # The failing first task cancels the queued tasks instead of running all 50.
+        assert len(started) < 50
 
 
 class TestCreateProgressBarCustomClass:


### PR DESCRIPTION
## Summary

Fixes #4518, based on the [investigation in this comment](https://github.com/huggingface/huggingface_hub/issues/4518#issuecomment-4963832266) and taking inspiration from #4524.

`tqdm.contrib.concurrent.thread_map` iterates over `Executor.map()`, which yields results in **submission order**. As a result, the `Fetching N files` bar only advances when the *next file in list order* finishes. A single slow early file (e.g. a large safetensors shard listed first) pins the counter near `0/N` while later files complete, then everything gets flushed at once when the bar closes.

Rather than hardcoding a `ThreadPoolExecutor` + `as_completed` loop in `_snapshot_download.py`, this adds a small `hf_thread_map` helper in `utils/tqdm.py` (named to match the existing `hf_tqdm` convention and to make clear it's *not* the official `tqdm.contrib` one).

The only behavior change beyond progress timing: a raised error now comes from the first *completed* failing task rather than the first *submitted* one.

No new tests added (per request).

## Example

```py
import time
from tqdm.contrib.concurrent import thread_map
from huggingface_hub.utils import hf_thread_map

def f(x):
    print("\n", x, "start")
    time.sleep(4 - x)
    print("\n", x, "done")

print("Using tqdm.contrib.concurrent.thread_map")
thread_map(f, range(4), max_workers=4, desc="test")

print("\n\nUsing huggingface_hub.utils.hf_thread_map")
hf_thread_map(f, range(4), max_workers=4, desc="test")
```

=> 
```
Using tqdm.contrib.concurrent.thread_map

 0 start

 1 start

 2 start

 3 start
test:   0%|                                                                                                                                   | 0/4 [00:00<?, ?it/s]
 3 done

 2 done

 1 done

 0 done
test: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:04<00:00,  1.00s/it]


Using huggingface_hub.utils.hf_thread_map
test:   0%|                                                                                                                                   | 0/4 [00:00<?, ?it/s]

 1 start

 0 start
 2 start

 3 start

 3 done
test:  25%|██████████████████████████████▊                                                                                            | 1/4 [00:01<00:03,  1.00s/it]
 2 done
test:  50%|█████████████████████████████████████████████████████████████▌                                                             | 2/4 [00:02<00:02,  1.00s/it]
 1 done
test:  75%|████████████████████████████████████████████████████████████████████████████████████████████▎                              | 3/4 [00:03<00:01,  1.00s/it]
 0 done
test: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:04<00:00,  1.00s/it]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to concurrent progress reporting and threading; behavior change on errors (first completed failure vs first submitted) is minor and covered by tests.
> 
> **Overview**
> Fixes **#4518**: the “Fetching N files” style counter stayed near **0/N** when an early-listed file was slow, because **`tqdm.contrib.concurrent.thread_map`** only advanced the bar when the next item in **submission order** completed.
> 
> This PR introduces **`hf_thread_map`** in `utils/tqdm.py`—a drop-in that uses **`as_completed`** so the bar updates when each task finishes, while still returning results in input order. Worker threads get a **shared tqdm lock** (like tqdm’s helper) so nested per-file bars stay safe; failures **cancel** queued futures.
> 
> **Call sites** now use `hf_thread_map` instead of `thread_map` in **`snapshot_download`**, parallel **LFS uploads**, **safetensors metadata parsing**, and **bucket copy** downloads. It is exported from **`huggingface_hub.utils`**.
> 
> **Tests** in `test_utils_tqdm.py` cover ordering, completion-order bar updates, error cancellation, lock sharing, and bar classes without a lock API. Minor **`type: ignore`** tweaks in `file_download.py` / `hf_api.py` only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cc233dd697eb54a24b58cb57ad8332e3e7a26c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->