### PR TITLE
[HfApi] Validate safetensors index entries

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -6972,6 +6972,13 @@ class HfApi:
                 tqdm_class=hf_tqdm,
             )
 
+            for tensor_name, filename in weight_map.items():
+                if tensor_name not in files_metadata[filename].tensors:
+                    raise SafetensorsParsingError(
+                        f"Safetensors index for '{repo_id}' is inconsistent: tensor '{tensor_name}' is mapped to "
+                        f"'{filename}' but is not present in that file."
+                    )
+
             return SafetensorsRepoMetadata(
                 metadata=index.get("metadata", None),
                 sharded=True,

--- a/tests/test_safetensors_metadata.py
+++ b/tests/test_safetensors_metadata.py
@@ -1,0 +1,74 @@
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+import re
+
+import pytest
+
+from huggingface_hub import HfApi, constants
+from huggingface_hub.utils import SafetensorsFileMetadata, SafetensorsParsingError, TensorInfo
+
+
+def _file_metadata(*tensor_names: str) -> SafetensorsFileMetadata:
+    return SafetensorsFileMetadata(
+        metadata={"format": "pt"},
+        tensors={
+            name: TensorInfo(dtype="F32", shape=[1], data_offsets=(index * 4, (index + 1) * 4))
+            for index, name in enumerate(tensor_names)
+        },
+    )
+
+
+def test_get_safetensors_metadata_rejects_tensor_missing_from_mapped_shard(tmp_path, mocker) -> None:
+    first_shard = "model-00001-of-00002.safetensors"
+    second_shard = "model-00002-of-00002.safetensors"
+    index_path = tmp_path / constants.SAFETENSORS_INDEX_FILE
+    index_path.write_text(
+        json.dumps(
+            {
+                "weight_map": {
+                    "first.weight": first_shard,
+                    "misplaced.weight": first_shard,
+                    "second.weight": second_shard,
+                }
+            }
+        )
+    )
+
+    api = HfApi()
+    mocker.patch.object(
+        api,
+        "file_exists",
+        side_effect=lambda *, filename, **kwargs: filename == constants.SAFETENSORS_INDEX_FILE,
+    )
+    mocker.patch.object(api, "hf_hub_download", return_value=str(index_path))
+    shard_metadata = {
+        first_shard: _file_metadata("first.weight"),
+        # Keep the missing tensor in another shard to prove that the index's exact mapping is validated.
+        second_shard: _file_metadata("misplaced.weight", "second.weight"),
+    }
+    mocker.patch.object(
+        api,
+        "parse_safetensors_file_metadata",
+        side_effect=lambda *, filename, **kwargs: shard_metadata[filename],
+    )
+
+    with pytest.raises(
+        SafetensorsParsingError,
+        match=re.escape(
+            "Safetensors index for 'namespace/repo' is inconsistent: tensor 'misplaced.weight' is mapped to "
+            f"'{first_shard}' but is not present in that file."
+        ),
+    ):
+        api.get_safetensors_metadata("namespace/repo")


### PR DESCRIPTION
Fixes #4725

## What does this PR do?

Reject inconsistent sharded safetensors indexes when a tensor is mapped to a shard that does not actually contain it.

Previously, `get_safetensors_metadata()` trusted `weight_map` after parsing every referenced shard. That could return metadata successfully even when a tensor existed only in a different shard than the index claimed, hiding corrupt repository metadata from callers.

The parser now validates each tensor against the exact shard named by `weight_map` and raises `SafetensorsParsingError` with the repository, tensor, and shard context when the mapping is inconsistent.

## Tests

- regression fails before the fix: expected `SafetensorsParsingError`, but none was raised
- regression passes after the fix
- existing safetensors API tests: 7 passed, including single-file, multi-shard, malformed, revision, and large-header cases
- Ruff format and lint checks pass

The regression deliberately puts the misplaced tensor in another parsed shard, proving validation is shard-specific rather than merely checking that the tensor exists somewhere in the repository.
