### PR TITLE
[Download] Follow redirects between Hub hosts when resolving files

### DIFF
--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -73,12 +73,9 @@ if _staging_mode:
     ENDPOINT = _HF_DEFAULT_STAGING_ENDPOINT
     HUGGINGFACE_CO_URL_TEMPLATE = _HF_DEFAULT_STAGING_ENDPOINT + "/{repo_id}/resolve/{revision}/{filename}"
 
-# Hosts we consider to be Hugging Face Hub endpoints. Includes the public Hub host and its ``hf.co`` short
-# domain, the staging host, and the host of the currently configured ``ENDPOINT`` so that self-hosted / staging
-# endpoints work too.
-# Used to parse web URLs into ``hf://`` URIs (see ``huggingface_hub/utils/_hf_uris.py``) and to decide which
-# redirects to follow while resolving files (see ``huggingface_hub/utils/_http.py``). The latter forwards the
-# authorization header to these hosts, so only add a host that is trusted with the user's token.
+# Hosts considered to be Hugging Face Hub endpoints: the public Hub host, its ``hf.co`` short domain, the staging
+# host, and the host of the configured ``ENDPOINT``. Used to parse web URLs into ``hf://`` URIs and to decide which
+# redirects to follow when resolving files. The auth header is forwarded to these hosts: only add trusted ones.
 HF_URL_HOSTS: frozenset[str] = frozenset(
     {"hf.co"}
     | {

--- a/src/huggingface_hub/constants.py
+++ b/src/huggingface_hub/constants.py
@@ -73,9 +73,12 @@ if _staging_mode:
     ENDPOINT = _HF_DEFAULT_STAGING_ENDPOINT
     HUGGINGFACE_CO_URL_TEMPLATE = _HF_DEFAULT_STAGING_ENDPOINT + "/{repo_id}/resolve/{revision}/{filename}"
 
-# Hosts whose web URLs can be parsed into a ``hf://`` URI (see ``huggingface_hub/utils/_hf_uris.py``).
-# Includes the public Hub host and its ``hf.co`` short domain, the staging host, and the host of the
-# currently configured ``ENDPOINT`` so that self-hosted / staging endpoints work too.
+# Hosts we consider to be Hugging Face Hub endpoints. Includes the public Hub host and its ``hf.co`` short
+# domain, the staging host, and the host of the currently configured ``ENDPOINT`` so that self-hosted / staging
+# endpoints work too.
+# Used to parse web URLs into ``hf://`` URIs (see ``huggingface_hub/utils/_hf_uris.py``) and to decide which
+# redirects to follow while resolving files (see ``huggingface_hub/utils/_http.py``). The latter forwards the
+# authorization header to these hosts, so only add a host that is trusted with the user's token.
 HF_URL_HOSTS: frozenset[str] = frozenset(
     {"hf.co"}
     | {

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -50,7 +50,7 @@ from .utils._http import (
     _DEFAULT_RETRY_ON_EXCEPTIONS,
     _DEFAULT_RETRY_ON_STATUS_CODES,
     _adjust_range_header,
-    _httpx_follow_relative_redirects_with_backoff,
+    _httpx_follow_hub_redirects_with_backoff,
     http_stream_backoff,
 )
 from .utils._runtime import is_xet_available
@@ -1618,7 +1618,7 @@ def get_hf_file_metadata(
     hf_headers["Accept-Encoding"] = "identity"  # prevent any compression => we want to know the real size of the file
 
     # Retrieve metadata
-    response = _httpx_follow_relative_redirects_with_backoff(
+    response = _httpx_follow_hub_redirects_with_backoff(
         method="HEAD", url=url, headers=hf_headers, timeout=timeout, retry_on_errors=retry_on_errors
     )
     hf_raise_for_status(response)
@@ -1740,9 +1740,10 @@ def _get_metadata_or_catch_error(
             commit_hash = metadata.commit_hash
             if commit_hash is None:
                 raise FileMetadataError(
-                    "Distant resource does not seem to be on huggingface.co. It is possible that a configuration issue"
-                    " prevents you from downloading resources from https://huggingface.co. Please check your firewall"
-                    " and proxy settings and make sure your SSL certificates are updated."
+                    f"Response from {url} is missing the '{constants.HUGGINGFACE_HEADER_X_REPO_COMMIT}' header, so it"
+                    " does not seem to be served by a Hugging Face Hub endpoint. If HF_ENDPOINT is set, check that it"
+                    " points to a Hub-compatible endpoint. Otherwise, check your firewall and proxy settings and make"
+                    " sure your SSL certificates are updated."
                 )
 
             # Etag must exist
@@ -1903,6 +1904,11 @@ def _raise_on_head_call_error(head_call_error: Exception, force_download: bool, 
         # Repo not found or gated => let's raise the actual error
         # Unauthorized => likely a token issue => let's raise the actual error
         raise head_call_error
+    elif isinstance(head_call_error, FileMetadataError):
+        # The call succeeded but the response lacked the metadata we need => a configuration issue, not connectivity.
+        raise LocalEntryNotFoundError(
+            f"{head_call_error} We also cannot find the requested files in the local cache."
+        ) from head_call_error
     else:
         # Otherwise: most likely a connection issue or Hub downtime => let's warn the user
         raise LocalEntryNotFoundError(

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -10,7 +10,7 @@ import warnings
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, BinaryIO, Literal, NoReturn, overload
-from urllib.parse import quote, urlparse
+from urllib.parse import quote
 
 import httpx
 from tqdm.auto import tqdm as base_tqdm
@@ -51,6 +51,7 @@ from .utils._http import (
     _DEFAULT_RETRY_ON_STATUS_CODES,
     _adjust_range_header,
     _httpx_follow_hub_redirects_with_backoff,
+    _is_same_or_hub_host,
     http_stream_backoff,
 )
 from .utils._runtime import is_xet_available
@@ -1765,12 +1766,12 @@ def _get_metadata_or_catch_error(
             # and ensure we download the exact atomic version even if it changed
             # between the HEAD and the GET (unlikely, but hey).
             #
-            # If url domain is different => we are downloading from a CDN => url is signed => don't send auth
-            # If url domain is the same => redirect due to repo rename AND downloading a regular file => keep auth
+            # If the final location is on a Hub host (same host, or e.g. huggingface.co reached through an
+            # HF_ENDPOINT mirror redirect) => keep auth. Otherwise it's a signed CDN url => don't send auth.
             if xet_file_data is None and url != metadata.location:
                 url_to_download = metadata.location
-                if urlparse(url).netloc != urlparse(metadata.location).netloc:
-                    # Remove authorization header when downloading a LFS blob
+                if not _is_same_or_hub_host(url, metadata.location):
+                    # Remove authorization header when downloading a LFS blob from a CDN
                     headers.pop("authorization", None)
         except httpx.ProxyError:
             # Actually raise on proxy error

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -162,7 +162,7 @@ from .utils import (
 from .utils import tqdm as hf_tqdm
 from .utils._auth import _get_token_from_environment, _get_token_from_file, _get_token_from_google_colab
 from .utils._deprecation import _deprecate_arguments, _deprecate_method
-from .utils._http import _httpx_follow_relative_redirects_with_backoff
+from .utils._http import _httpx_follow_hub_redirects_with_backoff
 from .utils._runtime import is_xet_available
 from .utils._typing import CallableT
 from .utils._verification import collect_local_files, resolve_local_root, verify_maps
@@ -14735,7 +14735,7 @@ class HfApi:
             42000
             ```
         """
-        response = _httpx_follow_relative_redirects_with_backoff(
+        response = _httpx_follow_hub_redirects_with_backoff(
             "HEAD",
             f"{self.endpoint}/buckets/{bucket_id}/resolve/{quote(remote_path, safe='')}",
             headers=self._build_hf_headers(token=token),

--- a/src/huggingface_hub/utils/_http.py
+++ b/src/huggingface_hub/utils/_http.py
@@ -691,6 +691,9 @@ def http_stream_backoff(
     )
 
 
+_MAX_REDIRECTS = 20  # same bound as httpx's default max_redirects
+
+
 def _httpx_follow_hub_redirects_with_backoff(
     method: HTTP_METHOD_T, url: str, *, retry_on_errors: bool = False, **httpx_kwargs
 ) -> httpx.Response:
@@ -722,7 +725,7 @@ def _httpx_follow_hub_redirects_with_backoff(
         {} if retry_on_errors else {"retry_on_exceptions": (), "retry_on_status_codes": ()}
     )
 
-    for _ in range(20):  # same bound as httpx's default max_redirects
+    for _ in range(_MAX_REDIRECTS):
         response = http_backoff(
             method=method,
             url=url,
@@ -743,7 +746,7 @@ def _httpx_follow_hub_redirects_with_backoff(
 
         url = target
 
-    raise httpx.TooManyRedirects(f"Exceeded 20 redirects while resolving '{url}'.")
+    raise httpx.TooManyRedirects(f"Exceeded {_MAX_REDIRECTS} redirects while resolving '{url}'.")
 
 
 def _is_same_or_hub_host(url: str, target: str) -> bool:

--- a/src/huggingface_hub/utils/_http.py
+++ b/src/huggingface_hub/utils/_http.py
@@ -701,11 +701,8 @@ def _httpx_follow_hub_redirects_with_backoff(
 
     Used to fetch HEAD /resolve on repo or bucket files.
 
-    A redirect is followed when it targets the host of the current request (e.g. a renamed repository, or the
-    `/api/resolve-cache/` route) or another known Hub host (e.g. an `HF_ENDPOINT` mirror redirecting to
-    `huggingface.co`). Redirects to any other host are *not* followed: those point to a CDN or storage bucket, the
-    file metadata is already carried by the redirect response itself, and the authorization header must not be
-    forwarded off the Hub.
+    Redirects to the same host or another Hub host are followed. Redirects to any other host (CDN, storage
+    bucket) are not: the file metadata is on the redirect response itself and the auth header must not leave the Hub.
 
     A backoff mechanism retries the HTTP call on errors (429, 5xx, timeout, network errors).
 

--- a/src/huggingface_hub/utils/_http.py
+++ b/src/huggingface_hub/utils/_http.py
@@ -691,9 +691,6 @@ def http_stream_backoff(
     )
 
 
-_MAX_HUB_REDIRECTS = 10
-
-
 def _httpx_follow_hub_redirects_with_backoff(
     method: HTTP_METHOD_T, url: str, *, retry_on_errors: bool = False, **httpx_kwargs
 ) -> httpx.Response:
@@ -725,7 +722,7 @@ def _httpx_follow_hub_redirects_with_backoff(
         {} if retry_on_errors else {"retry_on_exceptions": (), "retry_on_status_codes": ()}
     )
 
-    for _ in range(_MAX_HUB_REDIRECTS):
+    while True:
         response = http_backoff(
             method=method,
             url=url,
@@ -745,8 +742,6 @@ def _httpx_follow_hub_redirects_with_backoff(
             return response
 
         url = target
-
-    raise httpx.TooManyRedirects(f"Exceeded maximum of {_MAX_HUB_REDIRECTS} redirects while resolving '{url}'.")
 
 
 def _is_same_or_hub_host(url: str, target: str) -> bool:

--- a/src/huggingface_hub/utils/_http.py
+++ b/src/huggingface_hub/utils/_http.py
@@ -722,7 +722,7 @@ def _httpx_follow_hub_redirects_with_backoff(
         {} if retry_on_errors else {"retry_on_exceptions": (), "retry_on_status_codes": ()}
     )
 
-    while True:
+    for _ in range(20):  # same bound as httpx's default max_redirects
         response = http_backoff(
             method=method,
             url=url,
@@ -742,6 +742,8 @@ def _httpx_follow_hub_redirects_with_backoff(
             return response
 
         url = target
+
+    raise httpx.TooManyRedirects(f"Exceeded 20 redirects while resolving '{url}'.")
 
 
 def _is_same_or_hub_host(url: str, target: str) -> bool:

--- a/src/huggingface_hub/utils/_http.py
+++ b/src/huggingface_hub/utils/_http.py
@@ -26,7 +26,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from shlex import quote
 from typing import Any, TypeVar
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse
 
 import httpx
 
@@ -691,14 +691,21 @@ def http_stream_backoff(
     )
 
 
-def _httpx_follow_relative_redirects_with_backoff(
+_MAX_HUB_REDIRECTS = 10
+
+
+def _httpx_follow_hub_redirects_with_backoff(
     method: HTTP_METHOD_T, url: str, *, retry_on_errors: bool = False, **httpx_kwargs
 ) -> httpx.Response:
-    """Perform an HTTP request with backoff and follow relative redirects only.
+    """Perform an HTTP request with backoff, following redirects that stay on the Hub.
 
     Used to fetch HEAD /resolve on repo or bucket files.
 
-    This is useful to follow a redirection to a renamed repository without following redirection to a CDN.
+    A redirect is followed when it targets the host of the current request (e.g. a renamed repository, or the
+    `/api/resolve-cache/` route) or another known Hub host (e.g. an `HF_ENDPOINT` mirror redirecting to
+    `huggingface.co`). Redirects to any other host are *not* followed: those point to a CDN or storage bucket, the
+    file metadata is already carried by the redirect response itself, and the authorization header must not be
+    forwarded off the Hub.
 
     A backoff mechanism retries the HTTP call on errors (429, 5xx, timeout, network errors).
 
@@ -718,7 +725,7 @@ def _httpx_follow_relative_redirects_with_backoff(
         {} if retry_on_errors else {"retry_on_exceptions": (), "retry_on_status_codes": ()}
     )
 
-    while True:
+    for _ in range(_MAX_HUB_REDIRECTS):
         response = http_backoff(
             method=method,
             url=url,
@@ -728,18 +735,24 @@ def _httpx_follow_relative_redirects_with_backoff(
         )
         hf_raise_for_status(response)
 
-        # Check if response is a relative redirect
-        if 300 <= response.status_code <= 399:
-            parsed_target = urlparse(response.headers["Location"])
-            if parsed_target.netloc == "":
-                # Relative redirect -> update URL and retry
-                url = urlparse(url)._replace(path=parsed_target.path).geturl()
-                continue
+        if not response.has_redirect_location:
+            return response
 
-        # Break if no relative redirect
-        break
+        target = urljoin(url, response.headers["Location"])
+        if not _is_same_or_hub_host(url, target):
+            # Redirect to a CDN or storage host (signed URL): the file metadata is carried by this very response,
+            # and the authorization header must not be forwarded off the Hub => stop here.
+            return response
 
-    return response
+        url = target
+
+    raise httpx.TooManyRedirects(f"Exceeded maximum of {_MAX_HUB_REDIRECTS} redirects while resolving '{url}'.")
+
+
+def _is_same_or_hub_host(url: str, target: str) -> bool:
+    """Whether `target` is served by the same host as `url`, or by a known Hub host."""
+    target_host = (urlparse(target).hostname or "").lower()
+    return target_host == (urlparse(url).hostname or "").lower() or target_host in constants.HF_URL_HOSTS
 
 
 def fix_hf_endpoint_in_url(url: str, endpoint: str | None) -> str:


### PR DESCRIPTION
Fixes #4637.

## Summary

- When resolving a file, the client only followed redirects with a relative `Location`. An endpoint answering with an absolute redirect to another Hub host (e.g. a mirror set as `HF_ENDPOINT` redirecting to `huggingface.co`) was never followed: the client kept the raw `308`, found no `X-Repo-Commit` header on it, and failed with a misleading `LocalEntryNotFoundError: ... check your connection`.
- New rule: follow a redirect when the target stays on the same host or on a known Hub host (`constants.HF_URL_HOSTS`, i.e. `huggingface.co`, `hf.co`, staging, and the host of the configured `HF_ENDPOINT`). Stop at any other host: for LFS files the metadata lives on the redirect response itself, and the `Authorization` header must not be forwarded to a CDN.
- More accurate error when metadata is genuinely missing: the message now names the URL and the missing header and points at `HF_ENDPOINT`, instead of blaming the connection.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core HEAD/resolve and auth-forwarding behavior for downloads; logic is tightened around trusted Hub hosts but misconfigured `HF_URL_HOSTS` could affect redirects or token forwarding.
> 
> **Overview**
> Fixes file resolution when `HF_ENDPOINT` (or another Hub mirror) answers with an **absolute redirect** to a known Hub host (e.g. `huggingface.co`). The client previously only chased **relative** `Location` headers, so it could stop on a `308` without `X-Repo-Commit` and surface a misleading “check your connection” cache error.
> 
> **Redirect policy:** `_httpx_follow_relative_redirects_with_backoff` is replaced by `_httpx_follow_hub_redirects_with_backoff`, which follows redirects while the target stays on the **same host** or on `constants.HF_URL_HOSTS` (public Hub, `hf.co`, staging, configured endpoint). Redirects to CDNs/storage are **not** followed so LFS metadata on the redirect response is preserved and **`Authorization` is not sent off-Hub**. `_is_same_or_hub_host` is shared for HEAD chasing and for stripping auth on CDN download URLs.
> 
> **Errors:** Missing `X-Repo-Commit` now names the URL, the header, and `HF_ENDPOINT`. `FileMetadataError` during cache fallback is re-raised as `LocalEntryNotFoundError` with a configuration-focused message instead of a generic connectivity warning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 809e4fbbf0bac07911df52b8c0f49e2402fdb110. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->