### PR TITLE
Add JetInfer as an inference provider

### DIFF
--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -135,7 +135,7 @@ class InferenceClient:
             Note: for better compatibility with OpenAI's client, `model` has been aliased as `base_url`. Those 2
             arguments are mutually exclusive. If a URL is passed as `model` or `base_url` for chat completion, the `(/v1)/chat/completions` suffix path will be appended to the URL.
         provider (`str`, *optional*):
-            Name of the provider to use for inference. Can be `"baseten"`, `"cerebras"`, `"cohere"`, `"deepinfra"`, `"fal-ai"`, `"featherless-ai"`, `"fireworks-ai"`, `"groq"`, `"hf-inference"`, `"novita"`, `"nscale"`, `"openai"`, `"ovhcloud"`, `"publicai"`, `"replicate"`, `"scaleway"`, `"together"`, `"wavespeed"` or `"zai-org"`.
+            Name of the provider to use for inference. Can be `"baseten"`, `"cerebras"`, `"cohere"`, `"deepinfra"`, `"fal-ai"`, `"featherless-ai"`, `"fireworks-ai"`, `"groq"`, `"hf-inference"`, `"jetinfer"`, `"novita"`, `"nscale"`, `"openai"`, `"ovhcloud"`, `"publicai"`, `"replicate"`, `"scaleway"`, `"together"`, `"wavespeed"` or `"zai-org"`.
             Defaults to "auto": automatic routing, which defaults to "fastest" provider; you can
             switch to "cheapest" or "preferred" provider order at https://hf.co/settings/inference-providers.
             If model is a URL or `base_url` is passed, then `provider` is not used.

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -125,7 +125,7 @@ class AsyncInferenceClient:
             Note: for better compatibility with OpenAI's client, `model` has been aliased as `base_url`. Those 2
             arguments are mutually exclusive. If a URL is passed as `model` or `base_url` for chat completion, the `(/v1)/chat/completions` suffix path will be appended to the URL.
         provider (`str`, *optional*):
-            Name of the provider to use for inference. Can be `"baseten"`, `"cerebras"`, `"cohere"`, `"deepinfra"`, `"fal-ai"`, `"featherless-ai"`, `"fireworks-ai"`, `"groq"`, `"hf-inference"`, `"novita"`, `"nscale"`, `"openai"`, `"ovhcloud"`, `"publicai"`, `"replicate"`, `"scaleway"`, `"together"`, `"wavespeed"` or `"zai-org"`.
+            Name of the provider to use for inference. Can be `"baseten"`, `"cerebras"`, `"cohere"`, `"deepinfra"`, `"fal-ai"`, `"featherless-ai"`, `"fireworks-ai"`, `"groq"`, `"hf-inference"`, `"jetinfer"`, `"novita"`, `"nscale"`, `"openai"`, `"ovhcloud"`, `"publicai"`, `"replicate"`, `"scaleway"`, `"together"`, `"wavespeed"` or `"zai-org"`.
             Defaults to "auto": automatic routing, which defaults to "fastest" provider; you can
             switch to "cheapest" or "preferred" provider order at https://hf.co/settings/inference-providers.
             If model is a URL or `base_url` is passed, then `provider` is not used.

--- a/src/huggingface_hub/inference/_providers/__init__.py
+++ b/src/huggingface_hub/inference/_providers/__init__.py
@@ -34,6 +34,7 @@ from .hf_inference import (
     HFInferenceFeatureExtractionTask,
     HFInferenceTask,
 )
+from .jetinfer import JetInferConversationalTask
 from .novita import NovitaConversationalTask, NovitaTextGenerationTask, NovitaTextToVideoTask
 from .nscale import NscaleConversationalTask, NscaleTextToImageTask
 from .openai import OpenAIConversationalTask
@@ -79,6 +80,7 @@ PROVIDER_T = Literal[
     "fireworks-ai",
     "groq",
     "hf-inference",
+    "jetinfer",
     "novita",
     "nscale",
     "openai",
@@ -158,6 +160,9 @@ PROVIDERS: dict[PROVIDER_T, dict[str, TaskProviderHelper]] = {
         "translation": HFInferenceTask("translation"),
         "summarization": HFInferenceTask("summarization"),
         "visual-question-answering": HFInferenceBinaryInputTask("visual-question-answering"),
+    },
+    "jetinfer": {
+        "conversational": JetInferConversationalTask(),
     },
     "novita": {
         "text-generation": NovitaTextGenerationTask(),

--- a/src/huggingface_hub/inference/_providers/jetinfer.py
+++ b/src/huggingface_hub/inference/_providers/jetinfer.py
@@ -1,0 +1,6 @@
+from ._common import BaseConversationalTask
+
+
+class JetInferConversationalTask(BaseConversationalTask):
+    def __init__(self):
+        super().__init__(provider="jetinfer", base_url="https://api.jetinfer.com")

--- a/tests/test_inference_providers.py
+++ b/tests/test_inference_providers.py
@@ -45,6 +45,7 @@ from huggingface_hub.inference._providers.hf_inference import (
     HFInferenceFeatureExtractionTask,
     HFInferenceTask,
 )
+from huggingface_hub.inference._providers.jetinfer import JetInferConversationalTask
 from huggingface_hub.inference._providers.novita import NovitaConversationalTask, NovitaTextGenerationTask
 from huggingface_hub.inference._providers.nscale import NscaleConversationalTask, NscaleTextToImageTask
 from huggingface_hub.inference._providers.openai import OpenAIConversationalTask
@@ -1258,6 +1259,13 @@ class TestHFInferenceProvider:
         assert isinstance(request.data, bytes)
         assert request.headers["authorization"] == "Bearer hf_test_token"
         assert request.headers["content-type"] == "image/jpeg"  # based on filename
+
+
+class TestJetInferProvider:
+    def test_prepare_url_conversational(self):
+        helper = JetInferConversationalTask()
+        url = helper._prepare_url("jetinfer_token", "username/repo_name")
+        assert url == "https://api.jetinfer.com/v1/chat/completions"
 
 
 class TestNovitaProvider:


### PR DESCRIPTION
Registers **JetInfer** as an inference provider, per the [register-as-a-provider guide](https://huggingface.co/docs/inference-providers/register-as-a-provider). Companion JS PR: huggingface/huggingface.js#2402.

- Hub org: https://huggingface.co/jetinfer (Team plan)
- API: strictly OpenAI-compatible chat completions at `https://api.jetinfer.com/v1` — `conversational` only, so the helper extends `BaseConversationalTask` with no overrides
- Live now (e.g. `GET https://api.jetinfer.com/v1/models`); streaming, tool calling and structured output verified
- Static test added; registered in `PROVIDER_T`/`PROVIDERS` and the client docstrings

First model to map once enabled: `Qwen/Qwen3.8-27B`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive provider registration using the existing OpenAI-compatible helper; no auth or request-path changes beyond listing a new provider.
> 
> **Overview**
> Adds **JetInfer** as an inference provider for conversational (chat completion) requests.
> 
> `JetInferConversationalTask` extends `BaseConversationalTask` with no custom routing, targeting `https://api.jetinfer.com/v1/chat/completions`. The provider is wired into `PROVIDER_T`/`PROVIDERS`, client docstrings, and a unit test for URL construction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f9c0f7ec507baa958a3c516105536bc8f53f6c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->