### PR TITLE
[Jobs] Auto-name Jobs on creation

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -2028,7 +2028,7 @@ Add labels to a Job using `-l` or `--label`. Labels are a key=value pairs that a
 
 The my-label key doesn't specify a value so its value defaults to an empty string ("").
 
-Use `--name` to add the `name` label when creating a Job. Names make Jobs easier to find and identify in the UI; they are optional and do not have to be unique. If you don't pass `--name`, a name is derived automatically from the Docker image or the script, e.g. `python:3.12` → `python-3-12` You can also rename an existing Job:
+Use `--name` to add the `name` label when creating a Job. Names make Jobs easier to find and identify in the UI; they are optional and do not have to be unique. If you don't pass `--name`, a name is derived automatically from the Docker image or the script, plus a short hash of the command so reruns of the same command share a name (e.g. `python:3.12 foo --truc` → `python-3-12-1a2b3c4d`). You can also rename an existing Job:
 
 ```bash
 >>> hf jobs run --name training-v2 python:3.12 python train.py

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -2028,7 +2028,7 @@ Add labels to a Job using `-l` or `--label`. Labels are a key=value pairs that a
 
 The my-label key doesn't specify a value so its value defaults to an empty string ("").
 
-Use `--name` to add the `name` label when creating a Job. Names make Jobs easier to find and identify in the UI; they are optional and do not have to be unique. If you don't pass `--name`, one is derived automatically from the Docker image (`hf jobs run`) or the script (`hf jobs uv run`), e.g. `python:3.12` → `python-3-12` and `train.py` → `train`. Characters not allowed in a name (`/`, `:`, `.`, ...) are replaced with `-`. You can also name an existing Job:
+Use `--name` to add the `name` label when creating a Job. Names make Jobs easier to find and identify in the UI; they are optional and do not have to be unique. If you don't pass `--name`, a name is derived automatically from the Docker image or the script, e.g. `python:3.12` → `python-3-12` You can also rename an existing Job:
 
 ```bash
 >>> hf jobs run --name training-v2 python:3.12 python train.py

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -2028,7 +2028,7 @@ Add labels to a Job using `-l` or `--label`. Labels are a key=value pairs that a
 
 The my-label key doesn't specify a value so its value defaults to an empty string ("").
 
-Use `--name` to add the `name` label when creating a Job. Names make Jobs easier to find and identify in the UI; they are optional and do not have to be unique. If you don't pass `--name`, one is derived automatically from the Docker image (`hf jobs run`) or the script (`hf jobs uv run`), e.g. `python:3.12` → `python` and `train.py` → `train`. You can also name an existing Job:
+Use `--name` to add the `name` label when creating a Job. Names make Jobs easier to find and identify in the UI; they are optional and do not have to be unique. If you don't pass `--name`, one is derived automatically from the Docker image (`hf jobs run`) or the script (`hf jobs uv run`), e.g. `python:3.12` → `python-3-12` and `train.py` → `train`. Characters not allowed in a name (`/`, `:`, `.`, ...) are replaced with `-`. You can also name an existing Job:
 
 ```bash
 >>> hf jobs run --name training-v2 python:3.12 python train.py

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -2028,7 +2028,7 @@ Add labels to a Job using `-l` or `--label`. Labels are a key=value pairs that a
 
 The my-label key doesn't specify a value so its value defaults to an empty string ("").
 
-Use `--name` to add the `name` label when creating a Job. Names make Jobs easier to find and identify in the UI; they are optional and do not have to be unique. You can also name an existing Job:
+Use `--name` to add the `name` label when creating a Job. Names make Jobs easier to find and identify in the UI; they are optional and do not have to be unique. If you don't pass `--name`, one is derived automatically from the Docker image (`hf jobs run`) or the script (`hf jobs uv run`), e.g. `python:3.12` → `python` and `train.py` → `train`. You can also name an existing Job:
 
 ```bash
 >>> hf jobs run --name training-v2 python:3.12 python train.py

--- a/docs/source/en/guides/jobs.md
+++ b/docs/source/en/guides/jobs.md
@@ -514,7 +514,6 @@ Use `name` to make Jobs easier to find and identify in the UI. Names are optiona
 >>> run_job(name="daily-report", image="python:3.12", command=["python", "report.py"])
 ```
 
-
 From the CLI, pass `--name` when creating a Job, or name an existing Job through the labels command:
 
 ```bash

--- a/docs/source/en/guides/jobs.md
+++ b/docs/source/en/guides/jobs.md
@@ -514,7 +514,7 @@ Use `name` to make Jobs easier to find and identify in the UI. Names are optiona
 >>> run_job(name="daily-report", image="python:3.12", command=["python", "report.py"])
 ```
 
-If you don't pass a name, one is derived automatically: from the Docker image for `run_job`/`create_scheduled_job` (e.g. `python:3.12` → `python`) and from the script for `run_uv_job`/`create_scheduled_uv_job` (e.g. `train.py` → `train`).
+If you don't pass a name, one is derived automatically: from the Docker image for `run_job`/`create_scheduled_job` (e.g. `python:3.12` → `python-3-12`, `hf.co/spaces/lhoestq/duckdb` → `lhoestq-duckdb`) and from the script for `run_uv_job`/`create_scheduled_uv_job` (e.g. `train.py` → `train`). Characters not allowed in a name (`/`, `:`, `.`, ...) are replaced with `-`.
 
 From the CLI, pass `--name` when creating a Job, or name an existing Job through the labels command:
 

--- a/docs/source/en/guides/jobs.md
+++ b/docs/source/en/guides/jobs.md
@@ -531,7 +531,7 @@ From the CLI, pass `--name` when creating a Job, or name an existing Job through
 ... )
 ```
 
-If you don't pass `--name`, a name is derived automatically from the Docker image or the script, e.g. `python:3.12` → `python-3-12`
+If you don't pass `--name`, a name is derived automatically from the Docker image or the script, plus a short hash of the command so reruns of the same command share a name (e.g. `python:3.12 foo --truc` → `python-3-12-1a2b3c4d`).
 
 ### Update labels
 

--- a/docs/source/en/guides/jobs.md
+++ b/docs/source/en/guides/jobs.md
@@ -514,7 +514,6 @@ Use `name` to make Jobs easier to find and identify in the UI. Names are optiona
 >>> run_job(name="daily-report", image="python:3.12", command=["python", "report.py"])
 ```
 
-If you don't pass a name, one is derived automatically: from the Docker image for `run_job`/`create_scheduled_job` (e.g. `python:3.12` → `python-3-12`, `hf.co/spaces/lhoestq/duckdb` → `lhoestq-duckdb`) and from the script for `run_uv_job`/`create_scheduled_uv_job` (e.g. `train.py` → `train`). Characters not allowed in a name (`/`, `:`, `.`, ...) are replaced with `-`.
 
 From the CLI, pass `--name` when creating a Job, or name an existing Job through the labels command:
 
@@ -532,6 +531,8 @@ From the CLI, pass `--name` when creating a Job, or name an existing Job through
 ...     labels={"my-label": "my-value", "foo": "bar"},
 ... )
 ```
+
+If you don't pass `--name`, a name is derived automatically from the Docker image or the script, e.g. `python:3.12` → `python-3-12`
 
 ### Update labels
 

--- a/docs/source/en/guides/jobs.md
+++ b/docs/source/en/guides/jobs.md
@@ -514,6 +514,8 @@ Use `name` to make Jobs easier to find and identify in the UI. Names are optiona
 >>> run_job(name="daily-report", image="python:3.12", command=["python", "report.py"])
 ```
 
+If you don't pass a name, one is derived automatically: from the Docker image for `run_job`/`create_scheduled_job` (e.g. `python:3.12` → `python`) and from the script for `run_uv_job`/`create_scheduled_uv_job` (e.g. `train.py` → `train`).
+
 From the CLI, pass `--name` when creating a Job, or name an existing Job through the labels command:
 
 ```bash

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -2295,7 +2295,7 @@ $ hf jobs labels [OPTIONS] JOB_ID
 
 **Options**:
 
-* `--name TEXT`: Name the Job. Stored as the `name` label. Names do not have to be unique.
+* `--name TEXT`: Name the Job. Stored as the `name` label. Names do not have to be unique. Defaults to the image or script name.
 * `-l, --label TEXT`: Set labels. E.g. --label KEY=VALUE or --label LABEL
 * `--clear`: Remove all labels from the job.
 * `--namespace TEXT`: The namespace where the job will be running. Defaults to the current user's namespace.
@@ -2407,7 +2407,7 @@ $ hf jobs run [OPTIONS] IMAGE COMMAND...
 
 * `-e, --env TEXT`: Set environment variables. E.g. --env ENV=value
 * `-s, --secrets TEXT`: Set secret environment variables. E.g. --secrets SECRET=value or `--secrets HF_TOKEN` to pass your Hugging Face token.
-* `--name TEXT`: Name the Job. Stored as the `name` label. Names do not have to be unique.
+* `--name TEXT`: Name the Job. Stored as the `name` label. Names do not have to be unique. Defaults to the image or script name.
 * `-l, --label TEXT`: Set labels. E.g. --label KEY=VALUE or --label LABEL
 * `-v, --volume TEXT`: Mount one or more volumes. Format: hf://[TYPE/]SOURCE:/MOUNT_PATH[:ro|:rw] or LOCAL_DIR:/MOUNT_PATH[:ro|:rw]. TYPE is one of: models, datasets, spaces, buckets. TYPE defaults to models if omitted. models, datasets and spaces are always mounted read-only. buckets are read+write by default. A local directory source is first synced to a bucket and mounted read-only by default. E.g. -v hf://datasets/org/ds:/data or -v hf://buckets/org/b:/mnt:ro or -v ./inputs:/inputs
 * `--env-file TEXT`: Read in a file of environment variables.
@@ -2531,7 +2531,7 @@ $ hf jobs scheduled labels [OPTIONS] SCHEDULED_JOB_ID
 
 **Options**:
 
-* `--name TEXT`: Name the Job. Stored as the `name` label. Names do not have to be unique.
+* `--name TEXT`: Name the Job. Stored as the `name` label. Names do not have to be unique. Defaults to the image or script name.
 * `-l, --label TEXT`: Set labels. E.g. --label KEY=VALUE or --label LABEL
 * `--clear`: Remove all labels from the scheduled job.
 * `--namespace TEXT`: The namespace where the job will be running. Defaults to the current user's namespace.
@@ -2624,7 +2624,7 @@ $ hf jobs scheduled run [OPTIONS] SCHEDULE IMAGE COMMAND...
 * `--concurrency / --no-concurrency`: Allow multiple instances of this Job to run concurrently
 * `-e, --env TEXT`: Set environment variables. E.g. --env ENV=value
 * `-s, --secrets TEXT`: Set secret environment variables. E.g. --secrets SECRET=value or `--secrets HF_TOKEN` to pass your Hugging Face token.
-* `--name TEXT`: Name the Job. Stored as the `name` label. Names do not have to be unique.
+* `--name TEXT`: Name the Job. Stored as the `name` label. Names do not have to be unique. Defaults to the image or script name.
 * `-l, --label TEXT`: Set labels. E.g. --label KEY=VALUE or --label LABEL
 * `-v, --volume TEXT`: Mount one or more volumes. Format: hf://[TYPE/]SOURCE:/MOUNT_PATH[:ro|:rw] or LOCAL_DIR:/MOUNT_PATH[:ro|:rw]. TYPE is one of: models, datasets, spaces, buckets. TYPE defaults to models if omitted. models, datasets and spaces are always mounted read-only. buckets are read+write by default. A local directory source is first synced to a bucket and mounted read-only by default. E.g. -v hf://datasets/org/ds:/data or -v hf://buckets/org/b:/mnt:ro or -v ./inputs:/inputs
 * `--env-file TEXT`: Read in a file of environment variables.
@@ -2742,7 +2742,7 @@ $ hf jobs scheduled uv run [OPTIONS] SCHEDULE SCRIPT [SCRIPT_ARGS]...
 * `--flavor [cpu-basic|cpu-upgrade|cpu-performance|cpu-xl|t4-small|t4-medium|l4x1|l4x4|l40sx1|l40sx4|l40sx8|a10g-small|a10g-large|a10g-largex2|a10g-largex4|a100-large|a100x4|a100x8|h200|h200x2|h200x4|h200x8|rtx-pro-6000|rtx-pro-6000x2|rtx-pro-6000x4|rtx-pro-6000x8]`: Flavor for the hardware. Run 'hf jobs hardware' to list available flavors. Defaults to `cpu-basic`.
 * `-e, --env TEXT`: Set environment variables. E.g. --env ENV=value
 * `-s, --secrets TEXT`: Set secret environment variables. E.g. --secrets SECRET=value or `--secrets HF_TOKEN` to pass your Hugging Face token.
-* `--name TEXT`: Name the Job. Stored as the `name` label. Names do not have to be unique.
+* `--name TEXT`: Name the Job. Stored as the `name` label. Names do not have to be unique. Defaults to the image or script name.
 * `-l, --label TEXT`: Set labels. E.g. --label KEY=VALUE or --label LABEL
 * `-v, --volume TEXT`: Mount one or more volumes. Format: hf://[TYPE/]SOURCE:/MOUNT_PATH[:ro|:rw] or LOCAL_DIR:/MOUNT_PATH[:ro|:rw]. TYPE is one of: models, datasets, spaces, buckets. TYPE defaults to models if omitted. models, datasets and spaces are always mounted read-only. buckets are read+write by default. A local directory source is first synced to a bucket and mounted read-only by default. E.g. -v hf://datasets/org/ds:/data or -v hf://buckets/org/b:/mnt:ro or -v ./inputs:/inputs
 * `--env-file TEXT`: Read in a file of environment variables.
@@ -2867,7 +2867,7 @@ $ hf jobs uv run [OPTIONS] SCRIPT [SCRIPT_ARGS]...
 * `--flavor [cpu-basic|cpu-upgrade|cpu-performance|cpu-xl|t4-small|t4-medium|l4x1|l4x4|l40sx1|l40sx4|l40sx8|a10g-small|a10g-large|a10g-largex2|a10g-largex4|a100-large|a100x4|a100x8|h200|h200x2|h200x4|h200x8|rtx-pro-6000|rtx-pro-6000x2|rtx-pro-6000x4|rtx-pro-6000x8]`: Flavor for the hardware. Run 'hf jobs hardware' to list available flavors. Defaults to `cpu-basic`.
 * `-e, --env TEXT`: Set environment variables. E.g. --env ENV=value
 * `-s, --secrets TEXT`: Set secret environment variables. E.g. --secrets SECRET=value or `--secrets HF_TOKEN` to pass your Hugging Face token.
-* `--name TEXT`: Name the Job. Stored as the `name` label. Names do not have to be unique.
+* `--name TEXT`: Name the Job. Stored as the `name` label. Names do not have to be unique. Defaults to the image or script name.
 * `-l, --label TEXT`: Set labels. E.g. --label KEY=VALUE or --label LABEL
 * `-v, --volume TEXT`: Mount one or more volumes. Format: hf://[TYPE/]SOURCE:/MOUNT_PATH[:ro|:rw] or LOCAL_DIR:/MOUNT_PATH[:ro|:rw]. TYPE is one of: models, datasets, spaces, buckets. TYPE defaults to models if omitted. models, datasets and spaces are always mounted read-only. buckets are read+write by default. A local directory source is first synced to a bucket and mounted read-only by default. E.g. -v hf://datasets/org/ds:/data or -v hf://buckets/org/b:/mnt:ro or -v ./inputs:/inputs
 * `--env-file TEXT`: Read in a file of environment variables.

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -2295,7 +2295,7 @@ $ hf jobs labels [OPTIONS] JOB_ID
 
 **Options**:
 
-* `--name TEXT`: Name the Job. Stored as the `name` label. Names do not have to be unique. Defaults to the image or script name.
+* `--name TEXT`: Name the Job. Stored as the `name` label. Names do not have to be unique. Defaults to the image or script name plus a short hash of the command.
 * `-l, --label TEXT`: Set labels. E.g. --label KEY=VALUE or --label LABEL
 * `--clear`: Remove all labels from the job.
 * `--namespace TEXT`: The namespace where the job will be running. Defaults to the current user's namespace.
@@ -2407,7 +2407,7 @@ $ hf jobs run [OPTIONS] IMAGE COMMAND...
 
 * `-e, --env TEXT`: Set environment variables. E.g. --env ENV=value
 * `-s, --secrets TEXT`: Set secret environment variables. E.g. --secrets SECRET=value or `--secrets HF_TOKEN` to pass your Hugging Face token.
-* `--name TEXT`: Name the Job. Stored as the `name` label. Names do not have to be unique. Defaults to the image or script name.
+* `--name TEXT`: Name the Job. Stored as the `name` label. Names do not have to be unique. Defaults to the image or script name plus a short hash of the command.
 * `-l, --label TEXT`: Set labels. E.g. --label KEY=VALUE or --label LABEL
 * `-v, --volume TEXT`: Mount one or more volumes. Format: hf://[TYPE/]SOURCE:/MOUNT_PATH[:ro|:rw] or LOCAL_DIR:/MOUNT_PATH[:ro|:rw]. TYPE is one of: models, datasets, spaces, buckets. TYPE defaults to models if omitted. models, datasets and spaces are always mounted read-only. buckets are read+write by default. A local directory source is first synced to a bucket and mounted read-only by default. E.g. -v hf://datasets/org/ds:/data or -v hf://buckets/org/b:/mnt:ro or -v ./inputs:/inputs
 * `--env-file TEXT`: Read in a file of environment variables.
@@ -2531,7 +2531,7 @@ $ hf jobs scheduled labels [OPTIONS] SCHEDULED_JOB_ID
 
 **Options**:
 
-* `--name TEXT`: Name the Job. Stored as the `name` label. Names do not have to be unique. Defaults to the image or script name.
+* `--name TEXT`: Name the Job. Stored as the `name` label. Names do not have to be unique. Defaults to the image or script name plus a short hash of the command.
 * `-l, --label TEXT`: Set labels. E.g. --label KEY=VALUE or --label LABEL
 * `--clear`: Remove all labels from the scheduled job.
 * `--namespace TEXT`: The namespace where the job will be running. Defaults to the current user's namespace.
@@ -2624,7 +2624,7 @@ $ hf jobs scheduled run [OPTIONS] SCHEDULE IMAGE COMMAND...
 * `--concurrency / --no-concurrency`: Allow multiple instances of this Job to run concurrently
 * `-e, --env TEXT`: Set environment variables. E.g. --env ENV=value
 * `-s, --secrets TEXT`: Set secret environment variables. E.g. --secrets SECRET=value or `--secrets HF_TOKEN` to pass your Hugging Face token.
-* `--name TEXT`: Name the Job. Stored as the `name` label. Names do not have to be unique. Defaults to the image or script name.
+* `--name TEXT`: Name the Job. Stored as the `name` label. Names do not have to be unique. Defaults to the image or script name plus a short hash of the command.
 * `-l, --label TEXT`: Set labels. E.g. --label KEY=VALUE or --label LABEL
 * `-v, --volume TEXT`: Mount one or more volumes. Format: hf://[TYPE/]SOURCE:/MOUNT_PATH[:ro|:rw] or LOCAL_DIR:/MOUNT_PATH[:ro|:rw]. TYPE is one of: models, datasets, spaces, buckets. TYPE defaults to models if omitted. models, datasets and spaces are always mounted read-only. buckets are read+write by default. A local directory source is first synced to a bucket and mounted read-only by default. E.g. -v hf://datasets/org/ds:/data or -v hf://buckets/org/b:/mnt:ro or -v ./inputs:/inputs
 * `--env-file TEXT`: Read in a file of environment variables.
@@ -2742,7 +2742,7 @@ $ hf jobs scheduled uv run [OPTIONS] SCHEDULE SCRIPT [SCRIPT_ARGS]...
 * `--flavor [cpu-basic|cpu-upgrade|cpu-performance|cpu-xl|t4-small|t4-medium|l4x1|l4x4|l40sx1|l40sx4|l40sx8|a10g-small|a10g-large|a10g-largex2|a10g-largex4|a100-large|a100x4|a100x8|h200|h200x2|h200x4|h200x8|rtx-pro-6000|rtx-pro-6000x2|rtx-pro-6000x4|rtx-pro-6000x8]`: Flavor for the hardware. Run 'hf jobs hardware' to list available flavors. Defaults to `cpu-basic`.
 * `-e, --env TEXT`: Set environment variables. E.g. --env ENV=value
 * `-s, --secrets TEXT`: Set secret environment variables. E.g. --secrets SECRET=value or `--secrets HF_TOKEN` to pass your Hugging Face token.
-* `--name TEXT`: Name the Job. Stored as the `name` label. Names do not have to be unique. Defaults to the image or script name.
+* `--name TEXT`: Name the Job. Stored as the `name` label. Names do not have to be unique. Defaults to the image or script name plus a short hash of the command.
 * `-l, --label TEXT`: Set labels. E.g. --label KEY=VALUE or --label LABEL
 * `-v, --volume TEXT`: Mount one or more volumes. Format: hf://[TYPE/]SOURCE:/MOUNT_PATH[:ro|:rw] or LOCAL_DIR:/MOUNT_PATH[:ro|:rw]. TYPE is one of: models, datasets, spaces, buckets. TYPE defaults to models if omitted. models, datasets and spaces are always mounted read-only. buckets are read+write by default. A local directory source is first synced to a bucket and mounted read-only by default. E.g. -v hf://datasets/org/ds:/data or -v hf://buckets/org/b:/mnt:ro or -v ./inputs:/inputs
 * `--env-file TEXT`: Read in a file of environment variables.
@@ -2867,7 +2867,7 @@ $ hf jobs uv run [OPTIONS] SCRIPT [SCRIPT_ARGS]...
 * `--flavor [cpu-basic|cpu-upgrade|cpu-performance|cpu-xl|t4-small|t4-medium|l4x1|l4x4|l40sx1|l40sx4|l40sx8|a10g-small|a10g-large|a10g-largex2|a10g-largex4|a100-large|a100x4|a100x8|h200|h200x2|h200x4|h200x8|rtx-pro-6000|rtx-pro-6000x2|rtx-pro-6000x4|rtx-pro-6000x8]`: Flavor for the hardware. Run 'hf jobs hardware' to list available flavors. Defaults to `cpu-basic`.
 * `-e, --env TEXT`: Set environment variables. E.g. --env ENV=value
 * `-s, --secrets TEXT`: Set secret environment variables. E.g. --secrets SECRET=value or `--secrets HF_TOKEN` to pass your Hugging Face token.
-* `--name TEXT`: Name the Job. Stored as the `name` label. Names do not have to be unique. Defaults to the image or script name.
+* `--name TEXT`: Name the Job. Stored as the `name` label. Names do not have to be unique. Defaults to the image or script name plus a short hash of the command.
 * `-l, --label TEXT`: Set labels. E.g. --label KEY=VALUE or --label LABEL
 * `-v, --volume TEXT`: Mount one or more volumes. Format: hf://[TYPE/]SOURCE:/MOUNT_PATH[:ro|:rw] or LOCAL_DIR:/MOUNT_PATH[:ro|:rw]. TYPE is one of: models, datasets, spaces, buckets. TYPE defaults to models if omitted. models, datasets and spaces are always mounted read-only. buckets are read+write by default. A local directory source is first synced to a bucket and mounted read-only by default. E.g. -v hf://datasets/org/ds:/data or -v hf://buckets/org/b:/mnt:ro or -v ./inputs:/inputs
 * `--env-file TEXT`: Read in a file of environment variables.

--- a/src/huggingface_hub/_jobs_api.py
+++ b/src/huggingface_hub/_jobs_api.py
@@ -510,6 +510,30 @@ def _derive_job_volume_name(source: str | Path) -> str:
     return f"{dirname}-{digest}"
 
 
+def _default_job_name_from_image(image: str) -> str:
+    """Derive a default Job name from a Docker image or Space reference.
+
+    Drops the registry host, namespace and tag/digest, keeping the final image name.
+    E.g. `python:3.12` -> `python`, `pytorch/pytorch:2.6.0-cuda12.4-cudnn9-devel` -> `pytorch`,
+    `hf.co/spaces/lhoestq/duckdb` -> `duckdb`.
+    """
+    name = image.rstrip("/").split("/")[-1]  # keep the last path component
+    name = name.split("@", 1)[0].split(":", 1)[0]  # drop the tag or digest
+    return name or image
+
+
+def _default_job_name_from_script(script: str) -> str:
+    """Derive a default Job name from a UV script path, URL, or command.
+
+    Keeps the final path component and drops a trailing `.py` extension.
+    E.g. `my_script.py` -> `my_script`, `https://.../sft.py?raw=1` -> `sft`, `lighteval` -> `lighteval`.
+    """
+    name = script.split("?", 1)[0].split("#", 1)[0].rstrip("/").split("/")[-1]
+    if name.endswith(".py"):
+        name = name[: -len(".py")]
+    return name or script
+
+
 def _create_job_spec(
     *,
     image: str,

--- a/src/huggingface_hub/_jobs_api.py
+++ b/src/huggingface_hub/_jobs_api.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import hashlib
 import platform
+import re
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
@@ -90,6 +91,14 @@ class JobStage(str, Enum):
 
 # Stages indicating the Job has reached a terminal state and will not run further.
 TERMINAL_JOB_STAGES = (JobStage.COMPLETED, JobStage.CANCELED, JobStage.ERROR, JobStage.DELETED)
+
+# URL prefixes identifying an image that points to a HF Space rather than a Docker image.
+_SPACE_IMAGE_PREFIXES = (
+    "https://huggingface.co/spaces/",
+    "https://hf.co/spaces/",
+    "huggingface.co/spaces/",
+    "hf.co/spaces/",
+)
 
 
 @dataclass
@@ -510,28 +519,40 @@ def _derive_job_volume_name(source: str | Path) -> str:
     return f"{dirname}-{digest}"
 
 
+def _sanitize_job_name(name: str) -> str:
+    """Sanitize a string so it is a valid Job `name` label.
+
+    Job names must match `^[a-zA-Z0-9._-]*$` and are also stored as tags, which only allow
+    alphanumerics, `-` and `_`. Every other character (including `/`, `:` and `.`) is replaced with `-`.
+    """
+    return re.sub(r"[^a-zA-Z0-9_-]", "-", name)
+
+
 def _default_job_name_from_image(image: str) -> str:
     """Derive a default Job name from a Docker image or Space reference.
 
-    Drops the registry host, namespace and tag/digest, keeping the final image name.
-    E.g. `python:3.12` -> `python`, `pytorch/pytorch:2.6.0-cuda12.4-cudnn9-devel` -> `pytorch`,
-    `hf.co/spaces/lhoestq/duckdb` -> `duckdb`.
+    For a Space reference, keeps the `namespace/repo` id (e.g. `hf.co/spaces/lhoestq/duckdb` -> `lhoestq-duckdb`).
+    For a Docker image, keeps the final `name:tag` component, dropping the registry host and any namespace
+    (e.g. `python:3.12` -> `python-3-12`, `pytorch/pytorch:2.6.0-cuda12.4-cudnn9-devel` -> `pytorch-2-6-0-cuda12-4-cudnn9-devel`).
+    The result is sanitized to a valid `name` label (see [`_sanitize_job_name`]).
     """
-    name = image.rstrip("/").split("/")[-1]  # keep the last path component
-    name = name.split("@", 1)[0].split(":", 1)[0]  # drop the tag or digest
-    return name or image
+    for prefix in _SPACE_IMAGE_PREFIXES:
+        if image.startswith(prefix):
+            return _sanitize_job_name(image[len(prefix) :] or image)
+    name = image.rstrip("/").split("/")[-1] or image  # keep the last path component (registry/namespace dropped)
+    return _sanitize_job_name(name)
 
 
 def _default_job_name_from_script(script: str) -> str:
     """Derive a default Job name from a UV script path, URL, or command.
 
-    Keeps the final path component and drops a trailing `.py` extension.
-    E.g. `my_script.py` -> `my_script`, `https://.../sft.py?raw=1` -> `sft`, `lighteval` -> `lighteval`.
+    Keeps the final path component, drops a trailing `.py` extension, and sanitizes the result to a
+    valid `name` label. E.g. `my_script.py` -> `my_script`, `https://.../sft.py?raw=1` -> `sft`, `lighteval` -> `lighteval`.
     """
     name = script.split("?", 1)[0].split("#", 1)[0].rstrip("/").split("/")[-1]
     if name.endswith(".py"):
         name = name[: -len(".py")]
-    return name or script
+    return _sanitize_job_name(name or script)
 
 
 def _create_job_spec(
@@ -583,12 +604,7 @@ def _create_job_spec(
     if ssh:
         job_spec["ssh"] = {"enabled": True}
     # input is either from docker hub or from HF spaces
-    for prefix in (
-        "https://huggingface.co/spaces/",
-        "https://hf.co/spaces/",
-        "huggingface.co/spaces/",
-        "hf.co/spaces/",
-    ):
+    for prefix in _SPACE_IMAGE_PREFIXES:
         if image.startswith(prefix):
             job_spec["spaceId"] = image[len(prefix) :]
             break

--- a/src/huggingface_hub/_jobs_api.py
+++ b/src/huggingface_hub/_jobs_api.py
@@ -528,30 +528,44 @@ def _sanitize_job_name(name: str) -> str:
     return re.sub(r"[^a-zA-Z0-9_-]", "-", name)
 
 
-def _default_job_name_from_image(image: str) -> str:
-    """Derive a default Job name from a Docker image or Space reference.
+def _short_invocation_hash(parts: list[str]) -> str:
+    """Short, stable hash of a Job invocation (image/script + command line).
 
-    e.g. hf.co/spaces/lhoestq/duckdb                 -> lhoestq-duckdb
-         pytorch/pytorch:2.6.0-cuda12.4-cudnn9-devel -> pytorch-2-6-0-cuda12-4-cudnn9-devel
+    Appended to auto-generated names so reruns of the same command share a name while different ones don't.
+    """
+    return hashlib.sha256("\x00".join(parts).encode()).hexdigest()[:8]
+
+
+def _default_job_name_from_image(image: str, command: list[str]) -> str:
+    """Derive a default Job name from a Docker image or Space reference and its command.
+
+    A short hash of the full command line is appended to group reruns of the same command.
+    e.g. python:3.12 + [foo, --truc]             -> python-3-12-1a2b3c4d
+         hf.co/spaces/lhoestq/duckdb             -> lhoestq-duckdb-<hash>
+         pytorch/pytorch:2.6.0-cuda12.4-...      -> pytorch-2-6-0-cuda12-4-...-<hash>
     """
     for prefix in _SPACE_IMAGE_PREFIXES:
         if image.startswith(prefix):
-            return _sanitize_job_name(image[len(prefix) :] or image)
-    name = image.rstrip("/").split("/")[-1] or image  # keep the last path component (registry/namespace dropped)
-    return _sanitize_job_name(name)
+            base = _sanitize_job_name(image[len(prefix) :] or image)
+            break
+    else:
+        base = _sanitize_job_name(image.rstrip("/").split("/")[-1] or image)  # drop registry host and namespace
+    return f"{base}-{_short_invocation_hash([image, *command])}"
 
 
-def _default_job_name_from_script(script: str) -> str:
-    """Derive a default Job name from a UV script path, URL, or command.
+def _default_job_name_from_script(script: str, script_args: list[str]) -> str:
+    """Derive a default Job name from a UV script path, URL, or command and its arguments.
 
-    e.g. my_script.py             -> my_script
-         https://.../sft.py?raw=1 -> sft
-         lighteval                -> lighteval
+    A short hash of the full command line is appended to group reruns of the same command.
+    e.g. my_script.py + [--epochs, 3]  -> my_script-1a2b3c4d
+         https://.../sft.py?raw=1      -> sft-<hash>
+         lighteval                     -> lighteval-<hash>
     """
     name = script.split("?", 1)[0].split("#", 1)[0].rstrip("/").split("/")[-1]
     if name.endswith(".py"):
         name = name[: -len(".py")]
-    return _sanitize_job_name(name or script)
+    base = _sanitize_job_name(name or script)
+    return f"{base}-{_short_invocation_hash([script, *script_args])}"
 
 
 def _create_job_spec(

--- a/src/huggingface_hub/_jobs_api.py
+++ b/src/huggingface_hub/_jobs_api.py
@@ -531,10 +531,8 @@ def _sanitize_job_name(name: str) -> str:
 def _default_job_name_from_image(image: str) -> str:
     """Derive a default Job name from a Docker image or Space reference.
 
-    For a Space reference, keeps the `namespace/repo` id (e.g. `hf.co/spaces/lhoestq/duckdb` -> `lhoestq-duckdb`).
-    For a Docker image, keeps the final `name:tag` component, dropping the registry host and any namespace
-    (e.g. `python:3.12` -> `python-3-12`, `pytorch/pytorch:2.6.0-cuda12.4-cudnn9-devel` -> `pytorch-2-6-0-cuda12-4-cudnn9-devel`).
-    The result is sanitized to a valid `name` label (see [`_sanitize_job_name`]).
+    e.g. hf.co/spaces/lhoestq/duckdb                 -> lhoestq-duckdb
+         pytorch/pytorch:2.6.0-cuda12.4-cudnn9-devel -> pytorch-2-6-0-cuda12-4-cudnn9-devel
     """
     for prefix in _SPACE_IMAGE_PREFIXES:
         if image.startswith(prefix):
@@ -546,8 +544,9 @@ def _default_job_name_from_image(image: str) -> str:
 def _default_job_name_from_script(script: str) -> str:
     """Derive a default Job name from a UV script path, URL, or command.
 
-    Keeps the final path component, drops a trailing `.py` extension, and sanitizes the result to a
-    valid `name` label. E.g. `my_script.py` -> `my_script`, `https://.../sft.py?raw=1` -> `sft`, `lighteval` -> `lighteval`.
+    e.g. my_script.py             -> my_script
+         https://.../sft.py?raw=1 -> sft
+         lighteval                -> lighteval
     """
     name = script.split("?", 1)[0].split("#", 1)[0].rstrip("/").split("/")[-1]
     if name.endswith(".py"):

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -165,7 +165,7 @@ NameOpt = Annotated[
     str | None,
     Option(
         "--name",
-        help="Name the Job. Stored as the `name` label. Names do not have to be unique.",
+        help="Name the Job. Stored as the `name` label. Names do not have to be unique. Defaults to the image or script name.",
     ),
 ]
 
@@ -368,7 +368,11 @@ def jobs_run(
     )
     out.result("Job started", id=job.id, url=job.url)
     if name is None:
-        out.hint(f"Name this Job with `hf jobs labels {job.owner.name}/{job.id} --name NAME`.")
+        auto_name = (job.labels or {}).get("name")
+        out.hint(
+            f"Job auto-named '{auto_name}'. Pass `--name` or run "
+            f"`hf jobs labels {job.owner.name}/{job.id} --name NAME` to rename it."
+        )
     if isinstance(job.status.expose_urls, list):
         urls = "\n".join(f"  {url}" for url in job.status.expose_urls)
         out.hint(f"Exposed ports are reachable at (requires an HF token with read access to the job):\n{urls}")
@@ -951,7 +955,11 @@ def jobs_uv_run(
     )
     out.result("Job started", id=job.id, url=job.url)
     if name is None:
-        out.hint(f"Name this Job with `hf jobs labels {job.owner.name}/{job.id} --name NAME`.")
+        auto_name = (job.labels or {}).get("name")
+        out.hint(
+            f"Job auto-named '{auto_name}'. Pass `--name` or run "
+            f"`hf jobs labels {job.owner.name}/{job.id} --name NAME` to rename it."
+        )
     if isinstance(job.status.expose_urls, list):
         urls = "\n".join(f"  {url}" for url in job.status.expose_urls)
         out.hint(f"Exposed ports are reachable at (requires an HF token with read access to the job):\n{urls}")
@@ -1015,8 +1023,10 @@ def scheduled_run(
     )
     out.result("Scheduled Job created", id=scheduled_job.id)
     if name is None:
+        auto_name = (scheduled_job.job_spec.labels or {}).get("name")
         out.hint(
-            f"Name this scheduled Job with `hf jobs scheduled labels {scheduled_job.owner.name}/{scheduled_job.id} --name NAME`."
+            f"Scheduled Job auto-named '{auto_name}'. Pass `--name` or run "
+            f"`hf jobs scheduled labels {scheduled_job.owner.name}/{scheduled_job.id} --name NAME` to rename it."
         )
     out.hint(f"Use `hf jobs scheduled inspect {scheduled_job.owner.name}/{scheduled_job.id}` to view its details.")
 
@@ -1283,7 +1293,11 @@ def scheduled_uv_run(
     )
     out.result("Scheduled Job created", id=job.id)
     if name is None:
-        out.hint(f"Name this scheduled Job with `hf jobs scheduled labels {job.owner.name}/{job.id} --name NAME`.")
+        auto_name = (job.job_spec.labels or {}).get("name")
+        out.hint(
+            f"Scheduled Job auto-named '{auto_name}'. Pass `--name` or run "
+            f"`hf jobs scheduled labels {job.owner.name}/{job.id} --name NAME` to rename it."
+        )
     out.hint(f"Use `hf jobs scheduled inspect {job.owner.name}/{job.id}` to view its details.")
 
 

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -165,7 +165,7 @@ NameOpt = Annotated[
     str | None,
     Option(
         "--name",
-        help="Name the Job. Stored as the `name` label. Names do not have to be unique. Defaults to the image or script name.",
+        help="Name the Job. Stored as the `name` label. Names do not have to be unique. Defaults to the image or script name plus a short hash of the command.",
     ),
 ]
 

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -367,7 +367,7 @@ def jobs_run(
         namespace=namespace,
     )
     out.result("Job started", id=job.id, url=job.url)
-    if name is None:
+    if not _has_explicit_name(name, label):
         auto_name = (job.labels or {}).get("name")
         out.hint(
             f"Job auto-named '{auto_name}'. Pass `--name` or run "
@@ -954,7 +954,7 @@ def jobs_uv_run(
         namespace=namespace,
     )
     out.result("Job started", id=job.id, url=job.url)
-    if name is None:
+    if not _has_explicit_name(name, label):
         auto_name = (job.labels or {}).get("name")
         out.hint(
             f"Job auto-named '{auto_name}'. Pass `--name` or run "
@@ -1022,7 +1022,7 @@ def scheduled_run(
         namespace=namespace,
     )
     out.result("Scheduled Job created", id=scheduled_job.id)
-    if name is None:
+    if not _has_explicit_name(name, label):
         auto_name = (scheduled_job.job_spec.labels or {}).get("name")
         out.hint(
             f"Scheduled Job auto-named '{auto_name}'. Pass `--name` or run "
@@ -1292,7 +1292,7 @@ def scheduled_uv_run(
         namespace=namespace,
     )
     out.result("Scheduled Job created", id=job.id)
-    if name is None:
+    if not _has_explicit_name(name, label):
         auto_name = (job.job_spec.labels or {}).get("name")
         out.hint(
             f"Scheduled Job auto-named '{auto_name}'. Pass `--name` or run "
@@ -1302,6 +1302,11 @@ def scheduled_uv_run(
 
 
 ### UTILS
+
+
+def _has_explicit_name(name: str | None, label: list[str] | None) -> bool:
+    """Whether the user explicitly named the Job (via `--name` or a `name=` label)."""
+    return name is not None or any(item.split("=", 1)[0] == "name" for item in label or [])
 
 
 def _parse_labels_map(labels: list[str] | None, *, name: str | None = None) -> dict[str, str] | None:

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -75,6 +75,8 @@ from ._jobs_api import (
     JobStage,
     ScheduledJobInfo,
     _create_job_spec,
+    _default_job_name_from_image,
+    _default_job_name_from_script,
     _derive_job_volume_name,
 )
 from ._space_api import (
@@ -11862,7 +11864,7 @@ class HfApi:
 
             name (`str`, *optional*):
                 A name for the Job. Stored as the `name` label. Cannot be passed together with a `name` key in
-                `labels`. Names do not have to be unique.
+                `labels`. Names do not have to be unique. Defaults to a name derived from `image`.
 
             labels (`dict[str, str]`, *optional*):
                 Labels to attach to the job (key-value pairs).
@@ -11922,6 +11924,8 @@ class HfApi:
         """
         if namespace is None:
             namespace = self.whoami(token=token)["name"]
+        if name is None and not (labels and "name" in labels):
+            name = _default_job_name_from_image(image)
         job_spec = _create_job_spec(
             image=image,
             command=command,
@@ -12501,7 +12505,7 @@ class HfApi:
 
             name (`str`, *optional*):
                 A name for the Job. Stored as the `name` label. Cannot be passed together with a `name` key in
-                `labels`. Names do not have to be unique.
+                `labels`. Names do not have to be unique. Defaults to a name derived from `script`.
 
             labels (`dict[str, str]`, *optional*):
                 Labels to attach to the job (key-value pairs).
@@ -12572,6 +12576,9 @@ class HfApi:
         image = image or "ghcr.io/astral-sh/uv:python3.12-bookworm"
         env = env or {}
         secrets = secrets or {}
+        # Auto-name from the script (rather than the uv wrapper image) unless already named.
+        if name is None and not (labels and "name" in labels):
+            name = _default_job_name_from_script(script)
 
         # Build command
         command, env, secrets, extra_volumes = self._create_uv_command_env_and_secrets(
@@ -12661,7 +12668,7 @@ class HfApi:
 
             name (`str`, *optional*):
                 A name for the scheduled Job. Stored as the `name` label. Cannot be passed together with a `name`
-                key in `labels`. Names do not have to be unique.
+                key in `labels`. Names do not have to be unique. Defaults to a name derived from `image`.
 
             labels (`dict[str, str]`, *optional*):
                 Labels to attach to the job (key-value pairs).
@@ -12711,6 +12718,8 @@ class HfApi:
         """
         if namespace is None:
             namespace = self.whoami(token=token)["name"]
+        if name is None and not (labels and "name" in labels):
+            name = _default_job_name_from_image(image)
 
         # prepare payload to send to HF Jobs API
         job_spec = _create_job_spec(
@@ -13056,7 +13065,7 @@ class HfApi:
 
             name (`str`, *optional*):
                 A name for the scheduled Job. Stored as the `name` label. Cannot be passed together with a `name`
-                key in `labels`. Names do not have to be unique.
+                key in `labels`. Names do not have to be unique. Defaults to a name derived from `script`.
 
             labels (`dict[str, str]`, *optional*):
                 Labels to attach to the job (key-value pairs).
@@ -13109,6 +13118,9 @@ class HfApi:
             ```
         """
         image = image or "ghcr.io/astral-sh/uv:python3.12-bookworm"
+        # Auto-name from the script (rather than the uv wrapper image) unless already named.
+        if name is None and not (labels and "name" in labels):
+            name = _default_job_name_from_script(script)
         # Build command
         command, env, secrets, extra_volumes = self._create_uv_command_env_and_secrets(
             script=script,

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -11864,7 +11864,7 @@ class HfApi:
 
             name (`str`, *optional*):
                 A name for the Job. Stored as the `name` label. Cannot be passed together with a `name` key in
-                `labels`. Names do not have to be unique. Defaults to a name derived from `image`.
+                `labels`. Names do not have to be unique. Defaults to a name derived from image and command (with a short hash suffix).
 
             labels (`dict[str, str]`, *optional*):
                 Labels to attach to the job (key-value pairs).
@@ -11925,7 +11925,7 @@ class HfApi:
         if namespace is None:
             namespace = self.whoami(token=token)["name"]
         if name is None and not (labels and "name" in labels):
-            name = _default_job_name_from_image(image)
+            name = _default_job_name_from_image(image, command)
         job_spec = _create_job_spec(
             image=image,
             command=command,
@@ -12505,7 +12505,7 @@ class HfApi:
 
             name (`str`, *optional*):
                 A name for the Job. Stored as the `name` label. Cannot be passed together with a `name` key in
-                `labels`. Names do not have to be unique. Defaults to a name derived from `script`.
+                `labels`. Names do not have to be unique. Defaults to a name derived from script and its arguments (with a short hash suffix).
 
             labels (`dict[str, str]`, *optional*):
                 Labels to attach to the job (key-value pairs).
@@ -12578,7 +12578,7 @@ class HfApi:
         secrets = secrets or {}
 
         if name is None and not (labels and "name" in labels):
-            name = _default_job_name_from_script(script)
+            name = _default_job_name_from_script(script, script_args or [])
 
         # Build command
         command, env, secrets, extra_volumes = self._create_uv_command_env_and_secrets(
@@ -12668,7 +12668,7 @@ class HfApi:
 
             name (`str`, *optional*):
                 A name for the scheduled Job. Stored as the `name` label. Cannot be passed together with a `name`
-                key in `labels`. Names do not have to be unique. Defaults to a name derived from `image`.
+                key in `labels`. Names do not have to be unique. Defaults to a name derived from image and command (with a short hash suffix).
 
             labels (`dict[str, str]`, *optional*):
                 Labels to attach to the job (key-value pairs).
@@ -12719,7 +12719,7 @@ class HfApi:
         if namespace is None:
             namespace = self.whoami(token=token)["name"]
         if name is None and not (labels and "name" in labels):
-            name = _default_job_name_from_image(image)
+            name = _default_job_name_from_image(image, command)
 
         # prepare payload to send to HF Jobs API
         job_spec = _create_job_spec(
@@ -13065,7 +13065,7 @@ class HfApi:
 
             name (`str`, *optional*):
                 A name for the scheduled Job. Stored as the `name` label. Cannot be passed together with a `name`
-                key in `labels`. Names do not have to be unique. Defaults to a name derived from `script`.
+                key in `labels`. Names do not have to be unique. Defaults to a name derived from script and its arguments (with a short hash suffix).
 
             labels (`dict[str, str]`, *optional*):
                 Labels to attach to the job (key-value pairs).
@@ -13119,7 +13119,7 @@ class HfApi:
         """
         image = image or "ghcr.io/astral-sh/uv:python3.12-bookworm"
         if name is None and not (labels and "name" in labels):
-            name = _default_job_name_from_script(script)
+            name = _default_job_name_from_script(script, script_args or [])
 
         # Build command
         command, env, secrets, extra_volumes = self._create_uv_command_env_and_secrets(

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -12576,7 +12576,7 @@ class HfApi:
         image = image or "ghcr.io/astral-sh/uv:python3.12-bookworm"
         env = env or {}
         secrets = secrets or {}
-        # Auto-name from the script (rather than the uv wrapper image) unless already named.
+
         if name is None and not (labels and "name" in labels):
             name = _default_job_name_from_script(script)
 
@@ -13118,9 +13118,9 @@ class HfApi:
             ```
         """
         image = image or "ghcr.io/astral-sh/uv:python3.12-bookworm"
-        # Auto-name from the script (rather than the uv wrapper image) unless already named.
         if name is None and not (labels and "name" in labels):
             name = _default_job_name_from_script(script)
+
         # Build command
         command, env, secrets, extra_volumes = self._create_uv_command_env_and_secrets(
             script=script,

--- a/tests/test_jobs_api.py
+++ b/tests/test_jobs_api.py
@@ -96,7 +96,8 @@ class TestWaitForJob:
     ],
 )
 def test_default_job_name_from_image(image: str, expected: str) -> None:
-    assert _default_job_name_from_image(image) == expected
+    # The base name is derived from the image; a short hash of the command line is appended.
+    assert _default_job_name_from_image(image, ["python", "-c", "print(1)"]).startswith(expected + "-")
 
 
 @pytest.mark.parametrize(
@@ -115,4 +116,16 @@ def test_default_job_name_from_image(image: str, expected: str) -> None:
     ],
 )
 def test_default_job_name_from_script(script: str, expected: str) -> None:
-    assert _default_job_name_from_script(script) == expected
+    # The base name is derived from the script; a short hash of the command line is appended.
+    assert _default_job_name_from_script(script, []).startswith(expected + "-")
+
+
+def test_default_job_name_hash_groups_and_splits_by_command() -> None:
+    # Same image but different commands must yield different names (splits distinct runs)...
+    truc = _default_job_name_from_image("python:3.12", ["foo", "--truc"])
+    bar = _default_job_name_from_image("python:3.12", ["foo", "--bar"])
+    assert truc.startswith("python-3-12-")
+    assert bar.startswith("python-3-12-")
+    assert truc != bar
+    # ...while the same command yields the same name (groups identical runs).
+    assert truc == _default_job_name_from_image("python:3.12", ["foo", "--truc"])

--- a/tests/test_jobs_api.py
+++ b/tests/test_jobs_api.py
@@ -3,7 +3,11 @@ from unittest.mock import patch
 import pytest
 
 from huggingface_hub import HfApi, JobStage
-from huggingface_hub._jobs_api import JobInfo
+from huggingface_hub._jobs_api import (
+    JobInfo,
+    _default_job_name_from_image,
+    _default_job_name_from_script,
+)
 
 
 def _job_info(stage: str, job_id: str = "job-id") -> JobInfo:
@@ -74,3 +78,41 @@ class TestWaitForJob:
         ):
             job = self.api.wait_for_job(job_id="job-id", namespace="user", stages=[JobStage.RUNNING])
         assert job.status.stage == "ERROR"
+
+
+@pytest.mark.parametrize(
+    "image, expected",
+    [
+        # Plain image (no registry, no tag).
+        ("ubuntu", "ubuntu"),
+        # Tag is kept, with disallowed chars replaced by '-'.
+        ("python:3.12", "python-3-12"),
+        # Registry host and namespace are dropped, last component + tag is kept.
+        ("pytorch/pytorch:2.6.0-cuda12.4-cudnn9-devel", "pytorch-2-6-0-cuda12-4-cudnn9-devel"),
+        ("ghcr.io/astral-sh/uv:python3.12-bookworm", "uv-python3-12-bookworm"),
+        # Space references keep the `namespace/repo` id (sanitized), for every supported prefix.
+        ("hf.co/spaces/lhoestq/duckdb", "lhoestq-duckdb"),
+        ("https://huggingface.co/spaces/lhoestq/duckdb", "lhoestq-duckdb"),
+    ],
+)
+def test_default_job_name_from_image(image: str, expected: str) -> None:
+    assert _default_job_name_from_image(image) == expected
+
+
+@pytest.mark.parametrize(
+    "script, expected",
+    [
+        # Local script: keep the stem, drop the '.py' extension.
+        ("my_script.py", "my_script"),
+        ("./train.py", "train"),
+        # URL: keep the last path component, drop query/fragment and extension.
+        ("https://raw.githubusercontent.com/huggingface/trl/main/trl/scripts/sft.py", "sft"),
+        ("https://example.co/a/sft.py?raw=1", "sft"),
+        # Command (no extension): kept as-is.
+        ("lighteval", "lighteval"),
+        # Dots in the stem are disallowed chars and get replaced by '-'.
+        ("my.weird.script.py", "my-weird-script"),
+    ],
+)
+def test_default_job_name_from_script(script: str, expected: str) -> None:
+    assert _default_job_name_from_script(script) == expected


### PR DESCRIPTION
## Summary

Follow-up to #4532 (named Jobs). Jobs now get an automatic `name` when the user doesn't provide one, following: **auto-name == the script (uv) or image (docker) you run**, with a **short hash of the command line appended** so reruns of the same command group together while different runs stay distinct.

- `run_job` / `create_scheduled_job` → base from `image`: keep the final `name:tag` component (registry/namespace dropped), or the `namespace/repo` id for Spaces.
- `run_uv_job` / `create_scheduled_uv_job` → base from `script` (filename without `.py`).
- Suffix `-<hash>` where `<hash>` is the first 8 hex chars of `sha256(image/script + command line)`.
- Explicit `--name` / `name=` / `name` label still take precedence.

Job names are validated server-side against `^[a-zA-Z0-9._-]*$` **and** are also stored as tags (which additionally forbid `.`). So `:`, `/` and `.` can't be kept verbatim — every disallowed char in the base is replaced with `-`:

| input | auto-name |
|---|---|
| `python:3.12 foo --truc` | `python-3-12-7c6db949` |
| `python:3.12 foo --bar` | `python-3-12-2c9bffe9` |
| `pytorch/pytorch:2.6.0-cuda12.4-cudnn9-devel ...` | `pytorch-2-6-0-cuda12-4-cudnn9-devel-<hash>` |
| `hf.co/spaces/lhoestq/duckdb ...` | `lhoestq-duckdb-<hash>` |
| `train.py --epochs 3` (uv) | `train-2f161011` |
| `lighteval` (uv) | `lighteval-<hash>` |

Same image, same command → same name (groups reruns); same image, different command → different name.

Also updated CLI hints, `--name` help and the jobs/cli guides.

## Tests

Parametrized tests for the two derivation helpers (no mock / no HTTP), plus a test asserting `python:3.12 foo --truc` and `python:3.12 foo --bar` get different names while the same command is stable.

## Manual testing (real `hf` CLI)

```
$ hf jobs run --detach python:3.12 foo --truc
  id: 6a60b85c13e6ef894d54b949
Hint: Job auto-named 'python-3-12-7c6db949'. Pass `--name` or run `hf jobs labels Wauplin/... --name NAME` to rename it.

$ hf jobs uv run --detach train.py          # uv job -> named from script, not the uv image
Hint: Job auto-named 'train-<hash>'. ...

$ hf jobs run --detach --name my-custom python:3.12 python -c 'print("hi")'
✓ Job started                                # explicit --name: no auto-name hint

$ hf jobs run --detach --label name=explicit-lbl python:3.12 python -c 'print("hi")'
✓ Job started                                # name via --label: also treated as explicit, no auto hint
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)