### PR TITLE
reject safetensors indexes that point at missing tensors

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -164,6 +164,7 @@ from .utils._auth import _get_token_from_environment, _get_token_from_file, _get
 from .utils._deprecation import _deprecate_arguments, _deprecate_method
 from .utils._http import _httpx_follow_relative_redirects_with_backoff
 from .utils._runtime import is_xet_available
+from .utils._safetensors import _assert_weight_map_matches_shard_headers
 from .utils._typing import CallableT
 from .utils._verification import collect_local_files, resolve_local_root, verify_maps
 from .utils.endpoint_helpers import _is_emission_within_threshold
@@ -6971,6 +6972,8 @@ class HfApi:
                 desc="Parse safetensors files",
                 tqdm_class=hf_tqdm,
             )
+
+            _assert_weight_map_matches_shard_headers(weight_map, files_metadata)
 
             return SafetensorsRepoMetadata(
                 metadata=index.get("metadata", None),
@@ -15111,6 +15114,8 @@ def get_local_safetensors_metadata(path: str | Path) -> SafetensorsRepoMetadata:
         for shard_filename in set(weight_map.values()):
             shard_path = path / shard_filename
             files_metadata[shard_filename] = parse_local_safetensors_file_metadata(shard_path)
+
+        _assert_weight_map_matches_shard_headers(weight_map, files_metadata)
 
         return SafetensorsRepoMetadata(
             metadata=index.get("metadata", None),

--- a/src/huggingface_hub/utils/_safetensors.py
+++ b/src/huggingface_hub/utils/_safetensors.py
@@ -4,6 +4,8 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import Literal
 
+from huggingface_hub.errors import SafetensorsParsingError
+
 
 FILENAME_T = str
 TENSOR_NAME_T = str
@@ -109,3 +111,24 @@ class SafetensorsRepoMetadata:
             for dtype, nb_parameters_ in file_metadata.parameter_count.items():
                 parameter_count[dtype] += nb_parameters_
         self.parameter_count = dict(parameter_count)
+
+
+def _assert_weight_map_matches_shard_headers(
+    weight_map: dict[TENSOR_NAME_T, FILENAME_T],
+    files_metadata: dict[FILENAME_T, SafetensorsFileMetadata],
+) -> None:
+    """Raise if the index maps a tensor to a shard that does not list it."""
+    missing = [
+        (tensor_name, shard)
+        for tensor_name, shard in weight_map.items()
+        if files_metadata.get(shard) is None or tensor_name not in files_metadata[shard].tensors
+    ]
+    if not missing:
+        return
+    shown = missing[:5]
+    extra = f" (and {len(missing) - 5} more)" if len(missing) > 5 else ""
+    details = "; ".join(f"{name!r} listed in {shard!r}" for name, shard in shown)
+    raise SafetensorsParsingError(
+        "Safetensors index weight_map points at tensors that are not in the mapped shard headers: "
+        f"{details}{extra}."
+    )

--- a/tests/test_safetensors_weight_map.py
+++ b/tests/test_safetensors_weight_map.py
@@ -1,0 +1,35 @@
+from huggingface_hub.errors import SafetensorsParsingError
+from huggingface_hub.utils._safetensors import (
+    SafetensorsFileMetadata,
+    TensorInfo,
+    _assert_weight_map_matches_shard_headers,
+)
+
+
+def _file_meta(*names: str) -> SafetensorsFileMetadata:
+    tensors = {
+        name: TensorInfo(dtype="F32", shape=[2, 2], data_offsets=(0, 16)) for name in names
+    }
+    return SafetensorsFileMetadata(metadata={"format": "pt"}, tensors=tensors)
+
+
+def test_weight_map_matching_headers_is_ok() -> None:
+    shard = "model-00001-of-00002.safetensors"
+    _assert_weight_map_matches_shard_headers(
+        {"w.weight": shard, "w.bias": shard},
+        {shard: _file_meta("w.weight", "w.bias")},
+    )
+
+
+def test_weight_map_missing_tensor_raises() -> None:
+    shard = "model-00001-of-00002.safetensors"
+    try:
+        _assert_weight_map_matches_shard_headers(
+            {"w.weight": shard, "mtp.fc.weight": shard},
+            {shard: _file_meta("w.weight")},
+        )
+    except SafetensorsParsingError as exc:
+        assert "mtp.fc.weight" in str(exc)
+        assert shard in str(exc)
+    else:
+        raise AssertionError("expected SafetensorsParsingError")


### PR DESCRIPTION
Fixes #4725

`get_safetensors_metadata` (and the local equivalent) returns the index `weight_map` plus parsed shard headers, but never checks they agree. A repo can have an index entry whose tensor isn't in the mapped file, and the call still succeeds.

I hit this on `nightmedia/Qwen3.8-27B-Brainwaves` at `4cf25125` — `mtp.fc.weight` is in the index, missing from `model-00012-of-00012.safetensors`.

After parsing shards, require every `(tensor, shard)` in `weight_map` to exist in that shard's header. Raise `SafetensorsParsingError` if not.
