### PR TITLE
[Xet] Cache connection info to avoid one token request per file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def get_version() -> str:
 HF_XET_VERSION = "hf-xet>=1.5.2,<2.0.0"
 
 install_requires = [
-    "click>=8.4.2,<8.5.0",  # 8.4.0/8.4.1 shipped a broken fish completion script; 8.5.0 broke argument help rendering
+    "click>=8.4.2,<9.0.0",  # 8.4.0/8.4.1 shipped a broken fish completion script
     "filelock>=3.10.0",
     "fsspec>=2023.5.0",
     f"{HF_XET_VERSION}; platform_machine=='x86_64' or platform_machine=='amd64' or platform_machine=='AMD64' or platform_machine=='arm64' or platform_machine=='aarch64'",

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def get_version() -> str:
 HF_XET_VERSION = "hf-xet>=1.5.2,<2.0.0"
 
 install_requires = [
-    "click>=8.4.2,<9.0.0",  # 8.4.0/8.4.1 shipped a broken fish completion script
+    "click>=8.4.2,<8.5.0",  # 8.4.0/8.4.1 shipped a broken fish completion script; 8.5.0 broke argument help rendering
     "filelock>=3.10.0",
     "fsspec>=2023.5.0",
     f"{HF_XET_VERSION}; platform_machine=='x86_64' or platform_machine=='amd64' or platform_machine=='AMD64' or platform_machine=='arm64' or platform_machine=='aarch64'",

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -513,8 +513,9 @@ def xet_get(
         - Using authentication to ensure secure access
         - Providing progress updates during download
 
-        Authentication works transparently: the download group accepts a ``token_refresh_url``
-        that is used to refresh the short-lived xet access token as needed.
+        Authentication works transparently: the download group is seeded with a short-lived xet
+        access token (fetched once per repo revision and cached across files) and accepts a
+        ``token_refresh_url`` that is used to refresh it as needed.
 
         The download process works like this:
         1. Download tasks run in parallel:
@@ -545,10 +546,14 @@ def xet_get(
     if len(displayed_filename) > 40:
         displayed_filename = f"{displayed_filename[:40]}(…)"
 
-    from .utils._xet import abort_xet_session, get_xet_session, xet_headers_without_auth
+    from .utils._xet import abort_xet_session, fetch_xet_connection_info, get_xet_session, xet_headers_without_auth
     from .utils._xet_progress_reporting import XetDownloadProgressReporter
 
     xet_headers = xet_headers_without_auth(headers)
+
+    # Fetched once per repo revision and cached; otherwise each download group would request its own
+    # token, i.e. one Hub API call per file (rate-limited on large snapshot downloads, see #4722).
+    connection_info = fetch_xet_connection_info(xet_file_data.refresh_route, headers)
 
     session = get_xet_session()
 
@@ -563,6 +568,9 @@ def xet_get(
     ) as progress:
         try:
             with session.new_file_download_group(
+                endpoint=connection_info.endpoint,
+                token=connection_info.access_token,
+                token_expiry_unix_secs=connection_info.expiration_unix_epoch,
                 token_refresh_url=xet_file_data.refresh_route,
                 token_refresh_headers=headers,
                 custom_headers=xet_headers,

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -546,14 +546,14 @@ def xet_get(
     if len(displayed_filename) > 40:
         displayed_filename = f"{displayed_filename[:40]}(…)"
 
-    from .utils._xet import abort_xet_session, fetch_xet_connection_info, get_xet_session, xet_headers_without_auth
+    from .utils._xet import abort_xet_session, get_xet_session, refresh_xet_connection_info, xet_headers_without_auth
     from .utils._xet_progress_reporting import XetDownloadProgressReporter
 
     xet_headers = xet_headers_without_auth(headers)
 
     # Fetched once per repo revision and cached; otherwise each download group would request its own
     # token, i.e. one Hub API call per file (rate-limited on large snapshot downloads, see #4722).
-    connection_info = fetch_xet_connection_info(xet_file_data.refresh_route, headers)
+    connection_info = refresh_xet_connection_info(file_data=xet_file_data, headers=headers)
 
     session = get_xet_session()
 

--- a/src/huggingface_hub/utils/_xet.py
+++ b/src/huggingface_hub/utils/_xet.py
@@ -17,8 +17,8 @@ _REGEX_XET_HASH = re.compile(r"^[0-9a-fA-F]{64}$")
 XET_CONNECTION_INFO_SAFETY_PERIOD = 60  # seconds
 XET_CONNECTION_INFO_CACHE_SIZE = 1_000
 XET_CONNECTION_INFO_CACHE: dict[str, "XetConnectionInfo"] = {}
-_XET_CONNECTION_INFO_LOCKS: dict[str, threading.Lock] = {}
-_XET_CONNECTION_INFO_LOCKS_GUARD = threading.Lock()
+_XET_CONNECTION_INFO_LOCK = threading.Lock()  # guards the cache dict and the per-key lock registry
+_XET_CONNECTION_INFO_KEY_LOCKS: dict[str, threading.Lock] = {}
 
 
 def is_valid_xet_hash(xet_hash: str) -> bool:
@@ -166,14 +166,7 @@ def _fetch_xet_connection_info_with_url(
 
     # A per-key lock collapses concurrent workers into a single token request per expired/missing
     # key, without blocking fetches for other keys (e.g. other repos downloaded in parallel).
-    with _XET_CONNECTION_INFO_LOCKS_GUARD:
-        key_lock = _XET_CONNECTION_INFO_LOCKS.get(cache_key)
-        if key_lock is None:
-            if len(_XET_CONNECTION_INFO_LOCKS) >= XET_CONNECTION_INFO_CACHE_SIZE:
-                _XET_CONNECTION_INFO_LOCKS.pop(next(iter(_XET_CONNECTION_INFO_LOCKS)))
-            key_lock = _XET_CONNECTION_INFO_LOCKS[cache_key] = threading.Lock()
-
-    with key_lock:
+    with _key_lock(cache_key):
         cached_info = XET_CONNECTION_INFO_CACHE.get(cache_key)
         if cached_info is not None and not _is_expired(cached_info):
             return cached_info
@@ -186,17 +179,18 @@ def _fetch_xet_connection_info_with_url(
         if metadata is None:
             raise ValueError("Xet headers have not been correctly set by the server.")
 
-        # Delete expired cache entries
-        for k, v in list(XET_CONNECTION_INFO_CACHE.items()):
-            if _is_expired(v):
-                XET_CONNECTION_INFO_CACHE.pop(k, None)
+        with _XET_CONNECTION_INFO_LOCK:
+            # Delete expired cache entries
+            for k, v in list(XET_CONNECTION_INFO_CACHE.items()):
+                if _is_expired(v):
+                    XET_CONNECTION_INFO_CACHE.pop(k, None)
 
-        # Enforce cache size limit
-        if len(XET_CONNECTION_INFO_CACHE) >= XET_CONNECTION_INFO_CACHE_SIZE:
-            XET_CONNECTION_INFO_CACHE.pop(next(iter(XET_CONNECTION_INFO_CACHE)))
+            # Enforce cache size limit
+            if len(XET_CONNECTION_INFO_CACHE) >= XET_CONNECTION_INFO_CACHE_SIZE:
+                XET_CONNECTION_INFO_CACHE.pop(next(iter(XET_CONNECTION_INFO_CACHE)))
 
-        # Update cache
-        XET_CONNECTION_INFO_CACHE[cache_key] = metadata
+            # Update cache
+            XET_CONNECTION_INFO_CACHE[cache_key] = metadata
 
         return metadata
 
@@ -206,6 +200,12 @@ def _cache_key(url: str, headers: dict[str, str]) -> str:
     lower_headers = {k.lower(): v for k, v in headers.items()}  # casing is not guaranteed here
     auth_header = lower_headers.get("authorization", "")
     return f"{url}|{auth_header}"
+
+
+def _key_lock(cache_key: str) -> threading.Lock:
+    """Return the lock guarding token fetches for `cache_key`, creating it if needed."""
+    with _XET_CONNECTION_INFO_LOCK:
+        return _XET_CONNECTION_INFO_KEY_LOCKS.setdefault(cache_key, threading.Lock())
 
 
 def _is_expired(connection_info: XetConnectionInfo) -> bool:

--- a/src/huggingface_hub/utils/_xet.py
+++ b/src/huggingface_hub/utils/_xet.py
@@ -17,7 +17,8 @@ _REGEX_XET_HASH = re.compile(r"^[0-9a-fA-F]{64}$")
 XET_CONNECTION_INFO_SAFETY_PERIOD = 60  # seconds
 XET_CONNECTION_INFO_CACHE_SIZE = 1_000
 XET_CONNECTION_INFO_CACHE: dict[str, "XetConnectionInfo"] = {}
-_XET_CONNECTION_INFO_LOCK = threading.Lock()
+_XET_CONNECTION_INFO_LOCKS: dict[str, threading.Lock] = {}
+_XET_CONNECTION_INFO_LOCKS_GUARD = threading.Lock()
 
 
 def is_valid_xet_hash(xet_hash: str) -> bool:
@@ -163,8 +164,16 @@ def _fetch_xet_connection_info_with_url(
         if not _is_expired(cached_info):
             return cached_info
 
-    # The lock collapses concurrent workers into a single token request per expired/missing key.
-    with _XET_CONNECTION_INFO_LOCK:
+    # A per-key lock collapses concurrent workers into a single token request per expired/missing
+    # key, without blocking fetches for other keys (e.g. other repos downloaded in parallel).
+    with _XET_CONNECTION_INFO_LOCKS_GUARD:
+        key_lock = _XET_CONNECTION_INFO_LOCKS.get(cache_key)
+        if key_lock is None:
+            if len(_XET_CONNECTION_INFO_LOCKS) >= XET_CONNECTION_INFO_CACHE_SIZE:
+                _XET_CONNECTION_INFO_LOCKS.pop(next(iter(_XET_CONNECTION_INFO_LOCKS)))
+            key_lock = _XET_CONNECTION_INFO_LOCKS[cache_key] = threading.Lock()
+
+    with key_lock:
         cached_info = XET_CONNECTION_INFO_CACHE.get(cache_key)
         if cached_info is not None and not _is_expired(cached_info):
             return cached_info

--- a/src/huggingface_hub/utils/_xet.py
+++ b/src/huggingface_hub/utils/_xet.py
@@ -103,16 +103,18 @@ def parse_xet_connection_info_from_headers(headers: Mapping[str, str]) -> XetCon
     )
 
 
-def fetch_xet_connection_info(refresh_route: str, headers: dict[str, str]) -> XetConnectionInfo:
+@validate_hf_hub_args
+def refresh_xet_connection_info(
+    *,
+    file_data: XetFileData,
+    headers: dict[str, str],
+) -> XetConnectionInfo:
     """
-    Fetch the xet connection info (CAS endpoint, access token and expiration) from the Hub.
-
-    Results are cached until expiration so that concurrent and successive downloads share a single
-    token request per repo revision, instead of hitting the Hub API once per file.
-
+    Utilizes the information in the parsed metadata to request the Hub xet connection information.
+    This includes the access token, expiration, and XET service URL.
     Args:
-        refresh_route (`str`):
-            The fully-qualified URL of the token endpoint.
+        file_data: (`XetFileData`):
+            The file data needed to refresh the xet connection information.
         headers (`dict[str, str]`):
             Headers to use for the request, including authorization headers and user agent.
     Returns:
@@ -124,10 +126,42 @@ def fetch_xet_connection_info(refresh_route: str, headers: dict[str, str]) -> Xe
         [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
             If the Hub API response is improperly formatted.
     """
-    cache_key = _connection_info_cache_key(refresh_route, headers)
+    if file_data.refresh_route is None:
+        raise ValueError("The provided xet metadata does not contain a refresh endpoint.")
+    return _fetch_xet_connection_info_with_url(file_data.refresh_route, headers)
+
+
+@validate_hf_hub_args
+def _fetch_xet_connection_info_with_url(
+    url: str,
+    headers: dict[str, str],
+) -> XetConnectionInfo:
+    """
+    Requests the xet connection info from the supplied URL. This includes the
+    access token, expiration time, and endpoint to use for the xet storage service.
+
+    Result is cached to avoid redundant requests.
+
+    Args:
+        url: (`str`):
+            The access token endpoint URL.
+        headers (`dict[str, str]`):
+            Headers to use for the request, including authorization headers and user agent.
+    Returns:
+        `XetConnectionInfo`:
+            The connection information needed to make the request to the xet storage service.
+    Raises:
+        [`~utils.HfHubHTTPError`]
+            If the Hub API returned an error.
+        [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
+            If the Hub API response is improperly formatted.
+    """
+    # Check cache first
+    cache_key = _cache_key(url, headers)
     cached_info = XET_CONNECTION_INFO_CACHE.get(cache_key)
-    if cached_info is not None and not _is_expired(cached_info):
-        return cached_info
+    if cached_info is not None:
+        if not _is_expired(cached_info):
+            return cached_info
 
     # The lock collapses concurrent workers into a single token request per expired/missing key.
     with _XET_CONNECTION_INFO_LOCK:
@@ -135,30 +169,38 @@ def fetch_xet_connection_info(refresh_route: str, headers: dict[str, str]) -> Xe
         if cached_info is not None and not _is_expired(cached_info):
             return cached_info
 
-        resp = http_backoff("GET", refresh_route, headers=headers)
+        # Fetch from server
+        resp = http_backoff("GET", url, headers=headers)
         hf_raise_for_status(resp)
 
-        connection_info = parse_xet_connection_info_from_headers(resp.headers)
-        if connection_info is None:
+        metadata = parse_xet_connection_info_from_headers(resp.headers)
+        if metadata is None:
             raise ValueError("Xet headers have not been correctly set by the server.")
 
-        # Evict expired entries and enforce the cache size limit
-        for key, value in list(XET_CONNECTION_INFO_CACHE.items()):
-            if _is_expired(value):
-                XET_CONNECTION_INFO_CACHE.pop(key, None)
+        # Delete expired cache entries
+        for k, v in list(XET_CONNECTION_INFO_CACHE.items()):
+            if _is_expired(v):
+                XET_CONNECTION_INFO_CACHE.pop(k, None)
+
+        # Enforce cache size limit
         if len(XET_CONNECTION_INFO_CACHE) >= XET_CONNECTION_INFO_CACHE_SIZE:
             XET_CONNECTION_INFO_CACHE.pop(next(iter(XET_CONNECTION_INFO_CACHE)))
 
-        XET_CONNECTION_INFO_CACHE[cache_key] = connection_info
-        return connection_info
+        # Update cache
+        XET_CONNECTION_INFO_CACHE[cache_key] = metadata
+
+        return metadata
 
 
-def _connection_info_cache_key(url: str, headers: dict[str, str]) -> str:
-    lower_headers = {key.lower(): value for key, value in headers.items()}  # casing is not guaranteed here
-    return f"{url}|{lower_headers.get('authorization', '')}"
+def _cache_key(url: str, headers: dict[str, str]) -> str:
+    """Return a unique cache key for the given request parameters."""
+    lower_headers = {k.lower(): v for k, v in headers.items()}  # casing is not guaranteed here
+    auth_header = lower_headers.get("authorization", "")
+    return f"{url}|{auth_header}"
 
 
 def _is_expired(connection_info: XetConnectionInfo) -> bool:
+    """Check if the given XET connection info is expired."""
     return connection_info.expiration_unix_epoch <= int(time.time()) + XET_CONNECTION_INFO_SAFETY_PERIOD
 
 

--- a/src/huggingface_hub/utils/_xet.py
+++ b/src/huggingface_hub/utils/_xet.py
@@ -1,16 +1,23 @@
 import os
 import re
 import threading
+import time
+from collections.abc import Mapping
 from dataclasses import dataclass
 from enum import Enum
 
 import httpx
 
 from .. import constants
-from . import validate_hf_hub_args
+from . import hf_raise_for_status, http_backoff, validate_hf_hub_args
 
 
 _REGEX_XET_HASH = re.compile(r"^[0-9a-fA-F]{64}$")
+
+XET_CONNECTION_INFO_SAFETY_PERIOD = 60  # seconds
+XET_CONNECTION_INFO_CACHE_SIZE = 1_000
+XET_CONNECTION_INFO_CACHE: dict[str, "XetConnectionInfo"] = {}
+_XET_CONNECTION_INFO_LOCK = threading.Lock()
 
 
 def is_valid_xet_hash(xet_hash: str) -> bool:
@@ -27,6 +34,13 @@ class XetTokenType(str, Enum):
 class XetFileData:
     file_hash: str
     refresh_route: str
+
+
+@dataclass(frozen=True)
+class XetConnectionInfo:
+    access_token: str
+    expiration_unix_epoch: int
+    endpoint: str
 
 
 def parse_xet_file_data_from_response(response: httpx.Response, endpoint: str | None = None) -> XetFileData | None:
@@ -62,6 +76,90 @@ def parse_xet_file_data_from_response(response: httpx.Response, endpoint: str | 
         file_hash=file_hash,
         refresh_route=refresh_route,
     )
+
+
+def parse_xet_connection_info_from_headers(headers: Mapping[str, str]) -> XetConnectionInfo | None:
+    """
+    Parse XET connection info from the HTTP headers or return None if not found.
+    Args:
+        headers (`dict`):
+           HTTP headers to extract the XET metadata from.
+    Returns:
+        `XetConnectionInfo` or `None`:
+            The information needed to connect to the XET storage service.
+            Returns `None` if the headers do not contain the XET connection info.
+    """
+    try:
+        endpoint = headers[constants.HUGGINGFACE_HEADER_X_XET_ENDPOINT]
+        access_token = headers[constants.HUGGINGFACE_HEADER_X_XET_ACCESS_TOKEN]
+        expiration_unix_epoch = int(headers[constants.HUGGINGFACE_HEADER_X_XET_EXPIRATION])
+    except (KeyError, ValueError, TypeError):
+        return None
+
+    return XetConnectionInfo(
+        endpoint=endpoint,
+        access_token=access_token,
+        expiration_unix_epoch=expiration_unix_epoch,
+    )
+
+
+def fetch_xet_connection_info(refresh_route: str, headers: dict[str, str]) -> XetConnectionInfo:
+    """
+    Fetch the xet connection info (CAS endpoint, access token and expiration) from the Hub.
+
+    Results are cached until expiration so that concurrent and successive downloads share a single
+    token request per repo revision, instead of hitting the Hub API once per file.
+
+    Args:
+        refresh_route (`str`):
+            The fully-qualified URL of the token endpoint.
+        headers (`dict[str, str]`):
+            Headers to use for the request, including authorization headers and user agent.
+    Returns:
+        `XetConnectionInfo`:
+            The connection information needed to make the request to the xet storage service.
+    Raises:
+        [`~utils.HfHubHTTPError`]
+            If the Hub API returned an error.
+        [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
+            If the Hub API response is improperly formatted.
+    """
+    cache_key = _connection_info_cache_key(refresh_route, headers)
+    cached_info = XET_CONNECTION_INFO_CACHE.get(cache_key)
+    if cached_info is not None and not _is_expired(cached_info):
+        return cached_info
+
+    # The lock collapses concurrent workers into a single token request per expired/missing key.
+    with _XET_CONNECTION_INFO_LOCK:
+        cached_info = XET_CONNECTION_INFO_CACHE.get(cache_key)
+        if cached_info is not None and not _is_expired(cached_info):
+            return cached_info
+
+        resp = http_backoff("GET", refresh_route, headers=headers)
+        hf_raise_for_status(resp)
+
+        connection_info = parse_xet_connection_info_from_headers(resp.headers)
+        if connection_info is None:
+            raise ValueError("Xet headers have not been correctly set by the server.")
+
+        # Evict expired entries and enforce the cache size limit
+        for key, value in list(XET_CONNECTION_INFO_CACHE.items()):
+            if _is_expired(value):
+                XET_CONNECTION_INFO_CACHE.pop(key, None)
+        if len(XET_CONNECTION_INFO_CACHE) >= XET_CONNECTION_INFO_CACHE_SIZE:
+            XET_CONNECTION_INFO_CACHE.pop(next(iter(XET_CONNECTION_INFO_CACHE)))
+
+        XET_CONNECTION_INFO_CACHE[cache_key] = connection_info
+        return connection_info
+
+
+def _connection_info_cache_key(url: str, headers: dict[str, str]) -> str:
+    lower_headers = {key.lower(): value for key, value in headers.items()}  # casing is not guaranteed here
+    return f"{url}|{lower_headers.get('authorization', '')}"
+
+
+def _is_expired(connection_info: XetConnectionInfo) -> bool:
+    return connection_info.expiration_unix_epoch <= int(time.time()) + XET_CONNECTION_INFO_SAFETY_PERIOD
 
 
 @validate_hf_hub_args

--- a/tests/test_xet_download.py
+++ b/tests/test_xet_download.py
@@ -15,6 +15,7 @@ from huggingface_hub.file_download import (
     xet_get,
 )
 from huggingface_hub.utils import XetFileData
+from huggingface_hub.utils._xet import XetConnectionInfo
 
 from .testing_constants import (
     DUMMY_XET_FILE,
@@ -238,16 +239,21 @@ class TestXetFileDownload:
         mock_session = MagicMock()
         mock_session.new_file_download_group.return_value = mock_group
 
+        mock_connection_info = XetConnectionInfo(
+            access_token="mock_token", expiration_unix_epoch=9999999999, endpoint="https://cas.example"
+        )
+
         with self._patch_xet_file_metadata(with_xet_data=True):
             with patch("huggingface_hub.utils._xet.get_xet_session", return_value=mock_session):
-                with patch("huggingface_hub.file_download._create_symlink"):
-                    hf_hub_download(
-                        DUMMY_XET_MODEL_ID,
-                        filename=DUMMY_XET_FILE,
-                        cache_dir=tmp_path,
-                        force_download=True,
-                        headers=headers,
-                    )
+                with patch("huggingface_hub.utils._xet.fetch_xet_connection_info", return_value=mock_connection_info):
+                    with patch("huggingface_hub.file_download._create_symlink"):
+                        hf_hub_download(
+                            DUMMY_XET_MODEL_ID,
+                            filename=DUMMY_XET_FILE,
+                            cache_dir=tmp_path,
+                            force_download=True,
+                            headers=headers,
+                        )
 
         mock_group.__enter__.return_value.start_download_file.assert_called_once()
         kwargs = mock_session.new_file_download_group.call_args.kwargs

--- a/tests/test_xet_download.py
+++ b/tests/test_xet_download.py
@@ -245,7 +245,9 @@ class TestXetFileDownload:
 
         with self._patch_xet_file_metadata(with_xet_data=True):
             with patch("huggingface_hub.utils._xet.get_xet_session", return_value=mock_session):
-                with patch("huggingface_hub.utils._xet.fetch_xet_connection_info", return_value=mock_connection_info):
+                with patch(
+                    "huggingface_hub.utils._xet.refresh_xet_connection_info", return_value=mock_connection_info
+                ):
                     with patch("huggingface_hub.file_download._create_symlink"):
                         hf_hub_download(
                             DUMMY_XET_MODEL_ID,


### PR DESCRIPTION
## Summary

- Since the `XetSession` migration (#4116, shipped in v1.19.0), building a xet download group eagerly calls the `xet-read-token` endpoint to discover the CAS endpoint. One group = one file, so `snapshot_download` on a many-files repo makes one Hub API call per file (e.g. 77k files at ~25 files/s ≈ 1,500 calls/min) and eventually gets rate-limited: `hf_xet` retries with backoff for ~6 minutes (looks like a stalled download), then raises `ConnectionError: ... 429 Too Many Requests`.
- This PR restores the Python-side connection info cache (added in #3534 for exactly this problem, removed as dead code in #4482 once #4116 stopped calling it) and seeds `endpoint` / `token` / `token_expiry_unix_secs` on each download group, so `hf_xet` skips the eager per-group token request. The refresh URL is still passed for mid-download token expiry.
- No `hf_xet` change or pin bump needed: the seeding kwargs exist since `hf-xet` 1.5.0 (our floor is 1.5.2).

## Review guide: mostly a partial revert of #4482

The restored helpers come from the pre-#4482 file (`git show 8fa58388~1:src/huggingface_hub/utils/_xet.py`) and the `xet_get()` call site is the exact pre-#4116 line. `XetConnectionInfo`, `refresh_xet_connection_info`, `_is_expired` and the cache constants are verbatim. Deltas:

- `_fetch_xet_connection_info_with_url` / `_cache_key` lose their `params` and `cache_key_prefix` arguments: their only consumer was the upload-path helper `fetch_xet_connection_info_from_repo_info`, which is not restored (uploads request one token per commit, no cache needed). Same reason `reset_xet_connection_info_cache_for_repo` and its `delete_repo` hooks (#3847) don't come back: download cache keys embed the commit SHA via the refresh URL, so a recreated repo can never hit the cache.
- New per-key lock around the fetch: collapses the cold-cache stampede (one fetch per worker, measured 4 with `max_workers=4`) into a single request per key; under a real 429, one thread backs off via `http_backoff` while the others wait instead of all hammering the endpoint. The lock is per cache key so cold fetches for different repos downloaded in parallel don't serialize; a single global lock guards the cache dict and the per-key lock registry.
- `parse_xet_connection_info_from_headers` takes `Mapping` instead of `dict` + `# type: ignore` at the call site (`resp.headers` is `httpx.Headers`; `ty` rejects the old form).
- Helpers stay private (not re-exported in `huggingface_hub.utils`), as preferred in #4116/#4482.

Only `xet_get()` is seeded — the bucket download path already uses a single group per call. Tests intentionally not added yet (will follow before un-drafting); the `tests/test_xet_download.py` change fixes an existing test that now needs the fetch mocked.

## Notes on the hf_xet side

Longer term this cache probably belongs at the `XetSession` level in `hf_xet` (keyed by refresh URL): the eager refresh on group build happens whenever `endpoint` isn't seeded, every binding has to work around it the same way (huggingface.js maintains its own copy of this exact cache), and mid-download token expiry is still refreshed per live group, uncached, on the Rust side. Once a session-level cache exists there, this Python-side one can be dropped again.

## Manual testing

Counted `xet-read-token` calls with a local reverse proxy in front of huggingface.co, downloading 10 files with `max_workers=4` — one call per file on `main`, one call total with this PR:

Before:

```
   10  GET /api/datasets/ArlingtonCL2/DogSpeak_Dataset/xet-read-token/34c9047dcff6744700ce772d6acb313884ba8b14
```

After:

```
    1  GET /api/datasets/ArlingtonCL2/DogSpeak_Dataset/xet-read-token/34c9047dcff6744700ce772d6acb313884ba8b14
```

Simulated a rate-limited token endpoint (proxy returns 429 after the first two calls): on `main` the download stalls for minutes then fails with `ConnectionError: ... 429 Too Many Requests ... /xet-read-token/...`; with this PR the same scenario succeeds with a single token call. Downloaded bytes are identical to the plain-HTTP path (`sha256` match with `HF_HUB_DISABLE_XET=1`), and `pytest tests/test_xet_utils.py tests/test_xet_download.py` passes (33 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches download auth/token handling and shared caching under concurrency; wrong cache keys or expiry logic could cause failed downloads or stale tokens, but scope is limited to the Xet path and mirrors previously shipped behavior.
> 
> **Overview**
> Fixes **rate limiting and stalled multi-file Xet downloads** by restoring a cached Hub `xet-read-token` flow instead of letting each file’s download group trigger its own eager token fetch.
> 
> **`xet_get()`** now calls **`refresh_xet_connection_info()`** once per repo revision (keyed by refresh URL + auth) and passes **`endpoint`**, **`token`**, and **`token_expiry_unix_secs`** into **`new_file_download_group()`**, while still supplying **`token_refresh_url`** for mid-download refresh. **`utils/_xet.py`** adds **`XetConnectionInfo`**, header parsing, an in-memory cache with expiry buffer and size cap, and **per-key locks** so parallel workers don’t stampede the token endpoint on a cold cache.
> 
> Docs in **`file_download.py`** are updated to describe seeded tokens. **`tests/test_xet_download.py`** mocks the new fetch so existing header assertions keep working.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d66643eeba292cdab49bf955c37563720b7b4fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->