### PR TITLE
[MCP] Set upper bound mcp<2.0 for optional extra dependency `huggingface_hub[mcp]`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ extras["fastai"] = [
 
 extras["hf_xet"] = [HF_XET_VERSION]
 
-extras["mcp"] = ["mcp>=2.0.0"]
+extras["mcp"] = ["mcp>=1.8.0, <2.0.0"]
 
 extras["testing"] = (
     extras["oauth"]

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ extras["fastai"] = [
 
 extras["hf_xet"] = [HF_XET_VERSION]
 
-extras["mcp"] = ["mcp>=1.8.0"]
+extras["mcp"] = ["mcp>=2.0.0"]
 
 extras["testing"] = (
     extras["oauth"]

--- a/src/huggingface_hub/inference/_mcp/mcp_client.py
+++ b/src/huggingface_hub/inference/_mcp/mcp_client.py
@@ -183,7 +183,7 @@ class MCPClient:
             read, write = await self.exit_stack.enter_async_context(sse_client(**client_kwargs))
         elif type == "http":
             # Handle StreamableHTTP server
-            from mcp.client.streamable_http import streamablehttp_client
+            from mcp.client.streamable_http import streamable_http_client
 
             logger.info(f"Connecting to StreamableHTTP MCP server at: {params['url']}")
 
@@ -191,7 +191,7 @@ class MCPClient:
             for key in ["headers", "timeout", "sse_read_timeout", "terminate_on_close"]:
                 if params.get(key) is not None:
                     client_kwargs[key] = params[key]
-            read, write, _ = await self.exit_stack.enter_async_context(streamablehttp_client(**client_kwargs))
+            read, write, _ = await self.exit_stack.enter_async_context(streamable_http_client(**client_kwargs))
             # ^ TODO: should be handle `get_session_id_callback`? (function to retrieve the current session ID)
         else:
             raise ValueError(f"Unsupported server type: {type}")

--- a/src/huggingface_hub/inference/_mcp/mcp_client.py
+++ b/src/huggingface_hub/inference/_mcp/mcp_client.py
@@ -183,7 +183,7 @@ class MCPClient:
             read, write = await self.exit_stack.enter_async_context(sse_client(**client_kwargs))
         elif type == "http":
             # Handle StreamableHTTP server
-            from mcp.client.streamable_http import streamable_http_client
+            from mcp.client.streamable_http import streamablehttp_client
 
             logger.info(f"Connecting to StreamableHTTP MCP server at: {params['url']}")
 
@@ -191,7 +191,7 @@ class MCPClient:
             for key in ["headers", "timeout", "sse_read_timeout", "terminate_on_close"]:
                 if params.get(key) is not None:
                     client_kwargs[key] = params[key]
-            read, write, _ = await self.exit_stack.enter_async_context(streamable_http_client(**client_kwargs))
+            read, write, _ = await self.exit_stack.enter_async_context(streamablehttp_client(**client_kwargs))
             # ^ TODO: should be handle `get_session_id_callback`? (function to retrieve the current session ID)
         else:
             raise ValueError(f"Unsupported server type: {type}")


### PR DESCRIPTION
Fixes https://github.com/huggingface/huggingface_hub/issues/4733 following `mcp 2.0.0` release (see https://github.com/modelcontextprotocol/python-sdk/releases#release-v2.0.0) which broke from API. Let's just stick to `<2.0.0` which is the version it was developed on. This is an experimental unused tool anyway.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only change to the optional MCP extra; no runtime code paths are modified in this diff.
> 
> **Overview**
> The optional **`huggingface_hub[mcp]`** extra now pins **`mcp`** to **`>=1.8.0, <2.0.0`** instead of allowing any 1.8+ release.
> 
> Installs that use the MCP extra will not pull in **`mcp` 2.x**, avoiding breakage from the 2.0 SDK until the library is aligned with that major version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdb59d4519d6c2e8f7fa1b5372ec51d804b27dae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->