### PR TITLE
fix: remove deprecated labels/tags arguments from zero-shot and list_datasets

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -2733,7 +2733,7 @@ class HfApi:
         ... )
 
         # List FiftyOne datasets (identified by the tag "fiftyone" in dataset card)
-        >>> api.list_datasets(tags="fiftyone")
+        >>> api.list_datasets(filter="tag:fiftyone")
         ```
 
         Example usage with the `search` argument:

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -2733,7 +2733,7 @@ class HfApi:
         ... )
 
         # List FiftyOne datasets (identified by the tag "fiftyone" in dataset card)
-        >>> api.list_datasets(filter="tag:fiftyone")
+        >>> api.list_datasets(filter="fiftyone")
         ```
 
         Example usage with the `search` argument:

--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -3121,8 +3121,6 @@ class InferenceClient:
                 The input text to classify.
             candidate_labels (`list[str]`):
                 The set of possible class labels to classify the text into.
-            labels (`list[str]`, *optional*):
-                (deprecated) List of strings. Each string is the verbalization of a possible label for the input text.
             multi_label (`bool`, *optional*):
                 Whether multiple candidate labels can be true. If false, the scores are normalized such that the sum of
                 the label likelihoods for each sequence is 1. If true, the labels are considered independent and
@@ -3214,8 +3212,6 @@ class InferenceClient:
         *,
         model: str | None = None,
         hypothesis_template: str | None = None,
-        # deprecated argument
-        labels: list[str] = None,  # type: ignore
     ) -> list[ZeroShotImageClassificationOutputElement]:
         """
         Provide input image and text labels to predict text labels for the image.
@@ -3225,8 +3221,6 @@ class InferenceClient:
                 The input image to caption. It can be raw bytes, an image file, a URL to an online image, or a PIL Image.
             candidate_labels (`list[str]`):
                 The candidate labels for this image
-            labels (`list[str]`, *optional*):
-                (deprecated) List of string possible labels. There must be at least 2 labels.
             model (`str`, *optional*):
                 The model to use for inference. Can be a model ID hosted on the Hugging Face Hub or a URL to a deployed
                 Inference Endpoint. This parameter overrides the model defined at the instance level. If not provided, the default recommended zero-shot image classification model will be used.
@@ -3250,7 +3244,7 @@ class InferenceClient:
 
         >>> client.zero_shot_image_classification(
         ...     "https://upload.wikimedia.org/wikipedia/commons/thumb/4/43/Cute_dog.jpg/320px-Cute_dog.jpg",
-        ...     labels=["dog", "cat", "horse"],
+        ...     candidate_labels=["dog", "cat", "horse"],
         ... )
         [ZeroShotImageClassificationOutputElement(label='dog', score=0.956),...]
         ```


### PR DESCRIPTION
Closes #4742

Removed deprecated `labels` argument from `zero_shot_classification` and `zero_shot_image_classification` docstrings and signature. Updated example in `zero_shot_image_classification` to use `candidate_labels`. Updated `list_datasets` example to use `filter="tag:fiftyone"` instead of deprecated `tags`.

This finishes the cleanup that was partially done on sibling methods.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Doc and deprecated-parameter removal only; no runtime behavior changes beyond dropping an unused `labels` kwarg on one method.
> 
> **Overview**
> Finishes deprecation cleanup for Hugging Face Hub client docs and one inference API surface.
> 
> **InferenceClient:** Removes the deprecated `labels` argument from `zero_shot_image_classification` (signature and docs) and strips `labels` from `zero_shot_classification` docs. The image-classification doc example now uses **`candidate_labels`** instead of `labels`.
> 
> **HfApi:** Updates the `list_datasets` doc example from **`tags="fiftyone"`** to **`filter="fiftyone"`**, matching the supported filtering API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea1a7eb5ed6d9fae9eb47e43a92d09a162231e67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->