### PR TITLE
docs: mention HF_HUB_DISABLE_SYMLINKS_WARNING on the install page

### DIFF
--- a/docs/source/en/installation.md
+++ b/docs/source/en/installation.md
@@ -157,9 +157,13 @@ run on Windows. Here is an exhaustive list of known issues. Please let us know i
 encounter any undocumented problem by opening [an issue on Github](https://github.com/huggingface/huggingface_hub/issues/new/choose).
 
 - `huggingface_hub`'s cache system relies on symlinks to efficiently cache files downloaded
-from the Hub. On Windows, you must activate developer mode or run your script as admin to
-enable symlinks. If they are not activated, the cache-system still works but in a non-optimized
-manner. Please read [the cache limitations](./guides/manage-cache#limitations) section for more details.
+from the Hub. On Windows, you must [activate developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development)
+or run your script as admin to enable symlinks. If they are not activated, the cache-system
+still works but in a non-optimized manner and a warning is displayed. If neither option is
+possible (e.g. because of a company policy), you can set
+[`HF_HUB_DISABLE_SYMLINKS_WARNING=1`](./package_reference/environment_variables#hfhubdisablesymlinkswarning)
+to silence the warning and accept the extra disk usage. Please read
+[the cache limitations](./guides/manage-cache#limitations) section for more details.
 - Filepaths on the Hub can have special characters (e.g. `"path/to?/my/file"`). Windows is
 more restrictive on [special characters](https://learn.microsoft.com/en-us/windows/win32/intl/character-sets-used-in-file-names)
 which makes it impossible to download those files on Windows. Hopefully this is a rare case.


### PR DESCRIPTION
## Summary
The install page's Windows limitations section already covers developer mode and running as admin, but not the third option when neither is possible (company policy, etc.).

This adds `HF_HUB_DISABLE_SYMLINKS_WARNING=1` on that install-time list, with a link to the existing env-var reference. The cache guide already documents it; this is the remaining install-time gap from #3636.

Closes #3636

## Test plan
- [x] `doc-builder build huggingface_hub docs/source/en` (57 MDX files, internal links resolve)
- [x] `make quality`
- [x] Microsoft developer-mode URL returns 200
- [x] `#hfhubdisablesymlinkswarning` anchor matches `manage-cache.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API impact.
> 
> **Overview**
> **Windows limitations** on the installation page now documents the symlink cache behavior more completely for new installs.
> 
> The symlink bullet adds a link to Microsoft’s developer-mode docs, notes that a **warning** appears when symlinks are off, and describes a third path when developer mode and admin aren’t viable: set **`HF_HUB_DISABLE_SYMLINKS_WARNING=1`** (linked to the env-var reference) to suppress the warning and accept higher disk use.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 326951cd6634433a8a6720b8f1e2ac20ac8176f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->