### PR TITLE
[CLI] Fix table dropping columns absent from the first row

### DIFF
--- a/src/huggingface_hub/cli/_output.py
+++ b/src/huggingface_hub/cli/_output.py
@@ -117,7 +117,7 @@ class Output:
             return
 
         if headers is None:
-            all_columns = list(items[0].keys())
+            all_columns = list(dict.fromkeys(col for item in items for col in item))
             headers = [col for col in all_columns if any(item.get(col) is not None for item in items)]
         rows = [[item.get(h) for h in headers] for item in items]
 

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -170,6 +170,26 @@ def test_table_empty(check):
     )
 
 
+def test_table_auto_headers_cover_every_item(capsys):
+    """Auto-detected headers come from every item, not only the first one.
+
+    Callers build rows with `_dataclass_to_dict`, which drops `None` fields, so two items
+    of the same type can have different key sets (e.g. `hf jobs inspect running_job finished_job`).
+    """
+    items = [
+        {"id": "job-1", "stage": "RUNNING"},
+        {"id": "job-2", "stage": "COMPLETED", "finished_at": "2026-08-21"},
+    ]
+
+    o = Output()
+    o.set_mode(HUMAN)
+    o.table(items)
+
+    captured = capsys.readouterr()
+    assert "FINISHED_AT" in captured.out
+    assert "2026-08-21" in captured.out
+
+
 def test_table_adaptive_shrinks_widest_column(monkeypatch, capsys):
     """Narrow terminal: the wide column gets shrunk, naturally-narrow columns are preserved."""
     monkeypatch.setattr(shutil, "get_terminal_size", lambda *_: os.terminal_size((40, 24)))


### PR DESCRIPTION
`Output.table()` derives its column set from the first item only, so any field that happens to be
absent on the first row is dropped from the table for every row. The value is present in the data
and simply never renders.

The seed is taken at `src/huggingface_hub/cli/_output.py:120`:

```python
all_columns = list(items[0].keys())
headers = [col for col in all_columns if any(item.get(col) is not None for item in items)]
```

The filter on the next line already scans every item, so the batch-wide intent is there; only the
seed set is narrowed to `items[0]`.

Rows reaching this function do not have a uniform key set, because `_dataclass_to_dict` drops keys
whose value is `None`. `hf jobs inspect <id> <id>` is the clearest case: `JobInfo.finished_at` is
`None` while a job is running, `labels` is `None` when it has none, and `_surface_name` only injects
`name` when the job carries a name label. Inspecting one running job and one finished, named job
produces a first row without `finished_at`, `labels` or `name`, and a second row with all three, so
`NAME`, `FINISHED_AT` and `LABELS` never reach the rendered table. `--format json` still emits them,
so the human, agent and quiet views disagree with the JSON view for the same command.

The same shape applies to `hf jobs scheduled ls`, `hf datasets ls`, `hf collections ls` and
`hf discussions list`, all of which call `table()` without an explicit `headers=`.

The fix collects columns across all items, preserving first-appearance order:

```python
all_columns = list(dict.fromkeys(col for item in items for col in item))
```

`dict.fromkeys` dedupes while keeping order, so column order is unchanged for homogeneous input,
which is what every existing test uses. A set union would scramble the order.

One consequence worth stating: a key that first appears on a later row is appended at the end of the
column list, so in the `jobs inspect` case `NAME` renders last rather than first. Ordering by first
appearance is the minimal rule that does not require callers to supply an ordering.

Verified locally: the new test in `tests/test_cli_output.py` fails on unpatched source with
`assert 'FINISHED_AT' in 'ID    STAGE    \n----- ---------\njob-1 RUNNING  \njob-2 COMPLETED\n'`,
and the file goes from 32 to 33 passing with the change. `test_cli_output.py`,
`test_cli_framework.py` and `test_cli_errors.py` together are 78 passed. `ruff format --check` and
`ruff check` are clean on both touched files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI display fix with no auth, data, or API behavior changes. Column order can shift when a key first appears on a later row.
> 
> **Overview**
> CLI tables no longer drop columns that are absent from the first row.
> 
> `Output.table()` auto-headers now union keys across **all** items (first-seen order via `dict.fromkeys`) instead of `items[0]` only. That matches `_dataclass_to_dict` dropping `None` fields, so mixed rows (e.g. running vs finished jobs) still show `finished_at` and similar columns in human/agent/quiet output.
> 
> Adds a regression test for this case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4377449f9d050a96c14cab6cbc818e05da9a778. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->