### PR TITLE
[Download] Fix ResolvedRevision string value after pickle/copy

### DIFF
--- a/src/huggingface_hub/_revision.py
+++ b/src/huggingface_hub/_revision.py
@@ -39,5 +39,9 @@ class ResolvedRevision(str):
         revision.resolved = resolved
         return revision
 
+    def __reduce__(self):
+        # without this, pickle/copy rebuild the instance from its string value only, losing `initial` and `resolved`
+        return self.__class__, (self.resolved, self.initial)
+
     def __repr__(self) -> str:
         return f"ResolvedRevision(initial={self.initial!r}, resolved={self.resolved!r})"

--- a/tests/test_snapshot_download.py
+++ b/tests/test_snapshot_download.py
@@ -1,4 +1,6 @@
+import copy
 import os
+import pickle
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -359,6 +361,15 @@ def test_revision_str():
     revision = ResolvedRevision(resolved=COMMIT_HASH, initial="refs/pr/4")
     assert revision == "refs/pr/4"
     assert revision.resolved == COMMIT_HASH
+
+
+def test_revision_str_is_picklable():
+    revision = ResolvedRevision(resolved=COMMIT_HASH, initial="refs/pr/4")
+
+    for restored in (pickle.loads(pickle.dumps(revision)), copy.deepcopy(revision)):
+        assert restored == "refs/pr/4"
+        assert restored.initial == "refs/pr/4"
+        assert restored.resolved == COMMIT_HASH
 
 
 class TestResolveRevision:


### PR DESCRIPTION
## Summary

Fixes #4688.

`ResolvedRevision` is a `str` subclass, and pickle/`copy` rebuild `str` subclasses through `__new__` with only the string value. So unpickling called `__new__(cls, "3.0bpw")` — the string value landed in the `resolved` slot, `initial` fell back to `None`, and the (immutable) string value silently became `"main"`. The `__dict__` restore afterwards put `.initial`/`.resolved` back, which is why `repr()` still looked correct and this was easy to miss.

Adding `__reduce__` makes pickle and `copy`/`deepcopy` rebuild via `__new__(cls, resolved, initial)`.

## Impact

`hf_hub_download` and `snapshot_download` were unaffected since they read `.resolved`. Every other `HfApi` method uses the string value, so after a round-trip they silently operated on `main`:

```python
rev = HfApi().resolve_revision("turboderp/Qwen3-0.6B-exl3", revision="3.0bpw")
rev = pickle.loads(pickle.dumps(rev))  # or copy.deepcopy(rev)
```

before:

```python
>>> str(rev)
'main'
>>> HfApi().model_info("turboderp/Qwen3-0.6B-exl3", revision=rev).sha
'ae608a6054100aa0a60ec63f7cabb45d44a35a3a'  # main
>>> hf_hub_url("turboderp/Qwen3-0.6B-exl3", "config.json", revision=rev)
'.../resolve/main/config.json'
```

after:

```python
>>> str(rev)
'3.0bpw'
>>> HfApi().model_info("turboderp/Qwen3-0.6B-exl3", revision=rev).sha
'd46a12a64d5a0a9a546d862855c8f390b16b7436'  # 3.0bpw
>>> hf_hub_url("turboderp/Qwen3-0.6B-exl3", "config.json", revision=rev)
'.../resolve/3.0bpw/config.json'
```

## Notes

- `__reduce__` rather than `__getnewargs__` (as proposed in #4689): the latter widens `str.__getnewargs__`'s return type from `tuple[str]` to `tuple[str, str | None]`, which `ty check src` rejects as an invalid override.
- Verified on pickle protocols 0-5 plus `copy.copy`/`copy.deepcopy`, for both `initial="3.0bpw"` and `initial=None`. Protocols 0 and 1 were already fine — they reconstruct through `str.__new__` rather than the reduce protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit f61a57581fc7d2d99c53c2193e0ed2a68ac9eabe. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->