### PR TITLE
[Download] Don't retain caller frames when falling back to cache after a failed HEAD call

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1799,7 +1799,35 @@ def _get_metadata_or_catch_error(
     if not (local_files_only or etag is not None or head_error_call is not None):
         raise RuntimeError("etag is empty due to uncovered problems")
 
+    if head_error_call is not None:
+        _detach_tracebacks(head_error_call)
+
     return (url_to_download, etag, commit_hash, expected_size, xet_file_data, head_error_call)  # type: ignore
+
+
+def _detach_tracebacks(error: BaseException) -> None:
+    """Detach the tracebacks of an exception and of its whole `__cause__`/`__context__` chain.
+
+    Returning an exception instead of raising it means keeping its traceback alive. A traceback references the frames
+    it was raised from, and each frame references its caller (up to the user code calling `hf_hub_download`) and its
+    own local variables - including the returned exception itself. This creates a reference cycle that only the cyclic
+    garbage collector can break, so callers falling back to a cached file (i.e. discarding the error) keep their own
+    stack - and everything it references - alive until the next `gc.collect()`.
+
+    Only the frames are dropped: exception types, messages and the cause/context chain are preserved, so re-raising a
+    detached error still reports what went wrong.
+
+    See https://github.com/vllm-project/vllm/pull/50341 for a real-world report of this retention.
+    """
+    seen: set[int] = set()
+    pending = [error]
+    while pending:
+        current = pending.pop()
+        if id(current) in seen:  # defensive: exception chains can be cyclic
+            continue
+        seen.add(id(current))
+        current.__traceback__ = None
+        pending.extend(exc for exc in (current.__cause__, current.__context__) if exc is not None)
 
 
 def _xet_file_metadata_from_tree_cache(

--- a/src/huggingface_hub/utils/_http.py
+++ b/src/huggingface_hub/utils/_http.py
@@ -458,10 +458,12 @@ def _http_backoff_base(
     if "data" in kwargs and isinstance(kwargs["data"], (io.IOBase, SliceFileObj)):
         io_obj_initial_pos = kwargs["data"].tell()
 
-    client = get_session()
     while True:
         nb_tries += 1
         ratelimit_reset = None
+        # Fetched on each attempt: a previous attempt may have closed the shared client (see `close_session` below),
+        # and closed `httpx.Client` objects cannot be reused.
+        client = get_session()
         try:
             # If `data` is used and is a file object (or any IO), set back cursor to
             # initial position.


### PR DESCRIPTION
## Summary

Follow-up on [vllm-project/vllm#50341](https://github.com/vllm-project/vllm/pull/50341), where vLLM had to monkey-patch `huggingface_hub.file_download._get_metadata_or_catch_error` (their patch has a `TODO: Remove this compatibility patch when Hugging Face Hub detaches metadata errors before returning them to its download helpers` — so let's just do it here).

- `_get_metadata_or_catch_error` **returns** the HEAD-call exception instead of raising it. That exception keeps its `__traceback__`, which references the frames it was raised from — including `_get_metadata_or_catch_error`'s own frame, whose locals reference the exception. That's a reference cycle, and frames also reference their callers, so **the whole caller stack (and everything its locals reference) stays alive until the next `gc.collect()`** whenever we swallow the error and return a cached file.
- Fix: detach the tracebacks of the returned exception and of its whole `__cause__`/`__context__` chain (both need it, otherwise the chain re-creates the cycle). Exception types, messages and the chain are preserved, so `_raise_on_head_call_error` still reports what went wrong — only the frame lines of the original failure are gone.
- **Bonus fix, found while reproducing** (`utils/_http.py`, separate commit — happy to split it out): `_http_backoff_base` fetched the shared client *once*, before the retry loop, but we call `close_session()` when we get a `httpx.ConnectError`. Every retry after that reused the closed client and blew up with `RuntimeError: Cannot send a request, as the client has been closed.` — which isn't retryable and masked the real connection error. This was fine with `requests` (sessions survive `close()`) but not with `httpx`, so it's a v1.0 regression.

No test added for now (asked to skip); reproduced manually below.

## Reproduction

Dummy repo pre-seeded in the cache + `HF_ENDPOINT=http://127.0.0.1:1` so the HEAD call fails with a real `httpx.ConnectError` (no mocking). The caller holds an object we track with a weakref, and cyclic GC is disabled to observe the retention:

```python
def download_from_caller(owner):  # `owner` is a local of this frame
    return hf_hub_download(REPO_ID, FILENAME, cache_dir=CACHE)

gc.disable()
owner = Owner()
ref = weakref.ref(owner)
download_from_caller(owner)   # returns the cached file, HEAD call failed
del owner
print(ref() is not None)      # -> caller frame still alive?
```

Before:

```
cached file returned:      /tmp/tmpbuq2im7d/models--dummy-org--dummy-model/snapshots/00.../config.json
caller frame retained:     True
retained by frames:        ['download_from_caller']
freed only by gc.collect(): True (collected 144 objects)
```

After:

```
cached file returned:      /tmp/tmpo6k2cqzv/models--dummy-org--dummy-model/snapshots/00.../config.json
caller frame retained:     False
freed only by gc.collect(): True (collected 0 objects)
```

Same result for the `local_dir=` code path (`local_dir: caller frame retained: False`).

Error reporting when the file is *not* cached is unchanged — the chain is still intact:

```
httpcore.ConnectError: [Errno 111] Connection refused

The above exception was the direct cause of the following exception:

httpx.ConnectError: [Errno 111] Connection refused

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  ...
  File ".../file_download.py", line 1166, in _hf_hub_download_to_cache_dir
    _raise_on_head_call_error(head_call_error, force_download, local_files_only)
  File ".../file_download.py", line 1907, in _raise_on_head_call_error
    raise LocalEntryNotFoundError(
huggingface_hub.errors.LocalEntryNotFoundError: An error happened while trying to locate the file on the Hub and we cannot find the requested files in the local cache. ...
```

Note that this output is only reachable *with* the `_http.py` fix: on `main` the same scenario raises `RuntimeError: Cannot send a request, as the client has been closed.` on the first retry instead.

## Tests

- `tests/test_utils_http.py`: 63 passed.
- `tests/test_file_download.py`: passing, except hub-ci `504 Gateway Timeout` flakes unrelated to the change (`test_passing_token_false_is_respected`, plus a teardown error) — staging was returning "The request is taking longer than expected" throughout the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted lifecycle fixes in download metadata and HTTP retry paths; exception messages and re-raise behavior stay intact aside from missing original traceback frames on detached errors.
> 
> **Overview**
> When a Hub HEAD call fails but a cached file is returned, `_get_metadata_or_catch_error` now clears tracebacks on the returned exception (and its full `__cause__`/`__context__` chain) via new `_detach_tracebacks`, breaking a reference cycle that otherwise kept the caller’s stack alive until `gc.collect()`.
> 
> In `_http_backoff_base`, `get_session()` is called **inside** the retry loop so a retry after `close_session()` on `httpx.ConnectError` does not reuse a closed shared client (httpx v1.0 regression vs `requests`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f07d7363ad108819ae396f40e35378f200c1950. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->