### PR TITLE
Preserve query string when following relative redirects

### DIFF
--- a/src/huggingface_hub/utils/_http.py
+++ b/src/huggingface_hub/utils/_http.py
@@ -26,7 +26,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from shlex import quote
 from typing import Any, TypeVar
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse
 
 import httpx
 
@@ -731,8 +731,10 @@ def _httpx_follow_relative_redirects_with_backoff(
         if 300 <= response.status_code <= 399:
             parsed_target = urlparse(response.headers["Location"])
             if parsed_target.netloc == "":
-                # Relative redirect -> update URL and retry
-                url = urlparse(url)._replace(path=parsed_target.path).geturl()
+                # Relative redirect -> resolve it against the current URL and retry.
+                # `urljoin` follows RFC 3986 reference resolution, so the target's query string
+                # is preserved and dot-segments (e.g. `../`) are resolved.
+                url = urljoin(url, response.headers["Location"])
                 continue
 
         # Break if no relative redirect

--- a/tests/test_utils_http.py
+++ b/tests/test_utils_http.py
@@ -22,6 +22,7 @@ from huggingface_hub.utils._http import (
     _WARNED_TOPICS,
     RateLimitInfo,
     _adjust_range_header,
+    _httpx_follow_relative_redirects_with_backoff,
     _parse_bucket_id_from_url,
     _parse_repo_info_from_url,
     _parse_retry_after,
@@ -783,3 +784,44 @@ class TestRedactSensitiveBody:
         assert "refresh_token=<REDACTED>" in redacted
         assert "device_code=<REDACTED>" in redacted
         assert "client_id=abc" in redacted
+
+
+class TestFollowRelativeRedirects:
+    """Tests for `_httpx_follow_relative_redirects_with_backoff`."""
+
+    BASE_URL = "https://hf.co/repo/resolve/main/config.json?base=old"
+
+    @pytest.fixture(autouse=True)
+    def setup(self) -> Generator[None, None, None]:
+        patcher = patch("huggingface_hub.utils._http.http_backoff")
+        self.mock_backoff = patcher.start()
+        yield
+        patcher.stop()
+
+    def _follow(self, location: str) -> str:
+        """Follow a single relative redirect to `location` and return the URL requested next."""
+        self.mock_backoff.side_effect = [
+            httpx.Response(
+                308,
+                headers={"Location": location},
+                request=httpx.Request("HEAD", self.BASE_URL),
+            ),
+            httpx.Response(200, request=httpx.Request("HEAD", self.BASE_URL)),
+        ]
+        _httpx_follow_relative_redirects_with_backoff("HEAD", self.BASE_URL)
+        return self.mock_backoff.call_args_list[-1].kwargs["url"]
+
+    def test_target_query_is_preserved(self) -> None:
+        """The query string of the redirect target must be kept (e.g. xet `?etag=...`)."""
+        assert (
+            self._follow("/api/resolve-cache/config.json?etag=abc123")
+            == "https://hf.co/api/resolve-cache/config.json?etag=abc123"
+        )
+
+    def test_base_query_is_not_inherited(self) -> None:
+        """When the target has no query, the base query must not be carried over (RFC 3986)."""
+        assert self._follow("/api/resolve-cache/config.json") == "https://hf.co/api/resolve-cache/config.json"
+
+    def test_dot_segments_are_resolved(self) -> None:
+        """Relative targets with dot-segments must be resolved, not kept verbatim."""
+        assert self._follow("../other/config.json?etag=xyz") == "https://hf.co/repo/resolve/other/config.json?etag=xyz"

--- a/tests/test_utils_http.py
+++ b/tests/test_utils_http.py
@@ -825,3 +825,15 @@ class TestFollowRelativeRedirects:
     def test_dot_segments_are_resolved(self) -> None:
         """Relative targets with dot-segments must be resolved, not kept verbatim."""
         assert self._follow("../other/config.json?etag=xyz") == "https://hf.co/repo/resolve/other/config.json?etag=xyz"
+
+    def test_protocol_relative_redirect_is_not_followed(self) -> None:
+        """A protocol-relative target (`//host/...`) points to another host and must not be followed."""
+        redirect = httpx.Response(
+            308,
+            headers={"Location": "//huggingface.co/other/config.json"},
+            request=httpx.Request("HEAD", self.BASE_URL),
+        )
+        self.mock_backoff.side_effect = [redirect]
+        response = _httpx_follow_relative_redirects_with_backoff("HEAD", self.BASE_URL)
+        assert self.mock_backoff.call_count == 1  # no second request
+        assert response is redirect  # the redirect itself is returned


### PR DESCRIPTION
Refs #4637 (defect 1 — the dropped query string).

> **Note:** this does **not** close #4637. As verified by @vollegrewar against the mirror repro, the reported failure has a separate root cause (the absolute `308` from the mirror is never followed, so the response carries no `x-repo-commit`). This PR is a correctness fix on its own; the issue should stay open until the `308` leg and/or the error misclassification is addressed.

## Problem

`_httpx_follow_relative_redirects_with_backoff` rebuilt the redirect URL like this:

```python
url = urlparse(url)._replace(path=parsed_target.path).geturl()
```

Only `path` was swapped, so:

- the redirect target's **query string was dropped**,
- the **original URL's query was carried over** onto the new path,
- **dot-segments** (`../`) were left unresolved, producing URLs like `https://hf.co/../other/config.json`.

This matters for xet resolve redirects such as `307 /api/resolve-cache/models/.../config.json?etag=...`: losing `etag` changes the response.

## Change

```python
url = urljoin(url, response.headers["Location"])
```

`urljoin` is the stdlib implementation of RFC 3986 reference resolution, so the target's query is used and dot-segments are resolved. This is still inside the `parsed_target.netloc == ""` branch, so absolute redirects are not followed — the function's original intent is unchanged.

Note on query inheritance: per RFC 3986 §5.2.2, `T.query = R.query` applies whenever the reference defines a path, so a target without a query yields **no** query rather than inheriting the base's. The base query is only inherited when the reference path is empty (e.g. `Location: ?foo=bar`). `urljoin` and the minimal `_replace(path=..., query=...)` patch agree on that; they differ only on dot-segments, which `urljoin` handles correctly.

## Tests

Added `TestFollowRelativeRedirects` in `tests/test_utils_http.py` covering three cases:

- relative redirect **with** a query → target query preserved,
- relative redirect **without** a query → base query not inherited,
- relative redirect with **dot-segments** → resolved.

All three fail on `main` (the followed URL keeps `?base=old`) and pass with this change. `tests/test_utils_http.py` passes in full locally (66 passed), and `ruff format`/`ruff check` are clean on both files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to relative redirect resolution in shared HTTP helpers used for HEAD resolve/metadata; behavior aligns with RFC 3986 and is covered by new unit tests.
> 
> **Overview**
> Fixes how **`_httpx_follow_relative_redirects_with_backoff`** builds the next URL when the hub returns a **relative** `Location` (still only followed when `netloc` is empty; absolute and protocol-relative redirects are unchanged).
> 
> Instead of swapping only the path with `urlparse(...)._replace(path=...)`, the follow-up request now uses **`urljoin(current_url, Location)`**, so redirect targets keep their **query** (e.g. xet `?etag=...`), targets **without** a query no longer inherit the original URL’s query, and **`../` dot-segments** are normalized.
> 
> Adds **`TestFollowRelativeRedirects`** in `tests/test_utils_http.py` for query preservation, no base-query inheritance, dot-segment resolution, and that `//host/...` is not followed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fcf85af99bf8b3d768d102972a8299b37df607b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->