### PR TITLE
[CLI] Fix 'hf buckets rm --recursive' deleting lexical siblings of the prefix

### DIFF
--- a/src/huggingface_hub/cli/buckets.py
+++ b/src/huggingface_hub/cli/buckets.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Contains commands to interact with buckets via the CLI."""
 
+from collections.abc import Iterable, Iterator
 from typing import Annotated
 
 import click
@@ -21,6 +22,7 @@ from huggingface_hub import logging
 from huggingface_hub._buckets import (
     BUCKET_PREFIX,
     BucketFile,
+    BucketFolder,
     FilterMatcher,
     _parse_bucket_uri,
 )
@@ -230,6 +232,18 @@ def _list_buckets(
     out.table(items, alignments={"size": "right"})
 
 
+def _iter_under_prefix(items: Iterable[BucketFile | BucketFolder], prefix: str) -> Iterator[BucketFile | BucketFolder]:
+    """Drop entries that are not `prefix` itself or below it.
+
+    The server matches `prefix` lexically, so listing "logs" also returns "logs.json" or "logs_backup/...".
+    Filesystem semantics require path components => keep only what's actually under the prefix.
+    """
+    prefix = prefix.rstrip("/")
+    for item in items:
+        if not prefix or item.path == prefix or item.path.startswith(f"{prefix}/"):
+            yield item
+
+
 def _list_files(
     argument: str,
     human_readable: bool,
@@ -244,10 +258,13 @@ def _list_files(
     api = get_hf_api(token=token)
     parsed = _parse_bucket_uri(argument)
     items = list(
-        api.list_bucket_tree(
-            parsed.id,
-            prefix=parsed.path_in_repo or None,
-            recursive=recursive,
+        _iter_under_prefix(
+            api.list_bucket_tree(
+                parsed.id,
+                prefix=parsed.path_in_repo or None,
+                recursive=recursive,
+            ),
+            parsed.path_in_repo,
         )
     )
 
@@ -415,19 +432,16 @@ def remove(
     if recursive:
         status = out.status("Listing files from remote")
 
-        # The server matches `prefix` lexically, so listing "logs" also returns "logs.json" or "logs_backup/...".
-        # Removal must be scoped to path components => drop entries that aren't `prefix` itself or below it.
-        prefix = prefix.rstrip("/")
-
         all_files: list[BucketFile] = []
-        for item in api.list_bucket_tree(
-            bucket_id,
-            prefix=prefix or None,
-            recursive=True,
+        for item in _iter_under_prefix(
+            api.list_bucket_tree(
+                bucket_id,
+                prefix=prefix or None,
+                recursive=True,
+            ),
+            prefix,
         ):
-            if isinstance(item, BucketFile) and (
-                not prefix or item.path == prefix or item.path.startswith(f"{prefix}/")
-            ):
+            if isinstance(item, BucketFile):
                 all_files.append(item)
                 status.update(f"Listing files from remote ({len(all_files)} files)")
         status.done(f"Listing files from remote ({len(all_files)} files)")

--- a/src/huggingface_hub/cli/buckets.py
+++ b/src/huggingface_hub/cli/buckets.py
@@ -415,13 +415,19 @@ def remove(
     if recursive:
         status = out.status("Listing files from remote")
 
+        # The server matches `prefix` lexically, so listing "logs" also returns "logs.json" or "logs_backup/...".
+        # Removal must be scoped to path components => drop entries that aren't `prefix` itself or below it.
+        prefix = prefix.rstrip("/")
+
         all_files: list[BucketFile] = []
         for item in api.list_bucket_tree(
             bucket_id,
             prefix=prefix or None,
             recursive=True,
         ):
-            if isinstance(item, BucketFile):
+            if isinstance(item, BucketFile) and (
+                not prefix or item.path == prefix or item.path.startswith(f"{prefix}/")
+            ):
                 all_files.append(item)
                 status.update(f"Listing files from remote ({len(all_files)} files)")
         status.done(f"Listing files from remote ({len(all_files)} files)")

--- a/tests/test_buckets_cli.py
+++ b/tests/test_buckets_cli.py
@@ -685,6 +685,21 @@ def test_list_files_with_prefix(tree_bucket: str):
     )
 
 
+def test_list_files_with_prefix_path_boundary(api: HfApi, bucket_write: str):
+    """A prefix is scoped to path components: lexical siblings are not listed."""
+    api.batch_bucket_files(
+        bucket_write,
+        add=[
+            (b"a", "logs/a.log"),
+            (b"json", "logs.json"),
+            (b"backup", "logs_backup/a.log"),
+            (b"x", "logsx/c.log"),
+        ],
+    )
+
+    _check_list_output(f"hf buckets list {bucket_write}/logs -R --quiet", ["logs/a.log"])
+
+
 def test_list_files_with_hf_prefix(tree_bucket: str):
     """hf://buckets/ format works the same as short format."""
     _check_list_output(

--- a/tests/test_buckets_cli.py
+++ b/tests/test_buckets_cli.py
@@ -302,6 +302,40 @@ def test_rm_recursive(api: HfApi, bucket_write: str):
     assert _remote_files(api, bucket_write) == {"keep.txt"}
 
 
+def test_rm_recursive_path_boundary(api: HfApi, bucket_write: str):
+    """'hf buckets rm prefix --recursive' does not remove lexical siblings of the prefix."""
+    api.batch_bucket_files(
+        bucket_write,
+        add=[
+            (b"a", "logs/a.log"),
+            (b"b", "logs/b.log"),
+            (b"json", "logs.json"),
+            (b"backup", "logs_backup/a.log"),
+            (b"x", "logsx/c.log"),
+        ],
+    )
+
+    result = cli(f"hf buckets rm {bucket_write}/logs --recursive --yes")
+    assert result.exit_code == 0
+    assert "2 file(s)" in result.output
+
+    assert _remote_files(api, bucket_write) == {"logs.json", "logs_backup/a.log", "logsx/c.log"}
+
+
+def test_rm_recursive_trailing_slash(api: HfApi, bucket_write: str):
+    """'hf buckets rm prefix/ --recursive' behaves like the slash-less form."""
+    api.batch_bucket_files(
+        bucket_write,
+        add=[(b"a", "logs/a.log"), (b"json", "logs.json")],
+    )
+
+    result = cli(f"hf buckets rm {bucket_write}/logs/ --recursive --yes")
+    assert result.exit_code == 0
+    assert "1 file(s)" in result.output
+
+    assert _remote_files(api, bucket_write) == {"logs.json"}
+
+
 def test_rm_recursive_dry_run(api: HfApi, bucket_write: str):
     """'hf buckets rm prefix/ --recursive --dry-run' previews without deleting."""
     api.batch_bucket_files(


### PR DESCRIPTION
## TL;DR: `hf buckets ls username/my-bucket/logs -R` should list `logs/file_a.txt` but not `logs_file_root.txt`. Same for `hf buckets rm`. This PR fixes it.

---

Reported by Mordehai Attia (CORSEN AI, @CorsenAI) in #4749


## Summary

Fixes #4749.

`hf buckets rm <bucket>/<prefix> --recursive` was deleting every key whose name starts *lexically* with `<prefix>`, not only the keys under `<prefix>/`. The bucket tree endpoint matches `prefix` as a raw string (documented behavior of `list_bucket_tree`), and every other consumer in the lib compensates with a path-component filter (`HfFileSystem`, `_list_remote_files` for sync, `_copy_to_bucket`, `cli/_skills.py`) — the CLI didn't. With `--yes` and unversioned buckets, the loss is permanent.

Changes:
- `cli/buckets.py`: small `_iter_under_prefix()` helper that normalizes the prefix and keeps only entries that are the prefix itself or below it, applied to both `rm --recursive` (the destructive bug) and `ls` (same lexical behavior, non-destructive — included so the two commands agree).
- Three regression tests in `tests/test_buckets_cli.py`.

No change to `list_bucket_tree` itself: its lexical-prefix semantics are documented and relied on elsewhere.

## Repro (staging, before the fix)

```
--- prefix='logs' recursive=True ---
    file logs.json
    file logs/a.txt
    file logs/sub/b.txt
    file logs_backup/a.txt
    file logsx/c.txt
--- prefix='logs/' recursive=True ---
    file logs/a.txt
    file logs/sub/b.txt
```

So `hf buckets rm me/my-bucket/logs --recursive --yes` removed 5 files instead of 2, and `hf buckets ls me/my-bucket/logs -R` listed 5.

## After

```
$ hf buckets rm __DUMMY_HUB_USER__/my-bucket/logs --recursive --dry-run
delete: hf://buckets/__DUMMY_HUB_USER__/my-bucket/logs/a.log
delete: hf://buckets/__DUMMY_HUB_USER__/my-bucket/logs/b.log
(dry run) 2 file(s) totaling 2 B would be removed.

$ hf buckets ls __DUMMY_HUB_USER__/my-bucket/logs -R --quiet
logs/a.log
logs/b.log
```

`logs.json`, `logs_backup/a.log` and `logsx/c.log` are left alone.

## Notes on the details

- **The fix snippet suggested in the issue is subtly wrong.** `f.path == prefix or f.path.startswith(prefix + "/")` without normalizing breaks the trailing-slash form our own docs and CLI examples use (`hf buckets rm user/my-bucket/logs/ --recursive`): the prefix is `"logs/"` there, nothing matches `"logs//"`, and the command would report "No files to remove.". Hence the `rstrip("/")` and `test_rm_recursive_trailing_slash`, which pins that path.
- **Only recursive listing was affected.** Checked against staging: with `recursive=False` the server already treats the prefix as a directory (`prefix="logs"` returns `logs/a.txt` + `logs/sub` only). The filter is a no-op there, so `ls` without `-R` is unchanged.

## Tests

Against staging: `pytest tests/test_buckets_cli.py -k "list_files or rm_recursive or rm_single or remove_alias"` → 30 passed. Both new boundary tests fail on `main` (`rm` deletes 5 files instead of 2; `ls` lists 4 entries instead of 1) and pass here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how recursive bucket list and delete select files, including a destructive code path, though behavior is narrowed to match filesystem semantics and is covered by new regression tests.
> 
> **Overview**
> Fixes incorrect **lexical** prefix matching in `hf buckets list` and `hf buckets rm --recursive`, where keys like `logs.json` or `logs_backup/...` were treated as under prefix `logs`.
> 
> Adds **`_iter_under_prefix()`** in `cli/buckets.py`: strips trailing slashes on the prefix, then keeps only entries whose path equals the prefix or starts with `{prefix}/`. That filter wraps **`list_bucket_tree`** results for file listing and for building the delete set in recursive **`rm`**, so list and remove agree on what “under a prefix” means. **`list_bucket_tree`** itself is unchanged.
> 
> New CLI tests cover recursive **`rm`** path boundaries, **`logs/`** trailing-slash behavior, and prefixed **`list -R`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9566fb6d6dee3f7ff27fd6b38f2bff17873b3dfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->