### PR TITLE
[File download] Fall back to ranged GET for missing size

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1632,6 +1632,26 @@ def get_hf_file_metadata(
     )
     hf_raise_for_status(response)
 
+    size = _int_or_none(response.headers.get(constants.HUGGINGFACE_HEADER_X_LINKED_SIZE))
+    if size is None and not response.is_redirect:
+        size = _get_file_length_from_http_response(response)
+
+    # Some proxies strip Content-Length from HEAD responses. A ranged GET lets us recover the total size without
+    # downloading the complete file.
+    if size is None:
+        range_headers = {**hf_headers, "Range": "bytes=0-0"}
+        try:
+            range_response = _httpx_follow_hub_redirects_with_backoff(
+                method="GET", url=url, headers=range_headers, timeout=timeout, retry_on_errors=retry_on_errors
+            )
+            hf_raise_for_status(range_response)
+        except HfHubHTTPError:
+            logger.debug("Failed to retrieve file size with a ranged GET.", exc_info=True)
+        else:
+            size = _int_or_none(range_response.headers.get(constants.HUGGINGFACE_HEADER_X_LINKED_SIZE))
+            if size is None:
+                size = _get_file_length_from_http_response(range_response)
+
     # Return
     return HfFileMetadata(
         commit_hash=response.headers.get(constants.HUGGINGFACE_HEADER_X_REPO_COMMIT),
@@ -1642,10 +1662,7 @@ def get_hf_file_metadata(
         # Either from response headers (if redirected) or defaults to request url
         # Do not use directly `url` as we might have followed relative redirects.
         location=response.headers.get("Location") or str(response.request.url),  # type: ignore
-        size=_int_or_none(
-            response.headers.get(constants.HUGGINGFACE_HEADER_X_LINKED_SIZE)
-            or (None if response.is_redirect else response.headers.get("Content-Length"))
-        ),
+        size=size,
         xet_file_data=parse_xet_file_data_from_response(response, endpoint=endpoint),  # type: ignore
     )
 

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -70,6 +70,37 @@ DATASET_REVISION_ID_ONE_SPECIFIC_COMMIT = "e25d55a1c4933f987c46cc75d8ffadd67f257
 DATASET_SAMPLE_PY_FILE = "custom_squad.py"
 
 
+class TestGetHfFileMetadata:
+    def test_get_hf_file_metadata_falls_back_to_range_request_when_size_is_missing(self) -> None:
+        url = "https://huggingface.co/user/repo/resolve/main/config.json"
+        head_response = httpx.Response(
+            200,
+            headers={
+                constants.HUGGINGFACE_HEADER_X_REPO_COMMIT: "a" * 40,
+                "ETag": '"etag"',
+            },
+            request=httpx.Request("HEAD", url),
+        )
+        range_response = httpx.Response(
+            206,
+            headers={"Content-Range": "bytes 0-0/1234"},
+            content=b"{",
+            request=httpx.Request("GET", url),
+        )
+
+        with patch(
+            "huggingface_hub.file_download._httpx_follow_hub_redirects_with_backoff",
+            side_effect=[head_response, range_response],
+        ) as request_mock:
+            metadata = get_hf_file_metadata(url)
+
+        assert metadata.commit_hash == "a" * 40
+        assert metadata.etag == "etag"
+        assert metadata.size == 1234
+        assert [call.kwargs["method"] for call in request_mock.call_args_list] == ["HEAD", "GET"]
+        assert request_mock.call_args_list[1].kwargs["headers"]["Range"] == "bytes=0-0"
+
+
 class TestDiskUsageWarning:
     @pytest.fixture(scope="class", autouse=True)
     def setup(self, request):


### PR DESCRIPTION
## Summary

- Fall back to a `Range: bytes=0-0` GET when a metadata HEAD response has no usable file size.
- Parse the total size from `Content-Range` while preserving commit, ETag, and location metadata from the original HEAD response.
- Add a regression test for proxies that strip `Content-Length` from HEAD responses.

Fixes #4741.

The fallback follows this request flow:

```text
HEAD /resolve/... -> 200 (no Content-Length)
GET  /resolve/...
Range: bytes=0-0
      -> 206 Content-Range: bytes 0-0/1234
```

Validation completed locally:

- `.venv\Scripts\python.exe -m pytest tests/test_file_download.py -k falls_back_to_range_request -q`
- `.venv\Scripts\ruff.exe check tests src`
- `.venv\Scripts\ruff.exe format --check tests src`
- `.venv\Scripts\ty.exe check src`
- Static import, `__all__`, async client, and CLI reference checks