### PR TITLE
[CI] Unpin pytest-rerunfailures to fix cascading fixture setup errors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,9 @@ extras["testing"] = (
         "pytest-xdist",
         "pytest-vcr",  # to mock Inference
         "pytest-asyncio",  # for AsyncInferenceClient
-        "pytest-rerunfailures<16.0",  # to rerun flaky tests in CI
+        # 16.2 clears fixture finalizers when rerunning a test whose fixture failed at setup.
+        # Without it, any flaky fixture (e.g. a 502 from hub-ci) makes the rerun itself crash on pytest>=9.
+        "pytest-rerunfailures>=16.2",  # to rerun flaky tests in CI
         "pytest-mock",
         "urllib3<2.0",  # VCR.py broken with urllib3 2.0 (see https://urllib3.readthedocs.io/en/stable/v2-migration-guide.html)
         "soundfile",

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -1014,9 +1014,10 @@ class TestCommitApi:
 
     def test_prevent_empty_commit_if_no_op(self, api: HfApi, repo_factory: RepoFactory, caplog) -> None:
         repo_url = repo_factory()
+        caplog.clear()  # `at_level` doesn't scope capture => drop records emitted while setting up the repo
         with caplog.at_level("INFO", logger="huggingface_hub"):
             api.create_commit(repo_id=repo_url.repo_id, commit_message="Empty commit", operations=[])
-        records = [record for record in caplog.records if record.name.startswith("huggingface_hub")]
+        records = [record for record in caplog.records if record.name == "huggingface_hub.hf_api"]
         assert records[0].message == "No files have been modified since last commit. Skipping to prevent empty commit."
         assert records[0].levelname == "WARNING"
 
@@ -1030,6 +1031,7 @@ class TestCommitApi:
                 CommitOperationAdd(path_or_fileobj=b"LFS content", path_in_repo="lfs.bin"),
             ],
         )
+        caplog.clear()  # `at_level` doesn't scope capture => drop records emitted by the initial commit
         with caplog.at_level("INFO", logger="huggingface_hub"):
             api.create_commit(
                 repo_id=repo_url.repo_id,
@@ -1039,7 +1041,7 @@ class TestCommitApi:
                     CommitOperationAdd(path_or_fileobj=b"LFS content", path_in_repo="lfs.bin"),
                 ],
             )
-        records = [record for record in caplog.records if record.name.startswith("huggingface_hub")]
+        records = [record for record in caplog.records if record.name == "huggingface_hub.hf_api"]
         assert records[0].message == "Removing 2 file(s) from commit that have not changed."
         assert records[0].levelname == "INFO"
 
@@ -1059,6 +1061,7 @@ class TestCommitApi:
                 CommitOperationAdd(path_or_fileobj=b"LFS content", path_in_repo="lfs_copy.bin"),
             ],
         )
+        caplog.clear()  # `at_level` doesn't scope capture => drop records emitted by the initial commit
         with caplog.at_level("INFO", logger="huggingface_hub"):
             api.create_commit(
                 repo_id=repo_url.repo_id,
@@ -1068,7 +1071,7 @@ class TestCommitApi:
                     CommitOperationCopy(src_path_in_repo="lfs.bin", path_in_repo="lfs_copy.bin"),
                 ],
             )
-        records = [record for record in caplog.records if record.name.startswith("huggingface_hub")]
+        records = [record for record in caplog.records if record.name == "huggingface_hub.hf_api"]
         assert records[0].message == "Removing 2 file(s) from commit that have not changed."
         assert records[0].levelname == "INFO"
 
@@ -1110,6 +1113,7 @@ class TestCommitApi:
                 CommitOperationAdd(path_or_fileobj=b"LFS content 2.0", path_in_repo="lfs2.bin"),
             ],
         )
+        caplog.clear()  # `at_level` doesn't scope capture => drop records emitted by the initial commit
         with caplog.at_level("DEBUG", logger="huggingface_hub"):
             api.create_commit(
                 repo_id=repo_url.repo_id,
@@ -1129,7 +1133,7 @@ class TestCommitApi:
                     CommitOperationAdd(path_or_fileobj=b"LFS content 3.0", path_in_repo="lfs3.bin"),
                 ],
             )
-        records = [record for record in caplog.records if record.name.startswith("huggingface_hub")]
+        records = [record for record in caplog.records if record.name == "huggingface_hub.hf_api"]
         debug_logs = [record.message for record in records if record.levelname == "DEBUG"]
         info_logs = [record.message for record in records if record.levelname == "INFO"]
         warning_logs = [record.message for record in records if record.levelname == "WARNING"]
@@ -1170,6 +1174,7 @@ class TestCommitApi:
                 CommitOperationAdd(path_or_fileobj=b"LFS content 2.0", path_in_repo="lfs2.bin"),
             ],
         )
+        caplog.clear()  # `at_level` doesn't scope capture => drop records emitted by the initial commit
         with caplog.at_level("DEBUG", logger="huggingface_hub"):
             api.create_commit(
                 repo_id=repo_url.repo_id,
@@ -1189,7 +1194,7 @@ class TestCommitApi:
                     CommitOperationCopy(src_path_in_repo="lfs2.bin", path_in_repo="lfs3.bin"),
                 ],
             )
-        records = [record for record in caplog.records if record.name.startswith("huggingface_hub")]
+        records = [record for record in caplog.records if record.name == "huggingface_hub.hf_api"]
         debug_logs = [record.message for record in records if record.levelname == "DEBUG"]
         info_logs = [record.message for record in records if record.levelname == "INFO"]
         warning_logs = [record.message for record in records if record.levelname == "WARNING"]
@@ -1240,6 +1245,7 @@ class TestCommitApi:
                 CommitOperationAdd(path_or_fileobj=b"content 2.0", path_in_repo="file2.txt"),
             ],
         )
+        caplog.clear()  # `at_level` doesn't scope capture => drop records emitted by the initial commit
         with caplog.at_level("DEBUG", logger="huggingface_hub"):
             api.create_commit(
                 repo_id=repo_url.repo_id,
@@ -1253,7 +1259,7 @@ class TestCommitApi:
                     CommitOperationDelete(path_in_repo="file2.txt"),
                 ],
             )
-        records = [record for record in caplog.records if record.name.startswith("huggingface_hub")]
+        records = [record for record in caplog.records if record.name == "huggingface_hub.hf_api"]
         debug_logs = [record.message for record in records if record.levelname == "DEBUG"]
         info_logs = [record.message for record in records if record.levelname == "INFO"]
         warning_logs = [record.message for record in records if record.levelname == "WARNING"]

--- a/tests/test_utils_fixes.py
+++ b/tests/test_utils_fixes.py
@@ -36,10 +36,12 @@ class TestWeakFileLock:
         monkeypatch.setattr("huggingface_hub.constants.FILELOCK_LOG_EVERY_SECONDS", 0.1)
         lock_file = tmp_path / ".lock"
 
+        # Wait 10x the log interval but only assert on the first 3 messages: on a loaded CI runner
+        # a poll can take much longer than the interval, so we can't expect all 10 of them.
         with caplog.at_level(logging.INFO, logger="huggingface_hub.utils._fixes"):
             with WeakFileLock(lock_file):
                 with pytest.raises(filelock.Timeout) as exc_info:
-                    with WeakFileLock(lock_file, timeout=0.3):
+                    with WeakFileLock(lock_file, timeout=1.0):
                         pass
                 assert exc_info.value.lock_file == str(lock_file)
 


### PR DESCRIPTION
## Summary

Fixes a recurring CI failure class that hits random PRs (e.g. [this run](https://github.com/huggingface/huggingface_hub/actions/runs/30263156788)) and looks unrelated to whatever is being changed.

- One transient error in a test fixture (typically a `502 Bad Gateway` from hub-ci on `POST /api/repos/create`) currently takes down **every test sharing that fixture**, with an opaque `AssertionError` coming from pytest internals.
- Root cause: **pytest-rerunfailures 15.1** clears `FixtureDef.cached_result` but not `FixtureDef._finalizers`. pytest >= 9 asserts `_finalizers` is empty before executing a fixture, so the rerun itself crashes. The new error (`AssertionError`) no longer matches our `--only-rerun` regex, so nothing gets retried and the whole class cascades.
- Upstream fixed it in **16.2**: _"Clear fixture finalizers when removing cached results from failed fixtures to fix compatibility with pytest >= 9, which asserts that `_finalizers` is empty before executing a fixture."_
- The `<16.0` pin was added in a46daf57e on 2025-08-29 — the day 16.0 was released — bundled into an unrelated `ty` PR with no rationale. The likely reason is 16.0's pytest-xdist incompatibility, which upstream reverted in **16.0.1** four days later. The pin has been obsolete since Sept 2025.

## What it looks like today

From `build-windows (3.14, no hf_xet)`, 8 tests lost to a single 502:

```
ERROR tests/test_hf_api.py::TestHfApiDeleteFiles::test_delete_single_file - AssertionError
ERROR tests/test_hf_api.py::TestHfApiDeleteFiles::test_delete_multiple_files - AssertionError
ERROR tests/test_hf_api.py::TestHfApiDeleteFiles::test_delete_folder_with_pattern - AssertionError
... 5 more
```

```
>       assert not self._finalizers
E       AssertionError
..\.venv\Lib\site-packages\_pytest\fixtures.py:1221: AssertionError
----------------------------- Captured log setup ------------------------------
INFO  httpx: HTTP Request: POST https://hub-ci.huggingface.co/api/repos/create "HTTP/1.1 502 Bad Gateway"
```

Same thing in `build-windows (3.10, with hf_xet)` on `TestHfFileSystemRepositoryRW`, triggered by a 502 on `POST /api/datasets/.../commit/main?create_pr=1`.

## Repro

```python
# test_flaky.py
import pytest

CALLS = {"n": 0}

class TestFlakySetup:
    @pytest.fixture(autouse=True)
    def _repo(self, tmp_path):
        CALLS["n"] += 1
        if CALLS["n"] == 1:  # one-off 502, like hub-ci
            raise OSError("502 Server Error: Bad Gateway")
        yield tmp_path

    def test_a(self): pass
    def test_b(self): pass
    def test_c(self): pass
```

```console
$ # pytest 9.1.1 + pytest-rerunfailures 15.1 (current pin)
$ pytest test_flaky.py --reruns 8 --reruns-delay 0 --only-rerun 'OSError' -q
>       assert not self._finalizers
E       AssertionError
3 errors, 1 rerun in 0.36s

$ # pytest 9.1.1 + pytest-rerunfailures 16.4
$ pytest test_flaky.py --reruns 8 --reruns-delay 0 --only-rerun 'OSError' -q
R...                                                                     [100%]
3 passed, 1 rerun in 0.01s
```

Also verified with a permanently-failing fixture: on 16.4 the reruns actually happen and the report shows the **real** error (`OSError: 502 Server Error...`) instead of `assert not self._finalizers`, which should make future triage a lot easier.

## Manual testing

Installed 16.4 locally and ran a subset with the exact CI flags, including xdist (the reason for the original pin):

```console
$ pytest tests/test_utils_http.py tests/test_file_download.py -m "not xet" -n 4 \
    --reruns 8 --reruns-delay 2 --only-rerun '(OSError|FileNotFoundError|Timeout|HTTPError.*409|HTTPError.*502|HTTPError.*504|not less than or equal to 0.01)'
129 passed, 10 warnings, 1 rerun in 242.89s (0:04:02)
```

No xdist issues, no plugin regressions.

## Not fixed here

The same run had a second, unrelated flake in `TestHfHubDownloadToLocalDir`:

```
FAILED tests/test_file_download.py::TestHfHubDownloadToLocalDir::test_metadata_ok_and_etag_mismatch
  - AssertionError: Expected '_download_to_tmp_and_move' to have been called once. Called 0 times.
WARNING file_download.py:1333 Couldn't access the Hub to check for update but local file
  already exists. Defaulting to existing file. (error: The read operation timed out)
```

The HEAD metadata call timed out, `hf_hub_download` fell back to the existing local file (working as designed), and the test failed with a plain `AssertionError` that doesn't match `--only-rerun`, so it was never retried. This bump doesn't help there — leaving it for a separate PR.

Worth noting for that one: in `file_download.py`, when the HEAD call fails and the file is **absent** we retry on `_DEFAULT_RETRY_ON_EXCEPTIONS`, but when it's **present** we give up immediately. Making that branch retry too would fix the flake and arguably help real users (a network blip silently skipping an available update), but it's a behaviour change worth discussing on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and dev-dependency changes only; no production library behavior.
> 
> **Overview**
> **Bumps `pytest-rerunfailures` from `<16.0` to `>=16.2`** so flaky fixture setup (e.g. hub-ci 502s) can be retried on pytest ≥9 without reruns crashing on leftover fixture finalizers.
> 
> **Hardens empty-commit / caplog tests in `test_hf_api.py`:** clears `caplog` before each `at_level` block (setup commits pollute the buffer) and filters log records to `huggingface_hub.hf_api` only instead of any `huggingface_hub*` logger.
> 
> **Relaxes `TestWeakFileLock::test_lock_log_every`:** longer lock timeout and asserts at least three “still waiting” messages instead of a fixed count, to reduce CI timing flakes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea8a83756fce2669d3e3c885397bd32eeaaed714. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->