### PR TITLE
fix: pin empty agent-harness registry at conftest import for deterministic tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,17 @@ from .testing_constants import (
 from .testing_utils import repo_name
 
 
+# Pin an empty agent-harness registry as soon as this conftest is imported (i.e. before
+# any test module is collected), not just inside a fixture. `_clean_cli_env` below does
+# the same thing per-test via monkeypatch, but that runs too late for module-level code
+# that calls `detect_agent()` (via `_http_user_agent()`) at collection time, e.g.
+# `DEFAULT_USER_AGENT = _http_user_agent()` in `test_utils_headers.py`. Without this,
+# running the suite from inside an AI coding agent session appends `; agent/<id>` to
+# that module-level constant and every exact-match header assertion in
+# `TestAuthHeadersUtil` fails, even though nothing is actually broken in the library.
+_detect_agent._registry = _detect_agent._EMPTY_REGISTRY
+
+
 @pytest.fixture(autouse=True, scope="function")
 def patch_constants(mocker):
     with SoftTemporaryDirectory() as cache_dir:


### PR DESCRIPTION
Fixes #4685.

## Problem

Seven tests in `tests/test_utils_headers.py::TestAuthHeadersUtil` fail when the suite is run from inside an AI coding agent session (Claude Code, etc.) — which is exactly how CONTRIBUTING.md tells agent users to work.

`_http_user_agent()` appends `; agent/<id>` to the user-agent whenever `detect_agent()` matches a registered harness. `test_utils_headers.py` computes `DEFAULT_USER_AGENT = _http_user_agent()` at **module-collection time**, before the existing per-test `_clean_cli_env` fixture — which already pins an empty registry via `monkeypatch.setattr(_detect_agent, "_registry", _detect_agent._EMPTY_REGISTRY)` — gets a chance to run. So the module-level constant bakes in whatever harness is detected on the machine running the tests, and every exact-match assertion in `TestAuthHeadersUtil` fails outside a vacuum environment.

## Fix

Pin `_detect_agent._registry` to `_detect_agent._EMPTY_REGISTRY` as soon as `conftest.py` is imported (module-level, not inside a fixture), so detection deterministically reports "no agent" for every test — including module-level code executed at collection time. The existing per-test fixture keeps working unchanged for tests that explicitly override the registry locally (e.g. `test_cli_output.py::test_auto_resolves_to_agent`).

## Verification (macOS arm64, Python 3.13.12, editable `[dev]` install)

```
tests/test_utils_headers.py ....................  18 passed  (was 11 passed, 7 failed)
tests/test_utils_detect_agent.py ...................  24 passed  (unaffected)
tests/test_cli_output.py ...............  15 passed  (unaffected)
tests/test_utils_telemetry.py ........  8 passed  (unaffected)
ruff check / ruff format: clean
```

I also confirmed a naive module-level `detect_agent = lambda: None` monkeypatch (my first attempt) breaks `test_utils_detect_agent.py` and `test_cli_output.py::test_auto_resolves_to_agent` (7 failures) — this PR instead reuses the registry-pinning mechanism the repo already established in `_clean_cli_env`, just applied earlier, so it doesn't clobber the function other tests exercise directly.

## Disclosure

AI-assisted: repro, root cause analysis, fix, and test verification done with Claude Code (Atlas, my agent); I reviewed and ran everything above myself before opening this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change in conftest; no library runtime behavior is modified.
> 
> **Overview**
> Fixes flaky failures in `TestAuthHeadersUtil` when the test suite runs inside an AI coding agent session (e.g. per CONTRIBUTING.md).
> 
> **`tests/conftest.py`** now sets `_detect_agent._registry = _detect_agent._EMPTY_REGISTRY` at import time, before test modules are collected. The existing `_clean_cli_env` fixture already pins the same empty registry per test, but that runs after collection—too late for module-level `DEFAULT_USER_AGENT = _http_user_agent()` in `test_utils_headers.py`, which would otherwise bake in `; agent/<id>` and break exact `user-agent` header assertions. Per-test registry pinning is unchanged so tests that override detection locally still work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c0c087dc719198e3ea36da3f79d430e9a1729f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->