### PR TITLE
Bump pinned doc-builder workflow SHA to 23dc84b

### DIFF
--- a/.github/workflows/build_documentation.yaml
+++ b/.github/workflows/build_documentation.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
    build:
-    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@0f4784322c564503c4a4d67ccb7fba29e32f111a  # main
+    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@23dc84b78b3a9e82cfafe163292de87e5d2ee07f  # main
     with:
       commit_sha: ${{ github.sha }}
       package: huggingface_hub

--- a/.github/workflows/build_pr_documentation.yaml
+++ b/.github/workflows/build_pr_documentation.yaml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@0f4784322c564503c4a4d67ccb7fba29e32f111a  # main
+    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@23dc84b78b3a9e82cfafe163292de87e5d2ee07f  # main
     with:
       commit_sha: ${{ github.event.pull_request.head.sha }}
       pr_number: ${{ github.event.number }}

--- a/.github/workflows/upload_pr_documentation.yaml
+++ b/.github/workflows/upload_pr_documentation.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@0f4784322c564503c4a4d67ccb7fba29e32f111a  # main
+    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@23dc84b78b3a9e82cfafe163292de87e5d2ee07f  # main
     with:
       package_name: huggingface_hub
     secrets:


### PR DESCRIPTION
Bumps the three pinned `huggingface/doc-builder` reusable-workflow SHAs from `0f47843` to `23dc84b` (current doc-builder `main`):

- `.github/workflows/build_documentation.yaml`
- `.github/workflows/build_pr_documentation.yaml`
- `.github/workflows/upload_pr_documentation.yaml`

`23dc84b` is the merge of huggingface/doc-builder#810, which restores method names, anchors, signatures and the `**Parameters:**` / `**Returns:**` labels in the `.md` (llms / plain-text) export of `[[autodoc]]` pages. Before the fix, [`hf_api.md`](https://huggingface.co/docs/huggingface_hub/package_reference/hf_api.md) had **zero** `####` method headings — LLM consumers of `*.md` couldn't see method names or signatures at all.

Verified on the main-docs build that ran right after that merge ([run 30554127566](https://github.com/huggingface/huggingface_hub/actions/runs/30554127566)): `main/en/package_reference/hf_api.md` went from 0 to 204 `####` headings, with `**Parameters:**` ×192 and `**Returns:**` ×103, and is live at [`/docs/huggingface_hub/main/en/package_reference/hf_api.md`](https://huggingface.co/docs/huggingface_hub/main/en/package_reference/hf_api.md).

Note this pin only selects the workflow YAML version — the reusable workflow checks out doc-builder with no `ref`, so builds already install from `main`. This is pin hygiene, not a behavior change. The unversioned `/docs/huggingface_hub/…` URLs still serve `v1.26.0`, whose zip predates the fix and needs a release-tag doc rebuild to pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates reusable-workflow commit SHAs in CI; no application or library code changes.
> 
> **Overview**
> **Pins** the three documentation CI workflows (`build_documentation`, `build_pr_documentation`, `upload_pr_documentation`) to doc-builder commit **`23dc84b`** instead of **`0f47843`**.
> 
> That upstream change restores method headings, anchors, signatures, and **Parameters** / **Returns** labels in plain-text `.md` exports of `[[autodoc]]` pages. The pin is workflow-YAML hygiene; reusable workflows already pull doc-builder from `main`, so this is not expected to change runtime behavior beyond keeping pins aligned with the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dd0b68c172eca36059c9d4c8c638b4d4ab81cf1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->