### PR TITLE
[Inference Providers] deepinfra: add feature-extraction support

### DIFF
--- a/src/huggingface_hub/inference/_providers/__init__.py
+++ b/src/huggingface_hub/inference/_providers/__init__.py
@@ -13,6 +13,7 @@ from .cohere import CohereConversationalTask
 from .deepinfra import (
     DeepInfraAutomaticSpeechRecognitionTask,
     DeepInfraConversationalTask,
+    DeepInfraFeatureExtractionTask,
     DeepInfraTextGenerationTask,
     DeepInfraTextToSpeechTask,
 )
@@ -107,6 +108,7 @@ PROVIDERS: dict[PROVIDER_T, dict[str, TaskProviderHelper]] = {
     "deepinfra": {
         "automatic-speech-recognition": DeepInfraAutomaticSpeechRecognitionTask(),
         "conversational": DeepInfraConversationalTask(),
+        "feature-extraction": DeepInfraFeatureExtractionTask(),
         "text-generation": DeepInfraTextGenerationTask(),
         "text-to-speech": DeepInfraTextToSpeechTask(),
     },

--- a/src/huggingface_hub/inference/_providers/deepinfra.py
+++ b/src/huggingface_hub/inference/_providers/deepinfra.py
@@ -143,3 +143,24 @@ class DeepInfraTextToSpeechTask(TaskProviderHelper):
         if isinstance(response, bytes):
             return response
         raise ValueError(f"Expected raw audio bytes for text-to-speech, got {type(response).__name__}.")
+
+
+class DeepInfraFeatureExtractionTask(TaskProviderHelper):
+    def __init__(self):
+        super().__init__(provider=_PROVIDER, base_url=_BASE_URL, task="feature-extraction")
+
+    def _prepare_route(self, mapped_model: str, api_key: str) -> str:
+        return "/v1/openai/embeddings"
+
+    def _prepare_payload_as_dict(
+        self, inputs: Any, parameters: dict, provider_mapping_info: InferenceProviderMapping
+    ) -> dict | None:
+        # `model` is applied last so parameters cannot override the mapped provider model.
+        return {
+            "input": inputs,
+            **filter_none(parameters),
+            "model": provider_mapping_info.provider_id,
+        }
+
+    def get_response(self, response: bytes | dict, request_params: RequestParameters | None = None) -> Any:
+        return [item["embedding"] for item in _as_dict(response)["data"]]

--- a/tests/test_inference_providers.py
+++ b/tests/test_inference_providers.py
@@ -19,6 +19,7 @@ from huggingface_hub.inference._providers._common import (
 from huggingface_hub.inference._providers.cohere import CohereConversationalTask
 from huggingface_hub.inference._providers.deepinfra import (
     DeepInfraAutomaticSpeechRecognitionTask,
+    DeepInfraFeatureExtractionTask,
     DeepInfraTextToSpeechTask,
 )
 from huggingface_hub.inference._providers.fal_ai import (
@@ -392,6 +393,57 @@ class TestDeepInfraProvider:
         assert helper.get_response(b"audio_bytes") == b"audio_bytes"
         with pytest.raises(ValueError):
             helper.get_response({"not": "bytes"})
+
+    def test_feature_extraction_url(self):
+        helper = DeepInfraFeatureExtractionTask()
+        url = helper._prepare_url("hf_token", "Qwen/Qwen3-Embedding-0.6B")
+        assert url == "https://router.huggingface.co/deepinfra/v1/openai/embeddings"
+
+    def test_feature_extraction_payload(self):
+        helper = DeepInfraFeatureExtractionTask()
+        payload = helper._prepare_payload_as_dict(
+            "Hello, world!",
+            {"encoding_format": "float"},
+            InferenceProviderMapping(
+                provider="deepinfra",
+                hf_model_id="Qwen/Qwen3-Embedding-0.6B",
+                providerId="Qwen/Qwen3-Embedding-0.6B",
+                task="feature-extraction",
+                status="live",
+            ),
+        )
+        assert payload == {
+            "input": "Hello, world!",
+            "encoding_format": "float",
+            "model": "Qwen/Qwen3-Embedding-0.6B",
+        }
+
+    def test_feature_extraction_model_not_overridable(self):
+        helper = DeepInfraFeatureExtractionTask()
+        payload = helper._prepare_payload_as_dict(
+            "Hello, world!",
+            {"model": "attacker/model"},
+            InferenceProviderMapping(
+                provider="deepinfra",
+                hf_model_id="Qwen/Qwen3-Embedding-0.6B",
+                providerId="Qwen/Qwen3-Embedding-0.6B",
+                task="feature-extraction",
+                status="live",
+            ),
+        )
+        assert payload["model"] == "Qwen/Qwen3-Embedding-0.6B"
+
+    def test_feature_extraction_response(self):
+        helper = DeepInfraFeatureExtractionTask()
+        response = {
+            "object": "list",
+            "data": [
+                {"object": "embedding", "index": 0, "embedding": [0.1, 0.2, 0.3]},
+                {"object": "embedding", "index": 1, "embedding": [0.4, 0.5, 0.6]},
+            ],
+            "model": "Qwen/Qwen3-Embedding-0.6B",
+        }
+        assert helper.get_response(response) == [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
 
 
 class TestFalAIProvider:


### PR DESCRIPTION
## What

Adds `feature-extraction` support to the **deepinfra** inference provider.

## Details

- New `DeepInfraFeatureExtractionTask(TaskProviderHelper)` in `src/huggingface_hub/inference/_providers/deepinfra.py`.
- Targets DeepInfra's OpenAI-compatible endpoint `POST /v1/openai/embeddings` and returns the list of embedding vectors (`[item["embedding"] for item in response["data"]]`).
- The mapped provider model (`provider_mapping_info.provider_id`) is applied **last** in the payload so caller parameters cannot override it (consistent with the deepinfra ASR/TTS integrations, #4382 / #4559).
- Registered under `"deepinfra" -> "feature-extraction"` in `_providers/__init__.py`.

This is the Python counterpart of the huggingface.js change (companion PR).

## Tests

Added `TestDeepInfraProvider` cases mirroring the TTS ones: URL, payload, model-not-overridable, and response parsing.

```
pytest tests/test_inference_providers.py -k "DeepInfra and feature_extraction"  # 4 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive provider task support following existing patterns; no auth, routing, or core inference client changes.
> 
> **Overview**
> Adds **feature-extraction** (embeddings) support for the DeepInfra inference provider.
> 
> New `DeepInfraFeatureExtractionTask` calls DeepInfra's OpenAI-compatible `/v1/openai/embeddings` endpoint and returns embedding vectors from the response. The mapped provider model is applied last in the payload so callers cannot override it, matching existing DeepInfra ASR/TTS behavior.
> 
> Registers the task under `deepinfra` and adds unit tests for URL, payload, model override protection, and response parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50e0c45f1a5a1b0f2e2ca855e7ff34b47de9280d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->