### PR TITLE
[CLI] Fix argument help rendering with click 8.5

### DIFF
--- a/src/huggingface_hub/cli/_framework.py
+++ b/src/huggingface_hub/cli/_framework.py
@@ -465,10 +465,12 @@ class HfArgument(click.Argument):
         hidden: bool = False,
         **attrs: Any,
     ) -> None:
-        self.help = help
         self.show_default = show_default
         self.hidden = hidden
         super().__init__(param_decls, **attrs)
+        # Set *after* ``super().__init__``: Click >= 8.5 gives ``Argument`` its own ``help``
+        # parameter and resets ``self.help`` to ``None`` in its constructor.
+        self.help = help
 
     def make_metavar(self, ctx: click.Context) -> str:
         if self.metavar is not None:
@@ -548,6 +550,12 @@ def _format_params(command: click.Command, ctx: click.Context, formatter: click.
 class HfCommand(click.Command):
     """Leaf command that renders arguments and options in separate help sections."""
 
+    def format_arguments(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
+        # Click >= 8.5 added a `format_arguments` step to `format_help` that prints its own
+        # "Positional arguments" section. `_format_params` already lists arguments (Typer-style),
+        # so this override avoids printing them twice. Never called on Click < 8.5.
+        return None
+
     def format_options(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
         _format_params(self, ctx, formatter)
 
@@ -599,6 +607,10 @@ class HfGroup(click.Group):
 
     #: Command class used by ``@group.command()`` unless overridden per call.
     command_class: type[click.Command] = HfCommand
+
+    def format_arguments(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
+        # See `HfCommand.format_arguments`.
+        return None
 
     def format_options(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
         _format_params(self, ctx, formatter)

--- a/tests/test_cli_framework.py
+++ b/tests/test_cli_framework.py
@@ -206,6 +206,10 @@ class TestHelpRecords:
 
         out = self._help(f)
         assert "REPO_ID" in out and "the repo" in out and "[required]" in out
+        # Click >= 8.5 renders its own "Positional arguments" section on top of ours; make sure
+        # it stays suppressed so arguments are not listed twice.
+        assert "Positional arguments" not in out
+        assert out.count("the repo") == 1
 
     def test_bool_flag_default_string(self):
         def f(force: Annotated[bool, Option(help="force it")] = False): ...


### PR DESCRIPTION
## Summary

`click` 8.5.0 (released 2026-08-26) broke the CLI's argument help. Two changes, both from [pallets/click#3473](https://github.com/pallets/click/pull/3473):

- **`click.Argument` gained a `help` parameter** and its `__init__` now assigns `self.help = help` (default `None`). `HfArgument.__init__` set `self.help` *before* calling `super().__init__()`, so click overwrote it → argument descriptions vanished from `--help` and from the generated `cli.md`. Fix: assign it after the `super()` call.
- **`Command.format_help` gained a `format_arguments()` step** printing a native `Positional arguments:` section, on top of the `Arguments:` section `_format_params` already renders. Fix: no-op `format_arguments` override on `HfCommand`/`HfGroup` (never called on click < 8.5).

This is what produced the mystery docs diff in #4756: the nightly hardware-flavors bot runs `make style` with unpinned deps, so it regenerated `cli.md` without any argument descriptions.

**Still compatible with click 8.4**, so this replaces the cap in #4753 — no `<8.5.0` cap and no floor bump. I did check whether requiring `click>=8.5.0` would let us drop code instead: it wouldn't. Click's native section is titled `Positional arguments`, returns nothing when help is unset, and drops our `[default: …; required]` suffix, so we keep rendering arguments ourselves either way — bumping the floor would just force a brand-new click on every user for no gain.

Since already-released versions allow `click<9`, they're broken on fresh installs today — worth a patch release.

## Before / after with click 8.5.0

Before:

```
$ hf buckets cp --help
Positional arguments:
  SRC    [required]
  [DST]

Arguments:
  SRC    [required]
  [DST]
```

After (identical to click 8.4.2 output):

```
$ hf buckets cp --help
Arguments:
  SRC    Source: local file, hf:// URI (repo or bucket), or - for stdin.
         [required]
  [DST]  Destination: local path, hf:// URI (repo or bucket), or - for stdout.
```

## Verification

Ran everything against click 8.4.2 and 8.5.0 side by side:

- Dumped `--help` for every command in the tree (7115 lines): byte-identical between the two click versions, and identical to pre-fix output on 8.4.2.
- Generated `cli.md` matches the committed file under both versions.
- `tests/test_cli.py` (350) + `test_cli_framework/errors/output/generate_cli_reference` (79) pass under both. `make quality` green.

`test_argument_renders_help_and_required` already failed on `main` under click 8.5 (so did `test_annotated_argument`) — I extended it to also cover the duplicate-section half, which nothing caught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only CLI help formatting in the internal Click framework; no auth, network, or data-handling paths.
> 
> **Overview**
> **Restores positional argument help and removes duplicate help sections** after Click 8.5 changed how `Argument` and `format_help` work.
> 
> `HfArgument` now assigns `self.help` **after** `super().__init__()`, because Click 8.5’s `Argument` constructor sets `help` to `None` and overwrote values set earlier—so descriptions disappeared from `--help` and generated `cli.md`.
> 
> `HfCommand` and `HfGroup` override `format_arguments` as a no-op so Click 8.5’s new **Positional arguments** block does not appear alongside the existing Typer-style **Arguments** section from `_format_params`. Behavior on Click &lt; 8.5 is unchanged (that hook is not used).
> 
> Tests assert help text is present once and that **Positional arguments** never appears in help output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65d94e8926ec00c1181923aa10818ce5181d8d5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->