### PR TITLE
[CI] Make CI less flaky and stop 6h hung jobs

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -42,7 +42,7 @@ jobs:
       group: aws-general-8-plus
     # A healthy full-suite job takes ~20min. Anything much longer means something is stuck: fail fast instead of
     # burning a runner until GitHub's 6h limit.
-    timeout-minutes: 30
+    timeout-minutes: 45
     env:
       UV_HTTP_TIMEOUT: 600 # max 10min to install deps
 

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -8,9 +8,14 @@ on:
     paths-ignore:
       - "docs/**"
   pull_request:
-    types: [assigned, opened, synchronize, reopened]
+    types: [opened, synchronize, reopened]
     paths-ignore:
       - "docs/**"
+
+# Cancel superseded runs: a new push to a PR makes the previous run useless.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   check-imports:
@@ -35,6 +40,9 @@ jobs:
   build-ubuntu:
     runs-on:
       group: aws-general-8-plus
+    # A healthy full-suite job takes ~20min. Anything much longer means something is stuck: fail fast instead of
+    # burning a runner until GitHub's 6h limit.
+    timeout-minutes: 30
     env:
       UV_HTTP_TIMEOUT: 600 # max 10min to install deps
 
@@ -44,8 +52,6 @@ jobs:
         python-version: ["3.10", "3.14"]
         test_name: ["no hf_xet", "Inference only", "with hf_xet"]
         include:
-          - python-version: "3.14" # LFS not ran on 3.10
-            test_name: "lfs"
           - python-version: "3.10" # test torch~=1.11 on python 3.10 only.
             test_name: "Python 3.10, torch_1.11"
           - python-version: "3.12" # test torch latest on python 3.12 only.
@@ -78,11 +84,6 @@ jobs:
               sudo apt install -y libsndfile1-dev
               ;;
 
-            lfs)
-              git config --global user.email "ci@dummy.com"
-              git config --global user.name "ci"
-              ;;
-
             gradio)
               uv pip install "huggingface_hub[gradio] @ ."
             ;;
@@ -112,7 +113,7 @@ jobs:
         working-directory: ./src # For code coverage to work
         run: |
           source ../.venv/bin/activate
-          PYTEST="python -m pytest --cov=./huggingface_hub --cov-report=xml:../coverage.xml --vcr-record=none --reruns 8 --reruns-delay 2 --only-rerun '(OSError|FileNotFoundError|Timeout|HTTPError.*409|HTTPError.*502|HTTPError.*504|not less than or equal to 0.01)'"
+          PYTEST="python -m pytest --cov=./huggingface_hub --cov-report=xml:../coverage.xml --vcr-record=none --reruns 8 --reruns-delay 2 --only-rerun '(OSError|FileNotFoundError|Timeout|HTTPError.*409|HTTPError.*502|HTTPError.*504)'"
 
           case "${{ matrix.test_name }}" in
 
@@ -127,10 +128,6 @@ jobs:
               PYTEST="$PYTEST ../tests -m 'not xet and not inference' -n 4"
               echo $PYTEST
               eval $PYTEST
-            ;;
-
-            lfs)
-              eval "RUN_GIT_LFS_TESTS=1 $PYTEST ../tests -k 'Largefiles'"
             ;;
 
             gradio)
@@ -163,6 +160,7 @@ jobs:
     # (almost) Duplicate config compared to `build-ubuntu` but running on Windows.
     # Please make sure to keep it updated as well.
     runs-on: windows-latest
+    timeout-minutes: 30
     env:
       DISABLE_SYMLINKS_IN_WINDOWS_TESTS: 1
       UV_HTTP_TIMEOUT: 600 # max 10min to install deps
@@ -213,7 +211,7 @@ jobs:
             "--vcr-record=none",
             "--reruns", "8",
             "--reruns-delay", "2",
-            "--only-rerun", "(OSError|FileNotFoundError|Timeout|HTTPError.*409|HTTPError.*502|HTTPError.*504|not less than or equal to 0.01)",
+            "--only-rerun", "(OSError|FileNotFoundError|Timeout|HTTPError.*409|HTTPError.*502|HTTPError.*504)",
             "../tests"
           )
 

--- a/src/huggingface_hub/_upload_large_folder.py
+++ b/src/huggingface_hub/_upload_large_folder.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 WAITING_TIME_IF_NO_TASKS = 10  # seconds
+MAX_CONSECUTIVE_ERRORS = 8  # abort the upload after this many consecutive errors (all workers combined)
 MAX_NB_FILES_FETCH_UPLOAD_MODE = 100
 COMMIT_SIZE_SCALE: list[int] = [20, 50, 75, 100, 125, 200, 250, 400, 600, 1000]
 
@@ -272,12 +273,21 @@ def upload_large_folder_internal(
             if print_report:
                 _print_overwrite(status.current_report())
             last_report_ts = time.time()
+        if status.fatal_error is not None:
+            logger.error(f"Too many consecutive errors ({MAX_CONSECUTIVE_ERRORS}): exiting main loop")
+            break
         if status.is_done():
             logger.info("Is done: exiting main loop")
             break
 
     for thread in threads:
         thread.join()
+
+    if status.fatal_error is not None:
+        raise RuntimeError(
+            f"Upload aborted after {MAX_CONSECUTIVE_ERRORS} consecutive errors. Progress is saved locally: re-run the"
+            " same command to resume."
+        ) from status.fatal_error
 
     logger.info(status.current_report())
     logger.info("Upload is complete!")
@@ -317,6 +327,8 @@ class LargeUploadStatus:
         self.nb_workers_commit: int = 0
         self.nb_workers_waiting: int = 0
         self.last_commit_attempt: float | None = None
+        self.nb_consecutive_errors: int = 0
+        self.fatal_error: Exception | None = None
 
         self._started_at = datetime.now()
         self._chunk_idx: int = 1
@@ -335,6 +347,21 @@ class LargeUploadStatus:
                 self.queue_commit.put(item)
             else:
                 logger.debug(f"Skipping file {paths.path_in_repo} (already uploaded and committed)")
+
+    def report_success(self) -> None:
+        with self.lock:
+            self.nb_consecutive_errors = 0
+
+    def report_error(self, exc: Exception) -> None:
+        """Give up on the whole upload once errors keep piling up.
+
+        Failed items are put back in their queue and retried indefinitely, which spins forever (and hammers the Hub)
+        when the error is permanent. Stop after `MAX_CONSECUTIVE_ERRORS` failures without a single success in between.
+        """
+        with self.lock:
+            self.nb_consecutive_errors += 1
+            if self.nb_consecutive_errors >= MAX_CONSECUTIVE_ERRORS:
+                self.fatal_error = exc
 
     def target_chunk(self) -> int:
         with self._chunk_lock:
@@ -435,6 +462,8 @@ def _worker_job(
     Read `upload_large_folder` docstring for more information on how tasks are prioritized.
     """
     while True:
+        if status.fatal_error is not None:
+            return
         next_job: tuple[WorkerJob, list[JOB_ITEM_T]] | None = None
 
         # Determine next task
@@ -450,12 +479,14 @@ def _worker_job(
                 try:
                     _compute_sha256(item)
                     status.queue_get_upload_mode.put(item)
+                    status.report_success()
                 except KeyboardInterrupt:
                     raise
                 except Exception as e:
                     logger.error(f"Failed to compute sha256: {e}")
                     traceback.format_exc()
                     status.queue_sha256.put(item)
+                    status.report_error(e)
 
                 with status.lock:
                     status.nb_workers_sha256 -= 1
@@ -463,11 +494,13 @@ def _worker_job(
             case WorkerJob.GET_UPLOAD_MODE:
                 try:
                     _get_upload_mode(items, api=api, repo_id=repo_id, repo_type=repo_type, revision=revision)
+                    status.report_success()
                 except KeyboardInterrupt:
                     raise
                 except Exception as e:
                     logger.error(f"Failed to get upload mode: {e}")
                     traceback.format_exc()
+                    status.report_error(e)
 
                 # Items are either:
                 # - dropped (if should_ignore)
@@ -494,6 +527,7 @@ def _worker_job(
                     _preupload_lfs(items, api=api, repo_id=repo_id, repo_type=repo_type, revision=revision)
                     for item in items:
                         status.queue_commit.put(item)
+                    status.report_success()
                 except KeyboardInterrupt:
                     raise
                 except Exception as e:
@@ -501,6 +535,7 @@ def _worker_job(
                     traceback.format_exc()
                     for item in items:
                         status.queue_preupload_lfs.put(item)
+                    status.report_error(e)
 
                 with status.lock:
                     status.nb_workers_preupload_lfs -= 1
@@ -510,6 +545,7 @@ def _worker_job(
                 success = True
                 try:
                     _commit(items, api=api, repo_id=repo_id, repo_type=repo_type, revision=revision)
+                    status.report_success()
                 except KeyboardInterrupt:
                     raise
                 except Exception as e:
@@ -518,6 +554,7 @@ def _worker_job(
                     for item in items:
                         status.queue_commit.put(item)
                     success = False
+                    status.report_error(e)
                 duration = time.time() - start_ts
                 status.update_chunk(success, len(items), duration)
                 with status.lock:

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2681,7 +2681,9 @@ class TestHfApiPrivate:
                 _ = api.dataset_info(repo_id=self.repo_id)
 
     def test_list_private_models(self, api: HfApi):
-        kwargs = {"sort": "created_at", "limit": 100, "author": USER}
+        # Filter on the (unique) repo name rather than paging through the N most recent repos: every CI job shares
+        # `USER`, so the repo drops off a `sort="created_at"` page as soon as other jobs create repos of their own.
+        kwargs = {"search": self.repo_id.split("/")[-1], "author": USER}
         assert all(model.id != self.repo_id for model in api.list_models(token=False, **kwargs))
         assert any(model.id == self.repo_id for model in api.list_models(token=TOKEN, **kwargs))
 
@@ -3380,8 +3382,9 @@ class TestCommitInBackground:
         )
         t1 = time.time()
 
-        # all futures are queued instantly
-        assert t1 - t0 <= 0.01
+        # All futures are queued without waiting for the uploads themselves (which each take seconds). A generous
+        # threshold: a stricter one only measures how busy the CI runner is.
+        assert t1 - t0 <= 1
 
         # wait for the last job to complete
         upload_future_3.result()

--- a/tests/test_upload_large_folder.py
+++ b/tests/test_upload_large_folder.py
@@ -1,12 +1,13 @@
 # tests/test_upload_large_folder.py
 from hashlib import sha256
-from unittest.mock import MagicMock
+from typing import NamedTuple
 
 import pytest
 
 from huggingface_hub._local_folder import LocalUploadFileMetadata, LocalUploadFilePaths
 from huggingface_hub._upload_large_folder import (
     COMMIT_SIZE_SCALE,
+    MAX_CONSECUTIVE_ERRORS,
     MAX_FILES_PER_FOLDER,
     MAX_FILES_PER_REPO,
     LargeUploadStatus,
@@ -45,6 +46,25 @@ def test_update_chunk_transitions(status, start_idx, success, delta_items, durat
     assert status.target_chunk() == COMMIT_SIZE_SCALE[expected_idx]
 
 
+def test_fatal_error_after_max_consecutive_errors(status):
+    exc = RuntimeError("boom")
+    for _ in range(MAX_CONSECUTIVE_ERRORS - 1):
+        status.report_error(exc)
+    assert status.fatal_error is None
+
+    status.report_error(exc)
+    assert status.fatal_error is exc
+
+
+def test_success_resets_consecutive_errors(status):
+    for _ in range(MAX_CONSECUTIVE_ERRORS - 1):
+        status.report_error(RuntimeError("boom"))
+    status.report_success()
+
+    status.report_error(RuntimeError("boom"))
+    assert status.fatal_error is None
+
+
 def test_build_hacky_operation_preserves_lfs_preupload_state(tmp_path):
     file_path = tmp_path / "file.bin"
     content = b"content"
@@ -69,16 +89,28 @@ def test_build_hacky_operation_preserves_lfs_preupload_state(tmp_path):
     assert operation.path_or_fileobj == b""
 
 
+class MockFilePath(NamedTuple):
+    """Minimal `pathlib.Path` stand-in: `_validate_upload_limits` only needs `.stat().st_size`."""
+
+    st_size: int
+
+    def stat(self) -> "MockFilePath":
+        return self
+
+
 class TestValidateUploadLimits:
     """Test the _validate_upload_limits function directly."""
 
     class MockPath:
-        """Mock object to simulate LocalUploadFilePaths."""
+        """Mock object to simulate LocalUploadFilePaths.
+
+        Plain objects on purpose: these tests build up to `MAX_FILES_PER_REPO` instances and a `MagicMock` costs
+        ~660µs to create and configure, i.e. ~85s for the whole class.
+        """
 
         def __init__(self, path_in_repo, size_bytes=1000):
             self.path_in_repo = path_in_repo
-            self.file_path = MagicMock()
-            self.file_path.stat.return_value.st_size = size_bytes
+            self.file_path = MockFilePath(size_bytes)
 
     def test_no_warnings_under_limits(self, mocker):
         """Test that no warnings are issued when under all limits."""


### PR DESCRIPTION
### (human-written part)

Some fixes and config to have a less flaky CI.

In order:
1. add a max retry on `upload_large_folder` to avoid 6h-long jobs
2. `timeout-minutes: 30` at a workflow level to timeout early (no 6h-long jobs, no matter what)
3. `concurrency group` with `cancel-in-progress` => cancel CI if new changes pushed to a branch which triggers a new CI
4. since `TestHfLargefiles` is skipped, let's drop LFS tests from the matrix (all tests skipped at the moment)
5. optimization in `TestValidateUploadLimits` => 1s instead of 85s

**Goal:** a successful CI, or at least failing fast.

(note: -unrelated- biggest issue currently is related to LFS upload that is broken => asked infra team to look into it see internal slack https://huggingface.slack.com/archives/CTKK32GE8/p1788867376343589)

### (claude written below)

---


## Summary

Follow-up to an investigation of the recent CI flakiness (see [run 34211405158](https://github.com/huggingface/huggingface_hub/actions/runs/34211405158)).

**Every test failure in that run has a single, server-side cause**: plain-LFS uploads to `hub-ci` return `403 AccessDenied` on `s3:PutObject`. Reproduced 100% locally:

```
<Error><Code>AccessDenied</Code><Message>
User: arn:aws:sts::707930574880:assumed-role/hub-ci-moonlanding/aws-sdk-js-session-1788863086484
is not authorized to perform: s3:PutObject on resource:
"arn:aws:s3:::hf-hub-lfs-us-east-1-dev/repos/48/55/.../8f990ba0..."
because no identity-based policy allows the s3:PutObject action
</Message></Error>
```

Cleanly isolated — the Xet path is fine, only plain LFS is broken:

| upload path | hub-ci |
|---|---|
| Xet (real file path, `hf_xet` installed) | ✅ OK |
| LFS (`HF_HUB_DISABLE_XET=1`, or `BytesIO`, or no `hf_xet`) | ❌ 403, 15/15 attempts |

That's with the infra team. **This PR does not try to fix it** — it fixes how our CI *reacts* to an incident like this.

## 1. `upload_large_folder` retried forever → 6h hung jobs

`_worker_job` caught every exception, put the item straight back on its queue and looped, with no cap. With LFS returning 403, `TestLargeUpload::test_upload_large_folder` spun until GitHub's 6h job timeout. One cancelled job's log:

- **136,739** `Failed to preupload LFS` lines
- **60 MB** of log
- last real test activity at 37 min, then **5h23m** of pure retry loop
- ~3–5 req/s/worker hammering hub-ci's LFS batch endpoint

Every run since 2026-09-03 (29 runs sampled):

```
job                                  n   med   max   sum(h)  conclusions
build-ubuntu  (3.10, no hf_xet)     18   360   360    104.2  {'cancelled': 17, 'failure': 1}
build-ubuntu  (3.14, no hf_xet)     18   360   360    103.9  {'cancelled': 17, 'failure': 1}
build-windows (3.10, no hf_xet)     18   360   360    103.9  {'cancelled': 17, 'failure': 1}
build-windows (3.14, no hf_xet)     18   360   360    103.8  {'cancelled': 17, 'failure': 1}
build-ubuntu  (3.14, with hf_xet)   18    86   117     22.4  {'failure': 18}
...
TOTAL runner-hours over 29 runs: 504.5
```

**416 of 504 runner-hours (82%) were hung jobs producing zero signal**, and the run stays `in_progress` for 6h so PR checks never complete.

Fix: `LargeUploadStatus` now counts consecutive errors across all workers and aborts after `MAX_CONSECUTIVE_ERRORS = 8` (a single success resets the counter). No backoff — deliberately kept minimal, this is a deprecated path and the goal is CI stability, not UX.

Before / after on the currently-broken LFS path:

```console
$ HF_HUB_DISABLE_XET=1 pytest "tests/test_hf_api.py::TestLargeUpload::test_upload_large_folder"

# before: hangs for 6 hours
# after:
FAILED tests/test_hf_api.py::TestLargeUpload::test_upload_large_folder - Runt...
1 failed, 9 warnings in 18.24s
```

Happy path (Xet) unaffected:

```console
$ pytest tests/test_hf_api.py::TestLargeUpload tests/test_xet_upload.py::TestXetLargeUpload tests/test_upload_large_folder.py
18 passed in 73.11s
```

## 2. Workflow guardrails

- **`timeout-minutes: 30`** on `build-ubuntu` / `build-windows`. A healthy full-suite job is ~20 min; nothing should reach 6h.
- **`concurrency` group with `cancel-in-progress`** — `python-tests.yml` was the only heavy workflow without one. `fix/windows-pip-self-update` pushed 8 runs in 2h on Sep 6 → 8 × 4 hung jobs × 6h ≈ **192 runner-hours from one branch**.
- **Dropped the `assigned` PR trigger** — assigning a reviewer ran the whole suite.

## 3. Dropped the `lfs` matrix entry

`build-ubuntu (3.14, lfs)` finished in 29s:

```
collected 2825 items / 2824 deselected / 1 selected
1 skipped, 2824 deselected in 9.90s
```

`TestHfLargefiles` is `@pytest.mark.skip`ped (see the Slack link in its `reason`), so the job selected one test and skipped it — green but empty. Removed the matrix entry and its `git config` setup step. The test class, the `git_lfs` marker and the `RUN_GIT_LFS_TESTS` escape hatch are kept so it can still be run locally if we ever re-enable it.

## 4. `TestValidateUploadLimits`: 85s → 1s

The single slowest entry in every full run (96s on CI). It's a **pure unit test** — the cost was building `MAX_FILES_PER_REPO + 10` = 100,010 `MagicMock()` objects (~660µs each to create + configure). Swapped for a plain `NamedTuple`:

```console
# before
7 passed in 85.58s
# after
15 passed in 0.77s   # whole file
```

## 5. Two flaky-by-construction tests

**`test_commit_to_repo_in_background`** asserted `t1 - t0 <= 0.01` — a wall-clock assertion on a 4-worker shared runner. It's the reason `not less than or equal to 0.01` was hardcoded into `--only-rerun`. Raised to 1s (each upload takes seconds, so it still proves the futures don't block) and removed the regex entry on both platforms.

**`test_list_private_models`** asserted a just-created repo shows up in `list_models(sort="created_at", limit=100, author=USER)`. Every CI job shares `__DUMMY_HUB_USER__`; measured live, **the 100 newest model repos under that user span only 16 minutes**, so under load the repo falls off page 1. Now filters by the unique repo name with `search=`, which I verified is immediately consistent on hub-ci (10/10, sub-second) and is also much faster:

```
test_list_private_models   0.41s   (was a 100-item page fetch)
```

## Notes / decisions

- **Reruns were left alone on purpose.** Baseline check: run 33504928169 (2026-09-01, all green, 21–23 min) had **0 reruns**. Today's run also has 0 — the `--only-rerun` regex correctly does *not* match 403. The 899 reruns I counted across 50 jobs on Sep 4–7 were all downstream of Hub 502s / connection timeouts, not chronic test flakiness. So `--reruns 8 --reruns-delay 2` stays as-is.
- Not addressed here, noted for later: **setup + teardown is 46% of measurable test time** (1867s of 4047s in a healthy run) — repo create/delete on hub-ci, ~6.8s per class setup. That's the biggest remaining lever but a real refactor.
- Also not addressed: `TestHfHubDownloadToLocalDir::test_metadata_ok_and_etag_match_and_force_download` occasionally fails with `Expected '_download_to_tmp_and_move' to have been called once. Called 2 times` — an internal retry leaking into a strict mock assertion, only under Hub flakiness.

`make style` and `make quality` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes upload_large_folder failure semantics (fail-fast vs infinite retry) for real large-folder uploads; CI-only edits are low risk but the library behavior shift matters when Hub errors are persistent.
> 
> **Overview**
> **CI** gets guardrails so broken Hub/LFS incidents do not burn 6h runners: workflow **concurrency** with `cancel-in-progress`, **job timeouts** (45m Ubuntu / 30m Windows), PR runs no longer on **assign**, and the no-op **`lfs` matrix job** (only skipped tests) is removed. Pytest **`--only-rerun`** no longer masks the old 10ms timing flake.
> 
> **`upload_large_folder`** now stops after **8 consecutive worker failures** (any success resets the counter), exits workers, and raises a **`RuntimeError`** that tells users to re-run to resume—replacing an infinite re-queue loop that could hammer the Hub for hours.
> 
> **Tests** are stabilized and sped up: private model listing uses **`search`** on the repo name instead of a crowded `created_at` page; background-upload timing allows **≤1s**; **`TestValidateUploadLimits`** uses lightweight mocks (~85s → ~1s); new unit tests cover the consecutive-error abort logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit caa4a2c5c3f6f59f842b9e4c9b12a824fe5829ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->