### PR TITLE
[CI] [Release] Make notify-prs best-effort with a retry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1160,6 +1160,18 @@ jobs:
           RELEASE_URL: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ needs.prepare.outputs.tag }}
           REPO: ${{ github.repository }}
         run: |
+          # Best-effort by design: a single PR can fail for reasons unrelated to the others (transient
+          # API error, or a number extracted from a commit message that does not exist in this repo —
+          # e.g. PRs merged from a security-advisory private fork). We keep going through the whole
+          # list, retry each API call once, and only fail the job at the very end so that as many PRs
+          # as possible get notified.
+          retry() {
+            "$@" && return 0
+            echo "  API call failed, retrying in 2s..." >&2
+            sleep 2
+            "$@"
+          }
+
           # Extract unique PR numbers from commit messages between the two tags
           PR_NUMBERS=$(git log "${SINCE_TAG}..${TAG}" --oneline | grep -oP '\(#\K[0-9]+(?=\))' | sort -un)
 
@@ -1171,11 +1183,16 @@ jobs:
           echo "Found PRs: $(echo $PR_NUMBERS | tr '\n' ' ')"
           COMMENTED=0
           SKIPPED=0
+          FAILED=()
 
           for PR_NUM in $PR_NUMBERS; do
             # Check if huggingface-hub-bot already commented on this PR
-            HAS_BOT_COMMENT=$(gh api "repos/${REPO}/issues/${PR_NUM}/comments" \
-              --paginate --jq '.[] | select(.user.login == "huggingface-hub-bot[bot]") | .id' | head -1)
+            if ! HAS_BOT_COMMENT=$(retry gh api "repos/${REPO}/issues/${PR_NUM}/comments" \
+              --paginate --jq '.[] | select(.user.login == "huggingface-hub-bot[bot]") | .id'); then
+              echo "::warning::Could not list comments on PR #${PR_NUM} — skipping it"
+              FAILED+=("$PR_NUM")
+              continue
+            fi
 
             if [[ -n "$HAS_BOT_COMMENT" ]]; then
               echo "Skipping PR #${PR_NUM} — bot already commented"
@@ -1185,13 +1202,21 @@ jobs:
 
             # Post comment
             BODY="This PR has been shipped as part of the [${TAG}](${RELEASE_URL}) release."
-            gh api "repos/${REPO}/issues/${PR_NUM}/comments" \
-              -f body="$BODY" > /dev/null
-            echo "Commented on PR #${PR_NUM}"
-            COMMENTED=$((COMMENTED + 1))
+            if retry gh api "repos/${REPO}/issues/${PR_NUM}/comments" -f body="$BODY" > /dev/null; then
+              echo "Commented on PR #${PR_NUM}"
+              COMMENTED=$((COMMENTED + 1))
+            else
+              echo "::warning::Could not comment on PR #${PR_NUM}"
+              FAILED+=("$PR_NUM")
+            fi
           done
 
-          echo "Done: ${COMMENTED} commented, ${SKIPPED} skipped"
+          echo "Done: ${COMMENTED} commented, ${SKIPPED} skipped, ${#FAILED[@]} failed"
+
+          if [[ ${#FAILED[@]} -gt 0 ]]; then
+            echo "::error::Could not notify ${#FAILED[@]} PR(s): ${FAILED[*]}"
+            exit 1
+          fi
 
       - name: Notify Slack
         if: ${{ always() && needs.prepare.outputs.message_ts }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1165,11 +1165,22 @@ jobs:
           # e.g. PRs merged from a security-advisory private fork). We keep going through the whole
           # list, retry each API call once, and only fail the job at the very end so that as many PRs
           # as possible get notified.
+          # Buffer stdout and only echo it back for the attempt that succeeded: on an HTTP error
+          # `gh api` writes the raw error body to stdout (bypassing --jq), so forwarding a failed
+          # attempt's stdout would pollute the caller's output (e.g. make HAS_BOT_COMMENT non-empty).
           retry() {
-            "$@" && return 0
+            local output
+            if output=$("$@"); then
+              printf '%s' "$output"
+              return 0
+            fi
             echo "  API call failed, retrying in 2s..." >&2
             sleep 2
-            "$@"
+            if output=$("$@"); then
+              printf '%s' "$output"
+              return 0
+            fi
+            return 1
           }
 
           # Extract unique PR numbers from commit messages between the two tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1160,12 +1160,9 @@ jobs:
           RELEASE_URL: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ needs.prepare.outputs.tag }}
           REPO: ${{ github.repository }}
         run: |
-          # Best-effort by design: a single PR can fail for reasons unrelated to the others (transient
-          # API error, or a number extracted from a commit message that does not exist in this repo —
-          # e.g. PRs merged from a security-advisory private fork). We keep going through the whole
-          # list, retry each API call once, and only fail the job at the very end so that as many PRs
-          # as possible get notified.
-          # Buffer stdout and only echo it back for the attempt that succeeded: on an HTTP error
+          # Best-effort by design: a single PR can fail for reasons unrelated to the others. We keep going through the
+          # whole list, retry each API call once, and only fail the job at the very end so that as many PRs as possible
+          # get notified. Buffer stdout and only echo it back for the attempt that succeeded: on an HTTP error
           # `gh api` writes the raw error body to stdout (bypassing --jq), so forwarding a failed
           # attempt's stdout would pollute the caller's output (e.g. make HAS_BOT_COMMENT non-empty).
           retry() {


### PR DESCRIPTION
## Summary

The `notify-prs` job in `release.yml` [aborted on the first failing PR](https://github.com/huggingface/huggingface_hub/actions/runs/30251528708/job/89930651007) during the `v1.25.0` release. It commented on `#4378`, then got `gh: Validation Failed (HTTP 422)` on `#4525` and died — the remaining 14 PRs never got notified.

Root cause: `#4525` came from the security-advisory private fork (the ReDoS fix, merged as `922b819e4`). It's not reachable through the public API — `repos/.../issues/4525` and `repos/.../pulls/4525` both 404 — but oddly `repos/.../issues/4525/comments` *is* readable. So the "did the bot already comment?" listing succeeded, found nothing, and then the `POST` to create the comment returned 422. Nothing to fix on that side; the job just needs to tolerate a PR number it can't comment on.

Changes:
- **Retry once, 2s apart** — small `retry()` helper wrapping each `gh api` call, so transient API errors don't lose a PR.
- **Best-effort loop** — a PR that fails both attempts is recorded and the loop moves on instead of killing the step.
- **Still fails the job** — after the loop, if any PR failed, emit `::error::` with the list and `exit 1`. So we get a red job in GH (and the ❌ Slack notification) while still notifying as many PRs as possible.

Individual failures are also emitted as `::warning::` so they show up in the run annotations.

Heads-up on the consequence: every release whose range includes a security-advisory commit will now show a red `notify-prs` (with all other PRs correctly notified). Swallowing 404/422 would keep it green, but it would equally hide genuinely missed PRs — so per the requirement it stays loud.

### On `retry()` and stdout (thanks Bugbot)

On an HTTP error `gh api` writes the raw error body to **stdout** and bypasses `--jq`:

```
$ gh api "repos/huggingface/huggingface_hub/issues/999999/comments" \
    --paginate --jq '.[] | select(.user.login == "huggingface-hub-bot[bot]") | .id' 2>/dev/null
{"message":"Not Found","documentation_url":"...","status":"404"}
```

The first version of `retry()` forwarded that, so a fail-then-succeed listing left JSON in `HAS_BOT_COMMENT` and the `-n` check silently skipped the PR as "already notified". `retry()` now buffers stdout and only emits it for the attempt that succeeded. The pre-existing code had a variant of the same bug — `HAS_BOT_COMMENT=$(gh api ... | head -1)` takes its exit status from `head` (always 0) — which checking the exit status explicitly also fixes.

## Testing

Simulated the step locally by extracting the `run` script from the YAML and shimming `gh`/`git` on `PATH` (fake `gh` mirrors the real error-body-on-stdout behaviour). `#4378` already has a bot comment, `#4525` lists fine but 422s on POST, `#4560` fails its listing once then succeeds with no bot comment, `#4572` is clean.

```
Found PRs: 4378 4525 4560 4572
Skipping PR #4378 — bot already commented
gh: Validation Failed (HTTP 422)
  API call failed, retrying in 2s...
gh: Validation Failed (HTTP 422)
::warning::Could not comment on PR #4525
gh: Not Found (HTTP 404)
  API call failed, retrying in 2s...
Commented on PR #4560
Commented on PR #4572
Done: 2 commented, 1 skipped, 1 failed
::error::Could not notify 1 PR(s): 4525
=== exit code: 1 ===
```

`#4525` is the only casualty, `#4560` recovers on retry (and is *commented on*, not skipped), `#4572` still gets notified, and the step exits 1. Happy path (no failures) exits 0:

```
Found PRs: 4378 4572
Skipping PR #4378 — bot already commented
Commented on PR #4572
Done: 1 commented, 1 skipped, 0 failed
=== exit code: 0 ===
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release automation only; no library runtime or auth changes. Expected red jobs when security-advisory PR numbers cannot be commented on remain intentional.
> 
> **Overview**
> The **notify-prs** step in `release.yml` no longer stops on the first `gh api` failure. It wraps list/comment calls in a **`retry()`** helper (one retry after 2s), tracks PRs that still fail in **`FAILED`**, emits **`::warning::`** per PR, and only **`exit 1`** at the end with **`::error::`** listing missed PRs so the rest of the range still gets release comments.
> 
> **`retry()`** buffers stdout and only prints output from a successful attempt, so failed **`gh api`** error JSON on stdout cannot be mistaken for a bot comment ID (and listing now checks **`gh`** exit status instead of relying on **`head -1`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eeaf554db7e0985085f2deb47b145dd60369cd43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->