### PR TITLE
[CLI] Fix hf-mount install instructions in hf-cli skill

### DIFF
--- a/src/huggingface_hub/cli/skills.py
+++ b/src/huggingface_hub/cli/skills.py
@@ -73,7 +73,7 @@ _SKILL_TIPS = """
 
 To mount Hub repositories or buckets as local filesystems — no download, no copy, no waiting — use `hf-mount`. Files are fetched on demand. GitHub: https://github.com/huggingface/hf-mount
 
-Install: `curl -fsSL https://raw.githubusercontent.com/huggingface/hf-mount/main/install.sh | sh`
+Install: `brew install hf-mount`, or download a binary from https://github.com/huggingface/hf-mount/releases
 
 Some command examples:
 - `hf-mount start repo openai-community/gpt2 /tmp/gpt2` — mount a repo (read-only)


### PR DESCRIPTION
## Summary

Fixes #4738.

- The `hf-cli` skill (generated from `src/huggingface_hub/cli/skills.py`) told users to install `hf-mount` with `curl -fsSL https://raw.githubusercontent.com/huggingface/hf-mount/main/install.sh | sh`. That script was dropped from the `hf-mount` repo in favor of Homebrew / release binaries, so the URL now returns a 404.
- Replaced it with the currently recommended install methods: `brew install hf-mount` or a binary from [GitHub Releases](https://github.com/huggingface/hf-mount/releases).

Before:

```
Install: `curl -fsSL https://raw.githubusercontent.com/huggingface/hf-mount/main/install.sh | sh`
```

After:

```
Install: `brew install hf-mount`, or download a binary from https://github.com/huggingface/hf-mount/releases
```

Checked the rendered section of the generated `SKILL.md`:

```
$ python -c "from huggingface_hub.cli import skills; print(skills._SKILL_TIPS)"

## Mounting repos as local filesystems

To mount Hub repositories or buckets as local filesystems — no download, no copy, no waiting — use `hf-mount`. Files are fetched on demand. GitHub: https://github.com/huggingface/hf-mount

Install: `brew install hf-mount`, or download a binary from https://github.com/huggingface/hf-mount/releases

Some command examples:
- `hf-mount start repo openai-community/gpt2 /tmp/gpt2` — mount a repo (read-only)
- `hf-mount start --hf-token $HF_TOKEN bucket myuser/my-bucket /tmp/data` — mount a bucket (read-write)
- `hf-mount status` / `hf-mount stop /tmp/data` — list or unmount
```

`pytest tests/test_cli.py -k skill` → 18 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Text-only change to skill documentation; no runtime or auth behavior affected.
> 
> **Overview**
> Updates the **hf-mount** install line in the generated `hf-cli` skill (`_SKILL_TIPS` in `skills.py`), which is what `hf skills add` / `build_skill_md()` embeds for AI assistants.
> 
> The previous instruction pointed at a **removed** `hf-mount` install script URL (404). It now recommends **`brew install hf-mount`** or downloading a binary from the project's **GitHub Releases** page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d311d6e829575dc8223052032c812ff8201b3ed4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->