### PR TITLE
Pin hf_hub_download GET to the commit resolved by the metadata HEAD

### DIFF
--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1781,11 +1781,16 @@ def _get_metadata_or_catch_error(
                 if not _is_same_or_hub_host(url, metadata.location):
                     # Remove authorization header when downloading a LFS blob from a CDN
                     headers.pop("authorization", None)
-            elif xet_file_data is None and commit_hash is not None and not REGEX_COMMIT_HASH.match(revision):
-                # Direct Hub response (no CDN Location). The HEAD resolved `revision` (e.g. `main`)
-                # to `commit_hash`, but `url` still points at `/resolve/<revision>/`. Pin the GET
-                # to that commit so a push between HEAD and GET cannot store new bytes under the
-                # old snapshot folder / etag blob. See #4815.
+            if (
+                xet_file_data is None
+                and commit_hash is not None
+                and not REGEX_COMMIT_HASH.match(revision)
+                and _is_same_or_hub_host(url, url_to_download)
+            ):
+                # Pin the GET to the commit the HEAD resolved. Applies to a direct Hub
+                # response and to a Hub-to-Hub redirect (repo rename / HF_ENDPOINT), both
+                # of which still have `/resolve/<revision>/` in the URL. A signed CDN
+                # Location is a different host, so it is left alone. See #4815.
                 url_to_download = hf_hub_url(
                     repo_id, filename, repo_type=repo_type, revision=commit_hash, endpoint=endpoint
                 )

--- a/src/huggingface_hub/file_download.py
+++ b/src/huggingface_hub/file_download.py
@@ -1781,6 +1781,14 @@ def _get_metadata_or_catch_error(
                 if not _is_same_or_hub_host(url, metadata.location):
                     # Remove authorization header when downloading a LFS blob from a CDN
                     headers.pop("authorization", None)
+            elif xet_file_data is None and commit_hash is not None and not REGEX_COMMIT_HASH.match(revision):
+                # Direct Hub response (no CDN Location). The HEAD resolved `revision` (e.g. `main`)
+                # to `commit_hash`, but `url` still points at `/resolve/<revision>/`. Pin the GET
+                # to that commit so a push between HEAD and GET cannot store new bytes under the
+                # old snapshot folder / etag blob. See #4815.
+                url_to_download = hf_hub_url(
+                    repo_id, filename, repo_type=repo_type, revision=commit_hash, endpoint=endpoint
+                )
         except httpx.ProxyError:
             # Actually raise on proxy error
             raise

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -32,6 +32,7 @@ from huggingface_hub.file_download import (
     HfFileMetadata,
     _check_disk_space,
     _create_symlink,
+    _get_metadata_or_catch_error,
     _get_pointer_path,
     _normalize_etag,
     get_hf_file_metadata,
@@ -1476,6 +1477,64 @@ class TestNormalizeEtag:
         return _normalize_etag(
             response.headers.get(constants.HUGGINGFACE_HEADER_X_LINKED_ETAG) or response.headers.get("ETag")
         )
+
+
+class TestPinDownloadUrlToResolvedCommit:
+    """Direct Hub files must GET the commit the metadata HEAD resolved, not `/resolve/main/`. See #4815."""
+
+    _COMMIT = "0123456789abcdef0123456789abcdef01234567"
+
+    def _metadata(self, location: str) -> HfFileMetadata:
+        return HfFileMetadata(
+            commit_hash=self._COMMIT,
+            etag="etag123",
+            location=location,
+            size=12,
+            xet_file_data=None,
+        )
+
+    def _call(self, metadata: HfFileMetadata, revision: str = "main", headers: dict[str, str] | None = None):
+        with patch("huggingface_hub.file_download.get_hf_file_metadata", return_value=metadata):
+            return _get_metadata_or_catch_error(
+                repo_id="org/model",
+                filename="config.json",
+                repo_type="model",
+                revision=revision,
+                endpoint=None,
+                etag_timeout=10,
+                headers={} if headers is None else headers,
+                token=False,
+                local_files_only=False,
+            )
+
+    def test_mutable_revision_without_redirect_is_pinned_to_commit(self):
+        revision_url = hf_hub_url("org/model", "config.json", revision="main")
+        pinned_url = hf_hub_url("org/model", "config.json", revision=self._COMMIT)
+        url_to_download, etag, commit_hash, size, xet_file_data, error = self._call(self._metadata(revision_url))
+        assert error is None
+        assert commit_hash == self._COMMIT
+        assert etag == "etag123"
+        assert size == 12
+        assert xet_file_data is None
+        assert url_to_download == pinned_url
+        assert url_to_download != revision_url
+
+    def test_cdn_redirect_location_is_kept(self):
+        cdn_url = "https://cdn.hf.co/signed/config.json?token=abc"
+        headers = {"authorization": "Bearer tok"}
+        url_to_download, _, _, _, _, error = self._call(self._metadata(cdn_url), headers=headers)
+        assert error is None
+        assert url_to_download == cdn_url
+        assert "authorization" not in headers
+
+    def test_already_pinned_revision_keeps_commit_url(self):
+        pinned_url = hf_hub_url("org/model", "config.json", revision=self._COMMIT)
+        url_to_download, _, commit_hash, _, _, error = self._call(
+            self._metadata(pinned_url), revision=self._COMMIT
+        )
+        assert error is None
+        assert commit_hash == self._COMMIT
+        assert url_to_download == pinned_url
 
 
 @pytest.mark.production

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -1527,6 +1527,14 @@ class TestPinDownloadUrlToResolvedCommit:
         assert url_to_download == cdn_url
         assert "authorization" not in headers
 
+    def test_hub_to_hub_redirect_is_pinned_to_commit(self):
+        redirected = "https://huggingface.co/new-org/renamed/resolve/main/config.json"
+        pinned_url = hf_hub_url("org/model", "config.json", revision=self._COMMIT)
+        url_to_download, _, commit_hash, _, _, error = self._call(self._metadata(redirected))
+        assert error is None
+        assert commit_hash == self._COMMIT
+        assert url_to_download == pinned_url
+
     def test_already_pinned_revision_keeps_commit_url(self):
         pinned_url = hf_hub_url("org/model", "config.json", revision=self._COMMIT)
         url_to_download, _, commit_hash, _, _, error = self._call(


### PR DESCRIPTION
## Summary
- `hf_hub_download` HEAD-resolves a mutable revision such as `main` to a commit and etag, then for files served directly by the Hub still GETs `/resolve/<revision>/`.
- If the branch moves between HEAD and GET, the client can store the new bytes under the old snapshot folder and etag blob. Length is the only post-download check.
- The redirect/CDN path already follows `Location`. For the direct-Hub path, rewrite the download URL to `/resolve/<commit>/` once `commit_hash` is known.

## Test plan
- [x] mocked HEAD with `location` equal to the `main` URL pins `url_to_download` to the resolved commit
- [x] CDN `Location` is left alone (auth header still dropped)
- [x] a request that is already a 40-char commit keeps that URL

Fixes #4815

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core download URL selection in `_get_metadata_or_catch_error`; incorrect pinning could break downloads or cache integrity, but behavior is narrowly gated and covered by new unit tests.
> 
> **Overview**
> Fixes a cache consistency bug (#4815) where `hf_hub_download` could HEAD a mutable revision (e.g. `main`), record commit and etag for that snapshot, then still GET `/resolve/main/` and pull newer bytes if the branch moved in between.
> 
> After metadata is fetched in `_get_metadata_or_catch_error`, **Hub-hosted** downloads (direct resolve URLs and Hub-to-Hub redirects) are rewritten to `/resolve/<commit_hash>/` when the user did not already pass a full commit. **Signed CDN** `Location` URLs are unchanged, including stripping auth on cross-host LFS redirects.
> 
> Adds `TestPinDownloadUrlToResolvedCommit` with mocked HEAD metadata for pinning, CDN preservation, hub-to-hub redirect pinning, and idempotent behavior when revision is already a commit hash.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e8c5426ad83d0b545514159e4a0d41e4bf497fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->