### PR TITLE
[CI] Disable auto close

### DIFF
--- a/.github/workflows/close-unscoped-community-prs.yml
+++ b/.github/workflows/close-unscoped-community-prs.yml
@@ -12,8 +12,8 @@
 name: Close unscoped community PRs
 
 on:
-  pull_request_target:
-    types: [opened, reopened]
+  # pull_request_target: # disabling auto-close for now. Noise is still there and we don't want to discourage contributions
+  #   types: [opened, reopened]
   workflow_dispatch:
     inputs:
       pr_number:


### PR DESCRIPTION
following convo in https://huggingface.slack.com/archives/C0ACCEFPU9W/p1788299868568779 cc @hanouticelina @julien-c 

Let's still keep the workflow as it is since it's working (+ we can always trigger it manually if we want to)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that relaxes automation; no application or security behavior changes.
> 
> **Overview**
> Stops the **Close unscoped community PRs** workflow from running automatically when community PRs are opened or reopened. The `pull_request_target` trigger is commented out with a note that auto-close was adding noise and may discourage contributions.
> 
> **Manual evaluation is unchanged:** maintainers can still run the same checks via `workflow_dispatch` (with optional `dry_run`) when they want to enforce the issue-first policy on a specific PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0997d1c1a5a3845aaee5025b1f8507a7a2120c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->