### PR TITLE
Make chunk_iterable yield lists instead of lazy sub-iterators

### DIFF
--- a/src/huggingface_hub/utils/_chunk_utils.py
+++ b/src/huggingface_hub/utils/_chunk_utils.py
@@ -21,11 +21,8 @@ from typing import TypeVar
 T = TypeVar("T")
 
 
-def chunk_iterable(iterable: Iterable[T], chunk_size: int) -> Iterable[Iterable[T]]:
+def chunk_iterable(iterable: Iterable[T], chunk_size: int) -> Iterable[list[T]]:
     """Iterates over an iterator chunk by chunk.
-
-    Taken from https://stackoverflow.com/a/8998040.
-    See also https://github.com/huggingface/huggingface_hub/pull/920#discussion_r938793088.
 
     Args:
         iterable (`Iterable`):
@@ -57,8 +54,7 @@ def chunk_iterable(iterable: Iterable[T], chunk_size: int) -> Iterable[Iterable[
 
     iterator = iter(iterable)
     while True:
-        try:
-            next_item = next(iterator)
-        except StopIteration:
+        chunk = list(itertools.islice(iterator, chunk_size))
+        if not chunk:
             return
-        yield itertools.chain((next_item,), itertools.islice(iterator, chunk_size - 1))
+        yield chunk

--- a/tests/test_utils_chunks.py
+++ b/tests/test_utils_chunks.py
@@ -24,6 +24,19 @@ class TestUtilsCommon:
             ):
                 assert list(chunk) == expected_chunk
 
+    def test_chunk_iterable_chunks_are_lists(self):
+        # The docstring example prints each chunk directly, which only works if chunks
+        # are real lists (lazy sub-iterators printed as '<itertools.chain object ...>')
+        chunks = list(chunk_iterable(range(17), chunk_size=8))
+        assert chunks == [[0, 1, 2, 3, 4, 5, 6, 7], [8, 9, 10, 11, 12, 13, 14, 15], [16]]
+
+    def test_chunk_iterable_collect_then_consume(self):
+        # Chunks must stay valid when collected first and consumed later. With lazy
+        # sub-iterators sharing the source iterator, collecting first advanced the
+        # source by 1 item per chunk, degenerating every chunk to a single item.
+        chunks = list(chunk_iterable(iter(range(12)), chunk_size=4))
+        assert [list(chunk) for chunk in chunks] == [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]]
+
     def test_chunk_iterable_validation(self):
         with pytest.raises(ValueError):
             next(chunk_iterable(range(128), 0))


### PR DESCRIPTION
### What

`chunk_iterable`'s chunks are lazy `itertools.chain` objects sharing the underlying iterator, so they're only correct when each chunk is fully consumed before the next one is requested. Used any other way, the results are silently wrong.

The function's own docstring example doesn't reproduce:

```python
>>> for items in chunk_iterable(range(17), chunk_size=8):
...     print(items)
<itertools.chain object at 0x...>   # x17, not the 3 lists the comment shows
```

(and it's 17 iterations, not 3 — printing doesn't consume, so each "chunk" grabs one item and the loop restarts.)

Collect-then-consume degenerates every chunk to a single item:

```python
>>> chunks = list(chunk_iterable(range(12), chunk_size=4))
>>> [list(c) for c in chunks]
[[0], [1], [2], [3], [4], [5], [6], [7], [8], [9], [10], [11]]   # expected 3 chunks of 4
```

That's the dangerous case: no error, just wrong batches — and `chunk_iterable` is exported from public `huggingface_hub.utils`, where a downstream user has no reason to suspect `list()` breaks it.

### Why yielding lists is safe here

- All nine internal call sites in `hf_api.py` immediately do `list(chunk)` (or iterate the chunk to completion inside the loop body), so behaviour there is unchanged — the `list()` call just moves inside the helper.
- Laziness wasn't a hard requirement: in the original review discussion ([#920](https://github.com/huggingface/huggingface_hub/pull/920#discussion_r938793088)) the benefit was already described as marginal outside corner cases, and the chunk sizes used internally are ≤1000 small items.
- The return annotation tightens from `Iterable[Iterable[T]]` to `Iterable[list[T]]` — every existing consumer of the old contract still works, since a list is an `Iterable`.

With the change, the docstring example now runs verbatim and prints exactly what its comments claim.

### Tests

The three existing tests in `tests/test_utils_chunks.py` pass unchanged (they consume chunks inside the loop, which was the one usage pattern the old implementation got right). Added two regression tests:

- `test_chunk_iterable_chunks_are_lists` — pins the documented example's output shape
- `test_chunk_iterable_collect_then_consume` — pins the degeneration case above

Both fail on `main` and pass with the change. `ruff check` and `ruff format --check` are clean on both files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small utility change with equivalent behavior for existing in-loop consumers that already fully consume each chunk; mainly fixes a public API footgun.
> 
> **Overview**
> **`chunk_iterable`** now yields **`list[T]`** chunks built with `list(itertools.islice(...))` instead of lazy **`itertools.chain`** views that shared the source iterator.
> 
> That fixes silent wrong results when chunks are **materialized first** (e.g. `list(chunk_iterable(...))` then iterating each chunk) or when the docstring’s `print(items)` example is run—cases where lazy chunks only advanced the source by one item per “chunk.” The return type is tightened to **`Iterable[list[T]]`**.
> 
> Two regression tests lock in list-shaped output and collect-then-consume behavior; existing tests still pass because in-loop consumption was already correct.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc51ba3e127a8542d05864746fd40403ec268543. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->