### PR TITLE
Fix double percent-decode of URL revisions in parse_hf_uri

### DIFF
--- a/src/huggingface_hub/utils/_hf_uris.py
+++ b/src/huggingface_hub/utils/_hf_uris.py
@@ -142,11 +142,12 @@ class HfUri:
         parts: list[str] = [constants.HF_PROTOCOL, _TYPE_TO_PREFIX[self.type], "/", self.id]
         if self.revision is not None:
             # Encode '/' as '%2F' for revisions that would otherwise be split as '<revision>/<path>'
-            # at parse time. Special refs ('refs/pr/N', 'refs/convert/<name>') are kept verbatim
+            # at parse time, and '%' as '%25' because the parser unquotes the revision exactly once.
+            # Special refs ('refs/pr/N', 'refs/convert/<name>') are kept verbatim
             # because the parser matches them eagerly.
             revision = self.revision
-            if "/" in revision and _SPECIAL_REFS_REVISION_REGEX.fullmatch(revision) is None:
-                revision = revision.replace("/", "%2F")
+            if ("/" in revision or "%" in revision) and _SPECIAL_REFS_REVISION_REGEX.fullmatch(revision) is None:
+                revision = revision.replace("%", "%25").replace("/", "%2F")
             parts.append(f"@{revision}")
         if self.path_in_repo:
             parts.append(f"/{self.path_in_repo}")
@@ -358,6 +359,19 @@ def _decode_url_path_segment(segment: str) -> str:
     return unquote(segment).replace("/", "%2F")
 
 
+def _decode_url_revision_segment(segment: str) -> str:
+    """Percent-decode the revision segment of a URL for the canonical parser.
+
+    '_parse_repo_body' applies a single 'unquote' to the revision, so a literal '%'
+    in a branch or tag name (e.g. 'a%20b', URL-encoded as 'a%2520b') must be
+    re-escaped here — otherwise it would be decoded a second time and the revision
+    would silently change ('a%20b' -> 'a b'). A decoded '/' is kept as '%2F' for the
+    same reason as in '_decode_url_path_segment': it keeps branch names containing
+    '/' (e.g. 'feature/foo') a single revision segment.
+    """
+    return unquote(segment).replace("%", "%25").replace("/", "%2F")
+
+
 def _url_to_uri_body(url: str, endpoint: str | None = None) -> str:
     """Normalize a Hugging Face web URL into the body of a 'hf://' URI (everything after 'hf://').
 
@@ -435,8 +449,13 @@ def _url_to_uri_body(url: str, endpoint: str | None = None) -> str:
     # 'tail' is '<revision>/<path>'; reuse the canonical '@<revision>/<path>' splitting logic
     # (special refs, URL-encoded slashes, ...) by handing it back to the URI parser. Each segment
     # is percent-decoded first so file names with spaces, '#', ... resolve correctly; the revision
-    # segment's '%2F' survives (re-encoded by '_decode_url_path_segment') and is decoded downstream.
-    decoded = "/".join(_decode_url_path_segment(segment) for segment in tail)
+    # segment's '%2F' survives (re-encoded by '_decode_url_revision_segment') and is decoded
+    # downstream — re-escaped rather than decoded, because the canonical parser unquotes the
+    # revision exactly once.
+    decoded = "/".join(
+        _decode_url_revision_segment(segment) if i == 0 else _decode_url_path_segment(segment)
+        for i, segment in enumerate(tail)
+    )
     return f"{prefix}{repo_id}@{decoded}"
 
 

--- a/tests/test_utils_hf_uris.py
+++ b/tests/test_utils_hf_uris.py
@@ -153,6 +153,14 @@ URI_SUCCESS_CASES: list[tuple[str, HfUri, str]] = [
         HfUri(type="model", id="my-org/my-model", revision="feature/foo", path_in_repo="config.json"),
         "hf://models/my-org/my-model@feature%2Ffoo/config.json",
     ),
+    # Branch name containing a literal '%' (encoded as '%25') must survive the parser's
+    # single 'unquote' of the revision untouched, and 'to_uri' must re-escape it so the
+    # canonical form reparses to the same revision (idempotency).
+    (
+        "hf://my-org/my-model@a%2520b/config.json",
+        HfUri(type="model", id="my-org/my-model", revision="a%20b", path_in_repo="config.json"),
+        "hf://models/my-org/my-model@a%2520b/config.json",
+    ),
     # Special revision with no path after it
     (
         "hf://my-org/my-model@refs/pr/3",
@@ -342,6 +350,13 @@ URL_SUCCESS_CASES: list[tuple[str, HfUri]] = [
         "https://huggingface.co/my-org/my-model/blob/feature%2Ffoo/config.json",
         HfUri(type="model", id="my-org/my-model", revision="feature/foo", path_in_repo="config.json"),
     ),
+    # Branch name containing a literal '%' (URL-encoded as '%25') must not be decoded
+    # twice: the URL segment is decoded once here, and the canonical parser decodes the
+    # revision once more, so the intermediate form re-escapes it.
+    (
+        "https://huggingface.co/my-org/my-model/blob/a%2520b/config.json",
+        HfUri(type="model", id="my-org/my-model", revision="a%20b", path_in_repo="config.json"),
+    ),
     # --- Percent-encoded path (browsers encode spaces, '#', ... in file names) --
     (
         "https://huggingface.co/my-org/my-model/blob/main/my%20file.txt",
@@ -478,6 +493,12 @@ TO_URL_CASES: list[tuple[HfUri, str]] = [
     (
         HfUri(type="model", id="my-org/my-model", revision="fix#1", path_in_repo="config.json"),
         "/my-org/my-model/blob/fix%231/config.json",
+    ),
+    # A literal '%' in the revision is encoded as '%25'; re-parsing the rendered URL must
+    # give back the exact revision (no double decode).
+    (
+        HfUri(type="model", id="my-org/my-model", revision="a%20b", path_in_repo="config.json"),
+        "/my-org/my-model/blob/a%2520b/config.json",
     ),
     # '#' in the revision is also encoded on the folder (tree) route
     (


### PR DESCRIPTION
## Bug

A branch or tag name containing a literal percent sequence is decoded twice when parsed from a web URL, silently changing the revision.

```py
>>> parse_hf_uri("https://huggingface.co/org/repo/resolve/a%2520b/file.txt").revision
'a b'        # expected 'a%20b' — the branch is literally named "a%20b"
>>> parse_hf_uri("hf://org/repo@a%2520b/file.txt").revision
'a%20b'      # the equivalent hf:// form is correct
```

Git allows `%` in ref names, so such branches exist. A user copy-pasting the URL gets a silently wrong revision (`EntryNotFoundError` on download) while the equivalent `hf://` URI works — the same resource parses two different ways depending on input form.

Root cause: `_url_to_uri_body` percent-decodes each URL segment once, then hands the revision to the canonical parser, which applies a second `unquote` (`_parse_repo_body`). The path-in-repo is unaffected (it is not unquoted downstream); only the revision double-decodes.

## Fix

- The revision segment of a URL is now decoded with a dedicated helper that re-escapes `%` → `%25` (and keeps a decoded `/` as `%2F`, as before), so the canonical parser's single `unquote` restores the exact branch name.
- `to_uri` now escapes `%` in revisions the same way it already escaped `/`, so `parse → to_uri → parse` stays idempotent for such revisions.

## Verification

- New regression cases in all three parametrized suites: URL input, `hf://` input with `to_uri` round-trip, and the `to_url` round-trip (which already asserted that the revision must reparse exactly — it fails on `main` for these cases).
- Confirmed the wrong output on `main` directly (`'a b'`) vs the fixed output (`'a%20b'`).
- Full `tests/test_utils_hf_uris.py`: 143 passed. `ruff check` / `ruff format --check` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to HF URI/URL encoding in `utils/_hf_uris.py` with targeted tests; no auth, network, or data-path changes beyond fixing revision strings.
> 
> **Overview**
> Fixes **incorrect revision parsing** when a branch or tag name contains a literal `%` (e.g. `a%20b`). Web URLs were decoded twice—once when normalizing the URL and again in the canonical `hf://` parser—so the revision became `a b` instead of `a%20b`, while the same resource via `hf://` parsed correctly.
> 
> URL normalization now uses **`_decode_url_revision_segment`** for the revision path segment, re-escaping `%` → `%25` (and `/` → `%2F` as before) so the downstream single `unquote` restores the exact ref name. **`HfUri.to_uri`** applies the same `%` escaping for canonical round-trips. Regression tests cover `hf://`, Hub URLs, and `to_url` re-parse.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20b2c962fa317377d5baf061c7df68a6c4041bc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->