### PR TITLE
[Docs] Clarify Jobs argument forwarding and align examples

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -1899,7 +1899,13 @@ Running this will show the following output!
 This code ran with the following GPU: NVIDIA A10G
 ```
 
-A `--` can be used to separate the command from jobs options for clarity, e.g., `hf jobs run --flavor a10g-small -- python -c '...'`
+Place Jobs options before the image. If your command uses options that Jobs also recognises,
+such as `--help` or `--timeout`, add `--` between the image and command. Otherwise, Jobs can
+consume those options instead of forwarding them:
+
+```bash
+>>> hf jobs run --flavor cpu-basic python:3.12 -- python --help
+```
 
 That's it! You're now running code on Hugging Face's infrastructure.
 
@@ -2123,7 +2129,7 @@ Run UV scripts (Python scripts with inline dependencies) on HF infrastructure. U
 >>> hf jobs uv run --repo my-uv-scripts my_script.py
 
 # Run with GPU
->>> hf jobs uv run --flavor gpu-t4-small ml_training.py
+>>> hf jobs uv run --flavor t4-small ml_training.py
 
 # Pass arguments to script
 >>> hf jobs uv run process.py input.csv output.parquet
@@ -2140,7 +2146,11 @@ Run UV scripts (Python scripts with inline dependencies) on HF infrastructure. U
 
 UV scripts are Python scripts that include their dependencies directly in the file using a special comment syntax. This makes them perfect for self-contained tasks that don't require complex project setups. Learn more about UV scripts in the [UV documentation](https://docs.astral.sh/uv/guides/scripts/).
 
-A `--` can be used to separate the command from jobs/uv options for clarity, e.g., `hf jobs uv run --flavor gpu-t4-small --with torch -- python -c '...'`
+Put Jobs options before the script. Use `--` to forward script options that Jobs also recognises:
+
+```bash
+>>> hf jobs uv run --flavor t4-small train.py -- --help
+```
 
 ### hf jobs scheduled
 

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -1899,9 +1899,8 @@ Running this will show the following output!
 This code ran with the following GPU: NVIDIA A10G
 ```
 
-Place Jobs options before the image. If your command uses options that Jobs also recognises,
-such as `--help` or `--timeout`, add `--` between the image and command. Otherwise, Jobs can
-consume those options instead of forwarding them:
+Put Jobs options before the image for consistency. Use `--` between the image and command to
+prevent Jobs from consuming command options such as `--help` or `--timeout`.
 
 ```bash
 >>> hf jobs run --flavor cpu-basic python:3.12 -- python --help

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -2145,7 +2145,8 @@ Run UV scripts (Python scripts with inline dependencies) on HF infrastructure. U
 
 UV scripts are Python scripts that include their dependencies directly in the file using a special comment syntax. This makes them perfect for self-contained tasks that don't require complex project setups. Learn more about UV scripts in the [UV documentation](https://docs.astral.sh/uv/guides/scripts/).
 
-Use `--` to pass conflicting options through to your script:
+Use `--` to pass conflicting options through to your script. Here, `--help` reaches `train.py`
+rather than showing Jobs help:
 
 ```bash
 >>> hf jobs uv run --flavor t4-small train.py -- --help

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -1899,8 +1899,8 @@ Running this will show the following output!
 This code ran with the following GPU: NVIDIA A10G
 ```
 
-Put Jobs options before the image for consistency. Use `--` between the image and command to
-prevent Jobs from consuming command options such as `--help` or `--timeout`.
+Use `--` to separate Jobs options from arguments passed to your command or script.
+Jobs does not interpret options after `--`.
 
 ```bash
 >>> hf jobs run --flavor cpu-basic python:3.12 -- python --help
@@ -2145,7 +2145,7 @@ Run UV scripts (Python scripts with inline dependencies) on HF infrastructure. U
 
 UV scripts are Python scripts that include their dependencies directly in the file using a special comment syntax. This makes them perfect for self-contained tasks that don't require complex project setups. Learn more about UV scripts in the [UV documentation](https://docs.astral.sh/uv/guides/scripts/).
 
-Put Jobs options before the script. Use `--` to forward script options that Jobs also recognises:
+Use `--` to pass conflicting options through to your script:
 
 ```bash
 >>> hf jobs uv run --flavor t4-small train.py -- --help

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -2987,7 +2987,7 @@ $ hf jobs uv run [OPTIONS] SCRIPT [SCRIPT_ARGS]...
 Examples
   $ hf jobs uv run --name my-script my_script.py
   $ hf jobs uv run --detach my_script.py
-  $ hf jobs uv run ml_training.py --flavor a10g-small
+  $ hf jobs uv run --flavor a10g-small ml_training.py
   $ hf jobs uv run --with transformers train.py
   $ hf jobs uv run -v hf://org/my-model:/data -v hf://buckets/org/b:/mnt script.py
 

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -917,7 +917,7 @@ jobs_cli.add_group(uv_app, name="uv")
     examples=[
         "hf jobs uv run --name my-script my_script.py",
         "hf jobs uv run --detach my_script.py",
-        "hf jobs uv run ml_training.py --flavor a10g-small",
+        "hf jobs uv run --flavor a10g-small ml_training.py",
         "hf jobs uv run --with transformers train.py",
         "hf jobs uv run -v hf://org/my-model:/data -v hf://buckets/org/b:/mnt script.py",
     ],


### PR DESCRIPTION
I think it’s helpful to encourage users and agents to use `--` when passing options to a Job’s command or script, to avoid HF accidentally consuming options intended for that command—such as `--help`, `--timeout`, or `--token`. The current docs describe it as “for clarity”, but it can affect what actually runs.

- Clarify the separator’s purpose, with Docker and UV examples.
- Fix the Docker example’s missing image and replace `gpu-t4-small` with `t4-small`.
- Put `--flavor` before the script in CLI help and regenerate the reference.

No parser behavior changes. Examples checked against the current parser without launching Jobs. `make style` passed; `make quality` reported only two existing type errors in `_output.py`, reproduced on the base checkout.

Related: https://github.com/huggingface/hub-docs/pull/2758 and https://github.com/huggingface/hub-docs/pull/2762.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and embedded CLI examples only; no runtime or parsing behavior changes.
> 
> **Overview**
> **Documentation-only** updates for `hf jobs` and `hf jobs uv run`: the guide now states that `--` stops Jobs from parsing later flags, so options like `--help` go to the container or script—not only “for clarity.” New examples cover `hf jobs run ... -- python --help` and `hf jobs uv run ... train.py -- --help`.
> 
> Example fixes align with recommended flag order: **`gpu-t4-small` → `t4-small`**, and **`--flavor` before the script** in the UV help examples (`cli.md`, package reference, and the Typer `examples` list in `jobs.py`). **No CLI parser changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 968717b5ba1fc15b208a1731de1d79b9307c73ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->