### PR TITLE
[CLI] Fix duplicated GPU rows in hf jobs stats

### DIFF
--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -480,7 +480,7 @@ def _get_jobs_stats_rows(
             f"{_format_size(metrics['rx_bps'])}bps / {_format_size(metrics['tx_bps'])}bps",
         ]
         if metrics["gpus"] and isinstance(metrics["gpus"], dict):
-            rows = [row] + [[""] * len(row)] * (len(metrics["gpus"]) - 1)
+            rows = [row] + [[""] * len(row) for _ in range(len(metrics["gpus"]) - 1)]
             for row, gpu_id in zip(rows, sorted(metrics["gpus"])):
                 gpu = metrics["gpus"][gpu_id]
                 row += [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,7 +23,7 @@ from huggingface_hub.cli.cache import CacheDeletionCounts
 from huggingface_hub.cli.download import download
 from huggingface_hub.cli.hf import app
 from huggingface_hub.cli.hf import main as hf_main
-from huggingface_hub.cli.jobs import _parse_and_sync_job_volumes, _parse_namespace_from_job_id
+from huggingface_hub.cli.jobs import _get_jobs_stats_rows, _parse_and_sync_job_volumes, _parse_namespace_from_job_id
 from huggingface_hub.cli.skills import build_skill_md
 from huggingface_hub.cli.upload import _resolve_upload_paths, upload
 from huggingface_hub.errors import CLIError, DeviceCodeError, HfUriError, RevisionNotFoundError
@@ -3706,6 +3706,42 @@ class TestJobsCommand:
         assert volume_2.source == "org/b"
         assert volume_2.mount_path == "/output"
         assert volume_2.read_only is None
+
+    @pytest.mark.parametrize("num_gpus", [1, 2, 4, 8])
+    def test_stats_rows_one_row_per_gpu(self, num_gpus: int) -> None:
+        """`hf jobs stats` must render one row per GPU, each with its own metrics."""
+        headers = [
+            "JOB ID",
+            "CPU %",
+            "NUM CPU",
+            "MEM %",
+            "MEM USAGE",
+            "NET I/O",
+            "GPU UTIL %",
+            "GPU MEM %",
+            "GPU MEM USAGE",
+        ]
+        metrics = {
+            "cpu_usage_pct": 42,
+            "cpu_millicores": 8000,
+            "memory_used_bytes": 4_000_000_000,
+            "memory_total_bytes": 16_000_000_000,
+            "rx_bps": 1_000_000,
+            "tx_bps": 2_000_000,
+            "gpus": {
+                f"gpu-{index}": {
+                    "utilization": 10 * (index + 1),
+                    "memory_used_bytes": 1_000_000_000 * (index + 1),
+                    "memory_total_bytes": 80_000_000_000,
+                }
+                for index in range(num_gpus)
+            },
+        }
+        (rows,) = [rows for done, _, rows in _get_jobs_stats_rows("my-job-id", [metrics], headers) if not done]
+
+        assert len(rows) == num_gpus
+        assert all(len(row) == len(headers) for row in rows)
+        assert [row[headers.index("GPU UTIL %")] for row in rows] == [f"{10 * (i + 1)}%" for i in range(num_gpus)]
 
 
 class TestJobsWaitCommand:


### PR DESCRIPTION
## Summary

- On a job with 3 or more GPUs (`a100x4`, `a100x8`, `h200x4`, `l40sx8`, ...), `hf jobs stats` repeats the second GPU's line for every remaining GPU. The third and later GPUs are never shown, so the command cannot be used to spot an idle or OOM-ing GPU on exactly the flavors where that matters.
- `_get_jobs_stats_rows` builds the extra rows with `[[""] * len(row)] * (len(metrics["gpus"]) - 1)` (`cli/jobs.py:483`). That repeats a single list object rather than creating distinct lists, and the loop right below appends with `row += [...]`, which extends in place. So every "extra GPU" slot is the same list, extended once per GPU. `_tabulate` sizes its columns with `zip(*rows, headers)` and renders each row with `zip(row, col_widths)`, so that one list is printed N-1 times, each time showing only its first GPU block.
- 1 and 2 GPU jobs are unaffected: `[x] * 1` has nothing to alias, which is why this went unnoticed.
- Fixed by building the extra rows with a list comprehension so each row is its own list.

### Before

Rendering one metrics tick from an 8-GPU job through `_get_jobs_stats_rows` and `_tabulate`, i.e. what `hf jobs stats` prints:

```
JOB ID     CPU % NUM CPU MEM %  MEM USAGE        NET I/O             GPU UTIL % GPU MEM % GPU MEM USAGE
---------- ----- ------- ------ ---------------- ------------------- ---------- --------- ---------------
mzt4v9k2p8 37%   12.0    32.81% 42.0GB / 128.0GB 1.2Mbps / 800.0Kbps 90%        75.0%     60.0GB / 80.0GB
                                                                     91%        76.25%    61.0GB / 80.0GB
                                                                     91%        76.25%    61.0GB / 80.0GB
                                                                     91%        76.25%    61.0GB / 80.0GB
                                                                     91%        76.25%    61.0GB / 80.0GB
                                                                     91%        76.25%    61.0GB / 80.0GB
                                                                     91%        76.25%    61.0GB / 80.0GB
                                                                     91%        76.25%    61.0GB / 80.0GB
```

The row count is right, but GPU 2 is printed seven times and GPUs 3 to 8 never appear.

### After

```
JOB ID     CPU % NUM CPU MEM %  MEM USAGE        NET I/O             GPU UTIL % GPU MEM % GPU MEM USAGE
---------- ----- ------- ------ ---------------- ------------------- ---------- --------- ---------------
mzt4v9k2p8 37%   12.0    32.81% 42.0GB / 128.0GB 1.2Mbps / 800.0Kbps 90%        75.0%     60.0GB / 80.0GB
                                                                     91%        76.25%    61.0GB / 80.0GB
                                                                     92%        77.5%     62.0GB / 80.0GB
                                                                     93%        78.75%    63.0GB / 80.0GB
                                                                     94%        80.0%     64.0GB / 80.0GB
                                                                     95%        81.25%    65.0GB / 80.0GB
                                                                     96%        82.5%     66.0GB / 80.0GB
                                                                     97%        83.75%    67.0GB / 80.0GB
```

Regression test added to `tests/test_cli.py::TestJobsCommand`, parametrized over 1, 2, 4 and 8 GPUs: one row per GPU, each row the width of the header, and each row carrying its own GPU's numbers. It fails on `main` for the 4 and 8 GPU cases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI display-only change in stats row construction; behavior fix with targeted tests and no API or security impact.
> 
> **Overview**
> **Fixes `hf jobs stats` on jobs with 3+ GPUs**, where extra GPU lines all showed the same metrics instead of each GPU’s own utilization and memory.
> 
> `_get_jobs_stats_rows` now builds blank continuation rows with a list comprehension (`for _ in range(...)`) instead of multiplying a single inner list, so in-place `row += [...]` updates one row per GPU.
> 
> A parametrized test (`1`, `2`, `4`, `8` GPUs) asserts one row per GPU with distinct **GPU UTIL %** values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4efc3e46cefa861a1e1b44165249d112f5d29a74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->