### PR TITLE
Remove leftover deprecated `labels`/`tags` from docstrings and signature

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -2677,8 +2677,6 @@ class HfApi:
                 A string or list of strings that can be used to identify datasets on
                 the Hub by the size of the dataset such as `100K<n<1M` or
                 `1M<n<10M`.
-            tags (`str` or `List`, *optional*):
-                Deprecated. Pass tags in `filter` to filter datasets by tags.
             task_categories (`str` or `List`, *optional*):
                 A string or list of strings that can be used to identify datasets on
                 the Hub by the designed task, such as `audio_classification` or
@@ -2733,7 +2731,7 @@ class HfApi:
         ... )
 
         # List FiftyOne datasets (identified by the tag "fiftyone" in dataset card)
-        >>> api.list_datasets(tags="fiftyone")
+        >>> api.list_datasets(filter="fiftyone")
         ```
 
         Example usage with the `search` argument:

--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -3121,8 +3121,6 @@ class InferenceClient:
                 The input text to classify.
             candidate_labels (`list[str]`):
                 The set of possible class labels to classify the text into.
-            labels (`list[str]`, *optional*):
-                (deprecated) List of strings. Each string is the verbalization of a possible label for the input text.
             multi_label (`bool`, *optional*):
                 Whether multiple candidate labels can be true. If false, the scores are normalized such that the sum of
                 the label likelihoods for each sequence is 1. If true, the labels are considered independent and
@@ -3178,7 +3176,7 @@ class InferenceClient:
         >>> client = InferenceClient()
         >>> client.zero_shot_classification(
         ...    text="I really like our dinner and I'm very happy. I don't like the weather though.",
-        ...    labels=["positive", "negative", "pessimistic", "optimistic"],
+        ...    candidate_labels=["positive", "negative", "pessimistic", "optimistic"],
         ...    multi_label=True,
         ...    hypothesis_template="This text is {} towards the weather"
         ... )
@@ -3214,8 +3212,6 @@ class InferenceClient:
         *,
         model: str | None = None,
         hypothesis_template: str | None = None,
-        # deprecated argument
-        labels: list[str] = None,  # type: ignore
     ) -> list[ZeroShotImageClassificationOutputElement]:
         """
         Provide input image and text labels to predict text labels for the image.
@@ -3225,8 +3221,6 @@ class InferenceClient:
                 The input image to caption. It can be raw bytes, an image file, a URL to an online image, or a PIL Image.
             candidate_labels (`list[str]`):
                 The candidate labels for this image
-            labels (`list[str]`, *optional*):
-                (deprecated) List of string possible labels. There must be at least 2 labels.
             model (`str`, *optional*):
                 The model to use for inference. Can be a model ID hosted on the Hugging Face Hub or a URL to a deployed
                 Inference Endpoint. This parameter overrides the model defined at the instance level. If not provided, the default recommended zero-shot image classification model will be used.
@@ -3250,7 +3244,7 @@ class InferenceClient:
 
         >>> client.zero_shot_image_classification(
         ...     "https://upload.wikimedia.org/wikipedia/commons/thumb/4/43/Cute_dog.jpg/320px-Cute_dog.jpg",
-        ...     labels=["dog", "cat", "horse"],
+        ...     candidate_labels=["dog", "cat", "horse"],
         ... )
         [ZeroShotImageClassificationOutputElement(label='dog', score=0.956),...]
         ```

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -3172,8 +3172,6 @@ class AsyncInferenceClient:
                 The input text to classify.
             candidate_labels (`list[str]`):
                 The set of possible class labels to classify the text into.
-            labels (`list[str]`, *optional*):
-                (deprecated) List of strings. Each string is the verbalization of a possible label for the input text.
             multi_label (`bool`, *optional*):
                 Whether multiple candidate labels can be true. If false, the scores are normalized such that the sum of
                 the label likelihoods for each sequence is 1. If true, the labels are considered independent and
@@ -3231,7 +3229,7 @@ class AsyncInferenceClient:
         >>> client = AsyncInferenceClient()
         >>> await client.zero_shot_classification(
         ...    text="I really like our dinner and I'm very happy. I don't like the weather though.",
-        ...    labels=["positive", "negative", "pessimistic", "optimistic"],
+        ...    candidate_labels=["positive", "negative", "pessimistic", "optimistic"],
         ...    multi_label=True,
         ...    hypothesis_template="This text is {} towards the weather"
         ... )
@@ -3267,8 +3265,6 @@ class AsyncInferenceClient:
         *,
         model: str | None = None,
         hypothesis_template: str | None = None,
-        # deprecated argument
-        labels: list[str] = None,  # type: ignore
     ) -> list[ZeroShotImageClassificationOutputElement]:
         """
         Provide input image and text labels to predict text labels for the image.
@@ -3278,8 +3274,6 @@ class AsyncInferenceClient:
                 The input image to caption. It can be raw bytes, an image file, a URL to an online image, or a PIL Image.
             candidate_labels (`list[str]`):
                 The candidate labels for this image
-            labels (`list[str]`, *optional*):
-                (deprecated) List of string possible labels. There must be at least 2 labels.
             model (`str`, *optional*):
                 The model to use for inference. Can be a model ID hosted on the Hugging Face Hub or a URL to a deployed
                 Inference Endpoint. This parameter overrides the model defined at the instance level. If not provided, the default recommended zero-shot image classification model will be used.
@@ -3304,7 +3298,7 @@ class AsyncInferenceClient:
 
         >>> await client.zero_shot_image_classification(
         ...     "https://upload.wikimedia.org/wikipedia/commons/thumb/4/43/Cute_dog.jpg/320px-Cute_dog.jpg",
-        ...     labels=["dog", "cat", "horse"],
+        ...     candidate_labels=["dog", "cat", "horse"],
         ... )
         [ZeroShotImageClassificationOutputElement(label='dog', score=0.956),...]
         ```


### PR DESCRIPTION
## Summary

Fixes #4742. Two deprecations were only half-removed — the cleanup landed on one method but not on its sibling, so the removed arguments are still documented and still used in examples published on the API reference pages.

- `zero_shot_classification`: drop the stale `labels` entry from `Args:`, fix the second example to use `candidate_labels=`.
- `zero_shot_image_classification`: drop the dead `labels` parameter from the signature (nothing reads it — it was silently ignored), its `Args:` entry, and fix the example.
- `list_datasets`: drop the stale `tags` entry from `Args:`, fix the example to use `filter="fiftyone"`.
- `_async_client.py` regenerated with `make style`.

Docstrings only, except one real line: `labels: list[str] = None` in the `zero_shot_image_classification` signature. It was already a no-op (the deprecation handling was removed in #2878), so dropping it turns a silently-ignored kwarg into a `TypeError` — no working call breaks.

## Checks

The three examples from the issue no longer raise, and the dead parameter is gone from both sync and async clients:

```
>>> list(inspect.signature(client.zero_shot_image_classification).parameters)
['image', 'candidate_labels', 'model', 'hypothesis_template']
>>> list(inspect.signature(async_client.zero_shot_image_classification).parameters)
['image', 'candidate_labels', 'model', 'hypothesis_template']
```

`filter="fiftyone"` returns the same datasets the old `tags="fiftyone"` example did:

```
>>> [d.id for d in HfApi().list_datasets(filter="fiftyone", limit=3)]
['Voxel51/APAC-Egocentric-Stereo', 'Voxel51/spatial_lm_dataset', 'Voxel51/STONE']
```

`make style` + `make quality` pass.

## Note

This supersedes #4743 (thanks @abhi-0203!), which was missing the regenerated `_async_client.py` (CI red) and the `zero_shot_classification` example fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly documentation; the only behavioral change is rejecting the previously no-op `labels` kwarg on `zero_shot_image_classification`, which should not affect working callers.
> 
> **Overview**
> Finishes cleanup of half-removed deprecations so published API docs and examples match the real parameters.
> 
> **`HfApi.list_datasets`:** Drops the obsolete `tags` argument from the docstring and updates the FiftyOne example to `filter="fiftyone"` instead of `tags="fiftyone"`.
> 
> **Inference clients (sync + async):** Removes deprecated `labels` from zero-shot APIs—docstring-only for `zero_shot_classification` (examples now use `candidate_labels`), and both docstring and the unused `labels` kwarg on `zero_shot_image_classification`. Passing `labels=` to image zero-shot now raises `TypeError` instead of being silently ignored.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 547d011e818bc9f9caf971de5a671eb8e08ddbc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->