### PR TITLE
docs(jobs): mention cost attribution/spending-limit in resource_group_id docs

### DIFF
--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -2419,7 +2419,7 @@ $ hf jobs run [OPTIONS] IMAGE COMMAND...
 * `-d, --detach`: Run the Job in the background and print the Job ID.
 * `--expose INTEGER`: Expose a container port through the jobs proxy. Repeat the flag for multiple ports (e.g. `--expose 8000 --expose 8001`). Each exposed port is reachable on the public jobs domain; access requires an HF token with read access to the job's namespace.
 * `--ssh`: Make the job's container reachable over SSH. Connect with `hf jobs ssh <job_id>`. Requires an SSH public key registered on https://huggingface.co/settings/keys.
-* `--resource-group-id TEXT`: The ID of the resource group to create the Job in. Used to control access to resources within an organization.
+* `--resource-group-id TEXT`: The ID of the resource group to create the Job in. Used to control access to resources within an organization and for cost attribution/spending-limit features.
 * `--namespace TEXT`: The namespace where the job will be running. Defaults to the current user's namespace.
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `--help`: Show this message and exit.
@@ -2635,7 +2635,7 @@ $ hf jobs scheduled run [OPTIONS] SCHEDULE IMAGE COMMAND...
 * `--flavor [cpu-basic|cpu-upgrade|cpu-performance|cpu-xl|t4-small|t4-medium|l4x1|l4x4|l40sx1|l40sx4|l40sx8|a10g-small|a10g-large|a10g-largex2|a10g-largex4|a100-large|a100x4|a100x8|h200|h200x2|h200x4|h200x8|rtx-pro-6000|rtx-pro-6000x2|rtx-pro-6000x4|rtx-pro-6000x8]`: Flavor for the hardware. Run 'hf jobs hardware' to list available flavors. Defaults to `cpu-basic`.
 * `--timeout TEXT`: Max duration: int with s (seconds, default), m (minutes), h (hours) or d (days).
 * `--expose INTEGER`: Expose a container port through the jobs proxy. Repeat the flag for multiple ports (e.g. `--expose 8000 --expose 8001`). Each exposed port is reachable on the public jobs domain; access requires an HF token with read access to the job's namespace.
-* `--resource-group-id TEXT`: The ID of the resource group to create the Job in. Used to control access to resources within an organization.
+* `--resource-group-id TEXT`: The ID of the resource group to create the Job in. Used to control access to resources within an organization and for cost attribution/spending-limit features.
 * `--namespace TEXT`: The namespace where the job will be running. Defaults to the current user's namespace.
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `--help`: Show this message and exit.
@@ -2753,7 +2753,7 @@ $ hf jobs scheduled uv run [OPTIONS] SCHEDULE SCRIPT [SCRIPT_ARGS]...
 * `--secrets-file TEXT`: Read in a file of secret environment variables.
 * `--timeout TEXT`: Max duration: int with s (seconds, default), m (minutes), h (hours) or d (days).
 * `--expose INTEGER`: Expose a container port through the jobs proxy. Repeat the flag for multiple ports (e.g. `--expose 8000 --expose 8001`). Each exposed port is reachable on the public jobs domain; access requires an HF token with read access to the job's namespace.
-* `--resource-group-id TEXT`: The ID of the resource group to create the Job in. Used to control access to resources within an organization.
+* `--resource-group-id TEXT`: The ID of the resource group to create the Job in. Used to control access to resources within an organization and for cost attribution/spending-limit features.
 * `--namespace TEXT`: The namespace where the job will be running. Defaults to the current user's namespace.
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `--with TEXT`: Run with the given packages installed
@@ -2881,7 +2881,7 @@ $ hf jobs uv run [OPTIONS] SCRIPT [SCRIPT_ARGS]...
 * `-d, --detach`: Run the Job in the background and print the Job ID.
 * `--expose INTEGER`: Expose a container port through the jobs proxy. Repeat the flag for multiple ports (e.g. `--expose 8000 --expose 8001`). Each exposed port is reachable on the public jobs domain; access requires an HF token with read access to the job's namespace.
 * `--ssh`: Make the job's container reachable over SSH. Connect with `hf jobs ssh <job_id>`. Requires an SSH public key registered on https://huggingface.co/settings/keys.
-* `--resource-group-id TEXT`: The ID of the resource group to create the Job in. Used to control access to resources within an organization.
+* `--resource-group-id TEXT`: The ID of the resource group to create the Job in. Used to control access to resources within an organization and for cost attribution/spending-limit features.
 * `--namespace TEXT`: The namespace where the job will be running. Defaults to the current user's namespace.
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `--with TEXT`: Run with the given packages installed

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -196,7 +196,7 @@ ResourceGroupIdOpt = Annotated[
     str | None,
     Option(
         "--resource-group-id",
-        help="The ID of the resource group to create the Job in. Used to control access to resources within an organization.",
+        help="The ID of the resource group to create the Job in. Used to control access to resources within an organization and for cost attribution/spending-limit features.",
     ),
 ]
 

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -11933,8 +11933,9 @@ class HfApi:
                 (https://huggingface.co/settings/keys). Defaults to False.
 
             resource_group_id (`str`, *optional*):
-                The ID of the resource group to create the Job in. Resource groups are used to control access to
-                resources within an organization. If not provided, the Job is created outside of any resource group.
+                The ID of the resource group to create the Job in. Used to control access to resources within an
+                organization and for cost attribution/spending-limit features. If not provided, the Job is created
+                outside of any resource group.
 
             namespace (`str`, *optional*):
                 The namespace where the Job will be created. Defaults to the current user's namespace.
@@ -12580,8 +12581,9 @@ class HfApi:
                 (https://huggingface.co/settings/keys). Defaults to False.
 
             resource_group_id (`str`, *optional*):
-                The ID of the resource group to create the Job in. Resource groups are used to control access to
-                resources within an organization. If not provided, the Job is created outside of any resource group.
+                The ID of the resource group to create the Job in. Used to control access to resources within an
+                organization and for cost attribution/spending-limit features. If not provided, the Job is created
+                outside of any resource group.
 
             namespace (`str`, *optional*):
                 The namespace where the Job will be created. Defaults to the current user's namespace.
@@ -12743,9 +12745,9 @@ class HfApi:
                 requires an HF token with read access to the job's namespace.
 
             resource_group_id (`str`, *optional*):
-                The ID of the resource group to create the scheduled Job in. Resource groups are used to control
-                access to resources within an organization. If not provided, the scheduled Job is created outside
-                of any resource group.
+                The ID of the resource group to create the scheduled Job in. Used to control access to resources
+                within an organization and for cost attribution/spending-limit features. If not provided, the
+                scheduled Job is created outside of any resource group.
 
             namespace (`str`, *optional*):
                 The namespace where the Job will be created. Defaults to the current user's namespace.
@@ -13147,9 +13149,9 @@ class HfApi:
                 requires an HF token with read access to the job's namespace.
 
             resource_group_id (`str`, *optional*):
-                The ID of the resource group to create the scheduled Job in. Resource groups are used to control
-                access to resources within an organization. If not provided, the scheduled Job is created outside
-                of any resource group.
+                The ID of the resource group to create the scheduled Job in. Used to control access to resources
+                within an organization and for cost attribution/spending-limit features. If not provided, the
+                scheduled Job is created outside of any resource group.
 
             namespace (`str`, *optional*):
                 The namespace where the Job will be created. Defaults to the current user's namespace.


### PR DESCRIPTION
Follow-up to #4576.

The `resource_group_id` parameter (CLI `--resource-group-id` and `HfApi.run_job` / `run_uv_job` / `create_scheduled_job` / `create_scheduled_uv_job`) scopes not only access control but also **cost attribution** and **per-resource-group spend limits**. #4576 only documented the access-control side; this surfaces the cost/billing side in the same places.

Changes (docstrings / help text only, no behavior change):
- `src/huggingface_hub/cli/jobs.py` — `ResourceGroupIdOpt` help string.
- `src/huggingface_hub/hf_api.py` — 4 docstrings (`run_job`, `run_uv_job`, `create_scheduled_job`, `create_scheduled_uv_job`).
- `docs/source/en/package_reference/cli.md` — regenerated via `utils/generate_cli_reference.py --update` (the 4 `hf jobs` subcommand reference entries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Help text and docstring edits only; no logic, API, or CLI behavior changes.
> 
> **Overview**
> Documentation-only follow-up that expands **`resource_group_id`** / **`--resource-group-id`** descriptions beyond org access control to also call out **cost attribution** and **per-resource-group spending limits**.
> 
> The same wording is applied in **`ResourceGroupIdOpt`** (`cli/jobs.py`), four **`HfApi`** job-creation docstrings (`run_job`, `run_uv_job`, `create_scheduled_job`, `create_scheduled_uv_job`), and the regenerated **`cli.md`** entries for the four `hf jobs` subcommands that expose the flag. **No runtime or API behavior changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fbf6a646851846768a0718a3195a575560bb91d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->