### PR TITLE
feat: add Scalattice inference provider

### DIFF
--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -135,7 +135,7 @@ class InferenceClient:
             Note: for better compatibility with OpenAI's client, `model` has been aliased as `base_url`. Those 2
             arguments are mutually exclusive. If a URL is passed as `model` or `base_url` for chat completion, the `(/v1)/chat/completions` suffix path will be appended to the URL.
         provider (`str`, *optional*):
-            Name of the provider to use for inference. Can be `"baseten"`, `"cerebras"`, `"cohere"`, `"deepinfra"`, `"fal-ai"`, `"featherless-ai"`, `"fireworks-ai"`, `"groq"`, `"hf-inference"`, `"novita"`, `"nscale"`, `"openai"`, `"ovhcloud"`, `"publicai"`, `"replicate"`, `"scaleway"`, `"together"`, `"wavespeed"` or `"zai-org"`.
+            Name of the provider to use for inference. Can be `"baseten"`, `"cerebras"`, `"cohere"`, `"deepinfra"`, `"fal-ai"`, `"featherless-ai"`, `"fireworks-ai"`, `"groq"`, `"hf-inference"`, `"novita"`, `"nscale"`, `"openai"`, `"ovhcloud"`, `"publicai"`, `"replicate"`, `"scalattice"`, `"scaleway"`, `"together"`, `"wavespeed"` or `"zai-org"`.
             Defaults to "auto": automatic routing, which defaults to "fastest" provider; you can
             switch to "cheapest" or "preferred" provider order at https://hf.co/settings/inference-providers.
             If model is a URL or `base_url` is passed, then `provider` is not used.

--- a/src/huggingface_hub/inference/_providers/__init__.py
+++ b/src/huggingface_hub/inference/_providers/__init__.py
@@ -46,6 +46,7 @@ from .replicate import (
     ReplicateTextToImageTask,
     ReplicateTextToSpeechTask,
 )
+from .scalattice import ScalatticeConversationalTask
 from .scaleway import ScalewayConversationalTask, ScalewayFeatureExtractionTask
 from .together import (
     TogetherConversationalTask,
@@ -85,6 +86,7 @@ PROVIDER_T = Literal[
     "ovhcloud",
     "publicai",
     "replicate",
+    "scalattice",
     "scaleway",
     "together",
     "wavespeed",
@@ -183,6 +185,9 @@ PROVIDERS: dict[PROVIDER_T, dict[str, TaskProviderHelper]] = {
         "text-to-image": ReplicateTextToImageTask(),
         "text-to-speech": ReplicateTextToSpeechTask(),
         "text-to-video": ReplicateTask("text-to-video"),
+    },
+    "scalattice": {
+        "conversational": ScalatticeConversationalTask(),
     },
     "scaleway": {
         "conversational": ScalewayConversationalTask(),

--- a/src/huggingface_hub/inference/_providers/_common.py
+++ b/src/huggingface_hub/inference/_providers/_common.py
@@ -32,6 +32,7 @@ HARDCODED_MODEL_INFERENCE_MAPPING: dict[str, dict[str, InferenceProviderMapping]
     "nscale": {},
     "ovhcloud": {},
     "replicate": {},
+    "scalattice": {},
     "scaleway": {},
     "together": {},
     "wavespeed": {},

--- a/src/huggingface_hub/inference/_providers/scalattice.py
+++ b/src/huggingface_hub/inference/_providers/scalattice.py
@@ -1,0 +1,6 @@
+from ._common import BaseConversationalTask
+
+
+class ScalatticeConversationalTask(BaseConversationalTask):
+    def __init__(self):
+        super().__init__(provider="scalattice", base_url="https://api.scalattice.cloud")


### PR DESCRIPTION
## Summary
Registers Scalattice in the Python inference client, matching the huggingface.js helper.

- `ScalatticeConversationalTask` at `https://api.scalattice.cloud`
- Default `/v1/chat/completions` route
- Added to `PROVIDER_T` and `PROVIDERS` (alphabetical)

Companion JS PR is in huggingface/huggingface.js.

cc @Wauplin @hanouticelina

## Test plan
- [ ] `InferenceClient(provider="scalattice")` builds the chat completions URL
- [ ] Import of `_providers` succeeds

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive provider registration with no changes to existing routing or auth logic; risk is limited to incorrect URL or missing Hub model mappings at runtime.
> 
> **Overview**
> Adds **Scalattice** as a third-party inference provider so `InferenceClient(provider="scalattice")` can route **chat completion** requests through the standard provider registry.
> 
> A new `ScalatticeConversationalTask` subclasses `BaseConversationalTask`, pointing at `https://api.scalattice.cloud` and the usual `/v1/chat/completions` path. The provider id is wired into `PROVIDER_T`, the `PROVIDERS` map (conversational only), the dev `HARDCODED_MODEL_INFERENCE_MAPPING` stub, and the `InferenceClient` `provider` docstring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d7d57adbb9dbe587ebdbf1cf5cc30c7e7f25ace. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->