### PR TITLE
[CLI] Fix upload when local_path is a wildcard

### DIFF
--- a/src/huggingface_hub/cli/upload.py
+++ b/src/huggingface_hub/cli/upload.py
@@ -270,7 +270,7 @@ def _resolve_upload_paths(
             raise ValueError("Cannot set --include when local_path contains a wildcard.")
         if path_in_repo is not None and path_in_repo != ".":
             raise ValueError("Cannot set path_in_repo when local_path contains a wildcard.")
-        return ".", local_path, ["."]  # will be adjusted below; placeholder for type
+        return ".", ".", [local_path]
 
     if local_path is None and os.path.isfile(repo_name):
         return repo_name, repo_name, resolved_include

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -769,15 +769,15 @@ class TestResolveUploadPaths:
             repo_id=DUMMY_MODEL_ID, local_path="*.safetensors", path_in_repo=None, include=None
         )
         assert local_path == "."
-        assert path_in_repo == "*.safetensors"
-        assert include == ["."]
+        assert path_in_repo == "."
+        assert include == ["*.safetensors"]
 
         local_path, path_in_repo, include = _resolve_upload_paths(
             repo_id=DUMMY_MODEL_ID, local_path="subdir/*.safetensors", path_in_repo=None, include=None
         )
         assert local_path == "."
-        assert path_in_repo == "subdir/*.safetensors"
-        assert include == ["."]
+        assert path_in_repo == "."
+        assert include == ["subdir/*.safetensors"]
 
         with pytest.raises(ValueError):
             _resolve_upload_paths(


### PR DESCRIPTION
Fixes #4709

## Summary

- `hf upload repo '*.safetensors'` has been silently uploading nothing since the 1.0 CLI rewrite: the wildcard branch of `_resolve_upload_paths` returned its tuple in the wrong order, so the glob landed in `path_in_repo` and `allow_patterns` became `["."]`, which matches no files. The CLI then hit the empty-commit skip and still printed `Uploaded: <url>`.
- Now returns `".", ".", [local_path]` (the pre-1.0 behavior from #2868) and drops the stale "will be adjusted below" comment.
- `test_upload_with_wildcard` was pinning the broken values; updated to the real contract.

Manual check:

```python
>>> from huggingface_hub.cli.upload import _resolve_upload_paths
>>> _resolve_upload_paths(repo_id="user/repo", local_path="*.safetensors", path_in_repo=None, include=None)
('.', '.', ['*.safetensors'])          # was ('.', '*.safetensors', ['.'])
```

`pytest tests/test_cli.py -k "TestResolveUploadPaths or TestUploadCommand"`: 22 passed. Full `tests/test_cli.py`: 348 passed, 2 failed; the 2 failures (`TestDatasetsSqlCommand`) also fail on a clean checkout in my env (missing local dependency), unrelated to this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI path-resolution bugfix with no auth or API contract changes; risk is limited to glob-based uploads matching files again.
> 
> **Overview**
> Fixes `hf upload` silently skipping files when `local_path` is a glob (e.g. `*.safetensors`). `_resolve_upload_paths` had swapped `path_in_repo` and `include`, so `allow_patterns` became `["."]` and the glob never matched.
> 
> The wildcard branch now returns `".", ".", [local_path]` so the pattern is passed as `allow_patterns` to `upload_folder`. Tests that had encoded the broken tuple are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb0b45145b0176926719a587fdd91c96abbec998. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->