### PR TITLE
Update dataset card template for Amharic Idiom dataset

### DIFF
--- a/src/huggingface_hub/templates/datasetcard_template.md
+++ b/src/huggingface_hub/templates/datasetcard_template.md
@@ -4,7 +4,7 @@
 {{ card_data }}
 ---
 
-# Dataset Card for {{ pretty_name | default("Dataset Name", true) }}
+# Dataset Card for {{ pretty_name | default("Amharic Idiom classification dataset", true) }}
 
 <!-- Provide a quick summary of the dataset. -->
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> One-line template change, but it is the library-wide dataset card default, so it affects every generated card that omits pretty_name. Not security-related, but likely an unintended dataset-specific override of a shared template.
> 
> **Overview**
> Changes the Jinja fallback for `pretty_name` in the shared `datasetcard_template.md` from `"Dataset Name"` to `"Amharic Idiom classification dataset"`.
> 
> This default is used by `DatasetCard.from_template` whenever `pretty_name` is not provided, so **all newly generated dataset cards** without that field would get this dataset-specific title instead of a generic placeholder.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4f4deadddecd2848cf2a574f5789a618d01a745. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->