### PR TITLE
fix: detect packages in frozen environments (PyInstaller)

### DIFF
--- a/src/huggingface_hub/utils/_runtime.py
+++ b/src/huggingface_hub/utils/_runtime.py
@@ -70,6 +70,15 @@ for candidate_name, package_names in _CANDIDATES.items():
             break
         except importlib.metadata.PackageNotFoundError:
             pass
+    # Fallback: in frozen environments (e.g. PyInstaller) metadata is often
+    # stripped while the module itself is bundled. Use find_spec as a fallback
+    # so that bundled packages are still detected.
+    if _package_versions[candidate_name] == "N/A":
+        try:
+            if importlib.util.find_spec(candidate_name) is not None:
+                _package_versions[candidate_name] = "unknown"
+        except (ModuleNotFoundError, ValueError):
+            pass
 
 
 def _get_version(package_name: str) -> str:


### PR DESCRIPTION
# What does this PR do?

Fixes #4717

When a Python application is packaged with PyInstaller, `importlib.metadata.version()` cannot find package metadata even though the module itself is bundled. This causes `is_package_available("hf_xet")` to return `False`, so Xet downloads silently fall back to HTTP.

## Root cause

The runtime detection loop in `utils/_runtime.py` only uses `importlib.metadata.version()`. PyInstaller bundles modules but strips their `dist-info` metadata, so `PackageNotFoundError` fires and the package is marked `"N/A"`.

## Fix

Added `importlib.util.find_spec()` as a fallback after the metadata loop. When metadata lookup fails, `find_spec` checks whether the module itself is importable. The version is set to `"unknown"` since metadata isn't available, but `is_package_available()` now correctly returns `True`.

- No behavior change in standard Python environments (metadata lookup succeeds first)
- `get_xet_version()` returns `"unknown"` instead of `"N/A"` in frozen environments
- The fallback also benefits other optional dependencies bundled without metadata

## Who can review?

@Wauplin