### PR TITLE
docs: clarify allow_patterns=[] vs ignore_patterns=[] asymmetry in filter_repo_objects

### DIFF
--- a/src/huggingface_hub/utils/_paths.py
+++ b/src/huggingface_hub/utils/_paths.py
@@ -64,10 +64,15 @@ def filter_repo_objects(
             List of items to filter.
         allow_patterns (`str` or `list[str]`, *optional*):
             Patterns constituting the allowlist. If provided, item paths must match at
-            least one pattern from the allowlist.
+            least one pattern from the allowlist. Note that an **empty list** (`[]`) is
+            not equivalent to `None`: since no item can match any pattern in an empty
+            allowlist, `allow_patterns=[]` filters out every item, whereas
+            `allow_patterns=None` applies no allow-filtering at all.
         ignore_patterns (`str` or `list[str]`, *optional*):
             Patterns constituting the denylist. If provided, item paths must not match
-            any patterns from the denylist.
+            any patterns from the denylist. Unlike `allow_patterns`, an empty list
+            (`ignore_patterns=[]`) is a no-op and behaves the same as `None`, since no
+            item can match any pattern in an empty denylist.
         key (`Callable[[T], str]`, *optional*):
             Single-argument function to extract a path from each item. If not provided,
             the `items` must already be `str` or `Path`.

--- a/tests/test_utils_paths.py
+++ b/tests/test_utils_paths.py
@@ -109,6 +109,32 @@ class TestPathsUtils:
             ignore_patterns=[""],
         )
 
+    def test_empty_allow_patterns_list_matches_nothing(self) -> None:
+        """`allow_patterns=[]` is not a no-op: it filters out every item.
+
+        This is intentionally asymmetric with `ignore_patterns=[]` (a no-op, see
+        `test_empty_ignore_patterns_list_is_a_noop`), since an item can never match any
+        pattern in an empty allowlist. Regression/documentation test for
+        https://github.com/huggingface/huggingface_hub/issues/4653.
+        """
+        self._check(
+            items=["a.txt", "b.bin", "sub/c.txt"],
+            expected_items=[],
+            allow_patterns=[],
+        )
+
+    def test_empty_ignore_patterns_list_is_a_noop(self) -> None:
+        """`ignore_patterns=[]` behaves the same as `ignore_patterns=None`: nothing is excluded.
+
+        See `test_empty_allow_patterns_list_matches_nothing` for the (intentional)
+        asymmetry with `allow_patterns=[]`.
+        """
+        self._check(
+            items=["a.txt", "b.bin", "sub/c.txt"],
+            expected_items=["a.txt", "b.bin", "sub/c.txt"],
+            ignore_patterns=[],
+        )
+
     def test_filter_is_case_sensitive(self) -> None:
         """Pattern matching is case-sensitive.
         Regression test for https://github.com/huggingface/huggingface_hub/issues/4434.


### PR DESCRIPTION
## What does this PR do?

`filter_repo_objects()` treats `allow_patterns=[]` and `ignore_patterns=[]` asymmetrically:

- `allow_patterns=[]` matches **zero** items — `not any(...)` over an empty pattern list is `True` for every path, so everything is filtered out.
- `ignore_patterns=[]` is a **no-op** — `any(...)` over an empty pattern list is `False` for every path, so nothing is excluded.

This is intentional given how the allow/deny checks are implemented (confirmed by reading the code and running it — see below), but it's undocumented and easy to trip over: `allow_patterns` is frequently built up programmatically (from a config, a CLI flag, a comprehension over selected file types), and a list that resolves to `[]` silently turns `snapshot_download`/`upload_folder`/`CommitScheduler` into a no-op with no error. The upload/scheduler cases are the ones that actually hurt — the call succeeds and nothing is raised, so the caller believes the operation completed.

Reported in #4653. That issue lists several possible behavior changes (treat `[]` as `None`, raise, warn) as open API-design questions for maintainers to weigh in on — this PR does **not** make any of those calls. It only documents the current, actual behavior in the docstring and adds regression tests pinning both sides of the asymmetry. No behavior change.

## Verification

```
>>> from huggingface_hub.utils import filter_repo_objects
>>> list(filter_repo_objects(["a.txt", "b.bin", "sub/c.txt"], allow_patterns=None))
['a.txt', 'b.bin', 'sub/c.txt']
>>> list(filter_repo_objects(["a.txt", "b.bin", "sub/c.txt"], allow_patterns=[]))
[]
>>> list(filter_repo_objects(["a.txt", "b.bin", "sub/c.txt"], ignore_patterns=None))
['a.txt', 'b.bin', 'sub/c.txt']
>>> list(filter_repo_objects(["a.txt", "b.bin", "sub/c.txt"], ignore_patterns=[]))
['a.txt', 'b.bin', 'sub/c.txt']
```

Ran locally against a fresh editable install (Python 3.12, uv venv):

- `pytest tests/test_utils_paths.py -v`: 15 passed (13 existing + 2 new regression tests)
- `ruff check` / `ruff format --check` on both touched files: clean

Fixes #4653

---
*Disclosure: I'm Atlas, an AI agent operating under Gordon Lee's (@g0rdonL) direction. I verified the behavior directly (reproduced both branches of the asymmetry against the current `main` code) before opening this PR; the change is a docstring clarification plus regression tests, no logic change.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstring and test-only change; filtering logic is unchanged.
> 
> **Overview**
> Documents a non-obvious edge case in **`filter_repo_objects`**: **`allow_patterns=[]`** is **not** the same as **`None`**—it excludes every path—while **`ignore_patterns=[]`** is a no-op like **`None`**.
> 
> The **`filter_repo_objects`** docstring in **`_paths.py`** now spells out that asymmetry and why it follows from allow/deny matching. Two regression tests in **`test_utils_paths.py`** lock in both behaviors (issue **#4653**). **No runtime logic changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c18adef67b983c2b0f0533312aed23d229883b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->