### PR TITLE
[Download] Write cache ref file atomically in snapshot_download

### DIFF
--- a/src/huggingface_hub/_snapshot_download.py
+++ b/src/huggingface_hub/_snapshot_download.py
@@ -18,7 +18,13 @@ from .errors import (
     RepositoryNotFoundError,
     RevisionNotFoundError,
 )
-from .file_download import REGEX_COMMIT_HASH, DryRunFileInfo, hf_hub_download, repo_folder_name
+from .file_download import (
+    REGEX_COMMIT_HASH,
+    DryRunFileInfo,
+    _cache_commit_hash_for_specific_revision,
+    hf_hub_download,
+    repo_folder_name,
+)
 from .hf_api import HfApi, RepoFile
 from .utils import OfflineModeIsEnabled, filter_repo_objects, logging, validate_hf_hub_args
 from .utils._xet_progress_reporting import (
@@ -412,14 +418,15 @@ def snapshot_download(
     # if passed revision is not identical to commit_hash
     # then revision has to be a branch name or tag name.
     # In that case store a ref (except if ResolvedRevision, in which case it's already done).
-    if not isinstance(revision, ResolvedRevision) and revision != commit_hash:
-        ref_path = os.path.join(storage_folder, "refs", revision)
+    if not isinstance(revision, ResolvedRevision):
         try:
-            os.makedirs(os.path.dirname(ref_path), exist_ok=True)
-            with open(ref_path, "w") as f:
-                f.write(commit_hash)
+            # Skips the write if the ref is already up to date, and writes atomically otherwise so that
+            # concurrent readers never observe a truncated (empty) ref file.
+            _cache_commit_hash_for_specific_revision(storage_folder, revision, commit_hash)
         except OSError as e:
-            logger.warning(f"Ignored error while writing commit hash to {ref_path}: {e}.")
+            logger.warning(
+                f"Ignored error while writing commit hash to {os.path.join(storage_folder, 'refs', revision)}: {e}."
+            )
 
     results: list[str | DryRunFileInfo] = []
 


### PR DESCRIPTION
### (from me)

In `snapshot_download` we update the `refs/` cache on each and every download in an unsafe way (subject to concurrency issue). In `hf_hub_download` we do the same but with a safe and atomic `_cache_commit_hash_for_specific_revision`. This PR updates the snapshot_download logic to use the atomic method.

Note that this bug has been there for more than 4 years (added in https://github.com/huggingface/huggingface_hub/pull/801) and never got reported since it requires many concurrent `snapshot_download` runs happening at the same time on the same repo, which is what happened in transformers/vLLM: https://github.com/vllm-project/llm-compressor/issues/2984.

### (everything below is claude-generated)


---

---

## Summary

Fixes the DDP model-loading crash reported in https://github.com/vllm-project/llm-compressor/issues/2984.

- `snapshot_download` rewrites `refs/<revision>` with a plain `open(path, "w")` on **every** call, even when the commit hash is unchanged and the repo is fully cached. `open(..., "w")` truncates the file before rewriting it.
- A concurrent reader (`try_to_load_from_cache`, the offline path in `hf_hub_download`, `HfApi.resolve_revision`, ...) that hits that window reads `""`, looks for a snapshot folder named `""`, finds nothing, and reports a perfectly cached file as missing. Transformers turns that into `OSError: <repo> does not appear to have a file named model-000NN-of-00131.safetensors`.
- Fix: use the existing `_cache_commit_hash_for_specific_revision` helper, which skips the write when the ref is already correct and otherwise writes to a temp file + `os.replace`. `hf_hub_download` and `HfApi.resolve_revision` already go through it — this was the last hand-rolled ref write left. It was made atomic in #4306; the duplicate in `_snapshot_download.py` was missed then.

This also removes the write entirely from the fully-cached path, which is the common case under DDP.

## Note on #4811

https://github.com/huggingface/huggingface_hub/pull/4811 proposes a different fix for the same issue, making `_create_symlink` atomic. That race is real *in isolation* (I measured ~5.4% missed `os.path.isfile` checks calling the function in a loop), but the library never calls it that way: both call sites sit inside a `WeakFileLock` behind `if not os.path.exists(pointer_path)`, so the `os.remove(dst)` at the top never removes a live pointer.

Instrumenting `_create_symlink` across 8 processes downloading 131 shards:

| scenario | `_create_symlink` calls | of which dst already existed | `os.path.isfile` misses |
|---|---|---|---|
| cold cache | 131 | 0 | 0 / 2,947,470 |
| warm cache | 0 | 0 | 0 / 2,973,554 |

131 calls for 131 shards across 8 ranks — the lock and the guard already do their job.

## Reproduction

Private repo with 131 tiny fake shards, pre-downloaded, then 8 processes × 40 rounds of `snapshot_download` + `try_to_load_from_cache` for all shards (exactly what `transformers.utils.hub.cached_files` does):

| tree | failed checkpoint resolutions |
|---|---|
| `main` | 10 |
| `main` + #4811 | 14 |
| `main` + this PR | 0 (4 consecutive runs) |

On `main`, byte-for-byte the reported error:

```
[rank1] OSError: Wauplin/tmp-symlink-race-repro does not appear to have a file named
        model-00047-of-00131.safetensors. Checkout
        'https://huggingface.co/Wauplin/tmp-symlink-race-repro/tree/main' for available files.
```

Instrumenting the reader step by step shows the cause on every failure, with #4811 applied too:

```
step: "rev-not-in-shas rev='' shas=['8fb2f63c3c6d5c7b833d082defb6316b88e4fbda']"
pointer_lexists: true
pointer_isfile: true
```

The pointer is right there. Only the ref was momentarily empty.

## Checks

`pytest tests/test_snapshot_download.py tests/test_file_download.py` → 89 passed. `ruff` and `ty check src` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted swap to an existing atomic cache helper; lowers race risk in shared Hub cache refs without changing download APIs.
> 
> **Overview**
> **Fixes a concurrency bug** where `snapshot_download` rewrote `refs/<revision>` with a truncating `open(..., "w")`, so parallel readers could briefly see an empty ref and treat fully cached shards as missing (e.g. DDP / vLLM model load failures).
> 
> `snapshot_download` now calls **`_cache_commit_hash_for_specific_revision`** (same as `hf_hub_download`): skip when the ref is already correct, otherwise **temp file + `os.replace`**. Ref updates run for any non-`ResolvedRevision` revision; the helper still no-ops when `revision` equals the commit hash.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a8ff47170f1fa355a1cfc3f3dfc66ac1d744041. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->