### PR TITLE
[Buckets] Add support for updating bucket visibility

### DIFF
--- a/docs/source/en/guides/buckets.md
+++ b/docs/source/en/guides/buckets.md
@@ -172,6 +172,33 @@ username/logs
 ]
 ```
 
+### Change bucket visibility
+
+Use [`update_bucket_settings`] to switch an existing bucket between private and public.
+
+```py
+>>> from huggingface_hub import update_bucket_settings
+
+# Make a bucket private
+>>> update_bucket_settings("username/my-bucket", private=True)
+
+# Make it public again
+>>> update_bucket_settings("username/my-bucket", private=False)
+```
+
+Or via CLI:
+
+```bash
+# Make a bucket private
+>>> hf buckets settings username/my-bucket --private
+✓ Bucket settings updated
+  bucket_id: username/my-bucket
+  private: True
+
+# Make it public again
+>>> hf buckets settings username/my-bucket --public
+```
+
 ### Delete a bucket
 
 Use [`delete_bucket`] to delete a bucket. This operation is irreversible.

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -674,6 +674,18 @@ To get detailed information about a specific bucket (returned as JSON), use `hf 
 }
 ```
 
+### Change bucket visibility
+
+To switch a bucket between private and public, use `hf buckets settings`:
+
+```bash
+# Make a bucket private
+>>> hf buckets settings username/my-bucket --private
+
+# Make it public again
+>>> hf buckets settings username/my-bucket --public
+```
+
 ### Delete a bucket
 
 To delete a bucket, use `hf buckets delete`. You will be prompted for confirmation unless you pass `--yes`:

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -241,6 +241,7 @@ $ hf buckets [OPTIONS] COMMAND [ARGS]...
 * `list`: List buckets or files in a bucket. [alias: ls]
 * `move`: Move (rename) a bucket to a new name or...
 * `remove`: Remove files from a bucket. [alias: rm]
+* `settings`: Update bucket settings (visibility).
 * `sync`: Sync files between local directory and a...
 
 ### `hf buckets cp`
@@ -486,6 +487,37 @@ Examples
   $ hf buckets rm user/my-bucket/logs/ --recursive
   $ hf buckets rm user/my-bucket --recursive --include "*.tmp"
   $ hf buckets rm user/my-bucket/data/ --recursive --dry-run
+
+Learn more
+  Use `hf <command> --help` for more information about a command.
+  Read the documentation at https://huggingface.co/docs/huggingface_hub/en/guides/cli
+
+
+### `hf buckets settings`
+
+Update bucket settings (visibility).
+
+**Usage**:
+
+```console
+$ hf buckets settings [OPTIONS] BUCKET_ID
+```
+
+**Arguments**:
+
+* `BUCKET_ID`: Bucket ID: namespace/bucket_name or hf://buckets/namespace/bucket_name  [required]
+
+**Options**:
+
+* `--private`: Make the bucket private.
+* `--public`: Make the bucket public.
+* `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
+* `--help`: Show this message and exit.
+
+Examples
+  $ hf buckets settings user/my-bucket --private
+  $ hf buckets settings user/my-bucket --public
+  $ hf buckets settings hf://buckets/user/my-bucket --private
 
 Learn more
   Use `hf <command> --help` for more information about a command.

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -357,6 +357,7 @@ _SUBMOD_ATTRS = {
         "sync_job_volume",
         "trigger_scheduled_job",
         "unlike",
+        "update_bucket_settings",
         "update_collection_item",
         "update_collection_metadata",
         "update_collection_resource_group",
@@ -1136,6 +1137,7 @@ __all__ = [
     "try_to_load_from_cache",
     "typer_factory",
     "unlike",
+    "update_bucket_settings",
     "update_collection_item",
     "update_collection_metadata",
     "update_collection_resource_group",
@@ -1555,6 +1557,7 @@ if TYPE_CHECKING:  # pragma: no cover
         sync_job_volume,  # noqa: F401
         trigger_scheduled_job,  # noqa: F401
         unlike,  # noqa: F401
+        update_bucket_settings,  # noqa: F401
         update_collection_item,  # noqa: F401
         update_collection_metadata,  # noqa: F401
         update_collection_resource_group,  # noqa: F401

--- a/src/huggingface_hub/cli/buckets.py
+++ b/src/huggingface_hub/cli/buckets.py
@@ -520,6 +520,61 @@ def move(
     out.result("Bucket moved", from_id=parsed_from.id, to_id=parsed_to.id)
 
 
+@buckets_cli.command(
+    name="settings",
+    examples=[
+        "hf buckets settings user/my-bucket --private",
+        "hf buckets settings user/my-bucket --public",
+        "hf buckets settings hf://buckets/user/my-bucket --private",
+    ],
+)
+def settings(
+    bucket_id: Annotated[
+        str,
+        Argument(
+            help="Bucket ID: namespace/bucket_name or hf://buckets/namespace/bucket_name",
+        ),
+    ],
+    private: Annotated[
+        bool,
+        Option(
+            "--private",
+            help="Make the bucket private.",
+        ),
+    ] = False,
+    public: Annotated[
+        bool,
+        Option(
+            "--public",
+            help="Make the bucket public.",
+        ),
+    ] = False,
+    token: TokenOpt = None,
+) -> None:
+    """Update bucket settings (visibility)."""
+    if private == public:
+        raise click.BadParameter("Specify exactly one of --private or --public.")
+
+    if bucket_id.startswith(BUCKET_PREFIX):
+        parsed = _parse_bucket_uri(bucket_id)
+        if parsed.path_in_repo:
+            raise click.BadParameter(
+                f"Cannot specify a prefix for bucket settings: {bucket_id}."
+                f" Use namespace/bucket_name or {BUCKET_PREFIX}namespace/bucket_name."
+            )
+        bucket_id = parsed.id
+    elif "/" not in bucket_id:
+        raise click.BadParameter(
+            f"Invalid bucket ID: {bucket_id}."
+            f" Must be in format namespace/bucket_name or {BUCKET_PREFIX}namespace/bucket_name."
+        )
+
+    api = get_hf_api(token=token)
+    api.update_bucket_settings(bucket_id, private=private)
+    out.result("Bucket settings updated", bucket_id=bucket_id, private=private)
+    out.hint(f"Run `hf buckets info {bucket_id}` to view bucket details.")
+
+
 # =============================================================================
 # Sync command
 # =============================================================================

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -13975,6 +13975,51 @@ class HfApi:
         hf_raise_for_status(response)
 
     @validate_hf_hub_args
+    def update_bucket_settings(
+        self,
+        bucket_id: str,
+        *,
+        private: bool,
+        token: bool | str | None = None,
+    ) -> None:
+        """Update the settings of a bucket on the Hub.
+
+        Currently, the only supported setting is the bucket's visibility.
+
+        Args:
+            bucket_id (`str`):
+                The ID of the bucket (e.g. `"username/my-bucket"`).
+            private (`bool`):
+                Whether to make the bucket private.
+            token (`bool` or `str`, *optional*):
+                A valid user access token (string). Defaults to the locally saved
+                token, which is the recommended method for authentication (see
+                https://huggingface.co/docs/huggingface_hub/quick-start#authentication).
+                To disable authentication, pass `False`.
+
+        Raises:
+            [`~errors.BucketNotFoundError`]: If the bucket cannot be found. This may be because it doesn't exist,
+            or because it is set to `private` and you do not have access.
+
+        Example:
+            ```python
+            >>> from huggingface_hub import update_bucket_settings
+
+            >>> # Make a bucket public
+            >>> update_bucket_settings(bucket_id="Wauplin/first-bucket", private=False)
+
+            >>> # Make it private again
+            >>> update_bucket_settings(bucket_id="Wauplin/first-bucket", private=True)
+            ```
+        """
+        response = get_session().put(
+            f"{self.endpoint}/api/buckets/{bucket_id}/settings",
+            headers=self._build_hf_headers(token=token),
+            json={"private": private},
+        )
+        hf_raise_for_status(response)
+
+    @validate_hf_hub_args
     def list_bucket_tree(
         self,
         bucket_id: str,
@@ -15317,6 +15362,7 @@ bucket_info = api.bucket_info
 list_buckets = api.list_buckets
 delete_bucket = api.delete_bucket
 move_bucket = api.move_bucket
+update_bucket_settings = api.update_bucket_settings
 list_bucket_tree = api.list_bucket_tree
 get_bucket_paths_info = api.get_bucket_paths_info
 copy_files = api.copy_files

--- a/tests/test_buckets.py
+++ b/tests/test_buckets.py
@@ -244,6 +244,16 @@ def test_move_bucket_rename(api: HfApi, bucket_write: str):
     api.delete_bucket(new_bucket_id)
 
 
+def test_update_bucket_settings(api: HfApi, bucket_write: str):
+    assert api.bucket_info(bucket_write).private is False
+
+    api.update_bucket_settings(bucket_write, private=True)
+    assert api.bucket_info(bucket_write).private is True
+
+    api.update_bucket_settings(bucket_write, private=False)
+    assert api.bucket_info(bucket_write).private is False
+
+
 def test_list_bucket_tree_on_public_bucket(api: HfApi, bucket_read: str):
     tree = list(api.list_bucket_tree(bucket_read))
     assert len(tree) == 4

--- a/tests/test_buckets_cli.py
+++ b/tests/test_buckets_cli.py
@@ -195,6 +195,29 @@ def test_delete_bucket_not_found():
 
 
 # =============================================================================
+# Settings
+# =============================================================================
+
+
+def test_bucket_settings(api: HfApi, bucket_write: str):
+    result = cli(f"hf buckets settings {bucket_write} --private")
+    assert result.exit_code == 0
+    assert api.bucket_info(bucket_write).private is True
+
+    result = cli(f"hf buckets settings {bucket_write} --public")
+    assert result.exit_code == 0
+    assert api.bucket_info(bucket_write).private is False
+
+
+def test_bucket_settings_requires_exactly_one_flag(bucket_read: str):
+    result = cli(f"hf buckets settings {bucket_read} --private --public")
+    assert result.exit_code != 0
+
+    result = cli(f"hf buckets settings {bucket_read}")
+    assert result.exit_code != 0
+
+
+# =============================================================================
 # Remove / rm  (file removal only)
 # =============================================================================
 


### PR DESCRIPTION
Fixes #4696.

Bucket visibility could only be set at creation time. This adds the client-side plumbing for the existing server route so it can be changed afterwards.

## Summary

- New `HfApi.update_bucket_settings(bucket_id, *, private: bool)` (also exported at module level) — sends `PUT /api/buckets/{namespace}/{name}/settings` with `{"private": bool}`.
- New `hf buckets settings <bucket-id> --public|--private` CLI command.
- Docs: "Change bucket visibility" section in the buckets guide and the CLI guide, regenerated CLI reference.
- Tests: staging tests in `test_buckets.py` (flip visibility, re-read via `bucket_info`) and `test_buckets_cli.py` (happy path + flag validation). All pass.


## Examples

Real output, tested on production with a scratch bucket (since deleted):

```console
$ hf buckets create celinah/tmp-4696-demo --private
✓ Bucket created
  uri: hf://buckets/celinah/tmp-4696-demo
  url: https://huggingface.co/buckets/celinah/tmp-4696-demo

$ hf buckets settings celinah/tmp-4696-demo --public
✓ Bucket settings updated
  bucket_id: celinah/tmp-4696-demo
  private: False
Hint: Run `hf buckets info celinah/tmp-4696-demo` to view bucket details.

$ hf buckets info celinah/tmp-4696-demo
{"id": "celinah/tmp-4696-demo", "private": false, "created_at": "2026-08-21T09:38:37+00:00", "size": 0, "total_files": 0}

$ hf buckets settings hf://buckets/celinah/tmp-4696-demo --private
✓ Bucket settings updated
  bucket_id: celinah/tmp-4696-demo
  private: True
```

Flag validation:

```console
$ hf buckets settings celinah/tmp-4696-demo --private --public
Usage: hf buckets settings [OPTIONS] BUCKET_ID
Try 'hf buckets settings --help' for help.

Error: Invalid value: Specify exactly one of --private or --public.
```

Python:

```py
>>> from huggingface_hub import update_bucket_settings
>>> update_bucket_settings("celinah/tmp-4696-demo", private=False)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches bucket visibility (public vs private), which affects who can access stored objects, but is a thin authenticated PUT wrapper with tests and no auth-stack changes.
> 
> **Overview**
> Bucket visibility can now be changed after creation, not only at `create_bucket` time.
> 
> Adds `update_bucket_settings(bucket_id, *, private: bool)` on `HfApi` (also exported at module level). It `PUT`s `{"private": ...}` to `/api/buckets/{id}/settings`. The CLI gets `hf buckets settings <id> --private|--public`, requiring exactly one of those flags.
> 
> Docs cover the Python and CLI flows; staging tests flip visibility and reject invalid flag combinations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 871d0a397c750f94d18ac4257cc2513a058c5412. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->