### PR TITLE
[Cache] Remove unreferenced shared blobs in hf cache prune

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -1635,7 +1635,7 @@ When working outside the default cache location, pair the command with `--cache-
 
 ### hf cache prune
 
-`hf cache prune` is a convenience shortcut that reclaims space taken by cache garbage: every detached (unreferenced) revision (keeping only revisions still reachable through a branch or tag) and any leftover `.incomplete` files from interrupted downloads:
+`hf cache prune` is a convenience shortcut that reclaims space taken by cache garbage: every detached (unreferenced) revision (keeping only revisions still reachable through a branch or tag), any leftover `.incomplete` files from interrupted downloads, and shared blobs no longer referenced by any cached repo:
 
 ```bash
 >>> hf cache prune

--- a/docs/source/en/guides/manage-cache.md
+++ b/docs/source/en/guides/manage-cache.md
@@ -216,8 +216,10 @@ directory is never adopted or cleaned by `huggingface_hub`.
 
 Each shared file has a `<xet_hash>.refs` manifest containing the relative paths of repo
 blobs that reference it. A reference is flushed to the manifest before its symlink is
-made visible. `hf cache rm` and `hf cache prune` use this manifest to inspect only
-shared blobs affected by the current deletion, rather than scanning the full cache.
+made visible. `hf cache rm` uses this manifest to inspect only shared blobs affected by
+the current deletion, rather than scanning the full cache. `hf cache prune` also removes
+shared blobs that no cached repo references anymore, for example after a repo folder was
+deleted manually or with an older client.
 The manifest is only a hint: every line is checked against the actual symlink, stale
 lines are removed, and missing, malformed, or unreadable metadata causes the payload
 to be kept. Cache cleanup therefore prefers leaking reclaimable data over breaking a
@@ -699,9 +701,9 @@ Dry run: no files were deleted.
 When working outside the default cache location, pair the command with
 `--cache-dir PATH`.
 
-To clean up cache garbage in bulk, run `hf cache prune`. It automatically deletes both
-revisions that are no longer referenced by a branch or tag and any leftover `.incomplete`
-files from interrupted downloads:
+To clean up cache garbage in bulk, run `hf cache prune`. It automatically deletes
+revisions that are no longer referenced by a branch or tag, leftover `.incomplete` files
+from interrupted downloads, and shared blobs that no cached repo references anymore:
 
 ```text
 ➜ hf cache prune

--- a/src/huggingface_hub/_shared_blobs.py
+++ b/src/huggingface_hub/_shared_blobs.py
@@ -536,6 +536,22 @@ def shared_store_blob_paths(cache_dir: str | Path) -> set[Path]:
     return paths
 
 
+def unreferenced_shared_blobs(cache_dir: str | Path) -> dict[Path, int]:
+    """Return store payloads without any valid manifest reference, with their sizes.
+
+    Payloads with a missing or unreadable manifest are not listed, consistent with `sweep_shared_blob`.
+    """
+    unreferenced: dict[Path, int] = {}
+    for store_path in shared_store_blob_paths(cache_dir):
+        references = _read_valid_manifest_references(store_path, cache_dir)
+        if references is not None and not references:
+            try:
+                unreferenced[store_path] = store_path.lstat().st_size
+            except OSError:
+                pass
+    return unreferenced
+
+
 def _rewrite_manifest(manifest_path: Path, references: set[Path], cache_dir: str | Path) -> None:
     tmp_path = manifest_path.with_name(f"{manifest_path.name}.{uuid.uuid4().hex[:8]}.tmp")
     cache_dir = Path(os.path.abspath(cache_dir))

--- a/src/huggingface_hub/cli/cache.py
+++ b/src/huggingface_hub/cli/cache.py
@@ -25,6 +25,7 @@ import click
 
 from huggingface_hub.errors import CLIError
 
+from .. import _shared_blobs
 from ..utils import (
     ANSI,
     CachedRepoInfo,
@@ -109,14 +110,18 @@ def summarize_deletions(
     return CacheDeletionCounts(repo_count, partial_revision_count, total_revisions)
 
 
-def _prune_summary(revision_count: int, incomplete_count: int) -> str:
+def _prune_summary(revision_count: int, incomplete_count: int, shared_blob_count: int) -> str:
     """Build the human-readable summary of what `hf cache prune` is about to delete."""
     parts: list[str] = []
     if revision_count:
         parts.append(f"{revision_count} unreferenced revision(s)")
     if incomplete_count:
         parts.append(f"{incomplete_count} incomplete download(s)")
-    return " and ".join(parts)
+    if shared_blob_count:
+        parts.append(f"{shared_blob_count} unreferenced shared blob(s)")
+    if len(parts) > 1:
+        return ", ".join(parts[:-1]) + " and " + parts[-1]
+    return "".join(parts)
 
 
 def print_cache_selected_revisions(selected_by_repo: Mapping[CachedRepoInfo, frozenset[CachedRevisionInfo]]) -> None:
@@ -666,16 +671,22 @@ def prune(
         revisions.update(revision.commit_hash for revision in detached)
 
     incomplete_files = hf_cache_info.incomplete_files
+    # Shared blobs left behind when a repo folder is deleted manually or by an older client.
+    unreferenced_blobs = (
+        _shared_blobs.unreferenced_shared_blobs(hf_cache_info.cache_dir) if hf_cache_info.cache_dir is not None else {}
+    )
 
-    if len(revisions) == 0 and not incomplete_files:
-        out.text("No unreferenced revisions or incomplete downloads found. Nothing to prune.")
+    if len(revisions) == 0 and not incomplete_files and not unreferenced_blobs:
+        out.text("No unreferenced revisions, incomplete downloads or shared blobs found. Nothing to prune.")
         return
 
     strategy = hf_cache_info.delete_revisions(*sorted(revisions))
     counts = summarize_deletions(selected)
-    total_freed = strategy.expected_freed_size + hf_cache_info.incomplete_size_on_disk
+    total_freed = (
+        strategy.expected_freed_size + hf_cache_info.incomplete_size_on_disk + sum(unreferenced_blobs.values())
+    )
 
-    summary = _prune_summary(counts.total_revision_count, len(incomplete_files))
+    summary = _prune_summary(counts.total_revision_count, len(incomplete_files), len(unreferenced_blobs))
     out.text(f"About to delete {summary} ({_format_size(total_freed)} total).")
     print_cache_selected_revisions(selected)
 
@@ -685,6 +696,7 @@ def prune(
             dry_run=True,
             revisions=counts.total_revision_count,
             incomplete=len(incomplete_files),  # might be overstated but it's fine
+            shared_blobs=len(unreferenced_blobs),
             size=_format_size(total_freed),
         )
         return
@@ -699,10 +711,14 @@ def prune(
             pass  # already removed (e.g. by a full-repo deletion above)
         except OSError as exc:
             out.warning(f"Could not delete incomplete file {incomplete_file.file_path}: {exc}")
+    if hf_cache_info.cache_dir is not None:
+        for store_path in unreferenced_blobs:
+            _shared_blobs.sweep_shared_blob(store_path, cache_dir=hf_cache_info.cache_dir)
     out.result(
         f"Deleted {summary}; freed {_format_size(total_freed)}.",
         revisions_deleted=counts.total_revision_count,
         incomplete_deleted=len(incomplete_files),
+        shared_blobs_deleted=len(unreferenced_blobs),
         freed=_format_size(total_freed),
     )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -296,6 +296,7 @@ class TestCacheCommand:
 
         hf_cache_info.incomplete_files = frozenset()
         hf_cache_info.incomplete_size_on_disk = 0
+        hf_cache_info.cache_dir = None
 
         with (
             patch("huggingface_hub.cli.cache.scan_cache_dir", return_value=hf_cache_info),

--- a/tests/test_shared_blobs.py
+++ b/tests/test_shared_blobs.py
@@ -21,6 +21,7 @@ from huggingface_hub._shared_blobs import (
     shared_blobs_dir,
     sweep_shared_blob,
     try_link_from_shared_store,
+    unreferenced_shared_blobs,
 )
 from huggingface_hub.file_download import _chmod_and_move, hf_hub_download
 from huggingface_hub.utils import scan_cache_dir
@@ -353,6 +354,16 @@ class TestManifestGc:
         assert sweep_shared_blob(store_entry, cache_dir=tmp_path) == len(CONTENT)
         assert not store_entry.exists()
         assert not shared_blob_manifest_path(tmp_path, XET_HASH).exists()
+
+    def test_unreferenced_shared_blobs_lists_orphans_only(self, tmp_path: Path) -> None:
+        _publish(tmp_path)
+        _publish(tmp_path, repo_folder="models--org--repoB", xet_hash=OTHER_XET_HASH)
+        shutil.rmtree(tmp_path / "models--org--repoB")
+
+        assert unreferenced_shared_blobs(tmp_path) == {shared_blob_path(tmp_path, OTHER_XET_HASH): len(CONTENT)}
+
+        shared_blob_manifest_path(tmp_path, OTHER_XET_HASH).unlink()
+        assert unreferenced_shared_blobs(tmp_path) == {}
 
     def test_missing_manifest_leaks_instead_of_deleting(self, tmp_path: Path) -> None:
         blob = _publish(tmp_path)


### PR DESCRIPTION
Follow-up to #4498.

## Summary

- With the shared blob store on by default, deleting a repo folder by hand (`rm -rf models--org--big-model`) or with an older client leaves the whole Xet payload in `<cache>/blobs/` with only stale `.refs` lines. Nothing reclaimed it: `sweep_shared_blob` only runs for hashes touched by a `DeleteCacheStrategy`, and orphans are in no strategy.
- `hf cache prune` now lists store payloads with no valid manifest reference (`_shared_blobs.unreferenced_shared_blobs`), includes them in the "About to delete" summary and the dry-run total, and sweeps them after the revision deletion.
- Payloads with a missing or unreadable manifest are left alone, same posture as `sweep_shared_blob`. The sweep re-validates the manifest under the per-hash lock, so a download that links the payload between the confirmation prompt and the sweep keeps it alive.
- One sentence added to the prune paragraphs of both guides and to the shared-blobs section.

## Example

Download a repo whose weights land in the store, then delete the repo folder by hand:

```
$ hf cache ls --cache-dir /tmp/hub
No results found.

$ hf cache prune --cache-dir /tmp/hub --dry-run
About to delete 1 unreferenced shared blob(s) (4.0M total).
dry_run=True revisions=0 incomplete=0 shared_blobs=1 size=4.0M

$ hf cache prune --cache-dir /tmp/hub -y
About to delete 1 unreferenced shared blob(s) (4.0M total).
Cache deletion done. Saved 0.0.
revisions_deleted=0 incomplete_deleted=0 shared_blobs_deleted=1 freed=4.0M

$ hf cache prune --cache-dir /tmp/hub -y
No unreferenced revisions, incomplete downloads or shared blobs found. Nothing to prune.
```

Before this change the two `prune` calls printed "Nothing to prune" while `du` still showed the 4.0M payload.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes on-disk cache deletion for shared blob payloads; safety relies on manifest validation and existing sweep locking, but incorrect orphan detection could remove data still needed by another user’s symlink.
> 
> **Overview**
> **`hf cache prune`** now reclaims **orphaned Xet payloads** in the shared `<cache>/blobs/` store—typically left after manually deleting a repo folder or using an older client—instead of reporting “nothing to prune” while disk usage remains.
> 
> A new **`unreferenced_shared_blobs`** helper lists store files whose `.refs` manifest has **no valid symlink references** (missing/unreadable manifests are skipped, same as **`sweep_shared_blob`**). Prune folds those blobs into the confirmation summary, **dry-run** totals, structured result fields (`shared_blobs` / `shared_blobs_deleted`), and post-confirmation cleanup via **`sweep_shared_blob`**. **`_prune_summary`** now handles three deletion categories with clearer comma/“and” wording.
> 
> Docs for **`hf cache prune`** and the shared-blobs section are updated accordingly; tests cover orphan detection and CLI mocks set **`cache_dir`** where needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d80229e251f92c7dee23c8159c59821a5b2cc60a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->