### PR TITLE
[Release] [CI] Fix slack message generation follow-ups

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -642,13 +642,11 @@ jobs:
         run: |
           VERSION="${{ needs.prepare.outputs.version }}"
           BASE_VERSION=$(echo "$VERSION" | sed -E 's/\.rc.*//')
-          # Convert 1.7.0.rc0 -> 1.7.0rc0 for pip
-          RC_PIP_VERSION=$(echo "$VERSION" | sed -E 's/\.rc/rc/')
           # Create output directory (.release-notes/ is in .gitignore so absent after checkout)
           mkdir -p .release-notes
           python -m utils.release_notes.generate_slack_message \
             --version "v${BASE_VERSION}" \
-            --rc-version "${RC_PIP_VERSION}" \
+            --rc-version "${VERSION}" \
             --input notes.md
 
       - name: Print Slack message to summary

--- a/.opencode/skills/hf-release-notes/SLACK.md
+++ b/.opencode/skills/hf-release-notes/SLACK.md
@@ -9,7 +9,7 @@ description: Generate a concise Slack announcement message from drafted release 
 
 Generate a concise Slack announcement message from existing release notes. The message is intended for internal team communication to announce a prerelease and solicit testing from downstream maintainers.
 
-**Important:** You generate ONLY the message body (greeting through the pip install command). The "Ping:" section and closing line are appended by the calling script — do NOT generate those.
+**Important:** You generate ONLY the message body (greeting through the breaking changes line). The "Ping:" section and closing line are appended by the calling script — do NOT generate those.
 
 ## Workflow
 
@@ -17,7 +17,6 @@ Generate a concise Slack announcement message from existing release notes. The m
 
 The prompt will specify:
 - **Version**: The base release version (e.g., `v1.7.0`)
-- **RC version**: The prerelease version for pip install (e.g., `1.7.0rc0`)
 - **Release notes path**: Path to the full release notes markdown file
 - **Output path**: Where to write the Slack message
 
@@ -76,7 +75,8 @@ No breaking changes in this release.
 
 ### 5. Write output
 
-Write ONLY the message body to the specified output path. Stop after the pip install command. Do NOT include:
+Write ONLY the message body to the specified output path. Stop after the breaking changes line. Do NOT include:
+- Any pip install command
 - The "Ping:" section
 - The "Let us know if you spot any regressions..." closing line
 - Any separator lines
@@ -84,7 +84,6 @@ Write ONLY the message body to the specified output path. Stop after the pip ins
 ## Input
 
 - Version string (e.g., `v1.7.0`)
-- RC version string (e.g., `1.7.0rc0`)
 - Path to the release notes markdown file
 - Output path for the Slack message
 

--- a/.opencode/skills/hf-release-notes/references/slack-post-template.md
+++ b/.opencode/skills/hf-release-notes/references/slack-post-template.md
@@ -2,7 +2,7 @@
 
 This is the template for the Slack announcement message. The script appends the "Ping:" section
 and closing line automatically — the skill only generates the body from the greeting through the
-pip install command.
+breaking changes line.
 
 ## Template
 

--- a/utils/release_notes/generate_slack_message.py
+++ b/utils/release_notes/generate_slack_message.py
@@ -8,7 +8,7 @@ This script:
 4. Outputs the final message to .release-notes/
 
 Usage:
-  python -m utils.release_notes.generate_slack_message --version v1.7.0 --rc-version 1.7.0rc0
+  python -m utils.release_notes.generate_slack_message --version v1.7.0 --rc-version 1.7.0.rc0
 """
 
 import argparse
@@ -24,12 +24,11 @@ from .validate_notes import find_release_notes_file
 OUTPUT_DIR = Path(os.environ.get("RELEASE_NOTES_OUTPUT_DIR", ".release-notes"))
 
 # Downstream repos to ping for RC testing.
-# Each entry: (display_label, repo_name)
-DEFAULT_PING_LIST: list[tuple[str, str]] = [
-    ("transformers", "@U01JNPUN1ML", "transformers"),
-    ("datasets", "@U011YKS85FY", "datasets"),
-    ("diffusers", "@U03AU4E7DJB", "diffusers"),
-    ("sentence-transformers", "@U04E4DNPWG7", "sentence-transformers"),
+DEFAULT_PING_LIST: list[str] = [
+    "transformers",
+    "datasets",
+    "diffusers",
+    "sentence-transformers",
 ]
 
 
@@ -37,16 +36,16 @@ def build_ping_section(rc_version: str) -> str:
     """Build the "Ping:" block with CI compare URLs and closing line.
 
     Args:
-        rc_version: RC version for pip install (e.g., "1.7.0rc0")
+        rc_version: RC version used in the CI test branch names (e.g., "1.7.0.rc0")
 
     Returns:
         The ping section + closing line as a string.
     """
 
     lines = ["Ping:"]
-    for label, repo in DEFAULT_PING_LIST:
+    for repo in DEFAULT_PING_LIST:
         url = f"https://github.com/huggingface/{repo}/compare/main...ci-test-huggingface-hub-{rc_version}-release"
-        lines.append(f"- {label}  => {url}")
+        lines.append(f"- {repo}  => {url}")
 
     lines.append("")
     lines.append("Let us know if you spot any regressions! Release should be happening pretty soon :hugging_face:")
@@ -56,7 +55,6 @@ def build_ping_section(rc_version: str) -> str:
 
 def run_opencode_skill(
     version: str,
-    rc_version: str,
     input_file: Path,
     output_file: Path,
 ) -> bool:
@@ -64,7 +62,6 @@ def run_opencode_skill(
 
     Args:
         version: Base version (e.g., "v1.7.0")
-        rc_version: RC version for pip install (e.g., "1.7.0rc0")
         input_file: Path to the release notes markdown
         output_file: Path to write the Slack message body
 
@@ -74,7 +71,6 @@ def run_opencode_skill(
     prompt = (
         f"Run the hf-release-notes:slack skill. "
         f"Generate a Slack announcement message for version {version}. "
-        f"The RC version for the pip install command is {rc_version}. "
         f"Read the release notes from {input_file}. "
         f"Write the message body to {output_file}. "
         f"Do NOT include the Ping section or closing line — those are appended by the script."
@@ -108,7 +104,7 @@ def main(version: str, rc_version: str, input_file: Path | None = None, output_f
 
     Args:
         version: Base version (e.g., "v1.7.0")
-        rc_version: RC version for pip install (e.g., "1.7.0rc0")
+        rc_version: RC version used in the CI test branch names (e.g., "1.7.0.rc0")
         input_file: Path to release notes (auto-detected if None)
         output_file: Output path (defaults to .release-notes/SLACK_MESSAGE_{version}.md)
 
@@ -136,7 +132,7 @@ def main(version: str, rc_version: str, input_file: Path | None = None, output_f
 
     # Generate message body with OpenCode
     body_file = OUTPUT_DIR / f"_slack_body_{version}.md"
-    if not run_opencode_skill(version, rc_version, input_file, body_file):
+    if not run_opencode_skill(version, input_file, body_file):
         print("Failed to generate Slack message body", file=sys.stderr)
         return 1
 
@@ -175,11 +171,11 @@ def cli():
         epilog="""
 Examples:
   # Generate Slack message for v1.7.0 prerelease
-  python -m utils.release_notes.generate_slack_message --version v1.7.0 --rc-version 1.7.0rc0
+  python -m utils.release_notes.generate_slack_message --version v1.7.0 --rc-version 1.7.0.rc0
 
   # With custom input/output paths
   python -m utils.release_notes.generate_slack_message \\
-    --version v1.7.0 --rc-version 1.7.0rc0 \\
+    --version v1.7.0 --rc-version 1.7.0.rc0 \\
     --input .release-notes/RELEASE_NOTES_v1.7.0.md \\
     --output slack_message.md
 """,
@@ -192,7 +188,7 @@ Examples:
     parser.add_argument(
         "--rc-version",
         required=True,
-        help="Full RC version for pip install command (e.g., 1.7.0rc0)",
+        help="Full RC version used in the CI test branch names (e.g., 1.7.0.rc0)",
     )
     parser.add_argument(
         "--input",


### PR DESCRIPTION
## Summary

Follow-up on #4587 — I merged it a bit too quickly and left a few things inconsistent. Addresses the two bugbot comments ([1](https://github.com/huggingface/huggingface_hub/pull/4587#discussion_r3656229043), [2](https://github.com/huggingface/huggingface_hub/pull/4587#discussion_r3656229068)):

- **`DEFAULT_PING_LIST` crash**: entries were still 3-tuples with Slack mentions while the annotation/comment/unpacking said 2-tuples → `ValueError: too many values to unpack` on every run. Since the display label was equal to the repo name for all 4 entries, it's now just a plain `list[str]` of repo names (mentions dropped, as intended by #4587).
- **pip install leftovers**: the block was removed from the template but `SLACK.md` still instructed to write the body "through the pip install command" and listed the RC version as a skill input. Removed those mentions; the announcement no longer carries an install command, so `run_opencode_skill()` doesn't take `rc_version` anymore.
- **Bonus fix found while doing the above**: `rc_version` is now only used to build the downstream CI compare links, and those branches are named after the raw tag version (`ci-test-huggingface-hub-1.7.0.rc0-release`, see the `test-downstream` job), not the pip-normalized one. The workflow was passing `1.7.0rc0`, so every ping link 404'd. It now passes `${VERSION}` directly.

Ping section output after the fix:

```
Ping:
- transformers  => https://github.com/huggingface/transformers/compare/main...ci-test-huggingface-hub-1.7.0.rc0-release
- datasets  => https://github.com/huggingface/datasets/compare/main...ci-test-huggingface-hub-1.7.0.rc0-release
- diffusers  => https://github.com/huggingface/diffusers/compare/main...ci-test-huggingface-hub-1.7.0.rc0-release
- sentence-transformers  => https://github.com/huggingface/sentence-transformers/compare/main...ci-test-huggingface-hub-1.7.0.rc0-release

Let us know if you spot any regressions! Release should be happening pretty soon :hugging_face:
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release automation and documentation only; no runtime library or auth changes.
> 
> **Overview**
> Follow-up fixes for prerelease **Slack announcement** generation so the workflow, Python script, and OpenCode skill stay consistent after removing pip install from the message.
> 
> **`DEFAULT_PING_LIST`** is now a plain `list[str]` of repo names (no Slack mention tuples), fixing a `ValueError: too many values to unpack` when building the Ping section.
> 
> The **OpenCode skill** docs (`SLACK.md`, template) now say the generated body ends at the breaking-changes line—no pip install or RC version passed into `run_opencode_skill()`.
> 
> **`--rc-version`** is only used for **downstream CI compare URLs**. The release workflow passes `${VERSION}` (e.g. `1.7.0.rc0`) instead of a pip-normalized form (`1.7.0rc0`), matching `ci-test-huggingface-hub-${VERSION}-release` branches from `test-downstream` so ping links no longer 404.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c9cdc1e55f6c6020a49f668856102830f90f844. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->