### PR TITLE
[httpx migration] Expose `httpx` as a `huggingface_hub` submodule

### DIFF
--- a/docs/source/en/package_reference/utilities.md
+++ b/docs/source/en/package_reference/utilities.md
@@ -122,11 +122,9 @@ You can also enable or disable progress bars for specific groups. This allows yo
 
 ## Configuring the HTTP Backend
 
-<Tip>
+> [!TIP]
+> In `huggingface_hub` v0.x, HTTP requests were handled with `requests`, and configuration was done via `configure_http_backend`. Since we now use `httpx`, configuration works differently: you must provide a factory function that takes no arguments and returns an `httpx.Client`. You can review the [default implementation here](https://github.com/huggingface/huggingface_hub/blob/main/src/huggingface_hub/utils/_http.py) to see which parameters are used by default.
 
-In `huggingface_hub` v0.x, HTTP requests were handled with `requests`, and configuration was done via `configure_http_backend`. Since we now use `httpx`, configuration works differently: you must provide a factory function that takes no arguments and returns an `httpx.Client`. You can review the [default implementation here](https://github.com/huggingface/huggingface_hub/blob/main/src/huggingface_hub/utils/_http.py) to see which parameters are used by default.
-
-</Tip>
 
 
 In some setups, you may need to control how HTTP requests are made, for example when working behind a proxy. The `huggingface_hub` library allows you to configure this globally with [`set_client_factory`]. After configuration, all requests to the Hub will use your custom settings. Since `huggingface_hub` relies on `httpx.Client` under the hood, you can check the [`httpx` documentation](https://www.python-httpx.org/advanced/clients/) for details on available parameters.
@@ -149,11 +147,27 @@ For async code, use [`set_async_client_factory`] to configure an `httpx.AsyncCli
 
 [[autodoc]] get_async_session
 
-<Tip>
+> [!TIP]
+> Unlike the synchronous client, the lifecycle of the async client is not managed automatically. Use an async context manager to handle it properly.
 
-Unlike the synchronous client, the lifecycle of the async client is not managed automatically. Use an async context manager to handle it properly.
+### The `httpx` module
 
-</Tip>
+`huggingface_hub` re-exports the HTTP library it uses under the hood as `huggingface_hub.utils.httpx`:
+
+```py
+from huggingface_hub.utils import httpx
+
+try:
+    ...
+except httpx.HTTPError:
+    ...
+```
+
+This is mostly useful for third-party libraries built on top of `huggingface_hub`. `huggingface_hub` v1.x is built on [`httpx`](https://www.python-httpx.org/), while v2.x will be built on [`httpx2`](https://httpx2.pydantic.dev/) (its successor, distributed as a separate package). Importing the module from `huggingface_hub.utils` instead of importing `httpx` directly means you always get the version that `huggingface_hub` actually uses, and your library stays compatible with both major versions. See [this issue](https://github.com/huggingface/huggingface_hub/issues/4802) for more details about the migration plan.
+
+> [!WARNING]
+> Only use this if you need `httpx` types or exceptions (e.g. to catch errors). To make requests to the Hub, use [`get_session`] as described above.
+
 
 ## Handle HTTP errors
 

--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -13,6 +13,8 @@
 # limitations under the License
 
 # ruff: noqa: F401
+import httpx  # for forward compatibility - will be httpx2 in huggingface_hub v2.x
+
 from huggingface_hub.errors import (
     BadRequestError,
     BucketNotFoundError,


### PR DESCRIPTION
First step of https://github.com/huggingface/huggingface_hub/issues/4802#issue-5334254259.

In practice, downstream libraries will have to change from

```py
import httpx

try:
    ...
except httpx.ProxyError:
    ...
```

to

```py
from huggingface_hub.utils import httpx

try:
    ...
except httpx.ProxyError:
    ...
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a documented re-export and documentation-only callout formatting; no changes to HTTP client behavior or request paths.
> 
> **Overview**
> This PR is the first step toward the **httpx → httpx2** migration ([issue #4802](https://github.com/huggingface/huggingface_hub/issues/4802)). It **re-exports the HTTP stack** as `huggingface_hub.utils.httpx` by importing `httpx` in `utils/__init__.py`, so downstream libraries can catch `httpx` exceptions and use types without pinning to a separate `httpx` install.
> 
> The utilities docs add a **“The `httpx` module”** section with import/exception-handling examples, guidance to prefer [`get_session`] for Hub requests, and notes on v1.x (`httpx`) vs planned v2.x (`httpx2`). Doc-builder callouts were updated from `<Tip>` to `> [!TIP]` / `> [!WARNING]` markdown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fb8d495f60f045b7dfac05df8d86fb55463700e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->