### PR TITLE
[Safetensors] Fix truncated header on 100kb boundary

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -6905,8 +6905,8 @@ class HfApi:
         # 2. Parse and validate metadata size using shared helper
         metadata_size = _get_safetensors_metadata_size(response.content[:8], filename, context_msg)
 
-        # 3.a. Get metadata from payload
-        if metadata_size <= 100000:
+        # 3.a. Get metadata from payload, if fully contained in the response (minus the 8-byte size prefix)
+        if metadata_size <= len(response.content) - 8:
             metadata_as_bytes = response.content[8 : 8 + metadata_size]
         else:  # 3.b. Request full metadata
             response = get_session().get(

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2592,6 +2592,19 @@ class TestHfApiPublicProduction:
         assert tensor.parameter_count == 4096
         assert info.parameter_count == {"BF16": 989888512}
 
+    def test_parse_safetensors_metadata_100kb_header(self, api: HfApi) -> None:
+        """Regression test for https://github.com/huggingface/huggingface_hub/issues/4602.
+
+        This file has a header of exactly 100_000 bytes, which used to be truncated: HTTP ranges are
+        inclusive, so `bytes=0-100000` only returns 99_993 header bytes after the 8-byte size prefix.
+        """
+        info = api.parse_safetensors_file_metadata(
+            "nvidia/GLM-5-NVFP4",
+            "model-00008-of-00282.safetensors",
+            revision="dc54ff55a7e9e71b85db953d8bc22eca894b44c6",
+        )
+        assert len(info.tensors) == 852
+
     def test_not_a_safetensors_file(self, api: HfApi) -> None:
         with pytest.raises(SafetensorsParsingError):
             api.parse_safetensors_file_metadata("HuggingFaceH4/zephyr-7b-beta", "pytorch_model-00001-of-00008.bin")


### PR DESCRIPTION
Fixes #4602.

## Summary

- `parse_safetensors_file_metadata` requests `bytes=0-100000`. HTTP byte ranges are **inclusive**, so the response holds 100001 bytes = the 8-byte size prefix + only **99993** header bytes. But the code then checked `metadata_size <= 100000` before slicing `content[8 : 8 + metadata_size]` — so headers of 99994..100000 bytes were silently truncated and failed with `header is not json-encoded string`.
- Fix is one line: compare `metadata_size` against the bytes actually received (`len(response.content) - 8`) so those sizes fall through to the second GET, which already fetches the exact range. Kept the initial request at `bytes=0-100000` — the 100kb prefetch size is arbitrary anyway, so fetching 100kb-8bytes worth of header is fine.

Thanks @joe0731 for the very precise report — root cause was spot on.

## Reproduction

The reporter's shard has a header of exactly 100000 bytes:

```
$ python -c '...get(url, headers={"range": "bytes=0-100000"})...'
status 206  content-range bytes 0-100000/1507691856
len(content) 100001
metadata_size 100000
available after prefix 99993   # <-- 7 bytes short
```

Before:

```
$ python -c 'from huggingface_hub import HfApi; HfApi().parse_safetensors_file_metadata("nvidia/GLM-5-NVFP4", "model-00008-of-00282.safetensors", revision="dc54ff55a7e9e71b85db953d8bc22eca894b44c6")'
huggingface_hub.errors.SafetensorsParsingError: Failed to parse safetensors header for 'model-00008-of-00282.safetensors' (repo 'nvidia/GLM-5-NVFP4', revision 'dc54ff55a7e9e71b85db953d8bc22eca894b44c6'): header is not json-encoded string. Please make sure this is a correctly formatted safetensors file.
```

After:

```
model-00008-of-00282.safetensors -> 852 tensors
```

## Tests

Added a production regression test against that exact file, pinned to a commit revision. Checked it actually pins the bug: with the old `metadata_size <= 100000` line restored it raises `SafetensorsParsingError`, and passes with the fix. All safetensors tests pass:

```
$ pytest tests/test_hf_api.py -k "safetensors or Safetensors" -q
7 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to remote safetensors header fetching logic with a targeted regression test; no auth, security, or broad API surface impact.
> 
> **Overview**
> Fixes **`parse_safetensors_file_metadata`** failing on safetensors shards whose JSON header is at the edge of the 100KB prefetch (e.g. exactly 100,000 bytes), which surfaced as `SafetensorsParsingError: header is not json-encoded string` ([#4602](https://github.com/huggingface/huggingface_hub/issues/4602)).
> 
> After the initial ranged GET, the code no longer assumes a full 100KB of header is present when `metadata_size` is ≤ 100,000. It checks whether the **actual** response body (minus the 8-byte length prefix) contains the full header: `metadata_size <= len(response.content) - 8`. If not, it takes the existing second ranged request instead of slicing a truncated buffer.
> 
> Adds a production regression test against `nvidia/GLM-5-NVFP4` (`model-00008-of-00282.safetensors`) expecting **852** tensors parsed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43012f6754963028af5dffe5baed0cd0ca11a25a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->