### PR TITLE
fix(auth): clearer whoami network/DNS error without silent retry

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -2369,10 +2369,20 @@ class HfApi:
         return output
 
     def _inner_whoami(self, token: str) -> dict:
-        r = get_session().get(
-            f"{self.endpoint}/api/whoami-v2",
-            headers=self._build_hf_headers(token=token),
-        )
+        try:
+            r = get_session().get(
+                f"{self.endpoint}/api/whoami-v2",
+                headers=self._build_hf_headers(token=token),
+            )
+        except (httpx.ConnectError, httpx.TimeoutException, httpx.NetworkError) as err:
+            # Keep full traceback when debugging; otherwise surface a short actionable message.
+            # See https://github.com/huggingface/huggingface_hub/issues/4796
+            if constants.HF_DEBUG:
+                raise
+            raise OSError(
+                f"Couldn't reach {self.endpoint} (network/DNS). "
+                "Check your connection and retry. Set HF_DEBUG=1 for the full traceback."
+            ) from err
         try:
             hf_raise_for_status(r)
         except HfHubHTTPError as e:


### PR DESCRIPTION
## Summary
Per maintainer guidance on #4796: do **not** add whoami retries/backoff. Instead, when `whoami` fails with a network/DNS error, raise a short actionable message:

> Couldn't reach https://huggingface.co (network/DNS). Check your connection and retry. Set HF_DEBUG=1 for the full traceback.

With `HF_DEBUG=1`, the original `httpx` exception is re-raised unchanged.

Fixes #4796

## Test plan
- [x] Local: patched `ConnectError` → clear `OSError` when `HF_DEBUG` is off
- [ ] CI unit tests for `HfApi.whoami` / auth


Made with [Cursor](https://cursor.com)