### PR TITLE
[Release] Refresh OpenCode model cache before validating RELEASE_NOTES_MODEL

### DIFF
--- a/utils/release_notes/generate_release_notes.py
+++ b/utils/release_notes/generate_release_notes.py
@@ -19,6 +19,7 @@ import time
 from pathlib import Path
 
 from .fetch_prs import fetch_prs_since_tag
+from .opencode import check_opencode_model
 from .validate_notes import validate_release_notes
 
 
@@ -59,27 +60,6 @@ def bump_version(tag: str, bump_type: str = "patch") -> str:
 
     prefix = "v" if tag.startswith("v") else ""
     return f"{prefix}{major}.{minor}.{patch}"
-
-
-def check_opencode_model(model: str) -> None:
-    """Verify that ``model`` is listed by ``opencode models``.
-
-    OpenCode exits 0 and prints an error line when an unknown model is passed
-    via ``--model``, so calls silently no-op unless we validate up front.
-    Raises ``RuntimeError`` if opencode is missing or the model is unknown.
-    """
-    opencode_cmd = shutil.which("opencode")
-    if not opencode_cmd:
-        raise RuntimeError("'opencode' command not found in PATH")
-
-    result = subprocess.run([opencode_cmd, "models"], check=True, capture_output=True, text=True)
-    available = [line.strip() for line in result.stdout.splitlines() if line.strip()]
-    if model not in available:
-        raise RuntimeError(
-            f"RELEASE_NOTES_MODEL={model!r} not found in `opencode models` output. "
-            f"Expected the full `provider/model` form (e.g. `huggingface/zai-org/GLM-4.6`). "
-            f"{len(available)} model(s) available — first 10: {', '.join(available[:10])}"
-        )
 
 
 def run_opencode_skill(

--- a/utils/release_notes/generate_slack_message.py
+++ b/utils/release_notes/generate_slack_message.py
@@ -18,6 +18,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+from .opencode import check_opencode_model
 from .validate_notes import find_release_notes_file
 
 
@@ -111,6 +112,17 @@ def main(version: str, rc_version: str, input_file: Path | None = None, output_f
     Returns:
         Exit code (0 for success, non-zero for failure)
     """
+    # Validate the configured model before doing any expensive work.
+    # OpenCode exits 0 on unknown models, so a typo here would otherwise
+    # silently produce an empty Slack message.
+    model = os.environ.get("RELEASE_NOTES_MODEL")
+    if model:
+        try:
+            check_opencode_model(model)
+        except RuntimeError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            return 1
+
     # Resolve input file
     if input_file is None:
         input_file = find_release_notes_file(version)

--- a/utils/release_notes/opencode.py
+++ b/utils/release_notes/opencode.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Shared OpenCode helpers for the release notes scripts."""
+
+import shutil
+import subprocess
+
+
+def check_opencode_model(model: str) -> None:
+    """Verify that ``model`` is listed by ``opencode models``.
+
+    OpenCode exits 0 and prints an error line when an unknown model is passed
+    via ``--model``, so calls silently no-op unless we validate up front.
+    Raises ``RuntimeError`` if opencode is missing or the model is unknown.
+
+    ``--refresh`` is what makes this reliable on CI. OpenCode reads its model
+    catalog from ``~/.cache/opencode/models.json`` and falls back to the
+    models.dev snapshot embedded in the binary at build time when that file is
+    missing; the refresh it triggers runs in a background fiber that is never
+    awaited. On a fresh runner the first call therefore lists the snapshot of
+    the pinned OpenCode version, so any model released after that version looks
+    unknown. ``--refresh`` fetches the catalog up front and warms the cache for
+    the ``opencode run`` calls that follow.
+    """
+    opencode_cmd = shutil.which("opencode")
+    if not opencode_cmd:
+        raise RuntimeError("'opencode' command not found in PATH")
+
+    result = subprocess.run([opencode_cmd, "models", "--refresh"], check=True, capture_output=True, text=True)
+    available = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    if model not in available:
+        raise RuntimeError(
+            f"RELEASE_NOTES_MODEL={model!r} not found in `opencode models` output. "
+            f"Expected the full `provider/model` form (e.g. `huggingface/zai-org/GLM-4.6`). "
+            f"{len(available)} model(s) available — first 10: {', '.join(available[:10])}"
+        )


### PR DESCRIPTION
## Summary

The `release-notes` job of the last release [failed](https://github.com/huggingface/huggingface_hub/actions/runs/33062824690/job/98485628859) with:

```
Error: RELEASE_NOTES_MODEL='huggingface/zai-org/GLM-5.3-Flash' not found in `opencode models` output.
76 model(s) available — first 10: opencode/big-pickle, ..., huggingface/deepseek-ai/DeepSeek-V3
```

…while `opencode models` on the very same version (1.18.23) lists the model just fine locally.

**Why:** OpenCode reads its model catalog from `~/.cache/opencode/models.json`, and falls back to **the models.dev snapshot embedded in the binary at build time** when that file is missing. The refresh it triggers runs in a background fiber that is never awaited (5-minute mtime TTL, errors swallowed), so the list you get printed is whatever was on disk *when the process started*. On a fresh runner there is no cache file yet → we get the snapshot of the pinned OpenCode version → any model released after that version looks unknown. Locally the cache is warm, hence the discrepancy. Nothing to do with the token, the version pin, or HF router availability.

The fix is `opencode models --refresh`, which fetches the catalog up front (and conveniently warms the cache for the `opencode run` calls that follow).

* `check_opencode_model()` moves to a new `utils/release_notes/opencode.py` and now passes `--refresh`.
* `generate_slack_message.py` now runs that same check. It was passing `--model $RELEASE_NOTES_MODEL` with **no** validation, and the `slack-message` job also installs OpenCode cold — so on a clean runner it would have silently produced an empty message (OpenCode exits 0 on unknown models). It only went unnoticed because that step is skipped when `release-notes` fails.

Side benefit: the model list is no longer pinned to the OpenCode build date, so bumping `vars.RELEASE_NOTES_MODEL` to a freshly released model no longer requires bumping `vars.OPENCODE_VERSION` too.

## Reproduction

Same binary, same token, only `HOME`/XDG dirs changed (the 24 extra `togetherai` models come from a local API key; CI has none, hence its `76`):

| run | total | huggingface | GLM-5.3-Flash |
|---|---|---|---|
| real `$HOME` (warm cache) | 101 | 71 | ✅ |
| fresh `$HOME`, 1st call | 100 | 69 | ❌ |
| fresh `$HOME`, 2nd call | 101 | 71 | ✅ |
| fresh + `OPENCODE_DISABLE_MODELS_FETCH=1` | 100 | 69 | ❌ (no `models.json` written) |
| fresh + `opencode models --refresh` | 101 | 71 | ✅ |

`grep -a GLM-5.3-Flash` on the binary → 0 hits, `GLM-5.2` → hit. The cold list also contains `opencode/x-preview-f-free`, which the *live* catalog no longer has — confirming it is an older snapshot rather than a filtered list.

Before/after in a CI-like cold environment:

```
$ env HOME=$COLD ... python -c "from utils.release_notes.opencode import check_opencode_model; ..."
# before
RuntimeError: RELEASE_NOTES_MODEL='huggingface/zai-org/GLM-5.3-Flash' not found in `opencode models` output. ...
# after
OK: model accepted on a cold cache
OK: unknown model still rejected -> RELEASE_NOTES_MODEL='huggingface/does-not/Exist' not found in ...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect release-notes automation scripts and OpenCode CLI invocation; no runtime library or security-sensitive paths.
> 
> **Overview**
> Fixes release CI failures where `RELEASE_NOTES_MODEL` was rejected on cold runners because `opencode models` used an embedded snapshot until the cache warmed.
> 
> **`check_opencode_model`** moves into new `utils/release_notes/opencode.py` and now runs `opencode models --refresh` so the live catalog is loaded (and cached) before validation and subsequent `opencode run` calls. `generate_release_notes.py` imports the shared helper instead of defining it locally.
> 
> **`generate_slack_message.py`** now runs the same upfront model check when `RELEASE_NOTES_MODEL` is set, failing fast instead of silently producing an empty Slack body (OpenCode exits 0 on unknown models).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 062139635d7387433be44eb92a8d652c362e61a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->