### PR TITLE
[Tree cache] Rebuild HEAD metadata from tree listing without Xet

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1686,7 +1686,7 @@ def _get_metadata_or_catch_error(
 
     # Skip the per-file HEAD call when the file metadata can be rebuilt from a tree listing cached on disk.
     if tree_cache_folder is not None and REGEX_COMMIT_HASH.match(revision):
-        tree_metadata = _xet_file_metadata_from_tree_cache(
+        tree_metadata = _file_metadata_from_tree_cache(
             tree_cache_folder=tree_cache_folder,
             repo_id=repo_id,
             repo_type=repo_type,
@@ -1830,7 +1830,7 @@ def _detach_tracebacks(error: BaseException) -> None:
         pending.extend(exc for exc in (current.__cause__, current.__context__) if exc is not None)
 
 
-def _xet_file_metadata_from_tree_cache(
+def _file_metadata_from_tree_cache(
     *,
     tree_cache_folder: str,
     repo_id: str,
@@ -1838,43 +1838,55 @@ def _xet_file_metadata_from_tree_cache(
     commit_hash: str,
     filename: str,
     endpoint: str | None,
-) -> tuple[str, str, str, int, XetFileData, None] | None:
+) -> tuple[str, str, str, int, XetFileData | None, None] | None:
     """Rebuild the metadata a HEAD call would return, from the on-disk tree listing cache.
 
-    The optimization is intentionally limited to Xet files when Xet is enabled: that's the only case where
-    skipping the HEAD call pays off, since Xet downloads don't rely on the `/resolve` redirect the HEAD call
-    would resolve. For regular files (or when Xet is unavailable) we return `None` and let the caller make the
-    HEAD call as usual. Also returns `None` when the commit's tree listing or the file is not cached.
+    Skipping the per-file HEAD call whenever the tree listing is cached saves a round-trip per file, and is
+    required in setups where the HEAD call itself cannot be used reliably - e.g. downloading through a mirror
+    or reverse proxy that strips the `Content-Length` header from HEAD responses (see the `HF_HUB_DISABLE_XET`
+    use case where downloads must go through such a proxy).
+
+    For LFS-tracked files, ETag/size mirror the server's HEAD response: they come from the LFS metadata
+    (`lfs_sha256`/`lfs_size`) available in the tree listing. When Xet is available and the entry carries a valid
+    Xet hash, the returned metadata also includes the `XetFileData` so the download can use the Xet protocol.
+    Otherwise `xet_file_data` is `None` and the download falls back to the regular HTTP flow through the
+    `/resolve` endpoint (which is exactly what a mirror/proxy setup wants).
+
+    For regular (non-LFS) files, ETag/size come from the git blob (`blob_id`/`size`), matching what the server
+    returns on a HEAD call.
+
+    Returns `None` when the commit's tree listing or the file is not cached, or when the entry does not carry
+    enough metadata to rebuild the HEAD response.
     """
-    if not is_xet_available():
-        return None
     tree_entries = read_tree_cache(tree_cache_folder, commit_hash)
     if tree_entries is None:
         return None
     entry = tree_entries.get(filename)
-    if (
-        entry is None
-        or entry.xet_hash is None
-        or not is_valid_xet_hash(entry.xet_hash)
-        or entry.lfs_sha256 is None
-        or entry.lfs_size is None
-    ):
+    if entry is None:
         return None
 
-    xet_file_data = XetFileData(
-        file_hash=entry.xet_hash,
-        refresh_route=xet_connection_info_refresh_url(
-            token_type=XetTokenType.READ,
-            repo_id=repo_id,
-            repo_type=repo_type,
-            revision=commit_hash,
-            endpoint=endpoint,
-        ),
-    )
-    # Mirror the server's HEAD response: ETag/size come from the LFS metadata for LFS-tracked files (which Xet
-    # files are).
-    etag = entry.lfs_sha256
-    file_size = entry.lfs_size
+    if entry.lfs_sha256 is not None and entry.lfs_size is not None:
+        # LFS-tracked file: ETag/size mirror the server's HEAD response.
+        etag = entry.lfs_sha256
+        file_size = entry.lfs_size
+        xet_file_data = None
+        if is_xet_available() and entry.xet_hash is not None and is_valid_xet_hash(entry.xet_hash):
+            xet_file_data = XetFileData(
+                file_hash=entry.xet_hash,
+                refresh_route=xet_connection_info_refresh_url(
+                    token_type=XetTokenType.READ,
+                    repo_id=repo_id,
+                    repo_type=repo_type,
+                    revision=commit_hash,
+                    endpoint=endpoint,
+                ),
+            )
+    else:
+        # Regular file: use the git blob metadata from the tree listing.
+        etag = entry.blob_id
+        file_size = entry.size
+        xet_file_data = None
+
     location = hf_hub_url(repo_id, filename, repo_type=repo_type, revision=commit_hash, endpoint=endpoint)
     return (location, etag, commit_hash, file_size, xet_file_data, None)
 

--- a/tests/test_tree_cache.py
+++ b/tests/test_tree_cache.py
@@ -28,8 +28,8 @@ from huggingface_hub._tree_cache import (
 )
 from huggingface_hub.errors import CachedRepoTreeNotFoundError
 from huggingface_hub.file_download import (
+    _file_metadata_from_tree_cache,
     _get_metadata_or_catch_error,
-    _xet_file_metadata_from_tree_cache,
     hf_hub_url,
     repo_folder_name,
 )
@@ -131,15 +131,17 @@ def tree_cache_folder(tmp_path: Path):
 
 
 class TestTreeCacheSkipsHeadCall:
-    """The download path rebuilds metadata from the cached tree for Xet files, skipping the per-file HEAD call.
+    """The download path rebuilds metadata from the cached tree listing, skipping the per-file HEAD call.
 
-    The optimization is intentionally limited to Xet files (when Xet is enabled): that's the only case where
-    skipping the HEAD pays off. Regular files always HEAD, even with a cached tree.
+    Skipping the HEAD call is beneficial for Xet files (when Xet is enabled) but is also required in setups
+    where the HEAD call cannot be used reliably, e.g. when downloading through a reverse proxy that strips
+    the `Content-Length` header from HEAD responses (`HF_HUB_DISABLE_XET=1` + mirror). Regular files and
+    non-Xet downloads therefore also benefit from the cached tree.
     """
 
     def test_xet_file_metadata_from_tree_cache(self, tree_cache_folder: str):
         with patch("huggingface_hub.file_download.is_xet_available", return_value=True):
-            result = _xet_file_metadata_from_tree_cache(
+            result = _file_metadata_from_tree_cache(
                 tree_cache_folder=str(tree_cache_folder),
                 repo_id="user/repo",
                 repo_type="model",
@@ -160,41 +162,46 @@ class TestTreeCacheSkipsHeadCall:
             token_type=XetTokenType.READ, repo_id="user/repo", repo_type="model", revision=COMMIT_HASH
         )
 
-    def test_non_xet_file_returns_none(self, tree_cache_folder: str):
-        # `config.json` is a regular (non-Xet) file => the cache is not used, the caller must HEAD.
+    def test_non_xet_file_returns_metadata(self, tree_cache_folder: str):
+        # `config.json` is a regular (non-LFS) file: metadata is rebuilt from the git blob info.
         with patch("huggingface_hub.file_download.is_xet_available", return_value=True):
-            assert (
-                _xet_file_metadata_from_tree_cache(
-                    tree_cache_folder=tree_cache_folder,
-                    repo_id="user/repo",
-                    repo_type="model",
-                    commit_hash=COMMIT_HASH,
-                    filename="config.json",
-                    endpoint=None,
-                )
-                is None
+            result = _file_metadata_from_tree_cache(
+                tree_cache_folder=tree_cache_folder,
+                repo_id="user/repo",
+                repo_type="model",
+                commit_hash=COMMIT_HASH,
+                filename="config.json",
+                endpoint=None,
             )
+        assert result is not None
+        _location, etag, _commit_hash, size, xet_file_data, _error = result
+        assert etag == "blob-config"  # git blob id
+        assert size == 5
+        assert xet_file_data is None
 
-    def test_xet_file_returns_none_when_xet_unavailable(self, tree_cache_folder: str):
-        # Even a Xet file falls back to the HEAD call when Xet is not enabled.
+    def test_xet_file_returns_metadata_without_xet_when_xet_unavailable(self, tree_cache_folder: str):
+        # With Xet disabled, a Xet/LFS file still gets metadata from the cache (HTTP download flow) instead
+        # of falling back to the HEAD call.
         with patch("huggingface_hub.file_download.is_xet_available", return_value=False):
-            assert (
-                _xet_file_metadata_from_tree_cache(
-                    tree_cache_folder=tree_cache_folder,
-                    repo_id="user/repo",
-                    repo_type="model",
-                    commit_hash=COMMIT_HASH,
-                    filename="model.safetensors",
-                    endpoint=None,
-                )
-                is None
+            result = _file_metadata_from_tree_cache(
+                tree_cache_folder=tree_cache_folder,
+                repo_id="user/repo",
+                repo_type="model",
+                commit_hash=COMMIT_HASH,
+                filename="model.safetensors",
+                endpoint=None,
             )
+        assert result is not None
+        _location, etag, _commit_hash, size, xet_file_data, _error = result
+        assert etag == "sha256-model"
+        assert size == 1024
+        assert xet_file_data is None  # regular HTTP download through /resolve
 
     def test_no_tree_cache_returns_none(self, tmp_path: Path):  # not populated
         storage_folder = tmp_path / repo_folder_name(repo_id="user/repo", repo_type="model")
         with patch("huggingface_hub.file_download.is_xet_available", return_value=True):
             assert (
-                _xet_file_metadata_from_tree_cache(
+                _file_metadata_from_tree_cache(
                     tree_cache_folder=str(storage_folder),
                     repo_id="user/repo",
                     repo_type="model",
@@ -230,25 +237,28 @@ class TestTreeCacheSkipsHeadCall:
         assert xet_file_data is not None
         assert error is None
 
-    def test_get_metadata_heads_for_non_xet_file(self, tree_cache_folder: str):
-        # A regular file is not served from the tree cache => the HEAD call must still happen.
+    def test_get_metadata_skips_head_for_non_xet_file(self, tree_cache_folder: str):
+        # A regular (non-LFS) file is now also served from the tree cache => no HEAD call.
         with (
             patch("huggingface_hub.file_download.is_xet_available", return_value=True),
             patch("huggingface_hub.file_download.get_hf_file_metadata", side_effect=RuntimeError("HEAD called")),
         ):
-            with pytest.raises(RuntimeError, match="HEAD called"):
-                _get_metadata_or_catch_error(
-                    repo_id="user/repo",
-                    filename="config.json",
-                    repo_type="model",
-                    revision=COMMIT_HASH,
-                    endpoint=None,
-                    etag_timeout=10,
-                    headers={},
-                    token=None,
-                    local_files_only=False,
-                    tree_cache_folder=tree_cache_folder,
-                )
+            _url, etag, commit_hash, size, xet_file_data, error = _get_metadata_or_catch_error(
+                repo_id="user/repo",
+                filename="config.json",
+                repo_type="model",
+                revision=COMMIT_HASH,
+                endpoint=None,
+                etag_timeout=10,
+                headers={},
+                token=None,
+                local_files_only=False,
+                tree_cache_folder=tree_cache_folder,
+            )
+        assert etag == "blob-config"
+        assert size == 5
+        assert xet_file_data is None
+        assert error is None
 
     def test_get_metadata_does_not_use_tree_cache_for_branch(self, tree_cache_folder: str):
         # A branch/tag could have moved since the listing was cached => the HEAD call must still happen.
@@ -311,7 +321,7 @@ class TestGetCachedRepoTree:
 
 
 class TestTreeCacheForLocalDir:
-    def test_xet_file_metadata_from_tree_cache_reads_local_dir_location(self, tmp_path: Path):
+    def test_file_metadata_from_tree_cache_reads_local_dir_location(self, tmp_path: Path):
         # Metadata under .cache/huggingface/trees/...
         folder = tree_cache_folder_for_local_dir(str(tmp_path))
         assert folder == str(tmp_path / ".cache" / "huggingface")
@@ -319,7 +329,7 @@ class TestTreeCacheForLocalDir:
 
         # Cache is read correctly
         with patch("huggingface_hub.file_download.is_xet_available", return_value=True):
-            result = _xet_file_metadata_from_tree_cache(
+            result = _file_metadata_from_tree_cache(
                 tree_cache_folder=folder,
                 repo_id="user/repo",
                 repo_type="model",


### PR DESCRIPTION
## Summary

The tree-cache optimization (`_xet_file_metadata_from_tree_cache`) only kicked in when Xet was available: it returned `None` as soon as `is_xet_available()` was `False`, forcing a **per-file HEAD call** for every downloaded file. In setups where Xet must be disabled — e.g. `HF_HUB_DISABLE_XET=1` together with `HF_ENDPOINT` pointed at a self-hosted mirror/reverse proxy to download models in regions where `huggingface.co` is not directly reachable — this HEAD call cannot be relied on, and downloads of any repo with non-LFS metadata files fail hard.

This PR makes the tree cache usable **without Xet**: metadata (etag/size) is rebuilt from the cached `/tree` listing for both LFS and regular files, saving one round-trip per file and making proxy/mirror setups work.

## Why this is needed (real-world background)

For a China-based server we built a Hugging Face reverse proxy (nginx → `huggingface.co`) behind Cloudflare, and download models with:

```
HF_ENDPOINT=https://hf-mirror.example.com HF_HUB_DISABLE_XET=1 hf download <repo> --local-dir ./model
```

- `HF_HUB_DISABLE_XET=1` is mandatory here: with Xet enabled the download bytes go to `cas-server.xethub.hf.co` over the Xet protocol, bypassing the proxy entirely.
- With Xet disabled, every file needs a metadata HEAD call. Modern hub servers answer `HEAD /resolve/...` with a `307` to `/api/resolve-cache/...`, which the client follows.

The failure we hit: **Cloudflare (and similar edge proxies) strips the `Content-Length` header from HEAD responses** — in our testing, for any response > ~1KB whose content looks compressible, regardless of `cache-control: no-transform`, compression rules, or disabling every dynamic transformation setting (Automatic HTTPS Rewrites, Email Obfuscation, Rocket Loader, etc.). The result:

```
huggingface_hub.errors.FileMetadataError: Distant resource does not have a Content-Length.
```

every single non-LFS metadata file (README.md, config.json, tokenizer.json, manifests, ...) failed the download. LFS weight files (`*.safetensors`) were unaffected because their HEAD returns a `302` carrying `x-linked-size`/`x-linked-etag`, so the client never needs to follow up.

We also verified the workaround of `hf download --include "*.safetensors"` (weights only), and confirmed the tree-cache path is the right fix: the `/tree` listing already contains everything needed (`size`, `blob_id`, `lfs_sha256`, `lfs_size`, `xet_hash`) — it was just gated behind `is_xet_available()`.

## Changes

- Rename `_xet_file_metadata_from_tree_cache` → `_file_metadata_from_tree_cache` (it now serves all files, not just Xet ones).
- Remove the `is_xet_available()` early-return.
- LFS-tracked files: etag/size from `lfs_sha256`/`lfs_size` (mirroring the server HEAD response); `XetFileData` is attached only when Xet is available **and** the entry has a valid Xet hash — otherwise `xet_file_data=None` and the download falls back to the regular HTTP `/resolve` flow, which is exactly what a mirror/proxy setup wants.
- Regular (non-LFS) files: etag/size from the git blob (`blob_id`/`size`), matching what a HEAD call would return.
- Still returns `None` (→ caller does the HEAD call as before) when the tree listing or the entry metadata is not cached.

## Tests

- `tests/test_tree_cache.py`: 19 passed. Updated the three tests that asserted the old behavior (`test_non_xet_file_returns_none`, `test_xet_file_returns_none_when_xet_unavailable`, `test_get_metadata_heads_for_non_xet_file`) to assert the new one (metadata rebuilt without Xet, `xet_file_data=None`, no HEAD call).
- Manually verified end-to-end against the proxy described above: `hf download` of a full repo (metadata + weights) now succeeds, with bytes flowing through the reverse proxy.
- `ruff check` passes on both changed files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core download metadata resolution for all cached-tree downloads; incorrect etag/size from tree entries could affect cache keys or integrity checks, though behavior is limited to pinned commit hashes with existing tree cache.
> 
> **Overview**
> **Tree-cache metadata** no longer depends on Xet being enabled. `_xet_file_metadata_from_tree_cache` is renamed to `_file_metadata_from_tree_cache` and can rebuild per-file HEAD metadata (etag, size, URL, optional `XetFileData`) for **any** file in a cached `/tree` listing when the revision is a commit hash.
> 
> **LFS files** use `lfs_sha256` / `lfs_size` from the cache; `XetFileData` is attached only when Xet is available and the entry has a valid Xet hash—otherwise downloads use normal HTTP via `/resolve` (mirror/proxy friendly). **Non-LFS files** use `blob_id` / `size`. The old `is_xet_available()` gate and requirement that Xet/LFS fields all be present for every hit are removed.
> 
> Tests now expect regular files and Xet-disabled LFS files to skip the per-file HEAD call when the tree is cached; branch/tag revisions still HEAD as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86c6824a672267f28d98095bb5a2549c31448abf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->