### PR TITLE
Fix ValueError in 'hf jobs ls --label' when a label value contains '='

### DIFF
--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -637,7 +637,7 @@ def jobs_ps(
     for item in label or []:
         if "=" not in item:
             raise CLIError(f"Invalid label filter '{item}': must be in the form 'key=value'")
-        key, value = item.split("=")
+        key, value = item.split("=", 1)
         labels[key] = value
 
     jobs_iter = api.list_jobs(namespace=namespace, status=server_statuses, labels=labels or None)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3443,6 +3443,21 @@ class TestJobsCommand:
         assert kwargs["status"] == ["completed", "scheduling"]
         assert kwargs["labels"] == {"model": "Qwen3-06B"}
 
+    def test_ls_label_value_containing_equals_sign(self, runner: CliRunner) -> None:
+        """A label value containing '=' must not crash the key/value unpacking.
+
+        Regression test: `item.split('=')` raised `ValueError: too many values to
+        unpack` for a value like `callback=https://x?a=1`. Only the first '=' is the
+        key/value delimiter; any further '=' belong to the value.
+        """
+        with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            api.list_jobs.return_value = self._make_mock_jobs()
+            result = runner.invoke(app, ["jobs", "ls", "--label", "callback=https://x?a=1&b=2"])
+        assert result.exit_code == 0
+        kwargs = api.list_jobs.call_args.kwargs
+        assert kwargs["labels"] == {"callback": "https://x?a=1&b=2"}
+
     def test_ls_format_json(self, runner: CliRunner) -> None:
         """Test that `hf jobs ls -a --format json` outputs valid JSON with all fields."""
         import json


### PR DESCRIPTION
Running `hf jobs ls --label callback=https://x?a=1&b=2` crashes with `ValueError: too many values to unpack (expected 2)`. The inline label parser in the `jobs_ps` command (jobs.py, `jobs ls`/`jobs ps`) uses `item.split('=')`, which splits on every '=' so any label value that itself contains '=' (URLs with query strings, base64 tokens, key=value-ish strings) blows up the two-name unpack. This is inconsistent with the shared `_parse_labels_map` helper that the other jobs subcommands already use, which correctly does `split('=', 1)`.

The fix is a one-character change: `split('=', 1)` so only the first '=' separates the key from the value. I kept the explicit inline parser rather than delegating to `_parse_labels_map` because this command intentionally raises a CLIError for a key-only label (no '='), whereas the helper silently treats it as an empty-string value — preserving the stricter validation here felt safer than changing behavior. Added a regression test `test_ls_label_value_containing_equals_sign` next to the existing label-filter test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line parsing fix in the jobs list CLI with a targeted regression test; no auth or API contract changes.
> 
> **Overview**
> **`hf jobs ls`** no longer crashes when a **`--label`** value includes extra **`=`** characters (e.g. URLs with query strings).
> 
> Label filters in **`jobs_ps`** now use **`split('=', 1)`** so only the first **`=`** separates key from value, matching **`_parse_labels_map`** used elsewhere. Key-only labels still raise **`CLIError`** as before.
> 
> A regression test covers **`--label callback=https://x?a=1&b=2`** and asserts the full value is passed to **`list_jobs`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 784f40bfec52d8b4fc02902bd5b4b6f01982dc54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->