### PR TITLE
Fix ResolvedRevision silently becoming "main" after pickling

### DIFF
--- a/src/huggingface_hub/_revision.py
+++ b/src/huggingface_hub/_revision.py
@@ -39,5 +39,12 @@ class ResolvedRevision(str):
         revision.resolved = resolved
         return revision
 
+    def __getnewargs__(self) -> tuple[str, str | None]:
+        # `str` subclasses pickle through `__new__(cls, *args)`. The inherited
+        # `str.__getnewargs__` only returns the string value, so unpickling would call
+        # `__new__(cls, initial)` and treat `initial` as `resolved`. `initial` then
+        # defaults to `None` and the string value silently becomes `"main"`.
+        return (self.resolved, self.initial)
+
     def __repr__(self) -> str:
         return f"ResolvedRevision(initial={self.initial!r}, resolved={self.resolved!r})"

--- a/tests/test_snapshot_download.py
+++ b/tests/test_snapshot_download.py
@@ -1,4 +1,5 @@
 import os
+import pickle
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -359,6 +360,25 @@ def test_revision_str():
     revision = ResolvedRevision(resolved=COMMIT_HASH, initial="refs/pr/4")
     assert revision == "refs/pr/4"
     assert revision.resolved == COMMIT_HASH
+
+
+@pytest.mark.parametrize("protocol", range(pickle.HIGHEST_PROTOCOL + 1))
+def test_revision_survives_pickle(protocol: int):
+    """Unpickling must preserve the string value, `.initial`, and `.resolved`."""
+    revision = ResolvedRevision(resolved=COMMIT_HASH, initial="3.0bpw")
+    restored = pickle.loads(pickle.dumps(revision, protocol=protocol))
+
+    assert restored == "3.0bpw"
+    assert str(restored) == "3.0bpw"
+    assert restored.initial == "3.0bpw"
+    assert restored.resolved == COMMIT_HASH
+    assert repr(restored) == repr(revision)
+
+    default_revision = ResolvedRevision(resolved=COMMIT_HASH)
+    restored_default = pickle.loads(pickle.dumps(default_revision, protocol=protocol))
+    assert restored_default == "main"
+    assert restored_default.initial is None
+    assert restored_default.resolved == COMMIT_HASH
 
 
 class TestResolveRevision:


### PR DESCRIPTION
## Summary
Fixes #4688.

`ResolvedRevision` is a `str` subclass whose string value is the user-requested revision (`initial`, or `"main"` when `initial` is `None`) while `.resolved` holds the commit hash. Pickling a `str` subclass reconstructs it with `__new__(cls, *args)` from `__getnewargs__`. The inherited `str.__getnewargs__` only returns the string value, so unpickling called `__new__(cls, initial)`:

- `resolved` was set to the original string value
- `initial` defaulted to `None`
- the immutable string value became `"main"`
- `__dict__` restore then put the original attributes back, so `repr()` still looked correct

That combination is what made the bug hard to spot. Callers such as vLLM that pickle a resolved revision into a subprocess then fetch from `main` instead of the requested branch.

This adds `__getnewargs__` so unpickling calls `__new__(cls, resolved, initial)` and preserves both the string value and the commit hash. Tests cover every pickle protocol.

## Test plan
- [x] `PYTHONPATH=src python3` pickle round-trip of `ResolvedRevision(..., initial="3.0bpw")` keeps `str(...) == "3.0bpw"` on protocols 0–5
- [x] `pytest tests/test_snapshot_download.py -k "test_revision_str or test_revision_survives_pickle"` — 7 passed
- [x] `ruff check` / `ruff format --check` on the two changed files


Made with [Cursor](https://cursor.com)