### PR TITLE
[Repocard] Preserve order of appended keys in CardData.to_yaml

### DIFF
--- a/src/huggingface_hub/repocard_data.py
+++ b/src/huggingface_hub/repocard_data.py
@@ -211,9 +211,10 @@ class CardData:
             `str`: CardData represented as a YAML block.
         """
         if original_order:
+            original_order_set = set(original_order)
             self.__dict__ = {
                 k: self.__dict__[k]
-                for k in original_order + list(set(self.__dict__.keys()) - set(original_order))
+                for k in original_order + [k for k in self.__dict__ if k not in original_order_set]
                 if k in self.__dict__
             }
         return yaml_dump(self.to_dict(), sort_keys=False, line_break=line_break).strip()

--- a/tests/test_repocard_data.py
+++ b/tests/test_repocard_data.py
@@ -73,6 +73,19 @@ class TestBaseCardData:
         # .pop
         assert metadata.pop("foo") == "BAR"
 
+    def test_to_yaml_preserves_order_of_appended_keys(self):
+        # Keys not listed in `original_order` must be appended in their existing
+        # (insertion) order and deterministically, as documented -- not shuffled
+        # through set() ordering.
+        metadata = CardData(license="mit", tags=["a"])
+        for key in ["zzz", "aaa", "mmm", "bbb"]:
+            metadata[key] = "x"
+
+        yaml_block = metadata.to_yaml(original_order=["license", "tags"])
+        keys = [line.split(":")[0] for line in yaml_block.splitlines() if line and not line.startswith((" ", "-"))]
+
+        assert keys == ["license", "tags", "zzz", "aaa", "mmm", "bbb"]
+
 
 class TestModelCardData:
     def test_eval_results_to_model_index(self):


### PR DESCRIPTION
## Summary

- `CardData.to_yaml(original_order=...)` documents that keys not in `original_order` are appended "preserving their existing relative order". It built that list with `set(self.__dict__) - set(original_order)`, so the appended keys came out in arbitrary, hash-seed-dependent order.
- In practice this happens when a card is loaded and then extra metadata keys are added before saving (`RepoCard` passes the original key order to `to_yaml`). The keys that weren't in the original block get shuffled, and non-deterministically — so re-serializing the same card produces different output across runs and spurious README diffs.
- Fix: build the appended list by iterating `self.__dict__` (insertion order) instead of a `set` difference. Deterministic and matches the documented behavior.

### Reproduce (before the fix)

```python
from huggingface_hub.repocard import RepoCard

card = RepoCard("---\nlicense: mit\ntags:\n- a\n---\n# hi\n")
for k in ["zzz", "aaa", "mmm", "bbb"]:
    card.data[k] = "x"

print(card.data.to_yaml(original_order=card._original_order))
```

Running the above under different hash seeds gives different orderings of `zzz/aaa/mmm/bbb`:

```
$ PYTHONHASHSEED=1 python repro.py   # -> aaa, zzz, mmm, bbb
$ PYTHONHASHSEED=2 python repro.py   # -> mmm, zzz, aaa, bbb
$ PYTHONHASHSEED=3 python repro.py   # -> zzz, mmm, bbb, aaa
```

After the fix it is always the insertion order `zzz, aaa, mmm, bbb`.

Added a regression test in `tests/test_repocard_data.py`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small serialization-order fix in repocard metadata with a targeted regression test; no auth, data, or API behavior changes.
> 
> **Overview**
> Fixes **non-deterministic YAML key ordering** when `CardData.to_yaml(original_order=...)` re-serializes metadata after new keys are added (e.g. `RepoCard` round-trips with `_original_order`).
> 
> Keys not in `original_order` were appended via `set(self.__dict__) - set(original_order)`, so their order depended on hash seed and could shuffle on save. The change appends by scanning `self.__dict__` in **insertion order**, matching the documented “preserve their existing relative order” behavior.
> 
> Adds **`test_to_yaml_preserves_order_of_appended_keys`** to lock in stable output (`license`, `tags`, then `zzz`, `aaa`, `mmm`, `bbb`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a991247adda0849c5325750d1f96c778c0d433d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->