### PR TITLE
[Inference Endpoints] Omit `model.task` instead of sending null on create

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -9577,7 +9577,6 @@ class HfApi:
                 "framework": framework,
                 "repository": repository,
                 "revision": revision,
-                "task": task,
                 "image": image,
             },
             "name": name,
@@ -9590,6 +9589,9 @@ class HfApi:
         if scaling_metric:
             payload["compute"]["scaling"]["measure"] = {scaling_metric: scaling_threshold}  # type: ignore
         model_payload: dict[str, Any] = payload["model"]
+        # `model.task` is not nullable server-side, unlike `revision`, so omit it rather than sending null.
+        if task is not None:
+            model_payload["task"] = task
         if container_command is not None:
             model_payload["command"] = container_command
         if container_args is not None:

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -4760,46 +4760,6 @@ def test_create_inference_endpoint_custom_image_payload(
     assert payload["model"]["image"] == expected_image_payload
 
 
-@pytest.mark.parametrize("task", [None, "text-generation"], ids=["no_task", "with_task"])
-def test_create_inference_endpoint_task_payload(mocker, task: Optional[str]):
-    """`model.task` is not nullable server-side, unlike `revision`, so it must be omitted rather than sent as null."""
-    mock_session = mocker.patch("huggingface_hub.hf_api.get_session").return_value
-    mock_response = Mock()
-    mock_response.raise_for_status.return_value = None
-    mock_response.json.return_value = {
-        "name": "test-endpoint-task",
-        "model": {"repository": "Qwen/Qwen2.5-0.5B-Instruct", "framework": "custom", "revision": None, "task": None},
-        "status": {
-            "state": "pending",
-            "createdAt": "2025-03-07T15:30:13.949Z",
-            "updatedAt": "2025-03-07T15:30:13.949Z",
-        },
-        "healthRoute": "/health",
-        "type": "authenticated",
-    }
-    mock_session.post.return_value = mock_response
-
-    api = HfApi(endpoint=ENDPOINT_STAGING, token=TOKEN)
-    api.create_inference_endpoint(
-        name="test-endpoint-task",
-        repository="Qwen/Qwen2.5-0.5B-Instruct",
-        framework="custom",
-        accelerator="gpu",
-        instance_size="x1",
-        instance_type="nvidia-t4",
-        region="us-east-1",
-        vendor="aws",
-        namespace="Wauplin",
-        task=task,
-    )
-
-    model_payload = mock_session.post.call_args[1]["json"]["model"]
-    if task is None:
-        assert "task" not in model_payload
-    else:
-        assert model_payload["task"] == task
-
-
 def test_create_inference_endpoint_container_command_and_args_payload(mocker):
     mock_post = mocker.patch("huggingface_hub.hf_api.get_session")
     mock_session = mock_post.return_value

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -4760,6 +4760,46 @@ def test_create_inference_endpoint_custom_image_payload(
     assert payload["model"]["image"] == expected_image_payload
 
 
+@pytest.mark.parametrize("task", [None, "text-generation"], ids=["no_task", "with_task"])
+def test_create_inference_endpoint_task_payload(mocker, task: Optional[str]):
+    """`model.task` is not nullable server-side, unlike `revision`, so it must be omitted rather than sent as null."""
+    mock_session = mocker.patch("huggingface_hub.hf_api.get_session").return_value
+    mock_response = Mock()
+    mock_response.raise_for_status.return_value = None
+    mock_response.json.return_value = {
+        "name": "test-endpoint-task",
+        "model": {"repository": "Qwen/Qwen2.5-0.5B-Instruct", "framework": "custom", "revision": None, "task": None},
+        "status": {
+            "state": "pending",
+            "createdAt": "2025-03-07T15:30:13.949Z",
+            "updatedAt": "2025-03-07T15:30:13.949Z",
+        },
+        "healthRoute": "/health",
+        "type": "authenticated",
+    }
+    mock_session.post.return_value = mock_response
+
+    api = HfApi(endpoint=ENDPOINT_STAGING, token=TOKEN)
+    api.create_inference_endpoint(
+        name="test-endpoint-task",
+        repository="Qwen/Qwen2.5-0.5B-Instruct",
+        framework="custom",
+        accelerator="gpu",
+        instance_size="x1",
+        instance_type="nvidia-t4",
+        region="us-east-1",
+        vendor="aws",
+        namespace="Wauplin",
+        task=task,
+    )
+
+    model_payload = mock_session.post.call_args[1]["json"]["model"]
+    if task is None:
+        assert "task" not in model_payload
+    else:
+        assert model_payload["task"] == task
+
+
 def test_create_inference_endpoint_container_command_and_args_payload(mocker):
     mock_post = mocker.patch("huggingface_hub.hf_api.get_session")
     mock_session = mock_post.return_value


### PR DESCRIPTION
## Summary

`create_inference_endpoint` builds `model.task` unconditionally, so leaving `task` unset sends `"task": null` and the API rejects the whole request:

```
$ hf endpoints deploy tp-probe --repo Qwen/Qwen2.5-0.5B-Instruct --framework custom \
    --accelerator gpu --instance-size x4 --instance-type nvidia-t4 --region us-east-1 --vendor aws \
    --custom-image vllm/vllm-openai:v0.23.0

Error: Bad request:
Failed to parse the request body as JSON: model.task: expected value at line 1 column 261
```

`model.task` is a non-nullable `EndpointTask` in the OpenAPI spec, unlike `revision` which is explicitly `["string", "null"]`, and `task` is not in `EndpointModel`'s `required` list (`repository`, `framework`, `image`). So omitting it is valid and the server fills in the default. `update_inference_endpoint` already guards this with `if task is not None`; `create` now matches.

The effect was that `--task` was mandatory for `hf endpoints deploy` even though the flag is optional. It mostly bites `--framework custom` deploys, where a task is least meaningful.

Verified against the live API, using a deliberately invalid `type` so the request could never create anything:

```
task: null    -> 400  Failed to parse the request body as JSON: model.task: expected value
task omitted  -> 422  type: unknown variant `THIS-IS-NOT-A-VALID-TYPE`   <- model object deserialized fine
```

And end to end, on a real deploy that previously failed:

```
$ hf endpoints deploy tp-probe --repo Qwen/Qwen2.5-0.5B-Instruct --framework custom \
    --accelerator gpu --instance-size x4 --instance-type nvidia-t4 --region us-east-1 --vendor aws \
    --engine vllm --custom-image vllm/vllm-openai:v0.23.0 --tensor-parallel-size 4

name    : tp-probe | status: pending
task    : custom          <- filled in server-side
compute : nvidia-t4 x4
```

(That run used the `--engine` / `--tensor-parallel-size` flags from #4661; the `task` fix itself is independent of them.)

No breaking changes: passing `task` explicitly behaves exactly as before.

Split out of #4661, where this surfaced while live-testing the new `--engine` flag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted payload change for one API field; explicit `task` behavior is unchanged and risk is limited to inference endpoint creation.
> 
> **Overview**
> **`create_inference_endpoint` no longer sends `"task": null`** when `task` is omitted. The field is added to the request body only if `task is not None`, aligning create with **`update_inference_endpoint`** and the Inference Endpoints API (non-nullable `EndpointTask`, optional on `EndpointModel`).
> 
> This fixes **`hf endpoints deploy`** and custom-framework deploys that left `--task` unset, which previously failed with a JSON parse error on `model.task`. Explicit `task` values are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a7d7f7f31793bdda98168b5f1d8303812899585. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

