### PR TITLE
[CLI] Render missing table cells as empty in agent output

### DIFF
--- a/src/huggingface_hub/cli/_output.py
+++ b/src/huggingface_hub/cli/_output.py
@@ -352,6 +352,8 @@ def _truncate_columns(
 
 def _format_table_cell_agent(value: Any) -> str:
     """Format a cell value for agent TSV output (ISO timestamps, tabs escaped)."""
+    if value is None:
+        return ""
     if isinstance(value, datetime.datetime):
         return value.isoformat()
     return _single_line(str(value))

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -153,6 +153,15 @@ def test_table(check):
     )
 
 
+def test_table_agent_renders_missing_values_as_empty(capsys):
+    # Regression: in agent (TSV) mode a missing/None cell must be an empty field, not the
+    # literal string "None" (human and json modes already treat it as absent/empty).
+    o = Output()
+    o.set_mode(AGENT)
+    o.table([{"id": "a/x", "downloads": 100}, {"id": "b/y"}], headers=["id", "downloads"])
+    assert capsys.readouterr().out.splitlines() == ["id\tdownloads", "a/x\t100", "b/y\t"]
+
+
 def test_table_empty(check):
     check(
         lambda out: out.table([]),


### PR DESCRIPTION
## Summary

- In agent (TSV) output mode, a missing / `None` table cell was rendered as the literal string `None`. `_format_table_cell_agent` went straight to `str(value)`, while human mode maps `None -> ""` and json mode omits the key. So the machine-readable format was the only one emitting a bogus value.
- This is reachable in practice, e.g. `hf models ls --format agent`: different models expose different optional fields, headers are derived from the first row, and rows missing a header key produced a `None` cell.
- Fix: return `""` for `None` in `_format_table_cell_agent`, matching the other output modes.

### Before

```
$ hf models ls --format agent
id	downloads	likes	pipeline_tag
a/x	100	5	text-generation
b/y	100	7	None          # <- literal "None"
```

### After

```
id	downloads	likes	pipeline_tag
a/x	100	5	text-generation
b/y	100	7	              # <- empty field
```

Added a regression test in `tests/test_cli_output.py` (the existing `test_table` only used homogeneous rows with no missing values).

Note: booleans are intentionally left as-is (`True`/`False` are meaningful in machine-parsed TSV, unlike the human checkmark), so only `None` is changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI formatting fix in non-critical output code with a targeted regression test; no auth, data, or API behavior changes.
> 
> **Overview**
> **Agent (TSV) table output** no longer prints the literal string `None` for missing optional fields. `_format_table_cell_agent` now returns an empty string for `None`, consistent with human tables and JSON output.
> 
> This matters for commands like `hf models ls --format agent`, where headers come from the first row and later rows can lack keys (e.g. `pipeline_tag`), which previously produced bogus TSV values for parsers.
> 
> A regression test asserts agent-mode rows with a missing column render as an empty tab-separated field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbb77bf050bf5395c333924ad96ca7bae3fab7f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->