### PR TITLE
Reject `token=False` in `create_inference_endpoint_from_catalog` instead of silently ignoring it

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -9504,6 +9504,10 @@ class HfApi:
         > `create_inference_endpoint_from_catalog` is experimental. Its API is subject to change in the future. Please provide feedback
         > if you have any suggestions or requests.
         """
+        if token is False:
+            raise ValueError(
+                "Cannot use `token=False` with `create_inference_endpoint_from_catalog` as it requires authentication."
+            )
         token = token or self.token or get_token()
         payload: dict = {
             "namespace": namespace or self._get_namespace(token=token),

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -4651,6 +4651,14 @@ class TestHfApiInferenceCatalog:
         assert isinstance(endpoint, InferenceEndpoint)
         assert endpoint.name == "llama-3-2-3b-instruct-eey"
 
+    def test_create_inference_endpoint_from_catalog_rejects_token_false(self, api: HfApi) -> None:
+        # `token=False` means "do not authenticate", but this endpoint cannot be created without
+        # authentication. Reject it explicitly instead of silently falling back to a stored token.
+        with pytest.raises(ValueError, match="Cannot use `token=False`"):
+            api.create_inference_endpoint_from_catalog(
+                repo_id="meta-llama/Llama-3.2-3B-Instruct", namespace="Wauplin", token=False
+            )
+
 
 @pytest.mark.parametrize(
     "custom_image, expected_image_payload",


### PR DESCRIPTION
`create_inference_endpoint_from_catalog` resolves the token like this:

```python
token = token or self.token or get_token()
```

`token=False` means "do not authenticate" in this library, and it is not a hypothetical value:
`whoami` rejects it explicitly, and `build_hf_headers` has a branch for it. Because `False or x == x`,
passing it here falls straight through to the stored token, so the request goes out authenticated
after the caller asked for the opposite. Nothing is logged.

The idiom appears once in `hf_api.py`. Every other method passes the token to `_build_hf_headers`,
which uses `if token is None` and leaves `False` intact.

I went back and forth on the fix. Honouring `False` is not really possible, since creating a catalog
endpoint needs authentication and `_get_namespace` calls `whoami`, which rejects `False` anyway. So
this raises instead, matching what `whoami` already does for the same reason. If you would rather it
stayed silent, or preferred a warning, say so and I will redo it.

The added test fails without the change and passes with it. `ruff check` and `ruff format --check` are
clean on both files, and the surrounding `test_hf_api.py` selection (17 tests covering the catalog and
token paths) still passes. The existing catalog test passes `namespace` explicitly, which is the case
where this is completely silent, so nothing there covered it.

A note on severity. This is not a security hole and nothing leaks to a third party. The token goes to
the same Hugging Face endpoint it always would. What is wrong is that an explicit instruction is
ignored without a word, and someone deliberately running unauthenticated finds out from a 401 that
does not mention the token they thought they had turned off.

I did not check whether the async client or the CLI path share the idiom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized API behavior change for an invalid argument; no change to normal authenticated flows.
> 
> **Overview**
> **`create_inference_endpoint_from_catalog`** now raises **`ValueError`** when **`token=False`** is passed, instead of treating it like “no token” and falling through **`token or self.token or get_token()`** to a stored credential.
> 
> That matches **`whoami`**, which already rejects **`token=False`** because catalog endpoint creation requires auth (including **`_get_namespace`**). A unit test asserts the error is raised and documents the intended behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c11f0f3772886989c9eef52a7794b3e663e512b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->