### PR TITLE
[Upload] Forward token in _final_commit_info repo_info lookup

### DIFF
--- a/src/huggingface_hub/_upload_pipeline.py
+++ b/src/huggingface_hub/_upload_pipeline.py
@@ -622,7 +622,9 @@ class _UploadPipeline:
             # Nothing was committed (everything unchanged/ignored): mimic `create_commit` and
             # return info about the latest commit on the target revision.
             logger.warning("No files have been modified since last commit. Skipping to prevent empty commit.")
-            info = self.api.repo_info(repo_id=self.repo_id, repo_type=self.repo_type, revision=self.revision)
+            info = self.api.repo_info(
+                repo_id=self.repo_id, repo_type=self.repo_type, revision=self.revision, token=self.token
+            )
             url_prefix = self.api.endpoint
             if self.repo_type != constants.REPO_TYPE_MODEL:
                 url_prefix = f"{url_prefix}/{self.repo_type}s"


### PR DESCRIPTION
## Summary

Fixes #4571 cc @xiaoyao9184.

When `upload_folder` with a pipelined upload finds no local changes, `_final_commit_info` looks up the latest commit via `repo_info` but wasn't forwarding the token. On private/scoped repos this made the call unauthenticated and it failed with `401 Unauthorized`. Now the stored `self.token` is passed through, matching the rest of the pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-parameter fix in an edge-case code path; no change to commit or upload logic when files actually change.
> 
> **Overview**
> Fixes **401 Unauthorized** when a pipelined `upload_folder` run finds nothing to commit (all files unchanged or ignored) on **private or gated** repos.
> 
> In that path, `_final_commit_info` still returns a `CommitInfo` pointing at the latest revision by calling `repo_info`, but the lookup omitted **`token=self.token`**. The rest of `_UploadPipeline` already authenticates via `self.headers` / `self.token`; this change aligns the no-op fallback with that behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 902ba8077b50ffdf0bbfd3fc0e1e388329789072. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->