### PR TITLE
[CLI] Fix silent drop of --include when filenames are set

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -303,6 +303,8 @@ Fetching 8 files: 100%|███████████████████
 /home/wauplin/.cache/huggingface/hub/models--stabilityai--stable-diffusion-xl-base-1.0/snapshots/462165984030d82259a11f4367a4eed129e94a7b
 ```
 
+The two approaches cannot be combined: passing filenames together with `--include` or `--exclude` raises an error. Note that `--include` takes a single pattern per occurrence, so repeat the option to pass several of them (`--include "*.json" --include "*.txt"`).
+
 ### Download a dataset or a Space
 
 The examples above show how to download from a model repository. To download a dataset or a Space, use the `--repo-type` option:

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -303,7 +303,7 @@ Fetching 8 files: 100%|███████████████████
 /home/wauplin/.cache/huggingface/hub/models--stabilityai--stable-diffusion-xl-base-1.0/snapshots/462165984030d82259a11f4367a4eed129e94a7b
 ```
 
-The two approaches cannot be combined: passing filenames together with `--include` or `--exclude` raises an error. Note that `--include` takes a single pattern per occurrence, so repeat the option to pass several of them (`--include "*.json" --include "*.txt"`).
+The two approaches cannot be combined: passing filenames together with `--include` or `--exclude` raises an error. Note that both options take a single pattern per occurrence, so repeat them to pass several (`--include "*.json" --include "*.txt"`).
 
 ### Download a dataset or a Space
 

--- a/src/huggingface_hub/cli/download.py
+++ b/src/huggingface_hub/cli/download.py
@@ -163,7 +163,9 @@ def download(
             if exclude is not None and len(exclude) > 0:
                 raise CLIError(
                     f"Cannot combine filenames ('{regular_filenames[0]}') with `--exclude`. "
-                    f'Please use `--include "{regular_filenames[0]}"` with `--exclude` instead.'
+                    "`--exclude` takes one pattern per occurrence: repeat it "
+                    f'(e.g. `--exclude "{exclude[0]}" --exclude "{regular_filenames[0]}"`), '
+                    f'or use `--include "{regular_filenames[0]}"` with `--exclude` to select files explicitly.'
                 )
 
         # Single file to download (not a subfolder): use `hf_hub_download`

--- a/src/huggingface_hub/cli/download.py
+++ b/src/huggingface_hub/cli/download.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Contains command to download files from the Hub with the CLI."""
 
-import warnings
 from typing import Annotated
 
 from huggingface_hub import constants
@@ -152,12 +151,20 @@ def download(
                     f'Please use `--include "{subfolders[0]}*"` with `--exclude` instead.'
                 )
 
-        # Warn user if patterns are ignored (only if regular filenames are provided)
+        # Error if regular filenames are combined with --include/--exclude
+        # Both select what to download, so silently letting filenames win would drop files the user asked for
         if len(regular_filenames) > 0:
             if include is not None and len(include) > 0:
-                warnings.warn("Ignoring `--include` since filenames have been explicitly set.")
+                raise CLIError(
+                    f"Cannot combine filenames ('{regular_filenames[0]}') with `--include`. "
+                    "`--include` takes one pattern per occurrence: repeat it "
+                    f'(e.g. `--include "{include[0]}" --include "{regular_filenames[0]}"`) or pass filenames only.'
+                )
             if exclude is not None and len(exclude) > 0:
-                warnings.warn("Ignoring `--exclude` since filenames have been explicitly set.")
+                raise CLIError(
+                    f"Cannot combine filenames ('{regular_filenames[0]}') with `--exclude`. "
+                    f'Please use `--include "{regular_filenames[0]}"` with `--exclude` instead.'
+                )
 
         # Single file to download (not a subfolder): use `hf_hub_download`
         if len(regular_filenames) == 1 and len(subfolder_patterns) == 0:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1205,7 +1205,7 @@ class TestDownloadImpl:
     @patch("huggingface_hub.cli.download.hf_hub_download")
     def test_download_filenames_with_include_raises_error(self, mock_download: Mock, mock_snapshot: Mock) -> None:
         """Test that combining filenames with --include raises an error instead of silently dropping the patterns."""
-        with pytest.raises(CLIError, match="Cannot combine filenames"):
+        with pytest.raises(CLIError, match=r"Cannot combine filenames.*`--include` takes one pattern per occurrence"):
             download(
                 repo_id="author/model",
                 filenames=["README.md", "config.json"],
@@ -1219,7 +1219,9 @@ class TestDownloadImpl:
     @patch("huggingface_hub.cli.download.hf_hub_download")
     def test_download_filenames_with_exclude_raises_error(self, mock_download: Mock, mock_snapshot: Mock) -> None:
         """Test that combining filenames with --exclude raises an error instead of silently dropping the patterns."""
-        with pytest.raises(CLIError, match="Cannot combine filenames"):
+        # Guidance must be about `--exclude` itself: an earlier version suggested converting the filename into
+        # `--include`, which inverts intent when the user meant to skip that file.
+        with pytest.raises(CLIError, match=r"Cannot combine filenames.*`--exclude` takes one pattern per occurrence"):
             download(
                 repo_id="author/model",
                 filenames=["README.md", "config.json"],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,6 @@
 import json
 import os
 import sys
-import warnings
 from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
@@ -1204,41 +1203,31 @@ class TestDownloadImpl:
 
     @patch("huggingface_hub.cli.download.snapshot_download")
     @patch("huggingface_hub.cli.download.hf_hub_download")
-    def test_download_with_ignored_patterns(self, mock_download: Mock, mock_snapshot: Mock) -> None:
-        mock_snapshot.return_value = "folder-path"
-        with (
-            patch("builtins.print") as print_mock,
-            warnings.catch_warnings(record=True) as caught,
-        ):
+    def test_download_filenames_with_include_raises_error(self, mock_download: Mock, mock_snapshot: Mock) -> None:
+        """Test that combining filenames with --include raises an error instead of silently dropping the patterns."""
+        with pytest.raises(CLIError, match="Cannot combine filenames"):
             download(
                 repo_id="author/model",
                 filenames=["README.md", "config.json"],
                 repo_type=RepoType.model,
                 include=["*.json"],
-                exclude=["data/*"],
-                force_download=True,
             )
-        print_mock.assert_called_once_with("folder-path", flush=True)
-        warning_messages = [str(w.message) for w in caught]
-        assert warning_messages == [
-            "Ignoring `--include` since filenames have been explicitly set.",
-            "Ignoring `--exclude` since filenames have been explicitly set.",
-        ]
         mock_download.assert_not_called()
-        mock_snapshot.assert_called_once_with(
-            repo_id="author/model",
-            repo_type="model",
-            revision=None,
-            allow_patterns=["README.md", "config.json"],
-            ignore_patterns=None,
-            force_download=True,
-            cache_dir=None,
-            token=None,
-            local_dir=None,
-            library_name="huggingface-cli",
-            max_workers=8,
-            dry_run=False,
-        )
+        mock_snapshot.assert_not_called()
+
+    @patch("huggingface_hub.cli.download.snapshot_download")
+    @patch("huggingface_hub.cli.download.hf_hub_download")
+    def test_download_filenames_with_exclude_raises_error(self, mock_download: Mock, mock_snapshot: Mock) -> None:
+        """Test that combining filenames with --exclude raises an error instead of silently dropping the patterns."""
+        with pytest.raises(CLIError, match="Cannot combine filenames"):
+            download(
+                repo_id="author/model",
+                filenames=["README.md", "config.json"],
+                repo_type=RepoType.model,
+                exclude=["data/*"],
+            )
+        mock_download.assert_not_called()
+        mock_snapshot.assert_not_called()
 
     @patch("huggingface_hub.cli.download.snapshot_download")
     @patch("huggingface_hub.cli.download.hf_hub_download")


### PR DESCRIPTION
Fixes #4665. Would you mind assigning that issue to me? I don't have permission to self-assign.

## Summary

- `hf download REPO --include A B C` silently dropped `A` and exited 0. `--include` takes one value per occurrence, so `B` and `C` fell through to the positional `filenames` argument, which then took precedence.
- Raise `CLIError` instead of warning, matching what the subfolder branch ten lines above already does.
- The message points at the repeated-flag form, since that's the actual mistake being made.
- Added a note to the CLI guide — it presents filenames and `--include` as "two ways" without saying they're exclusive.

## Before

```
$ hf download hf-internal-testing/tiny-random-gpt2 \
    --include config.json special_tokens_map.json tokenizer_config.json \
    --local-dir ./repro
.../cli/download.py:158: UserWarning: Ignoring `--include` since filenames have been explicitly set.
path=./repro

$ echo $?
0
$ ls repro
special_tokens_map.json
tokenizer_config.json
```

`config.json` was asked for and never fetched, exit 0.

## After

```
$ hf download hf-internal-testing/tiny-random-gpt2 \
    --include config.json special_tokens_map.json tokenizer_config.json \
    --local-dir ./repro
Error: Cannot combine filenames ('special_tokens_map.json') with `--include`.
`--include` takes one pattern per occurrence: repeat it
(e.g. `--include "config.json" --include "special_tokens_map.json"`) or pass filenames only.
Hint: set HF_DEBUG=1 as environment variable for full traceback.

$ echo $?
1
$ ls repro
ls: repro: No such file or directory
```

Nothing is written — it fails before touching the filesystem.

And the form it suggests works:

```
$ hf download hf-internal-testing/tiny-random-gpt2 \
    --include config.json --include special_tokens_map.json --include tokenizer_config.json \
    --local-dir ./repro
$ ls repro
config.json
special_tokens_map.json
tokenizer_config.json
```

## Breaking change

Yes — an invocation that exited 0 now exits 1.

What makes it feel safe: `--include` can't widen a set already pinned by explicit filenames, so in that combination the option has never had any effect. There's no behavior to depend on, only a warning saying the selection got narrowed. The realistic way to reach this branch is the accident above, where the current behavior loses files.

If you'd rather not take the break, the smaller version is to keep the warning and just exit non-zero. Leaves two conflict styles in one function, but kills the false success. Happy to switch.

## Decisions

- **Error rather than merging filenames into `allow_patterns`.** Merging would guess at intent, and #3822 already set the precedent of erroring instead of guessing for this exact conflict.
- **`test_download_with_ignored_patterns` is replaced, not extended.** It asserted the old warning strings (tightened in #4337), so it can't survive. Replaced by `test_download_filenames_with_include_raises_error` and `..._exclude_raises_error`, named to match the adjacent subfolder tests. No coverage lost — `test_download_multiple_files` already covers filenames-only → `snapshot_download(allow_patterns=...)`. Kept to two tests per the AGENTS.md note about not testing every parameter permutation.
- **`import warnings` dropped from both files** because this removes its last use in each.
- Both new tests fail before the `download.py` change (`DID NOT RAISE CLIError`) and pass after.

`make style` and `make quality` are clean, `pytest tests/test_cli.py` is 314 passed. `uvx mypy src` reports 3 errors, all pre-existing in `_framework.py` and `_http.py`, none from this change.

## Disclosure

I used an AI agent for the investigation and the patch, run from the repo root so it picked up `AGENTS.md`. The terminal output above is real, captured from actual runs rather than written by hand. Happy to walk through any part of the diff or the reasoning behind it if anything looks off.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only validation change: previously ignored flag combinations now exit with an error, which is intentional and limits silent partial downloads.
> 
> **Overview**
> **`hf download` no longer warns and continues when positional filenames are used together with `--include` or `--exclude`.** It raises `CLIError` instead, aligned with the existing subfolder + pattern checks, so mistaken invocations (e.g. extra tokens after a single `--include`) fail before any download instead of exiting 0 while dropping patterns.
> 
> Error text explains that patterns are **one per flag** and suggests repeating `--include` / `--exclude` or using filenames only; the exclude path avoids steering users toward `--include` when they meant to skip files.
> 
> The CLI guide now states that filenames and `--include`/`--exclude` are **mutually exclusive**, and that multiple patterns require repeated flags. Tests replace the old “ignored patterns” warning case with include/exclude error coverage; unused `warnings` imports are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49a44cc2854d1f7e35bbe866686c3dadc0cce77f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->