### PR TITLE
[Docs] Normalize malformed docstring parameter entries

### DIFF
--- a/src/huggingface_hub/_commit_api.py
+++ b/src/huggingface_hub/_commit_api.py
@@ -66,7 +66,7 @@ class CommitOperationDelete:
         path_in_repo (`str`):
             Relative filepath in the repo, for example: `"checkpoints/1fec34a/weights.bin"`
             for a file or `"checkpoints/1fec34a/"` for a folder.
-        is_folder (`bool` or `Literal["auto"]`, *optional*)
+        is_folder (`bool` or `Literal["auto"]`, *optional*):
             Whether the Delete Operation applies to a folder or not. If "auto", the path
             type (file or folder) is guessed automatically by looking if path ends with
             a "/" (folder) or not (file). To explicitly set the path type, you can set

--- a/src/huggingface_hub/community.py
+++ b/src/huggingface_hub/community.py
@@ -114,7 +114,7 @@ class DiscussionWithDetails(Discussion):
             Whether or not this is a Pull Request.
         created_at (`datetime`):
             The `datetime` of creation of the Discussion / Pull Request.
-        events (`list` of [`DiscussionEvent`])
+        events (`list` of [`DiscussionEvent`]):
             The list of [`DiscussionEvents`] in this Discussion or Pull Request.
         conflicting_files (`Union[list[str], bool, None]`, *optional*):
             A list of conflicting files if this is a Pull Request.

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -5701,7 +5701,7 @@ class HfApi:
                 The git revision to commit from. Defaults to the head of the `"main"` branch.
             commit_message (`str`, *optional*):
                 The summary / title / first line of the generated commit
-            commit_description (`str` *optional*)
+            commit_description (`str`, *optional*):
                 The description of the generated commit
             create_pr (`boolean`, *optional*):
                 Whether or not to create a Pull Request with that commit. Defaults to `False`.
@@ -6111,7 +6111,7 @@ class HfApi:
             commit_message (`str`, *optional*):
                 The summary / title / first line of the generated commit. Defaults to
                 `f"Delete {path_in_repo} with huggingface_hub"`.
-            commit_description (`str` *optional*)
+            commit_description (`str`, *optional*):
                 The description of the generated commit
             create_pr (`boolean`, *optional*):
                 Whether or not to create a Pull Request with that commit. Defaults to `False`.
@@ -6206,7 +6206,7 @@ class HfApi:
             commit_message (`str`, *optional*):
                 The summary (first line) of the generated commit. Defaults to
                 `f"Delete files using huggingface_hub"`.
-            commit_description (`str` *optional*)
+            commit_description (`str`, *optional*):
                 The description of the generated commit.
             create_pr (`boolean`, *optional*):
                 Whether or not to create a Pull Request with that commit. Defaults to `False`.
@@ -6279,7 +6279,7 @@ class HfApi:
             commit_message (`str`, *optional*):
                 The summary / title / first line of the generated commit. Defaults to
                 `f"Delete folder {path_in_repo} with huggingface_hub"`.
-            commit_description (`str` *optional*)
+            commit_description (`str`, *optional*):
                 The description of the generated commit.
             create_pr (`boolean`, *optional*):
                 Whether or not to create a Pull Request with that commit. Defaults to `False`.
@@ -12076,7 +12076,7 @@ class HfApi:
             namespace (`str`, *optional*):
                 The namespace where the Job will be created. Defaults to the current user's namespace.
 
-            token `(Union[bool, str, None]`, *optional*):
+            token (`bool` or `str`, *optional*):
                 A valid user access token. If not provided, the locally saved token will be used, which is the
                 recommended authentication method. Set to `False` to disable authentication.
                 Refer to: https://huggingface.co/docs/huggingface_hub/quick-start#authentication.
@@ -12206,7 +12206,7 @@ class HfApi:
                 starts from the last N lines and continues streaming new logs. When `follow=False`,
                 returns only the last N lines from currently available logs.
 
-            token `(Union[bool, str, None]`, *optional*):
+            token (`bool` or `str`, *optional*):
                 A valid user access token. If not provided, the locally saved token will be used, which is the
                 recommended authentication method. Set to `False` to disable authentication.
                 Refer to: https://huggingface.co/docs/huggingface_hub/quick-start#authentication.
@@ -12275,7 +12275,7 @@ class HfApi:
             namespace (`str`, *optional*):
                 The namespace where the Job is running. Defaults to the current user's namespace.
 
-            token `(Union[bool, str, None]`, *optional*):
+            token (`bool` or `str`, *optional*):
                 A valid user access token. If not provided, the locally saved token will be used, which is the
                 recommended authentication method. Set to `False` to disable authentication.
                 Refer to: https://huggingface.co/docs/huggingface_hub/quick-start#authentication.
@@ -12350,7 +12350,7 @@ class HfApi:
             namespace (`str`, *optional*):
                 The namespace from where it lists the jobs. Defaults to the current user's namespace.
 
-            token `(Union[bool, str, None]`, *optional*):
+            token (`bool` or `str`, *optional*):
                 A valid user access token. If not provided, the locally saved token will be used, which is the
                 recommended authentication method. Set to `False` to disable authentication.
                 Refer to: https://huggingface.co/docs/huggingface_hub/quick-start#authentication.
@@ -12417,7 +12417,7 @@ class HfApi:
             namespace (`str`, *optional*):
                 The namespace where the Job is running. Defaults to the current user's namespace.
 
-            token `(Union[bool, str, None]`, *optional*):
+            token (`bool` or `str`, *optional*):
                 A valid user access token. If not provided, the locally saved token will be used, which is the
                 recommended authentication method. Set to `False` to disable authentication.
                 Refer to: https://huggingface.co/docs/huggingface_hub/quick-start#authentication.
@@ -12516,7 +12516,7 @@ class HfApi:
             namespace (`str`, *optional*):
                 The namespace where the Job(s) are running. Defaults to the current user's namespace.
 
-            token `(Union[bool, str, None]`, *optional*):
+            token (`bool` or `str`, *optional*):
                 A valid user access token. If not provided, the locally saved token will be used, which is the
                 recommended authentication method. Set to `False` to disable authentication.
                 Refer to: https://huggingface.co/docs/huggingface_hub/quick-start#authentication.
@@ -12582,7 +12582,7 @@ class HfApi:
             namespace (`str`, *optional*):
                 The namespace where the Job is running. Defaults to the current user's namespace.
 
-            token `(Union[bool, str, None]`, *optional*):
+            token (`bool` or `str`, *optional*):
                 A valid user access token. If not provided, the locally saved token will be used, which is the
                 recommended authentication method. Set to `False` to disable authentication.
                 Refer to: https://huggingface.co/docs/huggingface_hub/quick-start#authentication.
@@ -12620,7 +12620,7 @@ class HfApi:
             namespace (`str`, *optional*):
                 The namespace where the Job is running. Defaults to the current user's namespace.
 
-            token `(Union[bool, str, None]`, *optional*):
+            token (`bool` or `str`, *optional*):
                 A valid user access token. If not provided, the locally saved token will be used, which is the
                 recommended authentication method. Set to `False` to disable authentication.
                 Refer to: https://huggingface.co/docs/huggingface_hub/quick-start#authentication.
@@ -12667,13 +12667,13 @@ class HfApi:
             script (`str`):
                 Path or URL of the UV script, or a command.
 
-            script_args (`list[str]`, *optional*)
+            script_args (`list[str]`, *optional*):
                 Arguments to pass to the script or command.
 
-            dependencies (`list[str]`, *optional*)
+            dependencies (`list[str]`, *optional*):
                 Dependencies to use to run the UV script.
 
-            python (`str`, *optional*)
+            python (`str`, *optional*):
                 Use a specific Python version. Default is 3.12.
 
             image (`str`, *optional*, defaults to "ghcr.io/astral-sh/uv:python3.12-bookworm"):
@@ -12724,7 +12724,7 @@ class HfApi:
             namespace (`str`, *optional*):
                 The namespace where the Job will be created. Defaults to the current user's namespace.
 
-            token `(Union[bool, str, None]`, *optional*):
+            token (`bool` or `str`, *optional*):
                 A valid user access token. If not provided, the locally saved token will be used, which is the
                 recommended authentication method. Set to `False` to disable authentication.
                 Refer to: https://huggingface.co/docs/huggingface_hub/quick-start#authentication.
@@ -12888,7 +12888,7 @@ class HfApi:
             namespace (`str`, *optional*):
                 The namespace where the Job will be created. Defaults to the current user's namespace.
 
-            token `(Union[bool, str, None]`, *optional*):
+            token (`bool` or `str`, *optional*):
                 A valid user access token. If not provided, the locally saved token will be used, which is the
                 recommended authentication method. Set to `False` to disable authentication.
                 Refer to: https://huggingface.co/docs/huggingface_hub/quick-start#authentication.
@@ -12971,7 +12971,7 @@ class HfApi:
             namespace (`str`, *optional*):
                 The namespace from where it lists the jobs. Defaults to the current user's namespace.
 
-            token `(Union[bool, str, None]`, *optional*):
+            token (`bool` or `str`, *optional*):
                 A valid user access token. If not provided, the locally saved token will be used, which is the
                 recommended authentication method. Set to `False` to disable authentication.
                 Refer to: https://huggingface.co/docs/huggingface_hub/quick-start#authentication.
@@ -13003,7 +13003,7 @@ class HfApi:
             namespace (`str`, *optional*):
                 The namespace where the scheduled Job is. Defaults to the current user's namespace.
 
-            token `(Union[bool, str, None]`, *optional*):
+            token (`bool` or `str`, *optional*):
                 A valid user access token. If not provided, the locally saved token will be used, which is the
                 recommended authentication method. Set to `False` to disable authentication.
                 Refer to: https://huggingface.co/docs/huggingface_hub/quick-start#authentication.
@@ -13042,7 +13042,7 @@ class HfApi:
             namespace (`str`, *optional*):
                 The namespace where the scheduled Job is. Defaults to the current user's namespace.
 
-            token `(Union[bool, str, None]`, *optional*):
+            token (`bool` or `str`, *optional*):
                 A valid user access token. If not provided, the locally saved token will be used, which is the
                 recommended authentication method. Set to `False` to disable authentication.
                 Refer to: https://huggingface.co/docs/huggingface_hub/quick-start#authentication.
@@ -13072,7 +13072,7 @@ class HfApi:
             namespace (`str`, *optional*):
                 The namespace where the scheduled Job is. Defaults to the current user's namespace.
 
-            token `(Union[bool, str, None]`, *optional*):
+            token (`bool` or `str`, *optional*):
                 A valid user access token. If not provided, the locally saved token will be used, which is the
                 recommended authentication method. Set to `False` to disable authentication.
                 Refer to: https://huggingface.co/docs/huggingface_hub/quick-start#authentication.
@@ -13102,7 +13102,7 @@ class HfApi:
             namespace (`str`, *optional*):
                 The namespace where the scheduled Job is. Defaults to the current user's namespace.
 
-            token `(Union[bool, str, None]`, *optional*):
+            token (`bool` or `str`, *optional*):
                 A valid user access token. If not provided, the locally saved token will be used, which is the
                 recommended authentication method. Set to `False` to disable authentication.
                 Refer to: https://huggingface.co/docs/huggingface_hub/quick-start#authentication.
@@ -13136,7 +13136,7 @@ class HfApi:
             namespace (`str`, *optional*):
                 The namespace where the scheduled Job is. Defaults to the current user's namespace.
 
-            token `(Union[bool, str, None]`, *optional*):
+            token (`bool` or `str`, *optional*):
                 A valid user access token. If not provided, the locally saved token will be used, which is the
                 recommended authentication method. Set to `False` to disable authentication.
                 Refer to: https://huggingface.co/docs/huggingface_hub/quick-start#authentication.
@@ -13182,7 +13182,7 @@ class HfApi:
             namespace (`str`, *optional*):
                 The namespace where the scheduled Job is. Defaults to the current user's namespace.
 
-            token `(Union[bool, str, None]`, *optional*):
+            token (`bool` or `str`, *optional*):
                 A valid user access token. If not provided, the locally saved token will be used, which is the
                 recommended authentication method. Set to `False` to disable authentication.
                 Refer to: https://huggingface.co/docs/huggingface_hub/quick-start#authentication.
@@ -13231,7 +13231,7 @@ class HfApi:
             script (`str`):
                 Path or URL of the UV script, or a command.
 
-            script_args (`list[str]`, *optional*)
+            script_args (`list[str]`, *optional*):
                 Arguments to pass to the script, or a command.
 
             schedule (`str`):
@@ -13244,10 +13244,10 @@ class HfApi:
             concurrency (`bool`, *optional*):
                 If True, multiple instances of this Job can run concurrently. Defaults to False.
 
-            dependencies (`list[str]`, *optional*)
+            dependencies (`list[str]`, *optional*):
                 Dependencies to use to run the UV script.
 
-            python (`str`, *optional*)
+            python (`str`, *optional*):
                 Use a specific Python version. Default is 3.12.
 
             image (`str`, *optional*, defaults to "ghcr.io/astral-sh/uv:python3.12-bookworm"):
@@ -13292,7 +13292,7 @@ class HfApi:
             namespace (`str`, *optional*):
                 The namespace where the Job will be created. Defaults to the current user's namespace.
 
-            token `(Union[bool, str, None]`, *optional*):
+            token (`bool` or `str`, *optional*):
                 A valid user access token. If not provided, the locally saved token will be used, which is the
                 recommended authentication method. Set to `False` to disable authentication.
                 Refer to: https://huggingface.co/docs/huggingface_hub/quick-start#authentication.

--- a/src/huggingface_hub/repocard.py
+++ b/src/huggingface_hub/repocard.py
@@ -247,7 +247,7 @@ class RepoCard:
                 function is called by a child class, it will default to the child class's `repo_type`.
             commit_message (`str`, *optional*):
                 The summary / title / first line of the generated commit.
-            commit_description (`str`, *optional*)
+            commit_description (`str`, *optional*):
                 The description of the generated commit.
             revision (`str`, *optional*):
                 The git revision to commit from. Defaults to the head of the `"main"` branch.
@@ -721,7 +721,7 @@ def metadata_update(
         commit_message (`str`, *optional*):
             The summary / title / first line of the generated commit. Defaults to
             `f"Update metadata with huggingface_hub"`
-        commit_description (`str` *optional*)
+        commit_description (`str`, *optional*):
             The description of the generated commit
         revision (`str`, *optional*):
             The git revision to commit from. Defaults to the head of the

--- a/src/huggingface_hub/repocard_data.py
+++ b/src/huggingface_hub/repocard_data.py
@@ -483,29 +483,29 @@ class SpaceCardData(CardData):
     To get an exhaustive reference of Spaces configuration, please visit https://huggingface.co/docs/hub/spaces-config-reference#spaces-configuration-reference.
 
     Args:
-        title (`str`, *optional*)
+        title (`str`, *optional*):
             Title of the Space.
-        sdk (`str`, *optional*)
+        sdk (`str`, *optional*):
             SDK of the Space (one of `gradio`, `streamlit`, `docker`, or `static`).
-        sdk_version (`str`, *optional*)
+        sdk_version (`str`, *optional*):
             Version of the used SDK (if Gradio/Streamlit sdk).
-        python_version (`str`, *optional*)
+        python_version (`str`, *optional*):
             Python version used in the Space (if Gradio/Streamlit sdk).
-        app_file (`str`, *optional*)
+        app_file (`str`, *optional*):
             Path to your main application file (which contains either gradio or streamlit Python code, or static html code).
             Path is relative to the root of the repository.
-        app_port (`str`, *optional*)
+        app_port (`str`, *optional*):
             Port on which your application is running. Used only if sdk is `docker`.
-        license (`str`, *optional*)
+        license (`str`, *optional*):
             License of this model. Example: apache-2.0 or any license from
             https://huggingface.co/docs/hub/repositories-licenses.
-        duplicated_from (`str`, *optional*)
+        duplicated_from (`str`, *optional*):
             ID of the original Space if this is a duplicated Space.
         models (list[`str`], *optional*)
             List of models related to this Space. Should be a dataset ID found on https://hf.co/models.
-        datasets (`list[str]`, *optional*)
+        datasets (`list[str]`, *optional*):
             List of datasets related to this Space. Should be a dataset ID found on https://hf.co/datasets.
-        tags (`list[str]`, *optional*)
+        tags (`list[str]`, *optional*):
             List of tags to add to your Space that can be used when filtering on the Hub.
         ignore_metadata_errors (`str`):
             If True, errors while parsing the metadata section will be ignored. Some information might be lost during

--- a/src/huggingface_hub/repocard_data.py
+++ b/src/huggingface_hub/repocard_data.py
@@ -501,7 +501,7 @@ class SpaceCardData(CardData):
             https://huggingface.co/docs/hub/repositories-licenses.
         duplicated_from (`str`, *optional*):
             ID of the original Space if this is a duplicated Space.
-        models (list[`str`], *optional*)
+        models (`list[str]`, *optional*):
             List of models related to this Space. Should be a dataset ID found on https://hf.co/models.
         datasets (`list[str]`, *optional*):
             List of datasets related to this Space. Should be a dataset ID found on https://hf.co/datasets.

--- a/src/huggingface_hub/utils/_cache_manager.py
+++ b/src/huggingface_hub/utils/_cache_manager.py
@@ -873,9 +873,9 @@ def _try_delete_path(path: Path, path_type: str) -> None:
     If the path does not exist, error is logged as a warning and then ignored.
 
     Args:
-        path (`Path`)
+        path (`Path`):
             Path to delete. Can be a file or a folder.
-        path_type (`str`)
+        path_type (`str`):
             What path are we deleting ? Only for logging purposes. Example: "snapshot".
     """
     logger.info(f"Delete {path_type}: {path}")


### PR DESCRIPTION
## Summary

44 docstring parameter entries don't follow the ``name (`type`, *optional*):`` convention from [docs/README.md](https://github.com/huggingface/huggingface_hub/tree/main/docs#defining-arguments-in-a-method). Two distinct breakages:

- **Backtick before the paren — 18 entries**, all in the Jobs / scheduled-jobs block of `hf_api.py`:

  ```
  token `(Union[bool, str, None]`, *optional*):
  ```

  Normalized to the form the other ~133 `token` entries in the same file already use:

  ```
  token (`bool` or `str`, *optional*):
  ```

- **Missing trailing colon — 26 entries** across six files, sometimes also missing the comma before `*optional*`:

  ```
  commit_description (`str` *optional*)      ->  commit_description (`str`, *optional*):
  events (`list` of [`DiscussionEvent`])     ->  events (`list` of [`DiscussionEvent`]):
  path (`Path`)                              ->  path (`Path`):
  ```

Formatting only — 44 insertions, 44 deletions, no lines added or removed, no behavior change.

### One decision worth calling out

For the 18 `token` entries I changed the type text as well as the backtick placement. The minimal fix would have been moving the backtick and keeping `Union[bool, str, None]`, but that leaves those 18 as the only entries in the file spelling the type that way, and `AGENTS.md` prefers `str | None` over `Optional`/`Union` spellings. "Make the 18 match the other 133" felt like the more reviewable rule. Happy to switch to the backtick-only fix if you'd rather keep the diff smaller.

`community.py` is the clearest illustration of why these are worth fixing — the broken entry sits between two correct ones:

```
is_pull_request (`bool`):
    Whether or not this is a Pull Request.
events (`list` of [`DiscussionEvent`])          <- no colon
    The list of [`DiscussionEvents`] in this Discussion or Pull Request.
conflicting_files (`Union[list[str], bool, None]`, *optional*):
    A list of conflicting files if this is a Pull Request.
```

## Manual testing

```
$ make style && make quality
python utils/check_all_variable.py
✅ All good! the __all__ variable is up to date
python utils/generate_async_inference_client.py
✅ All good! (AsyncInferenceClient)
python utils/generate_cli_reference.py
✅ All good! (CLI reference)
ty check src
All checks passed!
```

Both breakages are gone afterwards:

```
$ grep -rcE '^\s+[a-z_][a-z_0-9]* `\(' --include='*.py' src/huggingface_hub | awk -F: '{s+=$2} END {print s+0}'
0
$ grep -rhE '^\s+[a-z_][a-z_0-9]* \(`.*\)\s*$' --include='*.py' src/huggingface_hub | wc -l
0
```

```
$ pytest tests/test_utils_paths.py tests/test_utils_cache.py tests/test_repocard.py -q
94 passed, 1 skipped
```

Two `TestRepocardMetadataUpdate` tests failed intermittently on a first full-file run; they pass both on `main` and on this branch when run in isolation, so they look like flakes against the live Hub rather than anything from this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstring-only edits with no logic, types, or public API changes.
> 
> **Overview**
> Brings **44** docstring `Args` lines in line with the project's ``name (`type`, *optional*):`` convention (see `docs/README.md`). No runtime or API behavior changes.
> 
> **Jobs APIs in `hf_api.py`:** Fixes **18** `token` parameter lines that had a stray backtick before the opening paren (`token `(Union[bool, str, None]`, ...`) and rewrites the type to ``(`bool` or `str`, *optional*):`` so they match the rest of the file.
> 
> **Across six modules:** Fixes **26** entries missing a trailing colon (and sometimes a comma before `*optional*`), including `commit_description` on upload/delete/commit helpers, `events` on `Discussion`, `is_folder` on `CommitOperationDelete`, `SpaceCardData` fields in `repocard_data.py`, and `path` / `path_type` in `_cache_manager.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04b86d9c9b19aa2b722203ae6521039bd95adef9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->