### PR TITLE
Fix Windows pip self-update

### DIFF
--- a/src/huggingface_hub/cli/system.py
+++ b/src/huggingface_hub/cli/system.py
@@ -46,13 +46,15 @@ def update() -> None:
         out.text(f"hf is up to date ({__version__})")
         return
 
-    # A pip-installed `hf.exe` cannot replace itself while it is running on Windows. Letting pip
+    # A pip-installed `hf` launcher cannot replace itself while it is running on Windows. Letting pip
     # attempt the upgrade can fail after uninstalling the current package, leaving the CLI broken.
+    # Console-script launchers may expose argv[0] as either `hf` or `hf.exe`, depending on the wrapper.
     # `python -m huggingface_hub.cli.hf update` does not hold the launcher open and remains safe.
-    running_hf_exe = bool(sys.argv) and sys.argv[0].lower().endswith("hf.exe")
-    if sys.platform == "win32" and running_hf_exe and installation_method() == "pip":
+    entry_point = sys.argv[0].replace("\\", "/").rsplit("/", 1)[-1].lower() if sys.argv else ""
+    running_hf_launcher = entry_point in {"hf", "hf.exe"}
+    if sys.platform == "win32" and running_hf_launcher and installation_method() == "pip":
         command = subprocess.list2cmdline([sys.executable, "-m", "pip", "install", "-U", "huggingface_hub"])
-        out.warning("Cannot safely update a pip-installed `hf` CLI while `hf.exe` is running on Windows.")
+        out.warning("Cannot safely update a pip-installed `hf` CLI while the `hf` launcher is running on Windows.")
         out.hint(f"After this command exits, run: {command}")
         return
 

--- a/src/huggingface_hub/cli/system.py
+++ b/src/huggingface_hub/cli/system.py
@@ -53,10 +53,10 @@ def update() -> None:
     entry_point = sys.argv[0].replace("\\", "/").rsplit("/", 1)[-1].lower() if sys.argv else ""
     running_hf_launcher = entry_point in {"hf", "hf.exe"}
     if sys.platform == "win32" and running_hf_launcher and installation_method() == "pip":
-        command = subprocess.list2cmdline([sys.executable, "-m", "pip", "install", "-U", "huggingface_hub"])
+        command = subprocess.list2cmdline([sys.executable, "-m", "huggingface_hub.cli.hf", "update"])
         out.warning("Cannot safely update a pip-installed `hf` CLI while the `hf` launcher is running on Windows.")
         out.hint(f"After this command exits, run: {command}")
-        return
+        raise click.exceptions.Exit(code=1)
 
     # The standalone installer installs the `hf-cli` skill by default. If it's not installed at this
     # point, the user opted out (or removed it): tell the installer to leave it alone instead of

--- a/src/huggingface_hub/cli/system.py
+++ b/src/huggingface_hub/cli/system.py
@@ -46,6 +46,14 @@ def update() -> None:
         out.text(f"hf is up to date ({__version__})")
         return
 
+    # A pip-installed `hf.exe` cannot replace itself while it is running on Windows. Letting pip
+    # attempt the upgrade can fail after uninstalling the current package, leaving the CLI broken.
+    if sys.platform == "win32" and installation_method() == "pip":
+        command = subprocess.list2cmdline([sys.executable, "-m", "pip", "install", "-U", "huggingface_hub"])
+        out.warning("Cannot safely update a pip-installed `hf` CLI while `hf.exe` is running on Windows.")
+        out.hint(f"After this command exits, run: {command}")
+        return
+
     # The standalone installer installs the `hf-cli` skill by default. If it's not installed at this
     # point, the user opted out (or removed it): tell the installer to leave it alone instead of
     # silently undoing that choice.

--- a/src/huggingface_hub/cli/system.py
+++ b/src/huggingface_hub/cli/system.py
@@ -48,7 +48,9 @@ def update() -> None:
 
     # A pip-installed `hf.exe` cannot replace itself while it is running on Windows. Letting pip
     # attempt the upgrade can fail after uninstalling the current package, leaving the CLI broken.
-    if sys.platform == "win32" and installation_method() == "pip":
+    # `python -m huggingface_hub.cli.hf update` does not hold the launcher open and remains safe.
+    running_hf_exe = bool(sys.argv) and sys.argv[0].lower().endswith("hf.exe")
+    if sys.platform == "win32" and running_hf_exe and installation_method() == "pip":
         command = subprocess.list2cmdline([sys.executable, "-m", "pip", "install", "-U", "huggingface_hub"])
         out.warning("Cannot safely update a pip-installed `hf` CLI while `hf.exe` is running on Windows.")
         out.hint(f"After this command exits, run: {command}")

--- a/tests/test_cli_update_windows.py
+++ b/tests/test_cli_update_windows.py
@@ -16,15 +16,18 @@ import subprocess
 import sys
 from unittest.mock import patch
 
+import pytest
+
 from huggingface_hub.cli import system
 
 
-def test_windows_pip_hf_exe_update_is_deferred_until_hf_exits() -> None:
+@pytest.mark.parametrize("argv0", [r"C:\\venv\\Scripts\\hf.exe", r"C:\\venv\\Scripts\\hf"])
+def test_windows_pip_hf_launcher_update_is_deferred_until_hf_exits(argv0: str) -> None:
     expected_command = subprocess.list2cmdline([sys.executable, "-m", "pip", "install", "-U", "huggingface_hub"])
 
     with (
         patch("huggingface_hub.cli.system.sys.platform", "win32"),
-        patch("huggingface_hub.cli.system.sys.argv", [r"C:\\venv\\Scripts\\hf.exe", "update"]),
+        patch("huggingface_hub.cli.system.sys.argv", [argv0, "update"]),
         patch("huggingface_hub.cli.system.installation_method", return_value="pip"),
         patch("huggingface_hub.cli.system._fetch_latest_pypi_version", return_value="999.0.0"),
         patch("huggingface_hub.cli.system.run_update") as mock_run_update,
@@ -35,7 +38,7 @@ def test_windows_pip_hf_exe_update_is_deferred_until_hf_exits() -> None:
 
     mock_run_update.assert_not_called()
     mock_warning.assert_called_once_with(
-        "Cannot safely update a pip-installed `hf` CLI while `hf.exe` is running on Windows."
+        "Cannot safely update a pip-installed `hf` CLI while the `hf` launcher is running on Windows."
     )
     mock_hint.assert_called_once_with(f"After this command exits, run: {expected_command}")
 

--- a/tests/test_cli_update_windows.py
+++ b/tests/test_cli_update_windows.py
@@ -16,14 +16,17 @@ import subprocess
 import sys
 from unittest.mock import patch
 
+import click
 import pytest
 
 from huggingface_hub.cli import system
 
 
-@pytest.mark.parametrize("argv0", [r"C:\\venv\\Scripts\\hf.exe", r"C:\\venv\\Scripts\\hf"])
+@pytest.mark.parametrize("argv0", [r"C:\venv\Scripts\hf.exe", r"C:\venv\Scripts\hf"])
 def test_windows_pip_hf_launcher_update_is_deferred_until_hf_exits(argv0: str) -> None:
-    expected_command = subprocess.list2cmdline([sys.executable, "-m", "pip", "install", "-U", "huggingface_hub"])
+    expected_command = subprocess.list2cmdline(
+        [sys.executable, "-m", "huggingface_hub.cli.hf", "update"]
+    )
 
     with (
         patch("huggingface_hub.cli.system.sys.platform", "win32"),
@@ -34,8 +37,10 @@ def test_windows_pip_hf_launcher_update_is_deferred_until_hf_exits(argv0: str) -
         patch("huggingface_hub.cli.system.out.warning") as mock_warning,
         patch("huggingface_hub.cli.system.out.hint") as mock_hint,
     ):
-        system.update()
+        with pytest.raises(click.exceptions.Exit) as error:
+            system.update()
 
+    assert error.value.exit_code == 1
     mock_run_update.assert_not_called()
     mock_warning.assert_called_once_with(
         "Cannot safely update a pip-installed `hf` CLI while the `hf` launcher is running on Windows."
@@ -47,19 +52,6 @@ def test_windows_pip_module_update_still_runs_in_process() -> None:
     with (
         patch("huggingface_hub.cli.system.sys.platform", "win32"),
         patch("huggingface_hub.cli.system.sys.argv", ["huggingface_hub.cli.hf", "update"]),
-        patch("huggingface_hub.cli.system.installation_method", return_value="pip"),
-        patch("huggingface_hub.cli.system._fetch_latest_pypi_version", return_value="999.0.0"),
-        patch("huggingface_hub.cli.system._installed_hf_cli_dirs", return_value=[]),
-        patch("huggingface_hub.cli.system.run_update", return_value=0) as mock_run_update,
-    ):
-        system.update()
-
-    mock_run_update.assert_called_once_with(exclude_skill=True)
-
-
-def test_non_windows_pip_update_still_runs_in_process() -> None:
-    with (
-        patch("huggingface_hub.cli.system.sys.platform", "linux"),
         patch("huggingface_hub.cli.system.installation_method", return_value="pip"),
         patch("huggingface_hub.cli.system._fetch_latest_pypi_version", return_value="999.0.0"),
         patch("huggingface_hub.cli.system._installed_hf_cli_dirs", return_value=[]),

--- a/tests/test_cli_update_windows.py
+++ b/tests/test_cli_update_windows.py
@@ -24,9 +24,7 @@ from huggingface_hub.cli import system
 
 @pytest.mark.parametrize("argv0", [r"C:\venv\Scripts\hf.exe", r"C:\venv\Scripts\hf"])
 def test_windows_pip_hf_launcher_update_is_deferred_until_hf_exits(argv0: str) -> None:
-    expected_command = subprocess.list2cmdline(
-        [sys.executable, "-m", "huggingface_hub.cli.hf", "update"]
-    )
+    expected_command = subprocess.list2cmdline([sys.executable, "-m", "huggingface_hub.cli.hf", "update"])
 
     with (
         patch("huggingface_hub.cli.system.sys.platform", "win32"),

--- a/tests/test_cli_update_windows.py
+++ b/tests/test_cli_update_windows.py
@@ -1,0 +1,52 @@
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import subprocess
+import sys
+from unittest.mock import patch
+
+from huggingface_hub.cli import system
+
+
+def test_windows_pip_update_is_deferred_until_hf_exits() -> None:
+    expected_command = subprocess.list2cmdline([sys.executable, "-m", "pip", "install", "-U", "huggingface_hub"])
+
+    with (
+        patch("huggingface_hub.cli.system.sys.platform", "win32"),
+        patch("huggingface_hub.cli.system.installation_method", return_value="pip"),
+        patch("huggingface_hub.cli.system._fetch_latest_pypi_version", return_value="999.0.0"),
+        patch("huggingface_hub.cli.system.run_update") as mock_run_update,
+        patch("huggingface_hub.cli.system.out.warning") as mock_warning,
+        patch("huggingface_hub.cli.system.out.hint") as mock_hint,
+    ):
+        system.update()
+
+    mock_run_update.assert_not_called()
+    mock_warning.assert_called_once_with(
+        "Cannot safely update a pip-installed `hf` CLI while `hf.exe` is running on Windows."
+    )
+    mock_hint.assert_called_once_with(f"After this command exits, run: {expected_command}")
+
+
+def test_non_windows_pip_update_still_runs_in_process() -> None:
+    with (
+        patch("huggingface_hub.cli.system.sys.platform", "linux"),
+        patch("huggingface_hub.cli.system.installation_method", return_value="pip"),
+        patch("huggingface_hub.cli.system._fetch_latest_pypi_version", return_value="999.0.0"),
+        patch("huggingface_hub.cli.system._installed_hf_cli_dirs", return_value=[]),
+        patch("huggingface_hub.cli.system.run_update", return_value=0) as mock_run_update,
+    ):
+        system.update()
+
+    mock_run_update.assert_called_once_with(exclude_skill=True)

--- a/tests/test_cli_update_windows.py
+++ b/tests/test_cli_update_windows.py
@@ -19,11 +19,12 @@ from unittest.mock import patch
 from huggingface_hub.cli import system
 
 
-def test_windows_pip_update_is_deferred_until_hf_exits() -> None:
+def test_windows_pip_hf_exe_update_is_deferred_until_hf_exits() -> None:
     expected_command = subprocess.list2cmdline([sys.executable, "-m", "pip", "install", "-U", "huggingface_hub"])
 
     with (
         patch("huggingface_hub.cli.system.sys.platform", "win32"),
+        patch("huggingface_hub.cli.system.sys.argv", [r"C:\\venv\\Scripts\\hf.exe", "update"]),
         patch("huggingface_hub.cli.system.installation_method", return_value="pip"),
         patch("huggingface_hub.cli.system._fetch_latest_pypi_version", return_value="999.0.0"),
         patch("huggingface_hub.cli.system.run_update") as mock_run_update,
@@ -37,6 +38,20 @@ def test_windows_pip_update_is_deferred_until_hf_exits() -> None:
         "Cannot safely update a pip-installed `hf` CLI while `hf.exe` is running on Windows."
     )
     mock_hint.assert_called_once_with(f"After this command exits, run: {expected_command}")
+
+
+def test_windows_pip_module_update_still_runs_in_process() -> None:
+    with (
+        patch("huggingface_hub.cli.system.sys.platform", "win32"),
+        patch("huggingface_hub.cli.system.sys.argv", ["huggingface_hub.cli.hf", "update"]),
+        patch("huggingface_hub.cli.system.installation_method", return_value="pip"),
+        patch("huggingface_hub.cli.system._fetch_latest_pypi_version", return_value="999.0.0"),
+        patch("huggingface_hub.cli.system._installed_hf_cli_dirs", return_value=[]),
+        patch("huggingface_hub.cli.system.run_update", return_value=0) as mock_run_update,
+    ):
+        system.update()
+
+    mock_run_update.assert_called_once_with(exclude_skill=True)
 
 
 def test_non_windows_pip_update_still_runs_in_process() -> None:


### PR DESCRIPTION
## Summary

Prevent `hf update` from invoking pip inside a running pip-installed `hf` / `hf.exe` launcher on Windows.

A pip-installed launcher cannot safely replace itself while it is running. Pip can fail with `WinError 32` after uninstalling the current package, leaving the CLI broken. On Windows pip installs, launcher-based `hf update` now warns, points the user to the safe `python -m huggingface_hub.cli.hf update` path to run after the launcher exits, and exits with status 1 instead of reporting a false success.

The module invocation remains able to perform the normal upgrade flow, including the existing skill refresh behavior. Non-Windows pip installs and the existing Homebrew / standalone-installer paths keep their current behavior.

## Tests

- cover both Windows console-script forms (`hf` and `hf.exe`) and verify the deferred path does not call `run_update`
- verify the deferred path exits nonzero and points to the module-based update command
- verify `python -m huggingface_hub.cli.hf update` still follows the existing in-process update path on Windows

Fixes #4819

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to the CLI update command on Windows pip installs only; avoids a known self-update failure mode without altering auth or data paths.
> 
> **Overview**
> **`hf update`** on **Windows** with a **pip** install now **refuses** to run the in-process upgrade when the process was started from the **`hf` / `hf.exe`** console-script launcher, because pip can uninstall the package while the launcher is still open and leave the CLI broken.
> 
> In that case it **warns**, prints a hint to run **`python -m huggingface_hub.cli.hf update`** after the command exits, and **exits with code 1** without calling **`run_update`**. Invoking update via **`python -m`** (or non-launcher entry points) still follows the existing **`run_update`** path.
> 
> Regression tests cover deferred launcher updates for **`hf`** and **`hf.exe`**, and that module-style invocation on Windows pip still calls **`run_update`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit add4f8b96d7173b0731ed246c7a4005f6ab3c830. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->