### PR TITLE
[CI] Fix torch 1.11 test lane install selector

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -92,7 +92,7 @@ jobs:
               uv pip install --upgrade torch
               ;;
 
-            "Python 3.9, torch_1.11")
+            "Python 3.10, torch_1.11")
               uv pip install "huggingface_hub[torch] @ ."
               uv pip install torch~=1.11
               ;;


### PR DESCRIPTION
## Summary

- Align the torch 1.11 install selector with the matrix entry, which was renamed from Python 3.9 to Python 3.10.
- Restore installation of `huggingface_hub[torch]` and `torch~=1.11` for the dedicated compatibility lane.
- Keep the existing test selector unchanged.

Fixes #4775

## Validation

- Verified the matrix entry, dependency-install selector, and test selector all use `Python 3.10, torch_1.11`.
- `git diff --check` passes.
- The Python 3.10 / torch 1.11 job will provide the environment-specific validation in CI; it is not available in the local environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change to a CI install case label; no runtime library or security behavior changes.
> 
> **Overview**
> Fixes a **CI wiring bug** where the `build-ubuntu` dependency-install `case` still matched `"Python 3.9, torch_1.11"` while the matrix job is named `"Python 3.10, torch_1.11"`.
> 
> Because of that mismatch, the torch 1.11 lane would skip installing `huggingface_hub[torch]` and `torch~=1.11` even though the job is meant to run hub mixin / serialization tests on Python 3.10 with pinned torch. The label is updated to **Python 3.10** so install behavior matches the matrix and the existing test selector.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51902f0ffb59718034db864179f329f9a92a14ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->