### PR TITLE
Add Aiqre inference provider

### DIFF
--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -135,7 +135,7 @@ class InferenceClient:
             Note: for better compatibility with OpenAI's client, `model` has been aliased as `base_url`. Those 2
             arguments are mutually exclusive. If a URL is passed as `model` or `base_url` for chat completion, the `(/v1)/chat/completions` suffix path will be appended to the URL.
         provider (`str`, *optional*):
-            Name of the provider to use for inference. Can be `"baseten"`, `"cerebras"`, `"cohere"`, `"deepinfra"`, `"fal-ai"`, `"featherless-ai"`, `"fireworks-ai"`, `"groq"`, `"hf-inference"`, `"novita"`, `"nscale"`, `"openai"`, `"ovhcloud"`, `"publicai"`, `"replicate"`, `"scaleway"`, `"together"`, `"wavespeed"` or `"zai-org"`.
+            Name of the provider to use for inference. Can be `"aiqre"`, `"baseten"`, `"cerebras"`, `"cohere"`, `"deepinfra"`, `"fal-ai"`, `"featherless-ai"`, `"fireworks-ai"`, `"groq"`, `"hf-inference"`, `"novita"`, `"nscale"`, `"openai"`, `"ovhcloud"`, `"publicai"`, `"replicate"`, `"scaleway"`, `"together"`, `"wavespeed"` or `"zai-org"`.
             Defaults to "auto": automatic routing, which defaults to "fastest" provider; you can
             switch to "cheapest" or "preferred" provider order at https://hf.co/settings/inference-providers.
             If model is a URL or `base_url` is passed, then `provider` is not used.

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -125,7 +125,7 @@ class AsyncInferenceClient:
             Note: for better compatibility with OpenAI's client, `model` has been aliased as `base_url`. Those 2
             arguments are mutually exclusive. If a URL is passed as `model` or `base_url` for chat completion, the `(/v1)/chat/completions` suffix path will be appended to the URL.
         provider (`str`, *optional*):
-            Name of the provider to use for inference. Can be `"baseten"`, `"cerebras"`, `"cohere"`, `"deepinfra"`, `"fal-ai"`, `"featherless-ai"`, `"fireworks-ai"`, `"groq"`, `"hf-inference"`, `"novita"`, `"nscale"`, `"openai"`, `"ovhcloud"`, `"publicai"`, `"replicate"`, `"scaleway"`, `"together"`, `"wavespeed"` or `"zai-org"`.
+            Name of the provider to use for inference. Can be `"aiqre"`, `"baseten"`, `"cerebras"`, `"cohere"`, `"deepinfra"`, `"fal-ai"`, `"featherless-ai"`, `"fireworks-ai"`, `"groq"`, `"hf-inference"`, `"novita"`, `"nscale"`, `"openai"`, `"ovhcloud"`, `"publicai"`, `"replicate"`, `"scaleway"`, `"together"`, `"wavespeed"` or `"zai-org"`.
             Defaults to "auto": automatic routing, which defaults to "fastest" provider; you can
             switch to "cheapest" or "preferred" provider order at https://hf.co/settings/inference-providers.
             If model is a URL or `base_url` is passed, then `provider` is not used.

--- a/src/huggingface_hub/inference/_providers/__init__.py
+++ b/src/huggingface_hub/inference/_providers/__init__.py
@@ -7,6 +7,7 @@ from huggingface_hub.inference._providers.featherless_ai import (
 from huggingface_hub.utils import logging
 
 from ._common import AutoRouterConversationalTask, TaskProviderHelper, _fetch_inference_provider_mapping
+from .aiqre import AiqreConversationalTask
 from .baseten import BasetenConversationalTask
 from .cerebras import CerebrasConversationalTask
 from .cohere import CohereConversationalTask
@@ -70,6 +71,7 @@ logger = logging.get_logger(__name__)
 
 
 PROVIDER_T = Literal[
+    "aiqre",
     "baseten",
     "cerebras",
     "cohere",
@@ -96,6 +98,9 @@ PROVIDER_OR_POLICY_T = Union[PROVIDER_T, Literal["auto"]]
 CONVERSATIONAL_AUTO_ROUTER = AutoRouterConversationalTask()
 
 PROVIDERS: dict[PROVIDER_T, dict[str, TaskProviderHelper]] = {
+    "aiqre": {
+        "conversational": AiqreConversationalTask(),
+    },
     "baseten": {
         "conversational": BasetenConversationalTask(),
     },

--- a/src/huggingface_hub/inference/_providers/aiqre.py
+++ b/src/huggingface_hub/inference/_providers/aiqre.py
@@ -1,0 +1,6 @@
+from ._common import BaseConversationalTask
+
+
+class AiqreConversationalTask(BaseConversationalTask):
+    def __init__(self):
+        super().__init__(provider="aiqre", base_url="https://api.aiqre.com")


### PR DESCRIPTION
This PR registers Aiqre (https://aiqre.com) as a conversational inference provider in the Python client, following the register-as-a-provider guide. Companion to the huggingface.js PR: https://github.com/huggingface/huggingface.js/pull/2437

Aiqre is an EU inference provider (Advanced AI s.r.o., Czech Republic) serving open-weight models via strictly OpenAI-compatible chat completions (streaming, tool calling, structured outputs) at https://api.aiqre.com/v1.

The provider class follows the BaseConversationalTask pattern (same as cerebras.py). Verified locally: get_provider_helper("aiqre", "conversational", ...) resolves and the full provider map imports cleanly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive provider registration following an established pattern; no changes to auth, billing, or core inference paths.
> 
> **Overview**
> Registers **Aiqre** as a third-party inference provider so `InferenceClient(provider="aiqre")` can route **conversational** (chat completion) requests to `https://api.aiqre.com` via the existing OpenAI-compatible `BaseConversationalTask` helper.
> 
> The change wires the provider into the central registry (`PROVIDER_T`, `PROVIDERS`) and documents `"aiqre"` in the sync and async client `provider` argument docs. No other tasks or routing logic are modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 506310cd4fe51b723ad1889879f9abcb661b7bc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->