### PR TITLE
switch windows executible

### DIFF
--- a/src/huggingface_hub/cli/extensions.py
+++ b/src/huggingface_hub/cli/extensions.py
@@ -693,7 +693,7 @@ def _github_repo_exists(*, owner: str, repo_name: str) -> bool:
 def _get_executable_name(short_name: str) -> str:
     name = f"hf-{short_name}"
     if os.name == "nt":
-        name += ".exe"
+        name += ".ps1"
     return name
 
 


### PR DESCRIPTION
follow up to https://github.com/huggingface/hf-claude/issues/5
the windows equivalent of `.sh` files is `.ps1` (PowerShell scripts), this pr switches the default executable on windows to PowerShell.

I do not recommend using `.exe` files, as they are bundled executables and are less convenient to work with and maintain.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single naming change in extension install/fetch logic; existing Windows installs with `.exe` paths in manifests would need reinstall to pick up `.ps1` unless repos still ship both.
> 
> **Overview**
> On Windows, the hf CLI extensions flow now treats **`hf-<name>.ps1`** as the platform entrypoint instead of **`hf-<name>.exe`**.
> 
> `_get_executable_name` drives remote binary downloads, on-disk install paths for binary extensions, and the console script name expected from pip-installed Python extensions, so Windows installs align with PowerShell scripts as the counterpart to Unix shell wrappers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a95477f9342b7a2af11346de4ac5233bc5a54b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->