### PR TITLE
[CI] Fix torch_1.11 case-arm label to match renamed matrix entry

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -92,7 +92,7 @@ jobs:
               uv pip install --upgrade torch
               ;;
 
-            "Python 3.9, torch_1.11")
+            "Python 3.10, torch_1.11")
               uv pip install "huggingface_hub[torch] @ ."
               uv pip install torch~=1.11
               ;;


### PR DESCRIPTION
Closes https://github.com/huggingface/huggingface_hub/issues/4775.

The `torch~=1.11` matrix entry's `test_name` was renamed to `"Python 3.10, torch_1.11"` in #4008 (`4c7b420f`, 2026-03-31), but the install step's `case` arm still matches the old `"Python 3.9, torch_1.11"`. There is no `*)` default arm, so the case falls through, torch is never installed on that lane, and its tests skip with "Test requires torch" while the job still reports green.

This changes that one label so the arm matches the entry it belongs to. Nothing else.

`git grep "Python 3.9, torch_1.11"` returns nothing after the change, so no other reference to the old label remains.

What I have not verified: whether the lane passes once torch actually installs. These tests have not run for 138 days, so some may fail on drift that accumulated while the lane was silently skipping. That would be a separate finding rather than a reason to leave the lane disabled, but it is worth expecting on the first green run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single string fix in CI install logic; restores intended torch 1.11 coverage with no runtime or security impact.
> 
> **Overview**
> Fixes a **silent CI gap** on the `torch~=1.11` lane: the matrix `test_name` was already `"Python 3.10, torch_1.11"`, but the dependency install `case` arm still matched the old `"Python 3.9, torch_1.11"` string.
> 
> Because that workflow has **no default `*)` branch**, the mismatch meant **torch was never installed** on that job. Hub-mixin/serialization tests could skip for missing torch while the job still looked successful.
> 
> The change updates that one install `case` label so it matches the matrix entry and the existing test-run arm; **no application code** is touched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf7b8a1dfdb84e10c7b63de8826016600bcc2de9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->