### PR TITLE
Add LLM Tech as an inference provider

### DIFF
--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -135,7 +135,7 @@ class InferenceClient:
             Note: for better compatibility with OpenAI's client, `model` has been aliased as `base_url`. Those 2
             arguments are mutually exclusive. If a URL is passed as `model` or `base_url` for chat completion, the `(/v1)/chat/completions` suffix path will be appended to the URL.
         provider (`str`, *optional*):
-            Name of the provider to use for inference. Can be `"baseten"`, `"cerebras"`, `"cohere"`, `"deepinfra"`, `"fal-ai"`, `"featherless-ai"`, `"fireworks-ai"`, `"groq"`, `"hf-inference"`, `"novita"`, `"nscale"`, `"openai"`, `"ovhcloud"`, `"publicai"`, `"replicate"`, `"scaleway"`, `"together"`, `"wavespeed"` or `"zai-org"`.
+            Name of the provider to use for inference. Can be `"baseten"`, `"cerebras"`, `"cohere"`, `"deepinfra"`, `"fal-ai"`, `"featherless-ai"`, `"fireworks-ai"`, `"groq"`, `"hf-inference"`, `"llmtech"`, `"novita"`, `"nscale"`, `"openai"`, `"ovhcloud"`, `"publicai"`, `"replicate"`, `"scaleway"`, `"together"`, `"wavespeed"` or `"zai-org"`.
             Defaults to "auto": automatic routing, which defaults to "fastest" provider; you can
             switch to "cheapest" or "preferred" provider order at https://hf.co/settings/inference-providers.
             If model is a URL or `base_url` is passed, then `provider` is not used.

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -125,7 +125,7 @@ class AsyncInferenceClient:
             Note: for better compatibility with OpenAI's client, `model` has been aliased as `base_url`. Those 2
             arguments are mutually exclusive. If a URL is passed as `model` or `base_url` for chat completion, the `(/v1)/chat/completions` suffix path will be appended to the URL.
         provider (`str`, *optional*):
-            Name of the provider to use for inference. Can be `"baseten"`, `"cerebras"`, `"cohere"`, `"deepinfra"`, `"fal-ai"`, `"featherless-ai"`, `"fireworks-ai"`, `"groq"`, `"hf-inference"`, `"novita"`, `"nscale"`, `"openai"`, `"ovhcloud"`, `"publicai"`, `"replicate"`, `"scaleway"`, `"together"`, `"wavespeed"` or `"zai-org"`.
+            Name of the provider to use for inference. Can be `"baseten"`, `"cerebras"`, `"cohere"`, `"deepinfra"`, `"fal-ai"`, `"featherless-ai"`, `"fireworks-ai"`, `"groq"`, `"hf-inference"`, `"llmtech"`, `"novita"`, `"nscale"`, `"openai"`, `"ovhcloud"`, `"publicai"`, `"replicate"`, `"scaleway"`, `"together"`, `"wavespeed"` or `"zai-org"`.
             Defaults to "auto": automatic routing, which defaults to "fastest" provider; you can
             switch to "cheapest" or "preferred" provider order at https://hf.co/settings/inference-providers.
             If model is a URL or `base_url` is passed, then `provider` is not used.

--- a/src/huggingface_hub/inference/_providers/__init__.py
+++ b/src/huggingface_hub/inference/_providers/__init__.py
@@ -34,6 +34,7 @@ from .hf_inference import (
     HFInferenceFeatureExtractionTask,
     HFInferenceTask,
 )
+from .llmtech import LLMTechConversationalTask
 from .novita import NovitaConversationalTask, NovitaTextGenerationTask, NovitaTextToVideoTask
 from .nscale import NscaleConversationalTask, NscaleTextToImageTask
 from .openai import OpenAIConversationalTask
@@ -79,6 +80,7 @@ PROVIDER_T = Literal[
     "fireworks-ai",
     "groq",
     "hf-inference",
+    "llmtech",
     "novita",
     "nscale",
     "openai",
@@ -158,6 +160,9 @@ PROVIDERS: dict[PROVIDER_T, dict[str, TaskProviderHelper]] = {
         "translation": HFInferenceTask("translation"),
         "summarization": HFInferenceTask("summarization"),
         "visual-question-answering": HFInferenceBinaryInputTask("visual-question-answering"),
+    },
+    "llmtech": {
+        "conversational": LLMTechConversationalTask(),
     },
     "novita": {
         "text-generation": NovitaTextGenerationTask(),

--- a/src/huggingface_hub/inference/_providers/llmtech.py
+++ b/src/huggingface_hub/inference/_providers/llmtech.py
@@ -1,0 +1,6 @@
+from ._common import BaseConversationalTask
+
+
+class LLMTechConversationalTask(BaseConversationalTask):
+    def __init__(self):
+        super().__init__(provider="llmtech", base_url="https://api.llmtech.eu")

--- a/tests/test_inference_providers.py
+++ b/tests/test_inference_providers.py
@@ -45,6 +45,7 @@ from huggingface_hub.inference._providers.hf_inference import (
     HFInferenceFeatureExtractionTask,
     HFInferenceTask,
 )
+from huggingface_hub.inference._providers.llmtech import LLMTechConversationalTask
 from huggingface_hub.inference._providers.novita import NovitaConversationalTask, NovitaTextGenerationTask
 from huggingface_hub.inference._providers.nscale import NscaleConversationalTask, NscaleTextToImageTask
 from huggingface_hub.inference._providers.openai import OpenAIConversationalTask
@@ -910,6 +911,18 @@ class TestGroqProvider:
         """Test route preparation for Groq conversational task."""
         helper = GroqConversationalTask()
         assert helper._prepare_route("username/repo_name", "hf_token") == "/openai/v1/chat/completions"
+
+
+class TestLLMTechProvider:
+    def test_prepare_route(self):
+        """Test route preparation for LLM Tech conversational task."""
+        helper = LLMTechConversationalTask()
+        assert helper._prepare_route("username/repo_name", "hf_token") == "/v1/chat/completions"
+
+    def test_prepare_base_url_direct_call(self):
+        """Direct calls with a provider key go to LLM Tech, routed calls go through HF."""
+        helper = LLMTechConversationalTask()
+        assert helper._prepare_base_url("llmtech_key") == "https://api.llmtech.eu"
 
 
 class TestHFInferenceProvider:


### PR DESCRIPTION
Registers **LLM Tech** as an inference provider, per the [register-as-a-provider guide](https://huggingface.co/docs/inference-providers/register-as-a-provider).

Companion PR (JS client): https://github.com/huggingface/huggingface.js/pull/2403

- Hub org: https://huggingface.co/llmtech
- API: strictly OpenAI-compatible chat completions at `https://api.llmtech.eu/v1` — `conversational` only, so the helper extends `BaseConversationalTask` with no overrides
- Live in production: we serve `Qwen/Qwen3.8-27B` on NanoGPT and are handling real user traffic today (121 requests, 593k tokens, zero failures on our side so far)
- `GET https://api.llmtech.eu/v1/models` exposes pricing and `context_length` in the documented format
- Billing endpoint (nano-USD, idempotent, batched) and `Inference-Id` header on every response, including streaming — implemented and tested
- Streaming, tool calling and structured outputs verified live

Changes follow the new-provider guide: provider helper, registration in `PROVIDER_T`/`PROVIDERS`, docstring updates in `InferenceClient` and the async client, and static tests (`tests/test_inference_providers.py` — full file passes, 178 passed).

About us: EU provider registered in Poland, hardware in Helsinki, Finland. Single-tenant GPUs, NVFP4 on NVIDIA Blackwell, full 262,144-token context. Zero data retention, EU-only processing.

First model to map once enabled: `Qwen/Qwen3.8-27B`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive provider registration with no auth, billing, or routing logic changes beyond wiring a new OpenAI-compatible helper.
> 
> **Overview**
> Adds **LLM Tech** (`llmtech`) as an inference provider for conversational (chat completion) requests.
> 
> The helper extends `BaseConversationalTask` with base URL `https://api.llmtech.eu` and the default `/v1/chat/completions` route. It is registered in `PROVIDER_T`/`PROVIDERS`, listed in the sync and async `InferenceClient` docs, and covered by route/base-URL unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40e2fad27bb880431b8b048b694b1aa7c9f7473a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->