### PR TITLE
Do not use a redirect's Content-Length as file size in get_hf_file_metadata

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1634,7 +1634,8 @@ def get_hf_file_metadata(
         # Do not use directly `url` as we might have followed relative redirects.
         location=response.headers.get("Location") or str(response.request.url),  # type: ignore
         size=_int_or_none(
-            response.headers.get(constants.HUGGINGFACE_HEADER_X_LINKED_SIZE) or response.headers.get("Content-Length")
+            response.headers.get(constants.HUGGINGFACE_HEADER_X_LINKED_SIZE)
+            or (None if response.is_redirect else response.headers.get("Content-Length"))
         ),
         xet_file_data=parse_xet_file_data_from_response(response, endpoint=endpoint),  # type: ignore
     )


### PR DESCRIPTION
Short PR for a small bug described in the attached issue. tl;dr content-length is not correct file size on redirect responses (redirect response body size is content-length not the file size).

AI summary: The metadata HEAD follows only relative redirects, so `get_hf_file_metadata` can read headers off an unfollowed absolute redirect. On a 3xx, `Content-Length` describes the redirect body, not the target file, so falling back to it when `X-Linked-Size` is absent records a wrong size. Only fall back to `Content-Length` on non-redirect responses and leave the size unknown otherwise. Matches the guard proposed for the Rust client in huggingface/hf-hub#191.

Fix #4698

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single conditional change in metadata header parsing; reduces wrong-size metadata without altering download or auth paths.
> 
> **Overview**
> **Fixes incorrect file size in `get_hf_file_metadata` when the metadata HEAD stops on an unfollowed redirect.**
> 
> Hub metadata requests only follow relative redirects, so a 3xx can leave `Content-Length` referring to the redirect body rather than the linked file. The `size` field now uses `X-Linked-Size` when present, and only falls back to `Content-Length` when `response.is_redirect` is false; otherwise size stays unknown. Aligns with the Rust `hf-hub` guard for [#4698](https://github.com/huggingface/huggingface_hub/issues/4698).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d6d05c00d72df3a985358260f48dc8adbc8b19c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->