### PR TITLE
[CLI] Don't crash when stdout can't encode non-ASCII output

### DIFF
--- a/src/huggingface_hub/cli/_file_listing.py
+++ b/src/huggingface_hub/cli/_file_listing.py
@@ -23,7 +23,7 @@ from huggingface_hub._buckets import BucketFile, BucketFolder
 from huggingface_hub.hf_api import RepoFile, RepoFolder
 
 from ._cli_utils import get_hf_api
-from ._output import OutputFormat, _dataclass_to_dict, out
+from ._output import OutputFormat, _ascii_safe, _dataclass_to_dict, out
 
 
 BucketItem = BucketFile | BucketFolder
@@ -131,7 +131,7 @@ def _render_tree(
     sorted_items = sorted(node.items())
     for i, (name, value) in enumerate(sorted_items):
         is_last = i == len(sorted_items) - 1
-        connector = "└── " if is_last else "├── "
+        connector = _ascii_safe("└── ", "`-- ") if is_last else _ascii_safe("├── ", "|-- ")
 
         is_dir = "__children__" in value
         children = value.get("__children__", {})
@@ -152,7 +152,7 @@ def _render_tree(
             lines.append(f"{indent}{connector}{name}{'/' if is_dir else ''}")
 
         if children:
-            child_indent = indent + ("    " if is_last else "│   ")
+            child_indent = indent + ("    " if is_last else _ascii_safe("│   ", "|   "))
             _render_tree(
                 children,
                 lines,

--- a/src/huggingface_hub/cli/_output.py
+++ b/src/huggingface_hub/cli/_output.py
@@ -21,6 +21,7 @@ import shutil
 import sys
 from collections.abc import Sequence
 from enum import Enum
+from functools import cache
 from typing import Any, cast
 
 import click
@@ -166,7 +167,7 @@ class Output:
         """Print a success summary to stdout."""
         match self.mode:
             case OutputFormat.human:  # ✓ message + key: value lines
-                parts = [ANSI.green(f"✓ {message}")]
+                parts = [ANSI.green(f"{_ascii_safe('✓', '[OK]')} {message}")]
                 for k, v in data.items():
                     if v is not None:
                         parts.append(f"  {k}: {v}")
@@ -239,6 +240,24 @@ class Output:
 # HELPERS
 
 
+@cache
+def _ascii_safe(char: str, fallback: str) -> str:
+    """Return `char`, or `fallback` if stdout cannot encode it.
+
+    On Windows, `sys.stdout` uses the ANSI code page (e.g. cp1252) instead of the console
+    encoding whenever it is not attached to a console (output redirected, piped, captured by
+    a CI step). Printing a decoration like "✓" then raises `UnicodeEncodeError` - a
+    `ValueError` subclass, so it surfaces as a confusing "Invalid value." error and aborts
+    the command. Cached since the stream encoding is fixed for the lifetime of the process.
+    """
+    encoding = getattr(sys.stdout, "encoding", None) or "utf-8"
+    try:
+        char.encode(encoding)
+    except (LookupError, UnicodeEncodeError):
+        return fallback
+    return char
+
+
 def _serialize_value(v: object) -> object:
     """Recursively serialize a value to be JSON-compatible."""
     if isinstance(v, datetime.datetime):
@@ -286,7 +305,7 @@ def _format_table_value_human(value: Any) -> str:
     if value is None:
         return ""
     if isinstance(value, bool):
-        return "✔" if value else ""
+        return _ascii_safe("✔", "yes") if value else ""
     if isinstance(value, datetime.datetime):
         return value.strftime("%Y-%m-%d")
     if isinstance(value, str) and re.match(r"^\d{4}-\d{2}-\d{2}T", value):

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -13,13 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import io
 import os
 import shutil
 import sys
 
 import pytest
 
-from huggingface_hub.cli._output import Output, OutputFormat, _to_header
+from huggingface_hub.cli._output import Output, OutputFormat, _ascii_safe, _to_header
 from huggingface_hub.errors import ConfirmationError
 
 
@@ -418,3 +419,41 @@ def test_status_only_enabled_for_humans(check, monkeypatch):
 )
 def test_to_header(input, expected):
     assert _to_header(input) == expected
+
+
+@pytest.fixture
+def stdout_encoding(monkeypatch):
+    """Swap `sys.stdout` for a stream with the given encoding, e.g. a legacy Windows code page."""
+
+    def _set(encoding: str) -> io.TextIOWrapper:
+        stream = io.TextIOWrapper(io.BytesIO(), encoding=encoding)
+        monkeypatch.setattr(sys, "stdout", stream)
+        return stream
+
+    _ascii_safe.cache_clear()  # cached per (char, fallback), not per stream
+    yield _set
+    _ascii_safe.cache_clear()
+
+
+@pytest.mark.parametrize(
+    ("encoding", "expected"),
+    [
+        ("utf-8", "✓"),
+        ("cp1252", "[OK]"),  # Windows ANSI code page, used when stdout is not a console
+        ("ascii", "[OK]"),
+    ],
+)
+def test_ascii_safe_falls_back_when_stdout_cannot_encode(stdout_encoding, encoding, expected):
+    stdout_encoding(encoding)
+    assert _ascii_safe("✓", "[OK]") == expected
+
+
+def test_result_uses_ascii_marker_on_legacy_windows_stdout(stdout_encoding):
+    stream = stdout_encoding("cp1252")
+
+    o = Output()
+    o.set_mode(HUMAN)
+    o.result("Logged in", user="Wauplin")
+
+    stream.flush()
+    assert "[OK] Logged in" in stream.buffer.getvalue().decode("cp1252")


### PR DESCRIPTION
Fixes #4609.

## Summary

On Windows, `sys.stdout` uses the ANSI code page (e.g. cp1252) instead of the console encoding whenever it isn't attached to a console (redirected, piped, captured by a CI step). Printing the `✓` from `out.result()` then raises `UnicodeEncodeError` → since that's a `ValueError` subclass, it surfaced as `Error: Invalid value.` with exit code 1. That's what has been breaking the `windows-installer` job of `check-installers.yml`.

Single change: **`_ascii_safe(char, fallback)` in `cli/_output.py`** — returns `char` if `sys.stdout` can encode it, else an ASCII fallback. `@cache`d since the stream encoding is fixed for the process. Used for the markers that carry meaning: `✓` → `[OK]`, `✔` → `yes`, and the `--tree` connectors (`└──` → `` `-- ``).

Two alternatives from the issue were considered and dropped:

- `sys.stdout.reconfigure(encoding="utf-8")` — writes UTF-8 bytes to consoles that really are cp437/cp1252 → mojibake.
- `sys.stdout.reconfigure(errors="replace")` — no mojibake, and it would blanket-protect every remaining decoration, but reconfiguring the user's streams from under them is heavier-handed than the bug warrants. Fixing our own output is enough.

Known gap from that choice: non-ASCII outside the output framework still can't be printed on a legacy code page — `⚠` in the `spaces hot-reload` help text, `❌` in `cache verify`, the `✘`/`∅`/`▶` icons in `spaces dev-mode`, em-dashes in a few help strings. Each is a one-line `_ascii_safe()` call if/when someone hits them; happy to fold them in here if preferred.

## Before / after

Reproduced on Linux with `PYTHONIOENCODING=cp1252`, which puts Python in exactly the same situation as a redirected Windows stdout.

Before:

```
$ PYTHONIOENCODING=cp1252 hf version --format human
Error: Invalid value. 'charmap' codec can't encode character '✓' in position 0: character maps to <undefined>
Hint: set HF_DEBUG=1 as environment variable for full traceback.
$ echo $?
1

$ PYTHONIOENCODING=cp1252 hf models ls openai-community/gpt2 --tree --format human
Error: Invalid value. 'charmap' codec can't encode characters in position 32-34: character maps to <undefined>
```

After:

```
$ PYTHONIOENCODING=cp1252 hf version --format human
[OK] hf version
  version: 1.26.0.dev0
$ echo $?
0

$ PYTHONIOENCODING=cp1252 hf models ls openai-community/gpt2 --tree --format human
      445  2022-09-29 15:22:02  |-- .gitattributes
125162496  2019-12-12 15:44:08  |-- 64-8bits.tflite
248269688  2019-12-12 15:43:43  |-- 64-fp16.tflite
     8092  2022-11-23 12:55:26  |-- README.md
                                |-- onnx/
[...]
```

UTF-8 terminals are unaffected — same `✓` / `└──` output as before.

## Tests

`tests/test_cli_output.py`: `_ascii_safe()` parametrized over utf-8 / cp1252 / ascii, plus an integration check that `out.result()` prints `[OK]` on a cp1252 stream. Full `tests/test_cli.py` + `tests/test_cli_output.py` suite passes (329 tests).

Draft for now — worth confirming the `windows-installer` job goes green (it only runs on `utils/installers/**` changes, so it may need a manual trigger on this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)