### PR TITLE
[Download] Reject redacted Xet hashes from tree cache

### DIFF
--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -20,6 +20,7 @@ from .errors import (
 from .file_download import REGEX_COMMIT_HASH, DryRunFileInfo, hf_hub_download, repo_folder_name
 from .hf_api import DatasetInfo, HfApi, KernelInfo, ModelInfo, RepoFile, SpaceInfo
 from .utils import OfflineModeIsEnabled, filter_repo_objects, logging, validate_hf_hub_args
+from .utils._xet import is_valid_xet_hash
 from .utils._xet_progress_reporting import (
     XET_BYTES_BAR_FORMAT,
     XET_TRANSFER_BAR_FORMAT,
@@ -381,7 +382,7 @@ def snapshot_download(
                 blob_id=f.blob_id,
                 lfs_sha256=f.lfs.sha256 if f.lfs is not None else None,
                 lfs_size=f.lfs.size if f.lfs is not None else None,
-                xet_hash=f.xet_hash,
+                xet_hash=f.xet_hash if f.xet_hash is not None and is_valid_xet_hash(f.xet_hash) else None,
             )
             for f in api.list_repo_tree(repo_id=repo_id, recursive=True, revision=commit_hash, repo_type=repo_type)
             if isinstance(f, RepoFile)

--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -380,10 +380,6 @@ def snapshot_download(
 
     # Retrieve /tree listing from cache or fetch it
     tree_entries = read_tree_cache(tree_cache_folder, commit_hash)
-    if tree_entries is not None and not is_valid_tree_entries(tree_entries):
-        # A redacted Xet hash means the tree was fetched without access to the gated repo contents. Refetch it in
-        # case access has since been granted instead of keeping the redacted tree cached forever.
-        tree_entries = None
     if tree_entries is None:
         tree_entries = {
             f.path: TreeCacheEntry(

--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -6,7 +6,13 @@ import httpx
 from tqdm.auto import tqdm as base_tqdm
 
 from . import constants
-from ._tree_cache import TreeCacheEntry, read_tree_cache, tree_cache_folder_for_local_dir, write_tree_cache
+from ._tree_cache import (
+    TreeCacheEntry,
+    is_valid_tree_entries,
+    read_tree_cache,
+    tree_cache_folder_for_local_dir,
+    write_tree_cache,
+)
 from .errors import (
     CachedRepoTreeNotFoundError,
     DryRunError,
@@ -20,7 +26,6 @@ from .errors import (
 from .file_download import REGEX_COMMIT_HASH, DryRunFileInfo, hf_hub_download, repo_folder_name
 from .hf_api import DatasetInfo, HfApi, KernelInfo, ModelInfo, RepoFile, SpaceInfo
 from .utils import OfflineModeIsEnabled, filter_repo_objects, logging, validate_hf_hub_args
-from .utils._xet import is_valid_xet_hash
 from .utils._xet_progress_reporting import (
     XET_BYTES_BAR_FORMAT,
     XET_TRANSFER_BAR_FORMAT,
@@ -375,18 +380,11 @@ def snapshot_download(
 
     # Retrieve /tree listing from cache or fetch it
     tree_entries = read_tree_cache(tree_cache_folder, commit_hash)
-    if tree_entries is not None and any(
-        entry.xet_hash is not None and not is_valid_xet_hash(entry.xet_hash) for entry in tree_entries.values()
-    ):
+    if tree_entries is not None and not is_valid_tree_entries(tree_entries):
         # A redacted Xet hash means the tree was fetched without access to the gated repo contents. Refetch it in
         # case access has since been granted instead of keeping the redacted tree cached forever.
         tree_entries = None
     if tree_entries is None:
-        repo_files = [
-            f
-            for f in api.list_repo_tree(repo_id=repo_id, recursive=True, revision=commit_hash, repo_type=repo_type)
-            if isinstance(f, RepoFile)
-        ]
         tree_entries = {
             f.path: TreeCacheEntry(
                 size=f.size,
@@ -395,9 +393,10 @@ def snapshot_download(
                 lfs_size=f.lfs.size if f.lfs is not None else None,
                 xet_hash=f.xet_hash,
             )
-            for f in repo_files
+            for f in api.list_repo_tree(repo_id=repo_id, recursive=True, revision=commit_hash, repo_type=repo_type)
+            if isinstance(f, RepoFile)
         }
-        if not dry_run and all(f.xet_hash is None or is_valid_xet_hash(f.xet_hash) for f in repo_files):
+        if not dry_run and is_valid_tree_entries(tree_entries):
             write_tree_cache(tree_cache_folder, commit_hash, tree_entries)
 
     filtered_repo_files = list(

--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -375,19 +375,29 @@ def snapshot_download(
 
     # Retrieve /tree listing from cache or fetch it
     tree_entries = read_tree_cache(tree_cache_folder, commit_hash)
+    if tree_entries is not None and any(
+        entry.xet_hash is not None and not is_valid_xet_hash(entry.xet_hash) for entry in tree_entries.values()
+    ):
+        # A redacted Xet hash means the tree was fetched without access to the gated repo contents. Refetch it in
+        # case access has since been granted instead of keeping the redacted tree cached forever.
+        tree_entries = None
     if tree_entries is None:
+        repo_files = [
+            f
+            for f in api.list_repo_tree(repo_id=repo_id, recursive=True, revision=commit_hash, repo_type=repo_type)
+            if isinstance(f, RepoFile)
+        ]
         tree_entries = {
             f.path: TreeCacheEntry(
                 size=f.size,
                 blob_id=f.blob_id,
                 lfs_sha256=f.lfs.sha256 if f.lfs is not None else None,
                 lfs_size=f.lfs.size if f.lfs is not None else None,
-                xet_hash=f.xet_hash if f.xet_hash is not None and is_valid_xet_hash(f.xet_hash) else None,
+                xet_hash=f.xet_hash,
             )
-            for f in api.list_repo_tree(repo_id=repo_id, recursive=True, revision=commit_hash, repo_type=repo_type)
-            if isinstance(f, RepoFile)
+            for f in repo_files
         }
-        if not dry_run:
+        if not dry_run and all(f.xet_hash is None or is_valid_xet_hash(f.xet_hash) for f in repo_files):
             write_tree_cache(tree_cache_folder, commit_hash, tree_entries)
 
     filtered_repo_files = list(

--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -6,13 +6,7 @@ import httpx
 from tqdm.auto import tqdm as base_tqdm
 
 from . import constants
-from ._tree_cache import (
-    TreeCacheEntry,
-    is_valid_tree_entries,
-    read_tree_cache,
-    tree_cache_folder_for_local_dir,
-    write_tree_cache,
-)
+from ._tree_cache import TreeCacheEntry, read_tree_cache, tree_cache_folder_for_local_dir, write_tree_cache
 from .errors import (
     CachedRepoTreeNotFoundError,
     DryRunError,
@@ -392,7 +386,7 @@ def snapshot_download(
             for f in api.list_repo_tree(repo_id=repo_id, recursive=True, revision=commit_hash, repo_type=repo_type)
             if isinstance(f, RepoFile)
         }
-        if not dry_run and is_valid_tree_entries(tree_entries):
+        if not dry_run:
             write_tree_cache(tree_cache_folder, commit_hash, tree_entries)
 
     filtered_repo_files = list(

--- a/src/huggingface_hub/_tree_cache.py
+++ b/src/huggingface_hub/_tree_cache.py
@@ -95,15 +95,17 @@ def tree_cache_folder_for_local_dir(local_dir: str) -> str:
 
 
 def read_tree_cache(tree_cache_folder: str, commit_hash: str) -> dict[str, TreeCacheEntry] | None:
-    """Return the cached tree listing for a commit hash, or `None` if not cached (or unreadable)."""
+    """Return the cached tree listing for a commit hash, or `None` if not cached, invalid, or unreadable."""
     path = _tree_cache_path(tree_cache_folder, commit_hash)
     with _IN_MEMORY_TREE_CACHE_LOCK:
         if path in _IN_MEMORY_TREE_CACHE:
-            return _IN_MEMORY_TREE_CACHE[path]
+            entries = _IN_MEMORY_TREE_CACHE[path]
+            return entries if is_valid_tree_entries(entries) else None
     entries = _read_tree_cache_from_disk(path)
-    if entries is not None:
-        with _IN_MEMORY_TREE_CACHE_LOCK:
-            _IN_MEMORY_TREE_CACHE[path] = entries
+    if entries is None or not is_valid_tree_entries(entries):
+        return None
+    with _IN_MEMORY_TREE_CACHE_LOCK:
+        _IN_MEMORY_TREE_CACHE[path] = entries
     return entries
 
 

--- a/src/huggingface_hub/_tree_cache.py
+++ b/src/huggingface_hub/_tree_cache.py
@@ -38,6 +38,7 @@ import threading
 from dataclasses import dataclass
 
 from .utils import logging
+from .utils._xet import is_valid_xet_hash
 
 
 logger = logging.get_logger(__name__)
@@ -77,6 +78,11 @@ class TreeCacheEntry:
             lfs_size=info.get("lfs_size"),
             xet_hash=info.get("xet_hash"),
         )
+
+
+def is_valid_tree_entries(entries: dict[str, TreeCacheEntry]) -> bool:
+    """Return whether all Xet hashes in the tree listing are valid."""
+    return all(entry.xet_hash is None or is_valid_xet_hash(entry.xet_hash) for entry in entries.values())
 
 
 def _tree_cache_path(tree_cache_folder: str, commit_hash: str) -> str:

--- a/src/huggingface_hub/_tree_cache.py
+++ b/src/huggingface_hub/_tree_cache.py
@@ -125,7 +125,10 @@ def _read_tree_cache_from_disk(path: str) -> dict[str, TreeCacheEntry] | None:
 
 
 def write_tree_cache(tree_cache_folder: str, commit_hash: str, entries: dict[str, TreeCacheEntry]) -> None:
-    """Write the tree listing of a commit hash to the cache (ignoring any failures)."""
+    """Write a valid tree listing to the cache (ignoring invalid entries and any failures)."""
+    if not is_valid_tree_entries(entries):
+        return
+
     path = _tree_cache_path(tree_cache_folder, commit_hash)
     data = {
         "format_version": TREE_CACHE_FORMAT_VERSION,

--- a/src/huggingface_hub/_tree_cache.py
+++ b/src/huggingface_hub/_tree_cache.py
@@ -99,8 +99,8 @@ def read_tree_cache(tree_cache_folder: str, commit_hash: str) -> dict[str, TreeC
     path = _tree_cache_path(tree_cache_folder, commit_hash)
     with _IN_MEMORY_TREE_CACHE_LOCK:
         if path in _IN_MEMORY_TREE_CACHE:
-            entries = _IN_MEMORY_TREE_CACHE[path]
-            return entries if is_valid_tree_entries(entries) else None
+            cached_entries = _IN_MEMORY_TREE_CACHE[path]
+            return cached_entries if is_valid_tree_entries(cached_entries) else None
     entries = _read_tree_cache_from_disk(path)
     if entries is None or not is_valid_tree_entries(entries):
         return None

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -53,7 +53,7 @@ from .utils._http import (
     http_stream_backoff,
 )
 from .utils._runtime import is_xet_available
-from .utils._xet import XetTokenType, xet_connection_info_refresh_url
+from .utils._xet import XetTokenType, is_valid_xet_hash, xet_connection_info_refresh_url
 from .utils.sha import sha_fileobj
 from .utils.tqdm import _get_progress_bar_context
 
@@ -1819,7 +1819,13 @@ def _xet_file_metadata_from_tree_cache(
     if tree_entries is None:
         return None
     entry = tree_entries.get(filename)
-    if entry is None or entry.xet_hash is None or entry.lfs_sha256 is None or entry.lfs_size is None:
+    if (
+        entry is None
+        or entry.xet_hash is None
+        or not is_valid_xet_hash(entry.xet_hash)
+        or entry.lfs_sha256 is None
+        or entry.lfs_size is None
+    ):
         return None
 
     xet_file_data = XetFileData(

--- a/src/huggingface_hub/utils/_xet.py
+++ b/src/huggingface_hub/utils/_xet.py
@@ -1,4 +1,5 @@
 import os
+import re
 import threading
 from dataclasses import dataclass
 from enum import Enum
@@ -7,6 +8,14 @@ import httpx
 
 from .. import constants
 from . import validate_hf_hub_args
+
+
+_REGEX_XET_HASH = re.compile(r"^[0-9a-fA-F]{64}$")
+
+
+def is_valid_xet_hash(xet_hash: str) -> bool:
+    """Return whether `xet_hash` looks like a real Xet content hash (64 hex chars)."""
+    return bool(_REGEX_XET_HASH.fullmatch(xet_hash))
 
 
 class XetTokenType(str, Enum):

--- a/tests/test_snapshot_download.py
+++ b/tests/test_snapshot_download.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from huggingface_hub import CommitOperationAdd, HfApi, snapshot_download
-from huggingface_hub._tree_cache import TreeCacheEntry, read_tree_cache, write_tree_cache
+from huggingface_hub._tree_cache import read_tree_cache
 from huggingface_hub.errors import IncompleteSnapshotError, LocalEntryNotFoundError, RepositoryNotFoundError
 from huggingface_hub.file_download import repo_folder_name
 from huggingface_hub.hf_api import RepoFile
@@ -17,7 +17,6 @@ from .testing_utils import OfflineSimulationMode, offline, repo_name
 
 COMMIT_HASH = "0123456789abcdef0123456789abcdef01234567"
 MASKED_XET_HASH = "*" * 64
-VALID_XET_HASH = "63bed80836ee0758c8fd4f8975d59bb0b864263ee2753547c358e8a37cde8758"
 
 
 def test_tree_with_redacted_xet_hash_is_not_cached(tmp_path: Path):
@@ -38,44 +37,6 @@ def test_tree_with_redacted_xet_hash_is_not_cached(tmp_path: Path):
 
     storage_folder = tmp_path / repo_folder_name(repo_id="user/repo", repo_type="model")
     assert read_tree_cache(str(storage_folder), COMMIT_HASH) is None
-
-
-def test_redacted_tree_cache_is_refetched(tmp_path: Path):
-    storage_folder = tmp_path / repo_folder_name(repo_id="user/repo", repo_type="model")
-    write_tree_cache(
-        str(storage_folder),
-        COMMIT_HASH,
-        {
-            "model.safetensors": TreeCacheEntry(
-                size=42,
-                blob_id="blob-model",
-                lfs_sha256="sha256-model",
-                lfs_size=42,
-                xet_hash=MASKED_XET_HASH,
-            )
-        },
-    )
-    repo_file = RepoFile(
-        path="model.safetensors",
-        size=42,
-        oid="blob-model",
-        lfs={"oid": "sha256-model", "size": 42, "pointerSize": 128},
-        xetHash=VALID_XET_HASH,
-    )
-
-    with (
-        patch("huggingface_hub._snapshot_download.HfApi.repo_info", return_value=MagicMock(sha=COMMIT_HASH)),
-        patch(
-            "huggingface_hub._snapshot_download.HfApi.list_repo_tree", return_value=[repo_file]
-        ) as mock_list_repo_tree,
-        patch("huggingface_hub._snapshot_download.hf_thread_map"),
-    ):
-        snapshot_download("user/repo", cache_dir=tmp_path)
-
-    mock_list_repo_tree.assert_called_once()
-    tree_entries = read_tree_cache(str(storage_folder), COMMIT_HASH)
-    assert tree_entries is not None
-    assert tree_entries["model.safetensors"].xet_hash == VALID_XET_HASH
 
 
 class TestSnapshotDownload:

--- a/tests/test_snapshot_download.py
+++ b/tests/test_snapshot_download.py
@@ -1,16 +1,81 @@
 import os
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from huggingface_hub import CommitOperationAdd, HfApi, snapshot_download
+from huggingface_hub._tree_cache import TreeCacheEntry, read_tree_cache, write_tree_cache
 from huggingface_hub.errors import IncompleteSnapshotError, LocalEntryNotFoundError, RepositoryNotFoundError
 from huggingface_hub.file_download import repo_folder_name
+from huggingface_hub.hf_api import RepoFile
 from huggingface_hub.utils import SoftTemporaryDirectory, _http
 
 from .testing_constants import TOKEN
 from .testing_utils import OfflineSimulationMode, offline, repo_name
+
+
+COMMIT_HASH = "0123456789abcdef0123456789abcdef01234567"
+MASKED_XET_HASH = "*" * 64
+VALID_XET_HASH = "63bed80836ee0758c8fd4f8975d59bb0b864263ee2753547c358e8a37cde8758"
+
+
+def test_tree_with_redacted_xet_hash_is_not_cached(tmp_path: Path):
+    repo_file = RepoFile(
+        path="model.safetensors",
+        size=42,
+        oid="blob-model",
+        lfs={"oid": "sha256-model", "size": 42, "pointerSize": 128},
+        xetHash=MASKED_XET_HASH,
+    )
+
+    with (
+        patch("huggingface_hub._snapshot_download.HfApi.repo_info", return_value=MagicMock(sha=COMMIT_HASH)),
+        patch("huggingface_hub._snapshot_download.HfApi.list_repo_tree", return_value=[repo_file]),
+        patch("huggingface_hub._snapshot_download.hf_thread_map"),
+    ):
+        snapshot_download("user/repo", cache_dir=tmp_path)
+
+    storage_folder = tmp_path / repo_folder_name(repo_id="user/repo", repo_type="model")
+    assert read_tree_cache(str(storage_folder), COMMIT_HASH) is None
+
+
+def test_redacted_tree_cache_is_refetched(tmp_path: Path):
+    storage_folder = tmp_path / repo_folder_name(repo_id="user/repo", repo_type="model")
+    write_tree_cache(
+        str(storage_folder),
+        COMMIT_HASH,
+        {
+            "model.safetensors": TreeCacheEntry(
+                size=42,
+                blob_id="blob-model",
+                lfs_sha256="sha256-model",
+                lfs_size=42,
+                xet_hash=MASKED_XET_HASH,
+            )
+        },
+    )
+    repo_file = RepoFile(
+        path="model.safetensors",
+        size=42,
+        oid="blob-model",
+        lfs={"oid": "sha256-model", "size": 42, "pointerSize": 128},
+        xetHash=VALID_XET_HASH,
+    )
+
+    with (
+        patch("huggingface_hub._snapshot_download.HfApi.repo_info", return_value=MagicMock(sha=COMMIT_HASH)),
+        patch(
+            "huggingface_hub._snapshot_download.HfApi.list_repo_tree", return_value=[repo_file]
+        ) as mock_list_repo_tree,
+        patch("huggingface_hub._snapshot_download.hf_thread_map"),
+    ):
+        snapshot_download("user/repo", cache_dir=tmp_path)
+
+    mock_list_repo_tree.assert_called_once()
+    tree_entries = read_tree_cache(str(storage_folder), COMMIT_HASH)
+    assert tree_entries is not None
+    assert tree_entries["model.safetensors"].xet_hash == VALID_XET_HASH
 
 
 class TestSnapshotDownload:

--- a/tests/test_tree_cache.py
+++ b/tests/test_tree_cache.py
@@ -85,6 +85,10 @@ class TestTreeCacheReadWrite:
     def test_missing_file_returns_none(self, tmp_path: Path):
         assert read_tree_cache(str(tmp_path), COMMIT_HASH) is None
 
+    def test_invalid_entries_return_none(self, tmp_path: Path):
+        write_tree_cache(str(tmp_path), COMMIT_HASH, _entries_with_masked_xet_hash())
+        assert read_tree_cache(str(tmp_path), COMMIT_HASH) is None
+
     def test_unknown_format_version_returns_none(self, tmp_path: Path):
         path = tmp_path / "trees" / f"{COMMIT_HASH}.json"
         path.parent.mkdir(parents=True)
@@ -190,25 +194,6 @@ class TestTreeCacheSkipsHeadCall:
             )
             is None
         )
-
-    @pytest.mark.xet
-    def test_get_metadata_heads_when_xet_hash_is_masked(self, tmp_path: Path):
-        storage_folder = tmp_path / repo_folder_name(repo_id="user/repo", repo_type="model")
-        write_tree_cache(str(storage_folder), COMMIT_HASH, _entries_with_masked_xet_hash())
-        with patch("huggingface_hub.file_download.get_hf_file_metadata", side_effect=RuntimeError("HEAD called")):
-            with pytest.raises(RuntimeError, match="HEAD called"):
-                _get_metadata_or_catch_error(
-                    repo_id="user/repo",
-                    filename="model.safetensors",
-                    repo_type="model",
-                    revision=COMMIT_HASH,
-                    endpoint=None,
-                    etag_timeout=10,
-                    headers={},
-                    token=None,
-                    local_files_only=False,
-                    tree_cache_folder=str(storage_folder),
-                )
 
     def test_no_tree_cache_returns_none(self, tmp_path: Path):  # not populated
         storage_folder = tmp_path / repo_folder_name(repo_id="user/repo", repo_type="model")

--- a/tests/test_tree_cache.py
+++ b/tests/test_tree_cache.py
@@ -175,29 +175,27 @@ class TestTreeCacheSkipsHeadCall:
                 is None
             )
 
+    @pytest.mark.xet
     def test_xet_file_returns_none_when_xet_hash_is_masked(self, tmp_path: Path):
         storage_folder = tmp_path / repo_folder_name(repo_id="user/repo", repo_type="model")
         write_tree_cache(str(storage_folder), COMMIT_HASH, _entries_with_masked_xet_hash())
-        with patch("huggingface_hub.file_download.is_xet_available", return_value=True):
-            assert (
-                _xet_file_metadata_from_tree_cache(
-                    tree_cache_folder=str(storage_folder),
-                    repo_id="user/repo",
-                    repo_type="model",
-                    commit_hash=COMMIT_HASH,
-                    filename="model.safetensors",
-                    endpoint=None,
-                )
-                is None
+        assert (
+            _xet_file_metadata_from_tree_cache(
+                tree_cache_folder=str(storage_folder),
+                repo_id="user/repo",
+                repo_type="model",
+                commit_hash=COMMIT_HASH,
+                filename="model.safetensors",
+                endpoint=None,
             )
+            is None
+        )
 
+    @pytest.mark.xet
     def test_get_metadata_heads_when_xet_hash_is_masked(self, tmp_path: Path):
         storage_folder = tmp_path / repo_folder_name(repo_id="user/repo", repo_type="model")
         write_tree_cache(str(storage_folder), COMMIT_HASH, _entries_with_masked_xet_hash())
-        with (
-            patch("huggingface_hub.file_download.is_xet_available", return_value=True),
-            patch("huggingface_hub.file_download.get_hf_file_metadata", side_effect=RuntimeError("HEAD called")),
-        ):
+        with patch("huggingface_hub.file_download.get_hf_file_metadata", side_effect=RuntimeError("HEAD called")):
             with pytest.raises(RuntimeError, match="HEAD called"):
                 _get_metadata_or_catch_error(
                     repo_id="user/repo",

--- a/tests/test_tree_cache.py
+++ b/tests/test_tree_cache.py
@@ -86,7 +86,18 @@ class TestTreeCacheReadWrite:
         assert read_tree_cache(str(tmp_path), COMMIT_HASH) is None
 
     def test_invalid_entries_return_none(self, tmp_path: Path):
-        write_tree_cache(str(tmp_path), COMMIT_HASH, _entries_with_masked_xet_hash())
+        path = tmp_path / "trees" / f"{COMMIT_HASH}.json"
+        path.parent.mkdir(parents=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "format_version": TREE_CACHE_FORMAT_VERSION,
+                    "files": {
+                        file_path: entry.to_json() for file_path, entry in _entries_with_masked_xet_hash().items()
+                    },
+                }
+            )
+        )
         assert read_tree_cache(str(tmp_path), COMMIT_HASH) is None
 
     def test_unknown_format_version_returns_none(self, tmp_path: Path):

--- a/tests/test_tree_cache.py
+++ b/tests/test_tree_cache.py
@@ -190,22 +190,6 @@ class TestTreeCacheSkipsHeadCall:
                 is None
             )
 
-    @pytest.mark.xet
-    def test_xet_file_returns_none_when_xet_hash_is_masked(self, tmp_path: Path):
-        storage_folder = tmp_path / repo_folder_name(repo_id="user/repo", repo_type="model")
-        write_tree_cache(str(storage_folder), COMMIT_HASH, _entries_with_masked_xet_hash())
-        assert (
-            _xet_file_metadata_from_tree_cache(
-                tree_cache_folder=str(storage_folder),
-                repo_id="user/repo",
-                repo_type="model",
-                commit_hash=COMMIT_HASH,
-                filename="model.safetensors",
-                endpoint=None,
-            )
-            is None
-        )
-
     def test_no_tree_cache_returns_none(self, tmp_path: Path):  # not populated
         storage_folder = tmp_path / repo_folder_name(repo_id="user/repo", repo_type="model")
         with patch("huggingface_hub.file_download.is_xet_available", return_value=True):

--- a/tests/test_tree_cache.py
+++ b/tests/test_tree_cache.py
@@ -52,6 +52,21 @@ def _entries():
     }
 
 
+MASKED_XET_HASH = "*" * 64
+
+
+def _entries_with_masked_xet_hash():
+    return {
+        "model.safetensors": TreeCacheEntry(
+            size=42,
+            blob_id="blob-model",
+            lfs_sha256="sha256-model",
+            lfs_size=1024,
+            xet_hash=MASKED_XET_HASH,
+        ),
+    }
+
+
 class TestTreeCacheReadWrite:
     def test_round_trip(self, tmp_path: Path):
         write_tree_cache(str(tmp_path), COMMIT_HASH, _entries())
@@ -158,6 +173,43 @@ class TestTreeCacheSkipsHeadCall:
                 )
                 is None
             )
+
+    def test_xet_file_returns_none_when_xet_hash_is_masked(self, tmp_path: Path):
+        storage_folder = tmp_path / repo_folder_name(repo_id="user/repo", repo_type="model")
+        write_tree_cache(str(storage_folder), COMMIT_HASH, _entries_with_masked_xet_hash())
+        with patch("huggingface_hub.file_download.is_xet_available", return_value=True):
+            assert (
+                _xet_file_metadata_from_tree_cache(
+                    tree_cache_folder=str(storage_folder),
+                    repo_id="user/repo",
+                    repo_type="model",
+                    commit_hash=COMMIT_HASH,
+                    filename="model.safetensors",
+                    endpoint=None,
+                )
+                is None
+            )
+
+    def test_get_metadata_heads_when_xet_hash_is_masked(self, tmp_path: Path):
+        storage_folder = tmp_path / repo_folder_name(repo_id="user/repo", repo_type="model")
+        write_tree_cache(str(storage_folder), COMMIT_HASH, _entries_with_masked_xet_hash())
+        with (
+            patch("huggingface_hub.file_download.is_xet_available", return_value=True),
+            patch("huggingface_hub.file_download.get_hf_file_metadata", side_effect=RuntimeError("HEAD called")),
+        ):
+            with pytest.raises(RuntimeError, match="HEAD called"):
+                _get_metadata_or_catch_error(
+                    repo_id="user/repo",
+                    filename="model.safetensors",
+                    repo_type="model",
+                    revision=COMMIT_HASH,
+                    endpoint=None,
+                    etag_timeout=10,
+                    headers={},
+                    token=None,
+                    local_files_only=False,
+                    tree_cache_folder=str(storage_folder),
+                )
 
     def test_no_tree_cache_returns_none(self, tmp_path: Path):  # not populated
         storage_folder = tmp_path / repo_folder_name(repo_id="user/repo", repo_type="model")

--- a/tests/test_tree_cache.py
+++ b/tests/test_tree_cache.py
@@ -37,6 +37,7 @@ from huggingface_hub.utils._xet import XetTokenType, xet_connection_info_refresh
 
 
 COMMIT_HASH = "0123456789abcdef0123456789abcdef01234567"
+VALID_XET_HASH = "63bed80836ee0758c8fd4f8975d59bb0b864263ee2753547c358e8a37cde8758"
 
 
 def _entries():
@@ -47,7 +48,7 @@ def _entries():
             blob_id="blob-model",
             lfs_sha256="sha256-model",
             lfs_size=1024,
-            xet_hash="xet-model",
+            xet_hash=VALID_XET_HASH,
         ),
     }
 
@@ -139,7 +140,7 @@ class TestTreeCacheSkipsHeadCall:
         assert size == 1024  # LFS size
         assert error is None
         assert xet_file_data is not None
-        assert xet_file_data.file_hash == "xet-model"
+        assert xet_file_data.file_hash == VALID_XET_HASH
         assert xet_file_data.refresh_route == xet_connection_info_refresh_url(
             token_type=XetTokenType.READ, repo_id="user/repo", repo_type="model", revision=COMMIT_HASH
         )
@@ -308,7 +309,7 @@ class TestGetCachedRepoTree:
         model = by_path["model.safetensors"]
         assert model.size == 42
         assert model.blob_id == "blob-model"
-        assert model.xet_hash == "xet-model"
+        assert model.xet_hash == VALID_XET_HASH
         assert model.lfs is None
 
     def test_resolves_branch_via_refs(self, tmp_path: Path):

--- a/tests/test_xet_utils.py
+++ b/tests/test_xet_utils.py
@@ -9,12 +9,28 @@ from _pytest.monkeypatch import MonkeyPatch
 from huggingface_hub.utils._xet import (
     XetSessionHolder,
     XetTokenType,
+    is_valid_xet_hash,
     parse_xet_file_data_from_response,
     xet_connection_info_refresh_url,
 )
 
 
 pytestmark = pytest.mark.xet
+
+
+@pytest.mark.parametrize(
+    ("xet_hash", "expected"),
+    [
+        ("63bed80836ee0758c8fd4f8975d59bb0b864263ee2753547c358e8a37cde8758", True),
+        ("63BED80836EE0758C8FD4F8975D59BB0B864263EE2753547C358E8A37CDE8758", True),
+        ("****************************************************************", False),
+        ("", False),
+        ("abc", False),
+        ("g" * 64, False),
+    ],
+)
+def test_is_valid_xet_hash(xet_hash: str, expected: bool) -> None:
+    assert is_valid_xet_hash(xet_hash) is expected
 
 
 def test_parse_valid_headers_file_info() -> None:


### PR DESCRIPTION
## Summary

Fixes [xet-core#895](https://github.com/huggingface/xet-core/issues/895): xet downloads failing with `Unable to parse string as hex hash value (got '****************************************************************')`.

- Root cause: [#4394](https://github.com/huggingface/huggingface_hub/pull/4394) added a tree-listing cache and skips per-file HEAD calls for xet files when metadata can be rebuilt from `/tree`. On gated repos, `/tree` can return a redacted `xetHash` (`64 × '*'`) when the caller lacks content access — the real hash only comes from HEAD (`X-Xet-Hash` on `/resolve`).
- Add `is_valid_xet_hash()` and reject invalid/masked hashes in `_xet_file_metadata_from_tree_cache` → fall back to HEAD instead of passing `'****...'` to hf-xet.
- Add `is_valid_tree_entries()` and enforce it directly in the tree-cache layer: `read_tree_cache` treats invalid/redacted trees as cache misses, while `write_tree_cache` skips them. This keeps `snapshot_download` unchanged and lets newly granted gate access refresh the metadata.

Repro the redacted tree hash:

```bash
curl -s 'https://huggingface.co/api/models/google/translategemma-4b-it/tree/main?recursive=true' \
  | jq '[.[] | select(.xetHash != null) | {path, xetHash}] | .[0]'
# → "xetHash": "****************************************************************"
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted validation on download/cache paths with tests; behavior change is to reject bad cached metadata and retry via HEAD, which is the safe fallback.
> 
> **Overview**
> Fixes Xet downloads failing when the Hub returns a **redacted** `xetHash` (`64 × '*'`) from `/tree` on gated repos without content access—the tree cache was treating that value as real and skipping per-file HEAD, so `hf-xet` tried to parse it as hex.
> 
> Adds **`is_valid_xet_hash()`** (64 hex characters) and uses it in **`_xet_file_metadata_from_tree_cache`** so invalid hashes fall back to HEAD (where `X-Xet-Hash` is correct). **`read_tree_cache`** / **`write_tree_cache`** enforce **`is_valid_tree_entries()`** so redacted listings are never stored or served from cache; after access is granted, a fresh tree can be cached normally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c6b4477284503018916543775dbbbe21dbeaacc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->