### PR TITLE
[Inference Providers] deepinfra: add text-to-video support

### DIFF
--- a/src/huggingface_hub/inference/_providers/__init__.py
+++ b/src/huggingface_hub/inference/_providers/__init__.py
@@ -16,6 +16,7 @@ from .deepinfra import (
     DeepInfraFeatureExtractionTask,
     DeepInfraTextGenerationTask,
     DeepInfraTextToSpeechTask,
+    DeepInfraTextToVideoTask,
 )
 from .fal_ai import (
     FalAIAutomaticSpeechRecognitionTask,
@@ -111,6 +112,7 @@ PROVIDERS: dict[PROVIDER_T, dict[str, TaskProviderHelper]] = {
         "feature-extraction": DeepInfraFeatureExtractionTask(),
         "text-generation": DeepInfraTextGenerationTask(),
         "text-to-speech": DeepInfraTextToSpeechTask(),
+        "text-to-video": DeepInfraTextToVideoTask(),
     },
     "fal-ai": {
         "automatic-speech-recognition": FalAIAutomaticSpeechRecognitionTask(),

--- a/src/huggingface_hub/inference/_providers/deepinfra.py
+++ b/src/huggingface_hub/inference/_providers/deepinfra.py
@@ -1,10 +1,12 @@
 import json
 import mimetypes
+import time
 import uuid
 from typing import Any
 
 from huggingface_hub.hf_api import InferenceProviderMapping
 from huggingface_hub.inference._common import MimeBytes, RequestParameters, _as_dict, _open_as_mime_bytes
+from huggingface_hub.utils import get_session, hf_raise_for_status
 
 from ._common import BaseConversationalTask, BaseTextGenerationTask, TaskProviderHelper, filter_none
 
@@ -164,3 +166,47 @@ class DeepInfraFeatureExtractionTask(TaskProviderHelper):
 
     def get_response(self, response: bytes | dict, request_params: RequestParameters | None = None) -> Any:
         return [item["embedding"] for item in _as_dict(response)["data"]]
+
+
+class DeepInfraTextToVideoTask(TaskProviderHelper):
+    def __init__(self):
+        super().__init__(provider=_PROVIDER, base_url=_BASE_URL, task="text-to-video")
+
+    def _prepare_route(self, mapped_model: str, api_key: str) -> str:
+        return "/v1/openai/videos"
+
+    def _prepare_payload_as_dict(
+        self, inputs: Any, parameters: dict, provider_mapping_info: InferenceProviderMapping
+    ) -> dict | None:
+        # DeepInfra video generation is asynchronous: this submits the job and get_response
+        # polls it. `prompt`/`model` are applied after caller parameters so neither can be overridden.
+        return {
+            **filter_none(parameters),
+            "prompt": inputs,
+            "model": provider_mapping_info.provider_id,
+        }
+
+    def get_response(self, response: bytes | dict, request_params: RequestParameters | None = None) -> Any:
+        if request_params is None:
+            raise ValueError("A `request_params` object is required to poll DeepInfra text-to-video jobs.")
+        job = _as_dict(response)
+        job_id = job.get("id")
+        if not job_id:
+            raise ValueError(f"Unexpected response from DeepInfra text-to-video API: {response!r}")
+        session = get_session()
+        status_url = f"{request_params.url.rstrip('/')}/{job_id}"
+        status = job.get("status")
+        while status not in ("succeeded", "failed"):
+            time.sleep(2)
+            poll = session.get(status_url, headers=request_params.headers)
+            hf_raise_for_status(poll)
+            job = poll.json()
+            status = job.get("status")
+        if status == "failed":
+            raise ValueError(f"DeepInfra text-to-video job failed: {job.get('error')}")
+        data = job.get("data")
+        if not (isinstance(data, list) and data and isinstance(data[0], dict) and data[0].get("url")):
+            raise ValueError(f"Unexpected response from DeepInfra text-to-video API: {job!r}")
+        video = session.get(data[0]["url"])
+        hf_raise_for_status(video)
+        return video.content

--- a/tests/test_inference_providers.py
+++ b/tests/test_inference_providers.py
@@ -22,6 +22,7 @@ from huggingface_hub.inference._providers.deepinfra import (
     DeepInfraAutomaticSpeechRecognitionTask,
     DeepInfraFeatureExtractionTask,
     DeepInfraTextToSpeechTask,
+    DeepInfraTextToVideoTask,
 )
 from huggingface_hub.inference._providers.fal_ai import (
     _POLLING_INTERVAL,
@@ -445,6 +446,67 @@ class TestDeepInfraProvider:
             "model": "Qwen/Qwen3-Embedding-0.6B",
         }
         assert helper.get_response(response) == [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+
+    def test_text_to_video_url(self):
+        helper = DeepInfraTextToVideoTask()
+        url = helper._prepare_url("hf_token", "Wan-AI/Wan2.1-T2V-14B")
+        assert url == "https://router.huggingface.co/deepinfra/v1/openai/videos"
+
+    def test_text_to_video_payload(self):
+        helper = DeepInfraTextToVideoTask()
+        payload = helper._prepare_payload_as_dict(
+            "a cat playing piano",
+            {"seed": 42, "guidance_scale": None},
+            InferenceProviderMapping(
+                provider="deepinfra",
+                hf_model_id="Wan-AI/Wan2.1-T2V-14B",
+                providerId="Wan-AI/Wan2.1-T2V-14B",
+                task="text-to-video",
+                status="live",
+            ),
+        )
+        assert payload == {"seed": 42, "prompt": "a cat playing piano", "model": "Wan-AI/Wan2.1-T2V-14B"}
+
+    def test_text_to_video_model_not_overridable(self):
+        helper = DeepInfraTextToVideoTask()
+        payload = helper._prepare_payload_as_dict(
+            "a cat",
+            {"model": "attacker/model", "prompt": "attacker prompt"},
+            InferenceProviderMapping(
+                provider="deepinfra",
+                hf_model_id="Wan-AI/Wan2.1-T2V-14B",
+                providerId="Wan-AI/Wan2.1-T2V-14B",
+                task="text-to-video",
+                status="live",
+            ),
+        )
+        assert payload["model"] == "Wan-AI/Wan2.1-T2V-14B"
+        assert payload["prompt"] == "a cat"
+
+    def test_text_to_video_response(self, mocker):
+        helper = DeepInfraTextToVideoTask()
+        mock_session = mocker.patch("huggingface_hub.inference._providers.deepinfra.get_session")
+        mocker.patch("huggingface_hub.inference._providers.deepinfra.time.sleep")
+        mocker.patch("huggingface_hub.inference._providers.deepinfra.hf_raise_for_status")
+        mock_session.return_value.get.side_effect = [
+            mocker.Mock(json=lambda: {"id": "vid_1", "status": "succeeded", "data": [{"url": "https://cdn/vid_1.mp4"}]}),
+            mocker.Mock(content=b"video_content"),
+        ]
+        request_params = RequestParameters(
+            url="https://router.huggingface.co/deepinfra/v1/openai/videos",
+            headers={},
+            task="text-to-video",
+            model="Wan-AI/Wan2.1-T2V-14B",
+            data=None,
+            json=None,
+        )
+        result = helper.get_response({"id": "vid_1", "status": "processing"}, request_params)
+        assert result == b"video_content"
+        # The first poll appends the job id to the submit URL.
+        assert (
+            mock_session.return_value.get.call_args_list[0][0][0]
+            == "https://router.huggingface.co/deepinfra/v1/openai/videos/vid_1"
+        )
 
 
 class TestFalAIProvider:


### PR DESCRIPTION
## What

Adds `DeepInfraTextToVideoTask` so the `deepinfra` provider supports `text-to-video`.

DeepInfra's video generation is asynchronous, so this submits and polls:
- `_prepare_route`: `/v1/openai/videos` (POST submits the job).
- `_prepare_payload_as_dict`: forwards `prompt`; applies `prompt`/`model` after caller parameters so neither can be overridden.
- `get_response`: reads the job `id`, polls `/v1/openai/videos/{id}` until `status` is `succeeded`/`failed`, then downloads `data[0].url` and returns the video bytes. Raises `ValueError` on failure/malformed output.

Wired in `_providers/__init__.py` under `deepinfra`. Existing tasks untouched.

## Test
Added `test_text_to_video_{url,payload,model_not_overridable,response}` to `TestDeepInfraProvider` (response test mocks the poll + download). All pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)