### PR TITLE
[Inference] Send max_tokens for Together and Novita text-generation

### DIFF
--- a/src/huggingface_hub/cli/_output.py
+++ b/src/huggingface_hub/cli/_output.py
@@ -352,6 +352,8 @@ def _truncate_columns(
 
 def _format_table_cell_agent(value: Any) -> str:
     """Format a cell value for agent TSV output (ISO timestamps, tabs escaped)."""
+    if value is None:
+        return ""
     if isinstance(value, datetime.datetime):
         return value.isoformat()
     return _single_line(str(value))

--- a/src/huggingface_hub/inference/_providers/novita.py
+++ b/src/huggingface_hub/inference/_providers/novita.py
@@ -23,6 +23,15 @@ class NovitaTextGenerationTask(BaseTextGenerationTask):
         # there is no v1/ route for novita
         return "/v3/openai/completions"
 
+    def _prepare_payload_as_dict(
+        self, inputs: Any, parameters: dict, provider_mapping_info: InferenceProviderMapping
+    ) -> dict | None:
+        params = filter_none(parameters.copy())
+        # Novita's completion endpoint is OpenAI-compatible and expects `max_tokens`.
+        params["max_tokens"] = params.pop("max_new_tokens", None)
+
+        return {"prompt": inputs, **params, "model": provider_mapping_info.provider_id}
+
     def get_response(self, response: bytes | dict, request_params: RequestParameters | None = None) -> Any:
         output = _as_dict(response)["choices"][0]
         return {

--- a/src/huggingface_hub/inference/_providers/together.py
+++ b/src/huggingface_hub/inference/_providers/together.py
@@ -58,6 +58,15 @@ class TogetherTextGenerationTask(BaseTextGenerationTask):
     def __init__(self):
         super().__init__(provider=_PROVIDER, base_url=_BASE_URL)
 
+    def _prepare_payload_as_dict(
+        self, inputs: Any, parameters: dict, provider_mapping_info: InferenceProviderMapping
+    ) -> dict | None:
+        params = filter_none(parameters.copy())
+        # Together's completion endpoint is OpenAI-compatible and expects `max_tokens`.
+        params["max_tokens"] = params.pop("max_new_tokens", None)
+
+        return {"prompt": inputs, **params, "model": provider_mapping_info.provider_id}
+
     def get_response(self, response: bytes | dict, request_params: RequestParameters | None = None) -> Any:
         output = _as_dict(response)["choices"][0]
         return {

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -153,6 +153,15 @@ def test_table(check):
     )
 
 
+def test_table_agent_renders_missing_values_as_empty(capsys):
+    # Regression: in agent (TSV) mode a missing/None cell must be an empty field, not the
+    # literal string "None" (human and json modes already treat it as absent/empty).
+    o = Output()
+    o.set_mode(AGENT)
+    o.table([{"id": "a/x", "downloads": 100}, {"id": "b/y"}], headers=["id", "downloads"])
+    assert capsys.readouterr().out.splitlines() == ["id\tdownloads", "a/x\t100", "b/y\t"]
+
+
 def test_table_empty(check):
     check(
         lambda out: out.table([]),

--- a/tests/test_inference_providers.py
+++ b/tests/test_inference_providers.py
@@ -57,6 +57,7 @@ from huggingface_hub.inference._providers.together import (
     TogetherFeatureExtractionTask,
     TogetherImageToImageTask,
     TogetherImageToVideoTask,
+    TogetherTextGenerationTask,
     TogetherTextToImageTask,
     TogetherTextToSpeechTask,
     TogetherTextToVideoTask,
@@ -1120,6 +1121,23 @@ class TestHFInferenceProvider:
 
 
 class TestNovitaProvider:
+    def test_text_generation_renames_max_new_tokens(self):
+        # Novita's completion endpoint is OpenAI-compatible and expects `max_tokens`.
+        helper = NovitaTextGenerationTask()
+        payload = helper._prepare_payload_as_dict(
+            "Hello",
+            {"max_new_tokens": 50, "temperature": 0.7},
+            InferenceProviderMapping(
+                provider="novita",
+                hf_model_id="meta-llama/Llama-3.1-8B-Instruct",
+                providerId="meta-llama/llama-3.1-8b-instruct",
+                task="text-generation",
+                status="live",
+            ),
+        )
+        assert "max_new_tokens" not in payload
+        assert payload["max_tokens"] == 50
+
     def test_prepare_url_text_generation(self):
         helper = NovitaTextGenerationTask()
         url = helper._prepare_url("novita_token", "username/repo_name")
@@ -1531,6 +1549,23 @@ class TestReplicateProvider:
 
 
 class TestTogetherProvider:
+    def test_text_generation_renames_max_new_tokens(self):
+        # Together's completion endpoint is OpenAI-compatible and expects `max_tokens`.
+        helper = TogetherTextGenerationTask()
+        payload = helper._prepare_payload_as_dict(
+            "Hello",
+            {"max_new_tokens": 50, "temperature": 0.7},
+            InferenceProviderMapping(
+                provider="together",
+                hf_model_id="meta-llama/Llama-3.3-70B-Instruct",
+                providerId="meta-llama/Llama-3.3-70B-Instruct-Turbo",
+                task="text-generation",
+                status="live",
+            ),
+        )
+        assert "max_new_tokens" not in payload
+        assert payload["max_tokens"] == 50
+
     def test_conversational_json_schema_flattens_envelope(self):
         # Together accepts `{type: "json_schema", schema: <schema>}`; unwrap the OpenAI
         # `{type: "json_schema", json_schema: {schema}}` envelope.


### PR DESCRIPTION
## Summary

- `InferenceClient.text_generation(...)` always sends the TGI-style `max_new_tokens` parameter.
- The Together and Novita **text-generation** tasks route to OpenAI-compatible completion endpoints (`/v1/completions` and `/v3/openai/completions`) and parse the OpenAI response shape (`choices[0]["text"]`), but they inherit the base payload builder, so they forwarded `max_new_tokens` unchanged. OpenAI-style endpoints expect `max_tokens` and silently ignore the unknown field — so the user's length limit had no effect.
- Fix: rename `max_new_tokens` → `max_tokens` in both `_prepare_payload_as_dict`, exactly as the sibling `DeepInfraTextGenerationTask` and `FeatherlessTextGenerationTask` already do for the same kind of endpoint. HF-inference (TGI) keeps `max_new_tokens`, so the base class is intentionally left unchanged.

### Before (payload sent to Together)

```python
{"prompt": "hi", "max_new_tokens": 50, "temperature": 0.7, "model": "..."}   # max_new_tokens ignored by the endpoint
```

### After

```python
{"prompt": "hi", "temperature": 0.7, "max_tokens": 50, "model": "..."}
```

Added payload tests for both providers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted inference payload mapping and CLI formatting with regression tests; no auth or broad API surface changes.
> 
> **Overview**
> Fixes **Together** and **Novita** text-generation so `InferenceClient.text_generation` length limits actually apply: both providers hit OpenAI-style completion APIs that expect **`max_tokens`**, but payloads still forwarded TGI-style **`max_new_tokens`**, which those endpoints ignore. Each provider now overrides **`_prepare_payload_as_dict`** to rename the field (same pattern as DeepInfra/Featherless); HF Inference / base text-generation behavior is unchanged.
> 
> Separately, **agent (TSV) CLI tables** now render missing/`None` cells as an **empty field** instead of the literal string `"None"`, matching human/json handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca659376303168e579647fd8549da8f45b447ff7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->