### PR TITLE
[hf_api] Make CommitInfo copy-able and pickle-able

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -556,8 +556,19 @@ class CommitInfo(str):
     pr_revision: str | None = field(init=False)
     pr_num: int | None = field(init=False)
 
-    def __new__(cls, *args, commit_url: str, **kwargs):
+    def __new__(cls, commit_url: str, *args, **kwargs):
         return str.__new__(cls, commit_url)
+
+    def __reduce__(self):
+        # without this, pickle/copy rebuild the instance from its string value only, losing the attributes
+        return self.__class__, (
+            self.commit_url,
+            self.commit_message,
+            self.commit_description,
+            self.oid,
+            self._endpoint,
+            self.pr_url,
+        )
 
     def __post_init__(self):
         """Populate pr-related fields after initialization.


### PR DESCRIPTION
Fixes #4821.

`CommitInfo.__new__` took `commit_url` as a required *keyword-only* argument. When `copy` or `pickle` rebuild a `str` subclass they call `cls.__new__(cls, *self.__getnewargs__())`, and `str.__getnewargs__` only returns the positional string value — so `commit_url` was never passed and reconstruction blew up with a `TypeError`. Making `commit_url` a regular (positional-or-keyword) parameter fixes that, and a `__reduce__` makes sure the other fields survive the round-trip instead of being silently dropped, the same way [`ResolvedRevision`](https://github.com/huggingface/huggingface_hub/pull/4692) already does. Since the dataclass `__init__` runs again on reconstruction, `repo_url`, `pr_revision` and `pr_num` are recomputed from `__post_init__` as usual.

As suggested in the issue, I checked the two other non-Enum `str` subclasses in the library, `RepoUrl` and `ResolvedRevision`: both already round-trip fine through `copy.copy`, `copy.deepcopy` and `pickle` (`RepoUrl` because its `__new__` takes the url positionally and its attributes live in `__dict__`, which pickle restores; `ResolvedRevision` because it got a `__reduce__` in #4692). So this PR only touches `CommitInfo`.

Before / after on the issue's repro (plus positional construction, which was broken as well):

```
                    before                  after
CommitInfo copy     TypeError               ok, all fields preserved
CommitInfo deepcopy TypeError               ok, all fields preserved
CommitInfo pickle   TypeError               ok, all fields preserved
RepoUrl    (all 3)  ok                      ok
ResolvedRevision    ok                      ok
```

```py
>>> import copy
>>> info = CommitInfo(commit_url="https://huggingface.co/u/r/commit/abc", commit_message="m", commit_description="d", oid="abc", pr_url="https://huggingface.co/u/r/discussions/3")
>>> c = copy.deepcopy(info)
>>> c == info, c.oid, c.repo_url.repo_id, c.pr_revision, c.pr_num
(True, 'abc', 'u/r', 'refs/pr/3', 3)
```

No new unit test (not requested), but the repro from the issue and a `_endpoint`-populated variant were both checked locally, and `make quality` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to `CommitInfo` serialization; existing keyword construction remains valid and behavior is unchanged except for copy/pickle support.
> 
> **Overview**
> **`CommitInfo`** (a `str` subclass returned from Hub commit APIs) could not be reconstructed by `copy`, `deepcopy`, or `pickle` because **`__new__`** required **`commit_url`** as keyword-only while the stdlib rebuild path passes only the string value positionally.
> 
> This PR makes **`commit_url`** the first positional parameter in **`__new__`** and adds **`__reduce__`** so round-trips preserve **`commit_message`**, **`oid`**, **`pr_url`**, and related fields (mirroring **`ResolvedRevision`**). Derived fields such as **`repo_url`**, **`pr_revision`**, and **`pr_num`** still come from **`__post_init__`** on rebuild.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc4b1311c82f7f4ce96bcc4f4249c2375d9a2749. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->