### PR TITLE
[Inference] Add IteraCompute provider

### DIFF
--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -3178,7 +3178,7 @@ $ hf models list [OPTIONS] [REPO_ID]
 * `--gated / --no-gated`: Filter by gated status. '--gated' for gated only, '--no-gated' for non-gated only.
 * `--apps TEXT`: Filter by app(s) that can run the model, e.g. 'ollama' or 'vllm'.
 * `--num-parameters TEXT`: Filter by parameter count, e.g. 'min:6B,max:128B'.
-* `--inference-provider [baseten|cerebras|cohere|deepinfra|fal-ai|featherless-ai|fireworks-ai|groq|hf-inference|novita|nscale|openai|ovhcloud|publicai|replicate|scaleway|together|wavespeed|zai-org]`: Filter by inference provider(s) serving the model, e.g. 'fireworks-ai'.
+* `--inference-provider [baseten|cerebras|cohere|deepinfra|fal-ai|featherless-ai|fireworks-ai|groq|hf-inference|iteracompute|novita|nscale|openai|ovhcloud|publicai|replicate|scaleway|together|wavespeed|zai-org]`: Filter by inference provider(s) serving the model, e.g. 'fireworks-ai'.
 * `--warm`: Only list models currently served by at least one inference provider.
 * `--sort [created_at|downloads|last_modified|likes|trending_score]`: Sort results.
 * `--limit INTEGER`: Limit the number of results.  [default: 30]

--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -135,7 +135,7 @@ class InferenceClient:
             Note: for better compatibility with OpenAI's client, `model` has been aliased as `base_url`. Those 2
             arguments are mutually exclusive. If a URL is passed as `model` or `base_url` for chat completion, the `(/v1)/chat/completions` suffix path will be appended to the URL.
         provider (`str`, *optional*):
-            Name of the provider to use for inference. Can be `"baseten"`, `"cerebras"`, `"cohere"`, `"deepinfra"`, `"fal-ai"`, `"featherless-ai"`, `"fireworks-ai"`, `"groq"`, `"hf-inference"`, `"novita"`, `"nscale"`, `"openai"`, `"ovhcloud"`, `"publicai"`, `"replicate"`, `"scaleway"`, `"together"`, `"wavespeed"` or `"zai-org"`.
+            Name of the provider to use for inference. Can be `"baseten"`, `"cerebras"`, `"cohere"`, `"deepinfra"`, `"fal-ai"`, `"featherless-ai"`, `"fireworks-ai"`, `"groq"`, `"hf-inference"`, `"iteracompute"`, `"novita"`, `"nscale"`, `"openai"`, `"ovhcloud"`, `"publicai"`, `"replicate"`, `"scaleway"`, `"together"`, `"wavespeed"` or `"zai-org"`.
             Defaults to "auto": automatic routing, which defaults to "fastest" provider; you can
             switch to "cheapest" or "preferred" provider order at https://hf.co/settings/inference-providers.
             If model is a URL or `base_url` is passed, then `provider` is not used.

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -125,7 +125,7 @@ class AsyncInferenceClient:
             Note: for better compatibility with OpenAI's client, `model` has been aliased as `base_url`. Those 2
             arguments are mutually exclusive. If a URL is passed as `model` or `base_url` for chat completion, the `(/v1)/chat/completions` suffix path will be appended to the URL.
         provider (`str`, *optional*):
-            Name of the provider to use for inference. Can be `"baseten"`, `"cerebras"`, `"cohere"`, `"deepinfra"`, `"fal-ai"`, `"featherless-ai"`, `"fireworks-ai"`, `"groq"`, `"hf-inference"`, `"novita"`, `"nscale"`, `"openai"`, `"ovhcloud"`, `"publicai"`, `"replicate"`, `"scaleway"`, `"together"`, `"wavespeed"` or `"zai-org"`.
+            Name of the provider to use for inference. Can be `"baseten"`, `"cerebras"`, `"cohere"`, `"deepinfra"`, `"fal-ai"`, `"featherless-ai"`, `"fireworks-ai"`, `"groq"`, `"hf-inference"`, `"iteracompute"`, `"novita"`, `"nscale"`, `"openai"`, `"ovhcloud"`, `"publicai"`, `"replicate"`, `"scaleway"`, `"together"`, `"wavespeed"` or `"zai-org"`.
             Defaults to "auto": automatic routing, which defaults to "fastest" provider; you can
             switch to "cheapest" or "preferred" provider order at https://hf.co/settings/inference-providers.
             If model is a URL or `base_url` is passed, then `provider` is not used.

--- a/src/huggingface_hub/inference/_providers/__init__.py
+++ b/src/huggingface_hub/inference/_providers/__init__.py
@@ -34,6 +34,7 @@ from .hf_inference import (
     HFInferenceFeatureExtractionTask,
     HFInferenceTask,
 )
+from .iteracompute import IteraComputeConversationalTask
 from .novita import NovitaConversationalTask, NovitaTextGenerationTask, NovitaTextToVideoTask
 from .nscale import NscaleConversationalTask, NscaleTextToImageTask
 from .openai import OpenAIConversationalTask
@@ -79,6 +80,7 @@ PROVIDER_T = Literal[
     "fireworks-ai",
     "groq",
     "hf-inference",
+    "iteracompute",
     "novita",
     "nscale",
     "openai",
@@ -158,6 +160,9 @@ PROVIDERS: dict[PROVIDER_T, dict[str, TaskProviderHelper]] = {
         "translation": HFInferenceTask("translation"),
         "summarization": HFInferenceTask("summarization"),
         "visual-question-answering": HFInferenceBinaryInputTask("visual-question-answering"),
+    },
+    "iteracompute": {
+        "conversational": IteraComputeConversationalTask(),
     },
     "novita": {
         "text-generation": NovitaTextGenerationTask(),

--- a/src/huggingface_hub/inference/_providers/iteracompute.py
+++ b/src/huggingface_hub/inference/_providers/iteracompute.py
@@ -1,0 +1,6 @@
+from ._common import BaseConversationalTask
+
+
+class IteraComputeConversationalTask(BaseConversationalTask):
+    def __init__(self):
+        super().__init__(provider="iteracompute", base_url="https://api.iteracompute.com/hf")

--- a/tests/test_inference_providers.py
+++ b/tests/test_inference_providers.py
@@ -45,6 +45,7 @@ from huggingface_hub.inference._providers.hf_inference import (
     HFInferenceFeatureExtractionTask,
     HFInferenceTask,
 )
+from huggingface_hub.inference._providers.iteracompute import IteraComputeConversationalTask
 from huggingface_hub.inference._providers.novita import NovitaConversationalTask, NovitaTextGenerationTask
 from huggingface_hub.inference._providers.nscale import NscaleConversationalTask, NscaleTextToImageTask
 from huggingface_hub.inference._providers.openai import OpenAIConversationalTask
@@ -910,6 +911,15 @@ class TestGroqProvider:
         """Test route preparation for Groq conversational task."""
         helper = GroqConversationalTask()
         assert helper._prepare_route("username/repo_name", "hf_token") == "/openai/v1/chat/completions"
+
+
+class TestIteraComputeProvider:
+    def test_prepare_url(self):
+        helper = IteraComputeConversationalTask()
+        assert (
+            helper._prepare_url("iteracompute_token", "username/repo_name")
+            == "https://api.iteracompute.com/hf/v1/chat/completions"
+        )
 
 
 class TestHFInferenceProvider:


### PR DESCRIPTION
## Summary

This PR adds IteraCompute as a conversational inference provider using the standard OpenAI-compatible provider helper and the dedicated provider base URL `https://api.iteracompute.com/hf`.

It updates the provider registry/type, synchronous and generated asynchronous client documentation, generated CLI reference, and provider URL tests.

## Validation

- Ruff check and format check: passed.
- Static import and inference parameter checks: passed.
- Async client and CLI documentation generation checks: passed.
- `ty` type check: passed.
- Targeted provider test: passed.
- Production `/hf` acceptance: non-streaming, streaming, tool calling, strict JSON schema, and billing passed.

## Submission timing

Opened as a draft while Hugging Face enables the server-side provider registration and Model Mapping API. We will mark it ready after the earlier onboarding steps are operational, following the provider registration guide.