### PR TITLE
[RepoCard] Read cards and templates as UTF-8, not the locale encoding

### DIFF
--- a/src/huggingface_hub/repocard.py
+++ b/src/huggingface_hub/repocard.py
@@ -325,9 +325,9 @@ class RepoCard:
         kwargs.update(template_kwargs)  # Template_kwargs have priority
 
         if template_path is not None:
-            template_str = Path(template_path).read_text()
+            template_str = Path(template_path).read_text(encoding="utf-8")
         if template_str is None:
-            template_str = Path(cls.default_template_path).read_text()
+            template_str = Path(cls.default_template_path).read_text(encoding="utf-8")
         template = jinja2.Template(template_str)
         content = template.render(card_data=card_data.to_yaml(), **kwargs)
         return cls(content)
@@ -513,7 +513,7 @@ def _detect_line_ending(content: str) -> Literal["\r", "\n", "\r\n", None]:  # n
 
 
 def metadata_load(local_path: str | Path) -> dict | None:
-    content = Path(local_path).read_text()
+    content = Path(local_path).read_text(encoding="utf-8")
     match = REGEX_YAML_BLOCK.search(content)
     if match:
         yaml_block = match.group(2)

--- a/tests/test_repocard.py
+++ b/tests/test_repocard.py
@@ -181,6 +181,14 @@ Custom template passed as a string.
 {{ repo_url | default("[More Information Needed]", true) }}
 """
 
+DUMMY_NON_ASCII_MODEL_CARD_TEMPLATE = """
+---
+{{ card_data }}
+---
+
+Modèle Á 北京
+"""
+
 
 require_jinja = pytest.mark.skipif(not is_jinja_available(), reason="test requires Jinja2.")
 
@@ -194,6 +202,14 @@ class TestRepocardMetadata:
         self.filepath.write_text(DUMMY_MODELCARD)
         data = metadata_load(self.filepath)
         assert data == {"license": "mit", "datasets": ["foo", "bar"]}
+
+    def test_metadata_load_non_ascii(self):
+        # `metadata_save` writes UTF-8, so `metadata_load` must decode UTF-8 on every platform.
+        # With the locale default (cp1252 on Windows) "é" comes back as "Ã©" and "Á"
+        # raises UnicodeDecodeError.
+        metadata = {"license": "mit", "pretty_name": "Café Á 北京"}
+        metadata_save(self.filepath, metadata)
+        assert metadata_load(self.filepath) == metadata
 
     def test_metadata_save(self):
         self.filepath.write_text(DUMMY_MODELCARD)
@@ -607,6 +623,15 @@ class TestRepoCard:
             some_data="asdf",
         )
         assert card.text.endswith("asdf"), "Custom template didn't set jinja variable correctly"
+
+    @require_jinja
+    def test_repo_card_from_custom_template_path_non_ascii(self, tmp_path):
+        # The template file is UTF-8; with the locale default (cp1252 on Windows) accented
+        # characters are mangled and "Á" raises UnicodeDecodeError.
+        template_path = tmp_path / "template.md"
+        template_path.write_text(DUMMY_NON_ASCII_MODEL_CARD_TEMPLATE, encoding="utf-8")
+        card = RepoCard.from_template(card_data=CardData(license="mit"), template_path=template_path)
+        assert card.text.strip() == "Modèle Á 北京"
 
     @require_jinja
     def test_repo_card_from_custom_template_string(self):

--- a/tests/test_repocard.py
+++ b/tests/test_repocard.py
@@ -204,9 +204,6 @@ class TestRepocardMetadata:
         assert data == {"license": "mit", "datasets": ["foo", "bar"]}
 
     def test_metadata_load_non_ascii(self):
-        # `metadata_save` writes UTF-8, so `metadata_load` must decode UTF-8 on every platform.
-        # With the locale default (cp1252 on Windows) "é" comes back as "Ã©" and "Á"
-        # raises UnicodeDecodeError.
         metadata = {"license": "mit", "pretty_name": "Café Á 北京"}
         metadata_save(self.filepath, metadata)
         assert metadata_load(self.filepath) == metadata
@@ -626,8 +623,6 @@ class TestRepoCard:
 
     @require_jinja
     def test_repo_card_from_custom_template_path_non_ascii(self, tmp_path):
-        # The template file is UTF-8; with the locale default (cp1252 on Windows) accented
-        # characters are mangled and "Á" raises UnicodeDecodeError.
         template_path = tmp_path / "template.md"
         template_path.write_text(DUMMY_NON_ASCII_MODEL_CARD_TEMPLATE, encoding="utf-8")
         card = RepoCard.from_template(card_data=CardData(license="mit"), template_path=template_path)


### PR DESCRIPTION
`metadata_load()` reads the card with `Path(local_path).read_text()` and no `encoding=`, so it decodes with the locale default. The library's own writers pin UTF-8, so on a stock Windows install it writes UTF-8 and cannot read it back.

In the same file, `_content_to_file` (132), `RepoCard.load` (186), `RepoCard.save` (274) and both `metadata_update` handles (539, 547) all pass an explicit encoding. The three patched reads were the only ones that did not.

On cp1252, `metadata_load()` on a card whose YAML block holds a non-ASCII value raises rather than returning it:

```
UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 40: character maps to <undefined>
```

`RepoCard.from_template()` has the same problem for a custom `template_path`, which is why it is fixed alongside.

Two tests added, both failing before. On the offline part of `tests/test_repocard.py` the count goes 42 to 44 passed with nothing failing either side.

The Hub-backed tests are excluded from that comparison deliberately: they are non-deterministic against `hub-ci` from here, and two runs of unmodified `main` gave six failures each with three different names each way, so a diff across them would not mean anything.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow encoding fix aligned with existing UTF-8 I/O elsewhere in repocard; no auth or data-model changes.
> 
> **Overview**
> Fixes **locale-dependent decoding** on three repo-card reads that omitted `encoding="utf-8"`: `metadata_load()`, and both template file reads in `RepoCard.from_template()` (custom `template_path` and the default template). Writers and other load paths in the same module already use UTF-8, so on Windows (e.g. cp1252) UTF-8 cards with non-ASCII metadata or templates could raise `UnicodeDecodeError` on read.
> 
> Adds regression tests for **non-ASCII metadata round-trip** via `metadata_save`/`metadata_load` and for **non-ASCII custom template paths** in `from_template`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a3791d0ee3010487fb2360d024f7fa5e4e048a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->