### PR TITLE
[Sandbox] Support custom Job labels

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -2215,6 +2215,9 @@ Manage scheduled jobs using
 >>> hf sandbox create
 ✓ Sandbox ready id=687f911eaea852de79c4a50a image=python:3.12 elapsed=6.0s
 
+# Attach labels to the underlying Job
+>>> hf sandbox create --label controller-run=run-42 --label team=data-infra
+
 # Run commands inside it (output is streamed, exit code is propagated)
 >>> hf sandbox exec 687f911eaea852de79c4a50a -- python -c "print('hi')"
 hi
@@ -2227,7 +2230,7 @@ hi
 >>> hf sandbox kill 687f911eaea852de79c4a50a
 ```
 
-Use `--flavor` to pick hardware (e.g. `a10g-small`), `--idle-timeout` to bound the sandbox lifetime, and `-e` / `--secrets` for environment variables. To fan out many cheap CPU sandboxes, warm a pool with `hf sandbox pool create` and spawn into it with `hf sandbox create --pool <id>` (see the [Sandboxes guide](./sandbox#from-the-cli)).
+Use `--flavor` to pick hardware (e.g. `a10g-small`), `--idle-timeout` to bound the sandbox lifetime, `-l` / `--label` to attach labels to its Job, and `-e` / `--secrets` for environment variables. To fan out many cheap CPU sandboxes, warm a pool with `hf sandbox pool create` and spawn into it with `hf sandbox create --pool <id>` (see the [Sandboxes guide](./sandbox#from-the-cli)).
 
 ## hf webhooks
 

--- a/docs/source/en/guides/sandbox.md
+++ b/docs/source/en/guides/sandbox.md
@@ -236,6 +236,9 @@ The `hf sandbox` command mirrors the Python API. A dedicated sandbox:
 >>> hf sandbox create
 ✓ Sandbox ready id=687f911eaea852de79c4a50a image=python:3.12 elapsed=6.0s
 
+# Attach labels to the underlying Job
+>>> hf sandbox create --label controller-run=run-42 --label team=data-infra
+
 >>> hf sandbox exec 687f911eaea852de79c4a50a -- python -c "print('hi')"
 hi
 

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -3936,6 +3936,7 @@ $ hf sandbox create [OPTIONS] [IMAGE]
 * `--idle-timeout TEXT`: Auto-terminate the sandbox after this much inactivity (e.g. '10m'). Defaults to 10m.
 * `-e, --env TEXT`: Set environment variables. E.g. --env ENV=value
 * `-s, --secrets TEXT`: Set secret environment variables. E.g. --secrets SECRET=value or `--secrets HF_TOKEN` to pass your Hugging Face token.
+* `-l, --label TEXT`: Set labels. E.g. --label KEY=VALUE or --label LABEL
 * `--env-file TEXT`: Read in a file of environment variables.
 * `--secrets-file TEXT`: Read in a file of secret environment variables.
 * `-v, --volume TEXT`: Mount one or more volumes. Format: hf://[TYPE/]SOURCE:/MOUNT_PATH[:ro]. TYPE is one of: models, datasets, spaces, buckets. TYPE defaults to models if omitted. models, datasets and spaces are always mounted read-only. buckets are read+write by default. E.g. -v hf://org/m:/data or -v hf://datasets/org/ds:/data or -v hf://buckets/org/b:/mnt:ro
@@ -3948,6 +3949,7 @@ Examples
   $ hf sandbox create
   $ hf sandbox create ubuntu:24.04
   $ hf sandbox create --flavor a10g-small
+  $ hf sandbox create --label controller-run=run-42
   $ hf sandbox create --pool pool-ab12cd34ef56 --env LOG_LEVEL=debug
 
 Learn more

--- a/src/huggingface_hub/_sandbox.py
+++ b/src/huggingface_hub/_sandbox.py
@@ -59,6 +59,8 @@ POOL_LABEL = "hf-sandbox-pool"
 # `Sandbox.connect(id)` can recompute the token from any machine with no local state.
 NONCE_LABEL = "hf-sandbox-nonce"
 
+RESERVED_SANDBOX_LABELS = frozenset({SANDBOX_LABEL, MODE_LABEL, POOL_LABEL, NONCE_LABEL})
+
 DEFAULT_IMAGE = "python:3.12"
 
 DEFAULT_IDLE_TIMEOUT = 10 * 60  # 10 minutes
@@ -527,6 +529,7 @@ class Sandbox:
         volumes: List[Volume] | None = None,
         namespace: str | None = None,
         forward_hf_token: bool = False,
+        labels: dict[str, str] | None = None,
         start_timeout: float = 120.0,
         token: str | None = None,
     ) -> "Sandbox":
@@ -557,6 +560,8 @@ class Sandbox:
                 User or org namespace to run under (defaults to current user).
             forward_hf_token (`bool`, *optional*, defaults to `False`):
                 If True, your HF token is injected as `HF_TOKEN` (opt-in).
+            labels (`dict[str, str]`, *optional*):
+                Labels to attach to the underlying HF Job.
             start_timeout (`float`, *optional*, defaults to `120.0`):
                 Max seconds to wait for the sandbox to become ready.
             token (`str`, *optional*):
@@ -566,6 +571,15 @@ class Sandbox:
         `wget`/`curl` if available, otherwise read off an always-mounted server bucket (which
         adds ~2-3s to cold start, so shipping `wget`/`curl` keeps it fast).
         """
+        if labels is not None:
+            if not isinstance(labels, dict):
+                raise ValueError(f"`labels` must be a dict[str, str], got {type(labels).__name__}")
+            for key, value in labels.items():
+                if not isinstance(key, str) or not isinstance(value, str):
+                    raise ValueError("`labels` keys and values must be strings")
+                if key in RESERVED_SANDBOX_LABELS:
+                    raise ValueError(f"Label '{key}' is reserved by huggingface_hub Sandbox and cannot be overridden.")
+
         api = HfApi(token=token)
         hf_token = _effective_token(api)
         nonce = token_hex(16)
@@ -589,7 +603,7 @@ class Sandbox:
             secrets=job_secrets,
             flavor=flavor,
             timeout=SANDBOX_MAX_LIFETIME,
-            labels={SANDBOX_LABEL: "1", MODE_LABEL: MODE_DEDICATED, NONCE_LABEL: nonce},
+            labels={**(labels or {}), SANDBOX_LABEL: "1", MODE_LABEL: MODE_DEDICATED, NONCE_LABEL: nonce},
             volumes=job_volumes or None,
             expose=[SANDBOX_SERVER_PORT],
             namespace=namespace,

--- a/src/huggingface_hub/cli/sandbox.py
+++ b/src/huggingface_hub/cli/sandbox.py
@@ -51,7 +51,7 @@ from ._cli_utils import (
 )
 from ._framework import Argument, Option
 from ._output import out
-from .jobs import FlavorOpt, NamespaceOpt
+from .jobs import FlavorOpt, LabelsOpt, NamespaceOpt, _parse_labels_map
 
 
 sandbox_cli = typer_factory(help="Run and manage experimental sandboxes on Hugging Face Jobs.")
@@ -81,6 +81,7 @@ def _connect(sandbox_id: str, *, namespace: str | None, token: str | None) -> It
         "hf sandbox create",
         "hf sandbox create ubuntu:24.04",
         "hf sandbox create --flavor a10g-small",
+        "hf sandbox create --label controller-run=run-42",
         "hf sandbox create --pool pool-ab12cd34ef56 --env LOG_LEVEL=debug",
     ],
 )
@@ -97,6 +98,7 @@ def sandbox_create(
     ] = None,
     env: EnvOpt = None,
     secrets: SecretsOpt = None,
+    label: LabelsOpt = None,
     env_file: EnvFileOpt = None,
     secrets_file: SecretsFileOpt = None,
     volume: VolumesOpt = None,
@@ -121,6 +123,8 @@ def sandbox_create(
             raise CLIError("--pool fixes the image/flavor (and volumes aren't supported); drop those options.")
         if secrets or secrets_file:
             raise CLIError("--pool can't encrypt secrets; pass them with --env/--env-file instead.")
+        if label:
+            raise CLIError("--label is only supported for dedicated sandboxes.")
         sbx = SandboxPool.connect(pool, namespace=namespace, token=token).create(
             env=parse_env_map(env, env_file),
             idle_timeout=idle,
@@ -140,6 +144,7 @@ def sandbox_create(
         volumes=parse_volumes(volume),
         namespace=namespace,
         forward_hf_token=forward_hf_token,
+        labels=_parse_labels_map(label),
         token=token,
     )
     # Release the HTTP client (the sandbox keeps running)


### PR DESCRIPTION
## Summary

- Add an optional `labels` mapping to dedicated `Sandbox.create()` calls.
- Expose the same repeatable `-l` / `--label` syntax as `hf jobs run` through `hf sandbox create`.
- Merge caller labels with the SDK bookkeeping used for discovery and reconnect, and reject invalid or reserved labels before starting a billable Job.
- Keep pool behavior unchanged: custom Job labels are only accepted for dedicated sandboxes.

Closes #4812

### Usage

```python
from huggingface_hub import Sandbox

sandbox = Sandbox.create(
    image="python:3.12",
    labels={"controller-run": "run-42"},
)
```

```console
$ hf sandbox create --label controller-run=run-42 --label team=data-infra
✓ Sandbox ready id=687f911eaea852de79c4a50a image=python:3.12 elapsed=6.0s
```

### Local output

```console
$ make quality
...
ty check src
All checks passed!

$ pytest tests/test_sandbox.py
...
============================= 41 passed in 15.94s ==============================

$ python <CLI label propagation smoke check>
exit code: 0
labels: {'controller-run': 'run-42', 'team': 'data-infra'}
```
