### PR TITLE
ci: add fallback error arms to python-tests.yml case blocks

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -97,6 +97,14 @@ jobs:
               uv pip install torch~=1.11
               ;;
 
+            "with hf_xet")
+              ;;
+
+            *)
+              echo "Unknown test_name: ${{ matrix.test_name }}" >&2
+              exit 1
+              ;;
+
           esac
 
           # Xet policy (see `xet_mode` fixture in tests/conftest.py):
@@ -149,6 +157,11 @@ jobs:
               echo $PYTEST
               eval $PYTEST
             ;;
+
+            *)
+              echo "Unknown test_name: ${{ matrix.test_name }}" >&2
+              exit 1
+              ;;
 
           esac
 

--- a/tests/test_testing_configuration.py
+++ b/tests/test_testing_configuration.py
@@ -4,3 +4,20 @@ from huggingface_hub import get_token
 def test_no_token_in_staging_environment():
     """Make sure no token is set in test environment."""
     assert get_token() is None
+
+from pathlib import Path
+import yaml
+
+
+def test_python_tests_workflow_case_statements():
+    """Ensure python-tests.yml handles all matrix test_names and has fallback arms."""
+    workflow_path = Path(__file__).parent.parent / ".github" / "workflows" / "python-tests.yml"
+    with open(workflow_path) as f:
+        data = yaml.safe_load(f)
+
+    steps = data["jobs"]["build-ubuntu"]["steps"]
+    run_step = next(s for s in steps if s.get("name") == "Run tests")
+    install_step = next(s for s in steps if "uv pip install" in s.get("run", "") and "case" in s.get("run", ""))
+
+    assert "*)" in install_step["run"], "Install step case is missing default fallback arm (*)"
+    assert "*)" in run_step["run"], "Run tests step case is missing default fallback arm (*)"


### PR DESCRIPTION
## Problem
In `.github/workflows/python-tests.yml`, both `case "${{ matrix.test_name }}"` blocks (dependency installation and test execution) lacked default fallback (`*)`) arms. An unrecognized matrix label would silently fall through without running installation or tests while still exiting 0.

## Root Cause
`case` statements in bash do not error on unhandled patterns without an explicit `*)` arm, allowing mismatched matrix labels to pass CI without executing test suites.

## Fix
- Added explicit no-op `"with hf_xet") ;;` arm and a fallback `*)` error arm to the dependency installation case block.
- Added a fallback `*)` error arm to the test execution case block.
- Added a unit test in `tests/test_testing_configuration.py` validating case statement fallbacks in `python-tests.yml`.

## Testing
Verified with `pytest tests/test_testing_configuration.py`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect CI workflow bash and a meta-test; no runtime library or auth behavior.
> 
> **Overview**
> **CI hardening:** Ubuntu `build-ubuntu` jobs in `python-tests.yml` no longer succeed when `matrix.test_name` does not match any `case` arm. Both the dependency install and **Run tests** bash `case` blocks now include a `*)` arm that prints an error and exits with status 1.
> 
> The install step also adds an explicit no-op branch for **`with hf_xet`** (base `huggingface_hub[testing]` install only; Xet uninstall logic stays outside the `case`).
> 
> **Regression guard:** `test_python_tests_workflow_case_statements` loads the workflow YAML and asserts both steps’ shell scripts contain a `*)` fallback, so future matrix renames cannot silently drop install or pytest execution again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 257eb94fec71f50a112fa59f80ba204bc35d46d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->