### PR TITLE
[HfApi] Return typed UserInfo object in whoami (#1902)

### DIFF
--- a/docs/source/en/package_reference/hf_api.md
+++ b/docs/source/en/package_reference/hf_api.md
@@ -57,6 +57,10 @@ models = hf_api.list_models()
 
 [[autodoc]] huggingface_hub.hf_api.DatasetLeaderboardEntry
 
+### EntityInfo
+
+[[autodoc]] huggingface_hub.hf_api.EntityInfo
+
 ### EvalResultEntry
 
 [[autodoc]] huggingface_hub.hf_api.EvalResultEntry
@@ -145,9 +149,17 @@ models = hf_api.list_models()
 
 [[autodoc]] huggingface_hub.hf_api.User
 
+### UserInfo
+
+[[autodoc]] huggingface_hub.hf_api.UserInfo
+
 ### UserLikes
 
 [[autodoc]] huggingface_hub.hf_api.UserLikes
+
+### UserOrgInfo
+
+[[autodoc]] huggingface_hub.hf_api.UserOrgInfo
 
 ### WebhookInfo
 

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -193,6 +193,7 @@ _SUBMOD_ATTRS = {
         "CommitOperationDelete",
         "DatasetInfo",
         "DatasetLeaderboardEntry",
+        "EntityInfo",
         "GitCommitInfo",
         "GitRefInfo",
         "GitRefs",
@@ -208,7 +209,9 @@ _SUBMOD_ATTRS = {
         "SpaceSearchResult",
         "SpaceTemplate",
         "User",
+        "UserInfo",
         "UserLikes",
+        "UserOrgInfo",
         "WebhookInfo",
         "WebhookWatchedItem",
         "accept_access_request",
@@ -734,6 +737,7 @@ __all__ = [
     "DocumentQuestionAnsweringOutputElement",
     "DocumentQuestionAnsweringParameters",
     "DryRunFileInfo",
+    "EntityInfo",
     "EvalResult",
     "EvalResultEntry",
     "FLAX_WEIGHTS_NAME",
@@ -908,7 +912,9 @@ __all__ = [
     "TranslationTruncationStrategy",
     "TypeEnum",
     "User",
+    "UserInfo",
     "UserLikes",
+    "UserOrgInfo",
     "VideoClassificationInput",
     "VideoClassificationOutputElement",
     "VideoClassificationOutputTransform",
@@ -1393,6 +1399,7 @@ if TYPE_CHECKING:  # pragma: no cover
         CommitOperationDelete,  # noqa: F401
         DatasetInfo,  # noqa: F401
         DatasetLeaderboardEntry,  # noqa: F401
+        EntityInfo,  # noqa: F401
         GitCommitInfo,  # noqa: F401
         GitRefInfo,  # noqa: F401
         GitRefs,  # noqa: F401
@@ -1408,7 +1415,9 @@ if TYPE_CHECKING:  # pragma: no cover
         SpaceSearchResult,  # noqa: F401
         SpaceTemplate,  # noqa: F401
         User,  # noqa: F401
+        UserInfo,  # noqa: F401
         UserLikes,  # noqa: F401
+        UserOrgInfo,  # noqa: F401
         WebhookInfo,  # noqa: F401
         WebhookWatchedItem,  # noqa: F401
         accept_access_request,  # noqa: F401

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -21,7 +21,7 @@ import struct
 import time
 import warnings
 from collections import defaultdict
-from collections.abc import Callable, Iterable, Iterator
+from collections.abc import Callable, Iterable, Iterator, Mapping
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
@@ -502,6 +502,528 @@ class SafeTensorsInfo(dict):
 
     def __post_init__(self):  # hack to make SafeTensorsInfo backward compatible
         self.update(asdict(self))
+
+
+T_EntityInfo = TypeVar("T_EntityInfo", bound="EntityInfo")
+_SENTINEL = object()
+
+
+@dataclass(eq=False)
+class EntityInfo(dict):
+    """
+    Base data structure containing information about a user or an organization on the Hub.
+
+    Inherits from `dict` for backward compatibility.
+
+    Attributes:
+        type (`str`):
+            Entity type (e.g. `"user"` or `"org"`).
+        id (`str`):
+            Entity ID.
+        name (`str`):
+            Username or organization name on the Hub.
+        fullname (`str`):
+            Full name of the user or organization.
+        email (`str`, *optional*):
+            Email address associated with the entity, if available.
+        can_pay (`bool`, *optional*):
+            Whether the entity has payment capabilities configured.
+        avatar_url (`str`):
+            URL of the entity's avatar image.
+    """
+
+    type: str = "user"
+    id: str = ""
+    name: str = ""
+    fullname: str = ""
+    email: str | None = None
+    can_pay: bool | None = None
+    avatar_url: str = ""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__()
+        data: dict[str, Any] = {}
+        if len(args) == 1:
+            if isinstance(args[0], (dict, Mapping)):
+                data.update(args[0])
+            elif hasattr(args[0], "items"):
+                data.update(dict(args[0]))
+            else:
+                try:
+                    data.update(dict(args[0]))
+                except (TypeError, ValueError):
+                    data["type"] = args[0]
+        elif args:
+            field_names = ("type", "id", "name", "fullname", "email", "can_pay", "avatar_url")
+            data.update(dict(zip(field_names, args)))
+        data.update(kwargs)
+
+        self.type = str(data.get("type", "user"))
+        self.id = str(data.get("id", ""))
+        self.name = str(data.get("name", ""))
+        self.fullname = str(data.get("fullname", ""))
+        self.email = data.get("email")
+
+        if "can_pay" in data:
+            self.can_pay = data["can_pay"]
+        elif "canPay" in data:
+            self.can_pay = data["canPay"]
+        else:
+            self.can_pay = None
+
+        if "avatar_url" in data:
+            self.avatar_url = str(data["avatar_url"])
+        elif "avatarUrl" in data:
+            self.avatar_url = str(data["avatarUrl"])
+        else:
+            self.avatar_url = ""
+
+        # Store all original raw_data in dict for full backward compatibility
+        super().update(data)
+
+        # Ensure canonical snake_case and camelCase keys are both present in dict
+        self["type"] = self.type
+        self["id"] = self.id
+        self["name"] = self.name
+        self["fullname"] = self.fullname
+        self["email"] = self.email
+        self["can_pay"] = self.can_pay
+        self["canPay"] = self.can_pay
+        self["avatar_url"] = self.avatar_url
+        self["avatarUrl"] = self.avatar_url
+
+    def copy(self: T_EntityInfo) -> T_EntityInfo:
+        """Return a shallow copy of the object preserving its type."""
+        import copy
+
+        return copy.copy(self)
+
+    def update(self, *args: Any, **kwargs: Any) -> None:
+        """Update dict entries and synchronize corresponding dataclass attributes."""
+        for k, v in dict(*args, **kwargs).items():
+            self[k] = v
+
+    def setdefault(self, key: Any, default: Any = None) -> Any:
+        """Insert key with a value of default if key is not in the dictionary, synchronizing attributes."""
+        if key in self:
+            return self[key]
+        self[key] = default
+        return default
+
+    @overload
+    def pop(self, key: Any, /) -> Any: ...
+
+    @overload
+    def pop(self, key: Any, default: Any, /) -> Any: ...
+
+    def pop(self, key: Any, /, default: Any = _SENTINEL) -> Any:
+        """Remove specified key and synchronize corresponding dataclass attributes."""
+        if key in self:
+            val = self[key]
+            del self[key]
+            return val
+        if default is not _SENTINEL:
+            return default
+        raise KeyError(key)
+
+    def popitem(self) -> tuple[str, Any]:
+        """Remove and return a (key, value) pair, synchronizing attributes."""
+        if not self:
+            raise KeyError("popitem(): dictionary is empty")
+        key = next(reversed(self))
+        val = self.pop(key)
+        return key, val
+
+    def clear(self) -> None:
+        """Remove all items from dict and reset attributes to defaults."""
+        super().clear()
+        object.__setattr__(self, "type", "")
+        object.__setattr__(self, "id", "")
+        object.__setattr__(self, "name", "")
+        object.__setattr__(self, "fullname", "")
+        object.__setattr__(self, "email", None)
+        object.__setattr__(self, "can_pay", None)
+        object.__setattr__(self, "avatar_url", "")
+
+    def __delitem__(self, key: str) -> None:
+        if key not in self:
+            raise KeyError(key)
+        dict.pop(self, key, None)
+        if key in ("avatarUrl", "avatar_url"):
+            self.avatar_url = ""
+            dict.pop(self, "avatarUrl", None)
+            dict.pop(self, "avatar_url", None)
+        elif key in ("canPay", "can_pay"):
+            self.can_pay = None
+            dict.pop(self, "canPay", None)
+            dict.pop(self, "can_pay", None)
+        elif key == "name":
+            self.name = ""
+        elif key == "fullname":
+            self.fullname = ""
+        elif key == "email":
+            self.email = None
+        elif key == "id":
+            self.id = ""
+        elif key == "type":
+            self.type = ""
+
+    def __delattr__(self, name: str) -> None:
+        if name in ("avatar_url", "avatarUrl"):
+            if "avatar_url" in self or "avatarUrl" in self:
+                del self["avatar_url"]
+            else:
+                self.avatar_url = ""
+        elif name in ("can_pay", "canPay"):
+            if "can_pay" in self or "canPay" in self:
+                del self["can_pay"]
+            else:
+                self.can_pay = None
+        elif name in self:
+            del self[name]
+        else:
+            try:
+                super().__delattr__(name)
+            except AttributeError:
+                pass
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        dict.__setitem__(self, key, value)
+        if key in ("avatarUrl", "avatar_url"):
+            self.avatar_url = value
+            dict.__setitem__(self, "avatarUrl", value)
+            dict.__setitem__(self, "avatar_url", value)
+        elif key in ("canPay", "can_pay"):
+            self.can_pay = value
+            dict.__setitem__(self, "canPay", value)
+            dict.__setitem__(self, "can_pay", value)
+        elif key == "name":
+            self.name = value
+        elif key == "fullname":
+            self.fullname = value
+        elif key == "email":
+            self.email = value
+        elif key == "id":
+            self.id = value
+        elif key == "type":
+            self.type = value
+
+    def __setattr__(self, key: str, value: Any) -> None:
+        super().__setattr__(key, value)
+        if key == "avatar_url":
+            dict.__setitem__(self, "avatar_url", value)
+            dict.__setitem__(self, "avatarUrl", value)
+        elif key == "can_pay":
+            dict.__setitem__(self, "can_pay", value)
+            dict.__setitem__(self, "canPay", value)
+        elif key in ("name", "fullname", "email", "id", "type"):
+            dict.__setitem__(self, key, value)
+
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, EntityInfo) and type(self) is not type(other):
+            return False
+        if isinstance(other, dict):
+            return dict.__eq__(self, other)
+        return False
+
+    @property
+    def avatarUrl(self) -> str:
+        return self.avatar_url
+
+    @avatarUrl.setter
+    def avatarUrl(self, value: str) -> None:
+        self.avatar_url = value
+
+    @avatarUrl.deleter
+    def avatarUrl(self) -> None:
+        del self["avatarUrl"]
+
+    @property
+    def canPay(self) -> bool | None:
+        return self.can_pay
+
+    @canPay.setter
+    def canPay(self, value: bool | None) -> None:
+        self.can_pay = value
+
+    @canPay.deleter
+    def canPay(self) -> None:
+        del self["canPay"]
+
+
+@dataclass(eq=False)
+class UserOrgInfo(EntityInfo):
+    """
+    Data structure containing information about an organization on the Hub.
+
+    Inherits from [`EntityInfo`] and `dict` for backward compatibility.
+
+    Attributes:
+        role_in_org (`str`, *optional*):
+            User's role in the organization (e.g. `"admin"`, `"write"`, `"read"`), if applicable.
+        is_enterprise (`bool`):
+            Whether the organization is an enterprise organization.
+    """
+
+    type: str = "org"
+    role_in_org: str | None = None
+    is_enterprise: bool = False
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        data: dict[str, Any] = {}
+        if len(args) == 1:
+            if isinstance(args[0], (dict, Mapping)):
+                data.update(args[0])
+            elif hasattr(args[0], "items"):
+                data.update(dict(args[0]))
+            else:
+                try:
+                    data.update(dict(args[0]))
+                except (TypeError, ValueError):
+                    data["type"] = args[0]
+        elif args:
+            field_names = (
+                "type",
+                "id",
+                "name",
+                "fullname",
+                "email",
+                "can_pay",
+                "avatar_url",
+                "role_in_org",
+                "is_enterprise",
+            )
+            data.update(dict(zip(field_names, args)))
+        data.update(kwargs)
+
+        if "type" not in data:
+            data["type"] = "org"
+
+        super().__init__(data)
+
+        if "role_in_org" in data:
+            self.role_in_org = data["role_in_org"]
+        elif "roleInOrg" in data:
+            self.role_in_org = data["roleInOrg"]
+        else:
+            self.role_in_org = None
+
+        if "is_enterprise" in data:
+            self.is_enterprise = bool(data["is_enterprise"])
+        elif "isEnterprise" in data:
+            self.is_enterprise = bool(data["isEnterprise"])
+        elif str(data.get("plan", "")).lower() == "enterprise":
+            self.is_enterprise = True
+        else:
+            self.is_enterprise = False
+
+        self["role_in_org"] = self.role_in_org
+        self["roleInOrg"] = self.role_in_org
+        self["is_enterprise"] = self.is_enterprise
+        self["isEnterprise"] = self.is_enterprise
+
+    def clear(self) -> None:
+        super().clear()
+        object.__setattr__(self, "type", "org")
+        object.__setattr__(self, "role_in_org", None)
+        object.__setattr__(self, "is_enterprise", False)
+
+    def __delitem__(self, key: str) -> None:
+        super().__delitem__(key)
+        if key in ("roleInOrg", "role_in_org"):
+            self.role_in_org = None
+            dict.pop(self, "roleInOrg", None)
+            dict.pop(self, "role_in_org", None)
+        elif key in ("isEnterprise", "is_enterprise"):
+            self.is_enterprise = False
+            dict.pop(self, "isEnterprise", None)
+            dict.pop(self, "is_enterprise", None)
+
+    def __delattr__(self, name: str) -> None:
+        if name in ("role_in_org", "roleInOrg"):
+            if "role_in_org" in self or "roleInOrg" in self:
+                del self["role_in_org"]
+            else:
+                self.role_in_org = None
+        elif name in ("is_enterprise", "isEnterprise"):
+            if "is_enterprise" in self or "isEnterprise" in self:
+                del self["is_enterprise"]
+            else:
+                self.is_enterprise = False
+        else:
+            super().__delattr__(name)
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        super().__setitem__(key, value)
+        if key in ("roleInOrg", "role_in_org"):
+            self.role_in_org = value
+            dict.__setitem__(self, "roleInOrg", value)
+            dict.__setitem__(self, "role_in_org", value)
+        elif key in ("isEnterprise", "is_enterprise"):
+            self.is_enterprise = bool(value)
+            dict.__setitem__(self, "isEnterprise", self.is_enterprise)
+            dict.__setitem__(self, "is_enterprise", self.is_enterprise)
+
+    def __setattr__(self, key: str, value: Any) -> None:
+        super().__setattr__(key, value)
+        if key == "role_in_org":
+            dict.__setitem__(self, "role_in_org", value)
+            dict.__setitem__(self, "roleInOrg", value)
+        elif key == "is_enterprise":
+            dict.__setitem__(self, "is_enterprise", bool(value))
+            dict.__setitem__(self, "isEnterprise", bool(value))
+
+    @property
+    def roleInOrg(self) -> str | None:
+        return self.role_in_org
+
+    @roleInOrg.setter
+    def roleInOrg(self, value: str | None) -> None:
+        self.role_in_org = value
+
+    @roleInOrg.deleter
+    def roleInOrg(self) -> None:
+        del self["roleInOrg"]
+
+    @property
+    def isEnterprise(self) -> bool:
+        return self.is_enterprise
+
+    @isEnterprise.setter
+    def isEnterprise(self, value: bool) -> None:
+        self.is_enterprise = value
+
+    @isEnterprise.deleter
+    def isEnterprise(self) -> None:
+        del self["isEnterprise"]
+
+
+@dataclass(eq=False)
+class UserInfo(EntityInfo):
+    """
+    Data structure containing information about the currently authenticated user on the Hub.
+
+    Inherits from [`EntityInfo`] and `dict` for backward compatibility.
+
+    Attributes:
+        is_pro (`bool`, *optional*):
+            Whether the user has a Pro subscription.
+        orgs (`list[UserOrgInfo]`):
+            List of organizations the user belongs to.
+    """
+
+    type: str = "user"
+    is_pro: bool | None = None
+    orgs: list[UserOrgInfo] = field(default_factory=list)
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        data: dict[str, Any] = {}
+        if len(args) == 1:
+            if isinstance(args[0], (dict, Mapping)):
+                data.update(args[0])
+            elif hasattr(args[0], "items"):
+                data.update(dict(args[0]))
+            else:
+                try:
+                    data.update(dict(args[0]))
+                except (TypeError, ValueError):
+                    data["type"] = args[0]
+        elif args:
+            field_names = ("type", "id", "name", "fullname", "email", "can_pay", "avatar_url", "is_pro", "orgs")
+            data.update(dict(zip(field_names, args)))
+        data.update(kwargs)
+
+        if "type" not in data:
+            data["type"] = "user"
+
+        super().__init__(data)
+
+        if "is_pro" in data:
+            self.is_pro = data["is_pro"]
+        elif "isPro" in data:
+            self.is_pro = data["isPro"]
+        else:
+            self.is_pro = None
+
+        raw_orgs = data.get("orgs")
+        if raw_orgs is None:
+            self.orgs = []
+        else:
+            self.orgs = [org if isinstance(org, UserOrgInfo) else UserOrgInfo(org) for org in raw_orgs]
+
+        self["is_pro"] = self.is_pro
+        self["isPro"] = self.is_pro
+        self["orgs"] = self.orgs
+
+    def clear(self) -> None:
+        super().clear()
+        object.__setattr__(self, "is_pro", None)
+        object.__setattr__(self, "orgs", [])
+
+    def __delitem__(self, key: str) -> None:
+        super().__delitem__(key)
+        if key in ("isPro", "is_pro"):
+            self.is_pro = None
+            dict.pop(self, "isPro", None)
+            dict.pop(self, "is_pro", None)
+        elif key == "orgs":
+            self.orgs = []
+            dict.pop(self, "orgs", None)
+
+    def __delattr__(self, name: str) -> None:
+        if name in ("is_pro", "isPro"):
+            if "is_pro" in self or "isPro" in self:
+                del self["is_pro"]
+            else:
+                self.is_pro = None
+        elif name == "orgs":
+            if "orgs" in self:
+                del self["orgs"]
+            else:
+                self.orgs = []
+        else:
+            super().__delattr__(name)
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        super().__setitem__(key, value)
+        if key in ("isPro", "is_pro"):
+            self.is_pro = value
+            dict.__setitem__(self, "isPro", value)
+            dict.__setitem__(self, "is_pro", value)
+        elif key == "orgs":
+            converted = (
+                [org if isinstance(org, UserOrgInfo) else UserOrgInfo(org) for org in value]
+                if value is not None
+                else []
+            )
+            self.orgs = converted
+            dict.__setitem__(self, "orgs", self.orgs)
+
+    def __setattr__(self, key: str, value: Any) -> None:
+        if key == "orgs":
+            value = (
+                [org if isinstance(org, UserOrgInfo) else UserOrgInfo(org) for org in value]
+                if value is not None
+                else []
+            )
+        super().__setattr__(key, value)
+        if key == "is_pro":
+            dict.__setitem__(self, "is_pro", value)
+            dict.__setitem__(self, "isPro", value)
+        elif key == "orgs":
+            dict.__setitem__(self, "orgs", value)
+
+    @property
+    def isPro(self) -> bool | None:
+        return self.is_pro
+
+    @isPro.setter
+    def isPro(self, value: bool | None) -> None:
+        self.is_pro = value
+
+    @isPro.deleter
+    def isPro(self) -> None:
+        del self["isPro"]
 
 
 @dataclass
@@ -2284,7 +2806,7 @@ class HfApi:
         self._thread_pool: ThreadPoolExecutor | None = None
 
         # /whoami-v2 is the only endpoint for which we may want to cache results
-        self._whoami_cache: dict[str, dict] = {}
+        self._whoami_cache: dict[str, UserInfo | UserOrgInfo] = {}
 
     def run_as_future(self, fn: Callable[..., R], *args, **kwargs) -> Future[R]:
         """
@@ -2327,7 +2849,7 @@ class HfApi:
         return self._thread_pool.submit(fn, *args, **kwargs)
 
     @validate_hf_hub_args
-    def whoami(self, token: bool | str | None = None, *, cache: bool = False) -> dict:
+    def whoami(self, token: bool | str | None = None, *, cache: bool = False) -> UserInfo | UserOrgInfo:
         """
         Call HF API to know "whoami".
 
@@ -2344,6 +2866,10 @@ class HfApi:
                 Whether to cache the result of the `whoami` call for subsequent calls.
                 If an error occurs during the first call, it won't be cached.
                 Defaults to `False`.
+
+        Returns:
+            [`UserInfo`] or [`UserOrgInfo`]:
+                Information about the user or organization corresponding to the token.
         """
         # Get the effective token using the helper function get_token
         token = self.token if token is None else token
@@ -2368,7 +2894,7 @@ class HfApi:
             self._whoami_cache[token] = output
         return output
 
-    def _inner_whoami(self, token: str) -> dict:
+    def _inner_whoami(self, token: str) -> UserInfo | UserOrgInfo:
         r = get_session().get(
             f"{self.endpoint}/api/whoami-v2",
             headers=self._build_hf_headers(token=token),
@@ -2398,7 +2924,10 @@ class HfApi:
                 )
                 raise HfHubHTTPError(error_message, response=e.response) from e
             raise
-        return r.json()
+        data = r.json()
+        if data.get("type") == "org":
+            return UserOrgInfo(**data)
+        return UserInfo(**data)
 
     def get_model_tags(self) -> dict:
         """

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,7 +14,7 @@ import httpx
 import pytest
 from click.testing import CliRunner
 
-from huggingface_hub import HfApi, InferenceEndpointHardware, constants
+from huggingface_hub import HfApi, InferenceEndpointHardware, UserInfo, constants
 from huggingface_hub._dataset_viewer import DatasetParquetEntry
 from huggingface_hub._jobs_api import JobInfo, JobOwner, _create_job_spec, _derive_job_volume_name
 from huggingface_hub._space_api import Volume
@@ -2039,6 +2039,28 @@ class TestAuthWhoamiCommand:
             result = runner.invoke(app, ["auth", "whoami", "--format", "json"])
         assert result.exit_code == 1
         assert "Not logged in" in result.output
+
+    def test_whoami_with_user_info_object(self, runner: CliRunner) -> None:
+        user_info = UserInfo(**self.MOCK_WHOAMI)
+        with (
+            patch("huggingface_hub.cli.auth.get_token", return_value="fake-token"),
+            patch("huggingface_hub.cli.auth.whoami", return_value=user_info),
+        ):
+            result = runner.invoke(app, ["auth", "whoami"])
+        assert result.exit_code == 0
+        assert "testuser" in result.stdout
+        assert "org1" in result.stdout
+        assert "org2" in result.stdout
+
+        with (
+            patch("huggingface_hub.cli.auth.get_token", return_value="fake-token"),
+            patch("huggingface_hub.cli.auth.whoami", return_value=user_info),
+        ):
+            result = runner.invoke(app, ["auth", "whoami", "--format", "json"])
+        assert result.exit_code == 0
+        parsed = json.loads(result.stdout)
+        assert parsed["user"] == "testuser"
+        assert parsed["orgs"] == "org1,org2"
 
 
 class TestAuthTokenCommand:

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import copy
 import datetime
+import json
 import os
 import re
 import subprocess
@@ -57,6 +58,7 @@ from huggingface_hub.hf_api import (
     CommitInfo,
     DatasetInfo,
     DatasetLeaderboardEntry,
+    EntityInfo,
     ExpandDatasetProperty_T,
     ExpandModelProperty_T,
     ExpandSpaceProperty_T,
@@ -70,6 +72,8 @@ from huggingface_hub.hf_api import (
     SpaceRuntime,
     SpaceSearchResult,
     User,
+    UserInfo,
+    UserOrgInfo,
     WebhookInfo,
     WebhookWatchedItem,
     repo_type_and_id_from_hf_id,
@@ -167,6 +171,36 @@ class TestHfApiEndpoints:
         valid_org = [org for org in info["orgs"] if org["name"] == "valid_org_hub"][0]
         assert valid_org["fullname"] == "Dummy Hub Org"
 
+        # Assert UserInfo typed object behavior
+        assert isinstance(info, UserInfo)
+        assert isinstance(info, EntityInfo)
+        assert isinstance(info, dict)
+        assert info.name == USER
+        assert info.fullname == FULL_NAME
+        assert info.type == "user"
+        assert isinstance(info.avatar_url, str)
+        assert info.avatar_url == info["avatarUrl"]
+        assert info.avatarUrl == info.avatar_url
+        assert info.can_pay == info["canPay"]
+        assert info.canPay == info.can_pay
+        assert info.is_pro == info["isPro"]
+        assert info.isPro == info.is_pro
+        assert info.orgs == info["orgs"]
+
+        # Assert UserOrgInfo typed object behavior
+        assert isinstance(valid_org, UserOrgInfo)
+        assert isinstance(valid_org, EntityInfo)
+        assert isinstance(valid_org, dict)
+        assert valid_org.name == "valid_org_hub"
+        assert valid_org.fullname == "Dummy Hub Org"
+        assert valid_org.type == "org"
+        assert valid_org.avatar_url == valid_org["avatarUrl"]
+        assert valid_org.avatarUrl == valid_org.avatar_url
+        assert valid_org.role_in_org == valid_org["roleInOrg"]
+        assert valid_org.roleInOrg == valid_org.role_in_org
+        assert isinstance(valid_org.is_enterprise, bool)
+        assert valid_org.is_enterprise == valid_org["isEnterprise"]
+
     def test_whoami_with_implicit_token_from_login(self, api: HfApi, mocker) -> None:
         """Test using `whoami` after a `hf auth login`."""
         mocker.patch("huggingface_hub.hf_api.get_token", return_value=TOKEN)
@@ -222,6 +256,358 @@ class TestHfApiEndpoints:
 
         with pytest.raises(ValueError):
             HfApi(token=False).whoami()
+
+    def test_whoami_typed_object_user(self) -> None:
+        """Test UserInfo object with attribute access, dict key access, org conversion, and serialization."""
+        raw_data = {
+            "type": "user",
+            "id": "u123",
+            "name": "test-user",
+            "fullname": "Test User",
+            "email": "test@example.com",
+            "canPay": True,
+            "isPro": False,
+            "avatarUrl": "https://example.com/avatar.png",
+            "billingMode": "postpaid",
+            "orgs": [
+                {
+                    "type": "org",
+                    "id": "o123",
+                    "name": "test-org",
+                    "fullname": "Test Org",
+                    "avatarUrl": "https://example.com/org.png",
+                    "roleInOrg": "admin",
+                    "plan": "enterprise",
+                }
+            ],
+            "auth": {"type": "access_token"},
+        }
+        user = UserInfo(**raw_data)
+
+        # Class inheritance & isinstance dict check
+        assert isinstance(user, UserInfo)
+        assert isinstance(user, EntityInfo)
+        assert isinstance(user, dict)
+
+        # Snake_case attribute access
+        assert user.type == "user"
+        assert user.id == "u123"
+        assert user.name == "test-user"
+        assert user.fullname == "Test User"
+        assert user.email == "test@example.com"
+        assert user.can_pay is True
+        assert user.is_pro is False
+        assert user.avatar_url == "https://example.com/avatar.png"
+        assert len(user.orgs) == 1
+
+        # CamelCase attribute property access
+        assert user.canPay is True
+        assert user.isPro is False
+        assert user.avatarUrl == "https://example.com/avatar.png"
+
+        # Dict key indexing (both camelCase and snake_case)
+        assert user["name"] == "test-user"
+        assert user["fullname"] == "Test User"
+        assert user["avatarUrl"] == "https://example.com/avatar.png"
+        assert user["avatar_url"] == "https://example.com/avatar.png"
+        assert user["canPay"] is True
+        assert user["can_pay"] is True
+        assert user["isPro"] is False
+        assert user["is_pro"] is False
+        assert user["billingMode"] == "postpaid"
+        assert user["auth"] == {"type": "access_token"}
+
+        # Org list conversion to UserOrgInfo
+        org = user.orgs[0]
+        assert isinstance(org, UserOrgInfo)
+        assert isinstance(org, EntityInfo)
+        assert isinstance(org, dict)
+        assert org.type == "org"
+        assert org.name == "test-org"
+        assert org.fullname == "Test Org"
+        assert org.avatar_url == "https://example.com/org.png"
+        assert org.avatarUrl == "https://example.com/org.png"
+        assert org.role_in_org == "admin"
+        assert org.roleInOrg == "admin"
+        assert org.is_enterprise is True
+        assert org.isEnterprise is True
+        assert org["roleInOrg"] == "admin"
+        assert org["role_in_org"] == "admin"
+        assert org["avatarUrl"] == "https://example.com/org.png"
+        assert org["avatar_url"] == "https://example.com/org.png"
+        assert user["orgs"][0]["name"] == "test-org"
+        assert user["orgs"][0].name == "test-org"
+
+        # JSON serialization
+        serialized = json.dumps(user)
+        deserialized = json.loads(serialized)
+        assert deserialized["name"] == "test-user"
+        assert deserialized["avatarUrl"] == "https://example.com/avatar.png"
+        assert deserialized["orgs"][0]["name"] == "test-org"
+        assert deserialized["orgs"][0]["roleInOrg"] == "admin"
+
+        # Dataclass asdict
+        dc_dict = fields(user)
+        assert [f.name for f in dc_dict] == [
+            "type",
+            "id",
+            "name",
+            "fullname",
+            "email",
+            "can_pay",
+            "avatar_url",
+            "is_pro",
+            "orgs",
+        ]
+
+        # Mutation synchronization
+        user.name = "renamed-user"
+        assert user["name"] == "renamed-user"
+        user["name"] = "dict-renamed-user"
+        assert user.name == "dict-renamed-user"
+
+        user.avatar_url = "https://example.com/new_avatar.png"
+        assert user["avatarUrl"] == "https://example.com/new_avatar.png"
+        assert user["avatar_url"] == "https://example.com/new_avatar.png"
+        user["avatarUrl"] = "https://example.com/newer_avatar.png"
+        assert user.avatar_url == "https://example.com/newer_avatar.png"
+        assert user["avatar_url"] == "https://example.com/newer_avatar.png"
+
+    def test_whoami_typed_object_org_token(self, api: HfApi) -> None:
+        """Test whoami returning UserOrgInfo when authenticated with an org token."""
+        org_payload = {
+            "type": "org",
+            "id": "org_uuid_1",
+            "name": "cool-org",
+            "fullname": "Cool Org Inc.",
+            "avatarUrl": "https://example.com/logo.png",
+            "canPay": True,
+            "plan": "enterprise",
+        }
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = org_payload
+
+        with patch("huggingface_hub.hf_api.get_session") as mock_get_session:
+            mock_client = Mock()
+            mock_client.get.return_value = mock_response
+            mock_get_session.return_value = mock_client
+
+            result = api.whoami(token="hf_mock_org_token")
+
+        assert isinstance(result, UserOrgInfo)
+        assert isinstance(result, EntityInfo)
+        assert isinstance(result, dict)
+        assert not isinstance(result, UserInfo)
+
+        assert result.type == "org"
+        assert result.id == "org_uuid_1"
+        assert result.name == "cool-org"
+        assert result.fullname == "Cool Org Inc."
+        assert result.avatar_url == "https://example.com/logo.png"
+        assert result.avatarUrl == "https://example.com/logo.png"
+        assert result.can_pay is True
+        assert result.is_enterprise is True
+        assert result.role_in_org is None
+
+        assert result["type"] == "org"
+        assert result["name"] == "cool-org"
+        assert result["avatarUrl"] == "https://example.com/logo.png"
+        assert result["isEnterprise"] is True
+
+        # JSON serialization
+        json_output = json.dumps(result)
+        assert "cool-org" in json_output
+
+    def test_whoami_dict_backward_compatibility(self) -> None:
+        """Test backward compatibility of dict methods, copy, and mutation synchronization."""
+        data = {
+            "type": "user",
+            "id": "u456",
+            "name": "compat-user",
+            "fullname": "Compat User",
+            "avatarUrl": "https://example.com/avatar.png",
+            "isPro": True,
+            "canPay": False,
+            "orgs": [],
+        }
+        # Test positional dict initialization (standard dict pattern: UserInfo(data))
+        user_from_dict = UserInfo(data)
+        assert user_from_dict.name == "compat-user"
+        assert user_from_dict.avatar_url == "https://example.com/avatar.png"
+        assert user_from_dict.is_pro is True
+        assert user_from_dict["name"] == "compat-user"
+        assert user_from_dict["avatarUrl"] == "https://example.com/avatar.png"
+
+        org_from_dict = UserOrgInfo({"name": "dict-org", "plan": "enterprise"})
+        assert org_from_dict.name == "dict-org"
+        assert org_from_dict.is_enterprise is True
+        assert org_from_dict["isEnterprise"] is True
+
+        user = UserInfo(**data)
+
+        # Test dict constructor
+        plain_dict = dict(user)
+        assert isinstance(plain_dict, dict)
+        assert plain_dict["name"] == "compat-user"
+        assert plain_dict["avatarUrl"] == "https://example.com/avatar.png"
+        assert plain_dict["isPro"] is True
+
+        # Test user.copy() method returns typed UserInfo instance
+        user_shallow_copy = user.copy()
+        assert isinstance(user_shallow_copy, UserInfo)
+        assert user_shallow_copy.name == user.name
+        assert user_shallow_copy.avatar_url == user.avatar_url
+        assert user_shallow_copy["avatarUrl"] == user["avatarUrl"]
+
+        # Test copy.copy and copy.deepcopy
+        user_copy = copy.copy(user)
+        assert isinstance(user_copy, UserInfo)
+        assert user_copy.name == user.name
+        assert user_copy["avatarUrl"] == user["avatarUrl"]
+
+        user_deepcopy = copy.deepcopy(user)
+        assert isinstance(user_deepcopy, UserInfo)
+        assert user_deepcopy.name == user.name
+
+        # Membership and get
+        assert "avatarUrl" in user
+        assert "avatar_url" in user
+        assert "isPro" in user
+        assert "is_pro" in user
+        assert user.get("avatarUrl") == "https://example.com/avatar.png"
+        assert user.get("avatar_url") == "https://example.com/avatar.png"
+        assert user.get("isPro") is True
+        assert user.get("is_pro") is True
+        assert user.get("non_existent", "default") == "default"
+
+        # Test update() synchronization for both snake_case and camelCase
+        user.update({"name": "updated-user", "avatarUrl": "https://example.com/updated.png"})
+        assert user.name == "updated-user"
+        assert user["name"] == "updated-user"
+        assert user.avatar_url == "https://example.com/updated.png"
+        assert user.avatarUrl == "https://example.com/updated.png"
+        assert user["avatarUrl"] == "https://example.com/updated.png"
+        assert user["avatar_url"] == "https://example.com/updated.png"
+
+        # Test pop() synchronization
+        popped_avatar = user.pop("avatarUrl")
+        assert popped_avatar == "https://example.com/updated.png"
+        assert "avatarUrl" not in user
+        assert "avatar_url" not in user
+        assert user.avatar_url == ""
+
+        # Test pop() with default
+        assert user.pop("non_existent", "default_val") == "default_val"
+
+        # Test delitem synchronization
+        assert user.can_pay is False
+        del user["can_pay"]
+        assert "can_pay" not in user
+        assert "canPay" not in user
+        assert user.can_pay is None
+
+        # Test attribute assignment for orgs wrapping dict into UserOrgInfo
+        user.orgs = [{"name": "assigned-org", "roleInOrg": "write"}]
+        assert len(user.orgs) == 1
+        assert isinstance(user.orgs[0], UserOrgInfo)
+        assert user.orgs[0].name == "assigned-org"
+        assert user.orgs[0].role_in_org == "write"
+        assert user["orgs"][0]["name"] == "assigned-org"
+
+        # Test setdefault() synchronization
+        user.setdefault("avatarUrl", "https://example.com/setdefault.png")
+        assert user.avatar_url == "https://example.com/setdefault.png"
+        assert user["avatarUrl"] == "https://example.com/setdefault.png"
+        assert user["avatar_url"] == "https://example.com/setdefault.png"
+
+        # Test popitem() synchronization
+        popped_k, popped_v = user.popitem()
+        assert popped_k not in user
+        if popped_k in ("avatarUrl", "avatar_url"):
+            assert user.avatar_url == ""
+
+        # Test property deleters
+        user.isPro = True
+        assert user.is_pro is True
+        del user.isPro
+        assert "isPro" not in user
+        assert "is_pro" not in user
+        assert user.is_pro is None
+
+        user.canPay = True
+        assert user.can_pay is True
+        del user.canPay
+        assert "canPay" not in user
+        assert "can_pay" not in user
+        assert user.can_pay is None
+
+        user.avatarUrl = "https://example.com/del.png"
+        assert user.avatar_url == "https://example.com/del.png"
+        del user.avatarUrl
+        assert "avatarUrl" not in user
+        assert "avatar_url" not in user
+        assert user.avatar_url == ""
+
+        # Test delattr synchronization
+        user.is_pro = True
+        del user.is_pro
+        assert "is_pro" not in user
+        assert "isPro" not in user
+        assert user.is_pro is None
+
+        # Test UserOrgInfo property deleters and delattr
+        test_org = UserOrgInfo(name="del-org", roleInOrg="write", isEnterprise=True)
+        assert test_org.roleInOrg == "write"
+        del test_org.roleInOrg
+        assert test_org.role_in_org is None
+        assert "roleInOrg" not in test_org
+
+        assert test_org.isEnterprise is True
+        del test_org.isEnterprise
+        assert test_org.is_enterprise is False
+        assert "isEnterprise" not in test_org
+
+        # Test initialization from iterable of key-value tuples
+        tuple_user = UserInfo(
+            [("name", "tuple-user"), ("avatarUrl", "https://example.com/tuple.png"), ("isPro", True)]
+        )
+        assert tuple_user.name == "tuple-user"
+        assert tuple_user.avatar_url == "https://example.com/tuple.png"
+        assert tuple_user.is_pro is True
+        assert tuple_user["name"] == "tuple-user"
+
+        tuple_org = UserOrgInfo([("name", "tuple-org"), ("roleInOrg", "read"), ("plan", "ENTERPRISE")])
+        assert tuple_org.name == "tuple-org"
+        assert tuple_org.role_in_org == "read"
+        assert tuple_org.is_enterprise is True
+
+        # Test user.orgs = None normalization to []
+        tuple_user.orgs = None
+        assert tuple_user.orgs == []
+        assert tuple_user["orgs"] == []
+
+        # Test equality with extra dictionary fields and cross-type distinction
+        u1 = UserInfo(name="alice", extra_scope="read")
+        u2 = UserInfo(name="alice", extra_scope="read")
+        u3 = UserInfo(name="alice", extra_scope="write")
+        o1 = UserOrgInfo(name="alice")
+        assert u1 == u2
+        assert u1 != u3
+        assert u1 != o1
+
+        # Test clear()
+        user.clear()
+        assert len(user) == 0
+        assert user.name == ""
+        assert user.avatar_url == ""
+        assert user.orgs == []
+
+        test_org.clear()
+        assert len(test_org) == 0
+        assert test_org.type == "org"
+        assert test_org.role_in_org is None
+        assert test_org.is_enterprise is False
 
     def test_delete_repo_error_message(self, api: HfApi):
         # test for #751


### PR DESCRIPTION
## Summary

This PR addresses #1902 by introducing typed dataclass structures for the `whoami()` output: [`UserInfo`], [`UserOrgInfo`], and base [`EntityInfo`].

Following the design outlined by @Wauplin in #1902 and existing codebase patterns (such as `LastCommitInfo(dict)` and `BlobLfsInfo(dict)`):
- Instances inherit from `dict` for 100% backward compatibility with dictionary indexing (`user["avatarUrl"]`, `user["isPro"]`, `user["orgs"][0]["name"]`).
- Provide typed snake_case attribute access (`user.name`, `user.avatar_url`, `user.is_pro`, `user.can_pay`, `user.orgs`).
- Provide camelCase property aliases (`user.avatarUrl`, `user.isPro`, `user.canPay`) matching Hub API JSON conventions.
- Automatically wrap nested organization entries in `user.orgs` into typed `UserOrgInfo` objects.
- Correctly handle organization tokens (`data.get("type") == "org"`), returning a `UserOrgInfo` instance.
- Synchronize all dictionary mutation and lifecycle methods (`__setitem__`, `__delitem__`, `__setattr__`, `__delattr__`, `pop()`, `popitem()`, `setdefault()`, `clear()`, `update()`, `copy()`).
- Support flexible dictionary constructor inputs (mappings, keyword args, and iterables of key-value pairs).
- Export `EntityInfo`, `UserInfo`, and `UserOrgInfo` in `huggingface_hub` and register them in package autodocs.
- Include unit tests in `tests/test_hf_api.py` and CLI tests in `tests/test_cli.py`.

Closes #1902

### Usage

```python
from huggingface_hub import whoami

# Typed attribute access
user = whoami()
print(user.name)
print(user.avatar_url)
print(user.is_pro)
for org in user.orgs:
    print(org.name, org.role_in_org, org.is_enterprise)

# Backward-compatible dict indexing remains fully supported
assert user["name"] == user.name
assert user["avatarUrl"] == user.avatar_url
assert user["isPro"] == user.is_pro
```

### Verification Record

- `uv run pytest tests/test_hf_api.py -k "test_whoami"` -> 9 passed
- `uv run pytest tests/test_cli.py -k "test_whoami"` -> 6 passed
- `uv run pytest tests/test_auth.py` -> 39 passed
- `uv run --with ruff ruff check src tests` -> All checks passed
- `uv run --with ruff ruff format --check src tests` -> 278 files already formatted
- `uv run --with ty ty check src` -> All checks passed
- `uv run --with mypy==1.15.0 mypy src/huggingface_hub/__init__.py --follow-imports=silent` -> Success: no issues found
- `uv run --with mypy==1.15.0 mypy src/huggingface_hub/hf_api.py --follow-imports=silent` -> Success: no issues found
- `check_static_imports.py --update` & `check_all_variable.py --update` -> In sync
