### PR TITLE
[Inference Endpoints] Support managed engine images in `custom_image`

### DIFF
--- a/docs/source/en/guides/inference_endpoints.md
+++ b/docs/source/en/guides/inference_endpoints.md
@@ -100,6 +100,24 @@ By default the Inference Endpoint is built from a docker image provided by Huggi
 
 The value to pass as `custom_image` is a dictionary containing a url to the docker container and configuration to run it. For more details about it, checkout the [Swagger documentation](https://api.endpoints.huggingface.cloud/#/v2%3A%3Aendpoint/create_endpoint).
 
+`custom_image` also accepts the managed engine images maintained by Hugging Face, by keying the dictionary with the engine name instead of describing a container. The supported keys are listed in `constants.INFERENCE_ENDPOINT_IMAGE_KEYS` (`vLLM`, `sGLang`, `tgi`, `tei`, `llamacpp`, ...):
+
+```python
+# Start an Inference Endpoint running the managed vLLM image
+>>> endpoint = create_inference_endpoint(
+...     "llama-3-1-8b-instruct-vllm",
+...     repository="meta-llama/Llama-3.1-8B-Instruct",
+...     framework="pytorch",
+...     task="text-generation",
+...     accelerator="gpu",
+...     vendor="aws",
+...     region="us-east-1",
+...     instance_size="x1",
+...     instance_type="nvidia-a10g",
+...     custom_image={"vLLM": {}},
+... )
+```
+
 For containers that need a custom entrypoint or runtime flags, pass `container_command` and/or `container_args` (each a list of tokens). They map to `model.command` and `model.args` in the API payload. They are not tied to custom images: managed engine images (e.g. vLLM, SGLang) accept engine flags through `container_args` as well. The same is available from the CLI via `hf endpoints deploy ... --container-command "..." --container-args "..."`.
 
 ### Get or list existing Inference Endpoints

--- a/docs/source/en/guides/inference_endpoints.md
+++ b/docs/source/en/guides/inference_endpoints.md
@@ -100,7 +100,7 @@ By default the Inference Endpoint is built from a docker image provided by Huggi
 
 The value to pass as `custom_image` is a dictionary containing a url to the docker container and configuration to run it. For more details about it, checkout the [Swagger documentation](https://api.endpoints.huggingface.cloud/#/v2%3A%3Aendpoint/create_endpoint).
 
-`custom_image` also accepts the engine images managed by Hugging Face, by keying the dictionary with the engine name instead of leaving it flat. The supported keys are listed in `constants.INFERENCE_ENDPOINT_IMAGE_KEYS` (`vLLM`, `sGLang`, `tgi`, `tei`, `llamacpp`, ...) and each engine takes its own tuning options on top of the container ones:
+`custom_image` also accepts the engine-specific container types supported by the API, by keying the dictionary with the engine name (`vLLM`, `vLLMNeuron`, `sGLang`, `tgi`, `tgiNeuron`, `tei`, `llamacpp`, `hfServe`, ...) instead of leaving it flat. Each engine takes the usual container fields (`url`, `port`, `healthRoute`) plus its own tuning options. Any dict without a top-level `url` is forwarded to the API untouched, so engines added to the API later work without upgrading `huggingface_hub`:
 
 ```python
 # Start an Inference Endpoint running the vLLM engine image

--- a/docs/source/en/guides/inference_endpoints.md
+++ b/docs/source/en/guides/inference_endpoints.md
@@ -100,10 +100,10 @@ By default the Inference Endpoint is built from a docker image provided by Huggi
 
 The value to pass as `custom_image` is a dictionary containing a url to the docker container and configuration to run it. For more details about it, checkout the [Swagger documentation](https://api.endpoints.huggingface.cloud/#/v2%3A%3Aendpoint/create_endpoint).
 
-`custom_image` also accepts the managed engine images maintained by Hugging Face, by keying the dictionary with the engine name instead of describing a container. The supported keys are listed in `constants.INFERENCE_ENDPOINT_IMAGE_KEYS` (`vLLM`, `sGLang`, `tgi`, `tei`, `llamacpp`, ...):
+`custom_image` also accepts the engine images managed by Hugging Face, by keying the dictionary with the engine name instead of leaving it flat. The supported keys are listed in `constants.INFERENCE_ENDPOINT_IMAGE_KEYS` (`vLLM`, `sGLang`, `tgi`, `tei`, `llamacpp`, ...) and each engine takes its own tuning options on top of the container ones:
 
 ```python
-# Start an Inference Endpoint running the managed vLLM image
+# Start an Inference Endpoint running the vLLM engine image
 >>> endpoint = create_inference_endpoint(
 ...     "llama-3-1-8b-instruct-vllm",
 ...     repository="meta-llama/Llama-3.1-8B-Instruct",
@@ -113,10 +113,19 @@ The value to pass as `custom_image` is a dictionary containing a url to the dock
 ...     vendor="aws",
 ...     region="us-east-1",
 ...     instance_size="x1",
-...     instance_type="nvidia-a10g",
-...     custom_image={"vLLM": {}},
+...     instance_type="nvidia-l4",
+...     custom_image={
+...         "vLLM": {
+...             "url": "vllm/vllm-openai:v0.23.0",
+...             "healthRoute": "/health",
+...             "port": 8000,
+...             "tensorParallelSize": 1,
+...         }
+...     },
 ... )
 ```
+
+Without the engine key, the same dictionary is sent as a plain custom container, so the engine-specific options (here `tensorParallelSize`) are dropped.
 
 For containers that need a custom entrypoint or runtime flags, pass `container_command` and/or `container_args` (each a list of tokens). They map to `model.command` and `model.args` in the API payload. They are not tied to custom images: managed engine images (e.g. vLLM, SGLang) accept engine flags through `container_args` as well. The same is available from the CLI via `hf endpoints deploy ... --container-command "..." --container-args "..."`.
 

--- a/src/huggingface_hub/_inference_endpoints.py
+++ b/src/huggingface_hub/_inference_endpoints.py
@@ -303,9 +303,9 @@ class InferenceEndpoint:
                 The task on which to deploy the model (e.g. `"text-classification"`).
             custom_image (`dict`, *optional*):
                 The container image to run. Either a dict keyed by engine to select a managed image (e.g.
-                `{"vLLM": {}}`, `{"tgi": {...}}`, one of `constants.INFERENCE_ENDPOINT_IMAGE_KEYS`), or a flat
-                dict describing a custom container (e.g. `{"url": ..., "port": ...}`), which is sent as
-                `{"custom": ...}`.
+                `{"vLLM": {"url": "vllm/vllm-openai:v0.23.0", "port": 8000}}`, one of
+                `constants.INFERENCE_ENDPOINT_IMAGE_KEYS`), or a flat dict describing a custom container
+                (e.g. `{"url": ..., "port": ...}`), which is sent as `{"custom": ...}`.
             container_command (`list[str]`, *optional*):
                 Override the container entrypoint command (maps to `model.command` in the API payload). Works with
                 both managed engine images (e.g. vLLM, SGLang) and custom images.

--- a/src/huggingface_hub/_inference_endpoints.py
+++ b/src/huggingface_hub/_inference_endpoints.py
@@ -302,8 +302,10 @@ class InferenceEndpoint:
             task (`str`, *optional*):
                 The task on which to deploy the model (e.g. `"text-classification"`).
             custom_image (`dict`, *optional*):
-                A custom Docker image to use for the Inference Endpoint. This is useful if you want to deploy an
-                Inference Endpoint running on the `text-generation-inference` (TGI) framework (see examples).
+                The container image to run. Either a dict keyed by engine to select a managed image (e.g.
+                `{"vLLM": {}}`, `{"tgi": {...}}`, one of `constants.INFERENCE_ENDPOINT_IMAGE_KEYS`), or a flat
+                dict describing a custom container (e.g. `{"url": ..., "port": ...}`), which is sent as
+                `{"custom": ...}`.
             container_command (`list[str]`, *optional*):
                 Override the container entrypoint command (maps to `model.command` in the API payload). Works with
                 both managed engine images (e.g. vLLM, SGLang) and custom images.

--- a/src/huggingface_hub/_inference_endpoints.py
+++ b/src/huggingface_hub/_inference_endpoints.py
@@ -302,10 +302,10 @@ class InferenceEndpoint:
             task (`str`, *optional*):
                 The task on which to deploy the model (e.g. `"text-classification"`).
             custom_image (`dict`, *optional*):
-                The container image to run. Either a dict keyed by engine to select a managed image (e.g.
-                `{"vLLM": {"url": "vllm/vllm-openai:v0.23.0", "port": 8000}}`, one of
-                `constants.INFERENCE_ENDPOINT_IMAGE_KEYS`), or a flat dict describing a custom container
-                (e.g. `{"url": ..., "port": ...}`), which is sent as `{"custom": ...}`.
+                The container image to run. Either a dict keyed by image variant (e.g.
+                `{"vLLM": {"url": "vllm/vllm-openai:v0.23.0", "port": 8000}}`, also `sGLang`, `tgi`, `tei`,
+                `llamacpp`, `hfServe`, ...), which is forwarded as-is, or a flat dict describing a custom
+                container (e.g. `{"url": ..., "port": ...}`), which is sent as `{"custom": ...}`.
             container_command (`list[str]`, *optional*):
                 Override the container entrypoint command (maps to `model.command` in the API payload). Works with
                 both managed engine images (e.g. vLLM, SGLang) and custom images.

--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -102,22 +102,6 @@ INFERENCE_ENDPOINT = os.environ.get("HF_INFERENCE_ENDPOINT", "https://api-infere
 INFERENCE_ENDPOINTS_ENDPOINT = "https://api.endpoints.huggingface.cloud/v2"
 INFERENCE_CATALOG_ENDPOINT = "https://endpoints.huggingface.co/api/catalog"
 
-# Variants of the `model.image` union, i.e. the managed engine images plus `custom`.
-# See https://api.endpoints.huggingface.cloud/#post-/v2/endpoint/-namespace-
-INFERENCE_ENDPOINT_IMAGE_KEYS = [
-    "custom",
-    "hfServe",
-    "huggingface",
-    "huggingfaceNeuron",
-    "llamacpp",
-    "sGLang",
-    "tei",
-    "tgi",
-    "tgiNeuron",
-    "vLLM",
-    "vLLMNeuron",
-]
-
 # Proxy for third-party providers
 INFERENCE_PROXY_TEMPLATE = "https://router.huggingface.co/{provider}"
 

--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -102,15 +102,20 @@ INFERENCE_ENDPOINT = os.environ.get("HF_INFERENCE_ENDPOINT", "https://api-infere
 INFERENCE_ENDPOINTS_ENDPOINT = "https://api.endpoints.huggingface.cloud/v2"
 INFERENCE_CATALOG_ENDPOINT = "https://endpoints.huggingface.co/api/catalog"
 
+# Variants of the `model.image` union, i.e. the managed engine images plus `custom`.
 # See https://api.endpoints.huggingface.cloud/#post-/v2/endpoint/-namespace-
 INFERENCE_ENDPOINT_IMAGE_KEYS = [
     "custom",
+    "hfServe",
     "huggingface",
     "huggingfaceNeuron",
     "llamacpp",
+    "sGLang",
     "tei",
     "tgi",
     "tgiNeuron",
+    "vLLM",
+    "vLLMNeuron",
 ]
 
 # Proxy for third-party providers

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -754,6 +754,17 @@ def _resolve_copy_target_path(
     return f"{destination_path.rstrip('/')}/{rel_path}"
 
 
+def _build_endpoint_image_payload(custom_image: dict) -> dict:
+    """Build the `model.image` payload of an Inference Endpoint from a user-provided image dict.
+
+    Already-keyed dicts (e.g. `{"vLLM": {...}}`, `{"tgi": {...}}`) are forwarded as-is, anything else is
+    assumed to describe a custom container and is wrapped in `{"custom": ...}`.
+    """
+    if next(iter(custom_image), None) in constants.INFERENCE_ENDPOINT_IMAGE_KEYS:
+        return custom_image
+    return {"custom": custom_image}
+
+
 @dataclass
 class RepoSibling:
     """
@@ -9412,9 +9423,10 @@ class HfApi:
             task (`str`, *optional*):
                 The task on which to deploy the model (e.g. `"text-classification"`).
             custom_image (`dict`, *optional*):
-                A custom Docker image to use for the Inference Endpoint. This is useful if you want to deploy an
-                Inference Endpoint running on the `text-generation-inference` (TGI) framework or a custom container
-                (see examples).
+                The container image to run. Either a dict keyed by engine to select a managed image (e.g.
+                `{"vLLM": {}}`, `{"tgi": {...}}`, one of `constants.INFERENCE_ENDPOINT_IMAGE_KEYS`), or a flat
+                dict describing a custom container (e.g. `{"url": ..., "port": ...}`), which is sent as
+                `{"custom": ...}` (see examples). Defaults to the Hugging Face managed image.
             container_command (`list[str]`, *optional*):
                 Override the container entrypoint command (maps to `model.command` in the API payload). Works with
                 both managed engine images (e.g. vLLM, SGLang) and custom images.
@@ -9536,14 +9548,7 @@ class HfApi:
                 FutureWarning,
             )
 
-        if custom_image is not None:
-            image = (
-                custom_image
-                if next(iter(custom_image)) in constants.INFERENCE_ENDPOINT_IMAGE_KEYS
-                else {"custom": custom_image}
-            )
-        else:
-            image = {"huggingface": {}}
+        image = _build_endpoint_image_payload(custom_image) if custom_image is not None else {"huggingface": {}}
 
         payload: dict = {
             "accountId": account_id,
@@ -9811,8 +9816,10 @@ class HfApi:
             task (`str`, *optional*):
                 The task on which to deploy the model (e.g. `"text-classification"`).
             custom_image (`dict`, *optional*):
-                A custom Docker image to use for the Inference Endpoint. This is useful if you want to deploy an
-                Inference Endpoint running on the `text-generation-inference` (TGI) framework (see examples).
+                The container image to run. Either a dict keyed by engine to select a managed image (e.g.
+                `{"vLLM": {}}`, `{"tgi": {...}}`, one of `constants.INFERENCE_ENDPOINT_IMAGE_KEYS`), or a flat
+                dict describing a custom container (e.g. `{"url": ..., "port": ...}`), which is sent as
+                `{"custom": ...}`.
             container_command (`list[str]`, *optional*):
                 Override the container entrypoint command (maps to `model.command` in the API payload). Works with
                 both managed engine images (e.g. vLLM, SGLang) and custom images.
@@ -9872,7 +9879,7 @@ class HfApi:
         if task is not None:
             payload["model"]["task"] = task
         if custom_image is not None:
-            payload["model"]["image"] = {"custom": custom_image}
+            payload["model"]["image"] = _build_endpoint_image_payload(custom_image)
         if container_command is not None:
             payload["model"]["command"] = container_command
         if container_args is not None:

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -9424,9 +9424,9 @@ class HfApi:
                 The task on which to deploy the model (e.g. `"text-classification"`).
             custom_image (`dict`, *optional*):
                 The container image to run. Either a dict keyed by engine to select a managed image (e.g.
-                `{"vLLM": {}}`, `{"tgi": {...}}`, one of `constants.INFERENCE_ENDPOINT_IMAGE_KEYS`), or a flat
-                dict describing a custom container (e.g. `{"url": ..., "port": ...}`), which is sent as
-                `{"custom": ...}` (see examples). Defaults to the Hugging Face managed image.
+                `{"vLLM": {"url": "vllm/vllm-openai:v0.23.0", "port": 8000}}`, one of
+                `constants.INFERENCE_ENDPOINT_IMAGE_KEYS`), or a flat dict describing a custom container
+                (e.g. `{"url": ..., "port": ...}`), which is sent as `{"custom": ...}` (see examples). Defaults to the Hugging Face managed image.
             container_command (`list[str]`, *optional*):
                 Override the container entrypoint command (maps to `model.command` in the API payload). Works with
                 both managed engine images (e.g. vLLM, SGLang) and custom images.
@@ -9817,9 +9817,9 @@ class HfApi:
                 The task on which to deploy the model (e.g. `"text-classification"`).
             custom_image (`dict`, *optional*):
                 The container image to run. Either a dict keyed by engine to select a managed image (e.g.
-                `{"vLLM": {}}`, `{"tgi": {...}}`, one of `constants.INFERENCE_ENDPOINT_IMAGE_KEYS`), or a flat
-                dict describing a custom container (e.g. `{"url": ..., "port": ...}`), which is sent as
-                `{"custom": ...}`.
+                `{"vLLM": {"url": "vllm/vllm-openai:v0.23.0", "port": 8000}}`, one of
+                `constants.INFERENCE_ENDPOINT_IMAGE_KEYS`), or a flat dict describing a custom container
+                (e.g. `{"url": ..., "port": ...}`), which is sent as `{"custom": ...}`.
             container_command (`list[str]`, *optional*):
                 Override the container entrypoint command (maps to `model.command` in the API payload). Works with
                 both managed engine images (e.g. vLLM, SGLang) and custom images.

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -757,14 +757,10 @@ def _resolve_copy_target_path(
 def _build_endpoint_image_payload(custom_image: dict) -> dict:
     """Build the `model.image` payload of an Inference Endpoint from a user-provided image dict.
 
-    `model.image` is a union keyed by image variant (`{"vLLM": {...}}`, `{"tgi": {...}}`, `{"custom": {...}}`,
-    ...). A flat container dict always carries `url` (required server-side by every variant but `huggingface`)
-    and no variant is named `url`, so it is the discriminator: dicts with a top-level `url` describe a custom
-    container and get wrapped in `{"custom": ...}`, anything else is already keyed and is forwarded as-is.
-
-    Forwarding unknown keys instead of allow-listing them keeps new engine variants working without a release,
-    and lets the server report a typo (e.g. `vllm` instead of `vLLM`) rather than silently turning it into a
-    malformed custom container.
+    `model.image` is a union keyed by variant (`{"vLLM": {...}}`, `{"custom": {...}}`, ...). Only a flat
+    container dict has a top-level `url` (required server-side, and no variant is named `url`), so dicts with
+    one are wrapped in `{"custom": ...}`. Everything else is forwarded as-is, so variants added to the API
+    later work without a release.
     """
     if "url" in custom_image:
         return {"custom": custom_image}

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -757,12 +757,18 @@ def _resolve_copy_target_path(
 def _build_endpoint_image_payload(custom_image: dict) -> dict:
     """Build the `model.image` payload of an Inference Endpoint from a user-provided image dict.
 
-    Already-keyed dicts (e.g. `{"vLLM": {...}}`, `{"tgi": {...}}`) are forwarded as-is, anything else is
-    assumed to describe a custom container and is wrapped in `{"custom": ...}`.
+    `model.image` is a union keyed by image variant (`{"vLLM": {...}}`, `{"tgi": {...}}`, `{"custom": {...}}`,
+    ...). A flat container dict always carries `url` (required server-side by every variant but `huggingface`)
+    and no variant is named `url`, so it is the discriminator: dicts with a top-level `url` describe a custom
+    container and get wrapped in `{"custom": ...}`, anything else is already keyed and is forwarded as-is.
+
+    Forwarding unknown keys instead of allow-listing them keeps new engine variants working without a release,
+    and lets the server report a typo (e.g. `vllm` instead of `vLLM`) rather than silently turning it into a
+    malformed custom container.
     """
-    if next(iter(custom_image), None) in constants.INFERENCE_ENDPOINT_IMAGE_KEYS:
-        return custom_image
-    return {"custom": custom_image}
+    if "url" in custom_image:
+        return {"custom": custom_image}
+    return custom_image
 
 
 @dataclass
@@ -9423,10 +9429,11 @@ class HfApi:
             task (`str`, *optional*):
                 The task on which to deploy the model (e.g. `"text-classification"`).
             custom_image (`dict`, *optional*):
-                The container image to run. Either a dict keyed by engine to select a managed image (e.g.
-                `{"vLLM": {"url": "vllm/vllm-openai:v0.23.0", "port": 8000}}`, one of
-                `constants.INFERENCE_ENDPOINT_IMAGE_KEYS`), or a flat dict describing a custom container
-                (e.g. `{"url": ..., "port": ...}`), which is sent as `{"custom": ...}` (see examples). Defaults to the Hugging Face managed image.
+                The container image to run. Either a dict keyed by image variant (e.g.
+                `{"vLLM": {"url": "vllm/vllm-openai:v0.23.0", "port": 8000}}`, also `sGLang`, `tgi`, `tei`,
+                `llamacpp`, `hfServe`, ...), which is forwarded as-is, or a flat dict describing a custom
+                container (e.g. `{"url": ..., "port": ...}`), which is sent as `{"custom": ...}` (see examples).
+                Defaults to the Hugging Face managed image.
             container_command (`list[str]`, *optional*):
                 Override the container entrypoint command (maps to `model.command` in the API payload). Works with
                 both managed engine images (e.g. vLLM, SGLang) and custom images.
@@ -9816,10 +9823,10 @@ class HfApi:
             task (`str`, *optional*):
                 The task on which to deploy the model (e.g. `"text-classification"`).
             custom_image (`dict`, *optional*):
-                The container image to run. Either a dict keyed by engine to select a managed image (e.g.
-                `{"vLLM": {"url": "vllm/vllm-openai:v0.23.0", "port": 8000}}`, one of
-                `constants.INFERENCE_ENDPOINT_IMAGE_KEYS`), or a flat dict describing a custom container
-                (e.g. `{"url": ..., "port": ...}`), which is sent as `{"custom": ...}`.
+                The container image to run. Either a dict keyed by image variant (e.g.
+                `{"vLLM": {"url": "vllm/vllm-openai:v0.23.0", "port": 8000}}`, also `sGLang`, `tgi`, `tei`,
+                `llamacpp`, `hfServe`, ...), which is forwarded as-is, or a flat dict describing a custom
+                container (e.g. `{"url": ..., "port": ...}`), which is sent as `{"custom": ...}`.
             container_command (`list[str]`, *optional*):
                 Override the container entrypoint command (maps to `model.command` in the API payload). Works with
                 both managed engine images (e.g. vLLM, SGLang) and custom images.

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -67,6 +67,7 @@ from huggingface_hub.hf_api import (
     User,
     WebhookInfo,
     WebhookWatchedItem,
+    _build_endpoint_image_payload,
     repo_type_and_id_from_hf_id,
 )
 from huggingface_hub.repocard_data import DatasetCardData, ModelCardData
@@ -4676,178 +4677,86 @@ class TestHfApiInferenceCatalog:
 @pytest.mark.parametrize(
     "custom_image, expected_image_payload",
     [
-        # Case 1: No custom_image provided
+        # A flat dict describes a custom container: it carries `url`, which no image variant is named after.
         (
-            None,
-            {
-                "huggingface": {},
-            },
+            {"url": "my.registry/my-image:latest", "port": 8080},
+            {"custom": {"url": "my.registry/my-image:latest", "port": 8080}},
         ),
-        # Case 2: Flat dictionary custom_image provided
+        # An explicitly keyed custom container is forwarded as-is, not wrapped a second time.
         (
-            {
-                "url": "my.registry/my-image:latest",
-                "port": 8080,
-            },
-            {
-                "custom": {
-                    "url": "my.registry/my-image:latest",
-                    "port": 8080,
-                }
-            },
+            {"custom": {"url": "another.registry/custom:v2"}},
+            {"custom": {"url": "another.registry/custom:v2"}},
         ),
-        # Case 3: Explicitly keyed ('tgi') custom_image provided
-        (
-            {
-                "tgi": {
-                    "url": "ghcr.io/huggingface/text-generation-inference:latest",
-                }
-            },
-            {
-                "tgi": {
-                    "url": "ghcr.io/huggingface/text-generation-inference:latest",
-                }
-            },
-        ),
-        # Case 4: Explicitly keyed ('custom') custom_image provided
-        (
-            {
-                "custom": {
-                    "url": "another.registry/custom:v2",
-                }
-            },
-            {
-                "custom": {
-                    "url": "another.registry/custom:v2",
-                }
-            },
-        ),
-        # Case 5: Explicitly keyed with an engine image ('vLLM'), engine options included
+        # An engine variant keeps its own tuning options instead of being flattened into a custom container.
         (
             {"vLLM": {"url": "vllm/vllm-openai:v0.23.0", "port": 8000, "tensorParallelSize": 8}},
             {"vLLM": {"url": "vllm/vllm-openai:v0.23.0", "port": 8000, "tensorParallelSize": 8}},
         ),
-        # Case 6: An image variant this client version doesn't know about is forwarded as-is, so engines added
-        # to the API later work without upgrading `huggingface_hub`.
+        # Variants this client version doesn't know about are forwarded too, so engines added to the API later
+        # work without upgrading `huggingface_hub` (and a typo is reported by the API, not silently wrapped).
         (
             {"futureEngine": {"url": "some.registry/future-engine:v1"}},
             {"futureEngine": {"url": "some.registry/future-engine:v1"}},
         ),
-        # Case 7: A mistyped variant ('vllm' instead of 'vLLM') also reaches the API, so it can report the bad
-        # key instead of us silently turning it into a malformed custom container.
-        (
-            {"vllm": {"url": "vllm/vllm-openai:v0.23.0"}},
-            {"vllm": {"url": "vllm/vllm-openai:v0.23.0"}},
-        ),
-        # Case 8: `url` is looked up anywhere in the dict, so the payload doesn't depend on key insertion
-        # order. Malformed on purpose (a variant key mixed with container fields): the API rejects it either
-        # way, we just don't want the same content to produce two different payloads.
-        (
-            {"tgi": {"url": "ghcr.io/huggingface/text-generation-inference:latest"}, "url": "my.registry/i:v1"},
-            {
-                "custom": {
-                    "tgi": {"url": "ghcr.io/huggingface/text-generation-inference:latest"},
-                    "url": "my.registry/i:v1",
-                }
-            },
-        ),
-        # Case 9: An empty dict has no `url` to discriminate on, so it reaches the API as-is rather than being
-        # reinterpreted as "no custom image".
-        ({}, {}),
     ],
-    ids=[
-        "no_custom_image",
-        "flat_dict_custom_image",
-        "keyed_tgi_custom_image",
-        "keyed_custom_custom_image",
-        "keyed_vllm_custom_image",
-        "unknown_variant_custom_image",
-        "mistyped_variant_custom_image",
-        "key_order_independent_custom_image",
-        "empty_custom_image",
+    ids=["flat_dict", "keyed_custom", "keyed_engine", "unknown_variant"],
+)
+def test_build_endpoint_image_payload(custom_image: dict, expected_image_payload: dict):
+    assert _build_endpoint_image_payload(custom_image) == expected_image_payload
+
+
+@pytest.mark.parametrize(
+    "custom_image, expected_image_payload",
+    [
+        (None, {"huggingface": {}}),
+        ({"vLLM": {"url": "vllm/vllm-openai:v0.23.0"}}, {"vLLM": {"url": "vllm/vllm-openai:v0.23.0"}}),
     ],
+    ids=["no_custom_image", "custom_image"],
 )
 def test_create_inference_endpoint_custom_image_payload(
     mocker,
     custom_image: Optional[dict],
     expected_image_payload: dict,
 ):
-    mock_post = mocker.patch("huggingface_hub.hf_api.get_session")
-    common_args = {
-        "name": "test-endpoint-custom-img",
-        "repository": "meta-llama/Llama-2-7b-chat-hf",
-        "framework": "pytorch",
-        "accelerator": "gpu",
-        "instance_size": "medium",
-        "instance_type": "nvidia-a10g",
-        "region": "us-east-1",
-        "vendor": "aws",
-        "type": "authenticated",
-        "task": "text-generation",
-        "namespace": "Wauplin",
-    }
-    mock_session = mock_post.return_value
-    mock_post_method = mock_session.post
+    """`custom_image` reaches `model.image`, and defaults to the Hugging Face managed image."""
+    mock_session = mocker.patch("huggingface_hub.hf_api.get_session").return_value
     mock_response = Mock()
     mock_response.raise_for_status.return_value = None
     mock_response.json.return_value = {
-        "compute": {
-            "accelerator": "gpu",
-            "id": "aws-us-east-1-nvidia-l4-x1",
-            "instanceSize": "x1",
-            "instanceType": "nvidia-l4",
-            "scaling": {
-                "maxReplica": 1,
-                "measure": {"hardwareUsage": None},
-                "metric": "hardwareUsage",
-                "minReplica": 0,
-                "scaleToZeroTimeout": 15,
-            },
-        },
+        "name": "test-endpoint-custom-img",
         "model": {
-            "env": {},
+            "repository": "meta-llama/Llama-2-7b-chat-hf",
             "framework": "pytorch",
-            "image": {
-                "tgi": {
-                    "disableCustomKernels": False,
-                    "healthRoute": "/health",
-                    "port": 80,
-                    "url": "ghcr.io/huggingface/text-generation-inference:3.1.1",
-                }
-            },
-            "repository": "meta-llama/Llama-3.2-3B-Instruct",
-            "revision": "0cb88a4f764b7a12671c53f0838cd831a0843b95",
-            "secrets": {},
+            "revision": None,
             "task": "text-generation",
         },
-        "name": "llama-3-2-3b-instruct-eey",
-        "provider": {"region": "us-east-1", "vendor": "aws"},
-        "healthRoute": "/health",
         "status": {
-            "createdAt": "2025-03-07T15:30:13.949Z",
-            "createdBy": {"id": "6273f303f6d63a28483fde12", "name": "Wauplin"},
-            "message": "Endpoint waiting to be scheduled",
-            "readyReplica": 0,
             "state": "pending",
-            "targetReplica": 1,
+            "createdAt": "2025-03-07T15:30:13.949Z",
             "updatedAt": "2025-03-07T15:30:13.949Z",
-            "updatedBy": {"id": "6273f303f6d63a28483fde12", "name": "Wauplin"},
         },
-        "type": "protected",
+        "healthRoute": "/health",
+        "type": "authenticated",
     }
-    mock_post_method.return_value = mock_response
+    mock_session.post.return_value = mock_response
 
     api = HfApi(endpoint=ENDPOINT_STAGING, token=TOKEN)
-    if custom_image is not None:
-        api.create_inference_endpoint(custom_image=custom_image, **common_args)
-    else:
-        api.create_inference_endpoint(**common_args)
+    api.create_inference_endpoint(
+        name="test-endpoint-custom-img",
+        repository="meta-llama/Llama-2-7b-chat-hf",
+        framework="pytorch",
+        accelerator="gpu",
+        instance_size="medium",
+        instance_type="nvidia-a10g",
+        region="us-east-1",
+        vendor="aws",
+        type="authenticated",
+        task="text-generation",
+        namespace="Wauplin",
+        custom_image=custom_image,
+    )
 
-    mock_post_method.assert_called_once()
-    _, call_kwargs = mock_post_method.call_args
-    payload = call_kwargs.get("json", {})
-
-    assert "model" in payload and "image" in payload["model"]
+    payload = mock_session.post.call_args[1]["json"]
     assert payload["model"]["image"] == expected_image_payload
 
 
@@ -4954,24 +4863,9 @@ def test_update_inference_endpoint_container_command_and_args_empty_payload(mock
     assert payload["model"]["args"] == []
 
 
-@pytest.mark.parametrize(
-    "custom_image, expected_image_payload",
-    [
-        # A keyed image is forwarded as-is, whether it's an engine image or an explicit custom container.
-        (
-            {"sGLang": {"url": "lmsysorg/sglang:v0.5.2rc1-cu126", "port": 30000}},
-            {"sGLang": {"url": "lmsysorg/sglang:v0.5.2rc1-cu126", "port": 30000}},
-        ),
-        ({"custom": {"url": "another.registry/custom:v2"}}, {"custom": {"url": "another.registry/custom:v2"}}),
-        # A flat dict describes a custom container and gets wrapped.
-        (
-            {"url": "my.registry/my-image:latest", "port": 8080},
-            {"custom": {"url": "my.registry/my-image:latest", "port": 8080}},
-        ),
-    ],
-    ids=["keyed_sglang_custom_image", "keyed_custom_custom_image", "flat_dict_custom_image"],
-)
-def test_update_inference_endpoint_custom_image_payload(mocker, custom_image: dict, expected_image_payload: dict):
+def test_update_inference_endpoint_custom_image_payload(mocker):
+    """Regression test for #4629: update used to wrap every image in `custom`, so engine images were
+    unreachable and an already-keyed one ended up double-wrapped."""
     mock_session = mocker.patch("huggingface_hub.hf_api.get_session").return_value
     mock_response = Mock()
     mock_response.raise_for_status.return_value = None
@@ -4989,10 +4883,12 @@ def test_update_inference_endpoint_custom_image_payload(mocker, custom_image: di
     mock_session.put.return_value = mock_response
 
     api = HfApi(endpoint=ENDPOINT_STAGING, token=TOKEN)
-    api.update_inference_endpoint(name="lfm2-endpoint", namespace="Wauplin", custom_image=custom_image)
+    api.update_inference_endpoint(
+        name="lfm2-endpoint", namespace="Wauplin", custom_image={"sGLang": {"url": "lmsysorg/sglang:v0.5.2"}}
+    )
 
     payload = mock_session.put.call_args[1]["json"]
-    assert payload["model"]["image"] == expected_image_payload
+    assert payload["model"]["image"] == {"sGLang": {"url": "lmsysorg/sglang:v0.5.2"}}
 
 
 class TestHfApiVerifyChecksums:

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -4727,6 +4727,18 @@ class TestHfApiInferenceCatalog:
             {"vLLM": {"url": "vllm/vllm-openai:v0.23.0", "port": 8000, "tensorParallelSize": 8}},
             {"vLLM": {"url": "vllm/vllm-openai:v0.23.0", "port": 8000, "tensorParallelSize": 8}},
         ),
+        # Case 6: An image variant this client version doesn't know about is forwarded as-is, so engines added
+        # to the API later work without upgrading `huggingface_hub`.
+        (
+            {"futureEngine": {"url": "some.registry/future-engine:v1"}},
+            {"futureEngine": {"url": "some.registry/future-engine:v1"}},
+        ),
+        # Case 7: A mistyped variant ('vllm' instead of 'vLLM') also reaches the API, so it can report the bad
+        # key instead of us silently turning it into a malformed custom container.
+        (
+            {"vllm": {"url": "vllm/vllm-openai:v0.23.0"}},
+            {"vllm": {"url": "vllm/vllm-openai:v0.23.0"}},
+        ),
     ],
     ids=[
         "no_custom_image",
@@ -4734,6 +4746,8 @@ class TestHfApiInferenceCatalog:
         "keyed_tgi_custom_image",
         "keyed_custom_custom_image",
         "keyed_vllm_custom_image",
+        "unknown_variant_custom_image",
+        "mistyped_variant_custom_image",
     ],
 )
 def test_create_inference_endpoint_custom_image_payload(

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -4739,6 +4739,21 @@ class TestHfApiInferenceCatalog:
             {"vllm": {"url": "vllm/vllm-openai:v0.23.0"}},
             {"vllm": {"url": "vllm/vllm-openai:v0.23.0"}},
         ),
+        # Case 8: `url` is looked up anywhere in the dict, so the payload doesn't depend on key insertion
+        # order. Malformed on purpose (a variant key mixed with container fields): the API rejects it either
+        # way, we just don't want the same content to produce two different payloads.
+        (
+            {"tgi": {"url": "ghcr.io/huggingface/text-generation-inference:latest"}, "url": "my.registry/i:v1"},
+            {
+                "custom": {
+                    "tgi": {"url": "ghcr.io/huggingface/text-generation-inference:latest"},
+                    "url": "my.registry/i:v1",
+                }
+            },
+        ),
+        # Case 9: An empty dict has no `url` to discriminate on, so it reaches the API as-is rather than being
+        # reinterpreted as "no custom image".
+        ({}, {}),
     ],
     ids=[
         "no_custom_image",
@@ -4748,6 +4763,8 @@ class TestHfApiInferenceCatalog:
         "keyed_vllm_custom_image",
         "unknown_variant_custom_image",
         "mistyped_variant_custom_image",
+        "key_order_independent_custom_image",
+        "empty_custom_image",
     ],
 )
 def test_create_inference_endpoint_custom_image_payload(

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -4722,8 +4722,19 @@ class TestHfApiInferenceCatalog:
                 }
             },
         ),
+        # Case 5: Explicitly keyed with a managed engine image ('vLLM')
+        (
+            {"vLLM": {"tensorParallelSize": 8}},
+            {"vLLM": {"tensorParallelSize": 8}},
+        ),
     ],
-    ids=["no_custom_image", "flat_dict_custom_image", "keyed_tgi_custom_image", "keyed_custom_custom_image"],
+    ids=[
+        "no_custom_image",
+        "flat_dict_custom_image",
+        "keyed_tgi_custom_image",
+        "keyed_custom_custom_image",
+        "keyed_vllm_custom_image",
+    ],
 )
 def test_create_inference_endpoint_custom_image_payload(
     mocker,
@@ -4910,6 +4921,44 @@ def test_update_inference_endpoint_container_command_and_args_empty_payload(mock
     payload = mock_session.put.call_args[1]["json"]
     assert payload["model"]["command"] == []
     assert payload["model"]["args"] == []
+
+
+@pytest.mark.parametrize(
+    "custom_image, expected_image_payload",
+    [
+        # A keyed image is forwarded as-is, whether it's a managed engine or an explicit custom container.
+        ({"sGLang": {}}, {"sGLang": {}}),
+        ({"custom": {"url": "another.registry/custom:v2"}}, {"custom": {"url": "another.registry/custom:v2"}}),
+        # A flat dict describes a custom container and gets wrapped.
+        (
+            {"url": "my.registry/my-image:latest", "port": 8080},
+            {"custom": {"url": "my.registry/my-image:latest", "port": 8080}},
+        ),
+    ],
+    ids=["keyed_sglang_custom_image", "keyed_custom_custom_image", "flat_dict_custom_image"],
+)
+def test_update_inference_endpoint_custom_image_payload(mocker, custom_image: dict, expected_image_payload: dict):
+    mock_session = mocker.patch("huggingface_hub.hf_api.get_session").return_value
+    mock_response = Mock()
+    mock_response.raise_for_status.return_value = None
+    mock_response.json.return_value = {
+        "name": "lfm2-endpoint",
+        "model": {"repository": "LiquidAI/LFM2-8B-A1B", "framework": "pytorch", "revision": None, "task": None},
+        "status": {
+            "state": "pending",
+            "createdAt": "2025-03-07T15:30:13.949Z",
+            "updatedAt": "2025-03-07T15:30:13.949Z",
+        },
+        "healthRoute": "/health",
+        "type": "authenticated",
+    }
+    mock_session.put.return_value = mock_response
+
+    api = HfApi(endpoint=ENDPOINT_STAGING, token=TOKEN)
+    api.update_inference_endpoint(name="lfm2-endpoint", namespace="Wauplin", custom_image=custom_image)
+
+    payload = mock_session.put.call_args[1]["json"]
+    assert payload["model"]["image"] == expected_image_payload
 
 
 class TestHfApiVerifyChecksums:

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -4722,10 +4722,10 @@ class TestHfApiInferenceCatalog:
                 }
             },
         ),
-        # Case 5: Explicitly keyed with a managed engine image ('vLLM')
+        # Case 5: Explicitly keyed with an engine image ('vLLM'), engine options included
         (
-            {"vLLM": {"tensorParallelSize": 8}},
-            {"vLLM": {"tensorParallelSize": 8}},
+            {"vLLM": {"url": "vllm/vllm-openai:v0.23.0", "port": 8000, "tensorParallelSize": 8}},
+            {"vLLM": {"url": "vllm/vllm-openai:v0.23.0", "port": 8000, "tensorParallelSize": 8}},
         ),
     ],
     ids=[
@@ -4926,8 +4926,11 @@ def test_update_inference_endpoint_container_command_and_args_empty_payload(mock
 @pytest.mark.parametrize(
     "custom_image, expected_image_payload",
     [
-        # A keyed image is forwarded as-is, whether it's a managed engine or an explicit custom container.
-        ({"sGLang": {}}, {"sGLang": {}}),
+        # A keyed image is forwarded as-is, whether it's an engine image or an explicit custom container.
+        (
+            {"sGLang": {"url": "lmsysorg/sglang:v0.5.2rc1-cu126", "port": 30000}},
+            {"sGLang": {"url": "lmsysorg/sglang:v0.5.2rc1-cu126", "port": 30000}},
+        ),
         ({"custom": {"url": "another.registry/custom:v2"}}, {"custom": {"url": "another.registry/custom:v2"}}),
         # A flat dict describes a custom container and gets wrapped.
         (


### PR DESCRIPTION
## Summary

Fixes #4629.

`INFERENCE_ENDPOINT_IMAGE_KEYS` was a stale allowlist: the Inference Endpoints API has since gained `vLLM`, `vLLMNeuron`, `sGLang` and `hfServe` `model.image` variants. Since anything whose first key isn't in the list gets wrapped as `{"custom": ...}`, passing a valid engine image dict silently produced an invalid payload.

Refreshing the list would just push the same bug to the next engine the API ships, so the allowlist is gone and `url` discriminates instead:

- every `model.image` variant except `huggingface` inherits `BaseContainer`, which requires `url`, and no variant is named `url`. A top-level `url` therefore means "flat custom container" and nothing else. `_build_endpoint_image_payload` wraps those in `{"custom": ...}` and forwards everything else untouched. Engines added to the API later work without a `huggingface_hub` release, and a typo like `vllm` instead of `vLLM` gets reported by the API rather than silently turned into a malformed custom container.
- the same helper is now used by `update_inference_endpoint`, which used to wrap unconditionally in `{"custom": ...}`. Even the already-listed variants (`tgi`, `tei`, ...) could not be set on update, and passing `{"custom": {...}}` produced a double-wrapped `{"custom": {"custom": {...}}}`. `EndpointModelUpdate.image` is the same `EndpointModelImage` union, so the same rule applies.

Flat dicts (`{"url": ..., "port": ...}`) keep being wrapped as `custom`, so no behavior change there.

## Breaking change

`constants.INFERENCE_ENDPOINT_IMAGE_KEYS` is removed. It is what made this bug possible and there is nothing left to allow-list. It was never exported at the package root, never in `__all__`, and never documented in the API reference, but it has been reachable as `huggingface_hub.constants.INFERENCE_ENDPOINT_IMAGE_KEYS` since #3076, so anyone reading it directly will get an `AttributeError`.

## Payload compatibility

No working call changes: every input that produced a payload the API accepted before produces a byte-identical payload now. Checked against the live API. `PUT` deserializes the request body before it looks up the endpoint, so the rejection cases below were probed against a non-existent endpoint name, with no side effects.

| `custom_image` | before | after |
| --- | --- | --- |
| flat, with `url` | accepted | accepted, identical |
| `{"tgi": ...}`, `{"custom": ...}`, engine variants | create: accepted / update: **broken** | accepted on both |
| flat, no `url` | `400 model.image.custom: missing field 'url'` | `400 model.image: unknown variant 'port', expected one of ...` |
| `{}` | create: `StopIteration` / update: `400 missing field 'url'` | `400 model.image: expected value` |
| mistyped `{"vllm": ...}` | `400 model.image.custom: missing field 'url'` | `400 unknown variant 'vllm', expected one of ... 'vLLM' ...` |

That last row is the practical upside of dropping the allowlist: the API answers with every valid variant, correct casing included, instead of a `url` error that says nothing about the actual mistake.

Also confirmed while checking: `{"vLLM": {}}` returns `400 model.image.vLLM: missing field 'url'`. Engine variants do not get a server-side default image, so the docs are right to make callers pass `url`.

### One regression worth knowing about

Passing a variant key *and* a top-level `url` in the same dict, i.e. mixing the keyed form with the flat form:

```python
custom_image={"tgi": {...}, "url": "ghcr.io/huggingface/text-generation-inference:latest"}
```

On create this used to go out unwrapped and get a `400`. It now gets wrapped as `{"custom": {"tgi": {...}, "url": ...}}`, which the API **accepts**: `CustomContainer` only requires `url`, and unknown fields inside a container are ignored, whereas they are rejected one level up at `image`. So the endpoint deploys as a plain custom container and the `tgi` block is silently dropped. On update this is not new, since update already wrapped everything unconditionally.

Nothing that worked stops working, because the old payload was rejected too. What is lost is the error. I don't think it's worth guarding client-side: `CustomContainer.credentials` is itself a dict, so `{"url": ..., "credentials": {...}}` is structurally identical to the bad input, and telling them apart means hardcoding container field names, which is the same staleness this PR removes.

### Before

```python
>>> api.create_inference_endpoint(..., custom_image={"vLLM": {"url": "vllm/vllm-openai:v0.23.0", "tensorParallelSize": 8}})
# model.image == {"custom": {"vLLM": {"url": "vllm/vllm-openai:v0.23.0", "tensorParallelSize": 8}}}   <- invalid
```

### After

```python
>>> api.create_inference_endpoint(..., custom_image={"vLLM": {"url": "vllm/vllm-openai:v0.23.0", "tensorParallelSize": 8}})
# model.image == {"vLLM": {"url": "vllm/vllm-openai:v0.23.0", "tensorParallelSize": 8}}

>>> api.update_inference_endpoint("my-endpoint", custom_image={"sGLang": {"url": "lmsysorg/sglang:v0.5.2"}})
# model.image == {"sGLang": {"url": "lmsysorg/sglang:v0.5.2"}}

# an engine this version has never heard of is forwarded too
>>> api.create_inference_endpoint(..., custom_image={"futureEngine": {"url": "some.registry/future:v1"}})
# model.image == {"futureEngine": {"url": "some.registry/future:v1"}}
```

## Tests

The normalization rule is a pure function now, so it is unit-tested directly. The mocked tests only cover what the helper can't: that the image reaches `model.image`, that `custom_image=None` still defaults to `{"huggingface": {}}`, and the #4629 update regression.

```
tests/test_hf_api.py::test_build_endpoint_image_payload[flat_dict] PASSED
tests/test_hf_api.py::test_build_endpoint_image_payload[keyed_custom] PASSED
tests/test_hf_api.py::test_build_endpoint_image_payload[keyed_engine] PASSED
tests/test_hf_api.py::test_build_endpoint_image_payload[unknown_variant] PASSED
tests/test_hf_api.py::test_create_inference_endpoint_custom_image_payload[no_custom_image] PASSED
tests/test_hf_api.py::test_create_inference_endpoint_custom_image_payload[custom_image] PASSED
tests/test_hf_api.py::test_update_inference_endpoint_custom_image_payload PASSED

7 passed, 342 deselected in 0.08s
```

Checked against `main`: the create case and the update regression both fail there. Checked against the intermediate allowlist commit: `unknown_variant` fails there, which is what pins the removal.


### End to end against production

Created a real endpoint with an engine-keyed image, switched it to another engine, switched it to a flat custom container, then deleted it. The interesting part is what the API echoes back for `model.image`:

```
1) CREATE with engine-keyed vLLM image
   server echoed model.image = {"vLLM": {"healthRoute": "/health", "port": 8000, "url": "vllm/vllm-openai:v0.11.0", "tensorParallelSize": 1}}
   -> kept as vLLM (not wrapped in custom): True

2) UPDATE to engine-keyed sGLang image
   server echoed model.image = {"sGLang": {"healthRoute": "/health", "port": 30000, "url": "lmsysorg/sglang:v0.5.2rc1-cu126"}}
   -> switched to sGLang, not double-wrapped: True

3) UPDATE to a flat custom container (must still wrap in `custom`)
   server echoed model.image = {"custom": {"healthRoute": "/health", "port": 8000, "url": "vllm/vllm-openai:v0.11.0"}}
   -> wrapped as custom: True

4) DELETED zz-pr4671-check
```

`tensorParallelSize` surviving the round trip is the actual #4629 fix: on `main` that dict lands inside `{"custom": {...}}` and the engine option never reaches vLLM.

## Note

Left the CLI alone: `hf endpoints deploy --custom-image` only takes an image URL and builds a `custom` container, so it's unaffected. Exposing engine images from the CLI would be a separate (bigger) design question.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how inference endpoint create/update API payloads are built; wrong wrapping could break deployments, but behavior is narrowed with clear rules and targeted tests.
> 
> **Overview**
> Fixes incorrect `model.image` payloads when deploying Inference Endpoints with **managed engine images** (`vLLM`, `sGLang`, `tgi`, etc.) via `custom_image`.
> 
> **Create** no longer relies on a hardcoded `INFERENCE_ENDPOINT_IMAGE_KEYS` allowlist (removed from `constants.py`). Shared helper `_build_endpoint_image_payload` wraps only **flat** container dicts that include a top-level `url` as `{"custom": ...}`; engine-keyed dicts and unknown future variants are sent to the API unchanged.
> 
> **Update** (`update_inference_endpoint`) now uses the same helper instead of always setting `{"custom": custom_image}`, which had broken engine images and could double-wrap `{"custom": {...}}`.
> 
> Docs and `custom_image` docstrings describe engine-keyed usage (e.g. vLLM with `tensorParallelSize`). Tests cover the helper, create/update payloads, and the #4629 update regression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a45636dff4fabec83a795384574296726fa4dda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


