### PR TITLE
[Docs] Clarify how many progress bars tqdm_class creates

### DIFF
--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -194,6 +194,8 @@ def snapshot_download(
             If provided, overwrites the default behavior for the progress bar. Passed
             argument must inherit from `tqdm.auto.tqdm` or at least mimic its behavior.
             Note that the `tqdm_class` is not passed to each individual download.
+            Three bars are created (files fetched, bytes received from the network, and
+            bytes written to disk), so the class is instantiated three times.
             Defaults to the custom HF progress bar that can be disabled by setting
             `HF_HUB_DISABLE_PROGRESS_BARS` environment variable.
         dry_run (`bool`, *optional*, defaults to `False`):

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -926,6 +926,8 @@ def hf_hub_download(
         tqdm_class (`tqdm`, *optional*):
             If provided, overwrites the default behavior for the progress bar. Passed
             argument must inherit from `tqdm.auto.tqdm` or at least mimic its behavior.
+            On Xet-backed repos two bars are created (bytes received from the network and
+            bytes written to disk), so the class is instantiated twice.
             Defaults to the custom HF progress bar that can be disabled by setting
             `HF_HUB_DISABLE_PROGRESS_BARS` environment variable.
         dry_run (`bool`, *optional*, defaults to `False`):

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -6608,6 +6608,8 @@ class HfApi:
             tqdm_class (`tqdm`, *optional*):
                 If provided, overwrites the default behavior for the progress bar. Passed
                 argument must inherit from `tqdm.auto.tqdm` or at least mimic its behavior.
+                On Xet-backed repos two bars are created (bytes received from the network and
+                bytes written to disk), so the class is instantiated twice.
                 Defaults to the custom HF progress bar that can be disabled by setting
                 `HF_HUB_DISABLE_PROGRESS_BARS` environment variable.
             dry_run (`bool`, *optional*, defaults to `False`):
@@ -6774,6 +6776,8 @@ class HfApi:
                 If provided, overwrites the default behavior for the progress bar. Passed
                 argument must inherit from `tqdm.auto.tqdm` or at least mimic its behavior.
                 Note that the `tqdm_class` is not passed to each individual download.
+                Three bars are created (files fetched, bytes received from the network, and
+                bytes written to disk), so the class is instantiated three times.
                 Defaults to the custom HF progress bar that can be disabled by setting
                 `HF_HUB_DISABLE_PROGRESS_BARS` environment variable.
             dry_run (`bool`, *optional*, defaults to `False`):


### PR DESCRIPTION
## Summary

The `tqdm_class` docstring says a custom class "must inherit from `tqdm.auto.tqdm` or at least mimic its behavior", which reads as if that were sufficient. It isn't: downloads create more than one bar, so the class is instantiated more than once. Both people who ran into this (#4633, #4646) had to read the source to find out.

This adds one sentence to each of the four `tqdm_class` docstrings. No behavior change.

- `hf_hub_download`: two bars on Xet-backed repos (network transfer + disk reconstruction)
- `snapshot_download`: three bars, always (files fetched + network transfer + disk reconstruction)

Verified by counting instantiations with a custom class:

```
hf_hub_download: instantiated 1x -> ['config.json']
snapshot:        instantiated 3x -> ['Downloading bytes', 'Reconstructing (incomplete total...)', 'Fetching 1 files']
```

(the `snapshot_download` count is on a non-Xet file, `config.json` has `xet_hash=None` — both byte bars are created unconditionally, see `_snapshot_download.py:431` and `:443`)

## Depends on #4647

The `hf_hub_download` sentence is only accurate once #4647 lands. Before it, the transfer bar is hardcoded to our own `tqdm`, so a custom class is instantiated **once**, not twice. Draft until then.

## Deliberately not documented

I did not document the `update_transfer` / `set_transfer_postfix_str` protocol that collapses the two byte bars into one. It has a single implementation (`_AggregatedTqdm` in `_snapshot_download.py`) and is consumed on both the Xet and plain HTTP paths, but making it public API is not worth the long-term commitment for how few people pass a custom `tqdm_class`. This PR only stops the docstring implying a single bar.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstring-only changes with no code or download behavior impact.
> 
> **Overview**
> **Documentation-only** update to the `tqdm_class` parameter docs on `hf_hub_download`, `snapshot_download`, and the matching `HfApi` download helpers.
> 
> The docs previously implied a single progress bar when you pass a custom tqdm class. The new text states how many bars are created and that **`tqdm_class` is instantiated that many times**:
> 
> - **Single-file download** (`hf_hub_download` / `HfApi.hf_hub_download`): on **Xet-backed** repos, **two** bars (network bytes + bytes written to disk).
> - **Snapshot download** (`snapshot_download` / `HfApi.snapshot_download`): **three** bars (files fetched + network bytes + disk reconstruction), with the existing note that the class is not passed to each per-file download.
> 
> No runtime or API behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14dbe3559fefe82d452b9da34d01ee388ec84140. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->