### PR TITLE
[experimental] feat(buckets): continuous/watch sync with volatility-aware uploads

### DIFF
--- a/docs/source/en/guides/buckets.md
+++ b/docs/source/en/guides/buckets.md
@@ -709,21 +709,21 @@ A continuous sync runs unattended, so it must not upload a file that is still be
 
 This is on by default and needs no flags. Files that are simply sitting on disk are **not** delayed — calmness is measured from the file's own mtime, so a directory of static files syncs immediately on the first pass. Only files actually being written wait.
 
-While a file is waiting, the sync says so, along with how long it has been quiet and how long it needs:
+On a terminal, watch mode draws a small panel that repaints in place rather than scrolling — it shows what is being watched, the calm period in force, and a row per file that has changed:
 
 ```text
-Continuous sync: ./data -> hf://buckets/user/my-bucket (every 5s, calm period 60s (<=1GiB) to 10m00s (>=10GiB), Ctrl-C to stop)
-  waiting: train.log (changed 3s ago, needs 60s quiet)
-  waiting: model.safetensors (changed 12s ago, needs 2m10s quiet)
-  upload: config.json (new file)
-Pass 4: 1 file(s) in 2s.
+watching:: ./data → hf://buckets/username/my-bucket
+calm 60s (≤1GiB) → 10m00s (≥10GiB)   lazy mode active
+
+2 files changed
+  train.log               ▅▅  ██████░░   45s/1m00s  ready in 15s
+  model-00001.safetensors ▁   ████████      stable  eta 4m10s
+uploaded 1 file in 2s
 ```
 
-Once a file has been quiet long enough it is uploaded, and the observed rate of change is reported alongside it:
+Each row carries two meters. The first is the **churn meter**, showing how rapidly the file is changing (`▇▇▇` for a write every second or two, down to `▁` for a file that has settled; blank until there are two samples to compare). The second is the **stability meter**, showing progress towards the calm period, with the elapsed/required times beside it. The tail says what has to happen next: `ready in 15s` while a file is still settling, or `eta 4m10s` — the predicted upload time — once it is stable.
 
-```text
-  upload: train.log (size differs, changes ~5s apart)
-```
+When output is not a terminal (redirected to a log file, or running under a supervisor), the panel degrades to plain appended lines, and a file is reported only when its status actually changes rather than on every pass.
 
 To override the ramp, use `--calm-time` for a fixed period regardless of size, or tune the two anchors:
 
@@ -749,7 +749,7 @@ A file that is appended to forever — an active log with a write every few seco
 A large file can pass the calm check and *still* be a bad upload: if it changes every few minutes and the upload itself would take longer than that, the copy is stale before it lands and the bandwidth is wasted. Continuous sync predicts this from the file's observed rate of change and the measured upload throughput, and refuses to start an upload that would be overtaken at least twice while in flight:
 
 ```text
-  waiting: checkpoint.safetensors (~4m10s upload would be overtaken ~3x)
+  checkpoint.safetensors  ▃   ████████      stable  eta 4m10s, overtaken ~3x
 ```
 
 Throughput is learned from the uploads it actually performs, so the estimate improves as the sync runs. The file is uploaded on a later pass, once it has calmed down enough for the upload to finish before the next write.

--- a/docs/source/en/guides/buckets.md
+++ b/docs/source/en/guides/buckets.md
@@ -677,6 +677,33 @@ The filter file uses `+` (include) and `-` (exclude) prefixes. Lines starting wi
 + *.json
 ```
 
+### Continuous sync
+
+By default `sync` runs a single pass and exits. Pass `--continuous` to keep it running, re-syncing on an interval until you interrupt it with `Ctrl-C`. This is useful for mirroring a job's output directory to a bucket while the job is still writing to it:
+
+```bash
+# Mirror ./checkpoints to the bucket, re-checking every 30s (default)
+>>> hf buckets sync ./checkpoints hf://buckets/username/my-bucket --continuous
+
+# Check more often, and only ship model weights
+>>> hf buckets sync ./checkpoints hf://buckets/username/my-bucket --continuous --interval 10 --include "*.safetensors"
+```
+
+Or via Python:
+
+```py
+>>> sync_bucket("./checkpoints", "hf://buckets/username/my-bucket", continuous=True, interval=10)
+```
+
+Each pass recomputes the plan from scratch, so only files that actually changed are transferred. A pass that fails (network blip, Hub outage) is logged and retried with exponential backoff rather than stopping the loop.
+
+Because a continuous sync runs unattended, two safety rules apply:
+
+- **Files still being written are skipped.** A file modified within the last `--settle-time` seconds (default `5`) is left for a later pass, so a half-written file isn't uploaded. Set `--settle-time 0` to disable this if your writes are atomic.
+- **`--delete` is not allowed with `--continuous`.** A transient local failure would otherwise propagate deletions to your bucket with nobody watching. Run a one-shot `sync --delete` when you want to prune the remote.
+
+`--continuous` also cannot be combined with `--plan`, `--apply`, or `--dry-run`, since those describe a single pass.
+
 ### Comparison modes
 
 By default, sync compares files using both size and modification time. You can customize this behavior:

--- a/docs/source/en/guides/buckets.md
+++ b/docs/source/en/guides/buckets.md
@@ -679,14 +679,14 @@ The filter file uses `+` (include) and `-` (exclude) prefixes. Lines starting wi
 
 ### Continuous sync
 
-By default `sync` runs a single pass and exits. Pass `--continuous` to keep it running, re-syncing on an interval until you interrupt it with `Ctrl-C`. This is useful for mirroring a job's output directory to a bucket while the job is still writing to it:
+By default `sync` runs a single pass and exits. Pass `--continuous` (or its alias `--watch`) to keep it running, re-syncing on an interval until you interrupt it with `Ctrl-C`. This is useful for mirroring a job's output directory to a bucket while the job is still writing to it:
 
 ```bash
 # Mirror ./checkpoints to the bucket, re-checking every 30s (default)
->>> hf buckets sync ./checkpoints hf://buckets/username/my-bucket --continuous
+>>> hf buckets sync ./checkpoints hf://buckets/username/my-bucket --watch
 
 # Check more often, and only ship model weights
->>> hf buckets sync ./checkpoints hf://buckets/username/my-bucket --continuous --interval 10 --include "*.safetensors"
+>>> hf buckets sync ./checkpoints hf://buckets/username/my-bucket --watch --interval 10 --include "*.safetensors"
 ```
 
 Or via Python:
@@ -695,14 +695,69 @@ Or via Python:
 >>> sync_bucket("./checkpoints", "hf://buckets/username/my-bucket", continuous=True, interval=10)
 ```
 
-Each pass recomputes the plan from scratch, so only files that actually changed are transferred. A pass that fails (network blip, Hub outage) is logged and retried with exponential backoff rather than stopping the loop.
+Each pass recomputes the plan from scratch, so only files that actually changed are transferred, and only the files actually uploaded are printed. A pass that fails (network blip, Hub outage) is logged and retried with exponential backoff rather than stopping the loop.
 
-Because a continuous sync runs unattended, two safety rules apply:
+#### Waiting for files to go quiet
 
-- **Files still being written are skipped.** A file modified within the last `--settle-time` seconds (default `5`) is left for a later pass, so a half-written file isn't uploaded. Set `--settle-time 0` to disable this if your writes are atomic.
+A continuous sync runs unattended, so it must not upload a file that is still being written. Each file has to sit **unchanged for a calm period** before it is eligible, and that period scales with size — a small log is cheap to re-upload if you guess wrong, a large checkpoint is not:
+
+| File size | Calm period |
+| --- | --- |
+| ≤ 1 GiB | 60s (`--calm-min`) |
+| between | log-interpolated |
+| ≥ 10 GiB | 10m (`--calm-max`) |
+
+This is on by default and needs no flags. Files that are simply sitting on disk are **not** delayed — calmness is measured from the file's own mtime, so a directory of static files syncs immediately on the first pass. Only files actually being written wait.
+
+While a file is waiting, the sync says so, along with how long it has been quiet and how long it needs:
+
+```text
+Continuous sync: ./data -> hf://buckets/user/my-bucket (every 5s, calm period 60s (<=1GiB) to 10m00s (>=10GiB), Ctrl-C to stop)
+  waiting: train.log (changed 3s ago, needs 60s quiet)
+  waiting: model.safetensors (changed 12s ago, needs 2m10s quiet)
+  upload: config.json (new file)
+Pass 4: 1 file(s) in 2s.
+```
+
+Once a file has been quiet long enough it is uploaded, and the observed rate of change is reported alongside it:
+
+```text
+  upload: train.log (size differs, changes ~5s apart)
+```
+
+To override the ramp, use `--calm-time` for a fixed period regardless of size, or tune the two anchors:
+
+```bash
+# Every file waits exactly 15s
+>>> hf buckets sync ./data hf://buckets/username/my-bucket --watch --calm-time 15
+
+# Upload sooner than the default, but still scale with size
+>>> hf buckets sync ./data hf://buckets/username/my-bucket --watch --calm-min 20 --calm-max 120
+
+# Disable the stability checks entirely (upload whatever is on disk each pass)
+>>> hf buckets sync ./data hf://buckets/username/my-bucket --watch --calm-time 0
+```
+
+<Tip warning={true}>
+
+A file that is appended to forever — an active log with a write every few seconds — never goes quiet, and so is never uploaded while the writer is running. It is uploaded once writing stops. If you want such a file shipped mid-flight, lower `--calm-time` to accept the risk of uploading a partial copy.
+
+</Tip>
+
+#### Expensive uploads that would be overtaken
+
+A large file can pass the calm check and *still* be a bad upload: if it changes every few minutes and the upload itself would take longer than that, the copy is stale before it lands and the bandwidth is wasted. Continuous sync predicts this from the file's observed rate of change and the measured upload throughput, and refuses to start an upload that would be overtaken at least twice while in flight:
+
+```text
+  waiting: checkpoint.safetensors (~4m10s upload would be overtaken ~3x)
+```
+
+Throughput is learned from the uploads it actually performs, so the estimate improves as the sync runs. The file is uploaded on a later pass, once it has calmed down enough for the upload to finish before the next write.
+
+#### Safety rules
+
 - **`--delete` is not allowed with `--continuous`.** A transient local failure would otherwise propagate deletions to your bucket with nobody watching. Run a one-shot `sync --delete` when you want to prune the remote.
-
-`--continuous` also cannot be combined with `--plan`, `--apply`, or `--dry-run`, since those describe a single pass.
+- **`--continuous` cannot be combined with `--plan`, `--apply`, or `--dry-run`**, since those describe a single pass.
 
 ### Comparison modes
 

--- a/src/huggingface_hub/_buckets.py
+++ b/src/huggingface_hub/_buckets.py
@@ -18,12 +18,14 @@ This module contains the core buckets logic used by both the CLI and the Python 
 
 import fnmatch
 import json
+import math
 import mimetypes
 import os
 import stat
 import sys
 import time
-from collections.abc import Iterator
+from collections import deque
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -562,22 +564,22 @@ def _compute_sync_plan(
     ignore_existing: bool = False,
     filter_matcher: FilterMatcher | None = None,
     status: Any | None = None,
-    min_age_seconds: float = 0.0,
+    local_filter: "Callable[[str, int, float], bool] | None" = None,
 ) -> SyncPlan:
     """Compute the sync plan by comparing source and destination.
 
     Args:
-        min_age_seconds (`float`, *optional*, defaults to `0.0`):
-            Ignore local files modified more recently than this many seconds ago. Used by continuous sync to
-            avoid uploading a file that is still being written. Only meaningful in the upload direction, and only
-            safe while ``delete`` is False -- an ignored file is invisible to the comparison, so it would otherwise
-            look like a deletion candidate on the remote side.
+        local_filter (`Callable[[str, int, float], bool]`, *optional*):
+            Called as ``(rel_path, size, mtime_ms)`` for every local file; return False to leave the file out of
+            this plan entirely. Used by continuous sync to hold back files that are still being written. Only
+            meaningful in the upload direction, and only safe while ``delete`` is False -- an excluded file is
+            invisible to the comparison, so it would otherwise look like a deletion candidate on the remote side.
 
     Returns:
         SyncPlan with all operations to be performed
     """
-    if min_age_seconds and delete:
-        raise ValueError("min_age_seconds cannot be combined with delete: unsettled files would look deleted.")
+    if local_filter is not None and delete:
+        raise ValueError("local_filter cannot be combined with delete: held-back files would look deleted.")
     filter_matcher = filter_matcher or FilterMatcher()
     is_upload = not _is_bucket_path(source) and _is_bucket_path(dest)
     is_download = _is_bucket_path(source) and not _is_bucket_path(dest)
@@ -603,13 +605,11 @@ def _compute_sync_plan(
 
         # Get local and remote file lists
         local_files = {}
-        unsettled = 0
-        settle_cutoff_ms = (time.time() - min_age_seconds) * 1000 if min_age_seconds else None
+        held_back = 0
         for rel_path, size, mtime_ms in _list_local_files(local_path):
-            if settle_cutoff_ms is not None and mtime_ms > settle_cutoff_ms:
-                # Still being written (or written a moment ago). Leave it for a later pass rather than
-                # uploading a torn copy.
-                unsettled += 1
+            if local_filter is not None and not local_filter(rel_path, size, mtime_ms):
+                # Still being written. Leave it for a later pass rather than uploading a torn copy.
+                held_back += 1
                 continue
             if filter_matcher.matches(rel_path):
                 local_files[rel_path] = (size, mtime_ms)
@@ -617,8 +617,8 @@ def _compute_sync_plan(
                 status.update(f"Scanning local directory ({len(local_files)} files)")
         if status:
             status.done(f"Scanning local directory ({len(local_files)} files)")
-        if unsettled:
-            logger.debug(f"Skipping {unsettled} local file(s) modified within the last {min_age_seconds}s.")
+        if held_back:
+            logger.debug(f"Holding back {held_back} local file(s) that are still changing.")
 
         remote_files = {}
         if status:
@@ -1016,10 +1016,208 @@ def _print_plan_summary(plan: SyncPlan) -> None:
 
 
 DEFAULT_SYNC_INTERVAL = 30.0
-DEFAULT_SYNC_SETTLE_TIME = 5.0
 # A failing pass backs off exponentially from the interval up to this ceiling, so a Hub outage doesn't turn
 # into a tight retry loop against the API.
 MAX_SYNC_BACKOFF = 300.0
+
+# ── Volatility detection ──────────────────────────────────────────────────────
+#
+# A continuous sync must not upload a file that is still being written. The rule is "wait until the file has
+# been quiet for a while", and how long "a while" is scales with the file: a 4 KB log settling for a minute is
+# cheap insurance, whereas a 20 GB checkpoint being written by a training job needs far longer before it is
+# worth spending an upload on. The anchors below are the defaults the ramp interpolates between.
+CALM_SMALL_SIZE = 1024**3  # 1 GiB -- at or below this, wait DEFAULT_CALM_MIN
+CALM_LARGE_SIZE = 10 * 1024**3  # 10 GiB -- at or above this, wait DEFAULT_CALM_MAX
+DEFAULT_CALM_MIN = 60.0  # seconds
+DEFAULT_CALM_MAX = 600.0  # seconds
+
+# A file whose observed changes average closer together than this is "changing rapidly" -- reported as such,
+# and never uploaded regardless of the calm ramp.
+RAPID_CHANGE_SECONDS = 10.0
+
+# An upload predicted to take at least this long is expensive enough that it is worth refusing to start it when
+# the file is likely to change out from under us before it finishes.
+HIGH_ETA_SECONDS = 60.0
+# Refuse the upload if the file is predicted to change at least this many times while it is in flight.
+THRASH_CHANGE_LIMIT = 2.0
+# Throughput assumed until a real upload has been measured.
+ASSUMED_THROUGHPUT_BPS = 50 * 1024**2  # 50 MiB/s
+# How many inter-change intervals to average over.
+MAX_CHANGE_SAMPLES = 8
+
+
+def _calm_period_for_size(size: int, calm_min: float = DEFAULT_CALM_MIN, calm_max: float = DEFAULT_CALM_MAX) -> float:
+    """How long a file of this size must sit unchanged before it is considered safe to upload.
+
+    Flat at ``calm_min`` up to `CALM_SMALL_SIZE`, flat at ``calm_max`` from `CALM_LARGE_SIZE`, and a
+    log-interpolated ramp in between (size spans decades, so interpolating in log space is the honest choice).
+    """
+    if size <= CALM_SMALL_SIZE:
+        return calm_min
+    if size >= CALM_LARGE_SIZE:
+        return calm_max
+    ratio = math.log10(size / CALM_SMALL_SIZE) / math.log10(CALM_LARGE_SIZE / CALM_SMALL_SIZE)
+    return calm_min + ratio * (calm_max - calm_min)
+
+
+def _format_duration(seconds: float) -> str:
+    """Compact human duration: `4s`, `2m10s`, `1h03m`."""
+    seconds = max(0.0, seconds)
+    if seconds < 60:
+        return f"{seconds:.0f}s"
+    if seconds < 3600:
+        return f"{int(seconds // 60)}m{int(seconds % 60):02d}s"
+    return f"{int(seconds // 3600)}h{int((seconds % 3600) // 60):02d}m"
+
+
+@dataclass
+class FileStability:
+    """What we have observed about one local file across sync passes."""
+
+    size: int
+    mtime_ms: float
+    #: Wall-clock times at which we saw the file change.
+    change_times: Any = field(default_factory=lambda: deque(maxlen=MAX_CHANGE_SAMPLES))
+    #: Byte deltas for those same changes.
+    change_deltas: Any = field(default_factory=lambda: deque(maxlen=MAX_CHANGE_SAMPLES))
+
+    @property
+    def change_count(self) -> int:
+        return len(self.change_times)
+
+    @property
+    def mean_interval(self) -> float | None:
+        """Mean seconds between observed changes, or None with fewer than two samples."""
+        if len(self.change_times) < 2:
+            return None
+        spans = [b - a for a, b in zip(self.change_times, list(self.change_times)[1:])]
+        return sum(spans) / len(spans)
+
+    @property
+    def is_rapid(self) -> bool:
+        interval = self.mean_interval
+        return interval is not None and interval < RAPID_CHANGE_SECONDS
+
+
+@dataclass
+class StabilityVerdict:
+    """Why a file was uploaded or held back on this pass."""
+
+    calm: bool
+    reason: str
+    quiet_for: float
+    calm_required: float
+    mean_interval: float | None = None
+    eta: float | None = None
+    predicted_changes: float | None = None
+
+
+class StabilityTracker:
+    """Tracks per-file volatility so a continuous sync only uploads files that have gone quiet.
+
+    Calmness is judged from the file's own mtime rather than from when we first noticed it, so a directory of
+    static files syncs immediately on the first pass -- only files actually being written wait.
+    """
+
+    def __init__(
+        self,
+        calm_min: float = DEFAULT_CALM_MIN,
+        calm_max: float = DEFAULT_CALM_MAX,
+        calm_override: float | None = None,
+    ):
+        self.calm_min = calm_min
+        self.calm_max = calm_max
+        self.calm_override = calm_override
+        self._files: dict[str, FileStability] = {}
+        self._throughput_bps: float = ASSUMED_THROUGHPUT_BPS
+        self._measured = False
+
+    # -- observation --
+
+    def observe(self, path: str, size: int, mtime_ms: float, now: float | None = None) -> FileStability:
+        """Record the current state of a file, noting a change if it differs from last pass."""
+        now = time.time() if now is None else now
+        state = self._files.get(path)
+        if state is None:
+            state = FileStability(size=size, mtime_ms=mtime_ms)
+            self._files[path] = state
+            return state
+        if mtime_ms != state.mtime_ms or size != state.size:
+            state.change_times.append(now)
+            state.change_deltas.append(size - state.size)
+            state.size = size
+            state.mtime_ms = mtime_ms
+        return state
+
+    def forget(self, keep: set[str]) -> None:
+        """Drop state for files that no longer exist, so the tracker doesn't grow without bound."""
+        for path in [p for p in self._files if p not in keep]:
+            del self._files[path]
+
+    # -- decisions --
+
+    def calm_required(self, size: int) -> float:
+        if self.calm_override is not None:
+            return self.calm_override
+        return _calm_period_for_size(size, self.calm_min, self.calm_max)
+
+    def verdict(self, path: str, size: int, mtime_ms: float, now: float | None = None) -> StabilityVerdict:
+        """Decide whether `path` is quiet enough to upload, and explain why."""
+        now = time.time() if now is None else now
+        state = self.observe(path, size, mtime_ms, now)
+        required = self.calm_required(size)
+        quiet_for = max(0.0, now - mtime_ms / 1000)
+        interval = state.mean_interval
+
+        if required <= 0:
+            return StabilityVerdict(True, "stability checks disabled", quiet_for, required, interval)
+
+        if quiet_for < required:
+            return StabilityVerdict(
+                False,
+                f"changed {_format_duration(quiet_for)} ago, needs {_format_duration(required)} quiet",
+                quiet_for,
+                required,
+                interval,
+            )
+
+        # Note: we deliberately do NOT gate on `state.is_rapid` here. Reaching this point already means the
+        # file has been quiet for the full calm period, so it is not currently churning; `mean_interval` is
+        # drawn from samples that never expire, so gating on it would block a file that churned once and then
+        # settled -- forever. The observed rate is used below to predict the future, and for reporting.
+
+        # The file is quiet. Would it stay quiet long enough for the upload to finish?
+        eta = self.eta(size)
+        predicted = eta / interval if interval else None
+        if eta >= HIGH_ETA_SECONDS and predicted is not None and predicted >= THRASH_CHANGE_LIMIT:
+            return StabilityVerdict(
+                False,
+                f"~{_format_duration(eta)} upload would be overtaken ~{predicted:.0f}x",
+                quiet_for,
+                required,
+                interval,
+                eta,
+                predicted,
+            )
+
+        return StabilityVerdict(True, f"quiet for {_format_duration(quiet_for)}", quiet_for, required, interval, eta)
+
+    def is_calm(self, path: str, size: int, mtime_ms: float) -> bool:
+        """Predicate form, for use as `_compute_sync_plan(local_filter=...)`."""
+        return self.verdict(path, size, mtime_ms).calm
+
+    # -- throughput --
+
+    def eta(self, size: int) -> float:
+        return size / self._throughput_bps if self._throughput_bps > 0 else 0.0
+
+    def record_transfer(self, num_bytes: int, seconds: float) -> None:
+        """Fold a completed upload into the throughput estimate (EWMA once we have a real measurement)."""
+        if seconds <= 0 or num_bytes <= 0:
+            return
+        observed = num_bytes / seconds
+        self._throughput_bps = observed if not self._measured else 0.7 * self._throughput_bps + 0.3 * observed
+        self._measured = True
 
 
 def _sync_continuous_loop(
@@ -1029,7 +1227,7 @@ def _sync_continuous_loop(
     api: "HfApi",
     filter_matcher: FilterMatcher,
     interval: float,
-    settle_time: float,
+    tracker: StabilityTracker,
     ignore_times: bool,
     ignore_sizes: bool,
     existing: bool,
@@ -1037,12 +1235,15 @@ def _sync_continuous_loop(
     verbose: bool,
     quiet: bool,
 ) -> SyncPlan:
-    """Re-run a sync on an interval until interrupted.
+    """Re-run a sync on an interval until interrupted, uploading only files that have gone quiet.
 
     Each pass recomputes the plan from scratch -- `_compute_sync_plan` is a pure function of
     (source, dest, filters), so no state carries between passes and a crash mid-loop leaves nothing to
-    reconcile. Returns the plan from the final pass (on `KeyboardInterrupt`), so callers still get a
-    `SyncPlan` back as in one-shot mode.
+    reconcile. The one thing that *is* carried across passes is `tracker`, which watches how each local file
+    changes over time so that files still being written are held back (see `StabilityTracker`).
+
+    Returns the plan from the final pass (on `KeyboardInterrupt`), so callers still get a `SyncPlan` back as in
+    one-shot mode.
 
     Note: every pass re-lists the whole remote bucket. For large buckets on a short interval that is the
     dominant cost of the loop. Caching remote state across passes is possible in the upload direction --
@@ -1051,16 +1252,37 @@ def _sync_continuous_loop(
     last_plan = SyncPlan(source=source, dest=dest, timestamp=datetime.now(timezone.utc).isoformat())
     backoff = interval
     passes = 0
+    # Files held back on the previous pass, so we only announce a change of state rather than repeating
+    # ourselves every interval.
+    announced: dict[str, str] = {}
 
-    if not quiet:
-        # flush on every write: continuous mode is typically redirected to a log file, where Python's
-        # block buffering would otherwise hide all progress until the process exits.
-        print(f"Continuous sync: {source} -> {dest} (every {interval:g}s, Ctrl-C to stop)", flush=True)
+    def emit(msg: str = "") -> None:
+        # flush on every write: continuous mode is typically redirected to a log file, where Python's block
+        # buffering would otherwise hide all progress until the process exits.
+        if not quiet:
+            print(msg, flush=True)
+
+    if tracker.calm_override is not None:
+        calm_desc = f"calm period {_format_duration(tracker.calm_override)}"
+    else:
+        calm_desc = (
+            f"calm period {_format_duration(tracker.calm_min)} (<=1GiB) to "
+            f"{_format_duration(tracker.calm_max)} (>=10GiB)"
+        )
+    emit(f"Continuous sync: {source} -> {dest} (every {interval:g}s, {calm_desc}, Ctrl-C to stop)")
 
     try:
         while True:
             passes += 1
             started = time.monotonic()
+            held: dict[str, StabilityVerdict] = {}
+
+            def gate(rel_path: str, size: int, mtime_ms: float) -> bool:
+                verdict = tracker.verdict(rel_path, size, mtime_ms)
+                if not verdict.calm:
+                    held[rel_path] = verdict
+                return verdict.calm
+
             try:
                 status = StatusLine(enabled=not quiet)
                 last_plan = _compute_sync_plan(
@@ -1074,26 +1296,44 @@ def _sync_continuous_loop(
                     ignore_existing=ignore_existing,
                     filter_matcher=filter_matcher,
                     status=status,
-                    min_age_seconds=settle_time,
+                    local_filter=gate,
                 )
-                summary = last_plan.summary()
-                changed = int(summary["uploads"]) + int(summary["downloads"])
-                if changed:
-                    if not quiet:
-                        _print_plan_summary(last_plan)
-                        sys.stdout.flush()
-                        print("Syncing...", flush=True)
+
+                uploads = [op for op in last_plan.operations if op.action in ("upload", "download")]
+                if uploads:
+                    total_bytes = sum(op.size or 0 for op in uploads)
+                    for op in uploads:
+                        state = tracker._files.get(op.path)
+                        detail = ""
+                        if state is not None and state.mean_interval is not None:
+                            detail = f", changes ~{_format_duration(state.mean_interval)} apart"
+                        emit(f"  {op.action}: {op.path} ({op.reason}{detail})")
                     if quiet:
                         disable_progress_bars()
+                    transfer_started = time.monotonic()
                     try:
-                        _execute_plan(last_plan, api, verbose=verbose, status=status)
+                        _execute_plan(last_plan, api, verbose=False, status=status)
                     finally:
                         if quiet:
                             enable_progress_bars()
-                    if not quiet:
-                        print(f"Pass {passes}: synced {changed} file(s).", flush=True)
-                elif verbose and not quiet:
-                    print(f"Pass {passes}: nothing to sync.", flush=True)
+                    elapsed = time.monotonic() - transfer_started
+                    tracker.record_transfer(total_bytes, elapsed)
+                    emit(f"Pass {passes}: {len(uploads)} file(s) in {_format_duration(elapsed)}.")
+                    announced.clear()
+
+                # Report held-back files, but only when their reason changes -- otherwise a file being written
+                # for an hour would print the same line every interval.
+                for path, verdict in sorted(held.items()):
+                    if announced.get(path) != verdict.reason:
+                        emit(f"  waiting: {path} ({verdict.reason})")
+                        announced[path] = verdict.reason
+                for path in [p for p in announced if p not in held]:
+                    del announced[path]
+
+                if not uploads and not held and verbose:
+                    emit(f"Pass {passes}: nothing to sync.")
+
+                tracker.forget(set(held) | {op.path for op in last_plan.operations})
                 backoff = interval
             except KeyboardInterrupt:
                 raise
@@ -1101,8 +1341,7 @@ def _sync_continuous_loop(
                 # Keep the loop alive across transient Hub/network failures -- the whole point of continuous
                 # mode is that it outlives them. Back off so an outage doesn't hammer the API.
                 logger.warning(f"Sync pass {passes} failed: {e}")
-                if not quiet:
-                    print(f"Pass {passes} failed ({e}); retrying in {backoff:g}s.", flush=True)
+                emit(f"Pass {passes} failed ({e}); retrying in {_format_duration(backoff)}.")
                 time.sleep(backoff)
                 backoff = min(backoff * 2, MAX_SYNC_BACKOFF)
                 continue
@@ -1110,8 +1349,7 @@ def _sync_continuous_loop(
             # Sleep the remainder of the interval, so a slow pass doesn't compound the period.
             time.sleep(max(0.0, interval - (time.monotonic() - started)))
     except KeyboardInterrupt:
-        if not quiet:
-            print(f"\nStopped after {passes} pass(es).", flush=True)
+        emit(f"\nStopped after {passes} pass(es).")
 
     return last_plan
 
@@ -1134,7 +1372,9 @@ def sync_bucket_internal(
     dry_run: bool = False,
     continuous: bool = False,
     interval: float = DEFAULT_SYNC_INTERVAL,
-    settle_time: float = DEFAULT_SYNC_SETTLE_TIME,
+    calm_time: float | None = None,
+    calm_min: float = DEFAULT_CALM_MIN,
+    calm_max: float = DEFAULT_CALM_MAX,
     verbose: bool = False,
     quiet: bool = False,
     token: bool | str | None = None,
@@ -1180,9 +1420,13 @@ def sync_bucket_internal(
             combined with ``delete``, ``plan``, ``apply`` or ``dry_run``.
         interval (`float`, *optional*, defaults to `30.0`):
             Seconds between passes in continuous mode.
-        settle_time (`float`, *optional*, defaults to `5.0`):
-            In continuous mode, ignore local files modified within this many seconds, so a file that is
-            still being written isn't uploaded half-finished. Set to 0 to disable.
+        calm_time (`float`, *optional*):
+            Fixed number of seconds a file must sit unchanged before it is uploaded, overriding the
+            size-based ramp. `0` disables the stability checks entirely.
+        calm_min (`float`, *optional*, defaults to `60.0`):
+            Calm period for files at or below 1 GiB.
+        calm_max (`float`, *optional*, defaults to `600.0`):
+            Calm period for files at or above 10 GiB. Sizes in between are log-interpolated.
         verbose (`bool`, *optional*, defaults to `False`):
             Show detailed per-file operations.
         quiet (`bool`, *optional*, defaults to `False`):
@@ -1319,8 +1563,12 @@ def sync_bucket_internal(
             )
         if interval <= 0:
             raise ValueError("interval must be greater than 0.")
-        if settle_time < 0:
-            raise ValueError("settle_time cannot be negative.")
+        if calm_time is not None and calm_time < 0:
+            raise ValueError("calm_time cannot be negative.")
+        if calm_min < 0 or calm_max < 0:
+            raise ValueError("calm_min and calm_max cannot be negative.")
+        if calm_max < calm_min:
+            raise ValueError("calm_max cannot be smaller than calm_min.")
 
     # Validate local path
     if source_is_bucket:
@@ -1348,7 +1596,7 @@ def sync_bucket_internal(
             api=api,
             filter_matcher=filter_matcher,
             interval=interval,
-            settle_time=settle_time,
+            tracker=StabilityTracker(calm_min=calm_min, calm_max=calm_max, calm_override=calm_time),
             ignore_times=ignore_times,
             ignore_sizes=ignore_sizes,
             existing=existing,

--- a/src/huggingface_hub/_buckets.py
+++ b/src/huggingface_hub/_buckets.py
@@ -562,12 +562,22 @@ def _compute_sync_plan(
     ignore_existing: bool = False,
     filter_matcher: FilterMatcher | None = None,
     status: Any | None = None,
+    min_age_seconds: float = 0.0,
 ) -> SyncPlan:
     """Compute the sync plan by comparing source and destination.
+
+    Args:
+        min_age_seconds (`float`, *optional*, defaults to `0.0`):
+            Ignore local files modified more recently than this many seconds ago. Used by continuous sync to
+            avoid uploading a file that is still being written. Only meaningful in the upload direction, and only
+            safe while ``delete`` is False -- an ignored file is invisible to the comparison, so it would otherwise
+            look like a deletion candidate on the remote side.
 
     Returns:
         SyncPlan with all operations to be performed
     """
+    if min_age_seconds and delete:
+        raise ValueError("min_age_seconds cannot be combined with delete: unsettled files would look deleted.")
     filter_matcher = filter_matcher or FilterMatcher()
     is_upload = not _is_bucket_path(source) and _is_bucket_path(dest)
     is_download = _is_bucket_path(source) and not _is_bucket_path(dest)
@@ -593,13 +603,22 @@ def _compute_sync_plan(
 
         # Get local and remote file lists
         local_files = {}
+        unsettled = 0
+        settle_cutoff_ms = (time.time() - min_age_seconds) * 1000 if min_age_seconds else None
         for rel_path, size, mtime_ms in _list_local_files(local_path):
+            if settle_cutoff_ms is not None and mtime_ms > settle_cutoff_ms:
+                # Still being written (or written a moment ago). Leave it for a later pass rather than
+                # uploading a torn copy.
+                unsettled += 1
+                continue
             if filter_matcher.matches(rel_path):
                 local_files[rel_path] = (size, mtime_ms)
             if status:
                 status.update(f"Scanning local directory ({len(local_files)} files)")
         if status:
             status.done(f"Scanning local directory ({len(local_files)} files)")
+        if unsettled:
+            logger.debug(f"Skipping {unsettled} local file(s) modified within the last {min_age_seconds}s.")
 
         remote_files = {}
         if status:
@@ -996,6 +1015,107 @@ def _print_plan_summary(plan: SyncPlan) -> None:
 # =============================================================================
 
 
+DEFAULT_SYNC_INTERVAL = 30.0
+DEFAULT_SYNC_SETTLE_TIME = 5.0
+# A failing pass backs off exponentially from the interval up to this ceiling, so a Hub outage doesn't turn
+# into a tight retry loop against the API.
+MAX_SYNC_BACKOFF = 300.0
+
+
+def _sync_continuous_loop(
+    *,
+    source: str,
+    dest: str,
+    api: "HfApi",
+    filter_matcher: FilterMatcher,
+    interval: float,
+    settle_time: float,
+    ignore_times: bool,
+    ignore_sizes: bool,
+    existing: bool,
+    ignore_existing: bool,
+    verbose: bool,
+    quiet: bool,
+) -> SyncPlan:
+    """Re-run a sync on an interval until interrupted.
+
+    Each pass recomputes the plan from scratch -- `_compute_sync_plan` is a pure function of
+    (source, dest, filters), so no state carries between passes and a crash mid-loop leaves nothing to
+    reconcile. Returns the plan from the final pass (on `KeyboardInterrupt`), so callers still get a
+    `SyncPlan` back as in one-shot mode.
+
+    Note: every pass re-lists the whole remote bucket. For large buckets on a short interval that is the
+    dominant cost of the loop. Caching remote state across passes is possible in the upload direction --
+    this process is the only writer -- but is deliberately left out of this first version.
+    """
+    last_plan = SyncPlan(source=source, dest=dest, timestamp=datetime.now(timezone.utc).isoformat())
+    backoff = interval
+    passes = 0
+
+    if not quiet:
+        # flush on every write: continuous mode is typically redirected to a log file, where Python's
+        # block buffering would otherwise hide all progress until the process exits.
+        print(f"Continuous sync: {source} -> {dest} (every {interval:g}s, Ctrl-C to stop)", flush=True)
+
+    try:
+        while True:
+            passes += 1
+            started = time.monotonic()
+            try:
+                status = StatusLine(enabled=not quiet)
+                last_plan = _compute_sync_plan(
+                    source=source,
+                    dest=dest,
+                    api=api,
+                    delete=False,  # refused upstream; see sync_bucket_internal
+                    ignore_times=ignore_times,
+                    ignore_sizes=ignore_sizes,
+                    existing=existing,
+                    ignore_existing=ignore_existing,
+                    filter_matcher=filter_matcher,
+                    status=status,
+                    min_age_seconds=settle_time,
+                )
+                summary = last_plan.summary()
+                changed = int(summary["uploads"]) + int(summary["downloads"])
+                if changed:
+                    if not quiet:
+                        _print_plan_summary(last_plan)
+                        sys.stdout.flush()
+                        print("Syncing...", flush=True)
+                    if quiet:
+                        disable_progress_bars()
+                    try:
+                        _execute_plan(last_plan, api, verbose=verbose, status=status)
+                    finally:
+                        if quiet:
+                            enable_progress_bars()
+                    if not quiet:
+                        print(f"Pass {passes}: synced {changed} file(s).", flush=True)
+                elif verbose and not quiet:
+                    print(f"Pass {passes}: nothing to sync.", flush=True)
+                backoff = interval
+            except KeyboardInterrupt:
+                raise
+            except Exception as e:
+                # Keep the loop alive across transient Hub/network failures -- the whole point of continuous
+                # mode is that it outlives them. Back off so an outage doesn't hammer the API.
+                logger.warning(f"Sync pass {passes} failed: {e}")
+                if not quiet:
+                    print(f"Pass {passes} failed ({e}); retrying in {backoff:g}s.", flush=True)
+                time.sleep(backoff)
+                backoff = min(backoff * 2, MAX_SYNC_BACKOFF)
+                continue
+
+            # Sleep the remainder of the interval, so a slow pass doesn't compound the period.
+            time.sleep(max(0.0, interval - (time.monotonic() - started)))
+    except KeyboardInterrupt:
+        if not quiet:
+            print(f"\nStopped after {passes} pass(es).", flush=True)
+
+    return last_plan
+
+
 def sync_bucket_internal(
     source: str | None = None,
     dest: str | None = None,
@@ -1012,6 +1132,9 @@ def sync_bucket_internal(
     plan: str | None = None,
     apply: str | None = None,
     dry_run: bool = False,
+    continuous: bool = False,
+    interval: float = DEFAULT_SYNC_INTERVAL,
+    settle_time: float = DEFAULT_SYNC_SETTLE_TIME,
     verbose: bool = False,
     quiet: bool = False,
     token: bool | str | None = None,
@@ -1052,6 +1175,14 @@ def sync_bucket_internal(
             Apply a previously saved plan file. When set, ``source`` and ``dest`` are not needed.
         dry_run (`bool`, *optional*, defaults to `False`):
             Print sync plan to stdout as JSONL without executing.
+        continuous (`bool`, *optional*, defaults to `False`):
+            Keep syncing on an interval until interrupted, instead of running a single pass. Cannot be
+            combined with ``delete``, ``plan``, ``apply`` or ``dry_run``.
+        interval (`float`, *optional*, defaults to `30.0`):
+            Seconds between passes in continuous mode.
+        settle_time (`float`, *optional*, defaults to `5.0`):
+            In continuous mode, ignore local files modified within this many seconds, so a file that is
+            still being written isn't uploaded half-finished. Set to 0 to disable.
         verbose (`bool`, *optional*, defaults to `False`):
             Show detailed per-file operations.
         quiet (`bool`, *optional*, defaults to `False`):
@@ -1130,6 +1261,8 @@ def sync_bucket_internal(
             raise ValueError("Cannot specify ignore_existing when using apply.")
         if dry_run:
             raise ValueError("Cannot specify dry_run when using apply.")
+        if continuous:
+            raise ValueError("Cannot specify continuous when using apply.")
 
         sync_plan = _load_plan(apply)
         status = StatusLine(enabled=not quiet)
@@ -1172,6 +1305,23 @@ def sync_bucket_internal(
     if dry_run and plan:
         raise ValueError("Cannot specify both dry_run and plan.")
 
+    if continuous:
+        # A plan/dry-run describes one pass; neither composes with a loop.
+        if plan or dry_run:
+            raise ValueError("Cannot specify continuous with plan or dry_run.")
+        if delete:
+            # Deliberately refused rather than merely warned about: an unattended loop that propagates
+            # deletions turns one transient local failure (a directory briefly unreadable, a disk hiccup)
+            # into unrecoverable remote data loss, with nobody watching. Run a one-shot sync for deletes.
+            raise ValueError(
+                "Cannot specify delete with continuous: an unattended loop could propagate accidental "
+                "local deletions to the remote. Run a one-shot `sync --delete` instead."
+            )
+        if interval <= 0:
+            raise ValueError("interval must be greater than 0.")
+        if settle_time < 0:
+            raise ValueError("settle_time cannot be negative.")
+
     # Validate local path
     if source_is_bucket:
         if os.path.exists(dest) and not os.path.isdir(dest):
@@ -1190,6 +1340,22 @@ def sync_bucket_internal(
         exclude_patterns=exclude,
         filter_rules=filter_rules,
     )
+
+    if continuous:
+        return _sync_continuous_loop(
+            source=source,
+            dest=dest,
+            api=api,
+            filter_matcher=filter_matcher,
+            interval=interval,
+            settle_time=settle_time,
+            ignore_times=ignore_times,
+            ignore_sizes=ignore_sizes,
+            existing=existing,
+            ignore_existing=ignore_existing,
+            verbose=verbose,
+            quiet=quiet,
+        )
 
     # Compute sync plan
     status = StatusLine(enabled=not quiet and not dry_run)

--- a/src/huggingface_hub/_buckets.py
+++ b/src/huggingface_hub/_buckets.py
@@ -21,6 +21,7 @@ import json
 import math
 import mimetypes
 import os
+import shutil
 import stat
 import sys
 import time
@@ -1220,6 +1221,162 @@ class StabilityTracker:
         self._measured = True
 
 
+# ── Watch display ─────────────────────────────────────────────────────────────
+
+
+@dataclass
+class WatchRow:
+    """One file's line in the watch display."""
+
+    path: str
+    quiet_for: float
+    calm_required: float
+    state: Literal["waiting", "ready", "deferred"]
+    mean_interval: float | None = None
+    eta: float | None = None
+    predicted_changes: float | None = None
+    note: str = ""
+
+
+def _bar(fraction: float, width: int = 8) -> str:
+    filled = min(width, max(0, round(fraction * width)))
+    return "\u2588" * filled + "\u2591" * (width - filled)
+
+
+def _churn_meter(interval: float | None) -> str:
+    """Three-cell meter of how rapidly a file is changing. Blank until we have two samples."""
+    if interval is None:
+        return "   "
+    if interval < 2:
+        return "\u2587\u2587\u2587"
+    if interval < 5:
+        return "\u2585\u2585 "
+    if interval < RAPID_CHANGE_SECONDS:
+        return "\u2583  "
+    return "\u2581  "
+
+
+class WatchDisplay:
+    """Minimal in-place TUI for `--watch`.
+
+    Repaints a small fixed block each pass rather than appending, so a long watch doesn't scroll the terminal.
+    Falls back to plain appended lines when stdout is not a TTY -- watch output is routinely redirected to a
+    log file, where cursor movement would be garbage.
+    """
+
+    def __init__(self, source: str, dest: str, calm_desc: str, quiet: bool = False):
+        self.source = source
+        self.dest = dest
+        self.calm_desc = calm_desc
+        self.quiet = quiet
+        self.tui = not quiet and sys.stdout.isatty()
+        self._painted = 0
+        self._announced: dict[str, str] = {}
+
+    # -- plain-mode helpers --
+
+    def _plain(self, msg: str) -> None:
+        if not self.quiet:
+            # flush on every write: watch output is typically redirected to a log file, where Python's block
+            # buffering would otherwise hide all progress until the process exits.
+            print(msg, flush=True)
+
+    def start(self) -> None:
+        if not self.tui:
+            self._plain(f"watching:: {self.source} -> {self.dest}")
+            self._plain(f"calm {self.calm_desc} | lazy mode active")
+
+    # -- painting --
+
+    def _compose(self, rows: list[WatchRow], last_event: str) -> list[str]:
+        width = max(40, shutil.get_terminal_size((100, 24)).columns)
+        name_width = min(38, max(12, *(len(r.path) for r in rows))) if rows else 12
+
+        lines = [
+            f"\033[1mwatching::\033[0m {self.source} \u2192 {self.dest}",
+            f"\033[90mcalm {self.calm_desc}   lazy mode active\033[0m",
+            "",
+        ]
+        if not rows:
+            lines.append("\033[90mno changes\033[0m")
+        else:
+            noun = "file" if len(rows) == 1 else "files"
+            lines.append(f"{len(rows)} {noun} changed")
+            for row in sorted(rows, key=lambda r: r.path):
+                name = row.path if len(row.path) <= name_width else "\u2026" + row.path[-(name_width - 1) :]
+                churn = _churn_meter(row.mean_interval)
+                if row.state == "waiting":
+                    frac = row.quiet_for / row.calm_required if row.calm_required else 1.0
+                    meter = _bar(frac)
+                    progress = f"{_format_duration(row.quiet_for)}/{_format_duration(row.calm_required)}"
+                    tail = f"ready in {_format_duration(max(0.0, row.calm_required - row.quiet_for))}"
+                elif row.state == "deferred":
+                    meter = _bar(1.0)
+                    progress = "stable"
+                    # Keep the panel terse; the full reason is in the plain/log rendering.
+                    tail = (
+                        f"eta {_format_duration(row.eta)}, overtaken ~{row.predicted_changes:.0f}x"
+                        if row.predicted_changes and row.eta is not None
+                        else "held"
+                    )
+                else:
+                    meter = _bar(1.0)
+                    progress = "stable"
+                    tail = f"eta {_format_duration(row.eta)}" if row.eta is not None else "uploading"
+                line = f"  {name:<{name_width}} {churn} {meter} {progress:>11}  \033[90m{tail}\033[0m"
+                lines.append(line[: width + 20])  # +20 slack for the ANSI escapes, which take no columns
+        if last_event:
+            lines.append(f"\033[90m{last_event}\033[0m")
+        return lines
+
+    def render(self, rows: list[WatchRow], last_event: str = "") -> None:
+        if self.quiet:
+            return
+        if not self.tui:
+            self._render_plain(rows, last_event)
+            return
+        lines = self._compose(rows, last_event)
+        out = []
+        if self._painted:
+            out.append(f"\033[{self._painted}A")  # back to the top of the previous block
+        for line in lines:
+            out.append("\033[2K" + line + "\n")
+        # Clear any lines left over from a taller previous frame.
+        for _ in range(max(0, self._painted - len(lines))):
+            out.append("\033[2K\n")
+        extra = max(0, self._painted - len(lines))
+        if extra:
+            out.append(f"\033[{extra}A")
+        sys.stdout.write("".join(out))
+        sys.stdout.flush()
+        self._painted = len(lines)
+
+    def _render_plain(self, rows: list[WatchRow], last_event: str) -> None:
+        """Append-only fallback: report a file only when its status changes, so logs stay readable."""
+        for row in sorted(rows, key=lambda r: r.path):
+            if row.state == "waiting":
+                msg = f"waiting: {row.path} ({_format_duration(row.quiet_for)} quiet of {_format_duration(row.calm_required)})"
+            elif row.state == "deferred":
+                msg = f"deferred: {row.path} ({row.note})"
+            else:
+                msg = f"ready: {row.path}"
+            if self._announced.get(row.path) != msg:
+                self._plain(f"  {msg}")
+                self._announced[row.path] = msg
+        for path in [p for p in self._announced if p not in {r.path for r in rows}]:
+            del self._announced[path]
+        if last_event:
+            self._plain(last_event)
+
+    def close(self, message: str) -> None:
+        if self.quiet:
+            return
+        if self.tui:
+            sys.stdout.write("\n")
+            sys.stdout.flush()
+        self._plain(message)
+
+
 def _sync_continuous_loop(
     *,
     source: str,
@@ -1239,8 +1396,8 @@ def _sync_continuous_loop(
 
     Each pass recomputes the plan from scratch -- `_compute_sync_plan` is a pure function of
     (source, dest, filters), so no state carries between passes and a crash mid-loop leaves nothing to
-    reconcile. The one thing that *is* carried across passes is `tracker`, which watches how each local file
-    changes over time so that files still being written are held back (see `StabilityTracker`).
+    reconcile. The two things that *are* carried across passes are `tracker`, which watches how each local file
+    changes over time so files still being written are held back (see `StabilityTracker`), and the display.
 
     Returns the plan from the final pass (on `KeyboardInterrupt`), so callers still get a `SyncPlan` back as in
     one-shot mode.
@@ -1252,24 +1409,14 @@ def _sync_continuous_loop(
     last_plan = SyncPlan(source=source, dest=dest, timestamp=datetime.now(timezone.utc).isoformat())
     backoff = interval
     passes = 0
-    # Files held back on the previous pass, so we only announce a change of state rather than repeating
-    # ourselves every interval.
-    announced: dict[str, str] = {}
-
-    def emit(msg: str = "") -> None:
-        # flush on every write: continuous mode is typically redirected to a log file, where Python's block
-        # buffering would otherwise hide all progress until the process exits.
-        if not quiet:
-            print(msg, flush=True)
 
     if tracker.calm_override is not None:
-        calm_desc = f"calm period {_format_duration(tracker.calm_override)}"
+        calm_desc = _format_duration(tracker.calm_override)
     else:
-        calm_desc = (
-            f"calm period {_format_duration(tracker.calm_min)} (<=1GiB) to "
-            f"{_format_duration(tracker.calm_max)} (>=10GiB)"
-        )
-    emit(f"Continuous sync: {source} -> {dest} (every {interval:g}s, {calm_desc}, Ctrl-C to stop)")
+        calm_desc = f"{_format_duration(tracker.calm_min)} (\u22641GiB) \u2192 {_format_duration(tracker.calm_max)} (\u226510GiB)"
+    display = WatchDisplay(source, dest, calm_desc, quiet=quiet)
+    display.start()
+    last_event = ""
 
     try:
         while True:
@@ -1284,7 +1431,6 @@ def _sync_continuous_loop(
                 return verdict.calm
 
             try:
-                status = StatusLine(enabled=not quiet)
                 last_plan = _compute_sync_plan(
                     source=source,
                     dest=dest,
@@ -1295,53 +1441,65 @@ def _sync_continuous_loop(
                     existing=existing,
                     ignore_existing=ignore_existing,
                     filter_matcher=filter_matcher,
-                    status=status,
+                    # No StatusLine: its scanning updates would fight the watch display for the terminal.
+                    status=None,
                     local_filter=gate,
                 )
 
-                uploads = [op for op in last_plan.operations if op.action in ("upload", "download")]
-                if uploads:
-                    total_bytes = sum(op.size or 0 for op in uploads)
-                    for op in uploads:
-                        state = tracker._files.get(op.path)
-                        detail = ""
-                        if state is not None and state.mean_interval is not None:
-                            detail = f", changes ~{_format_duration(state.mean_interval)} apart"
-                        emit(f"  {op.action}: {op.path} ({op.reason}{detail})")
-                    if quiet:
-                        disable_progress_bars()
+                transfers = [op for op in last_plan.operations if op.action in ("upload", "download")]
+                rows = [
+                    WatchRow(
+                        path=path,
+                        quiet_for=v.quiet_for,
+                        calm_required=v.calm_required,
+                        state="deferred" if v.predicted_changes else "waiting",
+                        mean_interval=v.mean_interval,
+                        eta=v.eta,
+                        predicted_changes=v.predicted_changes,
+                        note=v.reason,
+                    )
+                    for path, v in held.items()
+                ]
+                for op in transfers:
+                    state = tracker._files.get(op.path)
+                    rows.append(
+                        WatchRow(
+                            path=op.path,
+                            quiet_for=0.0,
+                            calm_required=tracker.calm_required(op.size or 0),
+                            state="ready",
+                            mean_interval=state.mean_interval if state else None,
+                            eta=tracker.eta(op.size or 0),
+                        )
+                    )
+                display.render(rows, last_event)
+
+                if transfers:
+                    total_bytes = sum(op.size or 0 for op in transfers)
+                    # Progress bars would scribble over the display; our own eta column covers it.
+                    disable_progress_bars()
                     transfer_started = time.monotonic()
                     try:
-                        _execute_plan(last_plan, api, verbose=False, status=status)
+                        _execute_plan(last_plan, api, verbose=False, status=None)
                     finally:
-                        if quiet:
-                            enable_progress_bars()
+                        enable_progress_bars()
                     elapsed = time.monotonic() - transfer_started
                     tracker.record_transfer(total_bytes, elapsed)
-                    emit(f"Pass {passes}: {len(uploads)} file(s) in {_format_duration(elapsed)}.")
-                    announced.clear()
-
-                # Report held-back files, but only when their reason changes -- otherwise a file being written
-                # for an hour would print the same line every interval.
-                for path, verdict in sorted(held.items()):
-                    if announced.get(path) != verdict.reason:
-                        emit(f"  waiting: {path} ({verdict.reason})")
-                        announced[path] = verdict.reason
-                for path in [p for p in announced if p not in held]:
-                    del announced[path]
-
-                if not uploads and not held and verbose:
-                    emit(f"Pass {passes}: nothing to sync.")
+                    noun = "file" if len(transfers) == 1 else "files"
+                    last_event = f"uploaded {len(transfers)} {noun} in {_format_duration(elapsed)}"
+                    # Repaint without the now-finished rows so the block reflects reality immediately.
+                    display.render([r for r in rows if r.state != "ready"], last_event)
 
                 tracker.forget(set(held) | {op.path for op in last_plan.operations})
                 backoff = interval
             except KeyboardInterrupt:
                 raise
             except Exception as e:
-                # Keep the loop alive across transient Hub/network failures -- the whole point of continuous
-                # mode is that it outlives them. Back off so an outage doesn't hammer the API.
+                # Keep the loop alive across transient Hub/network failures -- the whole point of watch mode
+                # is that it outlives them. Back off so an outage doesn't hammer the API.
                 logger.warning(f"Sync pass {passes} failed: {e}")
-                emit(f"Pass {passes} failed ({e}); retrying in {_format_duration(backoff)}.")
+                last_event = f"pass {passes} failed ({e}); retrying in {_format_duration(backoff)}"
+                display.render([], last_event)
                 time.sleep(backoff)
                 backoff = min(backoff * 2, MAX_SYNC_BACKOFF)
                 continue
@@ -1349,7 +1507,7 @@ def _sync_continuous_loop(
             # Sleep the remainder of the interval, so a slow pass doesn't compound the period.
             time.sleep(max(0.0, interval - (time.monotonic() - started)))
     except KeyboardInterrupt:
-        emit(f"\nStopped after {passes} pass(es).")
+        display.close(f"stopped after {passes} pass(es)")
 
     return last_plan
 

--- a/src/huggingface_hub/cli/buckets.py
+++ b/src/huggingface_hub/cli/buckets.py
@@ -20,8 +20,9 @@ import click
 from huggingface_hub import logging
 from huggingface_hub._buckets import (
     BUCKET_PREFIX,
+    DEFAULT_CALM_MAX,
+    DEFAULT_CALM_MIN,
     DEFAULT_SYNC_INTERVAL,
-    DEFAULT_SYNC_SETTLE_TIME,
     BucketFile,
     FilterMatcher,
     _parse_bucket_uri,
@@ -594,7 +595,8 @@ def settings(
         "hf buckets sync ./data hf://buckets/user/my-bucket --dry-run",
         "hf buckets sync ./data hf://buckets/user/my-bucket --dry-run | jq .",
         "hf buckets sync ./checkpoints hf://buckets/user/my-bucket --continuous",
-        "hf buckets sync ./logs hf://buckets/user/my-bucket --continuous --interval 10",
+        "hf buckets sync ./logs hf://buckets/user/my-bucket --watch --interval 10",
+        "hf buckets sync ./ckpt hf://buckets/user/my-bucket --watch --calm-min 30",
     ],
 )
 def sync(
@@ -653,6 +655,7 @@ def sync(
         bool,
         Option(
             "--continuous",
+            "--watch",
             help="Keep syncing on an interval until interrupted. Cannot be combined with --delete, --plan, --apply or --dry-run.",
         ),
     ] = False,
@@ -663,13 +666,27 @@ def sync(
             help="Seconds between passes in continuous mode.",
         ),
     ] = DEFAULT_SYNC_INTERVAL,
-    settle_time: Annotated[
+    calm_time: Annotated[
+        float | None,
+        Option(
+            "--calm-time",
+            help="Fixed seconds a file must sit unchanged before upload, overriding the size-based ramp. 0 disables stability checks.",
+        ),
+    ] = None,
+    calm_min: Annotated[
         float,
         Option(
-            "--settle-time",
-            help="In continuous mode, ignore local files modified within this many seconds so partially written files aren't uploaded. 0 disables.",
+            "--calm-min",
+            help="Calm period for files at or below 1 GiB.",
         ),
-    ] = DEFAULT_SYNC_SETTLE_TIME,
+    ] = DEFAULT_CALM_MIN,
+    calm_max: Annotated[
+        float,
+        Option(
+            "--calm-max",
+            help="Calm period for files at or above 10 GiB. Sizes in between are log-interpolated.",
+        ),
+    ] = DEFAULT_CALM_MAX,
     include: Annotated[
         list[str] | None,
         Option(
@@ -730,7 +747,9 @@ def sync(
         dry_run=dry_run,
         continuous=continuous,
         interval=interval,
-        settle_time=settle_time,
+        calm_time=calm_time,
+        calm_min=calm_min,
+        calm_max=calm_max,
         verbose=verbose,
         quiet=out.is_quiet(),
     )

--- a/src/huggingface_hub/cli/buckets.py
+++ b/src/huggingface_hub/cli/buckets.py
@@ -20,6 +20,8 @@ import click
 from huggingface_hub import logging
 from huggingface_hub._buckets import (
     BUCKET_PREFIX,
+    DEFAULT_SYNC_INTERVAL,
+    DEFAULT_SYNC_SETTLE_TIME,
     BucketFile,
     FilterMatcher,
     _parse_bucket_uri,
@@ -591,6 +593,8 @@ def settings(
         "hf buckets sync --apply sync-plan.jsonl",
         "hf buckets sync ./data hf://buckets/user/my-bucket --dry-run",
         "hf buckets sync ./data hf://buckets/user/my-bucket --dry-run | jq .",
+        "hf buckets sync ./checkpoints hf://buckets/user/my-bucket --continuous",
+        "hf buckets sync ./logs hf://buckets/user/my-bucket --continuous --interval 10",
     ],
 )
 def sync(
@@ -645,6 +649,27 @@ def sync(
             help="Print sync plan to stdout as JSONL without executing.",
         ),
     ] = False,
+    continuous: Annotated[
+        bool,
+        Option(
+            "--continuous",
+            help="Keep syncing on an interval until interrupted. Cannot be combined with --delete, --plan, --apply or --dry-run.",
+        ),
+    ] = False,
+    interval: Annotated[
+        float,
+        Option(
+            "--interval",
+            help="Seconds between passes in continuous mode.",
+        ),
+    ] = DEFAULT_SYNC_INTERVAL,
+    settle_time: Annotated[
+        float,
+        Option(
+            "--settle-time",
+            help="In continuous mode, ignore local files modified within this many seconds so partially written files aren't uploaded. 0 disables.",
+        ),
+    ] = DEFAULT_SYNC_SETTLE_TIME,
     include: Annotated[
         list[str] | None,
         Option(
@@ -703,6 +728,9 @@ def sync(
         plan=plan,
         apply=apply,
         dry_run=dry_run,
+        continuous=continuous,
+        interval=interval,
+        settle_time=settle_time,
         verbose=verbose,
         quiet=out.is_quiet(),
     )

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -38,6 +38,8 @@ from tqdm.auto import tqdm as base_tqdm
 
 from . import constants
 from ._buckets import (
+    DEFAULT_SYNC_INTERVAL,
+    DEFAULT_SYNC_SETTLE_TIME,
     BucketFile,
     BucketFileMetadata,
     BucketFolder,
@@ -14904,6 +14906,9 @@ class HfApi:
         plan: str | None = None,
         apply: str | None = None,
         dry_run: bool = False,
+        continuous: bool = False,
+        interval: float = DEFAULT_SYNC_INTERVAL,
+        settle_time: float = DEFAULT_SYNC_SETTLE_TIME,
         verbose: bool = False,
         quiet: bool = False,
         token: bool | str | None = None,
@@ -14942,6 +14947,14 @@ class HfApi:
                 Apply a previously saved plan file. When set, ``source`` and ``dest`` are not needed.
             dry_run (`bool`, *optional*, defaults to `False`):
                 Print sync plan to stdout as JSONL without executing.
+            continuous (`bool`, *optional*, defaults to `False`):
+                Keep syncing on an interval until interrupted, instead of running a single pass. Cannot be
+                combined with ``delete``, ``plan``, ``apply`` or ``dry_run``.
+            interval (`float`, *optional*, defaults to `30.0`):
+                Seconds between passes in continuous mode.
+            settle_time (`float`, *optional*, defaults to `5.0`):
+                In continuous mode, ignore local files modified within this many seconds, so a file that is
+                still being written isn't uploaded half-finished. Set to 0 to disable.
             verbose (`bool`, *optional*, defaults to `False`):
                 Show detailed per-file operations.
             quiet (`bool`, *optional*, defaults to `False`):
@@ -14979,6 +14992,9 @@ class HfApi:
             # Save plan for review, then apply
             >>> api.sync_bucket("./data", "hf://buckets/username/my-bucket", plan="sync-plan.jsonl")
             >>> api.sync_bucket(apply="sync-plan.jsonl")
+
+            # Keep a bucket mirrored to a local directory until interrupted
+            >>> api.sync_bucket("./checkpoints", "hf://buckets/username/my-bucket", continuous=True, interval=60)
             ```
         """
         return sync_bucket_internal(
@@ -14996,6 +15012,9 @@ class HfApi:
             plan=plan,
             apply=apply,
             dry_run=dry_run,
+            continuous=continuous,
+            interval=interval,
+            settle_time=settle_time,
             verbose=verbose,
             quiet=quiet,
             token=token,

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -38,8 +38,9 @@ from tqdm.auto import tqdm as base_tqdm
 
 from . import constants
 from ._buckets import (
+    DEFAULT_CALM_MAX,
+    DEFAULT_CALM_MIN,
     DEFAULT_SYNC_INTERVAL,
-    DEFAULT_SYNC_SETTLE_TIME,
     BucketFile,
     BucketFileMetadata,
     BucketFolder,
@@ -14908,7 +14909,9 @@ class HfApi:
         dry_run: bool = False,
         continuous: bool = False,
         interval: float = DEFAULT_SYNC_INTERVAL,
-        settle_time: float = DEFAULT_SYNC_SETTLE_TIME,
+        calm_time: float | None = None,
+        calm_min: float = DEFAULT_CALM_MIN,
+        calm_max: float = DEFAULT_CALM_MAX,
         verbose: bool = False,
         quiet: bool = False,
         token: bool | str | None = None,
@@ -14952,9 +14955,13 @@ class HfApi:
                 combined with ``delete``, ``plan``, ``apply`` or ``dry_run``.
             interval (`float`, *optional*, defaults to `30.0`):
                 Seconds between passes in continuous mode.
-            settle_time (`float`, *optional*, defaults to `5.0`):
-                In continuous mode, ignore local files modified within this many seconds, so a file that is
-                still being written isn't uploaded half-finished. Set to 0 to disable.
+            calm_time (`float`, *optional*):
+                Fixed number of seconds a file must sit unchanged before it is uploaded, overriding the
+                size-based ramp. `0` disables the stability checks entirely.
+            calm_min (`float`, *optional*, defaults to `60.0`):
+                Calm period for files at or below 1 GiB.
+            calm_max (`float`, *optional*, defaults to `600.0`):
+                Calm period for files at or above 10 GiB. Sizes in between are log-interpolated.
             verbose (`bool`, *optional*, defaults to `False`):
                 Show detailed per-file operations.
             quiet (`bool`, *optional*, defaults to `False`):
@@ -15014,7 +15021,9 @@ class HfApi:
             dry_run=dry_run,
             continuous=continuous,
             interval=interval,
-            settle_time=settle_time,
+            calm_time=calm_time,
+            calm_min=calm_min,
+            calm_max=calm_max,
             verbose=verbose,
             quiet=quiet,
             token=token,

--- a/tests/test_buckets_sync_continuous.py
+++ b/tests/test_buckets_sync_continuous.py
@@ -21,8 +21,18 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from huggingface_hub._buckets import (
+    CALM_LARGE_SIZE,
+    CALM_SMALL_SIZE,
+    DEFAULT_CALM_MAX,
+    DEFAULT_CALM_MIN,
+    HIGH_ETA_SECONDS,
     FilterMatcher,
+    StabilityTracker,
+    SyncOperation,
+    SyncPlan,
+    _calm_period_for_size,
     _compute_sync_plan,
+    _format_duration,
     _sync_continuous_loop,
     sync_bucket_internal,
 )
@@ -67,43 +77,179 @@ class TestContinuousValidation:
         with pytest.raises(ValueError, match="interval must be greater than 0"):
             sync_bucket_internal(sync_dir, BUCKET, api=mock_api, continuous=True, interval=interval)
 
-    def test_negative_settle_time_is_refused(self, mock_api, sync_dir):
-        with pytest.raises(ValueError, match="settle_time cannot be negative"):
-            sync_bucket_internal(sync_dir, BUCKET, api=mock_api, continuous=True, settle_time=-1)
+    def test_negative_calm_time_is_refused(self, mock_api, sync_dir):
+        with pytest.raises(ValueError, match="calm_time cannot be negative"):
+            sync_bucket_internal(sync_dir, BUCKET, api=mock_api, continuous=True, calm_time=-1)
+
+    def test_inverted_calm_range_is_refused(self, mock_api, sync_dir):
+        with pytest.raises(ValueError, match="calm_max cannot be smaller than calm_min"):
+            sync_bucket_internal(sync_dir, BUCKET, api=mock_api, continuous=True, calm_min=100, calm_max=10)
 
 
-class TestSettleTime:
-    """`min_age_seconds` keeps files that are still being written out of the plan."""
+class TestCalmPeriodRamp:
+    """Calm period scales with file size: flat, ramp, flat."""
 
-    def _plan(self, sync_dir, min_age_seconds):
+    def test_small_files_use_the_floor(self):
+        assert _calm_period_for_size(4096) == DEFAULT_CALM_MIN
+        assert _calm_period_for_size(CALM_SMALL_SIZE) == DEFAULT_CALM_MIN
+
+    def test_large_files_use_the_ceiling(self):
+        assert _calm_period_for_size(CALM_LARGE_SIZE) == DEFAULT_CALM_MAX
+        assert _calm_period_for_size(CALM_LARGE_SIZE * 100) == DEFAULT_CALM_MAX
+
+    def test_ramp_is_monotonic_between_anchors(self):
+        sizes = [CALM_SMALL_SIZE * m for m in (1, 2, 4, 8, 10)]
+        periods = [_calm_period_for_size(sz) for sz in sizes]
+        assert periods == sorted(periods)
+        assert DEFAULT_CALM_MIN < periods[2] < DEFAULT_CALM_MAX
+
+    def test_custom_anchors_are_honoured(self):
+        assert _calm_period_for_size(1024, calm_min=5, calm_max=50) == 5
+        assert _calm_period_for_size(CALM_LARGE_SIZE, calm_min=5, calm_max=50) == 50
+
+
+class TestStabilityTracker:
+    """Files that are still changing are held back; quiet files go through."""
+
+    def test_static_file_is_calm_immediately(self):
+        # mtime an hour old: nothing to wait for, even on the very first pass.
+        tracker = StabilityTracker()
+        old_mtime_ms = (time.time() - 3600) * 1000
+        assert tracker.is_calm("a.txt", 1000, old_mtime_ms)
+
+    def test_freshly_written_file_is_held_back(self):
+        tracker = StabilityTracker()
+        verdict = tracker.verdict("a.txt", 1000, time.time() * 1000)
+        assert not verdict.calm
+        assert "needs" in verdict.reason
+
+    def test_rapidly_changing_file_is_held_back_while_it_churns(self):
+        # A file rewritten every second never accumulates the required quiet time.
+        tracker = StabilityTracker(calm_min=60.0)
+        now = time.time()
+        for i in range(5):
+            verdict = tracker.verdict("log.txt", 100 * (i + 1), (now + i) * 1000, now=now + i)
+        assert tracker._files["log.txt"].is_rapid
+        assert not verdict.calm
+
+    def test_file_that_churned_then_settled_is_eventually_uploaded(self):
+        """Regression: historical churn must not block a file forever once it goes quiet."""
+        tracker = StabilityTracker(calm_min=60.0)
+        now = time.time()
+        for i in range(5):
+            tracker.verdict("log.txt", 100 * (i + 1), (now + i) * 1000, now=now + i)
+        assert tracker._files["log.txt"].is_rapid  # still remembers the churn
+        # Writing stopped at now+4; ask again well past the calm period with an unchanged file.
+        verdict = tracker.verdict("log.txt", 500, (now + 4) * 1000, now=now + 400)
+        assert verdict.calm, f"still blocked despite being quiet: {verdict.reason}"
+
+    def test_calm_override_of_zero_disables_checks(self):
+        tracker = StabilityTracker(calm_override=0)
+        assert tracker.is_calm("a.txt", 1000, time.time() * 1000)
+
+    def test_mean_interval_needs_two_samples(self):
+        tracker = StabilityTracker()
+        now = time.time()
+        tracker.observe("a.txt", 1, now * 1000, now=now)
+        tracker.observe("a.txt", 2, (now + 5) * 1000, now=now + 5)
+        assert tracker._files["a.txt"].mean_interval is None  # one change == no interval yet
+        tracker.observe("a.txt", 3, (now + 10) * 1000, now=now + 10)
+        assert tracker._files["a.txt"].mean_interval == pytest.approx(5.0)
+
+    def test_forget_drops_vanished_files(self):
+        tracker = StabilityTracker()
+        tracker.observe("a.txt", 1, time.time() * 1000)
+        tracker.observe("b.txt", 1, time.time() * 1000)
+        tracker.forget({"a.txt"})
+        assert set(tracker._files) == {"a.txt"}
+
+    def test_local_filter_with_delete_is_refused(self, sync_dir):
+        # A held-back file is invisible to the comparison, so it would look like a remote deletion.
+        with pytest.raises(ValueError, match="local_filter cannot be combined with delete"):
+            _compute_sync_plan(
+                source=sync_dir, dest=BUCKET, api=MagicMock(), delete=True, local_filter=lambda *a: True
+            )
+
+    def test_plan_excludes_held_back_files(self, sync_dir):
+        tracker = StabilityTracker()  # sync_dir files were just written -> not calm
         with patch("huggingface_hub._buckets._list_remote_files", return_value=iter([])):
-            return _compute_sync_plan(
+            plan = _compute_sync_plan(
                 source=sync_dir,
                 dest=BUCKET,
                 api=MagicMock(),
                 filter_matcher=FilterMatcher(),
-                min_age_seconds=min_age_seconds,
+                local_filter=tracker.is_calm,
             )
-
-    def test_fresh_file_is_skipped(self, sync_dir):
-        # a.txt was just written, so a settle window of an hour must exclude it.
-        plan = self._plan(sync_dir, min_age_seconds=3600)
         assert plan.summary()["uploads"] == 0
 
-    def test_settled_file_is_uploaded(self, sync_dir):
-        old = time.time() - 3600
+    def test_plan_includes_settled_files(self, sync_dir):
+        old = time.time() - 7200
         os.utime(os.path.join(sync_dir, "a.txt"), (old, old))
-        plan = self._plan(sync_dir, min_age_seconds=5)
+        with patch("huggingface_hub._buckets._list_remote_files", return_value=iter([])):
+            plan = _compute_sync_plan(
+                source=sync_dir,
+                dest=BUCKET,
+                api=MagicMock(),
+                filter_matcher=FilterMatcher(),
+                local_filter=StabilityTracker().is_calm,
+            )
         assert plan.summary()["uploads"] == 1
 
-    def test_disabled_settle_uploads_everything(self, sync_dir):
-        plan = self._plan(sync_dir, min_age_seconds=0)
-        assert plan.summary()["uploads"] == 1
 
-    def test_settle_with_delete_is_refused(self, sync_dir):
-        # An unsettled file is invisible to the comparison, so it would look like a remote deletion.
-        with pytest.raises(ValueError, match="min_age_seconds cannot be combined with delete"):
-            _compute_sync_plan(source=sync_dir, dest=BUCKET, api=MagicMock(), delete=True, min_age_seconds=5)
+class TestThrashAbort:
+    """An expensive upload is refused when the file would change out from under it."""
+
+    def _tracker_changing_every(self, seconds, calm_min=1.0):
+        tracker = StabilityTracker(calm_min=calm_min)
+        now = time.time()
+        for i in range(4):
+            tracker.observe("big.bin", 1000 * (i + 1), (now + i * seconds) * 1000, now=now + i * seconds)
+        return tracker, now + 4 * seconds
+
+    def test_slow_upload_of_churning_file_is_refused(self):
+        # Changes every 30s (not "rapid"), but a huge file at 1 B/s gives an enormous ETA.
+        tracker, now = self._tracker_changing_every(30.0)
+        tracker._throughput_bps = 1.0
+        tracker._measured = True
+        verdict = tracker.verdict("big.bin", 10_000, (now - 600) * 1000, now=now + 600)
+        assert not verdict.calm
+        assert "overtaken" in verdict.reason
+        assert verdict.predicted_changes >= 2
+
+    def test_fast_upload_of_same_file_is_allowed(self):
+        # Same churn, but throughput makes the upload near-instant, so there is nothing to lose.
+        tracker, now = self._tracker_changing_every(30.0)
+        tracker._throughput_bps = 10**9
+        tracker._measured = True
+        verdict = tracker.verdict("big.bin", 10_000, (now - 600) * 1000, now=now + 600)
+        assert verdict.calm
+        assert verdict.eta < HIGH_ETA_SECONDS
+
+    def test_record_transfer_updates_throughput(self):
+        tracker = StabilityTracker()
+        tracker.record_transfer(100 * 1024**2, 1.0)
+        assert tracker._throughput_bps == pytest.approx(100 * 1024**2)
+        # Later measurements are smoothed, not replaced outright.
+        tracker.record_transfer(0, 1.0)
+        assert tracker._throughput_bps == pytest.approx(100 * 1024**2)
+
+    def test_zero_duration_transfer_is_ignored(self):
+        tracker = StabilityTracker()
+        before = tracker._throughput_bps
+        tracker.record_transfer(1000, 0)
+        assert tracker._throughput_bps == before
+
+
+class TestFormatDuration:
+    @pytest.mark.parametrize(
+        "seconds,expected",
+        [(0, "0s"), (9.4, "9s"), (59, "59s"), (60, "1m00s"), (130, "2m10s"), (3600, "1h00m"), (3900, "1h05m")],
+    )
+    def test_formats(self, seconds, expected):
+        assert _format_duration(seconds) == expected
+
+    def test_negative_clamps_to_zero(self):
+        assert _format_duration(-5) == "0s"
 
 
 class TestContinuousLoop:
@@ -129,7 +275,7 @@ class TestContinuousLoop:
                 api=MagicMock(),
                 filter_matcher=FilterMatcher(),
                 interval=kwargs.pop("interval", 1.0),
-                settle_time=kwargs.pop("settle_time", 5.0),
+                tracker=kwargs.pop("tracker", StabilityTracker(calm_override=0)),
                 ignore_times=False,
                 ignore_sizes=False,
                 existing=False,
@@ -141,9 +287,15 @@ class TestContinuousLoop:
 
     @staticmethod
     def _plan_with(uploads):
-        plan = MagicMock()
-        plan.summary.return_value = {"uploads": uploads, "downloads": 0, "deletes": 0, "skips": 0, "total_size": 0}
-        return plan
+        """A real SyncPlan -- the loop iterates `operations`, so a MagicMock will not do."""
+        return SyncPlan(
+            source="/tmp/x",
+            dest=BUCKET,
+            timestamp="now",
+            operations=[
+                SyncOperation(action="upload", path=f"f{i}.bin", size=10, reason="new file") for i in range(uploads)
+            ],
+        )
 
     def test_replans_every_pass(self):
         _, compute, _ = self._run(lambda **kw: self._plan_with(0), passes_before_stop=3)
@@ -163,9 +315,9 @@ class TestContinuousLoop:
         _, compute, _ = self._run(lambda **kw: self._plan_with(0), passes_before_stop=2)
         assert all(call.kwargs["delete"] is False for call in compute.call_args_list)
 
-    def test_settle_time_is_passed_through(self):
-        _, compute, _ = self._run(lambda **kw: self._plan_with(0), passes_before_stop=2, settle_time=42.0)
-        assert all(call.kwargs["min_age_seconds"] == 42.0 for call in compute.call_args_list)
+    def test_local_filter_is_passed_through(self):
+        _, compute, _ = self._run(lambda **kw: self._plan_with(0), passes_before_stop=2)
+        assert all(callable(call.kwargs["local_filter"]) for call in compute.call_args_list)
 
     def test_failed_pass_does_not_stop_the_loop(self):
         results = [RuntimeError("hub down"), self._plan_with(1), self._plan_with(0)]

--- a/tests/test_buckets_sync_continuous.py
+++ b/tests/test_buckets_sync_continuous.py
@@ -1,0 +1,182 @@
+# coding=utf-8
+# Copyright 2026-present, the HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Offline tests for continuous bucket sync (`hf buckets sync --continuous`)."""
+
+import os
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from huggingface_hub._buckets import (
+    FilterMatcher,
+    _compute_sync_plan,
+    _sync_continuous_loop,
+    sync_bucket_internal,
+)
+
+
+BUCKET = "hf://buckets/user/my-bucket"
+
+
+@pytest.fixture
+def sync_dir(tmp_path):
+    (tmp_path / "a.txt").write_text("hello")
+    return str(tmp_path)
+
+
+@pytest.fixture
+def mock_api():
+    return MagicMock()
+
+
+class TestContinuousValidation:
+    """`--continuous` is refused in combinations that are meaningless or unsafe."""
+
+    def test_continuous_with_delete_is_refused(self, mock_api, sync_dir):
+        # Deliberate: an unattended loop must never propagate deletions to the remote.
+        with pytest.raises(ValueError, match="Cannot specify delete with continuous"):
+            sync_bucket_internal(sync_dir, BUCKET, api=mock_api, continuous=True, delete=True)
+
+    def test_continuous_with_plan_is_refused(self, mock_api, sync_dir):
+        with pytest.raises(ValueError, match="Cannot specify continuous with plan or dry_run"):
+            sync_bucket_internal(sync_dir, BUCKET, api=mock_api, continuous=True, plan="p.jsonl")
+
+    def test_continuous_with_dry_run_is_refused(self, mock_api, sync_dir):
+        with pytest.raises(ValueError, match="Cannot specify continuous with plan or dry_run"):
+            sync_bucket_internal(sync_dir, BUCKET, api=mock_api, continuous=True, dry_run=True)
+
+    def test_continuous_with_apply_is_refused(self, mock_api):
+        with pytest.raises(ValueError, match="Cannot specify continuous when using apply"):
+            sync_bucket_internal(api=mock_api, continuous=True, apply="p.jsonl")
+
+    @pytest.mark.parametrize("interval", [0, -1])
+    def test_non_positive_interval_is_refused(self, mock_api, sync_dir, interval):
+        with pytest.raises(ValueError, match="interval must be greater than 0"):
+            sync_bucket_internal(sync_dir, BUCKET, api=mock_api, continuous=True, interval=interval)
+
+    def test_negative_settle_time_is_refused(self, mock_api, sync_dir):
+        with pytest.raises(ValueError, match="settle_time cannot be negative"):
+            sync_bucket_internal(sync_dir, BUCKET, api=mock_api, continuous=True, settle_time=-1)
+
+
+class TestSettleTime:
+    """`min_age_seconds` keeps files that are still being written out of the plan."""
+
+    def _plan(self, sync_dir, min_age_seconds):
+        with patch("huggingface_hub._buckets._list_remote_files", return_value=iter([])):
+            return _compute_sync_plan(
+                source=sync_dir,
+                dest=BUCKET,
+                api=MagicMock(),
+                filter_matcher=FilterMatcher(),
+                min_age_seconds=min_age_seconds,
+            )
+
+    def test_fresh_file_is_skipped(self, sync_dir):
+        # a.txt was just written, so a settle window of an hour must exclude it.
+        plan = self._plan(sync_dir, min_age_seconds=3600)
+        assert plan.summary()["uploads"] == 0
+
+    def test_settled_file_is_uploaded(self, sync_dir):
+        old = time.time() - 3600
+        os.utime(os.path.join(sync_dir, "a.txt"), (old, old))
+        plan = self._plan(sync_dir, min_age_seconds=5)
+        assert plan.summary()["uploads"] == 1
+
+    def test_disabled_settle_uploads_everything(self, sync_dir):
+        plan = self._plan(sync_dir, min_age_seconds=0)
+        assert plan.summary()["uploads"] == 1
+
+    def test_settle_with_delete_is_refused(self, sync_dir):
+        # An unsettled file is invisible to the comparison, so it would look like a remote deletion.
+        with pytest.raises(ValueError, match="min_age_seconds cannot be combined with delete"):
+            _compute_sync_plan(source=sync_dir, dest=BUCKET, api=MagicMock(), delete=True, min_age_seconds=5)
+
+
+class TestContinuousLoop:
+    """The loop re-plans each pass, survives failures, and exits cleanly on Ctrl-C."""
+
+    def _run(self, compute_side_effect, execute=None, passes_before_stop=3, **kwargs):
+        """Run the loop, raising KeyboardInterrupt from sleep after N passes."""
+        calls = {"sleep": 0}
+
+        def fake_sleep(_seconds):
+            calls["sleep"] += 1
+            if calls["sleep"] >= passes_before_stop:
+                raise KeyboardInterrupt
+
+        with (
+            patch("huggingface_hub._buckets._compute_sync_plan", side_effect=compute_side_effect) as compute,
+            patch("huggingface_hub._buckets._execute_plan", side_effect=execute) as execute_mock,
+            patch("huggingface_hub._buckets.time.sleep", side_effect=fake_sleep),
+        ):
+            plan = _sync_continuous_loop(
+                source="/tmp/x",
+                dest=BUCKET,
+                api=MagicMock(),
+                filter_matcher=FilterMatcher(),
+                interval=kwargs.pop("interval", 1.0),
+                settle_time=kwargs.pop("settle_time", 5.0),
+                ignore_times=False,
+                ignore_sizes=False,
+                existing=False,
+                ignore_existing=False,
+                verbose=False,
+                quiet=True,
+            )
+        return plan, compute, execute_mock
+
+    @staticmethod
+    def _plan_with(uploads):
+        plan = MagicMock()
+        plan.summary.return_value = {"uploads": uploads, "downloads": 0, "deletes": 0, "skips": 0, "total_size": 0}
+        return plan
+
+    def test_replans_every_pass(self):
+        _, compute, _ = self._run(lambda **kw: self._plan_with(0), passes_before_stop=3)
+        assert compute.call_count == 3
+
+    def test_keyboard_interrupt_exits_cleanly(self):
+        # No exception should escape: Ctrl-C is the documented way to stop.
+        plan, _, _ = self._run(lambda **kw: self._plan_with(0), passes_before_stop=2)
+        assert plan is not None
+
+    def test_executes_only_when_there_is_work(self):
+        plans = [self._plan_with(0), self._plan_with(2), self._plan_with(0)]
+        _, _, execute = self._run(lambda **kw: plans.pop(0), passes_before_stop=3)
+        assert execute.call_count == 1
+
+    def test_never_deletes(self):
+        _, compute, _ = self._run(lambda **kw: self._plan_with(0), passes_before_stop=2)
+        assert all(call.kwargs["delete"] is False for call in compute.call_args_list)
+
+    def test_settle_time_is_passed_through(self):
+        _, compute, _ = self._run(lambda **kw: self._plan_with(0), passes_before_stop=2, settle_time=42.0)
+        assert all(call.kwargs["min_age_seconds"] == 42.0 for call in compute.call_args_list)
+
+    def test_failed_pass_does_not_stop_the_loop(self):
+        results = [RuntimeError("hub down"), self._plan_with(1), self._plan_with(0)]
+
+        def compute(**kw):
+            item = results.pop(0)
+            if isinstance(item, Exception):
+                raise item
+            return item
+
+        _, compute_mock, execute = self._run(compute, passes_before_stop=3)
+        # The loop kept going after the failure and did real work on a later pass.
+        assert compute_mock.call_count == 3
+        assert execute.call_count == 1

--- a/tests/test_buckets_sync_continuous.py
+++ b/tests/test_buckets_sync_continuous.py
@@ -15,6 +15,7 @@
 """Offline tests for continuous bucket sync (`hf buckets sync --continuous`)."""
 
 import os
+import re
 import time
 from unittest.mock import MagicMock, patch
 
@@ -30,7 +31,11 @@ from huggingface_hub._buckets import (
     StabilityTracker,
     SyncOperation,
     SyncPlan,
+    WatchDisplay,
+    WatchRow,
+    _bar,
     _calm_period_for_size,
+    _churn_meter,
     _compute_sync_plan,
     _format_duration,
     _sync_continuous_loop,
@@ -332,3 +337,117 @@ class TestContinuousLoop:
         # The loop kept going after the failure and did real work on a later pass.
         assert compute_mock.call_count == 3
         assert execute.call_count == 1
+
+
+class TestWatchDisplay:
+    """The watch panel repaints in place on a TTY and degrades to plain lines elsewhere."""
+
+    def _tty_display(self, monkeypatch):
+        monkeypatch.setattr("sys.stdout.isatty", lambda: True, raising=False)
+        return WatchDisplay("./data", BUCKET, "60s")
+
+    def test_plain_mode_when_not_a_tty(self, capsys):
+        # stdout is captured (not a TTY) under pytest, so this is the default path here.
+        display = WatchDisplay("./data", BUCKET, "60s")
+        assert not display.tui
+        display.start()
+        out = capsys.readouterr().out
+        assert "watching::" in out
+        assert "lazy mode active" in out
+        assert "\033[" not in out  # no cursor movement in a log file
+
+    def test_plain_mode_reports_a_file_only_when_its_status_changes(self, capsys):
+        display = WatchDisplay("./data", BUCKET, "60s")
+        display.start()
+        capsys.readouterr()
+        row = WatchRow("a.log", 3, 60, "waiting", 2.0)
+        display.render([row])
+        first = capsys.readouterr().out
+        display.render([row])  # identical status -> silence
+        second = capsys.readouterr().out
+        assert "a.log" in first
+        assert second == ""
+
+    def test_plain_mode_reprints_when_status_changes(self, capsys):
+        display = WatchDisplay("./data", BUCKET, "60s")
+        display.render([WatchRow("a.log", 3, 60, "waiting", 2.0)])
+        capsys.readouterr()
+        display.render([WatchRow("a.log", 30, 60, "waiting", 2.0)])
+        assert "a.log" in capsys.readouterr().out
+
+    def test_quiet_suppresses_everything(self, capsys):
+        display = WatchDisplay("./data", BUCKET, "60s", quiet=True)
+        display.start()
+        display.render([WatchRow("a.log", 3, 60, "waiting", 2.0)])
+        display.close("done")
+        assert capsys.readouterr().out == ""
+
+    def test_tui_moves_the_cursor_back_over_its_own_block(self, monkeypatch, capsys):
+        display = self._tty_display(monkeypatch)
+        assert display.tui
+        display.render([WatchRow("a.log", 3, 60, "waiting", 2.0)])
+        first = capsys.readouterr().out
+        painted = display._painted
+        display.render([WatchRow("a.log", 8, 60, "waiting", 2.0)])
+        second = capsys.readouterr().out
+        assert not re.search(r"\033\[\d+A", first)  # first frame does not rewind: nothing painted yet
+        assert f"\033[{painted}A" in second  # second frame rewinds exactly as far as it painted
+
+    def test_tui_clears_leftovers_when_the_frame_shrinks(self, monkeypatch, capsys):
+        display = self._tty_display(monkeypatch)
+        display.render([WatchRow(f"f{i}.log", 3, 60, "waiting") for i in range(4)])
+        tall = display._painted
+        capsys.readouterr()
+        display.render([])
+        out = capsys.readouterr().out
+        assert display._painted < tall
+        assert "\033[2K" in out  # leftover rows are erased, not left on screen
+
+    def test_row_shows_progress_and_eta(self, monkeypatch, capsys):
+        display = self._tty_display(monkeypatch)
+        display.render(
+            [
+                WatchRow("waiting.log", 30, 60, "waiting", 2.0),
+                WatchRow("ready.bin", 0, 60, "ready", None, 3.0),
+                WatchRow("held.bin", 60, 60, "deferred", 45.0, 250.0, 3.0),
+            ]
+        )
+        out = capsys.readouterr().out
+        assert "3 files changed" in out
+        assert "30s/1m00s" in out and "ready in 30s" in out
+        assert "eta 3s" in out
+        assert "overtaken ~3x" in out
+
+    def test_singular_and_empty_wording(self, monkeypatch, capsys):
+        display = self._tty_display(monkeypatch)
+        display.render([WatchRow("a.log", 3, 60, "waiting")])
+        assert "1 file changed" in capsys.readouterr().out
+        display.render([])
+        assert "no changes" in capsys.readouterr().out
+
+    def test_long_names_are_truncated_from_the_left(self, monkeypatch, capsys):
+        display = self._tty_display(monkeypatch)
+        display.render([WatchRow("a/very/deeply/nested/path/to/some/checkpoint-000123.safetensors", 3, 60, "waiting")])
+        out = capsys.readouterr().out
+        assert "\u2026" in out
+        assert "checkpoint-000123.safetensors" in out  # the informative tail survives
+
+
+class TestMeters:
+    def test_bar_endpoints(self):
+        assert _bar(0.0) == "\u2591" * 8
+        assert _bar(1.0) == "\u2588" * 8
+        assert _bar(0.5) == "\u2588" * 4 + "\u2591" * 4
+
+    def test_bar_clamps_out_of_range(self):
+        assert _bar(-1.0) == "\u2591" * 8
+        assert _bar(5.0) == "\u2588" * 8
+
+    def test_churn_meter_is_blank_without_samples(self):
+        assert _churn_meter(None).strip() == ""
+
+    def test_churn_meter_grows_with_rate(self):
+        rapid = _churn_meter(1.0).strip()
+        moderate = _churn_meter(4.0).strip()
+        calm = _churn_meter(60.0).strip()
+        assert len(rapid) > len(moderate) >= len(calm)


### PR DESCRIPTION
> **Status: draft / experimental — not asking for review.** A maintainer has already indicated in
> #4757 that this is not something the project wants to take on short term, and that's a reasonable
> call. This branch was written before that reply landed, so it is published as a reference for the
> design and the stability math rather than as a proposal. Happy for it to be closed.

## What this adds

`hf buckets sync` (and its `hf sync` alias) currently runs one pass and exits. This adds
`--continuous` / `--watch`, which keeps it running and re-syncs on an interval until interrupted —
for mirroring a job's output directory to a bucket while the job is still writing to it.

```bash
hf sync ./checkpoints hf://buckets/user/my-bucket --watch
```

The hard part is not the loop. It is **not uploading a file that is still being written**. An
unattended sync that ships a half-written checkpoint has done something worse than nothing, so most
of this PR is about deciding when a file has gone quiet enough to be worth uploading.

## The stability model

### 1. Calm period, scaled by size

Every file must sit **unchanged for a calm period** before it is eligible. That period scales with
size, because the cost of guessing wrong scales with size: re-uploading a 4 KB log you caught
mid-write is free, re-uploading a 20 GB checkpoint is not.

Two anchors, both flags:

| size | calm period |
| --- | --- |
| ≤ 1 GiB | 60s (`--calm-min`) |
| ≥ 10 GiB | 600s (`--calm-max`) |

Between them the period is interpolated **in log space**, since file sizes span decades and linear
interpolation across a 10× range would spend almost all its resolution on the top of the range:

```
ratio = log10(size / CALM_SMALL_SIZE) / log10(CALM_LARGE_SIZE / CALM_SMALL_SIZE)
calm  = calm_min + ratio * (calm_max - calm_min)
```

The anchors happen to span exactly one decade, so this reduces to
`calm = 60 + 540 * log10(size / 1GiB)` at the defaults — e.g. a 3.16 GiB file (10^0.5) gets 330s.
The ramp is flat outside the anchors, so the function is continuous and monotonic across the whole
size domain.

### 2. Calmness is measured from mtime, not from first sight

```
quiet_for = now - mtime
calm      = quiet_for >= calm_required
```

Using the file's own mtime rather than "when this process first noticed it" matters: it means a
directory of **static files syncs immediately on the first pass**. Only files actually being
written wait. A first-sight-based timer would have imposed a 60s delay on every ordinary sync,
which would be an unacceptable regression in the common case.

### 3. Churn rate

Each pass records `(size, mtime)` per file and appends a timestamp whenever either changed. Over
the last ≤ 8 change observations:

```
mean_interval = (1 / (n-1)) * Σ (t[i+1] - t[i])        , n >= 2
```

This feeds the prediction below and the on-screen meter. Two caveats, both real:

- It needs two observed changes, so it is `None` on first contact.
- It is **quantized to `--interval`** — a file written every 2s under a 5s poll reads as ~5s. The
  estimate is therefore conservative (it under-reports churn), which is the safe direction for the
  prediction that follows.

### 4. Refusing uploads that would be overtaken

A large file can pass the calm check and still be a bad upload: if it changes every few minutes and
the transfer takes longer than that, the copy is stale before it lands and the bandwidth is wasted.

Throughput is **measured, not assumed** — an EWMA over completed transfers, seeded at 50 MiB/s only
until the first real measurement replaces it outright:

```
observed = bytes / seconds
B <- observed                      (first measurement)
B <- 0.7 * B + 0.3 * observed      (thereafter)
eta = size / B
predicted_changes = eta / mean_interval
```

The upload is refused when `eta >= 60s AND predicted_changes >= 2` — i.e. only when the transfer is
expensive enough to care about *and* the file would be overtaken at least twice mid-flight. Both
conditions are required, so a fast upload of a churning file still proceeds.

**This is a pre-flight refusal, not a mid-flight abort.** Once bytes are handed to the Hub client
there is no interrupt point without reaching into the upload path, so the check decides whether to
*start*. Worth flagging explicitly since "abort the upload" is the more obvious reading.

### 5. Why the churn rate is not itself a gate

The first version also blocked any file whose `mean_interval` was under 10s. **That was a bug**: the
samples never age out, so a file that churned once and then went permanently quiet would have been
blocked *forever*. Reaching the eligibility check already proves the file has been quiet for the
full calm period, so the observed rate is now used only to predict the future and to render the
meter — never as an independent gate. There is a named regression test
(`test_file_that_churned_then_settled_is_eventually_uploaded`).

## Terminal output

Watch mode draws a small panel that repaints in place rather than scrolling:

```text
watching:: ./data → hf://buckets/user/my-bucket
calm 60s (≤1GiB) → 10m00s (≥10GiB)   lazy mode active

2 files changed
  train.log               ▅▅  ██████░░   45s/1m00s  ready in 15s
  model-00001.safetensors ▁   ████████      stable  eta 4m10s
uploaded 1 file in 2s
```

Per row: a **churn meter** (`▇▇▇` for a write every second or two, down to `▁` once settled; blank
until two samples exist), a **stability meter** showing progress toward the calm period with
elapsed/required beside it, and a tail saying what happens next — `ready in 15s` while settling, or
the predicted `eta` once stable. Files that have not changed are not listed at all.

**Non-TTY is not a second-class path.** When stdout is not a terminal the panel degrades to plain
appended lines, reporting a file only when its status actually changes. Watch output is routinely
redirected to a log file, where cursor movement would be garbage. (An earlier iteration of this
branch had a real bug here — Python block-buffers a non-TTY stdout, so a redirected watch produced a
*completely empty* logfile until exit. Everything the panel writes is now flushed.)

The scanning `StatusLine` and the transfer progress bars are suppressed while the panel is active;
they would scribble over it, and the `eta` column covers the same ground.

## Safety rules

- **`--delete` is refused with `--continuous`.** An unattended loop that propagates deletions turns
  one transient local failure — a directory briefly unreadable, a disk hiccup — into unrecoverable
  remote data loss with nobody watching. Run a one-shot `sync --delete` to prune.
- **`--continuous` is refused with `--plan` / `--apply` / `--dry-run`**, which each describe a
  single pass.
- A failed pass is logged and retried with exponential backoff to a 5-minute ceiling rather than
  ending the loop. `Ctrl-C` exits cleanly and returns the last plan, so the Python API contract is
  unchanged.

## Implementation notes

`_compute_sync_plan` and `_execute_plan` were already pure functions of `(source, dest, filters)`,
so each pass recomputes from scratch and no state carries between iterations — a crash mid-loop
leaves nothing to reconcile. The only things carried across passes are the `StabilityTracker` and
the display.

`_compute_sync_plan` gained a `local_filter` predicate (replacing a narrower `min_age_seconds`),
which keeps volatility policy out of plan computation. It refuses to combine with `delete`: an
excluded file is invisible to the comparison, so it would otherwise look like a remote deletion
candidate — the same failure mode as the `--delete` rule above, one layer down.

## Known limitations

- **Every pass re-lists the whole remote bucket**, which dominates cost on large buckets at short
  intervals. In the upload direction this process is the only writer, so remote state could be
  cached across passes; deliberately left out of a first version.
- **A file appended to forever never uploads while its writer runs.** That follows directly from
  "wait until it is calm", but it is a real consequence — documented with a warning box, and
  `--calm-time` lowers the bar for anyone who would rather accept partial copies.
- Downloads (bucket → local) go through the same machinery, but the stability logic only applies to
  the local side, so a remote file being rewritten mid-download is not protected.

## Testing

53 offline tests in `tests/test_buckets_sync_continuous.py` — the existing bucket tests all require
staging plus a token, so these are self-contained: the calm ramp and its endpoints, mtime-based
calmness, the overtake prediction in both directions, EWMA throughput, loop behaviour under failure
and `KeyboardInterrupt`, every refusal path, and the display (in-place rewind, leftover-row
clearing, plain-mode degradation, meter rendering).

Also verified end-to-end against a real bucket, driving the actual CLI under a pty and replaying the
ANSI stream: a file appended every 2s was held for its entire write phase and uploaded once writing
stopped, while a file written once uploaded as soon as its calm period elapsed. Nine passes produced
2720 bytes of terminal output total.

## Open questions

1. **Are the defaults right?** 60s/1 GiB → 600s/10 GiB is a guess informed by nothing but
   plausibility. Real checkpoint-writing patterns should set these.
2. **Should `--delete` + `--continuous` be refused outright, or gated behind a confirmation or a
   "refuse to delete more than X% of remote files" bound?** I picked the most conservative option;
   it is the most likely thing here to be wrong.
3. **Is the overtake heuristic worth its complexity**, or should an expensive churning file simply
   be left to the calm period?
4. **Remote-listing caching** — worth doing now, or premature?
