### PR TITLE
fix(hf_api): fallback to 0 for missing or null storage in RepoStorageInfo

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -1700,7 +1700,7 @@ class RepoStorageInfo:
         self.type = kwargs["type"]
         self.updated_at = parse_datetime(kwargs["updatedAt"])
         self.visibility = kwargs["visibility"]
-        self.storage = kwargs["storage"]
+        self.storage = kwargs.get("storage") or 0
         self.storage_percent = kwargs.get("storagePercent") or 0
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,7 +30,7 @@ from huggingface_hub.cli.jobs import _get_jobs_stats_rows, _parse_and_sync_job_v
 from huggingface_hub.cli.skills import build_skill_md
 from huggingface_hub.cli.upload import _resolve_upload_paths, upload
 from huggingface_hub.errors import CLIError, DeviceCodeError, HfUriError, RevisionNotFoundError
-from huggingface_hub.hf_api import ModelInfo
+from huggingface_hub.hf_api import ModelInfo, RepoStorageInfo
 from huggingface_hub.utils import (
     CachedFileInfo,
     CachedRepoInfo,
@@ -1887,6 +1887,37 @@ class TestRepoListCommand:
         api.delete_repo(model_id)
         api.delete_repo(dataset_id, repo_type="dataset")
         api.delete_repo(space_id, repo_type="space")
+
+    def test_repo_list_with_null_or_missing_storage(self, runner: CliRunner) -> None:
+        mock_api = Mock()
+        mock_api.list_user_repos.return_value = [
+            RepoStorageInfo(
+                id="user/repo-null-storage",
+                type="model",
+                updatedAt="2026-01-01T00:00:00Z",
+                visibility="public",
+                storage=None,
+            ),
+            RepoStorageInfo(
+                id="user/repo-missing-storage",
+                type="dataset",
+                updatedAt="2026-01-01T00:00:00Z",
+                visibility="private",
+            ),
+        ]
+
+        with patch("huggingface_hub.cli.repos.get_hf_api", return_value=mock_api):
+            result = runner.invoke(app, ["repos", "ls", "--format", "json"])
+
+        assert result.exit_code == 0
+        output = json.loads(result.stdout)
+        assert len(output) == 2
+        assert output[0]["id"] == "user/repo-null-storage"
+        assert output[0]["storage"] == "0 B"
+        assert output[0]["%_of_total"] == "0.0%"
+        assert output[1]["id"] == "user/repo-missing-storage"
+        assert output[1]["storage"] == "0 B"
+        assert output[1]["%_of_total"] == "0.0%"
 
 
 class TestRepoDeleteCommand:


### PR DESCRIPTION
## Problem
`hf repos ls` crashes with `TypeError: '<' not supported between instances of 'NoneType' and 'int'` when any repository returned by the API has `storage: null` or lacks a `storage` field.

## Root Cause
`RepoStorageInfo.__init__` directly assigns `self.storage = kwargs["storage"]` without a fallback or presence check. When `storage` is `None` or absent, `format_size(r.storage, human_readable=True)` in `repo_list` attempts comparison on `NoneType`, raising `TypeError` and causing `hf repos ls` to exit 1 with empty output.

## Fix
Safely fallback `storage` to `0` when `kwargs.get("storage")` is `None` or missing in `RepoStorageInfo.__init__` (mirroring `storage_percent` handling).

## Testing
Added `test_repo_list_with_null_or_missing_storage` in `tests/test_cli.py` and verified with pytest.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive default in API model parsing plus a regression test; no auth or data-handling changes.
> 
> **Overview**
> Fixes **`hf repos ls`** crashing when the Hub returns repositories with **`storage: null`** or no **`storage`** field.
> 
> **`RepoStorageInfo`** now sets **`storage`** via **`kwargs.get("storage") or 0`**, matching how **`storage_percent`** is already handled, so downstream size formatting no longer compares **`None`** to integers.
> 
> Adds a CLI test that mocks **`list_user_repos`** with null and missing **`storage`** and asserts JSON output shows **`0 B`** and **`0.0%`** for **`%_of_total`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6f185e918d959f465e842c456c34c04fad92b1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->