### PR TITLE
[Download] Add HF_HUB_DOWNLOAD_MODE env var

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -1785,6 +1785,7 @@ Copy-and-paste the text below in your GitHub issue.
 - HF_ASSETS_CACHE: /home/wauplin/.cache/huggingface/assets
 - HF_TOKEN_PATH: /home/wauplin/.cache/huggingface/token
 - HF_STORED_TOKENS_PATH: /home/wauplin/.cache/huggingface/stored_tokens
+- HF_HUB_DOWNLOAD_MODE: auto
 - HF_HUB_OFFLINE: False
 - HF_HUB_DISABLE_TELEMETRY: False
 - HF_HUB_DISABLE_PROGRESS_BARS: None

--- a/docs/source/en/package_reference/environment_variables.md
+++ b/docs/source/en/package_reference/environment_variables.md
@@ -76,6 +76,20 @@ Defaults to `"warning"`.
 
 For more details, see [logging reference](../package_reference/utilities#huggingface_hub.utils.logging.get_verbosity).
 
+### HF_HUB_DOWNLOAD_MODE
+
+Controls how `huggingface_hub` talks to the Hub when downloading files. Must be one of
+`{"auto", "prefer_offline", "offline"}` (case-insensitive).
+
+- `auto` (default): A HEAD request checks whether a newer version is available, then the cache is reused or the file is downloaded.
+- `prefer_offline`: if a file is already cached for the requested revision, return it without contacting the Hub. Missing files are still downloaded, pinned to the last cached commit when one is known (so you do not mix an old `config.json` with new weights). Other Hub HTTP calls (`HfApi`, inference, ...) are unchanged.
+- `offline`: no HTTP calls at all. Cached files are used; a missing file raises an error.
+
+If `HF_HUB_DOWNLOAD_MODE` is set, `HF_HUB_OFFLINE` and `TRANSFORMERS_OFFLINE` are ignored.
+If it is unset, those legacy booleans are translated once at import time: `1`/`true`/`yes`/`on` becomes `offline`, any other value becomes `auto`.
+
+You can check the effective mode with `huggingface_hub.constants.HF_HUB_DOWNLOAD_MODE`, or [`is_offline_mode`](../package_reference/utilities#huggingface_hub.is_offline_mode) (True only for `offline`).
+
 ### HF_HUB_ETAG_TIMEOUT
 
 Integer value to define the number of seconds to wait for server response when fetching the latest metadata from a repo before downloading a file. If the request times out, `huggingface_hub` will default to the locally cached files. Setting a lower value speeds up the workflow for machines with a slow connection that have already cached files. A higher value guarantees the metadata call to succeed in more cases. Default to 10s.
@@ -122,11 +136,14 @@ If set, the log level for the `huggingface_hub` logger is set to DEBUG. Addition
 
 ### HF_HUB_OFFLINE
 
-If set, no HTTP calls will be made to the Hugging Face Hub. If you try to download files, only the cached files will be accessed. If no cache file is detected, an error is raised This is useful in case your network is slow and you don't care about having the latest version of a file.
+> [!WARNING]
+> Deprecated. Use [`HF_HUB_DOWNLOAD_MODE`](#hf_hub_download_mode) instead. `HF_HUB_OFFLINE` is only read at import time to derive a download mode when `HF_HUB_DOWNLOAD_MODE` is unset (`1` → `offline`, otherwise → `auto`).
 
-If `HF_HUB_OFFLINE=1` is set as environment variable and you call any method of [`HfApi`], an [`~huggingface_hub.errors.OfflineModeIsEnabled`] exception will be raised.
+If set, no HTTP calls will be made to the Hugging Face Hub. If you try to download files, only the cached files will be accessed. If no cache file is detected, an error is raised. This is useful in case your network is slow and you don't care about having the latest version of a file.
 
-**Note:** even if the latest version of a file is cached, calling `hf_hub_download` still triggers a HTTP request to check that a new version is not available. Setting `HF_HUB_OFFLINE=1` will skip this call which speeds up your loading time.
+If `HF_HUB_OFFLINE=1` is set as environment variable (and `HF_HUB_DOWNLOAD_MODE` is unset) and you call any method of [`HfApi`], an [`~huggingface_hub.errors.OfflineModeIsEnabled`] exception will be raised.
+
+**Note:** even if the latest version of a file is cached, calling `hf_hub_download` still triggers a HTTP request to check that a new version is not available. Setting `HF_HUB_DOWNLOAD_MODE=offline` (or the legacy `HF_HUB_OFFLINE=1`) will skip this call which speeds up your loading time. To skip the freshness check while still downloading missing files, use `HF_HUB_DOWNLOAD_MODE=prefer_offline`.
 
 If you want to check if offline mode is enabled or not, you can use the [`is_offline_mode`] helper.
 

--- a/docs/source/en/package_reference/utilities.md
+++ b/docs/source/en/package_reference/utilities.md
@@ -185,7 +185,7 @@ except HfHubHTTPError as e:
 
 ### Check offline mode
 
-You can programmatically check if offline mode is enabled using `is_offline_mode`. Offline mode is enabled by setting `HF_HUB_OFFLINE=1` as environment variable.
+You can programmatically check if offline mode is enabled using `is_offline_mode`. Offline mode is enabled by setting `HF_HUB_DOWNLOAD_MODE=offline` (or the legacy `HF_HUB_OFFLINE=1` when `HF_HUB_DOWNLOAD_MODE` is unset).
 
 [[autodoc]] is_offline_mode
 
@@ -249,7 +249,7 @@ user as possible.
 
 `huggingface_hub` includes a helper to send telemetry data. This information helps us debug issues and prioritize new features.
 Users can disable telemetry collection at any time by setting the `HF_HUB_DISABLE_TELEMETRY=1` environment variable.
-Telemetry is also disabled in offline mode (i.e. when setting HF_HUB_OFFLINE=1).
+Telemetry is also disabled in offline mode (i.e. when `HF_HUB_DOWNLOAD_MODE=offline`, or the legacy `HF_HUB_OFFLINE=1`).
 
 If you are maintainer of a third-party library, sending telemetry data is as simple as making a call to [`send_telemetry`].
 Data is sent in a separate thread to reduce as much as possible the impact for users.

--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -18,7 +18,14 @@ from .errors import (
     RepositoryNotFoundError,
     RevisionNotFoundError,
 )
-from .file_download import REGEX_COMMIT_HASH, DryRunFileInfo, hf_hub_download, repo_folder_name
+from .file_download import (
+    REGEX_COMMIT_HASH,
+    DryRunFileInfo,
+    _get_cached_commit_hash,
+    _get_local_dir_cached_commit_hash,
+    hf_hub_download,
+    repo_folder_name,
+)
 from .hf_api import HfApi, RepoFile
 from .utils import OfflineModeIsEnabled, filter_repo_objects, logging, validate_hf_hub_args
 from .utils._xet_progress_reporting import (
@@ -261,6 +268,27 @@ def snapshot_download(
         commit_hash = revision
 
     api_call_error: Exception | None = None
+    prefer_offline = constants.is_prefer_offline_mode() and not force_download
+
+    # prefer_offline: reuse the last cached commit. A complete snapshot is returned as-is.
+    # Missing files are fetched from that same commit (no mixed revisions).
+    # For `local_dir`, prefer sibling `.metadata` over hub-cache refs (local_dir may not write refs).
+    if commit_hash is None and prefer_offline and not local_files_only:
+        if local_dir is not None:
+            commit_hash = _get_local_dir_cached_commit_hash(local_dir)
+        if commit_hash is None:
+            commit_hash = _get_cached_commit_hash(storage_folder, revision)
+        if commit_hash is not None and not dry_run:
+            base_dir = local_dir if local_dir is not None else os.path.join(storage_folder, "snapshots", commit_hash)
+            if os.path.isdir(base_dir) and _is_snapshot_complete(
+                tree_cache_folder=tree_cache_folder,
+                commit_hash=commit_hash,
+                base_dir=base_dir,
+                allow_patterns=allow_patterns,
+                ignore_patterns=ignore_patterns,
+            ):
+                return str(Path(base_dir).resolve()) if local_dir is not None else base_dir
+
     if commit_hash is None and not local_files_only:
         # try/except logic to handle different errors => taken from `hf_hub_download`
         try:
@@ -291,7 +319,7 @@ def snapshot_download(
 
     # At this stage, if the commit hash is unknown it means either:
     # - internet connection is down
-    # - internet connection is deactivated (local_files_only=True or HF_HUB_OFFLINE=True)
+    # - internet connection is deactivated (local_files_only=True or download mode is offline)
     # - repo is private/gated and invalid/missing token sent
     # - Hub is down
     # => let's look if we can find the appropriate folder in the cache:
@@ -360,7 +388,7 @@ def snapshot_download(
             raise LocalEntryNotFoundError(
                 "Cannot find an appropriate cached snapshot folder for the specified revision on the local disk and "
                 "outgoing traffic has been disabled. To enable repo look-ups and downloads online, set "
-                "'HF_HUB_OFFLINE=0' as environment variable."
+                "'HF_HUB_DOWNLOAD_MODE=auto' as environment variable."
             ) from api_call_error
         elif isinstance(api_call_error, (RepositoryNotFoundError, GatedRepoError)) or (
             isinstance(api_call_error, HfHubHTTPError) and api_call_error.response.status_code == 401
@@ -579,6 +607,27 @@ def _raise_if_incomplete_snapshot(
         "to complete the snapshot.",
         snapshot_path=base_dir,
     ) from api_call_error
+
+
+def _is_snapshot_complete(
+    *,
+    tree_cache_folder: str,
+    commit_hash: str,
+    base_dir: str,
+    allow_patterns: list[str] | str | None,
+    ignore_patterns: list[str] | str | None,
+) -> bool:
+    """Return whether `base_dir` contains every file listed in the cached tree for `commit_hash`.
+
+    Returns `False` when the tree listing is not cached (we cannot tell, so the caller should not skip the Hub).
+    """
+    tree_entries = read_tree_cache(tree_cache_folder, commit_hash)
+    if tree_entries is None:
+        return False
+    expected = filter_repo_objects(
+        items=tree_entries.keys(), allow_patterns=allow_patterns, ignore_patterns=ignore_patterns
+    )
+    return all(_local_file_exists(base_dir, path) for path in expected)
 
 
 @validate_hf_hub_args

--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -189,13 +189,44 @@ HF_ASSETS_CACHE = os.path.expandvars(
     )
 )
 
-HF_HUB_OFFLINE = _is_true(os.environ.get("HF_HUB_OFFLINE") or os.environ.get("TRANSFORMERS_OFFLINE"))
+HFHubDownloadMode = Literal["auto", "prefer_offline", "offline"]
+HF_HUB_DOWNLOAD_MODES: tuple[HFHubDownloadMode, ...] = typing.get_args(HFHubDownloadMode)
+
+
+def _hf_hub_download_mode() -> HFHubDownloadMode:
+    """Read download mode from the environment.
+
+    `HF_HUB_DOWNLOAD_MODE` wins when set. Otherwise the legacy `HF_HUB_OFFLINE` /
+    `TRANSFORMERS_OFFLINE` booleans are translated (`1` -> `offline`, `0` -> `auto`).
+    """
+    mode = (os.environ.get("HF_HUB_DOWNLOAD_MODE") or "").strip().lower()
+    if mode:
+        if mode not in HF_HUB_DOWNLOAD_MODES:
+            raise ValueError(
+                f"Invalid HF_HUB_DOWNLOAD_MODE={os.environ.get('HF_HUB_DOWNLOAD_MODE')!r}. "
+                f"Expected one of: {list(HF_HUB_DOWNLOAD_MODES)}."
+            )
+        return mode
+    if _is_true(os.environ.get("HF_HUB_OFFLINE") or os.environ.get("TRANSFORMERS_OFFLINE")):
+        return "offline"
+    return "auto"
+
+
+HF_HUB_DOWNLOAD_MODE = _hf_hub_download_mode()
+# Derived from `HF_HUB_DOWNLOAD_MODE` for backward compatibility. Downstream code that
+# still reads this constant will observe the effective offline state. Do not use it to
+# gate behavior in this library; use `HF_HUB_DOWNLOAD_MODE` / `is_offline_mode()`.
+HF_HUB_OFFLINE = HF_HUB_DOWNLOAD_MODE == "offline"
 
 
 def is_offline_mode() -> bool:
     """Returns whether we are in offline mode for the Hub.
 
     When offline mode is enabled, all HTTP requests made with `get_session` will raise an `OfflineModeIsEnabled` exception.
+
+    Offline mode is enabled by setting `HF_HUB_DOWNLOAD_MODE=offline`. The legacy
+    `HF_HUB_OFFLINE=1` (and `TRANSFORMERS_OFFLINE=1`) environment variables still enable
+    it when `HF_HUB_DOWNLOAD_MODE` is unset.
 
     Example:
         ```py
@@ -208,7 +239,19 @@ def is_offline_mode() -> bool:
                 ... # list files from Hub (complete experience)
         ```
     """
-    return HF_HUB_OFFLINE
+    return HF_HUB_DOWNLOAD_MODE == "offline"
+
+
+def is_prefer_offline_mode() -> bool:
+    """Returns whether downloads should reuse cached files without checking for updates.
+
+    When prefer-offline mode is enabled, existing cached files are returned as-is
+    (no freshness HEAD call). Missing files are still downloaded from the Hub, pinned
+    to the last cached revision when one is known.
+
+    Enabled by setting `HF_HUB_DOWNLOAD_MODE=prefer_offline`.
+    """
+    return HF_HUB_DOWNLOAD_MODE == "prefer_offline"
 
 
 # File created to mark that the version check has been done.

--- a/src/huggingface_hub/errors.py
+++ b/src/huggingface_hub/errors.py
@@ -84,7 +84,7 @@ class DeviceCodeError(Exception):
 
 
 class OfflineModeIsEnabled(ConnectionError):
-    """Raised when a request is made but `HF_HUB_OFFLINE=1` is set as environment variable."""
+    """Raised when a request is made but download mode is `offline` (`HF_HUB_DOWNLOAD_MODE=offline`)."""
 
 
 class HfHubHTTPError(HTTPError, OSError):

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -697,6 +697,46 @@ def _create_symlink(src: str, dst: str, new_blob: bool = False) -> None:
         shutil.copyfile(abs_src, abs_dst)
 
 
+def _get_cached_commit_hash(storage_folder: str, revision: str) -> str | None:
+    """Return the commit hash for `revision` if it is already a hash or a cached ref.
+
+    Reads `refs/{revision}` written by a previous download. Returns `None` when nothing
+    is cached locally (the caller should then resolve the revision from the Hub).
+    """
+    if REGEX_COMMIT_HASH.match(revision):
+        return revision
+    ref_path = Path(storage_folder) / "refs" / revision
+    if ref_path.is_file():
+        commit_hash = ref_path.read_text().strip()
+        return commit_hash or None
+    return None
+
+
+def _get_local_dir_cached_commit_hash(local_dir: str | Path) -> str | None:
+    """Return the newest commit hash recorded in `local_dir` download `.metadata` files.
+
+    `local_dir` downloads do not write hub-cache `refs/`, so prefer_offline uses these
+    sibling metadata entries to pin missing-file fetches to the same revision.
+    """
+    download_dir = Path(local_dir) / ".cache" / "huggingface" / "download"
+    if not download_dir.is_dir():
+        return None
+    best: tuple[float, str] | None = None
+    for metadata_path in download_dir.rglob("*.metadata"):
+        try:
+            with metadata_path.open() as f:
+                commit_hash = f.readline().strip()
+                f.readline()  # etag
+                timestamp = float(f.readline().strip())
+        except Exception:
+            continue
+        if not REGEX_COMMIT_HASH.match(commit_hash):
+            continue
+        if best is None or timestamp > best[0]:
+            best = (timestamp, commit_hash)
+    return best[1] if best is not None else None
+
+
 def _cache_commit_hash_for_specific_revision(storage_folder: str, revision: str, commit_hash: str) -> None:
     """Cache reference between a revision (tag, branch or truncated commit hash) and the corresponding commit hash.
 
@@ -1068,6 +1108,13 @@ def _hf_hub_download_to_cache_dir(
     # cross-platform transcription of filename, to be used as a local file path.
     relative_filename = os.path.join(*filename.split("/"))
 
+    # prefer_offline: pin to the last cached commit so existing files skip the Hub and
+    # missing files are fetched from that same commit (no mixed revisions).
+    if constants.is_prefer_offline_mode() and not force_download and not REGEX_COMMIT_HASH.match(revision):
+        cached_commit = _get_cached_commit_hash(storage_folder, revision)
+        if cached_commit is not None:
+            revision = cached_commit
+
     # if user provides a commit_hash and they already have the file on disk, shortcut everything.
     if REGEX_COMMIT_HASH.match(revision):
         pointer_path = _get_pointer_path(storage_folder, revision, relative_filename)
@@ -1290,6 +1337,23 @@ def _hf_hub_download_to_local_dir(
     paths = get_local_download_paths(local_dir=local_dir, filename=filename)
     local_metadata = read_download_metadata(local_dir=local_dir, filename=filename)
 
+    prefer_offline = constants.is_prefer_offline_mode() and not force_download
+    requested_revision = revision
+    hub_storage = os.path.join(cache_dir, repo_folder_name(repo_id=repo_id, repo_type=repo_type))
+
+    # prefer_offline: pin to a known local commit so existing files and missing-file
+    # downloads stay on the same revision (do not mix an old config with new weights).
+    # Prefer this file's / sibling `.metadata` (local_dir does not write hub `refs/`),
+    # then fall back to hub-cache refs when present.
+    if prefer_offline and not REGEX_COMMIT_HASH.match(revision):
+        cached_commit = (
+            (local_metadata.commit_hash if local_metadata is not None else None)
+            or _get_local_dir_cached_commit_hash(local_dir)
+            or _get_cached_commit_hash(hub_storage, revision)
+        )
+        if cached_commit is not None:
+            revision = cached_commit
+
     # Local file exists + metadata exists + commit_hash matches => return file
     if (
         REGEX_COMMIT_HASH.match(revision)
@@ -1309,6 +1373,22 @@ def _hf_hub_download_to_local_dir(
             )
         if not force_download:
             return local_file
+
+    # prefer_offline with no known pin: reuse any existing file without a freshness HEAD.
+    # (If we did pin above and metadata mismatched, fall through and re-fetch from that pin.)
+    if prefer_offline and paths.file_path.is_file() and revision == requested_revision:
+        local_file = str(paths.file_path)
+        if dry_run:
+            commit_hash = local_metadata.commit_hash if local_metadata is not None else revision
+            return DryRunFileInfo(
+                commit_hash=commit_hash,
+                file_size=os.path.getsize(local_file),
+                filename=filename,
+                is_cached=True,
+                local_path=local_file,
+                will_download=False,
+            )
+        return local_file
 
     # Local file doesn't exist or commit_hash doesn't match => we need the etag
     # - Xet file => might be cached in /tree listing

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -127,6 +127,7 @@ from .file_download import (
     DryRunFileInfo,
     HfFileMetadata,
     _cache_commit_hash_for_specific_revision,
+    _get_cached_commit_hash,
     get_hf_file_metadata,
     hf_hub_url,
     repo_folder_name,
@@ -3744,6 +3745,11 @@ class HfApi:
         )
 
         error: Exception | None = None
+        if constants.is_prefer_offline_mode() and not local_files_only:
+            cached_sha = _get_cached_commit_hash(storage_folder, revision or constants.DEFAULT_REVISION)
+            if cached_sha is not None:
+                return ResolvedRevision(resolved=cached_sha, initial=revision)
+
         if not local_files_only:
             try:
                 sha = self.repo_info(repo_id=repo_id, repo_type=repo_type, revision=revision, token=token).sha

--- a/src/huggingface_hub/utils/_detect_agent.py
+++ b/src/huggingface_hub/utils/_detect_agent.py
@@ -188,7 +188,7 @@ def _write_cached_registry(path: str, registry: Registry) -> None:
 
 def _fetch_registry() -> Registry | None:
     """Fetch the registry from the Hub. Returns `None` when offline or on any error."""
-    if constants.HF_HUB_OFFLINE:
+    if constants.is_offline_mode():
         return None
     try:
         from ._http import get_session

--- a/src/huggingface_hub/utils/_http.py
+++ b/src/huggingface_hub/utils/_http.py
@@ -258,7 +258,7 @@ def hf_request_event_hook(request: httpx.Request) -> None:
     """
     if constants.is_offline_mode():
         raise OfflineModeIsEnabled(
-            f"Cannot reach {request.url}: offline mode is enabled. To disable it, please unset the `HF_HUB_OFFLINE` environment variable."
+            f"Cannot reach {request.url}: offline mode is enabled. To disable it, set `HF_HUB_DOWNLOAD_MODE=auto`."
         )
 
     # Add random request ID => easier for server-side debugging

--- a/src/huggingface_hub/utils/_runtime.py
+++ b/src/huggingface_hub/utils/_runtime.py
@@ -428,6 +428,7 @@ def dump_environment_info() -> dict[str, Any]:
     info["HF_ASSETS_CACHE"] = constants.HF_ASSETS_CACHE
     info["HF_TOKEN_PATH"] = constants.HF_TOKEN_PATH
     info["HF_STORED_TOKENS_PATH"] = constants.HF_STORED_TOKENS_PATH
+    info["HF_HUB_DOWNLOAD_MODE"] = constants.HF_HUB_DOWNLOAD_MODE
     info["HF_HUB_OFFLINE"] = constants.HF_HUB_OFFLINE
     info["HF_HUB_DISABLE_TELEMETRY"] = constants.HF_HUB_DISABLE_TELEMETRY
     info["HF_HUB_DISABLE_PROGRESS_BARS"] = constants.HF_HUB_DISABLE_PROGRESS_BARS

--- a/src/huggingface_hub/utils/_telemetry.py
+++ b/src/huggingface_hub/utils/_telemetry.py
@@ -28,8 +28,8 @@ def send_telemetry(
 
     This usage data helps us debug issues and prioritize new features. However, we understand that not everyone wants
     to share additional information, and we respect your privacy. You can disable telemetry collection by setting the
-    `HF_HUB_DISABLE_TELEMETRY=1` as environment variable. Telemetry is also disabled in offline mode (i.e. when setting
-    `HF_HUB_OFFLINE=1`).
+    `HF_HUB_DISABLE_TELEMETRY=1` as environment variable. Telemetry is also disabled in offline mode (i.e. when
+    `HF_HUB_DOWNLOAD_MODE=offline`).
 
     Telemetry collection is run in a separate thread to minimize impact for the user.
 

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,0 +1,81 @@
+import pytest
+
+from huggingface_hub.constants import HF_HUB_DOWNLOAD_MODES, _hf_hub_download_mode
+
+
+@pytest.fixture
+def _clear_download_mode_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("HF_HUB_DOWNLOAD_MODE", raising=False)
+    monkeypatch.delenv("HF_HUB_OFFLINE", raising=False)
+    monkeypatch.delenv("TRANSFORMERS_OFFLINE", raising=False)
+
+
+def test_allowed_modes_match_literal() -> None:
+    assert HF_HUB_DOWNLOAD_MODES == ("auto", "prefer_offline", "offline")
+
+
+@pytest.mark.usefixtures("_clear_download_mode_env")
+def test_default_is_auto() -> None:
+    assert _hf_hub_download_mode() == "auto"
+
+
+@pytest.mark.usefixtures("_clear_download_mode_env")
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("auto", "auto"),
+        ("AUTO", "auto"),
+        ("prefer_offline", "prefer_offline"),
+        ("PREFER_OFFLINE", "prefer_offline"),
+        ("offline", "offline"),
+        ("OFFLINE", "offline"),
+    ],
+)
+def test_download_mode_wins_over_legacy_offline(monkeypatch: pytest.MonkeyPatch, value: str, expected: str) -> None:
+    monkeypatch.setenv("HF_HUB_DOWNLOAD_MODE", value)
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    monkeypatch.setenv("TRANSFORMERS_OFFLINE", "1")
+    assert _hf_hub_download_mode() == expected
+
+
+@pytest.mark.usefixtures("_clear_download_mode_env")
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("1", "offline"),
+        ("true", "offline"),
+        ("YES", "offline"),
+        ("0", "auto"),
+        ("false", "auto"),
+    ],
+)
+def test_legacy_hf_hub_offline_when_mode_unset(monkeypatch: pytest.MonkeyPatch, value: str, expected: str) -> None:
+    monkeypatch.setenv("HF_HUB_OFFLINE", value)
+    assert _hf_hub_download_mode() == expected
+
+
+@pytest.mark.usefixtures("_clear_download_mode_env")
+def test_legacy_hf_hub_offline_zero_wins_over_transformers_offline(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HF_HUB_OFFLINE", "0")
+    monkeypatch.setenv("TRANSFORMERS_OFFLINE", "1")
+    assert _hf_hub_download_mode() == "auto"
+
+
+@pytest.mark.usefixtures("_clear_download_mode_env")
+def test_transformers_offline_when_mode_and_hf_hub_offline_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TRANSFORMERS_OFFLINE", "1")
+    assert _hf_hub_download_mode() == "offline"
+
+
+@pytest.mark.usefixtures("_clear_download_mode_env")
+def test_empty_download_mode_falls_back_to_legacy(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HF_HUB_DOWNLOAD_MODE", "  ")
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    assert _hf_hub_download_mode() == "offline"
+
+
+@pytest.mark.usefixtures("_clear_download_mode_env")
+def test_invalid_download_mode_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HF_HUB_DOWNLOAD_MODE", "nope")
+    with pytest.raises(ValueError, match="Invalid HF_HUB_DOWNLOAD_MODE"):
+        _hf_hub_download_mode()

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -355,6 +355,21 @@ class TestCachedDownload:
                 for call in calls:
                     _check_user_agent(call.kwargs["headers"])
 
+    def test_prefer_offline_skips_head_when_cached(self):
+        with SoftTemporaryDirectory() as cache_dir:
+            path = hf_hub_download(DUMMY_MODEL_ID, filename=constants.CONFIG_NAME, cache_dir=cache_dir)
+            with patch("huggingface_hub.constants.HF_HUB_DOWNLOAD_MODE", "prefer_offline"):
+                with patch("huggingface_hub.file_download._get_metadata_or_catch_error") as mock_head:
+                    cached_path = hf_hub_download(DUMMY_MODEL_ID, filename=constants.CONFIG_NAME, cache_dir=cache_dir)
+            mock_head.assert_not_called()
+            assert cached_path == path
+
+    def test_prefer_offline_downloads_when_missing(self):
+        with SoftTemporaryDirectory() as cache_dir:
+            with patch("huggingface_hub.constants.HF_HUB_DOWNLOAD_MODE", "prefer_offline"):
+                path = hf_hub_download(DUMMY_MODEL_ID, filename=constants.CONFIG_NAME, cache_dir=cache_dir)
+            assert Path(path).is_file()
+
     def test_hf_hub_url_with_empty_subfolder(self):
         """
         Check subfolder arg is processed correctly when empty string is passed to
@@ -753,6 +768,59 @@ class TestHfHubDownloadToLocalDir:
             self.api.hf_hub_download(
                 self.repo_id, filename=self.file_name, local_dir=self.local_dir, local_files_only=True
             )
+
+    def test_prefer_offline_and_file_exists(self, monkeypatch):
+        self.file_path.write_text("content2")
+        monkeypatch.setattr(constants, "HF_HUB_DOWNLOAD_MODE", "prefer_offline")
+
+        with self.with_patch_head() as mock:
+            path = self.api.hf_hub_download(self.repo_id, filename=self.file_name, local_dir=self.local_dir)
+        mock.assert_not_called()
+        assert Path(path) == self.file_path
+        assert self.file_path.read_text() == "content2"
+
+    def test_prefer_offline_and_file_missing(self, monkeypatch):
+        monkeypatch.setattr(constants, "HF_HUB_DOWNLOAD_MODE", "prefer_offline")
+        path = self.api.hf_hub_download(
+            self.repo_id, filename=self.file_name, cache_dir=self.hub_cache_dir, local_dir=self.local_dir
+        )
+        assert Path(path) == self.file_path
+        assert self.file_path.is_file()
+
+    def test_prefer_offline_pins_missing_file_to_sibling_metadata(self, monkeypatch):
+        """Missing files must use sibling `.metadata` commit, not Hub tip / empty hub refs."""
+        monkeypatch.setattr(constants, "HF_HUB_DOWNLOAD_MODE", "prefer_offline")
+        self.file_path.write_text("content")
+        write_download_metadata(self.local_dir, self.file_name, self.commit_hash_1, etag=self.file_etag)
+
+        with self.with_patch_head() as mock_head:
+            mock_head.return_value = (
+                "https://example.com/lfs.bin",
+                self.lfs_etag,
+                self.commit_hash_1,
+                7,
+                None,
+                None,
+            )
+            with self.with_patch_download() as mock_download:
+                self.api.hf_hub_download(
+                    self.repo_id,
+                    filename=self.lfs_name,
+                    cache_dir=self.hub_cache_dir,
+                    local_dir=self.local_dir,
+                )
+        assert mock_head.call_args.kwargs["revision"] == self.commit_hash_1
+        mock_download.assert_called_once()
+
+    def test_prefer_offline_reuses_file_when_metadata_matches_pin(self, monkeypatch):
+        monkeypatch.setattr(constants, "HF_HUB_DOWNLOAD_MODE", "prefer_offline")
+        self.file_path.write_text("content")
+        write_download_metadata(self.local_dir, self.file_name, self.commit_hash_1, etag=self.file_etag)
+
+        with self.with_patch_head() as mock:
+            path = self.api.hf_hub_download(self.repo_id, filename=self.file_name, local_dir=self.local_dir)
+        mock.assert_not_called()
+        assert Path(path) == self.file_path
 
     def test_metadata_ok_and_etag_match(self):
         # 1 HEAD call + return early

--- a/tests/test_snapshot_download.py
+++ b/tests/test_snapshot_download.py
@@ -206,6 +206,26 @@ class TestSnapshotDownload:
             storage_folder = snapshot_download(self.repo_id, local_dir=tmpdir, local_files_only=True)
             assert str(tmpdir) == storage_folder
 
+    def test_prefer_offline_uses_cached_snapshot(self):
+        with SoftTemporaryDirectory() as tmpdir:
+            snapshot_download(self.repo_id, cache_dir=tmpdir)
+            with patch("huggingface_hub.constants.HF_HUB_DOWNLOAD_MODE", "prefer_offline"):
+                with patch("huggingface_hub._snapshot_download.HfApi.repo_info", side_effect=AssertionError) as mock:
+                    storage_folder = snapshot_download(self.repo_id, cache_dir=tmpdir)
+                mock.assert_not_called()
+            assert self.second_commit_hash in storage_folder
+
+    def test_prefer_offline_fetches_missing_file_from_cached_revision(self):
+        with SoftTemporaryDirectory() as tmpdir:
+            storage_folder = snapshot_download(self.repo_id, cache_dir=tmpdir)
+            os.remove(os.path.join(storage_folder, "dummy_file.txt"))
+            with patch("huggingface_hub.constants.HF_HUB_DOWNLOAD_MODE", "prefer_offline"):
+                with patch("huggingface_hub._snapshot_download.HfApi.repo_info", side_effect=AssertionError) as mock:
+                    storage_folder = snapshot_download(self.repo_id, cache_dir=tmpdir)
+                mock.assert_not_called()
+            with open(os.path.join(storage_folder, "dummy_file.txt")) as f:
+                assert f.read() == "v2"
+
     def test_download_model_to_local_dir_with_offline_mode(self):
         """Test that an already downloaded folder is returned when there is a connection error"""
         # first download folder to local_dir
@@ -399,6 +419,14 @@ class TestResolveRevision:
         # Already resolved => returned as is (no network call)
         with offline():
             assert api.resolve_revision(self.repo_id, revision=revision, cache_dir=tmp_path) is revision
+
+    def test_resolve_revision_prefer_offline(self, api: HfApi, tmp_path: Path):
+        api.resolve_revision(self.repo_id, cache_dir=tmp_path)
+        with patch("huggingface_hub.constants.HF_HUB_DOWNLOAD_MODE", "prefer_offline"):
+            with patch.object(api, "repo_info", side_effect=AssertionError) as mock:
+                revision = api.resolve_revision(self.repo_id, cache_dir=tmp_path)
+            mock.assert_not_called()
+        assert revision.resolved == self.commit_hash
 
     def test_resolve_revision_not_cached(self, api: HfApi, tmp_path: Path):
         with offline():

--- a/tests/test_utils_detect_agent.py
+++ b/tests/test_utils_detect_agent.py
@@ -162,7 +162,7 @@ class TestRegistryLoading:
         assert _detect_agent._load_registry() == _detect_agent._EMPTY_REGISTRY
 
     def test_fetch_skipped_when_offline(self, monkeypatch):
-        monkeypatch.setattr(constants, "HF_HUB_OFFLINE", True)
+        monkeypatch.setattr(constants, "HF_HUB_DOWNLOAD_MODE", "offline")
         assert _detect_agent._fetch_registry() is None
 
     def test_detection_never_raises_on_error(self, monkeypatch):

--- a/tests/test_utils_http.py
+++ b/tests/test_utils_http.py
@@ -265,7 +265,7 @@ class TestConfigureSession:
 
 class TestOfflineModeSession:
     def test_offline_mode(self):
-        with patch("huggingface_hub.constants.HF_HUB_OFFLINE", True):
+        with patch("huggingface_hub.constants.HF_HUB_DOWNLOAD_MODE", "offline"):
             set_client_factory(default_client_factory)
             client = get_session()
             with pytest.raises(OfflineModeIsEnabled):

--- a/tests/test_utils_telemetry.py
+++ b/tests/test_utils_telemetry.py
@@ -51,7 +51,7 @@ class TestSendTelemetry:
         assert self.mock_head.call_args[0][0] == f"{ENDPOINT_STAGING}/api/telemetry/foo%20bar"
 
     def test_hub_offline(self, mocker) -> None:
-        mocker.patch("huggingface_hub.utils._telemetry.constants.HF_HUB_OFFLINE", True)
+        mocker.patch("huggingface_hub.utils._telemetry.constants.HF_HUB_DOWNLOAD_MODE", "offline")
         send_telemetry(topic="topic")
         assert self.queue.empty()  # no tasks
         self.mock_head.assert_not_called()

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -111,7 +111,7 @@ def offline(mode=OfflineSimulationMode.CONNECTION_FAILS, timeout=1e-16):
             with patch("huggingface_hub.utils._http._GLOBAL_CLIENT", offline_client):
                 yield
     elif mode is OfflineSimulationMode.HF_HUB_OFFLINE_SET_TO_1:
-        with patch("huggingface_hub.constants.HF_HUB_OFFLINE", True):
+        with patch("huggingface_hub.constants.HF_HUB_DOWNLOAD_MODE", "offline"):
             yield
     else:
         raise ValueError("Please use a value from the OfflineSimulationMode enum.")


### PR DESCRIPTION
Introduce a new env var `HF_HUB_DOWNLOAD_MODE` which has the values:
* `auto`: default. Current behaviour like if `HF_HUB_OFFLINE` is not set or `0`
* `prefer_offline`: Only make network communication if files are missing. If everything is available, it doesn't produce network traffic and not even checks for updates.
* `offline`: no network communication. Same as `HF_HUB_OFFLINE=1`

`HF_HUB_OFFLINE` was deprecated (but still functional) as `HF_HUB_DOWNLOAD_MODE` superseds it.

So the main change is `prefer_offline` so cached files skip the Hub freshness check while missing files still download.


## HF_HUB_DOWNLOAD_MODE manual tests

Manual Docker checks used `snapshot_download("hf-internal-testing/tiny-random-bert")` with a shared volume so the cache survived `--network none` runs.

| Step | Network | Mode | Cache | Result |
| --- | --- | --- | --- | --- |
| 1 | on | `offline` | empty | failed (`LocalEntryNotFoundError`) |
| 2 | on | `auto` | empty | downloaded all 10 files |
| 3 | on | `prefer_offline` | empty | downloaded all 10 files |
| 4 | off | `auto` | empty | failed (DNS `ConnectError`) — network really off |
| 5 | off | `offline` | from step 2 | reused cache |
| 6 | off | `prefer_offline` | from step 2 | reused cache |

## References

https://github.com/huggingface/huggingface_hub/issues/3201


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core download and revision-resolution behavior across cache and local_dir paths, though legacy offline semantics are preserved and coverage is extensive.
> 
> **Overview**
> Adds **`HF_HUB_DOWNLOAD_MODE`** (`auto`, `prefer_offline`, `offline`) as the single knob for Hub download behavior, with **`prefer_offline`** as the new middle ground: reuse cached files without freshness HEAD calls while still fetching missing files, pinned to the last known commit so revisions are not mixed.
> 
> **`HF_HUB_OFFLINE`** / **`TRANSFORMERS_OFFLINE`** are deprecated when the new variable is set; otherwise they still map to `offline` vs `auto` at import. **`is_offline_mode()`** remains true only for full `offline`; **`is_prefer_offline_mode()`** gates the download-only optimizations.
> 
> Download paths now honor **`prefer_offline`** in **`hf_hub_download`** (hub cache and **`local_dir`**, including metadata-based commit pinning), **`snapshot_download`** (early return on complete cached snapshots via **`_is_snapshot_complete`**), and **`HfApi.resolve_revision`**. Error messages and telemetry/offline HTTP handling point users at **`HF_HUB_DOWNLOAD_MODE=auto`** instead of unsetting **`HF_HUB_OFFLINE`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6129c5ff145f87cabfc7a6f00e20012182f8067a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->




## AI Generated

* is most of this AI generated: for sure it is
* did I blindly push this: no. I did a close review on the produced code (even though I'm not an expert in this library) AND checked with the docker tests, that the behaviour is what it should be and not break the old behaviour.