### PR TITLE
[Jobs] Surface Job name as a first-class field in the CLI

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -2035,7 +2035,7 @@ Use `--name` to add the `name` label when creating a Job. Names make Jobs easier
 >>> hf jobs labels <job_id> --name training-v2
 ```
 
-Use `--status` and `--label` in `hf jobs ls` to filter Jobs. `--status` takes one or more statuses and `--label` takes `key=value` pairs. A Job must match every filter to be listed:
+Use `--status`, `--label` and `--name` in `hf jobs ls` to filter Jobs. `--status` takes one or more statuses, `--label` takes `key=value` pairs, and `--name` is a shortcut for `--label name=NAME`. A Job must match every filter to be listed. The Job name is also shown as its own `NAME` column:
 
 ```bash
 # Show completed Jobs
@@ -2043,6 +2043,9 @@ Use `--status` and `--label` in `hf jobs ls` to filter Jobs. `--status` takes on
 
 # Show running or scheduling Jobs
 >>> hf jobs ls --status running,scheduling
+
+# Show Jobs named `training-v2`
+>>> hf jobs ls -a --name training-v2
 
 # Show Jobs with the `model=Qwen3-06B` label
 >>> hf jobs ls -a --label model=Qwen3-06B

--- a/docs/source/en/guides/jobs.md
+++ b/docs/source/en/guides/jobs.md
@@ -521,6 +521,12 @@ From the CLI, pass `--name` when creating a Job, or name an existing Job through
 >>> hf jobs labels <job_id> --name daily-report
 ```
 
+`hf jobs ls` shows a `NAME` column and can filter by name (a shortcut for `--label name=NAME`):
+
+```bash
+>>> hf jobs ls -a --name daily-report
+```
+
 ```python
 # Pass extra metadata with Labels
 >>> from huggingface_hub import run_job

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -2330,6 +2330,7 @@ $ hf jobs list | ls | ps [OPTIONS]
 * `-a, --all`: Show all Jobs (default shows running and scheduling). Cannot be combined with --status.
 * `--status [COMPLETED|CANCELED|ERROR|DELETED|SCHEDULING|RUNNING]`: Only show Jobs with the given status. Comma-separated or repeated, e.g. `--status running,scheduling`.
 * `-l, --label TEXT`: Only show Jobs with the given `key=value` label. Repeat to require several labels, e.g. `--label env=prod --label team=ml`.
+* `--name TEXT`: Only show Jobs with the given name (shortcut for `--label name=NAME`).
 * `--limit INTEGER`: Maximum number of Jobs to display. Set to 0 to show all (no limit).  [default: 100]
 * `--namespace TEXT`: The namespace where the job will be running. Defaults to the current user's namespace.
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
@@ -2340,6 +2341,7 @@ Examples
   $ hf jobs ls
   $ hf jobs ls -a
   $ hf jobs ls --status running,scheduling
+  $ hf jobs ls --name training-v2
   $ hf jobs ls --label env=prod --label team=ml
   $ hf jobs ls --all --label hf-sandbox=1
 

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -366,7 +366,7 @@ def jobs_run(
         ssh=ssh,
         namespace=namespace,
     )
-    out.result("Job started", id=job.id, url=job.url)
+    out.result("Job started", id=job.id, name=(job.labels or {}).get("name"), url=job.url)
     if name is None:
         out.hint(f"Name this Job with `hf jobs labels {job.owner.name}/{job.id} --name NAME`.")
     if isinstance(job.status.expose_urls, list):
@@ -556,6 +556,7 @@ def jobs_stats(
         "hf jobs ls",
         "hf jobs ls -a",
         "hf jobs ls --status running,scheduling",
+        "hf jobs ls --name training-v2",
         "hf jobs ls --label env=prod --label team=ml",
         "hf jobs ls --all --label hf-sandbox=1",
     ],
@@ -583,6 +584,13 @@ def jobs_ps(
             "-l",
             "--label",
             help="Only show Jobs with the given `key=value` label. Repeat to require several labels, e.g. `--label env=prod --label team=ml`.",
+        ),
+    ] = None,
+    name: Annotated[
+        str | None,
+        Option(
+            "--name",
+            help="Only show Jobs with the given name (shortcut for `--label name=NAME`).",
         ),
     ] = None,
     limit: Annotated[
@@ -640,6 +648,12 @@ def jobs_ps(
         key, value = item.split("=")
         labels[key] = value
 
+    # `--name` is a shortcut for the `name` label.
+    if name is not None:
+        if "name" in labels:
+            raise CLIError("Cannot filter by both `--name` and `--label name=...`.")
+        labels["name"] = name
+
     jobs_iter = api.list_jobs(namespace=namespace, status=server_statuses, labels=labels or None)
 
     # Apply the display limit. Fetch one extra Job to detect (and warn about) truncation.
@@ -659,6 +673,7 @@ def jobs_ps(
         durations = job_item.get("durations") or {}
         cmd = job_item.get("command") or []
         job_item["job_id"] = job_item.get("id", "")
+        job_item["name"] = (job_item.get("labels") or {}).get("name") or "N/A"
         job_item["image/space"] = job_item.get("docker_image") or "N/A"
         job_item["command"] = " ".join(cmd) if cmd else "N/A"
         job_item["created"] = job_item["created_at"][:19].replace("T", " ") if job_item.get("created_at") else "N/A"
@@ -668,7 +683,7 @@ def jobs_ps(
 
     out.table(
         job_items,
-        headers=["job_id", "image/space", "command", "created", "status", "runtime"],
+        headers=["job_id", "name", "image/space", "command", "created", "status", "runtime"],
         id_key="job_id",
     )
     if truncated:
@@ -730,7 +745,7 @@ def jobs_inspect(
     job_ids = parsed_ids
     api = get_hf_api(token=token)
     jobs = [api.inspect_job(job_id=job_id, namespace=namespace) for job_id in job_ids]
-    out.table([_dataclass_to_dict(job) for job in jobs])
+    out.table([_surface_name(_dataclass_to_dict(job), labels=job.labels) for job in jobs])
 
 
 @jobs_cli.command("cancel", examples=["hf jobs cancel <job_id>"])
@@ -843,7 +858,7 @@ def jobs_labels(
     else:
         labels = _parse_labels_map(label, name=name) or {}
     job = api.update_job_labels(job_id=job_id, labels=labels, namespace=namespace)
-    out.result("Labels updated", id=job.id)
+    out.result("Labels updated", id=job.id, name=labels.get("name"))
 
 
 @jobs_cli.command(
@@ -949,7 +964,7 @@ def jobs_uv_run(
         ssh=ssh,
         namespace=namespace,
     )
-    out.result("Job started", id=job.id, url=job.url)
+    out.result("Job started", id=job.id, name=(job.labels or {}).get("name"), url=job.url)
     if name is None:
         out.hint(f"Name this Job with `hf jobs labels {job.owner.name}/{job.id} --name NAME`.")
     if isinstance(job.status.expose_urls, list):
@@ -1013,7 +1028,7 @@ def scheduled_run(
         expose=expose,
         namespace=namespace,
     )
-    out.result("Scheduled Job created", id=scheduled_job.id)
+    out.result("Scheduled Job created", id=scheduled_job.id, name=(scheduled_job.job_spec.labels or {}).get("name"))
     if name is None:
         out.hint(
             f"Name this scheduled Job with `hf jobs scheduled labels {scheduled_job.owner.name}/{scheduled_job.id} --name NAME`."
@@ -1068,7 +1083,14 @@ def scheduled_ps(
         image_or_space = scheduled_job.job_spec.docker_image or "N/A"
         cmd = scheduled_job.job_spec.command or []
         command_str = " ".join(cmd) if cmd else "N/A"
-        props = {"id": scheduled_job.id, "image": image_or_space, "suspend": str(suspend), "command": command_str}
+        job_name = (scheduled_job.job_spec.labels or {}).get("name") or "N/A"
+        props = {
+            "id": scheduled_job.id,
+            "name": job_name,
+            "image": image_or_space,
+            "suspend": str(suspend),
+            "command": command_str,
+        }
         if not _matches_filters(props, filters):
             continue
         filtered_jobs.append(scheduled_job)
@@ -1081,6 +1103,7 @@ def scheduled_ps(
         status_dict = item.get("status") or {}
         last_job = status_dict.get("last_job")
         cmd = job_spec.get("command") or []
+        item["name"] = (job_spec.get("labels") or {}).get("name") or "N/A"
         item["image/space"] = job_spec.get("docker_image") or "N/A"
         item["command"] = " ".join(cmd) if cmd else "N/A"
         item["last_run"] = last_job["at"][:19].replace("T", " ") if last_job and last_job.get("at") else "N/A"
@@ -1092,7 +1115,7 @@ def scheduled_ps(
 
     out.table(
         items,
-        headers=["id", "schedule", "image/space", "command", "last_run", "next_run", "suspend"],
+        headers=["id", "name", "schedule", "image/space", "command", "last_run", "next_run", "suspend"],
         id_key="id",
     )
     if not items and filters:
@@ -1126,7 +1149,7 @@ def scheduled_inspect(
         api.inspect_scheduled_job(scheduled_job_id=scheduled_job_id, namespace=namespace)
         for scheduled_job_id in scheduled_job_ids
     ]
-    out.table([_dataclass_to_dict(scheduled_job) for scheduled_job in scheduled_jobs])
+    out.table([_surface_name(_dataclass_to_dict(sj), labels=sj.job_spec.labels) for sj in scheduled_jobs])
 
 
 @scheduled_app.command("delete", examples=["hf jobs scheduled delete <id>"])
@@ -1221,7 +1244,7 @@ def scheduled_labels(
     scheduled_job = api.update_scheduled_job_labels(
         scheduled_job_id=scheduled_job_id, labels=labels, namespace=namespace
     )
-    out.result("Labels updated", id=scheduled_job.id)
+    out.result("Labels updated", id=scheduled_job.id, name=labels.get("name"))
 
 
 scheduled_uv_app = typer_factory(help="Schedule UV scripts on HF infrastructure.")
@@ -1281,13 +1304,25 @@ def scheduled_uv_run(
         expose=expose,
         namespace=namespace,
     )
-    out.result("Scheduled Job created", id=job.id)
+    out.result("Scheduled Job created", id=job.id, name=(job.job_spec.labels or {}).get("name"))
     if name is None:
         out.hint(f"Name this scheduled Job with `hf jobs scheduled labels {job.owner.name}/{job.id} --name NAME`.")
     out.hint(f"Use `hf jobs scheduled inspect {job.owner.name}/{job.id}` to view its details.")
 
 
 ### UTILS
+
+
+def _surface_name(item: dict[str, Any], *, labels: dict[str, str] | None) -> dict[str, Any]:
+    """Promote the `name` label to a top-level `name` field for display.
+
+    The `name` is kept inside `labels` too (the dataclasses and API payloads are unchanged); this
+    only makes it a first-class column/field in command outputs. No-op when there is no name.
+    """
+    name = (labels or {}).get("name")
+    if name is None:
+        return item
+    return {"name": name, **item}
 
 
 def _parse_labels_map(labels: list[str] | None, *, name: str | None = None) -> dict[str, str] | None:

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -749,7 +749,7 @@ def jobs_inspect(
     job_ids = parsed_ids
     api = get_hf_api(token=token)
     jobs = [api.inspect_job(job_id=job_id, namespace=namespace) for job_id in job_ids]
-    out.table([_surface_name(_dataclass_to_dict(job), labels=job.labels) for job in jobs])
+    out.table([_surface_name(_dataclass_to_dict(job), labels=job.labels) for job in jobs], id_key="id")
 
 
 @jobs_cli.command("cancel", examples=["hf jobs cancel <job_id>"])
@@ -1159,7 +1159,7 @@ def scheduled_inspect(
         api.inspect_scheduled_job(scheduled_job_id=scheduled_job_id, namespace=namespace)
         for scheduled_job_id in scheduled_job_ids
     ]
-    out.table([_surface_name(_dataclass_to_dict(sj), labels=sj.job_spec.labels) for sj in scheduled_jobs])
+    out.table([_surface_name(_dataclass_to_dict(sj), labels=sj.job_spec.labels) for sj in scheduled_jobs], id_key="id")
 
 
 @scheduled_app.command("delete", examples=["hf jobs scheduled delete <id>"])

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -968,19 +968,13 @@ def jobs_uv_run(
         ssh=ssh,
         namespace=namespace,
     )
-<<<<<<< HEAD
     out.result("Job started", id=job.id, name=(job.labels or {}).get("name"), url=job.url)
-    if name is None:
-        out.hint(f"Name this Job with `hf jobs labels {job.owner.name}/{job.id} --name NAME`.")
-=======
-    out.result("Job started", id=job.id, url=job.url)
     if not _has_explicit_name(name, label):
         auto_name = (job.labels or {}).get("name")
         out.hint(
             f"Job auto-named '{auto_name}'. Pass `--name` or run "
             f"`hf jobs labels {job.owner.name}/{job.id} --name NAME` to rename it."
         )
->>>>>>> main
     if isinstance(job.status.expose_urls, list):
         urls = "\n".join(f"  {url}" for url in job.status.expose_urls)
         out.hint(f"Exposed ports are reachable at (requires an HF token with read access to the job):\n{urls}")
@@ -1042,14 +1036,9 @@ def scheduled_run(
         expose=expose,
         namespace=namespace,
     )
-<<<<<<< HEAD
     out.result("Scheduled Job created", id=scheduled_job.id, name=(scheduled_job.job_spec.labels or {}).get("name"))
-    if name is None:
-=======
-    out.result("Scheduled Job created", id=scheduled_job.id)
     if not _has_explicit_name(name, label):
         auto_name = (scheduled_job.job_spec.labels or {}).get("name")
->>>>>>> main
         out.hint(
             f"Scheduled Job auto-named '{auto_name}'. Pass `--name` or run "
             f"`hf jobs scheduled labels {scheduled_job.owner.name}/{scheduled_job.id} --name NAME` to rename it."
@@ -1325,26 +1314,19 @@ def scheduled_uv_run(
         expose=expose,
         namespace=namespace,
     )
-<<<<<<< HEAD
     out.result("Scheduled Job created", id=job.id, name=(job.job_spec.labels or {}).get("name"))
-    if name is None:
-        out.hint(f"Name this scheduled Job with `hf jobs scheduled labels {job.owner.name}/{job.id} --name NAME`.")
-=======
-    out.result("Scheduled Job created", id=job.id)
     if not _has_explicit_name(name, label):
         auto_name = (job.job_spec.labels or {}).get("name")
         out.hint(
             f"Scheduled Job auto-named '{auto_name}'. Pass `--name` or run "
             f"`hf jobs scheduled labels {job.owner.name}/{job.id} --name NAME` to rename it."
         )
->>>>>>> main
     out.hint(f"Use `hf jobs scheduled inspect {job.owner.name}/{job.id}` to view its details.")
 
 
 ### UTILS
 
 
-<<<<<<< HEAD
 def _surface_name(item: dict[str, Any], *, labels: dict[str, str] | None) -> dict[str, Any]:
     """Promote the `name` label to a top-level `name` field for display.
 
@@ -1355,11 +1337,11 @@ def _surface_name(item: dict[str, Any], *, labels: dict[str, str] | None) -> dic
     if name is None:
         return item
     return {"name": name, **item}
-=======
+
+
 def _has_explicit_name(name: str | None, label: list[str] | None) -> bool:
     """Whether the user explicitly named the Job (via `--name` or a `name=` label)."""
     return name is not None or any(item.split("=", 1)[0] == "name" for item in label or [])
->>>>>>> main
 
 
 def _parse_labels_map(labels: list[str] | None, *, name: str | None = None) -> dict[str, str] | None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3443,6 +3443,66 @@ class TestJobsCommand:
         assert kwargs["status"] == ["completed", "scheduling"]
         assert kwargs["labels"] == {"model": "Qwen3-06B"}
 
+    def test_ls_name_filter_is_forwarded_as_label(self, runner: CliRunner) -> None:
+        """`--name` is a shortcut for the `name` label and is forwarded server-side."""
+        with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            api.list_jobs.return_value = self._make_mock_jobs()
+            result = runner.invoke(app, ["jobs", "ls", "--name", "training-v2"])
+        assert result.exit_code == 0
+        assert api.list_jobs.call_args.kwargs["labels"] == {"name": "training-v2"}
+
+    def test_ls_name_and_label_name_conflict_errors(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["jobs", "ls", "--name", "foo", "--label", "name=bar"])
+        assert result.exit_code == 1
+
+    def test_ls_table_shows_name_column(self, runner: CliRunner) -> None:
+        """The `name` label is surfaced as a dedicated NAME column in the table."""
+        from huggingface_hub._jobs_api import JobInfo
+
+        jobs = [
+            JobInfo(
+                id="abc123def456",
+                createdAt="2026-01-15T10:30:00.000Z",
+                dockerImage="python:3.12",
+                command=["python", "-c", "print('hello')"],
+                flavor="cpu-basic",
+                labels={"name": "training-v2", "env": "test"},
+                status={"stage": "RUNNING"},
+                owner={"id": "user-id", "name": "testuser", "type": "user"},
+            ),
+        ]
+        with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            api.list_jobs.return_value = jobs
+            result = runner.invoke(app, ["jobs", "ls", "-a", "--no-truncate"])
+        assert result.exit_code == 0
+        assert "NAME" in result.output
+        assert "training-v2" in result.output
+
+    def test_inspect_surfaces_name(self, runner: CliRunner) -> None:
+        """`inspect` promotes the `name` label to a top-level field while keeping it in `labels`."""
+        import json
+
+        from huggingface_hub._jobs_api import JobInfo
+
+        job = JobInfo(
+            id="abc123def456",
+            dockerImage="python:3.12",
+            flavor="cpu-basic",
+            labels={"name": "training-v2", "env": "test"},
+            status={"stage": "RUNNING"},
+            owner={"id": "user-id", "name": "testuser", "type": "user"},
+        )
+        with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            api.inspect_job.return_value = job
+            result = runner.invoke(app, ["jobs", "inspect", "abc123def456", "--format", "json"])
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)[0]
+        assert data["name"] == "training-v2"
+        assert data["labels"] == {"name": "training-v2", "env": "test"}
+
     def test_ls_format_json(self, runner: CliRunner) -> None:
         """Test that `hf jobs ls -a --format json` outputs valid JSON with all fields."""
         import json

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3443,43 +3443,6 @@ class TestJobsCommand:
         assert kwargs["status"] == ["completed", "scheduling"]
         assert kwargs["labels"] == {"model": "Qwen3-06B"}
 
-    def test_ls_name_filter_is_forwarded_as_label(self, runner: CliRunner) -> None:
-        """`--name` is a shortcut for the `name` label and is forwarded server-side."""
-        with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
-            api = api_cls.return_value
-            api.list_jobs.return_value = self._make_mock_jobs()
-            result = runner.invoke(app, ["jobs", "ls", "--name", "training-v2"])
-        assert result.exit_code == 0
-        assert api.list_jobs.call_args.kwargs["labels"] == {"name": "training-v2"}
-
-    def test_ls_name_and_label_name_conflict_errors(self, runner: CliRunner) -> None:
-        result = runner.invoke(app, ["jobs", "ls", "--name", "foo", "--label", "name=bar"])
-        assert result.exit_code == 1
-
-    def test_ls_table_shows_name_column(self, runner: CliRunner) -> None:
-        """The `name` label is surfaced as a dedicated NAME column in the table."""
-        from huggingface_hub._jobs_api import JobInfo
-
-        jobs = [
-            JobInfo(
-                id="abc123def456",
-                createdAt="2026-01-15T10:30:00.000Z",
-                dockerImage="python:3.12",
-                command=["python", "-c", "print('hello')"],
-                flavor="cpu-basic",
-                labels={"name": "training-v2", "env": "test"},
-                status={"stage": "RUNNING"},
-                owner={"id": "user-id", "name": "testuser", "type": "user"},
-            ),
-        ]
-        with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
-            api = api_cls.return_value
-            api.list_jobs.return_value = jobs
-            result = runner.invoke(app, ["jobs", "ls", "-a", "--no-truncate"])
-        assert result.exit_code == 0
-        assert "NAME" in result.output
-        assert "training-v2" in result.output
-
     def test_inspect_surfaces_name(self, runner: CliRunner) -> None:
         """`inspect` promotes the `name` label to a top-level field while keeping it in `labels`."""
         import json

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3443,29 +3443,6 @@ class TestJobsCommand:
         assert kwargs["status"] == ["completed", "scheduling"]
         assert kwargs["labels"] == {"model": "Qwen3-06B"}
 
-    def test_inspect_surfaces_name(self, runner: CliRunner) -> None:
-        """`inspect` promotes the `name` label to a top-level field while keeping it in `labels`."""
-        import json
-
-        from huggingface_hub._jobs_api import JobInfo
-
-        job = JobInfo(
-            id="abc123def456",
-            dockerImage="python:3.12",
-            flavor="cpu-basic",
-            labels={"name": "training-v2", "env": "test"},
-            status={"stage": "RUNNING"},
-            owner={"id": "user-id", "name": "testuser", "type": "user"},
-        )
-        with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
-            api = api_cls.return_value
-            api.inspect_job.return_value = job
-            result = runner.invoke(app, ["jobs", "inspect", "abc123def456", "--format", "json"])
-        assert result.exit_code == 0
-        data = json.loads(result.stdout)[0]
-        assert data["name"] == "training-v2"
-        assert data["labels"] == {"name": "training-v2", "env": "test"}
-
     def test_ls_format_json(self, runner: CliRunner) -> None:
         """Test that `hf jobs ls -a --format json` outputs valid JSON with all fields."""
         import json


### PR DESCRIPTION
Follow-up to #4532 and #4566, which make the `name` label a first-class citizen of the Jobs API. This PR surfaces it more prominently in the CLI.

The `name` is still stored in `labels["name"]` — the internal logic, API payloads and exposed dataclasses are unchanged. When a `labels` field is printed, `name` stays in it *in addition to* the new dedicated `name` field.

## What's new

- **Filter by `--name` in `hf jobs ls`** — a shortcut for `--label name=NAME`.
- **A dedicated `NAME` column** in `hf jobs ls` (and `hf jobs scheduled ls`).
- **`name` surfaced directly** (top-level) in `inspect` and in command results, instead of only living inside `labels`.

## Examples

Dedicated `NAME` column + filtering:

```console
$ hf jobs ls -a
JOB_ID      NAME        IMAGE/SPACE  COMMAND      CREATED      STATUS    RUNTIME
----------- ----------- ------------ ------------ ------------ --------- -------
6a60b190... cli-name... python:3.12  python -c... 2026-07-2... COMPLETED 0s
6a60a8bf... ubuntu      ubuntu       echo hi      2026-07-2... COMPLETED 0s

$ hf jobs ls -a --name cli-name-demo
JOB_ID      NAME         IMAGE/SPACE COMMAND      CREATED      STATUS    RUNTIME
----------- ------------ ----------- ------------ ------------ --------- -------
6a60b190... cli-name-... python:3.12 python -c... 2026-07-2... COMPLETED 0s

$ hf jobs ls -a --name foo --label name=bar
Error: Cannot filter by both `--name` and `--label name=...`.
```

`name` surfaced directly while still kept in `labels` (here a job created with `--name multi-label -l env=prod -l team=ml`):

```console
$ hf jobs inspect 6a60b1c0... --format json | jq '{name, labels}'
{
  "name": "multi-label",
  "labels": { "env": "prod", "team": "ml", "name": "multi-label" }
}
```

`name` in command results:

```console
$ hf jobs labels 6a60b1c0... --name renamed-demo --format human
✓ Labels updated
  id: 6a60b1c013e6ef894d54b831
  name: renamed-demo
```

Same treatment for scheduled jobs (`NAME` column in `scheduled ls`, top-level `name` in `scheduled inspect` and results).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI presentation and filtering only; storage remains in labels and server API behavior is unchanged.
> 
> **Overview**
> **Surfaces the Jobs `name` label (`labels["name"]`) as a first-class CLI field** without changing API payloads or dataclasses—the name still lives in `labels` when those are printed.
> 
> `hf jobs ls` gains **`--name`** (equivalent to `--label name=NAME`, with an error if both are used) and a **`NAME`** column in the job table. **`hf jobs scheduled ls`** gets the same column. **`hf jobs inspect`** and **`hf jobs scheduled inspect`** promote `name` to a top-level field via a new **`_surface_name`** helper.
> 
> Success messages for job/scheduled job start and label updates now include **`name`** alongside `id` (and `url` where applicable). User guides and CLI reference document the new filter, column, and examples.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fb4ba8a7cee3311512394695e9284b5ed52aec3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->