### PR TITLE
Add cancel_event to hf_hub_download for per-download cancellation

### DIFF
--- a/docs/source/en/package_reference/utilities.md
+++ b/docs/source/en/package_reference/utilities.md
@@ -245,6 +245,10 @@ user as possible.
 
 [[autodoc]] huggingface_hub.errors.OfflineModeIsEnabled
 
+#### DownloadCancelledError
+
+[[autodoc]] huggingface_hub.errors.DownloadCancelledError
+
 ## Telemetry
 
 `huggingface_hub` includes a helper to send telemetry data. This information helps us debug issues and prioritize new features.

--- a/src/huggingface_hub/errors.py
+++ b/src/huggingface_hub/errors.py
@@ -252,6 +252,13 @@ class FileMetadataError(OSError):
     """
 
 
+# DOWNLOAD ERRORS
+
+
+class DownloadCancelledError(OSError):
+    """Raised when a download is cancelled via the `cancel_event` argument of [`hf_hub_download`]."""
+
+
 # BUCKET ERRORS
 
 

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -4,12 +4,13 @@ import os
 import re
 import shutil
 import stat
+import threading
 import time
 import uuid
 import warnings
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, BinaryIO, Literal, NoReturn, overload
+from typing import Any, BinaryIO, Literal, NoReturn, Protocol, overload
 from urllib.parse import quote, urlparse
 
 import httpx
@@ -26,6 +27,7 @@ from ._local_folder import (
 from ._revision import ResolvedRevision
 from ._tree_cache import read_tree_cache, tree_cache_folder_for_local_dir
 from .errors import (
+    DownloadCancelledError,
     FileMetadataError,
     GatedRepoError,
     HfHubHTTPError,
@@ -67,6 +69,16 @@ _CACHED_NO_EXIST_T = Any
 
 # Regex to get filename from a "Content-Disposition" header for CDN-served files
 HEADER_FILENAME_PATTERN = re.compile(r'filename="(?P<filename>.*?)";')
+
+
+class CancelEvent(Protocol):
+    """Anything with an `is_set()` method, e.g. `threading.Event` or `asyncio.Event`.
+
+    Once set, the download it was passed to is cancelled and raises [`~errors.DownloadCancelledError`].
+    """
+
+    def is_set(self) -> bool: ...
+
 
 # Regex to check if the revision IS directly a commit_hash
 REGEX_COMMIT_HASH = re.compile(r"^[0-9a-f]{40}$")
@@ -331,6 +343,7 @@ def http_get(
     expected_size: int | None = None,
     displayed_filename: str | None = None,
     tqdm_class: type[base_tqdm] | None = None,
+    cancel_event: CancelEvent | None = None,
     _nb_retries: int = 5,
     _tqdm_bar: tqdm | None = None,
 ) -> None:
@@ -357,7 +370,13 @@ def http_get(
         displayed_filename (`str`, *optional*):
             The filename of the file that is being downloaded. Value is used only to display a nice progress bar. If
             not set, the filename is guessed from the URL or the `Content-Disposition` header.
+        cancel_event (`CancelEvent`, *optional*):
+            An event-like object with an `is_set()` method (e.g. `threading.Event`). Once set, the download stops
+            and [`~errors.DownloadCancelledError`] is raised. Only this download is affected.
     """
+    if cancel_event is not None and cancel_event.is_set():
+        raise DownloadCancelledError(f"Download cancelled: {displayed_filename or url}")
+
     if expected_size is not None and resume_size == expected_size:
         # If the file is already fully downloaded, we don't need to download it again.
         return
@@ -437,6 +456,8 @@ def http_get(
             new_resume_size = resume_size
             try:
                 for chunk in response.iter_bytes(chunk_size=constants.DOWNLOAD_CHUNK_SIZE):
+                    if cancel_event is not None and cancel_event.is_set():
+                        raise DownloadCancelledError(f"Download cancelled: {displayed_filename}")
                     if chunk:  # filter out keep-alive new chunks
                         progress.update(len(chunk))
                         if callable(update_transfer := getattr(progress, "update_transfer", None)):
@@ -462,6 +483,7 @@ def http_get(
                     headers=initial_headers,
                     expected_size=expected_size,
                     tqdm_class=tqdm_class,
+                    cancel_event=cancel_event,
                     _nb_retries=_nb_retries - 1,
                     # Reuse the existing progress bar across retries so a custom `tqdm_class` (e.g. snapshot_download's `_AggregatedTqdm`,
                     # which mutates a shared parent bar in `__init__`) is not re-instantiated and does not double-count `total`/`initial`.
@@ -484,6 +506,7 @@ def xet_get(
     expected_size: int | None = None,
     displayed_filename: str | None = None,
     tqdm_class: type[base_tqdm] | None = None,
+    cancel_event: CancelEvent | None = None,
     _tqdm_bar: tqdm | None = None,
 ) -> None:
     """
@@ -502,6 +525,10 @@ def xet_get(
         displayed_filename (`str`, *optional*):
             The filename of the file that is being downloaded. Value is used only to display a nice progress bar. If
             not set, the filename is guessed from the URL or the `Content-Disposition` header.
+        cancel_event (`CancelEvent`, *optional*):
+            An event-like object with an `is_set()` method (e.g. `threading.Event`). Once set, this download's group
+            is aborted and [`~errors.DownloadCancelledError`] is raised. Other downloads sharing the global xet
+            session are not affected.
 
     **How it works:**
         The file download system uses Xet storage, which is a content-addressable storage system that breaks files into chunks
@@ -548,6 +575,9 @@ def xet_get(
     from .utils._xet import abort_xet_session, get_xet_session, xet_headers_without_auth
     from .utils._xet_progress_reporting import XetDownloadProgressReporter
 
+    if cancel_event is not None and cancel_event.is_set():
+        raise DownloadCancelledError(f"Download cancelled: {displayed_filename}")
+
     xet_headers = xet_headers_without_auth(headers)
 
     session = get_xet_session()
@@ -561,6 +591,11 @@ def xet_get(
         tqdm_class=tqdm_class,
         external_reconstruction_bar=_tqdm_bar,
     ) as progress:
+        # When a `cancel_event` is provided, a watcher thread polls it and aborts this download's group only,
+        # leaving the shared xet session (and any concurrent downloads) untouched. The abort must not happen
+        # from inside the progress callback: `group.abort()` joins the progress thread and would deadlock.
+        stop_watcher = threading.Event()
+        watcher: threading.Thread | None = None
         try:
             with session.new_file_download_group(
                 token_refresh_url=xet_file_data.refresh_route,
@@ -568,12 +603,30 @@ def xet_get(
                 custom_headers=xet_headers,
                 progress_callback=progress.update_progress,
             ) as group:
+                if cancel_event is not None:
+
+                    def _watch_cancel():
+                        while not stop_watcher.wait(0.1):
+                            if cancel_event.is_set():
+                                group.abort()
+                                return
+
+                    watcher = threading.Thread(target=_watch_cancel, name="hf_xet_cancel_watcher", daemon=True)
+                    watcher.start()
                 group.start_download_file(
                     XetFileInfo(xet_file_data.file_hash, expected_size), str(incomplete_path.absolute())
                 )
         except KeyboardInterrupt:
             abort_xet_session()
             raise
+        except Exception as e:
+            if cancel_event is not None and cancel_event.is_set():
+                raise DownloadCancelledError(f"Download cancelled: {displayed_filename}") from e
+            raise
+        finally:
+            stop_watcher.set()
+            if watcher is not None:
+                watcher.join()
 
 
 def _normalize_etag(etag: str | None) -> str | None:
@@ -773,6 +826,7 @@ def hf_hub_download(
     headers: dict[str, str] | None = None,
     endpoint: str | None = None,
     tqdm_class: type[base_tqdm] | None = None,
+    cancel_event: CancelEvent | None = None,
     dry_run: Literal[False] = False,
 ) -> str: ...
 
@@ -797,6 +851,7 @@ def hf_hub_download(
     headers: dict[str, str] | None = None,
     endpoint: str | None = None,
     tqdm_class: type[base_tqdm] | None = None,
+    cancel_event: CancelEvent | None = None,
     dry_run: Literal[True] = True,
 ) -> DryRunFileInfo: ...
 
@@ -821,6 +876,7 @@ def hf_hub_download(
     headers: dict[str, str] | None = None,
     endpoint: str | None = None,
     tqdm_class: type[base_tqdm] | None = None,
+    cancel_event: CancelEvent | None = None,
     dry_run: bool = False,
 ) -> str | DryRunFileInfo: ...
 
@@ -845,6 +901,7 @@ def hf_hub_download(
     headers: dict[str, str] | None = None,
     endpoint: str | None = None,
     tqdm_class: type[base_tqdm] | None = None,
+    cancel_event: CancelEvent | None = None,
     dry_run: bool = False,
 ) -> str | DryRunFileInfo:
     """Download a given file if it's not already present in the local cache.
@@ -928,6 +985,10 @@ def hf_hub_download(
             argument must inherit from `tqdm.auto.tqdm` or at least mimic its behavior.
             Defaults to the custom HF progress bar that can be disabled by setting
             `HF_HUB_DISABLE_PROGRESS_BARS` environment variable.
+        cancel_event (`CancelEvent`, *optional*):
+            An event-like object with an `is_set()` method (e.g. `threading.Event`). Once set, this download stops
+            and [`~errors.DownloadCancelledError`] is raised. Only this download is cancelled: concurrent downloads
+            (including xet downloads sharing the process-wide session) are not affected.
         dry_run (`bool`, *optional*, defaults to `False`):
             If `True`, perform a dry run without actually downloading the file. Returns a
             [`DryRunFileInfo`] object containing information about what would be downloaded.
@@ -1013,6 +1074,7 @@ def hf_hub_download(
             force_download=force_download,
             local_files_only=local_files_only,
             tqdm_class=tqdm_class,
+            cancel_event=cancel_event,
             dry_run=dry_run,
         )
     else:
@@ -1033,6 +1095,7 @@ def hf_hub_download(
             local_files_only=local_files_only,
             force_download=force_download,
             tqdm_class=tqdm_class,
+            cancel_event=cancel_event,
             dry_run=dry_run,
         )
 
@@ -1055,6 +1118,7 @@ def _hf_hub_download_to_cache_dir(
     local_files_only: bool,
     force_download: bool,
     tqdm_class: type[base_tqdm] | None,
+    cancel_event: CancelEvent | None,
     dry_run: bool,
 ) -> str | DryRunFileInfo:
     """Download a given file to a cache folder, if not already present.
@@ -1250,6 +1314,7 @@ def _hf_hub_download_to_cache_dir(
             etag=etag,
             xet_file_data=xet_file_data,
             tqdm_class=tqdm_class,
+            cancel_event=cancel_event,
         )
         if not os.path.exists(pointer_path):
             _create_symlink(blob_path, pointer_path, new_blob=True)
@@ -1276,6 +1341,7 @@ def _hf_hub_download_to_local_dir(
     force_download: bool,
     local_files_only: bool,
     tqdm_class: type[base_tqdm] | None,
+    cancel_event: CancelEvent | None,
     dry_run: bool,
 ) -> str | DryRunFileInfo:
     """Download a given file to a local folder, if not already present.
@@ -1465,6 +1531,7 @@ def _hf_hub_download_to_local_dir(
             etag=etag,
             xet_file_data=xet_file_data,
             tqdm_class=tqdm_class,
+            cancel_event=cancel_event,
         )
 
     write_download_metadata(local_dir=local_dir, filename=filename, commit_hash=commit_hash, etag=etag)
@@ -1922,6 +1989,7 @@ def _download_to_tmp_and_move(
     etag: str | None,
     xet_file_data: XetFileData | None,
     tqdm_class: type[base_tqdm] | None = None,
+    cancel_event: CancelEvent | None = None,
 ) -> None:
     """Download content from a URL to a destination path.
 
@@ -1964,6 +2032,7 @@ def _download_to_tmp_and_move(
                     expected_size=expected_size,
                     displayed_filename=filename,
                     tqdm_class=tqdm_class,
+                    cancel_event=cancel_event,
                 )
             else:
                 if xet_file_data is not None and not constants.HF_HUB_DISABLE_XET:
@@ -1979,6 +2048,7 @@ def _download_to_tmp_and_move(
                     headers=headers,
                     expected_size=expected_size,
                     tqdm_class=tqdm_class,
+                    cancel_event=cancel_event,
                 )
 
         logger.debug(f"Download complete. Moving file to {destination_path}")

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -15,6 +15,7 @@ import io
 import os
 import shutil
 import stat
+import threading
 import warnings
 from contextlib import contextmanager
 from pathlib import Path
@@ -26,7 +27,12 @@ import pytest
 
 from huggingface_hub import HfApi, constants
 from huggingface_hub._local_folder import write_download_metadata
-from huggingface_hub.errors import EntryNotFoundError, GatedRepoError, LocalEntryNotFoundError
+from huggingface_hub.errors import (
+    DownloadCancelledError,
+    EntryNotFoundError,
+    GatedRepoError,
+    LocalEntryNotFoundError,
+)
 from huggingface_hub.file_download import (
     _CACHED_NO_EXIST,
     HfFileMetadata,
@@ -39,8 +45,9 @@ from huggingface_hub.file_download import (
     hf_hub_url,
     http_get,
     try_to_load_from_cache,
+    xet_get,
 )
-from huggingface_hub.utils import SoftTemporaryDirectory, WeakFileLock, get_session, hf_raise_for_status
+from huggingface_hub.utils import SoftTemporaryDirectory, WeakFileLock, XetFileData, get_session, hf_raise_for_status
 from huggingface_hub.utils._headers import build_hf_headers
 from huggingface_hub.utils._http import _http_backoff_base
 
@@ -1491,6 +1498,110 @@ class TestExtraLargeFileDownloadPaths:
                     revision="main",
                     etag_timeout=10,
                 )
+
+
+class _FakeXetDownloadGroup:
+    """Mimics hf_xet.XetFileDownloadGroup: blocks on normal exit until abort() is called."""
+
+    def __init__(self):
+        self.aborted = threading.Event()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if exc_type is None:
+            # Emulates wait_to_finish: the real group raises once aborted.
+            if self.aborted.wait(timeout=10):
+                raise RuntimeError("download group aborted")
+        return False
+
+    def start_download_file(self, file_info, dest_path):
+        pass
+
+    def abort(self):
+        self.aborted.set()
+
+
+class TestDownloadCancellation:
+    def test_http_get_cancel_event_preset_skips_request(self):
+        event = threading.Event()
+        event.set()
+        with patch("huggingface_hub.file_download.http_stream_backoff") as mock_stream_backoff:
+            with pytest.raises(DownloadCancelledError):
+                http_get("fake_url", temp_file=io.BytesIO(), cancel_event=event)
+        mock_stream_backoff.assert_not_called()
+
+    def test_http_get_cancel_event_stops_mid_stream(self):
+        event = threading.Event()
+
+        def _iter_content() -> Iterable[bytes]:
+            yield b"0" * 10
+            yield b"0" * 10
+            event.set()
+            yield b"0" * 10
+            yield b"0" * 10
+
+        with patch("huggingface_hub.file_download.http_stream_backoff") as mock_stream_backoff:
+            mock_response = Mock()
+            mock_response.headers = {"Content-Length": "40"}
+            mock_response.iter_bytes.side_effect = [_iter_content()]
+            mock_stream_backoff.return_value.__enter__.return_value = mock_response
+            mock_stream_backoff.return_value.__exit__.return_value = None
+
+            temp_file = io.BytesIO()
+            with pytest.raises(DownloadCancelledError):
+                http_get("fake_url", temp_file=temp_file, cancel_event=event)
+
+        # Chunks received before cancellation are written, nothing after it.
+        assert temp_file.tell() == 20
+
+    def test_xet_get_cancel_event_preset_skips_session(self, tmp_path):
+        event = threading.Event()
+        event.set()
+        with patch("huggingface_hub.utils._xet.get_xet_session") as mock_get_session:
+            with pytest.raises(DownloadCancelledError):
+                xet_get(
+                    incomplete_path=tmp_path / "file.incomplete",
+                    xet_file_data=XetFileData(file_hash="0" * 64, refresh_route="mock/route"),
+                    headers={},
+                    cancel_event=event,
+                )
+        mock_get_session.assert_not_called()
+
+    def test_xet_get_cancel_event_aborts_only_its_group(self, tmp_path):
+        group = _FakeXetDownloadGroup()
+        fake_session = Mock()
+        fake_session.new_file_download_group.return_value = group
+
+        event = threading.Event()
+        threading.Timer(0.2, event.set).start()
+
+        with patch("huggingface_hub.utils._xet.get_xet_session", return_value=fake_session):
+            with pytest.raises(DownloadCancelledError):
+                xet_get(
+                    incomplete_path=tmp_path / "file.incomplete",
+                    xet_file_data=XetFileData(file_hash="0" * 64, refresh_route="mock/route"),
+                    headers={},
+                    cancel_event=event,
+                )
+
+        assert group.aborted.is_set()
+
+    def test_hf_hub_download_forwards_cancel_event(self, tmp_path):
+        event = threading.Event()
+        with patch("huggingface_hub.file_download.get_hf_file_metadata") as mock_metadata:
+            mock_metadata.return_value = HfFileMetadata(
+                commit_hash="0" * 40,
+                etag="mock_etag",
+                location="mock_location",
+                size=1024,
+                xet_file_data=None,
+            )
+            with patch("huggingface_hub.file_download.http_get") as mock_http_get:
+                with patch("huggingface_hub.file_download._create_symlink"):
+                    hf_hub_download("user/repo", filename="file.txt", cache_dir=tmp_path, cancel_event=event)
+        assert mock_http_get.call_args.kwargs["cancel_event"] is event
 
 
 def _recursive_chmod(path: str, mode: int) -> None:


### PR DESCRIPTION
Fixes #4632.

## What

Adds a `cancel_event` argument to `hf_hub_download` (threaded through to `http_get` and `xet_get`): any object with an `is_set()` method (`threading.Event`, `asyncio.Event`, a custom flag). Once set, that download raises a new `DownloadCancelledError`; concurrent downloads are unaffected.

```python
import threading
from huggingface_hub import hf_hub_download
from huggingface_hub.errors import DownloadCancelledError

cancel = threading.Event()
# from the UI thread: cancel.set()
try:
    hf_hub_download(repo_id=..., filename=..., cancel_event=cancel)
except DownloadCancelledError:
    ...
```

## How

- **HTTP path**: the event is checked in the existing chunk loop of `http_get` (and forwarded through the retry recursion).
- **Xet path**: the key realization is that no Rust changes are needed for isolation. `hf_xet` already exposes `XetFileDownloadGroup.abort()`, which cancels a single group while leaving the process-wide session usable (its docs contrast it with `sigint_abort` explicitly), and `xet_get` already creates one group per file. A small watcher thread polls the event and calls `group.abort()` when set. The abort deliberately does not happen inside the progress callback: `abort()` joins the progress thread, so aborting from the callback would deadlock (and callbacks raised from `hf_xet`'s thread are swallowed anyway, per the issue).
- `DownloadCancelledError(OSError)` added to `errors.py` and to the errors reference docs.

## Tests

`TestDownloadCancellation` in `tests/test_file_download.py`, no network needed:

- pre-set event: `http_get` raises without issuing the request; `xet_get` raises without creating a session
- mid-stream: `http_get` stops at the cancellation point (mocked stream, same pattern as `TestHttpGet`)
- xet: watcher aborts the download group (fake group that blocks until aborted, mirroring `wait_to_finish` semantics)
- plumbing: `hf_hub_download(..., cancel_event=...)` forwards the event to the transport

`ruff check`, `ruff format --check`, and `ty check src` are clean on the changed files (the two pre-existing `ty` diagnostics in `cli/_output.py` are untouched).

## Verified end to end against the Hub

Two concurrent `hf_hub_download` calls (xet-backed), cancelling one 3s in: the cancelled one raised `DownloadCancelledError` with ~0.1s latency and the other completed normally. This is the exact scenario from #4632 that previously required `abort_xet_session()` and killed both.

## Known limitation (upstream)

While verifying with `/proc/net/dev`, I found that after `group.abort()` the aborted group's transfer keeps downloading in the background at full bandwidth until the file would have completed, then discards the bytes (chunk cache does not grow). So on the xet path this PR gives prompt API-level cancellation and correct isolation, but the bandwidth of the cancelled download is only truly released once the underlying transfer finishes. That is an `hf_xet` issue rather than something fixable from Python; filed with measurements as huggingface/xet-core#942. The HTTP path releases bandwidth immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core download paths (`hf_hub_download`, HTTP streaming, Xet) with a new public API and threading on Xet; behavior is scoped to opt-in cancellation and is well tested, but download failures/cleanup on cancel merit reviewer attention.
> 
> **Overview**
> Adds optional **`cancel_event`** to **`hf_hub_download`** (and internal **`http_get`** / **`xet_get`** paths) so callers can stop a single in-flight download without affecting others. Setting the event raises a new **`DownloadCancelledError`** (`OSError` subclass), documented in the errors reference.
> 
> On **HTTP**, cancellation is checked before the request and on each chunk; **`cancel_event`** is preserved across download retries. On **Xet**, a daemon watcher polls the event and calls **`group.abort()`** on that file’s download group only (not the shared session), avoiding abort from inside the progress callback to prevent deadlock.
> 
> **`TestDownloadCancellation`** covers pre-set cancel, mid-stream HTTP stop, Xet group abort, and plumbing from **`hf_hub_download`** to **`http_get`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec559da95071caec05fc65e407addbdacb57e07a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->