### PR TITLE
[CLI] Installer: point at shadowed newer Python on macOS

### DIFF
--- a/utils/installers/install.sh
+++ b/utils/installers/install.sh
@@ -229,8 +229,6 @@ ensure_python() {
                 done
                 if [ -n "$shadowed" ]; then
                     log_info "Found $shadowed ($("$shadowed" --version 2>&1)), but an older Python earlier in your PATH shadows it."
-                    log_info "Fix: put $(dirname "$shadowed") earlier in your PATH, or re-run the installer with:"
-                    log_info "  curl -LsSf https://hf.co/cli/install.sh | env PATH=\"$(dirname "$shadowed"):\$PATH\" bash"
                 else
                     log_info "On macOS: brew install python (or download Python 3.10+ from python.org)"
                 fi

--- a/utils/installers/install.sh
+++ b/utils/installers/install.sh
@@ -229,6 +229,7 @@ ensure_python() {
                 done
                 if [ -n "$shadowed" ]; then
                     log_info "Found $shadowed ($("$shadowed" --version 2>&1)), but an older Python earlier in your PATH shadows it."
+                    log_info "Put $(dirname "$shadowed") earlier in your PATH and re-run the installer."
                 else
                     log_info "On macOS: brew install python (or download Python 3.10+ from python.org)"
                 fi

--- a/utils/installers/install.sh
+++ b/utils/installers/install.sh
@@ -210,7 +210,7 @@ ensure_python() {
                 chosen="$candidate"
                 break
             else
-                log_warning "$candidate detected ($version_output) but Python 3.10+ is required."
+                log_warning "$candidate ($(command -v "$candidate")) is $version_output but Python 3.10+ is required."
             fi
         fi
     done
@@ -219,7 +219,21 @@ ensure_python() {
         log_error "Python 3.10+ is required but was not found."
         case "$(detect_os)" in
             macos)
-                log_info "On macOS: brew install python (or download Python 3.10+ from python.org)"
+                # A suitable Python is often already installed but shadowed by an older one earlier in PATH.
+                local shadowed="" location
+                for location in /opt/homebrew/bin/python3 /usr/local/bin/python3; do
+                    if [ -x "$location" ] && python_version_supported "$location"; then
+                        shadowed="$location"
+                        break
+                    fi
+                done
+                if [ -n "$shadowed" ]; then
+                    log_info "Found $shadowed ($("$shadowed" --version 2>&1)), but an older Python earlier in your PATH shadows it."
+                    log_info "Fix: put $(dirname "$shadowed") earlier in your PATH, or re-run the installer with:"
+                    log_info "  curl -LsSf https://hf.co/cli/install.sh | env PATH=\"$(dirname "$shadowed"):\$PATH\" bash"
+                else
+                    log_info "On macOS: brew install python (or download Python 3.10+ from python.org)"
+                fi
                 ;;
             linux)
                 if command_exists apt-get || command_exists apt; then


### PR DESCRIPTION
Fixes #4754.

## Summary

- When the installer rejects a Python candidate, the warning now says *where* it lives (e.g. `python3 (/usr/bin/python3) is Python 3.9.6 ...`), on all OSes.
- On macOS, before suggesting `brew install python`, the failure path now checks `/opt/homebrew/bin/python3` and `/usr/local/bin/python3`. If a suitable Python is already there but shadowed by an older one earlier in `PATH` (the situation in #4754: Apple's 3.9.6 in `/usr/bin` wins over Homebrew's 3.14), it says so instead of telling the user to install something they already have.

Before (reporter's situation, reproduced locally by putting `/usr/bin` ahead of `/opt/homebrew/bin`):

```
[WARNING] python3 detected (Python 3.9.6) but Python 3.10+ is required.
[ERROR] Python 3.10+ is required but was not found.
[INFO] On macOS: brew install python (or download Python 3.10+ from python.org)
```

After:

```
[WARNING] python3 (/usr/bin/python3) is Python 3.9.6 but Python 3.10+ is required.
[ERROR] Python 3.10+ is required but was not found.
[INFO] Found /opt/homebrew/bin/python3 (Python 3.14.6), but an older Python earlier in your PATH shadows it.
[INFO] Put /opt/homebrew/bin earlier in your PATH and re-run the installer.
```

When no suitable Python exists at those locations either, the message is unchanged:

```
[WARNING] python3 (/usr/bin/python3) is Python 3.9.6 but Python 3.10+ is required.
[ERROR] Python 3.10+ is required but was not found.
[INFO] On macOS: brew install python (or download Python 3.10+ from python.org)
```


Verified on macOS by running the actual script end to end: shadowed-PATH failure (output above), no-suitable-Python fallback, and a full hermetic install on a healthy PATH (`hf version` → 1.28.0, no new warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only installer log messages and macOS-specific guidance; no install logic, auth, or dependency resolution behavior.
> 
> **Overview**
> Improves **Hugging Face CLI installer** feedback when `ensure_python` rejects candidates or cannot find Python 3.10+.
> 
> Rejected candidates now log the **resolved binary path** (e.g. `python3 (/usr/bin/python3) is Python 3.9.6 ...`) instead of only the command name and version string.
> 
> On **macOS**, when no suitable `python3`/`python` is chosen from `PATH`, the script probes `/opt/homebrew/bin/python3` and `/usr/local/bin/python3`. If a 3.10+ binary exists there but is **shadowed** by an older interpreter earlier in `PATH`, it tells the user to reorder `PATH` rather than defaulting to “brew install python”. The existing brew/download hint remains when no suitable Python is found at those locations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72da420db39d74e6a8f1d5813ae8996de3d53b54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->