### PR TITLE
Add require_complete to snapshot_download

### DIFF
--- a/docs/source/en/guides/manage-cache.md
+++ b/docs/source/en/guides/manage-cache.md
@@ -107,6 +107,8 @@ Both [`snapshot_download`] and [`hf_hub_download`] read this cache to avoid netw
 
 Because the cached file list describes exactly what a commit should contain, [`snapshot_download`] can also tell whether a local snapshot is complete. If the Hub cannot be reached (you are offline, the connection fails, or you passed `local_files_only=True`) and some expected files are missing from the local snapshot, [`snapshot_download`] raises [`~errors.IncompleteSnapshotError`] instead of returning a partial folder. Before this, an incomplete snapshot was returned silently, which could leave you working with missing files without knowing it. Files excluded by `allow_patterns` or `ignore_patterns` are not counted as missing. The exception exposes the path to the incomplete snapshot via its `snapshot_path` attribute, so you can still locate the partially cached files if needed.
 
+When [`snapshot_download`] falls back to an existing local snapshot but no file list is cached for its commit, completeness cannot be checked and the snapshot is returned as-is. An existing non-empty `local_dir` is also returned as-is if its revision cannot be resolved locally. Pass `require_complete=True` to raise [`~errors.IncompleteSnapshotError`] in either case.
+
 ### .no_exist (advanced)
 
 In addition to the `blobs`, `refs` and `snapshots` folders, you might also find a `.no_exist` folder

--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -50,6 +50,7 @@ def snapshot_download(
     force_download: bool = False,
     token: bool | str | None = None,
     local_files_only: bool = False,
+    require_complete: bool = False,
     allow_patterns: list[str] | str | None = None,
     ignore_patterns: list[str] | str | None = None,
     max_workers: int = 8,
@@ -75,6 +76,7 @@ def snapshot_download(
     force_download: bool = False,
     token: bool | str | None = None,
     local_files_only: bool = False,
+    require_complete: bool = False,
     allow_patterns: list[str] | str | None = None,
     ignore_patterns: list[str] | str | None = None,
     max_workers: int = 8,
@@ -100,6 +102,7 @@ def snapshot_download(
     force_download: bool = False,
     token: bool | str | None = None,
     local_files_only: bool = False,
+    require_complete: bool = False,
     allow_patterns: list[str] | str | None = None,
     ignore_patterns: list[str] | str | None = None,
     max_workers: int = 8,
@@ -125,6 +128,7 @@ def snapshot_download(
     force_download: bool = False,
     token: bool | str | None = None,
     local_files_only: bool = False,
+    require_complete: bool = False,
     allow_patterns: list[str] | str | None = None,
     ignore_patterns: list[str] | str | None = None,
     max_workers: int = 8,
@@ -183,6 +187,10 @@ def snapshot_download(
             The Hub endpoint to send the request to. Defaults to the value of `HF_ENDPOINT`.
         local_files_only (`bool`, *optional*, defaults to `False`):
             If `True`, do not download any files even if they are not in `cache_dir` or `local_dir`.
+        require_complete (`bool`, *optional*, defaults to `False`):
+            If `True`, when falling back to an existing local snapshot, raise
+            [`~errors.IncompleteSnapshotError`] instead of returning it if completeness cannot be checked
+            because no tree listing is cached for the commit or the revision cannot be resolved locally.
         allow_patterns (`list[str]` or `str`, *optional*):
             If provided, only files matching at least one pattern are downloaded.
         ignore_patterns (`list[str]` or `str`, *optional*):
@@ -212,8 +220,9 @@ def snapshot_download(
         [`~utils.RevisionNotFoundError`]
             If the revision to download from cannot be found.
         [`~errors.IncompleteSnapshotError`]
-            If the Hub cannot be reached (offline, connection issue, or `local_files_only=True`) and the
-            cached snapshot is missing some of the requested files.
+            If an existing local snapshot is selected while the Hub cannot be reached (offline, connection
+            issue, or `local_files_only=True`) and it is missing some of the requested files, or, with
+            `require_complete=True`, cannot be shown to hold them.
         [`EnvironmentError`](https://docs.python.org/3/library/exceptions.html#EnvironmentError)
             If `token=True` and the token cannot be found.
         [`OSError`](https://docs.python.org/3/library/exceptions.html#OSError) if
@@ -327,6 +336,7 @@ def snapshot_download(
                     repo_id=repo_id,
                     revision=revision,
                     api_call_error=api_call_error,
+                    require_complete=require_complete,
                 )
                 return snapshot_folder
 
@@ -344,7 +354,22 @@ def snapshot_download(
                         repo_id=repo_id,
                         revision=revision,
                         api_call_error=api_call_error,
+                        require_complete=require_complete,
                     )
+                elif require_complete:
+                    if api_call_error is not None:
+                        reason = (
+                            f"Resolving the revision from the Hub failed "
+                            f"({api_call_error.__class__.__name__}: {api_call_error})."
+                        )
+                    else:
+                        reason = "Outgoing traffic is disabled ('local_files_only=True')."
+                    raise IncompleteSnapshotError(
+                        f"The local snapshot for '{repo_id}' (revision '{revision}') cannot be shown to be complete: "
+                        f"the revision cannot be resolved to a commit locally, so no cached tree listing can be "
+                        f"selected. {reason} Re-run the download with network access to cache the listing.",
+                        snapshot_path=str(local_dir),
+                    ) from api_call_error
                 logger.warning(
                     f"Returning existing local_dir `{local_dir}` as remote repo cannot be accessed in `snapshot_download` ({api_call_error})."
                 )
@@ -550,14 +575,29 @@ def _raise_if_incomplete_snapshot(
     repo_id: str,
     revision: str,
     api_call_error: Exception | None,
+    require_complete: bool = False,
 ) -> None:
     """Raise [`IncompleteSnapshotError`] if the cached tree listing shows `base_dir` misses requested files.
 
-    If the tree listing is not cached we cannot tell, so we do nothing and the caller keeps returning the
-    folder as-is. Otherwise every expected file (after pattern filtering) must exist under `base_dir`.
+    If the tree listing is not cached we cannot tell. By default we do nothing and the caller keeps
+    returning the folder as-is; with `require_complete` not being able to tell is itself an error.
+    Otherwise every expected file (after pattern filtering) must exist under `base_dir`.
     """
+    if api_call_error is not None:
+        reason = f"The Hub could not be reached ({api_call_error.__class__.__name__}: {api_call_error})."
+    else:
+        reason = "Outgoing traffic is disabled ('local_files_only=True')."
+
     tree_entries = read_tree_cache(tree_cache_folder, commit_hash)
     if tree_entries is None:
+        if require_complete:
+            raise IncompleteSnapshotError(
+                f"The cached snapshot for '{repo_id}' (revision '{revision}', commit {commit_hash}) cannot be "
+                f"shown to be complete: no tree listing is cached for this commit, so which files the "
+                f"repository holds is unknown. {reason} Re-run the download with network access to cache the "
+                "listing.",
+                snapshot_path=base_dir,
+            ) from api_call_error
         return
     expected = filter_repo_objects(
         items=tree_entries.keys(), allow_patterns=allow_patterns, ignore_patterns=ignore_patterns
@@ -569,10 +609,6 @@ def _raise_if_incomplete_snapshot(
     sample = ", ".join(missing[:3])
     if len(missing) > 3:
         sample += f", ... ({len(missing) - 3} more)"
-    if api_call_error is not None:
-        reason = f"The Hub could not be reached ({api_call_error.__class__.__name__}: {api_call_error})."
-    else:
-        reason = "Outgoing traffic is disabled ('local_files_only=True')."
     raise IncompleteSnapshotError(
         f"The cached snapshot for '{repo_id}' (revision '{revision}', commit {commit_hash}) is incomplete: "
         f"{len(missing)} file(s) are missing ({sample}). {reason} Re-run the download with network access "

--- a/src/huggingface_hub/errors.py
+++ b/src/huggingface_hub/errors.py
@@ -473,9 +473,10 @@ class LocalEntryNotFoundError(FileNotFoundError, EntryNotFoundError):
 
 class IncompleteSnapshotError(LocalEntryNotFoundError):
     """
-    Raised by [`snapshot_download`] when the Hub cannot be reached (offline, connection issue, or
-    `local_files_only=True`) and the cached snapshot is known to be incomplete: some files listed in
-    the repository's cached tree listing are missing from the local snapshot.
+    Raised by [`snapshot_download`] when falling back to an existing local snapshot that is known to be
+    incomplete: some files listed in the repository's cached tree listing are missing. With
+    `require_complete=True` it is also raised when no tree listing is cached for the commit or the revision
+    cannot be resolved locally, so the snapshot cannot be shown to be complete.
 
     This is a subclass of [`LocalEntryNotFoundError`] for backward compatibility.
 

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -6671,6 +6671,7 @@ class HfApi:
         force_download: bool = False,
         token: bool | str | None = None,
         local_files_only: bool = False,
+        require_complete: bool = False,
         allow_patterns: list[str] | str | None = None,
         ignore_patterns: list[str] | str | None = None,
         max_workers: int = 8,
@@ -6691,6 +6692,7 @@ class HfApi:
         force_download: bool = False,
         token: bool | str | None = None,
         local_files_only: bool = False,
+        require_complete: bool = False,
         allow_patterns: list[str] | str | None = None,
         ignore_patterns: list[str] | str | None = None,
         max_workers: int = 8,
@@ -6711,6 +6713,7 @@ class HfApi:
         force_download: bool = False,
         token: bool | str | None = None,
         local_files_only: bool = False,
+        require_complete: bool = False,
         allow_patterns: list[str] | str | None = None,
         ignore_patterns: list[str] | str | None = None,
         max_workers: int = 8,
@@ -6758,6 +6761,10 @@ class HfApi:
             local_files_only (`bool`, *optional*, defaults to `False`):
                 If `True`, avoid downloading the file and return the path to the
                 local cached file if it exists.
+            require_complete (`bool`, *optional*, defaults to `False`):
+                If `True`, when falling back to an existing local snapshot, raise
+                [`~errors.IncompleteSnapshotError`] instead of returning it if completeness cannot be checked
+                because no tree listing is cached for the commit or the revision cannot be resolved locally.
             allow_patterns (`list[str]` or `str`, *optional*):
                 If provided, only files matching at least one pattern are downloaded.
             ignore_patterns (`list[str]` or `str`, *optional*):
@@ -6786,6 +6793,10 @@ class HfApi:
                 or because it is set to `private` and you do not have access.
             [`~utils.RevisionNotFoundError`]
                 If the revision to download from cannot be found.
+            [`~errors.IncompleteSnapshotError`]
+                If an existing local snapshot is selected while the Hub cannot be reached and it is missing
+                some of the requested files, or, with `require_complete=True`, its completeness cannot be
+                established.
             [`EnvironmentError`](https://docs.python.org/3/library/exceptions.html#EnvironmentError)
                 If `token=True` and the token cannot be found.
             [`OSError`](https://docs.python.org/3/library/exceptions.html#OSError) if
@@ -6813,6 +6824,7 @@ class HfApi:
             force_download=force_download,
             token=token,
             local_files_only=local_files_only,
+            require_complete=require_complete,
             allow_patterns=allow_patterns,
             ignore_patterns=ignore_patterns,
             max_workers=max_workers,

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -3479,6 +3479,7 @@ class TestDownloadHfApiAlias:
             etag_timeout=10,
             force_download=False,
             local_files_only=False,
+            require_complete=False,
             allow_patterns=None,
             ignore_patterns=None,
             max_workers=8,

--- a/tests/test_snapshot_download.py
+++ b/tests/test_snapshot_download.py
@@ -44,6 +44,26 @@ def test_tree_with_redacted_xet_hash_is_not_cached(tmp_path: Path):
     assert read_tree_cache(str(storage_folder), COMMIT_HASH) is None
 
 
+def test_require_complete_with_unresolved_local_dir(tmp_path: Path):
+    local_dir = tmp_path / "local"
+    local_dir.mkdir()
+    (local_dir / "partial.txt").touch()
+
+    assert snapshot_download(
+        "user/repo", cache_dir=tmp_path / "cache", local_dir=local_dir, local_files_only=True
+    ) == str(local_dir)
+
+    with pytest.raises(IncompleteSnapshotError) as error:
+        snapshot_download(
+            "user/repo",
+            cache_dir=tmp_path / "cache",
+            local_dir=local_dir,
+            local_files_only=True,
+            require_complete=True,
+        )
+    assert error.value.snapshot_path == str(local_dir)
+
+
 class TestSnapshotDownload:
     @pytest.fixture(scope="class", autouse=True)
     def _shared_repo(self, request, api: HfApi):
@@ -263,7 +283,7 @@ class TestSnapshotDownload:
 
             # A complete cached snapshot is still returned offline.
             with offline():
-                assert snapshot_download(self.repo_id, cache_dir=tmpdir) == snapshot_path
+                assert snapshot_download(self.repo_id, cache_dir=tmpdir, require_complete=True) == snapshot_path
 
             # Remove a file from the snapshot => offline re-pull now raises instead of returning a partial folder.
             os.remove(os.path.join(snapshot_path, "dummy_file.txt"))
@@ -271,6 +291,20 @@ class TestSnapshotDownload:
                 with offline(mode=offline_mode):
                     with pytest.raises(IncompleteSnapshotError):
                         snapshot_download(self.repo_id, cache_dir=tmpdir)
+
+    def test_require_complete_without_tree_cache(self):
+        """`hf_hub_download` writes no tree listing, so the resulting snapshot cannot be checked."""
+        with SoftTemporaryDirectory() as tmpdir:
+            hf_hub_download(self.repo_id, "dummy_file.txt", cache_dir=tmpdir)
+
+            with offline():
+                # Without a listing, the partial snapshot is returned as-is...
+                snapshot_path = snapshot_download(self.repo_id, cache_dir=tmpdir)
+                assert os.listdir(snapshot_path) == ["dummy_file.txt"]
+
+                # ...unless the caller asks for a snapshot that can be shown to be complete.
+                with pytest.raises(IncompleteSnapshotError):
+                    snapshot_download(self.repo_id, cache_dir=tmpdir, require_complete=True)
 
     def test_download_model_local_only_multiple(self):
         # cache multiple commits and make sure correct commit is taken


### PR DESCRIPTION
## Summary

- add an opt-in `require_complete` check to `snapshot_download` and `HfApi.snapshot_download`
- raise `IncompleteSnapshotError` during local cache fallback when the requested snapshot cannot be shown to contain every requested file
- keep the current fallback by default so caches created by older clients or by `hf_hub_download` continue to work
- document the strict mode in the cache guide

Closes #4624.

Offline completeness checks depend on the cached tree listing for the resolved commit. A cache populated file by file with `hf_hub_download`, or written before tree listings were cached, may contain only part of a repository without a listing that lets `snapshot_download` detect the missing files.

`require_complete=True` makes that uncertainty an error:

```python
snapshot_download(
    "hf-internal-testing/dataset_with_data_files",
    repo_type="dataset",
    local_files_only=True,
    require_complete=True,
)
```

Manual check after caching only `data/train.txt` with `hf_hub_download`:

```python
import tempfile

from huggingface_hub import hf_hub_download, snapshot_download
from huggingface_hub.errors import IncompleteSnapshotError


cache_dir = tempfile.mkdtemp()
hf_hub_download(
    "hf-internal-testing/dataset_with_data_files",
    "data/train.txt",
    repo_type="dataset",
    cache_dir=cache_dir,
)
print("cached: data/train.txt")
try:
    snapshot_download(
        "hf-internal-testing/dataset_with_data_files",
        repo_type="dataset",
        cache_dir=cache_dir,
        local_files_only=True,
        require_complete=True,
    )
except IncompleteSnapshotError as error:
    print(f"{type(error).__name__}: {error}")
```

```text
cached: data/train.txt
IncompleteSnapshotError: The cached snapshot for 'hf-internal-testing/dataset_with_data_files' (revision 'main', commit c19550d35263090b1ec2bfefdbd737431fafec40) cannot be shown to be complete: no tree listing is cached for this commit, so which files the repository holds is unknown. Outgoing traffic is disabled ('local_files_only=True'). Re-run the download with network access to cache the listing.
```

The same call without `require_complete=True` keeps returning the cached folder, as before. 

“Complete” keeps the existing `snapshot_download` meaning: every file selected after `allow_patterns` and `ignore_patterns` exists locally. It does not verify file contents or checksums. Strict mode also rejects an existing non-empty `local_dir` when its revision cannot be resolved locally; otherwise that path could still return a snapshot that was never checked.

Doing the check inside `snapshot_download` avoids splitting the guarantee across `get_cached_repo_tree` and a later download call. A concurrent download can publish the tree cache before it finishes writing every file, so those two calls do not prove that the returned snapshot was checked against the listing they observed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error behavior on an opt-in flag only; default paths stay backward compatible, but callers enabling strict mode depend on tree-cache semantics for local/offline downloads.
> 
> **Overview**
> Adds opt-in **`require_complete=True`** to `snapshot_download` and `HfApi.snapshot_download` for stricter offline/local fallback behavior.
> 
> By default, when the Hub is unreachable and completeness cannot be verified (no cached `trees/` listing for the commit, or a non-empty `local_dir` whose revision cannot be resolved locally), the existing local snapshot is still returned. With **`require_complete=True`**, those cases raise **`IncompleteSnapshotError`** instead. When a tree listing exists, behavior is unchanged: missing files still raise **`IncompleteSnapshotError`**; the new flag only treats “cannot prove complete” as an error.
> 
> **`_raise_if_incomplete_snapshot`** centralizes the “no tree cache” path; **`IncompleteSnapshotError`** docs and the cache guide are updated. Tests cover unresolved `local_dir` and `hf_hub_download`-only caches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e55eaee5a78691aae81241086eb6120cb0a51772. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->