### PR TITLE
Add Urdu docs homepage translation

### DIFF
--- a/.github/workflows/build_documentation.yaml
+++ b/.github/workflows/build_documentation.yaml
@@ -13,6 +13,6 @@ jobs:
     with:
       commit_sha: ${{ github.sha }}
       package: huggingface_hub
-      languages: cn de fr en hi ko or ta
+      languages: cn de fr en hi ko or ta ur
     secrets:
       hf_token: ${{ secrets.HF_DOC_BUILD_PUSH }}

--- a/.github/workflows/build_pr_documentation.yaml
+++ b/.github/workflows/build_pr_documentation.yaml
@@ -14,4 +14,4 @@ jobs:
       commit_sha: ${{ github.event.pull_request.head.sha }}
       pr_number: ${{ github.event.number }}
       package: huggingface_hub
-      languages: cn de fr en hi ko or ta
+      languages: cn de fr en hi ko or ta ur

--- a/docs/source/ur/_toctree.yml
+++ b/docs/source/ur/_toctree.yml
@@ -1,0 +1,4 @@
+- title: 'شروع کریں'
+  sections:
+    - local: index
+      title: ہوم

--- a/docs/source/ur/index.md
+++ b/docs/source/ur/index.md
@@ -1,0 +1,42 @@
+<!--⚠️ Note that this file is in Markdown but contains specific syntax for our doc-builder (similar to MDX) that may not be
+rendered properly in your Markdown viewer.
+-->
+
+# 🤗 Hub کلائنٹ لائبریری
+
+`huggingface_hub` لائبریری آپ کو [Hugging Face Hub](https://hf.co) کے ساتھ کام کرنے دیتی ہے، جو creators اور collaborators کے لیے ایک machine learning platform ہے۔ اپنے projects کے لیے pre-trained models اور datasets دریافت کریں، یا Hub پر hosted hundreds of machine learning apps کے ساتھ تجربہ کریں۔ آپ اپنے models اور datasets بھی بنا کر community کے ساتھ share کر سکتے ہیں۔ `huggingface_hub` لائبریری Python کے ذریعے یہ سب کام کرنے کا ایک آسان طریقہ دیتی ہے۔
+
+`huggingface_hub` لائبریری کے ساتھ جلدی شروع کرنے کے لیے [quick start guide](quick-start) پڑھیں۔ آپ سیکھیں گے کہ Hub سے files کیسے download کرنی ہیں، repository کیسے بنانی ہے، اور files کو Hub پر کیسے upload کرنا ہے۔ آگے پڑھتے رہیں تاکہ آپ جان سکیں کہ 🤗 Hub پر اپنی repositories کیسے manage کرنی ہیں، discussions میں کیسے interact کرنا ہے، یا inference کیسے چلانا ہے۔
+
+<div class="mt-10">
+  <div class="w-full flex flex-col space-y-4 md:space-y-0 md:grid md:grid-cols-2 md:gap-y-4 md:gap-x-5">
+
+    <a class="!no-underline border dark:border-gray-700 p-5 rounded-lg shadow hover:shadow-lg" href="./guides/overview">
+      <div class="w-full text-center bg-gradient-to-br from-indigo-400 to-indigo-500 rounded-lg py-1.5 font-semibold mb-5 text-white text-lg leading-relaxed">طریقہ کار guides</div>
+      <p class="text-gray-700">عملی guides جو آپ کو ایک specific goal حاصل کرنے میں مدد دیتی ہیں۔ یہ guides دیکھیں تاکہ آپ سیکھ سکیں کہ real-world problems حل کرنے کے لیے huggingface_hub کیسے استعمال کرنا ہے۔</p>
+    </a>
+
+    <a class="!no-underline border dark:border-gray-700 p-5 rounded-lg shadow hover:shadow-lg" href="./package_reference/overview">
+      <div class="w-full text-center bg-gradient-to-br from-purple-400 to-purple-500 rounded-lg py-1.5 font-semibold mb-5 text-white text-lg leading-relaxed">حوالہ</div>
+      <p class="text-gray-700">huggingface_hub classes اور methods کی مکمل اور technical description۔</p>
+    </a>
+
+    <a class="!no-underline border dark:border-gray-700 p-5 rounded-lg shadow hover:shadow-lg" href="./concepts/git_vs_http">
+      <div class="w-full text-center bg-gradient-to-br from-pink-400 to-pink-500 rounded-lg py-1.5 font-semibold mb-5 text-white text-lg leading-relaxed">تصوراتی guides</div>
+      <p class="text-gray-700">huggingface_hub کی philosophy کو بہتر سمجھنے کے لیے high-level explanations۔</p>
+    </a>
+
+  </div>
+</div>
+
+<!--
+<a class="!no-underline border dark:border-gray-700 p-5 rounded-lg shadow hover:shadow-lg" href="./tutorials/overview"
+  ><div class="w-full text-center bg-gradient-to-br from-blue-400 to-blue-500 rounded-lg py-1.5 font-semibold mb-5 text-white text-lg leading-relaxed">Tutorials</div>
+  <p class="text-gray-700">Learn the basics and become familiar with using huggingface_hub to programmatically interact with the 🤗 Hub!</p>
+</a> -->
+
+## حصہ ڈالیں
+
+`huggingface_hub` میں ہر contribution welcome ہے اور برابر value رکھتا ہے! 🤗 Code میں existing issues add یا fix کرنے کے علاوہ، آپ documentation کو accurate اور up-to-date رکھنے میں بھی مدد کر سکتے ہیں، issues پر questions کا جواب دے سکتے ہیں، اور ایسی new features request کر سکتے ہیں جو آپ کے خیال میں library کو بہتر بنائیں گی۔ نیا issue یا feature request submit کرنے، pull request بھیجنے، اور اپنی contributions test کرنے کا طریقہ جاننے کے لیے [contribution guide](https://github.com/huggingface/huggingface_hub/blob/main/CONTRIBUTING.md) دیکھیں۔
+
+Contributors کو ہمارے [code of conduct](https://github.com/huggingface/huggingface_hub/blob/main/CODE_OF_CONDUCT.md) کا بھی احترام کرنا چاہیے تاکہ ہر ایک کے لیے ایک inclusive اور welcoming collaborative space بن سکے۔


### PR DESCRIPTION
## Summary
cc @Wauplin @stevhliu

- Adds the initial Urdu docs folder under `docs/source/ur`
- Translates the docs homepage (`index.md`) into Urdu
- Adds a minimal Urdu `_toctree.yml`
- Registers `ur` in the documentation build workflows

## Related issue

Part of #1820.

## Notes

This is a small first Urdu translation PR. I kept the scope limited to the homepage so the technical docs structure can be reviewed before translating more pages.

cc @Wauplin @stevhliu

## Verification

- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, API, or security impact; scope is limited to a single homepage and workflow language lists.
> 
> **Overview**
> Introduces **Urdu (`ur`)** as a new documentation locale for `huggingface_hub`.
> 
> **CI:** Both `build_documentation.yaml` and `build_pr_documentation.yaml` now include `ur` in the `languages` list so main and PR doc builds publish the new locale alongside existing languages.
> 
> **Content:** Adds `docs/source/ur/` with a minimal `_toctree.yml` (Get Started → Home) and an Urdu translation of the docs homepage in `index.md`, matching the English landing layout (intro, navigation cards to guides/reference/concepts, contribution section). Linked subpages are not translated in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64f49bfb5dcc46602d05300c640c0e1ef3b441f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

