### PR TITLE
fix: retry http_get when the response headers time out

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -337,9 +337,9 @@ def http_get(
     """
     Download a remote file. Do not gobble up errors, and will return errors tailored to the Hugging Face Hub.
 
-    If ConnectionError (SSLError) or ReadTimeout happen while streaming data from the server, it is most likely a
-    transient error (network outage?). We log a warning message and try to resume the download a few times before
-    giving up. The method gives up after 5 attempts if no new data has being received from the server.
+    If ConnectionError (SSLError) or ReadTimeout happen while requesting or streaming data from the server, it is most
+    likely a transient error (network outage?). We log a warning message and try to resume the download a few times
+    before giving up. The method gives up after 5 attempts if no new data has being received from the server.
 
     Args:
         url (`str`):
@@ -373,100 +373,114 @@ def http_get(
             " Install `hf_xet` with `pip install hf_xet` for xet-powered downloads."
         )
 
-    with http_stream_backoff(
-        method="GET",
-        url=url,
-        headers=headers,
-        timeout=constants.HF_HUB_DOWNLOAD_TIMEOUT,
-        retry_on_exceptions=(),
-        retry_on_status_codes=(408, 429),
-    ) as response:
-        hf_raise_for_status(response)
-
-        # If we requested a Range but got 200 back, the server ignored our Range header
-        # (e.g. CloudFront with Accept-Encoding: gzip). Reset file to avoid corruption.
-        if resume_size > 0 and response.status_code == 200:
-            temp_file.seek(0)
-            temp_file.truncate()
-            if _tqdm_bar is not None:
-                # When the progress bar is reused across retries, its counter has already been advanced by `resume_size`
-                # worth of chunks from earlier attempts. Those bytes are gone from disk now, so roll the counter back
-                # to keep the upcoming full re-download from double-counting (e.g. ending at 130/100 on a 100-byte file).
-                _tqdm_bar.update(-resume_size)
-                if callable(update_transfer := getattr(_tqdm_bar, "update_transfer", None)):
-                    update_transfer(-resume_size)
-            resume_size = 0
-
-        total: int | None = _get_file_length_from_http_response(response)
-        if total is None:
-            # Hub serves compressible text files (e.g. vocab.json) with `Content-Encoding: gzip` and
-            # `Transfer-Encoding: chunked`, so the response carries no `Content-Length`. Fall back to the caller's
-            # `expected_size` (always known from the metadata HEAD on the hf_hub path) so the progress bar, and any
-            # aggregating wrapper such as snapshot_download's `_AggregatedTqdm` — still sees the file size.
-            total = expected_size
-
-        if displayed_filename is None:
-            displayed_filename = url
-            content_disposition = response.headers.get("Content-Disposition")
-            if content_disposition is not None:
-                match = HEADER_FILENAME_PATTERN.search(content_disposition)
-                if match is not None:
-                    # Means file is on CDN
-                    displayed_filename = match.groupdict()["filename"]
-
-        # Truncate filename if too long to display
-        if len(displayed_filename) > 40:
-            displayed_filename = f"(…){displayed_filename[-40:]}"
-
-        consistency_error_message = (
-            f"Consistency check failed: file should be of size {expected_size} but has size"
-            f" {{actual_size}} ({displayed_filename}).\nThis is usually due to network issues while downloading the file."
-            " Please retry with `force_download=True`."
-        )
-        progress_cm = _get_progress_bar_context(
-            desc=displayed_filename,
-            log_level=logger.getEffectiveLevel(),
-            total=total,
-            initial=resume_size,
-            name="huggingface_hub.http_get",
+    def _resume_download(error: Exception, from_size: int, progress_bar: tqdm | None) -> None:
+        """Resume the download from `from_size` after a transient error, or give up if too many attempts failed."""
+        if _nb_retries <= 0:
+            logger.warning("Error while downloading from %s: %s\nMax retries exceeded.", url, str(error))
+            raise error
+        logger.warning("Error while downloading from %s: %s\nTrying to resume download...", url, str(error))
+        time.sleep(1)
+        return http_get(
+            url=url,
+            temp_file=temp_file,
+            resume_size=from_size,
+            headers=initial_headers,
+            expected_size=expected_size,
             tqdm_class=tqdm_class,
-            _tqdm_bar=_tqdm_bar,
+            _nb_retries=_nb_retries - 1,
+            # Reuse the existing progress bar across retries so a custom `tqdm_class` (e.g. snapshot_download's `_AggregatedTqdm`,
+            # which mutates a shared parent bar in `__init__`) is not re-instantiated and does not double-count `total`/`initial`.
+            _tqdm_bar=progress_bar,
         )
 
-        with progress_cm as progress:
-            new_resume_size = resume_size
-            try:
-                for chunk in response.iter_bytes(chunk_size=constants.DOWNLOAD_CHUNK_SIZE):
-                    if chunk:  # filter out keep-alive new chunks
-                        progress.update(len(chunk))
-                        if callable(update_transfer := getattr(progress, "update_transfer", None)):
-                            update_transfer(len(chunk))
-                        temp_file.write(chunk)
-                        new_resume_size += len(chunk)
-                        # Some data has been downloaded from the server so we reset the number of retries.
-                        _nb_retries = 5
-            except (httpx.ConnectError, httpx.TimeoutException, httpx.RemoteProtocolError) as e:
-                # If ConnectionError (SSLError), ReadTimeout, or RemoteProtocolError (peer closed the connection before
-                # sending the complete body) happen while streaming data from the server, it is most likely a transient
-                # error (network outage?). We log a warning message and try to resume the download a few times  before
-                # giving up. The retry mechanism is basic but should be enough in most cases.
-                if _nb_retries <= 0:
-                    logger.warning("Error while downloading from %s: %s\nMax retries exceeded.", url, str(e))
-                    raise
-                logger.warning("Error while downloading from %s: %s\nTrying to resume download...", url, str(e))
-                time.sleep(1)
-                return http_get(
-                    url=url,
-                    temp_file=temp_file,
-                    resume_size=new_resume_size,
-                    headers=initial_headers,
-                    expected_size=expected_size,
-                    tqdm_class=tqdm_class,
-                    _nb_retries=_nb_retries - 1,
-                    # Reuse the existing progress bar across retries so a custom `tqdm_class` (e.g. snapshot_download's `_AggregatedTqdm`,
-                    # which mutates a shared parent bar in `__init__`) is not re-instantiated and does not double-count `total`/`initial`.
-                    _tqdm_bar=progress,
-                )
+    body_started = False
+    try:
+        with http_stream_backoff(
+            method="GET",
+            url=url,
+            headers=headers,
+            timeout=constants.HF_HUB_DOWNLOAD_TIMEOUT,
+            retry_on_exceptions=(),
+            retry_on_status_codes=(408, 429),
+        ) as response:
+            hf_raise_for_status(response)
+
+            # If we requested a Range but got 200 back, the server ignored our Range header
+            # (e.g. CloudFront with Accept-Encoding: gzip). Reset file to avoid corruption.
+            if resume_size > 0 and response.status_code == 200:
+                temp_file.seek(0)
+                temp_file.truncate()
+                if _tqdm_bar is not None:
+                    # When the progress bar is reused across retries, its counter has already been advanced by `resume_size`
+                    # worth of chunks from earlier attempts. Those bytes are gone from disk now, so roll the counter back
+                    # to keep the upcoming full re-download from double-counting (e.g. ending at 130/100 on a 100-byte file).
+                    _tqdm_bar.update(-resume_size)
+                    if callable(update_transfer := getattr(_tqdm_bar, "update_transfer", None)):
+                        update_transfer(-resume_size)
+                resume_size = 0
+
+            total: int | None = _get_file_length_from_http_response(response)
+            if total is None:
+                # Hub serves compressible text files (e.g. vocab.json) with `Content-Encoding: gzip` and
+                # `Transfer-Encoding: chunked`, so the response carries no `Content-Length`. Fall back to the caller's
+                # `expected_size` (always known from the metadata HEAD on the hf_hub path) so the progress bar, and any
+                # aggregating wrapper such as snapshot_download's `_AggregatedTqdm` — still sees the file size.
+                total = expected_size
+
+            if displayed_filename is None:
+                displayed_filename = url
+                content_disposition = response.headers.get("Content-Disposition")
+                if content_disposition is not None:
+                    match = HEADER_FILENAME_PATTERN.search(content_disposition)
+                    if match is not None:
+                        # Means file is on CDN
+                        displayed_filename = match.groupdict()["filename"]
+
+            # Truncate filename if too long to display
+            if len(displayed_filename) > 40:
+                displayed_filename = f"(…){displayed_filename[-40:]}"
+
+            consistency_error_message = (
+                f"Consistency check failed: file should be of size {expected_size} but has size"
+                f" {{actual_size}} ({displayed_filename}).\nThis is usually due to network issues while downloading the file."
+                " Please retry with `force_download=True`."
+            )
+            progress_cm = _get_progress_bar_context(
+                desc=displayed_filename,
+                log_level=logger.getEffectiveLevel(),
+                total=total,
+                initial=resume_size,
+                name="huggingface_hub.http_get",
+                tqdm_class=tqdm_class,
+                _tqdm_bar=_tqdm_bar,
+            )
+
+            with progress_cm as progress:
+                body_started = True
+                new_resume_size = resume_size
+                try:
+                    for chunk in response.iter_bytes(chunk_size=constants.DOWNLOAD_CHUNK_SIZE):
+                        if chunk:  # filter out keep-alive new chunks
+                            progress.update(len(chunk))
+                            if callable(update_transfer := getattr(progress, "update_transfer", None)):
+                                update_transfer(len(chunk))
+                            temp_file.write(chunk)
+                            new_resume_size += len(chunk)
+                            # Some data has been downloaded from the server so we reset the number of retries.
+                            _nb_retries = 5
+                except (httpx.ConnectError, httpx.TimeoutException, httpx.RemoteProtocolError) as e:
+                    # If ConnectionError (SSLError), ReadTimeout, or RemoteProtocolError (peer closed the connection
+                    # before sending the complete body) happen while streaming data from the server, it is most likely
+                    # a transient error (network outage?). We log a warning message and try to resume the download a
+                    # few times before giving up. The retry mechanism is basic but should be enough in most cases.
+                    return _resume_download(e, from_size=new_resume_size, progress_bar=progress)
+    except (httpx.ConnectError, httpx.TimeoutException, httpx.RemoteProtocolError) as e:
+        if body_started:
+            raise  # transient error while streaming the body: already retried above
+        # Same transient errors, but raised before the body is streamed (e.g. timeout while waiting for the response
+        # headers). Nothing has been downloaded in this attempt, so resume from what is already on disk.
+        # See https://github.com/huggingface/huggingface_hub/issues/4670.
+        return _resume_download(e, from_size=resume_size, progress_bar=_tqdm_bar)
 
     if expected_size is not None and expected_size != temp_file.tell():
         raise OSError(

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -1356,6 +1356,47 @@ class TestHttpGet:
         assert tracker.total == 100
         assert tracker.n == 100
 
+    def test_http_get_retries_when_stream_fails_before_response(self, caplog):
+        """Test that http_get resumes when the request fails before the response body is streamed.
+
+        A timeout can happen while waiting for the response headers, i.e. before any chunk is
+        received. It must be retried like a mid-body failure instead of aborting the download.
+
+        Regression test for https://github.com/huggingface/huggingface_hub/issues/4670.
+        """
+
+        def _fail_after(data: bytes):
+            yield data
+            raise httpx.ReadTimeout("Fake timeout while streaming the body")
+
+        streamed = [
+            self._mock_response(headers={"Content-Length": "100"}, iter_bytes=_fail_after(b"A" * 30)),
+            httpx.ReadTimeout("Fake timeout while waiting for the response headers"),
+            self._mock_response(
+                status_code=206,
+                headers={"Content-Length": "70", "Content-Range": "bytes 30-99/100"},
+                iter_bytes=iter([b"B" * 70]),
+            ),
+        ]
+        it = iter(streamed)
+        ranges = []
+
+        @contextmanager
+        def _mock_stream(*args, **kwargs):
+            ranges.append(kwargs["headers"].get("Range"))
+            response = next(it)
+            if isinstance(response, Exception):
+                raise response
+            yield response
+
+        with patch("huggingface_hub.file_download.http_stream_backoff", side_effect=_mock_stream):
+            temp_file = io.BytesIO()
+            http_get("fake_url", temp_file=temp_file, expected_size=100)
+
+        assert temp_file.getvalue() == b"A" * 30 + b"B" * 70
+        # The retry after the header timeout must resume from the bytes already on disk.
+        assert ranges == [None, "bytes=30-", "bytes=30-"]
+
     def test_http_get_falls_back_to_expected_size_when_response_lacks_content_length(self):
         """Test correct progress on small files when the response is gzip+chunked (i.e. no Content-Length).
 


### PR DESCRIPTION
## Summary
`http_get` already retries transient errors on the body stream by resuming with a \`Range\` request. A timeout while waiting for *response headers* (the \`_receive_response_headers\` path in #4670) was not caught, so \`snapshot_download\` crashed after a few successful resumes.

Handle the same exception types before the body starts streaming, and resume from the bytes already on disk using the existing 5-attempt budget. No new retry policy.

Closes #4670

## Test plan
- [x] \`pytest tests/test_file_download.py::TestHttpGet::test_http_get_retries_when_stream_fails_before_response\` fails on current main with \`httpx.ReadTimeout\` and passes after
- [x] \`pytest tests/test_file_download.py tests/test_offline_utils.py tests/test_utils_http.py tests/test_utils_tqdm.py -q\` → 167 passed
- [x] \`make style\` / \`make quality\`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Hub download retry logic used by cache and snapshot downloads; behavior is an extension of existing resume semantics rather than a new policy, with a targeted regression test.
> 
> **Overview**
> **`http_get`** now treats **`ConnectError`**, **`TimeoutException`**, and **`RemoteProtocolError`** the same whether they occur while waiting for response headers or while streaming the body. Previously only mid-stream failures were resumed with a **`Range`** request, so a header timeout could abort **`snapshot_download`** even after partial progress (#4670).
> 
> Retry behavior is centralized in a **`_resume_download`** helper (same 5-attempt budget, progress bar reuse). A **`body_started`** flag avoids double-handling when the inner stream loop already retried.
> 
> Adds **`test_http_get_retries_when_stream_fails_before_response`** to assert resume from bytes already on disk after a header **`ReadTimeout`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01bc864d676ee26fd5c0f8d57acf11d9f459a26e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->