### PR TITLE
[CLI] Cap click to <8.5.0 (broke argument help rendering)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def get_version() -> str:
 HF_XET_VERSION = "hf-xet>=1.5.2,<2.0.0"
 
 install_requires = [
-    "click>=8.4.2,<9.0.0",  # 8.4.0/8.4.1 shipped a broken fish completion script
+    "click>=8.4.2,<8.5.0",  # 8.4.0/8.4.1 shipped a broken fish completion script; 8.5.0 broke argument help rendering
     "filelock>=3.10.0",
     "fsspec>=2023.5.0",
     f"{HF_XET_VERSION}; platform_machine=='x86_64' or platform_machine=='amd64' or platform_machine=='AMD64' or platform_machine=='arm64' or platform_machine=='aarch64'",


### PR DESCRIPTION
## Summary

- `click` 8.5.0 (released today) breaks the CLI's argument help rendering: descriptions disappear and the arguments section is printed twice, because click 8.5 now renders its own native arguments section on top of our custom `HfCommand.format_options`. This also makes `check_code_quality` fail on every PR (`generate_cli_reference.py` regenerates `cli.md` without any argument descriptions), since CI installs the latest `click`.
- This PR caps `click<8.5.0`, on the same line that already carries the 8.4.0/8.4.1 fish-completion cap.
- The durable follow-up is adapting our help formatter to click 8.5's native argument help and lifting the cap. Note that fresh installs of already-released versions (which allow `click<9`) are affected today; only a patch release with this cap can help there.

With `click` 8.5.0:

```
Positional arguments:
  SRC    [required]
  [DST]

Arguments:
  SRC    [required]
  [DST]
```

With `click` 8.4.2 (what this cap resolves to):

```
Arguments:
  SRC    Source: local file, hf:// URI (repo or bucket), or - for stdin.
         [required]
  [DST]  Destination: local path, hf:// URI (repo or bucket), or - for stdout.
```

Verified with a fresh resolve: `click` resolves to 8.4.2, `python utils/generate_cli_reference.py` passes, and `hf cp --help` renders argument descriptions again. The cap was also validated end-to-end on CI: https://github.com/huggingface/huggingface_hub/pull/4732 briefly carried this exact change and its `check_code_quality` went green ([run](https://github.com/huggingface/huggingface_hub/actions/runs/32995915389/job/98264980816)); it has been reverted there in favor of this standalone PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single dependency upper bound in packaging metadata with no runtime logic changes; low risk aside from blocking Click 8.5+ until a follow-up fix lands.
> 
> **Overview**
> **Pins `click` to `>=8.4.2,<8.5.0`** in `setup.py` so installs no longer pull in Click 8.5.0, which duplicates the CLI arguments section and drops argument descriptions when combined with the custom `HfCommand.format_options` help path.
> 
> The inline comment now documents both the existing fish-completion floor (8.4.0/8.4.1) and the new 8.5.0 regression. This is a temporary packaging guard until help formatting is updated for Click 8.5’s native argument rendering; it also keeps CI (`generate_cli_reference.py` / `check_code_quality`) on a compatible Click version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 589c3397081f9344d780b811aa10ab6332e6e5d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->