### PR TITLE
[Sandbox] Support caller-supplied labels in Sandbox.create (#4812)

### DIFF
--- a/src/huggingface_hub/_sandbox.py
+++ b/src/huggingface_hub/_sandbox.py
@@ -59,6 +59,8 @@ POOL_LABEL = "hf-sandbox-pool"
 # `Sandbox.connect(id)` can recompute the token from any machine with no local state.
 NONCE_LABEL = "hf-sandbox-nonce"
 
+RESERVED_SANDBOX_LABELS = frozenset({SANDBOX_LABEL, MODE_LABEL, POOL_LABEL, NONCE_LABEL})
+
 DEFAULT_IMAGE = "python:3.12"
 
 DEFAULT_IDLE_TIMEOUT = 10 * 60  # 10 minutes
@@ -527,6 +529,7 @@ class Sandbox:
         volumes: List[Volume] | None = None,
         namespace: str | None = None,
         forward_hf_token: bool = False,
+        labels: dict[str, str] | None = None,
         start_timeout: float = 120.0,
         token: str | None = None,
     ) -> "Sandbox":
@@ -557,6 +560,10 @@ class Sandbox:
                 User or org namespace to run under (defaults to current user).
             forward_hf_token (`bool`, *optional*, defaults to `False`):
                 If True, your HF token is injected as `HF_TOKEN` (opt-in).
+            labels (`dict[str, str]`, *optional*):
+                Custom correlation labels to attach to the underlying HF Job. Reserved
+                keys (`hf-sandbox`, `hf-sandbox-mode`, `hf-sandbox-pool`, `hf-sandbox-nonce`)
+                cannot be overridden.
             start_timeout (`float`, *optional*, defaults to `120.0`):
                 Max seconds to wait for the sandbox to become ready.
             token (`str`, *optional*):
@@ -566,6 +573,19 @@ class Sandbox:
         `wget`/`curl` if available, otherwise read off an always-mounted server bucket (which
         adds ~2-3s to cold start, so shipping `wget`/`curl` keeps it fast).
         """
+        if labels is not None:
+            if not isinstance(labels, dict):
+                raise ValueError(f"`labels` must be a dict[str, str], got {type(labels).__name__}")
+            for k, v in labels.items():
+                if not isinstance(k, str) or not isinstance(v, str):
+                    raise ValueError(
+                        f"`labels` keys and values must be strings, got key={k!r} ({type(k).__name__}) and value={v!r} ({type(v).__name__})"
+                    )
+                if k in RESERVED_SANDBOX_LABELS:
+                    raise ValueError(
+                        f"Label '{k}' is reserved by huggingface_hub Sandbox ({', '.join(sorted(RESERVED_SANDBOX_LABELS))}) and cannot be overridden."
+                    )
+
         api = HfApi(token=token)
         hf_token = _effective_token(api)
         nonce = token_hex(16)
@@ -582,6 +602,9 @@ class Sandbox:
             sandbox_token=sandbox_token,
         )
 
+        job_labels = dict(labels) if labels else {}
+        job_labels.update({SANDBOX_LABEL: "1", MODE_LABEL: MODE_DEDICATED, NONCE_LABEL: nonce})
+
         job = api.run_job(
             image=image,
             command=command,
@@ -589,7 +612,7 @@ class Sandbox:
             secrets=job_secrets,
             flavor=flavor,
             timeout=SANDBOX_MAX_LIFETIME,
-            labels={SANDBOX_LABEL: "1", MODE_LABEL: MODE_DEDICATED, NONCE_LABEL: nonce},
+            labels=job_labels,
             volumes=job_volumes or None,
             expose=[SANDBOX_SERVER_PORT],
             namespace=namespace,

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -12,6 +12,7 @@ from huggingface_hub._sandbox import (
     MODE_POOL,
     NONCE_LABEL,
     POOL_LABEL,
+    RESERVED_SANDBOX_LABELS,
     SANDBOX_LABEL,
     Sandbox,
     SandboxPool,
@@ -315,6 +316,85 @@ class TestSandboxClient:
             pass
         sandbox._server._api.cancel_job.assert_not_called()
         assert sandbox._server._client.is_closed
+
+    def test_create_propagates_custom_labels(self, monkeypatch, fake_server: str) -> None:
+        run_job_mock = MagicMock()
+        fake_job = MagicMock()
+        fake_job.id = "job-custom-labels"
+        fake_job.owner.name = "user"
+        run_job_mock.return_value = fake_job
+
+        monkeypatch.setattr(sandbox_mod.HfApi, "run_job", run_job_mock)
+        fake_server_obj = _make_server(fake_server, job_id="job-custom-labels")
+        monkeypatch.setattr(sandbox_mod._SandboxServer, "from_job", lambda **kw: fake_server_obj)
+        monkeypatch.setattr(fake_server_obj, "wait_ready", lambda timeout: None)
+
+        sandbox = Sandbox.create(
+            image="python:3.12",
+            labels={"controller-run": "run-42", "team": "data-infra"},
+            token="hf_test",
+        )
+        assert sandbox.id == "job-custom-labels"
+
+        run_job_mock.assert_called_once()
+        passed_labels = run_job_mock.call_args.kwargs["labels"]
+        assert passed_labels["controller-run"] == "run-42"
+        assert passed_labels["team"] == "data-infra"
+        assert passed_labels[SANDBOX_LABEL] == "1"
+        assert passed_labels[MODE_LABEL] == sandbox_mod.MODE_DEDICATED
+        assert NONCE_LABEL in passed_labels
+        assert len(passed_labels[NONCE_LABEL]) == 32
+
+    def test_create_without_labels_preserves_default_labels(self, monkeypatch, fake_server: str) -> None:
+        run_job_mock = MagicMock()
+        fake_job = MagicMock()
+        fake_job.id = "job-default-labels"
+        fake_job.owner.name = "user"
+        run_job_mock.return_value = fake_job
+
+        monkeypatch.setattr(sandbox_mod.HfApi, "run_job", run_job_mock)
+        fake_server_obj = _make_server(fake_server, job_id="job-default-labels")
+        monkeypatch.setattr(sandbox_mod._SandboxServer, "from_job", lambda **kw: fake_server_obj)
+        monkeypatch.setattr(fake_server_obj, "wait_ready", lambda timeout: None)
+
+        sandbox = Sandbox.create(image="python:3.12", token="hf_test")
+        assert sandbox.id == "job-default-labels"
+
+        run_job_mock.assert_called_once()
+        passed_labels = run_job_mock.call_args.kwargs["labels"]
+        assert passed_labels[SANDBOX_LABEL] == "1"
+        assert passed_labels[MODE_LABEL] == sandbox_mod.MODE_DEDICATED
+        assert NONCE_LABEL in passed_labels
+        assert set(passed_labels.keys()) == {SANDBOX_LABEL, MODE_LABEL, NONCE_LABEL}
+
+    @pytest.mark.parametrize("reserved_key", sorted(RESERVED_SANDBOX_LABELS))
+    def test_create_rejects_reserved_label_keys(self, monkeypatch, reserved_key: str) -> None:
+        run_job_mock = MagicMock()
+        monkeypatch.setattr(sandbox_mod.HfApi, "run_job", run_job_mock)
+
+        with pytest.raises(ValueError, match=f"Label '{reserved_key}' is reserved"):
+            Sandbox.create(image="python:3.12", labels={reserved_key: "forbidden"}, token="hf_test")
+
+        run_job_mock.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "invalid_labels",
+        [
+            "not-a-dict",
+            ["key", "val"],
+            {123: "val"},
+            {"key": 123},
+            {"key": None},
+        ],
+    )
+    def test_create_validates_label_types(self, monkeypatch, invalid_labels) -> None:
+        run_job_mock = MagicMock()
+        monkeypatch.setattr(sandbox_mod.HfApi, "run_job", run_job_mock)
+
+        with pytest.raises(ValueError, match="`labels`"):
+            Sandbox.create(image="python:3.12", labels=invalid_labels, token="hf_test")
+
+        run_job_mock.assert_not_called()
 
 
 class TestSharedSandbox:


### PR DESCRIPTION
## Summary

- Add optional `labels: dict[str, str] | None = None` parameter to `Sandbox.create()` for dedicated sandboxes.
- Merge caller-supplied labels into the underlying `HfApi.run_job()` invocation while retaining all internal SDK bookkeeping labels (`hf-sandbox`, `hf-sandbox-mode`, `hf-sandbox-nonce`).
- Validate label types (`dict[str, str]`) and reject collisions with reserved SDK keys (`RESERVED_SANDBOX_LABELS`) before creating the Job to avoid interfering with reconnect or discovery.
- Add unit test coverage in `tests/test_sandbox.py` covering label propagation, unchanged defaults, type validation, and reserved key rejection.

Closes #4812

### Usage

```python
from huggingface_hub import Sandbox

sandbox = Sandbox.create(
    image="python:3.12",
    labels={"controller-run": "run-42", "team": "data-infra"},
)
```

### Local Test Output

```
$ pytest tests/test_sandbox.py -v
======================= 52 passed, 1 warning in 49.44s ========================
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API on dedicated sandbox creation with upfront validation; no changes to pool mode or connect/token derivation paths.
> 
> **Overview**
> **`Sandbox.create`** now accepts an optional `labels` dict so callers can attach correlation metadata (e.g. controller run id, team) to the underlying HF Job.
> 
> Custom labels are merged into the job label set passed to `HfApi.run_job`, with SDK bookkeeping labels (`hf-sandbox`, mode, nonce) applied afterward so they always win. A new `RESERVED_SANDBOX_LABELS` set blocks overriding keys used for discovery and `Sandbox.connect`. Invalid types or reserved keys raise `ValueError` before any job is started.
> 
> Unit tests cover label propagation, unchanged behavior when `labels` is omitted, reserved-key rejection, and type validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5731a8f27f8020bd098d2782b97baa1778b5e4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->