### PR TITLE
Recreate the shared client in get_session() when it has been closed

### DIFF
--- a/src/huggingface_hub/utils/_http.py
+++ b/src/huggingface_hub/utils/_http.py
@@ -371,12 +371,16 @@ def get_session() -> httpx.Client:
 
     This client is shared between all calls made by `huggingface_hub`. Therefore you should not close it manually.
 
+    If the shared client has been closed (e.g. by a previous call to [`close_session`] or by closing it
+    manually), a new one is created transparently on the next call.
+
     Use [`set_client_factory`] to customize the `httpx.Client`.
     """
     global _GLOBAL_CLIENT
-    if _GLOBAL_CLIENT is None:
+    if _GLOBAL_CLIENT is None or _GLOBAL_CLIENT.is_closed:
         with _CLIENT_LOCK:
-            _GLOBAL_CLIENT = _GLOBAL_CLIENT_FACTORY()
+            if _GLOBAL_CLIENT is None or _GLOBAL_CLIENT.is_closed:
+                _GLOBAL_CLIENT = _GLOBAL_CLIENT_FACTORY()
     return _GLOBAL_CLIENT
 
 

--- a/tests/test_utils_http.py
+++ b/tests/test_utils_http.py
@@ -26,6 +26,7 @@ from huggingface_hub.utils._http import (
     _parse_repo_info_from_url,
     _parse_retry_after,
     _warn_on_warning_headers,
+    close_session,
     default_client_factory,
     fix_hf_endpoint_in_url,
     get_async_session,
@@ -226,6 +227,27 @@ class TestConfigureSession:
         client_1 = get_session()
         client_2 = get_session()
         assert client_1 is client_2  # exact same instance
+
+    def test_get_session_recreates_closed_client(self):
+        """A shared client that has been closed must be rebuilt on the next call.
+
+        This matches the contract documented in `close_session`: "If a Client is closed, it
+        will be recreated on the next call to get_session".
+        """
+        client_1 = get_session()
+        client_1.close()
+        assert client_1.is_closed
+
+        client_2 = get_session()
+        assert client_2 is not client_1
+        assert not client_2.is_closed
+
+    def test_get_session_recreates_after_close_session(self):
+        client_1 = get_session()
+        close_session()
+        client_2 = get_session()
+        assert client_2 is not client_1
+        assert not client_2.is_closed
 
     def test_get_session_twice_but_reconfigure_in_between(self):
         """Reconfiguring the session clears the cache."""


### PR DESCRIPTION
Fixes #4673

### What's the problem

`get_session()` returns the cached `_GLOBAL_CLIENT` whenever it is not `None`, without checking whether that client is still usable:

```python
if _GLOBAL_CLIENT is None:
    with _CLIENT_LOCK:
        _GLOBAL_CLIENT = _GLOBAL_CLIENT_FACTORY()
return _GLOBAL_CLIENT
```

If the shared client gets closed without going through `close_session()` (for example by closing it directly, or by using it as a context manager), the module never recovers. Every later hub call in the process raises:

```
RuntimeError: Cannot send a request, as the client has been closed.
```

`close_session()` avoids this by setting `_GLOBAL_CLIENT = None` before closing so the next call rebuilds, but nothing else restores that invariant, and `get_session()` itself does not verify it.

This also contradicts the behavior already documented in `close_session()`:

> If a Client is closed, it will be recreated on the next call to `get_session`.

which only holds when the client is closed through `close_session()`.

### The fix

`get_session()` now rebuilds the shared client when the current one is `None` **or** already closed. The check is repeated inside the lock so two threads racing on a closed client don't build two clients. `get_async_session()` is not affected since it already returns a fresh `AsyncClient` per call.

### Reproduction (before the fix)

```python
from huggingface_hub.utils import _http

s1 = _http.get_session()
s1.close()                    # e.g. accidentally, or 'with get_session(): ...'
s2 = _http.get_session()
print(s2 is s1)               # True  -> same, already-closed client
s2.get('https://huggingface.co')  # RuntimeError: Cannot send a request, as the client has been closed.
```

After the fix `s2` is a fresh, usable client.

### Tests

Added two regression tests in `TestConfigureSession`:
- `test_get_session_recreates_closed_client` — closes the client directly and asserts the next call returns a new, open client. This fails on `main` and passes with the fix.
- `test_get_session_recreates_after_close_session` — guards that the existing `close_session()` path keeps working.

Ran `ruff check`, `ruff format --check`, and the `TestConfigureSession` suite locally; all pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to global client lifecycle with double-checked locking; no auth or API contract changes.
> 
> **Overview**
> Fixes a case where the global `httpx.Client` from `get_session()` stayed cached after being closed (direct `.close()`, context manager, etc.), so later Hub calls failed with *Cannot send a request, as the client has been closed* unless `close_session()` had cleared the cache.
> 
> **`get_session()`** now treats a closed client like a missing one: it rebuilds via `_GLOBAL_CLIENT_FACTORY()` when `_GLOBAL_CLIENT` is `None` or `is_closed`, with the same check repeated under `_CLIENT_LOCK` so concurrent callers don’t create two clients. The docstring states that transparent recreation matches the existing `close_session()` contract.
> 
> Regression coverage adds **`test_get_session_recreates_closed_client`** and **`test_get_session_recreates_after_close_session`** in `TestConfigureSession`. **`get_async_session()`** is unchanged (still a new client per call).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e07c5e73230781cfb6c8ad60a24659479b6c46e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->