### PR TITLE
Fix: keep single-quoted values verbatim in load_dotenv

### DIFF
--- a/src/huggingface_hub/utils/_dotenv.py
+++ b/src/huggingface_hub/utils/_dotenv.py
@@ -55,9 +55,12 @@ def load_dotenv(dotenv_str: str, environ: dict[str, str] | None = None) -> dict[
                 raw_val = match.group(3) or ""
                 val = raw_val.strip()
                 # Remove surrounding quotes if quoted
-                if (val.startswith('"') and val.endswith('"')) or (val.startswith("'") and val.endswith("'")):
-                    escapes = _DOUBLE_QUOTE_ESCAPES if raw_val.startswith('"') else _ESCAPES
-                    val = _unescape(val[1:-1], escapes)
+                if val.startswith('"') and val.endswith('"'):
+                    # Double-quoted values expand escape sequences (\n, \t, \", \\, \$).
+                    val = _unescape(val[1:-1], _DOUBLE_QUOTE_ESCAPES)
+                elif val.startswith("'") and val.endswith("'"):
+                    # Single-quoted values are kept verbatim: no escape expansion.
+                    val = val[1:-1]
             elif environ is not None:
                 # Get it from the current environment
                 val = environ.get(key)

--- a/tests/test_utils_dotenv.py
+++ b/tests/test_utils_dotenv.py
@@ -91,3 +91,20 @@ def test_environ():
     """
     environ = {"A": "one", "B": "two", "D": "four", "EMPTY": ""}
     assert load_dotenv(data, environ=environ) == {"A": "1", "B": "two", "C": "3", "EMPTY": ""}
+
+
+def test_single_quoted_values_are_literal():
+    # Single-quoted values are kept verbatim: escape sequences such as "\n" and "\t"
+    # are NOT expanded (unlike double-quoted values).
+    data = r"""
+    NEWLINE='line1\nline2'
+    TAB='a\tb'
+    ESCAPED_QUOTE='a\"b'
+    """
+    assert load_dotenv(data) == {
+        "NEWLINE": r"line1\nline2",
+        "TAB": r"a\tb",
+        "ESCAPED_QUOTE": r'a\"b',
+    }
+    assert load_dotenv(r'DQ="line1\nline2"') == {"DQ": "line1\nline2"}
+

--- a/tests/test_utils_dotenv.py
+++ b/tests/test_utils_dotenv.py
@@ -104,7 +104,6 @@ def test_single_quoted_values_are_literal():
     assert load_dotenv(data) == {
         "NEWLINE": r"line1\nline2",
         "TAB": r"a\tb",
-        "ESCAPED_QUOTE": r'a\"b',
+        "ESCAPED_QUOTE": r"a\"b",
     }
     assert load_dotenv(r'DQ="line1\nline2"') == {"DQ": "line1\nline2"}
-


### PR DESCRIPTION
## What's wrong

`huggingface_hub.utils._dotenv.load_dotenv` expands escape sequences inside **single-quoted** values. Single quotes should be literal, so `\n`, `\t`, etc. must be preserved, not interpreted.

```python
from huggingface_hub.utils._dotenv import load_dotenv

load_dotenv(r"A='line1\nline2'")
# now:      {'A': 'line1\nline2'}   (a real newline)  <-- wrong
# expected: {'A': 'line1\\nline2'}  (literal backslash-n)
```

This contradicts the module's own documentation ("single-quoted values keep it verbatim") and standard `.env`/shell behavior. For reference, `python-dotenv` returns the literal `line1\nline2` here.

## Root cause

`load_dotenv` applied `_unescape` to both quote styles, only varying the escape table, so single-quoted values were run through `_unescape(..., _ESCAPES)`, expanding `\n`, `\t`, `\"`, `\\`.

## Fix

Handle the two quote styles separately: double-quoted values still expand escape sequences; single-quoted values are stripped of their quotes and kept verbatim. Double-quoted behavior is unchanged.

## Tests

Added `test_single_quoted_values_are_literal` covering `\n`, `\t`, and `\"` inside single quotes, plus a double-quoted counterpart that still expands. It fails on `main` and passes with this change. The full `tests/test_utils_dotenv.py` suite passes; `ruff check` and `ruff format` are clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized parser fix with no auth or network impact; only changes how single-quoted env values are interpreted.
> 
> **Overview**
> **`load_dotenv`** no longer runs **`_unescape`** on single-quoted values. After stripping the outer quotes, the inner string is returned as-is, so sequences like `\n`, `\t`, and `\"` stay literal. Double-quoted values still use **`_DOUBLE_QUOTE_ESCAPES`** and behave as before.
> 
> This matches the module docs and typical `.env`/shell semantics (and **`python-dotenv`**). A new test asserts literal single-quoted escapes and that double quotes still expand newlines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54f9a83e20b0bd85f24bc54092bde38b08c255fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->