### PR TITLE
[Cache] Check shared store entries are readable, fix HFCacheInfo docs

### DIFF
--- a/src/huggingface_hub/_shared_blobs.py
+++ b/src/huggingface_hub/_shared_blobs.py
@@ -86,6 +86,26 @@ def _is_directory(path: Path) -> bool:
         return False
 
 
+def _is_usable_store_entry(store_path: Path, expected_size: int) -> bool:
+    """Return whether `store_path` is a regular, readable payload of the expected size."""
+    try:
+        store_stat = store_path.lstat()
+    except OSError:
+        return False
+    if not stat.S_ISREG(store_stat.st_mode):
+        return False
+    if store_stat.st_size != expected_size:
+        logger.warning(
+            f"Shared blob '{store_path}' has an unexpected size ({store_stat.st_size} instead of {expected_size}). "
+            "Not using it."
+        )
+        return False
+    if not os.access(store_path, os.R_OK):
+        logger.warning(f"Shared blob '{store_path}' is not readable. Not using it.")
+        return False
+    return True
+
+
 def is_shared_blobs_dir(path: str | Path) -> bool:
     """Return whether `path` is an owned, supported shared blob store."""
     store_dir = Path(path)
@@ -355,9 +375,7 @@ def shared_blobs_enabled() -> bool:
     return not constants.HF_HUB_DISABLE_SHARED_BLOBS and not constants.HF_HUB_DISABLE_XET
 
 
-def try_link_from_shared_store(
-    *, blob_path: str, xet_hash: str, cache_dir: str | Path, expected_size: int | None
-) -> bool:
+def try_link_from_shared_store(*, blob_path: str, xet_hash: str, cache_dir: str | Path, expected_size: int) -> bool:
     """Materialize `blobs/<etag>` as a symlink to an existing store entry, if any.
 
     The reference manifest is flushed before the symlink becomes visible. Failures are
@@ -373,11 +391,7 @@ def try_link_from_shared_store(
     tmp_link: Path | None = None
     try:
         with _shared_blob_lock(store_path):
-            if not _is_regular_file(store_path):
-                return False
-            store_stat = store_path.lstat()
-            if expected_size is not None and store_stat.st_size != expected_size:
-                logger.warning(f"Shared blob '{store_path}' has an unexpected size. Ignoring it.")
+            if not _is_usable_store_entry(store_path, expected_size):
                 return False
 
             tmp_link = _make_temporary_symlink(Path(blob_path), store_path)
@@ -394,7 +408,7 @@ def try_link_from_shared_store(
     return True
 
 
-def has_shared_blob(*, xet_hash: str, cache_dir: str | Path, expected_size: int | None) -> bool:
+def has_shared_blob(*, xet_hash: str, cache_dir: str | Path, expected_size: int) -> bool:
     """Return whether a usable store entry exists, without touching the cache."""
     if (
         not shared_blobs_enabled()
@@ -402,13 +416,7 @@ def has_shared_blob(*, xet_hash: str, cache_dir: str | Path, expected_size: int 
         or not is_shared_blobs_dir(shared_blobs_dir(cache_dir))
     ):
         return False
-    store_path = shared_blob_path(cache_dir, xet_hash)
-    if not _is_regular_file(store_path):
-        return False
-    try:
-        return expected_size is None or store_path.lstat().st_size == expected_size
-    except OSError:
-        return False
+    return _is_usable_store_entry(shared_blob_path(cache_dir, xet_hash), expected_size)
 
 
 def publish_blob_to_shared_store(
@@ -416,7 +424,7 @@ def publish_blob_to_shared_store(
     blob_path: str,
     xet_hash: str,
     cache_dir: str | Path,
-    expected_size: int | None,
+    expected_size: int,
     replace_existing: bool = False,
 ) -> bool:
     """Move a fresh Xet download into the store and replace its repo blob with a symlink.
@@ -439,11 +447,7 @@ def publish_blob_to_shared_store(
     try:
         with _shared_blob_lock(store_path):
             tmp_link = _make_temporary_symlink(blob_path_obj, store_path)
-            store_is_usable = (
-                not replace_existing
-                and _is_regular_file(store_path)
-                and (expected_size is None or store_path.lstat().st_size == expected_size)
-            )
+            store_is_usable = not replace_existing and _is_usable_store_entry(store_path, expected_size)
             _append_manifest_reference(manifest_path, relative_blob_path)
             if not store_is_usable:
                 _prepare_shared_blob_permissions(blob_path_obj, prefix_dir, cache_dir)

--- a/src/huggingface_hub/utils/_cache_manager.py
+++ b/src/huggingface_hub/utils/_cache_manager.py
@@ -381,7 +381,9 @@ class HFCacheInfo:
 
     Args:
         size_on_disk (`int`):
-            Sum of all valid repo sizes in the cache-system.
+            Physical size of the cache-system in bytes. A blob shared across repos is
+            counted once, and store-only shared blobs no longer referenced by any repo are
+            included. Can be smaller than the sum of the per-repo sizes.
         repos (`frozenset[CachedRepoInfo]`):
             Set of [`~CachedRepoInfo`] describing all valid cached repos found on the
             cache-system while scanning.
@@ -396,8 +398,9 @@ class HFCacheInfo:
             Cache directory that was scanned.
 
     > [!WARNING]
-    > Here `size_on_disk` is equal to the sum of all repo sizes (only blobs). However if
-    > some cached repos are corrupted, their sizes are not taken into account.
+    > `size_on_disk` only accounts for blobs, and corrupted repos are skipped. It is a
+    > physical size: unlike `CachedRepoInfo.size_on_disk`, which attributes a shared blob
+    > to every repo referencing it, a shared blob is counted here only once.
     """
 
     size_on_disk: int
@@ -409,8 +412,7 @@ class HFCacheInfo:
     @property
     def size_on_disk_str(self) -> str:
         """
-        (property) Sum of all valid repo sizes in the cache-system as a human-readable
-        string.
+        (property) Physical size of the cache-system as a human-readable string.
 
         Example: "42.2K".
         """

--- a/tests/test_shared_blobs.py
+++ b/tests/test_shared_blobs.py
@@ -277,6 +277,23 @@ class TestLinkAndPublish:
         assert store_entry.read_bytes() == b"truncated"
         assert not blob_b.exists()
 
+    def test_unreadable_store_entry_is_not_used_and_gets_replaced(self, tmp_path: Path) -> None:
+        _publish(tmp_path)
+        store_entry = shared_blob_path(tmp_path, XET_HASH)
+        store_entry.chmod(0o000)
+        blob_b = tmp_path / "models--org--repoB" / "blobs" / "etag"
+        blob_b.parent.mkdir(parents=True)
+
+        assert not try_link_from_shared_store(
+            blob_path=str(blob_b), xet_hash=XET_HASH, cache_dir=tmp_path, expected_size=len(CONTENT)
+        )
+        assert not blob_b.exists()
+
+        blob_b = _publish(tmp_path, repo_folder="models--org--repoB")
+        assert blob_b.is_symlink()
+        assert blob_b.read_bytes() == CONTENT
+        assert os.access(store_entry, os.R_OK)
+
     def test_force_publication_atomically_replaces_canonical_file(self, tmp_path: Path) -> None:
         blob_a = _publish(tmp_path)
         store_entry = shared_blob_path(tmp_path, XET_HASH)


### PR DESCRIPTION
Follow-up to #4498 (targets the `shared-blob-cache` branch), addressing two review findings.

## Summary

- **Store entries must be readable to count as usable.** The three "is this store entry usable" checks (`try_link_from_shared_store`, `has_shared_blob`, `store_is_usable` in `publish_blob_to_shared_store`) were `lstat` + size only. A payload the current user cannot read (typically a wrong group in a shared cache without setgid) was linked anyway: `hf_hub_download` returned a path that raised `PermissionError` on open, and a force download re-fetched a verified copy only to discard it in favor of the unreadable entry. The only escape was `HF_HUB_DISABLE_SHARED_BLOBS=1`. They now share one `_is_usable_store_entry` helper that also checks `os.access(R_OK)`, so publish replaces an unreadable entry with the fresh verified download.
- **`expected_size` is an `int`.** Every caller sits behind `assert expected_size is not None`, so the `expected_size is None or ...` branches were dead. Removed.
- **`HFCacheInfo.size_on_disk` docstrings** (field doc, warning block, `size_on_disk_str`) still described the total as the sum of repo sizes. They now describe the physical total and point at `CachedRepoInfo.size_on_disk` for the logical per-repo view.

## Example

Payload published by repo A, then made unreadable; repo B asks for the same file:

```
# repoB asks for the same file
WARNING: Shared blob '<cache>/blobs/cf/cfababababababababababababababababababababababababababababababab' is not readable. Not using it.
linked from store: False
# repoB downloads it instead, then publishes
WARNING: Shared blob '<cache>/blobs/cf/cfababababababababababababababababababababababababababababababab' is not readable. Not using it.
published: True
store entry readable again: True | repoB reads through symlink: True
```

Before this change the first call returned `True` and the second `publish` kept the unreadable entry.

## Decisions

- The helper keeps the existing "unexpected size" warning and adds a matching one for unreadable entries, rather than going silent: both mean the store holds something we are not using, which is worth knowing. Force downloads short-circuit on `replace_existing` before the check, so they never warn.
- `os.access` uses the real uid, which is fine as a heuristic here; the store is already documented as a trust boundary.
- One test added for the unreadable case (not used at link time, replaced at publish time). No docs change needed.
