### PR TITLE
[CI] Enable enforcement in close-unscoped-community-prs workflow

### DIFF
--- a/.github/workflows/close-unscoped-community-prs.yml
+++ b/.github/workflows/close-unscoped-community-prs.yml
@@ -6,10 +6,8 @@
 # Uses `pull_request_target` because `GITHUB_TOKEN` is read-only for PRs opened from forks.
 # The PR branch is never checked out, so no untrusted code runs here.
 #
-# The automatic trigger is dry-run only for now: it logs its decision without commenting or
-# closing, so we can watch it against real PRs. To enable enforcement, drop
-# `github.event_name == 'pull_request_target'` from `DRY_RUN` below. Until then, act on a
-# single PR with `workflow_dispatch` and `dry_run` unchecked.
+# A single PR can also be evaluated manually with `workflow_dispatch`, with `dry_run` checked
+# to only log the decision without commenting or closing.
 
 name: Close unscoped community PRs
 
@@ -48,7 +46,7 @@ jobs:
         env:
           MAINTAINERS: Wauplin,hanouticelina
           PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
-          DRY_RUN: ${{ inputs.dry_run || github.event_name == 'pull_request_target' }}
+          DRY_RUN: ${{ inputs.dry_run || false }}
         with:
           script: |
             const MARKER = "<!-- close-unscoped-community-pr -->";


### PR DESCRIPTION
## Summary

- Drops the `github.event_name == 'pull_request_target'` clause from `DRY_RUN`, so automatic runs on newly opened/reopened community PRs now actually comment and close instead of only logging the decision.
- `workflow_dispatch` keeps its `dry_run` input (still defaulting to `true`) for manually evaluating a single PR without side effects.
- Updated the header comment accordingly.

The dry-run observation period did its job: on [PR #4762](https://github.com/huggingface/huggingface_hub/pull/4762) the workflow correctly reached the close verdict but stopped short because automatic runs were forced into dry-run ([run log](https://github.com/huggingface/huggingface_hub/actions/runs/33066991929/job/98499405492)):

```
Referenced numbers: 4630, 4749
[dry run] Would close PR #4762 with comment:
Hi @g0rdonL, thanks for taking the time to open this PR!
...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Live enforcement can automatically close external contributors’ PRs; mis-scoping would block valid work, though the same logic was exercised in dry-run on real PRs.
> 
> **Overview**
> Turns off the automatic dry-run mode for the **Close unscoped community PRs** workflow, so `pull_request_target` runs on opened/reopened PRs from non-write contributors will now post the standard comment and close PRs that do not link an issue with a maintainer reply, instead of only logging what they would do.
> 
> Manual **`workflow_dispatch`** runs still support **`dry_run`** (default `true`) to evaluate a single PR without commenting or closing. The workflow header comment was updated to match this behavior and drop the old “observation period” instructions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c064bfaefa2faefead3bf399c69d6ba7b2f3a90a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->