### PR TITLE
[HfApi] Add `region` to `ExpandSpaceProperty_T`

### DIFF
--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -4463,7 +4463,7 @@ $ hf spaces info [OPTIONS] SPACE_ID
 **Options**:
 
 * `--revision TEXT`: Git revision id which can be a branch name, a tag, or a commit hash.
-* `--expand TEXT`: Comma-separated properties to return. When used, only the listed properties (and id) are returned. Example: '--expand=likes,tags'. Valid: author, cardData, createdAt, datasets, disabled, lastModified, likes, models, private, resourceGroup, runtime, sdk, sha, siblings, subdomain, tags, trendingScore, usedStorage.
+* `--expand TEXT`: Comma-separated properties to return. When used, only the listed properties (and id) are returned. Example: '--expand=likes,tags'. Valid: author, cardData, createdAt, datasets, disabled, lastModified, likes, models, private, region, resourceGroup, runtime, sdk, sha, siblings, subdomain, tags, trendingScore, usedStorage.
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `--help`: Show this message and exit.
 
@@ -4500,7 +4500,7 @@ $ hf spaces list [OPTIONS] [REPO_ID]
 * `--filter TEXT`: Filter by tags (e.g. 'text-classification'). Can be used multiple times.
 * `--sort [created_at|last_modified|likes|trending_score]`: Sort results.
 * `--limit INTEGER`: Limit the number of results.  [default: 30]
-* `--expand TEXT`: Comma-separated properties to return. When used, only the listed properties (and id) are returned. Example: '--expand=likes,tags'. Valid: author, cardData, createdAt, datasets, disabled, lastModified, likes, models, private, resourceGroup, runtime, sdk, sha, siblings, subdomain, tags, trendingScore, usedStorage.
+* `--expand TEXT`: Comma-separated properties to return. When used, only the listed properties (and id) are returned. Example: '--expand=likes,tags'. Valid: author, cardData, createdAt, datasets, disabled, lastModified, likes, models, private, region, resourceGroup, runtime, sdk, sha, siblings, subdomain, tags, trendingScore, usedStorage.
 * `-h, --human-readable`: Show sizes in human readable format (only for listing files).
 * `--tree`: List files in tree format (only for listing files).
 * `-R, --recursive`: List files recursively (only for listing files).

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -239,6 +239,7 @@ ExpandSpaceProperty_T = Literal[
     "likes",
     "models",
     "private",
+    "region",
     "resourceGroup",
     "runtime",
     "sdk",
@@ -1289,6 +1290,8 @@ class SpaceInfo:
             List of models used by the Space.
         private (`bool`):
             Is the repo private.
+        region (`str`, *optional*):
+            Region in which the Space is stored.
         resource_group (`dict`, *optional*):
             Resource group information for the Space.
         runtime (`SpaceRuntime`, *optional*):
@@ -1321,6 +1324,7 @@ class SpaceInfo:
     likes: int | None
     models: list[str] | None
     private: bool | None
+    region: str | None
     resource_group: dict | None
     runtime: SpaceRuntime | None
     sdk: str | None
@@ -1379,6 +1383,7 @@ class SpaceInfo:
         self.runtime = SpaceRuntime(runtime) if runtime else None
         self.models = kwargs.pop("models", None)
         self.datasets = kwargs.pop("datasets", None)
+        self.region = kwargs.pop("region", None)
         self.resource_group = kwargs.pop("resourceGroup", None)
         # backwards compatibility
         self.lastModified = self.last_modified
@@ -2925,7 +2930,7 @@ class HfApi:
             expand (`list[ExpandSpaceProperty_T]`, *optional*):
                 List properties to return in the response. When used, only the properties in the list will be returned.
                 This parameter cannot be used if `full` is passed.
-                Possible values are `"author"`, `"cardData"`, `"datasets"`, `"disabled"`, `"lastModified"`, `"createdAt"`, `"likes"`, `"models"`, `"private"`, `"runtime"`, `"sdk"`, `"siblings"`, `"sha"`, `"subdomain"`, `"tags"`, `"trendingScore"`, `"usedStorage"`, and `"resourceGroup"`.
+                Possible values are `"author"`, `"cardData"`, `"datasets"`, `"disabled"`, `"lastModified"`, `"createdAt"`, `"likes"`, `"models"`, `"private"`, `"region"`, `"runtime"`, `"sdk"`, `"siblings"`, `"sha"`, `"subdomain"`, `"tags"`, `"trendingScore"`, `"usedStorage"`, and `"resourceGroup"`.
             full (`bool`, *optional*):
                 Whether to fetch all Spaces data, including the `last_modified`, `siblings`
                 and `card_data` fields.
@@ -3495,7 +3500,7 @@ class HfApi:
             expand (`list[ExpandSpaceProperty_T]`, *optional*):
                 List properties to return in the response. When used, only the properties in the list will be returned.
                 This parameter cannot be used if `full` is passed.
-                Possible values are `"author"`, `"cardData"`, `"createdAt"`, `"datasets"`, `"disabled"`, `"lastModified"`, `"likes"`, `"models"`, `"private"`, `"runtime"`, `"sdk"`, `"siblings"`, `"sha"`, `"subdomain"`, `"tags"`, `"trendingScore"`, `"usedStorage"`, and `"resourceGroup"`.
+                Possible values are `"author"`, `"cardData"`, `"createdAt"`, `"datasets"`, `"disabled"`, `"lastModified"`, `"likes"`, `"models"`, `"private"`, `"region"`, `"runtime"`, `"sdk"`, `"siblings"`, `"sha"`, `"subdomain"`, `"tags"`, `"trendingScore"`, `"usedStorage"`, and `"resourceGroup"`.
             token (`bool` or `str`, *optional*):
                 A valid user access token (string). Defaults to the locally saved
                 token, which is the recommended method for authentication (see

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -1291,7 +1291,7 @@ class SpaceInfo:
         private (`bool`):
             Is the repo private.
         region (`str`, *optional*):
-            Region in which the Space is stored.
+            Cloud region in which the Space is stored. Can be one of `"us"` or `"eu"`.
         resource_group (`dict`, *optional*):
             Resource group information for the Space.
         runtime (`SpaceRuntime`, *optional*):

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -1290,8 +1290,8 @@ class SpaceInfo:
             List of models used by the Space.
         private (`bool`):
             Is the repo private.
-        region (`str`, *optional*):
-            Cloud region in which the Space is stored. Can be one of `"us"` or `"eu"`.
+        region (`Literal["us", "eu"]`, *optional*):
+            Cloud region in which the Space is stored.
         resource_group (`dict`, *optional*):
             Resource group information for the Space.
         runtime (`SpaceRuntime`, *optional*):
@@ -1324,7 +1324,7 @@ class SpaceInfo:
     likes: int | None
     models: list[str] | None
     private: bool | None
-    region: str | None
+    region: REPO_REGIONS | None
     resource_group: dict | None
     runtime: SpaceRuntime | None
     sdk: str | None


### PR DESCRIPTION
## Summary

`tests/test_hf_api.py::TestExpandPropertyType::test_expand_space_property_type_is_up_to_date` started failing because the Hub added a new expandable property for spaces:

```
ValueError: Literal `ExpandSpaceProperty_T` is outdated! This is probably due to a server-side update.
New arg(s) to support: region
```

Confirmed server-side (`GET /api/spaces/<id>?expand=does_not_exist`):

```
"expand" must be one of [author, cardData, datasets, disabled, lastModified, createdAt, likes, private, region, runtime, sdk, siblings, sha, subdomain, tags, trendingScore, models, resourceGroup, xetEnabled, usedStorage]
```

The server-side change is huggingface/moon-landing#19411. Beside the allowlist, it also added `region` to the extra keys loaded by the single-space `GET /api/spaces/{namespace}/{repo}`, so a plain `space_info()` (no `expand`) now returns it too.

I diffed all three Joi allowlists in `apiListingRoutes.ts` against `get_args()` of our Literals: models (31) and datasets (20) already match, `region` was the only gap. So this PR:

- adds `"region"` to `ExpandSpaceProperty_T`
- updates the `expand` docstrings of `space_info` and `list_spaces`
- adds `region` as an official `SpaceInfo` attribute (typed + documented), following what was done for `mainSize` / `DatasetInfo.main_size` in #4136. Without it the value only lands in `__dict__` via the catch-all, so it isn't discoverable or type-checked. Typed as `REPO_REGIONS | None` (i.e. `Literal["us", "eu"] | None`) to mirror the server's closed `RepoRegion` union, same as `SpaceInfo.gated`. It's `| None` because `list_spaces` omits it unless you pass `expand=["region"]`.
- regenerates `docs/source/en/package_reference/cli.md` (the `--expand` help for `hf spaces info` / `hf spaces list` is derived from the Literal)

## Manual testing

```py
>>> from huggingface_hub import HfApi
>>> api = HfApi()
>>> info = api.space_info("black-forest-labs/FLUX.1-dev", expand=["region", "sdk"])
>>> info
SpaceInfo(id='black-forest-labs/FLUX.1-dev', ..., private=None, region='us', resource_group=None, runtime=None, sdk='gradio', ...)
>>> for s in api.list_spaces(limit=3, expand=["region"]):
...     print(s.id, s.region)
cinderholm/wan2-2-i2v-v3 us
prithivMLmods/Qwen-Image-Edit-2511-LoRAs-Fast us
multimodalart/minimax-h3 us
```

And from the CLI:

```
$ hf spaces info black-forest-labs/FLUX.1-dev --expand region,sdk
{"id": "black-forest-labs/FLUX.1-dev", "region": "us", "sdk": "gradio"}
```

The previously failing test now passes:

```
$ pytest tests/test_hf_api.py::TestExpandPropertyType -q
3 passed in 0.61s
```
