### PR TITLE
[CI] Auto-close community PRs without a maintainer-scoped issue

### DIFF
--- a/.github/workflows/close-unscoped-community-prs.yml
+++ b/.github/workflows/close-unscoped-community-prs.yml
@@ -53,16 +53,10 @@ jobs:
           script: |
             const MARKER = "<!-- close-unscoped-community-pr -->";
             const MAX_REFERENCES = 20;
-            // Two different questions. Whether an issue was discussed: a reply from anyone on the
-            // team counts, read from `author_association` so a new team member needs no edit here.
-            // Whether a PR is already being handled: only the maintainers, since any of the many
-            // org members could drop a passing comment on a PR without taking it on.
-            const TEAM_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
 
             const maintainers = process.env.MAINTAINERS.split(",").map((login) => login.trim());
             const logins = new Set(maintainers.map((login) => login.toLowerCase()));
             const isMaintainer = (user) => user != null && logins.has(user.login.toLowerCase());
-            const scopesIssue = (comment) => isMaintainer(comment.user) || TEAM_ASSOCIATIONS.has(comment.author_association);
             const dryRun = process.env.DRY_RUN === "true";
 
             const { data: pr } = await github.rest.pulls.get({
@@ -76,7 +70,10 @@ jobs:
             // Load-bearing: `dependabot[bot]` and our own app bots report `CONTRIBUTOR`, which the
             // check below does not exempt.
             if (pr.user.type === "Bot" || pr.user.login.endsWith("[bot]")) return skip("opened by a bot");
-            if (TEAM_ASSOCIATIONS.has(pr.author_association)) {
+            // Anyone with write access here is out of scope, whatever their name. Every other
+            // decision below asks for one of `MAINTAINERS` specifically: an org member commenting
+            // is not the same as one of us taking the change on.
+            if (["OWNER", "MEMBER", "COLLABORATOR"].includes(pr.author_association)) {
               return skip(`author is ${pr.author_association}, so they have write access here`);
             }
             if (isMaintainer(pr.user)) return skip("opened by a maintainer");
@@ -130,14 +127,14 @@ jobs:
                 throw error;
               }
               if (issue.pull_request) continue; // a PR, not an issue
-              // Only a reply counts. A maintainer opening an issue is not agreement that someone
-              // else should implement it: CONTRIBUTING.md says we usually pick those up ourselves.
+              // Only a maintainer reply counts. Them opening the issue is not agreement that
+              // someone else should implement it: CONTRIBUTING.md says we pick those up ourselves.
               const comments = await github.paginate(github.rest.issues.listComments, {
                 ...context.repo,
                 issue_number: number,
                 per_page: 100,
               });
-              const reply = comments.find(scopesIssue);
+              const reply = comments.find((comment) => isMaintainer(comment.user));
               if (reply) {
                 scoped = { number, login: reply.user.login };
                 break;

--- a/.github/workflows/close-unscoped-community-prs.yml
+++ b/.github/workflows/close-unscoped-community-prs.yml
@@ -130,10 +130,8 @@ jobs:
                 throw error;
               }
               if (issue.pull_request) continue; // a PR, not an issue
-              if (isMaintainer(issue.user, issue.author_association)) {
-                scoped = { number, login: issue.user.login, action: "opened it" };
-                break;
-              }
+              // Only a reply counts. A maintainer opening an issue is not agreement that someone
+              // else should implement it: CONTRIBUTING.md says we usually pick those up ourselves.
               const comments = await github.paginate(github.rest.issues.listComments, {
                 ...context.repo,
                 issue_number: number,
@@ -141,13 +139,13 @@ jobs:
               });
               const reply = comments.find((comment) => isMaintainer(comment.user, comment.author_association));
               if (reply) {
-                scoped = { number, login: reply.user.login, action: "replied to it" };
+                scoped = { number, login: reply.user.login };
                 break;
               }
             }
 
             if (scoped) {
-              core.info(`Keeping PR #${pr.number} open: @${scoped.login} ${scoped.action} in #${scoped.number}`);
+              core.info(`Keeping PR #${pr.number} open: @${scoped.login} replied to it in #${scoped.number}`);
               return;
             }
 

--- a/.github/workflows/close-unscoped-community-prs.yml
+++ b/.github/workflows/close-unscoped-community-prs.yml
@@ -53,16 +53,16 @@ jobs:
           script: |
             const MARKER = "<!-- close-unscoped-community-pr -->";
             const MAX_REFERENCES = 20;
-            // `author_association` is the server's answer to "does this person have write access
-            // here", for both the PR author and whoever replied on an issue. Relying on it means a
-            // new team member counts without editing this file. `MAINTAINERS` is only the list we
-            // ping in the comment, plus a safety net against ever closing a maintainer's own PR.
+            // Two different questions. Whether an issue was discussed: a reply from anyone on the
+            // team counts, read from `author_association` so a new team member needs no edit here.
+            // Whether a PR is already being handled: only the maintainers, since any of the many
+            // org members could drop a passing comment on a PR without taking it on.
             const TEAM_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
 
             const maintainers = process.env.MAINTAINERS.split(",").map((login) => login.trim());
             const logins = new Set(maintainers.map((login) => login.toLowerCase()));
-            const isNamedMaintainer = (user) => user != null && logins.has(user.login.toLowerCase());
-            const isMaintainer = (user, association) => isNamedMaintainer(user) || TEAM_ASSOCIATIONS.has(association);
+            const isMaintainer = (user) => user != null && logins.has(user.login.toLowerCase());
+            const scopesIssue = (comment) => isMaintainer(comment.user) || TEAM_ASSOCIATIONS.has(comment.author_association);
             const dryRun = process.env.DRY_RUN === "true";
 
             const { data: pr } = await github.rest.pulls.get({
@@ -79,7 +79,7 @@ jobs:
             if (TEAM_ASSOCIATIONS.has(pr.author_association)) {
               return skip(`author is ${pr.author_association}, so they have write access here`);
             }
-            if (isNamedMaintainer(pr.user)) return skip("opened by a maintainer");
+            if (isMaintainer(pr.user)) return skip("opened by a maintainer");
 
             // Only the author or someone with triage/write access can reopen a PR, so anyone other
             // than the author reopening it is a deliberate override. Don't undo it.
@@ -93,7 +93,7 @@ jobs:
               github.paginate(github.rest.issues.listComments, { ...context.repo, issue_number: pr.number, per_page: 100 }),
               github.paginate(github.rest.pulls.listReviews, { ...context.repo, pull_number: pr.number, per_page: 100 }),
             ]);
-            const engaged = [...prComments, ...prReviews].find((event) => isMaintainer(event.user, event.author_association));
+            const engaged = [...prComments, ...prReviews].find((event) => isMaintainer(event.user));
             if (engaged) return skip(`@${engaged.user.login} already commented on or reviewed it`);
 
             // The author can reopen their own PR, so we may land on the same one twice.
@@ -137,7 +137,7 @@ jobs:
                 issue_number: number,
                 per_page: 100,
               });
-              const reply = comments.find((comment) => isMaintainer(comment.user, comment.author_association));
+              const reply = comments.find(scopesIssue);
               if (reply) {
                 scoped = { number, login: reply.user.login };
                 break;

--- a/.github/workflows/close-unscoped-community-prs.yml
+++ b/.github/workflows/close-unscoped-community-prs.yml
@@ -55,8 +55,8 @@ jobs:
             const MAX_REFERENCES = 20;
             // `author_association` is the server's answer to "does this person have write access
             // here", for both the PR author and whoever replied on an issue. Relying on it means a
-            // new team member counts without editing this file. `MAINTAINERS` is the list we ping,
-            // and the fallback when there is no association to read (a `reopened` event sender).
+            // new team member counts without editing this file. `MAINTAINERS` is only the list we
+            // ping in the comment, plus a safety net against ever closing a maintainer's own PR.
             const TEAM_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
 
             const maintainers = process.env.MAINTAINERS.split(",").map((login) => login.trim());
@@ -81,9 +81,11 @@ jobs:
             }
             if (isNamedMaintainer(pr.user)) return skip("opened by a maintainer");
 
-            // Reopening is how a maintainer overrides a previous close, so don't close it again.
-            if (context.payload.action === "reopened" && isNamedMaintainer(context.payload.sender)) {
-              return skip(`reopened by @${context.payload.sender.login}`);
+            // Only the author or someone with triage/write access can reopen a PR, so anyone other
+            // than the author reopening it is a deliberate override. Don't undo it.
+            const sender = context.payload.sender;
+            if (context.payload.action === "reopened" && sender.login.toLowerCase() !== pr.user.login.toLowerCase()) {
+              return skip(`reopened by @${sender.login}`);
             }
 
             // A maintainer already engaged with the PR itself, so let the human decision stand.

--- a/.github/workflows/close-unscoped-community-prs.yml
+++ b/.github/workflows/close-unscoped-community-prs.yml
@@ -1,6 +1,7 @@
-# Enforces the "open an issue first" policy from CONTRIBUTING.md for first-time contributors:
-# a PR from someone who never contributed before is closed unless it links an issue that a
-# maintainer already replied to.
+# Enforces the "open an issue first" policy from CONTRIBUTING.md for community contributions:
+# a PR from anyone without write access on this repo is closed unless it links an issue that a
+# maintainer already replied to. This includes contributors who already had a PR merged, since
+# the policy is about scoping work upfront, not about being new.
 #
 # Uses `pull_request_target` because `GITHUB_TOKEN` is read-only for PRs opened from forks.
 # The PR branch is never checked out, so no untrusted code runs here.
@@ -10,7 +11,7 @@
 # `github.event_name == 'pull_request_target'` from `DRY_RUN` below. Until then, act on a
 # single PR with `workflow_dispatch` and `dry_run` unchecked.
 
-name: Close unscoped first-time PRs
+name: Close unscoped community PRs
 
 on:
   pull_request_target:
@@ -33,7 +34,7 @@ permissions: {}
 # in between would leave "I am closing this" on an open PR. Serializing also keeps the
 # already-commented check below reliable when two events land on the same PR.
 concurrency:
-  group: close-unscoped-first-pr-${{ github.event.pull_request.number || inputs.pr_number }}
+  group: close-unscoped-community-pr-${{ github.event.pull_request.number || inputs.pr_number }}
   cancel-in-progress: false
 
 jobs:
@@ -50,17 +51,18 @@ jobs:
           DRY_RUN: ${{ inputs.dry_run || github.event_name == 'pull_request_target' }}
         with:
           script: |
-            const MARKER = "<!-- close-unscoped-first-pr -->";
+            const MARKER = "<!-- close-unscoped-community-pr -->";
             const MAX_REFERENCES = 20;
-            // Trusting `author_association` means a new team member counts without editing this
-            // file. `MAINTAINERS` stays as the list we ping and as a fallback when the API
-            // reports no association (e.g. the sender of a `reopened` event).
+            // `author_association` is the server's answer to "does this person have write access
+            // here", for both the PR author and whoever replied on an issue. Relying on it means a
+            // new team member counts without editing this file. `MAINTAINERS` is the list we ping,
+            // and the fallback when there is no association to read (a `reopened` event sender).
             const TEAM_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
 
             const maintainers = process.env.MAINTAINERS.split(",").map((login) => login.trim());
             const logins = new Set(maintainers.map((login) => login.toLowerCase()));
-            const isMaintainer = (user, association) =>
-              (user != null && logins.has(user.login.toLowerCase())) || TEAM_ASSOCIATIONS.has(association);
+            const isNamedMaintainer = (user) => user != null && logins.has(user.login.toLowerCase());
+            const isMaintainer = (user, association) => isNamedMaintainer(user) || TEAM_ASSOCIATIONS.has(association);
             const dryRun = process.env.DRY_RUN === "true";
 
             const { data: pr } = await github.rest.pulls.get({
@@ -71,14 +73,16 @@ jobs:
             const skip = (reason) => core.info(`Skipping PR #${pr.number}: ${reason}`);
 
             if (pr.state !== "open") return skip("already closed");
+            // Load-bearing: `dependabot[bot]` and our own app bots report `CONTRIBUTOR`, which the
+            // check below does not exempt.
             if (pr.user.type === "Bot" || pr.user.login.endsWith("[bot]")) return skip("opened by a bot");
-            if (!["FIRST_TIMER", "FIRST_TIME_CONTRIBUTOR", "NONE"].includes(pr.author_association)) {
-              return skip(`author association is ${pr.author_association}, not a first-time contributor`);
+            if (TEAM_ASSOCIATIONS.has(pr.author_association)) {
+              return skip(`author is ${pr.author_association}, so they have write access here`);
             }
-            if (isMaintainer(pr.user, pr.author_association)) return skip("opened by a maintainer");
+            if (isNamedMaintainer(pr.user)) return skip("opened by a maintainer");
 
             // Reopening is how a maintainer overrides a previous close, so don't close it again.
-            if (context.payload.action === "reopened" && isMaintainer(context.payload.sender)) {
+            if (context.payload.action === "reopened" && isNamedMaintainer(context.payload.sender)) {
               return skip(`reopened by @${context.payload.sender.login}`);
             }
 

--- a/.github/workflows/close-unscoped-first-pr.yml
+++ b/.github/workflows/close-unscoped-first-pr.yml
@@ -61,14 +61,18 @@ jobs:
             }
             if (isMaintainer(pr.user)) return skip("opened by a maintainer");
 
+            // Reopening is how a maintainer overrides a previous close, so don't close it again.
+            if (context.payload.action === "reopened" && isMaintainer(context.payload.sender)) {
+              return skip(`reopened by @${context.payload.sender.login}`);
+            }
+
             // A maintainer already engaged with the PR itself, so let the human decision stand.
-            const prComments = await github.paginate(github.rest.issues.listComments, {
-              ...context.repo,
-              issue_number: pr.number,
-              per_page: 100,
-            });
-            const engaged = prComments.find((comment) => isMaintainer(comment.user));
-            if (engaged) return skip(`@${engaged.user.login} already commented on it`);
+            const [prComments, prReviews] = await Promise.all([
+              github.paginate(github.rest.issues.listComments, { ...context.repo, issue_number: pr.number, per_page: 100 }),
+              github.paginate(github.rest.pulls.listReviews, { ...context.repo, pull_number: pr.number, per_page: 100 }),
+            ]);
+            const engaged = [...prComments, ...prReviews].find((event) => isMaintainer(event.user));
+            if (engaged) return skip(`@${engaged.user.login} already commented on or reviewed it`);
 
             // Any `#123` or issue URL in the title or body counts as a reference. Over-matching is
             // intentional: a false reference leaves the PR open, a missed one closes it.

--- a/.github/workflows/close-unscoped-first-pr.yml
+++ b/.github/workflows/close-unscoped-first-pr.yml
@@ -1,0 +1,141 @@
+# Enforces the "open an issue first" policy from CONTRIBUTING.md for first-time contributors:
+# a PR from someone who never contributed before is closed unless it links an issue that a
+# maintainer already replied to.
+#
+# Uses `pull_request_target` because `GITHUB_TOKEN` is read-only for PRs opened from forks.
+# The PR branch is never checked out, so no untrusted code runs here.
+
+name: Close unscoped first-time PRs
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to evaluate"
+        required: true
+        type: string
+      dry_run:
+        description: "Log the decision without commenting or closing"
+        required: false
+        type: boolean
+        default: true
+
+permissions: {}
+
+concurrency:
+  group: close-unscoped-first-pr-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: true
+
+jobs:
+  check-scoped-issue:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: read
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          MAINTAINERS: Wauplin,hanouticelina
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+          DRY_RUN: ${{ inputs.dry_run || false }}
+        with:
+          script: |
+            const maintainers = process.env.MAINTAINERS.split(",").map((login) => login.trim());
+            const lowercased = new Set(maintainers.map((login) => login.toLowerCase()));
+            const isMaintainer = (user) => user != null && lowercased.has(user.login.toLowerCase());
+            const dryRun = process.env.DRY_RUN === "true";
+
+            const { data: pr } = await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: Number(process.env.PR_NUMBER),
+            });
+
+            const skip = (reason) => core.info(`Skipping PR #${pr.number}: ${reason}`);
+
+            if (pr.state !== "open") return skip("already closed");
+            if (pr.user.type === "Bot" || pr.user.login.endsWith("[bot]")) return skip("opened by a bot");
+            if (!["FIRST_TIMER", "FIRST_TIME_CONTRIBUTOR", "NONE"].includes(pr.author_association)) {
+              return skip(`author association is ${pr.author_association}, not a first-time contributor`);
+            }
+            if (isMaintainer(pr.user)) return skip("opened by a maintainer");
+
+            // A maintainer already engaged with the PR itself, so let the human decision stand.
+            const prComments = await github.paginate(github.rest.issues.listComments, {
+              ...context.repo,
+              issue_number: pr.number,
+              per_page: 100,
+            });
+            const engaged = prComments.find((comment) => isMaintainer(comment.user));
+            if (engaged) return skip(`@${engaged.user.login} already commented on it`);
+
+            // Any `#123` or issue URL in the title or body counts as a reference. Over-matching is
+            // intentional: a false reference leaves the PR open, a missed one closes it.
+            const text = `${pr.title}\n\n${pr.body || ""}`;
+            const referenced = new Set();
+            for (const [, number] of text.matchAll(/#(\d+)/g)) {
+              referenced.add(Number(number));
+            }
+            const issueUrl = /https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/issues\/(\d+)/gi;
+            for (const [, owner, repo, number] of text.matchAll(issueUrl)) {
+              if (owner.toLowerCase() === context.repo.owner.toLowerCase() && repo.toLowerCase() === context.repo.repo.toLowerCase()) {
+                referenced.add(Number(number));
+              }
+            }
+            core.info(`Referenced numbers: ${[...referenced].join(", ") || "none"}`);
+
+            let scoped = null;
+            for (const number of [...referenced].sort((a, b) => a - b)) {
+              let issue;
+              try {
+                ({ data: issue } = await github.rest.issues.get({ ...context.repo, issue_number: number }));
+              } catch (error) {
+                if (error.status === 404) continue;
+                throw error;
+              }
+              if (issue.pull_request) continue; // a PR, not an issue
+              if (isMaintainer(issue.user)) {
+                scoped = { number, login: issue.user.login, action: "opened it" };
+                break;
+              }
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                ...context.repo,
+                issue_number: number,
+                per_page: 100,
+              });
+              const reply = comments.find((comment) => isMaintainer(comment.user));
+              if (reply) {
+                scoped = { number, login: reply.user.login, action: "replied to it" };
+                break;
+              }
+            }
+
+            if (scoped) {
+              core.info(`Keeping PR #${pr.number} open: @${scoped.login} ${scoped.action} in #${scoped.number}`);
+              return;
+            }
+
+            const body = [
+              `Hi @${pr.user.login}, thanks for taking the time to open this PR!`,
+              "",
+              "As explained in our [contributing guide](https://github.com/huggingface/huggingface_hub/blob/main/CONTRIBUTING.md#found-a-bug-or-want-a-new-feature-open-an-issue-first), we ask that changes be discussed in an issue before any code is written. We prefer to implement most code changes ourselves, so that we can keep the codebase consistent and avoid long review cycles that end up being frustrating for everyone.",
+              "",
+              "This PR does not link an issue that a maintainer has replied to, so I am closing it for now. This is automated and it is not a judgment on your work.",
+              "",
+              "If you would like to take this further:",
+              "1. Open an issue describing what is wrong or missing, why it matters, and how you would expect it to work.",
+              `2. Wait for a maintainer (${maintainers.map((login) => `@${login}`).join(" or ")}) to reply and agree on the approach.`,
+              "3. Reopen this PR and link that issue in the description.",
+              "",
+              "Documentation improvements and typo fixes are always welcome without an issue. If that is what this PR does, say so here and a maintainer will reopen it.",
+            ].join("\n");
+
+            if (dryRun) {
+              core.info(`[dry run] Would close PR #${pr.number} with comment:\n${body}`);
+              return;
+            }
+
+            await github.rest.issues.createComment({ ...context.repo, issue_number: pr.number, body });
+            await github.rest.pulls.update({ ...context.repo, pull_number: pr.number, state: "closed" });
+            core.notice(`Closed PR #${pr.number}: no linked issue with a maintainer reply`);

--- a/.github/workflows/close-unscoped-first-pr.yml
+++ b/.github/workflows/close-unscoped-first-pr.yml
@@ -4,6 +4,11 @@
 #
 # Uses `pull_request_target` because `GITHUB_TOKEN` is read-only for PRs opened from forks.
 # The PR branch is never checked out, so no untrusted code runs here.
+#
+# The automatic trigger is dry-run only for now: it logs its decision without commenting or
+# closing, so we can watch it against real PRs. To enable enforcement, drop
+# `github.event_name == 'pull_request_target'` from `DRY_RUN` below. Until then, act on a
+# single PR with `workflow_dispatch` and `dry_run` unchecked.
 
 name: Close unscoped first-time PRs
 
@@ -24,9 +29,12 @@ on:
 
 permissions: {}
 
+# Deliberately not `cancel-in-progress`: commenting and closing are two calls, and a cancellation
+# in between would leave "I am closing this" on an open PR. Serializing also keeps the
+# already-commented check below reliable when two events land on the same PR.
 concurrency:
   group: close-unscoped-first-pr-${{ github.event.pull_request.number || inputs.pr_number }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   check-scoped-issue:
@@ -39,12 +47,20 @@ jobs:
         env:
           MAINTAINERS: Wauplin,hanouticelina
           PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
-          DRY_RUN: ${{ inputs.dry_run || false }}
+          DRY_RUN: ${{ inputs.dry_run || github.event_name == 'pull_request_target' }}
         with:
           script: |
+            const MARKER = "<!-- close-unscoped-first-pr -->";
+            const MAX_REFERENCES = 20;
+            // Trusting `author_association` means a new team member counts without editing this
+            // file. `MAINTAINERS` stays as the list we ping and as a fallback when the API
+            // reports no association (e.g. the sender of a `reopened` event).
+            const TEAM_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
+
             const maintainers = process.env.MAINTAINERS.split(",").map((login) => login.trim());
-            const lowercased = new Set(maintainers.map((login) => login.toLowerCase()));
-            const isMaintainer = (user) => user != null && lowercased.has(user.login.toLowerCase());
+            const logins = new Set(maintainers.map((login) => login.toLowerCase()));
+            const isMaintainer = (user, association) =>
+              (user != null && logins.has(user.login.toLowerCase())) || TEAM_ASSOCIATIONS.has(association);
             const dryRun = process.env.DRY_RUN === "true";
 
             const { data: pr } = await github.rest.pulls.get({
@@ -59,7 +75,7 @@ jobs:
             if (!["FIRST_TIMER", "FIRST_TIME_CONTRIBUTOR", "NONE"].includes(pr.author_association)) {
               return skip(`author association is ${pr.author_association}, not a first-time contributor`);
             }
-            if (isMaintainer(pr.user)) return skip("opened by a maintainer");
+            if (isMaintainer(pr.user, pr.author_association)) return skip("opened by a maintainer");
 
             // Reopening is how a maintainer overrides a previous close, so don't close it again.
             if (context.payload.action === "reopened" && isMaintainer(context.payload.sender)) {
@@ -71,8 +87,11 @@ jobs:
               github.paginate(github.rest.issues.listComments, { ...context.repo, issue_number: pr.number, per_page: 100 }),
               github.paginate(github.rest.pulls.listReviews, { ...context.repo, pull_number: pr.number, per_page: 100 }),
             ]);
-            const engaged = [...prComments, ...prReviews].find((event) => isMaintainer(event.user));
+            const engaged = [...prComments, ...prReviews].find((event) => isMaintainer(event.user, event.author_association));
             if (engaged) return skip(`@${engaged.user.login} already commented on or reviewed it`);
+
+            // The author can reopen their own PR, so we may land on the same one twice.
+            const alreadyNotified = prComments.some((comment) => comment.body?.includes(MARKER));
 
             // Any `#123` or issue URL in the title or body counts as a reference. Over-matching is
             // intentional: a false reference leaves the PR open, a missed one closes it.
@@ -87,19 +106,25 @@ jobs:
                 referenced.add(Number(number));
               }
             }
-            core.info(`Referenced numbers: ${[...referenced].join(", ") || "none"}`);
+            // Each reference costs an API round-trip, so cap them: a body stuffed with `#N` should
+            // not be able to burn the token's hourly budget.
+            const candidates = [...referenced].sort((a, b) => a - b);
+            core.info(`Referenced numbers: ${candidates.join(", ") || "none"}`);
+            if (candidates.length > MAX_REFERENCES) {
+              core.info(`Only checking the first ${MAX_REFERENCES} of ${candidates.length} references`);
+            }
 
             let scoped = null;
-            for (const number of [...referenced].sort((a, b) => a - b)) {
+            for (const number of candidates.slice(0, MAX_REFERENCES)) {
               let issue;
               try {
                 ({ data: issue } = await github.rest.issues.get({ ...context.repo, issue_number: number }));
               } catch (error) {
-                if (error.status === 404) continue;
+                if (error.status === 404 || error.status === 410) continue;
                 throw error;
               }
               if (issue.pull_request) continue; // a PR, not an issue
-              if (isMaintainer(issue.user)) {
+              if (isMaintainer(issue.user, issue.author_association)) {
                 scoped = { number, login: issue.user.login, action: "opened it" };
                 break;
               }
@@ -108,7 +133,7 @@ jobs:
                 issue_number: number,
                 per_page: 100,
               });
-              const reply = comments.find((comment) => isMaintainer(comment.user));
+              const reply = comments.find((comment) => isMaintainer(comment.user, comment.author_association));
               if (reply) {
                 scoped = { number, login: reply.user.login, action: "replied to it" };
                 break;
@@ -130,16 +155,20 @@ jobs:
               "If you would like to take this further:",
               "1. Open an issue describing what is wrong or missing, why it matters, and how you would expect it to work.",
               `2. Wait for a maintainer (${maintainers.map((login) => `@${login}`).join(" or ")}) to reply and agree on the approach.`,
-              "3. Reopen this PR and link that issue in the description.",
+              "3. Link that issue in this PR's description, then reopen the PR.",
               "",
               "Documentation improvements and typo fixes are always welcome without an issue. If that is what this PR does, say so here and a maintainer will reopen it.",
             ].join("\n");
 
             if (dryRun) {
-              core.info(`[dry run] Would close PR #${pr.number} with comment:\n${body}`);
+              core.info(`[dry run] Would close PR #${pr.number}${alreadyNotified ? " (already commented)" : " with comment"}:\n${body}`);
               return;
             }
 
-            await github.rest.issues.createComment({ ...context.repo, issue_number: pr.number, body });
+            if (alreadyNotified) {
+              core.info("Already commented on this PR once, closing without repeating it");
+            } else {
+              await github.rest.issues.createComment({ ...context.repo, issue_number: pr.number, body: `${body}\n\n${MARKER}` });
+            }
             await github.rest.pulls.update({ ...context.repo, pull_number: pr.number, state: "closed" });
             core.notice(`Closed PR #${pr.number}: no linked issue with a maintainer reply`);


### PR DESCRIPTION
## Summary

Enforces the "open an issue first" policy from [CONTRIBUTING.md](https://github.com/huggingface/huggingface_hub/blob/main/CONTRIBUTING.md#found-a-bug-or-want-a-new-feature-open-an-issue-first): when someone outside the team opens a PR that doesn't link an issue a maintainer has replied to, the bot comments and closes it.

Still a draft because auto-closing community PRs is a policy call, not just a code change. See the open questions at the bottom.

**Merging this closes nothing.** On the automatic trigger `DRY_RUN` is forced on, so it only writes its decision to the Actions log and we can watch it on live PRs first. Enabling enforcement later means deleting `github.event_name == 'pull_request_target'` from one line.

## What it does

Runs on `pull_request_target` (`opened`, `reopened`), plus a `workflow_dispatch` button that evaluates a single PR by number. It decides in this order and stops at the first match:

| Check | Result |
|---|---|
| PR is already closed | do nothing |
| Author is a bot | do nothing |
| Author has write access (`OWNER` / `MEMBER` / `COLLABORATOR`) | do nothing |
| Author is in `MAINTAINERS` | do nothing |
| Someone other than the author reopened it | do nothing, a human overrode the bot |
| A maintainer already commented on or reviewed the PR | do nothing, a human is handling it |
| The PR links an issue a maintainer replied to | do nothing, the work was scoped |
| none of the above | comment and close |

"Links an issue" means any `#123` or `huggingface_hub` issue URL in the title or body, up to 20 per PR, skipping references that turn out to be PRs or that don't exist. Only a maintainer **reply** counts. A maintainer opening the issue does not: per `CONTRIBUTING.md` we file issues we intend to pick up ourselves. Nor does a comment from another org member, since there are hundreds of them and a passing comment is not one of us agreeing to the change.

## Decisions worth calling out

- **`pull_request_target` with no checkout.** Needed because `GITHUB_TOKEN` is read-only for fork PRs. The PR branch is never checked out, and untrusted values (`pr.title`, `pr.body`) only reach the script as API data at runtime, so nothing untrusted is interpolated or executed. Uses `GITHUB_TOKEN` with `pull-requests: write` + `issues: read`, so no new secrets or App setup.
- **`CONTRIBUTOR` is in scope.** Someone who already had a PR merged here is treated like a newcomer, because the policy is about scoping work upfront, not about being new.
- **The bot guard is load-bearing.** `dependabot[bot]` and our app bots report `author_association: CONTRIBUTOR`, which is not exempt, so the `user.type == "Bot"` check is the only thing keeping their PRs alive.
- **Reopening is the override.** Only the author or someone with triage access can reopen a PR, so any sender other than the author means a human decided to keep it. That guard consults no list, so a stale `MAINTAINERS` can never cause a close nobody can undo.
- **We only comment once.** The comment carries an HTML marker. If the author reopens without linking a scoped issue, the PR is closed again but silently.
- **Reference detection over-matches on purpose.** A spurious `#123` leaves a PR open and a missed one closes it, so it fails in the safe direction. The 20-reference cap keeps a body stuffed with `#N` from burning the token's hourly API budget.
- **No `cancel-in-progress`.** Commenting and closing are two calls, and a cancellation in between would leave "I am closing this" sitting on an open PR.

## The comment contributors will get

> Hi @newcomer, thanks for taking the time to open this PR!
>
> As explained in our [contributing guide](https://github.com/huggingface/huggingface_hub/blob/main/CONTRIBUTING.md#found-a-bug-or-want-a-new-feature-open-an-issue-first), we ask that changes be discussed in an issue before any code is written. We prefer to implement most code changes ourselves, so that we can keep the codebase consistent and avoid long review cycles that end up being frustrating for everyone.
>
> This PR does not link an issue that a maintainer has replied to, so I am closing it for now. This is automated and it is not a judgment on your work.
>
> If you would like to take this further:
> 1. Open an issue describing what is wrong or missing, why it matters, and how you would expect it to work.
> 2. Wait for a maintainer (@Wauplin or @hanouticelina) to reply and agree on the approach.
> 3. Link that issue in this PR's description, then reopen the PR.
>
> Documentation improvements and typo fixes are always welcome without an issue. If that is what this PR does, say so here and a maintainer will reopen it.

Authors can reopen their own PRs, so step 3 needs no maintainer action. Linking comes before reopening on purpose: reopening first would just get the PR closed again, since the workflow re-reads the description on the `reopened` event.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
