### PR TITLE
[CLI] Support multi-line quoted values in .env parsing

### DIFF
--- a/src/huggingface_hub/utils/_dotenv.py
+++ b/src/huggingface_hub/utils/_dotenv.py
@@ -1,11 +1,25 @@
 # AI-generated module (ChatGPT)
 import re
+from collections.abc import Iterator
 
 
 # Escape sequences expanded inside quoted values. Double-quoted values additionally
 # expand "\$" to "$"; single-quoted values keep it verbatim.
 _ESCAPES = {"n": "\n", "t": "\t", '"': '"', "\\": "\\"}
 _DOUBLE_QUOTE_ESCAPES = {**_ESCAPES, "$": "$"}
+
+# A line whose value starts with a quote. Only the opening quote is captured; whether it is
+# closed on the same line is decided by `_quote_is_closed`.
+_QUOTED_VALUE_START = re.compile(
+    r"""
+    ^[^\S\n]*
+    (?:export[^\S\n]+)?               # optional export
+    [A-Za-z_][A-Za-z0-9_]*            # key
+    [^\S\n]*=[^\S\n]*
+    (['"])                            # opening quote
+""",
+    re.VERBOSE,
+)
 
 
 def _unescape(value: str, escapes: dict[str, str]) -> str:
@@ -16,6 +30,59 @@ def _unescape(value: str, escapes: dict[str, str]) -> str:
     e.g. `\\n` is a backslash followed by `n`, not a newline. Unknown escapes are kept as-is.
     """
     return re.sub(r"\\(.)", lambda match: escapes.get(match.group(1), match.group(0)), value)
+
+
+def _quote_is_closed(text: str, quote: str, start: int) -> bool:
+    """Whether the quote opened at `start - 1` is closed within `text`.
+
+    Backslash escapes are skipped as a unit so that an escaped quote does not end the value,
+    matching how `_unescape` reads them afterwards.
+    """
+    index = start
+    while index < len(text):
+        if text[index] == "\\":
+            index += 2
+            continue
+        if text[index] == quote:
+            return True
+        index += 1
+    return False
+
+
+def _logical_lines(dotenv_str: str) -> Iterator[str]:
+    r"""Split into logical lines, joining physical lines while a quoted value stays open.
+
+    A quoted value may span several lines — a PEM key or a JSON blob being the usual cases.
+    Splitting on newlines alone would end the value at the first newline while leaving the
+    opening quote in it, so `KEY="-----BEGIN X-----\n...\n-----END X-----"` would yield
+    `'"-----BEGIN X-----'` and then parse the remaining lines as separate entries.
+
+    A quote that is never closed is left alone: those lines are yielded one by one, so
+    malformed input degrades the same way it did before rather than swallowing the rest of
+    the file.
+    """
+    lines = dotenv_str.splitlines()
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        index += 1
+
+        match = _QUOTED_VALUE_START.match(line)
+        if match is None:
+            yield line
+            continue
+
+        quote, value_start = match.group(1), match.end(1)
+        joined, lookahead = line, index
+        while not _quote_is_closed(joined, quote, value_start) and lookahead < len(lines):
+            joined += "\n" + lines[lookahead]
+            lookahead += 1
+
+        if _quote_is_closed(joined, quote, value_start):
+            index = lookahead
+            yield joined
+        else:
+            yield line
 
 
 def load_dotenv(dotenv_str: str, environ: dict[str, str] | None = None) -> dict[str, str]:
@@ -42,7 +109,7 @@ def load_dotenv(dotenv_str: str, environ: dict[str, str] | None = None) -> dict[
         re.VERBOSE,
     )
 
-    for line in dotenv_str.splitlines():
+    for line in _logical_lines(dotenv_str):
         line = line.strip()
         if not line or line.startswith("#"):
             continue  # Skip comments and empty lines

--- a/tests/test_utils_dotenv.py
+++ b/tests/test_utils_dotenv.py
@@ -91,3 +91,31 @@ def test_environ():
     """
     environ = {"A": "one", "B": "two", "D": "four", "EMPTY": ""}
     assert load_dotenv(data, environ=environ) == {"A": "1", "B": "two", "C": "3", "EMPTY": ""}
+
+
+def test_multiline_quoted_value():
+    # A quoted value may span several lines (PEM keys, JSON blobs). This used to stop at the
+    # first newline and keep the opening quote, so the key came out as '"-----BEGIN...' and the
+    # base64 body line was parsed as a separate entry of its own.
+    data = 'KEY="-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQ==\n-----END PRIVATE KEY-----"\nOTHER=fine'
+    assert load_dotenv(data) == {
+        "KEY": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQ==\n-----END PRIVATE KEY-----",
+        "OTHER": "fine",
+    }
+
+
+def test_multiline_single_quoted_value():
+    # Single quotes span lines too, and a '#' inside the value is not an inline comment.
+    data = 'CONFIG=\'{\n  "a": 1,  # not a comment\n  "b": 2\n}\'\nNEXT=ok'
+    assert load_dotenv(data) == {"CONFIG": '{\n  "a": 1,  # not a comment\n  "b": 2\n}', "NEXT": "ok"}
+
+
+def test_multiline_value_with_trailing_comment():
+    data = 'A="line1\nline2"  # trailing comment\nB=2'
+    assert load_dotenv(data) == {"A": "line1\nline2", "B": "2"}
+
+
+def test_unterminated_quote_keeps_line_by_line_parsing():
+    # A quote that is never closed must not swallow the rest of the file.
+    data = 'A="oops\nB=2'
+    assert load_dotenv(data) == {"A": '"oops', "B": "2"}


### PR DESCRIPTION
Fixes #4634.

## Summary

- `load_dotenv` iterated `dotenv_str.splitlines()` and parsed each physical line alone, so a quoted value spanning lines ended at the first newline **with its opening quote still attached**, and the following lines were parsed as entries of their own.
- Physical lines are now joined while a quoted value stays open. Everything else — the value regex, escapes, the `" #"` comment rule, the `environ` fallback — is untouched.
- A quote that is never closed is left alone and still parses line by line, so malformed input degrades exactly as it does today instead of swallowing the rest of the file.

Reachable from the CLI: `parse_env_map` feeds `--env`/`--env-file` and `--secrets`/`--secrets-file` for `hf jobs` and `hf spaces`, so a multi-line secret was silently sent to the Hub wrong.

## Before / after

```python
>>> load_dotenv('A="line1\nline2"')
{'A': '"line1'}                  # before
{'A': 'line1\nline2'}            # after
```

A service-account key through the actual CLI path, `env_map_to_key_value_list(parse_env_map(env_file=...))`:

```
# before
[{"key": "SERVICE_ACCOUNT_KEY", "value": "\"-----BEGIN PRIVATE KEY-----"},
 {"key": "MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQ", "value": ""},
 {"key": "OTHER", "value": "fine"}]

# after
[{"key": "SERVICE_ACCOUNT_KEY", "value": "-----BEGIN PRIVATE KEY-----\nMIIEvQ...\n-----END PRIVATE KEY-----"},
 {"key": "OTHER", "value": "fine"}]
```

The base64 body line ends in `=`, which is why it used to become a key of its own — a fragment of the private key as an environment variable name.

## Decisions

- **Joining lines rather than rewriting the parser.** The existing regex already accepts newlines inside both quoted alternatives (`[^']` / `[^"]` match `\n`), so grouping the input into logical lines was enough and the value-parsing code needed no change. It also keeps this off the lines #4625 edits.
- **Unterminated quotes left as-is.** Consuming to EOF would have dropped valid `KEY=value` lines further down the file on malformed input. `_quote_is_closed` looks ahead first and only commits to the join when a closing quote actually exists, so `A="oops\nB=2` still yields `{'A': '"oops', 'B': '2'}` — same as today. There is a test pinning that.
- **Escapes skipped as a unit** when scanning for the closing quote, matching how `_unescape` reads them, so `A="say \"hi\"\nbye"` closes at the real end.

## Verification

- `pytest tests/test_utils_dotenv.py` — 14 passed. Three of the four new tests fail on `main`; `test_unterminated_quote_keeps_line_by_line_parsing` passes either way and is there to catch over-correction.
- `pytest tests/test_cli.py` — 310 passed. `TestDatasetsSqlCommand::test_datasets_sql_table` failed once on a network hiccup and passes 3/3 in isolation here, on `main` too.
- `make style`, `make quality` (ruff + `ty check src`) and `mypy src` all clean.
- Differential against `python-dotenv` (`interpolate=False`) over ~240k generated inputs, comparing pristine vs patched against the reference:

  | seed | fixed | newly wrong |
  |---|---|---|
  | 0 | 892 | 0 |
  | 1 | 815 | 0 |
  | 2 | 937 | 0 |
  | 3 | 924 | 2 |
  | 4 | 878 | 0 |
  | 5 | 914 | 0 |

  The two on seed 3 are unbalanced-quote fuzz soup (`"'\nKEY='1b=\\n\nKEY=\\n\tnn' "`) where a quote opens on one line and closes two lines later. `python-dotenv` lands on a fragment of the last line there; this branch reads it as the multi-line value it looks like. I did not treat those as regressions, but say the word if you would rather match `python-dotenv` exactly on that shape.

## Scope

Two divergences from `python-dotenv` are left alone, both pre-existing and neither a truncation:

- `A="foo" bar` returns `'"foo" bar'` (quotes included) because the regex falls back to the unquoted branch; `python-dotenv` rejects the line.
- Single-quoted values expand backslash escapes here, which the module comment reads as intentional. #4625 flagged the same one.

Happy to split either out if you want them addressed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches secret/env parsing used by Hub CLI jobs and spaces; behavior change for multiline quoted values is intentional but could affect anyone relying on the old broken split-line parsing.
> 
> **Overview**
> **`load_dotenv` now treats quoted values as logical lines** instead of stopping at the first physical newline, so PEM keys, JSON blobs, and similar secrets in `.env` files parse as a single value.
> 
> The change adds `_logical_lines`, `_quote_is_closed`, and `_QUOTED_VALUE_START` ahead of the existing line regex: physical lines are joined only while an opening quote stays unclosed (with escape-aware scanning). **Unterminated quotes still parse line-by-line** so malformed input does not consume the rest of the file.
> 
> Tests cover multiline double/single quotes, trailing comments after closed multiline values, and the unterminated-quote fallback. This path feeds **`parse_env_map`** for CLI `--env-file` / `--secrets-file` on jobs and spaces, where multiline secrets were previously split or mangled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a970ff0683584fdd797f7b12f88b64346c398083. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->