### PR TITLE
[Inference Providers] deepinfra: add text-to-image support

### DIFF
--- a/src/huggingface_hub/inference/_providers/__init__.py
+++ b/src/huggingface_hub/inference/_providers/__init__.py
@@ -15,6 +15,7 @@ from .deepinfra import (
     DeepInfraConversationalTask,
     DeepInfraFeatureExtractionTask,
     DeepInfraTextGenerationTask,
+    DeepInfraTextToImageTask,
     DeepInfraTextToSpeechTask,
 )
 from .fal_ai import (
@@ -110,6 +111,7 @@ PROVIDERS: dict[PROVIDER_T, dict[str, TaskProviderHelper]] = {
         "conversational": DeepInfraConversationalTask(),
         "feature-extraction": DeepInfraFeatureExtractionTask(),
         "text-generation": DeepInfraTextGenerationTask(),
+        "text-to-image": DeepInfraTextToImageTask(),
         "text-to-speech": DeepInfraTextToSpeechTask(),
     },
     "fal-ai": {

--- a/src/huggingface_hub/inference/_providers/deepinfra.py
+++ b/src/huggingface_hub/inference/_providers/deepinfra.py
@@ -1,3 +1,4 @@
+import base64
 import json
 import mimetypes
 import uuid
@@ -164,3 +165,29 @@ class DeepInfraFeatureExtractionTask(TaskProviderHelper):
 
     def get_response(self, response: bytes | dict, request_params: RequestParameters | None = None) -> Any:
         return [item["embedding"] for item in _as_dict(response)["data"]]
+
+
+class DeepInfraTextToImageTask(TaskProviderHelper):
+    def __init__(self):
+        super().__init__(provider=_PROVIDER, base_url=_BASE_URL, task="text-to-image")
+
+    def _prepare_route(self, mapped_model: str, api_key: str) -> str:
+        return "/v1/openai/images/generations"
+
+    def _prepare_payload_as_dict(
+        self, inputs: Any, parameters: dict, provider_mapping_info: InferenceProviderMapping
+    ) -> dict | None:
+        parameters = filter_none(parameters)
+        if "width" in parameters and "height" in parameters:
+            parameters["size"] = f"{parameters.pop('width')}x{parameters.pop('height')}"
+        # `prompt`/`model` are applied after the caller parameters so neither can be overridden.
+        return {
+            **parameters,
+            "response_format": "b64_json",
+            "prompt": inputs,
+            "model": provider_mapping_info.provider_id,
+        }
+
+    def get_response(self, response: bytes | dict, request_params: RequestParameters | None = None) -> Any:
+        response_dict = _as_dict(response)
+        return base64.b64decode(response_dict["data"][0]["b64_json"])

--- a/src/huggingface_hub/inference/_providers/deepinfra.py
+++ b/src/huggingface_hub/inference/_providers/deepinfra.py
@@ -180,6 +180,10 @@ class DeepInfraTextToImageTask(TaskProviderHelper):
         parameters = filter_none(parameters)
         if "width" in parameters and "height" in parameters:
             parameters["size"] = f"{parameters.pop('width')}x{parameters.pop('height')}"
+        # DeepInfra's OpenAI-compatible images endpoint ignores diffusion-specific fields;
+        # drop them so they are not silently swallowed by the provider.
+        for unsupported in ("num_inference_steps", "guidance_scale", "negative_prompt", "scheduler", "seed"):
+            parameters.pop(unsupported, None)
         # `prompt`/`model` are applied after the caller parameters so neither can be overridden.
         return {
             **parameters,

--- a/tests/test_inference_providers.py
+++ b/tests/test_inference_providers.py
@@ -456,7 +456,15 @@ class TestDeepInfraProvider:
         helper = DeepInfraTextToImageTask()
         payload = helper._prepare_payload_as_dict(
             "an astronaut riding a horse",
-            {"width": 1024, "height": 768, "num_inference_steps": None},
+            {
+                "width": 1024,
+                "height": 768,
+                "num_inference_steps": 20,
+                "guidance_scale": 7.5,
+                "negative_prompt": "blurry",
+                "scheduler": "DDIM",
+                "seed": 42,
+            },
             InferenceProviderMapping(
                 provider="deepinfra",
                 hf_model_id="stabilityai/sdxl-turbo",
@@ -465,6 +473,8 @@ class TestDeepInfraProvider:
                 status="live",
             ),
         )
+        # DeepInfra's OpenAI-compatible endpoint only supports size/response_format/prompt/model;
+        # diffusion-specific fields are dropped.
         assert payload == {
             "size": "1024x768",
             "response_format": "b64_json",

--- a/tests/test_inference_providers.py
+++ b/tests/test_inference_providers.py
@@ -21,6 +21,7 @@ from huggingface_hub.inference._providers.cohere import CohereConversationalTask
 from huggingface_hub.inference._providers.deepinfra import (
     DeepInfraAutomaticSpeechRecognitionTask,
     DeepInfraFeatureExtractionTask,
+    DeepInfraTextToImageTask,
     DeepInfraTextToSpeechTask,
 )
 from huggingface_hub.inference._providers.fal_ai import (
@@ -445,6 +446,52 @@ class TestDeepInfraProvider:
             "model": "Qwen/Qwen3-Embedding-0.6B",
         }
         assert helper.get_response(response) == [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+
+    def test_text_to_image_url(self):
+        helper = DeepInfraTextToImageTask()
+        url = helper._prepare_url("hf_token", "stabilityai/sdxl-turbo")
+        assert url == "https://router.huggingface.co/deepinfra/v1/openai/images/generations"
+
+    def test_text_to_image_payload(self):
+        helper = DeepInfraTextToImageTask()
+        payload = helper._prepare_payload_as_dict(
+            "an astronaut riding a horse",
+            {"width": 1024, "height": 768, "num_inference_steps": None},
+            InferenceProviderMapping(
+                provider="deepinfra",
+                hf_model_id="stabilityai/sdxl-turbo",
+                providerId="stabilityai/sdxl-turbo",
+                task="text-to-image",
+                status="live",
+            ),
+        )
+        assert payload == {
+            "size": "1024x768",
+            "response_format": "b64_json",
+            "prompt": "an astronaut riding a horse",
+            "model": "stabilityai/sdxl-turbo",
+        }
+
+    def test_text_to_image_model_not_overridable(self):
+        helper = DeepInfraTextToImageTask()
+        payload = helper._prepare_payload_as_dict(
+            "a cat",
+            {"model": "attacker/model", "prompt": "attacker prompt"},
+            InferenceProviderMapping(
+                provider="deepinfra",
+                hf_model_id="stabilityai/sdxl-turbo",
+                providerId="stabilityai/sdxl-turbo",
+                task="text-to-image",
+                status="live",
+            ),
+        )
+        assert payload["model"] == "stabilityai/sdxl-turbo"
+        assert payload["prompt"] == "a cat"
+
+    def test_text_to_image_response(self):
+        helper = DeepInfraTextToImageTask()
+        response = {"data": [{"b64_json": base64.b64encode(b"image-bytes").decode()}]}
+        assert helper.get_response(response) == b"image-bytes"
 
 
 class TestFalAIProvider:


### PR DESCRIPTION
## What

Adds `DeepInfraTextToImageTask` so the `deepinfra` provider supports `text-to-image`.

DeepInfra exposes an OpenAI-compatible image endpoint, so this mirrors the existing `nscale` text-to-image helper:
- Route: `/v1/openai/images/generations`
- `_prepare_payload_as_dict`: requests `response_format=b64_json`, maps `width`/`height` to `size`, and applies `prompt`/`model` after caller parameters so neither can be overridden.
- `get_response`: returns the base64-decoded image bytes (fed to `_bytes_to_image` by the client).

Wired in `_providers/__init__.py` under `deepinfra`. Existing deepinfra tasks are untouched.

## Test
Added `test_text_to_image_{url,payload,model_not_overridable,response}` to `TestDeepInfraProvider`. All pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive provider wiring with tested request shaping; no changes to auth or existing DeepInfra tasks.
> 
> **Overview**
> Adds **text-to-image** support for the **deepinfra** inference provider by introducing `DeepInfraTextToImageTask` and registering it under `deepinfra` → `text-to-image` in the provider map.
> 
> The helper targets DeepInfra’s OpenAI-style images API (`/v1/openai/images/generations`): it sends `response_format=b64_json`, maps `width`/`height` to `size`, strips diffusion-only parameters the endpoint ignores (`num_inference_steps`, `guidance_scale`, `negative_prompt`, `scheduler`, `seed`), and sets `prompt`/`model` after caller params so mapped model and inputs cannot be overridden. Responses are decoded from `data[0].b64_json` to raw image bytes.
> 
> Unit tests cover routed URL, payload shaping, model/prompt override protection, and response decoding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80b71d46f9fefddeefc7d3b37d3eb9ab936ac5d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->