### PR TITLE
[Core] Fix tilde expansion in CommitOperationAdd

### DIFF
--- a/src/huggingface_hub/_commit_api.py
+++ b/src/huggingface_hub/_commit_api.py
@@ -197,9 +197,9 @@ class CommitOperationAdd:
         if isinstance(self.path_or_fileobj, Path):
             self.path_or_fileobj = str(self.path_or_fileobj)
         if isinstance(self.path_or_fileobj, str):
-            path_or_fileobj = os.path.normpath(os.path.expanduser(self.path_or_fileobj))
-            if not os.path.isfile(path_or_fileobj):
-                raise ValueError(f"Provided path: '{path_or_fileobj}' is not a file on the local file system")
+            self.path_or_fileobj = os.path.normpath(os.path.expanduser(self.path_or_fileobj))
+            if not os.path.isfile(self.path_or_fileobj):
+                raise ValueError(f"Provided path: '{self.path_or_fileobj}' is not a file on the local file system")
         elif not isinstance(self.path_or_fileobj, (io.BufferedIOBase, bytes)):
             # ^^ Inspired from: https://stackoverflow.com/questions/44584829/how-to-determine-if-file-is-opened-in-binary-or-text-mode
             raise ValueError(


### PR DESCRIPTION
## Summary
this pr fixes a bug where passing a path with a tilde (`~/`) to `CommitOperationAdd` results in a `FileNotFoundError`

the `__post_init__` method was calculating the expanded path using `os.path.expanduser` but was assigning it to a local variable instead of `self.path_or_fileobj`
downstream calls (like `UploadInfo.from_path`) were still receiving the unexpanded path

Fixes #4611 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized fix in path validation for string paths; no auth or API contract changes.
> 
> **Overview**
> Fixes upload failures when `CommitOperationAdd` is given a local path containing `~` (e.g. `~/model.bin`).
> 
> In `__post_init__`, `normpath`/`expanduser` were applied to a **local** variable while `self.path_or_fileobj` stayed unchanged, so validation, `UploadInfo.from_path`, `as_file()`, and Xet uploads could still see the unexpanded path and raise `FileNotFoundError` or similar.
> 
> The expanded, normalized path is now written back to **`self.path_or_fileobj`** so the rest of the commit/upload pipeline uses the real filesystem path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14f5792c43f3e3aad87d70fd2e3e06be9a75d552. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->