### PR TITLE
[CLI] Accept a Hugging Face URL in `hf download`

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -326,7 +326,7 @@ The examples above show how to download from the latest commit on the main branc
 ...
 ```
 
-### Use an hf:// URI
+### Use an hf:// URI or a URL
 
 Instead of passing the repo type, revision and file path as separate arguments and options, you can provide a single `hf://` URI. The URI encodes everything at once, following the grammar `hf://[<TYPE>/]<ID>[@<REVISION>][/<PATH>]` (see the [HF URIs reference](../package_reference/hf_uris) for the full syntax):
 
@@ -344,7 +344,17 @@ Instead of passing the repo type, revision and file path as separate arguments a
 >>> hf download hf://openai-community/gpt2/config.json
 ```
 
-When a URI is given, `--repo-type` and `--revision` cannot be set as well since they are already part of the URI (an error is raised otherwise), and a file path embedded in the URI cannot be combined with positional filenames. A trailing `/` on the path denotes a subfolder (as with the positional argument). Branch names that contain a `/` must be URL-encoded as `%2F` (e.g. `hf://my-org/my-model@feature%2Ffoo`).
+A Hugging Face URL copy-pasted from your browser works the same way, which is handy to grab a single file out of a large repo:
+
+```bash
+# Equivalent to: hf download openai-community/gpt2 config.json
+>>> hf download https://huggingface.co/openai-community/gpt2/blob/main/config.json
+
+# The query string added by "Copy download link" is ignored
+>>> hf download https://huggingface.co/datasets/bigcode/the-stack/resolve/v1.1/README.md?download=true
+```
+
+When a URI or a URL is given, `--repo-type` and `--revision` cannot be set as well since they are already part of it (an error is raised otherwise), and an embedded file path cannot be combined with positional filenames. A trailing `/` on the path denotes a subfolder (as with the positional argument). Branch names that contain a `/` must be URL-encoded as `%2F` (e.g. `hf://my-org/my-model@feature%2Ffoo`).
 
 ### Download to a local folder
 

--- a/docs/source/en/guides/download.md
+++ b/docs/source/en/guides/download.md
@@ -156,7 +156,7 @@ Fetching 2 files: 100%|███████████████████
 /home/wauplin/.cache/huggingface/hub/models--gpt2/snapshots/11c5a3d5811f50298f278a704980280950aedb10
 ```
 
-You can also point at the repo (and optionally a revision and file) using a single `hf://` URI. The URI follows the grammar `hf://[<TYPE>/]<ID>[@<REVISION>][/<PATH>]` (see the [HF URIs reference](../package_reference/hf_uris) for the full syntax) and replaces the `--repo-type` and `--revision` options, which cannot be set alongside it:
+You can also point at the repo (and optionally a revision and file) using a single `hf://` URI or a Hugging Face URL copy-pasted from your browser. The URI follows the grammar `hf://[<TYPE>/]<ID>[@<REVISION>][/<PATH>]` (see the [HF URIs reference](../package_reference/hf_uris) for the full syntax) and replaces the `--repo-type` and `--revision` options, which cannot be set alongside it:
 
 ```bash
 # Download a single file from a dataset at a given revision
@@ -167,6 +167,9 @@ You can also point at the repo (and optionally a revision and file) using a sing
 
 # Download an entire repo
 >>> hf download hf://datasets/google/fleurs
+
+# Download a single file from its web URL
+>>> hf download https://huggingface.co/datasets/google/fleurs/blob/main/fleurs.py
 ```
 
 For more details about the CLI download command, please refer to the [CLI guide](./cli#hf-download).

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -1600,6 +1600,7 @@ Examples
   $ hf download meta-llama/Llama-3.2-1B-Instruct --local-dir ./models/llama
   $ hf download HuggingFaceM4/FineVision art/ --repo-type dataset
   $ hf download hf://datasets/HuggingFaceH4/ultrachat_200k
+  $ hf download https://huggingface.co/openai-community/gpt2/blob/main/config.json
 
 Learn more
   Use `hf <command> --help` for more information about a command.

--- a/src/huggingface_hub/cli/download.py
+++ b/src/huggingface_hub/cli/download.py
@@ -21,6 +21,7 @@ from huggingface_hub._snapshot_download import snapshot_download
 from huggingface_hub.errors import CLIError
 from huggingface_hub.file_download import DryRunFileInfo, hf_hub_download
 from huggingface_hub.utils import _format_size, parse_hf_uri
+from huggingface_hub.utils._hf_uris import _looks_like_hf_url
 
 from ._cli_utils import RepoIdArg, RepoType, RepoTypeOptionalOpt, RevisionOpt, TokenOpt
 from ._framework import Argument, Option
@@ -34,6 +35,7 @@ DOWNLOAD_EXAMPLES = [
     "hf download meta-llama/Llama-3.2-1B-Instruct --local-dir ./models/llama",
     "hf download HuggingFaceM4/FineVision art/ --repo-type dataset",
     "hf download hf://datasets/HuggingFaceH4/ultrachat_200k",
+    "hf download https://huggingface.co/openai-community/gpt2/blob/main/config.json",
 ]
 
 
@@ -99,17 +101,19 @@ def download(
             "or `--local-dir` for a one-off download to a specific directory."
         )
 
-    # `repo_id` may be a plain repo id or an `hf://` URI (e.g. `hf://datasets/my-org/my-dataset@v1.0/data/`).
-    # When a URI is provided, it is authoritative for the repo type, revision and (optionally) file path,
+    # `repo_id` may be a plain repo id, an `hf://` URI (e.g. `hf://datasets/my-org/my-dataset@v1.0/data/`) or a
+    # Hugging Face web URL copy-pasted from the browser (e.g.
+    # `https://huggingface.co/my-org/my-model/blob/main/config.json`).
+    # When a URI or URL is provided, it is authoritative for the repo type, revision and (optionally) file path,
     # so explicit `--repo-type` / `--revision` options are forbidden alongside it.
-    # We branch on the `hf://` prefix (the user's *intent*) rather than on whether the string parses as a
-    # valid URI: a malformed URI then surfaces a precise `HfUriError` (formatted globally in `cli/_errors.py`)
+    # We branch on the `hf://` prefix / URL shape (the user's *intent*) rather than on whether the string parses
+    # as a valid URI: a malformed one then surfaces a precise `HfUriError` (formatted globally in `cli/_errors.py`)
     # instead of silently falling through to the plain-repo-id path and failing later with an opaque error.
-    if repo_id.startswith(constants.HF_PROTOCOL):
+    if repo_id.startswith(constants.HF_PROTOCOL) or _looks_like_hf_url(repo_id):
         if repo_type is not None:
-            raise CLIError(f"'--repo-type' cannot be used with an 'hf://' URI ('{repo_id}').")
+            raise CLIError(f"'--repo-type' cannot be used with a Hub URI or URL ('{repo_id}').")
         if revision is not None:
-            raise CLIError(f"'--revision' cannot be used with an 'hf://' URI ('{repo_id}').")
+            raise CLIError(f"'--revision' cannot be used with a Hub URI or URL ('{repo_id}').")
         uri = parse_hf_uri(repo_id)
         if uri.is_bucket:
             raise CLIError("Buckets are not supported by `hf download`. Use `hf sync` instead.")
@@ -123,7 +127,7 @@ def download(
         if path_in_repo:
             if filenames:
                 raise CLIError(
-                    f"Cannot combine a file path in the hf:// URI ('{path_in_repo}') with positional filenames {filenames}."
+                    f"Cannot combine a file path from the URI or URL ('{path_in_repo}') with positional filenames {filenames}."
                 )
             filenames = [path_in_repo]
     else:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1391,7 +1391,7 @@ class TestDownloadImpl:
             download(repo_id="hf://datasets/missing-name")
 
     def test_download_hf_uri_with_revision_raises(self) -> None:
-        with pytest.raises(CLIError, match="'--revision' cannot be used with an 'hf://' URI"):
+        with pytest.raises(CLIError, match="'--revision' cannot be used with a Hub URI or URL"):
             download(repo_id="hf://datasets/author/dataset@v1.0", revision="v1.0")
 
     def test_download_hf_uri_with_filenames_raises(self) -> None:
@@ -1401,6 +1401,50 @@ class TestDownloadImpl:
     def test_download_hf_uri_rejects_buckets(self) -> None:
         with pytest.raises(CLIError, match="Buckets are not supported"):
             download(repo_id="hf://buckets/author/bucket")
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://huggingface.co/datasets/author/dataset/blob/v1.0/data/train.csv",
+            # "Copy download link" from the web UI appends a query string, which is ignored.
+            "https://huggingface.co/datasets/author/dataset/resolve/v1.0/data/train.csv?download=true",
+        ],
+    )
+    @patch("huggingface_hub.cli.download.snapshot_download")
+    @patch("huggingface_hub.cli.download.hf_hub_download")
+    def test_download_url_single_file(self, mock_download: Mock, mock_snapshot: Mock, url: str) -> None:
+        """A file URL copy-pasted from the browser resolves to a single-file download."""
+        mock_download.return_value = "file-path"
+        download(repo_id=url)
+        mock_snapshot.assert_not_called()
+        mock_download.assert_called_once_with(
+            repo_id="author/dataset",
+            repo_type="dataset",
+            revision="v1.0",
+            filename="data/train.csv",
+            cache_dir=None,
+            force_download=False,
+            token=None,
+            local_dir=None,
+            library_name="huggingface-cli",
+            dry_run=False,
+        )
+
+    @patch("huggingface_hub.cli.download.snapshot_download")
+    @patch("huggingface_hub.cli.download.hf_hub_download")
+    def test_download_url_full_repo(self, mock_download: Mock, mock_snapshot: Mock) -> None:
+        """A repository page URL resolves to a full-repo snapshot download."""
+        mock_snapshot.return_value = "folder-path"
+        download(repo_id="https://huggingface.co/openai-community/gpt2")
+        mock_download.assert_not_called()
+        assert mock_snapshot.call_args.kwargs["repo_id"] == "openai-community/gpt2"
+        assert mock_snapshot.call_args.kwargs["repo_type"] == "model"
+        assert mock_snapshot.call_args.kwargs["revision"] is None
+
+    def test_download_url_unknown_host_raises(self) -> None:
+        """A URL that is not a Hugging Face one is rejected instead of being taken for a repo id."""
+        with pytest.raises(HfUriError):
+            download(repo_id="https://example.com/author/dataset/blob/main/data/train.csv")
 
 
 class TestTagCommands:


### PR DESCRIPTION
`parse_hf_uri` already handles Hugging Face web URLs (blob, resolve, raw and tree routes) and turns them into the canonical `hf://` form. But `hf download` only ran the repo id through it when the string started with `hf://`, so pasting a file URL from the browser fell through to the plain repo id path and failed with an opaque `HFValidationError`.

This branches on the URL shape as well, so a pasted URL resolves to a repo type, revision and file path just like an `hf://` URI. The `--repo-type` / `--revision` conflict errors now say "Hub URI or URL" since they cover both. Docs and the CLI examples get a URL example.

Tests are in tests/test_cli.py::TestDownloadImpl: a blob URL and a resolve URL with `?download=true`, a repo page URL that pulls the whole repo, and a non-Hub host that still gets rejected. They fail on main and pass with this change.

Closes #4099
