### PR TITLE
[Sandbox] Don't send the HF token to sandbox jobs

### DIFF
--- a/src/huggingface_hub/_sandbox.py
+++ b/src/huggingface_hub/_sandbox.py
@@ -77,15 +77,16 @@ _MAX_PACK_ROUNDS = 8
 # hf-mount path where the server bucket is mounted on every sandbox job
 _SERVER_MOUNT_PATH = "/.hf-sbx-server"
 
-# Job startup script (needs only /bin/sh)
+# Job startup script (needs only /bin/sh). The server bucket is public, so the download is
+# unauthenticated: no HF credential is ever placed in the job environment (see `_derive_sandbox_token`).
 _BOOTSTRAP_DOWNLOAD = """\
 set -e
 d=/tmp/.sbx-server
-if command -v wget >/dev/null 2>&1; then wget -q --header "Authorization: Bearer $SBX_DL_TOKEN" -O "$d" "$SBX_SERVER_URL"
-elif command -v curl >/dev/null 2>&1; then curl -fsSL -H "Authorization: Bearer $SBX_DL_TOKEN" -o "$d" "$SBX_SERVER_URL"
+if command -v wget >/dev/null 2>&1; then wget -q -O "$d" "$SBX_SERVER_URL"
+elif command -v curl >/dev/null 2>&1; then curl -fsSL -o "$d" "$SBX_SERVER_URL"
 else cp "$SBX_SERVER_MOUNT/sbx-server" "$d"; fi
 chmod +x "$d"
-unset SBX_DL_TOKEN SBX_SERVER_URL SBX_SERVER_MOUNT
+unset SBX_SERVER_URL SBX_SERVER_MOUNT
 exec "$d"
 """
 
@@ -1685,7 +1686,6 @@ def _bootstrap_job_spec(
         job_secrets["HF_TOKEN"] = hf_token
 
     job_env["SBX_SERVER_URL"] = f"{api.endpoint}/buckets/{constants.SANDBOX_SERVER_BUCKET}/resolve/sbx-server"
-    job_secrets["SBX_DL_TOKEN"] = hf_token
     # Always mount the server bucket as a transparent fallback for images without wget/curl.
     # It's only read (paying the ~2-3s FUSE cost) when the bootstrap script can't download.
     job_env["SBX_SERVER_MOUNT"] = _SERVER_MOUNT_PATH


### PR DESCRIPTION
## Summary

Follow-up on an external security report about `Sandbox.create`.

- The bootstrap script downloaded the `sbx-server` binary with the user's HF token as a bearer token (`SBX_DL_TOKEN`), injected as a job secret **unconditionally** — including with the default `forward_hf_token=False`, which documents the opposite.
- The `huggingface/sbx-server` bucket is **public**, so that header was never needed. It's a leftover from when the bucket was private during development.
- This PR drops `SBX_DL_TOKEN` and the `Authorization` headers. The bootstrap now downloads anonymously, and no HF credential ever lands in the job environment unless the user opts in with `forward_hf_token=True`.

Why it matters: the image is chosen by the caller and provides `/bin/sh`, which is the first thing the job runs. The `unset SBX_DL_TOKEN` in the bootstrap happens *after* that, so it only protected against the user's own later processes — a hostile image could read the token before it ran. It also applied to `SandboxPool` hosts, which hardcode `forward_hf_token=False`.

This also restores what `_derive_sandbox_token` already claims in its docstring: *"The HF token itself is never sent to the sandbox."* `SBX_TOKEN` stays an HMAC derived from the HF token + a public per-job nonce, which is the whole point of that scheme.

## Verification

Public bucket, no auth needed:

```console
$ env -u HF_TOKEN curl -fsSL -o sbx-server "https://huggingface.co/buckets/huggingface/sbx-server/resolve/sbx-server"
$ file sbx-server
sbx-server: ELF 64-bit LSB pie executable, x86-64, static-pie linked, stripped
```

Real sandbox on the branch:

```console
$ python -c "
from huggingface_hub import Sandbox
with Sandbox.create(image='python:3.12') as sbx:
    print(sbx.run('env | grep -c SBX_DL_TOKEN || echo NO_DL_TOKEN').stdout.strip())
    print(sbx.run('python -c \"print(1+1)\"').stdout.strip())
"
booted in 9.3s -> 6a671391db23d7a7ec1cf80c
NO_DL_TOKEN
2
```

The `SBX_SERVER_MOUNT` fallback (for images shipping neither `wget` nor `curl`) is untouched and was already credential-free — the Jobs infra mounts the bucket, nothing lands in the container env.

## Notes

- No breaking change: `SBX_DL_TOKEN` was an internal implementation detail of the bootstrap, unset before `exec` and never documented.
- A short-lived scoped download token would have been the alternative if the bucket had to stay private. Since it's public, no credential at all is simply better.
- Anonymous downloads could in theory be rate-limited where authenticated ones aren't. Not expected to bite (one 666 KB static binary per boot, served from CDN), but if we ever see 429s at scale the follow-up is an ephemeral scoped token — not the reusable HF one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches credential injection for HF Jobs sandbox startup (security-sensitive), though the change only removes an unnecessary secret and relies on a public artifact URL.
> 
> **Overview**
> **Stops putting the user's HF token into sandbox jobs** for downloading `sbx-server`. `_bootstrap_job_spec` no longer sets the `SBX_DL_TOKEN` secret, and the `_BOOTSTRAP_DOWNLOAD` shell script fetches `SBX_SERVER_URL` with plain `wget`/`curl` (no `Authorization` header). Comments note the server bucket is public, so anonymous download is enough and credentials only appear when `forward_hf_token=True` opts in via `HF_TOKEN`.
> 
> This aligns runtime behavior with `_derive_sandbox_token`'s claim that the raw HF token is never sent to the sandbox; pool hosts (which keep `forward_hf_token=False`) benefit the same way. The read-only `SBX_SERVER_MOUNT` fallback is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a497283db7ff232e95d2c00f6d59244bf9b5d9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->