### PR TITLE
[Download] Retry timeout while opening resume stream

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -7,6 +7,7 @@ import stat
 import time
 import uuid
 import warnings
+from contextlib import ExitStack
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, BinaryIO, Literal, NoReturn, overload
@@ -373,14 +374,37 @@ def http_get(
             " Install `hf_xet` with `pip install hf_xet` for xet-powered downloads."
         )
 
-    with http_stream_backoff(
-        method="GET",
-        url=url,
-        headers=headers,
-        timeout=constants.HF_HUB_DOWNLOAD_TIMEOUT,
-        retry_on_exceptions=(),
-        retry_on_status_codes=(408, 429),
-    ) as response:
+    # Catch transient failures raised while entering the stream. A regular `with` statement raises these before the
+    # body-level retry handler below can resume the download.
+    with ExitStack() as stack:
+        try:
+            response = stack.enter_context(
+                http_stream_backoff(
+                    method="GET",
+                    url=url,
+                    headers=headers,
+                    timeout=constants.HF_HUB_DOWNLOAD_TIMEOUT,
+                    retry_on_exceptions=(),
+                    retry_on_status_codes=(408, 429),
+                )
+            )
+        except (httpx.ConnectError, httpx.TimeoutException, httpx.RemoteProtocolError) as e:
+            if _nb_retries <= 0:
+                logger.warning("Error while downloading from %s: %s\nMax retries exceeded.", url, str(e))
+                raise
+            logger.warning("Error while downloading from %s: %s\nTrying to resume download...", url, str(e))
+            time.sleep(1)
+            return http_get(
+                url=url,
+                temp_file=temp_file,
+                resume_size=resume_size,
+                headers=initial_headers,
+                expected_size=expected_size,
+                tqdm_class=tqdm_class,
+                _nb_retries=_nb_retries - 1,
+                _tqdm_bar=_tqdm_bar,
+            )
+
         hf_raise_for_status(response)
 
         # If we requested a Range but got 200 back, the server ignored our Range header

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -1101,6 +1101,59 @@ class TestHttpGet:
         # Note: The range headers are now handled internally by http_get's retry mechanism
         # The test verifies that the download completed successfully after retries
 
+    def test_http_get_retries_timeout_while_opening_resume_stream(self, caplog):
+        tracker, tqdm_class = self._make_aggregated_tqdm()
+
+        def _partial_then_timeout() -> Iterable[bytes]:
+            yield b"A" * 30
+            raise httpx.ReadTimeout("body timeout")
+
+        attempts = iter(
+            [
+                self._mock_response(headers={"Content-Length": "100"}, iter_bytes=_partial_then_timeout()),
+                httpx.ReadTimeout("response headers timeout"),
+                self._mock_response(
+                    status_code=206,
+                    headers={"Content-Length": "70", "Content-Range": "bytes 30-99/100"},
+                    iter_bytes=iter([b"B" * 70]),
+                ),
+            ]
+        )
+        request_headers = []
+
+        @contextmanager
+        def _mock_stream(*args, **kwargs):
+            request_headers.append(kwargs["headers"])
+            attempt = next(attempts)
+            if isinstance(attempt, Exception):
+                raise attempt
+            yield attempt
+
+        with (
+            patch("huggingface_hub.file_download.http_stream_backoff", side_effect=_mock_stream),
+            patch("huggingface_hub.file_download.time.sleep"),
+        ):
+            temp_file = io.BytesIO()
+            http_get("fake_url", temp_file=temp_file, expected_size=100, tqdm_class=tqdm_class)
+
+        assert temp_file.getvalue() == b"A" * 30 + b"B" * 70
+        assert request_headers == [{}, {"Range": "bytes=30-"}, {"Range": "bytes=30-"}]
+        assert tracker.instances == 1
+        assert tracker.n == 100
+        assert len([record for record in caplog.records if record.levelname == "WARNING"]) == 2
+
+    def test_http_get_header_timeout_respects_retry_budget(self, caplog):
+        with (
+            patch("huggingface_hub.file_download.http_stream_backoff") as mock_stream_backoff,
+            patch("huggingface_hub.file_download.time.sleep") as mock_sleep,
+            pytest.raises(httpx.ReadTimeout, match="response headers timeout"),
+        ):
+            mock_stream_backoff.return_value.__enter__.side_effect = httpx.ReadTimeout("response headers timeout")
+            http_get("fake_url", temp_file=io.BytesIO(), _nb_retries=0)
+
+        mock_sleep.assert_not_called()
+        assert "Max retries exceeded" in caplog.text
+
     @pytest.mark.parametrize(
         "initial_range,expected_ranges",
         [


### PR DESCRIPTION
Fixes #4670

## Summary

- retry transient errors raised while opening an HTTP download stream, not only errors raised while reading its body
- resume from the same byte range and preserve the existing bounded retry budget
- keep the response context closed normally through `ExitStack`

## Root cause

`http_get()` already catches transient errors raised by `response.iter_bytes()` and resumes with a Range request. In the reported traceback, `ReadTimeout` is raised earlier, while `client.stream()` is waiting for response headers. That exception occurs during context-manager entry, before the body retry handler can run, so it escapes and aborts the `snapshot_download` worker.

The regression test downloads 30 bytes, raises a body timeout, then raises a header timeout while opening the resume request. The same `bytes=30-` range is retried and the completed output contains exactly 100 bytes with no gap or duplication.

## Scope

The `ExitStack` is used only so context-manager entry can be caught without restructuring the existing body-stream logic. This does not add an unbounded retry policy or a snapshot-level retry. The existing body retry path, progress-bar reuse, and maximum retry behavior remain unchanged.

## Validation

```text
python -m pytest tests/test_file_download.py::TestHttpGet -q -n0 --basetemp <isolated-dir>
11 passed

python -m pytest tests/test_file_download.py -q -n0 --basetemp <isolated-dir>
65 passed, 4 skipped

ruff check src tests utils setup.py
All checks passed!

ruff format --check src tests utils setup.py
299 files already formatted

ty check src
All checks passed!
```

The static-import, `__all__`, inference-input, async-client, and CLI-reference consistency checks also pass. The tests were run on the exact PR head with Python 3.10.16 on Windows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to HTTP download retry behavior in `http_get`; no auth or API surface changes, with regression tests for resume and retry limits.
> 
> **Overview**
> Fixes failures where `http_get` aborted on timeouts or connection errors raised **before** response headers arrived—errors that a plain `with http_stream_backoff(...)` could not hand off to the existing body-stream retry loop.
> 
> `http_get` now opens the stream through `ExitStack`, catches `ConnectError`, `TimeoutException`, and `RemoteProtocolError` at entry, and **recursively resumes** with the same byte offset, `initial_headers`, and the existing `_nb_retries` budget (warn, 1s sleep, then retry or fail). Body streaming, progress-bar reuse, and range handling are unchanged.
> 
> Tests cover a body timeout followed by a header timeout on the resume request (correct `Range` and full file) and exhaustion when `_nb_retries=0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73e83a469d23242d58d66d63cbed4acdada5acd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->