### PR TITLE
[CLI] Don't let `hf update` self-upgrade a pip install on Windows

### DIFF
--- a/src/huggingface_hub/cli/system.py
+++ b/src/huggingface_hub/cli/system.py
@@ -20,6 +20,7 @@ import sys
 import click
 
 from huggingface_hub import __version__, constants
+from huggingface_hub.errors import CLIError
 
 from ..utils import dump_environment_info, installation_method
 from ._cli_utils import _fetch_latest_pypi_version, run_update
@@ -45,6 +46,17 @@ def update() -> None:
     if latest_version is not None and __version__ == latest_version:
         out.text(f"hf is up to date ({__version__})")
         return
+
+    # Windows refuses to replace the `hf.exe` launcher of a running process: pip would fail with a
+    # "file in use" error (WinError 32) *after* having uninstalled the current version, leaving a dead
+    # `hf.exe` and no `huggingface_hub` module behind. Print the command instead of running it, the same
+    # way pip refuses to upgrade itself on Windows.
+    if sys.platform == "win32" and installation_method() == "pip":
+        command = subprocess.list2cmdline([sys.executable, "-m", "pip", "install", "-U", "huggingface_hub"])
+        raise CLIError(
+            "On Windows, a pip-installed `hf` cannot update itself: pip is not allowed to replace `hf.exe` while it "
+            f"is running. Run this command instead:\n    {command}"
+        )
 
     # The standalone installer installs the `hf-cli` skill by default. If it's not installed at this
     # point, the user opted out (or removed it): tell the installer to leave it alone instead of

--- a/src/huggingface_hub/cli/system.py
+++ b/src/huggingface_hub/cli/system.py
@@ -20,7 +20,6 @@ import sys
 import click
 
 from huggingface_hub import __version__, constants
-from huggingface_hub.errors import CLIError
 
 from ..utils import dump_environment_info, installation_method
 from ._cli_utils import _fetch_latest_pypi_version, run_update
@@ -53,10 +52,11 @@ def update() -> None:
     # way pip refuses to upgrade itself on Windows.
     if sys.platform == "win32" and installation_method() == "pip":
         command = subprocess.list2cmdline([sys.executable, "-m", "pip", "install", "-U", "huggingface_hub"])
-        raise CLIError(
+        out.error(
             "On Windows, a pip-installed `hf` cannot update itself: pip is not allowed to replace `hf.exe` while it "
             f"is running. Run this command instead:\n    {command}"
         )
+        raise click.exceptions.Exit(code=1)
 
     # The standalone installer installs the `hf-cli` skill by default. If it's not installed at this
     # point, the user opted out (or removed it): tell the installer to leave it alone instead of

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5009,6 +5009,8 @@ class TestUpdateSkillOptOut:
         with (
             patch("huggingface_hub.cli.system._fetch_latest_pypi_version", return_value="99.0.0"),
             patch("huggingface_hub.cli.system.subprocess.call", return_value=0),
+            # `hf update` refuses to self-update a pip install on Windows: pretend we're not on Windows.
+            patch("huggingface_hub.cli.system.sys.platform", "linux"),
             patch("huggingface_hub.cli.system.run_update", return_value=0) as mock_run_update,
         ):
             yield mock_run_update


### PR DESCRIPTION
## Summary

On Windows, a running `.exe` can't be replaced, so `pip install -U huggingface_hub` launched from inside `hf.exe` blows up with `WinError 32` on `Scripts\hf.exe` — and it does so *after* pip has already uninstalled the current version, which leaves the user with a dead launcher and no `huggingface_hub` module at all (see the reproduction in #4819). The same upgrade works fine when pip isn't a child of `hf.exe`.

So `hf update` now simply refuses to do it: on Windows pip installs it prints the `python -m pip install -U huggingface_hub` command for the user to run themselves and exits non-zero, instead of half-breaking the install and reporting failure afterwards. This mirrors what pip itself does when asked to upgrade pip on Windows. Non-Windows pip installs, Homebrew and the standalone installer are untouched — the installer path already handles Windows on its own.

Simulated locally by faking `sys.platform`/installation method (no Windows box at hand), which gives:

```
> hf update
Current version: 1.30.0
Checking for updates to latest version...
Error: On Windows, a pip-installed `hf` cannot update itself: pip is not allowed to replace `hf.exe` while it is running. Run this command instead:
    C:\path\to\venv\Scripts\python.exe -m pip install -U huggingface_hub
```

The only test change is a `sys.platform` patch in `TestUpdateSkillOptOut`, so those tests keep exercising the normal update path when they run on Windows CI.

Fixes #4819. Alternative to #4820, which keys off `sys.argv[0]` to keep `python -m huggingface_hub.cli.hf update` working in-process; that path is safe but obscure enough that guarding the whole platform+install-method combination felt simpler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow guard on Windows + pip only; avoids a known failure mode without changing update behavior elsewhere.
> 
> **Overview**
> **`hf update`** now **refuses to run pip in-process** when the CLI is a **pip install on Windows**, instead of risking a broken install where pip uninstalls `huggingface_hub` then fails to replace `hf.exe` (WinError 32).
> 
> In that case it prints the exact `python -m pip install -U huggingface_hub` command to run in another shell and exits with code 1, similar to pip’s own self-upgrade behavior. Other platforms and install methods (Homebrew, standalone installer) are unchanged.
> 
> Tests in **`TestUpdateSkillOptOut`** patch **`sys.platform`** to **`linux`** so they still exercise the normal update path on Windows CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22c9cca8c7801d778ef47cdb2bf0d17a6dce2810. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->