### PR TITLE
[HfFileSystem] Raise FileNotFoundError when streaming a missing file

### DIFF
--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -1258,13 +1258,9 @@ class HfFileSystemStreamFile(fsspec.spec.AbstractBufferedFile):
             raise ValueError(f"HfFileSystemStreamFile only supports cache_type='none' but got {cache_type}")
         if "w" in mode:
             raise ValueError(f"HfFileSystemStreamFile only supports reading but got mode='{mode}'")
-        try:
-            self.resolved_path = fs.resolve_path(path, revision=revision)
-        except FileNotFoundError as e:
-            if "w" in kwargs.get("mode", ""):
-                raise FileNotFoundError(
-                    f"{e}.\nMake sure the repository and revision exist before writing data."
-                ) from e
+        # Let a missing repo/revision/file surface as FileNotFoundError (as the buffered
+        # `HfFileSystemFile` does) instead of an AttributeError on `self.resolved_path` below.
+        self.resolved_path = fs.resolve_path(path, revision=revision)
         # avoid an unnecessary .info() call to instantiate .details
         self.details = {"name": self.resolved_path.unresolve(), "size": None}
         super().__init__(

--- a/tests/test_hf_file_system.py
+++ b/tests/test_hf_file_system.py
@@ -817,6 +817,15 @@ def test_resolve_path_with_non_matching_revisions():
         fs.resolve_path("username/my_model@dev", revision="main")
 
 
+def test_stream_file_open_if_not_found():
+    # Regression test: opening a missing file in streaming mode (block_size=0) must raise
+    # FileNotFoundError like the buffered HfFileSystemFile, not an AttributeError.
+    fs = HfFileSystem()
+    with patch.object(fs, "resolve_path", side_effect=FileNotFoundError("missing/repo")):
+        with pytest.raises(FileNotFoundError):
+            HfFileSystemStreamFile(fs, "hf://missing/repo/not_existing_file.txt")
+
+
 @pytest.mark.parametrize(
     ("not_supported_path", "expected_error"),
     [


### PR DESCRIPTION
## Summary

- Opening a missing file through `HfFileSystem` in **streaming** mode (`block_size=0`) raised `AttributeError` instead of `FileNotFoundError`.
- `HfFileSystemStreamFile.__init__` wrapped `resolve_path()` in a `try/except FileNotFoundError` that only re-raised for write mode, checked via `kwargs.get("mode", "")`. But `mode` is an explicit parameter of this class (not part of `**kwargs`), so the check was always false, and write mode is already rejected a few lines above. The except therefore swallowed the error and fell through to `self.resolved_path`, which was never assigned.
- The buffered `HfFileSystemFile` does the right thing (bare `raise`). Since `AttributeError` is not an `OSError`, this also leaked past callers that catch `FileNotFoundError` (`exists`, `isfile`, ...).
- Fix: let `resolve_path()` propagate `FileNotFoundError` (the `try/except` was dead code for a read-only stream file).

### Before

```python
>>> from huggingface_hub import HfFileSystem
>>> fs = HfFileSystem()
>>> fs.open("hf://missing/repo/not_existing_file.txt", block_size=0)
AttributeError: 'HfFileSystemStreamFile' object has no attribute 'resolved_path'
```

### After

Raises `FileNotFoundError`, same as the buffered path (`block_size` unset).

Added a regression test (`test_stream_file_open_if_not_found`); the existing `test_open_if_not_found` only covered the buffered variant.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, read-path error-handling fix with a focused regression test; no API or security surface change.
> 
> **Overview**
> Fixes incorrect error handling when opening a missing path via **`HfFileSystem`** with **`block_size=0`** (streaming). **`HfFileSystemStreamFile.__init__`** no longer wraps **`resolve_path()`** in a **`try/except`** that swallowed **`FileNotFoundError`**; failures now propagate like the buffered **`HfFileSystemFile`** path.
> 
> Previously, init could continue without **`self.resolved_path`**, so callers saw **`AttributeError`** instead of **`FileNotFoundError`**, which also broke helpers that only catch **`OSError`**.
> 
> Adds **`test_stream_file_open_if_not_found`** to lock in streaming behavior alongside the existing buffered **`test_open_if_not_found`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da189929615fe5158354f60f690a914eb4e48abd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->