### PR TITLE
[CLI] Keep `hf extensions` off the metered GitHub REST API

### DIFF
--- a/src/huggingface_hub/cli/extensions.py
+++ b/src/huggingface_hub/cli/extensions.py
@@ -23,10 +23,12 @@ import venv
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from enum import Enum
+from html import unescape
 from pathlib import Path
 from typing import Annotated, Literal
 
 import click
+import httpx
 
 from huggingface_hub.errors import CLIError, CLIExtensionInstallError, ConfirmationError
 from huggingface_hub.utils import get_session, logging
@@ -53,7 +55,7 @@ logger = logging.get_logger(__name__)
 
 
 class _GitHubRateLimitError(CLIError):
-    """The GitHub API refused the request because the hourly quota is exhausted.
+    """The GitHub API refused the request because a rate limit is exhausted.
 
     Distinguished from other `CLIError`s because it says nothing about the extension being handled:
     it is not worth retrying on the next one, and it must not be mistaken for an install failure.
@@ -255,7 +257,8 @@ def extension_list() -> None:
 @extensions_cli.command("search", examples=["hf extensions search"])
 def extension_search() -> None:
     """Search extensions available on GitHub (tagged with 'hf-extension' topic)."""
-    response = _github_get(
+    response = _github_request(
+        "GET",
         "https://api.github.com/search/repositories",
         params={"q": f"topic:{_EXTENSIONS_GITHUB_TOPIC}", "sort": "stars", "order": "desc", "per_page": 100},
     )
@@ -361,7 +364,7 @@ def _auto_install_official_extension(short_name: str) -> Path | None:
         return None
 
     # Every unknown `hf <command>` reaches this point, typos included, so the existence check must
-    # not spend REST API quota (see `_github_get`).
+    # not spend REST API quota (see `_github_request`).
     try:
         if not _github_repo_exists(owner=owner, repo_name=repo_name):
             return None
@@ -394,11 +397,13 @@ def _load_installed_extension_for_update(name: str) -> ExtensionManifest:
 def _update_installed_extension(manifest: ExtensionManifest) -> _ExtensionUpdateStatus:
     owner, repo_name, short_name = manifest.owner, manifest.repo, manifest.short_name
 
-    latest_sha = _fetch_latest_commit_sha(owner=owner, repo_name=repo_name, warn=False)
-    if latest_sha is None:
-        out.warning(
-            f"Could not check updates for '{short_name}' ({owner}/{repo_name}): GitHub is unreachable. Skipping."
-        )
+    try:
+        latest_sha = _fetch_latest_commit_sha(owner=owner, repo_name=repo_name)
+    except _GitHubRateLimitError:
+        # Says nothing about this extension in particular, so let the caller stop the whole run.
+        raise
+    except Exception as error:
+        out.warning(f"Could not check updates for '{short_name}' ({owner}/{repo_name}): {error}. Skipping.")
         return _ExtensionUpdateStatus.SKIPPED
 
     if latest_sha == manifest.commit_sha:
@@ -440,12 +445,12 @@ def _install_extension(
 
         if commit_sha is None:
             # The extension itself is on disk by now, fetched from the CDN. The SHA only feeds update
-            # detection, so a metered-API failure must not throw the install away: without it, the next
+            # detection, so a failure here must not throw the install away: without it, the next
             # `hf extensions update` sees no known SHA, considers the extension outdated and reinstalls.
             try:
                 commit_sha = _fetch_latest_commit_sha(owner=owner, repo_name=repo_name)
-            except _GitHubRateLimitError as error:
-                out.warning(f"{error} Installing anyway, without a recorded version.")
+            except Exception as error:
+                out.warning(f"Could not record a version for '{owner}/{repo_name}', installing anyway: {error}")
 
         manifest = ExtensionManifest(
             owner=owner,
@@ -480,30 +485,24 @@ def _install_extension(
             shutil.rmtree(extension_dir, ignore_errors=True)
 
 
-def _fetch_latest_commit_sha(*, owner: str, repo_name: str, warn: bool = True) -> str | None:
-    """Best-effort fetch of the latest commit SHA on the default branch, to detect available updates.
+def _fetch_latest_commit_sha(*, owner: str, repo_name: str) -> str:
+    """Fetch the latest commit SHA on the default branch, used to detect available updates.
 
-    The only REST API call left in the install and update paths.
+    The only REST API call left in the install and update paths. Raises on failure: callers decide
+    whether a missing SHA is fatal, and report the reason themselves.
     """
-    try:
-        response = _github_get(
-            f"https://api.github.com/repos/{owner}/{repo_name}/commits/HEAD",
-            headers={"Accept": "application/vnd.github.sha"},
-        )
-        return response.text.strip() or None
-    except _GitHubRateLimitError:
-        # Worth reporting as-is rather than as "GitHub is unreachable".
-        raise
-    except Exception as error:
-        if warn:
-            out.warning(f"Could not fetch latest commit SHA for '{repo_name}' ({owner}/{repo_name}): {error}")
-        return None
+    response = _github_request(
+        "GET",
+        f"https://api.github.com/repos/{owner}/{repo_name}/commits/HEAD",
+        headers={"Accept": "application/vnd.github.sha"},
+    )
+    return response.text.strip()
 
 
 def _fetch_remote_binary(*, owner: str, repo_name: str, short_name: str) -> bytes:
     executable_name = _get_executable_name(short_name)
     raw_url = f"https://raw.githubusercontent.com/{owner}/{repo_name}/HEAD/{executable_name}"
-    response = _github_get(raw_url)
+    response = _github_request("GET", raw_url)
     return response.content
 
 
@@ -562,10 +561,14 @@ def _install_python_extension(*, extension_dir: Path, owner: str, repo_name: str
     return venv_executable.resolve()
 
 
+_GITHUB_ABOUT_RE = re.compile(r'<meta name="description" content="([^"]*)"')
+
+
 def _try_fetch_remote_description(owner: str, repo_name: str) -> str | None:
     """Try to fetch project description either from:
     - manifest.json
     - pyproject.toml
+    - the repository's GitHub "About" field
 
     Only best effort, no error handling.
     """
@@ -573,7 +576,7 @@ def _try_fetch_remote_description(owner: str, repo_name: str) -> str | None:
 
     # from manifest.json
     try:
-        response = _github_get(f"{base}/{MANIFEST_FILENAME}")
+        response = _github_request("GET", f"{base}/{MANIFEST_FILENAME}")
         description = response.json().get("description")
         if isinstance(description, str):
             return description
@@ -582,7 +585,7 @@ def _try_fetch_remote_description(owner: str, repo_name: str) -> str | None:
 
     # from pyproject.toml
     try:
-        response = _github_get(f"{base}/pyproject.toml")
+        response = _github_request("GET", f"{base}/pyproject.toml")
 
         # Weak parser but ok for "best effort"
         for line in response.text.splitlines():
@@ -590,6 +593,17 @@ def _try_fetch_remote_description(owner: str, repo_name: str) -> str | None:
             if line.startswith("description"):
                 _, _, value = line.partition("=")
                 return value.strip().strip("\"'")
+    except Exception:
+        pass
+
+    # from the repo page's "About" field. Served by github.com, so it costs no REST API quota.
+    try:
+        response = _github_request("GET", f"https://github.com/{owner}/{repo_name}")
+        if (match := _GITHUB_ABOUT_RE.search(response.text)) is not None:
+            # GitHub renders "<about> - <owner>/<repo>", and unrelated boilerplate when About is empty.
+            content = unescape(match.group(1))
+            if (description := content.removesuffix(f" - {owner}/{repo_name}")) != content:
+                return description
     except Exception:
         pass
 
@@ -603,43 +617,56 @@ def _get_extension_dir(short_name: str) -> Path:
     return EXTENSIONS_ROOT.expanduser() / f"hf-{short_name}"
 
 
-def _github_get(url: str, *, params: dict | None = None, headers: dict | None = None):
-    """Perform a GitHub GET request.
+def _github_request(
+    method: str, url: str, *, params: dict | None = None, headers: dict | None = None
+) -> httpx.Response:
+    """Perform a GitHub request.
 
-    Shared by every GitHub/Raw fetch in this module so the timeout and redirect policy are shared.
+    Shared by every GitHub/Raw fetch in this module so the timeout, redirect and rate-limit policy are
+    shared.
 
-    Unauthenticated `api.github.com` calls are capped at 60 per hour per IP address, and that quota is
-    shared with everything else calling GitHub from the same network (NAT, VPN, CI egress). Remote refs
-    are therefore always addressed as `HEAD`, which GitHub resolves to the repo's default branch on
+    Unauthenticated `api.github.com` calls are capped per IP address, and that quota is shared with
+    everything else calling GitHub from the same network (NAT, VPN, CI egress). Remote refs are therefore
+    always addressed as `HEAD`, which GitHub resolves to the repo's default branch on
     `raw.githubusercontent.com`, on the archive endpoint and on the REST API alike: no
     `GET /repos/{owner}/{repo}` lookup is needed to discover the branch name.
     """
-    response = get_session().get(
+    response = get_session().request(
+        method,
         url,
         params=params,
         headers=headers,
         follow_redirects=True,
         timeout=_EXTENSIONS_DOWNLOAD_TIMEOUT,
     )
-    if response.status_code in (403, 429) and response.headers.get("x-ratelimit-remaining") == "0":
-        raise _GitHubRateLimitError(_rate_limit_message(response.headers.get("x-ratelimit-reset")))
+    # Primary limits report an exhausted quota, secondary ones only ask to back off.
+    if response.status_code in (403, 429) and (
+        response.headers.get("x-ratelimit-remaining") == "0" or "retry-after" in response.headers
+    ):
+        raise _GitHubRateLimitError(_rate_limit_message(response.headers))
     response.raise_for_status()
     return response
 
 
-def _rate_limit_message(reset: str | None) -> str:
-    """Message for a GitHub API rate-limit rejection, `reset` being the `x-ratelimit-reset` header."""
+def _rate_limit_message(headers: httpx.Headers) -> str:
+    """Message for a GitHub rate-limit rejection, built from the response headers.
+
+    The cap itself is deliberately not quoted: it depends on the endpoint (60/hour on the core API,
+    10/minute on search), so only the reset time is reported.
+    """
     message = (
-        "GitHub API rate limit exceeded. Unauthenticated requests are capped at 60 per hour per IP address, "
-        "and that quota is shared with anything else calling GitHub from your network."
+        "GitHub API rate limit exceeded. Unauthenticated requests are capped per IP address, and that "
+        "quota is shared with anything else calling GitHub from your network."
     )
-    if reset is not None:
+    if (reset := headers.get("x-ratelimit-reset")) is not None:
         try:
             reset_at = datetime.fromtimestamp(int(reset), tz=timezone.utc).astimezone()
         except (OverflowError, OSError, ValueError):
             pass
         else:
-            message += f" It resets at {reset_at:%H:%M:%S}."
+            message += f" It resets at {reset_at:%H:%M:%S %Z}."
+    elif (retry_after := headers.get("retry-after")) is not None:
+        message += f" Retry in {retry_after}s."
     return message
 
 
@@ -647,17 +674,15 @@ def _github_repo_exists(*, owner: str, repo_name: str) -> bool:
     """Whether a public GitHub repo exists.
 
     Resolved against `github.com` rather than `GET /repos/{owner}/{repo}` to keep the check off the
-    metered REST API (see `_github_get`). Only a 404 answers `False`: an unreachable GitHub raises, so
-    callers don't report a missing repo when the network is down.
+    metered REST API (see `_github_request`). Only a 404 answers `False`: any other failure is reported
+    as such, so callers never present an unreachable GitHub as a missing repo.
     """
-    response = get_session().head(
-        f"https://github.com/{owner}/{repo_name}",
-        follow_redirects=True,
-        timeout=_EXTENSIONS_DOWNLOAD_TIMEOUT,
-    )
-    if response.status_code == 404:
-        return False
-    response.raise_for_status()
+    try:
+        _github_request("HEAD", f"https://github.com/{owner}/{repo_name}")
+    except httpx.HTTPError as error:
+        if isinstance(error, httpx.HTTPStatusError) and error.response.status_code == 404:
+            return False
+        raise CLIError(f"Could not reach GitHub to check whether '{owner}/{repo_name}' exists: {error}") from error
     return True
 
 

--- a/src/huggingface_hub/cli/extensions.py
+++ b/src/huggingface_hub/cli/extensions.py
@@ -430,6 +430,15 @@ def _install_extension(
                 extension_dir=extension_dir, owner=owner, repo_name=repo_name, short_name=short_name
             )
 
+        if commit_sha is None:
+            # The extension itself is on disk by now, fetched from the CDN. The SHA only feeds update
+            # detection, so a metered-API failure must not throw the install away: without it, the next
+            # `hf extensions update` sees no known SHA, considers the extension outdated and reinstalls.
+            try:
+                commit_sha = _fetch_latest_commit_sha(owner=owner, repo_name=repo_name)
+            except CLIError as error:
+                out.warning(f"{error} Installing anyway, without a recorded version.")
+
         manifest = ExtensionManifest(
             owner=owner,
             repo=repo_name,
@@ -439,7 +448,7 @@ def _install_extension(
             type="binary" if binary is not None else "python",
             installed_at=datetime.now(timezone.utc),
             description=_try_fetch_remote_description(owner=owner, repo_name=repo_name),
-            commit_sha=commit_sha or _fetch_latest_commit_sha(owner=owner, repo_name=repo_name),
+            commit_sha=commit_sha,
         )
         manifest.save(extension_dir)
         installed = True

--- a/src/huggingface_hub/cli/extensions.py
+++ b/src/huggingface_hub/cli/extensions.py
@@ -652,21 +652,25 @@ def _rate_limit_message(headers: httpx.Headers) -> str:
     """Message for a GitHub rate-limit rejection, built from the response headers.
 
     The cap itself is deliberately not quoted: it depends on the endpoint (60/hour on the core API,
-    10/minute on search), so only the reset time is reported.
+    10/minute on search), so only the wait is reported.
+
+    `retry-after` wins over `x-ratelimit-reset`: GitHub rides the primary window's reset timestamp on
+    every REST response, secondary rate limits included, so on a back-off it would point at an hourly
+    window that is not the one being enforced.
     """
     message = (
         "GitHub API rate limit exceeded. Unauthenticated requests are capped per IP address, and that "
         "quota is shared with anything else calling GitHub from your network."
     )
-    if (reset := headers.get("x-ratelimit-reset")) is not None:
+    if (retry_after := headers.get("retry-after")) is not None:
+        message += f" Retry in {retry_after}s."
+    elif (reset := headers.get("x-ratelimit-reset")) is not None:
         try:
             reset_at = datetime.fromtimestamp(int(reset), tz=timezone.utc).astimezone()
         except (OverflowError, OSError, ValueError):
             pass
         else:
             message += f" It resets at {reset_at:%H:%M:%S %Z}."
-    elif (retry_after := headers.get("retry-after")) is not None:
-        message += f" Retry in {retry_after}s."
     return message
 
 

--- a/src/huggingface_hub/cli/extensions.py
+++ b/src/huggingface_hub/cli/extensions.py
@@ -52,6 +52,14 @@ _EXTENSIONS_PIP_INSTALL_TIMEOUT = 300
 logger = logging.get_logger(__name__)
 
 
+class _GitHubRateLimitError(CLIError):
+    """The GitHub API refused the request because the hourly quota is exhausted.
+
+    Distinguished from other `CLIError`s because it says nothing about the extension being handled:
+    it is not worth retrying on the next one, and it must not be mistaken for an install failure.
+    """
+
+
 class _ExtensionUpdateStatus(str, Enum):
     UPDATED = "updated"
     UP_TO_DATE = "up_to_date"
@@ -181,8 +189,8 @@ def extension_update(
         out.log(f"Checking '{manifest.short_name}' ({manifest.repo_id})...")
         try:
             update_status = _update_installed_extension(manifest)
-        except CLIError:
-            # e.g. a GitHub rate limit: every remaining extension would fail the same way.
+        except _GitHubRateLimitError:
+            # Every remaining extension would fail the same way, so stop rather than repeat it.
             raise
         except Exception as error:
             # Keep updating the other extensions even if one fails.
@@ -436,7 +444,7 @@ def _install_extension(
             # `hf extensions update` sees no known SHA, considers the extension outdated and reinstalls.
             try:
                 commit_sha = _fetch_latest_commit_sha(owner=owner, repo_name=repo_name)
-            except CLIError as error:
+            except _GitHubRateLimitError as error:
                 out.warning(f"{error} Installing anyway, without a recorded version.")
 
         manifest = ExtensionManifest(
@@ -483,8 +491,8 @@ def _fetch_latest_commit_sha(*, owner: str, repo_name: str, warn: bool = True) -
             headers={"Accept": "application/vnd.github.sha"},
         )
         return response.text.strip() or None
-    except CLIError:
-        # A rate limit is worth reporting as-is rather than as "GitHub is unreachable".
+    except _GitHubRateLimitError:
+        # Worth reporting as-is rather than as "GitHub is unreachable".
         raise
     except Exception as error:
         if warn:
@@ -614,7 +622,7 @@ def _github_get(url: str, *, params: dict | None = None, headers: dict | None = 
         timeout=_EXTENSIONS_DOWNLOAD_TIMEOUT,
     )
     if response.status_code in (403, 429) and response.headers.get("x-ratelimit-remaining") == "0":
-        raise CLIError(_rate_limit_message(response.headers.get("x-ratelimit-reset")))
+        raise _GitHubRateLimitError(_rate_limit_message(response.headers.get("x-ratelimit-reset")))
     response.raise_for_status()
     return response
 

--- a/src/huggingface_hub/cli/extensions.py
+++ b/src/huggingface_hub/cli/extensions.py
@@ -122,13 +122,12 @@ def extension_install(
     if extension_dir.exists() and not force:
         raise CLIError(f"Extension '{short_name}' is already installed. Use --force to overwrite.")
 
-    branch, description = _fetch_github_repo_info(owner=owner, repo_name=repo_name)
+    if not _github_repo_exists(owner=owner, repo_name=repo_name):
+        raise CLIError(f"GitHub repository '{owner}/{repo_name}' not found. It must exist and be public.")
     if extension_dir.exists():
-        # --force reinstall: only remove the previous install once the repo metadata is resolved.
+        # --force reinstall: only remove the previous install once the repo is known to exist.
         shutil.rmtree(extension_dir)
-    manifest = _install_extension(
-        owner=owner, repo_name=repo_name, short_name=short_name, branch=branch, description=description
-    )
+    manifest = _install_extension(owner=owner, repo_name=repo_name, short_name=short_name)
     ext_type = manifest.type.capitalize()
     out.result(
         f"{ext_type} extension installed",
@@ -182,6 +181,9 @@ def extension_update(
         out.log(f"Checking '{manifest.short_name}' ({manifest.repo_id})...")
         try:
             update_status = _update_installed_extension(manifest)
+        except CLIError:
+            # e.g. a GitHub rate limit: every remaining extension would fail the same way.
+            raise
         except Exception as error:
             # Keep updating the other extensions even if one fails.
             out.warning(f"Could not update '{manifest.short_name}' ({manifest.repo_id}): {error}. Skipping.")
@@ -350,8 +352,11 @@ def _auto_install_official_extension(short_name: str) -> Path | None:
     if _get_extension_dir(short_name).exists():
         return None
 
+    # Every unknown `hf <command>` reaches this point, typos included, so the existence check must
+    # not spend REST API quota (see `_github_get`).
     try:
-        branch, description = _fetch_github_repo_info(owner=owner, repo_name=repo_name)
+        if not _github_repo_exists(owner=owner, repo_name=repo_name):
+            return None
     except Exception:
         return None
 
@@ -360,9 +365,7 @@ def _auto_install_official_extension(short_name: str) -> Path | None:
     except ConfirmationError:
         return None
     try:
-        manifest = _install_extension(
-            owner=owner, repo_name=repo_name, short_name=short_name, branch=branch, description=description
-        )
+        manifest = _install_extension(owner=owner, repo_name=repo_name, short_name=short_name)
         return Path(manifest.executable_path).expanduser()
     except Exception:
         return None
@@ -383,13 +386,7 @@ def _load_installed_extension_for_update(name: str) -> ExtensionManifest:
 def _update_installed_extension(manifest: ExtensionManifest) -> _ExtensionUpdateStatus:
     owner, repo_name, short_name = manifest.owner, manifest.repo, manifest.short_name
 
-    try:
-        branch, description = _fetch_github_repo_info(owner=owner, repo_name=repo_name)
-    except Exception as error:
-        out.warning(f"Could not check updates for '{short_name}' ({owner}/{repo_name}): {error}. Skipping.")
-        return _ExtensionUpdateStatus.SKIPPED
-
-    latest_sha = _fetch_latest_commit_sha(owner=owner, repo_name=repo_name, branch=branch, warn=False)
+    latest_sha = _fetch_latest_commit_sha(owner=owner, repo_name=repo_name, warn=False)
     if latest_sha is None:
         out.warning(
             f"Could not check updates for '{short_name}' ({owner}/{repo_name}): GitHub is unreachable. Skipping."
@@ -399,14 +396,7 @@ def _update_installed_extension(manifest: ExtensionManifest) -> _ExtensionUpdate
     if latest_sha == manifest.commit_sha:
         return _ExtensionUpdateStatus.UP_TO_DATE
 
-    _install_extension(
-        owner=owner,
-        repo_name=repo_name,
-        short_name=short_name,
-        branch=branch,
-        description=description,
-        commit_sha=latest_sha,
-    )
+    _install_extension(owner=owner, repo_name=repo_name, short_name=short_name, commit_sha=latest_sha)
     return _ExtensionUpdateStatus.UPDATED
 
 
@@ -415,8 +405,6 @@ def _install_extension(
     owner: str,
     repo_name: str,
     short_name: str,
-    branch: str,
-    description: str | None = None,
     commit_sha: str | None = None,
 ) -> ExtensionManifest:
     """Fetch and install an extension (binary or Python package), then persist its manifest.
@@ -429,7 +417,7 @@ def _install_extension(
     installed = False
     try:
         try:
-            binary = _fetch_remote_binary(owner=owner, repo_name=repo_name, branch=branch, short_name=short_name)
+            binary = _fetch_remote_binary(owner=owner, repo_name=repo_name, short_name=short_name)
         except Exception:
             binary = None
 
@@ -439,7 +427,7 @@ def _install_extension(
             )
         else:
             executable_path = _install_python_extension(
-                extension_dir=extension_dir, owner=owner, repo_name=repo_name, short_name=short_name, branch=branch
+                extension_dir=extension_dir, owner=owner, repo_name=repo_name, short_name=short_name
             )
 
         manifest = ExtensionManifest(
@@ -450,10 +438,8 @@ def _install_extension(
             executable_path=str(executable_path),
             type="binary" if binary is not None else "python",
             installed_at=datetime.now(timezone.utc),
-            description=_try_fetch_remote_description(
-                owner=owner, repo_name=repo_name, branch=branch, candidate_description=description
-            ),
-            commit_sha=commit_sha or _fetch_latest_commit_sha(owner=owner, repo_name=repo_name, branch=branch),
+            description=_try_fetch_remote_description(owner=owner, repo_name=repo_name),
+            commit_sha=commit_sha or _fetch_latest_commit_sha(owner=owner, repo_name=repo_name),
         )
         manifest.save(extension_dir)
         installed = True
@@ -477,23 +463,29 @@ def _install_extension(
             shutil.rmtree(extension_dir, ignore_errors=True)
 
 
-def _fetch_latest_commit_sha(*, owner: str, repo_name: str, branch: str, warn: bool = True) -> str | None:
-    """Best-effort fetch of the latest commit SHA for a branch, used to detect available updates."""
+def _fetch_latest_commit_sha(*, owner: str, repo_name: str, warn: bool = True) -> str | None:
+    """Best-effort fetch of the latest commit SHA on the default branch, to detect available updates.
+
+    The only REST API call left in the install and update paths.
+    """
     try:
         response = _github_get(
-            f"https://api.github.com/repos/{owner}/{repo_name}/commits/{branch}",
+            f"https://api.github.com/repos/{owner}/{repo_name}/commits/HEAD",
             headers={"Accept": "application/vnd.github.sha"},
         )
         return response.text.strip() or None
+    except CLIError:
+        # A rate limit is worth reporting as-is rather than as "GitHub is unreachable".
+        raise
     except Exception as error:
         if warn:
             out.warning(f"Could not fetch latest commit SHA for '{repo_name}' ({owner}/{repo_name}): {error}")
         return None
 
 
-def _fetch_remote_binary(*, owner: str, repo_name: str, branch: str, short_name: str) -> bytes:
+def _fetch_remote_binary(*, owner: str, repo_name: str, short_name: str) -> bytes:
     executable_name = _get_executable_name(short_name)
-    raw_url = f"https://raw.githubusercontent.com/{owner}/{repo_name}/refs/heads/{branch}/{executable_name}"
+    raw_url = f"https://raw.githubusercontent.com/{owner}/{repo_name}/HEAD/{executable_name}"
     response = _github_get(raw_url)
     return response.content
 
@@ -509,10 +501,8 @@ def _install_binary_extension(*, extension_dir: Path, short_name: str, binary: b
     return executable_path
 
 
-def _install_python_extension(
-    *, extension_dir: Path, owner: str, repo_name: str, short_name: str, branch: str
-) -> Path:
-    source_url = f"https://github.com/{owner}/{repo_name}/archive/refs/heads/{branch}.zip"
+def _install_python_extension(*, extension_dir: Path, owner: str, repo_name: str, short_name: str) -> Path:
+    source_url = f"https://github.com/{owner}/{repo_name}/archive/HEAD.zip"
     venv_dir = extension_dir / "venv"
     venv_python = _get_venv_bin_path(venv_dir, "python.exe" if os.name == "nt" else "python")
     uv_path = shutil.which("uv")
@@ -555,16 +545,14 @@ def _install_python_extension(
     return venv_executable.resolve()
 
 
-def _try_fetch_remote_description(
-    owner: str, repo_name: str, branch: str, candidate_description: str | None
-) -> str | None:
+def _try_fetch_remote_description(owner: str, repo_name: str) -> str | None:
     """Try to fetch project description either from:
     - manifest.json
     - pyproject.toml
 
     Only best effort, no error handling.
     """
-    base = f"https://raw.githubusercontent.com/{owner}/{repo_name}/refs/heads/{branch}"
+    base = f"https://raw.githubusercontent.com/{owner}/{repo_name}/HEAD"
 
     # from manifest.json
     try:
@@ -588,8 +576,7 @@ def _try_fetch_remote_description(
     except Exception:
         pass
 
-    # fallback to value fetched from GH API directly
-    return candidate_description
+    return None
 
 
 def _get_extension_dir(short_name: str) -> Path:
@@ -603,6 +590,12 @@ def _github_get(url: str, *, params: dict | None = None, headers: dict | None = 
     """Perform a GitHub GET request.
 
     Shared by every GitHub/Raw fetch in this module so the timeout and redirect policy are shared.
+
+    Unauthenticated `api.github.com` calls are capped at 60 per hour per IP address, and that quota is
+    shared with everything else calling GitHub from the same network (NAT, VPN, CI egress). Remote refs
+    are therefore always addressed as `HEAD`, which GitHub resolves to the repo's default branch on
+    `raw.githubusercontent.com`, on the archive endpoint and on the REST API alike: no
+    `GET /repos/{owner}/{repo}` lookup is needed to discover the branch name.
     """
     response = get_session().get(
         url,
@@ -611,15 +604,44 @@ def _github_get(url: str, *, params: dict | None = None, headers: dict | None = 
         follow_redirects=True,
         timeout=_EXTENSIONS_DOWNLOAD_TIMEOUT,
     )
+    if response.status_code in (403, 429) and response.headers.get("x-ratelimit-remaining") == "0":
+        raise CLIError(_rate_limit_message(response.headers.get("x-ratelimit-reset")))
     response.raise_for_status()
     return response
 
 
-def _fetch_github_repo_info(*, owner: str, repo_name: str) -> tuple[str, str | None]:
-    """Fetch `default_branch` + `description` for a GitHub repo from `GET /repos/{owner}/{repo}`."""
-    response = _github_get(f"https://api.github.com/repos/{owner}/{repo_name}")
-    data = response.json()
-    return data["default_branch"], data.get("description")
+def _rate_limit_message(reset: str | None) -> str:
+    """Message for a GitHub API rate-limit rejection, `reset` being the `x-ratelimit-reset` header."""
+    message = (
+        "GitHub API rate limit exceeded. Unauthenticated requests are capped at 60 per hour per IP address, "
+        "and that quota is shared with anything else calling GitHub from your network."
+    )
+    if reset is not None:
+        try:
+            reset_at = datetime.fromtimestamp(int(reset), tz=timezone.utc).astimezone()
+        except (OverflowError, OSError, ValueError):
+            pass
+        else:
+            message += f" It resets at {reset_at:%H:%M:%S}."
+    return message
+
+
+def _github_repo_exists(*, owner: str, repo_name: str) -> bool:
+    """Whether a public GitHub repo exists.
+
+    Resolved against `github.com` rather than `GET /repos/{owner}/{repo}` to keep the check off the
+    metered REST API (see `_github_get`). Only a 404 answers `False`: an unreachable GitHub raises, so
+    callers don't report a missing repo when the network is down.
+    """
+    response = get_session().head(
+        f"https://github.com/{owner}/{repo_name}",
+        follow_redirects=True,
+        timeout=_EXTENSIONS_DOWNLOAD_TIMEOUT,
+    )
+    if response.status_code == 404:
+        return False
+    response.raise_for_status()
+    return True
 
 
 def _get_executable_name(short_name: str) -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,12 +3,14 @@ import os
 import sys
 import warnings
 from contextlib import contextmanager
+from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Generator, Optional
 from unittest.mock import Mock, patch
 
 import click
+import httpx
 import pytest
 from click.testing import CliRunner
 
@@ -16,7 +18,7 @@ from huggingface_hub import HfApi, constants
 from huggingface_hub._dataset_viewer import DatasetParquetEntry
 from huggingface_hub._jobs_api import JobInfo, JobOwner, _create_job_spec, _derive_job_volume_name
 from huggingface_hub._space_api import Volume
-from huggingface_hub.cli import _skills, system
+from huggingface_hub.cli import _skills, extensions, system
 from huggingface_hub.cli._cli_utils import RepoType, _get_huggingface_hub_update_command, parse_volumes
 from huggingface_hub.cli._output import OutputFormat, out
 from huggingface_hub.cli.cache import CacheDeletionCounts
@@ -4820,3 +4822,129 @@ class TestSkillsMarketplaceCLI:
                 "huggingface-gradio: updated",
             )
         ), result.stdout
+
+
+class _FakeGitHubSession:
+    """Session double that records requested URLs and serves canned responses.
+
+    Patterns are matched as substrings of the URL; anything unmatched 404s.
+    """
+
+    def __init__(self, responses: Optional[dict[str, httpx.Response]] = None) -> None:
+        self.urls: list[str] = []
+        self.responses = responses or {}
+
+    def _respond(self, url: str) -> httpx.Response:
+        self.urls.append(url)
+        response = next((r for pattern, r in self.responses.items() if pattern in url), httpx.Response(404))
+        response.request = httpx.Request("GET", url)
+        return response
+
+    def get(self, url: str, **kwargs) -> httpx.Response:
+        return self._respond(url)
+
+    def head(self, url: str, **kwargs) -> httpx.Response:
+        return self._respond(url)
+
+    @property
+    def api_urls(self) -> list[str]:
+        """Requests that count against the 60 requests/hour unauthenticated REST API quota."""
+        return [url for url in self.urls if url.startswith("https://api.github.com/")]
+
+
+class TestExtensionsGitHubAccess:
+    """GitHub is reached without a token, so requests must stay off the metered REST API."""
+
+    def test_unknown_command_spends_no_api_quota(self, tmp_path: Path) -> None:
+        # Every mistyped `hf <command>` probes for an official extension, so this path must be free.
+        session = _FakeGitHubSession()
+        with (
+            patch.object(extensions, "get_session", return_value=session),
+            patch.object(extensions, "EXTENSIONS_ROOT", tmp_path),
+        ):
+            exit_code = extensions.dispatch_unknown_top_level_extension(["jbos"], {"jobs", "repos"})
+
+        assert exit_code is None
+        assert session.api_urls == []
+
+    def test_binary_install_uses_head_ref_and_a_single_api_call(self, tmp_path: Path) -> None:
+        sha = "a" * 40
+        session = _FakeGitHubSession(
+            {
+                "raw.githubusercontent.com/huggingface/hf-demo/HEAD/hf-demo": httpx.Response(
+                    200, content=b"#!/bin/sh"
+                ),
+                "HEAD/manifest.json": httpx.Response(200, json={"description": "Demo extension"}),
+                "api.github.com/repos/huggingface/hf-demo/commits/HEAD": httpx.Response(200, text=sha),
+            }
+        )
+        with (
+            patch.object(extensions, "get_session", return_value=session),
+            patch.object(extensions, "EXTENSIONS_ROOT", tmp_path),
+        ):
+            manifest = extensions._install_extension(owner="huggingface", repo_name="hf-demo", short_name="demo")
+
+        assert manifest.type == "binary"
+        assert manifest.commit_sha == sha
+        assert manifest.description == "Demo extension"
+        # The default branch is addressed as `HEAD`, so no `GET /repos/{owner}/{repo}` lookup is needed.
+        assert session.api_urls == ["https://api.github.com/repos/huggingface/hf-demo/commits/HEAD"]
+        assert all("/HEAD/" in url for url in session.urls if "raw.githubusercontent.com" in url)
+
+    def test_install_of_missing_repo_reports_a_clean_error(self, runner: CliRunner, tmp_path: Path) -> None:
+        session = _FakeGitHubSession()
+        with (
+            patch.object(extensions, "get_session", return_value=session),
+            patch.object(extensions, "EXTENSIONS_ROOT", tmp_path),
+        ):
+            result = runner.invoke(app, ["extensions", "install", "huggingface/hf-nope"])
+
+        assert isinstance(result.exception, CLIError)
+        assert "not found" in str(result.exception)
+        assert session.api_urls == []
+
+    def test_rate_limited_response_reports_the_reset_time(self, tmp_path: Path) -> None:
+        session = _FakeGitHubSession(
+            {
+                "api.github.com": httpx.Response(
+                    403,
+                    headers={"x-ratelimit-remaining": "0", "x-ratelimit-reset": "1786500000"},
+                ),
+            }
+        )
+        with patch.object(extensions, "get_session", return_value=session):
+            with pytest.raises(CLIError, match="rate limit exceeded"):
+                extensions._fetch_latest_commit_sha(owner="huggingface", repo_name="hf-demo")
+
+    def test_update_stops_on_rate_limit_instead_of_warning_per_extension(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        for short_name in ("one", "two"):
+            extensions.ExtensionManifest(
+                owner="huggingface",
+                repo=f"hf-{short_name}",
+                repo_id=f"huggingface/hf-{short_name}",
+                short_name=short_name,
+                executable_path=str(tmp_path / f"hf-{short_name}" / f"hf-{short_name}"),
+                type="binary",
+                installed_at=datetime.now(timezone.utc),
+            ).save(tmp_path / f"hf-{short_name}")
+
+        session = _FakeGitHubSession(
+            {
+                "api.github.com": httpx.Response(
+                    429,
+                    headers={"x-ratelimit-remaining": "0"},
+                ),
+            }
+        )
+        with (
+            patch.object(extensions, "get_session", return_value=session),
+            patch.object(extensions, "EXTENSIONS_ROOT", tmp_path),
+        ):
+            result = runner.invoke(app, ["extensions", "update"])
+
+        assert isinstance(result.exception, CLIError)
+        assert "rate limit exceeded" in str(result.exception)
+        # Bailed out on the first extension rather than repeating the failure for every one of them.
+        assert len(session.api_urls) == 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4836,26 +4836,34 @@ class _FakeGitHubSession:
     Patterns are matched as substrings of the URL; anything unmatched 404s.
     """
 
-    def __init__(self, responses: Optional[dict[str, httpx.Response]] = None) -> None:
+    def __init__(self, responses: dict[str, httpx.Response] | None = None) -> None:
         self.urls: list[str] = []
         self.responses = responses or {}
 
-    def _respond(self, url: str) -> httpx.Response:
+    def request(self, method: str, url: str, **kwargs) -> httpx.Response:
         self.urls.append(url)
         response = next((r for pattern, r in self.responses.items() if pattern in url), httpx.Response(404))
-        response.request = httpx.Request("GET", url)
+        response.request = httpx.Request(method, url)
         return response
-
-    def get(self, url: str, **kwargs) -> httpx.Response:
-        return self._respond(url)
-
-    def head(self, url: str, **kwargs) -> httpx.Response:
-        return self._respond(url)
 
     @property
     def api_urls(self) -> list[str]:
-        """Requests that count against the 60 requests/hour unauthenticated REST API quota."""
+        """Requests that count against the unauthenticated REST API quota."""
         return [url for url in self.urls if url.startswith("https://api.github.com/")]
+
+
+def _fake_install_extension(root: Path, *short_names: str) -> None:
+    """Write a manifest for each name, as if the extension had been installed."""
+    for short_name in short_names:
+        extensions.ExtensionManifest(
+            owner="huggingface",
+            repo=f"hf-{short_name}",
+            repo_id=f"huggingface/hf-{short_name}",
+            short_name=short_name,
+            executable_path=str(root / f"hf-{short_name}" / f"hf-{short_name}"),
+            type="binary",
+            installed_at=datetime.now(timezone.utc),
+        ).save(root / f"hf-{short_name}")
 
 
 class TestExtensionsGitHubAccess:
@@ -4930,35 +4938,24 @@ class TestExtensionsGitHubAccess:
         assert "not found" in str(result.exception)
         assert session.api_urls == []
 
-    def test_rate_limited_response_reports_the_reset_time(self, tmp_path: Path) -> None:
-        session = _FakeGitHubSession(
-            {
-                "api.github.com": httpx.Response(
-                    403,
-                    headers={"x-ratelimit-remaining": "0", "x-ratelimit-reset": "1786500000"},
-                ),
-            }
-        )
+    @pytest.mark.parametrize(
+        "headers, expected",
+        [
+            # Primary limit: an absolute reset timestamp.
+            ({"x-ratelimit-remaining": "0", "x-ratelimit-reset": "1786500000"}, r"It resets at \d{2}:\d{2}:\d{2}"),
+            # Secondary limit: a back-off delay, and no `x-ratelimit-remaining: 0`.
+            ({"retry-after": "60"}, r"Retry in 60s\."),
+        ],
+    )
+    def test_rate_limited_response_reports_when_to_retry(self, headers: dict, expected: str) -> None:
+        session = _FakeGitHubSession({"api.github.com": httpx.Response(403, headers=headers)})
         with patch.object(extensions, "get_session", return_value=session):
-            with pytest.raises(CLIError, match="rate limit exceeded"):
+            with pytest.raises(CLIError, match=rf"rate limit exceeded.*{expected}"):
                 extensions._fetch_latest_commit_sha(owner="huggingface", repo_name="hf-demo")
-
-    @staticmethod
-    def _fake_install(root: Path, *short_names: str) -> None:
-        for short_name in short_names:
-            extensions.ExtensionManifest(
-                owner="huggingface",
-                repo=f"hf-{short_name}",
-                repo_id=f"huggingface/hf-{short_name}",
-                short_name=short_name,
-                executable_path=str(root / f"hf-{short_name}" / f"hf-{short_name}"),
-                type="binary",
-                installed_at=datetime.now(timezone.utc),
-            ).save(root / f"hf-{short_name}")
 
     def test_update_keeps_going_when_one_extension_fails_to_install(self, runner: CliRunner, tmp_path: Path) -> None:
         # A failure that is specific to one extension says nothing about the others.
-        self._fake_install(tmp_path, "one", "two")
+        _fake_install_extension(tmp_path, "one", "two")
         attempted = []
 
         def fake_update(manifest):
@@ -4982,7 +4979,7 @@ class TestExtensionsGitHubAccess:
     def test_update_stops_on_rate_limit_instead_of_warning_per_extension(
         self, runner: CliRunner, tmp_path: Path
     ) -> None:
-        self._fake_install(tmp_path, "one", "two")
+        _fake_install_extension(tmp_path, "one", "two")
 
         session = _FakeGitHubSession(
             {
@@ -5002,3 +4999,64 @@ class TestExtensionsGitHubAccess:
         assert "rate limit exceeded" in str(result.exception)
         # Bailed out on the first extension rather than repeating the failure for every one of them.
         assert len(session.api_urls) == 1
+
+    def test_update_reports_why_an_extension_could_not_be_checked(self, runner: CliRunner, tmp_path: Path) -> None:
+        # A deleted or renamed repo must not be reported as an unreachable GitHub.
+        _fake_install_extension(tmp_path, "one")
+        session = _FakeGitHubSession()  # everything 404s
+
+        with (
+            patch.object(extensions, "get_session", return_value=session),
+            patch.object(extensions, "EXTENSIONS_ROOT", tmp_path),
+        ):
+            result = runner.invoke(app, ["extensions", "update"])
+
+        assert result.exit_code == 0, result.output
+        assert "404" in result.output
+        assert "Skipping" in result.output
+
+    def test_unreachable_github_is_not_reported_as_a_missing_repo(self, runner: CliRunner, tmp_path: Path) -> None:
+        session = _FakeGitHubSession({"https://github.com/huggingface/hf-demo": httpx.Response(500)})
+        with (
+            patch.object(extensions, "get_session", return_value=session),
+            patch.object(extensions, "EXTENSIONS_ROOT", tmp_path),
+        ):
+            result = runner.invoke(app, ["extensions", "install", "huggingface/hf-demo"])
+
+        # A clean CLIError, not a raw httpx traceback, and not the "repository not found" message.
+        assert isinstance(result.exception, CLIError)
+        assert "Could not reach GitHub" in str(result.exception)
+        assert "not found" not in str(result.exception)
+
+    @pytest.mark.parametrize(
+        "meta_content, expected",
+        [
+            ("A demo extension - huggingface/hf-demo", "A demo extension"),
+            # Empty About field: GitHub renders boilerplate, which must not be taken as a description.
+            ("Contribute to huggingface/hf-demo development by creating an account on GitHub.", None),
+        ],
+    )
+    def test_description_falls_back_to_the_github_about_field(
+        self, tmp_path: Path, meta_content: str, expected: str | None
+    ) -> None:
+        # Shell-script extensions ship neither manifest.json nor pyproject.toml, so the repo's "About"
+        # field is their only description. It is served by github.com, off the REST API quota.
+        session = _FakeGitHubSession(
+            {
+                "raw.githubusercontent.com/huggingface/hf-demo/HEAD/hf-demo": httpx.Response(
+                    200, content=b"#!/bin/sh"
+                ),
+                "https://github.com/huggingface/hf-demo": httpx.Response(
+                    200, text=f'<meta name="description" content="{meta_content}">'
+                ),
+                "api.github.com": httpx.Response(200, text="b" * 40),
+            }
+        )
+        with (
+            patch.object(extensions, "get_session", return_value=session),
+            patch.object(extensions, "EXTENSIONS_ROOT", tmp_path),
+        ):
+            manifest = extensions._install_extension(owner="huggingface", repo_name="hf-demo", short_name="demo")
+
+        assert manifest.description == expected
+        assert session.api_urls == ["https://api.github.com/repos/huggingface/hf-demo/commits/HEAD"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -28,13 +28,7 @@ from huggingface_hub.cli.hf import main as hf_main
 from huggingface_hub.cli.jobs import _parse_and_sync_job_volumes, _parse_namespace_from_job_id
 from huggingface_hub.cli.skills import build_skill_md
 from huggingface_hub.cli.upload import _resolve_upload_paths, upload
-from huggingface_hub.errors import (
-    CLIError,
-    CLIExtensionInstallError,
-    DeviceCodeError,
-    HfUriError,
-    RevisionNotFoundError,
-)
+from huggingface_hub.errors import CLIError, DeviceCodeError, HfUriError, RevisionNotFoundError
 from huggingface_hub.hf_api import ModelInfo
 from huggingface_hub.utils import (
     CachedFileInfo,
@@ -4926,8 +4920,19 @@ class TestExtensionsGitHubAccess:
         assert manifest.commit_sha is None
         assert Path(manifest.executable_path).is_file()
 
-    def test_install_of_missing_repo_reports_a_clean_error(self, runner: CliRunner, tmp_path: Path) -> None:
-        session = _FakeGitHubSession()
+    @pytest.mark.parametrize(
+        "repo_page, expected_error",
+        [
+            # A 404 is the only answer that means "missing".
+            (httpx.Response(404), "not found"),
+            # Anything else must not be presented as a missing repo, nor escape as an httpx traceback.
+            (httpx.Response(500), "Could not reach GitHub"),
+        ],
+    )
+    def test_install_distinguishes_a_missing_repo_from_an_unreachable_github(
+        self, runner: CliRunner, tmp_path: Path, repo_page: httpx.Response, expected_error: str
+    ) -> None:
+        session = _FakeGitHubSession({"https://github.com/huggingface/hf-nope": repo_page})
         with (
             patch.object(extensions, "get_session", return_value=session),
             patch.object(extensions, "EXTENSIONS_ROOT", tmp_path),
@@ -4935,57 +4940,25 @@ class TestExtensionsGitHubAccess:
             result = runner.invoke(app, ["extensions", "install", "huggingface/hf-nope"])
 
         assert isinstance(result.exception, CLIError)
-        assert "not found" in str(result.exception)
+        assert expected_error in str(result.exception)
         assert session.api_urls == []
-
-    @pytest.mark.parametrize(
-        "headers, expected",
-        [
-            # Primary limit: an absolute reset timestamp.
-            ({"x-ratelimit-remaining": "0", "x-ratelimit-reset": "1786500000"}, r"It resets at \d{2}:\d{2}:\d{2}"),
-            # Secondary limit: a back-off delay, and no `x-ratelimit-remaining: 0`.
-            ({"retry-after": "60"}, r"Retry in 60s\."),
-        ],
-    )
-    def test_rate_limited_response_reports_when_to_retry(self, headers: dict, expected: str) -> None:
-        session = _FakeGitHubSession({"api.github.com": httpx.Response(403, headers=headers)})
-        with patch.object(extensions, "get_session", return_value=session):
-            with pytest.raises(CLIError, match=rf"rate limit exceeded.*{expected}"):
-                extensions._fetch_latest_commit_sha(owner="huggingface", repo_name="hf-demo")
-
-    def test_update_keeps_going_when_one_extension_fails_to_install(self, runner: CliRunner, tmp_path: Path) -> None:
-        # A failure that is specific to one extension says nothing about the others.
-        _fake_install_extension(tmp_path, "one", "two")
-        attempted = []
-
-        def fake_update(manifest):
-            attempted.append(manifest.short_name)
-            if manifest.short_name == "one":
-                raise CLIExtensionInstallError("Pip install timed out for 'huggingface/hf-one'.")
-            return extensions._ExtensionUpdateStatus.UPDATED
-
-        with (
-            patch.object(extensions, "EXTENSIONS_ROOT", tmp_path),
-            patch.object(extensions, "_update_installed_extension", side_effect=fake_update),
-        ):
-            result = runner.invoke(app, ["extensions", "update"])
-
-        assert result.exit_code == 0, result.output
-        # 'two' was still checked and reported after 'one' failed.
-        assert attempted == ["one", "two"]
-        assert "Pip install timed out" in result.output
-        assert "Skipping" in result.output
 
     def test_update_stops_on_rate_limit_instead_of_warning_per_extension(
         self, runner: CliRunner, tmp_path: Path
     ) -> None:
         _fake_install_extension(tmp_path, "one", "two")
 
+        # A secondary limit: GitHub asks for a back-off and rides the *primary* window's reset
+        # timestamp alongside it, on a quota that is not exhausted. The back-off is what applies.
         session = _FakeGitHubSession(
             {
                 "api.github.com": httpx.Response(
                     429,
-                    headers={"x-ratelimit-remaining": "0"},
+                    headers={
+                        "x-ratelimit-remaining": "53",
+                        "x-ratelimit-reset": "1786500000",
+                        "retry-after": "60",
+                    },
                 ),
             }
         )
@@ -4997,36 +4970,10 @@ class TestExtensionsGitHubAccess:
 
         assert isinstance(result.exception, CLIError)
         assert "rate limit exceeded" in str(result.exception)
+        assert "Retry in 60s." in str(result.exception)
+        assert "It resets at" not in str(result.exception)
         # Bailed out on the first extension rather than repeating the failure for every one of them.
         assert len(session.api_urls) == 1
-
-    def test_update_reports_why_an_extension_could_not_be_checked(self, runner: CliRunner, tmp_path: Path) -> None:
-        # A deleted or renamed repo must not be reported as an unreachable GitHub.
-        _fake_install_extension(tmp_path, "one")
-        session = _FakeGitHubSession()  # everything 404s
-
-        with (
-            patch.object(extensions, "get_session", return_value=session),
-            patch.object(extensions, "EXTENSIONS_ROOT", tmp_path),
-        ):
-            result = runner.invoke(app, ["extensions", "update"])
-
-        assert result.exit_code == 0, result.output
-        assert "404" in result.output
-        assert "Skipping" in result.output
-
-    def test_unreachable_github_is_not_reported_as_a_missing_repo(self, runner: CliRunner, tmp_path: Path) -> None:
-        session = _FakeGitHubSession({"https://github.com/huggingface/hf-demo": httpx.Response(500)})
-        with (
-            patch.object(extensions, "get_session", return_value=session),
-            patch.object(extensions, "EXTENSIONS_ROOT", tmp_path),
-        ):
-            result = runner.invoke(app, ["extensions", "install", "huggingface/hf-demo"])
-
-        # A clean CLIError, not a raw httpx traceback, and not the "repository not found" message.
-        assert isinstance(result.exception, CLIError)
-        assert "Could not reach GitHub" in str(result.exception)
-        assert "not found" not in str(result.exception)
 
     @pytest.mark.parametrize(
         "meta_content, expected",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4891,6 +4891,25 @@ class TestExtensionsGitHubAccess:
         assert session.api_urls == ["https://api.github.com/repos/huggingface/hf-demo/commits/HEAD"]
         assert all("/HEAD/" in url for url in session.urls if "raw.githubusercontent.com" in url)
 
+    def test_install_completes_when_the_api_quota_is_exhausted(self, tmp_path: Path) -> None:
+        # The extension itself comes from the CDN, so only the optional version marker is lost.
+        session = _FakeGitHubSession(
+            {
+                "raw.githubusercontent.com/huggingface/hf-demo/HEAD/hf-demo": httpx.Response(
+                    200, content=b"#!/bin/sh"
+                ),
+                "api.github.com": httpx.Response(403, headers={"x-ratelimit-remaining": "0"}),
+            }
+        )
+        with (
+            patch.object(extensions, "get_session", return_value=session),
+            patch.object(extensions, "EXTENSIONS_ROOT", tmp_path),
+        ):
+            manifest = extensions._install_extension(owner="huggingface", repo_name="hf-demo", short_name="demo")
+
+        assert manifest.commit_sha is None
+        assert Path(manifest.executable_path).is_file()
+
     def test_install_of_missing_repo_reports_a_clean_error(self, runner: CliRunner, tmp_path: Path) -> None:
         session = _FakeGitHubSession()
         with (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4840,6 +4840,11 @@ class _FakeGitHubSession:
         response.request = httpx.Request(method, url)
         return response
 
+    def __getattr__(self, method: str):
+        # `.get()`, `.head()`, ... are recorded too: a quota assertion must not pass merely because
+        # the code under test reached GitHub without going through `request()`.
+        return lambda url, **kwargs: self.request(method.upper(), url, **kwargs)
+
     @property
     def api_urls(self) -> list[str]:
         """Requests that count against the unauthenticated REST API quota."""
@@ -4860,150 +4865,98 @@ def _fake_install_extension(root: Path, *short_names: str) -> None:
         ).save(root / f"hf-{short_name}")
 
 
+BINARY_URL = "raw.githubusercontent.com/huggingface/hf-demo/HEAD/hf-demo"
+REPO_PAGE_URL = "https://github.com/huggingface/hf-demo"
+COMMITS_URL = "https://api.github.com/repos/huggingface/hf-demo/commits/HEAD"
+
+
 class TestExtensionsGitHubAccess:
     """GitHub is reached without a token, so requests must stay off the metered REST API."""
 
-    def test_unknown_command_spends_no_api_quota(self, tmp_path: Path) -> None:
-        # Every mistyped `hf <command>` probes for an official extension, so this path must be free.
+    @pytest.fixture
+    def github(self, tmp_path: Path) -> Generator[_FakeGitHubSession, None, None]:
         session = _FakeGitHubSession()
         with (
             patch.object(extensions, "get_session", return_value=session),
             patch.object(extensions, "EXTENSIONS_ROOT", tmp_path),
         ):
-            exit_code = extensions.dispatch_unknown_top_level_extension(["jbos"], {"jobs", "repos"})
+            yield session
 
-        assert exit_code is None
-        assert session.api_urls == []
-
-    def test_binary_install_uses_head_ref_and_a_single_api_call(self, tmp_path: Path) -> None:
-        sha = "a" * 40
-        session = _FakeGitHubSession(
-            {
-                "raw.githubusercontent.com/huggingface/hf-demo/HEAD/hf-demo": httpx.Response(
-                    200, content=b"#!/bin/sh"
-                ),
-                "HEAD/manifest.json": httpx.Response(200, json={"description": "Demo extension"}),
-                "api.github.com/repos/huggingface/hf-demo/commits/HEAD": httpx.Response(200, text=sha),
-            }
-        )
-        with (
-            patch.object(extensions, "get_session", return_value=session),
-            patch.object(extensions, "EXTENSIONS_ROOT", tmp_path),
-        ):
-            manifest = extensions._install_extension(owner="huggingface", repo_name="hf-demo", short_name="demo")
-
-        assert manifest.type == "binary"
-        assert manifest.commit_sha == sha
-        assert manifest.description == "Demo extension"
-        # The default branch is addressed as `HEAD`, so no `GET /repos/{owner}/{repo}` lookup is needed.
-        assert session.api_urls == ["https://api.github.com/repos/huggingface/hf-demo/commits/HEAD"]
-        raw_prefix = "https://raw.githubusercontent.com/huggingface/hf-demo/"
-        raw_urls = [url for url in session.urls if url.startswith(raw_prefix)]
-        assert raw_urls and all(url.removeprefix(raw_prefix).startswith("HEAD/") for url in raw_urls)
-
-    def test_install_completes_when_the_api_quota_is_exhausted(self, tmp_path: Path) -> None:
-        # The extension itself comes from the CDN, so only the optional version marker is lost.
-        session = _FakeGitHubSession(
-            {
-                "raw.githubusercontent.com/huggingface/hf-demo/HEAD/hf-demo": httpx.Response(
-                    200, content=b"#!/bin/sh"
-                ),
-                "api.github.com": httpx.Response(403, headers={"x-ratelimit-remaining": "0"}),
-            }
-        )
-        with (
-            patch.object(extensions, "get_session", return_value=session),
-            patch.object(extensions, "EXTENSIONS_ROOT", tmp_path),
-        ):
-            manifest = extensions._install_extension(owner="huggingface", repo_name="hf-demo", short_name="demo")
-
-        assert manifest.commit_sha is None
-        assert Path(manifest.executable_path).is_file()
+    def test_unknown_command_spends_no_api_quota(self, github: _FakeGitHubSession) -> None:
+        # Every mistyped `hf <command>` probes for an official extension, so this path must be free.
+        assert extensions.dispatch_unknown_top_level_extension(["jbos"], {"jobs", "repos"}) is None
+        assert github.api_urls == []
 
     @pytest.mark.parametrize(
-        "repo_page, expected_error",
-        [
-            # A 404 is the only answer that means "missing".
-            (httpx.Response(404), "not found"),
-            # Anything else must not be presented as a missing repo, nor escape as an httpx traceback.
-            (httpx.Response(500), "Could not reach GitHub"),
-        ],
-    )
-    def test_install_distinguishes_a_missing_repo_from_an_unreachable_github(
-        self, runner: CliRunner, tmp_path: Path, repo_page: httpx.Response, expected_error: str
-    ) -> None:
-        session = _FakeGitHubSession({"https://github.com/huggingface/hf-nope": repo_page})
-        with (
-            patch.object(extensions, "get_session", return_value=session),
-            patch.object(extensions, "EXTENSIONS_ROOT", tmp_path),
-        ):
-            result = runner.invoke(app, ["extensions", "install", "huggingface/hf-nope"])
-
-        assert isinstance(result.exception, CLIError)
-        assert expected_error in str(result.exception)
-        assert session.api_urls == []
-
-    def test_update_stops_on_rate_limit_instead_of_warning_per_extension(
-        self, runner: CliRunner, tmp_path: Path
-    ) -> None:
-        _fake_install_extension(tmp_path, "one", "two")
-
-        # A secondary limit: GitHub asks for a back-off and rides the *primary* window's reset
-        # timestamp alongside it, on a quota that is not exhausted. The back-off is what applies.
-        session = _FakeGitHubSession(
-            {
-                "api.github.com": httpx.Response(
-                    429,
-                    headers={
-                        "x-ratelimit-remaining": "53",
-                        "x-ratelimit-reset": "1786500000",
-                        "retry-after": "60",
-                    },
-                ),
-            }
-        )
-        with (
-            patch.object(extensions, "get_session", return_value=session),
-            patch.object(extensions, "EXTENSIONS_ROOT", tmp_path),
-        ):
-            result = runner.invoke(app, ["extensions", "update"])
-
-        assert isinstance(result.exception, CLIError)
-        assert "rate limit exceeded" in str(result.exception)
-        assert "Retry in 60s." in str(result.exception)
-        assert "It resets at" not in str(result.exception)
-        # Bailed out on the first extension rather than repeating the failure for every one of them.
-        assert len(session.api_urls) == 1
-
-    @pytest.mark.parametrize(
-        "meta_content, expected",
+        "about, expected_description",
         [
             ("A demo extension - huggingface/hf-demo", "A demo extension"),
             # Empty About field: GitHub renders boilerplate, which must not be taken as a description.
             ("Contribute to huggingface/hf-demo development by creating an account on GitHub.", None),
         ],
     )
-    def test_description_falls_back_to_the_github_about_field(
-        self, tmp_path: Path, meta_content: str, expected: str | None
+    def test_install_uses_head_refs_and_a_single_api_call(
+        self, github: _FakeGitHubSession, about: str, expected_description: str | None
     ) -> None:
         # Shell-script extensions ship neither manifest.json nor pyproject.toml, so the repo's "About"
         # field is their only description. It is served by github.com, off the REST API quota.
-        session = _FakeGitHubSession(
-            {
-                "raw.githubusercontent.com/huggingface/hf-demo/HEAD/hf-demo": httpx.Response(
-                    200, content=b"#!/bin/sh"
-                ),
-                "https://github.com/huggingface/hf-demo": httpx.Response(
-                    200, text=f'<meta name="description" content="{meta_content}">'
-                ),
-                "api.github.com": httpx.Response(200, text="b" * 40),
-            }
-        )
-        with (
-            patch.object(extensions, "get_session", return_value=session),
-            patch.object(extensions, "EXTENSIONS_ROOT", tmp_path),
-        ):
-            manifest = extensions._install_extension(owner="huggingface", repo_name="hf-demo", short_name="demo")
+        github.responses = {
+            BINARY_URL: httpx.Response(200, content=b"#!/bin/sh"),
+            REPO_PAGE_URL: httpx.Response(200, text=f'<meta name="description" content="{about}">'),
+            COMMITS_URL: httpx.Response(200, text="a" * 40),
+        }
+        manifest = extensions._install_extension(owner="huggingface", repo_name="hf-demo", short_name="demo")
 
-        assert manifest.description == expected
-        assert session.api_urls == ["https://api.github.com/repos/huggingface/hf-demo/commits/HEAD"]
+        assert manifest.type == "binary"
+        assert manifest.commit_sha == "a" * 40
+        assert manifest.description == expected_description
+        # The default branch is addressed as `HEAD`, so no `GET /repos/{owner}/{repo}` lookup is needed.
+        assert github.api_urls == [COMMITS_URL]
+        raw_prefix = "https://raw.githubusercontent.com/huggingface/hf-demo/"
+        raw_urls = [url for url in github.urls if url.startswith(raw_prefix)]
+        assert raw_urls and all(url.removeprefix(raw_prefix).startswith("HEAD/") for url in raw_urls)
+
+    def test_install_completes_when_the_api_quota_is_exhausted(self, github: _FakeGitHubSession) -> None:
+        # The extension itself comes from the CDN, so only the optional version marker is lost.
+        github.responses = {
+            BINARY_URL: httpx.Response(200, content=b"#!/bin/sh"),
+            "HEAD/manifest.json": httpx.Response(200, json={"description": "Demo extension"}),
+            "api.github.com": httpx.Response(403, headers={"x-ratelimit-remaining": "0"}),
+        }
+        manifest = extensions._install_extension(owner="huggingface", repo_name="hf-demo", short_name="demo")
+
+        assert manifest.commit_sha is None
+        assert manifest.description == "Demo extension"
+        assert Path(manifest.executable_path).is_file()
+
+    def test_unreachable_github_is_not_reported_as_a_missing_repo(
+        self, github: _FakeGitHubSession, runner: CliRunner
+    ) -> None:
+        # Only a 404 means "missing"; anything else must not escape as a raw httpx traceback either.
+        github.responses = {REPO_PAGE_URL: httpx.Response(500)}
+        result = runner.invoke(app, ["extensions", "install", "huggingface/hf-demo"])
+
+        assert isinstance(result.exception, CLIError)
+        assert "Could not reach GitHub" in str(result.exception)
+        assert github.api_urls == []
+
+    def test_update_stops_on_rate_limit_instead_of_warning_per_extension(
+        self, github: _FakeGitHubSession, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        _fake_install_extension(tmp_path, "one", "two")
+        # A secondary limit: GitHub asks for a back-off and rides the *primary* window's reset
+        # timestamp alongside it, on a quota that is not exhausted. The back-off is what applies.
+        github.responses = {
+            "api.github.com": httpx.Response(
+                429,
+                headers={"x-ratelimit-remaining": "53", "x-ratelimit-reset": "1786500000", "retry-after": "60"},
+            )
+        }
+        result = runner.invoke(app, ["extensions", "update"])
+
+        assert isinstance(result.exception, CLIError)
+        assert "rate limit exceeded" in str(result.exception)
+        assert "Retry in 60s." in str(result.exception)
+        assert "It resets at" not in str(result.exception)
+        # Bailed out on the first extension rather than repeating the failure for every one of them.
+        assert len(github.api_urls) == 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4895,7 +4895,9 @@ class TestExtensionsGitHubAccess:
         assert manifest.description == "Demo extension"
         # The default branch is addressed as `HEAD`, so no `GET /repos/{owner}/{repo}` lookup is needed.
         assert session.api_urls == ["https://api.github.com/repos/huggingface/hf-demo/commits/HEAD"]
-        assert all("/HEAD/" in url for url in session.urls if "raw.githubusercontent.com" in url)
+        raw_prefix = "https://raw.githubusercontent.com/huggingface/hf-demo/"
+        raw_urls = [url for url in session.urls if url.startswith(raw_prefix)]
+        assert raw_urls and all(url.removeprefix(raw_prefix).startswith("HEAD/") for url in raw_urls)
 
     def test_install_completes_when_the_api_quota_is_exhausted(self, tmp_path: Path) -> None:
         # The extension itself comes from the CDN, so only the optional version marker is lost.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -28,7 +28,13 @@ from huggingface_hub.cli.hf import main as hf_main
 from huggingface_hub.cli.jobs import _parse_and_sync_job_volumes, _parse_namespace_from_job_id
 from huggingface_hub.cli.skills import build_skill_md
 from huggingface_hub.cli.upload import _resolve_upload_paths, upload
-from huggingface_hub.errors import CLIError, DeviceCodeError, HfUriError, RevisionNotFoundError
+from huggingface_hub.errors import (
+    CLIError,
+    CLIExtensionInstallError,
+    DeviceCodeError,
+    HfUriError,
+    RevisionNotFoundError,
+)
 from huggingface_hub.hf_api import ModelInfo
 from huggingface_hub.utils import (
     CachedFileInfo,
@@ -4935,19 +4941,46 @@ class TestExtensionsGitHubAccess:
             with pytest.raises(CLIError, match="rate limit exceeded"):
                 extensions._fetch_latest_commit_sha(owner="huggingface", repo_name="hf-demo")
 
-    def test_update_stops_on_rate_limit_instead_of_warning_per_extension(
-        self, runner: CliRunner, tmp_path: Path
-    ) -> None:
-        for short_name in ("one", "two"):
+    @staticmethod
+    def _fake_install(root: Path, *short_names: str) -> None:
+        for short_name in short_names:
             extensions.ExtensionManifest(
                 owner="huggingface",
                 repo=f"hf-{short_name}",
                 repo_id=f"huggingface/hf-{short_name}",
                 short_name=short_name,
-                executable_path=str(tmp_path / f"hf-{short_name}" / f"hf-{short_name}"),
+                executable_path=str(root / f"hf-{short_name}" / f"hf-{short_name}"),
                 type="binary",
                 installed_at=datetime.now(timezone.utc),
-            ).save(tmp_path / f"hf-{short_name}")
+            ).save(root / f"hf-{short_name}")
+
+    def test_update_keeps_going_when_one_extension_fails_to_install(self, runner: CliRunner, tmp_path: Path) -> None:
+        # A failure that is specific to one extension says nothing about the others.
+        self._fake_install(tmp_path, "one", "two")
+        attempted = []
+
+        def fake_update(manifest):
+            attempted.append(manifest.short_name)
+            if manifest.short_name == "one":
+                raise CLIExtensionInstallError("Pip install timed out for 'huggingface/hf-one'.")
+            return extensions._ExtensionUpdateStatus.UPDATED
+
+        with (
+            patch.object(extensions, "EXTENSIONS_ROOT", tmp_path),
+            patch.object(extensions, "_update_installed_extension", side_effect=fake_update),
+        ):
+            result = runner.invoke(app, ["extensions", "update"])
+
+        assert result.exit_code == 0, result.output
+        # 'two' was still checked and reported after 'one' failed.
+        assert attempted == ["one", "two"]
+        assert "Pip install timed out" in result.output
+        assert "Skipping" in result.output
+
+    def test_update_stops_on_rate_limit_instead_of_warning_per_extension(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        self._fake_install(tmp_path, "one", "two")
 
         session = _FakeGitHubSession(
             {


### PR DESCRIPTION
Alternative to #4651, with a different fix: instead of raising the quota ceiling with a GitHub token, remove the calls that were spending it.

## Summary

- **Address remote refs as `HEAD`** instead of resolving `default_branch` through `GET /repos/{owner}/{repo}`. GitHub resolves `HEAD` to a repo's default branch on `raw.githubusercontent.com`, on the archive endpoint and on the REST API alike, so that lookup was never needed. Deletes `_fetch_github_repo_info` and drops the `branch` parameter from six helpers.
- **Check repo existence against `github.com`** (CDN-served, no REST quota) rather than the REST API. As a side effect, `hf extensions install` on a missing repo now reports a real error instead of a raw traceback.
- **Turn a rate-limited response into a `CLIError`** naming the reset time.
- **`hf extensions update` stops on a rate limit** instead of repeating the same warning for every installed extension.

Calls against the 60 requests/hour unauthenticated quota, measured by counting `api.github.com` requests through a patched session:

| operation | before | after |
| --- | --- | --- |
| `hf extensions install <repo>` | 2 | 1 |
| `hf extensions update` | 2 per extension | 1 per extension |
| unknown `hf <command>` (typo) | 1 | 0 |
| `hf extensions search` | 1 | 1 |

The remaining call is `GET /repos/{owner}/{repo}/commits/HEAD`, which is how `update` detects that a new commit exists. On the install path it is best-effort: if it fails, the install still completes, just without a recorded version.

For context on the `update` numbers: with 4 extensions installed, a bare `hf extensions update` cost 8 calls before this PR and costs 4 now. That, rather than typos, is the realistic way to burn 60 requests in an hour.

## Manual testing

```
$ hf extensions install hanouticelina/hf-claude
source=hanouticelina/hf-claude command=hf claude
Hint: Run it with: hf claude
   [exit=0  api.github.com calls=1]

$ hf extensions update
Checking 'claude' (hanouticelina/hf-claude)...
up_to_date=claude
   [exit=0  api.github.com calls=1]

$ hf extensions ls
command	source	type	installed	description
hf claude	hanouticelina/hf-claude	binary	2026-08-13	Launch Claude Code with Hugging Face Inference Providers
   [exit=0  api.github.com calls=0]

$ hf extensions install huggingface/hf-nope
Error: GitHub repository 'huggingface/hf-nope' not found. It must exist and be public.
   [exit=1  api.github.com calls=0]
```

Both install paths were exercised end to end against real repos with the `HEAD` ref: `hanouticelina/hf-claude` (binary, via `raw.githubusercontent.com/.../HEAD/hf-claude`) and `alvarobartt/hf-mem` (Python, via `uv pip install https://github.com/alvarobartt/hf-mem/archive/HEAD.zip`, resolved and installed fine).

Verification that `HEAD` works as a ref on each endpoint:

```
raw.githubusercontent.com/{owner}/{repo}/HEAD/manifest.json   200   (also 200 on a master-default repo)
github.com/{owner}/{repo}/archive/HEAD.zip                    200
api.github.com/repos/{owner}/{repo}/commits/HEAD              200   83194964f04730ec10659997a62a0004936295c7
```

## Verifying it actually fixes the reported failure

The commands below were run against a session that returns GitHub's real rate-limit 403 (`x-ratelimit-remaining: 0`) for `api.github.com` while letting every other host reach the network, i.e. the state of a user whose hourly quota is gone.

On `main`, this reproduces the reported traceback:

```
unknown command `hf jbos` (typo path)
  OK    returned None   [api calls attempted: 1]
hf extensions install hanouticelina/hf-claude
  FAIL  HTTPStatusError: Client error '403 Forbidden' for url 'https://api.github.com/repos/hanouticelina/hf-claude'
hf extensions update
  OK    exit=0   (warns "Client error '403 Forbidden' ... Skipping.", then prints "Extensions update complete")
hf extensions search
  FAIL  HTTPStatusError: Client error '403 Forbidden' for url 'https://api.github.com/search/repositories'
```

With this PR:

```
unknown command `hf jbos` (typo path)
  OK    returned None   [api calls attempted: 0]
hf extensions install hanouticelina/hf-claude
  OK    exit=0   [api calls attempted: 1]
        | Warning: GitHub API rate limit exceeded. Unauthenticated requests are capped at 60 per hour
        |          per IP address ... It resets at 04:00:00. Installing anyway, without a recorded version.
        | source=hanouticelina/hf-claude command=hf claude
hf extensions update
  FAIL  CLIError: GitHub API rate limit exceeded. ... It resets at 04:00:00.
hf extensions search
  FAIL  CLIError: GitHub API rate limit exceeded. ... It resets at 04:00:00.
```

So, with the quota fully exhausted:

- **typo path**: no longer touches GitHub at all, so it cannot fail, and cannot contribute to exhausting the quota either.
- **install**: now succeeds. This needed the second commit. Removing the `default_branch` lookup was not enough on its own: the remaining `commits/HEAD` call still aborted the install, and the rollback in `_install_extension`'s `finally` then deleted files that had already downloaded fine from the CDN. The SHA is optional metadata (`commit_sha: str | None`), so it now warns and records no version instead. Verified end to end: the installed `hf-claude` binary runs (`hf-claude --help` exits 0), and once the quota is back `hf extensions update` sees no known SHA, reinstalls and records `cf1e66ec...`; a second `update` then reports `up_to_date`.
- **update** and **search**: still fail, and there is nothing to fix there. Both *are* REST API calls (detecting a new commit; topic search). They now fail with the reset time instead of a traceback. Note this is a deliberate behavior change for `update`: `main` warned per extension and then printed "Extensions update complete" having checked nothing, which reads as success. It now exits non-zero on the first rate-limited extension.

What this does **not** do is make `update` and `search` work on an IP whose quota is already spent by other tools. #4651 would, given a token. The tradeoff is that the two commands still needing the API are the two where waiting is a reasonable answer, while the paths that run constantly (typo probes) and the one that must not fail halfway (install) no longer depend on it.

## Decisions worth flagging

- **`_github_repo_exists` only returns `False` on a 404** and re-raises anything else, so an unreachable GitHub is not reported as a missing repo.
- **Kept `GET /repos/.../commits/HEAD`.** Two ways to reach zero exist and both were left out as not worth their cost right now: `git ls-remote --symref` (needs a subprocess, the `git` binary, plus `GIT_TERMINAL_PROMPT=0` and `-c credential.helper=` so it does not consult the user's keychain), and a `HEAD` on the archive URL, whose `content-disposition: attachment; filename=hf-claude-83194964….zip` carries the full SHA with no body transfer (verified, 0.27s) but relies on undocumented `codeload` behavior. Either is easy to add later if 4 calls per `update` is still too many.
- **No docs change.** #4651 documented the limit and the token env var. With no token support there is no user action to document beyond the error message itself, which now says when the limit resets. Happy to add a note if you want one anyway.
- **`hf extensions search` is untouched.** It is one call on an explicit interactive command, and the search endpoint's real cap is 10 requests/minute, which no token changes for a human running one search.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes install/update/network error behavior for a user-facing CLI path; misclassifying GitHub responses could affect repo existence or rate-limit handling, though scope is limited to extensions.
> 
> **Overview**
> **Reduces unauthenticated `api.github.com` traffic** for `hf extensions` by dropping `GET /repos/{owner}/{repo}` (default branch + description) and using **`HEAD`** everywhere for raw files, zip archives, and commit SHA lookups.
> 
> **Repo checks and metadata** move off the metered API: existence is verified with **`HEAD` on `github.com`** (404 = missing; other errors become a clear `CLIError`), and descriptions can fall back to parsing the repo page **About** meta tag. **`_github_get`** becomes **`_github_request`** with shared **403/429 rate-limit** handling via **`_GitHubRateLimitError`** and reset/retry messaging.
> 
> **Behavior changes:** install still completes if the optional commit-SHA fetch fails (warns, `commit_sha` may be `None`); **`hf extensions update`** aborts on rate limit instead of warning per extension; unknown **`hf <command>`** typo probing no longer spends API quota.
> 
> Adds **`TestExtensionsGitHubAccess`** with a fake session to assert API call counts and rate-limit paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca713a5e6c9ce0c468fbf3623801778ba4032c79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->