### PR TITLE
[Utils] Reject a trailing newline in repo_id validation

### DIFF
--- a/src/huggingface_hub/utils/_validators.py
+++ b/src/huggingface_hub/utils/_validators.py
@@ -32,7 +32,7 @@ REPO_ID_REGEX = re.compile(
     \b               # starts with a word boundary
     [\w\-.]{1,96}    # repo_name: alphanumeric + . _ -
     \b               # ends with a word boundary
-    $
+    \Z               # end of string ($ would also match before a trailing newline)
     """,
     flags=re.VERBOSE,
 )

--- a/tests/test_utils_validators.py
+++ b/tests/test_utils_validators.py
@@ -48,6 +48,7 @@ class TestRepoIdValidator:
         "foo--bar",  # Cannot contain "--"
         "foo..bar",  # Cannot contain "."
         "foo.git",  # Cannot end with ".git"
+        "foo/bar\n",  # Cannot contain a trailing newline
     )
 
     def test_valid_repo_ids(self) -> None:


### PR DESCRIPTION
## Summary

- `validate_repo_id` accepted a repo id with a **trailing newline**. `REPO_ID_REGEX` ends with `$`, and in Python `$` (without `re.MULTILINE`) matches at end-of-string *or* just before a single trailing `\n` — so the newline slipped through, while a trailing space or tab was correctly rejected.
- Anchored the end with `\Z` (absolute end of string), matching the intent of the surrounding `re.match`.

```python
>>> from huggingface_hub.utils import validate_repo_id
>>> validate_repo_id("foo/bar\n")   # before: silently valid;  after: raises HFValidationError
huggingface_hub.utils._validators.HFValidationError: Repo id must use alphanumeric chars, ...
```

Valid ids are unaffected (none end in a newline), and trailing `\r`/`\t`/space were already rejected. Added `"foo/bar\n"` to the validator's not-valid test cases.

---
Used AI assistance on this; I reviewed and tested the change myself.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small validation-only fix in input sanitization; no API or behavior change for valid repo ids.
> 
> **Overview**
> **`validate_repo_id`** no longer accepts repo ids with a trailing newline. **`REPO_ID_REGEX`** now ends with `\Z` instead of `$`, because `$` can match just before a trailing `\n` while other trailing whitespace was already rejected.
> 
> A regression test adds `"foo/bar\n"` to the invalid repo id cases. Legitimate ids are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbd780d0f12f33361d1444b34abc0d83da933770. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->