### PR TITLE
docs(inference): note OpenAI-compatible multi-model gateway base_url

### DIFF
--- a/docs/source/en/guides/inference.md
+++ b/docs/source/en/guides/inference.md
@@ -153,6 +153,8 @@ You can use [`InferenceClient`] to run chat completion with local inference serv
 
 > [!TIP]
 > Similarly to the OpenAI Python client, [`InferenceClient`] can be used to run Chat Completion inference with any OpenAI REST API-compatible endpoint.
+>
+> The same `base_url` / endpoint pattern also works with OpenAI-compatible multi-model gateways when you are not self-hosting — for example [DaoXE](https://daoxe.com) at `https://api.daoxe.com/v1`.
 
 ### Authentication
 


### PR DESCRIPTION
## Summary

The InferenceClient local-endpoints docs already explain that any OpenAI REST API-compatible endpoint works via the same client pattern.

This PR adds one concrete multi-model gateway example ([DaoXE](https://daoxe.com) at `https://api.daoxe.com/v1`) so readers who are not self-hosting know the same `base_url` / endpoint pattern applies.

Docs only — no runtime behavior changes.

## Test plan
- [ ] Inference guide renders
- [ ] Local endpoint example unchanged
- [ ] Tip is clearly optional

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API impact.
> 
> **Overview**
> Extends the **Using local endpoints** tip in the inference guide so readers know the same OpenAI-compatible `base_url` / endpoint setup applies beyond self-hosted servers.
> 
> Adds one optional example: hosted multi-model gateways such as [DaoXE](https://daoxe.com) at `https://api.daoxe.com/v1`. No code or API behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c20c6e11e41e5ec38832fff6cf02201ceeba9f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->