### PR TITLE
[Download] Add HfApi.resolve_revision and ResolvedRevision

### DIFF
--- a/docs/source/en/guides/manage-cache.md
+++ b/docs/source/en/guides/manage-cache.md
@@ -210,16 +210,16 @@ by setting the `HF_HUB_DISABLE_SYMLINKS_WARNING` environment variable to true.
 
 When a library downloads several files one by one, each call has to resolve `revision="main"` into a commit hash again. This costs one HTTP call per file and, worse, two calls made a few seconds apart can land on two different commits if the repo is updated in between.
 
-[`HfApi.resolve_revision`] resolves the revision once and returns a [`RevisionStr`]:
+[`HfApi.resolve_revision`] resolves the revision once and returns a [`ResolvedRevision`]:
 
 ```py
 >>> from huggingface_hub import resolve_revision
 >>> revision = resolve_revision("openai-community/gpt2")
 >>> revision
-RevisionStr(initial=None, resolved='607a30d783dfa663caf39e06633721c8d4cfcd7e')
+ResolvedRevision(initial=None, resolved='607a30d783dfa663caf39e06633721c8d4cfcd7e')
 ```
 
-[`RevisionStr`] is a `str` subclass, so it can be passed to any `huggingface_hub` method taking a `revision` argument. Its string value is what the user initially requested (`"main"` here, hence readable error messages), while `.resolved` holds the commit hash:
+[`ResolvedRevision`] is a `str` subclass, so it can be passed to any `huggingface_hub` method taking a `revision` argument. Its string value is what the user initially requested (`"main"` here, hence readable error messages), while `.resolved` holds the commit hash:
 
 ```py
 >>> revision == "main"
@@ -228,7 +228,7 @@ True
 '607a30d783dfa663caf39e06633721c8d4cfcd7e'
 ```
 
-Download helpers ([`hf_hub_download`], [`snapshot_download`], [`get_cached_repo_tree`], [`file_exists`]) detect a [`RevisionStr`] and use the commit hash directly. Every file is guaranteed to come from the same commit, and once the files are cached no HTTP call is needed at all:
+Download helpers ([`hf_hub_download`], [`snapshot_download`], [`get_cached_repo_tree`], [`file_exists`]) detect a [`ResolvedRevision`] and use the commit hash directly. Every file is guaranteed to come from the same commit, and once the files are cached no HTTP call is needed at all:
 
 ```py
 >>> from huggingface_hub import hf_hub_download

--- a/docs/source/en/guides/manage-cache.md
+++ b/docs/source/en/guides/manage-cache.md
@@ -206,14 +206,9 @@ by setting the `HF_HUB_DISABLE_SYMLINKS_WARNING` environment variable to true.
 ## Pin a revision (advanced)
 
 > [!TIP]
-> If you are integrating the Hub in an ML library, a single [`snapshot_download`] call is still the recommended
-> approach: it resolves the revision once, downloads everything in parallel and caches the file listing. What
-> follows is only useful for complex libraries that download and load many components separately (config,
-> weights, tokenizer, processor, adapters, ...) and cannot use a single call.
+> If you are integrating the Hub in an ML library, a single [`snapshot_download`] call is still the recommended approach: it resolves the revision once, downloads everything in parallel and caches the file listing. What follows is only useful for complex libraries that download and load many components separately (config, weights, tokenizer, processor, adapters, ...) and cannot use a single call.
 
-When a library downloads several files one by one, each call has to resolve `revision="main"` into a commit hash
-again. This costs one HTTP call per file and, worse, two calls made a few seconds apart can land on two different
-commits if the repo is updated in between.
+When a library downloads several files one by one, each call has to resolve `revision="main"` into a commit hash again. This costs one HTTP call per file and, worse, two calls made a few seconds apart can land on two different commits if the repo is updated in between.
 
 [`HfApi.resolve_revision`] resolves the revision once and returns a [`RevisionStr`]:
 
@@ -225,9 +220,7 @@ commits if the repo is updated in between.
 RevisionStr(initial=None, resolved='607a30d783dfa663caf39e06633721c8d4cfcd7e')
 ```
 
-[`RevisionStr`] is a `str` subclass, so it can be passed to any `huggingface_hub` method taking a `revision`
-argument. Its string value is what the user initially requested (`"main"` here, hence readable error messages),
-while `.resolved` holds the commit hash:
+[`RevisionStr`] is a `str` subclass, so it can be passed to any `huggingface_hub` method taking a `revision` argument. Its string value is what the user initially requested (`"main"` here, hence readable error messages), while `.resolved` holds the commit hash:
 
 ```py
 >>> revision == "main"
@@ -236,19 +229,14 @@ True
 '607a30d783dfa663caf39e06633721c8d4cfcd7e'
 ```
 
-Download helpers ([`hf_hub_download`], [`snapshot_download`], [`get_cached_repo_tree`], [`file_exists`]) detect a
-[`RevisionStr`] and use the commit hash directly. Every file is guaranteed to come from the same commit, and once
-the files are cached no HTTP call is needed at all:
+Download helpers ([`hf_hub_download`], [`snapshot_download`], [`get_cached_repo_tree`], [`file_exists`]) detect a [`RevisionStr`] and use the commit hash directly. Every file is guaranteed to come from the same commit, and once the files are cached no HTTP call is needed at all:
 
 ```py
 >>> config = hf_hub_download("openai-community/gpt2", "config.json", revision=revision)
 >>> weights = hf_hub_download("openai-community/gpt2", "model.safetensors", revision=revision)
 ```
 
-The `revision` -> `commit hash` mapping is also written to the `refs/` folder of the cache (see [Refs](#refs)).
-This means that if the Hub cannot be reached later on (offline mode, connection error, timeout, Hub downtime),
-[`HfApi.resolve_revision`] transparently falls back to the cached value. If nothing is cached either, a
-[`~errors.RevisionResolutionError`] is raised.
+The `revision` -> `commit hash` mapping is also written to the `refs/` folder of the cache (see [Refs](#refs)). This means that if the Hub cannot be reached later on (offline mode, connection error, timeout, Hub downtime), [`HfApi.resolve_revision`] transparently falls back to the cached value. If nothing is cached either, a [`~errors.RevisionResolutionError`] is raised.
 
 ## Chunk-based caching (Xet)
 

--- a/docs/source/en/guides/manage-cache.md
+++ b/docs/source/en/guides/manage-cache.md
@@ -228,7 +228,7 @@ True
 '607a30d783dfa663caf39e06633721c8d4cfcd7e'
 ```
 
-Download helpers ([`hf_hub_download`], [`snapshot_download`], [`get_cached_repo_tree`], [`file_exists`]) detect a [`ResolvedRevision`] and use the commit hash directly. Every file is guaranteed to come from the same commit, and once the files are cached no HTTP call is needed at all:
+Download helpers ([`hf_hub_download`], [`snapshot_download`], [`get_cached_repo_tree`]) detect a [`ResolvedRevision`] and use the commit hash directly. Every file is guaranteed to come from the same commit, and once the files are cached no HTTP call is needed at all:
 
 ```py
 >>> from huggingface_hub import hf_hub_download

--- a/docs/source/en/guides/manage-cache.md
+++ b/docs/source/en/guides/manage-cache.md
@@ -213,9 +213,8 @@ When a library downloads several files one by one, each call has to resolve `rev
 [`HfApi.resolve_revision`] resolves the revision once and returns a [`RevisionStr`]:
 
 ```py
->>> from huggingface_hub import HfApi, hf_hub_download
->>> api = HfApi()
->>> revision = api.resolve_revision("openai-community/gpt2")
+>>> from huggingface_hub import resolve_revision
+>>> revision = resolve_revision("openai-community/gpt2")
 >>> revision
 RevisionStr(initial=None, resolved='607a30d783dfa663caf39e06633721c8d4cfcd7e')
 ```
@@ -232,6 +231,7 @@ True
 Download helpers ([`hf_hub_download`], [`snapshot_download`], [`get_cached_repo_tree`], [`file_exists`]) detect a [`RevisionStr`] and use the commit hash directly. Every file is guaranteed to come from the same commit, and once the files are cached no HTTP call is needed at all:
 
 ```py
+>>> from huggingface_hub import hf_hub_download
 >>> config = hf_hub_download("openai-community/gpt2", "config.json", revision=revision)
 >>> weights = hf_hub_download("openai-community/gpt2", "model.safetensors", revision=revision)
 ```

--- a/docs/source/en/guides/manage-cache.md
+++ b/docs/source/en/guides/manage-cache.md
@@ -236,9 +236,9 @@ True
 '607a30d783dfa663caf39e06633721c8d4cfcd7e'
 ```
 
-Download helpers ([`hf_hub_download`], [`snapshot_download`], [`get_cached_repo_tree`]) detect a [`RevisionStr`]
-and use the commit hash directly. Every file is guaranteed to come from the same commit, and once the files are
-cached no HTTP call is needed at all:
+Download helpers ([`hf_hub_download`], [`snapshot_download`], [`get_cached_repo_tree`], [`file_exists`]) detect a
+[`RevisionStr`] and use the commit hash directly. Every file is guaranteed to come from the same commit, and once
+the files are cached no HTTP call is needed at all:
 
 ```py
 >>> config = hf_hub_download("openai-community/gpt2", "config.json", revision=revision)

--- a/docs/source/en/guides/manage-cache.md
+++ b/docs/source/en/guides/manage-cache.md
@@ -203,6 +203,53 @@ When symlinks are not supported, a warning message is displayed to the user to a
 them they are using a degraded version of the cache-system. This warning can be disabled
 by setting the `HF_HUB_DISABLE_SYMLINKS_WARNING` environment variable to true.
 
+## Pin a revision (advanced)
+
+> [!TIP]
+> If you are integrating the Hub in an ML library, a single [`snapshot_download`] call is still the recommended
+> approach: it resolves the revision once, downloads everything in parallel and caches the file listing. What
+> follows is only useful for complex libraries that download and load many components separately (config,
+> weights, tokenizer, processor, adapters, ...) and cannot use a single call.
+
+When a library downloads several files one by one, each call has to resolve `revision="main"` into a commit hash
+again. This costs one HTTP call per file and, worse, two calls made a few seconds apart can land on two different
+commits if the repo is updated in between.
+
+[`HfApi.resolve_revision`] resolves the revision once and returns a [`RevisionStr`]:
+
+```py
+>>> from huggingface_hub import HfApi, hf_hub_download
+>>> api = HfApi()
+>>> revision = api.resolve_revision("openai-community/gpt2")
+>>> revision
+RevisionStr(initial=None, resolved='607a30d783dfa663caf39e06633721c8d4cfcd7e')
+```
+
+[`RevisionStr`] is a `str` subclass, so it can be passed to any `huggingface_hub` method taking a `revision`
+argument. Its string value is what the user initially requested (`"main"` here, hence readable error messages),
+while `.resolved` holds the commit hash:
+
+```py
+>>> revision == "main"
+True
+>>> revision.resolved
+'607a30d783dfa663caf39e06633721c8d4cfcd7e'
+```
+
+Download helpers ([`hf_hub_download`], [`snapshot_download`], [`get_cached_repo_tree`]) detect a [`RevisionStr`]
+and use the commit hash directly. Every file is guaranteed to come from the same commit, and once the files are
+cached no HTTP call is needed at all:
+
+```py
+>>> config = hf_hub_download("openai-community/gpt2", "config.json", revision=revision)
+>>> weights = hf_hub_download("openai-community/gpt2", "model.safetensors", revision=revision)
+```
+
+The `revision` -> `commit hash` mapping is also written to the `refs/` folder of the cache (see [Refs](#refs)).
+This means that if the Hub cannot be reached later on (offline mode, connection error, timeout, Hub downtime),
+[`HfApi.resolve_revision`] transparently falls back to the cached value. If nothing is cached either, a
+[`~errors.RevisionResolutionError`] is raised.
+
 ## Chunk-based caching (Xet)
 
 To provide more efficient file transfers, `hf_xet` adds a `xet` directory to the existing `huggingface_hub` cache, creating additional caching layer to enable chunk-based deduplication. This cache holds chunks (immutable byte ranges of files ~64KB in size) and shards (a data structure that maps files to chunks). For more information on the Xet Storage system, see this [section](https://huggingface.co/docs/hub/xet/index).

--- a/docs/source/en/package_reference/file_download.md
+++ b/docs/source/en/package_reference/file_download.md
@@ -24,8 +24,7 @@ rendered properly in your Markdown viewer.
 
 ## Resolve a revision
 
-Resolve a branch/tag name to a commit hash once, then pass the result around to pin every download to the same
-commit. See [`HfApi.resolve_revision`] and the [cache-system guide](../guides/manage-cache#pin-a-revision-advanced).
+Resolve a branch/tag name to a commit hash once, then pass the result around to pin every download to the same commit. See [`HfApi.resolve_revision`] and the [cache-system guide](../guides/manage-cache#pin-a-revision-advanced).
 
 ### RevisionStr
 

--- a/docs/source/en/package_reference/file_download.md
+++ b/docs/source/en/package_reference/file_download.md
@@ -22,6 +22,15 @@ rendered properly in your Markdown viewer.
 
 [[autodoc]] huggingface_hub.get_cached_repo_tree
 
+## Resolve a revision
+
+Resolve a branch/tag name to a commit hash once, then pass the result around to pin every download to the same
+commit. See [`HfApi.resolve_revision`] and the [cache-system guide](../guides/manage-cache#pin-a-revision-advanced).
+
+### RevisionStr
+
+[[autodoc]] huggingface_hub.RevisionStr
+
 ## Get metadata about a file
 
 ### get_hf_file_metadata

--- a/docs/source/en/package_reference/file_download.md
+++ b/docs/source/en/package_reference/file_download.md
@@ -26,9 +26,9 @@ rendered properly in your Markdown viewer.
 
 Resolve a branch/tag name to a commit hash once, then pass the result around to pin every download to the same commit. See [`HfApi.resolve_revision`] and the [cache-system guide](../guides/manage-cache#pin-a-revision-advanced).
 
-### RevisionStr
+### ResolvedRevision
 
-[[autodoc]] huggingface_hub.RevisionStr
+[[autodoc]] huggingface_hub.ResolvedRevision
 
 ## Get metadata about a file
 

--- a/docs/source/en/package_reference/utilities.md
+++ b/docs/source/en/package_reference/utilities.md
@@ -213,6 +213,10 @@ user as possible.
 
 [[autodoc]] huggingface_hub.errors.RevisionNotFoundError
 
+#### RevisionResolutionError
+
+[[autodoc]] huggingface_hub.errors.RevisionResolutionError
+
 #### BadRequestError
 
 [[autodoc]] huggingface_hub.errors.BadRequestError

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -103,7 +103,7 @@ _SUBMOD_ATTRS = {
         "parse_huggingface_oauth",
     ],
     "_revision": [
-        "RevisionStr",
+        "ResolvedRevision",
     ],
     "_sandbox": [
         "Sandbox",
@@ -827,7 +827,7 @@ __all__ = [
     "RepoFolder",
     "RepoStorageInfo",
     "RepoUrl",
-    "RevisionStr",
+    "ResolvedRevision",
     "Sandbox",
     "SandboxCommandResult",
     "SandboxPool",
@@ -1300,7 +1300,7 @@ if TYPE_CHECKING:  # pragma: no cover
         attach_huggingface_oauth,  # noqa: F401
         parse_huggingface_oauth,  # noqa: F401
     )
-    from ._revision import RevisionStr  # noqa: F401
+    from ._revision import ResolvedRevision  # noqa: F401
     from ._sandbox import (
         Sandbox,  # noqa: F401
         SandboxCommandResult,  # noqa: F401

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -102,6 +102,9 @@ _SUBMOD_ATTRS = {
         "attach_huggingface_oauth",
         "parse_huggingface_oauth",
     ],
+    "_revision": [
+        "RevisionStr",
+    ],
     "_sandbox": [
         "Sandbox",
         "SandboxCommandResult",
@@ -333,6 +336,7 @@ _SUBMOD_ATTRS = {
         "repo_type_and_id_from_hf_id",
         "request_space_hardware",
         "request_space_storage",
+        "resolve_revision",
         "restart_space",
         "resume_inference_endpoint",
         "resume_scheduled_job",
@@ -823,6 +827,7 @@ __all__ = [
     "RepoFolder",
     "RepoStorageInfo",
     "RepoUrl",
+    "RevisionStr",
     "Sandbox",
     "SandboxCommandResult",
     "SandboxPool",
@@ -1098,6 +1103,7 @@ __all__ = [
     "repo_type_and_id_from_hf_id",
     "request_space_hardware",
     "request_space_storage",
+    "resolve_revision",
     "restart_space",
     "resume_inference_endpoint",
     "resume_scheduled_job",
@@ -1294,6 +1300,7 @@ if TYPE_CHECKING:  # pragma: no cover
         attach_huggingface_oauth,  # noqa: F401
         parse_huggingface_oauth,  # noqa: F401
     )
+    from ._revision import RevisionStr  # noqa: F401
     from ._sandbox import (
         Sandbox,  # noqa: F401
         SandboxCommandResult,  # noqa: F401
@@ -1523,6 +1530,7 @@ if TYPE_CHECKING:  # pragma: no cover
         repo_type_and_id_from_hf_id,  # noqa: F401
         request_space_hardware,  # noqa: F401
         request_space_storage,  # noqa: F401
+        resolve_revision,  # noqa: F401
         restart_space,  # noqa: F401
         resume_inference_endpoint,  # noqa: F401
         resume_scheduled_job,  # noqa: F401

--- a/src/huggingface_hub/_revision.py
+++ b/src/huggingface_hub/_revision.py
@@ -41,7 +41,3 @@ class ResolvedRevision(str):
 
     def __repr__(self) -> str:
         return f"ResolvedRevision(initial={self.initial!r}, resolved={self.resolved!r})"
-
-    def __reduce__(self):
-        # Default `str` reduction would drop `initial`/`resolved` when pickling or deep-copying.
-        return (ResolvedRevision, (self.resolved, self.initial))

--- a/src/huggingface_hub/_revision.py
+++ b/src/huggingface_hub/_revision.py
@@ -19,8 +19,8 @@ class RevisionStr(str):
 
     Example:
     ```python
-    >>> from huggingface_hub import HfApi
-    >>> revision = HfApi().resolve_revision("gpt2")
+    >>> from huggingface_hub import resolve_revision
+    >>> revision = resolve_revision("openai-community/gpt2")
     >>> revision
     RevisionStr(initial=None, resolved='607a30d783dfa663caf39e06633721c8d4cfcd7e')
     >>> revision == "main"  # it's a string

--- a/src/huggingface_hub/_revision.py
+++ b/src/huggingface_hub/_revision.py
@@ -1,10 +1,10 @@
 from . import constants
 
 
-class RevisionStr(str):
+class ResolvedRevision(str):
     """A git revision that has already been resolved to a commit hash.
 
-    `RevisionStr` is a `str` subclass, so it can be passed to any `huggingface_hub` method taking a `revision`
+    `ResolvedRevision` is a `str` subclass, so it can be passed to any `huggingface_hub` method taking a `revision`
     argument. Its string value is the revision initially requested by the user (e.g. `"main"`, `"refs/pr/4"`),
     which keeps URLs and error messages readable, while `.resolved` holds the commit hash it points to.
 
@@ -22,7 +22,7 @@ class RevisionStr(str):
     >>> from huggingface_hub import resolve_revision
     >>> revision = resolve_revision("openai-community/gpt2")
     >>> revision
-    RevisionStr(initial=None, resolved='607a30d783dfa663caf39e06633721c8d4cfcd7e')
+    ResolvedRevision(initial=None, resolved='607a30d783dfa663caf39e06633721c8d4cfcd7e')
     >>> revision == "main"  # it's a string
     True
     >>> revision.resolved
@@ -33,15 +33,15 @@ class RevisionStr(str):
     initial: str | None
     resolved: str
 
-    def __new__(cls, resolved: str, initial: str | None = None) -> "RevisionStr":
+    def __new__(cls, resolved: str, initial: str | None = None) -> "ResolvedRevision":
         revision = super().__new__(cls, initial if initial is not None else constants.DEFAULT_REVISION)
         revision.initial = initial
         revision.resolved = resolved
         return revision
 
     def __repr__(self) -> str:
-        return f"RevisionStr(initial={self.initial!r}, resolved={self.resolved!r})"
+        return f"ResolvedRevision(initial={self.initial!r}, resolved={self.resolved!r})"
 
     def __reduce__(self):
         # Default `str` reduction would drop `initial`/`resolved` when pickling or deep-copying.
-        return (RevisionStr, (self.resolved, self.initial))
+        return (ResolvedRevision, (self.resolved, self.initial))

--- a/src/huggingface_hub/_revision.py
+++ b/src/huggingface_hub/_revision.py
@@ -1,0 +1,47 @@
+from . import constants
+
+
+class RevisionStr(str):
+    """A git revision that has already been resolved to a commit hash.
+
+    `RevisionStr` is a `str` subclass, so it can be passed to any `huggingface_hub` method taking a `revision`
+    argument. Its string value is the revision initially requested by the user (e.g. `"main"`, `"refs/pr/4"`),
+    which keeps URLs and error messages readable, while `.resolved` holds the commit hash it points to.
+
+    Instances are built by [`HfApi.resolve_revision`], which also caches the `revision` -> `commit hash` mapping
+    in the local cache (`refs/` folder).
+
+    Attributes:
+        initial (`str` or `None`):
+            The revision initially requested by the user. If `None`, the string value defaults to `"main"`.
+        resolved (`str`):
+            The commit hash that `initial` resolves to.
+
+    Example:
+    ```python
+    >>> from huggingface_hub import HfApi
+    >>> revision = HfApi().resolve_revision("gpt2")
+    >>> revision
+    RevisionStr(initial=None, resolved='607a30d783dfa663caf39e06633721c8d4cfcd7e')
+    >>> revision == "main"  # it's a string
+    True
+    >>> revision.resolved
+    '607a30d783dfa663caf39e06633721c8d4cfcd7e'
+    ```
+    """
+
+    initial: str | None
+    resolved: str
+
+    def __new__(cls, resolved: str, initial: str | None = None) -> "RevisionStr":
+        revision = super().__new__(cls, initial if initial is not None else constants.DEFAULT_REVISION)
+        revision.initial = initial
+        revision.resolved = resolved
+        return revision
+
+    def __repr__(self) -> str:
+        return f"RevisionStr(initial={self.initial!r}, resolved={self.resolved!r})"
+
+    def __reduce__(self):
+        # Default `str` reduction would drop `initial`/`resolved` when pickling or deep-copying.
+        return (RevisionStr, (self.resolved, self.initial))

--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -6,6 +6,7 @@ import httpx
 from tqdm.auto import tqdm as base_tqdm
 
 from . import constants
+from ._revision import RevisionStr
 from ._tree_cache import TreeCacheEntry, read_tree_cache, tree_cache_folder_for_local_dir, write_tree_cache
 from .errors import (
     CachedRepoTreeNotFoundError,
@@ -18,7 +19,7 @@ from .errors import (
     RevisionNotFoundError,
 )
 from .file_download import REGEX_COMMIT_HASH, DryRunFileInfo, hf_hub_download, repo_folder_name
-from .hf_api import DatasetInfo, HfApi, KernelInfo, ModelInfo, RepoFile, SpaceInfo
+from .hf_api import HfApi, RepoFile
 from .utils import OfflineModeIsEnabled, filter_repo_objects, logging, validate_hf_hub_args
 from .utils._xet_progress_reporting import (
     XET_BYTES_BAR_FORMAT,
@@ -249,13 +250,38 @@ def snapshot_download(
         token=token,
     )
 
-    repo_info: ModelInfo | DatasetInfo | SpaceInfo | KernelInfo | None = None
+    commit_hash: str | None = None
+    if isinstance(revision, RevisionStr):
+        # Revision has already been resolved to a commit hash (see [`HfApi.resolve_revision`]) => no need to ask
+        # the Hub again. Keep the initial revision as a string for the `refs/` entry and the error messages.
+        commit_hash = revision.resolved
+        revision = str(revision)
+
+    # If the commit hash is already known, the tree listing might be cached on disk => no network call at all.
+    tree_entries = read_tree_cache(tree_cache_folder, commit_hash) if commit_hash is not None else None
+
     api_call_error: Exception | None = None
-    if not local_files_only:
+    if tree_entries is None and not local_files_only:
         # try/except logic to handle different errors => taken from `hf_hub_download`
         try:
             # if we have internet connection we want to list files to download
-            repo_info = api.repo_info(repo_id=repo_id, repo_type=repo_type, revision=revision)
+            if commit_hash is None:
+                repo_info = api.repo_info(repo_id=repo_id, repo_type=repo_type, revision=revision)
+                assert repo_info.sha is not None, "Repo info returned from server must have a revision sha."
+                commit_hash = repo_info.sha
+            tree_entries = {
+                f.path: TreeCacheEntry(
+                    size=f.size,
+                    blob_id=f.blob_id,
+                    lfs_sha256=f.lfs.sha256 if f.lfs is not None else None,
+                    lfs_size=f.lfs.size if f.lfs is not None else None,
+                    xet_hash=f.xet_hash,
+                )
+                for f in api.list_repo_tree(repo_id=repo_id, recursive=True, revision=commit_hash, repo_type=repo_type)
+                if isinstance(f, RepoFile)
+            }
+            if not dry_run:
+                write_tree_cache(tree_cache_folder, commit_hash, tree_entries)
         except httpx.ProxyError:
             # Actually raise on proxy error
             raise
@@ -277,7 +303,7 @@ def snapshot_download(
             api_call_error = error
             pass
 
-    # At this stage, if `repo_info` is None it means either:
+    # At this stage, if we couldn't reach the Hub it means either:
     # - internet connection is down
     # - internet connection is deactivated (local_files_only=True or HF_HUB_OFFLINE=True)
     # - repo is private/gated and invalid/missing token sent
@@ -286,22 +312,22 @@ def snapshot_download(
     #    - if the specified revision is a commit hash, look inside "snapshots".
     #    - f the specified revision is a branch or tag, look inside "refs".
     # => if local_dir is not None, we will return the path to the local folder if it exists.
-    if repo_info is None:
+    if local_files_only or api_call_error is not None:
         if dry_run:
             raise DryRunError(
                 "Dry run cannot be performed as the repository cannot be accessed. Please check your internet connection or authentication token."
             ) from api_call_error
 
         # Try to get which commit hash corresponds to the specified revision
-        commit_hash = None
-        if REGEX_COMMIT_HASH.match(revision):
-            commit_hash = revision
-        else:
-            ref_path = os.path.join(storage_folder, "refs", revision)
-            if os.path.exists(ref_path):
-                # retrieve commit_hash from refs file
-                with open(ref_path) as f:
-                    commit_hash = f.read()
+        if commit_hash is None:
+            if REGEX_COMMIT_HASH.match(revision):
+                commit_hash = revision
+            else:
+                ref_path = os.path.join(storage_folder, "refs", revision)
+                if os.path.exists(ref_path):
+                    # retrieve commit_hash from refs file
+                    with open(ref_path) as f:
+                        commit_hash = f.read()
 
         # Try to locate snapshot folder for this commit hash
         if commit_hash is not None and local_dir is None:
@@ -367,27 +393,9 @@ def snapshot_download(
                 " and try again."
             ) from api_call_error
 
-    # At this stage, internet connection is up and running
+    # At this stage, the commit hash and the tree listing are known
     # => let's download the files!
-    assert repo_info.sha is not None, "Repo info returned from server must have a revision sha."
-    commit_hash = repo_info.sha
-
-    # Retrieve /tree listing from cache or fetch it
-    tree_entries = read_tree_cache(tree_cache_folder, commit_hash)
-    if tree_entries is None:
-        tree_entries = {
-            f.path: TreeCacheEntry(
-                size=f.size,
-                blob_id=f.blob_id,
-                lfs_sha256=f.lfs.sha256 if f.lfs is not None else None,
-                lfs_size=f.lfs.size if f.lfs is not None else None,
-                xet_hash=f.xet_hash,
-            )
-            for f in api.list_repo_tree(repo_id=repo_id, recursive=True, revision=commit_hash, repo_type=repo_type)
-            if isinstance(f, RepoFile)
-        }
-        if not dry_run:
-            write_tree_cache(tree_cache_folder, commit_hash, tree_entries)
+    assert commit_hash is not None and tree_entries is not None
 
     filtered_repo_files = list(
         filter_repo_objects(
@@ -643,7 +651,9 @@ def get_cached_repo_tree(
 
     # The tree cache is keyed by commit hash. Resolve the revision to a commit hash: either it already is one,
     # or it's a branch/tag name recorded in `refs/` by a previous download.
-    if REGEX_COMMIT_HASH.match(revision):
+    if isinstance(revision, RevisionStr):
+        commit_hash = revision.resolved
+    elif REGEX_COMMIT_HASH.match(revision):
         commit_hash = revision
     else:
         ref_path = os.path.join(storage_folder, "refs", revision)

--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -411,8 +411,7 @@ def snapshot_download(
     snapshot_folder = os.path.join(storage_folder, "snapshots", commit_hash)
     # if passed revision is not identical to commit_hash
     # then revision has to be a branch name or tag name.
-    # In that case store a ref. Nothing to do for an already resolved revision: the ref has been written by
-    # `resolve_revision` and the pinned commit hash might be older than the one currently cached.
+    # In that case store a ref (except if ResolvedRevision, in which case it's already done).
     if not isinstance(revision, ResolvedRevision) and revision != commit_hash:
         ref_path = os.path.join(storage_folder, "refs", revision)
         try:

--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -251,9 +251,7 @@ def snapshot_download(
     )
 
     # The revision is already a commit hash if:
-    # - it's a `ResolvedRevision` (already resolved, see [`HfApi.resolve_revision`]). `revision` itself is kept as is:
-    #   its string value is the revision initially requested, which is what we want for the `refs/` entry and the
-    #   error messages.
+    # - it's a `ResolvedRevision` (already resolved, see [`HfApi.resolve_revision`])
     # - it's a commit hash, which is immutable
     # => in both cases, there is nothing to resolve and the `repo_info` call can be skipped.
     commit_hash: str | None = None

--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -253,9 +253,9 @@ def snapshot_download(
     commit_hash: str | None = None
     if isinstance(revision, RevisionStr):
         # Revision has already been resolved to a commit hash (see [`HfApi.resolve_revision`]) => no need to ask
-        # the Hub again. Keep the initial revision as a string for the `refs/` entry and the error messages.
+        # the Hub again. `revision` is kept as is: its string value is the initial revision, which is what we want
+        # for the local paths and the error messages.
         commit_hash = revision.resolved
-        revision = str(revision)
 
     # If the commit hash is already known, the tree listing might be cached on disk => no network call at all.
     tree_entries = read_tree_cache(tree_cache_folder, commit_hash) if commit_hash is not None else None
@@ -411,8 +411,9 @@ def snapshot_download(
     snapshot_folder = os.path.join(storage_folder, "snapshots", commit_hash)
     # if passed revision is not identical to commit_hash
     # then revision has to be a branch name or tag name.
-    # In that case store a ref.
-    if revision != commit_hash:
+    # In that case store a ref. Nothing to do for an already resolved revision: the ref has been written by
+    # `resolve_revision` and the pinned commit hash might be older than the one currently cached.
+    if not isinstance(revision, RevisionStr) and revision != commit_hash:
         ref_path = os.path.join(storage_folder, "refs", revision)
         try:
             os.makedirs(os.path.dirname(ref_path), exist_ok=True)

--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -250,38 +250,26 @@ def snapshot_download(
         token=token,
     )
 
+    # The revision is already a commit hash if:
+    # - it's a `RevisionStr` (already resolved, see [`HfApi.resolve_revision`]). `revision` itself is kept as is:
+    #   its string value is the revision initially requested, which is what we want for the `refs/` entry and the
+    #   error messages.
+    # - it's a commit hash, which is immutable
+    # => in both cases, there is nothing to resolve and the `repo_info` call can be skipped.
     commit_hash: str | None = None
     if isinstance(revision, RevisionStr):
-        # Revision has already been resolved to a commit hash (see [`HfApi.resolve_revision`]) => no need to ask
-        # the Hub again. `revision` is kept as is: its string value is the initial revision, which is what we want
-        # for the local paths and the error messages.
         commit_hash = revision.resolved
-
-    # If the commit hash is already known, the tree listing might be cached on disk => no network call at all.
-    tree_entries = read_tree_cache(tree_cache_folder, commit_hash) if commit_hash is not None else None
+    elif REGEX_COMMIT_HASH.match(revision):
+        commit_hash = revision
 
     api_call_error: Exception | None = None
-    if tree_entries is None and not local_files_only:
+    if commit_hash is None and not local_files_only:
         # try/except logic to handle different errors => taken from `hf_hub_download`
         try:
             # if we have internet connection we want to list files to download
-            if commit_hash is None:
-                repo_info = api.repo_info(repo_id=repo_id, repo_type=repo_type, revision=revision)
-                assert repo_info.sha is not None, "Repo info returned from server must have a revision sha."
-                commit_hash = repo_info.sha
-            tree_entries = {
-                f.path: TreeCacheEntry(
-                    size=f.size,
-                    blob_id=f.blob_id,
-                    lfs_sha256=f.lfs.sha256 if f.lfs is not None else None,
-                    lfs_size=f.lfs.size if f.lfs is not None else None,
-                    xet_hash=f.xet_hash,
-                )
-                for f in api.list_repo_tree(repo_id=repo_id, recursive=True, revision=commit_hash, repo_type=repo_type)
-                if isinstance(f, RepoFile)
-            }
-            if not dry_run:
-                write_tree_cache(tree_cache_folder, commit_hash, tree_entries)
+            repo_info = api.repo_info(repo_id=repo_id, repo_type=repo_type, revision=revision)
+            assert repo_info.sha is not None, "Repo info returned from server must have a revision sha."
+            commit_hash = repo_info.sha
         except httpx.ProxyError:
             # Actually raise on proxy error
             raise
@@ -303,7 +291,7 @@ def snapshot_download(
             api_call_error = error
             pass
 
-    # At this stage, if we couldn't reach the Hub it means either:
+    # At this stage, if the commit hash is unknown it means either:
     # - internet connection is down
     # - internet connection is deactivated (local_files_only=True or HF_HUB_OFFLINE=True)
     # - repo is private/gated and invalid/missing token sent
@@ -312,7 +300,7 @@ def snapshot_download(
     #    - if the specified revision is a commit hash, look inside "snapshots".
     #    - f the specified revision is a branch or tag, look inside "refs".
     # => if local_dir is not None, we will return the path to the local folder if it exists.
-    if local_files_only or api_call_error is not None:
+    if commit_hash is None or local_files_only:
         if dry_run:
             raise DryRunError(
                 "Dry run cannot be performed as the repository cannot be accessed. Please check your internet connection or authentication token."
@@ -320,14 +308,11 @@ def snapshot_download(
 
         # Try to get which commit hash corresponds to the specified revision
         if commit_hash is None:
-            if REGEX_COMMIT_HASH.match(revision):
-                commit_hash = revision
-            else:
-                ref_path = os.path.join(storage_folder, "refs", revision)
-                if os.path.exists(ref_path):
-                    # retrieve commit_hash from refs file
-                    with open(ref_path) as f:
-                        commit_hash = f.read()
+            ref_path = os.path.join(storage_folder, "refs", revision)
+            if os.path.exists(ref_path):
+                # retrieve commit_hash from refs file
+                with open(ref_path) as f:
+                    commit_hash = f.read()
 
         # Try to locate snapshot folder for this commit hash
         if commit_hash is not None and local_dir is None:
@@ -393,9 +378,26 @@ def snapshot_download(
                 " and try again."
             ) from api_call_error
 
-    # At this stage, the commit hash and the tree listing are known
+    # At this stage, the commit hash is known and internet connection is up and running
     # => let's download the files!
-    assert commit_hash is not None and tree_entries is not None
+    assert commit_hash is not None
+
+    # Retrieve /tree listing from cache or fetch it
+    tree_entries = read_tree_cache(tree_cache_folder, commit_hash)
+    if tree_entries is None:
+        tree_entries = {
+            f.path: TreeCacheEntry(
+                size=f.size,
+                blob_id=f.blob_id,
+                lfs_sha256=f.lfs.sha256 if f.lfs is not None else None,
+                lfs_size=f.lfs.size if f.lfs is not None else None,
+                xet_hash=f.xet_hash,
+            )
+            for f in api.list_repo_tree(repo_id=repo_id, recursive=True, revision=commit_hash, repo_type=repo_type)
+            if isinstance(f, RepoFile)
+        }
+        if not dry_run:
+            write_tree_cache(tree_cache_folder, commit_hash, tree_entries)
 
     filtered_repo_files = list(
         filter_repo_objects(

--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -6,7 +6,7 @@ import httpx
 from tqdm.auto import tqdm as base_tqdm
 
 from . import constants
-from ._revision import RevisionStr
+from ._revision import ResolvedRevision
 from ._tree_cache import TreeCacheEntry, read_tree_cache, tree_cache_folder_for_local_dir, write_tree_cache
 from .errors import (
     CachedRepoTreeNotFoundError,
@@ -251,13 +251,13 @@ def snapshot_download(
     )
 
     # The revision is already a commit hash if:
-    # - it's a `RevisionStr` (already resolved, see [`HfApi.resolve_revision`]). `revision` itself is kept as is:
+    # - it's a `ResolvedRevision` (already resolved, see [`HfApi.resolve_revision`]). `revision` itself is kept as is:
     #   its string value is the revision initially requested, which is what we want for the `refs/` entry and the
     #   error messages.
     # - it's a commit hash, which is immutable
     # => in both cases, there is nothing to resolve and the `repo_info` call can be skipped.
     commit_hash: str | None = None
-    if isinstance(revision, RevisionStr):
+    if isinstance(revision, ResolvedRevision):
         commit_hash = revision.resolved
     elif REGEX_COMMIT_HASH.match(revision):
         commit_hash = revision
@@ -415,7 +415,7 @@ def snapshot_download(
     # then revision has to be a branch name or tag name.
     # In that case store a ref. Nothing to do for an already resolved revision: the ref has been written by
     # `resolve_revision` and the pinned commit hash might be older than the one currently cached.
-    if not isinstance(revision, RevisionStr) and revision != commit_hash:
+    if not isinstance(revision, ResolvedRevision) and revision != commit_hash:
         ref_path = os.path.join(storage_folder, "refs", revision)
         try:
             os.makedirs(os.path.dirname(ref_path), exist_ok=True)
@@ -654,7 +654,7 @@ def get_cached_repo_tree(
 
     # The tree cache is keyed by commit hash. Resolve the revision to a commit hash: either it already is one,
     # or it's a branch/tag name recorded in `refs/` by a previous download.
-    if isinstance(revision, RevisionStr):
+    if isinstance(revision, ResolvedRevision):
         commit_hash = revision.resolved
     elif REGEX_COMMIT_HASH.match(revision):
         commit_hash = revision

--- a/src/huggingface_hub/errors.py
+++ b/src/huggingface_hub/errors.py
@@ -398,6 +398,14 @@ class RevisionNotFoundError(HfHubHTTPError):
     repo_type: str | None = None
 
 
+class RevisionResolutionError(Exception):
+    """
+    Raised by [`HfApi.resolve_revision`] when a revision cannot be resolved to a commit hash: the Hub could not be
+    reached (offline mode, connection error, timeout, Hub downtime, ...) and no matching entry was found in the
+    local cache.
+    """
+
+
 # ENTRY ERRORS
 class EntryNotFoundError(Exception):
     """

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -23,7 +23,7 @@ from ._local_folder import (
     read_download_metadata,
     write_download_metadata,
 )
-from ._revision import RevisionStr
+from ._revision import ResolvedRevision
 from ._tree_cache import read_tree_cache, tree_cache_folder_for_local_dir
 from .errors import (
     FileMetadataError,
@@ -961,7 +961,7 @@ def hf_hub_download(
 
     if revision is None:
         revision = constants.DEFAULT_REVISION
-    elif isinstance(revision, RevisionStr):
+    elif isinstance(revision, ResolvedRevision):
         # Revision has already been resolved to a commit hash (see [`HfApi.resolve_revision`]) => use it directly.
         # This pins the download to an immutable commit and lets us skip network calls when it's already cached.
         revision = revision.resolved

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -23,6 +23,7 @@ from ._local_folder import (
     read_download_metadata,
     write_download_metadata,
 )
+from ._revision import RevisionStr
 from ._tree_cache import read_tree_cache, tree_cache_folder_for_local_dir
 from .errors import (
     FileMetadataError,
@@ -960,6 +961,10 @@ def hf_hub_download(
 
     if revision is None:
         revision = constants.DEFAULT_REVISION
+    elif isinstance(revision, RevisionStr):
+        # Revision has already been resolved to a commit hash (see [`HfApi.resolve_revision`]) => use it directly.
+        # This pins the download to an immutable commit and lets us skip network calls when it's already cached.
+        revision = revision.resolved
 
     if cache_dir is None:
         cache_dir = constants.HF_HUB_CACHE

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -3708,9 +3708,8 @@ class HfApi:
 
         Example:
             ```py
-            >>> from huggingface_hub import HfApi, hf_hub_download
-            >>> api = HfApi()
-            >>> revision = api.resolve_revision("openai-community/gpt2")
+            >>> from huggingface_hub import hf_hub_download, resolve_revision
+            >>> revision = resolve_revision("openai-community/gpt2")
             >>> revision
             ResolvedRevision(initial=None, resolved='607a30d783dfa663caf39e06633721c8d4cfcd7e')
 
@@ -3907,10 +3906,6 @@ class HfApi:
             False
             ```
         """
-        if isinstance(revision, ResolvedRevision):
-            # Revision has already been resolved to a commit hash (see [`resolve_revision`]) => use it directly.
-            # Whether a file exists is fully determined by the commit hash, so the answer is the same.
-            revision = revision.resolved
         url = hf_hub_url(
             repo_id=repo_id, repo_type=repo_type, revision=revision, filename=filename, endpoint=self.endpoint
         )

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -79,6 +79,7 @@ from ._jobs_api import (
     _default_job_name_from_script,
     _derive_job_volume_name,
 )
+from ._revision import RevisionStr
 from ._space_api import (
     INTERMEDIATE_SPACE_STAGES,
     SpaceHardware,
@@ -108,11 +109,21 @@ from .errors import (
     HfHubHTTPError,
     HfUriError,
     LocalTokenNotFoundError,
+    OfflineModeIsEnabled,
     RemoteEntryNotFoundError,
     RepositoryNotFoundError,
     RevisionNotFoundError,
+    RevisionResolutionError,
 )
-from .file_download import DryRunFileInfo, HfFileMetadata, get_hf_file_metadata, hf_hub_url
+from .file_download import (
+    REGEX_COMMIT_HASH,
+    DryRunFileInfo,
+    HfFileMetadata,
+    _cache_commit_hash_for_specific_revision,
+    get_hf_file_metadata,
+    hf_hub_url,
+    repo_folder_name,
+)
 from .repocard_data import DatasetCardData, ModelCardData, SpaceCardData
 from .utils import (
     DEFAULT_IGNORE_PATTERNS,
@@ -3637,6 +3648,125 @@ class HfApi:
             expand=expand,  # type: ignore
             files_metadata=files_metadata,
         )
+
+    @validate_hf_hub_args
+    def resolve_revision(
+        self,
+        repo_id: str,
+        *,
+        repo_type: str | None = None,
+        revision: str | None = None,
+        cache_dir: str | Path | None = None,
+        local_files_only: bool = False,
+        token: bool | str | None = None,
+    ) -> RevisionStr:
+        """Resolve a revision (branch, tag, PR ref) to a commit hash.
+
+        This is meant for libraries that download and load several components of a repo separately (config,
+        weights, tokenizer, ...). Resolving the revision once and passing the returned [`RevisionStr`] around
+        guarantees that every subsequent call targets the exact same commit, even if the repo is updated in the
+        meantime. It also saves HTTP calls, as downloads made with a commit hash can be served from the local
+        cache without contacting the Hub.
+
+        The `revision` -> `commit hash` mapping is cached on disk (in the `refs/` folder of the cache), on a
+        best-effort basis. If the Hub cannot be reached later on (offline mode, connection error, timeout, Hub
+        downtime, ...), the cached value is used as a fallback.
+
+        > [!TIP]
+        > If you only need to download a full repo snapshot, a single [`snapshot_download`] call is enough and
+        > already does the right thing. `resolve_revision` is only useful when downloading files separately.
+
+        Args:
+            repo_id (`str`):
+                A user or an organization name and a repo name separated by a `/`.
+            repo_type (`str`, *optional*):
+                Set to `"dataset"`, `"space"` or `"kernel"` if the repo is a dataset, space or kernel repo,
+                `None` or `"model"` if it is a model. Default is `None`.
+            revision (`str`, *optional*):
+                The revision to resolve. Can be a branch name, a tag, a PR ref or a commit hash. Defaults to the
+                default branch. If a [`RevisionStr`] is passed, it is returned as is.
+            cache_dir (`str`, `Path`, *optional*):
+                Path to the folder where cached files are stored. Defaults to the value of `HF_HUB_CACHE`.
+            local_files_only (`bool`, *optional*, defaults to `False`):
+                If `True`, resolve the revision from the local cache only, without contacting the Hub.
+            token (`bool` or `str`, *optional*):
+                A valid user access token (string). Defaults to the locally saved token, which is the recommended
+                method for authentication (see https://huggingface.co/docs/huggingface_hub/quick-start#authentication).
+                To disable authentication, pass `False`.
+
+        Returns:
+            [`RevisionStr`]: A `str` subclass holding both the requested revision and the commit hash it resolves to.
+
+        Raises:
+            [`~errors.RevisionResolutionError`]
+                If the revision cannot be resolved: the Hub could not be reached and nothing is cached locally.
+            [`~errors.RevisionNotFoundError`]
+                If the revision does not exist on the Hub.
+            [`~errors.RepositoryNotFoundError`]
+                If the repository cannot be found. This may be because it doesn't exist, or because it is set to
+                `private` and you do not have access.
+
+        Example:
+            ```py
+            >>> from huggingface_hub import HfApi, hf_hub_download
+            >>> api = HfApi()
+            >>> revision = api.resolve_revision("openai-community/gpt2")
+            >>> revision
+            RevisionStr(initial=None, resolved='607a30d783dfa663caf39e06633721c8d4cfcd7e')
+
+            # Pass it around: every download is pinned to the same commit
+            >>> config = hf_hub_download("openai-community/gpt2", "config.json", revision=revision)
+            >>> weights = hf_hub_download("openai-community/gpt2", "model.safetensors", revision=revision)
+            ```
+        """
+        if isinstance(revision, RevisionStr):
+            return revision
+        if revision is not None and REGEX_COMMIT_HASH.match(revision):
+            return RevisionStr(resolved=revision, initial=revision)
+
+        if repo_type is None:
+            repo_type = constants.REPO_TYPE_MODEL
+        if cache_dir is None:
+            cache_dir = constants.HF_HUB_CACHE
+        storage_folder = str(
+            Path(cache_dir).expanduser().resolve() / repo_folder_name(repo_id=repo_id, repo_type=repo_type)
+        )
+
+        error: Exception | None = None
+        if not local_files_only:
+            try:
+                sha = self.repo_info(repo_id=repo_id, repo_type=repo_type, revision=revision, token=token).sha
+                assert sha is not None, "Repo info returned from server must have a revision sha."
+                try:  # best-effort caching, e.g. cache folder might be read-only
+                    _cache_commit_hash_for_specific_revision(
+                        storage_folder, revision or constants.DEFAULT_REVISION, sha
+                    )
+                except OSError as e:
+                    logger.warning(f"Ignored error while caching commit hash for '{repo_id}': {e}.")
+                return RevisionStr(resolved=sha, initial=revision)
+            except (httpx.TransportError, OfflineModeIsEnabled) as e:
+                # Hub cannot be reached (offline mode, connection error, timeout, ...) => fallback on cache
+                error = e
+            except HfHubHTTPError as e:
+                if e.response.status_code < 500:
+                    raise  # the Hub answered: repo/revision not found, missing permissions, ... => raise as is
+                error = e  # Hub is down => fallback on cache
+
+        ref_path = Path(storage_folder) / "refs" / (revision or constants.DEFAULT_REVISION)
+        if ref_path.is_file():
+            if error is not None:
+                logger.warning(f"Could not reach the Hub ({error}). Using cached commit hash for '{repo_id}'.")
+            return RevisionStr(resolved=ref_path.read_text().strip(), initial=revision)
+
+        reason = (
+            "'local_files_only=True' is set"
+            if error is None
+            else f"the Hub could not be reached ({error.__class__.__name__}: {error})"
+        )
+        raise RevisionResolutionError(
+            f"Cannot resolve revision '{revision or constants.DEFAULT_REVISION}' for {repo_type} '{repo_id}':"
+            f" {reason} and no matching entry was found in the local cache ('{ref_path}')."
+        ) from error
 
     @validate_hf_hub_args
     def repo_exists(
@@ -14921,6 +15051,7 @@ repo_exists = api.repo_exists
 revision_exists = api.revision_exists
 file_exists = api.file_exists
 repo_info = api.repo_info
+resolve_revision = api.resolve_revision
 list_repo_files = api.list_repo_files
 list_repo_refs = api.list_repo_refs
 list_repo_commits = api.list_repo_commits

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -3744,6 +3744,9 @@ class HfApi:
                 except OSError as e:
                     logger.warning(f"Ignored error while caching commit hash for '{repo_id}': {e}.")
                 return RevisionStr(resolved=sha, initial=revision)
+            except httpx.ProxyError:
+                # Actually raise on proxy error: a misconfigured proxy is not an unreachable Hub
+                raise
             except (httpx.TransportError, OfflineModeIsEnabled) as e:
                 # Hub cannot be reached (offline mode, connection error, timeout, ...) => fallback on cache
                 error = e

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -79,7 +79,7 @@ from ._jobs_api import (
     _default_job_name_from_script,
     _derive_job_volume_name,
 )
-from ._revision import RevisionStr
+from ._revision import ResolvedRevision
 from ._space_api import (
     INTERMEDIATE_SPACE_STAGES,
     SpaceHardware,
@@ -3659,11 +3659,11 @@ class HfApi:
         cache_dir: str | Path | None = None,
         local_files_only: bool = False,
         token: bool | str | None = None,
-    ) -> RevisionStr:
+    ) -> ResolvedRevision:
         """Resolve a revision (branch, tag, PR ref) to a commit hash.
 
         This is meant for libraries that download and load several components of a repo separately (config,
-        weights, tokenizer, ...). Resolving the revision once and passing the returned [`RevisionStr`] around
+        weights, tokenizer, ...). Resolving the revision once and passing the returned [`ResolvedRevision`] around
         guarantees that every subsequent call targets the exact same commit, even if the repo is updated in the
         meantime. It also saves HTTP calls, as downloads made with a commit hash can be served from the local
         cache without contacting the Hub.
@@ -3684,7 +3684,7 @@ class HfApi:
                 `None` or `"model"` if it is a model. Default is `None`.
             revision (`str`, *optional*):
                 The revision to resolve. Can be a branch name, a tag, a PR ref or a commit hash. Defaults to the
-                default branch. If a [`RevisionStr`] is passed, it is returned as is.
+                default branch. If a [`ResolvedRevision`] is passed, it is returned as is.
             cache_dir (`str`, `Path`, *optional*):
                 Path to the folder where cached files are stored. Defaults to the value of `HF_HUB_CACHE`.
             local_files_only (`bool`, *optional*, defaults to `False`):
@@ -3695,7 +3695,7 @@ class HfApi:
                 To disable authentication, pass `False`.
 
         Returns:
-            [`RevisionStr`]: A `str` subclass holding both the requested revision and the commit hash it resolves to.
+            [`ResolvedRevision`]: A `str` subclass holding both the requested revision and the commit hash it resolves to.
 
         Raises:
             [`~errors.RevisionResolutionError`]
@@ -3712,17 +3712,17 @@ class HfApi:
             >>> api = HfApi()
             >>> revision = api.resolve_revision("openai-community/gpt2")
             >>> revision
-            RevisionStr(initial=None, resolved='607a30d783dfa663caf39e06633721c8d4cfcd7e')
+            ResolvedRevision(initial=None, resolved='607a30d783dfa663caf39e06633721c8d4cfcd7e')
 
             # Pass it around: every download is pinned to the same commit
             >>> config = hf_hub_download("openai-community/gpt2", "config.json", revision=revision)
             >>> weights = hf_hub_download("openai-community/gpt2", "model.safetensors", revision=revision)
             ```
         """
-        if isinstance(revision, RevisionStr):
+        if isinstance(revision, ResolvedRevision):
             return revision
         if revision is not None and REGEX_COMMIT_HASH.match(revision):
-            return RevisionStr(resolved=revision, initial=revision)
+            return ResolvedRevision(resolved=revision, initial=revision)
 
         if repo_type is None:
             repo_type = constants.REPO_TYPE_MODEL
@@ -3743,7 +3743,7 @@ class HfApi:
                     )
                 except OSError as e:
                     logger.warning(f"Ignored error while caching commit hash for '{repo_id}': {e}.")
-                return RevisionStr(resolved=sha, initial=revision)
+                return ResolvedRevision(resolved=sha, initial=revision)
             except httpx.ProxyError:
                 # Actually raise on proxy error: a misconfigured proxy is not an unreachable Hub
                 raise
@@ -3759,7 +3759,7 @@ class HfApi:
         if ref_path.is_file():
             if error is not None:
                 logger.warning(f"Could not reach the Hub ({error}). Using cached commit hash for '{repo_id}'.")
-            return RevisionStr(resolved=ref_path.read_text().strip(), initial=revision)
+            return ResolvedRevision(resolved=ref_path.read_text().strip(), initial=revision)
 
         reason = (
             "'local_files_only=True' is set"
@@ -3907,7 +3907,7 @@ class HfApi:
             False
             ```
         """
-        if isinstance(revision, RevisionStr):
+        if isinstance(revision, ResolvedRevision):
             # Revision has already been resolved to a commit hash (see [`resolve_revision`]) => use it directly.
             # Whether a file exists is fully determined by the commit hash, so the answer is the same.
             revision = revision.resolved

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -3904,6 +3904,10 @@ class HfApi:
             False
             ```
         """
+        if isinstance(revision, RevisionStr):
+            # Revision has already been resolved to a commit hash (see [`resolve_revision`]) => use it directly.
+            # Whether a file exists is fully determined by the commit hash, so the answer is the same.
+            revision = revision.resolved
         url = hf_hub_url(
             repo_id=repo_id, repo_type=repo_type, revision=revision, filename=filename, endpoint=self.endpoint
         )

--- a/tests/test_snapshot_download.py
+++ b/tests/test_snapshot_download.py
@@ -403,6 +403,13 @@ class TestResolveRevision:
         mock.assert_not_called()
         assert snapshot_path.endswith(self.commit_hash)
 
+        # The `refs/` entry is not touched: it has been written by `resolve_revision` and might be more recent
+        # than the pinned commit hash.
+        ref_path = tmp_path / repo_folder_name(repo_id=self.repo_id, repo_type="model") / "refs" / "main"
+        ref_path.write_text(COMMIT_HASH)
+        snapshot_download(self.repo_id, revision=revision, cache_dir=tmp_path)
+        assert ref_path.read_text() == COMMIT_HASH
+
         # Everything is cached at this point => works offline as well
         with offline():
             assert hf_hub_download(self.repo_id, "dummy_file.txt", revision=revision, cache_dir=tmp_path).endswith(

--- a/tests/test_snapshot_download.py
+++ b/tests/test_snapshot_download.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from huggingface_hub import CommitOperationAdd, HfApi, RevisionStr, hf_hub_download, snapshot_download
+from huggingface_hub import CommitOperationAdd, HfApi, ResolvedRevision, hf_hub_download, snapshot_download
 from huggingface_hub._tree_cache import read_tree_cache
 from huggingface_hub.errors import (
     IncompleteSnapshotError,
@@ -350,13 +350,13 @@ class TestSnapshotDownload:
 
 
 def test_revision_str():
-    revision = RevisionStr(resolved=COMMIT_HASH)
+    revision = ResolvedRevision(resolved=COMMIT_HASH)
     assert revision == "main"  # defaults to `main` when no revision was requested
     assert revision.initial is None
     assert revision.resolved == COMMIT_HASH
-    assert repr(revision) == f"RevisionStr(initial=None, resolved='{COMMIT_HASH}')"
+    assert repr(revision) == f"ResolvedRevision(initial=None, resolved='{COMMIT_HASH}')"
 
-    revision = RevisionStr(resolved=COMMIT_HASH, initial="refs/pr/4")
+    revision = ResolvedRevision(resolved=COMMIT_HASH, initial="refs/pr/4")
     assert revision == "refs/pr/4"
     assert revision.resolved == COMMIT_HASH
 

--- a/tests/test_snapshot_download.py
+++ b/tests/test_snapshot_download.py
@@ -4,9 +4,14 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from huggingface_hub import CommitOperationAdd, HfApi, snapshot_download
+from huggingface_hub import CommitOperationAdd, HfApi, RevisionStr, hf_hub_download, snapshot_download
 from huggingface_hub._tree_cache import read_tree_cache
-from huggingface_hub.errors import IncompleteSnapshotError, LocalEntryNotFoundError, RepositoryNotFoundError
+from huggingface_hub.errors import (
+    IncompleteSnapshotError,
+    LocalEntryNotFoundError,
+    RepositoryNotFoundError,
+    RevisionResolutionError,
+)
 from huggingface_hub.file_download import repo_folder_name
 from huggingface_hub.hf_api import RepoFile
 from huggingface_hub.utils import SoftTemporaryDirectory, _http
@@ -342,3 +347,64 @@ class TestSnapshotDownload:
                 # Nothing has been added to cache dir (except some subfolders created)
                 for path in cache_dir.glob("*"):
                     assert path.is_dir()
+
+
+def test_revision_str():
+    revision = RevisionStr(resolved=COMMIT_HASH)
+    assert revision == "main"  # defaults to `main` when no revision was requested
+    assert revision.initial is None
+    assert revision.resolved == COMMIT_HASH
+    assert repr(revision) == f"RevisionStr(initial=None, resolved='{COMMIT_HASH}')"
+
+    revision = RevisionStr(resolved=COMMIT_HASH, initial="refs/pr/4")
+    assert revision == "refs/pr/4"
+    assert revision.resolved == COMMIT_HASH
+
+
+class TestResolveRevision:
+    @pytest.fixture(scope="class", autouse=True)
+    def _shared_repo(self, request, api: HfApi):
+        repo_id = api.create_repo(repo_name("resolve-revision")).repo_id
+        request.cls.repo_id = repo_id
+        request.cls.commit_hash = api.create_commit(
+            repo_id=repo_id,
+            operations=[CommitOperationAdd(path_in_repo="dummy_file.txt", path_or_fileobj=b"v1")],
+            commit_message="Add file to main branch",
+        ).oid
+        yield
+        api.delete_repo(repo_id=repo_id)
+
+    def test_resolve_revision(self, api: HfApi, tmp_path: Path):
+        revision = api.resolve_revision(self.repo_id, cache_dir=tmp_path)
+        assert revision == "main"
+        assert revision.resolved == self.commit_hash
+
+        # The mapping is cached on disk => can be resolved again without network
+        ref_path = tmp_path / repo_folder_name(repo_id=self.repo_id, repo_type="model") / "refs" / "main"
+        assert ref_path.read_text() == self.commit_hash
+        with offline():
+            assert api.resolve_revision(self.repo_id, cache_dir=tmp_path).resolved == self.commit_hash
+
+        # Already resolved => returned as is (no network call)
+        with offline():
+            assert api.resolve_revision(self.repo_id, revision=revision, cache_dir=tmp_path) is revision
+
+    def test_resolve_revision_not_cached(self, api: HfApi, tmp_path: Path):
+        with offline():
+            with pytest.raises(RevisionResolutionError):
+                api.resolve_revision(self.repo_id, cache_dir=tmp_path)
+
+    def test_download_with_resolved_revision(self, api: HfApi, tmp_path: Path):
+        """A resolved revision is used directly: no extra call to resolve it again."""
+        revision = api.resolve_revision(self.repo_id, cache_dir=tmp_path)
+
+        with patch("huggingface_hub._snapshot_download.HfApi.repo_info", side_effect=AssertionError) as mock:
+            snapshot_path = snapshot_download(self.repo_id, revision=revision, cache_dir=tmp_path)
+        mock.assert_not_called()
+        assert snapshot_path.endswith(self.commit_hash)
+
+        # Everything is cached at this point => works offline as well
+        with offline():
+            assert hf_hub_download(self.repo_id, "dummy_file.txt", revision=revision, cache_dir=tmp_path).endswith(
+                f"{self.commit_hash}/dummy_file.txt"
+            )


### PR DESCRIPTION
<details>

<summary>initial prompt</summary>

> I recently worked on https://github.com/vllm-project/vllm/pull/49990 and https://github.com/huggingface/transformers/pull/47611 to tackle an annoying problem regarding revision resolution. In a complex ML library, revision must be resolved first so that all methods/download/listing etc. are done with the exact same commit hash. It prevents concurrency issues (if repo is updated while it's been downloaded) but most of all it prevent resolving it multiple times - potentially saving some HTTP calls in the process. So the solution I've implemented so far is to have a resolve_revision at the beginning and then pass commit_hash everywhere. Problem is, the revision<>commit_hash resolution is not cached locally so later reuse of the model in offline mode might fail. Also we loose the initial requested revision so error message can be kriptic (e.g. "file not found on revision abcdef123456..." instead of "file not found on revision main"). A good solution would be to define a new type RevisionStr in huggingface_hub, deriving from str. Its str value would be the revision (e.g. "main", "refs/pr/4", a commit hash if passed explicitely by the user, etc.) but it would also have 2 other attributes: 1. .initial (str | None) and 2. .resolved (str). Initial is what the user requested first, while .resolved is a commit hash. Note that .initial can be None in which case the str value of RevisionStr will be "main". Make the repr print both initial and resolved values. On top of that, add a new method "HfApi.resolve_revision(repo_id, repo_type, revision, token) -> RevisionStr". If the input revision is already a RevisionStr, return it. Otherwise make a repo_info call to the Hub to get the .sha for that repo_id/repo_type/revision combination. If the call succeed, build the RevisionStr, cache the value in the cache (in the refs/ folder, as it's already done in `src/huggingface_hub/file_download.py` _cache_commit_hash_for_specific_revision - on best-effort basis), and return. If the call fails (offline mode, Hub down, timeout, etc.), default to the cached value. If call fails and no cached value => raise exception. Define a custom RevisionResolutionError. Once all of this will be implemented, we will reuse "resolve_revision" in transformers/vllm/etc. to resolve the revision first. Since RevisionStr IS a string, it can be passed to all huggingface_hub methods seamlessly. No need to update any existing type annotation. Please adapt the few methods for which it's useful to know the resolved revision, e.g. snapshot_download and hf_hub_download (with a "if isinstance(revision, RevisionStr): revision = revision.resolved" ...). Simplify all code that can be simplified. Update `docs/source/en/guides/manage-cache.md` to mention this new feature (advanced). The recommended approach for ML libraries integrating with the Hub is still to make a single snapshot_download call. The resolve_revision approach is for complex ML libraries that need to resolve/download many different components separately (config, model, tokenizer, etc.). Please open a draft PR with that. Do not over-unit test everything. Don't be too verbose in the PR description. Please copy-paste this exact prompt at the top of the PR description (as a quoted paragraph) for reference. Good luck!

</details>

## Summary

- New `ResolvedRevision` (a `str` subclass) with `.initial` (what the user asked for, `None` => string value is `"main"`) and `.resolved` (the commit hash). `repr` shows both.
- New `HfApi.resolve_revision(repo_id, repo_type=..., revision=..., cache_dir=..., local_files_only=..., token=...)`:
  - returns the input as is if it's already a `ResolvedRevision`, and short-circuits without any HTTP call if `revision` is already a commit hash,
  - otherwise `repo_info(...).sha`, then writes `refs/<revision>` (best-effort, reusing `_cache_commit_hash_for_specific_revision`),
  - falls back on the cached ref if the Hub can't be reached, raises the new `RevisionResolutionError` if there's nothing cached either.
- `hf_hub_download`, `snapshot_download` and `get_cached_repo_tree` use `.resolved` when they get a `ResolvedRevision`.
- Docs: new "Pin a revision (advanced)" section in the cache guide (with the "just use `snapshot_download`" tip first), plus reference entries.

## Example

```py
>>> from huggingface_hub import HfApi, hf_hub_download
>>> api = HfApi()
>>> revision = api.resolve_revision("openai-community/gpt2")
>>> revision
ResolvedRevision(initial=None, resolved='607a30d783dfa663caf39e06633721c8d4cfcd7e')
>>> revision == "main", revision.resolved
(True, '607a30d783dfa663caf39e06633721c8d4cfcd7e')

>>> config = hf_hub_download("openai-community/gpt2", "config.json", revision=revision)
>>> weights = hf_hub_download("openai-community/gpt2", "model.safetensors", revision=revision)
```

Downloading 5 small files one by one (`config.json`, `tokenizer.json`, `tokenizer_config.json`, `vocab.json`, `merges.txt`), counting HTTP calls:

| | cold cache | warm cache |
|---|---|---|
| `revision=None` | 15 | 10 |
| `revision=api.resolve_revision(...)` | 16 | **1** |

Cold cache costs one extra call (the `repo_info`), the win is on reuse: with everything cached, only the initial `repo_info` remains. Offline (once the ref is cached), it goes down to 0.

```
$ HF_HUB_OFFLINE=1 python -c "..."
Could not reach the Hub (offline mode is enabled...). Using cached commit hash for 'hf-internal-testing/tiny-random-gpt2'.
offline resolve -> ResolvedRevision(initial=None, resolved='71034c5d8bde858ff824298bdedc65515b97d2b9')
.../snapshots/71034c5d8bde858ff824298bdedc65515b97d2b9

$ # not cached at all:
RevisionResolutionError Cannot resolve revision 'main' for model 'hf-internal-testing/tiny-random-bert': the Hub
could not be reached (OfflineModeIsEnabled: ...) and no matching entry was found in the local cache
('.../models--hf-internal-testing--tiny-random-bert/refs/main').
```

## Decisions taken along the way

- **Which methods unwrap `ResolvedRevision`**: only the download helpers (`hf_hub_download`, `snapshot_download`, `get_cached_repo_tree`), i.e. the ones where knowing the commit hash saves HTTP calls / hits the cache. `repo_info`, `list_repo_tree` and `file_exists` are deliberately left out for now. Everywhere else a `ResolvedRevision` is just its string value, so behavior is unchanged.
- **When to fall back on the cached ref**: only when the Hub could not be reached (connection error, timeout, offline mode, 5xx). A 404/401/403 is a definitive answer from the Hub, so `RevisionNotFoundError`/`RepositoryNotFoundError`/`GatedRepoError` are raised as is rather than masked by a stale cached hash.
- **`snapshot_download`**: the "is this revision already a commit hash?" check moved to the top of the function, so a `ResolvedRevision` and a plain commit hash follow strictly the same path (skip `repo_info`, read the `trees/` cache, only hit the Hub if the tree listing is missing). `repo_info` and the tree listing stay in separate blocks as before, so error handling is unchanged. Warm cache, measured:

  | revision | HTTP calls |
  |---|---|
  | `None` / `"main"` | 1 (`repo_info`) |
  | commit hash | 0 |
  | `ResolvedRevision` | 0 |


## Tests

A few tests in `tests/test_snapshot_download.py`: `ResolvedRevision` basics, resolve + ref caching + offline fallback + `RevisionResolutionError`, and one checking that `snapshot_download` doesn't call `repo_info` when given a resolved revision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core download and revision-resolution paths; offline fallback only applies on transport/5xx errors, but stale ref misuse could still affect offline loads if refs are wrong.
> 
> **Overview**
> Adds **`ResolvedRevision`** (a `str` with `.initial` and `.resolved`) and **`HfApi.resolve_revision`** / top-level **`resolve_revision`** so libraries can resolve a branch/tag once, cache the mapping under `refs/`, and reuse it offline when the Hub is unreachable (otherwise **`RevisionResolutionError`**).
> 
> **`hf_hub_download`**, **`snapshot_download`**, and **`get_cached_repo_tree`** now treat a **`ResolvedRevision`** like an immutable commit hash (fewer HTTP calls, consistent commit across many per-file downloads). **`snapshot_download`** skips **`repo_info`** for resolved revisions and avoids rewriting **`refs/`** when the ref was already set by **`resolve_revision`**.
> 
> Docs add a “Pin a revision (advanced)” cache guide section plus API reference entries; tests cover resolution, offline fallback, and snapshot behavior without extra **`repo_info`** calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e47cbd1e7c1cb8bbe75845532f618512a26b15c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->