### PR TITLE
[Xet] Bump minimum hf-xet to 1.5.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def get_version() -> str:
 
 
 # hf-xet version used in both install_requires and extras["hf_xet"]
-HF_XET_VERSION = "hf-xet>=1.5.1,<2.0.0"
+HF_XET_VERSION = "hf-xet>=1.5.2,<2.0.0"
 
 install_requires = [
     "click>=8.4.2,<9.0.0",  # 8.4.0/8.4.1 shipped a broken fish completion script


### PR DESCRIPTION
## Summary

- Bump `HF_XET_VERSION` from `hf-xet>=1.5.1,<2.0.0` to `hf-xet>=1.5.2,<2.0.0` in [setup.py](setup.py). This applies to both `install_requires` and `extras["hf_xet"]`, since both reuse the same constant.
- `hf-xet` 1.5.2 ships a critical fix for possible hangs on poor networks. We were still allowing 1.5.1, so users installing fresh could end up on the buggy version. Reported by @seanses in https://github.com/huggingface/huggingface_hub/issues/4528.
- Kept the bump minimal at `>=1.5.2` (the version that carries the fix) rather than jumping to the latest `1.6.0`, to avoid forcing an unnecessary upgrade on users. The upper bound `<2.0.0` is unchanged, so anyone on 1.6.x is unaffected.

```
$ git diff main -- setup.py
-HF_XET_VERSION = "hf-xet>=1.5.1,<2.0.0"
+HF_XET_VERSION = "hf-xet>=1.5.2,<2.0.0"
```

No breaking changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line dependency floor change in packaging metadata only; no runtime code changes.
> 
> **Overview**
> Raises the minimum **`hf-xet`** dependency from **`>=1.5.1`** to **`>=1.5.2`** via the shared **`HF_XET_VERSION`** constant in **`setup.py`**, so both **`install_requires`** (on supported architectures) and **`extras["hf_xet"]`** no longer allow installs of 1.5.1.
> 
> The upper bound **`<2.0.0`** is unchanged; this targets a fix for possible hangs on poor networks without forcing a jump to newer releases like 1.6.x.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f63a1ae85c8f116ab1836139bbf801ee6bb2f3e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->