### PR TITLE
[CLI] Avoid deleting lexical prefix siblings

### DIFF
--- a/src/huggingface_hub/cli/buckets.py
+++ b/src/huggingface_hub/cli/buckets.py
@@ -426,6 +426,10 @@ def remove(
                 status.update(f"Listing files from remote ({len(all_files)} files)")
         status.done(f"Listing files from remote ({len(all_files)} files)")
 
+        if prefix:
+            prefix = prefix.rstrip("/")
+            all_files = [file for file in all_files if file.path == prefix or file.path.startswith(f"{prefix}/")]
+
         if include or exclude:
             matcher = FilterMatcher(include_patterns=include, exclude_patterns=exclude)
             matched_files = [f for f in all_files if matcher.matches(f.path)]

--- a/tests/test_buckets_cli.py
+++ b/tests/test_buckets_cli.py
@@ -320,6 +320,37 @@ def test_rm_recursive_dry_run(api: HfApi, bucket_write: str):
     assert _remote_files(api, bucket_write) == {"data/a.txt", "data/b.txt"}
 
 
+def test_rm_recursive_dry_run_respects_prefix_boundary(api: HfApi, bucket_write: str):
+    """'hf buckets rm --recursive' does not remove lexical prefix siblings."""
+    api.batch_bucket_files(
+        bucket_write,
+        add=[
+            (b"inside", "logs/a.txt"),
+            (b"deep", "logs/sub/deep.txt"),
+            (b"sibling", "logs.json"),
+            (b"sibling", "logs_backup/b.txt"),
+            (b"sibling", "logsx/c.txt"),
+        ],
+    )
+
+    result = cli(f"hf buckets rm {bucket_write}/logs --recursive --dry-run")
+    assert result.exit_code == 0
+    assert "2 file(s)" in result.output
+    assert f"delete: {BUCKET_PREFIX}{bucket_write}/logs/a.txt" in result.output
+    assert f"delete: {BUCKET_PREFIX}{bucket_write}/logs/sub/deep.txt" in result.output
+    for path in ("logs.json", "logs_backup/b.txt", "logsx/c.txt"):
+        assert f"delete: {BUCKET_PREFIX}{bucket_write}/{path}" not in result.output
+
+    # Files should still exist because this is a dry run.
+    assert _remote_files(api, bucket_write) == {
+        "logs/a.txt",
+        "logs/sub/deep.txt",
+        "logs.json",
+        "logs_backup/b.txt",
+        "logsx/c.txt",
+    }
+
+
 def test_rm_recursive_include(api: HfApi, bucket_write: str):
     """'hf buckets rm --recursive --include' only removes matching files."""
     api.batch_bucket_files(


### PR DESCRIPTION
## Summary

When `hf buckets rm --recursive` lists a prefix, the Hub can return lexical siblings such as `logs.json`, `logs_backup/`, and `logsx/`. The CLI previously passed all returned files to the delete operation.

- Normalize a requested prefix once and require an exact match or a slash-delimited descendant.
- Keep root-level recursive removal unchanged.
- Add a staging dry-run regression test covering files inside the prefix and lexical siblings.

Fixes #4749

Example covered by the regression test:

```
hf buckets rm user/my-bucket/logs --recursive --dry-run
delete: hf://buckets/user/my-bucket/logs/a.txt
delete: hf://buckets/user/my-bucket/logs/sub/deep.txt
(dry run) 2 file(s) ... would be removed.
```

## Checks

- `pytest tests/test_buckets_cli.py -k "prefix_boundary"` — 1 passed
- `ruff check src tests utils setup.py`
- `ruff format --check src tests utils setup.py`
- repository generation checks and `ty check src`

This PR was prepared with AI assistance and reviewed against the bucket CLI and staging behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes destructive delete selection for prefixed recursive `rm`; incorrect filtering could still delete wrong objects or skip intended files, though scope is narrow and covered by a new integration test.
> 
> **Overview**
> **Fixes overly broad deletes** when running `hf buckets rm <bucket>/logs --recursive`: the Hub listing for prefix `logs` can include paths like `logs.json`, `logs_backup/`, and `logsx/` that share the same string prefix but are not under the `logs/` directory.
> 
> After the recursive remote listing, the CLI now **normalizes the requested prefix** (trailing slashes stripped) and **keeps only paths that equal the prefix or are descendants** (`prefix` or `prefix/...`). Root-level `hf buckets rm <bucket> --recursive` is unchanged because this filter runs only when a path prefix is set.
> 
> A **staging dry-run regression test** asserts that only `logs/a.txt` and `logs/sub/deep.txt` would be removed, not the lexical sibling paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6144b5d9a4cae4775b6b2eae5df00a2d45dffa46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->