### PR TITLE
[Docs] Fix HF_XET_SHARD_CACHE_SIZE_LIMIT default (4GB → 16GB)

### DIFF
--- a/docs/source/en/package_reference/environment_variables.md
+++ b/docs/source/en/package_reference/environment_variables.md
@@ -102,7 +102,7 @@ Defaults to `0` (0 bytes, means chunk cache is disabled).
 
 To set the size of the Xet shard cache locally. Increasing this will improve upload efficiency as chunks referenced in cached shard files are not re-uploaded. Note that the default soft limit is likely sufficient for most workloads. 
 
-Defaults to `4000000000` (4GB).
+Defaults to `16000000000` (16GB).
 
 ### HF_XET_NUM_CONCURRENT_RANGE_GETS
 


### PR DESCRIPTION
## Summary

- Corrects the documented default for `HF_XET_SHARD_CACHE_SIZE_LIMIT` on the environment-variables page from `4000000000` (4GB) to `16000000000` (16GB).
- The Xet shard-cache soft limit in `xet-core` is **16 GB** — verified in `xet_runtime/src/config/groups/shard.rs` (`ByteSize::from("16gb")`) on both `main` and the latest release tag `v1.5.1`. The docs page had drifted to a stale 4 GB value.

Docs-only, one line — no code changes.

Companion to hub-docs PR huggingface/hub-docs#2668, which documents this and the other Xet cache variables on the *Using Xet Storage* page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012XmgpfqHUeQtJthDXJddq9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line documentation correction with no code or configuration changes.
> 
> **Overview**
> Updates the **environment variables** reference so `HF_XET_SHARD_CACHE_SIZE_LIMIT` is documented with the correct default of **`16000000000` (16GB)** instead of the stale **4GB** value.
> 
> No runtime or library behavior changes—documentation only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 342e574f3ba9f37d832e8670149d4344061f5613. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->