### PR TITLE
[HfFileSystem] Reject unsafe paths before local downloads

### DIFF
--- a/src/huggingface_hub/hf_file_system.py
+++ b/src/huggingface_hub/hf_file_system.py
@@ -20,6 +20,7 @@ from fsspec.utils import isfilelike
 
 from . import constants
 from ._commit_api import CommitOperationCopy, CommitOperationDelete
+from ._local_folder import _validate_relative_filename
 from .errors import (
     BucketNotFoundError,
     EntryNotFoundError,
@@ -1094,6 +1095,10 @@ class HfFileSystem(fsspec.AbstractFileSystem, metaclass=_Cached):  # ty: ignore[
 
         """
         revision = kwargs.get("revision")
+        resolve_remote_path = self.resolve_path(rpath, revision=revision)
+        # Recursive downloads map remote filenames to local paths, including on Windows.
+        # Validate before creating directories, opening files, or delegating to fsspec.
+        _validate_relative_filename(resolve_remote_path.path)
         unhandled_kwargs = set(kwargs.keys()) - {"revision"}
         if not isinstance(callback, (NoOpCallback, TqdmCallback)) or len(unhandled_kwargs) > 0:
             # for now, let's not handle custom callbacks
@@ -1118,7 +1123,6 @@ class HfFileSystem(fsspec.AbstractFileSystem, metaclass=_Cached):  # ty: ignore[
         initial_pos = outfile.tell()
 
         # Custom implementation of `get_file` to use `http_get`.
-        resolve_remote_path = self.resolve_path(rpath, revision=revision)
         expected_size = self.info(rpath, revision=revision)["size"]
         callback.set_size(expected_size)
         try:

--- a/tests/test_hf_file_system.py
+++ b/tests/test_hf_file_system.py
@@ -15,6 +15,7 @@ import pytest
 
 from huggingface_hub import HfApi, constants, hf_file_system
 from huggingface_hub.errors import BucketNotFoundError, RepositoryNotFoundError, RevisionNotFoundError
+from huggingface_hub.hf_api import RepoFile, RepoFolder
 from huggingface_hub.hf_file_system import (
     HfFileSystem,
     HfFileSystemFile,
@@ -25,6 +26,64 @@ from huggingface_hub.hf_file_system import (
 
 from .testing_constants import ENDPOINT_STAGING, TOKEN
 from .testing_utils import OfflineSimulationMode, offline, repo_name
+
+
+class TestDownloadPathValidation:
+    def test_recursive_get_rejects_traversal(self, tmp_path):
+        fs = HfFileSystem(token=False, skip_instance_cache=True)
+        filename = "folder/..\\..\\outside.txt"
+        tree = [RepoFolder(path="folder", oid="0" * 40), RepoFile(path=filename, size=7, oid="1" * 40)]
+        with (
+            patch.object(fs, "_repo_and_revision_exist", return_value=(True, None)),
+            patch.object(fs._api, "list_repo_tree", return_value=tree),
+            patch.object(hf_file_system, "http_get") as download,
+            patch("huggingface_hub.hf_file_system.open", create=True) as open_file,
+        ):
+            with pytest.raises(ValueError, match="Invalid filename"):
+                fs.get("user/repo/", str(tmp_path / "download"), recursive=True)
+        open_file.assert_not_called()
+        download.assert_not_called()
+        assert not (tmp_path / "outside.txt").exists()
+
+    @pytest.mark.parametrize("bucket", [False, True])
+    @pytest.mark.parametrize("kwargs", [{}, {"callback": fsspec.callbacks.Callback()}, {"custom_kwarg": 123}])
+    def test_get_file_rejects_before_local_io_or_fallback(self, tmp_path, bucket, kwargs):
+        fs = HfFileSystem(token=False, skip_instance_cache=True)
+        filename = "folder/..\\..\\outside.txt"
+        resolved = (
+            HfFileSystemResolvedBucketPath(bucket_id="user/bucket", path=filename)
+            if bucket
+            else HfFileSystemResolvedRepositoryPath("model", "user/repo", "main", filename)
+        )
+        with (
+            patch.object(fs, "resolve_path", return_value=resolved),
+            patch.object(fs, "isdir") as isdir,
+            patch.object(fsspec.AbstractFileSystem, "get_file") as fallback,
+            patch("huggingface_hub.hf_file_system.os.makedirs") as makedirs,
+            patch("huggingface_hub.hf_file_system.open", create=True) as open_file,
+        ):
+            with pytest.raises(ValueError, match="Invalid filename"):
+                fs.get_file(resolved.unresolve(), str(tmp_path / "download" / "file"), **kwargs)
+        isdir.assert_not_called()
+        fallback.assert_not_called()
+        makedirs.assert_not_called()
+        open_file.assert_not_called()
+
+    def test_get_file_safe_filename(self, tmp_path):
+        fs = HfFileSystem(token=False, skip_instance_cache=True)
+        resolved = HfFileSystemResolvedRepositoryPath("model", "user/repo", "main", "folder/safe.txt")
+        target = tmp_path / "download" / "safe.txt"
+        with (
+            patch.object(fs, "resolve_path", return_value=resolved),
+            patch.object(fs, "isdir", return_value=False),
+            patch.object(fs, "info", return_value={"size": 7}),
+            patch.object(fs, "url", return_value="https://huggingface.co/user/repo/resolve/main/folder/safe.txt"),
+            patch.object(
+                hf_file_system, "http_get", side_effect=lambda **kwargs: kwargs["temp_file"].write(b"content")
+            ),
+        ):
+            fs.get_file(resolved.unresolve(), str(target))
+        assert target.read_bytes() == b"content"
 
 
 class _HfFileSystemBaseTests:

--- a/tests/test_hf_file_system.py
+++ b/tests/test_hf_file_system.py
@@ -28,64 +28,6 @@ from .testing_constants import ENDPOINT_STAGING, TOKEN
 from .testing_utils import OfflineSimulationMode, offline, repo_name
 
 
-class TestDownloadPathValidation:
-    def test_recursive_get_rejects_traversal(self, tmp_path):
-        fs = HfFileSystem(token=False, skip_instance_cache=True)
-        filename = "folder/..\\..\\outside.txt"
-        tree = [RepoFolder(path="folder", oid="0" * 40), RepoFile(path=filename, size=7, oid="1" * 40)]
-        with (
-            patch.object(fs, "_repo_and_revision_exist", return_value=(True, None)),
-            patch.object(fs._api, "list_repo_tree", return_value=tree),
-            patch.object(hf_file_system, "http_get") as download,
-            patch("huggingface_hub.hf_file_system.open", create=True) as open_file,
-        ):
-            with pytest.raises(ValueError, match="Invalid filename"):
-                fs.get("user/repo/", str(tmp_path / "download"), recursive=True)
-        open_file.assert_not_called()
-        download.assert_not_called()
-        assert not (tmp_path / "outside.txt").exists()
-
-    @pytest.mark.parametrize("bucket", [False, True])
-    @pytest.mark.parametrize("kwargs", [{}, {"callback": fsspec.callbacks.Callback()}, {"custom_kwarg": 123}])
-    def test_get_file_rejects_before_local_io_or_fallback(self, tmp_path, bucket, kwargs):
-        fs = HfFileSystem(token=False, skip_instance_cache=True)
-        filename = "folder/..\\..\\outside.txt"
-        resolved = (
-            HfFileSystemResolvedBucketPath(bucket_id="user/bucket", path=filename)
-            if bucket
-            else HfFileSystemResolvedRepositoryPath("model", "user/repo", "main", filename)
-        )
-        with (
-            patch.object(fs, "resolve_path", return_value=resolved),
-            patch.object(fs, "isdir") as isdir,
-            patch.object(fsspec.AbstractFileSystem, "get_file") as fallback,
-            patch("huggingface_hub.hf_file_system.os.makedirs") as makedirs,
-            patch("huggingface_hub.hf_file_system.open", create=True) as open_file,
-        ):
-            with pytest.raises(ValueError, match="Invalid filename"):
-                fs.get_file(resolved.unresolve(), str(tmp_path / "download" / "file"), **kwargs)
-        isdir.assert_not_called()
-        fallback.assert_not_called()
-        makedirs.assert_not_called()
-        open_file.assert_not_called()
-
-    def test_get_file_safe_filename(self, tmp_path):
-        fs = HfFileSystem(token=False, skip_instance_cache=True)
-        resolved = HfFileSystemResolvedRepositoryPath("model", "user/repo", "main", "folder/safe.txt")
-        target = tmp_path / "download" / "safe.txt"
-        with (
-            patch.object(fs, "resolve_path", return_value=resolved),
-            patch.object(fs, "isdir", return_value=False),
-            patch.object(fs, "info", return_value={"size": 7}),
-            patch.object(fs, "url", return_value="https://huggingface.co/user/repo/resolve/main/folder/safe.txt"),
-            patch.object(
-                hf_file_system, "http_get", side_effect=lambda **kwargs: kwargs["temp_file"].write(b"content")
-            ),
-        ):
-            fs.get_file(resolved.unresolve(), str(target))
-        assert target.read_bytes() == b"content"
-
-
 class _HfFileSystemBaseTests:
     __test__ = False
     api = HfApi(endpoint=ENDPOINT_STAGING, token=TOKEN)

--- a/tests/test_hf_file_system.py
+++ b/tests/test_hf_file_system.py
@@ -15,7 +15,6 @@ import pytest
 
 from huggingface_hub import HfApi, constants, hf_file_system
 from huggingface_hub.errors import BucketNotFoundError, RepositoryNotFoundError, RevisionNotFoundError
-from huggingface_hub.hf_api import RepoFile, RepoFolder
 from huggingface_hub.hf_file_system import (
     HfFileSystem,
     HfFileSystemFile,


### PR DESCRIPTION
## Context: https://huggingface.slack.com/archives/C03Q18WK18T/p1788517230693939

## Summary

- `HfFileSystem.get(recursive=True)` maps server filenames onto the local destination through fsspec. A name such as `folder/..\..\outside.txt` reached `open(..., "wb")` unchanged and can escape that destination on Windows.
- Reuse `_validate_relative_filename()` in `get_file()` before directory creation, file opening, or delegation to fsspec for custom callbacks/kwargs. This also covers bucket paths and directory downloads. Keep remote-only listing/reading unchanged; validation happens at the download boundary.
- Add offline regression coverage for the real recursive `get()` flow, repository/bucket paths, both fallback triggers, and a successful safe download.

Follow-up to #1429 and #4540 (repo/cache downloads) and #4731 (bucket sync), none of which covered `HfFileSystem`. Related JS fix: https://github.com/huggingface/huggingface.js/pull/2429.

**Behavior change:** unsafe remote-relative filenames now raise `ValueError` on all platforms, including when downloading to an explicitly named file or a file object. A recursive download may have created safe directories/files before encountering an unsafe entry; this is not an atomic preflight of the entire tree.

Manual check on Linux, with repository-existence lookup mocked and the real `get_file()` method:

```python
from unittest.mock import patch
from huggingface_hub import HfFileSystem

fs = HfFileSystem(token=False, skip_instance_cache=True)
with patch.object(fs, "_repo_and_revision_exist", return_value=(True, None)):
    fs.get_file(r"user/repo/folder/..\..\outside.txt", "/tmp/hffs-safe-download/file.txt")
```

```text
ValueError: Invalid filename 'folder/..\..\outside.txt': cannot contain a '..' path segment. Please ask the repository owner to rename this file.
```

Validation in the isolated worktree:

```text
$ PYTHONPATH=src python -m pytest tests/test_hf_file_system.py -k TestDownloadPathValidation -q
8 passed, 116 deselected in 0.39s

$ make style
All checks passed!
$ make quality
All checks passed!
```

The earlier local investigation exercised the unguarded recursive download with mocked API/HTTP responses and confirmed escape under Python's Windows path semantics. I did not independently run a live-Hub/native-Windows reproduction; these regression tests run offline and reject the filename on every platform.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Security fix on the download path with a behavior change (downloads that previously succeeded may now raise), but scope is limited to filename validation before local I/O.
> 
> **Overview**
> **HfFileSystem** downloads now reject unsafe remote-relative filenames at the `get_file()` boundary, closing a path-traversal gap when recursive `get()` maps Hub names onto a local folder (notably on Windows).
> 
> `get_file()` resolves the remote path up front and calls `_validate_relative_filename()` on the repo/bucket-relative segment **before** `makedirs`, `open`, or the fsspec `super().get_file()` fallback (custom callbacks/extra kwargs). Names with `..` segments raise `ValueError` on all platforms; remote listing/reading is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc2a82c827d853e64e592f683eb36319d6263969. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->