### PR TITLE
[CLI] Fix destructive lexical prefix match in 'hf buckets remove --recursive'

### DIFF
--- a/src/huggingface_hub/cli/buckets.py
+++ b/src/huggingface_hub/cli/buckets.py
@@ -421,9 +421,16 @@ def remove(
             prefix=prefix or None,
             recursive=True,
         ):
-            if isinstance(item, BucketFile):
-                all_files.append(item)
-                status.update(f"Listing files from remote ({len(all_files)} files)")
+            if not isinstance(item, BucketFile):
+                continue
+            # The server-side prefix filter is a raw lexical match, so it can also return
+            # sibling keys that merely start with the same characters (e.g. prefix "logs"
+            # matching "logs.json" or "logs_backup/x"). Enforce a path-boundary match here,
+            # same as `_buckets.py` and `hf_api.py::_copy_to_bucket`.
+            if prefix and not (item.path == prefix or item.path.startswith(prefix + "/")):
+                continue
+            all_files.append(item)
+            status.update(f"Listing files from remote ({len(all_files)} files)")
         status.done(f"Listing files from remote ({len(all_files)} files)")
 
         if include or exclude:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,6 +15,7 @@ import pytest
 from click.testing import CliRunner
 
 from huggingface_hub import HfApi, InferenceEndpointHardware, constants
+from huggingface_hub._buckets import BucketFile
 from huggingface_hub._dataset_viewer import DatasetParquetEntry
 from huggingface_hub._jobs_api import JobInfo, JobOwner, _create_job_spec, _derive_job_volume_name
 from huggingface_hub._space_api import Volume
@@ -4176,6 +4177,42 @@ class TestBucketTransport:
         # Volume is scoped to the shared subfolder via Volume.path
         assert len(extra_volumes) == 1
         assert extra_volumes[0].path == upload_prefixes.pop()
+
+
+class TestBucketsRemoveRecursivePrefixBoundary:
+    """`hf buckets remove <prefix> --recursive` must only delete files under a path boundary.
+
+    Regression test for a destructive bug where removing prefix "logs" would also delete
+    lexical siblings like "logs.json" or "logs_backup/x.txt" that merely start with the same
+    characters but are not nested under "logs/".
+    """
+
+    @staticmethod
+    def _bucket_file(path: str) -> BucketFile:
+        return BucketFile(type="file", path=path, size=1, xetHash="deadbeef", mtime=None, uploadedAt=None)
+
+    def test_remove_recursive_does_not_delete_lexical_siblings(self, runner: CliRunner) -> None:
+        server_returned_paths = [
+            "logs",  # exact match of the prefix itself
+            "logs/a.log",  # nested under prefix -> should be removed
+            "logs/sub/b.log",  # nested under prefix -> should be removed
+            "logs.json",  # lexical sibling -> must be kept
+            "logs_backup/x.txt",  # lexical sibling -> must be kept
+            "logsx/y.txt",  # lexical sibling -> must be kept
+        ]
+
+        with patch("huggingface_hub.cli.buckets.get_hf_api") as api_cls:
+            api = api_cls.return_value
+            api.list_bucket_tree.return_value = [self._bucket_file(p) for p in server_returned_paths]
+            result = runner.invoke(app, ["buckets", "remove", "user/my-bucket/logs", "--recursive", "--yes"])
+
+        assert result.exit_code == 0
+        api.batch_bucket_files.assert_called_once()
+        deleted_paths = set(api.batch_bucket_files.call_args.kwargs["delete"])
+        assert deleted_paths == {"logs", "logs/a.log", "logs/sub/b.log"}
+        assert "logs.json" not in deleted_paths
+        assert "logs_backup/x.txt" not in deleted_paths
+        assert "logsx/y.txt" not in deleted_paths
 
     def test_update_job_labels(self, runner: CliRunner) -> None:
         with patch("huggingface_hub.cli.jobs.get_hf_api") as api_cls:


### PR DESCRIPTION
## Summary

- `hf buckets remove <bucket>/<prefix> --recursive` filtered the file listing returned by the server using a **raw lexical prefix match** on `item.path`, instead of a path-boundary match.
- This means removing prefix `logs` would also delete unrelated sibling keys that merely start with the same characters, e.g. `logs.json`, `logs_backup/x.txt`, `logsx/y.txt` — none of which are nested under `logs/`.
- Buckets are **not versioned**, so this is a silent, irreversible data-loss bug.
- Three other call sites already apply the correct path-boundary pattern (`path == prefix or path.startswith(prefix + "/")`): `_buckets.py`, `hf_file_system.py` (fixed in #4630), and `hf_api.py`'s `_copy_to_bucket`. The `cli/buckets.py` `remove --recursive` branch was missed when #4630 landed.

## Fix

Applied the exact same path-boundary filter used elsewhere in the codebase to the file-listing loop in `cli/buckets.py::remove`, before files are handed to `--include`/`--exclude` filtering and ultimately `batch_bucket_files(delete=...)`.

## Test plan

Added `TestBucketsRemoveRecursivePrefixBoundary` in `tests/test_cli.py` (mocked `HfApi`, no network) with fixture files `logs`, `logs/a.log`, `logs/sub/b.log`, `logs.json`, `logs_backup/x.txt`, `logsx/y.txt`. Asserts that removing prefix `logs` recursively only deletes `logs`, `logs/a.log`, `logs/sub/b.log`, leaving the lexical siblings untouched.

Verified the test fails on the old code (reverted the fix locally, ran the test → `AssertionError` showing `logs.json`, `logs_backup/x.txt`, `logsx/y.txt` incorrectly included in the delete set) and passes with the fix reapplied.

```
$ pytest tests/test_cli.py -k TestBucketsRemoveRecursivePrefixBoundary -v
4 passed

$ pytest tests/test_cli.py -q
351 passed, 1 warning in 138.26s
```

Also ran `ruff format --check` and `ruff check` on the touched files — both pass.

Fixes #4749

---
Note: this PR was prepared with AI assistance (agent-driven investigation + patch), and I've reviewed and verified the fix and test results above.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which bucket keys are deleted during recursive remove; the fix narrows deletions and prevents accidental loss of unrelated objects, but remove behavior is still irreversible.
> 
> **Overview**
> Fixes a **destructive data-loss bug** in `hf buckets remove <prefix> --recursive`: the CLI now drops list results that only match the prefix lexically (e.g. `logs.json`, `logs_backup/`) and keeps paths under the prefix boundary (`path == prefix` or `path.startswith(prefix + "/")`), matching `_buckets.py` and other bucket call sites.
> 
> Adds **`TestBucketsRemoveRecursivePrefixBoundary`** in `tests/test_cli.py` (mocked API) to assert recursive remove of prefix `logs` only deletes `logs`, `logs/a.log`, and `logs/sub/b.log`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0148b185c20ab3802e2786b31fe9b1c3c5dba936. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->