### PR TITLE
Improve wording in cache limitations documentation

### DIFF
--- a/docs/source/en/guides/manage-cache.md
+++ b/docs/source/en/guides/manage-cache.md
@@ -184,12 +184,12 @@ excluded from backups.
 
 In order to have an efficient cache-system, `huggingface-hub` uses symlinks. However,
 symlinks are not supported on all machines. This is a known limitation especially on
-Windows. When this is the case, `huggingface_hub` does not use the `blobs/` directory and
-stores the files directly in the `snapshots/` directory instead. This workaround allows
-users to download and cache files from the Hub in the same way. Tools for inspecting
-and deleting the cache (see below) are also supported. However, the cache system is less
-efficient because a single file might be downloaded several times if multiple revisions
-of the same repository are downloaded.
+Windows. When this is the case, `huggingface_hub` does not use the `blobs/` directory but
+directly stores the files in the `snapshots/` directory instead. This workaround allows
+users to download and cache files from the Hub exactly the same way. Tools to inspect
+and delete the cache (see below) are also supported. However, the cache-system is less
+efficient as a single file might be downloaded several times if multiple revisions of
+the same repo are downloaded.
 
 If you want to benefit from the symlink-based cache-system on a Windows machine, you
 either need to [activate Developer Mode](https://docs.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development)

--- a/docs/source/en/guides/manage-cache.md
+++ b/docs/source/en/guides/manage-cache.md
@@ -184,12 +184,12 @@ excluded from backups.
 
 In order to have an efficient cache-system, `huggingface-hub` uses symlinks. However,
 symlinks are not supported on all machines. This is a known limitation especially on
-Windows. When this is the case, `huggingface_hub` do not use the `blobs/` directory but
-directly stores the files in the `snapshots/` directory instead. This workaround allows
-users to download and cache files from the Hub exactly the same way. Tools to inspect
-and delete the cache (see below) are also supported. However, the cache-system is less
-efficient as a single file might be downloaded several times if multiple revisions of
-the same repo is downloaded.
+Windows. When this is the case, `huggingface_hub` does not use the `blobs/` directory and
+stores the files directly in the `snapshots/` directory instead. This workaround allows
+users to download and cache files from the Hub in the same way. Tools for inspecting
+and deleting the cache (see below) are also supported. However, the cache system is less
+efficient because a single file might be downloaded several times if multiple revisions
+of the same repository are downloaded.
 
 If you want to benefit from the symlink-based cache-system on a Windows machine, you
 either need to [activate Developer Mode](https://docs.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development)


### PR DESCRIPTION
## Summary

This PR improves the wording and grammar in the Windows cache limitations section of the documentation.

### Changes

- Fixes subject-verb agreement.
- Improves sentence clarity.
- Uses more natural wording while preserving the original meaning.

Related to #3636

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing docs wording only; no runtime, cache, or library logic is modified.
> 
> **Overview**
> **Documentation-only** edits in the **Limitations** subsection of `manage-cache.md` (Windows / no-symlink cache behavior).
> 
> - Corrects subject–verb agreement: `huggingface_hub` **does not** (was “do not”).
> - Fixes the conditional clause so **revisions … are downloaded** (was “revision … is downloaded”).
> 
> No behavioral or API changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2235934dcc36c9728ef69cab98d17ff0f593e3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->