### PR TITLE
[Download] Fix tqdm_class ignored by the Xet transfer bar

### DIFF
--- a/src/huggingface_hub/utils/_xet_progress_reporting.py
+++ b/src/huggingface_hub/utils/_xet_progress_reporting.py
@@ -114,7 +114,7 @@ class XetDownloadProgressReporter:
             self._owns_transfer_bar = False
         else:
             self.transfer_bar = _create_progress_bar(
-                cls=tqdm,
+                cls=cls,  # ty: ignore[invalid-argument-type]
                 log_level=log_level,
                 name=f"{name}.transfer" if name else None,
                 desc=transfer_desc,

--- a/tests/test_xet_progress_reporting.py
+++ b/tests/test_xet_progress_reporting.py
@@ -1,14 +1,10 @@
-import logging
-
 from huggingface_hub.utils._xet_progress_reporting import (
-    XetDownloadProgressReporter,
     _finish_transfer_bar,
     _format_speed_postfix,
     _set_aggregate_rate_postfix,
     _set_monotonic_total,
     _update_transfer_bar,
 )
-from huggingface_hub.utils.tqdm import tqdm
 
 
 class _RecordingBar:
@@ -21,10 +17,6 @@ class _RecordingBar:
 
     def refresh(self) -> None:
         pass
-
-
-class _CustomTqdm(tqdm):
-    """Custom class passed as `tqdm_class`."""
 
 
 class _RateBar:
@@ -80,17 +72,3 @@ class TestXetProgressBarHelpers:
         bar = _RateBar(rate=None)
         _set_aggregate_rate_postfix(bar)
         assert "???" in bar.postfix
-
-
-class TestXetDownloadProgressReporter:
-    def test_custom_tqdm_class_is_used_for_both_bars(self):
-        # Regression: the transfer bar was hardcoded to the default tqdm.
-        # https://github.com/huggingface/huggingface_hub/issues/4646
-        with XetDownloadProgressReporter(
-            reconstruction_desc="reconstructing",
-            total=100,
-            log_level=logging.INFO,
-            tqdm_class=_CustomTqdm,
-        ) as reporter:
-            assert isinstance(reporter.reconstruction_bar, _CustomTqdm)
-            assert isinstance(reporter.transfer_bar, _CustomTqdm)

--- a/tests/test_xet_progress_reporting.py
+++ b/tests/test_xet_progress_reporting.py
@@ -1,4 +1,8 @@
+import logging
+from types import SimpleNamespace
+
 from huggingface_hub.utils._xet_progress_reporting import (
+    XetDownloadProgressReporter,
     _finish_transfer_bar,
     _format_speed_postfix,
     _set_aggregate_rate_postfix,
@@ -17,6 +21,30 @@ class _RecordingBar:
 
     def refresh(self) -> None:
         pass
+
+
+class _FakeTqdm:
+    """Stub covering the whole bar surface the reporter drives, recording every instance created."""
+
+    created: list["_FakeTqdm"] = []
+
+    def __init__(self, **kwargs):
+        self.total = kwargs.get("total")
+        self.n = 0
+        self.closed = False
+        _FakeTqdm.created.append(self)
+
+    def update(self, n: int) -> None:
+        self.n += n
+
+    def set_postfix_str(self, postfix: str, refresh: bool = False) -> None:
+        self.postfix = postfix
+
+    def refresh(self) -> None:
+        pass
+
+    def close(self) -> None:
+        self.closed = True
 
 
 class _RateBar:
@@ -72,3 +100,34 @@ class TestXetProgressBarHelpers:
         bar = _RateBar(rate=None)
         _set_aggregate_rate_postfix(bar)
         assert "???" in bar.postfix
+
+
+class TestXetDownloadProgressReporter:
+    def test_custom_tqdm_class_receives_both_download_bars(self):
+        # Regression: the transfer bar was hardcoded to the built-in tqdm, so a caller-supplied
+        # `tqdm_class` drove only the reconstruction bar and Xet downloads opened a second bar
+        # the caller had no handle on.
+        _FakeTqdm.created.clear()
+        reporter = XetDownloadProgressReporter(
+            reconstruction_desc="reconstructing file",
+            transfer_desc="downloading bytes",
+            total=100,
+            log_level=logging.INFO,
+            name="huggingface_hub.test",
+            tqdm_class=_FakeTqdm,
+        )
+        reporter.update_progress(
+            SimpleNamespace(
+                total_bytes_completed=10,
+                total_transfer_bytes_completed=40,
+                total_bytes_completion_rate=None,
+                total_transfer_bytes_completion_rate=None,
+                total_bytes=100,
+            )
+        )
+        reporter.close()
+
+        assert _FakeTqdm.created == [reporter.reconstruction_bar, reporter.transfer_bar]
+        assert reporter.reconstruction_bar.n == 10
+        assert reporter.transfer_bar.n == 40
+        assert all(bar.closed for bar in _FakeTqdm.created)

--- a/tests/test_xet_progress_reporting.py
+++ b/tests/test_xet_progress_reporting.py
@@ -1,5 +1,4 @@
 import logging
-from types import SimpleNamespace
 
 from huggingface_hub.utils._xet_progress_reporting import (
     XetDownloadProgressReporter,
@@ -9,6 +8,7 @@ from huggingface_hub.utils._xet_progress_reporting import (
     _set_monotonic_total,
     _update_transfer_bar,
 )
+from huggingface_hub.utils.tqdm import tqdm
 
 
 class _RecordingBar:
@@ -23,28 +23,8 @@ class _RecordingBar:
         pass
 
 
-class _FakeTqdm:
-    """Stub covering the whole bar surface the reporter drives, recording every instance created."""
-
-    created: list["_FakeTqdm"] = []
-
-    def __init__(self, **kwargs):
-        self.total = kwargs.get("total")
-        self.n = 0
-        self.closed = False
-        _FakeTqdm.created.append(self)
-
-    def update(self, n: int) -> None:
-        self.n += n
-
-    def set_postfix_str(self, postfix: str, refresh: bool = False) -> None:
-        self.postfix = postfix
-
-    def refresh(self) -> None:
-        pass
-
-    def close(self) -> None:
-        self.closed = True
+class _CustomTqdm(tqdm):
+    """Custom class passed as `tqdm_class`."""
 
 
 class _RateBar:
@@ -103,31 +83,14 @@ class TestXetProgressBarHelpers:
 
 
 class TestXetDownloadProgressReporter:
-    def test_custom_tqdm_class_receives_both_download_bars(self):
-        # Regression: the transfer bar was hardcoded to the built-in tqdm, so a caller-supplied
-        # `tqdm_class` drove only the reconstruction bar and Xet downloads opened a second bar
-        # the caller had no handle on.
-        _FakeTqdm.created.clear()
-        reporter = XetDownloadProgressReporter(
-            reconstruction_desc="reconstructing file",
-            transfer_desc="downloading bytes",
+    def test_custom_tqdm_class_is_used_for_both_bars(self):
+        # Regression: the transfer bar was hardcoded to the default tqdm.
+        # https://github.com/huggingface/huggingface_hub/issues/4646
+        with XetDownloadProgressReporter(
+            reconstruction_desc="reconstructing",
             total=100,
             log_level=logging.INFO,
-            name="huggingface_hub.test",
-            tqdm_class=_FakeTqdm,
-        )
-        reporter.update_progress(
-            SimpleNamespace(
-                total_bytes_completed=10,
-                total_transfer_bytes_completed=40,
-                total_bytes_completion_rate=None,
-                total_transfer_bytes_completion_rate=None,
-                total_bytes=100,
-            )
-        )
-        reporter.close()
-
-        assert _FakeTqdm.created == [reporter.reconstruction_bar, reporter.transfer_bar]
-        assert reporter.reconstruction_bar.n == 10
-        assert reporter.transfer_bar.n == 40
-        assert all(bar.closed for bar in _FakeTqdm.created)
+            tqdm_class=_CustomTqdm,
+        ) as reporter:
+            assert isinstance(reporter.reconstruction_bar, _CustomTqdm)
+            assert isinstance(reporter.transfer_bar, _CustomTqdm)


### PR DESCRIPTION
## Problem

`tqdm_class` is documented as "overwrites the default behavior for the progress bar", but on a Xet-backed repo only one of the two download bars honours it.

`XetDownloadProgressReporter.__init__` resolves the caller's class into `cls` on line 83, uses it for the reconstruction bar on line 96, then hardcodes the built-in `tqdm` for the transfer bar on line 117. Both call sites were added in the same commit (#4400), one wired to `cls` and its sibling not.

So a caller who passes `tqdm_class` to send progress somewhere other than stderr gets a second `huggingface_hub` tqdm printing next to their own bar, with no reference to it:

```python
reporter = XetDownloadProgressReporter(..., tqdm_class=MyBar)
print(type(reporter.reconstruction_bar).__name__)  # MyBar
print(type(reporter.transfer_bar).__name__)        # tqdm
```

`hf_hub_download` reaches this branch. `_download_to_tmp_and_move` (`file_download.py:1960`) forwards `tqdm_class` to `xet_get` without `_tqdm_bar`, so `external_reconstruction_bar` is `None` and the `else` on line 116 runs.

## Solution

Pass `cls` to the transfer bar, the same value line 96 already uses. One argument.

## Scope

Only the standalone Xet download path changes.

- Default is untouched. With `tqdm_class=None`, `cls` is already the HF `tqdm` that line 117 hardcoded, so `HF_HUB_DISABLE_PROGRESS_BARS`, `disable_progress_bars()` and `TQDM_POSITION` behave exactly as before. I checked both: with the env var set, `reconstruction_bar.disable` and `transfer_bar.disable` are both `True`.
- `snapshot_download` is unaffected. Its `_AggregatedTqdm` defines `update_transfer`, so the reporter aggregates into one bar and never builds a second.
- `download_bucket_files` passes no custom class, so `cls` still resolves to the HF `tqdm`.
- The `# ty: ignore[invalid-argument-type]` matches line 96. Without it `ty` reports the same diagnostic on both lines, because `cls` is annotated as a broad `type` while `_create_progress_bar` asks for `type[old_tqdm]` even though it deliberately supports unrelated classes at runtime.

I did not touch the undocumented `update_transfer` contract reported in #4633. A custom class without that method still gets two bars, they are just both its own now.

## Validation

Base commit `f4c8347e`.

- New test `test_custom_tqdm_class_receives_both_download_bars` drives the reporter through construction, `update_progress()` and `close()`, then asserts exactly two bars were built, both from the supplied class, each fed its own byte stream. It fails on `main` with one recorded instance instead of two.
- `pytest tests/test_xet_progress_reporting.py tests/test_utils_tqdm.py tests/test_xet_utils.py` : 59 passed.
- `pytest tests/test_file_download.py -k "tqdm or progress or xet"` : 1 passed, 66 deselected.
- `ruff check src tests` and `ruff format --check src tests` : clean.
- `ty check src` : 2 diagnostics, both pre-existing in `cli/_output.py` and present on `main` unchanged.

## Related issue

Fixes #4646.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-argument change in progress UI wiring; default tqdm path is behaviorally identical.
> 
> **Overview**
> **Fixes inconsistent `tqdm_class` handling on Xet downloads.** When `external_reconstruction_bar` is absent, `XetDownloadProgressReporter` already builds the reconstruction bar with the resolved `cls` (`tqdm_class` or default HF `tqdm`), but the standalone transfer bar was still created with hardcoded `tqdm`. That meant `hf_hub_download` / `xet_get` callers with a custom `tqdm_class` could get one custom bar and a second default HF bar on stderr.
> 
> The transfer bar now uses the same `cls` as the reconstruction bar (with the same `# ty: ignore[invalid-argument-type]` as line 96). **Default behavior is unchanged** when `tqdm_class` is `None`. Aggregated paths (`snapshot_download`, external bars with `update_transfer`) still never instantiate a second bar.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 752052e78b6c21c45f678b2146efce935f341091. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->