### PR TITLE
[Inference] Add DeepInfra sentence-similarity provider helper

### DIFF
--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -1662,7 +1662,7 @@ class InferenceClient:
             api_key=self.token,
         )
         response = self._inner_post(request_parameters)
-        return _bytes_to_list(response)
+        return provider_helper.get_response(response)
 
     def summarization(
         self,

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -1702,7 +1702,7 @@ class AsyncInferenceClient:
             api_key=self.token,
         )
         response = await self._inner_post(request_parameters)
-        return _bytes_to_list(response)
+        return provider_helper.get_response(response)
 
     async def summarization(
         self,

--- a/src/huggingface_hub/inference/_providers/__init__.py
+++ b/src/huggingface_hub/inference/_providers/__init__.py
@@ -14,6 +14,7 @@ from .deepinfra import (
     DeepInfraAutomaticSpeechRecognitionTask,
     DeepInfraConversationalTask,
     DeepInfraFeatureExtractionTask,
+    DeepInfraSentenceSimilarityTask,
     DeepInfraTextGenerationTask,
     DeepInfraTextToSpeechTask,
 )
@@ -32,6 +33,7 @@ from .hf_inference import (
     HFInferenceBinaryInputTask,
     HFInferenceConversational,
     HFInferenceFeatureExtractionTask,
+    HFInferenceSentenceSimilarityTask,
     HFInferenceTask,
 )
 from .novita import NovitaConversationalTask, NovitaTextGenerationTask, NovitaTextToVideoTask
@@ -109,6 +111,7 @@ PROVIDERS: dict[PROVIDER_T, dict[str, TaskProviderHelper]] = {
         "automatic-speech-recognition": DeepInfraAutomaticSpeechRecognitionTask(),
         "conversational": DeepInfraConversationalTask(),
         "feature-extraction": DeepInfraFeatureExtractionTask(),
+        "sentence-similarity": DeepInfraSentenceSimilarityTask(),
         "text-generation": DeepInfraTextGenerationTask(),
         "text-to-speech": DeepInfraTextToSpeechTask(),
     },
@@ -150,7 +153,7 @@ PROVIDERS: dict[PROVIDER_T, dict[str, TaskProviderHelper]] = {
         "zero-shot-image-classification": HFInferenceBinaryInputTask("zero-shot-image-classification"),
         "zero-shot-classification": HFInferenceTask("zero-shot-classification"),
         "image-to-image": HFInferenceBinaryInputTask("image-to-image"),
-        "sentence-similarity": HFInferenceTask("sentence-similarity"),
+        "sentence-similarity": HFInferenceSentenceSimilarityTask(),
         "table-question-answering": HFInferenceTask("table-question-answering"),
         "tabular-classification": HFInferenceTask("tabular-classification"),
         "text-to-speech": HFInferenceTask("text-to-speech"),

--- a/src/huggingface_hub/inference/_providers/deepinfra.py
+++ b/src/huggingface_hub/inference/_providers/deepinfra.py
@@ -1,4 +1,5 @@
 import json
+import math
 import mimetypes
 import uuid
 from typing import Any
@@ -11,6 +12,14 @@ from ._common import BaseConversationalTask, BaseTextGenerationTask, TaskProvide
 
 _PROVIDER = "deepinfra"
 _BASE_URL = "https://api.deepinfra.com"
+
+
+def _cosine_similarity(a: list[float], b: list[float]) -> float:
+    dot = sum(x * y for x, y in zip(a, b))
+    norm_a = math.sqrt(sum(x * x for x in a))
+    norm_b = math.sqrt(sum(y * y for y in b))
+    denom = norm_a * norm_b
+    return dot / denom if denom else 0.0
 
 
 def _form_field_value(value: Any) -> str:
@@ -164,3 +173,34 @@ class DeepInfraFeatureExtractionTask(TaskProviderHelper):
 
     def get_response(self, response: bytes | dict, request_params: RequestParameters | None = None) -> Any:
         return [item["embedding"] for item in _as_dict(response)["data"]]
+
+
+class DeepInfraSentenceSimilarityTask(TaskProviderHelper):
+    def __init__(self):
+        super().__init__(provider=_PROVIDER, base_url=_BASE_URL, task="sentence-similarity")
+
+    def _prepare_route(self, mapped_model: str, api_key: str) -> str:
+        return "/v1/openai/embeddings"
+
+    def _prepare_payload_as_dict(
+        self, inputs: Any, parameters: dict, provider_mapping_info: InferenceProviderMapping
+    ) -> dict | None:
+        # DeepInfra has no native sentence-similarity endpoint, so we embed the source
+        # sentence (first) and the comparison sentences in a single embeddings request and
+        # derive the similarities from the returned vectors. `input` and `model` are applied
+        # after the caller parameters so neither can be overridden.
+        return {
+            **filter_none(parameters),
+            "input": [inputs["source_sentence"], *inputs["sentences"]],
+            "model": provider_mapping_info.provider_id,
+        }
+
+    def get_response(self, response: bytes | dict, request_params: RequestParameters | None = None) -> Any:
+        data = _as_dict(response).get("data")
+        if not isinstance(data, list) or not data:
+            raise ValueError(f"Unexpected output format from DeepInfra sentence-similarity API: {response!r}")
+        # `index` preserves request order: item 0 is the source sentence, items 1.. are the
+        # comparison sentences.
+        embeddings = [item["embedding"] for item in sorted(data, key=lambda item: item["index"])]
+        source, *rest = embeddings
+        return [_cosine_similarity(source, embedding) for embedding in rest]

--- a/src/huggingface_hub/inference/_providers/hf_inference.py
+++ b/src/huggingface_hub/inference/_providers/hf_inference.py
@@ -11,6 +11,7 @@ from huggingface_hub.inference._common import (
     RequestParameters,
     _b64_encode,
     _bytes_to_dict,
+    _bytes_to_list,
     _open_as_mime_bytes,
 )
 from huggingface_hub.inference._providers._common import TaskProviderHelper, filter_none
@@ -233,3 +234,13 @@ class HFInferenceFeatureExtractionTask(HFInferenceTask):
         if isinstance(response, bytes):
             return _bytes_to_dict(response)
         return response
+
+
+class HFInferenceSentenceSimilarityTask(HFInferenceTask):
+    def __init__(self):
+        super().__init__("sentence-similarity")
+
+    def get_response(self, response: bytes | dict, request_params: RequestParameters | None = None) -> Any:
+        # Preserve the historical client behavior: HF Inference returns the similarity scores
+        # directly, so we only decode the raw payload to a list.
+        return _bytes_to_list(response) if isinstance(response, bytes) else response

--- a/tests/test_inference_providers.py
+++ b/tests/test_inference_providers.py
@@ -21,6 +21,7 @@ from huggingface_hub.inference._providers.cohere import CohereConversationalTask
 from huggingface_hub.inference._providers.deepinfra import (
     DeepInfraAutomaticSpeechRecognitionTask,
     DeepInfraFeatureExtractionTask,
+    DeepInfraSentenceSimilarityTask,
     DeepInfraTextToSpeechTask,
 )
 from huggingface_hub.inference._providers.fal_ai import (
@@ -445,6 +446,67 @@ class TestDeepInfraProvider:
             "model": "Qwen/Qwen3-Embedding-0.6B",
         }
         assert helper.get_response(response) == [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+
+    def test_sentence_similarity_url(self):
+        helper = DeepInfraSentenceSimilarityTask()
+        url = helper._prepare_url("hf_token", "Qwen/Qwen3-Embedding-0.6B")
+        assert url == "https://router.huggingface.co/deepinfra/v1/openai/embeddings"
+
+    def test_sentence_similarity_payload(self):
+        helper = DeepInfraSentenceSimilarityTask()
+        payload = helper._prepare_payload_as_dict(
+            {"source_sentence": "that is a happy person", "sentences": ["that is a happy dog", "today is sunny"]},
+            {"encoding_format": "float"},
+            InferenceProviderMapping(
+                provider="deepinfra",
+                hf_model_id="Qwen/Qwen3-Embedding-0.6B",
+                providerId="Qwen/Qwen3-Embedding-0.6B",
+                task="sentence-similarity",
+                status="live",
+            ),
+        )
+        assert payload == {
+            "input": ["that is a happy person", "that is a happy dog", "today is sunny"],
+            "encoding_format": "float",
+            "model": "Qwen/Qwen3-Embedding-0.6B",
+        }
+
+    def test_sentence_similarity_model_not_overridable(self):
+        helper = DeepInfraSentenceSimilarityTask()
+        payload = helper._prepare_payload_as_dict(
+            {"source_sentence": "a", "sentences": ["b"]},
+            {"model": "attacker/model", "input": "attacker input"},
+            InferenceProviderMapping(
+                provider="deepinfra",
+                hf_model_id="Qwen/Qwen3-Embedding-0.6B",
+                providerId="Qwen/Qwen3-Embedding-0.6B",
+                task="sentence-similarity",
+                status="live",
+            ),
+        )
+        assert payload["model"] == "Qwen/Qwen3-Embedding-0.6B"
+        assert payload["input"] == ["a", "b"]
+
+    def test_sentence_similarity_response(self):
+        helper = DeepInfraSentenceSimilarityTask()
+        # Deliberately out of order to exercise the index-based sort: source (index 0) is
+        # identical to sentence index 1 (cosine 1.0) and orthogonal to index 2 (cosine 0.0).
+        response = {
+            "object": "list",
+            "data": [
+                {"object": "embedding", "index": 2, "embedding": [0.0, 1.0]},
+                {"object": "embedding", "index": 0, "embedding": [1.0, 0.0]},
+                {"object": "embedding", "index": 1, "embedding": [1.0, 0.0]},
+            ],
+            "model": "Qwen/Qwen3-Embedding-0.6B",
+        }
+        result = helper.get_response(response)
+        assert result == pytest.approx([1.0, 0.0])
+
+    def test_sentence_similarity_malformed_response(self):
+        helper = DeepInfraSentenceSimilarityTask()
+        with pytest.raises(ValueError):
+            helper.get_response({"object": "list"})
 
 
 class TestFalAIProvider:


### PR DESCRIPTION
> **Draft** — opening for maintainer feedback on the client-method change described below.

## What

Adds a `sentence-similarity` task helper for the **DeepInfra** inference provider.

DeepInfra serves its embedding models (bge, e5, gte, sentence-transformers, nvidia Nemotron-Embed, etc.) through an OpenAI-compatible `POST /v1/openai/embeddings` endpoint. Many of these repos carry `pipeline_tag: sentence-similarity` on the Hub, so a DeepInfra mapping can only be registered under the `sentence-similarity` task. Until now `sentence-similarity` had a helper only for `hf-inference`, so those mappings could not route through any partner provider.

## How

`DeepInfraSentenceSimilarityTask`:
- **route** → `/v1/openai/embeddings`
- **payload** → embeds `[source_sentence, *sentences]` in a single request (source first); `model` applied last so parameters cannot override the mapped provider model.
- **response** → embeddings preserve request order via `index` (item 0 = source, items 1.. = comparison sentences); returns the cosine similarity of each sentence against the source as `list[float]`, matching the task contract and the docstring ("by comparing their embeddings").

## ⚠️ Client-method change (the reason this is a draft)

`InferenceClient.sentence_similarity` (and the async client) previously returned `_bytes_to_list(response)` directly, **bypassing the provider helper's `get_response`**. A provider that doesn't natively return a bare list of scores (like DeepInfra, which returns embeddings) therefore cannot adapt its output.

This PR changes the client to route the response through `provider_helper.get_response(...)`, consistent with `feature_extraction` and most other tasks. To keep **HF Inference** behavior byte-for-byte identical, `HFInferenceSentenceSimilarityTask.get_response` returns `_bytes_to_list(response)`.

Happy to adjust the approach — e.g. keep the client as-is and instead special-case only DeepInfra — if you'd prefer not to touch the shared client path.

## Tests

- `tests/test_inference_providers.py::TestDeepInfraProvider` — route, payload, model-not-overridable, cosine response, index ordering.
- Existing `hf-inference` sentence-similarity tests still pass.

Validation: `pytest -k "DeepInfra or HFInference"` (45 passed) ✅, `ruff check` ✅, `ruff format --check` ✅, async client regenerated & in sync ✅.