### PR TITLE
[Utils] Fix load_dotenv truncating unquoted values at a bare '#'

### DIFF
--- a/src/huggingface_hub/utils/_dotenv.py
+++ b/src/huggingface_hub/utils/_dotenv.py
@@ -34,10 +34,11 @@ def load_dotenv(dotenv_str: str, environ: dict[str, str] | None = None) -> dict[
             (?:
                 '(?:\\'|[^'])*'           # single-quoted value
                 | \"(?:\\\"|[^\"])*\"     # double-quoted value
-                | [^#\n\r]+?              # unquoted value
+                | [^\n\r]*?               # unquoted value (may contain a bare '#')
             )
         )?
-        [^\S\n]*(?:\#.*)?$                # optional inline comment
+        (?:[^\S\n]+\#[^\n\r]*)?           # optional inline comment: '#' only starts a
+        [^\S\n]*$                         # comment when preceded by whitespace
     """,
         re.VERBOSE,
     )

--- a/tests/test_utils_dotenv.py
+++ b/tests/test_utils_dotenv.py
@@ -30,6 +30,25 @@ def test_export_and_inline_comment():
     assert load_dotenv(data) == {"KEY": "value"}
 
 
+def test_hash_without_preceding_whitespace_is_kept():
+    # A '#' only starts an inline comment when preceded by whitespace, matching
+    # python-dotenv and the rest of the ecosystem. A bare '#' inside an
+    # unquoted value (hex color, password, URL fragment, ...) is part of the
+    # value, not a comment. This used to be truncated at the first '#'.
+    data = """
+    COLOR=#FF0000
+    PASSWORD=p@ss#word
+    URL=http://example.com/page#section
+    COMMENTED=value # trailing comment
+    """
+    assert load_dotenv(data) == {
+        "COLOR": "#FF0000",
+        "PASSWORD": "p@ss#word",
+        "URL": "http://example.com/page#section",
+        "COMMENTED": "value",
+    }
+
+
 def test_ignore_invalid_lines():
     data = """
     this is not valid


### PR DESCRIPTION
## Summary

Fixes #4750.

`load_dotenv` treated any `#` in an unquoted value as the start of an inline comment, even with no whitespace before it, so values that legitimately contain a `#` were truncated (or emptied). The de-facto standard (`python-dotenv`, docker-compose, foreman) only starts an inline comment on a **whitespace-preceded** `#`.

This reaches users through the CLI env-file loading (`cli/_cli_utils.py` runs `--env` / `--env-file` contents through `load_dotenv`), so a job env var like `COLOR=#FF0000` or a password containing `#` was silently mangled.

- Allow a bare `#` inside unquoted values; only treat ` #` (whitespace then `#`) as an inline comment.
- Quoted values already preserved `#` and are unchanged; whitespace-preceded comments keep working.
- Added a regression test. Output now matches `python-dotenv` on the cases I checked.

## Before / after

```python
>>> from huggingface_hub.utils._dotenv import load_dotenv

# before
>>> load_dotenv("COLOR=#FF0000")
{'COLOR': ''}
>>> load_dotenv("PASSWORD=p@ss#word")
{'PASSWORD': 'p@ss'}
>>> load_dotenv("URL=http://example.com/page#section")
{'URL': 'http://example.com/page'}

# after
>>> load_dotenv("COLOR=#FF0000")
{'COLOR': '#FF0000'}
>>> load_dotenv("PASSWORD=p@ss#word")
{'PASSWORD': 'p@ss#word'}
>>> load_dotenv("URL=http://example.com/page#section")
{'URL': 'http://example.com/page#section'}

# unchanged (whitespace-preceded '#' is still a comment; quoted values keep their '#')
>>> load_dotenv("KEY=value # a comment")
{'KEY': 'value'}
>>> load_dotenv('K="a # b"')
{'K': 'a # b'}
```

I checked each case against `python-dotenv` and the results now agree. `make quality` (ruff format/check, mypy on the file) is clean and the `test_utils_dotenv.py` suite passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized parser fix with regression tests; behavior aligns with python-dotenv and only changes incorrect truncation of unquoted values.
> 
> **Overview**
> **Fixes `load_dotenv` truncating unquoted values at the first `#`.** Values like hex colors (`COLOR=#FF0000`), passwords, and URL fragments were cut off or emptied because any `#` was treated as an inline comment.
> 
> The line regex now matches **python-dotenv** / common tooling: unquoted values can include a bare `#`, and only **whitespace followed by `#`** starts an inline comment. Quoted values and existing `value # comment` behavior stay the same.
> 
> A regression test covers colors, passwords, URLs, and trailing comments. **CLI `--env` / `--env-file` loading** (`cli/_cli_utils.py`) uses this parser, so env files with `#` in values are no longer silently mangled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87943b6c932bd0c2c0da9216d6df9b2ff33ed260. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->