### PR TITLE
Fix import path in parse_hf_mount doc example

### DIFF
--- a/docs/source/en/package_reference/hf_uris.md
+++ b/docs/source/en/package_reference/hf_uris.md
@@ -186,7 +186,7 @@ Use the `type` and `id` fields directly. The boolean properties [`is_repo`] and 
 [`parse_hf_mount`] parses a mount specification (a HF URI with a local mount path and optional `:ro`/`:rw` flag) and returns a frozen [`HfMount`] dataclass. It uses [`parse_hf_uri`] under the hood.
 
 ```python
->>> from huggingface_hub import parse_hf_mount
+>>> from huggingface_hub.utils import parse_hf_mount
 >>> parse_hf_mount("hf://buckets/my-org/my-bucket/sub/dir:/mnt:ro")
 HfMount(source=HfUri(type='bucket', id='my-org/my-bucket', revision=None, path_in_repo='sub/dir'), mount_path='/mnt', read_only=True)
 ```


### PR DESCRIPTION
The example at `docs/source/en/package_reference/hf_uris.md:189` currently runs `from huggingface_hub import parse_hf_mount`, which raises `ImportError: cannot import name 'parse_hf_mount' from 'huggingface_hub'` (only `parse_hf_uri` is exported top-level).

The symbol lives in `huggingface_hub.utils`, as the source docstring already writes it (`src/huggingface_hub/utils/_hf_uris.py:468`) and as the autodoc directives in this same doc file use it (`hf_uris.md:204-210`, e.g. `[[autodoc]] huggingface_hub.utils.parse_hf_mount`). One-line docs change, no code touched.

Verified on this branch:

```
$ python -c "from huggingface_hub.utils import parse_hf_mount; print(parse_hf_mount('hf://buckets/my-org/my-bucket/sub/dir:/mnt:ro'))"
HfMount(source=HfUri(type='bucket', id='my-org/my-bucket', revision=None, path_in_repo='sub/dir'), mount_path='/mnt', read_only=True)
```

which matches the expected output already printed in the doc at line 191.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only fix to a single import line in an example; no code paths or public API surface are modified.
> 
> **Overview**
> Corrects the **Parsing mounts** doctest so it imports `parse_hf_mount` from `huggingface_hub.utils` instead of the top-level `huggingface_hub` package, which does not export that name and would raise `ImportError` if copied verbatim.
> 
> This matches the autodoc references on the same page and the implementation’s own docstring examples; no runtime or API behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bdff07ea3a57fc465b2e0be71dbe5e1f7b74572. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->