### PR TITLE
[CI] Remove `test_list_private_datasets` flaky test

### DIFF
--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2656,11 +2656,6 @@ class TestHfApiPrivate:
             with pytest.raises(HfHubHTTPError, match=r".*Repository Not Found.*"):
                 _ = api.dataset_info(repo_id=self.repo_id)
 
-    def test_list_private_datasets(self, api: HfApi):
-        kwargs = {"sort": "created_at", "limit": 100, "author": USER}
-        assert all(dataset.id != self.repo_id for dataset in api.list_datasets(token=False, **kwargs))
-        assert any(dataset.id == self.repo_id for dataset in api.list_datasets(token=TOKEN, **kwargs))
-
     def test_list_private_models(self, api: HfApi):
         kwargs = {"sort": "created_at", "limit": 100, "author": USER}
         assert all(model.id != self.repo_id for model in api.list_models(token=False, **kwargs))


### PR DESCRIPTION
Test is currently flaky in the CI and is duplicate of `test_list_private_models` so really not needed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only deletion with no library or API behavior changes.
> 
> **Overview**
> Removes **`test_list_private_datasets`** from `TestHfApiPrivate` in `tests/test_hf_api.py` because it was flaky in CI and duplicated the same authenticated vs unauthenticated **`list_*`** listing checks already covered by **`test_list_private_models`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29b4cbd91a2855f7bc0d5c1652600fab5b027394. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->