### PR TITLE
Raise CLIError when positional filenames are combined with --include/--exclude

### DIFF
--- a/src/huggingface_hub/cli/download.py
+++ b/src/huggingface_hub/cli/download.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Contains command to download files from the Hub with the CLI."""
 
-import warnings
 from typing import Annotated
 
 from huggingface_hub import constants
@@ -152,12 +151,20 @@ def download(
                     f'Please use `--include "{subfolders[0]}*"` with `--exclude` instead.'
                 )
 
-        # Warn user if patterns are ignored (only if regular filenames are provided)
+        # Error if regular filenames are combined with --include/--exclude
+        # Both select what to download, so silently letting filenames win would drop files the user asked for
         if len(regular_filenames) > 0:
             if include is not None and len(include) > 0:
-                warnings.warn("Ignoring `--include` since filenames have been explicitly set.")
+                raise CLIError(
+                    f"Cannot combine filenames ('{regular_filenames[0]}') with `--include`. "
+                    "`--include` takes one pattern per occurrence: repeat it "
+                    f'(e.g. `--include "{include[0]}" --include "{regular_filenames[0]}"`) or pass filenames only.'
+                )
             if exclude is not None and len(exclude) > 0:
-                warnings.warn("Ignoring `--exclude` since filenames have been explicitly set.")
+                raise CLIError(
+                    f"Cannot combine filenames ('{regular_filenames[0]}') with `--exclude`. "
+                    f'Please use `--include "{regular_filenames[0]}"` with `--exclude` instead.'
+                )
 
         # Single file to download (not a subfolder): use `hf_hub_download`
         if len(regular_filenames) == 1 and len(subfolder_patterns) == 0:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,6 @@
 import json
 import os
 import sys
-import warnings
 from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
@@ -1204,41 +1203,31 @@ class TestDownloadImpl:
 
     @patch("huggingface_hub.cli.download.snapshot_download")
     @patch("huggingface_hub.cli.download.hf_hub_download")
-    def test_download_with_ignored_patterns(self, mock_download: Mock, mock_snapshot: Mock) -> None:
-        mock_snapshot.return_value = "folder-path"
-        with (
-            patch("builtins.print") as print_mock,
-            warnings.catch_warnings(record=True) as caught,
-        ):
+    def test_download_filenames_with_include_raises_error(self, mock_download: Mock, mock_snapshot: Mock) -> None:
+        """Test that combining filenames with --include raises an error instead of silently dropping the patterns."""
+        with pytest.raises(CLIError, match="Cannot combine filenames"):
             download(
                 repo_id="author/model",
                 filenames=["README.md", "config.json"],
                 repo_type=RepoType.model,
                 include=["*.json"],
-                exclude=["data/*"],
-                force_download=True,
             )
-        print_mock.assert_called_once_with("folder-path", flush=True)
-        warning_messages = [str(w.message) for w in caught]
-        assert warning_messages == [
-            "Ignoring `--include` since filenames have been explicitly set.",
-            "Ignoring `--exclude` since filenames have been explicitly set.",
-        ]
         mock_download.assert_not_called()
-        mock_snapshot.assert_called_once_with(
-            repo_id="author/model",
-            repo_type="model",
-            revision=None,
-            allow_patterns=["README.md", "config.json"],
-            ignore_patterns=None,
-            force_download=True,
-            cache_dir=None,
-            token=None,
-            local_dir=None,
-            library_name="huggingface-cli",
-            max_workers=8,
-            dry_run=False,
-        )
+        mock_snapshot.assert_not_called()
+
+    @patch("huggingface_hub.cli.download.snapshot_download")
+    @patch("huggingface_hub.cli.download.hf_hub_download")
+    def test_download_filenames_with_exclude_raises_error(self, mock_download: Mock, mock_snapshot: Mock) -> None:
+        """Test that combining filenames with --exclude raises an error instead of silently dropping the patterns."""
+        with pytest.raises(CLIError, match="Cannot combine filenames"):
+            download(
+                repo_id="author/model",
+                filenames=["README.md", "config.json"],
+                repo_type=RepoType.model,
+                exclude=["data/*"],
+            )
+        mock_download.assert_not_called()
+        mock_snapshot.assert_not_called()
 
     @patch("huggingface_hub.cli.download.snapshot_download")
     @patch("huggingface_hub.cli.download.hf_hub_download")


### PR DESCRIPTION
Fixes #4663.

## What

`hf download` treats positional `filenames` and `--include`/`--exclude` as two ways of selecting what to download. When both are set, `filenames` silently wins: the CLI warns and exits 0.

Because `--include` takes one value per occurrence, this is easy to hit by accident:

```
hf download REPO --include "A.gguf" "B.gguf" "C.gguf"
```

parses as `include=["A.gguf"]`, `filenames=["B.gguf", "C.gguf"]`, downloads only B and C, and exits 0. A partial download reported as success — which in a script surfaces much later as a confusing downstream failure.

This raises `CLIError` instead.

## Why this way

The same class of conflict is already fatal a few lines above: combining a subfolder argument (`art/`) with `--include`/`--exclude` raises `CLIError` (added in #3822, which deliberately rejected that mix). The filenames branch has warned-and-continued since #1617, the original CLI download implementation, and looks like the branch that was never revisited rather than a considered decision to differ.

Since the root cause is the one-value-per-occurrence parsing, the error can hand back the working command:

```
Error: Cannot combine filenames ('special_tokens_map.json') with `--include`.
`--include` takes one pattern per occurrence: repeat it
(e.g. `--include "config.json" --include "special_tokens_map.json"`) or pass filenames only.
```

## On the behavior change

This does turn an exit-0 invocation into exit 1, so it is worth being explicit about it.

What makes it safe in practice: `--include` cannot widen a set already pinned by explicit filenames, so in that combination the option has never had any effect. There is no behavior to depend on — only a warning that the selection was narrowed. The realistic way to reach this branch is the accident above, where the current behavior actively loses files.

If you would rather not take the break, the smaller alternative is to keep the warning but exit non-zero. That leaves two conflict styles in one function, but it removes the false success signal. Happy to switch if you prefer that.

## Tests

`test_download_with_ignored_patterns` asserted the old warning strings (tightened in #4337), so it is replaced by `test_download_filenames_with_include_raises_error` and `test_download_filenames_with_exclude_raises_error`, named and structured to match the adjacent `test_download_subfolder_with_include_raises_error`.

No coverage is lost: `test_download_multiple_files` already covers filenames-only to `snapshot_download(allow_patterns=...)`.

Both new tests fail before the `download.py` change (`DID NOT RAISE CLIError`) and pass after.

`import warnings` is dropped from both files because this removes its last use.

## Verification

- `pytest tests/test_cli.py` — 314 passed
- `make quality` — `ruff check`, `ruff format --check`, `ty check src`, and all five `utils/` check/generate scripts pass
- End to end: the repro command now exits 1 and writes no files; the suggested repeated-flag form exits 0 with all three files present

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI validation-only change; previously `--include`/`--exclude` had no effect in this combination, so the main impact is exit 1 instead of exit 0 for mistaken invocations.
> 
> **Overview**
> **`hf download` now fails fast** when positional filenames are used together with `--include` or `--exclude`, instead of warning and continuing with filenames only (exit 0).
> 
> That aligns with the existing **subfolder + `--include`/`--exclude`** behavior and avoids accidental partial downloads—e.g. `hf download REPO --include "A.gguf" "B.gguf"` where extra tokens become filenames and some files are skipped while the command still succeeds.
> 
> **`CLIError` messages** explain the conflict and suggest repeating `--include` per pattern or using filenames only; for `--exclude`, they point users toward `--include` + `--exclude`.
> 
> Tests replace the old warning-based case with two error assertions; unused `warnings` imports are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 733e7ad63f1c8c71e696e95b2ac8cc39777014c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->