### PR TITLE
[Download] Validate cached file size before trusting it (#4768)

### DIFF
--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -535,6 +535,17 @@ def snapshot_download(
         assert all(isinstance(r, DryRunFileInfo) for r in results)
         return results  # type: ignore
 
+    # Safety net for the invariant "a successful snapshot has every requested file present and complete".
+    # `hf_hub_download` already validates (and repairs) each file it returns, so this should never fire in
+    # practice; it is one `stat` per requested file (expected sizes are already in memory from the tree
+    # listing) and turns any residual gap into an explicit error instead of a silently unusable snapshot.
+    _raise_if_snapshot_incomplete(
+        base_dir=str(local_dir) if local_dir is not None else snapshot_folder,
+        expected_sizes={path: tree_entries[path].size for path in filtered_repo_files},
+        repo_id=repo_id,
+        commit_hash=commit_hash,
+    )
+
     if local_dir is not None:
         return str(os.path.realpath(local_dir))
     return snapshot_folder
@@ -554,7 +565,9 @@ def _raise_if_incomplete_snapshot(
     """Raise [`IncompleteSnapshotError`] if the cached tree listing shows `base_dir` misses requested files.
 
     If the tree listing is not cached we cannot tell, so we do nothing and the caller keeps returning the
-    folder as-is. Otherwise every expected file (after pattern filtering) must exist under `base_dir`.
+    folder as-is. Otherwise every expected file (after pattern filtering) must exist under `base_dir` at
+    the size recorded in the tree listing (a truncated file counts as incomplete; a legitimate empty file
+    does not).
     """
     tree_entries = read_tree_cache(tree_cache_folder, commit_hash)
     if tree_entries is None:
@@ -562,7 +575,7 @@ def _raise_if_incomplete_snapshot(
     expected = filter_repo_objects(
         items=tree_entries.keys(), allow_patterns=allow_patterns, ignore_patterns=ignore_patterns
     )
-    missing = [path for path in expected if not _local_file_exists(base_dir, path)]
+    missing = [path for path in expected if not _local_file_is_complete(base_dir, path, tree_entries[path].size)]
     if not missing:
         return
 
@@ -575,8 +588,8 @@ def _raise_if_incomplete_snapshot(
         reason = "Outgoing traffic is disabled ('local_files_only=True')."
     raise IncompleteSnapshotError(
         f"The cached snapshot for '{repo_id}' (revision '{revision}', commit {commit_hash}) is incomplete: "
-        f"{len(missing)} file(s) are missing ({sample}). {reason} Re-run the download with network access "
-        "to complete the snapshot.",
+        f"{len(missing)} file(s) are missing or incomplete ({sample}). {reason} Re-run the download with "
+        "network access to complete the snapshot.",
         snapshot_path=base_dir,
     ) from api_call_error
 
@@ -680,13 +693,55 @@ def get_cached_repo_tree(
     ]
 
 
-def _local_file_exists(base_dir: str, path: str) -> bool:
-    """Check whether a repo file (path relative to `base_dir`, '/'-separated) exists on disk.
+def _local_file_full_path(base_dir: str, path: str) -> str:
+    """Resolve a repo file (path relative to `base_dir`, '/'-separated) to an on-disk path.
 
-    On Windows, paths longer than 255 characters must be prefixed with `\\\\?\\`, otherwise `os.path.isfile` reports an
+    On Windows, paths longer than 255 characters must be prefixed with `\\\\?\\`, otherwise `os.path` reports an
     existing file as missing.
     """
     full_path = os.path.join(base_dir, *path.split("/"))
     if os.name == "nt" and len(os.path.abspath(full_path)) > 255 and not full_path.startswith("\\\\?\\"):
         full_path = "\\\\?\\" + os.path.abspath(full_path)
-    return os.path.isfile(full_path)
+    return full_path
+
+
+def _local_file_is_complete(base_dir: str, path: str, expected_size: int | None) -> bool:
+    """Whether a repo file exists under `base_dir` at its expected size.
+
+    `expected_size is None` means the size is unknown, so only existence is required. An `expected_size`
+    of `0` is valid and is checked like any other size (a legitimate empty file passes).
+    """
+    try:
+        actual_size = os.path.getsize(_local_file_full_path(base_dir, path))
+    except OSError:
+        return False  # missing file or broken symlink
+    return expected_size is None or actual_size == expected_size
+
+
+def _raise_if_snapshot_incomplete(
+    *, base_dir: str, expected_sizes: dict[str, int], repo_id: str, commit_hash: str
+) -> None:
+    """Raise [`IncompleteSnapshotError`] if any just-downloaded file is missing or the wrong size."""
+    broken = [
+        f"{path} ({_describe_local_file(base_dir, path)} vs {expected_size} bytes expected)"
+        for path, expected_size in expected_sizes.items()
+        if not _local_file_is_complete(base_dir, path, expected_size)
+    ]
+    if not broken:
+        return
+    sample = ", ".join(broken[:3])
+    if len(broken) > 3:
+        sample += f", ... ({len(broken) - 3} more)"
+    raise IncompleteSnapshotError(
+        f"The snapshot for '{repo_id}' (commit {commit_hash}) is incomplete after download: {len(broken)} "
+        f"file(s) are missing or the wrong size ({sample}). This can happen if a partial file from an "
+        "interrupted download is cached; re-run with `force_download=True` to repair it.",
+        snapshot_path=base_dir,
+    )
+
+
+def _describe_local_file(base_dir: str, path: str) -> str:
+    try:
+        return f"{os.path.getsize(_local_file_full_path(base_dir, path))} bytes"
+    except OSError:
+        return "missing"

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1046,6 +1046,38 @@ def hf_hub_download(
         )
 
 
+def _cached_file_size_mismatch(path: str, expected_size: int | None) -> bool:
+    """Return whether the file at `path` exists but its size contradicts a known `expected_size`.
+
+    Used to detect a partial/corrupt cache entry (e.g. a blob left truncated by a download interrupted
+    with an older `huggingface_hub`) before trusting it as a completed download.
+
+    Returns `False` when `expected_size` is `None` (size unknown, nothing to check - preserve existing
+    behavior), when `path` does not exist, or when the size matches. An `expected_size` of `0` is a
+    valid expected size and is checked like any other.
+    """
+    if expected_size is None:
+        return False
+    try:
+        return os.path.getsize(path) != expected_size
+    except OSError:
+        # Missing file or broken symlink: not a size mismatch, handled by the normal "not cached" flow.
+        return False
+
+
+def _expected_size_from_tree_cache(tree_cache_folder: str, commit_hash: str, filename: str) -> int | None:
+    """Return the expected size of `filename` from the on-disk tree listing, or `None` if unknown.
+
+    The tree listing is populated by [`snapshot_download`]; when present it lets the commit-hash
+    shortcut validate a cached file's size without any network call.
+    """
+    entries = read_tree_cache(tree_cache_folder, commit_hash)
+    if entries is None:
+        return None
+    entry = entries.get(filename)
+    return entry.size if entry is not None else None
+
+
 def _hf_hub_download_to_cache_dir(
     *,
     # Destination
@@ -1080,7 +1112,13 @@ def _hf_hub_download_to_cache_dir(
     # if user provides a commit_hash and they already have the file on disk, shortcut everything.
     if REGEX_COMMIT_HASH.match(revision):
         pointer_path = _get_pointer_path(storage_folder, revision, relative_filename)
-        if os.path.exists(pointer_path):
+        # A commit hash is immutable, so an existing cached file can normally be returned without any
+        # network call. Guard against a partial/corrupt cached file when its expected size is already
+        # known locally from the on-disk tree listing (populated by `snapshot_download`); an unknown
+        # size keeps the fast path unchanged.
+        if os.path.exists(pointer_path) and not _cached_file_size_mismatch(
+            pointer_path, _expected_size_from_tree_cache(storage_folder, revision, filename)
+        ):
             if dry_run:
                 return DryRunFileInfo(
                     commit_hash=revision,
@@ -1182,20 +1220,35 @@ def _hf_hub_download_to_cache_dir(
     blob_path = os.path.join(storage_folder, "blobs", etag)
     pointer_path = _get_pointer_path(storage_folder, commit_hash, relative_filename)
 
+    # A cached blob/pointer whose size does not match the size the Hub reports for this commit is a
+    # partial/corrupt entry (e.g. left behind by a download interrupted with an older `huggingface_hub`,
+    # or a failed Xet reconstruction). Treat it exactly like `force_download` for this file: don't
+    # return it as-is, and let the download path below overwrite it. `expected_size` is authoritative
+    # here and a size of `0` is valid (checked in `_cached_file_size_mismatch`).
+    cached_entry_is_corrupt = not force_download and (
+        _cached_file_size_mismatch(pointer_path, expected_size) or _cached_file_size_mismatch(blob_path, expected_size)
+    )
+    if cached_entry_is_corrupt:
+        logger.warning(
+            f"Found a corrupted cache entry for {filename} ({repo_id}) at commit {commit_hash}: its size does not"
+            f" match the expected {expected_size} bytes. Re-downloading it."
+        )
+    must_download = force_download or cached_entry_is_corrupt
+
     if dry_run:
-        is_cached = os.path.exists(pointer_path) or os.path.exists(blob_path)
+        is_cached = (os.path.exists(pointer_path) or os.path.exists(blob_path)) and not cached_entry_is_corrupt
         return DryRunFileInfo(
             commit_hash=commit_hash,
             file_size=expected_size,
             filename=filename,
             is_cached=is_cached,
             local_path=pointer_path,
-            will_download=force_download or not is_cached,
+            will_download=must_download or not is_cached,
         )
 
     # Pointer already exists -> update the ref best-effort, then return without
     # attempting to write to the cache (which may be mounted read-only).
-    if not force_download and os.path.exists(pointer_path):
+    if not must_download and os.path.exists(pointer_path):
         try:
             _cache_commit_hash_for_specific_revision(storage_folder, revision, commit_hash)
         except OSError:
@@ -1239,13 +1292,13 @@ def _hf_hub_download_to_cache_dir(
     Path(lock_path).parent.mkdir(parents=True, exist_ok=True)
 
     # Blob exists but pointer must be (safely) created -> take the lock
-    if not force_download and os.path.exists(blob_path):
+    if not must_download and os.path.exists(blob_path):
         with WeakFileLock(lock_path):
             if not os.path.exists(pointer_path):
                 _create_symlink(blob_path, pointer_path, new_blob=False)
             return pointer_path
 
-    # Local file doesn't exist or etag isn't a match => retrieve file from remote (or cache)
+    # Local file doesn't exist, etag isn't a match, or the cached entry was corrupt => retrieve file from remote (or cache)
 
     with WeakFileLock(lock_path):
         _download_to_tmp_and_move(
@@ -1255,12 +1308,12 @@ def _hf_hub_download_to_cache_dir(
             headers=headers,
             expected_size=expected_size,
             filename=filename,
-            force_download=force_download,
+            force_download=must_download,
             etag=etag,
             xet_file_data=xet_file_data,
             tqdm_class=tqdm_class,
         )
-        if not os.path.exists(pointer_path):
+        if must_download or not os.path.exists(pointer_path):
             _create_symlink(blob_path, pointer_path, new_blob=True)
 
     return pointer_path
@@ -1298,13 +1351,19 @@ def _hf_hub_download_to_local_dir(
     local_dir = Path(local_dir)
     paths = get_local_download_paths(local_dir=local_dir, filename=filename)
     local_metadata = read_download_metadata(local_dir=local_dir, filename=filename)
+    tree_cache_folder = tree_cache_folder_for_local_dir(str(local_dir))
 
     # Local file exists + metadata exists + commit_hash matches => return file
+    # (unless its size contradicts the size recorded in the on-disk tree listing, i.e. it is a
+    # partial/corrupt file from an interrupted download - then fall through and re-download it).
     if (
         REGEX_COMMIT_HASH.match(revision)
         and paths.file_path.is_file()
         and local_metadata is not None
         and local_metadata.commit_hash == revision
+        and not _cached_file_size_mismatch(
+            str(paths.file_path), _expected_size_from_tree_cache(tree_cache_folder, revision, filename)
+        )
     ):
         local_file = str(paths.file_path)
         if dry_run:
@@ -1322,7 +1381,6 @@ def _hf_hub_download_to_local_dir(
     # Local file doesn't exist or commit_hash doesn't match => we need the etag
     # - Xet file => might be cached in /tree listing
     # - otherwise => HEAD /resolve call
-    tree_cache_folder = tree_cache_folder_for_local_dir(str(local_dir))
     (url_to_download, etag, commit_hash, expected_size, xet_file_data, head_call_error) = _get_metadata_or_catch_error(
         repo_id=repo_id,
         filename=filename,
@@ -1386,8 +1444,14 @@ def _hf_hub_download_to_local_dir(
     assert url_to_download is not None, "file location must have been retrieved from server"
     assert expected_size is not None, "expected_size must have been retrieved from server"
 
-    # Local file exists => check if it's up-to-date
-    if not force_download and paths.file_path.is_file():
+    # Local file exists and is complete => check if it's up-to-date
+    # (a size that contradicts the Hub's Content-Length means a partial/corrupt file from an
+    # interrupted download - fall through and re-download it even if the recorded etag still matches)
+    if (
+        not force_download
+        and paths.file_path.is_file()
+        and not _cached_file_size_mismatch(str(paths.file_path), expected_size)
+    ):
         # etag matches => update metadata and return file
         if local_metadata is not None and local_metadata.etag == etag:
             write_download_metadata(local_dir=local_dir, filename=filename, commit_hash=commit_hash, etag=etag)
@@ -1433,7 +1497,8 @@ def _hf_hub_download_to_local_dir(
             revision=commit_hash,
             repo_type=repo_type,
         )
-        if isinstance(cached_path, str):
+        # Only reuse the cache blob if it is complete; a truncated one must not be copied over.
+        if isinstance(cached_path, str) and not _cached_file_size_mismatch(cached_path, expected_size):
             with WeakFileLock(paths.lock_path):
                 paths.file_path.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copyfile(cached_path, paths.file_path)
@@ -1995,6 +2060,21 @@ def _download_to_tmp_and_move(
                     headers=headers,
                     expected_size=expected_size,
                     tqdm_class=tqdm_class,
+                )
+
+        # Promotion boundary: this temporary file is about to become the content-addressed `blobs/<etag>`
+        # entry, which every later download trusts without re-checking. Enforce the completion invariant
+        # for *both* backends here (`http_get` also checks internally; `xet_get`/`hf_xet` does not always):
+        # a partial/empty download - dropped connection, expired Xet token, interrupted reconstruction -
+        # must fail loudly instead of poisoning the cache. `expected_size` is authoritative; `0` is valid;
+        # an unknown size preserves existing behavior. See https://github.com/huggingface/huggingface_hub/issues/4768.
+        if expected_size is not None:
+            actual_size = tmp_path.stat().st_size if tmp_path.is_file() else 0
+            if actual_size != expected_size:
+                raise OSError(
+                    f"Consistency check failed: file should be of size {expected_size} but has size {actual_size}"
+                    f" ({filename}).\nThis is usually due to a network issue or an interrupted download. Please retry"
+                    " with `force_download=True`."
                 )
 
         logger.debug(f"Download complete. Moving file to {destination_path}")

--- a/tests/test_download_poisoned_cache.py
+++ b/tests/test_download_poisoned_cache.py
@@ -1,0 +1,442 @@
+"""Regression tests for https://github.com/huggingface/huggingface_hub/issues/4768.
+
+`hf download` (i.e. `snapshot_download` / `hf_hub_download`) could report success while returning a
+snapshot whose files were empty or truncated. Two failure modes:
+
+- Case A - a *new* download whose reconstruction/stream produced fewer bytes than expected was promoted
+  into the cache without any size check (Xet path only; the HTTP path already had one).
+- Case B - a cache *already poisoned* by an older buggy run was trusted forever: the commit-hash
+  shortcut in `_hf_hub_download_to_cache_dir` returned the cached file as soon as it existed, never
+  comparing its size to the expected size.
+
+The invariant under test: a successful return implies every requested file exists **and** matches the
+size the Hub reports for that commit - while a legitimate zero-byte file stays valid.
+"""
+
+import os
+import time
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+from huggingface_hub import hf_hub_download, snapshot_download
+from huggingface_hub._local_folder import get_local_download_paths, write_download_metadata
+from huggingface_hub._snapshot_download import _raise_if_snapshot_incomplete
+from huggingface_hub._tree_cache import TreeCacheEntry, tree_cache_folder_for_local_dir, write_tree_cache
+from huggingface_hub.errors import IncompleteSnapshotError
+from huggingface_hub.file_download import HfFileMetadata, _create_symlink, _get_pointer_path, repo_folder_name
+from huggingface_hub.hf_api import RepoFile
+from huggingface_hub.utils import XetFileData
+from huggingface_hub.utils._xet import XetConnectionInfo
+
+
+COMMIT = "1111111111111111111111111111111111111111"
+ETAG = "e" * 64  # sha256-shaped etag => treated as an LFS/Xet blob
+
+
+def _storage(cache_dir, repo_id="user/repo"):
+    return Path(cache_dir) / repo_folder_name(repo_id=repo_id, repo_type="model")
+
+
+def _seed_cache_entry(cache_dir, filename, *, blob_bytes, expected_size, etag=ETAG, xet=False, write_tree=True):
+    """Recreate on disk exactly what a previous (possibly interrupted) download would have left."""
+    storage = _storage(cache_dir)
+    (storage / "blobs").mkdir(parents=True, exist_ok=True)
+    (storage / "refs").mkdir(parents=True, exist_ok=True)
+    blob_path = storage / "blobs" / etag
+    blob_path.write_bytes(blob_bytes)
+
+    pointer = Path(_get_pointer_path(str(storage), COMMIT, filename))
+    pointer.parent.mkdir(parents=True, exist_ok=True)
+    _create_symlink(str(blob_path), str(pointer), new_blob=False)
+
+    if write_tree:
+        write_tree_cache(
+            str(storage),
+            COMMIT,
+            {
+                filename: TreeCacheEntry(
+                    size=expected_size,
+                    blob_id="blob-" + filename,
+                    lfs_sha256=etag if xet else None,
+                    lfs_size=expected_size if xet else None,
+                    xet_hash=("c" * 64) if xet else None,
+                )
+            },
+        )
+    return storage, blob_path, pointer
+
+
+def _http_metadata(size, etag=ETAG):
+    return HfFileMetadata(
+        commit_hash=COMMIT,
+        etag=etag,
+        location=f"https://hub.example/resolve/{COMMIT}/file",
+        size=size,
+        xet_file_data=None,
+    )
+
+
+def _fake_http_get(url, temp_file, *, expected_size=None, **kwargs):
+    """Stand-in for `http_get` that writes exactly `expected_size` bytes (a correct download)."""
+    temp_file.write(b"\0" * (expected_size or 0))
+
+
+def _fake_http_get_writing(nbytes):
+    def _inner(url, temp_file, *, expected_size=None, **kwargs):
+        temp_file.write(b"\0" * nbytes)
+
+    return _inner
+
+
+def _fake_xet_session(nbytes):
+    """A mocked hf_xet session whose reconstruction writes `nbytes` to the path it is given."""
+    group = Mock()
+
+    def _write(xet_file_info, path, *a, **k):
+        Path(path).write_bytes(b"\0" * nbytes)
+
+    group.__enter__ = Mock(return_value=group)
+    group.__exit__ = Mock(return_value=False)
+    group.start_download_file.side_effect = _write
+    session = Mock()
+    session.new_file_download_group.return_value = group
+    conn = XetConnectionInfo(access_token="t", expiration_unix_epoch=9999999999, endpoint="https://cas")
+    return patch.multiple(
+        "huggingface_hub.utils._xet",
+        get_xet_session=Mock(return_value=session),
+        refresh_xet_connection_info=Mock(return_value=conn),
+    )
+
+
+# --------------------------------------------------------------------------------------------------
+# Case B - poisoned cache is not trusted (commit-hash shortcut + post-metadata shortcuts)
+# --------------------------------------------------------------------------------------------------
+
+
+class TestPoisonedCacheRecovery:
+    def test_complete_cache_is_returned_without_any_download(self, tmp_path):
+        """Test 1: expected == actual => fast path, no network."""
+        _seed_cache_entry(tmp_path, "model.bin", blob_bytes=b"\0" * 100, expected_size=100)
+        with (
+            patch("huggingface_hub.file_download.http_get") as http_get,
+            patch("huggingface_hub.file_download.get_hf_file_metadata") as meta,
+        ):
+            path = hf_hub_download("user/repo", "model.bin", revision=COMMIT, cache_dir=tmp_path)
+        assert os.path.getsize(path) == 100
+        http_get.assert_not_called()
+        meta.assert_not_called()  # commit-hash shortcut skipped the HEAD call entirely
+
+    def test_poisoned_blob_repaired_through_commit_hash_shortcut(self, tmp_path):
+        """Test 2 + 6: 400 cached bytes vs 1000 expected (tree cache present) => must re-download."""
+        _, blob_path, pointer = _seed_cache_entry(tmp_path, "model.bin", blob_bytes=b"\0" * 400, expected_size=1000)
+        assert os.path.getsize(pointer) == 400  # poisoned
+
+        with (
+            patch("huggingface_hub.file_download.get_hf_file_metadata", return_value=_http_metadata(1000)),
+            patch("huggingface_hub.file_download.http_get", side_effect=_fake_http_get) as http_get,
+        ):
+            path = hf_hub_download("user/repo", "model.bin", revision=COMMIT, cache_dir=tmp_path)
+
+        http_get.assert_called_once()
+        assert os.path.getsize(path) == 1000
+        assert os.path.getsize(blob_path) == 1000  # blob repaired in place
+
+    def test_poisoned_blob_repaired_through_post_metadata_shortcut(self, tmp_path):
+        """Branch revision (commit-hash shortcut not taken) => the post-metadata size check must catch it."""
+        storage, blob_path, _ = _seed_cache_entry(
+            tmp_path, "model.bin", blob_bytes=b"\0" * 400, expected_size=1000, write_tree=False
+        )
+        (storage / "refs" / "main").write_text(COMMIT)
+
+        with (
+            patch("huggingface_hub.file_download.get_hf_file_metadata", return_value=_http_metadata(1000)),
+            patch("huggingface_hub.file_download.http_get", side_effect=_fake_http_get) as http_get,
+        ):
+            path = hf_hub_download("user/repo", "model.bin", revision="main", cache_dir=tmp_path)
+
+        http_get.assert_called_once()
+        assert os.path.getsize(path) == 1000
+
+    def test_zero_byte_file_is_valid(self, tmp_path):
+        """Test 3: expected == 0 and actual == 0 => valid, no re-download, no error."""
+        _seed_cache_entry(tmp_path, "empty.txt", blob_bytes=b"", expected_size=0)
+        with (
+            patch("huggingface_hub.file_download.http_get") as http_get,
+            patch("huggingface_hub.file_download.get_hf_file_metadata", return_value=_http_metadata(0)),
+        ):
+            path = hf_hub_download("user/repo", "empty.txt", revision=COMMIT, cache_dir=tmp_path)
+        assert os.path.getsize(path) == 0
+        http_get.assert_not_called()
+
+    def test_unknown_local_size_preserves_commit_hash_shortcut(self, tmp_path):
+        """Test 4: no tree listing => size unknown locally => immutable-commit shortcut is preserved.
+
+        The shortcut must NOT start making a HEAD call for every already-cached file, and must not
+        reject the cached file. (`force_download=True` remains the escape hatch for this narrow case.)
+        """
+        _seed_cache_entry(tmp_path, "model.bin", blob_bytes=b"\0" * 400, expected_size=1000, write_tree=False)
+        with (
+            patch("huggingface_hub.file_download.http_get") as http_get,
+            patch("huggingface_hub.file_download.get_hf_file_metadata") as meta,
+        ):
+            path = hf_hub_download("user/repo", "model.bin", revision=COMMIT, cache_dir=tmp_path)
+        assert os.path.getsize(path) == 400
+        http_get.assert_not_called()
+        meta.assert_not_called()
+
+    def test_interrupted_download_is_not_promoted_then_retry_succeeds(self, tmp_path):
+        """Test 5: a truncated stream must not become a cache entry; a later run completes cleanly."""
+        storage = _storage(tmp_path)
+
+        with patch("huggingface_hub.file_download.get_hf_file_metadata", return_value=_http_metadata(1000)):
+            # 1st attempt: server delivers only 400 bytes => http_get's own consistency check raises.
+            with patch("huggingface_hub.file_download.http_get", side_effect=_fake_http_get_writing(400)):
+                with pytest.raises(EnvironmentError):
+                    hf_hub_download("user/repo", "model.bin", revision=COMMIT, cache_dir=tmp_path)
+
+            # Nothing partial was promoted.
+            assert list((storage / "blobs").glob("*")) == [] if (storage / "blobs").exists() else True
+
+            # 2nd attempt: full download succeeds.
+            with patch("huggingface_hub.file_download.http_get", side_effect=_fake_http_get):
+                path = hf_hub_download("user/repo", "model.bin", revision=COMMIT, cache_dir=tmp_path)
+        assert os.path.getsize(path) == 1000
+
+
+# --------------------------------------------------------------------------------------------------
+# Xet path (Case A: new truncated reconstruction ; Case B: poisoned reconstruction)
+# --------------------------------------------------------------------------------------------------
+
+
+@pytest.mark.xet
+class TestPoisonedXetCache:
+    def _xet_metadata_patch(self, size):
+        return patch(
+            "huggingface_hub.file_download.get_hf_file_metadata",
+            return_value=HfFileMetadata(
+                commit_hash=COMMIT,
+                etag=ETAG,
+                location=f"https://hub.example/resolve/{COMMIT}/file",
+                size=size,
+                xet_file_data=XetFileData(file_hash="c" * 64, refresh_route="r"),
+            ),
+        )
+
+    def test_new_truncated_xet_reconstruction_raises(self, tmp_path):
+        """Test 8a: reconstruction writes fewer bytes than expected, no exception => must raise."""
+        storage = _storage(tmp_path)
+        with (
+            self._xet_metadata_patch(1000),
+            patch("huggingface_hub.file_download.is_xet_available", return_value=True),
+            _fake_xet_session(400),
+        ):
+            with pytest.raises(EnvironmentError, match="Consistency check failed"):
+                hf_hub_download("user/repo", "model.bin", revision=COMMIT, cache_dir=tmp_path)
+        assert (
+            [p for p in (storage / "blobs").glob("*") if p.is_file()] == [] if (storage / "blobs").exists() else True
+        )
+
+    def test_correct_xet_reconstruction_succeeds(self, tmp_path):
+        """Test 8b: reconstruction writes the expected size => success."""
+        with (
+            self._xet_metadata_patch(1000),
+            patch("huggingface_hub.file_download.is_xet_available", return_value=True),
+            _fake_xet_session(1000),
+        ):
+            path = hf_hub_download("user/repo", "model.bin", revision=COMMIT, cache_dir=tmp_path)
+        assert os.path.getsize(path) == 1000
+
+    def test_poisoned_xet_blob_is_repaired(self, tmp_path):
+        """Case B for Xet: a 400-byte cached blob (tree cache present) is re-reconstructed to 1000."""
+        _, blob_path, pointer = _seed_cache_entry(
+            tmp_path, "model.bin", blob_bytes=b"\0" * 400, expected_size=1000, xet=True
+        )
+        assert os.path.getsize(pointer) == 400
+        with patch("huggingface_hub.file_download.is_xet_available", return_value=True), _fake_xet_session(1000):
+            path = hf_hub_download("user/repo", "model.bin", revision=COMMIT, cache_dir=tmp_path)
+        assert os.path.getsize(path) == 1000
+        assert os.path.getsize(blob_path) == 1000
+
+
+# --------------------------------------------------------------------------------------------------
+# snapshot_download level
+# --------------------------------------------------------------------------------------------------
+
+
+class TestSnapshotLevelCompleteness:
+    def _tree(self, sizes: dict):
+        return [
+            RepoFile(
+                path=name, size=size, oid="blob-" + name, lfs={"oid": "s-" + name, "size": size, "pointerSize": 1}
+            )
+            for name, size in sizes.items()
+        ]
+
+    def test_snapshot_repairs_one_poisoned_file_among_many(self, tmp_path):
+        """Test 7 (recovery): file B truncated in cache => snapshot_download repairs it and succeeds."""
+        sizes = {"a.bin": 10, "b.bin": 20, "c.bin": 30}
+        # Let `snapshot_download` build the tree listing itself from `list_repo_tree` (write_tree=False).
+        _seed_cache_entry(tmp_path, "a.bin", blob_bytes=b"\0" * 10, expected_size=10, etag="a" * 64, write_tree=False)
+        _seed_cache_entry(tmp_path, "b.bin", blob_bytes=b"\0" * 4, expected_size=20, etag="b" * 64, write_tree=False)
+        _seed_cache_entry(tmp_path, "c.bin", blob_bytes=b"\0" * 30, expected_size=30, etag="c" * 64, write_tree=False)
+
+        def per_file_meta(url, **kw):
+            name = str(url).rsplit("/", 1)[-1]
+            return _http_metadata(sizes[name], etag=name[0] * 64)
+
+        with (
+            patch("huggingface_hub._snapshot_download.HfApi.repo_info", return_value=Mock(sha=COMMIT)),
+            patch("huggingface_hub._snapshot_download.HfApi.list_repo_tree", return_value=self._tree(sizes)),
+            patch("huggingface_hub.file_download.get_hf_file_metadata", side_effect=per_file_meta),
+            patch("huggingface_hub.file_download.http_get", side_effect=_fake_http_get) as http_get,
+        ):
+            folder = snapshot_download("user/repo", cache_dir=tmp_path)
+
+        for name, size in sizes.items():
+            assert os.path.getsize(os.path.join(folder, name)) == size
+        http_get.assert_called_once()  # only the poisoned file was re-downloaded
+
+    def test_snapshot_raises_if_a_file_is_left_incomplete(self, tmp_path):
+        """Test 10: the snapshot-level safety net turns a residual gap into an explicit error.
+
+        Here `hf_hub_download` is stubbed to return a path to a short file (simulating any residual gap
+        the per-file logic might miss); `snapshot_download` must not report success.
+        """
+        storage = _storage(tmp_path)
+        snap = storage / "snapshots" / COMMIT
+        snap.mkdir(parents=True, exist_ok=True)
+        (snap / "a.bin").write_bytes(b"\0" * 10)
+        (snap / "b.bin").write_bytes(b"\0" * 5)  # short vs expected 20
+
+        def fake_download(repo_id, *, filename, **kw):
+            return str(snap / filename)
+
+        with (
+            patch("huggingface_hub._snapshot_download.HfApi.repo_info", return_value=Mock(sha=COMMIT)),
+            patch(
+                "huggingface_hub._snapshot_download.HfApi.list_repo_tree",
+                return_value=self._tree({"a.bin": 10, "b.bin": 20}),
+            ),
+            patch("huggingface_hub._snapshot_download.hf_hub_download", side_effect=fake_download),
+        ):
+            with pytest.raises(IncompleteSnapshotError, match="incomplete after download"):
+                snapshot_download("user/repo", cache_dir=tmp_path)
+
+    def test_worker_exception_propagates_through_snapshot_download(self, tmp_path):
+        """Test 11 / Q9: a per-file failure must not be swallowed by `hf_thread_map`."""
+
+        def boom(repo_id, *, filename, **kw):
+            if filename == "b.bin":
+                raise RuntimeError("download failed for b.bin")
+            return str(tmp_path / filename)
+
+        (tmp_path / "a.bin").write_bytes(b"")
+        (tmp_path / "c.bin").write_bytes(b"")
+        with (
+            patch("huggingface_hub._snapshot_download.HfApi.repo_info", return_value=Mock(sha=COMMIT)),
+            patch(
+                "huggingface_hub._snapshot_download.HfApi.list_repo_tree",
+                return_value=self._tree({"a.bin": 0, "b.bin": 0, "c.bin": 0}),
+            ),
+            patch("huggingface_hub._snapshot_download.hf_hub_download", side_effect=boom),
+        ):
+            with pytest.raises(RuntimeError, match="download failed for b.bin"):
+                snapshot_download("user/repo", cache_dir=tmp_path)
+
+
+class TestLocalDirPoisonedCache:
+    """`local_dir` downloads: the snapshot-level net always prevents false success; the per-file
+    shortcut additionally self-heals when a tree listing is available, and preserves the no-network
+    fast path when it is not."""
+
+    def _seed(self, local_dir: Path, filename, *, on_disk: bytes, expected_size: int, write_tree: bool):
+        local_dir.mkdir(parents=True, exist_ok=True)
+        paths = get_local_download_paths(local_dir=local_dir, filename=filename)
+        paths.file_path.parent.mkdir(parents=True, exist_ok=True)
+        paths.file_path.write_bytes(on_disk)
+        write_download_metadata(local_dir=local_dir, filename=filename, commit_hash=COMMIT, etag=ETAG)
+        old = time.time() - 100  # back-date so `read_download_metadata` accepts the metadata
+        os.utime(paths.file_path, (old, old))
+        if write_tree:
+            write_tree_cache(
+                tree_cache_folder_for_local_dir(str(local_dir)),
+                COMMIT,
+                {filename: TreeCacheEntry(size=expected_size, blob_id="b", lfs_sha256=ETAG, lfs_size=expected_size)},
+            )
+
+    def test_single_file_repaired_when_tree_listing_available(self, tmp_path):
+        local_dir = tmp_path / "ld"
+        self._seed(local_dir, "model.bin", on_disk=b"\0" * 400, expected_size=1000, write_tree=True)
+        with (
+            patch("huggingface_hub.file_download.get_hf_file_metadata", return_value=_http_metadata(1000)),
+            patch("huggingface_hub.file_download.http_get", side_effect=_fake_http_get) as http_get,
+        ):
+            path = hf_hub_download("user/repo", "model.bin", revision=COMMIT, local_dir=local_dir)
+        assert os.path.getsize(path) == 1000
+        http_get.assert_called_once()
+
+    def test_single_file_without_tree_listing_preserves_fast_path(self, tmp_path):
+        """No local size info + immutable commit + matching sidecar => no-network fast path is kept
+        (documented limitation; `force_download=True` is the escape hatch)."""
+        local_dir = tmp_path / "ld"
+        self._seed(local_dir, "model.bin", on_disk=b"\0" * 400, expected_size=1000, write_tree=False)
+        with (
+            patch("huggingface_hub.file_download.http_get") as http_get,
+            patch("huggingface_hub.file_download.get_hf_file_metadata") as meta,
+        ):
+            path = hf_hub_download("user/repo", "model.bin", revision=COMMIT, local_dir=local_dir)
+        assert os.path.getsize(path) == 400
+        http_get.assert_not_called()
+        meta.assert_not_called()
+
+    def test_snapshot_download_local_dir_repairs_poisoned_file(self, tmp_path):
+        local_dir = tmp_path / "ld"
+        self._seed(local_dir, "model.bin", on_disk=b"\0" * 400, expected_size=1000, write_tree=False)
+        repo_file = RepoFile(path="model.bin", size=1000, oid="b", lfs={"oid": "s", "size": 1000, "pointerSize": 1})
+        with (
+            patch("huggingface_hub._snapshot_download.HfApi.repo_info", return_value=Mock(sha=COMMIT)),
+            patch("huggingface_hub._snapshot_download.HfApi.list_repo_tree", return_value=[repo_file]),
+            patch("huggingface_hub.file_download.get_hf_file_metadata", return_value=_http_metadata(1000)),
+            patch("huggingface_hub.file_download.http_get", side_effect=_fake_http_get),
+        ):
+            folder = snapshot_download("user/repo", local_dir=local_dir)
+        assert os.path.getsize(os.path.join(folder, "model.bin")) == 1000
+
+    def test_snapshot_download_local_dir_raises_if_left_incomplete(self, tmp_path):
+        """If per-file repair is somehow bypassed, the snapshot-level net still blocks false success."""
+        local_dir = tmp_path / "ld"
+        self._seed(local_dir, "model.bin", on_disk=b"\0" * 400, expected_size=1000, write_tree=False)
+        repo_file = RepoFile(path="model.bin", size=1000, oid="b", lfs={"oid": "s", "size": 1000, "pointerSize": 1})
+        with (
+            patch("huggingface_hub._snapshot_download.HfApi.repo_info", return_value=Mock(sha=COMMIT)),
+            patch("huggingface_hub._snapshot_download.HfApi.list_repo_tree", return_value=[repo_file]),
+            patch(
+                "huggingface_hub._snapshot_download.hf_hub_download",
+                side_effect=lambda r, *, filename, **k: str(local_dir / filename),
+            ),
+        ):
+            with pytest.raises(IncompleteSnapshotError, match="incomplete after download"):
+                snapshot_download("user/repo", local_dir=local_dir)
+
+
+def test_raise_if_snapshot_incomplete_accepts_zero_byte_files(tmp_path):
+    """Unit check: the snapshot-level validator treats a legit 0-byte file as complete."""
+    (tmp_path / "empty.txt").write_bytes(b"")
+    (tmp_path / "data.bin").write_bytes(b"\0" * 5)
+    # No raise: empty.txt expected 0 / actual 0, data.bin expected 5 / actual 5.
+    _raise_if_snapshot_incomplete(
+        base_dir=str(tmp_path),
+        expected_sizes={"empty.txt": 0, "data.bin": 5},
+        repo_id="user/repo",
+        commit_hash=COMMIT,
+    )
+    # Raises once a size disagrees.
+    with pytest.raises(IncompleteSnapshotError):
+        _raise_if_snapshot_incomplete(
+            base_dir=str(tmp_path),
+            expected_sizes={"empty.txt": 0, "data.bin": 9},
+            repo_id="user/repo",
+            commit_hash=COMMIT,
+        )

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -756,7 +756,9 @@ class TestHfHubDownloadToLocalDir:
 
     def test_metadata_ok_and_etag_match(self):
         # 1 HEAD call + return early
-        self.file_path.write_text("something")
+        # Local file must be consistent with the recorded etag: same content => same size as the remote
+        # file, otherwise the size-consistency check (see #4768) rightly forces a re-download.
+        self.file_path.write_text("content")
         write_download_metadata(self.local_dir, self.file_name, self.commit_hash_1, etag=self.file_etag)
 
         with self.with_patch_download() as mock:

--- a/tests/test_snapshot_download.py
+++ b/tests/test_snapshot_download.py
@@ -40,7 +40,11 @@ def test_tree_with_redacted_xet_hash_is_not_cached(tmp_path: Path):
         patch("huggingface_hub._snapshot_download.HfApi.list_repo_tree", return_value=[repo_file]),
         patch("huggingface_hub._snapshot_download.hf_thread_map"),
     ):
-        snapshot_download("user/repo", cache_dir=tmp_path)
+        # `hf_thread_map` is stubbed out, so no file is actually materialized: the post-download
+        # completeness check then (correctly) reports the snapshot as incomplete. What this test cares
+        # about is only that the redacted xet hash kept the tree listing from being cached.
+        with pytest.raises(IncompleteSnapshotError):
+            snapshot_download("user/repo", cache_dir=tmp_path)
 
     storage_folder = tmp_path / repo_folder_name(repo_id="user/repo", repo_type="model")
     assert read_tree_cache(str(storage_folder), COMMIT_HASH) is None

--- a/tests/test_xet_download.py
+++ b/tests/test_xet_download.py
@@ -26,6 +26,16 @@ from .testing_constants import (
 pytestmark = pytest.mark.xet
 
 
+def _fake_xet_get(*, incomplete_path, expected_size=None, **kwargs):
+    """Stand-in for `xet_get` that writes exactly `expected_size` bytes (a correct reconstruction)."""
+    Path(incomplete_path).write_bytes(b"\0" * (expected_size or 0))
+
+
+def _fake_http_get(url, temp_file, *, expected_size=None, **kwargs):
+    """Stand-in for `http_get` that writes exactly `expected_size` bytes (a correct download)."""
+    temp_file.write(b"\0" * (expected_size or 0))
+
+
 @pytest.mark.production
 class TestXetFileDownload:
     @contextmanager
@@ -47,7 +57,7 @@ class TestXetFileDownload:
     def test_xet_get_called_when_xet_metadata_present(self, tmp_path):
         """Test that xet_get is called when xet metadata is present."""
         with self._patch_xet_file_metadata(with_xet_data=True) as mock_file_metadata:
-            with patch("huggingface_hub.file_download.xet_get") as mock_xet_get:
+            with patch("huggingface_hub.file_download.xet_get", side_effect=_fake_xet_get) as mock_xet_get:
                 with patch("huggingface_hub.file_download._create_symlink"):
                     hf_hub_download(
                         DUMMY_XET_MODEL_ID,
@@ -65,7 +75,7 @@ class TestXetFileDownload:
     def test_backward_compatibility_no_xet_metadata(self, tmp_path):
         """Test backward compatibility when response has no xet metadata."""
         with self._patch_xet_file_metadata(with_xet_data=False):
-            with patch("huggingface_hub.file_download.http_get") as mock_http_get:
+            with patch("huggingface_hub.file_download.http_get", side_effect=_fake_http_get) as mock_http_get:
                 with patch("huggingface_hub.file_download._create_symlink"):
                     hf_hub_download(
                         DUMMY_XET_MODEL_ID,
@@ -173,7 +183,7 @@ class TestXetFileDownload:
         )
 
         # Force download should re-download even if in cache
-        with patch("huggingface_hub.file_download.xet_get") as mock_xet_get:
+        with patch("huggingface_hub.file_download.xet_get", side_effect=_fake_xet_get) as mock_xet_get:
             path2 = hf_hub_download(
                 DUMMY_XET_MODEL_ID,
                 filename=DUMMY_XET_FILE,
@@ -195,6 +205,7 @@ class TestXetFileDownload:
                 xet_get=DEFAULT,
                 _create_symlink=DEFAULT,
             ) as mocks:
+                mocks["http_get"].side_effect = _fake_http_get
                 hf_hub_download(
                     DUMMY_XET_MODEL_ID,
                     filename=DUMMY_XET_FILE,
@@ -216,6 +227,7 @@ class TestXetFileDownload:
                 xet_get=DEFAULT,
                 _create_symlink=DEFAULT,
             ) as mocks:
+                mocks["xet_get"].side_effect = _fake_xet_get
                 hf_hub_download(
                     DUMMY_XET_MODEL_ID,
                     filename=DUMMY_XET_FILE,
@@ -238,6 +250,13 @@ class TestXetFileDownload:
         mock_group = MagicMock()
         mock_session = MagicMock()
         mock_session.new_file_download_group.return_value = mock_group
+
+        # `_patch_xet_file_metadata` advertises a 1024-byte file; make the fake reconstruction actually
+        # write that many bytes so the post-reconstruction consistency check in `xet_get` passes.
+        def _write_expected_bytes(xet_file_info, path, *args, **kwargs):
+            Path(path).write_bytes(b"\0" * 1024)
+
+        mock_group.__enter__.return_value.start_download_file.side_effect = _write_expected_bytes
 
         mock_connection_info = XetConnectionInfo(
             access_token="mock_token", expiration_unix_epoch=9999999999, endpoint="https://cas.example"


### PR DESCRIPTION
## Summary

Fixes #4768: `hf download` could print `Download complete` and return a snapshot folder whose files are empty or truncated, with no error.

### The problem

Two ways the cache ends up holding a partial file that is then trusted forever:

- **New download, Xet path** — a Xet reconstruction that produced fewer bytes than expected was promoted straight into the content-addressed cache with no size check. The plain HTTP path already had a consistency check in `http_get`; the Xet path did not always.
- **Cache already poisoned** — once a truncated blob is in the cache (e.g. from a run interrupted by an older `huggingface_hub`), the commit-hash shortcut in `_hf_hub_download_to_cache_dir` returned it as soon as the pointer existed, never comparing its size to the expected size. `force_download=True` was the only escape hatch, and nothing told the user they needed it.

Net effect from the issue: `Fetching 32 files: 100%` / `Download complete`, snapshot folder is 2–4 GB of unusable files.

### The fix

Validate size at every point where a cached file is trusted, and at the promotion boundary where a temp file becomes a cache blob. Expected size is authoritative; an unknown expected size preserves the current fast path; size `0` is a valid size (legit empty files still pass).

`src/huggingface_hub/file_download.py`
- `_cached_file_size_mismatch()` / `_expected_size_from_tree_cache()` — compare a cached blob/pointer against its known expected size. For the commit-hash shortcut the size comes from the on-disk tree listing (written by `snapshot_download`, no network); afterwards it comes from the resolve metadata. A mismatch is treated exactly like `force_download` for that one file.
- `_hf_hub_download_to_cache_dir()` — the commit-hash shortcut, the pointer-exists shortcut and the blob-exists shortcut now all skip a corrupt entry and fall through to re-download; a `logger.warning` explains why.
- `_hf_hub_download_to_local_dir()` — same guard on the shortcut, the metadata-reuse path and the "copy from cache blob" path (a truncated blob is never copied into the local dir).
- `_download_to_tmp_and_move()` — enforce `actual_size == expected_size` at the move-into-cache boundary for **both** backends, so a partial Xet/HTTP download raises loudly instead of poisoning the cache.

`src/huggingface_hub/_snapshot_download.py`
- `_raise_if_snapshot_incomplete()` — safety net after all files are fetched: one `stat` per requested file (expected sizes are already in memory), turns any residual missing/truncated file into an explicit `IncompleteSnapshotError` instead of a silently unusable folder.
- `_raise_if_incomplete_snapshot()` (offline path) — now compares sizes too, not just existence; `_local_file_is_complete()` replaces `_local_file_exists()`.

No public API change, no cache-format change. A normal cache hit still costs only local `stat`/metadata checks — no extra network calls, no hashing.

### Tests

New file `tests/test_download_poisoned_cache.py` (regression tests for #4768):

- **Poisoned cache recovery** — complete cache still served with zero network; a 400-vs-1000-byte blob is re-downloaded and repaired in place via both the commit-hash shortcut and the post-metadata shortcut; zero-byte file stays valid; unknown local size preserves the no-network shortcut; an interrupted download is not promoted and a later run completes.
- **Xet path** — a new truncated reconstruction raises `Consistency check failed` and leaves no blob; a correct reconstruction succeeds; a poisoned Xet blob is re-reconstructed to full size.
- **`snapshot_download` level** — one poisoned file among many is repaired while the others are untouched (single `http_get` call); a residual gap raises `IncompleteSnapshotError`; a per-file worker exception propagates instead of being swallowed.
- **`local_dir` downloads** — per-file self-heal when a tree listing is available; no-network fast path preserved when it is not; snapshot-level net still blocks false success either way.
- Unit coverage for `_raise_if_snapshot_incomplete` accepting 0-byte files.

Existing suites adjusted for the stricter invariant: `tests/test_file_download.py`, `tests/test_snapshot_download.py`, `tests/test_xet_download.py` (fake `http_get` / `xet_get` now write `expected_size` bytes so the new consistency check passes).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core Hub download and cache fast paths; behavior is stricter but limited to local size checks and auto-repair when metadata is available, with broad regression coverage.
> 
> **Overview**
> Fixes **#4768**, where `snapshot_download` / `hf_hub_download` could finish with “Download complete” while returning **empty or truncated** files.
> 
> **Per-file (`file_download.py`):** Cached blobs and pointers are no longer returned on existence alone. When an expected size is known (Hub metadata or the on-disk tree listing from `snapshot_download`), a mismatch is treated like **`force_download`** for that file and triggers re-download with a warning. The same check applies on **`local_dir`** shortcuts and when copying from the main cache. **`_download_to_tmp_and_move`** now refuses to promote a temp file into `blobs/<etag>` unless its size matches the expected length—closing the gap where **Xet** reconstructions could poison the cache without the HTTP path’s existing check.
> 
> **Snapshot (`_snapshot_download.py`):** Offline/partial snapshot detection compares **sizes**, not just missing paths. After a full online download, **`_raise_if_snapshot_incomplete`** runs a cheap **`stat`** per requested file and raises **`IncompleteSnapshotError`** if anything is still wrong size or missing.
> 
> Legitimate **0-byte** files still pass. When expected size is **unknown locally** (no tree listing), the no-network commit-hash shortcut is unchanged; **`force_download=True`** remains the escape hatch.
> 
> Adds **`tests/test_download_poisoned_cache.py`** and adjusts existing download/Xet tests so mocks write the expected byte counts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31ee0efebdf89df803444b4217a31af804e2bd08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->