### PR TITLE
[CI] Fix torch 1.11 test lane install selector

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -92,7 +92,7 @@ jobs:
               uv pip install --upgrade torch
               ;;
 
-            "Python 3.9, torch_1.11")
+            "Python 3.10, torch_1.11")
               uv pip install "huggingface_hub[torch] @ ."
               uv pip install torch~=1.11
               ;;


### PR DESCRIPTION
## Summary

- Fix the `torch_1.11` install selector to match the current `Python 3.10, torch_1.11` matrix entry.
- Restore installation of `torch~=1.11` so the compatibility lane does not silently skip its torch-dependent tests.

Fixes #4775.

Coordination: [issue plan comment](https://github.com/huggingface/huggingface_hub/issues/4775#issuecomment-5468708965).

## Validation

- `pre-commit run --files .github/workflows/python-tests.yml` passed, including YAML validation and whitespace/conflict checks.
- Parsed `.github/workflows/python-tests.yml` successfully and verified the matrix, install, and test-run selectors use the same `Python 3.10, torch_1.11` label.
- `git diff --check` passed.
- The Python 3.10 / torch 1.11 GitHub Actions lane was not available locally; CI will exercise the restored installation and its existing test selection.

AI assistance was used to prepare this change. I reviewed the complete diff and the validation results.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow-only change with no runtime or library behavior impact; it restores intended dependency installation for one test matrix entry.
> 
> **Overview**
> Fixes a **label mismatch** in the Ubuntu CI workflow so the `Python 3.10, torch_1.11` matrix job actually runs its dedicated install path.
> 
> The install `case` branch still keyed off `Python 3.9, torch_1.11` while the matrix and test steps already used `Python 3.10, torch_1.11`, so that lane never installed `huggingface_hub[torch]` or `torch~=1.11` and torch compatibility tests could run without the intended PyTorch version. The selector is updated to `Python 3.10, torch_1.11` so `torch~=1.11` is installed again for that job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51902f0ffb59718034db864179f329f9a92a14ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->