### PR TITLE
[Inference Endpoints] Add `hf endpoints hardware` to list available instances

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -2285,6 +2285,9 @@ Use `hf endpoints` to list, deploy, describe, and manage Inference Endpoints dir
 # Lists endpoints in your namespace
 >>> hf endpoints ls
 
+# List the hardware you can deploy on
+>>> hf endpoints hardware
+
 # Deploy an endpoint from Model Catalog
 >>> hf endpoints catalog deploy --repo openai/gpt-oss-120b --name my-endpoint
 
@@ -2306,6 +2309,22 @@ Use `hf endpoints` to list, deploy, describe, and manage Inference Endpoints dir
 
 > [!TIP]
 > Add `--namespace` to target an organization, `--token` to override authentication.
+
+#### Discover the available hardware
+
+`hf endpoints deploy` expects an exact `--accelerator`/`--vendor`/`--region`/`--instance-type`/`--instance-size` combination. Use `hf endpoints hardware` to list the valid ones, optionally filtered with the very same flags:
+
+```bash
+>>> hf endpoints hardware --vendor aws --accelerator gpu
+VENDOR REGION    ACCELERATOR INSTANCE TYPE INSTANCE SIZE GPU MEMORY RAM    $/HOUR
+------ --------- ----------- ------------- ------------- ---------- ------ ------
+aws    us-east-1 gpu         nvidia-t4     x1            16 GB      15 GB     0.5
+aws    us-east-1 gpu         nvidia-l4     x1            24 GB      30 GB     0.8
+aws    us-east-1 gpu         nvidia-a100   x1            80 GB      145 GB    2.5
+...
+```
+
+Deprecated and unavailable hardware is hidden by default, pass `--all` to list it. Pass `--namespace` to also report the quota of that namespace.
 
 #### Deploy a custom container
 

--- a/docs/source/en/guides/inference_endpoints.md
+++ b/docs/source/en/guides/inference_endpoints.md
@@ -46,7 +46,22 @@ hf endpoints catalog deploy --repo openai/gpt-oss-120b --accelerator gpu
 ```
 
 
-In this example, we created an `authenticated` Inference Endpoint named `"my-endpoint-name"`, to serve [gpt2](https://huggingface.co/gpt2) for `text-generation`. An `authenticated` Inference Endpoint means your token is required to access the API. We also need to provide additional information to configure the hardware requirements, such as vendor, region, accelerator, instance type, and size. You can check out the list of available resources [here](https://api.endpoints.huggingface.cloud/#/v2%3A%3Aprovider/list_vendors). Alternatively, you can create an Inference Endpoint manually using the [Web interface](https://ui.endpoints.huggingface.co) for convenience. Refer to this [guide](https://huggingface.co/docs/inference-endpoints/guides/advanced) for details on advanced settings and their usage.
+In this example, we created an `authenticated` Inference Endpoint named `"my-endpoint-name"`, to serve [gpt2](https://huggingface.co/gpt2) for `text-generation`. An `authenticated` Inference Endpoint means your token is required to access the API. We also need to provide additional information to configure the hardware requirements, such as vendor, region, accelerator, instance type, and size. Use [`list_endpoint_hardware`] to list the valid combinations:
+
+```py
+>>> from huggingface_hub import list_endpoint_hardware
+
+>>> list_endpoint_hardware(vendor="aws", accelerator="gpu")
+[EndpointHardware(id='aws-us-east-1-nvidia-t4-x1', vendor='aws', region='us-east-1', accelerator='gpu', instance_type='nvidia-t4', instance_size='x1', architecture='Nvidia T4', status='available', price_per_hour=0.5), ...]
+```
+
+Or via CLI:
+
+```bash
+hf endpoints hardware --vendor aws --accelerator gpu
+```
+
+Pass a `namespace` to get the quota of that namespace, and `include_unavailable=True` to also list deprecated hardware. Alternatively, you can create an Inference Endpoint manually using the [Web interface](https://ui.endpoints.huggingface.co) for convenience. Refer to this [guide](https://huggingface.co/docs/inference-endpoints/guides/advanced) for details on advanced settings and their usage.
 
 The value returned by [`create_inference_endpoint`] is an [`InferenceEndpoint`] object:
 

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -1626,6 +1626,7 @@ $ hf endpoints [OPTIONS] COMMAND [ARGS]...
 * `delete`: Delete an Inference Endpoint permanently.
 * `deploy`: Deploy an Inference Endpoint from a Hub...
 * `describe`: Get information about an existing endpoint.
+* `hardware`: List the hardware available to deploy an...
 * `list`: Lists all Inference Endpoints for the... [alias: ls]
 * `list-catalog`: List available Catalog models.
 * `pause`: Pause an Inference Endpoint.
@@ -1735,6 +1736,9 @@ Learn more
 
 Deploy an Inference Endpoint from a Hub repository.
 
+Run `hf endpoints hardware` to list the valid `--accelerator`, `--vendor`, `--region`, `--instance-type` and
+`--instance-size` combinations.
+
 **Usage**:
 
 ```console
@@ -1805,6 +1809,36 @@ $ hf endpoints describe [OPTIONS] NAME
 
 Examples
   $ hf endpoints describe my-endpoint
+
+Learn more
+  Use `hf <command> --help` for more information about a command.
+  Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
+
+
+### `hf endpoints hardware`
+
+List the hardware available to deploy an Inference Endpoint.
+
+**Usage**:
+
+```console
+$ hf endpoints hardware [OPTIONS]
+```
+
+**Options**:
+
+* `--vendor TEXT`: Only list hardware hosted by this cloud vendor (e.g. 'aws').
+* `--region TEXT`: Only list hardware available in this cloud region (e.g. 'us-east-1').
+* `--accelerator TEXT`: Only list hardware with this accelerator (e.g. 'cpu', 'gpu', 'neuron').
+* `--instance-type TEXT`: Only list hardware with this instance type (e.g. 'nvidia-l4').
+* `--all`: Also list deprecated and unavailable hardware.
+* `--namespace TEXT`: The namespace associated with the Inference Endpoint. Defaults to the current user's namespace.
+* `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
+* `--help`: Show this message and exit.
+
+Examples
+  $ hf endpoints hardware
+  $ hf endpoints hardware --vendor aws --accelerator gpu
 
 Learn more
   Use `hf <command> --help` for more information about a command.

--- a/docs/source/en/package_reference/inference_endpoints.md
+++ b/docs/source/en/package_reference/inference_endpoints.md
@@ -12,6 +12,7 @@ Inference Endpoints can be fully managed via API. The endpoints are documented w
 A subset of the Inference Endpoint features are implemented in [`HfApi`]:
 
 - [`get_inference_endpoint`] and [`list_inference_endpoints`] to get information about your Inference Endpoints
+- [`list_endpoint_hardware`] to list the hardware you can deploy on
 - [`create_inference_endpoint`], [`update_inference_endpoint`] and [`delete_inference_endpoint`] to deploy and manage Inference Endpoints
 - [`pause_inference_endpoint`] and [`resume_inference_endpoint`] to pause and resume an Inference Endpoint
 - [`scale_to_zero_inference_endpoint`] to manually scale an Endpoint to 0 replicas
@@ -37,3 +38,7 @@ The main dataclass is [`InferenceEndpoint`]. It contains information about a dep
 ## InferenceEndpointError
 
 [[autodoc]] InferenceEndpointError
+
+## EndpointHardware
+
+[[autodoc]] EndpointHardware

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -70,6 +70,7 @@ _SUBMOD_ATTRS = {
         "parse_eval_result_entries",
     ],
     "_inference_endpoints": [
+        "EndpointHardware",
         "InferenceEndpoint",
         "InferenceEndpointError",
         "InferenceEndpointStatus",
@@ -293,6 +294,7 @@ _SUBMOD_ATTRS = {
         "list_daily_papers",
         "list_dataset_parquet_files",
         "list_datasets",
+        "list_endpoint_hardware",
         "list_inference_catalog",
         "list_inference_endpoints",
         "list_jobs",
@@ -731,6 +733,7 @@ __all__ = [
     "DocumentQuestionAnsweringOutputElement",
     "DocumentQuestionAnsweringParameters",
     "DryRunFileInfo",
+    "EndpointHardware",
     "EvalResult",
     "EvalResultEntry",
     "FLAX_WEIGHTS_NAME",
@@ -1045,6 +1048,7 @@ __all__ = [
     "list_daily_papers",
     "list_dataset_parquet_files",
     "list_datasets",
+    "list_endpoint_hardware",
     "list_inference_catalog",
     "list_inference_endpoints",
     "list_jobs",
@@ -1268,6 +1272,7 @@ if TYPE_CHECKING:  # pragma: no cover
         parse_eval_result_entries,  # noqa: F401
     )
     from ._inference_endpoints import (
+        EndpointHardware,  # noqa: F401
         InferenceEndpoint,  # noqa: F401
         InferenceEndpointError,  # noqa: F401
         InferenceEndpointStatus,  # noqa: F401
@@ -1487,6 +1492,7 @@ if TYPE_CHECKING:  # pragma: no cover
         list_daily_papers,  # noqa: F401
         list_dataset_parquet_files,  # noqa: F401
         list_datasets,  # noqa: F401
+        list_endpoint_hardware,  # noqa: F401
         list_inference_catalog,  # noqa: F401
         list_inference_endpoints,  # noqa: F401
         list_jobs,  # noqa: F401

--- a/src/huggingface_hub/_inference_endpoints.py
+++ b/src/huggingface_hub/_inference_endpoints.py
@@ -41,6 +41,104 @@ class InferenceEndpointScalingMetric(str, Enum):
 
 
 @dataclass
+class EndpointHardware:
+    """
+    Contains information about a hardware configuration available for Inference Endpoints.
+
+    Each item describes a single (vendor, region, instance type, instance size) combination, i.e. exactly the values
+    expected by [`HfApi.create_inference_endpoint`].
+
+    Args:
+        id (`str`):
+            The unique identifier of the hardware configuration (e.g. `"aws-us-east-1-nvidia-l4-x1"`).
+        vendor (`str`):
+            The cloud vendor hosting the hardware (e.g. `"aws"`).
+        region (`str`):
+            The cloud region in which the hardware is available (e.g. `"us-east-1"`).
+        accelerator (`str`):
+            The hardware accelerator (e.g. `"cpu"`, `"gpu"`, `"neuron"`).
+        instance_type (`str`):
+            The cloud instance type (e.g. `"nvidia-l4"`).
+        instance_size (`str`):
+            The instance size (e.g. `"x1"`).
+        architecture (`str`):
+            A human-readable name of the hardware architecture (e.g. `"Nvidia L4"`).
+        status (`str`):
+            The availability of the hardware (e.g. `"available"`, `"not_available"`, `"deprecated"`).
+        price_per_hour (`float`):
+            The hourly price in USD.
+        num_accelerators (`int`):
+            The number of accelerators (GPUs, Neuron cores or vCPU-based units).
+        num_cpus (`int`, *optional*):
+            The number of vCPUs, if reported by the server.
+        memory_gb (`float`, *optional*):
+            The amount of RAM in GB, if reported by the server.
+        gpu_memory_gb (`int`, *optional*):
+            The total amount of GPU memory in GB. `None` for non-GPU hardware.
+        used_accelerators (`int`, *optional*):
+            The number of accelerators already used by the namespace. Only meaningful when listing hardware for a
+            specific namespace.
+        max_accelerators (`int`, *optional*):
+            The maximum number of accelerators the namespace is allowed to use. Only meaningful when listing hardware
+            for a specific namespace.
+        raw (`dict`):
+            The raw dictionary data returned from the API.
+
+    Example:
+        ```python
+        >>> from huggingface_hub import list_endpoint_hardware
+        >>> list_endpoint_hardware(vendor="aws", accelerator="gpu")[0]
+        EndpointHardware(id='aws-us-east-1-nvidia-l4-x1', vendor='aws', region='us-east-1', accelerator='gpu', instance_type='nvidia-l4', instance_size='x1', architecture='Nvidia L4', status='available', price_per_hour=0.8)
+        ```
+    """
+
+    # Fields in __repr__
+    id: str
+    vendor: str
+    region: str
+    accelerator: str
+    instance_type: str
+    instance_size: str
+    architecture: str
+    status: str
+    price_per_hour: float
+
+    # Other fields
+    num_accelerators: int = field(repr=False)
+    num_cpus: int | None = field(repr=False)
+    memory_gb: float | None = field(repr=False)
+    gpu_memory_gb: int | None = field(repr=False)
+    used_accelerators: int | None = field(repr=False)
+    max_accelerators: int | None = field(repr=False)
+
+    # Raw dict from the API
+    raw: dict = field(repr=False)
+
+    @classmethod
+    def from_raw(cls, raw: dict, *, vendor: str, region: str) -> "EndpointHardware":
+        """Initialize object from a raw compute dictionary, as returned by the `/v2/provider` API."""
+        quota = raw.get("quota") or {}
+        return cls(
+            id=raw["id"],
+            vendor=vendor,
+            region=region,
+            accelerator=raw["accelerator"],
+            instance_type=raw["instanceType"],
+            instance_size=raw["instanceSize"],
+            architecture=raw["architecture"],
+            status=raw["status"],
+            price_per_hour=raw["pricePerHour"],
+            num_accelerators=raw["numAccelerators"],
+            num_cpus=raw.get("numCpus"),
+            memory_gb=raw.get("memoryGb"),
+            gpu_memory_gb=raw.get("gpuMemoryGb"),
+            used_accelerators=quota.get("usedAccelerators"),
+            max_accelerators=quota.get("maxAccelerators"),
+            raw=raw,
+        )
+
+
+@dataclass
 class InferenceEndpoint:
     """
     Contains information about a deployed Inference Endpoint.

--- a/src/huggingface_hub/cli/inference_endpoints.py
+++ b/src/huggingface_hub/cli/inference_endpoints.py
@@ -1,7 +1,7 @@
 """CLI commands for Hugging Face Inference Endpoints."""
 
 import shlex
-from typing import Annotated
+from typing import Annotated, Any
 
 import click
 
@@ -79,6 +79,83 @@ def ls(
             }
         )
     out.table(results, id_key="name")
+
+
+@ie_cli.command(
+    "hardware",
+    examples=[
+        "hf endpoints hardware",
+        "hf endpoints hardware --vendor aws --accelerator gpu",
+    ],
+)
+def hardware(
+    vendor: Annotated[
+        str | None,
+        Option(help="Only list hardware hosted by this cloud vendor (e.g. 'aws')."),
+    ] = None,
+    region: Annotated[
+        str | None,
+        Option(help="Only list hardware available in this cloud region (e.g. 'us-east-1')."),
+    ] = None,
+    accelerator: Annotated[
+        str | None,
+        Option(help="Only list hardware with this accelerator (e.g. 'cpu', 'gpu', 'neuron')."),
+    ] = None,
+    instance_type: Annotated[
+        str | None,
+        Option(help="Only list hardware with this instance type (e.g. 'nvidia-l4')."),
+    ] = None,
+    include_unavailable: Annotated[
+        bool,
+        Option("--all", help="Also list deprecated and unavailable hardware."),
+    ] = False,
+    namespace: NamespaceOpt = None,
+    token: TokenOpt = None,
+) -> None:
+    """List the hardware available to deploy an Inference Endpoint."""
+    api = get_hf_api(token=token)
+    try:
+        hardware_list = api.list_endpoint_hardware(
+            namespace=namespace,
+            vendor=vendor,
+            region=region,
+            accelerator=accelerator,
+            instance_type=instance_type,
+            include_unavailable=include_unavailable,
+            token=token,
+        )
+    except HfHubHTTPError as error:
+        out.error(f"Hardware fetch failed: {error}")
+        raise click.exceptions.Exit(code=error.response.status_code) from error
+
+    # Quota is only meaningful for a namespace with a dedicated capacity: hide the column otherwise.
+    show_quota = any(hw.max_accelerators for hw in hardware_list)
+    items = []
+    for hw in hardware_list:
+        item: dict[str, Any] = {
+            "vendor": hw.vendor,
+            "region": hw.region,
+            "accelerator": hw.accelerator,
+            "instance type": hw.instance_type,
+            "instance size": hw.instance_size,
+            "gpu memory": f"{hw.gpu_memory_gb} GB" if hw.gpu_memory_gb else None,
+            "ram": f"{hw.memory_gb:g} GB" if hw.memory_gb else None,
+            "$/hour": hw.price_per_hour,
+        }
+        if include_unavailable:
+            item["status"] = hw.status
+        if show_quota:
+            item["quota"] = f"{hw.used_accelerators}/{hw.max_accelerators}"
+        items.append(item)
+    out.table(items, id_key="instance type")
+
+    if hardware_list:
+        example = hardware_list[0]
+        out.hint(
+            "Deploy with e.g. 'hf endpoints deploy my-endpoint --repo <repo> --framework <framework> "
+            f"--accelerator {example.accelerator} --vendor {example.vendor} --region {example.region} "
+            f"--instance-type {example.instance_type} --instance-size {example.instance_size}'."
+        )
 
 
 @ie_cli.command(name="deploy", examples=["hf endpoints deploy my-endpoint --repo gpt2 --framework pytorch ..."])
@@ -218,7 +295,11 @@ def deploy(
         ),
     ] = None,
 ) -> None:
-    """Deploy an Inference Endpoint from a Hub repository."""
+    """Deploy an Inference Endpoint from a Hub repository.
+
+    Run `hf endpoints hardware` to list the valid `--accelerator`, `--vendor`, `--region`, `--instance-type` and
+    `--instance-size` combinations.
+    """
     # --health-route and --port are container-level fields, and the only container payload this
     # command can build is the custom one, so they need --custom-image. Container command/args are
     # top-level model fields and apply to managed engine images too, so they are not gated.

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -65,7 +65,12 @@ from ._commit_api import (
 )
 from ._dataset_viewer import DatasetParquetEntry
 from ._eval_results import EvalResultEntry, parse_eval_result_entries
-from ._inference_endpoints import InferenceEndpoint, InferenceEndpointScalingMetric, InferenceEndpointType
+from ._inference_endpoints import (
+    EndpointHardware,
+    InferenceEndpoint,
+    InferenceEndpointScalingMetric,
+    InferenceEndpointType,
+)
 from ._jobs_api import (
     TERMINAL_JOB_STAGES,
     JobHardware,
@@ -9694,6 +9699,74 @@ class HfApi:
         hf_raise_for_status(response)
         return response.json()["models"]
 
+    def list_endpoint_hardware(
+        self,
+        *,
+        namespace: str | None = None,
+        vendor: str | None = None,
+        region: str | None = None,
+        accelerator: str | None = None,
+        instance_type: str | None = None,
+        include_unavailable: bool = False,
+        token: bool | str | None = None,
+    ) -> list[EndpointHardware]:
+        """List the hardware configurations available for Inference Endpoints.
+
+        Use this to discover the `vendor`, `region`, `accelerator`, `instance_type` and `instance_size` values
+        accepted by [`create_inference_endpoint`].
+
+        Args:
+            namespace (`str`, *optional*):
+                The namespace to list hardware for. If provided, the returned quota values reflect the actual usage
+                and limits of that namespace. Defaults to listing the hardware catalog without quota information.
+            vendor (`str`, *optional*):
+                Only return hardware hosted by this cloud vendor (e.g. `"aws"`).
+            region (`str`, *optional*):
+                Only return hardware available in this cloud region (e.g. `"us-east-1"`).
+            accelerator (`str`, *optional*):
+                Only return hardware with this accelerator (e.g. `"cpu"`, `"gpu"`, `"neuron"`).
+            instance_type (`str`, *optional*):
+                Only return hardware with this instance type (e.g. `"nvidia-l4"`).
+            include_unavailable (`bool`, *optional*):
+                Whether to also return hardware that is deprecated or not available. Defaults to `False`.
+            token (`bool` or `str`, *optional*):
+                A valid user access token (string). Defaults to the locally saved
+                token, which is the recommended method for authentication (see
+                https://huggingface.co/docs/huggingface_hub/quick-start#authentication).
+                To disable authentication, pass `False`.
+
+        Returns:
+            list[`EndpointHardware`]: A list of available hardware configurations.
+
+        Example:
+        ```python
+        >>> from huggingface_hub import list_endpoint_hardware
+        >>> list_endpoint_hardware(vendor="aws", accelerator="gpu")[0]
+        EndpointHardware(id='aws-us-east-1-nvidia-l4-x1', vendor='aws', region='us-east-1', accelerator='gpu', instance_type='nvidia-l4', instance_size='x1', architecture='Nvidia L4', status='available', price_per_hour=0.8)
+        ```
+        """
+        path = f"{constants.INFERENCE_ENDPOINTS_ENDPOINT}/provider"
+        if namespace is not None:
+            path += f"/{namespace}"
+        response = get_session().get(path, headers=self._build_hf_headers(token=token))
+        hf_raise_for_status(response)
+
+        hardware = [
+            EndpointHardware.from_raw(compute, vendor=vendor_item["name"], region=region_item["name"])
+            for vendor_item in response.json()["vendors"]
+            for region_item in vendor_item["regions"]
+            for compute in region_item["computes"]
+        ]
+        return [
+            item
+            for item in hardware
+            if (include_unavailable or item.status == "available")
+            and (vendor is None or item.vendor == vendor)
+            and (region is None or item.region == region)
+            and (accelerator is None or item.accelerator == accelerator)
+            and (instance_type is None or item.instance_type == instance_type)
+        ]
+
     def get_inference_endpoint(
         self, name: str, *, namespace: str | None = None, token: bool | str | None = None
     ) -> InferenceEndpoint:
@@ -15167,6 +15240,7 @@ resume_inference_endpoint = api.resume_inference_endpoint
 scale_to_zero_inference_endpoint = api.scale_to_zero_inference_endpoint
 create_inference_endpoint_from_catalog = api.create_inference_endpoint_from_catalog
 list_inference_catalog = api.list_inference_catalog
+list_endpoint_hardware = api.list_endpoint_hardware
 
 # Collections API
 get_collection = api.get_collection

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,6 +14,7 @@ from click.testing import CliRunner
 
 from huggingface_hub import HfApi, constants
 from huggingface_hub._dataset_viewer import DatasetParquetEntry
+from huggingface_hub._inference_endpoints import EndpointHardware
 from huggingface_hub._jobs_api import JobInfo, JobOwner, _create_job_spec, _derive_job_volume_name
 from huggingface_hub._space_api import Volume
 from huggingface_hub.cli import _skills, system
@@ -2967,6 +2968,78 @@ class TestInferenceEndpointsCommands:
         api.list_inference_catalog.assert_called_once_with(token=None)
         assert '"models"' in result.stdout
         assert '"model"' in result.stdout
+
+    def test_hardware(self, runner: CliRunner) -> None:
+        hardware = EndpointHardware.from_raw(
+            {
+                "id": "aws-us-east-1-nvidia-l4-x1",
+                "accelerator": "gpu",
+                "numAccelerators": 1,
+                "numCpus": 8,
+                "memoryGb": 30.0,
+                "gpuMemoryGb": 24,
+                "instanceType": "nvidia-l4",
+                "instanceSize": "x1",
+                "architecture": "Nvidia L4",
+                "status": "available",
+                "pricePerHour": 0.8,
+                "quota": {"maxAccelerators": 0, "usedAccelerators": 0},
+            },
+            vendor="aws",
+            region="us-east-1",
+        )
+        with patch("huggingface_hub.cli.inference_endpoints.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            api.list_endpoint_hardware.return_value = [hardware]
+            result = runner.invoke(app, ["endpoints", "hardware", "--accelerator", "gpu", "--format", "json"])
+        assert result.exit_code == 0
+        api_cls.assert_called_once_with(token=None)
+        api.list_endpoint_hardware.assert_called_once_with(
+            namespace=None,
+            vendor=None,
+            region=None,
+            accelerator="gpu",
+            instance_type=None,
+            include_unavailable=False,
+            token=None,
+        )
+        output = json.loads(result.stdout)
+        assert output == [
+            {
+                "vendor": "aws",
+                "region": "us-east-1",
+                "accelerator": "gpu",
+                "instance type": "nvidia-l4",
+                "instance size": "x1",
+                "gpu memory": "24 GB",
+                "ram": "30 GB",
+                "$/hour": 0.8,
+            }
+        ]
+
+    def test_hardware_human_output_with_quota(self, runner: CliRunner) -> None:
+        hardware = Mock(
+            vendor="aws",
+            region="us-east-1",
+            accelerator="gpu",
+            instance_type="nvidia-l4",
+            instance_size="x1",
+            gpu_memory_gb=24,
+            memory_gb=30.0,
+            price_per_hour=0.8,
+            status="available",
+            used_accelerators=1,
+            max_accelerators=4,
+        )
+        with patch("huggingface_hub.cli.inference_endpoints.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            api.list_endpoint_hardware.return_value = [hardware]
+            result = runner.invoke(app, ["endpoints", "hardware", "--namespace", "my-org", "--format", "human"])
+        assert result.exit_code == 0
+        assert "INSTANCE TYPE" in result.stdout
+        assert "nvidia-l4" in result.stdout
+        assert "QUOTA" in result.stdout
+        assert "1/4" in result.stdout
 
 
 @contextmanager

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -52,6 +52,7 @@ from huggingface_hub.hf_api import (
     CommitInfo,
     DatasetInfo,
     DatasetLeaderboardEntry,
+    EndpointHardware,
     ExpandDatasetProperty_T,
     ExpandModelProperty_T,
     ExpandSpaceProperty_T,
@@ -4671,6 +4672,132 @@ class TestHfApiInferenceCatalog:
             api.create_inference_endpoint_from_catalog(
                 repo_id="meta-llama/Llama-3.2-3B-Instruct", namespace="Wauplin", token=False
             )
+
+
+def _compute(vendor: str, region: str, instance_type: str, instance_size: str, **kwargs) -> dict:
+    return {
+        "id": f"{vendor}-{region}-{instance_type}-{instance_size}",
+        "accelerator": "gpu",
+        "numAccelerators": 1,
+        "numCpus": 8,
+        "memoryGb": 30.0,
+        "gpuMemoryGb": 24,
+        "instanceType": instance_type,
+        "instanceSize": instance_size,
+        "architecture": "Nvidia L4",
+        "status": "available",
+        "pricePerHour": 0.8,
+        "quota": {"maxAccelerators": 4, "usedAccelerators": 1},
+        **kwargs,
+    }
+
+
+PROVIDER_RESPONSE = {
+    "vendors": [
+        {
+            "name": "aws",
+            "status": "available",
+            "regions": [
+                {
+                    "name": "us-east-1",
+                    "label": "N. Virginia (us-east-1)",
+                    "status": "available",
+                    "computes": [
+                        _compute("aws", "us-east-1", "nvidia-l4", "x1"),
+                        _compute("aws", "us-east-1", "nvidia-t4", "x1", status="deprecated"),
+                    ],
+                },
+                {
+                    "name": "eu-west-1",
+                    "label": "Dublin (eu-west-1)",
+                    "status": "available",
+                    "computes": [
+                        _compute(
+                            "aws", "eu-west-1", "intel-spr", "x1", accelerator="cpu", gpuMemoryGb=None, quota=None
+                        )
+                    ],
+                },
+            ],
+        },
+        {
+            "name": "gcp",
+            "status": "available",
+            "regions": [
+                {
+                    "name": "us-east4",
+                    "label": "Virginia (us-east4)",
+                    "status": "available",
+                    "computes": [_compute("gcp", "us-east4", "nvidia-l4", "x4")],
+                },
+            ],
+        },
+    ]
+}
+
+
+class TestHfApiEndpointHardware:
+    @pytest.fixture
+    def mock_get(self, mocker) -> Mock:
+        mock_get_session = mocker.patch("huggingface_hub.hf_api.get_session")
+        mock_get_session.return_value.get.return_value.json.return_value = PROVIDER_RESPONSE
+        return mock_get_session.return_value.get
+
+    def test_list_endpoint_hardware(self, api: HfApi, mock_get: Mock) -> None:
+        hardware = api.list_endpoint_hardware()
+
+        assert mock_get.call_args[0][0] == "https://api.endpoints.huggingface.cloud/v2/provider"
+
+        # Deprecated/unavailable hardware is filtered out by default.
+        assert [hw.id for hw in hardware] == [
+            "aws-us-east-1-nvidia-l4-x1",
+            "aws-eu-west-1-intel-spr-x1",
+            "gcp-us-east4-nvidia-l4-x4",
+        ]
+
+        hardware_item = hardware[0]
+        assert isinstance(hardware_item, EndpointHardware)
+        assert hardware_item.vendor == "aws"
+        assert hardware_item.region == "us-east-1"
+        assert hardware_item.accelerator == "gpu"
+        assert hardware_item.instance_type == "nvidia-l4"
+        assert hardware_item.instance_size == "x1"
+        assert hardware_item.architecture == "Nvidia L4"
+        assert hardware_item.status == "available"
+        assert hardware_item.price_per_hour == 0.8
+        assert hardware_item.num_accelerators == 1
+        assert hardware_item.num_cpus == 8
+        assert hardware_item.memory_gb == 30.0
+        assert hardware_item.gpu_memory_gb == 24
+        assert hardware_item.used_accelerators == 1
+        assert hardware_item.max_accelerators == 4
+
+        # A missing quota (e.g. unauthenticated call) is not an error.
+        assert hardware[1].used_accelerators is None
+        assert hardware[1].max_accelerators is None
+
+    def test_list_endpoint_hardware_include_unavailable(self, api: HfApi, mock_get: Mock) -> None:
+        hardware = api.list_endpoint_hardware(include_unavailable=True)
+        assert [hw.id for hw in hardware] == [
+            "aws-us-east-1-nvidia-l4-x1",
+            "aws-us-east-1-nvidia-t4-x1",
+            "aws-eu-west-1-intel-spr-x1",
+            "gcp-us-east4-nvidia-l4-x4",
+        ]
+
+    def test_list_endpoint_hardware_filters(self, api: HfApi, mock_get: Mock) -> None:
+        assert [hw.id for hw in api.list_endpoint_hardware(vendor="gcp")] == ["gcp-us-east4-nvidia-l4-x4"]
+        assert [hw.id for hw in api.list_endpoint_hardware(region="eu-west-1")] == ["aws-eu-west-1-intel-spr-x1"]
+        assert [hw.id for hw in api.list_endpoint_hardware(accelerator="cpu")] == ["aws-eu-west-1-intel-spr-x1"]
+        assert [hw.id for hw in api.list_endpoint_hardware(instance_type="nvidia-l4")] == [
+            "aws-us-east-1-nvidia-l4-x1",
+            "gcp-us-east4-nvidia-l4-x4",
+        ]
+        assert api.list_endpoint_hardware(vendor="gcp", accelerator="cpu") == []
+
+    def test_list_endpoint_hardware_with_namespace(self, api: HfApi, mock_get: Mock) -> None:
+        # Quota values are only meaningful when scoped to a namespace.
+        api.list_endpoint_hardware(namespace="Wauplin")
+        assert mock_get.call_args[0][0] == "https://api.endpoints.huggingface.cloud/v2/provider/Wauplin"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
[Inference Endpoints] Add `hf endpoints hardware` to list available instances

## Testing

6 new tests. tests/test_hf_api.py::TestHfApiEndpointHardware (4): parsing of the /v2/provider payload into EndpointHardware, default filtering of deprecated/unavailable hardware, include_unavailable=True, the vendor/region/accelerator/instance_type filters, and that a namespace routes to /v2/provider/{namespace}. tests/test_cli.py::TestInferenceEndpointsCommands::test_hardware and ::test_hardware_human_output_with_quota: the CLI forwards every filter flag to the API and renders the JSON rows plus the human table with the QUOTA column. All 6 fail before the change (EndpointHardware / list_endpoint_hardware / the `hardware` subcommand do not exist).

Added tests fail on the current code and pass with this change; the relevant suite was run locally.

Closes #4638

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive read-only API and CLI surface with tests; no changes to endpoint create/update/delete behavior.
> 
> **Overview**
> Adds **Inference Endpoint hardware discovery** so deploy flows no longer depend on external Swagger docs for valid `vendor` / `region` / `accelerator` / `instance-type` / `instance-size` tuples.
> 
> The Python API introduces **`EndpointHardware`** and **`list_endpoint_hardware`**, which call `/v2/provider` (optionally `/v2/provider/{namespace}` for quota), flatten the nested vendor/region/compute payload, and filter by the same dimensions as **`create_inference_endpoint`**. Unavailable/deprecated SKUs are omitted unless **`include_unavailable=True`** (CLI: **`--all`**).
> 
> The CLI adds **`hf endpoints hardware`** with matching filters, a tabular view (optional **quota** and **status** columns), and a deploy hint; **`hf endpoints deploy`** docs now point users at this command. Guides and package reference are updated accordingly, with API and CLI tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d944b2a325e63ac1b9d3120c3a888e6940f9972. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->