### PR TITLE
[Release] [CI] Update slack message generation

### DIFF
--- a/.opencode/skills/hf-release-notes/SLACK.md
+++ b/.opencode/skills/hf-release-notes/SLACK.md
@@ -9,7 +9,7 @@ description: Generate a concise Slack announcement message from drafted release 
 
 Generate a concise Slack announcement message from existing release notes. The message is intended for internal team communication to announce a prerelease and solicit testing from downstream maintainers.
 
-**Important:** You generate ONLY the message body (greeting through the pip install command). The "Pinging:" section and closing line are appended by the calling script — do NOT generate those.
+**Important:** You generate ONLY the message body (greeting through the pip install command). The "Ping:" section and closing line are appended by the calling script — do NOT generate those.
 
 ## Workflow
 
@@ -33,7 +33,7 @@ Write the Slack message body with these sections in order:
 
 #### Greeting
 ```
-Hello @canal :hello: The next release of `huggingface_hub` (vX.Y.Z) is on its way! :tadaco:
+Hello @channel :hello: Release `huggingface_hub vX.Y.Z` is on its way!
 ```
 
 #### Release notes link
@@ -43,24 +43,19 @@ Release notes :point_right: https://github.com/huggingface/huggingface_hub/relea
 
 #### Highlights
 ```
-:sparkles: Highlights
- :emoji: Feature name: brief 1-2 sentence description
- :emoji: Another feature: description
- A bunch of QoL improvements:
-  Sub-feature 1
-  Sub-feature 2
+**Highlights:**
+- **[Feature name]** 1 sentence summary of the feature.
+- **[Another feature]** brief description.
 ```
 
 Rules for highlights:
-- Use Slack emoji codes (`:package:`, `:robot_face:`, `:fire:`, `:electric_plug:`, `:bucket:`, `:computer:`, `:zap:`, `:chart_with_upwards_trend:`, etc.), NOT Unicode emoji
-- Keep each highlight to 1-2 sentences max — this is a summary, not the full release notes
+- Keep each highlight to 1-2 sentences max, even less — this is a summary, not the full release notes. Doesn't even have to be a full sentence.
 - Drop ALL PR attribution lines (`by @author in #1234`)
 - Drop ALL code examples and fenced code blocks
 - Drop internal/CI/test items entirely
 - Drop documentation-only items
-- Drop bug fixes from highlights (mention them as "a bunch of QoL improvements and fixes" if there are several)
+- Drop bug fixes from highlights
 - Group related small improvements together rather than listing each individually
-- Use single-space indentation for sub-items, matching the examples
 
 #### Breaking changes
 If there are breaking changes:
@@ -72,27 +67,17 @@ If none:
 No breaking changes in this release.
 ```
 
-#### Pre-release install command
-```
-You can try the pre-release now:
-pip install -U huggingface_hub==<RC_VERSION>
-```
-Where `<RC_VERSION>` is the RC version provided in the prompt (e.g., `1.7.0rc0`).
-
 ### 4. Formatting rules
 
 - **No markdown headers** (`##`, `###`) — Slack doesn't render these
-- **No bold** (`**text**`) — use plain text or Slack formatting (` `` ` for inline code)
 - **Use backticks** for command names and code: `` `hf extensions install` ``
-- **Use Slack emoji codes** (`:sparkles:`) not Unicode emoji
 - **Keep it informal and friendly** — this is team communication, not a formal changelog
-- **Single space indent** for highlight items under the `:sparkles: Highlights` header
 - **No trailing newlines** at the end of the output
 
 ### 5. Write output
 
 Write ONLY the message body to the specified output path. Stop after the pip install command. Do NOT include:
-- The "Pinging:" section
+- The "Ping:" section
 - The "Let us know if you spot any regressions..." closing line
 - Any separator lines
 

--- a/.opencode/skills/hf-release-notes/references/slack-post-template.md
+++ b/.opencode/skills/hf-release-notes/references/slack-post-template.md
@@ -1,103 +1,22 @@
 # Slack post template
 
-This is the template for the Slack announcement message. The script appends the "Pinging:" section
+This is the template for the Slack announcement message. The script appends the "Ping:" section
 and closing line automatically — the skill only generates the body from the greeting through the
 pip install command.
 
 ## Template
 
 ```
-Hello @canal :hello: The next release of `huggingface_hub` (vX.Y.Z) is on its way! :tadaco:
+Hello @channel :hello: Release `huggingface_hub vX.Y.Z` is on its way!
 
 Release notes :point_right: https://github.com/huggingface/huggingface_hub/releases/tag/vX.Y.Z
 
-:sparkles: Highlights
- :emoji: Feature name: 1-2 sentence summary of the feature.
- :emoji: Another feature: brief description.
- A bunch of QoL improvements to the CLI:
-  Sub-feature 1
-  Sub-feature 2
+**Highlights:**
+- **[Feature name]** 1 sentence summary of the feature.
+- **[Another feature]** brief description.
 
 <If breaking changes>
 :warning: Breaking changes: brief description of what changed.
 <If no breaking changes>
 No breaking changes in this release.
-
-We also introduced a bunch of QoL improvements and fixes!
-
-You can try the pre-release now:
-pip install -U huggingface_hub==X.Y.ZrcN
-```
-
-## Real examples
-
-### Example 1 (v1.7.0)
-
-```
-Hello @canal :hello: The next release of huggingface_hub (v1.7.0) is on its way! :tadaco:
-
-Release notes :point_right: https://github.com/huggingface/huggingface_hub/releases/tag/v1.7.0
-
-:sparkles: Highlights
- :package: CLI Extensions : extensions can now be full pip-installable Python packages (this may have slipped into the v1.6.0 release notes but is definitely shipped here :see_no_evil:). Plus a new hf extensions search command to discover extensions from the terminal.
-hf-xet bumped to 1.4.2 with upload optimizations and a fix for deadlocks on large file downloads. that should improve upload speed for large files
- A bunch of QoL improvements to the CLI:
-  All list commands normalized to list / ls aliases
-  Hidden --json shorthand for --format json
-  num_parameters filtering in hf models list
-Allow hf skills add to default to installing from the skills directory
-hf auth login has a new flag --force to override  if already logged in
-
-No breaking changes in this release.
-
-You can try the pre-release now:
-pip install -U huggingface_hub==1.7.0rc1
-```
-
-### Example 2 (v1.5.0)
-
-```
-Hello @canal :hello: The next release of `huggingface_hub` (v1.5.0) is on its way! :tadaco:
-
-Release notes :point_right: https://github.com/huggingface/huggingface_hub/releases/tag/v1.5.0.rc0
-
-:sparkles: Highlights
-:bucket: Buckets API! Create, list, sync, and manage buckets on the Hub. Sync local directories with hf buckets sync ./data hf://buckets/username/my-bucket.
-:robot_face: AI-first CLI: hf skills add to install skills for Claude, Codex, etc., output options (json/table) for composability, aliases for better consistency, etc.
-:fire: Spaces hot-reload: Patch Python files in a running Space with hf spaces hot-reload username/repo-name app.py.
-:electric_plug: CLI Extensions: Install and run external CLI extensions from GitHub repos with `hf extensions install hf-claude`.
-:chart_with_upwards_trend: Jobs: Multi-GPU training support, hf jobs hardware command, better filtering with labels, and --follow/-f logs flag.
-
-:warning: Breaking changes: hf repo is deprecated in favor of `hf repos`. Also, hf repo-files delete has moved to hf repo delete-files. Aliases are kept for backward compatibility.
-
-We also introduced a bunch of QoL improvements and fixes!
-
-You can try the pre-release now:
-pip install huggingface_hub==1.5.0rc0
-```
-
-### Example 3 (v1.6.0)
-
-```
-Hello @canal :hello: The next release of huggingface_hub (v1.6.0) is on its way! :tadaco:
-
-Release notes :point_right: https://github.com/huggingface/huggingface_hub/releases/tag/v1.6.0
-
-:sparkles: Highlights
-• :bucket: HfFileSystem for Buckets! Reading from buckets is as simple as pd.read_csv("hf://buckets/.../affluence.csv")  (thanks to @Quentin Lhoest).
-• :computer: New CLI commands:
- hf spaces dev-mode to enable dev mode and get SSH/VSCode connection instructions (cc @Quentin Lhoest)
- hf discussions for full discussion & PR management
-hf webhooks for CRUD on Hub webhooks
-hf datasets parquet + hf datasets sql to discover and query dataset parquet files with DuckDB cc @Caleb Fahlgren
-hf repos duplicate to duplicate any repo.
-• :electric_plug: pip-installable CLI extensions: hf extensions install now supports Python packages in addition to executables
-• :zap: NVIDIA provider support added to InferenceClient.
-
-:warning: Breaking change: the deprecated direction argument in list_models, list_datasets and list_spaces has been removed. (was announced since months)
-
-We also introduced a bunch of QoL improvements and fixes!
-
-You can try the pre-release now:
-pip install -U huggingface_hub==1.6.0rc0
 ```

--- a/utils/release_notes/generate_slack_message.py
+++ b/utils/release_notes/generate_slack_message.py
@@ -4,7 +4,7 @@
 This script:
 1. Reads the generated release notes markdown
 2. Invokes an OpenCode skill to summarize into a Slack-formatted message
-3. Appends a deterministic "Pinging" section with CI links
+3. Appends a deterministic "Ping" section with CI links
 4. Outputs the final message to .release-notes/
 
 Usage:
@@ -17,6 +17,7 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
+from unittest.mock import DEFAULT
 
 from .validate_notes import find_release_notes_file
 
@@ -24,37 +25,29 @@ from .validate_notes import find_release_notes_file
 OUTPUT_DIR = Path(os.environ.get("RELEASE_NOTES_OUTPUT_DIR", ".release-notes"))
 
 # Downstream repos to ping for RC testing.
-# Each entry: (display_label, slack_mention, repo_name_or_None)
-# repo_name=None means no CI link (e.g., lighteval has no automated HF Hub testing branch)
-DEFAULT_PING_LIST: list[tuple[str, str, str | None]] = [
-    ("transformers", "@U01JNPUN1ML", "transformers"),  # Yih-Dar
-    ("datasets", "@U011YKS85FY", "datasets"),  # Quentin
-    ("diffusers", "@U03AU4E7DJB", "diffusers"),  # Sayak
-    ("lighteval", "@U04MZDFL8DD", None),  # Nathan
-    ("sentence-transformers", "@U04E4DNPWG7", "sentence-transformers"),  # Tom
+# Each entry: (display_label, repo_name)
+DEFAULT_PING_LIST: list[tuple[str, str]] = [
+    ("transformers", "@U01JNPUN1ML", "transformers"),
+    ("datasets", "@U011YKS85FY", "datasets"),
+    ("diffusers", "@U03AU4E7DJB", "diffusers"),
+    ("sentence-transformers", "@U04E4DNPWG7", "sentence-transformers"),
 ]
 
 
-def build_ping_section(
-    ping_list: list[tuple[str, str, str | None]] | None = None,
-) -> str:
-    """Build the "Pinging:" block with CI compare URLs and closing line.
+def build_ping_section(rc_version: str) -> str:
+    """Build the "Ping:" block with CI compare URLs and closing line.
 
     Args:
-        ping_list: List of (label, slack_mention, repo_name_or_None). Defaults to DEFAULT_PING_LIST.
+        rc_version: RC version for pip install (e.g., "1.7.0rc0")
 
     Returns:
-        The pinging section + closing line as a string.
+        The ping section + closing line as a string.
     """
-    if ping_list is None:
-        ping_list = DEFAULT_PING_LIST
 
-    lines = ["Pinging:"]
-    for label, mention, repo in ping_list:
-        if repo is not None:
-            lines.append(f"- for {label} {mention} => link")
-        else:
-            lines.append(f"- for {label} {mention}")
+    lines = ["Ping:"]
+    for label, repo in DEFAULT_PING_LIST:
+        url = f"https://github.com/huggingface/{repo}/compare/main...ci-test-huggingface-hub-{rc_version}-release"
+        lines.append(f"- {label}  => {url}")
 
     lines.append("")
     lines.append("Let us know if you spot any regressions! Release should be happening pretty soon :hugging_face:")
@@ -85,7 +78,7 @@ def run_opencode_skill(
         f"The RC version for the pip install command is {rc_version}. "
         f"Read the release notes from {input_file}. "
         f"Write the message body to {output_file}. "
-        f"Do NOT include the Pinging section or closing line — those are appended by the script."
+        f"Do NOT include the Ping section or closing line — those are appended by the script."
     )
 
     opencode_cmd = shutil.which("opencode")
@@ -154,8 +147,8 @@ def main(version: str, rc_version: str, input_file: Path | None = None, output_f
 
     body = body_file.read_text().strip()
 
-    # Build pinging section
-    ping_section = build_ping_section()
+    # Build ping section
+    ping_section = build_ping_section(rc_version=rc_version)
 
     # Combine and write final message
     final_message = f"{body}\n\n{ping_section}\n"


### PR DESCRIPTION
- highlights less verbose
- less emojis
- more straight to the point 
- links already built-in
- no pings (they don't work)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Release-announcement tooling only, but the ping-list tuple/unpack mismatch can break message generation at runtime until fixed.
> 
> **Overview**
> **Slack message style** for `hf-release-notes:slack` is tightened: greeting uses `@channel` and a shorter line, highlights use **bold** bullet summaries instead of `:sparkles:` / per-item emoji blocks, and the long real-example appendix in `slack-post-template.md` is removed so the skill follows a minimal template. The skill docs no longer ask the model to include a **pip install** block (the script still describes output through that point in places, but the template body ends at breaking changes).
> 
> **`generate_slack_message.py`** renames **Pinging** → **Ping**, drops `lighteval` and Slack user mentions, and **embeds GitHub compare URLs** (`ci-test-huggingface-hub-{rc_version}-release`) per downstream repo. `build_ping_section` now takes `rc_version` and no longer accepts a custom ping list.
> 
> **Note:** `DEFAULT_PING_LIST` entries are still 3-tuples while the loop unpacks two values—likely a runtime error until aligned with the new `(label, repo)` shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d5b4b8fb4b6980be4efa55e2faff936304ebf16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->