### PR TITLE
[CI] Bound hanging tests and stabilize local download coverage

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -112,7 +112,9 @@ jobs:
         working-directory: ./src # For code coverage to work
         run: |
           source ../.venv/bin/activate
-          PYTEST="python -m pytest --cov=./huggingface_hub --cov-report=xml:../coverage.xml --vcr-record=none --reruns 8 --reruns-delay 2 --only-rerun '(OSError|FileNotFoundError|Timeout|HTTPError.*409|HTTPError.*502|HTTPError.*504|not less than or equal to 0.01)'"
+          # Kill stuck workers (including upload threads) and report the stalled test. The legacy
+          # large-folder uploader retries indefinitely, even when CI Hub LFS permissions are broken.
+          PYTEST="python -m pytest --timeout=600 --timeout-method=thread --cov=./huggingface_hub --cov-report=xml:../coverage.xml --vcr-record=none --reruns 8 --reruns-delay 2 --only-rerun '(OSError|FileNotFoundError|Timeout|HTTPError.*409|HTTPError.*502|HTTPError.*504|not less than or equal to 0.01)'"
 
           case "${{ matrix.test_name }}" in
 
@@ -208,6 +210,8 @@ jobs:
           $PYTEST_ARGS = @(
             "-m", "pytest",
             "-n", "4",
+            # Match Linux: terminate stuck workers and report the stalled test after 10 minutes.
+            "--timeout=600", "--timeout-method=thread",
             "--cov=./huggingface_hub",
             "--cov-report=xml:../coverage.xml",
             "--vcr-record=none",

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ extras["testing"] = (
         # Without it, any flaky fixture (e.g. a 502 from hub-ci) makes the rerun itself crash on pytest>=9.
         "pytest-rerunfailures>=16.2",  # to rerun flaky tests in CI
         "pytest-mock",
+        "pytest-timeout",  # bound hanging integration tests in CI
         "urllib3<2.0",  # VCR.py broken with urllib3 2.0 (see https://urllib3.readthedocs.io/en/stable/v2-migration-guide.html)
         "soundfile",
         "Pillow",

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -824,12 +824,6 @@ class TestHfHubDownloadToLocalDir:
 
         assert Path(path) == self.file_path
 
-    def test_file_exists_and_overwrites(self):
-        # 1 HEAD call + 1 download
-        self.file_path.write_text("another content")
-        self.api.hf_hub_download(self.repo_id, filename=self.file_name, local_dir=self.local_dir)
-        assert self.file_path.read_text() == "content"
-
     def test_passing_token_false_is_respected(self, mocker):
         """Regression test for #2385.
 
@@ -851,6 +845,37 @@ class TestHfHubDownloadToLocalDir:
         mock.assert_called()
         for call in mock.call_args_list:
             assert call.kwargs["token"] is False
+
+
+@pytest.mark.parametrize("head_timeout", [False, True])
+def test_local_file_overwrite_or_offline_fallback(tmp_path, mocker, head_timeout):
+    # A live HEAD timeout legitimately preserves the local file. Control the HTTP responses
+    # so testing the overwrite does not depend on CI Hub availability.
+    file_path = tmp_path / "file.txt"
+    file_path.write_text("another content")
+    methods = []
+
+    def handle_request(request):
+        methods.append(request.method)
+        if request.method == "HEAD" and head_timeout:
+            raise httpx.ReadTimeout("The read operation timed out", request=request)
+        return httpx.Response(
+            200,
+            headers={
+                "X-Repo-Commit": "a" * 40,
+                "ETag": "b" * 40,
+                "Content-Length": "7",
+            },
+            content=b"content" if request.method == "GET" else b"",
+        )
+
+    with httpx.Client(transport=httpx.MockTransport(handle_request)) as client:
+        mocker.patch("huggingface_hub.utils._http.get_session", return_value=client)
+        path = hf_hub_download("dummy/repo", "file.txt", local_dir=tmp_path, token=False)
+
+    assert Path(path) == file_path
+    assert file_path.read_text() == ("another content" if head_timeout else "content")
+    assert methods == (["HEAD"] if head_timeout else ["HEAD", "GET"])
 
 
 @pytest.mark.production


### PR DESCRIPTION
## Summary

- Investigated the shared failures on #4805 in an isolated git worktree based on `main`. Most failures need a CI Hub infrastructure fix (details below); this draft addresses the parts we can improve here.
- Replace the flaky live `test_file_exists_and_overwrites` with a transport-mocked test covering both successful overwrite and fallback after a HEAD timeout. It still exercises the real metadata, HTTP download, and local-file code. No change to downloader behavior.
- Add `pytest-timeout` to testing dependencies and a 600-second per-test watchdog in both Linux and Windows CI. Use the `thread` method so a stuck background upload cannot keep the worker alive. Local test runs have no timeout unless requested. The longest individual call in the inspected Linux/Xet job was 162 seconds, leaving room for slower runners and fixture setup.

The watchdog reports a stalled test as a worker crash under xdist, and the replacement worker can continue. It is a last resort: termination skips that worker's fixture cleanup and can lose its coverage data. It does not make broken uploads pass, and we keep the live LFS tests enabled.

### What still needs fixing on CI Hub

1. **AWS session duration:** both PyTorch jobs and the commit scheduler hit `The requested DurationSeconds exceeds the MaxSessionDuration set for this role` at the CI Hub LFS batch endpoint. The server's requested STS duration needs to be compatible with its target role/session limits. Example: [#4805 PyTorch log](https://github.com/huggingface/huggingface_hub/actions/runs/34122903238/job/101744813856). The same error appears on the unrelated [bucket-removal PR run](https://github.com/huggingface/huggingface_hub/actions/runs/34122852536/job/101744648918).
2. **S3 write permissions:** BytesIO and explicit LFS fallback uploads receive S3 `AccessDenied`: the `hub-ci-moonlanding` assumed role has no identity-based policy allowing `s3:PutObject` on `hf-hub-lfs-us-east-1-dev/repos/...`. CI Hub's signing role/permissions need correcting; changing the Python client's token or adding retries cannot grant that permission. Examples: [#4805 Xet job](https://github.com/huggingface/huggingface_hub/actions/runs/34122903238/job/101744813429), [current main PyTorch job](https://github.com/huggingface/huggingface_hub/actions/runs/34128275870/job/101761990106).
3. **Windows overwrite assertion:** the [failing test log](https://github.com/huggingface/huggingface_hub/actions/runs/34122903238/job/101744813088) shows a HEAD read timeout followed by the expected local-file fallback. The test incorrectly assumed that the live request would always succeed. The replacement explicitly covers both outcomes.

The no-Xet jobs were still running well after the Xet jobs finished. The legacy large-folder uploader unconditionally requeues failed uploads, including permanent LFS errors. The watchdog bounds this failure mode without changing the deprecated uploader's retry contract. Live logs for those unfinished jobs were not available, so their exact stuck test still needs confirmation.

### Local checks

The replacement test passes with and without `hf_xet` installed:

```console
$ .venv/bin/python -m pytest tests/test_file_download.py -k local_file_overwrite_or_offline_fallback --timeout=600 --timeout-method=thread -o addopts=-q
2 passed, 66 deselected in 0.23s
```

A temporary smoke test deliberately blocks on a non-daemon thread, followed by a passing test. With a two-second watchdog and one xdist worker:

```console
$ python -m pytest test_watchdog.py -n 1 --timeout=2 --timeout-method=thread --max-worker-restart=1 -s -q
[gw0] node down: Not properly terminated
FAILED test_watchdog.py::test_stuck_upload_worker - worker 'gw0' crashed whil...
1 failed, 1 passed in 2.84s
```

That failure is intentional and confirms that the stuck process is terminated and the replacement worker runs the next test. The smoke test lives outside the repository.

The local metadata and HTTP download tests also pass:

```console
$ .venv/bin/python -m pytest tests/test_local_folder.py tests/test_file_download.py::test_local_file_overwrite_or_offline_fallback tests/test_file_download.py::TestHttpGet --timeout=600 --timeout-method=thread -o addopts=-q
66 passed, 4 skipped in 18.70s
```

`make style` and `make quality` pass. Workflow YAML parses successfully. Windows execution remains for CI; local validation used Linux/Python 3.10. No public API or runtime behavior changes.
