### PR TITLE
[Tests] Fix two Windows-only CI failures + flaky-CI findings

### DIFF
--- a/tests/test_hf_file_system.py
+++ b/tests/test_hf_file_system.py
@@ -337,7 +337,7 @@ class _HfFileSystemBaseROTests(_HfFileSystemBaseTests):
 
     def test_get_file_with_temporary_folder(self):
         # Test passing a file path works
-        with tempfile.TemporaryDirectory() as temp_dir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
             temp_file = os.path.join(temp_dir, "temp_file.txt")
             self.hffs.get_file(self.text_file, temp_file)
             with open(temp_file, "rb") as f:
@@ -346,19 +346,19 @@ class _HfFileSystemBaseROTests(_HfFileSystemBaseTests):
     def test_get_file_with_kwargs(self):
         # If custom kwargs are passed, the function should still work but defaults to base implementation
         with patch.object(hf_file_system, "http_get") as mock:
-            with tempfile.TemporaryDirectory() as temp_dir:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
                 temp_file = os.path.join(temp_dir, "temp_file.txt")
                 self.hffs.get_file(self.text_file, temp_file, custom_kwarg=123)
             mock.assert_not_called()
 
-            with tempfile.TemporaryDirectory() as temp_dir:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
                 temp_file = os.path.join(temp_dir, "temp_file.txt")
                 self.hffs.get_file(self.text_file, temp_file)
             mock.assert_called_once()
 
     def test_get_file_on_folder(self):
         # Test it works with custom kwargs
-        with tempfile.TemporaryDirectory() as temp_dir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
             assert not (Path(temp_dir) / "data").exists()
             self.hffs.get_file(self.hf_path + "/data", temp_dir + "/data")
             assert (Path(temp_dir) / "data").exists()

--- a/tests/test_snapshot_download.py
+++ b/tests/test_snapshot_download.py
@@ -413,5 +413,5 @@ class TestResolveRevision:
         # Everything is cached at this point => works offline as well
         with offline():
             assert hf_hub_download(self.repo_id, "dummy_file.txt", revision=revision, cache_dir=tmp_path).endswith(
-                f"{self.commit_hash}/dummy_file.txt"
+                os.path.join(self.commit_hash, "dummy_file.txt")
             )


### PR DESCRIPTION
## Summary

Investigation into the recent CI flakiness, starting from [run 30545079048](https://github.com/huggingface/huggingface_hub/actions/runs/30545079048?pr=4614) (all 8 main test jobs red, failures unrelated to #4614). I pulled the logs from all 8 failing jobs and classified every failure.

**Verdict: 2 real client-side bugs, both Windows-only. Everything else is hub-ci server-side flakiness.**

Fixes here:

- **`tests/test_snapshot_download.py::TestResolveRevision::test_download_with_resolved_revision`** — deterministic failure on **4/4 Windows jobs, 0/4 Ubuntu jobs**. The test asserts `hf_hub_download(...).endswith(f"{self.commit_hash}/dummy_file.txt")`, but the returned value is a *local filesystem* path, so on Windows it ends with `...\<hash>\dummy_file.txt`. Fixed with `os.path.join`. Introduced in #4604 (a782edfa), which is why this started right around when CI "got flaky".

  ```
  E  AssertionError: assert False
  E   +  where False = <...>.endswith('0c514e269ae2d6d31e53cd1632c453a1502afbcf/dummy_file.txt')
  E   +    where '...\\snapshots\\0c514e269ae2d6d31e53cd1632c453a1502afbcf\\dummy_file.txt'.endswith
  ```

- **`tests/test_hf_file_system.py` `get_file` tests** — these download into a `tempfile.TemporaryDirectory()`. On Windows, when the download raises (e.g. a transient 504 from hub-ci), the file handle is still held, `TemporaryDirectory.__exit__` fails with `PermissionError: [WinError 32] The process cannot access the file because it is being used by another process`, and the context manager finally re-raises `NotADirectoryError: [WinError 267]`. **That last exception is what `pytest-rerunfailures` matches `--only-rerun` against** — and `NotADirectoryError: [WinError 267] ...` matches none of `(OSError|FileNotFoundError|Timeout|HTTPError.*409|HTTPError.*502|HTTPError.*504|...)`. So a 504 that *should* have been retried 8 times became an immediate hard failure. Passing `ignore_cleanup_errors=True` lets the real `HfHubHTTPError: ... 504 ...` surface, which does match the rerun regex.

  Real chain from `build-windows (3.10, with hf_xet)`:
  ```
  E   httpx.HTTPStatusError: Server error '504 Gateway Timeout' for url '.../api/datasets/__DUMMY_HUB_USER__/repo-556782-...'
  E       huggingface_hub.errors.HfHubHTTPError: Server error '504 Gateway Timeout' ...
  E               PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: '...\\tmpijb3qekj\\temp_file.txt'
  E       NotADirectoryError: [WinError 267] The directory name is invalid: '...\\tmpijb3qekj\\temp_file.txt'   <-- what --only-rerun sees
  ```

## Findings on the rest (not fixed here)

The remaining 39 failures across the 8 jobs are hub-ci-side. Numbers from the captured logs of the failing tests:

| status | count | share |
| --- | --- | --- |
| 200 | 528 | 80.0% |
| **504** | **76** | **11.5%** |
| 307 | 32 | 4.9% |
| 404 | 11 | 1.7% |
| 409 | 8 | 1.2% |
| 403 | 3 | 0.5% |

And the reruns are doing enormous work to hide it: **880 reruns across 261 distinct tests** in this single run (~100–130 reruns per job, on top of ~2300 tests). Job wall time is 35–40 min.

Two distinct server-side patterns, neither fixable client-side:

1. **Read-after-write lag** — a write returns `200`, the immediately-following read returns the *previous* state. These surface as `AssertionError`, which `--only-rerun` deliberately does not match, so they always hard-fail. Most frequent: `TestHfApiEndpoints::test_update_repo_settings` (6 failures, 3/4 Ubuntu jobs) does 6 × `PUT /settings` + `GET model_info` and fails with `assert 'auto' == 'manual'` / `assert False == 'auto'`. Same shape in `test_collection_items`, `test_commit_to_repo_in_background` (`assert 3 == 4`), `test_sync_local_folder`, `test_exists_after_repo_deletion`, `test_cp_remote_repo_to_repo`, and the `TestRepocardMetadataUpdate` cluster.

2. **`403 Forbidden` on `POST /api/repos/move`** — consistently fails `test_move_repo_normal_usage` and `test_download_regular_file_from_private_renamed_repo`. Looks like a hub-ci permission/config thing rather than a race; probably worth raising with the Hub team.

I deliberately did **not** widen `--only-rerun` to cover `AssertionError` — that would retry genuine regressions and hide real bugs. If the read-after-write lag stays this bad, the honest fix is a small poll-until-consistent helper used explicitly by the affected tests, but that's a bigger change and I'd rather agree on it first.

## Test plan

Both changed tests pass locally (Linux, hub-ci):

```
$ pytest tests/test_snapshot_download.py -k TestResolveRevision -q
3 passed, 17 deselected, 1 warning in 19.32s

$ pytest tests/test_hf_file_system.py -k "get_file" -q
4 passed, 112 deselected, 3 warnings in 11.85s
```

The first fix can only be *confirmed* by the Windows jobs on this PR — that's the main thing to watch. (Fun detail: the first attempt at that second command errored out in fixture setup from hub-ci flakiness, then passed on re-run. Very on-topic.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to test harness behavior; no production library code is modified.
> 
> **Overview**
> This PR tightens **test-only** fixes for two Windows CI failures that were masking or misreporting real errors.
> 
> In `test_download_with_resolved_revision`, the offline `hf_hub_download` assertion now uses `os.path.join(self.commit_hash, "dummy_file.txt")` instead of a POSIX-style `f"{hash}/dummy_file.txt"` suffix, so local paths with backslashes on Windows match correctly.
> 
> In `test_hf_file_system.py`, every `get_file` test that uses `tempfile.TemporaryDirectory()` now passes **`ignore_cleanup_errors=True`**. On Windows, a failed download can leave an open file handle; default temp-dir teardown then raises `NotADirectoryError`, which bypasses `pytest-rerunfailures` rules meant for transient HTTP errors like 504. Ignoring cleanup errors lets the underlying hub error surface and be retried as intended.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ace1fc05fe02ecca8d4a2ad745d4414ca3f4632. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->