### PR TITLE
[Docs] Add Turkish documentation foundation

### DIFF
--- a/.github/workflows/build_documentation.yaml
+++ b/.github/workflows/build_documentation.yaml
@@ -13,6 +13,6 @@ jobs:
     with:
       commit_sha: ${{ github.sha }}
       package: huggingface_hub
-      languages: cn de fr en hi ko or ta
+      languages: cn de fr en hi ko or ta tr
     secrets:
       hf_token: ${{ secrets.HF_DOC_BUILD_PUSH }}

--- a/.github/workflows/build_pr_documentation.yaml
+++ b/.github/workflows/build_pr_documentation.yaml
@@ -14,4 +14,4 @@ jobs:
       commit_sha: ${{ github.event.pull_request.head.sha }}
       pr_number: ${{ github.event.number }}
       package: huggingface_hub
-      languages: cn de fr en hi ko or ta
+      languages: cn de fr en hi ko or ta tr

--- a/docs/source/tr/_toctree.yml
+++ b/docs/source/tr/_toctree.yml
@@ -1,0 +1,6 @@
+- title: "Başlangıç"
+  sections:
+    - local: index
+      title: Ana sayfa
+    - local: installation
+      title: Kurulum

--- a/docs/source/tr/index.md
+++ b/docs/source/tr/index.md
@@ -1,0 +1,62 @@
+<!--⚠️ Bu dosya Markdown biçiminde olsa da dokümantasyon oluşturucumuza özgü söz dizimi içerir (MDX'e benzer).
+Bu nedenle Markdown görüntüleyicinizde düzgün işlenmeyebilir.
+-->
+
+# 🤗 Hub istemci kütüphanesi
+
+`huggingface_hub` kütüphanesi; içerik üretenlerin ve birlikte çalışanların buluştuğu bir
+makine öğrenmesi platformu olan [Hugging Face Hub](https://hf.co) ile etkileşim kurmanızı
+sağlar. Projeleriniz için önceden eğitilmiş modelleri ve veri kümelerini keşfedebilir veya
+Hub'da barındırılan yüzlerce makine öğrenmesi uygulamasını deneyebilirsiniz. Kendi model
+ve veri kümelerinizi oluşturup toplulukla da paylaşabilirsiniz. `huggingface_hub`
+kütüphanesi, tüm bunları Python ile yapmanın kolay bir yolunu sunar.
+
+`huggingface_hub` kütüphanesini hemen kullanmaya başlamak için [hızlı başlangıç
+rehberini](quick-start) okuyun. Hub'dan nasıl dosya indireceğinizi, depo oluşturacağınızı
+ve Hub'a dosya yükleyeceğinizi öğreneceksiniz. 🤗 Hub'daki depolarınızı nasıl
+yöneteceğinizi, tartışmalara nasıl katılacağınızı ve hatta nasıl çıkarım çalıştıracağınızı
+öğrenmek için okumaya devam edin.
+
+<div class="mt-10">
+  <div class="w-full flex flex-col space-y-4 md:space-y-0 md:grid md:grid-cols-2 md:gap-y-4 md:gap-x-5">
+
+    <a class="!no-underline border dark:border-gray-700 p-5 rounded-lg shadow hover:shadow-lg" href="./guides/overview">
+      <div class="w-full text-center bg-gradient-to-br from-indigo-400 to-indigo-500 rounded-lg py-1.5 font-semibold mb-5 text-white text-lg leading-relaxed">Nasıl yapılır rehberleri</div>
+      <p class="text-gray-700">Belirli bir hedefe ulaşmanıza yardımcı olacak uygulamalı rehberler. Gerçek dünya problemlerini huggingface_hub ile nasıl çözebileceğinizi öğrenmek için bu rehberlere göz atın.</p>
+    </a>
+
+    <a class="!no-underline border dark:border-gray-700 p-5 rounded-lg shadow hover:shadow-lg" href="./package_reference/overview">
+      <div class="w-full text-center bg-gradient-to-br from-purple-400 to-purple-500 rounded-lg py-1.5 font-semibold mb-5 text-white text-lg leading-relaxed">Referans</div>
+      <p class="text-gray-700">huggingface_hub sınıfları ve metotlarının kapsamlı teknik açıklaması.</p>
+    </a>
+
+    <a class="!no-underline border dark:border-gray-700 p-5 rounded-lg shadow hover:shadow-lg" href="./concepts/git_vs_http">
+      <div class="w-full text-center bg-gradient-to-br from-pink-400 to-pink-500 rounded-lg py-1.5 font-semibold mb-5 text-white text-lg leading-relaxed">Kavramsal rehberler</div>
+      <p class="text-gray-700">huggingface_hub yaklaşımını daha iyi anlamanıza yardımcı olacak üst düzey açıklamalar.</p>
+    </a>
+
+  </div>
+</div>
+
+<!--
+<a class="!no-underline border dark:border-gray-700 p-5 rounded-lg shadow hover:shadow-lg" href="./tutorials/overview"
+  ><div class="w-full text-center bg-gradient-to-br from-blue-400 to-blue-500 rounded-lg py-1.5 font-semibold mb-5 text-white text-lg leading-relaxed">Eğitimler</div>
+  <p class="text-gray-700">Temel bilgileri öğrenin ve 🤗 Hub ile programlı olarak etkileşim kurmak için huggingface_hub kullanımına alışın!</p>
+</a> -->
+
+## Katkıda bulunun
+
+`huggingface_hub` projesine yapılan her katkıyı memnuniyetle karşılıyor ve eşit derecede
+önemsiyoruz! 🤗 Koddaki mevcut sorunları gidermenin veya yeni özellikler eklemenin yanı
+sıra dokümantasyonun doğru ve güncel kalmasına yardımcı olabilir, issue sayfalarındaki
+soruları yanıtlayabilir ve kütüphaneyi geliştireceğini düşündüğünüz yeni özellikleri
+talep edebilirsiniz. Yeni bir issue ya da özellik talebi oluşturmayı, pull request
+göndermeyi ve her şeyin beklendiği gibi çalıştığından emin olmak için katkılarınızı test
+etmeyi öğrenmek üzere [katkı
+rehberine](https://github.com/huggingface/huggingface_hub/blob/main/CONTRIBUTING.md) göz
+atın.
+
+Herkes için kapsayıcı, sıcak ve iş birliğine açık bir ortam oluşturabilmek adına katkıda
+bulunanların [davranış
+kurallarımıza](https://github.com/huggingface/huggingface_hub/blob/main/CODE_OF_CONDUCT.md)
+saygı göstermesi gerekir.

--- a/docs/source/tr/installation.md
+++ b/docs/source/tr/installation.md
@@ -1,0 +1,192 @@
+<!--⚠️ Bu dosya Markdown biçiminde olsa da dokümantasyon oluşturucumuza özgü söz dizimi içerir (MDX'e benzer).
+Bu nedenle Markdown görüntüleyicinizde düzgün işlenmeyebilir.
+-->
+
+# Kurulum
+
+Başlamadan önce uygun paketleri yükleyerek ortamınızı hazırlamanız gerekir.
+
+`huggingface_hub`, **Python 3.10+** sürümlerinde test edilir.
+
+## pip ile kurulum
+
+`huggingface_hub` kütüphanesini bir [sanal
+ortama](https://docs.python.org/3/library/venv.html) kurmanız önemle tavsiye edilir.
+Python sanal ortamlarına aşina değilseniz bu [rehbere](https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/)
+göz atın. Sanal ortam; farklı projeleri yönetmeyi kolaylaştırır ve bağımlılıklar
+arasındaki uyumluluk sorunlarını önler.
+
+İlk olarak proje dizininizde bir sanal ortam oluşturun:
+
+```bash
+python -m venv .venv
+```
+
+Sanal ortamı etkinleştirin. Linux ve macOS'ta:
+
+```bash
+source .venv/bin/activate
+```
+
+Windows'ta:
+
+```bash
+.venv/Scripts/activate
+```
+
+Artık `huggingface_hub` kütüphanesini [PyPI kayıt
+sisteminden](https://pypi.org/project/huggingface-hub/) yüklemeye hazırsınız:
+
+```bash
+pip install --upgrade huggingface_hub
+```
+
+İşlem tamamlandığında kurulumun doğru çalıştığını [kontrol edin](#check-installation).
+
+### İsteğe bağlı bağımlılıkları yükleme
+
+`huggingface_hub` kütüphanesinin bazı bağımlılıkları
+[isteğe bağlıdır](https://setuptools.pypa.io/en/latest/userguide/dependency_management.html#optional-dependencies);
+çünkü kütüphanenin temel özelliklerini çalıştırmak için bunlara ihtiyaç duyulmaz. Ancak
+isteğe bağlı bağımlılıklar kurulmazsa bazı `huggingface_hub` özellikleri kullanılamayabilir.
+
+İsteğe bağlı bağımlılıkları `pip` ile yükleyebilirsiniz:
+
+```bash
+# Install dependencies for both torch-specific and MCP-specific features.
+pip install 'huggingface_hub[mcp,torch]'
+```
+
+`huggingface_hub` içindeki isteğe bağlı bağımlılıklar şunlardır:
+
+- `fastai`, `torch`: framework'e özgü özellikleri çalıştırmak için gereken bağımlılıklar.
+- `dev`: kütüphaneye katkıda bulunmak için gereken bağımlılıklar. Testleri çalıştırmak
+  için `testing`, tür denetleyicisini çalıştırmak için `typing` ve linter'ları çalıştırmak
+  için `quality` bağımlılıklarını içerir.
+
+### Kaynak koddan kurulum
+
+Bazı durumlarda `huggingface_hub` kütüphanesini doğrudan kaynak koddan kurmak
+isteyebilirsiniz. Böylece en son kararlı sürüm yerine en güncel `main` sürümünü
+kullanabilirsiniz. Örneğin bir hata son resmi sürümden sonra giderilmiş ancak henüz yeni
+bir sürüm yayımlanmamışsa `main` sürümü güncel gelişmeleri takip etmek için yararlıdır.
+
+Ancak bu, `main` sürümünün her zaman kararlı olmayabileceği anlamına gelir. `main`
+sürümünü çalışır durumda tutmaya özen gösteriyoruz ve çoğu sorun genellikle birkaç saat
+veya bir gün içinde çözülüyor. Bir sorunla karşılaşırsanız daha hızlı çözebilmemiz için
+lütfen bir issue açın!
+
+```bash
+pip install git+https://github.com/huggingface/huggingface_hub
+```
+
+Kaynak koddan kurulum yaparken belirli bir dalı da seçebilirsiniz. Bu seçenek, henüz
+birleştirilmemiş yeni bir özelliği veya hata düzeltmesini test etmek istediğinizde
+yararlıdır:
+
+```bash
+pip install git+https://github.com/huggingface/huggingface_hub@my-feature-branch
+```
+
+İşlem tamamlandığında kurulumun doğru çalıştığını [kontrol edin](#check-installation).
+
+### Düzenlenebilir kurulum
+
+Kaynak koddan kurulum, [düzenlenebilir bir
+kurulum](https://pip.pypa.io/en/stable/topics/local-project-installs/#editable-installs)
+oluşturmanıza da olanak tanır. `huggingface_hub` projesine katkıda bulunmayı ve kod
+değişikliklerini test etmeyi planlıyorsanız bu daha gelişmiş kurulum yöntemini
+kullanabilirsiniz. Bunun için `huggingface_hub` deposunun yerel bir kopyasını
+bilgisayarınıza klonlamanız gerekir.
+
+```bash
+# First, clone repo locally
+git clone https://github.com/huggingface/huggingface_hub.git
+
+# Then, install with -e flag
+cd huggingface_hub
+pip install -e .
+```
+
+Bu komutlar, klonladığınız klasörü Python kütüphane yollarınıza bağlar. Python bundan
+sonra normal kütüphane yollarının yanı sıra klonladığınız klasörün içine de bakar.
+Örneğin Python paketleriniz genellikle `./.venv/lib/python3.13/site-packages/` dizinine
+kuruluyorsa Python, klonladığınız `./huggingface_hub/` klasöründe de arama yapar.
+
+## Hugging Face CLI aracını yükleme
+
+Python ortamınıza dokunmadan `hf` CLI aracını kurmak için tek satırlık yükleyicilerimizi kullanın.
+
+macOS ve Linux'ta:
+
+```bash
+curl -LsSf https://hf.co/cli/install.sh | bash
+```
+
+Windows'ta:
+
+```powershell
+powershell -ExecutionPolicy ByPass -c "irm https://hf.co/cli/install.ps1 | iex"
+```
+
+Mevcut bir kurulumu yükseltmek için `hf update` komutunu çalıştırın. Bu komut `hf`
+kurulum yöntemini (bağımsız kurucu, Homebrew veya pip) algılar ve uygun komutu çalıştırır.
+
+## conda ile kurulum
+
+conda'yı daha iyi biliyorsanız `huggingface_hub` kütüphanesini [conda-forge
+kanalını](https://anaconda.org/conda-forge/huggingface_hub) kullanarak yükleyebilirsiniz:
+
+```bash
+conda install -c conda-forge huggingface_hub
+```
+
+İşlem tamamlandığında kurulumun doğru çalıştığını [kontrol edin](#check-installation).
+
+## Kurulumu kontrol etme [[check-installation]]
+
+Kurulumdan sonra aşağıdaki komutu çalıştırarak `huggingface_hub` kütüphanesinin düzgün
+çalıştığını kontrol edin:
+
+```bash
+python -c "from huggingface_hub import model_info; print(model_info('gpt2'))"
+```
+
+Bu komut, [gpt2](https://huggingface.co/gpt2) modeli hakkındaki bilgileri Hub'dan alır.
+Çıktı aşağıdakine benzer:
+
+```text
+Model Name: gpt2
+Tags: ['pytorch', 'tf', 'jax', 'tflite', 'rust', 'safetensors', 'gpt2', 'text-generation', 'en', 'doi:10.57967/hf/0039', 'transformers', 'exbert', 'license:mit', 'has_space']
+Task: text-generation
+```
+
+## Windows sınırlamaları
+
+Makine öğrenmesini her yerde erişilebilir kılma hedefimiz doğrultusunda `huggingface_hub`
+kütüphanesini platformlar arası çalışacak, özellikle hem Unix tabanlı sistemlerde hem de
+Windows'ta düzgün çalışacak biçimde geliştirdik. Ancak
+`huggingface_hub` Windows'ta çalıştırıldığında bazı sınırlamalara sahiptir. Bilinen
+sorunların tam listesini aşağıda bulabilirsiniz. Belgelenmemiş bir sorunla
+karşılaşırsanız [GitHub'da bir issue
+açarak](https://github.com/huggingface/huggingface_hub/issues/new/choose) lütfen bize
+bildirin.
+
+- `huggingface_hub` önbellek sistemi, Hub'dan indirilen dosyaları verimli biçimde
+  önbelleğe almak için sembolik bağlantılardan yararlanır. Windows'ta sembolik
+  bağlantıları etkinleştirmek için geliştirici modunu açmanız veya betiğinizi yönetici
+  olarak çalıştırmanız gerekir. Bunlar etkin değilse önbellek sistemi çalışmaya devam
+  eder ancak daha az verimli olur. Ayrıntılı bilgi için
+  [önbellek sınırlamaları](./guides/manage-cache#limitations) bölümünü okuyun.
+- Hub'daki dosya yollarında özel karakterler bulunabilir (örneğin
+  `"path/to?/my/file"`). Windows'un [özel
+  karakterler](https://learn.microsoft.com/en-us/windows/win32/intl/character-sets-used-in-file-names)
+  konusundaki daha katı kuralları bu dosyaların indirilmesini engeller. Neyse ki bu
+  durumla nadiren karşılaşılır. Bunun bir hata olduğunu düşünüyorsanız depo sahibiyle
+  veya bir çözüm bulabilmemiz için bizimle iletişime geçin.
+
+## Sonraki adımlar
+
+`huggingface_hub` bilgisayarınıza düzgün biçimde kurulduktan sonra başlangıç için [ortam
+değişkenlerini yapılandırabilir](package_reference/environment_variables) veya
+[rehberlerimizden birine](guides/overview) göz atabilirsiniz.


### PR DESCRIPTION
## Summary

- add the initial Turkish documentation scaffold and navigation
- translate the landing page and installation guide into Turkish
- register `tr` in both documentation build workflows
- preserve links, code blocks, commands, and the `check-installation` anchor

Part of #4592.

@Wauplin @stevhliu, could you please review this initial Turkish documentation contribution?

## Testing

- `doc-builder build huggingface_hub docs/source/tr --language tr`
- rendered both pages with the local doc-builder preview
- checked all active links and English fallback targets
- verified the translated `check-installation` anchor in a browser
- `make style`
- `make quality` passes through all formatting, lint, and generation checks; the final `ty check src` reports two pre-existing `invalid-type-form` diagnostics in the unchanged `src/huggingface_hub/cli/_output.py` with `ty 0.0.64`

## AI assistance

AI assistance was used for drafting and technical validation. The Turkish text, terminology, links, code blocks, and Turkish characters were manually reviewed before submission.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no impact on library behavior or security-sensitive code.
> 
> **Overview**
> Adds **Turkish (`tr`)** as a documentation locale for `huggingface_hub`.
> 
> CI for main and PR doc builds now includes `tr` in the `languages` list. A new `docs/source/tr/` tree provides a **Başlangıç** section with Turkish **Ana sayfa** (`index.md`) and **Kurulum** (`installation.md`), following the same doc-builder patterns as other locales (MDX-style markup, internal links to guides/reference, preserved `#check-installation` anchor).
> 
> No runtime or API changes—documentation and workflow configuration only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e65446c7a343f2351d33577eeaf8ce8aa748fb3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->