### PR TITLE
[Inference] Add Berget provider

### DIFF
--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -3178,7 +3178,7 @@ $ hf models list [OPTIONS] [REPO_ID]
 * `--gated / --no-gated`: Filter by gated status. '--gated' for gated only, '--no-gated' for non-gated only.
 * `--apps TEXT`: Filter by app(s) that can run the model, e.g. 'ollama' or 'vllm'.
 * `--num-parameters TEXT`: Filter by parameter count, e.g. 'min:6B,max:128B'.
-* `--inference-provider [baseten|cerebras|cohere|deepinfra|fal-ai|featherless-ai|fireworks-ai|groq|hf-inference|novita|nscale|openai|ovhcloud|publicai|replicate|scaleway|together|wavespeed|zai-org]`: Filter by inference provider(s) serving the model, e.g. 'fireworks-ai'.
+* `--inference-provider [baseten|berget|cerebras|cohere|deepinfra|fal-ai|featherless-ai|fireworks-ai|groq|hf-inference|novita|nscale|openai|ovhcloud|publicai|replicate|scaleway|together|wavespeed|zai-org]`: Filter by inference provider(s) serving the model, e.g. 'fireworks-ai'.
 * `--warm`: Only list models currently served by at least one inference provider.
 * `--sort [created_at|downloads|last_modified|likes|trending_score]`: Sort results.
 * `--limit INTEGER`: Limit the number of results.  [default: 30]

--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -135,7 +135,7 @@ class InferenceClient:
             Note: for better compatibility with OpenAI's client, `model` has been aliased as `base_url`. Those 2
             arguments are mutually exclusive. If a URL is passed as `model` or `base_url` for chat completion, the `(/v1)/chat/completions` suffix path will be appended to the URL.
         provider (`str`, *optional*):
-            Name of the provider to use for inference. Can be `"baseten"`, `"cerebras"`, `"cohere"`, `"deepinfra"`, `"fal-ai"`, `"featherless-ai"`, `"fireworks-ai"`, `"groq"`, `"hf-inference"`, `"novita"`, `"nscale"`, `"openai"`, `"ovhcloud"`, `"publicai"`, `"replicate"`, `"scaleway"`, `"together"`, `"wavespeed"` or `"zai-org"`.
+            Name of the provider to use for inference. Can be `"baseten"`, `"berget"`, `"cerebras"`, `"cohere"`, `"deepinfra"`, `"fal-ai"`, `"featherless-ai"`, `"fireworks-ai"`, `"groq"`, `"hf-inference"`, `"novita"`, `"nscale"`, `"openai"`, `"ovhcloud"`, `"publicai"`, `"replicate"`, `"scaleway"`, `"together"`, `"wavespeed"` or `"zai-org"`.
             Defaults to "auto": automatic routing, which defaults to "fastest" provider; you can
             switch to "cheapest" or "preferred" provider order at https://hf.co/settings/inference-providers.
             If model is a URL or `base_url` is passed, then `provider` is not used.

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -125,7 +125,7 @@ class AsyncInferenceClient:
             Note: for better compatibility with OpenAI's client, `model` has been aliased as `base_url`. Those 2
             arguments are mutually exclusive. If a URL is passed as `model` or `base_url` for chat completion, the `(/v1)/chat/completions` suffix path will be appended to the URL.
         provider (`str`, *optional*):
-            Name of the provider to use for inference. Can be `"baseten"`, `"cerebras"`, `"cohere"`, `"deepinfra"`, `"fal-ai"`, `"featherless-ai"`, `"fireworks-ai"`, `"groq"`, `"hf-inference"`, `"novita"`, `"nscale"`, `"openai"`, `"ovhcloud"`, `"publicai"`, `"replicate"`, `"scaleway"`, `"together"`, `"wavespeed"` or `"zai-org"`.
+            Name of the provider to use for inference. Can be `"baseten"`, `"berget"`, `"cerebras"`, `"cohere"`, `"deepinfra"`, `"fal-ai"`, `"featherless-ai"`, `"fireworks-ai"`, `"groq"`, `"hf-inference"`, `"novita"`, `"nscale"`, `"openai"`, `"ovhcloud"`, `"publicai"`, `"replicate"`, `"scaleway"`, `"together"`, `"wavespeed"` or `"zai-org"`.
             Defaults to "auto": automatic routing, which defaults to "fastest" provider; you can
             switch to "cheapest" or "preferred" provider order at https://hf.co/settings/inference-providers.
             If model is a URL or `base_url` is passed, then `provider` is not used.

--- a/src/huggingface_hub/inference/_providers/__init__.py
+++ b/src/huggingface_hub/inference/_providers/__init__.py
@@ -8,6 +8,7 @@ from huggingface_hub.utils import logging
 
 from ._common import AutoRouterConversationalTask, TaskProviderHelper, _fetch_inference_provider_mapping
 from .baseten import BasetenConversationalTask
+from .berget import BergetConversationalTask
 from .cerebras import CerebrasConversationalTask
 from .cohere import CohereConversationalTask
 from .deepinfra import (
@@ -71,6 +72,7 @@ logger = logging.get_logger(__name__)
 
 PROVIDER_T = Literal[
     "baseten",
+    "berget",
     "cerebras",
     "cohere",
     "deepinfra",
@@ -98,6 +100,9 @@ CONVERSATIONAL_AUTO_ROUTER = AutoRouterConversationalTask()
 PROVIDERS: dict[PROVIDER_T, dict[str, TaskProviderHelper]] = {
     "baseten": {
         "conversational": BasetenConversationalTask(),
+    },
+    "berget": {
+        "conversational": BergetConversationalTask(),
     },
     "cerebras": {
         "conversational": CerebrasConversationalTask(),

--- a/src/huggingface_hub/inference/_providers/berget.py
+++ b/src/huggingface_hub/inference/_providers/berget.py
@@ -1,0 +1,6 @@
+from ._common import BaseConversationalTask
+
+
+class BergetConversationalTask(BaseConversationalTask):
+    def __init__(self):
+        super().__init__(provider="berget", base_url="https://api.berget.ai")

--- a/src/huggingface_hub/inference/_providers/berget.py
+++ b/src/huggingface_hub/inference/_providers/berget.py
@@ -4,3 +4,12 @@ from ._common import BaseConversationalTask
 class BergetConversationalTask(BaseConversationalTask):
     def __init__(self):
         super().__init__(provider="berget", base_url="https://api.berget.ai")
+
+    def _prepare_api_key(self, api_key: str | None) -> str:
+        if api_key is None:
+            raise ValueError("You must provide an api_key to work with Berget API.")
+        if api_key.startswith("hf_"):
+            raise ValueError(
+                "Berget provider is not available through Hugging Face routing yet, please use your own Berget API key."
+            )
+        return api_key

--- a/tests/test_inference_providers.py
+++ b/tests/test_inference_providers.py
@@ -1355,6 +1355,20 @@ class TestBergetProvider:
         helper = BergetConversationalTask()
         assert helper._prepare_url("berget_token", "username/repo_name") == "https://api.berget.ai/v1/chat/completions"
 
+    def test_prepare_api_key(self):
+        helper = BergetConversationalTask()
+        assert helper._prepare_api_key("berget_token") == "berget_token"
+
+    def test_prepare_api_key_requires_key(self):
+        helper = BergetConversationalTask()
+        with pytest.raises(ValueError, match="You must provide an api_key"):
+            helper._prepare_api_key(None)
+
+    def test_prepare_api_key_rejects_hf_token(self):
+        helper = BergetConversationalTask()
+        with pytest.raises(ValueError, match="not available through Hugging Face routing"):
+            helper._prepare_api_key("hf_token")
+
 
 class TestNscaleProvider:
     def test_prepare_route_text_to_image(self):

--- a/tests/test_inference_providers.py
+++ b/tests/test_inference_providers.py
@@ -17,6 +17,7 @@ from huggingface_hub.inference._providers._common import (
     filter_none,
     recursive_merge,
 )
+from huggingface_hub.inference._providers.berget import BergetConversationalTask
 from huggingface_hub.inference._providers.cohere import CohereConversationalTask
 from huggingface_hub.inference._providers.deepinfra import (
     DeepInfraAutomaticSpeechRecognitionTask,
@@ -1347,6 +1348,12 @@ class TestPublicAIProvider:
             helper._prepare_url("publicai_token", "username/repo_name")
             == "https://api.publicai.co/v1/chat/completions"
         )
+
+
+class TestBergetProvider:
+    def test_prepare_url(self):
+        helper = BergetConversationalTask()
+        assert helper._prepare_url("berget_token", "username/repo_name") == "https://api.berget.ai/v1/chat/completions"
 
 
 class TestNscaleProvider:


### PR DESCRIPTION
## Summary

Adds [Berget](https://berget.ai) as a new inference provider, following `_providers/new_provider.md`:

- `_providers/berget.py`: `BergetConversationalTask` extending `BaseConversationalTask` with no overrides — the API at `https://api.berget.ai/v1/chat/completions` is OpenAI-compatible.
- Registered in `_providers/__init__.py` (import, `PROVIDER_T`, `PROVIDERS`, alphabetical).
- Provider list docstring updated in `_client.py` + regenerated `_generated/_async_client.py` (via `make style`, which also picked up the new `--inference-provider berget` choice in the CLI reference docs).
- Static test in `tests/test_inference_providers.py` (`TestBergetProvider.test_prepare_url`).

JS-side PR (step 2 of the registration guide) is open as well: https://github.com/huggingface/huggingface.js/pull/2446 — we're registering as a Hub provider and will contact the inference team to get `berget` enabled server-side. For this phase we only support the `conversational` task with direct requests (users bring their own Berget API key); routed-request billing comes later.

Tested manually:

```
$ python -m pytest tests/test_inference_providers.py -q -k "Berget" 
2 passed, 175 deselected

$ ruff check src tests
All checks passed!

$ ty check src/huggingface_hub/inference/_providers/berget.py src/huggingface_hub/inference/_client.py
All checks passed!
```

Notes:
- No VCR cassettes for `tests/test_inference_client.py` yet: recording them requires the provider to be enabled on the Hub server-side, which happens during the registration. Happy to record them in a follow-up (or you can, same as other provider PRs).
- Heads-up: `make quality` currently fails on 2 pre-existing `ty` diagnostics in `src/huggingface_hub/cli/_output.py` (also failing on fresh upstream/main with the latest `ty`, unrelated to this PR). All files touched here pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive provider registration and documentation with scoped API-key checks; no changes to core auth or existing provider behavior.
> 
> **Overview**
> Adds **Berget** (`berget`) as a third-party inference provider for **conversational** chat completions against `https://api.berget.ai/v1/chat/completions` (OpenAI-compatible via `BaseConversationalTask`).
> 
> Users must pass a **Berget API key**; missing keys and `hf_*` tokens are rejected because Hugging Face routing is not supported yet. The provider is registered in the inference provider registry, and **Berget** appears in sync/async client docs and the CLI `--inference-provider` filter list.
> 
> Unit tests cover URL construction and API key validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a1869ed86416ddc1e2fc9d7d9450282e8cb0e61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->