### PR TITLE
Update dataset details in datasetcard_template.md

### DIFF
--- a/src/huggingface_hub/templates/datasetcard_template.md
+++ b/src/huggingface_hub/templates/datasetcard_template.md
@@ -11,6 +11,7 @@
 {{ dataset_summary | default("", true) }}
 
 ## Dataset Details
+This dataset contains Amharic figurative expression samples designed for three-class classification: **Idiom**, **Proverb**, and **Literal**. The dataset was developed to support research on low-resource natural language processing, particularly figurative language understanding using multilingual transformer models.
 
 ### Dataset Description
 


### PR DESCRIPTION
Added a description for the Amharic figurative expression dataset.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The default DatasetCard template is used for all generated dataset cards, so this dataset-specific copy would appear on every new card. Not a security issue, but it is a library-wide template regression.
> 
> **Overview**
> Adds a **dataset-specific** paragraph under `## Dataset Details` in the default `datasetcard_template.md` used by `DatasetCard.from_template`.
> 
> The new text describes an Amharic idiom/proverb/literal classification dataset. That content does not belong in the generic Hub template and would be baked into every generated dataset card unless users override the whole template.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0d66ce73e1f8b7d868d30896dcc0f6db36dc451. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->