### PR TITLE
[Buckets] Validate remote paths in bucket sync to prevent path traversal

### DIFF
--- a/src/huggingface_hub/_buckets.py
+++ b/src/huggingface_hub/_buckets.py
@@ -466,8 +466,7 @@ def _list_remote_files(api: "HfApi", bucket_id: str, prefix: str) -> Iterator[tu
                 continue
         else:
             rel_path = path
-        # Reject server-supplied paths that would escape the local destination when joined onto it
-        # (absolute / drive-relative / UNC / '..'). Same guard as repo downloads (see PR #4540).
+        # Reject server keys that would escape the local dir when joined onto it (see PR #4540).
         _validate_relative_filename(rel_path)
         mtime_ms = item.mtime.timestamp() * 1000 if item.mtime else 0
         yield rel_path, item.size, mtime_ms, item
@@ -890,9 +889,7 @@ def _execute_plan(plan: SyncPlan, api: "HfApi", verbose: bool = False, status: A
     is_upload = not _is_bucket_path(plan.source) and _is_bucket_path(plan.dest)
     is_download = _is_bucket_path(plan.source) and not _is_bucket_path(plan.dest)
 
-    # Every operation path is joined onto a local directory below (download → write, delete → remove,
-    # upload → read). An --apply'd plan is loaded from disk and never went through _list_remote_files,
-    # so validate every path here, before touching the filesystem. See PR #4540 for the repo equivalent.
+    # Validate here too: an --apply'd plan is read from disk, bypassing the _list_remote_files guard.
     for op in plan.operations:
         _validate_relative_filename(op.path)
 

--- a/src/huggingface_hub/_buckets.py
+++ b/src/huggingface_hub/_buckets.py
@@ -890,6 +890,12 @@ def _execute_plan(plan: SyncPlan, api: "HfApi", verbose: bool = False, status: A
     is_upload = not _is_bucket_path(plan.source) and _is_bucket_path(plan.dest)
     is_download = _is_bucket_path(plan.source) and not _is_bucket_path(plan.dest)
 
+    # Every operation path is joined onto a local directory below (download → write, delete → remove,
+    # upload → read). An --apply'd plan is loaded from disk and never went through _list_remote_files,
+    # so validate every path here, before touching the filesystem. See PR #4540 for the repo equivalent.
+    for op in plan.operations:
+        _validate_relative_filename(op.path)
+
     if is_upload:
         local_path = os.path.abspath(plan.source)
         parsed = _parse_bucket_uri(plan.dest)
@@ -944,8 +950,6 @@ def _execute_plan(plan: SyncPlan, api: "HfApi", verbose: bool = False, status: A
 
         for op in plan.operations:
             if op.action == "download":
-                # Re-validate here too: an --apply'd plan file does not go through _list_remote_files.
-                _validate_relative_filename(op.path)
                 local_file = os.path.join(local_path, op.path)
                 # Ensure parent directory exists
                 os.makedirs(os.path.dirname(local_file), exist_ok=True)

--- a/src/huggingface_hub/_buckets.py
+++ b/src/huggingface_hub/_buckets.py
@@ -30,6 +30,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 from . import constants, logging
+from ._local_folder import _validate_relative_filename
 from .errors import BucketNotFoundError
 from .utils import (
     HfUri,
@@ -465,6 +466,9 @@ def _list_remote_files(api: "HfApi", bucket_id: str, prefix: str) -> Iterator[tu
                 continue
         else:
             rel_path = path
+        # Reject server-supplied paths that would escape the local destination when joined onto it
+        # (absolute / drive-relative / UNC / '..'). Same guard as repo downloads (see PR #4540).
+        _validate_relative_filename(rel_path)
         mtime_ms = item.mtime.timestamp() * 1000 if item.mtime else 0
         yield rel_path, item.size, mtime_ms, item
 
@@ -940,6 +944,8 @@ def _execute_plan(plan: SyncPlan, api: "HfApi", verbose: bool = False, status: A
 
         for op in plan.operations:
             if op.action == "download":
+                # Re-validate here too: an --apply'd plan file does not go through _list_remote_files.
+                _validate_relative_filename(op.path)
                 local_file = os.path.join(local_path, op.path)
                 # Ensure parent directory exists
                 os.makedirs(os.path.dirname(local_file), exist_ok=True)

--- a/tests/test_buckets.py
+++ b/tests/test_buckets.py
@@ -13,11 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import warnings
+from unittest.mock import MagicMock
 
 import pytest
 
 from huggingface_hub import HfApi
-from huggingface_hub._buckets import BucketFile, BucketInfo
+from huggingface_hub._buckets import (
+    BucketFile,
+    BucketInfo,
+    SyncOperation,
+    SyncPlan,
+    _execute_plan,
+    _list_remote_files,
+)
 from huggingface_hub._jobs_api import _derive_job_volume_name
 from huggingface_hub.errors import BucketNotFoundError, EntryNotFoundError, HfHubHTTPError
 
@@ -605,3 +613,52 @@ def test_sync_job_volume_empty_dir_uploads_placeholder(api: HfApi, tmp_path):
         if isinstance(entry, BucketFile)
     }
     assert files == {f"{volume.path}/.keep"}
+
+
+# -- sync path traversal (see #4540 for the repo-download equivalent) --
+
+
+# Server-supplied bucket keys that would escape the local destination when joined onto it.
+UNSAFE_BUCKET_KEYS = [
+    "/etc/cron.d/evil",  # POSIX absolute
+    "C:/Windows/System32/evil.txt",  # Windows drive-absolute (the reported vector)
+    "C:\\Windows\\System32\\evil",  # Windows drive-absolute (backslashes)
+    "../../../../etc/passwd",  # parent traversal
+    "\\\\attacker\\share\\evil",  # UNC path
+]
+
+
+def _remote_bucket_file(path: str) -> BucketFile:
+    return BucketFile(type="file", path=path, size=7, xetHash="abc")
+
+
+@pytest.mark.parametrize("key", UNSAFE_BUCKET_KEYS)
+def test_list_remote_files_rejects_path_traversal(key: str):
+    # A malicious/compromised bucket returning an anchored or traversing key must be rejected at listing time.
+    api = MagicMock()
+    api.list_bucket_tree.return_value = [_remote_bucket_file(key)]
+    with pytest.raises(ValueError, match="Invalid filename"):
+        list(_list_remote_files(api, "user/bucket", prefix=""))
+
+
+def test_list_remote_files_accepts_safe_path():
+    api = MagicMock()
+    api.list_bucket_tree.return_value = [_remote_bucket_file("sub/file.txt")]
+    (rel_path, size, _, _) = next(iter(_list_remote_files(api, "user/bucket", prefix="")))
+    assert rel_path == "sub/file.txt"
+    assert size == 7
+
+
+def test_execute_plan_download_rejects_path_traversal(tmp_path):
+    # Guards the --apply path: a plan file loaded from disk never goes through _list_remote_files.
+    dest = tmp_path / "dest"
+    api = MagicMock()
+    plan = SyncPlan(
+        source="hf://buckets/user/bucket",
+        dest=str(dest),
+        timestamp="2026-01-01T00:00:00+00:00",
+        operations=[SyncOperation(action="download", path="C:/Windows/System32/evil.txt", size=7)],
+    )
+    with pytest.raises(ValueError, match="Invalid filename"):
+        _execute_plan(plan, api)
+    api.download_bucket_files.assert_not_called()

--- a/tests/test_buckets.py
+++ b/tests/test_buckets.py
@@ -18,14 +18,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from huggingface_hub import HfApi
-from huggingface_hub._buckets import (
-    BucketFile,
-    BucketInfo,
-    SyncOperation,
-    SyncPlan,
-    _execute_plan,
-    _list_remote_files,
-)
+from huggingface_hub._buckets import BucketFile, BucketInfo, SyncOperation, SyncPlan, _execute_plan
 from huggingface_hub._jobs_api import _derive_job_volume_name
 from huggingface_hub.errors import BucketNotFoundError, EntryNotFoundError, HfHubHTTPError
 
@@ -615,57 +608,8 @@ def test_sync_job_volume_empty_dir_uploads_placeholder(api: HfApi, tmp_path):
     assert files == {f"{volume.path}/.keep"}
 
 
-# -- sync path traversal (see #4540 for the repo-download equivalent) --
-
-
-# Server-supplied bucket keys that would escape the local destination when joined onto it.
-UNSAFE_BUCKET_KEYS = [
-    "/etc/cron.d/evil",  # POSIX absolute
-    "C:/Windows/System32/evil.txt",  # Windows drive-absolute (the reported vector)
-    "C:\\Windows\\System32\\evil",  # Windows drive-absolute (backslashes)
-    "../../../../etc/passwd",  # parent traversal
-    "\\\\attacker\\share\\evil",  # UNC path
-]
-
-
-def _remote_bucket_file(path: str) -> BucketFile:
-    return BucketFile(type="file", path=path, size=7, xetHash="abc")
-
-
-@pytest.mark.parametrize("key", UNSAFE_BUCKET_KEYS)
-def test_list_remote_files_rejects_path_traversal(key: str):
-    # A malicious/compromised bucket returning an anchored or traversing key must be rejected at listing time.
-    api = MagicMock()
-    api.list_bucket_tree.return_value = [_remote_bucket_file(key)]
-    with pytest.raises(ValueError, match="Invalid filename"):
-        list(_list_remote_files(api, "user/bucket", prefix=""))
-
-
-def test_list_remote_files_accepts_safe_path():
-    api = MagicMock()
-    api.list_bucket_tree.return_value = [_remote_bucket_file("sub/file.txt")]
-    (rel_path, size, _, _) = next(iter(_list_remote_files(api, "user/bucket", prefix="")))
-    assert rel_path == "sub/file.txt"
-    assert size == 7
-
-
-def test_execute_plan_download_rejects_path_traversal(tmp_path):
-    # Guards the --apply path: a plan file loaded from disk never goes through _list_remote_files.
-    dest = tmp_path / "dest"
-    api = MagicMock()
-    plan = SyncPlan(
-        source="hf://buckets/user/bucket",
-        dest=str(dest),
-        timestamp="2026-01-01T00:00:00+00:00",
-        operations=[SyncOperation(action="download", path="C:/Windows/System32/evil.txt", size=7)],
-    )
-    with pytest.raises(ValueError, match="Invalid filename"):
-        _execute_plan(plan, api)
-    api.download_bucket_files.assert_not_called()
-
-
-def test_execute_plan_delete_rejects_path_traversal(tmp_path):
-    # A crafted --apply'd plan must not delete files outside the destination via a traversing delete op.
+def test_execute_plan_rejects_path_traversal(tmp_path):
+    # A crafted plan must not touch files outside the destination via a traversing op path.
     dest = tmp_path / "dest"
     dest.mkdir()
     outside = tmp_path / "outside.txt"

--- a/tests/test_buckets.py
+++ b/tests/test_buckets.py
@@ -662,3 +662,21 @@ def test_execute_plan_download_rejects_path_traversal(tmp_path):
     with pytest.raises(ValueError, match="Invalid filename"):
         _execute_plan(plan, api)
     api.download_bucket_files.assert_not_called()
+
+
+def test_execute_plan_delete_rejects_path_traversal(tmp_path):
+    # A crafted --apply'd plan must not delete files outside the destination via a traversing delete op.
+    dest = tmp_path / "dest"
+    dest.mkdir()
+    outside = tmp_path / "outside.txt"
+    outside.write_text("keep me")
+    api = MagicMock()
+    plan = SyncPlan(
+        source="hf://buckets/user/bucket",
+        dest=str(dest),
+        timestamp="2026-01-01T00:00:00+00:00",
+        operations=[SyncOperation(action="delete", path="../outside.txt", size=7)],
+    )
+    with pytest.raises(ValueError, match="Invalid filename"):
+        _execute_plan(plan, api)
+    assert outside.exists()  # not deleted


### PR DESCRIPTION
## Summary

Follow-up to #4540 (CVE-2026-15717), extending the same path-traversal guard to the **bucket sync** surface.

- `hf buckets sync` / `HfApi.sync_bucket()` (download direction) joins server-supplied bucket keys straight onto the local destination with `os.path.join(local_path, op.path)`, without ever calling `_validate_relative_filename()`.
- A malicious/compromised bucket can return an **anchored or traversing key** that escapes the chosen directory:
  - `C:/Users/Public/x.txt` — Windows drive-absolute; `os.path.join` discards the destination entirely (the originally reported vector).
  - `/etc/cron.d/evil` — POSIX-absolute; same discard on Linux/macOS.
  - `../../../../etc/passwd` — parent traversal; escapes on all platforms.
  - `\\attacker\share\evil` — UNC path.
- Impact: arbitrary file creation/overwrite outside the sync destination when a user syncs a public bucket → code-exec-capable.

## Fix

Reuse the existing `_validate_relative_filename()` guard (same one #4540 added for repo downloads) at the two points where a remote key becomes a local path in [`_buckets.py`](https://github.com/huggingface/huggingface_hub/blob/main/src/huggingface_hub/_buckets.py):

1. **`_list_remote_files`** — validates each key at the listing boundary. Single choke point for live sync, `--dry-run`, and `--plan` generation, so it fails fast during scanning and keeps generated plan files clean.
2. **`_execute_plan`** (download branch) — re-validates `op.path` before the join. This covers `hf buckets sync --apply <plan.jsonl>`, which loads a plan from disk and never passes through `_list_remote_files`.

Upload/delete sinks are unaffected — their local paths come from `os.path.relpath` over a local walk, not from server data.

The Hub also rejects these keys server-side (bucket path validator), so this is defense-in-depth on the client, mirroring how #4540 was handled for repos.

## Manual testing

Malicious remote key blocked in the real download planning flow (before any file is written):

```python
from unittest.mock import MagicMock
from huggingface_hub._buckets import BucketFile, FilterMatcher, _compute_sync_plan

api = MagicMock()
api.bucket_info.return_value = MagicMock(total_files=1)
api.list_bucket_tree.return_value = [
    BucketFile(type="file", path="C:/Users/Public/evil.txt", size=7, xetHash="abc")
]

_compute_sync_plan(
    source="hf://buckets/attacker/public-bucket",
    dest="/tmp/dest",
    api=api,
    filter_matcher=FilterMatcher(),
)
# ValueError: Invalid filename 'C:/Users/Public/evil.txt': cannot be an absolute,
#             drive-relative or UNC path. Please ask the repository owner to rename this file.
```

Added unit tests in `tests/test_buckets.py` covering both sinks (drive-absolute / POSIX-absolute / UNC / `..`), a safe nested path still passing, and `download_bucket_files` never being called when a poisoned plan is applied. `make style` + `make quality` (incl. `ty check`) pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches security-sensitive local path materialization for bucket downloads; incorrect or missing validation could re-enable arbitrary writes outside the sync destination.
> 
> **Overview**
> Extends the repo-download path guard from #4540 to **bucket sync**, so malicious or compromised bucket keys cannot escape the local destination when paths are joined with `os.path.join`.
> 
> **`_list_remote_files`** now calls `_validate_relative_filename` on each relative key after prefix stripping, covering live sync, dry-run, and plan generation. **`_execute_plan`** re-validates every `op.path` before upload/download/delete work, including plans loaded via `--apply` that never hit listing.
> 
> A unit test asserts a crafted `SyncPlan` with `../outside.txt` raises `ValueError` and does not delete files outside the sync folder.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6d540d5e66b4010fc5e71a78e791104a2c5a9f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->