### PR TITLE
fix(inference-endpoints): use the deploy namespace in catalog endpoint handle

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -9646,8 +9646,9 @@ class HfApi:
                 "Cannot use `token=False` with `create_inference_endpoint_from_catalog` as it requires authentication."
             )
         token = token or self.token or get_token()
+        namespace = namespace or self._get_namespace(token=token)
         payload: dict = {
-            "namespace": namespace or self._get_namespace(token=token),
+            "namespace": namespace,
             "repoId": repo_id,
         }
         if name is not None:
@@ -9662,7 +9663,7 @@ class HfApi:
         )
         hf_raise_for_status(response)
         data = response.json()["endpoint"]
-        return InferenceEndpoint.from_raw(data, namespace=data["name"], token=token)
+        return InferenceEndpoint.from_raw(data, namespace=namespace, token=token)
 
     @experimental
     @validate_hf_hub_args

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -4606,7 +4606,9 @@ class TestHfApiInferenceCatalog:
         assert len(models) > 0
         assert all(isinstance(model, str) for model in models)
 
-    def test_create_inference_endpoint_from_catalog(self, api: HfApi, mocker) -> None:
+    @pytest.fixture
+    def mock_catalog_deploy(self, mocker) -> Mock:
+        """Mock the catalog deploy call and return the mocked `post` method."""
         mock_get_session = mocker.patch("huggingface_hub.hf_api.get_session")
         mock_response = Mock()
         mock_response.json.return_value = {
@@ -4656,13 +4658,28 @@ class TestHfApiInferenceCatalog:
                 "type": "protected",
             }
         }
-        mock_get_session.return_value.post.return_value = mock_response
+        mock_post = mock_get_session.return_value.post
+        mock_post.return_value = mock_response
+        return mock_post
 
+    def test_create_inference_endpoint_from_catalog(self, api: HfApi, mock_catalog_deploy: Mock) -> None:
         endpoint = api.create_inference_endpoint_from_catalog(
             repo_id="meta-llama/Llama-3.2-3B-Instruct", namespace="Wauplin"
         )
         assert isinstance(endpoint, InferenceEndpoint)
         assert endpoint.name == "llama-3-2-3b-instruct-eey"
+        # Namespace must be the one the endpoint has been deployed to, not the endpoint name.
+        # Otherwise follow-up calls (pause, delete, fetch, ...) would 404.
+        assert endpoint.namespace == "Wauplin"
+
+    def test_create_inference_endpoint_from_catalog_default_namespace(
+        self, api: HfApi, mocker, mock_catalog_deploy: Mock
+    ) -> None:
+        mocker.patch.object(HfApi, "_get_namespace", return_value="Wauplin")
+
+        endpoint = api.create_inference_endpoint_from_catalog(repo_id="meta-llama/Llama-3.2-3B-Instruct")
+        assert endpoint.namespace == "Wauplin"
+        assert mock_catalog_deploy.call_args.kwargs["json"]["namespace"] == "Wauplin"
 
     def test_create_inference_endpoint_from_catalog_rejects_token_false(self, api: HfApi) -> None:
         # `token=False` means "do not authenticate", but this endpoint cannot be created without


### PR DESCRIPTION
fix(inference-endpoints): use the deploy namespace in catalog endpoint handle

## Testing

tests/test_hf_api.py::TestHfApiInferenceCatalog::test_create_inference_endpoint_from_catalog (extended with namespace assertion) and tests/test_hf_api.py::TestHfApiInferenceCatalog::test_create_inference_endpoint_from_catalog_default_namespace (new)

Added tests fail on the current code and pass with this change; the relevant suite was run locally.

Closes #4314

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted fix to experimental catalog deploy with added regression tests; no auth or broad API behavior changes beyond correcting the returned handle.
> 
> **Overview**
> Fixes a bug in **`create_inference_endpoint_from_catalog`** where the returned **`InferenceEndpoint`** was built with **`namespace=data["name"]`** (the generated endpoint name) instead of the Hub namespace used for deployment.
> 
> The method now resolves **`namespace`** once (explicit argument or **`_get_namespace`**) and passes that value into both the deploy JSON payload and **`InferenceEndpoint.from_raw`**, consistent with **`create_inference_endpoint`**. Follow-up operations on the handle (pause, delete, fetch, etc.) should no longer 404.
> 
> Tests add a shared **`mock_catalog_deploy`** fixture, assert **`endpoint.namespace`** on explicit deploy, and cover the default-namespace path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79fcdf50232c2e16805d818f3420bcf6fabf3320. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->