### PR TITLE
[Buckets] Fix path-boundary filter in hf buckets rm --recursive

### DIFF
--- a/src/huggingface_hub/cli/buckets.py
+++ b/src/huggingface_hub/cli/buckets.py
@@ -426,6 +426,17 @@ def remove(
                 status.update(f"Listing files from remote ({len(all_files)} files)")
         status.done(f"Listing files from remote ({len(all_files)} files)")
 
+        # Filter out lexical siblings: the server matches prefix lexically
+        # (e.g. prefix "logs" also returns "logs.json", "logs_backup/...").
+        # Filesystem semantics require that only the prefix itself and files
+        # directly under prefix/ are kept.
+        if prefix:
+            all_files = [
+                f
+                for f in all_files
+                if f.path == prefix or f.path.startswith(prefix + "/")
+            ]
+
         if include or exclude:
             matcher = FilterMatcher(include_patterns=include, exclude_patterns=exclude)
             matched_files = [f for f in all_files if matcher.matches(f.path)]

--- a/tests/test_buckets_cli.py
+++ b/tests/test_buckets_cli.py
@@ -291,6 +291,10 @@ def test_rm_recursive(api: HfApi, bucket_write: str):
             (b"a", "logs/a.log"),
             (b"b", "logs/b.log"),
             (b"deep", "logs/sub/deep.log"),
+            # Lexical siblings — must NOT be deleted
+            (b"sibling", "logs.json"),
+            (b"sibling_backup", "logs_backup/a.log"),
+            (b"sibling_x", "logsx/c.log"),
         ],
     )
 
@@ -299,7 +303,12 @@ def test_rm_recursive(api: HfApi, bucket_write: str):
     assert "3 file(s)" in result.output
     assert "totaling" in result.output
 
-    assert _remote_files(api, bucket_write) == {"keep.txt"}
+    assert _remote_files(api, bucket_write) == {
+        "keep.txt",
+        "logs.json",
+        "logs_backup/a.log",
+        "logsx/c.log",
+    }
 
 
 def test_rm_recursive_dry_run(api: HfApi, bucket_write: str):


### PR DESCRIPTION
## Summary

`hf buckets rm <bucket>/logs --recursive` deletes files whose names start lexically with `logs` — not just files under `logs/`. That means `logs.json`, `logs_backup/a.log`, and `logsx/c.log` get silently nuked alongside `logs/a.log`, and buckets arent versioned so the loss is permanent.

Every other path in the library already handles this — HfFileSystem, `_list_remote_files`, `_copy_to_bucket`, the sync skills. The `remove --recursive` branch was the one missing it.

## What changed

- **`src/huggingface_hub/cli/buckets.py`** — added the same post-list path filter the rest of the codebase uses: after listing remote files, keep only paths that match the prefix exactly or start with `prefix/`.
- **`tests/test_buckets_cli.py`** — seeded `logs.json`, `logs_backup/a.log`, and `logsx/c.log` into the `test_rm_recursive` fixture so over-deletion gets caught in CI.

The fix is 6 lines. The other `test_rm_recursive_*` tests are unchanged — they already use a trailing-slash prefix and their fixtures dont have lexical sibling files, so theyre safe.